### PR TITLE
Document 'cabal test --show-details=streaming' (#1964)

### DIFF
--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -1620,7 +1620,8 @@ testCommand = makeCommand name shortDesc longDesc defaultTestFlags options
       , option [] ["show-details"]
             ("'always': always show results of individual test cases. "
              ++ "'never': never show results of individual test cases. "
-             ++ "'failures': show results of failing test cases.")
+             ++ "'failures': show results of failing test cases. "
+             ++ "'streaming': show results of test cases in real time.")
             testShowDetails (\v flags -> flags { testShowDetails = v })
             (reqArg "FILTER"
                 (readP_to_E (\_ -> "--show-details flag expects one of "

--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -990,8 +990,8 @@ suites, otherwise, Cabal will run all test suites in the package.
 
 `--show-details=`_filter_
 :   Determines if the results of individual test cases are shown on the
-    terminal.  May be `always` (always show), `never` (never show), or
-    `failures` (show only the test cases of failing test suites).
+    terminal.  May be `always` (always show), `never` (never show), `failures`
+    (show only failed results), or `streaming` (show all results in real time).
 
 `--test-options=`_options_
 :   Give extra options to the test executables.


### PR DESCRIPTION
This fixes #1964.

Paging @ttuegel.
