### PR TITLE
Compat version of readProcessWithExitCode

### DIFF
--- a/cabal-install/Distribution/Client/Compat/Process.hs
+++ b/cabal-install/Distribution/Client/Compat/Process.hs
@@ -1,0 +1,43 @@
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Client.Compat.Process
+-- Copyright   :  (c) 2013 Liu Hao, Brent Yorgey
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Stability   :  provisional
+-- Portability :  portable
+--
+-- Cross-platform utilities for invoking processes.
+--
+-----------------------------------------------------------------------------
+
+module Distribution.Client.Compat.Process (
+  readProcessWithExitCode
+) where
+
+import           Control.Exception (catch, throw)
+import           System.Exit       (ExitCode (ExitFailure))
+import           System.IO.Error   (isDoesNotExistError)
+import qualified System.Process    as P
+
+-- | @readProcessWithExitCode@ creates an external process, reads its
+--   standard output and standard error strictly, waits until the
+--   process terminates, and then returns the @ExitCode@ of the
+--   process, the standard output, and the standard error.
+--
+--   See the documentation of the version from @System.Process@ for
+--   more information.
+--
+--   The version from @System.Process@ behaves inconsistently across
+--   platforms when an executable with the given name is not found: in
+--   some cases it returns an @ExitFailure@, in others it throws an
+--   exception.  This variant catches \"does not exist\" exceptions and
+--   turns them into @ExitFailure@s.
+readProcessWithExitCode :: FilePath -> [String] -> String -> IO (ExitCode, String, String)
+readProcessWithExitCode cmd args input =
+  P.readProcessWithExitCode cmd args input
+    `catch` \e -> if isDoesNotExistError e
+                    then return (ExitFailure 127, "", "")
+                    else throw e

--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -37,6 +37,8 @@ import Distribution.Client.FetchUtils
 import qualified Distribution.Client.Tar as Tar (extractTarGzFile)
 import Distribution.Client.IndexUtils as IndexUtils
         ( getSourcePackages )
+import Distribution.Client.Compat.Process
+        ( readProcessWithExitCode )
 import Distribution.Compat.Exception
         ( catchIO )
 
@@ -62,7 +64,7 @@ import System.Exit
 import System.FilePath
          ( (</>), (<.>), addTrailingPathSeparator )
 import System.Process
-         ( rawSystem, readProcessWithExitCode )
+         ( rawSystem )
 
 
 -- | Entry point for the 'cabal get' command.

--- a/cabal-install/Distribution/Client/Init/Heuristics.hs
+++ b/cabal-install/Distribution/Client/Init/Heuristics.hs
@@ -46,7 +46,8 @@ import System.Directory ( getDirectoryContents,
 import Distribution.Compat.Environment ( getEnvironment )
 import System.FilePath ( takeExtension, takeBaseName, dropExtension,
                          (</>), (<.>), splitDirectories, makeRelative )
-import System.Process ( readProcessWithExitCode )
+
+import Distribution.Client.Compat.Process ( readProcessWithExitCode )
 import System.Exit ( ExitCode(..) )
 
 -- |Guess the package name based on the given root directory

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -109,6 +109,7 @@ executable cabal
         Distribution.Client.Compat.Environment
         Distribution.Client.Compat.ExecutablePath
         Distribution.Client.Compat.FilePerms
+        Distribution.Client.Compat.Process
         Distribution.Client.Compat.Semaphore
         Distribution.Client.Compat.Time
         Paths_cabal_install


### PR DESCRIPTION
- Add a new module, Distribution.Client.Compat.Process, with a
  function readProcessWithExitCode.  Unlike the one from
  System.Process it always catches "does not exist" errors and turns
  them into ExitFailures.
- Change all calls to readProcessWithExitCode to use the new version.
- Fixes #1613.
