### PR TITLE
'Setup.hs sdist': invoke 'tar' with '--format ustar' if possible.

### DIFF
--- a/Cabal/Distribution/Simple/Program/Db.hs
+++ b/Cabal/Distribution/Simple/Program/Db.hs
@@ -337,6 +337,7 @@ configureProgram verbosity prog conf = do
             programDefaultArgs  = [],
             programOverrideArgs = userSpecifiedArgs prog conf,
             programOverrideEnv  = [("PATH", Just newPath)],
+            programProperties   = Map.empty,
             programLocation     = location
           }
       configuredProg' <- programPostConf prog verbosity configuredProg

--- a/Cabal/Distribution/Simple/Program/Types.hs
+++ b/Cabal/Distribution/Simple/Program/Types.hs
@@ -41,6 +41,7 @@ import Distribution.Verbosity
          ( Verbosity )
 
 import Data.Binary (Binary)
+import qualified Data.Map as Map
 import GHC.Generics (Generic)
 
 -- | Represents a program which can be configured.
@@ -101,6 +102,11 @@ data ConfiguredProgram = ConfiguredProgram {
        -- the current to form the environment for the new process.
        programOverrideEnv :: [(String, Maybe String)],
 
+       -- | A key-value map listing various properties of the program, useful
+       -- for feature detection. Populated during the configuration step, key
+       -- names depend on the specific program.
+       programProperties :: Map.Map String String,
+
        -- | Location of the program. eg. @\/usr\/bin\/ghc-6.4@
        programLocation :: ProgramLocation
      } deriving (Eq, Generic, Read, Show)
@@ -153,5 +159,6 @@ simpleConfiguredProgram name loc = ConfiguredProgram {
      programDefaultArgs  = [],
      programOverrideArgs = [],
      programOverrideEnv  = [],
+     programProperties   = Map.empty,
      programLocation     = loc
   }


### PR DESCRIPTION
Fixes #1901. Some variants of `tar` don't support the `--format` option, so we have to do feature detection.

Note that 'cabal sdist' (as opposed to `Setup.hs sdist`) uses the built-in tar.gz archiver (`Distribution.Client.Tar`) and doesn't invoke `tar` or `gzip`.
