### PR TITLE
Build selected test suites and benchmarks only

### DIFF
--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -611,7 +611,7 @@ testAction (testFlags, buildExFlags) extraArgs globalFlags = do
                 globalFlags noAddSource (buildNumJobs buildExFlags) checkFlags
 
   maybeWithSandboxDirOnSearchPath useSandbox $
-    build verbosity distPref mempty []
+    build verbosity distPref mempty extraArgs
 
   maybeWithSandboxDirOnSearchPath useSandbox $
     setupWrapper verbosity setupOptions Nothing
@@ -639,7 +639,7 @@ benchmarkAction (benchmarkFlags, buildExFlags) extraArgs globalFlags = do
                 checkFlags
 
   maybeWithSandboxDirOnSearchPath useSandbox $
-    build verbosity distPref mempty []
+    build verbosity distPref mempty extraArgs
 
   maybeWithSandboxDirOnSearchPath useSandbox $
     setupWrapper verbosity setupOptions Nothing


### PR DESCRIPTION
Issue #1451. Passes the extra arguments to 'cabal test' or 'cabal bench'
to the build phase so that only the requested test suites or benchmarks
are built.
