### PR TITLE
Add 'WeightedPSQ' and use it to sort package, flag, and stanza choices.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Degree.hs
+++ b/cabal-install/Distribution/Solver/Modular/Degree.hs
@@ -1,0 +1,21 @@
+module Distribution.Solver.Modular.Degree where
+
+-- | Approximation of the branching degree.
+--
+-- This is designed for computing the branching degree of a goal choice
+-- node. If the degree is 0 or 1, it is always good to take that goal,
+-- because we can either abort immediately, or have no other choice anyway.
+--
+-- So we do not actually want to compute the full degree (which is
+-- somewhat costly) in cases where we have such an easy choice.
+--
+data Degree = ZeroOrOne | Two | Other
+  deriving (Show, Eq)
+
+instance Ord Degree where
+  compare ZeroOrOne _         = LT -- lazy approximation
+  compare _         ZeroOrOne = GT -- approximation
+  compare Two       Two       = EQ
+  compare Two       Other     = LT
+  compare Other     Two       = GT
+  compare Other     Other     = EQ

--- a/cabal-install/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install/Distribution/Solver/Modular/Explore.hs
@@ -16,6 +16,7 @@ import qualified Distribution.Solver.Modular.PSQ as P
 import qualified Distribution.Solver.Modular.ConflictSet as CS
 import Distribution.Solver.Modular.RetryLog
 import Distribution.Solver.Modular.Tree
+import qualified Distribution.Solver.Modular.WeightedPSQ as W
 import Distribution.Solver.Types.PackagePath
 import Distribution.Solver.Types.Settings (EnableBackjumping(..), CountConflicts(..))
 
@@ -43,7 +44,7 @@ import Distribution.Solver.Types.Settings (EnableBackjumping(..), CountConflicts
 -- variable. See also the comments for 'avoidSet'.
 --
 backjump :: EnableBackjumping -> Var QPN
-         -> ConflictSet QPN -> P.PSQ k (ConflictMap -> ConflictSetLog a)
+         -> ConflictSet QPN -> W.WeightedPSQ w k (ConflictMap -> ConflictSetLog a)
          -> ConflictMap -> ConflictSetLog a
 backjump (EnableBackjumping enableBj) var initial xs =
     F.foldr combine logBackjump xs initial
@@ -105,7 +106,7 @@ exploreLog enableBj (CountConflicts countConflicts) = cata go
     go (DoneF rdm)              a            = \ _  -> succeedWith Success (a, rdm)
     go (PChoiceF qpn gr     ts) (A pa fa sa) =
       backjump enableBj (P qpn) (avoidSet (P qpn) gr) $ -- try children in order,
-        P.mapWithKey                                -- when descending ...
+        W.mapWithKey                                -- when descending ...
           (\ i@(POption k _) r cm ->
             let l = r (A (M.insert qpn k pa) fa sa) cm
             in tryWith (TryP qpn i) l
@@ -113,7 +114,7 @@ exploreLog enableBj (CountConflicts countConflicts) = cata go
         ts
     go (FChoiceF qfn gr _ _ ts) (A pa fa sa) =
       backjump enableBj (F qfn) (avoidSet (F qfn) gr) $ -- try children in order,
-        P.mapWithKey                                -- when descending ...
+        W.mapWithKey                                -- when descending ...
           (\ k r cm ->
             let l = r (A pa (M.insert qfn k fa) sa) cm
             in  tryWith (TryF qfn k) l
@@ -121,7 +122,7 @@ exploreLog enableBj (CountConflicts countConflicts) = cata go
         ts
     go (SChoiceF qsn gr _   ts) (A pa fa sa) =
       backjump enableBj (S qsn) (avoidSet (S qsn) gr) $ -- try children in order,
-        P.mapWithKey                                -- when descending ...
+        W.mapWithKey                                -- when descending ...
           (\ k r cm ->
             let l = r (A pa fa (M.insert qsn k sa)) cm
             in  tryWith (TryS qsn k) l

--- a/cabal-install/Distribution/Solver/Modular/PSQ.hs
+++ b/cabal-install/Distribution/Solver/Modular/PSQ.hs
@@ -40,6 +40,8 @@ module Distribution.Solver.Modular.PSQ
 -- (inefficiently implemented) lookup, because I think that queue-based
 -- operations and sorting turn out to be more efficiency-critical in practice.
 
+import Distribution.Solver.Modular.Degree
+
 import Control.Arrow (first, second)
 
 import qualified Data.Foldable as F
@@ -172,26 +174,6 @@ filter p (PSQ xs) = PSQ (S.filter (p . snd) xs)
 
 length :: PSQ k a -> Int
 length (PSQ xs) = S.length xs
-
--- | Approximation of the branching degree.
---
--- This is designed for computing the branching degree of a goal choice
--- node. If the degree is 0 or 1, it is always good to take that goal,
--- because we can either abort immediately, or have no other choice anyway.
---
--- So we do not actually want to compute the full degree (which is
--- somewhat costly) in cases where we have such an easy choice.
---
-data Degree = ZeroOrOne | Two | Other
-  deriving (Show, Eq)
-
-instance Ord Degree where
-  compare ZeroOrOne _         = LT -- lazy approximation
-  compare _         ZeroOrOne = GT -- approximation
-  compare Two       Two       = EQ
-  compare Two       Other     = LT
-  compare Other     Two       = GT
-  compare Other     Other     = EQ
 
 degree :: PSQ k a -> Degree
 degree (PSQ [])     = ZeroOrOne

--- a/cabal-install/Distribution/Solver/Modular/PSQ.hs
+++ b/cabal-install/Distribution/Solver/Modular/PSQ.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
 module Distribution.Solver.Modular.PSQ
     ( PSQ(..)  -- Unit test needs constructor access
-    , Degree(..)
     , casePSQ
     , cons
     , degree

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -50,7 +50,10 @@ import qualified Distribution.Solver.Modular.WeightedPSQ as W
 
 -- | Update the weights of children under 'PChoice' nodes. 'addWeights' takes a
 -- list of weight-calculating functions in order to avoid sorting the package
--- choices multiple times.
+-- choices multiple times. Each function takes the package name, sorted list of
+-- siblings' versions, and package option. 'addWeights' prepends the new
+-- weights to the existing weights, which gives precedence to preferences that
+-- are applied later.
 addWeights :: [PN -> [Ver] -> POption -> Weight] -> Tree a -> Tree a
 addWeights fs = trav go
   where

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -42,6 +42,7 @@ import Distribution.Simple.Setup (BooleanFlag(..))
 #ifdef DEBUG_TRACETREE
 import Distribution.Solver.Modular.Flag
 import qualified Distribution.Solver.Modular.ConflictSet as CS
+import qualified Distribution.Solver.Modular.WeightedPSQ as W
 
 import Debug.Trace.Tree (gtraceJson)
 import Debug.Trace.Tree.Simple
@@ -186,12 +187,15 @@ instance GSimpleTree (Tree QGoalReason) where
   fromGeneric = go
     where
       go :: Tree QGoalReason -> SimpleTree
-      go (PChoice qpn _     psq) = Node "P" $ Assoc $ L.map (uncurry (goP qpn)) $ PSQ.toList psq
-      go (FChoice _   _ _ _ psq) = Node "F" $ Assoc $ L.map (uncurry goFS)      $ PSQ.toList psq
-      go (SChoice _   _ _   psq) = Node "S" $ Assoc $ L.map (uncurry goFS)      $ PSQ.toList psq
+      go (PChoice qpn _     psq) = Node "P" $ Assoc $ L.map (uncurry (goP qpn)) $ psqToList  psq
+      go (FChoice _   _ _ _ psq) = Node "F" $ Assoc $ L.map (uncurry goFS)      $ psqToList  psq
+      go (SChoice _   _ _   psq) = Node "S" $ Assoc $ L.map (uncurry goFS)      $ psqToList  psq
       go (GoalChoice        psq) = Node "G" $ Assoc $ L.map (uncurry goG)       $ PSQ.toList psq
       go (Done _rdm)             = Node "D" $ Assoc []
       go (Fail cs _reason)       = Node "X" $ Assoc [("CS", Leaf $ goCS cs)]
+
+      psqToList :: W.WeightedPSQ w k v -> [(k, v)]
+      psqToList = L.map (\(_, k, v) -> (k, v)) . W.toList
 
       -- Show package choice
       goP :: QPN -> POption -> Tree QGoalReason -> (String, SimpleTree)

--- a/cabal-install/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install/Distribution/Solver/Modular/Tree.hs
@@ -26,7 +26,6 @@ import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Flag
 import Distribution.Solver.Modular.Package
 import Distribution.Solver.Modular.PSQ (PSQ)
-import qualified Distribution.Solver.Modular.PSQ as P
 import Distribution.Solver.Modular.Version
 import Distribution.Solver.Modular.WeightedPSQ (WeightedPSQ)
 import qualified Distribution.Solver.Modular.WeightedPSQ as W
@@ -161,9 +160,9 @@ dchoices :: Tree a -> Degree
 dchoices (PChoice    _ _     ts) = W.degree (W.filter active ts)
 dchoices (FChoice    _ _ _ _ ts) = W.degree (W.filter active ts)
 dchoices (SChoice    _ _ _   ts) = W.degree (W.filter active ts)
-dchoices (GoalChoice         _ ) = P.ZeroOrOne
-dchoices (Done       _         ) = P.ZeroOrOne
-dchoices (Fail       _ _       ) = P.ZeroOrOne
+dchoices (GoalChoice         _ ) = ZeroOrOne
+dchoices (Done       _         ) = ZeroOrOne
+dchoices (Fail       _ _       ) = ZeroOrOne
 
 -- | Variant of 'choices' that only approximates the number of choices.
 zeroOrOneChoices :: Tree a -> Bool

--- a/cabal-install/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install/Distribution/Solver/Modular/Tree.hs
@@ -34,7 +34,10 @@ import Distribution.Solver.Types.PackagePath
 
 type Weight = Double
 
--- | Type of the search tree. Inlining the choice nodes for now.
+-- | Type of the search tree. Inlining the choice nodes for now. Weights on
+-- package, flag, and stanza choices control the traversal order.
+-- TODO: The weight type should be changed from [Double] to Double to avoid
+-- giving too much weight to preferences that are applied later.
 data Tree a =
     -- | Choose a version for a package (or choose to link)
     PChoice QPN a (WeightedPSQ [Weight] POption (Tree a))

--- a/cabal-install/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install/Distribution/Solver/Modular/Tree.hs
@@ -7,7 +7,6 @@ module Distribution.Solver.Modular.Tree
     , Weight
     , ana
     , cata
-    , choices
     , dchoices
     , inn
     , innM
@@ -148,17 +147,8 @@ active :: Tree a -> Bool
 active (Fail _ _) = False
 active _          = True
 
--- | Determines how many active choices are available in a node. Note that we
--- count goal choices as having one choice, always.
-choices :: Tree a -> Int
-choices (PChoice    _ _     ts) = W.length (W.filter active ts)
-choices (FChoice    _ _ _ _ ts) = W.length (W.filter active ts)
-choices (SChoice    _ _ _   ts) = W.length (W.filter active ts)
-choices (GoalChoice         _ ) = 1
-choices (Done       _         ) = 1
-choices (Fail       _ _       ) = 0
-
--- | Variant of 'choices' that only approximates the number of choices.
+-- | Approximates the number of active choices that are available in a node.
+-- Note that we count goal choices as having one choice, always.
 dchoices :: Tree a -> Degree
 dchoices (PChoice    _ _     ts) = W.degree (W.filter active ts)
 dchoices (FChoice    _ _ _ _ ts) = W.degree (W.filter active ts)
@@ -167,7 +157,7 @@ dchoices (GoalChoice         _ ) = ZeroOrOne
 dchoices (Done       _         ) = ZeroOrOne
 dchoices (Fail       _ _       ) = ZeroOrOne
 
--- | Variant of 'choices' that only approximates the number of choices.
+-- | Variant of 'dchoices' that traverses fewer children.
 zeroOrOneChoices :: Tree a -> Bool
 zeroOrOneChoices (PChoice    _ _     ts) = W.isZeroOrOne (W.filter active ts)
 zeroOrOneChoices (FChoice    _ _ _ _ ts) = W.isZeroOrOne (W.filter active ts)

--- a/cabal-install/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install/Distribution/Solver/Modular/Tree.hs
@@ -21,6 +21,7 @@ import Data.Foldable
 import Data.Traversable
 import Prelude hiding (foldr, mapM, sequence)
 
+import Distribution.Solver.Modular.Degree
 import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Flag
 import Distribution.Solver.Modular.Package
@@ -156,7 +157,7 @@ choices (Done       _         ) = 1
 choices (Fail       _ _       ) = 0
 
 -- | Variant of 'choices' that only approximates the number of choices.
-dchoices :: Tree a -> P.Degree
+dchoices :: Tree a -> Degree
 dchoices (PChoice    _ _     ts) = W.degree (W.filter active ts)
 dchoices (FChoice    _ _ _ _ ts) = W.degree (W.filter active ts)
 dchoices (SChoice    _ _ _   ts) = W.degree (W.filter active ts)

--- a/cabal-install/Distribution/Solver/Modular/Validate.hs
+++ b/cabal-install/Distribution/Solver/Modular/Validate.hs
@@ -25,9 +25,9 @@ import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Flag
 import Distribution.Solver.Modular.Index
 import Distribution.Solver.Modular.Package
-import qualified Distribution.Solver.Modular.PSQ as P
 import Distribution.Solver.Modular.Tree
 import Distribution.Solver.Modular.Version (VR)
+import qualified Distribution.Solver.Modular.WeightedPSQ as W
 
 import Distribution.Solver.Types.ComponentDeps (Component)
 
@@ -106,7 +106,7 @@ validate = cata go
   where
     go :: TreeF a (Validate (Tree a)) -> Validate (Tree a)
 
-    go (PChoiceF qpn gr     ts) = PChoice qpn gr <$> sequence (P.mapWithKey (goP qpn) ts)
+    go (PChoiceF qpn gr     ts) = PChoice qpn gr <$> sequence (W.mapWithKey (goP qpn) ts)
     go (FChoiceF qfn gr b m ts) =
       do
         -- Flag choices may occur repeatedly (because they can introduce new constraints
@@ -115,22 +115,22 @@ validate = cata go
         PA _ pfa _ <- asks pa -- obtain current flag-preassignment
         case M.lookup qfn pfa of
           Just rb -> -- flag has already been assigned; collapse choice to the correct branch
-                     case P.lookup rb ts of
+                     case W.lookup rb ts of
                        Just t  -> goF qfn rb t
                        Nothing -> return $ Fail (varToConflictSet (F qfn)) (MalformedFlagChoice qfn)
           Nothing -> -- flag choice is new, follow both branches
-                     FChoice qfn gr b m <$> sequence (P.mapWithKey (goF qfn) ts)
+                     FChoice qfn gr b m <$> sequence (W.mapWithKey (goF qfn) ts)
     go (SChoiceF qsn gr b   ts) =
       do
         -- Optional stanza choices are very similar to flag choices.
         PA _ _ psa <- asks pa -- obtain current stanza-preassignment
         case M.lookup qsn psa of
           Just rb -> -- stanza choice has already been made; collapse choice to the correct branch
-                     case P.lookup rb ts of
+                     case W.lookup rb ts of
                        Just t  -> goS qsn rb t
                        Nothing -> return $ Fail (varToConflictSet (S qsn)) (MalformedStanzaChoice qsn)
           Nothing -> -- stanza choice is new, follow both branches
-                     SChoice qsn gr b <$> sequence (P.mapWithKey (goS qsn) ts)
+                     SChoice qsn gr b <$> sequence (W.mapWithKey (goS qsn) ts)
 
     -- We don't need to do anything for goal choices or failure nodes.
     go (GoalChoiceF              ts) = GoalChoice <$> sequence ts

--- a/cabal-install/Distribution/Solver/Modular/WeightedPSQ.hs
+++ b/cabal-install/Distribution/Solver/Modular/WeightedPSQ.hs
@@ -23,7 +23,7 @@ import Data.Ord (comparing)
 import qualified Data.Traversable as T
 import Prelude hiding (filter, length, lookup)
 
-import Distribution.Solver.Modular.PSQ (Degree(..))
+import Distribution.Solver.Modular.Degree
 
 newtype WeightedPSQ w k v = WeightedPSQ [(w, k, v)]
   deriving (Eq, Show, Functor, F.Foldable, T.Traversable)

--- a/cabal-install/Distribution/Solver/Modular/WeightedPSQ.hs
+++ b/cabal-install/Distribution/Solver/Modular/WeightedPSQ.hs
@@ -67,7 +67,7 @@ mapWeightsWithKey :: Ord w2
 mapWeightsWithKey f (WeightedPSQ xs) = fromList $
                                        L.map (\ (w, k, v) -> (f k w, k, v)) xs
 
-mapWithKey :: (k -> v -> v') -> WeightedPSQ w k v -> WeightedPSQ w k v'
+mapWithKey :: (k -> v1 -> v2) -> WeightedPSQ w k v1 -> WeightedPSQ w k v2
 mapWithKey f (WeightedPSQ xs) = WeightedPSQ $
                                 L.map (\ (w, k, v) -> (w, k, f k v)) xs
 

--- a/cabal-install/Distribution/Solver/Modular/WeightedPSQ.hs
+++ b/cabal-install/Distribution/Solver/Modular/WeightedPSQ.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
+module Distribution.Solver.Modular.WeightedPSQ (
+    WeightedPSQ
+  , filter
+  , fromList
+  , keys
+  , length
+  , degree
+  , isZeroOrOne
+  , lookup
+  , mapWeightsWithKey
+  , mapWithKey
+  , toList
+  , union
+  , weights
+  ) where
+
+-- Association lists that are always sorted by weight.
+
+import qualified Data.Foldable as F
+import qualified Data.List as L
+import Data.Ord (comparing)
+import qualified Data.Traversable as T
+import Prelude hiding (filter, length, lookup)
+
+import Distribution.Solver.Modular.PSQ (Degree(..))
+
+newtype WeightedPSQ w k v = WeightedPSQ [(w, k, v)]
+  deriving (Eq, Show, Functor, F.Foldable, T.Traversable)
+
+filter :: (v -> Bool) -> WeightedPSQ k w v -> WeightedPSQ k w v
+filter p (WeightedPSQ xs) = WeightedPSQ (L.filter (p . triple_3) xs)
+
+length :: WeightedPSQ k w v -> Int
+length (WeightedPSQ xs) = L.length xs
+
+degree :: WeightedPSQ w k v -> Degree
+degree (WeightedPSQ [])     = ZeroOrOne
+degree (WeightedPSQ [_])    = ZeroOrOne
+degree (WeightedPSQ [_, _]) = Two
+degree (WeightedPSQ _)      = Other
+
+isZeroOrOne :: WeightedPSQ w k v -> Bool
+isZeroOrOne (WeightedPSQ [])  = True
+isZeroOrOne (WeightedPSQ [_]) = True
+isZeroOrOne _                 = False
+
+toList :: WeightedPSQ w k v -> [(w, k, v)]
+toList (WeightedPSQ xs) = xs
+
+fromList :: Ord w => [(w, k, v)] -> WeightedPSQ w k v
+fromList = WeightedPSQ . L.sortBy (comparing triple_1)
+
+weights :: WeightedPSQ w k v -> [w]
+weights (WeightedPSQ xs) = L.map triple_1 xs
+
+keys :: WeightedPSQ w k v -> [k]
+keys (WeightedPSQ xs) = L.map triple_2 xs
+
+lookup :: Eq k => k -> WeightedPSQ w k v -> Maybe v
+lookup k (WeightedPSQ xs) = triple_3 `fmap` L.find ((k ==) . triple_2) xs
+
+mapWeightsWithKey :: Ord w2
+                  => (k -> w1 -> w2)
+                  -> WeightedPSQ w1 k v
+                  -> WeightedPSQ w2 k v
+mapWeightsWithKey f (WeightedPSQ xs) = fromList $
+                                       L.map (\ (w, k, v) -> (f k w, k, v)) xs
+
+mapWithKey :: (k -> v -> v') -> WeightedPSQ w k v -> WeightedPSQ w k v'
+mapWithKey f (WeightedPSQ xs) = WeightedPSQ $
+                                L.map (\ (w, k, v) -> (w, k, f k v)) xs
+
+union :: Ord w => WeightedPSQ w k v -> WeightedPSQ w k v -> WeightedPSQ w k v
+union (WeightedPSQ xs) (WeightedPSQ ys) = fromList (xs ++ ys)
+
+triple_1 :: (x, y, z) -> x
+triple_1 (x, _, _) = x
+
+triple_2 :: (x, y, z) -> y
+triple_2 (_, y, _) = y
+
+triple_3 :: (x, y, z) -> z
+triple_3 (_, _, z) = z

--- a/cabal-install/Distribution/Solver/Modular/WeightedPSQ.hs
+++ b/cabal-install/Distribution/Solver/Modular/WeightedPSQ.hs
@@ -5,7 +5,6 @@ module Distribution.Solver.Modular.WeightedPSQ (
   , toList
   , keys
   , weights
-  , length
   , degree
   , isZeroOrOne
   , filter
@@ -19,7 +18,7 @@ import qualified Data.Foldable as F
 import qualified Data.List as L
 import Data.Ord (comparing)
 import qualified Data.Traversable as T
-import Prelude hiding (filter, length, lookup)
+import Prelude hiding (filter, lookup)
 
 import Distribution.Solver.Modular.Degree
 
@@ -33,10 +32,6 @@ newtype WeightedPSQ w k v = WeightedPSQ [(w, k, v)]
 -- | /O(N)/.
 filter :: (v -> Bool) -> WeightedPSQ k w v -> WeightedPSQ k w v
 filter p (WeightedPSQ xs) = WeightedPSQ (L.filter (p . triple_3) xs)
-
--- | /O(N)/.
-length :: WeightedPSQ k w v -> Int
-length (WeightedPSQ xs) = L.length xs
 
 -- | /O(1)/. Return the length as a 'Degree' after traversing as few elements
 -- as possible.

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -428,6 +428,7 @@ Test-Suite unit-tests
     UnitTests.Distribution.Solver.Modular.RetryLog
     UnitTests.Distribution.Solver.Modular.Solver
     UnitTests.Distribution.Solver.Modular.DSL
+    UnitTests.Distribution.Solver.Modular.WeightedPSQ
     UnitTests.Options
   build-depends:
         base,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -335,6 +335,7 @@ executable cabal
         Distribution.Solver.Modular.Validate
         Distribution.Solver.Modular.Var
         Distribution.Solver.Modular.Version
+        Distribution.Solver.Modular.WeightedPSQ
         Paths_cabal_install
 
     -- NOTE: when updating build-depends, don't forget to update version regexps

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -317,6 +317,7 @@ executable cabal
         Distribution.Solver.Modular.ConfiguredConversion
         Distribution.Solver.Modular.ConflictSet
         Distribution.Solver.Modular.Cycles
+        Distribution.Solver.Modular.Degree
         Distribution.Solver.Modular.Dependency
         Distribution.Solver.Modular.Explore
         Distribution.Solver.Modular.Flag

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -11,6 +11,7 @@ import Distribution.Verbosity
 import Distribution.Compat.Time
 
 import qualified UnitTests.Distribution.Solver.Modular.PSQ
+import qualified UnitTests.Distribution.Solver.Modular.WeightedPSQ
 import qualified UnitTests.Distribution.Solver.Modular.Solver
 import qualified UnitTests.Distribution.Solver.Modular.RetryLog
 import qualified UnitTests.Distribution.Client.FileMonitor
@@ -38,6 +39,8 @@ tests mtimeChangeCalibrated =
   testGroup "Unit Tests"
   [ testGroup "UnitTests.Distribution.Solver.Modular.PSQ"
         UnitTests.Distribution.Solver.Modular.PSQ.tests
+  , testGroup "UnitTests.Distribution.Solver.Modular.WeightedPSQ"
+        UnitTests.Distribution.Solver.Modular.WeightedPSQ.tests
   , testGroup "UnitTests.Distribution.Solver.Modular.Solver"
         UnitTests.Distribution.Solver.Modular.Solver.tests
   , testGroup "UnitTests.Distribution.Solver.Modular.RetryLog"

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/WeightedPSQ.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/WeightedPSQ.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE ParallelListComp #-}
+module UnitTests.Distribution.Solver.Modular.WeightedPSQ (
+  tests
+  ) where
+
+import qualified Distribution.Solver.Modular.WeightedPSQ as W
+
+import Data.List (sort)
+
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (testCase, (@?=))
+import Test.Tasty.QuickCheck (Blind(..), testProperty)
+
+tests :: [TestTree]
+tests = [
+    testProperty "'toList . fromList' preserves elements" $ \xs ->
+        sort (xs :: [(Int, Char, Bool)]) == sort (W.toList (W.fromList xs))
+
+  , testProperty "'toList . fromList' sorts stably" $ \xs ->
+        let indexAsValue :: [(Int, (), Int)]
+            indexAsValue = [(x, (), i) | x <- xs | i <- [0..]]
+        in isSorted $ W.toList $ W.fromList indexAsValue
+
+  , testProperty "'mapWeightsWithKey' sorts by weight" $ \xs (Blind f) ->
+        isSorted $ W.weights $
+        W.mapWeightsWithKey (f :: Int -> Int -> Int) $
+        W.fromList (xs :: [(Int, Int, Int)])
+
+  , testCase "applying 'mapWeightsWithKey' twice sorts twice" $
+        let indexAsKey :: [((), Int, ())]
+            indexAsKey = [((), i, ()) | i <- [0..10]]
+            actual = W.toList $
+                     W.mapWeightsWithKey (\_ _ -> ()) $
+                     W.mapWeightsWithKey (\i _ -> -i) $ -- should not be ignored
+                     W.fromList indexAsKey
+        in reverse indexAsKey @?= actual
+
+  , testProperty "'union' sorts by weight" $ \xs ys ->
+        isSorted $ W.weights $
+        W.union (W.fromList xs) (W.fromList (ys :: [(Int, Int, Int)]))
+
+  , testProperty "'union' preserves elements" $ \xs ys ->
+        let union = W.union (W.fromList xs)
+                            (W.fromList (ys :: [(Int, Int, Int)]))
+        in sort (xs ++ ys) == sort (W.toList union)
+
+  , testCase "'lookup' returns first occurrence" $
+        let xs = W.fromList [((), False, 'A'), ((), True, 'C'), ((), True, 'B')]
+        in Just 'C' @?= W.lookup True xs
+  ]
+
+isSorted :: Ord a => [a] -> Bool
+isSorted (x1 : xs@(x2 : _)) = x1 <= x2 && isSorted xs
+isSorted _ = True


### PR DESCRIPTION
I split this out from #2917 because the data structure is also needed for goal-scoring (#3488).  `WeightedPSQ` associates weights with choices in the search tree.  This PR uses `WeightedPSQ` for package, flag, and stanza choices and `PSQ` for goal choices, but eventually all choices should use `WeightedPSQ`.  There are a few TODOs in the code.

/cc @kosmikus 

EDIT: This PR uses `[Double]` as the weight type to avoid changing the behavior of the solver.