### PR TITLE
Treat -O2 in ghc-options as a cabal check "warning"

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -108,6 +108,10 @@ data PackageCheck =
        -- ban them entirely.
      | PackageDistSuspicious { explanation :: String }
 
+       -- | Like PackageDistSuspicious but will only display warnings
+       -- rather than causing abnormal exit.
+     | PackageDistSuspiciousWarn { explanation :: String }
+
        -- | An issue that is OK in the author's environment but is almost
        -- certain to be a portability problem for other environments. We can
        -- quite legitimately refuse to publicly distribute packages with these
@@ -664,7 +668,7 @@ checkGhcOptions pkg =
       ++ "Setting it yourself interferes with the --disable-optimization flag."
 
   , checkFlags ["-O2"] $
-      PackageDistSuspicious $
+      PackageDistSuspiciousWarn $
       "'ghc-options: -O2' is rarely needed. "
       ++ "Check that it is giving a real benefit "
       ++ "and not just imposing longer compile times on your users."

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -455,8 +455,9 @@ printPackageProblems :: Verbosity -> PackageDescription -> IO ()
 printPackageProblems verbosity pkg_descr = do
   ioChecks      <- checkPackageFiles pkg_descr "."
   let pureChecks = checkConfiguredPackage pkg_descr
-      isDistError (PackageDistSuspicious _) = False
-      isDistError _                         = True
+      isDistError (PackageDistSuspicious     _) = False
+      isDistError (PackageDistSuspiciousWarn _) = False
+      isDistError _                             = True
       (errors, warnings) = partition isDistError (pureChecks ++ ioChecks)
   unless (null errors) $
       notice verbosity $ "Distribution quality errors:\n"

--- a/cabal-install/Distribution/Client/Check.hs
+++ b/cabal-install/Distribution/Client/Check.hs
@@ -50,6 +50,7 @@ check verbosity = do
         buildImpossible = [ x | x@PackageBuildImpossible {} <- packageChecks ]
         buildWarning    = [ x | x@PackageBuildWarning {}    <- packageChecks ]
         distSuspicious  = [ x | x@PackageDistSuspicious {}  <- packageChecks ]
+                          ++ [ x | x@PackageDistSuspiciousWarn {}  <- packageChecks ]
         distInexusable  = [ x | x@PackageDistInexcusable {} <- packageChecks ]
 
     unless (null buildImpossible) $ do
@@ -68,8 +69,11 @@ check verbosity = do
         putStrLn "The following errors will cause portability problems on other environments:"
         printCheckMessages distInexusable
 
-    let isDistError (PackageDistSuspicious {}) = False
-        isDistError _                          = True
+    let isDistError (PackageDistSuspicious     {}) = False
+        isDistError (PackageDistSuspiciousWarn {}) = False
+        isDistError _                              = True
+        isCheckError (PackageDistSuspiciousWarn {}) = False
+        isCheckError _                              = True
         errors = filter isDistError packageChecks
 
     unless (null errors) $
@@ -78,7 +82,7 @@ check verbosity = do
     when (null packageChecks) $
         putStrLn "No errors or warnings could be found in the package."
 
-    return (null packageChecks)
+    return (null . filter isCheckError $ packageChecks)
 
   where
     printCheckMessages = mapM_ (putStrLn . format . explanation)


### PR DESCRIPTION
Setup:
```
  % cat stats.cabal | grep ghc-options
    ghc-options: -Wall -threaded -O2
```

Before:
```
  % ../cabal/cabal-install/dist/build/cabal/cabal check
  These warnings may cause trouble when distributing the package:
  * 'ghc-options: -O2' is rarely needed. Check that it is giving a real benefit
  and not just imposing longer compile times on your users.


  % echo $?
  1
```

After:
```
  % ../cabal/cabal-install/dist/build/cabal/cabal check
  These warnings may cause trouble when distributing the package:
  * 'ghc-options: -O2' is rarely needed. Check that it is giving a real benefit
  and not just imposing longer compile times on your users.


  % echo $?
  0
```

This fixes #1764
