### PR TITLE
Add quickcheck test to compare dependency solving with and without backjumping

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
@@ -31,7 +31,8 @@ data SolverConfig = SolverConfig {
   avoidReinstalls       :: Bool,
   shadowPkgs            :: Bool,
   strongFlags           :: Bool,
-  maxBackjumps          :: Maybe Int
+  maxBackjumps          :: Maybe Int,
+  enableBackjumping     :: EnableBackjumping
 }
 
 -- | Run all solver phases.
@@ -76,7 +77,7 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
   prunePhase       $
   buildPhase
   where
-    explorePhase     = backjumpAndExplore
+    explorePhase     = backjumpAndExplore (enableBackjumping sc)
     heuristicsPhase  = (if preferEasyGoalChoices sc
                          then P.preferEasyGoalChoices -- also leaves just one choice
                          else P.firstGoal) . -- after doing goal-choice heuristics, commit to the first choice (saves space)

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -16,6 +16,7 @@
 module Distribution.Client.Dependency.Types (
     PreSolver(..),
     Solver(..),
+    EnableBackjumping(..),
     DependencyResolver,
     ResolverPackage(..),
 
@@ -104,6 +105,9 @@ instance Text PreSolver where
       "modular" -> return AlwaysModular
       "choose"  -> return Choose
       _         -> Parse.pfail
+
+newtype EnableBackjumping = EnableBackjumping Bool
+  deriving Show
 
 -- | A dependency resolver is a function that works out an installation plan
 -- given the set of installed and available packages and a set of deps to

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
@@ -397,9 +397,11 @@ exResolve :: ExampleDb
           -> Maybe Int
           -> IndepGoals
           -> ReorderGoals
+          -> EnableBackjumping
           -> [ExPreference]
           -> ([String], Either String CI.InstallPlan.SolverInstallPlan)
-exResolve db exts langs pkgConfigDb targets solver mbj (IndepGoals indepGoals) (ReorderGoals reorder) prefs
+exResolve db exts langs pkgConfigDb targets solver mbj (IndepGoals indepGoals)
+          (ReorderGoals reorder) enableBj prefs
     = runProgress $ resolveDependencies C.buildPlatform
                         compiler pkgConfigDb
                         solver
@@ -424,6 +426,7 @@ exResolve db exts langs pkgConfigDb targets solver mbj (IndepGoals indepGoals) (
                    $ setIndependentGoals indepGoals
                    $ setReorderGoals reorder
                    $ setMaxBackjumps mbj
+                   $ setEnableBackjumping enableBj
                    $ standardInstallPolicy instIdx avaiIdx targets'
     toLpc     pc = LabeledPackageConstraint pc ConstraintSourceUnknown
     toPref (ExPref n v) = PackageVersionPreference (C.PackageName n) v

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -19,7 +19,7 @@ import Language.Haskell.Extension ( Extension(..)
 
 -- cabal-install
 import Distribution.Client.PkgConfigDb (PkgConfigDb, pkgConfigDbFromList)
-import Distribution.Client.Dependency.Types (Solver(Modular))
+import Distribution.Client.Dependency.Types (EnableBackjumping(..), Solver(Modular))
 import UnitTests.Distribution.Client.Dependency.Modular.DSL
 import UnitTests.Options
 
@@ -244,7 +244,7 @@ runTest SolverTest{..} = askOption $ \(OptionShowSolverLog showSolverLog) ->
       let (_msgs, result) = exResolve testDb testSupportedExts
                             testSupportedLangs testPkgConfigDb testTargets
                             Modular Nothing testIndepGoals (ReorderGoals False)
-                            testSoftConstraints
+                            (EnableBackjumping True) testSoftConstraints
       when showSolverLog $ mapM_ putStrLn _msgs
       case result of
         Left  err  -> assertBool ("Unexpected error:\n" ++ err) (check testResult err)


### PR DESCRIPTION
Here is the test that I mentioned in #3357.  It added a lot more code than I expected, and it doesn't seem to find bugs in conflict sets any faster than the existing tests, so I'm not sure it's worth merging.