### PR TITLE
Simplify `GoalChoice`

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Builder.hs
+++ b/cabal-install/Distribution/Solver/Modular/Builder.hs
@@ -111,8 +111,9 @@ build = ana go
     -- it from the queue of open goals.
     go bs@(BS { rdeps = rds, open = gs, next = Goals })
       | P.null gs = DoneF rds
-      | otherwise = GoalChoiceF (P.mapWithKey (\ g (_sc, gs') -> bs { next = OneGoal g, open = gs' })
-                                              (P.splits gs))
+      | otherwise = GoalChoiceF $ P.mapKeys close
+                                $ P.mapWithKey (\ g (_sc, gs') -> bs { next = OneGoal g, open = gs' })
+                                $ P.splits gs
 
     -- If we have already picked a goal, then the choice depends on the kind
     -- of goal.

--- a/cabal-install/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install/Distribution/Solver/Modular/Explore.hs
@@ -90,7 +90,7 @@ exploreLog enableBj = cata go
     go (GoalChoiceF        ts) a           =
       P.casePSQ ts
         (failWith (Failure CS.empty EmptyGoalChoice) CS.empty) -- empty goal choice is an internal error
-        (\ k v _xs -> continueWith (Next (close k)) (v a))     -- commit to the first goal choice
+        (\ k v _xs -> continueWith (Next k) (v a))             -- commit to the first goal choice
 
 -- | Build a conflict set corresponding to the (virtual) option not to
 -- choose a solution for a goal at all.

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -295,9 +295,9 @@ preferBaseGoalChoice = trav go
     go (GoalChoiceF xs) = GoalChoiceF (P.preferByKeys isBase xs)
     go x                = x
 
-    isBase :: OpenGoal comp -> Bool
-    isBase (OpenGoal (Simple (Dep (Q _pp pn) _) _) _) | unPN pn == "base" = True
-    isBase _                                                              = False
+    isBase :: Goal QPN -> Bool
+    isBase (Goal (P (Q _pp pn)) _) = unPN pn == "base"
+    isBase _                       = False
 
 -- | Deal with setup dependencies after regular dependencies, so that we can
 -- will link setup depencencies against package dependencies when possible
@@ -307,9 +307,9 @@ deferSetupChoices = trav go
     go (GoalChoiceF xs) = GoalChoiceF (P.preferByKeys noSetup xs)
     go x                = x
 
-    noSetup :: OpenGoal comp -> Bool
-    noSetup (OpenGoal (Simple (Dep (Q (PP _ns (Setup _)) _) _) _) _) = False
-    noSetup _                                                        = True
+    noSetup :: Goal QPN -> Bool
+    noSetup (Goal (P (Q (PP _ns (Setup _)) _)) _) = False
+    noSetup _                                     = True
 
 -- | Transformation that tries to avoid making weak flag choices early.
 -- Weak flags are trivial flags (not influencing dependencies) or such

--- a/cabal-install/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install/Distribution/Solver/Modular/Tree.hs
@@ -30,10 +30,10 @@ import Distribution.Solver.Types.ConstraintSource
 
 -- | Type of the search tree. Inlining the choice nodes for now.
 data Tree a =
-    PChoice     QPN a           (PSQ POption       (Tree a))
-  | FChoice     QFN a Bool Bool (PSQ Bool          (Tree a)) -- Bool indicates whether it's weak/trivial, second Bool whether it's manual
-  | SChoice     QSN a Bool      (PSQ Bool          (Tree a)) -- Bool indicates whether it's trivial
-  | GoalChoice                  (PSQ (OpenGoal ()) (Tree a)) -- PSQ should never be empty
+    PChoice     QPN a           (PSQ POption    (Tree a))
+  | FChoice     QFN a Bool Bool (PSQ Bool       (Tree a)) -- Bool indicates whether it's weak/trivial, second Bool whether it's manual
+  | SChoice     QSN a Bool      (PSQ Bool       (Tree a)) -- Bool indicates whether it's trivial
+  | GoalChoice                  (PSQ (Goal QPN) (Tree a)) -- PSQ should never be empty
   | Done        RevDepMap
   | Fail        (ConflictSet QPN) FailReason
   deriving (Eq, Show, Functor)
@@ -87,10 +87,10 @@ data FailReason = InconsistentInitialConstraints
 
 -- | Functor for the tree type.
 data TreeF a b =
-    PChoiceF    QPN a           (PSQ POption       b)
-  | FChoiceF    QFN a Bool Bool (PSQ Bool          b)
-  | SChoiceF    QSN a Bool      (PSQ Bool          b)
-  | GoalChoiceF                 (PSQ (OpenGoal ()) b)
+    PChoiceF    QPN a           (PSQ POption    b)
+  | FChoiceF    QFN a Bool Bool (PSQ Bool       b)
+  | SChoiceF    QSN a Bool      (PSQ Bool       b)
+  | GoalChoiceF                 (PSQ (Goal QPN) b)
   | DoneF       RevDepMap
   | FailF       (ConflictSet QPN) FailReason
   deriving (Functor, Foldable, Traversable)


### PR DESCRIPTION
This PR makes two changes:

* Replace `OpenGoal` with `Goal` as keys for the PSQ in `GoalChoice`
* Document the invariant that the `QGoalReason` cached in `PChoice` and co must equal the reason stored on `GoalChoice` node directly above them.

Fixes #3398.

/cc @kosmikus   