### PR TITLE
Add GHCJS support to the Simple build infrastructure

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -180,6 +180,7 @@ library
     Distribution.Simple.Compiler
     Distribution.Simple.Configure
     Distribution.Simple.GHC
+    Distribution.Simple.GHCJS
     Distribution.Simple.Haddock
     Distribution.Simple.HaskellSuite
     Distribution.Simple.Hpc
@@ -229,6 +230,7 @@ library
     Distribution.Simple.GHC.Internal
     Distribution.Simple.GHC.IPI641
     Distribution.Simple.GHC.IPI642
+    Distribution.Simple.GHC.ImplInfo
     Paths_Cabal
 
   default-language: Haskell98

--- a/Cabal/Distribution/Compat/CreatePipe.hs
+++ b/Cabal/Distribution/Compat/CreatePipe.hs
@@ -15,6 +15,7 @@ import GHC.IO.FD (mkFD)
 import GHC.IO.Device (IODeviceType(Stream))
 import GHC.IO.Handle.FD (mkHandleFromFD)
 import System.IO (IOMode(ReadMode, WriteMode))
+#elif ghcjs_HOST_OS
 #else
 import System.Posix.IO (fdToHandle)
 import qualified System.Posix.IO as Posix
@@ -48,6 +49,8 @@ foreign import ccall "io.h _pipe" c__pipe ::
 
 foreign import ccall "io.h _close" c__close ::
     CInt -> IO CInt
+#elif ghcjs_HOST_OS
+createPipe = error "createPipe"
 #else
 createPipe = do
     (readfd, writefd) <- Posix.createPipe

--- a/Cabal/Distribution/Compat/TempFile.hs
+++ b/Cabal/Distribution/Compat/TempFile.hs
@@ -25,7 +25,7 @@ import Foreign.C              (getErrno, errnoToIOError)
 
 import System.Posix.Internals (c_getpid)
 
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS) || defined(ghcjs_HOST_OS)
 import System.Directory       ( createDirectory )
 #else
 import qualified System.Posix
@@ -121,7 +121,7 @@ createTempDirectory dir template = do
                 | otherwise              -> ioError e
 
 mkPrivateDir :: String -> IO ()
-#ifdef mingw32_HOST_OS
+#if defined(mingw32_HOST_OS) || defined(ghcjs_HOST_OS)
 mkPrivateDir s = createDirectory s
 #else
 mkPrivateDir s = System.Posix.createDirectory s 0o700

--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -162,6 +162,9 @@ generate pkg_descr lbi =
         supportsRelocatableProgs GHC  = case buildOS of
                            Windows   -> True
                            _         -> False
+        supportsRelocatableProgs GHCJS = case buildOS of
+                           Windows   -> True
+                           _         -> False
         supportsRelocatableProgs _    = False
 
         paths_modulename = autogenModuleName pkg_descr
@@ -171,9 +174,10 @@ generate pkg_descr lbi =
         path_sep = show [pathSeparator]
 
         supports_language_pragma =
-          compilerFlavor (compiler lbi) == GHC &&
+          (compilerFlavor (compiler lbi) == GHC &&
             (compilerVersion (compiler lbi)
-              `withinRange` orLaterVersion (Version [6,6,1] []))
+              `withinRange` orLaterVersion (Version [6,6,1] []))) ||
+           compilerFlavor (compiler lbi) == GHCJS
 
 -- | Generates the name of the environment variable controlling the path
 -- component of interest.

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -24,7 +24,9 @@ module Distribution.Simple.Compiler (
         -- * Haskell implementations
         module Distribution.Compiler,
         Compiler(..),
-        showCompilerId, compilerFlavor, compilerVersion,
+        showCompilerId, showCompilerIdWithAbi,
+        compilerFlavor, compilerVersion,
+        compilerCompatVersion,
         compilerInfo,
 
         -- * Support for package databases
@@ -59,7 +61,7 @@ import Control.Monad (liftM)
 import Data.Binary (Binary)
 import Data.List (nub)
 import qualified Data.Map as M (Map, lookup)
-import Data.Maybe (catMaybes, isNothing)
+import Data.Maybe (catMaybes, isNothing, listToMaybe)
 import GHC.Generics (Generic)
 import System.Directory (canonicalizePath)
 
@@ -84,11 +86,24 @@ instance Binary Compiler
 showCompilerId :: Compiler -> String
 showCompilerId = display . compilerId
 
+showCompilerIdWithAbi :: Compiler -> String
+showCompilerIdWithAbi comp =
+  display (compilerId comp) ++
+  case compilerAbiTag comp of
+    NoAbiTag  -> []
+    AbiTag xs -> '-':xs
+
 compilerFlavor ::  Compiler -> CompilerFlavor
 compilerFlavor = (\(CompilerId f _) -> f) . compilerId
 
 compilerVersion :: Compiler -> Version
 compilerVersion = (\(CompilerId _ v) -> v) . compilerId
+
+compilerCompatVersion :: CompilerFlavor -> Compiler -> Maybe Version
+compilerCompatVersion flavor comp
+  | compilerFlavor comp == flavor = Just (compilerVersion comp)
+  | otherwise    =
+      listToMaybe [ v | CompilerId fl v <- compilerCompat comp, fl == flavor ]
 
 compilerInfo :: Compiler -> CompilerInfo
 compilerInfo c = CompilerInfo (compilerId c)
@@ -232,7 +247,10 @@ packageKeySupported = ghcSupported "Uses package keys"
 ghcSupported :: String -> Compiler -> Bool
 ghcSupported key comp =
   case compilerFlavor comp of
-    GHC -> case M.lookup key (compilerProperties comp) of
-      Just "YES" -> True
-      _          -> False
-    _   -> False
+    GHC   -> checkProp
+    GHCJS -> checkProp
+    _     -> False
+  where checkProp =
+          case M.lookup key (compilerProperties comp) of
+            Just "YES" -> True
+            _          -> False

--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -1,0 +1,105 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Simple.GHC.ImplInfo
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Portability :  portable
+--
+-- This module contains the data structure describing invocation
+-- details for a GHC or GHC-derived compiler, such as supported flags
+-- and workarounds for bugs.
+
+module Distribution.Simple.GHC.ImplInfo (
+        GhcImplInfo(..), getImplInfo,
+        ghcVersionImplInfo, ghcjsVersionImplInfo, lhcVersionImplInfo
+        ) where
+
+import Distribution.Simple.Compiler
+  ( Compiler(..), CompilerId(..), CompilerFlavor(..)
+  , compilerFlavor, compilerVersion, compilerCompatVersion )
+import Distribution.Version ( Version(..) )
+
+{- |
+     Information about features and quirks of a GHC-based implementation.
+
+     Compiler flavors based on GHC behave similarly enough that some of
+     the support code for them is shared. Every implementation has its
+     own peculiarities, that may or may not be a direct result of the
+     underlying GHC version. This record keeps track of these differences.
+
+     All shared code (i.e. everything not in the Distribution.Simple.FLAVOR
+     module) should use implementation info rather than version numbers
+     to test for supported features.
+-}
+
+data GhcImplInfo = GhcImplInfo
+  { hasCcOdirBug         :: Bool -- ^ bug in -odir handling for C compilations.
+  , flagInfoLanguages    :: Bool -- ^ --info and --supported-languages flags
+  , fakeRecordPuns       :: Bool -- ^ use -XRecordPuns for NamedFieldPuns
+  , flagStubdir          :: Bool -- ^ -stubdir flag supported
+  , flagOutputDir        :: Bool -- ^ -outputdir flag supported
+  , noExtInSplitSuffix   :: Bool -- ^ split-obj suffix does not contain p_o ext
+  , flagFfiIncludes      :: Bool -- ^ -#include on command line for FFI includes
+  , flagBuildingCabalPkg :: Bool -- ^ -fbuilding-cabal-package flag supported
+  , flagPackageId        :: Bool -- ^ -package-id / -package flags supported
+  , separateGccMingw     :: Bool -- ^ mingw and gcc are in separate directories
+  , supportsHaskell2010  :: Bool -- ^ -XHaskell2010 and -XHaskell98 flags
+  , reportsNoExt         :: Bool -- ^ --supported-languages gives Ext and NoExt
+  , alwaysNondecIndent   :: Bool -- ^ NondecreasingIndentation is always on
+  , flagGhciScript       :: Bool -- ^ -ghci-script flag supported
+  , flagPackageConf      :: Bool -- ^ use package-conf instead of package-db
+  }
+
+getImplInfo :: Compiler -> GhcImplInfo
+getImplInfo comp =
+  case compilerFlavor comp of
+    GHC   -> ghcVersionImplInfo (compilerVersion comp)
+    LHC   -> lhcVersionImplInfo (compilerVersion comp)
+    GHCJS -> case compilerCompatVersion GHC comp of
+              Just ghcVer -> ghcjsVersionImplInfo (compilerVersion comp) ghcVer
+              _  -> error ("Distribution.Simple.GHC.Props.getImplProps: " ++
+                           "could not find GHC version for GHCJS compiler")
+    x     -> error ("Distribution.Simple.GHC.Props.getImplProps only works" ++
+                    "for GHC-like compilers (GHC, GHCJS, LHC)" ++
+                    ", but found " ++ show x)
+
+ghcVersionImplInfo :: Version -> GhcImplInfo
+ghcVersionImplInfo (Version v _) = GhcImplInfo
+  { hasCcOdirBug         = v <  [6,4,1]
+  , flagInfoLanguages    = v >= [6,7]
+  , fakeRecordPuns       = v >= [6,8] && v < [6,10]
+  , flagStubdir          = v >= [6,8]
+  , flagOutputDir        = v >= [6,10]
+  , noExtInSplitSuffix   = v <  [6,11]
+  , flagFfiIncludes      = v <  [6,11]
+  , flagBuildingCabalPkg = v >= [6,11]
+  , flagPackageId        = v >  [6,11]
+  , separateGccMingw     = v <  [6,12]
+  , supportsHaskell2010  = v >= [7]
+  , reportsNoExt         = v >= [7]
+  , alwaysNondecIndent   = v <  [7,1]
+  , flagGhciScript       = v >= [7,2]
+  , flagPackageConf      = v <  [7,5]
+  }
+
+ghcjsVersionImplInfo :: Version -> Version -> GhcImplInfo
+ghcjsVersionImplInfo _ghcjsVer _ghcVer = GhcImplInfo
+  { hasCcOdirBug         = False
+  , flagInfoLanguages    = True
+  , fakeRecordPuns       = False
+  , flagStubdir          = True
+  , flagOutputDir        = True
+  , noExtInSplitSuffix   = False
+  , flagFfiIncludes      = False
+  , flagBuildingCabalPkg = True
+  , flagPackageId        = True
+  , separateGccMingw     = False
+  , supportsHaskell2010  = True
+  , reportsNoExt         = True
+  , alwaysNondecIndent   = False
+  , flagGhciScript       = True
+  , flagPackageConf      = False
+  }
+
+lhcVersionImplInfo :: Version -> GhcImplInfo
+lhcVersionImplInfo = ghcVersionImplInfo

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -1,0 +1,884 @@
+module Distribution.Simple.GHCJS (
+        configure, getInstalledPackages, getPackageDBContents,
+        buildLib, buildExe,
+        replLib, replExe,
+        startInterpreter,
+        installLib, installExe,
+        libAbiHash,
+        hcPkgInfo,
+        registerPackage,
+        componentGhcOptions,
+        getLibDir,
+        isDynamic,
+        getGlobalPackageDB,
+        runCmd
+  ) where
+
+import Distribution.Simple.GHC.ImplInfo ( getImplInfo, ghcjsVersionImplInfo )
+import qualified Distribution.Simple.GHC.Internal as Internal
+import Distribution.PackageDescription as PD
+         ( PackageDescription(..), BuildInfo(..), Executable(..)
+         , Library(..), libModules, exeModules
+         , hcOptions, hcProfOptions, hcSharedOptions
+         , allExtensions )
+import Distribution.InstalledPackageInfo
+         ( InstalledPackageInfo )
+import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
+                                ( InstalledPackageInfo_(..) )
+import Distribution.Simple.PackageIndex ( InstalledPackageIndex )
+import qualified Distribution.Simple.PackageIndex as PackageIndex
+import Distribution.Simple.LocalBuildInfo
+         ( LocalBuildInfo(..), ComponentLocalBuildInfo(..)
+         , LibraryName(..) )
+import qualified Distribution.Simple.Hpc as Hpc
+import Distribution.Simple.InstallDirs hiding ( absoluteInstallDirs )
+import Distribution.Simple.BuildPaths
+import Distribution.Simple.Utils
+import Distribution.Simple.Program
+         ( Program(..), ConfiguredProgram(..), ProgramConfiguration
+         , ProgramSearchPath
+         , rawSystemProgramConf
+         , rawSystemProgramStdout, rawSystemProgramStdoutConf
+         , getProgramInvocationOutput
+         , requireProgramVersion, requireProgram
+         , userMaybeSpecifyPath, programPath
+         , lookupProgram, addKnownPrograms
+         , ghcjsProgram, ghcjsPkgProgram, c2hsProgram, hsc2hsProgram
+         , ldProgram, haddockProgram, stripProgram )
+import qualified Distribution.Simple.Program.HcPkg as HcPkg
+import qualified Distribution.Simple.Program.Ar    as Ar
+import qualified Distribution.Simple.Program.Ld    as Ld
+import qualified Distribution.Simple.Program.Strip as Strip
+import Distribution.Simple.Program.GHC
+import Distribution.Simple.Setup
+         ( toFlag, fromFlag, configCoverage, configDistPref )
+import qualified Distribution.Simple.Setup as Cabal
+        ( Flag )
+import Distribution.Simple.Compiler
+         ( CompilerFlavor(..), CompilerId(..), Compiler(..)
+         , PackageDB(..), PackageDBStack, AbiTag(..) )
+import Distribution.Version
+         ( Version(..), anyVersion, orLaterVersion )
+import Distribution.System
+         ( Platform(..) )
+import Distribution.Verbosity
+import Distribution.Utils.NubList
+         ( overNubListR, toNubListR )
+import Distribution.Text ( display )
+import Language.Haskell.Extension ( Extension(..)
+                                  , KnownExtension(..))
+
+import Control.Monad            ( unless, when )
+import Data.Char                ( isSpace )
+import qualified Data.Map as M  ( fromList  )
+import Data.Monoid              ( Monoid(..) )
+import System.Directory         ( doesFileExist )
+import System.FilePath          ( (</>), (<.>), takeExtension,
+                                  takeDirectory, replaceExtension,
+                                  splitExtension )
+import System.Environment (getEnv)
+import Distribution.Compat.Exception (catchIO)
+
+configure :: Verbosity -> Maybe FilePath -> Maybe FilePath
+          -> ProgramConfiguration
+          -> IO (Compiler, Maybe Platform, ProgramConfiguration)
+configure verbosity hcPath hcPkgPath conf0 = do
+  (ghcjsProg, ghcjsVersion, conf1) <-
+    requireProgramVersion verbosity ghcjsProgram
+      (orLaterVersion (Version [0,1] []))
+      (userMaybeSpecifyPath "ghcjs" hcPath conf0)
+  Just ghcjsGhcVersion <- findGhcjsGhcVersion verbosity (programPath ghcjsProg)
+  let implInfo = ghcjsVersionImplInfo ghcjsVersion ghcjsGhcVersion
+
+  -- This is slightly tricky, we have to configure ghcjs first, then we use the
+  -- location of ghcjs to help find ghcjs-pkg in the case that the user did not
+  -- specify the location of ghc-pkg directly:
+  (ghcjsPkgProg, ghcjsPkgVersion, conf2) <-
+    requireProgramVersion verbosity ghcjsPkgProgram {
+      programFindLocation = guessGhcjsPkgFromGhcjsPath ghcjsProg
+    }
+    anyVersion (userMaybeSpecifyPath "ghcjs-pkg" hcPkgPath conf1)
+
+  Just ghcjsPkgGhcVersion <- findGhcjsPkgGhcVersion
+                               verbosity (programPath ghcjsPkgProg)
+
+  when (ghcjsVersion /= ghcjsPkgVersion) $ die $
+       "Version mismatch between ghcjs and ghcjs-pkg: "
+    ++ programPath ghcjsProg ++ " is version " ++ display ghcjsVersion ++ " "
+    ++ programPath ghcjsPkgProg ++ " is version " ++ display ghcjsPkgVersion
+
+  when (ghcjsGhcVersion /= ghcjsPkgGhcVersion) $ die $
+       "Version mismatch between ghcjs and ghcjs-pkg: "
+    ++ programPath ghcjsProg
+    ++ " was built with GHC version " ++ display ghcjsGhcVersion ++ " "
+    ++ programPath ghcjsPkgProg
+    ++ " was built with GHC version " ++ display ghcjsPkgGhcVersion
+
+  -- be sure to use our versions of hsc2hs, c2hs, haddock and ghc
+  let hsc2hsProgram' =
+        hsc2hsProgram { programFindLocation =
+                          guessHsc2hsFromGhcjsPath ghcjsProg }
+      c2hsProgram' =
+        c2hsProgram { programFindLocation =
+                          guessC2hsFromGhcjsPath ghcjsProg }
+
+      haddockProgram' =
+        haddockProgram { programFindLocation =
+                          guessHaddockFromGhcjsPath ghcjsProg }
+      conf3 = addKnownPrograms [ hsc2hsProgram', c2hsProgram', haddockProgram' ] conf2
+
+  languages  <- Internal.getLanguages  verbosity implInfo ghcjsProg
+  extensions <- Internal.getExtensions verbosity implInfo ghcjsProg
+
+  ghcInfo <- Internal.getGhcInfo verbosity implInfo ghcjsProg
+  let ghcInfoMap = M.fromList ghcInfo
+
+  let comp = Compiler {
+        compilerId         = CompilerId GHCJS ghcjsVersion,
+        compilerAbiTag     = AbiTag $
+          "ghc" ++ intercalate "_" (map show . versionBranch $ ghcjsGhcVersion),
+        compilerCompat     = [CompilerId GHC ghcjsGhcVersion],
+        compilerLanguages  = languages,
+        compilerExtensions = extensions,
+        compilerProperties = ghcInfoMap
+      }
+      compPlatform = Internal.targetPlatform ghcInfo
+  -- configure gcc and ld
+  let conf4 = if ghcjsNativeToo comp
+                     then Internal.configureToolchain implInfo
+                            ghcjsProg ghcInfoMap conf3
+                     else conf3
+  return (comp, compPlatform, conf4)
+
+ghcjsNativeToo :: Compiler -> Bool
+ghcjsNativeToo = Internal.ghcLookupProperty "Native Too"
+
+guessGhcjsPkgFromGhcjsPath :: ConfiguredProgram -> Verbosity
+                           -> ProgramSearchPath -> IO (Maybe FilePath)
+guessGhcjsPkgFromGhcjsPath = guessToolFromGhcjsPath ghcjsPkgProgram
+
+guessHsc2hsFromGhcjsPath :: ConfiguredProgram -> Verbosity
+                         -> ProgramSearchPath -> IO (Maybe FilePath)
+guessHsc2hsFromGhcjsPath = guessToolFromGhcjsPath hsc2hsProgram
+
+guessC2hsFromGhcjsPath :: ConfiguredProgram -> Verbosity
+                       -> ProgramSearchPath -> IO (Maybe FilePath)
+guessC2hsFromGhcjsPath = guessToolFromGhcjsPath c2hsProgram
+
+guessHaddockFromGhcjsPath :: ConfiguredProgram -> Verbosity
+                          -> ProgramSearchPath -> IO (Maybe FilePath)
+guessHaddockFromGhcjsPath = guessToolFromGhcjsPath haddockProgram
+
+guessToolFromGhcjsPath :: Program -> ConfiguredProgram
+                       -> Verbosity -> ProgramSearchPath
+                       -> IO (Maybe FilePath)
+guessToolFromGhcjsPath tool ghcjsProg verbosity searchpath
+  = do let toolname          = programName tool
+           path              = programPath ghcjsProg
+           dir               = takeDirectory path
+           versionSuffix     = takeVersionSuffix (dropExeExtension path)
+           guessNormal       = dir </> toolname <.> exeExtension
+           guessGhcjsVersioned = dir </> (toolname ++ "-ghcjs" ++ versionSuffix)
+                                 <.> exeExtension
+           guessGhcjs        = dir </> (toolname ++ "-ghcjs")
+                               <.> exeExtension
+           guessVersioned    = dir </> (toolname ++ versionSuffix) <.> exeExtension
+           guesses | null versionSuffix = [guessGhcjs, guessNormal]
+                   | otherwise          = [guessGhcjsVersioned,
+                                           guessGhcjs,
+                                           guessVersioned,
+                                           guessNormal]
+       info verbosity $ "looking for tool " ++ toolname
+         ++ " near compiler in " ++ dir
+       exists <- mapM doesFileExist guesses
+       case [ file | (file, True) <- zip guesses exists ] of
+                   -- If we can't find it near ghc, fall back to the usual
+                   -- method.
+         []     -> programFindLocation tool verbosity searchpath
+         (fp:_) -> do info verbosity $ "found " ++ toolname ++ " in " ++ fp
+                      return (Just fp)
+
+  where takeVersionSuffix :: FilePath -> String
+        takeVersionSuffix = reverse . takeWhile (`elem ` "0123456789.-") .
+                            reverse
+
+        dropExeExtension :: FilePath -> FilePath
+        dropExeExtension filepath =
+          case splitExtension filepath of
+            (filepath', extension) | extension == exeExtension -> filepath'
+                                   | otherwise                 -> filepath
+
+
+-- | Given a single package DB, return all installed packages.
+getPackageDBContents :: Verbosity -> PackageDB -> ProgramConfiguration
+                     -> IO InstalledPackageIndex
+getPackageDBContents verbosity packagedb conf = do
+  pkgss <- getInstalledPackages' verbosity [packagedb] conf
+  toPackageIndex verbosity pkgss conf
+
+-- | Given a package DB stack, return all installed packages.
+getInstalledPackages :: Verbosity -> PackageDBStack -> ProgramConfiguration
+                     -> IO InstalledPackageIndex
+getInstalledPackages verbosity packagedbs conf = do
+  checkPackageDbEnvVar
+  checkPackageDbStack packagedbs
+  pkgss <- getInstalledPackages' verbosity packagedbs conf
+  index <- toPackageIndex verbosity pkgss conf
+  return $! index
+
+toPackageIndex :: Verbosity
+               -> [(PackageDB, [InstalledPackageInfo])]
+               -> ProgramConfiguration
+               -> IO InstalledPackageIndex
+toPackageIndex verbosity pkgss conf = do
+  -- On Windows, various fields have $topdir/foo rather than full
+  -- paths. We need to substitute the right value in so that when
+  -- we, for example, call gcc, we have proper paths to give it.
+  topDir <- getLibDir' verbosity ghcjsProg
+  let indices = [ PackageIndex.fromList (map (Internal.substTopDir topDir) pkgs)
+                | (_, pkgs) <- pkgss ]
+  return $! (mconcat indices)
+
+  where
+    Just ghcjsProg = lookupProgram ghcjsProgram conf
+
+checkPackageDbEnvVar :: IO ()
+checkPackageDbEnvVar = do
+    hasGPP <- (getEnv "GHCJS_PACKAGE_PATH" >> return True)
+              `catchIO` (\_ -> return False)
+    when hasGPP $
+      die $ "Use of GHCJS' environment variable GHCJS_PACKAGE_PATH is "
+         ++ "incompatible with Cabal. Use the flag --package-db to specify a "
+         ++ "package database (it can be used multiple times)."
+
+checkPackageDbStack :: PackageDBStack -> IO ()
+checkPackageDbStack (GlobalPackageDB:rest)
+  | GlobalPackageDB `notElem` rest = return ()
+checkPackageDbStack rest
+  | GlobalPackageDB `notElem` rest =
+  die $ "With current ghc versions the global package db is always used "
+     ++ "and must be listed first. This ghc limitation may be lifted in "
+     ++ "future, see http://hackage.haskell.org/trac/ghc/ticket/5977"
+checkPackageDbStack _ =
+  die $ "If the global package db is specified, it must be "
+     ++ "specified first and cannot be specified multiple times"
+
+getInstalledPackages' :: Verbosity -> [PackageDB] -> ProgramConfiguration
+                      -> IO [(PackageDB, [InstalledPackageInfo])]
+getInstalledPackages' verbosity packagedbs conf =
+  sequence
+    [ do pkgs <- HcPkg.dump (hcPkgInfo conf) verbosity packagedb
+         return (packagedb, pkgs)
+    | packagedb <- packagedbs ]
+
+getLibDir :: Verbosity -> LocalBuildInfo -> IO FilePath
+getLibDir verbosity lbi =
+    (reverse . dropWhile isSpace . reverse) `fmap`
+     rawSystemProgramStdoutConf verbosity ghcjsProgram
+     (withPrograms lbi) ["--print-libdir"]
+
+getLibDir' :: Verbosity -> ConfiguredProgram -> IO FilePath
+getLibDir' verbosity ghcjsProg =
+    (reverse . dropWhile isSpace . reverse) `fmap`
+     rawSystemProgramStdout verbosity ghcjsProg ["--print-libdir"]
+
+-- | Return the 'FilePath' to the global GHC package database.
+getGlobalPackageDB :: Verbosity -> ConfiguredProgram -> IO FilePath
+getGlobalPackageDB verbosity ghcjsProg =
+    (reverse . dropWhile isSpace . reverse) `fmap`
+     rawSystemProgramStdout verbosity ghcjsProg ["--print-global-package-db"]
+
+toJSLibName :: String -> String
+toJSLibName lib
+  | takeExtension lib `elem` [".dll",".dylib",".so"]
+                              = replaceExtension lib "js_so"
+  | takeExtension lib == ".a" = replaceExtension lib "js_a"
+  | otherwise                 = lib <.> "js_a"
+
+buildLib, replLib :: Verbosity -> Cabal.Flag (Maybe Int) -> PackageDescription
+                  -> LocalBuildInfo -> Library -> ComponentLocalBuildInfo
+                  -> IO ()
+buildLib = buildOrReplLib False
+replLib  = buildOrReplLib True
+
+buildOrReplLib :: Bool -> Verbosity  -> Cabal.Flag (Maybe Int)
+               -> PackageDescription -> LocalBuildInfo
+               -> Library            -> ComponentLocalBuildInfo -> IO ()
+buildOrReplLib forRepl verbosity numJobs _pkg_descr lbi lib clbi = do
+  libName <- case componentLibraries clbi of
+             [libName] -> return libName
+             [] -> die "No library name found when building library"
+             _  -> die "Multiple library names found when building library"
+  let libTargetDir = buildDir lbi
+      whenVanillaLib forceVanilla =
+        when (not forRepl && (forceVanilla || withVanillaLib lbi))
+      whenProfLib = when (not forRepl && withProfLib lbi)
+      whenSharedLib forceShared =
+        when (not forRepl &&  (forceShared || withSharedLib lbi))
+      whenGHCiLib = when (not forRepl && withGHCiLib lbi && withVanillaLib lbi)
+      ifReplLib = when forRepl
+      comp = compiler lbi
+      implInfo = getImplInfo comp
+      hole_insts = map (\(k,(p,n)) -> (k,(InstalledPackageInfo.packageKey p,n)))
+                       (instantiatedWith lbi)
+      nativeToo = ghcjsNativeToo comp
+
+  (ghcjsProg, _) <- requireProgram verbosity ghcjsProgram (withPrograms lbi)
+  let runGhcjsProg        = runGHC verbosity ghcjsProg comp
+      libBi               = libBuildInfo lib
+      isGhcjsDynamic      = isDynamic comp
+      dynamicTooSupported = supportsDynamicToo comp
+      doingTH = EnableExtension TemplateHaskell `elem` allExtensions libBi
+      forceVanillaLib = doingTH && not isGhcjsDynamic
+      forceSharedLib  = doingTH &&     isGhcjsDynamic
+      -- TH always needs default libs, even when building for profiling
+
+  -- Determine if program coverage should be enabled and if so, what
+  -- '-hpcdir' should be.
+  let isCoverageEnabled = fromFlag $ configCoverage $ configFlags lbi
+      -- Component name. Not 'libName' because that has the "HS" prefix
+      -- that GHC gives Haskell libraries.
+      cname = display $ PD.package $ localPkgDescr lbi
+      distPref = fromFlag $ configDistPref $ configFlags lbi
+      hpcdir | isCoverageEnabled = toFlag $ Hpc.mixDir distPref cname
+             | otherwise = mempty
+
+  createDirectoryIfMissingVerbose verbosity True libTargetDir
+  -- TODO: do we need to put hs-boot files into place for mutually recursive
+  -- modules?
+  let cObjs       = map (`replaceExtension` objExtension) (cSources libBi)
+      jsSrcs      = jsSources libBi
+      baseOpts    = componentGhcOptions verbosity lbi libBi clbi libTargetDir
+                    `mappend` mempty { ghcOptHPCDir = hpcdir }
+      linkJsLibOpts = mempty {
+                        ghcOptExtra = toNubListR $
+                          [ "-link-js-lib"     , (\(LibraryName l) -> l) libName
+                          , "-js-lib-outputdir", libTargetDir ] ++
+                          concatMap (\x -> ["-js-lib-src",x]) jsSrcs
+                      }
+      vanillaOptsNoJsLib = baseOpts `mappend` mempty {
+                      ghcOptMode         = toFlag GhcModeMake,
+                      ghcOptNumJobs      = numJobs,
+                      ghcOptPackageKey   = toFlag (pkgKey lbi),
+                      ghcOptSigOf        = hole_insts,
+                      ghcOptInputModules = toNubListR $ libModules lib
+                    }
+      vanillaOpts = vanillaOptsNoJsLib `mappend` linkJsLibOpts
+
+      profOpts    = adjustExts "p_hi" "p_o" vanillaOpts `mappend` mempty {
+                        ghcOptProfilingMode = toFlag True,
+                        ghcOptExtra         = toNubListR $
+                                              ghcjsProfOptions libBi
+                      }
+      sharedOpts  = adjustExts "dyn_hi" "dyn_o" vanillaOpts `mappend` mempty {
+                        ghcOptDynLinkMode = toFlag GhcDynamicOnly,
+                        ghcOptFPic        = toFlag True,
+                        ghcOptExtra       = toNubListR $
+                                            ghcjsSharedOptions libBi
+                      }
+      linkerOpts = mempty {
+                      ghcOptLinkOptions    = toNubListR $ PD.ldOptions libBi,
+                      ghcOptLinkLibs       = toNubListR $ extraLibs libBi,
+                      ghcOptLinkLibPath    = toNubListR $ extraLibDirs libBi,
+                      ghcOptLinkFrameworks = toNubListR $ PD.frameworks libBi,
+                      ghcOptInputFiles     =
+                        toNubListR $ [libTargetDir </> x | x <- cObjs] ++ jsSrcs
+                   }
+      replOpts    = vanillaOptsNoJsLib {
+                      ghcOptExtra        = overNubListR
+                                           Internal.filterGhciFlags
+                                           (ghcOptExtra vanillaOpts),
+                      ghcOptNumJobs      = mempty
+                    }
+                    `mappend` linkerOpts
+                    `mappend` mempty {
+                      ghcOptMode         = toFlag GhcModeInteractive,
+                      ghcOptOptimisation = toFlag GhcNoOptimisation
+                    }
+
+      vanillaSharedOpts = vanillaOpts `mappend`
+                            mempty {
+                              ghcOptDynLinkMode  = toFlag GhcStaticAndDynamic,
+                              ghcOptDynHiSuffix  = toFlag "dyn_hi",
+                              ghcOptDynObjSuffix = toFlag "dyn_o"
+                            }
+
+  unless (forRepl || (null (libModules lib) && null jsSrcs && null cObjs)) $
+    do let vanilla = whenVanillaLib forceVanillaLib (runGhcjsProg vanillaOpts)
+           shared  = whenSharedLib  forceSharedLib  (runGhcjsProg sharedOpts)
+           useDynToo = dynamicTooSupported &&
+                       (forceVanillaLib || withVanillaLib lbi) &&
+                       (forceSharedLib  || withSharedLib  lbi) &&
+                       null (ghcjsSharedOptions libBi)
+       if useDynToo
+           then runGhcjsProg vanillaSharedOpts
+           else if isGhcjsDynamic then do shared;  vanilla
+                                  else do vanilla; shared
+       whenProfLib (runGhcjsProg profOpts)
+
+  -- build any C sources
+  unless (null (cSources libBi) || not nativeToo) $ do
+     info verbosity "Building C Sources..."
+     sequence_
+       [ do let vanillaCcOpts =
+                  (Internal.componentCcGhcOptions verbosity implInfo
+                     lbi libBi clbi libTargetDir filename)
+                profCcOpts    = vanillaCcOpts `mappend` mempty {
+                                  ghcOptProfilingMode = toFlag True,
+                                  ghcOptObjSuffix     = toFlag "p_o"
+                                }
+                sharedCcOpts  = vanillaCcOpts `mappend` mempty {
+                                  ghcOptFPic        = toFlag True,
+                                  ghcOptDynLinkMode = toFlag GhcDynamicOnly,
+                                  ghcOptObjSuffix   = toFlag "dyn_o"
+                                }
+                odir          = fromFlag (ghcOptObjDir vanillaCcOpts)
+            createDirectoryIfMissingVerbose verbosity True odir
+            runGhcjsProg vanillaCcOpts
+            whenSharedLib forceSharedLib (runGhcjsProg sharedCcOpts)
+            whenProfLib (runGhcjsProg profCcOpts)
+       | filename <- cSources libBi]
+
+  -- TODO: problem here is we need the .c files built first, so we can load them
+  -- with ghci, but .c files can depend on .h files generated by ghc by ffi
+  -- exports.
+  unless (null (libModules lib)) $
+     ifReplLib (runGhcjsProg replOpts)
+
+  -- link:
+  when (nativeToo && not forRepl) $ do
+    info verbosity "Linking..."
+    let cProfObjs   = map (`replaceExtension` ("p_" ++ objExtension))
+                      (cSources libBi)
+        cSharedObjs = map (`replaceExtension` ("dyn_" ++ objExtension))
+                      (cSources libBi)
+        cid = compilerId (compiler lbi)
+        vanillaLibFilePath = libTargetDir </> mkLibName            libName
+        profileLibFilePath = libTargetDir </> mkProfLibName        libName
+        sharedLibFilePath  = libTargetDir </> mkSharedLibName cid  libName
+        ghciLibFilePath    = libTargetDir </> Internal.mkGHCiLibName libName
+
+    hObjs     <- Internal.getHaskellObjects implInfo lib lbi
+                      libTargetDir objExtension True
+    hProfObjs <-
+      if (withProfLib lbi)
+              then Internal.getHaskellObjects implInfo lib lbi
+                      libTargetDir ("p_" ++ objExtension) True
+              else return []
+    hSharedObjs <-
+      if (withSharedLib lbi)
+              then Internal.getHaskellObjects implInfo lib lbi
+                      libTargetDir ("dyn_" ++ objExtension) False
+              else return []
+
+    unless (null hObjs && null cObjs) $ do
+
+      let staticObjectFiles =
+                 hObjs
+              ++ map (libTargetDir </>) cObjs
+          profObjectFiles =
+                 hProfObjs
+              ++ map (libTargetDir </>) cProfObjs
+          ghciObjFiles =
+                 hObjs
+              ++ map (libTargetDir </>) cObjs
+          dynamicObjectFiles =
+                 hSharedObjs
+              ++ map (libTargetDir </>) cSharedObjs
+          -- After the relocation lib is created we invoke ghc -shared
+          -- with the dependencies spelled out as -package arguments
+          -- and ghc invokes the linker with the proper library paths
+          ghcSharedLinkArgs =
+              mempty {
+                ghcOptShared             = toFlag True,
+                ghcOptDynLinkMode        = toFlag GhcDynamicOnly,
+                ghcOptInputFiles         = toNubListR dynamicObjectFiles,
+                ghcOptOutputFile         = toFlag sharedLibFilePath,
+                ghcOptPackageKey         = toFlag (pkgKey lbi),
+                ghcOptNoAutoLinkPackages = toFlag True,
+                ghcOptPackageDBs         = withPackageDB lbi,
+                ghcOptPackages           = toNubListR $
+                                           Internal.mkGhcOptPackages clbi,
+                ghcOptLinkLibs           = toNubListR $ extraLibs libBi,
+                ghcOptLinkLibPath        = toNubListR $ extraLibDirs libBi
+              }
+
+      whenVanillaLib False $ do
+        Ar.createArLibArchive verbosity lbi vanillaLibFilePath staticObjectFiles
+
+      whenProfLib $ do
+        Ar.createArLibArchive verbosity lbi profileLibFilePath profObjectFiles
+
+      whenGHCiLib $ do
+        (ldProg, _) <- requireProgram verbosity ldProgram (withPrograms lbi)
+        Ld.combineObjectFiles verbosity ldProg
+          ghciLibFilePath ghciObjFiles
+
+      whenSharedLib False $
+        runGhcjsProg ghcSharedLinkArgs
+
+-- | Start a REPL without loading any source files.
+startInterpreter :: Verbosity -> ProgramConfiguration -> Compiler
+                 -> PackageDBStack -> IO ()
+startInterpreter verbosity conf comp packageDBs = do
+  let replOpts = mempty {
+        ghcOptMode       = toFlag GhcModeInteractive,
+        ghcOptPackageDBs = packageDBs
+        }
+  checkPackageDbStack packageDBs
+  (ghcjsProg, _) <- requireProgram verbosity ghcjsProgram conf
+  runGHC verbosity ghcjsProg comp replOpts
+
+buildExe, replExe :: Verbosity          -> Cabal.Flag (Maybe Int)
+                  -> PackageDescription -> LocalBuildInfo
+                  -> Executable         -> ComponentLocalBuildInfo -> IO ()
+buildExe = buildOrReplExe False
+replExe  = buildOrReplExe True
+
+buildOrReplExe :: Bool -> Verbosity  -> Cabal.Flag (Maybe Int)
+               -> PackageDescription -> LocalBuildInfo
+               -> Executable         -> ComponentLocalBuildInfo -> IO ()
+buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
+  exe@Executable { exeName = exeName', modulePath = modPath } clbi = do
+
+  (ghcjsProg, _) <- requireProgram verbosity ghcjsProgram (withPrograms lbi)
+  let comp         = compiler lbi
+      implInfo     = getImplInfo comp
+      runGhcjsProg = runGHC verbosity ghcjsProg comp
+      exeBi        = buildInfo exe
+
+  -- exeNameReal, the name that GHC really uses (with .exe on Windows)
+  let exeNameReal = exeName' <.>
+                    (if takeExtension exeName' /= ('.':exeExtension)
+                       then exeExtension
+                       else "")
+
+  let targetDir = (buildDir lbi) </> exeName'
+  let exeDir    = targetDir </> (exeName' ++ "-tmp")
+  createDirectoryIfMissingVerbose verbosity True targetDir
+  createDirectoryIfMissingVerbose verbosity True exeDir
+  -- TODO: do we need to put hs-boot files into place for mutually recursive
+  -- modules?  FIX: what about exeName.hi-boot?
+
+  -- Determine if program coverage should be enabled and if so, what
+  -- '-hpcdir' should be.
+  let isCoverageEnabled = fromFlag $ configCoverage $ configFlags lbi
+      distPref = fromFlag $ configDistPref $ configFlags lbi
+      hpcdir | isCoverageEnabled = toFlag $ Hpc.mixDir distPref exeName'
+             | otherwise = mempty
+
+  -- build executables
+
+  srcMainFile         <- findFile (exeDir : hsSourceDirs exeBi) modPath
+  let isGhcjsDynamic      = isDynamic comp
+      dynamicTooSupported = supportsDynamicToo comp
+      buildRunner = case clbi of
+                       ExeComponentLocalBuildInfo {} -> False
+                       _                             -> True
+      isHaskellMain = elem (takeExtension srcMainFile) [".hs", ".lhs"]
+      jsSrcs        = jsSources exeBi
+      cSrcs         = cSources exeBi ++ [srcMainFile | not isHaskellMain]
+      cObjs         = map (`replaceExtension` objExtension) cSrcs
+      nativeToo     = ghcjsNativeToo comp
+      baseOpts   = (componentGhcOptions verbosity lbi exeBi clbi exeDir)
+                    `mappend` mempty {
+                      ghcOptMode         = toFlag GhcModeMake,
+                      ghcOptInputFiles   = toNubListR $
+                        [ srcMainFile | isHaskellMain],
+                      ghcOptInputModules = toNubListR $
+                        [ m | not isHaskellMain, m <- exeModules exe],
+                      ghcOptHPCDir = hpcdir,
+                      ghcOptExtra =
+                        if buildRunner then toNubListR ["-build-runner"]
+                                       else mempty
+                    }
+      staticOpts = baseOpts `mappend` mempty {
+                      ghcOptDynLinkMode    = toFlag GhcStaticOnly
+                   }
+      profOpts   = adjustExts "p_hi" "p_o" baseOpts `mappend` mempty {
+                      ghcOptProfilingMode  = toFlag True,
+                      ghcOptExtra          = toNubListR $ ghcjsProfOptions exeBi
+                    }
+      dynOpts    = adjustExts "dyn_hi" "dyn_o" baseOpts `mappend` mempty {
+                      ghcOptDynLinkMode    = toFlag GhcDynamicOnly,
+                      ghcOptExtra          = toNubListR $
+                                             ghcjsSharedOptions exeBi
+                    }
+      dynTooOpts = adjustExts "dyn_hi" "dyn_o" staticOpts `mappend` mempty {
+                      ghcOptDynLinkMode    = toFlag GhcStaticAndDynamic
+                    }
+      linkerOpts = mempty {
+                      ghcOptLinkOptions    = toNubListR $ PD.ldOptions exeBi,
+                      ghcOptLinkLibs       = toNubListR $ extraLibs exeBi,
+                      ghcOptLinkLibPath    = toNubListR $ extraLibDirs exeBi,
+                      ghcOptLinkFrameworks = toNubListR $ PD.frameworks exeBi,
+                      ghcOptInputFiles     = toNubListR $
+                                             [exeDir </> x | x <- cObjs] ++ jsSrcs
+                   }
+      replOpts   = baseOpts {
+                      ghcOptExtra          = overNubListR
+                                             Internal.filterGhciFlags
+                                             (ghcOptExtra baseOpts)
+                   }
+                   -- For a normal compile we do separate invocations of ghc for
+                   -- compiling as for linking. But for repl we have to do just
+                   -- the one invocation, so that one has to include all the
+                   -- linker stuff too, like -l flags and any .o files from C
+                   -- files etc.
+                   `mappend` linkerOpts
+                   `mappend` mempty {
+                      ghcOptMode           = toFlag GhcModeInteractive,
+                      ghcOptOptimisation   = toFlag GhcNoOptimisation
+                   }
+      commonOpts  | withProfExe lbi = profOpts
+                  | withDynExe  lbi = dynOpts
+                  | otherwise       = staticOpts
+      compileOpts | useDynToo = dynTooOpts
+                  | otherwise = commonOpts
+      withStaticExe = (not $ withProfExe lbi) && (not $ withDynExe lbi)
+
+      -- For building exe's that use TH with -prof or -dynamic we actually have
+      -- to build twice, once without -prof/-dynamic and then again with
+      -- -prof/-dynamic. This is because the code that TH needs to run at
+      -- compile time needs to be the vanilla ABI so it can be loaded up and run
+      -- by the compiler.
+      -- With dynamic-by-default GHC the TH object files loaded at compile-time
+      -- need to be .dyn_o instead of .o.
+      doingTH = EnableExtension TemplateHaskell `elem` allExtensions exeBi
+      -- Should we use -dynamic-too instead of compiling twice?
+      useDynToo = dynamicTooSupported && isGhcjsDynamic
+                  && doingTH && withStaticExe && null (ghcjsSharedOptions exeBi)
+      compileTHOpts | isGhcjsDynamic = dynOpts
+                    | otherwise      = staticOpts
+      compileForTH
+        | forRepl      = False
+        | useDynToo    = False
+        | isGhcjsDynamic = doingTH && (withProfExe lbi || withStaticExe)
+        | otherwise      = doingTH && (withProfExe lbi || withDynExe lbi)
+
+      linkOpts = commonOpts `mappend`
+                 linkerOpts `mappend` mempty {
+                      ghcOptLinkNoHsMain   = toFlag (not isHaskellMain)
+                 }
+
+  -- Build static/dynamic object files for TH, if needed.
+  when compileForTH $
+    runGhcjsProg compileTHOpts { ghcOptNoLink  = toFlag True
+                               , ghcOptNumJobs = numJobs }
+
+  unless forRepl $
+    runGhcjsProg compileOpts { ghcOptNoLink  = toFlag True
+                             , ghcOptNumJobs = numJobs }
+
+  -- build any C sources
+  unless (null cSrcs || not nativeToo) $ do
+   info verbosity "Building C Sources..."
+   sequence_
+     [ do let opts = (Internal.componentCcGhcOptions verbosity implInfo lbi exeBi
+                         clbi exeDir filename) `mappend` mempty {
+                       ghcOptDynLinkMode   = toFlag (if withDynExe lbi
+                                                       then GhcDynamicOnly
+                                                       else GhcStaticOnly),
+                       ghcOptProfilingMode = toFlag (withProfExe lbi)
+                     }
+              odir = fromFlag (ghcOptObjDir opts)
+          createDirectoryIfMissingVerbose verbosity True odir
+          runGhcjsProg opts
+     | filename <- cSrcs ]
+
+  -- TODO: problem here is we need the .c files built first, so we can load them
+  -- with ghci, but .c files can depend on .h files generated by ghc by ffi
+  -- exports.
+  when forRepl $ runGhcjsProg replOpts
+
+  -- link:
+  unless forRepl $ do
+    info verbosity "Linking..."
+    runGhcjsProg linkOpts { ghcOptOutputFile = toFlag (targetDir </> exeNameReal) }
+
+-- |Install for ghc, .hi, .a and, if --with-ghci given, .o
+installLib    :: Verbosity
+              -> LocalBuildInfo
+              -> FilePath  -- ^install location
+              -> FilePath  -- ^install location for dynamic libraries
+              -> FilePath  -- ^Build location
+              -> PackageDescription
+              -> Library
+              -> ComponentLocalBuildInfo
+              -> IO ()
+installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
+  whenVanilla $ copyModuleFiles "js_hi"
+  whenProf    $ copyModuleFiles "js_p_hi"
+  whenShared  $ copyModuleFiles "js_dyn_hi"
+
+  whenVanilla $ mapM_ (installOrdinary builtDir targetDir . toJSLibName) vanillaLibNames
+  whenProf    $ mapM_ (installOrdinary builtDir targetDir . toJSLibName) profileLibNames
+  whenShared  $ mapM_ (installShared   builtDir dynlibTargetDir . toJSLibName) sharedLibNames
+
+  when (ghcjsNativeToo $ compiler lbi) $ do
+    -- copy .hi files over:
+    whenVanilla $ copyModuleFiles "hi"
+    whenProf    $ copyModuleFiles "p_hi"
+    whenShared  $ copyModuleFiles "dyn_hi"
+
+    -- copy the built library files over:
+    whenVanilla $ mapM_ (installOrdinary builtDir targetDir)       vanillaLibNames
+    whenProf    $ mapM_ (installOrdinary builtDir targetDir)       profileLibNames
+    whenGHCi    $ mapM_ (installOrdinary builtDir targetDir)       ghciLibNames
+    whenShared  $ mapM_ (installShared   builtDir dynlibTargetDir) sharedLibNames
+
+  where
+    install isShared srcDir dstDir name = do
+      let src = srcDir </> name
+          dst = dstDir </> name
+      createDirectoryIfMissingVerbose verbosity True dstDir
+      if isShared
+        then do when (stripLibs lbi) $ Strip.stripLib verbosity
+                                       (hostPlatform lbi) (withPrograms lbi) src
+                installExecutableFile verbosity src dst
+        else installOrdinaryFile   verbosity src dst
+
+    installOrdinary = install False
+    installShared   = install True
+
+    copyModuleFiles ext =
+      findModuleFiles [builtDir] [ext] (libModules lib)
+      >>= installOrdinaryFiles verbosity targetDir
+
+    cid = compilerId (compiler lbi)
+    libNames = componentLibraries clbi
+    vanillaLibNames = map mkLibName              libNames
+    profileLibNames = map mkProfLibName          libNames
+    ghciLibNames    = map Internal.mkGHCiLibName libNames
+    sharedLibNames  = map (mkSharedLibName cid)  libNames
+
+    hasLib    = not $ null (libModules lib)
+                   && null (cSources (libBuildInfo lib))
+    whenVanilla = when (hasLib && withVanillaLib lbi)
+    whenProf    = when (hasLib && withProfLib    lbi)
+    whenGHCi    = when (hasLib && withGHCiLib    lbi)
+    whenShared  = when (hasLib && withSharedLib  lbi)
+
+installExe :: Verbosity
+              -> LocalBuildInfo
+              -> InstallDirs FilePath -- ^Where to copy the files to
+              -> FilePath  -- ^Build location
+              -> (FilePath, FilePath)  -- ^Executable (prefix,suffix)
+              -> PackageDescription
+              -> Executable
+              -> IO ()
+installExe verbosity lbi installDirs buildPref
+           (progprefix, progsuffix) _pkg exe = do
+  let binDir = bindir installDirs
+  createDirectoryIfMissingVerbose verbosity True binDir
+  let exeFileName = exeName exe
+      fixedExeBaseName = progprefix ++ exeName exe ++ progsuffix
+      installBinary dest = do
+        rawSystemProgramConf verbosity ghcjsProgram (withPrograms lbi) $
+          [ "--install-executable"
+          , buildPref </> exeName exe </> exeFileName
+          , "-o", dest
+          ] ++
+          case (stripExes lbi, lookupProgram stripProgram $ withPrograms lbi) of
+           (True, Just strip) -> ["-strip-program", programPath strip]
+           _                  -> []
+  installBinary (binDir </> fixedExeBaseName)
+
+libAbiHash :: Verbosity -> PackageDescription -> LocalBuildInfo
+           -> Library -> ComponentLocalBuildInfo -> IO String
+libAbiHash verbosity _pkg_descr lbi lib clbi = do
+  let
+      libBi       = libBuildInfo lib
+      comp        = compiler lbi
+      vanillaArgs =
+        (componentGhcOptions verbosity lbi libBi clbi (buildDir lbi))
+        `mappend` mempty {
+          ghcOptMode         = toFlag GhcModeAbiHash,
+          ghcOptPackageKey   = toFlag (pkgKey lbi),
+          ghcOptInputModules = toNubListR $ exposedModules lib
+        }
+      profArgs = adjustExts "js_p_hi" "js_p_o" vanillaArgs `mappend` mempty {
+                     ghcOptProfilingMode = toFlag True,
+                     ghcOptExtra         = toNubListR (ghcjsProfOptions libBi)
+                 }
+      ghcArgs = if withVanillaLib lbi then vanillaArgs
+           else if withProfLib    lbi then profArgs
+           else error "libAbiHash: Can't find an enabled library way"
+  --
+  (ghcjsProg, _) <- requireProgram verbosity ghcjsProgram (withPrograms lbi)
+  getProgramInvocationOutput verbosity (ghcInvocation ghcjsProg comp ghcArgs)
+
+adjustExts :: String -> String -> GhcOptions -> GhcOptions
+adjustExts hiSuf objSuf opts =
+  opts `mappend` mempty {
+    ghcOptHiSuffix  = toFlag hiSuf,
+    ghcOptObjSuffix = toFlag objSuf
+  }
+
+registerPackage :: Verbosity
+                -> InstalledPackageInfo
+                -> PackageDescription
+                -> LocalBuildInfo
+                -> Bool
+                -> PackageDBStack
+                -> IO ()
+registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs =
+  HcPkg.reregister (hcPkgInfo $ withPrograms lbi) verbosity packageDbs
+    (Right installedPkgInfo)
+
+componentGhcOptions :: Verbosity -> LocalBuildInfo
+                    -> BuildInfo -> ComponentLocalBuildInfo -> FilePath
+                    -> GhcOptions
+componentGhcOptions verbosity lbi bi clbi odir =
+  let opts = Internal.componentGhcOptions verbosity lbi bi clbi odir
+  in  opts { ghcOptExtra = ghcOptExtra opts `mappend` toNubListR
+                             (hcOptions GHCJS bi)
+           }
+
+ghcjsProfOptions :: BuildInfo -> [String]
+ghcjsProfOptions bi =
+  hcProfOptions GHC bi `mappend` hcProfOptions GHCJS bi
+
+ghcjsSharedOptions :: BuildInfo -> [String]
+ghcjsSharedOptions bi =
+  hcSharedOptions GHC bi `mappend` hcSharedOptions GHCJS bi
+
+isDynamic :: Compiler -> Bool
+isDynamic = Internal.ghcLookupProperty "GHC Dynamic"
+
+supportsDynamicToo :: Compiler -> Bool
+supportsDynamicToo = Internal.ghcLookupProperty "Support dynamic-too"
+
+findGhcjsGhcVersion :: Verbosity -> FilePath -> IO (Maybe Version)
+findGhcjsGhcVersion verbosity pgm =
+  findProgramVersion "--numeric-ghc-version" id verbosity pgm
+
+findGhcjsPkgGhcVersion :: Verbosity -> FilePath -> IO (Maybe Version)
+findGhcjsPkgGhcVersion verbosity pgm =
+  findProgramVersion "--numeric-ghc-version" id verbosity pgm
+
+-- -----------------------------------------------------------------------------
+-- Registering
+
+hcPkgInfo :: ProgramConfiguration -> HcPkg.HcPkgInfo
+hcPkgInfo conf = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcjsPkgProg
+                                 , HcPkg.noPkgDbStack    = False
+                                 , HcPkg.noVerboseFlag   = False
+                                 , HcPkg.flagPackageConf = False
+                                 }
+  where
+    Just ghcjsPkgProg = lookupProgram ghcjsPkgProgram conf
+
+-- | Get the JavaScript file name and command and arguments to run a
+--   program compiled by GHCJS
+--   the exe should be the base program name without exe extension
+runCmd :: ProgramConfiguration -> FilePath
+            -> (FilePath, FilePath, [String])
+runCmd conf exe =
+  ( script
+  , programPath ghcjsProg
+  , programDefaultArgs ghcjsProg ++ programOverrideArgs ghcjsProg ++ ["--run"]
+  )
+  where
+    script = exe <.> "jsexe" </> "all" <.> "js"
+    Just ghcjsProg = lookupProgram ghcjsProgram conf

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -32,10 +32,11 @@ import Distribution.Simple.Compiler
          ( CompilerFlavor(..), compilerFlavor )
 import Distribution.Simple.Setup (CopyFlags(..), fromFlag)
 
-import qualified Distribution.Simple.GHC  as GHC
-import qualified Distribution.Simple.JHC  as JHC
-import qualified Distribution.Simple.LHC  as LHC
-import qualified Distribution.Simple.UHC  as UHC
+import qualified Distribution.Simple.GHC   as GHC
+import qualified Distribution.Simple.GHCJS as GHCJS
+import qualified Distribution.Simple.JHC   as JHC
+import qualified Distribution.Simple.LHC   as LHC
+import qualified Distribution.Simple.UHC   as UHC
 import qualified Distribution.Simple.HaskellSuite as HaskellSuite
 
 import Control.Monad (when, unless)
@@ -130,6 +131,10 @@ install pkg_descr lbi flags = do
                   GHC.installLib verbosity lbi libPref dynlibPref buildPref pkg_descr
                 withExe pkg_descr $
                   GHC.installExe verbosity lbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr
+     GHCJS-> do withLibLBI pkg_descr lbi $
+                  GHCJS.installLib verbosity lbi libPref dynlibPref buildPref pkg_descr
+                withExe pkg_descr $
+                  GHCJS.installExe verbosity lbi installDirs buildPref (progPrefixPref, progSuffixPref) pkg_descr
      LHC  -> do withLibLBI pkg_descr lbi $
                   LHC.installLib verbosity lbi libPref dynlibPref buildPref pkg_descr
                 withExe pkg_descr $

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -35,14 +35,15 @@ module Distribution.Simple.LHC (
         buildLib, buildExe,
         installLib, installExe,
         registerPackage,
+        hcPkgInfo,
         ghcOptions,
         ghcVerbosityOptions
  ) where
 
 import Distribution.PackageDescription as PD
          ( PackageDescription(..), BuildInfo(..), Executable(..)
-         , Library(..), libModules, hcOptions, usedExtensions, allExtensions
-         , hcSharedOptions, hcProfOptions )
+         , Library(..), libModules, hcOptions, hcProfOptions, hcSharedOptions
+         , usedExtensions, allExtensions )
 import Distribution.InstalledPackageInfo
                                 ( InstalledPackageInfo
                                 , parseInstalledPackageInfo )
@@ -784,6 +785,15 @@ registerPackage
   -> Bool
   -> PackageDBStack
   -> IO ()
-registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs = do
-  let Just lhcPkg = lookupProgram lhcPkgProgram (withPrograms lbi)
-  HcPkg.reregister verbosity lhcPkg packageDbs (Right installedPkgInfo)
+registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs =
+  HcPkg.reregister (hcPkgInfo $ withPrograms lbi) verbosity packageDbs
+    (Right installedPkgInfo)
+
+hcPkgInfo :: ProgramConfiguration -> HcPkg.HcPkgInfo
+hcPkgInfo conf = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = lhcPkgProg
+                                 , HcPkg.noPkgDbStack    = False
+                                 , HcPkg.noVerboseFlag   = False
+                                 , HcPkg.flagPackageConf = False
+                                 }
+  where
+    Just lhcPkgProg = lookupProgram lhcPkgProgram conf

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -44,7 +44,8 @@ import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.Simple.CCompiler
          ( cSourceExtensions )
 import Distribution.Simple.Compiler
-         ( CompilerFlavor(..), compilerFlavor, compilerVersion )
+         ( CompilerFlavor(..)
+         , compilerFlavor, compilerCompatVersion, compilerVersion )
 import Distribution.Simple.LocalBuildInfo
          ( LocalBuildInfo(..), Component(..) )
 import Distribution.Simple.BuildPaths (autogenModulesDir,cppHeaderName)
@@ -57,7 +58,7 @@ import Distribution.Simple.Program
          , requireProgram, requireProgramVersion
          , rawSystemProgramConf, rawSystemProgram
          , greencardProgram, cpphsProgram, hsc2hsProgram, c2hsProgram
-         , happyProgram, alexProgram, ghcProgram, gccProgram )
+         , happyProgram, alexProgram, ghcProgram, ghcjsProgram, gccProgram )
 import Distribution.Simple.Test.LibV09
          ( writeSimpleTestStub, stubFilePath, stubName )
 import Distribution.System
@@ -333,26 +334,28 @@ ppCpp = ppCpp' []
 ppCpp' :: [String] -> BuildInfo -> LocalBuildInfo -> PreProcessor
 ppCpp' extraArgs bi lbi =
   case compilerFlavor (compiler lbi) of
-    GHC -> ppGhcCpp (cppArgs ++ extraArgs) bi lbi
-    _   -> ppCpphs  (cppArgs ++ extraArgs) bi lbi
-
+    GHC   -> ppGhcCpp ghcProgram   (>= Version [6,6] []) args bi lbi
+    GHCJS -> ppGhcCpp ghcjsProgram (const True)          args bi lbi
+    _     -> ppCpphs  args bi lbi
   where cppArgs = getCppOptions bi lbi
+        args    = cppArgs ++ extraArgs
 
-ppGhcCpp :: [String] -> BuildInfo -> LocalBuildInfo -> PreProcessor
-ppGhcCpp extraArgs _bi lbi =
+ppGhcCpp :: Program -> (Version -> Bool)
+         -> [String] -> BuildInfo -> LocalBuildInfo -> PreProcessor
+ppGhcCpp program xHs extraArgs _bi lbi =
   PreProcessor {
     platformIndependent = False,
     runPreProcessor = mkSimplePreProcessor $ \inFile outFile verbosity -> do
-      (ghcProg, ghcVersion, _) <- requireProgramVersion verbosity
-                                    ghcProgram anyVersion (withPrograms lbi)
-      rawSystemProgram verbosity ghcProg $
+      (prog, version, _) <- requireProgramVersion verbosity
+                              program anyVersion (withPrograms lbi)
+      rawSystemProgram verbosity prog $
           ["-E", "-cpp"]
           -- This is a bit of an ugly hack. We're going to
           -- unlit the file ourselves later on if appropriate,
           -- so we need GHC not to unlit it now or it'll get
           -- double-unlitted. In the future we might switch to
           -- using cpphs --unlit instead.
-       ++ (if ghcVersion >= Version [6,6] [] then ["-x", "hs"] else [])
+       ++ (if xHs version then ["-x", "hs"] else [])
        ++ [ "-optP-include", "-optP"++ (autogenModulesDir lbi </> cppHeaderName) ]
        ++ ["-o", outFile, inFile]
        ++ extraArgs
@@ -439,8 +442,9 @@ ppHsc2hs bi lbi =
     isOSX = case buildOS of OSX -> True; _ -> False
     isELF = case buildOS of OSX -> False; Windows -> False; _ -> True;
     packageHacks = case compilerFlavor (compiler lbi) of
-      GHC -> hackRtsPackage
-      _   -> id
+      GHC   -> hackRtsPackage
+      GHCJS -> hackRtsPackage
+      _     -> id
     -- We don't link in the actual Haskell libraries of our dependencies, so
     -- the -u flags in the ldOptions of the rts package mean linking fails on
     -- OS X (it's ld is a tad stricter than gnu ld). Thus we remove the
@@ -504,6 +508,13 @@ platformDefines lbi =
       ["-D" ++ arch ++ "_BUILD_ARCH=1"] ++
       map (\os'   -> "-D" ++ os'   ++ "_HOST_OS=1")   osStr ++
       map (\arch' -> "-D" ++ arch' ++ "_HOST_ARCH=1") archStr
+    GHCJS ->
+      compatGlasgowHaskell ++
+      ["-D__GHCJS__=" ++ versionInt version] ++
+      ["-D" ++ os   ++ "_BUILD_OS=1"] ++
+      ["-D" ++ arch ++ "_BUILD_ARCH=1"] ++
+      map (\os'   -> "-D" ++ os'   ++ "_HOST_OS=1")   osStr ++
+      map (\arch' -> "-D" ++ arch' ++ "_HOST_ARCH=1") archStr
     JHC  -> ["-D__JHC__=" ++ versionInt version]
     HaskellSuite {} ->
       ["-D__HASKELL_SUITE__"] ++
@@ -514,6 +525,9 @@ platformDefines lbi =
     comp = compiler lbi
     Platform hostArch hostOS = hostPlatform lbi
     version = compilerVersion comp
+    compatGlasgowHaskell =
+      maybe [] (\v -> ["-D__GLASGOW_HASKELL__=" ++ versionInt v])
+               (compilerCompatVersion GHC comp)
     -- TODO: move this into the compiler abstraction
     -- FIXME: this forces GHC's crazy 4.8.2 -> 408 convention on all
     -- the other compilers. Check if that's really what they want.
@@ -543,6 +557,7 @@ platformDefines lbi =
       IRIX      -> ["irix"]
       HaLVM     -> []
       IOS       -> ["ios"]
+      Ghcjs     -> ["ghcjs"]
       OtherOS _ -> []
     archStr = case hostArch of
       I386        -> ["i386"]
@@ -560,6 +575,7 @@ platformDefines lbi =
       Rs6000      -> ["rs6000"]
       M68k        -> ["m68k"]
       Vax         -> ["vax"]
+      JavaScript  -> ["javascript"]
       OtherArch _ -> []
 
 ppHappy :: BuildInfo -> LocalBuildInfo -> PreProcessor
@@ -567,6 +583,7 @@ ppHappy _ lbi = pp { platformIndependent = True }
   where pp = standardPP lbi happyProgram (hcFlags hc)
         hc = compilerFlavor (compiler lbi)
         hcFlags GHC = ["-agc"]
+        hcFlags GHCJS = ["-agc"]
         hcFlags _ = []
 
 ppAlex :: BuildInfo -> LocalBuildInfo -> PreProcessor
@@ -574,6 +591,7 @@ ppAlex _ lbi = pp { platformIndependent = True }
   where pp = standardPP lbi alexProgram (hcFlags hc)
         hc = compilerFlavor (compiler lbi)
         hcFlags GHC = ["-g"]
+        hcFlags GHCJS = ["-g"]
         hcFlags _ = []
 
 standardPP :: LocalBuildInfo -> Program -> [String] -> PreProcessor

--- a/Cabal/Distribution/Simple/Program.hs
+++ b/Cabal/Distribution/Simple/Program.hs
@@ -92,6 +92,8 @@ module Distribution.Simple.Program (
     -- * Programs that Cabal knows about
     , ghcProgram
     , ghcPkgProgram
+    , ghcjsProgram
+    , ghcjsPkgProgram
     , lhcProgram
     , lhcPkgProgram
     , hmakeProgram

--- a/Cabal/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/Distribution/Simple/Program/Builtin.hs
@@ -18,6 +18,8 @@ module Distribution.Simple.Program.Builtin (
     -- * Programs that Cabal knows about
     ghcProgram,
     ghcPkgProgram,
+    ghcjsProgram,
+    ghcjsPkgProgram,
     lhcProgram,
     lhcPkgProgram,
     hmakeProgram,
@@ -75,6 +77,8 @@ builtinPrograms =
     -- compilers and related progs
       ghcProgram
     , ghcPkgProgram
+    , ghcjsProgram
+    , ghcjsPkgProgram
     , haskellSuiteProgram
     , haskellSuitePkgProgram
     , hmakeProgram
@@ -128,6 +132,21 @@ ghcPkgProgram = (simpleProgram "ghc-pkg") {
     programFindVersion = findProgramVersion "--version" $ \str ->
       -- Invoking "ghc-pkg --version" gives a string like
       -- "GHC package manager version 6.4.1"
+      case words str of
+        (_:_:_:_:ver:_) -> ver
+        _               -> ""
+  }
+
+ghcjsProgram :: Program
+ghcjsProgram = (simpleProgram "ghcjs") {
+    programFindVersion = findProgramVersion "--numeric-ghcjs-version" id
+  }
+
+ghcjsPkgProgram :: Program
+ghcjsPkgProgram = (simpleProgram "ghcjs-pkg") {
+    programFindVersion = findProgramVersion "--ghcjs-version" $ \str ->
+      -- Invoking "ghcjs-pkg --version" gives a string like
+      -- "GHCJS package manager version 6.4.1"
       case words str of
         (_:_:_:_:ver:_) -> ver
         _               -> ""

--- a/Cabal/Distribution/Simple/Program/Find.hs
+++ b/Cabal/Distribution/Simple/Program/Find.hs
@@ -89,6 +89,7 @@ findProgramOnSearchPath verbosity searchpath prog = do
         -- .bat; .cmd".
         extensions = case buildOS of
                        Windows -> ["", "exe"]
+                       Ghcjs   -> ["", "exe"]
                        _       -> [""]
 
     tryPathElem ProgramSearchPathDefault = do

--- a/Cabal/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/Distribution/Simple/Program/HcPkg.hs
@@ -7,9 +7,11 @@
 -- Portability :  portable
 --
 -- This module provides an library interface to the @hc-pkg@ program.
--- Currently only GHC and LHC have hc-pkg programs.
+-- Currently only GHC, GHCJS and LHC have hc-pkg programs.
 
 module Distribution.Simple.Program.HcPkg (
+    HcPkgInfo(..),
+
     init,
     invoke,
     register,
@@ -42,12 +44,10 @@ import Distribution.ParseUtils
 import Distribution.Simple.Compiler
          ( PackageDB(..), PackageDBStack )
 import Distribution.Simple.Program.Types
-         ( ConfiguredProgram(programId, programVersion) )
+         ( ConfiguredProgram(programId) )
 import Distribution.Simple.Program.Run
          ( ProgramInvocation(..), IOEncoding(..), programInvocation
          , runProgramInvocation, getProgramInvocationOutput )
-import Distribution.Version
-         ( Version(..) )
 import Distribution.Text
          ( display, simpleParse )
 import Distribution.Simple.Utils
@@ -67,95 +67,103 @@ import System.FilePath as FilePath
          ( (</>), splitPath, splitDirectories, joinPath, isPathSeparator )
 import qualified System.FilePath.Posix as FilePath.Posix
 
+-- | Information about the features and capabilities of an @hc-pkg@
+--   program.
+--
+data HcPkgInfo = HcPkgInfo
+  { hcPkgProgram    :: ConfiguredProgram
+  , noPkgDbStack    :: Bool -- ^ no package DB stack supported
+  , noVerboseFlag   :: Bool -- ^ hc-pkg does not support verbosity flags
+  , flagPackageConf :: Bool -- ^ use package-conf option instead of package-db
+  }
 
 -- | Call @hc-pkg@ to initialise a package database at the location {path}.
 --
 -- > hc-pkg init {path}
 --
-init :: Verbosity -> ConfiguredProgram -> FilePath -> IO ()
-init verbosity hcPkg path =
-  runProgramInvocation verbosity
-    (initInvocation hcPkg verbosity path)
+init :: HcPkgInfo -> Verbosity -> FilePath -> IO ()
+init hpi verbosity path =
+  runProgramInvocation verbosity (initInvocation hpi verbosity path)
 
 -- | Run @hc-pkg@ using a given package DB stack, directly forwarding the
 -- provided command-line arguments to it.
-invoke :: Verbosity -> ConfiguredProgram -> PackageDBStack -> [String] -> IO ()
-invoke verbosity hcPkg dbStack extraArgs =
+invoke :: HcPkgInfo -> Verbosity -> PackageDBStack -> [String] -> IO ()
+invoke hpi verbosity dbStack extraArgs =
   runProgramInvocation verbosity invocation
   where
-    args       = packageDbStackOpts hcPkg dbStack ++ extraArgs
-    invocation = programInvocation hcPkg args
+    args       = packageDbStackOpts hpi dbStack ++ extraArgs
+    invocation = programInvocation (hcPkgProgram hpi) args
 
 -- | Call @hc-pkg@ to register a package.
 --
 -- > hc-pkg register {filename | -} [--user | --global | --package-db]
 --
-register :: Verbosity -> ConfiguredProgram -> PackageDBStack
+register :: HcPkgInfo -> Verbosity -> PackageDBStack
          -> Either FilePath
                    InstalledPackageInfo
          -> IO ()
-register verbosity hcPkg packagedb pkgFile =
+register hpi verbosity packagedb pkgFile =
   runProgramInvocation verbosity
-    (registerInvocation hcPkg verbosity packagedb pkgFile)
+    (registerInvocation hpi verbosity packagedb pkgFile)
 
 
 -- | Call @hc-pkg@ to re-register a package.
 --
 -- > hc-pkg register {filename | -} [--user | --global | --package-db]
 --
-reregister :: Verbosity -> ConfiguredProgram -> PackageDBStack
+reregister :: HcPkgInfo -> Verbosity -> PackageDBStack
            -> Either FilePath
                      InstalledPackageInfo
            -> IO ()
-reregister verbosity hcPkg packagedb pkgFile =
+reregister hpi verbosity packagedb pkgFile =
   runProgramInvocation verbosity
-    (reregisterInvocation hcPkg verbosity packagedb pkgFile)
+    (reregisterInvocation hpi verbosity packagedb pkgFile)
 
 
 -- | Call @hc-pkg@ to unregister a package
 --
 -- > hc-pkg unregister [pkgid] [--user | --global | --package-db]
 --
-unregister :: Verbosity -> ConfiguredProgram -> PackageDB -> PackageId -> IO ()
-unregister verbosity hcPkg packagedb pkgid =
+unregister :: HcPkgInfo -> Verbosity -> PackageDB -> PackageId -> IO ()
+unregister hpi verbosity packagedb pkgid =
   runProgramInvocation verbosity
-    (unregisterInvocation hcPkg verbosity packagedb pkgid)
+    (unregisterInvocation hpi verbosity packagedb pkgid)
 
 
 -- | Call @hc-pkg@ to expose a package.
 --
 -- > hc-pkg expose [pkgid] [--user | --global | --package-db]
 --
-expose :: Verbosity -> ConfiguredProgram -> PackageDB -> PackageId -> IO ()
-expose verbosity hcPkg packagedb pkgid =
+expose :: HcPkgInfo -> Verbosity -> PackageDB -> PackageId -> IO ()
+expose hpi verbosity packagedb pkgid =
   runProgramInvocation verbosity
-    (exposeInvocation hcPkg verbosity packagedb pkgid)
+    (exposeInvocation hpi verbosity packagedb pkgid)
 
 
 -- | Call @hc-pkg@ to hide a package.
 --
 -- > hc-pkg hide [pkgid] [--user | --global | --package-db]
 --
-hide :: Verbosity -> ConfiguredProgram -> PackageDB -> PackageId -> IO ()
-hide verbosity hcPkg packagedb pkgid =
+hide :: HcPkgInfo -> Verbosity -> PackageDB -> PackageId -> IO ()
+hide hpi verbosity packagedb pkgid =
   runProgramInvocation verbosity
-    (hideInvocation hcPkg verbosity packagedb pkgid)
+    (hideInvocation hpi verbosity packagedb pkgid)
 
 
 -- | Call @hc-pkg@ to get all the details of all the packages in the given
 -- package database.
 --
-dump :: Verbosity -> ConfiguredProgram -> PackageDB -> IO [InstalledPackageInfo]
-dump verbosity hcPkg packagedb = do
+dump :: HcPkgInfo -> Verbosity -> PackageDB -> IO [InstalledPackageInfo]
+dump hpi verbosity packagedb = do
 
   output <- getProgramInvocationOutput verbosity
-              (dumpInvocation hcPkg verbosity packagedb)
-    `catchExit` \_ -> die $ programId hcPkg ++ " dump failed"
+              (dumpInvocation hpi verbosity packagedb)
+    `catchExit` \_ -> die $ programId (hcPkgProgram hpi) ++ " dump failed"
 
   case parsePackages output of
     Left ok -> return ok
     _       -> die $ "failed to parse output of '"
-                  ++ programId hcPkg ++ " dump'"
+                  ++ programId (hcPkgProgram hpi) ++ " dump'"
 
   where
     parsePackages str =
@@ -256,17 +264,18 @@ setInstalledPackageId pkginfo = pkginfo
 -- Note in particular that it does not include the 'InstalledPackageId', just
 -- the source 'PackageId' which is not necessarily unique in any package db.
 --
-list :: Verbosity -> ConfiguredProgram -> PackageDB -> IO [PackageId]
-list verbosity hcPkg packagedb = do
+list :: HcPkgInfo -> Verbosity -> PackageDB
+     -> IO [PackageId]
+list hpi verbosity packagedb = do
 
   output <- getProgramInvocationOutput verbosity
-              (listInvocation hcPkg verbosity packagedb)
-    `catchExit` \_ -> die $ programId hcPkg ++ " list failed"
+              (listInvocation hpi verbosity packagedb)
+    `catchExit` \_ -> die $ programId (hcPkgProgram hpi) ++ " list failed"
 
   case parsePackageIds output of
     Just ok -> return ok
     _       -> die $ "failed to parse output of '"
-                  ++ programId hcPkg ++ " list'"
+                  ++ programId (hcPkgProgram hpi) ++ " list'"
 
   where
     parsePackageIds = sequence . map simpleParse . words
@@ -276,138 +285,125 @@ list verbosity hcPkg packagedb = do
 -- The program invocations
 --
 
-initInvocation :: ConfiguredProgram
-               -> Verbosity -> FilePath -> ProgramInvocation
-initInvocation hcPkg verbosity path =
-    programInvocation hcPkg args
+initInvocation :: HcPkgInfo -> Verbosity -> FilePath -> ProgramInvocation
+initInvocation hpi verbosity path =
+    programInvocation (hcPkgProgram hpi) args
   where
     args = ["init", path]
-        ++ verbosityOpts hcPkg verbosity
+        ++ verbosityOpts hpi verbosity
 
 registerInvocation, reregisterInvocation
-  :: ConfiguredProgram -> Verbosity -> PackageDBStack
+  :: HcPkgInfo -> Verbosity -> PackageDBStack
   -> Either FilePath InstalledPackageInfo
   -> ProgramInvocation
 registerInvocation   = registerInvocation' "register"
 reregisterInvocation = registerInvocation' "update"
 
 
-registerInvocation' :: String
-                    -> ConfiguredProgram -> Verbosity -> PackageDBStack
+registerInvocation' :: String -> HcPkgInfo -> Verbosity -> PackageDBStack
                     -> Either FilePath InstalledPackageInfo
                     -> ProgramInvocation
-registerInvocation' cmdname hcPkg verbosity packagedbs (Left pkgFile) =
-    programInvocation hcPkg args
+registerInvocation' cmdname hpi verbosity packagedbs (Left pkgFile) =
+    programInvocation (hcPkgProgram hpi) args
   where
     args = [cmdname, pkgFile]
-        ++ (if legacyVersion hcPkg
-              then [packageDbOpts hcPkg (last packagedbs)]
-              else packageDbStackOpts hcPkg packagedbs)
-        ++ verbosityOpts hcPkg verbosity
+        ++ (if noPkgDbStack hpi
+              then [packageDbOpts hpi (last packagedbs)]
+              else packageDbStackOpts hpi packagedbs)
+        ++ verbosityOpts hpi verbosity
 
-registerInvocation' cmdname hcPkg verbosity packagedbs (Right pkgInfo) =
-    (programInvocation hcPkg args) {
+registerInvocation' cmdname hpi verbosity packagedbs (Right pkgInfo) =
+    (programInvocation (hcPkgProgram hpi) args) {
       progInvokeInput         = Just (showInstalledPackageInfo pkgInfo),
       progInvokeInputEncoding = IOEncodingUTF8
     }
   where
     args = [cmdname, "-"]
-        ++ (if legacyVersion hcPkg
-              then [packageDbOpts hcPkg (last packagedbs)]
-              else packageDbStackOpts hcPkg packagedbs)
-        ++ verbosityOpts hcPkg verbosity
+        ++ (if noPkgDbStack hpi
+              then [packageDbOpts hpi (last packagedbs)]
+              else packageDbStackOpts hpi packagedbs)
+        ++ verbosityOpts hpi verbosity
 
 
-unregisterInvocation :: ConfiguredProgram
-                     -> Verbosity -> PackageDB -> PackageId
+unregisterInvocation :: HcPkgInfo -> Verbosity -> PackageDB -> PackageId
                      -> ProgramInvocation
-unregisterInvocation hcPkg verbosity packagedb pkgid =
-  programInvocation hcPkg $
-       ["unregister", packageDbOpts hcPkg packagedb, display pkgid]
-    ++ verbosityOpts hcPkg verbosity
+unregisterInvocation hpi verbosity packagedb pkgid =
+  programInvocation (hcPkgProgram hpi) $
+       ["unregister", packageDbOpts hpi packagedb, display pkgid]
+    ++ verbosityOpts hpi verbosity
 
 
-exposeInvocation :: ConfiguredProgram
-                 -> Verbosity -> PackageDB -> PackageId -> ProgramInvocation
-exposeInvocation hcPkg verbosity packagedb pkgid =
-  programInvocation hcPkg $
-       ["expose", packageDbOpts hcPkg packagedb, display pkgid]
-    ++ verbosityOpts hcPkg verbosity
+exposeInvocation :: HcPkgInfo -> Verbosity -> PackageDB -> PackageId
+                 -> ProgramInvocation
+exposeInvocation hpi verbosity packagedb pkgid =
+  programInvocation (hcPkgProgram hpi) $
+       ["expose", packageDbOpts hpi packagedb, display pkgid]
+    ++ verbosityOpts hpi verbosity
 
 
-hideInvocation :: ConfiguredProgram
-               -> Verbosity -> PackageDB -> PackageId -> ProgramInvocation
-hideInvocation hcPkg verbosity packagedb pkgid =
-  programInvocation hcPkg $
-       ["hide", packageDbOpts hcPkg packagedb, display pkgid]
-    ++ verbosityOpts hcPkg verbosity
+hideInvocation :: HcPkgInfo -> Verbosity -> PackageDB -> PackageId
+               -> ProgramInvocation
+hideInvocation hpi verbosity packagedb pkgid =
+  programInvocation (hcPkgProgram hpi) $
+       ["hide", packageDbOpts hpi packagedb, display pkgid]
+    ++ verbosityOpts hpi verbosity
 
 
-dumpInvocation :: ConfiguredProgram
-               -> Verbosity -> PackageDB -> ProgramInvocation
-dumpInvocation hcPkg _verbosity packagedb =
-    (programInvocation hcPkg args) {
+dumpInvocation :: HcPkgInfo -> Verbosity -> PackageDB -> ProgramInvocation
+dumpInvocation hpi _verbosity packagedb =
+    (programInvocation (hcPkgProgram hpi) args) {
       progInvokeOutputEncoding = IOEncodingUTF8
     }
   where
-    args = ["dump", packageDbOpts hcPkg packagedb]
-        ++ verbosityOpts hcPkg silent
+    args = ["dump", packageDbOpts hpi packagedb]
+        ++ verbosityOpts hpi silent
            -- We use verbosity level 'silent' because it is important that we
            -- do not contaminate the output with info/debug messages.
 
-listInvocation :: ConfiguredProgram
-               -> Verbosity -> PackageDB -> ProgramInvocation
-listInvocation hcPkg _verbosity packagedb =
-    (programInvocation hcPkg args) {
+listInvocation :: HcPkgInfo -> Verbosity -> PackageDB -> ProgramInvocation
+listInvocation hpi _verbosity packagedb =
+    (programInvocation (hcPkgProgram hpi) args) {
       progInvokeOutputEncoding = IOEncodingUTF8
     }
   where
-    args = ["list", "--simple-output", packageDbOpts hcPkg packagedb]
-        ++ verbosityOpts hcPkg silent
+    args = ["list", "--simple-output", packageDbOpts hpi packagedb]
+        ++ verbosityOpts hpi silent
            -- We use verbosity level 'silent' because it is important that we
            -- do not contaminate the output with info/debug messages.
 
 
-packageDbStackOpts :: ConfiguredProgram -> PackageDBStack -> [String]
-packageDbStackOpts hcPkg dbstack = case dbstack of
+packageDbStackOpts :: HcPkgInfo -> PackageDBStack -> [String]
+packageDbStackOpts hpi dbstack = case dbstack of
   (GlobalPackageDB:UserPackageDB:dbs) -> "--global"
                                        : "--user"
                                        : map specific dbs
   (GlobalPackageDB:dbs)               -> "--global"
-                                       : ("--no-user-" ++ packageDbFlag hcPkg)
+                                       : ("--no-user-" ++ packageDbFlag hpi)
                                        : map specific dbs
   _                                   -> ierror
   where
-    specific (SpecificPackageDB db) = "--" ++ packageDbFlag hcPkg ++ "=" ++ db
+    specific (SpecificPackageDB db) = "--" ++ packageDbFlag hpi ++ "=" ++ db
     specific _ = ierror
     ierror :: a
     ierror     = error ("internal error: unexpected package db stack: " ++ show dbstack)
 
-packageDbFlag :: ConfiguredProgram -> String
-packageDbFlag hcPkg
-  | programVersion hcPkg < Just (Version [7,5] [])
+packageDbFlag :: HcPkgInfo -> String
+packageDbFlag hpi
+  | flagPackageConf hpi
   = "package-conf"
   | otherwise
   = "package-db"
 
-packageDbOpts :: ConfiguredProgram -> PackageDB -> String
+packageDbOpts :: HcPkgInfo -> PackageDB -> String
 packageDbOpts _ GlobalPackageDB        = "--global"
 packageDbOpts _ UserPackageDB          = "--user"
-packageDbOpts hcPkg (SpecificPackageDB db) = "--" ++ packageDbFlag hcPkg ++ "=" ++ db
+packageDbOpts hpi (SpecificPackageDB db) = "--" ++ packageDbFlag hpi ++ "=" ++ db
 
-verbosityOpts :: ConfiguredProgram -> Verbosity -> [String]
-verbosityOpts hcPkg v
-
-  -- ghc-pkg < 6.11 does not support -v
-  | programId hcPkg == "ghc-pkg"
- && programVersion hcPkg < Just (Version [6,11] [])
+verbosityOpts :: HcPkgInfo -> Verbosity -> [String]
+verbosityOpts hpi v
+  | noVerboseFlag hpi
                    = []
-
   | v >= deafening = ["-v2"]
   | v == silent    = ["-v0"]
   | otherwise      = []
 
--- Handle quirks in ghc-pkg 6.8 and older
-legacyVersion :: ConfiguredProgram -> Bool
-legacyVersion hcPkg = programId hcPkg == "ghc-pkg"
-                   && programVersion hcPkg < Just (Version [6,9] [])

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -376,11 +376,11 @@ configureOptions showOrParseArgs =
 
       ,option [] ["compiler"] "compiler"
          configHcFlavor (\v flags -> flags { configHcFlavor = v })
-         (choiceOpt [ (Flag GHC, ("g", ["ghc"]), "compile with GHC")
-                    , (Flag JHC, ([] , ["jhc"]), "compile with JHC")
-                    , (Flag LHC, ([] , ["lhc"]), "compile with LHC")
-                    , (Flag UHC, ([] , ["uhc"]), "compile with UHC")
-
+         (choiceOpt [ (Flag GHC,   ("g", ["ghc"]),   "compile with GHC")
+                    , (Flag GHCJS, ([] , ["ghcjs"]), "compile with GHCJS")
+                    , (Flag JHC,   ([] , ["jhc"]),   "compile with JHC")
+                    , (Flag LHC,   ([] , ["lhc"]),   "compile with LHC")
+                    , (Flag UHC,   ([] , ["uhc"]),   "compile with UHC")
                     -- "haskell-suite" compiler id string will be replaced
                     -- by a more specific one during the configure stage
                     , (Flag (HaskellSuite "haskell-suite"), ([] , ["haskell-suite"]),

--- a/Cabal/Distribution/System.hs
+++ b/Cabal/Distribution/System.hs
@@ -73,6 +73,7 @@ data OS = Linux | Windows | OSX        -- tier 1 desktop OSs
         | Solaris | AIX | HPUX | IRIX  -- ageing Unix OSs
         | HaLVM                        -- bare metal / VMs / hypervisors
         | IOS                          -- iOS
+        | Ghcjs
         | OtherOS String
   deriving (Eq, Generic, Ord, Show, Read, Typeable, Data)
 
@@ -88,7 +89,8 @@ knownOSs = [Linux, Windows, OSX
            ,FreeBSD, OpenBSD, NetBSD, DragonFly
            ,Solaris, AIX, HPUX, IRIX
            ,HaLVM
-           ,IOS]
+           ,IOS
+           ,Ghcjs]
 
 osAliases :: ClassificationStrictness -> OS -> [String]
 osAliases Permissive Windows = ["mingw32", "win32", "cygwin32"]
@@ -126,6 +128,7 @@ data Arch = I386  | X86_64 | PPC | PPC64 | Sparc
           | IA64  | S390
           | Alpha | Hppa   | Rs6000
           | M68k  | Vax
+          | JavaScript
           | OtherArch String
   deriving (Eq, Generic, Ord, Show, Read, Typeable, Data)
 
@@ -136,7 +139,8 @@ knownArches = [I386, X86_64, PPC, PPC64, Sparc
               ,Arm, Mips, SH
               ,IA64, S390
               ,Alpha, Hppa, Rs6000
-              ,M68k, Vax]
+              ,M68k, Vax
+              ,JavaScript]
 
 archAliases :: ClassificationStrictness -> Arch -> [String]
 archAliases Strict _     = []

--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -489,7 +489,8 @@ independence](#prefix-independence)).
 
 `$abitag`
 :   An optional tag that a compiler can use for telling incompatible ABI's
-    on the same architecture apart.
+    on the same architecture apart. GHCJS encodes the underlying GHC version
+    in the ABI tag.
 
 `$abi`
 :   A shortcut for getting a path that completely identifies the platform in terms

--- a/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
+++ b/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
@@ -41,7 +41,7 @@ import Distribution.Client.Setup       ( GlobalFlags(..), ConfigExFlags(..)
                                        , defaultSandboxLocation )
 import Distribution.Utils.NubList            ( toNubList )
 import Distribution.Simple.Compiler    ( Compiler, PackageDB(..)
-                                       , compilerFlavor, showCompilerId )
+                                       , compilerFlavor, showCompilerIdWithAbi )
 import Distribution.Simple.InstallDirs ( InstallDirs(..), PathTemplate
                                        , defaultInstallDirs, combineInstallDirs
                                        , fromPathTemplate, toPathTemplate )
@@ -217,7 +217,7 @@ sandboxPackageDBPath :: FilePath -> Compiler -> Platform -> String
 sandboxPackageDBPath sandboxDir compiler platform =
     sandboxDir
          </> (Text.display platform ++ "-"
-             ++ showCompilerId compiler
+             ++ showCompilerIdWithAbi compiler
              ++ "-packages.conf.d")
 -- The path in sandboxPackageDBPath should be kept in sync with the
 -- path in the bootstrap.sh which is used to bootstrap cabal-install

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -34,7 +34,6 @@ import Distribution.Simple.Compiler
 import Distribution.Text (display)
 
 import Data.Map (Map)
-import qualified Data.Map as Map
 import Network.URI (URI)
 import Data.ByteString.Lazy (ByteString)
 import Control.Exception


### PR DESCRIPTION
This is the whole GHCJS build system, I've tested this with GHCJS based on GHC HEAD and on 7.8.3, `cabal install`, `cabal test`, `cabal run`, Haddock, sandboxes etc all work. Apologies for the rather large amount of code in a single commit. Fortunately most of the changes are relatively straightforward:
- some of the code in `Distribution.Simple.GHC` is moved to `Distribution.Simple.GHC.Internal`, from where it can be shared between multiple similar (GHC-derived) compilers.
- In order to make the shared code work reasonably well, many of the feature / quirk dependent code paths now use `GhcImplProps` from `Distribution.Simple.GHC.Props` rather than checking version numbers (which are different between the compilers). This mostly affects the Haddock and HcPkg modules and GHC command line rendering.
- The `GHCJS` flavor is handled throughout the code and in some places the hardcoded assumption that GHC is used has been removed (Building `Setup.hs` scripts and initializing package databases for example)
- The `Distribution.Simple.GHCJS` module contains most of the GHCJS-specific build code. It's very similar to `Distribution.Simple.GHC` and pretty big. More code can be shared with the GHC flavour, but that would have required more invasive restructuring of the code, which i didn't want to do in the first version.

Note that the reported architecture of the GHCJS compiler is that of the build machine. This is done to support `native-too` mode, where all code is built for the build machine too.

The `Cabal` library is compiled to JavaScript as part of the GHCJS installation procedure (`ghcjs-boot`). Some functionality (`createPipe`) is not yet supported, so I'm just throwing an exception there on the `ghcjs_HOST_OS` platform. The limitation should be removed at some later point.
