### PR TITLE
Add show-build-info command

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -217,6 +217,7 @@ library
     Distribution.Simple.Program.Types
     Distribution.Simple.Register
     Distribution.Simple.Setup
+    Distribution.Simple.ShowBuildInfo
     Distribution.Simple.SrcDist
     Distribution.Simple.Test
     Distribution.Simple.Test.ExeV10
@@ -243,6 +244,7 @@ library
     Distribution.Simple.GHC.IPI641
     Distribution.Simple.GHC.IPI642
     Distribution.Simple.GHC.ImplInfo
+    Distribution.Simple.Utils.Json
     Paths_Cabal
 
   if flag(bundled-binary-generic)

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -42,6 +42,7 @@ module Distribution.Simple.Setup (
   HaddockFlags(..),  emptyHaddockFlags,  defaultHaddockFlags,  haddockCommand,
   HscolourFlags(..), emptyHscolourFlags, defaultHscolourFlags, hscolourCommand,
   BuildFlags(..),    emptyBuildFlags,    defaultBuildFlags,    buildCommand,
+                                                               showBuildInfoCommand,
   buildVerbose,
   ReplFlags(..),                         defaultReplFlags,     replCommand,
   CleanFlags(..),    emptyCleanFlags,    defaultCleanFlags,    cleanCommand,
@@ -1540,6 +1541,49 @@ instance Monoid CleanFlags where
     cleanVerbosity = combine cleanVerbosity
   }
     where combine field = field a `mappend` field b
+
+-- ------------------------------------------------------------
+-- * show-build-info flags
+-- ------------------------------------------------------------
+
+showBuildInfoCommand :: ProgramConfiguration -> CommandUI BuildFlags
+showBuildInfoCommand progConf = CommandUI
+  { commandName         = "show-build-info"
+  , commandSynopsis     = "Emit details about how a package would be built."
+  , commandDescription  = Just $ \_ -> wrapText $
+         "Components encompass executables, tests, and benchmarks.\n"
+      ++ "\n"
+      ++ "Affected by configuration options, see `configure`.\n"
+  , commandNotes        = Just $ \pname ->
+       "Examples:\n"
+        ++ "  " ++ pname ++ " show-build-info      "
+        ++ "    All the components in the package\n"
+        ++ "  " ++ pname ++ " show-build-info foo       "
+        ++ "    A component (i.e. lib, exe, test suite)\n\n"
+        ++ programFlagsDescription progConf
+--TODO: re-enable once we have support for module/file targets
+--        ++ "  " ++ pname ++ " show-build-info Foo.Bar   "
+--        ++ "    A module\n"
+--        ++ "  " ++ pname ++ " show-build-info Foo/Bar.hs"
+--        ++ "    A file\n\n"
+--        ++ "If a target is ambiguous it can be qualified with the component "
+--        ++ "name, e.g.\n"
+--        ++ "  " ++ pname ++ " show-build-info foo:Foo.Bar\n"
+--        ++ "  " ++ pname ++ " show-build-info testsuite1:Foo/Bar.hs\n"
+  , commandUsage        = usageAlternatives "show-build-info" $
+      [ "[FLAGS]"
+      , "COMPONENTS [FLAGS]"
+      ]
+  , commandDefaultFlags = defaultBuildFlags
+  , commandOptions      = \showOrParseArgs ->
+      [ optionVerbosity
+        buildVerbosity (\v flags -> flags { buildVerbosity = v })
+
+      , optionDistPref
+        buildDistPref (\d flags -> flags { buildDistPref = d }) showOrParseArgs
+      ]
+      ++ buildOptions progConf showOrParseArgs
+  }
 
 -- ------------------------------------------------------------
 -- * Build flags

--- a/Cabal/Distribution/Simple/ShowBuildInfo.hs
+++ b/Cabal/Distribution/Simple/ShowBuildInfo.hs
@@ -1,0 +1,139 @@
+-- |
+-- This module defines a simple JSON-based format for exporting basic
+-- information about a Cabal package and the compiler configuration Cabal
+-- would use to build it. This can be produced with the @cabal show-build-info@
+-- command.
+--
+-- This format is intended for consumption by external tooling and should
+-- therefore be rather stable. Moreover, this allows tooling users to avoid
+-- linking against Cabal. This is an important advantage as direct API usage
+-- tends to be rather fragile in the presence of user-initiated upgrades of
+-- Cabal.
+--
+-- Below is an example of the output this module produces,
+--
+-- @
+-- { "cabal_version": "1.23.0.0",
+--   "compiler": {
+--     "flavor": "GHC",
+--     "compiler_id": "ghc-7.10.2",
+--     "path": "/usr/bin/ghc",
+--   },
+--   "components": [
+--     { "type": "library",
+--       "name": "CLibName",
+--       "compiler_args":
+--         ["-O", "-XHaskell98", "-Wall",
+--          "-package-id", "parallel-3.2.0.6-b79c38c5c25fff77f3ea7271851879eb"]
+--       "modules": ["Project.ModA", "Project.ModB", "Paths_project"],
+--       "source_files": [],
+--       "source_dirs": ["src"]
+--     }
+--   ]
+-- }
+-- @
+--
+-- The @cabal_version@ property provides the version of the Cabal library
+-- which generated the output. The @compiler@ property gives some basic
+-- information about the compiler Cabal would use to compile the package.
+--
+-- The @components@ property gives a list of the Cabal 'Component's defined by
+-- the package. Each has,
+--
+-- * @type@: the type of the component (one of @library@, @executable@,
+--   @test-suite@, or @benchmark@)
+-- * @name@: a string serving to uniquely identify the component within the
+--   package.
+-- * @compiler_args@: the command-line arguments Cabal would pass to the
+--   compiler to compile the component
+-- * @modules@: the modules belonging to the component
+-- * @source_dirs@: a list of directories where the modules might be found
+-- * @source_files@: any other Haskell sources needed by the component
+--
+-- Note: At the moment this is only supported when using the GHC compiler.
+--
+
+module Distribution.Simple.ShowBuildInfo (mkBuildInfo) where
+
+import qualified Distribution.Simple.GHC   as GHC
+import qualified Distribution.Simple.Program.GHC as GHC
+
+import Distribution.PackageDescription
+import Distribution.Compiler
+import Distribution.Verbosity
+import Distribution.Simple.Compiler
+import Distribution.Simple.LocalBuildInfo
+import Distribution.Simple.Program
+import Distribution.Simple.Setup
+import Distribution.Simple.Utils (cabalVersion)
+import Distribution.Simple.Utils.Json
+import Distribution.Text
+
+-- | Construct a JSON document describing the build information for a package
+mkBuildInfo :: PackageDescription  -- ^ Mostly information from the .cabal file
+            -> LocalBuildInfo      -- ^ Configuration information
+            -> BuildFlags          -- ^ Flags that the user passed to build
+            -> [(ComponentName, ComponentLocalBuildInfo)]
+            -> Json
+mkBuildInfo pkg_descr lbi _flags componentsToBuild = info
+  where
+    (.=) :: String -> Json -> (String, Json)
+    k .= v = (k, v)
+
+    info = JsonObject
+      [ "cabal_version" .= JsonString (display cabalVersion)
+      , "compiler" .= mkCompilerInfo
+      , "components" .= JsonArray (map mkComponentInfo componentsToBuild)
+      ]
+
+    mkCompilerInfo = JsonObject
+      [ "flavour" .= JsonString (show $ compilerFlavor $ compiler lbi)
+      , "compiler_id" .= JsonString (showCompilerId $ compiler lbi)
+      , "path" .= path
+      ]
+      where
+        path = maybe JsonNull (JsonString . programPath)
+               $ lookupProgram ghcProgram (withPrograms lbi)
+
+    mkComponentInfo (name, clbi) = JsonObject
+      [ "type" .= JsonString compType
+      , "name" .= JsonString (show name)
+      , "compiler_args" .= JsonArray (map JsonString $ getCompilerArgs bi lbi clbi)
+      , "modules" .= JsonArray (map (JsonString . display) modules)
+      , "source_files" .= JsonArray (map JsonString source_files)
+      , "source_dirs" .= JsonArray (map JsonString $ hsSourceDirs bi)
+      ]
+      where
+        bi = componentBuildInfo comp
+        Just comp = lookupComponent pkg_descr name
+        compType = case comp of
+          CLib _     -> "library"
+          CExe _     -> "executable"
+          CTest _    -> "test-suite"
+          CBench _   -> "benchmark"
+        modules = case comp of
+          CLib lib -> libModules lib
+          CExe exe -> exeModules exe
+          _        -> []
+        source_files = case comp of
+          CLib _   -> []
+          CExe exe -> [modulePath exe]
+          _        -> []
+
+-- | Get the command-line arguments that would be passed
+-- to the compiler to build the given component.
+getCompilerArgs :: BuildInfo
+                -> LocalBuildInfo
+                -> ComponentLocalBuildInfo
+                -> [String]
+getCompilerArgs bi lbi clbi =
+  case compilerFlavor $ compiler lbi of
+      GHC   -> ghc
+      GHCJS -> ghc
+      c     -> error $ "ShowBuildInfo.getCompilerArgs: Don't know how to get "++
+                       "build arguments for compiler "++show c
+  where
+    -- This is absolutely awful
+    ghc = GHC.renderGhcOptions (compiler lbi) baseOpts
+      where
+        baseOpts = GHC.componentGhcOptions normal lbi bi clbi (buildDir lbi)

--- a/Cabal/Distribution/Simple/UserHooks.hs
+++ b/Cabal/Distribution/Simple/UserHooks.hs
@@ -70,7 +70,6 @@ data UserHooks = UserHooks {
 
     -- |Hook to run before build command.  Second arg indicates verbosity level.
     preBuild  :: Args -> BuildFlags -> IO HookedBuildInfo,
-
     -- |Over-ride this hook to get different behavior during build.
     buildHook :: PackageDescription -> LocalBuildInfo -> UserHooks -> BuildFlags -> IO (),
     -- |Hook to run after build command.  Second arg indicates verbosity level.

--- a/Cabal/Distribution/Simple/Utils/Json.hs
+++ b/Cabal/Distribution/Simple/Utils/Json.hs
@@ -1,0 +1,34 @@
+module Distribution.Simple.Utils.Json
+    ( Json(..)
+    , renderJson
+    ) where
+
+data Json = JsonArray [Json]
+          | JsonBool !Bool
+          | JsonNull
+          | JsonNumber !Int
+          | JsonObject [(String, Json)]
+          | JsonString !String
+
+renderJson :: Json -> ShowS
+renderJson (JsonArray objs)   =
+  surround "[" "]" $ intercalate "," $ map renderJson objs
+renderJson (JsonBool True)    = showString "true"
+renderJson (JsonBool False)   = showString "false"
+renderJson  JsonNull          = showString "null"
+renderJson (JsonNumber n)     = shows n
+renderJson (JsonObject attrs) =
+  surround "{" "}" $ intercalate "," $ map render attrs
+  where
+    render (k,v) = (surround "\"" "\"" $ showString k) . showString ":" . renderJson v
+renderJson (JsonString s)     = surround "\"" "\"" $ showString s
+
+surround :: String -> String -> ShowS -> ShowS
+surround begin end middle = showString begin . middle . showString end
+
+intercalate :: String -> [ShowS] -> ShowS
+intercalate sep = go
+  where
+    go []     = id
+    go [x]    = x
+    go (x:xs) = x . showString sep . go xs

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -1,6 +1,8 @@
 -*-change-log-*-
 
 1.23.x.x (current development version)
+	* Add 'show-build-info' command for tooling authors to get reliable
+	  access to Cabal's build configuration for a package
 	* Deal with extra C sources from preprocessors (#238).
 	* Include cabal_macros.h when running c2hs (#2600).
 	* Don't recompile C sources unless needed (#2601).

--- a/Cabal/doc/misc.markdown
+++ b/Cabal/doc/misc.markdown
@@ -47,6 +47,29 @@ deprecated without breaking older packages.
 
 ### Unstable command-line ###
 
+### Querying for compiler configuration for a package ###
+
+Cabal provides the `show-build-info` command-line action for tooling
+authors who need to query Cabal for details on how it would compile
+a package component. At the moment this is only supported when using the GHC
+compiler. This offers a few advantages over using the Cabal API directly,
+
+ * The `Cabal` interfaces are prone to change and are a bit verbose for casual
+   use
+
+ * Some tools built on top of Cabal provide features that further modify
+   the compiler configuration (e.g. the sandbox functionality of
+   `cabal-install`).
+
+  * Linking directly against `Cabal` has unfortunately interactions with
+  `cabal-install` in the presence of later upgrades.
+
+The `show-build-info` command addresses these issues by providing a lightweight,
+out-of-process interface for querying Cabal about compiler configuration. See
+the Haddock documentation in `Distribution.Simple.ShowBuildInfo` for further
+details on the format exposed by this command.
+
+
 ## Functions and Types ##
 
 The Cabal library follows the [Package Versioning Policy][PVP]. This

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -17,7 +17,7 @@ module Distribution.Client.Setup
     , configureExCommand, ConfigExFlags(..), defaultConfigExFlags
                         , configureExOptions
     , buildCommand, BuildFlags(..), BuildExFlags(..), SkipAddSourceDepsCheck(..)
-    , replCommand, testCommand, benchmarkCommand
+    , replCommand, showBuildInfoCommand, testCommand, benchmarkCommand
     , installCommand, InstallFlags(..), installOptions, defaultInstallFlags
     , listCommand, ListFlags(..)
     , updateCommand
@@ -190,6 +190,7 @@ globalCommand commands = CommandUI {
           , "haddock"
           , "hscolour"
           , "copy"
+          , "show-build-info"
           , "register"
           , "sandbox"
           , "exec"
@@ -236,6 +237,7 @@ globalCommand commands = CommandUI {
         , addCmd "upload"
         , addCmd "report"
         , par
+        , addCmd "show-build-info"
         , addCmd "freeze"
         , addCmd "haddock"
         , addCmd "hscolour"
@@ -576,6 +578,25 @@ instance Monoid BuildExFlags where
     buildOnly    = combine buildOnly
   }
     where combine field = field a `mappend` field b
+
+-- ------------------------------------------------------------
+-- * show-build-info command
+-- ------------------------------------------------------------
+
+showBuildInfoCommand :: CommandUI (BuildFlags, BuildExFlags)
+showBuildInfoCommand = parent {
+    commandDefaultFlags = (commandDefaultFlags parent, mempty),
+    commandOptions      =
+      \showOrParseArgs -> liftOptions fst setFst
+                          (commandOptions parent showOrParseArgs)
+                          ++
+                          liftOptions snd setSnd (buildExOptions showOrParseArgs)
+  }
+  where
+    setFst a (_,b) = (a,b)
+    setSnd b (a,_) = (a,b)
+
+    parent = Cabal.showBuildInfoCommand defaultProgramConfiguration
 
 -- ------------------------------------------------------------
 -- * Repl command


### PR DESCRIPTION
Interaction with Cabal poses a few challenges to third-party tooling authors,
1. The interfaces are rather unstable and tend to be verbose
2. Some features are provided instead by `cabal-install`, which currently has no publicly accessible programmatic interfaces
3. Linking against Cabal directly has unfortunate interactions with `cabal-install` in the presence of upgrades

While (1) can be addressed with library support easing common use-casese (see, for instance, https://github.com/bgamari/cabal-ghc-dynflags), (2) and (3) pose severe impediments to tooling development. This patch seeks to address this by removing the need to link against `Cabal` to retrieve build information. It does this by introducing the `show-build-info` command, which produces a small JSON document describing the compiler arguments Cabal would use to build the various components of the package. For instance,

``` javascript
{ "cabal_version": "1.23.0.0",
  "compiler": {
    "flavor": "GHC",
    "compiler_id": "ghc-7.10.2",
    "path": "/usr/bin/ghc",
  },
  "components": [
    { "type": "library",
      "name": "CLibName",
      "compiler_args":
        ["-O", "-XHaskell98", "-Wall",
         "-package-id", "parallel-3.2.0.6-b79c38c5c25fff77f3ea7271851879eb"]
      "modules": ["Project.ModA", "Project.ModB", "Paths_project"],
      "source_files": [],
      "source_dirs": ["src"]
    }
  ]
}
```

The goal here is not to replace the `Cabal` library as the primary means of querying package information. Rather, this command is supposed to target the narrow but important use-case of querying for build information, only providing enough information to allow a third-party tool to reconstruct the compiler configuration and relevant modules without having to link against `Cabal`. The format is small with the goal of making it relatively easy to ensure compatibility going forwards.
