### PR TITLE
Two more Haddock module attribute syntax updates

### DIFF
--- a/cabal-install/Distribution/Compat/Exception.hs
+++ b/cabal-install/Distribution/Compat/Exception.hs
@@ -2,7 +2,7 @@
 {-# OPTIONS_GHC -cpp #-}
 {-# OPTIONS_NHC98 -cpp #-}
 {-# OPTIONS_JHC -fcpp #-}
--- #hide
+{-# OPTIONS_HADDOCK hide #-}
 module Distribution.Compat.Exception (
   SomeException,
   onException,

--- a/cabal-install/Distribution/Compat/FilePerms.hs
+++ b/cabal-install/Distribution/Compat/FilePerms.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
--- #hide
+{-# OPTIONS_HADDOCK hide #-}
 module Distribution.Compat.FilePerms (
   setFileOrdinary,
   setFileExecutable,


### PR DESCRIPTION
Sorry, the first time I submitted a pull request on this (#1153), I only checked Cabal, not cabal-install.
