### PR TITLE
Add test case for new splits implementation

### DIFF
--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -5,6 +5,7 @@ import Test.Framework
 
 import qualified UnitTests.Distribution.Client.Sandbox
 import qualified UnitTests.Distribution.Client.Targets
+import qualified UnitTests.Distribution.Client.Dependency.Modular.PSQ
 
 tests :: [Test]
 tests = [
@@ -12,6 +13,8 @@ tests = [
        UnitTests.Distribution.Client.Sandbox.tests
   ,testGroup "Distribution.Client.Targets"
        UnitTests.Distribution.Client.Targets.tests
+  ,testGroup "UnitTests.Distribution.Client.Dependency.Modular.PSQ"
+        UnitTests.Distribution.Client.Dependency.Modular.PSQ.tests
   ]
 
 main :: IO ()

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/PSQ.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/PSQ.hs
@@ -1,0 +1,30 @@
+module UnitTests.Distribution.Client.Dependency.Modular.PSQ (
+  tests
+  ) where
+
+import Distribution.Client.Dependency.Modular.PSQ
+
+import Test.Framework                  as TF (Test)
+import Test.Framework.Providers.HUnit  (testCase)
+import Test.HUnit                      (Assertion, assertEqual)
+
+tests :: [TF.Test]
+tests = [ testCase "splitsAltImplementation" splitsTest
+        ]
+
+-- | Original splits implementation
+splits' :: PSQ k a -> PSQ k (a, PSQ k a)
+splits' xs =
+  casePSQ xs
+    (PSQ [])
+    (\ k v ys -> cons k (v, ys) (fmap (\ (w, zs) -> (w, cons k v zs)) (splits' ys)))
+
+splitsTest :: Assertion
+splitsTest = do
+  assertEqual "" (splits' psq1) (splits psq1)
+  assertEqual "" (splits' psq2) (splits psq2)
+  assertEqual "" (splits' psq3) (splits psq3)
+  where
+    psq1 = PSQ [ (1,2), (3,4), (5,6), (7,8) ] :: PSQ Int Int
+    psq2 = PSQ [ (1,2) ] :: PSQ Int Int
+    psq3 = PSQ [] :: PSQ Int Int


### PR DESCRIPTION
As requested in https://github.com/haskell/cabal/pull/1191 a test case comparing the two implementations of splits. Would have been a good fit for QuickCheck, but I did not want to add dependencies to the test suite, so I added representative examples to the HUnit test.
