### PR TITLE
Enable solver quickcheck tests in continuous integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,3 +26,4 @@ build_script:
   - ..\cabal build
   - ..\cabal test unit-tests --show-details=streaming --test-option=--pattern=!FileMonitor --test-option=--hide-successes
   - ..\cabal test integration-tests --show-details=streaming --test-option=--pattern=!exec --test-option=--hide-successes
+  - ..\cabal test solver-quickcheck --show-details=streaming --test-option=--hide-successes --test-option=--quickcheck-tests=1000

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -83,6 +83,8 @@ cabal build
 cabal haddock # see https://github.com/haskell/cabal/issues/2198
 cabal test unit-tests --show-details=streaming --test-option=--hide-successes
 cabal test integration-tests --show-details=streaming --test-option=--hide-successes
+cabal test solver-quickcheck --show-details=streaming --test-option=--hide-successes \
+    --test-option=--quickcheck-tests=1000
 cabal check
 ./dist/setup/setup sdist
 install_from_tarball


### PR DESCRIPTION
I used `--quickcheck-tests=1000`, which runs for about 4 seconds on Travis.