### PR TITLE
Fix windows build

### DIFF
--- a/cabal-install/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/Distribution/Client/InstallSymlink.hs
@@ -28,9 +28,7 @@ import Distribution.System
 symlinkBinaries :: Platform -> Compiler
                 -> ConfigFlags
                 -> InstallFlags
-                -> InstallPlan InstalledPackageInfo
-                               ConfiguredPackage
-                               iresult ifailure
+                -> InstallPlan 
                 -> IO [(PackageIdentifier, String, FilePath)]
 symlinkBinaries _ _ _ _ _ = return []
 


### PR DESCRIPTION
This one is trivial. Commit 8ea6f33c34e10dcc9faa046040266e91676e8062 has broken Windows build, this looks to me like a fix. The problem is that ```InstallSymlink.hs``` file is conditionally compiled and Windows part wasn't updated.