### PR TITLE
Since directory 1.2, no longer need old-time

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -30,6 +30,10 @@ source-repository head
   location: https://github.com/haskell/cabal/
   subdir:   cabal-install
 
+Flag old-directory
+  description:  Use directory < 1.2 and old-time
+  default:      False
+
 Library
     ghc-options: -Wall -fwarn-tabs
     if arch(arm)
@@ -114,12 +118,10 @@ Library
         bytestring >= 0.9      && < 1,
         Cabal      >= 1.17.0   && < 1.18,
         containers >= 0.1      && < 0.6,
-        directory  >= 1        && < 1.3,
         filepath   >= 1.0      && < 1.4,
         HTTP       >= 4000.0.8 && < 4001,
         mtl        >= 2.0      && < 3,
         network    >= 1        && < 3,
-        old-time   >= 1        && < 1.2,
         pretty     >= 1        && < 1.2,
         process    >= 1        && < 1.3,
         random     >= 1        && < 1.1,
@@ -127,6 +129,10 @@ Library
         time       >= 1.1      && < 1.5,
         zlib       >= 0.5.3    && < 0.6
 
+    if flag(old-directory)
+      build-depends: directory >= 1 && < 1.2, old-time >= 1 && < 1.2
+    else
+      build-depends: directory >= 1.2 && < 1.3
 
     if os(windows)
       build-depends: Win32 >= 2 && < 3


### PR DESCRIPTION
There's not a lot of point to this patch, since old-time comes with GHC and is likely to hang around forever (it's a dependency of haskell98), but I didn't work that out until after I'd written the code :)

Feel free to take it or leave it.
