### PR TITLE
Add support for automatic profiling detail levels, with reasonable defaults

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -473,7 +473,8 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
 
       profOpts    = vanillaOpts `mappend` mempty {
                       ghcOptProfilingMode = toFlag True,
-                      ghcOptProfilingAuto = toFlag GhcProfAutoExported,
+                      ghcOptProfilingAuto = Internal.profDetailLevelFlag True
+                                              (withProfLibDetail lbi),
                       ghcOptHiSuffix      = toFlag "p_hi",
                       ghcOptObjSuffix     = toFlag "p_o",
                       ghcOptExtra         = toNubListR $ hcProfOptions GHC libBi,
@@ -762,7 +763,8 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
                    }
       profOpts   = baseOpts `mappend` mempty {
                       ghcOptProfilingMode  = toFlag True,
-                      ghcOptProfilingAuto  = toFlag GhcProfAutoToplevel,
+                      ghcOptProfilingAuto  = Internal.profDetailLevelFlag False
+                                               (withProfExeDetail lbi),
                       ghcOptHiSuffix       = toFlag "p_hi",
                       ghcOptObjSuffix      = toFlag "p_o",
                       ghcOptExtra          = toNubListR (hcProfOptions GHC exeBi),
@@ -979,7 +981,8 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
                    }
       profArgs   = vanillaArgs `mappend` mempty {
                      ghcOptProfilingMode = toFlag True,
-                     ghcOptProfilingAuto = toFlag GhcProfAutoExported,
+                     ghcOptProfilingAuto = Internal.profDetailLevelFlag True
+                                             (withProfLibDetail lbi),
                      ghcOptHiSuffix      = toFlag "p_hi",
                      ghcOptObjSuffix     = toFlag "p_o",
                      ghcOptExtra         = toNubListR $ hcProfOptions GHC libBi

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -471,16 +471,14 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
                       ghcOptHPCDir       = hpcdir Hpc.Vanilla
                     }
 
-      profOpts    =
-        let defaultProfOptions = toNubListR [ "-fprof-auto-exported" ]
-            pkgProfOptions = toNubListR (hcProfOptions GHC libBi)
-        in vanillaOpts `mappend` mempty {
-          ghcOptProfilingMode = toFlag True,
-          ghcOptHiSuffix      = toFlag "p_hi",
-          ghcOptObjSuffix     = toFlag "p_o",
-          ghcOptExtra         = defaultProfOptions `mappend` pkgProfOptions,
-          ghcOptHPCDir        = hpcdir Hpc.Prof
-        }
+      profOpts    = vanillaOpts `mappend` mempty {
+                      ghcOptProfilingMode = toFlag True,
+                      ghcOptProfilingAuto = toFlag GhcProfAutoExported,
+                      ghcOptHiSuffix      = toFlag "p_hi",
+                      ghcOptObjSuffix     = toFlag "p_o",
+                      ghcOptExtra         = toNubListR $ hcProfOptions GHC libBi,
+                      ghcOptHPCDir        = hpcdir Hpc.Prof
+                    }
 
       sharedOpts  = vanillaOpts `mappend` mempty {
                       ghcOptDynLinkMode = toFlag GhcDynamicOnly,
@@ -762,16 +760,14 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
                       ghcOptDynLinkMode    = toFlag GhcStaticOnly,
                       ghcOptHPCDir         = hpcdir Hpc.Vanilla
                    }
-      profOpts   =
-        let defaultProfOptions = toNubListR [ "-fprof-auto-top" ]
-            pkgProfOptions = toNubListR (hcProfOptions GHC exeBi)
-        in baseOpts `mappend` mempty {
-          ghcOptProfilingMode  = toFlag True,
-          ghcOptHiSuffix       = toFlag "p_hi",
-          ghcOptObjSuffix      = toFlag "p_o",
-          ghcOptExtra          = defaultProfOptions `mappend` pkgProfOptions,
-          ghcOptHPCDir         = hpcdir Hpc.Prof
-        }
+      profOpts   = baseOpts `mappend` mempty {
+                      ghcOptProfilingMode  = toFlag True,
+                      ghcOptProfilingAuto  = toFlag GhcProfAutoToplevel,
+                      ghcOptHiSuffix       = toFlag "p_hi",
+                      ghcOptObjSuffix      = toFlag "p_o",
+                      ghcOptExtra          = toNubListR (hcProfOptions GHC exeBi),
+                      ghcOptHPCDir         = hpcdir Hpc.Prof
+                    }
       dynOpts    = baseOpts `mappend` mempty {
                       ghcOptDynLinkMode    = toFlag GhcDynamicOnly,
                       ghcOptHiSuffix       = toFlag "dyn_hi",
@@ -981,15 +977,13 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
                        ghcOptObjSuffix   = toFlag "dyn_o",
                        ghcOptExtra       = toNubListR $ hcSharedOptions GHC libBi
                    }
-      profArgs =
-        let defaultProfOptions = toNubListR [ "-fprof-auto-exported" ]
-            pkgProfOptions = toNubListR (hcProfOptions GHC libBi)
-        in vanillaArgs `mappend` mempty {
-          ghcOptProfilingMode = toFlag True,
-          ghcOptHiSuffix      = toFlag "p_hi",
-          ghcOptObjSuffix     = toFlag "p_o",
-          ghcOptExtra         = defaultProfOptions `mappend` pkgProfOptions
-        }
+      profArgs   = vanillaArgs `mappend` mempty {
+                     ghcOptProfilingMode = toFlag True,
+                     ghcOptProfilingAuto = toFlag GhcProfAutoExported,
+                     ghcOptHiSuffix      = toFlag "p_hi",
+                     ghcOptObjSuffix     = toFlag "p_o",
+                     ghcOptExtra         = toNubListR $ hcProfOptions GHC libBi
+                   }
       ghcArgs = if withVanillaLib lbi then vanillaArgs
            else if withSharedLib  lbi then sharedArgs
            else if withProfLib    lbi then profArgs

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -471,13 +471,16 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
                       ghcOptHPCDir       = hpcdir Hpc.Vanilla
                     }
 
-      profOpts    = vanillaOpts `mappend` mempty {
-                      ghcOptProfilingMode = toFlag True,
-                      ghcOptHiSuffix      = toFlag "p_hi",
-                      ghcOptObjSuffix     = toFlag "p_o",
-                      ghcOptExtra         = toNubListR $ hcProfOptions GHC libBi,
-                      ghcOptHPCDir        = hpcdir Hpc.Prof
-                    }
+      profOpts    =
+        let defaultProfOptions = toNubListR [ "-fprof-auto-exported" ]
+            pkgProfOptions = toNubListR (hcProfOptions GHC libBi)
+        in vanillaOpts `mappend` mempty {
+          ghcOptProfilingMode = toFlag True,
+          ghcOptHiSuffix      = toFlag "p_hi",
+          ghcOptObjSuffix     = toFlag "p_o",
+          ghcOptExtra         = defaultProfOptions `mappend` pkgProfOptions,
+          ghcOptHPCDir        = hpcdir Hpc.Prof
+        }
 
       sharedOpts  = vanillaOpts `mappend` mempty {
                       ghcOptDynLinkMode = toFlag GhcDynamicOnly,
@@ -759,14 +762,16 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
                       ghcOptDynLinkMode    = toFlag GhcStaticOnly,
                       ghcOptHPCDir         = hpcdir Hpc.Vanilla
                    }
-      profOpts   = baseOpts `mappend` mempty {
-                      ghcOptProfilingMode  = toFlag True,
-                      ghcOptHiSuffix       = toFlag "p_hi",
-                      ghcOptObjSuffix      = toFlag "p_o",
-                      ghcOptExtra          = toNubListR $
-                                             hcProfOptions GHC exeBi,
-                      ghcOptHPCDir         = hpcdir Hpc.Prof
-                    }
+      profOpts   =
+        let defaultProfOptions = toNubListR [ "-fprof-auto-top" ]
+            pkgProfOptions = toNubListR (hcProfOptions GHC exeBi)
+        in baseOpts `mappend` mempty {
+          ghcOptProfilingMode  = toFlag True,
+          ghcOptHiSuffix       = toFlag "p_hi",
+          ghcOptObjSuffix      = toFlag "p_o",
+          ghcOptExtra          = defaultProfOptions `mappend` pkgProfOptions,
+          ghcOptHPCDir         = hpcdir Hpc.Prof
+        }
       dynOpts    = baseOpts `mappend` mempty {
                       ghcOptDynLinkMode    = toFlag GhcDynamicOnly,
                       ghcOptHiSuffix       = toFlag "dyn_hi",
@@ -976,12 +981,15 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
                        ghcOptObjSuffix   = toFlag "dyn_o",
                        ghcOptExtra       = toNubListR $ hcSharedOptions GHC libBi
                    }
-      profArgs = vanillaArgs `mappend` mempty {
-                     ghcOptProfilingMode = toFlag True,
-                     ghcOptHiSuffix      = toFlag "p_hi",
-                     ghcOptObjSuffix     = toFlag "p_o",
-                     ghcOptExtra         = toNubListR $ hcProfOptions GHC libBi
-                 }
+      profArgs =
+        let defaultProfOptions = toNubListR [ "-fprof-auto-exported" ]
+            pkgProfOptions = toNubListR (hcProfOptions GHC libBi)
+        in vanillaArgs `mappend` mempty {
+          ghcOptProfilingMode = toFlag True,
+          ghcOptHiSuffix      = toFlag "p_hi",
+          ghcOptObjSuffix     = toFlag "p_o",
+          ghcOptExtra         = defaultProfOptions `mappend` pkgProfOptions
+        }
       ghcArgs = if withVanillaLib lbi then vanillaArgs
            else if withSharedLib  lbi then sharedArgs
            else if withProfLib    lbi then profArgs

--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -47,6 +47,7 @@ data GhcImplInfo = GhcImplInfo
   , reportsNoExt         :: Bool -- ^ --supported-languages gives Ext and NoExt
   , alwaysNondecIndent   :: Bool -- ^ NondecreasingIndentation is always on
   , flagGhciScript       :: Bool -- ^ -ghci-script flag supported
+  , flagProfAuto         :: Bool -- ^ new style -fprof-auto* flags
   , flagPackageConf      :: Bool -- ^ use package-conf instead of package-db
   , flagDebugInfo        :: Bool -- ^ -g flag supported
   }
@@ -80,6 +81,7 @@ ghcVersionImplInfo (Version v _) = GhcImplInfo
   , reportsNoExt         = v >= [7]
   , alwaysNondecIndent   = v <  [7,1]
   , flagGhciScript       = v >= [7,2]
+  , flagProfAuto         = v >= [7,4]
   , flagPackageConf      = v <  [7,5]
   , flagDebugInfo        = v >= [7,10]
   }
@@ -100,6 +102,7 @@ ghcjsVersionImplInfo _ghcjsVer _ghcVer = GhcImplInfo
   , reportsNoExt         = True
   , alwaysNondecIndent   = False
   , flagGhciScript       = True
+  , flagProfAuto         = True
   , flagPackageConf      = False
   , flagDebugInfo        = False
   }

--- a/Cabal/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Simple/LocalBuildInfo.hs
@@ -74,7 +74,7 @@ import Distribution.Package
          , PackageName )
 import Distribution.Simple.Compiler
          ( Compiler, compilerInfo, PackageDBStack, DebugInfoLevel
-         , OptimisationLevel )
+         , OptimisationLevel, ProfDetailLevel )
 import Distribution.Simple.PackageIndex
          ( InstalledPackageIndex, allPackages )
 import Distribution.ModuleName ( ModuleName )
@@ -139,6 +139,8 @@ data LocalBuildInfo = LocalBuildInfo {
         withSharedLib :: Bool,  -- ^Whether to build shared versions of libs.
         withDynExe    :: Bool,  -- ^Whether to link executables dynamically
         withProfExe   :: Bool,  -- ^Whether to build executables for profiling.
+        withProfLibDetail :: ProfDetailLevel, -- ^Level of automatic profile detail.
+        withProfExeDetail :: ProfDetailLevel, -- ^Level of automatic profile detail.
         withOptimization :: OptimisationLevel, -- ^Whether to build with optimization (if available).
         withDebugInfo :: DebugInfoLevel, -- ^Whether to emit debug info (if available).
         withGHCiLib   :: Bool,  -- ^Whether to build libs suitable for use with GHCi.

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -4,6 +4,7 @@ module Distribution.Simple.Program.GHC (
     GhcMode(..),
     GhcOptimisation(..),
     GhcDynLinkMode(..),
+    GhcProfAuto(..),
 
     ghcInvocation,
     renderGhcOptions,
@@ -161,6 +162,9 @@ data GhcOptions = GhcOptions {
   -- | Compile in profiling mode; the @ghc -prof@ flag.
   ghcOptProfilingMode :: Flag Bool,
 
+  -- | Automatically add profiling cost centers; the @ghc -fprof-auto*@ flags.
+  ghcOptProfilingAuto :: Flag GhcProfAuto,
+
   -- | Use the \"split object files\" feature; the @ghc -split-objs@ flag.
   ghcOptSplitObjs     :: Flag Bool,
 
@@ -230,6 +234,10 @@ data GhcDynLinkMode = GhcStaticOnly       -- ^ @-static@
                     | GhcStaticAndDynamic -- ^ @-static -dynamic-too@
  deriving (Show, Eq)
 
+data GhcProfAuto = GhcProfAutoAll       -- ^ @-fprof-auto@
+                 | GhcProfAutoToplevel  -- ^ @-fprof-auto-top@
+                 | GhcProfAutoExported  -- ^ @-fprof-auto-exported@
+ deriving (Show, Eq)
 
 runGHC :: Verbosity -> ConfiguredProgram -> Compiler -> GhcOptions -> IO ()
 runGHC verbosity ghcProg comp opts = do
@@ -282,6 +290,18 @@ renderGhcOptions comp opts
   , [ "-g" | flagDebugInfo implInfo && flagBool ghcOptDebugInfo ]
 
   , [ "-prof" | flagBool ghcOptProfilingMode ]
+
+  , case flagToMaybe (ghcOptProfilingAuto opts) of
+      Nothing                   -> []
+      Just GhcProfAutoAll
+        | flagProfAuto implInfo -> ["-fprof-auto"]
+        | otherwise             -> ["-auto-all"] -- not the same, but close
+      Just GhcProfAutoToplevel
+        | flagProfAuto implInfo -> ["-fprof-auto-top"]
+        | otherwise             -> ["-auto-all"]
+      Just GhcProfAutoExported
+        | flagProfAuto implInfo -> ["-fprof-auto-exported"]
+        | otherwise             -> ["-auto"]
 
   , [ "-split-objs" | flagBool ghcOptSplitObjs ]
 
@@ -485,6 +505,7 @@ instance Monoid GhcOptions where
     ghcOptOptimisation       = mempty,
     ghcOptDebugInfo          = mempty,
     ghcOptProfilingMode      = mempty,
+    ghcOptProfilingAuto      = mempty,
     ghcOptSplitObjs          = mempty,
     ghcOptNumJobs            = mempty,
     ghcOptHPCDir             = mempty,
@@ -538,6 +559,7 @@ instance Monoid GhcOptions where
     ghcOptOptimisation       = combine ghcOptOptimisation,
     ghcOptDebugInfo          = combine ghcOptDebugInfo,
     ghcOptProfilingMode      = combine ghcOptProfilingMode,
+    ghcOptProfilingAuto      = combine ghcOptProfilingAuto,
     ghcOptSplitObjs          = combine ghcOptSplitObjs,
     ghcOptNumJobs            = combine ghcOptNumJobs,
     ghcOptHPCDir             = combine ghcOptHPCDir,

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -292,6 +292,8 @@ renderGhcOptions comp opts
   , [ "-prof" | flagBool ghcOptProfilingMode ]
 
   , case flagToMaybe (ghcOptProfilingAuto opts) of
+      _ | not (flagBool ghcOptProfilingMode)
+                                -> []
       Nothing                   -> []
       Just GhcProfAutoAll
         | flagProfAuto implInfo -> ["-fprof-auto"]

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -5,6 +5,8 @@
 	* Include cabal_macros.h when running c2hs (#2600).
 	* Don't recompile C sources unless needed (#2601).
 	* Read 'builddir' option from 'CABAL_BUILDDIR' environment variable
+	* Enable '-fprof-auto-exported' for profiled libraries (#193).
+	* Enable '-fprof-auto-top' for profiled executables (#193).
 
 1.22.0.0 Johan Tibell <johan.tibell@gmail.com> January 2015
 	* Support GHC 7.10.

--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -1370,7 +1370,12 @@ values for these fields.
 
 `ghc-prof-options:` _token list_
 :   Additional options for GHC when the package is built with profiling
-    enabled.
+    enabled. For libraries, `-fprof-auto-exported` is enabled by
+    default, automatically adding cost center annotations to all
+    exported bindings. For executables, `-fprof-auto-top` is enabled
+    by default, automatically adding cost center annotations to all
+    top-level bindings. In either case, set `-fno-prof-auto` to
+    override the default.
 
 `ghc-shared-options:` _token list_
 :   Additional options for GHC when the package is built as shared library.

--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -1370,12 +1370,22 @@ values for these fields.
 
 `ghc-prof-options:` _token list_
 :   Additional options for GHC when the package is built with profiling
-    enabled. For libraries, `-fprof-auto-exported` is enabled by
-    default, automatically adding cost center annotations to all
-    exported bindings. For executables, `-fprof-auto-top` is enabled
-    by default, automatically adding cost center annotations to all
-    top-level bindings. In either case, set `-fno-prof-auto` to
-    override the default.
+    enabled.
+
+    Note that as of Cabal-1.24, the default profiling detail level defaults to
+    `exported-functions` for libraries and `toplevel-funcitons` for
+    executables. For GHC these correspond to the flags `-fprof-auto-exported`
+    and `-fprof-auto-top`. Prior to Cabal-1.24 the level defaulted to `none`.
+    These levels can be adjusted by the person building the package with the
+    `--profiling-detail` and `--library-profiling-detail` flags.
+
+    It is typically better for the person building the package to pick the
+    profiling detail level rather than for the package author. So unless you
+    have special needs it is probably better not to specify any of the GHC
+    `-fprof-auto*` flags here. However if you wish to override the profiling
+    detail level, you can do so using the `ghc-prof-options` field: use
+    `-fno-prof-auto` or one of the other `-fprof-auto*` flags.
+
 
 `ghc-shared-options:` _token list_
 :   Additional options for GHC when the package is built as shared library.

--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -626,24 +626,80 @@ be controlled with the following command line options.
 :   Build without optimization. This is suited for development: building
     will be quicker, but the resulting library or programs will be slower.
 
+`--enable-profiling`
+:   Build libraries and executables with profiling enabled (for compilers
+    that support profiling as a separate mode). For this to work, all
+    libraries used by this package must also have been built with profiling
+    support. For libraries this involves building an additional instance of
+    the library in addition to the normal non-profiling instance. For
+    executables it changes the single executable to be built in profiling mode.
+
+    This flag covers both libraries and executables, but can be overridden
+    by the `--enable-library-profiling` flag.
+
+    See also the `--profiling-detail` flag below.
+
+`--disable-profiling`
+:   (default) Do not enable profiling in generated libraries and executables.
+
 `--enable-library-profiling` or `-p`
-:   Request that an additional version of the library with profiling
-    features enabled be built and installed (only for implementations
-    that support profiling).
+:   As with `--enable-profiling` above, but it applies only for libraries. So
+    this generates an additional profiling instance of the library in addition
+    to the normal non-profiling instance.
+
+    The `--enable-profiling` flag controls the profiling mode for both
+    libraries and executables, but if different modes are desired for
+    libraries versus executables then use `--enable-library-profiling` as well.
 
 `--disable-library-profiling`
 :   (default) Do not generate an additional profiling version of the
     library.
 
-`--enable-profiling`
-:   Any executables generated should have profiling enabled (only for
-    implementations that support profiling). For this to work, all
-    libraries used by these executables must also have been built with
-    profiling support. The library will be built with profiling enabled (if
-    supported) unless `--disable-library-profiling` is specified.
+`--profiling-detail`[=_level_]
+:   Some compilers that support profiling, notably GHC, can allocate costs to
+    different parts of the program and there are different levels of
+    granularity or detail with which this can be done. In particular for GHC
+    this concept is called "cost centers", and GHC can automatically add cost
+    centers, and can do so in different ways.
 
-`--disable-profiling`
-:   (default) Do not enable profiling in generated executables.
+    This flag covers both libraries and executables, but can be overridden
+    by the `--library-profiling-detail` flag.
+
+    Currently this setting is ignored for compilers other than GHC. The levels
+    that cabal currently supports are:
+
+    `default`
+    :    For GHC this uses `exported-functions` for libraries and
+         `toplevel-functions` for executables.
+
+    `none`
+    :    No costs will be assigned to any code within this component.
+
+    `exported-functions`
+    :    Costs will be assigned at the granularity of all top level functions
+         exported from each module. In GHC specifically, this is for non-inline
+         functions.
+
+    `toplevel-functions`
+    :    Costs will be assigned at the granularity of all top level functions
+         in each module, whether they are exported from the module or not.
+         In GHC specifically, this is for non-inline functions.
+
+    `all-functions`
+    :    Costs will be assigned at the granularity of all functions in each
+         module, whether top level or local. In GHC specifically, this is for
+         non-inline toplevel or where-bound functions or values.
+
+    This flag is new in Cabal-1.24. Prior versions used the equivalent of
+    `none` above.
+
+`--library-profiling-detail`[=_level_]
+:   As with `--profiling-detail` above, but it applies only for libraries.
+
+    The level for both libraries and executables is set by the
+    `--profiling-detail` flag, but if different levels are desired for
+    libraries versus executables then use `--library-profiling-detail` as well.
+
 
 `--enable-library-vanilla`
 :   (default) Build ordinary libraries (as opposed to profiling

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -272,6 +272,8 @@ instance Monoid SavedConfig where
         configSharedLib           = combine configSharedLib,
         configDynExe              = combine configDynExe,
         configProfExe             = combine configProfExe,
+        configProfDetail          = combine configProfDetail,
+        configProfLibDetail       = combine configProfLibDetail,
         -- TODO: NubListify
         configConfigureArgs       = lastNonEmpty configConfigureArgs,
         configOptimization        = combine configOptimization,

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -393,7 +393,7 @@ configureOptions = commandOptions configureCommand
 
 filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
-  | cabalLibVersion >= Version [1,22,0] [] = flags_latest
+  | cabalLibVersion >= Version [1,23,0] [] = flags_latest
   -- ^ NB: we expect the latest version to be the most common case.
   | cabalLibVersion <  Version [1,3,10] [] = flags_1_3_10
   | cabalLibVersion <  Version [1,10,0] [] = flags_1_10_0
@@ -403,13 +403,18 @@ filterConfigureFlags flags cabalLibVersion
   | cabalLibVersion <  Version [1,19,2] [] = flags_1_19_1
   | cabalLibVersion <  Version [1,21,1] [] = flags_1_20_0
   | cabalLibVersion <  Version [1,22,0] [] = flags_1_21_0
+  | cabalLibVersion <  Version [1,23,0] [] = flags_1_22_0
   | otherwise = flags_latest
   where
     -- Cabal >= 1.19.1 uses '--dependency' and does not need '--constraint'.
     flags_latest = flags        { configConstraints = [] }
 
+    -- Cabal < 1.23 doesn't know about '--profiling-detail'.
+    flags_1_22_0 = flags_latest { configProfDetail    = NoFlag
+                                , configProfLibDetail = NoFlag }
+
     -- Cabal < 1.22 doesn't know about '--disable-debug-info'.
-    flags_1_21_0 = flags_latest { configDebugInfo = NoFlag }
+    flags_1_21_0 = flags_1_22_0 { configDebugInfo = NoFlag }
 
     -- Cabal < 1.21.1 doesn't know about 'disable-relocatable'
     -- Cabal < 1.21.1 doesn't know about 'enable-profiling'


### PR DESCRIPTION
This is based on top of @ttuegel's patch set "Enable reasonable default profiling options" #2555 