### PR TITLE
Add a warning for sections that are not on the top level.

### DIFF
--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -1029,8 +1029,14 @@ parsePackageDescription file = do
 
         let simplFlds = [ F l n v | F l n v <- allflds ]
             condFlds = [ f | f@IfBlock{} <- allflds ]
+            sections = [ s | s@Section{} <- allflds ]
 
         let (depFlds, dataFlds) = partition isConstraint simplFlds
+        
+        mapM_
+            (\(Section l n _ _) -> lift . warning $
+                "Unexpected section '" ++ n ++ "' on line " ++ show l)
+            sections
 
         a <- parser dataFlds
         deps <- liftM concat . mapM (lift . parseConstraint) $ depFlds


### PR DESCRIPTION
Fixes #712.

Since sections can only be at the top level of the .cabal file, we should warn the user if we find something that looks like a section anywhere else. Caveat: This might not be the best place to handle this. We could also handle this in the mkField or ifelse functions in the ParseUtils module, but that would require a more substantial/invasive change.
