### PR TITLE
'support sandboxes' in bootstrap

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
+++ b/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
@@ -218,7 +218,9 @@ sandboxPackageDBPath sandboxDir compiler platform =
          </> (Text.display platform ++ "-"
              ++ showCompilerId compiler
              ++ "-packages.conf.d")
-
+-- The path in sandboxPackageDBPath should be kept in sync with the
+-- path in the bootstrap.sh which is used to bootstrap cabal-install
+-- into a sandbox.
 
 -- | Use the package DB location specific for this compiler.
 setPackageDB :: FilePath -> Compiler -> Platform -> ConfigFlags -> ConfigFlags

--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -44,9 +44,10 @@ GZIP_PROGRAM="${GZIP_PROGRAM:-gzip}"
 # $ SCOPE_OF_INSTALLATION='--package-db=/my/prefix/packages.conf.d' \
 #   PREFIX=/my/prefix ./bootstrap.sh
 #
-# If you use the --global or --user arguments, this will override the
-# SCOPE_OF_INSTALLATION setting and not use a custom package database.
-#
+# If you use the --global,--user or --sandbox arguments, this will
+# override the SCOPE_OF_INSTALLATION setting and not use the package
+# database you pass in the SCOPE_OF_INSTALLATION variable.
+
 SCOPE_OF_INSTALLATION="${SCOPE_OF_INSTALLATION:---user}"
 DEFAULT_PREFIX="${HOME}/.cabal"
 
@@ -106,21 +107,30 @@ GHC_PKG_VER="$(${GHC_PKG} --version | cut -d' ' -f 5)"
   die "Version mismatch between ${GHC} and ${GHC_PKG}.
        If you set the GHC variable then set GHC_PKG too."
 
-for arg in "$@"
-do
-  case "${arg}" in
+while [ "$#" -gt 0 ]; do
+  case "${1}" in
     "--user")
-      SCOPE_OF_INSTALLATION=${arg}
+      SCOPE_OF_INSTALLATION="${1}"
       shift;;
     "--global")
-      SCOPE_OF_INSTALLATION=${arg}
+      SCOPE_OF_INSTALLATION="${1}"
       DEFAULT_PREFIX="/usr/local"
       shift;;
+    "--sandbox")
+      shift
+      # check if there is another argument which doesn't start with --
+      if [ "$#" -le 0 ] || [ ! -z $(echo "${1}" | grep "^--") ]
+      then
+          SANDBOX=".cabal-sandbox"
+      else
+          SANDBOX="${1}"
+          shift
+      fi;;
     "--no-doc")
       NO_DOCUMENTATION=1
       shift;;
     *)
-      echo "Unknown argument or option, quitting: ${arg}"
+      echo "Unknown argument or option, quitting: ${1}"
       echo "usage: bootstrap.sh [OPTION]"
       echo
       echo "options:"
@@ -130,6 +140,29 @@ do
       exit;;
   esac
 done
+
+abspath () { case "$1" in /*)printf "%s\n" "$1";; *)printf "%s\n" "$PWD/$1";;
+             esac; }
+
+if [ ! -z "$SANDBOX" ]
+then # set up variables for sandbox bootstrap
+  # Make the sandbox path absolute since it will be used from
+  # different working directories when the dependency packages are
+  # installed.
+  SANDBOX=$(abspath "$SANDBOX")
+  # Get the name of the package database which cabal sandbox would use.
+  GHC_ARCH=$(ghc --info |
+    sed -n 's/.*"Target platform".*"\([^-]\+\)-[^-]\+-\([^"]\+\)".*/\1-\2/p')
+  PACKAGEDB="$SANDBOX/${GHC_ARCH}-ghc-${GHC_VER}-packages.conf.d"
+  # Assume that if the directory is already there, it is already a
+  # package database. We will get an error immediately below if it
+  # isn't. Uses -r to try to be compatible with Solaris, and allow
+  # symlinks as well as a normal dir/file.
+  [ ! -r "$PACKAGEDB" ] && ghc-pkg init "$PACKAGEDB"
+  PREFIX="$SANDBOX"
+  SCOPE_OF_INSTALLATION="--package-db=$PACKAGEDB"
+  echo Bootstrapping in sandbox at \'$SANDBOX\'.
+fi
 
 # Check for haddock unless no documentation should be generated.
 if [ ! ${NO_DOCUMENTATION} ]
@@ -322,6 +355,12 @@ do_pkg   "random"       ${RANDOM_VER}  ${RANDOM_VER_REGEXP}
 do_pkg   "stm"          ${STM_VER}     ${STM_VER_REGEXP}
 
 install_pkg "cabal-install"
+
+# Use the newly built cabal to turn the prefix/package database into a
+# legit cabal sandbox. This works because 'cabal sandbox init' will
+# reuse the already existing package database and other files if they
+# are in the expected locations.
+[ ! -z "$SANDBOX" ] && $SANDBOX/bin/cabal sandbox init --sandbox $SANDBOX
 
 echo
 echo "==========================================="


### PR DESCRIPTION
This code adds `--default-sandbox` and `--sandbox path` to the bootstrap.sh. This effectively makes it look like cabal-install has been built in a sandbox when bootstrap.sh completes.

I am a bit unsure about the logic in the SandboxPkgDbName.hs file which tries to work out what the name cabal sandbox will use for the package database directory.

It also changes the check for already downloaded tarballs to allow symlinks also. I can split this into a separate request if you want.
