### PR TITLE
Fix cabal-install build error

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -687,7 +687,7 @@ maybeReinstallAddSourceDeps verbosity numJobsFlag configFlags' globalFlags' = do
         configProgramPaths = configProgramPaths sandboxConfigFlags
                              `mappend` configProgramPaths savedFlags,
         configProgramArgs  = configProgramArgs sandboxConfigFlags
-                             `mappend` configProgramArgs savedFlags,
+                             `mappend` configProgramArgs savedFlags
         -- NOTE: We don't touch the @configPackageDBs@ field because
         -- @sandboxConfigFlags@ contains the sandbox location which was set when
         -- creating @cabal.sandbox.config@.


### PR DESCRIPTION
Distribution/Client/Sandbox.hs:695:9: parse error on input `}'

Just a trailing comma.
