### PR TITLE
maybeDecompress: bail on all errors at the beginning of the stream with zlib < 0.6

### DIFF
--- a/cabal-install/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/Distribution/Client/GZipUtils.hs
@@ -77,7 +77,7 @@ maybeDecompress bytes = foldStream $ decompressWithErrors gzipOrZlibFormat defau
     -- Returning it as-is.
     -- TODO: alternatively, we might consider looking for the two magic bytes
     -- at the beginning of the gzip header.
-    foldStream (StreamError DataError _) = bytes
+    foldStream (StreamError _ _) = bytes
     foldStream somethingElse = doFold somethingElse
 
     doFold StreamEnd               = BS.Empty

--- a/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 module UnitTests.Distribution.Client.GZipUtils (
   tests
   ) where
@@ -21,9 +20,7 @@ import Test.Tasty.QuickCheck
 
 tests :: [TestTree]
 tests = [ testCase "maybeDecompress" maybeDecompressUnitTest
-#if MIN_VERSION_zlib(0,6,0)
         , testProperty "decompress plain" prop_maybeDecompress_plain
-#endif
         , testProperty "decompress zlib"  prop_maybeDecompress_zlib
         , testProperty "decompress gzip"  prop_maybeDecompress_gzip
         ]


### PR DESCRIPTION
Related to @23Skidoo question in https://github.com/haskell/cabal/pull/2706