### PR TITLE
Force-include 'cabal_macros.h' when compiling C sources.

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1189,7 +1189,9 @@ componentCcGhcOptions verbosity lbi bi clbi pref filename =
       ghcOptCcOptions      = PD.ccOptions bi
                              ++ case withOptimization lbi of
                                   NoOptimisation -> []
-                                  _              -> ["-O2"],
+                                  _              -> ["-O2"]
+                             ++ ["-include"
+                                ,autogenModulesDir lbi </> cppHeaderName],
       ghcOptObjDir         = toFlag odir
     }
   where


### PR DESCRIPTION
When compiling c-sources, GHC is now passed `-optc-include -optc/path/to/cabal_macros.h`. Note that `-optP-include` (which is used when compiling Haskell sources) doesn't work for this case.

Fixes #1434.
