### PR TITLE
Pass cpp-options to UHC.

### DIFF
--- a/Cabal/Distribution/Simple/UHC.hs
+++ b/Cabal/Distribution/Simple/UHC.hs
@@ -247,6 +247,8 @@ constructUHCCmdLine user system lbi bi clbi odir verbosity =
   ++ ["-i" ++ odir]
   ++ ["-i" ++ l | l <- nub (hsSourceDirs bi)]
   ++ ["-i" ++ autogenModulesDir lbi]
+     -- cpp options
+  ++ ["--optP=" ++ opt | opt <- cppOptions bi]
      -- output path
   ++ ["--odir=" ++ odir]
      -- optimization


### PR DESCRIPTION
This patch passes any cpp-options stanzas in the .cabal file on to UHC (before, they were ignored).
