### PR TITLE
Warn when the executable install dir is not in $PATH.

### DIFF
--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -54,8 +54,9 @@ import Distribution.Simple.LocalBuildInfo (
         substPathTemplate)
 import Distribution.Simple.BuildPaths (haddockName, haddockPref)
 import Distribution.Simple.Utils
-         ( createDirectoryIfMissingVerbose, installDirectoryContents
-         , installOrdinaryFile, die, info, notice, matchDirFileGlob )
+         ( createDirectoryIfMissingVerbose
+         , installDirectoryContents, installOrdinaryFile, isInSearchPath
+         , die, info, notice, warn, matchDirFileGlob )
 import Distribution.Simple.Compiler
          ( CompilerFlavor(..), compilerFlavor )
 import Distribution.Simple.Setup (CopyFlags(..), CopyDest(..), fromFlag)
@@ -143,8 +144,12 @@ install pkg_descr lbi flags = do
   let buildPref = buildDir lbi
   when (hasLibs pkg_descr) $
     notice verbosity ("Installing library in " ++ libPref)
-  when (hasExes pkg_descr) $
+  when (hasExes pkg_descr) $ do
     notice verbosity ("Installing executable(s) in " ++ binPref)
+    inPath <- isInSearchPath binPref
+    when (not inPath) $
+      warn verbosity ("The directory " ++ binPref
+                      ++ " is not in the system search path.")
 
   -- install include files for all compilers - they may be needed to compile
   -- haskell files (using the CPP extension)

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -97,6 +97,9 @@ module Distribution.Simple.Utils (
         findModuleFiles,
         getDirectoryContentsRecursive,
 
+        -- * environment variables
+        isInSearchPath,
+
         -- * simple file globbing
         matchFileGlob,
         matchDirFileGlob,
@@ -161,7 +164,8 @@ import System.Cmd
 import System.Exit
     ( exitWith, ExitCode(..) )
 import System.FilePath
-    ( normalise, (</>), (<.>), takeDirectory, splitFileName
+    ( normalise, (</>), (<.>)
+    , getSearchPath, takeDirectory, splitFileName
     , splitExtension, splitExtensions, splitDirectories )
 import System.Directory
     ( createDirectory, renameFile, removeDirectoryRecursive )
@@ -691,6 +695,13 @@ getDirectoryContentsRecursive topdir = recurseDirectories [""]
         ignore ['.']      = True
         ignore ['.', '.'] = True
         ignore _          = False
+
+------------------------
+-- Environment variables
+
+-- | Is this directory in the system search path?
+isInSearchPath :: FilePath -> IO Bool
+isInSearchPath path = fmap (elem path) getSearchPath
 
 ----------------
 -- File globbing


### PR DESCRIPTION
In [this Reddit thread](http://www.reddit.com/r/haskell/comments/12alw1/why_inbreeding_is_bad_for_your_community_cabal/) some people suggested that cabal-install should print a warning when installing binaries to a directory that is not in PATH. This patch implements that suggestion.

Example of how this warning looks like in action:

```
$ cabal install ghc-core
[...]
Linking dist/build/ghc-core/ghc-core ...
Installing executable(s) in /home/cabal-test/.cabal/bin
Warning: The directory /home/cabal-test/.cabal/bin is not in the system search
path.
Installed ghc-core-0.5.4
```
