### PR TITLE
Solver: Fix space leak in 'addlinking' (issue #2899)

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Builder.hs
+++ b/cabal-install/Distribution/Solver/Modular/Builder.hs
@@ -102,17 +102,18 @@ data BuildType =
   | Instance QPN I PInfo QGoalReason  -- ^ build a tree for a concrete instance
   deriving Show
 
-build :: BuildState -> Tree QGoalReason
-build = ana go
+build :: BuildState -> Tree' QGoalReason
+build = ana' go
   where
-    go :: BuildState -> TreeF QGoalReason BuildState
+    go :: BuildState -> TreeF QGoalReason (() -> BuildState)
 
     -- If we have a choice between many goals, we just record the choice in
     -- the tree. We select each open goal in turn, and before we descend, remove
     -- it from the queue of open goals.
     go bs@(BS { rdeps = rds, open = gs, next = Goals })
       | P.null gs = DoneF rds
-      | otherwise = GoalChoiceF $ P.mapKeys close
+      | otherwise = GoalChoiceF $ addDummyArgs
+                                $ P.mapKeys close
                                 $ P.mapWithKey (\ g (_sc, gs') -> bs { next = OneGoal g, open = gs' })
                                 $ P.splits gs
 
@@ -135,7 +136,7 @@ build = ana go
       -- messages though.
       case M.lookup pn idx of
         Nothing  -> PChoiceF qpn gr (P.fromList [])
-        Just pis -> PChoiceF qpn gr (P.fromList (L.map (\ (i, info) ->
+        Just pis -> PChoiceF qpn gr $ addDummyArgs (P.fromList (L.map (\ (i, info) ->
                                                            (POption i Nothing, bs { next = Instance qpn i info gr }))
                                                          (M.toList pis)))
           -- TODO: data structure conversion is rather ugly here
@@ -145,7 +146,7 @@ build = ana go
     --
     -- TODO: Should we include the flag default in the tree?
     go bs@(BS { next = OneGoal (OpenGoal (Flagged qfn@(FN (PI qpn _) _) (FInfo b m w) t f) gr) }) =
-      FChoiceF qfn gr weak m (P.fromList (reorder b
+      FChoiceF qfn gr weak m $ addDummyArgs (P.fromList (reorder b
         [(True,  (extendOpen qpn (L.map (flip OpenGoal (FDependency qfn True )) t) bs) { next = Goals }),
          (False, (extendOpen qpn (L.map (flip OpenGoal (FDependency qfn False)) f) bs) { next = Goals })]))
       where
@@ -160,7 +161,7 @@ build = ana go
     -- (try enabling the stanza if possible by moving the True branch first).
 
     go bs@(BS { next = OneGoal (OpenGoal (Stanza qsn@(SN (PI qpn _) _) t) gr) }) =
-      SChoiceF qsn gr trivial (P.fromList
+      SChoiceF qsn gr trivial $ addDummyArgs $ (P.fromList
         [(False,                                                             bs  { next = Goals }),
          (True,  (extendOpen qpn (L.map (flip OpenGoal (SDependency qsn)) t) bs) { next = Goals })])
       where
@@ -174,9 +175,14 @@ build = ana go
       go ((scopedExtendOpen qpn i (PDependency (PI qpn i)) fdeps fdefs bs)
              { next = Goals })
 
+    addDummyArgs :: P.PSQ k v -> P.PSQ k (() -> v)
+    addDummyArgs = P.map const
+
 -- | Interface to the tree builder. Just takes an index and a list of package names,
--- and computes the initial state and then the tree from there.
-buildTree :: Index -> IndependentGoals -> [PN] -> Tree QGoalReason
+-- and computes the initial state and then the tree from there. All subtrees
+-- take dummy arguments, so that they can be copied in later traversals without
+-- sharing data.
+buildTree :: Index -> IndependentGoals -> [PN] -> Tree' QGoalReason
 buildTree idx (IndependentGoals ind) igs =
     build BS {
         index = idx

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Distribution.Solver.Modular.Linking (
     addLinking
   , validateLinking
@@ -42,7 +43,7 @@ import Distribution.Solver.Types.ComponentDeps (Component)
 type RelatedGoals = Map (PN, I) [PackagePath]
 type Linker       = Reader RelatedGoals
 
--- | Introduce link nodes into tree tree
+-- | Introduce link nodes into the tree
 --
 -- Linking is a traversal of the solver tree that adapts package choice nodes
 -- and adds the option to link wherever appropriate: Package goals are called
@@ -57,10 +58,10 @@ type Linker       = Reader RelatedGoals
 -- package instance. Whenever we make a choice, we extend the map. Whenever we
 -- find a choice, we look into the map in order to find out what link options we
 -- have to add.
-addLinking :: Tree QGoalReason -> Tree QGoalReason
+addLinking :: Tree a -> Tree a
 addLinking = (`runReader` M.empty) .  cata go
   where
-    go :: TreeF QGoalReason (Linker (Tree QGoalReason)) -> Linker (Tree QGoalReason)
+    go :: TreeF a (Linker (Tree a)) -> Linker (Tree a)
 
     -- The only nodes of interest are package nodes
     go (PChoiceF qpn gr cs) = do
@@ -73,15 +74,15 @@ addLinking = (`runReader` M.empty) .  cata go
 
     -- Recurse underneath package choices. Here we just need to make sure
     -- that we record the package choice so that it is available below
-    goP :: QPN -> POption -> Linker (Tree QGoalReason) -> Linker (Tree QGoalReason)
+    goP :: QPN -> POption -> Linker (Tree a) -> Linker (Tree a)
     goP (Q pp pn) (POption i Nothing) = local (M.insertWith (++) (pn, i) [pp])
     goP _ _ = alreadyLinked
 
-linkChoices :: RelatedGoals -> QPN -> (POption, Tree QGoalReason) -> [(POption, Tree QGoalReason)]
+linkChoices :: forall a. RelatedGoals -> QPN -> (POption, a) -> [(POption, a)]
 linkChoices related (Q _pp pn) (POption i Nothing, subtree) =
     map aux (M.findWithDefault [] (pn, i) related)
   where
-    aux :: PackagePath -> (POption, Tree QGoalReason)
+    aux :: PackagePath -> (POption, a)
     aux pp = (POption i (Just pp), subtree)
 linkChoices _ _ (POption _ (Just _), _) =
     alreadyLinked
@@ -129,10 +130,10 @@ type Validate = Reader ValidateState
 -- * Linked dependencies,
 -- * Equal flag assignments
 -- * Equal stanza assignments
-validateLinking :: Index -> Tree QGoalReason -> Tree QGoalReason
+validateLinking :: Index -> Tree a -> Tree a
 validateLinking index = (`runReader` initVS) . cata go
   where
-    go :: TreeF QGoalReason (Validate (Tree QGoalReason)) -> Validate (Tree QGoalReason)
+    go :: TreeF a (Validate (Tree a)) -> Validate (Tree a)
 
     go (PChoiceF qpn gr cs) =
       PChoice qpn gr     <$> T.sequence (P.mapWithKey (goP qpn) cs)
@@ -147,7 +148,7 @@ validateLinking index = (`runReader` initVS) . cata go
     go (FailF conflictSet failReason) = return $ Fail conflictSet failReason
 
     -- Package choices
-    goP :: QPN -> POption -> Validate (Tree QGoalReason) -> Validate (Tree QGoalReason)
+    goP :: QPN -> POption -> Validate (Tree a) -> Validate (Tree a)
     goP qpn@(Q _pp pn) opt@(POption i _) r = do
       vs <- ask
       let PInfo deps _ _ = vsIndex vs ! pn ! i
@@ -157,7 +158,7 @@ validateLinking index = (`runReader` initVS) . cata go
         Right vs'       -> local (const vs') r
 
     -- Flag choices
-    goF :: QFN -> Bool -> Validate (Tree QGoalReason) -> Validate (Tree QGoalReason)
+    goF :: QFN -> Bool -> Validate (Tree a) -> Validate (Tree a)
     goF qfn b r = do
       vs <- ask
       case execUpdateState (pickFlag qfn b) vs of
@@ -165,7 +166,7 @@ validateLinking index = (`runReader` initVS) . cata go
         Right vs'       -> local (const vs') r
 
     -- Stanza choices (much the same as flag choices)
-    goS :: QSN -> Bool -> Validate (Tree QGoalReason) -> Validate (Tree QGoalReason)
+    goS :: QSN -> Bool -> Validate (Tree a) -> Validate (Tree a)
     goS qsn b r = do
       vs <- ask
       case execUpdateState (pickStanza qsn b) vs of

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -66,17 +66,17 @@ addLinking = (`runReader` M.empty) .  cata go
     -- The only nodes of interest are package nodes
     go (PChoiceF qpn gr cs) = do
       env <- ask
-      cs' <- T.sequence $ P.mapWithKey (goP qpn) cs
-      let newCs = concatMap (linkChoices env qpn) (P.toList cs')
-      return $ PChoice qpn gr (cs' `P.union` P.fromList newCs)
+      let linkedCs = concatMap (linkChoices env qpn) (P.toList cs)
+          allCs = cs `P.union` P.fromList linkedCs
+      allCs' <- T.sequence $ P.mapWithKey (goP qpn) allCs
+      return $ PChoice qpn gr allCs'
     go _otherwise =
       innM _otherwise
 
     -- Recurse underneath package choices. Here we just need to make sure
     -- that we record the package choice so that it is available below
     goP :: QPN -> POption -> Linker (Tree a) -> Linker (Tree a)
-    goP (Q pp pn) (POption i Nothing) = local (M.insertWith (++) (pn, i) [pp])
-    goP _ _ = alreadyLinked
+    goP (Q pp pn) (POption i _) = local (M.insertWith (++) (pn, i) [pp])
 
 linkChoices :: forall a. RelatedGoals -> QPN -> (POption, a) -> [(POption, a)]
 linkChoices related (Q _pp pn) (POption i Nothing, subtree) =


### PR DESCRIPTION
I took a pass at fixing #2899.  I created a tree type with subtrees that have dummy arguments, so that `addLinking` can copy the subtrees without causing them to share data.  I'm not sure if this is the best approach, though.  Another option would be to add the linked nodes during the "build" phase.

This isn't ready to be merged yet.  I at least need to document and rename the tree type.

/cc @kosmikus @edsko 