### PR TITLE
Don't pass unsupported flags to setups built with old Cabal versions. 

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -230,9 +230,20 @@ configureOptions = commandOptions configureCommand
 
 filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
-  | cabalLibVersion >= Version [1,3,10] [] = flags
-    -- older Cabal does not grok the constraints flag:
-  | otherwise = flags { configConstraints = [] }
+  | cabalLibVersion >= Version [1,14,0] [] = flags
+  | cabalLibVersion <  Version [1,3,10] [] = flags_1_3_10
+  | cabalLibVersion <  Version [1,10,0] [] = flags_1_10_0
+  | cabalLibVersion <  Version [1,14,0] [] = flags_1_14_0
+
+  -- A no-op that silences the "pattern match is non-exhaustive" warning.
+  | otherwise = flags
+  where
+    -- Cabal < 1.14.0 doesn't know about --disable-benchmarks.
+    flags_1_14_0 = flags        { configBenchmarks  = NoFlag }
+    -- Cabal < 1.10.0 doesn't know about --disable-tests.
+    flags_1_10_0 = flags_1_14_0 { configTests       = NoFlag }
+    -- Cabal < 1.3.10 does not grok the constraints flag.
+    flags_1_3_10 = flags_1_10_0 { configConstraints = [] }
 
 -- ------------------------------------------------------------
 -- * Config extra flags


### PR DESCRIPTION
We must not pass `--disable-benchmarks` to setup scripts built with Cabal < 1.14; the same is also true for `--disable-tests` and Cabal < 1.10.

Fixes #932 and #1004.

Without this patch:

```
$ cabal install -w /path/to/ghc-7.2.1/bin/ghc syb
[...]
unrecognized option `--disable-benchmarks'
Failed to install syb-0.3.7
```

With this patch:

```
$ cabal install -w /path/to/ghc-7.2.1/bin/ghc syb
[...]
Registering syb-0.3.7...
Installed syb-0.3.7
```
