### PR TITLE
Global Constraints Option

### DIFF
--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -610,7 +610,7 @@ be controlled with the following command line options.
     be a file or directory. Not all implementations support arbitrary
     package databases.
 
-`--constraints-file=` _file_
+`--default-user-config=` _file_
 :   Allows a "default" `cabal.config` freeze file to be passed in
     manually. This file will only be used if one does not exist in the
     project directory already. Typically, this can be set from the global

--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -610,6 +610,14 @@ be controlled with the following command line options.
     be a file or directory. Not all implementations support arbitrary
     package databases.
 
+`--constraints-file=` _file_
+:   Allows a "default" `cabal.config` freeze file to be passed in
+    manually. This file will only be used if one does not exist in the
+    project directory already. Typically, this can be set from the global
+    cabal `config` file so as to provide a default set of partial
+    constraints to be used by projects, providing a way for users to peg
+    themselves to stable package collections.
+
 `--enable-optimization`[=_n_] or `-O`[_n_]
 :   (default) Build with optimization flags (if available). This is
     appropriate for production use, taking more time to build faster

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -215,6 +215,7 @@ instance Monoid SavedConfig where
         globalNumericVersion    = combine globalNumericVersion,
         globalConfigFile        = combine globalConfigFile,
         globalSandboxConfigFile = combine globalSandboxConfigFile,
+        globalConstraintsFile   = combine globalConstraintsFile,
         globalRemoteRepos       = lastNonEmptyNL globalRemoteRepos,
         globalCacheDir          = combine globalCacheDir,
         globalLocalRepos        = lastNonEmptyNL globalLocalRepos,

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -272,8 +272,8 @@ data ConstraintSource =
   -- | Sandbox config file, which is ./cabal.sandbox.config by default.
   | ConstraintSourceSandboxConfig FilePath
 
-  -- | ./cabal.config.
-  | ConstraintSourceUserConfig
+  -- | User config file, which is ./cabal.config by default.
+  | ConstraintSourceUserConfig FilePath
 
   -- | Flag specified on the command line.
   | ConstraintSourceCommandlineFlag
@@ -306,7 +306,7 @@ showConstraintSource (ConstraintSourceMainConfig path) =
     "main config " ++ path
 showConstraintSource (ConstraintSourceSandboxConfig path) =
     "sandbox config " ++ path
-showConstraintSource ConstraintSourceUserConfig = "cabal.config"
+showConstraintSource (ConstraintSourceUserConfig path)= "user config " ++ path
 showConstraintSource ConstraintSourceCommandlineFlag = "command line flag"
 showConstraintSource ConstraintSourceUserTarget = "user target"
 showConstraintSource ConstraintSourceNonUpgradeablePackage =

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -227,7 +227,7 @@ freezePackages globalFlags verbosity pkgs = do
             }
         }
     constraint pkg =
-        (pkgIdToConstraint $ packageId pkg, ConstraintSourceUserConfig)
+        (pkgIdToConstraint $ packageId pkg, ConstraintSourceUserConfig userPackageEnvironmentFile)
       where
         pkgIdToConstraint pkgId =
             UserConstraintVersion (packageName pkgId)

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -112,7 +112,7 @@ freeze verbosity packageDBs repos comp platform conf mSandboxPkgInfo
                      "The following packages would be frozen:"
                    : formatPkgs pkgs
 
-             else freezePackages verbosity pkgs
+             else freezePackages globalFlags verbosity pkgs
 
   where
     dryRun = fromFlag (freezeDryRun freezeFlags)
@@ -213,10 +213,11 @@ pruneInstallPlan installPlan pkgSpecifiers =
     brokenPkgsErr = error "planPackages: installPlan contains broken packages"
 
 
-freezePackages :: Package pkg => Verbosity -> [pkg] -> IO ()
-freezePackages verbosity pkgs = do
+freezePackages :: Package pkg => GlobalFlags -> Verbosity -> [pkg] -> IO ()
+freezePackages globalFlags verbosity pkgs = do
+
     pkgEnv <- fmap (createPkgEnv . addFrozenConstraints) $
-                   loadUserConfig verbosity "" Nothing
+                   loadUserConfig verbosity ""  (flagToMaybe . globalConstraintsFile $ globalFlags)
     writeFileAtomic userPackageEnvironmentFile $ showPkgEnv pkgEnv
   where
     addFrozenConstraints config =

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -216,7 +216,7 @@ pruneInstallPlan installPlan pkgSpecifiers =
 freezePackages :: Package pkg => Verbosity -> [pkg] -> IO ()
 freezePackages verbosity pkgs = do
     pkgEnv <- fmap (createPkgEnv . addFrozenConstraints) $
-                   loadUserConfig verbosity ""
+                   loadUserConfig verbosity "" Nothing
     writeFileAtomic userPackageEnvironmentFile $ showPkgEnv pkgEnv
   where
     addFrozenConstraints config =

--- a/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
+++ b/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
@@ -284,10 +284,10 @@ inheritedPackageEnvironment verbosity pkgEnv = do
 userPackageEnvironment :: Verbosity -> FilePath -> Maybe FilePath -> IO PackageEnvironment
 userPackageEnvironment verbosity pkgEnvDir globalConfigLocation = do
     let path = pkgEnvDir </> userPackageEnvironmentFile
-    minp <- readPackageEnvironmentFile ConstraintSourceUserConfig mempty path
+    minp <- readPackageEnvironmentFile (ConstraintSourceUserConfig path) mempty path
     case (minp, globalConfigLocation) of
       (Just parseRes, _)  -> processConfigParse path parseRes
-      (_, Just globalLoc) -> maybe (warn verbosity ("no constraints file found at " ++ path) >> return mempty) (processConfigParse globalLoc) =<< readPackageEnvironmentFile ConstraintSourceUserConfig mempty globalLoc
+      (_, Just globalLoc) -> maybe (warn verbosity ("no constraints file found at " ++ globalLoc) >> return mempty) (processConfigParse globalLoc) =<< readPackageEnvironmentFile (ConstraintSourceUserConfig globalLoc) mempty globalLoc
       _ -> return mempty
   where
     processConfigParse path (ParseOk warns parseResult) = do

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -285,8 +285,8 @@ globalCommand commands = CommandUI {
          globalConfigFile (\v flags -> flags { globalSandboxConfigFile = v })
          (reqArgFlag "FILE")
 
-      ,option [] ["constraints-file"]
-         "Set a location for a global constraints file for projects without their own cabal.config freeze file."
+      ,option [] ["default-user-config"]
+         "Set a location for a cabal.config file for projects without their own cabal.config freeze file."
          globalConfigFile (\v flags -> flags {globalConstraintsFile = v})
          (reqArgFlag "FILE")
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -120,6 +120,7 @@ data GlobalFlags = GlobalFlags {
     globalNumericVersion    :: Flag Bool,
     globalConfigFile        :: Flag FilePath,
     globalSandboxConfigFile :: Flag FilePath,
+    globalConstraintsFile   :: Flag FilePath,
     globalRemoteRepos       :: NubList RemoteRepo,     -- ^ Available Hackage servers.
     globalCacheDir          :: Flag FilePath,
     globalLocalRepos        :: NubList FilePath,
@@ -136,6 +137,7 @@ defaultGlobalFlags  = GlobalFlags {
     globalNumericVersion    = Flag False,
     globalConfigFile        = mempty,
     globalSandboxConfigFile = mempty,
+    globalConstraintsFile   = mempty,
     globalRemoteRepos       = mempty,
     globalCacheDir          = mempty,
     globalLocalRepos        = mempty,
@@ -262,7 +264,7 @@ globalCommand commands = CommandUI {
     commandNotes = Nothing,
     commandDefaultFlags = mempty,
     commandOptions      = \showOrParseArgs ->
-      (case showOrParseArgs of ShowArgs -> take 7; ParseArgs -> id)
+      (case showOrParseArgs of ShowArgs -> take 8; ParseArgs -> id)
       [option ['V'] ["version"]
          "Print version information"
          globalVersion (\v flags -> flags { globalVersion = v })
@@ -281,6 +283,11 @@ globalCommand commands = CommandUI {
       ,option [] ["sandbox-config-file"]
          "Set an alternate location for the sandbox config file (default: './cabal.sandbox.config')"
          globalConfigFile (\v flags -> flags { globalSandboxConfigFile = v })
+         (reqArgFlag "FILE")
+
+      ,option [] ["constraints-file"]
+         "Set a location for a global constraints file for projects without their own cabal.config freeze file."
+         globalConfigFile (\v flags -> flags {globalConstraintsFile = v})
          (reqArgFlag "FILE")
 
       ,option [] ["require-sandbox"]
@@ -331,6 +338,7 @@ instance Monoid GlobalFlags where
     globalNumericVersion    = mempty,
     globalConfigFile        = mempty,
     globalSandboxConfigFile = mempty,
+    globalConstraintsFile   = mempty,
     globalRemoteRepos       = mempty,
     globalCacheDir          = mempty,
     globalLocalRepos        = mempty,
@@ -345,6 +353,7 @@ instance Monoid GlobalFlags where
     globalNumericVersion    = combine globalNumericVersion,
     globalConfigFile        = combine globalConfigFile,
     globalSandboxConfigFile = combine globalConfigFile,
+    globalConstraintsFile   = combine globalConstraintsFile,
     globalRemoteRepos       = combine globalRemoteRepos,
     globalCacheDir          = combine globalCacheDir,
     globalLocalRepos        = combine globalLocalRepos,


### PR DESCRIPTION
This lets you either pass `constraints-file` on the command line or in
the ~/.cabal/config file.

The constraints-file serves as a "default" cabal.config file for
freezes should one not be provided by a particular package.

Thus, a "minimal" platform can ship with a file that includes the
platform constraints. Later, a user can simply download a new file for
a new constraints set -- say lts -- and swap their config to point to
that instead.

This makes both the platform in its new ideally-more-minimal guise and
stackage play nicer together and with cabal, in a way that required
minimal changes to cabal proper.

Ideally this or a relative can land soon to help enable the minimal
platform plans (the work grew out of the discussion on:
https://github.com/haskell/haskell-platform/issues/206)

In PackageEnvironment.hs, the tryLoadSandboxPackageEnvironmentFile
doesn't check if this flag is set and handle that case. So this is
when we are already in a sandbox and the question is if we should
_also_ respect this flag, just as a sandbox also respects a
cabal.config file directly in the directory. My gut says "don't
respect it in sandboxes" which is what I now have implemented, but this is open for discussion.

Freeze.hs _does_ respect this flag.