### PR TITLE
Tests for #2731 (Ignore dependencies that are not Buildable)

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -77,6 +77,8 @@ extra-source-files:
   tests/PackageTests/BuildDeps/TargetSpecificDeps3/lemon.hs
   tests/PackageTests/BuildDeps/TargetSpecificDeps3/my.cabal
   tests/PackageTests/BuildTestSuiteDetailedV09/Dummy2.hs
+  tests/PackageTests/BuildableField/BuildableField.cabal
+  tests/PackageTests/BuildableField/Main.hs
   tests/PackageTests/CMain/Bar.hs
   tests/PackageTests/CMain/foo.c
   tests/PackageTests/CMain/my.cabal

--- a/Cabal/tests/PackageTests/BuildableField/BuildableField.cabal
+++ b/Cabal/tests/PackageTests/BuildableField/BuildableField.cabal
@@ -1,0 +1,16 @@
+name: BuildableField
+version: 0.1.0.0
+cabal-version: >=1.2
+build-type: Simple
+license: BSD3
+
+flag build-exe
+  default: True
+
+library
+
+executable my-executable
+  build-depends: base, unavailable-package
+  main-is: Main.hs
+  if !flag(build-exe)
+    buildable: False

--- a/Cabal/tests/PackageTests/BuildableField/Main.hs
+++ b/Cabal/tests/PackageTests/BuildableField/Main.hs
@@ -1,0 +1,4 @@
+import UnavailableModule
+
+main :: IO ()
+main = putStrLn "Hello"

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -223,6 +223,14 @@ tests config =
             cabal_build ["--enable-tests"]
             cabal "test" []
 
+  -- Test that Cabal can choose flags to disable building a component when that
+  -- component's dependencies are unavailable. The build should succeed without
+  -- requiring the component's dependencies or imports.
+  , tc "BuildableField" $ do
+        r <- cabal' "configure" ["-v"]
+        assertOutputContains "Flags chosen: build-exe=False" r
+        cabal "build" []
+
   ]
   where
     -- Shared test function for BuildDeps/InternalLibrary* tests.

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
@@ -16,6 +16,7 @@ module UnitTests.Distribution.Client.Dependency.Modular.DSL (
 -- base
 import Data.Either (partitionEithers)
 import Data.Maybe (catMaybes)
+import Data.List (nub)
 import Data.Monoid
 import Data.Version
 import qualified Data.Map as Map
@@ -163,7 +164,7 @@ exAvSrcPkg ex =
                        C.setupDepends = mkSetupDeps (CD.setupDeps (exAvDeps ex))
                      }
                  }
-             , C.genPackageFlags = concatMap extractFlags
+             , C.genPackageFlags = nub $ concatMap extractFlags
                                    (CD.libraryDeps (exAvDeps ex))
              , C.condLibrary     = Just $ mkCondTree (extsLib exts <> langLib mlang) libraryDeps
              , C.condExecutables = []

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
@@ -333,10 +333,10 @@ exInstIdx :: [ExampleInstalled] -> C.PackageIndex.InstalledPackageIndex
 exInstIdx = C.PackageIndex.fromList . map exInstInfo
 
 exResolve :: ExampleDb
-          -- List of extensions supported by the compiler.
-          -> [Extension]
-          -- A compiler can support multiple languages.
-          -> [Language]
+          -- List of extensions supported by the compiler, or Nothing if unknown.
+          -> Maybe [Extension]
+          -- List of languages supported by the compiler, or Nothing if unknown.
+          -> Maybe [Language]
           -> [ExamplePkgName]
           -> Bool
           -> [ExPreference]
@@ -348,12 +348,8 @@ exResolve db exts langs targets indepGoals prefs = runProgress $
                         params
   where
     defaultCompiler = C.unknownCompilerInfo C.buildCompilerId C.NoAbiTag
-    compiler = defaultCompiler { C.compilerInfoExtensions = if null exts
-                                                               then Nothing
-                                                               else Just exts
-                               , C.compilerInfoLanguages  = if null langs
-                                                                then Nothing
-                                                                else Just langs
+    compiler = defaultCompiler { C.compilerInfoExtensions = exts
+                               , C.compilerInfoLanguages  = langs
                                }
     (inst, avai) = partitionEithers db
     instIdx      = exInstIdx inst

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -120,8 +120,8 @@ data SolverTest = SolverTest {
   , testIndepGoals     :: Bool
   , testSoftConstraints :: [ExPreference]
   , testDb             :: ExampleDb
-  , testSupportedExts  :: [Extension]
-  , testSupportedLangs :: [Language]
+  , testSupportedExts  :: Maybe [Extension]
+  , testSupportedLangs :: Maybe [Language]
   }
 
 mkTest :: ExampleDb
@@ -129,7 +129,7 @@ mkTest :: ExampleDb
        -> [String]
        -> Maybe [(String, Int)]
        -> SolverTest
-mkTest = mkTestExtLang [] []
+mkTest = mkTestExtLang Nothing Nothing
 
 mkTestExts :: [Extension]
            -> ExampleDb
@@ -137,7 +137,7 @@ mkTestExts :: [Extension]
            -> [String]
            -> Maybe [(String, Int)]
            -> SolverTest
-mkTestExts exts = mkTestExtLang exts []
+mkTestExts exts = mkTestExtLang (Just exts) Nothing
 
 mkTestLangs :: [Language]
             -> ExampleDb
@@ -145,10 +145,10 @@ mkTestLangs :: [Language]
             -> [String]
             -> Maybe [(String, Int)]
             -> SolverTest
-mkTestLangs = mkTestExtLang []
+mkTestLangs = mkTestExtLang Nothing . Just
 
-mkTestExtLang :: [Extension]
-              -> [Language]
+mkTestExtLang :: Maybe [Extension]
+              -> Maybe [Language]
               -> ExampleDb
               -> String
               -> [String]

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -209,7 +209,7 @@ db3 :: ExampleDb
 db3 = [
      Right $ exAv "A" 1 []
    , Right $ exAv "A" 2 []
-   , Right $ exAv "B" 1 [ExFlag "flagB" [ExFix "A" 1] [ExFix "A" 2]]
+   , Right $ exAv "B" 1 [exFlag "flagB" [ExFix "A" 1] [ExFix "A" 2]]
    , Right $ exAv "C" 1 [ExFix "A" 1, ExAny "B"]
    , Right $ exAv "D" 1 [ExFix "A" 2, ExAny "B"]
    ]
@@ -252,7 +252,7 @@ db4 = [
    , Right $ exAv "Ax" 2 []
    , Right $ exAv "Ay" 1 []
    , Right $ exAv "Ay" 2 []
-   , Right $ exAv "B"  1 [ExFlag "flagB" [ExFix "Ax" 1] [ExFix "Ay" 1]]
+   , Right $ exAv "B"  1 [exFlag "flagB" [ExFix "Ax" 1] [ExFix "Ay" 1]]
    , Right $ exAv "C"  1 [ExFix "Ax" 2, ExAny "B"]
    , Right $ exAv "D"  1 [ExFix "Ay" 2, ExAny "B"]
    ]


### PR DESCRIPTION
I added a package test for the Cabal component and several unit tests for the solver component.  This PR also resolves a conflict between #2731 and #2732.  I had to make a few changes to the solver DSL:

* Allow a flag to be used multiple times in a package.  Reusing a flag previously caused this error:

        Exception: internal error: could not construct a valid install plan.
        The proposed (invalid) plan contained the following problems:
        Package B-1.0.0 has an invalid configuration, in particular:
          missing an assignment for the flag: my-flag

* Represent the Buildable field.  Now both sides of a conditional can be either not buildable, or buildable with a list of dependencies.
* Allow a compiler to support zero languages or extensions.  I changed the signature of `DSL.exResolve` to distinguish between not checking languages/extensions and not allowing any languages/extensions.

I thought of two other improvements, but I left them for separate issues or PRs.  I didn't see an easy way to check flag choices directly in the DSL.  I instead had to check the dependencies that the flags introduced.  I also noticed that the default flag value is false in the DSL and true in cabal-install/Cabal.  Some of these tests rely on the default, so it should probably be consistent.