### PR TITLE
Test suite: canonicalize binary path before execution

### DIFF
--- a/Cabal/tests/PackageTests/PackageTester.hs
+++ b/Cabal/tests/PackageTests/PackageTester.hs
@@ -176,8 +176,10 @@ cabal spec cabalArgs ghcPath = do
 run :: Maybe FilePath -> String -> [String] -> IO (String, ExitCode, String)
 run cwd path args = do
     verbosity <- getVerbosity
+    -- path is relative to the current directory; canonicalizePath makes it
+    -- absolute, so that runProcess will find it even when changing directory.
     path' <- do pathExists <- doesFileExist path
-                return (if pathExists then path else path <.> exeExtension)
+                canonicalizePath (if pathExists then path else path <.> exeExtension)
     printRawCommandAndArgs verbosity path' args
     (readh, writeh) <- createPipe
     pid <- runProcess path' args cwd Nothing Nothing (Just writeh) (Just writeh)


### PR DESCRIPTION
`runProcess` behavior a non-`Nothing` cwd with relative binary path is inconsistent, hence use `canonicalizePath` to ensure correct operation, as done in 48082b90726093298df8559b365ed08805ca6d8f (see also discussion in issue).

Possible improvement: create a wrapper for `runProcess` which uses `canonicalizePath`.

Fix #1458.
