### PR TITLE
A bare-bones 'repl' command.

### DIFF
--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -46,7 +46,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. -}
 
 module Distribution.Simple.Build (
-    build,
+    build, repl,
 
     initialBuildSteps,
     writeAutogenFiles,
@@ -66,7 +66,7 @@ import Distribution.Package
          ( Package(..), PackageName(..), PackageIdentifier(..)
          , Dependency(..), thisPackageVersion )
 import Distribution.Simple.Compiler
-         ( CompilerFlavor(..), compilerFlavor, PackageDB(..) )
+         ( CompilerFlavor(..), compilerFlavor, PackageDB(..), PackageDBStack )
 import Distribution.PackageDescription
          ( PackageDescription(..), BuildInfo(..), Library(..), Executable(..)
          , TestSuite(..), TestSuiteInterface(..), Benchmark(..)
@@ -151,6 +151,16 @@ build pkg_descr lbi flags suffixes = do
                    withPackageDB = withPackageDB lbi ++ [internalPackageDB]
                  }
     in buildComponent verbosity pkg_descr lbi' suffixes comp clbi distPref
+
+repl     :: Verbosity
+         -> CompilerFlavor -- ^ The interpreter to run
+         -> ProgramDb      -- ^ Path configuration information
+         -> PackageDBStack -- ^ Package DBs to use
+         -> IO ()
+repl verbosity compFlavor programDB packageDBs =
+  case compFlavor of
+    GHC  -> GHC.runRepl verbosity programDB packageDBs
+    _    -> die "Interpreter sessions are not supported with this compiler."
 
 
 buildComponent :: Verbosity

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -64,6 +64,7 @@ module Distribution.Simple.GHC (
         getGhcInfo,
         configure, getInstalledPackages, getPackageDBContents,
         buildLib, buildExe,
+        runRepl,
         installLib, installExe,
         libAbiHash,
         initPackageDB,
@@ -642,6 +643,21 @@ substTopDir topDir ipo
    }
     where f ('$':'t':'o':'p':'d':'i':'r':rest) = topDir ++ rest
           f x = x
+
+-- -----------------------------------------------------------------------------
+-- Repl
+
+-- | Open a GHCi session.
+--
+runRepl :: Verbosity -> ProgramConfiguration -> PackageDBStack -> IO ()
+runRepl verbosity programDB packageDBs = do
+  let ghciOpts = mempty {
+        ghcOptMode       = toFlag GhcModeInteractive,
+        ghcOptPackageDBs = packageDBs
+      }
+
+  (ghcProg, _) <- requireProgram verbosity ghcProgram programDB
+  runGHC verbosity ghcProg ghciOpts
 
 -- -----------------------------------------------------------------------------
 -- Building

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -80,7 +80,7 @@ module Distribution.Simple.Setup (
   buildOptions, installDirsOptions,
   programConfigurationOptions, programConfigurationPaths',
 
-  defaultDistPref,
+  defaultDistPref, optionDistPref,
 
   Flag(..),
   toFlag,

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -16,6 +16,7 @@ module Distribution.Client.Setup
     , configureExCommand, ConfigExFlags(..), defaultConfigExFlags
                         , configureExOptions
     , buildCommand, BuildFlags(..), BuildExFlags(..), SkipAddSourceDepsCheck(..)
+    , replCommand, ReplFlags(..)
     , testCommand, benchmarkCommand
     , installCommand, InstallFlags(..), installOptions, defaultInstallFlags
     , listCommand, ListFlags(..)
@@ -323,6 +324,52 @@ instance Monoid ConfigExFlags where
     configPreferences  = combine configPreferences,
     configSolver       = combine configSolver
   }
+    where combine field = field a `mappend` field b
+
+-- ------------------------------------------------------------
+-- * Repl flags
+-- ------------------------------------------------------------
+
+data ReplFlags = ReplFlags {
+  replVerbosity     :: Flag Verbosity,
+  replDistPref      :: Flag FilePath
+}
+
+defaultReplFlags :: ReplFlags
+defaultReplFlags = ReplFlags {
+  replVerbosity     = toFlag normal,
+  replDistPref      = toFlag Cabal.defaultDistPref
+  }
+
+replCommand :: CommandUI ReplFlags
+replCommand = CommandUI {
+  commandName         = "repl",
+  commandSynopsis     = "Open an interpreter session.",
+  commandDescription  = Nothing,
+  commandUsage        = \pname -> "Usage: " ++ pname ++ " repl\n\n"
+    ++ "Flags for repl:",
+
+  commandDefaultFlags = defaultReplFlags,
+  commandOptions      = \showOrParseArgs ->
+    [ optionVerbosity replVerbosity
+      (\v flags -> flags { replVerbosity = v })
+
+    , Cabal.optionDistPref
+      replDistPref (\d flags -> flags { replDistPref = d })
+      showOrParseArgs
+    ]
+
+  }
+
+instance Monoid ReplFlags where
+  mempty = ReplFlags {
+    replVerbosity     = mempty,
+    replDistPref      = mempty
+    }
+  mappend a b = ReplFlags {
+    replVerbosity     = combine replVerbosity,
+    replDistPref      = combine replDistPref
+    }
     where combine field = field a `mappend` field b
 
 -- ------------------------------------------------------------


### PR DESCRIPTION
Runs either 'ghci' or 'ghci -package-db .cabal-sandbox/...' if we're working
inside a sandbox.
