### PR TITLE
Glob monitor improvements

### DIFF
--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -9,7 +9,16 @@ module Distribution.Client.FileMonitor (
 
   -- * Declaring files to monitor
   MonitorFilePath(..),
+  MonitorKindFile(..),
+  MonitorKindDir(..),
   FilePathGlob(..),
+  monitorFile,
+  monitorFileHashed,
+  monitorNonExistentFile,
+  monitorDirectory,
+  monitorDirectoryExistence,
+  monitorFileOrDirectory,
+  monitorFileGlob,
   monitorFileSearchPath,
   monitorFileHashedSearchPath,
 
@@ -22,9 +31,6 @@ module Distribution.Client.FileMonitor (
   updateFileMonitor,
   MonitorTimestamp,
   beginUpdateFileMonitor,
-
-  matchFileGlob,
-  isTrivialFilePathGlob,
   ) where
 
 
@@ -38,9 +44,6 @@ import qualified Data.Map        as Map
 import qualified Data.ByteString.Lazy as BS
 import           Distribution.Compat.Binary
 import qualified Distribution.Compat.Binary as Binary
-#if !MIN_VERSION_base(4,8,0)
-import           Data.Traversable (traverse)
-#endif
 import qualified Data.Hashable as Hashable
 import           Data.List (sort)
 
@@ -49,15 +52,11 @@ import           Control.Applicative
 #endif
 import           Control.Monad
 import           Control.Monad.Trans (MonadIO, liftIO)
-import           Control.Monad.State (StateT)
+import           Control.Monad.State (StateT, mapStateT)
 import qualified Control.Monad.State as State
-import           Control.Monad.Except (ExceptT, runExceptT, throwError)
+import           Control.Monad.Except (ExceptT, runExceptT, withExceptT,
+                                       throwError)
 import           Control.Exception
-
-import           Distribution.Text
-import           Distribution.Compat.ReadP ((<++))
-import qualified Distribution.Compat.ReadP as ReadP
-import qualified Text.PrettyPrint as Disp
 
 import           Distribution.Client.Compat.Time
 import           Distribution.Client.Glob
@@ -77,65 +76,100 @@ import           GHC.Generics (Generic)
 
 -- | A description of a file (or set of files) to monitor for changes.
 --
--- All file paths here are relative to a common directory (e.g. project root).
+-- Where file paths are relative they are relative to a common directory
+-- (e.g. project root), not necessarily the process current directory.
 --
 data MonitorFilePath =
+     MonitorFile {
+       monitorKindFile :: !MonitorKindFile,
+       monitorKindDir  :: !MonitorKindDir,
+       monitorPath     :: !FilePath
+     }
+   | MonitorFileGlob {
+       monitorKindFile :: !MonitorKindFile,
+       monitorKindDir  :: !MonitorKindDir,
+       monitorPathGlob :: !FilePathGlob
+     }
+  deriving (Eq, Show, Generic)
 
-     -- | Monitor a single file for changes, based on its modification time.
-     -- The monitored file is considered to have changed if it no longer
-     -- exists or if its modification time has changed.
-     --
-     MonitorFile !FilePath
+data MonitorKindFile = FileExists
+                     | FileModTime
+                     | FileHashed
+                     | FileNotExists
+  deriving (Eq, Show, Generic)
 
-     -- | Monitor a single file for changes, based on its modification time
-     -- and content hash. The monitored file is considered to have changed if
-     -- it no longer exists or if its modification time and content hash have
-     -- changed.
-     --
-   | MonitorFileHashed !FilePath
-
-     -- | Monitor a single non-existent file for changes. The monitored file
-     -- is considered to have changed if it exists.
-     --
-   | MonitorNonExistentFile !FilePath
-
-     -- | Monitor a set of files identified by a file glob. The monitored glob
-     -- is considered to have changed if the set of files matching the glob
-     -- changes (i.e. creations or deletions), or if the modification time and
-     -- content hash of any matching file has changed.
-     --
-   | MonitorFileGlob !FilePathGlob
-     -- Note: currently file globs always use mtime+hash, so they're the
-     -- equivalent of MonitorFileHashed above. If we need globed files with
-     -- only mtime then it's perfectly ok to add it.
-
+data MonitorKindDir  = DirExists
+                     | DirModTime
+                     | DirNotExists
   deriving (Eq, Show, Generic)
 
 instance Binary MonitorFilePath
+instance Binary MonitorKindFile
+instance Binary MonitorKindDir
 
--- | A file path specified by globbing
+-- | Monitor a single file for changes, based on its modification time.
+-- The monitored file is considered to have changed if it no longer
+-- exists or if its modification time has changed.
 --
-data FilePathGlob
-   = GlobDir  !Glob !FilePathGlob
-   | GlobFile !Glob
-  deriving (Eq, Show, Generic)
+monitorFile :: FilePath -> MonitorFilePath
+monitorFile = MonitorFile FileModTime DirNotExists
 
-instance Binary FilePathGlob
+-- | Monitor a single file for changes, based on its modification time
+-- and content hash. The monitored file is considered to have changed if
+-- it no longer exists or if its modification time and content hash have
+-- changed.
+--
+monitorFileHashed :: FilePath -> MonitorFilePath
+monitorFileHashed = MonitorFile FileHashed DirNotExists
+
+-- | Monitor a single non-existent file for changes. The monitored file
+-- is considered to have changed if it exists.
+--
+monitorNonExistentFile :: FilePath -> MonitorFilePath
+monitorNonExistentFile = MonitorFile FileNotExists DirNotExists
+
+-- | Monitor a single directory for changes, based on its modification
+-- time. The monitored directory is considered to have changed if it no
+-- longer exists or if its modification time has changed.
+--
+monitorDirectory :: FilePath -> MonitorFilePath
+monitorDirectory = MonitorFile FileNotExists DirModTime
+
+-- | Monitor a single directory for existence. The monitored directory is
+-- considered to have changed only if it no longer exists.
+--
+monitorDirectoryExistence :: FilePath -> MonitorFilePath
+monitorDirectoryExistence = MonitorFile FileNotExists DirExists
+
+-- | Monitor a single file or directory for changes, based on its modification
+-- time. The monitored file is considered to have changed if it no longer
+-- exists or if its modification time has changed.
+--
+monitorFileOrDirectory :: FilePath -> MonitorFilePath
+monitorFileOrDirectory = MonitorFile FileModTime DirModTime
+
+-- | Monitor a set of files (or directories) identified by a file glob.
+-- The monitored glob is considered to have changed if the set of files
+-- matching the glob changes (i.e. creations or deletions), or for files if the
+-- modification time and content hash of any matching file has changed.
+--
+monitorFileGlob :: FilePathGlob -> MonitorFilePath
+monitorFileGlob = MonitorFileGlob FileHashed DirExists
 
 -- | Creates a list of files to monitor when you search for a file which
 -- unsuccessfully looked in @notFoundAtPaths@ before finding it at
 -- @foundAtPath@.
 monitorFileSearchPath :: [FilePath] -> FilePath -> [MonitorFilePath]
 monitorFileSearchPath notFoundAtPaths foundAtPath =
-    MonitorFile foundAtPath
-  : map MonitorNonExistentFile notFoundAtPaths
+    monitorFile foundAtPath
+  : map monitorNonExistentFile notFoundAtPaths
 
 -- | Similar to 'monitorFileSearchPath', but also instructs us to
 -- monitor the hash of the found file.
 monitorFileHashedSearchPath :: [FilePath] -> FilePath -> [MonitorFilePath]
 monitorFileHashedSearchPath notFoundAtPaths foundAtPath =
-    MonitorFileHashed foundAtPath
-  : map MonitorNonExistentFile notFoundAtPaths
+    monitorFileHashed foundAtPath
+  : map monitorNonExistentFile notFoundAtPaths
 
 
 ------------------------------------------------------------------------------
@@ -163,31 +197,46 @@ type Hash = Int
 -- did the snapshot (i.e. too new, changed since start of update process) or it
 -- no longer exists at all.
 --
-data MonitorStateFile
-   = MonitorStateFile       !(Maybe ModTime) -- ^ cached file mtime
-   | MonitorStateFileHashed !(Maybe ModTime)
-                            !Hash            -- ^ cached mtime and content hash
-   | MonitorStateFileNonExistent
+data MonitorStateFile = MonitorStateFile !MonitorKindFile !MonitorKindDir
+                                         !MonitorStateFileStatus
+  deriving (Show, Generic)
+
+data MonitorStateFileStatus
+   = MonitorStateFileExists
+   | MonitorStateFileModTime !ModTime        -- ^ cached file mtime
+   | MonitorStateFileHashed  !ModTime !Hash  -- ^ cached mtime and content hash
+   | MonitorStateDirExists
+   | MonitorStateDirModTime  !ModTime        -- ^ cached dir mtime
+   | MonitorStateNonExistent
+   | MonitorStateAlreadyChanged
   deriving (Show, Generic)
 
 instance Binary MonitorStateFile
+instance Binary MonitorStateFileStatus
 
 -- | The state necessary to determine whether the files matched by a globbing
 -- match have changed.
 --
-data MonitorStateGlob
+data MonitorStateGlob = MonitorStateGlob !MonitorKindFile !MonitorKindDir
+                                         !FilePathRoot !MonitorStateGlobRel
+  deriving (Show, Generic)
+
+data MonitorStateGlobRel
    = MonitorStateGlobDirs
-       !Glob !FilePathGlob
+       !Glob !FilePathGlobRel
        !ModTime
-       ![(FilePath, MonitorStateGlob)] -- invariant: sorted
+       ![(FilePath, MonitorStateGlobRel)] -- invariant: sorted
 
    | MonitorStateGlobFiles
        !Glob
        !ModTime
-       ![(FilePath, Maybe ModTime, Hash)] -- invariant: sorted
+       ![(FilePath, MonitorStateFileStatus)] -- invariant: sorted
+
+   | MonitorStateGlobDirTrailing
   deriving (Show, Generic)
 
 instance Binary MonitorStateGlob
+instance Binary MonitorStateGlobRel
 
 -- | We can build a 'MonitorStateFileSet' from a set of 'MonitorFilePath' by
 -- inspecting the state of the file system, and we can go in the reverse
@@ -199,16 +248,15 @@ reconstructMonitorFilePaths (MonitorStateFileSet singlePaths globPaths) =
                      (map getGlobPath globPaths)
                      singlePaths
   where
-    getSinglePath filepath monitorState =
-      case monitorState of
-        MonitorStateFile{}          -> MonitorFile            filepath
-        MonitorStateFileHashed{}    -> MonitorFileHashed      filepath
-        MonitorStateFileNonExistent -> MonitorNonExistentFile filepath
+    getSinglePath filepath (MonitorStateFile kindfile kinddir _) =
+      MonitorFile kindfile kinddir filepath
 
-    getGlobPath (MonitorStateGlobDirs  glob globs _ _) =
-      MonitorFileGlob (GlobDir  glob globs)
-    getGlobPath (MonitorStateGlobFiles glob       _ _) =
-      MonitorFileGlob (GlobFile glob)
+    getGlobPath (MonitorStateGlob kindfile kinddir root gstate) =
+      MonitorFileGlob kindfile kinddir $ FilePathGlob root $
+        case gstate of
+          MonitorStateGlobDirs  glob globs _ _ -> GlobDir  glob globs
+          MonitorStateGlobFiles glob       _ _ -> GlobFile glob
+          MonitorStateGlobDirTrailing          -> GlobDirTrailing
 
 ------------------------------------------------------------------------------
 -- Checking the status of monitored files
@@ -447,22 +495,16 @@ rewriteCacheFile FileMonitor {fileMonitorCacheFile} fileset key result =
 probeFileSystem :: FilePath -> MonitorStateFileSet
                 -> IO (Either FilePath (MonitorStateFileSet, CacheChanged))
 probeFileSystem root (MonitorStateFileSet singlePaths globPaths) =
-  runChangedM $
-    MonitorStateFileSet
-      <$> traverseWithKey (probeFileStatus root)     singlePaths
-      <*> traverse        (probeGlobStatus root ".") globPaths
-
-#if MIN_VERSION_containers(0,5,0)
-traverseWithKey :: Applicative t
-                => (k -> a -> t b) -> Map k a -> t (Map k b)
-traverseWithKey = Map.traverseWithKey
-#else
-traverseWithKey :: (Applicative t, Eq k)
-                => (k -> a -> t b) -> Map k a -> t (Map k b)
-traverseWithKey f = fmap Map.fromAscList
-                  . traverse (\(k, v) -> (,) k <$> f k v)
-                  . Map.toAscList
-#endif
+  runChangedM $ do
+    sequence_
+      [ probeMonitorStateFileStatus root file status
+      | (file, MonitorStateFile _ _ status) <- Map.toList singlePaths ]
+    -- The glob monitors can require state changes
+    globPaths' <-
+      sequence
+        [ probeMonitorStateGlob root globPath
+        | globPath <- globPaths ]
+    return (MonitorStateFileSet singlePaths globPaths')
 
 
 -----------------------------------------------
@@ -487,6 +529,10 @@ somethingChanged path = ChangedM $ throwError path
 cacheChanged :: ChangedM ()
 cacheChanged = ChangedM $ State.put CacheChanged
 
+mapChangedFile :: (FilePath -> FilePath) -> ChangedM a -> ChangedM a
+mapChangedFile adjust (ChangedM a) =
+    ChangedM (mapStateT (withExceptT adjust) a)
+
 data CacheChanged = CacheChanged | CacheUnchanged
 
 whenCacheChanged :: Monad m => CacheChanged -> m () -> m ()
@@ -497,37 +543,67 @@ whenCacheChanged CacheUnchanged _    = return ()
 
 -- | Probe the file system to see if a single monitored file has changed.
 --
-probeFileStatus :: FilePath -> FilePath -> MonitorStateFile
-                -> ChangedM MonitorStateFile
-probeFileStatus root file cached = do
-    case cached of
-      MonitorStateFile Nothing      -> somethingChanged file
-      MonitorStateFile (Just mtime) ->
+probeMonitorStateFileStatus :: FilePath -> FilePath
+                            -> MonitorStateFileStatus
+                            -> ChangedM ()
+probeMonitorStateFileStatus root file status =
+    case status of
+      MonitorStateFileExists ->
+        probeFileExistence root file
+
+      MonitorStateFileModTime mtime ->
         probeFileModificationTime root file mtime
 
-      MonitorStateFileHashed Nothing      _    -> somethingChanged file
-      MonitorStateFileHashed (Just mtime) hash ->
+      MonitorStateFileHashed  mtime hash ->
         probeFileModificationTimeAndHash root file mtime hash
 
-      MonitorStateFileNonExistent -> probeFileNonExistence root file
+      MonitorStateDirExists ->
+        probeDirExistence root file
 
-    return cached
+      MonitorStateDirModTime mtime ->
+        probeFileModificationTime root file mtime
+
+      MonitorStateNonExistent ->
+        probeFileNonExistence root file
+
+      MonitorStateAlreadyChanged ->
+        somethingChanged file
 
 
 -- | Probe the file system to see if a monitored file glob has changed.
 --
-probeGlobStatus :: FilePath      -- ^ root path
-                -> FilePath      -- ^ path of the directory we are looking in
-                                 --  relative to @root@
-                -> MonitorStateGlob
-                -> ChangedM MonitorStateGlob
-probeGlobStatus root dirName
-                (MonitorStateGlobDirs glob globPath mtime children) = do
+probeMonitorStateGlob :: FilePath      -- ^ root path
+                      -> MonitorStateGlob
+                      -> ChangedM MonitorStateGlob
+probeMonitorStateGlob relroot
+                      (MonitorStateGlob kindfile kinddir globroot glob) = do
+    root <- liftIO $ getFilePathRootDirectory globroot relroot
+    case globroot of
+      FilePathRelative ->
+        MonitorStateGlob kindfile kinddir globroot <$>
+        probeMonitorStateGlobRel kindfile kinddir root "." glob
+
+      -- for absolute cases, make the changed file we report absolute too
+      _ ->
+        mapChangedFile (root </>) $
+        MonitorStateGlob kindfile kinddir globroot <$>
+        probeMonitorStateGlobRel kindfile kinddir root "" glob
+
+probeMonitorStateGlobRel :: MonitorKindFile -> MonitorKindDir
+                         -> FilePath      -- ^ root path
+                         -> FilePath      -- ^ path of the directory we are
+                                          --   looking in relative to @root@
+                         -> MonitorStateGlobRel
+                         -> ChangedM MonitorStateGlobRel
+probeMonitorStateGlobRel kindfile kinddir root dirName
+                        (MonitorStateGlobDirs glob globPath mtime children) = do
     change <- liftIO $ checkDirectoryModificationTime (root </> dirName) mtime
     case change of
       Nothing -> do
         children' <- sequence
-          [ do fstate' <- probeGlobStatus root (dirName </> fname) fstate
+          [ do fstate' <- probeMonitorStateGlobRel
+                            kindfile kinddir root
+                            (dirName </> fname) fstate
                return (fname, fstate')
           | (fname, fstate) <- children ]
         return $! MonitorStateGlobDirs glob globPath mtime children'
@@ -537,7 +613,7 @@ probeGlobStatus root dirName
         -- a matching subdir may have been added or deleted
         matches <- filterM (\entry -> let subdir = root </> dirName </> entry
                                        in liftIO $ doesDirectoryExist subdir)
-                 . filter (globMatches glob)
+                 . filter (matchGlob glob)
                =<< liftIO (getDirectoryContents (root </> dirName))
 
         children' <- mapM probeMergeResult $
@@ -552,15 +628,15 @@ probeGlobStatus root dirName
         -- some other reason, we'll take advantage of that.
 
   where
-    probeMergeResult :: MergeResult (FilePath, MonitorStateGlob) FilePath
-                     -> ChangedM (FilePath, MonitorStateGlob)
+    probeMergeResult :: MergeResult (FilePath, MonitorStateGlobRel) FilePath
+                     -> ChangedM (FilePath, MonitorStateGlobRel)
 
     -- Only in cached (directory deleted)
-    probeMergeResult (OnlyInLeft (path, fstate)) =
+    probeMergeResult (OnlyInLeft (path, fstate)) = do
       case allMatchingFiles (dirName </> path) fstate of
         [] -> return (path, fstate)
         -- Strictly speaking we should be returning 'CacheChanged' above
-        -- as we should prune the now-missing 'MonitorStateGlob'. However
+        -- as we should prune the now-missing 'MonitorStateGlobRel'. However
         -- we currently just leave these now-redundant entries in the
         -- cache as they cost no IO and keeping them allows us to avoid
         -- rewriting the cache.
@@ -568,8 +644,8 @@ probeGlobStatus root dirName
 
     -- Only in current filesystem state (directory added)
     probeMergeResult (OnlyInRight path) = do
-      fstate <- liftIO $ buildMonitorStateGlob Nothing Map.empty
-                           root (dirName </> path) globPath
+      fstate <- liftIO $ buildMonitorStateGlobRel Nothing Map.empty
+                           kindfile kinddir root (dirName </> path) globPath
       case allMatchingFiles (dirName </> path) fstate of
         (file:_) -> somethingChanged file
         -- This is the only case where we use 'cacheChanged' because we can
@@ -579,55 +655,57 @@ probeGlobStatus root dirName
 
     -- Found in path
     probeMergeResult (InBoth (path, fstate) _) = do
-      fstate' <- probeGlobStatus root (dirName </> path) fstate
+      fstate' <- probeMonitorStateGlobRel kindfile kinddir
+                                          root (dirName </> path) fstate
       return (path, fstate')
 
     -- | Does a 'MonitorStateGlob' have any relevant files within it?
-    allMatchingFiles :: FilePath -> MonitorStateGlob -> [FilePath]
+    allMatchingFiles :: FilePath -> MonitorStateGlobRel -> [FilePath]
     allMatchingFiles dir (MonitorStateGlobFiles _ _   entries) =
-      [ dir </> fname | (fname, _, _) <- entries ]
+      [ dir </> fname | (fname, _) <- entries ]
     allMatchingFiles dir (MonitorStateGlobDirs  _ _ _ entries) =
       [ res
       | (subdir, fstate) <- entries
       , res <- allMatchingFiles (dir </> subdir) fstate ]
+    allMatchingFiles dir MonitorStateGlobDirTrailing =
+      [dir]
 
-
-probeGlobStatus root dirName (MonitorStateGlobFiles glob mtime children) = do
+probeMonitorStateGlobRel _ _ root dirName
+                         (MonitorStateGlobFiles glob mtime children) = do
     change <- liftIO $ checkDirectoryModificationTime (root </> dirName) mtime
     mtime' <- case change of
       Nothing     -> return mtime
       Just mtime' -> do
         -- directory modification time changed:
         -- a matching file may have been added or deleted
-        matches <- filterM (\entry -> let file = root </> dirName </> entry
-                                       in liftIO $ doesFileExist file)
-                 . filter (globMatches glob)
+        matches <- return . filter (matchGlob glob)
                =<< liftIO (getDirectoryContents (root </> dirName))
 
         mapM_ probeMergeResult $
-              mergeBy (\(path1,_,_) path2 -> compare path1 path2)
+              mergeBy (\(path1,_) path2 -> compare path1 path2)
                       children
                       (sort matches)
         return mtime'
 
     -- Check that none of the children have changed
-    forM_ children $ \(file, mfmtime, fhash) ->
-        case mfmtime of
-          Nothing     -> somethingChanged file
-          Just fmtime -> probeFileModificationTimeAndHash
-                           root (dirName </> file) fmtime fhash
+    forM_ children $ \(file, status) ->
+      probeMonitorStateFileStatus root (dirName </> file) status
+
 
     return (MonitorStateGlobFiles glob mtime' children)
     -- Again, we don't force a cache rewite with 'cacheChanged', but we do use
     -- the new mtime' if any.
   where
-    probeMergeResult :: MergeResult (FilePath, Maybe ModTime, Hash) FilePath
+    probeMergeResult :: MergeResult (FilePath, MonitorStateFileStatus) FilePath
                      -> ChangedM ()
     probeMergeResult mr = case mr of
-      InBoth _ _               -> return ()
+      InBoth _ _            -> return ()
     -- this is just to be able to accurately report which file changed:
-      OnlyInLeft  (path, _, _) -> somethingChanged (dirName </> path)
-      OnlyInRight path         -> somethingChanged (dirName </> path)
+      OnlyInLeft  (path, _) -> somethingChanged (dirName </> path)
+      OnlyInRight path      -> somethingChanged (dirName </> path)
+
+probeMonitorStateGlobRel _ _ _ _ MonitorStateGlobDirTrailing =
+    return MonitorStateGlobDirTrailing
 
 ------------------------------------------------------------------------------
 
@@ -704,35 +782,68 @@ buildMonitorStateFileSet mstartTime hashcache root =
     go !singlePaths !globPaths [] =
       return (MonitorStateFileSet singlePaths globPaths)
 
-    go !singlePaths !globPaths (MonitorFile file : monitors) = do
-      let absfile = root </> file
-      monitorState <- handleDoesNotExist (MonitorStateFile Nothing) $ do
-        mtime <- getModTime absfile
-        if changedDuringUpdate mstartTime mtime
-          then return (MonitorStateFile Nothing)
-          else return (MonitorStateFile (Just mtime))
-      let singlePaths' = Map.insert file monitorState singlePaths
-      go singlePaths' globPaths monitors
+    go !singlePaths !globPaths
+       (MonitorFile kindfile kinddir path : monitors) = do
+      monitorState <- MonitorStateFile kindfile kinddir
+                  <$> buildMonitorStateFile mstartTime hashcache
+                                            kindfile kinddir root path
+      go (Map.insert path monitorState singlePaths) globPaths monitors
 
-    go !singlePaths !globPaths (MonitorFileHashed file : monitors) = do
-      let absfile = root </> file
-      monitorState <- handleDoesNotExist (MonitorStateFileHashed Nothing 0) $ do
-        mtime <- getModTime absfile
-        if changedDuringUpdate mstartTime mtime
-          then return (MonitorStateFileHashed Nothing 0)
-          else do hash <- getFileHash hashcache file absfile mtime
-                  return (MonitorStateFileHashed (Just mtime) hash)
-      let singlePaths' = Map.insert file monitorState singlePaths
-      go singlePaths' globPaths monitors
-
-    go !singlePaths !globPaths (MonitorNonExistentFile path : monitors) = do
-      let singlePaths' = Map.insert path MonitorStateFileNonExistent singlePaths
-      go singlePaths' globPaths monitors
-
-    go !singlePaths !globPaths (MonitorFileGlob globPath : monitors) = do
+    go !singlePaths !globPaths
+       (MonitorFileGlob kindfile kinddir globPath : monitors) = do
       monitorState <- buildMonitorStateGlob mstartTime hashcache
-                                            root "." globPath
+                                            kindfile kinddir root globPath
       go singlePaths (monitorState : globPaths) monitors
+
+
+buildMonitorStateFile :: Maybe MonitorTimestamp -- ^ start time of update
+                      -> FileHashCache          -- ^ existing file hashes
+                      -> MonitorKindFile -> MonitorKindDir
+                      -> FilePath               -- ^ the root directory
+                      -> FilePath
+                      -> IO MonitorStateFileStatus
+buildMonitorStateFile mstartTime hashcache kindfile kinddir root path = do
+    let abspath = root </> path
+    isFile <- doesFileExist abspath
+    isDir  <- doesDirectoryExist abspath
+    case (isFile, kindfile, isDir, kinddir) of
+      (_, FileNotExists, _, DirNotExists) ->
+        -- we don't need to care if it exists now, since we check at probe time
+        return MonitorStateNonExistent
+
+      (False, _, False, _) ->
+        return MonitorStateAlreadyChanged
+
+      (True, FileExists, _, _)  ->
+        return MonitorStateFileExists
+
+      (True, FileModTime, _, _) ->
+        handleIOException MonitorStateAlreadyChanged $ do
+          mtime <- getModTime abspath
+          if changedDuringUpdate mstartTime mtime
+            then return MonitorStateAlreadyChanged
+            else return (MonitorStateFileModTime mtime)
+
+      (True, FileHashed, _, _) ->
+        handleIOException MonitorStateAlreadyChanged $ do
+          mtime <- getModTime abspath
+          if changedDuringUpdate mstartTime mtime
+            then return MonitorStateAlreadyChanged
+            else do hash <- getFileHash hashcache abspath abspath mtime
+                    return (MonitorStateFileHashed mtime hash)
+
+      (_, _, True, DirExists) ->
+        return MonitorStateDirExists
+
+      (_, _, True, DirModTime) ->
+        handleIOException MonitorStateAlreadyChanged $ do
+          mtime <- getModTime abspath
+          if changedDuringUpdate mstartTime mtime
+            then return MonitorStateAlreadyChanged
+            else return (MonitorStateDirModTime mtime)
+
+      (False, _, True,  DirNotExists) -> return MonitorStateAlreadyChanged
+      (True, FileNotExists, False, _) -> return MonitorStateAlreadyChanged
 
 -- | If we have a timestamp for the beginning of the update, then any file
 -- mtime later than this means that it changed during the update and we ought
@@ -752,74 +863,55 @@ changedDuringUpdate _ _ = False
 --
 buildMonitorStateGlob :: Maybe MonitorTimestamp -- ^ start time of update
                       -> FileHashCache     -- ^ existing file hashes
+                      -> MonitorKindFile -> MonitorKindDir
                       -> FilePath     -- ^ the root directory
-                      -> FilePath     -- ^ directory we are examining
-                                      --   relative to the root
                       -> FilePathGlob -- ^ the matching glob
                       -> IO MonitorStateGlob
-buildMonitorStateGlob mstartTime hashcache root dir globPath = do
+buildMonitorStateGlob mstartTime hashcache kindfile kinddir relroot
+                      (FilePathGlob globroot globPath) = do
+    root <- liftIO $ getFilePathRootDirectory globroot relroot
+    MonitorStateGlob kindfile kinddir globroot <$>
+      buildMonitorStateGlobRel
+        mstartTime hashcache kindfile kinddir root "." globPath
+
+buildMonitorStateGlobRel :: Maybe MonitorTimestamp -- ^ start time of update
+                         -> FileHashCache   -- ^ existing file hashes
+                         -> MonitorKindFile -> MonitorKindDir
+                         -> FilePath        -- ^ the root directory
+                         -> FilePath        -- ^ directory we are examining
+                                            --   relative to the root
+                         -> FilePathGlobRel -- ^ the matching glob
+                         -> IO MonitorStateGlobRel
+buildMonitorStateGlobRel mstartTime hashcache kindfile kinddir root
+                         dir globPath = do
     let absdir = root </> dir
     dirEntries <- getDirectoryContents absdir
     dirMTime   <- getModTime absdir
     case globPath of
       GlobDir glob globPath' -> do
         subdirs <- filterM (\subdir -> doesDirectoryExist (absdir </> subdir))
-                 $ filter (globMatches glob) dirEntries
+                 $ filter (matchGlob glob) dirEntries
         subdirStates <-
           forM (sort subdirs) $ \subdir -> do
-            fstate <- buildMonitorStateGlob mstartTime hashcache root
-                                            (dir </> subdir) globPath'
+            fstate <- buildMonitorStateGlobRel
+                        mstartTime hashcache kindfile kinddir root
+                        (dir </> subdir) globPath'
             return (subdir, fstate)
         return $! MonitorStateGlobDirs glob globPath' dirMTime subdirStates
 
       GlobFile glob -> do
-        files <- filterM (\fname -> doesFileExist (absdir </> fname))
-               $ filter (globMatches glob) dirEntries
+        let files = filter (matchGlob glob) dirEntries
         filesStates <-
           forM (sort files) $ \file -> do
-            let absfile = absdir </> file
-            mtime <- getModTime absfile
-            let mtime' | changedDuringUpdate mstartTime mtime
-                                   = Nothing
-                       | otherwise = Just mtime
-            hash <- getFileHash hashcache (dir </> file) absfile mtime
-            return (file, mtime', hash)
+            fstate <- buildMonitorStateFile
+                        mstartTime hashcache kindfile kinddir root
+                        (dir </> file)
+            return (file, fstate)
         return $! MonitorStateGlobFiles glob dirMTime filesStates
 
--- | Utility to match a file glob against the file system, starting from a
--- given root directory. The results are all relative to the given root.
---
-matchFileGlob :: FilePath -> FilePathGlob -> IO [FilePath]
-matchFileGlob root glob0 = go glob0 ""
-  where
-    go (GlobFile glob) dir = do
-      entries <- getDirectoryContents (root </> dir)
-      let files = filter (globMatches glob) entries
-      return (map (dir </>) files)
+      GlobDirTrailing ->
+        return MonitorStateGlobDirTrailing
 
-    go (GlobDir glob globPath) dir = do
-      entries <- getDirectoryContents (root </> dir)
-      subdirs <- filterM (\subdir -> doesDirectoryExist
-                                       (root </> dir </> subdir))
-               $ filter (globMatches glob) entries
-      concat <$> mapM (\subdir -> go globPath (dir </> subdir)) subdirs
---TODO: [code cleanup] plausibly FilePathGlob and matchFileGlob should be
--- moved into D.C.Glob and/or merged with similar functionality in Cabal.
-
-
--- | Check if a 'FilePathGlob' doesn't actually make use of any globbing and
--- is in fact equivalent to a non-glob 'FilePath'.
---
--- If it is trivial in this sense then the result is the equivalent constant
--- 'FilePath'. On the other hand if it is not trivial (so could in principle
--- match more than one file) then the result is @Nothing@.
---
-isTrivialFilePathGlob :: FilePathGlob -> Maybe FilePath
-isTrivialFilePathGlob = go []
-  where
-    go paths (GlobDir  (Glob [Literal path]) globs) = go (path:paths) globs
-    go paths (GlobFile (Glob [Literal path])) = Just (joinPath (reverse (path:paths)))
-    go _ _ = Nothing
 
 -- | We really want to avoid re-hashing files all the time. We already make
 -- the assumption that if a file mtime has not changed then we don't need to
@@ -867,11 +959,14 @@ readCacheFileHashes monitor =
         `Map.union` collectAllGlobHashes globPaths
 
     collectAllFileHashes =
-      Map.mapMaybe $ \fstate -> case fstate of
-        MonitorStateFileHashed (Just mtime) hash -> Just (mtime, hash)
-        _                                        -> Nothing
+      Map.mapMaybe $ \(MonitorStateFile _ _ fstate) -> case fstate of
+        MonitorStateFileHashed mtime hash -> Just (mtime, hash)
+        _                                 -> Nothing
 
-    collectAllGlobHashes = Map.fromList . concatMap (collectGlobHashes "")
+    collectAllGlobHashes globPaths =
+      Map.fromList [ (fpath, hash)
+                   | MonitorStateGlob _ _ _ gstate <- globPaths
+                   , (fpath, hash) <- collectGlobHashes "" gstate ]
 
     collectGlobHashes dir (MonitorStateGlobDirs _ _ _ entries) =
       [ res
@@ -880,7 +975,10 @@ readCacheFileHashes monitor =
 
     collectGlobHashes dir (MonitorStateGlobFiles  _ _ entries) =
       [ (dir </> fname, (mtime, hash))
-      | (fname, Just mtime, hash) <- entries ]
+      | (fname, MonitorStateFileHashed mtime hash) <- entries ]
+
+    collectGlobHashes _dir MonitorStateGlobDirTrailing =
+      []
 
 
 ------------------------------------------------------------------------------
@@ -904,19 +1002,34 @@ probeFileModificationTimeAndHash root file mtime hash = do
       checkFileModificationTimeAndHashUnchanged root file mtime hash
     unless unchanged (somethingChanged file)
 
+-- | Within the @root@ directory, check if @file@ still exists as a file.
+-- If it *does not* exist, short-circuit.
+probeFileExistence :: FilePath -> FilePath -> ChangedM ()
+probeFileExistence root file = do
+    existsFile <- liftIO $ doesFileExist (root </> file)
+    unless existsFile (somethingChanged file)
+
+-- | Within the @root@ directory, check if @dir@ still exists.
+-- If it *does not* exist, short-circuit.
+probeDirExistence :: FilePath -> FilePath -> ChangedM ()
+probeDirExistence root dir = do
+    existsDir  <- liftIO $ doesDirectoryExist (root </> dir)
+    unless existsDir (somethingChanged dir)
+
 -- | Within the @root@ directory, check if @file@ still does not exist.
 -- If it *does* exist, short-circuit.
 probeFileNonExistence :: FilePath -> FilePath -> ChangedM ()
 probeFileNonExistence root file = do
-    exists <- liftIO $ doesFileExist (root </> file)
-    when exists (somethingChanged file)
+    existsFile <- liftIO $ doesFileExist (root </> file)
+    existsDir  <- liftIO $ doesDirectoryExist (root </> file)
+    when (existsFile || existsDir) (somethingChanged file)
 
 -- | Returns @True@ if, inside the @root@ directory, @file@ has the same
 -- 'ModTime' as @mtime@.
 checkModificationTimeUnchanged :: FilePath -> FilePath
                                -> ModTime -> IO Bool
 checkModificationTimeUnchanged root file mtime =
-  handleDoesNotExist False $ do
+  handleIOException False $ do
     mtime' <- getModTime (root </> file)
     return (mtime == mtime')
 
@@ -925,7 +1038,7 @@ checkModificationTimeUnchanged root file mtime =
 checkFileModificationTimeAndHashUnchanged :: FilePath -> FilePath
                                           -> ModTime -> Hash -> IO Bool
 checkFileModificationTimeAndHashUnchanged root file mtime chash =
-  handleDoesNotExist False $ do
+  handleIOException False $ do
     mtime' <- getModTime (root </> file)
     if mtime == mtime'
       then return True
@@ -943,7 +1056,7 @@ readFileHash file =
 -- is the same as @mtime@, and the new 'ModTime' if it is not.
 checkDirectoryModificationTime :: FilePath -> ModTime -> IO (Maybe ModTime)
 checkDirectoryModificationTime dir mtime =
-  handleDoesNotExist Nothing $ do
+  handleIOException Nothing $ do
     mtime' <- getModTime dir
     if mtime == mtime'
       then return Nothing
@@ -955,21 +1068,24 @@ handleErrorCall :: a -> IO a -> IO a
 handleErrorCall e =
     handle (\(ErrorCall _) -> return e)
 
+-- | Run an IO computation, returning @e@ if there is any 'IOException'.
+--
+-- This policy is OK in the file monitor code because it just causes the
+-- monitor to report that something changed, and then code reacting to that
+-- will normally encounter the same IO exception when it re-runs the action
+-- that uses the file.
+--
+handleIOException :: a -> IO a -> IO a
+handleIOException e =
+    handle (anyIOException e)
+  where
+    anyIOException :: a -> IOException -> IO a
+    anyIOException x _ = return x
+
+
 ------------------------------------------------------------------------------
 -- Instances
 --
-
-instance Text FilePathGlob where
-  disp (GlobDir  glob pathglob) = disp glob Disp.<> Disp.char '/'
-                                            Disp.<> disp pathglob
-  disp (GlobFile glob)          = disp glob
-
-  parse = parse >>= \glob -> (asDir glob <++ asFile glob)
-    where
-      asDir  glob = do _ <- ReadP.char '/'
-                       globs <- parse
-                       return (GlobDir glob globs)
-      asFile glob = return (GlobFile glob)
 
 instance Binary MonitorStateFileSet where
   put (MonitorStateFileSet singlePaths globPaths) = do

--- a/cabal-install/Distribution/Client/Glob.hs
+++ b/cabal-install/Distribution/Client/Glob.hs
@@ -1,50 +1,157 @@
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE CPP, DeriveGeneric #-}
 
+--TODO: [code cleanup] plausibly much of this module should be merged with
+-- similar functionality in Cabal.
 module Distribution.Client.Glob
-    ( GlobAtom(..)
-    , Glob (..)
-    , globMatches
+    ( FilePathGlob(..)
+    , FilePathRoot(..)
+    , FilePathGlobRel(..)
+    , Glob
+    , GlobPiece(..)
+    , matchFileGlob
+    , matchFileGlobRel
+    , matchGlob
+    , isTrivialFilePathGlob
+    , getFilePathRootDirectory
     ) where
 
-import Data.List (stripPrefix)
-import Control.Monad (liftM2)
-import Distribution.Compat.Binary
-import GHC.Generics (Generic)
+import           Data.Char (toUpper)
+import           Data.List (stripPrefix)
+#if !MIN_VERSION_base(4,8,0)
+import           Control.Applicative
+#endif
+import           Control.Monad
+import           Distribution.Compat.Binary
+import           GHC.Generics (Generic)
 
-import Distribution.Text
-import Distribution.Compat.ReadP
+import           Distribution.Text
+import           Distribution.Compat.ReadP (ReadP, (<++), (+++))
+import qualified Distribution.Compat.ReadP as Parse
 import qualified Text.PrettyPrint as Disp
 
+import           System.FilePath
+import           System.Directory
 
--- | A piece of a globbing pattern
-data GlobAtom = WildCard
-              | Literal String
-              | Union [Glob]
+
+-- | A file path specified by globbing
+--
+data FilePathGlob = FilePathGlob FilePathRoot FilePathGlobRel
   deriving (Eq, Show, Generic)
 
-instance Binary GlobAtom
+data FilePathGlobRel
+   = GlobDir  !Glob !FilePathGlobRel
+   | GlobFile !Glob
+   | GlobDirTrailing                -- ^ trailing dir, a glob ending in @/@
+  deriving (Eq, Show, Generic)
 
 -- | A single directory or file component of a globbed path
-newtype Glob = Glob [GlobAtom]
+type Glob = [GlobPiece]
+
+-- | A piece of a globbing pattern
+data GlobPiece = WildCard
+               | Literal String
+               | Union [Glob]
   deriving (Eq, Show, Generic)
 
-instance Binary Glob
+data FilePathRoot
+   = FilePathRelative
+   | FilePathUnixRoot
+   | FilePathWinDrive Char
+   | FilePathHomeDir
+  deriving (Eq, Show, Generic)
+
+instance Binary FilePathGlob
+instance Binary FilePathRoot
+instance Binary FilePathGlobRel
+instance Binary GlobPiece
 
 
--- | Test whether a file path component matches a globbing pattern
+-- | Check if a 'FilePathGlob' doesn't actually make use of any globbing and
+-- is in fact equivalent to a non-glob 'FilePath'.
 --
-globMatches :: Glob -> String -> Bool
-globMatches (Glob atoms) = goStart atoms
+-- If it is trivial in this sense then the result is the equivalent constant
+-- 'FilePath'. On the other hand if it is not trivial (so could in principle
+-- match more than one file) then the result is @Nothing@.
+--
+isTrivialFilePathGlob :: FilePathGlob -> Maybe FilePath
+isTrivialFilePathGlob (FilePathGlob root pathglob) =
+    case root of
+      FilePathRelative       -> go []          pathglob
+      FilePathUnixRoot       -> go ["/"]       pathglob
+      FilePathWinDrive drive -> go [drive:":"] pathglob
+      FilePathHomeDir        -> Nothing
+  where
+    go paths (GlobDir  [Literal path] globs) = go (path:paths) globs
+    go paths (GlobFile [Literal path]) = Just (joinPath (reverse (path:paths)))
+    go paths  GlobDirTrailing          = Just (addTrailingPathSeparator
+                                                 (joinPath (reverse paths)))
+    go _ _ = Nothing
+
+-- | Get the 'FilePath' corresponding to a 'FilePathRoot'.
+--
+-- The 'FilePath' argument is required to supply the path for the
+-- 'FilePathRelative' case.
+--
+getFilePathRootDirectory :: FilePathRoot
+                         -> FilePath      -- ^ root for relative paths
+                         -> IO FilePath
+getFilePathRootDirectory  FilePathRelative     root = return root
+getFilePathRootDirectory  FilePathUnixRoot        _ = return "/"
+getFilePathRootDirectory (FilePathWinDrive drive) _ = return (drive:":")
+getFilePathRootDirectory  FilePathHomeDir         _ = getHomeDirectory
+
+
+------------------------------------------------------------------------------
+-- Matching
+--
+
+-- | Match a 'FilePathGlob' against the file system, starting from a given
+-- root directory for relative paths. The results of relative globs are
+-- relative to the given root. Matches for absolute globs are absolute.
+--
+matchFileGlob :: FilePath -> FilePathGlob -> IO [FilePath]
+matchFileGlob relroot (FilePathGlob globroot glob) = do
+    root <- getFilePathRootDirectory globroot relroot
+    matches <- matchFileGlobRel root glob
+    case globroot of
+      FilePathRelative -> return matches
+      _                -> return (map (root </>) matches)
+
+-- | Match a 'FilePathGlobRel' against the file system, starting from a
+-- given root directory. The results are all relative to the given root.
+--
+matchFileGlobRel :: FilePath -> FilePathGlobRel -> IO [FilePath]
+matchFileGlobRel root glob0 = go glob0 ""
+  where
+    go (GlobFile glob) dir = do
+      entries <- getDirectoryContents (root </> dir)
+      let files = filter (matchGlob glob) entries
+      return (map (dir </>) files)
+
+    go (GlobDir glob globPath) dir = do
+      entries <- getDirectoryContents (root </> dir)
+      subdirs <- filterM (\subdir -> doesDirectoryExist
+                                       (root </> dir </> subdir))
+               $ filter (matchGlob glob) entries
+      concat <$> mapM (\subdir -> go globPath (dir </> subdir)) subdirs
+
+    go GlobDirTrailing dir = return [dir]
+
+
+-- | Match a globbing pattern against a file path component
+--
+matchGlob :: Glob -> String -> Bool
+matchGlob = goStart
   where
     -- From the man page, glob(7):
     --   "If a filename starts with a '.', this character must be
     --    matched explicitly."
-    
-    go, goStart :: [GlobAtom] -> String -> Bool
+
+    go, goStart :: [GlobPiece] -> String -> Bool
 
     goStart (WildCard:_) ('.':_)  = False
-    goStart (Union globs:rest) cs = any (\(Glob glob) ->
-                                            goStart (glob ++ rest) cs) globs
+    goStart (Union globs:rest) cs = any (\glob -> goStart (glob ++ rest) cs)
+                                        globs
     goStart rest               cs = go rest cs
 
     go []                 ""    = True
@@ -54,53 +161,116 @@ globMatches (Glob atoms) = goStart atoms
       | otherwise               = False
     go [WildCard]         ""    = True
     go (WildCard:rest)   (c:cs) = go rest (c:cs) || go (WildCard:rest) cs
-    go (Union globs:rest)   cs  = any (\(Glob glob) ->
-                                          go (glob ++ rest) cs) globs
+    go (Union globs:rest)   cs  = any (\glob -> go (glob ++ rest) cs) globs
     go []                (_:_)  = False
     go (_:_)              ""    = False
 
-instance Text Glob where
-  disp (Glob atoms) = Disp.hcat (map dispAtom atoms) 
+
+------------------------------------------------------------------------------
+-- Parsing & printing
+--
+
+instance Text FilePathGlob where
+  disp (FilePathGlob root pathglob) = disp root Disp.<> disp pathglob
+  parse =
+    parse >>= \root ->
+        (FilePathGlob root <$> parse)
+    <++ (when (root == FilePathRelative) Parse.pfail >>
+         return (FilePathGlob root GlobDirTrailing))
+
+instance Text FilePathRoot where
+  disp  FilePathRelative    = Disp.empty
+  disp  FilePathUnixRoot    = Disp.char '/'
+  disp (FilePathWinDrive c) = Disp.char c
+                      Disp.<> Disp.char ':'
+                      Disp.<> Disp.char '\\'
+  disp FilePathHomeDir      = Disp.char '~'
+                      Disp.<> Disp.char '/'
+
+  parse =
+        (     (Parse.char '/' >> return FilePathUnixRoot)
+          +++ (Parse.char '~' >> Parse.char '/' >> return FilePathHomeDir)
+          +++ (do drive <- Parse.satisfy (\c -> (c >= 'a' && c <= 'z')
+                                             || (c >= 'A' && c <= 'Z'))
+                  _ <- Parse.char ':'
+                  _ <- Parse.char '/' +++ Parse.char '\\'
+                  return (FilePathWinDrive (toUpper drive)))
+        )
+    <++ return FilePathRelative
+
+instance Text FilePathGlobRel where
+  disp (GlobDir  glob pathglob) = dispGlob glob
+                          Disp.<> Disp.char '/'
+                          Disp.<> disp pathglob
+  disp (GlobFile glob)          = dispGlob glob
+  disp  GlobDirTrailing         = Disp.empty
+
+  parse = parsePath
     where
-      dispAtom WildCard      = Disp.char '*'
-      dispAtom (Literal str) = Disp.text (escape str)
-      dispAtom (Union globs) = Disp.braces
-                                 (Disp.hcat (Disp.punctuate (Disp.char ',')
-                                                            (map disp globs)))
+      parsePath :: ReadP r FilePathGlobRel
+      parsePath =
+        parseGlob >>= \globpieces ->
+            asDir globpieces
+        <++ asTDir globpieces
+        <++ asFile globpieces
 
-      escape []               = []
-      escape (c:cs)
-        | isGlobEscapedChar c = '\\' : c : escape cs
-        | otherwise           =        c : escape cs
+      asDir  glob = do dirSep
+                       globs <- parsePath
+                       return (GlobDir glob globs)
+      asTDir glob = do dirSep
+                       return (GlobDir glob GlobDirTrailing)
+      asFile glob = return (GlobFile glob)
 
-  parse = Glob `fmap` many1 globAtom
-    where
-      globAtom :: ReadP r GlobAtom
-      globAtom = literal +++ wildcard +++ union
+      dirSep = (Parse.char '/' >> return ())
+           +++ (do _ <- Parse.char '\\'
+                   -- check this isn't an escape code
+                   following <- Parse.look
+                   case following of
+                     (c:_) | isGlobEscapedChar c -> Parse.pfail
+                     _                           -> return ())
 
-      wildcard = char '*' >> return WildCard
 
-      union = between (char '{') (char '}')
-              (fmap (Union . map Glob) $ sepBy1 (many1 globAtom) (char ','))
+dispGlob :: Glob -> Disp.Doc
+dispGlob = Disp.hcat . map dispPiece
+  where
+    dispPiece WildCard      = Disp.char '*'
+    dispPiece (Literal str) = Disp.text (escape str)
+    dispPiece (Union globs) = Disp.braces
+                                (Disp.hcat (Disp.punctuate
+                                             (Disp.char ',')
+                                             (map dispGlob globs)))
+    escape []               = []
+    escape (c:cs)
+      | isGlobEscapedChar c = '\\' : c : escape cs
+      | otherwise           =        c : escape cs
 
-      literal = Literal `fmap` many1'
-        where
-          litchar = normal +++ escape
-          
-          normal  = satisfy (not . isGlobEscapedChar)
-          escape  = char '\\' >> satisfy isGlobEscapedChar
+parseGlob :: ReadP r Glob
+parseGlob = Parse.many1 parsePiece
+  where
+    parsePiece = literal +++ wildcard +++ union
 
-          many1' :: ReadP r [Char]
-          many1' = liftM2 (:) litchar many'
+    wildcard = Parse.char '*' >> return WildCard
 
-          many' :: ReadP r [Char]
-          many' = many1' <++ return []
+    union = Parse.between (Parse.char '{') (Parse.char '}') $
+              fmap Union (Parse.sepBy1 parseGlob (Parse.char ','))
+
+    literal = Literal `fmap` litchars1
+
+    litchar = normal +++ escape
+
+    normal  = Parse.satisfy (\c -> not (isGlobEscapedChar c)
+                                && c /= '/' && c /= '\\')
+    escape  = Parse.char '\\' >> Parse.satisfy isGlobEscapedChar
+
+    litchars1 :: ReadP r [Char]
+    litchars1 = liftM2 (:) litchar litchars
+
+    litchars :: ReadP r [Char]
+    litchars = litchars1 <++ return []
 
 isGlobEscapedChar :: Char -> Bool
 isGlobEscapedChar '*'  = True
 isGlobEscapedChar '{'  = True
 isGlobEscapedChar '}'  = True
 isGlobEscapedChar ','  = True
-isGlobEscapedChar '\\' = True
-isGlobEscapedChar '/'  = True
 isGlobEscapedChar _    = False

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -519,7 +519,7 @@ updatePackageBuildFileMonitor PackageFileMonitor{pkgFileMonitorBuild}
                               srcdir timestamp pkg pkgBuildStatus
                               allSrcFiles buildSuccess =
     updateFileMonitor pkgFileMonitorBuild srcdir (Just timestamp)
-                      (map MonitorFileHashed allSrcFiles)
+                      (map monitorFileHashed allSrcFiles)
                       buildComponents' buildSuccess
   where
     (_pkgconfig, buildComponents) = packageFileMonitorKeyValues pkg

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -17,6 +17,7 @@ module Distribution.Client.ProjectConfig.Legacy (
 
     -- * Internals, just for tests
     parsePackageLocationTokenQ,
+    renderPackageLocationToken,
   ) where
 
 import Distribution.Client.ProjectConfig.Types
@@ -755,6 +756,8 @@ renderPackageLocationToken s | needsQuoting = show s
     ok n ('{':cs) = ok (n+1) cs
     ok n ('}':cs) = ok (n-1) cs
     ok n (',':cs) = (n > 0) && ok n cs
+    ok _ (c:_)
+      | isSpace c = False
     ok n (_  :cs) = ok n cs
 
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -730,7 +730,7 @@ getInstalledPackages :: Verbosity
                      -> PackageDBStack 
                      -> Rebuild InstalledPackageIndex
 getInstalledPackages verbosity compiler progdb platform packagedbs = do
-    monitorFiles . map MonitorFile
+    monitorFiles . map monitorFileOrDirectory
       =<< liftIO (IndexUtils.getInstalledPackagesMonitorFiles
                     verbosity compiler
                     packagedbs progdb platform)
@@ -743,7 +743,7 @@ getPackageDBContents :: Verbosity
                      -> PackageDB
                      -> Rebuild InstalledPackageIndex
 getPackageDBContents verbosity compiler progdb platform packagedb = do
-    monitorFiles . map MonitorFile
+    monitorFiles . map monitorFileOrDirectory
       =<< liftIO (IndexUtils.getInstalledPackagesMonitorFiles
                     verbosity compiler
                     [packagedb] progdb platform)
@@ -762,7 +762,7 @@ getSourcePackages verbosity withRepoCtx = do
           sourcePkgDb <- IndexUtils.getSourcePackages verbosity repoctx
           return (sourcePkgDb, repoContextRepos repoctx)
 
-    monitorFiles . map MonitorFile
+    monitorFiles . map monitorFile
                  . IndexUtils.getSourcePackagesMonitorFiles
                  $ repos
     return sourcePkgDb
@@ -782,7 +782,7 @@ createPackageDBIfMissing verbosity compiler progdb packageDbs =
 recreateDirectory :: Verbosity -> Bool -> FilePath -> Rebuild ()
 recreateDirectory verbosity createParents dir = do
     liftIO $ createDirectoryIfMissingVerbose verbosity createParents dir
-    monitorFiles [MonitorFile dir]
+    monitorFiles [monitorDirectoryExistence dir]
 
 
 -- | Get the 'HashValue' for all the source packages where we use hashes,
@@ -827,7 +827,7 @@ getPackageSourceHashes verbosity withRepoCtx installPlan = do
           | (pkg, srcloc) <- newlyDownloaded ++ alreadyDownloaded
           , tarball <- maybeToList (tarballFileLocation srcloc) ]
 
-    monitorFiles [ MonitorFile tarball | (_pkgid, tarball) <- pkgsTarballs ]
+    monitorFiles [ monitorFile tarball | (_pkgid, tarball) <- pkgsTarballs ]
 
     liftM Map.fromList $ liftIO $
       sequence

--- a/cabal-install/Distribution/Client/RebuildMonad.hs
+++ b/cabal-install/Distribution/Client/RebuildMonad.hs
@@ -16,9 +16,21 @@ module Distribution.Client.RebuildMonad (
 
     -- * Setting up file monitoring
     monitorFiles,
-    MonitorFilePath(..),
+    MonitorFilePath,
+    monitorFile,
+    monitorFileHashed,
+    monitorNonExistentFile,
+    monitorDirectory,
+    monitorDirectoryExistence,
+    monitorFileOrDirectory,
     monitorFileSearchPath,
+    monitorFileHashedSearchPath,
+    -- ** Monitoring file globs
+    monitorFileGlob,
     FilePathGlob(..),
+    FilePathRoot(..),
+    FilePathGlobRel(..),
+    GlobPiece(..),
 
     -- * Using a file monitor
     FileMonitor(..),
@@ -29,8 +41,9 @@ module Distribution.Client.RebuildMonad (
     matchFileGlob,
   ) where
 
-import Distribution.Client.FileMonitor hiding (matchFileGlob)
-import qualified Distribution.Client.FileMonitor as FileMonitor (matchFileGlob)
+import Distribution.Client.FileMonitor
+import Distribution.Client.Glob hiding (matchFileGlob)
+import qualified Distribution.Client.Glob as Glob (matchFileGlob)
 
 import Distribution.Simple.Utils (debug)
 import Distribution.Verbosity    (Verbosity)
@@ -117,6 +130,6 @@ rerunIfChanged verbosity rootDir monitor key action = do
 --
 matchFileGlob :: FilePath -> FilePathGlob -> Rebuild [FilePath]
 matchFileGlob root glob = do
-    monitorFiles [MonitorFileGlob glob]
-    liftIO $ FileMonitor.matchFileGlob root glob
+    monitorFiles [monitorFileGlob glob]
+    liftIO $ Glob.matchFileGlob root glob
 

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -285,6 +285,7 @@ Test-Suite unit-tests
     UnitTests.Distribution.Client.Dependency.Modular.Solver
     UnitTests.Distribution.Client.Dependency.Modular.DSL
     UnitTests.Distribution.Client.FileMonitor
+    UnitTests.Distribution.Client.Glob
     UnitTests.Distribution.Client.GZipUtils
     UnitTests.Distribution.Client.Sandbox
     UnitTests.Distribution.Client.Sandbox.Timestamp

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -18,6 +18,7 @@ import qualified UnitTests.Distribution.Client.Compat.Time
 import qualified UnitTests.Distribution.Client.Dependency.Modular.PSQ
 import qualified UnitTests.Distribution.Client.Dependency.Modular.Solver
 import qualified UnitTests.Distribution.Client.FileMonitor
+import qualified UnitTests.Distribution.Client.Glob
 import qualified UnitTests.Distribution.Client.GZipUtils
 import qualified UnitTests.Distribution.Client.Sandbox
 import qualified UnitTests.Distribution.Client.Sandbox.Timestamp
@@ -45,6 +46,8 @@ tests mtimeChangeCalibrated =
         UnitTests.Distribution.Client.Dependency.Modular.Solver.tests
   , testGroup "UnitTests.Distribution.Client.FileMonitor" $
         UnitTests.Distribution.Client.FileMonitor.tests mtimeChange
+  , testGroup "UnitTests.Distribution.Client.Glob"
+        UnitTests.Distribution.Client.Glob.tests
   , testGroup "Distribution.Client.GZipUtils"
        UnitTests.Distribution.Client.GZipUtils.tests
   , testGroup "Distribution.Client.Sandbox"

--- a/cabal-install/tests/UnitTests/Distribution/Client/Glob.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Glob.hs
@@ -1,0 +1,202 @@
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module UnitTests.Distribution.Client.Glob (tests) where
+
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative
+#endif
+import Data.Char
+import Data.List
+import Distribution.Text (display, parse, simpleParse)
+import Distribution.Compat.ReadP
+
+import Distribution.Client.Glob
+import UnitTests.Distribution.Client.ArbitraryInstances
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Test.Tasty.HUnit
+import Control.Exception
+
+
+tests :: [TestTree]
+tests =
+  [ testProperty "print/parse roundtrip" prop_roundtrip_printparse
+  , testCase     "parse examples"        testParseCases
+  ]
+
+--TODO: [nice to have] tests for trivial globs, tests for matching,
+-- tests for windows style file paths
+
+prop_roundtrip_printparse :: FilePathGlob -> Bool
+prop_roundtrip_printparse pathglob =
+  -- can't use simpleParse because it mis-handles trailing spaces
+  case [ x | (x, []) <- readP_to_S parse (display pathglob) ] of
+    xs@(_:_) -> last xs == pathglob
+    _        -> False
+
+-- first run, where we don't even call updateMonitor
+testParseCases :: Assertion
+testParseCases = do
+
+  FilePathGlob FilePathUnixRoot GlobDirTrailing <- testparse "/"
+  FilePathGlob FilePathHomeDir  GlobDirTrailing <- testparse "~/"
+
+  FilePathGlob (FilePathWinDrive 'A') GlobDirTrailing <- testparse "A:/"
+  FilePathGlob (FilePathWinDrive 'Z') GlobDirTrailing <- testparse "z:/"
+  FilePathGlob (FilePathWinDrive 'C') GlobDirTrailing <- testparse "C:\\"
+  FilePathGlob FilePathRelative (GlobFile [Literal "_:"]) <- testparse "_:"
+
+  FilePathGlob FilePathRelative
+    (GlobFile [Literal "."]) <- testparse "."
+
+  FilePathGlob FilePathRelative
+    (GlobFile [Literal "~"]) <- testparse "~"
+
+  FilePathGlob FilePathRelative
+    (GlobDir  [Literal "."] GlobDirTrailing) <- testparse "./"
+
+  FilePathGlob FilePathRelative
+    (GlobFile [Literal "foo"]) <- testparse "foo"
+
+  FilePathGlob FilePathRelative
+    (GlobDir [Literal "foo"]
+      (GlobFile [Literal "bar"])) <- testparse "foo/bar"
+
+  FilePathGlob FilePathRelative
+    (GlobDir [Literal "foo"]
+      (GlobDir [Literal "bar"] GlobDirTrailing)) <- testparse "foo/bar/"
+
+  FilePathGlob FilePathUnixRoot
+    (GlobDir [Literal "foo"]
+      (GlobDir [Literal "bar"] GlobDirTrailing)) <- testparse "/foo/bar/"
+
+  FilePathGlob FilePathRelative
+    (GlobFile [WildCard]) <- testparse "*"
+
+  FilePathGlob FilePathRelative
+    (GlobFile [WildCard,WildCard]) <- testparse "**" -- not helpful but valid
+
+  FilePathGlob FilePathRelative
+    (GlobFile [WildCard, Literal "foo", WildCard]) <- testparse "*foo*"
+
+  FilePathGlob FilePathRelative
+    (GlobFile [Literal "foo", WildCard, Literal "bar"]) <- testparse "foo*bar"
+
+  FilePathGlob FilePathRelative
+    (GlobFile [Union [[WildCard], [Literal "foo"]]]) <- testparse "{*,foo}"
+
+  parseFail "{"
+  parseFail "}"
+  parseFail ","
+  parseFail "{"
+  parseFail "{{}"
+  parseFail "{}"
+  parseFail "{,}"
+  parseFail "{foo,}"
+  parseFail "{,foo}"
+
+  return ()
+
+testparse :: String -> IO FilePathGlob
+testparse s =
+    case simpleParse s of
+      Just p  -> return p
+      Nothing -> throwIO $ HUnitFailure ("expected parse of: " ++ s)
+
+parseFail :: String -> Assertion
+parseFail s =
+    case simpleParse s :: Maybe FilePathGlob of
+      Just _  -> throwIO $ HUnitFailure ("expected no parse of: " ++ s)
+      Nothing -> return ()
+
+instance Arbitrary FilePathGlob where
+  arbitrary = (FilePathGlob <$> arbitrary <*> arbitrary)
+                `suchThat` validFilePathGlob
+
+  shrink (FilePathGlob root pathglob) =
+    [ FilePathGlob root' pathglob'
+    | (root', pathglob') <- shrink (root, pathglob)
+    , validFilePathGlob (FilePathGlob root' pathglob') ]
+
+validFilePathGlob :: FilePathGlob -> Bool
+validFilePathGlob (FilePathGlob FilePathRelative pathglob) =
+  case pathglob of
+    GlobDirTrailing             -> False
+    GlobDir [Literal "~"] _     -> False
+    GlobDir [Literal (d:":")] _ 
+      | isLetter d              -> False
+    _                           -> True
+validFilePathGlob _ = True
+
+instance Arbitrary FilePathRoot where
+  arbitrary =
+    frequency
+      [ (3, pure FilePathRelative)
+      , (1, pure FilePathUnixRoot)
+      , (1, pure FilePathHomeDir)
+      , (1, FilePathWinDrive <$> choose ('A', 'Z'))
+      ]
+
+  shrink FilePathRelative     = []
+  shrink FilePathUnixRoot     = [FilePathRelative]
+  shrink FilePathHomeDir      = [FilePathRelative]
+  shrink (FilePathWinDrive d) = FilePathRelative
+                              : [ FilePathWinDrive d' | d' <- shrink d ]
+
+
+instance Arbitrary FilePathGlobRel where
+  arbitrary = sized $ \sz ->
+    oneof $ take (max 1 sz)
+      [ pure GlobDirTrailing
+      , GlobFile  <$> (getGlobPieces <$> arbitrary)
+      , GlobDir   <$> (getGlobPieces <$> arbitrary)
+                  <*> resize (sz `div` 2) arbitrary
+      ]
+
+  shrink GlobDirTrailing = []
+  shrink (GlobFile glob) =
+      GlobDirTrailing
+    : [ GlobFile (getGlobPieces glob') | glob' <- shrink (GlobPieces glob) ]
+  shrink (GlobDir glob pathglob) =
+      pathglob
+    : GlobFile glob
+    : [ GlobDir (getGlobPieces glob') pathglob'
+      | (glob', pathglob') <- shrink (GlobPieces glob, pathglob) ]
+
+newtype GlobPieces = GlobPieces { getGlobPieces :: [GlobPiece] }
+  deriving Eq
+
+instance Arbitrary GlobPieces where
+  arbitrary = GlobPieces . mergeLiterals <$> shortListOf1 5 arbitrary
+
+  shrink (GlobPieces glob) =
+    [ GlobPieces (mergeLiterals (getNonEmpty glob'))
+    | glob' <- shrink (NonEmpty glob) ]
+
+mergeLiterals :: [GlobPiece] -> [GlobPiece]
+mergeLiterals (Literal a : Literal b : ps) = mergeLiterals (Literal (a++b) : ps)
+mergeLiterals (Union as : ps) = Union (map mergeLiterals as) : mergeLiterals ps
+mergeLiterals (p:ps) = p : mergeLiterals ps
+mergeLiterals []     = []
+
+instance Arbitrary GlobPiece where
+  arbitrary = sized $ \sz ->
+    frequency
+      [ (3, Literal <$> shortListOf1 10 (elements globLiteralChars))
+      , (1, pure WildCard)
+      , (1, Union <$> resize (sz `div` 2) (shortListOf1 5 (shortListOf1 5 arbitrary)))
+      ]
+
+  shrink (Literal str) = [ Literal str'
+                         | str' <- shrink str
+                         , not (null str')
+                         , all (`elem` globLiteralChars) str' ]
+  shrink WildCard       = []
+  shrink (Union as)     = [ Union (map getGlobPieces (getNonEmpty as'))
+                          | as' <- shrink (NonEmpty (map GlobPieces as)) ]
+
+globLiteralChars :: [Char]
+globLiteralChars = ['\0'..'\128'] \\ "*{},/\\"
+

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -223,7 +223,8 @@ prop_roundtrip_printparse_specific config =
 
 prop_parsePackageLocationTokenQ :: PackageLocationString -> Bool
 prop_parsePackageLocationTokenQ (PackageLocationString str) =
-    case [ x | (x,"") <- Parse.readP_to_S parsePackageLocationTokenQ str ] of
+    case [ x | (x,"") <- Parse.readP_to_S parsePackageLocationTokenQ
+                                         (renderPackageLocationToken str) ] of
       [str'] -> str' == str
       _      -> False
 
@@ -259,8 +260,8 @@ instance Arbitrary PackageLocationString where
   arbitrary =
     PackageLocationString <$>
     oneof
-      [ --show <$> (arbitrary :: Gen String)
-        arbitraryGlobLikeStr
+      [ show . getNonEmpty <$> (arbitrary :: Gen (NonEmptyList String))
+      , arbitraryGlobLikeStr
       , show <$> (arbitrary :: Gen URI)
       ]
 


### PR DESCRIPTION
A bunch of improvements to file globs and the file monitor code. In particular the file globs can now be absolute with unix or windows paths, or home-dir relative. This is important since users can specify these in cabal.project files.

Also a bunch of improvements to make the file monitor code more regular and detect more kinds of changes.

More tests to cover everything.