### PR TITLE
Pass the correct probed xxx_HOST_OS and xxx_HOST_ARCH options to hsc2hs

### DIFF
--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -51,7 +51,7 @@ module Distribution.Simple.PreProcess (preprocessComponent, knownSuffixHandlers,
                                 ppSuffixes, PPSuffixHandler, PreProcessor(..),
                                 mkSimplePreProcessor, runSimplePreProcessor,
                                 ppCpp, ppCpp', ppGreenCard, ppC2hs, ppHsc2hs,
-                                ppHappy, ppAlex, ppUnlit
+                                ppHappy, ppAlex, ppUnlit, platformDefines
                                )
     where
 
@@ -90,7 +90,7 @@ import Distribution.Simple.Program
          , happyProgram, alexProgram, haddockProgram, ghcProgram, gccProgram )
 import Distribution.Simple.Test ( writeSimpleTestStub, stubFilePath, stubName )
 import Distribution.System
-         ( OS(OSX, Windows), buildOS )
+         ( OS(..), buildOS, Arch(..), Platform(..) )
 import Distribution.Text
 import Distribution.Version
          ( Version(..), anyVersion, orLaterVersion )
@@ -447,8 +447,7 @@ ppHsc2hs bi lbi =
           -- system's dynamic linker. This is needed because hsc2hs works by
           -- compiling a C program and then running it.
 
-       ++ [ "--cflag="   ++ opt | opt <- hcDefines (compiler lbi) ]
-       ++ [ "--cflag="   ++ opt | opt <- sysDefines ]
+       ++ [ "--cflag="   ++ opt | opt <- platformDefines lbi ]
 
           -- Options from the current package:
        ++ [ "--cflag=-I" ++ dir | dir <- PD.includeDirs  bi ]
@@ -532,43 +531,74 @@ ppC2hs bi lbi =
 --TODO: remove cc-options from cpphs for cabal-version: >= 1.10
 getCppOptions :: BuildInfo -> LocalBuildInfo -> [String]
 getCppOptions bi lbi
-    = hcDefines (compiler lbi)
-   ++ sysDefines
+    = platformDefines lbi
    ++ cppOptions bi
    ++ ["-I" ++ dir | dir <- PD.includeDirs bi]
    ++ [opt | opt@('-':c:_) <- PD.ccOptions bi, c `elem` "DIU"]
 
-sysDefines :: [String]
-sysDefines = ["-D" ++ os   ++ "_" ++ loc ++ "_OS"   | loc <- locations]
-          ++ ["-D" ++ arch ++ "_" ++ loc ++ "_ARCH" | loc <- locations]
-  where
-    locations = ["BUILD", "HOST"]
-
-hcDefines :: Compiler -> [String]
-hcDefines comp =
+platformDefines :: LocalBuildInfo -> [String]
+platformDefines lbi =
   case compilerFlavor comp of
-    GHC  -> ["-D__GLASGOW_HASKELL__=" ++ versionInt version]
+    GHC  ->
+        let ghcOS = case hostOS of
+                    Linux     -> ["linux"]
+                    Windows   -> ["mingw32"]
+                    OSX       -> ["darwin"]
+                    FreeBSD   -> ["freebsd"]
+                    OpenBSD   -> ["openbsd"]
+                    NetBSD    -> ["netbsd"]
+                    Solaris   -> ["solaris2"]
+                    AIX       -> ["aix"]
+                    HPUX      -> ["hpux"]
+                    IRIX      -> ["irix"]
+                    HaLVM     -> []
+                    IOS       -> ["ios"]
+                    OtherOS _ -> []
+            ghcArch = case hostArch of
+                      I386        -> ["i386"]
+                      X86_64      -> ["x86_64"]
+                      PPC         -> ["powerpc"]
+                      PPC64       -> ["powerpc64"]
+                      Sparc       -> ["sparc"]
+                      Arm         -> ["arm"]
+                      Mips        -> ["mips"]
+                      SH          -> []
+                      IA64        -> ["ia64"]
+                      S390        -> ["s390"]
+                      Alpha       -> ["alpha"]
+                      Hppa        -> ["hppa"]
+                      Rs6000      -> ["rs6000"]
+                      M68k        -> ["m68k"]
+                      Vax         -> ["vax"]
+                      OtherArch _ -> []
+        in ["-D__GLASGOW_HASKELL__=" ++ versionInt version] ++
+           ["-D" ++ os   ++ "_BUILD_OS=1"] ++
+           ["-D" ++ arch ++ "_BUILD_ARCH=1"] ++
+           map (\os'   -> "-D" ++ os'   ++ "_HOST_OS=1")   ghcOS ++
+           map (\arch' -> "-D" ++ arch' ++ "_HOST_ARCH=1") ghcArch
     JHC  -> ["-D__JHC__=" ++ versionInt version]
     NHC  -> ["-D__NHC__=" ++ versionInt version]
     Hugs -> ["-D__HUGS__"]
     _    -> []
-  where version = compilerVersion comp
-
--- TODO: move this into the compiler abstraction
--- FIXME: this forces GHC's crazy 4.8.2 -> 408 convention on all the other
--- compilers. Check if that's really what they want.
-versionInt :: Version -> String
-versionInt (Version { versionBranch = [] }) = "1"
-versionInt (Version { versionBranch = [n] }) = show n
-versionInt (Version { versionBranch = n1:n2:_ })
-  = -- 6.8.x -> 608
-    -- 6.10.x -> 610
-    let s1 = show n1
-        s2 = show n2
-        middle = case s2 of
-                 _ : _ : _ -> ""
-                 _         -> "0"
-    in s1 ++ middle ++ s2
+  where
+    comp = compiler lbi
+    Platform hostArch hostOS = hostPlatform lbi
+    version = compilerVersion comp
+    -- TODO: move this into the compiler abstraction
+    -- FIXME: this forces GHC's crazy 4.8.2 -> 408 convention on all
+    -- the other compilers. Check if that's really what they want.
+    versionInt :: Version -> String
+    versionInt (Version { versionBranch = [] }) = "1"
+    versionInt (Version { versionBranch = [n] }) = show n
+    versionInt (Version { versionBranch = n1:n2:_ })
+      = -- 6.8.x -> 608
+        -- 6.10.x -> 610
+        let s1 = show n1
+            s2 = show n2
+            middle = case s2 of
+                     _ : _ : _ -> ""
+                     _         -> "0"
+        in s1 ++ middle ++ s2
 
 ppHappy :: BuildInfo -> LocalBuildInfo -> PreProcessor
 ppHappy _ lbi = pp { platformIndependent = True }


### PR DESCRIPTION
These values are taken from the target platform returned by an invocation of ghc --info.
The method that Configure.hs used was correct. Now the correct function is used by both PreProcessor.hs and Configure.hs.
Previously PreProcessor.hs assumed that host == build, which meant it didn't work right for cross compiling (iOS in my case).
