### PR TITLE
Case-insensitive lookup of the PATH variable on Windows

### DIFF
--- a/Cabal/Distribution/Simple/Program/Find.hs
+++ b/Cabal/Distribution/Simple/Program/Find.hs
@@ -42,6 +42,8 @@ import System.FilePath
          ( (</>), (<.>), splitSearchPath, searchPathSeparator )
 import Data.List
          ( intercalate )
+import qualified Data.Char as Char
+         ( toUpper )
 
 
 -- | A search path to use when locating executables. This is analogous
@@ -116,4 +118,7 @@ programSearchPathAsPATHVar searchpath = do
     getEntries (ProgramSearchPathDir dir) = return [dir]
     getEntries ProgramSearchPathDefault   = do
       env <- getEnvironment
-      return (maybe [] splitSearchPath (lookup "PATH" env))
+      return (maybe [] splitSearchPath (lookup "PATH" $ normalizeKeys env))
+    -- Win32 is case-insensitive and often there is "Path" but no "PATH",
+    -- so convert all names to upper case before looking them up.
+    normalizeKeys = map (\(name, value) -> (map Char.toUpper name, value))

--- a/Cabal/Distribution/Simple/Program/Run.hs
+++ b/Cabal/Distribution/Simple/Program/Run.hs
@@ -31,6 +31,8 @@ import Distribution.Simple.Utils
 import Distribution.Verbosity
          ( Verbosity )
 
+import qualified Data.Char as Char
+         ( toUpper )
 import Data.List
          ( foldl', unfoldr )
 import qualified Data.Map as Map
@@ -176,11 +178,15 @@ getProgramInvocationOutput verbosity
 getEffectiveEnvironment :: [(String, Maybe String)] -> IO (Maybe [(String, String)])
 getEffectiveEnvironment []        = return Nothing
 getEffectiveEnvironment overrides =
-    fmap (Just . Map.toList . apply overrides . Map.fromList) getEnvironment
+    fmap (Just . stripKeys . Map.toList . apply overrides . Map.fromList . appendKeys) getEnvironment
   where
     apply os env = foldl' (flip update) env os
     update (var, Nothing)  = Map.delete var
-    update (var, Just val) = Map.insert var val
+    update (var, Just val) = Map.insert var (var, val)
+    -- Make sure that all keys are compared case-insensitively
+    -- while preserving their original case.
+    appendKeys = map $ \(name, val) -> (map Char.toUpper name, (name, val))
+    stripKeys  = map snd
 
 -- | Like the unix xargs program. Useful for when we've got very long command
 -- lines that might overflow an OS limit on command line length and so you


### PR DESCRIPTION
Currently, the HEAD version is broken on Windows because it fails to look up the PATH environment variable. On all recent Windows versions that I checked (Win7/8) it's named Path, not PATH.

This change attempts to fix this issue on Windows.

As I'm absolute newbie in Cabal, so I don't think that this fix is the best one but I'm open to suggestions/ideas.

P.S. I'm a Haskell newbie as well, please be forgiving :)
