### PR TITLE
Register packages inplace during configure, fixes #2710.

### DIFF
--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -21,6 +21,7 @@ module Distribution.Simple.Build (
 
     initialBuildSteps,
     writeAutogenFiles,
+    testSuiteLibV09AsLibAndExe,
   ) where
 
 import qualified Distribution.Simple.GHC   as GHC

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -41,6 +41,7 @@ module Distribution.Simple.GHC (
         libAbiHash,
         hcPkgInfo,
         registerPackage,
+        preregisterPackage,
         componentGhcOptions,
         componentCcGhcOptions,
         getLibDir,
@@ -1118,6 +1119,18 @@ registerPackage
   -> IO ()
 registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs =
   HcPkg.reregister (hcPkgInfo $ withPrograms lbi) verbosity
+    packageDbs (Right installedPkgInfo)
+
+preregisterPackage
+  :: Verbosity
+  -> InstalledPackageInfo
+  -> PackageDescription
+  -> LocalBuildInfo
+  -> Bool
+  -> PackageDBStack
+  -> IO ()
+preregisterPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs =
+  HcPkg.preregister (hcPkgInfo $ withPrograms lbi) verbosity
     packageDbs (Right installedPkgInfo)
 
 pkgRoot :: Verbosity -> LocalBuildInfo -> PackageDB -> IO FilePath

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -8,6 +8,7 @@ module Distribution.Simple.GHCJS (
         libAbiHash,
         hcPkgInfo,
         registerPackage,
+        preregisterPackage,
         componentGhcOptions,
         getLibDir,
         isDynamic,
@@ -840,6 +841,17 @@ registerPackage :: Verbosity
                 -> IO ()
 registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs =
   HcPkg.reregister (hcPkgInfo $ withPrograms lbi) verbosity packageDbs
+    (Right installedPkgInfo)
+
+preregisterPackage :: Verbosity
+                -> InstalledPackageInfo
+                -> PackageDescription
+                -> LocalBuildInfo
+                -> Bool
+                -> PackageDBStack
+                -> IO ()
+preregisterPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs =
+  HcPkg.preregister (hcPkgInfo $ withPrograms lbi) verbosity packageDbs
     (Right installedPkgInfo)
 
 componentGhcOptions :: Verbosity -> LocalBuildInfo

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -30,6 +30,7 @@ module Distribution.Simple.Register (
     initPackageDB,
     invokeHcPkg,
     registerPackage,
+    preregisterPackage,
     generateRegistrationInfo,
     inplaceInstalledPackageInfo,
     absoluteInstalledPackageInfo,
@@ -258,6 +259,23 @@ registerPackage verbosity installedPkgInfo pkg lbi inplace packageDbs = do
     HaskellSuite {} ->
       HaskellSuite.registerPackage verbosity installedPkgInfo pkg lbi inplace packageDbs
     _    -> die "Registering is not implemented for this compiler"
+
+preregisterPackage :: Verbosity
+                -> InstalledPackageInfo
+                -> PackageDescription
+                -> LocalBuildInfo
+                -> Bool
+                -> PackageDBStack
+                -> IO ()
+preregisterPackage verbosity installedPkgInfo pkg lbi inplace packageDbs = do
+  let msg = if inplace
+            then "In-place preregistering"
+            else "preregistering"
+  setupMessage verbosity msg (packageId pkg)
+  case compilerFlavor (compiler lbi) of
+    GHC   -> GHC.preregisterPackage   verbosity installedPkgInfo pkg lbi inplace packageDbs
+    GHCJS -> GHCJS.preregisterPackage verbosity installedPkgInfo pkg lbi inplace packageDbs
+    _    -> return ()
 
 writeHcPkgRegisterScript :: Verbosity
                          -> InstalledPackageInfo


### PR DESCRIPTION
Taking a leaf from GHC's build system playbook, we can
*pre*-register packages in the inplace database prior to
any code being built, by simply passing ghc-pkg --force
which makes it ignore those errors.  Doing this is handy
because it means Cabal can communicate information about
the package that is currently being built by the installed
package info, which is useful for Backpack features.

TODO: Currently, we register the package again after
building, to deal with compilers which don't know how
to preregister; however, this should be skippable for GHC
compilers.  To keep the code simpler we don't for now.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>