### PR TITLE
Frozen dependencies are printed on their own lines

### DIFF
--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -33,7 +33,7 @@ module Distribution.ParseUtils (
         parseSepList, parseCommaList, parseOptCommaList,
         showFilePath, showToken, showTestedWith, showFreeText, parseFreeText,
         field, simpleField, listField, spaceListField, commaListField,
-        optsField, liftField, boolField, parseQuoted,
+        commaNewLineListField, optsField, liftField, boolField, parseQuoted,
 
         UnrecFieldParser, warnUnrec, ignoreUnrec,
   ) where
@@ -188,13 +188,21 @@ simpleField :: String -> (a -> Doc) -> ReadP a a
 simpleField name showF readF get set
   = liftField get set $ field name showF readF
 
-commaListField :: String -> (a -> Doc) -> ReadP [a] a
+commaListField' :: ([Doc] -> Doc) -> String -> (a -> Doc) -> ReadP [a] a
                  -> (b -> [a]) -> ([a] -> b -> b) -> FieldDescr b
-commaListField name showF readF get set =
+commaListField' separator name showF readF get set =
   liftField get set' $
-    field name (fsep . punctuate comma . map showF) (parseCommaList readF)
+    field name (separator . punctuate comma . map showF) (parseCommaList readF)
   where
     set' xs b = set (get b ++ xs) b
+
+commaListField :: String -> (a -> Doc) -> ReadP [a] a
+                 -> (b -> [a]) -> ([a] -> b -> b) -> FieldDescr b
+commaListField = commaListField' fsep
+
+commaNewLineListField :: String -> (a -> Doc) -> ReadP [a] a
+                 -> (b -> [a]) -> ([a] -> b -> b) -> FieldDescr b
+commaNewLineListField = commaListField' sep
 
 spaceListField :: String -> (a -> Doc) -> ReadP [a] a
                  -> (b -> [a]) -> ([a] -> b -> b) -> FieldDescr b

--- a/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
+++ b/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
@@ -46,7 +46,7 @@ import Distribution.Simple.Setup       ( Flag(..), ConfigFlags(..)
                                        , fromFlagOrDefault, toFlag, flagToMaybe )
 import Distribution.Simple.Utils       ( die, info, notice, warn, lowercase )
 import Distribution.ParseUtils         ( FieldDescr(..), ParseResult(..)
-                                       , commaListField
+                                       , commaListField, commaNewLineListField
                                        , liftField, lineNo, locatedErrorMsg
                                        , parseFilePathQ, readFields
                                        , showPWarning, simpleField
@@ -390,7 +390,7 @@ pkgEnvFieldDescrs = [
     pkgEnvInherit (\v pkgEnv -> pkgEnv { pkgEnvInherit = v })
 
     -- FIXME: Should we make these fields part of ~/.cabal/config ?
-  , commaListField "constraints"
+  , commaNewLineListField "constraints"
     Text.disp Text.parse
     (configExConstraints . savedConfigureExFlags . pkgEnvSavedConfig)
     (\v pkgEnv -> updateConfigureExFlags pkgEnv


### PR DESCRIPTION
A new pretty-print has been introduced `D.ParseUtils.commaNewLineListField`.  It is similar to `D.ParseUtils.commaListField` but has each item on its own line.

The constraints section of the package environment is pretty printed with `commaNewLineListField`, but no other fields have been changed.

The constraints field was already sorted albeit case sensitvely. I have left that untouched. When I freeze the dependencies for cabal-install the cabal.config file is:

```
constraints: Cabal ==1.19.2,
             HTTP ==4000.2.11,
             array ==0.4.0.1,
             base ==4.6.0.1,
             bytestring ==0.10.0.2,
             cabal-install ==1.19.2,
             containers ==0.5.0.0,
             deepseq ==1.3.0.1,
             directory ==1.2.0.1,
             filepath ==1.3.0.1,
             ghc-prim ==0.3.0.0,
             integer-gmp ==0.5.0.0,
             mtl ==2.1.2,
             network ==2.4.2.2,
             old-locale ==1.0.0.5,
             old-time ==1.1.0.1,
             parsec ==3.1.5,
             pretty ==1.1.1.0,
             process ==1.1.0.2,
             random ==1.0.1.1,
             rts ==1.0,
             stm ==2.4.2,
             text ==1.1.0.1,
             time ==1.4.0.1,
             transformers ==0.3.0.0,
             unix ==2.6.0.1,
             zlib ==0.5.4.1

install-dirs 
```
