### PR TITLE
Prettify code to ensure compilation with -XNoMonomorphismRestriction

### DIFF
--- a/Cabal/Distribution/Simple/Program/Ar.hs
+++ b/Cabal/Distribution/Simple/Program/Ar.hs
@@ -124,6 +124,7 @@ wipeMetadata path = do
         , "0     " -- GID, 6 bytes
         , "0644    " -- mode, 8 bytes
         ]
+    headerSize :: Int
     headerSize = 60
 
     -- http://en.wikipedia.org/wiki/Ar_(Unix)#File_format_details

--- a/Cabal/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/Distribution/Simple/Program/HcPkg.hs
@@ -269,11 +269,7 @@ list verbosity hcPkg packagedb = do
                   ++ programId hcPkg ++ " list'"
 
   where
-    parsePackageIds str =
-      let parsed = map simpleParse (words str)
-       in case [ () | Nothing <- parsed ] of
-            [] -> Just [ pkgid | Just pkgid <- parsed ]
-            _  -> Nothing
+    parsePackageIds = sequence . map simpleParse . words
 
 
 --------------------------

--- a/cabal-install/Distribution/Client/World.hs
+++ b/cabal-install/Distribution/Client/World.hs
@@ -49,8 +49,6 @@ import Data.Char as Char
 
 import Data.List
          ( unionBy, deleteFirstsBy, nubBy )
-import Data.Maybe
-         ( isJust, fromJust )
 import System.IO.Error
          ( isDoesNotExistError )
 import qualified Data.ByteString.Lazy.Char8 as B
@@ -113,9 +111,9 @@ getContents :: FilePath -> IO [WorldPkgInfo]
 getContents world = do
   content <- safelyReadFile world
   let result = map simpleParse (lines $ B.unpack content)
-  if all isJust result
-    then return $ map fromJust result
-    else die "Could not parse world file."
+  case sequence result of
+    Nothing -> die "Could not parse world file."
+    Just xs -> return xs
   where
   safelyReadFile :: FilePath -> IO B.ByteString
   safelyReadFile file = B.readFile file `catchIO` handler


### PR DESCRIPTION
had it enabled in .ghci, got errors. fix is simple and cleans up code.

(i'd bet there are more cases where `sequence` could shorten things..)
