### PR TITLE
Add OS and arch to HTTP user-agent string

### DIFF
--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -31,6 +31,8 @@ import Distribution.Verbosity (Verbosity)
 import Distribution.Simple.Utils
          ( die, info, warn, debug, notice
          , copyFileVerbose, writeFileAtomic )
+import Distribution.System
+         ( buildOS, buildArch )
 import Distribution.Text
          ( display )
 import Data.Char ( isSpace )
@@ -67,7 +69,9 @@ mkRequest uri etag = Request{ rqURI     = uri
                             , rqMethod  = GET
                             , rqHeaders = Header HdrUserAgent userAgent : ifNoneMatchHdr
                             , rqBody    = ByteString.empty }
-  where userAgent = "cabal-install/" ++ display Paths_cabal_install.version
+  where userAgent = concat [ "cabal-install/", display Paths_cabal_install.version
+                           , " (", display buildOS, "; ", display buildArch, ")"
+                           ]
         ifNoneMatchHdr = maybe [] (\t -> [Header HdrIfNoneMatch t]) etag
 
 -- |Carry out a GET request, using the local proxy settings


### PR DESCRIPTION
This makes the HTTP user-agent field look like so:

```
User-Agent: cabal-install/1.21.0.0 (linux; x86_64)
```

This allows us to gather more statistics about our user-base as
with the current user-agent string we can only do a rough break-down by
cabal-install version numbers.
