### PR TITLE
Add DragonFly as a known OS to Cabal

### DIFF
--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -580,6 +580,7 @@ platformDefines lbi =
       FreeBSD   -> ["freebsd"]
       OpenBSD   -> ["openbsd"]
       NetBSD    -> ["netbsd"]
+      DragonFly -> ["dragonfly"]
       Solaris   -> ["solaris2"]
       AIX       -> ["aix"]
       HPUX      -> ["hpux"]

--- a/Cabal/Distribution/System.hs
+++ b/Cabal/Distribution/System.hs
@@ -65,6 +65,7 @@ data ClassificationStrictness = Permissive | Compat | Strict
 
 data OS = Linux | Windows | OSX        -- tier 1 desktop OSs
         | FreeBSD | OpenBSD | NetBSD   -- other free unix OSs
+        | DragonFly
         | Solaris | AIX | HPUX | IRIX  -- ageing Unix OSs
         | HaLVM                        -- bare metal / VMs / hypervisors
         | IOS                          -- iOS
@@ -78,7 +79,7 @@ data OS = Linux | Windows | OSX        -- tier 1 desktop OSs
 
 knownOSs :: [OS]
 knownOSs = [Linux, Windows, OSX
-           ,FreeBSD, OpenBSD, NetBSD
+           ,FreeBSD, OpenBSD, NetBSD, DragonFly
            ,Solaris, AIX, HPUX, IRIX
            ,HaLVM
            ,IOS]


### PR DESCRIPTION
Is there anything else to be done to make DragonFly known to Cabal (in particular hackage, since this is where the problem occurred in the first place)
