### PR TITLE
cabal-install: Add command 'cabal user-config diff'.

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -35,6 +35,7 @@ module Distribution.Client.Setup
     , win32SelfUpgradeCommand, Win32SelfUpgradeFlags(..)
     , sandboxCommand, defaultSandboxLocation, SandboxFlags(..)
     , execCommand, ExecFlags(..)
+    , userConfigCommand, UserConfigFlags(..)
 
     , parsePackageArgs
     --TODO: stop exporting these:
@@ -1722,6 +1723,43 @@ instance Monoid ExecFlags where
     execVerbosity = combine execVerbosity
     }
     where combine field = field a `mappend` field b
+
+-- ------------------------------------------------------------
+-- * UserConfig flags
+-- ------------------------------------------------------------
+
+data UserConfigFlags = UserConfigFlags {
+  userConfigVerbosity :: Flag Verbosity
+}
+
+instance Monoid UserConfigFlags where
+  mempty = UserConfigFlags {
+    userConfigVerbosity = toFlag normal
+    }
+  mappend a b = UserConfigFlags {
+    userConfigVerbosity = combine userConfigVerbosity
+    }
+    where combine field = field a `mappend` field b
+
+userConfigCommand :: CommandUI UserConfigFlags
+userConfigCommand = CommandUI {
+  commandName         = "user-config",
+  commandSynopsis     = "Manipulate the user's ~/.cabal/config file.",
+  commandDescription  = Just $ \_ ->
+       "Allows pseudo-diff-ing and updating of the user's ~/.cabal/config "
+    ++ "file. The\ndiff is against what cabal would generate if the user "
+    ++ "config file did not\nexist. The update command overlays the user's "
+    ++ "existing settings over the\ncurrent version of the default settings "
+    ++ "and writes it back to ~/.cabal/config.\n",
+
+  commandUsage        = \ pname ->
+      "Usage: " ++ pname ++ " user-config diff\n"
+   ++ "       " ++ pname ++ " user-config update\n",
+  commandDefaultFlags = mempty,
+  commandOptions      = \ _ -> [
+   optionVerbosity userConfigVerbosity (\v flags -> flags { userConfigVerbosity = v })
+   ]
+  }
 
 -- ------------------------------------------------------------
 -- * GetOpt Utils

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -179,6 +179,7 @@ Test-Suite unit-tests
     UnitTests.Distribution.Client.Targets
     UnitTests.Distribution.Client.Dependency.Modular.PSQ
     UnitTests.Distribution.Client.Sandbox
+    UnitTests.Distribution.Client.UserConfig
   build-depends:
         base,
         array,

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -4,12 +4,15 @@ module Main
 import Test.Framework
 
 import qualified UnitTests.Distribution.Client.Sandbox
+import qualified UnitTests.Distribution.Client.UserConfig
 import qualified UnitTests.Distribution.Client.Targets
 import qualified UnitTests.Distribution.Client.Dependency.Modular.PSQ
 
 tests :: [Test]
 tests = [
-   testGroup "Distribution.Client.Sandbox"
+   testGroup "UnitTests.Distribution.Client.UserConfig"
+       UnitTests.Distribution.Client.UserConfig.tests
+  ,testGroup "Distribution.Client.Sandbox"
        UnitTests.Distribution.Client.Sandbox.tests
   ,testGroup "Distribution.Client.Targets"
        UnitTests.Distribution.Client.Targets.tests

--- a/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
@@ -1,0 +1,101 @@
+module UnitTests.Distribution.Client.UserConfig
+    ( tests
+    ) where
+
+import Control.Exception (bracket)
+import Data.List (sort, nub)
+import Data.Monoid
+import System.Directory (getCurrentDirectory, removeDirectoryRecursive, createDirectoryIfMissing)
+import System.FilePath (takeDirectory)
+
+import Test.Framework as TF (Test)
+import Test.Framework.Providers.HUnit (testCase)
+import Test.HUnit (Assertion, assertBool)
+
+import Distribution.Client.Compat.Environment (lookupEnv, setEnv)
+import Distribution.Client.Config
+import Distribution.Utils.NubList (fromNubList)
+import Distribution.Client.Setup (GlobalFlags (..), InstallFlags (..))
+import Distribution.Simple.Setup (ConfigFlags (..), fromFlag)
+import Distribution.Verbosity (silent)
+
+tests :: [TF.Test]
+tests = [ testCase "nullDiffOnCreate" nullDiffOnCreateTest
+        , testCase "canDetectDifference" canDetectDifference
+        , testCase "canUpdateConfig" canUpdateConfig
+        , testCase "doubleUpdateConfig" doubleUpdateConfig
+        ]
+
+nullDiffOnCreateTest :: Assertion
+nullDiffOnCreateTest = bracketTest . const $ do
+    -- Create a new default config file in our test directory.
+    _ <- loadConfig silent mempty mempty
+    -- Now we read it in and compare it against the default.
+    diff <- userConfigDiff mempty
+    assertBool (unlines $ "Following diff should be empty:" : diff) $ null diff
+
+
+canDetectDifference :: Assertion
+canDetectDifference = bracketTest . const $ do
+    -- Create a new default config file in our test directory.
+    _ <- loadConfig silent mempty mempty
+    cabalFile <- defaultConfigFile
+    appendFile cabalFile "verbose: 0\n"
+    diff <- userConfigDiff mempty
+    assertBool (unlines $ "Should detect a difference:" : diff) $
+        diff == [ "- verbose: 1", "+ verbose: 0" ]
+
+
+canUpdateConfig :: Assertion
+canUpdateConfig = bracketTest . const $ do
+    cabalFile <- defaultConfigFile
+    createDirectoryIfMissing True $ takeDirectory cabalFile
+    -- Write a trivial cabal file.
+    writeFile cabalFile "tests: True\n"
+    -- Update the config file.
+    userConfigUpdate silent mempty
+    -- Load it again.
+    updated <- loadConfig silent mempty mempty
+    assertBool ("Field 'tests' should be True") $
+        fromFlag (configTests $ savedConfigureFlags updated)
+
+
+doubleUpdateConfig :: Assertion
+doubleUpdateConfig = bracketTest . const $ do
+    -- Create a new default config file in our test directory.
+    _ <- loadConfig silent mempty mempty
+    -- Update it.
+    userConfigUpdate silent mempty
+    userConfigUpdate silent mempty
+    -- Load it again.
+    updated <- loadConfig silent mempty mempty
+
+    assertBool ("Field 'remote-repo' doesn't contain duplicates") $
+        listUnique (map show . fromNubList . globalRemoteRepos $ savedGlobalFlags updated)
+    assertBool ("Field 'extra-prog-path' doesn't contain duplicates") $
+        listUnique (map show . fromNubList . configProgramPathExtra $ savedConfigureFlags updated)
+    assertBool ("Field 'build-summary' doesn't contain duplicates") $
+        listUnique (map show . fromNubList . installSummaryFile $ savedInstallFlags updated)
+
+
+listUnique :: Ord a => [a] -> Bool
+listUnique xs =
+    let sorted = sort xs
+    in nub sorted == xs
+
+
+bracketTest :: ((FilePath, FilePath) -> IO ()) -> Assertion
+bracketTest =
+    bracket testSetup testTearDown
+  where
+    testSetup :: IO (FilePath, FilePath)
+    testSetup = do
+        Just oldHome <- lookupEnv "HOME"
+        testdir <- fmap (++ "/test-user-config") getCurrentDirectory
+        setEnv "HOME" testdir
+        return (oldHome, testdir)
+
+    testTearDown :: (FilePath, FilePath) -> IO ()
+    testTearDown (oldHome, testdir) = do
+        setEnv "HOME" oldHome
+        removeDirectoryRecursive testdir


### PR DESCRIPTION
This command prints out a psuedo-diff between the user's `~/.cabal/config` file and what cabal would generate if it did not exist.

Tested with ghc 7.8.3 and 7.4.2. I'm trying to write a unit-test for it, but that's a little 'deep'. Thought I'd get some feedback on this first.
