### PR TITLE
Test cabal exec error message in a more portable way

### DIFF
--- a/cabal-install/tests/PackageTests/Exec/Check.hs
+++ b/cabal-install/tests/PackageTests/Exec/Check.hs
@@ -130,7 +130,7 @@ assertMyExecutableNotFound paths = do
     result <- cabal_exec paths dir ["my-executable"]
     assertExecFailed result
     let output = outputText result
-        expected = "cabal: The program 'my-executable' is required but it " ++
+        expected = "The program 'my-executable' is required but it " ++
                    "could not be found"
         errMsg = "should not have found a my-executable\n" ++ output
     assertBool errMsg $


### PR DESCRIPTION
This change allows the tests "can run executables installed in the sandbox" and
"adds the sandbox bin directory to the PATH" to run on Windows by removing the
executable name from the required error message.