### PR TITLE
Fix broken links to bootstrap.sh

### DIFF
--- a/cabal-install/README.md
+++ b/cabal-install/README.md
@@ -1,15 +1,16 @@
 The cabal-install package
 =========================
 
-See the [Cabal web site](http://www.haskell.org/cabal/) for more
-information.
+See the [Cabal web site] for more information.
 
 The `cabal-install` package provides a command line tool named `cabal`.
-It uses the `Cabal` library and provides a user interface to the
+It uses the [Cabal] library and provides a user interface to the
 Cabal/[Hackage] build automation and package management system. It can
 build and install both local and remote packages, including
 dependencies.
 
+[Cabal web site]: http://www.haskell.org/cabal/
+[Cabal]: ../Cabal/README.md
 
 Installing the `cabal` command-line tool
 ========================================
@@ -22,7 +23,7 @@ for example, on Debian or Ubuntu, it is located in the
 
 `cabal` requires a few other Haskell packages that are not always
 installed. The exact list is specified in the [.cabal] file or in the
-[bootsrap.sh] file. All these packages are available from [Hackage].
+[bootstrap.sh] file. All these packages are available from [Hackage].
 
 Note that on some Unix systems you may need to install an additional
 zlib development package using your system package manager; for example,
@@ -31,23 +32,23 @@ Fedora, it is located in the "zlib-devel" package. It is required
 because the Haskell zlib package uses the system zlib C library and
 header files.
 
-The `cabal-install` package is now part of the Haskell Platform, so you
+The `cabal-install` package is now part of the [Haskell Platform], so you
 do not usually need to install it separately. However, if you are
-starting from a minimal GHC installation then you need to install
-`cabal-install` manually. Since it is an ordinary Cabal package, it can
-be built in the standard way; to facilitate this, the process is
-partially automated. It is described below.
+starting from a minimal GHC installation, you need to install
+`cabal-install` manually. Since it is an ordinary Cabal package,
+`cabal-install` can be built the standard way; to facilitate this, the
+process has been partially automated. It is described below.
 
 [.cabal]: cabal-install.cabal
-[bootstrap.sh]: bootstrap.sh
 [network]: http://hackage.haskell.org/package/network
+[Haskell Platform]: http://www.haskell.org/platform/
 
 Quick start on Unix-like systems
 --------------------------------
 
 As a convenience for users on Unix-like systems, there is a
-[./bootstrap.sh] script that will download and install each of the
-dependencies in turn.
+[bootstrap.sh] script that will download and install each of
+`cabal-install`'s dependencies in turn.
 
     $ ./bootstrap.sh
 
@@ -55,17 +56,14 @@ It will download and install the dependencies. The script will install
 the library packages into `$HOME/.cabal/` and the `cabal` program into
 `$HOME/.cabal/bin/`.
 
-You then have the choice either to
-
-  * place `$HOME/.cabal/bin` on your `$PATH` or
-  * move the `cabal` program somewhere that is on your `$PATH`.
-
-Next, you can get the latest list of packages by running:
+You then have the choice either to place `$HOME/.cabal/bin` on your
+`$PATH` or move the `cabal` program to somewhere on your `$PATH`. Next,
+you can get the latest list of packages by running:
 
     $ cabal update
 
-This will also create a default configuration file (if it does not
-already exist) at `$HOME/.cabal/config`
+This will also create a default configuration file, if it does not
+already exist, at `$HOME/.cabal/config`.
 
 By default, `cabal` will install programs to `$HOME/.cabal/bin`. If you
 do not want to add this directory to your `$PATH`, you can change
@@ -78,10 +76,9 @@ following:
 Quick start on Windows systems
 ------------------------------
 
-For Windows users, a precompiled program, [cabal.exe], is provided.
-Download and put it somewhere on your `%PATH%`, for example:
-
-    C:\Program Files\Haskell\bin
+For Windows users, a precompiled program ([cabal.exe]) is provided.
+Download and put it somewhere on your `%PATH%` (for example,
+`C:\Program Files\Haskell\bin`.)
 
 Next, you can get the latest list of packages by running:
 
@@ -89,19 +86,18 @@ Next, you can get the latest list of packages by running:
 
 This will also create a default configuration file (if it does not
 already exist) at
-`C:\Documents and Settings\username\Application Data\cabal\config`.
+`C:\Documents and Settings\%USERNAME%\Application Data\cabal\config`.
 
-[cabal.exe]: http://haskell.org/cabal/release/cabal-install-latest/cabal.exe
+[cabal.exe]: http://www.haskell.org/cabal/release/cabal-install-latest/cabal.exe
 
-
-Using cabal-install
-===================
+Using `cabal`
+=============
 
 There are two sets of commands: commands for working with a local
-project build tree and ones for working with packages distributed
+project build tree and those for working with packages distributed
 from [Hackage].
 
-For a list of the full set of commands and the flags for each command,
+For the list of the full set of commands and flags for each command,
 run:
 
     $ cabal help
@@ -110,9 +106,9 @@ run:
 Commands for developers for local build trees
 ---------------------------------------------
 
-The commands for local project build trees are almost exactly the same
-as the `runghc Setup` command-line interface that you may already be
-familiar with. In particular, there are the following commands:
+The commands for local project build trees are almost the same as the
+`runghc Setup` command-line interface you may already be familiar with.
+In particular, it has the following commands:
 
   * `cabal configure`
   * `cabal build`
@@ -121,12 +117,9 @@ familiar with. In particular, there are the following commands:
   * `cabal sdist`
 
 The `install` command is somewhat different; it is an all-in-one
-operation. If you run
-
-    $ cabal install
-
-in your build tree, it will configure, build, and install. It takes all
-the flags that `configure` takes such as `--global` and `--prefix`.
+operation. If you run `cabal install` in your build tree, it will
+configure, build, and install. It takes all the flags that `configure`
+takes such as `--global` and `--prefix`.
 
 In addition, `cabal` will download and install any dependencies that are
 not already installed. It can also rebuild packages to ensure a
@@ -139,17 +132,15 @@ Commands for released Hackage packages
     $ cabal update
 
 This command gets the latest list of packages from the [Hackage] server.
-On occasion, this command must be run manually, for instance, if you
+On occasion, this command must be run manually--for instance, if you
 want to install a newly released package.
 
     $ cabal install xmonad
 
-This is the eponymous command. It installs one or more named packages,
-and all their dependencies, from Hackage.
-
-By default, it installs the latest available version; however, you may
-specify exact versions or version ranges. For example,
-`cabal install alex-2.2` or `cabal install parsec < 3`.
+This command installs one or more named packages, and all their
+dependencies, from Hackage. By default, it installs the latest available
+version; however, you may specify exact versions or version ranges. For
+example, `cabal install alex-2.2` or `cabal install parsec < 3`.
 
     $ cabal list xml
 
@@ -158,3 +149,4 @@ case-insensitive substring match on the package name.
 
 
 [Hackage]: http://hackage.haskell.org
+[bootstrap.sh]: bootstrap.sh


### PR DESCRIPTION
Additionally, add links to Haskell Platform and Cabal library README. Excise some verbiage.

EDIT: GitHub's markdown editor uses really imaginative names for branches. ;)
