### PR TITLE
Remove magic value from `globalCommand`

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -264,9 +264,17 @@ globalCommand commands = CommandUI {
       ++ "  " ++ pname ++ " update\n",
     commandNotes = Nothing,
     commandDefaultFlags = mempty,
-    commandOptions      = \showOrParseArgs ->
-      (case showOrParseArgs of ShowArgs -> take 8; ParseArgs -> id)
-      [option ['V'] ["version"]
+    commandOptions = args
+  }
+  where
+    args :: ShowOrParseArgs -> [OptionField GlobalFlags]
+    args ShowArgs  = argsShown
+    args ParseArgs = argsShown ++ argsNotShown
+
+    -- arguments we want to show in the help
+    argsShown :: [OptionField GlobalFlags]
+    argsShown = [
+       option ['V'] ["version"]
          "Print version information"
          globalVersion (\v flags -> flags { globalVersion = v })
          trueArg
@@ -305,8 +313,12 @@ globalCommand commands = CommandUI {
          "Set a transport for http(s) requests. Accepts 'curl', 'wget', 'powershell', and 'plain-http'. (default: 'curl')"
          globalConfigFile (\v flags -> flags { globalHttpTransport = v })
          (reqArgFlag "HttpTransport")
+      ]
 
-      ,option [] ["remote-repo"]
+    -- arguments we don't want shown in the help
+    argsNotShown :: [OptionField GlobalFlags]
+    argsNotShown = [
+       option [] ["remote-repo"]
          "The name and url for a remote repository"
          globalRemoteRepos (\v flags -> flags { globalRemoteRepos = v })
          (reqArg' "NAME:URL" (toNubList . maybeToList . readRepo) (map showRepo . fromNubList))
@@ -331,7 +343,6 @@ globalCommand commands = CommandUI {
          globalWorldFile (\v flags -> flags { globalWorldFile = v })
          (reqArgFlag "FILE")
       ]
-  }
 
 instance Monoid GlobalFlags where
   mempty = GlobalFlags {


### PR DESCRIPTION
In the definition of `globalCommand` we had

``` haskell
    (case showOrParseArgs of ShowArgs -> take 8; ParseArgs -> id) [..]
```

the intention here is that the first 8 options will be shown when the user asks for `--help`, and the rest are not. However, this is rather error prone. If we forget to update that value when adding a new command line argument, we might either be wondering why the option isn't showing in the help text, or--worse--push another flag out of the help text without noticing.

This commit changes this to

``` haskell
    args ShowArgs  = argsShown
    args ParseArgs = argsShown ++ argsNotShown

    argsShown    = [..]
    argsNotShown = [..]
```

which is a lot more robust.