### PR TITLE
Haddock module attributes specified with old syntax

### DIFF
--- a/Cabal/Distribution/Compat/CopyFile.hs
+++ b/Cabal/Distribution/Compat/CopyFile.hs
@@ -4,7 +4,7 @@
 {-# OPTIONS_GHC -cpp #-}
 {-# OPTIONS_NHC98 -cpp #-}
 {-# OPTIONS_JHC -fcpp #-}
--- #hide
+{-# OPTIONS_HADDOCK hide #-}
 module Distribution.Compat.CopyFile (
   copyFile,
   copyOrdinaryFile,

--- a/Cabal/Distribution/Compat/TempFile.hs
+++ b/Cabal/Distribution/Compat/TempFile.hs
@@ -4,7 +4,7 @@
 {-# OPTIONS_GHC -cpp #-}
 {-# OPTIONS_NHC98 -cpp #-}
 {-# OPTIONS_JHC -fcpp #-}
--- #hide
+{-# OPTIONS_HADDOCK hide #-}
 module Distribution.Compat.TempFile (
   openTempFile,
   openBinaryTempFile,

--- a/Cabal/Distribution/GetOpt.hs
+++ b/Cabal/Distribution/GetOpt.hs
@@ -36,7 +36,7 @@ over 1100 lines, we need only 195 here, including a 46 line example!
 :-)
 -}
 
--- #hide
+{-# OPTIONS_HADDOCK hide #-}
 module Distribution.GetOpt (
    -- * GetOpt
    getOpt, getOpt',

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. -}
 
 -- This module is meant to be local-only to Distribution...
 
--- #hide
+{-# OPTIONS_HADDOCK hide #-}
 module Distribution.ParseUtils (
         LineNo, PError(..), PWarning(..), locatedErrorMsg, syntaxError, warning,
         runP, runE, ParseResult(..), catchParseError, parseFail, showPWarning,


### PR DESCRIPTION
Several modules specify the Haddock hide attribute, but with the old, pre-Haddock-2 syntax.

Attached is a commit to just blindly swap all the old syntax with the new syntax.

However, I suggest we think a bit about whether or not the modules ought to have been hidden, whether or not they should continue to be hidden, and whether or not anything else should be hidden. If we decide anything other than the obvious, I'm happy to close this pull request and formulate a new one.

See also [this SO question](http://stackoverflow.com/q/13914500/812053) – some of the hide options are on modules which aren't exported, and hence are probably redundant.
