### PR TITLE
Add differenceVersionRanges

### DIFF
--- a/Cabal/Distribution/Version.hs
+++ b/Cabal/Distribution/Version.hs
@@ -53,6 +53,7 @@ module Distribution.Version (
   laterVersion, earlierVersion,
   orLaterVersion, orEarlierVersion,
   unionVersionRanges, intersectVersionRanges,
+  differenceVersionRanges,
   invertVersionRange,
   withinVersion,
   betweenVersionsInclusive,
@@ -239,6 +240,15 @@ unionVersionRanges = UnionVersionRanges
 --
 intersectVersionRanges :: VersionRange -> VersionRange -> VersionRange
 intersectVersionRanges = IntersectVersionRanges
+
+-- | The difference of two version ranges
+--
+-- >   withinRange v' (differenceVersionRanges vr1 vr2)
+-- > = withinRange v' vr1 && not (withinRange v' vr2)
+--
+differenceVersionRanges :: VersionRange -> VersionRange -> VersionRange
+differenceVersionRanges vr1 vr2 =
+    intersectVersionRanges vr1 (invertVersionRange vr2)
 
 -- | The inverse of a version range
 --

--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -41,6 +41,7 @@ versionTests =
   , property prop_orEarlierVersion
   , property prop_unionVersionRanges
   , property prop_intersectVersionRanges
+  , property prop_differenceVersionRanges
   , property prop_invertVersionRange
   , property prop_withinVersion
   , property prop_foldVersionRange
@@ -195,6 +196,11 @@ prop_intersectVersionRanges :: VersionRange -> VersionRange -> Version -> Bool
 prop_intersectVersionRanges vr1 vr2 v' =
      withinRange v' (intersectVersionRanges vr1 vr2)
   == (withinRange v' vr1 && withinRange v' vr2)
+
+prop_differenceVersionRanges :: VersionRange -> VersionRange -> Version -> Bool
+prop_differenceVersionRanges vr1 vr2 v' =
+     withinRange v' (differenceVersionRanges vr1 vr2)
+  == (withinRange v' vr1 && not (withinRange v' vr2))
 
 prop_invertVersionRange :: VersionRange -> Version -> Bool
 prop_invertVersionRange vr v' =


### PR DESCRIPTION
I recently needed this functionality and thought it should be in `Cabal` itself.

I think the name is somewhat inelegant but consistent with `intersectVersionRanges`, `unionVersionRanges` and the analogous functions in `containers`' `Data.Set`.