### PR TITLE
Make configPrograms a bit more backward compatible

### DIFF
--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -453,9 +453,9 @@ getBuildConfig hooks verbosity distPref = do
             -- Since the list of unconfigured programs is not serialized,
             -- restore it to the same value as normally used at the beginning
             -- of a configure run:
-            configPrograms = restoreProgramConfiguration
+            configPrograms_ = restoreProgramConfiguration
                                (builtinPrograms ++ hookedPrograms hooks)
-                               `fmap` configPrograms cFlags,
+                               `fmap` configPrograms_ cFlags,
 
             -- Use the current, not saved verbosity level:
             configVerbosity = Flag verbosity

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -125,7 +125,6 @@ import Text.PrettyPrint
     , quotes, punctuate, nest, sep, hsep )
 import Distribution.Compat.Environment ( lookupEnv )
 import Distribution.Compat.Exception ( catchExit, catchIO )
-import Distribution.Compat.Semigroup ( Last'(..) )
 
 -- | The errors that can be thrown when reading the @setup-config@ file.
 data ConfigStateFileError
@@ -347,7 +346,7 @@ configure (pkg_descr0', pbi) cfg = do
             (flagToMaybe (configHcFlavor cfg))
             (flagToMaybe (configHcPath cfg))
             (flagToMaybe (configHcPkg cfg))
-            (mkProgramsConfig cfg (configPrograms' cfg))
+            (mkProgramsConfig cfg (configPrograms cfg))
             (lessVerbose verbosity)
 
     -- The InstalledPackageIndex of all installed packages
@@ -686,11 +685,6 @@ configure (pkg_descr0', pbi) cfg = do
              [ name | (name, _, _) <- knownProfDetailLevels ]
         return (Flag ProfDetailDefault)
       checkProfDetail other = return other
-
-      -- | More convenient version of 'configPrograms'. Results in an
-      -- 'error' if internal invariant is violated.
-      configPrograms' :: ConfigFlags -> ProgramConfiguration
-      configPrograms' = maybe (error "FIXME: remove configPrograms") id . getLast' . configPrograms
 
 mkProgramsConfig :: ConfigFlags -> ProgramConfiguration -> ProgramConfiguration
 mkProgramsConfig cfg initialProgramsConfig = programsConfig

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -34,6 +34,7 @@ module Distribution.Simple.Setup (
 
   GlobalFlags(..),   emptyGlobalFlags,   defaultGlobalFlags,   globalCommand,
   ConfigFlags(..),   emptyConfigFlags,   defaultConfigFlags,   configureCommand,
+  configPrograms,
   AllowNewer(..),    AllowNewerDep(..),  isAllowNewer,
   configAbsolutePaths, readPackageDbList, showPackageDbList,
   CopyFlags(..),     emptyCopyFlags,     defaultCopyFlags,     copyCommand,
@@ -320,7 +321,7 @@ data ConfigFlags = ConfigFlags {
     -- because the type of configure is constrained by the UserHooks.
     -- when we change UserHooks next we should pass the initial
     -- ProgramConfiguration directly and not via ConfigFlags
-    configPrograms      :: Last' ProgramConfiguration, -- ^All programs that
+    configPrograms_     :: Last' ProgramConfiguration, -- ^All programs that
                                                        -- @cabal@ may run
 
     configProgramPaths  :: [(String, FilePath)], -- ^user specified programs paths
@@ -389,6 +390,11 @@ data ConfigFlags = ConfigFlags {
 
 instance Binary ConfigFlags
 
+-- | More convenient version of 'configPrograms'. Results in an
+-- 'error' if internal invariant is violated.
+configPrograms :: ConfigFlags -> ProgramConfiguration
+configPrograms = maybe (error "FIXME: remove configPrograms") id . getLast' . configPrograms_
+
 configAbsolutePaths :: ConfigFlags -> IO ConfigFlags
 configAbsolutePaths f =
   (\v -> f { configPackageDBs = v })
@@ -397,7 +403,7 @@ configAbsolutePaths f =
 
 defaultConfigFlags :: ProgramConfiguration -> ConfigFlags
 defaultConfigFlags progConf = emptyConfigFlags {
-    configPrograms     = pure progConf,
+    configPrograms_    = pure progConf,
     configHcFlavor     = maybe NoFlag Flag defaultCompilerFlavor,
     configVanillaLib   = Flag True,
     configProfLib      = NoFlag,

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -262,7 +262,7 @@ instance Semigroup SavedConfig where
           lastNonEmptyNL = lastNonEmptyNL' savedInstallFlags
 
       combinedSavedConfigureFlags = ConfigFlags {
-        configPrograms            = configPrograms . savedConfigureFlags $ b,
+        configPrograms_           = configPrograms_ . savedConfigureFlags $ b,
         -- TODO: NubListify
         configProgramPaths        = lastNonEmpty configProgramPaths,
         -- TODO: NubListify


### PR DESCRIPTION
This implements the suggestion from
https://github.com/haskell/cabal/pull/3196#issuecomment-190285328