### PR TITLE
Accommodate network/network-uri split

### DIFF
--- a/cabal-install/Distribution/Client/BuildReports/Upload.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Upload.hs
@@ -51,10 +51,14 @@ postBuildReport uri buildReport = do
   }
   case rspCode response of
     (3,0,3) | [Just buildId] <- [ do rel <- parseRelativeReference location
+#if defined(VERSION_network_uri)
+                                     return $ relativeTo rel uri
+#elif defined(VERSION_network)
 #if MIN_VERSION_network(2,4,0)
                                      return $ relativeTo rel uri
 #else
                                      relativeTo rel uri
+#endif
 #endif
                                   | Header HdrLocation location <- rspHeaders response ]
               -> return $ buildId

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -38,6 +38,10 @@ Flag old-directory
   description:  Use directory < 1.2 and old-time
   default:      False
 
+Flag network-uri
+  description:  Get Network.URI from the network-uri package
+  default:      True
+
 executable cabal
     main-is:        Main.hs
     ghc-options:    -Wall -fwarn-tabs
@@ -130,7 +134,6 @@ executable cabal
         filepath   >= 1.0      && < 1.4,
         HTTP       >= 4000.2.5 && < 4000.3,
         mtl        >= 2.0      && < 3,
-        network    >= 2.0      && < 2.6,
         pretty     >= 1        && < 1.2,
         random     >= 1        && < 1.1,
         stm        >= 2.0      && < 3,
@@ -143,6 +146,11 @@ executable cabal
     else
       build-depends: directory >= 1.2 && < 1.3,
                      process   >= 1.1.0.2  && < 1.3
+
+    if flag(network-uri)
+      build-depends: network-uri >= 2.6
+    else
+      build-depends: network     >= 2.0 && < 2.6
 
     if os(windows)
       build-depends: Win32 >= 2 && < 3


### PR DESCRIPTION
This adds the necessary flags and CPP logic to allow `cabal-install` to use the `network-uri` package (since it was split off recently from `network`). I suppose this would be a temporary workaround to allow `cabal-install` to build until issue #2033 is resolved.

The one thing I'm not quite happy about with this commit is the CPP macro logic that `Distribution.Client.BuildReports.Upload` uses to check if `network-uri` or `network` (and if the latter, which version) is installed. I wanted to do something like this:

``` haskell
#if defined(VERSION_network_uri) || MIN_VERSION_network(2,4,0)
    return $ relativeTo rel uri
#else
    relativeTo rel uri
#endif
```

But that won't work, since if `network-uri` is installed, then `MIN_VERSION_network` won't be defined in `cabal_macros.h`, causing the build to fail with `error: missing binary operator before token "("`. The workaround I used was:

``` haskell
#if defined(VERSION_network_uri)
    return $ relativeTo rel uri
#elif defined(VERSION_network)
#if MIN_VERSION_network(2,4,0)
    return $ relativeTo rel uri
#else
    relativeTo rel uri
#endif
#endif
```

but I feel like this could be made cleaner with some CPP wizardry.
