### PR TITLE
Support QuickCheck-2.9

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -396,7 +396,7 @@ test-suite unit-tests
     tasty-quickcheck,
     tagged,
     pretty,
-    QuickCheck >= 2.7 && < 2.9,
+    QuickCheck >= 2.7 && < 2.10,
     Cabal
   ghc-options: -Wall
   default-language: Haskell98

--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans
                 -fno-warn-incomplete-patterns
                 -fno-warn-deprecations
@@ -12,8 +13,11 @@ import Text.PrettyPrint as Disp (text, render, parens, hcat
 
 import Test.Tasty
 import Test.Tasty.QuickCheck
-import Test.QuickCheck.Utils
 import qualified Test.Laws as Laws
+
+#if !MIN_VERSION_QuickCheck(2,9,0)
+import Test.QuickCheck.Utils
+#endif
 
 import Control.Monad (liftM, liftM2)
 import Data.Maybe (isJust, fromJust)
@@ -100,6 +104,7 @@ versionTests =
 --     -- , property prop_parse_disp5
 --   ]
 
+#if !MIN_VERSION_QuickCheck(2,9,0)
 instance Arbitrary Version where
   arbitrary = do
     branch <- smallListOf1 $
@@ -115,6 +120,7 @@ instance Arbitrary Version where
     [ Version branch' [] | branch' <- shrink branch, not (null branch') ]
   shrink (Version branch _tags) =
     [ Version branch [] ]
+#endif
 
 instance Arbitrary VersionRange where
   arbitrary = sized verRangeExp

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -67,6 +67,7 @@ instance Arbitrary ShortToken where
 arbitraryShortToken :: Gen String
 arbitraryShortToken = getShortToken <$> arbitrary
 
+#if !MIN_VERSION_QuickCheck(2,9,0)
 instance Arbitrary Version where
   arbitrary = do
     branch <- shortListOf1 4 $
@@ -81,6 +82,7 @@ instance Arbitrary Version where
     [ Version branch' [] | branch' <- shrink branch, not (null branch') ]
   shrink (Version branch _tags) =
     [ Version branch [] ]
+#endif
 
 instance Arbitrary VersionRange where
   arbitrary = canonicaliseVersionRange <$> sized verRangeExp


### PR DESCRIPTION
This should be applied to `1.24` as well. I guess.