### PR TITLE
Force Cabal >= 1.24 dep when there's no custom-setup stanza.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,5 +1,5 @@
 name: Cabal
-version: 1.24.0.0
+version: 1.24.1.0
 copyright: 2003-2006, Isaac Jones
            2005-2011, Duncan Coutts
 license: BSD3

--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -97,7 +97,7 @@ module Distribution.PackageDescription (
         GenericPackageDescription(..),
         Flag(..), FlagName(..), FlagAssignment,
         CondTree(..), ConfVar(..), Condition(..),
-        cNot,
+        cNot, cAnd, cOr,
 
         -- * Source repositories
         SourceRepo(..),
@@ -111,7 +111,7 @@ module Distribution.PackageDescription (
 
 import Distribution.Compat.Binary
 import qualified Distribution.Compat.Semigroup as Semi ((<>))
-import Distribution.Compat.Semigroup as Semi (Monoid(..), Semigroup, gmempty, gmappend)
+import Distribution.Compat.Semigroup as Semi (Monoid(..), Semigroup, gmempty)
 import qualified Distribution.Compat.ReadP as Parse
 import Distribution.Compat.ReadP   ((<++))
 import Distribution.Package
@@ -308,18 +308,24 @@ instance Text BuildType where
 -- options authors can specify to just Haskell package dependencies.
 
 data SetupBuildInfo = SetupBuildInfo {
-        setupDepends :: [Dependency]
+        setupDepends        :: [Dependency],
+        defaultSetupDepends :: Bool
+        -- ^ Is this a default 'custom-setup' section added by the cabal-install
+        -- code (as opposed to user-provided)? This field is only used
+        -- internally, and doesn't correspond to anything in the .cabal
+        -- file. See #3199.
     }
     deriving (Generic, Show, Eq, Read, Typeable, Data)
 
 instance Binary SetupBuildInfo
 
 instance Semi.Monoid SetupBuildInfo where
-  mempty = gmempty
+  mempty  = SetupBuildInfo [] False
   mappend = (Semi.<>)
 
 instance Semigroup SetupBuildInfo where
-  (<>) = gmappend
+  a <> b = SetupBuildInfo (setupDepends a Semi.<> setupDepends b)
+           (defaultSetupDepends a || defaultSetupDepends b)
 
 -- ---------------------------------------------------------------------------
 -- Module renaming
@@ -1193,10 +1199,31 @@ data Condition c = Var c
                  | CAnd (Condition c) (Condition c)
     deriving (Show, Eq, Typeable, Data, Generic)
 
+-- | Boolean negation of a 'Condition' value.
 cNot :: Condition a -> Condition a
 cNot (Lit b)  = Lit (not b)
 cNot (CNot c) = c
 cNot c        = CNot c
+
+-- | Boolean AND of two 'Condtion' values.
+cAnd :: Condition a -> Condition a -> Condition a
+cAnd (Lit False) _           = Lit False
+cAnd _           (Lit False) = Lit False
+cAnd (Lit True)  x           = x
+cAnd x           (Lit True)  = x
+cAnd x           y           = CAnd x y
+
+-- | Boolean OR of two 'Condition' values.
+cOr :: Eq v => Condition v -> Condition v -> Condition v
+cOr  (Lit True)  _           = Lit True
+cOr  _           (Lit True)  = Lit True
+cOr  (Lit False) x           = x
+cOr  x           (Lit False) = x
+cOr  c           (CNot d)
+  | c == d                   = Lit True
+cOr  (CNot c)    d
+  | c == d                   = Lit True
+cOr  x           y           = COr x y
 
 instance Functor Condition where
   f `fmap` Var c    = Var (f c)

--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- -fno-warn-deprecations for use of Map.foldWithKey
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 -----------------------------------------------------------------------------
@@ -23,6 +24,7 @@ module Distribution.PackageDescription.Configuration (
     parseCondition,
     freeVars,
     extractCondition,
+    extractConditions,
     addBuildableCondition,
     mapCondTree,
     mapTreeData,
@@ -31,6 +33,9 @@ module Distribution.PackageDescription.Configuration (
     transformAllBuildInfos,
     transformAllBuildDepends,
   ) where
+
+import Control.Applicative -- 7.10 -Werror workaround.
+import Prelude
 
 import Distribution.Package
 import Distribution.PackageDescription
@@ -293,17 +298,24 @@ addBuildableCondition getInfo t =
     Lit False -> CondNode mempty mempty []
     c         -> CondNode mempty mempty [(c, t, Nothing)]
 
--- | Extract buildable condition from a cond tree.
+-- Note: extracting buildable conditions.
+-- --------------------------------------
 --
--- Background: If the conditions in a cond tree lead to Buildable being set to False,
--- then none of the dependencies for this cond tree should actually be taken into
--- account. On the other hand, some of the flags may only be decided in the solver,
--- so we cannot necessarily make the decision whether a component is Buildable or not
--- prior to solving.
+-- If the conditions in a cond tree lead to Buildable being set to False, then
+-- none of the dependencies for this cond tree should actually be taken into
+-- account. On the other hand, some of the flags may only be decided in the
+-- solver, so we cannot necessarily make the decision whether a component is
+-- Buildable or not prior to solving.
 --
--- What we are doing here is to partially evaluate a condition tree in order to extract
--- the condition under which Buildable is True. The predicate determines whether data
--- under a 'CondTree' is buildable.
+-- What we are doing here is to partially evaluate a condition tree in order to
+-- extract the condition under which Buildable is True. The predicate determines
+-- whether data under a 'CondTree' is buildable.
+
+
+-- | Extract the condition matched by the given predicate from a cond tree.
+--
+-- We use this mainly for extracting buildable conditions (see the Note above),
+-- but the function is in fact more general.
 extractCondition :: Eq v => (a -> Bool) -> CondTree v c a -> Condition v
 extractCondition p = go
   where
@@ -316,21 +328,20 @@ extractCondition p = go
         ct = go t
         ce = maybe (Lit True) go e
       in
-        ((c `cand` ct) `cor` (CNot c `cand` ce)) `cand` goList cs
+        ((c `cAnd` ct) `cOr` (CNot c `cAnd` ce)) `cAnd` goList cs
 
-    cand (Lit False) _           = Lit False
-    cand _           (Lit False) = Lit False
-    cand (Lit True)  x           = x
-    cand x           (Lit True)  = x
-    cand x           y           = CAnd x y
+-- | Extract conditions matched by the given predicate from all cond trees in a
+-- 'GenericPackageDescription'.
+extractConditions :: (BuildInfo -> Bool) -> GenericPackageDescription
+                     -> [Condition ConfVar]
+extractConditions f gpkg =
+  concat [
+      maybeToList $ extractCondition (f . libBuildInfo) <$> condLibrary     gpkg
+    , extractCondition (f . buildInfo)          . snd   <$> condExecutables gpkg
+    , extractCondition (f . testBuildInfo)      . snd   <$> condTestSuites  gpkg
+    , extractCondition (f . benchmarkBuildInfo) . snd   <$> condBenchmarks  gpkg
+    ]
 
-    cor  (Lit True)  _           = Lit True
-    cor  _           (Lit True)  = Lit True
-    cor  (Lit False) x           = x
-    cor  x           (Lit False) = x
-    cor  c           (CNot d)
-      | c == d                   = Lit True
-    cor  x           y           = COr x y
 
 -- | A map of dependencies that combines version ranges using 'unionVersionRanges'.
 newtype DepMapUnion = DepMapUnion { unDepMapUnion :: Map PackageName VersionRange }

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -184,18 +184,18 @@ configureSetupScript packageDBs
                      index
                      mpkg
   = SetupScriptOptions {
-      useCabalVersion   = cabalVersion
-    , useCabalSpecVersion = Nothing
-    , useCompiler       = Just comp
-    , usePlatform       = Just platform
-    , usePackageDB      = packageDBs'
-    , usePackageIndex   = index'
-    , useProgramConfig  = conf
-    , useDistPref       = distPref
-    , useLoggingHandle  = Nothing
-    , useWorkingDir     = Nothing
-    , setupCacheLock    = lock
-    , useWin32CleanHack = False
+      useCabalVersion          = cabalVersion
+    , useCabalSpecVersion      = Nothing
+    , useCompiler              = Just comp
+    , usePlatform              = Just platform
+    , usePackageDB             = packageDBs'
+    , usePackageIndex          = index'
+    , useProgramConfig         = conf
+    , useDistPref              = distPref
+    , useLoggingHandle         = Nothing
+    , useWorkingDir            = Nothing
+    , setupCacheLock           = lock
+    , useWin32CleanHack        = False
     , forceExternalSetupMethod = forceExternal
       -- If we have explicit setup dependencies, list them; otherwise, we give
       -- the empty list of dependencies; ideally, we would fix the version of
@@ -204,8 +204,8 @@ configureSetupScript packageDBs
       -- know the version of Cabal at this point, but only find this there.
       -- Therefore, for now, we just leave this blank.
     , useDependencies          = fromMaybe [] explicitSetupDeps
-    , useDependenciesExclusive = isJust explicitSetupDeps
-    , useVersionMacros         = isJust explicitSetupDeps
+    , useDependenciesExclusive = not defaultSetupDeps && isJust explicitSetupDeps
+    , useVersionMacros         = not defaultSetupDeps && isJust explicitSetupDeps
     }
   where
     -- When we are compiling a legacy setup script without an explicit
@@ -223,13 +223,24 @@ configureSetupScript packageDBs
         -- but if the user is using an odd db stack, don't touch it
         _otherwise -> (packageDBs, Just index)
 
+    maybeSetupBuildInfo :: Maybe PkgDesc.SetupBuildInfo
+    maybeSetupBuildInfo = do
+      ReadyPackage (ConfiguredPackage (SourcePackage _ gpkg _ _) _ _ _) _
+                 <- mpkg
+      PkgDesc.setupBuildInfo (PkgDesc.packageDescription gpkg)
+
+    -- Was a default 'custom-setup' stanza added by 'cabal-install' itself? If
+    -- so, 'setup-depends' must not be exclusive. See #3199.
+    defaultSetupDeps :: Bool
+    defaultSetupDeps = maybe False PkgDesc.defaultSetupDepends
+                       maybeSetupBuildInfo
+
     explicitSetupDeps :: Maybe [(UnitId, PackageId)]
     explicitSetupDeps = do
-      ReadyPackage (ConfiguredPackage (SourcePackage _ gpkg _ _) _ _ _) deps
-                 <- mpkg
-      -- Check if there is an explicit setup stanza
-      _buildInfo <- PkgDesc.setupBuildInfo (PkgDesc.packageDescription gpkg)
+      -- Check if there is an explicit setup stanza.
+      _buildInfo <- maybeSetupBuildInfo
       -- Return the setup dependencies computed by the solver
+      ReadyPackage _ deps <- mpkg
       return [ ( Installed.installedUnitId deppkg
                , Installed.sourcePackageId    deppkg
                )

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -92,16 +92,14 @@ import Distribution.Package
          , Package(..), packageName, packageVersion
          , UnitId, Dependency(Dependency))
 import qualified Distribution.PackageDescription as PD
-         ( PackageDescription(..), SetupBuildInfo(..)
-         , GenericPackageDescription(..)
-         , Flag(flagName), FlagName(..) )
+import qualified Distribution.PackageDescription.Configuration as PD
 import Distribution.PackageDescription.Configuration
          ( finalizePackageDescription )
 import Distribution.Client.PackageUtils
          ( externalBuildDepends )
 import Distribution.Version
-         ( VersionRange, anyVersion, thisVersion, withinRange
-         , simplifyVersionRange )
+         ( VersionRange, Version(..), anyVersion, orLaterVersion, thisVersion
+         , withinRange, simplifyVersionRange )
 import Distribution.Compiler
          ( CompilerInfo(..) )
 import Distribution.System
@@ -122,7 +120,7 @@ import Distribution.Verbosity
 import Data.List
          ( foldl', sort, sortBy, nubBy, maximumBy, intercalate, nub )
 import Data.Function (on)
-import Data.Maybe (fromMaybe)
+import Data.Maybe  (fromMaybe)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.Set (Set)
@@ -392,7 +390,7 @@ removeUpperBounds allowNewer     params =
 -- 'addSourcePackages'. Otherwise, the packages inserted by
 -- 'addSourcePackages' won't have upper bounds in dependencies relaxed.
 --
-addDefaultSetupDependencies :: (SourcePackage -> [Dependency])
+addDefaultSetupDependencies :: (SourcePackage -> Maybe [Dependency])
                             -> DepResolverParams -> DepResolverParams
 addDefaultSetupDependencies defaultSetupDeps params =
     params {
@@ -408,9 +406,12 @@ addDefaultSetupDependencies defaultSetupDeps params =
               PD.setupBuildInfo =
                 case PD.setupBuildInfo pkgdesc of
                   Just sbi -> Just sbi
-                  Nothing  -> Just PD.SetupBuildInfo {
-                                PD.setupDepends = defaultSetupDeps srcpkg
-                              }
+                  Nothing  -> case defaultSetupDeps srcpkg of
+                    Nothing -> Nothing
+                    Just deps -> Just PD.SetupBuildInfo {
+                      PD.defaultSetupDepends = True,
+                      PD.setupDepends        = deps
+                    }
             }
           }
         }
@@ -449,11 +450,40 @@ standardInstallPolicy
   . hideInstalledPackagesSpecificBySourcePackageId
       [ packageId pkg | SpecificSourcePackage pkg <- pkgSpecifiers ]
 
+  . addDefaultSetupDependencies mkDefaultSetupDeps
+
   . addSourcePackages
       [ pkg  | SpecificSourcePackage pkg <- pkgSpecifiers ]
 
   $ basicDepResolverParams
       installedPkgIndex sourcePkgIndex
+
+    where
+      -- Force Cabal >= 1.24 dep when the package is affected by #3199.
+      mkDefaultSetupDeps :: SourcePackage -> Maybe [Dependency]
+      mkDefaultSetupDeps srcpkg | affected        =
+        Just [Dependency (PackageName "Cabal")
+              (orLaterVersion $ Version [1,24] [])]
+                                | otherwise       = Nothing
+        where
+          gpkgdesc = packageDescription srcpkg
+          pkgdesc  = PD.packageDescription gpkgdesc
+          bt       = fromMaybe PD.Custom (PD.buildType pkgdesc)
+          affected = bt == PD.Custom && hasBuildableFalse gpkgdesc
+
+      -- Does this package contain any components with non-empty 'build-depends'
+      -- and a 'buildable' field that could potentially be set to 'False'? False
+      -- positives are possible.
+      hasBuildableFalse :: PD.GenericPackageDescription -> Bool
+      hasBuildableFalse gpkg =
+        not (all alwaysTrue (zipWith PD.cOr buildableConditions noDepConditions))
+        where
+          buildableConditions      = PD.extractConditions PD.buildable gpkg
+          noDepConditions          = PD.extractConditions
+                                     (null . PD.targetBuildDepends)    gpkg
+          alwaysTrue (PD.Lit True) = True
+          alwaysTrue _             = False
+
 
 applySandboxInstallPolicy :: SandboxPackageInfo
                              -> DepResolverParams

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -495,7 +495,7 @@ rebuildInstallPlan verbosity
             projectConfigLocalPackages
             (getMapMappend projectConfigSpecificPackage)
       where
-        withRepoCtx = projectConfigWithSolverRepoContext verbosity 
+        withRepoCtx = projectConfigWithSolverRepoContext verbosity
                         cabalPackageCacheDirectory
                         projectConfigShared
                         projectConfigBuildOnly
@@ -573,7 +573,7 @@ programsDbSignature progdb =
 
 getInstalledPackages :: Verbosity
                      -> Compiler -> ProgramDb -> Platform
-                     -> PackageDBStack 
+                     -> PackageDBStack
                      -> Rebuild InstalledPackageIndex
 getInstalledPackages verbosity compiler progdb platform packagedbs = do
     monitorFiles . map monitorFileOrDirectory
@@ -603,7 +603,7 @@ getSourcePackages :: Verbosity -> (forall a. (RepoContext -> IO a) -> IO a)
                   -> Rebuild SourcePackageDb
 getSourcePackages verbosity withRepoCtx = do
     (sourcePkgDb, repos) <-
-      liftIO $ 
+      liftIO $
         withRepoCtx $ \repoctx -> do
           sourcePkgDb <- IndexUtils.getSourcePackages verbosity repoctx
           return (sourcePkgDb, repoContextRepos repoctx)
@@ -907,7 +907,7 @@ elaborateInstallPlan platform compiler compilerprogdb
         pkgInstalledId
           | shouldBuildInplaceOnly pkg
           = mkUnitId (display pkgid ++ "-inplace")
-          
+
           | otherwise
           = assert (isJust pkgSourceHash) $
             hashedInstalledPackageId
@@ -1181,7 +1181,7 @@ elaboratePackageTargets ElaboratedConfiguredPackage{..} targets =
         --TODO: instead of listToMaybe we should be reporting an error here
         replTargets   = listToMaybe
                       . nubComponentTargets
-                      . map compatSubComponentTargets 
+                      . map compatSubComponentTargets
                       . concatMap elaborateReplTarget
                       $ targets
         buildHaddocks = HaddockDefaultComponents `elem` targets
@@ -1324,7 +1324,7 @@ pruneInstallPlanPass1 perPkgTargetsMap pkgs =
     -- The testsuite and benchmark targets are somewhat special in that we need
     -- to configure the packages with them enabled, and we need to do that even
     -- if we only want to build one of several testsuites.
-    -- 
+    --
     -- There are two cases in which we will enable the testsuites (or
     -- benchmarks): if one of the targets is a testsuite, or if all of the
     -- testsuite depencencies are already cached in the store. The rationale
@@ -1382,7 +1382,7 @@ pruneInstallPlanPass1 perPkgTargetsMap pkgs =
         | InstallPlan.PreExisting pkg <- pkgs ]
 
 optionalStanzasWithDepsAvailable :: Set InstalledPackageId
-                                 -> ElaboratedConfiguredPackage 
+                                 -> ElaboratedConfiguredPackage
                                  -> Set OptionalStanza
 optionalStanzasWithDepsAvailable availablePkgs pkg =
     Set.fromList
@@ -1499,7 +1499,7 @@ dependencyGraph pkgid deps pkgs =
     (graph, vertexToPkg', pkgidToVertex')
   where
     (graph, vertexToPkg, pkgidToVertex) =
-      Graph.graphFromEdges [ ( pkg, pkgid pkg, deps pkg ) 
+      Graph.graphFromEdges [ ( pkg, pkgid pkg, deps pkg )
                            | pkg <- pkgs ]
     vertexToPkg'   = (\(pkg,_,_) -> pkg)
                    . vertexToPkg
@@ -1605,7 +1605,7 @@ defaultSetupDeps platform pkg =
         --             install-plan (as GHC8 requires Cabal-1.24+). So let's
         --             set an implicit upper bound `Cabal < 2` instead.
           cabalCompatMaxVer = Version [2] []
- 
+
       -- For other build types (like Simple) if we still need to compile an
       -- external Setup.hs, it'll be one of the simple ones that only depends
       -- on Cabal and base.
@@ -1614,7 +1614,7 @@ defaultSetupDeps platform pkg =
              , Dependency basePkgname  anyVersion ]
         where
           cabalConstraint = orLaterVersion (PD.specVersion pkg)
-  
+
       -- The internal setup wrapper method has no deps at all.
       SetupNonCustomInternalLib -> Just []
 
@@ -2133,7 +2133,7 @@ packageHashConfigInputs
 -- | Given the 'InstalledPackageIndex' for a nix-style package store, and an
 -- 'ElaboratedInstallPlan', replace configured source packages by pre-existing
 -- installed packages whenever they exist.
--- 
+--
 improveInstallPlanWithPreExistingPackages :: InstalledPackageIndex
                                           -> ElaboratedInstallPlan
                                           -> ElaboratedInstallPlan
@@ -2158,4 +2158,3 @@ improveInstallPlanWithPreExistingPackages installedPkgIndex installPlan =
     replaceWithPreExisting =
       foldl' (\plan ipkg -> InstallPlan.preexisting
                               (installedPackageId ipkg) ipkg plan)
-

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1575,7 +1575,7 @@ packageSetupScriptStylePreSolver pkg
 -- we still need to distinguish the case of explicit and implict setup deps.
 -- See 'rememberImplicitSetupDeps'.
 --
-defaultSetupDeps :: Platform -> PD.PackageDescription -> [Dependency]
+defaultSetupDeps :: Platform -> PD.PackageDescription -> Maybe [Dependency]
 defaultSetupDeps platform pkg =
     case packageSetupScriptStylePreSolver pkg of
 
@@ -1583,6 +1583,7 @@ defaultSetupDeps platform pkg =
       -- setup dependencies, we add a dependency on Cabal and a number
       -- of other packages.
       SetupCustomImplicitDeps ->
+        Just $
         [ Dependency depPkgname anyVersion
         | depPkgname <- legacyCustomSetupPkgs platform ] ++
         -- The Cabal dep is slightly special:
@@ -1609,13 +1610,13 @@ defaultSetupDeps platform pkg =
       -- external Setup.hs, it'll be one of the simple ones that only depends
       -- on Cabal and base.
       SetupNonCustomExternalLib ->
-        [ Dependency cabalPkgname cabalConstraint
-        , Dependency basePkgname  anyVersion ]
+        Just [ Dependency cabalPkgname cabalConstraint
+             , Dependency basePkgname  anyVersion ]
         where
           cabalConstraint = orLaterVersion (PD.specVersion pkg)
   
       -- The internal setup wrapper method has no deps at all.
-      SetupNonCustomInternalLib -> []
+      SetupNonCustomInternalLib -> Just []
 
       SetupCustomExplicitDeps ->
         error $ "defaultSetupDeps: called for a package with explicit "

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -161,15 +161,16 @@ data SetupScriptOptions = SetupScriptOptions {
     useWorkingDir            :: Maybe FilePath,
     forceExternalSetupMethod :: Bool,
 
-    -- | List of dependencies to use when building Setup.hs
+    -- | List of dependencies to use when building Setup.hs.
     useDependencies :: [(UnitId, PackageId)],
 
     -- | Is the list of setup dependencies exclusive?
     --
-    -- When this is @False@, if we compile the Setup.hs script we do so with
-    -- the list in 'useDependencies' but all other packages in the environment
-    -- are also visible. Additionally, a suitable version of @Cabal@ library
-    -- is added to the list of dependencies (see 'useCabalVersion').
+    -- When this is @False@, if we compile the Setup.hs script we do so with the
+    -- list in 'useDependencies' but all other packages in the environment are
+    -- also visible. A suitable version of @Cabal@ library (see
+    -- 'useCabalVersion') is also added to the list of dependencies, unless
+    -- 'useDependencies' already contains a Cabal dependency.
     --
     -- When @True@, only the 'useDependencies' packages are used, with other
     -- packages in the environment hidden.
@@ -604,16 +605,22 @@ externalSetupMethod verbosity options pkg bt mkargs = do
           -- With 'useDependenciesExclusive' we enforce the deps specified,
           -- so only the given ones can be used. Otherwise we allow the use
           -- of packages in the ambient environment, and add on a dep on the
-          -- Cabal library.
+          -- Cabal library (unless 'useDependencies' already contains one).
           --
           -- With 'useVersionMacros' we use a version CPP macros .h file.
           --
           -- Both of these options should be enabled for packages that have
           -- opted-in and declared a custom-settup stanza.
           --
+          hasCabal (_, PackageIdentifier (PackageName "Cabal") _) = True
+          hasCabal _                                              = False
+
           selectedDeps | useDependenciesExclusive options'
                                    = useDependencies options'
-                       | otherwise = useDependencies options' ++ cabalDep
+                       | otherwise = useDependencies options' ++
+                                     if any hasCabal (useDependencies options')
+                                     then []
+                                     else cabalDep
           addRenaming (ipid, pid) = (ipid, pid, defaultRenaming)
           cppMacrosFile = setupDir </> "setup_macros.h"
           ghcOptions = mempty {

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -248,7 +248,7 @@ executable cabal
         base16-bytestring >= 0.1.1 && < 0.2,
         binary     >= 0.5      && < 0.9,
         bytestring >= 0.9      && < 1,
-        Cabal      >= 1.24     && < 1.25,
+        Cabal      >= 1.24.1   && < 1.25,
         containers >= 0.4      && < 0.6,
         cryptohash-sha256 >= 0.11 && < 0.12,
         filepath   >= 1.3      && < 1.5,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -80,6 +80,11 @@ Extra-Source-Files:
   tests/IntegrationTests/new-build/monitor_cabal_files/q/Setup.hs
   tests/IntegrationTests/new-build/monitor_cabal_files/q/q-broken.cabal.in
   tests/IntegrationTests/new-build/monitor_cabal_files/q/q-fixed.cabal.in
+  tests/IntegrationTests/regression/common.sh
+  tests/IntegrationTests/regression/t3199.sh
+  tests/IntegrationTests/regression/t3199/Main.hs
+  tests/IntegrationTests/regression/t3199/Setup.hs
+  tests/IntegrationTests/regression/t3199/test-3199.cabal
   tests/IntegrationTests/sandbox-sources/common.sh
   tests/IntegrationTests/sandbox-sources/should_fail/fail_removing_source_thats_not_registered.err
   tests/IntegrationTests/sandbox-sources/should_fail/fail_removing_source_thats_not_registered.sh

--- a/cabal-install/tests/IntegrationTests/regression/common.sh
+++ b/cabal-install/tests/IntegrationTests/regression/common.sh
@@ -1,0 +1,9 @@
+# Helper to run Cabal
+cabal() {
+    "$CABAL" $CABAL_ARGS "$@"
+}
+
+die() {
+    echo "die: $@"
+    exit 1
+}

--- a/cabal-install/tests/IntegrationTests/regression/t3199.sh
+++ b/cabal-install/tests/IntegrationTests/regression/t3199.sh
@@ -1,0 +1,12 @@
+. ./common.sh
+
+if [[ `ghc --numeric-version` =~ "7\\." ]]; then
+    cd t3199
+    tmpfile=$(mktemp /tmp/cabal-t3199.XXXXXX)
+    cabal sandbox init
+    cabal sandbox add-source ../../../../../Cabal
+    cabal install --package-db=clear --package-db=global --only-dep --dry-run > $tmpfile
+    grep -q "the following would be installed" $tmpfile || die "Should've installed Cabal"
+    grep -q Cabal $tmpfile || die "Should've installed Cabal"
+    rm $tmpfile
+fi

--- a/cabal-install/tests/IntegrationTests/regression/t3199/Main.hs
+++ b/cabal-install/tests/IntegrationTests/regression/t3199/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/cabal-install/tests/IntegrationTests/regression/t3199/Setup.hs
+++ b/cabal-install/tests/IntegrationTests/regression/t3199/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/cabal-install/tests/IntegrationTests/regression/t3199/test-3199.cabal
+++ b/cabal-install/tests/IntegrationTests/regression/t3199/test-3199.cabal
@@ -1,0 +1,27 @@
+name:                test-t3199
+version:             0.1.0.0
+license:             BSD3
+author:              Mikhail Glushenkov
+maintainer:          mikhail.glushenkov@gmail.com
+category:            Test
+build-type:          Custom
+cabal-version:       >=1.10
+
+flag exe_2
+     description: Build second exe
+     default:     False
+
+executable test-3199-1
+  main-is:             Main.hs
+  build-depends:       base
+  default-language:    Haskell2010
+
+executable test-3199-2
+  main-is:             Main.hs
+  build-depends:       base, ansi-terminal
+  default-language:    Haskell2010
+
+  if flag(exe_2)
+     buildable: True
+  else
+     buildable: False

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
@@ -168,7 +168,8 @@ exAvSrcPkg ex =
                  , C.benchmarks     = error "not yet configured: benchmarks"
                  , C.buildDepends   = error "not yet configured: buildDepends"
                  , C.setupBuildInfo = Just C.SetupBuildInfo {
-                       C.setupDepends = mkSetupDeps (CD.setupDeps (exAvDeps ex))
+                       C.setupDepends = mkSetupDeps (CD.setupDeps (exAvDeps ex)),
+                       C.defaultSetupDepends = False
                      }
                  }
              , C.genPackageFlags = nub $ concatMap extractFlags


### PR DESCRIPTION
Fixes #3199. 

To minimise the impact we should probably add default setup dependencies only to packages affected by #3199 (see @grayjay's [snippet](https://gist.github.com/grayjay/c5c2627d02303bd59a3b164055233bcb)). Note, however, that the setup wrapper will pick Cabal >= 1.24 anyway if it is installed, since it prefers new Cabal versions.

Note also that `cabal configure` will still fail (unlike `cabal install`), though the error message will be more helpful than it currently is:

```
Resolving dependencies...
Warning: solver failed to find a solution:
Could not resolve dependencies:
trying: test-t3199-0.1.0.0 (user goal)
next goal: test-t3199-setup.Cabal (dependency of test-t3199-0.1.0.0)
rejecting: test-t3199-setup.Cabal-1.22.5.0/installed-cfe... (conflict:
test-t3199 => test-t3199-setup.Cabal>=1.24)
Dependency tree exhaustively searched.
Trying configure anyway.
Configuring test-t3199-0.1.0.0...
```

/cc @dcoutts 