### PR TITLE
Fixes HTTP{S} auth when using wget

### DIFF
--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -18,7 +18,7 @@ import Network.HTTP
          , Header(..), HeaderName(..), lookupHeader )
 import Network.HTTP.Proxy ( Proxy(..), fetchProxy)
 import Network.URI
-         ( URI (..), URIAuth (..) )
+         ( URI (..), URIAuth (..), uriToString )
 import Network.Browser
          ( browse, setOutHandler, setErrHandler, setProxy
          , setAuthorityGen, request, setAllowBasicAuth, setUserAgent )
@@ -381,7 +381,7 @@ wgetTransport prog =
         (code, _err, etag') <- parseResponse uri resp
         return (code, etag')
       where
-        args = [ show uri
+        args = [ uriToString id uri ""
                , "--output-document=" ++ destPath
                , "--user-agent=" ++ userAgent
                , "--tries=5"
@@ -400,7 +400,7 @@ wgetTransport prog =
           BS.hPut tmpHandle body
           BS.writeFile "wget.in" body
           hClose tmpHandle
-          let args = [ show uri
+          let args = [ uriToString id uri ""
                      , "--post-file=" ++ tmpFile
                      , "--user-agent=" ++ userAgent
                      , "--server-response"


### PR DESCRIPTION
`wget` allows usernames and passwords to be encoded in URLs, and supports HTTPS. Thus, using `http-transport: wget` in the cabal configuration should permit the use of password-protected HTTPS hackage repositories. But because the arguments to wget are constructed using the `Show` instance for `Network.URI.URI`, password information in the repository URL is replaced with `...`, resulting in authentication failures. This PR corrects that by using the `Network.URI.uriToString` function to construct the URL argument to wget.

It fixes issue #2763 and should be considered to solve issue #2761.