### PR TITLE
Simplify a few InstallPlan utils, and use setup deps in a few places

### DIFF
--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -42,7 +42,6 @@ import Distribution.Package
 import Distribution.Simple.Compiler
          ( Compiler, compilerInfo, PackageDBStack )
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
-import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.Simple.Program
          ( ProgramConfiguration )
 import Distribution.Simple.Setup
@@ -202,15 +201,14 @@ pruneInstallPlan :: InstallPlan
                  -> [PackageSpecifier SourcePackage]
                  -> [PlanPackage]
 pruneInstallPlan installPlan pkgSpecifiers =
-    either (const brokenPkgsErr)
-           (removeSelf pkgIds . PackageIndex.allPackages) $
-    InstallPlan.dependencyClosure installPlan pkgIds
+    removeSelf pkgIds $
+    InstallPlan.dependencyClosure installPlan (map fakeComponentId pkgIds)
   where
-    pkgIds = [ packageId pkg | SpecificSourcePackage pkg <- pkgSpecifiers ]
-    removeSelf [thisPkg] = filter (\pp -> packageId pp /= thisPkg)
+    pkgIds = [ packageId pkg
+             | SpecificSourcePackage pkg <- pkgSpecifiers ]
+    removeSelf [thisPkg] = filter (\pp -> packageId pp /= packageId thisPkg)
     removeSelf _  = error $ "internal error: 'pruneInstallPlan' given "
                          ++ "unexpected package specifiers!"
-    brokenPkgsErr = error "planPackages: installPlan contains broken packages"
 
 
 freezePackages :: Package pkg => Verbosity -> [pkg] -> IO ()

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -42,6 +42,9 @@ module Distribution.Client.InstallPlan (
 
   -- ** Querying the install plan
   dependencyClosure,
+  reverseDependencyClosure,
+  topologicalOrder,
+  reverseTopologicalOrder,
   ) where
 
 import Distribution.InstalledPackageInfo
@@ -606,3 +609,28 @@ dependencyClosure plan =
   . Graph.dfs (planGraph plan)
   . map (planVertexOf plan)
 
+
+reverseDependencyClosure :: GenericInstallPlan ipkg srcpkg iresult ifailure
+                         -> [ComponentId]
+                         -> [GenericPlanPackage ipkg srcpkg iresult ifailure]
+reverseDependencyClosure plan =
+    map (planPkgOf plan)
+  . concatMap Tree.flatten
+  . Graph.dfs (planGraphRev plan)
+  . map (planVertexOf plan)
+
+
+topologicalOrder :: GenericInstallPlan ipkg srcpkg iresult ifailure
+                 -> [GenericPlanPackage ipkg srcpkg iresult ifailure]
+topologicalOrder plan =
+    map (planPkgOf plan)
+  . Graph.topSort
+  $ planGraph plan
+
+
+reverseTopologicalOrder :: GenericInstallPlan ipkg srcpkg iresult ifailure
+                        -> [GenericPlanPackage ipkg srcpkg iresult ifailure]
+reverseTopologicalOrder plan =
+    map (planPkgOf plan)
+  . Graph.topSort
+  $ planGraphRev plan

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -520,7 +520,7 @@ problems fakeMap indepGoals index =
   ++ [ PackageStateInvalid pkg pkg'
      | pkg <- PackageIndex.allPackages index
      , Just pkg' <- map (PlanIndex.fakeLookupComponentId fakeMap index)
-                    (CD.nonSetupDeps (depends pkg))
+                    (CD.flatDeps (depends pkg))
      , not (stateDependencyRelation pkg pkg') ]
 
 -- | The graph of packages (nodes) and dependencies (edges) must be acyclic.

--- a/cabal-install/Distribution/Client/PlanIndex.hs
+++ b/cabal-install/Distribution/Client/PlanIndex.hs
@@ -106,7 +106,7 @@ brokenPackages fakeMap index =
   [ (pkg, missing)
   | pkg  <- allPackages index
   , let missing =
-          [ pkg' | pkg' <- CD.nonSetupDeps (depends pkg)
+          [ pkg' | pkg' <- CD.flatDeps (depends pkg)
                  , isNothing (fakeLookupComponentId fakeMap index pkg') ]
   , not (null missing) ]
 
@@ -232,7 +232,8 @@ dependencyCycles :: (PackageFixedDeps pkg, HasComponentId pkg)
 dependencyCycles fakeMap index =
   [ vs | Graph.CyclicSCC vs <- Graph.stronglyConnComp adjacencyList ]
   where
-    adjacencyList = [ (pkg, installedComponentId pkg, CD.nonSetupDeps (fakeDepends fakeMap pkg))
+    adjacencyList = [ (pkg, installedComponentId pkg,
+                            CD.flatDeps (fakeDepends fakeMap pkg))
                     | pkg <- allPackages index ]
 
 
@@ -290,5 +291,5 @@ dependencyGraph fakeMap index = (graph, vertexToPkg, idToVertex)
     resolve   pid = Map.findWithDefault pid pid fakeMap
     edgesFrom pkg = ( ()
                     , resolve (installedComponentId pkg)
-                    , CD.nonSetupDeps (fakeDepends fakeMap pkg)
+                    , CD.flatDeps (fakeDepends fakeMap pkg)
                     )

--- a/cabal-install/Distribution/Client/PlanIndex.hs
+++ b/cabal-install/Distribution/Client/PlanIndex.hs
@@ -11,22 +11,17 @@ module Distribution.Client.PlanIndex (
   , fakeLookupComponentId
     -- * Graph traversal functions
   , brokenPackages
-  , dependencyClosure
   , dependencyCycles
   , dependencyGraph
   , dependencyInconsistencies
-  , reverseDependencyClosure
-  , reverseTopologicalOrder
-  , topologicalOrder
   ) where
 
 import Prelude hiding (lookup)
 import qualified Data.Map as Map
-import qualified Data.Tree  as Tree
 import qualified Data.Graph as Graph
 import Data.Array ((!))
 import Data.Map (Map)
-import Data.Maybe (isNothing, fromMaybe, fromJust)
+import Data.Maybe (isNothing, fromJust)
 import Data.Either (rights)
 
 #if !MIN_VERSION_base(4,8,0)
@@ -223,7 +218,6 @@ dependencyInconsistencies' fakeMap index =
 
 
 
-
 -- | Find if there are any cycles in the dependency graph. If there are no
 -- cycles the result is @[]@.
 --
@@ -270,45 +264,6 @@ dependencyClosure fakeMap index pkgids0 = case closure mempty [] pkgids0 of
             Nothing -> closure completed' failed pkgids'
               where completed' = insert pkg completed
                     pkgids'    = CD.nonSetupDeps (depends pkg) ++ pkgids
-
-
-topologicalOrder :: (PackageFixedDeps pkg, HasComponentId pkg)
-                 => FakeMap -> PackageIndex pkg -> [pkg]
-topologicalOrder fakeMap index = map toPkgId
-                               . Graph.topSort
-                               $ graph
-  where (graph, toPkgId, _) = dependencyGraph fakeMap index
-
-
-reverseTopologicalOrder :: (PackageFixedDeps pkg, HasComponentId pkg)
-                        => FakeMap -> PackageIndex pkg -> [pkg]
-reverseTopologicalOrder fakeMap index = map toPkgId
-                                      . Graph.topSort
-                                      . Graph.transposeG
-                                      $ graph
-  where (graph, toPkgId, _) = dependencyGraph fakeMap index
-
-
--- | Takes the transitive closure of the packages reverse dependencies.
---
--- * The given 'PackageIdentifier's must be in the index.
---
-reverseDependencyClosure :: (PackageFixedDeps pkg, HasComponentId pkg)
-                         => FakeMap
-                         -> PackageIndex pkg
-                         -> [ComponentId]
-                         -> [pkg]
-reverseDependencyClosure fakeMap index =
-    map vertexToPkg
-  . concatMap Tree.flatten
-  . Graph.dfs reverseDepGraph
-  . map (fromMaybe noSuchPkgId . pkgIdToVertex)
-
-  where
-    (depGraph, vertexToPkg, pkgIdToVertex) = dependencyGraph fakeMap index
-    reverseDepGraph = Graph.transposeG depGraph
-    noSuchPkgId = error "reverseDependencyClosure: package is not in the graph"
-
 
 
 -- | Builds a graph of the package dependencies.


### PR DESCRIPTION
Main thing is that the Graph inside the InstallPlan now includes setup dep edges, which means things based on that now take setup deps into account. Also audited other uses of nonSetupDeps vs flatDeps in InstallPlan and the PlanIndex code.