### PR TITLE
Fail more gracefully when tests can't be run

### DIFF
--- a/Cabal/Distribution/Simple/Program/Find.hs
+++ b/Cabal/Distribution/Simple/Program/Find.hs
@@ -35,7 +35,7 @@ import Distribution.Simple.Utils
 import Distribution.System
          ( OS(..), buildOS )
 import System.Directory
-         ( findExecutable )
+         ( canonicalizePath, findExecutable )
 import Distribution.Compat.Environment
          ( getEnvironment )
 import System.FilePath
@@ -109,7 +109,7 @@ findProgramOnSearchPath verbosity searchpath prog = do
     findFirstExe (f:fs) = do
       isExe <- doesExecutableExist f
       if isExe
-        then return (Just f)
+        then Just `fmap` canonicalizePath f
         else findFirstExe fs
 
 -- | Interpret a 'ProgramSearchPath' to construct a new @$PATH@ env var.

--- a/cabal-install/tests/IntegrationTests.hs
+++ b/cabal-install/tests/IntegrationTests.hs
@@ -15,7 +15,7 @@ import Distribution.Simple.Program.Builtin (ghcPkgProgram)
 import Distribution.Simple.Program.Db
         (defaultProgramDb, requireProgram, setProgramSearchPath)
 import Distribution.Simple.Program.Find
-        (ProgramSearchPathEntry(ProgramSearchPathDir), defaultProgramSearchPath)
+        (ProgramSearchPathEntry(ProgramSearchPathDir))
 import Distribution.Simple.Program.Types
         ( Program(..), simpleProgram, programPath)
 import Distribution.Simple.Setup ( Flag(..) )
@@ -256,9 +256,11 @@ main :: IO ()
 main = do
   -- Find executables and build directories, etc.
   distPref <- findDistPrefOrDefault NoFlag
-  buildDir <- canonicalizePath (distPref </> "build/cabal")
-  let programSearchPath = ProgramSearchPathDir buildDir : defaultProgramSearchPath
-  (cabal, _) <- requireProgram normal cabalProgram (setProgramSearchPath programSearchPath defaultProgramDb)
+  let programSearchPath = [ProgramSearchPathDir $ distPref </> "build/cabal"]
+  -- This throws an error if the cabal executable hasn't been built yet,
+  -- because test suites can't depend on executables.
+  (cabal, _) <- requireProgram normal cabalProgram
+                    (setProgramSearchPath programSearchPath defaultProgramDb)
   (ghcPkg, _) <- requireProgram normal ghcPkgProgram defaultProgramDb
   baseDirectory <- canonicalizePath $ "tests" </> "IntegrationTests"
   -- Set up environment variables for test scripts


### PR DESCRIPTION
If cabal-install isn't built yet, we can't run it's tests yet. Prior to
this commit, if you tried running "./Setup test" on cabal-install without
having built cabal-install yet you got:

package-tests: dist/build/cabal: canonicalizePath: does not exist (No such file or directory)

Now you get:

package-tests: user error (The program 'cabal' is required but it could not be found.)

I moved the canonicalization logic into findProgramOnSearchPath. This is
a change to the semantics of the library, but shouldn't break anything.
