### PR TITLE
Ignore tags when parsing version numbers

### DIFF
--- a/Cabal/Distribution/Text.hs
+++ b/Cabal/Distribution/Text.hs
@@ -57,8 +57,9 @@ instance Text Version where
 
   parse = do
       branch <- Parse.sepBy1 digits (Parse.char '.')
-      tags   <- Parse.many (Parse.char '-' >> Parse.munch1 Char.isAlphaNum)
-      return (Version branch tags)  --TODO: should we ignore the tags?
+                -- allow but ignore tags:
+      _tags  <- Parse.many (Parse.char '-' >> Parse.munch1 Char.isAlphaNum)
+      return (Version branch [])
     where
       digits = do
         first <- Parse.satisfy Char.isDigit


### PR DESCRIPTION
No change to the syntax, old tags syntax allowed but simply ignored.

Version tags have been deprecated for years and are disappearing from
the Version type in base soon.