### PR TITLE
Add (optional) tracetree support into the cabal executable

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -1,9 +1,16 @@
+{-# LANGUAGE CPP #-}
+#ifdef DEBUG_TRACETREE
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+#endif
 module Distribution.Solver.Modular.Solver
     ( SolverConfig(..)
     , solve
     ) where
 
 import Data.Map as M
+import Data.List as L
+import Data.Version
 
 import Distribution.Compiler (CompilerInfo)
 
@@ -24,8 +31,21 @@ import Distribution.Solver.Modular.Package
 import qualified Distribution.Solver.Modular.Preference as P
 import Distribution.Solver.Modular.Validate
 import Distribution.Solver.Modular.Linking
+import Distribution.Solver.Modular.PSQ (PSQ)
+import Distribution.Solver.Modular.Tree
+import qualified Distribution.Solver.Modular.PSQ as PSQ
 
 import Distribution.Simple.Setup (BooleanFlag(..))
+
+#ifdef DEBUG_TRACETREE
+import Distribution.Solver.Modular.Flag
+import qualified Distribution.Solver.Modular.ConflictSet as CS
+
+import Debug.Trace.Tree (gtraceJson)
+import Debug.Trace.Tree.Simple
+import Debug.Trace.Tree.Generic
+import Debug.Trace.Tree.Assoc (Assoc(..))
+#endif
 
 -- | Various options for the modular solver.
 data SolverConfig = SolverConfig {
@@ -73,7 +93,7 @@ solve :: SolverConfig ->                      -- ^ solver parameters
          Log Message (Assignment, RevDepMap)
 solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
   explorePhase     $
-  detectCyclesPhase$
+  detectCycles     $
   heuristicsPhase  $
   preferencesPhase $
   validationPhase  $
@@ -81,15 +101,18 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
   buildPhase
   where
     explorePhase     = backjumpAndExplore (enableBackjumping sc)
+    detectCycles     = traceTree "cycles.json" id . detectCyclesPhase
     heuristicsPhase  = (if asBool (preferEasyGoalChoices sc)
                          then P.preferEasyGoalChoices -- also leaves just one choice
                          else P.firstGoal) . -- after doing goal-choice heuristics, commit to the first choice (saves space)
+                       traceTree "heuristics.json" id .
                        P.deferWeakFlagChoices .
                        P.deferSetupChoices .
                        P.preferBaseGoalChoice .
                        P.preferLinked
     preferencesPhase = P.preferPackagePreferences userPrefs
-    validationPhase  = P.enforceManualFlags . -- can only be done after user constraints
+    validationPhase  = traceTree "validated.json" id .
+                       P.enforceManualFlags . -- can only be done after user constraints
                        P.enforcePackageConstraints userConstraints .
                        P.enforceSingleInstanceRestriction .
                        validateLinking idx .
@@ -101,4 +124,87 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
                                                   , PackageName "integer-gmp"
                                                   , PackageName "integer-simple"
                                                   ])
-    buildPhase       = addLinking $ buildTree idx (independentGoals sc) userGoals
+    buildPhase       = traceTree "build.json" id
+                     $ addLinking
+                     $ buildTree idx (independentGoals sc) userGoals
+
+-- | Dump solver tree to a file (in debugging mode)
+--
+-- This only does something if the @debug-tracetree@ configure argument was
+-- given; otherwise this is just the identity function.
+traceTree ::
+#ifdef DEBUG_TRACETREE
+  GSimpleTree a =>
+#endif
+     FilePath  -- ^ Output file
+  -> (a -> a)  -- ^ Function to summarize the tree before dumping
+  -> a -> a
+#ifdef DEBUG_TRACETREE
+traceTree = gtraceJson
+#else
+traceTree _ _ = id
+#endif
+
+#ifdef DEBUG_TRACETREE
+instance GSimpleTree (Tree QGoalReason) where
+  fromGeneric = go
+    where
+      go :: Tree QGoalReason -> SimpleTree
+      go (PChoice qpn _     psq) = Node "P" $ Assoc $ L.map (uncurry (goP qpn)) $ PSQ.toList psq
+      go (FChoice _   _ _ _ psq) = Node "F" $ Assoc $ L.map (uncurry goFS)      $ PSQ.toList psq
+      go (SChoice _   _ _   psq) = Node "S" $ Assoc $ L.map (uncurry goFS)      $ PSQ.toList psq
+      go (GoalChoice        psq) = Node "G" $ Assoc $ L.map (uncurry goG)       $ PSQ.toList psq
+      go (Done _rdm)             = Node "D" $ Assoc []
+      go (Fail cs _reason)       = Node "X" $ Assoc [("CS", Leaf $ goCS cs)]
+
+      -- Show package choice
+      goP :: QPN -> POption -> Tree QGoalReason -> (String, SimpleTree)
+      goP _        (POption (I ver _loc) Nothing)  subtree = (showVersion ver, go subtree)
+      goP (Q _ pn) (POption _           (Just pp)) subtree = (showQPN (Q pp pn), go subtree)
+
+      -- Show flag or stanza choice
+      goFS :: Bool -> Tree QGoalReason -> (String, SimpleTree)
+      goFS val subtree = (show val, go subtree)
+
+      -- Show goal choice
+      goG :: Goal QPN -> Tree QGoalReason -> (String, SimpleTree)
+      goG (Goal var gr) subtree = (showVar var ++ " (" ++ shortGR gr ++ ")", go subtree)
+
+      -- Variation on 'showGR' that produces shorter strings
+      -- (Actually, QGoalReason records more info than necessary: we only need
+      -- to know the variable that introduced the goal, not the value assigned
+      -- to that variable)
+      shortGR :: QGoalReason -> String
+      shortGR UserGoal               = "user"
+      shortGR (PDependency (PI nm _)) = showQPN nm
+      shortGR (FDependency nm _)      = showQFN nm
+      shortGR (SDependency nm)        = showQSN nm
+
+      -- Show conflict set
+      goCS :: ConflictSet QPN -> String
+      goCS cs = "{" ++ (intercalate "," . L.map showVar . CS.toList $ cs) ++ "}"
+#endif
+
+-- | Replace all goal reasons with a dummy goal reason in the tree
+--
+-- This is useful for debugging (when experimenting with the impact of GRs)
+_removeGR :: Tree QGoalReason -> Tree QGoalReason
+_removeGR = trav go
+  where
+   go :: TreeF QGoalReason (Tree QGoalReason) -> TreeF QGoalReason (Tree QGoalReason)
+   go (PChoiceF qpn _     psq) = PChoiceF qpn dummy     psq
+   go (FChoiceF qfn _ a b psq) = FChoiceF qfn dummy a b psq
+   go (SChoiceF qsn _ a   psq) = SChoiceF qsn dummy a   psq
+   go (GoalChoiceF        psq) = GoalChoiceF            (goG psq)
+   go (DoneF rdm)              = DoneF rdm
+   go (FailF cs reason)        = FailF cs reason
+
+   goG :: PSQ (Goal QPN) (Tree QGoalReason) -> PSQ (Goal QPN) (Tree QGoalReason)
+   goG = PSQ.fromList
+       . L.map (\(Goal var _, subtree) -> (Goal var dummy, subtree))
+       . PSQ.toList
+
+   dummy :: QGoalReason
+   dummy = PDependency
+         $ PI (Q (PP DefaultNamespace Unqualified) (PackageName "$"))
+              (I (Version [1] []) InRepo)

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -142,6 +142,10 @@ Flag debug-conflict-sets
   description:  Add additional information to ConflictSets
   default:      False
 
+Flag debug-tracetree
+  description:  Compile in support for tracetree (used to debug the solver)
+  default:      False
+
 executable cabal
     main-is:        Main.hs
     ghc-options:    -Wall -fwarn-tabs
@@ -331,6 +335,10 @@ executable cabal
       cpp-options: -DDEBUG_CONFLICT_SETS
       build-depends: base >= 4.8
 
+    if flag(debug-tracetree)
+      cpp-options: -DDEBUG_TRACETREE
+      build-depends: tracetree >= 0.1 && < 0.2
+
     default-language: Haskell2010
 
 -- Small, fast running tests.
@@ -403,6 +411,10 @@ Test-Suite unit-tests
     cpp-options: -DDEBUG_CONFLICT_SETS
     build-depends: base >= 4.8
 
+  if flag(debug-tracetree)
+      cpp-options: -DDEBUG_TRACETREE
+      build-depends: tracetree >= 0.1 && < 0.2
+
   default-language: Haskell2010
 
 -- Slow solver tests
@@ -461,6 +473,10 @@ Test-Suite solver-quickcheck
   if flag(debug-conflict-sets)
     cpp-options: -DDEBUG_CONFLICT_SETS
     build-depends: base >= 4.8
+
+  if flag(debug-tracetree)
+      cpp-options: -DDEBUG_TRACETREE
+      build-depends: tracetree >= 0.1 && < 0.2
 
   default-language: Haskell2010
 


### PR DESCRIPTION
This PR consists of two commits:

* The first just contains a bunch of additional solver tests that I've used to write the (so far, draft) blog post about backjumping in the solver
* The second add a new `debug-tracetree` configure flag. If enabled, it adds a dependency on my [tracetree](http://hackage.haskell.org/package/tracetree) library, and has the solver spit out the various build trees in .JSON format. This is useful only for debugging, and we don't want to spit these out for very large search trees (i.e., most of the them), but it's nonetheless very helpful when we _are_ debugging the solver or explain how the solver works. I used this to visualize the search trees in the [previous blog post](http://www.well-typed.com/blog/2015/03/qualified-goals/) above the solver, but the `tracetree` library wasn't really mature enough to be released to Hackage. That is changed now, so having this available in the master branch (even if conditionally enabled by a configure flag) might be useful to other people working on the solver.

/cc @kosmikus , @grayjay . 