### PR TITLE
Add mask, mask_ to Distribution.Compat.Exception

### DIFF
--- a/cabal-install/Distribution/Client/JobControl.hs
+++ b/cabal-install/Distribution/Client/JobControl.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.JobControl
@@ -29,7 +28,8 @@ module Distribution.Client.JobControl (
 
 import Control.Monad
 import Control.Concurrent hiding (QSem, newQSem, waitQSem, signalQSem)
-import Control.Exception
+import Control.Exception (SomeException, bracket_, throw, try)
+import Distribution.Compat.Exception (mask)
 import Distribution.Compat.Semaphore
 
 data JobControl m a = JobControl {
@@ -53,7 +53,6 @@ newSerialJobControl = do
     collect = join . readChan
 
 newParallelJobControl :: IO (JobControl IO a)
-#if MIN_VERSION_base(4,3,0)
 newParallelJobControl = do
     resultVar <- newEmptyMVar
     return JobControl {
@@ -71,9 +70,6 @@ newParallelJobControl = do
     collect :: MVar (Either SomeException a) -> IO a
     collect resultVar =
       takeMVar resultVar >>= either throw return
-#else
-newParallelJobControl = newSerialJobControl
-#endif
 
 data JobLimit = JobLimit QSem
 

--- a/cabal-install/Distribution/Compat/Exception.hs
+++ b/cabal-install/Distribution/Compat/Exception.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_HADDOCK hide #-}
 module Distribution.Compat.Exception (
   SomeException,
+  mask,
+  mask_,
   onException,
   catchIO,
   handleIO,
@@ -11,6 +14,24 @@ module Distribution.Compat.Exception (
 import System.Exit
 import qualified Control.Exception as Exception
 import Control.Exception (SomeException)
+
+#if MIN_VERSION_base(4,3,0)
+-- it's much less of a headache if we re-export the "real" mask and mask_
+-- so there's never more than one definition to conflict
+import Control.Exception (mask, mask_)
+#else
+import Control.Exception (block, unblock)
+#endif
+
+#if !MIN_VERSION_base(4,3,0)
+-- note: less polymorphic than 'real' mask, to avoid RankNTypes
+-- we don't need the full generality where we use it
+mask :: ((IO a -> IO a) -> IO b) -> IO b
+mask handler = block (handler unblock)
+
+mask_ :: IO a -> IO a
+mask_ = block
+#endif
 
 onException :: IO a -> IO b -> IO a
 onException = Exception.onException

--- a/cabal-install/Distribution/Compat/Semaphore.hs
+++ b/cabal-install/Distribution/Compat/Semaphore.hs
@@ -9,9 +9,11 @@ module Distribution.Compat.Semaphore
 
 import Control.Concurrent.STM (TVar, atomically, newTVar, readTVar, retry,
                                writeTVar)
-import Control.Exception (mask_, onException)
+import Control.Exception (onException)
 import Control.Monad (join, when)
 import Data.Typeable (Typeable)
+
+import Distribution.Compat.Exception (mask_)
 
 -- | 'QSem' is a quantity semaphore in which the resource is aqcuired
 -- and released in units of one. It provides guaranteed FIFO ordering


### PR DESCRIPTION
Fixes #1178.

It would be great if someone who knew about async exceptions could double-check that re-enabling the code that @dcoutts disabled in ce2fc30351579e1b15ae0efa78f758ed0d73c79f is ok. We're not using "real" mask, just block and unblock, but I think in this circumstance there's actually no difference.
