### PR TITLE
Change `moreRecentFile` test to workaround races

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -100,7 +100,7 @@ import Distribution.Simple.BuildPaths
     ( autogenModulesDir )
 import Distribution.Simple.Utils
     ( die, warn, info, setupMessage
-    , createDirectoryIfMissingVerbose, moreRecentFile
+    , createDirectoryIfMissingVerbose, notLessRecentFile
     , intercalate, cabalVersion
     , writeFileAtomic
     , withTempFile )
@@ -281,7 +281,7 @@ showHeader pkgId = BLC8.unwords
 -- .cabal file.
 checkPersistBuildConfigOutdated :: FilePath -> FilePath -> IO Bool
 checkPersistBuildConfigOutdated distPref pkg_descr_file = do
-  pkg_descr_file `moreRecentFile` (localBuildInfoFile distPref)
+  pkg_descr_file `notLessRecentFile` (localBuildInfoFile distPref)
 
 -- |@dist\/setup-config@
 localBuildInfoFile :: FilePath -> FilePath

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -51,7 +51,7 @@ import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.BuildPaths (autogenModulesDir,cppHeaderName)
 import Distribution.Simple.Utils
          ( createDirectoryIfMissingVerbose, withUTF8FileContents, writeUTF8File
-         , die, setupMessage, intercalate, copyFileVerbose, moreRecentFile
+         , die, setupMessage, intercalate, copyFileVerbose, notLessRecentFile
          , findFileWithExtension, findFileWithExtension' )
 import Distribution.Simple.Program
          ( Program(..), ConfiguredProgram(..), programPath
@@ -269,7 +269,7 @@ preprocessFile searchLoc buildLoc forSDist baseFile verbosity builtinSuffixes ha
               recomp <- case ppsrcFiles of
                           Nothing -> return True
                           Just ppsrcFile ->
-                              psrcFile `moreRecentFile` ppsrcFile
+                              psrcFile `notLessRecentFile` ppsrcFile
               when recomp $ do
                 let destDir = buildLoc </> dirName srcStem
                 createDirectoryIfMissingVerbose verbosity True destDir


### PR DESCRIPTION
This changes `moreRecentFile a b` to return true not only when `a`
is younger than `b`, but also when `a` is exactly the same age of `b`, as
that case is subject to race-conditions, and it's better to err on assuming
it needs to be regenerated.

This is an attempt to provide a pragmatic workaround for #2311
