### PR TITLE
Fix test interface detailed-0.9 with GHC 7.10

### DIFF
--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -390,7 +390,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
                               (package pkg) [] []
     }
     ipkgid = inplacePackageId (packageId pkg)
-    ipi    = inplaceInstalledPackageInfo pwd distPref pkg ipkgid lib lbi libClbi
+    ipi    = inplaceInstalledPackageInfo pwd distPref pkg ipkgid lib lbi' libClbi
     testDir = buildDir lbi </> stubName test
           </> stubName test ++ "-tmp"
     testLibDep = thisPackageVersion $ package pkg


### PR DESCRIPTION
Fixes #2476. Cabal could not build detailed-0.9 test suites with GHC
7.10 because the wrong package key was being used to build the test
suite library.

TODO: We should add real multi-library support to Cabal!