### PR TITLE
Use SVG for the Travis badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cabal [![Build Status](https://secure.travis-ci.org/haskell/cabal.png?branch=master)](http://travis-ci.org/haskell/cabal)
+# Cabal [![Build Status](https://secure.travis-ci.org/haskell/cabal.svg?branch=master)](http://travis-ci.org/haskell/cabal)
 
 This Cabal Git repository contains the following packages:
 


### PR DESCRIPTION
If you look at the [rendered diff](https://github.com/haskell/cabal/pull/1985/files?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8) the SVG version looks much better.
