### PR TITLE
Require QuickCheck >= 2.7

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -307,7 +307,7 @@ test-suite unit-tests
     tasty-hunit,
     tasty-quickcheck,
     pretty,
-    QuickCheck < 2.9,
+    QuickCheck >= 2.7 && < 2.9,
     Cabal
   ghc-options: -Wall
   default-language: Haskell98
@@ -327,9 +327,7 @@ test-suite package-tests
     base,
     containers,
     tasty,
-    tasty-quickcheck,
     tasty-hunit,
-    QuickCheck >= 2.1.0.1 && < 2.9,
     transformers,
     Cabal,
     process,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -287,7 +287,7 @@ Test-Suite unit-tests
         tasty-hunit,
         tasty-quickcheck,
         tagged,
-        QuickCheck >= 2.5
+        QuickCheck >= 2.7
 
   if flag(old-directory)
     build-depends: old-time


### PR DESCRIPTION
The tests use `===` and `counterexample`, which were added in QuickCheck-2.7.