### PR TITLE
Use a non-default build dir when building add-source deps.

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -440,8 +440,10 @@ reinstallAddSourceDeps :: Verbosity
                           -> InstallFlags -> GlobalFlags
                           -> FilePath
                           -> IO WereDepsReinstalled
-reinstallAddSourceDeps verbosity config configFlags configExFlags
+reinstallAddSourceDeps verbosity config configFlags' configExFlags
                        installFlags globalFlags sandboxDir = do
+  let configFlags       = configFlags'
+                          { configDistPref = Flag "sandbox-dist" }
   indexFile            <- tryGetIndexFilePath config
   buildTreeRefs        <- Index.listBuildTreeRefs verbosity
                           Index.DontListIgnored indexFile

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -75,7 +75,7 @@ import Distribution.Client.Sandbox            (sandboxInit
                                               ,dumpPackageEnvironment
 
                                               ,UseSandbox(..)
-                                              ,whenUsingSandbox
+                                              ,isUseSandbox, whenUsingSandbox
                                               ,ForceGlobalInstall(..)
                                               ,maybeForceGlobalInstall
                                               ,loadConfigOrSandboxConfig
@@ -458,7 +458,12 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags)
                           (configUserInstall configFlags)
   targets <- readUserTargets verbosity extraArgs
 
-  let configFlags'   = savedConfigureFlags   config `mappend` configFlags
+  let configFlags'   =
+        let flags    = savedConfigureFlags   config `mappend` configFlags
+        in if isUseSandbox useSandbox
+           then flags {configDistPref = Flag "sandbox-dist"}
+           else flags
+
       configExFlags' = defaultConfigExFlags         `mappend`
                        savedConfigureExFlags config `mappend` configExFlags
       installFlags'  = defaultInstallFlags          `mappend`


### PR DESCRIPTION
Fixes #1281.

I decided against using `.cabal-sandbox/dist/$PKGID` since we can have several add-source deps with a single `$PKGID`. Although that can probably be fixed by deleting the build dir when adding an add-source dep with an already-existing package id, there is another complication - when doing `install --only-dependencies`, there is no way to distinguish add-source deps (for which we want to cache the build dir under `.cabal-sandbox`) from regular ones (for which we likely don't).
