### PR TITLE
Add field for setting MacOS framework search path (fixes #182).

### DIFF
--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -812,6 +812,7 @@ data BuildInfo = BuildInfo {
         ldOptions         :: [String],  -- ^ options for linker
         pkgconfigDepends  :: [Dependency], -- ^ pkg-config packages that are used
         frameworks        :: [String], -- ^support frameworks for Mac OS X
+        frameworkDirs     :: [String],
         cSources          :: [FilePath],
         jsSources         :: [FilePath],
         hsSourceDirs      :: [FilePath], -- ^ where to look for the Haskell module hierarchy
@@ -851,6 +852,7 @@ instance Monoid BuildInfo where
     ldOptions         = [],
     pkgconfigDepends  = [],
     frameworks        = [],
+    frameworkDirs     = [],
     cSources          = [],
     jsSources         = [],
     hsSourceDirs      = [],
@@ -884,6 +886,7 @@ instance Semigroup BuildInfo where
     ldOptions         = combine    ldOptions,
     pkgconfigDepends  = combine    pkgconfigDepends,
     frameworks        = combineNub frameworks,
+    frameworkDirs     = combineNub frameworkDirs,
     cSources          = combineNub cSources,
     jsSources         = combineNub jsSources,
     hsSourceDirs      = combineNub hsSourceDirs,

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -405,6 +405,9 @@ binfoFieldDescrs =
  , listField "frameworks"
            showToken          parseTokenQ
            frameworks         (\val binfo -> binfo{frameworks=val})
+ , listField "framework-dirs"
+           showToken          parseFilePathQ
+           frameworkDirs      (\val binfo -> binfo{frameworkDirs=val})
  , listFieldWithSep vcat "c-sources"
            showFilePath       parseFilePathQ
            cSources           (\paths binfo -> binfo{cSources=paths})

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -546,10 +546,13 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
                       ghcOptHPCDir      = hpcdir Hpc.Dyn
                     }
       linkerOpts = mempty {
-                      ghcOptLinkOptions    = toNubListR $ PD.ldOptions libBi,
-                      ghcOptLinkLibs       = toNubListR $ extraLibs libBi,
-                      ghcOptLinkLibPath    = toNubListR $ extraLibDirs libBi,
-                      ghcOptLinkFrameworks = toNubListR $ PD.frameworks libBi,
+                      ghcOptLinkOptions       = toNubListR $ PD.ldOptions libBi,
+                      ghcOptLinkLibs          = toNubListR $ extraLibs libBi,
+                      ghcOptLinkLibPath       = toNubListR $ extraLibDirs libBi,
+                      ghcOptLinkFrameworks    = toNubListR $
+                                                PD.frameworks libBi,
+                      ghcOptLinkFrameworkDirs = toNubListR $
+                                                PD.frameworkDirs libBi,
                       ghcOptInputFiles     = toNubListR
                                              [libTargetDir </> x | x <- cObjs]
                    }
@@ -722,6 +725,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
                 ghcOptLinkLibs           = toNubListR $ extraLibs libBi,
                 ghcOptLinkLibPath        = toNubListR $ extraLibDirs libBi,
                 ghcOptLinkFrameworks     = toNubListR $ PD.frameworks libBi,
+                ghcOptLinkFrameworkDirs  = toNubListR $ PD.frameworkDirs libBi,
                 ghcOptRPaths             = rpaths
               }
 
@@ -844,10 +848,13 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
                       ghcOptHPCDir         = hpcdir Hpc.Dyn
                     }
       linkerOpts = mempty {
-                      ghcOptLinkOptions    = toNubListR $ PD.ldOptions exeBi,
-                      ghcOptLinkLibs       = toNubListR $ extraLibs exeBi,
-                      ghcOptLinkLibPath    = toNubListR $ extraLibDirs exeBi,
-                      ghcOptLinkFrameworks = toNubListR $ PD.frameworks exeBi,
+                      ghcOptLinkOptions       = toNubListR $ PD.ldOptions exeBi,
+                      ghcOptLinkLibs          = toNubListR $ extraLibs exeBi,
+                      ghcOptLinkLibPath       = toNubListR $ extraLibDirs exeBi,
+                      ghcOptLinkFrameworks    = toNubListR $
+                                                PD.frameworks exeBi,
+                      ghcOptLinkFrameworkDirs = toNubListR $
+                                                PD.frameworkDirs exeBi,
                       ghcOptInputFiles     = toNubListR
                                              [exeDir </> x | x <- cObjs]
                     }

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -107,6 +107,10 @@ data GhcOptions = GhcOptions {
   -- | OSX only: frameworks to link in; the @ghc -framework@ flag.
   ghcOptLinkFrameworks :: NubListR String,
 
+  -- | OSX only: Search path for frameworks to link in; the
+  -- @ghc -framework-path@ flag.
+  ghcOptLinkFrameworkDirs :: NubListR String,
+
   -- | Don't do the link step, useful in make mode; the @ghc -no-link@ flag.
   ghcOptNoLink :: Flag Bool,
 
@@ -363,6 +367,7 @@ renderGhcOptions comp opts
   , ["-l" ++ lib     | lib <- flags ghcOptLinkLibs ]
   , ["-L" ++ dir     | dir <- flags ghcOptLinkLibPath ]
   , concat [ ["-framework", fmwk] | fmwk <- flags ghcOptLinkFrameworks ]
+  , concat [ ["-framework-path", path] | path <- flags ghcOptLinkFrameworkDirs ]
   , [ "-no-hs-main"  | flagBool ghcOptLinkNoHsMain ]
   , [ "-dynload deploy" | not (null (flags ghcOptRPaths)) ]
   , concat [ [ "-optl-Wl,-rpath," ++ dir]
@@ -500,6 +505,7 @@ instance Monoid GhcOptions where
     ghcOptLinkLibPath        = mempty,
     ghcOptLinkOptions        = mempty,
     ghcOptLinkFrameworks     = mempty,
+    ghcOptLinkFrameworkDirs  = mempty,
     ghcOptNoLink             = mempty,
     ghcOptLinkNoHsMain       = mempty,
     ghcOptCcOptions          = mempty,
@@ -556,6 +562,7 @@ instance Semigroup GhcOptions where
     ghcOptLinkLibPath        = combine ghcOptLinkLibPath,
     ghcOptLinkOptions        = combine ghcOptLinkOptions,
     ghcOptLinkFrameworks     = combine ghcOptLinkFrameworks,
+    ghcOptLinkFrameworkDirs  = combine ghcOptLinkFrameworkDirs,
     ghcOptNoLink             = combine ghcOptNoLink,
     ghcOptLinkNoHsMain       = combine ghcOptLinkNoHsMain,
     ghcOptCcOptions          = combine ghcOptCcOptions,

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -339,7 +339,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
                                  -- We don't want cc-options to be propagated
                                  -- to C compilations in other packages.
     IPI.ldOptions          = ldOptions bi,
-    IPI.frameworkDirs      = [],
+    IPI.frameworkDirs      = frameworkDirs bi,
     IPI.frameworks         = frameworks bi,
     IPI.haddockInterfaces  = [haddockdir installDirs </> haddockName pkg],
     IPI.haddockHTMLs       = [htmldir installDirs],

--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -1464,6 +1464,10 @@ values for these fields.
     developer documentation for more details on frameworks.  This entry
     is ignored on all other platforms.
 
+`frameworks-dirs:` _directory list_
+:   On Darwin/MacOS X, a list of directories to search for frameworks.
+    This entry is ignored on all other platforms.
+
 ### Configurations ###
 
 Library and executable sections may include conditional


### PR DESCRIPTION
This adds a new field for specifying the framework search path on MacOS akin to include-dirs and extra-lib-dirs. It translates into specifying the -framework-path option on the GHC command line. The name was chosen to match the pre-existing field in InstalledPackageInfo.