### PR TITLE
Add cabal default dir flag

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -208,7 +208,8 @@ instance Monoid SavedConfig where
         globalLogsDir           = combine globalLogsDir,
         globalWorldFile         = combine globalWorldFile,
         globalRequireSandbox    = combine globalRequireSandbox,
-        globalIgnoreSandbox     = combine globalIgnoreSandbox
+        globalIgnoreSandbox     = combine globalIgnoreSandbox,
+        globalCabalDir          = combine globalCabalDir
         }
         where
           combine        = combine'        savedGlobalFlags

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -999,7 +999,7 @@ performInstallations verbosity
                             (packageId pkg) src' distPref $ \mpath ->
           installUnpackedPackage verbosity buildLimit installLock numJobs pkg_key
                                  (setupScriptOptions installedPkgIndex cacheLock)
-                                 miscOptions configFlags' installFlags haddockFlags
+                                 miscOptions configFlags' installFlags haddockFlags globalFlags
                                  cinfo platform pkg pkgoverride mpath useLogFile
 
   where
@@ -1308,6 +1308,7 @@ installUnpackedPackage
   -> ConfigFlags
   -> InstallFlags
   -> HaddockFlags
+  -> GlobalFlags
   -> CompilerInfo
   -> Platform
   -> PackageDescription
@@ -1317,7 +1318,7 @@ installUnpackedPackage
   -> IO BuildResult
 installUnpackedPackage verbosity buildLimit installLock numJobs pkg_key
                        scriptOptions miscOptions
-                       configFlags installFlags haddockFlags
+                       configFlags installFlags haddockFlags globalFlags
                        cinfo platform pkg pkgoverride workingDir useLogFile = do
 
   -- Override the .cabal file if necessary
@@ -1478,7 +1479,7 @@ installUnpackedPackage verbosity buildLimit installLock numJobs pkg_key
           scriptOptions { useLoggingHandle = logFileHandle
                         , useWorkingDir    = workingDir }
           (Just pkg)
-          cmd flags [])
+          cmd flags [] globalFlags)
 
     reexec cmd = do
       -- look for our own executable file and re-exec ourselves using a helper

--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -637,7 +637,7 @@ withSandboxPackageInfo verbosity configFlags globalFlags
 
   -- Get the package ids of modified (and installed) add-source deps.
   modifiedAddSourceDeps <- listModifiedDeps verbosity sandboxDir
-                           (compilerId comp) platform installedDepsMap
+                           (compilerId comp) platform installedDepsMap globalFlags
   -- 'fromJust' here is safe because 'modifiedAddSourceDeps' are guaranteed to
   -- be a subset of the keys of 'depsMap'.
   let modifiedDeps    = [ (modDepPath, fromJust $ M.lookup modDepPath depsMap)

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -312,6 +312,11 @@ globalCommand commands = CommandUI {
          "The location of the world file"
          globalWorldFile (\v flags -> flags { globalWorldFile = v })
          (reqArgFlag "FILE")
+
+      ,option [] ["cabal-default-dir"]
+         "The location of the cabal directory"
+         globalCabalDir (\v flags -> flags { globalCabalDir = v })
+         (reqArgFlag "DIR")
       ]
   }
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -120,7 +120,8 @@ data GlobalFlags = GlobalFlags {
     globalLogsDir           :: Flag FilePath,
     globalWorldFile         :: Flag FilePath,
     globalRequireSandbox    :: Flag Bool,
-    globalIgnoreSandbox     :: Flag Bool
+    globalIgnoreSandbox     :: Flag Bool,
+    globalCabalDir          :: Flag FilePath
   }
 
 defaultGlobalFlags :: GlobalFlags
@@ -135,7 +136,8 @@ defaultGlobalFlags  = GlobalFlags {
     globalLogsDir           = mempty,
     globalWorldFile         = mempty,
     globalRequireSandbox    = Flag False,
-    globalIgnoreSandbox     = Flag False
+    globalIgnoreSandbox     = Flag False,
+    globalCabalDir          = mempty
   }
 
 globalCommand :: [Command action] -> CommandUI GlobalFlags
@@ -325,7 +327,8 @@ instance Monoid GlobalFlags where
     globalLogsDir           = mempty,
     globalWorldFile         = mempty,
     globalRequireSandbox    = mempty,
-    globalIgnoreSandbox     = mempty
+    globalIgnoreSandbox     = mempty,
+    globalCabalDir          = mempty
   }
   mappend a b = GlobalFlags {
     globalVersion           = combine globalVersion,
@@ -338,7 +341,8 @@ instance Monoid GlobalFlags where
     globalLogsDir           = combine globalLogsDir,
     globalWorldFile         = combine globalWorldFile,
     globalRequireSandbox    = combine globalRequireSandbox,
-    globalIgnoreSandbox     = combine globalIgnoreSandbox
+    globalIgnoreSandbox     = combine globalIgnoreSandbox,
+    globalCabalDir          = combine globalCabalDir
   }
     where combine field = field a `mappend` field b
 

--- a/cabal-install/Distribution/Client/SrcDist.hs
+++ b/cabal-install/Distribution/Client/SrcDist.hs
@@ -22,7 +22,7 @@ import Distribution.Simple.Utils
          ( createDirectoryIfMissingVerbose, defaultPackageDesc
          , die, notice, withTempDirectory )
 import Distribution.Client.Setup
-         ( SDistFlags(..), SDistExFlags(..), ArchiveFormat(..) )
+         ( GlobalFlags(..), SDistFlags(..), SDistExFlags(..), ArchiveFormat(..) )
 import Distribution.Simple.Setup
          ( Flag(..), sdistCommand, flagToList, fromFlag, fromFlagOrDefault )
 import Distribution.Simple.BuildPaths ( srcPref)
@@ -39,8 +39,8 @@ import System.Process (runProcess, waitForProcess)
 import System.Exit    (ExitCode(..))
 
 -- |Create a source distribution.
-sdist :: SDistFlags -> SDistExFlags -> IO ()
-sdist flags exflags = do
+sdist :: SDistFlags -> SDistExFlags -> GlobalFlags -> IO ()
+sdist flags exflags globalFlags = do
   pkg <- return . flattenPackageDescription
          =<< readPackageDescription verbosity
          =<< defaultPackageDesc verbosity
@@ -59,7 +59,7 @@ sdist flags exflags = do
     -- Run 'setup sdist --output-directory=tmpDir' (or
     -- '--list-source'/'--output-directory=someOtherDir') in case we were passed
     -- those options.
-    setupWrapper verbosity setupOpts (Just pkg) sdistCommand (const flags') []
+    setupWrapper verbosity setupOpts (Just pkg) sdistCommand (const flags') [] globalFlags
 
     -- Unless we were given --list-sources or --output-directory ourselves,
     -- create an archive.


### PR DESCRIPTION
This adds a `cabal-default-dir` flag and configuration item. When this is set, it will be used to place `setup-exe-cache` in the right place, thus dealing with https://github.com/haskell/cabal/pull/1126 and https://github.com/haskell/cabal/issues/1242.

I am afraid I am not a regular cabal contributor, so I do not know all the places this should be used. I am most interested in dealing with `setup-exe-cache`, but I feel that it would be wrong to have this feature if it is blatantly disrespected elsewhere. What other places should this be used instead of `$HOME/.cabal`?
