### PR TITLE
New license-files field.

### DIFF
--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -163,7 +163,7 @@ data PackageDescription
         -- the following are required by all packages:
         package        :: PackageIdentifier,
         license        :: License,
-        licenseFile    :: FilePath,
+        licenseFiles   :: [FilePath],
         copyright      :: String,
         maintainer     :: String,
         author         :: String,
@@ -234,7 +234,7 @@ emptyPackageDescription
                       package      = PackageIdentifier (PackageName "")
                                                        (Version [] []),
                       license      = AllRightsReserved,
-                      licenseFile  = "",
+                      licenseFiles = [],
                       specVersionRaw = Right anyVersion,
                       buildType    = Nothing,
                       copyright    = "",

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -123,9 +123,24 @@ pkgDescrFieldDescrs =
  , simpleField "license"
            disp                   parseLicenseQ
            license                (\l pkg -> pkg{license=l})
+   -- We have both 'license-file' and 'license-files' fields.
+   -- Rather than declaring license-file to be deprecated, we will continue
+   -- to allow both. The 'license-file' will continue to only allow single
+   -- tokens, while 'license-files' allows multiple. On pretty-printing, we
+   -- will use 'license-file' if there's just one, and use 'license-files'
+   -- otherwise.
  , simpleField "license-file"
            showFilePath           parseFilePathQ
-           licenseFile            (\l pkg -> pkg{licenseFile=l})
+           (\pkg -> case licenseFiles pkg of
+                      [x] -> x
+                      _   -> "")
+           (\l pkg -> pkg{licenseFiles=licenseFiles pkg ++ [l]})
+ , listField "license-files"
+           showFilePath           parseFilePathQ
+           (\pkg -> case licenseFiles pkg of
+                      [_] -> []
+                      xs  -> xs)
+           (\ls pkg -> pkg{licenseFiles=ls})
  , simpleField "copyright"
            showFreeText           parseFreeText
            copyright              (\val pkg -> pkg{copyright=val})

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -711,7 +711,8 @@ parseFreeText = ReadP.munch (const True)
 -- ** Pretty printing
 
 showFilePath :: FilePath -> Doc
-showFilePath = showToken
+showFilePath "" = empty
+showFilePath x  = showToken x
 
 showToken :: String -> Doc
 showToken str

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -137,10 +137,12 @@ install pkg_descr lbi flags = do
         installOrdinaryFile verbosity haddockInterfaceFileSrc
                                       haddockInterfaceFileDest
 
-  let lfile = licenseFile pkg_descr
-  unless (null lfile) $ do
+  let lfiles = licenseFiles pkg_descr
+  unless (null lfiles) $ do
     createDirectoryIfMissingVerbose verbosity True docPref
-    installOrdinaryFile verbosity lfile (docPref </> takeFileName lfile)
+    sequence_
+      [ installOrdinaryFile verbosity lfile (docPref </> takeFileName lfile)
+      | lfile <- lfiles ]
 
   let buildPref = buildDir lbi
   when (hasLibs pkg_descr) $

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -254,10 +254,8 @@ listPackageSourcesOrdinary verbosity pkg_descr pps =
     . forM (extraDocFiles pkg_descr) $ \ filename ->
       matchFileGlob filename
 
-    -- License file.
-  , return $ case [licenseFile pkg_descr]
-             of [[]] -> []
-                l    -> l
+    -- License file(s).
+  , return (licenseFiles pkg_descr)
 
     -- Install-include files.
   , withLib $ \ l -> do

--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -809,9 +809,12 @@ describe the package as a whole:
 :   The type of license under which this package is distributed.
     License names are the constants of the [License][dist-license] type.
 
-`license-file:` _filename_
-:   The name of a file containing the precise license for this package.
-    It will be installed with the package.
+`license-file:` _filename_ or `license-files:` _filename list_
+:   The name of a file(s) containing the precise copyright license for
+    this package. The license file(s) will be installed with the package.
+
+    If you have multiple license files then use the `license-files`
+    field instead of (or in addition to) the `license-file` field.
 
 `copyright:` _freeform_
 :   The content of a copyright notice, typically the name of the holder


### PR DESCRIPTION
Based closely on the patches by Mathieu Boespflug mboes@cs.mcgill.ca

This field is intended to be used instead of (or in addition to) the
normal 'license-file' field by packages that have multiple files for
their license material. This is useful when eg the license is
supplemented by additional permissions and/or conditions. Notably,
the LGPL is structured in this way: it amends the GPL with additional
permissions, therefore one should distribute both the GPL in COPYING
and the LGPL in COPYING.LESSER.

So we keep both the license-file and license-files fields (rather than
deprecating one) and packages can use either or a mixture.
