### PR TITLE
Allow man page integration test to run on Windows.

### DIFF
--- a/cabal-install/tests/IntegrationTests/manpage/should_run/outputs_manpage.sh
+++ b/cabal-install/tests/IntegrationTests/manpage/should_run/outputs_manpage.sh
@@ -3,9 +3,9 @@
 OUTPUT=`cabal manpage`
 
 # contains visible command descriptions
-echo $OUTPUT | grep -q '\.B cabal install' || die "visible command description line not found in:\n----$OUTPUT\n----"
+echo $OUTPUT | grep -qE '\.B cabal(\.exe)? install' || die "visible command description line not found in:\n----$OUTPUT\n----"
 
 # does not contain hidden command descriptions
-echo $OUTPUT | grep -q '\.B cabal manpage' && die "hidden command description line found in:\n----$OUTPUT\n----"
+echo $OUTPUT | grep -qE '\.B cabal(\.exe)? manpage' && die "hidden command description line found in:\n----$OUTPUT\n----"
 
 exit 0


### PR DESCRIPTION
The man page generated on Windows lists commands such as `cabal.exe install`, but the test expects `cabal install`.  I'm not completely sure how the failure should be fixed.  This commit changes the test so that it accepts either `cabal` or `cabal.exe`.