### PR TITLE
Plumb --with-gcc= value through to GHC.

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -692,7 +692,8 @@ buildOrReplLib forRepl verbosity numJobsFlag pkg_descr lbi lib clbi = do
       (Platform _hostArch hostOS) = hostPlatform lbi
 
   (ghcProg, _) <- requireProgram verbosity ghcProgram (withPrograms lbi)
-  let runGhcProg = runGHC verbosity ghcProg comp
+  (gccProg, _) <- requireProgram verbosity gccProgram (withPrograms lbi)
+  let runGhcProg = runGHC verbosity ghcProg gccProg comp
 
   libBi <- hackThreadedFlag verbosity
              comp (withProfLib lbi) (libBuildInfo lib)
@@ -905,7 +906,8 @@ startInterpreter verbosity conf comp packageDBs = do
         }
   checkPackageDbStack packageDBs
   (ghcProg, _) <- requireProgram verbosity ghcProgram conf
-  runGHC verbosity ghcProg comp replOpts
+  (gccProg, _) <- requireProgram verbosity gccProgram conf
+  runGHC verbosity ghcProg gccProg comp replOpts
 
 -- | Build an executable with GHC.
 --
@@ -922,10 +924,11 @@ buildOrReplExe forRepl verbosity numJobsFlag _pkg_descr lbi
   exe@Executable { exeName = exeName', modulePath = modPath } clbi = do
 
   (ghcProg, _) <- requireProgram verbosity ghcProgram (withPrograms lbi)
+  (gccProg, _) <- requireProgram verbosity gccProgram (withPrograms lbi)
   let comp       = compiler lbi
       numJobs    = fromMaybe 1 $
                    fromFlagOrDefault Nothing numJobsFlag
-      runGhcProg = runGHC verbosity ghcProg comp
+      runGhcProg = runGHC verbosity ghcProg gccProg comp
 
   exeBi <- hackThreadedFlag verbosity
              comp (withProfExe lbi) (buildInfo exe)
@@ -1154,7 +1157,8 @@ libAbiHash verbosity pkg_descr lbi lib clbi = do
            else error "libAbiHash: Can't find an enabled library way"
   --
   (ghcProg, _) <- requireProgram verbosity ghcProgram (withPrograms lbi)
-  getProgramInvocationOutput verbosity (ghcInvocation ghcProg comp ghcArgs)
+  (gccProg, _) <- requireProgram verbosity gccProgram (withPrograms lbi)
+  getProgramInvocationOutput verbosity (ghcInvocation ghcProg gccProg comp ghcArgs)
 
 
 componentGhcOptions :: Verbosity -> LocalBuildInfo

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -211,15 +211,21 @@ data GhcDynLinkMode = GhcStaticOnly       -- ^ @-static@
  deriving (Show, Eq)
 
 
-runGHC :: Verbosity -> ConfiguredProgram -> Compiler -> GhcOptions -> IO ()
-runGHC verbosity ghcProg comp opts = do
-  runProgramInvocation verbosity (ghcInvocation ghcProg comp opts)
+runGHC :: Verbosity -> ConfiguredProgram -> ConfiguredProgram -> Compiler -> GhcOptions -> IO ()
+runGHC verbosity ghcProg ccProg comp opts = do
+  runProgramInvocation verbosity (ghcInvocation ghcProg ccProg comp opts)
 
 
-ghcInvocation :: ConfiguredProgram -> Compiler -> GhcOptions -> ProgramInvocation
-ghcInvocation prog comp opts =
-    programInvocation prog (renderGhcOptions comp opts)
+ghcInvocation :: ConfiguredProgram -> ConfiguredProgram -> Compiler -> GhcOptions -> ProgramInvocation
+ghcInvocation prog cc comp opts =
+    programInvocation prog (renderGhcOptions comp opts ++ renderGhcCcOptions cc)
 
+
+renderGhcCcOptions :: ConfiguredProgram -> [String]
+renderGhcCcOptions comp =
+     ("-pgmc=" ++ (programPath comp)) :
+     map ("-optc=" ++) (programDefaultArgs comp)
+  ++ map ("-optc=" ++) (programOverrideArgs comp)
 
 renderGhcOptions :: Compiler -> GhcOptions -> [String]
 renderGhcOptions comp opts


### PR DESCRIPTION
Previously, the c compiler selected by the user was only being used in
the early stages (preprocessing, perhaps another).  It seems obvous that
a user specifying --with-gcc=clang would want C code, such as any values
from cbits/*, to be compiled using clang.  We shoud likely plumb other
compiler options through as well, but doing so in a clean manner is
another issue.

Also, notice the option should be '--with-cc' someday.
