### PR TITLE
Generate object files for older versions of GHC

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -572,6 +572,20 @@ configure (pkg_descr0, pbi) cfg
                                           "--enable-split-objs; ignoring")
                                     return False
 
+        let ghciLibByDefault =
+              case compilerId comp of
+                CompilerId GHC _ ->
+                  -- If ghc is non-dynamic, then ghci needs object files,
+                  -- so we build one by default.
+                  -- 
+                  -- Technically, archive files should be sufficient for ghci,
+                  -- but because of GHC bug #8942, it has never been safe to
+                  -- rely on them. By the time that bug was fixed, ghci had
+                  -- been changed to read shared libraries instead of archive
+                  -- files (see next code block).
+                  not (GHC.ghcDynamic comp)
+                _ -> False
+
         let sharedLibsByDefault =
               case compilerId comp of
                 CompilerId GHC _ ->
@@ -605,7 +619,8 @@ configure (pkg_descr0, pbi) cfg
                     withDynExe          = fromFlag $ configDynExe cfg,
                     withProfExe         = fromFlag $ configProfExe cfg,
                     withOptimization    = fromFlag $ configOptimization cfg,
-                    withGHCiLib         = fromFlag $ configGHCiLib cfg,
+                    withGHCiLib         = fromFlagOrDefault ghciLibByDefault $
+                                          configGHCiLib cfg,
                     splitObjs           = split_objs,
                     stripExes           = fromFlag $ configStripExes cfg,
                     stripLibs           = fromFlag $ configStripLibs cfg,

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -333,7 +333,7 @@ defaultConfigFlags progConf = emptyConfigFlags {
     -- See #1589.
     configGHCiLib      = Flag True,
 #else
-    configGHCiLib      = Flag False,
+    configGHCiLib      = NoFlag,
 #endif
     configSplitObjs    = Flag False, -- takes longer, so turn off by default
     configStripExes    = Flag True,


### PR DESCRIPTION
This works around [GHC bug #8942](https://ghc.haskell.org/trac/ghc/ticket/8942), for the versions of GHC which are affected by this bug.

Basically, ghci has been able to read .a files for a while, but under certain circumstances the .a file is read twice, causing ghci to exit with an error message. The workaround is to also generate .o files, like cabal 1.16 was doing.

Starting from GHC 7.8, ghci now requires .so files instead of .o or .a files. For those versions of GHC, the workaround is not needed, so we continue to skip .o files, like cabal 1.18 and above are doing.
