### PR TITLE
Delete FakeMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ progress.txt
 
 # test files
 dist-test
+register.sh

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -10,7 +10,50 @@
 -- Maintainer  :  cabal-devel@haskell.org
 -- Portability :  portable
 --
--- An index of packages.
+-- An index of packages whose primary key is 'UnitId'.  Public libraries
+-- are additionally indexed by 'PackageName' and 'Version'.
+-- Technically, these are an index of *units* (so we should eventually
+-- rename it to 'UnitIndex'); but in the absence of internal libraries
+-- or Backpack each unit is equivalent to a package.
+--
+-- 'PackageIndex' is parametric over what it actually records, and it
+-- is used in two ways:
+--
+--      * The 'InstalledPackageIndex' (defined here) contains a graph of
+--        'InstalledPackageInfo's representing the packages in a
+--        package database stack.  It is used in a variety of ways:
+--
+--          * The primary use to let Cabal access the same installed
+--            package database which is used by GHC during compilation.
+--            For example, this data structure is used by 'ghc-pkg'
+--            and 'Cabal' to do consistency checks on the database
+--            (are the references closed).
+--
+--          * Given a set of dependencies, we can compute the transitive
+--            closure of dependencies.  This is to check if the versions
+--            of packages are consistent, and also needed by multiple
+--            tools (Haddock must be explicitly told about the every
+--            transitive package to do cross-package linking;
+--            preprocessors must know about the include paths of all
+--            transitive dependencies.)
+--
+--      * The 'PlanIndex' (defined in 'Distribution.Client.InstallPlan'),
+--        contains a graph of 'GenericPlanPackage'.  Ignoring its type
+--        parameters for a moment, a 'PlanIndex' is an extension of the
+--        'InstalledPackageIndex' to also record nodes for packages
+--        which are *planned* to be installed, but not actually
+--        installed yet.  A 'PlanIndex' containing only 'PreExisting'
+--        packages is essentially a 'PackageIndex'.
+--
+--        'PlanIndex'es actually require some auxiliary information, so
+--        most users interact with a 'GenericInstallPlan'.  This type is
+--        specialized as an 'ElaboratedInstallPlan' (for @cabal
+--        new-build@) or an 'InstallPlan' (for @cabal install@).
+--
+-- This 'PackageIndex' is NOT to be confused with
+-- 'Distribution.Client.PackageIndex', which indexes packages only by
+-- 'PackageName' (this makes it suitable for indexing source packages,
+-- for which we don't know 'UnitId's.)
 --
 module Distribution.Simple.PackageIndex (
   -- * Package index data type

--- a/cabal-install/Distribution/Client/BuildReports/Storage.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Storage.hs
@@ -132,7 +132,7 @@ fromPlanPackage :: Platform -> CompilerId
                 -> InstallPlan.PlanPackage
                 -> Maybe (BuildReport, Maybe Repo)
 fromPlanPackage (Platform arch os) comp planPackage = case planPackage of
-  InstallPlan.Installed (ReadyPackage (ConfiguredPackage srcPkg flags _ deps))
+  InstallPlan.Installed (ReadyPackage (ConfiguredPackage _ srcPkg flags _ deps))
                          _ result
     -> Just $ ( BuildReport.new os arch comp
                                 (packageId srcPkg) flags
@@ -140,7 +140,7 @@ fromPlanPackage (Platform arch os) comp planPackage = case planPackage of
                                 (Right result)
               , extractRepo srcPkg)
 
-  InstallPlan.Failed (ConfiguredPackage srcPkg flags _ deps) result
+  InstallPlan.Failed (ConfiguredPackage _ srcPkg flags _ deps) result
     -> Just $ ( BuildReport.new os arch comp
                                 (packageId srcPkg) flags
                                 (map confSrcId (CD.nonSetupDeps deps))

--- a/cabal-install/Distribution/Client/BuildReports/Storage.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Storage.hs
@@ -132,7 +132,7 @@ fromPlanPackage :: Platform -> CompilerId
                 -> InstallPlan.PlanPackage
                 -> Maybe (BuildReport, Maybe Repo)
 fromPlanPackage (Platform arch os) comp planPackage = case planPackage of
-  InstallPlan.Installed (ReadyPackage (ConfiguredPackage srcPkg flags _ _) deps)
+  InstallPlan.Installed (ReadyPackage (ConfiguredPackage srcPkg flags _ deps))
                          _ result
     -> Just $ ( BuildReport.new os arch comp
                                 (packageId srcPkg) flags

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -134,7 +134,7 @@ configure verbosity packageDBs repoCtxt comp platform conf
      let installPlan = InstallPlan.configureInstallPlan installPlan0
      in case InstallPlan.ready installPlan of
       [pkg@(ReadyPackage
-              (ConfiguredPackage (SourcePackage _ _ (LocalUnpackedPackage _) _)
+              (ConfiguredPackage _ (SourcePackage _ _ (LocalUnpackedPackage _) _)
                                  _ _ _))] -> do
         configurePackage verbosity
           platform (compilerInfo comp)
@@ -346,7 +346,7 @@ configurePackage :: Verbosity
                  -> [String]
                  -> IO ()
 configurePackage verbosity platform comp scriptOptions configFlags
-                 (ReadyPackage (ConfiguredPackage spkg flags stanzas deps))
+                 (ReadyPackage (ConfiguredPackage ipid spkg flags stanzas deps))
                  extraArgs =
 
   setupWrapper verbosity
@@ -355,6 +355,7 @@ configurePackage verbosity platform comp scriptOptions configFlags
   where
     gpkg = packageDescription spkg
     configureFlags   = filterConfigureFlags configFlags {
+      configIPID = toFlag (display ipid),
       configConfigurationsFlags = flags,
       -- We generate the legacy constraints as well as the new style precise
       -- deps.  In the end only one set gets passed to Setup.hs configure,

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -23,7 +23,7 @@ import Distribution.Client.Dependency.Types
          ( ConstraintSource(..)
          , LabeledPackageConstraint(..), showConstraintSource )
 import qualified Distribution.Client.InstallPlan as InstallPlan
-import Distribution.Client.InstallPlan (InstallPlan)
+import Distribution.Client.InstallPlan (SolverInstallPlan)
 import Distribution.Client.IndexUtils as IndexUtils
          ( getSourcePackages, getInstalledPackages )
 import Distribution.Client.PackageIndex ( PackageIndex, elemByPackageName )
@@ -130,9 +130,11 @@ configure verbosity packageDBs repoCtxt comp platform conf
       setupWrapper verbosity (setupScriptOptions installedPkgIndex Nothing)
         Nothing configureCommand (const configFlags) extraArgs
 
-    Right installPlan -> case InstallPlan.ready installPlan of
+    Right installPlan0 ->
+     let installPlan = InstallPlan.configureInstallPlan installPlan0
+     in case InstallPlan.ready installPlan of
       [pkg@(ReadyPackage
-             (ConfiguredPackage (SourcePackage _ _ (LocalUnpackedPackage _) _)
+              (ConfiguredPackage (SourcePackage _ _ (LocalUnpackedPackage _) _)
                                  _ _ _))] -> do
         configurePackage verbosity
           platform (compilerInfo comp)
@@ -269,7 +271,7 @@ planLocalPackage :: Verbosity -> Compiler
                  -> InstalledPackageIndex
                  -> SourcePackageDb
                  -> PkgConfigDb
-                 -> IO (Progress String String InstallPlan)
+                 -> IO (Progress String String SolverInstallPlan)
 planLocalPackage verbosity comp platform configFlags configExFlags
   installedPkgIndex (SourcePackageDb _ packagePrefs) pkgConfigDb = do
   pkg <- readPackageDescription verbosity =<< defaultPackageDesc verbosity

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -20,9 +20,9 @@ import qualified Distribution.Client.Dependency.TopDown.Constraints as Constrain
 import Distribution.Client.Dependency.TopDown.Constraints
          ( Satisfiable(..) )
 import Distribution.Client.Types
-         ( SourcePackage(..), ConfiguredPackage(..)
+         ( SourcePackage(..), SolverPackage(..)
          , UnresolvedPkgLoc, UnresolvedSourcePackage
-         , enableStanzas, ConfiguredId(..), fakeUnitId )
+         , enableStanzas, SolverId(..) )
 import Distribution.Client.Dependency.Types
          ( DependencyResolver, ResolverPackage(..)
          , PackageConstraint(..), unlabelPackageConstraint
@@ -612,11 +612,11 @@ finaliseSelectedPackages pref selected constraints =
 
     finaliseInstalled (InstalledPackageEx pkg _ _) = SelectedInstalled pkg
     finaliseSource mipkg (SemiConfiguredPackage pkg flags stanzas deps) =
-        SelectedSource (ConfiguredPackage pkg flags stanzas deps')
+        SelectedSource (SolverPackage pkg flags stanzas deps')
       where
         -- We cheat in the cabal solver, and classify all dependencies as
         -- library dependencies.
-        deps' :: ComponentDeps [ConfiguredId]
+        deps' :: ComponentDeps [SolverId]
         deps' = CD.fromLibraryDeps (unPackageName (packageName pkg))
                                    (map (confId . pickRemaining mipkg) deps)
 
@@ -624,32 +624,10 @@ finaliseSelectedPackages pref selected constraints =
     -- available, or an installed one, or both. In the case that we have both
     -- available, we don't yet know if we can pick the installed one (the
     -- dependencies may not match up, for instance); this is verified in
-    -- `improvePlan`.
-    --
-    -- This means that at this point we cannot construct a valid installed
-    -- package ID yet for the dependencies. We therefore have two options:
-    --
-    -- * We could leave the installed package ID undefined here, and have a
-    --   separate pass over the output of the top-down solver, fixing all
-    --   dependencies so that if we depend on an already installed package we
-    --   use the proper installed package ID.
-    --
-    -- * We can _always_ use fake installed IDs, irrespective of whether we the
-    --   dependency is on an already installed package or not. This is okay
-    --   because (i) the top-down solver does not (and never will) support
-    --   multiple package instances, and (ii) we initialize the FakeMap with
-    --   fake IDs for already installed packages.
-    --
-    -- For now we use the second option; if however we change the implementation
-    -- of these fake IDs so that we do away with the FakeMap and update a
-    -- package reverse dependencies as we execute the install plan and discover
-    -- real package IDs, then this is no longer possible and we have to
-    -- implement the first option (see also Note [FakeMap] in Cabal).
-    confId :: InstalledOrSource InstalledPackageEx UnconfiguredPackage -> ConfiguredId
-    confId pkg = ConfiguredId {
-        confSrcId  = packageId pkg
-      , confInstId = fakeUnitId (packageId pkg)
-      }
+    -- `improvePlan`.  So we just set everything to be a planned ID for
+    -- now.
+    confId :: InstalledOrSource InstalledPackageEx UnconfiguredPackage -> SolverId
+    confId pkg = PlannedId (packageId pkg)
 
     pickRemaining mipkg dep@(Dependency _name versionRange) =
           case PackageIndex.lookupDependency remainingChoices dep of

--- a/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown/Types.hs
@@ -14,9 +14,8 @@
 module Distribution.Client.Dependency.TopDown.Types where
 
 import Distribution.Client.Types
-         ( ConfiguredPackage(..)
-         , UnresolvedPkgLoc, UnresolvedSourcePackage
-         , OptionalStanza, ConfiguredId(..) )
+         ( UnresolvedPkgLoc, UnresolvedSourcePackage
+         , OptionalStanza, SolverPackage(..), SolverId(..) )
 import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo )
 import qualified Distribution.Client.ComponentDeps as CD
@@ -45,7 +44,7 @@ data InstalledOrSource installed source
 
 data FinalSelectedPackage
    = SelectedInstalled InstalledPackage
-   | SelectedSource    (ConfiguredPackage UnresolvedPkgLoc)
+   | SelectedSource    (SolverPackage UnresolvedPkgLoc)
 
 type TopologicalSortNumber = Int
 
@@ -68,6 +67,7 @@ data UnconfiguredPackage
        FlagAssignment
        [OptionalStanza]
 
+-- | This is a minor misnomer: it's more of a 'SemiSolverPackage'.
 data SemiConfiguredPackage
    = SemiConfiguredPackage
        UnresolvedSourcePackage           -- package info
@@ -132,8 +132,8 @@ class Package a => PackageSourceDeps a where
 instance PackageSourceDeps InstalledPackageEx where
   sourceDeps (InstalledPackageEx _ _ deps) = deps
 
-instance PackageSourceDeps (ConfiguredPackage loc) where
-  sourceDeps cpkg = map confSrcId $ CD.nonSetupDeps (confPkgDeps cpkg)
+instance PackageSourceDeps (SolverPackage loc) where
+  sourceDeps pkg = map solverSrcId $ CD.nonSetupDeps (solverPkgDeps pkg)
 
 instance PackageSourceDeps InstalledPackage where
   sourceDeps (InstalledPackage _ deps) = deps

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -52,7 +52,7 @@ import Data.Monoid
 import Distribution.Client.PkgConfigDb
          ( PkgConfigDb )
 import Distribution.Client.Types
-         ( OptionalStanza(..), SourcePackage(..), ConfiguredPackage )
+         ( OptionalStanza(..), SourcePackage(..), SolverPackage )
 
 import qualified Distribution.Compat.ReadP as Parse
          ( pfail, munch1 )
@@ -129,7 +129,7 @@ type DependencyResolver loc = Platform
 -- This is like the 'InstallPlan.PlanPackage' but with fewer cases.
 --
 data ResolverPackage loc = PreExisting InstalledPackageInfo
-                         | Configured  (ConfiguredPackage loc)
+                         | Configured  (SolverPackage loc)
 
 -- | Per-package constraints. Package constraints must be respected by the
 -- solver. Multiple constraints for each package can be given, though obviously

--- a/cabal-install/Distribution/Client/Fetch.hs
+++ b/cabal-install/Distribution/Client/Fetch.hs
@@ -138,7 +138,7 @@ planPackages verbosity comp platform fetchFlags
       -- The packages we want to fetch are those packages the 'InstallPlan'
       -- that are in the 'InstallPlan.Configured' state.
       return
-        [ confPkgSource cpkg
+        [ solverPkgSource cpkg
         | (InstallPlan.Configured cpkg)
             <- InstallPlan.toList installPlan ]
 

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -25,7 +25,7 @@ import Distribution.Client.Dependency.Types
 import Distribution.Client.IndexUtils as IndexUtils
          ( getSourcePackages, getInstalledPackages )
 import Distribution.Client.InstallPlan
-         ( InstallPlan, PlanPackage )
+         ( SolverInstallPlan, SolverPlanPackage )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.PkgConfigDb
          ( PkgConfigDb, readPkgConfigDb )
@@ -116,7 +116,7 @@ getFreezePkgs :: Verbosity
               -> Maybe SandboxPackageInfo
               -> GlobalFlags
               -> FreezeFlags
-              -> IO [PlanPackage]
+              -> IO [SolverPlanPackage]
 getFreezePkgs verbosity packageDBs repoCtxt comp platform conf mSandboxPkgInfo
       globalFlags freezeFlags = do
 
@@ -151,7 +151,7 @@ planPackages :: Verbosity
              -> SourcePackageDb
              -> PkgConfigDb
              -> [PackageSpecifier UnresolvedSourcePackage]
-             -> IO [PlanPackage]
+             -> IO [SolverPlanPackage]
 planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
              installedPkgIndex sourcePkgDb pkgConfigDb pkgSpecifiers = do
 
@@ -214,9 +214,9 @@ planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
 -- 2) not a dependency (directly or transitively) of the package we are
 --    freezing.  This is useful for removing previously installed packages
 --    which are no longer required from the install plan.
-pruneInstallPlan :: InstallPlan
+pruneInstallPlan :: SolverInstallPlan
                  -> [PackageSpecifier UnresolvedSourcePackage]
-                 -> [PlanPackage]
+                 -> [SolverPlanPackage]
 pruneInstallPlan installPlan pkgSpecifiers =
     removeSelf pkgIds $
     InstallPlan.dependencyClosure installPlan (map fakeUnitId pkgIds)

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -554,7 +554,14 @@ checkPrintPlan verbosity installed installPlan sourcePkgDb
     dryRun            = fromFlag (installDryRun            installFlags)
     overrideReinstall = fromFlag (installOverrideReinstall installFlags)
 
---TODO: this type is too specific
+-- | Given an 'InstallPlan', perform a dry run, producing the sequence
+-- of 'ReadyPackage's which would be compiled in order to carry
+-- out this plan.  This function is not actually used to execute a plan;
+-- presently, it is used only to (1) determine if the installation
+-- plan would cause reinstalls and (2) to print out what would be
+-- installed.
+--
+-- TODO: this type is too specific
 linearizeInstallPlan :: InstalledPackageIndex
                      -> InstallPlan
                      -> [(ReadyPackage, PackageStatus)]
@@ -568,7 +575,7 @@ linearizeInstallPlan installedPkgIndex plan =
           pkgid  = installedUnitId pkg
           status = packageStatus installedPkgIndex pkg
           ipkg   = Installed.emptyInstalledPackageInfo {
-                     Installed.sourcePackageId    = packageId pkg,
+                     Installed.sourcePackageId = packageId pkg,
                      Installed.installedUnitId = pkgid
                    }
           plan'' = InstallPlan.completed pkgid (Just ipkg)
@@ -577,7 +584,8 @@ linearizeInstallPlan installedPkgIndex plan =
           --FIXME: This is a bit of a hack,
           -- pretending that each package is installed
           -- It's doubly a hack because the installed package ID
-          -- didn't get updated...
+          -- didn't get updated.  But it doesn't really matter
+          -- because we're not going to use this for anything real.
 
 data PackageStatus = NewPackage
                    | NewVersion [Version]

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1415,12 +1415,15 @@ installUnpackedPackage verbosity buildLimit installLock numJobs
                     ++ " with the latest revision from the index."
       writeFileAtomic descFilePath pkgtxt
 
-  -- Compute the IPID
+  -- Compute the IPID of the *library*
   let flags (ReadyPackage cpkg _) = confPkgFlags cpkg
       pkg_name = pkgName (PackageDescription.package pkg)
-      cid = Configure.computeComponentId Cabal.NoFlag
-                (PackageDescription.package pkg) (CLibName (display pkg_name))
-                (map (\(SimpleUnitId cid0) -> cid0) (CD.libraryDeps (depends rpkg))) (flags rpkg)
+      cid = Configure.computeComponentId
+                Cabal.NoFlag -- This would let us override the computation
+                (PackageDescription.package pkg)
+                (CLibName (display pkg_name))
+                (map (\(SimpleUnitId cid0) -> cid0) (CD.libraryDeps (depends rpkg)))
+                (flags rpkg)
       ipid = SimpleUnitId cid
 
   -- Make sure that we pass --libsubdir etc to 'setup configure' (necessary if

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -66,16 +66,17 @@ import Distribution.Client.Types
          , PackageFixedDeps(..)
          , ConfiguredPackage(..), ConfiguredId(..)
          , UnresolvedPkgLoc, SolverPackage(..)
-         , GenericReadyPackage(..), fakeUnitId )
+         , GenericReadyPackage(..) )
 import Distribution.Version
          ( Version )
 import Distribution.Client.ComponentDeps (ComponentDeps)
 import qualified Distribution.Client.ComponentDeps as CD
 import Distribution.Simple.PackageIndex
          ( PackageIndex )
+import qualified Distribution.Simple.Configure as Configure
+import qualified Distribution.Simple.Setup as Cabal
+import qualified Distribution.PackageDescription as PD
 import qualified Distribution.Simple.PackageIndex as PackageIndex
-import Distribution.Client.PlanIndex
-         ( FakeMap )
 import qualified Distribution.Client.PlanIndex as PlanIndex
 import Distribution.Text
          ( display )
@@ -200,7 +201,6 @@ instance (HasUnitId ipkg, HasUnitId srcpkg) =>
 
 data GenericInstallPlan ipkg srcpkg iresult ifailure = GenericInstallPlan {
     planIndex      :: !(PlanIndex ipkg srcpkg iresult ifailure),
-    planFakeMap    :: !FakeMap,
     planIndepGoals :: !Bool,
 
     -- | Cached (lazily) graph
@@ -253,11 +253,22 @@ configureInstallPlan solverPlan =
                            -> ConfiguredPackage UnresolvedPkgLoc
     configureSolverPackage mapDep spkg =
       ConfiguredPackage {
+        confPkgId = SimpleUnitId
+                  $ Configure.computeComponentId
+                        Cabal.NoFlag
+                        (packageId spkg)
+                        (PD.CLibName (display (pkgName (packageId spkg))))
+                        -- TODO: this is a hack that won't work for Backpack.
+                        (map ((\(SimpleUnitId cid0) -> cid0) . confInstId)
+                             (CD.libraryDeps deps))
+                        (solverPkgFlags spkg),
         confPkgSource = solverPkgSource spkg,
         confPkgFlags  = solverPkgFlags spkg,
         confPkgStanzas = solverPkgStanzas spkg,
-        confPkgDeps   = fmap (map (configureSolverId mapDep)) (solverPkgDeps spkg)
+        confPkgDeps   = deps
       }
+      where
+        deps = fmap (map (configureSolverId mapDep)) (solverPkgDeps spkg)
 
     configureSolverId mapDep sid =
       ConfiguredId {
@@ -277,8 +288,7 @@ invariant :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
               HasUnitId srcpkg, PackageFixedDeps srcpkg)
           => GenericInstallPlan ipkg srcpkg iresult ifailure -> Bool
 invariant plan =
-    valid (planFakeMap plan)
-          (planIndepGoals plan)
+    valid (planIndepGoals plan)
           (planIndex plan)
 
 -- | Smart constructor that deals with caching the 'Graph' representation.
@@ -286,13 +296,11 @@ invariant plan =
 mkInstallPlan :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
                   HasUnitId srcpkg, PackageFixedDeps srcpkg)
               => PlanIndex ipkg srcpkg iresult ifailure
-              -> FakeMap
               -> Bool
               -> GenericInstallPlan ipkg srcpkg iresult ifailure
-mkInstallPlan index fakeMap indepGoals =
+mkInstallPlan index indepGoals =
     GenericInstallPlan {
       planIndex      = index,
-      planFakeMap    = fakeMap,
       planIndepGoals = indepGoals,
 
       -- lazily cache the graph stuff:
@@ -303,7 +311,7 @@ mkInstallPlan index fakeMap indepGoals =
     }
   where
     (graph, vertexToPkgId, pkgIdToVertex) =
-      PlanIndex.dependencyGraph fakeMap index
+      PlanIndex.dependencyGraph index
     noSuchPkgId = internalError "package is not in the graph"
 
 internalError :: String -> a
@@ -315,13 +323,12 @@ instance (HasUnitId ipkg,   PackageFixedDeps ipkg,
        => Binary (GenericInstallPlan ipkg srcpkg iresult ifailure) where
     put GenericInstallPlan {
               planIndex      = index,
-              planFakeMap    = fakeMap,
               planIndepGoals = indepGoals
-        } = put (index, fakeMap, indepGoals)
+        } = put (index, indepGoals)
 
     get = do
-      (index, fakeMap, indepGoals) <- get
-      return $! mkInstallPlan index fakeMap indepGoals
+      (index, indepGoals) <- get
+      return $! mkInstallPlan index indepGoals
 
 showPlanIndex :: (HasUnitId ipkg, HasUnitId srcpkg)
               => PlanIndex ipkg srcpkg iresult ifailure -> String
@@ -334,11 +341,7 @@ showPlanIndex index =
 
 showInstallPlan :: (HasUnitId ipkg, HasUnitId srcpkg)
                 => GenericInstallPlan ipkg srcpkg iresult ifailure -> String
-showInstallPlan plan =
-    showPlanIndex (planIndex plan) ++ "\n" ++
-    "fake map:\n  " ++
-    intercalate "\n  " (map showKV (Map.toList (planFakeMap plan)))
-  where showKV (k,v) = display k ++ " -> " ++ display v
+showInstallPlan = showPlanIndex . planIndex
 
 showPlanPackageTag :: GenericPlanPackage ipkg srcpkg iresult ifailure -> String
 showPlanPackageTag (PreExisting _)   = "PreExisting"
@@ -356,17 +359,8 @@ new :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
     -> Either [PlanProblem ipkg srcpkg iresult ifailure]
               (GenericInstallPlan ipkg srcpkg iresult ifailure)
 new indepGoals index =
-  -- NB: Need to pre-initialize the fake-map with pre-existing
-  -- packages
-  let isPreExisting (PreExisting _) = True
-      isPreExisting _ = False
-      fakeMap = Map.fromList
-              . map (\p -> (fakeUnitId (packageId p)
-                           ,installedUnitId p))
-              . filter isPreExisting
-              $ PackageIndex.allPackages index in
-  case problems fakeMap indepGoals index of
-    []    -> Right (mkInstallPlan index fakeMap indepGoals)
+  case problems indepGoals index of
+    []    -> Right (mkInstallPlan index indepGoals)
     probs -> Left probs
 
 toList :: GenericInstallPlan ipkg srcpkg iresult ifailure
@@ -424,11 +418,7 @@ lookupReadyPackage plan pkg = do
 
     isInstalledDep :: UnitId -> Maybe ipkg
     isInstalledDep pkgid =
-      -- NB: Need to check if the ID has been updated in planFakeMap, in which
-      -- case we might be dealing with an old pointer
-      case PlanIndex.fakeLookupUnitId
-           (planFakeMap plan) (planIndex plan) pkgid
-      of
+      case PackageIndex.lookupUnitId (planIndex plan) pkgid of
         Just (PreExisting ipkg)            -> Just ipkg
         Just (Configured  _)               -> Nothing
         Just (Processing  _)               -> Nothing
@@ -471,19 +461,11 @@ completed :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
 completed pkgid mipkg buildResult plan = assert (invariant plan') plan'
   where
     plan'     = plan {
-                  -- NB: installation can change the IPID, so better
-                  -- record it in the fake mapping...
-                  planFakeMap = insert_fake_mapping mipkg
-                              $ planFakeMap plan,
                   planIndex = PackageIndex.insert installed
                             . PackageIndex.deleteUnitId pkgid
                             $ planIndex plan
                 }
-    -- ...but be sure to use the *old* IPID for the lookup for the
-    -- preexisting record
     installed = Installed (lookupProcessingPackage plan pkgid) mipkg buildResult
-    insert_fake_mapping (Just ipkg) = Map.insert pkgid (installedUnitId ipkg)
-    insert_fake_mapping  _          = id
 
 -- | Marks a package in the graph as having failed. It also marks all the
 -- packages that depended on it as having failed.
@@ -520,7 +502,7 @@ packagesThatDependOn plan pkgid = map (planPkgOf plan)
                           . tail
                           . Graph.reachable (planGraphRev plan)
                           . planVertexOf plan
-                          $ Map.findWithDefault pkgid pkgid (planFakeMap plan)
+                          $ pkgid
 
 -- | Lookup a package that we expect to be in the processing state.
 --
@@ -528,8 +510,6 @@ lookupProcessingPackage :: GenericInstallPlan ipkg srcpkg iresult ifailure
                         -> UnitId
                         -> GenericReadyPackage srcpkg
 lookupProcessingPackage plan pkgid =
-  -- NB: processing packages are guaranteed to not indirect through
-  -- planFakeMap
   case PackageIndex.lookupUnitId (planIndex plan) pkgid of
     Just (Processing pkg) -> pkg
     _  -> internalError $ "not in processing state or no such pkg " ++
@@ -558,11 +538,6 @@ preexisting :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
 preexisting pkgid ipkg plan = assert (invariant plan') plan'
   where
     plan' = plan {
-                    -- NB: installation can change the IPID, so better
-                    -- record it in the fake mapping...
-      planFakeMap = Map.insert pkgid
-                               (installedUnitId ipkg)
-                               (planFakeMap plan),
       planIndex   = PackageIndex.insert (PreExisting ipkg)
                     -- ...but be sure to use the *old* IPID for the lookup for
                     -- the preexisting record
@@ -609,16 +584,12 @@ mapPreservingGraph :: (HasUnitId ipkg,
                    -> GenericInstallPlan ipkg' srcpkg' iresult' ifailure'
 mapPreservingGraph f plan =
     mkInstallPlan (PackageIndex.fromList pkgs')
-                  Map.empty -- empty fakeMap
                   (planIndepGoals plan)
   where
     -- The package mapping function may change the UnitId. So we
     -- walk over the packages in dependency order keeping track of these
     -- package id changes and use it to supply the correct set of package
     -- dependencies as an extra input to the package mapping function.
-    --
-    -- Having fully remapped all the deps this also means we can use an empty
-    -- FakeMap for the resulting install plan.
 
     (_, pkgs') = foldl' f' (Map.empty, []) (reverseTopologicalOrder plan)
 
@@ -648,11 +619,11 @@ mapPreservingGraph f plan =
 --
 valid :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
           HasUnitId srcpkg, PackageFixedDeps srcpkg)
-      => FakeMap -> Bool
+      => Bool
       -> PlanIndex ipkg srcpkg iresult ifailure
       -> Bool
-valid fakeMap indepGoals index =
-    null $ problems fakeMap indepGoals index
+valid indepGoals index =
+    null $ problems indepGoals index
 
 data PlanProblem ipkg srcpkg iresult ifailure =
      PackageMissingDeps   (GenericPlanPackage ipkg srcpkg iresult ifailure)
@@ -700,28 +671,28 @@ showPlanProblem (PackageStateInvalid pkg pkg') =
 --
 problems :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
              HasUnitId srcpkg, PackageFixedDeps srcpkg)
-         => FakeMap -> Bool
+         => Bool
          -> PlanIndex ipkg srcpkg iresult ifailure
          -> [PlanProblem ipkg srcpkg iresult ifailure]
-problems fakeMap indepGoals index =
+problems indepGoals index =
 
      [ PackageMissingDeps pkg
        (catMaybes
         (map
-         (fmap packageId . PlanIndex.fakeLookupUnitId fakeMap index)
+         (fmap packageId . PackageIndex.lookupUnitId index)
          missingDeps))
-     | (pkg, missingDeps) <- PlanIndex.brokenPackages fakeMap index ]
+     | (pkg, missingDeps) <- PlanIndex.brokenPackages index ]
 
   ++ [ PackageCycle cycleGroup
-     | cycleGroup <- PlanIndex.dependencyCycles fakeMap index ]
+     | cycleGroup <- PlanIndex.dependencyCycles index ]
 
   ++ [ PackageInconsistency name inconsistencies
      | (name, inconsistencies) <-
-       PlanIndex.dependencyInconsistencies fakeMap indepGoals index ]
+       PlanIndex.dependencyInconsistencies indepGoals index ]
 
   ++ [ PackageStateInvalid pkg pkg'
      | pkg <- PackageIndex.allPackages index
-     , Just pkg' <- map (PlanIndex.fakeLookupUnitId fakeMap index)
+     , Just pkg' <- map (PackageIndex.lookupUnitId index)
                     (CD.flatDeps (depends pkg))
      , not (stateDependencyRelation pkg pkg') ]
 
@@ -732,8 +703,8 @@ problems fakeMap indepGoals index =
 --
 acyclic :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
             HasUnitId srcpkg, PackageFixedDeps srcpkg)
-        => FakeMap -> PlanIndex ipkg srcpkg iresult ifailure -> Bool
-acyclic fakeMap = null . PlanIndex.dependencyCycles fakeMap
+        => PlanIndex ipkg srcpkg iresult ifailure -> Bool
+acyclic = null . PlanIndex.dependencyCycles
 
 -- | An installation plan is closed if for every package in the set, all of
 -- its dependencies are also in the set. That is, the set is closed under the
@@ -744,8 +715,8 @@ acyclic fakeMap = null . PlanIndex.dependencyCycles fakeMap
 --
 closed :: (PackageFixedDeps ipkg,
            PackageFixedDeps srcpkg)
-       => FakeMap -> PlanIndex ipkg srcpkg iresult ifailure -> Bool
-closed fakeMap = null . PlanIndex.brokenPackages fakeMap
+       => PlanIndex ipkg srcpkg iresult ifailure -> Bool
+closed = null . PlanIndex.brokenPackages
 
 -- | An installation plan is consistent if all dependencies that target a
 -- single package name, target the same version.
@@ -765,8 +736,8 @@ closed fakeMap = null . PlanIndex.brokenPackages fakeMap
 --
 consistent :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
                HasUnitId srcpkg, PackageFixedDeps srcpkg)
-           => FakeMap -> PlanIndex ipkg srcpkg iresult ifailure -> Bool
-consistent fakeMap = null . PlanIndex.dependencyInconsistencies fakeMap False
+           => PlanIndex ipkg srcpkg iresult ifailure -> Bool
+consistent = null . PlanIndex.dependencyInconsistencies False
 
 -- | The states of packages have that depend on each other must respect
 -- this relation. That is for very case where package @a@ depends on

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -147,8 +147,8 @@ import qualified Data.Traversable as T
 data GenericPlanPackage ipkg srcpkg iresult ifailure
    = PreExisting ipkg
    | Configured  srcpkg
-   | Processing  (GenericReadyPackage srcpkg ipkg)
-   | Installed   (GenericReadyPackage srcpkg ipkg) (Maybe ipkg) iresult
+   | Processing  (GenericReadyPackage srcpkg)
+   | Installed   (GenericReadyPackage srcpkg) (Maybe ipkg) iresult
    | Failed      srcpkg ifailure
   deriving (Eq, Show, Generic)
 
@@ -348,7 +348,7 @@ remove shouldRemove plan =
 --
 ready :: forall ipkg srcpkg iresult ifailure. PackageFixedDeps srcpkg
       => GenericInstallPlan ipkg srcpkg iresult ifailure
-      -> [GenericReadyPackage srcpkg ipkg]
+      -> [GenericReadyPackage srcpkg]
 ready plan = assert check readyPackages
   where
     check = if null readyPackages && null processingPackages
@@ -357,17 +357,17 @@ ready plan = assert check readyPackages
     configuredPackages = [ pkg | Configured pkg <- toList plan ]
     processingPackages = [ pkg | Processing pkg <- toList plan]
 
-    readyPackages :: [GenericReadyPackage srcpkg ipkg]
+    readyPackages :: [GenericReadyPackage srcpkg]
     readyPackages = catMaybes (map (lookupReadyPackage plan) configuredPackages)
 
 lookupReadyPackage :: forall ipkg srcpkg iresult ifailure.
                       PackageFixedDeps srcpkg
                    => GenericInstallPlan ipkg srcpkg iresult ifailure
                    -> srcpkg
-                   -> Maybe (GenericReadyPackage srcpkg ipkg)
+                   -> Maybe (GenericReadyPackage srcpkg)
 lookupReadyPackage plan pkg = do
-    deps <- hasAllInstalledDeps pkg
-    return (ReadyPackage pkg deps)
+    _ <- hasAllInstalledDeps pkg
+    return (ReadyPackage pkg)
   where
 
     hasAllInstalledDeps :: srcpkg -> Maybe (ComponentDeps [ipkg])
@@ -397,7 +397,7 @@ lookupReadyPackage plan pkg = do
 --
 processing :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
                HasUnitId srcpkg, PackageFixedDeps srcpkg)
-           => [GenericReadyPackage srcpkg ipkg]
+           => [GenericReadyPackage srcpkg]
            -> GenericInstallPlan ipkg srcpkg iresult ifailure
            -> GenericInstallPlan ipkg srcpkg iresult ifailure
 processing pkgs plan = assert (invariant plan') plan'
@@ -455,7 +455,7 @@ failed pkgid buildResult buildResult' plan = assert (invariant plan') plan'
     plan'    = plan {
                  planIndex = PackageIndex.merge (planIndex plan) failures
                }
-    ReadyPackage srcpkg _deps = lookupProcessingPackage plan pkgid
+    ReadyPackage srcpkg = lookupProcessingPackage plan pkgid
     failures = PackageIndex.fromList
              $ Failed srcpkg buildResult
              : [ Failed pkg' buildResult'
@@ -477,7 +477,7 @@ packagesThatDependOn plan pkgid = map (planPkgOf plan)
 --
 lookupProcessingPackage :: GenericInstallPlan ipkg srcpkg iresult ifailure
                         -> UnitId
-                        -> GenericReadyPackage srcpkg ipkg
+                        -> GenericReadyPackage srcpkg
 lookupProcessingPackage plan pkgid =
   -- NB: processing packages are guaranteed to not indirect through
   -- planFakeMap

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -168,7 +168,7 @@ instance (Package ipkg, Package srcpkg) =>
   packageId (Failed      spkg   _) = packageId spkg
 
 instance (PackageFixedDeps srcpkg,
-          PackageFixedDeps ipkg, HasUnitId ipkg) =>
+          PackageFixedDeps ipkg) =>
          PackageFixedDeps (GenericPlanPackage ipkg srcpkg iresult ifailure) where
   depends (PreExisting pkg)     = depends pkg
   depends (Configured  pkg)     = depends pkg
@@ -693,7 +693,7 @@ acyclic fakeMap = null . PlanIndex.dependencyCycles fakeMap
 -- * if the result is @False@ use 'PackageIndex.brokenPackages' to find out
 --   which packages depend on packages not in the index.
 --
-closed :: (HasUnitId ipkg, PackageFixedDeps ipkg,
+closed :: (PackageFixedDeps ipkg,
            PackageFixedDeps srcpkg)
        => FakeMap -> PlanIndex ipkg srcpkg iresult ifailure -> Bool
 closed fakeMap = null . PlanIndex.brokenPackages fakeMap

--- a/cabal-install/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/Distribution/Client/InstallSymlink.hs
@@ -40,14 +40,14 @@ symlinkBinary _ _ _ _ = fail "Symlinking feature not available on Windows"
 import Distribution.Client.Types
          ( SourcePackage(..)
          , GenericReadyPackage(..), ReadyPackage, enableStanzas
-         , ConfiguredPackage(..) , fakeUnitId)
+         , ConfiguredPackage(..))
 import Distribution.Client.Setup
          ( InstallFlags(installSymlinkBinDir) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.InstallPlan (InstallPlan)
 
 import Distribution.Package
-         ( PackageIdentifier, Package(packageId), UnitId(..) )
+         ( PackageIdentifier, Package(packageId), UnitId(..), installedUnitId )
 import Distribution.Compiler
          ( CompilerId(..) )
 import qualified Distribution.PackageDescription as PackageDescription
@@ -123,10 +123,10 @@ symlinkBinaries platform comp configFlags installFlags plan =
                then return Nothing
                else return (Just (pkgid, publicExeName,
                                   privateBinDir </> privateExeName))
-        | (ReadyPackage _cpkg, pkg, exe) <- exes
+        | (rpkg, pkg, exe) <- exes
         , let pkgid  = packageId pkg
               -- This is a bit dodgy; probably won't work for Backpack packages
-              ipid = fakeUnitId pkgid
+              ipid = installedUnitId rpkg
               publicExeName  = PackageDescription.exeName exe
               privateExeName = prefix ++ publicExeName ++ suffix
               prefix = substTemplate pkgid ipid prefixTemplate
@@ -141,7 +141,7 @@ symlinkBinaries platform comp configFlags installFlags plan =
 
     pkgDescription :: ReadyPackage -> PackageDescription
     pkgDescription (ReadyPackage (ConfiguredPackage
-                                    (SourcePackage _ pkg _ _)
+                                    _ (SourcePackage _ pkg _ _)
                                     flags stanzas _)) =
       case finalizePackageDescription flags
              (const True)

--- a/cabal-install/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/Distribution/Client/InstallSymlink.hs
@@ -123,7 +123,7 @@ symlinkBinaries platform comp configFlags installFlags plan =
                then return Nothing
                else return (Just (pkgid, publicExeName,
                                   privateBinDir </> privateExeName))
-        | (ReadyPackage _cpkg _, pkg, exe) <- exes
+        | (ReadyPackage _cpkg, pkg, exe) <- exes
         , let pkgid  = packageId pkg
               -- This is a bit dodgy; probably won't work for Backpack packages
               ipid = fakeUnitId pkgid
@@ -142,8 +142,7 @@ symlinkBinaries platform comp configFlags installFlags plan =
     pkgDescription :: ReadyPackage -> PackageDescription
     pkgDescription (ReadyPackage (ConfiguredPackage
                                     (SourcePackage _ pkg _ _)
-                                    flags stanzas _)
-                                  _) =
+                                    flags stanzas _)) =
       case finalizePackageDescription flags
              (const True)
              platform cinfo [] (enableStanzas stanzas pkg) of

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -628,7 +628,7 @@ rebuildTarget verbosity
               buildSettings downloadMap
               buildLimit installLock cacheLock
               sharedPackageConfig
-              rpkg@(ReadyPackage pkg _)
+              rpkg@(ReadyPackage pkg)
               pkgBuildStatus =
 
     -- We rely on the 'BuildStatus' to decide which phase to start from:
@@ -779,10 +779,10 @@ executeInstallPlan
      (HasUnitId ipkg,   PackageFixedDeps ipkg,
       HasUnitId srcpkg, PackageFixedDeps srcpkg)
   => Verbosity
-  -> JobControl IO ( GenericReadyPackage srcpkg ipkg
+  -> JobControl IO ( GenericReadyPackage srcpkg
                    , GenericBuildResult ipkg iresult BuildFailure )
   -> GenericInstallPlan ipkg srcpkg iresult BuildFailure
-  -> (    GenericReadyPackage srcpkg ipkg
+  -> (    GenericReadyPackage srcpkg
        -> IO (GenericBuildResult ipkg iresult BuildFailure))
   -> IO (GenericInstallPlan ipkg srcpkg iresult BuildFailure)
 executeInstallPlan verbosity jobCtl plan0 installPkg =
@@ -813,7 +813,7 @@ executeInstallPlan verbosity jobCtl plan0 installPkg =
           plan'      = updatePlan pkg buildResult plan
       tryNewTasks taskCount' plan'
 
-    updatePlan :: GenericReadyPackage srcpkg ipkg
+    updatePlan :: GenericReadyPackage srcpkg
                -> GenericBuildResult ipkg iresult BuildFailure
                -> GenericInstallPlan ipkg srcpkg iresult BuildFailure
                -> GenericInstallPlan ipkg srcpkg iresult BuildFailure
@@ -950,7 +950,7 @@ buildAndInstallUnpackedPackage verbosity
                                  pkgConfigPlatform  = platform,
                                  pkgConfigProgramDb = progdb
                                }
-                               rpkg@(ReadyPackage pkg _deps)
+                               rpkg@(ReadyPackage pkg)
                                srcdir builddir = do
 
     createDirectoryIfMissingVerbose verbosity False builddir
@@ -1106,7 +1106,7 @@ buildInplaceUnpackedPackage verbosity
                               pkgConfigCompiler  = compiler,
                               pkgConfigProgramDb = progdb
                             }
-                            rpkg@(ReadyPackage pkg _deps)
+                            rpkg@(ReadyPackage pkg)
                             buildStatus
                             srcdir builddir = do
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1225,7 +1225,7 @@ elaborateInstallPlan platform compiler progdb
       $ map installedPackageId
       $ InstallPlan.reverseDependencyClosure
           solverPlan
-          [ fakeUnitId (packageId pkg)
+          [ installedPackageId (PlannedId (packageId pkg))
           | pkg <- localPackages ]
 
     isLocalToProject :: Package pkg => pkg -> Bool

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -88,7 +88,6 @@ import qualified Distribution.PackageDescription as Cabal
 import qualified Distribution.PackageDescription as PD
 import qualified Distribution.PackageDescription.Configuration as PD
 import           Distribution.InstalledPackageInfo (InstalledPackageInfo)
-import qualified Distribution.InstalledPackageInfo as Installed
 import           Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import           Distribution.Simple.Compiler hiding (Flag)
@@ -366,7 +365,6 @@ instance Binary BuildStyle
 type CabalFileText = LBS.ByteString
 
 type ElaboratedReadyPackage = GenericReadyPackage ElaboratedConfiguredPackage
-                                                  InstalledPackageInfo
 
 --TODO: [code cleanup] this duplicates the InstalledPackageInfo quite a bit in an install plan
 -- because the same ipkg is used by many packages. So the binary file will be big.
@@ -1901,7 +1899,7 @@ setupHsScriptOptions :: ElaboratedReadyPackage
                      -> Bool
                      -> Lock
                      -> SetupScriptOptions
-setupHsScriptOptions (ReadyPackage ElaboratedConfiguredPackage{..} deps)
+setupHsScriptOptions (ReadyPackage ElaboratedConfiguredPackage{..})
                      ElaboratedSharedConfig{..} srcdir builddir
                      isParallelBuild cacheLock =
     SetupScriptOptions {
@@ -1911,8 +1909,8 @@ setupHsScriptOptions (ReadyPackage ElaboratedConfiguredPackage{..} deps)
       usePlatform              = Just pkgConfigPlatform,
       usePackageDB             = pkgSetupPackageDBStack,
       usePackageIndex          = Nothing,
-      useDependencies          = [ (installedPackageId ipkg, packageId ipkg)
-                                 | ipkg <- CD.setupDeps deps ],
+      useDependencies          = [ (uid, srcid)
+                                 | ConfiguredId srcid uid <- CD.setupDeps pkgDependencies ],
       useDependenciesExclusive = True,
       useVersionMacros         = pkgSetupScriptStyle == SetupCustomExplicitDeps,
       useProgramConfig         = pkgConfigProgramDb,
@@ -1972,8 +1970,7 @@ setupHsConfigureFlags :: ElaboratedReadyPackage
                       -> FilePath
                       -> Cabal.ConfigFlags
 setupHsConfigureFlags (ReadyPackage
-                         pkg@ElaboratedConfiguredPackage{..}
-                         pkgdeps)
+                         pkg@ElaboratedConfiguredPackage{..})
                       sharedConfig@ElaboratedSharedConfig{..}
                       verbosity builddir =
     assert (sanityCheckElaboratedConfiguredPackage sharedConfig pkg)
@@ -2027,11 +2024,10 @@ setupHsConfigureFlags (ReadyPackage
 
     -- we only use configDependencies, unless we're talking to an old Cabal
     -- in which case we use configConstraints
-    configDependencies        = [ (packageName (Installed.sourcePackageId deppkg),
-                                  Installed.installedUnitId deppkg)
-                                | deppkg <- CD.nonSetupDeps pkgdeps ]
-    configConstraints         = [ thisPackageVersion (packageId deppkg)
-                                | deppkg <- CD.nonSetupDeps pkgdeps ]
+    configDependencies        = [ (packageName srcid, uid)
+                                | ConfiguredId srcid uid <- CD.nonSetupDeps pkgDependencies ]
+    configConstraints         = [ thisPackageVersion srcid
+                                | ConfiguredId srcid _uid <- CD.nonSetupDeps pkgDependencies ]
 
     -- explicitly clear, then our package db stack
     -- TODO: [required eventually] have to do this differently for older Cabal versions

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -64,7 +64,7 @@ import           Distribution.Client.Types hiding
   (BuildResult,BuildSuccess(..), BuildFailure(..), DocsResult(..)
   ,TestsResult(..))
 import           Distribution.Client.InstallPlan
-                   ( GenericInstallPlan, InstallPlan, GenericPlanPackage )
+                   ( GenericInstallPlan, GenericPlanPackage, SolverInstallPlan )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import           Distribution.Client.Dependency
 import           Distribution.Client.Dependency.Types
@@ -196,9 +196,6 @@ type ElaboratedPlanPackage
    = GenericPlanPackage InstalledPackageInfo
                         ElaboratedConfiguredPackage
                         BuildSuccess BuildFailure
-
-type SolverInstallPlan
-   = InstallPlan --TODO: [code cleanup] redefine locally or move def to solver interface
 
 --TODO: [code cleanup] decide if we really need this, there's not much in it, and in principle
 --      even platform and compiler could be different if we're building things
@@ -808,7 +805,7 @@ getPackageSourceHashes verbosity withRepoCtx installPlan = do
            mloc <- checkFetched locm
            return (pkg, locm, mloc)
       | InstallPlan.Configured
-          (ConfiguredPackage pkg _ _ _) <- InstallPlan.toList installPlan ]
+          SolverPackage { solverPkgSource = pkg } <- InstallPlan.toList installPlan ]
 
     let requireDownloading = [ (pkg, locm) | (pkg, locm, Nothing) <- pkgslocs ]
         alreadyDownloaded  = [ (pkg, loc)  | (pkg, _, Just loc)   <- pkgslocs ]
@@ -1028,24 +1025,17 @@ elaborateInstallPlan platform compiler progdb
 
           InstallPlan.Configured  pkg ->
             InstallPlan.Configured
-              (elaborateConfiguredPackage (fixupDependencies mapDep pkg))
+              (elaborateSolverPackage mapDep pkg)
 
           _ -> error "elaborateInstallPlan: unexpected package state"
 
-    -- remap the installed package ids of the direct deps, since we're
-    -- changing the installed package ids of all the packages to use the
-    -- final nix-style hashed ids.
-    fixupDependencies mapDep
-       (ConfiguredPackage pkg flags stanzas deps) =
-        ConfiguredPackage pkg flags stanzas deps'
-      where
-        deps' = fmap (map (\d -> d { confInstId = mapDep (confInstId d) })) deps
-
-    elaborateConfiguredPackage :: ConfiguredPackage UnresolvedPkgLoc
-                               -> ElaboratedConfiguredPackage
-    elaborateConfiguredPackage
-        pkg@(ConfiguredPackage (SourcePackage pkgid gdesc srcloc descOverride)
-                               flags stanzas deps) =
+    elaborateSolverPackage :: (UnitId -> UnitId)
+                           -> SolverPackage UnresolvedPkgLoc
+                           -> ElaboratedConfiguredPackage
+    elaborateSolverPackage
+        mapDep
+        pkg@(SolverPackage (SourcePackage pkgid gdesc srcloc descOverride)
+                           flags stanzas deps0) =
         elaboratedPackage
       where
         -- Knot tying: the final elaboratedPackage includes the
@@ -1053,6 +1043,15 @@ elaborateInstallPlan platform compiler progdb
         -- of the other fields of the elaboratedPackage.
         --
         elaboratedPackage = ElaboratedConfiguredPackage {..}
+
+        deps = fmap (map elaborateSolverId) deps0
+
+        elaborateSolverId sid =
+            ConfiguredId {
+                confSrcId  = packageId sid,
+                -- Update the 'UnitId' to the final nix-style hashed ID
+                confInstId = mapDep (installedPackageId sid)
+            }
 
         pkgInstalledId
           | shouldBuildInplaceOnly pkg
@@ -1802,7 +1801,7 @@ rememberImplicitSetupDeps sourcePkgIndex plan =
       Set.fromList
         [ installedPackageId pkg
         | InstallPlan.Configured
-            pkg@(ConfiguredPackage newpkg _ _ _) <- InstallPlan.toList plan
+            pkg@(SolverPackage newpkg _ _ _) <- InstallPlan.toList plan
           -- has explicit setup deps now
         , hasExplicitSetupDeps newpkg
           -- but originally had no setup deps
@@ -1823,7 +1822,7 @@ rememberImplicitSetupDeps sourcePkgIndex plan =
 -- through the solver.
 --
 packageSetupScriptStylePostSolver :: Set InstalledPackageId
-                                  -> ConfiguredPackage loc
+                                  -> SolverPackage loc
                                   -> PD.PackageDescription
                                   -> SetupScriptStyle
 packageSetupScriptStylePostSolver pkgsImplicitSetupDeps pkg pkgDescription =

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -96,17 +96,16 @@ instance PackageFixedDeps InstalledPackageInfo where
                                  (installedDepends pkg)
 
 
--- | In order to reuse the implementation of PackageIndex which relies on
--- 'UnitId', we need to be able to synthesize these IDs prior
--- to installation.  Eventually, we'll move to a representation of
--- 'UnitId' which can be properly computed before compilation
--- (of course, it's a bit of a misnomer since the packages are not actually
--- installed yet.)  In any case, we'll synthesize temporary installed package
--- IDs to use as keys during install planning.  These should never be written
--- out!  Additionally, they need to be guaranteed unique within the install
--- plan.
-fakeUnitId :: PackageId -> UnitId
-fakeUnitId = mkUnitId . (".fake."++) . display
+-- | In order to reuse the implementation of PackageIndex which relies
+-- on 'UnitId' for 'SolverInstallPlan', we need to be able to synthesize
+-- these IDs prior to installation.   These should never be written out!
+-- Additionally, they need to be guaranteed unique within the install
+-- plan; this holds because an install plan only ever contains one
+-- instance of a particular package and version.  (To fix this,
+-- the IDs not only have to identify a package ID, but also the
+-- transitive requirementso n it.)
+unsafeInternalFakeUnitId :: PackageId -> UnitId
+unsafeInternalFakeUnitId = mkUnitId . (".fake."++) . display
 
 -- | A 'ConfiguredPackage' is a not-yet-installed package along with the
 -- total configuration information. The configuration information is total in
@@ -114,6 +113,7 @@ fakeUnitId = mkUnitId . (".fake."++) . display
 -- final configure process will be independent of the environment.
 --
 data ConfiguredPackage loc = ConfiguredPackage {
+       confPkgId :: UnitId, -- the generated 'UnitId' for this package
        confPkgSource :: SourcePackage loc, -- package info, including repo
        confPkgFlags :: FlagAssignment,     -- complete flag assignment for the package
        confPkgStanzas :: [OptionalStanza], -- list of enabled optional stanzas for the package
@@ -162,7 +162,7 @@ instance PackageFixedDeps (ConfiguredPackage loc) where
   depends cpkg = fmap (map installedUnitId) (confPkgDeps cpkg)
 
 instance HasUnitId (ConfiguredPackage loc) where
-  installedUnitId cpkg = fakeUnitId (packageId cpkg)
+  installedUnitId = confPkgId
 
 -- | Like 'ConfiguredPackage', but with all dependencies guaranteed to be
 -- installed already, hence itself ready to be installed.
@@ -198,7 +198,7 @@ instance Package (SolverPackage loc) where
 -- But this is strictly temporary: once we convert to a
 -- 'ConfiguredPackage' we'll record 'UnitId's for everything.
 instance HasUnitId (SolverPackage loc) where
-  installedUnitId = fakeUnitId . packageId . solverPkgSource
+  installedUnitId = unsafeInternalFakeUnitId . packageId . solverPkgSource
 
 instance PackageFixedDeps (SolverPackage loc) where
   depends pkg = fmap (map installedUnitId) (solverPkgDeps pkg)
@@ -222,7 +222,7 @@ instance Package SolverId where
 
 instance HasUnitId SolverId where
   installedUnitId (PreExistingId _ instId) = instId
-  installedUnitId (PlannedId pid) = fakeUnitId pid
+  installedUnitId (PlannedId pid) = unsafeInternalFakeUnitId pid
 
 -- | A package description along with the location of the package sources.
 --

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -----------------------------------------------------------------------------
 -- |
@@ -165,26 +166,10 @@ instance HasUnitId (ConfiguredPackage loc) where
 
 -- | Like 'ConfiguredPackage', but with all dependencies guaranteed to be
 -- installed already, hence itself ready to be installed.
-data GenericReadyPackage srcpkg ipkg
-   = ReadyPackage
-       srcpkg                  -- see 'ConfiguredPackage'.
-       (ComponentDeps [ipkg])  -- Installed dependencies.
-  deriving (Eq, Show, Generic)
+newtype GenericReadyPackage srcpkg = ReadyPackage srcpkg -- see 'ConfiguredPackage'.
+  deriving (Eq, Show, Generic, Package, PackageFixedDeps, HasUnitId, Binary)
 
-type ReadyPackage = GenericReadyPackage (ConfiguredPackage UnresolvedPkgLoc) InstalledPackageInfo
-
-instance Package srcpkg => Package (GenericReadyPackage srcpkg ipkg) where
-  packageId (ReadyPackage srcpkg _deps) = packageId srcpkg
-
-instance (Package srcpkg, HasUnitId ipkg) =>
-         PackageFixedDeps (GenericReadyPackage srcpkg ipkg) where
-  depends (ReadyPackage _ deps) = fmap (map installedUnitId) deps
-
-instance HasUnitId srcpkg =>
-         HasUnitId (GenericReadyPackage srcpkg ipkg) where
-  installedUnitId (ReadyPackage pkg _) = installedUnitId pkg
-
-instance (Binary srcpkg, Binary ipkg) => Binary (GenericReadyPackage srcpkg ipkg)
+type ReadyPackage = GenericReadyPackage (ConfiguredPackage UnresolvedPkgLoc)
 
 
 -- | A package description along with the location of the package sources.


### PR DESCRIPTION
This is only the last patch; the rest is #3281.

Compute 'UnitId' when we compute a 'ConfiguredPackage';
consequently, we can eliminate 'FakeMap' (finally!)
There is one hack remaining, which is that 'SolverInstallPlan'
gins up fake unit IDs so that it can be keyed on UnitIds.
But this data structure exists only very briefly before
being converted into an 'InstallPlan' or 'ElaboratedInstallPlan'.