### PR TITLE
Cabal freeze does not clobber cabal.config

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -32,6 +32,7 @@ module Distribution.Client.Sandbox (
 
     tryGetIndexFilePath,
     sandboxBuildDir,
+    getPkgEnvDir,
     getInstalledPackagesInSandbox,
 
     -- FIXME: move somewhere else


### PR DESCRIPTION
This PR has the freeze command update the `cabal.config` file without clobbering all of its content, as wanted in #1615.

There are some limitations in the final approach which has been taken: 1) any comments in the file are removed; 2) the ordering of the configuration items may be changed; and 3) an extraneous field `install-dirs` is included.  The ordering of the configuration items is stable, but in the case that a user has manually added new fields they may be changed.

I've taken a number of different approaches to get this working. I think that the final approach I've settled on is close to the correct one, but I'd appreciate it if someone could take a look and comment, and provide a suggestion on how to remove `install-dirs` from the included fields.
