### PR TITLE
Fix BuildTestSuiteDetailedV09 on case-insensitive file systems

### DIFF
--- a/Cabal/tests/PackageTests/BuildTestSuiteDetailedV09/my.cabal
+++ b/Cabal/tests/PackageTests/BuildTestSuiteDetailedV09/my.cabal
@@ -13,7 +13,7 @@ Library
     exposed-modules: Dummy
     build-depends: base, Cabal
 
-test-suite dummy
+test-suite test-Dummy
   type:       detailed-0.9
   test-module: Dummy
   build-depends: base, Cabal


### PR DESCRIPTION
Fixes #1297 (again). Compiled object files are deleted before the detailed test
suite library is built. This is a workaround until the underlying cause is
known.
