### PR TITLE
Restore Verbose-level logging of the haddock command line

### DIFF
--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -469,8 +469,13 @@ renderArgs verbosity tmpFileOpts version comp platform args k = do
                  withTempFileEx tmpFileOpts outputDir "haddock-response.txt" $
                     \responseFileName hf -> do
                          when haddockSupportsUTF8 (hSetEncoding hf utf8)
-                         hPutStr hf $ unlines $ map escapeArg renderedArgs
+                         let responseContents =
+                                 unlines $ map escapeArg renderedArgs
+                         hPutStr hf responseContents
                          hClose hf
+                         info verbosity $ responseFileName ++ " contents: <<<"
+                         info verbosity responseContents
+                         info verbosity $ ">>> " ++ responseFileName
                          let respFile = "@" ++ responseFileName
                          k ([respFile], result)
                else


### PR DESCRIPTION
(This is against tag 1.24 but should be considered for where ever convenient.)

Prior to the response file code, all of the details of the
command line for haddock would have been logged (with level
== Verbose), so this corrects an oversight and brings the
information in the logging back to what it used to be for
cabal's haddock invocations, by logging the contents of the
response file.

* Cabal/Distribution/Simple/Haddock.hs
  * Restore the logging of the entire command line used when
    invoking haddock to what it used to be prior to adding
    the response-file creation.