### PR TITLE
Fix #1788, printing of fields with default values

### DIFF
--- a/Cabal/Distribution/PackageDescription/PrettyPrint.hs
+++ b/Cabal/Distribution/PackageDescription/PrettyPrint.hs
@@ -74,6 +74,8 @@ ppSourceRepo repo                        =
   where
     sourceRepoFieldDescrs' = [fd | fd <- sourceRepoFieldDescrs, fieldName fd /= "kind"]
 
+-- TODO: this is a temporary hack. Ideally, fields containing default values
+-- would be filtered out when the @FieldDescr a@ list is generated.
 ppFieldsFiltered :: [(String, String)] -> [FieldDescr a] -> a -> Doc
 ppFieldsFiltered removable fields x = ppFields (filter nondefault fields) x
   where


### PR DESCRIPTION
- Remove dead pretty-printing code that was duplicated.
- Remove redundant space after `description:` field name.
- Eliminate trailing spaces on _some_ blank lines.
- Convert all field names to lower case.
- Eliminate redundant `buildable: True` and `exposed: True` fields.
- Fix Haddock module comment.
