### PR TITLE
Adapt to package-conf -> package-db change

### DIFF
--- a/Cabal/tests/PackageTests/PackageTester.hs
+++ b/Cabal/tests/PackageTests/PackageTester.hs
@@ -132,7 +132,7 @@ cabal spec cabalArgs = do
     r <- run (Just $ directory spec) "ghc"
              [ "--make"
              , "-fhpc"
-             , "-package-conf " ++ wd </> "../dist/package.conf.inplace"
+             , "-package-db " ++ wd </> "../dist/package.conf.inplace"
              , "Setup.hs"
              ]
     requireSuccess r


### PR DESCRIPTION
GHC and ghc-pkg package db flags changed from '_-package-conf' to
'_-package-db' in 7.5.  This commit follows the change and introduces a
version check whenever those flags are used.

See http://hackage.haskell.org/trac/ghc/ticket/5977.
