### PR TITLE
Rename 'extra-html-files' to 'extra-doc-files'.

### DIFF
--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -195,7 +195,7 @@ data PackageDescription
         dataDir        :: FilePath,
         extraSrcFiles  :: [FilePath],
         extraTmpFiles  :: [FilePath],
-        extraHtmlFiles :: [FilePath]
+        extraDocFiles  :: [FilePath]
     }
     deriving (Show, Read, Eq, Typeable, Data)
 
@@ -259,7 +259,7 @@ emptyPackageDescription
                       dataDir      = "",
                       extraSrcFiles = [],
                       extraTmpFiles = [],
-                      extraHtmlFiles = []
+                      extraDocFiles = []
                      }
 
 -- | The type of build system used by this package.

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -852,11 +852,11 @@ checkPaths pkg =
       _            -> False
     -- paths that must be relative
     relPaths =
-         [ (path, "extra-src-files")  | path <- extraSrcFiles  pkg ]
-      ++ [ (path, "extra-tmp-files")  | path <- extraTmpFiles  pkg ]
-      ++ [ (path, "extra-html-files") | path <- extraHtmlFiles pkg ]
-      ++ [ (path, "data-files")       | path <- dataFiles      pkg ]
-      ++ [ (path, "data-dir")         | path <- [dataDir       pkg]]
+         [ (path, "extra-src-files") | path <- extraSrcFiles pkg ]
+      ++ [ (path, "extra-tmp-files") | path <- extraTmpFiles pkg ]
+      ++ [ (path, "extra-doc-files") | path <- extraDocFiles pkg ]
+      ++ [ (path, "data-files")      | path <- dataFiles     pkg ]
+      ++ [ (path, "data-dir")        | path <- [dataDir      pkg]]
       ++ concat
          [    [ (path, "c-sources")        | path <- cSources        bi ]
            ++ [ (path, "install-includes") | path <- installIncludes bi ]

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -174,9 +174,9 @@ pkgDescrFieldDescrs =
  , listField "extra-tmp-files"
            showFilePath       parseFilePathQ
            extraTmpFiles          (\val pkg -> pkg{extraTmpFiles=val})
- , listField "extra-html-files"
+ , listField "extra-doc-files"
            showFilePath    parseFilePathQ
-           extraHtmlFiles         (\val pkg -> pkg{extraHtmlFiles=val})
+           extraDocFiles          (\val pkg -> pkg{extraDocFiles=val})
  ]
 
 -- | Store any fields beginning with "x-" in the customFields field of

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -237,7 +237,7 @@ haddock pkg_descr lbi suffixes flags = do
         CTest  _ -> when (flag haddockTestSuites)  $ doExe comp
         CBench _ -> when (flag haddockBenchmarks)  $ doExe comp
 
-    forM_ (extraHtmlFiles pkg_descr) $ \ fpath -> do
+    forM_ (extraDocFiles pkg_descr) $ \ fpath -> do
       files <- matchFileGlob fpath
       forM_ files $ copyFileTo verbosity (unDir $ argOutputDir commonArgs)
   where


### PR DESCRIPTION
Some people [complained](https://plus.google.com/116396165393082006231/posts/deEMzNUxNV9) that having a field named `extra-html-files` that is not meant for HTML files is unintuitive.
