### PR TITLE
FileMonitor features

### DIFF
--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -172,10 +172,10 @@ getCurrentModTime = System.Time.getClockTime
 -- This covers all the cases of 'MonitorFilePath' except for globs which is
 -- covered separately by 'MonitorStateGlob'.
 --
--- The @Maybe ModTime@ is to cover the case where the we already consider the
+-- The @Maybe ModTime@ is to cover the case where we already consider the
 -- file to have changed, either because it had already changed by the time we
 -- did the snapshot (i.e. too new, changed since start of update process) or it
--- no longer existes at all.
+-- no longer exists at all.
 --
 data MonitorStateFile
    = MonitorStateFile       !(Maybe ModTime) -- ^ cached file mtime

--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -580,7 +580,7 @@ probeGlobStatus root dirName
 
     -- Only in current filesystem state (directory added)
     probeMergeResult (OnlyInRight path) = do
-      fstate <- liftIO $ buildMonitorStateGlob Nothing
+      fstate <- liftIO $ buildMonitorStateGlob Nothing Map.empty
                            root (dirName </> path) globPath
       case allMatchingFiles (dirName </> path) fstate of
         (file:_) -> somethingChanged file
@@ -680,7 +680,8 @@ updateFileMonitor
   -> IO ()
 updateFileMonitor monitor root startTime monitorFiles
                   cachedKey cachedResult = do
-    msfs <- buildMonitorStateFileSet startTime root monitorFiles
+    hashcache <- readCacheFileHashes monitor
+    msfs <- buildMonitorStateFileSet startTime hashcache root monitorFiles
     rewriteCacheFile monitor msfs cachedKey cachedResult
 
 -- | A timestamp to help with the problem of file changes during actions.
@@ -702,11 +703,12 @@ beginUpdateFileMonitor = MonitorTimestamp <$> getCurrentModTime
 --
 buildMonitorStateFileSet :: Maybe MonitorTimestamp -- ^ optional: timestamp
                                               -- of the start of the action
+                         -> FileHashCache     -- ^ existing file hashes
                          -> FilePath          -- ^ root directory
                          -> [MonitorFilePath] -- ^ patterns of interest
                                               --   relative to root
                          -> IO MonitorStateFileSet
-buildMonitorStateFileSet mstartTime root =
+buildMonitorStateFileSet mstartTime hashcache root =
     go Map.empty []
   where
     go :: Map FilePath MonitorStateFile -> [MonitorStateGlob]
@@ -730,7 +732,9 @@ buildMonitorStateFileSet mstartTime root =
         mtime <- getModificationTime file
         if changedDuringUpdate mstartTime mtime
           then return (MonitorStateFileHashed Nothing 0)
-          else do hash <- readFileHash file
+          else do hash <- case lookupFileHashCache hashcache path mtime of
+                            Just hash -> return hash
+                            Nothing   -> readFileHash file
                   return (MonitorStateFileHashed (Just mtime) hash)
       let singlePaths' = Map.insert path monitorState singlePaths
       go singlePaths' globPaths monitors
@@ -740,7 +744,7 @@ buildMonitorStateFileSet mstartTime root =
       go singlePaths' globPaths monitors
 
     go !singlePaths !globPaths (MonitorFileGlob globPath : monitors) = do
-      monitorState <- buildMonitorStateGlob mstartTime
+      monitorState <- buildMonitorStateGlob mstartTime hashcache
                                             root "." globPath
       go singlePaths (monitorState : globPaths) monitors
 
@@ -761,12 +765,13 @@ changedDuringUpdate _ _ = False
 -- the monitored (globed) files for changes when we find a whole new subtree.
 --
 buildMonitorStateGlob :: Maybe MonitorTimestamp -- ^ start time of update
+                      -> FileHashCache     -- ^ existing file hashes
                       -> FilePath     -- ^ the root directory
                       -> FilePath     -- ^ directory we are examining
                                       --   relative to the root
                       -> FilePathGlob -- ^ the matching glob
                       -> IO MonitorStateGlob
-buildMonitorStateGlob mstartTime root dir globPath = do
+buildMonitorStateGlob mstartTime hashcache root dir globPath = do
     dirEntries <- getDirectoryContents (root </> dir)
     dirMTime   <- getModificationTime (root </> dir)
     case globPath of
@@ -776,7 +781,7 @@ buildMonitorStateGlob mstartTime root dir globPath = do
                  $ filter (globMatches glob) dirEntries
         subdirStates <-
           forM (sort subdirs) $ \subdir -> do
-            fstate <- buildMonitorStateGlob mstartTime root
+            fstate <- buildMonitorStateGlob mstartTime hashcache root
                                             (dir </> subdir) globPath'
             return (subdir, fstate)
         return $! MonitorStateGlobDirs glob globPath' dirMTime subdirStates
@@ -791,7 +796,9 @@ buildMonitorStateGlob mstartTime root dir globPath = do
             let mtime' | changedDuringUpdate mstartTime mtime
                                    = Nothing
                        | otherwise = Just mtime
-            hash <- readFileHash path
+            hash <- case lookupFileHashCache hashcache (dir </> file) mtime of
+                      Just hash -> return hash
+                      Nothing   -> readFileHash path
             return (file, mtime', hash)
         return $! MonitorStateGlobFiles glob dirMTime filesStates
 
@@ -814,6 +821,61 @@ matchFileGlob root glob0 = go glob0 ""
       concat <$> mapM (\subdir -> go globPath (dir </> subdir)) subdirs
 --TODO: [code cleanup] plausibly FilePathGlob and matchFileGlob should be
 -- moved into D.C.Glob and/or merged with similar functionality in Cabal.
+
+-- | We really want to avoid re-hashing files all the time. We already make
+-- the assumption that if a file mtime has not changed then we don't need to
+-- bother checking if the content hash has changed. We can apply the same
+-- assumption when updating the file monitor state. In the typical case of
+-- updating a file monitor the set of files is the same or largely the same so
+-- we can grab the previously known content hashes with their corresponding
+-- mtimes.
+--
+type FileHashCache = Map FilePath (ModTime, Hash)
+
+-- | We declare it a cache hit if the mtime of a file is the same as before.
+--
+lookupFileHashCache :: FileHashCache -> FilePath -> ModTime -> Maybe Hash
+lookupFileHashCache hashcache file mtime = do
+    (mtime', hash) <- Map.lookup file hashcache
+    guard (mtime' == mtime)
+    return hash
+
+-- | Build a 'FileHashCache' from the previous 'MonitorStateFileSet'. While
+-- in principle we could preserve the structure of the previous state, given
+-- that the set of files to monitor can change then it's simpler just to throw
+-- away the structure and use a finite map.
+--
+readCacheFileHashes :: (Binary a, Binary b)
+                    => FileMonitor a b -> IO FileHashCache
+readCacheFileHashes monitor =
+    handleDoesNotExist Map.empty $
+    handleErrorCall    Map.empty $ do
+      res <- readCacheFile monitor
+      case res of
+        Left _             -> return Map.empty
+        Right (msfs, _, _) -> return (mkFileHashCache msfs)
+  where
+    mkFileHashCache :: MonitorStateFileSet -> FileHashCache
+    mkFileHashCache (MonitorStateFileSet singlePaths globPaths) =
+                    collectAllFileHashes singlePaths
+        `Map.union` collectAllGlobHashes globPaths
+
+    collectAllFileHashes =
+      Map.mapMaybe $ \fstate -> case fstate of
+        MonitorStateFileHashed (Just mtime) hash -> Just (mtime, hash)
+        _                                        -> Nothing
+
+    collectAllGlobHashes = Map.fromList . concatMap (collectGlobHashes "")
+
+    collectGlobHashes dir (MonitorStateGlobDirs _ _ _ entries) =
+      [ res
+      | (subdir, fstate) <- entries
+      , res <- collectGlobHashes (dir </> subdir) fstate ]
+
+    collectGlobHashes dir (MonitorStateGlobFiles  _ _ entries) =
+      [ (dir </> fname, (mtime, hash))
+      | (fname, Just mtime, hash) <- entries ]
+
 
 ------------------------------------------------------------------------------
 -- Utils

--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -716,25 +716,25 @@ buildMonitorStateFileSet mstartTime hashcache root =
     go !singlePaths !globPaths [] =
       return (MonitorStateFileSet singlePaths globPaths)
 
-    go !singlePaths !globPaths (MonitorFile path : monitors) = do
-      let file = root </> path
+    go !singlePaths !globPaths (MonitorFile file : monitors) = do
+      let absfile = root </> file
       monitorState <- handleDoesNotExist (MonitorStateFile Nothing) $ do
-        mtime <- getModificationTime file
+        mtime <- getModificationTime absfile
         if changedDuringUpdate mstartTime mtime
           then return (MonitorStateFile Nothing)
           else return (MonitorStateFile (Just mtime))
-      let singlePaths' = Map.insert path monitorState singlePaths
+      let singlePaths' = Map.insert file monitorState singlePaths
       go singlePaths' globPaths monitors
 
-    go !singlePaths !globPaths (MonitorFileHashed path : monitors) = do
-      let file = root </> path
+    go !singlePaths !globPaths (MonitorFileHashed file : monitors) = do
+      let absfile = root </> file
       monitorState <- handleDoesNotExist (MonitorStateFileHashed Nothing 0) $ do
-        mtime <- getModificationTime file
+        mtime <- getModificationTime absfile
         if changedDuringUpdate mstartTime mtime
           then return (MonitorStateFileHashed Nothing 0)
-          else do hash <- getFileHash hashcache path file mtime
+          else do hash <- getFileHash hashcache file absfile mtime
                   return (MonitorStateFileHashed (Just mtime) hash)
-      let singlePaths' = Map.insert path monitorState singlePaths
+      let singlePaths' = Map.insert file monitorState singlePaths
       go singlePaths' globPaths monitors
 
     go !singlePaths !globPaths (MonitorNonExistentFile path : monitors) = do
@@ -770,12 +770,12 @@ buildMonitorStateGlob :: Maybe MonitorTimestamp -- ^ start time of update
                       -> FilePathGlob -- ^ the matching glob
                       -> IO MonitorStateGlob
 buildMonitorStateGlob mstartTime hashcache root dir globPath = do
-    dirEntries <- getDirectoryContents (root </> dir)
-    dirMTime   <- getModificationTime (root </> dir)
+    let absdir = root </> dir
+    dirEntries <- getDirectoryContents absdir
+    dirMTime   <- getModificationTime absdir
     case globPath of
       GlobDir glob globPath' -> do
-        subdirs <- filterM (\subdir -> doesDirectoryExist
-                                         (root </> dir </> subdir))
+        subdirs <- filterM (\subdir -> doesDirectoryExist (absdir </> subdir))
                  $ filter (globMatches glob) dirEntries
         subdirStates <-
           forM (sort subdirs) $ \subdir -> do
@@ -785,16 +785,16 @@ buildMonitorStateGlob mstartTime hashcache root dir globPath = do
         return $! MonitorStateGlobDirs glob globPath' dirMTime subdirStates
 
       GlobFile glob -> do
-        files <- filterM (\fname -> doesFileExist (root </> dir </> fname))
+        files <- filterM (\fname -> doesFileExist (absdir </> fname))
                $ filter (globMatches glob) dirEntries
         filesStates <-
           forM (sort files) $ \file -> do
-            let path = root </> dir </> file
-            mtime <- getModificationTime path
+            let absfile = absdir </> file
+            mtime <- getModificationTime absfile
             let mtime' | changedDuringUpdate mstartTime mtime
                                    = Nothing
                        | otherwise = Just mtime
-            hash <- getFileHash hashcache (dir </> file) path mtime
+            hash <- getFileHash hashcache (dir </> file) absfile mtime
             return (file, mtime', hash)
         return $! MonitorStateGlobFiles glob dirMTime filesStates
 

--- a/cabal-install/Distribution/Client/RebuildMonad.hs
+++ b/cabal-install/Distribution/Client/RebuildMonad.hs
@@ -30,11 +30,6 @@ module Distribution.Client.RebuildMonad (
   ) where
 
 import Distribution.Client.FileMonitor
-         ( MonitorFilePath(..), monitorFileSearchPath
-         , FilePathGlob(..), matchFileGlob
-         , FileMonitor(..), newFileMonitor
-         , MonitorChanged(..), MonitorChangedReason(..)
-         , checkFileMonitorChanged, updateFileMonitor )
 
 import Distribution.Simple.Utils (debug)
 import Distribution.Verbosity    (Verbosity)
@@ -98,8 +93,10 @@ rerunIfChanged verbosity rootDir monitor key action = do
       MonitorChanged reason -> do
         liftIO $ debug verbosity $ "File monitor '" ++ monitorName
                                 ++ "' changed: " ++ showReason reason
+        startTime <- liftIO $ beginUpdateFileMonitor
         (result, files) <- liftIO $ unRebuild action
-        liftIO $ updateFileMonitor monitor rootDir files key result
+        liftIO $ updateFileMonitor monitor rootDir
+                                   (Just startTime) files key result
         monitorFiles files
         return result
   where


### PR DESCRIPTION
Two new file monitor features, one for accuracy and one for performance.

Edsko reported (but no ticket) that edits to files during a build were not caught, and so the (new-)build command thought everything was now up to date when in fact it was not. The problem was that we take the file snapshot after the build completes and so obviously we miss changes during the build. Doing the snapshot before would be the obvious thing but in general it's hard to know in advance all the files. It's easier to find out the files as we go so we only know the full set at the end. This is certainly the pattern that the RebuildMonad follows.

The solution is quite simple and general: take a timestamp at the start of the build (or in general any action using the FileMonitor) and then when we take the snapshot at the end, any file that changed after we took the timestamp we can consider to have already changed. So we just record in the state that it already changed (we use the Nothing case of a Maybe ModTime for this purpose).

The performance one is simply that we were re-hashing all the files, even the ones that had not changed. Reusing the previous state as a cache is simple and effective.