### PR TITLE
Don't ignore 206 response in plain-http transport

### DIFF
--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -635,7 +635,7 @@ plainHttpTransport =
       (_, resp) <- cabalBrowse verbosity Nothing (request req)
       let code  = convertRspCode (rspCode resp)
           etag' = lookupHeader HdrETag (rspHeaders resp)
-      when (code==200) $
+      when (code==200 || code==206) $
         writeFileAtomic destPath $ rspBody resp
       return (code, etag')
 


### PR DESCRIPTION
The plainHttpTransport implementation saved the resulting file only when the
server responded with 200 OK, thus ignoring the payload from the server when
the server responded with a 206 Partial Content. This was causing incremental
updates through hackage-security to fail (it wouldn't fail fatally;
hackage-security would notice the invalid timestamp and download the whole
thing instead, but of course this means we're not actually getting any
incremental behaviour).