### PR TITLE
Add `integer-{gmp,simple}` and `template-haskell` to list of non-upgradables

### DIFF
--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -228,7 +228,8 @@ dontUpgradeBasePackage params =
     extraConstraints =
       [ PackageConstraintInstalled pkgname
       | all (/=PackageName "base") (depResolverTargets params)
-      , pkgname <-  [ PackageName "base", PackageName "ghc-prim" ]
+      , pkgname <- map PackageName [ "base", "ghc-prim", "integer-gmp"
+                                   , "integer-simple", "template-haskell" ]
       , isInstalled pkgname ]
     -- TODO: the top down resolver chokes on the base constraints
     -- below when there are no targets and thus no dep on base.

--- a/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
@@ -49,6 +49,10 @@ solve sc idx userPrefs userConstraints userGoals =
                        validateTree idx
     prunePhase       = (if avoidReinstalls sc then P.avoidReinstalls (const True) else id) .
                        -- packages that can never be "upgraded":
-                       P.requireInstalled (`elem` [PackageName "base",
-                                                   PackageName "ghc-prim"])
+                       P.requireInstalled (`elem` [ PackageName "base"
+                                                  , PackageName "ghc-prim"
+                                                  , PackageName "integer-gmp"
+                                                  , PackageName "integer-simple"
+                                                  , PackageName "template-haskell"
+                                                  ])
     buildPhase       = buildTree idx (independentGoals sc) userGoals


### PR DESCRIPTION
This is related to #667 and similiar issues
