### PR TITLE
allow sandbox init for a specific compiler flavor

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1631,7 +1631,7 @@ sandboxCommand = CommandUI {
   commandSynopsis     = "Create/modify/delete a sandbox.",
   commandDescription  = Nothing,
   commandUsage        = \pname ->
-       "Usage: " ++ pname ++ " sandbox init\n"
+       "Usage: " ++ pname ++ " sandbox init [COMPILERFLAVOR]\n"
     ++ "   or: " ++ pname ++ " sandbox delete\n"
     ++ "   or: " ++ pname ++ " sandbox add-source  [PATHS]\n"
     ++ "   or: " ++ pname ++ " sandbox delete-source  [PATHS]\n\n"


### PR DESCRIPTION
I don't think it's possible currently to conveniently initialize a sandbox for a specific compiler, since `cabal sandbox init` always used the default one. If you set `compiler: ghcjs` in your cabal config, and then run `cabal sandbox init`, you get a sandbox initialized for `ghcjs`, with no `compiler` setting you get `ghc`.

A typical workflow for working on client side (ghcjs) code would be creating a sandbox and then adjusting the `compiler: ghcjs` setting for just the sandbox. This patch adds an optional compiler flavor to the `cabal sandbox init` command, to specificy the compiler for which to initialize. `cabal sandbox init ghcjs` initializes a sandbox for ghcjs, or add a ghcjs package database to an existing sandbox.
