### PR TITLE
Add license type UnspecifiedLicense.

### DIFF
--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -156,7 +156,7 @@ emptyInstalledPackageInfo
         sourcePackageId    = PackageIdentifier (PackageName "") noVersion,
         packageKey         = OldPackageKey (PackageIdentifier
                                                (PackageName "") noVersion),
-        license           = AllRightsReserved,
+        license           = UnspecifiedLicense,
         copyright         = "",
         maintainer        = "",
         author            = "",

--- a/Cabal/Distribution/License.hs
+++ b/Cabal/Distribution/License.hs
@@ -105,9 +105,15 @@ data License =
     -- jurisdiction necessarily in the public domain elsewhere.
   | PublicDomain
 
-    -- | No license. The package may not be legally modified or redistributed by
-    -- anyone but the rightsholder.
+    -- | Explicitly 'All Rights Reserved', eg for proprietary software. The
+    -- package may not be legally modified or redistributed by anyone but the
+    -- rightsholder.
   | AllRightsReserved
+
+    -- | No license specified which legally defaults to 'All Rights Reserved'.
+    -- The package may not be legally modified or redistributed by anyone but
+    -- the rightsholder.
+  | UnspecifiedLicense
 
     -- | Any other software license.
   | OtherLicense

--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -125,7 +125,7 @@ import Distribution.ModuleName ( ModuleName )
 import Distribution.Version
          ( Version(Version), VersionRange, anyVersion, orLaterVersion
          , asVersionIntervals, LowerBound(..) )
-import Distribution.License  (License(AllRightsReserved))
+import Distribution.License  (License(UnspecifiedLicense))
 import Distribution.Compiler (CompilerFlavor)
 import Distribution.System   (OS, Arch)
 import Distribution.Text
@@ -230,7 +230,7 @@ emptyPackageDescription
     =  PackageDescription {
                       package      = PackageIdentifier (PackageName "")
                                                        (Version [] []),
-                      license      = AllRightsReserved,
+                      license      = UnspecifiedLicense,
                       licenseFiles = [],
                       specVersionRaw = Right anyVersion,
                       buildType    = Nothing,

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -475,10 +475,13 @@ checkLicense :: PackageDescription -> [PackageCheck]
 checkLicense pkg =
   catMaybes [
 
-    check (license pkg == AllRightsReserved) $
+    check (license pkg == UnspecifiedLicense) $
       PackageDistInexcusable
-        "The 'license' field is missing or specified as AllRightsReserved."
+        "The 'license' field is missing."
 
+  , check (license pkg == AllRightsReserved) $
+      PackageDistSuspicious
+        "The 'license' is AllRightsReserved. Is that really what you want?"
   , case license pkg of
       UnknownLicense l -> Just $
         PackageBuildWarning $
@@ -503,8 +506,9 @@ checkLicense pkg =
           ++ "version then please file a ticket."
       _ -> Nothing
 
-  , check (license pkg `notElem` [AllRightsReserved, PublicDomain]
-           -- AllRightsReserved and PublicDomain are not strictly
+  , check (license pkg `notElem` [ AllRightsReserved
+                                 , UnspecifiedLicense, PublicDomain]
+           -- *AllRightsReserved and PublicDomain are not strictly
            -- licenses so don't need license files.
         && null (licenseFiles pkg)) $
       PackageDistSuspicious "A 'license-file' is not specified."
@@ -1119,7 +1123,8 @@ checkCabalVersion pkg =
         intersectVersionRanges unionVersionRanges id
 
     compatLicenses = [ GPL Nothing, LGPL Nothing, AGPL Nothing, BSD3, BSD4
-                     , PublicDomain, AllRightsReserved, OtherLicense ]
+                     , PublicDomain, AllRightsReserved
+                     , UnspecifiedLicense, OtherLicense ]
 
     mentionedExtensions = [ ext | bi <- allBuildInfo pkg
                                 , ext <- allExtensions bi ]


### PR DESCRIPTION
Before this, AllrightsReservered had two separate meanings; the author
explicitly chose this license or not license was specified and therefore
defaults to AllRightsReserved.

The default license when no license is specified is now UnspecifiedLicense.

Closes: #2141
