### PR TITLE
Compatibility code

### DIFF
--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -77,9 +77,7 @@ import Data.Maybe (fromMaybe)
 import Data.Monoid (Monoid(..))
 import System.Directory (getAppUserDataDirectory)
 import System.FilePath ((</>), isPathSeparator, pathSeparator)
-#if defined(__HUGS__) || defined(__GLASGOW_HASKELL__)
 import System.FilePath (dropDrive)
-#endif
 
 import Distribution.Package
          ( PackageIdentifier, packageName, packageVersion )
@@ -585,20 +583,4 @@ foreign import stdcall unsafe "shlobj.h SHGetFolderPathW"
                               -> CInt
                               -> CWString
                               -> IO CInt
-#endif
-
-#if !(__HUGS__ || __GLASGOW_HASKELL__ > 606)
--- Compat: this function only appears in FilePath > 1.0
--- (which at the time of writing is unreleased)
-dropDrive :: FilePath -> FilePath
-dropDrive (c:cs) | isPathSeparator c = cs
-dropDrive (_:':':c:cs) | isWindows
-                      && isPathSeparator c = cs  -- path with drive letter
-dropDrive (_:':':cs)   | isWindows         = cs
-dropDrive cs = cs
-
-isWindows :: Bool
-isWindows = case buildOS of
-  Windows -> True
-  _       -> False
 #endif


### PR DESCRIPTION
I attach a commit that removes code that didn't compile unless you were neither on Hugs nor on GHC > 6.6. I suspect it hasn't been compiled in a long time, and since Cabal now depends on base >= 4 I don't think it is relevant any more.

I'm hoping to also start a discussion more generally about what build conditions we expect. I think it's important to state clearly and publically what build setups are still supported, so we can discard old unused code and simplify the job of new contributors.

(The readme still makes reference to GHC 6.4.1! That, too, should probably be amended).
