### PR TITLE
Parse C compiler flags from GHC correctly

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -237,6 +237,7 @@ library
     Distribution.Compat.CopyFile
     Distribution.Compat.TempFile
     Distribution.GetOpt
+    Distribution.Lex
     Distribution.Simple.GHC.Internal
     Distribution.Simple.GHC.IPI641
     Distribution.Simple.GHC.IPI642

--- a/Cabal/Distribution/Lex.hs
+++ b/Cabal/Distribution/Lex.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternGuards #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Lex
+-- Copyright   :  Ben Gamari 2015-2019
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Portability :  portable
+--
+-- This module contains a simple lexer supporting quoted strings
+
+module Distribution.Lex (
+        tokenizeQuotedWords
+ ) where
+
+import Data.Char (isSpace)
+#if __GLASGOW_HASKELL__ < 710
+import Data.Monoid
+#endif
+
+newtype DList a = DList ([a] -> [a])
+
+runDList :: DList a -> [a]
+runDList (DList run) = run []
+
+singleton :: a -> DList a
+singleton a = DList (a:)
+
+instance Monoid (DList a) where
+  mempty = DList id
+  DList a `mappend` DList b = DList (a . b)
+
+tokenizeQuotedWords :: String -> [String]
+tokenizeQuotedWords = filter (not . null) . go False mempty
+  where
+    go :: Bool        -- ^ in quoted region
+       -> DList Char  -- ^ accumulator
+       -> String      -- ^ string to be parsed
+       -> [String]    -- ^ parse result
+    go _ accum []
+      | [] <- accum' = []
+      | otherwise    = [accum']
+      where accum' = runDList accum
+
+    go False  accum (c:cs)
+      | isSpace c = runDList accum : go False mempty cs
+      | c == '"'  = go True accum cs
+
+    go True   accum (c:cs)
+      | c == '"'  = go False accum cs
+
+    go quoted accum (c:cs)
+                  = go quoted (accum `mappend` singleton c) cs
+


### PR DESCRIPTION
GHC hands us a `String` which we previously tried to parse as a `[String]`, causing GHC's compiler flags to be ignored.

It seems this is the result of an inconsistency between encodings of the settings exposed by `ghc --info`. In some cases (e.g. `Gcc Linker flags`) the flags are encoded as a `[String]` with `show` whereas in other cases (e.g. `C compiler flags`) the flags are just a `String`. We work around this by first attempting to parse a list, then falling back on tokenizing the string if this fails.

This fixes #2292.