### PR TITLE
Self-constraint not included in frozen constraints

### DIFF
--- a/cabal-install/tests/PackageTests/Freeze/Check.hs
+++ b/cabal-install/tests/PackageTests/Freeze/Check.hs
@@ -52,6 +52,14 @@ tests cabalPath =
           assertBool ("should not have frozen exceptions\n" ++ c) $ not $
               " exceptions ==" `isInfixOf` (intercalate " " $ lines $ c)
 
+    , testCase "does not include a constraint for the package being frozen" $ do
+          removeCabalConfig
+          result <- cabal_freeze dir [] cabalPath
+          assertFreezeSucceeded result
+          c <- readCabalConfig
+          assertBool ("should not have frozen self\n" ++ c) $ not $
+              " my ==" `isInfixOf` (intercalate " " $ lines $ c)
+
     , testCase "--dry-run does not modify the cabal.config file" $ do
           removeCabalConfig
           result <- cabal_freeze dir ["--dry-run"] cabalPath


### PR DESCRIPTION
`cabal freeze` no longer includes a constraint for the package being frozen. Fixes #1908.
