### PR TITLE
Retain --enable-executable-profiling and --enable-library-coverage options

### DIFF
--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -575,14 +575,14 @@ configureOptions showOrParseArgs =
          configTests (\v flags -> flags { configTests = v })
          (boolOpt [] [])
 
-      ,option "" ["library-coverage"]
-         "OBSOLETE. Please use --enable-coverage instead."
-         configLibCoverage (\v flags -> flags { configLibCoverage = v })
+      ,option "" ["coverage"]
+         "build package with Haskell Program Coverage. (GHC only)"
+         configCoverage (\v flags -> flags { configCoverage = v })
          (boolOpt [] [])
 
-      ,option "" ["coverage"]
-         "build package with Haskell Program Coverage enabled. (GHC only)"
-         configCoverage (\v flags -> flags { configCoverage = v })
+      ,option "" ["library-coverage"]
+         "build package with Haskell Program Coverage. (GHC only) (OBSOLETE)"
+         configLibCoverage (\v flags -> flags { configLibCoverage = v })
          (boolOpt [] [])
 
       ,option "" ["exact-configuration"]

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -453,8 +453,13 @@ configureOptions showOrParseArgs =
          configDynExe (\v flags -> flags { configDynExe = v })
          (boolOpt [] [])
 
-      ,option "" ["profiling", "executable-profiling"]
+      ,option "" ["profiling"]
          "Executable profiling (requires library profiling)"
+         configProfExe (\v flags -> flags { configProfExe = v })
+         (boolOpt [] [])
+
+      ,option "" ["executable-profiling"]
+         "Executable profiling (DEPRECATED)"
          configProfExe (\v flags -> flags { configProfExe = v })
          (boolOpt [] [])
 


### PR DESCRIPTION
Fix for #2313, rebased onto 1.22.