### PR TITLE
bootstrap.sh now also builds documentation of installed packages

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -18,6 +18,7 @@ die () { printf "\nError during cabal-install bootstrap:\n$1\n" >&2 && exit 2 ;}
 GHC="${GHC:-ghc}"
 GHC_PKG="${GHC_PKG:-ghc-pkg}"
 GHC_VER="$(${GHC} --numeric-version)"
+HADDOCK=${HADDOCK:-haddock}
 WGET="${WGET:-wget}"
 CURL="${CURL:-curl}"
 FETCH="${FETCH:-fetch}"
@@ -213,6 +214,9 @@ install_pkg () {
 
   ./Setup build ${EXTRA_BUILD_OPTS} ${VERBOSE} ||
      die "Building the ${PKG} package failed."
+
+  ./Setup haddock --with-ghc=${GHC} --with-haddock=${HADDOCK} ${VERBOSE} ||
+     die "Documenting the ${PKG} package failed."
 
   ./Setup install ${SCOPE_OF_INSTALLATION} ${EXTRA_INSTALL_OPTS} ${VERBOSE} ||
      die "Installing the ${PKG} package failed."


### PR DESCRIPTION
Regularly, when I install a new version of GHC and cabal-install, I modify the bootstrap.sh file to also build the documentation of installled packages.

I do this because otherwise `ghc-pkg check` reports missing documentation for the respective packages, and I like `ghc-pkg check` to output no issues to be sure of a clean, working installation.

You may ignore this pull request if you wish, as this is not an killer feature, but I wanted to share my idea, at last.
