### PR TITLE
Skip Cabal package tests that cannot run in the current environment

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -119,6 +119,7 @@ extra-source-files:
   tests/PackageTests/HaddockNewline/A.hs
   tests/PackageTests/HaddockNewline/HaddockNewline.cabal
   tests/PackageTests/HaddockNewline/Setup.hs
+  tests/PackageTests/Options.hs
   tests/PackageTests/OrderFlags/Foo.hs
   tests/PackageTests/OrderFlags/my.cabal
   tests/PackageTests/PathsModule/Executable/Main.hs

--- a/Cabal/tests/PackageTests.hs
+++ b/Cabal/tests/PackageTests.hs
@@ -180,7 +180,8 @@ main = do
     putStrLn $ "Building shared ./Setup executable"
     rawCompileSetup verbosity suite [] "tests"
 
-    defaultMain $ testGroup "Package Tests" (tests suite)
+    defaultMain $
+        runTestTree "Package Tests" (tests suite)
 
 -- Reverse of 'interpretPackageDbFlags'.
 -- prop_idem stk b

--- a/Cabal/tests/PackageTests/Options.hs
+++ b/Cabal/tests/PackageTests/Options.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module PackageTests.Options
+    ( OptionEnableAllTests(..)
+    ) where
+
+import Data.Typeable (Typeable)
+
+import Test.Tasty.Options (IsOption(..), flagCLParser, safeRead)
+
+newtype OptionEnableAllTests = OptionEnableAllTests Bool
+  deriving Typeable
+
+instance IsOption OptionEnableAllTests where
+  defaultValue   = OptionEnableAllTests False
+  parseValue     = fmap OptionEnableAllTests . safeRead
+  optionName     = return "enable-all-tests"
+  optionHelp     = return "Enable all tests"
+  optionCLParser = flagCLParser Nothing (OptionEnableAllTests True)

--- a/Cabal/tests/PackageTests/TestSuiteTests/ExeV10/Check.hs
+++ b/Cabal/tests/PackageTests/TestSuiteTests/ExeV10/Check.hs
@@ -85,7 +85,8 @@ hpcTestMatrix config = forM_ (choose4 [True, False]) $
               | otherwise = Nothing
     -- Ensure that both .tix file and markup are generated if coverage
     -- is enabled.
-    tc name ("WithHpc-" ++ name) $ do
+    testUnless ((exeDyn || shared) && not (hasSharedLibraries config)) $
+      tc name ("WithHpc-" ++ name) $ do
         isCorrectVersion <- liftIO $ correctHpcVersion
         when isCorrectVersion $ do
             dist_dir <- distDir

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -153,7 +153,8 @@ tests config = do
 
   -- Test building a dynamic library/executable which uses Template
   -- Haskell
-  tc "TemplateHaskell/dynamic" $ cabal_build ["--enable-shared", "--enable-executable-dynamic"]
+  testWhen (hasSharedLibraries config) $
+    tc "TemplateHaskell/dynamic" $ cabal_build ["--enable-shared", "--enable-executable-dynamic"]
 
   -- Test building an executable whose main() function is defined in a C
   -- file
@@ -252,14 +253,16 @@ tests config = do
       assertOutputContains "Flags chosen: build-exe=False" r
       cabal "build" []
 
-  tc "GhcPkgGuess/SameDirectory" $ ghc_pkg_guess "ghc"
-  tc "GhcPkgGuess/SameDirectoryVersion" $ ghc_pkg_guess "ghc-7.10"
-  tc "GhcPkgGuess/SameDirectoryGhcVersion" $ ghc_pkg_guess "ghc-7.10"
+  -- TODO: Enable these tests on Windows
+  unlessWindows $ do
+      tc "GhcPkgGuess/SameDirectory" $ ghc_pkg_guess "ghc"
+      tc "GhcPkgGuess/SameDirectoryVersion" $ ghc_pkg_guess "ghc-7.10"
+      tc "GhcPkgGuess/SameDirectoryGhcVersion" $ ghc_pkg_guess "ghc-7.10"
 
-  -- TODO: Disable these tests on Windows
-  tc "GhcPkgGuess/Symlink" $ ghc_pkg_guess "ghc"
-  tc "GhcPkgGuess/SymlinkVersion" $ ghc_pkg_guess "ghc"
-  tc "GhcPkgGuess/SymlinkGhcVersion" $ ghc_pkg_guess "ghc"
+  unlessWindows $ do
+      tc "GhcPkgGuess/Symlink" $ ghc_pkg_guess "ghc"
+      tc "GhcPkgGuess/SymlinkVersion" $ ghc_pkg_guess "ghc"
+      tc "GhcPkgGuess/SymlinkGhcVersion" $ ghc_pkg_guess "ghc"
 
   where
     ghc_pkg_guess bin_name = do

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ build_script:
   - Setup configure --user --ghc-option=-Werror --enable-tests
   - Setup build
   - Setup test unit-tests --show-details=streaming
-  # - Setup test package-tests --show-details=streaming
+  - Setup test package-tests --show-details=streaming
   - Setup install
   - cd ..\cabal-install
   - ghc --make -threaded -i -i. Setup.hs -Wall -Werror

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ build_script:
   - Setup configure --user --ghc-option=-Werror --enable-tests
   - Setup build
   - Setup test unit-tests --show-details=streaming
-  - Setup test package-tests --show-details=streaming --test-option=--skip-shared-library-tests --test-option=--pattern=!GhcPkgGuess
+  # - Setup test package-tests --show-details=streaming
   - Setup install
   - cd ..\cabal-install
   - ghc --make -threaded -i -i. Setup.hs -Wall -Werror


### PR DESCRIPTION
There are three commits:

##### Revert "Add flag to disable Cabal package tests that use shared libraries"
#3146 wasn't flexible enough to allow different tests to be skipped for different reasons.

##### Use a writer monad to define Cabal package tests
This commit addresses a TODO comment and allows tests to be filtered and grouped more easily.

##### Skip Cabal package tests that cannot run in the current environment
The functions `testWhen` and `testUnless` filter tests in the `TestTreeM` monad. The option `--enable-all-tests` ignores filtering.  This commit also applies filtering to the existing package tests that cannot run on Windows.

The test suite chooses whether to disable tests that use shared libraries by checking `D.System.buildOS` and the version of GHC used for `--with-ghc`.  Is that correct?

/cc @ezyang 