### PR TITLE
Add options of configure and installing as a non root user.

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -9,6 +9,8 @@
 # install settings, you can override these by setting environment vars
 #VERBOSE
 #EXTRA_CONFIGURE_OPTS
+#EXTRA_BUILD_OPTS
+#EXTRA_INSTALL_OPTS
 
 # programs, you can override these by setting environment vars
 GHC=${GHC:-ghc}
@@ -162,10 +164,10 @@ install_pkg () {
     ${EXTRA_CONFIGURE_OPTS} ${VERBOSE} \
     || die "Configuring the ${PKG} package failed"
 
-  ./Setup build ${VERBOSE} \
+  ./Setup build ${EXTRA_BUILD_OPTS} ${VERBOSE} \
     || die "Building the ${PKG} package failed"
 
-  ./Setup install ${VERBOSE} \
+  ./Setup install ${SCOPE_OF_INSTALLATION} ${EXTRA_INSTALL_OPTS} ${VERBOSE} \
     || die "Installing the ${PKG} package failed"
 }
 


### PR DESCRIPTION
I needed some extra options to install "cabal-install" into user directory as a non root user.
