### PR TITLE
Type refactoring

### DIFF
--- a/cabal-install/Distribution/Client/BuildReports/Storage.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Storage.hs
@@ -79,7 +79,9 @@ storeAnonymous reports = sequence_
                -> [(BuildReport, Repo, RemoteRepo)]
     onlyRemote rs =
       [ (report, repo, remoteRepo)
-      | (report, Just repo@Repo { repoKind = Left remoteRepo }) <- rs ]
+      | (report, Just repo) <- rs
+      , Just remoteRepo     <- [repoRemote' repo]
+      ]
 
 storeLocal :: CompilerInfo -> [PathTemplate] -> [(BuildReport, Maybe Repo)]
            -> Platform -> IO ()

--- a/cabal-install/Distribution/Client/BuildReports/Storage.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Storage.hs
@@ -80,7 +80,7 @@ storeAnonymous reports = sequence_
     onlyRemote rs =
       [ (report, repo, remoteRepo)
       | (report, Just repo) <- rs
-      , Just remoteRepo     <- [repoRemote' repo]
+      , Just remoteRepo     <- [maybeRepoRemote repo]
       ]
 
 storeLocal :: CompilerInfo -> [PathTemplate] -> [(BuildReport, Maybe Repo)]

--- a/cabal-install/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/Distribution/Client/FetchUtils.hs
@@ -11,6 +11,7 @@
 --
 -- Functions for fetching packages
 -----------------------------------------------------------------------------
+{-# LANGUAGE RecordWildCards #-}
 module Distribution.Client.FetchUtils (
 
     -- * fetching packages
@@ -131,14 +132,14 @@ fetchRepoTarball transport verbosity repo pkgid = do
     else do setupMessage verbosity "Downloading" pkgid
             downloadRepoPackage
   where
-    downloadRepoPackage = case repoKind repo of
-      Right LocalRepo -> return (packageFile repo pkgid)
+    downloadRepoPackage = case repo of
+      RepoLocal{..} -> return (packageFile repo pkgid)
 
-      Left remoteRepo -> do
-        remoteRepoCheckHttps transport remoteRepo
-        let uri  = packageURI remoteRepo pkgid
-            dir  = packageDir       repo pkgid
-            path = packageFile      repo pkgid
+      RepoRemote{..} -> do
+        remoteRepoCheckHttps transport repoRemote
+        let uri  = packageURI  repoRemote pkgid
+            dir  = packageDir  repo       pkgid
+            path = packageFile repo       pkgid
         createDirectoryIfMissing True dir
         _ <- downloadURI transport verbosity uri path
         return path

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -173,24 +173,24 @@ readRepoIndex verbosity repo mode =
 
     handleNotFound action = catchIO action $ \e -> if isDoesNotExistError e
       then do
-        case repoKind repo of
-          Left  remoteRepo -> warn verbosity $
-               "The package list for '" ++ remoteRepoName remoteRepo
+        case repo of
+          RepoRemote{..} -> warn verbosity $
+               "The package list for '" ++ remoteRepoName repoRemote
             ++ "' does not exist. Run 'cabal update' to download it."
-          Right _localRepo -> warn verbosity $
-               "The package list for the local repo '" ++ repoLocalDir repo
+          RepoLocal{..} -> warn verbosity $
+               "The package list for the local repo '" ++ repoLocalDir
             ++ "' is missing. The repo is invalid."
         return mempty
       else ioError e
 
     isOldThreshold = 15 --days
     warnIfIndexIsOld dt = do
-      when (dt >= isOldThreshold) $ case repoKind repo of
-        Left  remoteRepo -> warn verbosity $
-             "The package list for '" ++ remoteRepoName remoteRepo
+      when (dt >= isOldThreshold) $ case repo of
+        RepoRemote{..} -> warn verbosity $
+             "The package list for '" ++ remoteRepoName repoRemote
           ++ "' is " ++ shows (floor dt :: Int) " days old.\nRun "
           ++ "'cabal update' to get the latest list of available packages."
-        Right _localRepo -> return ()
+        RepoLocal{..} -> return ()
 
 
 -- | Return the age of the index file in days (as a Double).

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -839,7 +839,8 @@ storeDetailedBuildReports verbosity logsDir reports = sequence_
          createDirectoryIfMissing True reportsDir -- FIXME
          writeFile reportFile (show (BuildReports.show report, buildLog))
 
-  | (report, Just Repo { repoKind = Left remoteRepo }) <- reports
+  | (report, Just repo) <- reports
+  , Just remoteRepo <- [repoRemote' repo]
   , isLikelyToHaveLogFile (BuildReports.installOutcome report) ]
 
   where

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -840,7 +840,7 @@ storeDetailedBuildReports verbosity logsDir reports = sequence_
          writeFile reportFile (show (BuildReports.show report, buildLog))
 
   | (report, Just repo) <- reports
-  , Just remoteRepo <- [repoRemote' repo]
+  , Just remoteRepo <- [maybeRepoRemote repo]
   , isLikelyToHaveLogFile (BuildReports.installOutcome report) ]
 
   where

--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -45,7 +45,7 @@ module Distribution.Client.Sandbox (
 import Distribution.Client.Setup
   ( SandboxFlags(..), ConfigFlags(..), ConfigExFlags(..), InstallFlags(..)
   , GlobalFlags(..), defaultConfigExFlags, defaultInstallFlags
-  , defaultSandboxLocation, globalRepos )
+  , defaultSandboxLocation, withGlobalRepos )
 import Distribution.Client.Sandbox.Timestamp  ( listModifiedDeps
                                               , maybeAddCompilerTimestampRecord
                                               , withAddTimestamps
@@ -656,9 +656,10 @@ reinstallAddSourceDeps verbosity configFlags' configExFlags
                          comp platform conf sandboxDir $ \sandboxPkgInfo ->
     unless (null $ modifiedAddSourceDependencies sandboxPkgInfo) $ do
 
+     withGlobalRepos verbosity globalFlags $ \globalRepos -> do
       let args :: InstallArgs
           args = ((configPackageDB' configFlags)
-                 ,(globalRepos globalFlags)
+                 ,globalRepos
                  ,comp, platform, conf
                  ,UseSandbox sandboxDir, Just sandboxPkgInfo
                  ,globalFlags, configFlags, configExFlags, installFlags

--- a/cabal-install/Distribution/Client/Sandbox/Index.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Index.hs
@@ -24,7 +24,8 @@ import Distribution.Client.IndexUtils ( BuildTreeRefType(..)
                                       , refTypeFromTypeCode
                                       , typeCodeFromRefType
                                       , updatePackageIndexCacheFile
-                                      , getSourcePackagesStrict )
+                                      , getSourcePackagesStrict
+                                      , Index(..) )
 import Distribution.Client.PackageIndex ( allPackages )
 import Distribution.Client.Types ( Repo(..), LocalRepo(..)
                                  , SourcePackageDb(..)
@@ -155,8 +156,10 @@ addBuildTreeRefs verbosity path l' refType = do
       hSeek h AbsoluteSeek (fromIntegral offset)
       BS.hPut h (Tar.write entries)
       debug verbosity $ "Successfully appended to '" ++ path ++ "'"
-    updatePackageIndexCacheFile verbosity path
-      (path `replaceExtension` "cache")
+    updatePackageIndexCacheFile verbosity $ LocalIndex {
+        localIndexFile = path
+      , localCacheFile = path `replaceExtension` "cache"
+      }
 
 data DeleteSourceError = ErrNonregisteredSource { nrPath :: FilePath }
                        | ErrNonexistentSource   { nePath :: FilePath } deriving Show
@@ -191,7 +194,10 @@ removeBuildTreeRefs verbosity indexPath l = do
     ++ "' to '" ++ indexPath ++ "'"
 
   unless (null removedRefs) $
-    updatePackageIndexCacheFile verbosity indexPath (indexPath `replaceExtension` "cache")
+    updatePackageIndexCacheFile verbosity LocalIndex {
+        localIndexFile = indexPath
+      , localCacheFile = indexPath `replaceExtension` "cache"
+      }
 
   let results = fmap Right removedRefs
                 ++ fmap Left failures

--- a/cabal-install/Distribution/Client/Sandbox/Index.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Index.hs
@@ -27,7 +27,7 @@ import Distribution.Client.IndexUtils ( BuildTreeRefType(..)
                                       , getSourcePackagesStrict
                                       , Index(..) )
 import Distribution.Client.PackageIndex ( allPackages )
-import Distribution.Client.Types ( Repo(..), LocalRepo(..)
+import Distribution.Client.Types ( Repo(..)
                                  , SourcePackageDb(..)
                                  , SourcePackage(..), PackageLocation(..) )
 import Distribution.Client.Utils ( byteStringToFilePath, filePathToByteString
@@ -271,8 +271,7 @@ listBuildTreeRefs verbosity listIgnored refTypesToList path = do
 
       listWithoutIgnored :: IO [FilePath]
       listWithoutIgnored = do
-        let repo = Repo { repoKind = Right LocalRepo
-                        , repoLocalDir = takeDirectory path }
+        let repo = RepoLocal { repoLocalDir = takeDirectory path }
         pkgIndex <- fmap packageIndex
                     . getSourcePackagesStrict verbosity $ [repo]
         return [ pkgPath | (LocalUnpackedPackage pkgPath) <-

--- a/cabal-install/Distribution/Client/Sandbox/Index.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Index.hs
@@ -48,8 +48,7 @@ import Data.Either               (partitionEithers)
 import System.Directory          ( createDirectoryIfMissing,
                                    doesDirectoryExist, doesFileExist,
                                    renameFile, canonicalizePath)
-import System.FilePath           ( (</>), (<.>), takeDirectory, takeExtension
-                                 , replaceExtension )
+import System.FilePath           ( (</>), (<.>), takeDirectory, takeExtension )
 import System.IO                 ( IOMode(..), SeekMode(..)
                                  , hSeek, withBinaryFile )
 
@@ -156,10 +155,7 @@ addBuildTreeRefs verbosity path l' refType = do
       hSeek h AbsoluteSeek (fromIntegral offset)
       BS.hPut h (Tar.write entries)
       debug verbosity $ "Successfully appended to '" ++ path ++ "'"
-    updatePackageIndexCacheFile verbosity $ LocalIndex {
-        localIndexFile = path
-      , localCacheFile = path `replaceExtension` "cache"
-      }
+    updatePackageIndexCacheFile verbosity $ SandboxIndex path
 
 data DeleteSourceError = ErrNonregisteredSource { nrPath :: FilePath }
                        | ErrNonexistentSource   { nePath :: FilePath } deriving Show
@@ -194,10 +190,7 @@ removeBuildTreeRefs verbosity indexPath l = do
     ++ "' to '" ++ indexPath ++ "'"
 
   unless (null removedRefs) $
-    updatePackageIndexCacheFile verbosity LocalIndex {
-        localIndexFile = indexPath
-      , localCacheFile = indexPath `replaceExtension` "cache"
-      }
+    updatePackageIndexCacheFile verbosity $ SandboxIndex indexPath
 
   let results = fmap Right removedRefs
                 ++ fmap Left failures

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -49,7 +49,7 @@ module Distribution.Client.Setup
     ) where
 
 import Distribution.Client.Types
-         ( Username(..), Password(..), Repo(..), RemoteRepo(..), LocalRepo(..) )
+         ( Username(..), Password(..), Repo(..), RemoteRepo(..) )
 import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
 import Distribution.Client.Dependency.Types
@@ -381,12 +381,12 @@ globalRepos :: GlobalFlags -> [Repo]
 globalRepos globalFlags = remoteRepos ++ localRepos
   where
     remoteRepos =
-      [ Repo (Left remote) cacheDir
+      [ RepoRemote remote cacheDir
       | remote <- fromNubList $ globalRemoteRepos globalFlags
       , let cacheDir = fromFlag (globalCacheDir globalFlags)
                    </> remoteRepoName remote ]
     localRepos =
-      [ Repo (Right LocalRepo) local
+      [ RepoLocal local
       | local <- fromNubList $ globalLocalRepos globalFlags ]
 
 -- ------------------------------------------------------------

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -12,7 +12,7 @@
 --
 -----------------------------------------------------------------------------
 module Distribution.Client.Setup
-    ( globalCommand, GlobalFlags(..), defaultGlobalFlags, globalRepos
+    ( globalCommand, GlobalFlags(..), defaultGlobalFlags, withGlobalRepos
     , configureCommand, ConfigFlags(..), filterConfigureFlags
     , configureExCommand, ConfigExFlags(..), defaultConfigExFlags
                         , configureExOptions
@@ -377,8 +377,9 @@ instance Monoid GlobalFlags where
   }
     where combine field = field a `mappend` field b
 
-globalRepos :: GlobalFlags -> [Repo]
-globalRepos globalFlags = remoteRepos ++ localRepos
+withGlobalRepos :: Verbosity -> GlobalFlags -> ([Repo] -> IO a) -> IO a
+withGlobalRepos _verbosity globalFlags callback =
+    callback $ remoteRepos ++ localRepos
   where
     remoteRepos =
       [ RepoRemote remote cacheDir

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -255,9 +255,9 @@ data Repo =
 deriving instance Show Repo
 
 -- | Check if this is a remote repo
-repoRemote' :: Repo -> Maybe RemoteRepo
-repoRemote' (RepoLocal    _localDir  ) = Nothing
-repoRemote' (RepoRemote r _localDir  ) = Just r
+maybeRepoRemote :: Repo -> Maybe RemoteRepo
+maybeRepoRemote (RepoLocal    _localDir  ) = Nothing
+maybeRepoRemote (RepoRemote r _localDir  ) = Just r
 
 -- ------------------------------------------------------------
 -- * Build results

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE StandaloneDeriving #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Types
@@ -208,9 +209,6 @@ data PackageLocation local =
 --  | ScmPackage
   deriving (Show, Functor)
 
-data LocalRepo = LocalRepo
-  deriving (Show,Eq)
-
 data RemoteRepo =
     RemoteRepo {
       remoteRepoName     :: String,
@@ -242,11 +240,24 @@ data RemoteRepo =
 emptyRemoteRepo :: String -> RemoteRepo
 emptyRemoteRepo name = RemoteRepo name nullURI False [] 0 False
 
-data Repo = Repo {
-    repoKind     :: Either RemoteRepo LocalRepo,
-    repoLocalDir :: FilePath
-  }
-  deriving (Show,Eq)
+data Repo =
+    -- | Local repositories
+    RepoLocal {
+        repoLocalDir :: FilePath
+      }
+
+    -- | Standard (unsecured) remote repositores
+  | RepoRemote {
+        repoRemote   :: RemoteRepo
+      , repoLocalDir :: FilePath
+      }
+
+deriving instance Show Repo
+
+-- | Check if this is a remote repo
+repoRemote' :: Repo -> Maybe RemoteRepo
+repoRemote' (RepoLocal    _localDir  ) = Nothing
+repoRemote' (RepoRemote r _localDir  ) = Just r
 
 -- ------------------------------------------------------------
 -- * Build results

--- a/cabal-install/Distribution/Client/Update.hs
+++ b/cabal-install/Distribution/Client/Update.hs
@@ -21,7 +21,7 @@ import Distribution.Client.HttpUtils
 import Distribution.Client.FetchUtils
          ( downloadIndex )
 import Distribution.Client.IndexUtils
-         ( updateRepoIndexCache )
+         ( updateRepoIndexCache, Index(..) )
 import Distribution.Client.JobControl
          ( newParallelJobControl, spawnJob, collectJob )
 
@@ -64,4 +64,4 @@ updateRepo transport verbosity repo = case repoKind repo of
       FileDownloaded indexPath -> do
         writeFileAtomic (dropExtension indexPath) . maybeDecompress
                                                 =<< BS.readFile indexPath
-        updateRepoIndexCache verbosity repo
+        updateRepoIndexCache verbosity (GlobalIndex repo)

--- a/cabal-install/Distribution/Client/Update.hs
+++ b/cabal-install/Distribution/Client/Update.hs
@@ -16,7 +16,7 @@ module Distribution.Client.Update
     ) where
 
 import Distribution.Client.Types
-         ( Repo(..), RemoteRepo(..), repoRemote' )
+         ( Repo(..), RemoteRepo(..), maybeRepoRemote )
 import Distribution.Client.HttpUtils
          ( DownloadResult(..), HttpTransport(..) )
 import Distribution.Client.FetchUtils
@@ -43,7 +43,7 @@ update _ verbosity [] =
                 ++ "you would have one specified in the config file."
 update transport verbosity repos = do
   jobCtrl <- newParallelJobControl
-  let remoteRepos = catMaybes (map repoRemote' repos)
+  let remoteRepos = catMaybes (map maybeRepoRemote repos)
   case remoteRepos of
     [] -> return ()
     [remoteRepo] ->
@@ -65,4 +65,4 @@ updateRepo transport verbosity repo = case repo of
       FileDownloaded indexPath -> do
         writeFileAtomic (dropExtension indexPath) . maybeDecompress
                                                 =<< BS.readFile indexPath
-        updateRepoIndexCache verbosity (GlobalIndex repo)
+        updateRepoIndexCache verbosity (RepoIndex repo)

--- a/cabal-install/Distribution/Client/Upload.hs
+++ b/cabal-install/Distribution/Client/Upload.hs
@@ -4,7 +4,7 @@
 module Distribution.Client.Upload (check, upload, uploadDoc, report) where
 
 import Distribution.Client.Types ( Username(..), Password(..)
-                                 , Repo(..), RemoteRepo(..), repoRemote' )
+                                 , Repo(..), RemoteRepo(..), maybeRepoRemote )
 import Distribution.Client.HttpUtils
          ( HttpTransport(..), remoteRepoTryUpgradeToHttps )
 
@@ -38,7 +38,7 @@ upload :: HttpTransport -> Verbosity -> [Repo]
        -> IO ()
 upload transport verbosity repos mUsername mPassword paths = do
     targetRepo <-
-      case [ remoteRepo | Just remoteRepo <- map repoRemote' repos ] of
+      case [ remoteRepo | Just remoteRepo <- map maybeRepoRemote repos ] of
         [] -> die "Cannot upload. No remote repositories are configured."
         rs -> remoteRepoTryUpgradeToHttps transport (last rs)
     let targetRepoURI = remoteRepoURI targetRepo
@@ -59,7 +59,7 @@ uploadDoc :: HttpTransport -> Verbosity -> [Repo]
           -> IO ()
 uploadDoc transport verbosity repos mUsername mPassword path = do
     targetRepo <-
-      case [ remoteRepo | Just remoteRepo <- map repoRemote' repos ] of
+      case [ remoteRepo | Just remoteRepo <- map maybeRepoRemote repos ] of
         [] -> die $ "Cannot upload. No remote repositories are configured."
         rs -> remoteRepoTryUpgradeToHttps transport (last rs)
     let targetRepoURI = remoteRepoURI targetRepo
@@ -113,7 +113,7 @@ report verbosity repos mUsername mPassword = do
   Username username <- maybe promptUsername return mUsername
   Password password <- maybe promptPassword return mPassword
   let auth = (username,password)
-  let remoteRepos = catMaybes (map repoRemote' repos)
+  let remoteRepos = catMaybes (map maybeRepoRemote repos)
   forM_ remoteRepos $ \remoteRepo ->
       do dotCabal <- defaultCabalDir
          let srcDir = dotCabal </> "reports" </> remoteRepoName remoteRepo


### PR DESCRIPTION
This PR introduces four small changes; none of these change any functionality: they just change types around a bit to facilitate further changes in later PRs.

* `Index`

The first commit introduces

``` haskell
-- | Which index do we mean?
data Index =
    -- | The global index for the specified repository
    GlobalIndex Repo
    -- | A (sandbox) local repository
  | LocalIndex { localIndexFile :: FilePath, localCacheFile :: FilePath }
```

and then uses this in lieu of passing in two `FilePath`s to lots of functions. This means the definitions

``` haskell
indexFile (GlobalIndex repo) = repoLocalDir repo </> "00-index.tar"
cacheFile (GlobalIndex repo) = repoLocalDir repo </> "00-index.cache"
```

now only live in once place, and moreover we can, if we wanted, do something special in certain cases for certain kinds of `Repo`s (we will need that functionality later).

* `Cache`

The second commit introduces a type for the index cache; right now it's just a wrapper around the cache entries

```
data Cache = Cache {
    cacheEntries :: [IndexCacheEntry]
  }
```

This should make it a little easier to extend or change the cache format if we wanted to do that.

* `Repo`

The old `Repo` type was defined as

``` haskell
data Repo = Repo {
    repoKind     :: Either RemoteRepo LocalRepo,
    repoLocalDir :: FilePath
  }
```

where `LocalRepo` was isomorphic to unit:

``` haskell
data LocalRepo = LocalRepo
```

This commit changes `Repo` to

``` haskell
data Repo =
    -- | Local repositories
    RepoLocal {
        repoLocalDir :: FilePath
      }

    -- | Standard (unsecured) remote repositores
  | RepoRemote {
        repoRemote   :: RemoteRepo
      , repoLocalDir :: FilePath
      }
```

instead, which is a little more idiomatic and will make adding more repository types easier.

* `withGlobalRepos`

Finally, the last commit changes

``` haskell 
globalRepos :: GlobalFlags -> [Repo]
```

to

``` haskell
withGlobalRepos :: Verbosity -> GlobalFlags -> ([Repo] -> IO a) -> IO a
```

This will be necessary for repositories that need to do some repository-specific initialization (even if we don't currently have any, we will soon). The `Verbosity` flag is not used yet, but will be.