### PR TITLE
Fix construction of conflict sets during check for single instance restriction (maybe)

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
@@ -23,7 +23,6 @@ import qualified Data.Map as M
 import Data.Monoid
 import Control.Applicative
 #endif
-import qualified Data.Set as S
 import Prelude hiding (sequence)
 import Control.Monad.Reader hiding (sequence)
 import Data.Map (Map)
@@ -373,13 +372,13 @@ enforceSingleInstanceRestriction = (`runReader` M.empty) . cata go
 
     -- We just verify package choices.
     go (PChoiceF qpn gr cs) =
-      PChoice qpn gr <$> sequence (P.mapWithKey (goP qpn) cs)
+      PChoice qpn gr <$> sequence (P.mapWithKey (goP qpn gr) cs)
     go _otherwise =
       innM _otherwise
 
     -- The check proper
-    goP :: QPN -> POption -> EnforceSIR (Tree QGoalReasonChain) -> EnforceSIR (Tree QGoalReasonChain)
-    goP qpn@(Q _ pn) (POption i linkedTo) r = do
+    goP :: QPN -> QGoalReasonChain -> POption -> EnforceSIR (Tree QGoalReasonChain) -> EnforceSIR (Tree QGoalReasonChain)
+    goP qpn@(Q _ pn) gr (POption i linkedTo) r = do
       let inst = PI pn i
       env <- ask
       case (linkedTo, M.lookup inst env) of
@@ -389,6 +388,6 @@ enforceSingleInstanceRestriction = (`runReader` M.empty) . cata go
         (Nothing, Nothing) ->
           -- Not linked, not already used
           local (M.insert inst qpn) r
-        (Nothing, Just qpn') -> do
+        (Nothing, Just _) -> do
           -- Not linked, already used. This is an error
-          return $ Fail (S.fromList [P qpn, P qpn']) MultipleInstances
+          return $ Fail (toConflictSet (Goal (P qpn) gr)) MultipleInstances

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -463,17 +463,30 @@ db14 = [
   , Right $ exAv "E" 1 []
   ]
 
--- | When A and B are installed as independent goals, the single instance
+-- | Check that the solver can backtrack after encountering the SIR
+--
+-- When A and B are installed as independent goals, the single instance
 -- restriction prevents B from depending on C.  This database tests that the
 -- solver can backtrack after encountering the single instance restriction and
--- choose the only valid flag assignment (-flagA +flagB).
+-- choose the only valid flag assignment (-flagA +flagB):
+--
+-- > flagA flagB  B depends on
+-- >  On    _     C-*
+-- >  Off   On    E-*               <-- only valid flag assignment
+-- >  Off   Off   D-2.0, C-*
+--
+-- Since A depends on C-* and D-1.0, and C-1.0 depends on any version of D,
+-- we must build C-1.0 against D-1.0. Since B depends on D-2.0, we cannot have
+-- C in the transitive closure of B's dependencies, because that would mean we
+-- would need two instances of C: one built against D-1.0 and one built against
+-- D-2.0.
 db16 :: ExampleDb
 db16 = [
     Right $ exAv "A" 1 [ExAny "C", ExFix "D" 1]
   , Right $ exAv "B" 1 [ ExFix "D" 2
-                       , ExFlag "flagA"
+                       , exFlag "flagA"
                              [ExAny "C"]
-                             [ExFlag "flagB"
+                             [exFlag "flagB"
                                  [ExAny "E"]
                                  [ExAny "C"]]]
   , Right $ exAv "C" 1 [ExAny "D"]


### PR DESCRIPTION
If correct, this fixes #2843; the first commit is basically @grayjay 's detailed test case (for which many thanks!). However, this needs review by @kosmikus ; have sent a detailed email. 