### PR TITLE
Quote cabal and ghc-pkg paths in cabal-install integration tests

### DIFF
--- a/cabal-install/tests/IntegrationTests/custom/common.sh
+++ b/cabal-install/tests/IntegrationTests/custom/common.sh
@@ -1,6 +1,6 @@
 # Helper to run Cabal
 cabal() {
-    $CABAL $CABAL_ARGS "$@"
+    "$CABAL" $CABAL_ARGS "$@"
 }
 
 die() {

--- a/cabal-install/tests/IntegrationTests/exec/common.sh
+++ b/cabal-install/tests/IntegrationTests/exec/common.sh
@@ -1,6 +1,6 @@
 # Helper to run Cabal
 cabal() {
-    $CABAL $CABAL_ARGS "$@"
+    "$CABAL" $CABAL_ARGS "$@"
 }
 
 die() {

--- a/cabal-install/tests/IntegrationTests/exec/should_run/configures_cabal_to_use_sandbox.sh
+++ b/cabal-install/tests/IntegrationTests/exec/should_run/configures_cabal_to_use_sandbox.sh
@@ -7,8 +7,8 @@ cabal sandbox init > /dev/null
 cabal install > /dev/null
 
 # The library should not be available outside the sandbox
-$GHC_PKG list | grep -v "my-0.1"
+"$GHC_PKG" list | grep -v "my-0.1"
 
 # When run inside 'cabal-exec' the 'sandbox hc-pkg list' sub-command
 # should find the library.
-cabal exec sh -- -c 'cd subdir && $CABAL sandbox hc-pkg list' | grep "my-0.1"
+cabal exec sh -- -c 'cd subdir && "$CABAL" sandbox hc-pkg list' | grep "my-0.1"

--- a/cabal-install/tests/IntegrationTests/exec/should_run/configures_ghc_to_use_sandbox.sh
+++ b/cabal-install/tests/IntegrationTests/exec/should_run/configures_ghc_to_use_sandbox.sh
@@ -7,7 +7,7 @@ cabal sandbox init > /dev/null
 cabal install > /dev/null
 
 # The library should not be available outside the sandbox
-$GHC_PKG list | grep -v "my-0.1"
+"$GHC_PKG" list | grep -v "my-0.1"
 
 # Execute ghc-pkg inside the sandbox; it should find my-0.1
 cabal exec ghc-pkg list | grep "my-0.1"

--- a/cabal-install/tests/IntegrationTests/freeze/common.sh
+++ b/cabal-install/tests/IntegrationTests/freeze/common.sh
@@ -1,6 +1,6 @@
 # Helper to run Cabal
 cabal() {
-    $CABAL $CABAL_ARGS "$@"
+    "$CABAL" $CABAL_ARGS "$@"
 }
 
 die() {

--- a/cabal-install/tests/IntegrationTests/manpage/common.sh
+++ b/cabal-install/tests/IntegrationTests/manpage/common.sh
@@ -1,6 +1,6 @@
 # Helper to run Cabal
 cabal() {
-    $CABAL $CABAL_ARGS "$@"
+    "$CABAL" $CABAL_ARGS "$@"
 }
 
 die() {

--- a/cabal-install/tests/IntegrationTests/multiple-source/common.sh
+++ b/cabal-install/tests/IntegrationTests/multiple-source/common.sh
@@ -1,5 +1,5 @@
 cabal() {
-    $CABAL $CABAL_ARGS "$@"
+    "$CABAL" $CABAL_ARGS "$@"
 }
 
 die() {

--- a/cabal-install/tests/IntegrationTests/sandbox-sources/common.sh
+++ b/cabal-install/tests/IntegrationTests/sandbox-sources/common.sh
@@ -1,5 +1,5 @@
 cabal() {
-    $CABAL $CABAL_ARGS "$@"
+    "$CABAL" $CABAL_ARGS "$@"
 }
 
 die() {

--- a/cabal-install/tests/IntegrationTests/user-config/common.sh
+++ b/cabal-install/tests/IntegrationTests/user-config/common.sh
@@ -1,6 +1,6 @@
 # Helper to run Cabal
 cabal() {
-    $CABAL $CABAL_ARGS_NO_CONFIG_FILE "$@"
+    "$CABAL" $CABAL_ARGS_NO_CONFIG_FILE "$@"
 }
 
 die() {


### PR DESCRIPTION
Spaces in the path to `ghc-pkg` caused two tests to fail when run with the Haskell Platform on Windows.