### PR TITLE
Cabal: define MonadFail instances

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -179,6 +179,10 @@ library
   if impl(ghc < 7.6)
     build-depends: ghc-prim >= 0.2 && < 0.3
 
+  if !impl(ghc >= 8.0)
+    -- provides compat Control.Monad.Fail module
+    build-depends: fail == 4.9.*
+
   if !os(windows)
     build-depends:
       unix >= 2.5 && < 2.8

--- a/Cabal/Distribution/Compat/ReadP.hs
+++ b/Cabal/Distribution/Compat/ReadP.hs
@@ -70,6 +70,7 @@ module Distribution.Compat.ReadP
  where
 
 import Control.Monad( MonadPlus(..), liftM, liftM2, replicateM, ap, (>=>) )
+import qualified Control.Monad.Fail as Fail
 import Data.Char (isSpace)
 import Control.Applicative as AP (Applicative(..), Alternative(empty, (<|>)))
 
@@ -104,6 +105,9 @@ instance Monad (P s) where
   (Result x p) >>= k = k x `mplus` (p >>= k)
   (Final r)    >>= k = final [ys' | (x,s) <- r, ys' <- run (k x) s]
 
+  fail = Fail.fail
+
+instance Fail.MonadFail (P s) where
   fail _ = Fail
 
 instance Alternative (P s) where
@@ -156,8 +160,11 @@ instance Applicative (Parser r s) where
 
 instance Monad (Parser r s) where
   return = AP.pure
-  fail _    = R (const Fail)
+  fail = Fail.fail
   R m >>= f = R (\k -> m (\a -> let R m' = f a in m' k))
+
+instance Fail.MonadFail (Parser r s) where
+  fail _    = R (const Fail)
 
 --instance MonadPlus (Parser r s) where
 --  mzero = pfail

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -56,6 +56,7 @@ import Data.Maybe       (fromMaybe)
 import Data.Tree as Tree (Tree(..), flatten)
 import qualified Data.Map as Map
 import Control.Monad (foldM, ap)
+import qualified Control.Monad.Fail as Fail
 import Control.Applicative as AP (Applicative(..))
 import System.FilePath (normalise)
 import Data.List (sortBy)
@@ -100,6 +101,9 @@ instance Monad ParseResult where
         ParseOk ws x >>= f = case f x of
                                ParseFailed err -> ParseFailed err
                                ParseOk ws' x' -> ParseOk (ws'++ws) x'
+        fail = Fail.fail
+
+instance Fail.MonadFail ParseResult where
         fail s = ParseFailed (FromString s Nothing)
 
 catchParseError :: ParseResult a -> (PError -> ParseResult a)


### PR DESCRIPTION
This silences `-Wnoncanonical-monadfail-instances` warnings in the Cabal
library