### PR TITLE
Allow cabal freeze tests to run on Windows

### DIFF
--- a/cabal-install/tests/PackageTests/Freeze/Check.hs
+++ b/cabal-install/tests/PackageTests/Freeze/Check.hs
@@ -110,4 +110,7 @@ removeCabalConfig = do
 
 readCabalConfig :: IO String
 readCabalConfig = do
-    readFile $ dir </> "cabal.config"
+    config <- readFile $ dir </> "cabal.config"
+    -- Ensure that the file is closed so that it can be
+    -- deleted by the next test on Windows.
+    length config `seq` return config


### PR DESCRIPTION
The tests now read cabal.config strictly so that the file is closed by the time
it is deleted for the next test.