### PR TITLE
Testing with GHC 7.0 and 7.2 AND some improvements to package-tests

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -346,6 +346,14 @@ library
   if !impl(ghc >= 7.0)
     default-extensions: CPP
 
+executable cabal-setup
+  build-depends: base, Cabal
+  main-is: Setup.hs
+  -- Actually, we don't really want anything from tests; just
+  -- want to make sure we don't pick up source files in .
+  hs-source-dirs: tests
+  default-language: Haskell98
+
 -- Small, fast running tests.
 test-suite unit-tests
   type: exitcode-stdio-1.0
@@ -384,6 +392,7 @@ test-suite package-tests
     PackageTests.TestSuiteTests.ExeV10.Check
     PackageTests.PackageTester
   hs-source-dirs: tests
+  build-tools: cabal-setup
   build-depends:
     base,
     containers,

--- a/Cabal/tests/PackageTests.hs
+++ b/Cabal/tests/PackageTests.hs
@@ -227,10 +227,6 @@ main = do
     putStrLn $ "CABAL_PACKAGETESTS_DB_STACK=" ++ showDBStack packageDBStack0
     putStrLn $ "CABAL_PACKAGETESTS_WITH_DB_STACK=" ++ showDBStack withGhcDBStack0
 
-    -- Create a shared Setup executable to speed up Simple tests
-    putStrLn $ "Building shared ./Setup executable"
-    rawCompileSetup verbosity suite [] "tests"
-
     defaultMainWithIngredients options $
         runTestTree "Package Tests" (tests suite)
 

--- a/Cabal/tests/PackageTests/PackageTester.hs
+++ b/Cabal/tests/PackageTests/PackageTester.hs
@@ -277,7 +277,7 @@ type PackageSpec = FilePath
 simpleSetupPath :: TestM FilePath
 simpleSetupPath = do
     (suite, _) <- ask
-    return (absoluteCWD suite </> "tests/Setup")
+    return (cabalDistPref suite </> "build" </> "cabal-setup" </> "cabal-setup")
 
 -- | The absolute path to the directory containing the files for
 -- this tests; usually @Check.hs@ and any test packages.


### PR DESCRIPTION
In the process, I refactored the test suite a bit to be more robust
and handle the --with-compiler more correctly in most cases.

One note: I turned off the HPC tests with the GHC and WITH_GHC
parameters don't match.  In principle this should work but there
is some sort of bug.  I don't plan on fixing the bug.

UPDATE: This patch set now also has some refactorings to try to eliminate the LBI parsing nonsense, by using `build-tools` as per #220.