### PR TITLE
Implement 'scope' field for executables (#708)

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -224,6 +224,7 @@ library
     Distribution.Types.PackageId
     Distribution.Types.UnitId
     Distribution.Types.Executable
+    Distribution.Types.ExecutableScope
     Distribution.Types.Library
     Distribution.Types.ForeignLib
     Distribution.Types.ForeignLibType

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -49,6 +49,7 @@ import Distribution.Types.CondTree
 import Distribution.Types.Dependency
 import Distribution.Types.ExeDependency
 import Distribution.Types.PackageName
+import Distribution.Types.ExecutableScope
 import Distribution.Types.UnqualComponentName
 import Distribution.Simple.Utils hiding (findPackageDesc, notice)
 import Distribution.Version
@@ -308,6 +309,11 @@ checkExecutable pkg exe =
       PackageBuildImpossible $
            "On executable '" ++ display (exeName exe) ++ "' an 'autogen-module' is not "
         ++ "on 'other-modules'"
+
+  , checkSpecVersion pkg [1,25] (exeScope exe /= ExecutableScopeUnknown) $
+      PackageDistInexcusable $
+           "To use the 'scope' field the package needs to specify "
+        ++ "at least 'cabal-version: >= 1.25'."
 
   ]
   where

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -245,6 +245,9 @@ executableFieldDescrs =
   [ simpleField "main-is"
                            showFilePath       parseFilePathQ
                            modulePath         (\xs    exe -> exe{modulePath=xs})
+  , simpleField "scope"
+                           disp               parse
+                           exeScope           (\sc    exe -> exe{exeScope=sc})
   ]
   ++ map biToExe binfoFieldDescrs
   where biToExe = liftField buildInfo (\bi exe -> exe{buildInfo=bi})

--- a/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
@@ -242,6 +242,10 @@ executableFieldDescrs =
     , simpleField "main-is"
         showFilePath       parsecFilePath
         modulePath         (\xs    exe -> exe{modulePath=xs})
+
+    , simpleField "scope"
+        disp               parsec
+        exeScope           (\sc    exe -> exe{exeScope=sc})
     ]
     ++ map biToExe binfoFieldDescrs
   where

--- a/Cabal/Distribution/PackageDescription/PrettyPrint.hs
+++ b/Cabal/Distribution/PackageDescription/PrettyPrint.hs
@@ -145,14 +145,16 @@ ppCondExecutables exes                       =
     vcat [emptyLine $ (text "executable " <+> disp n)
               $+$ nest indentWith (ppCondTree condTree Nothing ppExe)| (n,condTree) <- exes]
   where
-    ppExe (Executable _ modulePath' buildInfo') Nothing =
+    ppExe (Executable _ modulePath' exeScope' buildInfo') Nothing =
         (if modulePath' == "" then mempty else text "main-is:" <+> text modulePath')
+            $+$ if exeScope' == mempty then mempty else text "scope:" <+> disp exeScope'
             $+$ ppFieldsFiltered binfoDefaults binfoFieldDescrs buildInfo'
             $+$  ppCustomFields (customFieldsBI buildInfo')
-    ppExe (Executable _ modulePath' buildInfo')
-            (Just (Executable _ modulePath2 buildInfo2)) =
+    ppExe (Executable _ modulePath' exeScope' buildInfo')
+            (Just (Executable _ modulePath2 exeScope2 buildInfo2)) =
             (if modulePath' == "" || modulePath' == modulePath2
                 then mempty else text "main-is:" <+> text modulePath')
+            $+$ if exeScope' == exeScope2 then mempty else text "scope:" <+> disp exeScope'
             $+$ ppDiffFields binfoFieldDescrs buildInfo' buildInfo2
             $+$ ppCustomFields (customFieldsBI buildInfo')
 

--- a/Cabal/Distribution/Parsec/Class.hs
+++ b/Cabal/Distribution/Parsec/Class.hs
@@ -60,6 +60,7 @@ import           Distribution.Types.PackageName
                  (PackageName, mkPackageName)
 import           Distribution.Types.UnqualComponentName
                  (UnqualComponentName, mkUnqualComponentName)
+import           Distribution.Types.ExecutableScope
 import           Distribution.Version
                  (Version, VersionRange (..), anyVersion, earlierVersion,
                  intersectVersionRanges, laterVersion, majorBoundVersion,
@@ -379,6 +380,14 @@ instance Parsec Mixin where
         P.spaces
         incl <- parsec
         return (Mixin mod_name incl)
+
+instance Parsec ExecutableScope where
+  parsec = do
+    name <- P.munch1 (\c -> isAlphaNum c || c == '-')
+    return $ case name of
+      "public"  -> ExecutablePublic
+      "private" -> ExecutablePrivate
+      _         -> ExecutableScopeUnknown
 
 -------------------------------------------------------------------------------
 -- Utilities

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -39,6 +39,7 @@ import Distribution.Types.MungedPackageId
 import Distribution.Types.MungedPackageName
 import Distribution.Types.UnqualComponentName
 import Distribution.Types.ComponentLocalBuildInfo
+import Distribution.Types.ExecutableScope
 
 import Distribution.Package
 import Distribution.Backpack
@@ -415,6 +416,7 @@ testSuiteExeV10AsExe test@TestSuite { testInterface = TestSuiteExeV10 _ mainFile
     Executable {
       exeName    = testName test,
       modulePath = mainFile,
+      exeScope   = ExecutablePublic,
       buildInfo  = testBuildInfo test
     }
 testSuiteExeV10AsExe TestSuite{} = error "testSuiteExeV10AsExe: wrong kind"
@@ -479,6 +481,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
     exe = Executable {
             exeName    = mkUnqualComponentName $ stubName test,
             modulePath = stubFilePath test,
+            exeScope   = ExecutablePublic,
             buildInfo  = (testBuildInfo test) {
                            hsSourceDirs       = [ testDir ],
                            targetBuildDepends = testLibDep
@@ -519,6 +522,7 @@ benchmarkExeV10asExe bm@Benchmark { benchmarkInterface = BenchmarkExeV10 _ f }
     exe = Executable {
             exeName    = benchmarkName bm,
             modulePath = f,
+            exeScope   = ExecutablePublic,
             buildInfo  = benchmarkBuildInfo bm
           }
     exeClbi = ExeComponentLocalBuildInfo {

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -750,10 +750,10 @@ configure (pkg_descr0', pbi) cfg = do
                          -> "  (fixed location)"
                   _      -> ""
 
-    dirinfo "Binaries"         (bindir dirs)     (bindir relative)
+    dirinfo "Executables"      (bindir dirs)     (bindir relative)
     dirinfo "Libraries"        (libdir dirs)     (libdir relative)
     dirinfo "Dynamic Libraries" (dynlibdir dirs) (dynlibdir relative)
-    dirinfo "Private binaries" (libexecdir dirs) (libexecdir relative)
+    dirinfo "Private executables" (libexecdir dirs) (libexecdir relative)
     dirinfo "Data files"       (datadir dirs)    (datadir relative)
     dirinfo "Documentation"    (docdir dirs)     (docdir relative)
     dirinfo "Configuration files" (sysconfdir dirs) (sysconfdir relative)

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1473,15 +1473,14 @@ componentCcGhcOptions verbosity lbi =
 -- |Install executables for GHC.
 installExe :: Verbosity
            -> LocalBuildInfo
-           -> InstallDirs FilePath -- ^Where to copy the files to
+           -> FilePath -- ^Where to copy the files to
            -> FilePath  -- ^Build location
            -> (FilePath, FilePath)  -- ^Executable (prefix,suffix)
            -> PackageDescription
            -> Executable
            -> IO ()
-installExe verbosity lbi installDirs buildPref
+installExe verbosity lbi binDir buildPref
   (progprefix, progsuffix) _pkg exe = do
-  let binDir = bindir installDirs
   createDirectoryIfMissingVerbose verbosity True binDir
   let exeName' = unUnqualComponentName $ exeName exe
       exeFileName = exeTargetName exe

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -747,15 +747,14 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
 
 installExe :: Verbosity
               -> LocalBuildInfo
-              -> InstallDirs FilePath -- ^Where to copy the files to
+              -> FilePath -- ^Where to copy the files to
               -> FilePath  -- ^Build location
               -> (FilePath, FilePath)  -- ^Executable (prefix,suffix)
               -> PackageDescription
               -> Executable
               -> IO ()
-installExe verbosity lbi installDirs buildPref
+installExe verbosity lbi binDir buildPref
            (progprefix, progsuffix) _pkg exe = do
-  let binDir = bindir installDirs
   createDirectoryIfMissingVerbose verbosity True binDir
   let exeName' = unUnqualComponentName $ exeName exe
       exeFileName = exeName'

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -35,6 +35,7 @@ import Distribution.Backpack.DescribeUnitId
 import Distribution.Types.ForeignLib
 import Distribution.Types.UnqualComponentName
 import Distribution.Types.ComponentLocalBuildInfo
+import Distribution.Types.ExecutableScope
 import Distribution.Package
 import qualified Distribution.ModuleName as ModuleName
 import Distribution.PackageDescription as PD hiding (Flag)
@@ -396,12 +397,14 @@ compToExe comp =
       Just Executable {
         exeName    = testName test,
         modulePath = f,
+        exeScope   = ExecutablePublic,
         buildInfo  = testBuildInfo test
       }
     CBench bench@Benchmark { benchmarkInterface = BenchmarkExeV10 _ f } ->
       Just Executable {
         exeName    = benchmarkName bench,
         modulePath = f,
+        exeScope   = ExecutablePublic,
         buildInfo  = benchmarkBuildInfo bench
       }
     CExe exe -> Just exe

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -38,6 +38,7 @@ module Distribution.Simple.InstallDirs (
         PathTemplateEnv,
         toPathTemplate,
         fromPathTemplate,
+        combinePathTemplate,
         substPathTemplate,
         initialPathTemplateEnv,
         platformTemplateEnv,

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -84,6 +84,7 @@ data InstallDirs dir = InstallDirs {
         dynlibdir    :: dir,
         flibdir      :: dir, -- ^ foreign libraries
         libexecdir   :: dir,
+        libexecsubdir:: dir,
         includedir   :: dir,
         datadir      :: dir,
         datasubdir   :: dir,
@@ -115,6 +116,7 @@ combineInstallDirs combine a b = InstallDirs {
     dynlibdir    = dynlibdir a  `combine` dynlibdir b,
     flibdir      = flibdir a    `combine` flibdir b,
     libexecdir   = libexecdir a `combine` libexecdir b,
+    libexecsubdir= libexecsubdir a `combine` libexecsubdir b,
     includedir   = includedir a `combine` includedir b,
     datadir      = datadir a    `combine` datadir b,
     datasubdir   = datasubdir a `combine` datasubdir b,
@@ -128,8 +130,10 @@ combineInstallDirs combine a b = InstallDirs {
 appendSubdirs :: (a -> a -> a) -> InstallDirs a -> InstallDirs a
 appendSubdirs append dirs = dirs {
     libdir     = libdir dirs `append` libsubdir dirs,
+    libexecdir = libexecdir dirs `append` libexecsubdir dirs,
     datadir    = datadir dirs `append` datasubdir dirs,
     libsubdir  = error "internal error InstallDirs.libsubdir",
+    libexecsubdir = error "internal error InstallDirs.libexecsubdir",
     datasubdir = error "internal error InstallDirs.datasubdir"
   }
 
@@ -199,6 +203,7 @@ defaultInstallDirs' False comp userInstall _hasLibs = do
            LHC    -> "$compiler"
            UHC    -> "$pkgid"
            _other -> "$abi",
+      libexecsubdir= "$abi" </> "$pkgid",
       flibdir      = "$libdir",
       libexecdir   = case buildOS of
         Windows   -> "$prefix" </> "$libname"
@@ -243,6 +248,7 @@ substituteInstallDirTemplates env dirs = dirs'
       dynlibdir  = subst dynlibdir  [prefixVar, bindirVar, libdirVar],
       flibdir    = subst flibdir    [prefixVar, bindirVar, libdirVar],
       libexecdir = subst libexecdir prefixBinLibVars,
+      libexecsubdir = subst libexecsubdir [],
       includedir = subst includedir prefixBinLibVars,
       datadir    = subst datadir    prefixBinLibVars,
       datasubdir = subst datasubdir [],

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -669,14 +669,13 @@ mkGHCiLibName lib = getHSLibraryName lib <.> "o"
 -- |Install executables for GHC.
 installExe :: Verbosity
            -> LocalBuildInfo
-           -> InstallDirs FilePath -- ^Where to copy the files to
+           -> FilePath -- ^Where to copy the files to
            -> FilePath  -- ^Build location
            -> (FilePath, FilePath)  -- ^Executable (prefix,suffix)
            -> PackageDescription
            -> Executable
            -> IO ()
-installExe verbosity lbi installDirs buildPref (progprefix, progsuffix) _pkg exe = do
-  let binDir = bindir installDirs
+installExe verbosity lbi binDir buildPref (progprefix, progsuffix) _pkg exe = do
   createDirectoryIfMissingVerbose verbosity True binDir
   let exeFileName = unUnqualComponentName (exeName exe) <.> exeExtension
       fixedExeBaseName = progprefix ++ unUnqualComponentName (exeName exe) ++ progsuffix

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -71,6 +71,7 @@ module Distribution.Simple.Setup (
   fromFlagOrDefault,
   flagToMaybe,
   flagToList,
+  maybeToFlag,
   BooleanFlag(..),
   boolOpt, boolOpt', trueArg, falseArg,
   optionVerbosity, optionNumJobs, readPToMaybe ) where
@@ -184,6 +185,10 @@ allFlags :: [Flag Bool] -> Flag Bool
 allFlags flags = if all (\f -> fromFlagOrDefault False f) flags
                  then Flag True
                  else NoFlag
+
+maybeToFlag :: Maybe a -> Flag a
+maybeToFlag Nothing  = NoFlag
+maybeToFlag (Just x) = Flag x
 
 -- | Types that represent boolean flags.
 class BooleanFlag a where

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -926,6 +926,11 @@ installDirsOptions =
       libexecdir (\v flags -> flags { libexecdir = v })
       installDirArg
 
+  , option "" ["libexecsubdir"]
+      "subdirectory of libexecdir in which private executables are installed"
+      libexecsubdir (\v flags -> flags { libexecsubdir = v })
+      installDirArg
+
   , option "" ["datadir"]
       "installation directory for read-only data"
       datadir (\v flags -> flags { datadir = v })

--- a/Cabal/Distribution/Types/Executable.hs
+++ b/Cabal/Distribution/Types/Executable.hs
@@ -13,11 +13,13 @@ import Distribution.Compat.Prelude
 
 import Distribution.Types.BuildInfo
 import Distribution.Types.UnqualComponentName
+import Distribution.Types.ExecutableScope
 import Distribution.ModuleName
 
 data Executable = Executable {
         exeName    :: UnqualComponentName,
         modulePath :: FilePath,
+        exeScope   :: ExecutableScope,
         buildInfo  :: BuildInfo
     }
     deriving (Generic, Show, Read, Eq, Typeable, Data)
@@ -32,6 +34,7 @@ instance Semigroup Executable where
   a <> b = Executable{
     exeName    = combine' exeName,
     modulePath = combine modulePath,
+    exeScope   = combine exeScope,
     buildInfo  = combine buildInfo
   }
     where combine field = field a `mappend` field b

--- a/Cabal/Distribution/Types/ExecutableScope.hs
+++ b/Cabal/Distribution/Types/ExecutableScope.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Distribution.Types.ExecutableScope (
+    ExecutableScope(..),
+) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+import Distribution.Text
+import qualified Distribution.Compat.ReadP as Parse
+
+import Text.PrettyPrint (text)
+
+data ExecutableScope = ExecutablePublic
+                     | ExecutablePrivate
+    deriving (Generic, Show, Read, Eq, Typeable, Data)
+
+instance Text ExecutableScope where
+  disp ExecutablePublic  = text "public"
+  disp ExecutablePrivate = text "private"
+
+  parse = Parse.choice
+    [ Parse.string "public"  >> return ExecutablePublic
+    , Parse.string "private" >> return ExecutablePrivate
+    ]
+
+instance Binary ExecutableScope
+
+instance Monoid ExecutableScope where
+    mempty = ExecutablePublic
+    mappend = (<>)
+
+instance Semigroup ExecutableScope where
+    x <> y | x /= y    = error "Ambiguous executable scope"
+           | otherwise = x

--- a/Cabal/Distribution/Types/ExecutableScope.hs
+++ b/Cabal/Distribution/Types/ExecutableScope.hs
@@ -13,13 +13,15 @@ import qualified Distribution.Compat.ReadP as Parse
 
 import Text.PrettyPrint (text)
 
-data ExecutableScope = ExecutablePublic
+data ExecutableScope = ExecutableScopeUnknown
+                     | ExecutablePublic
                      | ExecutablePrivate
     deriving (Generic, Show, Read, Eq, Typeable, Data)
 
 instance Text ExecutableScope where
   disp ExecutablePublic  = text "public"
   disp ExecutablePrivate = text "private"
+  disp ExecutableScopeUnknown = text "unknown"
 
   parse = Parse.choice
     [ Parse.string "public"  >> return ExecutablePublic
@@ -29,9 +31,11 @@ instance Text ExecutableScope where
 instance Binary ExecutableScope
 
 instance Monoid ExecutableScope where
-    mempty = ExecutablePublic
+    mempty = ExecutableScopeUnknown
     mappend = (<>)
 
 instance Semigroup ExecutableScope where
-    x <> y | x /= y    = error "Ambiguous executable scope"
-           | otherwise = x
+    ExecutableScopeUnknown <> x = x
+    x <> ExecutableScopeUnknown = x
+    x <> y | x == y             = x
+           | otherwise          = error "Ambiguous executable scope"

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -656,6 +656,14 @@ path options:
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
+.. option:: --libexecsubdir=dir
+
+    A subdirectory of *libexecdir* in which private executables are installed.
+
+    *dir* may contain the following path variables: ``$pkgid``,
+    ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
+    ``$abitag``
+
 .. option:: --datasubdir=dir
 
     A subdirectory of *datadir* in which data files are actually

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1419,9 +1419,12 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                    platform
                    defaultInstallDirs) {
 
-                  InstallDirs.libsubdir  = "", -- absoluteInstallDirs sets these as
-                  InstallDirs.datasubdir = ""  -- 'undefined' but we have to use
-                }                              -- them as "Setup.hs configure" args
+                  -- absoluteInstallDirs sets these as 'undefined' but we have
+                  -- to use them as "Setup.hs configure" args
+                  InstallDirs.libsubdir  = "",
+                  InstallDirs.libexecsubdir  = "",
+                  InstallDirs.datasubdir = ""
+                }
 
               | otherwise
               -- use special simplified install dirs
@@ -1553,9 +1556,12 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                platform
                defaultInstallDirs) {
 
-              InstallDirs.libsubdir  = "", -- absoluteInstallDirs sets these as
-              InstallDirs.datasubdir = ""  -- 'undefined' but we have to use
-            }                              -- them as "Setup.hs configure" args
+              -- absoluteInstallDirs sets these as 'undefined' but we have to
+              -- use them as "Setup.hs configure" args
+              InstallDirs.libsubdir  = "",
+              InstallDirs.libexecsubdir = "",
+              InstallDirs.datasubdir = ""
+            }
 
           | otherwise
           -- use special simplified install dirs
@@ -2916,6 +2922,7 @@ storePackageInstallDirs StoreDirLayout{storePackageDirectory}
     dynlibdir    = libdir
     flibdir      = libdir
     libexecdir   = prefix </> "libexec"
+    libexecsubdir= ""
     includedir   = libdir </> "include"
     datadir      = prefix </> "share"
     datasubdir   = ""

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -89,13 +89,13 @@ import Distribution.Simple.Setup
          , TestFlags(..), BenchmarkFlags(..)
          , SDistFlags(..), HaddockFlags(..)
          , readPackageDbList, showPackageDbList
-         , Flag(..), toFlag, flagToMaybe, flagToList
+         , Flag(..), toFlag, flagToMaybe, flagToList, maybeToFlag
          , BooleanFlag(..), optionVerbosity
          , boolOpt, boolOpt', trueArg, falseArg
          , optionNumJobs )
 import Distribution.Simple.InstallDirs
-         ( PathTemplate, InstallDirs(dynlibdir, sysconfdir)
-         , toPathTemplate, fromPathTemplate )
+         ( PathTemplate, InstallDirs(..)
+         , toPathTemplate, fromPathTemplate, combinePathTemplate )
 import Distribution.Version
          ( Version, mkVersion, nullVersion, anyVersion, thisVersion )
 import Distribution.Package
@@ -427,8 +427,13 @@ filterConfigureFlags flags cabalLibVersion
       -- Cabal < 1.25 doesn't support --deterministic
       configDeterministic = mempty
       }
-    configInstallDirs_1_25_0 = (configInstallDirs flags) { dynlibdir = NoFlag }
-
+    configInstallDirs_1_25_0 = let dirs = configInstallDirs flags in
+        dirs { dynlibdir = NoFlag
+             , libexecsubdir = NoFlag
+             , libexecdir = maybeToFlag $
+                 combinePathTemplate <$> flagToMaybe (libexecdir dirs)
+                                     <*> flagToMaybe (libexecsubdir dirs)
+             }
     -- Cabal < 1.23 doesn't know about '--profiling-detail'.
     -- Cabal < 1.23 has a hacked up version of 'enable-profiling'
     -- which we shouldn't use.

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -549,7 +549,7 @@ instance Arbitrary a => Arbitrary (InstallDirs a) where
         <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  4
         <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  8
         <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary -- 12
-        <*> arbitrary <*> arbitrary <*> arbitrary               -- 15
+        <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary -- 16
 
 instance Arbitrary PackageDB where
     arbitrary = oneof [ pure GlobalPackageDB


### PR DESCRIPTION
I use executables installed into '$libexecdir' with great effect in ghc-mod and cabal-helper but so far I've been using an ugly hack in Setup.hs so I figured why not get this upstreamed since it's relatively straightforward.

Now in #708 the request is for a boolean field "Is-Helper-Executable" but I figured having support for specifying an arbitrary path while using the `PathTemplate` variables is a lot more flexible and just seems like the consistent thing to do since there aren't any other such boolean fields anywhere in the PackageDescription apart from say 'buildable'.

I've added a check to make sure packages that end up on hackage don't have absolute paths in 'install-dir' which seems like a reasonable restriction.

I haven't tested the bits in PrettyPrint yet and I'd appreciate feedback on what is a sensible thing to do there since I just copied what is being done for 'main-is' but I'm not sure if that makes any sense.
