### PR TITLE
When lifting dependencies, compute the union of the ranges.

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Version.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Version.hs
@@ -29,6 +29,10 @@ eqVR = CV.thisVersion
 (.&&.) :: VR -> VR -> VR
 (.&&.) = CV.intersectVersionRanges
 
+-- | Union of two version ranges.
+(.||.) :: VR -> VR -> VR
+(.||.) = CV.unionVersionRanges
+
 -- | Simplify a version range.
 simplifyVR :: VR -> VR
 simplifyVR = CV.simplifyVersionRange


### PR DESCRIPTION
For a while now, we lift out dependencies from conditionals.  If a
package is dependended on regardless of the outcome of a test, the
dependency is lifted out. This has the advantage that we can choose an
instance for the package prior to choosing the value of the flag. Often,
this is the desired behaviour for flags, i.e., to have the flag choice
implied by the possible package choices, rather than the other way
around.

Prior to this change, lifting was simply adding an unconstrained
dependency to such a package at a higher level, which would then of
course still be refined after making the flag choice. We are now making
this more precise by actually computing the union of the ranges in both
branches of the conditional. So we will not choose an instance on the
top level that will later be rejected by both branches.