### PR TITLE
Support for network-2.6 1.18

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -34,6 +34,10 @@ Flag old-directory
   description:  Use directory < 1.2 and old-time
   default:      False
 
+flag network-uri
+  description: Get Network.URI from the network-uri package
+  default: True
+
 executable cabal
     main-is:        Main.hs
     ghc-options:    -Wall -fwarn-tabs
@@ -135,6 +139,11 @@ executable cabal
     else
       build-depends: directory >= 1.2 && < 1.3,
                      process   >= 1.1.0.2  && < 1.3
+
+    if flag(network-uri)
+      build-depends: network-uri >= 2.6, network >= 2.6
+    else
+      build-depends: network-uri < 2.6, network < 2.6
 
     if os(windows)
       build-depends: Win32 >= 2 && < 3


### PR DESCRIPTION
This one is pretty import, a `cabal install cabal-install --constraint 'Cabal == 1.18.*'` today will almost certainly fail.
