### PR TITLE
Make configIPID a bit more type-safe, fix a bug.

### DIFF
--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -294,7 +294,7 @@ data ConfigFlags = ConfigFlags {
     configScratchDir    :: Flag FilePath,
     configExtraLibDirs  :: [FilePath],   -- ^ path to search for extra libraries
     configExtraIncludeDirs :: [FilePath],   -- ^ path to search for header files
-    configIPID          :: Flag String, -- ^ explicit IPID to be used
+    configIPID          :: Flag UnitId, -- ^ explicit IPID to be used
 
     configDistPref :: Flag FilePath, -- ^"dist" prefix
     configVerbosity :: Flag Verbosity, -- ^verbosity level
@@ -561,7 +561,9 @@ configureOptions showOrParseArgs =
       ,option "" ["ipid"]
          "Installed package ID to compile this package as"
          configIPID (\v flags -> flags {configIPID = v})
-         (reqArgFlag "IPID")
+         (reqArg "IPID"
+                 (readP_to_E (const "ipid expected") (fmap Flag parse))
+                 (map display . flagToList))
 
       ,option "" ["extra-lib-dirs"]
          "A list of directories to search for external libraries"


### PR DESCRIPTION
Previously, configIPID was a String, which made it a bit confusing
whether or not it was a ComponentId or a UnitId.  I've decided (for now)
it should be a UnitId, for consistency with the existing backwards
compatibility InstalledPackageId, but this might have to change in the
future (I'm not sure, I have to work out which ends up being better.)
Since right now the string representations of UnitId and ComponentId are
interchangeable, it should be harmless to conflate the two.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>