### PR TITLE
Remove dead code

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -61,7 +61,7 @@ import Distribution.Client.Install            ( InstallArgs,
 import Distribution.Utils.NubList            ( fromNubList )
 
 import Distribution.Client.Sandbox.PackageEnvironment
-  ( PackageEnvironment(..), IncludeComments(..), PackageEnvironmentType(..)
+  ( PackageEnvironment(..), PackageEnvironmentType(..)
   , createPackageEnvironmentFile, classifyPackageEnvironment
   , tryLoadSandboxPackageEnvironmentFile, loadUserConfig
   , commentPackageEnvironment, showPackageEnvironmentWithComments
@@ -318,8 +318,7 @@ sandboxInit verbosity sandboxFlags globalFlags = do
 
   -- Create the package environment file.
   pkgEnvFile <- getSandboxConfigFilePath globalFlags
-  createPackageEnvironmentFile verbosity sandboxDir pkgEnvFile
-    NoComments comp platform
+  createPackageEnvironmentFile verbosity sandboxDir pkgEnvFile comp platform
   (_sandboxDir, pkgEnv) <- tryLoadSandboxConfig verbosity globalFlags
   let config      = pkgEnvSavedConfig pkgEnv
       configFlags = savedConfigureFlags config


### PR DESCRIPTION
Only the NoComments case of IncludeComments was ever used and we can
simplify the generation of the default "package environment file"
accordingly.

--
This is simplifies some of the work I'm doing around searching for sandboxes (so it's a prerequisite for that), but should be fine for merge as-is since it just eliminates dead code.