### PR TITLE
Implement "reexported-modules" field, towards fixing GHC bug #8407.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -146,6 +146,7 @@ library
     Distribution.License
     Distribution.Make
     Distribution.ModuleName
+    Distribution.ModuleExport
     Distribution.Package
     Distribution.PackageDescription
     Distribution.PackageDescription.Check

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -82,6 +82,8 @@ import qualified Distribution.Package as Package
          ( Package(..) )
 import Distribution.ModuleName
          ( ModuleName )
+import Distribution.ModuleExport
+         ( ModuleExport(..) )
 import Distribution.Version
          ( Version(..) )
 import Distribution.Text
@@ -89,6 +91,7 @@ import Distribution.Text
 
 -- -----------------------------------------------------------------------------
 -- The InstalledPackageInfo type
+
 
 data InstalledPackageInfo_ m
    = InstalledPackageInfo {
@@ -108,6 +111,7 @@ data InstalledPackageInfo_ m
         -- these parts are required by an installed package only:
         exposed           :: Bool,
         exposedModules    :: [m],
+        reexportedModules :: [ModuleExport m],
         hiddenModules     :: [m],
         trusted           :: Bool,
         importDirs        :: [FilePath],  -- contain sources in case of Hugs
@@ -150,6 +154,7 @@ emptyInstalledPackageInfo
         category          = "",
         exposed           = False,
         exposedModules    = [],
+        reexportedModules = [],
         hiddenModules     = [],
         trusted           = False,
         importDirs        = [],
@@ -247,6 +252,9 @@ installedFieldDescrs = [
  , listField   "exposed-modules"
         disp               parseModuleNameQ
         exposedModules     (\xs    pkg -> pkg{exposedModules=xs})
+ , listField   "reexported-modules"
+        disp               parse
+        reexportedModules  (\xs    pkg -> pkg{reexportedModules=xs})
  , listField   "hidden-modules"
         disp               parseModuleNameQ
         hiddenModules      (\xs    pkg -> pkg{hiddenModules=xs})

--- a/Cabal/Distribution/ModuleExport.hs
+++ b/Cabal/Distribution/ModuleExport.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+module Distribution.ModuleExport(ModuleExport(..)) where
+
+import Distribution.ParseUtils
+         ( parseQuoted )
+import Distribution.Text
+         ( Text(disp, parse) )
+import Distribution.Compat.ReadP
+         ( (<++) )
+import Data.List
+         ( intersperse )
+import Distribution.Package
+         ( PackageId )
+import qualified Distribution.Compat.ReadP as Parse
+import qualified Text.PrettyPrint as Disp
+import Data.Data
+
+-- ModuleExport has a very interesting invariant: in the installed
+-- package database, a ModuleExport is guaranteed to point to the
+-- original module which defined the module. Of course, when a user
+-- writes a ModuleExport, it may not have this property.  ghc-pkg is
+-- responsible for enforcing this invariant.
+
+data ModuleExport m = ModuleExport {
+    exportName :: m,
+    exportOrigPackageId :: PackageId,
+    exportOrigName :: m
+} deriving (Read, Show, Eq, Data, Typeable)
+
+-- EZY (Jul 2014): Honestly, a bit of a hack, but it's useful in GHC.
+instance Functor ModuleExport where
+    fmap f (ModuleExport m pid m') = ModuleExport (f m) pid (f m')
+
+instance Text m => Text (ModuleExport m) where
+    disp (ModuleExport m pid' m') =
+      Disp.hcat (intersperse (Disp.char ':') [disp m, disp pid', disp m'])
+    parse = do let parseQ = parseQuoted parse <++ parse
+               m <- parseQ
+               _ <- Parse.char ':'
+               pid' <- parse
+               _ <- Parse.char ':'
+               m' <- parseQ
+               return (ModuleExport m pid' m')

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -210,6 +210,7 @@ checkSanity pkg =
     bmNames = map benchmarkName $ benchmarks pkg
     duplicateNames = dups $ exeNames ++ testNames ++ bmNames
 
+-- XXX todo add some checks for reexported
 checkLibrary :: PackageDescription -> Library -> [PackageCheck]
 checkLibrary _pkg lib =
   catMaybes [

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -181,6 +181,9 @@ libFieldDescrs =
   [ listFieldWithSep vcat "exposed-modules" disp parseModuleNameQ
       exposedModules (\mods lib -> lib{exposedModules=mods})
 
+  , listFieldWithSep vcat "reexported-modules" disp parse
+      reexportedModules (\mods lib -> lib{reexportedModules=mods})
+
   , boolField "exposed"
       libExposed     (\val lib -> lib{libExposed=val})
   ] ++ map biToLib binfoFieldDescrs

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -356,6 +356,7 @@ testSuiteLibV09AsLibAndExe pkg_descr lbi
     bi  = testBuildInfo test
     lib = Library {
             exposedModules = [ m ],
+            reexportedModules = [],
             libExposed     = True,
             libBuildInfo   = bi
           }

--- a/Cabal/Distribution/Simple/GHC/IPI641.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI641.hs
@@ -65,7 +65,8 @@ mkInstalledPackageId :: Current.PackageIdentifier -> Current.InstalledPackageId
 mkInstalledPackageId = Current.InstalledPackageId . display
 
 toCurrent :: InstalledPackageInfo -> Current.InstalledPackageInfo
-toCurrent ipi@InstalledPackageInfo{} = Current.InstalledPackageInfo {
+toCurrent ipi@InstalledPackageInfo{} =
+  Current.InstalledPackageInfo {
     Current.installedPackageId = mkInstalledPackageId (convertPackageId (package ipi)),
     Current.sourcePackageId    = convertPackageId (package ipi),
     Current.license            = convertLicense (license ipi),
@@ -80,6 +81,7 @@ toCurrent ipi@InstalledPackageInfo{} = Current.InstalledPackageInfo {
     Current.category           = category ipi,
     Current.exposed            = exposed ipi,
     Current.exposedModules     = map convertModuleName (exposedModules ipi),
+    Current.reexportedModules  = [],
     Current.hiddenModules      = map convertModuleName (hiddenModules ipi),
     Current.trusted            = Current.trusted Current.emptyInstalledPackageInfo,
     Current.importDirs         = importDirs ipi,

--- a/Cabal/Distribution/Simple/GHC/IPI642.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI642.hs
@@ -100,7 +100,8 @@ convertLicense AllRightsReserved = Current.AllRightsReserved
 convertLicense OtherLicense = Current.OtherLicense
 
 toCurrent :: InstalledPackageInfo -> Current.InstalledPackageInfo
-toCurrent ipi@InstalledPackageInfo{} = Current.InstalledPackageInfo {
+toCurrent ipi@InstalledPackageInfo{} =
+  Current.InstalledPackageInfo {
     Current.installedPackageId = mkInstalledPackageId (convertPackageId (package ipi)),
     Current.sourcePackageId    = convertPackageId (package ipi),
     Current.license            = convertLicense (license ipi),
@@ -115,6 +116,7 @@ toCurrent ipi@InstalledPackageInfo{} = Current.InstalledPackageInfo {
     Current.category           = category ipi,
     Current.exposed            = exposed ipi,
     Current.exposedModules     = map convertModuleName (exposedModules ipi),
+    Current.reexportedModules  = [],
     Current.hiddenModules      = map convertModuleName (hiddenModules ipi),
     Current.trusted            = Current.trusted Current.emptyInstalledPackageInfo,
     Current.importDirs         = importDirs ipi,

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -84,6 +84,8 @@ import qualified Distribution.InstalledPackageInfo as IPI
 import Distribution.Version
          ( Version, withinRange )
 import Distribution.Simple.Utils (lowercase, comparing, equating)
+import Distribution.ModuleExport
+         ( ModuleExport(..) )
 
 
 -- | The collection of information about packages from one or more 'PackageDB's.
@@ -568,9 +570,17 @@ dependencyInconsistencies index =
         reallyIsInconsistent _ = True
 
 
+-- This function is only a rough approximation of GHC's module finder,
+-- and it's used to initialize the build-deps field in 'cabal init'
 moduleNameIndex :: PackageIndex -> Map ModuleName [InstalledPackageInfo]
 moduleNameIndex index =
-  Map.fromListWith (++)
-    [ (moduleName, [pkg])
-    | pkg        <- allPackages index
-    , moduleName <- IPI.exposedModules pkg ]
+  Map.fromListWith (++) . concat $
+    [ [(m, [pkg]) | m <- IPI.exposedModules pkg ] ++
+      [(m, [pkg]) | ModuleExport m _ m' <- IPI.reexportedModules pkg
+                  , m /= m' ]
+        -- The heuristic is this: we want to prefer the original package
+        -- which originally exported a module.  However, if a reexport
+        -- also *renamed* the module (m /= m'), then we have to use the
+        -- downstream package, since the upstream package has the wrong
+        -- module name!
+    | pkg        <- allPackages index ]

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -274,6 +274,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg lib clbi installDirs =
     IPI.category           = category    pkg,
     IPI.exposed            = libExposed  lib,
     IPI.exposedModules     = exposedModules lib,
+    IPI.reexportedModules  = reexportedModules lib,
     IPI.hiddenModules      = otherModules bi,
     IPI.trusted            = IPI.trusted IPI.emptyInstalledPackageInfo,
     IPI.importDirs         = [ libdir installDirs | hasModules ],


### PR DESCRIPTION
Hello lovely Cabalites. I have a preliminary patch for enabling module-reexports (https://ghc.haskell.org/trac/ghc/ticket/8407). This patch doesn't really do anything without the companion changes to ghc-pkg and GHC, but I'd like to get the review process rolling.

Re-exported modules allow packages to reexport modules from their
dependencies without having to create stub files.  Reexports of the same
original module don't count as ambiguous imports when module finding
occurs.

Here are the known TODO items:

TODO: Add some validation checks for the field, e.g. duplicates,
self-referential, etc. Please let me know if there are other validation checks you would like.

TODO: Syntax bikeshedding.  Implemented syntax:

```
Exported:pkg:Orig
```

but this is not very good.

Here is a syntax proposal:

```
"pkg" Orig as Exported
```

...with some syntax sugar for certain cases. When Exported = Orig:

```
"pkg" OrigName
```

(Unimplemented) Have Cabal figure out which package to use:

```
OrigName
```

Other syntax proposals welcomed.

Signed-off-by: Edward Z. Yang ezyang@cs.stanford.edu
