### PR TITLE
Compatibility options for profiling and coverage

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -308,6 +308,13 @@ configure (pkg_descr0, pbi) cfg
 
         setupMessage verbosity "Configuring" (packageId pkg_descr0)
 
+        unless (configProfExe cfg == NoFlag) $ do
+          let enable | fromFlag (configProfExe cfg) = "enable"
+                     | otherwise = "disable"
+          warn verbosity
+            ("The flag --" ++ enable ++ "-executable-profiling is deprecated. "
+             ++ "Please use --" ++ enable ++ "-profiling instead.")
+
         createDirectoryIfMissingVerbose (lessVerbose verbosity) True distPref
 
         let programsConfig = mkProgramsConfig cfg (configPrograms cfg)
@@ -627,12 +634,18 @@ configure (pkg_descr0, pbi) cfg
             ++ "is not being built. Linking will fail if any executables "
             ++ "depend on the library."
 
-        let withProfExe_ = fromFlagOrDefault False $ configProfExe cfg
+        let withProf_ = fromFlagOrDefault False (configProf cfg)
+            withProfExe_ = fromFlagOrDefault withProf_ $ configProfExe cfg
             withProfLib_ = fromFlagOrDefault withProfExe_ $ configProfLib cfg
         when (withProfExe_ && not withProfLib_) $ warn verbosity $
                "Executables will be built with profiling, but library "
             ++ "profiling is disabled. Linking will fail if any executables "
             ++ "depend on the library."
+
+        let configCoverage_ =
+              mappend (configCoverage cfg) (configLibCoverage cfg)
+
+            cfg' = cfg { configCoverage = configCoverage_ }
 
         reloc <-
            if not (fromFlag $ configRelocatable cfg)

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -296,13 +296,7 @@ localBuildInfoFile distPref = distPref </> "setup-config"
 configure :: (GenericPackageDescription, HookedBuildInfo)
           -> ConfigFlags -> IO LocalBuildInfo
 configure (pkg_descr0, pbi) cfg
-  = do  unless (configLibCoverage cfg == NoFlag) $ do
-            let enable | fromFlag (configLibCoverage cfg) = "enable"
-                       | otherwise = "disable"
-            die $ "Option --" ++ enable ++ "-library-coverage is obsolete! "
-                  ++ "Please use --" ++ enable ++ "-coverage instead."
-
-        let distPref = fromFlag (configDistPref cfg)
+  = do  let distPref = fromFlag (configDistPref cfg)
             buildDir' = distPref </> "build"
             verbosity = fromFlag (configVerbosity cfg)
 
@@ -314,6 +308,13 @@ configure (pkg_descr0, pbi) cfg
           warn verbosity
             ("The flag --" ++ enable ++ "-executable-profiling is deprecated. "
              ++ "Please use --" ++ enable ++ "-profiling instead.")
+
+        unless (configLibCoverage cfg == NoFlag) $ do
+          let enable | fromFlag (configLibCoverage cfg) = "enable"
+                     | otherwise = "disable"
+          warn verbosity
+            ("The flag --" ++ enable ++ "-library-coverage is deprecated. "
+             ++ "Please use --" ++ enable ++ "-coverage instead.")
 
         createDirectoryIfMissingVerbose (lessVerbose verbosity) True distPref
 
@@ -653,7 +654,7 @@ configure (pkg_descr0, pbi) cfg
                 else return True
 
         let lbi = LocalBuildInfo {
-                    configFlags         = cfg,
+                    configFlags         = cfg',
                     extraConfigArgs     = [],  -- Currently configure does not
                                                -- take extra args, but if it
                                                -- did they would go here.

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -287,6 +287,8 @@ data ConfigFlags = ConfigFlags {
                                           -- executables.
     configProfExe       :: Flag Bool,     -- ^Enable profiling in the
                                           -- executables.
+    configProf          :: Flag Bool,     -- ^Enable profiling in the library
+                                          -- and executables.
     configConfigureArgs :: [String],      -- ^Extra arguments to @configure@
     configOptimization  :: Flag OptimisationLevel,  -- ^Enable optimization.
     configProgPrefix    :: Flag PathTemplate, -- ^Installed executable prefix.
@@ -342,6 +344,7 @@ defaultConfigFlags progConf = emptyConfigFlags {
     configSharedLib    = NoFlag,
     configDynExe       = Flag False,
     configProfExe      = NoFlag,
+    configProf         = NoFlag,
     configOptimization = Flag NormalOptimisation,
     configProgPrefix   = Flag (toPathTemplate ""),
     configProgSuffix   = Flag (toPathTemplate ""),
@@ -455,7 +458,7 @@ configureOptions showOrParseArgs =
 
       ,option "" ["profiling"]
          "Executable profiling (requires library profiling)"
-         configProfExe (\v flags -> flags { configProfExe = v })
+         configProf (\v flags -> flags { configProf = v })
          (boolOpt [] [])
 
       ,option "" ["executable-profiling"]
@@ -728,6 +731,7 @@ instance Monoid ConfigFlags where
     configSharedLib     = mempty,
     configDynExe        = mempty,
     configProfExe       = mempty,
+    configProf          = mempty,
     configConfigureArgs = mempty,
     configOptimization  = mempty,
     configProgPrefix    = mempty,
@@ -770,6 +774,7 @@ instance Monoid ConfigFlags where
     configSharedLib     = combine configSharedLib,
     configDynExe        = combine configDynExe,
     configProfExe       = combine configProfExe,
+    configProf          = combine configProf,
     configConfigureArgs = combine configConfigureArgs,
     configOptimization  = combine configOptimization,
     configProgPrefix    = combine configProgPrefix,

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -316,7 +316,7 @@ data ConfigFlags = ConfigFlags {
     configTests               :: Flag Bool, -- ^Enable test suite compilation
     configBenchmarks          :: Flag Bool, -- ^Enable benchmark compilation
     configCoverage :: Flag Bool, -- ^Enable program coverage
-    configLibCoverage :: Flag Bool, -- ^OBSOLETE. Just used to signal error.
+    configLibCoverage :: Flag Bool, -- ^Enable program coverage (deprecated)
     configExactConfiguration  :: Flag Bool,
       -- ^All direct dependencies and flags are provided on the command line by
       -- the user via the '--dependency' and '--flags' options.
@@ -584,7 +584,7 @@ configureOptions showOrParseArgs =
          (boolOpt [] [])
 
       ,option "" ["library-coverage"]
-         "build package with Haskell Program Coverage. (GHC only) (OBSOLETE)"
+         "build package with Haskell Program Coverage. (GHC only) (DEPRECATED)"
          configLibCoverage (\v flags -> flags { configLibCoverage = v })
          (boolOpt [] [])
 

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -255,6 +255,7 @@ instance Monoid SavedConfig where
         configHcPkg               = combine configHcPkg,
         configVanillaLib          = combine configVanillaLib,
         configProfLib             = combine configProfLib,
+        configProf                = combine configProf,
         configSharedLib           = combine configSharedLib,
         configDynExe              = combine configDynExe,
         configProfExe             = combine configProfExe,

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -389,6 +389,8 @@ filterConfigureFlags flags cabalLibVersion
                    , configProfExe = configProf flags
                    , configProfLib =
                      mappend (configProf flags) (configProfLib flags)
+                   , configCoverage = NoFlag
+                   , configLibCoverage = configCoverage flags
                    }
     -- Cabal < 1.19.2 doesn't know about '--exact-configuration'.
     flags_1_19_1 = flags_1_20_0 { configExactConfiguration = NoFlag }

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -382,7 +382,14 @@ filterConfigureFlags flags cabalLibVersion
     flags_latest = flags        { configConstraints = [] }
 
     -- Cabal < 1.21.1 doesn't know about 'disable-relocatable'
-    flags_1_20_0 = flags_latest { configRelocatable = NoFlag }
+    -- Cabal < 1.21.1 doesn't know about 'enable-profiling'
+    flags_1_20_0 =
+      flags_latest { configRelocatable = NoFlag
+                   , configProf = NoFlag
+                   , configProfExe = configProf flags
+                   , configProfLib =
+                     mappend (configProf flags) (configProfLib flags)
+                   }
     -- Cabal < 1.19.2 doesn't know about '--exact-configuration'.
     flags_1_19_1 = flags_1_20_0 { configExactConfiguration = NoFlag }
     -- Cabal < 1.19.1 uses '--constraint' instead of '--dependency'.


### PR DESCRIPTION
This re-enables `--enable-library-coverage` and `--enable-executable-profiling`, but using these options will produce a warning about their deprecation. cabal-install will filter the options so `--enable-coverage` and `--enable-profiling` aren't passed to an old Cabal.