### PR TITLE
Cabal with ghc package tests

### DIFF
--- a/Cabal/tests/PackageTests.hs
+++ b/Cabal/tests/PackageTests.hs
@@ -92,6 +92,8 @@ main = do
     ghc_pkg_path <- getExePathFromEnvOrLBI "CABAL_PACKAGETESTS_GHC_PKG" ghcPkgProgram
     haddock_path <- getExePathFromEnvOrLBI "CABAL_PACKAGETESTS_HADDOCK" haddockProgram
 
+    with_ghc_path     <- fromMaybe ghc_path `fmap` lookupEnv "CABAL_PACKAGETESTS_WITH_GHC"
+
     ghc_version_env <- lookupEnv "CABAL_PACKAGETESTS_GHC_VERSION"
     ghc_version <- case ghc_version_env of
         Nothing -> do
@@ -144,6 +146,7 @@ main = do
                  , ghcPath = ghc_path
                  , ghcVersion = ghc_version
                  , ghcPkgPath = ghc_pkg_path
+                 , withGhcPath = with_ghc_path
                  , packageDBStack = packageDBStack2
                  , suiteVerbosity = verbosity
                  , absoluteCWD = test_dir
@@ -159,6 +162,7 @@ main = do
     putStrLn $ "CABAL_PACKAGETESTS_GHC=" ++ show ghc_path ++ " \\"
     putStrLn $ "CABAL_PACKAGETESTS_GHC_VERSION=" ++ show (display ghc_version) ++ " \\"
     putStrLn $ "CABAL_PACKAGETESTS_GHC_PKG=" ++ show ghc_pkg_path ++ " \\"
+    putStrLn $ "CABAL_PACKAGETESTS_WITH_GHC=" ++ show with_ghc_path ++ " \\"
     putStrLn $ "CABAL_PACKAGETESTS_HADDOCK=" ++ show haddock_path ++ " \\"
     -- For brevity, do pre-canonicalization
     putStrLn $ "CABAL_PACKAGETESTS_DB_STACK=" ++

--- a/Cabal/tests/PackageTests/BuildDeps/GlobalBuildDepsNotAdditive1/GlobalBuildDepsNotAdditive1.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/GlobalBuildDepsNotAdditive1/GlobalBuildDepsNotAdditive1.cabal
@@ -17,4 +17,4 @@ build-depends: base
 
 Library
     exposed-modules: MyLibrary
-    build-depends: bytestring, old-time
+    build-depends: bytestring, pretty

--- a/Cabal/tests/PackageTests/BuildDeps/GlobalBuildDepsNotAdditive1/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/GlobalBuildDepsNotAdditive1/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/GlobalBuildDepsNotAdditive2/GlobalBuildDepsNotAdditive2.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/GlobalBuildDepsNotAdditive2/GlobalBuildDepsNotAdditive2.cabal
@@ -17,4 +17,4 @@ build-depends: base
 
 Executable lemon
     main-is: lemon.hs
-    build-depends: bytestring, old-time
+    build-depends: bytestring, pretty

--- a/Cabal/tests/PackageTests/BuildDeps/GlobalBuildDepsNotAdditive2/lemon.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/GlobalBuildDepsNotAdditive2/lemon.hs
@@ -1,7 +1,7 @@
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 main = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "lemon"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary0/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary0/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary0/my.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary0/my.cabal
@@ -16,9 +16,9 @@ description:
 
 Library
     exposed-modules: MyLibrary
-    build-depends: base, bytestring, old-time
+    build-depends: base, bytestring, pretty
 
 Executable lemon
     main-is: lemon.hs
     hs-source-dirs: programs
-    build-depends: base, bytestring, old-time, InternalLibrary0
+    build-depends: base, bytestring, pretty, InternalLibrary0

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary0/programs/lemon.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary0/programs/lemon.hs
@@ -1,6 +1,6 @@
-import System.Time
+import Text.PrettyPrint
 import MyLibrary
 
 main = do
-    getClockTime
+    putStrLn (render (text "foo"))
     myLibFunc

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary1/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary1/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary1/my.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary1/my.cabal
@@ -15,9 +15,9 @@ description:
 
 Library
     exposed-modules: MyLibrary
-    build-depends: base, bytestring, old-time
+    build-depends: base, bytestring, pretty
 
 Executable lemon
     main-is: lemon.hs
     hs-source-dirs: programs
-    build-depends: base, bytestring, old-time, InternalLibrary1
+    build-depends: base, bytestring, pretty, InternalLibrary1

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary1/programs/lemon.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary1/programs/lemon.hs
@@ -1,6 +1,6 @@
-import System.Time
+import Text.PrettyPrint
 import MyLibrary
 
 main = do
-    getClockTime
+    putStrLn (render (text "foo"))
     myLibFunc

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary2/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary2/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc internal"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary2/my.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary2/my.cabal
@@ -15,9 +15,9 @@ description:
 
 Library
     exposed-modules: MyLibrary
-    build-depends: base, bytestring, old-time
+    build-depends: base, bytestring, pretty
 
 Executable lemon
     main-is: lemon.hs
     hs-source-dirs: programs
-    build-depends: base, bytestring, old-time, InternalLibrary2
+    build-depends: base, bytestring, pretty, InternalLibrary2

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary2/programs/lemon.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary2/programs/lemon.hs
@@ -1,6 +1,6 @@
-import System.Time
+import Text.PrettyPrint
 import MyLibrary
 
 main = do
-    getClockTime
+    putStrLn (render (text "foo"))
     myLibFunc

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary2/to-install/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary2/to-install/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc installed"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary2/to-install/my.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary2/to-install/my.cabal
@@ -15,4 +15,4 @@ description:
 
 Library
     exposed-modules: MyLibrary
-    build-depends: base, bytestring, old-time
+    build-depends: base, bytestring, pretty

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary3/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary3/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc internal"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary3/my.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary3/my.cabal
@@ -15,9 +15,9 @@ description:
 
 Library
     exposed-modules: MyLibrary
-    build-depends: base, bytestring, old-time
+    build-depends: base, bytestring, pretty
 
 Executable lemon
     main-is: lemon.hs
     hs-source-dirs: programs
-    build-depends: base, bytestring, old-time, InternalLibrary3
+    build-depends: base, bytestring, pretty, InternalLibrary3

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary3/programs/lemon.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary3/programs/lemon.hs
@@ -1,6 +1,6 @@
-import System.Time
+import Text.PrettyPrint
 import MyLibrary
 
 main = do
-    getClockTime
+    putStrLn (render (text "foo"))
     myLibFunc

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary3/to-install/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary3/to-install/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc installed"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary3/to-install/my.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary3/to-install/my.cabal
@@ -15,4 +15,4 @@ description:
 
 Library
     exposed-modules: MyLibrary
-    build-depends: base, bytestring, old-time
+    build-depends: base, bytestring, pretty

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary4/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary4/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc internal"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary4/my.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary4/my.cabal
@@ -15,9 +15,9 @@ description:
 
 Library
     exposed-modules: MyLibrary
-    build-depends: base, bytestring, old-time
+    build-depends: base, bytestring, pretty
 
 Executable lemon
     main-is: lemon.hs
     hs-source-dirs: programs
-    build-depends: base, bytestring, old-time, InternalLibrary4 >= 0.2
+    build-depends: base, bytestring, pretty, InternalLibrary4 >= 0.2

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary4/programs/lemon.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary4/programs/lemon.hs
@@ -1,6 +1,6 @@
-import System.Time
+import Text.PrettyPrint
 import MyLibrary
 
 main = do
-    getClockTime
+    putStrLn (render (text "foo"))
     myLibFunc

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary4/to-install/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary4/to-install/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc installed"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/InternalLibrary4/to-install/my.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/InternalLibrary4/to-install/my.cabal
@@ -15,4 +15,4 @@ description:
 
 Library
     exposed-modules: MyLibrary
-    build-depends: base, bytestring, old-time
+    build-depends: base, bytestring, pretty

--- a/Cabal/tests/PackageTests/BuildDeps/SameDepsAllRound/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/SameDepsAllRound/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/SameDepsAllRound/SameDepsAllRound.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/SameDepsAllRound/SameDepsAllRound.cabal
@@ -25,7 +25,7 @@ Library
 
 Executable lemon
     main-is: lemon.hs
-    build-depends: old-time
+    build-depends: pretty
 
 Executable pineapple
     main-is: pineapple.hs

--- a/Cabal/tests/PackageTests/BuildDeps/SameDepsAllRound/lemon.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/SameDepsAllRound/lemon.hs
@@ -1,7 +1,7 @@
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 main = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "lemon"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/SameDepsAllRound/pineapple.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/SameDepsAllRound/pineapple.hs
@@ -1,7 +1,7 @@
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 main = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "pineapple"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps1/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps1/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps1/lemon.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps1/lemon.hs
@@ -1,7 +1,7 @@
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 main = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "lemon"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps1/my.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps1/my.cabal
@@ -19,4 +19,4 @@ Library
 
 Executable lemon
     main-is: lemon.hs
-    build-depends: base, bytestring, old-time
+    build-depends: base, bytestring, pretty

--- a/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps2/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps2/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps2/my.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps2/my.cabal
@@ -17,7 +17,7 @@ description:
 
 Library
     exposed-modules: MyLibrary
-    build-depends: base, bytestring, old-time
+    build-depends: base, bytestring, pretty
 
 Executable lemon
     main-is: lemon.hs

--- a/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps3/MyLibrary.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps3/MyLibrary.hs
@@ -1,10 +1,10 @@
 module MyLibrary where
 
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 myLibFunc :: IO ()
 myLibFunc = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "myLibFunc"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps3/lemon.hs
+++ b/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps3/lemon.hs
@@ -1,7 +1,7 @@
 import qualified Data.ByteString.Char8 as C
-import System.Time
+import Text.PrettyPrint
 
 main = do
-    getClockTime
+    putStrLn (render (text "foo"))
     let text = "lemon"
     C.putStrLn $ C.pack text

--- a/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps3/my.cabal
+++ b/Cabal/tests/PackageTests/BuildDeps/TargetSpecificDeps3/my.cabal
@@ -15,7 +15,7 @@ description:
 
 Library
     exposed-modules: MyLibrary
-    build-depends: base, bytestring, old-time
+    build-depends: base, bytestring, pretty
 
 Executable lemon
     main-is: lemon.hs

--- a/Cabal/tests/PackageTests/PackageTester.hs
+++ b/Cabal/tests/PackageTests/PackageTester.hs
@@ -130,12 +130,14 @@ onlyIfExists m = liftIO $
 
 -- | Global configuration for the entire test suite.
 data SuiteConfig = SuiteConfig
-    -- | Where GHC lives
+    -- | Path to GHC that was used to compile Cabal library under test.
     { ghcPath :: FilePath
-    -- | Version of GHC
+    -- | Version of GHC that compiled Cabal.
     , ghcVersion :: Version
-    -- | Where ghc-pkg lives
+    -- | Path to ghc-pkg corresponding to 'ghcPath'.
     , ghcPkgPath :: FilePath
+    -- | Path to GHC that we should use to "./Setup --with-ghc"
+    , withGhcPath :: FilePath
     -- | The build directory that was used to build Cabal (used
     -- to compile Setup scripts.)
     , cabalDistPref :: FilePath
@@ -262,8 +264,12 @@ cabal' cmd extraArgs0 = do
                 -- here will make us error loudly if we try to install
                 -- into a bad place.
                 [ "--global"
-                , "--with-ghc", ghcPath suite
-                , "--with-ghc-pkg", ghcPkgPath suite
+                , "--with-ghc", withGhcPath suite
+                -- This improves precision but it increases the number
+                -- of flag ones has to specify and I don't like that;
+                -- Cabal is going to configure it and usually figure
+                -- out the right location in any case.
+                -- , "--with-ghc-pkg", withGhcPkgPath suite
                 -- Would really like to do this, but we're not always
                 -- going to be building against sufficiently recent
                 -- Cabal which provides this macro.
@@ -274,7 +280,11 @@ cabal' cmd extraArgs0 = do
                 , "--disable-optimization"
                 -- Specify where we want our installed packages to go
                 , "--prefix=" ++ prefix_dir
-                ] ++ packageDBParams (packageDBStack suite)
+                ] -- Only add the LBI package stack if the GHC version
+                  -- matches.
+                  ++ if withGhcPath suite == ghcPath suite
+                        then packageDBParams (packageDBStack suite)
+                        else []
                   ++ extraArgs0
             -- This gives us MUCH better error messages
             "build" -> "-v" : extraArgs0
@@ -337,6 +347,8 @@ compileSetup = do
 
 rawCompileSetup :: Verbosity -> SuiteConfig -> [(String, Maybe String)] -> FilePath -> IO ()
 rawCompileSetup verbosity suite e path = do
+    -- NB: Use 'ghcPath', not 'withGhcPath', since we need to be able to
+    -- link against the Cabal library which was built with 'ghcPath'.
     r <- rawRun verbosity (Just path) (ghcPath suite) e $
         [ "--make"] ++
         ghcPackageDBParams (ghcVersion suite) (packageDBStack suite) ++

--- a/Cabal/tests/PackageTests/PackageTester.hs
+++ b/Cabal/tests/PackageTests/PackageTester.hs
@@ -266,7 +266,7 @@ cabal' cmd extraArgs0 = do
                 [ "--global"
                 , "--with-ghc", withGhcPath suite
                 -- This improves precision but it increases the number
-                -- of flag ones has to specify and I don't like that;
+                -- of flags one has to specify and I don't like that;
                 -- Cabal is going to configure it and usually figure
                 -- out the right location in any case.
                 -- , "--with-ghc-pkg", withGhcPkgPath suite

--- a/Cabal/tests/PackageTests/PackageTester.hs
+++ b/Cabal/tests/PackageTests/PackageTester.hs
@@ -282,9 +282,9 @@ cabal' cmd extraArgs0 = do
                 , "--prefix=" ++ prefix_dir
                 ] -- Only add the LBI package stack if the GHC version
                   -- matches.
-                  ++ if withGhcPath suite == ghcPath suite
+                  ++ (if withGhcPath suite == ghcPath suite
                         then packageDBParams (packageDBStack suite)
-                        else []
+                        else [])
                   ++ extraArgs0
             -- This gives us MUCH better error messages
             "build" -> "-v" : extraArgs0

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -118,8 +118,8 @@ tests config =
       r <- shouldFail $ cabal' "build" []
       assertBool "error should be in MyLibrary.hs" $
           resultOutput r =~ "^MyLibrary.hs:"
-      assertBool "error should be \"Could not find module `System.Time\"" $
-          resultOutput r =~ "Could not find module.*System.Time"
+      assertBool "error should be \"Could not find module `Text\\.PrettyPrint\"" $
+          resultOutput r =~ "Could not find module.*Text\\.PrettyPrint"
 
   -- This is a control on TargetSpecificDeps1; it should
   -- succeed.
@@ -133,8 +133,8 @@ tests config =
       r <- shouldFail $ cabal' "build" []
       assertBool "error should be in lemon.hs" $
           resultOutput r =~ "^lemon.hs:"
-      assertBool "error should be \"Could not find module `System.Time\"" $
-          resultOutput r =~ "Could not find module.*System.Time"
+      assertBool "error should be \"Could not find module `Text\\.PrettyPrint\"" $
+          resultOutput r =~ "Could not find module.*Text\\.PrettyPrint"
 
   -- Test that Paths module is generated and available for executables.
   , tc "PathsModule/Executable" $ cabal_build []
@@ -240,7 +240,7 @@ tests config =
         r <- runExe' "lemon" []
         assertEqual
             ("executable should have linked with the " ++ expect ++ " library")
-            ("myLibFunc " ++ expect)
+            ("foofoomyLibFunc " ++ expect)
             (concat $ lines (resultOutput r))
 
     tc :: FilePath -> TestM a -> TestTree


### PR DESCRIPTION
In preparation for testing Cabal against old versions of GHC, I've made the tests more robust to being run against the boot package database, and added a new environment variable for PackageTests to make it use a different version of GHC.