### PR TITLE
Rewrite linker check to avoid grepping "ld"s.

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -81,7 +81,7 @@ LINK="$(for link in collect2 ld; do
     Please check your toolchain."
 
 # Warn that were's overriding $LD if set (if you want).
-[ -"$LD"- != -"$LINK"- ] &&
+[ -"$LD"- != -""- ] && [ -"$LD"- != -"$LINK"- ] &&
   echo "Warning: value set in $LD is not the same as C compiler's $LINK." >&2
   echo "Using $LINK instead." >&2
 


### PR DESCRIPTION
I was the one who introduced that bit, and it seems like well may have caused more trouble than it helped... so, sorry. :cry: 

Anyway, clang has since then grown the ability to `-print-prog-name`, so I've done away with all that "grepping through ""gcc -###" stuff that caused #1710, #2542, etc.

@creswick @23skidoo, could you try this out, see if it works for you?
