### PR TITLE
Use newtypes for Bool solver options

### DIFF
--- a/cabal-install/Distribution/Client/Dependency/Modular/Builder.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Builder.hs
@@ -29,6 +29,7 @@ import qualified Distribution.Client.Dependency.Modular.PSQ as P
 import Distribution.Client.Dependency.Modular.Tree
 
 import Distribution.Client.ComponentDeps (Component)
+import Distribution.Client.Dependency.Types (IndependentGoals(..))
 
 -- | The state needed during the build phase of the search tree.
 data BuildState = BS {
@@ -172,8 +173,8 @@ build = ana go
 
 -- | Interface to the tree builder. Just takes an index and a list of package names,
 -- and computes the initial state and then the tree from there.
-buildTree :: Index -> Bool -> [PN] -> Tree QGoalReason
-buildTree idx ind igs =
+buildTree :: Index -> IndependentGoals -> [PN] -> Tree QGoalReason
+buildTree idx (IndependentGoals ind) igs =
     build BS {
         index = idx
       , rdeps = M.fromList (L.map (\ qpn -> (qpn, []))              qpns)

--- a/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/Distribution/Client/Dependency/Modular/Solver.hs
@@ -23,6 +23,7 @@ import Distribution.Client.Dependency.Modular.Package
 import qualified Distribution.Client.Dependency.Modular.Preference as P
 import Distribution.Client.Dependency.Modular.Validate
 import Distribution.Client.Dependency.Modular.Linking
+import Distribution.Client.Types (BooleanFlag(..))
 
 -- | Various options for the modular solver.
 data SolverConfig = SolverConfig {
@@ -78,7 +79,7 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
   buildPhase
   where
     explorePhase     = backjumpAndExplore (enableBackjumping sc)
-    heuristicsPhase  = (if unReorderGoals (preferEasyGoalChoices sc)
+    heuristicsPhase  = (if asBool (preferEasyGoalChoices sc)
                          then P.preferEasyGoalChoices -- also leaves just one choice
                          else P.firstGoal) . -- after doing goal-choice heuristics, commit to the first choice (saves space)
                        P.deferWeakFlagChoices .
@@ -91,7 +92,7 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
                        P.enforceSingleInstanceRestriction .
                        validateLinking idx .
                        validateTree cinfo idx pkgConfigDB
-    prunePhase       = (if unAvoidReinstalls (avoidReinstalls sc) then P.avoidReinstalls (const True) else id) .
+    prunePhase       = (if asBool (avoidReinstalls sc) then P.avoidReinstalls (const True) else id) .
                        -- packages that can never be "upgraded":
                        P.requireInstalled (`elem` [ PackageName "base"
                                                   , PackageName "ghc-prim"

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -16,7 +16,14 @@
 module Distribution.Client.Dependency.Types (
     PreSolver(..),
     Solver(..),
+
+    ReorderGoals(..),
+    IndependentGoals(..),
+    AvoidReinstalls(..),
+    ShadowPkgs(..),
+    StrongFlags(..),
     EnableBackjumping(..),
+
     DependencyResolver,
     ResolverPackage(..),
 
@@ -106,8 +113,29 @@ instance Text PreSolver where
       "choose"  -> return Choose
       _         -> Parse.pfail
 
+newtype ReorderGoals = ReorderGoals { unReorderGoals :: Bool }
+  deriving (Eq, Generic, Show)
+
+newtype IndependentGoals = IndependentGoals { unIndependentGoals :: Bool }
+  deriving (Eq, Generic, Show)
+
+newtype AvoidReinstalls = AvoidReinstalls { unAvoidReinstalls :: Bool }
+  deriving (Eq, Generic, Show)
+
+newtype ShadowPkgs = ShadowPkgs { unShadowPkgs :: Bool }
+  deriving (Eq, Generic, Show)
+
+newtype StrongFlags = StrongFlags { unStrongFlags :: Bool }
+  deriving (Eq, Generic, Show)
+
 newtype EnableBackjumping = EnableBackjumping Bool
   deriving Show
+
+instance Binary ReorderGoals
+instance Binary IndependentGoals
+instance Binary AvoidReinstalls
+instance Binary ShadowPkgs
+instance Binary StrongFlags
 
 -- | A dependency resolver is a function that works out an installation plan
 -- given the set of installed and available packages and a set of deps to

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Dependency.Types
@@ -60,7 +61,8 @@ import Data.Monoid
 import Distribution.Client.PkgConfigDb
          ( PkgConfigDb )
 import Distribution.Client.Types
-         ( OptionalStanza(..), SourcePackage(..), SolverPackage )
+         ( BooleanFlag(..), OptionalStanza(..), SourcePackage(..)
+         , SolverPackage )
 
 import qualified Distribution.Compat.ReadP as Parse
          ( pfail, munch1 )
@@ -113,23 +115,23 @@ instance Text PreSolver where
       "choose"  -> return Choose
       _         -> Parse.pfail
 
-newtype ReorderGoals = ReorderGoals { unReorderGoals :: Bool }
-  deriving (Eq, Generic, Show)
+newtype ReorderGoals = ReorderGoals Bool
+  deriving (BooleanFlag, Eq, Generic, Show)
 
-newtype IndependentGoals = IndependentGoals { unIndependentGoals :: Bool }
-  deriving (Eq, Generic, Show)
+newtype IndependentGoals = IndependentGoals Bool
+  deriving (BooleanFlag, Eq, Generic, Show)
 
-newtype AvoidReinstalls = AvoidReinstalls { unAvoidReinstalls :: Bool }
-  deriving (Eq, Generic, Show)
+newtype AvoidReinstalls = AvoidReinstalls Bool
+  deriving (BooleanFlag, Eq, Generic, Show)
 
-newtype ShadowPkgs = ShadowPkgs { unShadowPkgs :: Bool }
-  deriving (Eq, Generic, Show)
+newtype ShadowPkgs = ShadowPkgs Bool
+  deriving (BooleanFlag, Eq, Generic, Show)
 
-newtype StrongFlags = StrongFlags { unStrongFlags :: Bool }
-  deriving (Eq, Generic, Show)
+newtype StrongFlags = StrongFlags Bool
+  deriving (BooleanFlag, Eq, Generic, Show)
 
 newtype EnableBackjumping = EnableBackjumping Bool
-  deriving Show
+  deriving (BooleanFlag, Eq, Generic, Show)
 
 instance Binary ReorderGoals
 instance Binary IndependentGoals

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -61,6 +61,8 @@ import Distribution.InstalledPackageInfo
 import Distribution.Package
          ( PackageIdentifier(..), PackageName(..), Package(..)
          , HasUnitId(..), UnitId(..) )
+import Distribution.Client.Dependency.Types
+         ( IndependentGoals(..) )
 import Distribution.Client.Types
          ( BuildSuccess, BuildFailure
          , PackageFixedDeps(..)
@@ -201,7 +203,7 @@ instance (HasUnitId ipkg, HasUnitId srcpkg) =>
 
 data GenericInstallPlan ipkg srcpkg iresult ifailure = GenericInstallPlan {
     planIndex      :: !(PlanIndex ipkg srcpkg iresult ifailure),
-    planIndepGoals :: !Bool,
+    planIndepGoals :: !IndependentGoals,
 
     -- | Cached (lazily) graph
     --
@@ -296,7 +298,7 @@ invariant plan =
 mkInstallPlan :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
                   HasUnitId srcpkg, PackageFixedDeps srcpkg)
               => PlanIndex ipkg srcpkg iresult ifailure
-              -> Bool
+              -> IndependentGoals
               -> GenericInstallPlan ipkg srcpkg iresult ifailure
 mkInstallPlan index indepGoals =
     GenericInstallPlan {
@@ -354,7 +356,7 @@ showPlanPackageTag (Failed    _   _) = "Failed"
 --
 new :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
         HasUnitId srcpkg, PackageFixedDeps srcpkg)
-    => Bool
+    => IndependentGoals
     -> PlanIndex ipkg srcpkg iresult ifailure
     -> Either [PlanProblem ipkg srcpkg iresult ifailure]
               (GenericInstallPlan ipkg srcpkg iresult ifailure)
@@ -619,7 +621,7 @@ mapPreservingGraph f plan =
 --
 valid :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
           HasUnitId srcpkg, PackageFixedDeps srcpkg)
-      => Bool
+      => IndependentGoals
       -> PlanIndex ipkg srcpkg iresult ifailure
       -> Bool
 valid indepGoals index =
@@ -671,7 +673,7 @@ showPlanProblem (PackageStateInvalid pkg pkg') =
 --
 problems :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
              HasUnitId srcpkg, PackageFixedDeps srcpkg)
-         => Bool
+         => IndependentGoals
          -> PlanIndex ipkg srcpkg iresult ifailure
          -> [PlanProblem ipkg srcpkg iresult ifailure]
 problems indepGoals index =
@@ -737,7 +739,7 @@ closed = null . PlanIndex.brokenPackages
 consistent :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
                HasUnitId srcpkg, PackageFixedDeps srcpkg)
            => PlanIndex ipkg srcpkg iresult ifailure -> Bool
-consistent = null . PlanIndex.dependencyInconsistencies False
+consistent = null . PlanIndex.dependencyInconsistencies (IndependentGoals False)
 
 -- | The states of packages have that depend on each other must respect
 -- this relation. That is for very case where package @a@ depends on

--- a/cabal-install/Distribution/Client/PlanIndex.hs
+++ b/cabal-install/Distribution/Client/PlanIndex.hs
@@ -32,6 +32,7 @@ import Distribution.Version
          ( Version )
 
 import qualified Distribution.Client.ComponentDeps as CD
+import Distribution.Client.Dependency.Types
 import Distribution.Client.Types
          ( PackageFixedDeps(..) )
 import Distribution.Simple.PackageIndex
@@ -62,7 +63,7 @@ brokenPackages index =
 -- cycle. Such cycles may or may not be an issue; either way, we don't check
 -- for them here.
 dependencyInconsistencies :: forall pkg. (PackageFixedDeps pkg, HasUnitId pkg)
-                          => Bool
+                          => IndependentGoals
                           -> PackageIndex pkg
                           -> [(PackageName, [(PackageIdentifier, Version)])]
 dependencyInconsistencies indepGoals index  =
@@ -80,8 +81,8 @@ dependencyInconsistencies indepGoals index  =
 -- as singletons sets if we are considering them as independent goals), along
 -- with all setup dependencies of all packages.
 rootSets :: (PackageFixedDeps pkg, HasUnitId pkg)
-         => Bool -> PackageIndex pkg -> [[UnitId]]
-rootSets indepGoals index =
+         => IndependentGoals -> PackageIndex pkg -> [[UnitId]]
+rootSets (IndependentGoals indepGoals) index =
        if indepGoals then map (:[]) libRoots else [libRoots]
     ++ setupRoots index
   where

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -47,6 +47,8 @@ import Distribution.Client.Glob
          ( isTrivialFilePathGlob )
 
 import Distribution.Client.Types
+import Distribution.Client.Dependency.Types
+         ( ReorderGoals(..), StrongFlags(..) )
 import Distribution.Client.DistDirLayout
          ( CabalDirLayout(..) )
 import Distribution.Client.GlobalFlags
@@ -205,8 +207,8 @@ resolveSolverSettings ProjectConfig{
        projectConfigSolver            = Flag defaultSolver,
        projectConfigAllowNewer        = Just AllowNewerNone,
        projectConfigMaxBackjumps      = Flag defaultMaxBackjumps,
-       projectConfigReorderGoals      = Flag False,
-       projectConfigStrongFlags       = Flag False
+       projectConfigReorderGoals      = Flag (ReorderGoals False),
+       projectConfigStrongFlags       = Flag (StrongFlags False)
      --projectConfigIndependentGoals  = Flag False,
      --projectConfigShadowPkgs        = Flag False,
      --projectConfigReinstall         = Flag False,

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -22,7 +22,7 @@ module Distribution.Client.ProjectConfig.Types (
 import Distribution.Client.Types
          ( RemoteRepo )
 import Distribution.Client.Dependency.Types
-         ( PreSolver, ConstraintSource )
+         ( PreSolver, ConstraintSource, ReorderGoals, StrongFlags )
 import Distribution.Client.Targets
          ( UserConstraint )
 import Distribution.Client.BuildReports.Types 
@@ -161,8 +161,8 @@ data ProjectConfigShared
        projectConfigSolver            :: Flag PreSolver,
        projectConfigAllowNewer        :: Maybe AllowNewer,
        projectConfigMaxBackjumps      :: Flag Int,
-       projectConfigReorderGoals      :: Flag Bool,
-       projectConfigStrongFlags       :: Flag Bool
+       projectConfigReorderGoals      :: Flag ReorderGoals,
+       projectConfigStrongFlags       :: Flag StrongFlags
 
        -- More things that only make sense for manual mode, not --local mode
        -- too much control!
@@ -315,8 +315,8 @@ data SolverSettings
        solverSettingSolver            :: PreSolver,
        solverSettingAllowNewer        :: AllowNewer,
        solverSettingMaxBackjumps      :: Maybe Int,
-       solverSettingReorderGoals      :: Bool,
-       solverSettingStrongFlags       :: Bool
+       solverSettingReorderGoals      :: ReorderGoals,
+       solverSettingStrongFlags       :: StrongFlags
        -- Things that only make sense for manual mode, not --local mode
        -- too much control!
      --solverSettingIndependentGoals  :: Bool,

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1409,7 +1409,7 @@ pruneInstallPlanToTargets :: Map InstalledPackageId [PackageTarget]
                           -> ElaboratedInstallPlan -> ElaboratedInstallPlan
 pruneInstallPlanToTargets perPkgTargetsMap =
     either (\_ -> assert False undefined) id
-  . InstallPlan.new False
+  . InstallPlan.new (IndependentGoals False)
   . PackageIndex.fromList
     -- We have to do this in two passes
   . pruneInstallPlanPass2

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -55,7 +55,7 @@ module Distribution.Client.Setup
     ) where
 
 import Distribution.Client.Types
-         ( Username(..), Password(..), RemoteRepo(..) )
+         ( BooleanFlag(..), Username(..), Password(..), RemoteRepo(..) )
 import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
 import Distribution.Client.Dependency.Types
@@ -1329,7 +1329,7 @@ installOptions showOrParseArgs =
 
       , option [] ["avoid-reinstalls"]
           "Do not select versions that would destructively overwrite installed packages."
-          (fmap unAvoidReinstalls . installAvoidReinstalls)
+          (fmap asBool . installAvoidReinstalls)
           (\v flags -> flags { installAvoidReinstalls = fmap AvoidReinstalls v })
           (yesNoOpt showOrParseArgs)
 
@@ -2081,7 +2081,7 @@ optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg _getig _setig getsip
                     (map show . flagToList))
   , option [] ["reorder-goals"]
       "Try to reorder goals according to certain heuristics. Slows things down on average, but may make backtracking faster for some packages."
-      (fmap unReorderGoals . getrg)
+      (fmap asBool . getrg)
       (setrg . fmap ReorderGoals)
       (yesNoOpt showOrParseArgs)
   -- TODO: Disabled for now because it does not work as advertised (yet).
@@ -2093,12 +2093,12 @@ optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg _getig _setig getsip
 -}
   , option [] ["shadow-installed-packages"]
       "If multiple package instances of the same version are installed, treat all but one as shadowed."
-      (fmap unShadowPkgs . getsip)
+      (fmap asBool . getsip)
       (setsip . fmap ShadowPkgs)
       (yesNoOpt showOrParseArgs)
   , option [] ["strong-flags"]
       "Do not defer flag choices (this used to be the default in cabal-install <= 1.20)."
-      (fmap unStrongFlags . getstrfl)
+      (fmap asBool . getstrfl)
       (setstrfl . fmap StrongFlags)
       (yesNoOpt showOrParseArgs)
   ]

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -59,7 +59,9 @@ import Distribution.Client.Types
 import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
 import Distribution.Client.Dependency.Types
-         ( PreSolver(..), ConstraintSource(..) )
+         ( PreSolver(..), ConstraintSource(..), ReorderGoals(..)
+         , IndependentGoals(..), AvoidReinstalls(..), ShadowPkgs(..)
+         , StrongFlags(..) )
 import qualified Distribution.Client.Init.Types as IT
          ( InitFlags(..), PackageType(..) )
 import Distribution.Client.Targets
@@ -602,10 +604,10 @@ data FetchFlags = FetchFlags {
       fetchDryRun    :: Flag Bool,
       fetchSolver           :: Flag PreSolver,
       fetchMaxBackjumps     :: Flag Int,
-      fetchReorderGoals     :: Flag Bool,
-      fetchIndependentGoals :: Flag Bool,
-      fetchShadowPkgs       :: Flag Bool,
-      fetchStrongFlags      :: Flag Bool,
+      fetchReorderGoals     :: Flag ReorderGoals,
+      fetchIndependentGoals :: Flag IndependentGoals,
+      fetchShadowPkgs       :: Flag ShadowPkgs,
+      fetchStrongFlags      :: Flag StrongFlags,
       fetchVerbosity :: Flag Verbosity
     }
 
@@ -616,10 +618,10 @@ defaultFetchFlags = FetchFlags {
     fetchDryRun    = toFlag False,
     fetchSolver           = Flag defaultSolver,
     fetchMaxBackjumps     = Flag defaultMaxBackjumps,
-    fetchReorderGoals     = Flag False,
-    fetchIndependentGoals = Flag False,
-    fetchShadowPkgs       = Flag False,
-    fetchStrongFlags      = Flag False,
+    fetchReorderGoals     = Flag (ReorderGoals False),
+    fetchIndependentGoals = Flag (IndependentGoals False),
+    fetchShadowPkgs       = Flag (ShadowPkgs False),
+    fetchStrongFlags      = Flag (StrongFlags False),
     fetchVerbosity = toFlag normal
    }
 
@@ -679,10 +681,10 @@ data FreezeFlags = FreezeFlags {
       freezeBenchmarks       :: Flag Bool,
       freezeSolver           :: Flag PreSolver,
       freezeMaxBackjumps     :: Flag Int,
-      freezeReorderGoals     :: Flag Bool,
-      freezeIndependentGoals :: Flag Bool,
-      freezeShadowPkgs       :: Flag Bool,
-      freezeStrongFlags      :: Flag Bool,
+      freezeReorderGoals     :: Flag ReorderGoals,
+      freezeIndependentGoals :: Flag IndependentGoals,
+      freezeShadowPkgs       :: Flag ShadowPkgs,
+      freezeStrongFlags      :: Flag StrongFlags,
       freezeVerbosity        :: Flag Verbosity
     }
 
@@ -693,10 +695,10 @@ defaultFreezeFlags = FreezeFlags {
     freezeBenchmarks       = toFlag False,
     freezeSolver           = Flag defaultSolver,
     freezeMaxBackjumps     = Flag defaultMaxBackjumps,
-    freezeReorderGoals     = Flag False,
-    freezeIndependentGoals = Flag False,
-    freezeShadowPkgs       = Flag False,
-    freezeStrongFlags      = Flag False,
+    freezeReorderGoals     = Flag (ReorderGoals False),
+    freezeIndependentGoals = Flag (IndependentGoals False),
+    freezeShadowPkgs       = Flag (ShadowPkgs False),
+    freezeStrongFlags      = Flag (StrongFlags False),
     freezeVerbosity        = toFlag normal
    }
 
@@ -1140,12 +1142,12 @@ data InstallFlags = InstallFlags {
     installHaddockIndex     :: Flag PathTemplate,
     installDryRun           :: Flag Bool,
     installMaxBackjumps     :: Flag Int,
-    installReorderGoals     :: Flag Bool,
-    installIndependentGoals :: Flag Bool,
-    installShadowPkgs       :: Flag Bool,
-    installStrongFlags      :: Flag Bool,
+    installReorderGoals     :: Flag ReorderGoals,
+    installIndependentGoals :: Flag IndependentGoals,
+    installShadowPkgs       :: Flag ShadowPkgs,
+    installStrongFlags      :: Flag StrongFlags,
     installReinstall        :: Flag Bool,
-    installAvoidReinstalls  :: Flag Bool,
+    installAvoidReinstalls  :: Flag AvoidReinstalls,
     installOverrideReinstall :: Flag Bool,
     installUpgradeDeps      :: Flag Bool,
     installOnly             :: Flag Bool,
@@ -1171,12 +1173,12 @@ defaultInstallFlags = InstallFlags {
     installHaddockIndex    = Flag docIndexFile,
     installDryRun          = Flag False,
     installMaxBackjumps    = Flag defaultMaxBackjumps,
-    installReorderGoals    = Flag False,
-    installIndependentGoals= Flag False,
-    installShadowPkgs      = Flag False,
-    installStrongFlags     = Flag False,
+    installReorderGoals    = Flag (ReorderGoals False),
+    installIndependentGoals= Flag (IndependentGoals False),
+    installShadowPkgs      = Flag (ShadowPkgs False),
+    installStrongFlags     = Flag (StrongFlags False),
     installReinstall       = Flag False,
-    installAvoidReinstalls = Flag False,
+    installAvoidReinstalls = Flag (AvoidReinstalls False),
     installOverrideReinstall = Flag False,
     installUpgradeDeps     = Flag False,
     installOnly            = Flag False,
@@ -1327,7 +1329,8 @@ installOptions showOrParseArgs =
 
       , option [] ["avoid-reinstalls"]
           "Do not select versions that would destructively overwrite installed packages."
-          installAvoidReinstalls (\v flags -> flags { installAvoidReinstalls = v })
+          (fmap unAvoidReinstalls . installAvoidReinstalls)
+          (\v flags -> flags { installAvoidReinstalls = fmap AvoidReinstalls v })
           (yesNoOpt showOrParseArgs)
 
       , option [] ["force-reinstalls"]
@@ -2065,10 +2068,10 @@ optionSolver get set =
 
 optionSolverFlags :: ShowOrParseArgs
                   -> (flags -> Flag Int   ) -> (Flag Int    -> flags -> flags)
-                  -> (flags -> Flag Bool  ) -> (Flag Bool   -> flags -> flags)
-                  -> (flags -> Flag Bool  ) -> (Flag Bool   -> flags -> flags)
-                  -> (flags -> Flag Bool  ) -> (Flag Bool   -> flags -> flags)
-                  -> (flags -> Flag Bool  ) -> (Flag Bool   -> flags -> flags)
+                  -> (flags -> Flag ReorderGoals)     -> (Flag ReorderGoals     -> flags -> flags)
+                  -> (flags -> Flag IndependentGoals) -> (Flag IndependentGoals -> flags -> flags)
+                  -> (flags -> Flag ShadowPkgs)       -> (Flag ShadowPkgs       -> flags -> flags)
+                  -> (flags -> Flag StrongFlags)      -> (Flag StrongFlags      -> flags -> flags)
                   -> [OptionField flags]
 optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg _getig _setig getsip setsip getstrfl setstrfl =
   [ option [] ["max-backjumps"]
@@ -2078,7 +2081,8 @@ optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg _getig _setig getsip
                     (map show . flagToList))
   , option [] ["reorder-goals"]
       "Try to reorder goals according to certain heuristics. Slows things down on average, but may make backtracking faster for some packages."
-      getrg setrg
+      (fmap unReorderGoals . getrg)
+      (setrg . fmap ReorderGoals)
       (yesNoOpt showOrParseArgs)
   -- TODO: Disabled for now because it does not work as advertised (yet).
 {-
@@ -2089,11 +2093,13 @@ optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg _getig _setig getsip
 -}
   , option [] ["shadow-installed-packages"]
       "If multiple package instances of the same version are installed, treat all but one as shadowed."
-      getsip setsip
+      (fmap unShadowPkgs . getsip)
+      (setsip . fmap ShadowPkgs)
       (yesNoOpt showOrParseArgs)
   , option [] ["strong-flags"]
       "Do not defer flag choices (this used to be the default in cabal-install <= 1.20)."
-      getstrfl setstrfl
+      (fmap unStrongFlags . getstrfl)
+      (setstrfl . fmap StrongFlags)
       (yesNoOpt showOrParseArgs)
   ]
 

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -51,6 +51,13 @@ import Distribution.Compat.Binary (Binary(..))
 newtype Username = Username { unUsername :: String }
 newtype Password = Password { unPassword :: String }
 
+-- | Types that represent boolean flags.
+class BooleanFlag a where
+    asBool :: a -> Bool
+
+instance BooleanFlag Bool where
+  asBool = id
+
 -- | This is the information we get from a @00-index.tar.gz@ hackage index.
 --
 data SourcePackageDb = SourcePackageDb {

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/DSL.hs
@@ -11,8 +11,6 @@ module UnitTests.Distribution.Client.Dependency.Modular.DSL (
   , ExamplePkgName
   , ExampleAvailable(..)
   , ExampleInstalled(..)
-  , IndepGoals(..)
-  , ReorderGoals(..)
   , exAv
   , exInst
   , exFlag
@@ -194,12 +192,6 @@ exInst pn v hash deps = ExInst pn v hash (map exInstHash deps)
 type ExampleDb = [Either ExampleInstalled ExampleAvailable]
 
 type DependencyTree a = C.CondTree C.ConfVar [C.Dependency] a
-
-newtype IndepGoals = IndepGoals Bool
-  deriving Show
-
-newtype ReorderGoals = ReorderGoals Bool
-  deriving Show
 
 exDbPkgs :: ExampleDb -> [ExamplePkgName]
 exDbPkgs = map (either exInstName exAvName)
@@ -396,13 +388,13 @@ exResolve :: ExampleDb
           -> [ExamplePkgName]
           -> Solver
           -> Maybe Int
-          -> IndepGoals
+          -> IndependentGoals
           -> ReorderGoals
           -> EnableBackjumping
           -> [ExPreference]
           -> ([String], Either String CI.InstallPlan.SolverInstallPlan)
-exResolve db exts langs pkgConfigDb targets solver mbj (IndepGoals indepGoals)
-          (ReorderGoals reorder) enableBj prefs
+exResolve db exts langs pkgConfigDb targets solver mbj indepGoals reorder
+          enableBj prefs
     = runProgress $ resolveDependencies C.buildPlatform
                         compiler pkgConfigDb
                         solver

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/QuickCheck.hs
@@ -19,9 +19,11 @@ import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck
 
 import qualified Distribution.Client.ComponentDeps as CD
-import Distribution.Client.ComponentDeps ( Component(..)
-                                         , ComponentDep, ComponentDeps)
-import Distribution.Client.Dependency.Types (EnableBackjumping(..), Solver(..))
+import Distribution.Client.ComponentDeps
+         ( Component(..), ComponentDep, ComponentDeps )
+import Distribution.Client.Dependency.Types
+         ( ReorderGoals(..), IndependentGoals(..), EnableBackjumping(..)
+         , Solver(..) )
 import Distribution.Client.PkgConfigDb (pkgConfigDbFromList)
 import Distribution.Client.Setup (defaultMaxBackjumps)
 
@@ -49,8 +51,8 @@ tests = [
     , testProperty
           "solvable without --independent-goals => solvable with --independent-goals" $
           \(SolverTest db targets) reorderGoals solver ->
-            let r1 = solve' (IndepGoals False) targets db
-                r2 = solve' (IndepGoals True)  targets db
+            let r1 = solve' (IndependentGoals False) targets db
+                r2 = solve' (IndependentGoals True)  targets db
                 solve' indep = solve (EnableBackjumping True)
                                      reorderGoals indep solver
              in counterexample (showResults r1 r2) $
@@ -87,7 +89,7 @@ tests = [
     isRight (Right _) = True
     isRight _         = False
 
-solve :: EnableBackjumping -> ReorderGoals -> IndepGoals
+solve :: EnableBackjumping -> ReorderGoals -> IndependentGoals
       -> Solver -> [PN] -> TestDb -> Result
 solve enableBj reorder indep solver targets (TestDb db) =
   let (lg, result) =
@@ -263,10 +265,10 @@ instance Arbitrary ReorderGoals where
 
   shrink (ReorderGoals reorder) = [ReorderGoals False | reorder]
 
-instance Arbitrary IndepGoals where
-  arbitrary = IndepGoals <$> arbitrary
+instance Arbitrary IndependentGoals where
+  arbitrary = IndependentGoals <$> arbitrary
 
-  shrink (IndepGoals indep) = [IndepGoals False | indep]
+  shrink (IndependentGoals indep) = [IndependentGoals False | indep]
 
 instance Arbitrary Solver where
   arbitrary = frequency [ (1, return TopDown)

--- a/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Dependency/Modular/Solver.hs
@@ -19,7 +19,9 @@ import Language.Haskell.Extension ( Extension(..)
 
 -- cabal-install
 import Distribution.Client.PkgConfigDb (PkgConfigDb, pkgConfigDbFromList)
-import Distribution.Client.Dependency.Types (EnableBackjumping(..), Solver(Modular))
+import Distribution.Client.Dependency.Types
+         ( ReorderGoals(..) , IndependentGoals(..), EnableBackjumping(..)
+         , Solver(Modular) )
 import UnitTests.Distribution.Client.Dependency.Modular.DSL
 import UnitTests.Options
 
@@ -142,7 +144,7 @@ tests = [
     -- | Combinator to turn on --independent-goals behavior, i.e. solve
     -- for the goals as if we were solving for each goal independently.
     -- (This doesn't really work well at the moment, see #2842)
-    indep test      = test { testIndepGoals = IndepGoals True }
+    indep test      = test { testIndepGoals = IndependentGoals True }
     soft prefs test = test { testSoftConstraints = prefs }
     mkvrThis        = V.thisVersion . makeV
     mkvrOrEarlier   = V.orEarlierVersion . makeV
@@ -156,7 +158,7 @@ data SolverTest = SolverTest {
     testLabel          :: String
   , testTargets        :: [String]
   , testResult         :: SolverResult
-  , testIndepGoals     :: IndepGoals
+  , testIndepGoals     :: IndependentGoals
   , testSoftConstraints :: [ExPreference]
   , testDb             :: ExampleDb
   , testSupportedExts  :: Maybe [Extension]
@@ -230,7 +232,7 @@ mkTestExtLangPC exts langs pkgConfigDb db label targets result = SolverTest {
     testLabel          = label
   , testTargets        = targets
   , testResult         = result
-  , testIndepGoals     = IndepGoals False
+  , testIndepGoals     = IndependentGoals False
   , testSoftConstraints = []
   , testDb             = db
   , testSupportedExts  = exts

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -572,6 +572,12 @@ instance Arbitrary FlagName where
 instance Arbitrary PreSolver where
     arbitrary = elements [minBound..maxBound]
 
+instance Arbitrary ReorderGoals where
+    arbitrary = ReorderGoals <$> arbitrary
+
+instance Arbitrary StrongFlags where
+    arbitrary = StrongFlags <$> arbitrary
+
 instance Arbitrary AllowNewer where
     arbitrary = oneof [ pure AllowNewerNone
                       , AllowNewerSome <$> shortListOf1 3 arbitrary


### PR DESCRIPTION
This commit shouldn't change any behavior, except possibly the serialization of GenericInstallPlan, InstallFlags, etc.