### PR TITLE
Remove same-package import lists, fixes #2835 for Cabal.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -265,6 +265,7 @@ library
     Distribution.Simple.GHC.Internal
     Distribution.Simple.GHC.IPI641
     Distribution.Simple.GHC.IPI642
+    Distribution.Simple.GHC.IPIConvert
     Distribution.Simple.GHC.ImplInfo
     Paths_Cabal
 

--- a/Cabal/Distribution/Compat/CopyFile.hs
+++ b/Cabal/Distribution/Compat/CopyFile.hs
@@ -11,20 +11,18 @@ module Distribution.Compat.CopyFile (
   setDirOrdinary,
   ) where
 
+import Distribution.Compat.Exception
+import Distribution.Compat.Internal.TempFile
 
 import Control.Monad
          ( when, unless )
 import Control.Exception
          ( bracketOnError, throwIO )
 import qualified Data.ByteString.Lazy as BSL
-import Distribution.Compat.Exception
-         ( catchIO )
 import System.IO.Error
          ( ioeSetLocation )
 import System.Directory
          ( doesFileExist, renameFile, removeFile )
-import Distribution.Compat.Internal.TempFile
-         ( openBinaryTempFile )
 import System.FilePath
          ( takeDirectory )
 import System.IO

--- a/Cabal/Distribution/Compat/Internal/TempFile.hs
+++ b/Cabal/Distribution/Compat/Internal/TempFile.hs
@@ -7,6 +7,7 @@ module Distribution.Compat.Internal.TempFile (
   createTempDirectory,
   ) where
 
+import Distribution.Compat.Exception
 
 import System.FilePath        ((</>))
 import Foreign.C              (CInt, eEXIST, getErrno, errnoToIOError)
@@ -18,7 +19,6 @@ import System.Posix.Internals (c_open, c_close, o_CREAT, o_EXCL, o_RDWR,
                                withFilePath, c_getpid)
 import System.IO.Error        (isAlreadyExistsError)
 import GHC.IO.Handle.FD       (fdToHandle)
-import Distribution.Compat.Exception (tryIO)
 import Control.Exception      (onException)
 
 #if defined(mingw32_HOST_OS) || defined(ghcjs_HOST_OS)

--- a/Cabal/Distribution/Compiler.hs
+++ b/Cabal/Distribution/Compiler.hs
@@ -42,14 +42,14 @@ module Distribution.Compiler (
   AbiTag(..), abiTagString
   ) where
 
-import Distribution.Compat.Binary (Binary)
+import Distribution.Compat.Binary
+import Language.Haskell.Extension
+
 import Data.Data (Data)
 import Data.Typeable (Typeable)
 import Data.Maybe (fromMaybe)
 import Distribution.Version (Version(..))
 import GHC.Generics (Generic)
-
-import Language.Haskell.Extension (Language, Extension)
 
 import qualified System.Info (compilerName, compilerVersion)
 import Distribution.Text (Text(..), display)

--- a/Cabal/Distribution/License.hs
+++ b/Cabal/Distribution/License.hs
@@ -47,13 +47,13 @@ module Distribution.License (
     knownLicenses,
   ) where
 
-import Distribution.Version (Version(Version))
-
-import Distribution.Text (Text(..), display)
+import Distribution.Version
+import Distribution.Text
 import qualified Distribution.Compat.ReadP as Parse
+import Distribution.Compat.Binary
+
 import qualified Text.PrettyPrint as Disp
 import Text.PrettyPrint ((<>))
-import Distribution.Compat.Binary (Binary)
 import qualified Data.Char as Char (isAlphaNum)
 import Data.Data (Data)
 import Data.Typeable (Typeable)

--- a/Cabal/Distribution/Make.hs
+++ b/Cabal/Distribution/Make.hs
@@ -62,22 +62,19 @@ module Distribution.Make (
 
 -- local
 import Distribution.Compat.Exception
-import Distribution.Package --must not specify imports, since we're exporting moule.
-import Distribution.Simple.Program(defaultProgramConfiguration)
+import Distribution.Package
+import Distribution.Simple.Program
 import Distribution.PackageDescription
 import Distribution.Simple.Setup
 import Distribution.Simple.Command
 
-import Distribution.Simple.Utils (rawSystemExit, cabalVersion)
+import Distribution.Simple.Utils
 
-import Distribution.License (License(..))
+import Distribution.License
 import Distribution.Version
-         ( Version(..) )
 import Distribution.Text
-         ( display )
 
 import System.Environment (getArgs, getProgName)
-import Data.List  (intercalate)
 import System.Exit
 
 defaultMain :: IO ()

--- a/Cabal/Distribution/ModuleName.hs
+++ b/Cabal/Distribution/ModuleName.hs
@@ -22,14 +22,13 @@ module Distribution.ModuleName (
   ) where
 
 import Distribution.Text
-         ( Text(..) )
+import Distribution.Compat.Binary
+import qualified Distribution.Compat.ReadP as Parse
 
-import Distribution.Compat.Binary (Binary)
 import qualified Data.Char as Char
          ( isAlphaNum, isUpper )
 import Data.Data (Data)
 import Data.Typeable (Typeable)
-import qualified Distribution.Compat.ReadP as Parse
 import qualified Text.PrettyPrint as Disp
 import Data.List
          ( intercalate, intersperse )

--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -26,6 +26,9 @@ module Distribution.Package (
         getHSLibraryName,
         InstalledPackageId, -- backwards compat
 
+        -- * ABI hash
+        AbiHash(..),
+
         -- * Package source dependencies
         Dependency(..),
         thisPackageVersion,
@@ -42,13 +45,13 @@ import Distribution.Version
          ( Version(..), VersionRange, anyVersion, thisVersion
          , notThisVersion, simplifyVersionRange )
 
-import Distribution.Text (Text(..))
 import qualified Distribution.Compat.ReadP as Parse
-import Distribution.Compat.ReadP ((<++))
 import qualified Text.PrettyPrint as Disp
+import Distribution.Compat.ReadP
+import Distribution.Compat.Binary
+import Distribution.Text
 
 import Control.DeepSeq (NFData(..))
-import Distribution.Compat.Binary (Binary)
 import qualified Data.Char as Char
     ( isDigit, isAlphaNum, )
 import Data.Data ( Data )
@@ -202,3 +205,14 @@ class Package pkg => HasComponentId pkg where
 -- Installed packages have exact dependencies 'installedDepends'.
 class (HasComponentId pkg) => PackageInstalled pkg where
   installedDepends :: pkg -> [ComponentId]
+
+-- -----------------------------------------------------------------------------
+-- ABI hash
+
+newtype AbiHash = AbiHash String
+    deriving (Eq, Show, Read, Generic)
+instance Binary AbiHash
+
+instance Text AbiHash where
+    disp (AbiHash abi) = Disp.text abi
+    parse = fmap AbiHash (Parse.munch Char.isAlphaNum)

--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -109,9 +109,20 @@ module Distribution.PackageDescription (
         SetupBuildInfo(..),
   ) where
 
-import Distribution.Compat.Binary (Binary)
+import Distribution.Compat.Binary
 import qualified Distribution.Compat.Semigroup as Semi ((<>))
 import Distribution.Compat.Semigroup as Semi (Monoid(..), Semigroup)
+import qualified Distribution.Compat.ReadP as Parse
+import Distribution.Compat.ReadP   ((<++))
+import Distribution.Package
+import Distribution.ModuleName
+import Distribution.Version
+import Distribution.License
+import Distribution.Compiler
+import Distribution.System
+import Distribution.Text
+import Language.Haskell.Extension
+
 import Data.Data                  (Data)
 import Data.Foldable              (traverse_)
 import Data.List                  (nub, intercalate)
@@ -123,26 +134,9 @@ import Control.Applicative as AP   (Alternative(..), Applicative(..))
 import Control.Monad               (MonadPlus(mplus,mzero), ap)
 import GHC.Generics                (Generic)
 import Text.PrettyPrint as Disp
-import qualified Distribution.Compat.ReadP as Parse
-import Distribution.Compat.ReadP   ((<++))
 import qualified Data.Char as Char (isAlphaNum, isDigit, toLower)
 import qualified Data.Map as Map
 import Data.Map                    (Map)
-
-import Distribution.Package
-         ( PackageName(PackageName), PackageIdentifier(PackageIdentifier)
-         , Dependency, Package(..), PackageName, packageName )
-import Distribution.ModuleName ( ModuleName )
-import Distribution.Version
-         ( Version(Version), VersionRange, anyVersion, orLaterVersion
-         , asVersionIntervals, LowerBound(..) )
-import Distribution.License  (License(UnspecifiedLicense))
-import Distribution.Compiler (CompilerFlavor)
-import Distribution.System   (OS, Arch)
-import Distribution.Text
-         ( Text(..), display )
-import Language.Haskell.Extension
-         ( Language, Extension )
 
 -- -----------------------------------------------------------------------------
 -- The PackageDescription type

--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -29,33 +29,18 @@ module Distribution.PackageDescription.Configuration (
   ) where
 
 import Distribution.Package
-         ( PackageName, Dependency(..) )
 import Distribution.PackageDescription
-         ( GenericPackageDescription(..), PackageDescription(..)
-         , Library(..), Executable(..), BuildInfo(..)
-         , Flag(..), FlagName(..), FlagAssignment
-         , Benchmark(..), CondTree(..), ConfVar(..), Condition(..)
-         , TestSuite(..) )
 import Distribution.PackageDescription.Utils
-         ( cabalBug, userBug )
 import Distribution.Version
-         ( VersionRange, anyVersion, intersectVersionRanges, withinRange )
 import Distribution.Compiler
-         ( CompilerId(CompilerId) )
 import Distribution.System
-         ( Platform(..), OS, Arch )
 import Distribution.Simple.Utils
-         ( currentDir, lowercase )
-import Distribution.Simple.Compiler
-         ( CompilerInfo(..) )
-
 import Distribution.Text
-         ( Text(parse) )
 import Distribution.Compat.ReadP as ReadP hiding ( char )
-import Control.Arrow (first)
 import qualified Distribution.Compat.ReadP as ReadP ( char )
 import Distribution.Compat.Semigroup as Semi
 
+import Control.Arrow (first)
 import Data.Char ( isAlphaNum )
 import Data.Maybe ( mapMaybe, maybeToList )
 import Data.Map ( Map, fromListWith, toList )

--- a/Cabal/Distribution/PackageDescription/PrettyPrint.hs
+++ b/Cabal/Distribution/PackageDescription/PrettyPrint.hs
@@ -17,25 +17,18 @@ module Distribution.PackageDescription.PrettyPrint (
     showGenericPackageDescription,
 ) where
 
-import Data.Monoid as Mon (Monoid(mempty))
 import Distribution.PackageDescription
-       ( Benchmark(..), BenchmarkInterface(..), benchmarkType
-       , TestSuite(..), TestSuiteInterface(..), testType
-       , SourceRepo(..),
-        customFieldsBI, CondTree(..), Condition(..), cNot,
-        FlagName(..), ConfVar(..), Executable(..), Library(..),
-        Flag(..), PackageDescription(..),
-        GenericPackageDescription(..))
+import Distribution.Simple.Utils
+import Distribution.ParseUtils
+import Distribution.PackageDescription.Parse
+import Distribution.Package
+import Distribution.Text
+
+import Data.Monoid as Mon (Monoid(mempty))
+import Data.Maybe (isJust)
 import Text.PrettyPrint
        (hsep, parens, char, nest, empty, isEmpty, ($$), (<+>),
         colon, (<>), text, vcat, ($+$), Doc, render)
-import Distribution.Simple.Utils (writeUTF8File)
-import Distribution.ParseUtils (showFreeText, FieldDescr(..), indentWith, ppField, ppFields)
-import Distribution.PackageDescription.Parse (pkgDescrFieldDescrs,binfoFieldDescrs,libFieldDescrs,
-       sourceRepoFieldDescrs,flagFieldDescrs)
-import Distribution.Package (Dependency(..))
-import Distribution.Text (Text(..))
-import Data.Maybe (isJust)
 
 -- | Recompile with false for regression testing
 simplifiedPrinting :: Bool

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -39,21 +39,16 @@ module Distribution.ParseUtils (
         UnrecFieldParser, warnUnrec, ignoreUnrec,
   ) where
 
-import Distribution.Compiler (CompilerFlavor, parseCompilerFlavorCompat)
+import Distribution.Compiler
 import Distribution.License
 import Distribution.Version
-         ( Version(..), VersionRange, anyVersion )
-import Distribution.Package     ( PackageName(..), Dependency(..) )
-import Distribution.ModuleName (ModuleName)
+import Distribution.Package
+import Distribution.ModuleName
 import Distribution.Compat.ReadP as ReadP hiding (get)
 import Distribution.ReadE
 import Distribution.Text
-         ( Text(..) )
 import Distribution.Simple.Utils
-         ( comparing, dropWhileEndLE, intercalate, lowercase
-         , normaliseLineEndings )
 import Language.Haskell.Extension
-         ( Language, Extension )
 
 import Text.PrettyPrint hiding (braces)
 import Data.Char (isSpace, toLower, isAlphaNum, isDigit)
@@ -657,8 +652,7 @@ parseVersionRangeQ = parseQuoted parse <++ parse
 parseOptVersion :: ReadP r Version
 parseOptVersion = parseQuoted ver <++ ver
   where ver :: ReadP r Version
-        ver = parse <++ return noVersion
-        noVersion = Version [] []
+        ver = parse <++ return (Version [] [])
 
 parseTestedWithQ :: ReadP r (CompilerFlavor,VersionRange)
 parseTestedWithQ = parseQuoted tw <++ tw

--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -56,53 +56,35 @@ module Distribution.Simple (
 -- local
 import Distribution.Simple.Compiler hiding (Flag)
 import Distribution.Simple.UserHooks
-import Distribution.Package --must not specify imports, since we're exporting module.
-import Distribution.PackageDescription
-         ( PackageDescription(..), GenericPackageDescription, Executable(..)
-         , updatePackageDescription, hasLibs
-         , HookedBuildInfo, emptyHookedBuildInfo )
+import Distribution.Package
+import Distribution.PackageDescription hiding (Flag)
 import Distribution.PackageDescription.Parse
-         ( readPackageDescription, readHookedBuildInfo )
 import Distribution.PackageDescription.Configuration
-         ( flattenPackageDescription )
 import Distribution.Simple.Program
-         ( defaultProgramConfiguration, builtinPrograms
-         , restoreProgramConfiguration)
 import Distribution.Simple.Program.Db
-import Distribution.Simple.Program.Find
-import Distribution.Simple.Program.Run
-import Distribution.Simple.Program.Types
-import Distribution.Simple.PreProcess (knownSuffixHandlers, PPSuffixHandler)
+import Distribution.Simple.PreProcess
 import Distribution.Simple.Setup
 import Distribution.Simple.Command
 
-import Distribution.Simple.Build        ( build, repl )
-import Distribution.Simple.SrcDist      ( sdist )
+import Distribution.Simple.Build
+import Distribution.Simple.SrcDist
 import Distribution.Simple.Register
-         ( register, unregister )
 
 import Distribution.Simple.Configure
-         ( getPersistBuildConfig, maybeGetPersistBuildConfig
-         , writePersistBuildConfig, checkPersistBuildConfigOutdated
-         , configure, checkForeignDeps, findDistPrefOrDefault )
 
-import Distribution.Simple.LocalBuildInfo ( LocalBuildInfo(..) )
-import Distribution.Simple.Bench (bench)
-import Distribution.Simple.BuildPaths ( srcPref)
-import Distribution.Simple.Test (test)
-import Distribution.Simple.Install (install)
-import Distribution.Simple.Haddock (haddock, hscolour)
+import Distribution.Simple.LocalBuildInfo
+import Distribution.Simple.Bench
+import Distribution.Simple.BuildPaths
+import Distribution.Simple.Test
+import Distribution.Simple.Install
+import Distribution.Simple.Haddock
 import Distribution.Simple.Utils
-         (die, notice, info, warn, setupMessage, chattyTry,
-          defaultPackageDesc, defaultHookedPackageDesc,
-          cabalVersion, topHandler )
 import Distribution.Utils.NubList
 import Distribution.Verbosity
 import Language.Haskell.Extension
 import Distribution.Version
 import Distribution.License
 import Distribution.Text
-         ( display )
 
 -- Base
 import System.Environment(getArgs, getProgName)
@@ -114,7 +96,7 @@ import Distribution.Compat.Environment (getEnvironment)
 
 import Control.Monad   (when)
 import Data.Foldable   (traverse_)
-import Data.List       (intercalate, unionBy, nub, (\\))
+import Data.List       (unionBy, nub, (\\))
 
 -- | A simple implementation of @main@ for a Cabal setup script.
 -- It reads the package description file using IO, and performs the
@@ -707,6 +689,5 @@ defaultRegHook :: PackageDescription -> LocalBuildInfo
 defaultRegHook pkg_descr localbuildinfo _ flags =
     if hasLibs pkg_descr
     then register pkg_descr localbuildinfo flags
-    else setupMessage verbosity
+    else setupMessage (fromFlag (regVerbosity flags))
            "Package contains no library to register:" (packageId pkg_descr)
-  where verbosity = fromFlag (regVerbosity flags)

--- a/Cabal/Distribution/Simple/Bench.hs
+++ b/Cabal/Distribution/Simple/Bench.hs
@@ -16,17 +16,13 @@ module Distribution.Simple.Bench
     ) where
 
 import qualified Distribution.PackageDescription as PD
-    ( PackageDescription(..), BuildInfo(buildable)
-    , Benchmark(..), BenchmarkInterface(..), benchmarkType, hasBenchmarks )
-import Distribution.Simple.BuildPaths ( exeExtension )
-import Distribution.Simple.Compiler ( compilerInfo )
+import Distribution.Simple.BuildPaths
+import Distribution.Simple.Compiler
 import Distribution.Simple.InstallDirs
-    ( fromPathTemplate, initialPathTemplateEnv, PathTemplateVariable(..)
-    , substPathTemplate , toPathTemplate, PathTemplate )
 import qualified Distribution.Simple.LocalBuildInfo as LBI
-import Distribution.Simple.Setup ( BenchmarkFlags(..), fromFlag )
-import Distribution.Simple.UserHooks ( Args )
-import Distribution.Simple.Utils ( die, notice, rawSystemExitCode )
+import Distribution.Simple.Setup
+import Distribution.Simple.UserHooks
+import Distribution.Simple.Utils
 import Distribution.Text
 
 import Control.Monad ( when, unless, forM )

--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -19,22 +19,14 @@ module Distribution.Simple.Build.PathsModule (
   ) where
 
 import Distribution.System
-         ( OS(Windows), buildOS, Arch(..), buildArch )
 import Distribution.Simple.Compiler
-         ( CompilerFlavor(..), compilerFlavor, compilerVersion )
 import Distribution.Package
-         ( packageId, packageName, packageVersion )
 import Distribution.PackageDescription
-         ( PackageDescription(..), hasLibs )
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.BuildPaths
-         ( autogenModuleName )
 import Distribution.Simple.Utils
-         ( shortRelativePath )
 import Distribution.Text
-         ( display )
 import Distribution.Version
-         ( Version(..), orLaterVersion, withinRange )
 
 import System.FilePath
          ( pathSeparator )

--- a/Cabal/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/Distribution/Simple/BuildPaths.hs
@@ -31,21 +31,16 @@ module Distribution.Simple.BuildPaths (
   ) where
 
 
-import System.FilePath ((</>), (<.>))
-
 import Distribution.Package
-         ( packageName, getHSLibraryName, ComponentId )
-import Distribution.ModuleName (ModuleName)
-import qualified Distribution.ModuleName as ModuleName
+import Distribution.ModuleName as ModuleName
 import Distribution.Compiler
-         ( CompilerId(..) )
-import Distribution.PackageDescription (PackageDescription)
+import Distribution.PackageDescription
 import Distribution.Simple.LocalBuildInfo
-         ( LocalBuildInfo(buildDir) )
-import Distribution.Simple.Setup (defaultDistPref)
+import Distribution.Simple.Setup
 import Distribution.Text
-         ( display )
-import Distribution.System (OS(..), buildOS)
+import Distribution.System
+
+import System.FilePath ((</>), (<.>))
 
 -- ---------------------------------------------------------------------------
 -- Build directories and files

--- a/Cabal/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/Distribution/Simple/BuildTarget.hs
@@ -32,40 +32,27 @@ module Distribution.Simple.BuildTarget (
   ) where
 
 import Distribution.Package
-         ( Package(..), PackageId, packageName )
-
 import Distribution.PackageDescription
-         ( PackageDescription
-         , Executable(..)
-         , TestSuite(..), TestSuiteInterface(..), testModules
-         , Benchmark(..), BenchmarkInterface(..), benchmarkModules
-         , BuildInfo(..), libModules, exeModules )
 import Distribution.ModuleName
-         ( ModuleName, toFilePath )
 import Distribution.Simple.LocalBuildInfo
-         ( Component(..), ComponentName(..)
-         , pkgComponents, componentName, componentBuildInfo )
-
 import Distribution.Text
-         ( display )
 import Distribution.Simple.Utils
-         ( die, lowercase, equating )
+
+import Distribution.Compat.Binary (Binary)
+import qualified Distribution.Compat.ReadP as Parse
+import Distribution.Compat.ReadP
+         ( (+++), (<++) )
 
 import Data.List
-         ( nub, stripPrefix, sortBy, groupBy, partition, intercalate )
-import Data.Ord
+         ( nub, stripPrefix, sortBy, groupBy, partition )
 import Data.Maybe
          ( listToMaybe, catMaybes )
 import Data.Either
          ( partitionEithers )
-import Distribution.Compat.Binary (Binary)
 import GHC.Generics (Generic)
 import qualified Data.Map as Map
 import Control.Monad
 import Control.Applicative as AP (Alternative(..), Applicative(..))
-import qualified Distribution.Compat.ReadP as Parse
-import Distribution.Compat.ReadP
-         ( (+++), (<++) )
 import Data.Char
          ( isSpace, isAlphaNum )
 import System.FilePath as FilePath
@@ -235,11 +222,11 @@ reportUserBuildTargetProblems problems = do
            ++ " - build foo:Data/Foo.hsc  -- file qualified by component"
 
 showUserBuildTarget :: UserBuildTarget -> String
-showUserBuildTarget = intercalate ":" . components
+showUserBuildTarget = intercalate ":" . getComponents
   where
-    components (UserBuildTargetSingle s1)       = [s1]
-    components (UserBuildTargetDouble s1 s2)    = [s1,s2]
-    components (UserBuildTargetTriple s1 s2 s3) = [s1,s2,s3]
+    getComponents (UserBuildTargetSingle s1)       = [s1]
+    getComponents (UserBuildTargetDouble s1 s2)    = [s1,s2]
+    getComponents (UserBuildTargetTriple s1 s2 s3) = [s1,s2,s3]
 
 showBuildTarget :: QualLevel -> PackageId -> BuildTarget -> String
 showBuildTarget ql pkgid bt =

--- a/Cabal/Distribution/Simple/Command.hs
+++ b/Cabal/Distribution/Simple/Command.hs
@@ -65,17 +65,17 @@ module Distribution.Simple.Command (
 
   ) where
 
+import qualified Distribution.GetOpt as GetOpt
+import Distribution.Text
+import Distribution.ParseUtils
+import Distribution.ReadE
+import Distribution.Simple.Utils
+
 import Control.Monad
 import Data.Char (isAlpha, toLower)
 import Data.List (sortBy)
 import Data.Maybe
 import Data.Monoid as Mon
-import qualified Distribution.GetOpt as GetOpt
-import Distribution.Text
-         ( Text(disp, parse) )
-import Distribution.ParseUtils
-import Distribution.ReadE
-import Distribution.Simple.Utils (die, intercalate)
 import Text.PrettyPrint ( punctuate, cat, comma, text )
 import Text.PrettyPrint as PP ( empty )
 

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -64,13 +64,13 @@ module Distribution.Simple.Compiler (
   ) where
 
 import Distribution.Compiler
-import Distribution.Version (Version(..))
-import Distribution.Text (display)
-import Language.Haskell.Extension (Language(Haskell98), Extension)
-import Distribution.Simple.Utils (lowercase)
+import Distribution.Version
+import Distribution.Text
+import Language.Haskell.Extension
+import Distribution.Simple.Utils
+import Distribution.Compat.Binary
 
 import Control.Monad (liftM)
-import Distribution.Compat.Binary (Binary)
 import Data.List (nub)
 import qualified Data.Map as M (Map, lookup)
 import Data.Maybe (catMaybes, isNothing, listToMaybe)

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -58,54 +58,31 @@ import qualified Distribution.Simple.GHC.IPI642 as IPI642
 import qualified Distribution.Simple.GHC.Internal as Internal
 import Distribution.Simple.GHC.ImplInfo
 import Distribution.PackageDescription as PD
-         ( PackageDescription(..), BuildInfo(..), Executable(..), Library(..)
-         , allExtensions, libModules, exeModules
-         , hcOptions, hcSharedOptions, hcProfOptions )
-import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo )
+import Distribution.InstalledPackageInfo (InstalledPackageInfo)
 import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
-                                ( InstalledPackageInfo(..) )
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.Simple.LocalBuildInfo
-         ( LocalBuildInfo(..), ComponentLocalBuildInfo(..)
-         , absoluteInstallDirs, depLibraryPaths )
 import qualified Distribution.Simple.Hpc as Hpc
-import Distribution.Simple.InstallDirs hiding ( absoluteInstallDirs )
 import Distribution.Simple.BuildPaths
 import Distribution.Simple.Utils
 import Distribution.Package
-         ( PackageName(..) )
 import qualified Distribution.ModuleName as ModuleName
 import Distribution.Simple.Program
-         ( Program(..), ConfiguredProgram(..), ProgramConfiguration
-         , ProgramSearchPath
-         , rawSystemProgramStdout, rawSystemProgramStdoutConf
-         , getProgramInvocationOutput, requireProgramVersion, requireProgram
-         , userMaybeSpecifyPath, programPath, lookupProgram, addKnownProgram
-         , ghcProgram, ghcPkgProgram, haddockProgram, hsc2hsProgram, ldProgram )
 import qualified Distribution.Simple.Program.HcPkg as HcPkg
 import qualified Distribution.Simple.Program.Ar    as Ar
 import qualified Distribution.Simple.Program.Ld    as Ld
 import qualified Distribution.Simple.Program.Strip as Strip
 import Distribution.Simple.Program.GHC
 import Distribution.Simple.Setup
-         ( toFlag, fromFlag, fromFlagOrDefault, configCoverage, configDistPref )
 import qualified Distribution.Simple.Setup as Cabal
-        ( Flag(..) )
-import Distribution.Simple.Compiler
-         ( CompilerFlavor(..), CompilerId(..), Compiler(..), compilerVersion
-         , PackageDB(..), PackageDBStack, AbiTag(..) )
+import Distribution.Simple.Compiler hiding (Flag)
 import Distribution.Version
-         ( Version(..), anyVersion, orLaterVersion )
 import Distribution.System
-         ( Platform(..), OS(..) )
 import Distribution.Verbosity
 import Distribution.Text
-         ( display )
 import Distribution.Utils.NubList
-         ( NubListR, overNubListR, toNubListR )
-import Language.Haskell.Extension (Extension(..), KnownExtension(..))
+import Language.Haskell.Extension
 
 import Control.Monad            ( unless, when )
 import Data.Char                ( isDigit, isSpace )

--- a/Cabal/Distribution/Simple/GHC/IPI641.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI641.hs
@@ -15,11 +15,8 @@ module Distribution.Simple.GHC.IPI641 (
 
 import qualified Distribution.InstalledPackageInfo as Current
 import qualified Distribution.Package as Current hiding (installedComponentId)
-import Distribution.Text (display)
-
-import Distribution.Simple.GHC.IPI642
-         ( PackageIdentifier, convertPackageId
-         , License, convertLicense, convertModuleName )
+import Distribution.Text
+import Distribution.Simple.GHC.IPIConvert
 
 -- | This is the InstalledPackageInfo type used by ghc-6.4 and 6.4.1.
 --
@@ -85,7 +82,7 @@ toCurrent ipi@InstalledPackageInfo{} =
     Current.abiHash            = Current.AbiHash "",
     Current.exposed            = exposed ipi,
     Current.exposedModules     = map (mkExposedModule . convertModuleName) (exposedModules ipi),
-    Current.instantiatedWith   = [],
+    Current.installedInstantiatedWith   = [],
     Current.hiddenModules      = map convertModuleName (hiddenModules ipi),
     Current.trusted            = Current.trusted Current.emptyInstalledPackageInfo,
     Current.importDirs         = importDirs ipi,

--- a/Cabal/Distribution/Simple/GHC/IPI642.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI642.hs
@@ -11,22 +11,13 @@
 module Distribution.Simple.GHC.IPI642 (
     InstalledPackageInfo(..),
     toCurrent,
-
-    -- Don't use these, they're only for conversion purposes
-    PackageIdentifier, convertPackageId,
-    License, convertLicense,
-    convertModuleName
   ) where
 
 import qualified Distribution.InstalledPackageInfo as Current
 import qualified Distribution.Package as Current hiding (installedComponentId)
-import qualified Distribution.License as Current
+import Distribution.Simple.GHC.IPIConvert
 
-import Distribution.Version (Version)
-import Distribution.ModuleName (ModuleName)
-import Distribution.Text (simpleParse,display)
-
-import Data.Maybe
+import Distribution.Text
 
 -- | This is the InstalledPackageInfo type used by ghc-6.4.2 and later.
 --
@@ -70,34 +61,8 @@ data InstalledPackageInfo = InstalledPackageInfo {
   }
   deriving Read
 
-data PackageIdentifier = PackageIdentifier {
-    pkgName    :: String,
-    pkgVersion :: Version
-  }
-  deriving Read
-
-data License = GPL | LGPL | BSD3 | BSD4
-             | PublicDomain | AllRightsReserved | OtherLicense
-  deriving Read
-
-convertPackageId :: PackageIdentifier -> Current.PackageIdentifier
-convertPackageId PackageIdentifier { pkgName = n, pkgVersion = v } =
-  Current.PackageIdentifier (Current.PackageName n) v
-
 mkComponentId :: Current.PackageIdentifier -> Current.ComponentId
 mkComponentId = Current.ComponentId . display
-
-convertModuleName :: String -> ModuleName
-convertModuleName s = fromJust $ simpleParse s
-
-convertLicense :: License -> Current.License
-convertLicense GPL  = Current.GPL  Nothing
-convertLicense LGPL = Current.LGPL Nothing
-convertLicense BSD3 = Current.BSD3
-convertLicense BSD4 = Current.BSD4
-convertLicense PublicDomain = Current.PublicDomain
-convertLicense AllRightsReserved = Current.AllRightsReserved
-convertLicense OtherLicense = Current.OtherLicense
 
 toCurrent :: InstalledPackageInfo -> Current.InstalledPackageInfo
 toCurrent ipi@InstalledPackageInfo{} =
@@ -121,7 +86,7 @@ toCurrent ipi@InstalledPackageInfo{} =
     Current.exposed            = exposed ipi,
     Current.exposedModules     = map (mkExposedModule . convertModuleName) (exposedModules ipi),
     Current.hiddenModules      = map convertModuleName (hiddenModules ipi),
-    Current.instantiatedWith   = [],
+    Current.installedInstantiatedWith   = [],
     Current.trusted            = Current.trusted Current.emptyInstalledPackageInfo,
     Current.importDirs         = importDirs ipi,
     Current.libraryDirs        = libraryDirs ipi,

--- a/Cabal/Distribution/Simple/GHC/IPIConvert.hs
+++ b/Cabal/Distribution/Simple/GHC/IPIConvert.hs
@@ -1,0 +1,51 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Simple.GHC.IPI642
+-- Copyright   :  (c) The University of Glasgow 2004
+-- License     :  BSD3
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Portability :  portable
+--
+-- Helper functions for 'Distribution.Simple.GHC.IPI642' and
+-- 'Distribution.Simple.GHC.IPI641'
+module Distribution.Simple.GHC.IPIConvert (
+    PackageIdentifier, convertPackageId,
+    License, convertLicense,
+    convertModuleName
+  ) where
+
+import qualified Distribution.Package as Current hiding (installedComponentId)
+import qualified Distribution.License as Current
+
+import Distribution.Version
+import Distribution.ModuleName
+import Distribution.Text
+
+import Data.Maybe
+
+data PackageIdentifier = PackageIdentifier {
+    pkgName    :: String,
+    pkgVersion :: Version
+  }
+  deriving Read
+
+convertPackageId :: PackageIdentifier -> Current.PackageIdentifier
+convertPackageId PackageIdentifier { pkgName = n, pkgVersion = v } =
+  Current.PackageIdentifier (Current.PackageName n) v
+
+data License = GPL | LGPL | BSD3 | BSD4
+             | PublicDomain | AllRightsReserved | OtherLicense
+  deriving Read
+
+convertModuleName :: String -> ModuleName
+convertModuleName s = fromJust $ simpleParse s
+
+convertLicense :: License -> Current.License
+convertLicense GPL  = Current.GPL  Nothing
+convertLicense LGPL = Current.LGPL Nothing
+convertLicense BSD3 = Current.BSD3
+convertLicense BSD4 = Current.BSD4
+convertLicense PublicDomain = Current.PublicDomain
+convertLicense AllRightsReserved = Current.AllRightsReserved
+convertLicense OtherLicense = Current.OtherLicense

--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -15,9 +15,7 @@ module Distribution.Simple.GHC.ImplInfo (
         ) where
 
 import Distribution.Simple.Compiler
-  ( Compiler(..), CompilerFlavor(..)
-  , compilerFlavor, compilerVersion, compilerCompatVersion )
-import Distribution.Version ( Version(..) )
+import Distribution.Version
 
 {- |
      Information about features and quirks of a GHC-based implementation.

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -30,43 +30,26 @@ module Distribution.Simple.GHC.Internal (
         showOsString,
  ) where
 
-import Distribution.Simple.GHC.ImplInfo ( GhcImplInfo (..) )
+import Distribution.Simple.GHC.ImplInfo
 import Distribution.Package
-         ( PackageId, ComponentId, getHSLibraryName )
 import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo )
 import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
-                                ( InstalledPackageInfo(..) )
-import Distribution.PackageDescription as PD
-         ( BuildInfo(..), Library(..), libModules
-         , hcOptions, usedExtensions, ModuleRenaming, lookupRenaming )
-import Distribution.Compat.Exception ( catchExit, catchIO )
-import Distribution.Lex (tokenizeQuotedWords)
-import Distribution.Simple.Compiler
-         ( CompilerFlavor(..), Compiler(..), DebugInfoLevel(..)
-         , OptimisationLevel(..), ProfDetailLevel(..) )
+import Distribution.PackageDescription as PD hiding (Flag)
+import Distribution.Compat.Exception
+import Distribution.Lex
+import Distribution.Simple.Compiler hiding (Flag)
 import Distribution.Simple.Program.GHC
 import Distribution.Simple.Setup
-         ( Flag, toFlag )
 import qualified Distribution.ModuleName as ModuleName
 import Distribution.Simple.Program
-         ( Program(..), ConfiguredProgram(..), ProgramConfiguration
-         , ProgramLocation(..), ProgramSearchPath, ProgramSearchPathEntry(..)
-         , rawSystemProgram, rawSystemProgramStdout, programPath
-         , addKnownProgram, arProgram, ldProgram, gccProgram, stripProgram
-         , getProgramOutput )
-import Distribution.Simple.Program.Types ( suppressOverrideArgs )
 import Distribution.Simple.LocalBuildInfo
-         ( LocalBuildInfo(..), ComponentLocalBuildInfo(..) )
 import Distribution.Simple.Utils
 import Distribution.Simple.BuildPaths
 import Distribution.System
-         ( Arch(..), buildOS, OS(..), Platform, platformFromTriple )
 import Distribution.Text ( display, simpleParse )
 import Distribution.Utils.NubList ( toNubListR )
 import Distribution.Verbosity
 import Language.Haskell.Extension
-         ( Language(..), Extension(..), KnownExtension(..) )
 
 import qualified Data.Map as M
 import Data.Char                ( isSpace )

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -26,60 +26,24 @@ import qualified Distribution.Simple.GHCJS as GHCJS
 -- local
 import Distribution.Compat.Semigroup as Semi
 import Distribution.Package
-         ( PackageIdentifier(..)
-         , Package(..)
-         , PackageName(..), packageName, ComponentId(..) )
 import qualified Distribution.ModuleName as ModuleName
-import Distribution.PackageDescription as PD
-         ( PackageDescription(..), BuildInfo(..), usedExtensions
-         , hcSharedOptions
-         , Library(..), hasLibs, Executable(..)
-         , TestSuite(..), TestSuiteInterface(..)
-         , Benchmark(..), BenchmarkInterface(..) )
-import Distribution.Simple.Compiler
-         ( Compiler, compilerInfo, CompilerFlavor(..)
-         , compilerFlavor, compilerCompatVersion )
+import Distribution.PackageDescription as PD hiding (Flag)
+import Distribution.Simple.Compiler hiding (Flag)
 import Distribution.Simple.Program.GHC
-         ( GhcOptions(..), GhcDynLinkMode(..), renderGhcOptions )
 import Distribution.Simple.Program
-         ( ConfiguredProgram(..), lookupProgramVersion, requireProgramVersion
-         , rawSystemProgram, rawSystemProgramStdout
-         , hscolourProgram, haddockProgram )
 import Distribution.Simple.PreProcess
-         ( PPSuffixHandler, preprocessComponent)
 import Distribution.Simple.Setup
-         ( defaultHscolourFlags
-         , Flag(..), toFlag, flagToMaybe, flagToList, fromFlag
-         , fromFlagOrDefault, HaddockFlags(..), HscolourFlags(..) )
-import Distribution.Simple.Build (initialBuildSteps)
+import Distribution.Simple.Build
 import Distribution.Simple.InstallDirs
-         ( InstallDirs(..)
-         , PathTemplateEnv, PathTemplate, PathTemplateVariable(..)
-         , toPathTemplate, fromPathTemplate
-         , substPathTemplate, initialPathTemplateEnv )
-import Distribution.Simple.LocalBuildInfo
-         ( LocalBuildInfo(..), Component(..), ComponentLocalBuildInfo(..)
-         , withAllComponentsInBuildOrder )
+import Distribution.Simple.LocalBuildInfo hiding (substPathTemplate)
 import Distribution.Simple.BuildPaths
-         ( haddockName, hscolourPref, autogenModulesDir)
-import Distribution.Simple.PackageIndex (dependencyClosure)
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
-         ( InstalledPackageInfo(..) )
-import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo )
+import Distribution.InstalledPackageInfo ( InstalledPackageInfo )
 import Distribution.Simple.Utils
-         ( die, copyFileTo, warn, notice, intercalate, setupMessage
-         , createDirectoryIfMissingVerbose
-         , TempFileOptions(..), defaultTempFileOptions
-         , withTempFileEx, copyFileVerbose
-         , withTempDirectoryEx, matchFileGlob
-         , findFileWithExtension, findFile )
 import Distribution.Text
-         ( display, simpleParse )
 import Distribution.Utils.NubList
-         ( toNubListR )
-
+import Distribution.Version
 import Distribution.Verbosity
 import Language.Haskell.Extension
 
@@ -94,7 +58,6 @@ import System.Directory (doesFileExist)
 import System.FilePath  ( (</>), (<.>)
                         , normalise, splitPath, joinPath, isAbsolute )
 import System.IO        (hClose, hPutStr, hPutStrLn, hSetEncoding, utf8)
-import Distribution.Version
 
 -- ------------------------------------------------------------------------------
 -- Types
@@ -645,7 +608,7 @@ haddockPackageFlags :: LocalBuildInfo
 haddockPackageFlags lbi clbi htmlTemplate = do
   let allPkgs = installedPkgs lbi
       directDeps = map fst (componentPackageDeps clbi)
-  transitiveDeps <- case dependencyClosure allPkgs directDeps of
+  transitiveDeps <- case PackageIndex.dependencyClosure allPkgs directDeps of
     Left x    -> return x
     Right inf -> die $ "internal error when calculating transitive "
                     ++ "package dependencies.\nDebug info: " ++ show inf

--- a/Cabal/Distribution/Simple/HaskellSuite.hs
+++ b/Cabal/Distribution/Simple/HaskellSuite.hs
@@ -20,7 +20,6 @@ import Distribution.System (Platform)
 import Distribution.Compat.Exception
 import Language.Haskell.Extension
 import Distribution.Simple.Program.Builtin
-  (haskellSuiteProgram, haskellSuitePkgProgram)
 
 configure
   :: Verbosity -> Maybe FilePath -> Maybe FilePath

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -47,21 +47,17 @@ module Distribution.Simple.InstallDirs (
 
 import Distribution.Compat.Binary (Binary)
 import Distribution.Compat.Semigroup as Semi
+import Distribution.Package
+import Distribution.System
+import Distribution.Compiler
+import Distribution.Text
+
 import Data.List (isPrefixOf)
 import Data.Maybe (fromMaybe)
 import GHC.Generics (Generic)
 import System.Directory (getAppUserDataDirectory)
 import System.FilePath ((</>), isPathSeparator, pathSeparator)
 import System.FilePath (dropDrive)
-
-import Distribution.Package
-         ( PackageIdentifier, packageName, packageVersion, ComponentId )
-import Distribution.System
-         ( OS(..), buildOS, Platform(..) )
-import Distribution.Compiler
-         ( AbiTag(..), abiTagString, CompilerInfo(..), CompilerFlavor(..) )
-import Distribution.Text
-         ( display )
 
 #if mingw32_HOST_OS
 import Foreign

--- a/Cabal/Distribution/Simple/JHC.hs
+++ b/Cabal/Distribution/Simple/JHC.hs
@@ -16,40 +16,23 @@ module Distribution.Simple.JHC (
         installLib, installExe
  ) where
 
-import Distribution.PackageDescription as PD
-       ( PackageDescription(..), BuildInfo(..), Executable(..)
-       , Library(..), libModules, hcOptions, usedExtensions )
+import Distribution.PackageDescription as PD hiding (Flag)
 import Distribution.InstalledPackageInfo
-         ( emptyInstalledPackageInfo, )
 import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.Simple.LocalBuildInfo
-         ( LocalBuildInfo(..), ComponentLocalBuildInfo(..) )
 import Distribution.Simple.BuildPaths
-                                ( autogenModulesDir, exeExtension )
 import Distribution.Simple.Compiler
-         ( CompilerFlavor(..), CompilerId(..), Compiler(..), AbiTag(..)
-         , PackageDBStack, Flag, languageToFlags, extensionsToFlags )
 import Language.Haskell.Extension
-         ( Language(Haskell98), Extension(..), KnownExtension(..))
 import Distribution.Simple.Program
-         ( ConfiguredProgram(..), jhcProgram, ProgramConfiguration
-         , userMaybeSpecifyPath, requireProgramVersion, lookupProgram
-         , rawSystemProgram, rawSystemProgramStdoutConf )
 import Distribution.Version
-         ( Version(..), orLaterVersion )
 import Distribution.Package
-         ( Package(..), ComponentId(ComponentId),
-           pkgName, pkgVersion, )
 import Distribution.Simple.Utils
-        ( createDirectoryIfMissingVerbose, writeFileAtomic
-        , installOrdinaryFile, installExecutableFile
-        , intercalate )
-import System.FilePath          ( (</>) )
 import Distribution.Verbosity
 import Distribution.Text
-         ( Text(parse), display )
+
+import System.FilePath          ( (</>) )
 import Distribution.Compat.ReadP
     ( readP_to_S, string, skipSpaces )
 import Distribution.System ( Platform )

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -40,50 +40,25 @@ module Distribution.Simple.LHC (
         ghcVerbosityOptions
  ) where
 
-import Distribution.PackageDescription as PD
-         ( PackageDescription(..), BuildInfo(..), Executable(..)
-         , Library(..), libModules, hcOptions, hcProfOptions, hcSharedOptions
-         , usedExtensions, allExtensions )
+import Distribution.PackageDescription as PD hiding (Flag)
 import Distribution.InstalledPackageInfo
-                                ( InstalledPackageInfo
-                                , parseInstalledPackageInfo )
 import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
-                                ( InstalledPackageInfo(..) )
 import Distribution.Simple.PackageIndex
 import qualified Distribution.Simple.PackageIndex as PackageIndex
-import Distribution.ParseUtils  ( ParseResult(..) )
 import Distribution.Simple.LocalBuildInfo
-         ( LocalBuildInfo(..), ComponentLocalBuildInfo(..) )
-import Distribution.Simple.InstallDirs
 import Distribution.Simple.BuildPaths
 import Distribution.Simple.Utils
 import Distribution.Package
-         ( Package(..), getHSLibraryName, ComponentId )
 import qualified Distribution.ModuleName as ModuleName
 import Distribution.Simple.Program
-         ( Program(..), ConfiguredProgram(..), ProgramConfiguration
-         , ProgramSearchPath, ProgramLocation(..)
-         , rawSystemProgram, rawSystemProgramConf
-         , rawSystemProgramStdout, rawSystemProgramStdoutConf
-         , requireProgramVersion
-         , userMaybeSpecifyPath, programPath, lookupProgram, addKnownProgram
-         , arProgram, ldProgram
-         , gccProgram, stripProgram
-         , lhcProgram, lhcPkgProgram )
 import qualified Distribution.Simple.Program.HcPkg as HcPkg
 import Distribution.Simple.Compiler
-         ( CompilerFlavor(..), CompilerId(..), Compiler(..), compilerVersion
-         , OptimisationLevel(..), PackageDB(..), PackageDBStack, AbiTag(..)
-         , Flag, languageToFlags, extensionsToFlags )
 import Distribution.Version
-         ( Version(..), orLaterVersion )
-import Distribution.System
-         ( OS(..), buildOS )
 import Distribution.Verbosity
 import Distribution.Text
-         ( display, simpleParse )
+import Distribution.Compat.Exception
+import Distribution.System
 import Language.Haskell.Extension
-         ( Language(Haskell98), Extension(..), KnownExtension(..) )
 
 import Control.Monad            ( unless, when )
 import Data.Monoid as Mon
@@ -96,8 +71,6 @@ import System.Directory         ( removeFile, renameFile,
 import System.FilePath          ( (</>), (<.>), takeExtension,
                                   takeDirectory, replaceExtension )
 import System.IO (hClose, hPutStrLn)
-import Distribution.Compat.Exception (catchExit, catchIO)
-import Distribution.System ( Platform )
 
 -- -----------------------------------------------------------------------------
 -- Configuring

--- a/Cabal/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Simple/LocalBuildInfo.hs
@@ -62,30 +62,18 @@ import Distribution.Simple.InstallDirs hiding (absoluteInstallDirs,
                                                prefixRelativeInstallDirs,
                                                substPathTemplate, )
 import qualified Distribution.Simple.InstallDirs as InstallDirs
-import Distribution.Simple.Program (ProgramConfiguration)
-import Distribution.InstalledPackageInfo (InstalledPackageInfo)
+import Distribution.Simple.Program
+import Distribution.InstalledPackageInfo
 import Distribution.PackageDescription
-         ( PackageDescription(..), withLib, Library(libBuildInfo), withExe
-         , Executable(exeName, buildInfo), withTest, TestSuite(..)
-         , BuildInfo(buildable), Benchmark(..), ModuleRenaming(..) )
 import qualified Distribution.InstalledPackageInfo as Installed
 import Distribution.Package
-         ( PackageId, Package(..), ComponentId(..)
-         , PackageName, ComponentId(..) )
 import Distribution.Simple.Compiler
-         ( Compiler, compilerInfo, PackageDBStack, DebugInfoLevel
-         , OptimisationLevel, ProfDetailLevel )
 import Distribution.Simple.PackageIndex
-         ( InstalledPackageIndex, allPackages )
-import Distribution.ModuleName ( ModuleName )
+import Distribution.ModuleName
 import Distribution.Simple.Setup
-         ( ConfigFlags )
 import Distribution.Simple.Utils
-         ( shortRelativePath )
 import Distribution.Text
-         ( display )
 import Distribution.System
-         ( Platform (..) )
 
 import Data.Array ((!))
 import Distribution.Compat.Binary (Binary)

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -61,36 +61,27 @@ module Distribution.Simple.PackageIndex (
   moduleNameIndex,
   ) where
 
+import Distribution.Compat.Binary
+import Distribution.Compat.Semigroup as Semi
+import Distribution.Package
+import Distribution.ModuleName
+import qualified Distribution.InstalledPackageInfo as IPI
+import Distribution.Version
+import Distribution.Simple.Utils
+
 import Control.Exception (assert)
 import Data.Array ((!))
 import qualified Data.Array as Array
-import Distribution.Compat.Binary (Binary)
-import Distribution.Compat.Semigroup as Semi
 import qualified Data.Graph as Graph
 import Data.List as List
          ( null, foldl', sort
-         , groupBy, sortBy, find, isInfixOf, nubBy, deleteBy, deleteFirstsBy )
+         , groupBy, sortBy, find, nubBy, deleteBy, deleteFirstsBy )
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe (isNothing, fromMaybe)
 import qualified Data.Tree  as Tree
 import GHC.Generics (Generic)
 import Prelude hiding (lookup)
-
-import Distribution.Package
-         ( PackageName(..), PackageId
-         , Package(..), packageName, packageVersion
-         , Dependency(Dependency)--, --PackageFixedDeps(..)
-         , HasComponentId(..), PackageInstalled(..)
-         , ComponentId )
-import Distribution.ModuleName
-         ( ModuleName )
-import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo )
-import qualified Distribution.InstalledPackageInfo as IPI
-import Distribution.Version
-         ( Version, withinRange )
-import Distribution.Simple.Utils (lowercase, comparing, equating)
 
 -- | The collection of information about packages from one or more 'PackageDB's.
 -- These packages generally should have an instance of 'PackageInstalled'
@@ -123,7 +114,7 @@ instance Binary a => Binary (PackageIndex a)
 
 -- | The default package index which contains 'InstalledPackageInfo'.  Normally
 -- use this.
-type InstalledPackageIndex = PackageIndex InstalledPackageInfo
+type InstalledPackageIndex = PackageIndex IPI.InstalledPackageInfo
 
 instance HasComponentId a => Monoid (PackageIndex a) where
   mempty  = PackageIndex Map.empty Map.empty
@@ -600,7 +591,7 @@ dependencyInconsistencies index =
 -- 'InstalledPackageIndex' and turns it into a map from module names to their
 -- source packages.  It's used to initialize the @build-deps@ field in @cabal
 -- init@.
-moduleNameIndex :: InstalledPackageIndex -> Map ModuleName [InstalledPackageInfo]
+moduleNameIndex :: InstalledPackageIndex -> Map ModuleName [IPI.InstalledPackageInfo]
 moduleNameIndex index =
   Map.fromListWith (++) $ do
     pkg <- allPackages index

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -27,49 +27,25 @@ module Distribution.Simple.PreProcess (preprocessComponent, preprocessExtras,
     where
 
 
-import Control.Monad
-import Distribution.Simple.PreProcess.Unlit (unlit)
+import Distribution.Simple.PreProcess.Unlit
 import Distribution.Package
-         ( Package(..), PackageName(..) )
 import qualified Distribution.ModuleName as ModuleName
 import Distribution.PackageDescription as PD
-         ( PackageDescription(..), BuildInfo(..)
-         , Executable(..)
-         , Library(..), libModules
-         , TestSuite(..), testModules
-         , TestSuiteInterface(..)
-         , Benchmark(..), benchmarkModules, BenchmarkInterface(..) )
 import qualified Distribution.InstalledPackageInfo as Installed
-         ( InstalledPackageInfo(..) )
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.Simple.CCompiler
-         ( cSourceExtensions )
 import Distribution.Simple.Compiler
-         ( CompilerFlavor(..)
-         , compilerFlavor, compilerCompatVersion, compilerVersion )
 import Distribution.Simple.LocalBuildInfo
-         ( LocalBuildInfo(..), Component(..) )
-import Distribution.Simple.BuildPaths (autogenModulesDir,cppHeaderName)
+import Distribution.Simple.BuildPaths
 import Distribution.Simple.Utils
-         ( createDirectoryIfMissingVerbose, withUTF8FileContents, writeUTF8File
-         , die, setupMessage, intercalate, copyFileVerbose, moreRecentFile
-         , findFileWithExtension, findFileWithExtension'
-         , getDirectoryContentsRecursive )
 import Distribution.Simple.Program
-         ( Program(..), ConfiguredProgram(..), programPath
-         , requireProgram, requireProgramVersion
-         , rawSystemProgramConf, rawSystemProgram
-         , greencardProgram, cpphsProgram, hsc2hsProgram, c2hsProgram
-         , happyProgram, alexProgram, ghcProgram, ghcjsProgram, gccProgram )
 import Distribution.Simple.Test.LibV09
-         ( writeSimpleTestStub, stubFilePath, stubName )
 import Distribution.System
-         ( OS(..), buildOS, Arch(..), Platform(..) )
 import Distribution.Text
 import Distribution.Version
-         ( Version(..), anyVersion, orLaterVersion )
 import Distribution.Verbosity
 
+import Control.Monad
 import Data.Maybe (fromMaybe)
 import Data.List (nub, isSuffixOf)
 import System.Directory (doesFileExist)

--- a/Cabal/Distribution/Simple/Program.hs
+++ b/Cabal/Distribution/Simple/Program.hs
@@ -132,11 +132,8 @@ import Distribution.Simple.Program.Run
 import Distribution.Simple.Program.Db
 import Distribution.Simple.Program.Builtin
 import Distribution.Simple.Program.Find
-
 import Distribution.Simple.Utils
-         ( die, findProgramLocation, findProgramVersion )
 import Distribution.Verbosity
-         ( Verbosity )
 
 
 -- | Runs the given configured program.

--- a/Cabal/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/Distribution/Simple/Program/Builtin.hs
@@ -46,27 +46,16 @@ module Distribution.Simple.Program.Builtin (
   ) where
 
 import Distribution.Simple.Program.Find
-         ( findProgramOnSearchPath )
 import Distribution.Simple.Program.Internal
-         ( stripExtractVersion )
 import Distribution.Simple.Program.Run
-         ( getProgramInvocationOutput, programInvocation )
 import Distribution.Simple.Program.Types
-         ( Program(..), ConfiguredProgram(..), simpleProgram )
 import Distribution.Simple.Utils
-         ( findProgramVersion )
 import Distribution.Compat.Exception
-         ( catchIO )
 import Distribution.Verbosity
-         ( lessVerbose )
 import Distribution.Version
-         ( Version(..), withinRange, earlierVersion, laterVersion
-         , intersectVersionRanges )
+
 import Data.Char
          ( isDigit )
-
-import Data.List
-         ( isInfixOf )
 import qualified Data.Map as Map
 
 -- ------------------------------------------------------------

--- a/Cabal/Distribution/Simple/Program/Db.hs
+++ b/Cabal/Distribution/Simple/Program/Db.hs
@@ -56,22 +56,14 @@ module Distribution.Simple.Program.Db (
   ) where
 
 import Distribution.Simple.Program.Types
-         ( Program(..), ProgArg, ConfiguredProgram(..), ProgramLocation(..) )
 import Distribution.Simple.Program.Find
-         ( ProgramSearchPath, defaultProgramSearchPath
-         , findProgramOnSearchPath, programSearchPathAsPATHVar )
 import Distribution.Simple.Program.Builtin
-         ( builtinPrograms )
 import Distribution.Simple.Utils
-         ( die, doesExecutableExist )
 import Distribution.Version
-         ( Version, VersionRange, isAnyVersion, withinRange )
 import Distribution.Text
-         ( display )
 import Distribution.Verbosity
-         ( Verbosity )
+import Distribution.Compat.Binary
 
-import Distribution.Compat.Binary (Binary(..))
 import Data.List
          ( foldl' )
 import Data.Maybe
@@ -455,7 +447,7 @@ lookupProgramVersion verbosity prog range programDb = do
           | otherwise                 ->
             return $! Left (badVersion version location)
         Nothing                       ->
-          return $! Left (noVersion location)
+          return $! Left (unknownVersion location)
 
   where notFound       = "The program '"
                       ++ programName prog ++ "'" ++ versionRequirement
@@ -464,7 +456,7 @@ lookupProgramVersion verbosity prog range programDb = do
                       ++ programName prog ++ "'" ++ versionRequirement
                       ++ " is required but the version found at "
                       ++ locationPath l ++ " is version " ++ display v
-        noVersion l    = "The program '"
+        unknownVersion l = "The program '"
                       ++ programName prog ++ "'" ++ versionRequirement
                       ++ " is required but the version of "
                       ++ locationPath l ++ " could not be determined."

--- a/Cabal/Distribution/Simple/Program/Find.hs
+++ b/Cabal/Distribution/Simple/Program/Find.hs
@@ -32,21 +32,18 @@ module Distribution.Simple.Program.Find (
   ) where
 
 import Distribution.Verbosity
-         ( Verbosity )
 import Distribution.Simple.Utils
-         ( debug, doesExecutableExist )
 import Distribution.System
-         ( OS(..), buildOS )
+import Distribution.Compat.Environment
+import Distribution.Compat.Binary
+
 import qualified System.Directory as Directory
          ( findExecutable )
-import Distribution.Compat.Environment
-         ( getEnvironment )
 import System.FilePath as FilePath
          ( (</>), (<.>), splitSearchPath, searchPathSeparator, getSearchPath
          , takeDirectory )
 import Data.List
-         ( intercalate, nub )
-import Distribution.Compat.Binary
+         ( nub )
 import GHC.Generics
 #if defined(mingw32_HOST_OS)
 import qualified System.Win32 as Win32

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -13,19 +13,18 @@ module Distribution.Simple.Program.GHC (
   ) where
 
 import Distribution.Compat.Semigroup as Semi
-import Distribution.Simple.GHC.ImplInfo ( getImplInfo, GhcImplInfo(..) )
+import Distribution.Simple.GHC.ImplInfo
 import Distribution.Package
 import Distribution.PackageDescription hiding (Flag)
 import Distribution.ModuleName
 import Distribution.Simple.Compiler hiding (Flag)
-import Distribution.Simple.Setup    ( Flag(..), flagToMaybe, fromFlagOrDefault,
-                                      flagToList )
+import Distribution.Simple.Setup
 import Distribution.Simple.Program.Types
 import Distribution.Simple.Program.Run
 import Distribution.Text
 import Distribution.Verbosity
-import Distribution.Utils.NubList   ( NubListR, fromNubListR )
-import Language.Haskell.Extension   ( Language(..), Extension(..) )
+import Distribution.Utils.NubList
+import Language.Haskell.Extension
 
 import qualified Data.Map as M
 import Data.List ( intercalate )

--- a/Cabal/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/Distribution/Simple/Program/HcPkg.hs
@@ -39,30 +39,18 @@ module Distribution.Simple.Program.HcPkg (
     listInvocation,
   ) where
 
-import Prelude hiding (init)
-import Distribution.Package
-         ( PackageId, ComponentId(..) )
+import Distribution.Package hiding (installedComponentId)
 import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo, InstalledPackageInfo(..)
-         , showInstalledPackageInfo
-         , emptyInstalledPackageInfo, fieldsInstalledPackageInfo )
 import Distribution.ParseUtils
 import Distribution.Simple.Compiler
-         ( PackageDB(..), PackageDBStack )
 import Distribution.Simple.Program.Types
-         ( ConfiguredProgram(programId) )
 import Distribution.Simple.Program.Run
-         ( ProgramInvocation(..), IOEncoding(..), programInvocation
-         , runProgramInvocation, getProgramInvocationOutput )
 import Distribution.Text
-         ( display, simpleParse )
 import Distribution.Simple.Utils
-         ( die, writeUTF8File )
 import Distribution.Verbosity
-         ( Verbosity, deafening, silent )
 import Distribution.Compat.Exception
-         ( catchIO )
 
+import Prelude hiding (init)
 import Data.Char
          ( isSpace )
 import Data.List

--- a/Cabal/Distribution/Simple/Program/Hpc.hs
+++ b/Cabal/Distribution/Simple/Program/Hpc.hs
@@ -13,14 +13,13 @@ module Distribution.Simple.Program.Hpc
     , union
     ) where
 
-import Distribution.ModuleName ( ModuleName )
+import Distribution.ModuleName
 import Distribution.Simple.Program.Run
-         ( ProgramInvocation, programInvocation, runProgramInvocation )
-import Distribution.Simple.Program.Types ( ConfiguredProgram(..) )
-import Distribution.Text ( display )
-import Distribution.Simple.Utils ( warn )
-import Distribution.Verbosity ( Verbosity )
-import Distribution.Version ( Version(..), orLaterVersion, withinRange )
+import Distribution.Simple.Program.Types
+import Distribution.Text
+import Distribution.Simple.Utils
+import Distribution.Verbosity
+import Distribution.Version
 
 -- | Invoke hpc with the given parameters.
 --

--- a/Cabal/Distribution/Simple/Program/Run.hs
+++ b/Cabal/Distribution/Simple/Program/Run.hs
@@ -24,12 +24,9 @@ module Distribution.Simple.Program.Run (
   ) where
 
 import Distribution.Simple.Program.Types
-         ( ConfiguredProgram(..), programPath )
 import Distribution.Simple.Utils
-         ( die, rawSystemExit, rawSystemIOWithEnv, rawSystemStdInOut
-         , toUTF8, fromUTF8, normaliseLineEndings )
 import Distribution.Verbosity
-         ( Verbosity )
+import Distribution.Compat.Environment
 
 import Data.List
          ( foldl', unfoldr )
@@ -38,8 +35,6 @@ import Control.Monad
          ( when )
 import System.Exit
          ( ExitCode(..), exitWith )
-import Distribution.Compat.Environment
-         ( getEnvironment )
 
 -- | Represents a specific invocation of a specific program.
 --

--- a/Cabal/Distribution/Simple/Program/Script.hs
+++ b/Cabal/Distribution/Simple/Program/Script.hs
@@ -17,9 +17,7 @@ module Distribution.Simple.Program.Script (
   ) where
 
 import Distribution.Simple.Program.Run
-         ( ProgramInvocation(..) )
 import Distribution.System
-         ( OS(..) )
 
 import Data.Maybe
          ( maybeToList )

--- a/Cabal/Distribution/Simple/Program/Strip.hs
+++ b/Cabal/Distribution/Simple/Program/Strip.hs
@@ -10,16 +10,13 @@
 module Distribution.Simple.Program.Strip (stripLib, stripExe)
        where
 
-import Distribution.Simple.Program (ProgramConfiguration, lookupProgram
-                                   , programVersion, rawSystemProgram
-                                   , stripProgram)
-import Distribution.Simple.Utils   (warn)
-import Distribution.System         (Arch(..), Platform(..), OS (..), buildOS)
-import Distribution.Verbosity      (Verbosity)
-import Distribution.Version        (orLaterVersion, withinRange)
+import Distribution.Simple.Program
+import Distribution.Simple.Utils
+import Distribution.System
+import Distribution.Verbosity
+import Distribution.Version
 
 import Control.Monad               (unless)
-import Data.Version                (Version(..))
 import System.FilePath             (takeBaseName)
 
 runStrip :: Verbosity -> ProgramConfiguration -> FilePath -> [String] -> IO ()

--- a/Cabal/Distribution/Simple/Program/Types.hs
+++ b/Cabal/Distribution/Simple/Program/Types.hs
@@ -33,14 +33,10 @@ module Distribution.Simple.Program.Types (
   ) where
 
 import Distribution.Simple.Program.Find
-         ( ProgramSearchPath, ProgramSearchPathEntry(..)
-         , findProgramOnSearchPath )
 import Distribution.Version
-         ( Version )
 import Distribution.Verbosity
-         ( Verbosity )
+import Distribution.Compat.Binary
 
-import Distribution.Compat.Binary (Binary)
 import qualified Data.Map as Map
 import GHC.Generics (Generic)
 

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -66,43 +66,26 @@ module Distribution.Simple.Setup (
   flagToList,
   boolOpt, boolOpt', trueArg, falseArg, optionVerbosity, optionNumJobs ) where
 
-import Distribution.Compiler ()
+import Distribution.Compiler
 import Distribution.ReadE
 import Distribution.Text
-         ( Text(..), display )
 import qualified Distribution.Compat.ReadP as Parse
 import qualified Text.PrettyPrint as Disp
 import Distribution.ModuleName
-import Distribution.Package ( Dependency(..)
-                            , PackageName
-                            , ComponentId(..) )
-import Distribution.PackageDescription
-         ( FlagName(..), FlagAssignment )
+import Distribution.Package
+import Distribution.PackageDescription hiding (Flag)
 import Distribution.Simple.Command hiding (boolOpt, boolOpt')
 import qualified Distribution.Simple.Command as Command
-import Distribution.Simple.Compiler
-         ( CompilerFlavor(..), defaultCompilerFlavor, PackageDB(..)
-         , DebugInfoLevel(..), flagToDebugInfoLevel
-         , OptimisationLevel(..), flagToOptimisationLevel
-         , ProfDetailLevel(..), flagToProfDetailLevel, showProfDetailLevel
-         , absolutePackageDBPath )
+import Distribution.Simple.Compiler hiding (Flag)
 import Distribution.Simple.Utils
-         ( wrapText, wrapLine, lowercase, intercalate )
-import Distribution.Simple.Program (Program(..), ProgramConfiguration,
-                             requireProgram,
-                             programInvocation, progInvokePath, progInvokeArgs,
-                             knownPrograms,
-                             addKnownProgram, emptyProgramConfiguration,
-                             haddockProgram, ghcProgram, gccProgram, ldProgram)
+import Distribution.Simple.Program
 import Distribution.Simple.InstallDirs
-         ( InstallDirs(..), CopyDest(..),
-           PathTemplate, toPathTemplate, fromPathTemplate )
 import Distribution.Verbosity
 import Distribution.Utils.NubList
-
-import Control.Monad (liftM)
 import Distribution.Compat.Binary (Binary)
 import Distribution.Compat.Semigroup as Semi
+
+import Control.Monad (liftM)
 import Data.List   ( sort )
 import Data.Char   ( isSpace, isAlpha )
 import GHC.Generics (Generic)
@@ -227,8 +210,8 @@ globalCommand commands = CommandUI
         align str = str ++ replicate (maxlen - length str) ' '
       in
          "Commands:\n"
-      ++ unlines [ "  " ++ align name ++ "    " ++ description
-                 | (name, description) <- cmdDescs ]
+      ++ unlines [ "  " ++ align name ++ "    " ++ descr
+                 | (name, descr) <- cmdDescs ]
       ++ "\n"
       ++ "For more information about a command use\n"
       ++ "  " ++ pname ++ " COMMAND --help\n\n"

--- a/Cabal/Distribution/Simple/Test.hs
+++ b/Cabal/Distribution/Simple/Test.hs
@@ -16,22 +16,17 @@ module Distribution.Simple.Test
     ) where
 
 import qualified Distribution.PackageDescription as PD
-         ( PackageDescription(..), BuildInfo(buildable)
-         , TestSuite(..)
-         , TestSuiteInterface(..), testType, hasTests )
-import Distribution.Simple.Compiler ( compilerInfo )
-import Distribution.Simple.Hpc ( markupPackage )
+import Distribution.Simple.Compiler
+import Distribution.Simple.Hpc
 import Distribution.Simple.InstallDirs
-    ( fromPathTemplate, initialPathTemplateEnv, substPathTemplate
-    , PathTemplate )
 import qualified Distribution.Simple.LocalBuildInfo as LBI
-import Distribution.Simple.Setup ( TestFlags(..), fromFlag, configCoverage )
-import Distribution.Simple.UserHooks ( Args )
+import Distribution.Simple.Setup
+import Distribution.Simple.UserHooks
 import qualified Distribution.Simple.Test.ExeV10 as ExeV10
 import qualified Distribution.Simple.Test.LibV09 as LibV09
 import Distribution.Simple.Test.Log
-import Distribution.Simple.Utils ( die, notice )
-import Distribution.TestSuite ( Result(..) )
+import Distribution.Simple.Utils
+import Distribution.TestSuite
 import Distribution.Text
 
 import Control.Monad ( when, unless, filterM )

--- a/Cabal/Distribution/Simple/Test/ExeV10.hs
+++ b/Cabal/Distribution/Simple/Test/ExeV10.hs
@@ -2,26 +2,22 @@ module Distribution.Simple.Test.ExeV10
        ( runTest
        ) where
 
-import Distribution.Compat.CreatePipe ( createPipe )
-import Distribution.Compat.Environment ( getEnvironment )
+import Distribution.Compat.CreatePipe
+import Distribution.Compat.Environment
 import qualified Distribution.PackageDescription as PD
-import Distribution.Simple.Build.PathsModule ( pkgPathEnvVar )
-import Distribution.Simple.BuildPaths ( exeExtension )
-import Distribution.Simple.Compiler ( compilerInfo )
-import Distribution.Simple.Hpc ( guessWay, markupTest, tixDir, tixFilePath )
+import Distribution.Simple.Build.PathsModule
+import Distribution.Simple.BuildPaths
+import Distribution.Simple.Compiler
+import Distribution.Simple.Hpc
 import Distribution.Simple.InstallDirs
-    ( fromPathTemplate, initialPathTemplateEnv, PathTemplateVariable(..)
-    , substPathTemplate , toPathTemplate, PathTemplate )
 import qualified Distribution.Simple.LocalBuildInfo as LBI
 import Distribution.Simple.Setup
-    ( TestFlags(..), TestShowDetails(..), fromFlag, configCoverage )
 import Distribution.Simple.Test.Log
 import Distribution.Simple.Utils
-    ( die, notice, rawSystemIOWithEnv, addLibraryPath )
-import Distribution.System ( Platform (..) )
+import Distribution.System
 import Distribution.TestSuite
 import Distribution.Text
-import Distribution.Verbosity ( normal )
+import Distribution.Verbosity
 
 import Control.Concurrent (forkIO)
 import Control.Monad ( unless, void, when )

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -6,28 +6,24 @@ module Distribution.Simple.Test.LibV09
        , writeSimpleTestStub
        ) where
 
-import Distribution.Compat.CreatePipe ( createPipe )
-import Distribution.Compat.Environment ( getEnvironment )
-import Distribution.Compat.Internal.TempFile ( openTempFile )
-import Distribution.ModuleName ( ModuleName )
+import Distribution.Compat.CreatePipe
+import Distribution.Compat.Environment
+import Distribution.Compat.Internal.TempFile
+import Distribution.ModuleName
 import qualified Distribution.PackageDescription as PD
-import Distribution.Simple.Build.PathsModule ( pkgPathEnvVar )
-import Distribution.Simple.BuildPaths ( exeExtension )
-import Distribution.Simple.Compiler ( compilerInfo )
-import Distribution.Simple.Hpc ( guessWay, markupTest, tixDir, tixFilePath )
+import Distribution.Simple.Build.PathsModule
+import Distribution.Simple.BuildPaths
+import Distribution.Simple.Compiler
+import Distribution.Simple.Hpc
 import Distribution.Simple.InstallDirs
-    ( fromPathTemplate, initialPathTemplateEnv, PathTemplateVariable(..)
-    , substPathTemplate , toPathTemplate, PathTemplate )
 import qualified Distribution.Simple.LocalBuildInfo as LBI
 import Distribution.Simple.Setup
-    ( TestFlags(..), TestShowDetails(..), fromFlag, configCoverage )
 import Distribution.Simple.Test.Log
 import Distribution.Simple.Utils
-    ( die, debug, notice, createProcessWithEnv, addLibraryPath )
-import Distribution.System ( Platform (..) )
+import Distribution.System
 import Distribution.TestSuite
 import Distribution.Text
-import Distribution.Verbosity ( normal )
+import Distribution.Verbosity
 
 import Control.Exception ( bracket )
 import Control.Monad ( when, unless )

--- a/Cabal/Distribution/Simple/Test/Log.hs
+++ b/Cabal/Distribution/Simple/Test/Log.hs
@@ -11,18 +11,16 @@ module Distribution.Simple.Test.Log
        , testSuiteLogPath
        ) where
 
-import Distribution.Package ( PackageId )
+import Distribution.Package
 import qualified Distribution.PackageDescription as PD
-import Distribution.Simple.Compiler ( Compiler(..), compilerInfo, CompilerId )
+import Distribution.Simple.Compiler
 import Distribution.Simple.InstallDirs
-    ( fromPathTemplate, initialPathTemplateEnv, PathTemplateVariable(..)
-    , substPathTemplate , toPathTemplate, PathTemplate )
 import qualified Distribution.Simple.LocalBuildInfo as LBI
-import Distribution.Simple.Setup ( TestShowDetails(..) )
-import Distribution.Simple.Utils ( notice )
-import Distribution.System ( Platform )
-import Distribution.TestSuite ( Options, Result(..) )
-import Distribution.Verbosity ( Verbosity )
+import Distribution.Simple.Setup
+import Distribution.Simple.Utils
+import Distribution.System
+import Distribution.TestSuite
+import Distribution.Verbosity
 
 import Control.Monad ( when )
 import Data.Char ( toUpper )
@@ -109,13 +107,13 @@ testSuiteLogPath :: PathTemplate
                  -> String -- ^ test suite name
                  -> TestLogs -- ^ test suite results
                  -> FilePath
-testSuiteLogPath template pkg_descr lbi name result =
+testSuiteLogPath template pkg_descr lbi test_name result =
     fromPathTemplate $ substPathTemplate env template
     where
         env = initialPathTemplateEnv
                 (PD.package pkg_descr) (LBI.localComponentId lbi)
                 (compilerInfo $ LBI.compiler lbi) (LBI.hostPlatform lbi)
-                ++  [ (TestSuiteNameVar, toPathTemplate name)
+                ++  [ (TestSuiteNameVar, toPathTemplate test_name)
                     , (TestSuiteResultVar, toPathTemplate $ resultString result)
                     ]
 

--- a/Cabal/Distribution/Simple/UHC.hs
+++ b/Cabal/Distribution/Simple/UHC.hs
@@ -19,9 +19,6 @@ module Distribution.Simple.UHC (
     buildLib, buildExe, installLib, registerPackage, inplacePackageDbPath
   ) where
 
-import Control.Monad
-import Data.List
-import qualified Data.Map as M ( empty )
 import Distribution.Compat.ReadP
 import Distribution.InstalledPackageInfo
 import Distribution.Package hiding (installedComponentId)
@@ -35,10 +32,14 @@ import Distribution.Simple.Utils
 import Distribution.Text
 import Distribution.Verbosity
 import Distribution.Version
+import Distribution.System
 import Language.Haskell.Extension
+
+import Control.Monad
+import Data.List
+import qualified Data.Map as M ( empty )
 import System.Directory
 import System.FilePath
-import Distribution.System ( Platform )
 
 -- -----------------------------------------------------------------------------
 -- Configuring

--- a/Cabal/Distribution/Simple/UserHooks.hs
+++ b/Cabal/Distribution/Simple/UserHooks.hs
@@ -29,16 +29,11 @@ module Distribution.Simple.UserHooks (
   ) where
 
 import Distribution.PackageDescription
-         (PackageDescription, GenericPackageDescription,
-          HookedBuildInfo, emptyHookedBuildInfo)
-import Distribution.Simple.Program    (Program)
-import Distribution.Simple.Command    (noExtraFlags)
-import Distribution.Simple.PreProcess (PPSuffixHandler)
+import Distribution.Simple.Program
+import Distribution.Simple.Command
+import Distribution.Simple.PreProcess
 import Distribution.Simple.Setup
-         (ConfigFlags, BuildFlags, ReplFlags, CleanFlags, CopyFlags,
-          InstallFlags, SDistFlags, RegisterFlags, HscolourFlags,
-          HaddockFlags, TestFlags, BenchmarkFlags)
-import Distribution.Simple.LocalBuildInfo (LocalBuildInfo)
+import Distribution.Simple.LocalBuildInfo
 
 type Args = [String]
 

--- a/Cabal/Distribution/System.hs
+++ b/Cabal/Distribution/System.hs
@@ -38,13 +38,14 @@ module Distribution.System (
 import qualified System.Info (os, arch)
 import qualified Data.Char as Char (toLower, isAlphaNum, isAlpha)
 
+import Distribution.Compat.Binary
+import Distribution.Text
+import qualified Distribution.Compat.ReadP as Parse
+
 import Control.Monad (liftM2)
-import Distribution.Compat.Binary (Binary)
 import Data.Data (Data)
 import Data.Typeable (Typeable)
 import Data.Maybe (fromMaybe, listToMaybe)
-import Distribution.Text (Text(..), display)
-import qualified Distribution.Compat.ReadP as Parse
 import GHC.Generics (Generic)
 import qualified Text.PrettyPrint as Disp
 import Text.PrettyPrint ((<>))

--- a/Cabal/Distribution/Utils/NubList.hs
+++ b/Cabal/Distribution/Utils/NubList.hs
@@ -12,8 +12,7 @@ module Distribution.Utils.NubList
 
 import Distribution.Compat.Semigroup as Semi
 import Distribution.Compat.Binary
-
-import Distribution.Simple.Utils (ordNub, listUnion, ordNubRight, listUnionRight)
+import Distribution.Simple.Utils
 
 import qualified Text.Read as R
 

--- a/Cabal/Distribution/Verbosity.hs
+++ b/Cabal/Distribution/Verbosity.hs
@@ -24,9 +24,10 @@ module Distribution.Verbosity (
   showForCabal, showForGHC
  ) where
 
-import Distribution.Compat.Binary (Binary)
-import Data.List (elemIndex)
+import Distribution.Compat.Binary
 import Distribution.ReadE
+
+import Data.List (elemIndex)
 import GHC.Generics
 
 data Verbosity = Silent | Normal | Verbose | Deafening

--- a/Cabal/Distribution/Version.hs
+++ b/Cabal/Distribution/Version.hs
@@ -99,9 +99,10 @@ import Data.Typeable    ( Typeable )
 import Data.Version     ( Version(..) )
 import GHC.Generics     ( Generic )
 
-import Distribution.Text ( Text(..) )
+import Distribution.Text
 import qualified Distribution.Compat.ReadP as Parse
-import Distribution.Compat.ReadP ((+++))
+import Distribution.Compat.ReadP hiding (get)
+
 import qualified Text.PrettyPrint as Disp
 import Text.PrettyPrint ((<>), (<+>))
 import qualified Data.Char as Char (isDigit)

--- a/Cabal/Language/Haskell/Extension.hs
+++ b/Cabal/Language/Haskell/Extension.hs
@@ -22,12 +22,13 @@ module Language.Haskell.Extension (
         deprecatedExtensions
   ) where
 
-import Distribution.Text (Text(..))
+import Distribution.Text
 import qualified Distribution.Compat.ReadP as Parse
+import Distribution.Compat.Binary
+
 import qualified Text.PrettyPrint as Disp
 import qualified Data.Char as Char (isAlphaNum)
 import Data.Array (Array, accumArray, bounds, Ix(inRange), (!))
-import Distribution.Compat.Binary (Binary)
 import Data.Data (Data)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)


### PR DESCRIPTION
Remove same-package import lists, fixes #2835.

Instead of qualifying, in some cases I just added an extra
'hiding' pragma to squelch errors.  Common conflicts
(just grep for hiding):

    - Flag
        - Distribution.Simple.Compiler
        - Distribution.PackageDescription
        - Distribution.Simple.Setup
    - installedComponentId
        - Distribution.Package
        - Distribution.InstalledPackageInfo
    - doesFileExist
        - Distribution.PackageDescription.Check
    - instantiatedWith
        - I renamed the field in InstalledPackageInfo.  But
          it's probably going away with Backpack bits; I
          migth just excise it soon.
    - absoluteInstallDirs and substPathTemplate
        - Distribution.Simple.InstallDirs
        - Distribution.Simple.LocalBuildInfo

I fixed some shadowing errors by renaming local variables in some cases.
Common shadowings (we should perhaps consider not using these as
method/field names):

    - freeVars
    - components
    - noVersion
    - verbosity
    - get
    - description
    - name

Some data structures were moved around (IPIConvert and ABIHash)
to make it easier to handle import lists.

Some functions in Utils could be turned into reexports of standard
library functions.

No explicit imports were removed from non-Cabal imports.  These
imports help maintain warning cleanliness across versions of GHC,
so I don't recommend removing them.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>