### PR TITLE
cabal upload: support package candidates

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -350,6 +350,7 @@ instance Semigroup SavedConfig where
                                        `mappend` savedGlobalInstallDirs b
 
       combinedSavedUploadFlags = UploadFlags {
+        uploadCandidate   = combine uploadCandidate,
         uploadCheck       = combine uploadCheck,
         uploadDoc         = combine uploadDoc,
         uploadUsername    = combine uploadUsername,

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1427,6 +1427,7 @@ instance Semigroup InstallFlags where
 -- ------------------------------------------------------------
 
 data UploadFlags = UploadFlags {
+    uploadCandidate   :: Flag Bool,
     uploadCheck       :: Flag Bool,
     uploadDoc         :: Flag Bool,
     uploadUsername    :: Flag Username,
@@ -1437,6 +1438,7 @@ data UploadFlags = UploadFlags {
 
 defaultUploadFlags :: UploadFlags
 defaultUploadFlags = UploadFlags {
+    uploadCandidate   = toFlag False,
     uploadCheck       = toFlag False,
     uploadDoc         = toFlag False,
     uploadUsername    = mempty,
@@ -1459,13 +1461,19 @@ uploadCommand = CommandUI {
     commandOptions      = \_ ->
       [optionVerbosity uploadVerbosity (\v flags -> flags { uploadVerbosity = v })
 
+      ,option ['C'] ["candidate"]
+        "Upload the package as candidate."
+        uploadCandidate (\v flags -> flags { uploadCandidate = v })
+        trueArg
+
       ,option ['c'] ["check"]
          "Do not upload, just do QA checks."
         uploadCheck (\v flags -> flags { uploadCheck = v })
         trueArg
 
       ,option ['d'] ["documentation"]
-        "Upload documentation instead of a source package. Cannot be used together with --check."
+        "Upload documentation instead of a source package. Cannot be used together with --check. \
+        \\nWhen combined with --candidate, uploads docuementation for a package candidate."
         uploadDoc (\v flags -> flags { uploadDoc = v })
         trueArg
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1438,7 +1438,7 @@ data UploadFlags = UploadFlags {
 
 defaultUploadFlags :: UploadFlags
 defaultUploadFlags = UploadFlags {
-    uploadCandidate   = toFlag False,
+    uploadCandidate   = toFlag True,
     uploadCheck       = toFlag False,
     uploadDoc         = toFlag False,
     uploadUsername    = mempty,
@@ -1461,10 +1461,10 @@ uploadCommand = CommandUI {
     commandOptions      = \_ ->
       [optionVerbosity uploadVerbosity (\v flags -> flags { uploadVerbosity = v })
 
-      ,option ['C'] ["candidate"]
-        "Upload the package as candidate."
+      ,option [] ["publish"]
+        "Publish the package instead of uploading it as a candidate."
         uploadCandidate (\v flags -> flags { uploadCandidate = v })
-        trueArg
+        falseArg
 
       ,option ['c'] ["check"]
          "Do not upload, just do QA checks."
@@ -1473,7 +1473,8 @@ uploadCommand = CommandUI {
 
       ,option ['d'] ["documentation"]
         "Upload documentation instead of a source package. Cannot be used together with --check. \
-        \\nWhen combined with --candidate, uploads docuementation for a package candidate."
+        \By default, this uploads documentation for a package candidate. To upload documentation for \
+        \a published package, combine with --publish."
         uploadDoc (\v flags -> flags { uploadDoc = v })
         trueArg
 

--- a/cabal-install/Distribution/Client/Upload.hs
+++ b/cabal-install/Distribution/Client/Upload.hs
@@ -60,7 +60,7 @@ upload verbosity repoCtxt mUsername mPassword candidate paths = do
                 else "upload"
         }
         packageURI pkgid = targetRepoURI {
-            uriPath = rootIfEmpty (uriPath targetRepoURI) FilePath.Posix.</> mconcat
+            uriPath = rootIfEmpty (uriPath targetRepoURI) FilePath.Posix.</> concat
               [ "package/", pkgid
               , if candidate then "/candidate" else ""
               ]
@@ -89,7 +89,7 @@ uploadDoc verbosity repoCtxt mUsername mPassword candidate path = do
     let targetRepoURI = remoteRepoURI targetRepo
         rootIfEmpty x = if null x then "/" else x
         uploadURI = targetRepoURI {
-            uriPath = rootIfEmpty (uriPath targetRepoURI) FilePath.Posix.</> mconcat
+            uriPath = rootIfEmpty (uriPath targetRepoURI) FilePath.Posix.</> concat
               [ "package/", pkgid
               , if candidate then "/candidate" else ""
               , "/docs"

--- a/cabal-install/Distribution/Client/Upload.hs
+++ b/cabal-install/Distribution/Client/Upload.hs
@@ -21,10 +21,10 @@ import Network.HTTP (Header(..), HeaderName(..))
 import System.IO        (hFlush, stdin, stdout, hGetEcho, hSetEcho)
 import System.Exit      (exitFailure)
 import Control.Exception (bracket)
-import System.FilePath  ((</>), takeExtension, takeFileName)
+import System.FilePath  ((</>), takeExtension, takeFileName, dropExtension)
 import qualified System.FilePath.Posix as FilePath.Posix ((</>))
 import System.Directory
-import Control.Monad (forM_, when)
+import Control.Monad (forM_, when, foldM)
 import Data.Maybe (catMaybes)
 import Data.Char (isSpace)
 
@@ -33,6 +33,13 @@ type Auth = Maybe (String, String)
 checkURI :: URI
 Just checkURI = parseURI $ "http://hackage.haskell.org/cgi-bin/"
                            ++ "hackage-scripts/check-pkg"
+
+stripExtensions :: [String] -> FilePath -> Maybe String
+stripExtensions exts path = foldM f path (reverse exts)
+ where
+  f p e
+    | takeExtension p == '.':e = Just (dropExtension p)
+    | otherwise = Nothing
 
 upload :: Verbosity -> RepoContext
        -> Maybe Username -> Maybe Password -> Bool -> [FilePath]
@@ -52,12 +59,22 @@ upload verbosity repoCtxt mUsername mPassword candidate paths = do
                 then "packages/candidates"
                 else "upload"
         }
+        packageURI pkgid = targetRepoURI {
+            uriPath = rootIfEmpty (uriPath targetRepoURI) FilePath.Posix.</> mconcat
+              [ "package/", pkgid
+              , if candidate then "/candidate" else ""
+              ]
+        }
     Username username <- maybe promptUsername return mUsername
     Password password <- maybe promptPassword return mPassword
     let auth = Just (username,password)
     forM_ paths $ \path -> do
       notice verbosity $ "Uploading " ++ path ++ "... "
-      handlePackage transport verbosity uploadURI auth path
+      case fmap takeFileName (stripExtensions ["tar", "gz"] path) of
+        Just pkgid -> handlePackage transport verbosity uploadURI (packageURI pkgid) auth candidate path
+        -- This case shouldn't really happen, since we check in Main that we only pass tar.gz files
+        -- to upload.
+        Nothing -> die $ "Not a tar.gz file: " ++ path
 
 uploadDoc :: Verbosity -> RepoContext
           -> Maybe Username -> Maybe Password -> Bool -> FilePath
@@ -153,23 +170,29 @@ check verbosity repoCtxt paths = do
     transport <- repoContextGetTransport repoCtxt
     forM_ paths $ \path -> do
       notice verbosity $ "Checking " ++ path ++ "... "
-      handlePackage transport verbosity checkURI Nothing path
+      handlePackage transport verbosity checkURI checkURI Nothing False path
 
-handlePackage :: HttpTransport -> Verbosity -> URI -> Auth
-              -> FilePath -> IO ()
-handlePackage transport verbosity uri auth path =
+handlePackage :: HttpTransport -> Verbosity -> URI -> URI -> Auth
+              -> Bool -> FilePath -> IO ()
+handlePackage transport verbosity uri packageUri auth candidate path =
   do resp <- postHttpFile transport verbosity uri path auth
      case resp of
-       (code,warnings) | code `elem` [200, 204] -> do
-          notice verbosity $ "Ok. " ++ formatWarnings (trim warnings)
+       (code,warnings) | code `elem` [200, 204] ->
+          notice verbosity $ okMessage ++
+            if null warnings then "" else "\n" ++ formatWarnings (trim warnings)
        (code,err)  -> do
           notice verbosity $ "Error uploading " ++ path ++ ": "
                           ++ "http code " ++ show code ++ "\n"
                           ++ err
           exitFailure
+ where
+  okMessage
+    | candidate =
+        "Package successfully uploaded as candidate. You can now preview the \
+        \result at " ++ show packageUri ++ ". To publish the candidate, use cabal upload --publish."
+    | otherwise = "Package successfully published. You can now view it at " ++ show packageUri ++ "."
 
 formatWarnings :: String -> String
-formatWarnings "" = ""
 formatWarnings x = "Warnings:\n" ++ (unlines . map ("- " ++) . lines) x
 
 -- Trim

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -1078,12 +1078,14 @@ uploadAction uploadFlags extraArgs globalFlags = do
                        repoContext
                        (flagToMaybe $ uploadUsername uploadFlags')
                        maybe_password
+                       (fromFlag (uploadCandidate uploadFlags'))
                        tarfile
     else do
       Upload.upload verbosity
                     repoContext
                     (flagToMaybe $ uploadUsername uploadFlags')
                     maybe_password
+                    (fromFlag (uploadCandidate uploadFlags'))
                     tarfiles
     where
     verbosity = fromFlag (uploadVerbosity uploadFlags)


### PR DESCRIPTION
This adds support for uploading package candidates by introducing a new
flag to `cabal upload`, --candidate. With this flag, `cabal upload` will 
upload all supplied tarballs as package candidates. If combined with `--documentation`, the
flag can also be used to upload documentation for a package candidate to
hackage.

The PR also changes `cabal upload` to display warnings that the server generates.
This is in particular useful with candidates. I'm not sure whether we should leave that behaviour
by default or only enable it if uploading candidates, because some of the warnings are not so useful,
like 

    Exposed modules use unallocated top-level names: Generics GHC

Currently, I enabled it for all package uploads, regardless of whether they are candidates or not.