### PR TITLE
Disable strip-unneeded on iOS too

### DIFF
--- a/Cabal/Distribution/Simple/Program/Strip.hs
+++ b/Cabal/Distribution/Simple/Program/Strip.hs
@@ -44,8 +44,9 @@ stripExe verbosity (Platform _arch os) conf path =
 stripLib :: Verbosity -> Platform -> ProgramConfiguration -> FilePath -> IO ()
 stripLib verbosity (Platform _arch os) conf path = do
   case os of
-    OSX -> -- '--strip-unneeded' is not supported on OS X. See #1630.
+    OSX -> -- '--strip-unneeded' is not supported on OS X or iOS. See #1630.
            return ()
+    IOS -> return ()
     _   -> runStrip verbosity conf path args
   where
     args = ["--strip-unneeded"]


### PR DESCRIPTION
Extends the disabling of --strip-unneeded to iOS compilation too.
