### PR TITLE
Install bash-completion during bootstraping

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -207,7 +207,7 @@ bash_compl_err_msg () {
     echo "   or /etc/bash_completion.d"
     echo " - copy 'cabal' file from bash-completion subdirectory of"
     echo "   cabal-install to your system's bash completion directory in /etc."
-    echo "   This requires root privelages."
+    echo "   This requires root privileges."
 }
 
 # Actually do something!


### PR DESCRIPTION
I've been using `cabal-install` for over a year and always got irritated about lack of bash completion. Recently I realised that there actually is a bash completion script, only it is not installed during bootstraping. So I modified the `bootstrap.sh` script to place bash completion script in appropriate system directory and if that fails give the user a meaningful information about manual installation.
