### PR TITLE
Minor type class cleanup

### DIFF
--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -112,11 +112,13 @@ data InstalledPackageInfo_ m
 
 instance Binary m => Binary (InstalledPackageInfo_ m)
 
-instance Package.Package          (InstalledPackageInfo_ str) where
+instance Package.Package (InstalledPackageInfo_ str) where
    packageId = sourcePackageId
 
-instance Package.PackageInstalled (InstalledPackageInfo_ str) where
+instance Package.HasInstalledPackageId (InstalledPackageInfo_ str) where
    installedPackageId = installedPackageId
+
+instance Package.PackageInstalled (InstalledPackageInfo_ str) where
    installedDepends = depends
 
 type InstalledPackageInfo = InstalledPackageInfo_ ModuleName

--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -38,7 +38,6 @@ module Distribution.Package (
 
         -- * Package classes
         Package(..), packageName, packageVersion,
-        PackageFixedDeps(..),
         PackageInstalled(..),
   ) where
 
@@ -359,16 +358,6 @@ packageVersion  = pkgVersion . packageId
 
 instance Package PackageIdentifier where
   packageId = id
-
--- | Subclass of packages that have specific versioned dependencies.
---
--- So for example a not-yet-configured package has dependencies on version
--- ranges, not specific versions. A configured or an already installed package
--- depends on exact versions. Some operations or data structures (like
---  dependency graphs) only make sense on this subclass of package types.
---
-class Package pkg => PackageFixedDeps pkg where
-  depends :: pkg -> [PackageIdentifier]
 
 -- | Class of installed packages.
 --

--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -38,6 +38,7 @@ module Distribution.Package (
 
         -- * Package classes
         Package(..), packageName, packageVersion,
+        HasInstalledPackageId(..),
         PackageInstalled(..),
   ) where
 
@@ -359,12 +360,15 @@ packageVersion  = pkgVersion . packageId
 instance Package PackageIdentifier where
   packageId = id
 
+-- | Packages that have an installed package ID
+class Package pkg => HasInstalledPackageId pkg where
+  installedPackageId :: pkg -> InstalledPackageId
+
 -- | Class of installed packages.
 --
 -- The primary data type which is an instance of this package is
 -- 'InstalledPackageInfo', but when we are doing install plans in Cabal install
 -- we may have other, installed package-like things which contain more metadata.
 -- Installed packages have exact dependencies 'installedDepends'.
-class Package pkg => PackageInstalled pkg where
-  installedPackageId :: pkg -> InstalledPackageId
+class HasInstalledPackageId pkg => PackageInstalled pkg where
   installedDepends :: pkg -> [InstalledPackageId]

--- a/Cabal/Distribution/Simple/GHC/IPI641.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI641.hs
@@ -14,7 +14,7 @@ module Distribution.Simple.GHC.IPI641 (
   ) where
 
 import qualified Distribution.InstalledPackageInfo as Current
-import qualified Distribution.Package as Current hiding (depends, installedPackageId)
+import qualified Distribution.Package as Current hiding (installedPackageId)
 import Distribution.Text (display)
 
 import Distribution.Simple.GHC.IPI642

--- a/Cabal/Distribution/Simple/GHC/IPI642.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI642.hs
@@ -19,7 +19,7 @@ module Distribution.Simple.GHC.IPI642 (
   ) where
 
 import qualified Distribution.InstalledPackageInfo as Current
-import qualified Distribution.Package as Current hiding (depends, installedPackageId)
+import qualified Distribution.Package as Current hiding (installedPackageId)
 import qualified Distribution.License as Current
 
 import Distribution.Version (Version)

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -33,11 +33,12 @@ import Distribution.Client.Dependency.Types
          , Progress(..), foldProgress )
 
 import qualified Distribution.Client.PackageIndex as PackageIndex
-import Distribution.Client.PackageIndex (PackageIndex)
+import Distribution.Client.PackageIndex
+         ( PackageIndex, PackageFixedDeps(depends) )
 import Distribution.Package
          ( PackageName(..), PackageId, Package(..), packageVersion, packageName
          , Dependency(Dependency), thisPackageVersion
-         , simplifyDependency, PackageFixedDeps(depends) )
+         , simplifyDependency )
 import Distribution.PackageDescription
          ( PackageDescription(buildDepends) )
 import Distribution.Client.PackageUtils

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Constraints.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Constraints.hs
@@ -26,11 +26,12 @@ module Distribution.Client.Dependency.TopDown.Constraints (
 
 import Distribution.Client.Dependency.TopDown.Types
 import qualified Distribution.Client.PackageIndex as PackageIndex
-import Distribution.Client.PackageIndex (PackageIndex)
+import Distribution.Client.PackageIndex
+        ( PackageIndex, PackageFixedDeps(depends) )
 import Distribution.Package
          ( PackageName, PackageId, PackageIdentifier(..)
          , Package(packageId), packageName, packageVersion
-         , Dependency, PackageFixedDeps(depends) )
+         , Dependency )
 import Distribution.Version
          ( Version )
 import Distribution.Client.Utils

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
@@ -14,10 +14,12 @@ module Distribution.Client.Dependency.TopDown.Types where
 
 import Distribution.Client.Types
          ( SourcePackage(..), InstalledPackage, OptionalStanza )
+import Distribution.Client.PackageIndex
+         ( PackageFixedDeps(depends) )
 
 import Distribution.Package
          ( PackageIdentifier, Dependency
-         , Package(packageId), PackageFixedDeps(depends) )
+         , Package(packageId) )
 import Distribution.PackageDescription
          ( FlagAssignment )
 

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -90,6 +90,8 @@ import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
 import Distribution.Client.SetupWrapper
          ( setupWrapper, SetupScriptOptions(..), defaultSetupScriptOptions )
+import Distribution.Client.PackageIndex
+         ( PackageFixedDeps(..) )
 import qualified Distribution.Client.BuildReports.Anonymous as BuildReports
 import qualified Distribution.Client.BuildReports.Storage as BuildReports
          ( storeAnonymous, storeLocal, fromInstallPlan, fromPlanningFailure )
@@ -128,7 +130,7 @@ import Distribution.Simple.InstallDirs as InstallDirs
          , initialPathTemplateEnv, installDirsTemplateEnv )
 import Distribution.Package
          ( PackageIdentifier(..), PackageId, packageName, packageVersion
-         , Package(..), PackageFixedDeps(..), PackageKey
+         , Package(..), PackageKey
          , Dependency(..), thisPackageVersion, InstalledPackageId, installedPackageId )
 import qualified Distribution.PackageDescription as PackageDescription
 import Distribution.PackageDescription

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -54,7 +54,7 @@ import Distribution.Client.Types
          , InstalledPackage(..), fakeInstalledPackageId )
 import Distribution.Package
          ( PackageIdentifier(..), PackageName(..), Package(..), packageName
-         , PackageFixedDeps(..), Dependency(..), InstalledPackageId
+         , Dependency(..), InstalledPackageId
          , PackageInstalled(..) )
 import Distribution.Version
          ( Version, withinRange )
@@ -63,6 +63,8 @@ import Distribution.PackageDescription
          , Flag(flagName), FlagName(..) )
 import Distribution.Client.PackageUtils
          ( externalBuildDepends )
+import Distribution.Client.PackageIndex
+         ( PackageFixedDeps(..) )
 import Distribution.PackageDescription.Configuration
          ( finalizePackageDescription )
 import Distribution.Simple.PackageIndex

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -55,7 +55,7 @@ import Distribution.Client.Types
 import Distribution.Package
          ( PackageIdentifier(..), PackageName(..), Package(..), packageName
          , Dependency(..), InstalledPackageId
-         , PackageInstalled(..) )
+         , HasInstalledPackageId(..), PackageInstalled(..) )
 import Distribution.Version
          ( Version, withinRange )
 import Distribution.PackageDescription
@@ -159,7 +159,7 @@ instance PackageFixedDeps PlanPackage where
   depends (Installed pkg _) = depends pkg
   depends (Failed    pkg _) = depends pkg
 
-instance PackageInstalled PlanPackage where
+instance HasInstalledPackageId PlanPackage where
   installedPackageId (PreExisting pkg)   = installedPackageId pkg
   installedPackageId (Configured  pkg)   = installedPackageId pkg
   installedPackageId (Processing  pkg)   = installedPackageId pkg
@@ -168,6 +168,7 @@ instance PackageInstalled PlanPackage where
   installedPackageId (Installed   pkg _) = installedPackageId pkg
   installedPackageId (Failed      pkg _) = installedPackageId pkg
 
+instance PackageInstalled PlanPackage where
   installedDepends (PreExisting pkg) = installedDepends pkg
   installedDepends (Configured  pkg) = installedDepends pkg
   installedDepends (Processing pkg)  = installedDepends pkg

--- a/cabal-install/Distribution/Client/PackageIndex.hs
+++ b/cabal-install/Distribution/Client/PackageIndex.hs
@@ -15,6 +15,7 @@
 module Distribution.Client.PackageIndex (
   -- * Package index data type
   PackageIndex,
+  PackageFixedDeps(..),
 
   -- * Creating an index
   fromList,
@@ -72,10 +73,20 @@ import Data.Maybe (isJust, isNothing, fromMaybe, catMaybes)
 import Distribution.Package
          ( PackageName(..), PackageIdentifier(..)
          , Package(..), packageName, packageVersion
-         , Dependency(Dependency), PackageFixedDeps(..) )
+         , Dependency(Dependency) )
 import Distribution.Version
          ( Version, withinRange )
 import Distribution.Simple.Utils (lowercase, equating, comparing)
+
+-- | Subclass of packages that have specific versioned dependencies.
+--
+-- So for example a not-yet-configured package has dependencies on version
+-- ranges, not specific versions. A configured or an already installed package
+-- depends on exact versions. Some operations or data structures (like
+--  dependency graphs) only make sense on this subclass of package types.
+--
+class Package pkg => PackageFixedDeps pkg where
+  depends :: pkg -> [PackageIdentifier]
 
 
 -- | The collection of information about packages from one or more 'PackageDB's.

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -17,7 +17,7 @@ module Distribution.Client.Types where
 import Distribution.Package
          ( PackageName, PackageId, Package(..)
          , mkPackageKey, PackageKey, InstalledPackageId(..)
-         , PackageInstalled(..) )
+         , HasInstalledPackageId(..), PackageInstalled(..) )
 import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo, packageKey )
 import Distribution.PackageDescription
@@ -75,8 +75,9 @@ instance Package InstalledPackage where
   packageId (InstalledPackage pkg _) = packageId pkg
 instance PackageFixedDeps InstalledPackage where
   depends (InstalledPackage _ deps) = deps
-instance PackageInstalled InstalledPackage where
+instance HasInstalledPackageId InstalledPackage where
   installedPackageId (InstalledPackage pkg _) = installedPackageId pkg
+instance PackageInstalled InstalledPackage where
   installedDepends (InstalledPackage pkg _) = installedDepends pkg
 
 
@@ -113,8 +114,9 @@ instance Package ConfiguredPackage where
 instance PackageFixedDeps ConfiguredPackage where
   depends (ConfiguredPackage _ _ _ deps) = deps
 
-instance PackageInstalled ConfiguredPackage where
+instance HasInstalledPackageId ConfiguredPackage where
   installedPackageId = fakeInstalledPackageId . packageId
+instance PackageInstalled ConfiguredPackage where
   installedDepends = map fakeInstalledPackageId . depends
 
 -- | Like 'ConfiguredPackage', but with all dependencies guaranteed to be
@@ -132,8 +134,9 @@ instance Package ReadyPackage where
 instance PackageFixedDeps ReadyPackage where
   depends (ReadyPackage _ _ _ deps) = map packageId deps
 
-instance PackageInstalled ReadyPackage where
+instance HasInstalledPackageId ReadyPackage where
   installedPackageId = fakeInstalledPackageId . packageId
+instance PackageInstalled ReadyPackage where
   installedDepends (ReadyPackage _ _ _ ipis) = map installedPackageId ipis
 
 -- | Extracts a package key from ReadyPackage, a common operation needed

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -15,7 +15,7 @@
 module Distribution.Client.Types where
 
 import Distribution.Package
-         ( PackageName, PackageId, Package(..), PackageFixedDeps(..)
+         ( PackageName, PackageId, Package(..)
          , mkPackageKey, PackageKey, InstalledPackageId(..)
          , PackageInstalled(..) )
 import Distribution.InstalledPackageInfo
@@ -26,7 +26,7 @@ import Distribution.PackageDescription
 import Distribution.PackageDescription.Configuration
          ( mapTreeData )
 import Distribution.Client.PackageIndex
-         ( PackageIndex )
+         ( PackageIndex, PackageFixedDeps(..) )
 import Distribution.Version
          ( VersionRange )
 import Distribution.Simple.Compiler


### PR DESCRIPTION
This pull request is the first of a set of pull requests working towards an implementation of setup dependencies.

This PR moves `installedPackageId` out of `PackageInstalled` into a new superclass `HasInstalledPackageId`, and moves the `PackageFixedDeps` class from `Cabal` to `cabal-install`.

/cc @dcoutts @kosmikus 