### PR TITLE
Change default flag value to True in solver DSL.

### DIFF
--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
@@ -215,7 +215,7 @@ exAvSrcPkg ex =
     extractFlags (ExFlag f a b) = C.MkFlag {
                                       C.flagName        = C.FlagName f
                                     , C.flagDescription = ""
-                                    , C.flagDefault     = False
+                                    , C.flagDefault     = True
                                     , C.flagManual      = False
                                     }
                                 : concatMap extractFlags (deps a ++ deps b)


### PR DESCRIPTION
This default is consistent with Cabal.

I updated the test cases from #3039 that rely on the default.  As far as I can tell, the other four tests that use flags are unaffected.  We could also add the ability to set defaults for individual flags.  That would be a bigger change, though, because it would require flags to be declared before they are used.