### PR TITLE
Allow versions with a tag not separated by dash

### DIFF
--- a/Cabal/Distribution/Text.hs
+++ b/Cabal/Distribution/Text.hs
@@ -21,7 +21,7 @@ import qualified Distribution.Compat.ReadP as Parse
 import qualified Text.PrettyPrint          as Disp
 
 import Data.Version (Version(Version))
-import qualified Data.Char as Char (isDigit, isAlphaNum, isSpace)
+import qualified Data.Char as Char (isDigit, isAlpha, isAlphaNum, isSpace)
 
 class Text a where
   disp  :: a -> Disp.Doc
@@ -58,6 +58,10 @@ instance Text Version where
   parse = do
       branch <- Parse.sepBy1 digits (Parse.char '.')
                 -- allow but ignore tags:
+      _tag   <- Parse.optional $ do
+        c  <- Parse.satisfy Char.isAlpha
+        cs <- Parse.munch   Char.isAlphaNum
+        return (c : cs)
       _tags  <- Parse.many (Parse.char '-' >> Parse.munch1 Char.isAlphaNum)
       return (Version branch [])
     where


### PR DESCRIPTION
Closes #163.

This extends the format of versions from something like

```
/ \d+ (\.\d+)* (-[:alnum:]+)* /x
```

to

```
/ \d+ (\.\d+)* ([:alpha:][:alnum:]*)? (-[:alnum:]+)* /x
```

That is, it allows a tag starting with a letter and then any string of letters/numbers to come after the digits but before the dashed tags. Like the dashed tags, this non-dash tag is ignored by the parser.

This allows OpenSSL versions like `0.9.8y`. But do note that since the tag is ignored, this is just equal to `0.9.8`. I don't think there exists a universal comparison between differently tagged but otherwise equal versions. For example my specific use case was a version of `libsndfile` installed from its [git repo](https://github.com/erikd/libsndfile), which currently has a version `1.0.26pre6`. Since it indicates a prerelease, in a perfect world this would be considered less than `1.0.26`.

I'm guessing this might touch a lot of areas of Cabal (parsing versions other than `pkg-config` ones?), so probably it should get a careful examination. I did run tests fine though.