### PR TITLE
Add DeriveLift to Language.Haskell.Extension

### DIFF
--- a/Cabal/Language/Haskell/Extension.hs
+++ b/Cabal/Language/Haskell/Extension.hs
@@ -714,6 +714,11 @@ data KnownExtension =
   -- * <http://www.haskell.org/ghc/docs/latest/html/users_guide/other-type-extensions.html#derive-any-class>
   | DeriveAnyClass
 
+  -- | Enable @deriving@ for the 'Language.Haskell.TH.Syntax.Lift' class.
+  --
+  -- * <http://www.haskell.org/ghc/docs/latest/html/users_guide/deriving.html#deriving-lift>
+  | DeriveLift
+
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable, Data)
 
 instance Binary KnownExtension


### PR DESCRIPTION
The `DeriveLift` extension is to be added to GHC as part of [Phab D1168](https://phabricator.haskell.org/D1168), but one of the GHC test suites needs to have `DeriveLIft` as a `Cabal`-recognized extension for it to pass.