### PR TITLE
Add delete-source to cabal sandbox help.

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1633,7 +1633,8 @@ sandboxCommand = CommandUI {
   commandUsage        = \pname ->
        "Usage: " ++ pname ++ " sandbox init\n"
     ++ "   or: " ++ pname ++ " sandbox delete\n"
-    ++ "   or: " ++ pname ++ " sandbox add-source  [PATHS]\n\n"
+    ++ "   or: " ++ pname ++ " sandbox add-source  [PATHS]\n"
+    ++ "   or: " ++ pname ++ " sandbox delete-source  [PATHS]\n\n"
     ++ "   or: " ++ pname ++ " sandbox hc-pkg      -- [ARGS]\n"
     ++ "   or: " ++ pname ++ " sandbox list-sources\n\n"
     ++ "Flags for sandbox:",

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -1052,13 +1052,14 @@ sandboxAction sandboxFlags extraArgs globalFlags = do
         sandboxHcPkg verbosity sandboxFlags globalFlags extra
     ["buildopts"] -> die "Not implemented!"
 
-    -- Hidden commands.
     ("delete-source":extra) -> do
         when (noExtraArgs extra) $
           die "The 'sandbox delete-source' command expects \
               \at least one argument"
         sandboxDeleteSource verbosity extra sandboxFlags globalFlags
     ["list-sources"] -> sandboxListSources verbosity sandboxFlags globalFlags
+
+    -- Hidden commands.
     ["dump-pkgenv"]  -> dumpPackageEnvironment verbosity sandboxFlags globalFlags
 
     -- Error handling.


### PR DESCRIPTION
I'm not sure I'm understanding what hidden commands are, so perhaps moving that comment wasn't appropriate.  

Fixes #1959 
