### PR TITLE
Exit with non-0 code when build fails

### DIFF
--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -8,7 +8,8 @@ module Distribution.Client.CmdBuild (
 
 import Distribution.Client.ProjectOrchestration
          ( PreBuildHooks(..), runProjectPreBuildPhase, selectTargets
-         , ProjectBuildContext(..), runProjectBuildPhase,  printPlan )
+         , ProjectBuildContext(..), runProjectBuildPhase
+         , printPlan, reportBuildFailures )
 import Distribution.Client.ProjectConfig
          ( BuildTimeSettings(..) )
 import Distribution.Client.ProjectPlanning
@@ -53,11 +54,10 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
     printPlan verbosity buildCtx
 
     unless (buildSettingDryRun buildSettings) $ do
-      _plan <- runProjectBuildPhase
-                 verbosity
-                 buildCtx
-      --TODO: [required eventually] report on build failures in residual plan
-      return ()
+      plan <- runProjectBuildPhase
+                verbosity
+                buildCtx
+      reportBuildFailures plan
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
 

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -8,7 +8,8 @@ module Distribution.Client.CmdRepl (
 
 import Distribution.Client.ProjectOrchestration
          ( PreBuildHooks(..), runProjectPreBuildPhase, selectTargets
-         , ProjectBuildContext(..), runProjectBuildPhase,  printPlan )
+         , ProjectBuildContext(..), runProjectBuildPhase
+         , printPlan, reportBuildFailures )
 import Distribution.Client.ProjectConfig
          ( BuildTimeSettings(..) )
 import Distribution.Client.ProjectPlanning
@@ -57,11 +58,10 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags)
     printPlan verbosity buildCtx
 
     unless (buildSettingDryRun buildSettings) $ do
-      _plan <- runProjectBuildPhase
-                 verbosity
-                 buildCtx
-      --TODO: [required eventually] report on build failures in residual plan
-      return ()
+      plan <- runProjectBuildPhase
+                verbosity
+                buildCtx
+      reportBuildFailures plan
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
 

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -50,6 +50,9 @@ module Distribution.Client.ProjectOrchestration (
 
     -- * Build phase: now do it.
     runProjectBuildPhase,
+
+    -- * Post build actions
+    reportBuildFailures,
   ) where
 
 import           Distribution.Client.ProjectConfig
@@ -85,6 +88,7 @@ import qualified Data.Map as Map
 import           Data.Map (Map)
 import           Data.List
 import           Data.Either
+import           System.Exit (exitFailure)
 
 
 -- | Command line configuration flags. These are used to extend\/override the
@@ -474,4 +478,18 @@ linearizeInstallPlan =
                      (InstallPlan.processing [pkg] plan)
     --TODO: [code cleanup] This is a bit of a hack, pretending that each package is installed
     -- could we use InstallPlan.topologicalOrder?
+
+
+reportBuildFailures :: ElaboratedInstallPlan -> IO ()
+reportBuildFailures plan =
+
+  case [ (pkg, reason)
+       | InstallPlan.Failed pkg reason <- InstallPlan.toList plan ] of
+    []      -> return ()
+    _failed -> exitFailure
+    --TODO: [required eventually] see the old printBuildFailures for an example
+    -- of the kind of things we could report, but we want to handle the special
+    -- case of the current package better, since if you do "cabal build" then
+    -- you don't need a lot of context to explain where the ghc error message
+    -- comes from, and indeed extra noise would just be annoying.
 


### PR DESCRIPTION
Fixes issue #3495

This also adds a stub where we can add more detailed failure reporting, but this starts with nothing more than the exit code.

Unlike the existing "cabal install" failure reporting, we don't need or want "build" failure reporting to be quite so noisy in common cases like the one local package failing to build, since ghc reports its own errors and there's enough context to see what's going on.

This is an alternative to #3501 which uses the existing "cabal install" build reporting, which is ok for install but too noisy by default for "cabal build". We can add extra reporting later.