### PR TITLE
Cabal lib for nix local build

### DIFF
--- a/Cabal/Distribution/Compiler.hs
+++ b/Cabal/Distribution/Compiler.hs
@@ -180,7 +180,7 @@ instance Binary CompilerInfo
 data AbiTag
   = NoAbiTag
   | AbiTag String
-  deriving (Generic, Show, Read)
+  deriving (Eq, Generic, Show, Read)
 
 instance Binary AbiTag
 

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -112,7 +112,7 @@ data InstalledPackageInfo
         haddockHTMLs      :: [FilePath],
         pkgRoot           :: Maybe FilePath
     }
-    deriving (Generic, Read, Show)
+    deriving (Eq, Generic, Read, Show)
 
 instance Binary InstalledPackageInfo
 
@@ -172,7 +172,7 @@ noVersion = Version [] []
 -- Exposed modules
 
 newtype AbiHash = AbiHash String
-    deriving (Show, Read, Generic)
+    deriving (Eq, Show, Read, Generic)
 instance Binary AbiHash
 
 instance Text AbiHash where
@@ -195,7 +195,7 @@ data ExposedModule
        exposedReexport  :: Maybe OriginalModule,
        exposedSignature :: Maybe OriginalModule -- This field is unused for now.
      }
-  deriving (Generic, Read, Show)
+  deriving (Eq, Generic, Read, Show)
 
 instance Text OriginalModule where
     disp (OriginalModule ipi m) =

--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -1129,12 +1129,12 @@ data GenericPackageDescription =
         condTestSuites     :: [(String, CondTree ConfVar [Dependency] TestSuite)],
         condBenchmarks     :: [(String, CondTree ConfVar [Dependency] Benchmark)]
       }
-    deriving (Show, Eq, Typeable, Data)
+    deriving (Show, Eq, Typeable, Data, Generic)
 
 instance Package GenericPackageDescription where
   packageId = packageId . packageDescription
 
---TODO: make PackageDescription an instance of Text.
+instance Binary GenericPackageDescription
 
 -- | A flag can represent a feature to be included, or a way of linking
 --   a target against its dependencies, or in fact whatever you can think of.
@@ -1144,7 +1144,9 @@ data Flag = MkFlag
     , flagDefault     :: Bool
     , flagManual      :: Bool
     }
-    deriving (Show, Eq, Typeable, Data)
+    deriving (Show, Eq, Typeable, Data, Generic)
+
+instance Binary Flag
 
 -- | A 'FlagName' is the name of a user-defined configuration flag
 newtype FlagName = FlagName String
@@ -1164,7 +1166,9 @@ data ConfVar = OS OS
              | Arch Arch
              | Flag FlagName
              | Impl CompilerFlavor VersionRange
-    deriving (Eq, Show, Typeable, Data)
+    deriving (Eq, Show, Typeable, Data, Generic)
+
+instance Binary ConfVar
 
 -- | A boolean expression parameterized over the variable type used.
 data Condition c = Var c
@@ -1172,7 +1176,7 @@ data Condition c = Var c
                  | CNot (Condition c)
                  | COr (Condition c) (Condition c)
                  | CAnd (Condition c) (Condition c)
-    deriving (Show, Eq, Typeable, Data)
+    deriving (Show, Eq, Typeable, Data, Generic)
 
 cNot :: Condition a -> Condition a
 cNot (Lit b)  = Lit (not b)
@@ -1226,6 +1230,8 @@ instance MonadPlus Condition where
   mzero = mempty
   mplus = mappend
 
+instance Binary c => Binary (Condition c)
+
 data CondTree v c a = CondNode
     { condTreeData        :: a
     , condTreeConstraints :: c
@@ -1233,4 +1239,6 @@ data CondTree v c a = CondNode
                               , CondTree v c a
                               , Maybe (CondTree v c a))]
     }
-    deriving (Show, Eq, Typeable, Data)
+    deriving (Show, Eq, Typeable, Data, Generic)
+
+instance (Binary v, Binary c, Binary a) => Binary (CondTree v c a)

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -209,9 +209,8 @@ buildComponent verbosity numJobs pkg_descr lbi suffixes
         installedPkgInfo = inplaceInstalledPackageInfo pwd distPref pkg_descr
                                                        (IPI.AbiHash "") lib' lbi clbi
 
-    registerPackage verbosity
-      installedPkgInfo pkg_descr lbi True -- True meaning in place
-      (withPackageDB lbi)
+    registerPackage verbosity (compiler lbi) (withPrograms lbi)
+                    (withPackageDB lbi) installedPkgInfo
 
 buildComponent verbosity numJobs pkg_descr lbi suffixes
                comp@(CExe exe) clbi _ = do
@@ -251,7 +250,8 @@ buildComponent verbosity numJobs pkg_descr lbi0 suffixes
     extras <- preprocessExtras comp lbi
     info verbosity $ "Building test suite " ++ testName test ++ "..."
     buildLib verbosity numJobs pkg lbi lib libClbi
-    registerPackage verbosity ipi pkg lbi True $ withPackageDB lbi
+    registerPackage verbosity (compiler lbi) (withPrograms lbi)
+                    (withPackageDB lbi) ipi
     let ebi = buildInfo exe
         exe' = exe { buildInfo = addExtraCSources ebi extras }
     buildExe verbosity numJobs pkg_descr lbi exe' exeClbi

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -486,9 +486,7 @@ createInternalPackageDB verbosity lbi distPref = do
             then removeDirectoryRecursive dbPath
             else do file_exists <- doesFileExist dbPath
                     when file_exists $ removeFile dbPath
-        if HcPkg.useSingleFileDb hpi
-            then writeFile dbPath "[]"
-            else HcPkg.init hpi verbosity dbPath
+        HcPkg.init hpi verbosity True dbPath
         return packageDB
 
 addInternalBuildTools :: PackageDescription -> LocalBuildInfo -> BuildInfo

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -208,7 +208,7 @@ buildComponent verbosity numJobs pkg_descr lbi suffixes
         installedPkgInfo = inplaceInstalledPackageInfo pwd distPref pkg_descr
                                                        (IPI.AbiHash "") lib' lbi clbi
 
-    registerPackage verbosity (compiler lbi) (withPrograms lbi)
+    registerPackage verbosity (compiler lbi) (withPrograms lbi) False
                     (withPackageDB lbi) installedPkgInfo
 
 buildComponent verbosity numJobs pkg_descr lbi suffixes
@@ -249,7 +249,7 @@ buildComponent verbosity numJobs pkg_descr lbi0 suffixes
     extras <- preprocessExtras comp lbi
     info verbosity $ "Building test suite " ++ testName test ++ "..."
     buildLib verbosity numJobs pkg lbi lib libClbi
-    registerPackage verbosity (compiler lbi) (withPrograms lbi)
+    registerPackage verbosity (compiler lbi) (withPrograms lbi) False
                     (withPackageDB lbi) ipi
     let ebi = buildInfo exe
         exe' = exe { buildInfo = addExtraCSources ebi extras }

--- a/Cabal/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/Distribution/Simple/BuildTarget.hs
@@ -14,10 +14,14 @@ module Distribution.Simple.BuildTarget (
     -- * Build targets
     BuildTarget(..),
     readBuildTargets,
+    showBuildTarget,
+    QualLevel(..),
+    buildTargetComponentName,
 
     -- * Parsing user build targets
     UserBuildTarget,
     readUserBuildTargets,
+    showUserBuildTarget,
     UserBuildTargetProblem(..),
     reportUserBuildTargetProblems,
 
@@ -130,6 +134,11 @@ data BuildTarget =
 
 instance Binary BuildTarget
 
+buildTargetComponentName :: BuildTarget -> ComponentName
+buildTargetComponentName (BuildTargetComponent cn)   = cn
+buildTargetComponentName (BuildTargetModule    cn _) = cn
+buildTargetComponentName (BuildTargetFile      cn _) = cn
+
 -- | Read a list of user-supplied build target strings and resolve them to
 -- 'BuildTarget's according to a 'PackageDescription'. If there are problems
 -- with any of the targets e.g. they don't exist or are misformatted, throw an
@@ -231,6 +240,10 @@ showUserBuildTarget = intercalate ":" . components
     components (UserBuildTargetSingle s1)       = [s1]
     components (UserBuildTargetDouble s1 s2)    = [s1,s2]
     components (UserBuildTargetTriple s1 s2 s3) = [s1,s2,s3]
+
+showBuildTarget :: QualLevel -> PackageId -> BuildTarget -> String
+showBuildTarget ql pkgid bt =
+    showUserBuildTarget (renderBuildTarget ql bt pkgid)
 
 
 -- ------------------------------------------------------------

--- a/Cabal/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/Distribution/Simple/BuildTarget.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.BuildTargets
@@ -53,6 +54,8 @@ import Data.Maybe
          ( listToMaybe, catMaybes )
 import Data.Either
          ( partitionEithers )
+import Distribution.Compat.Binary (Binary)
+import GHC.Generics (Generic)
 import qualified Data.Map as Map
 import Control.Monad
 import Control.Applicative as AP (Alternative(..), Applicative(..))
@@ -123,8 +126,9 @@ data BuildTarget =
      -- | A specific file within a specific component.
      --
    | BuildTargetFile ComponentName FilePath
-  deriving (Show,Eq)
+  deriving (Eq, Show, Generic)
 
+instance Binary BuildTarget
 
 -- | Read a list of user-supplied build target strings and resolve them to
 -- 'BuildTarget's according to a 'PackageDescription'. If there are problems

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -60,6 +60,7 @@ module Distribution.Simple.Compiler (
         ProfDetailLevel(..),
         knownProfDetailLevels,
         flagToProfDetailLevel,
+        showProfDetailLevel,
   ) where
 
 import Distribution.Compiler
@@ -336,4 +337,13 @@ knownProfDetailLevels =
   , ("toplevel-functions", ["toplevel", "top"], ProfDetailToplevelFunctions)
   , ("all-functions",      ["all"],             ProfDetailAllFunctions)
   ]
+
+showProfDetailLevel :: ProfDetailLevel -> String
+showProfDetailLevel dl = case dl of
+    ProfDetailNone              -> "none"
+    ProfDetailDefault           -> "default"
+    ProfDetailExportedFunctions -> "exported-functions"
+    ProfDetailToplevelFunctions -> "toplevel-functions"
+    ProfDetailAllFunctions      -> "all-functions"
+    ProfDetailOther other       -> other
 

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -90,7 +90,7 @@ data Compiler = Compiler {
         compilerProperties      :: M.Map String String
         -- ^ A key-value map for properties not covered by the above fields.
     }
-    deriving (Generic, Show, Read)
+    deriving (Eq, Generic, Show, Read)
 
 instance Binary Compiler
 

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -39,7 +39,9 @@ module Distribution.Simple.Configure (configure,
                                       findDistPref, findDistPrefOrDefault,
                                       computeComponentId,
                                       localBuildInfoFile,
-                                      getInstalledPackages, getPackageDBContents,
+                                      getInstalledPackages,
+                                      getInstalledPackagesMonitorFiles,
+                                      getPackageDBContents,
                                       configCompiler, configCompilerAux,
                                       configCompilerEx, configCompilerAuxEx,
                                       ccLdOptionsBuildInfo,
@@ -940,6 +942,22 @@ getPackageDBContents verbosity comp packageDB progconf = do
     -- For other compilers, try to fall back on 'getInstalledPackages'.
     _   -> getInstalledPackages verbosity comp [packageDB] progconf
 
+
+-- | A set of files (or directories) that can be monitored to detect when
+-- there might have been a change in the installed packages.
+--
+getInstalledPackagesMonitorFiles :: Verbosity -> Compiler
+                                 -> PackageDBStack
+                                 -> ProgramConfiguration -> Platform
+                                 -> IO [FilePath]
+getInstalledPackagesMonitorFiles verbosity comp packageDBs progconf platform =
+  case compilerFlavor comp of
+    GHC   -> GHC.getInstalledPackagesMonitorFiles
+               verbosity platform progconf packageDBs
+    other -> do
+      warn verbosity $ "don't know how to find change monitoring files for "
+                    ++ "the installed package databases for " ++ display other
+      return []
 
 -- | The user interface specifies the package dbs to use with a combination of
 -- @--global@, @--user@ and @--package-db=global|user|clear|$file@.

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1119,7 +1119,8 @@ hcPkgInfo conf = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcPkgProg
                                  , HcPkg.noPkgDbStack    = v < [6,9]
                                  , HcPkg.noVerboseFlag   = v < [6,11]
                                  , HcPkg.flagPackageConf = v < [7,5]
-                                 , HcPkg.useSingleFileDb = v < [7,9]
+                                 , HcPkg.supportsDirDbs  = v >= [6,8]
+                                 , HcPkg.requiresDirDbs  = v >= [7,10]
                                  }
   where
     v               = versionBranch ver

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1128,12 +1128,12 @@ hcPkgInfo conf = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcPkgProg
 
 registerPackage
   :: Verbosity
-  -> InstalledPackageInfo
-  -> LocalBuildInfo
+  -> ProgramConfiguration
   -> PackageDBStack
+  -> InstalledPackageInfo
   -> IO ()
-registerPackage verbosity installedPkgInfo lbi packageDbs =
-  HcPkg.reregister (hcPkgInfo $ withPrograms lbi) verbosity
+registerPackage verbosity progdb packageDbs installedPkgInfo =
+  HcPkg.reregister (hcPkgInfo progdb) verbosity
     packageDbs (Right installedPkgInfo)
 
 pkgRoot :: Verbosity -> LocalBuildInfo -> PackageDB -> IO FilePath

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -197,7 +197,7 @@ configure verbosity hcPath hcPkgPath conf0 = do
 --
 guessToolFromGhcPath :: Program -> ConfiguredProgram
                      -> Verbosity -> ProgramSearchPath
-                     -> IO (Maybe FilePath)
+                     -> IO (Maybe (FilePath, [FilePath]))
 guessToolFromGhcPath tool ghcProg verbosity searchpath
   = do let toolname          = programName tool
            path              = programPath ghcProg
@@ -220,7 +220,10 @@ guessToolFromGhcPath tool ghcProg verbosity searchpath
                    -- method.
          []     -> programFindLocation tool verbosity searchpath
          (fp:_) -> do info verbosity $ "found " ++ toolname ++ " in " ++ fp
-                      return (Just fp)
+                      let lookedAt = map fst
+                                   . takeWhile (\(_file, exist) -> not exist)
+                                   $ zip guesses exists
+                      return (Just (fp, lookedAt))
 
   where takeVersionSuffix :: FilePath -> String
         takeVersionSuffix = takeWhileEndLE isSuffixChar
@@ -243,7 +246,8 @@ guessToolFromGhcPath tool ghcProg verbosity searchpath
 -- > /usr/local/bin/ghc-pkg(.exe)
 --
 guessGhcPkgFromGhcPath :: ConfiguredProgram
-                       -> Verbosity -> ProgramSearchPath -> IO (Maybe FilePath)
+                       -> Verbosity -> ProgramSearchPath
+                       -> IO (Maybe (FilePath, [FilePath]))
 guessGhcPkgFromGhcPath = guessToolFromGhcPath ghcPkgProgram
 
 -- | Given something like /usr/local/bin/ghc-6.6.1(.exe) we try and find a
@@ -255,7 +259,8 @@ guessGhcPkgFromGhcPath = guessToolFromGhcPath ghcPkgProgram
 -- > /usr/local/bin/hsc2hs(.exe)
 --
 guessHsc2hsFromGhcPath :: ConfiguredProgram
-                       -> Verbosity -> ProgramSearchPath -> IO (Maybe FilePath)
+                       -> Verbosity -> ProgramSearchPath
+                       -> IO (Maybe (FilePath, [FilePath]))
 guessHsc2hsFromGhcPath = guessToolFromGhcPath hsc2hsProgram
 
 -- | Given something like /usr/local/bin/ghc-6.6.1(.exe) we try and find a
@@ -267,7 +272,8 @@ guessHsc2hsFromGhcPath = guessToolFromGhcPath hsc2hsProgram
 -- > /usr/local/bin/haddock(.exe)
 --
 guessHaddockFromGhcPath :: ConfiguredProgram
-                       -> Verbosity -> ProgramSearchPath -> IO (Maybe FilePath)
+                       -> Verbosity -> ProgramSearchPath
+                       -> IO (Maybe (FilePath, [FilePath]))
 guessHaddockFromGhcPath = guessToolFromGhcPath haddockProgram
 
 getGhcInfo :: Verbosity -> ConfiguredProgram -> IO [(String, String)]

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1129,12 +1129,10 @@ hcPkgInfo conf = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcPkgProg
 registerPackage
   :: Verbosity
   -> InstalledPackageInfo
-  -> PackageDescription
   -> LocalBuildInfo
-  -> Bool
   -> PackageDBStack
   -> IO ()
-registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs =
+registerPackage verbosity installedPkgInfo lbi packageDbs =
   HcPkg.reregister (hcPkgInfo $ withPrograms lbi) verbosity
     packageDbs (Right installedPkgInfo)
 

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1121,6 +1121,8 @@ hcPkgInfo conf = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcPkgProg
                                  , HcPkg.flagPackageConf = v < [7,5]
                                  , HcPkg.supportsDirDbs  = v >= [6,8]
                                  , HcPkg.requiresDirDbs  = v >= [7,10]
+                                 , HcPkg.nativeMultiInstance  = v >= [7,10]
+                                 , HcPkg.recacheMultiInstance = v >= [6,12]
                                  }
   where
     v               = versionBranch ver

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1132,12 +1132,18 @@ hcPkgInfo conf = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcPkgProg
 registerPackage
   :: Verbosity
   -> ProgramConfiguration
+  -> Bool
   -> PackageDBStack
   -> InstalledPackageInfo
   -> IO ()
-registerPackage verbosity progdb packageDbs installedPkgInfo =
-  HcPkg.reregister (hcPkgInfo progdb) verbosity
-    packageDbs (Right installedPkgInfo)
+registerPackage verbosity progdb multiInstance packageDbs installedPkgInfo
+  | multiInstance
+  = HcPkg.registerMultiInstance (hcPkgInfo progdb) verbosity
+      packageDbs installedPkgInfo
+
+  | otherwise
+  = HcPkg.reregister (hcPkgInfo progdb) verbosity
+      packageDbs (Right installedPkgInfo)
 
 pkgRoot :: Verbosity -> LocalBuildInfo -> PackageDB -> IO FilePath
 pkgRoot verbosity lbi = pkgRoot'

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -132,7 +132,8 @@ configureToolchain implInfo ghcProg ghcInfo =
           in  (b, b, b, b)
 
     findProg :: Program -> [FilePath]
-             -> Verbosity -> ProgramSearchPath -> IO (Maybe FilePath)
+             -> Verbosity -> ProgramSearchPath
+             -> IO (Maybe (FilePath, [FilePath]))
     findProg prog extraPath v searchpath =
         programFindLocation prog v searchpath'
       where

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -26,6 +26,8 @@ module Distribution.Simple.GHC.Internal (
         substTopDir,
         checkPackageDbEnvVar,
         profDetailLevelFlag,
+        showArchString,
+        showOsString,
  ) where
 
 import Distribution.Simple.GHC.ImplInfo ( GhcImplInfo (..) )
@@ -58,7 +60,8 @@ import Distribution.Simple.LocalBuildInfo
          ( LocalBuildInfo(..), ComponentLocalBuildInfo(..) )
 import Distribution.Simple.Utils
 import Distribution.Simple.BuildPaths
-import Distribution.System ( buildOS, OS(..), Platform, platformFromTriple )
+import Distribution.System
+         ( Arch(..), buildOS, OS(..), Platform, platformFromTriple )
 import Distribution.Text ( display, simpleParse )
 import Distribution.Utils.NubList ( toNubListR )
 import Distribution.Verbosity
@@ -518,3 +521,20 @@ profDetailLevelFlag forLib mpl =
       ProfDetailToplevelFunctions   -> toFlag GhcProfAutoToplevel
       ProfDetailAllFunctions        -> toFlag GhcProfAutoAll
       ProfDetailOther _             -> mempty
+
+-- | GHC's rendering of it's host or target 'Arch' as used in its platform
+-- strings and certain file locations (such as user package db location).
+--
+showArchString :: Arch -> String
+showArchString PPC   = "powerpc"
+showArchString PPC64 = "powerpc64"
+showArchString other = display other
+
+-- | GHC's rendering of it's host or target 'OS' as used in its platform
+-- strings and certain file locations (such as user package db location).
+--
+showOsString :: OS -> String
+showOsString Windows = "mingw32"
+showOsString OSX     = "darwin"
+showOsString Solaris = "solaris2"
+showOsString other   = display other

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -823,12 +823,18 @@ adjustExts hiSuf objSuf opts =
 
 registerPackage :: Verbosity
                 -> ProgramConfiguration
+                -> Bool
                 -> PackageDBStack
                 -> InstalledPackageInfo
                 -> IO ()
-registerPackage verbosity progdb packageDbs installedPkgInfo =
-  HcPkg.reregister (hcPkgInfo progdb) verbosity packageDbs
-    (Right installedPkgInfo)
+registerPackage verbosity progdb multiInstance packageDbs installedPkgInfo
+  | multiInstance
+  = HcPkg.registerMultiInstance (hcPkgInfo progdb) verbosity
+      packageDbs installedPkgInfo
+
+  | otherwise
+  = HcPkg.reregister (hcPkgInfo progdb) verbosity
+      packageDbs (Right installedPkgInfo)
 
 componentGhcOptions :: Verbosity -> LocalBuildInfo
                     -> BuildInfo -> ComponentLocalBuildInfo -> FilePath

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -869,7 +869,8 @@ hcPkgInfo conf = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcjsPkgProg
                                  , HcPkg.noPkgDbStack    = False
                                  , HcPkg.noVerboseFlag   = False
                                  , HcPkg.flagPackageConf = False
-                                 , HcPkg.useSingleFileDb = v < [7,9]
+                                 , HcPkg.supportsDirDbs  = True
+                                 , HcPkg.requiresDirDbs  = v >= [7,10]
                                  }
   where
     v                 = versionBranch ver

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -823,12 +823,10 @@ adjustExts hiSuf objSuf opts =
 
 registerPackage :: Verbosity
                 -> InstalledPackageInfo
-                -> PackageDescription
                 -> LocalBuildInfo
-                -> Bool
                 -> PackageDBStack
                 -> IO ()
-registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs =
+registerPackage verbosity installedPkgInfo lbi packageDbs =
   HcPkg.reregister (hcPkgInfo $ withPrograms lbi) verbosity packageDbs
     (Right installedPkgInfo)
 

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -871,6 +871,8 @@ hcPkgInfo conf = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcjsPkgProg
                                  , HcPkg.flagPackageConf = False
                                  , HcPkg.supportsDirDbs  = True
                                  , HcPkg.requiresDirDbs  = v >= [7,10]
+                                 , HcPkg.nativeMultiInstance  = v >= [7,10]
+                                 , HcPkg.recacheMultiInstance = True
                                  }
   where
     v                 = versionBranch ver

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -152,24 +152,24 @@ ghcjsNativeToo :: Compiler -> Bool
 ghcjsNativeToo = Internal.ghcLookupProperty "Native Too"
 
 guessGhcjsPkgFromGhcjsPath :: ConfiguredProgram -> Verbosity
-                           -> ProgramSearchPath -> IO (Maybe FilePath)
+                           -> ProgramSearchPath -> IO (Maybe (FilePath, [FilePath]))
 guessGhcjsPkgFromGhcjsPath = guessToolFromGhcjsPath ghcjsPkgProgram
 
 guessHsc2hsFromGhcjsPath :: ConfiguredProgram -> Verbosity
-                         -> ProgramSearchPath -> IO (Maybe FilePath)
+                         -> ProgramSearchPath -> IO (Maybe (FilePath, [FilePath]))
 guessHsc2hsFromGhcjsPath = guessToolFromGhcjsPath hsc2hsProgram
 
 guessC2hsFromGhcjsPath :: ConfiguredProgram -> Verbosity
-                       -> ProgramSearchPath -> IO (Maybe FilePath)
+                       -> ProgramSearchPath -> IO (Maybe (FilePath, [FilePath]))
 guessC2hsFromGhcjsPath = guessToolFromGhcjsPath c2hsProgram
 
 guessHaddockFromGhcjsPath :: ConfiguredProgram -> Verbosity
-                          -> ProgramSearchPath -> IO (Maybe FilePath)
+                          -> ProgramSearchPath -> IO (Maybe (FilePath, [FilePath]))
 guessHaddockFromGhcjsPath = guessToolFromGhcjsPath haddockProgram
 
 guessToolFromGhcjsPath :: Program -> ConfiguredProgram
                        -> Verbosity -> ProgramSearchPath
-                       -> IO (Maybe FilePath)
+                       -> IO (Maybe (FilePath, [FilePath]))
 guessToolFromGhcjsPath tool ghcjsProg verbosity searchpath
   = do let toolname          = programName tool
            path              = programPath ghcjsProg
@@ -194,7 +194,10 @@ guessToolFromGhcjsPath tool ghcjsProg verbosity searchpath
                    -- method.
          []     -> programFindLocation tool verbosity searchpath
          (fp:_) -> do info verbosity $ "found " ++ toolname ++ " in " ++ fp
-                      return (Just fp)
+                      let lookedAt = map fst
+                                   . takeWhile (\(_file, exist) -> not exist)
+                                   $ zip guesses exists
+                      return (Just (fp, lookedAt))
 
   where takeVersionSuffix :: FilePath -> String
         takeVersionSuffix = reverse . takeWhile (`elem ` "0123456789.-") .

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -822,12 +822,12 @@ adjustExts hiSuf objSuf opts =
   }
 
 registerPackage :: Verbosity
-                -> InstalledPackageInfo
-                -> LocalBuildInfo
+                -> ProgramConfiguration
                 -> PackageDBStack
+                -> InstalledPackageInfo
                 -> IO ()
-registerPackage verbosity installedPkgInfo lbi packageDbs =
-  HcPkg.reregister (hcPkgInfo $ withPrograms lbi) verbosity packageDbs
+registerPackage verbosity progdb packageDbs installedPkgInfo =
+  HcPkg.reregister (hcPkgInfo progdb) verbosity packageDbs
     (Right installedPkgInfo)
 
 componentGhcOptions :: Verbosity -> LocalBuildInfo

--- a/Cabal/Distribution/Simple/HaskellSuite.hs
+++ b/Cabal/Distribution/Simple/HaskellSuite.hs
@@ -200,12 +200,12 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir pkg lib _clbi = do
 
 registerPackage
   :: Verbosity
-  -> InstalledPackageInfo
-  -> LocalBuildInfo
+  -> ProgramConfiguration
   -> PackageDBStack
+  -> InstalledPackageInfo
   -> IO ()
-registerPackage verbosity installedPkgInfo lbi packageDbs = do
-  (hspkg, _) <- requireProgram verbosity haskellSuitePkgProgram (withPrograms lbi)
+registerPackage verbosity progdb packageDbs installedPkgInfo = do
+  (hspkg, _) <- requireProgram verbosity haskellSuitePkgProgram progdb
 
   runProgramInvocation verbosity $
     (programInvocation hspkg

--- a/Cabal/Distribution/Simple/HaskellSuite.hs
+++ b/Cabal/Distribution/Simple/HaskellSuite.hs
@@ -201,12 +201,10 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir pkg lib _clbi = do
 registerPackage
   :: Verbosity
   -> InstalledPackageInfo
-  -> PackageDescription
   -> LocalBuildInfo
-  -> Bool
   -> PackageDBStack
   -> IO ()
-registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs = do
+registerPackage verbosity installedPkgInfo lbi packageDbs = do
   (hspkg, _) <- requireProgram verbosity haskellSuitePkgProgram (withPrograms lbi)
 
   runProgramInvocation verbosity $

--- a/Cabal/Distribution/Simple/HaskellSuite.hs
+++ b/Cabal/Distribution/Simple/HaskellSuite.hs
@@ -56,7 +56,7 @@ configure verbosity mbHcPath hcPkgPath conf0 = do
       let
         haskellSuiteProgram' =
           haskellSuiteProgram
-            { programFindLocation = \v _p -> findProgramLocation v hcPath }
+            { programFindLocation = \v p -> findProgramOnSearchPath v p hcPath }
 
       -- NB: cannot call requireProgram right away — it'd think that
       -- the program is already configured and won't reconfigure it again.

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -96,7 +96,7 @@ data InstallDirs dir = InstallDirs {
         htmldir      :: dir,
         haddockdir   :: dir,
         sysconfdir   :: dir
-    } deriving (Generic, Read, Show)
+    } deriving (Eq, Read, Show, Generic)
 
 instance Binary dir => Binary (InstallDirs dir)
 
@@ -349,7 +349,8 @@ prefixRelativeInstallDirs pkgId libname compilerId platform dirs =
 -- | An abstract path, possibly containing variables that need to be
 -- substituted for to get a real 'FilePath'.
 --
-newtype PathTemplate = PathTemplate [PathComponent] deriving (Eq, Generic, Ord)
+newtype PathTemplate = PathTemplate [PathComponent]
+  deriving (Eq, Ord, Generic)
 
 instance Binary PathTemplate
 

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -789,6 +789,8 @@ hcPkgInfo conf = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = lhcPkgProg
                                  , HcPkg.flagPackageConf = False
                                  , HcPkg.supportsDirDbs  = True
                                  , HcPkg.requiresDirDbs  = True
+                                 , HcPkg.nativeMultiInstance  = False -- ?
+                                 , HcPkg.recacheMultiInstance = False -- ?
                                  }
   where
     Just lhcPkgProg = lookupProgram lhcPkgProgram conf

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -787,7 +787,8 @@ hcPkgInfo conf = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = lhcPkgProg
                                  , HcPkg.noPkgDbStack    = False
                                  , HcPkg.noVerboseFlag   = False
                                  , HcPkg.flagPackageConf = False
-                                 , HcPkg.useSingleFileDb = True
+                                 , HcPkg.supportsDirDbs  = True
+                                 , HcPkg.requiresDirDbs  = True
                                  }
   where
     Just lhcPkgProg = lookupProgram lhcPkgProgram conf

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -774,12 +774,12 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
 
 registerPackage
   :: Verbosity
-  -> InstalledPackageInfo
-  -> LocalBuildInfo
+  -> ProgramConfiguration
   -> PackageDBStack
+  -> InstalledPackageInfo
   -> IO ()
-registerPackage verbosity installedPkgInfo lbi packageDbs =
-  HcPkg.reregister (hcPkgInfo $ withPrograms lbi) verbosity packageDbs
+registerPackage verbosity progdb packageDbs installedPkgInfo =
+  HcPkg.reregister (hcPkgInfo progdb) verbosity packageDbs
     (Right installedPkgInfo)
 
 hcPkgInfo :: ProgramConfiguration -> HcPkg.HcPkgInfo

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -775,12 +775,10 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
 registerPackage
   :: Verbosity
   -> InstalledPackageInfo
-  -> PackageDescription
   -> LocalBuildInfo
-  -> Bool
   -> PackageDBStack
   -> IO ()
-registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs =
+registerPackage verbosity installedPkgInfo lbi packageDbs =
   HcPkg.reregister (hcPkgInfo $ withPrograms lbi) verbosity packageDbs
     (Right installedPkgInfo)
 

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -158,10 +158,11 @@ configureToolchain lhcProg =
 
     -- on Windows finding and configuring ghc's gcc and ld is a bit special
     findProg :: Program -> FilePath
-             -> Verbosity -> ProgramSearchPath -> IO (Maybe FilePath)
+             -> Verbosity -> ProgramSearchPath
+             -> IO (Maybe (FilePath, [FilePath]))
     findProg prog location | isWindows = \verbosity searchpath -> do
         exists <- doesFileExist location
-        if exists then return (Just location)
+        if exists then return (Just (location, []))
                   else do warn verbosity ("Couldn't find " ++ programName prog ++ " where I expected it. Trying the search path.")
                           programFindLocation prog verbosity searchpath
       | otherwise = programFindLocation prog

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -117,7 +117,7 @@ data PackageIndex a = PackageIndex
   -- preserved. See #1463 for discussion.
   !(Map PackageName (Map Version [a]))
 
-  deriving (Generic, Show, Read)
+  deriving (Eq, Generic, Show, Read)
 
 instance Binary a => Binary (PackageIndex a)
 

--- a/Cabal/Distribution/Simple/Program.hs
+++ b/Cabal/Distribution/Simple/Program.hs
@@ -223,4 +223,5 @@ restoreProgramConfiguration = restoreProgramDb
 {-# DEPRECATED findProgramOnPath "use findProgramOnSearchPath instead" #-}
 findProgramOnPath :: String -> Verbosity -> IO (Maybe FilePath)
 findProgramOnPath name verbosity =
+    fmap (fmap fst) $
     findProgramOnSearchPath verbosity defaultProgramSearchPath name

--- a/Cabal/Distribution/Simple/Program.hs
+++ b/Cabal/Distribution/Simple/Program.hs
@@ -38,7 +38,8 @@ module Distribution.Simple.Program (
     , ProgramSearchPath
     , ProgramSearchPathEntry(..)
     , simpleProgram
-    , findProgramLocation
+    , findProgramOnSearchPath
+    , defaultProgramSearchPath
     , findProgramVersion
 
     -- * Configured program and related functions
@@ -122,6 +123,7 @@ module Distribution.Simple.Program (
     , rawSystemProgramConf
     , rawSystemProgramStdoutConf
     , findProgramOnPath
+    , findProgramLocation
 
     ) where
 
@@ -129,6 +131,7 @@ import Distribution.Simple.Program.Types
 import Distribution.Simple.Program.Run
 import Distribution.Simple.Program.Db
 import Distribution.Simple.Program.Builtin
+import Distribution.Simple.Program.Find
 
 import Distribution.Simple.Utils
          ( die, findProgramLocation, findProgramVersion )
@@ -217,6 +220,7 @@ restoreProgramConfiguration :: [Program] -> ProgramConfiguration
                                          -> ProgramConfiguration
 restoreProgramConfiguration = restoreProgramDb
 
-{-# DEPRECATED findProgramOnPath "use findProgramLocation instead" #-}
+{-# DEPRECATED findProgramOnPath "use findProgramOnSearchPath instead" #-}
 findProgramOnPath :: String -> Verbosity -> IO (Maybe FilePath)
-findProgramOnPath = flip findProgramLocation
+findProgramOnPath name verbosity =
+    findProgramOnSearchPath verbosity defaultProgramSearchPath name

--- a/Cabal/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/Distribution/Simple/Program/Builtin.hs
@@ -227,16 +227,16 @@ haskellSuiteProgram :: Program
 haskellSuiteProgram = (simpleProgram "haskell-suite") {
     -- pretend that the program exists, otherwise it won't be in the
     -- "configured" state
-    programFindLocation =
-      \_verbosity _searchPath -> return $ Just "haskell-suite-dummy-location"
+    programFindLocation = \_verbosity _searchPath ->
+      return $ Just ("haskell-suite-dummy-location", [])
   }
 
 -- This represent a haskell-suite package manager. See the comments for
 -- haskellSuiteProgram.
 haskellSuitePkgProgram :: Program
 haskellSuitePkgProgram = (simpleProgram "haskell-suite-pkg") {
-    programFindLocation =
-      \_verbosity _searchPath -> return $ Just "haskell-suite-pkg-dummy-location"
+    programFindLocation = \_verbosity _searchPath ->
+      return $ Just ("haskell-suite-pkg-dummy-location", [])
   }
 
 

--- a/Cabal/Distribution/Simple/Program/Db.hs
+++ b/Cabal/Distribution/Simple/Program/Db.hs
@@ -124,17 +124,24 @@ updateConfiguredProgs update conf =
 
 
 -- Read & Show instances are based on listToFM
--- Note that we only serialise the configured part of the database, this is
--- because we don't need the unconfigured part after the configure stage, and
--- additionally because we cannot read/show 'Program' as it contains functions.
+
+-- | Note that this instance does not preserve the known 'Program's.
+-- See 'restoreProgramDb' for details.
+--
 instance Show ProgramDb where
   show = show . Map.toAscList . configuredProgs
 
+-- | Note that this instance does not preserve the known 'Program's.
+-- See 'restoreProgramDb' for details.
+--
 instance Read ProgramDb where
   readsPrec p s =
     [ (emptyProgramDb { configuredProgs = Map.fromList s' }, r)
     | (s', r) <- readsPrec p s ]
 
+-- | Note that this instance does not preserve the known 'Program's.
+-- See 'restoreProgramDb' for details.
+--
 instance Binary ProgramDb where
   put db = do
     put (progSearchPath db)
@@ -149,10 +156,10 @@ instance Binary ProgramDb where
     }
 
 
--- | The Read\/Show instance does not preserve all the unconfigured 'Programs'
--- because 'Program' is not in Read\/Show because it contains functions. So to
--- fully restore a deserialised 'ProgramDb' use this function to add
--- back all the known 'Program's.
+-- | The 'Read'\/'Show' and 'Binary' instances do not preserve all the
+-- unconfigured 'Programs' because 'Program' is not in 'Read'\/'Show' because
+-- it contains functions. So to fully restore a deserialised 'ProgramDb' use
+-- this function to add back all the known 'Program's.
 --
 -- * It does not add the default programs, but you probably want them, use
 --   'builtinPrograms' in addition to any extra you might need.

--- a/Cabal/Distribution/Simple/Program/Db.hs
+++ b/Cabal/Distribution/Simple/Program/Db.hs
@@ -136,10 +136,17 @@ instance Read ProgramDb where
     | (s', r) <- readsPrec p s ]
 
 instance Binary ProgramDb where
-  put = put . configuredProgs
+  put db = do
+    put (progSearchPath db)
+    put (configuredProgs db)
+
   get = do
-      progs <- get
-      return $! emptyProgramDb { configuredProgs = progs }
+    searchpath <- get
+    progs      <- get
+    return $! emptyProgramDb {
+      progSearchPath  = searchpath,
+      configuredProgs = progs
+    }
 
 
 -- | The Read\/Show instance does not preserve all the unconfigured 'Programs'

--- a/Cabal/Distribution/Simple/Program/Find.hs
+++ b/Cabal/Distribution/Simple/Program/Find.hs
@@ -37,10 +37,8 @@ import Distribution.Simple.Utils
          ( debug, doesExecutableExist )
 import Distribution.System
          ( OS(..), buildOS )
-#if MIN_VERSION_directory(1,2,1)
 import qualified System.Directory as Directory
          ( findExecutable )
-#endif
 import Distribution.Compat.Environment
          ( getEnvironment )
 import System.FilePath as FilePath
@@ -173,14 +171,20 @@ getSystemSearchPath = fmap nub $ do
     FilePath.getSearchPath
 #endif
 
-findExecutable :: FilePath -> IO (Maybe FilePath)
+#ifdef MIN_VERSION_directory
 #if MIN_VERSION_directory(1,2,1)
+#define HAVE_directory_121
+#endif
+#endif
+
+findExecutable :: FilePath -> IO (Maybe FilePath)
+#if HAVE_directory_121
 findExecutable = Directory.findExecutable
 #else
 findExecutable prog = do
       -- With directory < 1.2.1 'findExecutable' doesn't check that the path
       -- really refers to an executable.
-      mExe <- findExecutable prog
+      mExe <- Directory.findExecutable prog
       case mExe of
         Just exe -> do
           exeExists <- doesExecutableExist exe

--- a/Cabal/Distribution/Simple/Program/Find.hs
+++ b/Cabal/Distribution/Simple/Program/Find.hs
@@ -178,7 +178,7 @@ getSystemSearchPath = fmap nub $ do
 #endif
 
 findExecutable :: FilePath -> IO (Maybe FilePath)
-#if HAVE_directory_121
+#ifdef HAVE_directory_121
 findExecutable = Directory.findExecutable
 #else
 findExecutable prog = do

--- a/Cabal/Distribution/Simple/Program/Find.hs
+++ b/Cabal/Distribution/Simple/Program/Find.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP, DeriveGeneric #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Simple.Program.Find
@@ -42,7 +44,8 @@ import System.FilePath
          ( (</>), (<.>), splitSearchPath, searchPathSeparator )
 import Data.List
          ( intercalate )
-
+import Distribution.Compat.Binary
+import GHC.Generics
 
 -- | A search path to use when locating executables. This is analogous
 -- to the unix @$PATH@ or win32 @%PATH%@ but with the ability to use
@@ -60,6 +63,9 @@ type ProgramSearchPath = [ProgramSearchPathEntry]
 data ProgramSearchPathEntry =
          ProgramSearchPathDir FilePath  -- ^ A specific dir
        | ProgramSearchPathDefault       -- ^ The system default
+  deriving (Eq, Generic)
+
+instance Binary ProgramSearchPathEntry
 
 defaultProgramSearchPath :: ProgramSearchPath
 defaultProgramSearchPath = [ProgramSearchPathDefault]

--- a/Cabal/Distribution/Simple/Program/Find.hs
+++ b/Cabal/Distribution/Simple/Program/Find.hs
@@ -78,14 +78,14 @@ defaultProgramSearchPath :: ProgramSearchPath
 defaultProgramSearchPath = [ProgramSearchPathDefault]
 
 findProgramOnSearchPath :: Verbosity -> ProgramSearchPath
-                        -> FilePath -> IO (Maybe FilePath)
+                        -> FilePath -> IO (Maybe (FilePath, [FilePath]))
 findProgramOnSearchPath verbosity searchpath prog = do
     debug verbosity $ "Searching for " ++ prog ++ " in path."
     res <- tryPathElems [] searchpath
     case res of
       Nothing   -> debug verbosity ("Cannot find " ++ prog ++ " on the path")
       Just (path, _) -> debug verbosity ("Found " ++ prog ++ " at "++ path)
-    return (fmap fst res)
+    return res
   where
     tryPathElems :: [[FilePath]] -> [ProgramSearchPathEntry]
                  -> IO (Maybe (FilePath, [FilePath]))

--- a/Cabal/Distribution/Simple/Program/Find.hs
+++ b/Cabal/Distribution/Simple/Program/Find.hs
@@ -28,6 +28,7 @@ module Distribution.Simple.Program.Find (
     defaultProgramSearchPath,
     findProgramOnSearchPath,
     programSearchPathAsPATHVar,
+    getSystemSearchPath,
   ) where
 
 import Distribution.Verbosity
@@ -36,16 +37,22 @@ import Distribution.Simple.Utils
          ( debug, doesExecutableExist )
 import Distribution.System
          ( OS(..), buildOS )
-import System.Directory
+#if MIN_VERSION_directory(1,2,1)
+import qualified System.Directory as Directory
          ( findExecutable )
+#endif
 import Distribution.Compat.Environment
          ( getEnvironment )
-import System.FilePath
-         ( (</>), (<.>), splitSearchPath, searchPathSeparator )
+import System.FilePath as FilePath
+         ( (</>), (<.>), splitSearchPath, searchPathSeparator, getSearchPath
+         , takeDirectory )
 import Data.List
-         ( intercalate )
+         ( intercalate, nub )
 import Distribution.Compat.Binary
 import GHC.Generics
+#if defined(mingw32_HOST_OS)
+import qualified System.Win32
+#endif
 
 -- | A search path to use when locating executables. This is analogous
 -- to the unix @$PATH@ or win32 @%PATH%@ but with the ability to use
@@ -74,49 +81,65 @@ findProgramOnSearchPath :: Verbosity -> ProgramSearchPath
                         -> FilePath -> IO (Maybe FilePath)
 findProgramOnSearchPath verbosity searchpath prog = do
     debug verbosity $ "Searching for " ++ prog ++ " in path."
-    res <- tryPathElems searchpath
+    res <- tryPathElems [] searchpath
     case res of
       Nothing   -> debug verbosity ("Cannot find " ++ prog ++ " on the path")
-      Just path -> debug verbosity ("Found " ++ prog ++ " at "++ path)
-    return res
+      Just (path, _) -> debug verbosity ("Found " ++ prog ++ " at "++ path)
+    return (fmap fst res)
   where
-    tryPathElems []       = return Nothing
-    tryPathElems (pe:pes) = do
+    tryPathElems :: [[FilePath]] -> [ProgramSearchPathEntry]
+                 -> IO (Maybe (FilePath, [FilePath]))
+    tryPathElems _     []       = return Nothing
+    tryPathElems tried (pe:pes) = do
       res <- tryPathElem pe
       case res of
-        Nothing -> tryPathElems pes
-        Just _  -> return res
+        (Nothing,      notfoundat) -> tryPathElems (notfoundat : tried) pes
+        (Just foundat, notfoundat) -> return (Just (foundat, alltried))
+          where
+            alltried = concat (reverse (notfoundat : tried))
 
+    tryPathElem :: ProgramSearchPathEntry -> IO (Maybe FilePath, [FilePath])
     tryPathElem (ProgramSearchPathDir dir) =
-        findFirstExe [ dir </> prog <.> ext | ext <- extensions ]
-      where
-        -- Possible improvement: on Windows, read the list of extensions from
-        -- the PATHEXT environment variable. By default PATHEXT is ".com; .exe;
-        -- .bat; .cmd".
-        extensions = case buildOS of
-                       Windows -> ["", "exe"]
-                       Ghcjs   -> ["", "exe"]
-                       _       -> [""]
+        findFirstExe [ dir </> prog <.> ext | ext <- exeExtensions ]
 
-    tryPathElem ProgramSearchPathDefault = do
-      -- 'findExecutable' doesn't check that the path really refers to an
-      -- executable on Windows (at least with GHC < 7.8). See
-      -- https://ghc.haskell.org/trac/ghc/ticket/2184
-      mExe <- findExecutable prog
+    -- On windows, getSystemSearchPath is not guaranteed 100% correct so we
+    -- use findExecutable and then approximate the not-found-at locations.
+    tryPathElem ProgramSearchPathDefault | buildOS == Windows = do
+      mExe    <- findExecutable prog
+      syspath <- getSystemSearchPath
       case mExe of
-        Just exe -> do
-          exeExists <- doesExecutableExist exe
-          if exeExists
-            then return mExe
-            else return Nothing
-        _        -> return mExe
+        Nothing ->
+          let notfoundat = [ dir </> prog | dir <- syspath ] in
+          return (Nothing, notfoundat)
 
-    findFirstExe []     = return Nothing
-    findFirstExe (f:fs) = do
-      isExe <- doesExecutableExist f
-      if isExe
-        then return (Just f)
-        else findFirstExe fs
+        Just foundat -> do
+          let founddir   = takeDirectory foundat
+              notfoundat = [ dir </> prog
+                           | dir <- takeWhile (/= founddir) syspath ]
+          return (Just foundat, notfoundat)
+
+    -- On other OSs we can just do the simple thing
+    tryPathElem ProgramSearchPathDefault = do
+      dirs <- getSystemSearchPath
+      findFirstExe [ dir </> prog <.> ext | dir <- dirs, ext <- exeExtensions ]
+
+    -- Possible improvement: on Windows, read the list of extensions from
+    -- the PATHEXT environment variable. By default PATHEXT is ".com; .exe;
+    -- .bat; .cmd".
+    exeExtensions = case buildOS of
+                      Windows -> ["", "exe"]
+                      Ghcjs   -> ["", "exe"]
+                      _       -> [""]
+
+    findFirstExe :: [FilePath] -> IO (Maybe FilePath, [FilePath])
+    findFirstExe = go []
+      where
+        go fs' []     = return (Nothing, reverse fs')
+        go fs' (f:fs) = do
+          isExe <- doesExecutableExist f
+          if isExe
+            then return (Just f, reverse fs')
+            else go (f:fs') fs
 
 -- | Interpret a 'ProgramSearchPath' to construct a new @$PATH@ env var.
 -- Note that this is close but not perfect because on Windows the search
@@ -130,3 +153,40 @@ programSearchPathAsPATHVar searchpath = do
     getEntries ProgramSearchPathDefault   = do
       env <- getEnvironment
       return (maybe [] splitSearchPath (lookup "PATH" env))
+
+-- | Get the system search path. On Unix systems this is just the @$PATH@ env
+-- var, but on windows it's a bit more complicated.
+--
+getSystemSearchPath :: IO [FilePath]
+getSystemSearchPath = fmap nub $ do
+#if defined(mingw32_HOST_OS)
+    processdir <- liftM takeDirectory (Win32.getModuleFileName Win32.nullHANDLE)
+    currentdir <- getCurrentDirectory
+    systemdir  <- Win32.getSystemDirectory
+    windowsdir <- Win32.getWindowsDirectory
+    pathdirs   <- FilePath.getSearchPath
+    let path = processdir : currentdir
+             : systemdir  : windowsdir
+             : pathdirs
+    return path
+#else
+    FilePath.getSearchPath
+#endif
+
+findExecutable :: FilePath -> IO (Maybe FilePath)
+#if MIN_VERSION_directory(1,2,1)
+findExecutable = Directory.findExecutable
+#else
+findExecutable prog = do
+      -- With directory < 1.2.1 'findExecutable' doesn't check that the path
+      -- really refers to an executable.
+      mExe <- findExecutable prog
+      case mExe of
+        Just exe -> do
+          exeExists <- doesExecutableExist exe
+          if exeExists
+            then return mExe
+            else return Nothing
+        _     -> return mExe
+#endif
+

--- a/Cabal/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/Distribution/Simple/Program/HcPkg.hs
@@ -142,6 +142,15 @@ registerMultiInstance hpi verbosity packagedbs pkgInfo
   = runProgramInvocation verbosity
       (registerMultiInstanceInvocation hpi verbosity packagedbs (Right pkgInfo))
 
+    -- This is a trick. Older versions of GHC do not support the
+    -- --enable-multi-instance flag for ghc-pkg register but it turns out that
+    -- the same ability is available by using ghc-pkg recache. The recache
+    -- command is there to support distro package managers that like to work
+    -- by just installing files and running update commands, rather than
+    -- special add/remove commands. So the way to register by this method is
+    -- to write the package registration file directly into the package db and
+    -- then call hc-pkg recache.
+    --
   | recacheMultiInstance hpi
   = do let pkgdb = last packagedbs
        writeRegistrationFileDirectly hpi pkgdb pkgInfo

--- a/Cabal/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/Distribution/Simple/Program/HcPkg.hs
@@ -77,6 +77,8 @@ data HcPkgInfo = HcPkgInfo
   , flagPackageConf :: Bool -- ^ use package-conf option instead of package-db
   , supportsDirDbs  :: Bool -- ^ supports directory style package databases
   , requiresDirDbs  :: Bool -- ^ requires directory style package databases
+  , nativeMultiInstance  :: Bool -- ^ supports --enable-multi-instance flag
+  , recacheMultiInstance :: Bool -- ^ supports multi-instance via recache
   }
 
 -- | Call @hc-pkg@ to initialise a package database at the location {path}.

--- a/Cabal/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/Distribution/Simple/Program/HcPkg.hs
@@ -75,16 +75,22 @@ data HcPkgInfo = HcPkgInfo
   , noPkgDbStack    :: Bool -- ^ no package DB stack supported
   , noVerboseFlag   :: Bool -- ^ hc-pkg does not support verbosity flags
   , flagPackageConf :: Bool -- ^ use package-conf option instead of package-db
-  , useSingleFileDb :: Bool -- ^ requires single file package database
+  , supportsDirDbs  :: Bool -- ^ supports directory style package databases
+  , requiresDirDbs  :: Bool -- ^ requires directory style package databases
   }
 
 -- | Call @hc-pkg@ to initialise a package database at the location {path}.
 --
 -- > hc-pkg init {path}
 --
-init :: HcPkgInfo -> Verbosity -> FilePath -> IO ()
-init hpi verbosity path =
-  runProgramInvocation verbosity (initInvocation hpi verbosity path)
+init :: HcPkgInfo -> Verbosity -> Bool -> FilePath -> IO ()
+init hpi verbosity preferCompat path
+  |  not (supportsDirDbs hpi)
+ || (not (requiresDirDbs hpi) && preferCompat)
+  = writeFile path "[]"
+
+  | otherwise
+  = runProgramInvocation verbosity (initInvocation hpi verbosity path)
 
 -- | Run @hc-pkg@ using a given package DB stack, directly forwarding the
 -- provided command-line arguments to it.

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -28,6 +28,10 @@ module Distribution.Simple.Register (
     unregister,
 
     initPackageDB,
+    doesPackageDBExist,
+    createPackageDB,
+    deletePackageDB,
+
     invokeHcPkg,
     registerPackage,
     generateRegistrationInfo,
@@ -82,7 +86,8 @@ import Distribution.Verbosity as Verbosity
 
 import System.FilePath ((</>), (<.>), isAbsolute)
 import System.Directory
-         ( getCurrentDirectory )
+         ( getCurrentDirectory, removeDirectoryRecursive, removeFile
+         , doesDirectoryExist, doesFileExist )
 
 import Data.Version
 import Control.Monad (when)
@@ -225,6 +230,22 @@ createPackageDB verbosity comp progdb preferCompat dbPath =
       _              -> die $ "Distribution.Simple.Register.createPackageDB: "
                            ++ "not implemented for this compiler"
 
+doesPackageDBExist :: FilePath -> IO Bool
+doesPackageDBExist dbPath = do
+    -- currently one impl for all compiler flavours, but could change if needed
+    dir_exists <- doesDirectoryExist dbPath
+    if dir_exists
+        then return True
+        else doesFileExist dbPath
+
+deletePackageDB :: FilePath -> IO ()
+deletePackageDB dbPath = do
+    -- currently one impl for all compiler flavours, but could change if needed
+    dir_exists <- doesDirectoryExist dbPath
+    if dir_exists
+        then removeDirectoryRecursive dbPath
+        else do file_exists <- doesFileExist dbPath
+                when file_exists $ removeFile dbPath
 
 -- | Run @hc-pkg@ using a given package DB stack, directly forwarding the
 -- provided command-line arguments to it.

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -243,15 +243,18 @@ registerPackage :: Verbosity
                 -> PackageDBStack
                 -> IO ()
 registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs = do
-  case compilerFlavor (compiler lbi) of
-    GHC   -> GHC.registerPackage   verbosity installedPkgInfo lbi packageDbs
-    GHCJS -> GHCJS.registerPackage verbosity installedPkgInfo lbi packageDbs
-    LHC   -> LHC.registerPackage   verbosity installedPkgInfo lbi packageDbs
-    UHC   -> UHC.registerPackage   verbosity installedPkgInfo lbi packageDbs
+  case compilerFlavor comp of
+    GHC   -> GHC.registerPackage   verbosity      progdb packageDbs installedPkgInfo
+    GHCJS -> GHCJS.registerPackage verbosity      progdb packageDbs installedPkgInfo
+    LHC   -> LHC.registerPackage   verbosity      progdb packageDbs installedPkgInfo
+    UHC   -> UHC.registerPackage   verbosity comp progdb packageDbs installedPkgInfo
     JHC   -> notice verbosity "Registering for jhc (nothing to do)"
     HaskellSuite {} ->
-      HaskellSuite.registerPackage verbosity installedPkgInfo lbi packageDbs
+      HaskellSuite.registerPackage verbosity      progdb packageDbs installedPkgInfo
     _    -> die "Registering is not implemented for this compiler"
+  where
+    comp   = compiler lbi
+    progdb = withPrograms lbi
 
 writeHcPkgRegisterScript :: Verbosity
                          -> InstalledPackageInfo

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -114,8 +114,9 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
     case () of
      _ | modeGenerateRegFile   -> writeRegistrationFile installedPkgInfo
        | modeGenerateRegScript -> writeRegisterScript   installedPkgInfo
-       | otherwise             -> registerPackage verbosity
-                                    installedPkgInfo pkg lbi inplace packageDbs
+       | otherwise             -> do
+           setupMessage verbosity "Registering" (packageId pkg)
+           registerPackage verbosity installedPkgInfo pkg lbi inplace packageDbs
 
   where
     modeGenerateRegFile = isJust (flagToMaybe (regGenPkgConf regFlags))
@@ -241,11 +242,7 @@ registerPackage :: Verbosity
                 -> Bool
                 -> PackageDBStack
                 -> IO ()
-registerPackage verbosity installedPkgInfo pkg lbi inplace packageDbs = do
-  let msg = if inplace
-            then "In-place registering"
-            else "Registering"
-  setupMessage verbosity msg (packageId pkg)
+registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs = do
   case compilerFlavor (compiler lbi) of
     GHC   -> GHC.registerPackage   verbosity installedPkgInfo lbi packageDbs
     GHCJS -> GHCJS.registerPackage verbosity installedPkgInfo lbi packageDbs

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -121,7 +121,7 @@ register pkg@PackageDescription { library       = Just lib  } lbi regFlags
        | modeGenerateRegScript -> writeRegisterScript   installedPkgInfo
        | otherwise             -> do
            setupMessage verbosity "Registering" (packageId pkg)
-           registerPackage verbosity (compiler lbi) (withPrograms lbi)
+           registerPackage verbosity (compiler lbi) (withPrograms lbi) False
                            packageDbs installedPkgInfo
 
   where
@@ -268,13 +268,16 @@ withHcPkg name comp conf f =
 registerPackage :: Verbosity
                 -> Compiler
                 -> ProgramConfiguration
+                -> Bool
                 -> PackageDBStack
                 -> InstalledPackageInfo
                 -> IO ()
-registerPackage verbosity comp progdb packageDbs installedPkgInfo = do
+registerPackage verbosity comp progdb multiInstance packageDbs installedPkgInfo =
   case compilerFlavor comp of
-    GHC   -> GHC.registerPackage   verbosity      progdb packageDbs installedPkgInfo
-    GHCJS -> GHCJS.registerPackage verbosity      progdb packageDbs installedPkgInfo
+    GHC   -> GHC.registerPackage   verbosity progdb multiInstance packageDbs installedPkgInfo
+    GHCJS -> GHCJS.registerPackage verbosity progdb multiInstance packageDbs installedPkgInfo
+    _ | multiInstance
+          -> die "Registering multiple package instances is not yet supported for this compiler"
     LHC   -> LHC.registerPackage   verbosity      progdb packageDbs installedPkgInfo
     UHC   -> UHC.registerPackage   verbosity comp progdb packageDbs installedPkgInfo
     JHC   -> notice verbosity "Registering for jhc (nothing to do)"

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -247,13 +247,13 @@ registerPackage verbosity installedPkgInfo pkg lbi inplace packageDbs = do
             else "Registering"
   setupMessage verbosity msg (packageId pkg)
   case compilerFlavor (compiler lbi) of
-    GHC   -> GHC.registerPackage   verbosity installedPkgInfo pkg lbi inplace packageDbs
-    GHCJS -> GHCJS.registerPackage verbosity installedPkgInfo pkg lbi inplace packageDbs
-    LHC   -> LHC.registerPackage   verbosity installedPkgInfo pkg lbi inplace packageDbs
-    UHC   -> UHC.registerPackage   verbosity installedPkgInfo pkg lbi inplace packageDbs
+    GHC   -> GHC.registerPackage   verbosity installedPkgInfo lbi packageDbs
+    GHCJS -> GHCJS.registerPackage verbosity installedPkgInfo lbi packageDbs
+    LHC   -> LHC.registerPackage   verbosity installedPkgInfo lbi packageDbs
+    UHC   -> UHC.registerPackage   verbosity installedPkgInfo lbi packageDbs
     JHC   -> notice verbosity "Registering for jhc (nothing to do)"
     HaskellSuite {} ->
-      HaskellSuite.registerPackage verbosity installedPkgInfo pkg lbi inplace packageDbs
+      HaskellSuite.registerPackage verbosity installedPkgInfo lbi packageDbs
     _    -> die "Registering is not implemented for this compiler"
 
 writeHcPkgRegisterScript :: Verbosity

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -54,6 +54,7 @@ module Distribution.Simple.Setup (
   configureArgs, configureOptions, configureCCompiler, configureLinker,
   buildOptions, haddockOptions, installDirsOptions,
   programConfigurationOptions, programConfigurationPaths',
+  splitArgs,
 
   defaultDistPref, optionDistPref,
 

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -83,7 +83,7 @@ import Distribution.Simple.Compiler
          ( CompilerFlavor(..), defaultCompilerFlavor, PackageDB(..)
          , DebugInfoLevel(..), flagToDebugInfoLevel
          , OptimisationLevel(..), flagToOptimisationLevel
-         , ProfDetailLevel(..), flagToProfDetailLevel
+         , ProfDetailLevel(..), flagToProfDetailLevel, showProfDetailLevel
          , absolutePackageDBPath )
 import Distribution.Simple.Utils
          ( wrapText, wrapLine, lowercase, intercalate )
@@ -671,16 +671,8 @@ showPackageDbList = map showPackageDb
     showPackageDb (Just (SpecificPackageDB db)) = db
 
 showProfDetailLevelFlag :: Flag ProfDetailLevel -> [String]
-showProfDetailLevelFlag dl =
-  case dl of
-    NoFlag                           -> []
-    Flag ProfDetailNone              -> ["none"]
-    Flag ProfDetailDefault           -> ["default"]
-    Flag ProfDetailExportedFunctions -> ["exported-functions"]
-    Flag ProfDetailToplevelFunctions -> ["toplevel-functions"]
-    Flag ProfDetailAllFunctions      -> ["all-functions"]
-    Flag (ProfDetailOther other)     -> [other]
-
+showProfDetailLevelFlag NoFlag    = []
+showProfDetailLevelFlag (Flag dl) = [showProfDetailLevel dl]
 
 parseDependency :: Parse.ReadP r (PackageName, ComponentId)
 parseDependency = do

--- a/Cabal/Distribution/Simple/UHC.hs
+++ b/Cabal/Distribution/Simple/UHC.hs
@@ -264,13 +264,14 @@ uhcPackageSubDir       compilerid = compilerid </> uhcTarget </> uhcTargetVarian
 
 registerPackage
   :: Verbosity
-  -> InstalledPackageInfo
-  -> LocalBuildInfo
+  -> Compiler
+  -> ProgramConfiguration
   -> PackageDBStack
+  -> InstalledPackageInfo
   -> IO ()
-registerPackage verbosity installedPkgInfo lbi packageDbs = do
+registerPackage verbosity comp progdb packageDbs installedPkgInfo = do
     dbdir <- case last packageDbs of
-      GlobalPackageDB       -> getGlobalPackageDir verbosity (withPrograms lbi)
+      GlobalPackageDB       -> getGlobalPackageDir verbosity progdb
       UserPackageDB         -> getUserPackageDir
       SpecificPackageDB dir -> return dir
     let pkgdir = dbdir </> uhcPackageDir (display pkgid) (display compilerid)
@@ -279,4 +280,4 @@ registerPackage verbosity installedPkgInfo lbi packageDbs = do
                   (showInstalledPackageInfo installedPkgInfo)
   where
     pkgid      = sourcePackageId installedPkgInfo
-    compilerid = compilerId (compiler lbi)
+    compilerid = compilerId comp

--- a/Cabal/Distribution/Simple/UHC.hs
+++ b/Cabal/Distribution/Simple/UHC.hs
@@ -16,7 +16,7 @@
 
 module Distribution.Simple.UHC (
     configure, getInstalledPackages,
-    buildLib, buildExe, installLib, registerPackage
+    buildLib, buildExe, installLib, registerPackage, inplacePackageDbPath
   ) where
 
 import Control.Monad
@@ -281,3 +281,6 @@ registerPackage verbosity comp progdb packageDbs installedPkgInfo = do
   where
     pkgid      = sourcePackageId installedPkgInfo
     compilerid = compilerId comp
+
+inplacePackageDbPath :: LocalBuildInfo -> FilePath
+inplacePackageDbPath lbi = buildDir lbi

--- a/Cabal/Distribution/Simple/UHC.hs
+++ b/Cabal/Distribution/Simple/UHC.hs
@@ -91,14 +91,13 @@ getInstalledPackages :: Verbosity -> Compiler -> PackageDBStack -> ProgramConfig
                      -> IO InstalledPackageIndex
 getInstalledPackages verbosity comp packagedbs conf = do
   let compilerid = compilerId comp
-  systemPkgDir <- rawSystemProgramStdoutConf verbosity uhcProgram conf ["--meta-pkgdir-system"]
+  systemPkgDir <- getGlobalPackageDir verbosity conf
   userPkgDir   <- getUserPackageDir
   let pkgDirs    = nub (concatMap (packageDbPaths userPkgDir systemPkgDir) packagedbs)
   -- putStrLn $ "pkgdirs: " ++ show pkgDirs
-  -- call to "lines" necessary, because pkgdir contains an extra newline at the end
-  pkgs <- liftM (map addBuiltinVersions . concat) .
-          mapM (\ d -> getDirectoryContents d >>= filterM (isPkgDir (display compilerid) d)) .
-          concatMap lines $ pkgDirs
+  pkgs <- liftM (map addBuiltinVersions . concat) $
+          mapM (\ d -> getDirectoryContents d >>= filterM (isPkgDir (display compilerid) d))
+          pkgDirs
   -- putStrLn $ "pkgs: " ++ show pkgs
   let iPkgs =
         map mkInstalledPackageInfo $
@@ -107,9 +106,16 @@ getInstalledPackages verbosity comp packagedbs conf = do
   -- putStrLn $ "installed pkgs: " ++ show iPkgs
   return (fromList iPkgs)
 
+getGlobalPackageDir :: Verbosity -> ProgramConfiguration -> IO FilePath
+getGlobalPackageDir verbosity conf = do
+    output <- rawSystemProgramStdoutConf verbosity
+                uhcProgram conf ["--meta-pkgdir-system"]
+    -- call to "lines" necessary, because pkgdir contains an extra newline at the end
+    let [pkgdir] = lines output
+    return pkgdir
+
 getUserPackageDir :: IO FilePath
-getUserPackageDir =
-  do
+getUserPackageDir = do
     homeDir <- getHomeDirectory
     return $ homeDir </> ".cabal" </> "lib"  -- TODO: determine in some other way
 
@@ -161,7 +167,7 @@ buildLib :: Verbosity -> PackageDescription -> LocalBuildInfo
                       -> Library            -> ComponentLocalBuildInfo -> IO ()
 buildLib verbosity pkg_descr lbi lib clbi = do
 
-  systemPkgDir <- rawSystemProgramStdoutConf verbosity uhcProgram (withPrograms lbi) ["--meta-pkgdir-system"]
+  systemPkgDir <- getGlobalPackageDir verbosity (withPrograms lbi)
   userPkgDir   <- getUserPackageDir
   let runUhcProg = rawSystemProgramConf verbosity uhcProgram (withPrograms lbi)
   let uhcArgs =    -- set package name
@@ -183,7 +189,7 @@ buildLib verbosity pkg_descr lbi lib clbi = do
 buildExe :: Verbosity -> PackageDescription -> LocalBuildInfo
                       -> Executable         -> ComponentLocalBuildInfo -> IO ()
 buildExe verbosity _pkg_descr lbi exe clbi = do
-  systemPkgDir <- rawSystemProgramStdoutConf verbosity uhcProgram (withPrograms lbi) ["--meta-pkgdir-system"]
+  systemPkgDir <- getGlobalPackageDir verbosity (withPrograms lbi)
   userPkgDir   <- getUserPackageDir
   let runUhcProg = rawSystemProgramConf verbosity uhcProgram (withPrograms lbi)
   let uhcArgs =    -- common flags lib/exe

--- a/Cabal/Distribution/Simple/UHC.hs
+++ b/Cabal/Distribution/Simple/UHC.hs
@@ -265,12 +265,10 @@ uhcPackageSubDir       compilerid = compilerid </> uhcTarget </> uhcTargetVarian
 registerPackage
   :: Verbosity
   -> InstalledPackageInfo
-  -> PackageDescription
   -> LocalBuildInfo
-  -> Bool
   -> PackageDBStack
   -> IO ()
-registerPackage verbosity installedPkgInfo _pkg lbi _inplace packageDbs = do
+registerPackage verbosity installedPkgInfo lbi packageDbs = do
     dbdir <- case last packageDbs of
       GlobalPackageDB       -> getGlobalPackageDir verbosity (withPrograms lbi)
       UserPackageDB         -> getUserPackageDir

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -572,6 +572,8 @@ rawSystemStdInOut verbosity path args mcwd menv input outputBinary = do
       return (out, err, exitcode)
 
 
+{-# DEPRECATED findProgramLocation
+    "No longer used within Cabal, try findProgramOnSearchPath" #-}
 -- | Look for a program on the path.
 findProgramLocation :: Verbosity -> FilePath -> IO (Maybe FilePath)
 findProgramLocation verbosity prog = do


### PR DESCRIPTION
@23Skidoo @hvr ping

A series of patches to the Cabal lib that are needed for the nix-local-build branch of cabal-install.

There's quite a few patches here because I've tried to make each one be clear and do one thing.

Summary:

 * Misc exports of useful functions
 * Extra instances
 * Change the interface to registerPackage so we can use it in cabal-install. This allows cabal-install to register things itself, rather than always relying on Setup register. This requires that registerPackage take fewer unnecessary or big arguments (like LocalBuildInfo).
 * Extend registerPackage with a multi-instance capability
 * Add compiler-independent utils for creating, deleting and testing existence of package dbs, including requesting using dir-style, but keeping the ability for Cabal lib to use file style in preference
 * Expose enough info to be able to do file change monitoring, for package dbs and for programs. This just means reporting file locations of things, so that cabal-install can monitor those files for changes.