### PR TITLE
InstalledPackageId compatibility should be a UnitId, not a ComponentId.

### DIFF
--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -122,7 +122,7 @@ data ComponentId
     = ComponentId String
     deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
 
-type InstalledPackageId = ComponentId
+type InstalledPackageId = UnitId
 
 instance Binary ComponentId
 


### PR DESCRIPTION
Test-suite didn't catch it because we don't use this internally.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>