### PR TITLE
Adjustments for what deps we pick for legacy Setup scripts in new-build

### DIFF
--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -26,6 +26,7 @@ module Distribution.Simple.Compiler (
         Compiler(..),
         showCompilerId, showCompilerIdWithAbi,
         compilerFlavor, compilerVersion,
+        compilerCompatFlavor,
         compilerCompatVersion,
         compilerInfo,
 
@@ -112,6 +113,30 @@ compilerFlavor = (\(CompilerId f _) -> f) . compilerId
 compilerVersion :: Compiler -> Version
 compilerVersion = (\(CompilerId _ v) -> v) . compilerId
 
+
+-- | Is this compiler compatible with the compiler flavour we're interested in?
+--
+-- For example this checks if the compiler is actually GHC or is another
+-- compiler that claims to be compatible with some version of GHC, e.g. GHCJS.
+--
+-- > if compilerCompatFlavor GHC compiler then ... else ...
+--
+compilerCompatFlavor :: CompilerFlavor -> Compiler -> Bool
+compilerCompatFlavor flavor comp =
+    flavor == compilerFlavor comp
+ || flavor `elem` [ flavor' | CompilerId flavor' _ <- compilerCompat comp ]
+
+
+-- | Is this compiler compatible with the compiler flavour we're interested in,
+-- and if so what version does it claim to be compatible with.
+--
+-- For example this checks if the compiler is actually GHC-7.x or is another
+-- compiler that claims to be compatible with some GHC-7.x version.
+--
+-- > case compilerCompatVersion GHC compiler of
+-- >   Just (Version (7:_)) -> ...
+-- >   _                    -> ...
+--
 compilerCompatVersion :: CompilerFlavor -> Compiler -> Maybe Version
 compilerCompatVersion flavor comp
   | compilerFlavor comp == flavor = Just (compilerVersion comp)

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1740,25 +1740,31 @@ defaultSetupDeps compiler platform pkg =
         Just $
         [ Dependency depPkgname anyVersion
         | depPkgname <- legacyCustomSetupPkgs compiler platform ] ++
-        -- The Cabal dep is slightly special:
-        --  * we omit the dep for the Cabal lib itself (since it bootstraps),
-        --  * we constrain it to be less than 1.23 since all packages
-        --    relying on later Cabal spec versions are supposed to use
-        --    explit setup deps. Having this constraint also allows later
-        --    Cabal lib versions to make breaking API changes without breaking
-        --    all old Setup.hs scripts.
         [ Dependency cabalPkgname cabalConstraint
         | packageName pkg /= cabalPkgname ]
         where
-          cabalConstraint   = orLaterVersion (PD.specVersion pkg)
+          -- The Cabal dep is slightly special:
+          -- * We omit the dep for the Cabal lib itself, since it bootstraps.
+          -- * We constrain it to be >= 1.18 < 2
+          --
+          cabalConstraint   = orLaterVersion cabalCompatMinVer
+                                `intersectVersionRanges`
+                              orLaterVersion (PD.specVersion pkg)
                                 `intersectVersionRanges`
                               earlierVersion cabalCompatMaxVer
-        -- TODO/FIXME: turns out that constraining to less than 1.23 causes
-        --             problems with GHC8 as there's too many important packages
-        --             with Custom build-type, for which there wouldn't be any
-        --             install-plan (as GHC8 requires Cabal-1.24+). So let's
-        --             set an implicit upper bound `Cabal < 2` instead.
+          -- The idea here is that at some point we will make significant
+          -- breaking changes to the Cabal API that Setup.hs scripts use.
+          -- So for old custom Setup scripts that do not specify explicit
+          -- constraints, we constrain them to use a compatible Cabal version.
+          -- The exact version where we'll make this API break has not yet been
+          -- decided, so for the meantime we guess at 2.x.
           cabalCompatMaxVer = Version [2] []
+          -- In principle we can talk to any old Cabal version, and we need to
+          -- be able to do that for custom Setup scripts that require older
+          -- Cabal lib versions. However in practice we have currently have
+          -- problems with Cabal-1.16. (1.16 does not know about build targets)
+          -- If this is fixed we can relax this constraint.
+          cabalCompatMinVer = Version [1,18] []
 
       -- For other build types (like Simple) if we still need to compile an
       -- external Setup.hs, it'll be one of the simple ones that only depends

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -871,7 +871,7 @@ planPackages comp platform solver SolverSettings{..}
 
       . removeUpperBounds solverSettingAllowNewer
 
-      . addDefaultSetupDependencies (defaultSetupDeps platform
+      . addDefaultSetupDependencies (defaultSetupDeps comp platform
                                    . PD.packageDescription
                                    . packageDescription)
 
@@ -1727,8 +1727,10 @@ packageSetupScriptStylePreSolver pkg
 -- we still need to distinguish the case of explicit and implict setup deps.
 -- See 'rememberImplicitSetupDeps'.
 --
-defaultSetupDeps :: Platform -> PD.PackageDescription -> Maybe [Dependency]
-defaultSetupDeps platform pkg =
+defaultSetupDeps :: Compiler -> Platform
+                 -> PD.PackageDescription
+                 -> Maybe [Dependency]
+defaultSetupDeps compiler platform pkg =
     case packageSetupScriptStylePreSolver pkg of
 
       -- For packages with build type custom that do not specify explicit
@@ -1737,7 +1739,7 @@ defaultSetupDeps platform pkg =
       SetupCustomImplicitDeps ->
         Just $
         [ Dependency depPkgname anyVersion
-        | depPkgname <- legacyCustomSetupPkgs platform ] ++
+        | depPkgname <- legacyCustomSetupPkgs compiler platform ] ++
         -- The Cabal dep is slightly special:
         --  * we omit the dep for the Cabal lib itself (since it bootstraps),
         --  * we constrain it to be less than 1.23 since all packages
@@ -1868,14 +1870,18 @@ cabalPkgname = PackageName "Cabal"
 basePkgname  = PackageName "base"
 
 
-legacyCustomSetupPkgs :: Platform -> [PackageName]
-legacyCustomSetupPkgs (Platform _ os) =
+legacyCustomSetupPkgs :: Compiler -> Platform -> [PackageName]
+legacyCustomSetupPkgs compiler (Platform _ os) =
     map PackageName $
         [ "array", "base", "binary", "bytestring", "containers"
-        , "deepseq", "directory", "filepath", "pretty"
-        , "process", "time" ]
+        , "deepseq", "directory", "filepath", "old-time", "pretty"
+        , "process", "time", "transformers" ]
      ++ [ "Win32" | os == Windows ]
      ++ [ "unix"  | os /= Windows ]
+     ++ [ "ghc-prim"         | isGHC ]
+     ++ [ "template-haskell" | isGHC ]
+  where
+    isGHC = compilerCompatFlavor GHC compiler
 
 -- The other aspects of our Setup.hs policy lives here where we decide on
 -- the 'SetupScriptOptions'.


### PR DESCRIPTION
See patch descriptions. The main outstanding question that I've not properly checked yet is whether the old-time dep needs to be conditional. Do all current ghc versions still ship it as a core lib? If so it's fine, if not I'll have to make it conditional.

This ought to fix building a few Setup.hs scripts. I can't remember which one it was, but there was a real world example where it failed due to lacking both template-haskell and transformers.

Also add the >= 1.18 workaround that @hvr suggested.