### PR TITLE
Test reinstalling modified add-source dependencies

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -88,6 +88,11 @@ Extra-Source-Files:
   tests/IntegrationTests/regression/t3199/Main.hs
   tests/IntegrationTests/regression/t3199/Setup.hs
   tests/IntegrationTests/regression/t3199/test-3199.cabal
+  tests/IntegrationTests/sandbox-reinstalls/p/Main.hs
+  tests/IntegrationTests/sandbox-reinstalls/p/p.cabal
+  tests/IntegrationTests/sandbox-reinstalls/q/Q.hs
+  tests/IntegrationTests/sandbox-reinstalls/q/q.cabal
+  tests/IntegrationTests/sandbox-reinstalls/reinstall-modified-source.sh
   tests/IntegrationTests/sandbox-sources/fail_removing_source_thats_not_registered.err
   tests/IntegrationTests/sandbox-sources/fail_removing_source_thats_not_registered.sh
   tests/IntegrationTests/sandbox-sources/p/Setup.hs

--- a/cabal-install/tests/IntegrationTests/sandbox-reinstalls/p/Main.hs
+++ b/cabal-install/tests/IntegrationTests/sandbox-reinstalls/p/Main.hs
@@ -1,0 +1,4 @@
+import Q (message)
+
+main :: IO ()
+main = putStrLn message

--- a/cabal-install/tests/IntegrationTests/sandbox-reinstalls/p/p.cabal
+++ b/cabal-install/tests/IntegrationTests/sandbox-reinstalls/p/p.cabal
@@ -1,0 +1,8 @@
+name: p
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.2
+
+executable p
+  main-is: Main.hs
+  build-depends: q, base

--- a/cabal-install/tests/IntegrationTests/sandbox-reinstalls/q/Q.hs
+++ b/cabal-install/tests/IntegrationTests/sandbox-reinstalls/q/Q.hs
@@ -1,0 +1,4 @@
+module Q where
+
+message :: String
+message = "message"

--- a/cabal-install/tests/IntegrationTests/sandbox-reinstalls/q/q.cabal
+++ b/cabal-install/tests/IntegrationTests/sandbox-reinstalls/q/q.cabal
@@ -1,0 +1,8 @@
+name: q
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.2
+
+library
+  build-depends: base
+  exposed-modules: Q

--- a/cabal-install/tests/IntegrationTests/sandbox-reinstalls/reinstall-modified-source.sh
+++ b/cabal-install/tests/IntegrationTests/sandbox-reinstalls/reinstall-modified-source.sh
@@ -1,0 +1,16 @@
+. ./common.sh
+
+cd p
+cabal sandbox init
+cabal sandbox add-source ../q
+
+cabal install --only-dependencies
+cabal run p -v0 | grep -q '^message$' \
+    || die "Expected \"message\" in p's output."
+
+sleep 1
+# Append to the string that p imports from q and prints:
+echo '       ++ " updated"' >> ../q/Q.hs
+
+cabal run p -v0 | grep -q '^message updated$' \
+    || die "Expected \"message updated\" in p's output."


### PR DESCRIPTION
I started writing this test to debug something and thought it might be useful to add to the test suite.  It runs for about 10 seconds.  I wasn't sure about one part.  How should an integration test wait for timestamps to change?