### PR TITLE
Add Binary instances for many types

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -268,9 +268,9 @@ library
     Distribution.Verbosity
     Distribution.Version
     Language.Haskell.Extension
+    Distribution.Compat.Binary
 
   other-modules:
-    Distribution.Compat.Binary
     Distribution.Compat.CopyFile
     Distribution.Compat.Semigroup
     Distribution.GetOpt

--- a/cabal-install/Distribution/Client/BuildReports/Types.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.BuildReports.Types
@@ -24,9 +25,14 @@ import qualified Text.PrettyPrint as Disp
 
 import Data.Char as Char
          ( isAlpha, toLower )
+import GHC.Generics (Generic)
+import Distribution.Compat.Binary (Binary)
+
 
 data ReportLevel = NoReports | AnonymousReports | DetailedReports
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Enum, Show, Generic)
+
+instance Binary ReportLevel
 
 instance Text.Text ReportLevel where
   disp NoReports        = Disp.text "none"

--- a/cabal-install/Distribution/Client/ComponentDeps.hs
+++ b/cabal-install/Distribution/Client/ComponentDeps.hs
@@ -10,6 +10,7 @@
 -- > import qualified Distribution.Client.ComponentDeps as CD
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Distribution.Client.ComponentDeps (
     -- * Fine-grained package dependencies
     Component(..)
@@ -34,6 +35,8 @@ module Distribution.Client.ComponentDeps (
 
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Distribution.Compat.Binary (Binary)
+import GHC.Generics
 import Data.Foldable (fold)
 
 #if !MIN_VERSION_base(4,8,0)
@@ -53,14 +56,16 @@ data Component =
   | ComponentTest  String
   | ComponentBench String
   | ComponentSetup
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
+
+instance Binary Component
 
 -- | Dependency for a single component
 type ComponentDep a = (Component, a)
 
 -- | Fine-grained dependencies for a package
 newtype ComponentDeps a = ComponentDeps { unComponentDeps :: Map Component a }
-  deriving (Show, Functor, Eq, Ord)
+  deriving (Show, Functor, Eq, Ord, Generic)
 
 instance Monoid a => Monoid (ComponentDeps a) where
   mempty =
@@ -73,6 +78,8 @@ instance Foldable ComponentDeps where
 
 instance Traversable ComponentDeps where
   traverse f = fmap ComponentDeps . traverse f . unComponentDeps
+
+instance Binary a => Binary (ComponentDeps a)
 
 {-------------------------------------------------------------------------------
   Construction

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Dependency.Types
@@ -74,17 +75,22 @@ import Distribution.Text
 
 import Text.PrettyPrint
          ( text )
+import GHC.Generics (Generic)
+import Distribution.Compat.Binary (Binary(..))
 
 import Prelude hiding (fail)
 
 
 -- | All the solvers that can be selected.
 data PreSolver = AlwaysTopDown | AlwaysModular | Choose
-  deriving (Eq, Ord, Show, Bounded, Enum)
+  deriving (Eq, Ord, Show, Bounded, Enum, Generic)
 
 -- | All the solvers that can be used.
 data Solver = TopDown | Modular
-  deriving (Eq, Ord, Show, Bounded, Enum)
+  deriving (Eq, Ord, Show, Bounded, Enum, Generic)
+
+instance Binary PreSolver
+instance Binary Solver
 
 instance Text PreSolver where
   disp AlwaysTopDown = text "topdown"
@@ -134,7 +140,9 @@ data PackageConstraint
    | PackageConstraintSource    PackageName
    | PackageConstraintFlags     PackageName FlagAssignment
    | PackageConstraintStanzas   PackageName [OptionalStanza]
-  deriving (Show,Eq)
+  deriving (Eq,Show,Generic)
+
+instance Binary PackageConstraint
 
 -- | Provide a textual representation of a package constraint
 -- for debugging purposes.
@@ -216,6 +224,9 @@ data AllowNewer =
 
   -- | Ignore upper bounds in dependencies on all packages.
   | AllowNewerAll
+  deriving (Eq, Ord, Show, Generic)
+
+instance Binary AllowNewer
 
 -- | Convert 'AllowNewer' to a boolean.
 isAllowNewer :: AllowNewer -> Bool
@@ -300,7 +311,9 @@ data ConstraintSource =
 
   -- | The source of the constraint is not specified.
   | ConstraintSourceUnknown
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
+
+instance Binary ConstraintSource
 
 -- | Description of a 'ConstraintSource'.
 showConstraintSource :: ConstraintSource -> String

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DeriveGeneric #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.InstallPlan
@@ -76,6 +77,8 @@ import Data.Maybe
 import qualified Data.Graph as Graph
 import Data.Graph (Graph)
 import qualified Data.Tree as Tree
+import Distribution.Compat.Binary (Binary)
+import GHC.Generics
 import Control.Exception
          ( assert )
 import Data.Maybe (catMaybes)
@@ -142,6 +145,10 @@ data GenericPlanPackage ipkg srcpkg iresult ifailure
    | Processing  (GenericReadyPackage srcpkg ipkg)
    | Installed   (GenericReadyPackage srcpkg ipkg) (Maybe ipkg) iresult
    | Failed      srcpkg ifailure
+  deriving (Eq, Show, Generic)
+
+instance (Binary ipkg, Binary srcpkg, Binary  iresult, Binary  ifailure)
+      => Binary (GenericPlanPackage ipkg srcpkg iresult ifailure)
 
 type PlanPackage = GenericPlanPackage
                    InstalledPackageInfo ConfiguredPackage

--- a/cabal-install/Distribution/Client/PackageIndex.hs
+++ b/cabal-install/Distribution/Client/PackageIndex.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.PackageIndex
@@ -54,6 +55,8 @@ import Data.List (groupBy, sortBy, isInfixOf)
 import Data.Monoid (Monoid(..))
 #endif
 import Data.Maybe (isJust, fromMaybe)
+import GHC.Generics (Generic)
+import Distribution.Compat.Binary (Binary)
 
 import Distribution.Package
          ( PackageName(..), PackageIdentifier(..)
@@ -78,7 +81,8 @@ newtype PackageIndex pkg = PackageIndex
   --
   (Map PackageName [pkg])
 
-  deriving (Show, Read, Functor)
+  deriving (Eq, Show, Read, Functor, Generic)
+--FIXME: the Functor instance here relies on no package id changes
 
 instance Package pkg => Monoid (PackageIndex pkg) where
   mempty  = PackageIndex Map.empty
@@ -86,6 +90,8 @@ instance Package pkg => Monoid (PackageIndex pkg) where
   --save one mappend with empty in the common case:
   mconcat [] = mempty
   mconcat xs = foldr1 mappend xs
+
+instance Binary pkg => Binary (PackageIndex pkg)
 
 invariant :: Package pkg => PackageIndex pkg -> Bool
 invariant (PackageIndex m) = all (uncurry goodBucket) (Map.toList m)

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DeriveGeneric #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Setup
@@ -113,6 +114,8 @@ import Data.Maybe
 import Data.Monoid
          ( Monoid(..) )
 #endif
+import GHC.Generics (Generic)
+import Distribution.Compat.Binary (Binary)
 import Control.Monad
          ( liftM )
 import System.FilePath
@@ -411,6 +414,7 @@ data ConfigExFlags = ConfigExFlags {
     configSolver       :: Flag PreSolver,
     configAllowNewer   :: Flag AllowNewer
   }
+  deriving (Eq, Generic)
 
 defaultConfigExFlags :: ConfigExFlags
 defaultConfigExFlags = mempty { configSolver     = Flag defaultSolver
@@ -1178,6 +1182,9 @@ data InstallFlags = InstallFlags {
     installRunTests         :: Flag Bool,
     installOfflineMode      :: Flag Bool
   }
+  deriving (Eq, Generic)
+
+instance Binary InstallFlags
 
 defaultInstallFlags :: InstallFlags
 defaultInstallFlags = InstallFlags {

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE CPP, BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveGeneric #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Targets
@@ -109,6 +111,8 @@ import System.Directory
          ( doesFileExist, doesDirectoryExist )
 import Network.URI
          ( URI(..), URIAuth(..), parseAbsoluteURI )
+import GHC.Generics (Generic)
+import Distribution.Compat.Binary (Binary)
 
 -- ------------------------------------------------------------
 -- * User targets
@@ -185,7 +189,9 @@ data PackageSpecifier pkg =
      -- | A fully specified source package.
      --
    | SpecificSourcePackage pkg
-  deriving Show
+  deriving (Eq, Show, Generic)
+
+instance Binary pkg => Binary (PackageSpecifier pkg)
 
 pkgSpecifierTarget :: Package pkg => PackageSpecifier pkg -> PackageName
 pkgSpecifierTarget (NamedPackage name _)       = name
@@ -698,7 +704,9 @@ data UserConstraint =
    | UserConstraintSource    PackageName
    | UserConstraintFlags     PackageName FlagAssignment
    | UserConstraintStanzas   PackageName [OptionalStanza]
-  deriving (Show,Eq)
+  deriving (Eq, Show, Generic)
+
+instance Binary UserConstraint
 
 userConstraintPackageName :: UserConstraint -> PackageName
 userConstraintPackageName uc = case uc of

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -164,6 +164,7 @@ executable cabal
     build-depends:
         array      >= 0.4      && < 0.6,
         base       >= 4.5      && < 5,
+        binary     >= 0.5      && < 0.9,
         bytestring >= 0.9      && < 1,
         Cabal      >= 1.23.1   && < 1.24,
         containers >= 0.4      && < 0.6,
@@ -192,6 +193,10 @@ executable cabal
       build-depends: network-uri >= 2.6, network >= 2.6
     else
       build-depends: network     >= 2.4 && < 2.6
+
+    -- Needed for GHC.Generics before GHC 7.6
+    if impl(ghc < 7.6)
+      build-depends: ghc-prim >= 0.2 && < 0.3
 
     if os(windows)
       build-depends: Win32 >= 2 && < 3
@@ -239,6 +244,7 @@ Test-Suite unit-tests
         time,
         HTTP,
         zlib,
+        binary,
         random,
         hackage-security,
         tasty,
@@ -254,6 +260,9 @@ Test-Suite unit-tests
     build-depends: network-uri >= 2.6, network >= 2.6
   else
     build-depends: network-uri < 2.6, network < 2.6
+
+  if impl(ghc < 7.6)
+    build-depends: ghc-prim >= 0.2 && < 0.3
 
   if os(windows)
     build-depends: Win32


### PR DESCRIPTION
So we can use them in binary cache files.

This is the first step of merging the nix-local-build branch.