### PR TITLE
Exclude 'only-dependencies' from config field descriptions.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -401,7 +401,7 @@ configFieldDescriptions =
 
   ++ toSavedConfig liftInstallFlag
        (installOptions ParseArgs)
-       ["dry-run", "only"] []
+       ["dry-run", "only", "only-dependencies", "dependencies-only"] []
 
   ++ toSavedConfig liftUploadFlag
        (commandOptions uploadCommand ParseArgs)


### PR DESCRIPTION
It doesn't really make sense to enable this globally.
