### PR TITLE
Fix #1816 - give more descriptive errors when .cabal file cannot be found

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -64,7 +64,8 @@ import Distribution.Client.Sandbox.Types      ( SandboxPackageInfo(..)
                                               , UseSandbox(..) )
 import Distribution.Client.Types              ( PackageLocation(..)
                                               , SourcePackage(..) )
-import Distribution.Client.Utils              ( inDir, tryCanonicalizePath )
+import Distribution.Client.Utils              ( inDir, tryCanonicalizePath
+                                              , tryFindAddSourcePackageDesc )
 import Distribution.PackageDescription.Configuration
                                               ( flattenPackageDescription )
 import Distribution.PackageDescription.Parse  ( readPackageDescription )
@@ -80,7 +81,6 @@ import Distribution.Simple.Setup              ( Flag(..), HaddockFlags(..)
 import Distribution.Simple.SrcDist            ( prepareTree )
 import Distribution.Simple.Utils              ( die, debug, notice, info, warn
                                               , debugNoWrap, defaultPackageDesc
-                                              , tryFindPackageDesc
                                               , intercalate, topHandlerWith
                                               , createDirectoryIfMissingVerbose )
 import Distribution.Package                   ( Package(..) )
@@ -618,9 +618,9 @@ withSandboxPackageInfo verbosity configFlags globalFlags
   -- List all packages installed in the sandbox.
   installedPkgIndex <- getInstalledPackagesInSandbox verbosity
                        configFlags comp conf
-
+  let err = "Error reading sandbox package information."
   -- Get the package descriptions for all add-source deps.
-  depsCabalFiles <- mapM tryFindPackageDesc buildTreeRefs
+  depsCabalFiles <- mapM (flip tryFindAddSourcePackageDesc err) buildTreeRefs
   depsPkgDescs   <- mapM (readPackageDescription verbosity) depsCabalFiles
   let depsMap           = M.fromList (zip buildTreeRefs depsPkgDescs)
       isInstalled pkgid = not . null

--- a/cabal-install/Distribution/Client/Sandbox/Index.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Index.hs
@@ -29,9 +29,10 @@ import Distribution.Client.Types ( Repo(..), LocalRepo(..)
                                  , SourcePackage(..), PackageLocation(..) )
 import Distribution.Client.Utils ( byteStringToFilePath, filePathToByteString
                                  , makeAbsoluteToCwd, tryCanonicalizePath
-                                 , canonicalizePathNoThrow )
+                                 , canonicalizePathNoThrow
+                                 , tryFindAddSourcePackageDesc  )
 
-import Distribution.Simple.Utils ( die, debug, tryFindPackageDesc )
+import Distribution.Simple.Utils ( die, debug )
 import Distribution.Verbosity    ( Verbosity )
 
 import qualified Data.ByteString.Lazy as BS
@@ -61,7 +62,7 @@ buildTreeRefFromPath refType dir = do
   dirExists <- doesDirectoryExist dir
   unless dirExists $
     die $ "directory '" ++ dir ++ "' does not exist"
-  _ <- tryFindPackageDesc dir
+  _ <- tryFindAddSourcePackageDesc dir "Error adding source reference."
   return . Just $ BuildTreeRef refType dir
 
 -- | Given a tar archive entry, try to parse it as a local build tree reference.


### PR DESCRIPTION
This will give better errors when a .cabal file cannot be found when:
- Adding a source dep,
- Building existing source deps,
- Creating package index,
- Installing user specified local pkgs.

The first patch is a simple tidy-up: removing some inline, repeated strings, and manual layout formatting.
