### PR TITLE
Report process output decoding errors in context

### DIFF
--- a/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
+++ b/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
@@ -9,7 +9,9 @@ import Data.IORef
 import System.Directory ( doesDirectoryExist, doesFileExist
                         , getTemporaryDirectory
                         , removeDirectoryRecursive, removeFile )
-import System.IO (hClose)
+import System.IO (hClose, localeEncoding)
+import System.IO.Error
+import qualified Control.Exception as Exception
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -46,6 +48,24 @@ withTempDirRemovedTest = do
   withTempDirectory normal tempDir "foo" $ \dirPath -> do
     removeDirectoryRecursive dirPath
 
+rawSystemStdInOutTextDecodingTest :: Assertion
+rawSystemStdInOutTextDecodingTest
+    -- We can only get this exception when the locale encoding is UTF-8
+    -- so skip the test if it's not.
+  | show localeEncoding /= "UTF-8" = return ()
+  | otherwise = do
+  res <- Exception.try $
+    rawSystemStdInOut normal
+      -- hopefully this is sufficiently portable, we just need to execute a
+      -- program that will produce non-unicode output:
+      "ghc" ["-e", "Data.ByteString.putStr (Data.ByteString.pack [255])"]
+      Nothing Nothing Nothing
+      False -- not binary mode output, ie utf8 text mode so try to decode
+  case res of
+    Right _ -> assertFailure "expected IO decoding exception"
+    Left err | isDoesNotExistError err -> Exception.throwIO err -- no ghc!
+             | otherwise               -> return ()
+
 tests :: [TestTree]
 tests =
     [ testCase "withTempFile works as expected" $
@@ -56,4 +76,6 @@ tests =
       withTempDirTest
     , testCase "withTempDirectory can handle removed directories" $
       withTempDirRemovedTest
+    , testCase "rawSystemStdInOut reports text decoding errors" $
+      rawSystemStdInOutTextDecodingTest
     ]


### PR DESCRIPTION
It turns out that in rawSystemStdInOut any IO errors, including text
decoding, occurring while collecting the output (stderr or stdout) do
not get reported immediately, but only later if/when the output is
consumed. This is because the exceptions happened in the threads forked
to force the output, but if the main thread looks at the output later
then the exception is reported again.

This leads to very confusing results. In particular we had a case where
the configure process did not fail until writing out the LocalBuildInfo
because that was the first point that forced the output. So the distance
from when the exception really occurred and the fact that the exception
message does not include the name of the program run means that this is
then a pain to track down.

This patch makes sure that any exceptions arising from forcing the
program output occur immediately and with an error message that includes
the name of the program in question.