### PR TITLE
error if the config file is invalid

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -77,7 +77,7 @@ import Distribution.Simple.Command
 import Distribution.Simple.Program
          ( defaultProgramConfiguration )
 import Distribution.Simple.Utils
-         ( notice, warn, lowercase )
+         ( die, notice, warn, lowercase )
 import Distribution.Compiler
          ( CompilerFlavor(..), defaultCompilerFlavor )
 import Distribution.Verbosity
@@ -303,7 +303,7 @@ loadConfig verbosity configFileFlag userInstallFlag = addBaseConf $ do
       return conf
     Just (ParseFailed err) -> do
       let (line, msg) = locatedErrorMsg err
-      error $
+      die $
           "Error parsing config file " ++ configFile
         ++ maybe "" (\n -> ':' : show n) line ++ ":\n" ++ msg
 


### PR DESCRIPTION
This stops surprising the developer when their config file is ignored due to a typo.

Is there a preferred function over `error`?
