### PR TITLE
Allow regexes in cabal-install integration test .err and .out files

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -329,6 +329,7 @@ test-suite integration-tests
     directory,
     filepath,
     process,
+    regex-posix,
     tasty,
     tasty-hunit
 

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -36,6 +36,8 @@ Extra-Source-Files:
   tests/IntegrationTests/custom/should_run/plain/Setup.hs
   tests/IntegrationTests/custom/should_run/plain/plain.cabal
   tests/IntegrationTests/exec/common.sh
+  tests/IntegrationTests/exec/should_fail/exit_with_failure_without_args.err
+  tests/IntegrationTests/exec/should_fail/exit_with_failure_without_args.sh
   tests/IntegrationTests/exec/should_run/Foo.hs
   tests/IntegrationTests/exec/should_run/My.hs
   tests/IntegrationTests/exec/should_run/adds_sandbox_bin_directory_to_path.out
@@ -46,7 +48,6 @@ Extra-Source-Files:
   tests/IntegrationTests/exec/should_run/can_run_executables_installed_in_sandbox.sh
   tests/IntegrationTests/exec/should_run/configures_cabal_to_use_sandbox.sh
   tests/IntegrationTests/exec/should_run/configures_ghc_to_use_sandbox.sh
-  tests/IntegrationTests/exec/should_run/exit_with_failure_without_args.sh
   tests/IntegrationTests/exec/should_run/my.cabal
   tests/IntegrationTests/exec/should_run/runs_given_command.out
   tests/IntegrationTests/exec/should_run/runs_given_command.sh

--- a/cabal-install/tests/IntegrationTests/exec/should_fail/exit_with_failure_without_args.err
+++ b/cabal-install/tests/IntegrationTests/exec/should_fail/exit_with_failure_without_args.err
@@ -1,0 +1,1 @@
+RE:^cabal(\.exe)?: Please specify an executable to run$

--- a/cabal-install/tests/IntegrationTests/exec/should_fail/exit_with_failure_without_args.sh
+++ b/cabal-install/tests/IntegrationTests/exec/should_fail/exit_with_failure_without_args.sh
@@ -1,0 +1,3 @@
+. ../common.sh
+
+cabal exec

--- a/cabal-install/tests/IntegrationTests/exec/should_run/exit_with_failure_without_args.sh
+++ b/cabal-install/tests/IntegrationTests/exec/should_run/exit_with_failure_without_args.sh
@@ -1,6 +1,0 @@
-. ../common.sh
-
-# We should probably be using a .err file and should_fail,
-# but this fails on windows due to the ".exe" on the cabal
-# executable in the output.
-cabal exec 2>&1 > /dev/null | grep "Please specify an executable to run"

--- a/cabal-install/tests/IntegrationTests/user-config/should_fail/doesnt_overwrite_without_f.err
+++ b/cabal-install/tests/IntegrationTests/user-config/should_fail/doesnt_overwrite_without_f.err
@@ -1,1 +1,1 @@
-cabal: ./cabal-config already exists.
+RE:^cabal(\.exe)?: \./cabal-config already exists\.$


### PR DESCRIPTION
I implemented the simple option described in #2872.  Lines beginning with "RE:" are regular expressions, and other lines are exact matches.

I also updated the tests that check error messages containing the executable name so that they accept `cabal.exe` or `cabal`.

/cc @BardurArantsson