### PR TITLE
Don't change the types of 'withTemp[File,Directory]' in 1.18.

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -1036,8 +1036,8 @@ checkForeignDeps pkg lbi verbosity = do
 
         builds program args = do
             tempDir <- getTemporaryDirectory
-            withTempFile False tempDir ".c" $ \cName cHnd ->
-              withTempFile False tempDir "" $ \oNname oHnd -> do
+            withTempFile tempDir ".c" $ \cName cHnd ->
+              withTempFile tempDir "" $ \oNname oHnd -> do
                 hPutStrLn cHnd program
                 hClose cHnd
                 hClose oHnd

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -362,13 +362,13 @@ configureToolchain ghcProg ghcInfo =
     configureLd' :: Verbosity -> ConfiguredProgram -> IO [ProgArg]
     configureLd' verbosity ldProg = do
       tempDir <- getTemporaryDirectory
-      ldx <- withTempFile False tempDir ".c" $ \testcfile testchnd ->
-             withTempFile False tempDir ".o" $ \testofile testohnd -> do
+      ldx <- withTempFile tempDir ".c" $ \testcfile testchnd ->
+             withTempFile tempDir ".o" $ \testofile testohnd -> do
                hPutStrLn testchnd "int foo() { return 0; }"
                hClose testchnd; hClose testohnd
                rawSystemProgram verbosity ghcProg ["-c", testcfile,
                                                    "-o", testofile]
-               withTempFile False tempDir ".o" $ \testofile' testohnd' ->
+               withTempFile tempDir ".o" $ \testofile' testohnd' ->
                  do
                    hClose testohnd'
                    _ <- rawSystemProgramStdout verbosity ldProg

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -204,13 +204,13 @@ configureToolchain lhcProg =
     configureLd :: Verbosity -> ConfiguredProgram -> IO [ProgArg]
     configureLd verbosity ldProg = do
       tempDir <- getTemporaryDirectory
-      ldx <- withTempFile False tempDir ".c" $ \testcfile testchnd ->
-             withTempFile False tempDir ".o" $ \testofile testohnd -> do
+      ldx <- withTempFile tempDir ".c" $ \testcfile testchnd ->
+             withTempFile tempDir ".o" $ \testofile testohnd -> do
                hPutStrLn testchnd "int foo() { return 0; }"
                hClose testchnd; hClose testohnd
                rawSystemProgram verbosity lhcProg ["-c", testcfile,
                                                    "-o", testofile]
-               withTempFile False tempDir ".o" $ \testofile' testohnd' ->
+               withTempFile tempDir ".o" $ \testofile' testohnd' ->
                  do
                    hClose testohnd'
                    _ <- rawSystemProgramStdout verbosity ldProg

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -147,7 +147,7 @@ sdist pkg mb_lbi flags mkTmpDir pps =
 
         Nothing -> do
           createDirectoryIfMissingVerbose verbosity True tmpTargetDir
-          withTempDirectory verbosity False tmpTargetDir "sdist." $ \tmpDir -> do
+          withTempDirectory verbosity tmpTargetDir "sdist." $ \tmpDir -> do
             let targetDir = tmpDir </> tarBallName pkg'
             generateSourceDir targetDir pkg'
             targzFile <- createArchive verbosity pkg' mb_lbi tmpDir targetPref

--- a/cabal-install/Distribution/Client/Haddock.hs
+++ b/cabal-install/Distribution/Client/Haddock.hs
@@ -51,7 +51,7 @@ regenerateHaddockIndex verbosity pkgs conf index = do
 
       createDirectoryIfMissing True destDir
 
-      withTempDirectory verbosity False destDir "tmphaddock" $ \tempDir -> do
+      withTempDirectory verbosity destDir "tmphaddock" $ \tempDir -> do
 
         let flags = [ "--gen-contents"
                     , "--gen-index"

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1112,7 +1112,7 @@ installLocalTarballPackage
   -> IO BuildResult
 installLocalTarballPackage verbosity jobLimit pkgid tarballPath installPkg = do
   tmp <- getTemporaryDirectory
-  withTempDirectory verbosity False tmp (display pkgid) $ \tmpDirPath ->
+  withTempDirectory verbosity tmp (display pkgid) $ \tmpDirPath ->
     onFailure UnpackFailed $ do
       let relUnpackedPath = display pkgid
           absUnpackedPath = tmpDirPath </> relUnpackedPath

--- a/cabal-install/Distribution/Client/SrcDist.hs
+++ b/cabal-install/Distribution/Client/SrcDist.hs
@@ -45,7 +45,7 @@ sdist flags exflags = do
          =<< readPackageDescription verbosity
          =<< defaultPackageDesc verbosity
   let withDir = if not needMakeArchive then (\f -> f tmpTargetDir)
-                else withTempDirectory verbosity False tmpTargetDir "sdist."
+                else withTempDirectory verbosity tmpTargetDir "sdist."
   -- 'withTempDir' fails if we don't create 'tmpTargetDir'...
   when needMakeArchive $
     createDirectoryIfMissingVerbose verbosity True tmpTargetDir


### PR DESCRIPTION
Add new functions 'withTempFileEx' and 'withTempDirectoryEx' instead.

Fixes #1387.
