### PR TITLE
Implement offline mode for the 'install' command.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -241,7 +241,8 @@ instance Monoid SavedConfig where
         installSymlinkBinDir         = combine installSymlinkBinDir,
         installOneShot               = combine installOneShot,
         installNumJobs               = combine installNumJobs,
-        installRunTests              = combine installRunTests
+        installRunTests              = combine installRunTests,
+        installOfflineMode           = combine installOfflineMode
         }
         where
           combine        = combine'        savedInstallFlags

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -523,7 +523,7 @@ checkPrintPlan verbosity comp installed installPlan sourcePkgDb
       die $ "Can't download packages in offline mode. "
       ++ "Must download the following packages to proceed:\n"
       ++ intercalate ", " (map display notFetched)
-      ++ "\nTry running 'cabal install --only-dependencies'."
+      ++ "\nTry using 'cabal fetch'."
 
   where
     nothingToInstall = null (InstallPlan.ready installPlan)

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -35,7 +35,7 @@ import Data.List
          ( isPrefixOf, unfoldr, nub, sort, (\\) )
 import qualified Data.Set as S
 import Data.Maybe
-         ( isJust, fromMaybe, mapMaybe, catMaybes )
+         ( catMaybes, isJust, isNothing, fromMaybe, mapMaybe )
 import Control.Exception as Exception
          ( Exception(toException), bracket, catches
          , Handler(Handler), handleJust, IOException, SomeException )
@@ -54,7 +54,7 @@ import Data.Traversable
          ( traverse )
 #endif
 import Control.Monad
-         ( forM_, when, unless )
+         ( filterM, forM_, when, unless )
 import System.Directory
          ( getTemporaryDirectory, doesDirectoryExist, doesFileExist,
            createDirectoryIfMissing, removeFile, renameDirectory )
@@ -508,6 +508,22 @@ checkPrintPlan verbosity comp installed installPlan sourcePkgDb
                  ["Use --force-reinstalls if you want to install anyway."]
       else unless dryRun $ warn verbosity
              "Note that reinstalls are always dangerous. Continuing anyway..."
+
+  -- If we are explicitly told to not download anything, check that all packages
+  -- are already fetched.
+  let offline = fromFlagOrDefault False (installOfflineMode installFlags)
+  when offline $ do
+    let pkgs = [ sourcePkg
+               | InstallPlan.Configured (ConfiguredPackage sourcePkg _ _ _)
+                 <- InstallPlan.toList installPlan ]
+    notFetched <- fmap (map packageInfoId)
+                  . filterM (fmap isNothing . checkFetched . packageSource)
+                  $ pkgs
+    unless (null notFetched) $
+      die $ "Can't download packages in offline mode. "
+      ++ "Must download the following packages to proceed:\n"
+      ++ intercalate ", " (map display notFetched)
+      ++ "\nTry running 'cabal install --only-dependencies'."
 
   where
     nothingToInstall = null (InstallPlan.ready installPlan)

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1154,7 +1154,8 @@ data InstallFlags = InstallFlags {
     installSymlinkBinDir    :: Flag FilePath,
     installOneShot          :: Flag Bool,
     installNumJobs          :: Flag (Maybe Int),
-    installRunTests         :: Flag Bool
+    installRunTests         :: Flag Bool,
+    installOfflineMode      :: Flag Bool
   }
 
 defaultInstallFlags :: InstallFlags
@@ -1181,7 +1182,8 @@ defaultInstallFlags = InstallFlags {
     installSymlinkBinDir   = mempty,
     installOneShot         = Flag False,
     installNumJobs         = mempty,
-    installRunTests        = mempty
+    installRunTests        = mempty,
+    installOfflineMode     = Flag False
   }
   where
     docIndexFile = toPathTemplate ("$datadir" </> "doc"
@@ -1392,6 +1394,10 @@ installOptions showOrParseArgs =
       , optionNumJobs
         installNumJobs (\v flags -> flags { installNumJobs = v })
 
+      , option [] ["offline"]
+          "Don't download packages from the Internet."
+          installOfflineMode (\v flags -> flags { installOfflineMode = v })
+          (yesNoOpt showOrParseArgs)
       ] ++ case showOrParseArgs of      -- TODO: remove when "cabal install"
                                         -- avoids
           ParseArgs ->
@@ -1426,7 +1432,8 @@ instance Monoid InstallFlags where
     installSymlinkBinDir   = mempty,
     installOneShot         = mempty,
     installNumJobs         = mempty,
-    installRunTests        = mempty
+    installRunTests        = mempty,
+    installOfflineMode     = mempty
   }
   mappend a b = InstallFlags {
     installDocumentation   = combine installDocumentation,
@@ -1451,7 +1458,8 @@ instance Monoid InstallFlags where
     installSymlinkBinDir   = combine installSymlinkBinDir,
     installOneShot         = combine installOneShot,
     installNumJobs         = combine installNumJobs,
-    installRunTests        = combine installRunTests
+    installRunTests        = combine installRunTests,
+    installOfflineMode     = combine installOfflineMode
   }
     where combine field = field a `mappend` field b
 

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,13 +1,14 @@
 -*-change-log-*-
 
 1.23.x.x (current development version)
-	* If there are multiple remote repos, 'cabal update' now updates 
-	them in parallel (#2503)
-	* New 'cabal upload' option '-P'/'--password-command' for reading 
-	Hackage password from arbitrary program output (#2506)
-	* Better warning for 'cabal run' (#2510)
-	* 'cabal init' now warns if the chosen package name is already 
-	registered in the source package index (#2436)
+	* If there are multiple remote repos, 'cabal update' now updates
+	them in parallel (#2503).
+	* New 'cabal upload' option '-P'/'--password-command' for reading
+	Hackage password from arbitrary program output (#2506).
+	* Better warning for 'cabal run' (#2510).
+	* 'cabal init' now warns if the chosen package name is already
+	registered in the source package index (#2436).
+	* New 'cabal install' option: '--offline' (#2578).
 
 1.22.0.0 Johan Tibell <johan.tibell@gmail.com> January 2015
 	* New command: user-config (#2159).
@@ -22,7 +23,7 @@
 	* Support sandboxes in 'bootstrap.sh' (#2137).
 	* Install profiling and shared libs by default in 'bootstrap.sh'
 	(#2009).
-	
+
 1.20.0.3 Johan Tibell <johan.tibell@gmail.com> June 2014
 	* Don't attempt to rename dist if it is already named correctly
 	* Treat all flags of a package as interdependent.


### PR DESCRIPTION
When in offline mode, 'cabal install' only installs packages from the local
tarball cache. Offline mode can be enabled with the '--offline' flag.

Fixes #2566.