### PR TITLE
Fix HPC report generation for tests with internal package dependencies

### DIFF
--- a/Cabal/Distribution/Simple/Program/Hpc.hs
+++ b/Cabal/Distribution/Simple/Program/Hpc.hs
@@ -13,37 +13,53 @@ module Distribution.Simple.Program.Hpc
     , union
     ) where
 
+import Control.Monad ( unless )
 import Distribution.ModuleName ( ModuleName )
 import Distribution.Simple.Program.Run
          ( ProgramInvocation, programInvocation, runProgramInvocation )
-import Distribution.Simple.Program.Types ( ConfiguredProgram )
+import Distribution.Simple.Program.Types ( ConfiguredProgram(..) )
 import Distribution.Text ( display )
+import Distribution.Simple.Utils ( warn )
 import Distribution.Verbosity ( Verbosity )
+import Distribution.Version ( Version(..), orLaterVersion, withinRange )
 
 markup :: ConfiguredProgram
        -> Verbosity
        -> FilePath            -- ^ Path to .tix file
-       -> FilePath            -- ^ Path to directory with .mix files
+       -> [FilePath]          -- ^ Paths to .mix file directories
        -> FilePath            -- ^ Path where html output should be located
        -> [ModuleName]        -- ^ List of modules to exclude from report
        -> IO ()
-markup hpc verbosity tixFile hpcDir destDir excluded =
+markup hpc verbosity tixFile hpcDirs destDir excluded = do
+    unless atLeastHpc07 $ warn verbosity $
+           "This version of HPC has known issues. Coverage report generation "
+        ++ "may fail unexpectedly. Please upgrade to HPC 0.7 or later "
+        ++ "(GHC 7.8 or later) as soon as possible."
+        ++ versionMsg
     runProgramInvocation verbosity
-      (markupInvocation hpc tixFile hpcDir destDir excluded)
+      (markupInvocation hpc tixFile hpcDirs' destDir excluded)
+  where
+    hpcDirs' | atLeastHpc07 = hpcDirs
+             | otherwise = take 1 hpcDirs
+    atLeastHpc07 = maybe False (flip withinRange $ orLaterVersion version07)
+        $ programVersion hpc
+    version07 = Version { versionBranch = [0, 7], versionTags = [] }
+    versionMsg = maybe "" (\v -> " (Found HPC " ++ display v ++ ")")
+                          (programVersion hpc)
 
 markupInvocation :: ConfiguredProgram
                  -> FilePath            -- ^ Path to .tix file
-                 -> FilePath            -- ^ Path to directory with .mix files
+                 -> [FilePath]          -- ^ Paths to .mix file directories
                  -> FilePath            -- ^ Path where html output should be
                                         -- located
                  -> [ModuleName]        -- ^ List of modules to exclude from
                                         -- report
                  -> ProgramInvocation
-markupInvocation hpc tixFile hpcDir destDir excluded =
+markupInvocation hpc tixFile hpcDirs destDir excluded =
     let args = [ "markup", tixFile
-               , "--hpcdir=" ++ hpcDir
                , "--destdir=" ++ destDir
                ]
+            ++ map ("--hpcdir=" ++) hpcDirs
             ++ ["--exclude=" ++ display moduleName
                | moduleName <- excluded ]
     in programInvocation hpc args


### PR DESCRIPTION
Addresses ticket #1049. In conjunction with a new version of HPC, specifies all the .mix file search paths necessary to markup tests. Warns users of older versions of HPC that markup may fail and suggests that they upgrade.

I would not pull this until GHC accepts my patch to HPC, just in any changes become necessary on the Cabal side.
