### PR TITLE
Fix #2704

### DIFF
--- a/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module UnitTests.Distribution.Client.GZipUtils (
   tests
   ) where
@@ -20,7 +21,9 @@ import Test.Tasty.QuickCheck
 
 tests :: [TestTree]
 tests = [ testCase "maybeDecompress" maybeDecompressUnitTest
+#if MIN_VERSION_zlib(0,6,0)
         , testProperty "decompress plain" prop_maybeDecompress_plain
+#endif
         , testProperty "decompress zlib"  prop_maybeDecompress_zlib
         , testProperty "decompress gzip"  prop_maybeDecompress_gzip
         ]


### PR DESCRIPTION
Code branch with zlib <0.6 cannot recognise the uncompressed input.

---

OTOH, now as I think, maybe the property is ill-formed. QuickCheck *might* generate valid gzip or zlib stream for `[Word8]`. Opinions?