### PR TITLE
'cabal get': don't add the version number to the dir name when forking.

### DIFF
--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -225,9 +225,10 @@ forkPackage :: Verbosity
                -- ^ The package to fork.
             -> IO ()
 forkPackage verbosity branchers prefix kind src = do
-    let desc = PD.packageDescription (packageDescription src)
-    let pkgname = display (packageName src)
-    let destdir = prefix </> pkgname
+    let desc    = PD.packageDescription (packageDescription src)
+        pkgid   = display (packageId src)
+        pkgname = display (packageName src)
+        destdir = prefix </> pkgname
 
     destDirExists <- doesDirectoryExist destdir
     when destDirExists $ do
@@ -243,10 +244,12 @@ forkPackage verbosity branchers prefix kind src = do
             exitCode <- io verbosity destdir
             case exitCode of
                 ExitSuccess -> return ()
-                ExitFailure _ -> die ("Couldn't fork package " ++ pkgname)
+                ExitFailure _ -> die ("Couldn't fork package " ++ pkgid)
         Nothing -> case repos of
-            [] -> die ("Package " ++ pkgname ++ " does not have any source repositories.")
-            _ -> die ("Package " ++ pkgname ++ " does not have any usable source repositories.")
+            [] -> die ("Package " ++ pkgid
+                       ++ " does not have any source repositories.")
+            _ -> die ("Package " ++ pkgid
+                      ++ " does not have any usable source repositories.")
 
 -- | Given a set of possible branchers, and a set of possible source
 -- repositories, find a repository that is both 1) likely to be specific to


### PR DESCRIPTION
Fixes #1279.

Test:

```
$ cabal get binary
Downloading binary-0.7.0.1...
Unpacking to binary-0.7.0.1/

$ cabal get binary -s
git: clone "git://github.com/kolmodin/binary.git"
Cloning into 'binary'...
remote: Counting objects: 2912, done.
remote: Compressing objects: 100% (1383/1383), done.
remote: Total 2912 (delta 1184), reused 2868 (delta 1145)
Receiving objects: 100% (2912/2912), 571.62 KiB | 460 KiB/s, done.
Resolving deltas: 100% (1184/1184), done.
```
