### PR TITLE
"cabal get --source-repository" fails under ghc 7.7 when a brancher is missing

### DIFF
--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -39,7 +39,7 @@ import Distribution.Client.IndexUtils as IndexUtils
         ( getSourcePackages )
 
 import Control.Exception
-         ( finally )
+         ( catch, finally )
 import Control.Monad
          ( filterM, forM_, unless, when )
 import Data.List
@@ -204,7 +204,7 @@ allBranchers =
 -- exits successfully, that brancher is considered usable.
 findUsableBranchers :: IO (Data.Map.Map PD.RepoType Brancher)
 findUsableBranchers = do
-    let usable (_, brancher) = do
+    let usable (_, brancher) = flip catch (const (return False) :: IOError -> IO Bool) $ do
          let cmd = brancherBinary brancher
          (exitCode, _, _) <- readProcessWithExitCode cmd ["--help"] ""
          return (exitCode == ExitSuccess)


### PR DESCRIPTION
The behavior of readProcessWithExitCode changed a few months ago: now it raises an exception if the command to be run doesn't exist (or couldn't be started for some other reason).  This means that if the user doesn't have bzr installed, for example, "cabal get -s" will always fail, even when it would have cloned, say, a git repository.

This commit catches such exceptions and marks the corresponding launcher as not usable.
