### PR TITLE
Project config

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -39,7 +39,9 @@ module Distribution.Client.Config (
     withProgramOptionsFields,
     userConfigDiff,
     userConfigUpdate,
-    createDefaultConfigFile
+    createDefaultConfigFile,
+
+    remoteRepoFields
   ) where
 
 import Distribution.Client.Types

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -258,6 +258,9 @@ data ConstraintSource =
   -- | Main config file, which is ~/.cabal/config by default.
   ConstraintSourceMainConfig FilePath
 
+  -- | Local cabal.project file
+  | ConstraintSourceProjectConfig FilePath
+
   -- | Sandbox config file, which is ./cabal.sandbox.config by default.
   | ConstraintSourceSandboxConfig FilePath
 
@@ -295,6 +298,8 @@ instance Binary ConstraintSource
 showConstraintSource :: ConstraintSource -> String
 showConstraintSource (ConstraintSourceMainConfig path) =
     "main config " ++ path
+showConstraintSource (ConstraintSourceProjectConfig path) =
+    "project config " ++ path
 showConstraintSource (ConstraintSourceSandboxConfig path) =
     "sandbox config " ++ path
 showConstraintSource (ConstraintSourceUserConfig path)= "user config " ++ path

--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE RecordWildCards #-}
+
+-- | 
+--
+-- The layout of the .\/dist\/ directory where cabal keeps all of it's state
+-- and build artifacts.
+--
+module Distribution.Client.DistDirLayout where
+
+import System.FilePath
+import Distribution.Package
+         ( PackageId )
+import Distribution.Compiler
+import Distribution.Simple.Compiler (PackageDB(..))
+import Distribution.Text
+import Distribution.Client.Types
+         ( InstalledPackageId )
+
+
+
+-- | The layout of the project state directory. Traditionally this has been
+-- called the @dist@ directory.
+--
+data DistDirLayout = DistDirLayout {
+
+        -- | The dist directory, which is the root of where cabal keeps all its
+       -- state including the build artifacts from each package we build.
+       --
+       distDirectory                :: FilePath,
+
+       -- | The directory under dist where we keep the build artifacts for a
+       -- package we're building from a local directory.
+       --
+       -- This uses a 'PackageId' not just a 'PackageName' because technically
+       -- we can have multiple instances of the same package in a solution
+       -- (e.g. setup deps).
+       --
+       distBuildDirectory           :: PackageId -> FilePath,
+       distBuildRootDirectory       :: FilePath,
+
+       -- | The directory under dist where we put the unpacked sources of
+       -- packages, in those cases where it makes sense to keep the build
+       -- artifacts to reduce rebuild times. These can be tarballs or could be
+       -- scm repos.
+       --
+       distUnpackedSrcDirectory     :: PackageId -> FilePath,
+       distUnpackedSrcRootDirectory :: FilePath,
+
+       -- | The location for project-wide cache files (e.g. state used in
+       -- incremental rebuilds).
+       --
+       distProjectCacheFile         :: String -> FilePath,
+       distProjectCacheDirectory    :: FilePath,
+
+       -- | The location for package-specific cache files (e.g. state used in
+       -- incremental rebuilds).
+       --
+       distPackageCacheFile         :: PackageId -> String -> FilePath,
+       distPackageCacheDirectory    :: PackageId -> FilePath,
+
+       distTempDirectory            :: FilePath,
+       distBinDirectory             :: FilePath,
+
+       distPackageDB                :: CompilerId -> PackageDB
+     }
+
+
+
+--TODO: move to another module, e.g. CabalDirLayout?
+data CabalDirLayout = CabalDirLayout {
+       cabalStoreDirectory        :: CompilerId -> FilePath,
+       cabalStorePackageDirectory :: CompilerId -> InstalledPackageId
+                                                -> FilePath,
+       cabalStorePackageDBPath    :: CompilerId -> FilePath,
+       cabalStorePackageDB        :: CompilerId -> PackageDB,
+
+       cabalPackageCacheDirectory :: FilePath,
+       cabalLogsDirectory         :: FilePath,
+       cabalWorldFile             :: FilePath
+     }
+
+
+defaultDistDirLayout :: FilePath -> DistDirLayout
+defaultDistDirLayout projectRootDirectory =
+    DistDirLayout {..}
+  where
+    distDirectory = projectRootDirectory </> "dist-newstyle"
+    --TODO: switch to just dist at some point, or some other new name
+
+    distBuildRootDirectory   = distDirectory </> "build"
+    distBuildDirectory pkgid = distBuildRootDirectory </> display pkgid
+
+    distUnpackedSrcRootDirectory   = distDirectory </> "src"
+    distUnpackedSrcDirectory pkgid = distUnpackedSrcRootDirectory
+                                      </> display pkgid
+
+    distProjectCacheDirectory = distDirectory </> "cache"
+    distProjectCacheFile name = distProjectCacheDirectory </> name
+
+    distPackageCacheDirectory pkgid = distBuildDirectory pkgid </> "cache"
+    distPackageCacheFile pkgid name = distPackageCacheDirectory pkgid </> name
+
+    distTempDirectory = distDirectory </> "tmp"
+
+    distBinDirectory = distDirectory </> "bin"
+
+    distPackageDBPath compid = distDirectory </> "packagedb" </> display compid
+    distPackageDB = SpecificPackageDB . distPackageDBPath
+
+
+
+defaultCabalDirLayout :: FilePath -> CabalDirLayout
+defaultCabalDirLayout cabalDir =
+    CabalDirLayout {..}
+  where
+
+    cabalStoreDirectory compid =
+      cabalDir </> "store" </> display compid
+
+    cabalStorePackageDirectory compid ipkgid = 
+      cabalStoreDirectory compid </> display ipkgid
+
+    cabalStorePackageDBPath compid =
+      cabalStoreDirectory compid </> "package.db"
+
+    cabalStorePackageDB =
+      SpecificPackageDB . cabalStorePackageDBPath
+
+    cabalPackageCacheDirectory = cabalDir </> "packages"
+
+    cabalLogsDirectory = cabalDir </> "logs"
+
+    cabalWorldFile = cabalDir </> "world"
+

--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -24,6 +24,7 @@ module Distribution.Client.FileMonitor (
   beginUpdateFileMonitor,
 
   matchFileGlob,
+  isTrivialFilePathGlob,
   ) where
 
 
@@ -804,6 +805,14 @@ matchFileGlob root glob0 = go glob0 ""
       concat <$> mapM (\subdir -> go globPath (dir </> subdir)) subdirs
 --TODO: [code cleanup] plausibly FilePathGlob and matchFileGlob should be
 -- moved into D.C.Glob and/or merged with similar functionality in Cabal.
+
+
+isTrivialFilePathGlob :: FilePathGlob -> Maybe FilePath
+isTrivialFilePathGlob = go []
+  where
+    go paths (GlobDir  (Glob [Literal path]) globs) = go (path:paths) globs
+    go paths (GlobFile (Glob [Literal path])) = Just (joinPath (reverse (path:paths)))
+    go _ _ = Nothing
 
 -- | We really want to avoid re-hashing files all the time. We already make
 -- the assumption that if a file mtime has not changed then we don't need to

--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -807,6 +807,13 @@ matchFileGlob root glob0 = go glob0 ""
 -- moved into D.C.Glob and/or merged with similar functionality in Cabal.
 
 
+-- | Check if a 'FilePathGlob' doesn't actually make use of any globbing and
+-- is in fact equivalent to a non-glob 'FilePath'.
+--
+-- If it is trivial in this sense then the result is the equivalent constant
+-- 'FilePath'. On the other hand if it is not trivial (so could in principle
+-- match more than one file) then the result is @Nothing@.
+--
 isTrivialFilePathGlob :: FilePathGlob -> Maybe FilePath
 isTrivialFilePathGlob = go []
   where

--- a/cabal-install/Distribution/Client/ParseUtils.hs
+++ b/cabal-install/Distribution/Client/ParseUtils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ExistentialQuantification, NamedFieldPuns #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.ParseUtils
@@ -7,13 +9,41 @@
 -- Parsing utilities.
 -----------------------------------------------------------------------------
 
-module Distribution.Client.ParseUtils ( parseFields, ppFields, ppSection )
+module Distribution.Client.ParseUtils (
+
+    -- * Fields and field utilities
+    FieldDescr(..),
+    liftField,
+    liftFields,
+    filterFields,
+    mapFieldNames,
+    commandOptionToField,
+    commandOptionsToFields,
+
+    -- * Sections and utilities
+    SectionDescr(..),
+    liftSection,
+
+    -- * Parsing and printing flat config
+    parseFields,
+    ppFields,
+    ppSection,
+
+    -- * Parsing and printing config with sections and subsections
+    parseFieldsAndSections,
+    ppFieldsAndSections,
+
+    -- ** Top level of config files
+    parseConfig,
+    showConfig,
+  )
        where
 
 import Distribution.ParseUtils
-         ( FieldDescr(..), ParseResult(..), warning, lineNo )
-import qualified Distribution.ParseUtils as ParseUtils
-         ( Field(..) )
+         ( FieldDescr(..), ParseResult(..), warning, LineNo, lineNo
+         , Field(..), liftField, readFieldsFlat )
+import Distribution.Simple.Command
+         ( OptionField, viewAsFieldDescr )
 
 import Control.Monad    ( foldM )
 import Text.PrettyPrint ( (<>), (<+>), ($+$) )
@@ -21,17 +51,101 @@ import qualified Data.Map as Map
 import qualified Text.PrettyPrint as Disp
          ( Doc, text, colon, vcat, empty, isEmpty, nest )
 
-parseFields :: [FieldDescr a] -> a -> [ParseUtils.Field] -> ParseResult a
-parseFields fields = foldM setField
+
+-------------------------
+-- FieldDescr utilities
+--
+
+liftFields :: (b -> a)
+           -> (a -> b -> b)
+           -> [FieldDescr a]
+           -> [FieldDescr b]
+liftFields get set = map (liftField get set)
+
+
+-- | Given a collection of field descriptions, keep only a given list of them,
+-- identified by name.
+--
+filterFields :: [String] -> [FieldDescr a] -> [FieldDescr a]
+filterFields includeFields = filter ((`elem` includeFields) . fieldName)
+
+-- | Apply a name mangling function to the field names of all the field
+-- descriptions. The typical use case is to apply some prefix.
+--
+mapFieldNames :: (String -> String) -> [FieldDescr a] -> [FieldDescr a]
+mapFieldNames mangleName =
+    map (\descr -> descr { fieldName = mangleName (fieldName descr) })
+
+
+-- | Reuse a command line 'OptionField' as a config file 'FieldDescr'.
+--
+commandOptionToField :: OptionField a -> FieldDescr a
+commandOptionToField = viewAsFieldDescr
+
+-- | Reuse a bunch of command line 'OptionField's as config file 'FieldDescr's.
+--
+commandOptionsToFields :: [OptionField a] -> [FieldDescr a]
+commandOptionsToFields = map viewAsFieldDescr
+
+
+------------------------------------------
+-- SectionDescr definition and utilities
+--
+
+-- | The description of a section in a config file. It can contains both
+-- fields and optionally further subsections. See also 'FieldDescr'.
+--
+data SectionDescr a = forall b. SectionDescr {
+       sectionName        :: String,
+       sectionFields      :: [FieldDescr b],
+       sectionSubsections :: [SectionDescr b],
+       sectionGet         :: a -> [(String, b)],
+       sectionSet         :: LineNo -> String -> b -> a -> ParseResult a,
+       sectionEmpty       :: b
+     }
+
+-- | To help construction of config file descriptions in a modular way it is
+-- useful to define fields and sections on local types and then hoist them
+-- into the parent types when combining them in bigger descriptions.
+--
+-- This is essentially a lens operation for 'SectionDescr' to help embedding
+-- one inside another.
+--
+liftSection :: (b -> a)
+            -> (a -> b -> b)
+            -> SectionDescr a
+            -> SectionDescr b
+liftSection get' set' (SectionDescr name fields sections get set empty) =
+    let sectionGet' = get . get'
+        sectionSet' lineno param x y = do
+          x' <- set lineno param x (get' y)
+          return (set' x' y)
+     in SectionDescr name fields sections sectionGet' sectionSet' empty
+
+
+-------------------------------------
+-- Parsing and printing flat config
+--
+
+-- | Parse a bunch of semi-parsed 'Field's according to a set of field
+-- descriptions. It accumulates the result on top of a given initial value.
+--
+-- This only covers the case of flat configuration without subsections. See
+-- also 'parseFieldsAndSections'.
+--
+parseFields :: [FieldDescr a] -> a -> [Field] -> ParseResult a
+parseFields fieldDescrs =
+    foldM setField
   where
-    fieldMap = Map.fromList
-      [ (name, f) | f@(FieldDescr name _ _) <- fields ]
-    setField accum (ParseUtils.F line name value) =
+    fieldMap = Map.fromList [ (fieldName f, f) | f <- fieldDescrs ]
+
+    setField accum (F line name value) =
       case Map.lookup name fieldMap of
         Just (FieldDescr _ _ set) -> set line value accum
         Nothing -> do
           warning $ "Unrecognized field " ++ name ++ " on line " ++ show line
           return accum
+
     setField accum f = do
       warning $ "Unrecognized stanza on line " ++ show (lineNo f)
       return accum
@@ -40,8 +154,9 @@ parseFields fields = foldM setField
 -- that also optionally print default values for empty fields as comments.
 --
 ppFields :: [FieldDescr a] -> (Maybe a) -> a -> Disp.Doc
-ppFields fields def cur = Disp.vcat [ ppField name (fmap getter def) (getter cur)
-                                    | FieldDescr name getter _ <- fields]
+ppFields fields def cur =
+    Disp.vcat [ ppField name (fmap getter def) (getter cur)
+              | FieldDescr name getter _ <- fields]
 
 ppField :: String -> (Maybe Disp.Doc) -> Disp.Doc -> Disp.Doc
 ppField name mdef cur
@@ -50,6 +165,11 @@ ppField name mdef cur
                                 <> Disp.colon <+> def) mdef
   | otherwise        = Disp.text name <> Disp.colon <+> cur
 
+-- | Pretty print a section.
+--
+-- Since 'ppFields' does not cover subsections you can use this to add them.
+-- Or alternatively use a 'SectionDescr' and use 'ppFieldsAndSections'.
+--
 ppSection :: String -> String -> [FieldDescr a] -> (Maybe a) -> a -> Disp.Doc
 ppSection name arg fields def cur
   | Disp.isEmpty fieldsDoc = Disp.empty
@@ -59,3 +179,101 @@ ppSection name arg fields def cur
     fieldsDoc = ppFields fields def cur
     argDoc | arg == "" = Disp.empty
            | otherwise = Disp.text arg
+
+
+-----------------------------------------
+-- Parsing and printing non-flat config
+--
+
+-- | Much like 'parseFields' but it also allows subsections. The permitted
+-- subsections are given by a list of 'SectionDescr's.
+--
+parseFieldsAndSections :: [FieldDescr a] -> [SectionDescr a] -> a
+                       -> [Field] -> ParseResult a
+parseFieldsAndSections fieldDescrs sectionDescrs =
+    foldM setField
+  where
+    fieldMap   = Map.fromList [ (fieldName   f, f) | f <- fieldDescrs   ]
+    sectionMap = Map.fromList [ (sectionName s, s) | s <- sectionDescrs ]
+
+    setField a (F line name value) =
+      case Map.lookup name fieldMap of
+        Just (FieldDescr _ _ set) -> set line value a
+        Nothing -> do
+          warning $ "Unrecognized field '" ++ name
+                 ++ "' on line " ++ show line
+          return a
+
+    setField a (Section line name param fields) =
+      case Map.lookup name sectionMap of
+        Just (SectionDescr _ fieldDescrs' sectionDescrs' _ set sectionEmpty) -> do
+          b <- parseFieldsAndSections fieldDescrs' sectionDescrs' sectionEmpty fields
+          set line param b a
+        Nothing -> do
+          warning $ "Unrecognized section '" ++ name
+                 ++ "' on line " ++ show line
+          return a
+
+    setField accum (block@IfBlock {}) = do
+      warning $ "Unrecognized stanza on line " ++ show (lineNo block)
+      return accum
+
+-- | Much like 'ppFields' but also pretty prints any subsections. Subsection
+-- are only shown if they are non-empty.
+--
+-- Note that unlike 'ppFields', at present it does not support printing
+-- default values. If needed, adding such support would be quite reasonable.
+--
+ppFieldsAndSections :: [FieldDescr a] -> [SectionDescr a] -> a -> Disp.Doc
+ppFieldsAndSections fieldDescrs sectionDescrs val =
+    ppFields fieldDescrs Nothing val
+      $+$
+    Disp.vcat
+      [ Disp.text "" $+$ sectionDoc
+      | SectionDescr {
+          sectionName, sectionGet,
+          sectionFields, sectionSubsections
+        } <- sectionDescrs
+      , (param, x) <- sectionGet val
+      , let sectionDoc = ppSectionAndSubsections
+                           sectionName param
+                           sectionFields sectionSubsections x
+      , not (Disp.isEmpty sectionDoc)
+      ]
+
+-- | Unlike 'ppSection' which has to be called directly, this gets used via
+-- 'ppFieldsAndSections' and so does not need to be exported.
+--
+ppSectionAndSubsections :: String -> String
+                        -> [FieldDescr a] -> [SectionDescr a] -> a -> Disp.Doc
+ppSectionAndSubsections name arg fields sections cur
+  | Disp.isEmpty fieldsDoc = Disp.empty
+  | otherwise              = Disp.text name <+> argDoc
+                             $+$ (Disp.nest 2 fieldsDoc)
+  where
+    fieldsDoc = showConfig fields sections cur
+    argDoc | arg == "" = Disp.empty
+           | otherwise = Disp.text arg
+
+
+-----------------------------------------------
+-- Top level config file parsing and printing
+--
+
+-- | Parse a string in the config file syntax into a value, based on a
+-- description of the configuration file in terms of its fields and sections.
+--
+-- It accumulates the result on top of a given initial (typically empty) value.
+--
+parseConfig :: [FieldDescr a] -> [SectionDescr a] -> a
+            -> String -> ParseResult a
+parseConfig fieldDescrs sectionDescrs empty str =
+      parseFieldsAndSections fieldDescrs sectionDescrs empty
+  =<< readFieldsFlat str
+
+-- | Render a value in the config file syntax, based on a description of the
+-- configuration file in terms of its fields and sections.
+--
+showConfig :: [FieldDescr a] -> [SectionDescr a] -> a -> Disp.Doc
+showConfig = ppFieldsAndSections
+

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -1,0 +1,678 @@
+{-# LANGUAGE CPP, RecordWildCards, NamedFieldPuns, DeriveDataTypeable #-}
+
+-- | Handling project configuration.
+--
+module Distribution.Client.ProjectConfig (
+
+    -- * Types for project config
+    ProjectConfig(..),
+    ProjectConfigBuildOnly(..),
+    ProjectConfigShared(..),
+    PackageConfig(..),
+
+    -- * Project config files
+    findProjectRoot,
+    readProjectConfig,
+    writeProjectLocalExtraConfig,
+    writeProjectConfigFile,
+    commandLineFlagsToProjectConfig,
+
+    -- * Packages within projects
+    ProjectPackageLocation(..),
+    BadPackageLocation(..),
+    BadPackageLocationMatch(..),
+    findProjectPackages,
+    readSourcePackage,
+
+    -- * Resolving configuration
+    lookupLocalPackageConfig,
+    projectConfigWithBuilderRepoContext,
+    projectConfigWithSolverRepoContext,
+    SolverSettings(..),
+    resolveSolverSettings,
+    BuildTimeSettings(..),
+    resolveBuildTimeSettings,
+  ) where
+
+import Distribution.Client.ProjectConfig.Types
+import Distribution.Client.ProjectConfig.Legacy
+import Distribution.Client.RebuildMonad
+import Distribution.Client.FileMonitor
+         ( isTrivialFilePathGlob )
+
+import Distribution.Client.Types
+import Distribution.Client.DistDirLayout
+         ( CabalDirLayout(..) )
+import Distribution.Client.Glob
+         ( Glob(..), GlobAtom(..) )
+import Distribution.Client.GlobalFlags
+         ( RepoContext(..), withRepoContext' )
+import Distribution.Client.BuildReports.Types
+         ( ReportLevel(..) )
+import Distribution.Client.Config
+         ( loadConfig, defaultConfigFile )
+
+import Distribution.Package
+         ( PackageName, PackageId, packageId, UnitId, Dependency )
+import Distribution.System
+         ( Platform )
+import Distribution.PackageDescription
+         ( SourceRepo(..) )
+import Distribution.PackageDescription.Parse
+         ( readPackageDescription )
+import Distribution.Simple.Compiler
+         ( Compiler, compilerInfo )
+import Distribution.Simple.Setup
+         ( Flag(Flag), toFlag, flagToMaybe, flagToList
+         , fromFlag, AllowNewer(..) )
+import Distribution.Client.Setup
+         ( defaultSolver, defaultMaxBackjumps, )
+import Distribution.Simple.InstallDirs
+         ( PathTemplate, fromPathTemplate
+         , toPathTemplate, substPathTemplate, initialPathTemplateEnv )
+import Distribution.Simple.Utils
+         ( die, warn )
+import Distribution.Client.Utils
+         ( determineNumJobs )
+import Distribution.Utils.NubList
+         ( fromNubList )
+import Distribution.Verbosity
+         ( Verbosity, verbose )
+import Distribution.Text
+import Distribution.ParseUtils
+         ( ParseResult(..), locatedErrorMsg, showPWarning )
+
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative
+#endif
+import Control.Monad
+import Control.Monad.Trans (liftIO)
+import Control.Exception
+import Data.Typeable
+import Data.Maybe
+import Data.Either
+import qualified Data.Map as Map
+import Distribution.Compat.Semigroup
+import System.FilePath hiding (combine)
+import System.Directory
+import Network.URI (URI(..), URIAuth(..), parseAbsoluteURI)
+
+
+----------------------------------------
+-- Resolving configuration to settings
+--
+
+-- | Look up a 'PackageConfig' field in the 'ProjectConfig' for a specific
+-- 'PackageName'. This returns the configuration that applies to all local
+-- packages plus any package-specific configuration for this package.
+--
+lookupLocalPackageConfig :: (Semigroup a, Monoid a)
+                         => (PackageConfig -> a)
+                         -> ProjectConfig
+                         -> PackageName -> a
+lookupLocalPackageConfig field ProjectConfig {
+                           projectConfigLocalPackages,
+                           projectConfigSpecificPackage
+                         } pkgname =
+    field projectConfigLocalPackages
+ <> maybe mempty field (Map.lookup pkgname projectConfigSpecificPackage)
+
+
+-- | Use a 'RepoContext' based on the 'BuildTimeSettings'.
+--
+projectConfigWithBuilderRepoContext :: Verbosity
+                                    -> BuildTimeSettings
+                                    -> (RepoContext -> IO a) -> IO a
+projectConfigWithBuilderRepoContext verbosity BuildTimeSettings{..} =
+    withRepoContext'
+      verbosity
+      buildSettingRemoteRepos
+      buildSettingLocalRepos
+      buildSettingCacheDir
+      buildSettingHttpTransport
+      (Just buildSettingIgnoreExpiry)
+
+
+-- | Use a 'RepoContext', but only for the solver. The solver does not use the
+-- full facilities of the 'RepoContext' so we can get away with making one
+-- that doesn't have an http transport. And that avoids having to have access
+-- to the 'BuildTimeSettings'
+--
+projectConfigWithSolverRepoContext :: Verbosity
+                                   -> FilePath
+                                   -> ProjectConfigShared
+                                   -> ProjectConfigBuildOnly
+                                   -> (RepoContext -> IO a) -> IO a
+projectConfigWithSolverRepoContext verbosity downloadCacheRootDir
+                                   ProjectConfigShared{..}
+                                   ProjectConfigBuildOnly{..} =
+    withRepoContext'
+      verbosity
+      (fromNubList projectConfigRemoteRepos)
+      (fromNubList projectConfigLocalRepos)
+      downloadCacheRootDir
+      (flagToMaybe projectConfigHttpTransport)
+      (flagToMaybe projectConfigIgnoreExpiry)
+
+
+-- | Resolve the project configuration, with all its optional fields, into
+-- 'SolverSettings' with no optional fields (by applying defaults).
+--
+resolveSolverSettings :: ProjectConfigShared -> SolverSettings
+resolveSolverSettings projectConfig =
+    SolverSettings {..}
+  where
+    solverSettingRemoteRepos       = fromNubList projectConfigRemoteRepos
+    solverSettingLocalRepos        = fromNubList projectConfigLocalRepos
+    solverSettingConstraints       = projectConfigConstraints
+    solverSettingPreferences       = projectConfigPreferences
+    solverSettingFlagAssignment    = projectConfigFlagAssignment
+    solverSettingCabalVersion      = flagToMaybe projectConfigCabalVersion
+    solverSettingSolver            = fromFlag projectConfigSolver
+    solverSettingAllowNewer        = fromJust projectConfigAllowNewer
+    solverSettingMaxBackjumps      = case fromFlag projectConfigMaxBackjumps of
+                                       n | n < 0     -> Nothing
+                                         | otherwise -> Just n
+    solverSettingReorderGoals      = fromFlag projectConfigReorderGoals
+    solverSettingStrongFlags       = fromFlag projectConfigStrongFlags
+  --solverSettingIndependentGoals  = fromFlag projectConfigIndependentGoals
+  --solverSettingShadowPkgs        = fromFlag projectConfigShadowPkgs
+  --solverSettingReinstall         = fromFlag projectConfigReinstall
+  --solverSettingAvoidReinstalls   = fromFlag projectConfigAvoidReinstalls
+  --solverSettingOverrideReinstall = fromFlag projectConfigOverrideReinstall
+  --solverSettingUpgradeDeps       = fromFlag projectConfigUpgradeDeps
+
+    ProjectConfigShared {..} = defaults <> projectConfig
+
+    defaults = mempty {
+       projectConfigSolver            = Flag defaultSolver,
+       projectConfigAllowNewer        = Just AllowNewerNone,
+       projectConfigMaxBackjumps      = Flag defaultMaxBackjumps,
+       projectConfigReorderGoals      = Flag False,
+       projectConfigStrongFlags       = Flag False
+     --projectConfigIndependentGoals  = Flag False,
+     --projectConfigShadowPkgs        = Flag False,
+     --projectConfigReinstall         = Flag False,
+     --projectConfigAvoidReinstalls   = Flag False,
+     --projectConfigOverrideReinstall = Flag False,
+     --projectConfigUpgradeDeps       = Flag False
+    }
+
+
+-- | Resolve the project configuration, with all its optional fields, into
+-- 'BuildTimeSettings' with no optional fields (by applying defaults).
+--
+resolveBuildTimeSettings :: Verbosity
+                         -> CabalDirLayout
+                         -> ProjectConfigShared
+                         -> ProjectConfigBuildOnly
+                         -> ProjectConfigBuildOnly
+                         -> BuildTimeSettings
+resolveBuildTimeSettings verbosity
+                         CabalDirLayout {
+                           cabalLogsDirectory,
+                           cabalPackageCacheDirectory
+                         }
+                         ProjectConfigShared {
+                           projectConfigRemoteRepos,
+                           projectConfigLocalRepos
+                         }
+                         fromProjectFile
+                         fromCommandLine =
+    BuildTimeSettings {..}
+  where
+    buildSettingDryRun        = fromFlag    projectConfigDryRun
+    buildSettingOnlyDeps      = fromFlag    projectConfigOnlyDeps
+    buildSettingSummaryFile   = fromNubList projectConfigSummaryFile
+    --buildSettingLogFile       -- defined below, more complicated 
+    --buildSettingLogVerbosity  -- defined below, more complicated
+    buildSettingBuildReports  = fromFlag    projectConfigBuildReports
+    buildSettingSymlinkBinDir = flagToList  projectConfigSymlinkBinDir
+    buildSettingOneShot       = fromFlag    projectConfigOneShot
+    buildSettingNumJobs       = determineNumJobs projectConfigNumJobs
+    buildSettingOfflineMode   = fromFlag    projectConfigOfflineMode
+    buildSettingKeepTempFiles = fromFlag    projectConfigKeepTempFiles
+    buildSettingRemoteRepos   = fromNubList projectConfigRemoteRepos
+    buildSettingLocalRepos    = fromNubList projectConfigLocalRepos
+    buildSettingCacheDir      = cabalPackageCacheDirectory
+    buildSettingHttpTransport = flagToMaybe projectConfigHttpTransport
+    buildSettingIgnoreExpiry  = fromFlag    projectConfigIgnoreExpiry
+    buildSettingReportPlanningFailure
+                              = fromFlag projectConfigReportPlanningFailure
+    buildSettingRootCmd       = flagToMaybe projectConfigRootCmd
+
+    ProjectConfigBuildOnly{..} = defaults
+                              <> fromProjectFile
+                              <> fromCommandLine
+
+    defaults = mempty {
+      projectConfigDryRun                = toFlag False,
+      projectConfigOnlyDeps              = toFlag False,
+      projectConfigBuildReports          = toFlag NoReports,
+      projectConfigReportPlanningFailure = toFlag False,
+      projectConfigOneShot               = toFlag False,
+      projectConfigOfflineMode           = toFlag False,
+      projectConfigKeepTempFiles         = toFlag False,
+      projectConfigIgnoreExpiry          = toFlag False
+    }
+
+    -- The logging logic: what log file to use and what verbosity.
+    --
+    -- If the user has specified --remote-build-reporting=detailed, use the
+    -- default log file location. If the --build-log option is set, use the
+    -- provided location. Otherwise don't use logging, unless building in
+    -- parallel (in which case the default location is used).
+    --
+    buildSettingLogFile :: Maybe (Compiler -> Platform
+                               -> PackageId -> UnitId -> FilePath)
+    buildSettingLogFile
+      | useDefaultTemplate = Just (substLogFileName defaultTemplate)
+      | otherwise          = fmap  substLogFileName givenTemplate
+
+    defaultTemplate = toPathTemplate $
+                        cabalLogsDirectory </> "$pkgid" <.> "log"
+    givenTemplate   = flagToMaybe projectConfigLogFile
+
+    useDefaultTemplate
+      | buildSettingBuildReports == DetailedReports = True
+      | isJust givenTemplate                        = False
+      | isParallelBuild                             = True
+      | otherwise                                   = False
+
+    isParallelBuild = buildSettingNumJobs >= 2
+
+    substLogFileName :: PathTemplate
+                     -> Compiler -> Platform
+                     -> PackageId -> UnitId -> FilePath
+    substLogFileName template compiler platform pkgid uid =
+        fromPathTemplate (substPathTemplate env template)
+      where
+        env = initialPathTemplateEnv
+                pkgid uid (compilerInfo compiler) platform
+
+    -- If the user has specified --remote-build-reporting=detailed or
+    -- --build-log, use more verbose logging.
+    --
+    buildSettingLogVerbosity
+      | overrideVerbosity = max verbose verbosity
+      | otherwise         = verbosity
+
+    overrideVerbosity
+      | buildSettingBuildReports == DetailedReports = True
+      | isJust givenTemplate                        = True
+      | isParallelBuild                             = False
+      | otherwise                                   = False
+
+
+---------------------------------------------
+-- Reading and writing project config files
+--
+
+-- | Find the root of this project.
+--
+-- Searches for an explicit @cabal.project@ file, in the current directory or
+-- parent directories. If no project file is found then the current dir is the
+-- project root (and the project will use an implicit config).
+--
+findProjectRoot :: IO FilePath
+findProjectRoot = do
+
+    curdir  <- getCurrentDirectory
+    homedir <- getHomeDirectory
+
+    -- Search upwards. If we get to the users home dir or the filesystem root,
+    -- then use the current dir
+    let probe dir | isDrive dir || dir == homedir
+                  = return curdir -- implicit project root
+        probe dir = do
+          exists <- doesFileExist (dir </> "cabal.project")
+          if exists
+            then return dir       -- explicit project root
+            else probe (takeDirectory dir)
+
+    probe curdir
+   --TODO: [nice to have] add compat support for old style sandboxes
+
+
+-- | Read all the config relevant for a project. This includes the project
+-- file if any, plus other global config.
+--
+readProjectConfig :: Verbosity -> FilePath -> Rebuild ProjectConfig
+readProjectConfig verbosity projectRootDir = do
+    global <- readGlobalConfig verbosity
+    local  <- readProjectLocalConfig      verbosity projectRootDir
+    extra  <- readProjectLocalExtraConfig verbosity projectRootDir
+    return (global <> local <> extra)
+
+
+-- | Reads an explicit @cabal.project@ file in the given project root dir,
+-- or returns the default project config for an implicitly defined project.
+--
+readProjectLocalConfig :: Verbosity -> FilePath -> Rebuild ProjectConfig
+readProjectLocalConfig verbosity projectRootDir = do
+  usesExplicitProjectRoot <- liftIO $ doesFileExist projectFile
+  if usesExplicitProjectRoot
+    then do
+      monitorFiles [MonitorFileHashed projectFile]
+      liftIO readProjectFile
+    else do
+      monitorFiles [MonitorNonExistentFile projectFile]
+      return defaultImplicitProjectConfig
+
+  where
+    projectFile = projectRootDir </> "cabal.project"
+    readProjectFile =
+          reportParseResult verbosity "project file" projectFile
+        . parseProjectConfig
+      =<< readFile projectFile
+
+    defaultImplicitProjectConfig :: ProjectConfig
+    defaultImplicitProjectConfig =
+      mempty {
+        -- We expect a package in the current directory.
+        projectPackages         = [ "./*.cabal" ],
+
+        -- This is to automatically pick up deps that we unpack locally.
+        projectPackagesOptional = [ "./*/*.cabal" ]
+      }
+
+
+-- | Reads a @cabal.project.extra@ file in the given project root dir,
+-- or returns empty. This file gets written by @cabal configure@, or in
+-- principle can be edited manually or by other tools.
+--
+readProjectLocalExtraConfig :: Verbosity -> FilePath -> Rebuild ProjectConfig
+readProjectLocalExtraConfig verbosity projectRootDir = do
+    hasExtraConfig <- liftIO $ doesFileExist projectExtraConfigFile
+    if hasExtraConfig
+      then do monitorFiles [MonitorFileHashed projectExtraConfigFile]
+              liftIO readProjectExtraConfigFile
+      else do monitorFiles [MonitorNonExistentFile projectExtraConfigFile]
+              return mempty
+  where
+    projectExtraConfigFile = projectRootDir </> "cabal.project.extra"
+
+    readProjectExtraConfigFile =
+          reportParseResult verbosity "project extra configuration file"
+                            projectExtraConfigFile
+        . parseProjectConfig
+      =<< readFile projectExtraConfigFile
+
+
+-- | Parse the 'ProjectConfig' format.
+--
+-- For the moment this is implemented in terms of parsers for legacy
+-- configuration types, plus a conversion.
+--
+parseProjectConfig :: String -> ParseResult ProjectConfig
+parseProjectConfig content =
+    convertLegacyProjectConfig <$>
+      parseLegacyProjectConfig content
+
+
+-- | Render the 'ProjectConfig' format.
+--
+-- For the moment this is implemented in terms of a pretty printer for the
+-- legacy configuration types, plus a conversion.
+--
+showProjectConfig :: ProjectConfig -> String
+showProjectConfig =
+    showLegacyProjectConfig . convertToLegacyProjectConfig
+
+
+-- | Write a @cabal.project.extra@ file in the given project root dir.
+--
+writeProjectLocalExtraConfig :: FilePath -> ProjectConfig -> IO ()
+writeProjectLocalExtraConfig projectRootDir =
+    writeProjectConfigFile projectExtraConfigFile
+  where
+    projectExtraConfigFile = projectRootDir </> "cabal.project.extra"
+
+
+-- | Write in the @cabal.project@ format to the given file.
+--
+writeProjectConfigFile :: FilePath -> ProjectConfig -> IO ()
+writeProjectConfigFile file =
+    writeFile file . showProjectConfig
+
+
+-- | Read the user's @~/.cabal/config@ file.
+--
+readGlobalConfig :: Verbosity -> Rebuild ProjectConfig
+readGlobalConfig verbosity = do
+    config     <- liftIO (loadConfig verbosity mempty)
+    configFile <- liftIO defaultConfigFile
+    monitorFiles [MonitorFileHashed configFile]
+    return (convertLegacyGlobalConfig config)
+    --TODO: do this properly, there's several possible locations
+    -- and env vars, and flags for selecting the global config
+
+
+reportParseResult :: Verbosity -> String -> FilePath -> ParseResult a -> IO a
+reportParseResult verbosity _filetype filename (ParseOk warnings x) = do
+    unless (null warnings) $
+      let msg = unlines (map (showPWarning filename) warnings)
+       in warn verbosity msg
+    return x
+reportParseResult _verbosity filetype filename (ParseFailed err) =
+    let (line, msg) = locatedErrorMsg err
+     in die $ "Error parsing " ++ filetype ++ " " ++ filename
+           ++ maybe "" (\n -> ':' : show n) line ++ ":\n" ++ msg
+
+
+---------------------------------------------
+-- Reading packages in the project
+--
+
+data ProjectPackageLocation =
+     ProjectPackageLocalCabalFile FilePath
+   | ProjectPackageLocalDirectory FilePath FilePath -- dir and .cabal file
+   | ProjectPackageLocalTarball   FilePath
+   | ProjectPackageRemoteTarball  URI
+   | ProjectPackageRemoteRepo     SourceRepo
+   | ProjectPackageNamed          Dependency
+  deriving Show
+
+
+-- | Exception thrown by 'findProjectPackages'.
+--
+newtype BadPackageLocations = BadPackageLocations [BadPackageLocation]
+  deriving (Show, Typeable)
+
+instance Exception BadPackageLocations
+--TODO: [required eventually] displayException for nice rendering
+--TODO: [nice to have] custom exception subclass for Doc rendering, colour etc
+
+data BadPackageLocation
+   = BadPackageLocationFile    BadPackageLocationMatch
+   | BadLocGlobEmptyMatch      String
+   | BadLocGlobBadMatches      String [BadPackageLocationMatch]
+   | BadLocUnexpectedUriScheme String
+   | BadLocUnrecognisedUri     String
+   | BadLocUnrecognised        String
+  deriving Show
+
+data BadPackageLocationMatch
+   = BadLocUnexpectedFile      String
+   | BadLocNonexistantFile     String
+   | BadLocDirNoCabalFile      String
+   | BadLocDirManyCabalFiles   String
+  deriving Show
+
+
+-- | Given the project config, 
+--
+-- Throws 'BadPackageLocations'.
+--
+findProjectPackages :: FilePath -> ProjectConfig
+                    -> Rebuild [ProjectPackageLocation]
+findProjectPackages projectRootDir ProjectConfig{..} = do
+
+    requiredPkgs <- findPackageLocations True    projectPackages
+    optionalPkgs <- findPackageLocations False   projectPackagesOptional
+    let repoPkgs  = map ProjectPackageRemoteRepo projectPackagesRepo
+        namedPkgs = map ProjectPackageNamed      projectPackagesNamed
+
+    return (concat [requiredPkgs, optionalPkgs, repoPkgs, namedPkgs])
+  where
+    findPackageLocations required pkglocstr = do
+      (problems, pkglocs) <-
+        partitionEithers <$> mapM (findPackageLocation required) pkglocstr
+      unless (null problems) $
+        liftIO $ throwIO $ BadPackageLocations problems
+      return (concat pkglocs)
+
+
+    findPackageLocation :: Bool -> String
+                        -> Rebuild (Either BadPackageLocation
+                                          [ProjectPackageLocation])
+    findPackageLocation _required@True pkglocstr =
+      -- strategy: try first as a file:// or http(s):// URL.
+      -- then as a file glob (usually encompassing single file)
+      -- finally as a single file, for files that fail to parse as globs
+                    checkIsUriPackage pkglocstr
+      `mplusMaybeT` checkIsFileGlobPackage pkglocstr
+      `mplusMaybeT` checkIsSingleFilePackage pkglocstr
+      >>= maybe (return (Left (BadLocUnrecognised pkglocstr))) return
+
+
+    findPackageLocation _required@False pkglocstr = do
+      -- just globs for optional case
+      res <- checkIsFileGlobPackage pkglocstr
+      case res of
+        Nothing              -> return (Left (BadLocUnrecognised pkglocstr))
+        Just (Left _)        -> return (Right []) -- it's optional
+        Just (Right pkglocs) -> return (Right pkglocs)
+
+
+    checkIsUriPackage, checkIsFileGlobPackage, checkIsSingleFilePackage
+      :: String -> Rebuild (Maybe (Either BadPackageLocation
+                                         [ProjectPackageLocation]))
+    checkIsUriPackage pkglocstr =
+      return $!
+      case parseAbsoluteURI pkglocstr of
+        Just uri@URI {
+            uriScheme    = scheme,
+            uriAuthority = Just URIAuth { uriRegName = host }
+          }
+          | recognisedScheme && not (null host) ->
+            Just (Right [ProjectPackageRemoteTarball uri])
+
+          | not recognisedScheme && not (null host) ->
+            Just (Left (BadLocUnexpectedUriScheme pkglocstr))
+
+          | recognisedScheme && null host ->
+            Just (Left (BadLocUnrecognisedUri pkglocstr))
+          where
+            recognisedScheme = scheme == "http:" || scheme == "https:"
+                            || scheme == "file:"
+
+        _ -> Nothing
+
+
+    checkIsFileGlobPackage pkglocstr =
+      case simpleParse pkglocstr of
+        Nothing   -> return Nothing
+        Just glob -> liftM Just $ do
+          matches <- matchFileGlob projectRootDir glob
+          case matches of
+            [] | isJust (isTrivialFilePathGlob glob)
+               -> return (Left (BadPackageLocationFile 
+                                  (BadLocNonexistantFile pkglocstr)))
+
+            [] -> return (Left (BadLocGlobEmptyMatch pkglocstr))
+
+            _  -> do
+              (failures, pkglocs) <- partitionEithers <$>
+                                     mapM checkFilePackageMatch matches
+              if null pkglocs
+                then return (Left (BadLocGlobBadMatches pkglocstr failures))
+                else return (Right pkglocs)
+
+
+    checkIsSingleFilePackage pkglocstr = do
+      let filename = projectRootDir </> pkglocstr
+      isFile <- liftIO $ doesFileExist filename
+      isDir  <- liftIO $ doesDirectoryExist filename
+      if isFile || isDir
+        then checkFilePackageMatch pkglocstr
+         >>= either (return . Just . Left  . BadPackageLocationFile)
+                    (return . Just . Right . (\x->[x]))
+        else return Nothing
+
+
+    checkFilePackageMatch :: String -> Rebuild (Either BadPackageLocationMatch
+                                                       ProjectPackageLocation)
+    checkFilePackageMatch pkglocstr = do
+      let filename = projectRootDir </> pkglocstr
+      isDir  <- liftIO $ doesDirectoryExist filename
+      parentDirExists <- case takeDirectory filename of
+                           []  -> return False
+                           dir -> liftIO $ doesDirectoryExist dir
+      case () of
+        _ | isDir
+         -> do let dirname = filename -- now we know its a dir
+                   glob    = globStarDotCabal pkglocstr
+               matches <- matchFileGlob projectRootDir glob
+               case matches of
+                 [match]
+                     -> return (Right (ProjectPackageLocalDirectory
+                                         dirname cabalFile))
+                   where
+                     cabalFile = dirname </> match
+                 []  -> return (Left (BadLocDirNoCabalFile pkglocstr))
+                 _   -> return (Left (BadLocDirManyCabalFiles pkglocstr))
+
+          | extensionIsTarGz filename
+         -> return (Right (ProjectPackageLocalTarball filename))
+
+          | takeExtension filename == ".cabal"
+         -> return (Right (ProjectPackageLocalCabalFile filename))
+
+          | parentDirExists
+         -> return (Left (BadLocNonexistantFile pkglocstr))
+
+          | otherwise
+         -> return (Left (BadLocUnexpectedFile pkglocstr))
+
+
+    extensionIsTarGz f = takeExtension f                 == ".gz"
+                      && takeExtension (dropExtension f) == ".tar"
+
+
+globStarDotCabal :: FilePath -> FilePathGlob
+globStarDotCabal =
+    foldr (\dirpart -> GlobDir (Glob [Literal dirpart]))
+          (GlobFile (Glob [WildCard, Literal ".cabal"]))
+  . splitDirectories
+
+
+--TODO: [code cleanup] use sufficiently recent transformers package
+mplusMaybeT :: Monad m => m (Maybe a) -> m (Maybe a) -> m (Maybe a)
+mplusMaybeT ma mb = do
+  mx <- ma
+  case mx of
+    Nothing -> mb
+    Just x  -> return (Just x)
+
+
+readSourcePackage :: Verbosity -> ProjectPackageLocation
+                  -> Rebuild SourcePackage
+readSourcePackage verbosity (ProjectPackageLocalCabalFile cabalFile) =
+    readSourcePackage verbosity (ProjectPackageLocalDirectory dir cabalFile)
+  where
+    dir = takeDirectory cabalFile
+
+readSourcePackage verbosity (ProjectPackageLocalDirectory dir cabalFile) = do
+    -- no need to monitorFiles because findProjectCabalFiles did it already
+    pkgdesc <- liftIO $ readPackageDescription verbosity cabalFile
+    return SourcePackage {
+      packageInfoId        = packageId pkgdesc,
+      packageDescription   = pkgdesc,
+      packageSource        = LocalUnpackedPackage dir,
+      packageDescrOverride = Nothing
+    }
+readSourcePackage _verbosity _ =
+    fail $ "TODO: add support for fetching and reading local tarballs, remote "
+        ++ "tarballs, remote repos and passing named packages through"
+

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1,0 +1,1248 @@
+{-# LANGUAGE CPP, RecordWildCards, NamedFieldPuns, DeriveGeneric #-}
+
+-- | Project configuration, implementation in terms of legacy types.
+--
+module Distribution.Client.ProjectConfig.Legacy (
+
+    -- * Project config in terms of legacy types
+    LegacyProjectConfig,
+    parseLegacyProjectConfig,
+    showLegacyProjectConfig,
+
+    -- * Conversion to and from legacy config types
+    commandLineFlagsToProjectConfig,
+    convertLegacyProjectConfig,
+    convertLegacyGlobalConfig,
+    convertToLegacyProjectConfig,
+
+    -- * Internals, just for tests
+    parsePackageLocationTokenQ,
+  ) where
+
+import Distribution.Client.ProjectConfig.Types
+import Distribution.Client.Types
+         ( RemoteRepo(..), emptyRemoteRepo )
+import Distribution.Client.Dependency.Types
+         ( ConstraintSource(..) )
+import Distribution.Client.Config
+         ( SavedConfig(..), remoteRepoFields )
+
+import Distribution.Package
+import Distribution.PackageDescription
+         ( SourceRepo(..), RepoKind(..) )
+import Distribution.PackageDescription.Parse
+         ( sourceRepoFieldDescrs )
+import Distribution.Simple.Compiler
+         ( OptimisationLevel(..), DebugInfoLevel(..) )
+import Distribution.Simple.Setup
+         ( Flag(Flag), toFlag, fromFlagOrDefault
+         , ConfigFlags(..), configureOptions
+         , HaddockFlags(..), haddockOptions, defaultHaddockFlags
+         , programConfigurationPaths', splitArgs
+         , AllowNewer(..) )
+import Distribution.Client.Setup
+         ( GlobalFlags(..), globalCommand
+         , ConfigExFlags(..), configureExOptions, defaultConfigExFlags
+         , InstallFlags(..), installOptions, defaultInstallFlags )
+import Distribution.Simple.Program
+         ( programName, knownPrograms )
+import Distribution.Simple.Program.Db
+         ( ProgramDb, defaultProgramDb )
+import Distribution.Client.Targets
+         ( dispFlagAssignment, parseFlagAssignment )
+import Distribution.Simple.Utils
+         ( lowercase )
+import Distribution.Utils.NubList
+         ( toNubList, fromNubList, overNubList )
+import Distribution.Simple.LocalBuildInfo
+         ( toPathTemplate, fromPathTemplate )
+
+import Distribution.Text
+import qualified Distribution.Compat.ReadP as Parse
+import Distribution.Compat.ReadP
+         ( ReadP, (+++), (<++) )
+import qualified Text.Read as Read
+import qualified Text.PrettyPrint as Disp
+import Text.PrettyPrint
+         ( Doc, ($+$) )
+import qualified Distribution.ParseUtils as ParseUtils (field)
+import Distribution.ParseUtils
+         ( ParseResult(..), PError(..), syntaxError, PWarning(..), warning
+         , simpleField, commaNewLineListField
+         , showToken )
+import Distribution.Client.ParseUtils
+import Distribution.Simple.Command
+         ( CommandUI(commandOptions), ShowOrParseArgs(..)
+         , OptionField, option, reqArg' )
+
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative
+#endif
+import Control.Monad
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Char (isSpace)
+import Distribution.Compat.Semigroup
+import GHC.Generics (Generic)
+
+------------------------------------------------------------------
+-- Representing the project config file in terms of legacy types
+--
+
+-- | We already have parsers\/pretty-printers for almost all the fields in the
+-- project config file, but they're in terms of the types used for the command
+-- line flags for Setup.hs or cabal commands. We don't want to redefine them
+-- all, at least not yet so for the moment we use the parsers at the old types
+-- and use conversion functions.
+--
+-- Ultimately if\/when this project-based approach becomes the default then we
+-- can redefine the parsers directly for the new types.
+--
+data LegacyProjectConfig = LegacyProjectConfig {
+       legacyPackages          :: [String],
+       legacyPackagesOptional  :: [String],
+       legacyPackagesRepo      :: [SourceRepo],
+       legacyPackagesNamed     :: [Dependency],
+
+       legacySharedConfig      :: LegacySharedConfig,
+       legacyLocalConfig       :: LegacyPackageConfig,
+       legacySpecificConfig    :: Map PackageName LegacyPackageConfig
+     } deriving Generic
+
+instance Monoid LegacyProjectConfig where
+  mempty  = gmempty
+  mappend = (<>)
+
+instance Semigroup LegacyProjectConfig where
+  (<>) = gmappend
+
+data LegacyPackageConfig = LegacyPackageConfig {
+       legacyConfigureFlags    :: ConfigFlags,
+       legacyInstallPkgFlags   :: InstallFlags,
+       legacyHaddockFlags      :: HaddockFlags
+     } deriving Generic
+
+instance Monoid LegacyPackageConfig where
+  mempty  = gmempty
+  mappend = (<>)
+
+instance Semigroup LegacyPackageConfig where
+  (<>) = gmappend
+
+data LegacySharedConfig = LegacySharedConfig {
+       legacyGlobalFlags       :: GlobalFlags,
+       legacyConfigureShFlags  :: ConfigFlags,
+       legacyConfigureExFlags  :: ConfigExFlags,
+       legacyInstallFlags      :: InstallFlags
+     } deriving Generic
+
+instance Monoid LegacySharedConfig where
+  mempty  = gmempty
+  mappend = (<>)
+
+instance Semigroup LegacySharedConfig where
+  (<>) = gmappend
+
+
+------------------------------------------------------------------
+-- Converting from and to the legacy types
+--
+
+-- | Convert configuration from the @cabal configure@ or @cabal build@ command
+-- line into a 'ProjectConfig' value that can combined with configuration from
+-- other sources.
+--
+-- At the moment this uses the legacy command line flag types. See
+-- 'LegacyProjectConfig' for an explanation.
+--
+commandLineFlagsToProjectConfig :: GlobalFlags
+                                -> ConfigFlags  -> ConfigExFlags
+                                -> InstallFlags -> HaddockFlags
+                                -> ProjectConfig
+commandLineFlagsToProjectConfig globalFlags configFlags configExFlags
+                                installFlags haddockFlags =
+    mempty {
+      projectConfigBuildOnly     = convertLegacyBuildOnlyFlags
+                                     globalFlags configFlags
+                                     installFlags haddockFlags,
+      projectConfigShared        = convertLegacyAllPackageFlags
+                                     globalFlags configFlags
+                                     configExFlags installFlags,
+      projectConfigLocalPackages = convertLegacyPerPackageFlags
+                                     configFlags installFlags haddockFlags
+    }
+
+
+-- | Convert from the types currently used for the user-wide @~/.cabal/config@
+-- file into the 'ProjectConfig' type.
+--
+-- Only a subset of the 'ProjectConfig' can be represented in the user-wide
+-- config. In particular it does not include packages that are in the project,
+-- and it also doesn't support package-specific configuration (only
+-- configuration that applies to all packages).
+--
+convertLegacyGlobalConfig :: SavedConfig -> ProjectConfig
+convertLegacyGlobalConfig
+    SavedConfig {
+      savedGlobalFlags       = globalFlags,
+      savedInstallFlags      = installFlags,
+      savedConfigureFlags    = configFlags,
+      savedConfigureExFlags  = configExFlags,
+      savedUserInstallDirs   = _,
+      savedGlobalInstallDirs = _,
+      savedUploadFlags       = _,
+      savedReportFlags       = _,
+      savedHaddockFlags      = haddockFlags
+    } =
+    mempty {
+      projectConfigShared        = configAllPackages,
+      projectConfigLocalPackages = configLocalPackages,
+      projectConfigBuildOnly     = configBuildOnly
+    }
+  where
+    --TODO: [code cleanup] eliminate use of default*Flags here and specify the
+    -- defaults in the various resolve functions in terms of the new types.
+    configExFlags' = defaultConfigExFlags <> configExFlags
+    installFlags'  = defaultInstallFlags  <> installFlags
+    haddockFlags'  = defaultHaddockFlags  <> haddockFlags
+
+    configLocalPackages = convertLegacyPerPackageFlags
+                            configFlags installFlags' haddockFlags'
+    configAllPackages   = convertLegacyAllPackageFlags
+                            globalFlags configFlags
+                            configExFlags' installFlags'
+    configBuildOnly     = convertLegacyBuildOnlyFlags
+                            globalFlags configFlags
+                            installFlags' haddockFlags'
+
+
+-- | Convert the project config from the legacy types to the 'ProjectConfig'
+-- and associated types. See 'LegacyProjectConfig' for an explanation of the
+-- approach.
+--
+convertLegacyProjectConfig :: LegacyProjectConfig -> ProjectConfig
+convertLegacyProjectConfig
+  LegacyProjectConfig {
+    legacyPackages,
+    legacyPackagesOptional,
+    legacyPackagesRepo,
+    legacyPackagesNamed,
+    legacySharedConfig = LegacySharedConfig globalFlags configShFlags
+                                            configExFlags installSharedFlags,
+    legacyLocalConfig  = LegacyPackageConfig configFlags installPerPkgFlags
+                                             haddockFlags,
+    legacySpecificConfig
+  } =
+
+    ProjectConfig {
+      projectPackages              = legacyPackages,
+      projectPackagesOptional      = legacyPackagesOptional,
+      projectPackagesRepo          = legacyPackagesRepo,
+      projectPackagesNamed         = legacyPackagesNamed,
+
+      projectConfigBuildOnly       = configBuildOnly,
+      projectConfigShared          = configAllPackages,
+      projectConfigLocalPackages   = configLocalPackages,
+      projectConfigSpecificPackage = fmap perPackage legacySpecificConfig
+    }
+  where
+    configLocalPackages = convertLegacyPerPackageFlags
+                            configFlags installPerPkgFlags haddockFlags
+    configAllPackages   = convertLegacyAllPackageFlags
+                            globalFlags (configFlags <> configShFlags)
+                            configExFlags installSharedFlags
+    configBuildOnly     = convertLegacyBuildOnlyFlags
+                            globalFlags configShFlags
+                            installSharedFlags haddockFlags
+
+    perPackage (LegacyPackageConfig perPkgConfigFlags perPkgInstallFlags
+                                    perPkgHaddockFlags) =
+      convertLegacyPerPackageFlags
+        perPkgConfigFlags perPkgInstallFlags perPkgHaddockFlags
+
+
+-- | Helper used by other conversion functions that returns the
+-- 'ProjectConfigShared' subset of the 'ProjectConfig'.
+--
+convertLegacyAllPackageFlags :: GlobalFlags -> ConfigFlags
+                             -> ConfigExFlags -> InstallFlags
+                             -> ProjectConfigShared
+convertLegacyAllPackageFlags globalFlags configFlags
+                             configExFlags installFlags =
+    ProjectConfigShared{..}
+  where
+    GlobalFlags {
+      globalConfigFile        = _, -- TODO: [required feature]
+      globalSandboxConfigFile = _, -- ??
+      globalRemoteRepos       = projectConfigRemoteRepos,
+      globalLocalRepos        = projectConfigLocalRepos
+    } = globalFlags
+
+    ConfigFlags {
+      configProgramPaths,
+      configProgramArgs,
+      configProgramPathExtra    = projectConfigProgramPathExtra,
+      configHcFlavor            = projectConfigHcFlavor,
+      configHcPath              = projectConfigHcPath,
+      configHcPkg               = projectConfigHcPkg,
+    --configInstallDirs         = projectConfigInstallDirs,
+    --configUserInstall         = projectConfigUserInstall,
+    --configPackageDBs          = projectConfigPackageDBs,
+      configConfigurationsFlags = projectConfigFlagAssignment,
+      configAllowNewer          = projectConfigAllowNewer
+    } = configFlags
+    projectConfigProgramPaths   = Map.fromList configProgramPaths
+    projectConfigProgramArgs    = Map.fromList configProgramArgs
+
+    ConfigExFlags {
+      configCabalVersion        = projectConfigCabalVersion,
+      configExConstraints       = projectConfigConstraints,
+      configPreferences         = projectConfigPreferences,
+      configSolver              = projectConfigSolver
+    } = configExFlags
+
+    InstallFlags {
+      installHaddockIndex       = projectConfigHaddockIndex,
+    --installReinstall          = projectConfigReinstall,
+    --installAvoidReinstalls    = projectConfigAvoidReinstalls,
+    --installOverrideReinstall  = projectConfigOverrideReinstall,
+      installMaxBackjumps       = projectConfigMaxBackjumps,
+    --installUpgradeDeps        = projectConfigUpgradeDeps,
+      installReorderGoals       = projectConfigReorderGoals,
+    --installIndependentGoals   = projectConfigIndependentGoals,
+    --installShadowPkgs         = projectConfigShadowPkgs,
+      installStrongFlags        = projectConfigStrongFlags
+    } = installFlags
+
+
+
+-- | Helper used by other conversion functions that returns the
+-- 'PackageConfig' subset of the 'ProjectConfig'.
+--
+convertLegacyPerPackageFlags :: ConfigFlags -> InstallFlags -> HaddockFlags
+                             -> PackageConfig
+convertLegacyPerPackageFlags configFlags installFlags haddockFlags =
+    PackageConfig{..}
+  where
+    ConfigFlags {
+      configVanillaLib          = packageConfigVanillaLib,
+      configProfLib             = packageConfigProfLib,
+      configSharedLib           = packageConfigSharedLib,
+      configDynExe              = packageConfigDynExe,
+      configProfExe             = packageConfigProfExe,
+      configProf                = packageConfigProf,
+      configProfDetail          = packageConfigProfDetail,
+      configProfLibDetail       = packageConfigProfLibDetail,
+      configConfigureArgs       = packageConfigConfigureArgs,
+      configOptimization        = packageConfigOptimization,
+      configProgPrefix          = packageConfigProgPrefix,
+      configProgSuffix          = packageConfigProgSuffix,
+      configGHCiLib             = packageConfigGHCiLib,
+      configSplitObjs           = packageConfigSplitObjs,
+      configStripExes           = packageConfigStripExes,
+      configStripLibs           = packageConfigStripLibs,
+      configExtraLibDirs        = packageConfigExtraLibDirs,
+      configExtraFrameworkDirs  = packageConfigExtraFrameworkDirs,
+      configExtraIncludeDirs    = packageConfigExtraIncludeDirs,
+      configConfigurationsFlags = _projectConfigFlagAssignment, --TODO: should be per pkg
+      configTests               = packageConfigTests,
+      configBenchmarks          = packageConfigBenchmarks,
+      configCoverage            = coverage,
+      configLibCoverage         = libcoverage, --deprecated
+      configDebugInfo           = packageConfigDebugInfo,
+      configRelocatable         = packageConfigRelocatable
+    } = configFlags
+
+    packageConfigCoverage       = coverage <> libcoverage
+    --TODO: defer this merging to the resolve phase
+
+    InstallFlags {
+      installDocumentation      = packageConfigDocumentation,
+      installRunTests           = packageConfigRunTests
+    } = installFlags
+
+    HaddockFlags {
+      haddockHoogle             = packageConfigHaddockHoogle,
+      haddockHtml               = packageConfigHaddockHtml,
+      haddockHtmlLocation       = packageConfigHaddockHtmlLocation,
+      haddockExecutables        = packageConfigHaddockExecutables,
+      haddockTestSuites         = packageConfigHaddockTestSuites,
+      haddockBenchmarks         = packageConfigHaddockBenchmarks,
+      haddockInternal           = packageConfigHaddockInternal,
+      haddockCss                = packageConfigHaddockCss,
+      haddockHscolour           = packageConfigHaddockHscolour,
+      haddockHscolourCss        = packageConfigHaddockHscolourCss,
+      haddockContents           = packageConfigHaddockContents
+    } = haddockFlags
+
+
+
+-- | Helper used by other conversion functions that returns the
+-- 'ProjectConfigBuildOnly' subset of the 'ProjectConfig'.
+--
+convertLegacyBuildOnlyFlags :: GlobalFlags -> ConfigFlags
+                            -> InstallFlags -> HaddockFlags
+                            -> ProjectConfigBuildOnly
+convertLegacyBuildOnlyFlags globalFlags configFlags
+                              installFlags haddockFlags =
+    ProjectConfigBuildOnly{..}
+  where
+    GlobalFlags {
+      globalCacheDir          = projectConfigCacheDir,
+      globalLogsDir           = projectConfigLogsDir,
+      globalWorldFile         = projectConfigWorldFile,
+      globalHttpTransport     = projectConfigHttpTransport,
+      globalIgnoreExpiry      = projectConfigIgnoreExpiry
+    } = globalFlags
+
+    ConfigFlags {
+      configVerbosity           = projectConfigVerbosity
+    } = configFlags
+
+    InstallFlags {
+      installDryRun             = projectConfigDryRun,
+      installOnly               = _,
+      installOnlyDeps           = projectConfigOnlyDeps,
+      installRootCmd            = projectConfigRootCmd,
+      installSummaryFile        = projectConfigSummaryFile,
+      installLogFile            = projectConfigLogFile,
+      installBuildReports       = projectConfigBuildReports,
+      installReportPlanningFailure = projectConfigReportPlanningFailure,
+      installSymlinkBinDir      = projectConfigSymlinkBinDir,
+      installOneShot            = projectConfigOneShot,
+      installNumJobs            = projectConfigNumJobs,
+      installOfflineMode        = projectConfigOfflineMode
+    } = installFlags
+
+    HaddockFlags {
+      haddockKeepTempFiles      = projectConfigKeepTempFiles --TODO: this ought to live elsewhere
+    } = haddockFlags
+
+
+convertToLegacyProjectConfig :: ProjectConfig -> LegacyProjectConfig
+convertToLegacyProjectConfig
+    projectConfig@ProjectConfig {
+      projectPackages,
+      projectPackagesOptional,
+      projectPackagesRepo,
+      projectPackagesNamed,
+      projectConfigLocalPackages,
+      projectConfigSpecificPackage
+    } =
+    LegacyProjectConfig {
+      legacyPackages         = projectPackages,
+      legacyPackagesOptional = projectPackagesOptional,
+      legacyPackagesRepo     = projectPackagesRepo,
+      legacyPackagesNamed    = projectPackagesNamed,
+      legacySharedConfig     = convertToLegacySharedConfig projectConfig,
+      legacyLocalConfig      = convertToLegacyAllPackageConfig projectConfig
+                            <> convertToLegacyPerPackageConfig
+                                 projectConfigLocalPackages,
+      legacySpecificConfig   = fmap convertToLegacyPerPackageConfig
+                                    projectConfigSpecificPackage
+    }
+
+convertToLegacySharedConfig :: ProjectConfig -> LegacySharedConfig
+convertToLegacySharedConfig
+    ProjectConfig {
+      projectConfigBuildOnly     = ProjectConfigBuildOnly {..},
+      projectConfigShared        = ProjectConfigShared {..}
+    } =
+
+    LegacySharedConfig {
+      legacyGlobalFlags      = globalFlags,
+      legacyConfigureShFlags = configFlags,
+      legacyConfigureExFlags = configExFlags,
+      legacyInstallFlags     = installFlags
+    }
+  where
+    globalFlags = GlobalFlags {
+      globalVersion           = mempty,
+      globalNumericVersion    = mempty,
+      globalConfigFile        = mempty,
+      globalSandboxConfigFile = mempty,
+      globalConstraintsFile   = mempty,
+      globalRemoteRepos       = projectConfigRemoteRepos,
+      globalCacheDir          = projectConfigCacheDir,
+      globalLocalRepos        = projectConfigLocalRepos,
+      globalLogsDir           = projectConfigLogsDir,
+      globalWorldFile         = projectConfigWorldFile,
+      globalRequireSandbox    = mempty,
+      globalIgnoreSandbox     = mempty,
+      globalIgnoreExpiry      = projectConfigIgnoreExpiry,
+      globalHttpTransport     = projectConfigHttpTransport
+    }
+
+    configFlags = mempty {
+      configVerbosity     = projectConfigVerbosity,
+      configAllowNewer    = projectConfigAllowNewer
+    }
+
+    configExFlags = ConfigExFlags {
+      configCabalVersion  = projectConfigCabalVersion,
+      configExConstraints = projectConfigConstraints,
+      configPreferences   = projectConfigPreferences,
+      configSolver        = projectConfigSolver
+    }
+
+    installFlags = InstallFlags {
+      installDocumentation     = mempty,
+      installHaddockIndex      = projectConfigHaddockIndex,
+      installDryRun            = projectConfigDryRun,
+      installReinstall         = mempty, --projectConfigReinstall,
+      installAvoidReinstalls   = mempty, --projectConfigAvoidReinstalls,
+      installOverrideReinstall = mempty, --projectConfigOverrideReinstall,
+      installMaxBackjumps      = projectConfigMaxBackjumps,
+      installUpgradeDeps       = mempty, --projectConfigUpgradeDeps,
+      installReorderGoals      = projectConfigReorderGoals,
+      installIndependentGoals  = mempty, --projectConfigIndependentGoals,
+      installShadowPkgs        = mempty, --projectConfigShadowPkgs,
+      installStrongFlags       = projectConfigStrongFlags,
+      installOnly              = mempty,
+      installOnlyDeps          = projectConfigOnlyDeps,
+      installRootCmd           = projectConfigRootCmd,
+      installSummaryFile       = projectConfigSummaryFile,
+      installLogFile           = projectConfigLogFile,
+      installBuildReports      = projectConfigBuildReports,
+      installReportPlanningFailure = projectConfigReportPlanningFailure,
+      installSymlinkBinDir     = projectConfigSymlinkBinDir,
+      installOneShot           = projectConfigOneShot,
+      installNumJobs           = projectConfigNumJobs,
+      installRunTests          = mempty,
+      installOfflineMode       = projectConfigOfflineMode
+    }
+
+
+convertToLegacyAllPackageConfig :: ProjectConfig -> LegacyPackageConfig
+convertToLegacyAllPackageConfig
+    ProjectConfig {
+      projectConfigBuildOnly = ProjectConfigBuildOnly {..},
+      projectConfigShared    = ProjectConfigShared {..}
+    } =
+
+    LegacyPackageConfig {
+      legacyConfigureFlags = configFlags,
+      legacyInstallPkgFlags= mempty,
+      legacyHaddockFlags   = haddockFlags
+    }
+  where
+    configFlags = ConfigFlags {
+      configPrograms_           = mempty,
+      configProgramPaths        = Map.toList projectConfigProgramPaths,
+      configProgramArgs         = Map.toList projectConfigProgramArgs,
+      configProgramPathExtra    = projectConfigProgramPathExtra,
+      configHcFlavor            = projectConfigHcFlavor,
+      configHcPath              = projectConfigHcPath,
+      configHcPkg               = projectConfigHcPkg,
+      configVanillaLib          = mempty,
+      configProfLib             = mempty,
+      configSharedLib           = mempty,
+      configDynExe              = mempty,
+      configProfExe             = mempty,
+      configProf                = mempty,
+      configProfDetail          = mempty,
+      configProfLibDetail       = mempty,
+      configConfigureArgs       = mempty,
+      configOptimization        = mempty,
+      configProgPrefix          = mempty,
+      configProgSuffix          = mempty,
+      configInstallDirs         = mempty,
+      configScratchDir          = mempty,
+      configDistPref            = mempty,
+      configVerbosity           = mempty,
+      configUserInstall         = mempty, --projectConfigUserInstall,
+      configPackageDBs          = mempty, --projectConfigPackageDBs,
+      configGHCiLib             = mempty,
+      configSplitObjs           = mempty,
+      configStripExes           = mempty,
+      configStripLibs           = mempty,
+      configExtraLibDirs        = mempty,
+      configExtraFrameworkDirs  = mempty,
+      configConstraints         = mempty,
+      configDependencies        = mempty,
+      configExtraIncludeDirs    = mempty,
+      configIPID                = mempty,
+      configConfigurationsFlags = projectConfigFlagAssignment,
+      configTests               = mempty,
+      configCoverage            = mempty, --TODO: don't merge
+      configLibCoverage         = mempty, --TODO: don't merge
+      configExactConfiguration  = mempty,
+      configBenchmarks          = mempty,
+      configFlagError           = mempty,                --TODO: ???
+      configRelocatable         = mempty,
+      configDebugInfo           = mempty,
+      configAllowNewer          = mempty
+    }
+
+    haddockFlags = mempty {
+      haddockKeepTempFiles = projectConfigKeepTempFiles
+    }
+
+
+convertToLegacyPerPackageConfig :: PackageConfig -> LegacyPackageConfig
+convertToLegacyPerPackageConfig PackageConfig {..} =
+    LegacyPackageConfig {
+      legacyConfigureFlags  = configFlags,
+      legacyInstallPkgFlags = installFlags,
+      legacyHaddockFlags    = haddockFlags
+    }
+  where
+    configFlags = ConfigFlags {
+      configPrograms_           = configPrograms_ mempty,
+      configProgramPaths        = mempty,
+      configProgramArgs         = mempty,
+      configProgramPathExtra    = mempty,
+      configHcFlavor            = mempty,
+      configHcPath              = mempty,
+      configHcPkg               = mempty,
+      configVanillaLib          = packageConfigVanillaLib,
+      configProfLib             = packageConfigProfLib,
+      configSharedLib           = packageConfigSharedLib,
+      configDynExe              = packageConfigDynExe,
+      configProfExe             = packageConfigProfExe,
+      configProf                = packageConfigProf,
+      configProfDetail          = packageConfigProfDetail,
+      configProfLibDetail       = packageConfigProfLibDetail,
+      configConfigureArgs       = packageConfigConfigureArgs,
+      configOptimization        = packageConfigOptimization,
+      configProgPrefix          = packageConfigProgPrefix,
+      configProgSuffix          = packageConfigProgSuffix,
+      configInstallDirs         = mempty,
+      configScratchDir          = mempty,
+      configDistPref            = mempty,
+      configVerbosity           = mempty,
+      configUserInstall         = mempty,
+      configPackageDBs          = mempty,
+      configGHCiLib             = packageConfigGHCiLib,
+      configSplitObjs           = packageConfigSplitObjs,
+      configStripExes           = packageConfigStripExes,
+      configStripLibs           = packageConfigStripLibs,
+      configExtraLibDirs        = packageConfigExtraLibDirs,
+      configExtraFrameworkDirs  = packageConfigExtraFrameworkDirs,
+      configConstraints         = mempty,
+      configDependencies        = mempty,
+      configExtraIncludeDirs    = packageConfigExtraIncludeDirs,
+      configIPID                = mempty,
+      configConfigurationsFlags = mempty,
+      configTests               = packageConfigTests,
+      configCoverage            = packageConfigCoverage, --TODO: don't merge
+      configLibCoverage         = packageConfigCoverage, --TODO: don't merge
+      configExactConfiguration  = mempty,
+      configBenchmarks          = packageConfigBenchmarks,
+      configFlagError           = mempty,                --TODO: ???
+      configRelocatable         = packageConfigRelocatable,
+      configDebugInfo           = packageConfigDebugInfo,
+      configAllowNewer          = mempty
+    }
+
+    installFlags = mempty {
+      installDocumentation      = packageConfigDocumentation,
+      installRunTests           = packageConfigRunTests
+    }
+
+    haddockFlags = HaddockFlags {
+      haddockProgramPaths  = mempty,
+      haddockProgramArgs   = mempty,
+      haddockHoogle        = packageConfigHaddockHoogle,
+      haddockHtml          = packageConfigHaddockHtml,
+      haddockHtmlLocation  = packageConfigHaddockHtmlLocation,
+      haddockForHackage    = mempty, --TODO: added recently
+      haddockExecutables   = packageConfigHaddockExecutables,
+      haddockTestSuites    = packageConfigHaddockTestSuites,
+      haddockBenchmarks    = packageConfigHaddockBenchmarks,
+      haddockInternal      = packageConfigHaddockInternal,
+      haddockCss           = packageConfigHaddockCss,
+      haddockHscolour      = packageConfigHaddockHscolour,
+      haddockHscolourCss   = packageConfigHaddockHscolourCss,
+      haddockContents      = packageConfigHaddockContents,
+      haddockDistPref      = mempty,
+      haddockKeepTempFiles = mempty,
+      haddockVerbosity     = mempty
+    }
+
+
+------------------------------------------------
+-- Parsing and showing the project config file
+--
+
+parseLegacyProjectConfig :: String -> ParseResult LegacyProjectConfig
+parseLegacyProjectConfig =
+    parseConfig legacyProjectConfigFieldDescrs
+                legacyPackageConfigSectionDescrs
+                mempty
+
+showLegacyProjectConfig :: LegacyProjectConfig -> String
+showLegacyProjectConfig config =
+    Disp.render $
+    showConfig  legacyProjectConfigFieldDescrs
+                legacyPackageConfigSectionDescrs
+                config
+  $+$
+    Disp.text ""
+
+
+legacyProjectConfigFieldDescrs :: [FieldDescr LegacyProjectConfig]
+legacyProjectConfigFieldDescrs =
+
+    [ newLineListField "packages"
+        (Disp.text . renderPackageLocationToken) parsePackageLocationTokenQ
+        legacyPackages
+        (\v flags -> flags { legacyPackages = v })
+    , newLineListField "optional-packages"
+        (Disp.text . renderPackageLocationToken) parsePackageLocationTokenQ
+        legacyPackagesOptional
+        (\v flags -> flags { legacyPackagesOptional = v })
+    , commaNewLineListField "extra-packages"
+        disp parse
+        legacyPackagesNamed
+        (\v flags -> flags { legacyPackagesNamed = v })
+    ]
+
+ ++ map (liftField
+           legacySharedConfig
+           (\flags conf -> conf { legacySharedConfig = flags }))
+        legacySharedConfigFieldDescrs
+
+ ++ map (liftField
+           legacyLocalConfig
+           (\flags conf -> conf { legacyLocalConfig = flags }))
+        legacyPackageConfigFieldDescrs
+
+-- | This is a bit tricky since it has to cover globs which have embedded @,@
+-- chars. But we don't just want to parse strictly as a glob since we want to
+-- allow http urls which don't parse as globs, and possibly some
+-- system-dependent file paths. So we parse fairly liberally as a token, but
+-- we allow @,@ inside matched @{}@ braces.
+--
+parsePackageLocationTokenQ :: ReadP r String
+parsePackageLocationTokenQ = parseHaskellString
+                   Parse.<++ parsePackageLocationToken
+  where
+    parsePackageLocationToken :: ReadP r String
+    parsePackageLocationToken = fmap fst (Parse.gather outerTerm)
+      where
+        outerTerm   = alternateEither1 outerToken (braces innerTerm)
+        innerTerm   = alternateEither  innerToken (braces innerTerm)
+        outerToken  = Parse.munch1 outerChar >> return ()
+        innerToken  = Parse.munch1 innerChar >> return ()
+        outerChar c = not (isSpace c || c == '{' || c == '}' || c == ',')
+        innerChar c = not (isSpace c || c == '{' || c == '}')
+        braces      = Parse.between (Parse.char '{') (Parse.char '}')
+
+    alternateEither, alternateEither1,
+      alternatePQs, alternate1PQs, alternateQsP, alternate1QsP
+      :: ReadP r () -> ReadP r () -> ReadP r ()
+
+    alternateEither1 p q = alternate1PQs p q +++ alternate1QsP q p
+    alternateEither  p q = alternateEither1 p q +++ return ()
+    alternate1PQs    p q = p >> alternateQsP q p
+    alternatePQs     p q = alternate1PQs p q +++ return ()
+    alternate1QsP    q p = Parse.many1 q >> alternatePQs p q
+    alternateQsP     q p = alternate1QsP q p +++ return ()
+
+renderPackageLocationToken :: String -> String
+renderPackageLocationToken s | needsQuoting = show s
+                             | otherwise    = s
+  where
+    needsQuoting  = not (ok 0 s)
+                 || s == "." -- . on its own on a line has special meaning
+                 || take 2 s == "--" -- on its own line is comment syntax
+                 --TODO: [code cleanup] these "." and "--" escaping issues
+                 -- ought to be dealt with systematically in ParseUtils.
+    ok :: Int -> String -> Bool
+    ok n []       = n == 0
+    ok _ ('"':_)  = False
+    ok n ('{':cs) = ok (n+1) cs
+    ok n ('}':cs) = ok (n-1) cs
+    ok n (',':cs) = (n > 0) && ok n cs
+    ok n (_  :cs) = ok n cs
+
+
+legacySharedConfigFieldDescrs :: [FieldDescr LegacySharedConfig]
+legacySharedConfigFieldDescrs =
+
+  ( liftFields
+      legacyGlobalFlags
+      (\flags conf -> conf { legacyGlobalFlags = flags })
+  . addFields
+      [ newLineListField "local-repo"
+          showTokenQ parseTokenQ
+          (fromNubList . globalLocalRepos)
+          (\v conf -> conf { globalLocalRepos = toNubList v })
+      ]
+  . filterFields
+      [ "remote-repo-cache"
+      , "logs-dir", "world-file", "ignore-expiry", "http-transport"
+      ]
+  . commandOptionsToFields
+  ) (commandOptions (globalCommand []) ParseArgs)
+ ++
+  ( liftFields
+      legacyConfigureShFlags
+      (\flags conf -> conf { legacyConfigureShFlags = flags })
+  . addFields
+      [ simpleField "allow-newer"
+        (maybe mempty dispAllowNewer) (fmap Just parseAllowNewer)
+        configAllowNewer (\v conf -> conf { configAllowNewer = v })
+      ]
+  . filterFields ["verbose"]
+  . commandOptionsToFields
+  ) (configureOptions ParseArgs)
+ ++
+  ( liftFields
+      legacyConfigureExFlags
+      (\flags conf -> conf { legacyConfigureExFlags = flags })
+  . addFields
+      [ commaNewLineListField "constraints"
+        (disp . fst) (fmap (\constraint -> (constraint, constraintSrc)) parse)
+        configExConstraints (\v conf -> conf { configExConstraints = v })
+
+      , commaNewLineListField "preferences"
+        disp parse
+        configPreferences (\v conf -> conf { configPreferences = v })
+      ]
+  . filterFields
+      [ "cabal-lib-version", "solver"
+        -- not "constraint" or "preference", we use our own plural ones above
+      ]
+  . commandOptionsToFields
+  ) (configureExOptions ParseArgs constraintSrc)
+ ++
+  ( liftFields
+      legacyInstallFlags
+      (\flags conf -> conf { legacyInstallFlags = flags })
+  . addFields
+      [ newLineListField "build-summary"
+          (showTokenQ . fromPathTemplate) (fmap toPathTemplate parseTokenQ)
+          (fromNubList . installSummaryFile)
+          (\v conf -> conf { installSummaryFile = toNubList v })
+      ]
+  . filterFields
+      [ "doc-index-file"
+      , "root-cmd", "symlink-bindir"
+      , "build-log"
+      , "remote-build-reporting", "report-planning-failure"
+      , "one-shot", "jobs", "offline"
+        -- solver flags:
+      , "max-backjumps", "reorder-goals", "strong-flags"
+      ]
+  . commandOptionsToFields
+  ) (installOptions ParseArgs)
+  where
+    constraintSrc = ConstraintSourceProjectConfig "TODO"
+
+parseAllowNewer :: ReadP r AllowNewer
+parseAllowNewer =
+     ((const AllowNewerNone <$> (Parse.string "none" +++ Parse.string "None"))
+  +++ (const AllowNewerAll  <$> (Parse.string "all"  +++ Parse.string "All")))
+  <++ (      AllowNewerSome <$> parseOptCommaList parse)
+
+dispAllowNewer :: AllowNewer -> Doc
+dispAllowNewer  AllowNewerNone       = Disp.text "None"
+dispAllowNewer (AllowNewerSome pkgs) = Disp.fsep . Disp.punctuate Disp.comma
+                                                 . map disp $ pkgs
+dispAllowNewer  AllowNewerAll        = Disp.text "All"
+
+
+legacyPackageConfigFieldDescrs :: [FieldDescr LegacyPackageConfig]
+legacyPackageConfigFieldDescrs =
+  ( liftFields
+      legacyConfigureFlags
+      (\flags conf -> conf { legacyConfigureFlags = flags })
+  . addFields
+      [ newLineListField "extra-include-dirs"
+          showTokenQ parseTokenQ
+          configExtraIncludeDirs
+          (\v conf -> conf { configExtraIncludeDirs = v })
+      , newLineListField "extra-lib-dirs"
+          showTokenQ parseTokenQ
+          configExtraLibDirs
+          (\v conf -> conf { configExtraLibDirs = v })
+      , newLineListField "extra-framework-dirs"
+          showTokenQ parseTokenQ
+          configExtraFrameworkDirs
+          (\v conf -> conf { configExtraFrameworkDirs = v })
+      , newLineListField "extra-prog-path"
+          showTokenQ parseTokenQ
+          (fromNubList . configProgramPathExtra)
+          (\v conf -> conf { configProgramPathExtra = toNubList v })
+      , newLineListField "configure-options"
+          showTokenQ parseTokenQ
+          configConfigureArgs
+          (\v conf -> conf { configConfigureArgs = v })
+      , simpleField "flags"
+          dispFlagAssignment parseFlagAssignment
+          configConfigurationsFlags
+          (\v conf -> conf { configConfigurationsFlags = v })
+      ]
+  . filterFields
+      [ "compiler", "with-compiler", "with-hc-pkg"
+      , "program-prefix", "program-suffix"
+      , "library-vanilla", "library-profiling"
+      , "shared", "executable-dynamic"
+      , "profiling", "executable-profiling"
+      , "profiling-detail", "library-profiling-detail"
+      , "optimization", "debug-info", "library-for-ghci", "split-objs"
+      , "executable-stripping", "library-stripping"
+      , "tests", "benchmarks"
+      , "coverage", "library-coverage"
+      , "relocatable"
+        -- not "extra-include-dirs", "extra-lib-dirs", "extra-framework-dirs"
+        -- or "extra-prog-path". We use corrected ones above that parse
+        -- as list fields.
+      ]
+  . commandOptionsToFields
+  ) (configureOptions ParseArgs)
+ ++
+    liftFields
+      legacyConfigureFlags
+      (\flags conf -> conf { legacyConfigureFlags = flags })
+    [ overrideFieldCompiler
+    , overrideFieldOptimization
+    , overrideFieldDebugInfo
+    ]
+ ++
+  ( liftFields
+      legacyInstallPkgFlags
+      (\flags conf -> conf { legacyInstallPkgFlags = flags })
+  . filterFields
+      [ "documentation", "run-tests"
+      ]
+  . commandOptionsToFields
+  ) (installOptions ParseArgs)
+ ++
+  ( liftFields
+      legacyHaddockFlags
+      (\flags conf -> conf { legacyHaddockFlags = flags })
+  . mapFieldNames
+      ("haddock-"++)
+  . filterFields
+      [ "hoogle", "html", "html-location"
+      , "executables", "tests", "benchmarks", "all", "internal", "css"
+      , "hyperlink-source", "hscolour-css"
+      , "contents-location", "keep-temp-files"
+      ]
+  . commandOptionsToFields
+  ) (haddockOptions ParseArgs)
+
+  where
+    overrideFieldCompiler =
+      simpleField "compiler"
+        (fromFlagOrDefault Disp.empty . fmap disp)
+        (Parse.option mempty (fmap toFlag parse))
+        configHcFlavor (\v flags -> flags { configHcFlavor = v })
+
+
+    -- TODO: [code cleanup] The following is a hack. The "optimization" and
+    -- "debug-info" fields are OptArg, and viewAsFieldDescr fails on that.
+    -- Instead of a hand-written parser and printer, we should handle this case
+    -- properly in the library.
+
+    overrideFieldOptimization =
+      liftField configOptimization
+                (\v flags -> flags { configOptimization = v }) $
+      let name = "optimization" in
+      FieldDescr name
+        (\f -> case f of
+                 Flag NoOptimisation      -> Disp.text "False"
+                 Flag NormalOptimisation  -> Disp.text "True"
+                 Flag MaximumOptimisation -> Disp.text "2"
+                 _                        -> Disp.empty)
+        (\line str _ -> case () of
+         _ |  str == "False" -> ParseOk [] (Flag NoOptimisation)
+           |  str == "True"  -> ParseOk [] (Flag NormalOptimisation)
+           |  str == "0"     -> ParseOk [] (Flag NoOptimisation)
+           |  str == "1"     -> ParseOk [] (Flag NormalOptimisation)
+           |  str == "2"     -> ParseOk [] (Flag MaximumOptimisation)
+           | lstr == "false" -> ParseOk [caseWarning] (Flag NoOptimisation)
+           | lstr == "true"  -> ParseOk [caseWarning] (Flag NormalOptimisation)
+           | otherwise       -> ParseFailed (NoParse name line)
+           where
+             lstr = lowercase str
+             caseWarning = PWarning $
+               "The '" ++ name ++ "' field is case sensitive, use 'True' or 'False'.")
+
+    overrideFieldDebugInfo =
+      liftField configDebugInfo (\v flags -> flags { configDebugInfo = v }) $
+      let name = "debug-info" in
+      FieldDescr name
+        (\f -> case f of
+                 Flag NoDebugInfo      -> Disp.text "False"
+                 Flag MinimalDebugInfo -> Disp.text "1"
+                 Flag NormalDebugInfo  -> Disp.text "True"
+                 Flag MaximalDebugInfo -> Disp.text "3"
+                 _                     -> Disp.empty)
+        (\line str _ -> case () of
+         _ |  str == "False" -> ParseOk [] (Flag NoDebugInfo)
+           |  str == "True"  -> ParseOk [] (Flag NormalDebugInfo)
+           |  str == "0"     -> ParseOk [] (Flag NoDebugInfo)
+           |  str == "1"     -> ParseOk [] (Flag MinimalDebugInfo)
+           |  str == "2"     -> ParseOk [] (Flag NormalDebugInfo)
+           |  str == "3"     -> ParseOk [] (Flag MaximalDebugInfo)
+           | lstr == "false" -> ParseOk [caseWarning] (Flag NoDebugInfo)
+           | lstr == "true"  -> ParseOk [caseWarning] (Flag NormalDebugInfo)
+           | otherwise       -> ParseFailed (NoParse name line)
+           where
+             lstr = lowercase str
+             caseWarning = PWarning $
+               "The '" ++ name ++ "' field is case sensitive, use 'True' or 'False'.")
+
+
+legacyPackageConfigSectionDescrs :: [SectionDescr LegacyProjectConfig]
+legacyPackageConfigSectionDescrs =
+    [ packageRepoSectionDescr
+    , packageSpecificOptionsSectionDescr
+    , liftSection
+        legacyLocalConfig
+        (\flags conf -> conf { legacyLocalConfig = flags })
+        programOptionsSectionDescr
+    , liftSection
+        legacyLocalConfig
+        (\flags conf -> conf { legacyLocalConfig = flags })
+        programLocationsSectionDescr
+    , liftSection
+        legacySharedConfig
+        (\flags conf -> conf { legacySharedConfig = flags }) $
+      liftSection
+        legacyGlobalFlags
+        (\flags conf -> conf { legacyGlobalFlags = flags })
+        remoteRepoSectionDescr
+    ]
+
+packageRepoSectionDescr :: SectionDescr LegacyProjectConfig
+packageRepoSectionDescr =
+    SectionDescr {
+      sectionName        = "source-repository-package",
+      sectionFields      = sourceRepoFieldDescrs,
+      sectionSubsections = [],
+      sectionGet         = map (\x->("", x))
+                         . legacyPackagesRepo,
+      sectionSet         =
+        \lineno unused pkgrepo projconf -> do
+          unless (null unused) $
+            syntaxError lineno "the section 'source-repository-package' takes no arguments"
+          return projconf {
+            legacyPackagesRepo = legacyPackagesRepo projconf ++ [pkgrepo]
+          },
+      sectionEmpty       = SourceRepo {
+                             repoKind     = RepoThis, -- hopefully unused
+                             repoType     = Nothing,
+                             repoLocation = Nothing,
+                             repoModule   = Nothing,
+                             repoBranch   = Nothing,
+                             repoTag      = Nothing,
+                             repoSubdir   = Nothing
+                           }
+    }
+
+packageSpecificOptionsSectionDescr :: SectionDescr LegacyProjectConfig
+packageSpecificOptionsSectionDescr =
+    SectionDescr {
+      sectionName        = "package",
+      sectionFields      = legacyPackageConfigFieldDescrs
+                        ++ programOptionsFieldDescrs
+                             (configProgramArgs . legacyConfigureFlags)
+                             (\args pkgconf -> pkgconf {
+                                 legacyConfigureFlags = (legacyConfigureFlags pkgconf) {
+                                   configProgramArgs  = args
+                                 }
+                               }
+                             ),
+      sectionSubsections = [],
+      sectionGet         = \projconf ->
+                             [ (display pkgname, pkgconf)
+                             | (pkgname, pkgconf) <- Map.toList (legacySpecificConfig projconf) ],
+      sectionSet         =
+        \lineno pkgnamestr pkgconf projconf -> do
+          pkgname <- case simpleParse pkgnamestr of
+            Just pkgname -> return pkgname
+            Nothing      -> syntaxError lineno $
+                                "a 'package' section requires a package name "
+                             ++ "as an argument"
+          return projconf {
+            legacySpecificConfig =
+              Map.insertWith mappend pkgname pkgconf
+                             (legacySpecificConfig projconf)
+          },
+      sectionEmpty       = mempty
+    }
+
+programOptionsFieldDescrs :: (a -> [(String, [String])])
+                          -> ([(String, [String])] -> a -> a)
+                          -> [FieldDescr a]
+programOptionsFieldDescrs get set =
+    commandOptionsToFields
+  $ programConfigurationOptions
+      defaultProgramDb
+      ParseArgs get set
+
+programOptionsSectionDescr :: SectionDescr LegacyPackageConfig
+programOptionsSectionDescr =
+    SectionDescr {
+      sectionName        = "program-options",
+      sectionFields      = programOptionsFieldDescrs
+                             configProgramArgs
+                             (\args conf -> conf { configProgramArgs = args }),
+      sectionSubsections = [],
+      sectionGet         = (\x->[("", x)])
+                         . legacyConfigureFlags,
+      sectionSet         =
+        \lineno unused confflags pkgconf -> do
+          unless (null unused) $
+            syntaxError lineno "the section 'program-options' takes no arguments"
+          return pkgconf {
+            legacyConfigureFlags = legacyConfigureFlags pkgconf <> confflags
+          },
+      sectionEmpty       = mempty
+    }
+
+programLocationsFieldDescrs :: [FieldDescr ConfigFlags]
+programLocationsFieldDescrs =
+     commandOptionsToFields
+   $ programConfigurationPaths'
+       (++ "-location")
+       defaultProgramDb
+       ParseArgs
+       configProgramPaths
+       (\paths conf -> conf { configProgramPaths = paths })
+
+programLocationsSectionDescr :: SectionDescr LegacyPackageConfig
+programLocationsSectionDescr =
+    SectionDescr {
+      sectionName        = "program-locations",
+      sectionFields      = programLocationsFieldDescrs,
+      sectionSubsections = [],
+      sectionGet         = (\x->[("", x)])
+                         . legacyConfigureFlags,
+      sectionSet         =
+        \lineno unused confflags pkgconf -> do
+          unless (null unused) $
+            syntaxError lineno "the section 'program-locations' takes no arguments"
+          return pkgconf {
+            legacyConfigureFlags = legacyConfigureFlags pkgconf <> confflags
+          },
+      sectionEmpty       = mempty
+    }
+
+
+-- | For each known program @PROG@ in 'progConf', produce a @PROG-options@
+-- 'OptionField'.
+programConfigurationOptions
+  :: ProgramDb
+  -> ShowOrParseArgs
+  -> (flags -> [(String, [String])])
+  -> ([(String, [String])] -> (flags -> flags))
+  -> [OptionField flags]
+programConfigurationOptions progConf showOrParseArgs get set =
+  case showOrParseArgs of
+    -- we don't want a verbose help text list so we just show a generic one:
+    ShowArgs  -> [programOptions  "PROG"]
+    ParseArgs -> map (programOptions . programName . fst)
+                 (knownPrograms progConf)
+  where
+    programOptions prog =
+      option "" [prog ++ "-options"]
+        ("give extra options to " ++ prog)
+        get set
+        (reqArg' "OPTS" (\args -> [(prog, splitArgs args)])
+           (\progArgs -> [ joinsArgs args
+                         | (prog', args) <- progArgs, prog==prog' ]))
+
+
+    joinsArgs = unwords . map escape
+    escape arg | any isSpace arg = "\"" ++ arg ++ "\""
+               | otherwise       = arg
+
+
+remoteRepoSectionDescr :: SectionDescr GlobalFlags
+remoteRepoSectionDescr =
+    SectionDescr {
+      sectionName        = "repository",
+      sectionFields      = remoteRepoFields,
+      sectionSubsections = [],
+      sectionGet         = map (\x->(remoteRepoName x, x)) . fromNubList
+                         . globalRemoteRepos,
+      sectionSet         =
+        \lineno reponame repo0 conf -> do
+          when (null reponame) $
+            syntaxError lineno $ "a 'repository' section requires the "
+                              ++ "repository name as an argument"
+          let repo = repo0 { remoteRepoName = reponame }
+          when (remoteRepoKeyThreshold repo
+                 > length (remoteRepoRootKeys repo)) $
+            warning $ "'key-threshold' for repository "
+                   ++ show (remoteRepoName repo)
+                   ++ " higher than number of keys"
+          when (not (null (remoteRepoRootKeys repo))
+                && remoteRepoSecure repo /= Just True) $
+            warning $ "'root-keys' for repository "
+                   ++ show (remoteRepoName repo)
+                   ++ " non-empty, but 'secure' not set to True."
+          return conf {
+            globalRemoteRepos = overNubList (++[repo]) (globalRemoteRepos conf)
+          },
+      sectionEmpty       = emptyRemoteRepo ""
+    }
+
+
+-------------------------------
+-- Local field utils
+--
+
+--TODO: [code cleanup] all these utils should move to Distribution.ParseUtils
+-- either augmenting or replacing the ones there
+
+--TODO: [code cleanup] this is a different definition from listField, like
+-- commaNewLineListField it pretty prints on multiple lines
+newLineListField :: String -> (a -> Doc) -> ReadP [a] a
+                 -> (b -> [a]) -> ([a] -> b -> b) -> FieldDescr b
+newLineListField = listFieldWithSep Disp.sep
+
+--TODO: [code cleanup] local copy purely so we can use the fixed version
+-- of parseOptCommaList below
+listFieldWithSep :: ([Doc] -> Doc) -> String -> (a -> Doc) -> ReadP [a] a
+                 -> (b -> [a]) -> ([a] -> b -> b) -> FieldDescr b
+listFieldWithSep separator name showF readF get set =
+  liftField get set' $
+    ParseUtils.field name showF' (parseOptCommaList readF)
+  where
+    set' xs b = set (get b ++ xs) b
+    showF'    = separator . map showF
+
+--TODO: [code cleanup] local redefinition that should replace the version in
+-- D.ParseUtils. This version avoid parse ambiguity for list element parsers
+-- that have multiple valid parses of prefixes.
+parseOptCommaList :: ReadP r a -> ReadP r [a]
+parseOptCommaList p = Parse.sepBy p sep
+  where
+    -- The separator must not be empty or it introduces ambiguity
+    sep = (Parse.skipSpaces >> Parse.char ',' >> Parse.skipSpaces)
+      +++ (Parse.satisfy isSpace >> Parse.skipSpaces)
+
+--TODO: [code cleanup] local redefinition that should replace the version in
+-- D.ParseUtils called showFilePath. This version escapes "." and "--" which
+-- otherwise are special syntax.
+showTokenQ :: String -> Doc
+showTokenQ ""            = Disp.empty
+showTokenQ x@('-':'-':_) = Disp.text (show x)
+showTokenQ x@('.':[])    = Disp.text (show x)
+showTokenQ x             = showToken x
+
+-- This is just a copy of parseTokenQ, using the fixed parseHaskellString
+parseTokenQ :: ReadP r String
+parseTokenQ = parseHaskellString
+          <++ Parse.munch1 (\x -> not (isSpace x) && x /= ',')
+
+--TODO: [code cleanup] use this to replace the parseHaskellString in
+-- Distribution.ParseUtils. It turns out Read instance for String accepts
+-- the ['a', 'b'] syntax, which we do not want. In particular it messes
+-- up any token starting with [].
+parseHaskellString :: ReadP r String
+parseHaskellString =
+  Parse.readS_to_P $
+    Read.readPrec_to_S (do Read.String s <- Read.lexP; return s) 0
+
+-- Handy util
+addFields :: [FieldDescr a]
+          -> ([FieldDescr a] -> [FieldDescr a])
+addFields = (++)

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -1,0 +1,333 @@
+{-# LANGUAGE DeriveGeneric, DeriveDataTypeable #-}
+
+-- | Handling project configuration, types.
+--
+module Distribution.Client.ProjectConfig.Types (
+
+    -- * Types for project config
+    ProjectConfig(..),
+    ProjectConfigBuildOnly(..),
+    ProjectConfigShared(..),
+    PackageConfig(..),
+
+    -- * Resolving configuration
+    SolverSettings(..),
+    BuildTimeSettings(..),
+
+  ) where
+
+import Distribution.Client.Types
+         ( RemoteRepo )
+import Distribution.Client.Dependency.Types
+         ( PreSolver, ConstraintSource )
+import Distribution.Client.Targets
+         ( UserConstraint )
+import Distribution.Client.BuildReports.Types 
+         ( ReportLevel(..) )
+
+import Distribution.Package
+         ( PackageName, PackageId, UnitId, Dependency )
+import Distribution.Version
+         ( Version )
+import Distribution.System
+         ( Platform )
+import Distribution.PackageDescription
+         ( FlagAssignment, SourceRepo(..) )
+import Distribution.Simple.Compiler
+         ( Compiler, CompilerFlavor
+         , OptimisationLevel(..), ProfDetailLevel, DebugInfoLevel(..) )
+import Distribution.Simple.Setup
+         ( Flag, AllowNewer(..) )
+import Distribution.Simple.InstallDirs
+         ( PathTemplate )
+import Distribution.Utils.NubList
+         ( NubList )
+import Distribution.Verbosity
+         ( Verbosity )
+
+import Data.Map (Map)
+import Distribution.Compat.Binary (Binary)
+import Distribution.Compat.Semigroup
+import GHC.Generics (Generic)
+
+
+-------------------------------
+-- Project config types
+--
+
+-- | This type corresponds directly to what can be written in the
+-- @cabal.project@ file. Other sources of configuration can also be injected
+-- into this type, such as the user-wide @~/.cabal/config@ file and the
+-- command line of @cabal configure@ or @cabal build@.
+--
+-- Since it corresponds to the external project file it is an instance of
+-- 'Monoid' and all the fields can be empty. This also means there has to
+-- be a step where we resolve configuration. At a minimum resolving means
+-- applying defaults but it can also mean merging information from multiple
+-- sources. For example for package-specific configuration the project file
+-- can specify configuration that applies to all local packages, and then
+-- additional configuration for a specific package.
+--
+-- Future directions: multiple profiles, conditionals. If we add these
+-- features then the gap between configuration as written in the config file
+-- and resolved settings we actually use will become even bigger.
+--
+data ProjectConfig
+   = ProjectConfig {
+
+       -- | Packages in this project, including local dirs, local .cabal files
+       -- local and remote tarballs. Where these are file globs, they must
+       -- match something.
+       projectPackages              :: [String],
+
+       -- | Like 'projectConfigPackageGlobs' but /optional/ in the sense that
+       -- file globs are allowed to match nothing. The primary use case for
+       -- this is to be able to say @optional-packages: */@ to automagically
+       -- pick up deps that we unpack locally.
+       projectPackagesOptional      :: [String],
+
+       -- | Packages in this project from remote source repositories.
+       projectPackagesRepo          :: [SourceRepo],
+
+       -- | Packages in this project from hackage repositories.
+       projectPackagesNamed         :: [Dependency],
+
+       projectConfigBuildOnly       :: ProjectConfigBuildOnly,
+       projectConfigShared          :: ProjectConfigShared,
+       projectConfigLocalPackages   :: PackageConfig,
+       projectConfigSpecificPackage :: Map PackageName PackageConfig
+     }
+  deriving (Eq, Show, Generic)
+
+-- | That part of the project configuration that only affects /how/ we build
+-- and not the /value/ of the things we build. This means this information
+-- does not need to be tracked for changes since it does not affect the
+-- outcome.
+--
+data ProjectConfigBuildOnly
+   = ProjectConfigBuildOnly {
+       projectConfigVerbosity             :: Flag Verbosity,
+       projectConfigDryRun                :: Flag Bool,
+       projectConfigOnlyDeps              :: Flag Bool,
+       projectConfigSummaryFile           :: NubList PathTemplate,
+       projectConfigLogFile               :: Flag PathTemplate,
+       projectConfigBuildReports          :: Flag ReportLevel,
+       projectConfigReportPlanningFailure :: Flag Bool,
+       projectConfigSymlinkBinDir         :: Flag FilePath,
+       projectConfigOneShot               :: Flag Bool,
+       projectConfigNumJobs               :: Flag (Maybe Int),
+       projectConfigOfflineMode           :: Flag Bool,
+       projectConfigKeepTempFiles         :: Flag Bool,
+       projectConfigHttpTransport         :: Flag String,
+       projectConfigIgnoreExpiry          :: Flag Bool,
+       projectConfigCacheDir              :: Flag FilePath,
+       projectConfigLogsDir               :: Flag FilePath,
+       projectConfigWorldFile             :: Flag FilePath,
+       projectConfigRootCmd               :: Flag String
+     }
+  deriving (Eq, Show, Generic)
+
+
+-- | Project configuration that is shared between all packages in the project.
+-- In particular this includes configuration that affects the solver.
+--
+data ProjectConfigShared
+   = ProjectConfigShared {
+       projectConfigProgramPaths      :: Map String FilePath,
+       projectConfigProgramArgs       :: Map String [String],
+       projectConfigProgramPathExtra  :: NubList FilePath,
+       projectConfigHcFlavor          :: Flag CompilerFlavor,
+       projectConfigHcPath            :: Flag FilePath,
+       projectConfigHcPkg             :: Flag FilePath,
+       projectConfigHaddockIndex      :: Flag PathTemplate,
+
+       -- Things that only make sense for manual mode, not --local mode
+       -- too much control!
+     --projectConfigUserInstall       :: Flag Bool,
+     --projectConfigInstallDirs       :: InstallDirs (Flag PathTemplate),
+     --TODO: [required eventually] decide what to do with InstallDirs
+     -- currently we don't allow it to be specified in the config file
+     --projectConfigPackageDBs        :: [Maybe PackageDB],
+
+       -- configuration used both by the solver and other phases
+       projectConfigRemoteRepos       :: NubList RemoteRepo,     -- ^ Available Hackage servers.
+       projectConfigLocalRepos        :: NubList FilePath,
+
+       -- solver configuration
+       projectConfigConstraints       :: [(UserConstraint, ConstraintSource)],
+       projectConfigPreferences       :: [Dependency],
+       projectConfigFlagAssignment    :: FlagAssignment, --TODO: [required eventually] must be per-package, not global
+       projectConfigCabalVersion      :: Flag Version,  --TODO: [required eventually] unused
+       projectConfigSolver            :: Flag PreSolver,
+       projectConfigAllowNewer        :: Maybe AllowNewer,
+       projectConfigMaxBackjumps      :: Flag Int,
+       projectConfigReorderGoals      :: Flag Bool,
+       projectConfigStrongFlags       :: Flag Bool
+
+       -- More things that only make sense for manual mode, not --local mode
+       -- too much control!
+     --projectConfigIndependentGoals  :: Flag Bool,
+     --projectConfigShadowPkgs        :: Flag Bool,
+     --projectConfigReinstall         :: Flag Bool,
+     --projectConfigAvoidReinstalls   :: Flag Bool,
+     --projectConfigOverrideReinstall :: Flag Bool,
+     --projectConfigUpgradeDeps       :: Flag Bool
+     }
+  deriving (Eq, Show, Generic)
+
+
+-- | Project configuration that is specific to each package, that is where we
+-- can in principle have different values for different packages in the same
+-- project.
+--
+data PackageConfig
+   = PackageConfig {
+       packageConfigVanillaLib          :: Flag Bool,
+       packageConfigSharedLib           :: Flag Bool,
+       packageConfigDynExe              :: Flag Bool,
+       packageConfigProf                :: Flag Bool, --TODO: [code cleanup] sort out
+       packageConfigProfLib             :: Flag Bool, --      this duplication
+       packageConfigProfExe             :: Flag Bool, --      and consistency
+       packageConfigProfDetail          :: Flag ProfDetailLevel,
+       packageConfigProfLibDetail       :: Flag ProfDetailLevel,
+       packageConfigConfigureArgs       :: [String],
+       packageConfigOptimization        :: Flag OptimisationLevel,
+       packageConfigProgPrefix          :: Flag PathTemplate,
+       packageConfigProgSuffix          :: Flag PathTemplate,
+       packageConfigExtraLibDirs        :: [FilePath],
+       packageConfigExtraFrameworkDirs  :: [FilePath],
+       packageConfigExtraIncludeDirs    :: [FilePath],
+       packageConfigGHCiLib             :: Flag Bool,
+       packageConfigSplitObjs           :: Flag Bool,
+       packageConfigStripExes           :: Flag Bool,
+       packageConfigStripLibs           :: Flag Bool,
+       packageConfigTests               :: Flag Bool,
+       packageConfigBenchmarks          :: Flag Bool,
+       packageConfigCoverage            :: Flag Bool,
+       packageConfigRelocatable         :: Flag Bool,
+       packageConfigDebugInfo           :: Flag DebugInfoLevel,
+       packageConfigRunTests            :: Flag Bool, --TODO: [required eventually] use this
+       packageConfigDocumentation       :: Flag Bool, --TODO: [required eventually] use this
+       packageConfigHaddockHoogle       :: Flag Bool, --TODO: [required eventually] use this
+       packageConfigHaddockHtml         :: Flag Bool, --TODO: [required eventually] use this
+       packageConfigHaddockHtmlLocation :: Flag String, --TODO: [required eventually] use this
+       packageConfigHaddockExecutables  :: Flag Bool, --TODO: [required eventually] use this
+       packageConfigHaddockTestSuites   :: Flag Bool, --TODO: [required eventually] use this
+       packageConfigHaddockBenchmarks   :: Flag Bool, --TODO: [required eventually] use this
+       packageConfigHaddockInternal     :: Flag Bool, --TODO: [required eventually] use this
+       packageConfigHaddockCss          :: Flag FilePath, --TODO: [required eventually] use this
+       packageConfigHaddockHscolour     :: Flag Bool, --TODO: [required eventually] use this
+       packageConfigHaddockHscolourCss  :: Flag FilePath, --TODO: [required eventually] use this
+       packageConfigHaddockContents     :: Flag PathTemplate --TODO: [required eventually] use this
+     }
+  deriving (Eq, Show, Generic)
+
+instance Binary ProjectConfig
+instance Binary ProjectConfigBuildOnly
+instance Binary ProjectConfigShared
+instance Binary PackageConfig
+
+
+instance Monoid ProjectConfig where
+  mempty = gmempty
+  mappend = (<>)
+
+instance Semigroup ProjectConfig where
+  (<>) = gmappend
+
+
+instance Monoid ProjectConfigBuildOnly where
+  mempty = gmempty
+  mappend = (<>)
+
+instance Semigroup ProjectConfigBuildOnly where
+  (<>) = gmappend
+
+
+instance Monoid ProjectConfigShared where
+  mempty = gmempty
+  mappend = (<>)
+
+instance Semigroup ProjectConfigShared where
+  (<>) = gmappend
+
+
+instance Monoid PackageConfig where
+  mempty = gmempty
+  mappend = (<>)
+
+instance Semigroup PackageConfig where
+  (<>) = gmappend
+
+----------------------------------------
+-- Resolving configuration to settings
+--
+
+-- | Resolved configuration for the solver. The idea is that this is easier to
+-- use than the raw configuration because in the raw configuration everything
+-- is optional (monoidial). In the 'BuildTimeSettings' every field is filled
+-- in, if only with the defaults.
+--
+-- Use 'resolveSolverSettings' to make one from the project config (by
+-- applying defaults etc).
+--
+data SolverSettings
+   = SolverSettings {
+       solverSettingRemoteRepos       :: [RemoteRepo],     -- ^ Available Hackage servers.
+       solverSettingLocalRepos        :: [FilePath],
+       solverSettingConstraints       :: [(UserConstraint, ConstraintSource)],
+       solverSettingPreferences       :: [Dependency],
+       solverSettingFlagAssignment    :: FlagAssignment, --TODO: [required eventually] must be per-package, not global
+       solverSettingCabalVersion      :: Maybe Version,  --TODO: [required eventually] unused
+       solverSettingSolver            :: PreSolver,
+       solverSettingAllowNewer        :: AllowNewer,
+       solverSettingMaxBackjumps      :: Maybe Int,
+       solverSettingReorderGoals      :: Bool,
+       solverSettingStrongFlags       :: Bool
+       -- Things that only make sense for manual mode, not --local mode
+       -- too much control!
+     --solverSettingIndependentGoals  :: Bool,
+     --solverSettingShadowPkgs        :: Bool,
+     --solverSettingReinstall         :: Bool,
+     --solverSettingAvoidReinstalls   :: Bool,
+     --solverSettingOverrideReinstall :: Bool,
+     --solverSettingUpgradeDeps       :: Bool
+     }
+  deriving (Eq, Show, Generic)
+
+instance Binary SolverSettings
+
+
+-- | Resolved configuration for things that affect how we build and not the
+-- value of the things we build. The idea is that this is easier to use than
+-- the raw configuration because in the raw configuration everything is
+-- optional (monoidial). In the 'BuildTimeSettings' every field is filled in,
+-- if only with the defaults.
+--
+-- Use 'resolveBuildTimeSettings' to make one from the project config (by
+-- applying defaults etc).
+--
+data BuildTimeSettings
+   = BuildTimeSettings {
+       buildSettingDryRun                :: Bool,
+       buildSettingOnlyDeps              :: Bool,
+       buildSettingSummaryFile           :: [PathTemplate],
+       buildSettingLogFile               :: Maybe (Compiler  -> Platform
+                                                -> PackageId -> UnitId
+                                                             -> FilePath),
+       buildSettingLogVerbosity          :: Verbosity,
+       buildSettingBuildReports          :: ReportLevel,
+       buildSettingReportPlanningFailure :: Bool,
+       buildSettingSymlinkBinDir         :: [FilePath],
+       buildSettingOneShot               :: Bool,
+       buildSettingNumJobs               :: Int,
+       buildSettingOfflineMode           :: Bool,
+       buildSettingKeepTempFiles         :: Bool,
+       buildSettingRemoteRepos           :: [RemoteRepo],
+       buildSettingLocalRepos            :: [FilePath],
+       buildSettingCacheDir              :: FilePath,
+       buildSettingHttpTransport         :: Maybe String,
+       buildSettingIgnoreExpiry          :: Bool,
+       buildSettingRootCmd               :: Maybe String
+     }
+

--- a/cabal-install/Distribution/Client/RebuildMonad.hs
+++ b/cabal-install/Distribution/Client/RebuildMonad.hs
@@ -29,7 +29,8 @@ module Distribution.Client.RebuildMonad (
     matchFileGlob,
   ) where
 
-import Distribution.Client.FileMonitor
+import Distribution.Client.FileMonitor hiding (matchFileGlob)
+import qualified Distribution.Client.FileMonitor as FileMonitor (matchFileGlob)
 
 import Distribution.Simple.Utils (debug)
 import Distribution.Verbosity    (Verbosity)
@@ -106,4 +107,16 @@ rerunIfChanged verbosity rootDir monitor key action = do
     showReason (MonitoredValueChanged _)   = "monitor value changed"
     showReason  MonitorFirstRun            = "first run"
     showReason  MonitorCorruptCache        = "invalid cache file"
+
+
+-- | Utility to match a file glob against the file system, starting from a
+-- given root directory. The results are all relative to the given root.
+--
+-- Since this operates in the 'Rebuild' monad, it also monitrs the given glob
+-- for changes.
+--
+matchFileGlob :: FilePath -> FilePathGlob -> Rebuild [FilePath]
+matchFileGlob root glob = do
+    monitorFiles [MonitorFileGlob glob]
+    liftIO $ FileMonitor.matchFileGlob root glob
 

--- a/cabal-install/Distribution/Client/RebuildMonad.hs
+++ b/cabal-install/Distribution/Client/RebuildMonad.hs
@@ -112,7 +112,7 @@ rerunIfChanged verbosity rootDir monitor key action = do
 -- | Utility to match a file glob against the file system, starting from a
 -- given root directory. The results are all relative to the given root.
 --
--- Since this operates in the 'Rebuild' monad, it also monitrs the given glob
+-- Since this operates in the 'Rebuild' monad, it also monitors the given glob
 -- for changes.
 --
 matchFileGlob :: FilePath -> FilePathGlob -> Rebuild [FilePath]

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -23,6 +23,7 @@ module Distribution.Client.Setup
     , buildCommand, BuildFlags(..), BuildExFlags(..), SkipAddSourceDepsCheck(..)
     , replCommand, testCommand, benchmarkCommand
     , installCommand, InstallFlags(..), installOptions, defaultInstallFlags
+    , defaultSolver, defaultMaxBackjumps
     , listCommand, ListFlags(..)
     , updateCommand
     , upgradeCommand

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -262,12 +262,12 @@ globalCommand commands = CommandUI {
 
       ,option [] ["sandbox-config-file"]
          "Set an alternate location for the sandbox config file (default: './cabal.sandbox.config')"
-         globalConfigFile (\v flags -> flags { globalSandboxConfigFile = v })
+         globalSandboxConfigFile (\v flags -> flags { globalSandboxConfigFile = v })
          (reqArgFlag "FILE")
 
       ,option [] ["default-user-config"]
          "Set a location for a cabal.config file for projects without their own cabal.config freeze file."
-         globalConfigFile (\v flags -> flags {globalConstraintsFile = v})
+         globalConstraintsFile (\v flags -> flags {globalConstraintsFile = v})
          (reqArgFlag "FILE")
 
       ,option [] ["require-sandbox"]
@@ -287,7 +287,7 @@ globalCommand commands = CommandUI {
 
       ,option [] ["http-transport"]
          "Set a transport for http(s) requests. Accepts 'curl', 'wget', 'powershell', and 'plain-http'. (default: 'curl')"
-         globalConfigFile (\v flags -> flags { globalHttpTransport = v })
+         globalHttpTransport (\v flags -> flags { globalHttpTransport = v })
          (reqArgFlag "HttpTransport")
       ]
 

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -44,7 +44,9 @@ module Distribution.Client.Targets (
   UserConstraint(..),
   userConstraintPackageName,
   readUserConstraint,
-  userToPackageConstraint
+  userToPackageConstraint,
+  dispFlagAssignment,
+  parseFlagAssignment,
 
   ) where
 
@@ -757,12 +759,6 @@ instance Text UserConstraint where
                                                     <+> Disp.text "source"
   disp (UserConstraintFlags     pkgname flags)    = disp pkgname
                                                     <+> dispFlagAssignment flags
-    where
-      dispFlagAssignment = Disp.hsep . map dispFlagValue
-      dispFlagValue (f, True)   = Disp.char '+' <> dispFlagName f
-      dispFlagValue (f, False)  = Disp.char '-' <> dispFlagName f
-      dispFlagName (FlagName f) = Disp.text f
-
   disp (UserConstraintStanzas   pkgname stanzas)  = disp pkgname
                                                     <+> dispStanzas stanzas
     where
@@ -772,37 +768,51 @@ instance Text UserConstraint where
 
   parse = parse >>= parseConstraint
     where
-      spaces = Parse.satisfy isSpace >> Parse.skipSpaces
-
       parseConstraint pkgname =
             ((parse >>= return . UserConstraintVersion pkgname)
-        +++ (do spaces
+        +++ (do skipSpaces1
                 _ <- Parse.string "installed"
                 return (UserConstraintInstalled pkgname))
-        +++ (do spaces
+        +++ (do skipSpaces1
                 _ <- Parse.string "source"
                 return (UserConstraintSource pkgname))
-        +++ (do spaces
+        +++ (do skipSpaces1
                 _ <- Parse.string "test"
                 return (UserConstraintStanzas pkgname [TestStanzas]))
-        +++ (do spaces
+        +++ (do skipSpaces1
                 _ <- Parse.string "bench"
                 return (UserConstraintStanzas pkgname [BenchStanzas])))
-        <++ (parseFlagAssignment >>= (return . UserConstraintFlags pkgname))
+        <++ (do skipSpaces1
+                flags <- parseFlagAssignment
+                return (UserConstraintFlags pkgname flags))
 
-      parseFlagAssignment = Parse.many1 (spaces >> parseFlagValue)
-      parseFlagValue =
-            (do Parse.optional (Parse.char '+')
-                f <- parseFlagName
-                return (f, True))
-        +++ (do _ <- Parse.char '-'
-                f <- parseFlagName
-                return (f, False))
-      parseFlagName = liftM FlagName ident
+--TODO: [code cleanup] move these somewhere else
+dispFlagAssignment :: FlagAssignment -> Disp.Doc
+dispFlagAssignment = Disp.hsep . map dispFlagValue
+  where
+    dispFlagValue (f, True)   = Disp.char '+' <> dispFlagName f
+    dispFlagValue (f, False)  = Disp.char '-' <> dispFlagName f
+    dispFlagName (FlagName f) = Disp.text f
 
-      ident :: Parse.ReadP r String
-      ident = Parse.munch1 identChar >>= \s -> check s >> return s
-        where
-          identChar c   = isAlphaNum c || c == '_' || c == '-'
-          check ('-':_) = Parse.pfail
-          check _       = return ()
+parseFlagAssignment :: Parse.ReadP r FlagAssignment
+parseFlagAssignment = Parse.sepBy1 parseFlagValue skipSpaces1
+  where
+    parseFlagValue =
+          (do Parse.optional (Parse.char '+')
+              f <- parseFlagName
+              return (f, True))
+      +++ (do _ <- Parse.char '-'
+              f <- parseFlagName
+              return (f, False))
+    parseFlagName = liftM (FlagName . lowercase) ident
+
+    ident :: Parse.ReadP r String
+    ident = Parse.munch1 identChar >>= \s -> check s >> return s
+      where
+        identChar c   = isAlphaNum c || c == '_' || c == '-'
+        check ('-':_) = Parse.pfail
+        check _       = return ()
+
+skipSpaces1 :: Parse.ReadP r ()
+skipSpaces1 = Parse.satisfy isSpace >> Parse.skipSpaces
+

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -64,6 +64,22 @@ instance Binary SourcePackageDb
 -- * Various kinds of information about packages
 -- ------------------------------------------------------------
 
+-- | Within Cabal the library we no longer have a @InstalledPackageId@ type.
+-- That's because it deals with the compilers' notion of a registered library,
+-- and those really are libraries not packages. Those are now named units.
+--
+-- The package management layer does however deal with installed packages, as
+-- whole packages not just as libraries. So we do still need a type for
+-- installed package ids. At the moment however we track instaled packages via
+-- their primary library, which is a unit id. In future this may change
+-- slightly and we may distinguish these two types and have an explicit
+-- conversion when we register units with the compiler.
+--
+type InstalledPackageId = UnitId
+
+installedPackageId :: HasUnitId pkg => pkg -> InstalledPackageId
+installedPackageId = installedUnitId
+
 -- | Subclass of packages that have specific versioned dependencies.
 --
 -- So for example a not-yet-configured package has dependencies on version

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -69,7 +69,7 @@ import qualified Distribution.Client.List as List
 --TODO: temporary import, just to force these modules to be built.
 -- It will be replaced by import of new build command once merged.
 import Distribution.Client.RebuildMonad ()
-import Distribution.Client.DistDirLayout ()
+import Distribution.Client.ProjectConfig ()
 
 import Distribution.Client.Install            (install)
 import Distribution.Client.Configure          (configure)

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -69,6 +69,7 @@ import qualified Distribution.Client.List as List
 --TODO: temporary import, just to force these modules to be built.
 -- It will be replaced by import of new build command once merged.
 import Distribution.Client.RebuildMonad ()
+import Distribution.Client.DistDirLayout ()
 
 import Distribution.Client.Install            (install)
 import Distribution.Client.Configure          (configure)

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -153,6 +153,7 @@ executable cabal
         Distribution.Client.Dependency.Modular.Tree
         Distribution.Client.Dependency.Modular.Validate
         Distribution.Client.Dependency.Modular.Version
+        Distribution.Client.DistDirLayout
         Distribution.Client.Exec
         Distribution.Client.Fetch
         Distribution.Client.FetchUtils

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -180,6 +180,9 @@ executable cabal
         Distribution.Client.PackageUtils
         Distribution.Client.ParseUtils
         Distribution.Client.PlanIndex
+        Distribution.Client.ProjectConfig
+        Distribution.Client.ProjectConfig.Types
+        Distribution.Client.ProjectConfig.Legacy
         Distribution.Client.Run
         Distribution.Client.RebuildMonad
         Distribution.Client.Sandbox

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -271,6 +271,7 @@ Test-Suite unit-tests
   hs-source-dirs: tests, .
   ghc-options: -Wall -fwarn-tabs
   other-modules:
+    UnitTests.Distribution.Client.ArbitraryInstances
     UnitTests.Distribution.Client.Targets
     UnitTests.Distribution.Client.Compat.Time
     UnitTests.Distribution.Client.Dependency.Modular.PSQ
@@ -282,6 +283,7 @@ Test-Suite unit-tests
     UnitTests.Distribution.Client.Sandbox.Timestamp
     UnitTests.Distribution.Client.Tar
     UnitTests.Distribution.Client.UserConfig
+    UnitTests.Distribution.Client.ProjectConfig
     UnitTests.Options
   build-depends:
         base,

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -24,6 +24,7 @@ import qualified UnitTests.Distribution.Client.Sandbox.Timestamp
 import qualified UnitTests.Distribution.Client.Tar
 import qualified UnitTests.Distribution.Client.Targets
 import qualified UnitTests.Distribution.Client.UserConfig
+import qualified UnitTests.Distribution.Client.ProjectConfig
 
 import UnitTests.Options
 
@@ -56,6 +57,8 @@ tests mtimeChangeCalibrated =
        UnitTests.Distribution.Client.Targets.tests
   , testGroup "UnitTests.Distribution.Client.UserConfig"
        UnitTests.Distribution.Client.UserConfig.tests
+  , testGroup "UnitTests.Distribution.Client.ProjectConfig"
+       UnitTests.Distribution.Client.ProjectConfig.tests
   ]
 
 main :: IO ()

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module UnitTests.Distribution.Client.ArbitraryInstances (
+    adjustSize,
+    shortListOf,
+    shortListOf1,
+    arbitraryFlag,
+    ShortToken(..),
+    arbitraryShortToken,
+    NonMEmpty(..),
+    NoShrink(..),
+  ) where
+
+import Data.Char
+import Data.List
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid
+import Control.Applicative
+#endif
+import Control.Monad
+
+import Distribution.Version
+import Distribution.Package
+import Distribution.System
+import Distribution.Verbosity
+
+import Distribution.Simple.Setup
+import Distribution.Simple.InstallDirs
+
+import Distribution.Utils.NubList
+
+import Test.QuickCheck
+
+
+adjustSize :: (Int -> Int) -> Gen a -> Gen a
+adjustSize adjust gen = sized (\n -> resize (adjust n) gen)
+
+shortListOf :: Int -> Gen a -> Gen [a]
+shortListOf bound gen =
+    sized $ \n -> do
+      k <- choose (0, (n `div` 2) `min` bound)
+      vectorOf k gen
+
+shortListOf1 :: Int -> Gen a -> Gen [a]
+shortListOf1 bound gen =
+    sized $ \n -> do
+      k <- choose (1, 1 `max` ((n `div` 2) `min` bound))
+      vectorOf k gen
+
+newtype ShortToken = ShortToken { getShortToken :: String }
+  deriving Show
+
+instance Arbitrary ShortToken where
+  arbitrary =
+    ShortToken <$>
+      (shortListOf1 5 (choose ('#', '~'))
+       `suchThat` (not . ("[]" `isPrefixOf`)))
+    --TODO: [code cleanup] need to replace parseHaskellString impl to stop
+    -- accepting Haskell list syntax [], ['a'] etc, just allow String syntax.
+    -- Workaround, don't generate [] as this does not round trip.
+
+
+  shrink (ShortToken cs) =
+    [ ShortToken cs' | cs' <- shrink cs, not (null cs') ]
+
+arbitraryShortToken :: Gen String
+arbitraryShortToken = getShortToken <$> arbitrary
+
+instance Arbitrary Version where
+  arbitrary = do
+    branch <- shortListOf1 4 $
+                frequency [(3, return 0)
+                          ,(3, return 1)
+                          ,(2, return 2)
+                          ,(1, return 3)]
+    return (Version branch []) -- deliberate []
+    where
+
+  shrink (Version branch []) =
+    [ Version branch' [] | branch' <- shrink branch, not (null branch') ]
+  shrink (Version branch _tags) =
+    [ Version branch [] ]
+
+instance Arbitrary VersionRange where
+  arbitrary = canonicaliseVersionRange <$> sized verRangeExp
+    where
+      verRangeExp n = frequency $
+        [ (2, return anyVersion)
+        , (1, liftM thisVersion arbitrary)
+        , (1, liftM laterVersion arbitrary)
+        , (1, liftM orLaterVersion arbitrary)
+        , (1, liftM orLaterVersion' arbitrary)
+        , (1, liftM earlierVersion arbitrary)
+        , (1, liftM orEarlierVersion arbitrary)
+        , (1, liftM orEarlierVersion' arbitrary)
+        , (1, liftM withinVersion arbitrary)
+        , (2, liftM VersionRangeParens arbitrary)
+        ] ++ if n == 0 then [] else
+        [ (2, liftM2 unionVersionRanges     verRangeExp2 verRangeExp2)
+        , (2, liftM2 intersectVersionRanges verRangeExp2 verRangeExp2)
+        ]
+        where
+          verRangeExp2 = verRangeExp (n `div` 2)
+
+      orLaterVersion'   v =
+        unionVersionRanges (laterVersion v)   (thisVersion v)
+      orEarlierVersion' v =
+        unionVersionRanges (earlierVersion v) (thisVersion v)
+
+      canonicaliseVersionRange = fromVersionIntervals . toVersionIntervals
+
+instance Arbitrary PackageName where
+    arbitrary = PackageName . intercalate "-" <$> shortListOf1 2 nameComponent
+      where
+        nameComponent = shortListOf1 5 (elements packageChars)
+                        `suchThat` (not . all isDigit)
+        packageChars  = filter isAlphaNum ['\0'..'\127']
+
+instance Arbitrary Dependency where
+    arbitrary = Dependency <$> arbitrary <*> arbitrary
+
+instance Arbitrary OS where
+    arbitrary = elements knownOSs
+
+instance Arbitrary Arch where
+    arbitrary = elements knownArches
+
+instance Arbitrary Platform where
+    arbitrary = Platform <$> arbitrary <*> arbitrary
+
+instance Arbitrary a => Arbitrary (Flag a) where
+    arbitrary = arbitraryFlag arbitrary
+    shrink NoFlag   = []
+    shrink (Flag x) = NoFlag : [ Flag x' | x' <- shrink x ]
+
+arbitraryFlag :: Gen a -> Gen (Flag a)
+arbitraryFlag genA =
+    sized $ \sz ->
+      case sz of
+        0 -> pure NoFlag
+        _ -> frequency [ (1, pure NoFlag)
+                       , (3, Flag <$> genA) ]
+
+
+instance (Arbitrary a, Ord a) => Arbitrary (NubList a) where
+    arbitrary = toNubList <$> arbitrary
+    shrink xs = [ toNubList [] | (not . null) (fromNubList xs) ]
+    -- try empty, otherwise don't shrink as it can loop
+
+instance Arbitrary Verbosity where
+    arbitrary = elements [minBound..maxBound]
+
+instance Arbitrary PathTemplate where
+    arbitrary = toPathTemplate <$> arbitraryShortToken
+    shrink t  = [ toPathTemplate s | s <- shrink (show t), not (null s) ]
+
+
+newtype NonMEmpty a = NonMEmpty { getNonMEmpty :: a }
+  deriving (Eq, Ord, Show)
+
+instance (Arbitrary a, Monoid a, Eq a) => Arbitrary (NonMEmpty a) where
+  arbitrary = NonMEmpty <$> (arbitrary `suchThat` (/= mempty))
+  shrink (NonMEmpty x) = [ NonMEmpty x' | x' <- shrink x, x' /= mempty ]
+
+newtype NoShrink a = NoShrink { getNoShrink :: a }
+  deriving (Eq, Ord, Show)
+
+instance Arbitrary a => Arbitrary (NoShrink a) where
+    arbitrary = NoShrink <$> arbitrary
+    shrink _  = []
+

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -1,0 +1,609 @@
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module UnitTests.Distribution.Client.ProjectConfig (tests) where
+
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid
+import Control.Applicative
+#endif
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.List
+
+import Distribution.Package
+import Distribution.PackageDescription hiding (Flag)
+import Distribution.Compiler
+import Distribution.Version
+import Distribution.ParseUtils
+import Distribution.Simple.Compiler
+import Distribution.Simple.Setup
+import Distribution.Simple.InstallDirs
+import qualified Distribution.Compat.ReadP as Parse
+import Distribution.Simple.Utils
+import Distribution.Simple.Program.Types
+import Distribution.Simple.Program.Db
+
+import Distribution.Client.Types
+import Distribution.Client.Dependency.Types
+import Distribution.Client.BuildReports.Types
+import Distribution.Client.Targets
+import Distribution.Utils.NubList
+import Network.URI
+
+import Distribution.Client.ProjectConfig
+import Distribution.Client.ProjectConfig.Legacy
+
+import UnitTests.Distribution.Client.ArbitraryInstances
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+tests :: [TestTree]
+tests =
+  [ testGroup "ProjectConfig <-> LegacyProjectConfig round trip" $
+    [ testProperty "packages"  prop_roundtrip_legacytypes_packages
+    , testProperty "buildonly" prop_roundtrip_legacytypes_buildonly
+    , testProperty "specific"  prop_roundtrip_legacytypes_specific
+    ] ++
+    -- a couple tests seem to trigger a RTS fault in ghc-7.6 and older
+    -- unclear why as of yet
+    concat
+    [ [ testProperty "shared"    prop_roundtrip_legacytypes_shared
+      , testProperty "local"     prop_roundtrip_legacytypes_local
+      , testProperty "all"       prop_roundtrip_legacytypes_all
+      ]
+    | not usingGhc76orOlder
+    ]
+
+  , testGroup "individual parser tests"
+    [ testProperty "package location"  prop_parsePackageLocationTokenQ
+    ]
+
+  , testGroup "ProjectConfig printing/parsing round trip"
+    [ testProperty "packages"  prop_roundtrip_printparse_packages
+    , testProperty "buildonly" prop_roundtrip_printparse_buildonly
+    , testProperty "shared"    prop_roundtrip_printparse_shared
+    , testProperty "local"     prop_roundtrip_printparse_local
+    , testProperty "specific"  prop_roundtrip_printparse_specific
+    , testProperty "all"       prop_roundtrip_printparse_all
+    ]
+  ]
+  where
+    usingGhc76orOlder =
+      case buildCompilerId of
+        CompilerId GHC v -> v < Version [7,7] []
+        _                -> False
+
+
+------------------------------------------------
+-- Round trip: conversion to/from legacy types
+--
+
+roundtrip :: Eq a => (a -> b) -> (b -> a) -> a -> Bool
+roundtrip f f_inv x =
+    (f_inv . f) x == x
+
+roundtrip_legacytypes :: ProjectConfig -> Bool
+roundtrip_legacytypes =
+    roundtrip convertToLegacyProjectConfig
+              convertLegacyProjectConfig
+
+
+prop_roundtrip_legacytypes_all :: ProjectConfig -> Bool
+prop_roundtrip_legacytypes_all =
+    roundtrip_legacytypes
+
+prop_roundtrip_legacytypes_packages :: ProjectConfig -> Bool
+prop_roundtrip_legacytypes_packages config =
+    roundtrip_legacytypes
+      config {
+        projectConfigBuildOnly       = mempty,
+        projectConfigShared          = mempty,
+        projectConfigLocalPackages   = mempty,
+        projectConfigSpecificPackage = mempty
+      }
+
+prop_roundtrip_legacytypes_buildonly :: ProjectConfigBuildOnly -> Bool
+prop_roundtrip_legacytypes_buildonly config =
+    roundtrip_legacytypes
+      mempty { projectConfigBuildOnly = config }
+
+prop_roundtrip_legacytypes_shared :: ProjectConfigShared -> Bool
+prop_roundtrip_legacytypes_shared config =
+    roundtrip_legacytypes
+      mempty { projectConfigShared = config }
+
+prop_roundtrip_legacytypes_local :: PackageConfig -> Bool
+prop_roundtrip_legacytypes_local config =
+    roundtrip_legacytypes
+      mempty { projectConfigLocalPackages = config }
+
+prop_roundtrip_legacytypes_specific :: Map PackageName PackageConfig -> Bool
+prop_roundtrip_legacytypes_specific config =
+    roundtrip_legacytypes
+      mempty { projectConfigSpecificPackage = config }
+
+
+--------------------------------------------
+-- Round trip: printing and parsing config
+--
+
+roundtrip_printparse :: ProjectConfig -> Bool
+roundtrip_printparse config =
+    case (fmap convertLegacyProjectConfig
+        . parseLegacyProjectConfig
+        . showLegacyProjectConfig
+        . convertToLegacyProjectConfig)
+          config of
+      ParseOk _ x -> x == config
+      _           -> False
+
+
+prop_roundtrip_printparse_all :: ProjectConfig -> Bool
+prop_roundtrip_printparse_all config =
+    roundtrip_printparse config {
+      projectConfigBuildOnly =
+        hackProjectConfigBuildOnly (projectConfigBuildOnly config),
+
+      projectConfigShared =
+        hackProjectConfigShared (projectConfigShared config)
+    }
+
+prop_roundtrip_printparse_packages :: [PackageLocationString]
+                                   -> [PackageLocationString]
+                                   -> [SourceRepo]
+                                   -> [Dependency]
+                                   -> Bool
+prop_roundtrip_printparse_packages pkglocstrs1 pkglocstrs2 repos named =
+    roundtrip_printparse
+      mempty {
+        projectPackages         = map getPackageLocationString pkglocstrs1,
+        projectPackagesOptional = map getPackageLocationString pkglocstrs2,
+        projectPackagesRepo     = repos,
+        projectPackagesNamed    = named
+      }
+
+prop_roundtrip_printparse_buildonly :: ProjectConfigBuildOnly -> Bool
+prop_roundtrip_printparse_buildonly config =
+    roundtrip_printparse
+      mempty {
+        projectConfigBuildOnly = hackProjectConfigBuildOnly config
+      }
+
+hackProjectConfigBuildOnly :: ProjectConfigBuildOnly -> ProjectConfigBuildOnly
+hackProjectConfigBuildOnly config =
+    config {
+      -- These two fields are only command line transitory things, not
+      -- something to be recorded persistently in a config file
+      projectConfigOnlyDeps = mempty,
+      projectConfigDryRun   = mempty
+    }
+
+prop_roundtrip_printparse_shared :: ProjectConfigShared -> Bool
+prop_roundtrip_printparse_shared config =
+    roundtrip_printparse
+      mempty {
+        projectConfigShared = hackProjectConfigShared config
+      }
+
+hackProjectConfigShared :: ProjectConfigShared -> ProjectConfigShared
+hackProjectConfigShared config =
+    config {
+      projectConfigConstraints =
+      --TODO: [required eventually] parse ambiguity in constraint
+      -- "pkgname -any" as either any version or disabled flag "any".
+        let ambiguous ((UserConstraintFlags _pkg flags), _) =
+              (not . null) [ () | (FlagName name, False) <- flags
+                                , "any" `isPrefixOf` name ]
+            ambiguous _ = False
+         in filter (not . ambiguous) (projectConfigConstraints config)
+    }
+
+
+prop_roundtrip_printparse_local :: PackageConfig -> Bool
+prop_roundtrip_printparse_local config =
+    roundtrip_printparse
+      mempty {
+        projectConfigLocalPackages = config
+      }
+
+prop_roundtrip_printparse_specific :: Map PackageName (NonMEmpty PackageConfig)
+                                   -> Bool
+prop_roundtrip_printparse_specific config =
+    roundtrip_printparse
+      mempty {
+        projectConfigSpecificPackage = fmap getNonMEmpty config
+      }
+
+
+----------------------------
+-- Individual Parser tests 
+--
+
+prop_parsePackageLocationTokenQ :: PackageLocationString -> Bool
+prop_parsePackageLocationTokenQ (PackageLocationString str) =
+    case [ x | (x,"") <- Parse.readP_to_S parsePackageLocationTokenQ str ] of
+      [str'] -> str' == str
+      _      -> False
+
+
+------------------------
+-- Arbitrary instances
+--
+
+instance Arbitrary ProjectConfig where
+    arbitrary =
+      ProjectConfig
+        <$> (map getPackageLocationString <$> arbitrary)
+        <*> (map getPackageLocationString <$> arbitrary)
+        <*> shortListOf 3 arbitrary
+        <*> arbitrary
+        <*> arbitrary <*> arbitrary
+        <*> arbitrary
+        <*> (fmap getNonMEmpty . Map.fromList <$> shortListOf 3 arbitrary)
+        -- package entries with no content are equivalent to
+        -- the entry not existing at all, so exclude empty
+
+    shrink (ProjectConfig x0 x1 x2 x3 x4 x5 x6 x7) =
+      [ ProjectConfig x0' x1' x2' x3' x4' x5' x6' (fmap getNonMEmpty x7')
+      | ((x0', x1', x2', x3'), (x4', x5', x6', x7'))
+          <- shrink ((x0, x1, x2, x3), (x4, x5, x6, fmap NonMEmpty x7))
+      ]
+
+newtype PackageLocationString
+      = PackageLocationString { getPackageLocationString :: String }
+  deriving Show
+
+instance Arbitrary PackageLocationString where
+  arbitrary =
+    PackageLocationString <$>
+    oneof
+      [ --show <$> (arbitrary :: Gen String)
+        arbitraryGlobLikeStr
+      , show <$> (arbitrary :: Gen URI)
+      ]
+
+arbitraryGlobLikeStr :: Gen String
+arbitraryGlobLikeStr = outerTerm
+  where
+    outerTerm  = concat <$> shortListOf1 4
+                  (frequency [ (2, token)
+                             , (1, braces <$> innerTerm) ])
+    innerTerm  = intercalate "," <$> shortListOf1 3
+                  (frequency [ (3, token)
+                             , (1, braces <$> innerTerm) ])
+    token      = shortListOf1 4 (elements (['#'..'~'] \\ "{,}"))
+    braces s   = "{" ++ s ++ "}"
+
+
+instance Arbitrary ProjectConfigBuildOnly where
+    arbitrary =
+      ProjectConfigBuildOnly
+        <$> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> (toNubList <$> shortListOf 2 arbitrary)             --  4
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> (fmap getShortToken <$> arbitrary)                  --  8
+        <*> arbitrary
+        <*> arbitraryNumJobs
+        <*> arbitrary
+        <*> arbitrary                                           -- 12
+        <*> (fmap getShortToken <$> arbitrary)
+        <*> arbitrary
+        <*> (fmap getShortToken <$> arbitrary)
+        <*> (fmap getShortToken <$> arbitrary)                  -- 16
+        <*> (fmap getShortToken <$> arbitrary)
+        <*> (fmap getShortToken <$> arbitrary)
+      where
+        arbitraryNumJobs = fmap (fmap getPositive) <$> arbitrary
+
+    shrink (ProjectConfigBuildOnly
+              x00 x01 x02 x03 x04 x05 x06 x07
+              x08 x09 x10 x11 x12 x13 x14 x15
+              x16 x17) =
+      [ ProjectConfigBuildOnly
+          x00' x01' x02' x03' x04'
+          x05' x06' x07' x08' (postShrink_NumJobs x09')
+          x10' x11' x12  x13' x14
+          x15 x16 x17
+      | ((x00', x01', x02', x03', x04'),
+         (x05', x06', x07', x08', x09'),
+         (x10', x11',       x13'))
+          <- shrink
+               ((x00, x01, x02, x03, x04),
+                (x05, x06, x07, x08, preShrink_NumJobs x09),
+                (x10, x11,      x13))
+      ]
+      where
+        preShrink_NumJobs  = fmap (fmap Positive)
+        postShrink_NumJobs = fmap (fmap getPositive)
+
+instance Arbitrary ProjectConfigShared where
+    arbitrary =
+      ProjectConfigShared
+        <$> (Map.fromList <$> shortListOf 10 
+              ((,) <$> arbitraryProgramName
+                   <*> arbitraryShortToken))
+        <*> (Map.fromList <$> shortListOf 10 
+              ((,) <$> arbitraryProgramName
+                   <*> listOf arbitraryShortToken))
+        <*> (toNubList <$> listOf arbitraryShortToken)
+        <*> arbitrary                                           --  4
+        <*> arbitraryFlag arbitraryShortToken
+        <*> arbitraryFlag arbitraryShortToken
+        <*> arbitrary
+        <*> arbitrary                                           --  8
+        <*> (toNubList <$> listOf arbitraryShortToken)
+        <*> arbitraryConstraints
+        <*> arbitrary <*> shortListOf 2 arbitrary               -- 12
+        <*> arbitrary <*> arbitrary
+        <*> arbitrary <*> arbitrary                             -- 16
+        <*> arbitrary <*> arbitrary
+      where
+        arbitraryProgramName :: Gen String
+        arbitraryProgramName =
+          elements [ programName prog
+                   | (prog, _) <- knownPrograms (defaultProgramDb) ]
+
+        arbitraryConstraints :: Gen [(UserConstraint, ConstraintSource)]
+        arbitraryConstraints =
+            map (\uc -> (uc, projectConfigConstraintSource)) <$> arbitrary
+
+    shrink (ProjectConfigShared
+              x00 x01 x02 x03 x04
+              x05 x06 x07 x08 x09
+              x10 x11 x12 x13 x14
+              x15 x16 x17) =
+      [ ProjectConfigShared
+          (postShrink_Paths x00')
+          (postShrink_Args  x01')
+          x02' x03'
+          (fmap getNonEmpty x04')
+          (fmap getNonEmpty x05')
+               x06' x07' x08'
+          (postShrink_Constraints x09')
+          x10' x11' x12' x13' x14'
+          x15' x16' x17'
+      | ((x00', x01', x02', x03', x04'),
+         (x05', x06', x07', x08', x09'),
+         (x10', x11', x12', x13', x14'),
+         (x15', x16', x17'))
+          <- shrink
+               ((preShrink_Paths x00,
+                 preShrink_Args  x01,
+                 x02, x03, fmap NonEmpty x04),
+                (fmap NonEmpty x05, x06, x07, x08, preShrink_Constraints x09),
+                (x10, x11, x12, x13, x14),
+                (x15, x16, x17))
+      ]
+      where
+        preShrink_Paths  = Map.map NonEmpty . Map.mapKeys NoShrink
+        postShrink_Paths = Map.map getNonEmpty . Map.mapKeys getNoShrink
+        preShrink_Args   = Map.map (NonEmpty . map NonEmpty)
+                         . Map.mapKeys NoShrink
+        postShrink_Args  = Map.map (map getNonEmpty . getNonEmpty)
+                         . Map.mapKeys getNoShrink
+        preShrink_Constraints  = map fst
+        postShrink_Constraints = map (\uc -> (uc, projectConfigConstraintSource))
+
+projectConfigConstraintSource :: ConstraintSource
+projectConfigConstraintSource = 
+    ConstraintSourceProjectConfig "TODO"
+
+instance Arbitrary PackageConfig where
+    arbitrary =
+      PackageConfig
+        <$> arbitrary <*> arbitrary
+        <*> arbitrary <*> arbitrary                             --  4
+        <*> arbitrary <*> arbitrary
+        <*> arbitrary <*> arbitrary                             --  8
+        <*> shortListOf 5 arbitraryShortToken
+        <*> arbitrary
+        <*> arbitrary <*> arbitrary                             -- 12
+        <*> shortListOf 5 arbitraryShortToken
+        <*> shortListOf 5 arbitraryShortToken
+        <*> shortListOf 5 arbitraryShortToken
+        <*> arbitrary                                           -- 16
+        <*> arbitrary <*> arbitrary
+        <*> arbitrary <*> arbitrary                             -- 20
+        <*> arbitrary <*> arbitrary
+        <*> arbitrary <*> arbitrary                             -- 24
+        <*> arbitrary <*> arbitrary
+        <*> arbitrary <*> arbitrary                             -- 28
+        <*> arbitraryFlag arbitraryShortToken
+        <*> arbitrary
+        <*> arbitrary <*> arbitrary                             -- 32
+        <*> arbitrary
+        <*> arbitraryFlag arbitraryShortToken
+        <*> arbitrary
+        <*> arbitraryFlag arbitraryShortToken                   -- 36
+        <*> arbitrary
+
+    shrink (PackageConfig
+              x00 x01 x02 x03 x04
+              x05 x06 x07 x08 x09
+              x10 x11 x12 x13 x14
+              x15 x16 x17 x18 x19
+              x20 x21 x22 x23 x24
+              x25 x26 x27 x28 x29
+              x30 x31 x32 x33 x34
+              x35 x36) =
+      [ PackageConfig
+          x00' x01' x02' x03' x04'
+          x05' x06' x07' (map getNonEmpty x08') x09'
+          x10' x11'
+          (map getNonEmpty x12')
+          (map getNonEmpty x13')
+          (map getNonEmpty x14')
+          x15' x16' x17' x18' x19'
+          x20' x21' x22' x23' x24'
+          x25' x26' x27' x28' x29'
+          x30' x31' x32' (fmap getNonEmpty x33') x34'
+          (fmap getNonEmpty x35') x36'
+      | (((x00', x01', x02', x03', x04'),
+          (x05', x06', x07', x08', x09'),
+          (x10', x11', x12', x13', x14'),
+          (x15', x16', x17', x18', x19')),
+         ((x20', x21', x22', x23', x24'),
+          (x25', x26', x27', x28', x29'),
+          (x30', x31', x32', x33', x34'),
+          (x35', x36')))
+          <- shrink
+               (((x00, x01, x02, x03, x04),
+                 (x05, x06, x07, map NonEmpty x08, x09),
+                 (x10, x11,
+                  map NonEmpty x12,
+                  map NonEmpty x13,
+                  map NonEmpty x14),
+                 (x15, x16, x17, x18, x19)),
+                ((x20, x21, x22, x23, x24),
+                 (x25, x26, x27, x28, x29),
+                 (x30, x31, x32, fmap NonEmpty x33, x34),
+                 (fmap NonEmpty x35, x36)))
+      ]
+
+
+instance Arbitrary SourceRepo where
+    arbitrary = (SourceRepo RepoThis
+                           <$> arbitrary
+                           <*> (fmap getShortToken <$> arbitrary)
+                           <*> (fmap getShortToken <$> arbitrary)
+                           <*> (fmap getShortToken <$> arbitrary)
+                           <*> (fmap getShortToken <$> arbitrary)
+                           <*> (fmap getShortToken <$> arbitrary))
+                `suchThat` (/= emptySourceRepo)
+
+    shrink (SourceRepo _ x1 x2 x3 x4 x5 x6) =
+      [ repo
+      | ((x1', x2', x3'), (x4', x5', x6'))
+          <- shrink ((x1,
+                      fmap ShortToken x2,
+                      fmap ShortToken x3),
+                     (fmap ShortToken x4,
+                      fmap ShortToken x5,
+                      fmap ShortToken x6))
+      , let repo = SourceRepo RepoThis x1'
+                              (fmap getShortToken x2')
+                              (fmap getShortToken x3')
+                              (fmap getShortToken x4')
+                              (fmap getShortToken x5')
+                              (fmap getShortToken x6')
+      , repo /= emptySourceRepo
+      ]
+
+emptySourceRepo :: SourceRepo
+emptySourceRepo = SourceRepo RepoThis Nothing Nothing Nothing
+                                      Nothing Nothing Nothing
+
+
+instance Arbitrary RepoType where
+    arbitrary = elements knownRepoTypes
+
+instance Arbitrary ReportLevel where
+    arbitrary = elements [NoReports .. DetailedReports]
+
+instance Arbitrary CompilerFlavor where
+    arbitrary = elements knownCompilerFlavors
+      where
+        --TODO: [code cleanup] export knownCompilerFlavors from D.Compiler
+        -- it's already defined there, just need it exported.
+        knownCompilerFlavors =
+          [GHC, GHCJS, NHC, YHC, Hugs, HBC, Helium, JHC, LHC, UHC]
+
+instance Arbitrary a => Arbitrary (InstallDirs a) where
+    arbitrary =
+      InstallDirs
+        <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  4
+        <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  8
+        <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary -- 12
+        <*> arbitrary <*> arbitrary                             -- 14
+
+instance Arbitrary PackageDB where
+    arbitrary = oneof [ pure GlobalPackageDB
+                      , pure UserPackageDB
+                      , SpecificPackageDB . getShortToken <$> arbitrary
+                      ]
+
+instance Arbitrary RemoteRepo where
+    arbitrary =
+      RemoteRepo
+        <$> arbitraryShortToken `suchThat` (not . (":" `isPrefixOf`))
+        <*> arbitrary  -- URI
+        <*> arbitrary
+        <*> listOf arbitraryRootKey
+        <*> (fmap getNonNegative arbitrary)
+        <*> pure False
+      where
+        arbitraryRootKey =
+          shortListOf1 5 (oneof [ choose ('0', '9')
+                                , choose ('a', 'f') ])
+
+instance Arbitrary UserConstraint where
+    arbitrary =
+      oneof
+        [ UserConstraintVersion   <$> arbitrary <*> arbitrary
+        , UserConstraintInstalled <$> arbitrary
+        , UserConstraintSource    <$> arbitrary
+        , UserConstraintFlags     <$> arbitrary <*> shortListOf1 3 arbitrary
+        , UserConstraintStanzas   <$> arbitrary <*> ((\x->[x]) <$> arbitrary)
+        ]
+
+instance Arbitrary OptionalStanza where
+    arbitrary = elements [minBound..maxBound]
+
+instance Arbitrary FlagName where
+    arbitrary = FlagName <$> flagident
+      where
+        flagident   = lowercase <$> shortListOf1 5 (elements flagChars)
+                      `suchThat` (("-" /=) . take 1)
+        flagChars   = "-_" ++ ['a'..'z']
+
+instance Arbitrary PreSolver where
+    arbitrary = elements [minBound..maxBound]
+
+instance Arbitrary AllowNewer where
+    arbitrary = oneof [ pure AllowNewerNone
+                      , AllowNewerSome <$> shortListOf1 3 arbitrary
+                      , pure AllowNewerAll
+                      ]
+
+instance Arbitrary AllowNewerDep where
+    arbitrary = oneof [ AllowNewerDep       <$> arbitrary
+                      , AllowNewerDepScoped <$> arbitrary <*> arbitrary
+                      ]
+
+instance Arbitrary ProfDetailLevel where
+    arbitrary = elements [ d | (_,_,d) <- knownProfDetailLevels ]
+
+instance Arbitrary OptimisationLevel where
+    arbitrary = elements [minBound..maxBound]
+
+instance Arbitrary DebugInfoLevel where
+    arbitrary = elements [minBound..maxBound]
+
+instance Arbitrary URI where
+    arbitrary =
+      URI <$> elements ["file:", "http:", "https:"]
+          <*> (Just <$> arbitrary)
+          <*> (('/':) <$> arbitraryURIToken)
+          <*> (('?':) <$> arbitraryURIToken)
+          <*> pure ""
+
+instance Arbitrary URIAuth where
+    arbitrary =
+      URIAuth <$> pure ""   -- no password as this does not roundtrip
+              <*> arbitraryURIToken
+              <*> arbitraryURIPort
+
+arbitraryURIToken :: Gen String
+arbitraryURIToken =
+    shortListOf1 6 (elements (filter isUnreserved ['\0'..'\255']))
+
+arbitraryURIPort :: Gen String
+arbitraryURIPort =
+    oneof [ pure "", (':':) <$> shortListOf1 4 (choose ('0','9')) ]
+


### PR DESCRIPTION
Supersedes PR #3156. Significant changes since then:

 * Split huge `ProjectConfig` module into three as suggested by @23Skidoo 

 * Proper QC tests: can round trip from `ProjectConfig` type out to a config file and back. Doing this detected lots of plumbing problems which are all now fixed.

 * Several field parsers have to be implemented locally rather than using generic infrastructure. This is directly related to the above point, we need to do that to round trip correctly.

 * Specifying packages in projects is greatly extended. Previously only one field for globs which could only match `.cabal` files and the globs were all allowed to match nothing. Matching nothing is useful in one major use case, allowing optional local or "vendor" unpacked deps, so one can just unpack and start using those local deps without any extra explict config however matching nothing is not ok for many other normal use cases. So we now split that into two fields `packages` and `optional-packages`. Only the latter can be globs that are allowed to match nothing.

 * We can now specify packages in the project as:
    * `.cabal` files
    * directories
    * local tarballs
    * any of the above via file globs
    * remote http tarballs
    * remote source repositories (git, darcs etc, same syntax as in .cabal files)
 
  Only the first two have full support. For the rest the syntax is supported but there's not yet support for downloading and unpacking them.
