### PR TITLE
Correctly pass setup options to sdist invocation.

### DIFF
--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -1197,7 +1197,7 @@ buildInplaceUnpackedPackage verbosity
           --TODO: [required eventually] this doesn't track file
           --non-existence, so we could fail to rebuild if someone
           --adds a new file which changes behavior.
-          allSrcFiles <- allPackageSourceFiles verbosity srcdir
+          allSrcFiles <- allPackageSourceFiles verbosity scriptOptions srcdir
 
           updatePackageBuildFileMonitor packageFileMonitor srcdir timestamp
                                         pkg buildStatus

--- a/cabal-install/Distribution/Client/Sandbox/Timestamp.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Timestamp.hs
@@ -38,6 +38,7 @@ import Distribution.Client.SrcDist (allPackageSourceFiles)
 import Distribution.Client.Sandbox.Index
   (ListIgnoredBuildTreeRefs (ListIgnored), RefTypesToList(OnlyLinks)
   ,listBuildTreeRefs)
+import Distribution.Client.SetupWrapper
 
 import Distribution.Compat.Exception                 (catchIO)
 import Distribution.Compat.Time               (ModTime, getCurTime,
@@ -227,7 +228,9 @@ withActionOnCompilerTimestamps f sandboxDir compId platform act = do
 isDepModified :: Verbosity -> ModTime -> AddSourceTimestamp -> IO Bool
 isDepModified verbosity now (packageDir, timestamp) = do
   debug verbosity ("Checking whether the dependency is modified: " ++ packageDir)
-  depSources <- allPackageSourceFiles verbosity packageDir
+  -- TODO: we should properly plumb the correct options through
+  -- instead of using defaultSetupScriptOptions
+  depSources <- allPackageSourceFiles verbosity defaultSetupScriptOptions packageDir
   go depSources
 
   where


### PR DESCRIPTION
This fixes a bug I noticed when converting cabal-install to use convenience libraries.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>