### PR TITLE
Distribution/Client/Tar.hs: make clearer error message when tar fails to...

### DIFF
--- a/cabal-install/Distribution/Client/Tar.hs
+++ b/cabal-install/Distribution/Client/Tar.hs
@@ -527,8 +527,10 @@ checkEntryTarbomb _ entry | nonFilesystemEntry = Nothing
 checkEntryTarbomb expectedTopDir entry =
   case FilePath.Native.splitDirectories (entryPath entry) of
     (topDir:_) | topDir == expectedTopDir -> Nothing
-    _ -> Just $ "File in tar archive is not in the expected directory "
+    s -> Just $ "File in tar archive is not in the expected directory "
              ++ show expectedTopDir
+             ++ " but got the following hierarchy: "
+             ++ show s
 
 
 --


### PR DESCRIPTION
... unpack source

Patch improves error reporting to give a clue what broke
when unpacking:
    $ dist/build/cabal/cabal unpack hackport
    Unpacking to hackport-0.3.2/
    cabal: File in tar archive is not in the expected directory "hackport-0.3.2"
    but got the following hierarchy: [".",".","@LongLink"]

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
