### PR TITLE
Compare file paths with equalFilePath for portability

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -117,7 +117,8 @@ import System.Directory                       ( createDirectory
                                               , removeDirectoryRecursive
                                               , removeFile
                                               , renameDirectory )
-import System.FilePath                        ( (</>), getSearchPath
+import System.FilePath                        ( (</>), equalFilePath
+                                              , getSearchPath
                                               , searchPathSeparator
                                               , takeDirectory )
 
@@ -340,8 +341,8 @@ sandboxDelete verbosity _sandboxFlags globalFlags = do
 
       -- Remove the @cabal.sandbox.config@ file, unless it's in a non-standard
       -- location.
-      let isNonDefaultConfigLocation =
-            pkgEnvFile /= (curDir </> sandboxPackageEnvironmentFile)
+      let isNonDefaultConfigLocation = not $ equalFilePath pkgEnvFile $
+                                       curDir </> sandboxPackageEnvironmentFile
 
       if isNonDefaultConfigLocation
         then warn verbosity $ "Sandbox config file is in non-default location: '"
@@ -349,8 +350,8 @@ sandboxDelete verbosity _sandboxFlags globalFlags = do
         else removeFile pkgEnvFile
 
       -- Remove the sandbox directory, unless we're using a shared sandbox.
-      let isNonDefaultSandboxLocation =
-            sandboxDir /= (curDir </> defaultSandboxLocation)
+      let isNonDefaultSandboxLocation = not $ equalFilePath sandboxDir $
+                                        curDir </> defaultSandboxLocation
 
       when isNonDefaultSandboxLocation $
         die $ "Non-default sandbox location used: '" ++ sandboxDir


### PR DESCRIPTION
Without this change, differences in filename capitalization caused `cabal sandbox delete` to fail with this error message when used with a default sandbox on Windows:

    cabal.exe: Non-default sandbox location used:
    'C:\folder\.cabal-sandbox'.
    Assuming a shared sandbox. Please delete
    'C:\folder\.cabal-sandbox' manually.

This commit also allows the cabal-install package tests that delete sandboxes to run on Windows.