### PR TITLE
check linker, other script fixups

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # A script to bootstrap cabal-install.
 
@@ -12,21 +12,73 @@
 #EXTRA_BUILD_OPTS
 #EXTRA_INSTALL_OPTS
 
+die () { printf "\nError during cabal-install bootstrap:\n$1\n" >&2 && exit 2 ;}
+
 # programs, you can override these by setting environment vars
-CC=${CC:-gcc}
-LD=${LD:-ld}
-GHC=${GHC:-ghc}
-GHC_PKG=${GHC_PKG:-ghc-pkg}
-WGET=${WGET:-wget}
-CURL=${CURL:-curl}
-FETCH=${FETCH:-fetch}
-TAR=${TAR:-tar}
-GUNZIP=${GUNZIP:-gunzip}
+GHC="${GHC:-ghc}"
+GHC_PKG="${GHC_PKG:-ghc-pkg}"
+GHC_VER="$(${GHC} --numeric-version)"
+WGET="${WGET:-wget}"
+CURL="${CURL:-curl}"
+FETCH="${FETCH:-fetch}"
+TAR="${TAR:-tar}"
+GZIP="${GUNZIP:-gzip}"
 SCOPE_OF_INSTALLATION="--user"
 DEFAULT_PREFIX="${HOME}/.cabal"
 
+# Check for a C compiler.
+[ ! -x "$CC" ] && for ccc in gcc clang cc icc; do
+  ${CC} --version > /dev/null 2>&1 && CC=$ccc &&
+  echo "Using $CC for C compiler. If this is not what you want, set $CC." >&2 &&
+  break
+done
 
-for arg in $*
+# None found.
+[ ! -x "$CC" ] &&
+  die "C compiler not found (or could not be run).
+       If a C compiler is installed make sure it is on your PATH,
+       or set the CC variable."
+
+# Check the C compiler/linker work.
+LINK="$(for link in collect2 ld; do
+  echo 'main;' | ${CC} -v -x c - -o /dev/null -\#\#\# 2>&1 | grep -q $link &&
+  echo 'main;' | ${CC} -v -x c - -o /dev/null -\#\#\# 2>&1 | grep    $link |
+  sed -e "s|\(.*$link\).*|\1|" -e 's/ //g' -e 's|"||' && break
+done)"
+
+# They don't.
+[ -z "$LINK" ] &&
+  die "C compiler and linker could not compile a simple test program.
+       Please check your toolchain."
+
+## Warn that were's overriding $LD if set (if you want).
+
+[ -x "$LD" ] && [ "$LD" != "$LINK" ] &&
+  echo "Warning: value set in $LD is not the same as C compiler's $LINK." >&2
+  echo "Using $LINK instead." >&2
+
+# Set LD, overriding environment if necessary.
+LD=$LINK
+
+# Check we're in the right directory, etc.
+grep "cabal-install" ./cabal-install.cabal > /dev/null 2>&1 ||
+  die "The bootstrap.sh script must be run in the cabal-install directory"
+
+${GHC} --numeric-version > /dev/null 2>&1  ||
+  die "${GHC} not found (or could not be run).
+       If ghc is installed,  make sure it is on your PATH,
+       or set the GHC and GHC_PKG vars."
+
+${GHC_PKG} --version     > /dev/null 2>&1  || die "${GHC_PKG} not found."
+
+GHC_VER="$(${GHC} --numeric-version)"
+GHC_PKG_VER="$(${GHC_PKG} --version | cut -d' ' -f 5)"
+
+[ ${GHC_VER} = ${GHC_PKG_VER} ] ||
+  die "Version mismatch between ${GHC} and ${GHC_PKG}.
+       If you set the GHC variable then set GHC_PKG too."
+
+for arg in "$@"
 do
   case "${arg}" in
     "--user")
@@ -51,49 +103,37 @@ PREFIX=${PREFIX:-${DEFAULT_PREFIX}}
 
 # Versions of the packages to install.
 # The version regex says what existing installed versions are ok.
-PARSEC_VER="3.1.5";    PARSEC_VER_REGEXP="[23]\."              # == 2.* || == 3.*
-DEEPSEQ_VER="1.3.0.2"; DEEPSEQ_VER_REGEXP="1\.[1-9]\."         # >= 1.1 && < 2
-TEXT_VER="1.1.0.0";    TEXT_VER_REGEXP="((1\.[01]\.)|(0\.([2-9]|(1[0-1]))\.))" # >= 0.2 && < 1.2
-NETWORK_VER="2.4.2.2"; NETWORK_VER_REGEXP="2\."                # == 2.*
-CABAL_VER="1.19.2";    CABAL_VER_REGEXP="1\.1[9]\."            # >= 1.19 && < 1.20
-TRANS_VER="0.3.0.0";   TRANS_VER_REGEXP="0\.[23]\."            # >= 0.2.* && < 0.4.*
-MTL_VER="2.1.2";       MTL_VER_REGEXP="[2]\."                  #  == 2.*
-HTTP_VER="4000.2.10";  HTTP_VER_REGEXP="4000\.[012]\."         # == 4000.0.* || 4000.1.* || 4000.2.*
-ZLIB_VER="0.5.4.1";    ZLIB_VER_REGEXP="0\.[45]\."             # == 0.4.* || == 0.5.*
-TIME_VER="1.4.1"       TIME_VER_REGEXP="1\.[1234]\.?"          # >= 1.1 && < 1.5
-RANDOM_VER="1.0.1.1"   RANDOM_VER_REGEXP="1\.0\."              # >= 1 && < 1.1
-STM_VER="2.4.2";       STM_VER_REGEXP="2\."                    # == 2.*
+PARSEC_VER="3.1.5";    PARSEC_VER_REGEXP="[23]\."
+                       # == 2.* || == 3.*
+DEEPSEQ_VER="1.3.0.2"; DEEPSEQ_VER_REGEXP="1\.[1-9]\."
+                       # >= 1.1 && < 2
+TEXT_VER="1.1.0.0";    TEXT_VER_REGEXP="((1\.[01]\.)|(0\.([2-9]|(1[0-1]))\.))"
+                       # >= 0.2 && < 1.2
+NETWORK_VER="2.4.2.2"; NETWORK_VER_REGEXP="2\."
+                       # == 2.*
+# CABAL_VER="1.19.2";    CABAL_VER_REGEXP="1\.1[9]\."
+                       # >= 1.19 && < 1.20
+TRANS_VER="0.3.0.0";   TRANS_VER_REGEXP="0\.[23]\."
+                       # >= 0.2.* && < 0.4.*
+MTL_VER="2.1.2";       MTL_VER_REGEXP="[2]\."
+                       #  == 2.*
+HTTP_VER="4000.2.10";  HTTP_VER_REGEXP="4000\.[012]\."
+                       # == 4000.0.* || 4000.1.* || 4000.2.*
+ZLIB_VER="0.5.4.1";    ZLIB_VER_REGEXP="0\.[45]\."
+                       # == 0.4.* || == 0.5.*
+TIME_VER="1.4.1"       TIME_VER_REGEXP="1\.[1234]\.?"
+                       # >= 1.1 && < 1.5
+RANDOM_VER="1.0.1.1"   RANDOM_VER_REGEXP="1\.0\."
+                       # >= 1 && < 1.1
+STM_VER="2.4.2";       STM_VER_REGEXP="2\."
+                       # == 2.*
 
 HACKAGE_URL="http://hackage.haskell.org/package"
 
-die () {
-  echo
-  echo "Error during cabal-install bootstrap:"
-  echo $1 >&2
-  exit 2
-}
-
-# Check we're in the right directory:
-grep "cabal-install" ./cabal-install.cabal > /dev/null 2>&1 \
-  || die "The bootstrap.sh script must be run in the cabal-install directory"
-
-${CC} --version > /dev/null \
-  || die "${CC} not found (or could not be run).  If this C compiler is installed make sure it is on your PATH or set the CC variable."
-${LD} --version > /dev/null \
-  || die "${LD} not found (or could not be run).  If this linker is installed make sure it is on your PATH or set the LD variable."
-${GHC} --numeric-version > /dev/null \
-  || die "${GHC} not found (or could not be run). If ghc is installed make sure it is on your PATH or set the GHC and GHC_PKG vars."
-${GHC_PKG} --version     > /dev/null \
-  || die "${GHC_PKG} not found."
-GHC_VER=`${GHC} --numeric-version`
-GHC_PKG_VER=`${GHC_PKG} --version | cut -d' ' -f 5`
-[ ${GHC_VER} = ${GHC_PKG_VER} ] \
-  || die "Version mismatch between ${GHC} and ${GHC_PKG} If you set the GHC variable then set GHC_PKG too"
-
 # Cache the list of packages:
 echo "Checking installed packages for ghc-${GHC_VER}..."
-${GHC_PKG} list --global ${SCOPE_OF_INSTALLATION} > ghc-pkg.list \
-  || die "running '${GHC_PKG} list' failed"
+${GHC_PKG} list --global ${SCOPE_OF_INSTALLATION} > ghc-pkg.list ||
+  die "running '${GHC_PKG} list' failed"
 
 # Will we need to install this package, or is a suitable version installed?
 need_pkg () {
@@ -138,21 +178,17 @@ fetch_pkg () {
   else
     die "Failed to find a downloader. 'curl', 'wget' or 'fetch' is required."
   fi
-  [ -f "${PKG}-${VER}.tar.gz" ] \
-    || die "Downloading ${URL} did not create ${PKG}-${VER}.tar.gz"
+  [ -f "${PKG}-${VER}.tar.gz" ] ||
+     die "Downloading ${URL} did not create ${PKG}-${VER}.tar.gz"
 }
 
 unpack_pkg () {
   PKG=$1
   VER=$2
 
-  rm -rf "${PKG}-${VER}.tar" "${PKG}-${VER}"/
-  ${GUNZIP} -f "${PKG}-${VER}.tar.gz" \
-    || die "Failed to gunzip ${PKG}-${VER}.tar.gz"
-  ${TAR} -xf "${PKG}-${VER}.tar" \
-    || die "Failed to untar ${PKG}-${VER}.tar.gz"
-  [ -d "${PKG}-${VER}" ] \
-    || die "Unpacking ${PKG}-${VER}.tar.gz did not create ${PKG}-${VER}/"
+  rm -rf "${PKG}-${VER}.tar" "${PKG}-${VER}"
+  gzip -d < "${PKG}-${VER}.tar.gz" | ${TAR} -x -
+  [ -d "${PKG}-${VER}" ] || die "Failed to unpack ${PKG}-${VER}.tar.gz"
 }
 
 install_pkg () {
@@ -161,20 +197,22 @@ install_pkg () {
   [ -x Setup ] && ./Setup clean
   [ -f Setup ] && rm Setup
 
-  ${GHC} --make Setup -o Setup \
-    || die "Compiling the Setup script failed"
+  ${GHC} --make Setup -o Setup ||
+    die "Compiling the Setup script failed."
+
   [ -x Setup ] || die "The Setup script does not exist or cannot be run"
 
-  ./Setup configure ${SCOPE_OF_INSTALLATION} "--prefix=${PREFIX}" \
-    --with-compiler=${GHC} --with-hc-pkg=${GHC_PKG} --with-gcc=${CC} --with-ld=${LD} \
-    ${EXTRA_CONFIGURE_OPTS} ${VERBOSE} \
-    || die "Configuring the ${PKG} package failed"
+  args="${SCOPE_OF_INSTALLATION} --prefix=${PREFIX} --with-compiler=${GHC}"
+  args="$args --with-hc-pkg=${GHC_PKG} --with-gcc=${CC} --with-ld=${LD}"
+  args="$args ${EXTRA_CONFIGURE_OPTS} ${VERBOSE}"
 
-  ./Setup build ${EXTRA_BUILD_OPTS} ${VERBOSE} \
-    || die "Building the ${PKG} package failed"
+  ./Setup configure $args || die "Configuring the ${PKG} package failed."
 
-  ./Setup install ${SCOPE_OF_INSTALLATION} ${EXTRA_INSTALL_OPTS} ${VERBOSE} \
-    || die "Installing the ${PKG} package failed"
+  ./Setup build ${EXTRA_BUILD_OPTS} ${VERBOSE} ||
+     die "Building the ${PKG} package failed."
+
+  ./Setup install ${SCOPE_OF_INSTALLATION} ${EXTRA_INSTALL_OPTS} ${VERBOSE} ||
+     die "Installing the ${PKG} package failed."
 }
 
 do_pkg () {


### PR DESCRIPTION
As requested in #1672. Since I'm at it, a few other minor fixups:
- add clang, cc fallbacks if $CC is unset and gcc is not found
- replace backticks with POSIX-style (nestable) `$()` expansions
- remove unnecessary escaped newlines over logical operator `||`.
- use `/usr/bin/env sh` shebang so a better sh in path will override  `/bin/sh`
- fix to wrap columns 80
