### PR TITLE
Initialise the 'jobs' config file setting with the current number of CPU cores.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -36,6 +36,8 @@ import Distribution.Client.Setup
          , UploadFlags(..), uploadCommand
          , ReportFlags(..), reportCommand
          , showRepo, parseRepo )
+import Distribution.Client.Utils
+         ( numberOfProcessors )
 
 import Distribution.Simple.Compiler
          ( OptimisationLevel(..) )
@@ -200,7 +202,8 @@ initialSavedConfig = do
     },
     savedInstallFlags    = mempty {
       installSummaryFile = [toPathTemplate (logsDir </> "build.log")],
-      installBuildReports= toFlag AnonymousReports
+      installBuildReports= toFlag AnonymousReports,
+      installNumJobs     = toFlag (Just numberOfProcessors)
     }
   }
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -616,7 +616,7 @@ data InstallFlags = InstallFlags {
     installBuildReports     :: Flag ReportLevel,
     installSymlinkBinDir    :: Flag FilePath,
     installOneShot          :: Flag Bool,
-    installNumJobs          :: Flag Int
+    installNumJobs          :: Flag (Maybe Int)
   }
 
 defaultInstallFlags :: InstallFlags
@@ -640,7 +640,7 @@ defaultInstallFlags = InstallFlags {
     installBuildReports    = Flag NoReports,
     installSymlinkBinDir   = mempty,
     installOneShot         = Flag False,
-    installNumJobs         = Flag 1
+    installNumJobs         = mempty
   }
   where
     docIndexFile = toPathTemplate ("$datadir" </> "doc" </> "index.html")
@@ -792,9 +792,11 @@ installOptions showOrParseArgs =
       , option "j" ["jobs"]
         "Run NUM jobs simultaneously."
         installNumJobs (\v flags -> flags { installNumJobs = v })
-        (reqArg "NUM" (readP_to_E (\_ -> "jobs should be a number")
-                                  (fmap toFlag (Parse.readS_to_P reads)))
-                      (map show . flagToList))
+        (optArg "NUM" (readP_to_E (\_ -> "jobs should be a number")
+                                  (fmap (toFlag . Just)
+                                        (Parse.readS_to_P reads)))
+                      (Flag Nothing)
+                      (map (fmap show) . flagToList))
       ] ++ case showOrParseArgs of      -- TODO: remove when "cabal install" avoids
           ParseArgs ->
             option [] ["only"]

--- a/cabal-install/Distribution/Client/Utils.hs
+++ b/cabal-install/Distribution/Client/Utils.hs
@@ -1,10 +1,17 @@
-module Distribution.Client.Utils where
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Distribution.Client.Utils ( MergeResult(..)
+                                 , mergeBy, duplicates, duplicatesBy
+                                 , moreRecentFile, inDir, numberOfProcessors )
+       where
 
 import Data.List
          ( sortBy, groupBy )
+import Foreign.C.Types ( CInt(..) )
 import System.Directory
          ( doesFileExist, getModificationTime
          , getCurrentDirectory, setCurrentDirectory )
+import System.IO.Unsafe ( unsafePerformIO )
 import qualified Control.Exception as Exception
          ( finally )
 
@@ -58,3 +65,10 @@ inDir (Just d) m = do
   old <- getCurrentDirectory
   setCurrentDirectory d
   m `Exception.finally` setCurrentDirectory old
+
+foreign import ccall "getNumberOfProcessors" c_getNumberOfProcessors :: IO CInt
+
+-- The number of processors is not going to change during the duration of the
+-- program, so unsafePerformIO is safe here.
+numberOfProcessors :: Int
+numberOfProcessors = fromEnum $ unsafePerformIO c_getNumberOfProcessors

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -136,4 +136,5 @@ Executable cabal
       cpp-options: -DWIN32
     else
       build-depends: unix >= 1.0 && < 2.6
-    extensions: CPP
+    extensions: CPP, ForeignFunctionInterface
+    c-sources: cbits/getnumcores.c

--- a/cabal-install/cbits/getnumcores.c
+++ b/cabal-install/cbits/getnumcores.c
@@ -1,0 +1,46 @@
+#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 612)
+/* Since version 6.12, GHC's threaded RTS includes a getNumberOfProcessors
+   function, so we try to use that if available. cabal-install is always built
+   with -threaded nowadays.  */
+#define HAS_GET_NUMBER_OF_PROCESSORS
+#endif
+
+
+#ifndef HAS_GET_NUMBER_OF_PROCESSORS
+
+#ifdef _WIN32
+#include <windows.h>
+#elif MACOS
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#elif __linux__
+#include <unistd.h>
+#endif
+
+int getNumberOfProcessors() {
+#ifdef WIN32
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    return sysinfo.dwNumberOfProcessors;
+#elif MACOS
+    int nm[2];
+    size_t len = 4;
+    uint32_t count;
+
+    nm[0] = CTL_HW; nm[1] = HW_AVAILCPU;
+    sysctl(nm, 2, &count, &len, NULL, 0);
+
+    if(count < 1) {
+        nm[1] = HW_NCPU;
+        sysctl(nm, 2, &count, &len, NULL, 0);
+        if(count < 1) { count = 1; }
+    }
+    return count;
+#elif __linux__
+    return sysconf(_SC_NPROCESSORS_ONLN);
+#else
+    return 1;
+#endif
+}
+
+#endif /* HAS_GET_NUMBER_OF_PROCESSORS */


### PR DESCRIPTION
Fixes #982. Additionally, running `install -j` without the numerical argument
will have the same effect at runtime.

Side effect: `install -jNUM` doesn't work when there's a space between `-j` and
`NUM` (a peculiarity of the Cabal option parser).
