### PR TITLE
Introduce RepoContext

### DIFF
--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -28,7 +28,8 @@ import Distribution.Client.IndexUtils as IndexUtils
          ( getSourcePackages, getInstalledPackages )
 import Distribution.Client.PackageIndex ( PackageIndex, elemByPackageName )
 import Distribution.Client.Setup
-         ( ConfigExFlags(..), configureCommand, filterConfigureFlags )
+         ( ConfigExFlags(..), configureCommand, filterConfigureFlags
+         , RepoContext(..) )
 import Distribution.Client.Types as Source
 import Distribution.Client.SetupWrapper
          ( setupWrapper, SetupScriptOptions(..), defaultSetupScriptOptions )
@@ -93,7 +94,7 @@ chooseCabalVersion configExFlags maybeVersion =
 -- | Configure the package found in the local directory
 configure :: Verbosity
           -> PackageDBStack
-          -> [Repo]
+          -> RepoContext
           -> Compiler
           -> Platform
           -> ProgramConfiguration
@@ -101,11 +102,11 @@ configure :: Verbosity
           -> ConfigExFlags
           -> [String]
           -> IO ()
-configure verbosity packageDBs repos comp platform conf
+configure verbosity packageDBs repoCtxt comp platform conf
   configFlags configExFlags extraArgs = do
 
   installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-  sourcePkgDb       <- getSourcePackages    verbosity repos
+  sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
   checkConfigExFlags verbosity installedPkgIndex
                      (packageIndex sourcePkgDb) configExFlags
 

--- a/cabal-install/Distribution/Client/Fetch.hs
+++ b/cabal-install/Distribution/Client/Fetch.hs
@@ -21,11 +21,9 @@ import Distribution.Client.FetchUtils hiding (fetchPackage)
 import Distribution.Client.Dependency
 import Distribution.Client.IndexUtils as IndexUtils
          ( getSourcePackages, getInstalledPackages )
-import Distribution.Client.HttpUtils
-         ( configureTransport, HttpTransport(..) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.Setup
-         ( GlobalFlags(..), FetchFlags(..) )
+         ( GlobalFlags(..), FetchFlags(..), RepoContext(..) )
 
 import Distribution.Package
          ( packageId )
@@ -35,7 +33,7 @@ import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import Distribution.Simple.Program
          ( ProgramConfiguration )
 import Distribution.Simple.Setup
-         ( fromFlag, flagToMaybe )
+         ( fromFlag )
 import Distribution.Simple.Utils
          ( die, notice, debug )
 import Distribution.System
@@ -66,7 +64,7 @@ import Control.Monad
 --
 fetch :: Verbosity
       -> PackageDBStack
-      -> [Repo]
+      -> RepoContext
       -> Compiler
       -> Platform
       -> ProgramConfiguration
@@ -77,17 +75,15 @@ fetch :: Verbosity
 fetch verbosity _ _ _ _ _ _ _ [] =
     notice verbosity "No packages requested. Nothing to do."
 
-fetch verbosity packageDBs repos comp platform conf
+fetch verbosity packageDBs repoCtxt comp platform conf
       globalFlags fetchFlags userTargets = do
 
     mapM_ checkTarget userTargets
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages    verbosity repos
+    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
 
-    transport <- configureTransport verbosity (flagToMaybe (globalHttpTransport globalFlags))
-
-    pkgSpecifiers <- resolveUserTargets verbosity transport
+    pkgSpecifiers <- resolveUserTargets verbosity repoCtxt
                        (fromFlag $ globalWorldFile globalFlags)
                        (packageIndex sourcePkgDb)
                        userTargets
@@ -109,7 +105,7 @@ fetch verbosity packageDBs repos comp platform conf
                      "The following packages would be fetched:"
                    : map (display . packageId) pkgs'
 
-             else mapM_ (fetchPackage transport verbosity . packageSource) pkgs'
+             else mapM_ (fetchPackage verbosity repoCtxt . packageSource) pkgs'
 
   where
     dryRun = fromFlag (fetchDryRun fetchFlags)
@@ -185,8 +181,8 @@ checkTarget target = case target of
             ++ "In the meantime you can use the 'unpack' commands."
     _ -> return ()
 
-fetchPackage :: HttpTransport -> Verbosity -> PackageLocation a -> IO ()
-fetchPackage transport verbosity pkgsrc = case pkgsrc of
+fetchPackage :: Verbosity -> RepoContext -> PackageLocation a -> IO ()
+fetchPackage verbosity repoCtxt pkgsrc = case pkgsrc of
     LocalUnpackedPackage _dir  -> return ()
     LocalTarballPackage  _file -> return ()
 
@@ -195,5 +191,5 @@ fetchPackage transport verbosity pkgsrc = case pkgsrc of
          ++ "In the meantime you can use the 'unpack' commands."
 
     RepoTarballPackage repo pkgid _ -> do
-      _ <- fetchRepoTarball transport verbosity repo pkgid
+      _ <- fetchRepoTarball verbosity repoCtxt repo pkgid
       return ()

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -28,9 +28,8 @@ import Distribution.Client.InstallPlan
          ( InstallPlan, PlanPackage )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.Setup
-         ( GlobalFlags(..), FreezeFlags(..), ConfigExFlags(..) )
-import Distribution.Client.HttpUtils
-         ( configureTransport )
+         ( GlobalFlags(..), FreezeFlags(..), ConfigExFlags(..)
+         , RepoContext(..) )
 import Distribution.Client.Sandbox.PackageEnvironment
          ( loadUserConfig, pkgEnvSavedConfig, showPackageEnvironment,
            userPackageEnvironmentFile )
@@ -76,7 +75,7 @@ import Distribution.Version
 --
 freeze :: Verbosity
       -> PackageDBStack
-      -> [Repo]
+      -> RepoContext
       -> Compiler
       -> Platform
       -> ProgramConfiguration
@@ -84,16 +83,13 @@ freeze :: Verbosity
       -> GlobalFlags
       -> FreezeFlags
       -> IO ()
-freeze verbosity packageDBs repos comp platform conf mSandboxPkgInfo
+freeze verbosity packageDBs repoCtxt comp platform conf mSandboxPkgInfo
       globalFlags freezeFlags = do
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages    verbosity repos
+    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
 
-    transport <- configureTransport verbosity
-                 (flagToMaybe (globalHttpTransport globalFlags))
-
-    pkgSpecifiers <- resolveUserTargets verbosity transport
+    pkgSpecifiers <- resolveUserTargets verbosity repoCtxt
                        (fromFlag $ globalWorldFile globalFlags)
                        (packageIndex sourcePkgDb)
                        [UserTargetLocalDir "."]

--- a/cabal-install/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/Distribution/Client/GlobalFlags.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE CPP #-}
+module Distribution.Client.GlobalFlags (
+    GlobalFlags(..)
+  , defaultGlobalFlags
+  ) where
+
+import Distribution.Client.Types
+         ( RemoteRepo(..) )
+import Distribution.Simple.Setup
+         ( Flag(..) )
+import Distribution.Utils.NubList
+         ( NubList )
+
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid
+         ( Monoid(..) )
+#endif
+
+-- ------------------------------------------------------------
+-- * Global flags
+-- ------------------------------------------------------------
+
+-- | Flags that apply at the top level, not to any sub-command.
+data GlobalFlags = GlobalFlags {
+    globalVersion           :: Flag Bool,
+    globalNumericVersion    :: Flag Bool,
+    globalConfigFile        :: Flag FilePath,
+    globalSandboxConfigFile :: Flag FilePath,
+    globalConstraintsFile   :: Flag FilePath,
+    globalRemoteRepos       :: NubList RemoteRepo,     -- ^ Available Hackage servers.
+    globalCacheDir          :: Flag FilePath,
+    globalLocalRepos        :: NubList FilePath,
+    globalLogsDir           :: Flag FilePath,
+    globalWorldFile         :: Flag FilePath,
+    globalRequireSandbox    :: Flag Bool,
+    globalIgnoreSandbox     :: Flag Bool,
+    globalIgnoreExpiry      :: Flag Bool,    -- ^ Ignore security expiry dates
+    globalHttpTransport     :: Flag String
+  }
+
+defaultGlobalFlags :: GlobalFlags
+defaultGlobalFlags  = GlobalFlags {
+    globalVersion           = Flag False,
+    globalNumericVersion    = Flag False,
+    globalConfigFile        = mempty,
+    globalSandboxConfigFile = mempty,
+    globalConstraintsFile   = mempty,
+    globalRemoteRepos       = mempty,
+    globalCacheDir          = mempty,
+    globalLocalRepos        = mempty,
+    globalLogsDir           = mempty,
+    globalWorldFile         = mempty,
+    globalRequireSandbox    = Flag False,
+    globalIgnoreSandbox     = Flag False,
+    globalIgnoreExpiry      = Flag False,
+    globalHttpTransport     = mempty
+  }
+
+instance Monoid GlobalFlags where
+  mempty = GlobalFlags {
+    globalVersion           = mempty,
+    globalNumericVersion    = mempty,
+    globalConfigFile        = mempty,
+    globalSandboxConfigFile = mempty,
+    globalConstraintsFile   = mempty,
+    globalRemoteRepos       = mempty,
+    globalCacheDir          = mempty,
+    globalLocalRepos        = mempty,
+    globalLogsDir           = mempty,
+    globalWorldFile         = mempty,
+    globalRequireSandbox    = mempty,
+    globalIgnoreSandbox     = mempty,
+    globalIgnoreExpiry      = mempty,
+    globalHttpTransport     = mempty
+  }
+  mappend a b = GlobalFlags {
+    globalVersion           = combine globalVersion,
+    globalNumericVersion    = combine globalNumericVersion,
+    globalConfigFile        = combine globalConfigFile,
+    globalSandboxConfigFile = combine globalConfigFile,
+    globalConstraintsFile   = combine globalConstraintsFile,
+    globalRemoteRepos       = combine globalRemoteRepos,
+    globalCacheDir          = combine globalCacheDir,
+    globalLocalRepos        = combine globalLocalRepos,
+    globalLogsDir           = combine globalLogsDir,
+    globalWorldFile         = combine globalWorldFile,
+    globalRequireSandbox    = combine globalRequireSandbox,
+    globalIgnoreSandbox     = combine globalIgnoreSandbox,
+    globalIgnoreExpiry      = combine globalIgnoreExpiry,
+    globalHttpTransport     = combine globalHttpTransport
+  }
+    where combine field = field a `mappend` field b

--- a/cabal-install/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/Distribution/Client/GlobalFlags.hs
@@ -2,14 +2,25 @@
 module Distribution.Client.GlobalFlags (
     GlobalFlags(..)
   , defaultGlobalFlags
+  , RepoContext(..)
+  , withRepoContext
   ) where
 
 import Distribution.Client.Types
-         ( RemoteRepo(..) )
+         ( Repo(..), RemoteRepo(..) )
 import Distribution.Simple.Setup
-         ( Flag(..) )
+         ( Flag(..), fromFlag, fromFlagOrDefault, flagToMaybe )
 import Distribution.Utils.NubList
-         ( NubList )
+         ( NubList, fromNubList )
+import Distribution.Client.HttpUtils
+         ( HttpTransport, configureTransport )
+import Distribution.Verbosity
+         ( Verbosity )
+
+import Control.Concurrent
+         ( MVar, newMVar, modifyMVar )
+import System.FilePath
+         ( (</>) )
 
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid
@@ -90,3 +101,56 @@ instance Monoid GlobalFlags where
     globalHttpTransport     = combine globalHttpTransport
   }
     where combine field = field a `mappend` field b
+
+-- ------------------------------------------------------------
+-- * Repo context
+-- ------------------------------------------------------------
+
+-- | Access to repositories
+data RepoContext = RepoContext {
+    -- | All user-specified repositories
+    repoContextRepos :: [Repo]
+
+    -- | Get the HTTP transport
+    --
+    -- The transport will be initialized on the first call to this function.
+    --
+    -- NOTE: It is important that we don't eagerly initialize the transport.
+    -- Initializing the transport is not free, and especially in contexts where
+    -- we don't know a-priori whether or not we need the transport (for instance
+    -- when using cabal in "nix mode") incurring the overhead of transport
+    -- initialization on _every_ invocation (eg @cabal build@) is undesirable.
+  , repoContextGetTransport :: IO HttpTransport
+
+    -- | Should we ignore expiry times (when checking security)?
+  , repoContextIgnoreExpiry :: Bool
+  }
+
+withRepoContext :: Verbosity -> GlobalFlags -> (RepoContext -> IO a) -> IO a
+withRepoContext verbosity globalFlags callback = do
+    transportRef <- newMVar Nothing
+    callback RepoContext {
+        repoContextRepos        = remoteRepos ++ localRepos
+      , repoContextGetTransport = getTransport transportRef
+      , repoContextIgnoreExpiry = fromFlagOrDefault False
+                                    (globalIgnoreExpiry globalFlags)
+      }
+  where
+    remoteRepos =
+      [ RepoRemote remote cacheDir
+      | remote <- fromNubList $ globalRemoteRepos globalFlags
+      , let cacheDir = fromFlag (globalCacheDir globalFlags)
+                   </> remoteRepoName remote ]
+    localRepos =
+      [ RepoLocal local
+      | local <- fromNubList $ globalLocalRepos globalFlags ]
+
+    getTransport :: MVar (Maybe HttpTransport) -> IO HttpTransport
+    getTransport transportRef =
+      modifyMVar transportRef $ \mTransport -> do
+        transport <- case mTransport of
+          Just tr -> return tr
+          Nothing -> configureTransport
+                       verbosity
+                       (flagToMaybe (globalHttpTransport globalFlags))
+        return (Just transport, transport)

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -59,6 +59,8 @@ import Distribution.Verbosity
          ( Verbosity, normal, lessVerbose )
 import Distribution.Simple.Utils
          ( die, warn, info, fromUTF8, ignoreBOM )
+import Distribution.Client.Setup
+         ( RepoContext(..) )
 
 import Data.Char   (isAlphaNum)
 import Data.Maybe  (mapMaybe, catMaybes, maybeToList)
@@ -108,17 +110,17 @@ getInstalledPackages verbosity comp packageDbs conf =
 -- 'Repo'.
 --
 -- This is a higher level wrapper used internally in cabal-install.
-getSourcePackages :: Verbosity -> [Repo] -> IO SourcePackageDb
-getSourcePackages verbosity [] = do
+getSourcePackages :: Verbosity -> RepoContext -> IO SourcePackageDb
+getSourcePackages verbosity repoCtxt | null (repoContextRepos repoCtxt) = do
   warn verbosity $ "No remote package servers have been specified. Usually "
                 ++ "you would have one specified in the config file."
   return SourcePackageDb {
     packageIndex       = mempty,
     packagePreferences = mempty
   }
-getSourcePackages verbosity repos = do
+getSourcePackages verbosity repoCtxt = do
   info verbosity "Reading available packages..."
-  pkgss <- mapM (\r -> readRepoIndex verbosity r) repos
+  pkgss <- mapM (\r -> readRepoIndex verbosity repoCtxt r) (repoContextRepos repoCtxt)
   let (pkgs, prefs) = mconcat pkgss
       prefs' = Map.fromListWith intersectVersionRanges
                  [ (name, range) | Dependency name range <- prefs ]
@@ -143,13 +145,13 @@ readCacheStrict verbosity index mkPkg = do
 --
 -- This is a higher level wrapper used internally in cabal-install.
 --
-readRepoIndex :: Verbosity -> Repo
+readRepoIndex :: Verbosity -> RepoContext -> Repo
               -> IO (PackageIndex SourcePackage, [Dependency])
-readRepoIndex verbosity repo =
+readRepoIndex verbosity repoCtxt repo =
   handleNotFound $ do
     warnIfIndexIsOld =<< getIndexFileAge repo
-    updateRepoIndexCache verbosity (RepoIndex repo)
-    readPackageIndexCacheFile mkAvailablePackage (RepoIndex repo)
+    updateRepoIndexCache verbosity (RepoIndex repoCtxt repo)
+    readPackageIndexCacheFile mkAvailablePackage (RepoIndex repoCtxt repo)
 
   where
     mkAvailablePackage pkgEntry =
@@ -356,19 +358,19 @@ lazySequence = unsafeInterleaveIO . go
 -- | Which index do we mean?
 data Index =
     -- | The main index for the specified repository
-    RepoIndex Repo
+    RepoIndex RepoContext Repo
 
     -- | A sandbox-local repository
     -- Argument is the location of the index file
   | SandboxIndex FilePath
 
 indexFile :: Index -> FilePath
-indexFile (RepoIndex    repo)  = repoLocalDir repo </> "00-index.tar"
-indexFile (SandboxIndex index) = index
+indexFile (RepoIndex _ctxt repo) = repoLocalDir repo </> "00-index.tar"
+indexFile (SandboxIndex index)   = index
 
 cacheFile :: Index -> FilePath
-cacheFile (RepoIndex    repo)  = repoLocalDir repo </> "00-index.cache"
-cacheFile (SandboxIndex index) = index `replaceExtension` "cache"
+cacheFile (RepoIndex _ctxt repo) = repoLocalDir repo </> "00-index.cache"
+cacheFile (SandboxIndex index)   = index `replaceExtension` "cache"
 
 updatePackageIndexCacheFile :: Verbosity -> Index -> IO ()
 updatePackageIndexCacheFile verbosity index = do

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -98,19 +98,21 @@ import Distribution.Client.PackageIndex
 import Distribution.Client.IndexUtils
   ( getSourcePackages )
 import Distribution.Client.Types
-  ( SourcePackageDb(..), Repo )
+  ( SourcePackageDb(..) )
+import Distribution.Client.Setup
+  ( RepoContext(..) )
 
 initCabal :: Verbosity
           -> PackageDBStack
-          -> [Repo]
+          -> RepoContext
           -> Compiler
           -> ProgramConfiguration
           -> InitFlags
           -> IO ()
-initCabal verbosity packageDBs repos comp conf initFlags = do
+initCabal verbosity packageDBs repoCtxt comp conf initFlags = do
 
   installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-  sourcePkgDb <- getSourcePackages verbosity repos
+  sourcePkgDb <- getSourcePackages verbosity repoCtxt
 
   hSetBuffering stdout NoBuffering
 

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -73,14 +73,14 @@ import Distribution.Client.Dependency.Types
          ( Solver(..), ConstraintSource(..), LabeledPackageConstraint(..) )
 import Distribution.Client.FetchUtils
 import Distribution.Client.HttpUtils
-         ( configureTransport, HttpTransport (..) )
+         ( HttpTransport (..) )
 import qualified Distribution.Client.Haddock as Haddock (regenerateHaddockIndex)
 import Distribution.Client.IndexUtils as IndexUtils
          ( getSourcePackages, getInstalledPackages )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.InstallPlan (InstallPlan)
 import Distribution.Client.Setup
-         ( GlobalFlags(..)
+         ( GlobalFlags(..), RepoContext(..)
          , ConfigFlags(..), configureCommand, filterConfigureFlags
          , ConfigExFlags(..), InstallFlags(..) )
 import Distribution.Client.Config
@@ -186,7 +186,7 @@ import Distribution.Simple.BuildPaths ( exeExtension )
 install
   :: Verbosity
   -> PackageDBStack
-  -> [Repo]
+  -> RepoContext
   -> Compiler
   -> Platform
   -> ProgramConfiguration
@@ -239,7 +239,7 @@ type InstallContext = ( InstalledPackageIndex, SourcePackageDb
 -- rid of it completely.
 -- | Initial arguments given to 'install' or 'makeInstallContext'.
 type InstallArgs = ( PackageDBStack
-                   , [Repo]
+                   , RepoContext
                    , Compiler
                    , Platform
                    , ProgramConfiguration
@@ -255,15 +255,14 @@ type InstallArgs = ( PackageDBStack
 makeInstallContext :: Verbosity -> InstallArgs -> Maybe [UserTarget]
                       -> IO InstallContext
 makeInstallContext verbosity
-  (packageDBs, repos, comp, _, conf,_,_,
+  (packageDBs, repoCtxt, comp, _, conf,_,_,
    globalFlags, _, configExFlags, _, _) mUserTargets = do
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages    verbosity repos
+    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
     checkConfigExFlags verbosity installedPkgIndex
                        (packageIndex sourcePkgDb) configExFlags
-    transport <- configureTransport verbosity
-                 (flagToMaybe (globalHttpTransport globalFlags))
+    transport <- repoContextGetTransport repoCtxt
 
     (userTargets, pkgSpecifiers) <- case mUserTargets of
       Nothing           ->
@@ -277,7 +276,7 @@ makeInstallContext verbosity
         let userTargets | null userTargets0 = [UserTargetLocalDir "."]
                         | otherwise         = userTargets0
 
-        pkgSpecifiers <- resolveUserTargets verbosity transport
+        pkgSpecifiers <- resolveUserTargets verbosity repoCtxt
                          (fromFlag $ globalWorldFile globalFlags)
                          (packageIndex sourcePkgDb)
                          userTargets
@@ -1034,7 +1033,7 @@ performInstallations :: Verbosity
                      -> InstallPlan
                      -> IO InstallPlan
 performInstallations verbosity
-  (packageDBs, _, comp, platform, conf, useSandbox, _,
+  (packageDBs, repoCtxt, comp, platform, conf, useSandbox, _,
    globalFlags, configFlags, configExFlags, installFlags, haddockFlags)
   installedPkgIndex installPlan = do
 
@@ -1051,13 +1050,10 @@ performInstallations verbosity
   installLock  <- newLock -- serialise installation
   cacheLock    <- newLock -- serialise access to setup exe cache
 
-  transport <- configureTransport verbosity
-               (flagToMaybe (globalHttpTransport globalFlags))
-
   executeInstallPlan verbosity comp jobControl useLogFile installPlan $ \rpkg ->
     installReadyPackage platform cinfo configFlags
                         rpkg $ \configFlags' src pkg pkgoverride ->
-      fetchSourcePackage transport verbosity fetchLimit src $ \src' ->
+      fetchSourcePackage verbosity repoCtxt fetchLimit src $ \src' ->
         installLocalPackage verbosity buildLimit
                             (packageId pkg) src' distPref $ \mpath ->
           installUnpackedPackage verbosity buildLimit installLock numJobs
@@ -1265,19 +1261,19 @@ installReadyPackage platform cinfo configFlags
       Right (desc, _) -> desc
 
 fetchSourcePackage
-  :: HttpTransport
-  -> Verbosity
+  :: Verbosity
+  -> RepoContext
   -> JobLimit
   -> PackageLocation (Maybe FilePath)
   -> (PackageLocation FilePath -> IO BuildResult)
   -> IO BuildResult
-fetchSourcePackage transport verbosity fetchLimit src installPkg = do
+fetchSourcePackage verbosity repoCtxt fetchLimit src installPkg = do
   fetched <- checkFetched src
   case fetched of
     Just src' -> installPkg src'
     Nothing   -> onFailure DownloadFailed $ do
                    loc <- withJobLimit fetchLimit $
-                            fetchPackage transport verbosity src
+                            fetchPackage verbosity repoCtxt src
                    installPkg loc
 
 

--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -44,7 +44,7 @@ module Distribution.Client.Sandbox (
 import Distribution.Client.Setup
   ( SandboxFlags(..), ConfigFlags(..), ConfigExFlags(..), InstallFlags(..)
   , GlobalFlags(..), defaultConfigExFlags, defaultInstallFlags
-  , defaultSandboxLocation, withGlobalRepos )
+  , defaultSandboxLocation, withRepoContext )
 import Distribution.Client.Sandbox.Timestamp  ( listModifiedDeps
                                               , maybeAddCompilerTimestampRecord
                                               , withAddTimestamps
@@ -655,10 +655,10 @@ reinstallAddSourceDeps verbosity configFlags' configExFlags
                          comp platform conf sandboxDir $ \sandboxPkgInfo ->
     unless (null $ modifiedAddSourceDependencies sandboxPkgInfo) $ do
 
-     withGlobalRepos verbosity globalFlags $ \globalRepos -> do
+     withRepoContext verbosity globalFlags $ \repoContext -> do
       let args :: InstallArgs
           args = ((configPackageDB' configFlags)
-                 ,globalRepos
+                 ,repoContext
                  ,comp, platform, conf
                  ,UseSandbox sandboxDir, Just sandboxPkgInfo
                  ,globalFlags, configFlags, configExFlags, installFlags

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -12,7 +12,8 @@
 --
 -----------------------------------------------------------------------------
 module Distribution.Client.Setup
-    ( globalCommand, GlobalFlags(..), defaultGlobalFlags, withGlobalRepos
+    ( globalCommand, GlobalFlags(..), defaultGlobalFlags
+    , RepoContext(..), withRepoContext
     , configureCommand, ConfigFlags(..), filterConfigureFlags
     , configureExCommand, ConfigExFlags(..), defaultConfigExFlags
                         , configureExOptions
@@ -49,7 +50,7 @@ module Distribution.Client.Setup
     ) where
 
 import Distribution.Client.Types
-         ( Username(..), Password(..), Repo(..), RemoteRepo(..) )
+         ( Username(..), Password(..), RemoteRepo(..) )
 import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
 import Distribution.Client.Dependency.Types
@@ -73,7 +74,7 @@ import Distribution.Simple.Setup
          , TestFlags(..), BenchmarkFlags(..)
          , SDistFlags(..), HaddockFlags(..)
          , readPackageDbList, showPackageDbList
-         , Flag(..), toFlag, fromFlag, flagToMaybe, flagToList
+         , Flag(..), toFlag, flagToMaybe, flagToList
          , optionVerbosity, boolOpt, boolOpt', trueArg, falseArg, optionNumJobs )
 import Distribution.Simple.InstallDirs
          ( PathTemplate, InstallDirs(sysconfdir)
@@ -95,7 +96,9 @@ import Distribution.Verbosity
 import Distribution.Simple.Utils
          ( wrapText, wrapLine )
 import Distribution.Client.GlobalFlags
-         ( GlobalFlags(..), defaultGlobalFlags )
+         ( GlobalFlags(..), defaultGlobalFlags
+         , RepoContext(..), withRepoContext
+         )
 
 import Data.Char
          ( isSpace, isAlphaNum )
@@ -313,19 +316,6 @@ globalCommand commands = CommandUI {
          globalWorldFile (\v flags -> flags { globalWorldFile = v })
          (reqArgFlag "FILE")
       ]
-
-withGlobalRepos :: Verbosity -> GlobalFlags -> ([Repo] -> IO a) -> IO a
-withGlobalRepos _verbosity globalFlags callback =
-    callback $ remoteRepos ++ localRepos
-  where
-    remoteRepos =
-      [ RepoRemote remote cacheDir
-      | remote <- fromNubList $ globalRemoteRepos globalFlags
-      , let cacheDir = fromFlag (globalCacheDir globalFlags)
-                   </> remoteRepoName remote ]
-    localRepos =
-      [ RepoLocal local
-      | local <- fromNubList $ globalLocalRepos globalFlags ]
 
 -- ------------------------------------------------------------
 -- * Config flags

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -61,6 +61,7 @@ import Distribution.Client.Targets
 import Distribution.Utils.NubList
          ( NubList, toNubList, fromNubList)
 
+
 import Distribution.Simple.Compiler (PackageDB)
 import Distribution.Simple.Program
          ( defaultProgramConfiguration )
@@ -93,6 +94,8 @@ import Distribution.Verbosity
          ( Verbosity, normal )
 import Distribution.Simple.Utils
          ( wrapText, wrapLine )
+import Distribution.Client.GlobalFlags
+         ( GlobalFlags(..), defaultGlobalFlags )
 
 import Data.Char
          ( isSpace, isAlphaNum )
@@ -110,46 +113,6 @@ import System.FilePath
          ( (</>) )
 import Network.URI
          ( parseAbsoluteURI, uriToString )
-
--- ------------------------------------------------------------
--- * Global flags
--- ------------------------------------------------------------
-
--- | Flags that apply at the top level, not to any sub-command.
-data GlobalFlags = GlobalFlags {
-    globalVersion           :: Flag Bool,
-    globalNumericVersion    :: Flag Bool,
-    globalConfigFile        :: Flag FilePath,
-    globalSandboxConfigFile :: Flag FilePath,
-    globalConstraintsFile   :: Flag FilePath,
-    globalRemoteRepos       :: NubList RemoteRepo,     -- ^ Available Hackage servers.
-    globalCacheDir          :: Flag FilePath,
-    globalLocalRepos        :: NubList FilePath,
-    globalLogsDir           :: Flag FilePath,
-    globalWorldFile         :: Flag FilePath,
-    globalRequireSandbox    :: Flag Bool,
-    globalIgnoreSandbox     :: Flag Bool,
-    globalIgnoreExpiry      :: Flag Bool,    -- ^ Ignore security expiry dates
-    globalHttpTransport     :: Flag String
-  }
-
-defaultGlobalFlags :: GlobalFlags
-defaultGlobalFlags  = GlobalFlags {
-    globalVersion           = Flag False,
-    globalNumericVersion    = Flag False,
-    globalConfigFile        = mempty,
-    globalSandboxConfigFile = mempty,
-    globalConstraintsFile   = mempty,
-    globalRemoteRepos       = mempty,
-    globalCacheDir          = mempty,
-    globalLocalRepos        = mempty,
-    globalLogsDir           = mempty,
-    globalWorldFile         = mempty,
-    globalRequireSandbox    = Flag False,
-    globalIgnoreSandbox     = Flag False,
-    globalIgnoreExpiry      = Flag False,
-    globalHttpTransport     = mempty
-  }
 
 globalCommand :: [Command action] -> CommandUI GlobalFlags
 globalCommand commands = CommandUI {
@@ -350,41 +313,6 @@ globalCommand commands = CommandUI {
          globalWorldFile (\v flags -> flags { globalWorldFile = v })
          (reqArgFlag "FILE")
       ]
-
-instance Monoid GlobalFlags where
-  mempty = GlobalFlags {
-    globalVersion           = mempty,
-    globalNumericVersion    = mempty,
-    globalConfigFile        = mempty,
-    globalSandboxConfigFile = mempty,
-    globalConstraintsFile   = mempty,
-    globalRemoteRepos       = mempty,
-    globalCacheDir          = mempty,
-    globalLocalRepos        = mempty,
-    globalLogsDir           = mempty,
-    globalWorldFile         = mempty,
-    globalRequireSandbox    = mempty,
-    globalIgnoreSandbox     = mempty,
-    globalIgnoreExpiry      = mempty,
-    globalHttpTransport     = mempty
-  }
-  mappend a b = GlobalFlags {
-    globalVersion           = combine globalVersion,
-    globalNumericVersion    = combine globalNumericVersion,
-    globalConfigFile        = combine globalConfigFile,
-    globalSandboxConfigFile = combine globalConfigFile,
-    globalConstraintsFile   = combine globalConstraintsFile,
-    globalRemoteRepos       = combine globalRemoteRepos,
-    globalCacheDir          = combine globalCacheDir,
-    globalLocalRepos        = combine globalLocalRepos,
-    globalLogsDir           = combine globalLogsDir,
-    globalWorldFile         = combine globalWorldFile,
-    globalRequireSandbox    = combine globalRequireSandbox,
-    globalIgnoreSandbox     = combine globalIgnoreSandbox,
-    globalIgnoreExpiry      = combine globalIgnoreExpiry,
-    globalHttpTransport     = combine globalHttpTransport
-  }
-    where combine field = field a `mappend` field b
 
 withGlobalRepos :: Verbosity -> GlobalFlags -> ([Repo] -> IO a) -> IO a
 withGlobalRepos _verbosity globalFlags callback =

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -114,6 +114,7 @@ executable cabal
         Distribution.Client.FetchUtils
         Distribution.Client.Freeze
         Distribution.Client.Get
+        Distribution.Client.GlobalFlags
         Distribution.Client.GZipUtils
         Distribution.Client.Haddock
         Distribution.Client.HttpUtils


### PR DESCRIPTION
**NOTE**: This PR consists of two commits, not four; the first two commits listed here are actually #3029.

The first of these commits just moves `GlobalFlags` to its own module, nothing else; this avoids circular module dependencies in the next commit.

The next commit introduces `RepoContext`:

``` haskell
-- | Access to repositories
data RepoContext = RepoContext {
    -- | All user-specified repositories
    repoContextRepos :: [Repo]

    -- | Get the HTTP transport
    --
    -- The transport will be initialized on the first call to this function
  , repoContextGetTransport :: IO HttpTransport

    -- | Should we ignore expiry times (when checking security)?
  , repoContextIgnoreExpiry :: Bool
  }
```

The `RepoContext` records the information about all available repositories, and how to access them (that is, the transport). The rest of the commit is mostly boring stuff:

* All functions that previously took a `[Repo]` argument now take a `RepoContext` argument
* All functions that previously had a `HttpTransport` argument now take a `RepoContext` argument
* A handful of functions that had neither now also have this `RepoContext` argument 
* The definition of `IndexFile` is now

    ``` haskell
    data Index = RepoIndex RepoContext Repo | SandboxIndex FilePath
    ```
* Calls to `configureTransport` are replaced with calls to `repoContextGetTransport`. 

The `HttpTransport` returned by `repoContextGetTransport` is initialized on first use, and cached thereafter. This means that we now always use a single transport, and it gets initialized with the information from the `GlobalFlags` (previously it was initialized in a few places were we had lost track of the `GlobalFlags` and so had to provide `Nothing` for the second argument to `configureTransport`).

The `RepoContext` is important for two reasons:

* `cabal-install` was creating `Repos` upfront, but delaying the construction of the transport until needed. However, when constructing a secure repo, we need to know the transport up front. By coupling these two we fix the impedance mismatch; the security integration will refer to the transport created in the repo context to create the `HttpLib` instance (in other words, we will use the `HttpTransport` in the security integration).
* In the security integration as it stood, `Repo` was extended with a third constructor for secure repos, but this constructed carried a stateful `Repository`. This was causing difficulties for the `nix-local-build` branch, which needs the `Repo` type to remain serializable. In the new integration (not yet pushed) the `RepoSecure` constructor still exists, but no longer carries the actual stateful `Repository`; this mapping is available separately from the `RepoContext`.