### PR TITLE
configureToolchain: Use the same program names as 'ghc --info'.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -189,7 +189,8 @@ library
 
   ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs
   if impl(ghc >= 8.0)
-    ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances
+                 -Wnoncanonical-monadfail-instances
 
   exposed-modules:
     Distribution.Compat.CreatePipe
@@ -295,17 +296,19 @@ test-suite unit-tests
   type: exitcode-stdio-1.0
   hs-source-dirs: tests
   other-modules:
+    Test.Laws
+    Test.QuickCheck.Utils
     UnitTests.Distribution.Compat.CreatePipe
     UnitTests.Distribution.Compat.ReadP
     UnitTests.Distribution.Simple.Program.Internal
-    UnitTests.Distribution.Utils.NubList
+    UnitTests.Distribution.Simple.Utils
     UnitTests.Distribution.System
+    UnitTests.Distribution.Utils.NubList
     UnitTests.Distribution.Version
-    Test.Laws
-    Test.QuickCheck.Utils
   main-is: UnitTests.hs
   build-depends:
     base,
+    directory,
     tasty,
     tasty-hunit,
     tasty-quickcheck,

--- a/Cabal/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/Distribution/Simple/BuildPaths.hs
@@ -98,11 +98,9 @@ mkSharedLibName (CompilerId compilerFlavor compilerVersion) lib
 -- (typically @\"\"@ on Unix and @\"exe\"@ on Windows or OS\/2)
 exeExtension :: String
 exeExtension = case buildOS of
-                   -- TODO: This should be determined via autoconf (AC_EXEEXT)
                    Windows -> "exe"
                    _       -> ""
 
--- TODO: This should be determined via autoconf (AC_OBJEXT)
 -- | Extension for object files. For GHC the extension is @\"o\"@.
 objExtension :: String
 objExtension = "o"

--- a/Cabal/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/Distribution/Simple/BuildPaths.hs
@@ -94,11 +94,11 @@ mkSharedLibName (CompilerId compilerFlavor compilerVersion) lib
 -- * Platform file extensions
 -- ------------------------------------------------------------
 
--- ToDo: This should be determined via autoconf (AC_EXEEXT)
--- | Extension for executable files
+-- | Default extension for executable files on the current platform.
 -- (typically @\"\"@ on Unix and @\"exe\"@ on Windows or OS\/2)
 exeExtension :: String
 exeExtension = case buildOS of
+                   -- TODO: This should be determined via autoconf (AC_EXEEXT)
                    Windows -> "exe"
                    _       -> ""
 

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -96,9 +96,9 @@ import Data.Version             ( showVersion )
 import System.Directory
          ( doesFileExist, getAppUserDataDirectory, createDirectoryIfMissing
          , canonicalizePath )
-import System.FilePath          ( (</>), (<.>), takeExtension,
-                                  takeDirectory, replaceExtension,
-                                  splitExtension, isRelative )
+import System.FilePath          ( (</>), (<.>), takeExtension
+                                , takeDirectory, replaceExtension
+                                , isRelative )
 import qualified System.Info
 
 -- -----------------------------------------------------------------------------
@@ -218,12 +218,6 @@ guessToolFromGhcPath tool ghcProg verbosity searchpath
 
         isSuffixChar :: Char -> Bool
         isSuffixChar c = isDigit c || c == '.' || c == '-'
-
-        dropExeExtension :: FilePath -> FilePath
-        dropExeExtension filepath =
-          case splitExtension filepath of
-            (filepath', extension) | extension == exeExtension -> filepath'
-                                   | otherwise                 -> filepath
 
 -- | Given something like /usr/local/bin/ghc-6.6.1(.exe) we try and find a
 -- corresponding ghc-pkg, we try looking for both a versioned and unversioned

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -151,7 +151,8 @@ configure verbosity hcPath hcPkgPath conf0 = do
       -- filter out `TemplateHaskell`
       extensions | ghcVersion < Version [8] []
                  , Just "NO" <- M.lookup "Have interpreter" ghcInfoMap
-                   = filter ((/= EnableExtension TemplateHaskell) . fst) extensions0
+                   = filter ((/= EnableExtension TemplateHaskell) . fst)
+                     extensions0
                  | otherwise = extensions0
 
   let comp = Compiler {
@@ -186,7 +187,8 @@ guessToolFromGhcPath tool ghcProg verbosity searchpath
        let real_dir           = takeDirectory real_path
            versionSuffix path = takeVersionSuffix (dropExeExtension path)
            guessNormal       dir = dir </> toolname <.> exeExtension
-           guessGhcVersioned dir = dir </> (toolname ++ "-ghc" ++ versionSuffix dir)
+           guessGhcVersioned dir = dir </> (toolname ++ "-ghc"
+                                            ++ versionSuffix dir)
                                        <.> exeExtension
            guessVersioned    dir = dir </> (toolname ++ versionSuffix dir)
                                        <.> exeExtension
@@ -276,7 +278,8 @@ getPackageDBContents verbosity packagedb conf = do
   toPackageIndex verbosity pkgss conf
 
 -- | Given a package DB stack, return all installed packages.
-getInstalledPackages :: Verbosity -> Compiler -> PackageDBStack -> ProgramConfiguration
+getInstalledPackages :: Verbosity -> Compiler -> PackageDBStack
+                     -> ProgramConfiguration
                      -> IO InstalledPackageIndex
 getInstalledPackages verbosity comp packagedbs conf = do
   checkPackageDbEnvVar
@@ -822,10 +825,11 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
       profOpts   = baseOpts `mappend` mempty {
                       ghcOptProfilingMode  = toFlag True,
                       ghcOptProfilingAuto  = Internal.profDetailLevelFlag False
-                                               (withProfExeDetail lbi),
+                                             (withProfExeDetail lbi),
                       ghcOptHiSuffix       = toFlag "p_hi",
                       ghcOptObjSuffix      = toFlag "p_o",
-                      ghcOptExtra          = toNubListR (hcProfOptions GHC exeBi),
+                      ghcOptExtra          = toNubListR
+                                             (hcProfOptions GHC exeBi),
                       ghcOptHPCDir         = hpcdir Hpc.Prof
                     }
       dynOpts    = baseOpts `mappend` mempty {
@@ -895,10 +899,11 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
         | isGhcDynamic = doingTH && (withProfExe lbi || withStaticExe)
         | otherwise    = doingTH && (withProfExe lbi || withDynExe lbi)
 
-      linkOpts = commonOpts `mappend`
-                 linkerOpts `mappend`
-                 mempty { ghcOptLinkNoHsMain   = toFlag (not isHaskellMain) } `mappend`
-                 (if withDynExe lbi then dynLinkerOpts else mempty)
+      linkOpts =
+        commonOpts `mappend`
+        linkerOpts `mappend`
+        mempty { ghcOptLinkNoHsMain   = toFlag (not isHaskellMain) } `mappend`
+        (if withDynExe lbi then dynLinkerOpts else mempty)
 
   -- Build static/dynamic object files for TH, if needed.
   when compileForTH $

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -46,9 +46,8 @@ import Data.Char                ( isSpace )
 import qualified Data.Map as M  ( fromList  )
 import Data.Monoid as Mon       ( Monoid(..) )
 import System.Directory         ( doesFileExist )
-import System.FilePath          ( (</>), (<.>), takeExtension,
-                                  takeDirectory, replaceExtension,
-                                  splitExtension )
+import System.FilePath          ( (</>), (<.>), takeExtension
+                                , takeDirectory, replaceExtension )
 
 configure :: Verbosity -> Maybe FilePath -> Maybe FilePath
           -> ProgramConfiguration
@@ -175,13 +174,6 @@ guessToolFromGhcjsPath tool ghcjsProg verbosity searchpath
   where takeVersionSuffix :: FilePath -> String
         takeVersionSuffix = reverse . takeWhile (`elem ` "0123456789.-") .
                             reverse
-
-        dropExeExtension :: FilePath -> FilePath
-        dropExeExtension filepath =
-          case splitExtension filepath of
-            (filepath', extension) | extension == exeExtension -> filepath'
-                                   | otherwise                 -> filepath
-
 
 -- | Given a single package DB, return all installed packages.
 getPackageDBContents :: Verbosity -> PackageDB -> ProgramConfiguration

--- a/Cabal/Distribution/Simple/Program/Find.hs
+++ b/Cabal/Distribution/Simple/Program/Find.hs
@@ -118,14 +118,6 @@ findProgramOnSearchPath verbosity searchpath prog = do
       dirs <- getSystemSearchPath
       findFirstExe [ dir </> prog <.> ext | dir <- dirs, ext <- exeExtensions ]
 
-    -- Possible improvement: on Windows, read the list of extensions from
-    -- the PATHEXT environment variable. By default PATHEXT is ".com; .exe;
-    -- .bat; .cmd".
-    exeExtensions = case buildOS of
-                      Windows -> ["", "exe"]
-                      Ghcjs   -> ["", "exe"]
-                      _       -> [""]
-
     findFirstExe :: [FilePath] -> IO (Maybe FilePath, [FilePath])
     findFirstExe = go []
       where

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -68,6 +68,8 @@ module Distribution.Simple.Utils (
         -- * file names
         currentDir,
         shortRelativePath,
+        dropExeExtension,
+        exeExtensions,
 
         -- * finding files
         findFile,
@@ -1190,6 +1192,24 @@ shortRelativePath from to =
     dropCommonPrefix (x:xs) (y:ys)
         | x == y    = dropCommonPrefix xs ys
     dropCommonPrefix xs ys = (xs,ys)
+
+-- | Drop the extension if it's one of 'exeExtensions', or return the path
+-- unchanged.
+dropExeExtension :: FilePath -> FilePath
+dropExeExtension filepath =
+  case splitExtension filepath of
+    (filepath', extension) | extension `elem` exeExtensions -> filepath'
+                           | otherwise                      -> filepath
+
+-- | List of possible executable file extensions on the current platform.
+exeExtensions :: [String]
+exeExtensions = case buildOS of
+  -- Possible improvement: on Windows, read the list of extensions from the
+  -- PATHEXT environment variable. By default PATHEXT is ".com; .exe; .bat;
+  -- .cmd".
+  Windows -> ["", "exe"]
+  Ghcjs   -> ["", "exe"]
+  _       -> [""]
 
 -- ------------------------------------------------------------
 -- * Finding the description file

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -472,7 +472,8 @@ createProcessWithEnv :: Verbosity
                      -> Process.StdStream  -- ^ stdin
                      -> Process.StdStream  -- ^ stdout
                      -> Process.StdStream  -- ^ stderr
-                     -> IO (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
+                     -> IO (Maybe Handle, Maybe Handle, Maybe Handle
+                           ,ProcessHandle)
                         -- ^ Any handles created for stdin, stdout, or stderr
                         -- with 'CreateProcess', and a handle to the process.
 createProcessWithEnv verbosity path args mcwd menv inp out err = do
@@ -1021,7 +1022,8 @@ copyDirectoryRecursive :: Verbosity -> FilePath -> FilePath -> IO ()
 copyDirectoryRecursive verbosity srcDir destDir = do
   info verbosity ("copy directory '" ++ srcDir ++ "' to '" ++ destDir ++ "'.")
   srcFiles <- getDirectoryContentsRecursive srcDir
-  copyFilesWith (const copyFile) verbosity destDir [ (srcDir, f) | f <- srcFiles ]
+  copyFilesWith (const copyFile) verbosity destDir [ (srcDir, f)
+                                                   | f <- srcFiles ]
 
 -------------------
 -- File permissions

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -477,18 +477,18 @@ rawSystemIOWithEnv verbosity path args mcwd menv inp out err = do
     mbToStd :: Maybe Handle -> Process.StdStream
     mbToStd = maybe Process.Inherit Process.UseHandle
 
-createProcessWithEnv :: Verbosity
-                     -> FilePath
-                     -> [String]
-                     -> Maybe FilePath           -- ^ New working dir or inherit
-                     -> Maybe [(String, String)] -- ^ New environment or inherit
-                     -> Process.StdStream  -- ^ stdin
-                     -> Process.StdStream  -- ^ stdout
-                     -> Process.StdStream  -- ^ stderr
-                     -> IO (Maybe Handle, Maybe Handle, Maybe Handle
-                           ,ProcessHandle)
-                        -- ^ Any handles created for stdin, stdout, or stderr
-                        -- with 'CreateProcess', and a handle to the process.
+createProcessWithEnv ::
+  Verbosity
+  -> FilePath
+  -> [String]
+  -> Maybe FilePath           -- ^ New working dir or inherit
+  -> Maybe [(String, String)] -- ^ New environment or inherit
+  -> Process.StdStream  -- ^ stdin
+  -> Process.StdStream  -- ^ stdout
+  -> Process.StdStream  -- ^ stderr
+  -> IO (Maybe Handle, Maybe Handle, Maybe Handle,ProcessHandle)
+  -- ^ Any handles created for stdin, stdout, or stderr
+  -- with 'CreateProcess', and a handle to the process.
 createProcessWithEnv verbosity path args mcwd menv inp out err = do
     printRawCommandAndArgsAndEnv verbosity path args menv
     hFlush stdout

--- a/Cabal/Distribution/System.hs
+++ b/Cabal/Distribution/System.hs
@@ -13,7 +13,7 @@
 -- probably know about the 'System.Info.os' however using that is very
 -- inconvenient because it is a string and different Haskell implementations
 -- do not agree on using the same strings for the same platforms! (In
--- particular see the controversy over \"windows\" vs \"ming32\"). So to make it
+-- particular see the controversy over \"windows\" vs \"mingw32\"). So to make it
 -- more consistent and easy to use we have an 'OS' enumeration.
 --
 module Distribution.System (

--- a/Cabal/tests/UnitTests.hs
+++ b/Cabal/tests/UnitTests.hs
@@ -7,24 +7,27 @@ import Test.Tasty
 import qualified UnitTests.Distribution.Compat.CreatePipe
 import qualified UnitTests.Distribution.Compat.ReadP
 import qualified UnitTests.Distribution.Simple.Program.Internal
-import qualified UnitTests.Distribution.Utils.NubList
+import qualified UnitTests.Distribution.Simple.Utils
 import qualified UnitTests.Distribution.System
+import qualified UnitTests.Distribution.Utils.NubList
 import qualified UnitTests.Distribution.Version (versionTests)
 
 tests :: TestTree
 tests = testGroup "Unit Tests" $
-    [ testGroup "Distribution.Compat.ReadP"
-        UnitTests.Distribution.Compat.ReadP.tests
-    , testGroup "Distribution.Compat.CreatePipe"
+    [ testGroup "Distribution.Compat.CreatePipe"
         UnitTests.Distribution.Compat.CreatePipe.tests
+    , testGroup "Distribution.Compat.ReadP"
+        UnitTests.Distribution.Compat.ReadP.tests
     , testGroup "Distribution.Simple.Program.Internal"
         UnitTests.Distribution.Simple.Program.Internal.tests
+    , testGroup "Distribution.Simple.Utils"
+        UnitTests.Distribution.Simple.Utils.tests
     , testGroup "Distribution.Utils.NubList"
         UnitTests.Distribution.Utils.NubList.tests
     , testGroup "Distribution.System"
         UnitTests.Distribution.System.tests
-    , UnitTests.Distribution.Version.versionTests
---    , UnitTests.Distribution.Version.parseTests
+    , testGroup "Distribution.Version"
+        UnitTests.Distribution.Version.versionTests
     ]
 
 main :: IO ()

--- a/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
+++ b/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
@@ -5,8 +5,10 @@ module UnitTests.Distribution.Simple.Utils
 import Distribution.Simple.Utils
 import Distribution.Verbosity
 
-import System.Directory (getTemporaryDirectory, removeDirectoryRecursive
-                        ,removeFile)
+import Data.IORef
+import System.Directory ( doesDirectoryExist, doesFileExist
+                        , getTemporaryDirectory
+                        , removeDirectoryRecursive, removeFile )
 import System.IO (hClose)
 
 import Test.Tasty
@@ -14,6 +16,15 @@ import Test.Tasty.HUnit
 
 withTempFileTest :: Assertion
 withTempFileTest = do
+  fileName <- newIORef ""
+  tempDir  <- getTemporaryDirectory
+  withTempFile tempDir ".foo" $ \fileName' _handle -> do
+    writeIORef fileName fileName'
+  fileExists <- readIORef fileName >>= doesFileExist
+  assertBool "Temporary file not deleted by 'withTempFile'!" (not fileExists)
+
+withTempFileRemovedTest :: Assertion
+withTempFileRemovedTest = do
   tempDir <- getTemporaryDirectory
   withTempFile tempDir ".foo" $ \fileName handle -> do
     hClose handle
@@ -21,14 +32,28 @@ withTempFileTest = do
 
 withTempDirTest :: Assertion
 withTempDirTest = do
+  dirName <- newIORef ""
+  tempDir <- getTemporaryDirectory
+  withTempDirectory normal tempDir "foo" $ \dirName' -> do
+    writeIORef dirName dirName'
+  dirExists <- readIORef dirName >>= doesDirectoryExist
+  assertBool "Temporary directory not deleted by 'withTempDirectory'!"
+    (not dirExists)
+
+withTempDirRemovedTest :: Assertion
+withTempDirRemovedTest = do
   tempDir <- getTemporaryDirectory
   withTempDirectory normal tempDir "foo" $ \dirPath -> do
     removeDirectoryRecursive dirPath
 
 tests :: [TestTree]
 tests =
-    [ testCase "withTempFile can handle removed files" $
+    [ testCase "withTempFile works as expected" $
       withTempFileTest
-    , testCase "withTempDirectory can handle removed directories" $
+    , testCase "withTempFile can handle removed files" $
+      withTempFileRemovedTest
+    , testCase "withTempDirectory works as expected" $
       withTempDirTest
+    , testCase "withTempDirectory can handle removed directories" $
+      withTempDirRemovedTest
     ]

--- a/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
+++ b/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
@@ -1,0 +1,34 @@
+module UnitTests.Distribution.Simple.Utils
+    ( tests
+    ) where
+
+import Distribution.Simple.Utils
+import Distribution.Verbosity
+
+import System.Directory (getTemporaryDirectory, removeDirectoryRecursive
+                        ,removeFile)
+import System.IO (hClose)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+withTempFileTest :: Assertion
+withTempFileTest = do
+  tempDir <- getTemporaryDirectory
+  withTempFile tempDir ".foo" $ \fileName handle -> do
+    hClose handle
+    removeFile fileName
+
+withTempDirTest :: Assertion
+withTempDirTest = do
+  tempDir <- getTemporaryDirectory
+  withTempDirectory normal tempDir "foo" $ \dirPath -> do
+    removeDirectoryRecursive dirPath
+
+tests :: [TestTree]
+tests =
+    [ testCase "withTempFile can handle removed files" $
+      withTempFileTest
+    , testCase "withTempDirectory can handle removed directories" $
+      withTempDirTest
+    ]

--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -10,7 +10,7 @@ import Distribution.Text
 import Text.PrettyPrint as Disp (text, render, parens, hcat
                                 ,punctuate, int, char, (<>), (<+>))
 
-import Test.Tasty (TestTree, testGroup)
+import Test.Tasty
 import Test.Tasty.QuickCheck
 import Test.QuickCheck.Utils
 import qualified Test.Laws as Laws
@@ -20,9 +20,8 @@ import Data.Maybe (isJust, fromJust)
 import Data.List (sort, sortBy, nub)
 import Data.Ord  (comparing)
 
-versionTests :: TestTree
+versionTests :: [TestTree]
 versionTests =
-  testGroup "Distribution.Version" $
   zipWith (\n p -> testProperty ("Range Property " ++ show n) p) [1::Int ..]
     -- properties to validate the test framework
   [ property prop_nonNull
@@ -85,9 +84,8 @@ versionTests =
   , property prop_invertVersionIntervalsTwice
   ]
 
--- parseTests :: TestTree
+-- parseTests :: [TestTree]
 -- parseTests =
---   testGroup "Distribution.Version" $
 --   zipWith (\n p -> testProperty ("Parse Property " ++ show n) p) [1::Int ..]
 --    -- parsing and pretty printing
 --   [ -- property prop_parse_disp1  --FIXME: actually wrong

--- a/HACKING.md
+++ b/HACKING.md
@@ -132,11 +132,13 @@ use the relative path, you are set.)
 Coding Conventions
 ------------------
 
-If you modify a file, please follow the style conventions used in
-that file. When you add a new top-level definition, please also
-add a Haddock comment. Use of GHC extensions is allowed (except
-Template Haskell), provided that the dependencies policy is
-respected.
+Use spaces, not tabs. Use lines no longer than 80 characters. If you modify a
+file, please follow the style conventions used in that file. When you add a new
+top-level definition, please also add a Haddock comment. Use of GHC extensions
+is allowed (except Template Haskell), provided that the dependencies policy is
+respected. In general, try to adhere to [this style guide][guide].
+
+[guide]: https://github.com/tibbe/haskell-style-guide/blob/master/haskell-style.md
 
 Dependencies policy
 -------------------

--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -68,7 +68,6 @@ import           Distribution.Client.Utils (mergeBy, MergeResult(..))
 import           System.FilePath
 import           System.Directory
 import           System.IO
-import           System.IO.Error
 import           GHC.Generics (Generic)
 
 

--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -62,7 +62,7 @@ import qualified Distribution.Compat.ReadP as ReadP
 import qualified Text.PrettyPrint as Disp
 
 import           Distribution.Client.Glob
-import           Distribution.Simple.Utils (writeFileAtomic)
+import           Distribution.Simple.Utils (handleDoesNotExist, writeFileAtomic)
 import           Distribution.Client.Utils (mergeBy, MergeResult(..))
 
 import           System.FilePath
@@ -821,14 +821,6 @@ checkDirectoryModificationTime dir mtime =
     if mtime == mtime'
       then return Nothing
       else return (Just mtime')
-
--- | Run an IO computation, returning @e@ if it raises a "file
--- does not exist" error.
-handleDoesNotExist :: a -> IO a -> IO a
-handleDoesNotExist e =
-    handleJust
-      (\ioe -> if isDoesNotExistError ioe then Just ioe else Nothing)
-      (\_ -> return e)
 
 -- | Run an IO computation, returning @e@ if there is an 'error'
 -- call. ('ErrorCall')

--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -6,7 +6,7 @@
 -- input values they depend on have changed.
 --
 module Distribution.Client.FileMonitor (
-  
+
   -- * Declaring files to monitor
   MonitorFilePath(..),
   FilePathGlob(..),
@@ -758,7 +758,7 @@ matchFileGlob root glob0 = go glob0 ""
 
 ------------------------------------------------------------------------------
 -- Utils
--- 
+--
 
 -- | Within the @root@ directory, check if @file@ has its 'ModTime' is
 -- the same as @mtime@, short-circuiting if it is different.
@@ -830,7 +830,7 @@ handleErrorCall e =
 
 ------------------------------------------------------------------------------
 -- Instances
--- 
+--
 
 instance Text FilePathGlob where
   disp (GlobDir  glob pathglob) = disp glob Disp.<> Disp.char '/'
@@ -877,4 +877,3 @@ instance Binary MonitorStateFileSet where
               globPaths   <- get
               return $! MonitorStateFileSet singlePaths globPaths
       else fail "MonitorStateFileSet: wrong version"
-


### PR DESCRIPTION
For example, we used to search for `ld` when the program name specified by `ghc --info` was `i386-unknown-linux-ld`.

Fixes #3140.