### PR TITLE
Add simple heuristic to cabal init to guess common extra-source-files

### DIFF
--- a/cabal-install/Distribution/Client/Init/Types.hs
+++ b/cabal-install/Distribution/Client/Init/Types.hs
@@ -52,6 +52,7 @@ data InitFlags =
 
               , synopsis     :: Flag String
               , category     :: Flag (Either String Category)
+              , extraSrc     :: Maybe [String]
 
               , packageType  :: Flag PackageType
               , language     :: Flag Language
@@ -67,6 +68,10 @@ data InitFlags =
               , overwrite     :: Flag Bool
               }
   deriving (Show)
+
+  -- the Monoid instance for Flag has later values override earlier
+  -- ones, which is why we want Maybe [foo] for collecting foo values,
+  -- not Flag [foo].
 
 data PackageType = Library | Executable
   deriving (Show, Read, Eq)
@@ -91,6 +96,7 @@ instance Monoid InitFlags where
     , homepage       = mempty
     , synopsis       = mempty
     , category       = mempty
+    , extraSrc       = mempty
     , packageType    = mempty
     , language       = mempty
     , exposedModules = mempty
@@ -116,6 +122,7 @@ instance Monoid InitFlags where
     , homepage       = combine homepage
     , synopsis       = combine synopsis
     , category       = combine category
+    , extraSrc       = combine extraSrc
     , packageType    = combine packageType
     , language       = combine language
     , exposedModules = combine exposedModules

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1094,6 +1094,12 @@ initCommand = CommandUI {
         (reqArg' "CATEGORY" (\s -> toFlag $ maybe (Left s) Right (readMaybe s))
                             (flagToList . fmap (either id show)))
 
+      , option ['x'] ["extra-source-file"]
+        "Extra source file to be distributed with tarball."
+        IT.extraSrc (\v flags -> flags { IT.extraSrc = v })
+        (reqArg' "FILE" (Just . (:[]))
+                        (fromMaybe []))
+
       , option [] ["is-library"]
         "Build a library."
         IT.packageType (\v flags -> flags { IT.packageType = v })


### PR DESCRIPTION
Looks for things named 'README_', 'CHANGES_', or 'CHANGELOG*' and adds them to the extra-source-files field.
