### PR TITLE
Run package tests with cabal executable in build directory

### DIFF
--- a/cabal-install/tests/PackageTests.hs
+++ b/cabal-install/tests/PackageTests.hs
@@ -11,7 +11,7 @@ import Distribution.Simple.Program.Builtin (ghcPkgProgram)
 import Distribution.Simple.Program.Db
         (defaultProgramDb, requireProgram, setProgramSearchPath)
 import Distribution.Simple.Program.Find
-        (ProgramSearchPathEntry(ProgramSearchPathDir), defaultProgramSearchPath)
+        (ProgramSearchPathEntry(ProgramSearchPathDir))
 import Distribution.Simple.Program.Types
         ( Program(..), simpleProgram, programPath)
 import Distribution.Simple.Utils ( findProgramVersion )
@@ -54,7 +54,7 @@ cabalProgram = (simpleProgram "cabal") {
 main :: IO ()
 main = do
     buildDir <- canonicalizePath "dist/build/cabal"
-    let programSearchPath = ProgramSearchPathDir buildDir : defaultProgramSearchPath
+    let programSearchPath = [ProgramSearchPathDir buildDir]
     (cabal, _) <- requireProgram normal cabalProgram
                       (setProgramSearchPath programSearchPath defaultProgramDb)
     (ghcPkg, _) <- requireProgram normal ghcPkgProgram defaultProgramDb

--- a/cabal-install/tests/PackageTests/Exec/Check.hs
+++ b/cabal-install/tests/PackageTests/Exec/Check.hs
@@ -102,7 +102,12 @@ tests paths =
 
           assertMyLibIsNotAvailableOutsideofSandbox paths libNameAndVersion
 
-          result <- cabal_exec paths dir ["bash", "--", "-c", "cd subdir ; cabal sandbox hc-pkg list"]
+          result <- cabal_exec paths dir
+                    [ "bash"
+                    , "--"
+                    , "-c"
+                    , "cd subdir ; ../../../../dist/build/cabal/cabal sandbox hc-pkg list"
+                    ]
           assertExecSucceeded result
           let output = outputText result
               errMsg = "my library should have been found"


### PR DESCRIPTION
The test "configures cabal to use the sandbox" runs the command `cabal sandbox hc-pkg list`.  That cabal may not be the development version.

When I looked into fixing the test, I noticed an inconsistency in the rest of the test suite.  The package tests locate cabal by searching both dist/build/cabal and the default program search path.  However, main also calls `canonicalizePath "dist/build/cabal"`, which throws an exception when the path doesn't exist.

Which solution is preferable?

1. Hard code the path as "dist/build/cabal/cabal" for all of the cabal-install package tests.
2. Search the default program search path if cabal is not in the build directory.  This would allow people to build cabal in other ways, such as installing it in a sandbox (See https://github.com/haskell/cabal/commit/3f99cc0c8d4b153f4341685147a329781f767).

This pull request implements the first option, but I'd be happy to change it.
