### PR TITLE
Eliminate InstalledPackageInfo module name parameter.

### DIFF
--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -27,7 +27,7 @@
 -- This module is meant to be local-only to Distribution...
 
 module Distribution.InstalledPackageInfo (
-        InstalledPackageInfo_(..), InstalledPackageInfo,
+        InstalledPackageInfo(..),
         libraryName,
         OriginalModule(..), ExposedModule(..),
         ParseResult(..), PError(..), PWarning,
@@ -71,7 +71,7 @@ import GHC.Generics (Generic)
 -- The InstalledPackageInfo type
 
 
-data InstalledPackageInfo_ m
+data InstalledPackageInfo
    = InstalledPackageInfo {
         -- these parts are exactly the same as PackageDescription
         installedPackageId :: InstalledPackageId,
@@ -90,8 +90,8 @@ data InstalledPackageInfo_ m
         -- these parts are required by an installed package only:
         exposed           :: Bool,
         exposedModules    :: [ExposedModule],
-        instantiatedWith  :: [(m, OriginalModule)],
-        hiddenModules     :: [m],
+        instantiatedWith  :: [(ModuleName, OriginalModule)],
+        hiddenModules     :: [ModuleName],
         trusted           :: Bool,
         importDirs        :: [FilePath],
         libraryDirs       :: [FilePath],
@@ -112,23 +112,21 @@ data InstalledPackageInfo_ m
     }
     deriving (Generic, Read, Show)
 
-libraryName :: InstalledPackageInfo_ a -> LibraryName
+libraryName :: InstalledPackageInfo -> LibraryName
 libraryName ipi = Package.packageKeyLibraryName (sourcePackageId ipi) (packageKey ipi)
 
-instance Binary m => Binary (InstalledPackageInfo_ m)
+instance Binary InstalledPackageInfo
 
-instance Package.Package (InstalledPackageInfo_ str) where
+instance Package.Package InstalledPackageInfo where
    packageId = sourcePackageId
 
-instance Package.HasInstalledPackageId (InstalledPackageInfo_ str) where
+instance Package.HasInstalledPackageId InstalledPackageInfo where
    installedPackageId = installedPackageId
 
-instance Package.PackageInstalled (InstalledPackageInfo_ str) where
+instance Package.PackageInstalled InstalledPackageInfo where
    installedDepends = depends
 
-type InstalledPackageInfo = InstalledPackageInfo_ ModuleName
-
-emptyInstalledPackageInfo :: InstalledPackageInfo_ m
+emptyInstalledPackageInfo :: InstalledPackageInfo
 emptyInstalledPackageInfo
    = InstalledPackageInfo {
         installedPackageId = InstalledPackageId "",

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -388,7 +388,7 @@ testSuiteLibV09AsLibAndExe :: PackageDescription
                            -> (PackageDescription,
                                Library, ComponentLocalBuildInfo,
                                LocalBuildInfo,
-                               IPI.InstalledPackageInfo_ ModuleName,
+                               IPI.InstalledPackageInfo,
                                Executable, ComponentLocalBuildInfo)
 testSuiteLibV09AsLibAndExe pkg_descr
                      test@TestSuite { testInterface = TestSuiteLibV09 _ m }

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -60,7 +60,7 @@ import Distribution.PackageDescription as PD
 import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo )
 import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
-                                ( InstalledPackageInfo_(..) )
+                                ( InstalledPackageInfo(..) )
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.Simple.LocalBuildInfo

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -36,7 +36,7 @@ import Distribution.Package
 import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo )
 import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
-                                ( InstalledPackageInfo_(..) )
+                                ( InstalledPackageInfo(..) )
 import Distribution.PackageDescription as PD
          ( BuildInfo(..), Library(..), libModules
          , hcOptions, usedExtensions, ModuleRenaming, lookupRenaming )

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -25,7 +25,7 @@ import Distribution.PackageDescription as PD
 import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo )
 import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
-                                ( InstalledPackageInfo_(..) )
+                                ( InstalledPackageInfo(..) )
 import Distribution.Package ( LibraryName(..), getHSLibraryName )
 import Distribution.Simple.PackageIndex ( InstalledPackageIndex )
 import qualified Distribution.Simple.PackageIndex as PackageIndex

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -64,7 +64,7 @@ import Distribution.Simple.BuildPaths
 import Distribution.Simple.PackageIndex (dependencyClosure)
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
-         ( InstalledPackageInfo_(..) )
+         ( InstalledPackageInfo(..) )
 import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo )
 import Distribution.Simple.Utils

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -49,7 +49,7 @@ import Distribution.InstalledPackageInfo
                                 ( InstalledPackageInfo
                                 , parseInstalledPackageInfo )
 import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
-                                ( InstalledPackageInfo_(..) )
+                                ( InstalledPackageInfo(..) )
 import Distribution.Simple.PackageIndex
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.ParseUtils  ( ParseResult(..) )

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -40,7 +40,7 @@ import Distribution.PackageDescription as PD
          , TestSuiteInterface(..)
          , Benchmark(..), benchmarkModules, BenchmarkInterface(..) )
 import qualified Distribution.InstalledPackageInfo as Installed
-         ( InstalledPackageInfo_(..) )
+         ( InstalledPackageInfo(..) )
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.Simple.CCompiler
          ( cSourceExtensions )

--- a/Cabal/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/Distribution/Simple/Program/HcPkg.hs
@@ -37,7 +37,7 @@ import Prelude hiding (init)
 import Distribution.Package
          ( PackageId, InstalledPackageId(..) )
 import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo, InstalledPackageInfo_(..)
+         ( InstalledPackageInfo, InstalledPackageInfo(..)
          , showInstalledPackageInfo
          , emptyInstalledPackageInfo, fieldsInstalledPackageInfo )
 import Distribution.ParseUtils

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -67,7 +67,7 @@ import Distribution.Package
          ( Package(..), packageName, InstalledPackageId(..)
          , getHSLibraryName )
 import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo, InstalledPackageInfo_(InstalledPackageInfo)
+         ( InstalledPackageInfo, InstalledPackageInfo(InstalledPackageInfo)
          , showInstalledPackageInfo )
 import qualified Distribution.InstalledPackageInfo as IPI
 import Distribution.Simple.Utils

--- a/cabal-install/Distribution/Client/Haddock.hs
+++ b/cabal-install/Distribution/Client/Haddock.hs
@@ -31,7 +31,7 @@ import Distribution.Simple.PackageIndex
 import Distribution.Simple.Utils
          ( comparing, debug, installDirectoryContents, withTempDirectory )
 import Distribution.InstalledPackageInfo as InstalledPackageInfo
-         ( InstalledPackageInfo_(exposed) )
+         ( InstalledPackageInfo(exposed) )
 
 regenerateHaddockIndex :: Verbosity
                        -> InstalledPackageIndex -> ProgramConfiguration

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -20,7 +20,7 @@ import Distribution.Package
          , HasInstalledPackageId(..), PackageInstalled(..)
          , LibraryName, packageKeyLibraryName )
 import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo, InstalledPackageInfo_ )
+         ( InstalledPackageInfo )
 import Distribution.PackageDescription
          ( Benchmark(..), GenericPackageDescription(..), FlagAssignment
          , TestSuite(..) )
@@ -68,7 +68,7 @@ data SourcePackageDb = SourcePackageDb {
 class Package pkg => PackageFixedDeps pkg where
   depends :: pkg -> ComponentDeps [InstalledPackageId]
 
-instance PackageFixedDeps (InstalledPackageInfo_ str) where
+instance PackageFixedDeps InstalledPackageInfo where
   depends = CD.fromInstalled . installedDepends
 
 


### PR DESCRIPTION
This parameter was a legacy when GHC depended directly on
Cabal; this is no longer the case so there is no need for
this parameter (which is unused inside Cabal.)

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>