### PR TITLE
Compiling against directory-1.2.0.0

### DIFF
--- a/cabal-install/Distribution/Client/Tar.hs
+++ b/cabal-install/Distribution/Client/Tar.hs
@@ -91,8 +91,8 @@ import Distribution.Compat.FilePerms
          ( setFileExecutable )
 import System.Posix.Types
          ( FileMode )
-import System.Time
-         ( ClockTime(..) )
+import Data.Time.Clock.POSIX
+         ( utcTimeToPOSIXSeconds )
 import System.IO
          ( IOMode(ReadMode), openBinaryFile, hFileSize )
 import System.IO.Unsafe (unsafeInterleaveIO)
@@ -930,5 +930,5 @@ recurseDirectories base (dir:dirs) = unsafeInterleaveIO $ do
 
 getModTime :: FilePath -> IO EpochTime
 getModTime path = do
-  (TOD s _) <- getModificationTime path
-  return $! fromIntegral s
+  utc <- getModificationTime path
+  return $! round $ utcTimeToPOSIXSeconds utc

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -122,7 +122,7 @@ Executable cabal
     else
       build-depends: base       >= 3,
                      process    >= 1   && < 1.2,
-                     directory  >= 1   && < 1.3,
+                     directory  >= 1.2 && < 1.3,
                      pretty     >= 1   && < 1.2,
                      random     >= 1   && < 1.1,
                      containers >= 0.1 && < 0.6,
@@ -138,6 +138,6 @@ Executable cabal
       build-depends: Win32 >= 2 && < 3
       cpp-options: -DWIN32
     else
-      build-depends: unix >= 1.0 && < 2.6
+      build-depends: unix >= 1.0 && < 2.7
     extensions: CPP, ForeignFunctionInterface
     c-sources: cbits/getnumcores.c


### PR DESCRIPTION
I was working on getting some sort of cabal-install installed on top of my brand-new ghc-7.6.1. I ended up going with HEAD...but I found a problem when compiling against directory-1.2.0.0. The return type of getModificationTime changed from ClockTime (from the old-time package) to UTCTime (from the time package).

I don't know what the procedure is for this sort of thing...but the code works for me, so hopefully it's useful to everyone else.
