### PR TITLE
Fix dead link to parsing paper

### DIFF
--- a/Cabal/Distribution/Compat/ReadP.hs
+++ b/Cabal/Distribution/Compat/ReadP.hs
@@ -14,7 +14,7 @@
 -- it makes no difference which branch is \"shorter\".
 --
 -- See also Koen's paper /Parallel Parsing Processes/
--- (<http://www.cs.chalmers.se/~koen/publications.html>).
+-- (<http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.19.9217>).
 --
 -- This version of ReadP has been locally hacked to make it H98, by
 -- Martin Sj&#xF6;gren <mailto:msjogren@gmail.com>


### PR DESCRIPTION
I've got a copy now too, in case the current link disappears
