### PR TITLE
add Android OS

### DIFF
--- a/Cabal/Distribution/System.hs
+++ b/Cabal/Distribution/System.hs
@@ -72,24 +72,19 @@ data OS = Linux | Windows | OSX        -- tier 1 desktop OSs
         | DragonFly
         | Solaris | AIX | HPUX | IRIX  -- ageing Unix OSs
         | HaLVM                        -- bare metal / VMs / hypervisors
-        | IOS                          -- iOS
+        | IOS  | Android               -- mobile OSs
         | Ghcjs
         | OtherOS String
   deriving (Eq, Generic, Ord, Show, Read, Typeable, Data)
 
 instance Binary OS
 
---TODO: decide how to handle Android and iOS.
--- They are like Linux and OSX but with some differences.
--- Should they be separate from Linux/OS X, or a subtype?
--- e.g. should we have os(linux) && os(android) true simultaneously?
-
 knownOSs :: [OS]
 knownOSs = [Linux, Windows, OSX
            ,FreeBSD, OpenBSD, NetBSD, DragonFly
            ,Solaris, AIX, HPUX, IRIX
            ,HaLVM
-           ,IOS
+           ,IOS, Android
            ,Ghcjs]
 
 osAliases :: ClassificationStrictness -> OS -> [String]


### PR DESCRIPTION
See https://github.com/haskell/cabal/issues/2348

Though Android OSs are based on Linux, they have very unique APIs that desktop OSs do not have.
e.g. Bonic C lib, /dev/binder, libandroid.so, lots of Java native APIs, etc.
Plus, Android has own different directory structures, environment variables, application starting scheme and security.
I think it seems better choise to distinguish mobile platforms from desktop OSs.