### PR TITLE
sandbox delete-source removes only registered sources

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -444,8 +444,11 @@ sandboxDeleteSource verbosity buildTreeRefs _sandboxFlags globalFlags = do
   (sandboxDir, pkgEnv) <- tryLoadSandboxConfig verbosity globalFlags
   indexFile            <- tryGetIndexFilePath (pkgEnvSavedConfig pkgEnv)
 
+  refs <- Index.listBuildTreeRefs verbosity
+          Index.ListIgnored Index.LinksAndSnapshots indexFile
+
   withRemoveTimestamps sandboxDir $ do
-    Index.removeBuildTreeRefs verbosity indexFile buildTreeRefs
+    Index.removeBuildTreeRefs verbosity indexFile buildTreeRefs refs
 
   notice verbosity $ "Note: 'sandbox delete-source' only unregisters the " ++
     "source dependency, but does not remove the package " ++


### PR DESCRIPTION
This resolves #2155
To prevent #1360 from happening again `delete-source` checks only for registered sources. It still doesn't care whether input dirs exist or not.