### PR TITLE
Warn when constraints or preferences refer to unknown packages (fixes #2719)

### DIFF
--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -15,23 +15,25 @@ module Distribution.Client.Configure (
     configure,
     configureSetupScript,
     chooseCabalVersion,
+    checkConfigExFlags
   ) where
 
 import Distribution.Client.Dependency
 import Distribution.Client.Dependency.Types
          ( AllowNewer(..), isAllowNewer, ConstraintSource(..)
-         , LabeledPackageConstraint(..) )
+         , LabeledPackageConstraint(..), showConstraintSource )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.InstallPlan (InstallPlan)
 import Distribution.Client.IndexUtils as IndexUtils
          ( getSourcePackages, getInstalledPackages )
+import Distribution.Client.PackageIndex ( PackageIndex, elemByPackageName )
 import Distribution.Client.Setup
          ( ConfigExFlags(..), configureCommand, filterConfigureFlags )
 import Distribution.Client.Types as Source
 import Distribution.Client.SetupWrapper
          ( setupWrapper, SetupScriptOptions(..), defaultSetupScriptOptions )
 import Distribution.Client.Targets
-         ( userToPackageConstraint )
+         ( userToPackageConstraint, userConstraintPackageName )
 import qualified Distribution.Client.ComponentDeps as CD
 import Distribution.Package (PackageId)
 import Distribution.Client.JobControl (Lock)
@@ -41,7 +43,8 @@ import Distribution.Simple.Compiler
 import Distribution.Simple.Program (ProgramConfiguration )
 import Distribution.Simple.Setup
          ( ConfigFlags(..), fromFlag, toFlag, flagToMaybe, fromFlagOrDefault )
-import Distribution.Simple.PackageIndex (InstalledPackageIndex)
+import Distribution.Simple.PackageIndex
+         ( InstalledPackageIndex, lookupPackageName )
 import Distribution.Simple.Utils
          ( defaultPackageDesc )
 import qualified Distribution.InstalledPackageInfo as Installed
@@ -57,14 +60,16 @@ import Distribution.PackageDescription.Configuration
 import Distribution.Version
          ( anyVersion, thisVersion )
 import Distribution.Simple.Utils as Utils
-         ( notice, info, debug, die )
+         ( warn, notice, info, debug, die )
 import Distribution.System
          ( Platform )
+import Distribution.Text ( display )
 import Distribution.Verbosity as Verbosity
          ( Verbosity )
 import Distribution.Version
          ( Version(..), VersionRange, orLaterVersion )
 
+import Control.Monad (unless)
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid (Monoid(..))
 #endif
@@ -101,6 +106,8 @@ configure verbosity packageDBs repos comp platform conf
 
   installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
   sourcePkgDb       <- getSourcePackages    verbosity repos
+  checkConfigExFlags verbosity installedPkgIndex
+                     (packageIndex sourcePkgDb) configExFlags
 
   progress <- planLocalPackage verbosity comp platform configFlags configExFlags
                                installedPkgIndex sourcePkgDb
@@ -222,6 +229,31 @@ configureSetupScript packageDBs
                )
              | deppkg <- CD.setupDeps deps
              ]
+
+-- | Warn if any constraints or preferences name packages that are not in the
+-- source package index or installed package index.
+checkConfigExFlags :: Package pkg
+                   => Verbosity
+                   -> InstalledPackageIndex
+                   -> PackageIndex pkg
+                   -> ConfigExFlags
+                   -> IO ()
+checkConfigExFlags verbosity installedPkgIndex sourcePkgIndex flags = do
+  unless (null unknownConstraints) $ warn verbosity $
+             "Constraint refers to an unknown package: "
+          ++ showConstraint (head unknownConstraints)
+  unless (null unknownPreferences) $ warn verbosity $
+             "Preference refers to an unknown package: "
+          ++ display (head unknownPreferences)
+  where
+    unknownConstraints = filter (unknown . userConstraintPackageName . fst) $
+                         configExConstraints flags
+    unknownPreferences = filter (unknown . \(Dependency name _) -> name) $
+                         configPreferences flags
+    unknown pkg = null (lookupPackageName installedPkgIndex pkg)
+               && not (elemByPackageName sourcePkgIndex pkg)
+    showConstraint (uc, src) =
+        display uc ++ " (" ++ showConstraintSource src ++ ")"
 
 -- | Make an 'InstallPlan' for the unpacked package in the current directory,
 -- and all its dependencies.

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -67,7 +67,7 @@ import System.IO.Error
 
 import Distribution.Client.Targets
 import Distribution.Client.Configure
-         ( chooseCabalVersion, configureSetupScript )
+         ( chooseCabalVersion, configureSetupScript, checkConfigExFlags )
 import Distribution.Client.Dependency
 import Distribution.Client.Dependency.Types
          ( Solver(..), ConstraintSource(..), LabeledPackageConstraint(..) )
@@ -254,10 +254,12 @@ makeInstallContext :: Verbosity -> InstallArgs -> Maybe [UserTarget]
                       -> IO InstallContext
 makeInstallContext verbosity
   (packageDBs, repos, comp, _, conf,_,_,
-   globalFlags, _, _, _, _) mUserTargets = do
+   globalFlags, _, configExFlags, _, _) mUserTargets = do
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
     sourcePkgDb       <- getSourcePackages    verbosity repos
+    checkConfigExFlags verbosity installedPkgIndex
+                       (packageIndex sourcePkgDb) configExFlags
     transport <- configureTransport verbosity
                  (flagToMaybe (globalHttpTransport globalFlags))
 

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -40,6 +40,7 @@ module Distribution.Client.Targets (
 
   -- * User constraints
   UserConstraint(..),
+  userConstraintPackageName,
   readUserConstraint,
   userToPackageConstraint
 
@@ -692,6 +693,13 @@ data UserConstraint =
    | UserConstraintStanzas   PackageName [OptionalStanza]
   deriving (Show,Eq)
 
+userConstraintPackageName :: UserConstraint -> PackageName
+userConstraintPackageName uc = case uc of
+  UserConstraintVersion   name _ -> name
+  UserConstraintInstalled name   -> name
+  UserConstraintSource    name   -> name
+  UserConstraintFlags     name _ -> name
+  UserConstraintStanzas   name _ -> name
 
 userToPackageConstraint :: UserConstraint -> PackageConstraint
 -- At the moment, the types happen to be directly equivalent


### PR DESCRIPTION
`cabal install` and `cabal configure` warn when any constraint or preference names a package that is not in the source package index or installed package index.

I tried to keep it simple and unobtrusive by only printing the first bad constraint or preference.  Would it be better to summarize all of them?