### PR TITLE
Respect $PKG_CONFIG_PATH environment variable

### DIFF
--- a/Cabal/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/Distribution/Simple/Program/Builtin.hs
@@ -55,6 +55,8 @@ import Distribution.Simple.Program.Types
          ( Program(..), ConfiguredProgram(..), simpleProgram )
 import Distribution.Simple.Utils
          ( findProgramVersion )
+import Distribution.Compat.Environment
+         ( lookupEnv )
 import Distribution.Compat.Exception
          ( catchIO )
 import Distribution.Verbosity
@@ -69,8 +71,6 @@ import Data.List
          ( isInfixOf )
 import Data.Maybe
          ( isJust )
-import System.Environment
-         ( lookupEnv )
 import qualified Data.Map as Map
 
 -- ------------------------------------------------------------

--- a/Cabal/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/Distribution/Simple/Program/Builtin.hs
@@ -67,6 +67,10 @@ import Data.Char
 
 import Data.List
          ( isInfixOf )
+import Data.Maybe
+         ( isJust )
+import System.Environment
+         ( lookupEnv )
 import qualified Data.Map as Map
 
 -- ------------------------------------------------------------
@@ -344,5 +348,12 @@ cppProgram = simpleProgram "cpp"
 
 pkgConfigProgram :: Program
 pkgConfigProgram = (simpleProgram "pkg-config") {
-    programFindVersion = findProgramVersion "--version" id
+    programFindVersion = findProgramVersion "--version" id,
+    programPostConf = \_ pkgProg -> do
+        pkgConfigPath <- lookupEnv "PKG_CONFIG_PATH"
+        let pkgProg' = pkgProg {
+            programOverrideEnv = ("PKG_CONFIG_PATH", pkgConfigPath)
+                                : programOverrideEnv pkgProg
+            }
+        return (if isJust pkgConfigPath then pkgProg' else pkgProg)
   }


### PR DESCRIPTION
This commit makes sure the `PKG_CONFIG_PATH` variable (for adding custom directories to the `pkg-config` search path) is set to match its value in the user's shell if it was set when they invoked cabal.

This is really useful if the user has some important libraries installed in a non-standard path.