### PR TITLE
fixed bug where sandbox was not using cabal.config to override cabal.san...

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
+++ b/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
@@ -327,8 +327,8 @@ tryLoadSandboxPackageEnvironmentFile verbosity pkgEnvFile configFileFlag = do
   cabalConfig <- loadConfig verbosity configFileFlag NoFlag
   return (sandboxDir,
           (base `mappend` (toPkgEnv cabalConfig) `mappend`
-           common `mappend` inherited `mappend` user)
-          `overrideSandboxSettings` pkgEnv)
+           common `mappend` inherited)
+          `overrideSandboxSettings` pkgEnv `overrideSandboxSettings` user)
     where
       toPkgEnv config = mempty { pkgEnvSavedConfig = config }
 


### PR DESCRIPTION
I think is the cabal.config override behavior that was documented (but not implemented).
