### PR TITLE
Much faster Distribution.Client.Dependency.Modular.PSQ.splits

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/PSQ.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/PSQ.hs
@@ -66,10 +66,11 @@ casePSQ (PSQ xs) n c =
     (k, v) : ys -> c k v (PSQ ys)
 
 splits :: PSQ k a -> PSQ k (a, PSQ k a)
-splits xs =
-  casePSQ xs
-    (PSQ [])
-    (\ k v ys -> cons k (v, ys) (fmap (\ (w, zs) -> (w, cons k v zs)) (splits ys)))
+splits = go id 
+  where
+    go f xs = casePSQ xs
+        (PSQ [])
+        (\ k v ys -> cons k (v, f ys) (go (f . cons k v) ys))
 
 sortBy :: (a -> a -> Ordering) -> PSQ k a -> PSQ k a
 sortBy cmp (PSQ xs) = PSQ (S.sortBy (cmp `on` snd) xs)


### PR DESCRIPTION
I tried to speed up cabal-install with the file at http://anonscm.debian.org/darcs/pkg-haskell/tools/all-packages/all-packages.cabal. At first I thought I could add special handling for == dependencies. But after looking at the profile I found the attached patch to have a much greater impact.

This reduces the runtime of "cabal install --dry-run" on the file  from ~12s to 2.1s. 

Equivalency with previous implementation verified with QuickCheck in ghci.
