### PR TITLE
BC fix: libraries -> library/subLibraries (#3574)

### DIFF
--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -206,7 +206,9 @@ buildComponent verbosity numJobs pkg_descr lbi suffixes
                comp@(CLib lib) clbi distPref = do
     preprocessComponent pkg_descr comp lbi clbi False verbosity suffixes
     extras <- preprocessExtras comp lbi
-    info verbosity $ "Building library " ++ libName lib ++ "..."
+    case libName lib of
+        Nothing -> info verbosity $ "Building library..."
+        Just n -> info verbosity $ "Building library " ++ n ++ "..."
     let libbi = libBuildInfo lib
         lib' = lib { libBuildInfo = addExtraCSources libbi extras }
     buildLib verbosity numJobs pkg_descr lbi lib' clbi
@@ -407,7 +409,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
   where
     bi  = testBuildInfo test
     lib = Library {
-            libName = testName test,
+            libName = Nothing,
             exposedModules = [ m ],
             reexportedModules = [],
             requiredSignatures = [],
@@ -421,7 +423,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
     compat_key = computeCompatPackageKey (compiler lbi) compat_name pkg_ver (componentUnitId clbi)
     libClbi = LibComponentLocalBuildInfo
                 { componentPackageDeps = componentPackageDeps clbi
-                , componentLocalName = CLibName (testName test)
+                , componentLocalName = CSubLibName (testName test)
                 , componentIsPublic = False
                 , componentIncludes = componentIncludes clbi
                 , componentUnitId = componentUnitId clbi
@@ -434,7 +436,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
           , buildDepends = targetBuildDepends $ testBuildInfo test
           , executables  = []
           , testSuites   = []
-          , libraries    = [lib]
+          , subLibraries = [lib]
           }
     ipi    = inplaceInstalledPackageInfo pwd distPref pkg (AbiHash "") lib lbi libClbi
     testDir = buildDir lbi </> stubName test

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -169,9 +169,9 @@ copyComponent verbosity pkg_descr lbi (CLib lib) clbi copydest = do
     -- For the moment use dynlibdir = libdir
         dynlibPref = libPref
 
-    if componentUnitId clbi == localUnitId lbi
-        then notice verbosity ("Installing library in " ++ libPref)
-        else notice verbosity ("Installing internal library " ++ libName lib ++ " in " ++ libPref)
+    case libName lib of
+        Nothing -> notice verbosity ("Installing library in " ++ libPref)
+        Just n -> notice verbosity ("Installing internal library " ++ n ++ " in " ++ libPref)
 
     -- install include files for all compilers - they may be needed to compile
     -- haskell files (using the CPP extension)

--- a/Cabal/Distribution/Simple/JHC.hs
+++ b/Cabal/Distribution/Simple/JHC.hs
@@ -154,10 +154,9 @@ constructJHCCmdLine lbi bi clbi _odir verbosity =
 jhcPkgConf :: PackageDescription -> String
 jhcPkgConf pd =
   let sline name sel = name ++ ": "++sel pd
-      lib pd' = case libraries pd' of
-                [lib'] -> lib'
-                [] -> error "no library available"
-                _ -> error "JHC does not support multiple libraries (yet)"
+      lib pd' = case library pd' of
+                Just lib' -> lib'
+                Nothing -> error "no library available"
       comma = intercalate "," . map display
   in unlines [sline "name" (display . pkgName . packageId)
              ,sline "version" (display . pkgVersion . packageId)

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -46,7 +46,7 @@ import Distribution.Version
 import Distribution.Verbosity
 
 import Control.Monad
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.List (nub, isSuffixOf, isPrefixOf)
 import System.Directory (doesFileExist)
 import System.Info (os, arch)
@@ -664,7 +664,7 @@ preprocessExtras comp lbi = case comp of
     component_dirs = component_names (localPkgDescr lbi)
     -- TODO: libify me
     component_names pkg_descr =
-        map libName (libraries pkg_descr) ++
+        mapMaybe libName (subLibraries pkg_descr) ++
         map exeName (executables pkg_descr) ++
         map testName (testSuites pkg_descr) ++
         map benchmarkName (benchmarks pkg_descr)

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -230,7 +230,7 @@ listPackageSourcesOrdinary verbosity pkg_descr pps =
   where
     -- We have to deal with all libs and executables, so we have local
     -- versions of these functions that ignore the 'buildable' attribute:
-    withAllLib       action = mapM action (libraries pkg_descr)
+    withAllLib       action = mapM action (allLibraries pkg_descr)
     withAllExe       action = mapM action (executables pkg_descr)
     withAllTest      action = mapM action (testSuites pkg_descr)
     withAllBenchmark action = mapM action (benchmarks pkg_descr)
@@ -311,7 +311,8 @@ filterAutogenModule :: PackageDescription -> PackageDescription
 filterAutogenModule pkg_descr0 = mapLib filterAutogenModuleLib $
                                  mapAllBuildInfo filterAutogenModuleBI pkg_descr0
   where
-    mapLib f pkg = pkg { libraries = map f (libraries pkg) }
+    mapLib f pkg = pkg { library      = fmap f (library pkg)
+                       , subLibraries = map f (subLibraries pkg) }
     filterAutogenModuleLib lib = lib {
       exposedModules = filter (/=autogenModule) (exposedModules lib)
     }
@@ -467,7 +468,8 @@ tarBallName = display . packageId
 mapAllBuildInfo :: (BuildInfo -> BuildInfo)
                 -> (PackageDescription -> PackageDescription)
 mapAllBuildInfo f pkg = pkg {
-    libraries   = fmap mapLibBi (libraries pkg),
+    library     = fmap mapLibBi (library pkg),
+    subLibraries = fmap mapLibBi (subLibraries pkg),
     executables = fmap mapExeBi (executables pkg),
     testSuites  = fmap mapTestBi (testSuites pkg),
     benchmarks  = fmap mapBenchBi (benchmarks pkg)

--- a/Cabal/tests/PackageTests/Macros/macros.cabal
+++ b/Cabal/tests/PackageTests/Macros/macros.cabal
@@ -7,7 +7,7 @@ maintainer:          ezyang@cs.stanford.edu
 build-type:          Simple
 cabal-version:       >=1.10
 
-library macros
+library
   exposed-modules:     C
   hs-source-dirs:      src
   build-depends:       base, filepath

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -10,7 +10,7 @@ import qualified PackageTests.TestSuiteTests.ExeV10.Check
 import Distribution.Simple.LocalBuildInfo
   ( LocalBuildInfo(localPkgDescr, compiler), absoluteComponentInstallDirs
   , InstallDirs(libdir), maybeGetComponentLocalBuildInfo
-  , ComponentLocalBuildInfo(componentUnitId), ComponentName(CLibName) )
+  , ComponentLocalBuildInfo(componentUnitId), ComponentName(..) )
 import Distribution.Simple.InstallDirs ( CopyDest(NoCopyDest) )
 import Distribution.Simple.BuildPaths  ( mkLibName, mkSharedLibName )
 import Distribution.Simple.Compiler    ( compilerId )
@@ -540,7 +540,7 @@ tests config = do
             lbi <- liftIO $ getPersistBuildConfig dist_dir
             let pkg_descr = localPkgDescr lbi
                 compiler_id = compilerId (compiler lbi)
-                cname = (CLibName "foo-internal")
+                cname = CSubLibName "foo-internal"
                 Just clbi = maybeGetComponentLocalBuildInfo lbi cname
                 uid = componentUnitId clbi
                 dir = libdir (absoluteComponentInstallDirs pkg_descr lbi uid

--- a/cabal-install/Distribution/Client/BuildTarget.hs
+++ b/cabal-install/Distribution/Client/BuildTarget.hs
@@ -604,29 +604,29 @@ renderBuildTarget ql t =
 
       BuildTargetComponent p c ->
         case ql of
-          QL1 -> [t1                     (dispC c)]
-          QL2 -> [t2 (dispP p)           (dispC c),
-                  t2           (dispK c) (dispC c)]
-          QL3 -> [t3 (dispP p) (dispK c) (dispC c)]
+          QL1 -> [t1                     (dispC p c)]
+          QL2 -> [t2 (dispP p)           (dispC p c),
+                  t2           (dispK c) (dispC p c)]
+          QL3 -> [t3 (dispP p) (dispK c) (dispC p c)]
           QL4 -> []
 
       BuildTargetModule p c m ->
         case ql of
           QL1 -> [t1                                 (dispM m)]
           QL2 -> [t2 (dispP p)                       (dispM m),
-                  t2                     (dispC c) (dispM m)]
-          QL3 -> [t3 (dispP p)           (dispC c) (dispM m),
-                  t3           (dispK c) (dispC c) (dispM m)]
-          QL4 -> [t4 (dispP p) (dispK c) (dispC c) (dispM m)]
+                  t2                     (dispC p c) (dispM m)]
+          QL3 -> [t3 (dispP p)           (dispC p c) (dispM m),
+                  t3           (dispK c) (dispC p c) (dispM m)]
+          QL4 -> [t4 (dispP p) (dispK c) (dispC p c) (dispM m)]
 
       BuildTargetFile p c f ->
         case ql of
           QL1 -> [t1                                 f]
           QL2 -> [t2 (dispP p)                       f,
-                  t2                     (dispC c) f]
-          QL3 -> [t3 (dispP p)           (dispC c) f,
-                  t3           (dispK c) (dispC c) f]
-          QL4 -> [t4 (dispP p) (dispK c) (dispC c) f]
+                  t2                     (dispC p c) f]
+          QL3 -> [t3 (dispP p)           (dispC p c) f,
+                  t3           (dispK c) (dispC p c) f]
+          QL4 -> [t4 (dispP p) (dispK c) (dispC p c) f]
   where
     t1  s1 = UserBuildTargetFileStatus1 s1 none
     t1' s1 = UserBuildTargetFileStatus1 s1
@@ -1062,7 +1062,7 @@ selectComponentInfo :: PackageInfo -> PackageDescription -> [ComponentInfo]
 selectComponentInfo pinfo pkg =
     [ ComponentInfo {
         cinfoName    = componentName c,
-        cinfoStrName = componentStringName (componentName c),
+        cinfoStrName = componentStringName pkg (componentName c),
         cinfoPackage = pinfo,
         cinfoSrcDirs = hsSourceDirs bi,
 --                       [ pkgroot </> srcdir
@@ -1077,11 +1077,12 @@ selectComponentInfo pinfo pkg =
     , let bi = componentBuildInfo c ]
 
 
-componentStringName :: ComponentName -> ComponentStringName
-componentStringName (CLibName   name) = name
-componentStringName (CExeName   name) = name
-componentStringName (CTestName  name) = name
-componentStringName (CBenchName name) = name
+componentStringName :: Package pkg => pkg -> ComponentName -> ComponentStringName
+componentStringName pkg CLibName          = display (packageName pkg)
+componentStringName _ (CSubLibName name) = name
+componentStringName _ (CExeName   name) = name
+componentStringName _ (CTestName  name) = name
+componentStringName _ (CBenchName name) = name
 
 componentModules :: Component -> [ModuleName]
 componentModules (CLib   lib)   = libModules lib
@@ -1108,7 +1109,8 @@ data ComponentKind = LibKind | ExeKind | TestKind | BenchKind
   deriving (Eq, Ord, Show)
 
 componentKind :: ComponentName -> ComponentKind
-componentKind (CLibName   _) = LibKind
+componentKind  CLibName      = LibKind
+componentKind (CSubLibName _) = LibKind
 componentKind (CExeName   _) = ExeKind
 componentKind (CTestName  _) = TestKind
 componentKind (CBenchName _) = BenchKind

--- a/cabal-install/Distribution/Client/Dependency/TopDown.hs
+++ b/cabal-install/Distribution/Client/Dependency/TopDown.hs
@@ -308,10 +308,9 @@ topDownResolver' platform cinfo installedPkgIndex sourcePkgIndex
     toResolverPackage :: FinalSelectedPackage -> ResolverPackage UnresolvedPkgLoc
     toResolverPackage (SelectedInstalled (InstalledPackage pkg pid_deps))
                                               = PreExisting pkg deps
-        where deps = CD.fromLibraryDeps lib
+        where deps = CD.fromLibraryDeps
                    . zipWith PreExistingId pid_deps
                    $ InstalledPackageInfo.depends pkg
-              lib = display (packageName pkg)
     toResolverPackage (SelectedSource    pkg) = Configured  pkg
 
 addTopLevelTargets :: [PackageName]
@@ -624,8 +623,7 @@ finaliseSelectedPackages pref selected constraints =
         -- We cheat in the cabal solver, and classify all dependencies as
         -- library dependencies.
         deps' :: ComponentDeps [SolverId]
-        deps' = CD.fromLibraryDeps (unPackageName (packageName pkg))
-                                   (map (confId . pickRemaining mipkg) deps)
+        deps' = CD.fromLibraryDeps (map (confId . pickRemaining mipkg) deps)
 
     -- InstalledOrSource indicates that we either have a source package
     -- available, or an installed one, or both. In the case that we have both

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -629,7 +629,7 @@ configureInstallPlan solverPlan =
                   $ Configure.computeComponentId
                         Cabal.NoFlag
                         (packageId spkg)
-                        (PD.CLibName (display (pkgName (packageId spkg))))
+                        PD.CLibName
                         -- TODO: this is a hack that won't work for Backpack.
                         (map ((\(SimpleUnitId cid0) -> cid0) . confInstId)
                              (CD.libraryDeps deps))

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -63,7 +63,7 @@ import Distribution.Client.FetchUtils
 import Data.List
          ( sortBy, groupBy, sort, nub, intersperse, maximumBy, partition )
 import Data.Maybe
-         ( listToMaybe, fromJust, fromMaybe, isJust )
+         ( listToMaybe, fromJust, fromMaybe, isJust, maybeToList )
 import qualified Data.Map as Map
 import Data.Tree as Tree
 import Control.Monad
@@ -458,13 +458,14 @@ mergePackageInfo versionPref installedPkgs sourcePkgs selectedPkg showVer =
     flags        = maybe [] Source.genPackageFlags sourceGeneric,
     hasLib       = isJust installed
                 || fromMaybe False
-                   (fmap (not . null . Source.condLibraries) sourceGeneric),
+                   (fmap (isJust . Source.condLibrary) sourceGeneric),
     hasExe       = fromMaybe False
                    (fmap (not . null . Source.condExecutables) sourceGeneric),
     executables  = map fst (maybe [] Source.condExecutables sourceGeneric),
     modules      = combine (map Installed.exposedName . Installed.exposedModules)
                            installed
-                           (concatMap getListOfExposedModules . Source.libraries)
+                           -- NB: only for the PUBLIC library
+                           (concatMap getListOfExposedModules . maybeToList . Source.library)
                            source,
     dependencies =
       combine (map (SourceDependency . simplifyDependency)

--- a/cabal-install/Distribution/Client/PackageUtils.hs
+++ b/cabal-install/Distribution/Client/PackageUtils.hs
@@ -32,5 +32,5 @@ externalBuildDepends pkg = filter (not . internal) (buildDepends pkg)
     internal (Dependency depName versionRange) =
            (depName == packageName pkg &&
             packageVersion pkg `withinRange` versionRange) ||
-           (unPackageName depName `elem` map libName (libraries pkg) &&
+           (Just (unPackageName depName) `elem` map libName (subLibraries pkg) &&
             isAnyVersion versionRange)

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -90,7 +90,8 @@ encodePlanAsJson elaboratedInstallPlan _elaboratedSharedConfig =
     -- TODO: maybe move this helper to "ComponentDeps" module?
     --       Or maybe define a 'Text' instance?
     comp2str c = case c of
-        ComponentDeps.ComponentLib s   -> "lib:"   <> s
+        ComponentDeps.ComponentLib     -> "lib"
+        ComponentDeps.ComponentSubLib s -> "lib:"   <> s
         ComponentDeps.ComponentExe s   -> "exe:"   <> s
         ComponentDeps.ComponentTest s  -> "test:"  <> s
         ComponentDeps.ComponentBench s -> "bench:" <> s

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1612,7 +1612,7 @@ pruneInstallPlanPass2 pkgs =
         keepNeeded _                     _ = True
 
         targetsRequiredForRevDeps =
-          [ ComponentTarget (Cabal.defaultLibName (pkgSourceId pkg)) WholeComponent
+          [ ComponentTarget Cabal.defaultLibName WholeComponent
           -- if anything needs this pkg, build the library component
           | installedPackageId pkg `Set.member` hasReverseLibDeps
           ]
@@ -2036,11 +2036,11 @@ setupHsBuildArgs pkg =
 
 
 showComponentTarget :: ElaboratedConfiguredPackage -> ComponentTarget -> String
-showComponentTarget _pkg =
+showComponentTarget pkg =
     showBuildTarget . toBuildTarget
   where
     showBuildTarget t =
-      Cabal.showBuildTarget (qlBuildTarget t) t
+      Cabal.showBuildTarget (qlBuildTarget t) (packageId pkg) t
 
     qlBuildTarget Cabal.BuildTargetComponent{} = Cabal.QL2
     qlBuildTarget _                            = Cabal.QL3
@@ -2213,7 +2213,8 @@ packageHashInputs
     }
   where
     -- Obviously the main deps are relevant
-    relevantDeps (CD.ComponentLib _)   = True
+    relevantDeps CD.ComponentLib       = True
+    relevantDeps (CD.ComponentSubLib _) = True
     relevantDeps (CD.ComponentExe _)   = True
     -- Setup deps can affect the Setup.hs behaviour and thus what is built
     relevantDeps  CD.ComponentSetup    = True

--- a/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
@@ -53,7 +53,8 @@ import Data.Traversable (Traversable(traverse))
 
 -- | Component of a package.
 data Component =
-    ComponentLib   String
+    ComponentLib
+  | ComponentSubLib String
   | ComponentExe   String
   | ComponentTest  String
   | ComponentBench String
@@ -113,8 +114,8 @@ filterDeps :: (Component -> a -> Bool) -> ComponentDeps a -> ComponentDeps a
 filterDeps p = ComponentDeps . Map.filterWithKey p . unComponentDeps
 
 -- | ComponentDeps containing library dependencies only
-fromLibraryDeps :: String -> a -> ComponentDeps a
-fromLibraryDeps n = singleton (ComponentLib n)
+fromLibraryDeps :: a -> ComponentDeps a
+fromLibraryDeps = singleton ComponentLib
 
 -- | ComponentDeps containing setup dependencies only.
 fromSetupDeps :: a -> ComponentDeps a
@@ -123,7 +124,7 @@ fromSetupDeps = singleton ComponentSetup
 -- | ComponentDeps for installed packages.
 --
 -- We assume that installed packages only record their library dependencies.
-fromInstalled :: String -> a -> ComponentDeps a
+fromInstalled :: a -> ComponentDeps a
 fromInstalled = fromLibraryDeps
 
 {-------------------------------------------------------------------------------
@@ -148,9 +149,11 @@ flatDeps = fold
 nonSetupDeps :: Monoid a => ComponentDeps a -> a
 nonSetupDeps = select (/= ComponentSetup)
 
--- | Library dependencies proper only.
+-- | Library dependencies proper only.  (Includes dependencies
+-- of internal libraries.)
 libraryDeps :: Monoid a => ComponentDeps a -> a
-libraryDeps = select (\c -> case c of ComponentLib _ -> True
+libraryDeps = select (\c -> case c of ComponentSubLib _ -> True
+                                      ComponentLib -> True
                                       _ -> False)
 
 -- | Setup dependencies.

--- a/cabal-install/Distribution/Solver/Types/PackageFixedDeps.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageFixedDeps.hs
@@ -4,10 +4,9 @@ module Distribution.Solver.Types.PackageFixedDeps
 
 import           Distribution.InstalledPackageInfo ( InstalledPackageInfo )
 import           Distribution.Package
-                   ( Package(..), UnitId(..), pkgName, installedDepends)
+                   ( Package(..), UnitId(..), installedDepends)
 import           Distribution.Solver.Types.ComponentDeps ( ComponentDeps )
 import qualified Distribution.Solver.Types.ComponentDeps as CD
-import           Distribution.Text (display)
 
 -- | Subclass of packages that have specific versioned dependencies.
 --
@@ -20,6 +19,5 @@ class Package pkg => PackageFixedDeps pkg where
   depends :: pkg -> ComponentDeps [UnitId]
 
 instance PackageFixedDeps InstalledPackageInfo where
-  depends pkg = CD.fromInstalled (display (pkgName (packageId pkg)))
-                                 (installedDepends pkg)
+  depends pkg = CD.fromInstalled (installedDepends pkg)
 

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -172,7 +172,7 @@ data ExampleQualifier =
 exAv :: ExamplePkgName -> ExamplePkgVersion -> [ExampleDependency]
      -> ExampleAvailable
 exAv n v ds = ExAv { exAvName = n, exAvVersion = v
-                   , exAvDeps = CD.fromLibraryDeps n ds }
+                   , exAvDeps = CD.fromLibraryDeps ds }
 
 withSetupDeps :: ExampleAvailable -> [ExampleDependency] -> ExampleAvailable
 withSetupDeps ex setupDeps = ex {
@@ -231,7 +231,8 @@ exAvSrcPkg ex =
          , packageDescription   = C.GenericPackageDescription {
                C.packageDescription = C.emptyPackageDescription {
                    C.package        = exAvPkgId ex
-                 , C.libraries      = error "not yet configured: library"
+                 , C.library        = error "not yet configured: library"
+                 , C.subLibraries   = error "not yet configured: subLibraries"
                  , C.executables    = error "not yet configured: executables"
                  , C.testSuites     = error "not yet configured: testSuites"
                  , C.benchmarks     = error "not yet configured: benchmarks"
@@ -243,9 +244,10 @@ exAvSrcPkg ex =
                  }
              , C.genPackageFlags = nub $ concatMap extractFlags $
                                    CD.libraryDeps (exAvDeps ex) ++ concatMap snd testSuites
-             , C.condLibraries   = [(exAvName ex, mkCondTree (extsLib exts <> langLib mlang <> pcpkgLib pcpkgs)
+             , C.condLibrary = Just (mkCondTree (extsLib exts <> langLib mlang <> pcpkgLib pcpkgs)
                                                      disableLib
-                                                     (Buildable libraryDeps))]
+                                                     (Buildable libraryDeps))
+             , C.condSubLibraries = []
              , C.condExecutables = []
              , C.condTestSuites  =
                  let mkTree = mkCondTree mempty disableTest . Buildable

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -280,15 +280,16 @@ instance Arbitrary Solver where
   shrink TopDown = [Modular]
 
 instance Arbitrary Component where
-  arbitrary = oneof [ ComponentLib <$> arbitraryComponentName
+  arbitrary = oneof [ return ComponentLib
+                    , ComponentSubLib <$> arbitraryComponentName
                     , ComponentExe <$> arbitraryComponentName
                     , ComponentTest <$> arbitraryComponentName
                     , ComponentBench <$> arbitraryComponentName
                     , return ComponentSetup
                     ]
 
-  shrink (ComponentLib "") = []
-  shrink _ = [ComponentLib ""]
+  shrink ComponentLib = []
+  shrink _ = [ComponentLib]
 
 instance Arbitrary ExampleInstalled where
   arbitrary = error "arbitrary not implemented: ExampleInstalled"


### PR DESCRIPTION
The resulting code is more verbose, but it is more backwards-compatible
and actually is simpler to understand in some cases (because
CLibName uniquely identifies the "public library"; no faffing
about with package names to figure it out.)

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>