### PR TITLE
Better message when new cabal-install available

### DIFF
--- a/cabal-install/Distribution/Client/Update.hs
+++ b/cabal-install/Distribution/Client/Update.hs
@@ -83,10 +83,10 @@ checkForSelfUpgrade verbosity repos = do
         ]
 
   unless (null laterPreferredVersions) $ mapM_ (notice verbosity)
-    [ "Note: I am not the latest version of cabal-install."
-    , "These versions are available and are newer than me: "
-      ++ (intercalate ", " . map showVersion) laterPreferredVersions
-    , "My version is: " ++ showVersion currentVersion
+    [ "Note: You are not currently running the latest version of cabal-install."
+    , "The currently running version is: " ++ showVersion currentVersion
+    , "These available versions are newer: "
+      ++ (intercalate ", " . map showVersion) laterPreferredVersion
     , "If you have already installed a newer version, and intended "
-      ++ "to run it, maybe check your $PATH variable?"
+      ++ "to run it, maybe check your PATH environment variable?"
     ]


### PR DESCRIPTION
A common mistake new users of cabal-install seem to make is to run
`cabal update`, see the message "Note: there is a new version of
cabal-install available.", accordingly install a new version of
cabal-install by doing `cabal install cabal-install`, neglect to make
sure that the newly installed cabal-install executable is in their path,
and continue to run the cabal-install executable they had before.  The
next time they do `cabal update`, they see the same message and become
confused.

This commit changes the message in question to be more informative and
helpful.  In particular, if the currently running version of
cabal-install is older than the newest version available from hackage,
the user will not be told simply that "there is a new version of
cabal-install available", but rather will be informed exactly what new
versions are available, and what version they are currently running,
along with a hint to change their $PATH variable if it turns out they're
not running the version of cabal-install they thought they were.
