### PR TITLE
Add support for emitting debug info

### DIFF
--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -40,6 +40,10 @@ module Distribution.Simple.Compiler (
         OptimisationLevel(..),
         flagToOptimisationLevel,
 
+        -- * Support for debug info levels
+        DebugInfoLevel(..),
+        flagToDebugInfoLevel,
+
         -- * Support for language extensions
         Flag,
         languageToFlags,
@@ -192,6 +196,33 @@ flagToOptimisationLevel (Just s) = case reads s of
     | otherwise -> error $ "Bad optimisation level: " ++ show i
                         ++ ". Valid values are 0..2"
   _             -> error $ "Can't parse optimisation level " ++ s
+
+-- ------------------------------------------------------------
+-- * Debug info levels
+-- ------------------------------------------------------------
+
+-- | Some compilers support emitting debug info. Some have different
+-- levels.  For compilers that do not the level is just capped to the
+-- level they do support.
+--
+data DebugInfoLevel = NoDebugInfo
+                    | MinimalDebugInfo
+                    | NormalDebugInfo
+                    | MaximalDebugInfo
+    deriving (Bounded, Enum, Eq, Generic, Read, Show)
+
+instance Binary DebugInfoLevel
+
+flagToDebugInfoLevel :: Maybe String -> DebugInfoLevel
+flagToDebugInfoLevel Nothing  = NormalDebugInfo
+flagToDebugInfoLevel (Just s) = case reads s of
+  [(i, "")]
+    | i >= fromEnum (minBound :: DebugInfoLevel)
+   && i <= fromEnum (maxBound :: DebugInfoLevel)
+                -> toEnum i
+    | otherwise -> error $ "Bad debug info level: " ++ show i
+                        ++ ". Valid values are 0..3"
+  _             -> error $ "Can't parse debug info level " ++ s
 
 -- ------------------------------------------------------------
 -- * Languages and Extensions

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -660,6 +660,7 @@ configure (pkg_descr0, pbi) cfg
                     withDynExe          = withDynExe_,
                     withProfExe         = withProfExe_,
                     withOptimization    = fromFlag $ configOptimization cfg,
+                    withDebugInfo       = fromFlag $ configDebugInfo cfg,
                     withGHCiLib         = fromFlagOrDefault ghciLibByDefault $
                                           configGHCiLib cfg,
                     splitObjs           = split_objs,

--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -48,6 +48,7 @@ data GhcImplInfo = GhcImplInfo
   , alwaysNondecIndent   :: Bool -- ^ NondecreasingIndentation is always on
   , flagGhciScript       :: Bool -- ^ -ghci-script flag supported
   , flagPackageConf      :: Bool -- ^ use package-conf instead of package-db
+  , flagDebugInfo        :: Bool -- ^ -g flag supported
   }
 
 getImplInfo :: Compiler -> GhcImplInfo
@@ -80,6 +81,7 @@ ghcVersionImplInfo (Version v _) = GhcImplInfo
   , alwaysNondecIndent   = v <  [7,1]
   , flagGhciScript       = v >= [7,2]
   , flagPackageConf      = v <  [7,5]
+  , flagDebugInfo        = v >= [7,10]
   }
 
 ghcjsVersionImplInfo :: Version -> Version -> GhcImplInfo
@@ -99,6 +101,7 @@ ghcjsVersionImplInfo _ghcjsVer _ghcVer = GhcImplInfo
   , alwaysNondecIndent   = False
   , flagGhciScript       = True
   , flagPackageConf      = False
+  , flagDebugInfo        = False
   }
 
 lhcVersionImplInfo :: Version -> GhcImplInfo

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -389,10 +389,11 @@ componentGhcOptions verbosity lbi bi clbi odir =
     toGhcOptimisation NormalOptimisation  = toFlag GhcNormalOptimisation
     toGhcOptimisation MaximumOptimisation = toFlag GhcMaximumOptimisation
 
+    -- GHC doesn't support debug info levels yet.
     toGhcDebugInfo NoDebugInfo      = mempty
-    toGhcDebugInfo MinimalDebugInfo = toFlag GhcMinimalDebugInfo
-    toGhcDebugInfo NormalDebugInfo  = toFlag GhcNormalDebugInfo
-    toGhcDebugInfo MaximalDebugInfo = toFlag GhcMaximalDebugInfo
+    toGhcDebugInfo MinimalDebugInfo = toFlag True
+    toGhcDebugInfo NormalDebugInfo  = toFlag True
+    toGhcDebugInfo MaximalDebugInfo = toFlag True
 
 -- | Strip out flags that are not supported in ghci
 filterGhciFlags :: [String] -> [String]

--- a/Cabal/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Simple/LocalBuildInfo.hs
@@ -73,7 +73,8 @@ import Distribution.Package
          ( PackageId, Package(..), InstalledPackageId(..), PackageKey
          , PackageName )
 import Distribution.Simple.Compiler
-         ( Compiler, compilerInfo, PackageDBStack, OptimisationLevel )
+         ( Compiler, compilerInfo, PackageDBStack, DebugInfoLevel
+         , OptimisationLevel )
 import Distribution.Simple.PackageIndex
          ( InstalledPackageIndex, allPackages )
 import Distribution.ModuleName ( ModuleName )
@@ -139,6 +140,7 @@ data LocalBuildInfo = LocalBuildInfo {
         withDynExe    :: Bool,  -- ^Whether to link executables dynamically
         withProfExe   :: Bool,  -- ^Whether to build executables for profiling.
         withOptimization :: OptimisationLevel, -- ^Whether to build with optimization (if available).
+        withDebugInfo :: DebugInfoLevel, -- ^Whether to emit debug info (if available).
         withGHCiLib   :: Bool,  -- ^Whether to build libs suitable for use with GHCi.
         splitObjs     :: Bool,  -- ^Use -split-objs with GHC, if available
         stripExes     :: Bool,  -- ^Whether to strip executables during install

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -2,6 +2,7 @@ module Distribution.Simple.Program.GHC (
     GhcOptions(..),
     GhcMode(..),
     GhcOptimisation(..),
+    GhcDebugInfo(..),
     GhcDynLinkMode(..),
 
     ghcInvocation,
@@ -152,6 +153,9 @@ data GhcOptions = GhcOptions {
   -- | What optimisation level to use; the @ghc -O@ flag.
   ghcOptOptimisation  :: Flag GhcOptimisation,
 
+    -- | What debug info level to use; the @ghc -g@ flag.
+  ghcOptDebugInfo  :: Flag GhcDebugInfo,
+
   -- | Compile in profiling mode; the @ghc -prof@ flag.
   ghcOptProfilingMode :: Flag Bool,
 
@@ -219,6 +223,12 @@ data GhcOptimisation = GhcNoOptimisation             -- ^ @-O0@
                      | GhcSpecialOptimisation String -- ^ e.g. @-Odph@
  deriving (Show, Eq)
 
+data GhcDebugInfo = GhcNoDebugInfo       -- ^ @-g0@
+                  | GhcMinimalDebugInfo  -- ^ @-g1@
+                  | GhcNormalDebugInfo   -- ^ @-g@
+                  | GhcMaximalDebugInfo  -- ^ @-g3@
+ deriving (Show, Eq)
+
 data GhcDynLinkMode = GhcStaticOnly       -- ^ @-static@
                     | GhcDynamicOnly      -- ^ @-dynamic@
                     | GhcStaticAndDynamic -- ^ @-static -dynamic-too@
@@ -272,6 +282,13 @@ renderGhcOptions comp opts
       Just GhcNormalOptimisation      -> ["-O"]
       Just GhcMaximumOptimisation     -> ["-O2"]
       Just (GhcSpecialOptimisation s) -> ["-O" ++ s] -- eg -Odph
+
+  , concat [ case flagToMaybe (ghcOptDebugInfo opts) of
+        Nothing                      -> []
+        Just GhcNoDebugInfo          -> ["-g0"]
+        Just GhcMinimalDebugInfo     -> ["-g1"]
+        Just GhcNormalDebugInfo      -> ["-g"]
+        Just GhcMaximalDebugInfo     -> ["-g3"] | flagDebugInfo implInfo ]
 
   , [ "-prof" | flagBool ghcOptProfilingMode ]
 
@@ -475,6 +492,7 @@ instance Monoid GhcOptions where
     ghcOptExtensions         = mempty,
     ghcOptExtensionMap       = mempty,
     ghcOptOptimisation       = mempty,
+    ghcOptDebugInfo          = mempty,
     ghcOptProfilingMode      = mempty,
     ghcOptSplitObjs          = mempty,
     ghcOptNumJobs            = mempty,
@@ -527,6 +545,7 @@ instance Monoid GhcOptions where
     ghcOptExtensions         = combine ghcOptExtensions,
     ghcOptExtensionMap       = combine ghcOptExtensionMap,
     ghcOptOptimisation       = combine ghcOptOptimisation,
+    ghcOptDebugInfo          = combine ghcOptDebugInfo,
     ghcOptProfilingMode      = combine ghcOptProfilingMode,
     ghcOptSplitObjs          = combine ghcOptSplitObjs,
     ghcOptNumJobs            = combine ghcOptNumJobs,

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -2,7 +2,6 @@ module Distribution.Simple.Program.GHC (
     GhcOptions(..),
     GhcMode(..),
     GhcOptimisation(..),
-    GhcDebugInfo(..),
     GhcDynLinkMode(..),
 
     ghcInvocation,
@@ -153,8 +152,8 @@ data GhcOptions = GhcOptions {
   -- | What optimisation level to use; the @ghc -O@ flag.
   ghcOptOptimisation  :: Flag GhcOptimisation,
 
-    -- | What debug info level to use; the @ghc -g@ flag.
-  ghcOptDebugInfo  :: Flag GhcDebugInfo,
+    -- | Emit debug info; the @ghc -g@ flag.
+  ghcOptDebugInfo  :: Flag Bool,
 
   -- | Compile in profiling mode; the @ghc -prof@ flag.
   ghcOptProfilingMode :: Flag Bool,
@@ -223,12 +222,6 @@ data GhcOptimisation = GhcNoOptimisation             -- ^ @-O0@
                      | GhcSpecialOptimisation String -- ^ e.g. @-Odph@
  deriving (Show, Eq)
 
-data GhcDebugInfo = GhcNoDebugInfo       -- ^ @-g0@
-                  | GhcMinimalDebugInfo  -- ^ @-g1@
-                  | GhcNormalDebugInfo   -- ^ @-g@
-                  | GhcMaximalDebugInfo  -- ^ @-g3@
- deriving (Show, Eq)
-
 data GhcDynLinkMode = GhcStaticOnly       -- ^ @-static@
                     | GhcDynamicOnly      -- ^ @-dynamic@
                     | GhcStaticAndDynamic -- ^ @-static -dynamic-too@
@@ -283,12 +276,7 @@ renderGhcOptions comp opts
       Just GhcMaximumOptimisation     -> ["-O2"]
       Just (GhcSpecialOptimisation s) -> ["-O" ++ s] -- eg -Odph
 
-  , concat [ case flagToMaybe (ghcOptDebugInfo opts) of
-        Nothing                      -> []
-        Just GhcNoDebugInfo          -> ["-g0"]
-        Just GhcMinimalDebugInfo     -> ["-g1"]
-        Just GhcNormalDebugInfo      -> ["-g"]
-        Just GhcMaximalDebugInfo     -> ["-g3"] | flagDebugInfo implInfo ]
+  , [ "-g" | flagDebugInfo implInfo && flagBool ghcOptDebugInfo ]
 
   , [ "-prof" | flagBool ghcOptProfilingMode ]
 

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -53,7 +53,7 @@ import Distribution.Utils.NubList
          ( NubList, fromNubList, toNubList)
 
 import Distribution.Simple.Compiler
-         ( OptimisationLevel(..) )
+         ( DebugInfoLevel(..), OptimisationLevel(..) )
 import Distribution.Simple.Setup
          ( ConfigFlags(..), configureOptions, defaultConfigFlags
          , HaddockFlags(..), haddockOptions, defaultHaddockFlags
@@ -261,6 +261,7 @@ instance Monoid SavedConfig where
         -- TODO: NubListify
         configConfigureArgs       = lastNonEmpty configConfigureArgs,
         configOptimization        = combine configOptimization,
+        configDebugInfo           = combine configDebugInfo,
         configProgPrefix          = combine configProgPrefix,
         configProgSuffix          = combine configProgSuffix,
         -- Parametrised by (Flag PathTemplate), so safe to use 'mappend'.
@@ -601,10 +602,11 @@ configFieldDescriptions =
        [simpleField "compiler"
           (fromFlagOrDefault Disp.empty . fmap Text.disp) (optional Text.parse)
           configHcFlavor (\v flags -> flags { configHcFlavor = v })
-        -- TODO: The following is a temporary fix. The "optimization" field is
-        -- OptArg, and viewAsFieldDescr fails on that. Instead of a hand-written
-        -- hackaged parser and printer, we should handle this case properly in
-        -- the library.
+        -- TODO: The following is a temporary fix. The "optimization"
+        -- and "debug-info" fields are OptArg, and viewAsFieldDescr
+        -- fails on that. Instead of a hand-written hackaged parser
+        -- and printer, we should handle this case properly in the
+        -- library.
        ,liftField configOptimization (\v flags -> flags { configOptimization = v }) $
         let name = "optimization" in
         FieldDescr name
@@ -621,6 +623,29 @@ configFieldDescriptions =
              |  str == "2"     -> ParseOk [] (Flag MaximumOptimisation)
              | lstr == "false" -> ParseOk [caseWarning] (Flag NoOptimisation)
              | lstr == "true"  -> ParseOk [caseWarning] (Flag NormalOptimisation)
+             | otherwise       -> ParseFailed (NoParse name line)
+             where
+               lstr = lowercase str
+               caseWarning = PWarning $
+                 "The '" ++ name ++ "' field is case sensitive, use 'True' or 'False'.")
+       ,liftField configDebugInfo (\v flags -> flags { configDebugInfo = v }) $
+        let name = "debug-info" in
+        FieldDescr name
+          (\f -> case f of
+                   Flag NoDebugInfo      -> Disp.text "False"
+                   Flag MinimalDebugInfo -> Disp.text "1"
+                   Flag NormalDebugInfo  -> Disp.text "True"
+                   Flag MaximalDebugInfo -> Disp.text "3"
+                   _                     -> Disp.empty)
+          (\line str _ -> case () of
+           _ |  str == "False" -> ParseOk [] (Flag NoDebugInfo)
+             |  str == "True"  -> ParseOk [] (Flag NormalDebugInfo)
+             |  str == "0"     -> ParseOk [] (Flag NoDebugInfo)
+             |  str == "1"     -> ParseOk [] (Flag MinimalDebugInfo)
+             |  str == "2"     -> ParseOk [] (Flag NormalDebugInfo)
+             |  str == "3"     -> ParseOk [] (Flag MaximalDebugInfo)
+             | lstr == "false" -> ParseOk [caseWarning] (Flag NoDebugInfo)
+             | lstr == "true"  -> ParseOk [caseWarning] (Flag NormalDebugInfo)
              | otherwise       -> ParseFailed (NoParse name line)
              where
                lstr = lowercase str


### PR DESCRIPTION
If the compiler (e.g. GHC 7.10) supports outputting OS native debug
info (e.g. DWARF) passing --enable-debug-info[=n] to cabal will
instruct it to do so.