### PR TITLE
Fix AMP warnings

### DIFF
--- a/Cabal/Distribution/Compat/ReadP.hs
+++ b/Cabal/Distribution/Compat/ReadP.hs
@@ -69,9 +69,9 @@ module Distribution.Compat.ReadP
   )
  where
 
-import Control.Monad( MonadPlus(..), liftM2, ap )
+import Control.Monad( MonadPlus(..), liftM, liftM2, ap )
 import Data.Char (isSpace)
-import Control.Applicative (Applicative(..))
+import Control.Applicative (Applicative(..), Alternative(empty, (<|>)))
 
 infixr 5 +++, <++
 
@@ -89,7 +89,7 @@ data P s a
 -- Monad, MonadPlus
 
 instance Functor (P s) where
-  fmap f x = x >>= return . f
+  fmap = liftM
 
 instance Applicative (P s) where
   pure = return
@@ -105,6 +105,10 @@ instance Monad (P s) where
   (Final r)    >>= k = final [ys' | (x,s) <- r, ys' <- run (k x) s]
 
   fail _ = Fail
+
+instance Alternative (P s) where
+      empty = mzero
+      (<|>) = mplus
 
 instance MonadPlus (P s) where
   mzero = Fail

--- a/Cabal/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/Distribution/Simple/BuildTarget.hs
@@ -55,7 +55,7 @@ import Data.Either
          ( partitionEithers )
 import qualified Data.Map as Map
 import Control.Monad
-import Control.Applicative (Applicative(..))
+import Control.Applicative (Applicative(..), Alternative(..))
 import qualified Distribution.Compat.ReadP as Parse
 import Distribution.Compat.ReadP
          ( (+++), (<++) )
@@ -744,6 +744,10 @@ data MatchError = MatchErrorExpected String String
                 | MatchErrorNoSuch   String String
   deriving (Show, Eq)
 
+
+instance Alternative Match where
+      empty = mzero
+      (<|>) = mplus
 
 instance MonadPlus Match where
   mzero = matchZero


### PR DESCRIPTION
The Applicative-Monad warning will be part of GHC 7.8. This patch from @quchen fills in the missing `Alternative` warnings (which I'd like in `Cabal-1.18.0.1`.)
