### PR TITLE
Update dependencies in cabal-install.cabal

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -108,23 +108,24 @@ Library
     Other-Modules:
         Paths_cabal_install
 
-    build-depends: base     >= 4        && < 5,
-                   Cabal    >= 1.17.0   && < 1.18,
-                   filepath >= 1.0      && < 1.4,
-                   network  >= 1        && < 3,
-                   HTTP     >= 4000.0.8 && < 4001,
-                   zlib     >= 0.5.3    && < 0.6,
-                   time     >= 1.1      && < 1.5,
-                   mtl      >= 2.0      && < 3,
-                   stm      >= 2.0      && < 3,
-                     bytestring >= 0.9 && < 1,
-                     process    >= 1   && < 1.3,
-                     directory  >= 1   && < 1.3,
-                     pretty     >= 1   && < 1.2,
-                     random     >= 1   && < 1.1,
-                     containers >= 0.1 && < 0.6,
-                     array      >= 0.1 && < 0.5,
-                     old-time   >= 1   && < 1.2
+    build-depends:
+        array      >= 0.1      && < 0.5,
+        base       >= 4        && < 5,
+        bytestring >= 0.9      && < 1,
+        Cabal      >= 1.17.0   && < 1.18,
+        containers >= 0.1      && < 0.6,
+        directory  >= 1        && < 1.3,
+        filepath   >= 1.0      && < 1.4,
+        HTTP       >= 4000.0.8 && < 4001,
+        mtl        >= 2.0      && < 3,
+        network    >= 1        && < 3,
+        old-time   >= 1        && < 1.2,
+        pretty     >= 1        && < 1.2,
+        process    >= 1        && < 1.3,
+        random     >= 1        && < 1.1,
+        stm        >= 2.0      && < 3,
+        time       >= 1.1      && < 1.5,
+        zlib       >= 0.5.3    && < 0.6
 
 
     if os(windows)


### PR DESCRIPTION
Testing this was a little tricky because of issues related to #1229 but I think it's okay. Would be worth someone double-checking just in case.

Since it was necessary to reshuffle the dependency list anyway, I took the liberty of alphasorting it, except with base and Cabal at the top because they are in some sense the most important. I don't know if that's what people want, but I'm happy to change the formatting to whatever people feel is appropriate – might as well do it now, while we're touching it.
