### PR TITLE
Allow directories in cabal data-files (#713)

### DIFF
--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -695,16 +695,21 @@ data FileGlob
    --    @FileGlob \"foo\/bar\" \".baz\"@
    | FileGlob FilePath String
 
+   -- | A directory which explicitly ends with a slash. This means "Include all
+   -- the files below me recursively"
+   | DirTrailingSlash FilePath
+
 parseFileGlob :: FilePath -> Maybe FileGlob
 parseFileGlob filepath = case splitExtensions filepath of
   (filepath', ext) -> case splitFileName filepath' of
     (dir, "*") | '*' `elem` dir
               || '*' `elem` ext
-              || null ext            -> Nothing
-               | null dir            -> Just (FileGlob "." ext)
-               | otherwise           -> Just (FileGlob dir ext)
-    _          | '*' `elem` filepath -> Nothing
-               | otherwise           -> Just (NoGlob filepath)
+              || null ext             -> Nothing
+               | null dir             -> Just (FileGlob "." ext)
+               | otherwise            -> Just (FileGlob dir ext)
+    _          | '*' `elem` filepath  -> Nothing
+               | last filepath == '/' -> Just (DirTrailingSlash filepath)
+               | otherwise            -> Just (NoGlob filepath)
 
 matchFileGlob :: FilePath -> IO [FilePath]
 matchFileGlob = matchDirFileGlob "."
@@ -725,6 +730,9 @@ matchDirFileGlob dir filepath = case parseFileGlob filepath of
       []      -> die $ "filepath wildcard '" ++ filepath
                     ++ "' does not match any files."
       matches -> return matches
+  Just (DirTrailingSlash dir') ->
+    let contents = getDirectoryContentsRecursive (dir </> dir')
+    in  (fmap . fmap) (dir' ++) contents
 
 ----------------------------------------
 -- Copying and installing files and dirs


### PR DESCRIPTION
This commit adds the capability to specify a whole directory which
contains data-files in a project's .cabal file.

If a data-files entry ends with a slash, like "static/", then it will
pull in all files under the directory named "static/".

Notes:

* This has only been tested by calling matchDirFileGlob in GHCi.
* I'm not sure about the name (data FileGlob = DirTrailingSlash --
  perhaps it should have Glob on the end like the others?) but I've been
  unable to come up with anything better.