### PR TITLE
Use 'Progress' type to print the solver log in unit tests

### DIFF
--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -21,6 +21,7 @@ module UnitTests.Distribution.Solver.Modular.DSL (
   , withSetupDeps
   , withTest
   , withTests
+  , runProgress
   ) where
 
 -- base
@@ -416,13 +417,10 @@ exResolve :: ExampleDb
           -> EnableBackjumping
           -> Maybe [ExampleVar]
           -> [ExPreference]
-          -> ([String], Either String CI.InstallPlan.SolverInstallPlan)
+          -> Progress String String CI.InstallPlan.SolverInstallPlan
 exResolve db exts langs pkgConfigDb targets solver mbj indepGoals reorder
           enableBj vars prefs
-    = runProgress $ resolveDependencies C.buildPlatform
-                        compiler pkgConfigDb
-                        solver
-                        params
+    = resolveDependencies C.buildPlatform compiler pkgConfigDb solver params
   where
     defaultCompiler = C.unknownCompilerInfo C.buildCompilerId C.NoAbiTag
     compiler = defaultCompiler { C.compilerInfoExtensions = exts
@@ -491,8 +489,6 @@ extractInstallPlan = catMaybes . map confPkg . CI.InstallPlan.toList
 -------------------------------------------------------------------------------}
 
 -- | Run Progress computation
---
--- Like `runLog`, but for the more general `Progress` type.
 runProgress :: Progress step e a -> ([step], Either e a)
 runProgress = go
   where

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -95,7 +95,7 @@ solve :: EnableBackjumping -> ReorderGoals -> IndependentGoals
       -> Solver -> [PN] -> TestDb -> Result
 solve enableBj reorder indep solver targets (TestDb db) =
   let (lg, result) =
-        exResolve db Nothing Nothing
+        runProgress $ exResolve db Nothing Nothing
                   (pkgConfigDbFromList [])
                   (map unPN targets)
                   solver


### PR DESCRIPTION
This change avoids holding the whole log in memory.