### PR TITLE
Make secure remote repos a bit more discoverable.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -978,7 +978,9 @@ installDirsFields = map viewAsFieldDescr installDirsOptions
 
 ppRemoteRepoSection :: RemoteRepo -> Doc
 ppRemoteRepoSection vals = ppSection "repository" (remoteRepoName vals)
-        remoteRepoFields Nothing vals
+        remoteRepoFields def vals
+  where
+    def = Just (emptyRemoteRepo "ignored") { remoteRepoSecure = Just False }
 
 remoteRepoFields :: [FieldDescr RemoteRepo]
 remoteRepoFields =


### PR DESCRIPTION
Before this change, the relevant section of the default config file looked like this:
```
repository hackage.haskell.org
  url: http://hackage.haskell.org/
```
With this change, it looks like this:
```
repository hackage.haskell.org
  url: http://hackage.haskell.org/
  -- secure: False
  -- root-keys:
  -- key-threshold:
```

/cc @edsko @dcoutts 