### PR TITLE
Re-order CC options.

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1207,10 +1207,10 @@ componentCcGhcOptions verbosity lbi bi clbi pref filename =
                                    ++ PD.includeDirs bi,
       ghcOptPackageDBs     = withPackageDB lbi,
       ghcOptPackages       = componentPackageDeps clbi,
-      ghcOptCcOptions      = PD.ccOptions bi
-                             ++ case withOptimization lbi of
+      ghcOptCcOptions      = (case withOptimization lbi of
                                   NoOptimisation -> []
-                                  _              -> ["-O2"],
+                                  _              -> ["-O2"]) ++
+                                  PD.ccOptions bi,
       ghcOptObjDir         = toFlag odir
     }
   where


### PR DESCRIPTION
A default -O2 coming second over-rides packages that specify -O3.
Among other issues, this means expected AVX instructions are not being
generated and performance takes orders of magnitude dive in some cases.
