### PR TITLE
Parameterize SourcePackage and ConfiguredPackage on package location

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular.hs
@@ -12,9 +12,7 @@ module Distribution.Client.Dependency.Modular
 import Data.Map as M
          ( fromListWith )
 import Distribution.Client.Dependency.Modular.Assignment
-         ( Assignment, toCPs )
-import Distribution.Client.Dependency.Modular.Dependency
-         ( RevDepMap )
+         ( toCPs )
 import Distribution.Client.Dependency.Modular.ConfiguredConversion
          ( convCP )
 import Distribution.Client.Dependency.Modular.IndexConversion
@@ -26,14 +24,14 @@ import Distribution.Client.Dependency.Modular.Package
 import Distribution.Client.Dependency.Modular.Solver
          ( SolverConfig(..), solve )
 import Distribution.Client.Dependency.Types
-         ( DependencyResolver, ResolverPackage
+         ( DependencyResolver
          , PackageConstraint(..), unlabelPackageConstraint )
 import Distribution.System
          ( Platform(..) )
 
 -- | Ties the two worlds together: classic cabal-install vs. the modular
 -- solver. Performs the necessary translations before and after.
-modularResolver :: SolverConfig -> DependencyResolver
+modularResolver :: SolverConfig -> DependencyResolver loc
 modularResolver sc (Platform arch os) cinfo iidx sidx pkgConfigDB pprefs pcs pns =
   fmap (uncurry postprocess)      $ -- convert install plan
   logToProgress (maxBackjumps sc) $ -- convert log format into progress format
@@ -47,7 +45,6 @@ modularResolver sc (Platform arch os) cinfo iidx sidx pkgConfigDB pprefs pcs pns
           pair lpc = (pcName $ unlabelPackageConstraint lpc, [lpc])
 
       -- Results have to be converted into an install plan.
-      postprocess :: Assignment -> RevDepMap -> [ResolverPackage]
       postprocess a rdm = map (convCP iidx sidx) (toCPs a rdm)
 
       -- Helper function to extract the PN from a constraint.

--- a/cabal-install/Distribution/Client/Dependency/Modular/ConfiguredConversion.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/ConfiguredConversion.hs
@@ -21,8 +21,8 @@ import Distribution.Client.ComponentDeps (ComponentDeps)
 -- a 'ResolverPackage', which can then be converted into
 -- the install plan.
 convCP :: SI.InstalledPackageIndex ->
-          CI.PackageIndex SourcePackage ->
-          CP QPN -> ResolverPackage
+          CI.PackageIndex (SourcePackage loc) ->
+          CP QPN -> ResolverPackage loc
 convCP iidx sidx (CP qpi fa es ds) =
   case convPI qpi of
     Left  pi -> PreExisting

--- a/cabal-install/Distribution/Client/Dependency/Modular/IndexConversion.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/IndexConversion.hs
@@ -38,7 +38,7 @@ import Distribution.Client.Dependency.Modular.Version
 -- fix the problem there, so for now, shadowing is only activated if
 -- explicitly requested.
 convPIs :: OS -> Arch -> CompilerInfo -> Bool -> Bool ->
-           SI.InstalledPackageIndex -> CI.PackageIndex SourcePackage -> Index
+           SI.InstalledPackageIndex -> CI.PackageIndex (SourcePackage loc) -> Index
 convPIs os arch comp sip strfl iidx sidx =
   mkIndex (convIPI' sip iidx ++ convSPI' os arch comp strfl sidx)
 
@@ -88,11 +88,11 @@ convIPId pn' idx ipid =
 -- | Convert a cabal-install source package index to the simpler,
 -- more uniform index format of the solver.
 convSPI' :: OS -> Arch -> CompilerInfo -> Bool ->
-            CI.PackageIndex SourcePackage -> [(PN, I, PInfo)]
+            CI.PackageIndex (SourcePackage loc) -> [(PN, I, PInfo)]
 convSPI' os arch cinfo strfl = L.map (convSP os arch cinfo strfl) . CI.allPackages
 
 -- | Convert a single source package into the solver-specific format.
-convSP :: OS -> Arch -> CompilerInfo -> Bool -> SourcePackage -> (PN, I, PInfo)
+convSP :: OS -> Arch -> CompilerInfo -> Bool -> SourcePackage loc -> (PN, I, PInfo)
 convSP os arch cinfo strfl (SourcePackage (PackageIdentifier pn pv) gpd _ _pl) =
   let i = I pv InRepo
   in  (pn, i, convGPD os arch cinfo strfl (PI pn i) gpd)

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
@@ -15,6 +15,7 @@ module Distribution.Client.Dependency.TopDown.Types where
 
 import Distribution.Client.Types
          ( SourcePackage(..), ConfiguredPackage(..)
+         , UnresolvedPkgLoc
          , OptionalStanza, ConfiguredId(..) )
 import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo )
@@ -44,7 +45,7 @@ data InstalledOrSource installed source
 
 data FinalSelectedPackage
    = SelectedInstalled InstalledPackage
-   | SelectedSource    ConfiguredPackage
+   | SelectedSource    (ConfiguredPackage UnresolvedPkgLoc)
 
 type TopologicalSortNumber = Int
 
@@ -62,18 +63,18 @@ data InstalledPackageEx
 
 data UnconfiguredPackage
    = UnconfiguredPackage
-       SourcePackage
+       (SourcePackage UnresolvedPkgLoc)
        !TopologicalSortNumber
        FlagAssignment
        [OptionalStanza]
 
 data SemiConfiguredPackage
    = SemiConfiguredPackage
-       SourcePackage     -- package info
-       FlagAssignment    -- total flag assignment for the package
-       [OptionalStanza]  -- enabled optional stanzas
-       [Dependency]      -- dependencies we end up with when we apply
-                         -- the flag assignment
+       (SourcePackage UnresolvedPkgLoc)  -- package info
+       FlagAssignment                    -- total flag assignment for the package
+       [OptionalStanza]                  -- enabled optional stanzas
+       [Dependency]                      -- dependencies we end up with when we apply
+                                         -- the flag assignment
 
 instance Package InstalledPackage where
   packageId (InstalledPackage pkg _) = packageId pkg
@@ -131,7 +132,7 @@ class Package a => PackageSourceDeps a where
 instance PackageSourceDeps InstalledPackageEx where
   sourceDeps (InstalledPackageEx _ _ deps) = deps
 
-instance PackageSourceDeps ConfiguredPackage where
+instance PackageSourceDeps (ConfiguredPackage loc) where
   sourceDeps (ConfiguredPackage _ _ _ deps) = map confSrcId $ CD.nonSetupDeps deps
 
 instance PackageSourceDeps InstalledPackage where

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -113,23 +113,23 @@ instance Text PreSolver where
 -- solving the package dependency problem and we want to make it easy to swap
 -- in alternatives.
 --
-type DependencyResolver = Platform
-                       -> CompilerInfo
-                       -> InstalledPackageIndex
-                       ->          PackageIndex.PackageIndex SourcePackage
-                       -> PkgConfigDb
-                       -> (PackageName -> PackagePreferences)
-                       -> [LabeledPackageConstraint]
-                       -> [PackageName]
-                       -> Progress String String [ResolverPackage]
+type DependencyResolver loc = Platform
+                           -> CompilerInfo
+                           -> InstalledPackageIndex
+                           -> PackageIndex.PackageIndex (SourcePackage loc)
+                           -> PkgConfigDb
+                           -> (PackageName -> PackagePreferences)
+                           -> [LabeledPackageConstraint]
+                           -> [PackageName]
+                           -> Progress String String [ResolverPackage loc]
 
 -- | The dependency resolver picks either pre-existing installed packages
 -- or it picks source packages along with package configuration.
 --
 -- This is like the 'InstallPlan.PlanPackage' but with fewer cases.
 --
-data ResolverPackage = PreExisting InstalledPackageInfo
-                     | Configured  ConfiguredPackage
+data ResolverPackage loc = PreExisting InstalledPackageInfo
+                         | Configured  (ConfiguredPackage loc)
 
 -- | Per-package constraints. Package constraints must be respected by the
 -- solver. Multiple constraints for each package can be given, though obviously

--- a/cabal-install/Distribution/Client/Fetch.hs
+++ b/cabal-install/Distribution/Client/Fetch.hs
@@ -120,8 +120,8 @@ planPackages :: Verbosity
              -> InstalledPackageIndex
              -> SourcePackageDb
              -> PkgConfigDb
-             -> [PackageSpecifier SourcePackage]
-             -> IO [SourcePackage]
+             -> [PackageSpecifier (SourcePackage UnresolvedPkgLoc)]
+             -> IO [SourcePackage UnresolvedPkgLoc]
 planPackages verbosity comp platform fetchFlags
              installedPkgIndex sourcePkgDb pkgConfigDb pkgSpecifiers
 

--- a/cabal-install/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/Distribution/Client/FetchUtils.hs
@@ -63,7 +63,7 @@ import qualified Hackage.Security.Client as Sec
 -- | Returns @True@ if the package has already been fetched
 -- or does not need fetching.
 --
-isFetched :: PackageLocation (Maybe FilePath) -> IO Bool
+isFetched :: UnresolvedPkgLoc -> IO Bool
 isFetched loc = case loc of
     LocalUnpackedPackage _dir       -> return True
     LocalTarballPackage  _file      -> return True
@@ -71,7 +71,7 @@ isFetched loc = case loc of
     RepoTarballPackage repo pkgid _ -> doesFileExist (packageFile repo pkgid)
 
 
-checkFetched :: PackageLocation (Maybe FilePath)
+checkFetched :: UnresolvedPkgLoc
              -> IO (Maybe (PackageLocation FilePath))
 checkFetched loc = case loc of
     LocalUnpackedPackage dir  ->
@@ -96,7 +96,7 @@ checkFetched loc = case loc of
 --
 fetchPackage :: Verbosity
              -> RepoContext
-             -> PackageLocation (Maybe FilePath)
+             -> UnresolvedPkgLoc
              -> IO (PackageLocation FilePath)
 fetchPackage verbosity repoCtxt loc = case loc of
     LocalUnpackedPackage dir  ->

--- a/cabal-install/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/Distribution/Client/FetchUtils.hs
@@ -72,7 +72,7 @@ isFetched loc = case loc of
 
 
 checkFetched :: UnresolvedPkgLoc
-             -> IO (Maybe (PackageLocation FilePath))
+             -> IO (Maybe ResolvedPkgLoc)
 checkFetched loc = case loc of
     LocalUnpackedPackage dir  ->
       return (Just $ LocalUnpackedPackage dir)
@@ -97,7 +97,7 @@ checkFetched loc = case loc of
 fetchPackage :: Verbosity
              -> RepoContext
              -> UnresolvedPkgLoc
-             -> IO (PackageLocation FilePath)
+             -> IO ResolvedPkgLoc
 fetchPackage verbosity repoCtxt loc = case loc of
     LocalUnpackedPackage dir  ->
       return (LocalUnpackedPackage dir)

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -131,7 +131,7 @@ planPackages :: Verbosity
              -> InstalledPackageIndex
              -> SourcePackageDb
              -> PkgConfigDb
-             -> [PackageSpecifier SourcePackage]
+             -> [PackageSpecifier (SourcePackage UnresolvedPkgLoc)]
              -> IO [PlanPackage]
 planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
              installedPkgIndex sourcePkgDb pkgConfigDb pkgSpecifiers = do
@@ -196,7 +196,7 @@ planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
 --    freezing.  This is useful for removing previously installed packages
 --    which are no longer required from the install plan.
 pruneInstallPlan :: InstallPlan
-                 -> [PackageSpecifier SourcePackage]
+                 -> [PackageSpecifier (SourcePackage UnresolvedPkgLoc)]
                  -> [PlanPackage]
 pruneInstallPlan installPlan pkgSpecifiers =
     removeSelf pkgIds $

--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -113,13 +113,13 @@ get verbosity repoCtxt globalFlags getFlags userTargets = do
 
     prefix = fromFlagOrDefault "" (getDestDir getFlags)
 
-    fork :: [SourcePackage] -> IO ()
+    fork :: [SourcePackage UnresolvedPkgLoc] -> IO ()
     fork pkgs = do
       let kind = fromFlag . getSourceRepository $ getFlags
       branchers <- findUsableBranchers
       mapM_ (forkPackage verbosity branchers prefix kind) pkgs
 
-    unpack :: [SourcePackage] -> IO ()
+    unpack :: [SourcePackage UnresolvedPkgLoc] -> IO ()
     unpack pkgs = do
       forM_ pkgs $ \pkg -> do
         location <- fetchPackage verbosity repoCtxt (packageSource pkg)
@@ -226,7 +226,7 @@ forkPackage :: Verbosity
                -- be created.
             -> (Maybe PD.RepoKind)
                -- ^ Which repo to choose.
-            -> SourcePackage
+            -> SourcePackage loc
                -- ^ The package to fork.
             -> IO ()
 forkPackage verbosity branchers prefix kind src = do

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -154,7 +154,7 @@ readCacheStrict verbosity index mkPkg = do
 -- This is a higher level wrapper used internally in cabal-install.
 --
 readRepoIndex :: Verbosity -> RepoContext -> Repo
-              -> IO (PackageIndex SourcePackage, [Dependency])
+              -> IO (PackageIndex (SourcePackage UnresolvedPkgLoc), [Dependency])
 readRepoIndex verbosity repoCtxt repo =
   handleNotFound $ do
     warnIfIndexIsOld =<< getIndexFileAge repo

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1285,7 +1285,7 @@ fetchSourcePackage
   -> RepoContext
   -> JobLimit
   -> UnresolvedPkgLoc
-  -> (PackageLocation FilePath -> IO BuildResult)
+  -> (ResolvedPkgLoc -> IO BuildResult)
   -> IO BuildResult
 fetchSourcePackage verbosity repoCtxt fetchLimit src installPkg = do
   fetched <- checkFetched src
@@ -1300,7 +1300,7 @@ fetchSourcePackage verbosity repoCtxt fetchLimit src installPkg = do
 installLocalPackage
   :: Verbosity
   -> JobLimit
-  -> PackageIdentifier -> PackageLocation FilePath -> FilePath
+  -> PackageIdentifier -> ResolvedPkgLoc -> FilePath
   -> (Maybe FilePath -> IO BuildResult)
   -> IO BuildResult
 installLocalPackage verbosity jobLimit pkgid location distPref installPkg =

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -237,7 +237,7 @@ install verbosity packageDBs repos comp platform conf useSandbox mSandboxPkgInfo
 -- | Common context for makeInstallPlan and processInstallPlan.
 type InstallContext = ( InstalledPackageIndex, SourcePackageDb
                       , PkgConfigDb
-                      , [UserTarget], [PackageSpecifier SourcePackage]
+                      , [UserTarget], [PackageSpecifier (SourcePackage UnresolvedPkgLoc)]
                       , HttpTransport )
 
 -- TODO: Make InstallArgs a proper data type with documented fields or just get
@@ -342,7 +342,7 @@ planPackages :: Compiler
              -> InstalledPackageIndex
              -> SourcePackageDb
              -> PkgConfigDb
-             -> [PackageSpecifier SourcePackage]
+             -> [PackageSpecifier (SourcePackage UnresolvedPkgLoc)]
              -> Progress String String InstallPlan
 planPackages comp platform mSandboxPkgInfo solver
              configFlags configExFlags installFlags
@@ -467,7 +467,7 @@ checkPrintPlan :: Verbosity
                -> InstallPlan
                -> SourcePackageDb
                -> InstallFlags
-               -> [PackageSpecifier SourcePackage]
+               -> [PackageSpecifier (SourcePackage UnresolvedPkgLoc)]
                -> IO ()
 checkPrintPlan verbosity installed installPlan sourcePkgDb
   installFlags pkgSpecifiers = do
@@ -680,14 +680,14 @@ printPlan dryRun verbosity plan sourcePkgDb = case plan of
     toFlagAssignment :: [Flag] -> FlagAssignment
     toFlagAssignment = map (\ f -> (flagName f, flagDefault f))
 
-    nonDefaultFlags :: ConfiguredPackage -> FlagAssignment
+    nonDefaultFlags :: ConfiguredPackage loc -> FlagAssignment
     nonDefaultFlags (ConfiguredPackage spkg fa _ _) =
       let defaultAssignment =
             toFlagAssignment
              (genPackageFlags (Source.packageDescription spkg))
       in  fa \\ defaultAssignment
 
-    stanzas :: ConfiguredPackage -> [OptionalStanza]
+    stanzas :: ConfiguredPackage loc -> [OptionalStanza]
     stanzas (ConfiguredPackage _ _ sts _) = sts
 
     showStanzas :: [OptionalStanza] -> String
@@ -1247,7 +1247,7 @@ executeInstallPlan verbosity _comp jobCtl useLogFile plan0 installPkg =
 installReadyPackage :: Platform -> CompilerInfo
                     -> ConfigFlags
                     -> ReadyPackage
-                    -> (ConfigFlags -> PackageLocation (Maybe FilePath)
+                    -> (ConfigFlags -> UnresolvedPkgLoc
                                     -> PackageDescription
                                     -> PackageDescriptionOverride
                                     -> a)
@@ -1284,7 +1284,7 @@ fetchSourcePackage
   :: Verbosity
   -> RepoContext
   -> JobLimit
-  -> PackageLocation (Maybe FilePath)
+  -> UnresolvedPkgLoc
   -> (PackageLocation FilePath -> IO BuildResult)
   -> IO BuildResult
 fetchSourcePackage verbosity repoCtxt fetchLimit src installPkg = do

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -56,6 +56,7 @@ import Distribution.Package
 import Distribution.Client.Types
          ( BuildSuccess, BuildFailure
          , PackageFixedDeps(..), ConfiguredPackage
+         , UnresolvedPkgLoc
          , GenericReadyPackage(..), fakeUnitId )
 import Distribution.Version
          ( Version )
@@ -151,7 +152,7 @@ instance (Binary ipkg, Binary srcpkg, Binary  iresult, Binary  ifailure)
       => Binary (GenericPlanPackage ipkg srcpkg iresult ifailure)
 
 type PlanPackage = GenericPlanPackage
-                   InstalledPackageInfo ConfiguredPackage
+                   InstalledPackageInfo (ConfiguredPackage UnresolvedPkgLoc)
                    BuildSuccess BuildFailure
 
 instance (Package ipkg, Package srcpkg) =>
@@ -213,7 +214,7 @@ planPkgOf plan v =
 
 -- | 'GenericInstallPlan' specialised to most commonly used types.
 type InstallPlan = GenericInstallPlan
-                   InstalledPackageInfo ConfiguredPackage
+                   InstalledPackageInfo (ConfiguredPackage UnresolvedPkgLoc)
                    BuildSuccess BuildFailure
 
 type PlanIndex ipkg srcpkg iresult ifailure =

--- a/cabal-install/Distribution/Client/Sandbox/Types.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Types.hs
@@ -14,7 +14,7 @@ module Distribution.Client.Sandbox.Types (
   ) where
 
 import qualified Distribution.Simple.PackageIndex as InstalledPackageIndex
-import Distribution.Client.Types (SourcePackage)
+import Distribution.Client.Types (SourcePackage, UnresolvedPkgLoc)
 import Distribution.Compat.Semigroup (Semigroup((<>)))
 
 #if !MIN_VERSION_base(4,8,0)
@@ -49,11 +49,11 @@ whenUsingSandbox (UseSandbox sandboxDir) act = act sandboxDir
 -- | Data about the packages installed in the sandbox that is passed from
 -- 'reinstallAddSourceDeps' to the solver.
 data SandboxPackageInfo = SandboxPackageInfo {
-  modifiedAddSourceDependencies :: ![SourcePackage],
+  modifiedAddSourceDependencies :: ![SourcePackage UnresolvedPkgLoc],
   -- ^ Modified add-source deps that we want to reinstall. These are guaranteed
   -- to be already installed in the sandbox.
 
-  otherAddSourceDependencies    :: ![SourcePackage],
+  otherAddSourceDependencies    :: ![SourcePackage UnresolvedPkgLoc],
   -- ^ Remaining add-source deps. Some of these may be not installed in the
   -- sandbox.
 

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -53,7 +53,7 @@ import Distribution.Package
          , PackageIdentifier(..), packageName, packageVersion
          , Dependency(Dependency) )
 import Distribution.Client.Types
-         ( SourcePackage(..), PackageLocation(..), OptionalStanza(..) )
+         ( SourcePackage(..), PackageLocation(..), UnresolvedPkgLoc, OptionalStanza(..) )
 import Distribution.Client.Dependency.Types
          ( PackageConstraint(..), ConstraintSource(..)
          , LabeledPackageConstraint(..) )
@@ -372,7 +372,7 @@ resolveUserTargets :: Package pkg
                    -> FilePath
                    -> PackageIndex pkg
                    -> [UserTarget]
-                   -> IO [PackageSpecifier SourcePackage]
+                   -> IO [PackageSpecifier (SourcePackage UnresolvedPkgLoc)]
 resolveUserTargets verbosity repoCtxt worldFile available userTargets = do
 
     -- given the user targets, get a list of fully or partially resolved
@@ -482,7 +482,7 @@ fetchPackageTarget verbosity repoCtxt target = case target of
 --
 readPackageTarget :: Verbosity
                   -> PackageTarget (PackageLocation FilePath)
-                  -> IO (PackageTarget SourcePackage)
+                  -> IO (PackageTarget (SourcePackage UnresolvedPkgLoc))
 readPackageTarget verbosity target = case target of
 
     PackageTargetNamed pkgname constraints userTarget ->

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -53,7 +53,8 @@ import Distribution.Package
          , PackageIdentifier(..), packageName, packageVersion
          , Dependency(Dependency) )
 import Distribution.Client.Types
-         ( SourcePackage(..), PackageLocation(..), UnresolvedPkgLoc, OptionalStanza(..) )
+         ( SourcePackage(..), PackageLocation(..), OptionalStanza(..)
+         , ResolvedPkgLoc, UnresolvedPkgLoc )
 import Distribution.Client.Dependency.Types
          ( PackageConstraint(..), ConstraintSource(..)
          , LabeledPackageConstraint(..) )
@@ -467,7 +468,7 @@ localPackageError dir =
 fetchPackageTarget :: Verbosity
                    -> RepoContext
                    -> PackageTarget (PackageLocation ())
-                   -> IO (PackageTarget (PackageLocation FilePath))
+                   -> IO (PackageTarget ResolvedPkgLoc)
 fetchPackageTarget verbosity repoCtxt target = case target of
     PackageTargetNamed      n cs ut -> return (PackageTargetNamed      n cs ut)
     PackageTargetNamedFuzzy n cs ut -> return (PackageTargetNamedFuzzy n cs ut)
@@ -481,7 +482,7 @@ fetchPackageTarget verbosity repoCtxt target = case target of
 -- This only affects targets given by location, named targets are unaffected.
 --
 readPackageTarget :: Verbosity
-                  -> PackageTarget (PackageLocation FilePath)
+                  -> PackageTarget ResolvedPkgLoc
                   -> IO (PackageTarget (SourcePackage UnresolvedPkgLoc))
 readPackageTarget verbosity target = case target of
 

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -209,6 +209,8 @@ enableStanzas stanzas gpkg = gpkg
 
 type UnresolvedPkgLoc = PackageLocation (Maybe FilePath)
 
+type ResolvedPkgLoc = PackageLocation FilePath
+
 data PackageLocation local =
 
     -- | An unpacked package in the given dir, or current dir

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -53,7 +53,7 @@ newtype Password = Password { unPassword :: String }
 -- | This is the information we get from a @00-index.tar.gz@ hackage index.
 --
 data SourcePackageDb = SourcePackageDb {
-  packageIndex       :: PackageIndex SourcePackage,
+  packageIndex       :: PackageIndex (SourcePackage UnresolvedPkgLoc),
   packagePreferences :: Map PackageName VersionRange
 }
   deriving (Eq, Generic)
@@ -95,18 +95,18 @@ fakeUnitId = mkUnitId . (".fake."++) . display
 -- the sense that it provides all the configuration information and so the
 -- final configure process will be independent of the environment.
 --
-data ConfiguredPackage = ConfiguredPackage
-       SourcePackage       -- package info, including repo
-       FlagAssignment      -- complete flag assignment for the package
-       [OptionalStanza]    -- list of enabled optional stanzas for the package
+data ConfiguredPackage loc = ConfiguredPackage
+       (SourcePackage loc)     -- package info, including repo
+       FlagAssignment          -- complete flag assignment for the package
+       [OptionalStanza]        -- list of enabled optional stanzas for the package
        (ComponentDeps [ConfiguredId])
-                           -- set of exact dependencies (installed or source).
-                           -- These must be consistent with the 'buildDepends'
-                           -- in the 'PackageDescription' that you'd get by
-                           -- applying the flag assignment and optional stanzas.
+                               -- set of exact dependencies (installed or source).
+                               -- These must be consistent with the 'buildDepends'
+                               -- in the 'PackageDescription' that you'd get by
+                               -- applying the flag assignment and optional stanzas.
   deriving (Eq, Show, Generic)
 
-instance Binary ConfiguredPackage
+instance Binary loc => Binary (ConfiguredPackage loc)
 
 -- | A ConfiguredId is a package ID for a configured package.
 --
@@ -131,13 +131,13 @@ instance Binary ConfiguredId
 instance Show ConfiguredId where
   show = show . confSrcId
 
-instance Package ConfiguredPackage where
+instance Package (ConfiguredPackage loc) where
   packageId (ConfiguredPackage pkg _ _ _) = packageId pkg
 
-instance PackageFixedDeps ConfiguredPackage where
+instance PackageFixedDeps (ConfiguredPackage loc) where
   depends (ConfiguredPackage _ _ _ deps) = fmap (map confInstId) deps
 
-instance HasUnitId ConfiguredPackage where
+instance HasUnitId (ConfiguredPackage loc) where
   installedUnitId = fakeUnitId . packageId
 
 -- | Like 'ConfiguredPackage', but with all dependencies guaranteed to be
@@ -148,7 +148,7 @@ data GenericReadyPackage srcpkg ipkg
        (ComponentDeps [ipkg])  -- Installed dependencies.
   deriving (Eq, Show, Generic)
 
-type ReadyPackage = GenericReadyPackage ConfiguredPackage InstalledPackageInfo
+type ReadyPackage = GenericReadyPackage (ConfiguredPackage UnresolvedPkgLoc) InstalledPackageInfo
 
 instance Package srcpkg => Package (GenericReadyPackage srcpkg ipkg) where
   packageId (ReadyPackage srcpkg _deps) = packageId srcpkg
@@ -166,21 +166,21 @@ instance (Binary srcpkg, Binary ipkg) => Binary (GenericReadyPackage srcpkg ipkg
 
 -- | A package description along with the location of the package sources.
 --
-data SourcePackage = SourcePackage {
+data SourcePackage loc = SourcePackage {
     packageInfoId        :: PackageId,
     packageDescription   :: GenericPackageDescription,
-    packageSource        :: PackageLocation (Maybe FilePath),
+    packageSource        :: loc,
     packageDescrOverride :: PackageDescriptionOverride
   }
   deriving (Eq, Show, Generic)
 
-instance Binary SourcePackage
+instance (Binary loc) => Binary (SourcePackage loc)
 
 -- | We sometimes need to override the .cabal file in the tarball with
 -- the newer one from the package index.
 type PackageDescriptionOverride = Maybe ByteString
 
-instance Package SourcePackage where packageId = packageInfoId
+instance Package (SourcePackage a) where packageId = packageInfoId
 
 data OptionalStanza
     = TestStanzas
@@ -206,6 +206,8 @@ enableStanzas stanzas gpkg = gpkg
 -- ------------------------------------------------------------
 -- * Package locations and repositories
 -- ------------------------------------------------------------
+
+type UnresolvedPkgLoc = PackageLocation (Maybe FilePath)
 
 data PackageLocation local =
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
@@ -156,7 +156,7 @@ type DependencyTree a = C.CondTree C.ConfVar [C.Dependency] a
 exDbPkgs :: ExampleDb -> [ExamplePkgName]
 exDbPkgs = map (either exInstName exAvName)
 
-exAvSrcPkg :: ExampleAvailable -> SourcePackage
+exAvSrcPkg :: ExampleAvailable -> SourcePackage UnresolvedPkgLoc
 exAvSrcPkg ex =
     let (libraryDeps, testSuites, exts, mlang, pcpkgs) = splitTopLevel (CD.libraryDeps (exAvDeps ex))
     in SourcePackage {
@@ -339,7 +339,7 @@ exInstPkgId ex = C.PackageIdentifier {
     , pkgVersion = Version [exInstVersion ex, 0, 0] []
     }
 
-exAvIdx :: [ExampleAvailable] -> CI.PackageIndex.PackageIndex SourcePackage
+exAvIdx :: [ExampleAvailable] -> CI.PackageIndex.PackageIndex (SourcePackage UnresolvedPkgLoc)
 exAvIdx = CI.PackageIndex.fromList . map exAvSrcPkg
 
 exInstIdx :: [ExampleInstalled] -> C.PackageIndex.InstalledPackageIndex
@@ -391,7 +391,7 @@ extractInstallPlan = catMaybes . map confPkg . CI.InstallPlan.toList
     confPkg (CI.InstallPlan.Configured pkg) = Just $ srcPkg pkg
     confPkg _                               = Nothing
 
-    srcPkg :: ConfiguredPackage -> (String, Int)
+    srcPkg :: ConfiguredPackage UnresolvedPkgLoc -> (String, Int)
     srcPkg (ConfiguredPackage pkg _flags _stanzas _deps) =
       let C.PackageIdentifier (C.PackageName p) (Version (n:_) _) =
             packageInfoId pkg


### PR DESCRIPTION
This is a step towards breaking the dependency from the modular
solver on cabal-install.