### PR TITLE
Ask source directory in cabal init

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -25,7 +25,7 @@ import System.IO
   ( hSetBuffering, stdout, BufferMode(..) )
 import System.Directory
   ( getCurrentDirectory, doesDirectoryExist, doesFileExist, copyFile
-  , getDirectoryContents )
+  , getDirectoryContents, createDirectoryIfMissing )
 import System.FilePath
   ( (</>), (<.>), takeBaseName )
 import Data.Time
@@ -45,7 +45,7 @@ import Data.Traversable
 import Control.Applicative
   ( (<$>) )
 import Control.Monad
-  ( when, unless, (>=>), join )
+  ( when, unless, (>=>), join, forM_ )
 import Control.Arrow
   ( (&&&), (***) )
 
@@ -107,6 +107,7 @@ initCabal verbosity packageDBs comp conf initFlags = do
 
   writeLicense initFlags'
   writeSetupFile initFlags'
+  createSourceDirectories initFlags'
   success <- writeCabalFile initFlags'
 
   when success $ generateWarnings initFlags'
@@ -639,6 +640,12 @@ writeFileSafe :: InitFlags -> FilePath -> String -> IO ()
 writeFileSafe flags fileName content = do
   moveExistingFile flags fileName
   writeFile fileName content
+
+-- | Create source directories, if they were given.
+createSourceDirectories :: InitFlags -> IO ()
+createSourceDirectories flags = case sourceDirs flags of
+                                  Just dirs -> forM_ dirs (createDirectoryIfMissing True)
+                                  Nothing   -> return ()
 
 -- | Move an existing file, if there is one, and the overwrite flag is
 --   not set.


### PR DESCRIPTION
From #1967.
- `hs-source-dirs` will be asked at last of interactive prompt, and the answer will be added to `.cabal`
- Default is `none`, which doesn't add `hs-source-dirs`
- Won't ask source directory if `src` exists.

@byorgey Thanks for pointing out where to start! Could you review this?

Example:

```
$ cabal init
...
Source directory:
 * 1) (none)
   2) src
   3) Other (specify)
Your choice? [default: (none)] 2

Guessing dependencies...

Generating LICENSE...
Warning: unknown license type, you must put a copy in LICENSE yourself.
Generating Setup.hs...
Generating sample.cabal...

Warning: no synopsis given. You should edit the .cabal file and add one.
You may want to edit the .cabal file and add a Description field.
```

This will generate `src` directory:

```
$ tree .
.
├── Setup.hs
├── sample.cabal
└── src
```

And add `hs-source-dirs`:

```
$ cat sample.cabal
-- Initial sample.cabal generated by cabal init.  For further 
-- documentation, see http://haskell.org/cabal/users-guide/

name:                sample
version:             0.1.0.0
-- synopsis:            
-- description:         
-- license:             
license-file:        LICENSE
author:              Fujimura Daisuke
maintainer:          me@fujimuradaisuke.com
-- copyright:           
-- category:            
build-type:          Simple
-- extra-source-files:  
cabal-version:       >=1.10

library
  -- exposed-modules:     
  -- other-modules:       
  -- other-extensions:    
  build-depends:       base >=4.7 && <4.8
  hs-source-dirs:      src
  default-language:    Haskell2010
```
