### PR TITLE
Monitor contents of Cabal files so we rerun solver upon edits (#3323, #3324).

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -89,7 +89,9 @@ extra-source-files:
   tests/PackageTests/CMain/my.cabal
   tests/PackageTests/Configure/A.hs
   tests/PackageTests/Configure/Setup.hs
+  tests/PackageTests/Configure/X11.buildinfo.in
   tests/PackageTests/Configure/X11.cabal
+  tests/PackageTests/Configure/include/HsX11Config.h.in
   tests/PackageTests/CopyAssumeDepsUpToDate/CopyAssumeDepsUpToDate.cabal
   tests/PackageTests/CopyAssumeDepsUpToDate/Main.hs
   tests/PackageTests/CopyAssumeDepsUpToDate/P.hs

--- a/Cabal/misc/gen-extra-source-files.sh
+++ b/Cabal/misc/gen-extra-source-files.sh
@@ -9,7 +9,7 @@ fi
 set -ex
 
 git ls-files tests \
-    | awk '/\.(hs|lhs|c|sh|cabal|hsc|err|out)$|ghc/ { print } { next }' \
+    | awk '/\.(hs|lhs|c|sh|cabal|hsc|err|out|in)$|ghc/ { print } { next }' \
     | awk '/Check.hs$|UnitTests|PackageTester|autogen|register.sh|PackageTests.hs|IntegrationTests.hs|CreatePipe|^tests\/Test/ { next } { print }' \
     | LC_ALL=C sort \
     | sed -e 's/^/  /' \

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -678,7 +678,7 @@ readSourcePackage verbosity (ProjectPackageLocalCabalFile cabalFile) =
     dir = takeDirectory cabalFile
 
 readSourcePackage verbosity (ProjectPackageLocalDirectory dir cabalFile) = do
-    -- no need to monitorFiles because findProjectCabalFiles did it already
+    monitorFiles [monitorFileHashed cabalFile]
     pkgdesc <- liftIO $ readPackageDescription verbosity cabalFile
     return SourcePackage {
       packageInfoId        = packageId pkgdesc,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -76,6 +76,14 @@ Extra-Source-Files:
   tests/IntegrationTests/multiple-source/p/p.cabal
   tests/IntegrationTests/multiple-source/q/Setup.hs
   tests/IntegrationTests/multiple-source/q/q.cabal
+  tests/IntegrationTests/new-build/monitor_cabal_files.sh
+  tests/IntegrationTests/new-build/monitor_cabal_files/p/P.hs
+  tests/IntegrationTests/new-build/monitor_cabal_files/p/Setup.hs
+  tests/IntegrationTests/new-build/monitor_cabal_files/p/p.cabal
+  tests/IntegrationTests/new-build/monitor_cabal_files/q/Main.hs
+  tests/IntegrationTests/new-build/monitor_cabal_files/q/Setup.hs
+  tests/IntegrationTests/new-build/monitor_cabal_files/q/q-broken.cabal.in
+  tests/IntegrationTests/new-build/monitor_cabal_files/q/q-fixed.cabal.in
   tests/IntegrationTests/sandbox-sources/fail_removing_source_thats_not_registered.err
   tests/IntegrationTests/sandbox-sources/fail_removing_source_thats_not_registered.sh
   tests/IntegrationTests/sandbox-sources/p/Setup.hs

--- a/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files.sh
+++ b/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files.sh
@@ -1,0 +1,8 @@
+. ./common.sh
+cd monitor_cabal_files
+cp q/q-broken.cabal.in q/q.cabal
+echo "Run 1" | awk '{print;print > "/dev/stderr"}'
+! cabal new-build q
+cp q/q-fixed.cabal.in q/q.cabal
+echo "Run 2" | awk '{print;print > "/dev/stderr"}'
+cabal new-build q

--- a/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/.gitignore
+++ b/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/.gitignore
@@ -1,0 +1,1 @@
+q/q.cabal

--- a/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/cabal.project
+++ b/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/cabal.project
@@ -1,0 +1,1 @@
+packages: p/p.cabal q/q.cabal

--- a/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/p/P.hs
+++ b/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/p/P.hs
@@ -1,0 +1,1 @@
+module P where

--- a/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/p/Setup.hs
+++ b/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/p/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/p/p.cabal
+++ b/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/p/p.cabal
@@ -1,0 +1,12 @@
+name:                p
+version:             1.0
+license:             BSD3
+author:              Edward Z. Yang
+maintainer:          ezyang@cs.stanford.edu
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  exposed-modules:     P
+  build-depends:       base
+  default-language:    Haskell2010

--- a/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/q/Main.hs
+++ b/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/q/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+import P
+main :: IO ()
+main = return ()

--- a/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/q/Setup.hs
+++ b/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/q/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/q/q-broken.cabal.in
+++ b/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/q/q-broken.cabal.in
@@ -1,0 +1,12 @@
+name:                q
+version:             0.1.0.0
+license:             BSD3
+author:              Edward Z. Yang
+maintainer:          ezyang@cs.stanford.edu
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable q
+  main-is:             Main.hs
+  build-depends:       base
+  default-language:    Haskell2010

--- a/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/q/q-fixed.cabal.in
+++ b/cabal-install/tests/IntegrationTests/new-build/monitor_cabal_files/q/q-fixed.cabal.in
@@ -1,0 +1,12 @@
+name:                q
+version:             0.1.0.0
+license:             BSD3
+author:              Edward Z. Yang
+maintainer:          ezyang@cs.stanford.edu
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable q
+  main-is:             Main.hs
+  build-depends:       base, p
+  default-language:    Haskell2010


### PR DESCRIPTION
There was a comment claiming that it was done already but this function
does not exist. I think it was referring to findProjectPackages, but
this function tests only matchFileGlob (so it will notice if a.cabal is
renamed to b.cabal) and not the actual contents of the file.

Fixes #3323 (probably) and #3324 (has test).

CC @dcoutts