### PR TITLE
Change Cabal's GHC support window to GHC 6.12 or later

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -111,7 +111,7 @@ configure verbosity hcPath hcPkgPath conf0 = do
 
   (ghcProg, ghcVersion, conf1) <-
     requireProgramVersion verbosity ghcProgram
-      (orLaterVersion (Version [6,4] []))
+      (orLaterVersion (Version [6,11] []))
       (userMaybeSpecifyPath "ghc" hcPath conf0)
   let implInfo = ghcVersionImplInfo ghcVersion
 

--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -31,17 +31,7 @@ import Distribution.Version
 -}
 
 data GhcImplInfo = GhcImplInfo
-  { hasCcOdirBug         :: Bool -- ^ bug in -odir handling for C compilations.
-  , flagInfoLanguages    :: Bool -- ^ --info and --supported-languages flags
-  , fakeRecordPuns       :: Bool -- ^ use -XRecordPuns for NamedFieldPuns
-  , flagStubdir          :: Bool -- ^ -stubdir flag supported
-  , flagOutputDir        :: Bool -- ^ -outputdir flag supported
-  , noExtInSplitSuffix   :: Bool -- ^ split-obj suffix does not contain p_o ext
-  , flagFfiIncludes      :: Bool -- ^ -#include on command line for FFI includes
-  , flagBuildingCabalPkg :: Bool -- ^ -fbuilding-cabal-package flag supported
-  , flagPackageId        :: Bool -- ^ -package-id / -package flags supported
-  , separateGccMingw     :: Bool -- ^ mingw and gcc are in separate directories
-  , supportsHaskell2010  :: Bool -- ^ -XHaskell2010 and -XHaskell98 flags
+  { supportsHaskell2010  :: Bool -- ^ -XHaskell2010 and -XHaskell98 flags
   , reportsNoExt         :: Bool -- ^ --supported-languages gives Ext and NoExt
   , alwaysNondecIndent   :: Bool -- ^ NondecreasingIndentation is always on
   , flagGhciScript       :: Bool -- ^ -ghci-script flag supported
@@ -65,17 +55,7 @@ getImplInfo comp =
 
 ghcVersionImplInfo :: Version -> GhcImplInfo
 ghcVersionImplInfo (Version v _) = GhcImplInfo
-  { hasCcOdirBug         = v <  [6,4,1]
-  , flagInfoLanguages    = v >= [6,7]
-  , fakeRecordPuns       = v >= [6,8] && v < [6,10]
-  , flagStubdir          = v >= [6,8]
-  , flagOutputDir        = v >= [6,10]
-  , noExtInSplitSuffix   = v <  [6,11]
-  , flagFfiIncludes      = v <  [6,11]
-  , flagBuildingCabalPkg = v >= [6,11]
-  , flagPackageId        = v >  [6,11]
-  , separateGccMingw     = v <  [6,12]
-  , supportsHaskell2010  = v >= [7]
+  { supportsHaskell2010  = v >= [7]
   , reportsNoExt         = v >= [7]
   , alwaysNondecIndent   = v <  [7,1]
   , flagGhciScript       = v >= [7,2]
@@ -86,17 +66,7 @@ ghcVersionImplInfo (Version v _) = GhcImplInfo
 
 ghcjsVersionImplInfo :: Version -> Version -> GhcImplInfo
 ghcjsVersionImplInfo _ghcjsVer _ghcVer = GhcImplInfo
-  { hasCcOdirBug         = False
-  , flagInfoLanguages    = True
-  , fakeRecordPuns       = False
-  , flagStubdir          = True
-  , flagOutputDir        = True
-  , noExtInSplitSuffix   = False
-  , flagFfiIncludes      = False
-  , flagBuildingCabalPkg = True
-  , flagPackageId        = True
-  , separateGccMingw     = False
-  , supportsHaskell2010  = True
+  { supportsHaskell2010  = True
   , reportsNoExt         = True
   , alwaysNondecIndent   = False
   , flagGhciScript       = True

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -83,11 +83,9 @@ data GhcOptions = GhcOptions {
   -- | GHC package databases to use, the @ghc -package-conf@ flag.
   ghcOptPackageDBs    :: PackageDBStack,
 
-  -- | The GHC packages to use. For compatability with old and new ghc, this
-  -- requires both the short and long form of the package id;
-  -- the @ghc -package@ or @ghc -package-id@ flags.
+  -- | The GHC packages to use, the @ghc -package-id@ flags.
   ghcOptPackages      ::
-    NubListR (UnitId, PackageId, ModuleRenaming),
+    NubListR (UnitId, ModuleRenaming),
 
   -- | Start with a clean package set; the @ghc -hide-all-packages@ flag
   ghcOptHideAllPackages :: Flag Bool,
@@ -279,8 +277,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
 
   , maybe [] verbosityOpts (flagToMaybe (ghcOptVerbosity opts))
 
-  , [ "-fbuilding-cabal-package" | flagBool ghcOptCabal
-                                 , flagBuildingCabalPkg implInfo ]
+  , [ "-fbuilding-cabal-package" | flagBool ghcOptCabal ]
 
   ----------------
   -- Compilation
@@ -342,12 +339,10 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
   , concat [ ["-hisuf",   suf] | suf <- flag ghcOptHiSuffix  ]
   , concat [ ["-dynosuf", suf] | suf <- flag ghcOptDynObjSuffix ]
   , concat [ ["-dynhisuf",suf] | suf <- flag ghcOptDynHiSuffix  ]
-  , concat [ ["-outputdir", dir] | dir <- flag ghcOptOutputDir
-                                 , flagOutputDir implInfo ]
+  , concat [ ["-outputdir", dir] | dir <- flag ghcOptOutputDir ]
   , concat [ ["-odir",    dir] | dir <- flag ghcOptObjDir ]
   , concat [ ["-hidir",   dir] | dir <- flag ghcOptHiDir  ]
-  , concat [ ["-stubdir", dir] | dir <- flag ghcOptStubDir
-                               , flagStubdir implInfo ]
+  , concat [ ["-stubdir", dir] | dir <- flag ghcOptStubDir ]
 
   -----------------------
   -- Source search path
@@ -362,8 +357,6 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
   , [ "-optP" ++ opt | opt <- flags ghcOptCppOptions ]
   , concat [ [ "-optP-include", "-optP" ++ inc]
            | inc <- flags ghcOptCppIncludes ]
-  , [ "-#include \"" ++ inc ++ "\""
-    | inc <- flags ghcOptFfiIncludes, flagFfiIncludes implInfo ]
   , [ "-optc" ++ opt | opt <- flags ghcOptCcOptions ]
 
   -----------------
@@ -400,13 +393,10 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
 
   , packageDbArgs implInfo (ghcOptPackageDBs opts)
 
-  , concat $ if flagPackageId implInfo
-      then let space "" = ""
-               space xs = ' ' : xs
-           in [ ["-package-id", display ipkgid ++ space (display rns)]
-              | (ipkgid,_,rns) <- flags ghcOptPackages ]
-      else [ ["-package",    display  pkgid]
-           | (_,pkgid,_)  <- flags ghcOptPackages ]
+  , concat $ let space "" = ""
+                 space xs = ' ' : xs
+             in [ ["-package-id", display ipkgid ++ space (display rns)]
+                | (ipkgid,rns) <- flags ghcOptPackages ]
 
   ----------------------------
   -- Language and extensions

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -614,7 +614,7 @@ externalSetupMethod verbosity options pkg bt mkargs = do
           selectedDeps | useDependenciesExclusive options'
                                    = useDependencies options'
                        | otherwise = useDependencies options' ++ cabalDep
-          addRenaming (ipid, pid) = (ipid, pid, defaultRenaming)
+          addRenaming (ipid, _) = (ipid, defaultRenaming)
           cppMacrosFile = setupDir </> "setup_macros.h"
           ghcOptions = mempty {
               ghcOptVerbosity       = Flag verbosity


### PR DESCRIPTION
JUST THE LATEST PATCH, it was based off of #3066, but I think it should not be difficult to commute earlier. See #3108 for some rationale.