### PR TITLE
Add `conflictSetOrigin` debugging field

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Dependency.hs
+++ b/cabal-install/Distribution/Solver/Modular/Dependency.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE CPP #-}
+#ifdef DEBUG_CONFLICT_SETS
+{-# LANGUAGE ImplicitParams #-}
+#endif
 module Distribution.Solver.Modular.Dependency (
     -- * Variables
     Var(..)
@@ -56,6 +60,10 @@ import qualified Distribution.Solver.Modular.ConflictSet as CS
 
 import Distribution.Solver.Types.ComponentDeps (Component(..))
 
+#ifdef DEBUG_CONFLICT_SETS
+import GHC.Stack (CallStack)
+#endif
+
 {-------------------------------------------------------------------------------
   Constrained instances
 -------------------------------------------------------------------------------}
@@ -85,7 +93,11 @@ showCI (Constrained vr) = showVR (collapse vr)
 -- set in the sense the it contains variables that allow us to backjump
 -- further. We might apply some heuristics here, such as to change the
 -- order in which we check the constraints.
-merge :: Ord qpn => CI qpn -> CI qpn -> Either (ConflictSet qpn, (CI qpn, CI qpn)) (CI qpn)
+merge ::
+#ifdef DEBUG_CONFLICT_SETS
+  (?loc :: CallStack) =>
+#endif
+  Ord qpn => CI qpn -> CI qpn -> Either (ConflictSet qpn, (CI qpn, CI qpn)) (CI qpn)
 merge c@(Fixed i g1)       d@(Fixed j g2)
   | i == j                                    = Right c
   | otherwise                                 = Left (CS.union (varToConflictSet g1) (varToConflictSet g2), (c, d))

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -130,6 +130,10 @@ Flag network-uri
   description:  Get Network.URI from the network-uri package
   default:      True
 
+Flag debug-conflict-sets
+  description:  Add additional information to ConflictSets
+  default:      False
+
 executable cabal
     main-is:        Main.hs
     ghc-options:    -Wall -fwarn-tabs
@@ -310,6 +314,10 @@ executable cabal
     if !(arch(arm) && impl(ghc < 7.6))
       ghc-options: -threaded
 
+    if flag(debug-conflict-sets)
+      cpp-options: -DDEBUG_CONFLICT_SETS
+      build-depends: base >= 4.8
+
     default-language: Haskell2010
 
 -- Small, fast running tests.
@@ -377,6 +385,11 @@ Test-Suite unit-tests
 
   if !(arch(arm) && impl(ghc < 7.6))
     ghc-options: -threaded
+
+  if flag(debug-conflict-sets)
+    cpp-options: -DDEBUG_CONFLICT_SETS
+    build-depends: base >= 4.8
+
   default-language: Haskell2010
 
 -- Slow solver tests
@@ -431,6 +444,11 @@ Test-Suite solver-quickcheck
 
   if !(arch(arm) && impl(ghc < 7.6))
     ghc-options: -threaded
+
+  if flag(debug-conflict-sets)
+    cpp-options: -DDEBUG_CONFLICT_SETS
+    build-depends: base >= 4.8
+
   default-language: Haskell2010
 
 test-suite integration-tests


### PR DESCRIPTION
This field is only added if the `debug-conflict-sets` flag is specified to
`cabal config`; it adds a tree to `CallStack`s to a `ConflictSet`. This is very
useful when trying to understand how a certain conflict set was constructed.

/cc @kosmikus 