### PR TITLE
Propose code for supporting haddock response files

### DIFF
--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -466,15 +466,28 @@ renderArgs :: Verbosity
               -> (([String], FilePath) -> IO a)
               -> IO a
 renderArgs verbosity tmpFileOpts version comp args k = do
+  let haddockSupportsUTF8          = version >= Version [2,14,4] []
+      haddockSupportsResponseFiles = version >  Version [2,16,0] []
   createDirectoryIfMissingVerbose verbosity True outputDir
   withTempFileEx tmpFileOpts outputDir "haddock-prologue.txt" $
     \prologueFileName h -> do
           do
-             when (version >= Version [2,14,4] []) (hSetEncoding h utf8)
+             when haddockSupportsUTF8 (hSetEncoding h utf8)
              hPutStrLn h $ fromFlag $ argPrologue args
              hClose h
              let pflag = "--prologue=" ++ prologueFileName
-             k (pflag : renderPureArgs version comp args, result)
+                 renderedArgs = pflag : renderPureArgs version comp args
+             if haddockSupportsResponseFiles 
+               then
+                 withTempFileEx tmpFileOpts outputDir "haddock-response.txt" $
+                    \responseFileName hf -> do
+                         when haddockSupportsUTF8 (hSetEncoding hf utf8)
+                         mapM_ (hPutStrLn hf) renderedArgs
+                         hClose hf
+                         let respFile = "@" ++ responseFileName
+                         k ([respFile], result)
+               else
+                 k (renderedArgs, result)
     where
       outputDir = (unDir $ argOutputDir args)
       result = intercalate ", "


### PR DESCRIPTION
Ref: haskell/cabal#1681 and haskell/haddock#285
(but also see haskell/haddock#379)

This change is just a proposal (but I am using it in my build
for the Haskell Platform 2015.2.0.0 on Windows) for adding
the ehancement to support haddock response files.  (One
mystery I have is where some additional arguments are
possibly still being added to the command line, based on
the verbose level 2 output, which might simply be a logging
error that prints some arguments more than once.)

Modified:

* Cabal/Distribution/Simple/Haddock.hs
  * renderArgs function: I put a couple of things into locals
    since I needed another use for UTF8 support check, plus I
    added another check based on version; the temp file logic
    was just as the prologue case above but I did need to
    repeat the invocation of the 'k' function in order to
    keep the cases separate and allow proper handling of the
    temp file automatic (or not, per --keep-temp-files)
    deletion.  Important: the haddock version being check
    against for response file support, greater than 2.16.0,
    is a placeholder and may or may not be the actual value
    since that will depend on the as-yet-unreleased haddock
    (which looks like it may be 2.16.1 but at this moment is
    not released).