### PR TITLE
Define Semigroup instances

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -253,6 +253,7 @@ library
   other-modules:
     Distribution.Compat.Binary
     Distribution.Compat.CopyFile
+    Distribution.Compat.Semigroup
     Distribution.GetOpt
     Distribution.Lex
     Distribution.Simple.GHC.Internal

--- a/Cabal/Distribution/Compat/Semigroup.hs
+++ b/Cabal/Distribution/Compat/Semigroup.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE CPP #-}
+
+-- | Compatibility layer for "Data.Semigroup"
+module Distribution.Compat.Semigroup
+    ( Semigroup((<>))
+    , Mon.Monoid(..)
+    , All(..)
+    , Any(..)
+    ) where
+
+#if __GLASGOW_HASKELL__ >= 711
+-- Data.Semigroup is available since GHC 8.0/base-4.9
+import Data.Semigroup
+import qualified Data.Monoid as Mon
+#else
+-- provide internal simplified non-exposed class for older GHCs
+import Data.Monoid as Mon (Monoid(..), All(..), Any(..), Dual(..))
+
+class Semigroup a where
+    (<>) :: a -> a -> a
+
+-- several primitive instances
+instance Semigroup () where
+    _ <> _ = ()
+
+instance Semigroup [a] where
+    (<>) = (++)
+
+instance Semigroup a => Semigroup (Dual a) where
+    Dual a <> Dual b = Dual (b <> a)
+
+instance Semigroup a => Semigroup (Maybe a) where
+    Nothing <> b       = b
+    a       <> Nothing = a
+    Just a  <> Just b  = Just (a <> b)
+
+instance Semigroup (Either a b) where
+    Left _ <> b = b
+    a      <> _ = a
+
+instance Semigroup Ordering where
+    LT <> _ = LT
+    EQ <> y = y
+    GT <> _ = GT
+
+instance Semigroup b => Semigroup (a -> b) where
+    f <> g = \a -> f a <> g a
+
+instance Semigroup All where
+    All a <> All b = All (a && b)
+
+instance Semigroup Any where
+    Any a <> Any b = Any (a || b)
+
+instance (Semigroup a, Semigroup b) => Semigroup (a, b) where
+    (a,b) <> (a',b') = (a<>a',b<>b')
+
+instance (Semigroup a, Semigroup b, Semigroup c)
+         => Semigroup (a, b, c) where
+    (a,b,c) <> (a',b',c') = (a<>a',b<>b',c<>c')
+
+instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d)
+         => Semigroup (a, b, c, d) where
+    (a,b,c,d) <> (a',b',c',d') = (a<>a',b<>b',c<>c',d<>d')
+
+instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e)
+         => Semigroup (a, b, c, d, e) where
+    (a,b,c,d,e) <> (a',b',c',d',e') = (a<>a',b<>b',c<>c',d<>d',e<>e')
+
+#endif

--- a/Cabal/Distribution/Lex.hs
+++ b/Cabal/Distribution/Lex.hs
@@ -14,7 +14,7 @@ module Distribution.Lex (
  ) where
 
 import Data.Char (isSpace)
-import Data.Monoid as Mon
+import Distribution.Compat.Semigroup as Semi
 
 newtype DList a = DList ([a] -> [a])
 
@@ -24,9 +24,12 @@ runDList (DList run) = run []
 singleton :: a -> DList a
 singleton a = DList (a:)
 
-instance Mon.Monoid (DList a) where
+instance Monoid (DList a) where
   mempty = DList id
-  DList a `mappend` DList b = DList (a . b)
+  mappend = (Semi.<>)
+
+instance Semigroup (DList a) where
+  DList a <> DList b = DList (a . b)
 
 tokenizeQuotedWords :: String -> [String]
 tokenizeQuotedWords = filter (not . null) . go False mempty

--- a/Cabal/Distribution/Simple/CCompiler.hs
+++ b/Cabal/Distribution/Simple/CCompiler.hs
@@ -46,8 +46,7 @@ module Distribution.Simple.CCompiler (
    filenameCDialect
   ) where
 
-import Data.Monoid as Mon
-     ( Monoid(..) )
+import Distribution.Compat.Semigroup as Semi
 
 import System.FilePath
      ( takeExtension )
@@ -62,17 +61,18 @@ data CDialect = C
               | ObjectiveCPlusPlus
               deriving (Eq, Show)
 
-instance Mon.Monoid CDialect where
+instance Monoid CDialect where
   mempty = C
+  mappend = (Semi.<>)
 
-  mappend C                  anything           = anything
-  mappend ObjectiveC         CPlusPlus          = ObjectiveCPlusPlus
-  mappend CPlusPlus          ObjectiveC         = ObjectiveCPlusPlus
-  mappend _                  ObjectiveCPlusPlus = ObjectiveCPlusPlus
-  mappend ObjectiveC         _                  = ObjectiveC
-  mappend CPlusPlus          _                  = CPlusPlus
-  mappend ObjectiveCPlusPlus _                  = ObjectiveCPlusPlus
-
+instance Semigroup CDialect where
+  C                  <> anything           = anything
+  ObjectiveC         <> CPlusPlus          = ObjectiveCPlusPlus
+  CPlusPlus          <> ObjectiveC         = ObjectiveCPlusPlus
+  _                  <> ObjectiveCPlusPlus = ObjectiveCPlusPlus
+  ObjectiveC         <> _                  = ObjectiveC
+  CPlusPlus          <> _                  = CPlusPlus
+  ObjectiveCPlusPlus <> _                  = ObjectiveCPlusPlus
 
 -- | A list of all file extensions which are recognized as possibly containing
 --   some dialect of C code.  Note that this list is only for source files,

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -24,6 +24,7 @@ import qualified Distribution.Simple.GHC   as GHC
 import qualified Distribution.Simple.GHCJS as GHCJS
 
 -- local
+import Distribution.Compat.Semigroup as Semi
 import Distribution.Package
          ( PackageIdentifier(..)
          , Package(..)
@@ -86,7 +87,6 @@ import Language.Haskell.Extension
 import Control.Monad    ( when, forM_ )
 import Data.Either      ( rights )
 import Data.Foldable    ( traverse_ )
-import Data.Monoid
 import Data.Maybe       ( fromMaybe, listToMaybe )
 
 import System.Directory (doesFileExist)
@@ -794,7 +794,10 @@ instance Monoid HaddockArgs where
                 argGhcLibDir = mempty,
                 argTargets = mempty
              }
-    mappend a b = HaddockArgs {
+    mappend = (Semi.<>)
+
+instance Semigroup HaddockArgs where
+    a <> b = HaddockArgs {
                 argInterfaceFile = mult argInterfaceFile,
                 argPackageName = mult argPackageName,
                 argHideModules = mult argHideModules,
@@ -816,4 +819,7 @@ instance Monoid HaddockArgs where
 
 instance Monoid Directory where
     mempty = Dir "."
-    mappend (Dir m) (Dir n) = Dir $ m </> n
+    mappend = (Semi.<>)
+
+instance Semigroup Directory where
+    Dir m <> Dir n = Dir $ m </> n

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -46,11 +46,9 @@ module Distribution.Simple.InstallDirs (
 
 
 import Distribution.Compat.Binary (Binary)
+import Distribution.Compat.Semigroup as Semi
 import Data.List (isPrefixOf)
 import Data.Maybe (fromMaybe)
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid (Monoid(..))
-#endif
 import GHC.Generics (Generic)
 import System.Directory (getAppUserDataDirectory)
 import System.FilePath ((</>), isPathSeparator, pathSeparator)
@@ -118,7 +116,7 @@ instance Functor InstallDirs where
     sysconfdir   = f (sysconfdir dirs)
   }
 
-instance Monoid dir => Monoid (InstallDirs dir) where
+instance (Semigroup dir, Monoid dir) => Monoid (InstallDirs dir) where
   mempty = InstallDirs {
       prefix       = mempty,
       bindir       = mempty,
@@ -135,7 +133,10 @@ instance Monoid dir => Monoid (InstallDirs dir) where
       haddockdir   = mempty,
       sysconfdir   = mempty
   }
-  mappend = combineInstallDirs mappend
+  mappend = (Semi.<>)
+
+instance Semigroup dir => Semigroup (InstallDirs dir) where
+  (<>) = combineInstallDirs (<>)
 
 combineInstallDirs :: (a -> b -> c)
                    -> InstallDirs a

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -65,11 +65,11 @@ import Control.Exception (assert)
 import Data.Array ((!))
 import qualified Data.Array as Array
 import Distribution.Compat.Binary (Binary)
+import Distribution.Compat.Semigroup as Semi
 import qualified Data.Graph as Graph
 import Data.List as List
          ( null, foldl', sort
          , groupBy, sortBy, find, isInfixOf, nubBy, deleteBy, deleteFirstsBy )
-import Data.Monoid as Mon (Monoid(..))
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (isNothing, fromMaybe)
@@ -127,10 +127,13 @@ type InstalledPackageIndex = PackageIndex InstalledPackageInfo
 
 instance HasComponentId a => Monoid (PackageIndex a) where
   mempty  = PackageIndex Map.empty Map.empty
-  mappend = merge
+  mappend = (Semi.<>)
   --save one mappend with empty in the common case:
-  mconcat [] = Mon.mempty
+  mconcat [] = mempty
   mconcat xs = foldr1 mappend xs
+
+instance HasComponentId a => Semigroup (PackageIndex a) where
+  (<>) = merge
 
 invariant :: HasComponentId a => PackageIndex a -> Bool
 invariant (PackageIndex pids pnames) =

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -12,6 +12,7 @@ module Distribution.Simple.Program.GHC (
 
   ) where
 
+import Distribution.Compat.Semigroup as Semi
 import Distribution.Simple.GHC.ImplInfo ( getImplInfo, GhcImplInfo(..) )
 import Distribution.Package
 import Distribution.PackageDescription hiding (Flag)
@@ -27,7 +28,6 @@ import Distribution.Utils.NubList   ( NubListR, fromNubListR )
 import Language.Haskell.Extension   ( Language(..), Extension(..) )
 
 import qualified Data.Map as M
-import Data.Monoid as Mon
 import Data.List ( intercalate )
 
 -- | A structured set of GHC options/flags
@@ -491,7 +491,7 @@ packageDbArgs implInfo
 
 instance Monoid GhcOptions where
   mempty = GhcOptions {
-    ghcOptMode               = Mon.mempty,
+    ghcOptMode               = mempty,
     ghcOptExtra              = mempty,
     ghcOptExtraDefault       = mempty,
     ghcOptInputFiles         = mempty,
@@ -544,7 +544,10 @@ instance Monoid GhcOptions where
     ghcOptVerbosity          = mempty,
     ghcOptCabal              = mempty
   }
-  mappend a b = GhcOptions {
+  mappend = (Semi.<>)
+
+instance Semigroup GhcOptions where
+  a <> b = GhcOptions {
     ghcOptMode               = combine ghcOptMode,
     ghcOptExtra              = combine ghcOptExtra,
     ghcOptExtraDefault       = combine ghcOptExtraDefault,

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -102,11 +102,9 @@ import Distribution.Utils.NubList
 
 import Control.Monad (liftM)
 import Distribution.Compat.Binary (Binary)
+import Distribution.Compat.Semigroup as Semi
 import Data.List   ( sort )
 import Data.Char   ( isSpace, isAlpha )
-#if __GLASGOW_HASKELL__ < 710
-import Data.Monoid ( Monoid(..) )
-#endif
 import GHC.Generics (Generic)
 
 -- FIXME Not sure where this should live
@@ -144,8 +142,11 @@ instance Functor Flag where
 
 instance Monoid (Flag a) where
   mempty = NoFlag
-  _ `mappend` f@(Flag _) = f
-  f `mappend` NoFlag     = f
+  mappend = (Semi.<>)
+
+instance Semigroup (Flag a) where
+  _ <> f@(Flag _) = f
+  f <> NoFlag     = f
 
 instance Bounded a => Bounded (Flag a) where
   minBound = toFlag minBound
@@ -256,7 +257,10 @@ instance Monoid GlobalFlags where
     globalVersion        = mempty,
     globalNumericVersion = mempty
   }
-  mappend a b = GlobalFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup GlobalFlags where
+  a <> b = GlobalFlags {
     globalVersion        = combine globalVersion,
     globalNumericVersion = combine globalNumericVersion
   }
@@ -803,7 +807,10 @@ instance Monoid ConfigFlags where
     configRelocatable   = mempty,
     configDebugInfo     = mempty
   }
-  mappend a b =  ConfigFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup ConfigFlags where
+  a <> b =  ConfigFlags {
     configPrograms      = configPrograms b,
     configProgramPaths  = combine configProgramPaths,
     configProgramArgs   = combine configProgramArgs,
@@ -905,7 +912,10 @@ instance Monoid CopyFlags where
     copyDistPref  = mempty,
     copyVerbosity = mempty
   }
-  mappend a b = CopyFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup CopyFlags where
+  a <> b = CopyFlags {
     copyDest      = combine copyDest,
     copyDistPref  = combine copyDistPref,
     copyVerbosity = combine copyVerbosity
@@ -984,7 +994,10 @@ instance Monoid InstallFlags where
     installInPlace    = mempty,
     installVerbosity = mempty
   }
-  mappend a b = InstallFlags{
+  mappend = (Semi.<>)
+
+instance Semigroup InstallFlags where
+  a <> b = InstallFlags{
     installPackageDB = combine installPackageDB,
     installDistPref  = combine installDistPref,
     installUseWrapper = combine installUseWrapper,
@@ -1061,7 +1074,10 @@ instance Monoid SDistFlags where
     sDistListSources = mempty,
     sDistVerbosity   = mempty
   }
-  mappend a b = SDistFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup SDistFlags where
+  a <> b = SDistFlags {
     sDistSnapshot    = combine sDistSnapshot,
     sDistDirectory   = combine sDistDirectory,
     sDistDistPref    = combine sDistDistPref,
@@ -1186,7 +1202,10 @@ instance Monoid RegisterFlags where
     regDistPref    = mempty,
     regVerbosity   = mempty
   }
-  mappend a b = RegisterFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup RegisterFlags where
+  a <> b = RegisterFlags {
     regPackageDB   = combine regPackageDB,
     regGenScript   = combine regGenScript,
     regGenPkgConf  = combine regGenPkgConf,
@@ -1233,7 +1252,10 @@ instance Monoid HscolourFlags where
     hscolourDistPref    = mempty,
     hscolourVerbosity   = mempty
   }
-  mappend a b = HscolourFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup HscolourFlags where
+  a <> b = HscolourFlags {
     hscolourCSS         = combine hscolourCSS,
     hscolourExecutables = combine hscolourExecutables,
     hscolourTestSuites  = combine hscolourTestSuites,
@@ -1471,7 +1493,10 @@ instance Monoid HaddockFlags where
     haddockKeepTempFiles= mempty,
     haddockVerbosity    = mempty
   }
-  mappend a b = HaddockFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup HaddockFlags where
+  a <> b = HaddockFlags {
     haddockProgramPaths = combine haddockProgramPaths,
     haddockProgramArgs  = combine haddockProgramArgs,
     haddockHoogle       = combine haddockHoogle,
@@ -1542,7 +1567,10 @@ instance Monoid CleanFlags where
     cleanDistPref  = mempty,
     cleanVerbosity = mempty
   }
-  mappend a b = CleanFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup CleanFlags where
+  a <> b = CleanFlags {
     cleanSaveConf  = combine cleanSaveConf,
     cleanDistPref  = combine cleanDistPref,
     cleanVerbosity = combine cleanVerbosity
@@ -1646,7 +1674,10 @@ instance Monoid BuildFlags where
     buildNumJobs     = mempty,
     buildArgs        = mempty
   }
-  mappend a b = BuildFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup BuildFlags where
+  a <> b = BuildFlags {
     buildProgramPaths = combine buildProgramPaths,
     buildProgramArgs = combine buildProgramArgs,
     buildVerbosity   = combine buildVerbosity,
@@ -1686,7 +1717,10 @@ instance Monoid ReplFlags where
     replDistPref    = mempty,
     replReload      = mempty
   }
-  mappend a b = ReplFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup ReplFlags where
+  a <> b = ReplFlags {
     replProgramPaths = combine replProgramPaths,
     replProgramArgs = combine replProgramArgs,
     replVerbosity   = combine replVerbosity,
@@ -1787,7 +1821,10 @@ instance Text TestShowDetails where
 --TODO: do we need this instance?
 instance Monoid TestShowDetails where
     mempty = Never
-    mappend a b = if a < b then b else a
+    mappend = (Semi.<>)
+
+instance Semigroup TestShowDetails where
+    a <> b = if a < b then b else a
 
 data TestFlags = TestFlags {
     testDistPref    :: Flag FilePath,
@@ -1899,7 +1936,10 @@ instance Monoid TestFlags where
     testKeepTix     = mempty,
     testOptions     = mempty
   }
-  mappend a b = TestFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup TestFlags where
+  a <> b = TestFlags {
     testDistPref    = combine testDistPref,
     testVerbosity   = combine testVerbosity,
     testHumanLog    = combine testHumanLog,
@@ -1982,7 +2022,10 @@ instance Monoid BenchmarkFlags where
     benchmarkVerbosity = mempty,
     benchmarkOptions   = mempty
   }
-  mappend a b = BenchmarkFlags {
+  mappend = (Semi.<>)
+
+instance Semigroup BenchmarkFlags where
+  a <> b = BenchmarkFlags {
     benchmarkDistPref  = combine benchmarkDistPref,
     benchmarkVerbosity = combine benchmarkVerbosity,
     benchmarkOptions   = combine benchmarkOptions

--- a/Cabal/Distribution/Utils/NubList.hs
+++ b/Cabal/Distribution/Utils/NubList.hs
@@ -10,9 +10,8 @@ module Distribution.Utils.NubList
     , overNubListR
     ) where
 
+import Distribution.Compat.Semigroup as Semi
 import Distribution.Compat.Binary
-import Data.Monoid
-import Prelude
 
 import Distribution.Simple.Utils (ordNub, listUnion, ordNubRight, listUnionRight)
 
@@ -52,7 +51,10 @@ overNubList f (NubList list) = toNubList . f $ list
 
 instance Ord a => Monoid (NubList a) where
     mempty = NubList []
-    mappend (NubList xs) (NubList ys) = NubList $ xs `listUnion` ys
+    mappend = (Semi.<>)
+
+instance Ord a => Semigroup (NubList a) where
+    (NubList xs) <> (NubList ys) = NubList $ xs `listUnion` ys
 
 instance Show a => Show (NubList a) where
     show (NubList list) = show list
@@ -89,7 +91,10 @@ overNubListR f (NubListR list) = toNubListR . f $ list
 
 instance Ord a => Monoid (NubListR a) where
   mempty = NubListR []
-  mappend (NubListR xs) (NubListR ys) = NubListR $ xs `listUnionRight` ys
+  mappend = (Semi.<>)
+
+instance Ord a => Semigroup (NubListR a) where
+  (NubListR xs) <> (NubListR ys) = NubListR $ xs `listUnionRight` ys
 
 instance Show a => Show (NubListR a) where
   show (NubListR list) = show list


### PR DESCRIPTION
This makes the code `-Wcompat`-clean with GHC 8.0

Due to the amount of `Monoid` instances, a compat-layer is used
rather than flooding the code-base with CPP conditionals.