### PR TITLE
pass --no-check-certificate to wget

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -189,7 +189,7 @@ fetch_pkg () {
     ${CURL} -L --fail -O ${URL} || die "Failed to download ${PKG}."
   elif which ${WGET} > /dev/null
   then
-    ${WGET} -c ${URL} || die "Failed to download ${PKG}."
+    ${WGET} --no-check-certificate -c ${URL} || die "Failed to download ${PKG}."
   elif which ${FETCH} > /dev/null
     then
       ${FETCH} ${URL} || die "Failed to download ${PKG}."


### PR DESCRIPTION
https://github.com/haskell/cabal/issues/1796

(The current https://hackage.haskell.org/ SSL certificate does not have
identity validation, so `--no-check-certificate` must be passed to `wget`
in order for it to fetch without error.)
