### PR TITLE
Consolidate exposed-modules and reexported-modules in InstalledPackageInfo

### DIFF
--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -367,7 +367,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
                 { componentPackageDeps = componentPackageDeps clbi
                 , componentPackageRenaming = componentPackageRenaming clbi
                 , componentLibraries = [LibraryName (testName test)]
-                , componentModuleReexports = []
+                , componentExposedModules = [IPI.ExposedModule m Nothing Nothing]
                 }
     pkg = pkg_descr {
             package      = (package pkg_descr) {

--- a/Cabal/Distribution/Simple/GHC/IPI641.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI641.hs
@@ -67,6 +67,7 @@ mkInstalledPackageId = Current.InstalledPackageId . display
 toCurrent :: InstalledPackageInfo -> Current.InstalledPackageInfo
 toCurrent ipi@InstalledPackageInfo{} =
   let pid = convertPackageId (package ipi)
+      mkExposedModule m = Current.ExposedModule m Nothing Nothing
   in Current.InstalledPackageInfo {
     Current.installedPackageId = mkInstalledPackageId (convertPackageId (package ipi)),
     Current.sourcePackageId    = pid,
@@ -82,8 +83,7 @@ toCurrent ipi@InstalledPackageInfo{} =
     Current.description        = description ipi,
     Current.category           = category ipi,
     Current.exposed            = exposed ipi,
-    Current.exposedModules     = map convertModuleName (exposedModules ipi),
-    Current.reexportedModules  = [],
+    Current.exposedModules     = map (mkExposedModule . convertModuleName) (exposedModules ipi),
     Current.hiddenModules      = map convertModuleName (hiddenModules ipi),
     Current.trusted            = Current.trusted Current.emptyInstalledPackageInfo,
     Current.importDirs         = importDirs ipi,

--- a/Cabal/Distribution/Simple/GHC/IPI642.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI642.hs
@@ -102,6 +102,7 @@ convertLicense OtherLicense = Current.OtherLicense
 toCurrent :: InstalledPackageInfo -> Current.InstalledPackageInfo
 toCurrent ipi@InstalledPackageInfo{} =
   let pid = convertPackageId (package ipi)
+      mkExposedModule m = Current.ExposedModule m Nothing Nothing
   in Current.InstalledPackageInfo {
     Current.installedPackageId = mkInstalledPackageId (convertPackageId (package ipi)),
     Current.sourcePackageId    = pid,
@@ -117,8 +118,7 @@ toCurrent ipi@InstalledPackageInfo{} =
     Current.description        = description ipi,
     Current.category           = category ipi,
     Current.exposed            = exposed ipi,
-    Current.exposedModules     = map convertModuleName (exposedModules ipi),
-    Current.reexportedModules  = [],
+    Current.exposedModules     = map (mkExposedModule . convertModuleName) (exposedModules ipi),
     Current.hiddenModules      = map convertModuleName (hiddenModules ipi),
     Current.trusted            = Current.trusted Current.emptyInstalledPackageInfo,
     Current.importDirs         = importDirs ipi,

--- a/Cabal/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Simple/LocalBuildInfo.hs
@@ -67,7 +67,6 @@ import Distribution.PackageDescription
          , Executable(exeName, buildInfo), withTest, TestSuite(..)
          , BuildInfo(buildable), Benchmark(..), ModuleRenaming(..) )
 import qualified Distribution.InstalledPackageInfo as Installed
-    ( ModuleReexport(..) )
 import Distribution.Package
          ( PackageId, Package(..), InstalledPackageId(..), PackageKey
          , PackageName )
@@ -192,7 +191,7 @@ data ComponentLocalBuildInfo
     -- satisfied in terms of version ranges. This field fixes those dependencies
     -- to the specific versions available on this machine for this compiler.
     componentPackageDeps :: [(InstalledPackageId, PackageId)],
-    componentModuleReexports :: [Installed.ModuleReexport],
+    componentExposedModules :: [Installed.ExposedModule],
     componentPackageRenaming :: Map PackageName ModuleRenaming,
     componentLibraries :: [LibraryName]
   }

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -450,9 +450,10 @@ mergePackageInfo versionPref installedPkgs sourcePkgs selectedPkg showVer =
     hasExe       = fromMaybe False
                    (fmap (not . null . Source.condExecutables) sourceGeneric),
     executables  = map fst (maybe [] Source.condExecutables sourceGeneric),
-    modules      = combine Installed.exposedModules installed
-                           (maybe [] Source.exposedModules
-                                   . Source.library) source,
+    modules      = combine (map Installed.exposedName . Installed.exposedModules)
+                           installed
+                           (maybe [] getListOfExposedModules . Source.library)
+                           source,
     dependencies =
       combine (map (SourceDependency . simplifyDependency)
                . Source.buildDepends) source
@@ -466,6 +467,10 @@ mergePackageInfo versionPref installedPkgs sourcePkgs selectedPkg showVer =
     combine f x g y  = fromJust (fmap f x `mplus` fmap g y)
     installed :: Maybe Installed.InstalledPackageInfo
     installed = latestWithPref versionPref installedPkgs
+
+    getListOfExposedModules lib = Source.exposedModules lib
+                               ++ map Source.moduleReexportName
+                                      (Source.reexportedModules lib)
 
     sourceSelected
       | isJust selectedPkg = selectedPkg


### PR DESCRIPTION
A note first: this patch does NOT modify the user-facing experience in Cabal
files; it only changes how we register information in the installed package
database.

This patch takes the exposed-modules and reexported-modules fields in
the InstalledPackageInfo structure and consolidates them into just the
exposed module fields, which now has a Maybe flag indicating if a
module is reexported and, if it is, what the original module was.  I've
also added in a field for signatures although it is currently unused.

The big benefit of this change is that it will make processing at the GHC level
much more uniform when we add signatures: signatures can also be reexported
and the new representation means we can share the code.

Signed-off-by: Edward Z. Yang ezyang@cs.stanford.edu
