### PR TITLE
Fix bugs with bash completion

### DIFF
--- a/cabal-install/bash-completion/cabal
+++ b/cabal-install/bash-completion/cabal
@@ -10,9 +10,10 @@
 #   - executable|test-suite|benchmark for the three
 _cabal_list()
 {
-	cat *.cabal |
-	grep -Ei "^[[:space:]]*($1)[[:space:]]" |
-	sed -e "s/.* \([^ ]*\).*/\1/"
+    for f in ./*.cabal; do
+        grep -Ei "^[[:space:]]*($1)[[:space:]]" "$f" |
+        sed -e "s/.* \([^ ]*\).*/\1/"
+    done
 }
 
 # List possible targets depending on the command supplied as parameter.  The
@@ -20,17 +21,16 @@ _cabal_list()
 # This is a temporary workaround.
 _cabal_targets()
 {
-	# If command ($*) contains build, repl, test or bench completes with
-	# targets of according type.
-	[ -f *.cabal ] || return 0
-	local comp
-	for comp in $*; do
-		[ $comp == build ] && _cabal_list "executable|test-suite|benchmark" && break
-		[ $comp == repl  ] && _cabal_list "executable|test-suite|benchmark" && break
-		[ $comp == run   ] && _cabal_list "executable"                      && break
-		[ $comp == test  ] && _cabal_list            "test-suite"           && break
-		[ $comp == bench ] && _cabal_list                       "benchmark" && break
-	done
+    # If command ($*) contains build, repl, test or bench completes with
+    # targets of according type.
+    local comp
+    for comp in "$@"; do
+        [ "$comp" == build ] && _cabal_list "executable|test-suite|benchmark" && break
+        [ "$comp" == repl  ] && _cabal_list "executable|test-suite|benchmark" && break
+        [ "$comp" == run   ] && _cabal_list "executable"                      && break
+        [ "$comp" == test  ] && _cabal_list            "test-suite"           && break
+        [ "$comp" == bench ] && _cabal_list                       "benchmark" && break
+    done
 }
 
 # List possible subcommands of a cabal subcommand.
@@ -87,7 +87,7 @@ _cabal()
     cmd[${COMP_CWORD}]="--list-options"
 
     # the resulting completions should be put into this array
-    COMPREPLY=( $( compgen -W "$( ${cmd[@]} ) $( _cabal_targets ${cmd[@]} ) $( _cabal_subcommands ${COMP_WORDS[@]} )" -- $cur ) )
+    COMPREPLY=( $( compgen -W "$( eval "${cmd[@]}" 2>/dev/null ) $( _cabal_targets "${cmd[@]}" ) $( _cabal_subcommands "${COMP_WORDS[@]}" )" -- "$cur" ) )
 }
 
 complete -F _cabal -o default cabal


### PR DESCRIPTION
The bash completion suffers from a number of issues,
some fix with this patch;

With this patch we expand the path to cabal as well as its arguments.
For example;
~/code/cabal configure --with-ghc=$GHC <tab><tab>
will now work. Both ~ and the $GHC variable will be expanded.

If there are no .cabal files, or multiple files, the script will no longer
crash.

We still invoke cabal to get completions. If cabal detects an error and writes
errors to STDERR, these will no longer be printed to the console. Instead we
don't offer any completions.