### PR TITLE
Fix build with GHC 6.12

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -37,7 +37,7 @@ Library
                    filepath   >= 1   && < 1.4,
                    directory  >= 1   && < 1.3,
                    process    >= 1   && < 1.2,
-                   time       >= 1.4 && < 1.5,
+                   time       >= 1.1 && < 1.5,
                    containers >= 0.1 && < 0.6,
                    array      >= 0.1 && < 0.5,
                    pretty     >= 1   && < 1.2,

--- a/Cabal/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/Distribution/Simple/BuildTarget.hs
@@ -55,7 +55,6 @@ import Data.Maybe
 import Data.Either
          ( partitionEithers )
 import qualified Data.Map as Map
-import Data.Map (Map)
 import Control.Monad
 import qualified Distribution.Compat.ReadP as Parse
 import Distribution.Compat.ReadP
@@ -884,7 +883,7 @@ matchExactly xs =
 -- function, then we would get case insensitive matching (but it will still
 -- report an exact match when the case matches too).
 --
-matchInexactly :: forall a a' b. (Ord a, Ord a') =>
+matchInexactly :: (Ord a, Ord a') =>
                         (a -> a') ->
                         [(a, b)] -> (a -> Match b)
 matchInexactly cannonicalise xs =
@@ -894,11 +893,9 @@ matchInexactly cannonicalise xs =
                          Just ys -> inexactMatches ys
                          Nothing -> matchZero
   where
-    m :: Ord a => Map a [b]
     m = Map.fromListWith (++) [ (k,[x]) | (k,x) <- xs ]
 
     -- the map of canonicalised keys to groups of inexact matches
-    m' :: Ord a' => Map a' [b]
     m' = Map.mapKeysWith (++) cannonicalise m
 
 


### PR DESCRIPTION
These are the changes necessary for me to build Cabal on GHC 6.12.3. I can't run the test-suite with them because it fails even without my changes, but I think they're reasonably non-controversial (except that I can't find a good changelog for the time package, so I'm not _certain_ there were no functionality changes we should be worried about, but I don't think so)
