### PR TITLE
Propagate globally specified build-deps into each buildable component.

### DIFF
--- a/Cabal/tests/PackageTests.hs
+++ b/Cabal/tests/PackageTests.hs
@@ -40,6 +40,7 @@ import PackageTests.EmptyLib.Check
 import PackageTests.TestOptions.Check
 import PackageTests.TestStanza.Check
 import PackageTests.TestSuiteExeV10.Check
+import PackageTests.PropagateGlobalBuildDeps.Check
 
 hunit :: TestName -> HUnit.Test -> Test
 hunit name test = testGroup name $ hUnitTestToTests test
@@ -81,6 +82,8 @@ tests version inplaceSpec =
       PackageTests.EmptyLib.Check.emptyLib
     , hunit "BuildTestSuiteDetailedV09"
       $ PackageTests.BuildTestSuiteDetailedV09.Check.suite inplaceSpec
+    , hunit "PropagateGlobalBuildDeps"
+      PackageTests.PropagateGlobalBuildDeps.Check.suite
     ] ++
     -- These tests are only required to pass on cabal version >= 1.7
     (if version >= Version [1, 7] []

--- a/Cabal/tests/PackageTests/PropagateGlobalBuildDeps/Check.hs
+++ b/Cabal/tests/PackageTests/PropagateGlobalBuildDeps/Check.hs
@@ -1,0 +1,18 @@
+module PackageTests.PropagateGlobalBuildDeps.Check where
+
+import Test.HUnit
+import PackageTests.PackageTester
+import System.FilePath
+import Control.Exception
+import Prelude hiding (catch)
+
+
+suite :: Test
+suite = TestCase $ do
+    let spec = PackageSpec ("PackageTests" </> "PropagateGlobalBuildDeps") []
+    result <- cabal_build spec
+    do
+        assertEqual "cabal build should succeed - see test-log.txt" True (successful result)
+      `catch` \exc -> do
+        putStrLn $ "Cabal result was "++show result
+        throwIO (exc :: SomeException)

--- a/Cabal/tests/PackageTests/PropagateGlobalBuildDeps/Foo.hs
+++ b/Cabal/tests/PackageTests/PropagateGlobalBuildDeps/Foo.hs
@@ -1,0 +1,5 @@
+module Foo (bar) where
+
+import Data.List
+
+bar = find

--- a/Cabal/tests/PackageTests/PropagateGlobalBuildDeps/my.cabal
+++ b/Cabal/tests/PackageTests/PropagateGlobalBuildDeps/my.cabal
@@ -1,0 +1,19 @@
+name: PropagateGlobalBuildDeps
+version: 0.1
+license: BSD3
+author: Oleksandr Manzyuk
+stability: stable
+category: PackageTests
+build-type: Simple
+cabal-version: >= 1.2
+
+description:
+    Check that Cabal propagates dependencies specified with
+    the `build-depends' option in the global section to the
+    `library' component.
+
+build-depends: base
+
+library
+  exposed-modules:
+    Foo


### PR DESCRIPTION
This is my attempt to fix #417.  Frankly, I'm not 100% sure I'm doing the right thing here, but it seems to have the right effect.  On the other hand, @dcoutts has announced that he was rewriting the parser of .cabal files using Parsec, so it's probably pointless to fix this issue now if the whole parser is going to be replaced.  I'm sending this pull request anyway.
