### PR TITLE
Use larger conflict set when solver chooses wrong version for package in link group

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Linking.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Linking.hs
@@ -246,7 +246,7 @@ makeCanonical lg qpn@(Q pp _) i =
     case lgCanon lg of
       -- There is already a canonical member. Fail.
       Just _ ->
-        conflict ( S.fromList (P qpn : lgBlame lg)
+        conflict ( P qpn `S.insert` lgConflictSet lg
                  ,    "cannot make " ++ showQPN qpn
                    ++ " canonical member of " ++ showLinkGroup lg
                  )

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -125,6 +125,9 @@ tests = [
         , runTest $ mkTestPCDepends [("pkgA", "1.0.0"), ("pkgB", "1.0.0")] dbPC1 "pruneNotFound" ["C"] (Just [("A", 1), ("B", 1), ("C", 1)])
         , runTest $ mkTestPCDepends [("pkgA", "1.0.0"), ("pkgB", "2.0.0")] dbPC1 "chooseNewest" ["C"] (Just [("A", 1), ("B", 2), ("C", 1)])
         ]
+    , testGroup "Independent goals" [
+          runTest $ indep $ mkTest db17 "indepGoals" ["A", "B"] (Just [("A", 1), ("B", 1), ("C", 1), ("D", 1)])
+        ]
     ]
   where
     -- | Combinator to turn on --independent-goals behavior, i.e. solve
@@ -505,6 +508,24 @@ db15 = [
   , Right $ exAv   "C" 2            []            `withSetupDeps` [ExAny "D"]
   , Right $ exAv   "D" 1            [ExAny "C"  ]
   , Right $ exAv   "E" 1            [ExFix "C" 2]
+  ]
+
+-- | This database checks that when the solver discovers a constraint on a
+-- package's version after choosing to link that package, it can backtrack to
+-- try alternative versions for the linked-to package.
+--
+-- When A and B are installed as independent goals, their dependencies on C
+-- must be linked. Since C depends on D, A and B's dependencies on D must also
+-- be linked. This test relies on the fact that the solver chooses D-2 for both
+-- 0.D and 1.D before it encounters the test suites' constraints. The solver
+-- must backtrack to try D-1 for both 0.D and 1.D.
+db17 :: ExampleDb
+db17 = [
+    Right $ exAv "A" 1 [ExAny "C"] `withTest` ExTest "test" [ExFix "D" 1]
+  , Right $ exAv "B" 1 [ExAny "C"] `withTest` ExTest "test" [ExFix "D" 1]
+  , Right $ exAv "C" 1 [ExAny "D"]
+  , Right $ exAv "D" 1 []
+  , Right $ exAv "D" 2 []
   ]
 
 dbExts1 :: ExampleDb


### PR DESCRIPTION
This commit replaces a call to `lgBlame` with a call to `lgConflictSet`. `lgConflictSet` adds the members of the link group to the conflict set. The other members are required, for example, when a linked package's version doesn't match a constraint, and the solver must try other versions for the linked-to package.

I merged #3221, #3234, #3237, and @edsko's branch off of #3268 into master to try to find any remaining failures in the solver quickcheck test.  The log below is from that branch. This commit adds `0.D` to the conflict set when the solver rejects `1.D-1`.

I'm still not sure if the conflict set is large enough.  Should it also contain the variables from the `GoalReasonChain`s for `0.D` and `1.D`?

```
 1  targets: A, B
 2        indepGoals:                                       constraints:
 3    stanzas A test (unknown source)
 4    stanzas B test (unknown source)
 5    stanzas C test (unknown source)
 6    stanzas D test (unknown source)
 7    stanzas D test (unknown source)
 8  preferences:
 9  strategy: PreferLatestForSelected
10  reorder goals: False
11  independent goals: True
12  avoid reinstalls: False
13  shadow packages: False
14  strong flags: False
15  max backjumps: infinite
16  [__0] trying: 0.A-1.0.0 (user goal)
17  [__1] trying: 0.C-1.0.0 (dependency of 0.A-1.0.0)
18  [__2] trying: 0.D-2.0.0 (dependency of 0.C-1.0.0)
19  [__3] trying: 1.B-1.0.0 (user goal)
20  [__4] trying: 1.C~>0.C-1.0.0 (dependency of 1.B-1.0.0)
21  [__5] trying: 1.D~>0.D-2.0.0 (dependency of 1.C-1.0.0)
22  [__6] rejecting: 1.B-1.0.0:!test (constraint from unknown source requires opposite flag selection)
23  [__6] rejecting: 1.B-1.0.0:*test (conflict: 1.D==2.0.0, 1.B-1.0.0:test => 1.D==1.0.0)
24  [__6] fail (backjumping, conflict set: 1.B, 1.C, 1.D, 1.B-1.0.0:test)
25  [__5] rejecting: 1.D-2.0.0 (multiple instances)
26  [__5] rejecting: 1.D-1.0.0 (dependencies not linked: cannot make 1.D canonical member of {*0.D-2.0.0,1.D-2.0.0}; conflict set: 1.C, 1.D)
27  [__5] fail (backjumping, conflict set: 1.B, 1.C, 1.D, 1.B-1.0.0:test)
28  [__4] rejecting: 1.C-1.0.0 (multiple instances)
29  [__0] fail (backjumping, conflict set: 1.B, 1.C, 1.D, 1.B-1.0.0:test)
30  FAIL
31          Unexpected error:
32          Could not resolve dependencies:
33          trying: 1.B-1.0.0 (user goal)
34          trying: 1.C~>0.C-1.0.0 (dependency of 1.B-1.0.0)
35          trying: 1.D~>0.D-2.0.0 (dependency of 1.C-1.0.0)
36          rejecting: 1.B-1.0.0:!test (constraint from unknown source requires opposite flag selection)
37          rejecting: 1.B-1.0.0:*test (conflict: 1.D==2.0.0, 1.B-1.0.0:test => 1.D==1.0.0)
38          Dependency tree exhaustively searched.
```