### PR TITLE
Resolve https://github.com/haskell/cabal/issues/3444

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -218,8 +218,8 @@ checkLibrary pkg lib =
             "Duplicate modules in library: "
          ++ commaSep (map display moduleDuplicates)
 
-  , check (null (libModules lib)) $
-      PackageBuildWarning $
+  , check (null (libModules lib ++ reexportedModules lib)) $
+      PackageDistSuspiciousWarn $
            "Library " ++ libName lib ++ " does not expose any modules"
 
     -- check use of required-signatures/exposed-signatures sections

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -218,6 +218,10 @@ checkLibrary pkg lib =
             "Duplicate modules in library: "
          ++ commaSep (map display moduleDuplicates)
 
+  , check (not (null (libModules lib))) $
+      PackageBuildWarning $
+           "Library " ++ libName lib ++ " does not expose any modules"
+
     -- check use of required-signatures/exposed-signatures sections
   , checkVersion [1,21] (not (null (requiredSignatures lib))) $
       PackageDistInexcusable $

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -218,7 +218,7 @@ checkLibrary pkg lib =
             "Duplicate modules in library: "
          ++ commaSep (map display moduleDuplicates)
 
-  , check (not (null (libModules lib))) $
+  , check (null (libModules lib)) $
       PackageBuildWarning $
            "Library " ++ libName lib ++ " does not expose any modules"
 


### PR DESCRIPTION
Resolution for issue https://github.com/haskell/cabal/issues/3444 - `cabal check` rejects packages which were ok previously

Checks for re-exported modules and uses a weaker warning type.