### PR TITLE
init: Only add exposed-modules which are in an hs-source-dir

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -29,7 +29,7 @@ import System.Directory
   ( getCurrentDirectory, doesDirectoryExist, doesFileExist, copyFile
   , getDirectoryContents, createDirectoryIfMissing )
 import System.FilePath
-  ( (</>), (<.>), takeBaseName )
+  ( (</>), (<.>), takeBaseName, equalFilePath )
 import Data.Time
   ( getCurrentTime, utcToLocalTime, toGregorian, localDay, getCurrentTimeZone )
 
@@ -381,19 +381,26 @@ guessSourceDir flags = do
              then Just "src"
              else Nothing
 
+-- | Check whether a potential source file is located in one of the
+--   source directories.
+isSourceFile :: Maybe [FilePath] -> SourceFileEntry -> Bool
+isSourceFile Nothing        sf = isSourceFile (Just ["."]) sf
+isSourceFile (Just srcDirs) sf = any (equalFilePath (relativeSourcePath sf)) srcDirs
+
 -- | Get the list of exposed modules and extra tools needed to build them.
 getModulesBuildToolsAndDeps :: InstalledPackageIndex -> InitFlags -> IO InitFlags
 getModulesBuildToolsAndDeps pkgIx flags = do
   dir <- maybe getCurrentDirectory return . flagToMaybe $ packageDir flags
 
-  -- TODO: really should use guessed source roots.
   sourceFiles <- scanForModules dir
 
+  let sourceFiles' = filter (isSourceFile (sourceDirs flags)) sourceFiles
+
   Just mods <-      return (exposedModules flags)
-           ?>> (return . Just . map moduleName $ sourceFiles)
+           ?>> (return . Just . map moduleName $ sourceFiles')
 
   tools <-     return (buildTools flags)
-           ?>> (return . Just . neededBuildPrograms $ sourceFiles)
+           ?>> (return . Just . neededBuildPrograms $ sourceFiles')
 
   deps <-      return (dependencies flags)
            ?>> Just <$> importsToDeps flags
@@ -402,13 +409,13 @@ getModulesBuildToolsAndDeps pkgIx flags = do
                              . filter (`notElem` mods)  -- don't consider modules from
                                                         -- this package itself
                              . concatMap imports
-                             $ sourceFiles
+                             $ sourceFiles'
                            )
                         )
                         pkgIx
 
   exts <-     return (otherExts flags)
-          ?>> (return . Just . nub . concatMap extensions $ sourceFiles)
+          ?>> (return . Just . nub . concatMap extensions $ sourceFiles')
 
   return $ flags { exposedModules = Just mods
                  , buildTools     = tools


### PR DESCRIPTION
Only those modules found in a directory in hs-source-dirs will be added
to exposed-modules.  If a directory 'src' is found it will be used as
hs-source-dirs (note in this case any .hs files in the root directory
will NOT be added to exposed-modules).  If any directories are specified
on the command line with --source-dir, they will be used.  If no
directories are specified on the command line and there is no directory
named src, the root directory will be used.

Fixes #3484.