### PR TITLE
Ignore dependencies that are not Buildable

### DIFF
--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -236,6 +236,7 @@ resolveWithFlags dom os arch impl constrs trees checkDeps =
 
     -- simplify trees by (partially) evaluating all conditions and converting
     -- dependencies to dependency maps.
+    simplifiedTrees :: [CondTree FlagName DependencyMap PDTagged]
     simplifiedTrees = map ( mapTreeConstrs toDepMap  -- convert to maps
                           . mapTreeConds (fst . simplifyWithSysParams os arch impl))
                           trees
@@ -244,6 +245,9 @@ resolveWithFlags dom os arch impl constrs trees checkDeps =
     -- either succeeds or returns a binary tree with the missing dependencies
     -- encountered in each run.  Since the tree is constructed lazily, we
     -- avoid some computation overhead in the successful case.
+    try :: [(FlagName, [Bool])]
+        -> [(FlagName, Bool)]
+        -> Either (BT [Dependency]) (TargetSet PDTagged, FlagAssignment)
     try [] flags =
         let targetSet = TargetSet $ flip map simplifiedTrees $
                 -- apply additional constraints to all dependencies
@@ -350,11 +354,11 @@ overallDependencies (TargetSet targets) = mconcat depss
   where
     (depss, _) = unzip $ filter (removeDisabledSections . snd) targets
     removeDisabledSections :: PDTagged -> Bool
-    removeDisabledSections (Lib _) = True
-    removeDisabledSections (Exe _ _) = True
-    removeDisabledSections (Test _ t) = testEnabled t
-    removeDisabledSections (Bench _ b) = benchmarkEnabled b
-    removeDisabledSections PDNull = True
+    removeDisabledSections (Lib l)     = buildable (libBuildInfo l)
+    removeDisabledSections (Exe _ e)   = buildable (buildInfo e)
+    removeDisabledSections (Test _ t)  = testEnabled t && buildable (testBuildInfo t)
+    removeDisabledSections (Bench _ b) = benchmarkEnabled b && buildable (benchmarkBuildInfo b)
+    removeDisabledSections PDNull      = True
 
 -- Apply extra constraints to a dependency map.
 -- Combines dependencies where the result will only contain keys from the left
@@ -492,10 +496,6 @@ finalizePackageDescription userflags satisfyDep
                     , testSuites = tests'
                     , benchmarks = bms'
                     , buildDepends = fromDepMap (overallDependencies targetSet)
-                      --TODO: we need to find a way to avoid pulling in deps
-                      -- for non-buildable components. However cannot simply
-                      -- filter at this stage, since if the package were not
-                      -- available we would have failed already.
                     }
               , flagVals )
 


### PR DESCRIPTION
Hopefully fixes #1725 

There are two separate changes here:

   1. In the solver, we rewrite the condition trees for packages prior to solving. First, we try to extract from the condition tree of each component the condition under which the component is Buildable. Then we place all build dependencies of the package under the same condition. This should ensure that the solver treats this correctly. Note that we cannot necessarily decide whether a component is Buildable *prior* to solving, because the conditions can involve automatic flags.

   2. When configuring a package (this is in the library), we apply the configuration data and flag assignment in order to collapse down the condition trees of the components. We then also learn whether the components are Buildable or not. We now disregard dependencies for non-buildable components at this point. Fixing this should automatically also fix the sanity check that cabal-install applies to the install plans produced by the solver.