### PR TITLE
include "hs-source-dirs: " field in generated cabal files

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -722,7 +722,7 @@ generateCabalFile fileName c =
 
      , fieldS "hs-source-dirs" (listFieldS (sourceDirs c'))
               (Just "Directories containing source files.")
-              False
+              True
 
      , fieldS "build-tools" (listFieldS (buildTools c'))
               (Just "Extra tools (e.g. alex, hsc2hs, ...) needed to build the source.")


### PR DESCRIPTION
...ds included in a .cabal file generated by "cabal init"

Signed-off-by: Carter Tazio Schonwald carter.schonwald@gmail.com

discussed in issue https://github.com/haskell/cabal/issues/1222#issuecomment-14243646
