### PR TITLE
Fix bug in link validation

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Linking.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Linking.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 module Distribution.Client.Dependency.Modular.Linking (
     addLinking
   , validateLinking
@@ -187,7 +188,13 @@ type Conflict = (ConflictSet QPN, String)
 newtype UpdateState a = UpdateState {
     unUpdateState :: StateT ValidateState (Either Conflict) a
   }
-  deriving (Functor, Applicative, Monad, MonadState ValidateState)
+  deriving (Functor, Applicative, Monad)
+
+instance MonadState ValidateState UpdateState where
+  get    = UpdateState $ get
+  put st = UpdateState $ do
+             assert (lgInvariant $ vsLinks st) $ return ()
+             put st
 
 lift' :: Either Conflict a -> UpdateState a
 lift' = UpdateState . lift
@@ -217,28 +224,36 @@ pickConcrete qpn@(Q pp _) i = do
         makeCanonical lg qpn i
 
 pickLink :: QPN -> I -> PP -> FlaggedDeps comp QPN -> UpdateState ()
-pickLink qpn@(Q pp pn) i pp' deps = do
+pickLink qpn@(Q _pp pn) i pp' deps = do
     vs <- get
-    -- Find the link group for the package we are linking to, and add this package
+
+    -- The package might already be in a link group
+    -- (because one of its reverse dependencies is)
+    let lgSource = case M.lookup qpn (vsLinks vs) of
+                     Nothing -> lgSingleton qpn Nothing
+                     Just lg -> lg
+
+    -- Find the link group for the package we are linking to
     --
     -- Since the builder never links to a package without having first picked a
     -- concrete instance for that package, and since we create singleton link
     -- groups for concrete instances, this link group must exist (and must
     -- in fact already have a canonical member).
-    let lg = vsLinks vs ! Q pp' pn
+    let lgTarget = vsLinks vs ! Q pp' pn
 
     -- Verify here that the member we add is in fact for the same package and
     -- matches the version of the canonical instance. However, violations of
     -- these checks would indicate a bug in the linker, not a true conflict.
     let sanityCheck :: Maybe (PI PP) -> Bool
         sanityCheck Nothing              = False
-        sanityCheck (Just (PI _ canonI)) = pn == lgPackage lg && i == canonI
-    assert (sanityCheck (lgCanon lg)) $ return ()
+        sanityCheck (Just (PI _ canonI)) = pn == lgPackage lgTarget && i == canonI
+    assert (sanityCheck (lgCanon lgTarget)) $ return ()
 
-    -- Since we already have a canonical member, we just need to add the new
-    -- member into the group
-    let lg' = lg { lgMembers = S.insert pp (lgMembers lg) }
-    updateLinkGroup lg'
+    -- Merge the two link groups (updateLinkGroup will propagate the change)
+    lgTarget' <- lift' $ lgMerge [] lgSource lgTarget
+    updateLinkGroup lgTarget'
+
+    -- Make sure all dependencies are linked as well
     linkDeps [P qpn] pp' deps
 
 makeCanonical :: LinkGroup -> QPN -> I -> UpdateState ()
@@ -454,7 +469,18 @@ data LinkGroup = LinkGroup {
       -- of the link group itself)
     , lgBlame :: [Var QPN]
     }
-    deriving Show
+    deriving (Show, Eq)
+
+-- | Invariant for the set of link groups: every element in the link group
+-- must be pointing to the /same/ link group
+lgInvariant :: Map QPN LinkGroup -> Bool
+lgInvariant links = all invGroup (M.elems links)
+  where
+    invGroup :: LinkGroup -> Bool
+    invGroup lg = allEqual $ map (`M.lookup` links) members
+      where
+        members :: [QPN]
+        members = map (`Q` lgPackage lg) $ S.toList (lgMembers lg)
 
 -- | Package version of this group
 --

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -463,6 +463,30 @@ db14 = [
   , Right $ exAv "E" 1 []
   ]
 
+-- | Tricky test case with independent goals
+--
+-- Suppose we are installing D, E, and F as independent goals:
+--
+-- * D depends on A-* and C-1, requiring A-1 to be built against C-1
+-- * E depends on B-* and C-2, requiring B-1 to be built against C-2
+-- * F depends on A-* and B-*; this means we need A-1 and B-1 both to be built
+--     against the same version of C, violating the single instance restriction.
+--
+-- We can visualize this DB as:
+--
+-- >    C-1   C-2
+-- >    /|\   /|\
+-- >   / | \ / | \
+-- >  /  |  X  |  \
+-- > |   | / \ |   |
+-- > |   |/   \|   |
+-- > |   +     +   |
+-- > |   |     |   |
+-- > |   A     B   |
+-- >  \  |\   /|  /
+-- >   \ | \ / | /
+-- >    \|  V  |/
+-- >     D  F  E
 db20 :: ExampleDb
 db20 = [
     Right $ exAv "A" 1 [ExAny "C"]

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -119,6 +119,9 @@ tests = [
         , runTest $ mkTestPCDepends [("pkgA", "1.0.0"), ("pkgB", "1.0.0")] dbPC1 "pruneNotFound" ["C"] (Just [("A", 1), ("B", 1), ("C", 1)])
         , runTest $ mkTestPCDepends [("pkgA", "1.0.0"), ("pkgB", "2.0.0")] dbPC1 "chooseNewest" ["C"] (Just [("A", 1), ("B", 2), ("C", 1)])
         ]
+    , testGroup "Independent goals" [
+          runTest $ indep $ mkTest db20 "indepGoals" ["D", "E", "F"] Nothing -- The target
+        ]
     ]
   where
     indep test      = test { testIndepGoals = True }
@@ -458,6 +461,17 @@ db14 = [
   , Right $ exAv "C" 1 [exFlag "flagC" [ExAny "D"] [ExAny "E"]]
   , Right $ exAv "D" 1 [ExAny "C"]
   , Right $ exAv "E" 1 []
+  ]
+
+db20 :: ExampleDb
+db20 = [
+    Right $ exAv "A" 1 [ExAny "C"]
+  , Right $ exAv "B" 1 [ExAny "C"]
+  , Right $ exAv "C" 1 []
+  , Right $ exAv "C" 2 []
+  , Right $ exAv "D" 1 [ExAny "A", ExFix "C" 1]
+  , Right $ exAv "E" 1 [ExAny "B", ExFix "C" 2]
+  , Right $ exAv "F" 1 [ExAny "A", ExAny "B"]
   ]
 
 dbExts1 :: ExampleDb


### PR DESCRIPTION
When we are choosing to link a package (`pickLink`), it is possible that that package was _already_ linked (because its reverse dependencies got linked). Thus, this requires a merge of link groups: it is not correct to simply add the package into the target link group.

This fixes #2842. Thank you @grayjay for yet another very high quality bug report! All this independent goals/linking is all very new so it's really great to have somebody like you taking such a detailed look at it. Much appreciated!

Pinging @kosmikus and @dcoutts .