### PR TITLE
Simplify the Travis script now that Cabal uses build-type Simple.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # NB: don't set `language: haskell` here
 
-# The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
+# The following enables several GHC versions to be tested; often it's enough to
+# test only against the last release in a major GHC version. Feel free to omit
+# lines listings versions you don't need/want testing for.
 env:
  - GHCVER=7.4.2
  - GHCVER=7.6.3
@@ -17,32 +19,34 @@ before_install:
 
 install:
  - cabal update
-# We intentionally do not install anything before trying to build Cabal because
-# it should build with each supported GHC version out-of-the-box.
+ # We intentionally do not install anything before trying to build Cabal because
+ # it should build with each supported GHC version out-of-the-box.
 
-# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
-# Using ./dist/setup/setup here instead of cabal-install to avoid breakage
-# when the build config format changed
+# Here starts the actual work to be performed for the package under test; any
+# command which exits with a non-zero exit code causes the build to fail.
 script:
+ - cabal sandbox init
  - cd Cabal
- - mkdir -p ./dist/setup
- - cp Setup.hs ./dist/setup/setup.hs
-# Should be able to build setup without extra dependencies
- - /opt/ghc/$GHCVER/bin/ghc --make -odir ./dist/setup -hidir ./dist/setup -i -i. ./dist/setup/setup.hs -o ./dist/setup/setup -Wall -Werror -threaded  # the command cabal-install would use to build setup
+ - cabal sandbox init --sandbox ../.cabal-sandbox
+ - cabal configure --ghc-option=-Werror -v2 # -v2 provides useful information for debugging.
+ - cabal build
 
 # Need extra dependencies for test suite
  - cabal install --only-dependencies --enable-tests
  - sudo /opt/ghc/$GHCVER/bin/ghc-pkg recache
  - /opt/ghc/$GHCVER/bin/ghc-pkg recache --user
 
- - ./dist/setup/setup configure --user --enable-tests --enable-benchmarks --ghc-option=-Werror -v2  # -v2 provides useful information for debugging
- - ./dist/setup/setup build   # this builds all libraries and executables (including tests/benchmarks)
- - ./dist/setup/setup haddock # see #2198
- - ./dist/setup/setup test --show-details=streaming
+ - cabal configure --enable-tests --enable-benchmarks --ghc-option=-Werror -v2  # -v2 provides useful information for debugging.
+ # This builds all libraries and executables (including tests/benchmarks).
+ - cabal build
+ # Test that docs can be built (see #2198).
+ - cabal haddock
+ - cabal test --show-details=streaming
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 
-# The following scriptlet checks that the resulting source distribution can be built & installed
+# The following scriptlet checks that the resulting source distribution can be
+# built & installed
  - function install_from_tarball {
    export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
    if [ -f "dist/$SRC_TGZ" ]; then
@@ -56,8 +60,8 @@ script:
 
 # Also build cabal-install.
  - cd ../cabal-install
- - cabal sandbox init
- - cabal sandbox add-source ../Cabal
+ # Cabal lib should be already installed in the sandbox, so don't add-source it.
+ - cabal sandbox init --sandbox ../.cabal-sandbox
  - cabal install --dependencies-only --enable-tests
  - cabal configure --enable-tests --ghc-option=-Werror
  - cabal build


### PR DESCRIPTION
Please don't merge until the build passes on Travis.