### PR TITLE
Add frameworks when linking a dynamic library

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -656,6 +656,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
                                            Internal.mkGhcOptPackages clbi ,
                 ghcOptLinkLibs           = toNubListR $ extraLibs libBi,
                 ghcOptLinkLibPath        = toNubListR $ extraLibDirs libBi,
+                ghcOptLinkFrameworks     = toNubListR $ PD.frameworks libBi,
                 ghcOptRPaths             = rpaths
               }
 


### PR DESCRIPTION
This fixes the Cabal side of [GHC trac #10568](https://ghc.haskell.org/trac/ghc/ticket/10568)