### PR TITLE
Don't freeze non-required installed packages

### DIFF
--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -163,7 +163,7 @@ planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
 
 -- | Remove all unneeded packages from an install plan.
 --
--- A package is uneeded if it is not a dependency (directly or
+-- A package is unneeded if it is not a dependency (directly or
 -- transitively) of any of the 'PackageSpecifier SourcePackage's.  This is
 -- useful for removing previously installed packages which are no longer
 -- required from the install plan.


### PR DESCRIPTION
An InstallPlan contains installed packages in the package database which are not required to satisfy the dependencies of the user targets. To prevent including them in the frozen set of constraints, `Freeze.planPackages` uses `D.C.PackageIndex.dependencyClosure` to try and take the transitive closure of the package dependencies.

Whilst it is possible for `pruneInstallPlan` to fail, only valid `InstallPlan`s are passed to it. If a failure does occur, we error.OThe
