### PR TITLE
Make sure we test valid C99 programs.

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -364,7 +364,7 @@ configureToolchain ghcProg ghcInfo =
       tempDir <- getTemporaryDirectory
       ldx <- withTempFile False tempDir ".c" $ \testcfile testchnd ->
              withTempFile False tempDir ".o" $ \testofile testohnd -> do
-               hPutStrLn testchnd "int foo() {}"
+               hPutStrLn testchnd "int foo() { return 0; }"
                hClose testchnd; hClose testohnd
                rawSystemProgram verbosity ghcProg ["-c", testcfile,
                                                    "-o", testofile]

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -206,7 +206,7 @@ configureToolchain lhcProg =
       tempDir <- getTemporaryDirectory
       ldx <- withTempFile False tempDir ".c" $ \testcfile testchnd ->
              withTempFile False tempDir ".o" $ \testofile testohnd -> do
-               hPutStrLn testchnd "int foo() {}"
+               hPutStrLn testchnd "int foo() { return 0; }"
                hClose testchnd; hClose testohnd
                rawSystemProgram verbosity lhcProg ["-c", testcfile,
                                                    "-o", testofile]


### PR DESCRIPTION
In particular, Clang is very fussy about not having this. It doesn't
really hurt anything, but it's better to suppress the annoying warning
properly.
