### PR TITLE
Extend cabal list cmd

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1035,7 +1035,7 @@ listCommand = CommandUI {
             trueArg
 
         , option [] ["simple-output"]
-            "Print in a easy-to-parse format"
+            "Print in an easy-to-parse format"
             listSimpleOutput (\v flags -> flags { listSimpleOutput = v })
             trueArg
 

--- a/cabal-install/Distribution/Client/Utils.hs
+++ b/cabal-install/Distribution/Client/Utils.hs
@@ -72,8 +72,6 @@ import System.IO.Error (ioError, mkIOError, doesNotExistErrorType)
 
 -- | Generic merging utility. For sorted input lists this is a full outer join.
 --
--- * The result list never contains @(Nothing, Nothing)@.
---
 mergeBy :: (a -> b -> Ordering) -> [a] -> [b] -> [MergeResult a b]
 mergeBy cmp = merge
   where


### PR DESCRIPTION
Implements a solution to #879 by extending the cabal 'list' command with a --dependencies option.

I generalize the idea of listing the license field to listing multiple, arbitrary fields (a --field option) of the packages that are dependencies.

This doesn't address the extraction of License files (as discussed in #879).
