### PR TITLE
-dynamic is not a debug flag

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -594,8 +594,9 @@ checkGhcOptions pkg =
   , checkFlags ["-fhpc"] $
       PackageDistInexcusable $
         "'ghc-options: -fhpc' is not appropriate for a distributed package."
-
-  , check (any ("-d" `isPrefixOf`) all_ghc_options) $
+    
+    -- -dynamic is not a debug flag
+  , check (any (\opt -> "-d" `isPrefixOf` opt && opt /= "-dynamic") all_ghc_options) $
       PackageDistInexcusable $
         "'ghc-options: -d*' debug flags are not appropriate for a distributed package."
 


### PR DESCRIPTION
cabal check will refuse a package that contains ghc-options: -dynamic, claiming it's a debug flag. It's not! If -dynamic is not a flag that should be used for some reason, we should give a more meaningful error message.
