### PR TITLE
Fix construction of conflict sets during link validation

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/ConflictSet.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/ConflictSet.hs
@@ -62,7 +62,7 @@ singleton = CS . S.singleton . simplifyVar
 member :: Ord qpn => Var qpn -> ConflictSet qpn -> Bool
 member var (CS set) = S.member (simplifyVar var) set
 
-filter :: (Var qpn -> Bool) -> ConflictSet qpn -> ConflictSet qpn
+filter :: Ord qpn => (Var qpn -> Bool) -> ConflictSet qpn -> ConflictSet qpn
 filter p (CS set) = CS $ S.filter p set
 
 fromList :: Ord qpn => [Var qpn] -> ConflictSet qpn

--- a/cabal-install/Distribution/Client/Dependency/Modular/ConflictSet.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/ConflictSet.hs
@@ -1,8 +1,25 @@
+-- | Conflict sets
+--
+-- Intended for double import
+--
+-- > import Distribution.Client.Dependency.Modular.ConflictSet (ConflictSet)
+-- > import qualified Distribution.Client.Dependency.Modular.ConflictSet as CS
 module Distribution.Client.Dependency.Modular.ConflictSet (
-    ConflictSet
+    ConflictSet -- opaque
   , showCS
+    -- Set-like operations
+  , toList
+  , union
+  , unions
+  , insert
+  , empty
+  , singleton
+  , member
+  , filter
+  , fromList
   ) where
 
+import Prelude hiding (filter)
 import Data.List (intercalate)
 import Data.Set (Set)
 import qualified Data.Set as S
@@ -10,7 +27,43 @@ import qualified Data.Set as S
 import Distribution.Client.Dependency.Modular.Package
 import Distribution.Client.Dependency.Modular.Var
 
-type ConflictSet qpn = Set (Var qpn)
+-- | The set of variables involved in a solver conflict
+--
+-- Since these variables should be preprocessed in some way, this type is
+-- kept abstract.
+newtype ConflictSet qpn = CS { fromConflictSet :: Set (Var qpn) }
+  deriving (Eq, Ord, Show)
 
 showCS :: ConflictSet QPN -> String
-showCS = intercalate ", " . map showVar . S.toList
+showCS = intercalate ", " . map showVar . toList
+
+{-------------------------------------------------------------------------------
+  Set-like operations
+-------------------------------------------------------------------------------}
+
+toList :: ConflictSet qpn -> [Var qpn]
+toList = S.toList . fromConflictSet
+
+union :: Ord qpn => ConflictSet qpn -> ConflictSet qpn -> ConflictSet qpn
+union (CS a) (CS b) = CS (a `S.union` b)
+
+unions :: Ord qpn => [ConflictSet qpn] -> ConflictSet qpn
+unions = CS . S.unions . map fromConflictSet
+
+insert :: Ord qpn => Var qpn -> ConflictSet qpn -> ConflictSet qpn
+insert var (CS set) = CS (S.insert (simplifyVar var) set)
+
+empty :: ConflictSet qpn
+empty = CS S.empty
+
+singleton :: Var qpn -> ConflictSet qpn
+singleton = CS . S.singleton . simplifyVar
+
+member :: Ord qpn => Var qpn -> ConflictSet qpn -> Bool
+member var (CS set) = S.member (simplifyVar var) set
+
+filter :: (Var qpn -> Bool) -> ConflictSet qpn -> ConflictSet qpn
+filter p (CS set) = CS $ S.filter p set
+
+fromList :: Ord qpn => [Var qpn] -> ConflictSet qpn
+fromList = CS . S.fromList . map simplifyVar

--- a/cabal-install/Distribution/Client/Dependency/Modular/ConflictSet.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/ConflictSet.hs
@@ -1,0 +1,16 @@
+module Distribution.Client.Dependency.Modular.ConflictSet (
+    ConflictSet
+  , showCS
+  ) where
+
+import Data.List (intercalate)
+import Data.Set (Set)
+import qualified Data.Set as S
+
+import Distribution.Client.Dependency.Modular.Package
+import Distribution.Client.Dependency.Modular.Var
+
+type ConflictSet qpn = Set (Var qpn)
+
+showCS :: ConflictSet QPN -> String
+showCS = intercalate ", " . map showVar . S.toList

--- a/cabal-install/Distribution/Client/Dependency/Modular/ConflictSet.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/ConflictSet.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- | Conflict sets
 --
 -- Intended for double import
@@ -62,7 +63,11 @@ singleton = CS . S.singleton . simplifyVar
 member :: Ord qpn => Var qpn -> ConflictSet qpn -> Bool
 member var (CS set) = S.member (simplifyVar var) set
 
+#if MIN_VERSION_containers(0,5,0)
+filter :: (Var qpn -> Bool) -> ConflictSet qpn -> ConflictSet qpn
+#else
 filter :: Ord qpn => (Var qpn -> Bool) -> ConflictSet qpn -> ConflictSet qpn
+#endif
 filter p (CS set) = CS $ S.filter p set
 
 fromList :: Ord qpn => [Var qpn] -> ConflictSet qpn

--- a/cabal-install/Distribution/Client/Dependency/Modular/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Dependency.hs
@@ -38,9 +38,7 @@ module Distribution.Client.Dependency.Modular.Dependency (
 
 import Prelude hiding (pi)
 
-import Data.List (intercalate)
 import Data.Map (Map)
-import Data.Set (Set)
 import qualified Data.List as L
 import qualified Data.Set  as S
 
@@ -48,56 +46,13 @@ import Language.Haskell.Extension (Extension(..), Language(..))
 
 import Distribution.Text
 
+import Distribution.Client.Dependency.Modular.ConflictSet
 import Distribution.Client.Dependency.Modular.Flag
 import Distribution.Client.Dependency.Modular.Package
+import Distribution.Client.Dependency.Modular.Var
 import Distribution.Client.Dependency.Modular.Version
 
 import Distribution.Client.ComponentDeps (Component(..))
-
-{-------------------------------------------------------------------------------
-  Variables
--------------------------------------------------------------------------------}
-
--- | The type of variables that play a role in the solver.
--- Note that the tree currently does not use this type directly,
--- and rather has separate tree nodes for the different types of
--- variables. This fits better with the fact that in most cases,
--- these have to be treated differently.
---
--- TODO: This isn't the ideal location to declare the type,
--- but we need them for constrained instances.
-data Var qpn = P qpn | F (FN qpn) | S (SN qpn)
-  deriving (Eq, Ord, Show, Functor)
-
--- | For computing conflict sets, we map flag choice vars to a
--- single flag choice. This means that all flag choices are treated
--- as interdependent. So if one flag of a package ends up in a
--- conflict set, then all flags are being treated as being part of
--- the conflict set.
-simplifyVar :: Var qpn -> Var qpn
-simplifyVar (P qpn)       = P qpn
-simplifyVar (F (FN pi _)) = F (FN pi (mkFlag "flag"))
-simplifyVar (S qsn)       = S qsn
-
-showVar :: Var QPN -> String
-showVar (P qpn) = showQPN qpn
-showVar (F qfn) = showQFN qfn
-showVar (S qsn) = showQSN qsn
-
--- | Extract the package instance from a Var
-varPI :: Var QPN -> (QPN, Maybe I)
-varPI (P qpn)               = (qpn, Nothing)
-varPI (F (FN (PI qpn i) _)) = (qpn, Just i)
-varPI (S (SN (PI qpn i) _)) = (qpn, Just i)
-
-{-------------------------------------------------------------------------------
-  Conflict sets
--------------------------------------------------------------------------------}
-
-type ConflictSet qpn = Set (Var qpn)
-
-showCS :: ConflictSet QPN -> String
-showCS = intercalate ", " . L.map showVar . S.toList
 
 {-------------------------------------------------------------------------------
   Constrained instances

--- a/cabal-install/Distribution/Client/Dependency/Modular/Log.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Log.hs
@@ -10,7 +10,6 @@ module Distribution.Client.Dependency.Modular.Log
 import Control.Applicative
 import Data.List as L
 import Data.Maybe (isNothing)
-import Data.Set as S
 
 import Distribution.Client.Dependency.Types -- from Cabal
 
@@ -18,6 +17,7 @@ import Distribution.Client.Dependency.Modular.Dependency
 import Distribution.Client.Dependency.Modular.Message
 import Distribution.Client.Dependency.Modular.Package
 import Distribution.Client.Dependency.Modular.Tree (FailReason(..))
+import qualified Distribution.Client.Dependency.Modular.ConflictSet as CS
 
 -- | The 'Log' datatype.
 --
@@ -82,7 +82,7 @@ logToProgress mbj l = let
     go ms r           (Step x xs)           = Step x (go ms r  xs)
     go ms _           (Fail (exh, Just cs)) = Fail $
                                               "Could not resolve dependencies:\n" ++
-                                              unlines (messages $ showMessages (L.foldr (\ v _ -> v `S.member` cs) True) False ms) ++
+                                              unlines (messages $ showMessages (L.foldr (\ v _ -> v `CS.member` cs) True) False ms) ++
                                               (if exh then "Dependency tree exhaustively searched.\n"
                                                       else "Backjump limit reached (" ++ currlimit mbj ++
                                                                "change with --max-backjumps or try to run with --reorder-goals).\n")

--- a/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Preference.hs
@@ -23,7 +23,6 @@ import qualified Data.Map as M
 import Data.Monoid
 import Control.Applicative
 #endif
-import qualified Data.Set as S
 import Prelude hiding (sequence)
 import Control.Monad.Reader hiding (sequence)
 import Data.Map (Map)
@@ -373,13 +372,13 @@ enforceSingleInstanceRestriction = (`runReader` M.empty) . cata go
 
     -- We just verify package choices.
     go (PChoiceF qpn gr cs) =
-      PChoice qpn gr <$> sequence (P.mapWithKey (goP qpn) cs)
+      PChoice qpn gr <$> sequence (P.mapWithKey (goP qpn gr) cs)
     go _otherwise =
       innM _otherwise
 
     -- The check proper
-    goP :: QPN -> POption -> EnforceSIR (Tree QGoalReasonChain) -> EnforceSIR (Tree QGoalReasonChain)
-    goP qpn@(Q _ pn) (POption i linkedTo) r = do
+    goP :: QPN -> QGoalReasonChain -> POption -> EnforceSIR (Tree QGoalReasonChain) -> EnforceSIR (Tree QGoalReasonChain)
+    goP qpn@(Q _ pn) gr (POption i linkedTo) r = do
       let inst = PI pn i
       env <- ask
       case (linkedTo, M.lookup inst env) of
@@ -389,6 +388,6 @@ enforceSingleInstanceRestriction = (`runReader` M.empty) . cata go
         (Nothing, Nothing) ->
           -- Not linked, not already used
           local (M.insert inst qpn) r
-        (Nothing, Just qpn') -> do
+        (Nothing, Just _) -> do
           -- Not linked, already used. This is an error
-          return $ Fail (S.fromList [P qpn, P qpn']) MultipleInstances
+          return $ Fail (toConflictSet (Goal (P qpn) gr)) MultipleInstances

--- a/cabal-install/Distribution/Client/Dependency/Modular/Var.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Var.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DeriveFunctor #-}
+module Distribution.Client.Dependency.Modular.Var (
+    Var(..)
+  , simplifyVar
+  , showVar
+  , varPI
+  ) where
+
+import Prelude hiding (pi)
+
+import Distribution.Client.Dependency.Modular.Flag
+import Distribution.Client.Dependency.Modular.Package
+
+{-------------------------------------------------------------------------------
+  Variables
+-------------------------------------------------------------------------------}
+
+-- | The type of variables that play a role in the solver.
+-- Note that the tree currently does not use this type directly,
+-- and rather has separate tree nodes for the different types of
+-- variables. This fits better with the fact that in most cases,
+-- these have to be treated differently.
+data Var qpn = P qpn | F (FN qpn) | S (SN qpn)
+  deriving (Eq, Ord, Show, Functor)
+
+-- | For computing conflict sets, we map flag choice vars to a
+-- single flag choice. This means that all flag choices are treated
+-- as interdependent. So if one flag of a package ends up in a
+-- conflict set, then all flags are being treated as being part of
+-- the conflict set.
+simplifyVar :: Var qpn -> Var qpn
+simplifyVar (P qpn)       = P qpn
+simplifyVar (F (FN pi _)) = F (FN pi (mkFlag "flag"))
+simplifyVar (S qsn)       = S qsn
+
+showVar :: Var QPN -> String
+showVar (P qpn) = showQPN qpn
+showVar (F qfn) = showQFN qfn
+showVar (S qsn) = showQSN qsn
+
+-- | Extract the package instance from a Var
+varPI :: Var QPN -> (QPN, Maybe I)
+varPI (P qpn)               = (qpn, Nothing)
+varPI (F (FN (PI qpn i) _)) = (qpn, Just i)
+varPI (S (SN (PI qpn i) _)) = (qpn, Just i)

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -137,6 +137,7 @@ executable cabal
         Distribution.Client.Dependency.Modular.Builder
         Distribution.Client.Dependency.Modular.Configured
         Distribution.Client.Dependency.Modular.ConfiguredConversion
+        Distribution.Client.Dependency.Modular.ConflictSet
         Distribution.Client.Dependency.Modular.Cycles
         Distribution.Client.Dependency.Modular.Dependency
         Distribution.Client.Dependency.Modular.Explore
@@ -152,6 +153,7 @@ executable cabal
         Distribution.Client.Dependency.Modular.Solver
         Distribution.Client.Dependency.Modular.Tree
         Distribution.Client.Dependency.Modular.Validate
+        Distribution.Client.Dependency.Modular.Var
         Distribution.Client.Dependency.Modular.Version
         Distribution.Client.Exec
         Distribution.Client.Fetch

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -527,6 +527,7 @@ db18 = [
   , Right $ exAv "G" 1 []
   ]
 
+
 dbExts1 :: ExampleDb
 dbExts1 = [
     Right $ exAv "A" 1 [ExExt (EnableExtension RankNTypes)]

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -501,6 +501,16 @@ db16 = [
 -- A and B's dependencies on D is -flagA +flagB. This database tests that the
 -- solver can backtrack to find the right combination of flags (requiring F, but
 -- not E or G) and apply it to both 0.C and 1.C.
+--
+-- > flagA flagB  C depends on
+-- >  On    _     D-1, E-*
+-- >  Off   On    F-*        <-- Only valid choice
+-- >  Off   Off   D-2, G-*
+--
+-- The single instance restriction means we cannot have one instance of C
+-- built against D-1 and one instance built against D-2; since A depends on
+-- D-1, and B depends on C-2, it is therefore important that C cannot depend
+-- on any version of D.
 db18 :: ExampleDb
 db18 = [
     Right $ exAv "A" 1 [ExAny "C", ExFix "D" 1]

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -43,6 +43,7 @@ tests = [
         , runTest $         mkTest db3 "forceFlagOff" ["D"]      (Just [("A", 2), ("B", 1), ("D", 1)])
         , runTest $ indep $ mkTest db3 "linkFlags1"   ["C", "D"] Nothing
         , runTest $ indep $ mkTest db4 "linkFlags2"   ["C", "D"] Nothing
+        , runTest $ indep $ mkTest db18 "linkFlags3"  ["A", "B"] (Just [("A", 1), ("B", 1), ("C", 1), ("D", 1), ("D", 2), ("F", 1)])
         ]
     , testGroup "Stanzas" [
           runTest $         mkTest db5 "simpleTest1" ["C"]      (Just [("A", 2), ("C", 1)])
@@ -493,6 +494,27 @@ db16 = [
   , Right $ exAv "D" 1 []
   , Right $ exAv "D" 2 []
   , Right $ exAv "E" 1 []
+  ]
+
+-- | When both A and B are installed as independent goals, their dependencies on
+-- C must be linked. The only combination of C's flags that is consistent with
+-- A and B's dependencies on D is -flagA +flagB. This database tests that the
+-- solver can backtrack to find the right combination of flags (requiring F, but
+-- not E or G) and apply it to both 0.C and 1.C.
+db18 :: ExampleDb
+db18 = [
+    Right $ exAv "A" 1 [ExAny "C", ExFix "D" 1]
+  , Right $ exAv "B" 1 [ExAny "C", ExFix "D" 2]
+  , Right $ exAv "C" 1 [exFlag "flagA"
+                           [ExFix "D" 1, ExAny "E"]
+                           [exFlag "flagB"
+                               [ExAny "F"]
+                               [ExFix "D" 2, ExAny "G"]]]
+  , Right $ exAv "D" 1 []
+  , Right $ exAv "D" 2 []
+  , Right $ exAv "E" 1 []
+  , Right $ exAv "F" 1 []
+  , Right $ exAv "G" 1 []
   ]
 
 dbExts1 :: ExampleDb

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -463,17 +463,30 @@ db14 = [
   , Right $ exAv "E" 1 []
   ]
 
--- | When A and B are installed as independent goals, the single instance
+-- | Check that the solver can backtrack after encountering the SIR
+--
+-- When A and B are installed as independent goals, the single instance
 -- restriction prevents B from depending on C.  This database tests that the
 -- solver can backtrack after encountering the single instance restriction and
--- choose the only valid flag assignment (-flagA +flagB).
+-- choose the only valid flag assignment (-flagA +flagB):
+--
+-- > flagA flagB  B depends on
+-- >  On    _     C-*
+-- >  Off   On    E-*               <-- only valid flag assignment
+-- >  Off   Off   D-2.0, C-*
+--
+-- Since A depends on C-* and D-1.0, and C-1.0 depends on any version of D,
+-- we must build C-1.0 against D-1.0. Since B depends on D-2.0, we cannot have
+-- C in the transitive closure of B's dependencies, because that would mean we
+-- would need two instances of C: one built against D-1.0 and one built against
+-- D-2.0.
 db16 :: ExampleDb
 db16 = [
     Right $ exAv "A" 1 [ExAny "C", ExFix "D" 1]
   , Right $ exAv "B" 1 [ ExFix "D" 2
-                       , ExFlag "flagA"
+                       , exFlag "flagA"
                              [ExAny "C"]
-                             [ExFlag "flagB"
+                             [exFlag "flagB"
                                  [ExAny "E"]
                                  [ExAny "C"]]]
   , Right $ exAv "C" 1 [ExAny "D"]


### PR DESCRIPTION
**NOTE**: This commit contains four commits, not two; the first two are #3221.

In #2834 @grayjay points out another conflict set construction bug. Actually, this is almost the same bug that was present in the check for the single instance restriction: we were forgetting to call `simplifyVar` on some variables before adding them to the conflict set.

This PR first adds @grayjay 's test case (another excellent test, thank you very much! :) ) . The next commit just adds some comments to the test explaining what is going on. Commit number 3 just moves some code out of the `Modular.Dependency` module into two separate `Var` and `ConflictSet` modules; it does not make any actual changes to the semantics. The actual fix is in the final commit, which makes `ConflictSet` abstract and makes sure that whenever we add a variable to a `ConflictSet`, or check whether a variable is a member of a conflict set, that we call `simplifyVar` first. This fixes this particular test case and also makes me feel a lot less anxious about other such bugs still being present.

Pinging @kosmikus and @dcoutts .