### PR TITLE
Add `ghcOptOutputDir` to `GhcOptions` for GHC's `-outputdir`

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1159,6 +1159,7 @@ componentGhcOptions verbosity lbi bi clbi odir =
       ghcOptObjDir          = toFlag odir,
       ghcOptHiDir           = toFlag odir,
       ghcOptStubDir         = toFlag odir,
+      ghcOptOutputDir       = toFlag odir,
       ghcOptOptimisation    = toGhcOptimisation (withOptimization lbi),
       ghcOptExtra           = hcOptions GHC bi,
       ghcOptLanguage        = toFlag (fromMaybe Haskell98 (defaultLanguage bi)),

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -163,6 +163,7 @@ data GhcOptions = GhcOptions {
   ghcOptDynObjSuffix  :: Flag String,   -- ^ only in 'GhcStaticAndDynamic' mode
   ghcOptHiDir         :: Flag FilePath,
   ghcOptObjDir        :: Flag FilePath,
+  ghcOptOutputDir     :: Flag FilePath,
   ghcOptStubDir       :: Flag FilePath,
 
   --------------------
@@ -277,6 +278,7 @@ renderGhcOptions version@(Version ver _) opts =
   , concat [ ["-hisuf",   suf] | suf <- flag ghcOptHiSuffix  ]
   , concat [ ["-dynosuf", suf] | suf <- flag ghcOptDynObjSuffix ]
   , concat [ ["-dynhisuf",suf] | suf <- flag ghcOptDynHiSuffix  ]
+  , concat [ ["-outputdir", dir] | dir <- flag ghcOptOutputDir, ver >= [6,10] ]
   , concat [ ["-odir",    dir] | dir <- flag ghcOptObjDir ]
   , concat [ ["-hidir",   dir] | dir <- flag ghcOptHiDir  ]
   , concat [ ["-stubdir", dir] | dir <- flag ghcOptStubDir, ver >= [6,8] ]
@@ -430,6 +432,7 @@ instance Monoid GhcOptions where
     ghcOptDynObjSuffix       = mempty,
     ghcOptHiDir              = mempty,
     ghcOptObjDir             = mempty,
+    ghcOptOutputDir          = mempty,
     ghcOptStubDir            = mempty,
     ghcOptDynLinkMode        = mempty,
     ghcOptShared             = mempty,
@@ -477,6 +480,7 @@ instance Monoid GhcOptions where
     ghcOptDynObjSuffix       = combine ghcOptDynObjSuffix,
     ghcOptHiDir              = combine ghcOptHiDir,
     ghcOptObjDir             = combine ghcOptObjDir,
+    ghcOptOutputDir          = combine ghcOptOutputDir,
     ghcOptStubDir            = combine ghcOptStubDir,
     ghcOptDynLinkMode        = combine ghcOptDynLinkMode,
     ghcOptShared             = combine ghcOptShared,


### PR DESCRIPTION
The flag `-outputdir` sets `-odir`, `-hidir`, `-stubdir`, and `-dumpdir`.

Using `-outputdir` has the benefit of redirecting all output files with
only one flag to a temporary directory.

Cabal currently only sets the first three but not the `-dumpdir` flag for
compiling Haskell modules, which clutters the top-level package directory
and sometimes dump files get overwritten if their names collide for
different build targets.

This minimal commit merely adds the `ghcOptOutputDir` flag to the data
structures and enables its use for the compilation of Haskell modules. A
later commit may remove the use of the now redundant `ghcOptStubDir` and
`ghcOptHiDir` flags in favor of the new `ghcOptOutputDir` flag.

The flag `-outputdir` is available since GHC 6.10; see also
ghc/ghc@bb074cb7f881ab865e9fba04ab7244a3951d3494 and
http://ghc.haskell.org/trac/ghc/ticket/2295
