### PR TITLE
Require QuickCheck >= 2.8.2 for cabal-install unit tests

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -317,7 +317,7 @@ Test-Suite unit-tests
         tasty-hunit,
         tasty-quickcheck,
         tagged,
-        QuickCheck >= 2.7
+        QuickCheck >= 2.8.2
 
   if flag(old-directory)
     build-depends: old-time


### PR DESCRIPTION
The 'ProjectConfig' tests use the Arbitrary instance for Map added in 2.8.2.

(cherry picked from commit 68ef50116132cbcfae3857d46540a313d717df4a)

This commit is from #3238, but it also applies to 1.24.