### PR TITLE
Backwards compatibility patch for cross-compilation changes.

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -69,7 +69,7 @@ import Distribution.PackageDescription.Configuration
 import Distribution.PackageDescription.Parse  ( readPackageDescription )
 import Distribution.Simple.Compiler           ( Compiler(..), PackageDB(..)
                                               , PackageDBStack )
-import Distribution.Simple.Configure          ( configCompilerAux
+import Distribution.Simple.Configure          ( configCompilerAuxEx
                                               , interpretPackageDbFlags
                                               , getPackageDBContents )
 import Distribution.Simple.PreProcess         ( knownSuffixHandlers )
@@ -294,7 +294,7 @@ sandboxInit verbosity sandboxFlags globalFlags = do
 
   -- Determine which compiler to use (using the value from ~/.cabal/config).
   userConfig <- loadConfig verbosity (globalConfigFile globalFlags) NoFlag
-  (comp, platform, _) <- configCompilerAux (savedConfigureFlags userConfig)
+  (comp, platform, _) <- configCompilerAuxEx (savedConfigureFlags userConfig)
 
   -- Create the package environment file.
   pkgEnvFile <- getSandboxConfigFilePath globalFlags
@@ -353,7 +353,7 @@ doAddSource verbosity buildTreeRefs sandboxDir pkgEnv refType = do
 
   -- If we're running 'sandbox add-source' for the first time for this compiler,
   -- we need to create an initial timestamp record.
-  (comp, platform, _) <- configCompilerAux . savedConfigureFlags $ savedConfig
+  (comp, platform, _) <- configCompilerAuxEx . savedConfigureFlags $ savedConfig
   maybeAddCompilerTimestampRecord verbosity sandboxDir indexFile
     (compilerId comp) platform
 
@@ -715,6 +715,6 @@ configPackageDB' cfg =
 configCompilerAux' :: ConfigFlags
                    -> IO (Compiler, Platform, ProgramConfiguration)
 configCompilerAux' configFlags =
-  configCompilerAux configFlags
+  configCompilerAuxEx configFlags
     --FIXME: make configCompilerAux use a sensible verbosity
     { configVerbosity = fmap lessVerbose (configVerbosity configFlags) }

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -38,7 +38,7 @@ import Distribution.PackageDescription
 import Distribution.PackageDescription.Parse
          ( readPackageDescription )
 import Distribution.Simple.Configure
-         ( configCompiler )
+         ( configCompilerEx )
 import Distribution.Compiler ( buildCompilerId )
 import Distribution.Simple.Compiler
          ( CompilerFlavor(GHC), Compiler(compilerId)
@@ -306,7 +306,7 @@ externalSetupMethod verbosity options pkg bt mkargs = do
     (comp, conf) <- case useCompiler options' of
       Just comp -> return (comp, useProgramConfig options')
       Nothing   -> do (comp, _, conf) <-
-                        configCompiler (Just GHC) Nothing Nothing
+                        configCompilerEx (Just GHC) Nothing Nothing
                         (useProgramConfig options') verbosity
                       return (comp, conf)
     -- Whenever we need to call configureCompiler, we also need to access the

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -101,7 +101,7 @@ import Distribution.Simple.Command
 import Distribution.Simple.Compiler
          ( Compiler(..) )
 import Distribution.Simple.Configure
-         ( checkPersistBuildConfigOutdated, configCompilerAux
+         ( checkPersistBuildConfigOutdated, configCompilerAuxEx
          , ConfigStateFileErrorType(..), localBuildInfoFile
          , tryGetPersistBuildConfig )
 import qualified Distribution.Simple.LocalBuildInfo as LBI
@@ -231,7 +231,7 @@ configureAction (configFlags, configExFlags) extraArgs globalFlags = do
   let configFlags'   = savedConfigureFlags   config `mappend` configFlags
       configExFlags' = savedConfigureExFlags config `mappend` configExFlags
       globalFlags'   = savedGlobalFlags      config `mappend` globalFlags
-  (comp, platform, conf) <- configCompilerAux configFlags'
+  (comp, platform, conf) <- configCompilerAuxEx configFlags'
 
   -- If we're working inside a sandbox and the user has set the -w option, we
   -- may need to create a sandbox-local package DB for this compiler and add a
@@ -662,7 +662,7 @@ infoAction infoFlags extraArgs globalFlags = do
   (_, config) <- loadConfigOrSandboxConfig verbosity globalFlags mempty
   let configFlags  = savedConfigureFlags config
       globalFlags' = savedGlobalFlags    config `mappend` globalFlags
-  (comp, _, conf) <- configCompilerAux configFlags
+  (comp, _, conf) <- configCompilerAuxEx configFlags
   List.info verbosity
        (configPackageDB' configFlags)
        (globalRepos globalFlags')


### PR DESCRIPTION
Changes back the types of `configCompiler` and `configCompilerEx`, but marks them as deprecated. Adds new functions `configCompilerEx` and `configCompilerAuxEx`.

The remaining functions that changed type after the cross-compilation changes shouldn't matter from the backwards compatibility standpoint:
- `InstallDirs.{absoluteInstallDirs, prefixRelativeInstallDirs, initialPathTemplateEnv}` - the versions in `D.S.LocalBuildInfo` retain their old types and are usually used instead. In any case, removing the `Platform` parameter from here is problematic because the default install dirs now include `$arch` and `$os` vars.
- `D.S.Configure.configure` - shouldn't be used by the setup scripts.

See #1214 for the original (backwards-incompatible) patches.
