### PR TITLE
Introduce secure repos

### DIFF
--- a/cabal-install/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/Distribution/Client/GlobalFlags.hs
@@ -1,4 +1,9 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RecordWildCards #-}
 module Distribution.Client.GlobalFlags (
     GlobalFlags(..)
   , defaultGlobalFlags
@@ -16,16 +21,35 @@ import Distribution.Client.HttpUtils
          ( HttpTransport, configureTransport )
 import Distribution.Verbosity
          ( Verbosity )
+import Distribution.Simple.Utils
+         ( info )
 
 import Control.Concurrent
          ( MVar, newMVar, modifyMVar )
+import Control.Exception
+         ( throwIO )
+import Control.Monad
+         ( when )
 import System.FilePath
          ( (</>) )
+import Network.URI
+         ( uriScheme, uriPath )
+import Data.Map
+         ( Map )
+import qualified Data.Map as Map
 
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid
          ( Monoid(..) )
 #endif
+
+import qualified Hackage.Security.Client                    as Sec
+import qualified Hackage.Security.Util.Path                 as Sec
+import qualified Hackage.Security.Util.Pretty               as Sec
+import qualified Hackage.Security.Client.Repository.Cache   as Sec
+import qualified Hackage.Security.Client.Repository.Local   as Sec.Local
+import qualified Hackage.Security.Client.Repository.Remote  as Sec.Remote
+import qualified Distribution.Client.Security.HTTP          as Sec.HTTP
 
 -- ------------------------------------------------------------
 -- * Global flags
@@ -122,22 +146,44 @@ data RepoContext = RepoContext {
     -- initialization on _every_ invocation (eg @cabal build@) is undesirable.
   , repoContextGetTransport :: IO HttpTransport
 
+    -- | Get the (initialized) secure repo
+    --
+    -- (the 'Repo' type itself is stateless and must remain so, because it
+    -- must be serializable)
+  , repoContextWithSecureRepo :: forall a.
+                                 Repo
+                              -> (forall down. Sec.Repository down -> IO a)
+                              -> IO a
+
     -- | Should we ignore expiry times (when checking security)?
   , repoContextIgnoreExpiry :: Bool
   }
 
+-- | Wrapper around 'Repository', hiding the type argument
+data SecureRepo = forall down. SecureRepo (Sec.Repository down)
+
 withRepoContext :: Verbosity -> GlobalFlags -> (RepoContext -> IO a) -> IO a
-withRepoContext verbosity globalFlags callback = do
+withRepoContext verbosity globalFlags = \callback -> do
     transportRef <- newMVar Nothing
-    callback RepoContext {
-        repoContextRepos        = remoteRepos ++ localRepos
-      , repoContextGetTransport = getTransport transportRef
-      , repoContextIgnoreExpiry = fromFlagOrDefault False
-                                    (globalIgnoreExpiry globalFlags)
-      }
+    let httpLib = Sec.HTTP.transportAdapter
+                    verbosity
+                    (getTransport transportRef)
+    initSecureRepos verbosity httpLib secureRemoteRepos $ \secureRepos' ->
+      callback RepoContext {
+          repoContextRepos          = allRemoteRepos ++ localRepos
+        , repoContextGetTransport   = getTransport transportRef
+        , repoContextWithSecureRepo = withSecureRepo secureRepos'
+        , repoContextIgnoreExpiry   = fromFlagOrDefault False
+                                        (globalIgnoreExpiry globalFlags)
+        }
   where
-    remoteRepos =
-      [ RepoRemote remote cacheDir
+    secureRemoteRepos =
+      [ (remote, cacheDir)
+      | RepoSecure remote cacheDir <- allRemoteRepos ]
+    allRemoteRepos =
+      [ case remoteRepoSecure remote of
+          Just True  -> RepoSecure remote cacheDir
+          _otherwise -> RepoRemote remote cacheDir
       | remote <- fromNubList $ globalRemoteRepos globalFlags
       , let cacheDir = fromFlag (globalCacheDir globalFlags)
                    </> remoteRepoName remote ]
@@ -154,3 +200,82 @@ withRepoContext verbosity globalFlags callback = do
                        verbosity
                        (flagToMaybe (globalHttpTransport globalFlags))
         return (Just transport, transport)
+
+    withSecureRepo :: Map Repo SecureRepo
+                   -> Repo
+                   -> (forall down. Sec.Repository down -> IO a)
+                   -> IO a
+    withSecureRepo secureRepos repo callback =
+      case Map.lookup repo secureRepos of
+        Just (SecureRepo secureRepo) -> callback secureRepo
+        Nothing -> throwIO $ userError "repoContextWithSecureRepo: unknown repo"
+
+-- | Initialize the provided secure repositories
+--
+-- Assumed invariant: `remoteRepoSecure` should be set for all these repos.
+initSecureRepos :: forall a. Verbosity
+                -> Sec.HTTP.HttpLib
+                -> [(RemoteRepo, FilePath)]
+                -> (Map Repo SecureRepo -> IO a)
+                -> IO a
+initSecureRepos verbosity httpLib repos callback = go Map.empty repos
+  where
+    go :: Map Repo SecureRepo -> [(RemoteRepo, FilePath)] -> IO a
+    go !acc [] = callback acc
+    go !acc ((r,cacheDir):rs) = do
+      cachePath <- Sec.makeAbsolute $ Sec.fromFilePath cacheDir
+      initSecureRepo verbosity httpLib r cachePath $ \r' ->
+        go (Map.insert (RepoSecure r cacheDir) r' acc) rs
+
+-- | Initialize the given secure repo
+--
+-- The security library has its own concept of a "local" repository, distinct
+-- from @cabal-install@'s; these are secure repositories, but live in the local
+-- file system. We use the convention that these repositories are identified by
+-- URLs of the form @file:/path/to/local/repo@.
+initSecureRepo :: Verbosity
+               -> Sec.HTTP.HttpLib
+               -> RemoteRepo  -- ^ Secure repo ('remoteRepoSecure' assumed)
+               -> Sec.Path Sec.Absolute -- ^ Cache dir
+               -> (SecureRepo -> IO a)  -- ^ Callback
+               -> IO a
+initSecureRepo verbosity httpLib RemoteRepo{..} cachePath = \callback -> do
+    withRepo $ \r -> do
+      requiresBootstrap <- Sec.requiresBootstrap r
+      when requiresBootstrap $ Sec.uncheckClientErrors $
+        Sec.bootstrap r
+          (map Sec.KeyId    remoteRepoRootKeys)
+          (Sec.KeyThreshold (fromIntegral remoteRepoKeyThreshold))
+      callback $ SecureRepo r
+  where
+    -- Initialize local or remote repo depending on the URI
+    withRepo :: (forall down. Sec.Repository down -> IO a) -> IO a
+    withRepo callback | uriScheme remoteRepoURI == "file:" = do
+      dir <- Sec.makeAbsolute $ Sec.fromFilePath (uriPath remoteRepoURI)
+      Sec.Local.withRepository dir
+                               cache
+                               Sec.hackageRepoLayout
+                               Sec.hackageIndexLayout
+                               logTUF
+                               callback
+    withRepo callback =
+      Sec.Remote.withRepository httpLib
+                                [remoteRepoURI]
+                                Sec.Remote.defaultRepoOpts
+                                cache
+                                Sec.hackageRepoLayout
+                                Sec.hackageIndexLayout
+                                logTUF
+                                callback
+
+    cache :: Sec.Cache
+    cache = Sec.Cache {
+        cacheRoot   = cachePath
+      , cacheLayout = Sec.cabalCacheLayout
+      }
+
+    -- We display any TUF progress only in verbose mode, including any transient
+    -- verification errors. If verification fails, then the final exception that
+    -- is thrown will of course be shown.
+    logTUF :: Sec.LogMessage -> IO ()
+    logTUF = info verbosity . Sec.pretty

--- a/cabal-install/Distribution/Client/Security/HTTP.hs
+++ b/cabal-install/Distribution/Client/Security/HTTP.hs
@@ -1,0 +1,174 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+-- | Implementation of 'HttpLib' using cabal-install's own 'HttpTransport'
+module Distribution.Client.Security.HTTP (HttpLib, transportAdapter) where
+
+-- stdlibs
+import Control.Exception
+         ( Exception(..), IOException )
+import Data.List
+         ( intercalate )
+import Data.Typeable
+         ( Typeable )
+import System.Directory
+         ( getTemporaryDirectory )
+import Network.URI
+         ( URI )
+import qualified Data.ByteString.Lazy as BS.L
+import qualified Network.HTTP         as HTTP
+
+-- Cabal/cabal-install
+import Distribution.Verbosity
+         ( Verbosity )
+import Distribution.Client.HttpUtils
+         ( HttpTransport(..), HttpCode )
+import Distribution.Client.Utils
+         ( withTempFileName )
+
+-- hackage-security
+import Hackage.Security.Client
+import Hackage.Security.Client.Repository.HttpLib
+import Hackage.Security.Util.Checked
+import Hackage.Security.Util.Pretty
+import qualified Hackage.Security.Util.Lens as Lens
+
+{-------------------------------------------------------------------------------
+  'HttpLib' implementation
+-------------------------------------------------------------------------------}
+
+-- | Translate from hackage-security's 'HttpLib' to cabal-install's 'HttpTransport'
+--
+-- NOTE: The match between these two APIs is currently not perfect:
+--
+-- * We don't get any response headers back from the 'HttpTransport', so we
+--   don't know if the server supports range requests. For now we optimistically
+--   assume that it does.
+-- * The 'HttpTransport' wants to know where to place the resulting file,
+--   whereas the 'HttpLib' expects an 'IO' action which streams the download;
+--   the security library then makes sure that the file gets written to a
+--   location which is suitable (in particular, to a temporary file in the
+--   directory where the file needs to end up, so that it can "finalize" the
+--   file simply by doing 'renameFile'). Right now we write the file to a
+--   temporary file in the system temp directory here and then read it again
+--   to pass it to the security library; this is a problem for two reasons: it
+--   is a source of inefficiency; and it means that the security library cannot
+--   insist on a minimum download rate (potential security attack).
+--   Fixing it however would require changing the 'HttpTransport'.
+transportAdapter :: Verbosity -> IO HttpTransport -> HttpLib
+transportAdapter verbosity getTransport = HttpLib{
+      httpGet      = \headers uri callback -> do
+                        transport <- getTransport
+                        get verbosity transport headers uri callback
+    , httpGetRange = \headers uri range callback -> do
+                        transport <- getTransport
+                        getRange verbosity transport headers uri range callback
+    }
+
+get :: Throws SomeRemoteError
+    => Verbosity
+    -> HttpTransport
+    -> [HttpRequestHeader] -> URI
+    -> ([HttpResponseHeader] -> BodyReader -> IO a)
+    -> IO a
+get verbosity transport reqHeaders uri callback = wrapCustomEx $ do
+  get' verbosity transport reqHeaders uri Nothing $ \code respHeaders br ->
+    case code of
+      200 -> callback respHeaders br
+      _   -> throwChecked $ UnexpectedResponse uri code
+
+getRange :: Throws SomeRemoteError
+         => Verbosity
+         -> HttpTransport
+         -> [HttpRequestHeader] -> URI -> (Int, Int)
+         -> (HttpStatus -> [HttpResponseHeader] -> BodyReader -> IO a)
+         -> IO a
+getRange verbosity transport reqHeaders uri range callback = wrapCustomEx $ do
+  get' verbosity transport reqHeaders uri (Just range) $ \code respHeaders br ->
+    case code of
+       200 -> callback HttpStatus200OK             respHeaders br
+       206 -> callback HttpStatus206PartialContent respHeaders br
+       _   -> throwChecked $ UnexpectedResponse uri code
+
+-- | Internal generalization of 'get' and 'getRange'
+get' :: Verbosity
+     -> HttpTransport
+     -> [HttpRequestHeader] -> URI -> Maybe (Int, Int)
+     -> (HttpCode -> [HttpResponseHeader] -> BodyReader -> IO a)
+     -> IO a
+get' verbosity transport reqHeaders uri mRange callback = do
+    tempDir <- getTemporaryDirectory
+    withTempFileName tempDir "transportAdapterGet" $ \temp -> do
+      (code, _etag) <- getHttp transport verbosity uri Nothing temp reqHeaders'
+      br <- bodyReaderFromBS =<< BS.L.readFile temp
+      callback code [HttpResponseAcceptRangesBytes] br
+  where
+    reqHeaders' = mkReqHeaders reqHeaders mRange
+
+{-------------------------------------------------------------------------------
+  Request headers
+-------------------------------------------------------------------------------}
+
+mkRangeHeader :: Int -> Int -> HTTP.Header
+mkRangeHeader from to = HTTP.Header HTTP.HdrRange rangeHeader
+  where
+    -- Content-Range header uses inclusive rather than exclusive bounds
+    -- See <http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html>
+    rangeHeader = "bytes=" ++ show from ++ "-" ++ show (to - 1)
+
+mkReqHeaders :: [HttpRequestHeader] -> Maybe (Int, Int) -> [HTTP.Header]
+mkReqHeaders reqHeaders mRange = concat [
+      tr [] reqHeaders
+    , [mkRangeHeader fr to | Just (fr, to) <- [mRange]]
+    ]
+  where
+    tr :: [(HTTP.HeaderName, [String])] -> [HttpRequestHeader] -> [HTTP.Header]
+    tr acc [] =
+      concatMap finalize acc
+    tr acc (HttpRequestMaxAge0:os) =
+      tr (insert HTTP.HdrCacheControl ["max-age=0"] acc) os
+    tr acc (HttpRequestNoTransform:os) =
+      tr (insert HTTP.HdrCacheControl ["no-transform"] acc) os
+
+    -- Some headers are comma-separated, others need multiple headers for
+    -- multiple options.
+    --
+    -- TODO: Right we we just comma-separate all of them.
+    finalize :: (HTTP.HeaderName, [String]) -> [HTTP.Header]
+    finalize (name, strs) = [HTTP.Header name (intercalate ", " (reverse strs))]
+
+    insert :: Eq a => a -> [b] -> [(a, [b])] -> [(a, [b])]
+    insert x y = Lens.modify (Lens.lookupM x) (++ y)
+
+{-------------------------------------------------------------------------------
+  Custom exceptions
+-------------------------------------------------------------------------------}
+
+data UnexpectedResponse = UnexpectedResponse URI Int
+  deriving (Typeable)
+
+instance Pretty UnexpectedResponse where
+  pretty (UnexpectedResponse uri code) = "Unexpected response " ++ show code
+                                      ++ "for " ++ show uri
+
+#if MIN_VERSION_base(4,8,0)
+deriving instance Show UnexpectedResponse
+instance Exception UnexpectedResponse where displayException = pretty
+#else
+instance Show UnexpectedResponse where show = pretty
+instance Exception UnexpectedResponse
+#endif
+
+wrapCustomEx :: ( ( Throws UnexpectedResponse
+                  , Throws IOException
+                  ) => IO a)
+             -> (Throws SomeRemoteError => IO a)
+wrapCustomEx act = handleChecked (\(ex :: UnexpectedResponse) -> go ex)
+                 $ handleChecked (\(ex :: IOException)        -> go ex)
+                 $ act
+  where
+    go ex = throwChecked (SomeRemoteError ex)

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RankNTypes #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Setup
@@ -2249,7 +2252,7 @@ parseRepo = do
   return RemoteRepo {
     remoteRepoName           = name,
     remoteRepoURI            = uri,
-    remoteRepoSecure         = False,
+    remoteRepoSecure         = Nothing,
     remoteRepoRootKeys       = [],
     remoteRepoKeyThreshold   = 0,
     remoteRepoShouldTryHttps = False

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -139,6 +139,7 @@ executable cabal
         Distribution.Client.Sandbox.PackageEnvironment
         Distribution.Client.Sandbox.Timestamp
         Distribution.Client.Sandbox.Types
+        Distribution.Client.Security.HTTP
         Distribution.Client.Setup
         Distribution.Client.SetupWrapper
         Distribution.Client.SrcDist
@@ -174,7 +175,8 @@ executable cabal
         stm        >= 2.0      && < 3,
         tar        >= 0.5.0.1  && < 0.6,
         time       >= 1.4      && < 1.7,
-        zlib       >= 0.5.3    && < 0.7
+        zlib       >= 0.5.3    && < 0.7,
+        hackage-security >= 0.5 && < 0.6
 
     if flag(old-directory)
       build-depends: directory >= 1.1 && < 1.2, old-time >= 1 && < 1.2,
@@ -238,6 +240,7 @@ Test-Suite unit-tests
         HTTP,
         zlib,
         random,
+        hackage-security,
         tasty,
         tasty-hunit,
         tasty-quickcheck,


### PR DESCRIPTION
So this is the final PR that introduces support for secure repositories.

**NOTE**: Do not merge this, this currently relies on as-yet-unreleased versions of both the `hackage-security` library (it needs the latest `master` from https://github.com/well-typed/hackage-security) as well as the `tar` package (it currently needs the `pr/TarIndex-toList` branch of https://github.com/edsko/tar/). 

Submitting this as a PR right now so that it can be reviewed now and then merged quickly once the other libraries have been released. (Note that we will also want to have come to a decision re dependencies.) 