### PR TITLE
Call addInfoForKnownRepos in initialSavedConfig

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -428,7 +428,7 @@ initialSavedConfig = do
   return mempty {
     savedGlobalFlags     = mempty {
       globalCacheDir     = toFlag cacheDir,
-      globalRemoteRepos  = toNubList [defaultRemoteRepo],
+      globalRemoteRepos  = toNubList [addInfoForKnownRepos defaultRemoteRepo],
       globalWorldFile    = toFlag worldFile
     },
     savedConfigureFlags  = mempty {


### PR DESCRIPTION
@dcoutts introduced `addInfoForKnownRepos` in 8617d39d3c0be275e4373c1c6d5ddc7368083960, but while we called `addInfoForKnownRepos` when _parsing_ a file, we didn't call it when creating the initial file. This meant that when we created an initial file, we would end up with a different internal configuration (which would not have `addInfoForKnownRepos` applied) than if we wrote out and then read back that same initial file (which would).