### PR TITLE
cabal-install.cabal: add missing modules

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -86,6 +86,7 @@ Executable cabal
         Distribution.Client.Install
         Distribution.Client.InstallPlan
         Distribution.Client.InstallSymlink
+        Distribution.Client.JobControl
         Distribution.Client.List
         Distribution.Client.PackageIndex
         Distribution.Client.PackageUtils
@@ -103,6 +104,7 @@ Executable cabal
         Distribution.Client.Win32SelfUpgrade
         Distribution.Compat.Exception
         Distribution.Compat.FilePerms
+        Distribution.Compat.Time
         Paths_cabal_install
 
     build-depends: base     >= 2        && < 5,


### PR DESCRIPTION
Add Distribution.Client.JobControl and Distribution.Compat.Time modules to cabal-install.cabal so that cabal-install sdist tarball can build.
