### PR TITLE
Support new section syntax for remote-repo.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -107,6 +107,8 @@ import qualified Text.PrettyPrint as Disp
          ( render, text, empty )
 import Text.PrettyPrint
          ( ($+$) )
+import Text.PrettyPrint.HughesPJ
+         ( text, Doc )
 import System.Directory
          ( createDirectoryIfMissing, getAppUserDataDirectory, renameFile )
 import Network.URI
@@ -126,8 +128,6 @@ import Data.Version
 import Data.Char
          ( isSpace )
 import qualified Data.Map as M
-import Text.PrettyPrint.HughesPJ
-         ( text )
 import Data.Function
          ( on )
 import Data.List

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -867,7 +867,7 @@ showConfigWithComments :: SavedConfig -> SavedConfig -> String
 showConfigWithComments comment vals = Disp.render $
       case fmap ppRemoteRepoSection . fromNubList . globalRemoteRepos . savedGlobalFlags $ vals of
         [] -> Disp.text ""
-        (x:xs) -> foldl' ($+$) x xs
+        (x:xs) -> foldl' (\ r r' -> r $+$ Disp.text "" $+$ r') x xs
   $+$ Disp.text ""
   $+$ ppFields (skipSomeFields configFieldDescriptions) mcomment vals
   $+$ Disp.text ""

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -43,6 +43,7 @@ module Distribution.Client.Setup
     --TODO: stop exporting these:
     , showRepo
     , parseRepo
+    , readRepo
     ) where
 
 import Distribution.Client.Types
@@ -2148,8 +2149,9 @@ parseRepo = do
   uriStr <- Parse.munch1 (\c -> isAlphaNum c || c `elem` "+-=._/*()@'$:;&!?~")
   uri <- maybe Parse.pfail return (parseAbsoluteURI uriStr)
   return $ RemoteRepo {
-    remoteRepoName = name,
-    remoteRepoURI  = uri
+    remoteRepoName     = name,
+    remoteRepoURI      = uri,
+    remoteRepoRootKeys = ()
   }
 
 -- ------------------------------------------------------------

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -235,11 +235,20 @@ data PackageLocation local =
 data LocalRepo = LocalRepo
   deriving (Show,Eq)
 
-data RemoteRepo = RemoteRepo {
-    remoteRepoName :: String,
-    remoteRepoURI  :: URI
-  }
+data RemoteRepo =
+    RemoteRepo {
+      remoteRepoName     :: String,
+      remoteRepoURI      :: URI,
+      remoteRepoRootKeys :: ()
+    }
+
+  -- FIXME: discuss this type some more.
+
   deriving (Show,Eq,Ord)
+
+-- | Construct a partial 'RemoteRepo' value to fold the field parser list over.
+emptyRemoteRepo :: String -> RemoteRepo
+emptyRemoteRepo name = RemoteRepo name (error "RemoteRepo: empty URI!") ()
 
 data Repo = Repo {
     repoKind     :: Either RemoteRepo LocalRepo,


### PR DESCRIPTION
Joint work with several people on zurihac.

Almost self-contained, and should be backwards-compatible.  The purpose of the change is that we want to add more fields to the remote-repo sections for hackage-security data types.

Hopefully there will be more progress tomorrow.
