### PR TITLE
Avoid`fromFlag`

### DIFF
--- a/Cabal/Distribution/Make.hs
+++ b/Cabal/Distribution/Make.hs
@@ -128,7 +128,7 @@ defaultMainHelper args =
 configureAction :: ConfigFlags -> [String] -> IO ()
 configureAction flags args = do
   noExtraFlags args
-  let verbosity = fromFlag (configVerbosity flags)
+  let verbosity = getVerbosity configVerbosity flags
   rawSystemExit verbosity "sh" $
     "configure"
     : configureArgs backwardsCompatHack flags
@@ -140,42 +140,42 @@ copyAction flags args = do
   let destArgs = case fromFlag $ copyDest flags of
         NoCopyDest      -> ["install"]
         CopyTo path     -> ["copy", "destdir=" ++ path]
-  rawSystemExit (fromFlag $ copyVerbosity flags) "make" destArgs
+  rawSystemExit (getVerbosity copyVerbosity flags) "make" destArgs
 
 installAction :: InstallFlags -> [String] -> IO ()
 installAction flags args = do
   noExtraFlags args
-  rawSystemExit (fromFlag $ installVerbosity flags) "make" ["install"]
-  rawSystemExit (fromFlag $ installVerbosity flags) "make" ["register"]
+  rawSystemExit (getVerbosity installVerbosity flags) "make" ["install"]
+  rawSystemExit (getVerbosity installVerbosity flags) "make" ["register"]
 
 haddockAction :: HaddockFlags -> [String] -> IO ()
 haddockAction flags args = do
   noExtraFlags args
-  rawSystemExit (fromFlag $ haddockVerbosity flags) "make" ["docs"]
+  rawSystemExit (getVerbosity haddockVerbosity flags) "make" ["docs"]
     `catchIO` \_ ->
-    rawSystemExit (fromFlag $ haddockVerbosity flags) "make" ["doc"]
+    rawSystemExit (getVerbosity haddockVerbosity flags) "make" ["doc"]
 
 buildAction :: BuildFlags -> [String] -> IO ()
 buildAction flags args = do
   noExtraFlags args
-  rawSystemExit (fromFlag $ buildVerbosity flags) "make" []
+  rawSystemExit (getVerbosity buildVerbosity flags) "make" []
 
 cleanAction :: CleanFlags -> [String] -> IO ()
 cleanAction flags args = do
   noExtraFlags args
-  rawSystemExit (fromFlag $ cleanVerbosity flags) "make" ["clean"]
+  rawSystemExit (getVerbosity cleanVerbosity flags) "make" ["clean"]
 
 sdistAction :: SDistFlags -> [String] -> IO ()
 sdistAction flags args = do
   noExtraFlags args
-  rawSystemExit (fromFlag $ sDistVerbosity flags) "make" ["dist"]
+  rawSystemExit (getVerbosity sDistVerbosity flags) "make" ["dist"]
 
 registerAction :: RegisterFlags -> [String] -> IO ()
 registerAction  flags args = do
   noExtraFlags args
-  rawSystemExit (fromFlag $ regVerbosity flags) "make" ["register"]
+  rawSystemExit (getVerbosity regVerbosity flags) "make" ["register"]
 
 unregisterAction :: RegisterFlags -> [String] -> IO ()
 unregisterAction flags args = do
   noExtraFlags args
-  rawSystemExit (fromFlag $ regVerbosity flags) "make" ["unregister"]
+  rawSystemExit (getVerbosity regVerbosity flags) "make" ["unregister"]

--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -212,7 +212,7 @@ configureAction hooks flags args = do
     postConf hooks args flags' pkg_descr localbuildinfo
     return localbuildinfo
   where
-    verbosity = fromFlag (configVerbosity flags)
+    verbosity = getVerbosity configVerbosity flags
 
 confPkgDescr :: UserHooks -> Verbosity -> IO (Maybe FilePath, GenericPackageDescription)
 confPkgDescr hooks verbosity = do
@@ -227,7 +227,7 @@ confPkgDescr hooks verbosity = do
 buildAction :: UserHooks -> BuildFlags -> Args -> IO ()
 buildAction hooks flags args = do
   distPref <- findDistPrefOrDefault (buildDistPref flags)
-  let verbosity = fromFlag $ buildVerbosity flags
+  let verbosity = getVerbosity buildVerbosity flags
       flags' = flags { buildDistPref = toFlag distPref }
 
   lbi <- getBuildConfig hooks verbosity distPref
@@ -243,7 +243,7 @@ buildAction hooks flags args = do
 replAction :: UserHooks -> ReplFlags -> Args -> IO ()
 replAction hooks flags args = do
   distPref <- findDistPrefOrDefault (replDistPref flags)
-  let verbosity = fromFlag $ replVerbosity flags
+  let verbosity = getVerbosity replVerbosity flags
       flags' = flags { replDistPref = toFlag distPref }
 
   lbi <- getBuildConfig hooks verbosity distPref
@@ -262,7 +262,7 @@ replAction hooks flags args = do
 hscolourAction :: UserHooks -> HscolourFlags -> Args -> IO ()
 hscolourAction hooks flags args = do
     distPref <- findDistPrefOrDefault (hscolourDistPref flags)
-    let verbosity = fromFlag $ hscolourVerbosity flags
+    let verbosity = getVerbosity hscolourVerbosity flags
         flags' = flags { hscolourDistPref = toFlag distPref }
     hookedAction preHscolour hscolourHook postHscolour
                  (getBuildConfig hooks verbosity distPref)
@@ -271,7 +271,7 @@ hscolourAction hooks flags args = do
 haddockAction :: UserHooks -> HaddockFlags -> Args -> IO ()
 haddockAction hooks flags args = do
   distPref <- findDistPrefOrDefault (haddockDistPref flags)
-  let verbosity = fromFlag $ haddockVerbosity flags
+  let verbosity = getVerbosity haddockVerbosity flags
       flags' = flags { haddockDistPref = toFlag distPref }
 
   lbi <- getBuildConfig hooks verbosity distPref
@@ -301,12 +301,12 @@ cleanAction hooks flags args = do
     cleanHook hooks pkg_descr () hooks flags'
     postClean hooks args flags' pkg_descr ()
   where
-    verbosity = fromFlag (cleanVerbosity flags)
+    verbosity = getVerbosity cleanVerbosity flags
 
 copyAction :: UserHooks -> CopyFlags -> Args -> IO ()
 copyAction hooks flags args = do
     distPref <- findDistPrefOrDefault (copyDistPref flags)
-    let verbosity = fromFlag $ copyVerbosity flags
+    let verbosity = getVerbosity copyVerbosity flags
         flags' = flags { copyDistPref = toFlag distPref }
     hookedAction preCopy copyHook postCopy
                  (getBuildConfig hooks verbosity distPref)
@@ -315,7 +315,7 @@ copyAction hooks flags args = do
 installAction :: UserHooks -> InstallFlags -> Args -> IO ()
 installAction hooks flags args = do
     distPref <- findDistPrefOrDefault (installDistPref flags)
-    let verbosity = fromFlag $ installVerbosity flags
+    let verbosity = getVerbosity installVerbosity flags
         flags' = flags { installDistPref = toFlag distPref }
     hookedAction preInst instHook postInst
                  (getBuildConfig hooks verbosity distPref)
@@ -337,7 +337,7 @@ sdistAction hooks flags args = do
     sDistHook hooks pkg_descr mlbi hooks flags'
     postSDist hooks args flags' pkg_descr mlbi
   where
-    verbosity = fromFlag (sDistVerbosity flags)
+    verbosity = getVerbosity sDistVerbosity flags
 
 testAction :: UserHooks -> TestFlags -> Args -> IO ()
 testAction hooks flags args = do
@@ -367,7 +367,7 @@ benchAction hooks flags args = do
 registerAction :: UserHooks -> RegisterFlags -> Args -> IO ()
 registerAction hooks flags args = do
     distPref <- findDistPrefOrDefault (regDistPref flags)
-    let verbosity = fromFlag $ regVerbosity flags
+    let verbosity = getVerbosity regVerbosity flags
         flags' = flags { regDistPref = toFlag distPref }
     hookedAction preReg regHook postReg
                  (getBuildConfig hooks verbosity distPref)
@@ -376,7 +376,7 @@ registerAction hooks flags args = do
 unregisterAction :: UserHooks -> RegisterFlags -> Args -> IO ()
 unregisterAction hooks flags args = do
     distPref <- findDistPrefOrDefault (regDistPref flags)
-    let verbosity = fromFlag $ regVerbosity flags
+    let verbosity = getVerbosity regVerbosity flags
         flags' = flags { regDistPref = toFlag distPref }
     hookedAction preUnreg unregHook postUnreg
                  (getBuildConfig hooks verbosity distPref)
@@ -495,7 +495,7 @@ clean pkg_descr flags = do
             isFile <- doesFileExist fname
             if isDir then removeDirectoryRecursive fname
               else when isFile $ removeFile fname
-        verbosity = fromFlag (cleanVerbosity flags)
+        verbosity = getVerbosity cleanVerbosity flags
 
 -- --------------------------------------------------------------------------
 -- Default hooks
@@ -524,7 +524,7 @@ simpleUserHooks =
     finalChecks _args flags pkg_descr lbi =
       checkForeignDeps pkg_descr lbi (lessVerbose verbosity)
       where
-        verbosity = fromFlag (configVerbosity flags)
+        verbosity = getVerbosity configVerbosity flags
 
 -- | Basic autoconf 'UserHooks':
 --
@@ -542,7 +542,7 @@ simpleUserHooks =
 defaultUserHooks :: UserHooks
 defaultUserHooks = autoconfUserHooks {
           confHook = \pkg flags -> do
-                       let verbosity = fromFlag (configVerbosity flags)
+                       let verbosity = getVerbosity configVerbosity flags
                        warn verbosity
                          "defaultUserHooks in Setup script is deprecated."
                        confHook autoconfUserHooks pkg flags,
@@ -552,7 +552,7 @@ defaultUserHooks = autoconfUserHooks {
     -- It's here for compatibility with existing Setup.hs scripts. See:
     -- https://github.com/haskell/cabal/issues/158
     where oldCompatPostConf args flags pkg_descr lbi
-              = do let verbosity = fromFlag (configVerbosity flags)
+              = do let verbosity = getVerbosity configVerbosity flags
                    noExtraFlags args
                    confExists <- doesFileExist "configure"
                    when confExists $
@@ -582,7 +582,7 @@ autoconfUserHooks
       }
     where defaultPostConf :: Args -> ConfigFlags -> PackageDescription -> LocalBuildInfo -> IO ()
           defaultPostConf args flags pkg_descr lbi
-              = do let verbosity = fromFlag (configVerbosity flags)
+              = do let verbosity = getVerbosity configVerbosity flags
                    noExtraFlags args
                    confExists <- doesFileExist "configure"
                    if confExists
@@ -601,14 +601,14 @@ autoconfUserHooks
           readHookWithArgs get_verbosity _ flags = do
               getHookedBuildInfo verbosity
             where
-              verbosity = fromFlag (get_verbosity flags)
+              verbosity = getVerbosity get_verbosity flags
 
           readHook :: (a -> Flag Verbosity) -> Args -> a -> IO HookedBuildInfo
           readHook get_verbosity a flags = do
               noExtraFlags a
               getHookedBuildInfo verbosity
             where
-              verbosity = fromFlag (get_verbosity flags)
+              verbosity = getVerbosity get_verbosity flags
 
 runConfigureScript :: Verbosity -> Bool -> ConfigFlags -> LocalBuildInfo
                    -> IO ()
@@ -694,5 +694,5 @@ defaultRegHook :: PackageDescription -> LocalBuildInfo
 defaultRegHook pkg_descr localbuildinfo _ flags =
     if hasLibs pkg_descr
     then register pkg_descr localbuildinfo flags
-    else setupMessage (fromFlag (regVerbosity flags))
+    else setupMessage (getVerbosity regVerbosity flags)
            "Package contains no library to register:" (packageId pkg_descr)

--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -469,7 +469,7 @@ getBuildConfig hooks verbosity distPref = do
 
 clean :: PackageDescription -> CleanFlags -> IO ()
 clean pkg_descr flags = do
-    let distPref = fromFlagOrDefault defaultDistPref $ cleanDistPref flags
+    let distPref = getDistPref cleanDistPref flags
     notice verbosity "cleaning..."
 
     maybeConfig <- if fromFlag (cleanSaveConf flags)

--- a/Cabal/Distribution/Simple/Bench.hs
+++ b/Cabal/Distribution/Simple/Bench.hs
@@ -37,7 +37,7 @@ bench :: Args                    -- ^positional command-line arguments
       -> BenchmarkFlags          -- ^flags sent to benchmark
       -> IO ()
 bench args pkg_descr lbi flags = do
-    let verbosity         = fromFlag $ benchmarkVerbosity flags
+    let verbosity         = getVerbosity benchmarkVerbosity flags
         benchmarkNames    = args
         pkgBenchmarks     = PD.benchmarks pkg_descr
         enabledBenchmarks = [ t | t <- pkgBenchmarks

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -130,7 +130,7 @@ build pkg_descr lbi flags suffixes
                    lbi' suffixes comp clbi distPref
  where
   distPref  = fromFlag (buildDistPref flags)
-  verbosity = fromFlag (buildVerbosity flags)
+  verbosity = getVerbosity buildVerbosity flags
 
 
 repl     :: PackageDescription  -- ^ Mostly information from the .cabal file
@@ -141,7 +141,7 @@ repl     :: PackageDescription  -- ^ Mostly information from the .cabal file
          -> IO ()
 repl pkg_descr lbi flags suffixes args = do
   let distPref  = fromFlag (replDistPref flags)
-      verbosity = fromFlag (replVerbosity flags)
+      verbosity = getVerbosity replVerbosity flags
 
   targets  <- readBuildTargets pkg_descr args
   targets' <- case targets of

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -76,7 +76,7 @@ build    :: PackageDescription  -- ^ Mostly information from the .cabal file
          -> [ PPSuffixHandler ] -- ^ preprocessors to run before compiling
          -> IO ()
 build pkg_descr lbi flags suffixes
- | fromFlag (buildAssumeDepsUpToDate flags) = do
+ | fromFlagOrDefault False (buildAssumeDepsUpToDate flags) = do
   -- TODO: if checkBuildTargets ignores a target we may accept
   -- a --assume-deps-up-to-date with multiple arguments. Arguably, we should
   -- error early in this case.

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -129,7 +129,7 @@ build pkg_descr lbi flags suffixes
     buildComponent verbosity (buildNumJobs flags) pkg_descr
                    lbi' suffixes comp clbi distPref
  where
-  distPref  = fromFlag (buildDistPref flags)
+  distPref  = getDistPref buildDistPref flags
   verbosity = getVerbosity buildVerbosity flags
 
 
@@ -140,7 +140,7 @@ repl     :: PackageDescription  -- ^ Mostly information from the .cabal file
          -> [String]
          -> IO ()
 repl pkg_descr lbi flags suffixes args = do
-  let distPref  = fromFlag (replDistPref flags)
+  let distPref  = getDistPref replDistPref flags
       verbosity = getVerbosity replVerbosity flags
 
   targets  <- readBuildTargets pkg_descr args

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -739,7 +739,7 @@ configure (pkg_descr0', pbi) cfg = do
     return lbi
 
     where
-      verbosity = fromFlag (configVerbosity cfg)
+      verbosity = getVerbosity configVerbosity cfg
 
       checkProfDetail (Flag (ProfDetailOther other)) = do
         warn verbosity $
@@ -1386,7 +1386,7 @@ configCompilerAuxEx cfg = configCompilerEx (flagToMaybe $ configHcFlavor cfg)
                                            (flagToMaybe $ configHcPath cfg)
                                            (flagToMaybe $ configHcPkg cfg)
                                            programsConfig
-                                           (fromFlag (configVerbosity cfg))
+                                           (getVerbosity configVerbosity cfg)
   where
     programsConfig = mkProgramsConfig cfg defaultProgramConfiguration
 

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -334,7 +334,7 @@ configure (pkg_descr0', pbi) cfg = do
 
     -- Where to build the package
     let distPref :: FilePath -- e.g. dist
-        distPref = fromFlag (configDistPref cfg)
+        distPref = getDistPref configDistPref cfg
         buildDir :: FilePath -- e.g. dist/build
         -- fromFlag OK due to Distribution.Simple calling
         -- findDistPrefOrDefault to fill it in

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -295,7 +295,7 @@ buildOrReplLib forRepl verbosity numJobs _pkg_descr lbi lib clbi = do
   -- '-hpcdir' should be.
   let isCoverageEnabled = fromFlag $ configCoverage $ configFlags lbi
       pkg_name = display $ PD.package $ localPkgDescr lbi
-      distPref = fromFlag $ configDistPref $ configFlags lbi
+      distPref = getDistPref configDistPref $ configFlags lbi
       hpcdir way
         | isCoverageEnabled = toFlag $ Hpc.mixDir distPref way pkg_name
         | otherwise = Mon.mempty
@@ -535,7 +535,7 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
   -- Determine if program coverage should be enabled and if so, what
   -- '-hpcdir' should be.
   let isCoverageEnabled = fromFlag $ configCoverage $ configFlags lbi
-      distPref = fromFlag $ configDistPref $ configFlags lbi
+      distPref = getDistPref configDistPref $ configFlags lbi
       hpcdir way
         | isCoverageEnabled = toFlag $ Hpc.mixDir distPref way exeName'
         | otherwise = mempty

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -125,7 +125,7 @@ haddock pkg_descr _ _ haddockFlags
     && not (fromFlag $ haddockExecutables haddockFlags)
     && not (fromFlag $ haddockTestSuites  haddockFlags)
     && not (fromFlag $ haddockBenchmarks  haddockFlags) =
-      warn (fromFlag $ haddockVerbosity haddockFlags) $
+      warn (getVerbosity haddockVerbosity haddockFlags) $
            "No documentation was generated as this package does not contain "
         ++ "a library. Perhaps you want to use the --executables, --tests or"
         ++ " --benchmarks flags."
@@ -203,7 +203,7 @@ haddock pkg_descr lbi suffixes flags' = do
                 runHaddock verbosity tmpFileOpts comp platform
                   confHaddock exeArgs'
           Nothing -> do
-           warn (fromFlag $ haddockVerbosity flags)
+           warn (getVerbosity haddockVerbosity flags)
              "Unsupported component, skipping..."
            return ()
       case component of
@@ -676,7 +676,7 @@ hscolour' onNoHsColour haddockTarget pkg_descr lbi suffixes flags =
                               </> exeName exe </> "src"
               runHsColour hscolourProg outputDir =<< getExeSourceFiles lbi exe clbi
             Nothing -> do
-              warn (fromFlag $ hscolourVerbosity flags)
+              warn (getVerbosity hscolourVerbosity flags)
                 "Unsupported component, skipping..."
               return ()
         case comp of
@@ -689,7 +689,7 @@ hscolour' onNoHsColour haddockTarget pkg_descr lbi suffixes flags =
 
     stylesheet = flagToMaybe (hscolourCSS flags)
 
-    verbosity  = fromFlag (hscolourVerbosity flags)
+    verbosity  = getVerbosity hscolourVerbosity flags
     distPref   = fromFlag (hscolourDistPref flags)
 
     runHsColour prog outputDir moduleFiles = do

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -27,7 +27,7 @@ import Distribution.Simple.Utils
 import Distribution.Simple.Compiler
          ( CompilerFlavor(..), compilerFlavor )
 import Distribution.Simple.Setup
-         ( CopyFlags(..), fromFlag, HaddockTarget(ForDevelopment) )
+         ( CopyFlags(..), fromFlag, getVerbosity, HaddockTarget(ForDevelopment) )
 import Distribution.Simple.BuildTarget
 
 import qualified Distribution.Simple.GHC   as GHC
@@ -83,7 +83,7 @@ install pkg_descr lbi flags
     copyComponent verbosity pkg_descr lbi comp clbi copydest
  where
   distPref  = fromFlag (copyDistPref flags)
-  verbosity = fromFlag (copyVerbosity flags)
+  verbosity = getVerbosity copyVerbosity flags
   copydest  = fromFlag (copyDest flags)
 
   checkHasLibsOrExes =

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -27,7 +27,8 @@ import Distribution.Simple.Utils
 import Distribution.Simple.Compiler
          ( CompilerFlavor(..), compilerFlavor )
 import Distribution.Simple.Setup
-         ( CopyFlags(..), fromFlag, getVerbosity, HaddockTarget(ForDevelopment) )
+         ( CopyFlags(..), fromFlag, getDistPref, getVerbosity
+         , HaddockTarget(ForDevelopment) )
 import Distribution.Simple.BuildTarget
 
 import qualified Distribution.Simple.GHC   as GHC
@@ -82,7 +83,7 @@ install pkg_descr lbi flags
   withComponentsInBuildOrder pkg_descr lbi (map fst targets') $ \comp clbi ->
     copyComponent verbosity pkg_descr lbi comp clbi copydest
  where
-  distPref  = fromFlag (copyDistPref flags)
+  distPref  = getDistPref copyDistPref flags
   verbosity = getVerbosity copyVerbosity flags
   copydest  = fromFlag (copyDest flags)
 

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -138,7 +138,7 @@ generateOne pkg lib lbi clbi regFlags
     -- fail if dependencies cannot be satisfied.
     packageDbs = nub $ withPackageDB lbi
                     ++ maybeToList (flagToMaybe  (regPackageDB regFlags))
-    distPref  = fromFlag (regDistPref regFlags)
+    distPref  = getDistPref regDistPref regFlags
     verbosity = getVerbosity regVerbosity regFlags
 
 registerAll :: PackageDescription -> LocalBuildInfo -> RegisterFlags

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -117,7 +117,7 @@ register pkg_descr lbi flags = when (hasPublicLib pkg_descr) doRegister
     registerAll pkg_descr lbi flags ipis
     return ()
    where
-    verbosity = fromFlag (regVerbosity flags)
+    verbosity = getVerbosity regVerbosity flags
 
 generateOne :: PackageDescription -> Library -> LocalBuildInfo -> ComponentLocalBuildInfo
             -> RegisterFlags
@@ -139,7 +139,7 @@ generateOne pkg lib lbi clbi regFlags
     packageDbs = nub $ withPackageDB lbi
                     ++ maybeToList (flagToMaybe  (regPackageDB regFlags))
     distPref  = fromFlag (regDistPref regFlags)
-    verbosity = fromFlag (regVerbosity regFlags)
+    verbosity = getVerbosity regVerbosity regFlags
 
 registerAll :: PackageDescription -> LocalBuildInfo -> RegisterFlags
             -> [InstalledPackageInfo]
@@ -174,7 +174,7 @@ registerAll pkg lbi regFlags ipis
     -- fail if dependencies cannot be satisfied.
     packageDbs = nub $ withPackageDB lbi
                     ++ maybeToList (flagToMaybe  (regPackageDB regFlags))
-    verbosity = fromFlag (regVerbosity regFlags)
+    verbosity = getVerbosity regVerbosity regFlags
 
     writeRegistrationFileOrDirectory = do
       -- Handles overwriting both directory and file
@@ -513,7 +513,7 @@ unregister :: PackageDescription -> LocalBuildInfo -> RegisterFlags -> IO ()
 unregister pkg lbi regFlags = do
   let pkgid     = packageId pkg
       genScript = fromFlag (regGenScript regFlags)
-      verbosity = fromFlag (regVerbosity regFlags)
+      verbosity = getVerbosity regVerbosity regFlags
       packageDb = fromFlagOrDefault (registrationPackageDB (withPackageDB lbi))
                                     (regPackageDB regFlags)
       unreg hpi =

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -66,6 +66,7 @@ module Distribution.Simple.Setup (
   toFlag,
   fromFlag,
   fromFlagOrDefault,
+  getVerbosity,
   flagToMaybe,
   flagToList,
   BooleanFlag(..),
@@ -164,6 +165,9 @@ fromFlag NoFlag   = error "fromFlag NoFlag. Use fromFlagOrDefault"
 fromFlagOrDefault :: a -> Flag a -> a
 fromFlagOrDefault _   (Flag x) = x
 fromFlagOrDefault def NoFlag   = def
+
+getVerbosity :: (a -> Flag Verbosity) -> a -> Verbosity
+getVerbosity f = fromFlagOrDefault normal . f
 
 flagToMaybe :: Flag a -> Maybe a
 flagToMaybe (Flag x) = Just x

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -66,7 +66,7 @@ module Distribution.Simple.Setup (
   toFlag,
   fromFlag,
   fromFlagOrDefault,
-  getVerbosity,
+  getVerbosity, getDistPref,
   flagToMaybe,
   flagToList,
   BooleanFlag(..),
@@ -168,6 +168,9 @@ fromFlagOrDefault def NoFlag   = def
 
 getVerbosity :: (a -> Flag Verbosity) -> a -> Verbosity
 getVerbosity f = fromFlagOrDefault normal . f
+
+getDistPref :: (a -> Flag FilePath) -> a -> FilePath
+getDistPref f = fromFlagOrDefault defaultDistPref . f
 
 flagToMaybe :: Flag a -> Maybe a
 flagToMaybe (Flag x) = Just x

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -118,7 +118,7 @@ sdist pkg mb_lbi flags mkTmpDir pps =
     verbosity = getVerbosity sDistVerbosity flags
     snapshot  = fromFlag (sDistSnapshot flags)
 
-    distPref     = fromFlag $ sDistDistPref flags
+    distPref     = getDistPref sDistDistPref flags
     targetPref   = distPref
     tmpTargetDir = mkTmpDir distPref
 

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -115,7 +115,7 @@ sdist pkg mb_lbi flags mkTmpDir pps =
       when snapshot $
         overwriteSnapshotPackageDesc verbosity pkg' targetDir
 
-    verbosity = fromFlag (sDistVerbosity flags)
+    verbosity = getVerbosity sDistVerbosity flags
     snapshot  = fromFlag (sDistSnapshot flags)
 
     distPref     = fromFlag $ sDistDistPref flags

--- a/Cabal/Distribution/Simple/Test.hs
+++ b/Cabal/Distribution/Simple/Test.hs
@@ -43,7 +43,7 @@ test :: Args                    -- ^positional command-line arguments
      -> TestFlags               -- ^flags sent to test
      -> IO ()
 test args pkg_descr lbi flags = do
-    let verbosity = fromFlag $ testVerbosity flags
+    let verbosity = getVerbosity testVerbosity flags
         machineTemplate = fromFlag $ testMachineLog flags
         distPref = fromFlag $ testDistPref flags
         testLogDir = distPref </> "test"

--- a/Cabal/Distribution/Simple/Test.hs
+++ b/Cabal/Distribution/Simple/Test.hs
@@ -45,7 +45,7 @@ test :: Args                    -- ^positional command-line arguments
 test args pkg_descr lbi flags = do
     let verbosity = getVerbosity testVerbosity flags
         machineTemplate = fromFlag $ testMachineLog flags
-        distPref = fromFlag $ testDistPref flags
+        distPref = getDistPref testDistPref flags
         testLogDir = distPref </> "test"
         testNames = args
         pkgTests = PD.testSuites pkg_descr

--- a/Cabal/Distribution/Simple/Test/ExeV10.hs
+++ b/Cabal/Distribution/Simple/Test/ExeV10.hs
@@ -127,7 +127,7 @@ runTest pkg_descr lbi flags suite = do
 
     return suiteLog
   where
-    distPref = fromFlag $ testDistPref flags
+    distPref = getDistPref testDistPref flags
     verbosity = getVerbosity testVerbosity flags
     details = fromFlag $ testShowDetails flags
     testLogDir = distPref </> "test"

--- a/Cabal/Distribution/Simple/Test/ExeV10.hs
+++ b/Cabal/Distribution/Simple/Test/ExeV10.hs
@@ -128,7 +128,7 @@ runTest pkg_descr lbi flags suite = do
     return suiteLog
   where
     distPref = fromFlag $ testDistPref flags
-    verbosity = fromFlag $ testVerbosity flags
+    verbosity = getVerbosity testVerbosity flags
     details = fromFlag $ testShowDetails flags
     testLogDir = distPref </> "test"
 

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -155,7 +155,7 @@ runTest pkg_descr lbi flags suite = do
         (f, h) <- openTempFile testLogDir $ "cabal-test-" <.> "log"
         hClose h >> return f
 
-    distPref = fromFlag $ testDistPref flags
+    distPref = getDistPref testDistPref flags
     verbosity = getVerbosity testVerbosity flags
 
 -- TODO: This is abusing the notion of a 'PathTemplate'.  The result isn't

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -156,7 +156,7 @@ runTest pkg_descr lbi flags suite = do
         hClose h >> return f
 
     distPref = fromFlag $ testDistPref flags
-    verbosity = fromFlag $ testVerbosity flags
+    verbosity = getVerbosity testVerbosity flags
 
 -- TODO: This is abusing the notion of a 'PathTemplate'.  The result isn't
 -- necessarily a path.


### PR DESCRIPTION
I was debugging a failing test in my `reconfigure` branch; in the end, I cleaned up many uses of the partial `fromFlag` function. Given that there is an unambiguous default for these cases, I didn't think there was much sense in even admitting the possibility of raising an exception.