### PR TITLE
Fix path (mis)handling when scanning for modules

### DIFF
--- a/cabal-install/Distribution/Client/Init/Heuristics.hs
+++ b/cabal-install/Distribution/Client/Init/Heuristics.hs
@@ -98,7 +98,7 @@ scanForModulesIn projectRoot srcRoot = scan srcRoot []
     scanRecursive parent hierarchy entry
       | isUpper (head entry) = scan (parent </> entry) (entry : hierarchy)
       | isLower (head entry) && not (ignoreDir entry) =
-          scanForModulesIn projectRoot $ foldl (</>) srcRoot (entry : hierarchy)
+          scanForModulesIn projectRoot $ foldl (</>) srcRoot (reverse (entry : hierarchy))
       | otherwise = return []
     ignoreDir ('.':_)  = True
     ignoreDir dir      = dir `elem` ["dist", "_darcs"]


### PR DESCRIPTION
This is an untested attempt to fix: https://github.com/haskell/cabal/issues/1160
