### PR TITLE
Export componentCcGhcOptions

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -41,6 +41,7 @@ module Distribution.Simple.GHC (
         hcPkgInfo,
         registerPackage,
         componentGhcOptions,
+        componentCcGhcOptions,
         getLibDir,
         isDynamic,
         getGlobalPackageDB,
@@ -951,6 +952,16 @@ componentGhcOptions :: Verbosity -> LocalBuildInfo
                     -> BuildInfo -> ComponentLocalBuildInfo -> FilePath
                     -> GhcOptions
 componentGhcOptions = Internal.componentGhcOptions
+
+componentCcGhcOptions :: Verbosity -> LocalBuildInfo
+                      -> BuildInfo -> ComponentLocalBuildInfo
+                      -> FilePath -> FilePath
+                      -> GhcOptions
+componentCcGhcOptions verbosity lbi =
+    Internal.componentCcGhcOptions verbosity implInfo lbi
+  where
+    comp     = compiler lbi
+    implInfo = getImplInfo comp
 
 -- -----------------------------------------------------------------------------
 -- Installing


### PR DESCRIPTION
This is useful for clients who use Cabal to call the C compiler, and cannot be defined client side because it requires the `.GHC.Internal` module.