### PR TITLE
use a liberal import of Control.Exception to grab the new ErrorCall pattern in base

### DIFF
--- a/Cabal/Distribution/Compat/Binary.hs
+++ b/Cabal/Distribution/Compat/Binary.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 711
+{-# LANGUAGE PatternSynonyms #-}
+#endif
 
 #ifndef MIN_VERSION_binary
 #define MIN_VERSION_binary(x, y, z) 0
@@ -14,7 +17,12 @@ module Distribution.Compat.Binary
 #endif
        ) where
 
-import Control.Exception (ErrorCall(..), catch, evaluate)
+import Control.Exception (catch, evaluate)
+#if __GLASGOW_HASKELL__ >= 711
+import Control.Exception (pattern ErrorCall)
+#else
+import Control.Exception (ErrorCall(..))
+#endif
 import Data.ByteString.Lazy (ByteString)
 
 #if __GLASGOW_HASKELL__ < 706

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+#if __GLASGOW_HASKELL__ >= 711
+{-# LANGUAGE PatternSynonyms #-}
+#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -122,7 +125,12 @@ import qualified Distribution.Simple.HaskellSuite as HaskellSuite
 -- Prefer the more generic Data.Traversable.mapM to Prelude.mapM
 import Prelude hiding ( mapM )
 import Control.Exception
-    ( ErrorCall(..), Exception, evaluate, throw, throwIO, try )
+    ( Exception, evaluate, throw, throwIO, try )
+#if __GLASGOW_HASKELL__ >= 711
+import Control.Exception ( pattern ErrorCall )
+#else
+import Control.Exception ( ErrorCall(..) )
+#endif
 import Control.Monad
     ( liftM, when, unless, foldM, filterM )
 import Distribution.Compat.Binary ( decodeOrFailIO, encode )


### PR DESCRIPTION
This is a prerequisite for GHC Phabricator [D861](https://phabricator.haskell.org/D861).