### PR TITLE
Implement better error handling for "sandbox delete-source".

### DIFF
--- a/cabal-install/tests/IntegrationTests/sandbox-sources/should_fail/fail_on_nonexistent_source.err
+++ b/cabal-install/tests/IntegrationTests/sandbox-sources/should_fail/fail_on_nonexistent_source.err
@@ -1,0 +1,5 @@
+Warning: Source directory not found for paths: "p"
+If you are trying to delete a reference to a removed directory, please provide
+the full absolute path (as given by `sandbox list-sources`).
+
+cabal: The sources with the above errors were skipped. ("p")

--- a/cabal-install/tests/IntegrationTests/sandbox-sources/should_fail/fail_on_nonexistent_source.sh
+++ b/cabal-install/tests/IntegrationTests/sandbox-sources/should_fail/fail_on_nonexistent_source.sh
@@ -8,8 +8,7 @@ cabal sandbox add-source p > /dev/null
 cabal sandbox add-source q > /dev/null
 
 # delete the directory on disk
-# FIXME: the following line needs to be uncommented, but this depends on fixing a regression to #1360 first 
-#rm -R p
+rm -R p
 
 # Remove the registered source which is no longer on disk
 cabal sandbox delete-source p

--- a/cabal-install/tests/IntegrationTests/sandbox-sources/should_fail/fail_removing_source_thats_not_registered.err
+++ b/cabal-install/tests/IntegrationTests/sandbox-sources/should_fail/fail_removing_source_thats_not_registered.err
@@ -1,1 +1,7 @@
-cabal: Skipped the following nonregistered sources: "q"
+Warning: Source directory not found for paths: "r" "s"
+If you are trying to delete a reference to a removed directory, please provide
+the full absolute path (as given by `sandbox list-sources`).
+
+Warning: Sources not registered: "q"
+
+cabal: The sources with the above errors were skipped. ("r" "s" "q")

--- a/cabal-install/tests/IntegrationTests/sandbox-sources/should_fail/fail_removing_source_thats_not_registered.sh
+++ b/cabal-install/tests/IntegrationTests/sandbox-sources/should_fail/fail_removing_source_thats_not_registered.sh
@@ -7,4 +7,4 @@ cabal sandbox init > /dev/null
 cabal sandbox add-source p > /dev/null
 
 # Remove a source that exists on disk, but is not registered
-cabal sandbox delete-source q
+cabal sandbox delete-source q r s

--- a/cabal-install/tests/IntegrationTests/sandbox-sources/should_run/tolerate_nonexistent_source.out
+++ b/cabal-install/tests/IntegrationTests/sandbox-sources/should_run/tolerate_nonexistent_source.out
@@ -1,6 +1,0 @@
-Success deleting sources: "p"
-
-Note: 'sandbox delete-source' only unregisters the source dependency, but does
-not remove the package from the sandbox package DB.
-
-Use 'sandbox hc-pkg -- unregister' to do that.


### PR DESCRIPTION
This is a continuation of [pull/2939](https://github.com/haskell/cabal/pull/2939) with cleaned-up commits.