### PR TITLE
make rawSystemIOWithEnv close its handles

### DIFF
--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -175,7 +175,7 @@ import System.Directory
 import System.IO
     ( Handle, openFile, openBinaryFile, openBinaryTempFile
     , IOMode(ReadMode), hSetBinaryMode
-    , hGetContents, stderr, stdout, hPutStr, hFlush, hClose )
+    , hGetContents, stdin, stderr, stdout, hPutStr, hFlush, hClose )
 import System.IO.Error as IO.Error
     ( isDoesNotExistError, isAlreadyExistsError
     , ioeSetFileName, ioeGetFileName, ioeGetErrorString )
@@ -473,9 +473,15 @@ rawSystemIOWithEnv verbosity path args mcwd menv inp out err = do
                 , Process.std_err = mbToStd err }
     unless (exitcode == ExitSuccess) $ do
       debug verbosity $ path ++ " returned " ++ show exitcode
+    mapM_ maybeClose [inp, out, err]
     return exitcode
   where
   -- Also taken from System.Process
+  maybeClose :: Maybe Handle -> IO ()
+  maybeClose (Just  hdl)
+    | hdl /= stdin && hdl /= stdout && hdl /= stderr = hClose hdl
+  maybeClose _ = return ()
+
   mbToStd :: Maybe Handle -> StdStream
   mbToStd Nothing    = Inherit
   mbToStd (Just hdl) = UseHandle hdl


### PR DESCRIPTION
Some comments claim that `rawSystemIOWithEnv` closes the handles passed to it before returning, but it doesn't, which caused some _Resource temporarily unavailable_ problems with `cabal test` on my system (i686 linux with GHC HEAD). This patch fixes that.

The patch uses the same method as `runProcess` to close the handles (instead of passing `close_fds = True` in the `CreateProcess` struct):
http://git.haskell.org/packages/process.git/blob/HEAD:/System/Process.hs#l154
