### PR TITLE
Add 'cabal get --only-package-description'

### DIFF
--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -1821,6 +1821,10 @@ The `get` command supports the following options:
 :   Fork the package's source repository using the appropriate version control
     system. The optional argument allows to choose a specific repo kind.
 
+`--only-package-description`
+:   Unpack only the package description file. Uses only information already
+    available locally in one of the repository indices. Ignores `-s`.
+
 
 ## Accessing data files from package code ##
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -738,6 +738,7 @@ instance Monoid ReportFlags where
 
 data GetFlags = GetFlags {
     getDestDir          :: Flag FilePath,
+    getOnlyPkgDescr     :: Flag Bool,
     getPristine         :: Flag Bool,
     getSourceRepository :: Flag (Maybe RepoKind),
     getVerbosity        :: Flag Verbosity
@@ -746,6 +747,7 @@ data GetFlags = GetFlags {
 defaultGetFlags :: GetFlags
 defaultGetFlags = GetFlags {
     getDestDir          = mempty,
+    getOnlyPkgDescr     = mempty,
     getPristine         = mempty,
     getSourceRepository = mempty,
     getVerbosity        = toFlag normal
@@ -759,7 +761,9 @@ getCommand = CommandUI {
           "Creates a local copy of a package's source code. By default it gets "
        ++ "the source\ntarball and unpacks it in a local subdirectory. "
        ++ "Alternatively, with -s it will\nget the code from the source "
-       ++ "repository specified by the package.\n",
+       ++ "repository specified by the package.\n"
+       ++ "With --only-package-description, it will ignore -s and unpack only "
+       ++ "the package\ndescription.\n",
     commandUsage        = usagePackages "get",
     commandDefaultFlags = defaultGetFlags,
     commandOptions      = \_ -> [
@@ -777,6 +781,16 @@ getCommand = CommandUI {
                                               (fmap (toFlag . Just) parse))
                                   (Flag Nothing)
                                   (map (fmap show) . flagToList))
+
+       , option [] ["only-package-description"]
+           "Unpack only the package description file."
+           getOnlyPkgDescr (\v flags -> flags { getOnlyPkgDescr = v })
+           trueArg
+
+       , option [] ["package-description-only"]
+           "A synonym for --only-package-description."
+           getOnlyPkgDescr (\v flags -> flags { getOnlyPkgDescr = v })
+           trueArg
 
        , option [] ["pristine"]
            ("Unpack the original pristine tarball, rather than updating the "
@@ -796,12 +810,14 @@ unpackCommand = getCommand {
 instance Monoid GetFlags where
   mempty = GetFlags {
     getDestDir          = mempty,
+    getOnlyPkgDescr     = mempty,
     getPristine         = mempty,
     getSourceRepository = mempty,
     getVerbosity        = mempty
     }
   mappend a b = GetFlags {
     getDestDir          = combine getDestDir,
+    getOnlyPkgDescr     = combine getOnlyPkgDescr,
     getPristine         = combine getPristine,
     getSourceRepository = combine getSourceRepository,
     getVerbosity        = combine getVerbosity


### PR DESCRIPTION
With this option, 'cabal get' writes to the destination directory only the package description already available locally in one of the repository indices.

As requested by myself in #1954.
