### PR TITLE
Fix a redundant constraint

### DIFF
--- a/cabal-install/Distribution/Client/PlanIndex.hs
+++ b/cabal-install/Distribution/Client/PlanIndex.hs
@@ -104,7 +104,7 @@ fakeLookupInstalledPackageId fakeMap index pkg =
 --
 -- Returns such packages along with the dependencies that they're missing.
 --
-brokenPackages :: (HasInstalledPackageId pkg, PackageFixedDeps pkg)
+brokenPackages :: (PackageFixedDeps pkg)
                => FakeMap
                -> PackageIndex pkg
                -> [(pkg, [InstalledPackageId])]


### PR DESCRIPTION
This appears to cause CI jobs on GHC head to fail; I guess GHC is now
issuing warnings for redundant constraints.

See https://travis-ci.org/haskell/cabal/jobs/57191163 for example.