### PR TITLE
Warn when 'cabal configure' cannot resolve dependencies.

### DIFF
--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -62,7 +62,7 @@ import Distribution.PackageDescription.Configuration
 import Distribution.Version
          ( anyVersion, thisVersion )
 import Distribution.Simple.Utils as Utils
-         ( warn, notice, info, debug, die )
+         ( warn, notice, debug, die )
 import Distribution.Simple.Setup
          ( isAllowNewer )
 import Distribution.System
@@ -121,8 +121,8 @@ configure verbosity packageDBs repoCtxt comp platform conf
                             progress
   case maybePlan of
     Left message -> do
-      info verbosity $
-           "Warning: solver failed to find a solution:\n"
+      warn verbosity $
+           "solver failed to find a solution:\n"
         ++ message
         ++ "Trying configure anyway."
       setupWrapper verbosity (setupScriptOptions installedPkgIndex Nothing)


### PR DESCRIPTION
See #2614.  This commit turns the info-level message into a warning.  Here is an example:

`package` requires a version of Cabal that is not available:

    custom-setup
      setup-depends: Cabal == 1.24.0.0

Before this commit:
```
$ cabal configure
Resolving dependencies...
[1 of 1] Compiling Main             ( dist/setup/setup.hs, dist/setup/Main.o )
Linking ./dist/setup/setup ...
Warning: package.cabal: Ignoring unknown section type: custom-setup
Configuring package-1.0...
```

After:
```
$ cabal configure
Resolving dependencies...
Warning: solver failed to find a solution:
Could not resolve dependencies:
trying: package-1.0 (user goal)
next goal: package-setup.Cabal (dependency of package-1.0)
rejecting: package-setup.Cabal-1.22.4.0/installed-43c... (conflict: package =>
package-setup.Cabal==1.24.0.0)
Dependency tree exhaustively searched.
Trying configure anyway.
[1 of 1] Compiling Main             ( dist/setup/setup.hs, dist/setup/Main.o )
Linking ./dist/setup/setup ...
Warning: package.cabal: Ignoring unknown section type: custom-setup
Configuring package-1.0...
```
