### PR TITLE
Add test build directory to LD_LIBRARY_PATH when -executable-dynamic

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -203,6 +203,7 @@ extra-source-files:
   tests/PackageTests/TestSuiteTests/LibV09/Lib.hs
   tests/PackageTests/TestSuiteTests/LibV09/LibV09.cabal
   tests/PackageTests/TestSuiteTests/LibV09/tests/Deadlock.hs
+  tests/PackageTests/TestSuiteTests/LibV09/tests/PassesTrivially.hs
   tests/PackageTests/Tests.hs
   tests/PackageTests/UniqueIPID/P1/M.hs
   tests/PackageTests/UniqueIPID/P1/my.cabal

--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -54,6 +54,10 @@ module Distribution.Simple (
   ) where
 
 -- local
+import qualified Distribution.InstalledPackageInfo as Installed
+import qualified Distribution.PackageDescription as PD
+import qualified Distribution.Simple.PackageIndex as PackageIndex
+
 import Distribution.Simple.Compiler hiding (Flag)
 import Distribution.Simple.UserHooks
 import Distribution.Package
@@ -88,16 +92,20 @@ import Distribution.Text
 
 -- Base
 import System.Environment (getArgs, getProgName)
-import System.Directory   (removeFile, doesFileExist
+import System.Directory   (removeFile, doesFileExist, getTemporaryDirectory
                           ,doesDirectoryExist, removeDirectoryRecursive)
 import System.Exit                          (exitWith,ExitCode(..))
-import System.FilePath                      (searchPathSeparator)
+import System.FilePath                      (searchPathSeparator, (</>))
+import System.IO                            (hPutStrLn, hClose)
 import Distribution.Compat.Environment      (getEnvironment)
+import Distribution.Compat.Exception        (catchExit, catchIO)
 import Distribution.Compat.GetShortPathName (getShortPathName)
 
-import Control.Monad   (when)
+import Control.Monad   (when, filterM)
 import Data.Foldable   (traverse_)
-import Data.List       (unionBy)
+import Data.List       (unionBy, inits)
+import Data.Maybe      (isNothing)
+
 
 -- | A simple implementation of @main@ for a Cabal setup script.
 -- It reads the package description file using IO, and performs the
@@ -521,6 +529,165 @@ simpleUserHooks =
       checkForeignDeps pkg_descr lbi (lessVerbose verbosity)
       where
         verbosity = fromFlag (configVerbosity flags)
+
+-- Try to build a test C program which includes every header and links every
+-- lib. If that fails, try to narrow it down by preprocessing (only) and linking
+-- with individual headers and libs.  If none is the obvious culprit then give a
+-- generic error message.
+-- TODO: produce a log file from the compiler errors, if any.
+checkForeignDeps :: PackageDescription -> LocalBuildInfo -> Verbosity -> IO ()
+checkForeignDeps pkg lbi verbosity = do
+  ifBuildsWith allHeaders (commonCcArgs ++ makeLdArgs allLibs) -- I'm feeling
+                                                               -- lucky
+           (return ())
+           (do missingLibs <- findMissingLibs
+               missingHdr  <- findOffendingHdr
+               explainErrors missingHdr missingLibs)
+      where
+        allHeaders = collectField PD.includes
+        allLibs    = collectField PD.extraLibs
+
+        ifBuildsWith headers args success failure = do
+            ok <- builds (makeProgram headers) args
+            if ok then success else failure
+
+        findOffendingHdr =
+            ifBuildsWith allHeaders ccArgs
+                         (return Nothing)
+                         (go . tail . inits $ allHeaders)
+            where
+              go [] = return Nothing       -- cannot happen
+              go (hdrs:hdrsInits) =
+                    -- Try just preprocessing first
+                    ifBuildsWith hdrs cppArgs
+                      -- If that works, try compiling too
+                      (ifBuildsWith hdrs ccArgs
+                        (go hdrsInits)
+                        (return . Just . Right . last $ hdrs))
+                      (return . Just . Left . last $ hdrs)
+
+              cppArgs = "-E":commonCppArgs -- preprocess only
+              ccArgs  = "-c":commonCcArgs  -- don't try to link
+
+        findMissingLibs = ifBuildsWith [] (makeLdArgs allLibs)
+                                       (return [])
+                                       (filterM (fmap not . libExists) allLibs)
+
+        libExists lib = builds (makeProgram []) (makeLdArgs [lib])
+
+        commonCppArgs = platformDefines lbi
+                     -- TODO: This is a massive hack, to work around the
+                     -- fact that the test performed here should be
+                     -- PER-component (c.f. the "I'm Feeling Lucky"; we
+                     -- should NOT be glomming everything together.)
+                     ++ [ "-I" ++ buildDir lbi </> "autogen" ]
+                     ++ [ "-I" ++ dir | dir <- collectField PD.includeDirs ]
+                     ++ ["-I."]
+                     ++ collectField PD.cppOptions
+                     ++ collectField PD.ccOptions
+                     ++ [ "-I" ++ dir
+                        | dep <- deps
+                        , dir <- Installed.includeDirs dep ]
+                     ++ [ opt
+                        | dep <- deps
+                        , opt <- Installed.ccOptions dep ]
+
+        commonCcArgs  = commonCppArgs
+                     ++ collectField PD.ccOptions
+                     ++ [ opt
+                        | dep <- deps
+                        , opt <- Installed.ccOptions dep ]
+
+        commonLdArgs  = [ "-L" ++ dir | dir <- collectField PD.extraLibDirs ]
+                     ++ collectField PD.ldOptions
+                     ++ [ "-L" ++ dir
+                        | dep <- deps
+                        , dir <- Installed.libraryDirs dep ]
+                     --TODO: do we also need dependent packages' ld options?
+        makeLdArgs libs = [ "-l"++lib | lib <- libs ] ++ commonLdArgs
+
+        makeProgram hdrs = unlines $
+                           [ "#include \""  ++ hdr ++ "\"" | hdr <- hdrs ] ++
+                           ["int main(int argc, char** argv) { return 0; }"]
+
+        collectField f = concatMap f allBi
+        allBi = allBuildInfo pkg
+        deps = PackageIndex.topologicalOrder (installedPkgs lbi)
+
+        builds program args = do
+            tempDir <- getTemporaryDirectory
+            withTempFile tempDir ".c" $ \cName cHnd ->
+              withTempFile tempDir "" $ \oNname oHnd -> do
+                hPutStrLn cHnd program
+                hClose cHnd
+                hClose oHnd
+                _ <- rawSystemProgramStdoutConf verbosity
+                  gccProgram (withPrograms lbi) (cName:"-o":oNname:args)
+                return True
+           `catchIO`   (\_ -> return False)
+           `catchExit` (\_ -> return False)
+
+        explainErrors Nothing [] = return () -- should be impossible!
+        explainErrors _ _
+           | isNothing . lookupProgram gccProgram . withPrograms $ lbi
+
+                              = die $ unlines $
+              [ "No working gcc",
+                  "This package depends on foreign library but we cannot "
+               ++ "find a working C compiler. If you have it in a "
+               ++ "non-standard location you can use the --with-gcc "
+               ++ "flag to specify it." ]
+
+        explainErrors hdr libs = die $ unlines $
+             [ if plural
+                 then "Missing dependencies on foreign libraries:"
+                 else "Missing dependency on a foreign library:"
+             | missing ]
+          ++ case hdr of
+               Just (Left h) -> ["* Missing (or bad) header file: " ++ h ]
+               _             -> []
+          ++ case libs of
+               []    -> []
+               [lib] -> ["* Missing C library: " ++ lib]
+               _     -> ["* Missing C libraries: " ++ intercalate ", " libs]
+          ++ [if plural then messagePlural else messageSingular | missing]
+          ++ case hdr of
+               Just (Left  _) -> [ headerCppMessage ]
+               Just (Right h) -> [ (if missing then "* " else "")
+                                   ++ "Bad header file: " ++ h
+                                 , headerCcMessage ]
+               _              -> []
+
+          where
+            plural  = length libs >= 2
+            -- Is there something missing? (as opposed to broken)
+            missing = not (null libs)
+                   || case hdr of Just (Left _) -> True; _ -> False
+
+        messageSingular =
+             "This problem can usually be solved by installing the system "
+          ++ "package that provides this library (you may need the "
+          ++ "\"-dev\" version). If the library is already installed "
+          ++ "but in a non-standard location then you can use the flags "
+          ++ "--extra-include-dirs= and --extra-lib-dirs= to specify "
+          ++ "where it is."
+        messagePlural =
+             "This problem can usually be solved by installing the system "
+          ++ "packages that provide these libraries (you may need the "
+          ++ "\"-dev\" versions). If the libraries are already installed "
+          ++ "but in a non-standard location then you can use the flags "
+          ++ "--extra-include-dirs= and --extra-lib-dirs= to specify "
+          ++ "where they are."
+        headerCppMessage =
+             "If the header file does exist, it may contain errors that "
+          ++ "are caught by the C compiler at the preprocessing stage. "
+          ++ "In this case you can re-run configure with the verbosity "
+          ++ "flag -v3 to see the error messages."
+        headerCcMessage =
+             "The header file contains a compile error. "
+          ++ "You can re-run configure with the verbosity flag "
+          ++ "-v3 to see the error messages from the C compiler."
+
 
 -- | Basic autoconf 'UserHooks':
 --

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -99,8 +99,15 @@ runTest pkg_descr lbi flags suite = do
                                                    lbi
                                                    (LBI.CTestName
                                                       (PD.testName suite))
+                                      (_, _, _, _, _, _, exeClbi) =
+                                          testSuiteLibV09AsLibAndExe
+                                              pkg_descr suite clbi lbi
+                                              distPref pwd
+                                  -- Get the dependencies of the stub
+                                  -- executable. They should include the test
+                                  -- library itself (#2039).
                                   paths <- LBI.depLibraryPaths
-                                             True False lbi clbi
+                                             True False lbi exeClbi
                                   return (addLibraryPath os paths shellEnv)
                                 else return shellEnv
                 createProcessWithEnv verbosity cmd opts Nothing (Just shellEnv')

--- a/Cabal/tests/PackageTests/TestSuiteTests/LibV09/LibV09.cabal
+++ b/Cabal/tests/PackageTests/TestSuiteTests/LibV09/LibV09.cabal
@@ -14,6 +14,12 @@ library
   exposed-modules: Lib
   build-depends: base, Cabal
 
+test-suite LibV09-PassesTrivially
+  type: detailed-0.9
+  hs-source-dirs: tests
+  test-module: PassesTrivially
+  build-depends: base, Cabal
+
 test-suite LibV09-Deadlock
   type: detailed-0.9
   hs-source-dirs: tests

--- a/Cabal/tests/PackageTests/TestSuiteTests/LibV09/tests/PassesTrivially.hs
+++ b/Cabal/tests/PackageTests/TestSuiteTests/LibV09/tests/PassesTrivially.hs
@@ -1,0 +1,7 @@
+module PassesTrivially where
+
+import Distribution.TestSuite
+
+tests :: IO [Test]
+tests = return []
+

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -51,12 +51,20 @@ tests config = do
   testWhen (hasCabalForGhc config)
    . tcs "TestSuiteTests/LibV09" "Build" $ cabal_build ["--enable-tests"]
 
+  -- Test for #2039: `-enable-tests --enable-executable-dynamic` should work.
+  testWhen (hasCabalForGhc config && hasSharedLibraries config)
+   . tcs "TestSuiteTests/LibV09" "ExecutableDynamic" $ do
+        cabal "configure" ["--enable-tests", "--enable-executable-dynamic"]
+        cabal "build" ["LibV09-PassesTrivially"]
+        cabal "test"  ["LibV09-PassesTrivially"]
+
   -- Tests for #2489, stdio deadlock
   testWhen (hasCabalForGhc config)
    . mapTestTrees (localOption (mkTimeout $ 10 ^ (8 :: Int)))
    . tcs "TestSuiteTests/LibV09" "Deadlock" $ do
-      cabal_build ["--enable-tests"]
-      shouldFail $ cabal "test" []
+      cabal "configure" ["--enable-tests"]
+      cabal "build" ["LibV09-Deadlock"]
+      shouldFail $ cabal "test" ["LibV09-Deadlock"]
 
   ---------------------------------------------------------------------
   -- * Inline tests

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -160,7 +160,7 @@ cabal_dependencies() {
 
 cabal_build() {
     ./dist/setup/setup configure \
-        --user --ghc-option=-Werror --enable-tests --enable-benchmarks \
+        --user --ghc-option=-Werror --enable-tests --enable-benchmarks --enable-shared \
         -v2 # -v2 provides useful information for debugging
 
     # Build all libraries and executables (including tests/benchmarks)


### PR DESCRIPTION
Since commit 18fcd9c1aaeddd9d10a25e44c0e986c9889f06a7, Cabal builds the stub executable and the test library for a LibV09 (detailed-0.9) test in different directories.

This is good, but when running the test with --enable-executable-dynamic, we now have to add the test build directory to (DY)LD_LIBRARY_PATH, so that the linker can find the test library when running the stub executable (see #2289 for details).

This fixes #2039 (read: no parse). The GHC panic mentioned in that ticket must have been resolved earlier already, perhaps also by commit 18fcd9c1aaeddd9d10a25e44c0e986c9889f06a7.

CC @ezyang, @christiaanb 
