### PR TITLE
Add architecture to hash sandbox dir

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -93,7 +93,7 @@ import Distribution.Simple.Utils              ( die, debug, notice, info, warn
                                               , intercalate, topHandlerWith
                                               , createDirectoryIfMissingVerbose )
 import Distribution.Package                   ( Package(..) )
-import Distribution.System                    ( Platform )
+import Distribution.System                    ( Platform(..) )
 import Distribution.Text                      ( display )
 import Distribution.Verbosity                 ( Verbosity, lessVerbose )
 import Distribution.Compat.Environment        ( lookupEnv, setEnv )
@@ -141,10 +141,10 @@ snapshotDirectoryName = "snapshots"
 
 -- | Non-standard build dir that is used for building add-source deps instead of
 -- "dist". Fixes surprising behaviour in some cases (see issue #1281).
-sandboxBuildDir :: FilePath -> FilePath
-sandboxBuildDir sandboxDir = "dist/dist-sandbox-" ++ showHex sandboxDirHash ""
+sandboxBuildDir :: FilePath -> Platform -> FilePath
+sandboxBuildDir sandboxDir (Platform arch _) = "dist/dist-sandbox-" ++ showHex sandboxDirHash ""
   where
-    sandboxDirHash = jenkins sandboxDir
+    sandboxDirHash = jenkins $ sandboxDir ++ show arch
 
     -- See http://en.wikipedia.org/wiki/Jenkins_hash_function
     jenkins :: String -> Word32
@@ -598,7 +598,8 @@ reinstallAddSourceDeps :: Verbosity
                           -> IO WereDepsReinstalled
 reinstallAddSourceDeps verbosity configFlags' configExFlags
                        installFlags globalFlags sandboxDir = topHandler' $ do
-  let sandboxDistPref     = sandboxBuildDir sandboxDir
+  (_, platform', _)      <- configCompilerAux' configFlags'
+  let sandboxDistPref     = sandboxBuildDir sandboxDir platform'
       configFlags         = configFlags'
                             { configDistPref  = Flag sandboxDistPref }
       haddockFlags        = mempty

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -686,12 +686,12 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags)
   let installFlags'   = defaultInstallFlags          `mappend`
                         savedInstallFlags     config `mappend` installFlags
 
-  (_, platform', _) <- let configFlags' = maybeForceTests installFlags' $
-                                          savedConfigureFlags   config `mappend` configFlags
-                       in configCompilerAux' configFlags'
+  (comp', platform', _) <- let configFlags' = maybeForceTests installFlags' $
+                                              savedConfigureFlags config `mappend` configFlags
+                           in configCompilerAux' configFlags'
   let sandboxDistPref = case useSandbox of
         NoSandbox             -> NoFlag
-        UseSandbox sandboxDir -> Flag $ sandboxBuildDir sandboxDir platform'
+        UseSandbox sandboxDir -> Flag $ sandboxBuildDir sandboxDir comp' platform'
   distPref <- findSavedDistPref config
               (configDistPref configFlags `mappend` sandboxDistPref)
 

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -683,9 +683,15 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags)
   -- However, this is the same behaviour that 'cabal install' has in the normal
   -- mode of operation, so we stick to it for consistency.
 
+  let installFlags'   = defaultInstallFlags          `mappend`
+                        savedInstallFlags     config `mappend` installFlags
+
+  (_, platform', _) <- let configFlags' = maybeForceTests installFlags' $
+                                          savedConfigureFlags   config `mappend` configFlags
+                       in configCompilerAux' configFlags'
   let sandboxDistPref = case useSandbox of
         NoSandbox             -> NoFlag
-        UseSandbox sandboxDir -> Flag $ sandboxBuildDir sandboxDir
+        UseSandbox sandboxDir -> Flag $ sandboxBuildDir sandboxDir platform'
   distPref <- findSavedDistPref config
               (configDistPref configFlags `mappend` sandboxDistPref)
 
@@ -694,8 +700,6 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags)
                         configFlags { configDistPref = toFlag distPref }
       configExFlags'  = defaultConfigExFlags         `mappend`
                         savedConfigureExFlags config `mappend` configExFlags
-      installFlags'   = defaultInstallFlags          `mappend`
-                        savedInstallFlags     config `mappend` installFlags
       haddockFlags'   = defaultHaddockFlags          `mappend`
                         savedHaddockFlags     config `mappend`
                         haddockFlags { haddockDistPref = toFlag distPref }


### PR DESCRIPTION
This patch allows for 32-bit and 64-bit concurrent builds.

This ensures that dependencies built for different architectures will not get mixed into the same dist-sandbox directory thus allowing for x86 and x86_64 builds in the same working space and even concurrently.
