### PR TITLE
Enable tests in setup-dev.sh

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -28,8 +28,7 @@ setup() {
     ./Setup configure --enable-tests --package-db="$PACKAGEDB" || die "$NAME: 'configure' failed"
     ./Setup build || die "$NAME: 'build' failed"
     # Run tests
-    # Disabled for now: There are some test failures
-    #./Setup test || die "$1 'test' failed"
+    ./Setup test || die "$1 'test' failed"
 }
 
 # Build


### PR DESCRIPTION
It seems there are no longer any spurious failures, so we
can enable tests in setup-dev.sh