### PR TITLE
cabal-install-1.18 doesn't build on GHC 7.10

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -119,7 +119,7 @@ executable cabal
     -- in bootstrap.sh.
     build-depends:
         array      >= 0.1      && < 0.6,
-        base       >= 4        && < 5,
+        base       >= 4        && < 4.8,
         bytestring >= 0.9      && < 1,
         Cabal      >= 1.18.0   && < 1.19,
         containers >= 0.1      && < 0.6,


### PR DESCRIPTION
```
Distribution/Client/Tar.hs:679:10:
    No instance for (Applicative Partial)
      arising from the superclasses of an instance declaration
    In the instance declaration for ‘Monad Partial’
xcabal: Error: some packages failed to install:
cabal-install-1.18.1.0 failed during the building phase. The exception was:
ExitFailure 1
```