### PR TITLE
Fixed bash completion for sandbox subcommands

### DIFF
--- a/cabal-install/bash-completion/cabal
+++ b/cabal-install/bash-completion/cabal
@@ -45,14 +45,8 @@ _cabal_subcommands()
         case "$word" in
           sandbox)
             # Get list of "cabal sandbox" subcommands from its help message.
-            #
-            # Following command short-circuits if it reaches flags section.
-            # This is to prevent any problems that might arise from unfortunate
-            # word combinations in flag descriptions. Usage section is parsed
-            # using simple regexp and "sandbox" subcommand is printed for each
-            # successful substitution.
             "$1" help sandbox |
-            sed -rn '/Flags/q;s/^.* cabal sandbox  *([^ ]*).*/\1/;t p;b;: p;p'
+            sed -n '1,/^Subcommands:$/d;/^Flags for sandbox:$/,$d;/^ /d;s/^\(.*\):/\1/p'
             break  # Terminate for loop.
             ;;
         esac


### PR DESCRIPTION
The regex used to parse sandbox help message was outdated and relied on the unportable sed -r option which doesn't work on BSDs. I've changed the regex to parse the current format of the help message and use portable basic regex sed syntax.