### PR TITLE
Limit qualifier depth

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Builder.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Builder.hs
@@ -180,4 +180,4 @@ buildTree idx ind igs =
     topLevelGoal qpn = OpenGoal (Simple (Dep qpn (Constrained [])) ()) [UserGoal]
 
     qpns | ind       = makeIndependent igs
-         | otherwise = L.map (Q None) igs
+         | otherwise = L.map (Q (PP DefaultNamespace Unqualified)) igs

--- a/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
@@ -308,8 +308,8 @@ deferSetupChoices = trav go
     go x                = x
 
     noSetup :: OpenGoal comp -> Bool
-    noSetup (OpenGoal (Simple (Dep (Q (Setup _ _) _) _) _) _) = False
-    noSetup _                                                 = True
+    noSetup (OpenGoal (Simple (Dep (Q (PP _ns (Setup _)) _) _) _) _) = False
+    noSetup _                                                        = True
 
 -- | Transformation that tries to avoid making weak flag choices early.
 -- Weak flags are trivial flags (not influencing dependencies) or such

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -79,8 +79,8 @@ tests = [
         , runTest $ mkTest db14 "cycleWithFlagChoice1"  ["C"]      (Just [("C", 1), ("E", 1)])
         , runTest $ mkTest db15 "cycleThroughSetupDep1" ["A"]      Nothing
         , runTest $ mkTest db15 "cycleThroughSetupDep2" ["B"]      Nothing
---        , runTest $ mkTest db15 "cycleThroughSetupDep3" ["C"]      Nothing -- TODO
---        , runTest $ mkTest db15 "cycleThroughSetupDep4" ["D"]      Nothing -- TODO
+        , runTest $ mkTest db15 "cycleThroughSetupDep3" ["C"]      (Just [("C", 2), ("D", 1)])
+        , runTest $ mkTest db15 "cycleThroughSetupDep4" ["D"]      (Just [("D", 1)])
         , runTest $ mkTest db15 "cycleThroughSetupDep5" ["E"]      (Just [("C", 2), ("D", 1), ("E", 1)])
         ]
     , testGroup "Extensions" [

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -74,9 +74,14 @@ tests = [
         , runTest $ mkTest db12 "baseShim6" ["E"] (Just [("E", 1), ("syb", 2)])
         ]
     , testGroup "Cycles" [
-          runTest $ mkTest db14 "simpleCycle1"         ["A"]      Nothing
-        , runTest $ mkTest db14 "simpleCycle2"         ["A", "B"] Nothing
-        , runTest $ mkTest db14 "cycleWithFlagChoice1" ["C"]      (Just [("C", 1), ("E", 1)])
+          runTest $ mkTest db14 "simpleCycle1"          ["A"]      Nothing
+        , runTest $ mkTest db14 "simpleCycle2"          ["A", "B"] Nothing
+        , runTest $ mkTest db14 "cycleWithFlagChoice1"  ["C"]      (Just [("C", 1), ("E", 1)])
+        , runTest $ mkTest db15 "cycleThroughSetupDep1" ["A"]      Nothing
+        , runTest $ mkTest db15 "cycleThroughSetupDep2" ["B"]      Nothing
+--        , runTest $ mkTest db15 "cycleThroughSetupDep3" ["C"]      Nothing -- TODO
+--        , runTest $ mkTest db15 "cycleThroughSetupDep4" ["D"]      Nothing -- TODO
+        , runTest $ mkTest db15 "cycleThroughSetupDep5" ["E"]      (Just [("C", 2), ("D", 1), ("E", 1)])
         ]
     , testGroup "Extensions" [
           runTest $ mkTestExts [EnableExtension CPP] dbExts1 "unsupported" ["A"] Nothing
@@ -458,6 +463,29 @@ db14 = [
   , Right $ exAv "C" 1 [exFlag "flagC" [ExAny "D"] [ExAny "E"]]
   , Right $ exAv "D" 1 [ExAny "C"]
   , Right $ exAv "E" 1 []
+  ]
+
+-- | Cycles through setup dependencies
+--
+-- The first cycle is unsolvable: package A has a setup dependency on B,
+-- B has a regular dependency on A, and we only have a single version available
+-- for both.
+--
+-- The second cycle can be broken by picking different versions: package C-2.0
+-- has a setup dependency on D, and D has a regular dependency on C-*. However,
+-- version C-1.0 is already available (perhaps it didn't have this setup dep).
+-- Thus, we should be able to break this cycle even if we are installing package
+-- E, which explictly depends on C-2.0.
+db15 :: ExampleDb
+db15 = [
+    -- First example (real cycle, no solution)
+    Right $ exAv   "A" 1            []            `withSetupDeps` [ExAny "B"]
+  , Right $ exAv   "B" 1            [ExAny "A"]
+    -- Second example (cycle can be broken by picking versions carefully)
+  , Left  $ exInst "C" 1 "C-1-inst" []
+  , Right $ exAv   "C" 2            []            `withSetupDeps` [ExAny "D"]
+  , Right $ exAv   "D" 1            [ExAny "C"  ]
+  , Right $ exAv   "E" 1            [ExFix "C" 2]
   ]
 
 dbExts1 :: ExampleDb


### PR DESCRIPTION
This PR changes the structure of package paths to:

``` haskell
data PP        = PP Namespace Qualifier
data Namespace = DefaultNamespace | Independent Int
data Qualifier = Unqualified | Base PN | Setup PN
```

This separates out a _namespace_ from a _qualifier_; the same space is just used to distinguish top-level goals, which are supposed to be entirely independent from each other. Qualifiers are used when we want to make independent choices for dependencies. Crucially, qualifiers do not have any kind of nesting structure. This addresses the problem described in detail in #3160, but it also introduces a change in behaviour; we will find fewer solutions (though still strictly more solutions than existing released versions of cabal). 

My suggestion would be that @dcoutts first cherry-picks this PR into the nix-local-build branch so we can experiment with it, before we merge this into master. 