### PR TITLE
Remove the 'run tests' step from setup-dev.sh

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -27,8 +27,6 @@ setup() {
     echo "Cabal package DB location: $PACKAGEDB"
     ./Setup configure --enable-tests --package-db="$PACKAGEDB" || die "$NAME: 'configure' failed"
     ./Setup build || die "$NAME: 'build' failed"
-    # Run tests
-    ./Setup test || die "$1 'test' failed"
 }
 
 # Build


### PR DESCRIPTION
As it turns out we often get spurious test failures, and it's generally
more useful to be able to actually build *everything* rather than having
the tests pass while building. (We already have pre-merge Travis checks,
so it's not that likely that something will slip through anyway.)