### PR TITLE
Generate package DB flags for skipped global #2772

### DIFF
--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -457,6 +457,11 @@ packageDbArgs implInfo dbstack = case dbstack of
   (GlobalPackageDB:UserPackageDB:dbs) -> concatMap specific dbs
   (GlobalPackageDB:dbs)               -> ("-no-user-" ++ packageDbFlag)
                                        : concatMap specific dbs
+  (UserPackageDB:dbs)                 -> ("-no-global-" ++ packageDbFlag)
+                                       : concatMap specific dbs
+  dbs                                 -> ("-no-global-" ++ packageDbFlag)
+                                       : ("-no-user-" ++ packageDbFlag)
+                                       : concatMap specific dbs
   _ -> ierror
   where
     specific (SpecificPackageDB db) = [ '-':packageDbFlag , db ]


### PR DESCRIPTION
I tried to implement this in as small a way as possible, though overall the PackageDBStack approach feels slightly wrong: if we're hardcoding an order of optional global, optional user, other DBs, a data type like the following would be better:

```haskell
data PackageDBStack = PackageDBStack
    { includeGlobal :: Bool
    , includeUser :: Bool
    , extraDBs :: [FilePath]
    }
```

However, ship's probably sailed on that one. Assuming the configure step guarantees that databases come in in the correct order, this patch should be fine.