### PR TITLE
Bug fix: packagesThatDependOn should go through the fake map.

### DIFF
--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -367,10 +367,11 @@ failed pkgid buildResult buildResult' plan = assert (invariant plan') plan'
 --
 packagesThatDependOn :: InstallPlan
                      -> InstalledPackageId -> [PlanPackage]
-packagesThatDependOn plan = map (planPkgOf plan)
+packagesThatDependOn plan pkgid = map (planPkgOf plan)
                           . tail
                           . Graph.reachable (planGraphRev plan)
                           . planVertexOf plan
+                          $ Map.findWithDefault pkgid pkgid (planFakeMap plan)
 
 -- | Lookup a package that we expect to be in the processing state.
 --


### PR DESCRIPTION
This fix got dropped shuffling PRs around when we committed
ff6c718be2cca2ac31eb461e9ca777e1f149b5a1
