### PR TITLE
Exit with an error if $CABAL_SANDBOX_CONFIG does not point to extant file

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -102,6 +102,7 @@ import Control.Exception                      ( assert, bracket_ )
 import Control.Monad                          ( forM, liftM2, unless, when )
 import Data.Bits                              ( shiftL, shiftR, xor )
 import Data.Char                              ( ord )
+import Data.Foldable                          ( forM_ )
 import Data.IORef                             ( newIORef, writeIORef, readIORef )
 import Data.List                              ( delete, foldl' )
 import Data.Maybe                             ( fromJust )
@@ -170,7 +171,11 @@ updateSandboxConfigFileFlag globalFlags =
   case globalSandboxConfigFile globalFlags of
     Flag _ -> return globalFlags
     NoFlag -> do
-      f' <- fmap (maybe NoFlag Flag) . lookupEnv $ "CABAL_SANDBOX_CONFIG"
+      fp <- lookupEnv "CABAL_SANDBOX_CONFIG"
+      forM_ fp $ \fp' -> do      -- Check for existence if environment variable set
+        exists <- doesFileExist fp'
+        unless exists $ die $ "Cabal sandbox file in $CABAL_SANDBOX_CONFIG does not exist: " ++ fp'
+      let f' = maybe NoFlag Flag fp
       return globalFlags { globalSandboxConfigFile = f' }
 
 -- | Return the path to the sandbox config file - either the default or the one


### PR DESCRIPTION
--

I think this fixes #2224. I haven't done extensive manual testing, but the tests all (obviously) still pass.

Example output:

cabal: Cabal sandbox file in $CABAL_SANDBOX_CONFIG does not exist: foo

the "foo" is the content of the env variable.

I should note that the error occurs quite "aggressively", i.e. when the settings are read, and not when they are actually used -- so even things like "cabal info" will fail if the env variable is invalid. I think a more relaxed would be a lot more error-prone since it would be easy to miss cases.
