### PR TITLE
Added --oldest-deps flag, which builds using the oldest versions allowed

### DIFF
--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -420,6 +420,7 @@ interpretPackagesPreference selected defaultPref prefs =
     installPrefDefault = case defaultPref of
       PreferAllLatest         -> \_       -> PreferLatest
       PreferAllInstalled      -> \_       -> PreferInstalled
+      PreferAllOldest         -> \_       -> PreferOldest
       PreferLatestForSelected -> \pkgname ->
         -- When you say cabal install foo, what you really mean is, prefer the
         -- latest version of foo, but the installed version of everything else
@@ -471,6 +472,7 @@ resolveWithoutDependencies (DepResolverParams targets constraints
                           (installPref pkg, versionPref pkg, packageVersion pkg)
         installPref   = case preferInstalled of
           PreferLatest    -> const False
+          PreferOldest    -> const False
           PreferInstalled -> not . null . InstalledPackageIndex.lookupSourcePackageId
                                                      installedPkgIndex
                            . packageId

--- a/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
@@ -52,9 +52,10 @@ preferPackagePreferences pcs = packageOrderFor (const True) preference
       preferInstalledOrdering v1 v2 `mappend` preferLatestOrdering v1 v2
     locationsOrdering PreferLatest v1 v2 =
       preferLatestOrdering v1 v2 `mappend` preferInstalledOrdering v1 v2
-    -- For the oldest ordering we just prefer the oldest version
-    locationsOrdering PreferOldest v1 v2 = preferOldestOrdering v1 v2
-      
+    -- For the oldest ordering we just prefer the oldest installed version
+    locationsOrdering PreferOldest v1 v2 = 
+      preferInstalledOrdering v1 v2 `mappend` preferLatestOrdering v2 v1
+
 -- | Ordering that treats installed instances as greater than uninstalled ones.
 preferInstalledOrdering :: I -> I -> Ordering
 preferInstalledOrdering (I _ (Inst _)) (I _ (Inst _)) = EQ
@@ -65,10 +66,6 @@ preferInstalledOrdering _              _              = EQ
 -- | Compare instances by their version numbers.
 preferLatestOrdering :: I -> I -> Ordering
 preferLatestOrdering (I v1 _) (I v2 _) = compare v1 v2
-
--- | Compare instances by their version numbers.
-preferOldestOrdering :: I -> I -> Ordering
-preferOldestOrdering (I v1 _) (I v2 _) = compare v2 v1
 
 -- | Helper function that tries to enforce a single package constraint on a
 -- given instance for a P-node. Translates the constraint into a

--- a/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
@@ -52,7 +52,9 @@ preferPackagePreferences pcs = packageOrderFor (const True) preference
       preferInstalledOrdering v1 v2 `mappend` preferLatestOrdering v1 v2
     locationsOrdering PreferLatest v1 v2 =
       preferLatestOrdering v1 v2 `mappend` preferInstalledOrdering v1 v2
-
+    -- For the oldest ordering we just prefer the oldest version
+    locationsOrdering PreferOldest v1 v2 = preferOldestOrdering v1 v2
+      
 -- | Ordering that treats installed instances as greater than uninstalled ones.
 preferInstalledOrdering :: I -> I -> Ordering
 preferInstalledOrdering (I _ (Inst _)) (I _ (Inst _)) = EQ
@@ -63,6 +65,10 @@ preferInstalledOrdering _              _              = EQ
 -- | Compare instances by their version numbers.
 preferLatestOrdering :: I -> I -> Ordering
 preferLatestOrdering (I v1 _) (I v2 _) = compare v1 v2
+
+-- | Compare instances by their version numbers.
+preferOldestOrdering :: I -> I -> Ordering
+preferOldestOrdering (I v1 _) (I v2 _) = compare v2 v1
 
 -- | Helper function that tries to enforce a single package constraint on a
 -- given instance for a P-node. Translates the constraint into a

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -117,6 +117,9 @@ explore pref (ChoiceNode _ choices)  =
           comparing (\(p,_) -> (               isPreferred p, packageId p))
         PreferInstalled ->
           comparing (\(p,_) -> (isInstalled p, isPreferred p, packageId p))
+        PreferOldest    ->
+          flip $ comparing (\(p,_) -> packageVersion p)
+          
       where
         isInstalled (SourceOnly _) = False
         isInstalled _              = True

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -60,7 +60,7 @@ import Data.List
 import Data.Maybe
          ( fromJust, fromMaybe, catMaybes )
 import Data.Monoid
-         ( Monoid(mempty) )
+         ( Monoid(mempty, mappend) )
 import Control.Monad
          ( guard )
 import qualified Data.Set as Set
@@ -117,9 +117,10 @@ explore pref (ChoiceNode _ choices)  =
           comparing (\(p,_) -> (               isPreferred p, packageId p))
         PreferInstalled ->
           comparing (\(p,_) -> (isInstalled p, isPreferred p, packageId p))
-        PreferOldest    ->
-          flip $ comparing (\(p,_) -> packageVersion p)
-          
+        PreferOldest    -> \v1 v2 ->
+                    comparing (\(p,_) -> (isInstalled p, isPreferred p)) v1 v2 
+          `mappend` comparing (packageId . fst) v2 v1
+
       where
         isInstalled (SourceOnly _) = False
         isInstalled _              = True

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -139,9 +139,9 @@ data PackageConstraint
 data PackagePreferences = PackagePreferences VersionRange InstalledPreference
 
 -- | Wether we prefer an installed version of a package or simply the latest
--- version.
+-- version. We can also choose the oldest version for debugging purposes
 --
-data InstalledPreference = PreferInstalled | PreferLatest
+data InstalledPreference = PreferInstalled | PreferLatest | PreferOldest
 
 -- | Global policy for all packages to say if we prefer package versions that
 -- are already installed locally or if we just prefer the latest available.
@@ -166,6 +166,10 @@ data PackagesPreferenceDefault =
      -- * This is the standard policy for install.
      --
    | PreferLatestForSelected
+
+     -- | Always prefer the oldest versions. This is useful for debugging puposes
+
+   | PreferAllOldest
 
 -- | A type to represent the unfolding of an expensive long running
 -- calculation that may fail. We may get intermediate steps before the final

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -167,7 +167,7 @@ data PackagesPreferenceDefault =
      --
    | PreferLatestForSelected
 
-     -- | Always prefer the oldest versions. This is useful for debugging puposes
+     -- | Always prefer the oldest versions for direct dependencies. This is useful for debugging puposes.
 
    | PreferAllOldest
 

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -291,11 +291,9 @@ planPackages comp platform solver configFlags configExFlags installFlags
 
       . setShadowPkgs shadowPkgs
 
-      . setPreferenceDefault (if upgradeDeps
-                              then PreferAllLatest
-                              else if oldestDeps
-                              then PreferAllOldest
-                              else PreferLatestForSelected
+      . setPreferenceDefault (if      upgradeDeps then PreferAllLatest
+                              else if oldestDeps  then PreferAllOldest
+                                                  else PreferLatestForSelected
                              )
 
       . addPreferences

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -291,8 +291,12 @@ planPackages comp platform solver configFlags configExFlags installFlags
 
       . setShadowPkgs shadowPkgs
 
-      . setPreferenceDefault (if upgradeDeps then PreferAllLatest
-                                             else PreferLatestForSelected)
+      . setPreferenceDefault (if upgradeDeps
+                              then PreferAllLatest
+                              else if oldestDeps
+                              then PreferAllOldest
+                              else PreferLatestForSelected
+                             )
 
       . addPreferences
           -- preferences from the config file or command line
@@ -334,7 +338,8 @@ planPackages comp platform solver configFlags configExFlags installFlags
     maxBackjumps     = fromFlag (installMaxBackjumps     installFlags)
     upgradeDeps      = fromFlag (installUpgradeDeps      installFlags)
     onlyDeps         = fromFlag (installOnlyDeps         installFlags)
-
+    oldestDeps       = fromFlag (installOldestDeps       installFlags)
+ 
 -- | Remove the provided targets from the install plan.
 pruneInstallPlan :: Package pkg => [PackageSpecifier pkg] -> InstallPlan
                     -> Progress String String InstallPlan

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -674,6 +674,7 @@ data InstallFlags = InstallFlags {
     installAvoidReinstalls  :: Flag Bool,
     installOverrideReinstall :: Flag Bool,
     installUpgradeDeps      :: Flag Bool,
+    installOldestDeps       :: Flag Bool,
     installOnly             :: Flag Bool,
     installOnlyDeps         :: Flag Bool,
     installRootCmd          :: Flag String,
@@ -698,6 +699,7 @@ defaultInstallFlags = InstallFlags {
     installAvoidReinstalls = Flag False,
     installOverrideReinstall = Flag False,
     installUpgradeDeps     = Flag False,
+    installOldestDeps      = Flag False,
     installOnly            = Flag False,
     installOnlyDeps        = Flag False,
     installRootCmd         = mempty,
@@ -817,6 +819,11 @@ installOptions showOrParseArgs =
           installUpgradeDeps (\v flags -> flags { installUpgradeDeps = v })
           (yesNoOpt showOrParseArgs)
 
+      , option [] ["oldest-dependencies"]
+          "Pick the oldest version for all dependencies, useful for debugging purposes."
+          installOldestDeps (\v flags -> flags { installOldestDeps = v })
+          (yesNoOpt showOrParseArgs)
+
       , option [] ["only-dependencies"]
           "Install only the dependencies necessary to build the given packages"
           installOnlyDeps (\v flags -> flags { installOnlyDeps = v })
@@ -887,6 +894,7 @@ instance Monoid InstallFlags where
     installOverrideReinstall = mempty,
     installMaxBackjumps    = mempty,
     installUpgradeDeps     = mempty,
+    installOldestDeps      = mempty,
     installReorderGoals    = mempty,
     installIndependentGoals= mempty,
     installShadowPkgs      = mempty,
@@ -909,6 +917,7 @@ instance Monoid InstallFlags where
     installOverrideReinstall = combine installOverrideReinstall,
     installMaxBackjumps    = combine installMaxBackjumps,
     installUpgradeDeps     = combine installUpgradeDeps,
+    installOldestDeps      = combine installOldestDeps,
     installReorderGoals    = combine installReorderGoals,
     installIndependentGoals= combine installIndependentGoals,
     installShadowPkgs      = combine installShadowPkgs,


### PR DESCRIPTION
The --oldest-deps flag makes cabal prefer older version over newer versions when resolving dependencies.

This is useful for debugging to check whether the lower bounds of a package are still valid. The feature is best used on a separate package database or --one-shot to prevent messing up the global package database.