### PR TITLE
Add support for 'main-is' to 'cabal init'

### DIFF
--- a/cabal-install/Distribution/Client/Init/Types.hs
+++ b/cabal-install/Distribution/Client/Init/Types.hs
@@ -54,7 +54,7 @@ data InitFlags =
               , extraSrc     :: Maybe [String]
 
               , packageType  :: Flag PackageType
-              , mainIs       :: Maybe FilePath
+              , mainIs       :: Flag FilePath
               , language     :: Flag Language
 
               , exposedModules :: Maybe [ModuleName]
@@ -127,7 +127,7 @@ instance Monoid InitFlags where
     , category       = combine category
     , extraSrc       = combine extraSrc
     , packageType    = combine packageType
-    , mainIs         = getLast $ combine (Last . mainIs)
+    , mainIs         = combine mainIs
     , language       = combine language
     , exposedModules = combine exposedModules
     , otherModules   = combine otherModules

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1404,7 +1404,7 @@ initCommand = CommandUI {
         "Specify the main module."
         IT.mainIs
         (\v flags -> flags { IT.mainIs = v })
-        (reqArg' "FILE" Just maybeToList)
+        (reqArgFlag "FILE")
 
       , option [] ["language"]
         "Specify the default language."


### PR DESCRIPTION
An updated version of #1550 with review comments by @byorgey addressed.

Does not use `scanForModules` etc. (maybe later...).
