### PR TITLE
fix `sdist' tar invocation to be compatible with Solaris' tar

### DIFF
--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -417,7 +417,7 @@ createArchive verbosity pkg_descr mb_lbi tmpDir targetPref = do
    -- sequences to set up the paths correctly, which is problematic in a Windows
    -- setting.]
   rawSystemProgram verbosity tarProg
-           ["-C", tmpDir, "-czf", tarBallFilePath, tarBallName pkg_descr]
+           ["-czf", tarBallFilePath, "-C", tmpDir, tarBallName pkg_descr]
   return tarBallFilePath
 
 -- | Given a buildinfo, return the names of all source files.


### PR DESCRIPTION
This patch just changes an order of tar parameters. Solaris' tar likes to have -C <dir> after -czf <tarbal>. GNU tar is OK with this too so there is no reason not to change this to be more compatible.
