### PR TITLE
Reconfigure when there is no cabal file, fix #1905

### DIFF
--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -131,6 +131,7 @@ import Distribution.Simple.Configure
 import qualified Distribution.Simple.LocalBuildInfo as LBI
 import Distribution.Simple.Program (defaultProgramConfiguration
                                    ,configureAllKnownPrograms)
+import Distribution.Simple.Program.Db (reconfigurePrograms)
 import qualified Distribution.Simple.Setup as Cabal
 import Distribution.Simple.Utils
          ( cabalVersion, die, notice, info, topHandler
@@ -406,7 +407,11 @@ replAction (replFlags, buildExFlags) extraArgs globalFlags = do
                                mempty
       let configFlags = savedConfigureFlags config
       (comp, _platform, programDb) <- configCompilerAux' configFlags
-      startInterpreter verbosity programDb comp (configPackageDB' configFlags)
+      programDb' <- reconfigurePrograms verbosity
+                                        (replProgramPaths replFlags)
+                                        (replProgramArgs replFlags)
+                                        programDb
+      startInterpreter verbosity programDb' comp (configPackageDB' configFlags)
 
 -- | Re-configure the package in the current directory if needed. Deciding
 -- when to reconfigure and with which options is convoluted:


### PR DESCRIPTION
This is done so that arguments such as --with-ghc get picked up.

I am not sure if there are any places where reconfiguring will cause problems. It seemed to work fine for me™.