### PR TITLE
Remove DefaultSetup.hs

### DIFF
--- a/Cabal/DefaultSetup.hs
+++ b/Cabal/DefaultSetup.hs
@@ -1,2 +1,0 @@
-import Distribution.Simple
-main = defaultMain


### PR DESCRIPTION
Following on from the discussion at #1171, I reckon DefaultSetup is expendable, but the `Makefile` is seemingly the only way of building the user's guide stuff at the moment, so that stays for now.
