### PR TITLE
Faster 'cabal update'

### DIFF
--- a/cabal-install/Distribution/Client/Update.hs
+++ b/cabal-install/Distribution/Client/Update.hs
@@ -21,6 +21,8 @@ import Distribution.Client.FetchUtils
 import qualified Distribution.Client.PackageIndex as PackageIndex
 import Distribution.Client.IndexUtils
          ( getSourcePackages, updateRepoIndexCache )
+import Distribution.Client.Utils
+         ( writeFileAtomic )
 import qualified Paths_cabal_install
          ( version )
 
@@ -29,12 +31,11 @@ import Distribution.Package
 import Distribution.Version
          ( anyVersion, withinRange )
 import Distribution.Simple.Utils
-         ( warn, notice, writeFileAtomic )
+         ( warn, notice )
 import Distribution.Verbosity
          ( Verbosity )
 
 import qualified Data.ByteString.Lazy       as BS
-import qualified Data.ByteString.Lazy.Char8 as BS.Char8
 import Distribution.Client.GZipUtils (maybeDecompress)
 import qualified Data.Map as Map
 import System.FilePath (dropExtension)
@@ -57,8 +58,7 @@ updateRepo verbosity repo = case repoKind repo of
     notice verbosity $ "Downloading the latest package list from "
                     ++ remoteRepoName remoteRepo
     indexPath <- downloadIndex verbosity remoteRepo (repoLocalDir repo)
-    writeFileAtomic (dropExtension indexPath) . BS.Char8.unpack
-                                              . maybeDecompress
+    writeFileAtomic (dropExtension indexPath) . maybeDecompress
                                             =<< BS.readFile indexPath
     updateRepoIndexCache verbosity repo
 


### PR DESCRIPTION
Currently, 'cabal update' uses Distribution.Simple.Utils.writeFileAtomic.
But it requires data as `String`, so very very slow.
3.7MB of 00-index.tar.gz is extracted to 61MB of 00-index.tar.
It takes about 8 seconds to write 00-index.tar on my machine (i5-2400 CPU @ 3.10GHz).
cabal-install can depends on `bytestring', so I rewrite`writeFileAtomic` to use bytstring.
The bottleneck is resolved (< 1 second).
