### PR TITLE
System.Win32.DLL import seems redunant

### DIFF
--- a/cabal-install/Distribution/Client/Win32SelfUpgrade.hs
+++ b/cabal-install/Distribution/Client/Win32SelfUpgrade.hs
@@ -45,7 +45,6 @@ module Distribution.Client.Win32SelfUpgrade (
 #if mingw32_HOST_OS
 
 import qualified System.Win32 as Win32
-import qualified System.Win32.DLL as Win32
 import System.Win32 (DWORD, BOOL, HANDLE, LPCTSTR)
 import Foreign.Ptr (Ptr, nullPtr)
 import System.Process (runProcess)


### PR DESCRIPTION
```
Distribution\Client\Win32SelfUpgrade.hs:48:1: Warning:
    The qualified import of `System.Win32.DLL' is redundant
      except perhaps to import instances from `System.Win32.DLL'
```
