### PR TITLE
Support pure test packages (issue #1186)

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -190,9 +190,12 @@ checkSanity pkg =
   , check (null . versionBranch . packageVersion $ pkg) $
       PackageBuildImpossible "No 'version' field."
 
-  , check (null (executables pkg) && isNothing (library pkg)) $
+  , check (all ($ pkg) [ null . executables
+                       , null . testSuites
+                       , null . benchmarks
+                       , isNothing . library ]) $
       PackageBuildImpossible
-        "No executables and no library found. Nothing to do."
+        "No executables, libraries, tests, or benchmarks found. Nothing to do."
 
   , check (not (null duplicateNames)) $
       PackageBuildImpossible $ "Duplicate sections: " ++ commaSep duplicateNames

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -42,7 +42,7 @@ import Distribution.Simple.Compiler
 import Distribution.PackageDescription
          ( PackageDescription(..), BuildInfo(..), Library(..), Executable(..)
          , TestSuite(..), TestSuiteInterface(..), Benchmark(..)
-         , BenchmarkInterface(..), defaultRenaming )
+         , BenchmarkInterface(..), allBuildInfo, defaultRenaming )
 import qualified Distribution.InstalledPackageInfo as IPI
 import qualified Distribution.ModuleName as ModuleName
 import Distribution.ModuleName (ModuleName)
@@ -80,8 +80,6 @@ import Distribution.Text
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import Data.Maybe
-         ( maybeToList )
 import Data.Either
          ( partitionEithers )
 import Data.List
@@ -571,12 +569,10 @@ initialBuildSteps :: FilePath -- ^"dist" prefix
                   -> IO ()
 initialBuildSteps _distPref pkg_descr lbi verbosity = do
   -- check that there's something to build
-  let buildInfos =
-          map libBuildInfo (maybeToList (library pkg_descr)) ++
-          map buildInfo (executables pkg_descr)
-  unless (any buildable buildInfos) $ do
+  unless (not . null $ allBuildInfo pkg_descr) $ do
     let name = display (packageId pkg_descr)
-    die ("Package " ++ name ++ " can't be built on this system.")
+    die $ "No libraries, executables, tests, or benchmarks "
+       ++ "are enabled for package " ++ name ++ "."
 
   createDirectoryIfMissingVerbose verbosity True (buildDir lbi)
 

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -79,6 +79,8 @@ install pkg_descr lbi flags = do
       progPrefixPref = substPathTemplate (packageId pkg_descr) lbi (progPrefix lbi)
       progSuffixPref = substPathTemplate (packageId pkg_descr) lbi (progSuffix lbi)
 
+  unless (hasLibs pkg_descr || hasExes pkg_descr) $
+      die "No executables and no library found. Nothing to do."
   docExists <- doesDirectoryExist $ haddockPref distPref pkg_descr
   info verbosity ("directory " ++ haddockPref distPref pkg_descr ++
                   " does exist: " ++ show docExists)


### PR DESCRIPTION
This commit relaxes `D.PackageDescription.Check.checkConfiguredPackage` so that it
only warns when a package declares no executables, libraries, tests, or
benchmarks.  Similarly, it relaxes the check during build to only require one
component that is buildable and enabled.  Install now requires an executable or
library.

Note that `cabal install` downloads test packages before failing to install them.  I figured that checking for libraries and executables earlier wasn't worth the added complexity.

/cc @ttuegel 