### PR TITLE
Improve goal reorder heuristics.

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
@@ -74,13 +74,12 @@ solve sc cinfo idx userPrefs userConstraints userGoals =
   buildPhase
   where
     explorePhase     = exploreTreeLog . backjump
-    heuristicsPhase  = P.firstGoal . -- after doing goal-choice heuristics, commit to the first choice (saves space)
-                       P.deferSetupChoices .
+    heuristicsPhase  = (if preferEasyGoalChoices sc
+                         then P.preferEasyGoalChoices -- also leaves just one choice
+                         else P.firstGoal) .
                        P.deferWeakFlagChoices .
+                       P.deferSetupChoices .
                        P.preferBaseGoalChoice .
-                       (if preferEasyGoalChoices sc
-                         then P.lpreferEasyGoalChoices
-                         else id) .
                        P.preferLinked
     preferencesPhase = P.preferPackagePreferences userPrefs
     validationPhase  = P.enforceManualFlags . -- can only be done after user constraints

--- a/cabal-install/Distribution/Client/Dependency/Modular/Tree.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Tree.hs
@@ -7,11 +7,12 @@ module Distribution.Client.Dependency.Modular.Tree
     , ana
     , cata
     , choices
+    , dchoices
     , inn
     , innM
-    , lchoices
     , para
     , trav
+    , zeroOrOneChoices
     ) where
 
 import Control.Monad hiding (mapM, sequence)
@@ -134,15 +135,23 @@ choices (GoalChoice         _ ) = 1
 choices (Done       _         ) = 1
 choices (Fail       _ _       ) = 0
 
--- | Variant of 'choices' that only approximates the number of choices,
--- using 'llength'.
-lchoices :: Tree a -> Int
-lchoices (PChoice    _ _     ts) = P.llength (P.filter active ts)
-lchoices (FChoice    _ _ _ _ ts) = P.llength (P.filter active ts)
-lchoices (SChoice    _ _ _   ts) = P.llength (P.filter active ts)
-lchoices (GoalChoice         _ ) = 1
-lchoices (Done       _         ) = 1
-lchoices (Fail       _ _       ) = 0
+-- | Variant of 'choices' that only approximates the number of choices.
+dchoices :: Tree a -> P.Degree
+dchoices (PChoice    _ _     ts) = P.degree (P.filter active ts)
+dchoices (FChoice    _ _ _ _ ts) = P.degree (P.filter active ts)
+dchoices (SChoice    _ _ _   ts) = P.degree (P.filter active ts)
+dchoices (GoalChoice         _ ) = P.ZeroOrOne
+dchoices (Done       _         ) = P.ZeroOrOne
+dchoices (Fail       _ _       ) = P.ZeroOrOne
+
+-- | Variant of 'choices' that only approximates the number of choices.
+zeroOrOneChoices :: Tree a -> Bool
+zeroOrOneChoices (PChoice    _ _     ts) = P.isZeroOrOne (P.filter active ts)
+zeroOrOneChoices (FChoice    _ _ _ _ ts) = P.isZeroOrOne (P.filter active ts)
+zeroOrOneChoices (SChoice    _ _ _   ts) = P.isZeroOrOne (P.filter active ts)
+zeroOrOneChoices (GoalChoice         _ ) = True
+zeroOrOneChoices (Done       _         ) = True
+zeroOrOneChoices (Fail       _ _       ) = True
 
 -- | Catamorphism on trees.
 cata :: (TreeF a b -> b) -> Tree a -> b


### PR DESCRIPTION
This change primarily does two things:

1. For `--reorder-goals`, we use a dedicated datatype `Degree`
   rather than an `Int` to compute the approximate branching
   degree. We map 0 and 1 to the same value. We then use a
   lazy ordering and a shortcutting minimum function to look
   for the "best" goal.

   The motivation here is that we do not want to spend
   unnecessary work. Following any goal that has 0 or 1 as degree
   cannot really be "wrong", so we should not look at any others
   and waste time.

   This will still not always make the use of `--reorder-goals`
   better than not using it, but it will reduce the overhead
   introduced by it.

2. We use partitioning rather than sorting for most of the other
   goal reordering heuristics that are active in all situations.
   I think this is slightly more straightforward and also slightly
   more efficient, whether `--reorder-goals` is used or not.

I have run some preliminary performance comparisons and they
seem to confirm that in both cases separately (with or without
`--reorder-goals`), these changes are a relative improvement
over the status quo. I will run additional tests before
merging this into master.