### PR TITLE
Add way to exclude generated modules from sdists

### DIFF
--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -56,11 +56,13 @@ module Distribution.Simple.SrcDist (
 
   -- ** Parts of 'sdist'
   printPackageProblems,
+  prepareTreeWithoutGeneratedModules,
   prepareTree,
   createArchive,
 
   -- ** Snaphots
   prepareSnapshotTree,
+  prepareSnapshotTreeWithoutGeneratedModules,
   snapshotPackage,
   snapshotVersion,
   dateToSnapshotNumber,
@@ -140,17 +142,17 @@ sdist pkg mb_lbi flags mkTmpDir pps = do
     generateSourceDir targetDir pkg' = do
 
       setupMessage verbosity "Building source dist for" (packageId pkg')
-      prepareTree verbosity pkg' mb_lbi distPref targetDir pps
+      prepareTreeWithoutGeneratedModules verbosity pkg' mb_lbi distPref targetDir pps generatedModules
       when snapshot $
         overwriteSnapshotPackageDesc verbosity pkg' targetDir
 
     verbosity = fromFlag (sDistVerbosity flags)
     snapshot  = fromFlag (sDistSnapshot flags)
+    generatedModules = sDistGeneratedModules flags
 
     distPref     = fromFlag $ sDistDistPref flags
     targetPref   = distPref
     tmpTargetDir = mkTmpDir distPref
-
 
 -- |Prepare a directory tree of source files.
 prepareTree :: Verbosity          -- ^verbosity
@@ -160,7 +162,21 @@ prepareTree :: Verbosity          -- ^verbosity
             -> FilePath           -- ^source tree to populate
             -> [PPSuffixHandler]  -- ^extra preprocessors (includes suffixes)
             -> IO ()
-prepareTree verbosity pkg_descr0 mb_lbi distPref targetDir pps = do
+prepareTree verbosity pkg_descr mb_lbi distPref targetDir pps =
+  prepareTreeWithoutGeneratedModules verbosity pkg_descr mb_lbi distPref targetDir pps []
+
+-- |Prepare a directory tree of source files, except for generated modules.
+-- Note that this automatically ignores the Paths_<pkg>.hs module.
+prepareTreeWithoutGeneratedModules 
+    :: Verbosity          -- ^verbosity
+    -> PackageDescription -- ^info from the cabal file
+    -> Maybe LocalBuildInfo
+    -> FilePath           -- ^dist dir
+    -> FilePath           -- ^source tree to populate
+    -> [PPSuffixHandler]  -- ^extra preprocessors (includes suffixes)
+    -> [ModuleName]       -- ^generated modules to ignore
+    -> IO ()
+prepareTreeWithoutGeneratedModules verbosity pkg_descr0 mb_lbi distPref targetDir pps generatedModules0 = do
   createDirectoryIfMissingVerbose verbosity True targetDir
 
   -- maybe move the library files into place
@@ -262,11 +278,12 @@ prepareTree verbosity pkg_descr0 mb_lbi distPref targetDir pps = do
   installOrdinaryFile verbosity descFile (targetDir </> descFile)
 
   where
-    pkg_descr = mapAllBuildInfo filterAutogenModule pkg_descr0
-    filterAutogenModule bi = bi {
-      otherModules = filter (/=autogenModule) (otherModules bi)
+    pkg_descr = mapAllBuildInfo filterGeneratedModules pkg_descr0
+    filterGeneratedModules bi = bi {
+      otherModules = filter (flip notElem generatedModules) (otherModules bi)
     }
-    autogenModule = autogenModuleName pkg_descr0
+    -- Paths_<pkg>.hs, as well as the modules specified by the caller.
+    generatedModules = autogenModuleName pkg_descr0 : generatedModules0
 
     findInc [] f = die ("can't find include file " ++ f)
     findInc (d:ds) f = do
@@ -292,8 +309,24 @@ prepareSnapshotTree :: Verbosity          -- ^verbosity
                     -> FilePath           -- ^source tree to populate
                     -> [PPSuffixHandler]  -- ^extra preprocessors (includes suffixes)
                     -> IO ()
-prepareSnapshotTree verbosity pkg mb_lbi distPref targetDir pps = do
-  prepareTree verbosity pkg mb_lbi distPref targetDir pps
+prepareSnapshotTree verbosity pkg mb_lbi distPref targetDir pps =
+  prepareSnapshotTreeWithoutGeneratedModules verbosity pkg mb_lbi distPref targetDir pps []
+
+-- | Prepare a directory tree of source files for a snapshot version, without
+-- the specified generated modules (as well as Paths_<pkg>.hs).
+-- It is expected that the appropriate snapshot version has already been set
+-- in the package description, eg using 'snapshotPackage' or 'snapshotVersion'.
+prepareSnapshotTreeWithoutGeneratedModules
+    :: Verbosity          -- ^verbosity
+    -> PackageDescription -- ^info from the cabal file
+    -> Maybe LocalBuildInfo
+    -> FilePath           -- ^dist dir
+    -> FilePath           -- ^source tree to populate
+    -> [PPSuffixHandler]  -- ^extra preprocessors (includes suffixes)
+    -> [ModuleName]       -- ^generated modules to ignore
+    -> IO ()
+prepareSnapshotTreeWithoutGeneratedModules verbosity pkg mb_lbi distPref targetDir pps generatedModules = do
+  prepareTreeWithoutGeneratedModules verbosity pkg mb_lbi distPref targetDir pps generatedModules
   overwriteSnapshotPackageDesc verbosity pkg targetDir
 
 overwriteSnapshotPackageDesc :: Verbosity          -- ^verbosity

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -278,10 +278,17 @@ prepareTreeWithoutGeneratedModules verbosity pkg_descr0 mb_lbi distPref targetDi
   installOrdinaryFile verbosity descFile (targetDir </> descFile)
 
   where
-    pkg_descr = mapAllBuildInfo filterGeneratedModules pkg_descr0
-    filterGeneratedModules bi = bi {
-      otherModules = filter (flip notElem generatedModules) (otherModules bi)
+    pkg_descr1 = mapAllBuildInfo filterGeneratedOtherModules pkg_descr0
+    pkg_descr = pkg_descr1 {
+      library = fmap filterGeneratedExposedModules (library pkg_descr1)
     }
+    filterGeneratedOtherModules bi = bi {
+      otherModules = filterGeneratedModules (otherModules bi)
+    }
+    filterGeneratedExposedModules libr = libr {
+      exposedModules = filterGeneratedModules (exposedModules libr)
+    }
+    filterGeneratedModules = filter (flip notElem generatedModules)
     -- Paths_<pkg>.hs, as well as the modules specified by the caller.
     generatedModules = autogenModuleName pkg_descr0 : generatedModules0
 

--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -785,12 +785,21 @@ the setup script, the sources of the modules named in the package
 description file, and files named in the `license-file`, `main-is`,
 `c-sources`, `data-files` and `extra-source-files` fields.
 
+If the package includes generated Haskell source files, they can be
+excluded from the distribution on the command line.  `Paths_`_pkgname_
+does not need to be so specified; Cabal automatically knows to exclude it.
+
 This command takes the following option:
 
 `--snapshot`
 :   Append today's date (in "YYYYMMDD" format) to the version number for
     the generated source package.  The original package is unaffected.
 
+`--generated-module=`_module_
+:   Specify that the named module is machine-generated and not to be included
+    it in the distribution.  Note that this takes a module name, not a
+    path name (that is, `Distribution.GeneratedModule` rather than
+    `Distribution/GeneratedModule.hs`).
 
 [dist-simple]:  ../libraries/Cabal/Distribution-Simple.html
 [dist-make]:    ../libraries/Cabal/Distribution-Make.html

--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -788,6 +788,8 @@ description file, and files named in the `license-file`, `main-is`,
 If the package includes generated Haskell source files, they can be
 excluded from the distribution on the command line.  `Paths_`_pkgname_
 does not need to be so specified; Cabal automatically knows to exclude it.
+All the necessary scripts and data to re-generate the modules should be listed
+in the `extra-source-files` field of the `.cabal` file.
 
 This command takes the following option:
 


### PR DESCRIPTION
In one of my projects, I am machine-generating a number of modules, which other parts of the code then import. These need to be specified in the .cabal file, otherwise hard-to-debug linker errors happen. However, then they get included in sdist tarballs, or sdist chokes if they're not present, which is undesirable. This patch lets generated modules be excluded from sdists on the command line with a `--generated-module` option.

(An alternative (and perhaps more robust) approach would be to add a `generated-modules` field to cabal files, but that's only just occurred to me and this patch is sitting here!)