### PR TITLE
Fix unit test that didn't compile

### DIFF
--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
@@ -378,7 +378,7 @@ extractInstallPlan = catMaybes . map confPkg . CI.InstallPlan.toList
     confPkg _                               = Nothing
 
     srcPkg :: ConfiguredPackage -> (String, Int)
-    srcPkg (ConfiguredPackage pkg _flags _stanzas _deps _) =
+    srcPkg (ConfiguredPackage pkg _flags _stanzas _deps) =
       let C.PackageIdentifier (C.PackageName p) (Version (n:_) _) =
             packageInfoId pkg
       in (p, n)


### PR DESCRIPTION
Broke with 335ac900e3f571ea9222ba4934ab9ab930153ad2.