### PR TITLE
More nix-local-build merging: solver and setup wrapper features

### DIFF
--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -182,6 +182,7 @@ configureSetupScript packageDBs
                      mpkg
   = SetupScriptOptions {
       useCabalVersion   = cabalVersion
+    , useCabalSpecVersion = Nothing
     , useCompiler       = Just comp
     , usePlatform       = Just platform
     , usePackageDB      = packageDBs'

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -201,6 +201,7 @@ configureSetupScript packageDBs
       -- Therefore, for now, we just leave this blank.
     , useDependencies          = fromMaybe [] explicitSetupDeps
     , useDependenciesExclusive = isJust explicitSetupDeps
+    , useVersionMacros         = isJust explicitSetupDeps
     }
   where
     -- When we are compiling a legacy setup script without an explicit

--- a/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
@@ -324,9 +324,12 @@ deferWeakFlagChoices = trav go
     go (GoalChoiceF xs) = GoalChoiceF (P.sortBy defer xs)
     go x                = x
 
+    -- weak flags go very last, weak stanzas second last
     defer :: Tree a -> Tree a -> Ordering
     defer (FChoice _ _ True _ _) _ = GT
     defer _ (FChoice _ _ True _ _) = LT
+    defer (SChoice _ _ True _) _   = GT
+    defer _ (SChoice _ _ True _)   = LT
     defer _ _                      = EQ
 
 -- Transformation that sorts choice nodes so that

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -170,10 +170,8 @@ planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
 
     logMsg message rest = debug verbosity message >> rest
 
-    stanzas = concat
-        [ if testsEnabled      then [TestStanzas]  else []
-        , if benchmarksEnabled then [BenchStanzas] else []
-        ]
+    stanzas = [ TestStanzas | testsEnabled ]
+           ++ [ BenchStanzas | benchmarksEnabled ]
     testsEnabled      = fromFlagOrDefault False $ freezeTests freezeFlags
     benchmarksEnabled = fromFlagOrDefault False $ freezeBenchmarks freezeFlags
 

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -402,11 +402,9 @@ planPackages comp platform mSandboxPkgInfo solver
       $ standardInstallPolicy
         installedPkgIndex sourcePkgDb pkgSpecifiers
 
-    stanzas = concat
-        [ if testsEnabled then [TestStanzas] else []
-        , if benchmarksEnabled then [BenchStanzas] else []
-        ]
-    testsEnabled = fromFlagOrDefault False $ configTests configFlags
+    stanzas           = [ TestStanzas | testsEnabled ]
+                     ++ [ BenchStanzas | benchmarksEnabled ]
+    testsEnabled      = fromFlagOrDefault False $ configTests configFlags
     benchmarksEnabled = fromFlagOrDefault False $ configBenchmarks configFlags
 
     reinstall        = fromFlag (installOverrideReinstall installFlags) ||

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -126,6 +126,8 @@ import qualified System.Win32 as Win32
 -- policies (like if we should add the Cabal lib as a dep, and if so which
 -- version). This could be structured as an action that returns a fully
 -- elaborated 'SetupScriptOptions' containing no remaining policy choices.
+--
+-- See also the discussion at https://github.com/haskell/cabal/pull/3094
 
 data SetupScriptOptions = SetupScriptOptions {
     -- | The version of the Cabal library to use (if 'useDependenciesExclusive'


### PR DESCRIPTION
Mostly two things:

 * solver: allow specifying default setup dependencies for packages that don't specify them explicitly
 * setup wrapper: a couple extra features we will need

See individual patch descriptions for details.