### PR TITLE
Clean up FIXMEs

### DIFF
--- a/cabal-install/Distribution/Client/BuildReports/Anonymous.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Anonymous.hs
@@ -191,7 +191,6 @@ parse s = case parseFields s of
   ParseFailed perror -> Left  msg where (_, msg) = locatedErrorMsg perror
   ParseOk   _ report -> Right report
 
---FIXME: this does not allow for optional or repeated fields
 parseFields :: String -> ParseResult BuildReport
 parseFields input = do
   fields <- mapM extractField =<< readFields input

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -640,7 +640,7 @@ configFieldDescriptions src =
        (["builddir", "constraint", "dependency"]
         ++ map fieldName installDirsFields)
 
-        --FIXME: this is only here because viewAsFieldDescr gives us a parser
+        -- This is only here because viewAsFieldDescr gives us a parser
         -- that only recognises 'ghc' etc, the case-sensitive flag names, not
         -- what the normal case-insensitive parser gives us.
        [simpleField "compiler"

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -88,13 +88,13 @@ import System.IO.Unsafe (unsafeInterleaveIO)
 import System.IO.Error (isDoesNotExistError)
 
 
+-- | Reduced-verbosity version of 'Configure.getInstalledPackages'
 getInstalledPackages :: Verbosity -> Compiler
                      -> PackageDBStack -> ProgramConfiguration
                      -> IO InstalledPackageIndex
 getInstalledPackages verbosity comp packageDbs conf =
     Configure.getInstalledPackages verbosity' comp packageDbs conf
   where
-    --FIXME: make getInstalledPackages use sensible verbosity in the first place
     verbosity'  = lessVerbose verbosity
 
 ------------------------------------------------------------------------

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -688,7 +688,6 @@ printPlan dryRun verbosity plan sourcePkgDb = case plan of
     showStanza TestStanzas  = "*test"
     showStanza BenchStanzas = "*bench"
 
-    -- FIXME: this should be a proper function in a proper place
     showFlagAssignment :: FlagAssignment -> String
     showFlagAssignment = concatMap ((' ' :) . showFlagValue)
     showFlagValue (f, True)   = '+' : showFlagName f

--- a/cabal-install/Distribution/Client/ParseUtils.hs
+++ b/cabal-install/Distribution/Client/ParseUtils.hs
@@ -21,7 +21,6 @@ import qualified Data.Map as Map
 import qualified Text.PrettyPrint as Disp
          ( Doc, text, colon, vcat, empty, isEmpty, nest )
 
---FIXME: replace this with something better
 parseFields :: [FieldDescr a] -> a -> [ParseUtils.Field] -> ParseResult a
 parseFields fields = foldM setField
   where

--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -38,7 +38,6 @@ module Distribution.Client.Sandbox (
     updateSandboxConfigFileFlag,
     updateInstallDirs,
 
-    -- FIXME: move somewhere else
     configPackageDB', configCompilerAux', getPersistOrConfigCompiler
   ) where
 
@@ -384,7 +383,7 @@ doAddSource verbosity buildTreeRefs sandboxDir pkgEnv refType = do
     (compilerId comp) platform
 
   withAddTimestamps sandboxDir $ do
-    -- FIXME: path canonicalisation is done in addBuildTreeRefs, but we do it
+    -- Path canonicalisation is done in addBuildTreeRefs, but we do it
     -- twice because of the timestamps file.
     buildTreeRefs' <- mapM tryCanonicalizePath buildTreeRefs
     Index.addBuildTreeRefs verbosity indexFile buildTreeRefs' refType

--- a/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
+++ b/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
@@ -403,7 +403,6 @@ pkgEnvFieldDescrs src = [
     (fromFlagOrDefault Disp.empty . fmap Disp.text) (optional parseFilePathQ)
     pkgEnvInherit (\v pkgEnv -> pkgEnv { pkgEnvInherit = v })
 
-    -- FIXME: Should we make these fields part of ~/.cabal/config ?
   , commaNewLineListField "constraints"
     (Text.disp . fst) ((\pc -> (pc, src)) `fmap` Text.parse)
     (configExConstraints . savedConfigureExFlags . pkgEnvSavedConfig)

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -728,7 +728,6 @@ readUserConstraint str =
          "expected a package name followed by a constraint, which is "
       ++ "either a version range, 'installed', 'source' or flags"
 
---FIXME: use Text instance for FlagName and FlagAssignment
 instance Text UserConstraint where
   disp (UserConstraintVersion   pkgname verrange) = disp pkgname
                                                     <+> disp verrange

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -232,8 +232,6 @@ data RemoteRepo =
       remoteRepoShouldTryHttps :: Bool
     }
 
-  -- FIXME: discuss this type some more.
-
   deriving (Show,Eq,Ord)
 
 -- | Construct a partial 'RemoteRepo' value to fold the field parser list over.

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -726,7 +726,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags)
     maybeAddCompilerTimestampRecord verbosity sandboxDir indexFile
       (compilerId comp) platform
 
-  -- FIXME: Passing 'SandboxPackageInfo' to install unconditionally here means
+  -- TODO: Passing 'SandboxPackageInfo' to install unconditionally here means
   -- that 'cabal install some-package' inside a sandbox will sometimes reinstall
   -- modified add-source deps, even if they are not among the dependencies of
   -- 'some-package'. This can also prevent packages that depend on older


### PR DESCRIPTION
Some FIXMEs are downgraded to simple comments, some outright removed --
especially very old and non-severe-looking.

(All by my judgment of severity.)

---

This doesn't "handle" all the FIXMEs; this is mostly ones that are easy to judge the severity of. I might do a second round to eliminate all the remaining ones; perhaps creating real GitHub issues for them.