### PR TITLE
Auto-generate CHANGELOG.md in cabal init

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -257,12 +257,13 @@ guessExtraSourceFiles flags = do
     maybe getCurrentDirectory return . flagToMaybe $ packageDir flags
   files <- getDirectoryContents dir
   let extraFiles = filter isExtra files
-  if any (likeFileNameBase changelogLikeBases) extraFiles
+  if any isLikeChangelog extraFiles
     then return extraFiles
     else return (defaultChangelog : extraFiles)
 
   where
     isExtra = likeFileNameBase ("README" : changelogLikeBases)
+    isLikeChangelog = likeFileNameBase changelogLikeBases
     likeFileNameBase candidates = (`elem` candidates) . map toUpper . takeBaseName
     changelogLikeBases = ["CHANGES", "CHANGELOG"]
 

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -107,6 +107,7 @@ initCabal verbosity packageDBs comp conf initFlags = do
 
   writeLicense initFlags'
   writeSetupFile initFlags'
+  writeChangelog initFlags'
   createSourceDirectories initFlags'
   success <- writeCabalFile initFlags'
 
@@ -626,6 +627,21 @@ writeSetupFile flags = do
     [ "import Distribution.Simple"
     , "main = defaultMain"
     ]
+
+writeChangelog :: InitFlags -> IO ()
+writeChangelog flags = do
+  message flags "Generating changelog.md..."
+  writeFileSafe flags "changelog.md" changelog
+ where
+  changelog = unlines
+    [ "# Revision history for " ++ pname
+    , ""
+    , "## " ++ pver ++ "  YYYY-mm-dd"
+    , ""
+    , "* First version. Released on an unsuspecting world."
+    ]
+  pname = maybe "" display $ flagToMaybe $ packageName flags
+  pver = maybe "" display $ flagToMaybe $ version flags
 
 writeCabalFile :: InitFlags -> IO Bool
 writeCabalFile flags@(InitFlags{packageName = NoFlag}) = do

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -264,7 +264,7 @@ guessExtraSourceFiles flags = do
   where
     isExtra = likeFileNameBase ("README" : changelogLikeBases)
     likeFileNameBase candidates = (`elem` candidates) . map toUpper . takeBaseName
-    changelogLikeBases = ["CHANGES", "CHANGLOG"]
+    changelogLikeBases = ["CHANGES", "CHANGELOG"]
 
 -- | Ask whether the project builds a library or executable.
 getLibOrExec :: InitFlags -> IO InitFlags


### PR DESCRIPTION
This patch makes `cabal init` auto-generate a skeleton CHANGELOG.md, motivating hackage developers to write proper changelogs for their hackages.

The auto-generated CHANGELOG.md is included in `extra-source-files` field in .cabal file. If there's already a changelog-like file, it won't auto-generate CHANGELOG.md.
