### PR TITLE
Don't use './Setup' for building 'cabal-install'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,15 +69,12 @@ script:
  - cd ../cabal-install
  - ../Cabal/misc/gen-extra-source-files.sh cabal-install.cabal
  - ../Cabal/misc/travis-diff-files.sh
- - mkdir -p ./dist/setup
- - cp Setup.hs ./dist/setup/setup.hs
- - ghc --make -odir ./dist/setup -hidir ./dist/setup -i -i. ./dist/setup/setup.hs -o ./dist/setup/setup -Wall -Werror -threaded  # the command cabal-install would use to build setup
 
  - cabal install --only-dependencies --enable-tests --enable-benchmarks
- - ./dist/setup/setup configure --user --ghc-option=-Werror --enable-tests --enable-benchmarks -v2 # -v2 provides useful information for debugging
- - ./dist/setup/setup build
- - ./dist/setup/setup haddock # see https://github.com/haskell/cabal/issues/2198
- - ./dist/setup/setup test --show-details=streaming --test-option=--hide-successes
+ - cabal configure --user --ghc-option=-Werror --enable-tests --enable-benchmarks -v2 # -v2 provides useful information for debugging
+ - cabal build
+ - cabal haddock # see https://github.com/haskell/cabal/issues/2198
+ - cabal test --show-details=streaming --test-option=--hide-successes
  - cabal check
  - cabal sdist
  - install_from_tarball


### PR DESCRIPTION
Same fix as #3218, but now for `master` instead of `1.24`.