### PR TITLE
Fix bug in solver independent goals.

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
@@ -51,9 +51,9 @@ solve sc cinfo idx userPrefs userConstraints userGoals =
                        P.deferSetupChoices .
                        P.deferWeakFlagChoices .
                        P.preferBaseGoalChoice .
-                       if preferEasyGoalChoices sc
+                       (if preferEasyGoalChoices sc
                          then P.lpreferEasyGoalChoices
-                         else id .
+                         else id) .
                        P.preferLinked
     preferencesPhase = P.preferPackagePreferences userPrefs
     validationPhase  = P.enforceManualFlags . -- can only be done after user constraints


### PR DESCRIPTION
Missing parentheses caused the solver to skip preferring linked packages with the use of `--reorder-goals`.