### PR TITLE
topHandler passes all non-die exceptions to top level, fixes #3310.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -195,6 +195,10 @@ extra-source-files:
   tests/PackageTests/TestSuiteTests/LibV09/LibV09.cabal
   tests/PackageTests/TestSuiteTests/LibV09/tests/Deadlock.hs
   tests/PackageTests/Tests.hs
+  tests/PackageTests/TopHandler/Die/Setup.hs
+  tests/PackageTests/TopHandler/DieWithLocation/Setup.hs
+  tests/PackageTests/TopHandler/Error/Setup.hs
+  tests/PackageTests/TopHandler/FileDoesNotExist/Setup.hs
   tests/PackageTests/UniqueIPID/P1/M.hs
   tests/PackageTests/UniqueIPID/P1/my.cabal
   tests/PackageTests/UniqueIPID/P2/M.hs

--- a/Cabal/misc/gen-extra-source-files.sh
+++ b/Cabal/misc/gen-extra-source-files.sh
@@ -8,9 +8,9 @@ fi
 
 set -ex
 
-find tests -type f \( -name '*.hs' -or -name '*.lhs' -or -name '*.c' -or -name '*.sh' \
-    -or -name '*.cabal' -or -name '*.hsc' -or -name '*.err' -or -name '*.out' -or -name "ghc*" \) -and -not -regex ".*/dist.*/.*" \
-    | awk '/Check.hs$|UnitTests|PackageTester|autogen|PackageTests.hs|IntegrationTests.hs|CreatePipe|^tests\/Test/ { next } { print }' \
+git ls-files tests \
+    | awk '/\.(hs|lhs|c|sh|cabal|hsc|err|out)$|ghc/ { print } { next }' \
+    | awk '/Check.hs$|UnitTests|PackageTester|autogen|register.sh|PackageTests.hs|IntegrationTests.hs|CreatePipe|^tests\/Test/ { next } { print }' \
     | LC_ALL=C sort \
     | sed -e 's/^/  /' \
     > source-file-list

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -408,6 +408,30 @@ tests config = do
     cabal "build" []
     runExe' "T3294" [] >>= assertOutputContains "bbb"
 
+  tc "TopHandler/FileDoesNotExist" $ do
+    r <- shouldFail $ cabal' "configure" []
+    assertOutputContains "Setup" r          -- executable name
+    assertOutputContains "does-not-exist" r -- file which does not exist
+    assertOutputContains "does not exist" r -- short error message
+    assertOutputContains "No such file or directory" r -- long error message
+
+  tc "TopHandler/Die" $ do
+    r <- shouldFail $ cabal' "configure" []
+    assertOutputContains "Setup" r   -- executable name
+    assertOutputContains "oopsies" r -- the error message from dying
+
+  tc "TopHandler/DieWithLocation" $ do
+    r <- shouldFail $ cabal' "configure" []
+    assertOutputContains "Setup" r     -- executable name
+    assertOutputContains "oopsies" r   -- the error message from dying
+    assertOutputContains "MyFile.hs" r -- the source file
+    assertOutputContains "42" r        -- the line number
+
+  tc "TopHandler/Error" $ do
+    r <- shouldFail $ cabal' "configure" []
+    assertOutputContains "Setup" r     -- executable name
+    assertOutputContains "foobar" r    -- the error message from error
+
   where
     ghc_pkg_guess bin_name = do
         cwd <- packageDir

--- a/Cabal/tests/PackageTests/TopHandler/Die/Setup.hs
+++ b/Cabal/tests/PackageTests/TopHandler/Die/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple.Utils
+
+main = topHandler $ die "oopsies"

--- a/Cabal/tests/PackageTests/TopHandler/DieWithLocation/Setup.hs
+++ b/Cabal/tests/PackageTests/TopHandler/DieWithLocation/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple.Utils
+
+main = topHandler $ dieWithLocation "MyFile.hs" (Just 42) "oopsies"

--- a/Cabal/tests/PackageTests/TopHandler/Error/Setup.hs
+++ b/Cabal/tests/PackageTests/TopHandler/Error/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple.Utils
+
+main = topHandler $ error "foobar"

--- a/Cabal/tests/PackageTests/TopHandler/FileDoesNotExist/Setup.hs
+++ b/Cabal/tests/PackageTests/TopHandler/FileDoesNotExist/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple.Utils
+
+main = topHandler $ readFile "does-not-exist"

--- a/update-cabal-files.sh
+++ b/update-cabal-files.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+(cd Cabal; misc/gen-extra-source-files.sh Cabal.cabal)
+(cd cabal-install; ../Cabal/misc/gen-extra-source-files.sh cabal-install.cabal)


### PR DESCRIPTION
Fix https://github.com/haskell/cabal/issues/3310

The big benefit is on Windows, where file information is not stored in
the usual places in the IOErrors, so that the existing topHandler
gives a very bad message:

On Windows:

With:   -- Try deleting a file we have an open handle to
Before: progname: permission denied
After:  progname: DeleteFile "C:\msys64\tmp\tmp-11944\foo": permission denied (The process cannot access the file because it is being used by another process.)

This patch does not affect Linux error messages too much, although
I think they are modestly superior.  Treatment of die/dieWithLocation
is unchanged.

On Linux:

With:   die "oopsies"
Before: progname: oopsies
After:  progname: oopsies

With:   dieWithLocation "MyFile.hs" (Just 42) "oopsies"
Before: progname: Myfile.hs:42: oopsies
After:  progname: Myfile.hs:42: oopsies

With:   readFile "someRandomFile"
Before: progname: someRandomFile: does not exist
After:  progname: someRandomFile: openFile: does not exist (No such file or directory)

With:   writeFile "/aff" "/aff"
Before: progname: /aff: permission denied
After:  progname: /aff: openFile: permission denied (Permission denied)
