### PR TITLE
put executeInstallPlan into newly created Shell monad (#975)

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -136,7 +136,9 @@ library
     containers >= 0.1 && < 0.6,
     array      >= 0.1 && < 0.6,
     pretty     >= 1   && < 1.2,
-    bytestring >= 0.9
+    bytestring >= 0.9,
+    transformers >= 0.3 && < 0.5,
+    exceptions   >= 0.6 && < 0.7
 
   if !os(windows)
     build-depends:

--- a/cabal-install/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/Distribution/Client/FetchUtils.hs
@@ -28,6 +28,7 @@ module Distribution.Client.FetchUtils (
 import Distribution.Client.Types
 import Distribution.Client.HttpUtils
          ( downloadURI, isOldHackageURI, DownloadResult(..) )
+import Distribution.Client.Shell ( Shell, liftIO )
 
 import Distribution.Package
          ( PackageId, packageName, packageVersion )
@@ -49,7 +50,6 @@ import qualified System.FilePath.Posix as FilePath.Posix
          ( combine, joinPath )
 import Network.URI
          ( URI(uriPath) )
-
 -- ------------------------------------------------------------
 -- * Actually fetch things
 -- ------------------------------------------------------------
@@ -66,7 +66,7 @@ isFetched loc = case loc of
 
 
 checkFetched :: PackageLocation (Maybe FilePath)
-             -> IO (Maybe (PackageLocation FilePath))
+             -> Shell (Maybe (PackageLocation FilePath))
 checkFetched loc = case loc of
     LocalUnpackedPackage dir  ->
       return (Just $ LocalUnpackedPackage dir)
@@ -80,7 +80,7 @@ checkFetched loc = case loc of
     RemoteTarballPackage _uri Nothing -> return Nothing
     RepoTarballPackage repo pkgid Nothing -> do
       let file = packageFile repo pkgid
-      exists <- doesFileExist file
+      exists <- liftIO (doesFileExist file)
       if exists
         then return (Just $ RepoTarballPackage repo pkgid file)
         else return Nothing

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -34,16 +34,15 @@ import qualified Data.Set as S
 import Data.Maybe
          ( isJust, fromMaybe, maybeToList )
 import Control.Exception as Exception
-         ( Exception(toException), bracket, catches
-         , Handler(Handler), handleJust, IOException, SomeException )
+         ( Exception(toException)
+         , handleJust, IOException, SomeException )
 #ifndef mingw32_HOST_OS
 import Control.Exception as Exception
          ( Exception(fromException) )
 #endif
+import qualified Control.Monad.Catch as MC
 import System.Exit
          ( ExitCode(..) )
-import Distribution.Compat.Exception
-         ( catchIO, catchExit )
 import Control.Monad
          ( when, unless )
 import System.Directory
@@ -52,7 +51,8 @@ import System.Directory
 import System.FilePath
          ( (</>), (<.>), takeDirectory )
 import System.IO
-         ( openFile, IOMode(AppendMode), hClose )
+         ( openFile, IOMode(AppendMode)
+         , hClose )
 import System.IO.Error
          ( isDoesNotExistError, ioeGetFileName )
 
@@ -96,7 +96,9 @@ import qualified Distribution.Client.World as World
 import qualified Distribution.InstalledPackageInfo as Installed
 import Distribution.Client.Compat.ExecutablePath
 import Distribution.Client.JobControl
+import Distribution.Client.Shell
 
+import Distribution.Simple.Command ( CommandUI )
 import Distribution.Simple.Compiler
          ( CompilerId(..), Compiler(compilerId), compilerFlavor
          , PackageDB(..), PackageDBStack )
@@ -135,7 +137,7 @@ import Distribution.ParseUtils
 import Distribution.Version
          ( Version )
 import Distribution.Simple.Utils as Utils
-         ( notice, info, warn, debug, debugNoWrap, die
+         ( notice, warn, debugNoWrap, die
          , intercalate, withTempDirectory )
 import Distribution.Client.Utils
          ( determineNumJobs, inDir, mergeBy, MergeResult(..)
@@ -187,7 +189,7 @@ install verbosity packageDBs repos comp platform conf useSandbox mSandboxPkgInfo
   userTargets0 = do
 
     installContext <- makeInstallContext verbosity args (Just userTargets0)
-    installPlan    <- foldProgress logMsg die' return =<<
+    installPlan    <- foldProgress logMsg die'' return =<<
                       makeInstallPlan verbosity args installContext
 
     processInstallPlan verbosity args installContext installPlan
@@ -197,8 +199,8 @@ install verbosity packageDBs repos comp platform conf useSandbox mSandboxPkgInfo
             globalFlags, configFlags, configExFlags, installFlags,
             haddockFlags)
 
-    die' message = die (message ++ if isUseSandbox useSandbox
-                                   then installFailedInSandbox else [])
+    die'' message = die (message ++ if isUseSandbox useSandbox
+                                    then installFailedInSandbox else [])
     -- TODO: use a better error message, remove duplication.
     installFailedInSandbox =
       "\nNote: when using a sandbox, all packages are required to have "
@@ -903,7 +905,7 @@ performInstallations verbosity
   installLock  <- newLock -- serialise installation
   cacheLock    <- newLock -- serialise access to setup exe cache
 
-  executeInstallPlan verbosity jobControl useLogFile installPlan $ \rpkg ->
+  runShell verbosity $ executeInstallPlan verbosity jobControl useLogFile installPlan $ \rpkg ->
     installReadyPackage platform compid configFlags
                         rpkg $ \configFlags' src pkg pkgoverride ->
       fetchSourcePackage verbosity fetchLimit src $ \src' ->
@@ -1006,11 +1008,11 @@ performInstallations verbosity
 
 
 executeInstallPlan :: Verbosity
-                   -> JobControl IO (PackageId, BuildResult)
+                   -> JobControl Shell (PackageId, BuildResult)
                    -> UseLogFile
                    -> InstallPlan
-                   -> (ReadyPackage -> IO BuildResult)
-                   -> IO InstallPlan
+                   -> (ReadyPackage -> Shell BuildResult)
+                   -> Shell InstallPlan
 executeInstallPlan verbosity jobCtl useLogFile plan0 installPkg =
     tryNewTasks 0 plan0
   where
@@ -1020,7 +1022,7 @@ executeInstallPlan verbosity jobCtl useLogFile plan0 installPkg =
            | otherwise      -> waitForTasks taskCount plan
         pkgs                -> do
           sequence_
-            [ do info verbosity $ "Ready to install " ++ display pkgid
+            [ do info' $ "Ready to install " ++ display pkgid
                  spawnJob jobCtl $ do
                    buildResult <- installPkg pkg
                    return (packageId pkg, buildResult)
@@ -1032,7 +1034,7 @@ executeInstallPlan verbosity jobCtl useLogFile plan0 installPkg =
           waitForTasks taskCount' plan'
 
     waitForTasks taskCount plan = do
-      info verbosity $ "Waiting for install task to finish..."
+      info' "Waiting for install task to finish..."
       (pkgid, buildResult) <- collectJob jobCtl
       printBuildResult pkgid buildResult
       let taskCount' = taskCount-1
@@ -1054,21 +1056,21 @@ executeInstallPlan verbosity jobCtl useLogFile plan0 installPkg =
 
     -- Print build log if something went wrong, and 'Installed $PKGID'
     -- otherwise.
-    printBuildResult :: PackageId -> BuildResult -> IO ()
+    printBuildResult :: PackageId -> BuildResult -> Shell ()
     printBuildResult pkgid buildResult = case buildResult of
-        (Right _) -> notice verbosity $ "Installed " ++ display pkgid
+        (Right _) -> notice' $ "Installed " ++ display pkgid
         (Left _)  -> do
-          notice verbosity $ "Failed to install " ++ display pkgid
+          notice' $ "Failed to install " ++ display pkgid
           when (verbosity >= normal) $
             case useLogFile of
               Nothing                 -> return ()
               Just (mkLogFileName, _) -> do
                 let logName = mkLogFileName pkgid
-                putStr $ "Build log ( " ++ logName ++ " ):\n"
-                printFile logName
+                notice' $ "Build log ( " ++ logName ++ " ):\n"
+                printFile logName >>= notice'
 
-    printFile :: FilePath -> IO ()
-    printFile path = readFile path >>= putStr
+    printFile :: FilePath -> Shell String
+    printFile path = liftIO (readFile path)
 
 -- | Call an installer for an 'SourcePackage' but override the configure
 -- flags with the ones given by the 'ReadyPackage'. In particular the
@@ -1114,15 +1116,15 @@ fetchSourcePackage
   :: Verbosity
   -> JobLimit
   -> PackageLocation (Maybe FilePath)
-  -> (PackageLocation FilePath -> IO BuildResult)
-  -> IO BuildResult
+  -> (PackageLocation FilePath -> Shell BuildResult)
+  -> Shell BuildResult
 fetchSourcePackage verbosity fetchLimit src installPkg = do
   fetched <- checkFetched src
   case fetched of
     Just src' -> installPkg src'
     Nothing   -> onFailure DownloadFailed $ do
                    loc <- withJobLimit fetchLimit $
-                            fetchPackage verbosity src
+                            liftIO (fetchPackage verbosity src)
                    installPkg loc
 
 
@@ -1130,8 +1132,8 @@ installLocalPackage
   :: Verbosity
   -> JobLimit
   -> PackageIdentifier -> PackageLocation FilePath -> FilePath
-  -> (Maybe FilePath -> IO BuildResult)
-  -> IO BuildResult
+  -> (Maybe FilePath -> Shell BuildResult)
+  -> Shell BuildResult
 installLocalPackage verbosity jobLimit pkgid location distPref installPkg =
 
   case location of
@@ -1156,11 +1158,11 @@ installLocalTarballPackage
   :: Verbosity
   -> JobLimit
   -> PackageIdentifier -> FilePath -> FilePath
-  -> (Maybe FilePath -> IO BuildResult)
-  -> IO BuildResult
+  -> (Maybe FilePath -> Shell BuildResult)
+  -> Shell BuildResult
 installLocalTarballPackage verbosity jobLimit pkgid
                            tarballPath distPref installPkg = do
-  tmp <- getTemporaryDirectory
+  tmp <- liftIO getTemporaryDirectory
   withTempDirectory verbosity tmp (display pkgid) $ \tmpDirPath ->
     onFailure UnpackFailed $ do
       let relUnpackedPath = display pkgid
@@ -1168,12 +1170,12 @@ installLocalTarballPackage verbosity jobLimit pkgid
           descFilePath = absUnpackedPath
                      </> display (packageName pkgid) <.> "cabal"
       withJobLimit jobLimit $ do
-        info verbosity $ "Extracting " ++ tarballPath
-                      ++ " to " ++ tmpDirPath ++ "..."
-        extractTarGzFile tmpDirPath relUnpackedPath tarballPath
-        exists <- doesFileExist descFilePath
+        info' $ "Extracting " ++ tarballPath
+                ++ " to " ++ tmpDirPath ++ "..."
+        liftIO (extractTarGzFile tmpDirPath relUnpackedPath tarballPath)
+        exists <- liftIO (doesFileExist descFilePath)
         when (not exists) $
-          die $ "Package .cabal file not found: " ++ show descFilePath
+          die' $ "Package .cabal file not found: " ++ show descFilePath
         maybeRenameDistDir absUnpackedPath
 
       installPkg (Just absUnpackedPath)
@@ -1185,22 +1187,22 @@ installLocalTarballPackage verbosity jobLimit pkgid
     --
     -- TODO: 'cabal get happy && cd sandbox && cabal install ../happy' still
     -- fails even with this workaround. We probably can live with that.
-    maybeRenameDistDir :: FilePath -> IO ()
+    maybeRenameDistDir :: FilePath -> Shell ()
     maybeRenameDistDir absUnpackedPath = do
       let distDirPath    = absUnpackedPath </> defaultDistPref
           distDirPathTmp = absUnpackedPath </> (defaultDistPref ++ "-tmp")
           distDirPathNew = absUnpackedPath </> distPref
-      distDirExists <- doesDirectoryExist distDirPath
+      distDirExists <- liftIO (doesDirectoryExist distDirPath)
       when distDirExists $ do
         -- NB: we need to handle the case when 'distDirPathNew' is a
         -- subdirectory of 'distDirPath' (e.g. 'dist/dist-sandbox-3688fbc2').
-        debug verbosity $ "Renaming '" ++ distDirPath ++ "' to '"
+        debug' $ "Renaming '" ++ distDirPath ++ "' to '"
           ++ distDirPathTmp ++ "'."
-        renameDirectory distDirPath distDirPathTmp
-        createDirectoryIfMissingVerbose verbosity False distDirPath
-        debug verbosity $ "Renaming '" ++ distDirPathTmp ++ "' to '"
+        liftIO $ renameDirectory distDirPath distDirPathTmp
+        liftIO $ createDirectoryIfMissingVerbose verbosity False distDirPath
+        debug' $ "Renaming '" ++ distDirPathTmp ++ "' to '"
           ++ distDirPathNew ++ "'."
-        renameDirectory distDirPathTmp distDirPathNew
+        liftIO $ renameDirectory distDirPathTmp distDirPathNew
 
 installUnpackedPackage
   :: Verbosity
@@ -1218,22 +1220,21 @@ installUnpackedPackage
   -> PackageDescriptionOverride
   -> Maybe FilePath -- ^ Directory to change to before starting the installation.
   -> UseLogFile -- ^ File to log output to (if any)
-  -> IO BuildResult
+  -> Shell BuildResult
 installUnpackedPackage verbosity buildLimit installLock numJobs
                        scriptOptions miscOptions
                        configFlags installFlags haddockFlags
                        compid platform pkg pkgoverride workingDir useLogFile = do
-
   -- Override the .cabal file if necessary
   case pkgoverride of
     Nothing     -> return ()
     Just pkgtxt -> do
       let descFilePath = fromMaybe "." workingDir
                      </> display (packageName pkgid) <.> "cabal"
-      info verbosity $
+      info' $
         "Updating " ++ display (packageName pkgid) <.> "cabal"
                     ++ " with the latest revision from the index."
-      writeFileAtomic descFilePath pkgtxt
+      liftIO (writeFileAtomic descFilePath pkgtxt)
 
   -- Make sure that we pass --libsubdir etc to 'setup configure' (necessary if
   -- the setup script was compiled against an old version of the Cabal lib).
@@ -1249,13 +1250,13 @@ installUnpackedPackage verbosity buildLimit installLock numJobs
 
   -- Configure phase
   onFailure ConfigureFailed $ withJobLimit buildLimit $ do
-    when (numJobs > 1) $ notice verbosity $
+    when (numJobs > 1) $ notice' $
       "Configuring " ++ display pkgid ++ "..."
     setup configureCommand configureFlags mLogPath
 
   -- Build phase
     onFailure BuildFailed $ do
-      when (numJobs > 1) $ notice verbosity $
+      when (numJobs > 1) $ notice' $
         "Building " ++ display pkgid ++ "..."
       setup buildCommand' buildFlags mLogPath
 
@@ -1263,13 +1264,13 @@ installUnpackedPackage verbosity buildLimit installLock numJobs
       docsResult <- if shouldHaddock
         then (do setup haddockCommand haddockFlags' mLogPath
                  return DocsOk)
-               `catchIO`   (\_ -> return DocsFailed)
-               `catchExit` (\_ -> return DocsFailed)
+               `catchIO'` (\_ -> return DocsFailed)
+               `catchExit'` (\_ -> return DocsFailed)
         else return DocsNotTried
 
   -- Tests phase
       onFailure TestsFailed $ do
-        when (testsEnabled && PackageDescription.hasTests pkg) $
+        when (testsEnabled && PackageDescription.hasTests pkg) $ do
             setup Cabal.testCommand testFlags mLogPath
 
         let testsResult | testsEnabled = TestsOk
@@ -1283,7 +1284,7 @@ installUnpackedPackage verbosity buildLimit installLock numJobs
           -- Actual installation
           withWin32SelfUpgrade verbosity configFlags compid platform pkg $ do
             case rootCmd miscOptions of
-              (Just cmd) -> reexec cmd
+              (Just cmd) -> liftIO (reexec cmd)
               Nothing    -> do
                 setup Cabal.copyCommand copyFlags mLogPath
                 when shouldRegister $ do
@@ -1320,9 +1321,9 @@ installUnpackedPackage verbosity buildLimit installLock numJobs
     verbosity' = maybe verbosity snd useLogFile
     tempTemplate name = name ++ "-" ++ display pkgid
 
-    addDefaultInstallDirs :: ConfigFlags -> IO ConfigFlags
+    addDefaultInstallDirs :: ConfigFlags -> Shell ConfigFlags
     addDefaultInstallDirs configFlags' = do
-      defInstallDirs <- InstallDirs.defaultInstallDirs flavor userInstall False
+      defInstallDirs <- liftIO (InstallDirs.defaultInstallDirs flavor userInstall False)
       return $ configFlags' {
           configInstallDirs = fmap Cabal.Flag .
                               InstallDirs.substituteInstallDirTemplates env $
@@ -1336,12 +1337,12 @@ installUnpackedPackage verbosity buildLimit installLock numJobs
                         (configUserInstall configFlags')
 
     maybeGenPkgConf :: Maybe FilePath
-                    -> IO (Maybe Installed.InstalledPackageInfo)
+                    -> Shell (Maybe Installed.InstalledPackageInfo)
     maybeGenPkgConf mLogPath =
       if shouldRegister then do
-        tmp <- getTemporaryDirectory
+        tmp <- liftIO getTemporaryDirectory
         withTempFile tmp (tempTemplate "pkgConf") $ \pkgConfFile handle -> do
-          hClose handle
+          liftIO (hClose handle)
           let registerFlags' version = (registerFlags version) {
                 Cabal.regGenPkgConf = toFlag (Just pkgConfFile)
               }
@@ -1351,39 +1352,42 @@ installUnpackedPackage verbosity buildLimit installLock numJobs
               Installed.ParseFailed perror    -> pkgConfParseFailed perror
               Installed.ParseOk warns pkgConf -> do
                 unless (null warns) $
-                  warn verbosity $ unlines (map (showPWarning pkgConfFile) warns)
+                  warn' $ unlines (map (showPWarning pkgConfFile) warns)
                 return (Just pkgConf)
       else return Nothing
 
-    pkgConfParseFailed :: Installed.PError -> IO a
+    pkgConfParseFailed :: Installed.PError -> Shell a
     pkgConfParseFailed perror =
-      die $ "Couldn't parse the output of 'setup register --gen-pkg-config':"
-            ++ show perror
+      die' $ "Couldn't parse the output of 'setup register --gen-pkg-config':"
+             ++ show perror
 
-    maybeLogPath :: IO (Maybe FilePath)
+    maybeLogPath :: Shell (Maybe FilePath)
     maybeLogPath =
       case useLogFile of
          Nothing                 -> return Nothing
          Just (mkLogFileName, _) -> do
            let logFileName = mkLogFileName (packageId pkg)
                logDir      = takeDirectory logFileName
-           unless (null logDir) $ createDirectoryIfMissing True logDir
-           logFileExists <- doesFileExist logFileName
-           when logFileExists $ removeFile logFileName
+           unless (null logDir) $ liftIO (createDirectoryIfMissing True logDir)
+           logFileExists <- liftIO (doesFileExist logFileName)
+           when logFileExists $ liftIO (removeFile logFileName)
            return (Just logFileName)
 
+    setup :: CommandUI flags0 -> (Version -> flags0) -> Maybe FilePath -> Shell ()
     setup cmd flags mLogPath =
-      Exception.bracket
+      MC.bracket
       (maybe (return Nothing)
-             (\path -> Just `fmap` openFile path AppendMode) mLogPath)
-      (maybe (return ()) hClose)
+             (\path -> Just `fmap` liftIO (openFile path AppendMode)) mLogPath)
+      (maybe (return ()) (liftIO . hClose))
       (\logFileHandle ->
-        setupWrapper verbosity
+        -- TODO: put setupWrapper in shell, there is some use of "die" in there
+        liftIO $ setupWrapper verbosity
           scriptOptions { useLoggingHandle = logFileHandle
                         , useWorkingDir    = workingDir }
           (Just pkg)
           cmd flags [])
 
+    reexec :: FilePath -> IO ()
     reexec cmd = do
       -- look for our own executable file and re-exec ourselves using a helper
       -- program like sudo to elevate privileges:
@@ -1398,14 +1402,14 @@ installUnpackedPackage verbosity buildLimit installLock numJobs
 
 
 -- helper
-onFailure :: (SomeException -> BuildFailure) -> IO BuildResult -> IO BuildResult
+onFailure :: (SomeException -> BuildFailure) -> Shell BuildResult -> Shell BuildResult
 onFailure result action =
-  action `catches`
-    [ Handler $ \ioe  -> handler (ioe  :: IOException)
-    , Handler $ \exit -> handler (exit :: ExitCode)
+  action `MC.catches`
+    [ MC.Handler $ \ioe  -> handler (ioe  :: IOException)
+    , MC.Handler $ \exit -> handler (exit :: ExitCode)
     ]
   where
-    handler :: Exception e => e -> IO BuildResult
+    handler :: Exception e => e -> Shell BuildResult
     handler = return . Left . result . toException
 
 
@@ -1418,11 +1422,11 @@ withWin32SelfUpgrade :: Verbosity
                      -> CompilerId
                      -> Platform
                      -> PackageDescription
-                     -> IO a -> IO a
+                     -> Shell a -> Shell a
 withWin32SelfUpgrade _ _ _ _ _ action | buildOS /= Windows = action
 withWin32SelfUpgrade verbosity configFlags compid platform pkg action = do
 
-  defaultDirs <- InstallDirs.defaultInstallDirs
+  defaultDirs <- liftIO $ InstallDirs.defaultInstallDirs
                    compFlavor
                    (fromFlag (configUserInstall configFlags))
                    (PackageDescription.hasLibs pkg)

--- a/cabal-install/Distribution/Client/Shell.hs
+++ b/cabal-install/Distribution/Client/Shell.hs
@@ -1,0 +1,121 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Client.Shell
+-- Copyright   :  (c) 2014 Greg Horn
+-- License     :  BSD-like
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Stability   :  provisional
+-- Portability :  portable
+--
+-- Wrapper around IO with concurrency and logging, used for
+-- nice running summary messages durring parallel builds.
+-----------------------------------------------------------------------------
+{-# OPTIONS_GHC -Wall #-}
+module Distribution.Client.Shell ( Shell
+                                 , liftIO -- reexport for convenience
+                                 , warn', notice', info', debug', die'
+                                 , forkIO'
+                                 , runShell
+                                 , catchIO', catchExit'
+                                 ) where
+
+import Distribution.Verbosity ( Verbosity )
+import Distribution.Simple.Utils as Utils
+         ( notice, info, warn, debug, die )
+
+import System.Exit
+import qualified Control.Exception as Exception
+import qualified Control.Concurrent as CC
+import Control.Applicative
+import Control.Monad.IO.Class
+import Control.Monad.Catch ( MonadCatch, MonadThrow, MonadMask )
+import qualified Control.Monad.Catch as MC
+
+-- | This is basically the IO monad where you only print to the terminal
+-- through special commands (warn', notice', info', etc). This lets us write
+-- a nice ncurses UI.
+-- .
+-- Shell is an instance of MonadIO, though you better not use that to print
+-- to terminal. (Maybe this instance should be hidden).
+-- .
+-- This monad can be forked with forkIO'.
+-- .
+-- Shell also carries around the state of the parallel build progress.
+newtype Shell a = Shell { unShell :: CC.MVar Verbosity -> IO a }
+
+instance Functor Shell where
+  fmap f (Shell sh) = Shell (fmap f . sh)
+
+instance Applicative Shell where
+  pure x = Shell $ const (pure x)
+  Shell f <*> Shell v = Shell $ \r -> f r <*> v r
+
+instance Monad Shell where
+  return x = Shell $ \_ -> return x
+  Shell m >>= k  = Shell $ \r -> do
+      a <- m r
+      unShell (k a) r
+  fail msg = Shell $ \_ -> fail msg
+
+instance MonadIO Shell where
+  liftIO = Shell . const
+
+instance MonadCatch Shell where
+  catch (Shell m) c = Shell $ \r -> m r `MC.catch` \e -> unShell (c e) r
+
+instance MonadThrow Shell where
+  throwM e = liftIO (MC.throwM e)
+
+instance MonadMask Shell where
+  mask a = Shell $ \e -> MC.mask $ \u -> unShell (a $ q u) e
+    where q u (Shell b) = Shell (u . b)
+  uninterruptibleMask a =
+    Shell $ \e -> MC.uninterruptibleMask $ \u -> unShell (a $ q u) e
+      where q u (Shell b) = Shell (u . b)
+
+-- | execute the Shell action in the IO monad
+runShell :: Verbosity -> Shell a -> IO a
+runShell verbosity (Shell sh) = do
+  r <- CC.newMVar verbosity
+  sh r
+
+-- | wrapped version of forkIO in the Shell monad
+forkIO' :: Shell () -> Shell CC.ThreadId
+forkIO' (Shell f) = Shell $ \r -> CC.forkIO (f r)
+
+withVerbosity :: (Verbosity -> IO a) -> Shell a
+withVerbosity f = Shell $ \r -> do
+  v <- CC.readMVar r
+  f v
+
+-- | Shell wrapper around `Distribution.Simple.Utils(info)`
+info' :: String -> Shell ()
+info' msg = do
+  withVerbosity (\v -> info v msg)
+
+-- | Shell wrapper around `Distribution.Simple.Utils(notice)`
+notice' :: String -> Shell ()
+notice' msg = do
+  withVerbosity (\v -> notice v msg)
+
+-- | Shell wrapper around `Distribution.Simple.Utils(warn)`
+warn' :: String -> Shell ()
+warn' msg = do
+  withVerbosity (\v -> warn v msg)
+
+-- | Shell wrapper around `Distribution.Simple.Utils(debug)`
+debug' :: String -> Shell ()
+debug' msg = do
+  withVerbosity (\v -> debug v msg)
+
+-- | Shell wrapper around `Distribution.Simple.Utils(die)`
+die' :: String -> Shell a
+die' msg = do
+  liftIO (die msg)
+
+catchIO' :: Shell a -> (Exception.IOException -> Shell a) -> Shell a
+catchIO' = MC.catch
+
+catchExit' :: Shell a -> (ExitCode -> Shell a) -> Shell a
+catchExit' = MC.catch

--- a/cabal-install/Distribution/Client/Shell.hs
+++ b/cabal-install/Distribution/Client/Shell.hs
@@ -40,7 +40,7 @@ import qualified Control.Monad.Catch as MC
 
 -- | status of one package which is currently being installed
 data PackageInstallStatus = PISConfiguring
-                          | PISBuilding
+                          | PISBuilding (Maybe (Int,Int,Bool))
                           | PISTesting
                           | PISHaddocking
                           | PISInstalling

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -101,6 +101,7 @@ executable cabal
         Distribution.Client.Sandbox.Types
         Distribution.Client.Setup
         Distribution.Client.SetupWrapper
+        Distribution.Client.Shell
         Distribution.Client.SrcDist
         Distribution.Client.Tar
         Distribution.Client.Targets
@@ -134,7 +135,9 @@ executable cabal
         random     >= 1        && < 1.1,
         stm        >= 2.0      && < 3,
         time       >= 1.1      && < 1.5,
-        zlib       >= 0.5.3    && < 0.6
+        zlib       >= 0.5.3    && < 0.6,
+        transformers >= 0.3 && < 0.5,
+        exceptions   >= 0.6 && < 0.7
 
     if flag(old-directory)
       build-depends: directory >= 1 && < 1.2, old-time >= 1 && < 1.2,


### PR DESCRIPTION
This commit puts `executeInstallPlan` into a newly created `Shell` Monad, which tracks the status of the parallel install. It should be trivial to implement #975 by tweaking `Distribution.Client.Shell`. I realize this is quite a big change which also adds a dependency on `exceptions`, so I'd appreciate a review before this is merged.

commit messages follows:

The Shell monad is basically an IO monad which carries around the state
of the parallel install. It is an instance of MonadIO but you print output
through with special commands warn', notice', info', etc which will in the
future be redirected to write a nice UI.

Shell can also be forked with forkIO'.

This adds dependencies on transformers (which was already implied by the mtl
dependency) and exceptions (which is new but has no additional dependencies).