### PR TITLE
Solver: limit where package target constraints apply

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Package.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Package.hs
@@ -89,6 +89,15 @@ stripBase (Setup pn      pp) = Setup pn      (stripBase pp)
 stripBase (Base _pn      pp) =                stripBase pp
 stripBase None               = None
 
+-- | Is the package in the primary group of packages. In particular this
+-- does not include packages pulled in as setup deps.
+--
+primaryPP :: PP -> Bool
+primaryPP (Independent _ pp) = primaryPP pp
+primaryPP (Setup       _ _ ) = False
+primaryPP (Base        _ pp) = primaryPP pp
+primaryPP  None              = True
+
 -- | String representation of a package path.
 --
 -- NOTE: This always ends in a period


### PR DESCRIPTION
When we have a target like "foo-1.0", in terms of solver input this
gets turned into a target package name of "foo" and a (labelled)
constraint of "foo == 1.0". This constraint is of course to ensure
that we pick the right target. However, with the recent addition of
qualified package goals we have the possibility of picking multiple
versions of the same package (e.g. via setup deps). If we have a
constraint like "foo == 1.0" apply everywhere then it becomes
impossible to pick multiple versions of package "foo", which may
mean we cannot find a solution at all. But the constraint for the
target need not apply everywhere, it's just to ensure that for the
"main" instance, we pick the right version.

This patch makes that precise. We have these constraints arising
from targets apply only to package name goals that are suitably
unqualified: qualifications arising from independent goals and from
base version trickery are ok, but qualifiactions from setup deps
are not. Or to put it another way, these target constraints do not
apply to goals arising as the result of setup dependencies.

As a more concrete example, this allows a situation where a package
needs an old version of Cabal as a setup dep, but a new version of
Cabal is also present in the main part of the solution as a normal
library dep. Whenever we solve for that main Cabal lib as a target
it would previously fail (it would be impossible to satisfy the
conflicting constraints on the Cabal setup dep) and it now works.