### PR TITLE
Eliminate duplicate hsc2hs command line arguments

### DIFF
--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -54,7 +54,7 @@ import Distribution.Simple.Utils
          ( createDirectoryIfMissingVerbose, withUTF8FileContents, writeUTF8File
          , die, setupMessage, intercalate, copyFileVerbose, moreRecentFile
          , findFileWithExtension, findFileWithExtension'
-         , getDirectoryContentsRecursive )
+         , getDirectoryContentsRecursive, ordNubRight )
 import Distribution.Simple.Program
          ( Program(..), ConfiguredProgram(..), programPath
          , requireProgram, requireProgramVersion
@@ -393,7 +393,9 @@ ppHsc2hs bi lbi =
     platformIndependent = False,
     runPreProcessor = mkSimplePreProcessor $ \inFile outFile verbosity -> do
       (gccProg, _) <- requireProgram verbosity gccProgram (withPrograms lbi)
-      rawSystemProgramConf verbosity hsc2hsProgram (withPrograms lbi) . nub $
+      -- ordNubRight function helps a bit in case dependent packages bring too many
+      -- command line arguments (see pull request #2516).
+      rawSystemProgramConf verbosity hsc2hsProgram (withPrograms lbi) . ordNubRight $
           [ "--cc=" ++ programPath gccProg
           , "--ld=" ++ programPath gccProg ]
 

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -393,7 +393,7 @@ ppHsc2hs bi lbi =
     platformIndependent = False,
     runPreProcessor = mkSimplePreProcessor $ \inFile outFile verbosity -> do
       (gccProg, _) <- requireProgram verbosity gccProgram (withPrograms lbi)
-      rawSystemProgramConf verbosity hsc2hsProgram (withPrograms lbi) $
+      rawSystemProgramConf verbosity hsc2hsProgram (withPrograms lbi) . nub $
           [ "--cc=" ++ programPath gccProg
           , "--ld=" ++ programPath gccProg ]
 


### PR DESCRIPTION
I've recently stumbled upon an issue that didn't let me to build my Haskell project on Windows. It manifested itself as an error:

`cabal: w:\haskell\bin\hsc2hs.exe: does not exist`

The file that seemed to be missing (hsc2hs.exe binary) was actually present in necessary directory, so I started investigating the issue.

It turned out that the core reason was that hsc2hs command line exceeded the maximum allowed length of 32767 characters. The reason why it exceeded the limit was the huge amount of duplicate `--cflag` arguments that appeared from the dependent packages. As a quick fix I just added a `nub` function call to eliminate duplicate arguments and the problem is fixed at least for my project.

While this fix doesn't completely eliminate the problem (at some point there eventually will be user with huge number of distinct arguments to hsc2hs), it still does offer some help to me, so I decided to make a pull request.