### PR TITLE
Extend repo config with security settings

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2310,7 +2310,9 @@ parseRepo = do
   return RemoteRepo {
     remoteRepoName           = name,
     remoteRepoURI            = uri,
-    remoteRepoRootKeys       = (),
+    remoteRepoSecure         = False,
+    remoteRepoRootKeys       = [],
+    remoteRepoKeyThreshold   = 0,
     remoteRepoShouldTryHttps = False
   }
 

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -215,7 +215,15 @@ data RemoteRepo =
     RemoteRepo {
       remoteRepoName     :: String,
       remoteRepoURI      :: URI,
-      remoteRepoRootKeys :: (),
+
+      -- | Enable secure access to Hackage?
+      remoteRepoSecure :: Bool,
+
+      -- | Root key IDs (for bootstrapping)
+      remoteRepoRootKeys :: [String],
+
+      -- | Threshold for verification during bootstrapping
+      remoteRepoKeyThreshold :: Int,
 
       -- | Normally a repo just specifies an HTTP or HTTPS URI, but as a
       -- special case we may know a repo supports both and want to try HTTPS
@@ -232,7 +240,7 @@ data RemoteRepo =
 
 -- | Construct a partial 'RemoteRepo' value to fold the field parser list over.
 emptyRemoteRepo :: String -> RemoteRepo
-emptyRemoteRepo name = RemoteRepo name nullURI () False
+emptyRemoteRepo name = RemoteRepo name nullURI False [] 0 False
 
 data Repo = Repo {
     repoKind     :: Either RemoteRepo LocalRepo,


### PR DESCRIPTION
This extends `RemoteRepo` with new fields

``` haskell
-- | Enable secure access to Hackage?
remoteRepoSecure :: Bool,

-- | Root key IDs (for bootstrapping)
remoteRepoRootKeys :: [String],

-- | Threshold for verification during bootstrapping
remoteRepoKeyThreshold :: Int,
```

and modifies the parser accordingly. This does not yet require a dependency on the security library (nor are these settings yet used anywhere).

NOTE: We suggest to make the security functionality opt-in, rather than opt-out, for the first official release. Thus, the 'secure' field will be set to `False` when initialising a `~/.cabal/config` file, and existing `~/.cabal/config` files will be interpreted as if they had `secure: False`.