### PR TITLE
Top-level command for Freezing dependencies

### DIFF
--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -1,0 +1,172 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Client.Freeze
+-- Copyright   :  (c) David Himmelstrup 2005
+--                    Duncan Coutts 2011
+-- License     :  BSD-like
+--
+-- Maintainer  :  cabal-devel@gmail.com
+-- Stability   :  provisional
+-- Portability :  portable
+--
+-- The cabal freeze command
+-----------------------------------------------------------------------------
+module Distribution.Client.Freeze (
+    freeze,
+  ) where
+
+import Distribution.Client.Types
+import Distribution.Client.Targets
+import Distribution.Client.Dependency
+import Distribution.Client.IndexUtils as IndexUtils
+         ( getSourcePackages, getInstalledPackages )
+import Distribution.Client.InstallPlan
+         ( PlanPackage )
+import qualified Distribution.Client.InstallPlan as InstallPlan
+import Distribution.Client.Setup
+         ( GlobalFlags(..), FreezeFlags(..) )
+import Distribution.Client.Sandbox.PackageEnvironment
+         ( userPackageEnvironmentFile )
+import Distribution.Client.Sandbox.Types
+         ( SandboxPackageInfo(..) )
+
+import Distribution.Package
+         ( packageId, packageName, packageVersion )
+import Distribution.Simple.Compiler
+         ( Compiler(compilerId), PackageDBStack )
+import Distribution.Simple.PackageIndex (PackageIndex)
+import Distribution.Simple.Program
+         ( ProgramConfiguration )
+import Distribution.Simple.Setup
+         ( fromFlag )
+import Distribution.Simple.Utils
+         ( die, notice, debug, intercalate, writeFileAtomic )
+import Distribution.System
+         ( Platform )
+import Distribution.Text
+         ( display )
+import Distribution.Verbosity
+         ( Verbosity )
+
+import qualified Data.ByteString.Lazy.Char8 as BS.Char8
+import Data.Version
+         ( showVersion )
+
+-- ------------------------------------------------------------
+-- * The freeze command
+-- ------------------------------------------------------------
+
+--TODO:
+-- * Don't overwrite all of `cabal.config`, just the constaints section.
+-- * Should the package represented by `UserTargetLocalDir "."` be
+--   constrained too? What about `base`?
+
+
+-- | Freeze all of the dependencies by writing a constraints section
+-- constraining each dependency to an exact version.
+--
+freeze :: Verbosity
+      -> PackageDBStack
+      -> [Repo]
+      -> Compiler
+      -> Platform
+      -> ProgramConfiguration
+      -> Maybe SandboxPackageInfo
+      -> GlobalFlags
+      -> FreezeFlags
+      -> IO ()
+freeze verbosity packageDBs repos comp platform conf mSandboxPkgInfo
+      globalFlags freezeFlags = do
+
+    installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
+    sourcePkgDb       <- getSourcePackages    verbosity repos
+
+    pkgSpecifiers <- resolveUserTargets verbosity
+                       (fromFlag $ globalWorldFile globalFlags)
+                       (packageIndex sourcePkgDb)
+                       [UserTargetLocalDir "."]
+
+    pkgs  <- planPackages
+               verbosity comp platform mSandboxPkgInfo freezeFlags
+               installedPkgIndex sourcePkgDb pkgSpecifiers
+
+    if null pkgs
+      then notice verbosity $ "No packages to be frozen. "
+                           ++ "As this package has no dependencies."
+      else if dryRun
+             then notice verbosity $ unlines $
+                     "The following packages would be frozen:"
+                   : formatPkgs pkgs
+
+             else freezePackages pkgs
+
+  where
+    dryRun = fromFlag (freezeDryRun freezeFlags)
+
+
+planPackages :: Verbosity
+             -> Compiler
+             -> Platform
+             -> Maybe SandboxPackageInfo
+             -> FreezeFlags
+             -> PackageIndex
+             -> SourcePackageDb
+             -> [PackageSpecifier SourcePackage]
+             -> IO [PlanPackage]
+planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
+             installedPkgIndex sourcePkgDb pkgSpecifiers = do
+
+  solver <- chooseSolver verbosity
+            (fromFlag (freezeSolver freezeFlags)) (compilerId comp)
+  notice verbosity "Resolving dependencies..."
+
+  installPlan <- foldProgress logMsg die return $
+                   resolveDependencies
+                     platform (compilerId comp)
+                     solver
+                     resolverParams
+
+  return $ InstallPlan.toList installPlan
+
+  where
+    resolverParams =
+
+        setMaxBackjumps (if maxBackjumps < 0 then Nothing
+                                             else Just maxBackjumps)
+
+      . setIndependentGoals independentGoals
+
+      . setReorderGoals reorderGoals
+
+      . setShadowPkgs shadowPkgs
+
+      . maybe id applySandboxInstallPolicy mSandboxPkgInfo
+
+      $ standardInstallPolicy installedPkgIndex sourcePkgDb pkgSpecifiers
+
+    logMsg message rest = debug verbosity message >> rest
+
+    reorderGoals     = fromFlag (freezeReorderGoals     freezeFlags)
+    independentGoals = fromFlag (freezeIndependentGoals freezeFlags)
+    shadowPkgs       = fromFlag (freezeShadowPkgs       freezeFlags)
+    maxBackjumps     = fromFlag (freezeMaxBackjumps     freezeFlags)
+
+freezePackages :: [PlanPackage] -> IO ()
+freezePackages pkgs =
+    writeFileAtomic userPackageEnvironmentFile $ constraints pkgs
+  where
+    constraints = BS.Char8.pack
+                . (++ "\n")
+                . (prefix' ++)
+                . intercalate separator
+                . formatPkgs
+    prefix' = "constraints: "
+    separator = "\n" ++ (replicate (length prefix' - 2) ' ') ++ ", "
+
+
+formatPkgs :: [PlanPackage] -> [String]
+formatPkgs = map $ showPkg . packageId
+  where
+    showPkg pid = name pid ++ " == " ++ version pid
+    name = display . packageName
+    version = showVersion . packageVersion

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -23,6 +23,7 @@ module Distribution.Client.Setup
     , upgradeCommand
     , infoCommand, InfoFlags(..)
     , fetchCommand, FetchFlags(..)
+    , freezeCommand, FreezeFlags(..)
     , getCommand, unpackCommand, GetFlags(..)
     , checkCommand
     , uploadCommand, UploadFlags(..)
@@ -499,6 +500,57 @@ fetchCommand = CommandUI {
                          fetchReorderGoals     (\v flags -> flags { fetchReorderGoals     = v })
                          fetchIndependentGoals (\v flags -> flags { fetchIndependentGoals = v })
                          fetchShadowPkgs       (\v flags -> flags { fetchShadowPkgs       = v })
+
+  }
+
+-- ------------------------------------------------------------
+-- * Freeze command
+-- ------------------------------------------------------------
+
+data FreezeFlags = FreezeFlags {
+      freezeDryRun           :: Flag Bool,
+      freezeSolver           :: Flag PreSolver,
+      freezeMaxBackjumps     :: Flag Int,
+      freezeReorderGoals     :: Flag Bool,
+      freezeIndependentGoals :: Flag Bool,
+      freezeShadowPkgs       :: Flag Bool,
+      freezeVerbosity        :: Flag Verbosity
+    }
+
+defaultFreezeFlags :: FreezeFlags
+defaultFreezeFlags = FreezeFlags {
+    freezeDryRun           = toFlag False,
+    freezeSolver           = Flag defaultSolver,
+    freezeMaxBackjumps     = Flag defaultMaxBackjumps,
+    freezeReorderGoals     = Flag False,
+    freezeIndependentGoals = Flag False,
+    freezeShadowPkgs       = Flag False,
+    freezeVerbosity        = toFlag normal
+   }
+
+freezeCommand :: CommandUI FreezeFlags
+freezeCommand = CommandUI {
+    commandName         = "freeze",
+    commandSynopsis     = "Freeze dependencies.",
+    commandDescription  = Nothing,
+    commandUsage        = usagePackages "freeze",
+    commandDefaultFlags = defaultFreezeFlags,
+    commandOptions      = \ showOrParseArgs -> [
+         optionVerbosity freezeVerbosity (\v flags -> flags { freezeVerbosity = v })
+
+       , option [] ["dry-run"]
+           "Do not freeze anything, only print what would be frozen"
+           freezeDryRun (\v flags -> flags { freezeDryRun = v })
+           trueArg
+
+       ] ++
+
+       optionSolver      freezeSolver           (\v flags -> flags { freezeSolver           = v }) :
+       optionSolverFlags showOrParseArgs
+                         freezeMaxBackjumps     (\v flags -> flags { freezeMaxBackjumps     = v })
+                         freezeReorderGoals     (\v flags -> flags { freezeReorderGoals     = v })
+                         freezeIndependentGoals (\v flags -> flags { freezeIndependentGoals = v })
+                         freezeShadowPkgs       (\v flags -> flags { freezeShadowPkgs       = v })
 
   }
 

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -71,6 +71,7 @@ executable cabal
         Distribution.Client.Dependency.Modular.Version
         Distribution.Client.Fetch
         Distribution.Client.FetchUtils
+        Distribution.Client.Freeze
         Distribution.Client.Get
         Distribution.Client.GZipUtils
         Distribution.Client.Haddock


### PR DESCRIPTION
This series of patches implements a new top-level command, `freeze`, which will resolve the dependencies to exact versions and write a constraints section to `cabal.config`.

The new command takes a number of options related to resolving dependencies, namely, `--solver`, `--max-backjumps`, `--reorder-goals` and `--shadow-installed-packages`.  Previously, I had asked [whether other option are required](https://github.com/haskell/cabal/issues/1502#issuecomment-24871974).  As no-one said that they are, I've taken that to mean that they are not.

Issues that may still need addressing include:
- What should happen if this command is run outside of a sandbox.
- Whether or not `cabal.config` can be entirely overwritten.

Regarding the last point, @tibbe has stated that it should not, whilst @gregwebs is of the opinion that it is fine to do so. Before I invest any time in replacing only the `constraints` section, I'd like to have some agreement on whether or not it is required.

This branch contains a number of dead-end efforts. If you'd like them to be rebased away, let me know. I've hesitated doing that as I didn't want to force push.

See issues #1502 and #1499 for discussion of this feature.
