### PR TITLE
add Eq instance for CDialect

### DIFF
--- a/Cabal/Distribution/Simple/CCompiler.hs
+++ b/Cabal/Distribution/Simple/CCompiler.hs
@@ -59,7 +59,7 @@ data CDialect = C
               | ObjectiveC
               | CPlusPlus
               | ObjectiveCPlusPlus
-              deriving (Show)
+              deriving (Eq, Show)
 
 instance Monoid CDialect where
   mempty = C


### PR DESCRIPTION
It might be useful to add more instances as well, however I thought some semantic meaning should perhaps be attached to the Ord instance, so this is just Eq.
