### PR TITLE
add data-dir to InstalledPackageInfo

### DIFF
--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -91,6 +91,7 @@ data InstalledPackageInfo_ m
         trusted           :: Bool,
         importDirs        :: [FilePath],
         libraryDirs       :: [FilePath],
+        dataDir           :: FilePath,
         hsLibraries       :: [String],
         extraLibraries    :: [String],
         extraGHCiLibraries:: [String],    -- overrides extraLibraries for GHCi
@@ -140,6 +141,7 @@ emptyInstalledPackageInfo
         trusted           = False,
         importDirs        = [],
         libraryDirs       = [],
+        dataDir           = "",
         hsLibraries       = [],
         extraLibraries    = [],
         extraGHCiLibraries= [],
@@ -318,6 +320,9 @@ installedFieldDescrs = [
  , listField   "library-dirs"
         showFilePath       parseFilePathQ
         libraryDirs        (\xs pkg -> pkg{libraryDirs=xs})
+ , simpleField "data-dir"
+        showFilePath       (parseFilePathQ Parse.<++ return "")
+        dataDir            (\val pkg -> pkg{dataDir=val})
  , listField   "hs-libraries"
         showFilePath       parseTokenQ
         hsLibraries        (\xs pkg -> pkg{hsLibraries=xs})

--- a/Cabal/Distribution/Simple/GHC/IPI641.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI641.hs
@@ -88,6 +88,7 @@ toCurrent ipi@InstalledPackageInfo{} =
     Current.trusted            = Current.trusted Current.emptyInstalledPackageInfo,
     Current.importDirs         = importDirs ipi,
     Current.libraryDirs        = libraryDirs ipi,
+    Current.dataDir            = "",
     Current.hsLibraries        = hsLibraries ipi,
     Current.extraLibraries     = extraLibraries ipi,
     Current.extraGHCiLibraries = [],

--- a/Cabal/Distribution/Simple/GHC/IPI642.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI642.hs
@@ -123,6 +123,7 @@ toCurrent ipi@InstalledPackageInfo{} =
     Current.trusted            = Current.trusted Current.emptyInstalledPackageInfo,
     Current.importDirs         = importDirs ipi,
     Current.libraryDirs        = libraryDirs ipi,
+    Current.dataDir            = "",
     Current.hsLibraries        = hsLibraries ipi,
     Current.extraLibraries     = extraLibraries ipi,
     Current.extraGHCiLibraries = extraGHCiLibraries ipi,

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -276,9 +276,12 @@ generalInstalledPackageInfo adjustRelIncDirs pkg ipid lib lbi clbi installDirs =
     IPI.hiddenModules      = otherModules bi,
     IPI.trusted            = IPI.trusted IPI.emptyInstalledPackageInfo,
     IPI.importDirs         = [ libdir installDirs | hasModules ],
+    -- Note. the libsubdir and datasubdir templates have already been expanded
+    -- into libdir and datadir.
     IPI.libraryDirs        = if hasLibrary
                                then libdir installDirs : extraLibDirs bi
                                else                      extraLibDirs bi,
+    IPI.dataDir            = datadir installDirs,
     IPI.hsLibraries        = [ libname
                              | LibraryName libname <- componentLibraries clbi
                              , hasLibrary ],
@@ -335,8 +338,7 @@ inplaceInstalledPackageInfo inplaceDir distPref pkg ipid lib lbi clbi =
     installDirs =
       (absoluteInstallDirs pkg lbi NoCopyDest) {
         libdir     = inplaceDir </> buildDir lbi,
-        datadir    = inplaceDir,
-        datasubdir = distPref,
+        datadir    = inplaceDir </> dataDir pkg,
         docdir     = inplaceDocdir,
         htmldir    = inplaceHtmldir,
         haddockdir = inplaceHtmldir


### PR DESCRIPTION
This adds the `data-dir` to `InstalledPackageInfo` so that it's available to GHC. It still needs a few changes in `ghc` and `ghc-pkg` to actually be used.

This is required for GHCJS to be able to correctly make `data-files` for packages available at link time, without having to expose all contents of the hard drive over HTTP. See https://ghc.haskell.org/trac/ghc/ticket/9808

I'm submitting this part first since this is the only part of the GHCJS support patch that requires changes in GHC (`bin-package-db` serialization). I'll submit those once this has been merged.
