### PR TITLE
Enable reasonable default profiling options

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -471,13 +471,16 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
                       ghcOptHPCDir       = hpcdir Hpc.Vanilla
                     }
 
-      profOpts    = vanillaOpts `mappend` mempty {
-                      ghcOptProfilingMode = toFlag True,
-                      ghcOptHiSuffix      = toFlag "p_hi",
-                      ghcOptObjSuffix     = toFlag "p_o",
-                      ghcOptExtra         = toNubListR $ hcProfOptions GHC libBi,
-                      ghcOptHPCDir        = hpcdir Hpc.Prof
-                    }
+      profOpts    =
+        let defaultProfOptions = toNubListR [ "-fprof-auto-exported" ]
+            pkgProfOptions = toNubListR (hcProfOptions GHC libBi)
+        in vanillaOpts `mappend` mempty {
+          ghcOptProfilingMode = toFlag True,
+          ghcOptHiSuffix      = toFlag "p_hi",
+          ghcOptObjSuffix     = toFlag "p_o",
+          ghcOptExtra         = defaultProfOptions `mappend` pkgProfOptions,
+          ghcOptHPCDir        = hpcdir Hpc.Prof
+        }
 
       sharedOpts  = vanillaOpts `mappend` mempty {
                       ghcOptDynLinkMode = toFlag GhcDynamicOnly,
@@ -757,14 +760,16 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
                       ghcOptDynLinkMode    = toFlag GhcStaticOnly,
                       ghcOptHPCDir         = hpcdir Hpc.Vanilla
                    }
-      profOpts   = baseOpts `mappend` mempty {
-                      ghcOptProfilingMode  = toFlag True,
-                      ghcOptHiSuffix       = toFlag "p_hi",
-                      ghcOptObjSuffix      = toFlag "p_o",
-                      ghcOptExtra          = toNubListR $
-                                             hcProfOptions GHC exeBi,
-                      ghcOptHPCDir         = hpcdir Hpc.Prof
-                    }
+      profOpts   =
+        let defaultProfOptions = toNubListR [ "-fprof-auto-top" ]
+            pkgProfOptions = toNubListR (hcProfOptions GHC exeBi)
+        in baseOpts `mappend` mempty {
+          ghcOptProfilingMode  = toFlag True,
+          ghcOptHiSuffix       = toFlag "p_hi",
+          ghcOptObjSuffix      = toFlag "p_o",
+          ghcOptExtra          = defaultProfOptions `mappend` pkgProfOptions,
+          ghcOptHPCDir         = hpcdir Hpc.Prof
+        }
       dynOpts    = baseOpts `mappend` mempty {
                       ghcOptDynLinkMode    = toFlag GhcDynamicOnly,
                       ghcOptHiSuffix       = toFlag "dyn_hi",
@@ -957,12 +962,15 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
                        ghcOptObjSuffix   = toFlag "dyn_o",
                        ghcOptExtra       = toNubListR $ hcSharedOptions GHC libBi
                    }
-      profArgs = vanillaArgs `mappend` mempty {
-                     ghcOptProfilingMode = toFlag True,
-                     ghcOptHiSuffix      = toFlag "p_hi",
-                     ghcOptObjSuffix     = toFlag "p_o",
-                     ghcOptExtra         = toNubListR $ hcProfOptions GHC libBi
-                 }
+      profArgs =
+        let defaultProfOptions = toNubListR [ "-fprof-auto-exported" ]
+            pkgProfOptions = toNubListR (hcProfOptions GHC libBi)
+        in vanillaArgs `mappend` mempty {
+          ghcOptProfilingMode = toFlag True,
+          ghcOptHiSuffix      = toFlag "p_hi",
+          ghcOptObjSuffix     = toFlag "p_o",
+          ghcOptExtra         = defaultProfOptions `mappend` pkgProfOptions
+        }
       ghcArgs = if withVanillaLib lbi then vanillaArgs
            else if withSharedLib  lbi then sharedArgs
            else if withProfLib    lbi then profArgs

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -2,6 +2,8 @@
 
 1.23.x.x (current development version) 
 	* Deal with extra C sources from preprocessors (#238).
+	* Enable '-fprof-auto-exported' for profiled libraries (#193).
+	* Enable '-fprof-auto-top' for profiled executables (#193).
 
 1.22.0.0 Johan Tibell <johan.tibell@gmail.com> January 2015
 	* Support GHC 7.10.

--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -1369,7 +1369,12 @@ values for these fields.
 
 `ghc-prof-options:` _token list_
 :   Additional options for GHC when the package is built with profiling
-    enabled.
+    enabled. For libraries, `-fprof-auto-exported` is enabled by
+    default, automatically adding cost center annotations to all
+    exported bindings. For executables, `-fprof-auto-top` is enabled
+    by default, automatically adding cost center annotations to all
+    top-level bindings. In either case, set `-fno-prof-auto` to
+    override the default.
 
 `ghc-shared-options:` _token list_
 :   Additional options for GHC when the package is built as shared library.


### PR DESCRIPTION
This fixes #193 by adding reasonable default profiling options. The defaults are `-fprof-auto-exported` for libraries and `-fprof-auto-top` for executables. There seems to be [some agreement](http://haskell.1045720.n5.nabble.com/ghc-prof-options-and-libraries-on-Hackage-td5756706.html) in the community that the former, at least, is a reasonable setting.

/cc @ocharles @23Skidoo 
You were both involved in #2162, do you have thoughts on this?