### PR TITLE
Run cabal-install unit tests on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,4 +21,4 @@ build_script:
   - echo "" | cabal install --only-dependencies --enable-tests --force-reinstalls
   - Setup configure --user --ghc-option=-Werror --enable-tests
   - Setup build
-  # - Setup test unit-tests --show-details=streaming
+  - Setup test unit-tests --show-details=streaming --test-option=--pattern=!FileMonitor


### PR DESCRIPTION
I excluded the FileMonitor tests because of exceptions from `removeDirectoryRecursive` (https://github.com/haskell/cabal/issues/3126#issuecomment-184080769).

I also wanted to enable the integration tests, but I couldn't figure out how to exclude more than one group of tests.  `tasty` doesn't support multiple filters: https://github.com/feuerbach/tasty/issues/38.