### PR TITLE
don't special-case versions with leading zeroes

### DIFF
--- a/Cabal/Distribution/Text.hs
+++ b/Cabal/Distribution/Text.hs
@@ -63,7 +63,5 @@ instance Text Version where
     where
       digits = do
         first <- Parse.satisfy Char.isDigit
-        if first == '0'
-          then return 0
-          else do rest <- Parse.munch Char.isDigit
-                  return (read (first : rest))
+        rest <- Parse.munch Char.isDigit
+        return (read (first : rest))


### PR DESCRIPTION
I could not install pcre-light because cabal failed with:

  parsing output of pkg-config --modversion failed

The output of that command was simply "8.02", which cabal could not
parse into a Version because of the leading zero. With this patch,
"8.02" now parses as (Version [8,2] []).