### PR TITLE
Use standard mechanism to tell ./configure the c-compiler

### DIFF
--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -641,7 +641,7 @@ runConfigureScript verbosity backwardsCompatHack flags lbi = do
       spSep = [searchPathSeparator]
       pathEnv = maybe (intercalate spSep extraPath) ((intercalate spSep extraPath ++ spSep)++) $ lookup "PATH" env
       overEnv = ("CFLAGS", Just cflagsEnv) : [("PATH", Just pathEnv) | not (null extraPath)]
-      args' = args ++ ["--with-gcc=" ++ ccProg]
+      args' = args ++ ["CC=" ++ ccProg]
       shProg = simpleProgram "sh"
       progDb = modifyProgramSearchPath (\p -> map ProgramSearchPathDir extraPath ++ p) emptyProgramDb
   shConfiguredProg <- lookupProgram shProg `fmap` configureProgram  verbosity shProg progDb


### PR DESCRIPTION
Most Autoconf configure scripts don't support the non-standard `--with-gcc`
flag, and there does not seem to be any good reason to do so, since
Autoconf has already a proper way to set the c-compiler:

Either via the `CC` environment variable, or (with higher precedence)
by passing a commandline argument of the form `CC=clang-3.8`.

This patch simply replaces the previous non-standard `--with-gcc=clang-3.8`
argument (which was clearly misnamed to begin with) by a `CC=clang-3.8`
command-line argument to the `configure` script.