### PR TITLE
Fix documentation for sharing a sandbox

### DIFF
--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -133,9 +133,9 @@ can be easily done with the `--sandbox` option:
 $ cd /path/to/shared-sandbox
 $ cabal sandbox init
 $ cd /path/to/package-a
-$ cabal sandbox init --sandbox /path/to/shared-sandbox
+$ cabal sandbox init --sandbox /path/to/shared-sandbox/.cabal-sandbox
 $ cd /path/to/package-b
-$ cabal sandbox init --sandbox /path/to/shared-sandbox
+$ cabal sandbox init --sandbox /path/to/shared-sandbox/.cabal-sandbox
 ~~~~~~~~~~~~~~~
 
 Using multiple different compiler versions simultaneously is also supported, via


### PR DESCRIPTION
When specifying a `--sandbox` argument, you have to actually point directly to the created `.cabal-sandbox` directory.
