### PR TITLE
Cabal Dir Environment variable added

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -220,7 +220,7 @@ defaultCabalDir = do
   env <- try $ getEnv "CABAL_HOME"
   case env of
     Left  _ -> getAppUserDataDirectory "cabal"
-    Right a -> return a :: IO FilePath
+    Right a -> return a
 
 defaultConfigFile :: IO FilePath
 defaultConfigFile = do


### PR DESCRIPTION
I adjusted the defaultCabalDir function so that if you have CABAL_DIR environment variable it will default to that location instead of $HOME/.cabal
