### PR TITLE
Solver: support setup deps for --allow-newer

### DIFF
--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -410,6 +410,8 @@ removeUpperBounds allowNewer params =
         onTestSuite  tst  = tst { PD.testBuildInfo = f' $ PD.testBuildInfo tst }
         onBenchmark  bmk  = bmk { PD.benchmarkBuildInfo =
                                      f' $ PD.benchmarkBuildInfo bmk }
+        onSetup      stp  = stp { PD.setupDepends  =
+                                     map f $ PD.setupDepends stp }
 
         srcPkg' = srcPkg { packageDescription = gpd' }
         gpd'    = gpd {
@@ -424,7 +426,8 @@ removeUpperBounds allowNewer params =
           PD.library      = fmap onLibrary    (PD.library pd),
           PD.executables  = map  onExecutable (PD.executables pd),
           PD.testSuites   = map  onTestSuite  (PD.testSuites pd),
-          PD.benchmarks   = map  onBenchmark  (PD.benchmarks pd)
+          PD.benchmarks   = map  onBenchmark  (PD.benchmarks pd),
+          PD.setupBuildInfo = fmap onSetup    (PD.setupBuildInfo pd)
           }
         condLib'    = fmap (onCondTree onLibrary)             condLib
         condExes'   = map  (mapSnd $ onCondTree onExecutable) condExes


### PR DESCRIPTION
The "allow newer" feature works by transforming the package descriptions
to adjust the dependencies on certain packages. This transformation was
not being applied to the dependencies of custom setup scripts.