### PR TITLE
rollback API changes about --enable-profiling

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -302,13 +302,6 @@ configure (pkg_descr0, pbi) cfg
 
         setupMessage verbosity "Configuring" (packageId pkg_descr0)
 
-        unless (configProfExe cfg == NoFlag) $ do
-          let enable | fromFlag (configProfExe cfg) = "enable"
-                     | otherwise = "disable"
-          warn verbosity
-            ("The flag --" ++ enable ++ "-executable-profiling is deprecated. "
-             ++ "Please use --" ++ enable ++ "-profiling instead.")
-
         unless (configLibCoverage cfg == NoFlag) $ do
           let enable | fromFlag (configLibCoverage cfg) = "enable"
                      | otherwise = "disable"
@@ -635,8 +628,7 @@ configure (pkg_descr0, pbi) cfg
             ++ "is not being built. Linking will fail if any executables "
             ++ "depend on the library."
 
-        let withProf_ = fromFlagOrDefault False (configProf cfg)
-            withProfExe_ = fromFlagOrDefault withProf_ $ configProfExe cfg
+        let withProfExe_ = fromFlagOrDefault False $ configProfExe cfg
             withProfLib_ = fromFlagOrDefault withProfExe_ $ configProfLib cfg
         when (withProfExe_ && not withProfLib_) $ warn verbosity $
                "Executables will be built with profiling, but library "

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -287,8 +287,6 @@ data ConfigFlags = ConfigFlags {
                                           -- executables.
     configProfExe       :: Flag Bool,     -- ^Enable profiling in the
                                           -- executables.
-    configProf          :: Flag Bool,     -- ^Enable profiling in the library
-                                          -- and executables.
     configConfigureArgs :: [String],      -- ^Extra arguments to @configure@
     configOptimization  :: Flag OptimisationLevel,  -- ^Enable optimization.
     configProgPrefix    :: Flag PathTemplate, -- ^Installed executable prefix.
@@ -344,7 +342,6 @@ defaultConfigFlags progConf = emptyConfigFlags {
     configSharedLib    = NoFlag,
     configDynExe       = Flag False,
     configProfExe      = NoFlag,
-    configProf         = NoFlag,
     configOptimization = Flag NormalOptimisation,
     configProgPrefix   = Flag (toPathTemplate ""),
     configProgSuffix   = Flag (toPathTemplate ""),
@@ -458,7 +455,7 @@ configureOptions showOrParseArgs =
 
       ,option "" ["profiling"]
          "Executable profiling (requires library profiling)"
-         configProf (\v flags -> flags { configProf = v })
+         configProfExe (\v flags -> flags { configProfLib = v, configProfExe = v })
          (boolOpt [] [])
 
       ,option "" ["executable-profiling"]
@@ -731,7 +728,6 @@ instance Monoid ConfigFlags where
     configSharedLib     = mempty,
     configDynExe        = mempty,
     configProfExe       = mempty,
-    configProf          = mempty,
     configConfigureArgs = mempty,
     configOptimization  = mempty,
     configProgPrefix    = mempty,
@@ -774,7 +770,6 @@ instance Monoid ConfigFlags where
     configSharedLib     = combine configSharedLib,
     configDynExe        = combine configDynExe,
     configProfExe       = combine configProfExe,
-    configProf          = combine configProf,
     configConfigureArgs = combine configConfigureArgs,
     configOptimization  = combine configOptimization,
     configProgPrefix    = combine configProgPrefix,

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -255,7 +255,6 @@ instance Monoid SavedConfig where
         configHcPkg               = combine configHcPkg,
         configVanillaLib          = combine configVanillaLib,
         configProfLib             = combine configProfLib,
-        configProf                = combine configProf,
         configSharedLib           = combine configSharedLib,
         configDynExe              = combine configDynExe,
         configProfExe             = combine configProfExe,

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -385,10 +385,8 @@ filterConfigureFlags flags cabalLibVersion
     -- Cabal < 1.21.1 doesn't know about 'enable-profiling'
     flags_1_20_0 =
       flags_latest { configRelocatable = NoFlag
-                   , configProf = NoFlag
-                   , configProfExe = configProf flags
-                   , configProfLib =
-                     mappend (configProf flags) (configProfLib flags)
+                   , configProfExe = configProfExe flags
+                   , configProfLib = configProfLib flags
                    , configCoverage = NoFlag
                    , configLibCoverage = configCoverage flags
                    }


### PR DESCRIPTION
Now the released version of cabal-install can be built against
Cabal-1.22.1.0, and there is no need to modify the upper bound on
Hackage. This change prevents Cabal-1.22.1.0 from emitting deprecation
warnings about --enable-executable-profiling, but the correct behavior
of --enable-profiling is preserved. There is no need to rollback the API
changes on master; cabal-install already requires Cabal to have the same
major version.

Tested against cabal-install-1.22.0.0 and cabal-install from the same git branch.

Fixes #2389.