### PR TITLE
Use userInstallDirs as the sandbox location.

### DIFF
--- a/cabal-install/Distribution/Client/PackageEnvironment.hs
+++ b/cabal-install/Distribution/Client/PackageEnvironment.hs
@@ -99,7 +99,7 @@ commonPackageEnvironmentConfig :: FilePath -> SavedConfig
 commonPackageEnvironmentConfig sandboxDir =
   mempty {
     savedConfigureFlags = mempty {
-       configUserInstall = toFlag False,
+       configUserInstall = toFlag True,
        configInstallDirs = sandboxInstallDirs
        },
     savedUserInstallDirs   = sandboxInstallDirs,


### PR DESCRIPTION
We set both globalInstallDirs and userInstallDirs to the same value, but using
'--global' makes cabal-install want to do unnecessary things like invoking
itself with 'sudo'.
