### PR TITLE
Add hasUpperBound and hasLowerBound

### DIFF
--- a/Cabal/Distribution/Version.hs
+++ b/Cabal/Distribution/Version.hs
@@ -44,6 +44,8 @@ module Distribution.Version (
   simplifyVersionRange,
   foldVersionRange,
   foldVersionRange',
+  hasUpperBound,
+  hasLowerBound,
 
   -- ** Modification
   removeUpperBound,
@@ -805,3 +807,29 @@ instance Text VersionRange where
                      (">",  LaterVersion),
                      (">=", orLaterVersion),
                      ("==", ThisVersion) ]
+
+-- | Does the version range have an upper bound?
+--
+-- @since 1.24.0.0
+hasUpperBound :: VersionRange -> Bool
+hasUpperBound AnyVersion = False
+hasUpperBound (ThisVersion _) = True
+hasUpperBound (LaterVersion _) = False
+hasUpperBound (EarlierVersion _) = True
+hasUpperBound (WildcardVersion _) = True
+hasUpperBound (UnionVersionRanges x y) = hasUpperBound x && hasUpperBound y
+hasUpperBound (IntersectVersionRanges x y) = hasUpperBound x || hasUpperBound y
+hasUpperBound (VersionRangeParens x) = hasUpperBound x
+
+-- | Does the version range have a lower bound?
+--
+-- @since 1.24.0.0
+hasLowerBound :: VersionRange -> Bool
+hasLowerBound AnyVersion = False
+hasLowerBound (ThisVersion _) = True
+hasLowerBound (LaterVersion _) = True
+hasLowerBound (EarlierVersion _) = False
+hasLowerBound (WildcardVersion _) = True
+hasLowerBound (UnionVersionRanges x y) = hasLowerBound x && hasLowerBound y
+hasLowerBound (IntersectVersionRanges x y) = hasLowerBound x || hasLowerBound y
+hasLowerBound (VersionRangeParens x) = hasLowerBound x


### PR DESCRIPTION
This is useful for performing PVP bounds checking, especially for
tooling that wants to automate such dependency bounds. A demonstration
of this being used in practice is the --pvp-bounds flag for stack:

https://github.com/commercialhaskell/stack/commit/c774f9905b3b112f58fc3789dfb9c26389d33b24