### PR TITLE
Make the default doc index file path compiler/arch/os-dependent.

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1010,7 +1010,8 @@ defaultInstallFlags = InstallFlags {
     installRunTests        = mempty
   }
   where
-    docIndexFile = toPathTemplate ("$datadir" </> "doc" </> "index.html")
+    docIndexFile = toPathTemplate ("$datadir" </> "doc"
+                                   </> "$arch-$os-$compiler" </> "index.html")
 
 allowNewerParser :: ReadE AllowNewer
 allowNewerParser = ReadE $ \s ->


### PR DESCRIPTION
Fixes #2135.
