### PR TITLE
cabal-install.cabal: add missing new modules

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -108,6 +108,7 @@ Executable cabal
         Distribution.Client.Win32SelfUpgrade
         Distribution.Compat.Exception
         Distribution.Compat.FilePerms
+        Distribution.Compat.Time
         Paths_cabal_install
 
     build-depends: base     >= 2        && < 5,


### PR DESCRIPTION
Add missing Distribution.Client.JobControl, Distribution.Client.Sandbox, and Distribution.Compat.Time modules to cabal-install.cabal to allow building sdist tarball.
