### PR TITLE
RFC: --index-snapshot <posix-time>

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -248,6 +248,7 @@ instance Semigroup SavedConfig where
         installUpgradeDeps           = combine installUpgradeDeps,
         installOnly                  = combine installOnly,
         installOnlyDeps              = combine installOnlyDeps,
+        installIndexSnapshot         = combine installIndexSnapshot,
         installRootCmd               = combine installRootCmd,
         installSummaryFile           = lastNonEmptyNL installSummaryFile,
         installLogFile               = combine installLogFile,

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -110,7 +110,7 @@ configure verbosity packageDBs repoCtxt comp platform conf
   configFlags configExFlags extraArgs = do
 
   installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-  sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
+  sourcePkgDb       <- getSourcePackages    verbosity repoCtxt Nothing
   pkgConfigDb       <- readPkgConfigDb      verbosity conf
 
   checkConfigExFlags verbosity installedPkgIndex

--- a/cabal-install/Distribution/Client/Fetch.hs
+++ b/cabal-install/Distribution/Client/Fetch.hs
@@ -83,7 +83,7 @@ fetch verbosity packageDBs repoCtxt comp platform conf
     mapM_ checkTarget userTargets
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
+    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt Nothing
     pkgConfigDb       <- readPkgConfigDb      verbosity conf
 
     pkgSpecifiers <- resolveUserTargets verbosity repoCtxt

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -121,7 +121,7 @@ getFreezePkgs verbosity packageDBs repoCtxt comp platform conf mSandboxPkgInfo
       globalFlags freezeFlags = do
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
+    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt Nothing -- FIXME
     pkgConfigDb       <- readPkgConfigDb      verbosity conf
 
     pkgSpecifiers <- resolveUserTargets verbosity repoCtxt

--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -88,7 +88,7 @@ get verbosity repoCtxt globalFlags getFlags userTargets = do
   unless useFork $
     mapM_ checkTarget userTargets
 
-  sourcePkgDb <- getSourcePackages verbosity repoCtxt
+  sourcePkgDb <- getSourcePackages verbosity repoCtxt Nothing
 
   pkgSpecifiers <- resolveUserTargets verbosity repoCtxt
                    (fromFlag $ globalWorldFile globalFlags)

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -21,6 +21,8 @@ module Distribution.Client.IndexUtils (
   getSourcePackages,
   getSourcePackagesMonitorFiles,
 
+  IndexSnapshotSpec,
+
   Index(..),
   PackageEntry(..),
   parsePackageIndex,
@@ -64,7 +66,7 @@ import Distribution.Text
 import Distribution.Verbosity
          ( Verbosity, normal, lessVerbose )
 import Distribution.Simple.Utils
-         ( die, warn, info, fromUTF8, ignoreBOM )
+         ( die, warn, info, notice, fromUTF8, ignoreBOM )
 import Distribution.Client.Setup
          ( RepoContext(..) )
 
@@ -74,6 +76,7 @@ import Data.List   (isPrefixOf)
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid (Monoid(..))
 #endif
+import Data.Int (Int64)
 import qualified Data.Map as Map
 import Control.Monad (when, liftM)
 import Control.Exception (evaluate)
@@ -111,6 +114,9 @@ getInstalledPackages verbosity comp packageDbs conf =
 -- Reading the source package index
 --
 
+type IndexSnapshotSpec = Maybe Timestamp
+type Timestamp = Int64
+
 -- | Read a repository index from disk, from the local files specified by
 -- a list of 'Repo's.
 --
@@ -118,17 +124,20 @@ getInstalledPackages verbosity comp packageDbs conf =
 -- 'Repo'.
 --
 -- This is a higher level wrapper used internally in cabal-install.
-getSourcePackages :: Verbosity -> RepoContext -> IO SourcePackageDb
-getSourcePackages verbosity repoCtxt | null (repoContextRepos repoCtxt) = do
+getSourcePackages :: Verbosity -> RepoContext -> IndexSnapshotSpec -> IO SourcePackageDb
+getSourcePackages verbosity repoCtxt _ | null (repoContextRepos repoCtxt) = do
   warn verbosity $ "No remote package servers have been specified. Usually "
                 ++ "you would have one specified in the config file."
   return SourcePackageDb {
     packageIndex       = mempty,
     packagePreferences = mempty
   }
-getSourcePackages verbosity repoCtxt = do
-  info verbosity "Reading available packages..."
-  pkgss <- mapM (\r -> readRepoIndex verbosity repoCtxt r) (repoContextRepos repoCtxt)
+getSourcePackages verbosity repoCtxt idxSnapshot = do
+  case idxSnapshot of
+      Nothing -> info verbosity "Reading available packages..."
+      Just time -> notice verbosity ("Reading available packages (timestamp < " ++ show time ++ ")...")
+
+  pkgss <- mapM (\r -> readRepoIndex verbosity repoCtxt r idxSnapshot) (repoContextRepos repoCtxt)
   let (pkgs, prefs) = mconcat pkgss
       prefs' = Map.fromListWith intersectVersionRanges
                  [ (name, range) | Dependency name range <- prefs ]
@@ -139,12 +148,12 @@ getSourcePackages verbosity repoCtxt = do
     packagePreferences = prefs'
   }
 
-readCacheStrict :: Verbosity -> Index -> (PackageEntry -> pkg) -> IO ([pkg], [Dependency])
-readCacheStrict verbosity index mkPkg = do
+readCacheStrict :: Verbosity -> Index -> (PackageEntry -> pkg) -> IndexSnapshotSpec -> IO ([pkg], [Dependency])
+readCacheStrict verbosity index mkPkg idxSnapshot = do
     updateRepoIndexCache verbosity index
     cache <- liftM readIndexCache $ BSS.readFile (cacheFile index)
     withFile (indexFile index) ReadMode $ \indexHnd ->
-      packageListFromCache mkPkg indexHnd cache ReadPackageIndexStrict
+      packageListFromCache mkPkg indexHnd cache idxSnapshot ReadPackageIndexStrict
 
 -- | Read a repository index from disk, from the local file specified by
 -- the 'Repo'.
@@ -153,13 +162,13 @@ readCacheStrict verbosity index mkPkg = do
 --
 -- This is a higher level wrapper used internally in cabal-install.
 --
-readRepoIndex :: Verbosity -> RepoContext -> Repo
+readRepoIndex :: Verbosity -> RepoContext -> Repo -> IndexSnapshotSpec
               -> IO (PackageIndex SourcePackage, [Dependency])
-readRepoIndex verbosity repoCtxt repo =
+readRepoIndex verbosity repoCtxt repo idxSnapshot =
   handleNotFound $ do
     warnIfIndexIsOld =<< getIndexFileAge repo
     updateRepoIndexCache verbosity (RepoIndex repoCtxt repo)
-    readPackageIndexCacheFile mkAvailablePackage (RepoIndex repoCtxt repo)
+    readPackageIndexCacheFile mkAvailablePackage (RepoIndex repoCtxt repo) idxSnapshot
 
   where
     mkAvailablePackage pkgEntry =
@@ -211,7 +220,7 @@ getIndexFileAge repo = getFileAge $ repoLocalDir repo </> "00-index.tar"
 --
 getSourcePackagesMonitorFiles :: [Repo] -> [FilePath]
 getSourcePackagesMonitorFiles repos =
-    [ repoLocalDir repo </> "00-index.cache"
+    [ repoLocalDir repo </> "01-index.cache"
     | repo <- repos ]
 
 -- | It is not necessary to call this, as the cache will be updated when the
@@ -388,7 +397,7 @@ indexFile (RepoIndex _ctxt repo) = repoLocalDir repo </> "00-index.tar"
 indexFile (SandboxIndex index)   = index
 
 cacheFile :: Index -> FilePath
-cacheFile (RepoIndex _ctxt repo) = repoLocalDir repo </> "00-index.cache"
+cacheFile (RepoIndex _ctxt repo) = repoLocalDir repo </> "01-index.cache"
 cacheFile (SandboxIndex index)   = index `replaceExtension` "cache"
 
 updatePackageIndexCacheFile :: Verbosity -> Index -> IO ()
@@ -422,19 +431,36 @@ withIndexEntries :: Index -> ([IndexCacheEntry] -> IO a) -> IO a
 withIndexEntries (RepoIndex repoCtxt repo@RepoSecure{..}) callback =
     repoContextWithSecureRepo repoCtxt repo $ \repoSecure ->
       Sec.withIndex repoSecure $ \Sec.IndexCallbacks{..} -> do
-        let mk :: (Sec.DirectoryEntry, fp, Maybe (Sec.Some Sec.IndexFile))
-               -> IO [IndexCacheEntry]
+        let mk :: (Sec.DirectoryEntry, fp, Maybe (Sec.Some Sec.IndexFile)) -> IO [IndexCacheEntry]
             mk (_, _fp, Nothing) =
               return [] -- skip unrecognized file
             mk (_, _fp, Just (Sec.Some (Sec.IndexPkgMetadata _pkgId))) =
               return [] -- skip metadata
-            mk (dirEntry, _fp, Just (Sec.Some (Sec.IndexPkgCabal pkgId))) = do
+            mk (dirEntry, _fp, Just (Sec.Some file@(Sec.IndexPkgCabal pkgId))) = do
               let blockNo = fromIntegral (Sec.directoryEntryBlockNo dirEntry)
-              return [CachePackageId pkgId blockNo]
+              timestamp <- Sec.indexEntryTime `fmap` indexLookupFileEntry dirEntry file
+              return [CachePackageId pkgId blockNo timestamp]
             mk (dirEntry, _fp, Just (Sec.Some file@(Sec.IndexPkgPrefs _pkgName))) = do
+              let blockNo = fromIntegral (Sec.directoryEntryBlockNo dirEntry)
               content <- Sec.indexEntryContent `fmap` indexLookupFileEntry dirEntry file
-              return $ map CachePreference (parsePreferredVersions content)
-        entriess <- lazySequence $ map mk (Sec.directoryEntries indexDirectory)
+              timestamp <- Sec.indexEntryTime `fmap` indexLookupFileEntry dirEntry file
+              return $ map (\x ->  CachePreference x blockNo timestamp) (parsePreferredVersions content)
+
+        -- TODO/FIXME: turn into lazy non-reversed list-generation
+        let go :: [(Sec.DirectoryEntry, Sec.IndexPath, Maybe (Sec.Some Sec.IndexFile))]
+                  -> Sec.DirectoryEntry
+                  -> IO [(Sec.DirectoryEntry, Sec.IndexPath, Maybe (Sec.Some Sec.IndexFile))]
+            go acc dent = do
+                (sie0, mde) <- indexLookupEntry dent
+                let e = case sie0 of Sec.Some sie -> (dent, Sec.indexEntryPath sie, fmap Sec.Some (Sec.indexEntryPathParsed sie))
+                    acc' = e:acc
+                maybe (return acc') (go acc') mde
+
+        -- entriess <- lazySequence $ map mk (Sec.directoryEntries indexDirectory)
+        -- we need all historic entries, including the overwritten ones
+        rents <- go [] (Sec.directoryFirst indexDirectory)
+        entriess <- lazySequence $ map mk (reverse rents)
+
         callback $ concat entriess
 withIndexEntries index callback = do
     withFile (indexFile index) ReadMode $ \h -> do
@@ -443,9 +469,9 @@ withIndexEntries index callback = do
       callback $ map toCache (catMaybes pkgsOrPrefs)
   where
     toCache :: PackageOrDep -> IndexCacheEntry
-    toCache (Pkg (NormalPackage pkgid _ _ blockNo)) = CachePackageId pkgid blockNo
+    toCache (Pkg (NormalPackage pkgid _ _ blockNo)) = CachePackageId pkgid blockNo 0 -- FIXME
     toCache (Pkg (BuildTreeRef refType _ _ _ blockNo)) = CacheBuildTreeRef refType blockNo
-    toCache (Dep d) = CachePreference d
+    toCache (Dep d) = CachePreference d 0 0 -- FIXME
 
 data ReadPackageIndexMode = ReadPackageIndexStrict
                           | ReadPackageIndexLazyIO
@@ -453,20 +479,22 @@ data ReadPackageIndexMode = ReadPackageIndexStrict
 readPackageIndexCacheFile :: Package pkg
                           => (PackageEntry -> pkg)
                           -> Index
+                          -> IndexSnapshotSpec
                           -> IO (PackageIndex pkg, [Dependency])
-readPackageIndexCacheFile mkPkg index = do
+readPackageIndexCacheFile mkPkg index idxSnapshot = do
   cache    <- liftM readIndexCache $ BSS.readFile (cacheFile index)
   indexHnd <- openFile (indexFile index) ReadMode
-  packageIndexFromCache mkPkg indexHnd cache ReadPackageIndexLazyIO
+  packageIndexFromCache mkPkg indexHnd cache idxSnapshot ReadPackageIndexLazyIO
 
 packageIndexFromCache :: Package pkg
                       => (PackageEntry -> pkg)
                       -> Handle
                       -> Cache
+                      -> IndexSnapshotSpec
                       -> ReadPackageIndexMode
                       -> IO (PackageIndex pkg, [Dependency])
-packageIndexFromCache mkPkg hnd cache mode = do
-     (pkgs, prefs) <- packageListFromCache mkPkg hnd cache mode
+packageIndexFromCache mkPkg hnd cache idxSnapshot mode = do
+     (pkgs, prefs) <- packageListFromCache mkPkg hnd cache idxSnapshot mode
      pkgIndex <- evaluate $ PackageIndex.fromList pkgs
      return (pkgIndex, prefs)
 
@@ -478,13 +506,27 @@ packageIndexFromCache mkPkg hnd cache mode = do
 packageListFromCache :: (PackageEntry -> pkg)
                      -> Handle
                      -> Cache
+                     -> IndexSnapshotSpec
                      -> ReadPackageIndexMode
                      -> IO ([pkg], [Dependency])
-packageListFromCache mkPkg hnd Cache{..} mode = accum mempty [] cacheEntries
+packageListFromCache mkPkg hnd Cache{..} idxSnapshot mode = accum mempty [] cacheEntries
   where
-    accum srcpkgs prefs [] = return (reverse srcpkgs, prefs)
+    accum srcpkgs prefs [] = do
+        -- keep last overriding/masking entry for a given packagename
+        -- TODO/FIXME: the accumulating 'srcpkgs' and 'prefs' arguments
+        -- could both be changed to be a Data.Map. The use-sites of
+        -- 'packageListFromCache' quite likely don't need any specific
+        -- order, nor do they care about masked entries.
+        -- This would then probably fix #2956
+        prefs' <- evaluate $ Map.elems $ Map.fromList [ (pn,dep) | dep@(Dependency pn _) <- reverse prefs ]
+        return (reverse srcpkgs, prefs')
 
-    accum srcpkgs prefs (CachePackageId pkgid blockno : entries) = do
+    accum srcpkgs prefs (CachePackageId pkgid blockno ti : entries)
+      | Just maxTime <- idxSnapshot, ti > maxTime =
+          -- skip entry due to index-wayback filter
+            accum srcpkgs prefs entries
+
+      | otherwise = do
       -- Given the cache entry, make a package index entry.
       -- The magic here is that we use lazy IO to read the .cabal file
       -- from the index tarball if it turns out that we need it.
@@ -512,8 +554,12 @@ packageListFromCache mkPkg hnd Cache{..} mode = accum mempty [] cacheEntries
       let srcpkg = mkPkg (BuildTreeRef refType (packageId pkg) pkg path blockno)
       accum (srcpkg:srcpkgs) prefs entries
 
-    accum srcpkgs prefs (CachePreference pref : entries) =
-      accum srcpkgs (pref:prefs) entries
+    accum srcpkgs prefs (CachePreference pref _ ti : entries)
+      | Just maxTime <- idxSnapshot, ti > maxTime =
+        -- skip entry due to index-snapshot filter
+        accum srcpkgs prefs entries
+
+      | otherwise = accum srcpkgs (pref:prefs) entries
 
     getEntryContent :: BlockNo -> IO ByteString
     getEntryContent blockno = do
@@ -544,35 +590,45 @@ packageListFromCache mkPkg hnd Cache{..} mode = accum mempty [] cacheEntries
 --
 type BlockNo = Tar.TarEntryOffset
 
-data IndexCacheEntry = CachePackageId PackageId BlockNo
+data IndexCacheEntry = CachePackageId PackageId BlockNo Timestamp
                      | CacheBuildTreeRef BuildTreeRefType BlockNo
-                     | CachePreference Dependency
+                     | CachePreference Dependency BlockNo Timestamp
   deriving (Eq)
 
-installedUnitId, blocknoKey, buildTreeRefKey, preferredVersionKey :: String
+installedUnitId, blocknoKey, timeKey, buildTreeRefKey, preferredVersionKey :: String
 installedUnitId = "pkg:"
 blocknoKey = "b#"
+timeKey = "t#"
 buildTreeRefKey     = "build-tree-ref:"
 preferredVersionKey = "pref-ver:"
 
 readIndexCacheEntry :: BSS.ByteString -> Maybe IndexCacheEntry
 readIndexCacheEntry = \line ->
   case BSS.words line of
-    [key, pkgnamestr, pkgverstr, sep, blocknostr]
-      | key == BSS.pack installedUnitId && sep == BSS.pack blocknoKey ->
+    [key, sep, blocknostr, sep2, timestr, pkgnamestr, pkgverstr]
+      | key == BSS.pack installedUnitId
+      , sep == BSS.pack blocknoKey
+      , sep2 == BSS.pack timeKey ->
       case (parseName pkgnamestr, parseVer pkgverstr [],
-            parseBlockNo blocknostr) of
-        (Just pkgname, Just pkgver, Just blockno)
-          -> Just (CachePackageId (PackageIdentifier pkgname pkgver) blockno)
+            parseBlockNo blocknostr, parseTime timestr) of
+        (Just pkgname, Just pkgver, Just blockno, Just time)
+          -> Just (CachePackageId (PackageIdentifier pkgname pkgver) blockno time)
         _ -> Nothing
+
     [key, typecodestr, blocknostr] | key == BSS.pack buildTreeRefKey ->
       case (parseRefType typecodestr, parseBlockNo blocknostr) of
         (Just refType, Just blockno)
           -> Just (CacheBuildTreeRef refType blockno)
         _ -> Nothing
 
-    (key: remainder) | key == BSS.pack preferredVersionKey ->
-      fmap CachePreference (simpleParse (BSS.unpack (BSS.unwords remainder)))
+    (key : sep : blocknostr : sep2 : timestr : remainder)
+      | key == BSS.pack preferredVersionKey
+      , sep == BSS.pack blocknoKey
+      , sep2 == BSS.pack timeKey
+      , Just blockno <- parseBlockNo blocknostr
+      , Just time <- parseTime timestr ->
+        fmap (\p -> CachePreference p blockno time) (simpleParse (BSS.unpack (BSS.unwords remainder)))
+
     _  -> Nothing
   where
     parseName str
@@ -594,6 +650,12 @@ readIndexCacheEntry = \line ->
           | BSS.null remainder -> Just (fromIntegral blockno)
         _                      -> Nothing
 
+    parseTime str =
+      case BSS.readInt str of
+        Just (t, remainder)
+          | BSS.null remainder -> Just (fromIntegral t :: Timestamp)
+        _                      -> Nothing
+
     parseRefType str =
       case BSS.uncons str of
         Just (typeCode, remainder)
@@ -603,17 +665,23 @@ readIndexCacheEntry = \line ->
 
 showIndexCacheEntry :: IndexCacheEntry -> String
 showIndexCacheEntry entry = unwords $ case entry of
-   CachePackageId pkgid b -> [ installedUnitId
-                             , display (packageName pkgid)
-                             , display (packageVersion pkgid)
+   CachePackageId pkgid b t -> [ installedUnitId
                              , blocknoKey
                              , show b
+                             , timeKey
+                             , show t
+                             , display (packageName pkgid)
+                             , display (packageVersion pkgid)
                              ]
    CacheBuildTreeRef t b  -> [ buildTreeRefKey
                              , [typeCodeFromRefType t]
                              , show b
                              ]
-   CachePreference dep    -> [ preferredVersionKey
+   CachePreference dep b t-> [ preferredVersionKey
+                             , blocknoKey
+                             , show b
+                             , timeKey
+                             , show t
                              , display dep
                              ]
 

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -114,7 +114,7 @@ initCabal :: Verbosity
 initCabal verbosity packageDBs repoCtxt comp conf initFlags = do
 
   installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-  sourcePkgDb <- getSourcePackages verbosity repoCtxt
+  sourcePkgDb <- getSourcePackages verbosity repoCtxt Nothing
 
   hSetBuffering stdout NoBuffering
 

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -261,10 +261,12 @@ makeInstallContext :: Verbosity -> InstallArgs -> Maybe [UserTarget]
                       -> IO InstallContext
 makeInstallContext verbosity
   (packageDBs, repoCtxt, comp, _, conf,_,_,
-   globalFlags, _, configExFlags, _, _) mUserTargets = do
+   globalFlags, _, configExFlags, installFlags, _) mUserTargets = do
+
+    let indexSnapSpec = fmap fromIntegral $ flagToMaybe $ installIndexSnapshot installFlags
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
+    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt indexSnapSpec
     pkgConfigDb       <- readPkgConfigDb      verbosity conf
 
     checkConfigExFlags verbosity installedPkgIndex

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -84,7 +84,7 @@ getPkgList :: Verbosity
            -> IO [PackageDisplayInfo]
 getPkgList verbosity packageDBs repoCtxt comp conf listFlags pats = do
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages verbosity repoCtxt
+    sourcePkgDb       <- getSourcePackages verbosity repoCtxt Nothing
     let sourcePkgIndex = packageIndex sourcePkgDb
         prefs name = fromMaybe anyVersion
                        (Map.lookup name (packagePreferences sourcePkgDb))
@@ -176,7 +176,7 @@ info verbosity packageDBs repoCtxt comp conf
      globalFlags _listFlags userTargets = do
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages verbosity repoCtxt
+    sourcePkgDb       <- getSourcePackages verbosity repoCtxt Nothing -- FIXME?
     let sourcePkgIndex = packageIndex sourcePkgDb
         prefs name = fromMaybe anyVersion
                        (Map.lookup name (packagePreferences sourcePkgDb))

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -192,6 +192,8 @@ resolveSolverSettings ProjectConfig{
                                          | otherwise -> Just n
     solverSettingReorderGoals      = fromFlag projectConfigReorderGoals
     solverSettingStrongFlags       = fromFlag projectConfigStrongFlags
+    solverSettingIndexSnapshot     = fmap fromIntegral
+                                          (flagToMaybe projectConfigIndexSnapshot)
   --solverSettingIndependentGoals  = fromFlag projectConfigIndependentGoals
   --solverSettingShadowPkgs        = fromFlag projectConfigShadowPkgs
   --solverSettingReinstall         = fromFlag projectConfigReinstall

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -300,6 +300,7 @@ convertLegacyAllPackageFlags globalFlags configFlags
     --installReinstall          = projectConfigReinstall,
     --installAvoidReinstalls    = projectConfigAvoidReinstalls,
     --installOverrideReinstall  = projectConfigOverrideReinstall,
+      installIndexSnapshot        = projectConfigIndexSnapshot,
       installMaxBackjumps       = projectConfigMaxBackjumps,
     --installUpgradeDeps        = projectConfigUpgradeDeps,
       installReorderGoals       = projectConfigReorderGoals,
@@ -499,6 +500,7 @@ convertToLegacySharedConfig
       installStrongFlags       = projectConfigStrongFlags,
       installOnly              = mempty,
       installOnlyDeps          = projectConfigOnlyDeps,
+      installIndexSnapshot       = projectConfigIndexSnapshot,
       installRootCmd           = projectConfigRootCmd,
       installSummaryFile       = projectConfigSummaryFile,
       installLogFile           = projectConfigLogFile,
@@ -826,6 +828,7 @@ legacySharedConfigFieldDescrs =
       , "one-shot", "jobs", "offline"
         -- solver flags:
       , "max-backjumps", "reorder-goals", "strong-flags"
+      , "index-snapshot"
       ]
   . commandOptionsToFields
   ) (installOptions ParseArgs)

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -48,6 +48,7 @@ import Distribution.Utils.NubList
 import Distribution.Verbosity
          ( Verbosity )
 
+import Data.Int (Int64)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Distribution.Compat.Binary (Binary)
@@ -153,6 +154,9 @@ data ProjectConfigShared
        -- configuration used both by the solver and other phases
        projectConfigRemoteRepos       :: NubList RemoteRepo,     -- ^ Available Hackage servers.
        projectConfigLocalRepos        :: NubList FilePath,
+
+       -- TODO/FIXME
+       projectConfigIndexSnapshot     :: Flag Int,
 
        -- solver configuration
        projectConfigConstraints       :: [(UserConstraint, ConstraintSource)],
@@ -316,7 +320,8 @@ data SolverSettings
        solverSettingAllowNewer        :: AllowNewer,
        solverSettingMaxBackjumps      :: Maybe Int,
        solverSettingReorderGoals      :: Bool,
-       solverSettingStrongFlags       :: Bool
+       solverSettingStrongFlags       :: Bool,
+       solverSettingIndexSnapshot     :: Maybe Int64
        -- Things that only make sense for manual mode, not --local mode
        -- too much control!
      --solverSettingIndependentGoals  :: Bool,

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -417,6 +417,10 @@ rebuildInstallPlan verbosity
                                                     compiler progdb platform
                                                     corePackageDbs
           sourcePkgDb       <- getSourcePackages    verbosity withRepoCtx
+                                                    (fmap fromIntegral
+                                                     . flagToMaybe
+                                                     . projectConfigIndexSnapshot
+                                                     $ projectConfigShared)
           pkgConfigDB       <- getPkgConfigDb      verbosity progdb
 
           --TODO: [code cleanup] it'd be better if the Compiler contained the
@@ -608,12 +612,13 @@ getPackageDBContents verbosity compiler progdb platform packagedb = do
                                  packagedb progdb
 
 getSourcePackages :: Verbosity -> (forall a. (RepoContext -> IO a) -> IO a)
+                  -> IndexUtils.IndexSnapshotSpec
                   -> Rebuild SourcePackageDb
-getSourcePackages verbosity withRepoCtx = do
+getSourcePackages verbosity withRepoCtx idxSnapSpec = do
     (sourcePkgDb, repos) <-
       liftIO $
         withRepoCtx $ \repoctx -> do
-          sourcePkgDb <- IndexUtils.getSourcePackages verbosity repoctx
+          sourcePkgDb <- IndexUtils.getSourcePackages verbosity repoctx idxSnapSpec
           return (sourcePkgDb, repoContextRepos repoctx)
 
     monitorFiles . map monitorFile

--- a/cabal-install/Distribution/Client/Sandbox/Index.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Index.hs
@@ -95,7 +95,7 @@ readBuildTreeRefsFromFile = liftM (readBuildTreeRefs . Tar.read) . BS.readFile
 -- | Read build tree references from an index cache
 readBuildTreeRefsFromCache :: Verbosity -> FilePath -> IO [BuildTreeRef]
 readBuildTreeRefsFromCache verbosity indexPath = do
-    (mRefs, _prefs) <- readCacheStrict verbosity (SandboxIndex indexPath) buildTreeRef
+    (mRefs, _prefs) <- readCacheStrict verbosity (SandboxIndex indexPath) buildTreeRef Nothing
     return (catMaybes mRefs)
   where
     buildTreeRef pkgEntry =

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1150,6 +1150,7 @@ data InstallFlags = InstallFlags {
     installUpgradeDeps      :: Flag Bool,
     installOnly             :: Flag Bool,
     installOnlyDeps         :: Flag Bool,
+    installIndexSnapshot    :: Flag Int,
     installRootCmd          :: Flag String,
     installSummaryFile      :: NubList PathTemplate,
     installLogFile          :: Flag PathTemplate,
@@ -1181,6 +1182,7 @@ defaultInstallFlags = InstallFlags {
     installUpgradeDeps     = Flag False,
     installOnly            = Flag False,
     installOnlyDeps        = Flag False,
+    installIndexSnapshot   = mempty,
     installRootCmd         = mempty,
     installSummaryFile     = mempty,
     installLogFile         = mempty,
@@ -1349,6 +1351,13 @@ installOptions showOrParseArgs =
           "A synonym for --only-dependencies"
           installOnlyDeps (\v flags -> flags { installOnlyDeps = v })
           (yesNoOpt showOrParseArgs)
+
+      , option [] ["index-snapshot"]
+          "Operate on package index state rolled back to given unix-timestamp"
+          installIndexSnapshot (\v flags -> flags { installIndexSnapshot = v })
+          (reqArg "NUM" (readP_to_E ("Cannot parse number: "++)
+                         (fmap toFlag parse))
+           (map show . flagToList))
 
       , option [] ["root-cmd"]
           "Command used to gain root privileges, when installing with --global."


### PR DESCRIPTION
_This is an early working proof-of-concept (which already works), and I'm submitting this here to solicit an early general discussion/feedback regarding the direction the implementation is going._


This is a forward-ported version of

https://github.com/hvr/cabal/commit/3dea2190df1f45987bc1f730167222dfe26d15de

mostly aimed at use with `new-build` & `cabal.project` files.

This introduces a flag `--index-snapshot` and a respective property `index-snapshot: ...` for use in `cabal.project`(`.local`) files which currently only supports a unix timestamp argument. The `--index-snapshot`-value acts as a timestamp-filter on the package index. For now, only posix-timestamps are supported as filtering criteria. Additionally an "index serial-number" is planned, which would enumerate all entries in the `01-index`-tarball incrementing the serial number for each `.cabal` and each `preferred-versions` entry. This is a more exact/granular way to specify the index-state, as there could be more than one index-entry with the same timestamp.

By setting  `--index-snapshot` to a timestamp from the past(!), this effectively freezes the hackage index to the state and thereby allows for simple way to provide (non-curated) deterministic install-plans.

This requires enabling secure repos to have any useful effect (non-secure repos have a 0-timestamp for all entries, therefore all entries lay in the past of positive `--index-snapshot` values and are not filtered).

Since the index-cache format is extended, this uses a different name `01-index.cache` and the contents looks like

```
pkg: b# 0 t# 1157499455 iconv 0.2
pkg: b# 3 t# 1159125300 Crypto 3.0.3
...
pkg: b# 663524 t# 1460923884 aeson-flatten 0.1.0.0
pkg: b# 663530 t# 1460924055 aeson-flatten 0.1.0.1
pkg: b# 663536 t# 1460924864 aeson-prefix 0.1.0.1
pref-ver: b# 663542 t# 1460924975 aeson-prefix <0.1.0.0 || >0.1.0.0
pref-ver: b# 663544 t# 1460925074 aeson-flatten <0.1.0.0 || >0.1.0.0
pkg: b# 663546 t# 1460925526 aeson-prefix 0.1.0.2
pref-ver: b# 663554 t# 1460925649 aeson-prefix <0.1.0.0 || >0.1.0.0 && <0.1.0.1 || >0.1.0.1
pkg: b# 663556 t# 1460927930 data-default-instances-base 0.1.0
pkg: b# 663560 t# 1460928015 data-default 0.6.0
pkg: b# 663565 t# 1460955096 ether 0.4.0.1
pkg: b# 663578 t# 1460955492 ether 0.4.0.1
...
```

where `b#` denotes the block-offset into the index-tarball and `t#` denotes the posix-time of that entry


PS: This patch is based on 1.24 as I started working on this rebased patch a couple of weeks ago already and was planning to have this merged in time for 1.24.1

/cc @ezyang @dcoutts @23Skidoo 