### PR TITLE
Fix bash-completion after "--"

### DIFF
--- a/cabal-install/bash-completion/cabal
+++ b/cabal-install/bash-completion/cabal
@@ -55,11 +55,16 @@ _cabal_subcommands()
 
 __cabal_has_doubledash ()
 {
-    for w in "${COMP_WORDS[@]}"
-    do
-        if [ "--" == "$w" ]; then
+    local c=1
+    # Ignore the last word, because it is replaced anyways.
+    # This allows expansion for flags on "cabal foo --",
+    # but does not try to complete after "cabal foo -- ".
+    local n=$((${#COMP_WORDS[@]} - 1))
+    while [ $c -lt $n ]; do
+        if [ "--" = "${COMP_WORDS[c]}" ]; then
             return 0
         fi
+        ((c++))
     done
     return 1
 }


### PR DESCRIPTION
#3272 accidentally disabled completions at the start of flags,
e.g. on "cabal install --".
[CI SKIP]

(I shouldn't have considered more why git did not use a for-loop - because it was not a for loop.)

(Tested all of "cabal run", "cabal run -", "cabal run --", "cabal run -- ". This change does not seem to break #3271 again.)

Sorry for the noise.
