### PR TITLE
Remove build-depends from pkgDescrFieldDescrs

### DIFF
--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -123,9 +123,6 @@ pkgDescrFieldDescrs =
  , simpleField "maintainer"
            showFreeText           parseFreeText
            maintainer             (\val pkg -> pkg{maintainer=val})
- , commaListFieldWithSep vcat "build-depends"
-           disp                   parse
-           buildDepends           (\xs    pkg -> pkg{buildDepends=xs})
  , simpleField "stability"
            showFreeText           parseFreeText
            stability              (\val pkg -> pkg{stability=val})


### PR DESCRIPTION
Remove the build-depends field from the top-level parser of Cabal files.

Why do I think this is OK? Two reasons:
1. We never consult buildDepends until after `Distribution/PackageDescription/Configuration.hs` runs, in which case the contents of the field get overwritten with the true dependency picks. We do consult the field for some package syntax checks but as I argue in https://github.com/haskell/cabal/issues/2065 this the wrong place to try to do the check.
2. The `build-depends` field already gets lifted up by special case code in `sectionizeFields` to propagate it to the stanzas, which is the _true_ codepath how we account for these build-depends.

Duncan would feel better if we ran this modification on Hackage to make sure it's good. But based on code reading and light testing, I think it's right.

Signed-off-by: Edward Z. Yang ezyang@cs.stanford.edu
