### PR TITLE
Don't recommend --force-reinstalls

### DIFF
--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -432,7 +432,7 @@ checkPrintPlan verbosity installed installPlan sourcePkgDb
                  ["Continuing even though the plan contains dangerous reinstalls."]
                else
                  ["Try --avoid-reinstalls to avoid selecting destructive reinstalls or " ++
-                  "manually unregister conflicting packages (using 'ghc-pkg unregister').",
+                  "manually uninstall conflicting packages.",
                   "Use --force-reinstalls if you want to install anyway (including destructive reinstalls)."]
       else unless dryRun $ warn verbosity
              "Note that reinstalls are always dangerous. Continuing anyway..."


### PR DESCRIPTION
In case 'cabal install' selects destructive reinstalls it suggests '--force-reinstalls'. In my experience this is seldom what one wants since it is likely to destroy other installed libraries. It should additionally suggest '--avoid-reinstalls' and/or manually unregistering conflicting packages.

Feel free to rephrase the warning message.
