### PR TITLE
Backwards compatibility type synonym for InstalledPackageId.

### DIFF
--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -24,6 +24,7 @@ module Distribution.Package (
         -- * Package keys/installed package IDs (used for linker symbols)
         ComponentId(..),
         getHSLibraryName,
+        InstalledPackageId, -- backwards compat
 
         -- * Package source dependencies
         Dependency(..),
@@ -113,6 +114,8 @@ instance NFData PackageIdentifier where
 data ComponentId
     = ComponentId String
     deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+
+type InstalledPackageId = ComponentId
 
 instance Binary ComponentId
 


### PR DESCRIPTION
Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>