### PR TITLE
Improve algorithm for choosing flags with './Setup configure'

### DIFF
--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -819,7 +819,7 @@ configureFinalizedPackage verbosity cfg
                    pkg_descr0''
             of Right r -> return r
                Left missing ->
-                   die $ "At least the following dependencies are missing:\n"
+                   die $ "Encountered missing dependencies:\n"
                      ++ (render . nest 4 . sep . punctuate comma
                                 . map (disp . simplifyDependency)
                                 $ missing)


### PR DESCRIPTION
Cabal previously tried all flag combinations, which was very slow.  The new
algorithm assigns one flag at a time, and backtracks when a flag introduces a
dependency that is unavailable.

The new algorithm handles the Buildable field by adding an extra conditional at
the top level of each component that represents the condition for which the
component is buildable.  Since all dependencies go under the "then" branch, they
are only required when a flag choice makes the component buildable.  The buildable
logic is taken from the cabal-install dependency solver.

This commit also changes the error message that is shown when dependencies are
missing.  Previously, Cabal printed the shortest list of missing dependencies
from a single flag assignment.  Now it takes the union of all dependencies that
caused it to backtrack when trying different combinations of flags, which
requires less searching.

I updated #2925 to allow backtracking to work with the Buildable field.  I moved the `extractCondition` function (added in #2731) from the modular solver to `Distribution.PackageDescription.Configuration` so that it can be used by Cabal and cabal-install.  Since `extractCondition` is not a very general utility function, I was wondering if there is a better place to put it.