### PR TITLE
do not warn about no docs for rts-1.0

### DIFF
--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -558,7 +558,7 @@ haddockPackageFlags lbi clbi htmlTemplate = do
     , pkgName (packageId ipkg) `notElem` noHaddockWhitelist
     ]
 
-  let missing = [ pkgid | Left pkgid <- interfaces ]
+  let missing = [ pkgid | Left pkgid <- interfaces, display pkgid /= "rts-1.0" ]
       warning = "The documentation for the following packages are not "
              ++ "installed. No links will be generated to these packages: "
              ++ intercalate ", " (map display missing)


### PR DESCRIPTION
Every time the haddock command is run Cabal outputs
an unhelpful warning:

Warning: The documentation for the following packages are not installed. No
links will be generated to these packages: rts-1.0

Excluding rts, which has no docs, will allow meaningful
warnings about missing docs only to be displayed.
