### PR TITLE
Fix #676.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -83,6 +83,8 @@ extra-source-files:
   tests/PackageTests/CMain/foo.c
   tests/PackageTests/CMain/my.cabal
   tests/PackageTests/EmptyLib/empty/empty.cabal
+  tests/PackageTests/OrderFlags/Foo.hs
+  tests/PackageTests/OrderFlags/my.cabal
   tests/PackageTests/PathsModule/Executable/Main.hs
   tests/PackageTests/PathsModule/Executable/my.cabal
   tests/PackageTests/PathsModule/Library/my.cabal
@@ -248,8 +250,9 @@ test-suite package-tests
     PackageTests.BuildDeps.TargetSpecificDeps2.Check
     PackageTests.BuildDeps.TargetSpecificDeps3.Check
     PackageTests.BuildTestSuiteDetailedV09.Check
-    PackageTests.EmptyLib.Check
     PackageTests.CMain.Check
+    PackageTests.EmptyLib.Check
+    PackageTests.OrderFlags.Check
     PackageTests.PackageTester
     PackageTests.PathsModule.Executable.Check
     PackageTests.PathsModule.Library.Check

--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -326,7 +326,7 @@ simplifyCondTree :: (Monoid a, Monoid d) =>
                  -> CondTree v d a
                  -> (d, a)
 simplifyCondTree env (CondNode a d ifs) =
-    foldr mappend (d, a) $ catMaybes $ map simplifyIf ifs
+    mconcat $ (d, a) : catMaybes (map simplifyIf ifs)
   where
     simplifyIf (cnd, t, me) =
         case simplifyCondition cnd env of

--- a/Cabal/tests/PackageTests.hs
+++ b/Cabal/tests/PackageTests.hs
@@ -40,6 +40,7 @@ import PackageTests.EmptyLib.Check
 import PackageTests.TestOptions.Check
 import PackageTests.TestStanza.Check
 import PackageTests.TestSuiteExeV10.Check
+import PackageTests.OrderFlags.Check
 
 hunit :: TestName -> HUnit.Test -> Test
 hunit name test = testGroup name $ hUnitTestToTests test
@@ -81,6 +82,8 @@ tests version inplaceSpec =
       PackageTests.EmptyLib.Check.emptyLib
     , hunit "BuildTestSuiteDetailedV09"
       $ PackageTests.BuildTestSuiteDetailedV09.Check.suite inplaceSpec
+    , hunit "OrderFlags"
+      PackageTests.OrderFlags.Check.suite
     ] ++
     -- These tests are only required to pass on cabal version >= 1.7
     (if version >= Version [1, 7] []

--- a/Cabal/tests/PackageTests/OrderFlags/Check.hs
+++ b/Cabal/tests/PackageTests/OrderFlags/Check.hs
@@ -1,0 +1,18 @@
+module PackageTests.OrderFlags.Check where
+
+import Test.HUnit
+import PackageTests.PackageTester
+import System.FilePath
+import Control.Exception
+import Prelude hiding (catch)
+
+
+suite :: Test
+suite = TestCase $ do
+    let spec = PackageSpec ("PackageTests" </> "OrderFlags") []
+    result <- cabal_build spec
+    do
+        assertEqual "cabal build should succeed - see test-log.txt" True (successful result)
+      `catch` \exc -> do
+        putStrLn $ "Cabal result was "++show result
+        throwIO (exc :: SomeException)

--- a/Cabal/tests/PackageTests/OrderFlags/Foo.hs
+++ b/Cabal/tests/PackageTests/OrderFlags/Foo.hs
@@ -1,0 +1,8 @@
+module Foo where
+
+x :: IO Int
+x = return 5
+
+f :: IO Int
+f = do x
+       return 3

--- a/Cabal/tests/PackageTests/OrderFlags/my.cabal
+++ b/Cabal/tests/PackageTests/OrderFlags/my.cabal
@@ -1,0 +1,20 @@
+name: OrderFlags
+version: 0.1
+license: BSD3
+author: Oleksandr Manzyuk
+stability: stable
+category: PackageTests
+build-type: Simple
+cabal-version: >=1.9.2
+
+description:
+    Check that Cabal correctly orders flags that are passed to GHC.
+
+library
+    exposed-modules: Foo
+    build-depends: base
+
+    ghc-options: -Wall -Werror
+
+    if impl(ghc >= 6.12.1)
+        ghc-options: -fno-warn-unused-do-bind


### PR DESCRIPTION
The culprit of the problem is the function `simplifyCondTree`, which traverses `CondTree` in post-order.  I've changed that to pre-order traversal.
