### PR TITLE
Use configured compiler for cabal sandbox hc-pkg

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -39,7 +39,7 @@ module Distribution.Client.Sandbox (
     updateInstallDirs,
 
     -- FIXME: move somewhere else
-    configPackageDB', configCompilerAux'
+    configPackageDB', configCompilerAux', getPersistOrConfigCompiler
   ) where
 
 import Distribution.Client.Setup

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -100,6 +100,7 @@ import Distribution.Client.Sandbox            (sandboxInit
                                               ,updateInstallDirs
 
                                               ,configCompilerAux'
+                                              ,getPersistOrConfigCompiler
                                               ,configPackageDB')
 import Distribution.Client.Sandbox.PackageEnvironment
                                               (setPackageDB
@@ -1158,7 +1159,7 @@ execAction execFlags extraArgs globalFlags = do
   let verbosity = fromFlag (execVerbosity execFlags)
   (useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags
   let configFlags = savedConfigureFlags config
-  (comp, platform, conf) <- configCompilerAux' configFlags
+  (comp, platform, conf) <- getPersistOrConfigCompiler configFlags
   exec verbosity useSandbox comp platform conf extraArgs
 
 userConfigAction :: UserConfigFlags -> [String] -> GlobalFlags -> IO ()


### PR DESCRIPTION
For most commands (e.g. `cabal install`), the `package-db` field in `cabal.sandbox.config` is ignored, and the path is reconstructed from the `prefix` and current compiler instead.  This is arguably the right behaviour, because the right package DB depends on the arch/compiler, so it doesn't make sense to specify only one.  This commit makes `cabal sandbox hc-pkg` behave similarly, to avoid invoking ghc-pkg on an incompatible package DB (fixes #1935).

Moreover, the compiler version to use is now picked up from the most recently configured compiler, if any.  Otherwise, the global default compiler is used, as before.

I think the `package-db` field should probably be removed from `cabal.sandbox.config` completely, but I haven't yet investigated this.

@luite hopefully this will make `cabal configure -w ghcjs && cabal sandbox hc-pkg list` just do the right thing; please yell if not!