### PR TITLE
Pass '--libdir' etc to 'setup configure' when installing.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -24,6 +24,7 @@ module Distribution.Client.Config (
     defaultCacheDir,
     defaultCompiler,
     defaultLogsDir,
+    defaultUserInstall,
 
     baseSavedConfig,
     commentSavedConfig,


### PR DESCRIPTION
Otherwise libs with 'build-type: Custom' get installed under `$prefix/lib/$pkgname` instead of `$prefix/lib/$arch-$compiler-$os/$pkgname`.
