### PR TITLE
Improvements to '--allow-newer'

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -32,6 +32,10 @@ extra-source-files:
   -- Generated with 'misc/gen-extra-source-files.sh'
   -- Do NOT edit this section manually; instead, run the script.
   -- BEGIN gen-extra-source-files
+  tests/PackageTests/AllowNewer/AllowNewer.cabal
+  tests/PackageTests/AllowNewer/benchmarks/Bench.hs
+  tests/PackageTests/AllowNewer/src/Foo.hs
+  tests/PackageTests/AllowNewer/tests/Test.hs
   tests/PackageTests/BenchmarkExeV10/Foo.hs
   tests/PackageTests/BenchmarkExeV10/benchmarks/bench-Foo.hs
   tests/PackageTests/BenchmarkExeV10/my.cabal

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -19,6 +19,8 @@
 	  work-around for #2398)
 	* Library support for multi-instance package DBs (#2948).
 	* Improved the './Setup configure' solver (#3082, #3076).
+	* The '--allow-newer' option can be now used with './Setup
+	configure' (#3163).
 
 1.22.0.0 Johan Tibell <johan.tibell@gmail.com> January 2015
 	* Support GHC 7.10.

--- a/Cabal/tests/PackageTests/AllowNewer/AllowNewer.cabal
+++ b/Cabal/tests/PackageTests/AllowNewer/AllowNewer.cabal
@@ -1,0 +1,25 @@
+name:                AllowNewer
+version:             0.1.0.0
+license:             BSD3
+author:              Foo Bar
+maintainer:          cabal-dev@haskell.org
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  exposed-modules:     Foo
+  hs-source-dirs:      src
+  build-depends:       base < 1
+  default-language:    Haskell2010
+
+test-suite foo-test
+  type: exitcode-stdio-1.0
+  main-is:             Test.hs
+  hs-source-dirs:      tests
+  build-depends:       base < 1
+
+benchmark foo-bench
+  type: exitcode-stdio-1.0
+  main-is:             Bench.hs
+  hs-source-dirs:      benchmarks
+  build-depends:       base < 1

--- a/Cabal/tests/PackageTests/AllowNewer/benchmarks/Bench.hs
+++ b/Cabal/tests/PackageTests/AllowNewer/benchmarks/Bench.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = return ()

--- a/Cabal/tests/PackageTests/AllowNewer/src/Foo.hs
+++ b/Cabal/tests/PackageTests/AllowNewer/src/Foo.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = return ()

--- a/Cabal/tests/PackageTests/AllowNewer/tests/Test.hs
+++ b/Cabal/tests/PackageTests/AllowNewer/tests/Test.hs
@@ -1,0 +1,4 @@
+!module Main where
+
+main :: IO ()
+main = return ()

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -227,6 +227,8 @@ nonSharedLibTests config =
         cabal "configure" ["--allow-newer"]
         shouldFail $ cabal "configure" ["--allow-newer=baz,quux"]
         cabal "configure" ["--allow-newer=base", "--allow-newer=baz,quux"]
+        cabal "configure" ["--allow-newer=bar", "--allow-newer=base,baz"
+                          ,"--allow-newer=quux"]
         shouldFail $ cabal "configure" ["--enable-tests"]
         cabal "configure" ["--enable-tests", "--allow-newer"]
         shouldFail $ cabal "configure" ["--enable-benchmarks"]

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -221,6 +221,20 @@ nonSharedLibTests config =
             cabal_build ["--enable-tests"]
             cabal "test" []
 
+  -- Test that '--allow-newer' works via the 'Setup.hs configure' interface.
+  , tc "AllowNewer" $ do
+        shouldFail $ cabal "configure" []
+        cabal "configure" ["--allow-newer"]
+        shouldFail $ cabal "configure" ["--allow-newer=baz,quux"]
+        cabal "configure" ["--allow-newer=base", "--allow-newer=baz,quux"]
+        shouldFail $ cabal "configure" ["--enable-tests"]
+        cabal "configure" ["--enable-tests", "--allow-newer"]
+        shouldFail $ cabal "configure" ["--enable-benchmarks"]
+        cabal "configure" ["--enable-benchmarks", "--allow-newer"]
+        shouldFail $ cabal "configure" ["--enable-benchmarks", "--enable-tests"]
+        cabal "configure" ["--enable-benchmarks", "--enable-tests"
+                          ,"--allow-newer"]
+
   -- Test that Cabal can choose flags to disable building a component when that
   -- component's dependencies are unavailable. The build should succeed without
   -- requiring the component's dependencies or imports.

--- a/HACKING.md
+++ b/HACKING.md
@@ -70,7 +70,7 @@ To build and test the `Cabal` library, do:
     we cannot use `cabal` for the next steps;
     we need to use Setup instead.
     So, compile Setup.hs:
-    
+
     ~~~~
     ghc --make -threaded Setup.hs
     ~~~~
@@ -89,7 +89,7 @@ To build and test the `Cabal` library, do:
     ~~~~
     ~/MyHaskellCode/cabal/Cabal/.cabal-sandbox/$SOMESTUFF-packages.conf.d
     ~~~~
-    
+
     (or, as a relative path with my setup:)
 
     ~~~~

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -324,7 +324,8 @@ instance Semigroup SavedConfig where
         configLibCoverage         = combine configLibCoverage,
         configExactConfiguration  = combine configExactConfiguration,
         configFlagError           = combine configFlagError,
-        configRelocatable         = combine configRelocatable
+        configRelocatable         = combine configRelocatable,
+        configAllowNewer          = combine configAllowNewer
         }
         where
           combine        = combine'        savedConfigureFlags
@@ -337,8 +338,7 @@ instance Semigroup SavedConfig where
         configExConstraints = lastNonEmpty configExConstraints,
         -- TODO: NubListify
         configPreferences   = lastNonEmpty configPreferences,
-        configSolver        = combine configSolver,
-        configAllowNewer    = combine configAllowNewer
+        configSolver        = combine configSolver
         }
         where
           combine      = combine' savedConfigureExFlags

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -204,6 +204,11 @@ instance Semigroup SavedConfig where
       combine'        field subfield =
         (subfield . field $ a) `mappend` (subfield . field $ b)
 
+      combineMonoid :: Monoid mon => (SavedConfig -> flags) -> (flags -> mon)
+                    -> mon
+      combineMonoid field subfield =
+        (subfield . field $ a) `mappend` (subfield . field $ b)
+
       lastNonEmpty' :: (SavedConfig -> flags) -> (flags -> [a]) -> [a]
       lastNonEmpty'   field subfield =
         let a' = subfield . field $ a
@@ -325,7 +330,8 @@ instance Semigroup SavedConfig where
         configExactConfiguration  = combine configExactConfiguration,
         configFlagError           = combine configFlagError,
         configRelocatable         = combine configRelocatable,
-        configAllowNewer          = combine configAllowNewer
+        configAllowNewer          = combineMonoid savedConfigureFlags
+                                    configAllowNewer
         }
         where
           combine        = combine'        savedConfigureFlags

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -20,7 +20,7 @@ module Distribution.Client.Configure (
 
 import Distribution.Client.Dependency
 import Distribution.Client.Dependency.Types
-         ( AllowNewer(..), isAllowNewer, ConstraintSource(..)
+         ( ConstraintSource(..)
          , LabeledPackageConstraint(..), showConstraintSource )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.InstallPlan (InstallPlan)
@@ -62,6 +62,8 @@ import Distribution.Version
          ( anyVersion, thisVersion )
 import Distribution.Simple.Utils as Utils
          ( warn, notice, info, debug, die )
+import Distribution.Simple.Setup
+         ( AllowNewer(..), isAllowNewer )
 import Distribution.System
          ( Platform )
 import Distribution.Text ( display )
@@ -78,14 +80,14 @@ import Data.Maybe (isJust, fromMaybe)
 
 -- | Choose the Cabal version such that the setup scripts compiled against this
 -- version will support the given command-line flags.
-chooseCabalVersion :: ConfigExFlags -> Maybe Version -> VersionRange
-chooseCabalVersion configExFlags maybeVersion =
+chooseCabalVersion :: ConfigFlags -> Maybe Version -> VersionRange
+chooseCabalVersion configFlags maybeVersion =
   maybe defaultVersionRange thisVersion maybeVersion
   where
     -- Cabal < 1.19.2 doesn't support '--exact-configuration' which is needed
     -- for '--allow-newer' to work.
     allowNewer = fromFlagOrDefault False $
-                 fmap isAllowNewer (configAllowNewer configExFlags)
+                 fmap isAllowNewer (configAllowNewer configFlags)
 
     defaultVersionRange = if allowNewer
                           then orLaterVersion (Version [1,19,2] [])
@@ -152,7 +154,7 @@ configure verbosity packageDBs repoCtxt comp platform conf
            (useDistPref defaultSetupScriptOptions)
            (configDistPref configFlags))
         (chooseCabalVersion
-           configExFlags
+           configFlags
            (flagToMaybe (configCabalVersion configExFlags)))
         Nothing
         False
@@ -288,7 +290,7 @@ planLocalPackage verbosity comp platform configFlags configExFlags
 
       resolverParams =
           removeUpperBounds (fromFlagOrDefault AllowNewerNone $
-                             configAllowNewer configExFlags)
+                             configAllowNewer configFlags)
 
         . addPreferences
             -- preferences from the config file or command line

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -63,7 +63,7 @@ import Distribution.Version
 import Distribution.Simple.Utils as Utils
          ( warn, notice, info, debug, die )
 import Distribution.Simple.Setup
-         ( AllowNewer(..), isAllowNewer )
+         ( isAllowNewer )
 import Distribution.System
          ( Platform )
 import Distribution.Text ( display )
@@ -86,8 +86,7 @@ chooseCabalVersion configFlags maybeVersion =
   where
     -- Cabal < 1.19.2 doesn't support '--exact-configuration' which is needed
     -- for '--allow-newer' to work.
-    allowNewer = fromFlagOrDefault False $
-                 fmap isAllowNewer (configAllowNewer configFlags)
+    allowNewer = isAllowNewer (configAllowNewer configFlags)
 
     defaultVersionRange = if allowNewer
                           then orLaterVersion (Version [1,19,2] [])
@@ -289,8 +288,7 @@ planLocalPackage verbosity comp platform configFlags configExFlags
         fromFlagOrDefault False $ configBenchmarks configFlags
 
       resolverParams =
-          removeUpperBounds (fromFlagOrDefault AllowNewerNone $
-                             configAllowNewer configFlags)
+          removeUpperBounds (configAllowNewer configFlags)
 
         . addPreferences
             -- preferences from the config file or command line

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -78,7 +78,7 @@ import Distribution.Client.Dependency.Types
          , PackageConstraint(..), showPackageConstraint
          , LabeledPackageConstraint(..), unlabelPackageConstraint
          , ConstraintSource(..), showConstraintSource
-         , AllowNewer(..), PackagePreferences(..), InstalledPreference(..)
+         , PackagePreferences(..), InstalledPreference(..)
          , PackagesPreferenceDefault(..)
          , Progress(..), foldProgress )
 import Distribution.Client.Sandbox.Types
@@ -110,6 +110,8 @@ import Distribution.Client.Utils
          ( duplicates, duplicatesBy, mergeBy, MergeResult(..) )
 import Distribution.Simple.Utils
          ( comparing, warn, info )
+import Distribution.Simple.Setup
+         ( AllowNewer(..) )
 import Distribution.Text
          ( display )
 import Distribution.Verbosity

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -19,7 +19,6 @@ module Distribution.Client.Dependency.Types (
     DependencyResolver,
     ResolverPackage(..),
 
-    AllowNewer(..), isAllowNewer,
     PackageConstraint(..),
     showPackageConstraint,
     PackagePreferences(..),
@@ -210,31 +209,6 @@ data PackagesPreferenceDefault =
      --
    | PreferLatestForSelected
   deriving Show
-
--- | Policy for relaxing upper bounds in dependencies. For example, given
--- 'build-depends: array >= 0.3 && < 0.5', are we allowed to relax the upper
--- bound and choose a version of 'array' that is greater or equal to 0.5? By
--- default the upper bounds are always strictly honored.
-data AllowNewer =
-
-  -- | Default: honor the upper bounds in all dependencies, never choose
-  -- versions newer than allowed.
-  AllowNewerNone
-
-  -- | Ignore upper bounds in dependencies on the given packages.
-  | AllowNewerSome [PackageName]
-
-  -- | Ignore upper bounds in dependencies on all packages.
-  | AllowNewerAll
-  deriving (Eq, Ord, Show, Generic)
-
-instance Binary AllowNewer
-
--- | Convert 'AllowNewer' to a boolean.
-isAllowNewer :: AllowNewer -> Bool
-isAllowNewer AllowNewerNone     = False
-isAllowNewer (AllowNewerSome _) = True
-isAllowNewer AllowNewerAll      = True
 
 -- | A type to represent the unfolding of an expensive long running
 -- calculation that may fail. We may get intermediate steps before the final

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -417,7 +417,7 @@ planPackages comp platform mSandboxPkgInfo solver
     maxBackjumps     = fromFlag (installMaxBackjumps      installFlags)
     upgradeDeps      = fromFlag (installUpgradeDeps       installFlags)
     onlyDeps         = fromFlag (installOnlyDeps          installFlags)
-    allowNewer       = fromFlag (configAllowNewer         configFlags)
+    allowNewer       = (configAllowNewer         configFlags)
 
 -- | Remove the provided targets from the install plan.
 pruneInstallPlan :: Package targetpkg

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -417,7 +417,7 @@ planPackages comp platform mSandboxPkgInfo solver
     maxBackjumps     = fromFlag (installMaxBackjumps      installFlags)
     upgradeDeps      = fromFlag (installUpgradeDeps       installFlags)
     onlyDeps         = fromFlag (installOnlyDeps          installFlags)
-    allowNewer       = fromFlag (configAllowNewer         configExFlags)
+    allowNewer       = fromFlag (configAllowNewer         configFlags)
 
 -- | Remove the provided targets from the install plan.
 pruneInstallPlan :: Package targetpkg
@@ -1092,7 +1092,7 @@ performInstallations verbosity
         platform
         conf
         distPref
-        (chooseCabalVersion configExFlags (libVersion miscOptions))
+        (chooseCabalVersion configFlags (libVersion miscOptions))
         (Just lock)
         parallelInstall
         index

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -370,7 +370,7 @@ filterConfigureFlags flags cabalLibVersion
       configConstraints = [],
       -- Passing '--allow-newer' to Setup.hs is unnecessary, we use
       -- '--exact-configuration' instead.
-      configAllowNewer  = NoFlag
+      configAllowNewer  = Cabal.AllowNewerNone
       }
 
     -- Cabal < 1.23 doesn't know about '--profiling-detail'.

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -58,7 +58,7 @@ import Distribution.Client.Types
 import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
 import Distribution.Client.Dependency.Types
-         ( AllowNewer(..), PreSolver(..), ConstraintSource(..) )
+         ( PreSolver(..), ConstraintSource(..) )
 import qualified Distribution.Client.Init.Types as IT
          ( InitFlags(..), PackageType(..) )
 import Distribution.Client.Targets
@@ -79,7 +79,8 @@ import Distribution.Simple.Setup
          , SDistFlags(..), HaddockFlags(..)
          , readPackageDbList, showPackageDbList
          , Flag(..), toFlag, flagToMaybe, flagToList
-         , optionVerbosity, boolOpt, boolOpt', trueArg, falseArg, optionNumJobs )
+         , optionVerbosity, boolOpt, boolOpt', trueArg, falseArg
+         , readPToMaybe, optionNumJobs )
 import Distribution.Simple.InstallDirs
          ( PathTemplate, InstallDirs(sysconfdir)
          , toPathTemplate, fromPathTemplate )
@@ -94,7 +95,7 @@ import Distribution.Text
 import Distribution.ReadE
          ( ReadE(..), readP_to_E, succeedReadE )
 import qualified Distribution.Compat.ReadP as Parse
-         ( ReadP, readP_to_S, readS_to_P, char, munch1, pfail, sepBy1, (+++) )
+         ( ReadP, readS_to_P, char, munch1, pfail,  (+++) )
 import Distribution.Compat.Semigroup
          ( Semigroup((<>)) )
 import Distribution.Verbosity
@@ -107,11 +108,11 @@ import Distribution.Client.GlobalFlags
          )
 
 import Data.Char
-         ( isSpace, isAlphaNum )
+         ( isAlphaNum )
 import Data.List
          ( intercalate, deleteFirstsBy )
 import Data.Maybe
-         ( listToMaybe, maybeToList, fromMaybe )
+         ( maybeToList, fromMaybe )
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid
          ( Monoid(..) )
@@ -364,8 +365,13 @@ filterConfigureFlags flags cabalLibVersion
   | cabalLibVersion <  Version [1,23,0] [] = flags_1_22_0
   | otherwise = flags_latest
   where
-    -- Cabal >= 1.19.1 uses '--dependency' and does not need '--constraint'.
-    flags_latest = flags        { configConstraints = [] }
+    flags_latest = flags        {
+      -- Cabal >= 1.19.1 uses '--dependency' and does not need '--constraint'.
+      configConstraints = [],
+      -- Passing '--allow-newer' to Setup.hs is unnecessary, we use
+      -- '--exact-configuration' instead.
+      configAllowNewer  = NoFlag
+      }
 
     -- Cabal < 1.23 doesn't know about '--profiling-detail'.
     flags_1_22_0 = flags_latest { configProfDetail    = NoFlag
@@ -418,14 +424,12 @@ data ConfigExFlags = ConfigExFlags {
     configCabalVersion :: Flag Version,
     configExConstraints:: [(UserConstraint, ConstraintSource)],
     configPreferences  :: [Dependency],
-    configSolver       :: Flag PreSolver,
-    configAllowNewer   :: Flag AllowNewer
+    configSolver       :: Flag PreSolver
   }
   deriving (Eq, Generic)
 
 defaultConfigExFlags :: ConfigExFlags
-defaultConfigExFlags = mempty { configSolver     = Flag defaultSolver
-                              , configAllowNewer = Flag AllowNewerNone }
+defaultConfigExFlags = mempty { configSolver     = Flag defaultSolver }
 
 configureExCommand :: CommandUI (ConfigFlags, ConfigExFlags)
 configureExCommand = configureCommand {
@@ -469,23 +473,14 @@ configureExOptions _showOrParseArgs src =
 
   , optionSolver configSolver (\v flags -> flags { configSolver = v })
 
-  , option [] ["allow-newer"]
-    ("Ignore upper bounds in all dependencies or " ++ allowNewerArgument)
-    configAllowNewer (\v flags -> flags { configAllowNewer = v})
-    (optArg allowNewerArgument
-     (fmap Flag allowNewerParser) (Flag AllowNewerAll)
-     allowNewerPrinter)
-
   ]
-  where allowNewerArgument = "DEPS"
 
 instance Monoid ConfigExFlags where
   mempty = ConfigExFlags {
     configCabalVersion = mempty,
     configExConstraints= mempty,
     configPreferences  = mempty,
-    configSolver       = mempty,
-    configAllowNewer   = mempty
+    configSolver       = mempty
   }
   mappend = (<>)
 
@@ -494,8 +489,7 @@ instance Semigroup ConfigExFlags where
     configCabalVersion = combine configCabalVersion,
     configExConstraints= combine configExConstraints,
     configPreferences  = combine configPreferences,
-    configSolver       = combine configSolver,
-    configAllowNewer   = combine configAllowNewer
+    configSolver       = combine configSolver
   }
     where combine field = field a `mappend` field b
 
@@ -1241,27 +1235,6 @@ defaultInstallFlags = InstallFlags {
   where
     docIndexFile = toPathTemplate ("$datadir" </> "doc"
                                    </> "$arch-$os-$compiler" </> "index.html")
-
-allowNewerParser :: ReadE AllowNewer
-allowNewerParser = ReadE $ \s ->
-  case s of
-    ""      -> Right AllowNewerNone
-    "False" -> Right AllowNewerNone
-    "True"  -> Right AllowNewerAll
-    _       ->
-      case readPToMaybe pkgsParser s of
-        Just pkgs -> Right . AllowNewerSome $ pkgs
-        Nothing   -> Left ("Cannot parse the list of packages: " ++ s)
-  where
-    pkgsParser = Parse.sepBy1 parse (Parse.char ',')
-
-allowNewerPrinter :: Flag AllowNewer -> [Maybe String]
-allowNewerPrinter (Flag AllowNewerNone)        = [Just "False"]
-allowNewerPrinter (Flag AllowNewerAll)         = [Just "True"]
-allowNewerPrinter (Flag (AllowNewerSome pkgs)) =
-  [Just . intercalate "," . map display $ pkgs]
-allowNewerPrinter NoFlag                       = []
-
 
 defaultMaxBackjumps :: Int
 defaultMaxBackjumps = 2000
@@ -2289,10 +2262,6 @@ parsePackageArgs = parsePkgArgs []
         Nothing  -> Left $
          show arg ++ " is not valid syntax for a package name or"
                   ++ " package dependency."
-
-readPToMaybe :: Parse.ReadP a a -> String -> Maybe a
-readPToMaybe p str = listToMaybe [ r | (r,s) <- Parse.readP_to_S p str
-                                     , all isSpace s ]
 
 parseDependencyOrPackageId :: Parse.ReadP r Dependency
 parseDependencyOrPackageId = parse Parse.+++ liftM pkgidToDependency parse

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -42,6 +42,8 @@
 	default location or as specified by --config-file (#2553).
 	* The man page for 'cabal-install' is now automatically generated
 	(#2877).
+	* The '--allow-newer' option now works as expected when specified
+	multiple times (#2588).
 
 1.22.0.0 Johan Tibell <johan.tibell@gmail.com> January 2015
 	* New command: user-config (#2159).

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
@@ -66,7 +66,7 @@ import qualified Distribution.Client.ComponentDeps as CD
   * The difference between `GenericPackageDescription` and `PackageDescription`
     is that `PackageDescription` describes a particular _configuration_ of a
     package (for instance, see documentation for `checkPackage`). A
-    `GenericPackageDescription` can be returned into a `PackageDescription` in
+    `GenericPackageDescription` can be turned into a `PackageDescription` in
     two ways:
 
       a. `finalizePackageDescription` does the proper translation, by taking


### PR DESCRIPTION
Two improvements:

* `--allow-newer=foo --allow-newer=bar` now works as expected (equivalent to `--allow-newer=foo,bar`). Fixes #2588.
* `./Setup configure --allow-newer[=foo[,bar]]` now works. Fixes #3163.