### PR TITLE
Lower memory usage during index file parsing #2396

### DIFF
--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -61,13 +61,13 @@ import Distribution.Simple.Utils
          ( die, warn, info, fromUTF8, ignoreBOM )
 
 import Data.Char   (isAlphaNum)
-import Data.Maybe  (mapMaybe, fromMaybe)
+import Data.Maybe  (mapMaybe)
 import Data.List   (isPrefixOf)
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid (Monoid(..))
 #endif
 import qualified Data.Map as Map
-import Control.Monad (MonadPlus(mplus), when, liftM)
+import Control.Monad (when, liftM)
 import Control.Exception (evaluate)
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Lazy.Char8 as BS.Char8

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -18,7 +18,6 @@ module Distribution.Client.IndexUtils (
   getSourcePackagesStrict,
   convert,
 
-  --readPackageIndexFile,
   parsePackageIndex,
   readRepoIndex,
   updateRepoIndexCache,


### PR DESCRIPTION
Fixes #2396

As stated in one of the commit messages:

The parsePackageIndex wasn't streaming because resulting list was
hidden in two constructors: Either and tuple. By removing that, error
semantics changed in updatePackageIndexCacheFile.

The updatePackageIndexCacheFile problem was sequence call that evaluated
whole list produced by parsePackageIndex. By using lazySequence, any error
during index file parsing will be raised during writing to cache file.

Also removed readPackageIndexFile, as it wasn't used anywhere as far as
I can tell. If this is a mistake I'll include it again.