### PR TITLE
Haddock action reconfigures if need be

### DIFF
--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -823,8 +823,14 @@ benchmarkAction (benchmarkFlags, buildFlags, buildExFlags)
 
 haddockAction :: HaddockFlags -> [String] -> GlobalFlags -> IO ()
 haddockAction haddockFlags extraArgs globalFlags = do
-  let verbosity = fromFlag (haddockVerbosity haddockFlags)
-  (_useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags mempty
+  let verbosity   = fromFlag (haddockVerbosity haddockFlags)
+      distPref    = fromFlagOrDefault (useDistPref defaultSetupScriptOptions)
+                    (haddockDistPref haddockFlags)
+
+  (_useSandbox, config) <- reconfigure verbosity distPref mempty []
+                          globalFlags DontSkipAddSourceDepsCheck NoFlag
+                          (const Nothing)
+  --(_useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags mempty
   let haddockFlags' = defaultHaddockFlags      `mappend`
                       savedHaddockFlags config `mappend` haddockFlags
       setupScriptOptions = defaultSetupScriptOptions {


### PR DESCRIPTION
Implements https://github.com/haskell/cabal/issues/2083. 

I'm unsure if `DontSkipAddSourceDepsCheck` should be used in a call to `reconfigure`, but `buildExFlags` is not available to `haddockAction`, so I went with a more conservative parameter (addSourceDepsCheck is always executed).