### PR TITLE
Use explicit export lists for modular solver

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Assignment.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Assignment.hs
@@ -1,4 +1,12 @@
-module Distribution.Client.Dependency.Modular.Assignment where
+module Distribution.Client.Dependency.Modular.Assignment
+    ( Assignment(..)
+    , FAssignment
+    , SAssignment
+    , PreAssignment(..)
+    , extend
+    , finalize
+    , toCPs
+    ) where
 
 import Control.Applicative
 import Control.Monad

--- a/cabal-install/Distribution/Client/Dependency/Modular/Builder.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Builder.hs
@@ -24,7 +24,8 @@ import Distribution.Client.Dependency.Modular.Dependency
 import Distribution.Client.Dependency.Modular.Flag
 import Distribution.Client.Dependency.Modular.Index
 import Distribution.Client.Dependency.Modular.Package
-import Distribution.Client.Dependency.Modular.PSQ as P
+import Distribution.Client.Dependency.Modular.PSQ (PSQ)
+import qualified Distribution.Client.Dependency.Modular.PSQ as P
 import Distribution.Client.Dependency.Modular.Tree
 
 import Distribution.Client.ComponentDeps (Component)
@@ -61,7 +62,7 @@ extendOpen qpn' gs s@(BS { rdeps = gs', open = o' }) = go gs' o' gs
     go g o (   (OpenGoal (Simple (Ext _ext ) _) _gr) : ngs) = go g o ngs
     go g o (   (OpenGoal (Simple (Lang _lang)_) _gr) : ngs) = go g o ngs
 
-    cons' = cons . forgetCompOpenGoal
+    cons' = P.cons . forgetCompOpenGoal
 
 -- | Given the current scope, qualify all the package names in the given set of
 -- dependencies and then extend the set of open goals accordingly.

--- a/cabal-install/Distribution/Client/Dependency/Modular/Configured.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Configured.hs
@@ -1,4 +1,6 @@
-module Distribution.Client.Dependency.Modular.Configured where
+module Distribution.Client.Dependency.Modular.Configured
+    ( CP(..)
+    ) where
 
 import Distribution.PackageDescription (FlagAssignment) -- from Cabal
 import Distribution.Client.Types (OptionalStanza)

--- a/cabal-install/Distribution/Client/Dependency/Modular/ConfiguredConversion.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/ConfiguredConversion.hs
@@ -1,4 +1,6 @@
-module Distribution.Client.Dependency.Modular.ConfiguredConversion where
+module Distribution.Client.Dependency.Modular.ConfiguredConversion
+    ( convCP
+    ) where
 
 import Data.Maybe
 import Prelude hiding (pi)

--- a/cabal-install/Distribution/Client/Dependency/Modular/Explore.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Explore.hs
@@ -1,4 +1,8 @@
-module Distribution.Client.Dependency.Modular.Explore where
+module Distribution.Client.Dependency.Modular.Explore
+    ( backjump
+    , exploreTree
+    , exploreTreeLog
+    ) where
 
 import Control.Applicative as A
 import Data.Foldable
@@ -11,7 +15,7 @@ import Distribution.Client.Dependency.Modular.Dependency
 import Distribution.Client.Dependency.Modular.Log
 import Distribution.Client.Dependency.Modular.Message
 import Distribution.Client.Dependency.Modular.Package
-import Distribution.Client.Dependency.Modular.PSQ as P
+import qualified Distribution.Client.Dependency.Modular.PSQ as P
 import Distribution.Client.Dependency.Modular.Tree
 
 -- | Backjumping.
@@ -93,7 +97,7 @@ explore = cata go
         (\ k r -> r (A pa fa (M.insert qsn k sa))) -- record the flag choice
       ts
     go (GoalChoiceF        ts) a              =
-      casePSQ ts A.empty                      -- empty goal choice is an internal error
+      P.casePSQ ts A.empty                    -- empty goal choice is an internal error
         (\ _k v _xs -> v a)                   -- commit to the first goal choice
 
 -- | Version of 'explore' that returns a 'Log'.
@@ -125,7 +129,7 @@ exploreLog = cata go
                     r (A pa fa (M.insert qsn k sa))) -- record the pkg choice
       ts
     go (GoalChoiceF        ts) a           =
-      casePSQ ts
+      P.casePSQ ts
         (failWith (Failure S.empty EmptyGoalChoice))   -- empty goal choice is an internal error
         (\ k v _xs -> continueWith (Next (close k)) (v a))     -- commit to the first goal choice
 

--- a/cabal-install/Distribution/Client/Dependency/Modular/Flag.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Flag.hs
@@ -1,5 +1,20 @@
 {-# LANGUAGE DeriveFunctor #-}
-module Distribution.Client.Dependency.Modular.Flag where
+module Distribution.Client.Dependency.Modular.Flag
+    ( FInfo(..)
+    , Flag
+    , FlagInfo
+    , FN(..)
+    , QFN
+    , QSN
+    , SN(..)
+    , getPN
+    , mkFlag
+    , showFBool
+    , showQFN
+    , showQFNBool
+    , showQSN
+    , showQSNBool
+    ) where
 
 import Data.Map as M
 import Prelude hiding (pi)

--- a/cabal-install/Distribution/Client/Dependency/Modular/Index.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Index.hs
@@ -1,4 +1,9 @@
-module Distribution.Client.Dependency.Modular.Index where
+module Distribution.Client.Dependency.Modular.Index
+    ( Index
+    , PInfo(..)
+    , defaultQualifyOptions
+    , mkIndex
+    ) where
 
 import Data.List as L
 import Data.Map as M

--- a/cabal-install/Distribution/Client/Dependency/Modular/Log.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Log.hs
@@ -1,4 +1,13 @@
-module Distribution.Client.Dependency.Modular.Log where
+module Distribution.Client.Dependency.Modular.Log
+    ( Log
+    , continueWith
+    , failWith
+    , logToProgress
+    , logToProgress'
+    , runLogIO
+    , succeedWith
+    , tryWith
+    ) where
 
 import Control.Applicative
 import Data.List as L

--- a/cabal-install/Distribution/Client/Dependency/Modular/PSQ.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/PSQ.hs
@@ -1,5 +1,28 @@
 {-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveFoldable, DeriveTraversable #-}
-module Distribution.Client.Dependency.Modular.PSQ where
+module Distribution.Client.Dependency.Modular.PSQ
+    ( PSQ(..)  -- Unit test needs constructor access
+    , casePSQ
+    , cons
+    , delete
+    , length
+    , llength
+    , lookup
+    , filter
+    , filterKeys
+    , fromList
+    , keys
+    , map
+    , mapKeys
+    , mapWithKey
+    , mapWithKeyState
+    , null
+    , snoc
+    , sortBy
+    , sortByKeys
+    , splits
+    , toList
+    , union
+    ) where
 
 -- Priority search queues.
 --
@@ -8,14 +31,14 @@ module Distribution.Client.Dependency.Modular.PSQ where
 -- (inefficiently implemented) lookup, because I think that queue-based
 -- operations and sorting turn out to be more efficiency-critical in practice.
 
-import Data.Foldable
+import qualified Data.Foldable as F
 import Data.Function
-import Data.List as S hiding (foldr)
+import qualified Data.List as S
 import Data.Traversable
-import Prelude hiding (foldr)
+import Prelude hiding (foldr, length, lookup, filter, null, map)
 
 newtype PSQ k v = PSQ [(k, v)]
-  deriving (Eq, Show, Functor, Foldable, Traversable)
+  deriving (Eq, Show, Functor, F.Foldable, Traversable) -- Qualified Foldable to avoid issues with FTP
 
 keys :: PSQ k v -> [k]
 keys (PSQ xs) = fmap fst xs
@@ -34,12 +57,12 @@ mapWithKey f (PSQ xs) = PSQ (fmap (\ (k, v) -> (k, f k v)) xs)
 
 mapWithKeyState :: (s -> k -> a -> (b, s)) -> PSQ k a -> s -> PSQ k b
 mapWithKeyState p (PSQ xs) s0 =
-  PSQ (foldr (\ (k, v) r s -> case p s k v of
-                                (w, n) -> (k, w) : (r n))
-             (const []) xs s0)
+  PSQ (F.foldr (\ (k, v) r s -> case p s k v of
+                                  (w, n) -> (k, w) : (r n))
+               (const []) xs s0)
 
 delete :: Eq k => k -> PSQ k a -> PSQ k a
-delete k (PSQ xs) = PSQ (snd (partition ((== k) . fst) xs))
+delete k (PSQ xs) = PSQ (snd (S.partition ((== k) . fst) xs))
 
 fromList :: [(k, a)] -> PSQ k a
 fromList = PSQ

--- a/cabal-install/Distribution/Client/Dependency/Modular/Package.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Package.hs
@@ -1,7 +1,28 @@
 {-# LANGUAGE DeriveFunctor #-}
 module Distribution.Client.Dependency.Modular.Package
-  (module Distribution.Client.Dependency.Modular.Package,
-   module Distribution.Package) where
+  ( ComponentId
+  , I(..)
+  , Loc(..)
+  , PackageId
+  , PackageIdentifier(..)
+  , PackageName(..)
+  , PI(..)
+  , PN
+  , PP(..)
+  , QPN
+  , QPV
+  , Q(..)
+  , instI
+  , instPI
+  , makeIndependent
+  , primaryPP
+  , showI
+  , showPI
+  , showQPN
+  , stripBase
+  , unPN
+  , unQualify
+  ) where
 
 import Data.List as L
 

--- a/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
@@ -1,5 +1,22 @@
 {-# LANGUAGE CPP #-}
-module Distribution.Client.Dependency.Modular.Preference where
+module Distribution.Client.Dependency.Modular.Preference
+    ( avoidReinstalls
+    , deferSetupChoices
+    , deferWeakFlagChoices
+    , enforceManualFlags
+    , enforcePackageConstraints
+    , enforceSingleInstanceRestriction
+    , firstGoal
+    , lpreferEasyGoalChoices
+    , preferBaseGoalChoice
+    , preferEasyGoalChoices
+    , preferEasyGoalChoices'
+    , preferInstalled
+    , preferLatest
+    , preferLinked
+    , preferPackagePreferences
+    , requireInstalled
+    ) where
 
 -- Reordering or pruning the tree in order to prefer or make certain choices.
 
@@ -25,7 +42,7 @@ import Distribution.Client.Types
 import Distribution.Client.Dependency.Modular.Dependency
 import Distribution.Client.Dependency.Modular.Flag
 import Distribution.Client.Dependency.Modular.Package
-import Distribution.Client.Dependency.Modular.PSQ as P
+import qualified Distribution.Client.Dependency.Modular.PSQ as P
 import Distribution.Client.Dependency.Modular.Tree
 import Distribution.Client.Dependency.Modular.Version
 
@@ -251,7 +268,7 @@ avoidReinstalls p = trav go
       | otherwise = PChoiceF qpn gr cs
       where
         disableReinstalls =
-          let installed = [ v | (POption (I v (Inst _)) _, _) <- toList cs ]
+          let installed = [ v | (POption (I v (Inst _)) _, _) <- P.toList cs ]
           in  P.mapWithKey (notReinstall installed) cs
 
         notReinstall vs (POption (I v InRepo) _) _ | v `elem` vs =
@@ -269,8 +286,8 @@ avoidReinstalls p = trav go
 firstGoal :: Tree a -> Tree a
 firstGoal = trav go
   where
-    go (GoalChoiceF xs) = -- casePSQ xs (GoalChoiceF xs) (\ _ t _ -> out t) -- more space efficient, but removes valuable debug info
-                          casePSQ xs (GoalChoiceF (fromList [])) (\ g t _ -> GoalChoiceF (fromList [(g, t)]))
+    go (GoalChoiceF xs) = -- P.casePSQ xs (GoalChoiceF xs) (\ _ t _ -> out t) -- more space efficient, but removes valuable debug info
+                          P.casePSQ xs (GoalChoiceF (P.fromList [])) (\ g t _ -> GoalChoiceF (P.fromList [(g, t)]))
     go x                = x
     -- Note that we keep empty choice nodes, because they mean success.
 

--- a/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
@@ -1,4 +1,7 @@
-module Distribution.Client.Dependency.Modular.Solver where
+module Distribution.Client.Dependency.Modular.Solver
+    ( SolverConfig(..)
+    , solve
+    ) where
 
 import Data.Map as M
 

--- a/cabal-install/Distribution/Client/Dependency/Modular/Tree.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Tree.hs
@@ -1,5 +1,20 @@
 {-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
-module Distribution.Client.Dependency.Modular.Tree where
+module Distribution.Client.Dependency.Modular.Tree
+    ( FailReason(..)
+    , POption(..)
+    , Tree(..)
+    , TreeF(..)
+    , ana
+    , anaM
+    , cata
+    , cataM
+    , choices
+    , inn
+    , innM
+    , lchoices
+    , para
+    , trav
+    ) where
 
 import Control.Monad hiding (mapM, sequence)
 import Data.Foldable
@@ -9,7 +24,8 @@ import Prelude hiding (foldr, mapM, sequence)
 import Distribution.Client.Dependency.Modular.Dependency
 import Distribution.Client.Dependency.Modular.Flag
 import Distribution.Client.Dependency.Modular.Package
-import Distribution.Client.Dependency.Modular.PSQ as P
+import Distribution.Client.Dependency.Modular.PSQ (PSQ)
+import qualified Distribution.Client.Dependency.Modular.PSQ as P
 import Distribution.Client.Dependency.Modular.Version
 import Distribution.Client.Dependency.Types ( ConstraintSource(..) )
 

--- a/cabal-install/Distribution/Client/Dependency/Modular/Validate.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Validate.hs
@@ -23,7 +23,7 @@ import Distribution.Client.Dependency.Modular.Dependency
 import Distribution.Client.Dependency.Modular.Flag
 import Distribution.Client.Dependency.Modular.Index
 import Distribution.Client.Dependency.Modular.Package
-import Distribution.Client.Dependency.Modular.PSQ as P
+import qualified Distribution.Client.Dependency.Modular.PSQ as P
 import Distribution.Client.Dependency.Modular.Tree
 
 import Distribution.Client.ComponentDeps (Component)

--- a/cabal-install/Distribution/Client/Dependency/Modular/Version.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Version.hs
@@ -1,4 +1,16 @@
-module Distribution.Client.Dependency.Modular.Version where
+module Distribution.Client.Dependency.Modular.Version
+    ( Ver
+    , VR
+    , anyVR
+    , checkVR
+    , eqVR
+    , mkV
+    , showVer
+    , showVR
+    , simplifyVR
+    , (.&&.)
+    , (.||.)
+    ) where
 
 import qualified Distribution.Version as CV -- from Cabal
 import Distribution.Text -- from Cabal


### PR DESCRIPTION
Using explicit export lists allows for trivial detection of dead code,
and this commit also removes quite a bit of said dead code.

---
This is preliminary work to separating out the solver into its own package.