### PR TITLE
Avoid the timestamp check for `add-source --snapshot` dependencies.

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox/Timestamp.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Timestamp.hs
@@ -41,7 +41,8 @@ import Distribution.Version                          (Version (..),
                                                       orLaterVersion)
 
 import Distribution.Client.Sandbox.Index
-  (ListIgnoredBuildTreeRefs (..), listBuildTreeRefs)
+  (ListIgnoredBuildTreeRefs (DontListIgnored), RefTypesToList(OnlyLinks)
+  ,listBuildTreeRefs)
 import Distribution.Client.SetupWrapper              (SetupScriptOptions (..),
                                                       defaultSetupScriptOptions,
                                                       setupWrapper)
@@ -141,7 +142,8 @@ maybeAddCompilerTimestampRecord :: Verbosity -> FilePath -> FilePath
                                    -> IO ()
 maybeAddCompilerTimestampRecord verbosity sandboxDir indexFile
                                 compId platform = do
-  buildTreeRefs <- listBuildTreeRefs verbosity DontListIgnored indexFile
+  buildTreeRefs <- listBuildTreeRefs verbosity DontListIgnored OnlyLinks
+                                     indexFile
   withTimestampFile sandboxDir $ \timestampRecords -> do
     let key = timestampRecordKey compId platform
     case lookup key timestampRecords of

--- a/cabal-install/Distribution/Client/Tar.hs
+++ b/cabal-install/Distribution/Client/Tar.hs
@@ -40,6 +40,8 @@ module Distribution.Client.Tar (
   TypeCode,
   Format(..),
   buildTreeRefTypeCode,
+  buildTreeSnapshotTypeCode,
+  isBuildTreeRefTypeCode,
   entrySizeInBlocks,
   entrySizeInBytes,
 
@@ -158,6 +160,17 @@ data Entry = Entry {
 -- path.
 buildTreeRefTypeCode :: TypeCode
 buildTreeRefTypeCode = 'C'
+
+-- | Type code for the local build tree snapshot entry type.
+buildTreeSnapshotTypeCode :: TypeCode
+buildTreeSnapshotTypeCode = 'S'
+
+-- | Is this a type code for a build tree reference?
+isBuildTreeRefTypeCode :: TypeCode -> Bool
+isBuildTreeRefTypeCode typeCode
+  | (typeCode == buildTreeRefTypeCode
+     || typeCode == buildTreeSnapshotTypeCode) = True
+  | otherwise                                  = False
 
 -- | Native 'FilePath' of the file or directory within the archive.
 --


### PR DESCRIPTION
Snapshot deps now behave more like `cabal-dev add-source`. Implemented by adding a `BuildTreeRefType` field to the `BuildRef` index entry.

Fixes #1321.
