### PR TITLE
cabal check will fail on -fprof-auto passed as a ghc-option

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -696,6 +696,11 @@ checkGhcOptions pkg =
         "'ghc-prof-options: -auto-all' is fine during development, but "
         ++ "not recommended in a distributed package. "
 
+  , checkProfFlags ["-fprof-auto"] $
+      PackageDistSuspicious $
+        "'ghc-prof-options: -fprof-auto' is fine during development, but "
+        ++ "not recommended in a distributed package. "
+
   , check ("-threaded" `elem` lib_ghc_options) $
       PackageDistSuspicious $
            "'ghc-options: -threaded' has no effect for libraries. It should "


### PR DESCRIPTION
This is consistent with the the current -auto-all behavior.

This fixes #2479.

Setup:
```
  % grep -- '-fprof-auto' stats.cabal
    ghc-prof-options: -Wall -fprof-auto -caf-all -threaded "-with-rtsopts=-p"
```

Before:
```
  % ../cabal/cabal-install/.cabal-sandbox/bin/cabal check
  No errors or warnings could be found in the package.
```

After:
```
  % ../cabal/cabal-install/.cabal-sandbox/bin/cabal check
  These warnings may cause trouble when distributing the package:
  * 'ghc-prof-options: -fprof-auto' is fine during development, but not
  recommended in a distributed package.
```

