### PR TITLE
Fix `cabal-install/bootstrap.sh` for the new Hackage server

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -122,7 +122,7 @@ fetch_pkg () {
   URL=${HACKAGE_URL}/${PKG}/${VER}/${PKG}-${VER}.tar.gz
   if which ${CURL} > /dev/null
   then
-    ${CURL} --fail -C - -O ${URL} || die "Failed to download ${PKG}."
+    ${CURL} -L --fail -C - -O ${URL} || die "Failed to download ${PKG}."
   elif which ${WGET} > /dev/null
   then
     ${WGET} -c ${URL} || die "Failed to download ${PKG}."


### PR DESCRIPTION
The new Hackage server uses slightly different URLs for packages, and it returns 301 redirects for the old URLs. The current invocation of `curl` in `bootstrap.sh` doesn't follow redirects:

```
$ curl -v --fail -C - -O http://hackage.haskell.org/packages/archive/Cabal/1.18.0/Cabal-1.18.0.tar.gz
* About to connect() to hackage.haskell.org port 80 (#0)
*   Trying 88.198.224.242...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* connected
* Connected to hackage.haskell.org (88.198.224.242) port 80 (#0)
> GET /packages/archive/Cabal/1.18.0/Cabal-1.18.0.tar.gz HTTP/1.1
> User-Agent: curl/7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8y zlib/1.2.5
> Host: hackage.haskell.org
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.4.2
< Date: Fri, 27 Sep 2013 02:14:17 GMT
< Content-Type: text/plain; charset=UTF-8
< Transfer-Encoding: chunked
< Connection: keep-alive
< Location: /package/Cabal-1.18.0/Cabal-1.18.0.tar.gz
<
{ [data not shown]
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Connection #0 to host hackage.haskell.org left intact
* Closing connection #0
```

Adding the `-L` flag causes `curl` to follow redirects and get the packages as intended.

Note that `wget` (the second-choice downloader) follows redirects automatically. I'm not sure about `fetch`.
