### PR TITLE
Constraint to installed version of template-haskell by default.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -50,6 +50,8 @@ import Distribution.Client.Setup
          , UploadFlags(..), uploadCommand
          , ReportFlags(..), reportCommand
          , showRepo, parseRepo )
+import Distribution.Client.Targets
+         ( UserConstraint (..) )
 import Distribution.Utils.NubList
          ( NubList, fromNubList, toNubList)
 
@@ -87,6 +89,8 @@ import Distribution.Compiler
          ( CompilerFlavor(..), defaultCompilerFlavor )
 import Distribution.Verbosity
          ( Verbosity, normal )
+import Distribution.Package
+         ( PackageName (..) )
 
 import Data.List
          ( partition, find, foldl' )
@@ -436,6 +440,9 @@ initialSavedConfig = do
     },
     savedConfigureFlags  = mempty {
       configProgramPathExtra = toNubList extraPath
+    },
+    savedConfigureExFlags  = mempty {
+      configExConstraints = [UserConstraintInstalled $ PackageName "template-haskell"]
     },
     savedInstallFlags    = mempty {
       installSummaryFile = toNubList [toPathTemplate (logsDir </> "build.log")],


### PR DESCRIPTION
I don't know if this is the right approach or not, but I made this pull request after running into https://ghc.haskell.org/trac/ghc/ticket/10192#ticket. As explained in the ticket, allowing template-haskell to upgrade might cause compile time errors that I wasn't able to track down. So it might be better to have by default a constraint on the template-haskell package that disallows users to upgrade.