### PR TITLE
Refactoring: change the return type of 'InstallPlan.ready'.

### DIFF
--- a/cabal-install/Distribution/Client/BuildReports/Storage.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Storage.hs
@@ -117,9 +117,10 @@ fromPlanPackage :: Platform -> CompilerId
                 -> Maybe (BuildReport, Repo)
 fromPlanPackage (Platform arch os) comp planPackage = case planPackage of
 
-  InstallPlan.Installed pkg@(ConfiguredPackage (SourcePackage {
+  InstallPlan.Installed pkg@(ReadyPackage (SourcePackage {
                           packageSource = RepoTarballPackage repo _ _ }) _ _ _) result
-    -> Just $ (BuildReport.new os arch comp pkg (Right result), repo)
+    -> Just $ (BuildReport.new os arch comp
+               (readyPackageToConfiguredPackage pkg) (Right result), repo)
 
   InstallPlan.Failed pkg@(ConfiguredPackage (SourcePackage {
                        packageSource = RepoTarballPackage repo _ _ }) _ _ _) result

--- a/cabal-install/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/Distribution/Client/InstallSymlink.hs
@@ -35,7 +35,7 @@ symlinkBinary _ _ _ _ = fail "Symlinking feature not available on Windows"
 #else
 
 import Distribution.Client.Types
-         ( SourcePackage(..), ConfiguredPackage(..), enableStanzas )
+         ( SourcePackage(..), ReadyPackage(..), enableStanzas )
 import Distribution.Client.Setup
          ( InstallFlags(installSymlinkBinDir) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
@@ -127,12 +127,12 @@ symlinkBinaries configFlags installFlags plan =
       , exe <- PackageDescription.executables pkg
       , PackageDescription.buildable (PackageDescription.buildInfo exe) ]
 
-    pkgDescription :: ConfiguredPackage -> PackageDescription
-    pkgDescription (ConfiguredPackage (SourcePackage _ pkg _ _) flags stanzas _) =
+    pkgDescription :: ReadyPackage -> PackageDescription
+    pkgDescription (ReadyPackage (SourcePackage _ pkg _ _) flags stanzas _) =
       case finalizePackageDescription flags
              (const True)
              platform compilerId [] (enableStanzas stanzas pkg) of
-        Left _ -> error "finalizePackageDescription ConfiguredPackage failed"
+        Left _ -> error "finalizePackageDescription ReadyPackage failed"
         Right (desc, _) -> desc
 
     -- This is sadly rather complicated. We're kind of re-doing part of the

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -91,6 +91,27 @@ instance Package ConfiguredPackage where
 instance PackageFixedDeps ConfiguredPackage where
   depends (ConfiguredPackage _ _ _ deps) = deps
 
+-- | Like 'ConfiguredPackage', but with all dependencies guaranteed to be
+-- installed already, hence itself ready to be installed.
+data ReadyPackage = ReadyPackage
+       SourcePackage           -- see 'ConfiguredPackage'.
+       FlagAssignment          --
+       [OptionalStanza]        --
+       [InstalledPackageInfo]  -- Installed dependencies.
+  deriving Show
+
+instance Package ReadyPackage where
+  packageId (ReadyPackage pkg _ _ _) = packageId pkg
+
+instance PackageFixedDeps ReadyPackage where
+  depends (ReadyPackage _ _ _ deps) = map packageId deps
+
+-- | Sometimes we need to convert a 'ReadyPackage' back to a
+-- 'ConfiguredPackage'. For example, a failed 'PlanPackage' can be *either*
+-- Ready or Configured.
+readyPackageToConfiguredPackage :: ReadyPackage -> ConfiguredPackage
+readyPackageToConfiguredPackage (ReadyPackage srcpkg flags stanzas deps) =
+  ConfiguredPackage srcpkg flags stanzas (map packageId deps)
 
 -- | A package description along with the location of the package sources.
 --


### PR DESCRIPTION
Introduce a new type `ReadyPackage` to represent packages that have all dependencies already installed. Make `InstallPlan.ready` return `[ReadyPackage]` instead of `[(ConfiguredPackage, InstalledPackageInfo)]`.

`ReadyPackage` is probably not the best possible name; I'm open to suggestions.
