### PR TITLE
Move solver types to Distribution.Solver.* namespace

### DIFF
--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -19,8 +19,6 @@ module Distribution.Client.Configure (
   ) where
 
 import Distribution.Client.Dependency
-import Distribution.Client.Dependency.Types
-         ( LabeledPackageConstraint(..) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.InstallPlan (SolverInstallPlan)
 import Distribution.Client.IndexUtils as IndexUtils
@@ -38,6 +36,7 @@ import Distribution.Client.JobControl (Lock)
 
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ConstraintSource
+import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PackageIndex
                    ( PackageIndex, elemByPackageName )

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -74,7 +74,7 @@ import Distribution.Client.Types
          , UnresolvedPkgLoc, UnresolvedSourcePackage
          , enableStanzas )
 import Distribution.Client.Dependency.Types
-         ( PreSolver(..), Solver(..), DependencyResolver
+         ( PreSolver(..), Solver(..)
          , PackagesPreferenceDefault(..) )
 import Distribution.Client.Sandbox.Types
          ( SandboxPackageInfo(..) )
@@ -113,6 +113,7 @@ import Distribution.Verbosity
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ConstraintSource
+import           Distribution.Solver.Types.DependencyResolver
 import           Distribution.Solver.Types.InstalledPreference
 import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -75,7 +75,6 @@ import Distribution.Client.Types
          , enableStanzas )
 import Distribution.Client.Dependency.Types
          ( PreSolver(..), Solver(..), DependencyResolver
-         , LabeledPackageConstraint(..), unlabelPackageConstraint
          , PackagePreferences(..), InstalledPreference(..)
          , PackagesPreferenceDefault(..) )
 import Distribution.Client.Sandbox.Types
@@ -115,6 +114,7 @@ import Distribution.Verbosity
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ConstraintSource
+import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PackageConstraint
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -75,7 +75,6 @@ import Distribution.Client.Types
          , enableStanzas )
 import Distribution.Client.Dependency.Types
          ( PreSolver(..), Solver(..), DependencyResolver
-         , PackagePreferences(..)
          , PackagesPreferenceDefault(..) )
 import Distribution.Client.Sandbox.Types
          ( SandboxPackageInfo(..) )
@@ -118,6 +117,7 @@ import           Distribution.Solver.Types.InstalledPreference
 import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PackageConstraint
+import           Distribution.Solver.Types.PackagePreferences
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
 import           Distribution.Solver.Types.PkgConfigDb (PkgConfigDb)
 import           Distribution.Solver.Types.Progress

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -75,7 +75,7 @@ import Distribution.Client.Types
          , enableStanzas )
 import Distribution.Client.Dependency.Types
          ( PreSolver(..), Solver(..), DependencyResolver
-         , PackagePreferences(..), InstalledPreference(..)
+         , PackagePreferences(..)
          , PackagesPreferenceDefault(..) )
 import Distribution.Client.Sandbox.Types
          ( SandboxPackageInfo(..) )
@@ -114,6 +114,7 @@ import Distribution.Verbosity
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ConstraintSource
+import           Distribution.Solver.Types.InstalledPreference
 import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PackageConstraint

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -75,7 +75,6 @@ import Distribution.Client.Types
          , enableStanzas )
 import Distribution.Client.Dependency.Types
          ( PreSolver(..), Solver(..), DependencyResolver
-         , PackageConstraint(..), showPackageConstraint
          , LabeledPackageConstraint(..), unlabelPackageConstraint
          , PackagePreferences(..), InstalledPreference(..)
          , PackagesPreferenceDefault(..) )
@@ -117,6 +116,7 @@ import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ConstraintSource
 import           Distribution.Solver.Types.OptionalStanza
+import           Distribution.Solver.Types.PackageConstraint
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
 import           Distribution.Solver.Types.PkgConfigDb (PkgConfigDb)
 import           Distribution.Solver.Types.Progress

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -23,8 +23,7 @@ import Distribution.Client.Types
          ( UnresolvedPkgLoc
          , UnresolvedSourcePackage, enableStanzas )
 import Distribution.Client.Dependency.Types
-         ( DependencyResolver
-         , PackagePreferences(..) )
+         ( DependencyResolver )
 
 
 import qualified Distribution.Simple.PackageIndex  as InstalledPackageIndex
@@ -60,6 +59,7 @@ import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.PackageConstraint
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
 import           Distribution.Solver.Types.PackageIndex (PackageIndex)
+import           Distribution.Solver.Types.PackagePreferences
 import           Distribution.Solver.Types.Progress
 import           Distribution.Solver.Types.ResolverPackage
 import           Distribution.Solver.Types.SolverId

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -22,9 +22,6 @@ import Distribution.Client.Dependency.TopDown.Constraints
 import Distribution.Client.Types
          ( UnresolvedPkgLoc
          , UnresolvedSourcePackage, enableStanzas )
-import Distribution.Client.Dependency.Types
-         ( DependencyResolver )
-
 
 import qualified Distribution.Simple.PackageIndex  as InstalledPackageIndex
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
@@ -54,6 +51,7 @@ import Distribution.Text
 
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
+import           Distribution.Solver.Types.DependencyResolver
 import           Distribution.Solver.Types.InstalledPreference
 import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.PackageConstraint

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -24,8 +24,9 @@ import Distribution.Client.Types
          , UnresolvedSourcePackage, enableStanzas )
 import Distribution.Client.Dependency.Types
          ( DependencyResolver
-         , PackageConstraint(..), unlabelPackageConstraint
+         , unlabelPackageConstraint
          , PackagePreferences(..), InstalledPreference(..) )
+
 
 import qualified Distribution.Simple.PackageIndex  as InstalledPackageIndex
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
@@ -53,10 +54,11 @@ import Distribution.Simple.Utils
 import Distribution.Text
          ( display )
 
-import           Distribution.Solver.Types.ComponentDeps ( ComponentDeps )
+import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
+import           Distribution.Solver.Types.PackageConstraint
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
-import           Distribution.Solver.Types.PackageIndex ( PackageIndex )
+import           Distribution.Solver.Types.PackageIndex (PackageIndex)
 import           Distribution.Solver.Types.Progress
 import           Distribution.Solver.Types.ResolverPackage
 import           Distribution.Solver.Types.SolverId

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -24,7 +24,6 @@ import Distribution.Client.Types
          , UnresolvedSourcePackage, enableStanzas )
 import Distribution.Client.Dependency.Types
          ( DependencyResolver
-         , unlabelPackageConstraint
          , PackagePreferences(..), InstalledPreference(..) )
 
 
@@ -56,6 +55,7 @@ import Distribution.Text
 
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
+import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.PackageConstraint
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
 import           Distribution.Solver.Types.PackageIndex (PackageIndex)

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -24,7 +24,7 @@ import Distribution.Client.Types
          , UnresolvedSourcePackage, enableStanzas )
 import Distribution.Client.Dependency.Types
          ( DependencyResolver
-         , PackagePreferences(..), InstalledPreference(..) )
+         , PackagePreferences(..) )
 
 
 import qualified Distribution.Simple.PackageIndex  as InstalledPackageIndex
@@ -55,6 +55,7 @@ import Distribution.Text
 
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
+import           Distribution.Solver.Types.InstalledPreference
 import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.PackageConstraint
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -17,7 +17,6 @@ module Distribution.Client.Dependency.Types (
 
     DependencyResolver,
 
-    PackagePreferences(..),
     PackagesPreferenceDefault(..),
 
   ) where
@@ -25,10 +24,9 @@ module Distribution.Client.Dependency.Types (
 import Data.Char
          ( isAlpha, toLower )
 
-import Distribution.Solver.Types.InstalledPreference
 import Distribution.Solver.Types.LabeledPackageConstraint
-import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PkgConfigDb ( PkgConfigDb )
+import Distribution.Solver.Types.PackagePreferences
 import Distribution.Solver.Types.PackageIndex ( PackageIndex )
 import Distribution.Solver.Types.Progress
 import Distribution.Solver.Types.ResolverPackage
@@ -39,8 +37,6 @@ import qualified Distribution.Compat.ReadP as Parse
 import Distribution.Simple.PackageIndex ( InstalledPackageIndex )
 import Distribution.Package
          ( PackageName )
-import Distribution.Version
-         ( VersionRange )
 import Distribution.Compiler
          ( CompilerInfo )
 import Distribution.System
@@ -96,21 +92,6 @@ type DependencyResolver loc = Platform
                            -> [LabeledPackageConstraint]
                            -> [PackageName]
                            -> Progress String String [ResolverPackage loc]
-
--- | Per-package preferences on the version. It is a soft constraint that the
--- 'DependencyResolver' should try to respect where possible. It consists of
--- an 'InstalledPreference' which says if we prefer versions of packages
--- that are already installed. It also has (possibly multiple)
--- 'PackageVersionPreference's which are suggested constraints on the version
--- number. The resolver should try to use package versions that satisfy
--- the maximum number of the suggested version constraints.
---
--- It is not specified if preferences on some packages are more important than
--- others.
---
-data PackagePreferences = PackagePreferences [VersionRange]
-                                             InstalledPreference
-                                             [OptionalStanza]
 
 -- | Global policy for all packages to say if we prefer package versions that
 -- are already installed locally or if we just prefer the latest available.

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -1,16 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
------------------------------------------------------------------------------
--- |
--- Module      :  Distribution.Client.Dependency.Types
--- Copyright   :  (c) Duncan Coutts 2008
--- License     :  BSD-like
---
--- Maintainer  :  cabal-devel@haskell.org
--- Stability   :  provisional
--- Portability :  portable
---
--- Common types for dependency resolution.
------------------------------------------------------------------------------
 module Distribution.Client.Dependency.Types (
     PreSolver(..),
     Solver(..),

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -18,7 +18,6 @@ module Distribution.Client.Dependency.Types (
     DependencyResolver,
 
     PackagePreferences(..),
-    InstalledPreference(..),
     PackagesPreferenceDefault(..),
 
   ) where
@@ -26,6 +25,7 @@ module Distribution.Client.Dependency.Types (
 import Data.Char
          ( isAlpha, toLower )
 
+import Distribution.Solver.Types.InstalledPreference
 import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PkgConfigDb ( PkgConfigDb )
@@ -111,12 +111,6 @@ type DependencyResolver loc = Platform
 data PackagePreferences = PackagePreferences [VersionRange]
                                              InstalledPreference
                                              [OptionalStanza]
-
--- | Whether we prefer an installed version of a package or simply the latest
--- version.
---
-data InstalledPreference = PreferInstalled | PreferLatest
-  deriving Show
 
 -- | Global policy for all packages to say if we prefer package versions that
 -- are already installed locally or if we just prefer the latest available.

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -21,18 +21,14 @@ module Distribution.Client.Dependency.Types (
     InstalledPreference(..),
     PackagesPreferenceDefault(..),
 
-    LabeledPackageConstraint(..),
-    unlabelPackageConstraint
-
   ) where
 
 import Data.Char
          ( isAlpha, toLower )
 
-import Distribution.Solver.Types.ConstraintSource
+import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PkgConfigDb ( PkgConfigDb )
-import Distribution.Solver.Types.PackageConstraint ( PackageConstraint )
 import Distribution.Solver.Types.PackageIndex ( PackageIndex )
 import Distribution.Solver.Types.Progress
 import Distribution.Solver.Types.ResolverPackage
@@ -146,10 +142,3 @@ data PackagesPreferenceDefault =
      --
    | PreferLatestForSelected
   deriving Show
-
--- | 'PackageConstraint' labeled with its source.
-data LabeledPackageConstraint
-   = LabeledPackageConstraint PackageConstraint ConstraintSource
-
-unlabelPackageConstraint :: LabeledPackageConstraint -> PackageConstraint
-unlabelPackageConstraint (LabeledPackageConstraint pc _) = pc

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -15,8 +15,6 @@ module Distribution.Client.Dependency.Types (
     PreSolver(..),
     Solver(..),
 
-    DependencyResolver,
-
     PackagesPreferenceDefault(..),
 
   ) where
@@ -24,23 +22,8 @@ module Distribution.Client.Dependency.Types (
 import Data.Char
          ( isAlpha, toLower )
 
-import Distribution.Solver.Types.LabeledPackageConstraint
-import Distribution.Solver.Types.PkgConfigDb ( PkgConfigDb )
-import Distribution.Solver.Types.PackagePreferences
-import Distribution.Solver.Types.PackageIndex ( PackageIndex )
-import Distribution.Solver.Types.Progress
-import Distribution.Solver.Types.ResolverPackage
-import Distribution.Solver.Types.SourcePackage
-
 import qualified Distribution.Compat.ReadP as Parse
          ( pfail, munch1 )
-import Distribution.Simple.PackageIndex ( InstalledPackageIndex )
-import Distribution.Package
-         ( PackageName )
-import Distribution.Compiler
-         ( CompilerInfo )
-import Distribution.System
-         ( Platform )
 import Distribution.Text
          ( Text(..) )
 
@@ -74,24 +57,6 @@ instance Text PreSolver where
       "modular" -> return AlwaysModular
       "choose"  -> return Choose
       _         -> Parse.pfail
-
--- | A dependency resolver is a function that works out an installation plan
--- given the set of installed and available packages and a set of deps to
--- solve for.
---
--- The reason for this interface is because there are dozens of approaches to
--- solving the package dependency problem and we want to make it easy to swap
--- in alternatives.
---
-type DependencyResolver loc = Platform
-                           -> CompilerInfo
-                           -> InstalledPackageIndex
-                           -> PackageIndex (SourcePackage loc)
-                           -> PkgConfigDb
-                           -> (PackageName -> PackagePreferences)
-                           -> [LabeledPackageConstraint]
-                           -> [PackageName]
-                           -> Progress String String [ResolverPackage loc]
 
 -- | Global policy for all packages to say if we prefer package versions that
 -- are already installed locally or if we just prefer the latest available.

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -17,8 +17,6 @@ module Distribution.Client.Dependency.Types (
 
     DependencyResolver,
 
-    PackageConstraint(..),
-    showPackageConstraint,
     PackagePreferences(..),
     InstalledPreference(..),
     PackagesPreferenceDefault(..),
@@ -34,6 +32,7 @@ import Data.Char
 import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PkgConfigDb ( PkgConfigDb )
+import Distribution.Solver.Types.PackageConstraint ( PackageConstraint )
 import Distribution.Solver.Types.PackageIndex ( PackageIndex )
 import Distribution.Solver.Types.Progress
 import Distribution.Solver.Types.ResolverPackage
@@ -41,19 +40,17 @@ import Distribution.Solver.Types.SourcePackage
 
 import qualified Distribution.Compat.ReadP as Parse
          ( pfail, munch1 )
-import Distribution.PackageDescription
-         ( FlagAssignment, FlagName(..) )
 import Distribution.Simple.PackageIndex ( InstalledPackageIndex )
 import Distribution.Package
          ( PackageName )
 import Distribution.Version
-         ( VersionRange, simplifyVersionRange )
+         ( VersionRange )
 import Distribution.Compiler
          ( CompilerInfo )
 import Distribution.System
          ( Platform )
 import Distribution.Text
-         ( Text(..), display )
+         ( Text(..) )
 
 import Text.PrettyPrint
          ( text )
@@ -103,42 +100,6 @@ type DependencyResolver loc = Platform
                            -> [LabeledPackageConstraint]
                            -> [PackageName]
                            -> Progress String String [ResolverPackage loc]
-
--- | Per-package constraints. Package constraints must be respected by the
--- solver. Multiple constraints for each package can be given, though obviously
--- it is possible to construct conflicting constraints (eg impossible version
--- range or inconsistent flag assignment).
---
-data PackageConstraint
-   = PackageConstraintVersion   PackageName VersionRange
-   | PackageConstraintInstalled PackageName
-   | PackageConstraintSource    PackageName
-   | PackageConstraintFlags     PackageName FlagAssignment
-   | PackageConstraintStanzas   PackageName [OptionalStanza]
-  deriving (Eq,Show,Generic)
-
-instance Binary PackageConstraint
-
--- | Provide a textual representation of a package constraint
--- for debugging purposes.
---
-showPackageConstraint :: PackageConstraint -> String
-showPackageConstraint (PackageConstraintVersion pn vr) =
-  display pn ++ " " ++ display (simplifyVersionRange vr)
-showPackageConstraint (PackageConstraintInstalled pn) =
-  display pn ++ " installed"
-showPackageConstraint (PackageConstraintSource pn) =
-  display pn ++ " source"
-showPackageConstraint (PackageConstraintFlags pn fs) =
-  "flags " ++ display pn ++ " " ++ unwords (map (uncurry showFlag) fs)
-  where
-    showFlag (FlagName f) True  = "+" ++ f
-    showFlag (FlagName f) False = "-" ++ f
-showPackageConstraint (PackageConstraintStanzas pn ss) =
-  "stanzas " ++ display pn ++ " " ++ unwords (map showStanza ss)
-  where
-    showStanza TestStanzas  = "test"
-    showStanza BenchStanzas = "bench"
 
 -- | Per-package preferences on the version. It is a soft constraint that the
 -- 'DependencyResolver' should try to respect where possible. It consists of

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -32,8 +32,6 @@ import Text.PrettyPrint
 import GHC.Generics (Generic)
 import Distribution.Compat.Binary (Binary(..))
 
-import Prelude hiding (fail)
-
 
 -- | All the solvers that can be selected.
 data PreSolver = AlwaysTopDown | AlwaysModular | Choose

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -20,8 +20,6 @@ import Distribution.Client.Config ( SavedConfig(..) )
 import Distribution.Client.Types
 import Distribution.Client.Targets
 import Distribution.Client.Dependency
-import Distribution.Client.Dependency.Types
-         ( LabeledPackageConstraint(..) )
 import Distribution.Client.IndexUtils as IndexUtils
          ( getSourcePackages, getInstalledPackages )
 import Distribution.Client.InstallPlan
@@ -37,9 +35,9 @@ import Distribution.Client.Sandbox.Types
          ( SandboxPackageInfo(..) )
 
 import Distribution.Solver.Types.ConstraintSource
+import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PkgConfigDb
-         ( PkgConfigDb, readPkgConfigDb )
 import Distribution.Solver.Types.SolverId
 
 import Distribution.Package

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -72,7 +72,7 @@ import Distribution.Client.Configure
          ( chooseCabalVersion, configureSetupScript, checkConfigExFlags )
 import Distribution.Client.Dependency
 import Distribution.Client.Dependency.Types
-         ( Solver(..), LabeledPackageConstraint(..) )
+         ( Solver(..) )
 import Distribution.Client.FetchUtils
 import Distribution.Client.HttpUtils
          ( HttpTransport (..) )
@@ -111,6 +111,7 @@ import Distribution.Client.JobControl
 
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ConstraintSource
+import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import qualified Distribution.Solver.Types.PackageIndex as SourcePackageIndex
 import           Distribution.Solver.Types.PackageFixedDeps

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -41,14 +41,13 @@ import Distribution.Verbosity (Verbosity)
 import Distribution.Text
          ( Text(disp), display )
 
+import           Distribution.Solver.Types.PackageConstraint
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
 import           Distribution.Solver.Types.SourcePackage
 
 import Distribution.Client.Types
          ( SourcePackageDb(..)
          , UnresolvedSourcePackage )
-import Distribution.Client.Dependency.Types
-         ( PackageConstraint(..) )
 import Distribution.Client.Targets
          ( UserTarget, resolveUserTargets, PackageSpecifier(..) )
 import Distribution.Client.Setup

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -79,6 +79,7 @@ import           Distribution.Utils.NubList
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import           Distribution.Solver.Types.ConstraintSource
+import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PackageFixedDeps
 import qualified Distribution.Solver.Types.PackageIndex as SourcePackageIndex

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -57,10 +57,9 @@ import Distribution.Package
 import Distribution.Client.Types
          ( PackageLocation(..)
          , ResolvedPkgLoc, UnresolvedSourcePackage )
-import Distribution.Client.Dependency.Types
-         ( LabeledPackageConstraint(..) )
 
 import           Distribution.Solver.Types.ConstraintSource
+import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PackageConstraint
 import           Distribution.Solver.Types.PackageIndex (PackageIndex)

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -58,11 +58,11 @@ import Distribution.Client.Types
          ( PackageLocation(..)
          , ResolvedPkgLoc, UnresolvedSourcePackage )
 import Distribution.Client.Dependency.Types
-         ( PackageConstraint(..)
-         , LabeledPackageConstraint(..) )
+         ( LabeledPackageConstraint(..) )
 
 import           Distribution.Solver.Types.ConstraintSource
 import           Distribution.Solver.Types.OptionalStanza
+import           Distribution.Solver.Types.PackageConstraint
 import           Distribution.Solver.Types.PackageIndex (PackageIndex)
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
 import           Distribution.Solver.Types.SourcePackage

--- a/cabal-install/Distribution/Solver/Modular.hs
+++ b/cabal-install/Distribution/Solver/Modular.hs
@@ -23,10 +23,10 @@ import Distribution.Solver.Modular.Package
          ( PN )
 import Distribution.Solver.Modular.Solver
          ( SolverConfig(..), solve )
+import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.PackageConstraint
 import Distribution.Client.Dependency.Types
-         ( DependencyResolver
-         , unlabelPackageConstraint )
+         ( DependencyResolver )
 import Distribution.System
          ( Platform(..) )
 

--- a/cabal-install/Distribution/Solver/Modular.hs
+++ b/cabal-install/Distribution/Solver/Modular.hs
@@ -25,8 +25,7 @@ import Distribution.Solver.Modular.Solver
          ( SolverConfig(..), solve )
 import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.PackageConstraint
-import Distribution.Client.Dependency.Types
-         ( DependencyResolver )
+import Distribution.Solver.Types.DependencyResolver
 import Distribution.System
          ( Platform(..) )
 

--- a/cabal-install/Distribution/Solver/Modular.hs
+++ b/cabal-install/Distribution/Solver/Modular.hs
@@ -23,9 +23,10 @@ import Distribution.Solver.Modular.Package
          ( PN )
 import Distribution.Solver.Modular.Solver
          ( SolverConfig(..), solve )
+import Distribution.Solver.Types.PackageConstraint
 import Distribution.Client.Dependency.Types
          ( DependencyResolver
-         , PackageConstraint(..), unlabelPackageConstraint )
+         , unlabelPackageConstraint )
 import Distribution.System
          ( Platform(..) )
 

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -29,9 +29,9 @@ import Data.Map (Map)
 import Data.Traversable (sequence)
 
 import Distribution.Client.Dependency.Types
-  ( LabeledPackageConstraint(..)
-  , PackagePreferences(..), InstalledPreference(..) )
+  ( PackagePreferences(..), InstalledPreference(..) )
 import Distribution.Solver.Types.ConstraintSource
+import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PackageConstraint
 

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -28,13 +28,12 @@ import Control.Monad.Reader hiding (sequence)
 import Data.Map (Map)
 import Data.Traversable (sequence)
 
-import Distribution.Client.Dependency.Types
-  ( PackagePreferences(..) )
 import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.InstalledPreference
 import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PackageConstraint
+import Distribution.Solver.Types.PackagePreferences
 
 import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Flag

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -29,10 +29,11 @@ import Data.Map (Map)
 import Data.Traversable (sequence)
 
 import Distribution.Client.Dependency.Types
-  ( PackageConstraint(..), LabeledPackageConstraint(..)
+  ( LabeledPackageConstraint(..)
   , PackagePreferences(..), InstalledPreference(..) )
 import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.OptionalStanza
+import Distribution.Solver.Types.PackageConstraint
 
 import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Flag

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -29,8 +29,9 @@ import Data.Map (Map)
 import Data.Traversable (sequence)
 
 import Distribution.Client.Dependency.Types
-  ( PackagePreferences(..), InstalledPreference(..) )
+  ( PackagePreferences(..) )
 import Distribution.Solver.Types.ConstraintSource
+import Distribution.Solver.Types.InstalledPreference
 import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PackageConstraint

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -7,12 +7,10 @@ import Data.Map as M
 
 import Distribution.Compiler (CompilerInfo)
 
+import Distribution.Solver.Types.PackagePreferences
 import Distribution.Solver.Types.PkgConfigDb (PkgConfigDb)
 import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.Settings
-
-import Distribution.Client.Dependency.Types
-         ( PackagePreferences )
 
 import Distribution.Solver.Modular.Assignment
 import Distribution.Solver.Modular.Builder

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -8,10 +8,11 @@ import Data.Map as M
 import Distribution.Compiler (CompilerInfo)
 
 import Distribution.Solver.Types.PkgConfigDb (PkgConfigDb)
+import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.Settings
 
 import Distribution.Client.Dependency.Types
-         ( PackagePreferences, LabeledPackageConstraint )
+         ( PackagePreferences )
 
 import Distribution.Solver.Modular.Assignment
 import Distribution.Solver.Modular.Builder

--- a/cabal-install/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install/Distribution/Solver/Types/ConstraintSource.hs
@@ -7,8 +7,6 @@ module Distribution.Solver.Types.ConstraintSource
 import GHC.Generics (Generic)
 import Distribution.Compat.Binary (Binary(..))
 
-import Prelude hiding (fail)
-
 -- | Source of a 'PackageConstraint'.
 data ConstraintSource =
 

--- a/cabal-install/Distribution/Solver/Types/DependencyResolver.hs
+++ b/cabal-install/Distribution/Solver/Types/DependencyResolver.hs
@@ -1,0 +1,34 @@
+module Distribution.Solver.Types.DependencyResolver
+    ( DependencyResolver
+    ) where
+
+import Distribution.Solver.Types.LabeledPackageConstraint
+import Distribution.Solver.Types.PkgConfigDb ( PkgConfigDb )
+import Distribution.Solver.Types.PackagePreferences
+import Distribution.Solver.Types.PackageIndex ( PackageIndex )
+import Distribution.Solver.Types.Progress
+import Distribution.Solver.Types.ResolverPackage
+import Distribution.Solver.Types.SourcePackage
+
+import Distribution.Simple.PackageIndex ( InstalledPackageIndex )
+import Distribution.Package ( PackageName )
+import Distribution.Compiler ( CompilerInfo )
+import Distribution.System ( Platform )
+
+-- | A dependency resolver is a function that works out an installation plan
+-- given the set of installed and available packages and a set of deps to
+-- solve for.
+--
+-- The reason for this interface is because there are dozens of approaches to
+-- solving the package dependency problem and we want to make it easy to swap
+-- in alternatives.
+--
+type DependencyResolver loc = Platform
+                           -> CompilerInfo
+                           -> InstalledPackageIndex
+                           -> PackageIndex (SourcePackage loc)
+                           -> PkgConfigDb
+                           -> (PackageName -> PackagePreferences)
+                           -> [LabeledPackageConstraint]
+                           -> [PackageName]
+                           -> Progress String String [ResolverPackage loc]

--- a/cabal-install/Distribution/Solver/Types/InstalledPreference.hs
+++ b/cabal-install/Distribution/Solver/Types/InstalledPreference.hs
@@ -1,0 +1,9 @@
+module Distribution.Solver.Types.InstalledPreference
+    ( InstalledPreference(..),
+    ) where
+
+-- | Whether we prefer an installed version of a package or simply the latest
+-- version.
+--
+data InstalledPreference = PreferInstalled | PreferLatest
+  deriving Show

--- a/cabal-install/Distribution/Solver/Types/LabeledPackageConstraint.hs
+++ b/cabal-install/Distribution/Solver/Types/LabeledPackageConstraint.hs
@@ -1,0 +1,14 @@
+module Distribution.Solver.Types.LabeledPackageConstraint
+    ( LabeledPackageConstraint(..)
+    , unlabelPackageConstraint
+    ) where
+
+import Distribution.Solver.Types.ConstraintSource
+import Distribution.Solver.Types.PackageConstraint
+
+-- | 'PackageConstraint' labeled with its source.
+data LabeledPackageConstraint
+   = LabeledPackageConstraint PackageConstraint ConstraintSource
+
+unlabelPackageConstraint :: LabeledPackageConstraint -> PackageConstraint
+unlabelPackageConstraint (LabeledPackageConstraint pc _) = pc

--- a/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DeriveGeneric #-}
+module Distribution.Solver.Types.PackageConstraint (
+    PackageConstraint(..),
+    showPackageConstraint,
+  ) where
+
+import Distribution.Compat.Binary (Binary(..))
+import Distribution.PackageDescription (FlagAssignment, FlagName(..))
+import Distribution.Package (PackageName)
+import Distribution.Solver.Types.OptionalStanza
+import Distribution.Text (display)
+import Distribution.Version (VersionRange, simplifyVersionRange)
+import GHC.Generics (Generic)
+
+-- | Per-package constraints. Package constraints must be respected by the
+-- solver. Multiple constraints for each package can be given, though obviously
+-- it is possible to construct conflicting constraints (eg impossible version
+-- range or inconsistent flag assignment).
+--
+data PackageConstraint
+   = PackageConstraintVersion   PackageName VersionRange
+   | PackageConstraintInstalled PackageName
+   | PackageConstraintSource    PackageName
+   | PackageConstraintFlags     PackageName FlagAssignment
+   | PackageConstraintStanzas   PackageName [OptionalStanza]
+  deriving (Eq, Show, Generic)
+
+instance Binary PackageConstraint
+
+-- | Provide a textual representation of a package constraint
+-- for debugging purposes.
+--
+showPackageConstraint :: PackageConstraint -> String
+showPackageConstraint (PackageConstraintVersion pn vr) =
+  display pn ++ " " ++ display (simplifyVersionRange vr)
+showPackageConstraint (PackageConstraintInstalled pn) =
+  display pn ++ " installed"
+showPackageConstraint (PackageConstraintSource pn) =
+  display pn ++ " source"
+showPackageConstraint (PackageConstraintFlags pn fs) =
+  "flags " ++ display pn ++ " " ++ unwords (map (uncurry showFlag) fs)
+  where
+    showFlag (FlagName f) True  = "+" ++ f
+    showFlag (FlagName f) False = "-" ++ f
+showPackageConstraint (PackageConstraintStanzas pn ss) =
+  "stanzas " ++ display pn ++ " " ++ unwords (map showStanza ss)
+  where
+    showStanza TestStanzas  = "test"
+    showStanza BenchStanzas = "bench"

--- a/cabal-install/Distribution/Solver/Types/PackagePreferences.hs
+++ b/cabal-install/Distribution/Solver/Types/PackagePreferences.hs
@@ -1,0 +1,22 @@
+module Distribution.Solver.Types.PackagePreferences
+    ( PackagePreferences(..)
+    ) where
+
+import Distribution.Solver.Types.InstalledPreference
+import Distribution.Solver.Types.OptionalStanza
+import Distribution.Version (VersionRange)
+
+-- | Per-package preferences on the version. It is a soft constraint that the
+-- 'DependencyResolver' should try to respect where possible. It consists of
+-- an 'InstalledPreference' which says if we prefer versions of packages
+-- that are already installed. It also has (possibly multiple)
+-- 'PackageVersionPreference's which are suggested constraints on the version
+-- number. The resolver should try to use package versions that satisfy
+-- the maximum number of the suggested version constraints.
+--
+-- It is not specified if preferences on some packages are more important than
+-- others.
+--
+data PackagePreferences = PackagePreferences [VersionRange]
+                                             InstalledPreference
+                                             [OptionalStanza]

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -222,6 +222,7 @@ executable cabal
         Distribution.Client.Compat.Semaphore
         Distribution.Solver.Types.ComponentDeps
         Distribution.Solver.Types.ConstraintSource
+        Distribution.Solver.Types.DependencyResolver
         Distribution.Solver.Types.Internal.Utils
         Distribution.Solver.Types.InstalledPreference
         Distribution.Solver.Types.LabeledPackageConstraint

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -224,6 +224,7 @@ executable cabal
         Distribution.Solver.Types.ConstraintSource
         Distribution.Solver.Types.Internal.Utils
         Distribution.Solver.Types.OptionalStanza
+        Distribution.Solver.Types.PackageConstraint
         Distribution.Solver.Types.PackageFixedDeps
         Distribution.Solver.Types.PackageIndex
         Distribution.Solver.Types.PkgConfigDb

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -223,6 +223,7 @@ executable cabal
         Distribution.Solver.Types.ComponentDeps
         Distribution.Solver.Types.ConstraintSource
         Distribution.Solver.Types.Internal.Utils
+        Distribution.Solver.Types.LabeledPackageConstraint
         Distribution.Solver.Types.OptionalStanza
         Distribution.Solver.Types.PackageConstraint
         Distribution.Solver.Types.PackageFixedDeps

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -229,6 +229,7 @@ executable cabal
         Distribution.Solver.Types.PackageConstraint
         Distribution.Solver.Types.PackageFixedDeps
         Distribution.Solver.Types.PackageIndex
+        Distribution.Solver.Types.PackagePreferences
         Distribution.Solver.Types.PkgConfigDb
         Distribution.Solver.Types.Progress
         Distribution.Solver.Types.ResolverPackage

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -223,6 +223,7 @@ executable cabal
         Distribution.Solver.Types.ComponentDeps
         Distribution.Solver.Types.ConstraintSource
         Distribution.Solver.Types.Internal.Utils
+        Distribution.Solver.Types.InstalledPreference
         Distribution.Solver.Types.LabeledPackageConstraint
         Distribution.Solver.Types.OptionalStanza
         Distribution.Solver.Types.PackageConstraint

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -49,6 +49,7 @@ import qualified Distribution.Client.InstallPlan       as CI.InstallPlan
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ConstraintSource
+import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import qualified Distribution.Solver.Types.PackageIndex      as CI.PackageIndex
 import qualified Distribution.Solver.Types.PkgConfigDb as PC


### PR DESCRIPTION
This completes the move of all the solver types which the modular solver requires to Distribution.Solver.*.

Like last time there are few *tiny* modules, but again I've decided to go for consistency; see #3383.

This means that we now have:

```sh
$ grep -r Client cabal-install/Distribution/Solver|wc -l
0
```

which is to say that there are no longer any dependencies from the Solver namespace to the Client namespace. We should probably add a Travis check or something that ensures that none are added back accidentally.