### PR TITLE
Correctly remove .exe from the cabal command listed in the man page.

### DIFF
--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -164,7 +164,7 @@ import qualified Paths_cabal_install (version)
 
 import System.Environment       (getArgs, getProgName)
 import System.Exit              (exitFailure)
-import System.FilePath          ( splitExtension, takeBaseName
+import System.FilePath          ( dropExtension, splitExtension
                                 , takeExtension, (</>), (<.>))
 import System.IO                ( BufferMode(LineBuffering), hSetBuffering
 #ifdef mingw32_HOST_OS
@@ -1271,4 +1271,7 @@ manpageAction commands _ extraArgs _ = do
   unless (null extraArgs) $
     die $ "'manpage' doesn't take any extra arguments: " ++ unwords extraArgs
   pname <- getProgName
-  putStrLn $ manpage (takeBaseName pname) commands
+  let cabalCmd = if takeExtension pname == ".exe"
+                 then dropExtension pname
+                 else pname
+  putStrLn $ manpage cabalCmd commands


### PR DESCRIPTION
This commit only removes the extension when it is equal to ".exe".  It fixes the change made in #3103, which didn't handle executable names like `cabal-1.23`.