### PR TITLE
Remove ambiguous import of 'catch'

### DIFF
--- a/cabal-install/Distribution/Client/Compat/Process.hs
+++ b/cabal-install/Distribution/Client/Compat/Process.hs
@@ -17,7 +17,7 @@ module Distribution.Client.Compat.Process (
   readProcessWithExitCode
 ) where
 
-import           Control.Exception (catch, throw)
+import           Control.Exception (throw)
 import           System.Exit       (ExitCode (ExitFailure))
 import           System.IO.Error   (isDoesNotExistError)
 import qualified System.Process    as P


### PR DESCRIPTION
Running 'cabal install Cabal/ cabal-install/' from the latest git version resulted in:

Distribution/Client/Compat/Process.hs:41:5:
    Ambiguous occurrence `catch'
    It could refer to either`Prelude.catch',
                             imported from `Prelude' at Distribution/Client/Compat/Process.hs:16:8-41
                             (and originally defined in`System.IO.Error')
                          or `Control.Exception.catch',
                             imported from`Control.Exception' at Distribution/Client/Compat/Process.hs:20:37-41
                             (and originally defined in `Control.Exception.Base')

This pull requests fixes that.
