### PR TITLE
Fix file globbing with multiple dots (#784)

### DIFF
--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -146,7 +146,7 @@ import Control.Monad
 import Control.Concurrent.MVar
     ( newEmptyMVar, putMVar, takeMVar )
 import Data.List
-  ( nub, unfoldr, isPrefixOf, tails, intercalate )
+  ( nub, unfoldr, isPrefixOf, isSuffixOf, tails, intercalate )
 import Data.Char as Char
     ( toLower, chr, ord )
 import Data.Bits
@@ -716,12 +716,12 @@ matchDirFileGlob dir filepath = case parseFileGlob filepath of
                 ++ " name, not in the directory name or file extension."
                 ++ " If a wildcard is used it must be with an file extension."
   Just (NoGlob filepath') -> return [filepath']
-  Just (FileGlob dir' ext) -> do
+  Just (FileGlob dir' globExt) -> do
     files <- getDirectoryContents (dir </> dir')
     case   [ dir' </> file
            | file <- files
-           , let (name, ext') = splitExtensions file
-           , not (null name) && ext' == ext ] of
+           , let (name, fileExt) = splitExtensions file
+           , not (null name) && globExt `isSuffixOf` fileExt ] of
       []      -> die $ "filepath wildcard '" ++ filepath
                     ++ "' does not match any files."
       matches -> return matches


### PR DESCRIPTION
Setting the "data-files" field in a .cabal file to pull in
"resources/*.js" would previously not work for any file containing more
than one dot, for example "resources/jquery-1.9.1.js".

This commit changes this behaviour so that a glob counts as a match,
provided that its extension is a suffix of the filename. So, if
resources/ contains foo.js and foo.bar.js:

* "resources/*.js" will match both "resources/foo.js" and
  "resources/foo.bar.js"
* "resources/*.bar.js" will match "resources/foo.bar.js" but not
  "resources/foo.js"

It should be noted that I've only tested this by calling
matchFileDirGlob in ghci -- I'm fairly new to Cabal, and can't see how
to test it properly.