### PR TITLE
upload: don't allow 'publish' in cabal.config

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -734,7 +734,7 @@ configFieldDescriptions src =
 
   ++ toSavedConfig liftUploadFlag
        (commandOptions uploadCommand ParseArgs)
-       ["verbose", "check", "documentation"] []
+       ["verbose", "check", "documentation", "publish"] []
 
   ++ toSavedConfig liftReportFlag
        (commandOptions reportCommand ParseArgs)


### PR DESCRIPTION
This hides the "publish" flag, so it is not possible to set publish from
cabal.config. Previously, cabal would successfully accept a line "publish: publish"
in cabal.config, but it wouldn't change anything. Now, setting this
field is no longer allowed.

We could have instead allowed setting a default behaviour for publishing packages
in the config file, but it would make the user interface more difficult, since
cabal upload would then have to support three options for setting IsCandidate:
use from config (default), publish (override config), candidate (override config).