### PR TITLE
Provide cabal_macros in c2hs invocation.

### DIFF
--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -486,6 +486,7 @@ ppC2hs bi lbi =
           -- Options from the current package:
            [ "--cpp=" ++ programPath gccProg, "--cppopts=-E" ]
         ++ [ "--cppopts=" ++ opt | opt <- getCppOptions bi lbi ]
+        ++ [ "--cppopts=-include" ++ (autogenModulesDir lbi </> cppHeaderName) ]
         ++ [ "--include=" ++ outBaseDir ]
 
           -- Options from dependent packages

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -2,6 +2,7 @@
 
 1.23.x.x (current development version) 
 	* Deal with extra C sources from preprocessors (#238).
+	* Include cabal_macros.h when running c2hs.
 
 1.22.0.0 Johan Tibell <johan.tibell@gmail.com> January 2015
 	* Support GHC 7.10.


### PR DESCRIPTION
This commit includes cabal_macros in c2hs call, so it will
be possible to use MIN_VERSION macros in chs files.