### PR TITLE
Make `cabal init` reject extra arguments.

### DIFF
--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -1132,7 +1132,9 @@ unpackAction getFlags extraArgs globalFlags = do
   getAction getFlags extraArgs globalFlags
 
 initAction :: InitFlags -> [String] -> Action
-initAction initFlags _extraArgs globalFlags = do
+initAction initFlags extraArgs globalFlags = do
+  when (extraArgs /= []) $
+    die $ "'init' doesn't take any extra arguments: " ++ unwords extraArgs
   let verbosity = fromFlag (initVerbosity initFlags)
   (_useSandbox, config) <- loadConfigOrSandboxConfig verbosity
                            (globalFlags { globalRequireSandbox = Flag False })


### PR DESCRIPTION
This is better than ignoring them because one is likely in some state of
confusion when passing extraneous arguments to `cabal init` and would
probably appreciate being taken out of that state sooner rather than
later.