### PR TITLE
Handle "\r\n" in internal library package tests (fixes #3147)

### DIFF
--- a/Cabal/tests/PackageTests/PackageTester.hs
+++ b/Cabal/tests/PackageTests/PackageTester.hs
@@ -46,6 +46,7 @@ module PackageTests.PackageTester
     , assertOutputContains
     , assertOutputDoesNotContain
     , assertFindInFile
+    , concatOutput
 
     , getPersistBuildConfig
 

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -238,8 +238,8 @@ nonSharedLibTests config =
         r <- runExe' "lemon" []
         assertEqual
             ("executable should have linked with the " ++ expect ++ " library")
-            ("foofoomyLibFunc " ++ expect)
-            (concat $ lines (resultOutput r))
+            ("foo foo myLibFunc " ++ expect)
+            (concatOutput (resultOutput r))
 
     tc :: FilePath -> TestM a -> TestTree
     tc = testCase config

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ build_script:
   - Setup configure --user --ghc-option=-Werror --enable-tests
   - Setup build
   - Setup test unit-tests --show-details=streaming
-  # - Setup test package-tests --show-details=streaming --test-options=--skip-shared-library-tests
+  - Setup test package-tests --show-details=streaming --test-options=--skip-shared-library-tests
   - Setup install
   - cd ..\cabal-install
   - ghc --make -threaded -i -i. Setup.hs -Wall -Werror


### PR DESCRIPTION
I also enabled the Cabal package tests on AppVeyor.