### PR TITLE
Fix space leak in solver backjumping

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Log.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Log.hs
@@ -91,14 +91,16 @@ logToProgress mbj l = let
     go _  _           (Done s)              = Done s
     go _  _           (Fail (_, Nothing))   = Fail ("Could not resolve dependencies; something strange happened.") -- should not happen
 
-failWith :: m -> Log m a
-failWith m = Step m (Fail ())
+failWith :: step -> fail -> Progress step fail done
+failWith s f = Step s (Fail f)
 
-succeedWith :: m -> a -> Log m a
-succeedWith m x = Step m (Done x)
+succeedWith :: step -> done -> Progress step fail done
+succeedWith s d = Step s (Done d)
 
-continueWith :: m -> Log m a -> Log m a
+continueWith :: step -> Progress step fail done -> Progress step fail done
 continueWith = Step
 
-tryWith :: Message -> Log Message a -> Log Message a
-tryWith m x = Step m (Step Enter x) <|> failWith Leave
+tryWith :: Message
+        -> Progress Message fail done
+        -> Progress Message fail done
+tryWith m = Step m . Step Enter . foldProgress Step (failWith Leave) Done

--- a/cabal-install/Distribution/Client/Dependency/Modular/Log.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Log.hs
@@ -9,6 +9,7 @@ module Distribution.Client.Dependency.Modular.Log
 
 import Control.Applicative
 import Data.List as L
+import Data.Maybe (isNothing)
 import Data.Set as S
 
 import Distribution.Client.Dependency.Types -- from Cabal
@@ -25,79 +26,70 @@ import Distribution.Client.Dependency.Modular.Tree (FailReason(..))
 -- Parameterized over the type of actual messages and the final result.
 type Log m a = Progress m () a
 
--- | Turns a log into a list of messages paired with a final result. A final result
--- of 'Nothing' indicates failure. A final result of 'Just' indicates success.
--- Keep in mind that forcing the second component of the returned pair will force the
--- entire log.
-runLog :: Log m a -> ([m], Maybe a)
-runLog (Done x)       = ([], Just x)
-runLog (Fail _)       = ([], Nothing)
-runLog (Step m p)     = let
-                          (ms, r) = runLog p
-                        in
-                          (m : ms, r)
+messages :: Progress step fail done -> [step]
+messages = foldProgress (:) (const []) (const [])
 
 -- | Postprocesses a log file. Takes as an argument a limit on allowed backjumps.
 -- If the limit is 'Nothing', then infinitely many backjumps are allowed. If the
 -- limit is 'Just 0', backtracking is completely disabled.
 logToProgress :: Maybe Int -> Log Message a -> Progress String String a
 logToProgress mbj l = let
-                        (ms, s) = runLog l
-                        -- 'Nothing' for 's' means search tree exhaustively searched and failed
-                        (es, e) = proc 0 ms -- catch first error (always)
-                        -- 'Nothing' in 'e' means no backjump found
-                        (ns, t) = case mbj of
-                                     Nothing -> (ms, Nothing)
-                                     Just n  -> proc n ms
-                        -- 'Nothing' in 't' means backjump limit not reached
-                        -- prefer first error over later error
-                        (exh, r) = case t of
-                                     -- backjump limit not reached
-                                     Nothing -> case s of
-                                                  Nothing -> (True, e) -- failed after exhaustive search
-                                                  Just _  -> (True, Nothing) -- success
-                                     -- backjump limit reached; prefer first error
-                                     Just _  -> (False, e) -- failed after backjump limit was reached
+                        es = proc (Just 0) l -- catch first error (always)
+                        ms = useFirstError (proc mbj l)
                       in go es es -- trace for first error
-                            (showMessages (const True) True ns) -- shortened run
-                            r s exh
+                            (showMessages (const True) True ms) -- run with backjump limit applied
   where
-    -- Proc takes the allowed number of backjumps and a list of messages and explores the
-    -- message list until the maximum number of backjumps has been reached. The log until
-    -- that point as well as whether we have encountered an error or not are returned.
-    proc :: Int -> [Message] -> ([Message], Maybe (ConflictSet QPN))
-    proc _ []                             = ([], Nothing)
-    proc n (   Failure cs Backjump  : xs@(Leave : Failure cs' Backjump : _))
-      | cs == cs'                         = proc n xs -- repeated backjumps count as one
-    proc 0 (   Failure cs Backjump  : _ ) = ([], Just cs)
-    proc n (x@(Failure _  Backjump) : xs) = (\ ~(ys, r) -> (x : ys, r)) (proc (n - 1) xs)
-    proc n (x                       : xs) = (\ ~(ys, r) -> (x : ys, r)) (proc  n      xs)
+    -- Proc takes the allowed number of backjumps and a 'Progress' and explores the
+    -- messages until the maximum number of backjumps has been reached. It filters out
+    -- and ignores repeated backjumps. If proc reaches the backjump limit, it truncates
+    -- the 'Progress' and ends it with the last conflict set. Otherwise, it leaves the
+    -- original success result or replaces the original failure with 'Nothing'.
+    proc :: Maybe Int -> Progress Message a b -> Progress Message (Maybe (ConflictSet QPN)) b
+    proc _        (Done x)                          = Done x
+    proc _        (Fail _)                          = Fail Nothing
+    proc mbj'     (Step   (Failure cs Backjump) xs@(Step Leave (Step (Failure cs' Backjump) _)))
+      | cs == cs'                                   = proc mbj' xs -- repeated backjumps count as one
+    proc (Just 0) (Step   (Failure cs Backjump)  _) = Fail (Just cs)
+    proc (Just n) (Step x@(Failure _  Backjump) xs) = Step x (proc (Just (n - 1)) xs)
+    proc mbj'     (Step x                       xs) = Step x (proc mbj'           xs)
 
-    -- This function takes a lot of arguments. The first two are both supposed to be
-    -- the log up to the first error. That's the error that will always be printed in
-    -- case we do not find a solution. We pass this log twice, because we evaluate it
-    -- in parallel with the full log, but we also want to retain the reference to its
-    -- beginning for when we print it. This trick prevents a space leak!
+    -- Sets the conflict set from the first backjump as the final error, and records
+    -- whether the search was exhaustive.
+    useFirstError :: Progress Message (Maybe (ConflictSet QPN)) b
+                  -> Progress Message (Bool, Maybe (ConflictSet QPN)) b
+    useFirstError = replace Nothing
+      where
+        replace _       (Done x)                          = Done x
+        replace cs'     (Fail cs)                         = -- 'Nothing' means backjump limit not reached.
+                                                            -- Prefer first error over later error.
+                                                            Fail (isNothing cs, cs' <|> cs)
+        replace Nothing (Step x@(Failure cs Backjump) xs) = Step x $ replace (Just cs) xs
+        replace cs'     (Step x                       xs) = Step x $ replace cs' xs
+
+    -- The first two arguments are both supposed to be the log up to the first error.
+    -- That's the error that will always be printed in case we do not find a solution.
+    -- We pass this log twice, because we evaluate it in parallel with the full log,
+    -- but we also want to retain the reference to its beginning for when we print it.
+    -- This trick prevents a space leak!
     --
-    -- The third argument is the full log, the fifth and six error conditions.
-    -- The seventh argument indicates whether the search was exhaustive.
-    --
-    -- The order of arguments is important! In particular 's' must not be evaluated
-    -- unless absolutely necessary. It contains the final result, and if we shortcut
-    -- with an error due to backjumping, evaluating 's' would still require traversing
-    -- the entire tree.
-    go ms (_ : ns) (x : xs) r         s        exh = Step x (go ms ns xs r s exh)
-    go ms []       (x : xs) r         s        exh = Step x (go ms [] xs r s exh)
-    go ms _        []       (Just cs) _        exh = Fail $
-                                                     "Could not resolve dependencies:\n" ++
-                                                     unlines (showMessages (L.foldr (\ v _ -> v `S.member` cs) True) False ms) ++
-                                                     (if exh then "Dependency tree exhaustively searched.\n"
-                                                             else "Backjump limit reached (" ++ currlimit mbj ++
-                                                                      "change with --max-backjumps or try to run with --reorder-goals).\n")
-                                                         where currlimit (Just n) = "currently " ++ show n ++ ", "
-                                                               currlimit Nothing  = ""
-    go _  _        []       _         (Just s) _   = Done s
-    go _  _        []       _         _        _   = Fail ("Could not resolve dependencies; something strange happened.") -- should not happen
+    -- The third argument is the full log, ending with either the solution or the
+    -- exhaustiveness and first conflict set.
+    go :: Progress Message a b
+       -> Progress Message a b
+       -> Progress String (Bool, Maybe (ConflictSet QPN)) b
+       -> Progress String String b
+    go ms (Step _ ns) (Step x xs)           = Step x (go ms ns xs)
+    go ms r           (Step x xs)           = Step x (go ms r  xs)
+    go ms _           (Fail (exh, Just cs)) = Fail $
+                                              "Could not resolve dependencies:\n" ++
+                                              unlines (messages $ showMessages (L.foldr (\ v _ -> v `S.member` cs) True) False ms) ++
+                                              (if exh then "Dependency tree exhaustively searched.\n"
+                                                      else "Backjump limit reached (" ++ currlimit mbj ++
+                                                               "change with --max-backjumps or try to run with --reorder-goals).\n")
+                                                  where currlimit (Just n) = "currently " ++ show n ++ ", "
+                                                        currlimit Nothing  = ""
+    go _  _           (Done s)              = Done s
+    go _  _           (Fail (_, Nothing))   = Fail ("Could not resolve dependencies; something strange happened.") -- should not happen
 
 failWith :: m -> Log m a
 failWith m = Step m (Fail ())

--- a/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
@@ -46,7 +46,7 @@ solve sc cinfo idx userPrefs userConstraints userGoals =
   prunePhase       $
   buildPhase
   where
-    explorePhase     = exploreTreeLog . backjump
+    explorePhase     = backjumpAndExplore
     heuristicsPhase  = P.firstGoal . -- after doing goal-choice heuristics, commit to the first choice (saves space)
                        P.deferSetupChoices .
                        P.deferWeakFlagChoices .


### PR DESCRIPTION
This commit refactors backjumping so that it uses the `Progress` type instead of
separate references to a node's children and the conflict set calculated from
those children.  The behavior should be unchanged.

I added to #2914 so that I could test memory usage more easily.  These heap profiles were generated with `cabal --ignore-sandbox install --dry-run --max-backjumps -1 hackage-server-0.4 aeson yesod --with-compiler C:/ghc-7.6.3_64/bin/ghc +RTS -p -s -h -L50`.

after #2914 (https://github.com/haskell/cabal/commit/90c777299251deda571083ec0b95b68ca20e0873):
![cabal-refactored-logging](https://cloud.githubusercontent.com/assets/4276753/11019389/c4b64036-85ab-11e5-9097-10bb2e702940.png)

after both commits (https://github.com/haskell/cabal/commit/c1189c3d61585207e99818531e3cd990d4babf3a):
![cabal](https://cloud.githubusercontent.com/assets/4276753/11019366/f4cd1cfa-85aa-11e5-8af5-481f1eb0c0dc.png)

longer run with both commits, using ` -i10`.  I don't know why it increases later.
![cabal-longer-run](https://cloud.githubusercontent.com/assets/4276753/11019369/fcc05364-85aa-11e5-8f3c-0ef2826c3bb0.png)

I have a few concerns about this PR.  I combined backjumping and exploring the tree into one traversal, which is less modular.  Is there a way that we could use two passes without storing conflict sets directly on the tree's nodes?  The `combine` function is also less recognizable after the refactoring.  I'd like to make it clearer, if possible.

~~I deleted several unused functions that didn't compile with my change, such as `explore`.  Is that alright, or should I refactor them?~~