### PR TITLE
GHC: Build normal and profiling libraries in parallel.

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -788,9 +788,11 @@ buildOrReplLib forRepl verbosity pkg_descr lbi lib clbi = do
                                 }
                 odir          = fromFlag (ghcOptObjDir vanillaCcOpts)
             createDirectoryIfMissingVerbose verbosity True odir
-            runGhcProg vanillaCcOpts
+            m <- newEmptyMVar
+            _ <- forkIO $ runGhcProg vanillaCcOpts >> putMVar m ()
             whenSharedLib forceSharedLib (runGhcProg sharedCcOpts)
             whenProfLib (runGhcProg profCcOpts)
+            takeMVar m
        | filename <- cSources libBi]
 
   -- TODO: problem here is we need the .c files built first, so we can load them


### PR DESCRIPTION
This looks quite straightforward.

Most probably we have to add a little bit of code to terminate early if there is an error in any of the threads, but that shouldn't be too hard. What are your thoughts on this?

Also, do you see any other problematic points?

The speed-up gained by this is significant (factor 2 for all my code, since I always have profiling enabled).
