### PR TITLE
Pretty utils

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -291,6 +291,7 @@ library
     Distribution.PackageDescription.PrettyPrint
     Distribution.PackageDescription.Utils
     Distribution.ParseUtils
+    Distribution.PrettyUtils
     Distribution.ReadE
     Distribution.Simple
     Distribution.Simple.Bench

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -65,7 +65,6 @@ import Data.List (sortBy)
 -- -----------------------------------------------------------------------------
 
 type LineNo    = Int
-type Separator = ([Doc] -> Doc)
 
 data PError = AmbiguousParse String LineNo
             | NoParse String LineNo

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -49,6 +49,7 @@ import Distribution.Compat.ReadP as ReadP hiding (get)
 import Distribution.ReadE
 import Distribution.Text
 import Distribution.Simple.Utils
+import Distribution.PrettyUtils
 import Language.Haskell.Extension
 
 import Text.PrettyPrint hiding (braces)
@@ -712,39 +713,3 @@ parseQuoted = between (ReadP.char '"') (ReadP.char '"')
 
 parseFreeText :: ReadP.ReadP s String
 parseFreeText = ReadP.munch (const True)
-
--- --------------------------------------------
--- ** Pretty printing
-
-showFilePath :: FilePath -> Doc
-showFilePath "" = empty
-showFilePath x  = showToken x
-
-showToken :: String -> Doc
-showToken str
- | not (any dodgy str) &&
-   not (null str)       = text str
- | otherwise            = text (show str)
-  where dodgy c = isSpace c || c == ','
-
-showTestedWith :: (CompilerFlavor,VersionRange) -> Doc
-showTestedWith (compiler, version) = text (show compiler) <+> disp version
-
--- | Pretty-print free-format text, ensuring that it is vertically aligned,
--- and with blank lines replaced by dots for correct re-parsing.
-showFreeText :: String -> Doc
-showFreeText "" = empty
-showFreeText s  = vcat [text (if null l then "." else l) | l <- lines_ s]
-
--- | 'lines_' breaks a string up into a list of strings at newline
--- characters.  The resulting strings do not contain newlines.
-lines_                   :: String -> [String]
-lines_ []                =  [""]
-lines_ s                 =  let (l, s') = break (== '\n') s
-                            in  l : case s' of
-                                        []    -> []
-                                        (_:s'') -> lines_ s''
-
--- | the indentation used for pretty printing
-indentWith :: Int
-indentWith = 4

--- a/Cabal/Distribution/PrettyUtils.hs
+++ b/Cabal/Distribution/PrettyUtils.hs
@@ -1,0 +1,58 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.PrettyUtils
+-- Copyright   :  (c) The University of Glasgow 2004
+-- License     :  BSD3
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Portability :  portable
+--
+-- Utilities for pretty printing.
+{-# OPTIONS_HADDOCK hide #-}
+module Distribution.PrettyUtils (
+    showFilePath,
+    showToken,
+    showTestedWith,
+    showFreeText,
+    indentWith,
+    ) where
+
+import Distribution.Compiler (CompilerFlavor)
+import Distribution.Version  (VersionRange)
+
+import Data.Char             (isSpace)
+import Distribution.Text     (disp)
+import Text.PrettyPrint      (Doc, empty, text, vcat, (<+>))
+
+showFilePath :: FilePath -> Doc
+showFilePath "" = empty
+showFilePath x  = showToken x
+
+showToken :: String -> Doc
+showToken str
+    | not (any dodgy str) && not (null str)  = text str
+    | otherwise                              = text (show str)
+  where
+    dodgy c = isSpace c || c == ','
+
+showTestedWith :: (CompilerFlavor, VersionRange) -> Doc
+showTestedWith (compiler, vr) = text (show compiler) <+> disp vr
+
+-- | Pretty-print free-format text, ensuring that it is vertically aligned,
+-- and with blank lines replaced by dots for correct re-parsing.
+showFreeText :: String -> Doc
+showFreeText "" = empty
+showFreeText s  = vcat [text (if null l then "." else l) | l <- lines_ s]
+
+-- | 'lines_' breaks a string up into a list of strings at newline
+-- characters.  The resulting strings do not contain newlines.
+lines_                   :: String -> [String]
+lines_ []                =  [""]
+lines_ s                 =  let (l, s') = break (== '\n') s
+                            in  l : case s' of
+                                        []    -> []
+                                        (_:s'') -> lines_ s''
+
+-- | the indentation used for pretty printing
+indentWith :: Int
+indentWith = 4

--- a/Cabal/Distribution/PrettyUtils.hs
+++ b/Cabal/Distribution/PrettyUtils.hs
@@ -10,6 +10,8 @@
 -- Utilities for pretty printing.
 {-# OPTIONS_HADDOCK hide #-}
 module Distribution.PrettyUtils (
+    Separator,
+    -- * Internal
     showFilePath,
     showToken,
     showTestedWith,
@@ -23,6 +25,8 @@ import Distribution.Version  (VersionRange)
 import Data.Char             (isSpace)
 import Distribution.Text     (disp)
 import Text.PrettyPrint      (Doc, empty, text, vcat, (<+>))
+
+type Separator = ([Doc] -> Doc)
 
 showFilePath :: FilePath -> Doc
 showFilePath "" = empty


### PR DESCRIPTION
Move pretty-printing related stuff out of `Parse*` modules.

The move of `writePackageDescription` is breaking change, but on the way for `Parsec` the whole 
`Distribution.PackageDescription.Parse` will be redone (types will change).

