### PR TITLE
Correctly link setup dependencies of linked packages

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Linking.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Linking.hs
@@ -30,7 +30,7 @@ import Distribution.Client.Dependency.Modular.Tree
 import qualified Distribution.Client.Dependency.Modular.PSQ as P
 
 import Distribution.Client.Types (OptionalStanza(..))
-import Distribution.Client.ComponentDeps (Component)
+import Distribution.Client.ComponentDeps (Component(ComponentSetup))
 
 {-------------------------------------------------------------------------------
   Add linking
@@ -198,7 +198,7 @@ conflict = lift' . Left
 execUpdateState :: UpdateState () -> ValidateState -> Either Conflict ValidateState
 execUpdateState = execStateT . unUpdateState
 
-pickPOption :: QPN -> POption -> FlaggedDeps comp QPN -> UpdateState ()
+pickPOption :: QPN -> POption -> FlaggedDeps Component QPN -> UpdateState ()
 pickPOption qpn (POption i Nothing)    _deps = pickConcrete qpn i
 pickPOption qpn (POption i (Just pp'))  deps = pickLink     qpn i pp' deps
 
@@ -216,7 +216,7 @@ pickConcrete qpn@(Q pp _) i = do
       Just lg ->
         makeCanonical lg qpn i
 
-pickLink :: QPN -> I -> PP -> FlaggedDeps comp QPN -> UpdateState ()
+pickLink :: QPN -> I -> PP -> FlaggedDeps Component QPN -> UpdateState ()
 pickLink qpn@(Q pp pn) i pp' deps = do
     vs <- get
     -- Find the link group for the package we are linking to, and add this package
@@ -263,10 +263,12 @@ makeCanonical lg qpn@(Q pp _) i =
 -- because having the direct dependencies in a link group means that we must
 -- have already made or will make sooner or later a link choice for one of these
 -- as well, and cover their dependencies at that point.
-linkDeps :: [Var QPN] -> PP -> FlaggedDeps comp QPN -> UpdateState ()
+linkDeps :: [Var QPN] -> PP -> FlaggedDeps Component QPN -> UpdateState ()
 linkDeps parents pp' = mapM_ go
   where
-    go :: FlaggedDep comp QPN -> UpdateState ()
+    go :: FlaggedDep Component QPN -> UpdateState ()
+    -- Skip setup dependencies.
+    go (Simple _ ComponentSetup) = return ()
     go (Simple (Dep qpn@(Q _ pn) _) _) = do
       vs <- get
       let qpn' = Q pp' pn

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -57,14 +57,15 @@ tests = [
         , runTest $ indep $ mkTest db6 "depsWithTests2" ["C", "D"] (Just [("A", 1), ("B", 1), ("C", 1), ("D", 1)])
         ]
     , testGroup "Setup dependencies" [
-          runTest $ mkTest db7  "setupDeps1" ["B"] (Just [("A", 2), ("B", 1)])
-        , runTest $ mkTest db7  "setupDeps2" ["C"] (Just [("A", 2), ("C", 1)])
-        , runTest $ mkTest db7  "setupDeps3" ["D"] (Just [("A", 1), ("D", 1)])
-        , runTest $ mkTest db7  "setupDeps4" ["E"] (Just [("A", 1), ("A", 2), ("E", 1)])
-        , runTest $ mkTest db7  "setupDeps5" ["F"] (Just [("A", 1), ("A", 2), ("F", 1)])
-        , runTest $ mkTest db8  "setupDeps6" ["C", "D"] (Just [("A", 1), ("B", 1), ("B", 2), ("C", 1), ("D", 1)])
-        , runTest $ mkTest db9  "setupDeps7" ["F", "G"] (Just [("A", 1), ("B", 1), ("B",2 ), ("C", 1), ("D", 1), ("E", 1), ("E", 2), ("F", 1), ("G", 1)])
-        , runTest $ mkTest db10 "setupDeps8" ["C"] (Just [("C", 1)])
+          runTest $         mkTest db7  "setupDeps1" ["B"] (Just [("A", 2), ("B", 1)])
+        , runTest $         mkTest db7  "setupDeps2" ["C"] (Just [("A", 2), ("C", 1)])
+        , runTest $         mkTest db7  "setupDeps3" ["D"] (Just [("A", 1), ("D", 1)])
+        , runTest $         mkTest db7  "setupDeps4" ["E"] (Just [("A", 1), ("A", 2), ("E", 1)])
+        , runTest $         mkTest db7  "setupDeps5" ["F"] (Just [("A", 1), ("A", 2), ("F", 1)])
+        , runTest $         mkTest db8  "setupDeps6" ["C", "D"] (Just [("A", 1), ("B", 1), ("B", 2), ("C", 1), ("D", 1)])
+        , runTest $         mkTest db9  "setupDeps7" ["F", "G"] (Just [("A", 1), ("B", 1), ("B",2 ), ("C", 1), ("D", 1), ("E", 1), ("E", 2), ("F", 1), ("G", 1)])
+        , runTest $         mkTest db10 "setupDeps8" ["C"] (Just [("C", 1)])
+        , runTest $ indep $ mkTest dbSetupDeps "setupDeps9" ["A", "B"] (Just [("A", 1), ("B", 1), ("C", 1), ("D", 1), ("D", 2)])
         ]
     , testGroup "Base shim" [
           runTest $ mkTest db11 "baseShim1" ["A"] (Just [("A", 1)])
@@ -424,6 +425,23 @@ db10 =
     , Left a2
     , Right $ exAv "C" 1 [ExFix "A" 2] `withSetupDeps` [ExFix "A" 1]
     ]
+
+-- | This database tests that linking a package does not also link the package's
+-- setup dependencies.
+--
+-- When A and B are installed as independent goals, their dependencies on C must
+-- be linked, due to the single instance restriction. Since C depends on D, 0.D
+-- and 1.D must also be linked. However, C's setup dependency on D should remain
+-- independent. The solver should be able to choose D-1 for C's library and D-2
+-- for C's setup script.
+dbSetupDeps :: ExampleDb
+dbSetupDeps = [
+    Right $ exAv "A" 1 [ExAny "C"]
+  , Right $ exAv "B" 1 [ExAny "C"]
+  , Right $ exAv "C" 1 [ExFix "D" 1] `withSetupDeps` [ExFix "D" 2]
+  , Right $ exAv "D" 1 []
+  , Right $ exAv "D" 2 []
+  ]
 
 -- | Tests for dealing with base shims
 db11 :: ExampleDb


### PR DESCRIPTION
When the solver links a package, it also merges the `LinkGroup`s of the package's direct dependencies.  This commit causes the solver to skip setup dependencies, which should remain independent of the package's other dependencies.

Here is the test's log without the fix.  It shows a `LinkGroup` containing both setup and non-setup goals for package `D`, which causes the solver to reject `D-2` for `C`'s setup script.

```
targets: A, B
      setupDeps9:                                       constraints:
  stanzas A test (unknown source)
  stanzas B test (unknown source)
  stanzas C test (unknown source)
  stanzas D test (unknown source)
  stanzas D test (unknown source)
preferences:
strategy: PreferLatestForSelected
reorder goals: False
independent goals: True
avoid reinstalls: False
shadow packages: False
strong flags: False
max backjumps: infinite
[__0] trying: 0.A-1.0.0 (user goal)
[__1] trying: 0.C-1.0.0 (dependency of 0.A-1.0.0)
[__2] next goal: 0.D (dependency of 0.C-1.0.0)
[__2] rejecting: 0.D-2.0.0 (conflict: 0.C => 0.D==1.0.0)
[__2] trying: 0.D-1.0.0
[__3] trying: 1.B-1.0.0 (user goal)
[__4] trying: 1.C~>0.C-1.0.0 (dependency of 1.B-1.0.0)
[__5] trying: 1.D~>0.D-1.0.0 (dependency of 1.C-1.0.0)
[__6] next goal: C-setup.1.D (dependency of 1.C-1.0.0)
[__6] rejecting: C-setup.1.D~>1.D-1.0.0, C-setup.1.D~>0.D-1.0.0 (conflict: 1.C => C-setup.1.D==2.0.0)
[__6] rejecting: C-setup.1.D-2.0.0 (dependencies not linked: cannot make C-setup.1.D canonical member of {*0.D-1.0.0,1.D-1.0.0,C-setup.1.D-1.0.0}; conflict set: 1.C, C-setup.1.D)
[__6] rejecting: C-setup.1.D-1.0.0 (multiple instances)
[__5] fail (backjumping, conflict set: 0.D, 1.B, 1.C, C-setup.1.D)
[__4] rejecting: 1.C-1.0.0 (multiple instances)
[__3] fail (backjumping, conflict set: 0.C, 0.D, 1.B, 1.C, C-setup.1.D)
[__0] fail (backjumping, conflict set: 0.A, 0.C, 0.D, 1.B, 1.C, C-setup.1.D)
FAIL
```