### PR TITLE
Re-enable setting jobs: $nprocs in the default ~/.cabal/config.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -44,6 +44,7 @@ import Distribution.Client.Setup
          , UploadFlags(..), uploadCommand
          , ReportFlags(..), reportCommand
          , showRepo, parseRepo )
+import Distribution.Client.Utils (numberOfProcessors)
 
 import Distribution.Simple.Compiler
          ( OptimisationLevel(..) )
@@ -209,8 +210,8 @@ initialSavedConfig = do
     },
     savedInstallFlags    = mempty {
       installSummaryFile = [toPathTemplate (logsDir </> "build.log")],
-      installBuildReports= toFlag AnonymousReports
-      --installNumJobs     = toFlag (Just numberOfProcessors)
+      installBuildReports= toFlag AnonymousReports,
+      installNumJobs     = toFlag (Just numberOfProcessors)
     }
   }
 


### PR DESCRIPTION
This feature was disabled because it doesn't work with Cabal-1.16, but the
cabal-install in master has a '>= 1.17.0 & < 1.18' dependency.
