### PR TITLE
Fix sandbox delete-source error message typo

### DIFF
--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -1105,8 +1105,8 @@ sandboxAction sandboxFlags extraArgs globalFlags = do
         sandboxAddSource verbosity extra sandboxFlags globalFlags
     ("delete-source":extra) -> do
         when (noExtraArgs extra) $
-          die "The 'sandbox delete-source' command expects \
-              \at least one argument"
+          die ("The 'sandbox delete-source' command expects " ++
+              "at least one argument")
         sandboxDeleteSource verbosity extra sandboxFlags globalFlags
     ["list-sources"] -> sandboxListSources verbosity sandboxFlags globalFlags
 


### PR DESCRIPTION
\a is considered as a bell character, which is omitted as a result. The error message is `The 'sandbox delete-source' command expects t least one argument`