### PR TITLE
'cabal build' implies 'cabal configure'; 'cabal test' and 'cabal bench' imply 'cabal build'

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -15,6 +15,7 @@ module Distribution.Client.Setup
     , configureCommand, ConfigFlags(..), filterConfigureFlags
     , configureExCommand, ConfigExFlags(..), defaultConfigExFlags
                         , configureExOptions
+    , buildCommand, BuildFlags(..)
     , installCommand, InstallFlags(..), installOptions, defaultInstallFlags
     , listCommand, ListFlags(..)
     , updateCommand
@@ -49,9 +50,9 @@ import Distribution.Simple.Program
          ( defaultProgramConfiguration )
 import Distribution.Simple.Command hiding (boolOpt)
 import qualified Distribution.Simple.Setup as Cabal
-         ( configureCommand, sdistCommand, haddockCommand )
+         ( configureCommand, buildCommand, sdistCommand, haddockCommand )
 import Distribution.Simple.Setup
-         ( ConfigFlags(..), SDistFlags(..), HaddockFlags(..) )
+         ( ConfigFlags(..), BuildFlags(..), SDistFlags(..), HaddockFlags(..) )
 import Distribution.Simple.Setup
          ( Flag(..), toFlag, fromFlag, flagToMaybe, flagToList
          , optionVerbosity, boolOpt, trueArg, falseArg )
@@ -297,6 +298,15 @@ instance Monoid ConfigExFlags where
     configSolver       = combine configSolver
   }
     where combine field = field a `mappend` field b
+
+-- ------------------------------------------------------------
+-- * Build flags
+-- ------------------------------------------------------------
+
+buildCommand :: CommandUI BuildFlags
+buildCommand = (Cabal.buildCommand defaultProgramConfiguration) {
+    commandDefaultFlags = mempty
+  }
 
 -- ------------------------------------------------------------
 -- * Fetch command


### PR DESCRIPTION
These commits improve the user interface of the cabal-install tool by automatically running 'configure' before 'build' as necessary and by running `build` before `test` and `bench`. The end result is that `cabal unpack foo; cd foo; cabal test` very probably does what the user expects.

The commits for running `build` before `test` and `bench` are largely plumbing. The first commit, which runs `configure` before `build`, has a bit of convoluted logic to decide what `ConfigFlags` to use when reconfiguring.
