### PR TITLE
Platform dependent search path separator

### DIFF
--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -145,7 +145,7 @@ import qualified Paths_cabal_install (version)
 
 import System.Environment       (getArgs, getProgName)
 import System.Exit              (exitFailure)
-import System.FilePath          (splitExtension, takeExtension)
+import System.FilePath          (splitExtension, takeExtension, searchPathSeparator)
 import System.IO                ( BufferMode(LineBuffering), hSetBuffering
 #ifdef mingw32_HOST_OS
                                 , stderr
@@ -1061,7 +1061,8 @@ execAction execFlags extraArgs globalFlags = do
                 exitFailure
             Just ghcProg ->  do
                 g <- ghcGlobalPackageDB verbosity ghcProg
-                getEffectiveEnvironment [("GHC_PACKAGE_PATH", Just $ s ++ ":" ++ g)]
+                getEffectiveEnvironment
+                  [("GHC_PACKAGE_PATH", Just $ s ++ [searchPathSeparator] ++ g)]
 
 -- | See 'Distribution.Client.Install.withWin32SelfUpgrade' for details.
 --


### PR DESCRIPTION
When using cabal exec on Windows, it would give an error such as:

ghc.exe: can't find a package database at
C:\Users\tchakkazulu\path\to\dir.cabal-sandbox\i386-windows-ghc-7.6.3-packages.conf.d:C:\Program
Files (x86)\Haskell Platform\2013.2.0.0\lib\package.conf.d
