### PR TITLE
Fix #2598. Omit empty CondTree branches

### DIFF
--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -98,6 +98,7 @@ module Distribution.PackageDescription (
         GenericPackageDescription(..),
         Flag(..), FlagName(..), FlagAssignment,
         CondTree(..), ConfVar(..), Condition(..),
+        cNot,
 
         -- * Source repositories
         SourceRepo(..),
@@ -1175,6 +1176,11 @@ data Condition c = Var c
                  | COr (Condition c) (Condition c)
                  | CAnd (Condition c) (Condition c)
     deriving (Show, Eq, Typeable, Data)
+
+cNot :: Condition a -> Condition a
+cNot (Lit b)  = Lit (not b)
+cNot (CNot c) = c
+cNot c        = CNot c
 
 instance Functor Condition where
   f `fmap` Var c    = Var (f c)


### PR DESCRIPTION
As we don't know whether some field was specified explicitly in the cabal file, we can omit `if` branches as we omit fields.

### Examples

```
name:                test
cabal-version:       -any
license:             UnspecifiedLicense

Flag myflag
  Default:           False

library
  if flag(myflag)
    Buildable:       True
  else
    Buildable:       False
```

&rarr;

```
name: test
cabal-version: -any
license: UnspecifiedLicense

flag myflag
    default: False

library
    
    if !flag(myflag)
        buildable: False
```

---

```
name: test
cabal-version: -any
license: UnspecifiedLicense

flag myflag
    default: False

library
  if flag(myflag)
    extra-libraries:
  else
    extra-libraries: mylib
```

&rarr;

```
name: test
cabal-version: -any
license: UnspecifiedLicense

flag myflag
    default: False

library
    
    if !flag(myflag)
        extra-libraries:
            mylib
```

---

```
name: test
cabal-version: -any
license: UnspecifiedLicense

flag myflag
    default: False

library
  if !flag(myflag)
    extra-libraries:
  else
    extra-libraries: mylib
```

&rarr;

```
name: test
cabal-version: -any
license: UnspecifiedLicense

flag myflag
    default: False

library
    
    if flag(myflag)
        extra-libraries:
            mylib


```

---

```
name: test
cabal-version: -any
license: UnspecifiedLicense

flag myflag
    default: False

library
  if flag(myflag)
    buildable: False
    extra-libraries:  
  else
    buildable: True
    extra-libraries: mylib
```

&rarr;

```
name: test
cabal-version: -any
license: UnspecifiedLicense

flag myflag
    default: False

library
    
    if flag(myflag)
        buildable: False
    else
        extra-libraries:
            mylib
```

---

```
name: test
cabal-version: -any
license: UnspecifiedLicense

flag myflag
    default: False

library
  if flag(myflag)
    buildable: True
```

&rarr;

```
name: test
cabal-version: -any
license: UnspecifiedLicense

flag myflag
    default: False

library
```