### PR TITLE
Support module thinning and renaming Cabal-side.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -290,6 +290,7 @@ test-suite package-tests
   build-depends:
     base,
     binary     >= 0.7 && < 0.8,
+    containers,
     test-framework,
     test-framework-quickcheck2 >= 0.2.12,
     test-framework-hunit,

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -45,6 +45,7 @@ module Distribution.Simple.Compiler (
         unsupportedExtensions,
         parmakeSupported,
         reexportedModulesSupported,
+        renamingPackageFlagsSupported,
         packageKeySupported
   ) where
 
@@ -206,6 +207,10 @@ parmakeSupported = ghcSupported "Support parallel --make"
 -- | Does this compiler support reexported-modules?
 reexportedModulesSupported :: Compiler -> Bool
 reexportedModulesSupported = ghcSupported "Support reexported-modules"
+
+-- | Does this compiler support thinning/renaming on package flags?
+renamingPackageFlagsSupported :: Compiler -> Bool
+renamingPackageFlagsSupported = ghcSupported "Support thinning and renaming package flags"
 
 -- | Does this compiler support package keys?
 packageKeySupported :: Compiler -> Bool

--- a/Cabal/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Simple/LocalBuildInfo.hs
@@ -65,11 +65,12 @@ import Distribution.Simple.Program (ProgramConfiguration)
 import Distribution.PackageDescription
          ( PackageDescription(..), withLib, Library(libBuildInfo), withExe
          , Executable(exeName, buildInfo), withTest, TestSuite(..)
-         , BuildInfo(buildable), Benchmark(..) )
+         , BuildInfo(buildable), Benchmark(..), ModuleRenaming(..) )
 import qualified Distribution.InstalledPackageInfo as Installed
     ( ModuleReexport(..) )
 import Distribution.Package
-         ( PackageId, Package(..), InstalledPackageId(..), PackageKey )
+         ( PackageId, Package(..), InstalledPackageId(..), PackageKey
+         , PackageName )
 import Distribution.Simple.Compiler
          ( Compiler(..), PackageDBStack, OptimisationLevel )
 import Distribution.Simple.PackageIndex
@@ -88,6 +89,7 @@ import Data.List (nub, find)
 import Data.Maybe
 import Data.Tree  (flatten)
 import GHC.Generics (Generic)
+import Data.Map (Map)
 
 -- | Data cached after configuration step.  See also
 -- 'Distribution.Simple.Setup.ConfigFlags'.
@@ -193,17 +195,21 @@ data ComponentLocalBuildInfo
     -- satisfied in terms of version ranges. This field fixes those dependencies
     -- to the specific versions available on this machine for this compiler.
     componentPackageDeps :: [(InstalledPackageId, PackageId)],
-    componentLibraries   :: [LibraryName],
-    componentModuleReexports :: [Installed.ModuleReexport]
+    componentModuleReexports :: [Installed.ModuleReexport],
+    componentPackageRenaming :: Map PackageName ModuleRenaming,
+    componentLibraries :: [LibraryName]
   }
   | ExeComponentLocalBuildInfo {
-    componentPackageDeps :: [(InstalledPackageId, PackageId)]
+    componentPackageDeps :: [(InstalledPackageId, PackageId)],
+    componentPackageRenaming :: Map PackageName ModuleRenaming
   }
   | TestComponentLocalBuildInfo {
-    componentPackageDeps :: [(InstalledPackageId, PackageId)]
+    componentPackageDeps :: [(InstalledPackageId, PackageId)],
+    componentPackageRenaming :: Map PackageName ModuleRenaming
   }
   | BenchComponentLocalBuildInfo {
-    componentPackageDeps :: [(InstalledPackageId, PackageId)]
+    componentPackageDeps :: [(InstalledPackageId, PackageId)],
+    componentPackageRenaming :: Map PackageName ModuleRenaming
   }
   deriving (Generic, Read, Show)
 

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -12,6 +12,7 @@ module Distribution.Simple.Program.GHC (
   ) where
 
 import Distribution.Package
+import Distribution.PackageDescription hiding (Flag)
 import Distribution.ModuleName
 import Distribution.Simple.Compiler hiding (Flag)
 import Distribution.Simple.Setup    ( Flag(..), flagToMaybe, fromFlagOrDefault,
@@ -76,7 +77,7 @@ data GhcOptions = GhcOptions {
   -- | The GHC packages to use. For compatability with old and new ghc, this
   -- requires both the short and long form of the package id;
   -- the @ghc -package@ or @ghc -package-id@ flags.
-  ghcOptPackages      :: [(InstalledPackageId, PackageId)],
+  ghcOptPackages      :: [(InstalledPackageId, PackageId, ModuleRenaming)],
 
   -- | Start with a clean package set; the @ghc -hide-all-packages@ flag
   ghcOptHideAllPackages :: Flag Bool,
@@ -339,8 +340,10 @@ renderGhcOptions comp opts
   , packageDbArgs version (flags ghcOptPackageDBs)
 
   , concat $ if ver >= [6,11]
-      then [ ["-package-id", display ipkgid] | (ipkgid,_) <- flags ghcOptPackages ]
-      else [ ["-package",    display  pkgid] | (_,pkgid)  <- flags ghcOptPackages ]
+      then let space "" = ""
+               space xs = ' ' : xs
+           in [ ["-package-id", display ipkgid ++ space (display rns)] | (ipkgid,_,rns) <- flags ghcOptPackages ]
+      else [ ["-package",    display  pkgid] | (_,pkgid,_)  <- flags ghcOptPackages ]
 
   ----------------------------
   -- Language and extensions

--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -1294,6 +1294,23 @@ values for these fields.
 
     It is only syntactic sugar. It is exactly equivalent to `foo >= 1.2 && < 1.3`.
 
+    With Cabal 1.20 and GHC 7.10, `build-depends` also supports module
+    thinning and renaming, which allows you to selectively decide what
+    modules become visible from a package dependency.  For example:
+
+    ~~~~~~~~~~~~~~~~
+    build-depends: containers (Data.Set, Data.IntMap as Map)
+    ~~~~~~~~~~~~~~~~
+
+    This results in only the modules `Data.Set` and `Map` being visible to
+    the user from containers, hiding all other modules.  To add additional
+    names for modules without hiding the others, you can use the `with`
+    keyword:
+
+    ~~~~~~~~~~~~~~~~
+    build-depends: containers with (Data.IntMap as Map)
+    ~~~~~~~~~~~~~~~~
+
     Note: Prior to Cabal 1.8, build-depends specified in each section
     were global to all sections. This was unintentional, but some packages
     were written to depend on it, so if you need your build-depends to

--- a/Cabal/tests/PackageTests/BenchmarkStanza/Check.hs
+++ b/Cabal/tests/PackageTests/BenchmarkStanza/Check.hs
@@ -2,6 +2,7 @@ module PackageTests.BenchmarkStanza.Check where
 
 import Test.HUnit
 import System.FilePath
+import qualified Data.Map as Map
 import PackageTests.PackageTester
 import Distribution.Version
 import Distribution.PackageDescription.Parse
@@ -14,7 +15,7 @@ import Distribution.PackageDescription
         ( PackageDescription(..), BuildInfo(..), Benchmark(..)
         , BenchmarkInterface(..)
         , emptyBuildInfo
-        , emptyBenchmark )
+        , emptyBenchmark, defaultRenaming )
 import Distribution.Verbosity (silent)
 import Distribution.System (buildPlatform)
 import Distribution.Compiler
@@ -36,6 +37,8 @@ suite ghcPath = TestCase $ do
             , benchmarkBuildInfo = emptyBuildInfo
                     { targetBuildDepends =
                             [ Dependency (PackageName "base") anyVersion ]
+                    , targetBuildRenaming =
+                            Map.singleton (PackageName "base") defaultRenaming
                     , hsSourceDirs = ["."]
                     }
             , benchmarkEnabled = False

--- a/Cabal/tests/PackageTests/TestStanza/Check.hs
+++ b/Cabal/tests/PackageTests/TestStanza/Check.hs
@@ -2,6 +2,7 @@ module PackageTests.TestStanza.Check where
 
 import Test.HUnit
 import System.FilePath
+import qualified  Data.Map as Map
 import PackageTests.PackageTester
 import Distribution.Version
 import Distribution.PackageDescription.Parse (readPackageDescription)
@@ -10,7 +11,8 @@ import Distribution.PackageDescription.Configuration
 import Distribution.Package (PackageName(..), Dependency(..))
 import Distribution.PackageDescription
     ( PackageDescription(..), BuildInfo(..), TestSuite(..)
-    , TestSuiteInterface(..), emptyBuildInfo, emptyTestSuite)
+    , TestSuiteInterface(..), emptyBuildInfo, emptyTestSuite
+    , defaultRenaming)
 import Distribution.Verbosity (silent)
 import Distribution.System (buildPlatform)
 import Distribution.Compiler (CompilerId(..), CompilerFlavor(..))
@@ -31,6 +33,8 @@ suite ghcPath = TestCase $ do
             , testBuildInfo = emptyBuildInfo
                     { targetBuildDepends =
                             [ Dependency (PackageName "base") anyVersion ]
+                    , targetBuildRenaming =
+                            Map.singleton (PackageName "base") defaultRenaming
                     , hsSourceDirs = ["."]
                     }
             , testEnabled = False

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -34,7 +34,7 @@ import Distribution.Package
 import Distribution.PackageDescription
          ( GenericPackageDescription(packageDescription)
          , PackageDescription(..), specVersion
-         , BuildType(..), knownBuildTypes )
+         , BuildType(..), knownBuildTypes, defaultRenaming )
 import Distribution.PackageDescription.Parse
          ( readPackageDescription )
 import Distribution.Simple.Configure
@@ -461,7 +461,7 @@ externalSetupMethod verbosity options pkg bt mkargs = do
             , ghcOptSourcePath      = [workingDir]
             , ghcOptPackageDBs      = usePackageDB options''
             , ghcOptPackages        = maybe []
-                                      (\ipkgid -> [(ipkgid, cabalPkgid)])
+                                      (\ipkgid -> [(ipkgid, cabalPkgid, defaultRenaming)])
                                       maybeCabalLibInstalledPkgId
             , ghcOptExtra           = ["-threaded"]
             }


### PR DESCRIPTION
NB: unlike GHC, Cabal will still try to find a globally consistent choice for
all package names, i.e. this does _not_ implement private dependencies.

Signed-off-by: Edward Z. Yang ezyang@cs.stanford.edu
