### PR TITLE
Automatically run `configure` before `haddock`

### DIFF
--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -824,7 +824,11 @@ benchmarkAction (benchmarkFlags, buildFlags, buildExFlags)
 haddockAction :: HaddockFlags -> [String] -> GlobalFlags -> IO ()
 haddockAction haddockFlags extraArgs globalFlags = do
   let verbosity = fromFlag (haddockVerbosity haddockFlags)
-  (_useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags mempty
+      distPref  = fromFlagOrDefault (useDistPref defaultSetupScriptOptions)
+                  (haddockDistPref haddockFlags)
+  (_useSandbox, config) <- reconfigure verbosity distPref
+                          mempty [] globalFlags DontSkipAddSourceDepsCheck
+                          NoFlag (const Nothing)
   let haddockFlags' = defaultHaddockFlags      `mappend`
                       savedHaddockFlags config `mappend` haddockFlags
       setupScriptOptions = defaultSetupScriptOptions {


### PR DESCRIPTION
Fixes #2275.

I just copied and tweaked the code from `buildAction`, which had this same issue fixed (`cabal build` used to also say `Run the 'configure' command first.`)