### PR TITLE
Get linker flags correctly from GHC ≥ 7.8

### DIFF
--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -139,8 +139,10 @@ configureToolchain implInfo ghcProg ghcInfo =
     mbStripLocation = M.lookup "strip command" ghcInfo
 
     ccFlags        = getFlags "C compiler flags"
-    gccLinkerFlags = getFlags "Gcc Linker flags"
-    ldLinkerFlags  = getFlags "Ld Linker flags"
+    -- GHC 7.8 renamed "Gcc Linker flags" to "C compiler link flags"
+    -- and "Ld Linker flags" to "ld flags" (GHC #4862).
+    gccLinkerFlags = getFlags "Gcc Linker flags" ++ getFlags "C compiler link flags"
+    ldLinkerFlags  = getFlags "Ld Linker flags" ++ getFlags "ld flags"
 
     -- It appears that GHC 7.6 and earlier encode the tokenized flags as a
     -- [String] in these settings whereas later versions just encode the flags as


### PR DESCRIPTION
GHC 7.8 [renamed](https://ghc.haskell.org/trac/ghc/ticket/4862) `"Gcc Linker flags"` to `"C compiler link flags"` and `"Ld Linker flags"` to `"ld flags"`. Without this corresponding fix in Cabal, the `old-time` package fails to compile on Ubuntu yakkety amd64, where the system GCC now defaults to `-pie` and GHC has

```console
$ ghc --info | grep -i pie
 ,("C compiler flags","-fno-PIE -fno-stack-protector")
 ,("C compiler link flags","-no-pie")
 ,("ld flags","-no-pie")
```
