### PR TITLE
Add a goal order parameter to the dependency solver

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Dependency.hs
+++ b/cabal-install/Distribution/Solver/Modular/Dependency.hs
@@ -35,6 +35,7 @@ module Distribution.Solver.Modular.Dependency (
   , GoalReason(..)
   , QGoalReason
   , ResetVar(..)
+  , goalToVar
   , goalVarToConflictSet
   , varToConflictSet
   , goalReasonToVars
@@ -360,6 +361,9 @@ instance ResetVar Dep where
 
 instance ResetVar Var where
   resetVar = const
+
+goalToVar :: Goal a -> Var a
+goalToVar (Goal v _) = v
 
 -- | Compute a singleton conflict set from a goal, containing just
 -- the goal variable.

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -109,9 +109,9 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
                        traceTree "heuristics.json" id .
                        P.deferWeakFlagChoices .
                        P.deferSetupChoices .
-                       P.preferBaseGoalChoice .
-                       P.preferLinked
-    preferencesPhase = P.preferPackagePreferences userPrefs
+                       P.preferBaseGoalChoice
+    preferencesPhase = P.preferLinked .
+                       P.preferPackagePreferences userPrefs
     validationPhase  = traceTree "validated.json" id .
                        P.enforceManualFlags . -- can only be done after user constraints
                        P.enforcePackageConstraints userConstraints .

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -19,6 +19,7 @@ import Distribution.Solver.Types.PackagePreferences
 import Distribution.Solver.Types.PkgConfigDb (PkgConfigDb)
 import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.Settings
+import Distribution.Solver.Types.Variable
 
 import Distribution.Solver.Modular.Assignment
 import Distribution.Solver.Modular.Builder
@@ -56,7 +57,8 @@ data SolverConfig = SolverConfig {
   shadowPkgs            :: ShadowPkgs,
   strongFlags           :: StrongFlags,
   maxBackjumps          :: Maybe Int,
-  enableBackjumping     :: EnableBackjumping
+  enableBackjumping     :: EnableBackjumping,
+  goalOrder             :: Maybe (Variable QPN -> Variable QPN -> Ordering)
 }
 
 -- | Run all solver phases.
@@ -103,13 +105,20 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
   where
     explorePhase     = backjumpAndExplore (enableBackjumping sc)
     detectCycles     = traceTree "cycles.json" id . detectCyclesPhase
-    heuristicsPhase  = (if asBool (preferEasyGoalChoices sc)
-                         then P.preferEasyGoalChoices -- also leaves just one choice
-                         else P.firstGoal) . -- after doing goal-choice heuristics, commit to the first choice (saves space)
-                       traceTree "heuristics.json" id .
-                       P.deferWeakFlagChoices .
-                       P.deferSetupChoices .
-                       P.preferBaseGoalChoice
+    heuristicsPhase  =
+      let heuristicsTree = traceTree "heuristics.json" id
+      in case goalOrder sc of
+           Nothing -> (if asBool (preferEasyGoalChoices sc)
+                        then P.preferEasyGoalChoices -- also leaves just one choice
+                        else P.firstGoal) . -- after doing goal-choice heuristics,
+                                            -- commit to the first choice (saves space)
+                      heuristicsTree .
+                      P.deferWeakFlagChoices .
+                      P.deferSetupChoices .
+                      P.preferBaseGoalChoice
+           Just order -> P.firstGoal .
+                         heuristicsTree .
+                         P.sortGoals order
     preferencesPhase = P.preferLinked .
                        P.preferPackagePreferences userPrefs
     validationPhase  = traceTree "validated.json" id .

--- a/cabal-install/Distribution/Solver/Types/Variable.hs
+++ b/cabal-install/Distribution/Solver/Types/Variable.hs
@@ -1,0 +1,14 @@
+module Distribution.Solver.Types.Variable where
+
+import Distribution.Solver.Types.OptionalStanza
+
+import Distribution.PackageDescription (FlagName)
+
+-- | Variables used by the dependency solver. This type is similar to the
+-- internal 'Var' type, except that flags and stanzas are associated with
+-- package names instead of package instances.
+data Variable qpn =
+    PackageVar qpn
+  | FlagVar qpn FlagName
+  | StanzaVar qpn OptionalStanza
+  deriving Eq

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -281,6 +281,7 @@ executable cabal
         Distribution.Solver.Types.SolverId
         Distribution.Solver.Types.SolverPackage
         Distribution.Solver.Types.SourcePackage
+        Distribution.Solver.Types.Variable
         Distribution.Solver.Modular
         Distribution.Solver.Modular.Assignment
         Distribution.Solver.Modular.Builder

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -102,7 +102,7 @@ solve enableBj reorder indep solver targets (TestDb db) =
                   -- The backjump limit prevents individual tests from using
                   -- too much time and memory.
                   (Just defaultMaxBackjumps)
-                  indep reorder enableBj []
+                  indep reorder enableBj Nothing []
 
       failure :: String -> Failure
       failure msg
@@ -223,12 +223,12 @@ arbitraryComponentDep :: TestDb -> Gen (ComponentDep [ExampleDependency])
 arbitraryComponentDep db = do
   comp <- arbitrary
   deps <- case comp of
-            ComponentSetup -> smallListOf (arbitraryExDep db Setup)
-            _              -> boundedListOf 5 (arbitraryExDep db NonSetup)
+            ComponentSetup -> smallListOf (arbitraryExDep db SetupDep)
+            _              -> boundedListOf 5 (arbitraryExDep db NonSetupDep)
   return (comp, deps)
 
 -- | Location of an 'ExampleDependency'. It determines which values are valid.
-data ExDepLocation = Setup | NonSetup
+data ExDepLocation = SetupDep | NonSetupDep
 
 arbitraryExDep :: TestDb -> ExDepLocation -> Gen ExampleDependency
 arbitraryExDep db@(TestDb pkgs) level =
@@ -247,13 +247,13 @@ arbitraryExDep db@(TestDb pkgs) level =
           ]
   in oneof $
       case level of
-        NonSetup -> flag : other
-        Setup -> other
+        NonSetupDep -> flag : other
+        SetupDep -> other
 
 arbitraryDeps :: TestDb -> Gen Dependencies
 arbitraryDeps db = frequency
     [ (1, return NotBuildable)
-    , (20, Buildable <$> smallListOf (arbitraryExDep db NonSetup))
+    , (20, Buildable <$> smallListOf (arbitraryExDep db NonSetupDep))
     ]
 
 arbitraryFlagName :: Gen String

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -135,7 +135,7 @@ tests = [
     , testGroup "Independent goals" [
           runTest $ indep $ mkTest db16 "indepGoals1" ["A", "B"] (SolverSuccess [("A", 1), ("B", 1), ("C", 1), ("D", 1), ("D", 2), ("E", 1)])
         , runTest $ testIndepGoals2 "indepGoals2"
-        , runTest $ indep $ mkTest db19 "indepGoals3" ["D", "E", "F"] anySolverFailure -- The target order is important.
+        , runTest $ testIndepGoals3 "indepGoals3"
         , runTest $ testIndepGoals4 "indepGoals4"
         , runTest $ indep $ mkTest db23 "indepGoals5" ["X", "Y"] (SolverSuccess [("A", 1), ("A", 2), ("B", 1), ("C", 1), ("C", 2), ("X", 1), ("Y", 1)])
         , runTest $ indep $ mkTest db24 "indepGoals6" ["X", "Y"] (SolverSuccess [("A", 1), ("A", 2), ("B", 1), ("B", 2), ("X", 1), ("Y", 1)])
@@ -702,16 +702,35 @@ db18 = [
 -- >   \ | \ / | /
 -- >    \|  V  |/
 -- >     D  F  E
-db19 :: ExampleDb
-db19 = [
-    Right $ exAv "A" 1 [ExAny "C"]
-  , Right $ exAv "B" 1 [ExAny "C"]
-  , Right $ exAv "C" 1 []
-  , Right $ exAv "C" 2 []
-  , Right $ exAv "D" 1 [ExAny "A", ExFix "C" 1]
-  , Right $ exAv "E" 1 [ExAny "B", ExFix "C" 2]
-  , Right $ exAv "F" 1 [ExAny "A", ExAny "B"]
-  ]
+testIndepGoals3 :: String -> SolverTest
+testIndepGoals3 name =
+    goalOrder goals $ indep $
+    mkTest db name ["D", "E", "F"] anySolverFailure
+  where
+    db :: ExampleDb
+    db = [
+        Right $ exAv "A" 1 [ExAny "C"]
+      , Right $ exAv "B" 1 [ExAny "C"]
+      , Right $ exAv "C" 1 []
+      , Right $ exAv "C" 2 []
+      , Right $ exAv "D" 1 [ExAny "A", ExFix "C" 1]
+      , Right $ exAv "E" 1 [ExAny "B", ExFix "C" 2]
+      , Right $ exAv "F" 1 [ExAny "A", ExAny "B"]
+      ]
+
+    goals :: [ExampleVar]
+    goals = [
+        P (Indep 0) "D"
+      , P (Indep 0) "C"
+      , P (Indep 0) "A"
+      , P (Indep 1) "E"
+      , P (Indep 1) "C"
+      , P (Indep 1) "B"
+      , P (Indep 2) "F"
+      , P (Indep 2) "B"
+      , P (Indep 2) "C"
+      , P (Indep 2) "A"
+      ]
 
 -- | This test checks that the solver correctly backjumps when dependencies
 -- of linked packages are not linked. It is an example where the conflict set

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -172,6 +172,7 @@ data SolverTest = SolverTest {
   , testTargets        :: [String]
   , testResult         :: SolverResult
   , testIndepGoals     :: IndependentGoals
+  , testGoalOrder      :: Maybe [ExampleVar]
   , testSoftConstraints :: [ExPreference]
   , testDb             :: ExampleDb
   , testSupportedExts  :: Maybe [Extension]
@@ -246,6 +247,7 @@ mkTestExtLangPC exts langs pkgConfigDb db label targets result = SolverTest {
   , testTargets        = targets
   , testResult         = result
   , testIndepGoals     = IndependentGoals False
+  , testGoalOrder      = Nothing
   , testSoftConstraints = []
   , testDb             = db
   , testSupportedExts  = exts
@@ -259,7 +261,7 @@ runTest SolverTest{..} = askOption $ \(OptionShowSolverLog showSolverLog) ->
       let (_msgs, result) = exResolve testDb testSupportedExts
                             testSupportedLangs testPkgConfigDb testTargets
                             Modular Nothing testIndepGoals (ReorderGoals False)
-                            (EnableBackjumping True) testSoftConstraints
+                            (EnableBackjumping True) testGoalOrder testSoftConstraints
       when showSolverLog $ mapM_ putStrLn _msgs
       case result of
         Left  err  -> assertBool ("Unexpected error:\n" ++ err) (check testResult err)


### PR DESCRIPTION
This PR implements #3489.  It isn't ready to be merged yet, because I need to finish updating the tests that are affected by goal order.

I wanted to make it available for review before finishing it, because it probably overlaps with #3502.  The second commit exposes the solver's goal qualification types.  I moved types like `Q`, `QPN`, and `PP` into a new module, `D.Solver.Types.PackagePath`, and renamed some of them.  /cc @dcoutts