### PR TITLE
reword help text in allow-newer

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -352,14 +352,14 @@ configureExOptions _showOrParseArgs =
   , optionSolver configSolver (\v flags -> flags { configSolver = v })
 
   , option [] ["allow-newer"]
-    ("Ignore upper bounds on all packages or " ++ allowNewerArgument)
+    ("Ignore upper bounds in all dependencies or " ++ allowNewerArgument)
     configAllowNewer (\v flags -> flags { configAllowNewer = v})
     (optArg allowNewerArgument
      (fmap Flag allowNewerParser) (Flag AllowNewerAll)
      allowNewerPrinter)
 
   ]
-  where allowNewerArgument = "PKGS"
+  where allowNewerArgument = "DEPS"
 
 instance Monoid ConfigExFlags where
   mempty = ConfigExFlags {


### PR DESCRIPTION
"Ignore upper bounds in dependencies on some or all packages." -> "Ignore upper bounds on all packages or PKGS"

The latter is more clear and succinct.
