### PR TITLE
Canonicalize path to Cabal file, partially towards #2994.

### DIFF
--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -107,7 +107,8 @@ import Distribution.Text
 -- Base
 import System.Environment(getArgs, getProgName)
 import System.Directory(removeFile, doesFileExist,
-                        doesDirectoryExist, removeDirectoryRecursive)
+                        doesDirectoryExist, removeDirectoryRecursive,
+                        canonicalizePath)
 import System.Exit       (exitWith,ExitCode(..))
 import System.FilePath(searchPathSeparator)
 import Distribution.Compat.Environment (getEnvironment)
@@ -232,7 +233,8 @@ configureAction hooks flags args = do
         case mdescr of
           Just descr -> return (Nothing, descr)
           Nothing -> do
-              pdfile <- defaultPackageDesc verbosity
+              pdfile0 <- defaultPackageDesc verbosity
+              pdfile <- canonicalizePath pdfile0
               descr  <- readPackageDescription verbosity pdfile
               return (Just pdfile, descr)
 


### PR DESCRIPTION
The actual reason I want this is because it gives me a reliable way to find the test files for the Cabal test suite. An alternate thing that would work is to store the CWD in the LBI when we make it.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>