### PR TITLE
Set bug-reports to github instead of trac in cabal-install.cabal.

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -6,7 +6,7 @@ Description:
     Haskell software by automating the fetching, configuration, compilation
     and installation of Haskell libraries and programs.
 homepage:           http://www.haskell.org/cabal/
-bug-reports:        http://hackage.haskell.org/trac/hackage/
+bug-reports:        https://github.com/haskell/cabal/issues
 License:            BSD3
 License-File:       LICENSE
 Author:             Lemmih <lemmih@gmail.com>


### PR DESCRIPTION
This link shows up on the hackage page for cabal-install.
That will often be the first place people will look if they
need to report a bug. So this is important.
