### PR TITLE
Resolve #2593: Lift global database restrictions

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -863,7 +863,7 @@ getInstalledPackages verbosity comp packageDBs progconf = do
 
   info verbosity "Reading installed packages..."
   case compilerFlavor comp of
-    GHC   -> GHC.getInstalledPackages verbosity packageDBs progconf
+    GHC   -> GHC.getInstalledPackages verbosity comp packageDBs progconf
     GHCJS -> GHCJS.getInstalledPackages verbosity packageDBs progconf
     JHC   -> JHC.getInstalledPackages verbosity packageDBs progconf
     LHC   -> LHC.getInstalledPackages verbosity packageDBs progconf


### PR DESCRIPTION
I'm not sure whether cabal-install should really check that we have recent enough GHC.

I tried this shortly with [composition](http://hackage.haskell.org/package/composition-1.0.1.1/docs/Data-Composition.html) package, `cabal repl` session:

```
λ *Data.Composition > let x f g = f .: g
λ *Data.Composition > :t x
x :: (c -> d) -> (a -> b -> c) -> a -> b -> d
λ *Data.Composition > :t String

<interactive>:1:1: Not in scope: data constructor ‘String’
```