### PR TITLE
Introduce ignore-expiry cmdline arg

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -225,6 +225,7 @@ instance Monoid SavedConfig where
         globalWorldFile         = combine globalWorldFile,
         globalRequireSandbox    = combine globalRequireSandbox,
         globalIgnoreSandbox     = combine globalIgnoreSandbox,
+        globalIgnoreExpiry      = combine globalIgnoreExpiry,
         globalHttpTransport     = combine globalHttpTransport
         }
         where

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -129,6 +129,7 @@ data GlobalFlags = GlobalFlags {
     globalWorldFile         :: Flag FilePath,
     globalRequireSandbox    :: Flag Bool,
     globalIgnoreSandbox     :: Flag Bool,
+    globalIgnoreExpiry      :: Flag Bool,    -- ^ Ignore security expiry dates
     globalHttpTransport     :: Flag String
   }
 
@@ -146,6 +147,7 @@ defaultGlobalFlags  = GlobalFlags {
     globalWorldFile         = mempty,
     globalRequireSandbox    = Flag False,
     globalIgnoreSandbox     = Flag False,
+    globalIgnoreExpiry      = Flag False,
     globalHttpTransport     = mempty
   }
 
@@ -309,6 +311,11 @@ globalCommand commands = CommandUI {
          globalIgnoreSandbox (\v flags -> flags { globalIgnoreSandbox = v })
          trueArg
 
+      ,option [] ["ignore-expiry"]
+         "Ignore expiry dates on signed metadata (use only in exception circumstances)"
+         globalIgnoreExpiry (\v flags -> flags { globalIgnoreExpiry = v })
+         trueArg
+
       ,option [] ["http-transport"]
          "Set a transport for http(s) requests. Accepts 'curl', 'wget', 'powershell', and 'plain-http'. (default: 'curl')"
          globalConfigFile (\v flags -> flags { globalHttpTransport = v })
@@ -358,6 +365,7 @@ instance Monoid GlobalFlags where
     globalWorldFile         = mempty,
     globalRequireSandbox    = mempty,
     globalIgnoreSandbox     = mempty,
+    globalIgnoreExpiry      = mempty,
     globalHttpTransport     = mempty
   }
   mappend a b = GlobalFlags {
@@ -373,6 +381,7 @@ instance Monoid GlobalFlags where
     globalWorldFile         = combine globalWorldFile,
     globalRequireSandbox    = combine globalRequireSandbox,
     globalIgnoreSandbox     = combine globalIgnoreSandbox,
+    globalIgnoreExpiry      = combine globalIgnoreExpiry,
     globalHttpTransport     = combine globalHttpTransport
   }
     where combine field = field a `mappend` field b

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -312,7 +312,7 @@ globalCommand commands = CommandUI {
          trueArg
 
       ,option [] ["ignore-expiry"]
-         "Ignore expiry dates on signed metadata (use only in exception circumstances)"
+         "Ignore expiry dates on signed metadata (use only in exceptional circumstances)"
          globalIgnoreExpiry (\v flags -> flags { globalIgnoreExpiry = v })
          trueArg
 

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -940,8 +940,9 @@ updateAction verbosityFlag extraArgs globalFlags = do
                            (globalFlags { globalRequireSandbox = Flag False })
   let globalFlags' = savedGlobalFlags config `mappend` globalFlags
   transport <- configureTransport verbosity (flagToMaybe (globalHttpTransport globalFlags'))
-  withGlobalRepos verbosity globalFlags' $ \globalRepos ->
-    update transport verbosity globalRepos
+  withGlobalRepos verbosity globalFlags' $ \globalRepos -> do
+    let ignoreExpiry = fromFlagOrDefault False (globalIgnoreExpiry globalFlags)
+    update transport verbosity ignoreExpiry globalRepos
 
 upgradeAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags)
               -> [String] -> Action


### PR DESCRIPTION
If used, this will instruct the hackage-security library (once integrated_ to ignore expiry dates on TUF metadata (to be used only if, say, the main server is down and we need to rely on mirrors that have not been updated for longer than the expiry period on the timestamp). Right now this command line argument is unused.

I think this will be the last PR before the PR that adds support for secure repositories. I've set the series of PRs up in such a way that that last PR will be very small and will also make it very obvious that this does not change any of the old code paths (i.e., if you don't opt-in for security you will not get a change in behaviour). However, it will rely on as-yet-unreleased versions of both hackage-security and tar. 

Anyway, this commit is still independent. 