### PR TITLE
Turn 'configPrograms' field into a 'Last'-monoid

### DIFF
--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -455,7 +455,7 @@ getBuildConfig hooks verbosity distPref = do
             -- of a configure run:
             configPrograms = restoreProgramConfiguration
                                (builtinPrograms ++ hookedPrograms hooks)
-                               (configPrograms cFlags),
+                               <$> configPrograms cFlags,
 
             -- Use the current, not saved verbosity level:
             configVerbosity = Flag verbosity

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -125,6 +125,7 @@ import Text.PrettyPrint
     , quotes, punctuate, nest, sep, hsep )
 import Distribution.Compat.Environment ( lookupEnv )
 import Distribution.Compat.Exception ( catchExit, catchIO )
+import Distribution.Compat.Semigroup ( Last'(..) )
 
 -- | The errors that can be thrown when reading the @setup-config@ file.
 data ConfigStateFileError
@@ -346,7 +347,7 @@ configure (pkg_descr0', pbi) cfg = do
             (flagToMaybe (configHcFlavor cfg))
             (flagToMaybe (configHcPath cfg))
             (flagToMaybe (configHcPkg cfg))
-            (mkProgramsConfig cfg (configPrograms cfg))
+            (mkProgramsConfig cfg (configPrograms' cfg))
             (lessVerbose verbosity)
 
     -- The InstalledPackageIndex of all installed packages
@@ -685,6 +686,11 @@ configure (pkg_descr0', pbi) cfg = do
              [ name | (name, _, _) <- knownProfDetailLevels ]
         return (Flag ProfDetailDefault)
       checkProfDetail other = return other
+
+      -- | More convenient version of 'configPrograms'. Results in an
+      -- 'error' if internal invariant is violated.
+      configPrograms' :: ConfigFlags -> ProgramConfiguration
+      configPrograms' = maybe (error "FIXME: remove configPrograms") id . getLast' . configPrograms
 
 mkProgramsConfig :: ConfigFlags -> ProgramConfiguration -> ProgramConfiguration
 mkProgramsConfig cfg initialProgramsConfig = programsConfig

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -327,8 +327,8 @@ data ConfigFlags = ConfigFlags {
     -- because the type of configure is constrained by the UserHooks.
     -- when we change UserHooks next we should pass the initial
     -- ProgramConfiguration directly and not via ConfigFlags
-    configPrograms      :: ProgramConfiguration, -- ^All programs that cabal may
-                                                 -- run
+    configPrograms      :: Last' ProgramConfiguration, -- ^All programs that
+                                                       -- @cabal@ may run
 
     configProgramPaths  :: [(String, FilePath)], -- ^user specified programs paths
     configProgramArgs   :: [(String, [String])], -- ^user specified programs args
@@ -404,7 +404,7 @@ configAbsolutePaths f =
 
 defaultConfigFlags :: ProgramConfiguration -> ConfigFlags
 defaultConfigFlags progConf = emptyConfigFlags {
-    configPrograms     = progConf,
+    configPrograms     = pure progConf,
     configHcFlavor     = maybe NoFlag Flag defaultCompilerFlavor,
     configVanillaLib   = Flag True,
     configProfLib      = NoFlag,
@@ -812,7 +812,7 @@ emptyConfigFlags = mempty
 
 instance Monoid ConfigFlags where
   mempty = ConfigFlags {
-    configPrograms      = error "FIXME: remove configPrograms",
+    configPrograms      = mempty,
     configProgramPaths  = mempty,
     configProgramArgs   = mempty,
     configProgramPathExtra = mempty,

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -862,7 +862,7 @@ instance Monoid ConfigFlags where
 
 instance Semigroup ConfigFlags where
   a <> b =  ConfigFlags {
-    configPrograms      = configPrograms b,
+    configPrograms      = combine configPrograms,
     configProgramPaths  = combine configProgramPaths,
     configProgramArgs   = combine configProgramArgs,
     configProgramPathExtra = combine configProgramPathExtra,


### PR DESCRIPTION
This implements the suggestions mentioned at
https://github.com/haskell/cabal/issues/3169#issuecomment-189281916

The main benefit of this change is turning 'ConfigFlags' into a uniform
product-type suitable for generic derivation of pointwise
`Semigroup`/`Monoid` instances.

NB: This changes the `Binary` serialisation of `ConfigFlags` since there's now an additional `Maybe` inserted in `configPrograms`'s type