### PR TITLE
Add a 'no-threaded' flag to cabal-install.cabal

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -38,7 +38,11 @@ flag bytestring-in-base
 
 Executable cabal
     Main-Is:            Main.hs
-    ghc-options:        -Wall -threaded
+    ghc-options:        -Wall
+    if !arch(arm)
+       ghc-options: -threaded
+    else
+       cc-options:  -DCABAL_NO_THREADED
     if impl(ghc >= 6.8)
       ghc-options: -fwarn-tabs
     Other-Modules:

--- a/cabal-install/cbits/getnumcores.c
+++ b/cabal-install/cbits/getnumcores.c
@@ -1,4 +1,4 @@
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 612)
+#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 612) && !defined(CABAL_NO_THREADED)
 /* Since version 6.12, GHC's threaded RTS includes a getNumberOfProcessors
    function, so we try to use that if available. cabal-install is always built
    with -threaded nowadays.  */


### PR DESCRIPTION
Some platforms (e.g. ARM) don't have a threaded RTS, which makes it impossible
to build cabal-install without editing the source by hand (see #1129). This
patch makes life a bit easier for people using these platforms.

Alternatively, we could add a configure check instead of a flag, but that would
make building cabal-install harder on Windows.
