### PR TITLE
Don't pretty-print unparseable test suite types.

### DIFF
--- a/Cabal/Distribution/PackageDescription/PrettyPrint.hs
+++ b/Cabal/Distribution/PackageDescription/PrettyPrint.hs
@@ -46,6 +46,7 @@ module Distribution.PackageDescription.PrettyPrint (
     showGenericPackageDescription,
 ) where
 
+import Data.Monoid (Monoid(mempty))
 import Distribution.PackageDescription
        ( TestSuite(..), TestSuiteInterface(..), testType
        , SourceRepo(..),
@@ -169,13 +170,17 @@ ppTestSuites suites =
                      | (n,condTree) <- suites]
   where
     ppTestSuite testsuite Nothing =
-                text "type:" <+> disp (testType testsuite)
+                maybe empty (\t -> text "type:"        <+> disp t)
+                            maybeTestType
             $+$ maybe empty (\f -> text "main-is:"     <+> text f)
                             (testSuiteMainIs testsuite)
             $+$ maybe empty (\m -> text "test-module:" <+> disp m)
                             (testSuiteModule testsuite)
             $+$ ppFields binfoFieldDescrs (testBuildInfo testsuite)
             $+$ ppCustomFields (customFieldsBI (testBuildInfo testsuite))
+      where
+        maybeTestType | testInterface testsuite == mempty = Nothing
+                      | otherwise = Just (testType testsuite)
 
     ppTestSuite (TestSuite _ _ buildInfo' _)
                     (Just (TestSuite _ _ buildInfo2 _)) =


### PR DESCRIPTION
Issue #1202. The pretty printer was printing 'type: -' for empty test
suite interfaces.  The empty test interface type is the result of
parsing a branch in a conditional block where no type is explicitly
specified (i.e., the type is inherited from a higher level or propagated
up from a lower one).  Therefore, the pretty-printer should not print
any 'type' field at all for test suites with an empty test interface
type.
