### PR TITLE
Add --ipid-extra flag.

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -1310,8 +1310,9 @@ computeComponentId :: PackageDescription
             -- TODO: careful here!
             -> [ComponentId] -- IPIDs of the component dependencies
             -> FlagAssignment
+            -> String -- Any extra information you might want to add in
             -> IO ComponentId
-computeComponentId pkg_descr cname dep_ipids flagAssignment = do
+computeComponentId pkg_descr cname dep_ipids flagAssignment extra = do
     -- show is found to be faster than intercalate and then replacement of
     -- special character used in intercalating. We cannot simply hash by
     -- doubly concating list, as it just flatten out the nested list, so
@@ -1323,6 +1324,7 @@ computeComponentId pkg_descr cname dep_ipids flagAssignment = do
                 (display (package pkg_descr))
                       ++ (show $ dep_ipids)
                       ++ show flagAssignment
+                      ++ show extra
     return . ComponentId $
                 display (package pkg_descr)
                     ++ "-" ++ hash
@@ -1370,7 +1372,7 @@ mkComponentsLocalBuildInfo cfg comp installedPackages pkg_descr
                 str = fromPathTemplate (substPathTemplate env (toPathTemplate lib_hash0))
             in return (ComponentId str)
         _ ->
-          computeComponentId pkg_descr CLibName (getDeps CLibName) flagAssignment
+          computeComponentId pkg_descr CLibName (getDeps CLibName) flagAssignment (fromFlagOrDefault "" (configIPIDExtra cfg))
     let extractCandidateCompatKey s
             = case simpleParse s :: Maybe PackageId of
                 -- Something like 'foo-0.1', use it verbatim.

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -310,6 +310,7 @@ data ConfigFlags = ConfigFlags {
     configExtraLibDirs  :: [FilePath],   -- ^ path to search for extra libraries
     configExtraIncludeDirs :: [FilePath],   -- ^ path to search for header files
     configIPID          :: Flag String, -- ^ explicit IPID to be used
+    configIPIDExtra     :: Flag String, -- ^ extra string for IPID calculation
 
     configDistPref :: Flag FilePath, -- ^"dist" prefix
     configVerbosity :: Flag Verbosity, -- ^verbosity level
@@ -579,6 +580,11 @@ configureOptions showOrParseArgs =
          configIPID (\v flags -> flags {configIPID = v})
          (reqArgFlag "IPID")
 
+      ,option "" ["ipid-extra"]
+         "Extra information to incorporate into an installed package ID"
+         configIPIDExtra (\v flags -> flags {configIPIDExtra = v})
+         (reqArgFlag "STRING")
+
       ,option "" ["extra-lib-dirs"]
          "A list of directories to search for external libraries"
          configExtraLibDirs (\v flags -> flags {configExtraLibDirs = v})
@@ -802,6 +808,7 @@ instance Monoid ConfigFlags where
     configInstantiateWith     = mempty,
     configExtraIncludeDirs    = mempty,
     configIPID          = mempty,
+    configIPIDExtra     = mempty,
     configConfigurationsFlags = mempty,
     configTests               = mempty,
     configCoverage         = mempty,
@@ -848,6 +855,7 @@ instance Monoid ConfigFlags where
     configInstantiateWith     = combine configInstantiateWith,
     configExtraIncludeDirs    = combine configExtraIncludeDirs,
     configIPID          = combine configIPID,
+    configIPIDExtra     = combine configIPIDExtra,
     configConfigurationsFlags = combine configConfigurationsFlags,
     configTests               = combine configTests,
     configCoverage         = combine configCoverage,


### PR DESCRIPTION
This flag uses the default IPID generation algorithm, but
permits users to add some extra information which can be used
to ensure that the IPID is unique.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>