### PR TITLE
Automatically configure and build before 'cabal test' and 'cabal bench'

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -27,6 +27,7 @@ module Distribution.Client.Setup
     , unpackCommand, UnpackFlags(..)
     , initCommand, IT.InitFlags(..)
     , sdistCommand, SDistFlags(..), SDistExFlags(..), ArchiveFormat(..)
+    , commandWithConfigFlags
 
     , parsePackageArgs
     --TODO: stop exporting these:
@@ -1117,6 +1118,24 @@ instance Monoid SDistExFlags where
   }
     where
       combine field = field a `mappend` field b
+
+-- ------------------------------------------------------------
+-- * Test and Benchmark Flags
+-- ------------------------------------------------------------
+
+commandWithConfigFlags :: Monoid a => CommandUI a
+                       -> CommandUI (ConfigFlags, ConfigExFlags, a)
+commandWithConfigFlags wrappedCommand = wrappedCommand
+    { commandOptions = \showOrParseArgs ->
+        liftOptions get1 set1 (configureOptions showOrParseArgs)
+        ++ liftOptions get2 set2 (configureExOptions showOrParseArgs)
+        ++ liftOptions get3 set3 (commandOptions wrappedCommand showOrParseArgs)
+    , commandDefaultFlags = (mempty, mempty, mempty)
+    } 
+  where
+    get1 (a,_,_) = a; set1 a (_,b,c) = (a,b,c)
+    get2 (_,b,_) = b; set2 b (a,_,c) = (a,b,c)
+    get3 (_,_,c) = c; set3 c (a,b,_) = (a,b,c)
 
 -- ------------------------------------------------------------
 -- * GetOpt Utils


### PR DESCRIPTION
Issue: https://github.com/haskell/cabal/issues/585

I can merge this pull request myself, but I wanted to solicit feedback from interested parties first (especially because of the command line UI change).

This patch changes the behaviour of the test and bench commands in cabal-install so that the package in the current directory is configured and built before attempting to run the test suites or benchmarks. The net result is that running 'cabal unpack foo; cd foo; cabal test' does what you mean, rather than ordering you to run 'cabal configure' first. Happily, this also solves the problem where a developer's changes were not being detected in the test suite because the affected files had not been rebuilt.

This is accompanied by a user interface change: the test and bench commands now accept ConfigFlags and ConfigExFlags in the same way the install command does. I think the test and bench commands  should reflect the install command because they now do mostly the same things. Also, if we plan to have the test and bench commands eventually pull in the necessary dependencies, there will really be no way around this UI change.
