### PR TITLE
Remove flags for unsupported compilers from Cabal.cabal

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -48,10 +48,7 @@ library
     build-depends:
       unix >= 2.0 && < 2.7
 
-  ghc-options: -Wall -fno-ignore-asserts
-  if impl(ghc >= 6.8)
-    ghc-options: -fwarn-tabs
-  nhc98-options: -K4M
+  ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs
 
   exposed-modules:
     Distribution.Compiler,


### PR DESCRIPTION
Cabal isn't required to (and probably won't) build on GHC pre6.8 or NHC anymore.
