### PR TITLE
HACKING.md: Add quotation to sed command

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -74,7 +74,7 @@ To build and test the `Cabal` library, do:
     for example with:
 
     ~~~~
-    cabal exec -- sh -c "echo \$GHC_PACKAGE_PATH" | sed s/:.*//
+    cabal exec -- sh -c "echo \$GHC_PACKAGE_PATH" | sed 's/:.*//'
     ~~~~
 
     the result should be something like


### PR DESCRIPTION
The command line given to get the sandbox package database path is missing quotation which may make it fail in some shells (given certain globbing options). This adds single quotation marks to avoid such potential issues.