### PR TITLE
Use global db in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
  - GHCVER=7.8.4
  - GHCVER=7.10.1
  - GHCVER=7.10.2
+ # TODO add PARSEC_BUNDLED=YES when it's so
  - GHCVER=head
 
 # Note: the distinction between `before_install` and `install` is not important.
@@ -29,7 +30,7 @@ install:
 # build config format changed.
 script:
  # We depend on parsec nowadays, which isn't distributed with GHC <8.0
- - cabal install parsec
+ - if [ "$PARSEC_BUNDLED" != "YES" ]; then cabal install parsec; fi
 
 # Cabal
  - cd Cabal

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
  - GHCVER=7.6.3
  - GHCVER=7.8.4
  - GHCVER=7.10.1
+ - GHCVER=7.10.2
  - GHCVER=head
 
 # Note: the distinction between `before_install` and `install` is not important.
@@ -15,7 +16,7 @@ before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
  - travis_retry sudo apt-get install cabal-install-1.22 ghc-$GHCVER-prof ghc-$GHCVER-dyn happy
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/1.22/bin:$PATH
+ - export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/1.22/bin:$PATH
 
 install:
  - cabal update
@@ -27,23 +28,20 @@ install:
 # ./dist/setup/setup here instead of cabal-install to avoid breakage when the
 # build config format changed.
 script:
- - cabal sandbox init
+ # We depend on parsec nowadays, which isn't distributed with GHC <8.0
+ - cabal install parsec
+
+# Cabal
  - cd Cabal
  - mkdir -p ./dist/setup
  - cp Setup.hs ./dist/setup/setup.hs
-# Should be able to build setup without extra dependencies
- - /opt/ghc/$GHCVER/bin/ghc --make -odir ./dist/setup -hidir ./dist/setup -i -i. ./dist/setup/setup.hs -o ./dist/setup/setup -Wall -Werror -threaded  # the command cabal-install would use to build setup
+ - ghc --make -odir ./dist/setup -hidir ./dist/setup -i -i. ./dist/setup/setup.hs -o ./dist/setup/setup -Wall -Werror -threaded  # the command cabal-install would use to build setup
 
-# Need extra dependencies for test suite. Installing them into the common
-# sandbox speeds up the build a little.
- - cabal sandbox init --sandbox ../.cabal-sandbox
- - cabal install --only-dependencies --enable-tests
- - sudo /opt/ghc/$GHCVER/bin/ghc-pkg recache
- - /opt/ghc/$GHCVER/bin/ghc-pkg recache --user
-
- - ./dist/setup/setup configure --user --enable-tests --enable-benchmarks --ghc-option=-Werror -v2  --package-db=clear --package-db=global --package-db=../.cabal-sandbox/$(uname -i)-linux-ghc-$GHCVER-packages.conf.d # -v2 provides useful information for debugging
+# Install test dependencies only after setup is built
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks
+ - ./dist/setup/setup configure --user --ghc-option=-Werror --enable-tests --enable-benchmarks -v2 # -v2 provides useful information for debugging
  - ./dist/setup/setup build   # this builds all libraries and executables (including tests/benchmarks)
- - ./dist/setup/setup haddock # see #2198
+ - ./dist/setup/setup haddock # see https://github.com/haskell/cabal/issues/2198
  - ./dist/setup/setup test --show-details=streaming
  - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
@@ -64,14 +62,21 @@ script:
 
 # Also build cabal-install.
  - cd ../cabal-install
- - cabal sandbox init --sandbox ../.cabal-sandbox
- - cabal install --dependencies-only --enable-tests
- - cabal configure --enable-tests --ghc-option=-Werror
- - cabal build
- - cabal test
+ - mkdir -p ./dist/setup
+ - cp Setup.hs ./dist/setup/setup.hs
+ - ghc --make -odir ./dist/setup -hidir ./dist/setup -i -i. ./dist/setup/setup.hs -o ./dist/setup/setup -Wall -Werror -threaded  # the command cabal-install would use to build setup
+
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks
+ - ./dist/setup/setup configure --user --ghc-option=-Werror --enable-tests --enable-benchmarks -v2 # -v2 provides useful information for debugging
+ - ./dist/setup/setup build
+ - ./dist/setup/setup haddock # see https://github.com/haskell/cabal/issues/2198
+ - ./dist/setup/setup test --show-details=streaming
  - cabal check
  - cabal sdist
  - install_from_tarball
+
+# Check what we got
+ - $HOME/.cabal/bin/cabal --version
 
 matrix:
   allow_failures:

--- a/cabal-install/Setup.hs
+++ b/cabal-install/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+main :: IO ()
 main = defaultMain

--- a/cabal-install/tests/IntegrationTests/freeze/should_run/enable_benchmarks_freezes_bench_deps.sh
+++ b/cabal-install/tests/IntegrationTests/freeze/should_run/enable_benchmarks_freezes_bench_deps.sh
@@ -1,3 +1,4 @@
 . ../common.sh
-cabal freeze --enable-benchmarks
+# TODO: solver should find solution without extra flags too
+cabal freeze --enable-benchmarks --reorder-goals --max-backjumps=-1
 grep " criterion ==" cabal.config || die "should have frozen criterion"


### PR DESCRIPTION
Without sandbox, there are less moving parts, and tests seem to be more robust.