### PR TITLE
bootstrap.sh: fixes linker matching to avoid cases where tested linker names appear unexpectedly in compiler output (fixes #2542)

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -70,8 +70,8 @@ done
 
 # Check the C compiler/linker work.
 LINK="$(for link in collect2 ld; do
-  echo 'main;' | ${CC} -v -x c - -o /dev/null -\#\#\# 2>&1 | grep -q $link &&
-  echo 'main;' | ${CC} -v -x c - -o /dev/null -\#\#\# 2>&1 | grep    $link |
+  echo 'main;' | ${CC} -v -x c - -o /dev/null -\#\#\# 2>&1 | grep -qw $link &&
+  echo 'main;' | ${CC} -v -x c - -o /dev/null -\#\#\# 2>&1 | grep -w  $link |
   sed -e "s|\(.*$link\).*|\1|" -e 's/ //g' -e 's|"||' && break
 done)"
 


### PR DESCRIPTION
This fixes cases where strings like "ld" appear in compiler output on lines that have nothing to do with the linker command invocation.