### PR TITLE
Don't strip libraries in build directory

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1075,11 +1075,13 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
       let src = srcDir </> name
           dst = dstDir </> name
       createDirectoryIfMissingVerbose verbosity True dstDir
+
       if isShared
-        then do when (stripLibs lbi) $ Strip.stripLib verbosity
-                                       (hostPlatform lbi) (withPrograms lbi) src
-                installExecutableFile verbosity src dst
+        then installExecutableFile verbosity src dst
         else installOrdinaryFile   verbosity src dst
+
+      when (stripLibs lbi) $ Strip.stripLib verbosity
+                             (hostPlatform lbi) (withPrograms lbi) dst
 
     installOrdinary = install False
     installShared   = install True

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -740,11 +740,13 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
       let src = srcDir </> name
           dst = dstDir </> name
       createDirectoryIfMissingVerbose verbosity True dstDir
+
       if isShared
-        then do when (stripLibs lbi) $ Strip.stripLib verbosity
-                                       (hostPlatform lbi) (withPrograms lbi) src
-                installExecutableFile verbosity src dst
+        then installExecutableFile verbosity src dst
         else installOrdinaryFile   verbosity src dst
+
+      when (stripLibs lbi) $ Strip.stripLib verbosity
+                             (hostPlatform lbi) (withPrograms lbi) dst
 
     installOrdinary = install False
     installShared   = install True

--- a/Cabal/Distribution/Simple/Program/Ar.hs
+++ b/Cabal/Distribution/Simple/Program/Ar.hs
@@ -15,7 +15,7 @@ module Distribution.Simple.Program.Ar (
     multiStageProgramInvocation
   ) where
 
-import Control.Monad (when, unless)
+import Control.Monad (unless)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import Data.Char (isSpace)
@@ -26,8 +26,6 @@ import Distribution.Simple.Program
 import Distribution.Simple.Program.Run
          ( programInvocation, multiStageProgramInvocation
          , runProgramInvocation )
-import qualified Distribution.Simple.Program.Strip as Strip
-         ( stripLib )
 import Distribution.Simple.Utils
          ( dieWithLocation, withTempDirectory )
 import Distribution.System
@@ -86,7 +84,6 @@ createArLibArchive verbosity lbi targetPath files = do
         | inv <- multiStageProgramInvocation
                    simple (initial, middle, final) files ]
 
-  when stripLib $ Strip.stripLib verbosity platform progConf tmpPath
   unless (hostArch == Arm) $ -- See #1537
     wipeMetadata tmpPath
   equal <- filesEqual tmpPath targetPath
@@ -94,8 +91,7 @@ createArLibArchive verbosity lbi targetPath files = do
 
   where
     progConf = withPrograms lbi
-    stripLib = stripLibs    lbi
-    platform@(Platform hostArch hostOS) = hostPlatform lbi
+    Platform hostArch hostOS = hostPlatform lbi
     verbosityOpts v | v >= deafening = ["-v"]
                     | v >= verbose   = []
                     | otherwise      = ["-c"]

--- a/Cabal/tests/PackageTests/DeterministicAr/Check.hs
+++ b/Cabal/tests/PackageTests/DeterministicAr/Check.hs
@@ -7,12 +7,7 @@ import Control.Monad
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import Data.Char (isSpace)
-import Data.List
-#if __GLASGOW_HASKELL__ < 710
-import Data.Traversable
-#endif
 import PackageTests.PackageTester
-import System.Exit
 import System.FilePath
 import System.IO
 import Test.Tasty.HUnit (Assertion, assertFailure)
@@ -30,29 +25,6 @@ import Distribution.Simple.LocalBuildInfo (LocalBuildInfo, compiler, localLibrar
 assertFailure' :: String -> IO a
 assertFailure' msg = assertFailure msg >> return {-unpossible!-}undefined
 
-ghcPkg_field :: SuiteConfig -> String -> String -> IO [FilePath]
-ghcPkg_field config libraryName fieldName = do
-    (cmd, exitCode, raw) <- run Nothing (ghcPkgPath config) []
-        ["--user", "field", libraryName, fieldName]
-    let output = filter ('\r' /=) raw -- Windows
-    -- copypasta of PackageTester.requireSuccess
-    unless (exitCode == ExitSuccess) . assertFailure $
-        "Command " ++ cmd ++ " failed.\n" ++ "output: " ++ output
-
-    let prefix = fieldName ++ ": "
-    case traverse (stripPrefix prefix) (lines output) of
-        Nothing -> assertFailure' $ "Command " ++ cmd ++ " failed: expected "
-            ++ show prefix ++ " prefix on every line.\noutput: " ++ output
-        Just fields -> return fields
-
-ghcPkg_field1 :: SuiteConfig -> String -> String -> IO FilePath
-ghcPkg_field1 config libraryName fieldName = do
-    fields <- ghcPkg_field config libraryName fieldName
-    case fields of
-        [field] -> return field
-        _ -> assertFailure' $ "Command ghc-pkg field failed: "
-            ++ "output not a single line.\noutput: " ++ show fields
-
 ------------------------------------------------------------------------
 
 this :: String
@@ -67,15 +39,12 @@ suite config = do
             , distPref = Nothing
             }
 
-    unregister config this
-    iResult <- cabal_install config spec
-    assertInstallSucceeded iResult
+    result <- cabal_build config spec
+    assertBuildSucceeded result
 
     let distBuild = dir </> "dist" </> "build"
-    libdir <- ghcPkg_field1 config this "library-dirs"
     lbi    <- getPersistBuildConfig (dir </> "dist")
-    mapM_ (checkMetadata lbi) [distBuild, libdir]
-    unregister config this
+    checkMetadata lbi distBuild
 
 -- Almost a copypasta of Distribution.Simple.Program.Ar.wipeMetadata
 checkMetadata :: LocalBuildInfo -> FilePath -> Assertion


### PR DESCRIPTION
Two changes:

  * strip static libraries (.a files) at install/copy time, instead of
    at build time. Note that Cabal strips shared libraries (.so files)
    and executables at install/copy time also.

    This is needed for GHC, because it uses Cabal (via ghc-cabal copy)
    to install the boot libraries, and relies on Cabal to take of
    library stripping. Currently .so files indeed get properly stripped,
    but .a files do not.

    (Stripping static libraries at build time was introduced in
    60409cb9493de99f6549956e09604596e3f28938, with the explanation:
    "Call 'stripLib' from createLibArchive so that it's done only
    once.")

    This bug (if you want to call it that) partially explains the
    difference in size of a GHC installation before and after manual
    stripping, reported in (edit: https://github.com/haskell/cabal/issues/1622#issuecomment-62076817) .
    (The other parts are that the
    GHC build system currently doesn't strip executables on
    installation: https://ghc.haskell.org/trac/ghc/ticket/9087, and
    neither are the RTS library stripped, since they don't go through
    Cabal).

  * never strip the copy of a library in the build directory. Only
    strip the copy that is installed. Note that Cabal never strips
    executables in the build directory either.

    This might speed up compilation of a package under development,
    since stripping won't be performed for every 'cabal build'. It is
    also consistent with the GNU coding standards for 'install-strip':

      "install-strip should not strip the executables in the build
      directory which are being copied for installation. It should only
      strip the copies that are installed."

    Source:
    http://www.gnu.org/prep/standards/html_node/Standard-Targets.html