### PR TITLE
Show '--config-file' in 'cabal help' output.

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -138,7 +138,7 @@ globalCommand = CommandUI {
       ++ "  " ++ pname ++ " update\n",
     commandDefaultFlags = defaultGlobalFlags,
     commandOptions      = \showOrParseArgs ->
-      (case showOrParseArgs of ShowArgs -> take 2; ParseArgs -> id)
+      (case showOrParseArgs of ShowArgs -> take 3; ParseArgs -> id)
       [option ['V'] ["version"]
          "Print version information"
          globalVersion (\v flags -> flags { globalVersion = v })


### PR DESCRIPTION
Fixes #1113.

If `--config-file` is hidden intentionally, we should mark #1113 and #1114 as wontfix.
