### PR TITLE
Refactor LocalBuildInfo interface.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -370,6 +370,7 @@ library
     Distribution.Types.ComponentLocalBuildInfo
     Distribution.Types.LocalBuildInfo
     Distribution.Types.ComponentEnabledSpec
+    Distribution.Types.TargetInfo
     Distribution.Utils.NubList
     Distribution.Verbosity
     Distribution.Version

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -77,6 +77,8 @@ import Distribution.Simple.Register (createInternalPackageDB)
 import Distribution.System
 import Distribution.Version
 import Distribution.Verbosity
+import qualified Distribution.Compat.Graph as Graph
+import Distribution.Compat.Graph (Node(..))
 
 import qualified Distribution.Simple.GHC   as GHC
 import qualified Distribution.Simple.GHCJS as GHCJS
@@ -98,7 +100,7 @@ import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy.Char8 as BLC8
 import Data.List
-    ( (\\), nub, partition, isPrefixOf, inits, stripPrefix )
+    ( (\\), nub, partition, isPrefixOf, inits, stripPrefix, foldl' )
 import Data.Maybe
     ( isNothing, catMaybes, fromMaybe, mapMaybe, isJust )
 import Data.Either
@@ -127,8 +129,6 @@ import Text.PrettyPrint
     , punctuate, quotes, render, renderStyle, sep, text )
 import Distribution.Compat.Environment ( lookupEnv )
 import Distribution.Compat.Exception ( catchExit, catchIO )
-
-import Data.Graph (graphFromEdges, topSort)
 
 -- | The errors that can be thrown when reading the @setup-config@ file.
 data ConfigStateFileError
@@ -673,6 +673,10 @@ configure (pkg_descr0', pbi) cfg = do
             then return False
             else return True
 
+    let buildComponentsMap =
+            foldl' (\m clbi -> Map.insertWith (++) (componentLocalName clbi) [clbi] m)
+                   Map.empty buildComponents
+
     let lbi = LocalBuildInfo {
                 configFlags         = cfg',
                 flagAssignment      = flags,
@@ -684,7 +688,8 @@ configure (pkg_descr0', pbi) cfg = do
                 compiler            = comp,
                 hostPlatform        = compPlatform,
                 buildDir            = buildDir,
-                componentsConfigs   = buildComponents,
+                componentGraph      = Graph.fromList buildComponents,
+                componentNameMap    = buildComponentsMap,
                 installedPkgs       = packageDependsIndex,
                 pkgDescrFile        = Nothing,
                 localPkgDescr       = pkg_descr',
@@ -1449,12 +1454,12 @@ mkComponentsGraph :: ComponentEnabledSpec
                   -> Either [ComponentName]
                             [(Component, [ComponentName])]
 mkComponentsGraph enabled pkg_descr internalPkgDeps =
-    let graph = [ (c, componentName c, componentDeps c)
-                | c <- pkgBuildableComponents pkg_descr
-                , componentEnabled enabled c ]
-     in case checkComponentsCyclic graph of
-          Just ccycle -> Left  [ cname | (_,cname,_) <- ccycle ]
-          Nothing     -> Right [ (c, cdeps) | (c, _, cdeps) <- topSortFromEdges graph ]
+    let g = Graph.fromList [ N c (componentName c) (componentDeps c)
+                           | c <- pkgBuildableComponents pkg_descr
+                           , componentEnabled enabled c ]
+    in case Graph.cycles g of
+          []     -> Right (map (\(N c _ cs) -> (c, cs)) (Graph.revTopSort g))
+          ccycles -> Left  [ componentName c | N c _ _ <- concat ccycles ]
   where
     -- The dependencies for the given component
     componentDeps component =
@@ -1640,13 +1645,6 @@ computeCompatPackageKey comp pkg_name pkg_version (SimpleUnitId (ComponentId str
         in fromMaybe rehashed_key (mb_verbatim_key `mplus` mb_truncated_key)
     | otherwise = str
 
-
-topSortFromEdges :: Ord key => [(node, key, [key])]
-                            -> [(node, key, [key])]
-topSortFromEdges es =
-    let (graph, vertexToNode, _) = graphFromEdges es
-    in reverse (map vertexToNode (topSort graph))
-
 mkComponentsLocalBuildInfo :: ConfigFlags
                            -> Compiler
                            -> InstalledPackageIndex
@@ -1655,32 +1653,32 @@ mkComponentsLocalBuildInfo :: ConfigFlags
                            -> [InstalledPackageInfo] -- external package deps
                            -> [(Component, [ComponentName])]
                            -> FlagAssignment
-                           -> IO [(ComponentLocalBuildInfo,
-                                   [UnitId])]
+                           -> IO [ComponentLocalBuildInfo]
 mkComponentsLocalBuildInfo cfg comp installedPackages pkg_descr
                            internalPkgDeps externalPkgDeps
                            graph flagAssignment =
     foldM go [] graph
   where
     go z (component, dep_cnames) = do
-        clbi <- componentLocalBuildInfo z component
         -- NB: We want to preserve cdeps because it contains extra
         -- information like build-tools ordering
         let dep_uids = [ componentUnitId dep_clbi
                        | cname <- dep_cnames
                        -- Being in z relies on topsort!
-                       , (dep_clbi, _) <- z
+                       , dep_clbi <- z
                        , componentLocalName dep_clbi == cname ]
-        return ((clbi, dep_uids):z)
+        clbi <- componentLocalBuildInfo z component dep_uids
+        return (clbi:z)
 
     -- The allPkgDeps contains all the package deps for the whole package
     -- but we need to select the subset for this specific component.
     -- we just take the subset for the package names this component
     -- needs. Note, this only works because we cannot yet depend on two
     -- versions of the same package.
-    componentLocalBuildInfo :: [(ComponentLocalBuildInfo, [UnitId])]
-                            -> Component -> IO ComponentLocalBuildInfo
-    componentLocalBuildInfo internalComps component =
+    componentLocalBuildInfo :: [ComponentLocalBuildInfo]
+                            -> Component -> [UnitId] -> IO ComponentLocalBuildInfo
+    componentLocalBuildInfo internalComps component dep_uids =
+      -- (putStrLn $ "configuring " ++ display (componentName component)) >>
       case component of
       CLib lib -> do
         let exports = map (\n -> Installed.ExposedModule n Nothing)
@@ -1695,6 +1693,7 @@ mkComponentsLocalBuildInfo cfg comp installedPackages pkg_descr
 
         return LibComponentLocalBuildInfo {
           componentPackageDeps = cpds,
+          componentInternalDeps = dep_uids,
           componentUnitId = uid,
           componentLocalName = componentName component,
           componentIsPublic = libName lib == Nothing,
@@ -1706,6 +1705,7 @@ mkComponentsLocalBuildInfo cfg comp installedPackages pkg_descr
       CExe _ ->
         return ExeComponentLocalBuildInfo {
           componentUnitId = uid,
+          componentInternalDeps = dep_uids,
           componentLocalName = componentName component,
           componentPackageDeps = cpds,
           componentIncludes = includes
@@ -1713,6 +1713,7 @@ mkComponentsLocalBuildInfo cfg comp installedPackages pkg_descr
       CTest _ ->
         return TestComponentLocalBuildInfo {
           componentUnitId = uid,
+          componentInternalDeps = dep_uids,
           componentLocalName = componentName component,
           componentPackageDeps = cpds,
           componentIncludes = includes
@@ -1720,6 +1721,7 @@ mkComponentsLocalBuildInfo cfg comp installedPackages pkg_descr
       CBench _ ->
         return BenchComponentLocalBuildInfo {
           componentUnitId = uid,
+          componentInternalDeps = dep_uids,
           componentLocalName = componentName component,
           componentPackageDeps = cpds,
           componentIncludes = includes
@@ -1740,7 +1742,7 @@ mkComponentsLocalBuildInfo cfg comp installedPackages pkg_descr
 
         lookupInternalPkg :: PackageId -> UnitId
         lookupInternalPkg pkgid = do
-            let matcher (clbi, _)
+            let matcher clbi
                     | CLibName <- componentLocalName clbi
                     , pkgName pkgid == packageName pkg_descr
                     = Just (componentUnitId clbi)
@@ -1750,7 +1752,9 @@ mkComponentsLocalBuildInfo cfg comp installedPackages pkg_descr
                 matcher _ = Nothing
             case catMaybes (map matcher internalComps) of
                 [x] -> x
-                _ -> error "lookupInternalPkg"
+                _ -> error $ "lookupInternalPkg " ++ display pkgid
+                          ++ " " ++ intercalate ", "
+                            (map (display . componentUnitId) internalComps)
 
         cpds = if newPackageDepsBehaviour pkg_descr
                then dedup $

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -72,6 +72,7 @@ import Distribution.Simple.Program
 import Distribution.Simple.Setup as Setup
 import qualified Distribution.Simple.InstallDirs as InstallDirs
 import Distribution.Simple.LocalBuildInfo
+import Distribution.Types.LocalBuildInfo
 import Distribution.Simple.Utils
 import Distribution.Simple.Register (createInternalPackageDB)
 import Distribution.System
@@ -237,7 +238,7 @@ writePersistBuildConfig distPref lbi = do
     writeFileAtomic (localBuildInfoFile distPref) $
       BLC8.unlines [showHeader pkgId, encode lbi]
   where
-    pkgId = packageId $ localPkgDescr lbi
+    pkgId = localPackage lbi
 
 -- | Identifier of the current Cabal package.
 currentCabalId :: PackageIdentifier

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -518,7 +518,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
       -- has the package name.  I'm going to avoid changing this for
       -- now, but it would probably be better for this to be the
       -- component ID instead...
-      pkg_name = display $ PD.package $ localPkgDescr lbi
+      pkg_name = display (PD.package pkg_descr)
       distPref = fromFlag $ configDistPref $ configFlags lbi
       hpcdir way
         | forRepl = Mon.mempty  -- HPC is not supported in ghci

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -266,7 +266,7 @@ replLib  = buildOrReplLib True
 buildOrReplLib :: Bool -> Verbosity  -> Cabal.Flag (Maybe Int)
                -> PackageDescription -> LocalBuildInfo
                -> Library            -> ComponentLocalBuildInfo -> IO ()
-buildOrReplLib forRepl verbosity numJobs _pkg_descr lbi lib clbi = do
+buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
   let uid = componentUnitId clbi
       libTargetDir = buildDir lbi
       whenVanillaLib forceVanilla =
@@ -294,7 +294,7 @@ buildOrReplLib forRepl verbosity numJobs _pkg_descr lbi lib clbi = do
   -- Determine if program coverage should be enabled and if so, what
   -- '-hpcdir' should be.
   let isCoverageEnabled = fromFlag $ configCoverage $ configFlags lbi
-      pkg_name = display $ PD.package $ localPkgDescr lbi
+      pkg_name = display $ PD.package pkg_descr
       distPref = fromFlag $ configDistPref $ configFlags lbi
       hpcdir way
         | isCoverageEnabled = toFlag $ Hpc.mixDir distPref way pkg_name

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -64,7 +64,7 @@ install :: PackageDescription -- ^information from the .cabal file
 install pkg_descr lbi flags
  | fromFlag (copyAssumeDepsUpToDate flags) = do
   checkHasLibsOrExes
-  targets <- readTargetInfos verbosity lbi (copyArgs flags)
+  targets <- readTargetInfos verbosity pkg_descr lbi (copyArgs flags)
   case targets of
     _ | null (copyArgs flags)
       -> copyPackage verbosity pkg_descr lbi distPref copydest
@@ -76,12 +76,12 @@ install pkg_descr lbi flags
 
  | otherwise = do
   checkHasLibsOrExes
-  targets <- readTargetInfos verbosity lbi (copyArgs flags)
+  targets <- readTargetInfos verbosity pkg_descr lbi (copyArgs flags)
 
   copyPackage verbosity pkg_descr lbi distPref copydest
 
   -- It's not necessary to do these in build-order, but it's harmless
-  withNeededTargetsInBuildOrder lbi (map nodeKey targets) $ \target ->
+  withNeededTargetsInBuildOrder' pkg_descr lbi (map nodeKey targets) $ \target ->
     let comp = targetComponent target
         clbi = targetCLBI target
     in copyComponent verbosity pkg_descr lbi comp clbi copydest

--- a/Cabal/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Simple/LocalBuildInfo.hs
@@ -32,7 +32,6 @@ module Distribution.Simple.LocalBuildInfo (
         showComponentName,
         componentNameString,
         ComponentLocalBuildInfo(..),
-        getLocalComponent,
         componentComponentId,
         componentBuildDir,
         foldComponent,
@@ -43,12 +42,9 @@ module Distribution.Simple.LocalBuildInfo (
         pkgBuildableComponents,
         lookupComponent,
         getComponent,
-        maybeGetDefaultLibraryLocalBuildInfo,
-        maybeGetComponentLocalBuildInfo,
         getComponentLocalBuildInfo,
         allComponentsInBuildOrder,
         componentsInBuildOrder,
-        checkComponentsCyclic,
         depLibraryPaths,
 
         withAllComponentsInBuildOrder,
@@ -60,7 +56,6 @@ module Distribution.Simple.LocalBuildInfo (
         withTestLBI,
         enabledTestLBIs,
         enabledBenchLBIs,
-        enabledComponents,
 
         -- TODO: Don't export me
         ComponentEnabledSpec(..),
@@ -84,6 +79,7 @@ import Distribution.Types.ComponentEnabledSpec
 import Distribution.Types.PackageDescription
 import Distribution.Types.ComponentLocalBuildInfo
 import Distribution.Types.LocalBuildInfo
+import Distribution.Types.TargetInfo
 
 import Distribution.Simple.InstallDirs hiding (absoluteInstallDirs,
                                                prefixRelativeInstallDirs,
@@ -95,21 +91,19 @@ import Distribution.Package
 import Distribution.Simple.Compiler
 import Distribution.Simple.PackageIndex
 import Distribution.Simple.Utils
+import Distribution.Text
+import qualified Distribution.Compat.Graph as Graph
+import Distribution.Compat.Graph (IsNode(..))
 
-import Data.Array ((!))
-import Data.Graph
 import Data.List (stripPrefix)
 import Data.Maybe
-import Data.Tree  (flatten)
 import System.FilePath
+import qualified Data.Map as Map
 
 import System.Directory (doesDirectoryExist, canonicalizePath)
 
 -- -----------------------------------------------------------------------------
 -- Configuration information of buildable components
-
-getLocalComponent :: PackageDescription -> ComponentLocalBuildInfo -> Component
-getLocalComponent pkg_descr clbi = getComponent pkg_descr (componentLocalName clbi)
 
 componentBuildDir :: LocalBuildInfo -> ComponentLocalBuildInfo -> FilePath
 -- For now, we assume that libraries/executables/test-suites/benchmarks
@@ -123,61 +117,39 @@ componentBuildDir lbi clbi
                         CTestName s  -> s
                         CBenchName s -> s
 
+{-# DEPRECATED getComponentLocalBuildInfo "This function is not well-defined, because a 'ComponentName' does not uniquely identify a 'ComponentLocalBuildInfo'.  If you have a 'TargetInfo', you should use 'targetCLBI' to get the 'ComponentLocalBuildInfo'.  Otherwise, use 'componentNameTargets' to get all possible 'ComponentLocalBuildInfo's.  This will be removed in Cabal 2.2." #-}
 getComponentLocalBuildInfo :: LocalBuildInfo -> ComponentName -> ComponentLocalBuildInfo
 getComponentLocalBuildInfo lbi cname =
-    case maybeGetComponentLocalBuildInfo lbi cname of
-      Just clbi -> clbi
-      Nothing   ->
+    case componentNameTargets lbi cname of
+      [target] -> targetCLBI target
+      [] ->
           error $ "internal error: there is no configuration data "
                ++ "for component " ++ show cname
-
-maybeGetComponentLocalBuildInfo
-    :: LocalBuildInfo -> ComponentName -> Maybe ComponentLocalBuildInfo
-maybeGetComponentLocalBuildInfo lbi cname =
-    case [ clbi
-         | (clbi, _) <- componentsConfigs lbi
-         , cid <- componentNameToUnitIds lbi cname
-         , cid == componentUnitId clbi ] of
-      [clbi] -> Just clbi
-      _      -> Nothing
-
-maybeGetDefaultLibraryLocalBuildInfo
-    :: LocalBuildInfo
-    -> Maybe ComponentLocalBuildInfo
-maybeGetDefaultLibraryLocalBuildInfo lbi =
-    case [ clbi
-         | (clbi@LibComponentLocalBuildInfo{}, _) <- componentsConfigs lbi
-         , componentIsPublic clbi
-         ] of
-      [clbi] -> Just clbi
-      _ -> Nothing
-
-componentNameToUnitIds :: LocalBuildInfo -> ComponentName -> [UnitId]
-componentNameToUnitIds lbi cname =
-    [ componentUnitId clbi
-    | (clbi, _) <- componentsConfigs lbi
-    , componentName (getLocalComponent (localPkgDescr lbi) clbi) == cname ]
+      targets ->
+          error $ "internal error: the component name " ++ show cname
+               ++ "is ambiguous.  Refers to: "
+               ++ intercalate ", " (map (display . nodeKey) targets)
 
 -- | Perform the action on each enabled 'library' in the package
 -- description with the 'ComponentLocalBuildInfo'.
 withLibLBI :: PackageDescription -> LocalBuildInfo
            -> (Library -> ComponentLocalBuildInfo -> IO ()) -> IO ()
-withLibLBI pkg lbi f =
-    sequence_
-        [ f lib clbi
-        | (clbi@LibComponentLocalBuildInfo{}, _) <- componentsConfigs lbi
-        , CLib lib <- [getComponent pkg (componentLocalName clbi)] ]
+withLibLBI _pkg lbi f =
+    withAllTargetsInBuildOrder lbi $ \target ->
+        case targetComponent target of
+            CLib lib -> f lib (targetCLBI target)
+            _ -> return ()
 
 -- | Perform the action on each enabled 'Executable' in the package
 -- description.  Extended version of 'withExe' that also gives corresponding
 -- build info.
 withExeLBI :: PackageDescription -> LocalBuildInfo
            -> (Executable -> ComponentLocalBuildInfo -> IO ()) -> IO ()
-withExeLBI pkg lbi f =
-    sequence_
-        [ f exe clbi
-        | (clbi@ExeComponentLocalBuildInfo{}, _) <- componentsConfigs lbi
-        , CExe exe <- [getComponent pkg (componentLocalName clbi)] ]
+withExeLBI _pkg lbi f =
+    withAllTargetsInBuildOrder lbi $ \target ->
+        case targetComponent target of
+            CExe exe -> f exe (targetCLBI target)
+            _ -> return ()
 
 -- | Perform the action on each enabled 'Benchmark' in the package
 -- description.
@@ -193,28 +165,17 @@ withTestLBI pkg lbi f =
 
 enabledTestLBIs :: PackageDescription -> LocalBuildInfo
              -> [(TestSuite, ComponentLocalBuildInfo)]
-enabledTestLBIs pkg lbi =
-        [ (test, clbi)
-        | (clbi@TestComponentLocalBuildInfo{}, _) <- componentsConfigs lbi
-        , CTest test <- [getComponent pkg (componentLocalName clbi)] ]
+enabledTestLBIs _pkg lbi =
+    [ (test, targetCLBI target)
+    | target <- allTargetsInBuildOrder lbi
+    , CTest test <- [targetComponent target] ]
 
 enabledBenchLBIs :: PackageDescription -> LocalBuildInfo
              -> [(Benchmark, ComponentLocalBuildInfo)]
-enabledBenchLBIs pkg lbi =
-        [ (test, clbi)
-        | (clbi@BenchComponentLocalBuildInfo{}, _) <- componentsConfigs lbi
-        , CBench test <- [getComponent pkg (componentLocalName clbi)] ]
-
--- | Get a list of all enabled 'Component's (both buildable and
--- requested by the user at configure-time).
---
--- @since 2.0.0.0
-enabledComponents :: PackageDescription -> LocalBuildInfo
-                  -> [Component]
-enabledComponents pkg lbi =
-        [ getComponent pkg (componentLocalName clbi)
-        | (clbi, _) <- componentsConfigs lbi ]
-
+enabledBenchLBIs _pkg lbi =
+    [ (bench, targetCLBI target)
+    | target <- allTargetsInBuildOrder lbi
+    , CBench bench <- [targetComponent target] ]
 
 {-# DEPRECATED withComponentsLBI "Use withAllComponentsInBuildOrder" #-}
 withComponentsLBI :: PackageDescription -> LocalBuildInfo
@@ -228,67 +189,40 @@ withComponentsLBI = withAllComponentsInBuildOrder
 withAllComponentsInBuildOrder :: PackageDescription -> LocalBuildInfo
                               -> (Component -> ComponentLocalBuildInfo -> IO ())
                               -> IO ()
-withAllComponentsInBuildOrder pkg lbi f =
-    sequence_
-      [ f (getLocalComponent pkg clbi) clbi
-      | clbi <- allComponentsInBuildOrder lbi ]
+withAllComponentsInBuildOrder _pkg lbi f =
+    withAllTargetsInBuildOrder lbi $ \target ->
+        f (targetComponent target) (targetCLBI target)
 
+{-# DEPRECATED withComponentsInBuildOrder "You have got a 'TargetInfo' right? Use 'withNeededTargetsInBuildOrder' on the 'UnitId's you can 'nodeKey' out." #-}
 withComponentsInBuildOrder :: PackageDescription -> LocalBuildInfo
                            -> [ComponentName]
                            -> (Component -> ComponentLocalBuildInfo -> IO ())
                            -> IO ()
-withComponentsInBuildOrder pkg lbi cnames f =
-    sequence_
-      [ f (getLocalComponent pkg clbi) clbi
-      | clbi <- componentsInBuildOrder lbi cnames ]
+withComponentsInBuildOrder _pkg lbi cnames f =
+    withNeededTargetsInBuildOrder lbi uids $ \target ->
+        f (targetComponent target) (targetCLBI target)
+  where uids = concatMap (componentNameToUnitIds lbi) cnames
 
 allComponentsInBuildOrder :: LocalBuildInfo
                           -> [ComponentLocalBuildInfo]
 allComponentsInBuildOrder lbi =
-    componentsInBuildOrder' lbi
-      [ componentUnitId clbi | (clbi, _) <- componentsConfigs lbi ]
+    Graph.topSort (componentGraph lbi)
 
+-- | Private helper function for some of the deprecated implementations.
+componentNameToUnitIds :: LocalBuildInfo -> ComponentName -> [UnitId]
+componentNameToUnitIds lbi cname =
+    case Map.lookup cname (componentNameMap lbi) of
+        Just clbis -> map componentUnitId clbis
+        Nothing -> error $ "componentNameToUnitIds " ++ display cname
+
+{-# DEPRECATED componentsInBuildOrder "You've got 'TargetInfo' right? Use 'neededTargetsInBuildOrder' on the 'UnitId's you can 'nodeKey' out." #-}
 componentsInBuildOrder :: LocalBuildInfo -> [ComponentName]
                        -> [ComponentLocalBuildInfo]
-componentsInBuildOrder lbi cnames =
-    componentsInBuildOrder' lbi
-        (concatMap (componentNameToUnitIds lbi) cnames)
+componentsInBuildOrder lbi cnames = map targetCLBI (neededTargetsInBuildOrder lbi uids)
+  where uids = concatMap (componentNameToUnitIds lbi) cnames
 
-componentsInBuildOrder' :: LocalBuildInfo -> [UnitId]
-                       -> [ComponentLocalBuildInfo]
-componentsInBuildOrder' lbi cids =
-      map ((\(clbi,_,_) -> clbi) . vertexToNode)
-    . postOrder graph
-    . map (\cid -> fromMaybe (noSuchComp cid) (keyToVertex cid))
-    $ cids
-  where
-    (graph, vertexToNode, keyToVertex) =
-      graphFromEdges (map (\(clbi,internal_deps) ->
-                            (clbi,componentUnitId clbi,internal_deps)) (componentsConfigs lbi))
-
-    noSuchComp cid = error $ "internal error: componentsInBuildOrder: "
-                            ++ "no such component: " ++ show cid
-
-    postOrder :: Graph -> [Vertex] -> [Vertex]
-    postOrder g vs = postorderF (dfs g vs) []
-
-    postorderF   :: Forest a -> [a] -> [a]
-    postorderF ts = foldr (.) id $ map postorderT ts
-
-    postorderT :: Tree a -> [a] -> [a]
-    postorderT (Node a ts) = postorderF ts . (a :)
-
-checkComponentsCyclic :: Ord key => [(node, key, [key])]
-                      -> Maybe [(node, key, [key])]
-checkComponentsCyclic es =
-    let (graph, vertexToNode, _) = graphFromEdges es
-        cycles                   = [ flatten c | c <- scc graph, isCycle c ]
-        isCycle (Node v [])      = selfCyclic v
-        isCycle _                = True
-        selfCyclic v             = v `elem` graph ! v
-     in case cycles of
-         []    -> Nothing
-         (c:_) -> Just (map vertexToNode c)
+-- -----------------------------------------------------------------------------
+-- A random function that has no business in this module
 
 -- | Determine the directories containing the dynamic libraries of the
 -- transitive dependencies of the component we are building.
@@ -308,15 +242,10 @@ depLibraryPaths inplace relative lbi clbi = do
         relDir | executable = bindir installDirs
                | otherwise  = libdir installDirs
 
-    let -- TODO: this is kind of inefficient
-        internalDeps = [ cid
-                       | (cid, _) <- componentPackageDeps clbi
-                       -- Test that it's internal
-                       , (sub_clbi, _) <- componentsConfigs lbi
-                       , componentUnitId sub_clbi == cid ]
-        internalLibs = [ getLibDir sub_clbi
-                       | sub_clbi <- componentsInBuildOrder'
-                                        lbi internalDeps ]
+    let internalCLBIs = filter ((/= componentUnitId clbi) . componentUnitId)
+                      . map targetCLBI
+                      $ neededTargetsInBuildOrder lbi [componentUnitId clbi]
+        internalLibs = map getLibDir internalCLBIs
         getLibDir sub_clbi
           | inplace    = componentBuildDir lbi sub_clbi
           | otherwise  = libdir (absoluteComponentInstallDirs pkgDescr lbi (componentUnitId sub_clbi) NoCopyDest)

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -94,7 +94,7 @@ register pkg_descr lbi flags = when (hasPublicLib pkg_descr) doRegister
   -- usefully (they're not public.)  If we start supporting scoped
   -- packages, we'll have to relax this.
   doRegister = do
-    targets <- readTargetInfos verbosity lbi (regArgs flags)
+    targets <- readTargetInfos verbosity pkg_descr lbi (regArgs flags)
 
     -- It's important to register in build order, because ghc-pkg
     -- will complain if a dependency is not registered.
@@ -117,7 +117,7 @@ register pkg_descr lbi flags = when (hasPublicLib pkg_descr) doRegister
             _ -> die "In --assume-deps-up-to-date mode you can only register a single target"
         else fmap catMaybes
            . mapM maybeGenerateOne
-           $ neededTargetsInBuildOrder lbi (map nodeKey targets)
+           $ neededTargetsInBuildOrder' pkg_descr lbi (map nodeKey targets)
     registerAll pkg_descr lbi flags ipis
     return ()
    where

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -44,6 +44,9 @@ module Distribution.Simple.Register (
     generalInstalledPackageInfo,
   ) where
 
+import Distribution.Types.TargetInfo
+import Distribution.Types.LocalBuildInfo
+
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.BuildPaths
 
@@ -67,6 +70,7 @@ import Distribution.Simple.Utils
 import Distribution.System
 import Distribution.Text
 import Distribution.Verbosity as Verbosity
+import Distribution.Compat.Graph (IsNode(nodeKey))
 
 import System.FilePath ((</>), (<.>), isAbsolute)
 import System.Directory
@@ -90,22 +94,22 @@ register pkg_descr lbi flags = when (hasPublicLib pkg_descr) doRegister
   -- usefully (they're not public.)  If we start supporting scoped
   -- packages, we'll have to relax this.
   doRegister = do
-    targets <- readBuildTargets pkg_descr (regArgs flags)
-    targets' <- checkBuildTargets verbosity pkg_descr lbi targets
+    targets <- readTargetInfos verbosity lbi (regArgs flags)
 
     -- It's important to register in build order, because ghc-pkg
     -- will complain if a dependency is not registered.
-    let maybeGenerateOne clbi
-            | CLib lib <- getLocalComponent pkg_descr clbi
+    let maybeGenerateOne target
+            | CLib lib <- targetComponent target
             = fmap Just (generateOne pkg_descr lib lbi clbi flags)
             | otherwise = return Nothing
+          where clbi = targetCLBI target
 
     ipis <-
       if fromFlag (regAssumeDepsUpToDate flags)
         then
-          case targets' of
-            [(cname, _)] -> do
-                mb_ipi <- maybeGenerateOne (getComponentLocalBuildInfo lbi cname)
+          case targets of
+            [target] -> do
+                mb_ipi <- maybeGenerateOne target
                 case mb_ipi of
                     Nothing -> die "Cannot --assume-deps-up-to-date register non-library target"
                     Just ipi -> return [ipi]
@@ -113,7 +117,7 @@ register pkg_descr lbi flags = when (hasPublicLib pkg_descr) doRegister
             _ -> die "In --assume-deps-up-to-date mode you can only register a single target"
         else fmap catMaybes
            . mapM maybeGenerateOne
-           $ componentsInBuildOrder lbi (map fst targets')
+           $ neededTargetsInBuildOrder lbi (map nodeKey targets)
     registerAll pkg_descr lbi flags ipis
     return ()
    where

--- a/Cabal/Distribution/Simple/Test/ExeV10.hs
+++ b/Cabal/Distribution/Simple/Test/ExeV10.hs
@@ -30,10 +30,11 @@ import System.IO ( hGetContents, hPutStr, stdout, stderr )
 
 runTest :: PD.PackageDescription
         -> LBI.LocalBuildInfo
+        -> LBI.ComponentLocalBuildInfo
         -> TestFlags
         -> PD.TestSuite
         -> IO TestSuiteLog
-runTest pkg_descr lbi flags suite = do
+runTest pkg_descr lbi clbi flags suite = do
     let isCoverageEnabled = fromFlag $ configCoverage $ LBI.configFlags lbi
         way = guessWay lbi
         tixDir_ = tixDir distPref way $ PD.testName suite
@@ -86,8 +87,6 @@ runTest pkg_descr lbi flags suite = do
     -- Add (DY)LD_LIBRARY_PATH if needed
     shellEnv' <- if LBI.withDynExe lbi
                     then do let (Platform _ os) = LBI.hostPlatform lbi
-                                clbi = LBI.getComponentLocalBuildInfo lbi
-                                         (LBI.CTestName (PD.testName suite))
                             paths <- LBI.depLibraryPaths True False lbi clbi
                             return (addLibraryPath os paths shellEnv)
                     else return shellEnv

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -39,10 +39,11 @@ import System.Process (StdStream(..), waitForProcess)
 
 runTest :: PD.PackageDescription
         -> LBI.LocalBuildInfo
+        -> LBI.ComponentLocalBuildInfo
         -> TestFlags
         -> PD.TestSuite
         -> IO TestSuiteLog
-runTest pkg_descr lbi flags suite = do
+runTest pkg_descr lbi clbi flags suite = do
     let isCoverageEnabled = fromFlag $ configCoverage $ LBI.configFlags lbi
         way = guessWay lbi
 
@@ -85,10 +86,6 @@ runTest pkg_descr lbi flags suite = do
                 shellEnv' <- if LBI.withDynExe lbi
                                 then do
                                   let (Platform _ os) = LBI.hostPlatform lbi
-                                      clbi = LBI.getComponentLocalBuildInfo
-                                                   lbi
-                                                   (LBI.CTestName
-                                                      (PD.testName suite))
                                   paths <- LBI.depLibraryPaths
                                              True False lbi clbi
                                   return (addLibraryPath os paths shellEnv)

--- a/Cabal/Distribution/Types/ComponentLocalBuildInfo.hs
+++ b/Cabal/Distribution/Types/ComponentLocalBuildInfo.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Distribution.Types.ComponentLocalBuildInfo (
   ComponentLocalBuildInfo(..),
@@ -11,9 +12,11 @@ import Distribution.PackageDescription
 import qualified Distribution.InstalledPackageInfo as Installed
 import Distribution.Package
 
+import Distribution.Compat.Graph (IsNode(..))
 import Distribution.Compat.Binary (Binary)
 import GHC.Generics (Generic)
 
+-- | The first five fields are common across all algebraic variants.
 data ComponentLocalBuildInfo
   = LibComponentLocalBuildInfo {
     -- | It would be very convenient to store the literal Library here,
@@ -23,14 +26,26 @@ data ComponentLocalBuildInfo
     -- PackageDescription.  NB: eventually, this will NOT uniquely
     -- identify the ComponentLocalBuildInfo.
     componentLocalName :: ComponentName,
+    -- | The computed 'UnitId' which uniquely identifies this
+    -- component.
+    componentUnitId :: UnitId,
     -- | Resolved internal and external package dependencies for this component.
     -- The 'BuildInfo' specifies a set of build dependencies that must be
     -- satisfied in terms of version ranges. This field fixes those dependencies
     -- to the specific versions available on this machine for this compiler.
     componentPackageDeps :: [(UnitId, PackageId)],
-    -- | The computed 'UnitId' which uniquely identifies this
-    -- component.
-    componentUnitId :: UnitId,
+    -- | The set of packages that are brought into scope during
+    -- compilation, including a 'ModuleRenaming' which may used
+    -- to hide or rename modules.  This is what gets translated into
+    -- @-package-id@ arguments.  This is a modernized version of
+    -- 'componentPackageDeps', which is kept around for BC purposes.
+    componentIncludes :: [(UnitId, ModuleRenaming)],
+    -- | The internal dependencies which induce a graph on the
+    -- 'ComponentLocalBuildInfo' of this package.  This does NOT
+    -- coincide with 'componentPackageDeps' because it ALSO records
+    -- 'build-tool' dependencies on executables.  Maybe one day
+    -- @cabal-install@ will also handle these correctly too!
+    componentInternalDeps :: [UnitId],
     -- | Compatibility "package key" that we pass to older versions of GHC.
     componentCompatPackageKey :: String,
     -- | Compatability "package name" that we register this component as.
@@ -40,35 +55,38 @@ data ComponentLocalBuildInfo
     componentExposedModules :: [Installed.ExposedModule],
     -- | Convenience field, specifying whether or not this is the
     -- "public library" that has the same name as the package.
-    componentIsPublic :: Bool,
-    -- | The set of packages that are brought into scope during
-    -- compilation, including a 'ModuleRenaming' which may used
-    -- to hide or rename modules.  This is what gets translated into
-    -- @-package-id@ arguments.  This is a modernized version of
-    -- 'componentPackageDeps', which is kept around for BC purposes.
-    componentIncludes :: [(UnitId, ModuleRenaming)]
+    componentIsPublic :: Bool
   }
   | ExeComponentLocalBuildInfo {
     componentLocalName :: ComponentName,
     componentUnitId :: UnitId,
     componentPackageDeps :: [(UnitId, PackageId)],
-    componentIncludes :: [(UnitId, ModuleRenaming)]
+    componentIncludes :: [(UnitId, ModuleRenaming)],
+    componentInternalDeps :: [UnitId]
   }
   | TestComponentLocalBuildInfo {
     componentLocalName :: ComponentName,
     componentUnitId :: UnitId,
     componentPackageDeps :: [(UnitId, PackageId)],
-    componentIncludes :: [(UnitId, ModuleRenaming)]
+    componentIncludes :: [(UnitId, ModuleRenaming)],
+    componentInternalDeps :: [UnitId]
+
   }
   | BenchComponentLocalBuildInfo {
     componentLocalName :: ComponentName,
     componentUnitId :: UnitId,
     componentPackageDeps :: [(UnitId, PackageId)],
-    componentIncludes :: [(UnitId, ModuleRenaming)]
+    componentIncludes :: [(UnitId, ModuleRenaming)],
+    componentInternalDeps :: [UnitId]
   }
   deriving (Generic, Read, Show)
 
 instance Binary ComponentLocalBuildInfo
+
+instance IsNode ComponentLocalBuildInfo where
+    type Key ComponentLocalBuildInfo = UnitId
+    nodeKey = componentUnitId
+    nodeNeighbors = componentInternalDeps
 
 componentComponentId :: ComponentLocalBuildInfo -> ComponentId
 componentComponentId clbi = case componentUnitId clbi of

--- a/Cabal/Distribution/Types/HookedBuildInfo.hs
+++ b/Cabal/Distribution/Types/HookedBuildInfo.hs
@@ -36,15 +36,16 @@ import Distribution.Types.BuildInfo
 --         'sanityCheckHookedBuildInfo'.
 --      3. We update our 'PackageDescription' (either freshly read
 --         or cached from 'LocalBuildInfo') with 'updatePackageDescription'.
---         In doing so, we must be careful to also update it in
---         'localPkgDescr' in 'LocalBuildInfo', where a user can
---         also get to it.  In practice the code also passes around
---         the updated 'PackageDescription' around explicitly (redundantly)
---         which is what everyone used to get the actual 'Component'.
---         And that's a good thing because up until recently
---         'localPkgDescr' was NOT updated.  Although, it doesn't
---         look like anyone saw a bug because of this, thanks to
---         1c20a6328579af9e37677d507e2e9836ef70ab9d.
+--
+--         In principle, we are also supposed to update the copy of
+--         the 'PackageDescription' stored in 'LocalBuildInfo'
+--         at 'localPkgDescr'.  Unfortunately, in practice, there
+--         are lots of Custom setup scripts which fail to update
+--         'localPkgDescr' so you really shouldn't rely on it.
+--         It's not DEPRECATED because there are legitimate uses
+--         for it, but... yeah.  Sharp knife.  See
+--         <https://github.com/haskell/cabal/issues/3606>
+--         for more information on the issue.
 --
 -- It is not well-specified whether or not a 'HookedBuildInfo' applied
 -- at configure time is persistent to the 'LocalBuildInfo'.  The

--- a/Cabal/Distribution/Types/TargetInfo.hs
+++ b/Cabal/Distribution/Types/TargetInfo.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE TypeFamilies #-}
+module Distribution.Types.TargetInfo (
+    TargetInfo(..)
+) where
+
+import Distribution.Types.ComponentLocalBuildInfo
+import Distribution.Types.Component
+
+import Distribution.Package
+import Distribution.Compat.Graph (IsNode(..))
+
+-- | The 'TargetInfo' contains all the information necessary to build a
+-- specific target (e.g., component/module/file) in a package.  In
+-- principle, one can get the 'Component' from a
+-- 'ComponentLocalBuildInfo' and 'LocalBuildInfo', but it is much more
+-- convenient to have the component in hand.
+data TargetInfo = TargetInfo {
+        targetCLBI      :: ComponentLocalBuildInfo,
+        targetComponent :: Component
+        -- TODO: BuildTargets supporting parsing these is dumb,
+        -- we don't have support for compiling single modules or
+        -- file paths. Accommodating it now is premature
+        -- generalization.  Figure it out later.
+        -- targetSub       :: Maybe (Either ModuleName FilePath)
+    }
+
+instance IsNode TargetInfo where
+    type Key TargetInfo = UnitId
+    nodeKey       = nodeKey       . targetCLBI
+    nodeNeighbors = nodeNeighbors . targetCLBI

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -47,6 +47,9 @@
 	* Add support for `--allow-older` (dual to `--allow-newer`) (#3466)
 	* Improved an error message for process output decoding errors
 	(#3408).
+	* 'getComponentLocalBuildInfo', 'withComponentsInBuildOrder'
+	  and 'componentsInBuildOrder' are deprecated in favor of a
+	  new interface in "Distribution.Types.LocalBuildInfo".
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* Support GHC 8.

--- a/Cabal/tests/PackageTests/TestSuiteTests/ExeV10/Check.hs
+++ b/Cabal/tests/PackageTests/TestSuiteTests/ExeV10/Check.hs
@@ -7,9 +7,9 @@ import System.FilePath
 import Test.Tasty.HUnit (testCase)
 
 import Distribution.Compiler (CompilerFlavor(..), CompilerId(..))
-import Distribution.PackageDescription (package)
 import Distribution.Simple.Compiler (compilerId)
-import Distribution.Simple.LocalBuildInfo (compiler, localPkgDescr, localCompatPackageKey)
+import Distribution.Types.LocalBuildInfo (localPackage)
+import Distribution.Simple.LocalBuildInfo (compiler, localCompatPackageKey)
 import Distribution.Simple.Hpc
 import Distribution.Simple.Program.Builtin (hpcProgram)
 import Distribution.Simple.Program.Db
@@ -98,7 +98,7 @@ hpcTestMatrix config = forM_ (choose4 [True, False]) $
                 subdir
                   | comp == GHC && version >= Version [7, 10] [] =
                       localCompatPackageKey lbi
-                  | otherwise = display (package $ localPkgDescr lbi)
+                  | otherwise = display (localPackage lbi)
             mapM_ shouldExist
                 [ mixDir dist_dir way "my-0.1" </> subdir </> "Foo.mix"
                 , mixDir dist_dir way "test-Short" </> "Main.mix"

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -569,7 +569,7 @@ tests config = do
             let pkg_descr = localPkgDescr lbi
                 compiler_id = compilerId (compiler lbi)
                 cname = CSubLibName "foo-internal"
-                [target] = componentNameTargets lbi cname
+                [target] = componentNameTargets' pkg_descr lbi cname
                 uid = componentUnitId (targetCLBI target)
                 dir = libdir (absoluteComponentInstallDirs pkg_descr lbi uid
                               NoCopyDest)

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -7,9 +7,12 @@ import qualified PackageTests.TestStanza.Check
 import qualified PackageTests.DeterministicAr.Check
 import qualified PackageTests.TestSuiteTests.ExeV10.Check
 
+import Distribution.Types.TargetInfo
+import Distribution.Types.LocalBuildInfo
+
 import Distribution.Simple.LocalBuildInfo
-  ( LocalBuildInfo(localPkgDescr, compiler), absoluteComponentInstallDirs
-  , InstallDirs(libdir), maybeGetComponentLocalBuildInfo
+  ( absoluteComponentInstallDirs
+  , InstallDirs(libdir)
   , ComponentLocalBuildInfo(componentUnitId), ComponentName(..) )
 import Distribution.Simple.InstallDirs ( CopyDest(NoCopyDest) )
 import Distribution.Simple.BuildPaths  ( mkLibName, mkSharedLibName )
@@ -566,8 +569,8 @@ tests config = do
             let pkg_descr = localPkgDescr lbi
                 compiler_id = compilerId (compiler lbi)
                 cname = CSubLibName "foo-internal"
-                Just clbi = maybeGetComponentLocalBuildInfo lbi cname
-                uid = componentUnitId clbi
+                [target] = componentNameTargets lbi cname
+                uid = componentUnitId (targetCLBI target)
                 dir = libdir (absoluteComponentInstallDirs pkg_descr lbi uid
                               NoCopyDest)
             assertBool "interface files should NOT be installed" . not

--- a/cabal-install/Distribution/Client/Run.hs
+++ b/cabal-install/Distribution/Client/Run.hs
@@ -11,6 +11,9 @@
 module Distribution.Client.Run ( run, splitRunArgs )
        where
 
+import Distribution.Types.TargetInfo     (targetCLBI)
+import Distribution.Types.LocalBuildInfo (componentNameTargets)
+
 import Distribution.Client.Utils             (tryCanonicalizePath)
 
 import Distribution.PackageDescription       (Executable (..),
@@ -23,7 +26,6 @@ import Distribution.Simple.Build.PathsModule (pkgPathEnvVar)
 import Distribution.Simple.BuildPaths        (exeExtension)
 import Distribution.Simple.LocalBuildInfo    (ComponentName (..),
                                               LocalBuildInfo (..),
-                                              getComponentLocalBuildInfo,
                                               depLibraryPaths)
 import Distribution.Simple.Utils             (die, notice, warn,
                                               rawSystemExitWithEnv,
@@ -130,8 +132,10 @@ run verbosity lbi exe exeArgs = do
   -- Add (DY)LD_LIBRARY_PATH if needed
   env' <- if withDynExe lbi
              then do let (Platform _ os) = hostPlatform lbi
-                         clbi = getComponentLocalBuildInfo lbi
-                                  (CExeName (exeName exe))
+                     clbi <- case componentNameTargets lbi (CExeName (exeName exe)) of
+                                [target] -> return (targetCLBI target)
+                                [] -> die "run: Could not find executable in LocalBuildInfo"
+                                _ -> die "run: Found multiple matching exes in LocalBuildInfo"
                      paths <- depLibraryPaths True False lbi clbi
                      return (addLibraryPath os paths env)
              else return env

--- a/cabal-install/Distribution/Client/Run.hs
+++ b/cabal-install/Distribution/Client/Run.hs
@@ -12,7 +12,7 @@ module Distribution.Client.Run ( run, splitRunArgs )
        where
 
 import Distribution.Types.TargetInfo     (targetCLBI)
-import Distribution.Types.LocalBuildInfo (componentNameTargets)
+import Distribution.Types.LocalBuildInfo (componentNameTargets')
 
 import Distribution.Client.Utils             (tryCanonicalizePath)
 
@@ -132,7 +132,7 @@ run verbosity lbi exe exeArgs = do
   -- Add (DY)LD_LIBRARY_PATH if needed
   env' <- if withDynExe lbi
              then do let (Platform _ os) = hostPlatform lbi
-                     clbi <- case componentNameTargets lbi (CExeName (exeName exe)) of
+                     clbi <- case componentNameTargets' pkg_descr lbi (CExeName (exeName exe)) of
                                 [target] -> return (targetCLBI target)
                                 [] -> die "run: Could not find executable in LocalBuildInfo"
                                 _ -> die "run: Found multiple matching exes in LocalBuildInfo"

--- a/travis-bootstrap.sh
+++ b/travis-bootstrap.sh
@@ -31,10 +31,22 @@ install_from_tarball() {
 
 timed cabal update
 
+# NB: The cabal cleans here hack around an sdist bug where
+# the bootstrapped Cabal/cabal-install may be built
+# without a Paths_* module available.  Under some situations
+# which I have not been able to reproduce except on Travis,
+# cabal sdist will incorrectly pick up the left over dist
+# directory from the bootstrap and then try to package
+# up the Paths module, but to no avail because it is not
+# available.  I ran out of patience trying to debug this
+# issue, and it is easy enough to work around: clean first.
+
 echo Cabal
+(cd Cabal && timed cabal clean)
 (cd Cabal && timed cabal sdist)
 (cd Cabal && timed install_from_tarball)
 
 echo cabal-install
+(cd cabal-install && timed cabal clean)
 (cd cabal-install && timed cabal sdist)
 (cd cabal-install && timed install_from_tarball)


### PR DESCRIPTION
This is an omnibus patch, with the overall goal of making
LocalBuildInfo Great Again.  The essential ideas:

* New type 'TargetInfo' which bundles together 'ComponentLocalBuildInfo'
  and 'Component'.  Eventually, it will also record file paths / module
  targets.  This data structure is basically what you want; a lot of
  old Cabal code did lots of gyrations converting from
  'ComponentLocalBuildInfo' to 'Component' and vice versa, now
  it's all centralized.

* The "new" API for 'LocalBuildInfo' is in
  "Distribution.Types.LocalBuildInfo".  The general principle
  is, where we previous dealt in 'ComponentLocalBuildInfo',
  we now deal in 'TargetInfo'.  There are shockingly few
  functions we need!

* I've restored 'componentsConfigs' to its Cabal 1.24 signature
  for BC.

* I killed a number of unused functions from "Distribution.Simple.LocalBuildInfo":
  'getLocalComponent', 'maybeGetDefaultLibraryLocalBuildInfo',
  'maybeGetComponentLocalBuildInfo', 'checkComponentsCyclic' and
  'enabledComponents'.  For each I checked on Hackage that they were
  not used.

* 'getComponentLocalBuildInfo', 'withComponentsInBuildOrder' and
  'componentsInBuildOrder' are deprecated to encourage people
  to instead use the 'TargetInfo's to finger which components
  they want built.

* 'ComponentLocalBuildInfo' now stores internally the computed
  'componentInternalDeps', so that 'LocalBuildInfo' can simply store
  a graph of 'ComponentLocalBuildInfo'.

* The code in Configure has been streamlined to use our new Graph
  data type to great success.

* The type of 'runTest' changed to take a 'ComponentLocalBuildInfo',
  bringing it more in line with everything else.

* New function 'readTargetInfos' which combines 'readBuildTargets'
  and 'checkBuildTargets', which is what you really wanted anyway.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>