### PR TITLE
Use `-fno-warn-implicit-prelude' in Paths_* module

### DIFF
--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -49,7 +49,7 @@ generate :: PackageDescription -> LocalBuildInfo -> String
 generate pkg_descr lbi =
    let pragmas = cpp_pragma ++ ffi_pragmas ++ warning_pragmas
 
-       cpp_pragma | supports_cpp = "{-# LANGUAGE CPP #-}"
+       cpp_pragma | supports_cpp = "{-# LANGUAGE CPP #-}\n"
                   | otherwise    = ""
 
        ffi_pragmas
@@ -61,7 +61,8 @@ generate pkg_descr lbi =
           "{-# OPTIONS_JHC -fffi #-}\n"
 
        warning_pragmas =
-        "{-# OPTIONS_GHC -fno-warn-missing-import-lists #-}\n"
+        "{-# OPTIONS_GHC -fno-warn-missing-import-lists #-}\n"++
+        "{-# OPTIONS_GHC -fno-warn-implicit-prelude #-}\n"
 
        foreign_imports
         | absolute = ""


### PR DESCRIPTION
When GHC is invoked with `-fwarn-implicit-prelude', then autogenerated
Paths_* modules are source of unnecessary warnings.

This commit adds OPTIONS_GHC pragma with `-fno-warn-implicit-prelude' in
to Paths_* module, so that such warnings are suppressed.