### PR TITLE
Use the sandbox config for "cabal get"

### DIFF
--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -1090,7 +1090,7 @@ getAction :: GetFlags -> [String] -> GlobalFlags -> IO ()
 getAction getFlags extraArgs globalFlags = do
   let verbosity = fromFlag (getVerbosity getFlags)
   targets <- readUserTargets verbosity extraArgs
-  config <- loadConfig verbosity (globalConfigFile globalFlags)
+  (_useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags mempty
   let globalFlags' = savedGlobalFlags config `mappend` globalFlags
   get verbosity
     (globalRepos (savedGlobalFlags config))


### PR DESCRIPTION
If I try to use a local cabal-install repo cache by adding a
"remote-repo-cache: <dir>" setting to the local cabal.config, this is
respected by "cabal update" but then ignored by "cabal get", which seems
wrong.  This respects the local cabal.config in "cabal get" too.  Maybe
all commands should do this?