### PR TITLE
Make `cabal init` create Main.hs if it doesn't exist.

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -707,7 +707,7 @@ mainHs = unlines
   [ "module Main where"
   , ""
   , "main :: IO ()"
-  , "main = putStrLn \"Hello, World!\""
+  , "main = putStrLn \"Hello, Haskell!\""
   ]
 
 -- | Move an existing file, if there is one, and the overwrite flag is


### PR DESCRIPTION
`cabal init` will create Main.hs if the following conditions hold:
- creating an executable (not a library)
- the mainIs flag has been specified
- the file the mainIs flag is pointing to doesn't exist

This implements issue #2304.

Now, after doing `cabal init`, you can immediately do `cabal install`, `cabal run`, etc.