### PR TITLE
Bugfix to failReadE in Distribution.ReadE

### DIFF
--- a/Cabal/Distribution/ReadE.hs
+++ b/Cabal/Distribution/ReadE.hs
@@ -63,7 +63,7 @@ succeedReadE :: (String -> a) -> ReadE a
 succeedReadE f = ReadE (Right . f)
 
 failReadE :: ErrorMsg -> ReadE a
-failReadE = ReadE . const Left
+failReadE = ReadE . const . Left
 
 parseReadE :: ReadE a -> ReadP r a
 parseReadE (ReadE p) = do


### PR DESCRIPTION
Currently, `failReadE "some error"` returns `ReadE Left` --- dropping the supplied error message on the floor. This changes it to return `ReadE (const ( Left "some error"))`, which I assume is what's intended.

Not the biggest deal in the world, as so far as I can tell failReadE isn't actually used anywhere. But it might save some confusion down the road.
