### PR TITLE
Move ConstraintSource and ResolverPackage to Distribution.Solver.*

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -48,8 +48,6 @@ import Distribution.Client.Types
          ( RemoteRepo(..), Username(..), Password(..), emptyRemoteRepo )
 import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
-import Distribution.Client.Dependency.Types
-         ( ConstraintSource(..) )
 import Distribution.Client.Setup
          ( GlobalFlags(..), globalCommand, defaultGlobalFlags
          , ConfigExFlags(..), configureExOptions, defaultConfigExFlags
@@ -98,6 +96,8 @@ import Distribution.Compiler
          ( CompilerFlavor(..), defaultCompilerFlavor )
 import Distribution.Verbosity
          ( Verbosity, normal )
+
+import Distribution.Solver.Types.ConstraintSource
 
 import Data.List
          ( partition, find, foldl' )

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -20,8 +20,7 @@ module Distribution.Client.Configure (
 
 import Distribution.Client.Dependency
 import Distribution.Client.Dependency.Types
-         ( ConstraintSource(..)
-         , LabeledPackageConstraint(..), showConstraintSource )
+         ( LabeledPackageConstraint(..) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.InstallPlan (SolverInstallPlan)
 import Distribution.Client.IndexUtils as IndexUtils
@@ -38,6 +37,7 @@ import Distribution.Package (PackageId)
 import Distribution.Client.JobControl (Lock)
 
 import qualified Distribution.Solver.Types.ComponentDeps as CD
+import           Distribution.Solver.Types.ConstraintSource
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PackageIndex
                    ( PackageIndex, elemByPackageName )

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -77,7 +77,6 @@ import Distribution.Client.Dependency.Types
          ( PreSolver(..), Solver(..), DependencyResolver, ResolverPackage(..)
          , PackageConstraint(..), showPackageConstraint
          , LabeledPackageConstraint(..), unlabelPackageConstraint
-         , ConstraintSource(..), showConstraintSource
          , PackagePreferences(..), InstalledPreference(..)
          , PackagesPreferenceDefault(..) )
 import Distribution.Client.Sandbox.Types
@@ -116,6 +115,7 @@ import Distribution.Verbosity
 
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
+import           Distribution.Solver.Types.ConstraintSource
 import           Distribution.Solver.Types.OptionalStanza
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
 import           Distribution.Solver.Types.PkgConfigDb (PkgConfigDb)

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -74,7 +74,7 @@ import Distribution.Client.Types
          , UnresolvedPkgLoc, UnresolvedSourcePackage
          , enableStanzas )
 import Distribution.Client.Dependency.Types
-         ( PreSolver(..), Solver(..), DependencyResolver, ResolverPackage(..)
+         ( PreSolver(..), Solver(..), DependencyResolver
          , PackageConstraint(..), showPackageConstraint
          , LabeledPackageConstraint(..), unlabelPackageConstraint
          , PackagePreferences(..), InstalledPreference(..)
@@ -120,6 +120,7 @@ import           Distribution.Solver.Types.OptionalStanza
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
 import           Distribution.Solver.Types.PkgConfigDb (PkgConfigDb)
 import           Distribution.Solver.Types.Progress
+import           Distribution.Solver.Types.ResolverPackage
 import           Distribution.Solver.Types.Settings
 import           Distribution.Solver.Types.SolverId
 import           Distribution.Solver.Types.SolverPackage

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -23,7 +23,7 @@ import Distribution.Client.Types
          ( UnresolvedPkgLoc
          , UnresolvedSourcePackage, enableStanzas )
 import Distribution.Client.Dependency.Types
-         ( DependencyResolver, ResolverPackage(..)
+         ( DependencyResolver
          , PackageConstraint(..), unlabelPackageConstraint
          , PackagePreferences(..), InstalledPreference(..) )
 
@@ -58,6 +58,7 @@ import qualified Distribution.Solver.Types.ComponentDeps as CD
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
 import           Distribution.Solver.Types.PackageIndex ( PackageIndex )
 import           Distribution.Solver.Types.Progress
+import           Distribution.Solver.Types.ResolverPackage
 import           Distribution.Solver.Types.SolverId
 import           Distribution.Solver.Types.SolverPackage
 import           Distribution.Solver.Types.SourcePackage

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -27,15 +27,14 @@ module Distribution.Client.Dependency.Types (
     PackagesPreferenceDefault(..),
 
     LabeledPackageConstraint(..),
-    ConstraintSource(..),
-    unlabelPackageConstraint,
-    showConstraintSource
+    unlabelPackageConstraint
 
   ) where
 
 import Data.Char
          ( isAlpha, toLower )
 
+import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PkgConfigDb ( PkgConfigDb )
 import Distribution.Solver.Types.PackageIndex ( PackageIndex )
@@ -206,65 +205,3 @@ data LabeledPackageConstraint
 
 unlabelPackageConstraint :: LabeledPackageConstraint -> PackageConstraint
 unlabelPackageConstraint (LabeledPackageConstraint pc _) = pc
-
--- | Source of a 'PackageConstraint'.
-data ConstraintSource =
-
-  -- | Main config file, which is ~/.cabal/config by default.
-  ConstraintSourceMainConfig FilePath
-
-  -- | Local cabal.project file
-  | ConstraintSourceProjectConfig FilePath
-
-  -- | Sandbox config file, which is ./cabal.sandbox.config by default.
-  | ConstraintSourceSandboxConfig FilePath
-
-  -- | User config file, which is ./cabal.config by default.
-  | ConstraintSourceUserConfig FilePath
-
-  -- | Flag specified on the command line.
-  | ConstraintSourceCommandlineFlag
-
-  -- | Target specified by the user, e.g., @cabal install package-0.1.0.0@
-  -- implies @package==0.1.0.0@.
-  | ConstraintSourceUserTarget
-
-  -- | Internal requirement to use installed versions of packages like ghc-prim.
-  | ConstraintSourceNonUpgradeablePackage
-
-  -- | Internal requirement to use the add-source version of a package when that
-  -- version is installed and the source is modified.
-  | ConstraintSourceModifiedAddSourceDep
-
-  -- | Internal constraint used by @cabal freeze@.
-  | ConstraintSourceFreeze
-
-  -- | Constraint specified by a config file, a command line flag, or a user
-  -- target, when a more specific source is not known.
-  | ConstraintSourceConfigFlagOrTarget
-
-  -- | The source of the constraint is not specified.
-  | ConstraintSourceUnknown
-  deriving (Eq, Show, Generic)
-
-instance Binary ConstraintSource
-
--- | Description of a 'ConstraintSource'.
-showConstraintSource :: ConstraintSource -> String
-showConstraintSource (ConstraintSourceMainConfig path) =
-    "main config " ++ path
-showConstraintSource (ConstraintSourceProjectConfig path) =
-    "project config " ++ path
-showConstraintSource (ConstraintSourceSandboxConfig path) =
-    "sandbox config " ++ path
-showConstraintSource (ConstraintSourceUserConfig path)= "user config " ++ path
-showConstraintSource ConstraintSourceCommandlineFlag = "command line flag"
-showConstraintSource ConstraintSourceUserTarget = "user target"
-showConstraintSource ConstraintSourceNonUpgradeablePackage =
-    "non-upgradeable package"
-showConstraintSource ConstraintSourceModifiedAddSourceDep =
-    "modified add-source dependency"
-showConstraintSource ConstraintSourceFreeze = "cabal freeze"
-showConstraintSource ConstraintSourceConfigFlagOrTarget =
-    "config file, command line flag, or user target"
-showConstraintSource ConstraintSourceUnknown = "unknown source"

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Dependency.Types

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -18,7 +18,6 @@ module Distribution.Client.Dependency.Types (
     Solver(..),
 
     DependencyResolver,
-    ResolverPackage(..),
 
     PackageConstraint(..),
     showPackageConstraint,
@@ -39,15 +38,13 @@ import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PkgConfigDb ( PkgConfigDb )
 import Distribution.Solver.Types.PackageIndex ( PackageIndex )
 import Distribution.Solver.Types.Progress
+import Distribution.Solver.Types.ResolverPackage
 import Distribution.Solver.Types.SourcePackage
-import Distribution.Solver.Types.SolverPackage
 
 import qualified Distribution.Compat.ReadP as Parse
          ( pfail, munch1 )
 import Distribution.PackageDescription
          ( FlagAssignment, FlagName(..) )
-import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo )
 import Distribution.Simple.PackageIndex ( InstalledPackageIndex )
 import Distribution.Package
          ( PackageName )
@@ -108,14 +105,6 @@ type DependencyResolver loc = Platform
                            -> [LabeledPackageConstraint]
                            -> [PackageName]
                            -> Progress String String [ResolverPackage loc]
-
--- | The dependency resolver picks either pre-existing installed packages
--- or it picks source packages along with package configuration.
---
--- This is like the 'InstallPlan.PlanPackage' but with fewer cases.
---
-data ResolverPackage loc = PreExisting InstalledPackageInfo
-                         | Configured  (SolverPackage loc)
 
 -- | Per-package constraints. Package constraints must be respected by the
 -- solver. Multiple constraints for each package can be given, though obviously

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -21,7 +21,7 @@ import Distribution.Client.Types
 import Distribution.Client.Targets
 import Distribution.Client.Dependency
 import Distribution.Client.Dependency.Types
-         ( ConstraintSource(..), LabeledPackageConstraint(..) )
+         ( LabeledPackageConstraint(..) )
 import Distribution.Client.IndexUtils as IndexUtils
          ( getSourcePackages, getInstalledPackages )
 import Distribution.Client.InstallPlan
@@ -36,6 +36,7 @@ import Distribution.Client.Sandbox.PackageEnvironment
 import Distribution.Client.Sandbox.Types
          ( SandboxPackageInfo(..) )
 
+import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PkgConfigDb
          ( PkgConfigDb, readPkgConfigDb )

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -72,7 +72,7 @@ import Distribution.Client.Configure
          ( chooseCabalVersion, configureSetupScript, checkConfigExFlags )
 import Distribution.Client.Dependency
 import Distribution.Client.Dependency.Types
-         ( Solver(..), ConstraintSource(..), LabeledPackageConstraint(..) )
+         ( Solver(..), LabeledPackageConstraint(..) )
 import Distribution.Client.FetchUtils
 import Distribution.Client.HttpUtils
          ( HttpTransport (..) )
@@ -110,6 +110,7 @@ import Distribution.Client.Compat.ExecutablePath
 import Distribution.Client.JobControl
 
 import qualified Distribution.Solver.Types.ComponentDeps as CD
+import           Distribution.Solver.Types.ConstraintSource
 import           Distribution.Solver.Types.OptionalStanza
 import qualified Distribution.Solver.Types.PackageIndex as SourcePackageIndex
 import           Distribution.Solver.Types.PackageFixedDeps

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -23,10 +23,10 @@ module Distribution.Client.ProjectConfig.Legacy (
 import Distribution.Client.ProjectConfig.Types
 import Distribution.Client.Types
          ( RemoteRepo(..), emptyRemoteRepo )
-import Distribution.Client.Dependency.Types
-         ( ConstraintSource(..) )
 import Distribution.Client.Config
          ( SavedConfig(..), remoteRepoFields )
+
+import Distribution.Solver.Types.ConstraintSource
 
 import Distribution.Package
 import Distribution.PackageDescription

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -22,14 +22,14 @@ module Distribution.Client.ProjectConfig.Types (
 import Distribution.Client.Types
          ( RemoteRepo )
 import Distribution.Client.Dependency.Types
-         ( PreSolver, ConstraintSource )
+         ( PreSolver )
 import Distribution.Client.Targets
          ( UserConstraint )
 import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
 
 import Distribution.Solver.Types.Settings
-         ( ReorderGoals, StrongFlags )
+import Distribution.Solver.Types.ConstraintSource
 
 import Distribution.Package
          ( PackageName, PackageId, UnitId, Dependency )

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -78,6 +78,7 @@ import           Distribution.Utils.NubList
 
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
+import           Distribution.Solver.Types.ConstraintSource
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PackageFixedDeps
 import qualified Distribution.Solver.Types.PackageIndex as SourcePackageIndex

--- a/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
+++ b/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
@@ -36,7 +36,6 @@ import Distribution.Client.Config      ( SavedConfig(..), commentSavedConfig
                                        , installDirsFields, withProgramsFields
                                        , withProgramOptionsFields
                                        , defaultCompiler )
-import Distribution.Client.Dependency.Types ( ConstraintSource (..) )
 import Distribution.Client.ParseUtils  ( parseFields, ppFields, ppSection )
 import Distribution.Client.Setup       ( GlobalFlags(..), ConfigExFlags(..)
                                        , InstallFlags(..)
@@ -51,6 +50,7 @@ import Distribution.Simple.Setup       ( Flag(..)
                                        , ConfigFlags(..), HaddockFlags(..)
                                        , fromFlagOrDefault, toFlag, flagToMaybe )
 import Distribution.Simple.Utils       ( die, info, notice, warn )
+import Distribution.Solver.Types.ConstraintSource
 import Distribution.ParseUtils         ( FieldDescr(..), ParseResult(..)
                                        , commaListField, commaNewLineListField
                                        , liftField, lineNo, locatedErrorMsg

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -59,7 +59,7 @@ import Distribution.Client.Types
 import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
 import Distribution.Client.Dependency.Types
-         ( PreSolver(..), ConstraintSource(..) )
+         ( PreSolver(..) )
 import qualified Distribution.Client.Init.Types as IT
          ( InitFlags(..), PackageType(..) )
 import Distribution.Client.Targets
@@ -67,6 +67,7 @@ import Distribution.Client.Targets
 import Distribution.Utils.NubList
          ( NubList, toNubList, fromNubList)
 
+import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.Settings
 
 import Distribution.Simple.Compiler (PackageDB)

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -58,9 +58,10 @@ import Distribution.Client.Types
          ( PackageLocation(..)
          , ResolvedPkgLoc, UnresolvedSourcePackage )
 import Distribution.Client.Dependency.Types
-         ( PackageConstraint(..), ConstraintSource(..)
+         ( PackageConstraint(..)
          , LabeledPackageConstraint(..) )
 
+import           Distribution.Solver.Types.ConstraintSource
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PackageIndex (PackageIndex)
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/cabal-install/Distribution/Solver/Modular/ConfiguredConversion.hs
+++ b/cabal-install/Distribution/Solver/Modular/ConfiguredConversion.hs
@@ -7,14 +7,14 @@ import Prelude hiding (pi)
 
 import Distribution.Package (UnitId, packageId)
 
-import Distribution.Client.Dependency.Types (ResolverPackage(..))
 import qualified Distribution.Simple.PackageIndex as SI
 
 import Distribution.Solver.Modular.Configured
 import Distribution.Solver.Modular.Package
 
-import qualified Distribution.Solver.Types.PackageIndex as CI
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
+import qualified Distribution.Solver.Types.PackageIndex as CI
+import           Distribution.Solver.Types.ResolverPackage
 import           Distribution.Solver.Types.SolverId
 import           Distribution.Solver.Types.SolverPackage
 import           Distribution.Solver.Types.SourcePackage

--- a/cabal-install/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install/Distribution/Solver/Modular/Message.hs
@@ -15,9 +15,8 @@ import Distribution.Solver.Modular.Flag
 import Distribution.Solver.Modular.Package
 import Distribution.Solver.Modular.Tree
          ( FailReason(..), POption(..) )
+import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.Progress
-import Distribution.Client.Dependency.Types
-         ( ConstraintSource(..), showConstraintSource )
 
 data Message =
     Enter           -- ^ increase indentation level

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -29,8 +29,9 @@ import Data.Map (Map)
 import Data.Traversable (sequence)
 
 import Distribution.Client.Dependency.Types
-  ( PackageConstraint(..), LabeledPackageConstraint(..), ConstraintSource(..)
+  ( PackageConstraint(..), LabeledPackageConstraint(..)
   , PackagePreferences(..), InstalledPreference(..) )
+import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.OptionalStanza
 
 import Distribution.Solver.Modular.Dependency

--- a/cabal-install/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install/Distribution/Solver/Modular/Tree.hs
@@ -26,7 +26,7 @@ import Distribution.Solver.Modular.Package
 import Distribution.Solver.Modular.PSQ (PSQ)
 import qualified Distribution.Solver.Modular.PSQ as P
 import Distribution.Solver.Modular.Version
-import Distribution.Client.Dependency.Types ( ConstraintSource(..) )
+import Distribution.Solver.Types.ConstraintSource
 
 -- | Type of the search tree. Inlining the choice nodes for now.
 data Tree a =

--- a/cabal-install/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install/Distribution/Solver/Types/ConstraintSource.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Distribution.Solver.Types.ConstraintSource
+    ( ConstraintSource(..)
+    , showConstraintSource
+    ) where
+
+import GHC.Generics (Generic)
+import Distribution.Compat.Binary (Binary(..))
+
+import Prelude hiding (fail)
+
+-- | Source of a 'PackageConstraint'.
+data ConstraintSource =
+
+  -- | Main config file, which is ~/.cabal/config by default.
+  ConstraintSourceMainConfig FilePath
+
+  -- | Local cabal.project file
+  | ConstraintSourceProjectConfig FilePath
+
+  -- | Sandbox config file, which is ./cabal.sandbox.config by default.
+  | ConstraintSourceSandboxConfig FilePath
+
+  -- | User config file, which is ./cabal.config by default.
+  | ConstraintSourceUserConfig FilePath
+
+  -- | Flag specified on the command line.
+  | ConstraintSourceCommandlineFlag
+
+  -- | Target specified by the user, e.g., @cabal install package-0.1.0.0@
+  -- implies @package==0.1.0.0@.
+  | ConstraintSourceUserTarget
+
+  -- | Internal requirement to use installed versions of packages like ghc-prim.
+  | ConstraintSourceNonUpgradeablePackage
+
+  -- | Internal requirement to use the add-source version of a package when that
+  -- version is installed and the source is modified.
+  | ConstraintSourceModifiedAddSourceDep
+
+  -- | Internal constraint used by @cabal freeze@.
+  | ConstraintSourceFreeze
+
+  -- | Constraint specified by a config file, a command line flag, or a user
+  -- target, when a more specific source is not known.
+  | ConstraintSourceConfigFlagOrTarget
+
+  -- | The source of the constraint is not specified.
+  | ConstraintSourceUnknown
+  deriving (Eq, Show, Generic)
+
+instance Binary ConstraintSource
+
+-- | Description of a 'ConstraintSource'.
+showConstraintSource :: ConstraintSource -> String
+showConstraintSource (ConstraintSourceMainConfig path) =
+    "main config " ++ path
+showConstraintSource (ConstraintSourceProjectConfig path) =
+    "project config " ++ path
+showConstraintSource (ConstraintSourceSandboxConfig path) =
+    "sandbox config " ++ path
+showConstraintSource (ConstraintSourceUserConfig path)= "user config " ++ path
+showConstraintSource ConstraintSourceCommandlineFlag = "command line flag"
+showConstraintSource ConstraintSourceUserTarget = "user target"
+showConstraintSource ConstraintSourceNonUpgradeablePackage =
+    "non-upgradeable package"
+showConstraintSource ConstraintSourceModifiedAddSourceDep =
+    "modified add-source dependency"
+showConstraintSource ConstraintSourceFreeze = "cabal freeze"
+showConstraintSource ConstraintSourceConfigFlagOrTarget =
+    "config file, command line flag, or user target"
+showConstraintSource ConstraintSourceUnknown = "unknown source"

--- a/cabal-install/Distribution/Solver/Types/ResolverPackage.hs
+++ b/cabal-install/Distribution/Solver/Types/ResolverPackage.hs
@@ -1,0 +1,15 @@
+module Distribution.Solver.Types.ResolverPackage
+    ( ResolverPackage(..)
+    ) where
+
+import Distribution.InstalledPackageInfo (InstalledPackageInfo)
+import Distribution.Solver.Types.SolverPackage
+
+-- | The dependency resolver picks either pre-existing installed packages
+-- or it picks source packages along with package configuration.
+--
+-- This is like the 'InstallPlan.PlanPackage' but with fewer cases.
+--
+data ResolverPackage loc = PreExisting InstalledPackageInfo
+                         | Configured  (SolverPackage loc)
+

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -223,6 +223,7 @@ executable cabal
         Distribution.Solver.Types.PackageIndex
         Distribution.Solver.Types.PkgConfigDb
         Distribution.Solver.Types.Progress
+        Distribution.Solver.Types.ResolverPackage
         Distribution.Solver.Types.Settings
         Distribution.Solver.Types.SolverId
         Distribution.Solver.Types.SolverPackage

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -216,6 +216,7 @@ executable cabal
         Distribution.Client.Compat.Process
         Distribution.Client.Compat.Semaphore
         Distribution.Solver.Types.ComponentDeps
+        Distribution.Solver.Types.ConstraintSource
         Distribution.Solver.Types.Internal.Utils
         Distribution.Solver.Types.OptionalStanza
         Distribution.Solver.Types.PackageFixedDeps

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -31,6 +31,7 @@ import Distribution.Client.Targets
 import Distribution.Utils.NubList
 import Network.URI
 
+import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.Settings
 

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -48,6 +48,7 @@ import qualified Distribution.Client.InstallPlan       as CI.InstallPlan
 
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
+import           Distribution.Solver.Types.ConstraintSource
 import           Distribution.Solver.Types.OptionalStanza
 import qualified Distribution.Solver.Types.PackageIndex      as CI.PackageIndex
 import qualified Distribution.Solver.Types.PkgConfigDb as PC


### PR DESCRIPTION
As a follow-up to #3381 these commits move ConstraintSource and ResolverPackage too.

Incidentally, ResolverPackage is a bit anemic as a module, but I've decided to stick with the general pattern of `Distribution.Solver.Types.*` for now. I think it'll be easier to see if there's anything that should perhaps be re-combined later on.