### PR TITLE
Fix compiler warning.

### DIFF
--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -15,7 +15,7 @@ module Distribution.Simple.GHC.ImplInfo (
         ) where
 
 import Distribution.Simple.Compiler
-  ( Compiler(..), CompilerId(..), CompilerFlavor(..)
+  ( Compiler(..), CompilerFlavor(..)
   , compilerFlavor, compilerVersion, compilerCompatVersion )
 import Distribution.Version ( Version(..) )
 


### PR DESCRIPTION
This was warning about CompilerId being a redundant import.