### PR TITLE
Add extra-ghci-libraries support to .cabal files

### DIFF
--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -623,6 +623,7 @@ data BuildInfo = BuildInfo {
         oldExtensions     :: [Extension],   -- ^ the old extensions field, treated same as 'defaultExtensions'
 
         extraLibs         :: [String], -- ^ what libraries to link with when compiling a program that uses your package
+        extraGHCiLibs     :: [String], -- ^ if present, overrides extraLibs when package is loaded with GHCi.
         extraLibDirs      :: [String],
         includeDirs       :: [FilePath], -- ^directories to find .h files
         includes          :: [FilePath], -- ^ The .h files to be found in includeDirs
@@ -655,6 +656,7 @@ instance Monoid BuildInfo where
     otherExtensions   = [],
     oldExtensions     = [],
     extraLibs         = [],
+    extraGHCiLibs     = [],
     extraLibDirs      = [],
     includeDirs       = [],
     includes          = [],
@@ -682,6 +684,7 @@ instance Monoid BuildInfo where
     otherExtensions   = combineNub otherExtensions,
     oldExtensions     = combineNub oldExtensions,
     extraLibs         = combine    extraLibs,
+    extraGHCiLibs     = combine    extraGHCiLibs,
     extraLibDirs      = combineNub extraLibDirs,
     includeDirs       = combineNub includeDirs,
     includes          = combineNub includes,

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -423,6 +423,9 @@ binfoFieldDescrs =
  , listFieldWithSep vcat "extra-libraries"
            showToken          parseTokenQ
            extraLibs          (\xs    binfo -> binfo{extraLibs=xs})
+ , listFieldWithSep vcat "extra-ghci-libraries"
+           showToken          parseTokenQ
+           extraGHCiLibs      (\xs    binfo -> binfo{extraGHCiLibs=xs})
  , listField   "extra-lib-dirs"
            showFilePath       parseFilePathQ
            extraLibDirs       (\xs    binfo -> binfo{extraLibDirs=xs})

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -284,7 +284,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg lib clbi installDirs =
                              | LibraryName libname <- componentLibraries clbi
                              , hasLibrary ],
     IPI.extraLibraries     = extraLibs bi,
-    IPI.extraGHCiLibraries = [],
+    IPI.extraGHCiLibraries = extraGHCiLibs bi,
     IPI.includeDirs        = absinc ++ adjustRelIncDirs relinc,
     IPI.includes           = includes bi,
     IPI.depends            = map fst (componentPackageDeps clbi),

--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -1390,6 +1390,10 @@ values for these fields.
 `extra-libraries:` _token list_
 :   A list of extra libraries to link with.
 
+`extra-ghci-libraries:` _token list_
+:   A list of extra libraries to be used instead of 'extra-libraries' when
+    the package is loaded with GHCi.
+
 `extra-lib-dirs:` _directory list_
 :   A list of directories to search for libraries.
 


### PR DESCRIPTION
As stated [here][http://www.haskell.org/ghc/docs/7.8.2/html/users_guide/ghci-invocation.html] in the "Extra libraries" section, GHCi on windows resolves extra libraries by just appending .dll extension to their name and ignoring an import library contents that were linked during a build. This raises issues when dll name doesn't match an import library one. To overcome that ghc introduced an extra-ghci-libraries parameter a long time ago.

It turned out that Cabal aready knows about an existance of that parameter in its InstalledPackageInfo data type. But it always uses empty list for that parameter value so it was somewhat useless.

The proposed patch adds a new field "extra-ghci-libraries" to .cabal files and passes that value right to the InstalledPackageInfo during the build.

Some relevant links:

This guy had the same troubles as I did: http://www.haskell.org/pipermail/libraries/2007-November/008641.html
Here is suggested workaround for cabal not supporting extra-ghci-libraries: https://groups.google.com/forum/#!topic/fa.haskell/eH_FbkEz06M
