### PR TITLE
Don't create symlinks in global space when using a sandbox

### DIFF
--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -667,7 +667,8 @@ postInstallActions verbosity
   regenerateHaddockIndex verbosity packageDBs comp platform conf
                          configFlags installFlags installPlan
 
-  symlinkBinaries verbosity configFlags installFlags installPlan
+  unless (isUseSandbox useSandbox) $
+    symlinkBinaries verbosity configFlags installFlags installPlan
 
   printBuildFailures installPlan
 


### PR DESCRIPTION
At the moment, cabal-install symlinks binaries built in a sandbox into the global symlink-bindir. While there are probably cases where this is useful, I think in general this is probably not desired. This patch just skips symlinking if we're using a sandbox.

(This closes #1514)
