### PR TITLE
Read .cabal file as UTF-8

### DIFF
--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -116,7 +116,7 @@ import qualified Distribution.Simple.Setup as Cabal
          , testCommand, TestFlags(..), emptyTestFlags )
 import Distribution.Simple.Utils
          ( createDirectoryIfMissingVerbose, rawSystemExit, comparing
-         , writeFileAtomic, withTempFile , withFileContents )
+         , writeFileAtomic, withTempFile , withUTF8FileContents )
 import Distribution.Simple.InstallDirs as InstallDirs
          ( PathTemplate, fromPathTemplate, toPathTemplate, substPathTemplate
          , initialPathTemplateEnv, installDirsTemplateEnv )
@@ -1350,7 +1350,7 @@ installUnpackedPackage verbosity buildLimit installLock numJobs
                 Cabal.regGenPkgConf = toFlag (Just pkgConfFile)
               }
           setup Cabal.registerCommand registerFlags' mLogPath
-          withFileContents pkgConfFile $ \pkgConfText ->
+          withUTF8FileContents pkgConfFile $ \pkgConfText ->
             case Installed.parseInstalledPackageInfo pkgConfText of
               Installed.ParseFailed perror    -> pkgConfParseFailed perror
               Installed.ParseOk warns pkgConf -> do


### PR DESCRIPTION
https://github.com/haskell/cabal/issues/1883 Accoring to users guide .cabal file must be writting in UTF-8.
http://www.haskell.org/cabal/users-guide/developing-packages.html#package-descriptions
