### PR TITLE
Upgrade to zlib >=0.6.

### DIFF
--- a/cabal-install/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/Distribution/Client/GZipUtils.hs
@@ -45,9 +45,9 @@ maybeDecompress bytes = runST (go bytes decompressor)
     decompressor = decompressST gzipOrZlibFormat defaultDecompressParams
 
     -- DataError at the beginning of the stream probably means that stream is
-    -- not compressed, so we return it it as-is.
+    -- not compressed, so we return it as-is.
     -- TODO: alternatively, we might consider looking for the two magic bytes
-    -- at the beginning of the gzip header.
+    -- at the beginning of the gzip header.  (not an option for zlib, though.)
     go :: Monad m => ByteString -> DecompressStream m -> m ByteString
     go cs (DecompressOutputAvailable bs k) = liftM (Chunk bs) $ go' cs =<< k
     go _  (DecompressStreamEnd       bs  ) = return $ Chunk bs Empty

--- a/cabal-install/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/Distribution/Client/GZipUtils.hs
@@ -51,7 +51,7 @@ maybeDecompress bytes = runST (go bytes decompressor)
     go :: Monad m => ByteString -> DecompressStream m -> m ByteString
     go cs (DecompressOutputAvailable bs k) = liftM (Chunk bs) $ go' cs =<< k
     go _  (DecompressStreamEnd       bs  ) = return $ Chunk bs Empty
-    go cs (DecompressStreamError _err    ) = return cs
+    go _  (DecompressStreamError _err    ) = return bytes
     go cs (DecompressInputRequired      k) = go cs' =<< k c
       where
         (c, cs') = uncons cs

--- a/cabal-install/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/Distribution/Client/GZipUtils.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -19,34 +20,30 @@ module Distribution.Client.GZipUtils (
 
 import Data.Monoid ((<>))
 import Control.Monad.ST.Lazy (ST)
-import Data.ByteString.Lazy as BS (ByteString, take, unpack, fromChunks)
+#if MIN_VERSION_zlib(0,6,0)
+import Data.ByteString.Lazy as BS (ByteString, fromChunks)
+#else
+import Data.ByteString.Lazy.Internal as BS (ByteString(Empty, Chunk))
+#endif
 import qualified Data.ByteString as SBS (ByteString)
-import qualified Codec.Compression.GZip as GZip
 import Codec.Compression.Zlib.Internal
 import Data.Maybe (fromMaybe)
 
--- | Does the argument start with @0x1f8b@?  See
--- <http://tools.ietf.org/html/rfc1952#page-5>.
-verifyGzipMagicHeader :: ByteString -> Bool
-verifyGzipMagicHeader = (== [31, 139]) . BS.unpack . BS.take 2
-
--- | If first two bytes of input contain magic gzip marker, decompress as gzip.
--- If they don't, attempt to decompress as zlib.  If that fails, return input
--- bytestring.  It is the callers responsibility to verify that it is not, in
--- fact, garbage.
+-- | Attempts to decompress the `bytes' under the assumption that
+-- "data format" error at the very beginning of the stream means
+-- that it is already decompressed. Caller should make sanity checks
+-- to verify that it is not, in fact, garbage.
 --
 -- This is to deal with http proxies that lie to us and transparently
 -- decompress without removing the content-encoding header. See:
--- <https://github.com/haskell/cabal/issues/678>.  (Zlib does not provide a
--- magic marker that we can check for, so the only safe way to determine
--- whether the string is zlib-compressed is to try decompress it.)
+-- <https://github.com/haskell/cabal/issues/678>
 --
 maybeDecompress :: ByteString -> ByteString
-maybeDecompress bytes | verifyGzipMagicHeader bytes = GZip.decompress bytes
+#if MIN_VERSION_zlib(0,6,0)
 maybeDecompress bytes = fromMaybe bytes $ foldDecompressStreamWithInput outputAv inputReq err s bytes
   where
     outputAv :: SBS.ByteString -> Maybe ByteString -> Maybe ByteString
-    outputAv outchunk = fmap (<> fromChunks [outchunk])
+    outputAv outchunk = fmap (fromChunks [outchunk] <>)
       -- (7.4.2 and down do not support 'fromStrict'.)
 
     inputReq :: ByteString -> Maybe ByteString
@@ -57,3 +54,17 @@ maybeDecompress bytes = fromMaybe bytes $ foldDecompressStreamWithInput outputAv
 
     s :: forall s . DecompressStream (ST s)
     s = decompressST gzipOrZlibFormat defaultDecompressParams
+#else
+maybeDecompress bytes = foldStream $ decompressWithErrors gzipOrZlibFormat defaultDecompressParams bytes
+  where
+    -- DataError at the beginning of the stream probably means that stream is not compressed.
+    -- Returning it as-is.
+    -- TODO: alternatively, we might consider looking for the two magic bytes
+    -- at the beginning of the gzip header.
+    foldStream (StreamError DataError _) = bytes
+    foldStream somethingElse = doFold somethingElse
+
+    doFold StreamEnd               = BS.Empty
+    doFold (StreamChunk bs stream) = BS.Chunk bs (doFold stream)
+    doFold (StreamError _ msg)  = error $ "Codec.Compression.Zlib: " ++ msg
+#endif

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -142,7 +142,7 @@ executable cabal
         random     >= 1        && < 1.2,
         stm        >= 2.0      && < 3,
         time       >= 1.1      && < 1.6,
-        zlib       >= 0.5.3    && < 0.6
+        zlib       >= 0.6
 
     if flag(old-directory)
       build-depends: directory >= 1 && < 1.2, old-time >= 1 && < 1.2,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -142,7 +142,7 @@ executable cabal
         random     >= 1        && < 1.2,
         stm        >= 2.0      && < 3,
         time       >= 1.1      && < 1.6,
-        zlib       >= 0.6      && < 0.7
+        zlib       >= 0.5.3      && < 0.6
 
     if flag(old-directory)
       build-depends: directory >= 1 && < 1.2, old-time >= 1 && < 1.2,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -142,7 +142,7 @@ executable cabal
         random     >= 1        && < 1.2,
         stm        >= 2.0      && < 3,
         time       >= 1.1      && < 1.6,
-        zlib       >= 0.6
+        zlib       >= 0.6      && < 0.7
 
     if flag(old-directory)
       build-depends: directory >= 1 && < 1.2, old-time >= 1 && < 1.2,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -142,7 +142,7 @@ executable cabal
         random     >= 1        && < 1.2,
         stm        >= 2.0      && < 3,
         time       >= 1.1      && < 1.6,
-        zlib       >= 0.5.3      && < 0.6
+        zlib       >= 0.5.3    && < 0.7
 
     if flag(old-directory)
       build-depends: directory >= 1 && < 1.2, old-time >= 1 && < 1.2,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -142,7 +142,7 @@ executable cabal
         random     >= 1        && < 1.2,
         stm        >= 2.0      && < 3,
         time       >= 1.1      && < 1.6,
-        zlib       >= 0.5.3    && < 0.7
+        zlib       >= 0.5.3    && < 0.6
 
     if flag(old-directory)
       build-depends: directory >= 1 && < 1.2, old-time >= 1 && < 1.2,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -142,7 +142,7 @@ executable cabal
         random     >= 1        && < 1.2,
         stm        >= 2.0      && < 3,
         time       >= 1.1      && < 1.6,
-        zlib       >= 0.5.3    && < 0.6
+        zlib       >= 0.5.3    && < 0.7
 
     if flag(old-directory)
       build-depends: directory >= 1 && < 1.2, old-time >= 1 && < 1.2,

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -7,6 +7,7 @@ import Test.Tasty.Options
 import qualified UnitTests.Distribution.Client.Sandbox
 import qualified UnitTests.Distribution.Client.UserConfig
 import qualified UnitTests.Distribution.Client.Targets
+import qualified UnitTests.Distribution.Client.GZipUtils
 import qualified UnitTests.Distribution.Client.Dependency.Modular.PSQ
 import qualified UnitTests.Distribution.Client.Dependency.Modular.Solver
 
@@ -18,6 +19,8 @@ tests = testGroup "Unit Tests" [
        UnitTests.Distribution.Client.Sandbox.tests
   ,testGroup "Distribution.Client.Targets"
        UnitTests.Distribution.Client.Targets.tests
+  ,testGroup "Distribution.Client.GZipUtils"
+       UnitTests.Distribution.Client.GZipUtils.tests
   ,testGroup "UnitTests.Distribution.Client.Dependency.Modular.PSQ"
         UnitTests.Distribution.Client.Dependency.Modular.PSQ.tests
   ,testGroup "UnitTests.Distribution.Client.Dependency.Modular.Solver"

--- a/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
@@ -21,9 +21,9 @@ tests = [ testCase "maybeDecompress" maybeDecompressUnitTest
 
 maybeDecompressUnitTest :: Assertion
 maybeDecompressUnitTest =
-        assertBool "decompress plain" (maybeDecompress original       == original)
-     >> assertBool "decompress zlib"  (maybeDecompress compressedZlib == original)
-     >> assertBool "decompress gzip"  (maybeDecompress compressedGZip == original)
+        assertBool "decompress plain"            (maybeDecompress original              == original)
+     >> assertBool "decompress zlib (with show)" (show (maybeDecompress compressedZlib) == show original)
+     >> assertBool "decompress gzip (with show)" (show (maybeDecompress compressedGZip) == show original)
      >> (runBrokenStream >>= assertBool "decompress broken" . isLeft)
   where
     original = BS.pack "original uncompressed input"

--- a/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
@@ -8,7 +8,6 @@ import Control.Exception.Base                  (evaluate)
 import Control.Exception                       (try, SomeException)
 import Control.Monad                           (void)
 import Data.ByteString.Lazy.Char8     as BS    (pack, init, length)
-import Data.Either                             (isLeft)
 import Data.Monoid                             ((<>))
 import Distribution.Client.GZipUtils           (maybeDecompress)
 
@@ -34,3 +33,8 @@ maybeDecompressUnitTest =
 
     runBrokenStream :: IO (Either SomeException ())
     runBrokenStream = try . void . evaluate . BS.length $ maybeDecompress (BS.init compressedZlib <> BS.pack "*")
+
+-- (Only available from "Data.Either" since 7.8.)
+isLeft :: Either a b -> Bool
+isLeft (Right _) = False
+isLeft (Left _) = True

--- a/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
@@ -24,7 +24,7 @@ maybeDecompressUnitTest =
         assertBool "decompress plain"            (maybeDecompress original              == original)
      >> assertBool "decompress zlib (with show)" (show (maybeDecompress compressedZlib) == show original)
      >> assertBool "decompress gzip (with show)" (show (maybeDecompress compressedGZip) == show original)
-     >> (runBrokenStream >>= assertBool "decompress broken" . isLeft)
+     >> (runBrokenStream >>= assertBool "decompress broken stream" . isLeft)
   where
     original = BS.pack "original uncompressed input"
     compressedZlib = Zlib.compress original

--- a/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
@@ -24,6 +24,8 @@ maybeDecompressUnitTest =
         assertBool "decompress plain"            (maybeDecompress original              == original)
      >> assertBool "decompress zlib (with show)" (show (maybeDecompress compressedZlib) == show original)
      >> assertBool "decompress gzip (with show)" (show (maybeDecompress compressedGZip) == show original)
+     >> assertBool "decompress zlib"             (maybeDecompress compressedZlib        == original)
+     >> assertBool "decompress gzip"             (maybeDecompress compressedGZip        == original)
      >> (runBrokenStream >>= assertBool "decompress broken stream" . isLeft)
   where
     original = BS.pack "original uncompressed input"

--- a/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
@@ -1,0 +1,25 @@
+module UnitTests.Distribution.Client.GZipUtils (
+  tests
+  ) where
+
+import Distribution.Client.GZipUtils         (maybeDecompress)
+import Data.ByteString.Lazy.Char8    as BS   (pack)
+import Codec.Compression.Zlib        as Zlib
+import Codec.Compression.GZip        as GZip
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: [TestTree]
+tests = [ testCase "maybeDecompress" maybeDecompressUnitTest
+        ]
+
+maybeDecompressUnitTest :: Assertion
+maybeDecompressUnitTest =
+        assertBool "decompress plain" (maybeDecompress original       == original)
+     >> assertBool "decompress zlib"  (maybeDecompress compressedZlib == original)
+     >> assertBool "decompress gzip"  (maybeDecompress compressedGZip == original)
+  where
+    original = BS.pack "original uncompressed input"
+    compressedZlib = Zlib.compress original
+    compressedGZip = GZip.compress original

--- a/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
@@ -2,10 +2,15 @@ module UnitTests.Distribution.Client.GZipUtils (
   tests
   ) where
 
-import Distribution.Client.GZipUtils         (maybeDecompress)
-import Data.ByteString.Lazy.Char8    as BS   (pack)
-import Codec.Compression.Zlib        as Zlib
-import Codec.Compression.GZip        as GZip
+import Codec.Compression.GZip          as GZip
+import Codec.Compression.Zlib          as Zlib
+import Control.Exception.Base                  (evaluate)
+import Control.Exception                       (try, SomeException)
+import Control.Monad                           (void)
+import Data.ByteString.Lazy.Char8     as BS    (pack, init, length)
+import Data.Either                             (isLeft)
+import Data.Monoid                             ((<>))
+import Distribution.Client.GZipUtils           (maybeDecompress)
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -19,7 +24,11 @@ maybeDecompressUnitTest =
         assertBool "decompress plain" (maybeDecompress original       == original)
      >> assertBool "decompress zlib"  (maybeDecompress compressedZlib == original)
      >> assertBool "decompress gzip"  (maybeDecompress compressedGZip == original)
+     >> (runBrokenStream >>= assertBool "decompress broken" . isLeft)
   where
     original = BS.pack "original uncompressed input"
     compressedZlib = Zlib.compress original
     compressedGZip = GZip.compress original
+
+    runBrokenStream :: IO (Either SomeException ())
+    runBrokenStream = try . void . evaluate . BS.length $ maybeDecompress (BS.init compressedZlib <> BS.pack "*")


### PR DESCRIPTION
In order to link to hackage-security, we need to bump zlib version and adjust to api changes.

I am not familiar with cabal coding guidelines and habits, but I appreciate any suggestions.  Also, I have questions:

1. Should I write a test?  (Haven't found one on this.)
2. Is there really a need for zlib compression?  If we only had to do gzip, things would look a lot easier.
3. Should we really trust the gzip magic header?  It's just two bytes, and they may match for some random reason even on unzipped data.
4. Should I throw out the gzip case?  The zlib case should handle both as before.

Thanks,
m.