### PR TITLE
Remove all references to Data.Version.versionTags

### DIFF
--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -157,7 +157,7 @@ emptyInstalledPackageInfo
     }
 
 noVersion :: Version
-noVersion = Version{ versionBranch=[], versionTags=[] }
+noVersion = Version [] []
 
 -- -----------------------------------------------------------------------------
 -- Module re-exports

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -657,7 +657,7 @@ parseOptVersion :: ReadP r Version
 parseOptVersion = parseQuoted ver <++ ver
   where ver :: ReadP r Version
         ver = parse <++ return noVersion
-        noVersion = Version{ versionBranch=[], versionTags=[] }
+        noVersion = Version [] []
 
 parseTestedWithQ :: ReadP r (CompilerFlavor,VersionRange)
 parseTestedWithQ = parseQuoted tw <++ tw

--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -80,7 +80,8 @@ generate pkg_descr lbi =
         "catchIO = Exception.catch\n" ++
         "\n"++
         "\nversion :: Version"++
-        "\nversion = " ++ show (packageVersion pkg_descr)
+        "\nversion = Version " ++ show branch ++ " " ++ show tags
+          where Version branch tags = packageVersion pkg_descr
 
        body
         | absolute =

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -815,8 +815,7 @@ interpretPackageDbFlags userInstall specificDBs =
     extra dbs' (Just db:dbs) = extra (dbs' ++ [db]) dbs
 
 newPackageDepsBehaviourMinVersion :: Version
-newPackageDepsBehaviourMinVersion = Version { versionBranch = [1,7,1],
-                                              versionTags = [] }
+newPackageDepsBehaviourMinVersion = Version [1,7,1] []
 
 -- In older cabal versions, there was only one set of package dependencies for
 -- the whole package. In this version, we can have separate dependencies per

--- a/Cabal/Distribution/Simple/Program/Hpc.hs
+++ b/Cabal/Distribution/Simple/Program/Hpc.hs
@@ -55,7 +55,7 @@ markup hpc hpcVer verbosity tixFile hpcDirs destDir excluded = do
     runProgramInvocation verbosity
       (markupInvocation hpc tixFile hpcDirs' destDir excluded)
   where
-    version07 = Version { versionBranch = [0, 7], versionTags = [] }
+    version07 = Version [0, 7] []
     (passedDirs, droppedDirs) = splitAt 1 hpcDirs
 
 markupInvocation :: ConfiguredProgram

--- a/Cabal/Distribution/Version.hs
+++ b/Cabal/Distribution/Version.hs
@@ -118,7 +118,7 @@ instance Binary Version where
         br <- get
         tags <- get
         return $ Version br tags
-    put v = put (versionBranch v) >> put (versionTags v)
+    put (Version br tags) = put br >> put tags
 
 {-# DEPRECATED AnyVersion "Use 'anyVersion', 'foldVersionRange' or 'asVersionIntervals'" #-}
 {-# DEPRECATED ThisVersion "use 'thisVersion', 'foldVersionRange' or 'asVersionIntervals'" #-}

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -165,7 +165,7 @@ getPackageName flags = do
 --  if possible.
 getVersion :: InitFlags -> IO InitFlags
 getVersion flags = do
-  let v = Just $ Version { versionBranch = [0,1,0,0], versionTags = [] }
+  let v = Just $ Version [0,1,0,0] []
   v' <-     return (flagToMaybe $ version flags)
         ?>> maybePrompt flags (prompt "Package version" v)
         ?>> return v


### PR DESCRIPTION
Data.Version.versionTags will be deprecated in GHC 7.10, see https://ghc.haskell.org/trac/ghc/ticket/2496.

I have a patch ready for GHC, but to let GHC validate without warnings I would need Cabal to not refer to versionTags in the 'autogen/Patch_*.hs' files created during the build (via the functions build ->  initialBuildSteps -> writeAutogenFiles -> generate). Currently it does so by calling show on a Version in Cabal/Distribution/Simple/Build/PathsModule.hs.

Extra: this patch removes all references to versionTags, to let Cabal itself compile without extra deprecation warnings once 7.10 comes out. 
