### PR TITLE
Weaken dependency on process.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -131,7 +131,7 @@ library
     deepseq    >= 1.3 && < 1.4,
     filepath   >= 1   && < 1.4,
     directory  >= 1   && < 1.3,
-    process    >= 1.2 && < 1.3,
+    process    >= 1.1.0.1 && < 1.3,
     time       >= 1.1 && < 1.5,
     containers >= 0.1 && < 0.6,
     array      >= 0.1 && < 0.6,

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -379,10 +379,12 @@ rawSystemExitWithEnv verbosity path args env = do
     hFlush stdout
     (_,_,_,ph) <- createProcess $
                   (Process.proc path args) { Process.env = (Just env)
-#ifndef BOOTSTRAPPING
+#ifdef MIN_VERSION_process
+#if MIN_VERSION_process(1,2,0)
 -- delegate_ctlc has been added in process 1.2, and we still want to be able to
 -- bootstrap GHC on systems not having that version
                                            , Process.delegate_ctlc = True
+#endif
 #endif
                                            }
     exitcode <- waitForProcess ph
@@ -410,10 +412,12 @@ rawSystemIOWithEnv verbosity path args mcwd menv inp out err = do
                                            , Process.std_in        = mbToStd inp
                                            , Process.std_out       = mbToStd out
                                            , Process.std_err       = mbToStd err
-#ifndef BOOTSTRAPPING
+#ifdef MIN_VERSION_process
+#if MIN_VERSION_process(1,2,0)
 -- delegate_ctlc has been added in process 1.2, and we still want to be able to
 -- bootstrap GHC on systems not having that version
                                            , Process.delegate_ctlc = True
+#endif
 #endif
                                            }
     exitcode <- waitForProcess ph


### PR DESCRIPTION
See #1763

GHC 7.6 still distributes by default with an old version of process, which
means that requiring the most recent version prevents GHC from properly
bootstrapping out of the box.  In this patch, we relax the version requirement
on process, disabling proper ctl-c handling when the version is not sufficiently
new.

Perhaps one problem with lowering the bound, is if someone attempts to install
Cabal out of the box on GHC 7.6, the dependency solver will prefer the old
installed version, so it is very easy to end up with a cabal-install which
doesn't have working ctl-c.

Signed-off-by: Edward Z. Yang ezyang@cs.stanford.edu
