### PR TITLE
Disable Ar.wipeMetadata for AIX

### DIFF
--- a/Cabal/Distribution/Simple/Program/Ar.hs
+++ b/Cabal/Distribution/Simple/Program/Ar.hs
@@ -84,7 +84,8 @@ createArLibArchive verbosity lbi targetPath files = do
         | inv <- multiStageProgramInvocation
                    simple (initial, middle, final) files ]
 
-  unless (hostArch == Arm) $ -- See #1537
+  unless (hostArch == Arm -- See #1537
+          || hostOS == AIX) $ -- AIX uses its own "ar" format variant
     wipeMetadata tmpPath
   equal <- filesEqual tmpPath targetPath
   unless equal $ renameFile tmpPath targetPath


### PR DESCRIPTION
AIX uses its own `ar` format variant (with a different header),
which causes Cabal to abort with

    Distribution.Simple.Program.Ar.wipeMetadata: Bad global header

This patch simply disables this non-essential operation for AIX.