### PR TITLE
Always setup (DY)LD_LIBRARY_PATH for testsuite

### DIFF
--- a/Cabal/Distribution/Simple/Test/ExeV10.hs
+++ b/Cabal/Distribution/Simple/Test/ExeV10.hs
@@ -83,7 +83,7 @@ runTest pkg_descr lbi flags suite = do
         shellEnv = [("HPCTIXFILE", tixFile) | isCoverageEnabled] ++ pkgPathEnv
 
     -- Add (DY)LD_LIBRARY_PATH if needed
-    shellEnv' <- if LBI.relocatable lbi && LBI.withDynExe lbi
+    shellEnv' <- if LBI.withDynExe lbi
                     then do let (Platform _ os) = LBI.hostPlatform lbi
                                 clbi = LBI.getComponentLocalBuildInfo lbi
                                          (LBI.CTestName (PD.testName suite))

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -90,7 +90,7 @@ runTest pkg_descr lbi flags suite = do
                     shellEnv = [("HPCTIXFILE", tixFile) | isCoverageEnabled]
                              ++ pkgPathEnv
                 -- Add (DY)LD_LIBRARY_PATH if needed
-                shellEnv' <- if LBI.relocatable lbi && LBI.withDynExe lbi
+                shellEnv' <- if LBI.withDynExe lbi
                                 then do
                                   let (Platform _ os) = LBI.hostPlatform lbi
                                       clbi = LBI.getComponentLocalBuildInfo

--- a/cabal-install/Distribution/Client/Run.hs
+++ b/cabal-install/Distribution/Client/Run.hs
@@ -81,7 +81,7 @@ run verbosity lbi exe exeArgs = do
 
   env  <- (dataDirEnvVar:) <$> getEnvironment
   -- Add (DY)LD_LIBRARY_PATH if needed
-  env' <- if relocatable lbi && withDynExe lbi
+  env' <- if withDynExe lbi
              then do let (Platform _ os) = hostPlatform lbi
                          clbi = getComponentLocalBuildInfo lbi
                                   (CExeName (exeName exe))


### PR DESCRIPTION
Now that Cabal is in charge of RPATH handling on certain OS',
we must always setup a correct (DY)LD_LIBRARY_PATH when
running the testsuite. Not just when we are building relocatable
packages.

The "problem" is, is that Cabal now adds an RPATH pointing
to the installation location of the library. However, during
testing, the library won't be there yet. We much hence setup
a (DY)LD_LIBRARY_PATH that includes the dist/build dir.
