### PR TITLE
bootstrap.sh: add missing pkg and fix tar position

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -219,6 +219,8 @@ HACKAGE_SECURITY_VER="0.5.0.2"; HACKAGE_SECURITY_VER_REGEXP="0\.5\.?"
                        # >= 0.5 && < 0.6
 TAR_VER="0.5.0.1";     TAR_VER_REGEXP="0\.5\.([1-9]|1[0-9]|0\.1)\.?"
                        # >= 0.5.0.1  && < 0.6
+BASE64_BYTESTRING_VER="1.0.0.1";    BASE64_BYTESTRING_REGEXP="1\."
+                                    # >=1.0
 
 HACKAGE_URL="https://hackage.haskell.org/package"
 
@@ -391,8 +393,9 @@ info_pkg "stm"          ${STM_VER}     ${STM_VER_REGEXP}
 info_pkg "byteable"         ${BYTEABLE_VER}         ${BYTEABLE_VER_REGEXP}
 info_pkg "cryptohash"       ${CRYPTOHASH_VER}       ${CRYPTOHASH_VER_REGEXP}
 info_pkg "ed25519"          ${ED25519_VER}          ${ED25519_VER_REGEXP}
-info_pkg "hackage-security" ${HACKAGE_SECURITY_VER} ${HACKAGE_SECURITY_VER_REGEXP}
 info_pkg "tar"              ${TAR_VER}              ${TAR_VER_REGEXP}
+info_pkg "base64-bytestring" ${BASE64_BYTESTRING_VER} ${BASE64_BYTESTRING_VER_REGEXP}
+info_pkg "hackage-security" ${HACKAGE_SECURITY_VER} ${HACKAGE_SECURITY_VER_REGEXP}
 
 do_pkg   "deepseq"      ${DEEPSEQ_VER} ${DEEPSEQ_VER_REGEXP}
 do_pkg   "binary"       ${BINARY_VER}  ${BINARY_VER_REGEXP}
@@ -416,8 +419,9 @@ do_pkg   "stm"          ${STM_VER}     ${STM_VER_REGEXP}
 do_pkg   "byteable"         ${BYTEABLE_VER}         ${BYTEABLE_VER_REGEXP}
 do_pkg   "cryptohash"       ${CRYPTOHASH_VER}       ${CRYPTOHASH_VER_REGEXP}
 do_pkg   "ed25519"          ${ED25519_VER}          ${ED25519_VER_REGEXP}
-do_pkg   "hackage-security" ${HACKAGE_SECURITY_VER} ${HACKAGE_SECURITY_VER_REGEXP}
 do_pkg   "tar"              ${TAR_VER}              ${TAR_VER_REGEXP}
+do_pkg   "base64-bytestring" ${BASE64_BYTESTRING_VER} ${BASE64_BYTESTRING_VER_REGEXP}
+do_pkg   "hackage-security" ${HACKAGE_SECURITY_VER} ${HACKAGE_SECURITY_VER_REGEXP}
 
 
 install_pkg "cabal-install"


### PR DESCRIPTION
* tar needs to be installed before hackage-security
* base64-bytestring is also required