### PR TITLE
Test Distribution.Client.Dependency.Modular.PSQ.splits with QuickCheck

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -177,7 +177,9 @@ Test-Suite unit-tests
         filepath,
         test-framework,
         test-framework-hunit,
+        test-framework-quickcheck2,
         HUnit,
+        QuickCheck (>= 2.5),
         cabal-install,
         Cabal
   ghc-options: -Wall

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/PSQ.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/PSQ.hs
@@ -4,12 +4,11 @@ module UnitTests.Distribution.Client.Dependency.Modular.PSQ (
 
 import Distribution.Client.Dependency.Modular.PSQ
 
-import Test.Framework                  as TF (Test)
-import Test.Framework.Providers.HUnit  (testCase)
-import Test.HUnit                      (Assertion, assertEqual)
+import Test.Framework as TF (Test)
+import Test.Framework.Providers.QuickCheck2
 
 tests :: [TF.Test]
-tests = [ testCase "splitsAltImplementation" splitsTest
+tests = [ testProperty "splitsAltImplementation" splitsTest
         ]
 
 -- | Original splits implementation
@@ -19,12 +18,5 @@ splits' xs =
     (PSQ [])
     (\ k v ys -> cons k (v, ys) (fmap (\ (w, zs) -> (w, cons k v zs)) (splits' ys)))
 
-splitsTest :: Assertion
-splitsTest = do
-  assertEqual "" (splits' psq1) (splits psq1)
-  assertEqual "" (splits' psq2) (splits psq2)
-  assertEqual "" (splits' psq3) (splits psq3)
-  where
-    psq1 = PSQ [ (1,2), (3,4), (5,6), (7,8) ] :: PSQ Int Int
-    psq2 = PSQ [ (1,2) ] :: PSQ Int Int
-    psq3 = PSQ [] :: PSQ Int Int
+splitsTest :: [(Int, Int)] -> Bool
+splitsTest psq = splits' (PSQ psq) == splits (PSQ psq)


### PR DESCRIPTION
Encouraged by https://github.com/haskell/cabal/pull/1193#issuecomment-13438287 I added QuickCheck to the test dependencies and changed the test.

This is function is getting quite a bit of test treatment, more than it deserves, but let's just say it is for good karma.
