### PR TITLE
Make compatible with `network-2.4` API

### DIFF
--- a/cabal-install/Distribution/Client/BuildReports/Upload.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Upload.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE CPP, PatternGuards #-}
 -- This is a quick hack for uploading build reports to Hackage.
 
 module Distribution.Client.BuildReports.Upload
@@ -51,7 +51,11 @@ postBuildReport uri buildReport = do
   }
   case rspCode response of
     (3,0,3) | [Just buildId] <- [ do rel <- parseRelativeReference location
+#if MIN_VERSION_network(2,4,0)
+                                     return $ relativeTo rel uri
+#else
                                      relativeTo rel uri
+#endif
                                   | Header HdrLocation location <- rspHeaders response ]
               -> return $ buildId
     _         -> error "Unrecognised response from server."


### PR DESCRIPTION
The specific API change in `relativeTo` this changeset
compensates for has been introduced in

 haskell/network@4a3fdefe2228e0998bbf80969e5dddf943ebe99a
