### PR TITLE
Only warn for missing Setup.hs if build type isn't Simple

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -1523,10 +1523,11 @@ checkLicensesExist ops pkg = do
 checkSetupExists :: Monad m => CheckPackageContentOps m
                  -> PackageDescription
                  -> m (Maybe PackageCheck)
-checkSetupExists ops _ = do
+checkSetupExists ops pkg = do
+  let simpleBuild = buildType pkg == Just Simple
   hsexists  <- doesFileExist ops "Setup.hs"
   lhsexists <- doesFileExist ops "Setup.lhs"
-  return $ check (not hsexists && not lhsexists) $
+  return $ check (not simpleBuild && not hsexists && not lhsexists) $
     PackageDistInexcusable $
       "The package is missing a Setup.hs or Setup.lhs script."
 


### PR DESCRIPTION
Because `cabal sdist` will add a default `Setup.hs` anyway. See #1125 and #2629.