### PR TITLE
Eliminate a warning in Distribution.Client.Get

### DIFF
--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -51,8 +51,6 @@ import Data.Monoid
          ( mempty )
 import Data.Ord
          ( comparing )
-import System.Cmd
-         ( rawSystem )
 import System.Directory
          ( createDirectoryIfMissing, doesDirectoryExist, doesFileExist
          , getCurrentDirectory, setCurrentDirectory
@@ -62,7 +60,7 @@ import System.Exit
 import System.FilePath
          ( (</>), (<.>), addTrailingPathSeparator )
 import System.Process
-         ( readProcessWithExitCode )
+         ( rawSystem, readProcessWithExitCode )
 
 
 -- | Entry point for the 'cabal get' command.


### PR DESCRIPTION
System.Cmd has simply reexported rawSystem from System.Process
since at least process-1.0.1.1, the minimum version we allow,
and has been deprecated just as long :)
