### PR TITLE
Instead of pruning, make an install plan for the whole environment.

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox/Types.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Types.hs
@@ -8,8 +8,12 @@
 -----------------------------------------------------------------------------
 
 module Distribution.Client.Sandbox.Types (
-  UseSandbox(..), isUseSandbox, whenUsingSandbox
+  UseSandbox(..), isUseSandbox, whenUsingSandbox,
+  SandboxPackageInfo(..)
   ) where
+
+import qualified Distribution.Simple.PackageIndex as InstalledPackageIndex
+import Distribution.Client.Types (SourcePackage)
 
 import Data.Monoid
 
@@ -34,3 +38,20 @@ isUseSandbox NoSandbox      = False
 whenUsingSandbox :: UseSandbox -> (FilePath -> IO ()) -> IO ()
 whenUsingSandbox NoSandbox               _   = return ()
 whenUsingSandbox (UseSandbox sandboxDir) act = act sandboxDir
+
+-- | Data about the packages installed in the sandbox that is passed from
+-- 'reinstallAddSourceDeps' to the solver.
+data SandboxPackageInfo = SandboxPackageInfo {
+  modifiedAddSourceDependencies  :: [SourcePackage],
+  -- ^ Modified add-source deps that we want to reinstall. These are guaranteed
+  -- to be already installed in the sandbox.
+
+  otherAddSourceDependencies     :: [SourcePackage],
+  -- ^ Remaining add-source deps. Some of these may be not installed in the
+  -- sandbox.
+
+  otherInstalledSandboxPackages :: InstalledPackageIndex.PackageIndex
+  -- ^ All packages installed in the sandbox. Intersection with
+  -- 'modifiedAddSourceDependencies' and/or 'otherAddSourceDependencies' can be
+  -- non-empty.
+  }

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -512,8 +512,9 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags)
     install verbosity
             (configPackageDB' configFlags'')
             (globalRepos globalFlags')
-            comp platform conf globalFlags' configFlags'' configExFlags'
-            installFlags' haddockFlags
+            comp platform conf
+            Nothing -- FIXME
+            globalFlags' configFlags'' configExFlags' installFlags' haddockFlags
             targets
 
 testAction :: (TestFlags, BuildExFlags) -> [String] -> GlobalFlags -> IO ()


### PR DESCRIPTION
Previously, we used a hack for reinstalling reverse dependencies: we created an install plan for the sandboxed package and the modified add-source deps and then pruned the sandboxed package from it. This missed those revdeps that the sandboxed package didn't depend on and also broke the sandboxed package if it was installed in the sandboxed package DB (see #1229).

This commit replaces that hack with a more principled approach: we create a plan for the whole environment (all packages in the depResolverInstalledPkgIndex), constraining the modified add-source deps to be reinstalled and the already installed packages to be preferably not.

Fixes #1229.
