### PR TITLE
Make newly-added add-source deps override previously installed versions.

### DIFF
--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -325,7 +325,7 @@ applySandboxInstallPolicy :: SandboxPackageInfo
                              -> DepResolverParams
                              -> DepResolverParams
 applySandboxInstallPolicy
-  (SandboxPackageInfo modifiedDeps otherDeps allSandboxPkgs)
+  (SandboxPackageInfo modifiedDeps otherDeps allSandboxPkgs _allDeps)
   params
 
   = addPreferences [ PackageInstalledPreference n PreferInstalled

--- a/cabal-install/Distribution/Client/Sandbox/Types.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Types.hs
@@ -16,6 +16,7 @@ import qualified Distribution.Simple.PackageIndex as InstalledPackageIndex
 import Distribution.Client.Types (SourcePackage)
 
 import Data.Monoid
+import qualified Data.Set as S
 
 -- | Are we using a sandbox?
 data UseSandbox = UseSandbox FilePath | NoSandbox
@@ -50,8 +51,11 @@ data SandboxPackageInfo = SandboxPackageInfo {
   -- ^ Remaining add-source deps. Some of these may be not installed in the
   -- sandbox.
 
-  otherInstalledSandboxPackages :: InstalledPackageIndex.PackageIndex
+  otherInstalledSandboxPackages :: InstalledPackageIndex.PackageIndex,
   -- ^ All packages installed in the sandbox. Intersection with
   -- 'modifiedAddSourceDependencies' and/or 'otherAddSourceDependencies' can be
   -- non-empty.
+
+  allAddSourceDependencies :: S.Set FilePath
+  -- ^ A set of paths to all add-source dependencies, for convenience.
   }

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -45,8 +45,6 @@ import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
 import Distribution.Client.Dependency.Types
          ( PreSolver(..) )
-import Distribution.Client.Sandbox.Types
-         ( UseSandbox(..) )
 import qualified Distribution.Client.Init.Types as IT
          ( InitFlags(..), PackageType(..) )
 import Distribution.Client.Targets
@@ -778,8 +776,7 @@ data InstallFlags = InstallFlags {
     installBuildReports     :: Flag ReportLevel,
     installSymlinkBinDir    :: Flag FilePath,
     installOneShot          :: Flag Bool,
-    installNumJobs          :: Flag (Maybe Int),
-    installUseSandbox       :: UseSandbox
+    installNumJobs          :: Flag (Maybe Int)
   }
 
 defaultInstallFlags :: InstallFlags
@@ -803,8 +800,7 @@ defaultInstallFlags = InstallFlags {
     installBuildReports    = Flag NoReports,
     installSymlinkBinDir   = mempty,
     installOneShot         = Flag False,
-    installNumJobs         = mempty,
-    installUseSandbox      = mempty
+    installNumJobs         = mempty
   }
   where
     docIndexFile = toPathTemplate ("$datadir" </> "doc" </> "index.html")
@@ -996,8 +992,7 @@ instance Monoid InstallFlags where
     installBuildReports    = mempty,
     installSymlinkBinDir   = mempty,
     installOneShot         = mempty,
-    installNumJobs         = mempty,
-    installUseSandbox      = mempty
+    installNumJobs         = mempty
   }
   mappend a b = InstallFlags {
     installDocumentation   = combine installDocumentation,
@@ -1019,8 +1014,7 @@ instance Monoid InstallFlags where
     installBuildReports    = combine installBuildReports,
     installSymlinkBinDir   = combine installSymlinkBinDir,
     installOneShot         = combine installOneShot,
-    installNumJobs         = combine installNumJobs,
-    installUseSandbox      = combine installUseSandbox
+    installNumJobs         = combine installNumJobs
   }
     where combine field = field a `mappend` field b
 


### PR DESCRIPTION
Fixes #1197.

This patch is a bit large because it includes several related changes:

1) Remove `installUseSandbox` from `InstallFlags` and pass `useSandbox` as an additional argument instead.

2) Instead of calling `reinstallAddSourceDeps` from `installAction`, always pass `SandboxPackageInfo` to `install`.

3) Set the timestamps of newly-added add-source deps to 0 in the timestamp file.

4) Move the timestamp file update to `postInstallActions` from `withModifiedDeps`. This way, the timestamps are updated even when the user runs `install --only-dependencies` or `install some-add-source-dep-package-id`.
