### PR TITLE
Fix for autoconf misbehaviour caused by cabal

### DIFF
--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -632,7 +632,7 @@ runConfigureScript verbosity backwardsCompatHack flags lbi = do
     rawSystemExitWithEnv verbosity "sh" args' env'
 
   where
-    args = "configure" : configureArgs backwardsCompatHack flags
+    args = "./configure" : configureArgs backwardsCompatHack flags
 
     appendToEnvironment (key, val) [] = [(key, val)]
     appendToEnvironment (key, val) (kv@(k, v) : rest)


### PR DESCRIPTION
The autoconf generated configure script tries to automatically determine the
location of the configure script. If the name (argv[0]) of the configure script
does not include a path separator autoconf will _first_ scan the path for a
file named "configure" before defaulting to the current directory.

Cabal previously called configure by doing "sh configure" this will result in
it finding any files named "configure" in the path and using the location of
that file as the basedir to look for (amongst other things) C sources. The
result is that any C sources in the unpacked cabal directories are not found,
resulting in configure/build failures for all such packages (e.g. unix-time)
and all packages depending on those.

Changing cabal to call "sh ./configure" will avoid this behaviour, the presence
of a path separator causes autoconf to default to checking the current
directory _first_.
