### PR TITLE
Replace use of deprecated QSem with MVar 

### DIFF
--- a/cabal-install/Distribution/Client/JobControl.hs
+++ b/cabal-install/Distribution/Client/JobControl.hs
@@ -28,8 +28,9 @@ module Distribution.Client.JobControl (
   ) where
 
 import Control.Monad
-import Control.Concurrent
+import Control.Concurrent hiding (QSem, newQSem, waitQSem, signalQSem)
 import Control.Exception
+import Distribution.Compat.Semaphore
 
 data JobControl m a = JobControl {
        spawnJob    :: m a -> m (),

--- a/cabal-install/Distribution/Compat/Semaphore.hs
+++ b/cabal-install/Distribution/Compat/Semaphore.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+module Distribution.Compat.Semaphore (
+    QSem, newQSem, waitQSem, signalQSem
+  ) where
+
+import Control.Concurrent hiding (QSem, newQSem, waitQSem, signalQSem)
+import Control.Concurrent.STM
+import Control.Monad
+import Data.Typeable
+import Control.Exception
+
+data QSem = QSem !(TVar Int) !(TVar [TVar Bool]) !(TVar [TVar Bool])
+  deriving (Eq, Typeable)
+
+newQSem :: Int -> IO QSem
+newQSem i = atomically $ do
+  q <- newTVar i
+  b1 <- newTVar []
+  b2 <- newTVar []
+  return (QSem q b1 b2)
+
+waitQSem :: QSem -> IO ()
+waitQSem (QSem q b1 b2) =
+  join $ atomically $ do
+     v <- readTVar q
+     if v == 0
+        then do b <- newTVar False
+                ys <- readTVar b2
+                writeTVar b2 (b:ys)
+                return (wait b)
+        else do writeTVar q $! v - 1
+                return (return ())
+
+wait t = atomically $ do
+  v <- readTVar t
+  when (not v) retry
+
+wake t = atomically $ writeTVar t True
+
+signalQSem :: QSem -> IO ()
+signalQSem (QSem q b1 b2) = mask_ $ join $ atomically $ do
+         -- join, so we don't force the reverse inside the txn
+         -- mask_ is needed so we don't lose a wakeup
+  v <- readTVar q
+  if v /= 0
+     then do writeTVar q $! v + 1
+             return (return ())
+     else do
+        xs <- readTVar b1
+        case xs of
+            [] -> do ys <- readTVar b2
+                     case ys of
+                       [] -> do writeTVar q 1
+                                return (return ())
+                       _  -> do let (z:zs) = reverse ys
+                                writeTVar b1 zs
+                                writeTVar b2 []
+                                return (wake z)
+            (b:xs') -> do writeTVar b1 xs'
+                          return (wake b)

--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -58,6 +58,7 @@ HTTP_VER="4000.2.4";   HTTP_VER_REGEXP="4000\.[012]\." # == 4000.0.* || 4000.1.*
 ZLIB_VER="0.5.4.0";    ZLIB_VER_REGEXP="0\.[45]\." # == 0.4.* || == 0.5.*
 TIME_VER="1.4.0.1"     TIME_VER_REGEXP="1\.[1234]\.?" # >= 1.1 && < 1.5
 RANDOM_VER="1.0.1.1"   RANDOM_VER_REGEXP="1\.0\." # >= 1 && < 1.1
+STM_VER="2.4";         STM_VER_REGEXP="2\." # == 2.*
 
 HACKAGE_URL="http://hackage.haskell.org/packages/archive"
 
@@ -198,6 +199,7 @@ info_pkg "time"         ${TIME_VER}    ${TIME_VER_REGEXP}
 info_pkg "HTTP"         ${HTTP_VER}    ${HTTP_VER_REGEXP}
 info_pkg "zlib"         ${ZLIB_VER}    ${ZLIB_VER_REGEXP}
 info_pkg "random"       ${RANDOM_VER}  ${RANDOM_VER_REGEXP}
+info_pkg "stm"          ${STM_VER}     ${STM_VER_REGEXP}
 
 do_pkg   "Cabal"        ${CABAL_VER}   ${CABAL_VER_REGEXP}
 do_pkg   "transformers" ${TRANS_VER}   ${TRANS_VER_REGEXP}
@@ -210,6 +212,7 @@ do_pkg   "time"         ${TIME_VER}    ${TIME_VER_REGEXP}
 do_pkg   "HTTP"         ${HTTP_VER}    ${HTTP_VER_REGEXP}
 do_pkg   "zlib"         ${ZLIB_VER}    ${ZLIB_VER_REGEXP}
 do_pkg   "random"       ${RANDOM_VER}  ${RANDOM_VER_REGEXP}
+do_pkg   "stm"          ${STM_VER}     ${STM_VER_REGEXP}
 
 install_pkg "cabal-install"
 

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -119,7 +119,8 @@ Executable cabal
                    HTTP     >= 4000.0.8 && < 4001,
                    zlib     >= 0.4      && < 0.6,
                    time     >= 1.1      && < 1.5,
-                   mtl      >= 2.0      && < 3
+                   mtl      >= 2.0      && < 3,
+                   stm      >= 2.0      && < 3
 
     if flag(old-base)
       build-depends: base < 3


### PR DESCRIPTION
If my reading of the MVar documentation is correct, this should be safe
as we are accounting for the case where two threads can putMVar
simultaneously. Would someone like to confirm this? Otherwise it compiles and appears to work correctly (although testing is hampered by the brokenness of my GHC 7.7 tree at the moment).
