### PR TITLE
Make sure to pass the package key to ghc

### DIFF
--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -162,7 +162,6 @@ haddock pkg_descr _ _ haddockFlags
         ++ " --benchmarks flags."
 
 haddock pkg_descr lbi suffixes flags = do
-
     setupMessage verbosity "Running Haddock for" (packageId pkg_descr)
     (confHaddock, version, _) <-
       requireProgramVersion verbosity haddockProgram
@@ -308,9 +307,10 @@ fromLibrary verbosity tmp lbi lib clbi htmlTemplate haddockVersion = do
                           -- haddock stomps on our precious .hi
                           -- and .o files. Workaround by telling
                           -- haddock to write them elsewhere.
-                          ghcOptObjDir  = toFlag tmp,
-                          ghcOptHiDir   = toFlag tmp,
-                          ghcOptStubDir = toFlag tmp
+                          ghcOptObjDir     = toFlag tmp,
+                          ghcOptHiDir      = toFlag tmp,
+                          ghcOptStubDir    = toFlag tmp,
+                          ghcOptPackageKey = toFlag $ pkgKey lbi
                       } `mappend` getGhcCppOpts haddockVersion bi
         sharedOpts = vanillaOpts {
                          ghcOptDynLinkMode = toFlag GhcDynamicOnly,
@@ -498,8 +498,7 @@ renderPureArgs version comp args = concat
                       , "--package-version="++display (pkgVersion pkg)
                       ])
              . fromFlag . argPackageName $ args
-        else (\pname -> ["--optghc=-package-name", "--optghc=" ++ pname])
-             . display . fromFlag . argPackageName $ args
+        else []
 
     , (\(All b,xs) -> bool (map (("--hide=" ++). display) xs) [] b)
                      . argHideModules $ args


### PR DESCRIPTION
In https://github.com/haskell/cabal/pull/2439 the invocation of Haddock is
changed to use Haddock's new `--package-name` and `--package-version` flags,
necessary for GHC >= 7.10 (Cabal issue
https://github.com/haskell/cabal/issues/2297 / Haddock issue
https://github.com/haskell/haddock/issues/353). However, this commit also
removes the `-package-name` argument to GHC. This is incorrect, as it means
that GHC will end up calling the package `main` and we end up with Haddock link
environments such as

    (trans_H9c1w14lEUN3zdWCTsn8jG:Control.Monad.Trans.Error.strMsg, main:Control.Monad.Error.Class)

Note that before this commit we ended up with

    (trans_H9c1w14lEUN3zdWCTsn8jG:Control.Monad.Trans.Error.strMsg, mtl-2.1.1:Control.Monad.Error.Class)

which is equally wrong as it uses a package source ID rather than a package key
(Haddock issue https://github.com/haskell/haddock/issues/362). Instead, we need
to pass _both_ `--package-name` and `--package-version` to Haddock, and
`-package-name` or `-this-package-key` to GHC, depending on the version.
Thankfully the infrastructure for chosing between `-package-name` and
`-this-package-key` is already in place, so we just have to make sure to
populate the `ghcPackageKey` field. After this commit the link environment
looks like

    (trans_H9c1w14lEUN3zdWCTsn8jG:Control.Monad.Trans.Error.strMsg, mtl_Koly6qxRZLf86guywd4tkE:Control.Monad.Error.Class)

which is correct.