### PR TITLE
Add a stack.yaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Cabal/ghc.mk
 # TAGS files
 TAGS
 tags
+
+# stack artifacts
+/.stack-work/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,19 @@
+flags:
+  text:
+    integer-simple: false
+packages:
+- Cabal/
+- cabal-install/
+extra-deps:
+- HTTP-4000.2.20
+- mtl-2.2.1
+- network-2.6.2.0
+- network-uri-2.6.0.3
+- old-locale-1.0.0.7
+- old-time-1.1.0.3
+- parsec-3.1.9
+- random-1.1
+- stm-2.4.4
+- text-1.2.1.1
+- zlib-0.5.4.2
+resolver: ghc-7.10


### PR DESCRIPTION
I needed this when building cabal.exe for MinGHC (see:
https://github.com/fpco/minghc/issues/69). I thought others might find
this useful, especially for the use case of bootstrapping cabal
development.

I went the direction of no curation and explicit packages in the
extra-deps, as I thought that would make more sense for a project low on
the dependency chain, but this could certainly be tweaked to use LTS
Haskell or Stackage Nightly instead.