### PR TITLE
Prevent bootstrap.sh from building haddocks for hackage-security

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -228,8 +228,9 @@ HASHABLE_VER="1.2.4.0"; HASHABLE_VER_REGEXP="1\."
 
 HACKAGE_URL="https://hackage.haskell.org/package"
 
-# Haddock fails for network-2.5.0.0.
-NO_DOCS_PACKAGES_VER_REGEXP="network-uri-2\.5\.[0-9]+\.[0-9]+"
+# Haddock fails for network-2.5.0.0, and for hackage-security for
+# GHC <8, c.f. https://github.com/well-typed/hackage-security/issues/149
+NO_DOCS_PACKAGES_VER_REGEXP="network-uri-2\.5\.[0-9]+\.[0-9]+|hackage-security-0\.5\.[0-9]+\.[0-9]+"
 
 # Cache the list of packages:
 echo "Checking installed packages for ghc-${GHC_VER}..."


### PR DESCRIPTION
An outstanding bug in GHC pre-8 causes haddock comments on GADT constructors to fail, which in turn prevents the bootstrapping process from finishing. This works around it by skipping haddocks for hackage-security.

This addresses the problem described in #3389 and well-typed/hackage-security#149, and this fix won't be necessary at all for GHC 8+.