### PR TITLE
Clean up graph traversal code

### DIFF
--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -112,11 +112,13 @@ data InstalledPackageInfo_ m
 
 instance Binary m => Binary (InstalledPackageInfo_ m)
 
-instance Package.Package          (InstalledPackageInfo_ str) where
+instance Package.Package (InstalledPackageInfo_ str) where
    packageId = sourcePackageId
 
-instance Package.PackageInstalled (InstalledPackageInfo_ str) where
+instance Package.HasInstalledPackageId (InstalledPackageInfo_ str) where
    installedPackageId = installedPackageId
+
+instance Package.PackageInstalled (InstalledPackageInfo_ str) where
    installedDepends = depends
 
 type InstalledPackageInfo = InstalledPackageInfo_ ModuleName

--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -38,7 +38,6 @@ module Distribution.Package (
 
         -- * Package classes
         Package(..), packageName, packageVersion,
-        PackageFixedDeps(..),
         PackageInstalled(..),
   ) where
 
@@ -359,16 +358,6 @@ packageVersion  = pkgVersion . packageId
 
 instance Package PackageIdentifier where
   packageId = id
-
--- | Subclass of packages that have specific versioned dependencies.
---
--- So for example a not-yet-configured package has dependencies on version
--- ranges, not specific versions. A configured or an already installed package
--- depends on exact versions. Some operations or data structures (like
---  dependency graphs) only make sense on this subclass of package types.
---
-class Package pkg => PackageFixedDeps pkg where
-  depends :: pkg -> [PackageIdentifier]
 
 -- | Class of installed packages.
 --

--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -38,6 +38,7 @@ module Distribution.Package (
 
         -- * Package classes
         Package(..), packageName, packageVersion,
+        HasInstalledPackageId(..),
         PackageInstalled(..),
   ) where
 
@@ -359,12 +360,15 @@ packageVersion  = pkgVersion . packageId
 instance Package PackageIdentifier where
   packageId = id
 
+-- | Packages that have an installed package ID
+class Package pkg => HasInstalledPackageId pkg where
+  installedPackageId :: pkg -> InstalledPackageId
+
 -- | Class of installed packages.
 --
 -- The primary data type which is an instance of this package is
 -- 'InstalledPackageInfo', but when we are doing install plans in Cabal install
 -- we may have other, installed package-like things which contain more metadata.
 -- Installed packages have exact dependencies 'installedDepends'.
-class Package pkg => PackageInstalled pkg where
-  installedPackageId :: pkg -> InstalledPackageId
+class HasInstalledPackageId pkg => PackageInstalled pkg where
   installedDepends :: pkg -> [InstalledPackageId]

--- a/Cabal/Distribution/Simple/GHC/IPI641.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI641.hs
@@ -14,7 +14,7 @@ module Distribution.Simple.GHC.IPI641 (
   ) where
 
 import qualified Distribution.InstalledPackageInfo as Current
-import qualified Distribution.Package as Current hiding (depends, installedPackageId)
+import qualified Distribution.Package as Current hiding (installedPackageId)
 import Distribution.Text (display)
 
 import Distribution.Simple.GHC.IPI642

--- a/Cabal/Distribution/Simple/GHC/IPI642.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI642.hs
@@ -19,7 +19,7 @@ module Distribution.Simple.GHC.IPI642 (
   ) where
 
 import qualified Distribution.InstalledPackageInfo as Current
-import qualified Distribution.Package as Current hiding (depends, installedPackageId)
+import qualified Distribution.Package as Current hiding (installedPackageId)
 import qualified Distribution.License as Current
 
 import Distribution.Version (Version)

--- a/cabal-install/Distribution/Client/BuildReports/Storage.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Storage.hs
@@ -135,7 +135,7 @@ fromPlanPackage (Platform arch os) comp planPackage = case planPackage of
 
   InstallPlan.Failed (ConfiguredPackage srcPkg flags _ deps) result
     -> Just $ ( BuildReport.new os arch comp
-                                (packageId srcPkg) flags deps
+                                (packageId srcPkg) flags (map confSrcId deps)
                                 (Left result)
               , extractRepo srcPkg )
 

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -33,11 +33,12 @@ import Distribution.Client.Dependency.Types
          , Progress(..), foldProgress )
 
 import qualified Distribution.Client.PackageIndex as PackageIndex
-import Distribution.Client.PackageIndex (PackageIndex)
+import Distribution.Client.PackageIndex
+         ( PackageIndex, PackageFixedDeps(depends) )
 import Distribution.Package
          ( PackageName(..), PackageId, Package(..), packageVersion, packageName
          , Dependency(Dependency), thisPackageVersion
-         , simplifyDependency, PackageFixedDeps(depends) )
+         , simplifyDependency )
 import Distribution.PackageDescription
          ( PackageDescription(buildDepends) )
 import Distribution.Client.PackageUtils

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -33,6 +33,7 @@ import Distribution.Client.Dependency.Types
          , Progress(..), foldProgress )
 
 import qualified Distribution.Client.PackageIndex as PackageIndex
+import qualified Distribution.Client.PlanIndex as PlanIndex
 import Distribution.Client.PackageIndex
          ( PackageIndex, PackageFixedDeps(depends) )
 import Distribution.Package
@@ -424,7 +425,7 @@ annotateInstalledPackages dfsNumber installed = PackageIndex.fromList
     transitiveDepends :: InstalledPackage -> [PackageId]
     transitiveDepends = map (packageId . toPkg) . tail . Graph.reachable graph
                       . fromJust . toVertex . packageId
-    (graph, toPkg, toVertex) = PackageIndex.dependencyGraph installed
+    (graph, toPkg, toVertex) = PlanIndex.dependencyGraph installed
 
 
 -- | Annotate each available packages with its topological sort number and any
@@ -667,7 +668,7 @@ improvePlan installed constraints0 selected0 =
                                   . Graph.topSort
                                   . Graph.transposeG
                                   $ graph
-      where (graph, toPkg, _) = PackageIndex.dependencyGraph index
+      where (graph, toPkg, _) = PlanIndex.dependencyGraph index
 
 -- ------------------------------------------------------------
 -- * Adding and recording constraints

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Constraints.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Constraints.hs
@@ -27,7 +27,7 @@ module Distribution.Client.Dependency.TopDown.Constraints (
 import Distribution.Client.Dependency.TopDown.Types
 import qualified Distribution.Client.PackageIndex as PackageIndex
 import Distribution.Client.PackageIndex
-        ( PackageIndex, PackageFixedDeps(depends) )
+        ( PackageIndex )
 import Distribution.Package
          ( PackageName, PackageId, PackageIdentifier(..)
          , Package(packageId), packageName, packageVersion
@@ -225,14 +225,12 @@ transitionsTo constraints @(Constraints _ available  excluded  _ _)
       SourceOnly           b -> SourceOnly    (g b)
       InstalledAndSource a b -> InstalledAndSource (f a) (g b)
 
-
 -- | We construct 'Constraints' with an initial 'PackageIndex' of all the
 -- packages available.
 --
-empty :: (PackageFixedDeps installed, Package source)
-      => PackageIndex installed
-      -> PackageIndex source
-      -> Constraints installed source reason
+empty :: PackageIndex InstalledPackageEx
+      -> PackageIndex UnconfiguredPackage
+      -> Constraints InstalledPackageEx UnconfiguredPackage reason
 empty installed source =
     Constraints targets pkgs excluded pairs pkgs
   where
@@ -254,8 +252,8 @@ empty installed source =
       , let name   = packageName pkg1
             pkgid1 = packageId pkg1
             pkgid2 = packageId pkg2
-      ,    any ((pkgid1==) . packageId) (depends pkg2)
-        || any ((pkgid2==) . packageId) (depends pkg1) ]
+      ,    any ((pkgid1==) . packageId) (sourceDeps pkg2)
+        || any ((pkgid2==) . packageId) (sourceDeps pkg1) ]
 
 
 -- | The package targets.

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Constraints.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Constraints.hs
@@ -26,11 +26,12 @@ module Distribution.Client.Dependency.TopDown.Constraints (
 
 import Distribution.Client.Dependency.TopDown.Types
 import qualified Distribution.Client.PackageIndex as PackageIndex
-import Distribution.Client.PackageIndex (PackageIndex)
+import Distribution.Client.PackageIndex
+        ( PackageIndex, PackageFixedDeps(depends) )
 import Distribution.Package
          ( PackageName, PackageId, PackageIdentifier(..)
          , Package(packageId), packageName, packageVersion
-         , Dependency, PackageFixedDeps(depends) )
+         , Dependency )
 import Distribution.Version
          ( Version )
 import Distribution.Client.Utils

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
@@ -14,7 +14,7 @@ module Distribution.Client.Dependency.TopDown.Types where
 
 import Distribution.Client.Types
          ( SourcePackage(..), ReadyPackage(..), InstalledPackage(..)
-         , OptionalStanza )
+         , OptionalStanza, ConfiguredId(..) )
 import Distribution.Client.InstallPlan
          ( ConfiguredPackage(..), PlanPackage(..) )
 
@@ -113,7 +113,7 @@ instance PackageSourceDeps InstalledPackageEx where
   sourceDeps (InstalledPackageEx _ _ deps) = deps
 
 instance PackageSourceDeps ConfiguredPackage where
-  sourceDeps (ConfiguredPackage _ _ _ deps) = deps
+  sourceDeps (ConfiguredPackage _ _ _ deps) = map confSrcId deps
 
 instance PackageSourceDeps ReadyPackage where
   sourceDeps (ReadyPackage _ _ _ deps) = map packageId deps

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
@@ -14,10 +14,12 @@ module Distribution.Client.Dependency.TopDown.Types where
 
 import Distribution.Client.Types
          ( SourcePackage(..), InstalledPackage, OptionalStanza )
+import Distribution.Client.PackageIndex
+         ( PackageFixedDeps(depends) )
 
 import Distribution.Package
          ( PackageIdentifier, Dependency
-         , Package(packageId), PackageFixedDeps(depends) )
+         , Package(packageId) )
 import Distribution.PackageDescription
          ( FlagAssignment )
 

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
@@ -13,9 +13,10 @@
 module Distribution.Client.Dependency.TopDown.Types where
 
 import Distribution.Client.Types
-         ( SourcePackage(..), InstalledPackage, OptionalStanza )
-import Distribution.Client.PackageIndex
-         ( PackageFixedDeps(depends) )
+         ( SourcePackage(..), ReadyPackage(..), InstalledPackage(..)
+         , OptionalStanza )
+import Distribution.Client.InstallPlan
+         ( ConfiguredPackage(..), PlanPackage(..) )
 
 import Distribution.Package
          ( PackageIdentifier, Dependency
@@ -65,9 +66,6 @@ data SemiConfiguredPackage
 instance Package InstalledPackageEx where
   packageId (InstalledPackageEx p _ _) = packageId p
 
-instance PackageFixedDeps InstalledPackageEx where
-  depends (InstalledPackageEx _ _ deps) = deps
-
 instance Package UnconfiguredPackage where
   packageId (UnconfiguredPackage p _ _ _) = packageId p
 
@@ -91,3 +89,41 @@ instance (Package installed, Package source)
 data InstalledConstraint = InstalledConstraint
                          | SourceConstraint
   deriving (Eq, Show)
+
+-- | Package dependencies
+--
+-- The top-down solver uses its down type class for package dependencies,
+-- because it wants to know these dependencies as PackageIds, rather than as
+-- InstalledPackageIds (so it cannot use PackageFixedDeps).
+--
+-- Ideally we would switch the top-down solver over to use InstalledPackageIds
+-- throughout; that means getting rid of this type class, and changing over the
+-- package index type to use Cabal's rather than cabal-install's. That will
+-- avoid the need for the local definitions of dependencyGraph and
+-- reverseTopologicalOrder in the top-down solver.
+--
+-- Note that the top-down solver does not (and probably will never) make a
+-- distinction between the various kinds of dependencies, so we return a flat
+-- list here. If we get rid of this type class then any use of `sourceDeps`
+-- should be replaced by @fold . depends@.
+class Package a => PackageSourceDeps a where
+  sourceDeps :: a -> [PackageIdentifier]
+
+instance PackageSourceDeps InstalledPackageEx where
+  sourceDeps (InstalledPackageEx _ _ deps) = deps
+
+instance PackageSourceDeps ConfiguredPackage where
+  sourceDeps (ConfiguredPackage _ _ _ deps) = deps
+
+instance PackageSourceDeps ReadyPackage where
+  sourceDeps (ReadyPackage _ _ _ deps) = map packageId deps
+
+instance PackageSourceDeps InstalledPackage where
+  sourceDeps (InstalledPackage _ deps) = deps
+
+instance PackageSourceDeps PlanPackage where
+  sourceDeps (PreExisting pkg) = sourceDeps pkg
+  sourceDeps (Configured  pkg) = sourceDeps pkg
+  sourceDeps (Processing pkg)  = sourceDeps pkg
+  sourceDeps (Installed pkg _) = sourceDeps pkg
+  sourceDeps (Failed    pkg _) = sourceDeps pkg

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -39,6 +39,7 @@ import Distribution.Simple.Compiler
          ( Compiler, compilerInfo, PackageDBStack )
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import qualified Distribution.Client.PackageIndex as PackageIndex
+import qualified Distribution.Client.PlanIndex as PlanIndex
 import Distribution.Simple.Program
          ( ProgramConfiguration )
 import Distribution.Simple.Setup
@@ -196,7 +197,7 @@ pruneInstallPlan :: InstallPlan.InstallPlan
                  -> Either [PlanPackage] [(PlanPackage, [PackageIdentifier])]
 pruneInstallPlan installPlan pkgSpecifiers =
     mapLeft (removeSelf pkgIds . PackageIndex.allPackages) $
-    PackageIndex.dependencyClosure pkgIdx pkgIds
+    PlanIndex.dependencyClosure pkgIdx pkgIds
   where
     pkgIdx = PackageIndex.fromList $ InstallPlan.toList installPlan
     pkgIds = [ packageId pkg | SpecificSourcePackage pkg <- pkgSpecifiers ]

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -34,12 +34,11 @@ import Distribution.Client.Sandbox.Types
          ( SandboxPackageInfo(..) )
 
 import Distribution.Package
-         ( Package, PackageIdentifier, packageId, packageName, packageVersion )
+         ( Package, packageId, packageName, packageVersion )
 import Distribution.Simple.Compiler
          ( Compiler, compilerInfo, PackageDBStack )
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
-import qualified Distribution.Client.PackageIndex as PackageIndex
-import qualified Distribution.Client.PlanIndex as PlanIndex
+import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.Simple.Program
          ( ProgramConfiguration )
 import Distribution.Simple.Setup
@@ -141,9 +140,7 @@ planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
                      solver
                      resolverParams
 
-  return $ either id
-                  (error "planPackages: installPlan contains broken packages")
-                  (pruneInstallPlan installPlan pkgSpecifiers)
+  return $ pruneInstallPlan installPlan pkgSpecifiers
 
   where
     resolverParams =
@@ -194,15 +191,14 @@ planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
 --    which are no longer required from the install plan.
 pruneInstallPlan :: InstallPlan.InstallPlan
                  -> [PackageSpecifier SourcePackage]
-                 -> Either [PlanPackage] [(PlanPackage, [PackageIdentifier])]
+                 -> [PlanPackage]
 pruneInstallPlan installPlan pkgSpecifiers =
     mapLeft (removeSelf pkgIds . PackageIndex.allPackages) $
-    PlanIndex.dependencyClosure pkgIdx pkgIds
+    InstallPlan.dependencyClosure installPlan pkgIds
   where
-    pkgIdx = PackageIndex.fromList $ InstallPlan.toList installPlan
     pkgIds = [ packageId pkg | SpecificSourcePackage pkg <- pkgSpecifiers ]
-    mapLeft f (Left v)  = Left $ f v
-    mapLeft _ (Right v) = Right v
+    mapLeft f (Left v)  = f v
+    mapLeft _ (Right _) = error "planPackages: installPlan contains broken packages"
     removeSelf [thisPkg] = filter (\pp -> packageId pp /= thisPkg)
     removeSelf _ =
         error $ "internal error: 'pruneInstallPlan' given "

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -561,12 +561,12 @@ packageStatus _comp installedPkgIndex cpkg =
     changes :: Installed.InstalledPackageInfo
             -> ReadyPackage
             -> [MergeResult PackageIdentifier PackageIdentifier]
-    changes pkg pkg' =
-      filter changed
-      $ mergeBy (comparing packageName)
-          (resolveInstalledIds $ Installed.depends pkg)
-          (resolveInstalledIds $ depends $ pkg')
+    changes pkg pkg' = filter changed $
+      mergeBy (comparing packageName)
+        (resolveInstalledIds $ Installed.depends pkg) -- deps of installed pkg
+        (resolveInstalledIds $ depends $ pkg')        -- deps of configured pkg
 
+    -- convert to source pkg ids via index
     resolveInstalledIds :: [InstalledPackageId] -> [PackageIdentifier]
     resolveInstalledIds =
         nub

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -90,6 +90,8 @@ import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
 import Distribution.Client.SetupWrapper
          ( setupWrapper, SetupScriptOptions(..), defaultSetupScriptOptions )
+import Distribution.Client.PackageIndex
+         ( PackageFixedDeps(..) )
 import qualified Distribution.Client.BuildReports.Anonymous as BuildReports
 import qualified Distribution.Client.BuildReports.Storage as BuildReports
          ( storeAnonymous, storeLocal, fromInstallPlan, fromPlanningFailure )
@@ -128,7 +130,7 @@ import Distribution.Simple.InstallDirs as InstallDirs
          , initialPathTemplateEnv, installDirsTemplateEnv )
 import Distribution.Package
          ( PackageIdentifier(..), PackageId, packageName, packageVersion
-         , Package(..), PackageFixedDeps(..), PackageKey
+         , Package(..), PackageKey
          , Dependency(..), thisPackageVersion, InstalledPackageId, installedPackageId )
 import qualified Distribution.PackageDescription as PackageDescription
 import Distribution.PackageDescription

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -54,7 +54,7 @@ import Distribution.Client.Types
          , InstalledPackage(..), fakeInstalledPackageId )
 import Distribution.Package
          ( PackageIdentifier(..), PackageName(..), Package(..), packageName
-         , PackageFixedDeps(..), Dependency(..), InstalledPackageId
+         , Dependency(..), InstalledPackageId
          , PackageInstalled(..) )
 import Distribution.Version
          ( Version, withinRange )
@@ -63,6 +63,8 @@ import Distribution.PackageDescription
          , Flag(flagName), FlagName(..) )
 import Distribution.Client.PackageUtils
          ( externalBuildDepends )
+import Distribution.Client.PackageIndex
+         ( PackageFixedDeps(..) )
 import Distribution.PackageDescription.Configuration
          ( finalizePackageDescription )
 import Distribution.Simple.PackageIndex

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -54,10 +54,12 @@ import Distribution.Client.Types
          ( SourcePackage(packageDescription), ConfiguredPackage(..)
          , ReadyPackage(..), readyPackageToConfiguredPackage
          , InstalledPackage, BuildFailure, BuildSuccess(..), enableStanzas
-         , InstalledPackage(..), fakeInstalledPackageId )
+         , InstalledPackage(..), fakeInstalledPackageId
+         , ConfiguredId(..)
+         )
 import Distribution.Package
          ( PackageIdentifier(..), PackageName(..), Package(..), packageName
-         , Dependency(..), InstalledPackageId
+         , Dependency(..), PackageId, InstalledPackageId
          , HasInstalledPackageId(..), PackageInstalled(..) )
 import Distribution.Version
          ( Version, withinRange )
@@ -594,7 +596,7 @@ showPackageProblem (InvalidDep dep pkgid) =
 configuredPackageProblems :: Platform -> CompilerInfo
                           -> ConfiguredPackage -> [PackageProblem]
 configuredPackageProblems platform cinfo
-  (ConfiguredPackage pkg specifiedFlags stanzas specifiedDeps) =
+  (ConfiguredPackage pkg specifiedFlags stanzas specifiedDeps') =
      [ DuplicateFlag flag | ((flag,_):_) <- duplicates specifiedFlags ]
   ++ [ MissingFlag flag | OnlyInLeft  flag <- mergedFlags ]
   ++ [ ExtraFlag   flag | OnlyInRight flag <- mergedFlags ]
@@ -605,6 +607,9 @@ configuredPackageProblems platform cinfo
   ++ [ InvalidDep dep pkgid | InBoth      dep pkgid <- mergedDeps
                             , not (packageSatisfiesDependency pkgid dep) ]
   where
+    specifiedDeps :: [PackageId]
+    specifiedDeps = map confSrcId specifiedDeps'
+
     mergedFlags = mergeBy compare
       (sort $ map flagName (genPackageFlags (packageDescription pkg)))
       (sort $ map fst specifiedFlags)

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -55,7 +55,7 @@ import Distribution.Client.Types
 import Distribution.Package
          ( PackageIdentifier(..), PackageName(..), Package(..), packageName
          , Dependency(..), InstalledPackageId
-         , PackageInstalled(..) )
+         , HasInstalledPackageId(..), PackageInstalled(..) )
 import Distribution.Version
          ( Version, withinRange )
 import Distribution.PackageDescription
@@ -159,7 +159,7 @@ instance PackageFixedDeps PlanPackage where
   depends (Installed pkg _) = depends pkg
   depends (Failed    pkg _) = depends pkg
 
-instance PackageInstalled PlanPackage where
+instance HasInstalledPackageId PlanPackage where
   installedPackageId (PreExisting pkg)   = installedPackageId pkg
   installedPackageId (Configured  pkg)   = installedPackageId pkg
   installedPackageId (Processing  pkg)   = installedPackageId pkg
@@ -168,6 +168,7 @@ instance PackageInstalled PlanPackage where
   installedPackageId (Installed   pkg _) = installedPackageId pkg
   installedPackageId (Failed      pkg _) = installedPackageId pkg
 
+instance PackageInstalled PlanPackage where
   installedDepends (PreExisting pkg) = installedDepends pkg
   installedDepends (Configured  pkg) = installedDepends pkg
   installedDepends (Processing pkg)  = installedDepends pkg

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -143,6 +143,17 @@ type PlanIndex = PackageIndex PlanPackage
 -- have problems with inconsistent dependencies.
 -- On the other hand it is true that every closed sub plan is valid.
 
+-- | Packages in an install plan
+--
+-- NOTE: 'ConfiguredPackage', 'ReadyPackage' and 'PlanPackage' intentionally
+-- have no 'PackageInstalled' instance. `This is important: PackageInstalled
+-- returns only library dependencies, but for package that aren't yet installed
+-- we know many more kinds of dependencies (setup dependencies, exe, test-suite,
+-- benchmark, ..). Any functions that operate on dependencies in cabal-install
+-- should consider what to do with these dependencies; if we give a
+-- 'PackageInstalled' instance it would be too easy to get this wrong (and,
+-- for instance, call graph traversal functions from Cabal rather than from
+-- cabal-install). Instead, see 'PackageFixedDeps'.
 data PlanPackage = PreExisting InstalledPackage
                  | Configured  ConfiguredPackage
                  | Processing  ReadyPackage
@@ -239,8 +250,6 @@ new platform cinfo index =
           }
       where (graph, vertexToPkgId, pkgIdToVertex) =
               PlanIndex.dependencyGraph fakeMap index
-              -- NB: doesn't need to know planFakeMap because the
-              -- fakemap is empty at this point.
             noSuchPkgId = internalError "package is not in the graph"
     probs -> Left probs
 

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -73,8 +73,10 @@ import Distribution.Client.PackageIndex
 import Distribution.PackageDescription.Configuration
          ( finalizePackageDescription )
 import Distribution.Simple.PackageIndex
-         ( PackageIndex, FakeMap )
+         ( PackageIndex )
 import qualified Distribution.Simple.PackageIndex as PackageIndex
+import Distribution.Client.PlanIndex
+         ( FakeMap )
 import qualified Distribution.Client.PlanIndex as PlanIndex
 import Distribution.Text
          ( display )
@@ -299,7 +301,7 @@ ready plan = assert check readyPackages
     isInstalledDep pkgid =
       -- NB: Need to check if the ID has been updated in planFakeMap, in which case we
       -- might be dealing with an old pointer
-      case PackageIndex.fakeLookupInstalledPackageId (planFakeMap plan) (planIndex plan) pkgid of
+      case PlanIndex.fakeLookupInstalledPackageId (planFakeMap plan) (planIndex plan) pkgid of
         Just (Configured  _)                            -> Nothing
         Just (Processing  _)                            -> Nothing
         Just (Failed    _ _)                            -> internalError depOnFailed
@@ -471,7 +473,7 @@ problems platform cinfo fakeMap index =
      , let packageProblems = configuredPackageProblems platform cinfo pkg
      , not (null packageProblems) ]
 
-  ++ [ PackageMissingDeps pkg (catMaybes (map (fmap packageId . PackageIndex.fakeLookupInstalledPackageId fakeMap index) missingDeps))
+  ++ [ PackageMissingDeps pkg (catMaybes (map (fmap packageId . PlanIndex.fakeLookupInstalledPackageId fakeMap index) missingDeps))
      | (pkg, missingDeps) <- PlanIndex.brokenPackages fakeMap index ]
 
   ++ [ PackageCycle cycleGroup
@@ -482,7 +484,7 @@ problems platform cinfo fakeMap index =
 
   ++ [ PackageStateInvalid pkg pkg'
      | pkg <- PackageIndex.allPackages index
-     , Just pkg' <- map (PackageIndex.fakeLookupInstalledPackageId fakeMap index) (depends pkg)
+     , Just pkg' <- map (PlanIndex.fakeLookupInstalledPackageId fakeMap index) (depends pkg)
      , not (stateDependencyRelation pkg pkg') ]
 
 -- | The graph of packages (nodes) and dependencies (edges) must be acyclic.

--- a/cabal-install/Distribution/Client/PackageIndex.hs
+++ b/cabal-install/Distribution/Client/PackageIndex.hs
@@ -18,7 +18,6 @@ module Distribution.Client.PackageIndex (
 
   -- * Fine-grained package dependencies
   PackageFixedDeps(..),
-  fakeDepends,
 
   -- * Creating an index
   fromList,
@@ -68,8 +67,8 @@ import Distribution.Version
          ( withinRange )
 import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo_ )
-import Distribution.Simple.Utils (lowercase, comparing)
-import Distribution.Simple.PackageIndex (FakeMap)
+import Distribution.Simple.Utils
+         ( lowercase, comparing )
 
 -- | Subclass of packages that have specific versioned dependencies.
 --
@@ -80,15 +79,6 @@ import Distribution.Simple.PackageIndex (FakeMap)
 --
 class Package pkg => PackageFixedDeps pkg where
   depends :: pkg -> [InstalledPackageId]
-
--- | Variant of `depends` which accepts a `FakeMap`
---
--- Analogous to `fakeInstalledDepends`. See Note [FakeMap].
-fakeDepends :: PackageFixedDeps pkg => FakeMap -> pkg -> [InstalledPackageId]
-fakeDepends fakeMap = map resolveFakeId . depends
-  where
-    resolveFakeId :: InstalledPackageId -> InstalledPackageId
-    resolveFakeId ipid = Map.findWithDefault ipid ipid fakeMap
 
 instance PackageFixedDeps (InstalledPackageInfo_ str) where
   depends info = installedDepends info

--- a/cabal-install/Distribution/Client/PackageIndex.hs
+++ b/cabal-install/Distribution/Client/PackageIndex.hs
@@ -15,6 +15,7 @@
 module Distribution.Client.PackageIndex (
   -- * Package index data type
   PackageIndex,
+  PackageFixedDeps(..),
 
   -- * Creating an index
   fromList,
@@ -72,10 +73,20 @@ import Data.Maybe (isJust, isNothing, fromMaybe, catMaybes)
 import Distribution.Package
          ( PackageName(..), PackageIdentifier(..)
          , Package(..), packageName, packageVersion
-         , Dependency(Dependency), PackageFixedDeps(..) )
+         , Dependency(Dependency) )
 import Distribution.Version
          ( Version, withinRange )
 import Distribution.Simple.Utils (lowercase, equating, comparing)
+
+-- | Subclass of packages that have specific versioned dependencies.
+--
+-- So for example a not-yet-configured package has dependencies on version
+-- ranges, not specific versions. A configured or an already installed package
+-- depends on exact versions. Some operations or data structures (like
+--  dependency graphs) only make sense on this subclass of package types.
+--
+class Package pkg => PackageFixedDeps pkg where
+  depends :: pkg -> [PackageIdentifier]
 
 
 -- | The collection of information about packages from one or more 'PackageDB's.

--- a/cabal-install/Distribution/Client/PackageIndex.hs
+++ b/cabal-install/Distribution/Client/PackageIndex.hs
@@ -44,39 +44,25 @@ module Distribution.Client.PackageIndex (
   -- ** Bulk queries
   allPackages,
   allPackagesByName,
-
-  -- ** Special queries
-  brokenPackages,
-  dependencyClosure,
-  reverseDependencyClosure,
-  topologicalOrder,
-  reverseTopologicalOrder,
-  dependencyInconsistencies,
-  dependencyCycles,
-  dependencyGraph,
   ) where
 
 import Prelude hiding (lookup)
 import Control.Exception (assert)
 import qualified Data.Map as Map
 import Data.Map (Map)
-import qualified Data.Tree  as Tree
-import qualified Data.Graph as Graph
-import qualified Data.Array as Array
-import Data.Array ((!))
-import Data.List (groupBy, sortBy, nub, isInfixOf)
+import Data.List (groupBy, sortBy, isInfixOf)
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid (Monoid(..))
 #endif
-import Data.Maybe (isJust, isNothing, fromMaybe, catMaybes)
+import Data.Maybe (isJust, fromMaybe)
 
 import Distribution.Package
          ( PackageName(..), PackageIdentifier(..)
          , Package(..), packageName, packageVersion
          , Dependency(Dependency) )
 import Distribution.Version
-         ( Version, withinRange )
-import Distribution.Simple.Utils (lowercase, equating, comparing)
+         ( withinRange )
+import Distribution.Simple.Utils (lowercase, comparing)
 
 -- | Subclass of packages that have specific versioned dependencies.
 --
@@ -330,172 +316,3 @@ searchByNameSubstring (PackageIndex m) searchterm =
     , lsearchterm `isInfixOf` lowercase name ]
   where
     lsearchterm = lowercase searchterm
-
---
--- * Special queries
---
-
--- | All packages that have dependencies that are not in the index.
---
--- Returns such packages along with the dependencies that they're missing.
---
-brokenPackages :: PackageFixedDeps pkg
-               => PackageIndex pkg
-               -> [(pkg, [PackageIdentifier])]
-brokenPackages index =
-  [ (pkg, missing)
-  | pkg  <- allPackages index
-  , let missing = [ pkg' | pkg' <- depends pkg
-                         , isNothing (lookupPackageId index pkg') ]
-  , not (null missing) ]
-
--- | Tries to take the transitive closure of the package dependencies.
---
--- If the transitive closure is complete then it returns that subset of the
--- index. Otherwise it returns the broken packages as in 'brokenPackages'.
---
--- * Note that if the result is @Right []@ it is because at least one of
--- the original given 'PackageIdentifier's do not occur in the index.
---
-dependencyClosure :: PackageFixedDeps pkg
-                  => PackageIndex pkg
-                  -> [PackageIdentifier]
-                  -> Either (PackageIndex pkg)
-                            [(pkg, [PackageIdentifier])]
-dependencyClosure index pkgids0 = case closure mempty [] pkgids0 of
-  (completed, []) -> Left completed
-  (completed, _)  -> Right (brokenPackages completed)
-  where
-    closure completed failed []             = (completed, failed)
-    closure completed failed (pkgid:pkgids) = case lookupPackageId index pkgid of
-      Nothing   -> closure completed (pkgid:failed) pkgids
-      Just pkg  -> case lookupPackageId completed (packageId pkg) of
-        Just _  -> closure completed  failed pkgids
-        Nothing -> closure completed' failed pkgids'
-          where completed' = insert pkg completed
-                pkgids'    = depends pkg ++ pkgids
-
--- | Takes the transitive closure of the packages reverse dependencies.
---
--- * The given 'PackageIdentifier's must be in the index.
---
-reverseDependencyClosure :: PackageFixedDeps pkg
-                         => PackageIndex pkg
-                         -> [PackageIdentifier]
-                         -> [pkg]
-reverseDependencyClosure index =
-    map vertexToPkg
-  . concatMap Tree.flatten
-  . Graph.dfs reverseDepGraph
-  . map (fromMaybe noSuchPkgId . pkgIdToVertex)
-
-  where
-    (depGraph, vertexToPkg, pkgIdToVertex) = dependencyGraph index
-    reverseDepGraph = Graph.transposeG depGraph
-    noSuchPkgId = error "reverseDependencyClosure: package is not in the graph"
-
-topologicalOrder :: PackageFixedDeps pkg => PackageIndex pkg -> [pkg]
-topologicalOrder index = map toPkgId
-                       . Graph.topSort
-                       $ graph
-  where (graph, toPkgId, _) = dependencyGraph index
-
-reverseTopologicalOrder :: PackageFixedDeps pkg => PackageIndex pkg -> [pkg]
-reverseTopologicalOrder index = map toPkgId
-                              . Graph.topSort
-                              . Graph.transposeG
-                              $ graph
-  where (graph, toPkgId, _) = dependencyGraph index
-
--- | Given a package index where we assume we want to use all the packages
--- (use 'dependencyClosure' if you need to get such a index subset) find out
--- if the dependencies within it use consistent versions of each package.
--- Return all cases where multiple packages depend on different versions of
--- some other package.
---
--- Each element in the result is a package name along with the packages that
--- depend on it and the versions they require. These are guaranteed to be
--- distinct.
---
-dependencyInconsistencies :: PackageFixedDeps pkg
-                          => PackageIndex pkg
-                          -> [(PackageName, [(PackageIdentifier, Version)])]
-dependencyInconsistencies index =
-  [ (name, inconsistencies)
-  | (name, uses) <- Map.toList inverseIndex
-  , let inconsistencies = duplicatesBy uses
-        versions = map snd inconsistencies
-  , reallyIsInconsistent name (nub versions) ]
-
-  where inverseIndex = Map.fromListWith (++)
-          [ (packageName dep, [(packageId pkg, packageVersion dep)])
-          | pkg <- allPackages index
-          , dep <- depends pkg ]
-
-        duplicatesBy = (\groups -> if length groups == 1
-                                     then []
-                                     else concat groups)
-                     . groupBy (equating snd)
-                     . sortBy (comparing snd)
-
-        reallyIsInconsistent :: PackageName -> [Version] -> Bool
-        reallyIsInconsistent _    []       = False
-        reallyIsInconsistent name [v1, v2] =
-          case (mpkg1, mpkg2) of
-            (Just pkg1, Just pkg2) -> pkgid1 `notElem` depends pkg2
-                                   && pkgid2 `notElem` depends pkg1
-            _ -> True
-          where
-            pkgid1 = PackageIdentifier name v1
-            pkgid2 = PackageIdentifier name v2
-            mpkg1 = lookupPackageId index pkgid1
-            mpkg2 = lookupPackageId index pkgid2
-
-        reallyIsInconsistent _ _ = True
-
--- | Find if there are any cycles in the dependency graph. If there are no
--- cycles the result is @[]@.
---
--- This actually computes the strongly connected components. So it gives us a
--- list of groups of packages where within each group they all depend on each
--- other, directly or indirectly.
---
-dependencyCycles :: PackageFixedDeps pkg
-                 => PackageIndex pkg
-                 -> [[pkg]]
-dependencyCycles index =
-  [ vs | Graph.CyclicSCC vs <- Graph.stronglyConnComp adjacencyList ]
-  where
-    adjacencyList = [ (pkg, packageId pkg, depends pkg)
-                    | pkg <- allPackages index ]
-
--- | Builds a graph of the package dependencies.
---
--- Dependencies on other packages that are not in the index are discarded.
--- You can check if there are any such dependencies with 'brokenPackages'.
---
-dependencyGraph :: PackageFixedDeps pkg
-                => PackageIndex pkg
-                -> (Graph.Graph,
-                    Graph.Vertex -> pkg,
-                    PackageIdentifier -> Maybe Graph.Vertex)
-dependencyGraph index = (graph, vertexToPkg, pkgIdToVertex)
-  where
-    graph = Array.listArray bounds $
-            map (catMaybes . map pkgIdToVertex . depends) pkgs
-    vertexToPkg vertex = pkgTable ! vertex
-    pkgIdToVertex = binarySearch 0 topBound
-
-    pkgTable   = Array.listArray bounds pkgs
-    pkgIdTable = Array.listArray bounds (map packageId pkgs)
-    pkgs = sortBy (comparing packageId) (allPackages index)
-    topBound = length pkgs - 1
-    bounds = (0, topBound)
-
-    binarySearch a b key
-      | a > b     = Nothing
-      | otherwise = case compare key (pkgIdTable ! mid) of
-          LT -> binarySearch a (mid-1) key
-          EQ -> Just mid
-          GT -> binarySearch (mid+1) b key
-      where mid = (a + b) `div` 2

--- a/cabal-install/Distribution/Client/PlanIndex.hs
+++ b/cabal-install/Distribution/Client/PlanIndex.hs
@@ -1,0 +1,205 @@
+{-# LANGUAGE CPP #-}
+module Distribution.Client.PlanIndex (
+    brokenPackages
+  , dependencyClosure
+  , dependencyCycles
+  , dependencyGraph
+  , dependencyInconsistencies
+  , reverseDependencyClosure
+  , reverseTopologicalOrder
+  , topologicalOrder
+  ) where
+
+import Prelude hiding (lookup)
+import qualified Data.Map as Map
+import qualified Data.Tree  as Tree
+import qualified Data.Graph as Graph
+import qualified Data.Array as Array
+import Data.Array ((!))
+import Data.List (groupBy, sortBy, nub)
+import Data.Maybe (isNothing, fromMaybe, catMaybes)
+
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid (Monoid(..))
+#endif
+
+import Distribution.Package
+         ( PackageName(..), PackageIdentifier(..)
+         , Package(..), packageName, packageVersion
+         )
+import Distribution.Version
+         ( Version )
+import Distribution.Simple.Utils (equating, comparing)
+
+import Distribution.Client.PackageIndex
+         ( PackageFixedDeps(..) )
+import Distribution.Client.PackageIndex
+         ( PackageIndex, lookupPackageId, allPackages, insert )
+
+-- | All packages that have dependencies that are not in the index.
+--
+-- Returns such packages along with the dependencies that they're missing.
+--
+brokenPackages :: PackageFixedDeps pkg
+               => PackageIndex pkg
+               -> [(pkg, [PackageIdentifier])]
+brokenPackages index =
+  [ (pkg, missing)
+  | pkg  <- allPackages index
+  , let missing = [ pkg' | pkg' <- depends pkg
+                         , isNothing (lookupPackageId index pkg') ]
+  , not (null missing) ]
+
+-- | Given a package index where we assume we want to use all the packages
+-- (use 'dependencyClosure' if you need to get such a index subset) find out
+-- if the dependencies within it use consistent versions of each package.
+-- Return all cases where multiple packages depend on different versions of
+-- some other package.
+--
+-- Each element in the result is a package name along with the packages that
+-- depend on it and the versions they require. These are guaranteed to be
+-- distinct.
+--
+dependencyInconsistencies :: PackageFixedDeps pkg
+                          => PackageIndex pkg
+                          -> [(PackageName, [(PackageIdentifier, Version)])]
+dependencyInconsistencies index =
+  [ (name, inconsistencies)
+  | (name, uses) <- Map.toList inverseIndex
+  , let inconsistencies = duplicatesBy uses
+        versions = map snd inconsistencies
+  , reallyIsInconsistent name (nub versions) ]
+
+  where inverseIndex = Map.fromListWith (++)
+          [ (packageName dep, [(packageId pkg, packageVersion dep)])
+          | pkg <- allPackages index
+          , dep <- depends pkg ]
+
+        duplicatesBy = (\groups -> if length groups == 1
+                                     then []
+                                     else concat groups)
+                     . groupBy (equating snd)
+                     . sortBy (comparing snd)
+
+        reallyIsInconsistent :: PackageName -> [Version] -> Bool
+        reallyIsInconsistent _    []       = False
+        reallyIsInconsistent name [v1, v2] =
+          case (mpkg1, mpkg2) of
+            (Just pkg1, Just pkg2) -> pkgid1 `notElem` depends pkg2
+                                   && pkgid2 `notElem` depends pkg1
+            _ -> True
+          where
+            pkgid1 = PackageIdentifier name v1
+            pkgid2 = PackageIdentifier name v2
+            mpkg1 = lookupPackageId index pkgid1
+            mpkg2 = lookupPackageId index pkgid2
+
+        reallyIsInconsistent _ _ = True
+
+-- | Find if there are any cycles in the dependency graph. If there are no
+-- cycles the result is @[]@.
+--
+-- This actually computes the strongly connected components. So it gives us a
+-- list of groups of packages where within each group they all depend on each
+-- other, directly or indirectly.
+--
+dependencyCycles :: PackageFixedDeps pkg
+                 => PackageIndex pkg
+                 -> [[pkg]]
+dependencyCycles index =
+  [ vs | Graph.CyclicSCC vs <- Graph.stronglyConnComp adjacencyList ]
+  where
+    adjacencyList = [ (pkg, packageId pkg, depends pkg)
+                    | pkg <- allPackages index ]
+
+-- | Tries to take the transitive closure of the package dependencies.
+--
+-- If the transitive closure is complete then it returns that subset of the
+-- index. Otherwise it returns the broken packages as in 'brokenPackages'.
+--
+-- * Note that if the result is @Right []@ it is because at least one of
+-- the original given 'PackageIdentifier's do not occur in the index.
+--
+dependencyClosure :: PackageFixedDeps pkg
+                  => PackageIndex pkg
+                  -> [PackageIdentifier]
+                  -> Either (PackageIndex pkg)
+                            [(pkg, [PackageIdentifier])]
+dependencyClosure index pkgids0 = case closure mempty [] pkgids0 of
+  (completed, []) -> Left completed
+  (completed, _)  -> Right (brokenPackages completed)
+  where
+    closure completed failed []             = (completed, failed)
+    closure completed failed (pkgid:pkgids) = case lookupPackageId index pkgid of
+      Nothing   -> closure completed (pkgid:failed) pkgids
+      Just pkg  -> case lookupPackageId completed (packageId pkg) of
+        Just _  -> closure completed  failed pkgids
+        Nothing -> closure completed' failed pkgids'
+          where completed' = insert pkg completed
+                pkgids'    = depends pkg ++ pkgids
+
+topologicalOrder :: PackageFixedDeps pkg => PackageIndex pkg -> [pkg]
+topologicalOrder index = map toPkgId
+                       . Graph.topSort
+                       $ graph
+  where (graph, toPkgId, _) = dependencyGraph index
+
+reverseTopologicalOrder :: PackageFixedDeps pkg => PackageIndex pkg -> [pkg]
+reverseTopologicalOrder index = map toPkgId
+                              . Graph.topSort
+                              . Graph.transposeG
+                              $ graph
+  where (graph, toPkgId, _) = dependencyGraph index
+
+-- | Takes the transitive closure of the packages reverse dependencies.
+--
+-- * The given 'PackageIdentifier's must be in the index.
+--
+reverseDependencyClosure :: PackageFixedDeps pkg
+                         => PackageIndex pkg
+                         -> [PackageIdentifier]
+                         -> [pkg]
+reverseDependencyClosure index =
+    map vertexToPkg
+  . concatMap Tree.flatten
+  . Graph.dfs reverseDepGraph
+  . map (fromMaybe noSuchPkgId . pkgIdToVertex)
+
+  where
+    (depGraph, vertexToPkg, pkgIdToVertex) = dependencyGraph index
+    reverseDepGraph = Graph.transposeG depGraph
+    noSuchPkgId = error "reverseDependencyClosure: package is not in the graph"
+
+
+
+
+-- | Builds a graph of the package dependencies.
+--
+-- Dependencies on other packages that are not in the index are discarded.
+-- You can check if there are any such dependencies with 'brokenPackages'.
+--
+dependencyGraph :: PackageFixedDeps pkg
+                => PackageIndex pkg
+                -> (Graph.Graph,
+                    Graph.Vertex -> pkg,
+                    PackageIdentifier -> Maybe Graph.Vertex)
+dependencyGraph index = (graph, vertexToPkg, pkgIdToVertex)
+  where
+    graph = Array.listArray bounds $
+            map (catMaybes . map pkgIdToVertex . depends) pkgs
+    vertexToPkg vertex = pkgTable ! vertex
+    pkgIdToVertex = binarySearch 0 topBound
+
+    pkgTable   = Array.listArray bounds pkgs
+    pkgIdTable = Array.listArray bounds (map packageId pkgs)
+    pkgs = sortBy (comparing packageId) (allPackages index)
+    topBound = length pkgs - 1
+    bounds = (0, topBound)
+
+    binarySearch a b key
+      | a > b     = Nothing
+      | otherwise = case compare key (pkgIdTable ! mid) of
+          LT -> binarySearch a (mid-1) key
+          EQ -> Just mid
+          GT -> binarySearch (mid+1) b key
+      where mid = (a + b) `div` 2

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -17,7 +17,7 @@ module Distribution.Client.Types where
 import Distribution.Package
          ( PackageName, PackageId, Package(..)
          , mkPackageKey, PackageKey, InstalledPackageId(..)
-         , PackageInstalled(..) )
+         , HasInstalledPackageId(..), PackageInstalled(..) )
 import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo, packageKey )
 import Distribution.PackageDescription
@@ -75,8 +75,9 @@ instance Package InstalledPackage where
   packageId (InstalledPackage pkg _) = packageId pkg
 instance PackageFixedDeps InstalledPackage where
   depends (InstalledPackage _ deps) = deps
-instance PackageInstalled InstalledPackage where
+instance HasInstalledPackageId InstalledPackage where
   installedPackageId (InstalledPackage pkg _) = installedPackageId pkg
+instance PackageInstalled InstalledPackage where
   installedDepends (InstalledPackage pkg _) = installedDepends pkg
 
 
@@ -113,8 +114,9 @@ instance Package ConfiguredPackage where
 instance PackageFixedDeps ConfiguredPackage where
   depends (ConfiguredPackage _ _ _ deps) = deps
 
-instance PackageInstalled ConfiguredPackage where
+instance HasInstalledPackageId ConfiguredPackage where
   installedPackageId = fakeInstalledPackageId . packageId
+instance PackageInstalled ConfiguredPackage where
   installedDepends = map fakeInstalledPackageId . depends
 
 -- | Like 'ConfiguredPackage', but with all dependencies guaranteed to be
@@ -132,8 +134,9 @@ instance Package ReadyPackage where
 instance PackageFixedDeps ReadyPackage where
   depends (ReadyPackage _ _ _ deps) = map packageId deps
 
-instance PackageInstalled ReadyPackage where
+instance HasInstalledPackageId ReadyPackage where
   installedPackageId = fakeInstalledPackageId . packageId
+instance PackageInstalled ReadyPackage where
   installedDepends (ReadyPackage _ _ _ ipis) = map installedPackageId ipis
 
 -- | Extracts a package key from ReadyPackage, a common operation needed

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -15,7 +15,7 @@
 module Distribution.Client.Types where
 
 import Distribution.Package
-         ( PackageName, PackageId, Package(..), PackageFixedDeps(..)
+         ( PackageName, PackageId, Package(..)
          , mkPackageKey, PackageKey, InstalledPackageId(..)
          , PackageInstalled(..) )
 import Distribution.InstalledPackageInfo
@@ -26,7 +26,7 @@ import Distribution.PackageDescription
 import Distribution.PackageDescription.Configuration
          ( mapTreeData )
 import Distribution.Client.PackageIndex
-         ( PackageIndex )
+         ( PackageIndex, PackageFixedDeps(..) )
 import Distribution.Version
          ( VersionRange )
 import Distribution.Simple.Compiler

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -98,6 +98,7 @@ executable cabal
         Distribution.Client.PackageIndex
         Distribution.Client.PackageUtils
         Distribution.Client.ParseUtils
+        Distribution.Client.PlanIndex
         Distribution.Client.Run
         Distribution.Client.Sandbox
         Distribution.Client.Sandbox.Index


### PR DESCRIPTION
This pull request is the second of a set of pull requests working towards an implementation of setup dependencies, and depends on #2487 .

There is a lot of duplication between Cabal and cabal-install, and in fact, a lot of dead code in cabal-install. There is still duplication, but no dead code anymore, and at least the situation is clarified now. Details in the commit messages.

/cc @dcoutts @kosmikus 