### PR TITLE
#1698 - Don't attempt to rename dist if it is already named correctly

### DIFF
--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1191,7 +1191,7 @@ installLocalTarballPackage verbosity jobLimit pkgid
           distDirPathTmp = absUnpackedPath </> (defaultDistPref ++ "-tmp")
           distDirPathNew = absUnpackedPath </> distPref
       distDirExists <- doesDirectoryExist distDirPath
-      when distDirExists $ do
+      when (distDirExists && distDirPath /= distDirPathNew) $ do
         -- NB: we need to handle the case when 'distDirPathNew' is a
         -- subdirectory of 'distDirPath' (e.g. 'dist/dist-sandbox-3688fbc2').
         debug verbosity $ "Renaming '" ++ distDirPath ++ "' to '"


### PR DESCRIPTION
See https://github.com/haskell/cabal/issues/1698.
