### PR TITLE
haddock/hscolour: fix highlighted source location

### DIFF
--- a/Cabal/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/Distribution/Simple/BuildPaths.hs
@@ -13,7 +13,7 @@
 
 module Distribution.Simple.BuildPaths (
     defaultDistPref, srcPref,
-    hscolourPref, haddockPref,
+    haddockDirName, hscolourPref, haddockPref,
     autogenModulesDir,
 
     autogenModuleName,
@@ -48,12 +48,19 @@ import System.FilePath ((</>), (<.>))
 srcPref :: FilePath -> FilePath
 srcPref distPref = distPref </> "src"
 
-hscolourPref :: FilePath -> PackageDescription -> FilePath
+hscolourPref :: HaddockTarget -> FilePath -> PackageDescription -> FilePath
 hscolourPref = haddockPref
 
-haddockPref :: FilePath -> PackageDescription -> FilePath
-haddockPref distPref pkg_descr
-    = distPref </> "doc" </> "html" </> display (packageName pkg_descr)
+-- | This is the name of the directory in which the generated haddocks
+-- should be stored. It does not include the @<dist>/doc/html@ prefix.
+haddockDirName :: HaddockTarget -> PackageDescription -> FilePath
+haddockDirName ForDevelopment = display . packageName
+haddockDirName ForHackage = (++ "-docs") . display . packageId
+
+-- | The directory to which generated haddock documentation should be written.
+haddockPref :: HaddockTarget -> FilePath -> PackageDescription -> FilePath
+haddockPref haddockTarget distPref pkg_descr
+    = distPref </> "doc" </> "html" </> haddockDirName haddockTarget pkg_descr
 
 -- |The directory in which we put auto-generated modules
 autogenModulesDir :: LocalBuildInfo -> ComponentLocalBuildInfo -> String

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -26,7 +26,8 @@ import Distribution.Simple.Utils
          , die, info, notice, warn, matchDirFileGlob )
 import Distribution.Simple.Compiler
          ( CompilerFlavor(..), compilerFlavor )
-import Distribution.Simple.Setup (CopyFlags(..), fromFlag)
+import Distribution.Simple.Setup
+         ( CopyFlags(..), fromFlag, HaddockTarget(ForDevelopment) )
 import Distribution.Simple.BuildTarget
 
 import qualified Distribution.Simple.GHC   as GHC
@@ -118,8 +119,8 @@ copyPackage verbosity pkg_descr lbi distPref copydest = do
 
   -- Install (package-global) Haddock files
   -- TODO: these should be done per-library
-  docExists <- doesDirectoryExist $ haddockPref distPref pkg_descr
-  info verbosity ("directory " ++ haddockPref distPref pkg_descr ++
+  docExists <- doesDirectoryExist $ haddockPref ForDevelopment distPref pkg_descr
+  info verbosity ("directory " ++ haddockPref ForDevelopment distPref pkg_descr ++
                   " does exist: " ++ show docExists)
 
   -- TODO: this is a bit questionable, Haddock files really should
@@ -127,13 +128,13 @@ copyPackage verbosity pkg_descr lbi distPref copydest = do
   when docExists $ do
       createDirectoryIfMissingVerbose verbosity True htmlPref
       installDirectoryContents verbosity
-          (haddockPref distPref pkg_descr) htmlPref
+          (haddockPref ForDevelopment distPref pkg_descr) htmlPref
       -- setPermissionsRecursive [Read] htmlPref
       -- The haddock interface file actually already got installed
       -- in the recursive copy, but now we install it where we actually
       -- want it to be (normally the same place). We could remove the
       -- copy in htmlPref first.
-      let haddockInterfaceFileSrc  = haddockPref distPref pkg_descr
+      let haddockInterfaceFileSrc  = haddockPref ForDevelopment distPref pkg_descr
                                                    </> haddockName pkg_descr
           haddockInterfaceFileDest = interfacePref </> haddockName pkg_descr
       -- We only generate the haddock interface file for libs, So if the

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -1026,7 +1026,7 @@ haddockFlagsFields = [ field
                            name  = fieldName field
                      , name `notElem` exclusions ]
   where
-    exclusions = ["verbose", "builddir"]
+    exclusions = ["verbose", "builddir", "for-hackage"]
 
 -- | Fields for the 'program-locations' section.
 withProgramsFields :: [FieldDescr [(String, FilePath)]]

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -46,7 +46,8 @@ import Distribution.Client.Setup
          , manpageCommand
          )
 import Distribution.Simple.Setup
-         ( HaddockFlags(..), haddockCommand, defaultHaddockFlags
+         ( HaddockTarget(..)
+         , HaddockFlags(..), haddockCommand, defaultHaddockFlags
          , HscolourFlags(..), hscolourCommand
          , ReplFlags(..)
          , CopyFlags(..), copyCommand
@@ -901,7 +902,7 @@ haddockAction haddockFlags extraArgs globalFlags = do
       setupScriptOptions = defaultSetupScriptOptions { useDistPref = distPref }
   setupWrapper verbosity setupScriptOptions Nothing
     haddockCommand (const haddockFlags') extraArgs
-  when (fromFlagOrDefault False $ haddockForHackage haddockFlags) $ do
+  when (haddockForHackage haddockFlags == Flag ForHackage) $ do
     pkg <- fmap LBI.localPkgDescr (getPersistBuildConfig distPref)
     let dest = distPref </> name <.> "tar.gz"
         name = display (packageId pkg) ++ "-docs"
@@ -1103,7 +1104,7 @@ uploadAction uploadFlags extraArgs globalFlags = do
         ++ "If you need to customise Haddock options, "
         ++ "run 'haddock --for-hackage' first "
         ++ "to generate a documentation tarball."
-      haddockAction (defaultHaddockFlags { haddockForHackage = Flag True })
+      haddockAction (defaultHaddockFlags { haddockForHackage = Flag ForHackage })
                     [] globalFlags
       distPref <- findSavedDistPref config NoFlag
       pkg <- fmap LBI.localPkgDescr (getPersistBuildConfig distPref)


### PR DESCRIPTION
When generating haddocks with the `--for-hackage` switch, the generated
haddocks are placed in a different directory than the normal ones, which
includes the package id instead of just the package name. When we ran
hscolour, we didn't respect this, so the highlighted source would not
be placed in the correct directory and thus was missing from the tarball.
This patch fixes that.

Fixes #3451