### PR TITLE
cabal haddock: add --for-hackage flag

### DIFF
--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -1303,6 +1303,7 @@ data HaddockFlags = HaddockFlags {
     haddockHoogle       :: Flag Bool,
     haddockHtml         :: Flag Bool,
     haddockHtmlLocation :: Flag String,
+    haddockForHackage   :: Flag Bool,
     haddockExecutables  :: Flag Bool,
     haddockTestSuites   :: Flag Bool,
     haddockBenchmarks   :: Flag Bool,
@@ -1324,6 +1325,7 @@ defaultHaddockFlags  = HaddockFlags {
     haddockHoogle       = Flag False,
     haddockHtml         = Flag False,
     haddockHtmlLocation = NoFlag,
+    haddockForHackage   = Flag False,
     haddockExecutables  = Flag False,
     haddockTestSuites   = Flag False,
     haddockBenchmarks   = Flag False,
@@ -1389,6 +1391,11 @@ haddockOptions showOrParseArgs =
    haddockHtmlLocation (\v flags -> flags { haddockHtmlLocation = v })
    (reqArgFlag "URL")
 
+  ,option "" ["for-hackage"]
+   "Collection of flags to generate documentation suitable for upload to hackage"
+   haddockForHackage (\v flags -> flags { haddockForHackage = v })
+   trueArg
+
   ,option "" ["executables"]
    "Run haddock for Executables targets"
    haddockExecutables (\v flags -> flags { haddockExecutables = v })
@@ -1452,6 +1459,7 @@ instance Monoid HaddockFlags where
     haddockHoogle       = mempty,
     haddockHtml         = mempty,
     haddockHtmlLocation = mempty,
+    haddockForHackage   = mempty,
     haddockExecutables  = mempty,
     haddockTestSuites   = mempty,
     haddockBenchmarks   = mempty,
@@ -1470,6 +1478,7 @@ instance Monoid HaddockFlags where
     haddockHoogle       = combine haddockHoogle,
     haddockHtml         = combine haddockHtml,
     haddockHtmlLocation = combine haddockHtmlLocation,
+    haddockForHackage   = combine haddockForHackage,
     haddockExecutables  = combine haddockExecutables,
     haddockTestSuites   = combine haddockTestSuites,
     haddockBenchmarks   = combine haddockBenchmarks,

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -369,6 +369,7 @@ instance Monoid SavedConfig where
         haddockHoogle        = combine haddockHoogle,
         haddockHtml          = combine haddockHtml,
         haddockHtmlLocation  = combine haddockHtmlLocation,
+        haddockForHackage    = combine haddockForHackage,
         haddockExecutables   = combine haddockExecutables,
         haddockTestSuites    = combine haddockTestSuites,
         haddockBenchmarks    = combine haddockBenchmarks,


### PR DESCRIPTION
This is the first step to implement #2080. It adds a new flag
to `cabal haddock`, called `--for-hackage`, which will generate
documentation suitable for upload to hackage. It's only a collection
of flags, and matches the flags used by the hackage doc builder.