### PR TITLE
cabal-install.cabal : Add missing test dependency.

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -231,6 +231,7 @@ test-suite package-tests
   other-modules:
     PackageTests.Exec.Check
     PackageTests.Freeze.Check
+    PackageTests.MultipleSource.Check
     PackageTests.PackageTester
   build-depends:
     Cabal,


### PR DESCRIPTION
Closes: https://github.com/haskell/cabal/issues/2447