### PR TITLE
Have Cabal build a Setup executable and test with it.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -342,6 +342,14 @@ library
   if !impl(ghc >= 7.0)
     default-extensions: CPP
 
+executable cabal-setup
+  build-depends: base, Cabal
+  main-is: Setup.hs
+  -- Actually, we don't really want anything from tests; just
+  -- want to make sure we don't pick up source files in .
+  hs-source-dirs: tests
+  default-language: Haskell98
+
 -- Small, fast running tests.
 test-suite unit-tests
   type: exitcode-stdio-1.0
@@ -380,6 +388,7 @@ test-suite package-tests
     PackageTests.TestSuiteTests.ExeV10.Check
     PackageTests.PackageTester
   hs-source-dirs: tests
+  build-tools: cabal-setup
   build-depends:
     base,
     containers,

--- a/Cabal/tests/PackageTests.hs
+++ b/Cabal/tests/PackageTests.hs
@@ -187,10 +187,6 @@ main = do
                     (showPackageDbList (uninterpretPackageDBFlags
                                         packageDBStack0)))
 
-    -- Create a shared Setup executable to speed up Simple tests
-    putStrLn $ "Building shared ./Setup executable"
-    rawCompileSetup verbosity suite [] "tests"
-
     defaultMainWithIngredients options $
         runTestTree "Package Tests" (tests suite)
 

--- a/Cabal/tests/PackageTests/PackageTester.hs
+++ b/Cabal/tests/PackageTests/PackageTester.hs
@@ -204,7 +204,7 @@ type PackageSpec = FilePath
 simpleSetupPath :: TestM FilePath
 simpleSetupPath = do
     (suite, _) <- ask
-    return (absoluteCWD suite </> "tests/Setup")
+    return (cabalDistPref suite </> "build" </> "cabal-setup" </> "cabal-setup")
 
 -- | The absolute path to the directory containing the files for
 -- this tests; usually @Check.hs@ and any test packages.


### PR DESCRIPTION
I recently discovered that build-tools can be used to specify
dependencies on internal executables (#220).  This means that
we can make a nice improvement to the package-tests test suite:
instead of manually building a Setup.hs script ourselves,
we can add one to the Cabal file for Cabal, and have the
test suite have a build-tools dependency on it.

Perhaps the only objection to this is that the Cabal *library*
now has an executable cabal-setup.  Maybe with some buildable
shenanigans we can make it so that we never build this executable
unless the user asks for it, or the test suite is enabled.
Alternately, cabal-setup is a generally handy executable to have
around.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>