### PR TITLE
Refactoring installplan

### DIFF
--- a/cabal-install/Distribution/Client/BuildReports/Storage.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Storage.hs
@@ -118,16 +118,16 @@ storeLocal cinfo templates reports platform = sequence_
 -- * InstallPlan support
 -- ------------------------------------------------------------
 
-fromInstallPlan :: InstallPlan InstalledPackageInfo
+fromInstallPlan :: Platform -> CompilerId
+                -> InstallPlan InstalledPackageInfo
                                ConfiguredPackage
                                BuildSuccess BuildFailure
                 -> [(BuildReport, Maybe Repo)]
-fromInstallPlan plan = catMaybes
-                     . map (fromPlanPackage platform comp)
-                     . InstallPlan.toList
-                     $ plan
-  where platform = InstallPlan.planPlatform plan
-        comp     = compilerInfoId (InstallPlan.planCompiler plan)
+fromInstallPlan platform comp plan =
+     catMaybes
+   . map (fromPlanPackage platform comp)
+   . InstallPlan.toList
+   $ plan
 
 fromPlanPackage :: Platform -> CompilerId
                 -> InstallPlan.PlanPackage InstalledPackageInfo

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -122,8 +122,7 @@ configure verbosity packageDBs repos comp platform conf
                                  _ _ _)
              _)] -> do
         configurePackage verbosity
-          (InstallPlan.planPlatform installPlan)
-          (InstallPlan.planCompiler installPlan)
+          platform (compilerInfo comp)
           (setupScriptOptions installedPkgIndex (Just pkg))
           configFlags pkg extraArgs
 

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -618,7 +618,7 @@ validateSolverResult :: Platform
                                     iresult ifailure
 validateSolverResult platform comp indepGoals pkgs =
     case planPackagesProblems platform comp pkgs of
-      [] -> case InstallPlan.new platform comp indepGoals index of
+      [] -> case InstallPlan.new indepGoals index of
               Right plan     -> plan
               Left  problems -> error (formatPlanProblems problems)
       problems               -> error (formatPkgProblems problems)

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -83,6 +83,8 @@ import Distribution.Client.Targets
 import Distribution.Client.ComponentDeps (ComponentDeps)
 import qualified Distribution.Client.ComponentDeps as CD
 import qualified Distribution.InstalledPackageInfo as Installed
+import Distribution.InstalledPackageInfo
+         ( InstalledPackageInfo )
 import Distribution.Package
          ( PackageName(..), PackageIdentifier(PackageIdentifier), PackageId
          , Package(..), packageName, packageVersion
@@ -523,7 +525,10 @@ resolveDependencies :: Platform
                     -> CompilerInfo
                     -> Solver
                     -> DepResolverParams
-                    -> Progress String String InstallPlan
+                    -> Progress String String
+                                (InstallPlan InstalledPackageInfo
+                                             ConfiguredPackage
+                                             iresult ifailure)
 
     --TODO: is this needed here? see dontUpgradeNonUpgradeablePackages
 resolveDependencies platform comp _solver params
@@ -608,7 +613,9 @@ validateSolverResult :: Platform
                      -> CompilerInfo
                      -> Bool
                      -> [ResolverPackage]
-                     -> InstallPlan
+                     -> InstallPlan InstalledPackageInfo
+                                    ConfiguredPackage
+                                    iresult ifailure
 validateSolverResult platform comp indepGoals pkgs =
     case planPackagesProblems platform comp pkgs of
       [] -> case InstallPlan.new platform comp indepGoals index of

--- a/cabal-install/Distribution/Client/Dependency/Modular.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular.hs
@@ -26,9 +26,7 @@ import Distribution.Client.Dependency.Modular.Package
 import Distribution.Client.Dependency.Modular.Solver
          ( SolverConfig(..), solve )
 import Distribution.Client.Dependency.Types
-         ( DependencyResolver, PackageConstraint(..) )
-import Distribution.Client.InstallPlan
-         ( PlanPackage )
+         ( DependencyResolver, ResolverPackage, PackageConstraint(..) )
 import Distribution.System
          ( Platform(..) )
 
@@ -46,7 +44,7 @@ modularResolver sc (Platform arch os) cinfo iidx sidx pprefs pcs pns =
       gcs    = M.fromListWith (++) (map (\ pc -> (pcName pc, [pc])) pcs)
 
       -- Results have to be converted into an install plan.
-      postprocess :: Assignment -> RevDepMap -> [PlanPackage]
+      postprocess :: Assignment -> RevDepMap -> [ResolverPackage]
       postprocess a rdm = map (convCP iidx sidx) (toCPs a rdm)
 
       -- Helper function to extract the PN from a constraint.

--- a/cabal-install/Distribution/Client/Dependency/Modular/ConfiguredConversion.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/ConfiguredConversion.hs
@@ -3,12 +3,10 @@ module Distribution.Client.Dependency.Modular.ConfiguredConversion where
 import Data.Maybe
 import Prelude hiding (pi)
 
-import Distribution.Client.InstallPlan
 import Distribution.Client.Types
-import Distribution.Compiler
+import Distribution.Client.Dependency.Types (ResolverPackage(..))
 import qualified Distribution.Client.PackageIndex as CI
 import qualified Distribution.Simple.PackageIndex as SI
-import Distribution.System
 
 import Distribution.Client.Dependency.Modular.Configured
 import Distribution.Client.Dependency.Modular.Package
@@ -16,14 +14,9 @@ import Distribution.Client.Dependency.Modular.Package
 import Distribution.Client.ComponentDeps (ComponentDeps)
 import qualified Distribution.Client.ComponentDeps as CD
 
-mkPlan :: Platform -> CompilerInfo -> Bool ->
-          SI.InstalledPackageIndex -> CI.PackageIndex SourcePackage ->
-          [CP QPN] -> Either [PlanProblem] InstallPlan
-mkPlan plat comp indepGoals iidx sidx cps =
-  new plat comp indepGoals (SI.fromList (map (convCP iidx sidx) cps))
 
 convCP :: SI.InstalledPackageIndex -> CI.PackageIndex SourcePackage ->
-          CP QPN -> PlanPackage
+          CP QPN -> ResolverPackage
 convCP iidx sidx (CP qpi fa es ds) =
   case convPI qpi of
     Left  pi -> PreExisting $ InstalledPackage

--- a/cabal-install/Distribution/Client/Dependency/Modular/ConfiguredConversion.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/ConfiguredConversion.hs
@@ -12,16 +12,14 @@ import Distribution.Client.Dependency.Modular.Configured
 import Distribution.Client.Dependency.Modular.Package
 
 import Distribution.Client.ComponentDeps (ComponentDeps)
-import qualified Distribution.Client.ComponentDeps as CD
 
 
 convCP :: SI.InstalledPackageIndex -> CI.PackageIndex SourcePackage ->
           CP QPN -> ResolverPackage
 convCP iidx sidx (CP qpi fa es ds) =
   case convPI qpi of
-    Left  pi -> PreExisting $ InstalledPackage
+    Left  pi -> PreExisting
                   (fromJust $ SI.lookupInstalledPackageId iidx pi)
-                  (map confSrcId $ CD.nonSetupDeps ds')
     Right pi -> Configured $ ConfiguredPackage
                   (fromJust $ CI.lookupPackageId sidx pi)
                   fa

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -292,7 +292,8 @@ topDownResolver' platform cinfo installedPkgIndex sourcePkgIndex
       $ finaliseSelectedPackages preferences selected' constraints'
 
     toResolverPackage :: FinalSelectedPackage -> ResolverPackage
-    toResolverPackage (SelectedInstalled pkg) = PreExisting pkg
+    toResolverPackage (SelectedInstalled (InstalledPackage pkg _))
+                                              = PreExisting pkg
     toResolverPackage (SelectedSource    pkg) = Configured  pkg
 
 addTopLevelTargets :: [PackageName]

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
@@ -14,8 +14,7 @@
 module Distribution.Client.Dependency.TopDown.Types where
 
 import Distribution.Client.Types
-         ( SourcePackage(..), ReadyPackage(..)
-         , ConfiguredPackage(..)
+         ( SourcePackage(..), ConfiguredPackage(..)
          , OptionalStanza, ConfiguredId(..) )
 import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo )
@@ -134,9 +133,6 @@ instance PackageSourceDeps InstalledPackageEx where
 
 instance PackageSourceDeps ConfiguredPackage where
   sourceDeps (ConfiguredPackage _ _ _ deps) = map confSrcId $ CD.nonSetupDeps deps
-
-instance PackageSourceDeps ReadyPackage where
-  sourceDeps (ReadyPackage _ _ _ deps) = map packageId $ CD.nonSetupDeps deps
 
 instance PackageSourceDeps InstalledPackage where
   sourceDeps (InstalledPackage _ deps) = deps

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
@@ -14,13 +14,15 @@
 module Distribution.Client.Dependency.TopDown.Types where
 
 import Distribution.Client.Types
-         ( InstalledPackage(..), SourcePackage(..), ReadyPackage(..)
+         ( SourcePackage(..), ReadyPackage(..)
          , ConfiguredPackage(..)
          , OptionalStanza, ConfiguredId(..) )
+import Distribution.InstalledPackageInfo
+         ( InstalledPackageInfo )
 import qualified Distribution.Client.ComponentDeps as CD
 
 import Distribution.Package
-         ( PackageIdentifier, Dependency
+         ( PackageId, PackageIdentifier, Dependency
          , Package(packageId) )
 import Distribution.PackageDescription
          ( FlagAssignment )
@@ -47,6 +49,12 @@ data FinalSelectedPackage
 
 type TopologicalSortNumber = Int
 
+-- | InstalledPackage caches its dependencies as source package IDs.
+data InstalledPackage
+   = InstalledPackage
+       InstalledPackageInfo
+       [PackageId]
+
 data InstalledPackageEx
    = InstalledPackageEx
        InstalledPackage
@@ -67,6 +75,9 @@ data SemiConfiguredPackage
        [OptionalStanza]  -- enabled optional stanzas
        [Dependency]      -- dependencies we end up with when we apply
                          -- the flag assignment
+
+instance Package InstalledPackage where
+  packageId (InstalledPackage pkg _) = packageId pkg
 
 instance Package InstalledPackageEx where
   packageId (InstalledPackageEx p _ _) = packageId p

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
@@ -14,10 +14,9 @@
 module Distribution.Client.Dependency.TopDown.Types where
 
 import Distribution.Client.Types
-         ( SourcePackage(..), ReadyPackage(..), InstalledPackage(..)
+         ( InstalledPackage(..), SourcePackage(..), ReadyPackage(..)
+         , ConfiguredPackage(..)
          , OptionalStanza, ConfiguredId(..) )
-import Distribution.Client.InstallPlan
-         ( ConfiguredPackage(..), PlanPackage(..) )
 import qualified Distribution.Client.ComponentDeps as CD
 
 import Distribution.Package
@@ -41,6 +40,10 @@ data InstalledOrSource installed source
    | SourceOnly                   source
    | InstalledAndSource installed source
   deriving Eq
+
+data FinalSelectedPackage
+   = SelectedInstalled InstalledPackage
+   | SelectedSource    ConfiguredPackage
 
 type TopologicalSortNumber = Int
 
@@ -79,6 +82,10 @@ instance (Package installed, Package source)
   packageId (InstalledOnly      p  ) = packageId p
   packageId (SourceOnly         p  ) = packageId p
   packageId (InstalledAndSource p _) = packageId p
+
+instance Package FinalSelectedPackage where
+  packageId (SelectedInstalled pkg) = packageId pkg
+  packageId (SelectedSource    pkg) = packageId pkg
 
 
 -- | We can have constraints on selecting just installed or just source
@@ -123,9 +130,7 @@ instance PackageSourceDeps ReadyPackage where
 instance PackageSourceDeps InstalledPackage where
   sourceDeps (InstalledPackage _ deps) = deps
 
-instance PackageSourceDeps PlanPackage where
-  sourceDeps (PreExisting pkg) = sourceDeps pkg
-  sourceDeps (Configured  pkg) = sourceDeps pkg
-  sourceDeps (Processing pkg)  = sourceDeps pkg
-  sourceDeps (Installed pkg _) = sourceDeps pkg
-  sourceDeps (Failed    pkg _) = sourceDeps pkg
+instance PackageSourceDeps FinalSelectedPackage where
+  sourceDeps (SelectedInstalled pkg) = sourceDeps pkg
+  sourceDeps (SelectedSource    pkg) = sourceDeps pkg
+

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -46,8 +46,7 @@ import Data.Monoid
 #endif
 
 import Distribution.Client.Types
-         ( OptionalStanza(..), SourcePackage(..), ConfiguredPackage
-         , InstalledPackage )
+         ( OptionalStanza(..), SourcePackage(..), ConfiguredPackage )
 
 import Distribution.Compat.ReadP
          ( (<++) )
@@ -56,6 +55,8 @@ import qualified Distribution.Compat.ReadP as Parse
          ( pfail, munch1 )
 import Distribution.PackageDescription
          ( FlagAssignment, FlagName(..) )
+import Distribution.InstalledPackageInfo
+         ( InstalledPackageInfo )
 import qualified Distribution.Client.PackageIndex as PackageIndex
          ( PackageIndex )
 import Distribution.Simple.PackageIndex ( InstalledPackageIndex )
@@ -128,7 +129,7 @@ type DependencyResolver = Platform
 --
 -- This is like the 'InstallPlan.PlanPackage' but with fewer cases.
 --
-data ResolverPackage = PreExisting InstalledPackage
+data ResolverPackage = PreExisting InstalledPackageInfo
                      | Configured  ConfiguredPackage
 
 -- | Per-package constraints. Package constraints must be respected by the

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -13,8 +13,6 @@
 -- Common types for dependency resolution.
 -----------------------------------------------------------------------------
 module Distribution.Client.Dependency.Types (
-    ExtDependency(..),
-
     PreSolver(..),
     Solver(..),
     DependencyResolver,
@@ -48,9 +46,6 @@ import Data.Monoid
 import Distribution.Client.Types
          ( OptionalStanza(..), SourcePackage(..), ConfiguredPackage )
 
-import Distribution.Compat.ReadP
-         ( (<++) )
-
 import qualified Distribution.Compat.ReadP as Parse
          ( pfail, munch1 )
 import Distribution.PackageDescription
@@ -61,7 +56,7 @@ import qualified Distribution.Client.PackageIndex as PackageIndex
          ( PackageIndex )
 import Distribution.Simple.PackageIndex ( InstalledPackageIndex )
 import Distribution.Package
-         ( Dependency, PackageName, InstalledPackageId )
+         ( PackageName )
 import Distribution.Version
          ( VersionRange, simplifyVersionRange )
 import Distribution.Compiler
@@ -76,16 +71,6 @@ import Text.PrettyPrint
 
 import Prelude hiding (fail)
 
--- | Covers source dependencies and installed dependencies in
--- one type.
-data ExtDependency = SourceDependency Dependency
-                   | InstalledDependency InstalledPackageId
-
-instance Text ExtDependency where
-  disp (SourceDependency    dep) = disp dep
-  disp (InstalledDependency dep) = disp dep
-
-  parse = (SourceDependency `fmap` parse) <++ (InstalledDependency `fmap` parse)
 
 -- | All the solvers that can be selected.
 data PreSolver = AlwaysTopDown | AlwaysModular | Choose

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -18,6 +18,7 @@ module Distribution.Client.Dependency.Types (
     PreSolver(..),
     Solver(..),
     DependencyResolver,
+    ResolverPackage(..),
 
     AllowNewer(..), isAllowNewer,
     PackageConstraint(..),
@@ -45,8 +46,8 @@ import Data.Monoid
 #endif
 
 import Distribution.Client.Types
-         ( OptionalStanza(..), SourcePackage(..) )
-import qualified Distribution.Client.InstallPlan as InstallPlan
+         ( OptionalStanza(..), SourcePackage(..), ConfiguredPackage
+         , InstalledPackage )
 
 import Distribution.Compat.ReadP
          ( (<++) )
@@ -120,7 +121,15 @@ type DependencyResolver = Platform
                        -> (PackageName -> PackagePreferences)
                        -> [PackageConstraint]
                        -> [PackageName]
-                       -> Progress String String [InstallPlan.PlanPackage]
+                       -> Progress String String [ResolverPackage]
+
+-- | The dependency resolver picks either pre-existing installed packages
+-- or it picks source packages along with package configuration.
+--
+-- This is like the 'InstallPlan.PlanPackage' but with fewer cases.
+--
+data ResolverPackage = PreExisting InstalledPackage
+                     | Configured  ConfiguredPackage
 
 -- | Per-package constraints. Package constraints must be respected by the
 -- solver. Multiple constraints for each package can be given, though obviously

--- a/cabal-install/Distribution/Client/Fetch.hs
+++ b/cabal-install/Distribution/Client/Fetch.hs
@@ -139,7 +139,7 @@ planPackages verbosity comp platform fetchFlags
       -- that are in the 'InstallPlan.Configured' state.
       return
         [ pkg
-        | (InstallPlan.Configured (InstallPlan.ConfiguredPackage pkg _ _ _))
+        | (InstallPlan.Configured (ConfiguredPackage pkg _ _ _))
             <- InstallPlan.toList installPlan ]
 
   | otherwise =

--- a/cabal-install/Distribution/Client/Fetch.hs
+++ b/cabal-install/Distribution/Client/Fetch.hs
@@ -87,7 +87,7 @@ fetch verbosity packageDBs repos comp platform conf
 
     transport <- configureTransport verbosity (flagToMaybe (globalHttpTransport globalFlags))
 
-    pkgSpecifiers <- resolveUserTargets transport verbosity
+    pkgSpecifiers <- resolveUserTargets verbosity transport
                        (fromFlag $ globalWorldFile globalFlags)
                        (packageIndex sourcePkgDb)
                        userTargets

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -91,7 +91,7 @@ freeze verbosity packageDBs repos comp platform conf mSandboxPkgInfo
 
     transport <- configureTransport verbosity (flagToMaybe (globalHttpTransport globalFlags))
 
-    pkgSpecifiers <- resolveUserTargets transport verbosity
+    pkgSpecifiers <- resolveUserTargets verbosity transport
                        (fromFlag $ globalWorldFile globalFlags)
                        (packageIndex sourcePkgDb)
                        [UserTargetLocalDir "."]

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -197,16 +197,15 @@ pruneInstallPlan :: InstallPlan.InstallPlan
                  -> [PackageSpecifier SourcePackage]
                  -> [PlanPackage]
 pruneInstallPlan installPlan pkgSpecifiers =
-    mapLeft (removeSelf pkgIds . PackageIndex.allPackages) $
+    either (const brokenPkgsErr)
+           (removeSelf pkgIds . PackageIndex.allPackages) $
     InstallPlan.dependencyClosure installPlan pkgIds
   where
     pkgIds = [ packageId pkg | SpecificSourcePackage pkg <- pkgSpecifiers ]
-    mapLeft f (Left v)  = f v
-    mapLeft _ (Right _) = error "planPackages: installPlan contains broken packages"
     removeSelf [thisPkg] = filter (\pp -> packageId pp /= thisPkg)
-    removeSelf _ =
-        error $ "internal error: 'pruneInstallPlan' given "
-           ++ "unexpected package specifiers!"
+    removeSelf _  = error $ "internal error: 'pruneInstallPlan' given "
+                         ++ "unexpected package specifiers!"
+    brokenPkgsErr = error "planPackages: installPlan contains broken packages"
 
 
 freezePackages :: Package pkg => Verbosity -> [pkg] -> IO ()

--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -94,7 +94,7 @@ get verbosity repos globalFlags getFlags userTargets = do
 
   transport <- configureTransport verbosity (flagToMaybe (globalHttpTransport globalFlags))
 
-  pkgSpecifiers <- resolveUserTargets transport verbosity
+  pkgSpecifiers <- resolveUserTargets verbosity transport
                    (fromFlag $ globalWorldFile globalFlags)
                    (packageIndex sourcePkgDb)
                    userTargets

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -271,7 +271,7 @@ makeInstallContext verbosity
         let userTargets | null userTargets0 = [UserTargetLocalDir "."]
                         | otherwise         = userTargets0
 
-        pkgSpecifiers <- resolveUserTargets transport verbosity
+        pkgSpecifiers <- resolveUserTargets verbosity transport
                          (fromFlag $ globalWorldFile globalFlags)
                          (packageIndex sourcePkgDb)
                          userTargets

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -96,8 +96,6 @@ import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
 import Distribution.Client.SetupWrapper
          ( setupWrapper, SetupScriptOptions(..), defaultSetupScriptOptions )
-import Distribution.Client.PackageIndex
-         ( PackageFixedDeps(..) )
 import qualified Distribution.Client.BuildReports.Anonymous as BuildReports
 import qualified Distribution.Client.BuildReports.Storage as BuildReports
          ( storeAnonymous, storeLocal, fromInstallPlan, fromPlanningFailure )

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -136,13 +136,17 @@ import Distribution.Simple.InstallDirs as InstallDirs
 import Distribution.Package
          ( PackageIdentifier(..), PackageId, packageName, packageVersion
          , Package(..), PackageKey
-         , Dependency(..), thisPackageVersion, InstalledPackageId, installedPackageId )
+         , Dependency(..), thisPackageVersion
+         , InstalledPackageId, installedPackageId
+         , HasInstalledPackageId(..) )
 import qualified Distribution.PackageDescription as PackageDescription
 import Distribution.PackageDescription
          ( PackageDescription, GenericPackageDescription(..), Flag(..)
          , FlagName(..), FlagAssignment )
 import Distribution.PackageDescription.Configuration
          ( finalizePackageDescription )
+import Distribution.InstalledPackageInfo
+         ( InstalledPackageInfo )
 import Distribution.ParseUtils
          ( showPWarning )
 import Distribution.Version
@@ -279,7 +283,10 @@ makeInstallContext verbosity
 
 -- | Make an install plan given install context and install arguments.
 makeInstallPlan :: Verbosity -> InstallArgs -> InstallContext
-                -> IO (Progress String String InstallPlan)
+                -> IO (Progress String String
+                                (InstallPlan InstalledPackageInfo
+                                             ConfiguredPackage
+                                             iresult ifailure))
 makeInstallPlan verbosity
   (_, _, comp, platform, _, _, mSandboxPkgInfo,
    _, configFlags, configExFlags, installFlags,
@@ -296,13 +303,15 @@ makeInstallPlan verbosity
 
 -- | Given an install plan, perform the actual installations.
 processInstallPlan :: Verbosity -> InstallArgs -> InstallContext
-                   -> InstallPlan
+                   -> InstallPlan InstalledPackageInfo
+                                  ConfiguredPackage
+                                  BuildSuccess BuildFailure
                    -> IO ()
 processInstallPlan verbosity
-  args@(_,_, comp, _, _, _, _, _, _, _, installFlags, _)
+  args@(_,_, _, _, _, _, _, _, _, _, installFlags, _)
   (installedPkgIndex, sourcePkgDb,
    userTargets, pkgSpecifiers, _) installPlan = do
-    checkPrintPlan verbosity comp installedPkgIndex installPlan sourcePkgDb
+    checkPrintPlan verbosity installedPkgIndex installPlan sourcePkgDb
       installFlags pkgSpecifiers
 
     unless (dryRun || nothingToInstall) $ do
@@ -327,7 +336,10 @@ planPackages :: Compiler
              -> InstalledPackageIndex
              -> SourcePackageDb
              -> [PackageSpecifier SourcePackage]
-             -> Progress String String InstallPlan
+             -> Progress String String
+                         (InstallPlan InstalledPackageInfo
+                                      ConfiguredPackage
+                                      iresult ifailure)
 planPackages comp platform mSandboxPkgInfo solver
              configFlags configExFlags installFlags
              installedPkgIndex sourcePkgDb pkgSpecifiers =
@@ -407,8 +419,13 @@ planPackages comp platform mSandboxPkgInfo solver
     allowNewer       = fromFlag (configAllowNewer        configExFlags)
 
 -- | Remove the provided targets from the install plan.
-pruneInstallPlan :: Package pkg => [PackageSpecifier pkg] -> InstallPlan
-                    -> Progress String String InstallPlan
+pruneInstallPlan :: (Package targetpkg, Package srcpkg, Package ipkg,
+                     PackageFixedDeps srcpkg, PackageFixedDeps ipkg,
+                     HasInstalledPackageId srcpkg, HasInstalledPackageId ipkg)
+                 => [PackageSpecifier targetpkg]
+                 -> InstallPlan ipkg srcpkg iresult ifailure
+                 -> Progress String String
+                             (InstallPlan ipkg srcpkg iresult ifailure)
 pruneInstallPlan pkgSpecifiers =
   -- TODO: this is a general feature and should be moved to D.C.Dependency
   -- Also, the InstallPlan.remove should return info more precise to the
@@ -416,7 +433,7 @@ pruneInstallPlan pkgSpecifiers =
   either (Fail . explain) Done
   . InstallPlan.remove (\pkg -> packageName pkg `elem` targetnames)
   where
-    explain :: [InstallPlan.PlanProblem] -> String
+    explain :: [InstallPlan.PlanProblem ipkg srcpkg iresult ifailure] -> String
     explain problems =
       "Cannot select only the dependencies (as requested by the "
       ++ "'--only-dependencies' flag), "
@@ -441,14 +458,15 @@ pruneInstallPlan pkgSpecifiers =
 -- | Perform post-solver checks of the install plan and print it if
 -- either requested or needed.
 checkPrintPlan :: Verbosity
-               -> Compiler
                -> InstalledPackageIndex
-               -> InstallPlan
+               -> InstallPlan InstalledPackageInfo
+                              ConfiguredPackage
+                              BuildSuccess ifailure
                -> SourcePackageDb
                -> InstallFlags
                -> [PackageSpecifier SourcePackage]
                -> IO ()
-checkPrintPlan verbosity comp installed installPlan sourcePkgDb
+checkPrintPlan verbosity installed installPlan sourcePkgDb
   installFlags pkgSpecifiers = do
 
   -- User targets that are already installed.
@@ -465,7 +483,7 @@ checkPrintPlan verbosity comp installed installPlan sourcePkgDb
        : map (display . packageId) preExistingTargets
       ++ ["Use --reinstall if you want to reinstall anyway."]
 
-  let lPlan = linearizeInstallPlan comp installed installPlan
+  let lPlan = linearizeInstallPlan installed installPlan
   -- Are any packages classified as reinstalls?
   let reinstalledPkgs = concatMap (extractReinstalls . snd) lPlan
   -- Packages that are already broken.
@@ -533,11 +551,13 @@ checkPrintPlan verbosity comp installed installPlan sourcePkgDb
     dryRun            = fromFlag (installDryRun            installFlags)
     overrideReinstall = fromFlag (installOverrideReinstall installFlags)
 
-linearizeInstallPlan :: Compiler
-                     -> InstalledPackageIndex
-                     -> InstallPlan
-                     -> [(ReadyPackage, PackageStatus)]
-linearizeInstallPlan comp installedPkgIndex plan =
+--TODO: this type is too specific
+linearizeInstallPlan :: (PackageFixedDeps srcpkg, HasInstalledPackageId srcpkg)
+                     => InstalledPackageIndex
+                     -> InstallPlan InstalledPackageInfo srcpkg
+                                    BuildSuccess ifailure
+                     -> [(ReadyPackage srcpkg InstalledPackageInfo, PackageStatus)]
+linearizeInstallPlan installedPkgIndex plan =
     unfoldr next plan
   where
     next plan' = case InstallPlan.ready plan' of
@@ -545,12 +565,13 @@ linearizeInstallPlan comp installedPkgIndex plan =
       (pkg:_) -> Just ((pkg, status), plan'')
         where
           pkgid  = installedPackageId pkg
-          status = packageStatus comp installedPkgIndex pkg
-          plan'' = InstallPlan.completed pkgid
-                     (BuildOk DocsNotTried TestsNotTried
-                              (Just $ Installed.emptyInstalledPackageInfo
-                              { Installed.sourcePackageId = packageId pkg
-                              , Installed.installedPackageId = pkgid }))
+          status = packageStatus installedPkgIndex pkg
+          ipkg   = Installed.emptyInstalledPackageInfo {
+                     Installed.sourcePackageId    = packageId pkg,
+                     Installed.installedPackageId = pkgid
+                   }
+          plan'' = InstallPlan.completed pkgid (Just ipkg)
+                     (BuildOk DocsNotTried TestsNotTried (Just ipkg))
                      (InstallPlan.processing [pkg] plan')
           --FIXME: This is a bit of a hack,
           -- pretending that each package is installed
@@ -567,8 +588,11 @@ extractReinstalls :: PackageStatus -> [InstalledPackageId]
 extractReinstalls (Reinstall ipids _) = ipids
 extractReinstalls _                   = []
 
-packageStatus :: Compiler -> InstalledPackageIndex -> ReadyPackage -> PackageStatus
-packageStatus _comp installedPkgIndex cpkg =
+packageStatus :: (Package srcpkg, HasInstalledPackageId ipkg)
+              => InstalledPackageIndex
+              -> ReadyPackage srcpkg ipkg
+              -> PackageStatus
+packageStatus installedPkgIndex cpkg =
   case PackageIndex.lookupPackageName installedPkgIndex
                                       (packageName cpkg) of
     [] -> NewPackage
@@ -580,8 +604,9 @@ packageStatus _comp installedPkgIndex cpkg =
 
   where
 
-    changes :: Installed.InstalledPackageInfo
-            -> ReadyPackage
+    changes :: (Package srcpkg, HasInstalledPackageId ipkg)
+            => Installed.InstalledPackageInfo
+            -> ReadyPackage srcpkg ipkg
             -> [MergeResult PackageIdentifier PackageIdentifier]
     changes pkg pkg' = filter changed $
       mergeBy (comparing packageName)
@@ -602,7 +627,7 @@ packageStatus _comp installedPkgIndex cpkg =
 
 printPlan :: Bool -- is dry run
           -> Verbosity
-          -> [(ReadyPackage, PackageStatus)]
+          -> [(ReadyPackage ConfiguredPackage ipkg, PackageStatus)]
           -> SourcePackageDb
           -> IO ()
 printPlan dryRun verbosity plan sourcePkgDb = case plan of
@@ -622,7 +647,7 @@ printPlan dryRun verbosity plan sourcePkgDb = case plan of
     showPkg (pkg, _) = display (packageId pkg) ++
                        showLatest (pkg)
 
-    showPkgAndReason (pkg', pr) = display (packageId pkg') ++
+    showPkgAndReason (ReadyPackage pkg' _, pr) = display (packageId pkg') ++
           showLatest pkg' ++
           showFlagAssignment (nonDefaultFlags pkg') ++
           showStanzas (stanzas pkg') ++ " " ++
@@ -633,7 +658,7 @@ printPlan dryRun verbosity plan sourcePkgDb = case plan of
                 []   -> ""
                 diff -> " changes: "  ++ intercalate ", " (map change diff)
 
-    showLatest :: ReadyPackage -> String
+    showLatest :: Package srcpkg => srcpkg -> String
     showLatest pkg = case mLatestVersion of
         Just latestVersion ->
             if packageVersion pkg < latestVersion
@@ -651,15 +676,15 @@ printPlan dryRun verbosity plan sourcePkgDb = case plan of
     toFlagAssignment :: [Flag] -> FlagAssignment
     toFlagAssignment = map (\ f -> (flagName f, flagDefault f))
 
-    nonDefaultFlags :: ReadyPackage -> FlagAssignment
-    nonDefaultFlags (ReadyPackage spkg fa _ _) =
+    nonDefaultFlags :: ConfiguredPackage -> FlagAssignment
+    nonDefaultFlags (ConfiguredPackage spkg fa _ _) =
       let defaultAssignment =
             toFlagAssignment
              (genPackageFlags (Source.packageDescription spkg))
       in  fa \\ defaultAssignment
 
-    stanzas :: ReadyPackage -> [OptionalStanza]
-    stanzas (ReadyPackage _ _ sts _) = sts
+    stanzas :: ConfiguredPackage -> [OptionalStanza]
+    stanzas (ConfiguredPackage _ _ sts _) = sts
 
     showStanzas :: [OptionalStanza] -> String
     showStanzas = concatMap ((' ' :) . showStanza)
@@ -759,7 +784,9 @@ theSpecifiedPackage pkgSpec =
 postInstallActions :: Verbosity
                    -> InstallArgs
                    -> [UserTarget]
-                   -> InstallPlan
+                   -> InstallPlan InstalledPackageInfo
+                                  ConfiguredPackage
+                                  BuildSuccess BuildFailure
                    -> IO ()
 postInstallActions verbosity
   (packageDBs, _, comp, platform, conf, useSandbox, mSandboxPkgInfo
@@ -837,7 +864,7 @@ regenerateHaddockIndex :: Verbosity
                        -> UseSandbox
                        -> ConfigFlags
                        -> InstallFlags
-                       -> InstallPlan
+                       -> InstallPlan ipkg srcpkg BuildSuccess ifailure
                        -> IO ()
 regenerateHaddockIndex verbosity packageDBs comp platform conf useSandbox
                        configFlags installFlags installPlan
@@ -874,8 +901,8 @@ regenerateHaddockIndex verbosity packageDBs comp platform conf useSandbox
         normalUserInstall     = (UserPackageDB `elem` packageDBs)
                              && all (not . isSpecificPackageDB) packageDBs
 
-        installedDocs (InstallPlan.Installed _ (BuildOk DocsOk _ _)) = True
-        installedDocs _                                              = False
+        installedDocs (InstallPlan.Installed _ _ (BuildOk DocsOk _ _)) = True
+        installedDocs _                                                = False
         isSpecificPackageDB (SpecificPackageDB _) = True
         isSpecificPackageDB _                     = False
 
@@ -896,7 +923,10 @@ symlinkBinaries :: Verbosity
                 -> Compiler
                 -> ConfigFlags
                 -> InstallFlags
-                -> InstallPlan -> IO ()
+                -> InstallPlan InstalledPackageInfo
+                               ConfiguredPackage
+                               iresult ifailure
+                -> IO ()
 symlinkBinaries verbosity comp configFlags installFlags plan = do
   failed <- InstallSymlink.symlinkBinaries comp configFlags installFlags plan
   case failed of
@@ -920,7 +950,9 @@ symlinkBinaries verbosity comp configFlags installFlags plan = do
     bindir = fromFlag (installSymlinkBinDir installFlags)
 
 
-printBuildFailures :: InstallPlan -> IO ()
+printBuildFailures :: Package srcpkg
+                   => InstallPlan ipkg srcpkg iresult BuildFailure
+                   -> IO ()
 printBuildFailures plan =
   case [ (pkg, reason)
        | InstallPlan.Failed pkg reason <- InstallPlan.toList plan ] of
@@ -964,15 +996,18 @@ printBuildFailures plan =
 -- | If we're working inside a sandbox and some add-source deps were installed,
 -- update the timestamps of those deps.
 updateSandboxTimestampsFile :: UseSandbox -> Maybe SandboxPackageInfo
-                            -> Compiler -> Platform -> InstallPlan
+                            -> Compiler -> Platform
+                            -> InstallPlan ipkg ConfiguredPackage
+                                           iresult ifailure
                             -> IO ()
 updateSandboxTimestampsFile (UseSandbox sandboxDir)
                             (Just (SandboxPackageInfo _ _ _ allAddSourceDeps))
                             comp platform installPlan =
   withUpdateTimestamps sandboxDir (compilerId comp) platform $ \_ -> do
-    let allInstalled = [ pkg | InstallPlan.Installed pkg _
+    let allInstalled = [ pkg | InstallPlan.Installed pkg _ _
                             <- InstallPlan.toList installPlan ]
-        allSrcPkgs   = [ pkg | ReadyPackage pkg _ _ _ <- allInstalled ]
+        allSrcPkgs   = [ pkg | ReadyPackage (ConfiguredPackage pkg _ _ _) _
+                            <- allInstalled ]
         allPaths     = [ pth | LocalUnpackedPackage pth
                             <- map packageSource allSrcPkgs]
     allPathsCanonical <- mapM tryCanonicalizePath allPaths
@@ -996,8 +1031,12 @@ type UseLogFile = Maybe (PackageIdentifier -> PackageKey -> FilePath, Verbosity)
 performInstallations :: Verbosity
                      -> InstallArgs
                      -> InstalledPackageIndex
-                     -> InstallPlan
-                     -> IO InstallPlan
+                     -> InstallPlan InstalledPackageInfo
+                                    ConfiguredPackage
+                                    BuildSuccess BuildFailure
+                     -> IO (InstallPlan InstalledPackageInfo
+                                        ConfiguredPackage
+                                        BuildSuccess BuildFailure)
 performInstallations verbosity
   (packageDBs, _, comp, _, conf, useSandbox, _,
    globalFlags, configFlags, configExFlags, installFlags, haddockFlags)
@@ -1115,9 +1154,15 @@ executeInstallPlan :: Verbosity
                    -> Compiler
                    -> JobControl IO (PackageId, PackageKey, BuildResult)
                    -> UseLogFile
-                   -> InstallPlan
-                   -> (ReadyPackage -> IO BuildResult)
-                   -> IO InstallPlan
+                   -> InstallPlan InstalledPackageInfo
+                                  ConfiguredPackage
+                                  BuildSuccess BuildFailure
+                   -> (ReadyPackage ConfiguredPackage
+                                    InstalledPackageInfo
+                       -> IO BuildResult)
+                   -> IO (InstallPlan InstalledPackageInfo
+                                      ConfiguredPackage
+                                      BuildSuccess BuildFailure)
 executeInstallPlan verbosity comp jobCtl useLogFile plan0 installPkg =
     tryNewTasks 0 plan0
   where
@@ -1147,12 +1192,18 @@ executeInstallPlan verbosity comp jobCtl useLogFile plan0 installPkg =
           plan'      = updatePlan pkgid buildResult plan
       tryNewTasks taskCount' plan'
 
-    updatePlan :: PackageIdentifier -> BuildResult -> InstallPlan -> InstallPlan
-    updatePlan pkgid (Right buildSuccess) =
-      InstallPlan.completed (Source.fakeInstalledPackageId pkgid) buildSuccess
+    updatePlan :: PackageIdentifier -> BuildResult
+               -> InstallPlan InstalledPackageInfo ConfiguredPackage
+                              BuildSuccess BuildFailure
+               -> InstallPlan InstalledPackageInfo ConfiguredPackage
+                              BuildSuccess BuildFailure
+    updatePlan pkgid (Right buildSuccess@(BuildOk _ _ mipkg)) =
+        InstallPlan.completed (Source.fakeInstalledPackageId pkgid)
+                              mipkg buildSuccess
 
     updatePlan pkgid (Left buildFailure) =
-      InstallPlan.failed    (Source.fakeInstalledPackageId pkgid) buildFailure depsFailure
+        InstallPlan.failed (Source.fakeInstalledPackageId pkgid)
+                           buildFailure depsFailure
       where
         depsFailure = DependentFailed pkgid
         -- So this first pkgid failed for whatever reason (buildFailure).
@@ -1187,16 +1238,21 @@ executeInstallPlan verbosity comp jobCtl useLogFile plan0 installPkg =
 -- NB: when updating this function, don't forget to also update
 -- 'configurePackage' in D.C.Configure.
 installReadyPackage :: Platform -> CompilerInfo
-                       -> ConfigFlags
-                       -> ReadyPackage
-                       -> (ConfigFlags -> PackageLocation (Maybe FilePath)
-                                       -> PackageDescription
-                                       -> PackageDescriptionOverride -> a)
-                       -> a
+                    -> ConfigFlags
+                    -> ReadyPackage ConfiguredPackage
+                                    InstalledPackageInfo
+                    -> (ConfigFlags -> PackageLocation (Maybe FilePath)
+                                    -> PackageDescription
+                                    -> PackageDescriptionOverride
+                                    -> a)
+                    -> a
 installReadyPackage platform cinfo configFlags
-  (ReadyPackage (SourcePackage _ gpkg source pkgoverride)
-   flags stanzas deps)
-  installPkg = installPkg configFlags {
+                    (ReadyPackage (ConfiguredPackage
+                                    (SourcePackage _ gpkg source pkgoverride)
+                                    flags stanzas _)
+                                   deps)
+                    installPkg =
+  installPkg configFlags {
     configConfigurationsFlags = flags,
     -- We generate the legacy constraints as well as the new style precise deps.
     -- In the end only one set gets passed to Setup.hs configure, depending on

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -672,10 +672,11 @@ configuredPackageProblems platform cinfo
 
 -- | Compute the dependency closure of a _source_ package in a install plan
 --
--- See `Distribution.Simple.dependencyClosure`
+-- See `Distribution.Client.PlanIndex.dependencyClosure`
 dependencyClosure :: InstallPlan
                   -> [PackageIdentifier]
-                  -> Either (PackageIndex PlanPackage) [(PlanPackage, [InstalledPackageId])]
+                  -> Either [(PlanPackage, [InstalledPackageId])]
+                            (PackageIndex PlanPackage)
 dependencyClosure installPlan pids =
     PlanIndex.dependencyClosure
       (planFakeMap installPlan)

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -49,9 +49,9 @@ module Distribution.Client.InstallPlan (
 import Distribution.Client.Types
          ( ConfiguredPackage(..)
          , ReadyPackage(..), readyPackageToConfiguredPackage
-         , InstalledPackage, BuildFailure, BuildSuccess(..)
-         , InstalledPackage(..), fakeInstalledPackageId
+         , BuildFailure, BuildSuccess(..)
          , PackageFixedDeps(..)
+         , fakeInstalledPackageId
          )
 import Distribution.Package
          ( PackageIdentifier(..), PackageName(..), Package(..)
@@ -74,6 +74,8 @@ import Distribution.Compiler
          ( CompilerInfo(..) )
 import Distribution.Simple.Utils
          ( intercalate )
+import Distribution.InstalledPackageInfo
+         ( InstalledPackageInfo )
 import qualified Distribution.InstalledPackageInfo as Installed
 
 import Data.Maybe
@@ -141,7 +143,7 @@ type PlanIndex = PackageIndex PlanPackage
 -- 'PackageInstalled' instance it would be too easy to get this wrong (and,
 -- for instance, call graph traversal functions from Cabal rather than from
 -- cabal-install). Instead, see 'PackageFixedDeps'.
-data PlanPackage = PreExisting InstalledPackage
+data PlanPackage = PreExisting InstalledPackageInfo
                  | Configured  ConfiguredPackage
                  | Processing  ReadyPackage
                  | Installed   ReadyPackage BuildSuccess
@@ -294,7 +296,7 @@ ready plan = assert check readyPackages
         Just (Configured  _)                            -> Nothing
         Just (Processing  _)                            -> Nothing
         Just (Failed    _ _)                            -> internalError depOnFailed
-        Just (PreExisting (InstalledPackage instPkg _)) -> Just instPkg
+        Just (PreExisting instPkg)                      -> Just instPkg
         Just (Installed _ (BuildOk _ _ (Just instPkg))) -> Just instPkg
         Just (Installed _ (BuildOk _ _ Nothing))        -> internalError depOnNonLib
         Nothing                                         -> internalError incomplete

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -55,7 +55,7 @@ import Distribution.Client.Types
          , ReadyPackage(..), readyPackageToConfiguredPackage
          , InstalledPackage, BuildFailure, BuildSuccess(..), enableStanzas
          , InstalledPackage(..), fakeInstalledPackageId
-         , ConfiguredId(..)
+         , ConfiguredId(..), PackageFixedDeps(..)
          )
 import Distribution.Package
          ( PackageIdentifier(..), PackageName(..), Package(..), packageName
@@ -70,8 +70,6 @@ import Distribution.PackageDescription
          )
 import Distribution.Client.PackageUtils
          ( externalBuildDepends )
-import Distribution.Client.PackageIndex
-         ( PackageFixedDeps(..) )
 import Distribution.Client.ComponentDeps (ComponentDeps)
 import qualified Distribution.Client.ComponentDeps as CD
 import Distribution.PackageDescription.Configuration

--- a/cabal-install/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/Distribution/Client/InstallSymlink.hs
@@ -23,15 +23,16 @@ import Distribution.Client.InstallPlan (InstallPlan)
 import Distribution.Client.Setup (InstallFlags)
 import Distribution.Simple.Setup (ConfigFlags)
 import Distribution.Simple.Compiler
+import Distribution.System
 
-symlinkBinaries :: Compiler
+symlinkBinaries :: Platform -> Compiler
                 -> ConfigFlags
                 -> InstallFlags
                 -> InstallPlan InstalledPackageInfo
                                ConfiguredPackage
                                iresult ifailure
                 -> IO [(PackageIdentifier, String, FilePath)]
-symlinkBinaries _ _ _ _ = return []
+symlinkBinaries _ _ _ _ _ = return []
 
 symlinkBinary :: FilePath -> FilePath -> String -> String -> IO Bool
 symlinkBinary _ _ _ _ = fail "Symlinking feature not available on Windows"
@@ -63,7 +64,9 @@ import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo )
 import qualified Distribution.InstalledPackageInfo as Installed
 import Distribution.Simple.Compiler
-         ( Compiler, CompilerInfo(..), packageKeySupported )
+         ( Compiler, compilerInfo, CompilerInfo(..), packageKeySupported )
+import Distribution.System
+         ( Platform )
 
 import System.Posix.Files
          ( getSymbolicLinkStatus, isSymbolicLink, createSymbolicLink
@@ -102,14 +105,14 @@ import Data.Maybe
 -- controlled from the config file. Of course it only works on POSIX systems
 -- with symlinks so is not available to Windows users.
 --
-symlinkBinaries :: Compiler
+symlinkBinaries :: Platform -> Compiler
                 -> ConfigFlags
                 -> InstallFlags
                 -> InstallPlan InstalledPackageInfo
                                ConfiguredPackage
                                iresult ifailure
                 -> IO [(PackageIdentifier, String, FilePath)]
-symlinkBinaries comp configFlags installFlags plan =
+symlinkBinaries platform comp configFlags installFlags plan =
   case flagToMaybe (installSymlinkBinDir installFlags) of
     Nothing            -> return []
     Just symlinkBinDir
@@ -178,8 +181,7 @@ symlinkBinaries comp configFlags installFlags plan =
     fromFlagTemplate = fromFlagOrDefault (InstallDirs.toPathTemplate "")
     prefixTemplate   = fromFlagTemplate (configProgPrefix configFlags)
     suffixTemplate   = fromFlagTemplate (configProgSuffix configFlags)
-    platform         = InstallPlan.planPlatform plan
-    cinfo            = InstallPlan.planCompiler plan
+    cinfo            = compilerInfo comp
     (CompilerId compilerFlavor _) = compilerInfoId cinfo
 
 symlinkBinary :: FilePath -- ^ The canonical path of the public bin dir

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -190,7 +190,7 @@ info verbosity packageDBs repos comp conf
                    ++ map packageId
                       (PackageIndex.allPackages sourcePkgIndex)
     transport <- configureTransport verbosity (flagToMaybe (globalHttpTransport globalFlags))
-    pkgSpecifiers <- resolveUserTargets transport verbosity
+    pkgSpecifiers <- resolveUserTargets verbosity transport
                        (fromFlag $ globalWorldFile globalFlags)
                        sourcePkgs' userTargets
 

--- a/cabal-install/Distribution/Client/PackageIndex.hs
+++ b/cabal-install/Distribution/Client/PackageIndex.hs
@@ -16,9 +16,6 @@ module Distribution.Client.PackageIndex (
   -- * Package index data type
   PackageIndex,
 
-  -- * Fine-grained package dependencies
-  PackageFixedDeps(..),
-
   -- * Creating an index
   fromList,
 
@@ -61,30 +58,12 @@ import Data.Maybe (isJust, fromMaybe)
 import Distribution.Package
          ( PackageName(..), PackageIdentifier(..)
          , Package(..), packageName, packageVersion
-         , Dependency(Dependency)
-         , InstalledPackageId, installedDepends )
+         , Dependency(Dependency) )
 import Distribution.Version
          ( withinRange )
-import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo_ )
 import Distribution.Simple.Utils
          ( lowercase, comparing )
 
-import Distribution.Client.ComponentDeps (ComponentDeps)
-import qualified Distribution.Client.ComponentDeps as CD
-
--- | Subclass of packages that have specific versioned dependencies.
---
--- So for example a not-yet-configured package has dependencies on version
--- ranges, not specific versions. A configured or an already installed package
--- depends on exact versions. Some operations or data structures (like
---  dependency graphs) only make sense on this subclass of package types.
---
-class Package pkg => PackageFixedDeps pkg where
-  depends :: pkg -> ComponentDeps [InstalledPackageId]
-
-instance PackageFixedDeps (InstalledPackageInfo_ str) where
-  depends = CD.fromInstalled . installedDepends
 
 -- | The collection of information about packages from one or more 'PackageDB's.
 --

--- a/cabal-install/Distribution/Client/PlanIndex.hs
+++ b/cabal-install/Distribution/Client/PlanIndex.hs
@@ -27,7 +27,7 @@ import qualified Data.Graph as Graph
 import Data.Array ((!))
 import Data.Map (Map)
 import Data.Maybe (isNothing, fromMaybe, fromJust)
-import Data.Either (lefts)
+import Data.Either (rights)
 
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid (Monoid(..))
@@ -131,7 +131,7 @@ dependencyInconsistencies fakeMap indepGoals index  =
     concatMap (dependencyInconsistencies' fakeMap) subplans
   where
     subplans :: [PackageIndex pkg]
-    subplans = lefts $
+    subplans = rights $
                  map (dependencyClosure fakeMap index)
                      (rootSets fakeMap indepGoals index)
 
@@ -253,11 +253,11 @@ dependencyClosure :: (PackageFixedDeps pkg, HasInstalledPackageId pkg)
                   => FakeMap
                   -> PackageIndex pkg
                   -> [InstalledPackageId]
-                  -> Either (PackageIndex pkg)
-                            [(pkg, [InstalledPackageId])]
+                  -> Either [(pkg, [InstalledPackageId])]
+                            (PackageIndex pkg)
 dependencyClosure fakeMap index pkgids0 = case closure mempty [] pkgids0 of
-  (completed, []) -> Left completed
-  (completed, _)  -> Right (brokenPackages fakeMap completed)
+  (completed, []) -> Right completed
+  (completed, _)  -> Left (brokenPackages fakeMap completed)
  where
     closure completed failed []             = (completed, failed)
     closure completed failed (pkgid:pkgids) =

--- a/cabal-install/Distribution/Client/PlanIndex.hs
+++ b/cabal-install/Distribution/Client/PlanIndex.hs
@@ -42,7 +42,7 @@ import Distribution.Version
 
 import Distribution.Client.ComponentDeps (ComponentDeps)
 import qualified Distribution.Client.ComponentDeps as CD
-import Distribution.Client.PackageIndex
+import Distribution.Client.Types
          ( PackageFixedDeps(..) )
 import Distribution.Simple.PackageIndex
          ( PackageIndex, allPackages, insert, lookupInstalledPackageId )

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -351,13 +351,13 @@ reportUserTargetProblems problems = do
 -- or they can be named packages (with or without version info).
 --
 resolveUserTargets :: Package pkg
-                   => HttpTransport
-                   -> Verbosity
+                   => Verbosity
+                   -> HttpTransport
                    -> FilePath
                    -> PackageIndex pkg
                    -> [UserTarget]
                    -> IO [PackageSpecifier SourcePackage]
-resolveUserTargets transport verbosity worldFile available userTargets = do
+resolveUserTargets verbosity transport worldFile available userTargets = do
 
     -- given the user targets, get a list of fully or partially resolved
     -- package references

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -130,43 +130,33 @@ instance HasInstalledPackageId ConfiguredPackage where
 
 -- | Like 'ConfiguredPackage', but with all dependencies guaranteed to be
 -- installed already, hence itself ready to be installed.
-data ReadyPackage = ReadyPackage
-       SourcePackage                           -- see 'ConfiguredPackage'.
-       FlagAssignment                          --
-       [OptionalStanza]                        --
-       (ComponentDeps [InstalledPackageInfo])  -- Installed dependencies.
-  deriving Show
+data ReadyPackage srcpkg ipkg
+   = ReadyPackage
+       srcpkg                  -- see 'ConfiguredPackage'.
+       (ComponentDeps [ipkg])  -- Installed dependencies.
+  deriving (Eq, Show)
 
-instance Package ReadyPackage where
-  packageId (ReadyPackage pkg _ _ _) = packageId pkg
+instance Package srcpkg => Package (ReadyPackage srcpkg ipkg) where
+  packageId (ReadyPackage srcpkg _deps) = packageId srcpkg
 
-instance PackageFixedDeps ReadyPackage where
-  depends (ReadyPackage _ _ _ deps) = fmap (map installedPackageId) deps
+instance (Package srcpkg, HasInstalledPackageId ipkg) =>
+         PackageFixedDeps (ReadyPackage srcpkg ipkg) where
+  depends (ReadyPackage _ deps) = fmap (map installedPackageId) deps
 
-instance HasInstalledPackageId ReadyPackage where
-  installedPackageId = fakeInstalledPackageId . packageId
+instance HasInstalledPackageId srcpkg =>
+         HasInstalledPackageId (ReadyPackage srcpkg ipkg) where
+  installedPackageId (ReadyPackage pkg _) = installedPackageId pkg
 
 
 -- | Extracts a package key from ReadyPackage, a common operation needed
 -- to calculate build paths.
-readyPackageKey :: Compiler -> ReadyPackage -> PackageKey
-readyPackageKey comp (ReadyPackage pkg _ _ deps) =
+readyPackageKey :: Package srcpkg
+                => Compiler
+                -> ReadyPackage srcpkg InstalledPackageInfo
+                -> PackageKey
+readyPackageKey comp (ReadyPackage pkg deps) =
     mkPackageKey (packageKeySupported comp) (packageId pkg)
                  (map Info.packageKey (CD.nonSetupDeps deps)) []
-
-
--- | Sometimes we need to convert a 'ReadyPackage' back to a
--- 'ConfiguredPackage'. For example, a failed 'PlanPackage' can be *either*
--- Ready or Configured.
-readyPackageToConfiguredPackage :: ReadyPackage -> ConfiguredPackage
-readyPackageToConfiguredPackage (ReadyPackage srcpkg flags stanzas deps) =
-    ConfiguredPackage srcpkg flags stanzas (fmap (map aux) deps)
-  where
-    aux :: InstalledPackageInfo -> ConfiguredId
-    aux info = ConfiguredId {
-        confSrcId  = Info.sourcePackageId info
-      , confInstId = installedPackageId info
-      }
 
 
 -- | A package description along with the location of the package sources.

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -19,14 +19,14 @@ import Distribution.Package
          , mkPackageKey, PackageKey, InstalledPackageId(..)
          , HasInstalledPackageId(..), PackageInstalled(..) )
 import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo )
+         ( InstalledPackageInfo, InstalledPackageInfo_ )
 import Distribution.PackageDescription
          ( Benchmark(..), GenericPackageDescription(..), FlagAssignment
          , TestSuite(..) )
 import Distribution.PackageDescription.Configuration
          ( mapTreeData )
 import Distribution.Client.PackageIndex
-         ( PackageIndex, PackageFixedDeps(..) )
+         ( PackageIndex )
 import Distribution.Client.ComponentDeps
          ( ComponentDeps )
 import qualified Distribution.Client.ComponentDeps as CD
@@ -56,6 +56,20 @@ data SourcePackageDb = SourcePackageDb {
 -- ------------------------------------------------------------
 -- * Various kinds of information about packages
 -- ------------------------------------------------------------
+
+-- | Subclass of packages that have specific versioned dependencies.
+--
+-- So for example a not-yet-configured package has dependencies on version
+-- ranges, not specific versions. A configured or an already installed package
+-- depends on exact versions. Some operations or data structures (like
+--  dependency graphs) only make sense on this subclass of package types.
+--
+class Package pkg => PackageFixedDeps pkg where
+  depends :: pkg -> ComponentDeps [InstalledPackageId]
+
+instance PackageFixedDeps (InstalledPackageInfo_ str) where
+  depends = CD.fromInstalled . installedDepends
+
 
 -- | InstalledPackage caches its dependencies as source package IDs.
 -- This is for the benefit of the top-down solver only.

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -71,22 +71,6 @@ instance PackageFixedDeps (InstalledPackageInfo_ str) where
   depends = CD.fromInstalled . installedDepends
 
 
--- | InstalledPackage caches its dependencies as source package IDs.
--- This is for the benefit of the top-down solver only.
-data InstalledPackage = InstalledPackage
-       InstalledPackageInfo
-       [PackageId]
-
-instance Package InstalledPackage where
-  packageId (InstalledPackage pkg _) = packageId pkg
-instance PackageFixedDeps InstalledPackage where
-  depends (InstalledPackage pkg _) = depends pkg
-instance HasInstalledPackageId InstalledPackage where
-  installedPackageId (InstalledPackage pkg _) = installedPackageId pkg
-instance PackageInstalled InstalledPackage where
-  installedDepends (InstalledPackage pkg _) = installedDepends pkg
-
-
 -- | In order to reuse the implementation of PackageIndex which relies on
 -- 'InstalledPackageId', we need to be able to synthesize these IDs prior
 -- to installation.  Eventually, we'll move to a representation of

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
@@ -259,7 +259,11 @@ exInstIdx = C.PackageIndex.fromList . map exInstInfo
 exResolve :: ExampleDb
           -> [ExamplePkgName]
           -> Bool
-          -> ([String], Either String CI.InstallPlan.InstallPlan)
+          -> ([String], Either String
+                               (CI.InstallPlan.InstallPlan
+                                    C.InstalledPackageInfo
+                                    ConfiguredPackage
+                                    isuccess ifailure))
 exResolve db targets indepGoals = runProgress $
     resolveDependencies C.buildPlatform
                         (C.unknownCompilerInfo C.buildCompilerId C.NoAbiTag)
@@ -280,11 +284,14 @@ exResolve db targets indepGoals = runProgress $
                        depResolverIndependentGoals = indepGoals
                      }
 
-extractInstallPlan :: CI.InstallPlan.InstallPlan
+extractInstallPlan :: CI.InstallPlan.InstallPlan ipkg ConfiguredPackage
+                                                 isuccess ifailure
                    -> [(ExamplePkgName, ExamplePkgVersion)]
 extractInstallPlan = catMaybes . map confPkg . CI.InstallPlan.toList
   where
-    confPkg :: CI.InstallPlan.PlanPackage -> Maybe (String, Int)
+    confPkg :: CI.InstallPlan.PlanPackage ipkg ConfiguredPackage
+                                          isuccess ifailure
+            -> Maybe (String, Int)
     confPkg (CI.InstallPlan.Configured pkg) = Just $ srcPkg pkg
     confPkg _                               = Nothing
 


### PR DESCRIPTION
A few trivial cleanups plus a bunch of things related to generalising the InstallPlan type so we can have plans with different types of package (which is useful for other ongoing work).