### PR TITLE
Allow template-haskell to be upgradable again

### DIFF
--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -258,7 +258,7 @@ dontUpgradeNonUpgradeablePackages params =
       [ PackageConstraintInstalled pkgname
       | all (/=PackageName "base") (depResolverTargets params)
       , pkgname <- map PackageName [ "base", "ghc-prim", "integer-gmp"
-                                   , "integer-simple", "template-haskell" ]
+                                   , "integer-simple" ]
       , isInstalled pkgname ]
     -- TODO: the top down resolver chokes on the base constraints
     -- below when there are no targets and thus no dep on base.

--- a/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
@@ -56,6 +56,5 @@ solve sc idx userPrefs userConstraints userGoals =
                                                   , PackageName "ghc-prim"
                                                   , PackageName "integer-gmp"
                                                   , PackageName "integer-simple"
-                                                  , PackageName "template-haskell"
                                                   ])
     buildPhase       = buildTree idx (independentGoals sc) userGoals


### PR DESCRIPTION
This partly reverts 65e9b88bc849e76040ed7947591ea7172cd02db5
which marked `template-haskell` non-upgradable. However, since are now
able to fix-up wrong .cabal meta-data on Hackage, previous `template-haskell`
releases have been augmented by proper version bounds so that it's now
safe again to let the Cabal solver handle reinstalling `template-haskell`

See also #1811, #667, #1761, and #1444
