### PR TITLE
Improve algorithm for choosing flags with `./Setup configure`

### DIFF
--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -189,7 +189,7 @@ instance Monoid d => Mon.Monoid (DepTestRslt d) where
     mappend (MissingDeps d) (MissingDeps d') = MissingDeps (d `mappend` d')
 
 
-data BT a = BTN a | BTB (BT a) (BT a)  -- very simple binary tree
+data Tree a = Tree a [Tree a]
 
 
 -- | Try to find a flag assignment that satisfies the constraints of all trees.
@@ -224,10 +224,7 @@ resolveWithFlags ::
   -> Either [Dependency] (TargetSet PDTagged, FlagAssignment)
        -- ^ Either the missing dependencies (error case), or a pair of
        -- (set of build targets with dependencies, chosen flag assignments)
-resolveWithFlags dom os arch impl constrs trees checkDeps =
-    case try dom [] of
-      Right r -> Right r
-      Left dbt -> Left $ findShortest dbt
+resolveWithFlags dom os arch impl constrs trees checkDeps = explore $ build dom []
   where
     extraConstrs = toDepMap constrs
 
@@ -241,44 +238,53 @@ resolveWithFlags dom os arch impl constrs trees checkDeps =
     -- either succeeds or returns a binary tree with the missing dependencies
     -- encountered in each run.  Since the tree is constructed lazily, we
     -- avoid some computation overhead in the successful case.
-    try [] flags =
+    explore :: Tree FlagAssignment
+            -> Either [Dependency] (TargetSet PDTagged, FlagAssignment)
+    explore (Tree flags ts) =
         let targetSet = TargetSet $ flip map simplifiedTrees $
                 -- apply additional constraints to all dependencies
                 first (`constrainBy` extraConstrs) .
                 simplifyCondTree (env flags)
             deps = overallDependencies targetSet
         in case checkDeps (fromDepMap deps) of
-             DepOk           -> Right (targetSet, flags)
-             MissingDeps mds -> Left (BTN mds)
+             DepOk | null ts   -> Right (targetSet, flags)
+                   | otherwise -> tryAll $ map explore ts
+             MissingDeps mds   -> Left mds
 
-    try ((n, vals):rest) flags =
-        tryAll $ map (\v -> try rest ((n, v):flags)) vals
+    build :: [(FlagName, [Bool])]
+          -> FlagAssignment
+          -> Tree FlagAssignment
+    build [] flags = Tree flags []
+    build ((n, vals):rest) flags =
+        Tree flags $ map (\v -> build rest ((n, v):flags)) vals
 
+    tryAll :: [Either [a] b] -> Either [a] b
     tryAll = foldr mp mz
 
     -- special version of `mplus' for our local purposes
-    mp (Left xs)   (Left ys)   = (Left (BTB xs ys))
-    mp (Left _)    m@(Right _) = m
+    mp :: Either [a] b -> Either [a] b -> Either [a] b
     mp m@(Right _) _           = m
+    mp _           m@(Right _) = m
+    mp (Left xs)   (Left ys)   = let shortest = findShortest xs ys
+                                 in shortest `seq` Left shortest
 
     -- `mzero'
-    mz = Left (BTN [])
+    mz :: Either [a] b
+    mz = Left []
 
+    env :: FlagAssignment -> FlagName -> Either FlagName Bool
     env flags flag = (maybe (Left flag) Right . lookup flag) flags
 
     -- for the error case we inspect our lazy tree of missing dependencies and
     -- pick the shortest list of missing dependencies
-    findShortest (BTN x) = x
-    findShortest (BTB lt rt) =
-        let l = findShortest lt
-            r = findShortest rt
-        in case (l,r) of
-             ([], xs) -> xs  -- [] is too short
-             (xs, []) -> xs
-             ([x], _) -> [x] -- single elem is optimum
-             (_, [x]) -> [x]
-             (xs, ys) -> if lazyLengthCmp xs ys
-                         then xs else ys
+    findShortest l r =
+        case (l,r) of
+          ([], xs) -> xs  -- [] is too short
+          (xs, []) -> xs
+          ([x], _) -> [x] -- single elem is optimum
+          (_, [x]) -> [x]
+          (xs, ys) -> if lazyLengthCmp xs ys
+                      then xs else ys
     -- lazy variant of @\xs ys -> length xs <= length ys@
     lazyLengthCmp [] _ = True
     lazyLengthCmp _ [] = False
@@ -301,6 +307,8 @@ toDepMap ds =
 fromDepMap :: DependencyMap -> [Dependency]
 fromDepMap m = [ Dependency p vr | (p,vr) <- toList (unDependencyMap m) ]
 
+-- | Flattens a CondTree using a partial flag assignment.  When a condition
+-- cannot be evaluated, both branches are ignored.
 simplifyCondTree :: (Monoid a, Monoid d) =>
                     (v -> Either v Bool)
                  -> CondTree v d a
@@ -312,7 +320,7 @@ simplifyCondTree env (CondNode a d ifs) =
         case simplifyCondition cnd env of
           (Lit True, _) -> Just $ simplifyCondTree env t
           (Lit False, _) -> fmap (simplifyCondTree env) me
-          _ -> error $ "Environment not defined for all free vars"
+          _ -> Nothing
 
 -- | Flatten a CondTree.  This will resolve the CondTree by taking all
 --  possible paths into account.  Note that since branches represent exclusive

--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -39,7 +39,8 @@ import Distribution.PackageDescription
 import Distribution.PackageDescription.Utils
          ( cabalBug, userBug )
 import Distribution.Version
-         ( VersionRange, anyVersion, intersectVersionRanges, withinRange )
+         ( VersionRange, anyVersion, intersectVersionRanges
+         , simplifyVersionRange, unionVersionRanges, withinRange )
 import Distribution.Compiler
          ( CompilerId(CompilerId) )
 import Distribution.System
@@ -198,8 +199,9 @@ data Tree a = Tree a [Tree a]
 -- resulting data, the associated dependencies, and the chosen flag
 -- assignments.
 --
--- In case of failure, the _smallest_ number of of missing dependencies is
--- returned. [TODO: Could also be specified with a function argument.]
+-- In case of failure, the union of the dependencies that led to backtracking
+-- on all branches is returned.
+-- [TODO: Could also be specified with a function argument.]
 --
 -- TODO: The current algorithm is rather naive.  A better approach would be to:
 --
@@ -224,7 +226,8 @@ resolveWithFlags ::
   -> Either [Dependency] (TargetSet PDTagged, FlagAssignment)
        -- ^ Either the missing dependencies (error case), or a pair of
        -- (set of build targets with dependencies, chosen flag assignments)
-resolveWithFlags dom os arch impl constrs trees checkDeps = explore $ build dom []
+resolveWithFlags dom os arch impl constrs trees checkDeps =
+    either (Left . fromDepMapUnion) Right $ explore (build dom [])
   where
     extraConstrs = toDepMap constrs
 
@@ -234,12 +237,13 @@ resolveWithFlags dom os arch impl constrs trees checkDeps = explore $ build dom 
                           . mapTreeConds (fst . simplifyWithSysParams os arch impl))
                           trees
 
-    -- @try@ recursively tries all possible flag assignments in the domain and
-    -- either succeeds or returns a binary tree with the missing dependencies
-    -- encountered in each run.  Since the tree is constructed lazily, we
-    -- avoid some computation overhead in the successful case.
+    -- @explore@ searches a tree of assignments, backtracking whenever a flag
+    -- introduces a dependency that cannot be satisfied.  If there is no
+    -- solution, @explore@ returns the union of all dependencies that caused
+    -- it to backtrack.  Since the tree is constructed lazily, we avoid some
+    -- computation overhead in the successful case.
     explore :: Tree FlagAssignment
-            -> Either [Dependency] (TargetSet PDTagged, FlagAssignment)
+            -> Either DepMapUnion (TargetSet PDTagged, FlagAssignment)
     explore (Tree flags ts) =
         let targetSet = TargetSet $ flip map simplifiedTrees $
                 -- apply additional constraints to all dependencies
@@ -249,46 +253,44 @@ resolveWithFlags dom os arch impl constrs trees checkDeps = explore $ build dom 
         in case checkDeps (fromDepMap deps) of
              DepOk | null ts   -> Right (targetSet, flags)
                    | otherwise -> tryAll $ map explore ts
-             MissingDeps mds   -> Left mds
+             MissingDeps mds   -> Left (toDepMapUnion mds)
 
-    build :: [(FlagName, [Bool])]
-          -> FlagAssignment
-          -> Tree FlagAssignment
+    -- Builds a tree of all possible flag assignments.  Internal nodes
+    -- have only partial assignments.
+    build :: [(FlagName, [Bool])] -> FlagAssignment -> Tree FlagAssignment
     build [] flags = Tree flags []
     build ((n, vals):rest) flags =
         Tree flags $ map (\v -> build rest ((n, v):flags)) vals
 
-    tryAll :: [Either [a] b] -> Either [a] b
+    tryAll :: [Either DepMapUnion a] -> Either DepMapUnion a
     tryAll = foldr mp mz
 
     -- special version of `mplus' for our local purposes
-    mp :: Either [a] b -> Either [a] b -> Either [a] b
+    mp :: Either DepMapUnion a -> Either DepMapUnion a -> Either DepMapUnion a
     mp m@(Right _) _           = m
     mp _           m@(Right _) = m
-    mp (Left xs)   (Left ys)   = let shortest = findShortest xs ys
-                                 in shortest `seq` Left shortest
+    mp (Left xs)   (Left ys)   =
+        let union = Map.foldrWithKey (Map.insertWith' combine)
+                    (unDepMapUnion xs) (unDepMapUnion ys)
+            combine x y = simplifyVersionRange $ unionVersionRanges x y
+        in union `seq` Left (DepMapUnion union)
 
     -- `mzero'
-    mz :: Either [a] b
-    mz = Left []
+    mz :: Either DepMapUnion a
+    mz = Left (DepMapUnion Map.empty)
 
     env :: FlagAssignment -> FlagName -> Either FlagName Bool
     env flags flag = (maybe (Left flag) Right . lookup flag) flags
 
-    -- for the error case we inspect our lazy tree of missing dependencies and
-    -- pick the shortest list of missing dependencies
-    findShortest l r =
-        case (l,r) of
-          ([], xs) -> xs  -- [] is too short
-          (xs, []) -> xs
-          ([x], _) -> [x] -- single elem is optimum
-          (_, [x]) -> [x]
-          (xs, ys) -> if lazyLengthCmp xs ys
-                      then xs else ys
-    -- lazy variant of @\xs ys -> length xs <= length ys@
-    lazyLengthCmp [] _ = True
-    lazyLengthCmp _ [] = False
-    lazyLengthCmp (_:xs) (_:ys) = lazyLengthCmp xs ys
+-- | A map of dependencies that combines version ranges using 'unionVersionRanges'.
+newtype DepMapUnion = DepMapUnion { unDepMapUnion :: Map PackageName VersionRange }
+
+toDepMapUnion :: [Dependency] -> DepMapUnion
+toDepMapUnion ds =
+  DepMapUnion $ fromListWith unionVersionRanges [ (p,vr) | Dependency p vr <- ds ]
+
+fromDepMapUnion :: DepMapUnion -> [Dependency]
+fromDepMapUnion m = [ Dependency p vr | (p,vr) <- toList (unDepMapUnion m) ]
 
 -- | A map of dependencies.  Newtyped since the default monoid instance is not
 --   appropriate.  The monoid instance uses 'intersectVersionRanges'.
@@ -470,9 +472,10 @@ instance Monoid PDTagged where
 --
 -- This function will fail if it cannot find a flag assignment that leads to
 -- satisfiable dependencies.  (It will not try alternative assignments for
--- explicitly specified flags.)  In case of failure it will return a /minimum/
--- number of dependencies that could not be satisfied.  On success, it will
--- return the package description and the full flag assignment chosen.
+-- explicitly specified flags.)  In case of failure it will return the missing
+-- dependencies that it encountered when trying different flag assignments.
+-- On success, it will return the package description and the full flag
+-- assignment chosen.
 --
 finalizePackageDescription ::
      FlagAssignment  -- ^ Explicitly specified flag assignments

--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -225,7 +225,7 @@ resolveWithFlags ::
        -- ^ Either the missing dependencies (error case), or a pair of
        -- (set of build targets with dependencies, chosen flag assignments)
 resolveWithFlags dom os arch impl constrs trees checkDeps =
-    either (Left . fromDepMapUnion) Right $ explore (build dom [])
+    either (Left . fromDepMapUnion) Right $ explore (build [] dom)
   where
     extraConstrs = toDepMap constrs
 
@@ -255,10 +255,10 @@ resolveWithFlags dom os arch impl constrs trees checkDeps =
 
     -- Builds a tree of all possible flag assignments.  Internal nodes
     -- have only partial assignments.
-    build :: [(FlagName, [Bool])] -> FlagAssignment -> Tree FlagAssignment
-    build [] flags = Node flags []
-    build ((n, vals):rest) flags =
-        Node flags $ map (\v -> build rest ((n, v):flags)) vals
+    build :: FlagAssignment -> [(FlagName, [Bool])] -> Tree FlagAssignment
+    build assigned [] = Node assigned []
+    build assigned ((fn, vals) : unassigned) =
+        Node assigned $ map (\v -> build ((fn, v) : assigned) unassigned) vals
 
     tryAll :: [Either DepMapUnion a] -> Either DepMapUnion a
     tryAll = foldr mp mz

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -470,7 +470,7 @@ configure (pkg_descr0, pbi) cfg
                        pkg_descr0''
                 of Right r -> return r
                    Left missing ->
-                       die $ "At least the following dependencies are missing:\n"
+                       die $ "Encountered missing dependencies:\n"
                          ++ (render . nest 4 . sep . punctuate comma
                                     . map (disp . simplifyDependency)
                                     $ missing)


### PR DESCRIPTION
This pull request fixes the space leak in #2777 and should also improve the run time in many cases.  The new algorithm assigns one flag at a time and backtracks when a flag introduces a dependency that is unavailable, instead of always trying every flag combination until one succeeds.

The first commit changes the search algorithm, and the second commit updates error messages.  Previously, Cabal printed the shortest list of missing dependencies from a single complete flag assignment.  Now it is easier to take the union of all dependencies that caused Cabal to backtrack.  Is this change okay?  Here is an example:


    library
      if flag(flag1)
        build-depends: unknown-package1
        if flag(flag2)
          build-depends: unknown-package2
        else
          build-depends: unknown-package3
      else
        build-depends: unknown-package4
        if flag(flag3)
          build-depends: unknown-package5
        else
          build-depends: unknown-package6

`./Setup configure` on master prints:

    Configuring example-0.1.0.0...
    Setup: At least the following dependencies are missing:
    unknown-package1 -any, unknown-package2 -any

This branch only lists the dependencies introduced by flag1, because there is no need to search farther:

    Configuring example-0.1.0.0...
    Setup: At least one of the following dependencies is missing:
    unknown-package1 -any, unknown-package4 -any

EDIT: I think that the new error message is a little confusing, especially when a package has no flags, but I'm not sure how to reword it.