### PR TITLE
Improve stdout flushing

### DIFF
--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -117,6 +117,7 @@ import qualified Paths_cabal_install (version)
 import System.Environment       (getArgs, getProgName)
 import System.Exit              (exitFailure)
 import System.FilePath          (splitExtension, takeExtension)
+import System.IO                (BufferMode(LineBuffering), hSetBuffering, stdout)
 import System.Directory         (doesFileExist)
 import Data.List                (intercalate)
 import Data.Monoid              (Monoid(..))
@@ -125,7 +126,11 @@ import Control.Monad            (when, unless)
 -- | Entry point
 --
 main :: IO ()
-main = getArgs >>= mainWorker
+main = do
+  -- Enable line buffering so that we can get fast feedback even when piped.
+  -- This is especially important for CI and build systems.
+  hSetBuffering stdout LineBuffering
+  getArgs >>= mainWorker
 
 mainWorker :: [String] -> IO ()
 mainWorker args = topHandler $


### PR DESCRIPTION
Flushing after every line is helpful to see information quickly.

By default, Haskell application use NoBuffering when piped into
another process, which for example hides the output of cabal build
when run via a Continuous Integration server, an output-capturing
build tool, or ssh.
