### PR TITLE
Distribution.Simple.Setup: fix HaddockFlags mappend

### DIFF
--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -1428,7 +1428,7 @@ instance Monoid HaddockFlags where
     haddockProgramPaths = combine haddockProgramPaths,
     haddockProgramArgs  = combine haddockProgramArgs,
     haddockHoogle       = combine haddockHoogle,
-    haddockHtml         = combine haddockHoogle,
+    haddockHtml         = combine haddockHtml,
     haddockHtmlLocation = combine haddockHtmlLocation,
     haddockExecutables  = combine haddockExecutables,
     haddockTestSuites   = combine haddockTestSuites,


### PR DESCRIPTION
mappend of HaddockFlags uses the wrong function. Simple one line fix.