### PR TITLE
Improve the 'getModTime' implementation.

### DIFF
--- a/cabal-install/Distribution/Client/Compat/Time.hs
+++ b/cabal-install/Distribution/Client/Compat/Time.hs
@@ -1,31 +1,94 @@
 {-# LANGUAGE CPP, ForeignFunctionInterface #-}
 module Distribution.Client.Compat.Time
-       (EpochTime, getModTime, getFileAge, getCurTime)
+       ( ModTime(..) -- Needed for testing
+       , getModTime, getFileAge, getCurTime
+       , posixSecondsToModTime )
        where
 
-import Data.Int (Int64)
-import System.Directory (getModificationTime)
+import Control.Arrow    ( first )
+import Data.Int         ( Int64 )
+import Data.Word        ( Word64 )
+import System.Directory ( getModificationTime )
 
+import Data.Time.Clock.POSIX ( POSIXTime, getPOSIXTime )
 #if MIN_VERSION_directory(1,2,0)
-import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds, posixDayLength)
-import Data.Time (getCurrentTime, diffUTCTime)
+import Data.Time.Clock.POSIX ( posixDayLength )
+import Data.Time             ( diffUTCTime, getCurrentTime )
 #else
-import System.Time (ClockTime(..), getClockTime
-                   ,diffClockTimes, normalizeTimeDiff, tdDay, tdHour)
+import System.Time ( getClockTime, diffClockTimes
+                   , normalizeTimeDiff, tdDay, tdHour )
 #endif
 
 #if defined mingw32_HOST_OS
 
+import Data.Bits          ((.|.), unsafeShiftL)
 #if MIN_VERSION_base(4,7,0)
-import Data.Bits          ((.|.), finiteBitSize, unsafeShiftL)
+import Data.Bits          (finiteBitSize)
 #else
-import Data.Bits          ((.|.), bitSize, unsafeShiftL)
+import Data.Bits          (bitSize)
 #endif
-import Data.Int           (Int32)
-import Data.Word          (Word64)
-import Foreign            (allocaBytes, peekByteOff)
-import System.IO.Error    (mkIOError, doesNotExistErrorType)
-import System.Win32.Types (BOOL, DWORD, LPCTSTR, LPVOID, withTString)
+
+import Data.Int           ( Int32 )
+import Foreign            ( allocaBytes, peekByteOff )
+import System.IO.Error    ( mkIOError, doesNotExistErrorType )
+import System.Win32.Types ( BOOL, DWORD, LPCTSTR, LPVOID, withTString )
+
+#else
+
+import System.Posix.Files ( FileStatus, getFileStatus )
+
+#if MIN_VERSION_unix(2,6,0)
+import System.Posix.Files ( modificationTimeHiRes )
+#else
+import System.Posix.Files ( modificationTime )
+#endif
+
+#endif
+
+-- | An opaque type representing a file's modification time, represented
+-- internally as a 64-bit unsigned integer in the Windows UTC format.
+newtype ModTime = ModTime Word64
+                deriving (Bounded, Eq, Ord)
+
+instance Show ModTime where
+  show (ModTime x) = show x
+
+instance Read ModTime where
+  readsPrec p str = map (first ModTime) (readsPrec p str)
+
+-- | Return modification time of the given file. Works around the low clock
+-- resolution problem that 'getModificationTime' has on GHC < 7.8.
+--
+-- This is a modified version of the code originally written for Shake by Neil
+-- Mitchell. See module Development.Shake.FileInfo.
+getModTime :: FilePath -> IO ModTime
+
+#if defined mingw32_HOST_OS
+
+-- Directly against the Win32 API.
+getModTime path = allocaBytes size_WIN32_FILE_ATTRIBUTE_DATA $ \info -> do
+  res <- getFileAttributesEx path info
+  if not res
+    then do
+      let err = mkIOError doesNotExistErrorType
+                "Distribution.Client.Compat.Time.getModTime"
+                Nothing (Just path)
+      ioError err
+    else do
+      dwLow  <- peekByteOff info
+                index_WIN32_FILE_ATTRIBUTE_DATA_ftLastWriteTime_dwLowDateTime
+      dwHigh <- peekByteOff info
+                index_WIN32_FILE_ATTRIBUTE_DATA_ftLastWriteTime_dwHighDateTime
+#if MIN_VERSION_base(4,7,0)
+      let qwTime =
+            (fromIntegral (dwHigh :: DWORD) `unsafeShiftL` finiteBitSize dwHigh)
+            .|. (fromIntegral (dwLow :: DWORD))
+#else
+      let qwTime =
+            (fromIntegral (dwHigh :: DWORD) `unsafeShiftL` bitSize dwHigh)
+            .|. (fromIntegral (dwLow :: DWORD))
+#endif
+      return $! ModTime (qwTime :: Word64)
 
 #ifdef x86_64_HOST_ARCH
 #define CALLCONV ccall
@@ -51,73 +114,38 @@ index_WIN32_FILE_ATTRIBUTE_DATA_ftLastWriteTime_dwLowDateTime :: Int
 index_WIN32_FILE_ATTRIBUTE_DATA_ftLastWriteTime_dwLowDateTime = 20
 
 index_WIN32_FILE_ATTRIBUTE_DATA_ftLastWriteTime_dwHighDateTime :: Int
-index_WIN32_FILE_ATTRIBUTE_DATA_ftLastWriteTime_dwHighDateTime = 24
+index_WIN32_FILE_ATTRIBUTE_DATA_ftLastWriteTime_dwHighDateTime = 20
 
-#else
-
-import Foreign.C.Types    (CTime(..))
-import System.Posix.Files (getFileStatus, modificationTime)
-
-#endif
-
--- | The number of seconds since the UNIX epoch.
-type EpochTime = Int64
-
--- | Return modification time of given file. Works around the low clock
--- resolution problem that 'getModificationTime' has on GHC < 7.8.
---
--- This is a modified version of the code originally written for OpenShake by
--- Neil Mitchell. See module Development.Shake.FileTime.
-getModTime :: FilePath -> IO EpochTime
-
-#if defined mingw32_HOST_OS
-
--- Directly against the Win32 API.
-getModTime path = allocaBytes size_WIN32_FILE_ATTRIBUTE_DATA $ \info -> do
-  res <- getFileAttributesEx path info
-  if not res
-    then do
-      let err = mkIOError doesNotExistErrorType
-                "Distribution.Client.Compat.Time.getModTime"
-                Nothing (Just path)
-      ioError err
-    else do
-      dwLow  <- peekByteOff info
-                index_WIN32_FILE_ATTRIBUTE_DATA_ftLastWriteTime_dwLowDateTime
-      dwHigh <- peekByteOff info
-                index_WIN32_FILE_ATTRIBUTE_DATA_ftLastWriteTime_dwHighDateTime
-      return $! windowsTimeToPOSIXSeconds dwLow dwHigh
-        where
-          windowsTimeToPOSIXSeconds :: DWORD -> DWORD -> EpochTime
-          windowsTimeToPOSIXSeconds dwLow dwHigh =
-            let wINDOWS_TICK      = 10000000
-                sEC_TO_UNIX_EPOCH = 11644473600
-#if MIN_VERSION_base(4,7,0)
-                qwTime = (fromIntegral dwHigh `unsafeShiftL` finiteBitSize dwHigh)
-                         .|. (fromIntegral dwLow)
-#else
-                qwTime = (fromIntegral dwHigh `unsafeShiftL` bitSize dwHigh)
-                         .|. (fromIntegral dwLow)
-#endif
-                res    = ((qwTime :: Word64) `div` wINDOWS_TICK)
-                         - sEC_TO_UNIX_EPOCH
-            -- TODO: What if the result is not representable as POSIX seconds?
-            -- Probably fine to return garbage.
-            in fromIntegral res
 #else
 
 -- Directly against the unix library.
 getModTime path = do
-    -- CTime is Int32 in base 4.5, Int64 in base >= 4.6, and an abstract type in
-    -- base < 4.5.
-    t <- fmap modificationTime $ getFileStatus path
-#if MIN_VERSION_base(4,5,0)
-    let CTime i = t
-    return (fromIntegral i)
+    st <- getFileStatus path
+    return $! (extractFileTime st)
+
+extractFileTime :: FileStatus -> ModTime
+#if MIN_VERSION_unix(2,6,0)
+extractFileTime x = posixTimeToModTime (modificationTimeHiRes x)
 #else
-    return (read . show $ t)
+extractFileTime x = posixSecondsToModTime $ fromIntegral $ fromEnum $
+                    modificationTime x
 #endif
+
 #endif
+
+windowsTick, secToUnixEpoch :: Word64
+windowsTick    = 10000000
+secToUnixEpoch = 11644473600
+
+-- | Convert POSIX seconds to ModTime.
+posixSecondsToModTime :: Int64 -> ModTime
+posixSecondsToModTime s =
+  ModTime $ ((fromIntegral s :: Word64) + secToUnixEpoch) * windowsTick
+
+-- | Convert 'POSIXTime' to 'ModTime'.
+posixTimeToModTime :: POSIXTime -> ModTime
+posixTimeToModTime p = ModTime $ (ceiling $ p * 1e7) -- 100 ns precision
+                       + (secToUnixEpoch * windowsTick)
 
 -- | Return age of given file in days.
 getFileAge :: FilePath -> IO Double
@@ -132,11 +160,6 @@ getFileAge file = do
   return $ fromIntegral ((24 * tdDay dt) + tdHour dt) / 24.0
 #endif
 
-getCurTime :: IO EpochTime
-getCurTime =  do
-#if MIN_VERSION_directory(1,2,0)
-  (truncate . utcTimeToPOSIXSeconds) `fmap` getCurrentTime
-#else
-  (TOD s _) <- getClockTime
-  return $! fromIntegral s
-#endif
+-- | Return the current time as 'ModTime'.
+getCurTime :: IO ModTime
+getCurTime = posixTimeToModTime `fmap` getPOSIXTime -- Uses 'gettimeofday'.

--- a/cabal-install/Distribution/Client/Compat/Time.hs
+++ b/cabal-install/Distribution/Client/Compat/Time.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, ForeignFunctionInterface #-}
+{-# LANGUAGE CPP, ForeignFunctionInterface, GeneralizedNewtypeDeriving #-}
 module Distribution.Client.Compat.Time
        ( ModTime(..) -- Needed for testing
        , getModTime, getFileAge, getCurTime
@@ -9,6 +9,8 @@ import Control.Arrow    ( first )
 import Data.Int         ( Int64 )
 import Data.Word        ( Word64 )
 import System.Directory ( getModificationTime )
+
+import Distribution.Compat.Binary ( Binary )
 
 import Data.Time.Clock.POSIX ( POSIXTime, getPOSIXTime )
 #if MIN_VERSION_directory(1,2,0)
@@ -48,7 +50,7 @@ import System.Posix.Files ( modificationTime )
 -- | An opaque type representing a file's modification time, represented
 -- internally as a 64-bit unsigned integer in the Windows UTC format.
 newtype ModTime = ModTime Word64
-                deriving (Bounded, Eq, Ord)
+                deriving (Binary, Bounded, Eq, Ord)
 
 instance Show ModTime where
   show (ModTime x) = show x

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -115,7 +115,9 @@ executable cabal
     main-is:        Main.hs
     ghc-options:    -Wall -fwarn-tabs
     if impl(ghc >= 8.0)
-        ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+        ghc-options: -Wcompat
+                     -Wnoncanonical-monad-instances
+                     -Wnoncanonical-monadfail-instances
 
     other-modules:
         Distribution.Client.BuildReports.Anonymous

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -276,6 +276,7 @@ Test-Suite unit-tests
     UnitTests.Distribution.Client.Sandbox
     UnitTests.Distribution.Client.Tar
     UnitTests.Distribution.Client.UserConfig
+    UnitTests.Options
   build-depends:
         base,
         array,

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -1,8 +1,18 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Main
        where
 
 import Test.Tasty
-import Test.Tasty.Options
+
+import Control.Monad
+import Data.Time.Clock
+import System.FilePath
+
+import Distribution.Simple.Utils
+import Distribution.Verbosity
+
+import Distribution.Client.Compat.Time
 
 import qualified UnitTests.Distribution.Client.Compat.Time
 import qualified UnitTests.Distribution.Client.Dependency.Modular.PSQ
@@ -15,16 +25,25 @@ import qualified UnitTests.Distribution.Client.Tar
 import qualified UnitTests.Distribution.Client.Targets
 import qualified UnitTests.Distribution.Client.UserConfig
 
-tests :: TestTree
-tests = testGroup "Unit Tests"
-  [ testGroup "UnitTests.Distribution.Client.Compat.Time"
-        UnitTests.Distribution.Client.Compat.Time.tests
+import UnitTests.Options
+
+
+tests :: Int -> TestTree
+tests mtimeChangeCalibrated =
+  askOption $ \(OptionMtimeChangeDelay mtimeChangeProvided) ->
+  let mtimeChange = if mtimeChangeProvided /= 0
+                    then mtimeChangeProvided
+                    else mtimeChangeCalibrated
+  in
+  testGroup "Unit Tests"
+  [ testGroup "UnitTests.Distribution.Client.Compat.Time" $
+        UnitTests.Distribution.Client.Compat.Time.tests mtimeChange
   , testGroup "UnitTests.Distribution.Client.Dependency.Modular.PSQ"
         UnitTests.Distribution.Client.Dependency.Modular.PSQ.tests
   , testGroup "UnitTests.Distribution.Client.Dependency.Modular.Solver"
         UnitTests.Distribution.Client.Dependency.Modular.Solver.tests
-  , testGroup "UnitTests.Distribution.Client.FileMonitor"
-        UnitTests.Distribution.Client.FileMonitor.tests
+  , testGroup "UnitTests.Distribution.Client.FileMonitor" $
+        UnitTests.Distribution.Client.FileMonitor.tests mtimeChange
   , testGroup "Distribution.Client.GZipUtils"
        UnitTests.Distribution.Client.GZipUtils.tests
   , testGroup "Distribution.Client.Sandbox"
@@ -39,13 +58,35 @@ tests = testGroup "Unit Tests"
        UnitTests.Distribution.Client.UserConfig.tests
   ]
 
--- Extra options for running the test suite
-extraOptions :: [OptionDescription]
-extraOptions = concat [
-    UnitTests.Distribution.Client.Dependency.Modular.Solver.options
-  ]
-
 main :: IO ()
-main = defaultMainWithIngredients
+main = do
+  mtimeChangeDelay <- calibrateMtimeChangeDelay
+  defaultMainWithIngredients
          (includingOptions extraOptions : defaultIngredients)
-         tests
+         (tests mtimeChangeDelay)
+
+-- Based on code written by Neill Mitchell for Shake. See
+-- 'sleepFileTimeCalibrate' in 'Test.Type'.
+calibrateMtimeChangeDelay :: IO Int
+calibrateMtimeChangeDelay = do
+  withTempDirectory silent "." "calibration-" $ \dir -> do
+    let fileName = dir </> "probe"
+    mtimes <- forM [1..10] $ \(i::Int) -> time $ do
+      writeFile fileName $ show i
+      t0 <- getModTime fileName
+      let spin j = do
+            writeFile fileName $ show (i,j)
+            t1 <- getModTime fileName
+            unless (t0 < t1) (spin $ j + 1)
+      spin (0::Int)
+    let mtimeChange = maximum mtimes
+    putStrLn $ "Mtime delay calibration completed, calculated delay: "
+      ++ (show mtimeChange) ++ " ms."
+    return $ min 1000000 mtimeChange
+  where
+    time :: IO () -> IO Int
+    time act = do
+      t0 <- getCurrentTime
+      act
+      t1 <- getCurrentTime
+      return . ceiling $! (t1 `diffUTCTime` t0) * 1e6 -- microseconds

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -4,33 +4,39 @@ module Main
 import Test.Tasty
 import Test.Tasty.Options
 
-import qualified UnitTests.Distribution.Client.Sandbox
-import qualified UnitTests.Distribution.Client.UserConfig
-import qualified UnitTests.Distribution.Client.Tar
-import qualified UnitTests.Distribution.Client.Targets
-import qualified UnitTests.Distribution.Client.GZipUtils
+import qualified UnitTests.Distribution.Client.Compat.Time
 import qualified UnitTests.Distribution.Client.Dependency.Modular.PSQ
 import qualified UnitTests.Distribution.Client.Dependency.Modular.Solver
 import qualified UnitTests.Distribution.Client.FileMonitor
+import qualified UnitTests.Distribution.Client.GZipUtils
+import qualified UnitTests.Distribution.Client.Sandbox
+import qualified UnitTests.Distribution.Client.Sandbox.Timestamp
+import qualified UnitTests.Distribution.Client.Tar
+import qualified UnitTests.Distribution.Client.Targets
+import qualified UnitTests.Distribution.Client.UserConfig
 
 tests :: TestTree
-tests = testGroup "Unit Tests" [
-   testGroup "UnitTests.Distribution.Client.UserConfig"
-       UnitTests.Distribution.Client.UserConfig.tests
-  ,testGroup "Distribution.Client.Sandbox"
-       UnitTests.Distribution.Client.Sandbox.tests
-  ,testGroup "Distribution.Client.Tar"
-       UnitTests.Distribution.Client.Tar.tests
-  ,testGroup "Distribution.Client.Targets"
-       UnitTests.Distribution.Client.Targets.tests
-  ,testGroup "Distribution.Client.GZipUtils"
-       UnitTests.Distribution.Client.GZipUtils.tests
-  ,testGroup "UnitTests.Distribution.Client.Dependency.Modular.PSQ"
+tests = testGroup "Unit Tests"
+  [ testGroup "UnitTests.Distribution.Client.Compat.Time"
+        UnitTests.Distribution.Client.Compat.Time.tests
+  , testGroup "UnitTests.Distribution.Client.Dependency.Modular.PSQ"
         UnitTests.Distribution.Client.Dependency.Modular.PSQ.tests
-  ,testGroup "UnitTests.Distribution.Client.Dependency.Modular.Solver"
+  , testGroup "UnitTests.Distribution.Client.Dependency.Modular.Solver"
         UnitTests.Distribution.Client.Dependency.Modular.Solver.tests
-  ,testGroup "UnitTests.Distribution.Client.FileMonitor"
+  , testGroup "UnitTests.Distribution.Client.FileMonitor"
         UnitTests.Distribution.Client.FileMonitor.tests
+  , testGroup "Distribution.Client.GZipUtils"
+       UnitTests.Distribution.Client.GZipUtils.tests
+  , testGroup "Distribution.Client.Sandbox"
+       UnitTests.Distribution.Client.Sandbox.tests
+  , testGroup "Distribution.Client.Sandbox.Timestamp"
+       UnitTests.Distribution.Client.Sandbox.Timestamp.tests
+  , testGroup "Distribution.Client.Tar"
+       UnitTests.Distribution.Client.Tar.tests
+  , testGroup "Distribution.Client.Targets"
+       UnitTests.Distribution.Client.Targets.tests
+  , testGroup "UnitTests.Distribution.Client.UserConfig"
+       UnitTests.Distribution.Client.UserConfig.tests
   ]
 
 -- Extra options for running the test suite

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -66,7 +66,8 @@ main = do
          (tests mtimeChangeDelay)
 
 -- Based on code written by Neill Mitchell for Shake. See
--- 'sleepFileTimeCalibrate' in 'Test.Type'.
+-- 'sleepFileTimeCalibrate' in 'Test.Type'. The returned delay is never smaller
+-- than 10 ms, but never larger than 1 second.
 calibrateMtimeChangeDelay :: IO Int
 calibrateMtimeChangeDelay = do
   withTempDirectory silent "." "calibration-" $ \dir -> do
@@ -81,8 +82,8 @@ calibrateMtimeChangeDelay = do
       spin (0::Int)
     let mtimeChange = maximum mtimes
     putStrLn $ "Mtime delay calibration completed, calculated delay: "
-      ++ (show mtimeChange) ++ " ms."
-    return $ min 1000000 mtimeChange
+      ++ (show $ fromIntegral mtimeChange / (1000.0 :: Double)) ++ " ms."
+    return $ min 1000000 (max 10000 mtimeChange)
   where
     time :: IO () -> IO Int
     time act = do

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -90,7 +90,7 @@ calibrateMtimeChangeDelay = do
     return mtimeChange'
   where
     toMillis :: Int -> Double
-    toMillis x = fromIntegral x / (1000.0 :: Double)
+    toMillis x = fromIntegral x / 1000.0
 
     time :: IO () -> IO Int
     time act = do

--- a/cabal-install/tests/UnitTests/Distribution/Client/Compat/Time.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Compat/Time.hs
@@ -11,40 +11,37 @@ import Distribution.Client.Compat.Time
 import Test.Tasty
 import Test.Tasty.HUnit
 
--- TODO: Calibrate, like Shake's test suite does.
-mtimeDelay :: Int
-mtimeDelay = 500000 -- 0.5 s
+tests :: Int -> [TestTree]
+tests mtimeChange =
+  [ testCase "getModTime has sub-second resolution" $ getModTimeTest mtimeChange
+  , testCase "getCurTime works as expected"         $ getCurTimeTest mtimeChange
+  ]
 
-tests :: [TestTree]
-tests =
-  [ testCase "getModTime has sub-second resolution" getModTimeTest
-  , testCase "getCurTime works as expected"         getCurTimeTest ]
-
-getModTimeTest :: Assertion
-getModTimeTest =
+getModTimeTest :: Int -> Assertion
+getModTimeTest mtimeChange =
   withTempDirectory silent "." "getmodtime-" $ \dir -> do
     let fileName = dir </> "foo"
     writeFile fileName "bar"
     t0 <- getModTime fileName
-    threadDelay mtimeDelay
+    threadDelay mtimeChange
     writeFile fileName "baz"
     t1 <- getModTime fileName
     assertBool "expected different file mtimes" (t1 > t0)
 
 
-getCurTimeTest :: Assertion
-getCurTimeTest =
+getCurTimeTest :: Int -> Assertion
+getCurTimeTest mtimeChange =
   withTempDirectory silent "." "getmodtime-" $ \dir -> do
     let fileName = dir </> "foo"
     writeFile fileName "bar"
     t0 <- getModTime fileName
-    threadDelay mtimeDelay
+    threadDelay mtimeChange
     t1 <- getCurTime
     assertBool("expected file mtime (" ++ show t0
                ++ ") to be earlier than current time (" ++ show t1 ++ ")")
       (t0 < t1)
 
-    threadDelay mtimeDelay
+    threadDelay mtimeChange
     writeFile fileName "baz"
     t2 <- getModTime fileName
     assertBool ("expected current time (" ++ show t1

--- a/cabal-install/tests/UnitTests/Distribution/Client/Compat/Time.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Compat/Time.hs
@@ -1,0 +1,52 @@
+module UnitTests.Distribution.Client.Compat.Time (tests) where
+
+import Control.Concurrent (threadDelay)
+import System.FilePath
+
+import Distribution.Simple.Utils (withTempDirectory)
+import Distribution.Verbosity
+
+import Distribution.Client.Compat.Time
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- TODO: Calibrate, like Shake's test suite does.
+mtimeDelay :: Int
+mtimeDelay = 500000 -- 0.5 s
+
+tests :: [TestTree]
+tests =
+  [ testCase "getModTime has sub-second resolution" getModTimeTest
+  , testCase "getCurTime works as expected"         getCurTimeTest ]
+
+getModTimeTest :: Assertion
+getModTimeTest =
+  withTempDirectory silent "." "getmodtime-" $ \dir -> do
+    let fileName = dir </> "foo"
+    writeFile fileName "bar"
+    t0 <- getModTime fileName
+    threadDelay mtimeDelay
+    writeFile fileName "baz"
+    t1 <- getModTime fileName
+    assertBool "expected different file mtimes" (t1 > t0)
+
+
+getCurTimeTest :: Assertion
+getCurTimeTest =
+  withTempDirectory silent "." "getmodtime-" $ \dir -> do
+    let fileName = dir </> "foo"
+    writeFile fileName "bar"
+    t0 <- getModTime fileName
+    threadDelay mtimeDelay
+    t1 <- getCurTime
+    assertBool("expected file mtime (" ++ show t0
+               ++ ") to be earlier than current time (" ++ show t1 ++ ")")
+      (t0 < t1)
+
+    threadDelay mtimeDelay
+    writeFile fileName "baz"
+    t2 <- getModTime fileName
+    assertBool ("expected current time (" ++ show t1
+                ++ ") to be earlier than file mtime (" ++ show t2 ++ ")")
+      (t1 < t2)

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-module UnitTests.Distribution.Client.Dependency.Modular.Solver (tests, options) where
+module UnitTests.Distribution.Client.Dependency.Modular.Solver (tests)
+       where
 
 -- base
 import Control.Monad
 import Data.Maybe (isNothing)
-import Data.Proxy
-import Data.Typeable
 
 import qualified Data.Version         as V
 import qualified Distribution.Version as V
@@ -14,13 +12,14 @@ import qualified Distribution.Version as V
 -- test-framework
 import Test.Tasty as TF
 import Test.Tasty.HUnit (testCase, assertEqual, assertBool)
-import Test.Tasty.Options
 
 -- Cabal
-import Language.Haskell.Extension (Extension(..), KnownExtension(..), Language(..))
+import Language.Haskell.Extension ( Extension(..)
+                                  , KnownExtension(..), Language(..))
 
 -- cabal-install
 import UnitTests.Distribution.Client.Dependency.Modular.DSL
+import UnitTests.Options
 
 tests :: [TF.TestTree]
 tests = [
@@ -493,22 +492,3 @@ dbBuildable2 = [
         ]
   , Right $ exAv "B" 3 [ExAny "unknown"]
   ]
-
-{-------------------------------------------------------------------------------
-  Test options
--------------------------------------------------------------------------------}
-
-options :: [OptionDescription]
-options = [
-    Option (Proxy :: Proxy OptionShowSolverLog)
-  ]
-
-newtype OptionShowSolverLog = OptionShowSolverLog Bool
-  deriving Typeable
-
-instance IsOption OptionShowSolverLog where
-  defaultValue   = OptionShowSolverLog False
-  parseValue     = fmap OptionShowSolverLog . safeRead
-  optionName     = return "show-solver-log"
-  optionHelp     = return "Show full log from the solver"
-  optionCLParser = flagCLParser Nothing (OptionShowSolverLog True)

--- a/cabal-install/tests/UnitTests/Distribution/Client/Sandbox/Timestamp.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Sandbox/Timestamp.hs
@@ -1,0 +1,63 @@
+module UnitTests.Distribution.Client.Sandbox.Timestamp (tests) where
+
+import System.FilePath
+
+import Distribution.Simple.Utils (withTempDirectory)
+import Distribution.Verbosity
+
+import Distribution.Client.Compat.Time
+import Distribution.Client.Sandbox.Timestamp
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: [TestTree]
+tests =
+  [ testCase "timestamp record version 1 can be read" timestampReadTest_v1
+  , testCase "timestamp record version 2 can be read" timestampReadTest_v2
+  , testCase "written timestamp record can be read"   timestampReadWriteTest ]
+
+timestampRecord_v1 :: String
+timestampRecord_v1 =
+  "[(\"i386-linux-ghc-8.0.0.20160204\",[(\"/foo/bar/Baz\",1455350946)])" ++
+  ",(\"i386-linux-ghc-7.10.3\",[(\"/foo/bar/Baz\",1455484719)])]\n"
+
+timestampRecord_v2 :: String
+timestampRecord_v2 =
+  "2\n" ++
+  "[(\"i386-linux-ghc-8.0.0.20160204\",[(\"/foo/bar/Baz\",1455350946)])" ++
+  ",(\"i386-linux-ghc-7.10.3\",[(\"/foo/bar/Baz\",1455484719)])]"
+
+timestampReadTest_v1 :: Assertion
+timestampReadTest_v1 =
+  timestampReadTest timestampRecord_v1 $
+  map (\(i, ts) ->
+        (i, map (\(p, ModTime t) ->
+                  (p, posixSecondsToModTime . fromIntegral $ t)) ts))
+  timestampRecord
+
+timestampReadTest_v2 :: Assertion
+timestampReadTest_v2 = timestampReadTest timestampRecord_v2 timestampRecord
+
+timestampReadTest :: FilePath -> [TimestampFileRecord] -> Assertion
+timestampReadTest fileContent expected =
+  withTempDirectory silent "." "cabal-timestamp-" $ \dir -> do
+    let fileName = dir </> "timestamp-record"
+    writeFile fileName fileContent
+    tRec <- readTimestampFile fileName
+    assertEqual "expected timestamp records to be equal"
+      expected tRec
+
+timestampRecord :: [TimestampFileRecord]
+timestampRecord =
+  [("i386-linux-ghc-8.0.0.20160204",[("/foo/bar/Baz",ModTime 1455350946)])
+  ,("i386-linux-ghc-7.10.3",[("/foo/bar/Baz",ModTime 1455484719)])]
+
+timestampReadWriteTest :: Assertion
+timestampReadWriteTest =
+  withTempDirectory silent "." "cabal-timestamp-" $ \dir -> do
+    let fileName = dir </> "timestamp-record"
+    writeTimestampFile fileName timestampRecord
+    tRec <- readTimestampFile fileName
+    assertEqual "expected timestamp records to be equal"
+      timestampRecord tRec

--- a/cabal-install/tests/UnitTests/Options.hs
+++ b/cabal-install/tests/UnitTests/Options.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module UnitTests.Options ( OptionShowSolverLog(..)
+                         , OptionMtimeChangeDelay(..)
+                         , extraOptions )
+       where
+
+import Data.Proxy
+import Data.Typeable
+
+import Test.Tasty.Options
+
+{-------------------------------------------------------------------------------
+  Test options
+-------------------------------------------------------------------------------}
+
+extraOptions :: [OptionDescription]
+extraOptions =
+  [ Option (Proxy :: Proxy OptionShowSolverLog)
+  , Option (Proxy :: Proxy OptionMtimeChangeDelay)
+  ]
+
+newtype OptionShowSolverLog = OptionShowSolverLog Bool
+  deriving Typeable
+
+instance IsOption OptionShowSolverLog where
+  defaultValue   = OptionShowSolverLog False
+  parseValue     = fmap OptionShowSolverLog . safeRead
+  optionName     = return "show-solver-log"
+  optionHelp     = return "Show full log from the solver"
+  optionCLParser = flagCLParser Nothing (OptionShowSolverLog True)
+
+newtype OptionMtimeChangeDelay = OptionMtimeChangeDelay Int
+  deriving Typeable
+
+instance IsOption OptionMtimeChangeDelay where
+  defaultValue   = OptionMtimeChangeDelay 0
+  parseValue     = fmap OptionMtimeChangeDelay . safeRead
+  optionName     = return "mtime-change-delay"
+  optionHelp     = return $ "How long to wait before attempting to detect"
+                   ++ "file modification, in microseconds"


### PR DESCRIPTION
Two changes:

  * `getModTime` now uses `modificationTimeHiRes` instead of `modificationTime`
    on Unix when the former is available.

  * `ModTime` is now represented as a 64-bit unsigned integer in Windows UTC
    format (that is, 100 ns resolution and day zero is 1601-01-01) on all
    platforms. Previously we used POSIX seconds, which was wrong (low
    resolution). Sandbox timestamp files in old format are now up-converted on
    the fly.

Fixes #3132.