### PR TITLE
Parsec parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ matrix:
    - env: GHCVER=8.0.1 SCRIPT=solver-debug-flags
      sudo: required
      os: linux
+   - env: GHCVER=8.0.1 SCRIPT=script PARSEC=YES
+     os: linux
+     sudo: required
    - env: GHCVER=8.0.1 SCRIPT=bootstrap
      sudo: required
      os: linux
@@ -89,6 +92,7 @@ before_install:
  - export PATH=$HOME/.local/bin:$PATH
  - export PATH=/opt/cabal/1.24/bin:$PATH
  - export PATH=/opt/happy/1.19.5/bin:$PATH
+ - export PATH=/opt/alex/3.1.7/bin:$PATH
  - ./travis-install.sh
 
  # Set up deployment to the haskell/cabal-website repo.

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -327,6 +327,11 @@ flag parsec
   default:      False
   manual:       True
 
+flag parsec-struct-diff
+  description:  Use StructDiff in parsec tests. Affects only parsec tests.
+  default:      False
+  manual:       True
+
 library
   build-depends:
     array      >= 0.1 && < 0.6,
@@ -648,9 +653,7 @@ test-suite parser-tests
 
   type: exitcode-stdio-1.0
   main-is: ParserTests.hs
-  other-modules:
-    DiffInstances
-    StructDiff
+
   hs-source-dirs: tests
   build-depends:
     base,
@@ -659,11 +662,19 @@ test-suite parser-tests
     bytestring,
     directory,
     filepath,
-    generics-sop ==0.2.*,
-    these >=0.7.1 && <0.8,
-    singleton-bool >=0.1.1.0 && <0.2,
-    keys,
     Cabal
+
+  if flag(parsec-struct-diff)
+    build-depends:
+      generics-sop ==0.2.*,
+      these >=0.7.1 && <0.8,
+      singleton-bool >=0.1.1.0 && <0.2,
+      keys
+    other-modules:
+      DiffInstances
+      StructDiff
+    cpp-options: -DHAS_STRUCT_DIFF
+
   ghc-options: -Wall -rtsopts
   default-extensions: CPP
   default-language: Haskell2010

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -322,6 +322,11 @@ flag old-directory
   description:  Use directory < 1.2 and old-time
   default:      False
 
+flag parsec
+  description:  Use parsec parser
+  default:      False
+  manual:       True
+
 library
   build-depends:
     array      >= 0.1 && < 0.6,
@@ -482,6 +487,30 @@ library
     Language.Haskell.Extension
     Distribution.Compat.Binary
 
+  if flag(parsec)
+    cpp-options: -DCABAL_PARSEC
+    build-depends:
+      transformers,
+      parsec >= 3.1.9 && <3.2
+    build-tools:
+      alex >= 3.1.4
+    exposed-modules:
+      Distribution.Compat.Parsec
+      Distribution.PackageDescription.Parsec
+      Distribution.PackageDescription.Parsec.FieldDescr
+      Distribution.Parsec.Class
+      Distribution.Parsec.ConfVar
+      Distribution.Parsec.Lexer
+      Distribution.Parsec.LexerMonad
+      Distribution.Parsec.Parser
+      Distribution.Parsec.Types.Common
+      Distribution.Parsec.Types.Field
+      Distribution.Parsec.Types.FieldDescr
+      Distribution.Parsec.Types.ParseResult
+      Distribution.Compat.DList
+
+  -- Move DList to other-module if/when D.C.Lens is done
+
   other-modules:
     Distribution.Backpack.PreExistingComponent
     Distribution.Backpack.ReadyComponent
@@ -609,6 +638,32 @@ test-suite package-tests
     old-time
   if !os(windows)
     build-depends: unix, exceptions
+  ghc-options: -Wall -rtsopts
+  default-extensions: CPP
+  default-language: Haskell2010
+
+test-suite parser-tests
+  if !flag(parsec)
+    buildable: False
+
+  type: exitcode-stdio-1.0
+  main-is: ParserTests.hs
+  other-modules:
+    DiffInstances
+    StructDiff
+  hs-source-dirs: tests
+  build-depends:
+    base,
+    containers,
+    tar >=0.5 && <0.6,
+    bytestring,
+    directory,
+    filepath,
+    generics-sop ==0.2.*,
+    these >=0.7.1 && <0.8,
+    singleton-bool >=0.1.1.0 && <0.2,
+    keys,
+    Cabal
   ghc-options: -Wall -rtsopts
   default-extensions: CPP
   default-language: Haskell2010

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -543,6 +543,7 @@ library
     Distribution.Compat.GetShortPathName
     Distribution.Compat.MonadFail
     Distribution.Compat.Prelude
+    Distribution.Compat.SnocList
     Distribution.GetOpt
     Distribution.Lex
     Distribution.Utils.String

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -498,7 +498,7 @@ library
       transformers,
       parsec >= 3.1.9 && <3.2
     build-tools:
-      alex >= 3.1.4
+      alex >=3.1.4 && <3.3
     exposed-modules:
       Distribution.Compat.Parsec
       Distribution.PackageDescription.Parsec

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -303,6 +303,7 @@ extra-source-files:
   tests/PackageTests/UniqueIPID/P2/M.hs
   tests/PackageTests/UniqueIPID/P2/my.cabal
   tests/PackageTests/multInst/my.cabal
+  tests/ParserTests/warnings/bom.cabal
   tests/Setup.hs
   tests/hackage/check.sh
   tests/hackage/download.sh
@@ -651,7 +652,25 @@ test-suite parser-tests
     buildable: False
 
   type: exitcode-stdio-1.0
+  hs-source-dirs: tests
   main-is: ParserTests.hs
+  build-depends:
+    base,
+    bytestring,
+    filepath,
+    tasty,
+    tasty-hunit,
+    tasty-quickcheck,
+    Cabal
+  ghc-options: -Wall
+  default-language: Haskell2010
+
+test-suite parser-hackage-tests
+  if !flag(parsec)
+    buildable: False
+
+  type: exitcode-stdio-1.0
+  main-is: ParserHackageTests.hs
 
   hs-source-dirs: tests
   build-depends:

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -304,6 +304,7 @@ extra-source-files:
   tests/PackageTests/UniqueIPID/P2/my.cabal
   tests/PackageTests/multInst/my.cabal
   tests/ParserTests/warnings/bom.cabal
+  tests/ParserTests/warnings/nbsp.cabal
   tests/Setup.hs
   tests/hackage/check.sh
   tests/hackage/download.sh

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -528,7 +528,6 @@ library
     Distribution.Compat.CopyFile
     Distribution.Compat.GetShortPathName
     Distribution.Compat.MonadFail
-    Distribution.Compat.DList
     Distribution.Compat.Prelude
     Distribution.GetOpt
     Distribution.Lex

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -304,7 +304,19 @@ extra-source-files:
   tests/PackageTests/UniqueIPID/P2/my.cabal
   tests/PackageTests/multInst/my.cabal
   tests/ParserTests/warnings/bom.cabal
+  tests/ParserTests/warnings/bool.cabal
+  tests/ParserTests/warnings/deprecatedfield.cabal
+  tests/ParserTests/warnings/extratestmodule.cabal
+  tests/ParserTests/warnings/gluedop.cabal
   tests/ParserTests/warnings/nbsp.cabal
+  tests/ParserTests/warnings/newsyntax.cabal
+  tests/ParserTests/warnings/oldsyntax.cabal
+  tests/ParserTests/warnings/subsection.cabal
+  tests/ParserTests/warnings/trailingfield.cabal
+  tests/ParserTests/warnings/unknownfield.cabal
+  tests/ParserTests/warnings/unknownsection.cabal
+  tests/ParserTests/warnings/utf8.cabal
+  tests/ParserTests/warnings/versiontag.cabal
   tests/Setup.hs
   tests/hackage/check.sh
   tests/hackage/download.sh

--- a/Cabal/Distribution/Compat/DList.hs
+++ b/Cabal/Distribution/Compat/DList.hs
@@ -13,6 +13,7 @@ module Distribution.Compat.DList (
     DList,
     runDList,
     singleton,
+    snoc,
 ) where
 
 import Prelude ()
@@ -27,6 +28,9 @@ runDList (DList run) = run []
 -- | Make 'DList' with containing single element.
 singleton :: a -> DList a
 singleton a = DList (a:)
+
+snoc :: DList a -> a -> DList a
+snoc xs x = xs <> singleton x
 
 instance Monoid (DList a) where
   mempty = DList id

--- a/Cabal/Distribution/Compat/Parsec.hs
+++ b/Cabal/Distribution/Compat/Parsec.hs
@@ -56,7 +56,8 @@ integral = toNumber <$> some d P.<?> "integral"
     f '9' = Just 9
     f _   = Nothing
 
--- | Greedely munch characters while predicate holds.
+-- | Greedily munch characters while predicate holds.
+-- Require at least one character.
 munch1
     :: P.Stream s m Char
     => (Char -> Bool)
@@ -64,6 +65,7 @@ munch1
 munch1 = some . P.satisfy
 
 -- | Greedely munch characters while predicate holds.
+-- Always succeeds.
 munch
     :: P.Stream s m Char
     => (Char -> Bool)

--- a/Cabal/Distribution/Compat/Parsec.hs
+++ b/Cabal/Distribution/Compat/Parsec.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE FlexibleContexts #-}
+module Distribution.Compat.Parsec (
+    P.Parsec,
+    P.ParsecT,
+    P.Stream,
+    (P.<?>),
+
+    P.runParser,
+
+    -- * Combinators
+    P.between,
+    P.option,
+    P.optional,
+    P.optionMaybe,
+    P.try,
+    P.sepBy,
+    P.sepBy1,
+    P.choice,
+
+    -- * Char
+    integral,
+    P.char,
+    P.anyChar,
+    P.satisfy,
+    P.space,
+    P.spaces,
+    P.string,
+    munch,
+    munch1,
+    P.oneOf,
+    ) where
+
+import           Distribution.Compat.Prelude
+import           Prelude ()
+
+import qualified Text.Parsec                 as P
+import qualified Text.Parsec.Pos             as P
+
+integral :: (P.Stream s m Char, Integral a) => P.ParsecT s u m a
+integral = toNumber <$> some d P.<?> "integral"
+  where
+    toNumber = foldl' (\a b -> a * 10 + b) 0
+    d = P.tokenPrim
+          (\c -> show [c])
+          (\pos c _cs -> P.updatePosChar pos c)
+          f
+    f '0' = Just 0
+    f '1' = Just 1
+    f '2' = Just 2
+    f '3' = Just 3
+    f '4' = Just 4
+    f '5' = Just 5
+    f '6' = Just 6
+    f '7' = Just 7
+    f '8' = Just 8
+    f '9' = Just 9
+    f _   = Nothing
+
+-- | Greedely munch characters while predicate holds.
+munch1
+    :: P.Stream s m Char
+    => (Char -> Bool)
+    -> P.ParsecT s u m String
+munch1 = some . P.satisfy
+
+-- | Greedely munch characters while predicate holds.
+munch
+    :: P.Stream s m Char
+    => (Char -> Bool)
+    -> P.ParsecT s u m String
+munch = many . P.satisfy

--- a/Cabal/Distribution/Compat/SnocList.hs
+++ b/Cabal/Distribution/Compat/SnocList.hs
@@ -1,0 +1,33 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Compat.SnocList
+-- License     :  BSD3
+--
+-- Maintainer  :  cabal-dev@haskell.org
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- A very reversed list. Has efficient `snoc`
+module Distribution.Compat.SnocList (
+    SnocList,
+    runSnocList,
+    snoc,
+) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+newtype SnocList a = SnocList [a]
+
+snoc :: SnocList a -> a -> SnocList a
+snoc (SnocList xs) x = SnocList (x : xs)
+
+runSnocList :: SnocList a -> [a]
+runSnocList (SnocList xs) = reverse xs
+
+instance Semigroup (SnocList a) where
+    SnocList xs <> SnocList ys = SnocList (ys <> xs)
+
+instance Monoid (SnocList a) where
+    mempty = SnocList []
+    mappend = (<>)

--- a/Cabal/Distribution/ModuleName.hs
+++ b/Cabal/Distribution/ModuleName.hs
@@ -13,7 +13,7 @@
 -- Data type for Haskell module names.
 
 module Distribution.ModuleName (
-        ModuleName,
+        ModuleName (..), -- TODO: move Parsec instance here, don't export constructor
         fromString,
         fromComponents,
         components,

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -1,0 +1,541 @@
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE Rank2Types #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.PackageDescription.Parsec
+-- Copyright   :  Isaac Jones 2003-2005
+-- License     :  BSD3
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Portability :  portable
+--
+-- This defined parsers and partial pretty printers for the @.cabal@ format.
+
+module Distribution.PackageDescription.Parsec (
+    -- * Package descriptions
+    readGenericPackageDescription,
+    parseGenericPackageDescription,
+
+    -- ** Parsing
+    ParseResult,
+
+    -- ** Supplementary build information
+    -- readHookedBuildInfo,
+    -- parseHookedBuildInfo,
+    ) where
+
+import           Distribution.Compat.Prelude
+import           Prelude ()
+
+import qualified Data.ByteString                                   as BS
+import           Data.List                                         (partition)
+import qualified Data.Map                                          as Map
+import           System.Directory
+                 (doesFileExist)
+import qualified Text.Parsec                                       as P
+import qualified Text.Parsec.Error                                 as P
+
+import           Distribution.PackageDescription
+import           Distribution.Simple.Utils
+                 (die, fromUTF8BS, warn)
+import           Distribution.Verbosity                            (Verbosity)
+
+import           Distribution.PackageDescription.Parsec.FieldDescr
+import           Distribution.Parsec.Class                         (parsec)
+import           Distribution.Parsec.ConfVar
+                 (parseConditionConfVar)
+import           Distribution.Parsec.Parser
+import           Distribution.Parsec.Types.Common
+import           Distribution.Parsec.Types.Field                   (getName)
+import           Distribution.Parsec.Types.FieldDescr
+import           Distribution.Parsec.Types.ParseResult
+
+import Distribution.Text (display)
+import Distribution.Version (mkVersion, Version, asVersionIntervals, orLaterVersion, LowerBound (..))
+
+--import Debug.Trace
+
+-- ---------------------------------------------------------------
+-- Parsing
+
+-- | Helper combinator to do parsing plumbing for files.
+--
+-- Given a parser and a filename, return the parse of the file,
+-- after checking if the file exists.
+--
+-- Argument order is chosen to encourage partial application.
+readAndParseFile
+    :: (BS.ByteString -> ParseResult a)
+    -> Verbosity
+    -> FilePath
+    -> IO a
+readAndParseFile parser verbosity fpath = do
+    exists <- doesFileExist fpath
+    unless exists
+        (die $ "Error Parsing: file \"" ++ fpath ++ "\" doesn't exist. Cannot continue.")
+    bs <- BS.readFile fpath
+    let (warnings, errors, result) = runParseResult (parser bs)
+    traverse_ (warn verbosity . showPWarning fpath) warnings
+    traverse_ (warn verbosity . showPError fpath) errors
+    case result of
+        Nothing -> die $ "Failing parsing \"" ++ fpath ++ "\"."
+        Just x  -> return x
+
+-- | Parse the given package file.
+readGenericPackageDescription :: Verbosity -> FilePath -> IO GenericPackageDescription
+readGenericPackageDescription = readAndParseFile parseGenericPackageDescription
+
+------------------------------------------------------------------------------
+-- | Parses the given file into a 'GenericPackageDescription'.
+--
+-- In Cabal 1.2 the syntax for package descriptions was changed to a format
+-- with sections and possibly indented property descriptions.
+--
+-- TODO: add lex warnings
+parseGenericPackageDescription :: BS.ByteString -> ParseResult GenericPackageDescription
+parseGenericPackageDescription bs = case readFields bs of
+    Right fs  -> parseGenericPackageDescription' fs
+    -- | TODO: better marshalling of errors
+    Left perr -> parseFatalFailure (Position 0 0) (show perr)
+
+runFieldParser :: FieldParser a -> [FieldLine Position] -> ParseResult a
+runFieldParser p ls = runFieldParser' pos p =<< fieldlinesToString pos ls
+  where
+    -- TODO: make per line lookup
+    pos = case ls of
+        []                     -> Position 0 0
+        (FieldLine pos' _ : _) -> pos'
+
+fieldlinesToBS :: [FieldLine ann] -> BS.ByteString
+fieldlinesToBS = BS.intercalate "\n" . map (\(FieldLine _ bs) -> bs)
+
+-- TODO: Take position  from FieldLine
+-- TODO: Take field name
+fieldlinesToString :: Position -> [FieldLine ann] -> ParseResult String
+fieldlinesToString pos fls =
+    let str = intercalate "\n" . map (\(FieldLine _ bs') -> fromUTF8BS bs') $ fls
+    in if '\xfffd' `elem` str
+        then str <$ parseWarning pos PWTUTF "Invalid UTF8 encoding"
+        else pure str
+
+runFieldParser' :: Position -> FieldParser a -> String -> ParseResult a
+runFieldParser' (Position row col) p str = case P.runParser p' [] "<field>" str of
+    Right (pok, ws) -> do
+        -- | TODO: map pos
+        traverse_ (\(PWarning t pos w) -> parseWarning pos t w) ws 
+        pure pok
+    Left err        -> do
+        let ppos = P.errorPos err
+        -- Positions start from 1:1, not 0:0
+        let epos = Position (row - 1 + P.sourceLine ppos) (col - 1 + P.sourceColumn ppos)
+        let msg = P.showErrorMessages
+                "or" "unknown parse error" "expecting" "unexpected" "end of input"
+                (P.errorMessages err)
+
+        parseFatalFailure epos $ msg ++ ": " ++ show str
+  where
+    p' = (,) <$ P.spaces <*> p <* P.spaces <* P.eof <*> P.getState
+
+data GPDS = Fields | Sections
+
+-- Note [Accumulating parser]
+parseGenericPackageDescription'
+    :: [Field Position]
+    -> ParseResult GenericPackageDescription
+parseGenericPackageDescription' fs = do
+    let (newSyntax, fs') = sectionizeFields fs
+    (_, gpd) <- foldM go (Fields, emptyGpd) fs'
+    -- Various post checks
+    maybeWarnCabalVersion newSyntax (packageDescription gpd)
+    checkForUndefinedFlags gpd
+    -- TODO: do other validations
+    return gpd
+  where
+    go :: (GPDS, GenericPackageDescription)
+       -> Field Position
+       -> ParseResult (GPDS, GenericPackageDescription)
+    go s                (IfElseBlock pos _ _ _)  = do
+        parseFailure pos "if else block on the top level"
+        return s
+    go (Fields, gpd)   (Field (Name pos name) fieldLines) =
+        case Map.lookup name pdFieldParsers of
+            -- | TODO: can be more accurate
+            Nothing -> fieldlinesToString pos fieldLines >>= \value -> case storeXFieldsPD name value (packageDescription gpd) of
+                Nothing -> do
+                    parseWarning pos PWTUnknownField $ "Unknown field: " ++ show name
+                    return (Fields, gpd)
+                Just pd -> return (Fields, gpd { packageDescription = pd })
+            Just parser -> (\pd -> (Fields, gpd { packageDescription = pd }))
+                <$> runFieldParser (parser $ packageDescription gpd) fieldLines
+    go (Sections, gpd) (Field (Name pos _) _) = do
+        parseWarning pos PWTTrailingFields "Ignoring trailing fields after sections"
+        return (Sections, gpd)
+    go (s, gpd)        (Section name args fields) =
+        (,) s <$> parseSection gpd name args fields
+
+    pdFieldParsers :: Map FieldName (PackageDescription -> FieldParser PackageDescription)
+    pdFieldParsers = Map.fromList $
+        map (\x -> (fieldName x, fieldParser x)) pkgDescrFieldDescrs
+
+    emptyGpd :: GenericPackageDescription
+    emptyGpd = GenericPackageDescription emptyPackageDescription [] Nothing [] [] [] []
+
+    parseSection
+        :: GenericPackageDescription
+        -> Name Position
+        -> [SectionArg Position]
+        -> [Field Position]
+        -> ParseResult GenericPackageDescription
+    parseSection gpd (Name pos name) args fields
+        | name == "library" && null args = do
+            -- TODO: check that library is defined once
+            l <- parseCondTree libFieldDescrs storeXFieldsLib (targetBuildDepends . libBuildInfo) emptyLibrary fields
+            let gpd' = gpd { condLibrary = Just l }
+            pure gpd'
+
+        | name == "executable" = do
+            -- TODO: make a combinator for this, repeated in tests and bench
+            name' <- parseName pos args
+            -- Note: we don't parse the "executable" field here, hence the tail hack. Duncan 2010
+            exe <- parseCondTree (tail executableFieldDescrs) storeXFieldsExe (targetBuildDepends . buildInfo) emptyExecutable fields
+            -- TODO check duplicate name here?
+            let gpd' = gpd { condExecutables = condExecutables gpd ++ [(name', exe)] }
+            pure gpd'
+
+        | name == "test-suite" = do
+            name' <- parseName pos args
+            testStanza <- parseCondTree testSuiteFieldDescrs storeXFieldsTest (targetBuildDepends . testStanzaBuildInfo) emptyTestStanza fields
+            testSuite <- traverse (validateTestSuite pos) testStanza
+            -- TODO check duplicate name here?
+            let gpd' = gpd { condTestSuites = condTestSuites gpd ++ [(name', testSuite)] }
+            pure gpd'
+
+        | name == "benchmark" = do
+            name' <- parseName pos args
+            benchStanza <- parseCondTree benchmarkFieldDescrs storeXFieldsBenchmark (targetBuildDepends . benchmarkStanzaBuildInfo) emptyBenchmarkStanza fields
+            bench <- traverse (validateBenchmark pos) benchStanza
+            -- TODO check duplicate name here?
+            let gpd' = gpd { condBenchmarks = condBenchmarks gpd ++ [(name', bench)] }
+            pure gpd'
+
+        | name == "flag" = do
+            name' <- parseName pos args
+            name'' <- runFieldParser' pos parsec name' `recoverWith` FlagName ""
+            flag <- parseFields flagFieldDescrs warnUnrec (emptyFlag name'') fields
+            -- Check default flag
+            let gpd' = gpd { genPackageFlags = genPackageFlags gpd ++ [flag] }
+            pure gpd'
+
+        | name == "custom-setup" && null args = do
+            sbi <- parseFields setupBInfoFieldDescrs warnUnrec mempty fields
+            let pd = packageDescription gpd
+            -- TODO: what if already defined?
+            let gpd' = gpd { packageDescription = pd { setupBuildInfo = Just sbi } }
+            pure gpd'
+
+        | name == "source-repository" = do
+            kind <- case args of
+                [SecArgName spos secName] ->
+                    runFieldParser' spos parsec (fromUTF8BS secName) `recoverWith` RepoHead
+                [] -> do
+                    parseFailure pos $ "'source-repository' needs one argument"
+                    pure RepoHead
+                _ -> do
+                    parseFailure pos $ "Invalid source-repository kind " ++ show args
+                    pure RepoHead
+            sr <- parseFields sourceRepoFieldDescrs warnUnrec (emptySourceRepo kind) fields
+            -- I want lens
+            let pd =  packageDescription gpd
+            let srs = sourceRepos pd
+            let gpd' = gpd { packageDescription = pd { sourceRepos = srs ++ [sr] } }
+            pure gpd'
+
+        | otherwise = do
+            parseWarning pos PWTUnknownSection $ "Ignoring section: " ++ show name
+            pure gpd
+
+    newSyntaxVersion :: Version
+    newSyntaxVersion = mkVersion [1, 2]
+
+    maybeWarnCabalVersion :: Bool -> PackageDescription -> ParseResult ()
+    maybeWarnCabalVersion newsyntax pkg
+      | newsyntax && specVersion pkg < newSyntaxVersion 
+      = parseWarning (Position 0 0) PWTNewSyntax $
+             "A package using section syntax must specify at least\n"
+          ++ "'cabal-version: >= 1.2'."
+
+    maybeWarnCabalVersion newsyntax pkg
+      | not newsyntax && specVersion pkg >= newSyntaxVersion 
+      = parseWarning (Position 0 0) PWTOldSyntax $
+             "A package using 'cabal-version: "
+          ++ displaySpecVersion (specVersionRaw pkg)
+          ++ "' must use section syntax. See the Cabal user guide for details."
+      where
+        displaySpecVersion (Left version)       = display version
+        displaySpecVersion (Right versionRange) =
+          case asVersionIntervals versionRange of
+            [] {- impossible -}           -> display versionRange
+            ((LowerBound version _, _):_) -> display (orLaterVersion version)
+
+    maybeWarnCabalVersion _ _ = return ()
+
+{-
+    handleFutureVersionParseFailure :: Version -> ParseResult a -> ParseResult GenericPackageDescription
+    handleFutureVersionParseFailure _cabalVersionNeeded _parseBody =
+        error "handleFutureVersionParseFailure"
+-}
+
+ {-
+      undefined (unless versionOk (warning message) >> parseBody)
+        `catchParseError` \parseError -> case parseError of
+        TabsError _   -> parseFail parseError
+        _ | versionOk -> parseFail parseError
+          | otherwise -> fail message
+      where versionOk = cabalVersionNeeded <= cabalVersion
+            message   = "This package requires at least Cabal version "
+                     ++ display cabalVersionNeeded
+    -}
+
+    checkForUndefinedFlags
+        :: GenericPackageDescription
+        -> ParseResult ()
+    checkForUndefinedFlags _gpd = pure ()
+{-
+        let definedFlags = map flagName flags
+        mapM_ (checkCondTreeFlags definedFlags) (maybeToList mlib)
+        mapM_ (checkCondTreeFlags definedFlags . snd) sub_libs
+        mapM_ (checkCondTreeFlags definedFlags . snd) exes
+        mapM_ (checkCondTreeFlags definedFlags . snd) tests
+
+    checkCondTreeFlags :: [FlagName] -> CondTree ConfVar c a -> PM ()
+    checkCondTreeFlags definedFlags ct = do
+        let fv = nub $ freeVars ct
+        unless (all (`elem` definedFlags) fv) $
+            fail $ "These flags are used without having been defined: "
+                ++ intercalate ", " [ n | FlagName n <- fv \\ definedFlags ]
+-}
+
+parseName :: Position -> [SectionArg Position] -> ParseResult String
+parseName pos args = case args of
+    [SecArgName _pos secName] ->
+         pure $ fromUTF8BS secName
+    [SecArgStr _pos secName] ->
+         pure secName
+    [] -> do
+         parseFailure pos $ "name required"
+         pure ""
+    _ -> do
+         -- TODO: pretty print args
+         parseFailure pos $ "Invalid name " ++ show args
+         pure ""
+
+-- | Parse a list of fields, given a list of field descriptions,
+--   a structure to accumulate the parsed fields, and a function
+--   that can decide what to do with fields which don't match any
+--   of the field descriptions.
+parseFields
+    :: forall a.
+       [FieldDescr a]        -- ^ descriptions of fields we know how to parse
+    -> UnknownFieldParser a  -- ^ possibly do something with unrecognized fields
+    -> a                     -- ^ accumulator
+    -> [Field Position]      -- ^ fields to be parsed
+    -> ParseResult a
+parseFields descrs _unknown = foldM go
+  where
+    go :: a -> Field Position -> ParseResult a
+    go x (Section (Name pos name) _ _) = do
+        -- Even we occur a subsection, we can continue parsing
+        parseFailure pos $ "invalid subsection " ++ show name
+        return x
+    go x (IfElseBlock pos _ _ _) = do
+        parseFailure pos $ "invalid if-else-block"
+        return x
+    go x (Field (Name pos name) fieldLines) =
+        case Map.lookup name fieldParsers of
+            Nothing -> do
+                -- TODO: use 'unknown'
+                parseWarning pos PWTUnknownField $ "Unknown field: " ++ show name
+                return x
+            Just parser ->
+                runFieldParser (parser x) fieldLines
+
+    fieldParsers :: Map FieldName (a -> FieldParser a)
+    fieldParsers = Map.fromList $
+        map (\x -> (fieldName x, fieldParser x)) descrs
+
+type C c a = (Condition ConfVar, CondTree ConfVar c a, Maybe (CondTree ConfVar c a))
+
+parseCondTree
+    :: forall a c.
+       [FieldDescr a]        -- ^ Field descriptions
+    -> UnknownFieldParser a  -- ^ How to parse unknown fields
+    -> (a -> c)              -- ^ Condition extractor
+    -> a                     -- ^ Initial value
+    -> [Field Position]      -- ^ Fields to parse
+    -> ParseResult (CondTree ConfVar c a)
+parseCondTree descs unknown cond ini = go0
+  where
+    go0 fields = do
+        (x, xs) <- foldM go (ini, []) fields
+        return $ CondNode x (cond x) xs
+
+    -- | TODO: change to take and return condnode
+    go :: (a, [C c a])  -> Field Position -> ParseResult (a, [C c a])
+    go x (Section (Name pos name) _ _) = do
+        -- Even we occur a subsection, we can continue parsing
+        -- http://hackage.haskell.org/package/constraints-0.1/constraints.cabal
+        parseWarning pos PWTInvalidSubsection $ "invalid subsection " ++ show name
+        return x
+
+    go (x, xs) (IfElseBlock _pos tes con alt) = do
+        tes'  <- parseConditionConfVar tes
+        con' <- go0 con
+        alt' <- case alt of
+            [] -> pure Nothing
+            _  -> Just <$> go0 alt
+        let ieb = (tes', con', alt')
+        return (x, xs ++ [ieb])
+
+    go (x, xs) (Field (Name pos name) fieldLines) =
+        case Map.lookup name fieldParsers of
+            Nothing -> fieldlinesToString pos fieldLines >>= \value -> case unknown name value x of
+                Nothing -> do
+                    parseWarning pos PWTUnknownField $ "Unknown field: " ++ show name
+                    return (x, xs)
+                Just x' -> return (x', xs)
+            Just parser ->
+                (,xs) <$> runFieldParser (parser x) fieldLines
+
+    fieldParsers :: Map FieldName (a -> FieldParser a)
+    fieldParsers = Map.fromList $
+        map (\x -> (fieldName x, fieldParser x)) descs
+{-
+    -- Extracts all fields in a block and returns a 'CondTree'.
+    --
+    -- We have to recurse down into conditionals and we treat fields that
+    -- describe dependencies specially.
+    collectFields :: ([Field Position] -> PM a) -> [Field Position]
+                  -> PM (CondTree ConfVar [Dependency] a)
+    collectFields parser allflds = do
+
+        let simplFlds = [ f | f@Field{} <- allflds ]
+            condFlds = [ f | f@IfElseBlock{} <- allflds ]
+            sections = [ s | s@Section{} <- allflds ]
+
+        -- Put these through the normal parsing pass too, so that we
+        -- collect the ModRenamings
+        let depFlds = filter isConstraint simplFlds
+
+        mapM_
+            (\(Section (Name pos n) _ _) -> lift . warning $
+                "Unexpected section '" ++ show n ++ "' on " ++ showPos pos)
+            sections
+
+        a <- parser simplFlds
+        deps <- liftM concat . mapM (lift . parseConstraint) $ depFlds
+
+        ifs <- mapM processIfs condFlds
+
+        return (CondNode a deps ifs)
+      where
+        isConstraint (Field (Name _ n) _) = n `elem` constraintFieldNames
+        isConstraint _ = False
+
+        processIfs (IfElseBlock c t e) = do
+            cnd <- lift $ runP undefined "if" parseCondition (undefined c)
+            t' <- collectFields parser t
+            e' <- case e of
+                   [] -> return Nothing
+                   es -> do fs <- collectFields parser es
+                            return (Just fs)
+            return (cnd, t', e')
+        processIfs _ = cabalBug "processIfs called with wrong field type"
+-}
+
+{- Note [Accumulating parser]
+
+In there parser, @'FieldDescr' a@ is transformed into @Map FieldName (a ->
+FieldParser a)@.  The weird value is used because we accumulate structure of
+@a@ by folding over the fields.  There are various reasons for that:
+
+* Almost all fields are optional
+
+* This is simple approach so declarative bi-directional format (parsing and
+printing) of structure could be specified (list of @'FieldDescr' a@)
+
+* There are surface syntax fields corresponding to single field in the file:
+  @license-file@ and @license-files@
+
+* This is quite safe approach.
+
+When/if we re-implement the parser to support formatting preservging roundtrip
+with new AST, this all need to be rewritten.
+-}
+
+-------------------------------------------------------------------------------
+-- Old syntax
+-------------------------------------------------------------------------------
+
+-- | "Sectionize" an old-style Cabal file.  A sectionized file has:
+--
+--  * all global fields at the beginning, followed by
+--
+--  * all flag declarations, followed by
+--
+--  * an optional library section, and an arbitrary number of executable
+--    sections (in any order).
+--
+-- The current implementation just gathers all library-specific fields
+-- in a library section and wraps all executable stanzas in an executable
+-- section.
+--
+-- Boolean in the return pair is 'False', if the file was using old syntax.
+sectionizeFields :: [Field ann] -> (Bool, [Field ann])
+sectionizeFields fs = case classifyFields fs of
+    Just fields -> (False, convert fields)
+    Nothing     -> (True, fs)
+  where
+    -- return 'Just' if all fields are simple fields
+    classifyFields :: [Field ann] -> Maybe [(Name ann, [FieldLine ann])]
+    classifyFields = traverse f
+      where
+        f (Field name fieldlines) = Just (name, fieldlines)
+        f _                      = Nothing
+
+    trim = BS.dropWhile isSpace' . BS.reverse . BS.dropWhile isSpace' . BS.reverse
+    isSpace' = (== 32)
+
+    convert :: [(Name ann, [FieldLine ann])] -> [Field ann]
+    convert fields =
+      let
+        toField (name, ls) = Field name ls
+        -- "build-depends" is a local field now.  To be backwards
+        -- compatible, we still allow it as a global field in old-style
+        -- package description files and translate it to a local field by
+        -- adding it to every non-empty section
+        (hdr0, exes0) = break ((=="executable") . getName . fst) fields
+        (hdr, libfs0) = partition (not . (`elem` libFieldNames) . getName . fst) hdr0
+
+        (deps, libfs) = partition ((== "build-depends") . getName . fst)
+                                   libfs0
+
+        exes = unfoldr toExe exes0
+        toExe [] = Nothing
+        toExe ((Name pos n, ls) : r)
+          | n == "executable" =
+              let (efs, r') = break ((== "executable") . getName . fst) r
+              in Just (Section (Name pos "executable") [SecArgName pos $ trim $ fieldlinesToBS ls] (map toField $ deps ++ efs), r')
+        toExe _ = error "unexpected input to 'toExe'"
+
+        lib = case libfs of
+            []                         -> []
+            ((Name pos _,  _) : _) ->
+                [Section (Name pos "library") [] (map toField $ deps ++ libfs)]
+
+      in map toField hdr ++ lib ++ exes
+
+libFieldNames :: [FieldName]
+libFieldNames = map fieldName libFieldDescrs

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -98,7 +98,7 @@ readGenericPackageDescription = readAndParseFile parseGenericPackageDescription
 parseGenericPackageDescription :: BS.ByteString -> ParseResult GenericPackageDescription
 parseGenericPackageDescription bs = case readFields' bs of
     Right (fs, lexWarnings) -> parseGenericPackageDescription' lexWarnings fs
-    -- | TODO: better marshalling of errors
+    -- TODO: better marshalling of errors
     Left perr -> parseFatalFailure (Position 0 0) (show perr)
 
 runFieldParser :: FieldParser a -> [FieldLine Position] -> ParseResult a
@@ -124,7 +124,7 @@ fieldlinesToString pos fls =
 runFieldParser' :: Position -> FieldParser a -> String -> ParseResult a
 runFieldParser' (Position row col) p str = case P.runParser p' [] "<field>" str of
     Right (pok, ws) -> do
-        -- | TODO: map pos
+        -- TODO: map pos
         traverse_ (\(PWarning t pos w) -> parseWarning pos t w) ws
         pure pok
     Left err        -> do
@@ -161,7 +161,7 @@ parseGenericPackageDescription' lexWarnings fs = do
        -> ParseResult (GPDS, GenericPackageDescription)
     go (Fields, gpd)   (Field (Name pos name) fieldLines) =
         case Map.lookup name pdFieldParsers of
-            -- | TODO: can be more accurate
+            -- TODO: can be more accurate
             Nothing -> fieldlinesToString pos fieldLines >>= \value -> case storeXFieldsPD name value (packageDescription gpd) of
                 Nothing -> do
                     parseWarning pos PWTUnknownField $ "Unknown field: " ++ show name

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -172,8 +172,8 @@ parseGenericPackageDescription' lexWarnings fs = do
     go (Sections, gpd) (Field (Name pos _) _) = do
         parseWarning pos PWTTrailingFields "Ignoring trailing fields after sections"
         return (Sections, gpd)
-    go (s, gpd)        (Section name args fields) =
-        (,) s <$> parseSection gpd name args fields
+    go (_, gpd)        (Section name args fields) =
+        (,) Sections <$> parseSection gpd name args fields
 
     pdFieldParsers :: Map FieldName (PackageDescription -> FieldParser PackageDescription)
     pdFieldParsers = Map.fromList $

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -195,8 +195,15 @@ parseGenericPackageDescription' lexWarnings fs = do
             let gpd' = gpd { condLibrary = Just l }
             pure gpd'
 
+        -- Sublibraries
+        | name == "library" = do
+            name' <- parseName pos args
+            lib <- parseCondTree libFieldDescrs storeXFieldsLib (targetBuildDepends . libBuildInfo) emptyLibrary fields
+            -- TODO check duplicate name here?
+            let gpd' = gpd { condSubLibraries = condSubLibraries gpd ++ [(name', lib)] }
+            pure gpd'
+
         | name == "executable" = do
-            -- TODO: make a combinator for this, repeated in tests and bench
             name' <- parseName pos args
             -- Note: we don't parse the "executable" field here, hence the tail hack. Duncan 2010
             exe <- parseCondTree (tail executableFieldDescrs) storeXFieldsExe (targetBuildDepends . buildInfo) emptyExecutable fields

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE Rank2Types          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
-{-# LANGUAGE Rank2Types #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.PackageDescription.Parsec
@@ -27,36 +27,34 @@ module Distribution.PackageDescription.Parsec (
     -- parseHookedBuildInfo,
     ) where
 
-import           Distribution.Compat.Prelude
 import           Prelude ()
-
+import           Distribution.Compat.Prelude
 import qualified Data.ByteString                                   as BS
 import           Data.List                                         (partition)
 import qualified Data.Map                                          as Map
-import           System.Directory
-                 (doesFileExist)
-import qualified Text.Parsec                                       as P
-import qualified Text.Parsec.Error                                 as P
-
 import           Distribution.PackageDescription
-import           Distribution.Simple.Utils
-                 (die, fromUTF8BS, warn)
-import           Distribution.Verbosity                            (Verbosity)
-
 import           Distribution.PackageDescription.Parsec.FieldDescr
 import           Distribution.Parsec.Class                         (parsec)
 import           Distribution.Parsec.ConfVar
                  (parseConditionConfVar)
+import           Distribution.Parsec.LexerMonad
+                 (LexWarning, toPWarning)
 import           Distribution.Parsec.Parser
 import           Distribution.Parsec.Types.Common
 import           Distribution.Parsec.Types.Field                   (getName)
 import           Distribution.Parsec.Types.FieldDescr
 import           Distribution.Parsec.Types.ParseResult
-import           Distribution.Parsec.LexerMonad
-                 (LexWarning, toPWarning)
-
-import Distribution.Text (display)
-import Distribution.Version (mkVersion, Version, asVersionIntervals, orLaterVersion, LowerBound (..))
+import           Distribution.Simple.Utils
+                 (die, fromUTF8BS, warn)
+import           Distribution.Text                                 (display)
+import           Distribution.Verbosity                            (Verbosity)
+import           Distribution.Version
+                 (LowerBound (..), Version, asVersionIntervals, mkVersion,
+                 orLaterVersion)
+import           System.Directory
+                 (doesFileExist)
+import qualified Text.Parsec                                       as P
+import qualified Text.Parsec.Error                                 as P
 
 -- ---------------------------------------------------------------
 -- Parsing
@@ -68,9 +66,9 @@ import Distribution.Version (mkVersion, Version, asVersionIntervals, orLaterVers
 --
 -- Argument order is chosen to encourage partial application.
 readAndParseFile
-    :: (BS.ByteString -> ParseResult a)
-    -> Verbosity
-    -> FilePath
+    :: (BS.ByteString -> ParseResult a)  -- ^ File contents to final value parser
+    -> Verbosity                         -- ^ Verbosity level
+    -> FilePath                          -- ^ File to read
     -> IO a
 readAndParseFile parser verbosity fpath = do
     exists <- doesFileExist fpath

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -58,8 +58,6 @@ import           Distribution.Parsec.LexerMonad
 import Distribution.Text (display)
 import Distribution.Version (mkVersion, Version, asVersionIntervals, orLaterVersion, LowerBound (..))
 
---import Debug.Trace
-
 -- ---------------------------------------------------------------
 -- Parsing
 

--- a/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
@@ -1,0 +1,576 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | 'GenericPackageDescription' Field descriptions
+module Distribution.PackageDescription.Parsec.FieldDescr (
+    -- * Package description
+    pkgDescrFieldDescrs,
+    storeXFieldsPD,
+    -- * Library
+    libFieldDescrs,
+    storeXFieldsLib,
+    -- * Executable
+    executableFieldDescrs,
+    storeXFieldsExe,
+    -- * Test suite
+    TestSuiteStanza (..),
+    emptyTestStanza,
+    testSuiteFieldDescrs,
+    storeXFieldsTest,
+    validateTestSuite,
+    -- * Benchmark
+    BenchmarkStanza (..),
+    emptyBenchmarkStanza,
+    benchmarkFieldDescrs,
+    storeXFieldsBenchmark,
+    validateBenchmark,
+    -- * Flag
+    flagFieldDescrs,
+    -- * Source repository
+    sourceRepoFieldDescrs,
+    -- * Setup build info
+    setupBInfoFieldDescrs,
+    ) where
+
+import           Distribution.Compat.Prelude
+import           Prelude ()
+
+import           Text.PrettyPrint                      (vcat)
+
+import qualified Data.ByteString                       as BS
+import           Data.List                             (dropWhileEnd)
+import qualified Distribution.Compat.Parsec            as Parsec
+import           Distribution.Compiler                 (CompilerFlavor (..))
+import           Distribution.ModuleName               (ModuleName)
+import           Distribution.Package
+import           Distribution.PackageDescription
+import           Distribution.Parsec.Class
+import           Distribution.Parsec.Types.Common
+import           Distribution.Parsec.Types.FieldDescr
+import           Distribution.Parsec.Types.ParseResult
+import           Distribution.PrettyUtils
+import           Distribution.Simple.Utils             (fromUTF8BS)
+import           Distribution.Text                     (disp, display)
+
+-------------------------------------------------------------------------------
+-- common FieldParsers
+-------------------------------------------------------------------------------
+
+-- | This is /almost/ @'many' 'Distribution.Compat.Parsec.anyChar'@, but it
+--
+-- * trims whitespace from ends of the lines,
+--
+-- * converts lines with only single dot into empty line.
+--
+freeTextFieldParser :: FieldParser String
+freeTextFieldParser = dropDotLines <$ Parsec.spaces <*> many Parsec.anyChar
+  where
+    -- http://hackage.haskell.org/package/copilot-cbmc-0.1/copilot-cbmc.cabal
+    dropDotLines "." = "."
+    dropDotLines x = intercalate "\n" . map dotToEmpty . lines $ x
+    dotToEmpty x | trim' x == "." = ""
+    dotToEmpty x                  = trim x
+
+    trim' = dropWhileEnd (`elem` (" \t" :: String))
+
+-------------------------------------------------------------------------------
+-- PackageDescription
+-------------------------------------------------------------------------------
+
+-- TODO: other-files isn't used in any cabla file on Hackage.
+pkgDescrFieldDescrs :: [FieldDescr PackageDescription]
+pkgDescrFieldDescrs =
+    [ simpleField "name"
+        disp                   parsec
+        packageName            (\name pkg -> pkg{package=(package pkg){pkgName=name}})
+    , simpleField "version"
+        disp                   parsec
+        packageVersion         (\ver pkg -> pkg{package=(package pkg){pkgVersion=ver}})
+    , simpleField "cabal-version"
+             (either disp disp)     (Left <$> parsec <|> Right <$> parsec)
+             specVersionRaw         (\v pkg -> pkg{specVersionRaw=v})
+    , simpleField "build-type"
+             (maybe mempty disp)    (Just <$> parsec)
+             buildType              (\t pkg -> pkg{buildType=t})
+    , simpleField "license"
+             disp                   (parsecMaybeQuoted parsec)
+             license                (\l pkg -> pkg{license=l})
+    , simpleField "license-file"
+             showFilePath           parsecFilePath
+             (\pkg -> case licenseFiles pkg of
+                        [x] -> x
+                        _   -> "")
+             (\l pkg -> pkg{licenseFiles=licenseFiles pkg ++ [l]})
+     -- We have both 'license-file' and 'license-files' fields.
+     -- Rather than declaring license-file to be deprecated, we will continue
+     -- to allow both. The 'license-file' will continue to only allow single
+     -- tokens, while 'license-files' allows multiple. On pretty-printing, we
+     -- will use 'license-file' if there's just one, and use 'license-files'
+     -- otherwise.
+   , listField "license-files"
+             showFilePath          parsecFilePath
+             (\pkg -> case licenseFiles pkg of
+                        [_] -> []
+                        xs  -> xs)
+             (\ls pkg -> pkg{licenseFiles=ls})
+   , simpleField "copyright"
+             showFreeText           freeTextFieldParser
+             copyright              (\val pkg -> pkg{copyright=val})
+   , simpleField "maintainer"
+             showFreeText           freeTextFieldParser
+             maintainer             (\val pkg -> pkg{maintainer=val})
+   , simpleField "stability"
+             showFreeText           freeTextFieldParser
+             stability              (\val pkg -> pkg{stability=val})
+   , simpleField "homepage"
+             showFreeText           freeTextFieldParser
+             homepage               (\val pkg -> pkg{homepage=val})
+   , simpleField "package-url"
+             showFreeText           freeTextFieldParser
+             pkgUrl                 (\val pkg -> pkg{pkgUrl=val})
+   , simpleField "bug-reports"
+             showFreeText           freeTextFieldParser
+             bugReports             (\val pkg -> pkg{bugReports=val})
+   , simpleField "synopsis"
+             showFreeText           freeTextFieldParser
+             synopsis               (\val pkg -> pkg{synopsis=val})
+   , simpleField "description"
+             showFreeText           freeTextFieldParser
+             description            (\val pkg -> pkg{description=val})
+   , simpleField "category"
+             showFreeText           freeTextFieldParser
+             category               (\val pkg -> pkg{category=val})
+   , simpleField "author"
+             showFreeText           freeTextFieldParser
+             author                 (\val pkg -> pkg{author=val})
+   , listField "tested-with"
+             showTestedWith         parsecTestedWith
+             testedWith             (\val pkg -> pkg{testedWith=val})
+   , listFieldWithSep vcat "data-files"
+             showFilePath           parsecFilePath
+             dataFiles              (\val pkg -> pkg{dataFiles=val})
+   , simpleField "data-dir"
+             showFilePath           parsecFilePath
+             dataDir                (\val pkg -> pkg{dataDir=val})
+   , listFieldWithSep vcat "extra-source-files"
+             showFilePath           parsecFilePath
+             extraSrcFiles          (\val pkg -> pkg{extraSrcFiles=val})
+   , listFieldWithSep vcat "extra-tmp-files"
+             showFilePath           parsecFilePath
+             extraTmpFiles          (\val pkg -> pkg{extraTmpFiles=val})
+   , listFieldWithSep vcat "extra-doc-files"
+             showFilePath           parsecFilePath
+             extraDocFiles          (\val pkg -> pkg{extraDocFiles=val})
+   ]
+
+-- | Store any fields beginning with "x-" in the customFields field of
+--   a PackageDescription.  All other fields will generate a warning.
+storeXFieldsPD :: UnknownFieldParser PackageDescription
+storeXFieldsPD f val pkg | beginsWithX f =
+    Just pkg { customFieldsPD = customFieldsPD pkg ++ [(fromUTF8BS f, trim val)] }
+storeXFieldsPD _ _ _ = Nothing
+
+-------------------------------------------------------------------------------
+-- Library
+-------------------------------------------------------------------------------
+
+libFieldDescrs :: [FieldDescr Library]
+libFieldDescrs =
+    [ listFieldWithSep vcat "exposed-modules" disp (parsecMaybeQuoted parsec)
+        exposedModules (\mods lib -> lib{exposedModules=mods})
+    , commaListFieldWithSep vcat "reexported-modules" disp parsec
+        reexportedModules (\mods lib -> lib{reexportedModules=mods})
+
+{-
+  , listFieldWithSep vcat "required-signatures" disp parseModuleNameQ
+      requiredSignatures (\mods lib -> lib{requiredSignatures=mods})
+
+-}
+    , boolField "exposed"
+        libExposed     (\val lib -> lib{libExposed=val})
+    ] ++ map biToLib binfoFieldDescrs
+  where
+    biToLib = liftField libBuildInfo (\bi lib -> lib{libBuildInfo=bi})
+
+storeXFieldsLib :: UnknownFieldParser Library
+storeXFieldsLib f val l@Library { libBuildInfo = bi } | beginsWithX f =
+    Just $ l {libBuildInfo =
+                 bi{ customFieldsBI = customFieldsBI bi ++ [(fromUTF8BS f, trim val)]}}
+storeXFieldsLib _ _ _ = Nothing
+
+-------------------------------------------------------------------------------
+-- Executable
+-------------------------------------------------------------------------------
+
+executableFieldDescrs :: [FieldDescr Executable]
+executableFieldDescrs =
+    [ -- note ordering: configuration must come first, for
+      -- showPackageDescription.
+      simpleField "executable"
+        showToken          parsecToken
+        exeName            (\xs    exe -> exe{exeName=xs})
+    , simpleField "main-is"
+        showFilePath       parsecFilePath
+        modulePath         (\xs    exe -> exe{modulePath=xs})
+    ]
+    ++ map biToExe binfoFieldDescrs
+  where
+    biToExe = liftField buildInfo (\bi exe -> exe{buildInfo=bi})
+
+storeXFieldsExe :: UnknownFieldParser Executable
+storeXFieldsExe f val e@Executable { buildInfo = bi } | beginsWithX f =
+    Just $ e {buildInfo = bi{ customFieldsBI = (fromUTF8BS f, trim val) : customFieldsBI bi}}
+storeXFieldsExe _ _ _ = Nothing
+
+-------------------------------------------------------------------------------
+-- TestSuite
+-------------------------------------------------------------------------------
+
+-- | An intermediate type just used for parsing the test-suite stanza.
+-- After validation it is converted into the proper 'TestSuite' type.
+data TestSuiteStanza = TestSuiteStanza
+    { testStanzaTestType   :: Maybe TestType
+    , testStanzaMainIs     :: Maybe FilePath
+    , testStanzaTestModule :: Maybe ModuleName
+    , testStanzaBuildInfo  :: BuildInfo
+    }
+
+emptyTestStanza :: TestSuiteStanza
+emptyTestStanza = TestSuiteStanza Nothing Nothing Nothing mempty
+
+testSuiteFieldDescrs :: [FieldDescr TestSuiteStanza]
+testSuiteFieldDescrs =
+    [ simpleField "type"
+        (maybe mempty disp)   (Just <$> parsec)
+        testStanzaTestType    (\x suite -> suite { testStanzaTestType = x })
+    , simpleField "main-is"
+        (maybe mempty showFilePath) (Just <$> parsecFilePath)
+        testStanzaMainIs      (\x suite -> suite { testStanzaMainIs = x })
+    , simpleField "test-module"
+        (maybe mempty disp)   (Just <$> parsecMaybeQuoted parsec)
+        testStanzaTestModule  (\x suite -> suite { testStanzaTestModule = x })
+    ]
+    ++ map biToTest binfoFieldDescrs
+  where
+    biToTest = liftField
+        testStanzaBuildInfo
+        (\bi suite -> suite { testStanzaBuildInfo = bi })
+
+storeXFieldsTest :: UnknownFieldParser TestSuiteStanza
+storeXFieldsTest f val t@TestSuiteStanza { testStanzaBuildInfo = bi }
+    | beginsWithX f =
+        Just $ t {testStanzaBuildInfo = bi{ customFieldsBI = (fromUTF8BS f,val):customFieldsBI bi}}
+storeXFieldsTest _ _ _ = Nothing
+
+validateTestSuite :: Position -> TestSuiteStanza -> ParseResult TestSuite
+validateTestSuite pos stanza = case testStanzaTestType stanza of
+    Nothing -> return $
+        emptyTestSuite { testBuildInfo = testStanzaBuildInfo stanza }
+
+    Just tt@(TestTypeUnknown _ _) ->
+        pure emptyTestSuite
+            { testInterface = TestSuiteUnsupported tt
+            , testBuildInfo = testStanzaBuildInfo stanza
+            }
+
+    Just tt | tt `notElem` knownTestTypes ->
+        pure emptyTestSuite
+            { testInterface = TestSuiteUnsupported tt
+            , testBuildInfo = testStanzaBuildInfo stanza
+            }
+
+    Just tt@(TestTypeExe ver) -> case testStanzaMainIs stanza of
+        Nothing   -> do
+            parseFailure pos (missingField "main-is" tt)
+            pure emptyTestSuite
+        Just file -> do
+            when (isJust (testStanzaTestModule stanza)) $
+                parseWarning pos PWTExtraBenchmarkModule (extraField "test-module" tt)
+            pure emptyTestSuite
+                { testInterface = TestSuiteExeV10 ver file
+                , testBuildInfo = testStanzaBuildInfo stanza
+                }
+
+    Just tt@(TestTypeLib ver) -> case testStanzaTestModule stanza of
+         Nothing      -> do
+             parseFailure pos (missingField "test-module" tt)
+             pure emptyTestSuite
+         Just module_ -> do
+            when (isJust (testStanzaMainIs stanza)) $
+                parseWarning pos PWTExtraMainIs (extraField "main-is" tt)
+            pure emptyTestSuite
+                { testInterface = TestSuiteLibV09 ver module_
+                , testBuildInfo = testStanzaBuildInfo stanza
+                }
+
+  where
+    missingField name tt = "The '" ++ name ++ "' field is required for the "
+                        ++ display tt ++ " test suite type."
+
+    extraField   name tt = "The '" ++ name ++ "' field is not used for the '"
+                        ++ display tt ++ "' test suite type."
+
+-------------------------------------------------------------------------------
+-- Benchmark
+-------------------------------------------------------------------------------
+
+-- | An intermediate type just used for parsing the benchmark stanza.
+-- After validation it is converted into the proper 'Benchmark' type.
+data BenchmarkStanza = BenchmarkStanza
+    { benchmarkStanzaBenchmarkType   :: Maybe BenchmarkType
+    , benchmarkStanzaMainIs          :: Maybe FilePath
+    , benchmarkStanzaBenchmarkModule :: Maybe ModuleName
+    , benchmarkStanzaBuildInfo        :: BuildInfo
+    }
+
+emptyBenchmarkStanza :: BenchmarkStanza
+emptyBenchmarkStanza = BenchmarkStanza Nothing Nothing Nothing mempty
+
+benchmarkFieldDescrs :: [FieldDescr BenchmarkStanza]
+benchmarkFieldDescrs =
+    [ simpleField "type"
+        (maybe mempty disp)    (Just <$> parsec)
+        benchmarkStanzaBenchmarkType
+        (\x suite -> suite { benchmarkStanzaBenchmarkType = x })
+    , simpleField "main-is"
+        (maybe mempty showFilePath)  (Just <$> parsecFilePath)
+        benchmarkStanzaMainIs
+        (\x suite -> suite { benchmarkStanzaMainIs = x })
+    ]
+    ++ map biToBenchmark binfoFieldDescrs
+  where
+    biToBenchmark = liftField benchmarkStanzaBuildInfo
+                    (\bi suite -> suite { benchmarkStanzaBuildInfo = bi })
+
+storeXFieldsBenchmark :: UnknownFieldParser BenchmarkStanza
+storeXFieldsBenchmark f val t@BenchmarkStanza { benchmarkStanzaBuildInfo = bi } | beginsWithX f =
+    Just $ t {benchmarkStanzaBuildInfo =
+                       bi{ customFieldsBI = (fromUTF8BS f, trim val):customFieldsBI bi}}
+storeXFieldsBenchmark _ _ _ = Nothing
+
+validateBenchmark :: Position -> BenchmarkStanza -> ParseResult Benchmark
+validateBenchmark pos stanza = case benchmarkStanzaBenchmarkType stanza of
+    Nothing -> pure emptyBenchmark
+        { benchmarkBuildInfo = benchmarkStanzaBuildInfo stanza }
+
+    Just tt@(BenchmarkTypeUnknown _ _) -> pure emptyBenchmark
+        { benchmarkInterface = BenchmarkUnsupported tt
+        , benchmarkBuildInfo = benchmarkStanzaBuildInfo stanza
+        }
+
+    Just tt | tt `notElem` knownBenchmarkTypes -> pure emptyBenchmark
+        { benchmarkInterface = BenchmarkUnsupported tt
+        , benchmarkBuildInfo = benchmarkStanzaBuildInfo stanza
+        }
+
+    Just tt@(BenchmarkTypeExe ver) -> case benchmarkStanzaMainIs stanza of
+        Nothing   -> do
+            parseFailure pos (missingField "main-is" tt)
+            pure emptyBenchmark
+        Just file -> do
+            when (isJust (benchmarkStanzaBenchmarkModule stanza)) $
+                parseWarning pos PWTExtraBenchmarkModule (extraField "benchmark-module" tt)
+            pure emptyBenchmark
+                { benchmarkInterface = BenchmarkExeV10 ver file
+                , benchmarkBuildInfo = benchmarkStanzaBuildInfo stanza
+                }
+
+  where
+    missingField name tt = "The '" ++ name ++ "' field is required for the "
+                        ++ display tt ++ " benchmark type."
+
+    extraField   name tt = "The '" ++ name ++ "' field is not used for the '"
+                        ++ display tt ++ "' benchmark type."
+
+-------------------------------------------------------------------------------
+-- BuildInfo
+-------------------------------------------------------------------------------
+
+binfoFieldDescrs :: [FieldDescr BuildInfo]
+binfoFieldDescrs =
+ [ boolField "buildable"
+           buildable          (\val binfo -> binfo{buildable=val})
+ , commaListField  "build-tools"
+           disp               parsecBuildTool
+           buildTools         (\xs  binfo -> binfo{buildTools=xs})
+ , commaListFieldWithSep vcat "build-depends"
+       disp               parsec
+       targetBuildDepends (\xs binfo -> binfo{targetBuildDepends=xs})
+ , spaceListField "cpp-options"
+           showToken          parsecToken'
+           cppOptions          (\val binfo -> binfo{cppOptions=val})
+ , spaceListField "cc-options"
+           showToken          parsecToken'
+           ccOptions          (\val binfo -> binfo{ccOptions=val})
+ , spaceListField "ld-options"
+           showToken          parsecToken'
+           ldOptions          (\val binfo -> binfo{ldOptions=val})
+ , commaListField  "pkgconfig-depends"
+           disp               parsecPkgconfigDependency
+           pkgconfigDepends   (\xs  binfo -> binfo{pkgconfigDepends=xs})
+ , listField "frameworks"
+           showToken          parsecToken
+           frameworks         (\val binfo -> binfo{frameworks=val})
+ , listField "extra-framework-dirs"
+           showToken          parsecFilePath
+           extraFrameworkDirs (\val binfo -> binfo{extraFrameworkDirs=val})
+ , listFieldWithSep vcat "c-sources"
+           showFilePath       parsecFilePath
+           cSources           (\paths binfo -> binfo{cSources=paths})
+ , listFieldWithSep vcat "js-sources"
+           showFilePath       parsecFilePath
+           jsSources          (\paths binfo -> binfo{jsSources=paths})
+   , simpleField "default-language"
+       (maybe mempty disp) (Parsec.optionMaybe $ parsecMaybeQuoted parsec)
+        defaultLanguage    (\lang  binfo -> binfo{defaultLanguage=lang})
+ , listField   "other-languages"
+           disp              (parsecMaybeQuoted parsec)
+           otherLanguages     (\langs binfo -> binfo{otherLanguages=langs})
+   , listField   "default-extensions"
+       disp               (parsecMaybeQuoted parsec)
+       defaultExtensions  (\exts  binfo -> binfo{defaultExtensions=exts})
+   , listField   "other-extensions"
+       disp               (parsecMaybeQuoted parsec)
+       otherExtensions    (\exts  binfo -> binfo{otherExtensions=exts})
+   , listField   "extensions"
+       -- TODO: this is deprecated field, isn't it?
+       disp               (parsecMaybeQuoted parsec)
+       oldExtensions      (\exts  binfo -> binfo{oldExtensions=exts})
+ , listFieldWithSep vcat "extra-libraries"
+           showToken          parsecToken
+           extraLibs          (\xs    binfo -> binfo{extraLibs=xs})
+ , listFieldWithSep vcat "extra-ghci-libraries"
+           showToken          parsecToken
+           extraGHCiLibs      (\xs    binfo -> binfo{extraGHCiLibs=xs})
+ , listField   "extra-lib-dirs"
+           showFilePath       parsecFilePath
+           extraLibDirs       (\xs    binfo -> binfo{extraLibDirs=xs})
+ , listFieldWithSep vcat "includes"
+           showFilePath       parsecFilePath
+           includes           (\paths binfo -> binfo{includes=paths})
+ , listFieldWithSep vcat "install-includes"
+           showFilePath       parsecFilePath
+           installIncludes    (\paths binfo -> binfo{installIncludes=paths})
+ , listField   "include-dirs"
+           showFilePath       parsecFilePath
+           includeDirs        (\paths binfo -> binfo{includeDirs=paths})
+   , listField   "hs-source-dirs"
+       showFilePath        parsecFilePath
+       hsSourceDirs       (\paths binfo -> binfo{hsSourceDirs=paths})
+   , deprecatedField "hs-source-dirs" $ listField  "hs-source-dir"
+       showFilePath        parsecFilePath
+       (const [])          (\paths binfo -> binfo{hsSourceDirs=paths})
+   , listFieldWithSep vcat "other-modules"
+       disp               (parsecMaybeQuoted parsec)
+       otherModules       (\val binfo -> binfo{otherModules=val})
+ , optsField   "ghc-prof-options" GHC
+           profOptions        (\val binfo -> binfo{profOptions=val})
+ , optsField   "ghcjs-prof-options" GHCJS
+           profOptions        (\val binfo -> binfo{profOptions=val})
+ , optsField   "ghc-shared-options" GHC
+           sharedOptions      (\val binfo -> binfo{sharedOptions=val})
+ , optsField   "ghcjs-shared-options" GHCJS
+           sharedOptions      (\val binfo -> binfo{sharedOptions=val})
+   , optsField   "ghc-options"  GHC
+        options            (\path  binfo -> binfo{options=path})
+ , optsField   "ghcjs-options" GHCJS
+           options            (\path  binfo -> binfo{options=path})
+ , optsField   "jhc-options"  JHC
+           options            (\path  binfo -> binfo{options=path})
+ -- NOTE: Hugs and NHC are not supported anymore, but these fields are kept
+ -- around for backwards compatibility.
+ --
+ -- TODO: deprecate?
+ , optsField   "hugs-options" Hugs
+           options            (const id)
+ , optsField   "nhc98-options" NHC
+           options            (const id)
+   ]
+
+{-
+storeXFieldsBI :: UnknownFieldParser BuildInfo
+--storeXFieldsBI (f@('x':'-':_),val) bi = Just bi{ customFieldsBI = (f,val):customFieldsBI bi }
+storeXFieldsBI _ _ = Nothing
+-}
+
+-------------------------------------------------------------------------------
+-- Flag
+-------------------------------------------------------------------------------
+
+flagFieldDescrs :: [FieldDescr Flag]
+flagFieldDescrs =
+    [ simpleField "description"
+        showFreeText     freeTextFieldParser
+        flagDescription  (\val fl -> fl{ flagDescription = val })
+    , boolField "default"
+        flagDefault      (\val fl -> fl{ flagDefault = val })
+    , boolField "manual"
+        flagManual       (\val fl -> fl{ flagManual = val })
+    ]
+
+-------------------------------------------------------------------------------
+-- SourceRepo
+-------------------------------------------------------------------------------
+
+sourceRepoFieldDescrs :: [FieldDescr SourceRepo]
+sourceRepoFieldDescrs =
+    [ simpleField "type"
+        (maybe mempty disp)         (Just <$> parsec)
+        repoType                    (\val repo -> repo { repoType = val })
+    , simpleField "location"
+        (maybe mempty showFreeText) (Just <$> freeTextFieldParser)
+        repoLocation                (\val repo -> repo { repoLocation = val })
+    , simpleField "module"
+        (maybe mempty showToken)    (Just <$> parsecToken)
+        repoModule                  (\val repo -> repo { repoModule = val })
+    , simpleField "branch"
+        (maybe mempty showToken)    (Just <$> parsecToken)
+        repoBranch                  (\val repo -> repo { repoBranch = val })
+    , simpleField "tag"
+        (maybe mempty showToken)    (Just <$> parsecToken)
+        repoTag                     (\val repo -> repo { repoTag = val })
+    , simpleField "subdir"
+        (maybe mempty showFilePath) (Just <$> parsecFilePath)
+        repoSubdir                  (\val repo -> repo { repoSubdir = val })
+    ]
+
+-------------------------------------------------------------------------------
+-- SetupBuildInfo
+-------------------------------------------------------------------------------
+
+setupBInfoFieldDescrs :: [FieldDescr SetupBuildInfo]
+setupBInfoFieldDescrs =
+    [ commaListFieldWithSep vcat "setup-depends"
+        disp         parsec
+        setupDepends (\xs binfo -> binfo{setupDepends=xs})
+    ]
+
+
+-------------------------------------------------------------------------------
+-- Utilities
+-------------------------------------------------------------------------------
+
+beginsWithX :: FieldName -> Bool
+beginsWithX bs = case BS.uncons bs of
+    Just (x, _)
+        | x == fromIntegral (ord 'x') -> True
+    _                                 -> False
+
+-- | Mark the field as deprecated.
+deprecatedField
+    :: FieldName   -- ^ alternative field
+    -> FieldDescr a
+    -> FieldDescr a
+deprecatedField newFieldName fd = FieldDescr
+    { fieldName   = oldFieldName
+    , fieldPretty = const mempty  -- we don't print deprecated field
+    , fieldParser = \x -> do
+        parsecWarning PWTDeprecatedField $
+            "The field " <> show oldFieldName <>
+            " is deprecated, please use " <> show newFieldName
+        fieldParser fd x
+    }
+  where
+    oldFieldName = fieldName fd
+
+-- Used to trim x-fields
+trim :: String -> String
+trim = dropWhile isSpace . dropWhileEnd isSpace

--- a/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
@@ -30,11 +30,8 @@ module Distribution.PackageDescription.Parsec.FieldDescr (
     setupBInfoFieldDescrs,
     ) where
 
-import           Distribution.Compat.Prelude
 import           Prelude ()
-
-import           Text.PrettyPrint                      (vcat)
-
+import           Distribution.Compat.Prelude
 import qualified Data.ByteString                       as BS
 import           Data.List                             (dropWhileEnd)
 import qualified Distribution.Compat.Parsec            as Parsec
@@ -49,6 +46,7 @@ import           Distribution.Parsec.Types.ParseResult
 import           Distribution.PrettyUtils
 import           Distribution.Simple.Utils             (fromUTF8BS)
 import           Distribution.Text                     (disp, display)
+import           Text.PrettyPrint                      (vcat)
 
 -------------------------------------------------------------------------------
 -- common FieldParsers

--- a/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
@@ -63,6 +63,7 @@ import           Distribution.Text                     (disp, display)
 freeTextFieldParser :: FieldParser String
 freeTextFieldParser = dropDotLines <$ Parsec.spaces <*> many Parsec.anyChar
   where
+    -- Example package with dot lines
     -- http://hackage.haskell.org/package/copilot-cbmc-0.1/copilot-cbmc.cabal
     dropDotLines "." = "."
     dropDotLines x = intercalate "\n" . map dotToEmpty . lines $ x
@@ -75,7 +76,7 @@ freeTextFieldParser = dropDotLines <$ Parsec.spaces <*> many Parsec.anyChar
 -- PackageDescription
 -------------------------------------------------------------------------------
 
--- TODO: other-files isn't used in any cabla file on Hackage.
+-- TODO: other-files isn't used in any cabal file on Hackage.
 pkgDescrFieldDescrs :: [FieldDescr PackageDescription]
 pkgDescrFieldDescrs =
     [ simpleField "name"

--- a/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
@@ -552,11 +552,9 @@ setupBInfoFieldDescrs =
 -- Utilities
 -------------------------------------------------------------------------------
 
+-- | Predicate to test field names beginning with "x-"
 beginsWithX :: FieldName -> Bool
-beginsWithX bs = case BS.uncons bs of
-    Just (x, _)
-        | x == fromIntegral (ord 'x') -> True
-    _                                 -> False
+beginsWithX bs = BS.take 2 bs == "x-"
 
 -- | Mark the field as deprecated.
 deprecatedField

--- a/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
@@ -461,6 +461,9 @@ binfoFieldDescrs =
    , listFieldWithSep vcat "other-modules"
        disp               (parsecMaybeQuoted parsec)
        otherModules       (\val binfo -> binfo{otherModules=val})
+   , listFieldWithSep vcat "autogen-modules"
+       disp               (parsecMaybeQuoted parsec)
+       autogenModules     (\val binfo -> binfo{autogenModules=val})
  , optsField   "ghc-prof-options" GHC
            profOptions        (\val binfo -> binfo{profOptions=val})
  , optsField   "ghcjs-prof-options" GHCJS

--- a/Cabal/Distribution/Parsec/Class.hs
+++ b/Cabal/Distribution/Parsec/Class.hs
@@ -51,7 +51,7 @@ import           Distribution.Types.SourceRepo
 import           Distribution.Types.TestType                  (TestType (..))
 import           Distribution.Version
                  (Version, mkVersion, VersionRange (..), anyVersion, earlierVersion,
-                 intersectVersionRanges, laterVersion, noVersion,
+                 intersectVersionRanges, laterVersion, majorBoundVersion, noVersion,
                  orEarlierVersion, orLaterVersion, thisVersion,
                  unionVersionRanges, withinVersion)
 import           Language.Haskell.Extension
@@ -180,6 +180,7 @@ instance Parsec VersionRange where
                      ("<=", orEarlierVersion),
                      (">",  laterVersion),
                      (">=", orLaterVersion),
+                     ("^>=", majorBoundVersion),
                      ("==", thisVersion) ]
 
 instance Parsec Language where

--- a/Cabal/Distribution/Parsec/Class.hs
+++ b/Cabal/Distribution/Parsec/Class.hs
@@ -16,14 +16,12 @@ module Distribution.Parsec.Class (
     parsecOptCommaList,
     ) where
 
-import           Distribution.Compat.Prelude
 import           Prelude ()
-
+import           Distribution.Compat.Prelude
 import           Data.Functor.Identity                        (Identity)
+import qualified Distribution.Compat.Parsec                   as P
 import           Distribution.Parsec.Types.Common
                  (PWarnType (..), PWarning (..), Position (..))
-
-import qualified Distribution.Compat.Parsec                   as P
 import qualified Text.Parsec                                  as Parsec
 import qualified Text.Parsec.Language                         as Parsec
 import qualified Text.Parsec.Token                            as Parsec
@@ -34,6 +32,7 @@ import           Distribution.Compiler
                  (CompilerFlavor (..), classifyCompilerFlavor)
 import           Distribution.License                         (License (..))
 import           Distribution.ModuleName                      (ModuleName)
+import qualified Distribution.ModuleName                      as ModuleName
 import           Distribution.Package
                  (Dependency (..), PackageName, mkPackageName)
 import           Distribution.System
@@ -50,13 +49,12 @@ import           Distribution.Types.SourceRepo
                  (RepoKind, RepoType, classifyRepoKind, classifyRepoType)
 import           Distribution.Types.TestType                  (TestType (..))
 import           Distribution.Version
-                 (Version, mkVersion, VersionRange (..), anyVersion, earlierVersion,
-                 intersectVersionRanges, laterVersion, majorBoundVersion, noVersion,
-                 orEarlierVersion, orLaterVersion, thisVersion,
-                 unionVersionRanges, withinVersion)
+                 (Version, VersionRange (..), anyVersion, earlierVersion,
+                 intersectVersionRanges, laterVersion, majorBoundVersion,
+                 mkVersion, noVersion, orEarlierVersion, orLaterVersion,
+                 thisVersion, unionVersionRanges, withinVersion)
 import           Language.Haskell.Extension
                  (Extension, Language, classifyExtension, classifyLanguage)
-import qualified Distribution.ModuleName as ModuleName
 
 -------------------------------------------------------------------------------
 -- Class
@@ -303,6 +301,7 @@ parsecToken' = parsecHaskellString <|> (P.munch1 (not . isSpace) P.<?> "token")
 parsecFilePath :: P.Stream s Identity Char => P.Parsec s [PWarning] String
 parsecFilePath = parsecToken
 
+-- | Parse a benchmark/test-suite types.
 stdParse
     :: P.Stream s Identity Char
     => (Version -> String -> a)

--- a/Cabal/Distribution/Parsec/Class.hs
+++ b/Cabal/Distribution/Parsec/Class.hs
@@ -174,7 +174,7 @@ instance Parsec VersionRange where
                 P.spaces
                 return (VersionRangeParens a))
 
-        -- | TODO: make those non back-tracking
+        -- TODO: make those non back-tracking
         parseRangeOp (s,f) = P.try (P.string s *> P.spaces *> fmap f parsec)
         rangeOps = [ ("<",  earlierVersion),
                      ("<=", orEarlierVersion),

--- a/Cabal/Distribution/Parsec/Class.hs
+++ b/Cabal/Distribution/Parsec/Class.hs
@@ -1,0 +1,372 @@
+{-# LANGUAGE FlexibleContexts #-}
+module Distribution.Parsec.Class (
+    Parsec(..),
+    -- * Warnings
+    parsecWarning,
+    -- * Utilities
+    parsecTestedWith,
+    parsecPkgconfigDependency,
+    parsecBuildTool,
+    parsecToken,
+    parsecToken',
+    parsecFilePath,
+    parsecQuoted,
+    parsecMaybeQuoted,
+    parsecCommaList,
+    parsecOptCommaList,
+    ) where
+
+import           Distribution.Compat.Prelude
+import           Prelude ()
+
+import           Data.Functor.Identity                        (Identity)
+import           Distribution.Parsec.Types.Common
+                 (PWarnType (..), PWarning (..), Position (..))
+
+import qualified Distribution.Compat.Parsec                   as P
+import qualified Text.Parsec                                  as Parsec
+import qualified Text.Parsec.Language                         as Parsec
+import qualified Text.Parsec.Token                            as Parsec
+
+-- Instances
+
+import           Distribution.Compiler
+                 (CompilerFlavor (..), classifyCompilerFlavor)
+import           Distribution.License                         (License (..))
+import           Distribution.ModuleName                      (ModuleName)
+import           Distribution.Package
+                 (Dependency (..), PackageName, mkPackageName)
+import           Distribution.System
+                 (Arch (..), ClassificationStrictness (..), OS (..),
+                 classifyArch, classifyOS)
+import           Distribution.Text                            (display)
+import           Distribution.Types.BenchmarkType
+                 (BenchmarkType (..))
+import           Distribution.Types.BuildType                 (BuildType (..))
+import           Distribution.Types.GenericPackageDescription (FlagName (..))
+import           Distribution.Types.ModuleReexport
+                 (ModuleReexport (..))
+import           Distribution.Types.SourceRepo
+                 (RepoKind, RepoType, classifyRepoKind, classifyRepoType)
+import           Distribution.Types.TestType                  (TestType (..))
+import           Distribution.Version
+                 (Version, mkVersion, VersionRange (..), anyVersion, earlierVersion,
+                 intersectVersionRanges, laterVersion, noVersion,
+                 orEarlierVersion, orLaterVersion, thisVersion,
+                 unionVersionRanges, withinVersion)
+import           Language.Haskell.Extension
+                 (Extension, Language, classifyExtension, classifyLanguage)
+import qualified Distribution.ModuleName as ModuleName
+
+-------------------------------------------------------------------------------
+-- Class
+-------------------------------------------------------------------------------
+
+-- |
+--
+-- TODO: implementation details: should be careful about consuming trailing whitespace?
+-- Should we always consume it?
+class Parsec a where
+    parsec :: P.Stream s Identity Char => P.Parsec s [PWarning] a
+
+    -- | 'parsec' /could/ consume trailing spaces, this function /must/ consume.
+    lexemeParsec :: P.Stream s Identity Char => P.Parsec s [PWarning] a
+    lexemeParsec = parsec <* P.spaces
+
+parsecWarning :: PWarnType -> String -> P.Parsec s [PWarning] ()
+parsecWarning t w =
+    Parsec.modifyState (PWarning t (Position 0 0) w :)
+
+-------------------------------------------------------------------------------
+-- Instances
+-------------------------------------------------------------------------------
+
+-- TODO: use lexemeParsec
+
+instance Parsec PackageName where
+    -- todo
+    parsec = mkPackageName . intercalate "-" <$> P.sepBy1 component (P.char '-')
+      where
+        component :: P.Stream s Identity Char => P.Parsec s [PWarning] String
+        component = do
+          cs <- P.munch1 isAlphaNum
+          if all isDigit cs then fail "all digits PackageName" else return cs
+
+instance Parsec ModuleName where
+    parsec = ModuleName.fromComponents <$> P.sepBy1 component (P.char '.')
+      where
+        component = do
+            c  <- P.satisfy isUpper
+            cs <- P.munch validModuleChar
+            return (c:cs)
+
+        validModuleChar :: Char -> Bool
+        validModuleChar c = isAlphaNum c || c == '_' || c == '\''
+
+instance Parsec FlagName where
+    parsec = FlagName . map toLower . intercalate "-" <$> P.sepBy1 component (P.char '-')
+      where
+        -- http://hackage.haskell.org/package/cabal-debian-4.24.8/cabal-debian.cabal
+        -- has flag with all digit component: pretty-112
+        component :: P.Stream s Identity Char => P.Parsec s [PWarning] String
+        component = P.munch1 (\c -> isAlphaNum c || c `elem` "_")
+
+instance Parsec Dependency where
+    parsec = do
+        name <- lexemeParsec
+        ver  <- parsec <|> pure anyVersion
+        return (Dependency name ver)
+
+instance Parsec Version where
+    parsec = mkVersion <$>
+        P.sepBy1 P.integral (P.char '.')
+        <* tags
+      where
+        tags = do
+            ts <- P.optionMaybe $ some $ P.char '-' *> some (P.satisfy isAlphaNum)
+            case ts of
+                Nothing -> pure ()
+                -- TODO: make this warning severe
+                Just _  -> parsecWarning PWTVersionTag "version with tags"
+
+-- TODO: this is not good parsec code
+-- use lexer, also see D.P.ConfVar
+instance Parsec VersionRange where
+    parsec = expr
+      where
+        expr   = do P.spaces
+                    t <- term
+                    P.spaces
+                    (do _  <- P.string "||"
+                        P.spaces
+                        e <- expr
+                        return (unionVersionRanges t e)
+                     <|>
+                     return t)
+        term   = do f <- factor
+                    P.spaces
+                    (do _  <- P.string "&&"
+                        P.spaces
+                        t <- term
+                        return (intersectVersionRanges f t)
+                     <|>
+                     return f)
+        factor = P.choice
+            $ parens expr
+            : parseAnyVersion
+            : parseNoVersion
+            : parseWildcardRange
+            : map parseRangeOp rangeOps
+        parseAnyVersion    = P.string "-any" >> return anyVersion
+        parseNoVersion     = P.string "-none" >> return noVersion
+
+        parseWildcardRange = P.try $ do
+          _ <- P.string "=="
+          P.spaces
+          branch <- some (P.integral <* P.char '.')
+          _ <- P.char '*'
+          return (withinVersion (mkVersion branch))
+
+        parens p = P.between
+            (P.char '(' >> P.spaces)
+            (P.char ')' >> P.spaces)
+            (do a <- p
+                P.spaces
+                return (VersionRangeParens a))
+
+        -- | TODO: make those non back-tracking
+        parseRangeOp (s,f) = P.try (P.string s *> P.spaces *> fmap f parsec)
+        rangeOps = [ ("<",  earlierVersion),
+                     ("<=", orEarlierVersion),
+                     (">",  laterVersion),
+                     (">=", orLaterVersion),
+                     ("==", thisVersion) ]
+
+instance Parsec Language where
+    parsec = classifyLanguage <$> P.munch1 isAlphaNum
+
+instance Parsec Extension where
+    parsec = classifyExtension <$> P.munch1 isAlphaNum
+
+instance Parsec RepoType where
+    parsec = classifyRepoType <$> P.munch1 isIdent
+
+instance Parsec RepoKind where
+    parsec = classifyRepoKind <$> P.munch1 isIdent
+
+instance Parsec License where
+  parsec = do
+    name    <- P.munch1 isAlphaNum
+    version <- P.optionMaybe (P.char '-' *> parsec)
+    return $! case (name, version :: Maybe Version) of
+      ("GPL",               _      ) -> GPL  version
+      ("LGPL",              _      ) -> LGPL version
+      ("AGPL",              _      ) -> AGPL version
+      ("BSD2",              Nothing) -> BSD2
+      ("BSD3",              Nothing) -> BSD3
+      ("BSD4",              Nothing) -> BSD4
+      ("ISC",               Nothing) -> ISC
+      ("MIT",               Nothing) -> MIT
+      ("MPL",         Just version') -> MPL version'
+      ("Apache",            _      ) -> Apache version
+      ("PublicDomain",      Nothing) -> PublicDomain
+      ("AllRightsReserved", Nothing) -> AllRightsReserved
+      ("OtherLicense",      Nothing) -> OtherLicense
+      _                              -> UnknownLicense $ name ++
+                                        maybe "" (('-':) . display) version
+
+instance Parsec BuildType where
+  parsec = do
+    name <- P.munch1 isAlphaNum
+    return $ case name of
+      "Simple"    -> Simple
+      "Configure" -> Configure
+      "Custom"    -> Custom
+      "Make"      -> Make
+      _           -> UnknownBuildType name
+
+instance Parsec TestType where
+  parsec = stdParse $ \ver name -> case name of
+      "exitcode-stdio" -> TestTypeExe ver
+      "detailed"       -> TestTypeLib ver
+      _                -> TestTypeUnknown name ver
+
+instance Parsec BenchmarkType where
+    parsec = stdParse $ \ver name -> case name of
+       "exitcode-stdio" -> BenchmarkTypeExe ver
+       _                -> BenchmarkTypeUnknown name ver
+
+instance Parsec OS where
+    parsec = classifyOS Compat <$> parsecIdent
+
+instance Parsec Arch where
+    parsec = classifyArch Strict <$> parsecIdent
+
+instance Parsec CompilerFlavor where
+    parsec = classifyCompilerFlavor <$> component
+      where
+        component :: P.Stream s Identity Char => P.Parsec s [PWarning] String
+        component = do
+          cs <- P.munch1 isAlphaNum
+          if all isDigit cs then fail "all digits compiler name" else return cs
+
+instance Parsec ModuleReexport where
+    parsec = do
+        mpkgname <- P.optionMaybe (P.try $ parsec <* P.char ':')
+        origname <- parsec
+        newname  <- P.option origname $ P.try $ do
+            P.spaces
+            _ <- P.string "as"
+            P.spaces
+            parsec
+        return (ModuleReexport mpkgname origname newname)
+
+-------------------------------------------------------------------------------
+-- Utilities
+-------------------------------------------------------------------------------
+
+isIdent :: Char -> Bool
+isIdent c = isAlphaNum c || c == '_' || c == '-'
+
+parsecTestedWith :: P.Stream s Identity Char => P.Parsec s [PWarning] (CompilerFlavor, VersionRange)
+parsecTestedWith = do
+    name <- lexemeParsec
+    ver  <- parsec <|> pure anyVersion
+    return (name, ver)
+
+parsecPkgconfigDependency :: P.Stream s Identity Char => P.Parsec s [PWarning] Dependency
+parsecPkgconfigDependency = do
+    name <- P.munch1 (\c -> isAlphaNum c || c `elem` "+-._")
+    P.spaces
+    verRange <- parsec <|> pure anyVersion
+    pure $ Dependency (mkPackageName name) verRange
+
+parsecBuildTool :: P.Stream s Identity Char => P.Parsec s [PWarning] Dependency
+parsecBuildTool = do
+    name <- parsecMaybeQuoted nameP
+    P.spaces
+    verRange <- parsec <|> pure anyVersion
+    pure $ Dependency (mkPackageName name) verRange
+  where
+    nameP = intercalate "-" <$> P.sepBy1 component (P.char '-')
+    component = do
+        cs <- P.munch1 (\c -> isAlphaNum c || c == '+' || c == '_')
+        if all isDigit cs then fail "invalid component" else return cs
+
+parsecToken :: P.Stream s Identity Char => P.Parsec s [PWarning] String
+parsecToken = parsecHaskellString <|> (P.munch1 (\x -> not (isSpace x) && x /= ',')  P.<?> "identifier" )
+
+parsecToken' :: P.Stream s Identity Char => P.Parsec s [PWarning] String
+parsecToken' = parsecHaskellString <|> (P.munch1 (not . isSpace) P.<?> "token")
+
+parsecFilePath :: P.Stream s Identity Char => P.Parsec s [PWarning] String
+parsecFilePath = parsecToken
+
+stdParse
+    :: P.Stream s Identity Char
+    => (Version -> String -> a)
+    -> P.Parsec s [PWarning] a
+stdParse f = do
+    -- TODO: this backtracks
+    cs   <- some $ P.try (component <* P.char '-')
+    ver  <- parsec
+    let name = map toLower (intercalate "-" cs)
+    return $! f ver name
+  where
+    component = do
+      cs <- P.munch1 isAlphaNum
+      if all isDigit cs then fail "all digit component" else return cs
+      -- each component must contain an alphabetic character, to avoid
+      -- ambiguity in identifiers like foo-1 (the 1 is the version number).
+
+parsecCommaList
+    :: P.Stream s Identity Char
+    => P.Parsec s [PWarning] a
+    -> P.Parsec s [PWarning] [a]
+parsecCommaList p = P.sepBy (p <* P.spaces) (P.char ',' *> P.spaces)
+
+parsecOptCommaList
+    :: P.Stream s Identity Char
+    => P.Parsec s [PWarning] a
+    -> P.Parsec s [PWarning] [a]
+parsecOptCommaList p = P.sepBy (p <* P.spaces) (P.optional comma)
+  where
+    comma = P.char ',' *>  P.spaces
+
+
+-- | Content isn't unquoted
+parsecQuoted
+     :: P.Stream s Identity Char
+     => P.Parsec s [PWarning] a
+     -> P.Parsec s [PWarning] a
+parsecQuoted = P.between (P.char '"') (P.char '"')
+
+-- | @parsecMaybeQuoted p = 'parsecQuoted' p <|> p@.
+parsecMaybeQuoted
+     :: P.Stream s Identity Char
+     => P.Parsec s [PWarning] a
+     -> P.Parsec s [PWarning] a
+parsecMaybeQuoted p = parsecQuoted p <|> p
+
+parsecHaskellString :: P.Stream s Identity Char => P.Parsec s [PWarning] String
+parsecHaskellString = Parsec.stringLiteral $ Parsec.makeTokenParser Parsec.emptyDef
+    { Parsec.commentStart   = "{-"
+    , Parsec.commentEnd     = "-}"
+    , Parsec.commentLine    = "--"
+    , Parsec.nestedComments = True
+    , Parsec.identStart     = P.satisfy isAlphaNum
+    , Parsec.identLetter    = P.satisfy isAlphaNum <|> P.oneOf "_'"
+    , Parsec.opStart        = opl
+    , Parsec.opLetter       = opl
+    , Parsec.reservedOpNames= []
+    , Parsec.reservedNames  = []
+    , Parsec.caseSensitive  = True
+    }
+  where
+    opl = P.oneOf ":!#$%&*+./<=>?@\\^|-~"
+
+parsecIdent :: P.Stream s Identity Char => P.Parsec s [PWarning] String
+parsecIdent = (:) <$> firstChar <*> rest
+  where
+    firstChar = P.satisfy isAlpha
+    rest      = P.munch (\c -> isAlphaNum c || c == '_' || c == '-')

--- a/Cabal/Distribution/Parsec/ConfVar.hs
+++ b/Cabal/Distribution/Parsec/ConfVar.hs
@@ -19,7 +19,7 @@ import           Distribution.Types.GenericPackageDescription
                  (Condition (..), ConfVar (..))
 import           Distribution.Version
                  (mkVersion, anyVersion, earlierVersion,
-                 intersectVersionRanges, laterVersion, noVersion,
+                 intersectVersionRanges, laterVersion, noVersion, majorBoundVersion,
                  orEarlierVersion, orLaterVersion, thisVersion,
                  unionVersionRanges, withinVersion)
 
@@ -97,6 +97,7 @@ parser = condOr
                      ("<=", orEarlierVersion),
                      (">",  laterVersion),
                      (">=", orLaterVersion),
+                     ("^>=", majorBoundVersion),
                      ("==", thisVersion) ]
 
     -- numbers are weird: SecArgNum (Position 65 15) "7.6.1"

--- a/Cabal/Distribution/Parsec/ConfVar.hs
+++ b/Cabal/Distribution/Parsec/ConfVar.hs
@@ -134,5 +134,5 @@ parser = condOr
         i <- ident
         case P.runParser (p <* P.eof) [] "<ident>" i of
             Right x  -> pure x
-            -- | TODO: better lifting or errors / warnings
+            -- TODO: better lifting or errors / warnings
             Left err -> fail $ show err

--- a/Cabal/Distribution/Parsec/ConfVar.hs
+++ b/Cabal/Distribution/Parsec/ConfVar.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Distribution.Parsec.ConfVar (parseConditionConfVar) where
+
+import           Distribution.Compat.Prelude
+import           Prelude ()
+
+import           Distribution.Compat.Parsec                   (integral)
+import qualified Text.Parsec                                  as P
+--import qualified Text.Parsec.Pos                              as P
+import qualified Text.Parsec.Error                            as P
+
+import           Distribution.Parsec.Class                    (Parsec (..))
+import           Distribution.Parsec.Types.Common
+import           Distribution.Parsec.Types.Field              (SectionArg (..))
+import           Distribution.Parsec.Types.ParseResult
+import           Distribution.Simple.Utils                    (fromUTF8BS)
+import           Distribution.Types.GenericPackageDescription
+                 (Condition (..), ConfVar (..))
+import           Distribution.Version
+                 (mkVersion, anyVersion, earlierVersion,
+                 intersectVersionRanges, laterVersion, noVersion,
+                 orEarlierVersion, orLaterVersion, thisVersion,
+                 unionVersionRanges, withinVersion)
+
+-- | Parse @'Condition' 'ConfVar'@ from section arguments provided by parsec
+-- based outline parser.
+parseConditionConfVar :: [SectionArg Position] -> ParseResult (Condition ConfVar)
+parseConditionConfVar args = do
+    -- Warnings!
+    args' <- preprocess args
+    case P.runParser (parser <* P.eof) () "<condition>" args' of
+        Right x  -> pure x
+        Left err -> do
+            let ppos = P.errorPos err
+            let epos = Position (P.sourceLine ppos) (P.sourceColumn ppos)
+            let msg = P.showErrorMessages
+                    "or" "unknown parse error" "expecting" "unexpected" "end of input"
+                    (P.errorMessages err)
+            parseFailure epos msg
+            pure $ Lit True
+
+-- This is a hack, as we have "broken" .cabal files on Hackage
+preprocess :: [SectionArg Position] -> ParseResult [SectionArg Position]
+preprocess (SecArgOther pos "&&!" : rest) = do
+    parseWarning pos PWTGluedOperators "Glued operators: &&!"
+    (\rest' -> SecArgOther pos "&&" : SecArgOther pos "!" : rest') <$> preprocess rest
+preprocess (x : rest) =
+    (x: ) <$> preprocess rest
+preprocess [] = pure []
+
+type Parser = P.Parsec [SectionArg Position] ()
+
+parser :: Parser (Condition ConfVar)
+parser = condOr
+  where
+    condOr       = P.sepBy1 condAnd (oper "||") >>= return . foldl1 COr
+    condAnd      = P.sepBy1 cond    (oper "&&") >>= return . foldl1 CAnd
+    cond         = P.choice
+         [ boolLiteral, parens condOr,  notCond, osCond, archCond, flagCond, implCond ]
+
+    notCond      = CNot <$ oper "!" <*> cond
+
+    boolLiteral  = Lit <$> boolLiteral'
+    osCond       = Var . OS   <$ string "os"   <*> parens fromParsec
+    flagCond     = Var . Flag <$ string "flag" <*> parens fromParsec
+    archCond     = Var . Arch <$ string "arch" <*> parens fromParsec
+    implCond     = Var        <$ string "impl" <*> parens implCond'
+
+    implCond'    = Impl
+        <$> fromParsec
+        <*> P.option anyVersion versionRange
+
+    version = fromParsec
+    versionStar  = mkVersion <$> fromParsec' versionStar' <* oper "*"
+    versionStar' = some (integral <* P.char '.')
+
+    versionRange = expr
+      where
+        expr = foldl1 unionVersionRanges     <$> P.sepBy1 term   (oper "||")
+        term = foldl1 intersectVersionRanges <$> P.sepBy1 factor (oper "&&")
+
+        factor = P.choice
+            $ parens expr
+            : parseAnyVersion
+            : parseNoVersion
+            : parseWildcardRange
+            : map parseRangeOp rangeOps
+
+        parseAnyVersion    = anyVersion <$ string "-any"
+        parseNoVersion     = noVersion  <$ string "-none"
+
+        parseWildcardRange = P.try $ withinVersion <$ oper "==" <*> versionStar
+
+        parseRangeOp (s,f) = P.try (f <$ oper s <*> version)
+        rangeOps = [ ("<",  earlierVersion),
+                     ("<=", orEarlierVersion),
+                     (">",  laterVersion),
+                     (">=", orLaterVersion),
+                     ("==", thisVersion) ]
+
+    -- numbers are weird: SecArgNum (Position 65 15) "7.6.1"
+    ident = tokenPrim $ \case
+        SecArgName _ s -> Just $ fromUTF8BS s
+        SecArgNum  _ s -> Just $ fromUTF8BS s
+        _              -> Nothing
+
+    boolLiteral' = tokenPrim $ \case
+        SecArgName _ s
+            | s == "True"  -> Just True
+            | s == "true"  -> Just True
+            | s == "False" -> Just False
+            | s == "false" -> Just False
+        _                  -> Nothing
+
+    string s = tokenPrim $ \case
+        SecArgName _ s' | s == s' -> Just ()
+        _                         -> Nothing
+
+    oper o = tokenPrim $ \case
+        SecArgOther _ o' | o == o' -> Just ()
+        _                          -> Nothing
+
+    parens = P.between (oper "(") (oper ")")
+
+    tokenPrim = P.tokenPrim prettySectionArg updatePosition
+    updatePosition x _ _ = x
+    prettySectionArg = show
+
+    fromParsec :: Parsec a => Parser a
+    fromParsec = fromParsec' parsec
+
+    fromParsec' p = do
+        i <- ident
+        case P.runParser (p <* P.eof) [] "<ident>" i of
+            Right x  -> pure x
+            -- | TODO: better lifting or errors / warnings
+            Left err -> fail $ show err

--- a/Cabal/Distribution/Parsec/Lexer.x
+++ b/Cabal/Distribution/Parsec/Lexer.x
@@ -1,0 +1,263 @@
+{
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Parsec.Lexer
+-- License     :  BSD3
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Portability :  portable
+--
+-- Lexer for the cabal files.
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
+#ifdef CABAL_PARSEC_DEBUG
+{-# LANGUAGE PatternGuards #-}
+#endif
+module Distribution.Parsec.Lexer
+  (ltest, lexToken, Token(..), LToken(..)
+  ,bol_section, in_section, in_field_layout, in_field_braces
+  ,mkLexState) where
+
+import Prelude ()
+import qualified Prelude as Prelude
+import Distribution.Compat.Prelude
+
+import Distribution.Parsec.LexerMonad
+import Distribution.Parsec.Types.Common (Position (..), incPos, retPos)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as B.Char8
+import Data.Word (Word8)
+
+#ifdef CABAL_PARSEC_DEBUG
+import Debug.Trace
+import qualified Data.Vector as V
+import qualified Data.Text   as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Text.Encoding.Error as T
+#endif
+
+}
+-- Various character classes
+
+$space           = \          -- single space char
+$digit           = 0-9        -- digits
+$alpha           = [a-z A-Z]  -- alphabetic characters
+$symbol          = [\= \< \> \+ \* \- \& \| \! \$ \% \^ \@ \# \? \/ \\ \~]
+$ctlchar         = [\x0-\x1f \x7f]
+$printable       = \x0-\x10ffff # $ctlchar   -- so no \n \r
+$spacetab        = [$space \t]
+$bom             = \xfeff
+$nbsp            = \xa0
+$nbspspacetab    = [$nbsp $space \t]
+
+$paren           = [ \( \) \[ \] ]
+$field_layout    = [$printable \t]
+$field_layout'   = [$printable] # [$space]
+$field_braces    = [$printable \t] # [\{ \}]
+$field_braces'   = [$printable] # [\{ \} $space]
+$comment         = [$printable \t]
+$namecore        = [$alpha]
+$nameextra       = [$namecore $digit \- \_ \. \']
+$instr           = [$printable $space] # [\"]
+$instresc        = $printable
+
+@nl          = \n | \r\n | \r
+@name        = $nameextra* $namecore $nameextra*
+@string      = \" ( $instr | \\ $instresc )* \"
+@numlike     = $digit [$digit \.]*
+@oplike      = [ \, \. \= \< \> \+ \* \- \& \| \! \$ \% \^ \@ \# \? \/ \\ \~ ]+
+
+tokens :-
+
+<0> {
+  $bom   { \_ _ _ -> addWarning LexWarningBOM "Byte-order mark found at the beginning of the file" >> lexToken }
+  ()     ;
+}
+
+<bol_section, bol_field_layout, bol_field_braces> {
+  $spacetab* @nl                        { \_ _ _ -> adjustPos retPos >> lexToken }
+  $nbspspacetab+ @nl                    { \_ _ _ -> adjustPos retPos >> addWarning LexWarningNBSP "Non-breaking space occured" >> lexToken }
+  -- no @nl here to allow for comments on last line of the file with no trailing \n
+  $spacetab* "--" $comment*             ;  -- TODO: check the lack of @nl works here
+                                        -- including counting line numbers
+}
+
+<bol_section> {
+  $spacetab*  --TODO prevent or record leading tabs
+                   { \pos len inp -> if B.length inp == len
+                                       then return (L pos EOF)
+                                       else setStartCode in_section
+                                         >> return (L pos (Indent len)) }
+  $spacetab* \{    { tok  OpenBrace }
+  $spacetab* \}    { tok  CloseBrace }
+}
+
+<in_section> {
+  $spacetab+   ; --TODO: don't allow tab as leading space
+
+  "--" $comment* ;
+
+  @name        { toki TokSym }
+  @string      { \p l i -> case reads (B.Char8.unpack (B.take l i)) of
+                             [(str,[])] -> return (L p (TokStr str))
+                             _          -> lexicalError p i }
+  @numlike     { toki TokNum }
+  @oplike      { toki TokOther }
+  $paren       { toki TokOther }
+  \:           { tok  Colon }
+  \{           { tok  OpenBrace }
+  \}           { tok  CloseBrace }
+  @nl          { \_ _ _ -> adjustPos retPos >> setStartCode bol_section >> lexToken }
+}
+
+<bol_field_layout> {
+  $spacetab*   --TODO prevent or record leading tabs
+                { \pos len inp -> if B.length inp == len
+                                    then return (L pos EOF)
+                                    else setStartCode in_field_layout
+                                      >> return (L pos (Indent len)) }
+}
+
+<in_field_layout> {
+  $spacetab+; --TODO prevent or record leading tabs
+  $field_layout' $field_layout*  { toki TokFieldLine }
+  @nl             { \_ _ _ -> adjustPos retPos >> setStartCode bol_field_layout >> lexToken }
+}
+
+<bol_field_braces> {
+   ()                { \_ _ _ -> setStartCode in_field_braces >> lexToken }
+}
+
+<in_field_braces> {
+  $spacetab+; --TODO prevent or record leading tabs
+  $field_braces' $field_braces*    { toki TokFieldLine }
+  \{                { tok  OpenBrace  }
+  \}                { tok  CloseBrace }
+  @nl               { \_ _ _ -> adjustPos retPos >> setStartCode bol_field_braces >> lexToken }
+}
+
+{
+
+-- | Tokens of outer cabal file structure. Field values are treated opaquely.
+data Token = TokSym   !ByteString       -- ^ Haskell-like identifier
+           | TokStr   !String           -- ^ String in quotes
+           | TokNum   !ByteString       -- ^ Integral
+           | TokOther !ByteString       -- ^ Operator like token
+           | Indent   !Int              -- ^ Indentation token
+           | TokFieldLine !ByteString   -- ^ Lines after @:@
+           | Colon
+           | OpenBrace
+           | CloseBrace
+           | EOF
+           | LexicalError InputStream --TODO: add separate string lexical error
+  deriving Show
+
+data LToken = L !Position !Token
+  deriving Show
+
+toki :: Monad m => (ByteString -> Token) -> Position -> Int -> ByteString -> m LToken
+toki t pos  len  input = return $! L pos (t (B.take len input))
+
+tok :: Monad m => Token -> Position -> t -> t1 -> m LToken
+tok  t pos _len _input = return $! L pos t
+
+-- -----------------------------------------------------------------------------
+-- The input type
+
+type AlexInput = InputStream
+
+alexInputPrevChar :: AlexInput -> Char
+alexInputPrevChar _ = error "alexInputPrevChar not used"
+
+alexGetByte :: AlexInput -> Maybe (Word8,AlexInput)
+alexGetByte = B.uncons
+
+lexicalError :: Position -> InputStream -> Lex LToken
+lexicalError pos inp = do
+  setInput B.empty
+  return $! L pos (LexicalError inp)
+
+lexToken :: Lex LToken
+lexToken = do
+  pos <- getPos
+  inp <- getInput
+  st  <- getStartCode
+  case alexScan inp st of
+    AlexEOF -> return (L pos EOF)
+    AlexError inp' ->
+        let !len_bytes = B.length inp - B.length inp' in
+            --FIXME: we want len_chars here really
+            -- need to decode utf8 up to this point
+        lexicalError (incPos len_bytes pos) inp'
+    AlexSkip  inp' len_chars -> do
+        checkPosition pos inp inp' len_chars
+        adjustPos (incPos len_chars)
+        setInput inp'
+        lexToken
+    AlexToken inp' len_chars action -> do
+        checkPosition pos inp inp' len_chars
+        adjustPos (incPos len_chars)
+        setInput inp'
+        let !len_bytes = B.length inp - B.length inp'
+        t <- action pos len_bytes inp
+        --traceShow t $ return tok
+        return t
+
+
+checkPosition :: Position -> ByteString -> ByteString -> Int -> Lex ()
+#ifdef CABAL_PARSEC_DEBUG
+checkPosition pos@(Position lineno colno) inp inp' len_chars = do
+    text_lines <- getDbgText
+    let len_bytes = B.length inp - B.length inp'
+        pos_txt   | lineno-1 < V.length text_lines = T.take len_chars (T.drop (colno-1) (text_lines V.! (lineno-1)))
+                  | otherwise = T.empty
+        real_txt  = B.take len_bytes inp
+    when (pos_txt /= T.decodeUtf8 real_txt) $
+      traceShow (pos, pos_txt, T.decodeUtf8 real_txt) $
+      traceShow (take 3 (V.toList text_lines)) $ return ()
+  where
+    getDbgText = Lex $ \s@LexState{ dbgText = txt } -> LexResult s txt
+#else
+checkPosition _ _ _ _ = return ()
+#endif
+
+lexAll :: Lex [LToken]
+lexAll = do
+  t <- lexToken
+  case t of
+    L _ EOF -> return [t]
+    _       -> do ts <- lexAll
+                  return (t : ts)
+
+ltest :: Int -> String -> Prelude.IO ()
+ltest code s =
+  let (ws, xs) = execLexer (setStartCode code >> lexAll) (B.Char8.pack s)
+   in traverse_ print ws >> traverse_ print xs
+
+
+mkLexState :: ByteString -> LexState
+mkLexState input = LexState
+  { curPos   = Position 1 1
+  , curInput = input
+  , curCode  = bol_section
+  , warnings = []
+#ifdef CABAL_PARSEC_DEBUG
+  , dbgText  = V.fromList . lines' . T.decodeUtf8With T.lenientDecode $ input
+#endif
+  }
+
+#ifdef CABAL_PARSEC_DEBUG
+lines' :: T.Text -> [T.Text]
+lines' s1
+  | T.null s1 = []
+  | otherwise = case T.break (\c -> c == '\r' || c == '\n') s1 of
+                  (l, s2) | Just (c,s3) <- T.uncons s2
+                         -> case T.uncons s3 of
+                              Just ('\n', s4) | c == '\r' -> l `T.snoc` '\r' `T.snoc` '\n' : lines' s4
+                              _                           -> l `T.snoc` c : lines' s3
+
+                          | otherwise
+                         -> [l]
+#endif
+}

--- a/Cabal/Distribution/Parsec/LexerMonad.hs
+++ b/Cabal/Distribution/Parsec/LexerMonad.hs
@@ -31,19 +31,17 @@ module Distribution.Parsec.LexerMonad (
 
   ) where
 
-import Prelude ()
-import Distribution.Compat.Prelude
-
-import Distribution.Parsec.Types.Common (Position (..), PWarning (..), PWarnType (..))
-
-import qualified Data.ByteString as B
-
+import           Prelude ()
+import           Distribution.Compat.Prelude
+import qualified Data.ByteString                  as B
+import           Distribution.Parsec.Types.Common
+                 (PWarnType (..), PWarning (..), Position (..))
 
 #ifdef CABAL_PARSEC_DEBUG
 -- testing only:
-import qualified Data.Vector as V
-import qualified Data.Text   as T
-import qualified Data.Text.Encoding as T
+import qualified Data.Text                        as T
+import qualified Data.Text.Encoding               as T
+import qualified Data.Vector                      as V
 #endif
 
 -- simple state monad
@@ -80,12 +78,12 @@ toPWarning (LexWarning t p s) = PWarning t' p s
         LexWarningBOM  -> PWTLexBOM
 
 data LexState = LexState {
-        curPos   :: {-# UNPACK #-} !Position,        -- position at current input location
-        curInput :: {-# UNPACK #-} !InputStream,     -- the current input
-        curCode  :: {-# UNPACK #-} !StartCode,       -- lexer code
+        curPos   :: {-# UNPACK #-} !Position,        -- ^ position at current input location
+        curInput :: {-# UNPACK #-} !InputStream,     -- ^ the current input
+        curCode  :: {-# UNPACK #-} !StartCode,       -- ^ lexer code
         warnings :: [LexWarning]
 #ifdef CABAL_PARSEC_DEBUG
-        , dbgText  :: V.Vector T.Text
+        , dbgText  :: V.Vector T.Text                -- ^ input lines, to print pretty debug info
 #endif
      } --TODO: check if we should cache the first token
        -- since it looks like parsec's uncons can be called many times on the same input

--- a/Cabal/Distribution/Parsec/LexerMonad.hs
+++ b/Cabal/Distribution/Parsec/LexerMonad.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE CPP #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Parsec.LexerMonad
+-- License     :  BSD3
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Portability :  portable
+module Distribution.Parsec.LexerMonad (
+    InputStream,
+    LexState(..),
+    LexResult(..),
+
+    Lex(..),
+    execLexer,
+
+    getPos,
+    setPos,
+    adjustPos,
+
+    getInput,
+    setInput,
+
+    getStartCode,
+    setStartCode,
+
+    LexWarning(..),
+    LexWarningType(..),
+    addWarning,
+    toPWarning,
+
+  ) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+import Distribution.Parsec.Types.Common (Position (..), PWarning (..), PWarnType (..))
+
+import qualified Data.ByteString as B
+
+
+#ifdef CABAL_PARSEC_DEBUG
+-- testing only:
+import qualified Data.Vector as V
+import qualified Data.Text   as T
+import qualified Data.Text.Encoding as T
+#endif
+
+-- simple state monad
+newtype Lex a = Lex { unLex :: LexState -> LexResult a }
+
+instance Functor Lex where
+  fmap = liftM
+
+instance Applicative Lex where
+  pure = returnLex
+  (<*>) = ap
+
+instance Monad Lex where
+  return = pure
+  (>>=)  = thenLex
+
+data LexResult a = LexResult {-# UNPACK #-} !LexState a
+
+data LexWarningType
+    = LexWarningNBSP  -- ^ Encountered non breaking space
+    | LexWarningBOM   -- ^ BOM at the start of the cabal file
+  deriving (Show)
+
+data LexWarning = LexWarning                !LexWarningType
+                             {-# UNPACK #-} !Position
+                                            !String
+  deriving (Show)
+
+toPWarning :: LexWarning -> PWarning
+toPWarning (LexWarning t p s) = PWarning t' p s
+  where
+    t' = case t of
+        LexWarningNBSP -> PWTLexNBSP
+        LexWarningBOM  -> PWTLexBOM
+
+data LexState = LexState {
+        curPos   :: {-# UNPACK #-} !Position,        -- position at current input location
+        curInput :: {-# UNPACK #-} !InputStream,     -- the current input
+        curCode  :: {-# UNPACK #-} !StartCode,       -- lexer code
+        warnings :: [LexWarning]
+#ifdef CABAL_PARSEC_DEBUG
+        , dbgText  :: V.Vector T.Text
+#endif
+     } --TODO: check if we should cache the first token
+       -- since it looks like parsec's uncons can be called many times on the same input
+
+type StartCode   = Int    -- ^ An @alex@ lexer start code
+type InputStream = B.ByteString
+
+
+
+-- | Execute the given lexer on the supplied input stream.
+execLexer :: Lex a -> InputStream -> ([LexWarning], a)
+execLexer (Lex lexer) input =
+    case lexer initialState of
+      LexResult LexState{ warnings = ws } result -> (ws, result)
+  where
+    initialState = LexState
+      -- TODO: add 'startPosition'
+      { curPos   = Position 1 1
+      , curInput = input
+      , curCode  = 0
+      , warnings = []
+#ifdef CABAL_PARSEC_DEBUG
+      , dbgText  = V.fromList . T.lines . T.decodeUtf8 $ input
+#endif
+      }
+
+{-# INLINE returnLex #-}
+returnLex :: a -> Lex a
+returnLex a = Lex $ \s -> LexResult s a
+
+{-# INLINE thenLex #-}
+thenLex :: Lex a -> (a -> Lex b) -> Lex b
+(Lex m) `thenLex` k = Lex $ \s -> case m s of LexResult s' a -> (unLex (k a)) s'
+
+setPos :: Position -> Lex ()
+setPos pos = Lex $ \s -> LexResult s{ curPos = pos } ()
+
+getPos :: Lex Position
+getPos = Lex $ \s@LexState{ curPos = pos } -> LexResult s pos
+
+adjustPos :: (Position -> Position) -> Lex ()
+adjustPos f = Lex $ \s@LexState{ curPos = pos } -> LexResult s{ curPos = f pos } ()
+
+getInput :: Lex InputStream
+getInput = Lex $ \s@LexState{ curInput = i } -> LexResult s i
+
+setInput :: InputStream -> Lex ()
+setInput i = Lex $ \s -> LexResult s{ curInput = i } ()
+
+getStartCode :: Lex Int
+getStartCode = Lex $ \s@LexState{ curCode = c } -> LexResult s c
+
+setStartCode :: Int -> Lex ()
+setStartCode c = Lex $ \s -> LexResult s{ curCode = c } ()
+
+-- | Add warning at the current position
+addWarning :: LexWarningType -> String -> Lex ()
+addWarning wt msg = Lex $ \s@LexState{ curPos = pos, warnings = ws  } ->
+    LexResult s{ warnings = LexWarning wt pos msg : ws } ()

--- a/Cabal/Distribution/Parsec/Parser.hs
+++ b/Cabal/Distribution/Parsec/Parser.hs
@@ -320,7 +320,7 @@ readFields s = fmap elaborate $ parse cabalStyleFile "the input" lexSt
     lexSt = mkLexState' (mkLexState s)
 
 readFields' :: B.ByteString -> Either ParseError ([Field Position], [LexWarning])
-readFields' s = parse (liftM2 (,) cabalStyleFile getLexerWarnings) "the input" lexSt
+readFields' s = fmap (first elaborate) $ parse (liftM2 (,) cabalStyleFile getLexerWarnings) "the input" lexSt
   where
     lexSt = mkLexState' (mkLexState s)
 

--- a/Cabal/Distribution/Parsec/Parser.hs
+++ b/Cabal/Distribution/Parsec/Parser.hs
@@ -320,8 +320,13 @@ readFields s = fmap fst (readFields' s)
 readFields' :: B8.ByteString -> Either ParseError ([Field Position], [LexWarning])
 readFields' s = parse (liftM2 (,) cabalStyleFile getLexerWarnings) "the input" lexSt
   where
-    s' = B.pack .encodeStringUtf8 . decodeStringUtf8 . B.unpack $ s
+    s' = B.pack . recodeStringUtf8 . B.unpack $ s
     lexSt = mkLexState' (mkLexState s')
+
+-- TODO: For some reason alex parser cannot handle BOM, is it a bug?
+recodeStringUtf8 :: [Word8] -> [Word8]
+recodeStringUtf8 (0xef : 0xbb : 0xbf : bytes) = encodeStringUtf8 (decodeStringUtf8 bytes)
+recodeStringUtf8 bytes                        = encodeStringUtf8 (decodeStringUtf8 bytes)
 
 #ifdef CABAL_PARSEC_DEBUG
 parseTest' :: Show a => Parsec LexState' () a -> SourceName -> B8.ByteString -> IO ()

--- a/Cabal/Distribution/Parsec/Parser.hs
+++ b/Cabal/Distribution/Parsec/Parser.hs
@@ -1,0 +1,416 @@
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+#ifdef CABAL_PARSEC_DEBUG
+{-# LANGUAGE PatternGuards         #-}
+#endif
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Parsec.Parser
+-- License     :  BSD3
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Portability :  portable
+module Distribution.Parsec.Parser (
+    -- * Types
+    Field(..),
+    Name(..),
+    FieldLine(..),
+    SectionArg(..),
+    -- * Grammar and parsing
+    -- $grammar
+    readFields,
+    readFields',
+    -- * Transformations
+    elaborate,
+    fromOldSyntax,
+#ifdef CABAL_PARSEC_DEBUG
+    parseFile,
+    parseStr,
+    parseBS,
+#endif
+    ) where
+
+import           Distribution.Compat.Prelude
+import           Prelude
+                 ()
+
+-- TODO: introduce Distribution.Compat.Parsec
+import           Distribution.Parsec.Lexer
+import           Distribution.Parsec.LexerMonad
+                 (LexResult (..), LexState (..), LexWarning, unLex)
+import           Distribution.Parsec.Types.Common
+import           Distribution.Parsec.Types.Field
+
+import           Control.Monad
+                 (guard)
+import qualified Data.ByteString.Char8            as B
+import           Data.Functor.Identity
+import           Text.Parsec.Combinator           hiding
+                 (eof, notFollowedBy)
+import           Text.Parsec.Error
+import           Text.Parsec.Pos
+import           Text.Parsec.Prim                 hiding
+                 (many, (<|>))
+
+#ifdef CABAL_PARSEC_DEBUG
+import qualified Data.Text                        as T
+import qualified Data.Text.Encoding               as T
+import qualified Data.Text.Encoding.Error         as T
+#endif
+
+data LexState' = LexState' !LexState (LToken, LexState')
+
+mkLexState' :: LexState -> LexState'
+mkLexState' st = LexState' st
+                   (case unLex lexToken st of LexResult st' tok -> (tok, mkLexState' st'))
+
+type Parser a = ParsecT LexState' () Identity a
+
+instance Stream LexState' Identity LToken where
+  uncons (LexState' _ (tok, st')) =
+    case tok of
+      L _ EOF -> return Nothing
+      _       -> return (Just (tok, st'))
+
+-- | Get lexer warnings accumulated so far
+getLexerWarnings :: Parser [LexWarning]
+getLexerWarnings = do
+  LexState' (LexState { warnings = ws }) _ <- getInput
+  return ws
+
+setLexerMode :: Int -> Parser ()
+setLexerMode code = do
+  LexState' ls _ <- getInput
+  setInput $! mkLexState' ls { curCode = code }
+
+getToken :: (Token -> Maybe a) -> Parser a
+getToken getTok = getTokenWithPos (\(L _ t) -> getTok t)
+
+getTokenWithPos :: (LToken -> Maybe a) -> Parser a
+getTokenWithPos getTok = tokenPrim (\(L _ t) -> describeToken t) updatePos getTok
+  where
+    updatePos :: SourcePos -> LToken -> LexState' -> SourcePos
+    updatePos pos (L (Position col line) _) _ = newPos (sourceName pos) col line
+
+describeToken :: Token -> String
+describeToken t = case t of
+  TokSym   s      -> "name "   ++ show s
+  TokStr   s      -> "string " ++ show s
+  TokNum   s      -> "number " ++ show s
+  TokOther s      -> "symbol " ++ show s
+  Indent _        -> "new line"
+  TokFieldLine _  -> "field content"
+  Colon           -> "\":\""
+  OpenBrace       -> "\"{\""
+  CloseBrace      -> "\"}\""
+--  SemiColon       -> "\";\""
+  EOF             -> "end of file"
+  LexicalError is -> "character in input " ++ show (B.head is)
+
+tokName :: Parser (Name Position)
+tokName', tokStr, tokNum, tokOther :: Parser (SectionArg Position)
+tokIndent :: Parser Int
+tokColon, tokOpenBrace, tokCloseBrace :: Parser ()
+tokFieldLine :: Parser (FieldLine Position)
+
+tokName       = getTokenWithPos $ \t -> case t of L pos (TokSym x) -> Just (mkName pos x);  _ -> Nothing
+tokName'      = getTokenWithPos $ \t -> case t of L pos (TokSym x) -> Just (SecArgName pos x);  _ -> Nothing
+tokStr        = getTokenWithPos $ \t -> case t of L pos (TokStr   x) -> Just (SecArgStr pos x);  _ -> Nothing
+tokNum        = getTokenWithPos $ \t -> case t of L pos (TokNum   x) -> Just (SecArgNum pos x);  _ -> Nothing
+tokOther      = getTokenWithPos $ \t -> case t of L pos (TokOther x) -> Just (SecArgOther pos x);  _ -> Nothing
+tokIndent     = getToken $ \t -> case t of Indent   x -> Just x;  _ -> Nothing
+tokColon      = getToken $ \t -> case t of Colon      -> Just (); _ -> Nothing
+tokOpenBrace  = getToken $ \t -> case t of OpenBrace  -> Just (); _ -> Nothing
+tokCloseBrace = getToken $ \t -> case t of CloseBrace -> Just (); _ -> Nothing
+tokFieldLine  = getTokenWithPos $ \t -> case t of L pos (TokFieldLine s) -> Just (FieldLine pos s); _ -> Nothing
+
+colon, openBrace, closeBrace :: Parser ()
+
+sectionArg :: Parser (SectionArg Position)
+sectionArg   = tokName' <|> tokStr
+            <|> tokNum <|> tokOther <?> "section parameter"
+
+fieldSecName :: Parser (Name Position)
+fieldSecName = tokName              <?> "field or section name"
+
+colon        = tokColon      <?> "\":\""
+openBrace    = tokOpenBrace  <?> "\"{\""
+closeBrace   = tokCloseBrace <?> "\"}\""
+
+fieldContent :: Parser (FieldLine Position)
+fieldContent = tokFieldLine <?> "field contents"
+
+newtype IndentLevel = IndentLevel Int
+
+zeroIndentLevel :: IndentLevel
+zeroIndentLevel = IndentLevel 0
+
+incIndentLevel :: IndentLevel -> IndentLevel
+incIndentLevel (IndentLevel i) = IndentLevel (succ i)
+
+indentOfAtLeast :: IndentLevel -> Parser IndentLevel
+indentOfAtLeast (IndentLevel i) = try $ do
+  j <- tokIndent
+  guard (j >= i) <?> "indentation of at least " ++ show i
+  return (IndentLevel j)
+
+
+newtype LexerMode = LexerMode Int
+
+inLexerMode :: LexerMode -> Parser p -> Parser p
+inLexerMode (LexerMode mode) p =
+  do setLexerMode mode; x <- p; setLexerMode in_section; return x
+
+
+-----------------------
+-- Cabal file grammar
+--
+
+-- $grammar
+--
+-- @
+-- SecElems      ::= SecElem* '\n'?
+-- SecElem       ::= '\n' SecElemLayout | SecElemBraces
+-- SecElemLayout ::= FieldLayout | FieldBraces | SectionLayout | SectionBraces
+-- SecElemBraces ::= FieldInline | FieldBraces |                 SectionBraces
+-- FieldLayout   ::= name ':' line? ('\n' line)*
+-- FieldBraces   ::= name ':' '\n'? '{' content '}'
+-- FieldInline   ::= name ':' content
+-- SectionLayout ::= name arg* SecElems
+-- SectionBraces ::= name arg* '\n'? '{' SecElems '}'
+-- @
+--
+-- and the same thing but left factored...
+--
+-- @
+-- SecElems              ::= SecElem*
+-- SecElem               ::= '\n' name SecElemLayout
+--                         |      name SecElemBraces
+-- SecElemLayout         ::= ':'   FieldLayoutOrBraces
+--                         | arg*  SectionLayoutOrBraces
+-- FieldLayoutOrBraces   ::= '\n'? '{' content '}'
+--                         | line? ('\n' line)*
+-- SectionLayoutOrBraces ::= '\n'? '{' SecElems '\n'? '}'
+--                         | SecElems
+-- SecElemBraces         ::= ':' FieldInlineOrBraces
+--                         | arg* '\n'? '{' SecElems '\n'? '}'
+-- FieldInlineOrBraces   ::= '\n'? '{' content '}'
+--                         | content
+-- @
+--
+-- Note how we have several productions with the sequence:
+--
+-- > '\n'? '{'
+--
+-- That is, an optional newline (and indent) followed by a @{@ token.
+-- In the @SectionLayoutOrBraces@ case you can see that this makes it
+-- not fully left factored (because @SecElems@ can start with a @\n@).
+-- Fully left factoring here would be ugly, and though we could use a
+-- lookahead of two tokens to resolve the alternatives, we can't
+-- conveniently use Parsec's 'try' here to get a lookahead of only two.
+-- So instead we deal with this case in the lexer by making a line
+-- where the first non-space is @{@ lex as just the @{@ token, without
+-- the usual indent token. Then in the parser we can resolve everything
+-- with just one token of lookahead and so without using 'try'.
+
+-- Top level of a file using cabal syntax
+--
+cabalStyleFile :: Parser [Field Position]
+cabalStyleFile = do es <- elements zeroIndentLevel
+                    eof
+                    return es
+
+-- Elements that live at the top level or inside a section, ie fields
+-- and sectionscontent
+--
+-- elements ::= element*
+elements :: IndentLevel -> Parser [Field Position]
+elements ilevel = many (element ilevel)
+
+-- An individual element, ie a field or a section. These can either use
+-- layout style or braces style. For layout style then it must start on
+-- a line on it's own (so that we know its indentation level).
+--
+-- element ::= '\n' name elementInLayoutContext
+--           |      name elementInNonLayoutContext
+element :: IndentLevel -> Parser (Field Position)
+element ilevel =
+      (do ilevel' <- indentOfAtLeast ilevel
+          name    <- fieldSecName
+          elementInLayoutContext (incIndentLevel ilevel') name)
+  <|> (do name    <- fieldSecName
+          elementInNonLayoutContext name)
+
+-- An element (field or section) that is valid in a layout context.
+-- In a layout context we can have fields and sections that themselves
+-- either use layout style or that use braces style.
+--
+-- elementInLayoutContext ::= ':'  fieldLayoutOrBraces
+--                          | arg* sectionLayoutOrBraces
+elementInLayoutContext :: IndentLevel -> Name Position -> Parser (Field Position)
+elementInLayoutContext ilevel name =
+      (do colon; fieldLayoutOrBraces ilevel name)
+  <|> (do args  <- many sectionArg
+          elems <- sectionLayoutOrBraces ilevel
+          return (Section name args elems))
+
+-- An element (field or section) that is valid in a non-layout context.
+-- In a non-layout context we can have only have fields and sections that
+-- themselves use braces style, or inline style fields.
+--
+-- elementInNonLayoutContext ::= ':' FieldInlineOrBraces
+--                             | arg* '\n'? '{' elements '\n'? '}'
+elementInNonLayoutContext :: Name Position -> Parser (Field Position)
+elementInNonLayoutContext name =
+      (do colon; fieldInlineOrBraces name)
+  <|> (do args <- many sectionArg
+          openBrace
+          elems <- elements zeroIndentLevel
+          optional tokIndent
+          closeBrace
+          return (Section name args elems))
+
+-- The body of a field, using either layout style or braces style.
+--
+-- fieldLayoutOrBraces   ::= '\n'? '{' content '}'
+--                         | line? ('\n' line)*
+fieldLayoutOrBraces :: IndentLevel -> Name Position -> Parser (Field Position)
+fieldLayoutOrBraces ilevel name =
+      (do openBrace
+          ls <- inLexerMode (LexerMode in_field_braces) (many fieldContent)
+          closeBrace
+          return (Field name ls))
+  <|> (inLexerMode (LexerMode in_field_layout)
+        (do l  <- option (FieldLine (Position 0 0) B.empty) fieldContent
+                  --FIXME ^^ having to add an extra empty here is silly!
+            ls <- many (do _ <- indentOfAtLeast ilevel; fieldContent)
+            return (Field name (l:ls))))
+
+-- The body of a section, using either layout style or braces style.
+--
+-- sectionLayoutOrBraces ::= '\n'? '{' elements \n? '}'
+--                         | elements
+sectionLayoutOrBraces :: IndentLevel -> Parser [Field Position]
+sectionLayoutOrBraces ilevel =
+      (do openBrace
+          elems <- elements zeroIndentLevel
+          optional tokIndent
+          closeBrace
+          return elems)
+  <|> (elements ilevel)
+
+-- The body of a field, using either inline style or braces.
+--
+-- fieldInlineOrBraces   ::= '\n'? '{' content '}'
+--                         | content
+fieldInlineOrBraces :: Name Position -> Parser (Field Position)
+fieldInlineOrBraces name =
+      (do openBrace
+          ls <- inLexerMode (LexerMode in_field_braces) (many fieldContent)
+          closeBrace
+          return (Field name ls))
+  <|> (do ls <- inLexerMode (LexerMode in_field_braces) (option [] (fmap (\l -> [l]) fieldContent))
+          return (Field name ls))
+
+
+readFields :: B.ByteString -> Either ParseError [Field Position]
+readFields s = fmap elaborate $ parse cabalStyleFile "the input" lexSt
+  where
+    lexSt = mkLexState' (mkLexState s)
+
+readFields' :: B.ByteString -> Either ParseError ([Field Position], [LexWarning])
+readFields' s = parse (liftM2 (,) cabalStyleFile getLexerWarnings) "the input" lexSt
+  where
+    lexSt = mkLexState' (mkLexState s)
+
+#ifdef CABAL_PARSEC_DEBUG
+parseTest' :: Show a => Parsec LexState' () a -> SourceName -> B.ByteString -> IO ()
+parseTest' p fname s =
+    case parse p fname (lexSt s) of
+      Left err -> putStrLn (formatError s err)
+
+      Right x  -> print x
+  where
+    lexSt = mkLexState' . mkLexState
+
+parseFile :: Show a => Parser a -> FilePath -> IO ()
+parseFile p f = B.readFile f >>= \s -> parseTest' p f s
+
+parseStr  :: Show a => Parser a -> String -> IO ()
+parseStr p = parseBS p . B.pack
+
+parseBS  :: Show a => Parser a -> B.ByteString -> IO ()
+parseBS p = parseTest' p "<input string>"
+
+formatError :: B.ByteString -> ParseError -> String
+formatError input perr =
+    unlines
+      [ "Parse error "++ show (errorPos perr) ++ ":"
+      , errLine
+      , indicator ++ errmsg ]
+  where
+    pos       = errorPos perr
+    ls        = lines' (T.decodeUtf8With T.lenientDecode input)
+    errLine   = T.unpack (ls !! (sourceLine pos - 1))
+    indicator = replicate (sourceColumn pos) ' ' ++ "^"
+    errmsg    = showErrorMessages "or" "unknown parse error"
+                                  "expecting" "unexpected" "end of file"
+                                  (errorMessages perr)
+
+lines' :: T.Text -> [T.Text]
+lines' s1
+  | T.null s1 = []
+  | otherwise = case T.break (\c -> c == '\r' || c == '\n') s1 of
+                  (l, s2) | Just (c,s3) <- T.uncons s2
+                         -> case T.uncons s3 of
+                              Just ('\n', s4) | c == '\r' -> l : lines' s4
+                              _               -> l : lines' s3
+                          | otherwise -> [l]
+#endif
+
+eof :: Parser ()
+eof = notFollowedBy anyToken <?> "end of file"
+  where
+    notFollowedBy :: Parser LToken -> Parser ()
+    notFollowedBy p = try (    (do L _ t <- try p; unexpected (describeToken t))
+                           <|> return ())
+--showErrorMessages "or" "unknown parse error"
+--                            "expecting" "unexpected" "end of input"
+
+-- | Elaborate a 'Section's with @if@ name into the 'IfElseBlock's.
+--
+-- TOOD: rename
+elaborate :: Show a => [Field a] -> [Field a]
+elaborate [] = []
+elaborate (field@Field{} : rest) = field : elaborate rest
+elaborate (IfElseBlock ann args t e : rest) =
+  IfElseBlock ann args (elaborate t) (elaborate e) : elaborate rest
+elaborate (Section name@(Name ann _) args fields : Section ename [] efields : rest)
+  | getName name == "if" && getName ename == "else" =
+    IfElseBlock ann args (elaborate fields) (elaborate efields) : elaborate rest
+elaborate (Section name@(Name ann _) args fields : rest)
+  | getName name == "if" =
+    IfElseBlock ann args (elaborate fields) [] : elaborate rest
+  | otherwise            =
+    Section name args (elaborate fields) : elaborate rest
+
+-- | TODO
+data OldSyntax = OldSyntax | NewSyntax
+    deriving (Show)
+
+-- | "Sectionize" an old-style Cabal file.  A sectionized file has:
+--
+--  * all global fields at the beginning, followed by
+--
+--  * all flag declarations, followed by
+--
+--  * an optional library section, and an arbitrary number of executable
+--    sections (in any order).
+--
+-- The current implementation just gathers all library-specific fields
+-- in a library section and wraps all executable stanzas in an executable
+-- section.
+fromOldSyntax :: [Field a] -> (OldSyntax, [Field a])
+-- TODO: implement me
+fromOldSyntax fs = (NewSyntax, fs)

--- a/Cabal/Distribution/Parsec/Types/Common.hs
+++ b/Cabal/Distribution/Parsec/Types/Common.hs
@@ -22,15 +22,16 @@ import System.FilePath (normalise)
 
 import qualified Text.Parsec as Parsec
 
+-- | Parser error.
 data PError = PError Position String
     deriving (Show)
 
--- | We do classify warnings.
+-- | Type of parser warning. We do classify warnings.
 --
 -- Different application may decide not to show some, or have fatal behaviour on others
 data PWarnType
     = PWTOther                 -- ^ Unclassified warning
-    | PWTUTF
+    | PWTUTF                   -- ^ Invalid UTF encoding
     | PWTBoolCase              -- ^ @true@ or @false@, not @True@ or @False@
     | PWTGluedOperators        -- ^ @&&!@
     | PWTVersionTag            -- ^ there are version with tags
@@ -48,7 +49,7 @@ data PWarnType
     | PWTLexBOM
     deriving (Eq, Ord, Show, Enum, Bounded)
 
-
+-- | Parser warning.
 data PWarning = PWarning !PWarnType !Position String
     deriving (Show)
 
@@ -64,20 +65,25 @@ showPError fpath (PError pos msg) =
 -- Field parser
 -------------------------------------------------------------------------------
 
-type FieldParser = Parsec.Parsec String [PWarning]
+-- | Field value parsers.
+type FieldParser = Parsec.Parsec String [PWarning] -- :: * -> *
+
 
 -------------------------------------------------------------------------------
 -- Position
 -------------------------------------------------------------------------------
 
+-- | 1-indexed row and column positions in a file.
 data Position = Position
     {-# UNPACK #-}  !Int           -- row
     {-# UNPACK #-}  !Int           -- column
   deriving (Eq, Show)
 
+-- | Shift position by n columns to the right.
 incPos :: Int -> Position -> Position
 incPos n (Position row col) = Position row (col + n)
 
+-- | Shift position to beginning of next row.
 retPos :: Position -> Position
 retPos (Position row _col) = Position (row + 1) 1
 

--- a/Cabal/Distribution/Parsec/Types/Common.hs
+++ b/Cabal/Distribution/Parsec/Types/Common.hs
@@ -1,0 +1,85 @@
+-- | Module containing small types
+module Distribution.Parsec.Types.Common (
+    -- * Diagnostics
+    PError (..),
+    showPError,
+    PWarning (..),
+    PWarnType (..),
+    showPWarning,
+    -- * Field parser
+    FieldParser,
+    -- * Position
+    Position (..),
+    incPos,
+    retPos,
+    showPos,
+    ) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+import System.FilePath (normalise)
+
+import qualified Text.Parsec as Parsec
+
+data PError = PError Position String
+    deriving (Show)
+
+-- | We do classify warnings.
+--
+-- Different application may decide not to show some, or have fatal behaviour on others
+data PWarnType
+    = PWTOther                 -- ^ Unclassified warning
+    | PWTUTF
+    | PWTBoolCase              -- ^ @true@ or @false@, not @True@ or @False@
+    | PWTGluedOperators        -- ^ @&&!@
+    | PWTVersionTag            -- ^ there are version with tags
+    | PWTNewSyntax             -- ^ New syntax used, but no @cabal-version: >= 1.2@ specified
+    | PWTOldSyntax             -- ^ Old syntax used, and @cabal-version >= 1.2@ specified
+    | PWTDeprecatedField
+    | PWTInvalidSubsection
+    | PWTUnknownField
+    | PWTUnknownSection
+    | PWTTrailingFields
+    | PWTExtraMainIs           -- ^ extra main-is field
+    | PWTExtraTestModule       -- ^ extra test-module field
+    | PWTExtraBenchmarkModule  -- ^ extra benchmark-module field
+    | PWTLexNBSP
+    | PWTLexBOM
+    deriving (Eq, Ord, Show, Enum, Bounded)
+
+
+data PWarning = PWarning !PWarnType !Position String
+    deriving (Show)
+
+showPWarning :: FilePath -> PWarning -> String
+showPWarning fpath (PWarning _ pos msg) =
+  normalise fpath ++ ":" ++ showPos pos ++ ": " ++ msg
+
+showPError :: FilePath -> PError -> String
+showPError fpath (PError pos msg) =
+  normalise fpath ++ ":" ++ showPos pos ++ ": " ++ msg
+
+-------------------------------------------------------------------------------
+-- Field parser
+-------------------------------------------------------------------------------
+
+type FieldParser = Parsec.Parsec String [PWarning]
+
+-------------------------------------------------------------------------------
+-- Position
+-------------------------------------------------------------------------------
+
+data Position = Position
+    {-# UNPACK #-}  !Int           -- row
+    {-# UNPACK #-}  !Int           -- column
+  deriving (Eq, Show)
+
+incPos :: Int -> Position -> Position
+incPos n (Position row col) = Position row (col + n)
+
+retPos :: Position -> Position
+retPos (Position row _col) = Position (row + 1) 1
+
+showPos :: Position -> String
+showPos (Position row col) = show row ++ ":" ++ show col

--- a/Cabal/Distribution/Parsec/Types/Common.hs
+++ b/Cabal/Distribution/Parsec/Types/Common.hs
@@ -15,12 +15,10 @@ module Distribution.Parsec.Types.Common (
     showPos,
     ) where
 
-import Prelude ()
-import Distribution.Compat.Prelude
-
-import System.FilePath (normalise)
-
-import qualified Text.Parsec as Parsec
+import           Prelude ()
+import           Distribution.Compat.Prelude
+import           System.FilePath             (normalise)
+import qualified Text.Parsec                 as Parsec
 
 -- | Parser error.
 data PError = PError Position String

--- a/Cabal/Distribution/Parsec/Types/Field.hs
+++ b/Cabal/Distribution/Parsec/Types/Field.hs
@@ -16,13 +16,11 @@ module Distribution.Parsec.Types.Field (
     nameAnn,
     ) where
 
-import Prelude ()
-import Distribution.Compat.Prelude
-
-import Data.ByteString (ByteString)
-
-import qualified Data.Char as Char
-import qualified Data.ByteString.Char8 as B
+import           Prelude ()
+import           Distribution.Compat.Prelude
+import           Data.ByteString             (ByteString)
+import qualified Data.ByteString.Char8       as B
+import qualified Data.Char                   as Char
 
 -------------------------------------------------------------------------------
 -- Cabal file
@@ -51,7 +49,7 @@ data SectionArg ann
     | SecArgStr   !ann !String
       -- ^ quoted string
     | SecArgNum   !ann !ByteString
-      -- ^ integral number
+      -- ^ Something which loos like number. Also many dot numbers, i.e. "7.6.3"
     | SecArgOther !ann !ByteString
       -- ^ everything else, mm. operators (e.g. in if-section conditionals)
   deriving (Eq, Show, Functor)

--- a/Cabal/Distribution/Parsec/Types/Field.hs
+++ b/Cabal/Distribution/Parsec/Types/Field.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE DeriveFunctor #-}
+-- | Cabal-like file AST types: 'Field', 'Section' etc
+--
+-- These types are parametrized by an annotation.
 module Distribution.Parsec.Types.Field (
     -- * Cabal file
     Field (..),
@@ -34,14 +37,23 @@ fieldAnn :: Field ann -> ann
 fieldAnn (Field (Name ann _) _)     = ann
 fieldAnn (Section (Name ann _) _ _) = ann
 
+-- | A line of text representing the value of a field from a Cabal file.
+-- A field may contain multiple lines.
+--
+-- /Invariant:/ 'ByteString' has no newlines.
 data FieldLine ann  = FieldLine  !ann !ByteString
   deriving (Eq, Show, Functor)
 
+-- | Section arguments, e.g. name of the library
 data SectionArg ann
     = SecArgName  !ann !ByteString
+      -- ^ identifier
     | SecArgStr   !ann !String
+      -- ^ quoted string
     | SecArgNum   !ann !ByteString
+      -- ^ integral number
     | SecArgOther !ann !ByteString
+      -- ^ everything else, mm. operators (e.g. in if-section conditionals)
   deriving (Eq, Show, Functor)
 
 -- | Extract annotation from 'SectionArg'.
@@ -55,13 +67,16 @@ sectionArgAnn (SecArgOther ann _) = ann
 -- Name
 -------------------------------------------------------------------------------
 
+-- | A field name.
+--
+-- /Invariant/: 'ByteString' is lower-case ASCII.
 data Name ann  = Name       !ann !ByteString
   deriving (Eq, Show, Functor)
 
 mkName :: ann -> ByteString -> Name ann
 mkName ann bs = Name ann (B.map Char.toLower bs)
 
-getName :: Name a -> ByteString
+getName :: Name ann -> ByteString
 getName (Name _ bs) = bs
 
 nameAnn :: Name ann -> ann

--- a/Cabal/Distribution/Parsec/Types/Field.hs
+++ b/Cabal/Distribution/Parsec/Types/Field.hs
@@ -28,14 +28,11 @@ import qualified Data.ByteString.Char8 as B
 data Field ann
     = Field   !(Name ann) [FieldLine ann]
     | Section !(Name ann) [SectionArg ann] [Field ann]
-    -- TODO: reconsider whether we actually need `IfElseBlock`
-    | IfElseBlock ann [SectionArg ann] [Field ann] [Field ann]
   deriving (Eq, Show, Functor)
 
 fieldAnn :: Field ann -> ann
 fieldAnn (Field (Name ann _) _)     = ann
 fieldAnn (Section (Name ann _) _ _) = ann
-fieldAnn (IfElseBlock ann _ _ _)    = ann
 
 data FieldLine ann  = FieldLine  !ann !ByteString
   deriving (Eq, Show, Functor)

--- a/Cabal/Distribution/Parsec/Types/Field.hs
+++ b/Cabal/Distribution/Parsec/Types/Field.hs
@@ -26,6 +26,7 @@ import qualified Data.Char                   as Char
 -- Cabal file
 -------------------------------------------------------------------------------
 
+-- | A Cabal-like file consists of a series of fields (@foo: bar@) and sections (@library ...@).
 data Field ann
     = Field   !(Name ann) [FieldLine ann]
     | Section !(Name ann) [SectionArg ann] [Field ann]

--- a/Cabal/Distribution/Parsec/Types/Field.hs
+++ b/Cabal/Distribution/Parsec/Types/Field.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DeriveFunctor #-}
+module Distribution.Parsec.Types.Field (
+    -- * Cabal file
+    Field (..),
+    fieldAnn,
+    FieldLine (..),
+    SectionArg (..),
+    sectionArgAnn,
+    -- * Name
+    Name (..),
+    mkName,
+    getName,
+    nameAnn,
+    ) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+import Data.ByteString (ByteString)
+
+import qualified Data.Char as Char
+import qualified Data.ByteString.Char8 as B
+
+-------------------------------------------------------------------------------
+-- Cabal file
+-------------------------------------------------------------------------------
+
+data Field ann
+    = Field   !(Name ann) [FieldLine ann]
+    | Section !(Name ann) [SectionArg ann] [Field ann]
+    -- TODO: reconsider whether we actually need `IfElseBlock`
+    | IfElseBlock ann [SectionArg ann] [Field ann] [Field ann]
+  deriving (Eq, Show, Functor)
+
+fieldAnn :: Field ann -> ann
+fieldAnn (Field (Name ann _) _)     = ann
+fieldAnn (Section (Name ann _) _ _) = ann
+fieldAnn (IfElseBlock ann _ _ _)    = ann
+
+data FieldLine ann  = FieldLine  !ann !ByteString
+  deriving (Eq, Show, Functor)
+
+data SectionArg ann
+    = SecArgName  !ann !ByteString
+    | SecArgStr   !ann !String
+    | SecArgNum   !ann !ByteString
+    | SecArgOther !ann !ByteString
+  deriving (Eq, Show, Functor)
+
+-- | Extract annotation from 'SectionArg'.
+sectionArgAnn :: SectionArg ann -> ann
+sectionArgAnn (SecArgName ann _)  = ann
+sectionArgAnn (SecArgStr ann _)   = ann
+sectionArgAnn (SecArgNum ann _)   = ann
+sectionArgAnn (SecArgOther ann _) = ann
+
+-------------------------------------------------------------------------------
+-- Name
+-------------------------------------------------------------------------------
+
+data Name ann  = Name       !ann !ByteString
+  deriving (Eq, Show, Functor)
+
+mkName :: ann -> ByteString -> Name ann
+mkName ann bs = Name ann (B.map Char.toLower bs)
+
+getName :: Name a -> ByteString
+getName (Name _ bs) = bs
+
+nameAnn :: Name ann -> ann
+nameAnn (Name ann _) = ann

--- a/Cabal/Distribution/Parsec/Types/FieldDescr.hs
+++ b/Cabal/Distribution/Parsec/Types/FieldDescr.hs
@@ -32,20 +32,18 @@ module Distribution.Parsec.Types.FieldDescr (
     ignoreUnrec,
     ) where
 
-import           Distribution.Compat.Prelude      hiding (get)
 import           Prelude ()
-
+import           Distribution.Compat.Prelude      hiding (get)
 import qualified Data.ByteString                  as BS
 import           Data.Ord                         (comparing)
-import           Text.PrettyPrint
-                 (Doc, colon, comma, fsep, hsep, isEmpty, nest, punctuate,
-                 text, vcat, ($+$), (<+>))
-
 import qualified Distribution.Compat.Parsec       as P
 import           Distribution.Compiler            (CompilerFlavor)
 import           Distribution.Parsec.Class
 import           Distribution.Parsec.Types.Common
 import           Distribution.PrettyUtils
+import           Text.PrettyPrint
+                 (Doc, colon, comma, fsep, hsep, isEmpty, nest, punctuate,
+                 text, vcat, ($+$), (<+>))
 
 type FieldName = BS.ByteString
 

--- a/Cabal/Distribution/Parsec/Types/FieldDescr.hs
+++ b/Cabal/Distribution/Parsec/Types/FieldDescr.hs
@@ -1,0 +1,240 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Parsec.Types.FieldDescr
+-- License     :  BSD3
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Portability :  portable
+--
+module Distribution.Parsec.Types.FieldDescr (
+    -- * Field name
+    FieldName,
+    -- * Field description
+    FieldDescr (..),
+    liftField,
+    simpleField,
+    boolField,
+    optsField,
+    listField,
+    listFieldWithSep,
+    commaListField,
+    commaListFieldWithSep,
+    spaceListField,
+    -- ** Pretty printing
+    ppFields,
+    ppField,
+    -- * Unknown fields
+    UnknownFieldParser,
+    warnUnrec,
+    ignoreUnrec,
+    ) where
+
+import           Distribution.Compat.Prelude      hiding (get)
+import           Prelude ()
+
+import qualified Data.ByteString                  as BS
+import           Data.Ord                         (comparing)
+import           Text.PrettyPrint
+                 (Doc, colon, comma, fsep, hsep, isEmpty, nest, punctuate,
+                 text, vcat, ($+$), (<+>))
+
+import qualified Distribution.Compat.Parsec       as P
+import           Distribution.Compiler            (CompilerFlavor)
+import           Distribution.Parsec.Class
+import           Distribution.Parsec.Types.Common
+import           Distribution.PrettyUtils
+
+type FieldName = BS.ByteString
+
+-------------------------------------------------------------------------------
+-- Unrecoginsed fields
+-------------------------------------------------------------------------------
+
+-- | How to handle unknown fields.
+type UnknownFieldParser a = FieldName -> String -> a -> Maybe a
+
+-- | A default unrecognized field parser which simply returns Nothing,
+--   i.e. ignores all unrecognized fields, so warnings will be generated.
+warnUnrec :: UnknownFieldParser a
+warnUnrec _ _ _ = Nothing
+
+-- | A default unrecognized field parser which silently (i.e. no
+--   warnings will be generated) ignores unrecognized fields, by
+--   returning the structure being built unmodified.
+ignoreUnrec :: UnknownFieldParser a
+ignoreUnrec _ _ = Just
+
+-------------------------------------------------------------------------------
+-- Field description
+-------------------------------------------------------------------------------
+
+data FieldDescr a = FieldDescr
+    { fieldName   :: FieldName
+    , fieldPretty :: a -> Doc
+    , fieldParser :: a -> FieldParser a
+    }
+
+liftField :: (b -> a) -> (a -> b -> b) -> FieldDescr a -> FieldDescr b
+liftField get set fd = FieldDescr
+    (fieldName fd)
+    (fieldPretty fd . get)
+    (\b -> flip set b <$> fieldParser fd (get b))
+
+simpleField
+    :: FieldName       -- ^ fieldname
+    -> (a -> Doc)      -- ^ show
+    -> FieldParser a   -- ^ parser
+    -> (b -> a)        -- ^ getter
+    -> (a -> b -> b)   -- ^ setter
+    -> FieldDescr b
+simpleField name pretty parse get set = FieldDescr
+    name
+    (pretty . get)
+    (\a -> flip set a <$> parse)
+
+boolField
+    :: FieldName
+    -> (b -> Bool)
+    -> (Bool -> b -> b)
+    -> FieldDescr b
+boolField name get set = liftField get set (FieldDescr name showF parseF)
+  where
+    showF = text . show
+    parseF _ = P.munch1 isAlpha >>= postprocess
+    postprocess str
+        |  str == "True"  = pure True
+        |  str == "False" = pure False
+        | lstr == "true"  = parsecWarning PWTBoolCase caseWarning *> pure True
+        | lstr == "false" = parsecWarning PWTBoolCase caseWarning *> pure False
+        | otherwise       = fail $ "Not a boolena: " ++ str
+      where
+        lstr = map toLower str
+        caseWarning =
+            "The " ++ show name ++ " field is case sensitive, use 'True' or 'False'."
+
+optsField
+    :: FieldName
+    -> CompilerFlavor
+    -> (b -> [(CompilerFlavor,[String])])
+    -> ([(CompilerFlavor,[String])] -> b -> b)
+    -> FieldDescr b
+optsField name flavor get set = liftField
+    (fromMaybe [] . lookup flavor . get)
+    (\opts b -> set (reorder (update flavor opts (get b))) b)
+    $ field name showF (many $ parsecToken' <* P.munch isSpace)
+  where
+    update _ opts l | all null opts = l  --empty opts as if no opts
+    update f opts [] = [(f,opts)]
+    update f opts ((f',opts'):rest)
+        | f == f'   = (f, opts' ++ opts) : rest
+        | otherwise = (f',opts') : update f opts rest
+    reorder = sortBy (comparing fst)
+    showF   = hsep . map text
+
+listField
+    :: FieldName
+    -> (a -> Doc)
+    -> FieldParser a
+    -> (b -> [a])
+    -> ([a] -> b -> b)
+    -> FieldDescr b
+listField = listFieldWithSep fsep
+
+listFieldWithSep
+    :: Separator
+    -> FieldName
+    -> (a -> Doc)
+    -> FieldParser a
+    -> (b -> [a])
+    -> ([a] -> b -> b)
+    -> FieldDescr b
+listFieldWithSep separator name showF parseF get set =
+    liftField get set' $
+        field name showF' (parsecOptCommaList parseF)
+  where
+    set' xs b = set (get b ++ xs) b
+    showF'    = separator . map showF
+
+
+commaListField
+    :: FieldName -> (a -> Doc) -> FieldParser a
+    -> (b -> [a]) -> ([a] -> b -> b) -> FieldDescr b
+commaListField = commaListFieldWithSep fsep
+
+commaListFieldWithSep
+    :: Separator -> FieldName  -> (a -> Doc) -> FieldParser a
+    -> (b -> [a]) -> ([a] -> b -> b) -> FieldDescr b
+commaListFieldWithSep separator name showF parseF get set =
+    liftField get set' $
+        field name showF' (parsecCommaList parseF)
+   where
+     set' xs b = set (get b ++ xs) b
+     showF'    = separator . punctuate comma . map showF
+
+spaceListField
+    :: FieldName -> (a -> Doc) -> FieldParser a
+    -> (b -> [a]) -> ([a] -> b -> b) -> FieldDescr b
+spaceListField name showF parseF get set = liftField get set' $
+    field name showF' (many $ parseF <* P.spaces)
+  where
+    set' xs b = set (get b ++ xs) b
+    showF'    = fsep . map showF
+
+-- Overriding field
+field :: FieldName -> (a -> Doc) -> FieldParser a -> FieldDescr a
+field name showF parseF =
+    FieldDescr name showF (const parseF)
+
+-------------------------------------------------------------------------------
+-- Pretty printing
+-------------------------------------------------------------------------------
+
+ppFields :: [FieldDescr a] -> a -> Doc
+ppFields fields x =
+   vcat [ ppField name (getter x) | FieldDescr name getter _ <- fields ]
+
+ppField :: FieldName -> Doc -> Doc
+ppField name fielddoc
+   | isEmpty fielddoc         = mempty
+   | name `elem` nestedFields = text namestr <<>> colon $+$ nest indentWith fielddoc
+   | otherwise                = text namestr <<>> colon <+> fielddoc
+   where
+      namestr = show name -- TODO: do this
+      nestedFields :: [BS.ByteString]
+      nestedFields =
+         [ "description"
+         , "build-depends"
+         , "data-files"
+         , "extra-source-files"
+         , "extra-tmp-files"
+         , "exposed-modules"
+         , "c-sources"
+         , "js-sources"
+         , "extra-libraries"
+         , "includes"
+         , "install-includes"
+         , "other-modules"
+         , "depends"
+         ]
+
+-- | Handle deprecated fields
+--
+-- *TODO:* use Parsec
+{-
+deprecField :: Field Position -> Parsec (Field Position)
+deprecField = undefined  {-
+-}
+
+ (Field (Name pos fld) val) = do
+  fld' <- case lookup fld deprecatedFields of
+            Nothing -> return fld
+            Just newName -> do
+              warning $ "The field " ++ show fld
+                      ++ " is deprecated, please use " ++ show newName
+              return newName
+  return (Field (Name pos fld') val)
+deprecField _ = cabalBug "'deprecField' called on a non-field"
+-}

--- a/Cabal/Distribution/Parsec/Types/ParseResult.hs
+++ b/Cabal/Distribution/Parsec/Types/ParseResult.hs
@@ -7,6 +7,7 @@ module Distribution.Parsec.Types.ParseResult (
     parseFailure,
     parseFatalFailure,
     parseFatalFailure',
+    parseWarnings',
     ) where
 
 import           Distribution.Compat.Prelude
@@ -60,6 +61,10 @@ recoverWith (PR f) x = PR $ \s -> case f s of
 parseWarning :: Position -> PWarnType -> String -> ParseResult ()
 parseWarning pos t msg = PR $ \(PRState warns errs) ->
     (Just (), PRState (PWarning t pos msg : warns) errs)
+
+parseWarnings' :: [PWarning] -> ParseResult ()
+parseWarnings' newWarns = PR $ \(PRState warns errs) ->
+    (Just (), PRState (warns ++ newWarns) errs) 
 
 -- | Add an error, but not fail the parser yet.
 parseFailure :: Position -> String -> ParseResult ()

--- a/Cabal/Distribution/Parsec/Types/ParseResult.hs
+++ b/Cabal/Distribution/Parsec/Types/ParseResult.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE CPP #-}
+module Distribution.Parsec.Types.ParseResult (
+    ParseResult,
+    runParseResult,
+    recoverWith,
+    parseWarning,
+    parseFailure,
+    parseFatalFailure,
+    parseFatalFailure',
+    ) where
+
+import           Distribution.Compat.Prelude
+import           Prelude ()
+
+import           Distribution.Parsec.Types.Common
+                 (PError (..), PWarnType (..), PWarning (..), Position (..))
+
+-- | A monad with failure and accumulating errors
+newtype ParseResult a = PR { runPR :: PRState -> (Maybe a, PRState) }
+
+data PRState = PRState ![PWarning] ![PError]
+
+emptyPRState :: PRState
+emptyPRState = PRState [] []
+
+runParseResult :: ParseResult a -> ([PWarning], [PError], Maybe a)
+runParseResult pr = case runPR pr emptyPRState of
+    (res, PRState warns errs)
+        -- If there are any errors, don't return the result
+        | null errs -> (warns, [], res)
+        | otherwise -> (warns, errs, Nothing)
+
+instance Functor ParseResult where
+    fmap f (PR pr) = PR $ \s -> case pr s of
+        (r, s') -> (fmap f r, s')
+
+-- | Note: this is not a Monad!
+instance Applicative ParseResult where
+    pure x = PR $ \s -> (Just x, s)
+    -- | Make it concat perrors
+    (<*>) = ap
+    PR a *> PR b = PR $ \s0 -> case a s0 of
+        (x, s1) -> case b s1 of
+            (y, s2) -> (x *> y, s2)
+
+instance Monad ParseResult where
+    return = pure
+    (>>) = (*>)
+    PR m >>= k = PR $ \s -> case m s of
+        (Nothing, s') -> (Nothing, s')
+        (Just x,  s') -> runPR (k x) s'
+
+-- | "Recover" the parse result, so we can proceed parsing.
+-- 'runParseResult' will still result 'Nothing', if there are recorded errors.
+recoverWith :: ParseResult a -> a -> ParseResult a
+recoverWith (PR f) x = PR $ \s -> case f s of
+    (Nothing, s') -> (Just x, s')
+    r             -> r
+
+parseWarning :: Position -> PWarnType -> String -> ParseResult ()
+parseWarning pos t msg = PR $ \(PRState warns errs) ->
+    (Just (), PRState (PWarning t pos msg : warns) errs)
+
+-- | Add an error, but not fail the parser yet.
+parseFailure :: Position -> String -> ParseResult ()
+parseFailure pos msg = PR $ \(PRState warns errs) ->
+    (Just (), PRState warns (PError pos msg : errs))
+
+parseFatalFailure :: Position -> String -> ParseResult a
+parseFatalFailure pos msg = PR $ \(PRState warns errs) ->
+    (Nothing, PRState warns (PError pos msg : errs))
+
+parseFatalFailure' :: ParseResult a
+parseFatalFailure' = PR f
+  where
+    f s@(PRState warns errs)
+        | null errs = (Nothing, PRState warns [PError (Position 0 0) "Unknown failure"])
+        | otherwise = (Nothing, s)

--- a/Cabal/Distribution/Parsec/Types/ParseResult.hs
+++ b/Cabal/Distribution/Parsec/Types/ParseResult.hs
@@ -11,9 +11,8 @@ module Distribution.Parsec.Types.ParseResult (
     parseWarnings',
     ) where
 
-import           Distribution.Compat.Prelude
 import           Prelude ()
-
+import           Distribution.Compat.Prelude
 import           Distribution.Parsec.Types.Common
                  (PError (..), PWarnType (..), PWarning (..), Position (..))
 
@@ -66,7 +65,7 @@ parseWarning pos t msg = PR $ \(PRState warns errs) ->
 
 parseWarnings' :: [PWarning] -> ParseResult ()
 parseWarnings' newWarns = PR $ \(PRState warns errs) ->
-    (Just (), PRState (warns ++ newWarns) errs) 
+    (Just (), PRState (warns ++ newWarns) errs)
 
 -- | Add an error, but not fail the parser yet.
 --

--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -65,7 +66,6 @@ import Distribution.Simple.Compiler hiding (Flag)
 import Distribution.Simple.UserHooks
 import Distribution.Package
 import Distribution.PackageDescription hiding (Flag)
-import Distribution.PackageDescription.Parse
 import Distribution.PackageDescription.Configuration
 import Distribution.Simple.Program
 import Distribution.Simple.Program.Db
@@ -103,6 +103,13 @@ import Distribution.Compat.Environment      (getEnvironment)
 import Distribution.Compat.GetShortPathName (getShortPathName)
 
 import Data.List       (unionBy, (\\))
+
+#ifdef CABAL_PARSEC
+import Distribution.PackageDescription.Parsec
+import Distribution.PackageDescription.Parse (readHookedBuildInfo)
+#else
+import Distribution.PackageDescription.Parse
+#endif
 
 -- | A simple implementation of @main@ for a Cabal setup script.
 -- It reads the package description file using IO, and performs the
@@ -228,7 +235,11 @@ confPkgDescr hooks verbosity mb_path = do
         pdfile <- case mb_path of
                     Nothing -> defaultPackageDesc verbosity
                     Just path -> return path
+#ifdef CABAL_PARSEC
+        descr  <- readGenericPackageDescription verbosity pdfile
+#else
         descr  <- readPackageDescription verbosity pdfile
+#endif
         return (Just pdfile, descr)
 
 buildAction :: UserHooks -> BuildFlags -> Args -> IO ()

--- a/Cabal/tests/DiffInstances.hs
+++ b/Cabal/tests/DiffInstances.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies    #-}
+{-# OPTIONS_GHC -freduction-depth=0 -fno-warn-orphans #-}
+module DiffInstances where
+
+import           Generics.SOP.TH
+import           StructDiff
+
+-------------------------------------------------------------------------------
+
+import           Distribution.Compiler           (CompilerFlavor)
+import           Distribution.License            (License)
+import           Distribution.ModuleName         (ModuleName)
+import           Distribution.Package
+                 (Dependency, PackageIdentifier, PackageName)
+import           Distribution.PackageDescription
+                 (Benchmark, BenchmarkInterface, BenchmarkType, BuildInfo,
+                 BuildType, CondTree, Condition, Executable, Flag, FlagName,
+                 GenericPackageDescription, Library, ModuleReexport,
+                 ModuleRenaming, PackageDescription, RepoKind, RepoType,
+                 SetupBuildInfo, SourceRepo, TestSuite, TestSuiteInterface,
+                 TestType)
+import Distribution.Types.IncludeRenaming (IncludeRenaming)
+import           Distribution.Version            (Version, VersionRange)
+import           Language.Haskell.Extension
+                 (Extension, KnownExtension, Language)
+
+-------------------------------------------------------------------------------
+-- instances
+-------------------------------------------------------------------------------
+
+deriveGeneric ''Benchmark
+deriveGeneric ''BenchmarkInterface
+deriveGeneric ''BenchmarkType
+deriveGeneric ''BuildInfo
+deriveGeneric ''BuildType
+deriveGeneric ''CompilerFlavor
+deriveGeneric ''CondTree
+deriveGeneric ''Dependency
+deriveGeneric ''Executable
+deriveGeneric ''Extension
+deriveGeneric ''Flag
+deriveGeneric ''GenericPackageDescription
+deriveGeneric ''KnownExtension
+deriveGeneric ''Language
+deriveGeneric ''Library
+deriveGeneric ''License
+deriveGeneric ''ModuleReexport
+deriveGeneric ''ModuleRenaming
+deriveGeneric ''PackageDescription
+deriveGeneric ''PackageIdentifier
+deriveGeneric ''PackageName
+deriveGeneric ''RepoKind
+deriveGeneric ''RepoType
+deriveGeneric ''SetupBuildInfo
+deriveGeneric ''SourceRepo
+deriveGeneric ''TestSuite
+deriveGeneric ''TestSuiteInterface
+deriveGeneric ''TestType
+deriveGeneric ''VersionRange
+deriveGeneric ''IncludeRenaming
+
+instance (Eq a, Show a) => Diff (Condition a) where diff = eqDiff
+instance (Show a, Diff b, Diff c, Show b, Show c, Eq a, Eq c, Eq b) => Diff (CondTree a b c)
+
+instance Diff Benchmark
+instance Diff BenchmarkInterface
+instance Diff BenchmarkType
+instance Diff BuildInfo
+instance Diff BuildType
+instance Diff CompilerFlavor
+instance Diff Dependency
+instance Diff Executable
+instance Diff Extension
+instance Diff Flag
+instance Diff FlagName where diff = eqDiff
+instance Diff GenericPackageDescription
+instance Diff KnownExtension
+instance Diff Language
+instance Diff Library
+instance Diff License
+instance Diff ModuleName where diff = eqDiff
+instance Diff ModuleReexport
+instance Diff ModuleRenaming
+instance Diff PackageDescription
+instance Diff PackageIdentifier
+instance Diff PackageName where diff = eqDiff
+instance Diff RepoKind
+instance Diff RepoType
+instance Diff SetupBuildInfo
+instance Diff SourceRepo
+instance Diff TestSuite
+instance Diff TestSuiteInterface
+instance Diff TestType
+instance Diff Version where diff = eqDiff
+instance Diff VersionRange
+instance Diff IncludeRenaming 

--- a/Cabal/tests/ParserHackageTests.hs
+++ b/Cabal/tests/ParserHackageTests.hs
@@ -1,0 +1,365 @@
+{-# LANGUAGE Rank2Types #-}
+module Main where
+
+import           Control.Applicative
+                 (Applicative (..), (<$>), Const (..))
+import           Control.Monad                          (when)
+import           Data.Foldable
+                 (foldMap, for_, traverse_)
+import           Data.List                              (isPrefixOf, isSuffixOf)
+import           Data.Maybe                             (mapMaybe, listToMaybe)
+import           Data.Monoid                            (Monoid (..), Sum (..))
+import           Data.Traversable                       (traverse)
+import           Distribution.Simple.Utils              (fromUTF8LBS, ignoreBOM)
+import           System.Directory
+                 (getAppUserDataDirectory)
+import           System.Environment                     (getArgs)
+import           System.Exit                            (exitFailure)
+import           System.FilePath                        ((</>))
+
+import           Distribution.Package (Dependency)
+import           Distribution.PackageDescription
+
+import qualified Codec.Archive.Tar                      as Tar
+import qualified Data.ByteString                        as B
+import qualified Data.ByteString.Char8                  as B8
+import qualified Data.ByteString.Lazy                   as BSL
+import qualified Data.Map                               as Map
+import qualified Distribution.PackageDescription.Parse  as ReadP
+import qualified Distribution.PackageDescription.Parsec as Parsec
+import qualified Distribution.Parsec.Parser             as Parsec
+import qualified Distribution.Parsec.Types.Common       as Parsec
+import qualified Distribution.Parsec.Types.ParseResult  as Parsec
+import qualified Distribution.ParseUtils                as ReadP
+import qualified Distribution.Compat.DList              as DList
+
+#if __GLASGOW_HASKELL__ >= 708
+import Data.Coerce
+#else
+import Unsafe.Coerce
+#endif
+
+#ifdef HAS_STRUCT_DIFF
+import           DiffInstances ()
+import           StructDiff
+#endif
+
+parseIndex :: Monoid a => (FilePath -> BSL.ByteString -> IO a) -> IO a
+parseIndex action = do
+    cabalDir  <- getAppUserDataDirectory "cabal"
+    cfg       <- B.readFile (cabalDir </> "config")
+    cfgFields <- either (fail . show) pure $ Parsec.readFields cfg
+    let repos        = reposFromConfig cfgFields
+        repoCache    = case lookupInConfig "remote-repo-cache" cfgFields of
+            []        -> cabalDir </> "packages"  -- Default
+            (rrc : _) -> rrc                      -- User-specified
+        tarName repo = repoCache </> repo </> "01-index.tar"
+    mconcat <$> traverse (parseIndex' action . tarName) repos
+
+
+parseIndex' :: Monoid a => (FilePath -> BSL.ByteString -> IO a) -> FilePath -> IO a
+parseIndex' action path = do
+    putStrLn $ "Reading index from: " ++ path
+    contents <- BSL.readFile path
+    let entries = Tar.read contents
+    Tar.foldEntries (\e m -> mappend <$> f e <*> m) (return mempty) (fail . show) entries
+
+  where
+    f entry = case Tar.entryContent entry of
+        Tar.NormalFile contents _
+            | ".cabal" `isSuffixOf` fpath -> action fpath contents
+            | otherwise                   -> return mempty
+        Tar.Directory -> return mempty
+        _             -> putStrLn ("Unknown content in " ++ fpath) >> return mempty
+     where
+       fpath = Tar.entryPath entry
+
+readFieldTest :: FilePath -> BSL.ByteString -> IO ()
+readFieldTest fpath bsl = case Parsec.readFields $ BSL.toStrict bsl of
+    Right _  -> return ()
+    Left err -> putStrLn $ fpath ++ "\n" ++ show err
+
+-- | Map with unionWith monoid
+newtype M k v = M (Map.Map k v)
+    deriving (Show)
+instance (Ord k, Monoid v) => Monoid (M k v) where
+    mempty = M Map.empty
+    mappend (M a) (M b) = M (Map.unionWith mappend a b)
+
+compareTest
+    :: String  -- ^ prefix of first packages to start traversal
+    -> FilePath -> BSL.ByteString -> IO (Sum Int, Sum Int, M Parsec.PWarnType (Sum Int))
+compareTest pfx fpath bsl
+    | any ($ fpath) problematicFiles = mempty
+    | not $ pfx `isPrefixOf` fpath   = mempty
+    | otherwise = do
+    let str = ignoreBOM $ fromUTF8LBS bsl
+
+    putStrLn $ "::: " ++ fpath
+    (readp, readpWarnings)  <- case ReadP.parsePackageDescription str of
+        ReadP.ParseOk ws x    -> return (x, ws)
+        ReadP.ParseFailed err -> print err >> exitFailure
+    traverse_ (putStrLn . ReadP.showPWarning fpath) readpWarnings
+
+    let (warnings, errors, parsec') = Parsec.runParseResult $ Parsec.parseGenericPackageDescription (BSL.toStrict bsl)
+    traverse_ (putStrLn . Parsec.showPWarning fpath) warnings
+    traverse_ (putStrLn . Parsec.showPError fpath) errors
+    parsec <- maybe (print readp >> exitFailure) return parsec'
+
+    -- Old parser is broken for many descriptions, and other free text fields
+    let readp0  = readp
+            & set (packageDescription_ .  description_) ""
+            & set (packageDescription_ .  synopsis_)    ""
+            & set (packageDescription_ .  maintainer_)  ""
+    let parsec0  = parsec
+            & set (packageDescription_ .  description_) ""
+            & set (packageDescription_ .  synopsis_)    ""
+            & set (packageDescription_ .  maintainer_)  ""
+
+    -- hs-source-dirs ".", old parser broken
+    -- See e.g. http://hackage.haskell.org/package/hledger-ui-0.27/hledger-ui.cabal executable
+    let parsecHsSrcDirs = parsec0 & toListOf (buildInfos_ . hsSourceDirs_)
+    let readpHsSrcDirs  = readp0  & toListOf (buildInfos_ . hsSourceDirs_)
+    let filterDotDirs   = filter (/= ".")
+
+    let parsec1 = if parsecHsSrcDirs /= readpHsSrcDirs && fmap filterDotDirs parsecHsSrcDirs == readpHsSrcDirs
+        then parsec0 & over (buildInfos_ . hsSourceDirs_) filterDotDirs
+        else parsec0
+
+    -- Compare two parse results
+    if readp0 == parsec1
+        then return ()
+        else do
+#if HAS_STRUCT_DIFF
+            prettyResultIO $ diff readp parsec
+#else
+            putStrLn "<<<<<<"
+            print readp
+            putStrLn "======"
+            print parsec
+            putStrLn ">>>>>>"
+#endif
+            exitFailure
+
+    let readpWarnCount  = Sum (length readpWarnings)
+    let parsecWarnCount = Sum (length warnings)
+
+    when (readpWarnCount > parsecWarnCount) $ do
+        putStrLn "There are more readpWarnings"
+        exitFailure
+
+    let parsecWarnMap   = foldMap (\(Parsec.PWarning t _ _) -> M $ Map.singleton t 1) warnings
+    return (readpWarnCount, parsecWarnCount, parsecWarnMap)
+
+parseReadpTest :: FilePath -> BSL.ByteString -> IO ()
+parseReadpTest fpath bsl = when (not $ any ($ fpath) problematicFiles) $ do
+    let str = fromUTF8LBS bsl
+    case ReadP.parsePackageDescription str of
+        ReadP.ParseOk _ _     -> return ()
+        ReadP.ParseFailed err -> print err >> exitFailure
+
+parseParsecTest :: FilePath -> BSL.ByteString -> IO ()
+parseParsecTest fpath bsl = when (not $ any ($ fpath) problematicFiles) $ do
+    let bs = BSL.toStrict bsl
+    let (_warnings, errors, parsec) = Parsec.runParseResult $ Parsec.parseGenericPackageDescription bs
+    case parsec of
+        Just _ -> return ()
+        Nothing -> do
+            traverse_ (putStrLn . Parsec.showPError fpath) errors
+            exitFailure
+
+problematicFiles :: [FilePath -> Bool]
+problematicFiles =
+    [
+    -- Indent failure
+      eq "control-monad-exception-mtl/0.10.3/control-monad-exception-mtl.cabal"
+    -- Other modules <- no dash
+    , eq "DSTM/0.1/DSTM.cabal"
+    , eq "DSTM/0.1.1/DSTM.cabal"
+    , eq "DSTM/0.1.2/DSTM.cabal"
+    -- colon : after section header
+    , eq "ds-kanren/0.2.0.0/ds-kanren.cabal"
+    , eq "ds-kanren/0.2.0.1/ds-kanren.cabal"
+    , eq "metric/0.1.4/metric.cabal"
+    , eq "metric/0.2.0/metric.cabal"
+    , eq "phasechange/0.1/phasechange.cabal"
+    , eq "shelltestrunner/1.3/shelltestrunner.cabal"
+    , eq "smartword/0.0.0.5/smartword.cabal"
+    -- \DEL
+    , eq "vacuum-opengl/0.0/vacuum-opengl.cabal"
+    , eq "vacuum-opengl/0.0.1/vacuum-opengl.cabal"
+    -- dashes in version, not even tag
+    , isPrefixOf "free-theorems-webui/"
+    -- {- comment -}
+    , eq "ixset/1.0.4/ixset.cabal"
+    -- comments in braces
+    , isPrefixOf "hint/"
+    ]
+  where
+    eq = (==)
+
+main :: IO ()
+main = do
+    args <- getArgs
+    case args of
+        ["read-field"]   -> parseIndex readFieldTest
+        ["parse-readp"]  -> parseIndex parseReadpTest
+        ["parse-parsec"] -> parseIndex parseParsecTest
+        [pfx]            -> defaultMain pfx
+        _                -> defaultMain ""
+  where
+    defaultMain pfx = do
+        (Sum readpCount, Sum parsecCount, M warn) <- parseIndex (compareTest pfx)
+        putStrLn $ "readp warnings: " ++ show readpCount
+        putStrLn $ "parsec count:   " ++ show parsecCount
+        for_ (Map.toList warn) $ \(t, Sum c) ->
+            putStrLn $ " - " ++ show t ++ " : " ++ show c
+
+-------------------------------------------------------------------------------
+-- Index shuffling
+-------------------------------------------------------------------------------
+
+-- TODO: Use 'Cabal' for this?
+reposFromConfig :: [Parsec.Field ann] -> [String]
+reposFromConfig fields = takeWhile (/= ':') <$> mapMaybe f fields
+  where
+    f (Parsec.Field (Parsec.Name _ name) fieldLines)
+        | B8.unpack name == "remote-repo" =
+            Just $ fieldLinesToString fieldLines
+    f (Parsec.Section (Parsec.Name _ name) [Parsec.SecArgName _ secName] _fieldLines)
+        | B8.unpack name == "repository" =
+            Just $ B8.unpack secName
+    f _ = Nothing
+
+-- | Looks up the given key in the cabal configuration file
+lookupInConfig :: String -> [Parsec.Field ann] -> [String]
+lookupInConfig key = mapMaybe f
+  where
+    f (Parsec.Field (Parsec.Name _ name) fieldLines)
+        | B8.unpack name == key =
+            Just $ fieldLinesToString fieldLines
+    f _ = Nothing
+
+fieldLinesToString :: [Parsec.FieldLine ann] -> String
+fieldLinesToString fieldLines =
+    B8.unpack $ B.concat $ bsFromFieldLine <$> fieldLines
+  where
+    bsFromFieldLine (Parsec.FieldLine _ bs) = bs
+
+-------------------------------------------------------------------------------
+-- Distribution.Compat.Lens
+-------------------------------------------------------------------------------
+
+type Lens' s a = forall f. Functor f => (a -> f a) -> s -> f s
+type Traversal' s a = forall f. Applicative f => (a -> f a) -> s -> f s
+
+type Getting r s a = (a -> Const r a) -> s -> Const r s
+type ASetter' s a = (a -> I a) -> s -> I s
+
+
+
+-- | View the value pointed to by a 'Getting' or 'Lens' or the
+-- result of folding over all the results of a 'Control.Lens.Fold.Fold' or
+-- 'Control.Lens.Traversal.Traversal' that points at a monoidal values.
+view :: s -> Getting a s a -> a
+view s l = getConst (l Const s)
+
+-- | Replace the target of a 'Lens'' or 'Traversal'' with a constant value.
+set :: ASetter' s a -> a -> s -> s
+set l x = over l (const x)
+
+-- | Modify the target of a 'Lens'' or all the targets of a 'Traversal''
+-- with a function.
+over :: ASetter' s a -> (a -> a) -> s -> s
+#if __GLASGOW_HASKELL__ >= 708
+over l f = coerce . l (coerce . f)
+#else
+over l f = unsafeCoerce . l (unsafeCoerce . f)
+#endif
+
+-- | Build a 'Lens'' from a getter and a setter.
+lens :: (s -> a) -> (s -> a -> s) -> Lens' s a
+lens sa sbt afb s = sbt s <$> afb (sa s)
+
+-- | Build an 'Getting' from an arbitrary Haskell function.
+to :: (s -> a) -> Getting r s a
+to f g a = Const $ getConst $ g (f a)
+
+-- | Extract a list of the targets of a 'Lens'' or 'Traversal''.
+toListOf :: Getting (DList.DList a) s a -> s -> [a]
+toListOf l = DList.runDList . getConst . l (Const . DList.singleton)
+
+-- | Retrieve the first entry of a 'Traversal'' or retrieve 'Just' the result
+-- from a 'Getting' or 'Lens''.
+firstOf :: Getting (DList.DList a) s a -> s -> Maybe a
+firstOf l = listToMaybe . toListOf l
+
+-- | '&' is a reverse application operator
+(&) :: a -> (a -> b) -> b
+(&) = flip ($)
+{-# INLINE (&) #-}
+infixl 1 &
+
+-------------------------------------------------------------------------------
+-- Distribution.Compat.BasicFunctors
+-------------------------------------------------------------------------------
+
+newtype I a = I a
+
+unI :: I a -> a
+unI (I x) = x
+
+instance Functor I where
+    fmap f (I x) = I (f x)
+
+instance Applicative I where
+    pure        = I
+    I f <*> I x = I (f x)
+    _ *> x      = x
+
+_2 :: Lens' (a, b) b
+_2 = lens snd $ \(a, _) b -> (a, b)
+
+-------------------------------------------------------------------------------
+-- Distribution.PackageDescription.Lens
+-------------------------------------------------------------------------------
+
+packageDescription_ :: Lens' GenericPackageDescription PackageDescription
+packageDescription_ = lens packageDescription $ \s a -> s { packageDescription = a }
+
+condLibrary_ :: Lens' GenericPackageDescription (Maybe (CondTree ConfVar [Dependency] Library))
+condLibrary_ = lens condLibrary $ \s a -> s { condLibrary = a}
+
+condExecutables_ :: Lens' GenericPackageDescription [(String, CondTree ConfVar [Dependency] Executable)]
+condExecutables_ = lens condExecutables $ \s a -> s { condExecutables = a }
+
+condTreeData_ :: Lens' (CondTree v c a) a
+condTreeData_ = lens condTreeData $ \s a -> s { condTreeData = a }
+
+description_, synopsis_, maintainer_ :: Lens' PackageDescription String
+description_ = lens description $ \s a -> s { description = a }
+synopsis_    = lens synopsis    $ \s a -> s { synopsis    = a }
+maintainer_  = lens maintainer  $ \s a -> s { maintainer  = a }
+
+class HasBuildInfo a where
+    buildInfo_ :: Lens' a BuildInfo
+
+instance HasBuildInfo Library where
+    buildInfo_ = lens libBuildInfo $ \s a -> s { libBuildInfo = a }
+
+instance HasBuildInfo Executable where
+    buildInfo_ = lens buildInfo $ \s a -> s { buildInfo = a }
+
+-- | This forgets a lot of structure, but might be nice for some stuff
+buildInfos_ :: Traversal' GenericPackageDescription BuildInfo
+buildInfos_ f gpd = mkGpd
+    <$> (traverse . traverse . buildInfo_) f (condLibrary gpd)
+    <*> (traverse . _2 . traverse . buildInfo_) f (condExecutables gpd)
+  where
+      mkGpd lib exe = gpd
+          { condLibrary     = lib
+          , condExecutables = exe
+          }
+
+hsSourceDirs_ :: Lens' BuildInfo [FilePath]
+hsSourceDirs_ = lens hsSourceDirs $ \s a -> s { hsSourceDirs = a }

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -23,6 +23,7 @@ tests = testGroup "parsec tests"
 warningTests :: TestTree
 warningTests = testGroup "warnings triggered"
     [ warningTest PWTLexBOM "bom.cabal"
+    , warningTest PWTLexNBSP "nbsp.cabal"
     ]
 
 warningTest :: PWarnType -> FilePath -> TestTree
@@ -30,7 +31,7 @@ warningTest wt fp = testCase (show wt) $ do
     contents <- BS.readFile $ "tests" </> "ParserTests" </> "warnings" </> fp
     let res =  parseGenericPackageDescription contents
     let (warns, errs, x) = runParseResult res
-    
+
     assertBool "parses successfully" $ isJust x
     assertBool "parses without errors" $ null errs
 

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -43,7 +43,7 @@ parseIndex action = do
         repoCache    = case lookupInConfig "remote-repo-cache" cfg of
             []        -> c </> "packages"  -- Default
             (rrc : _) -> rrc               -- User-specified
-        tarName repo = repoCache </> repo </> "00-index.tar"
+        tarName repo = repoCache </> repo </> "01-index.tar"
     mconcat <$> traverse (parseIndex' action . tarName) repos
 
 
@@ -80,7 +80,7 @@ compareTest
     -> FilePath -> BSL.ByteString -> IO (Sum Int, Sum Int, M Parsec.PWarnType (Sum Int))
 compareTest pfx fpath bsl
     | any ($ fpath) problematicFiles = mempty
-    | fpath < pfx                    = mempty
+    | not $ pfx `isPrefixOf` fpath   = mempty
     | otherwise = do
     let str = fromUTF8LBS bsl
 
@@ -183,6 +183,12 @@ problematicFiles =
     , isPrefixOf "writer-cps-transformers/"
     -- {- comment -}
     , eq "ixset/1.0.4/ixset.cabal"
+    -- comments in braces
+    , isPrefixOf "hint/"
+    -- something weird: FromString "unrecognised field or section: \"\\65279\"" (Just 1)
+    , eq "Workflow/0.8.3/Workflow.cabal"
+    , eq "dictionary-sharing/0.1.0.0/dictionary-sharing.cabal"
+    , eq "testing-type-modifiers/0.1.0.0/testing-type-modifiers.cabal"
     ]
   where
     eq = (==)

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -144,14 +144,9 @@ parseParsecTest fpath bsl = when (not $ any ($ fpath) problematicFiles) $ do
 
 problematicFiles :: [FilePath -> Bool]
 problematicFiles =
-    -- used tag in version
     [
     -- Indent failure
       eq "control-monad-exception-mtl/0.10.3/control-monad-exception-mtl.cabal"
-    -- readp parser fails (description: {} )
-    , eq "Cardinality/0.1/Cardinality.cabal"
-    , eq "Cardinality/0.2/Cardinality.cabal"
-    , eq "ConfigFileTH/0.1/ConfigFileTH.cabal"
     -- Other modules <- no dash
     , eq "DSTM/0.1/DSTM.cabal"
     , eq "DSTM/0.1.1/DSTM.cabal"

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 module Main
     ( main
     ) where
@@ -22,8 +21,21 @@ tests = testGroup "parsec tests"
 -- Verify that we trigger warnings
 warningTests :: TestTree
 warningTests = testGroup "warnings triggered"
-    [ warningTest PWTLexBOM "bom.cabal"
-    , warningTest PWTLexNBSP "nbsp.cabal"
+    [ warningTest PWTLexBOM            "bom.cabal"
+    , warningTest PWTLexNBSP           "nbsp.cabal"
+    , warningTest PWTUTF               "utf8.cabal"
+    , warningTest PWTBoolCase          "bool.cabal"
+    , warningTest PWTGluedOperators    "gluedop.cabal"
+    , warningTest PWTVersionTag        "versiontag.cabal"
+    , warningTest PWTNewSyntax         "newsyntax.cabal"
+    , warningTest PWTOldSyntax         "oldsyntax.cabal"
+    , warningTest PWTDeprecatedField   "deprecatedfield.cabal"
+    , warningTest PWTInvalidSubsection "subsection.cabal"
+    , warningTest PWTUnknownField      "unknownfield.cabal"
+    , warningTest PWTUnknownSection    "unknownsection.cabal"
+    , warningTest PWTTrailingFields    "trailingfield.cabal"
+    -- TODO: not implemented yet
+    -- , warningTest PWTExtraTestModule   "extratestmodule.cabal"
     ]
 
 warningTest :: PWarnType -> FilePath -> TestTree

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -1,0 +1,252 @@
+module Main where
+
+import           Control.Applicative
+                 (Applicative (..), (<$>))
+import           Control.Monad                          (when)
+import           Data.Char                              (isSpace)
+import           Data.Foldable
+                 (foldMap, for_, traverse_)
+import           Data.List                              (isPrefixOf, isSuffixOf)
+import           Data.Maybe                             (catMaybes)
+import           Data.Monoid                            (Monoid (..), Sum (..))
+import           Data.Traversable                       (traverse)
+import           Distribution.Simple.Utils              (fromUTF8LBS)
+import           System.Directory
+                 (getAppUserDataDirectory)
+import           System.Environment                     (getArgs)
+import           System.Exit                            (exitFailure)
+import           System.FilePath                        ((</>))
+
+
+import           Distribution.PackageDescription
+
+import qualified Codec.Archive.Tar                      as Tar
+import qualified Data.ByteString.Lazy                   as BSL
+import qualified Data.Map                               as Map
+import qualified Distribution.PackageDescription.Parse  as ReadP
+import qualified Distribution.PackageDescription.Parsec as Parsec
+import qualified Distribution.Parsec.Parser             as Parsec
+import qualified Distribution.Parsec.Types.Common       as Parsec
+import qualified Distribution.Parsec.Types.ParseResult  as Parsec
+import qualified Distribution.ParseUtils                as ReadP
+
+import           DiffInstances ()
+import           StructDiff
+
+parseIndex :: Monoid a => (FilePath -> BSL.ByteString -> IO a) -> IO a
+parseIndex action = do
+    c <- getAppUserDataDirectory "cabal"
+    cfg <- readFile (c </> "config")
+    let repos        = reposFromConfig cfg
+        repoCache    = case lookupInConfig "remote-repo-cache" cfg of
+            []        -> c </> "packages"  -- Default
+            (rrc : _) -> rrc               -- User-specified
+        tarName repo = repoCache </> repo </> "00-index.tar"
+    mconcat <$> traverse (parseIndex' action . tarName) repos
+
+
+parseIndex' :: Monoid a => (FilePath -> BSL.ByteString -> IO a) -> FilePath -> IO a
+parseIndex' action path = do
+    contents <- BSL.readFile path
+    let entries = Tar.read contents
+    Tar.foldEntries (\e m -> mappend <$> f e <*> m) (return mempty) (fail . show) entries
+
+  where
+    f entry = case Tar.entryContent entry of
+        Tar.NormalFile contents _
+            | ".cabal" `isSuffixOf` fpath -> action fpath contents
+            | otherwise                   -> return mempty
+        Tar.Directory -> return mempty
+        _             -> putStrLn ("Unknown content in " ++ fpath) >> return mempty
+     where
+       fpath = Tar.entryPath entry
+
+readFieldTest :: FilePath -> BSL.ByteString -> IO ()
+readFieldTest fpath bsl = case Parsec.readFields $ BSL.toStrict bsl of
+    Right _  -> return ()
+    Left err -> putStrLn $ fpath ++ "\n" ++ show err
+
+-- | Map with unionWith monoid
+newtype M k v = M (Map.Map k v)
+    deriving (Show)
+instance (Ord k, Monoid v) => Monoid (M k v) where
+    mempty = M Map.empty
+    mappend (M a) (M b) = M (Map.unionWith mappend a b)
+
+compareTest
+    :: String  -- ^ prefix of first packages to start traversal
+    -> FilePath -> BSL.ByteString -> IO (Sum Int, Sum Int, M Parsec.PWarnType (Sum Int))
+compareTest pfx fpath bsl
+    | any ($ fpath) problematicFiles = mempty
+    | fpath < pfx                    = mempty
+    | otherwise = do
+    let str = fromUTF8LBS bsl
+
+    putStrLn $ "::: " ++ fpath
+    (readp, readpWarnings)  <- case ReadP.parsePackageDescription str of
+        ReadP.ParseOk ws x    -> return (x, ws)
+        ReadP.ParseFailed err -> print err >> exitFailure
+    traverse_ (putStrLn . ReadP.showPWarning fpath) readpWarnings
+
+    let (warnings, errors, parsec') = Parsec.runParseResult $ Parsec.parseGenericPackageDescription (BSL.toStrict bsl)
+    traverse_ (putStrLn . Parsec.showPWarning fpath) warnings
+    traverse_ (putStrLn . Parsec.showPError fpath) errors
+    parsec <- maybe (print readp >> exitFailure) return parsec'
+
+    -- Old parser is broken for many descriptions, and other free text fields
+    let readp0  = readp  { packageDescription = (packageDescription readp)  { description = "", synopsis = "", maintainer = "" }}
+    let parsec0 = parsec { packageDescription = (packageDescription parsec) { description = "", synopsis = "", maintainer = "" }}
+
+    if readp0 == parsec0
+        then return ()
+        else do
+            {-
+            putStrLn "<<<<<<"
+            print readp
+            putStrLn "======"
+            print parsec
+            putStrLn ">>>>>>"
+            -}
+            prettyResultIO $ diff readp parsec
+            exitFailure
+
+    let readpWarnCount  = Sum (length readpWarnings)
+    let parsecWarnCount = Sum (length warnings)
+
+    when (readpWarnCount > parsecWarnCount) $ do
+        putStrLn "There are more readpWarnings"
+        exitFailure
+
+    let parsecWarnMap   = foldMap (\(Parsec.PWarning t _ _) -> M $ Map.singleton t 1) warnings
+    return (readpWarnCount, parsecWarnCount, parsecWarnMap)
+
+parseReadpTest :: FilePath -> BSL.ByteString -> IO ()
+parseReadpTest fpath bsl = when (not $ any ($ fpath) problematicFiles) $ do
+    let str = fromUTF8LBS bsl
+    case ReadP.parsePackageDescription str of
+        ReadP.ParseOk _ _     -> return ()
+        ReadP.ParseFailed err -> print err >> exitFailure
+
+parseParsecTest :: FilePath -> BSL.ByteString -> IO ()
+parseParsecTest fpath bsl = when (not $ any ($ fpath) problematicFiles) $ do
+    let bs = BSL.toStrict bsl
+    let (_warnings, errors, parsec) = Parsec.runParseResult $ Parsec.parseGenericPackageDescription bs
+    case parsec of
+        Just _ -> return ()
+        Nothing -> do
+            traverse_ (putStrLn . Parsec.showPError fpath) errors
+            exitFailure
+
+problematicFiles :: [FilePath -> Bool]
+problematicFiles =
+    -- used tag in version
+    [
+    -- Indent failure
+      eq "control-monad-exception-mtl/0.10.3/control-monad-exception-mtl.cabal"
+    -- readp parser fails (description: {} )
+    , eq "Cardinality/0.1/Cardinality.cabal"
+    , eq "Cardinality/0.2/Cardinality.cabal"
+    , eq "ConfigFileTH/0.1/ConfigFileTH.cabal"
+    -- Other modules <- no dash
+    , eq "DSTM/0.1/DSTM.cabal"
+    , eq "DSTM/0.1.1/DSTM.cabal"
+    , eq "DSTM/0.1.2/DSTM.cabal"
+    -- executable
+    {-
+    , eq "DefendTheKing/0.1/DefendTheKing.cabal"
+    , eq "DefendTheKing/0.2/DefendTheKing.cabal"
+    , eq "DefendTheKing/0.2.1/DefendTheKing.cabal"
+    , isPrefixOf "HaLeX/"
+    , isPrefixOf "PerfectHash/"
+    , isPrefixOf "hburg/"
+    , isPrefixOf "hemkay/"
+    , isPrefixOf "historian/"
+    , isPrefixOf "hp2any-graph/"
+    , isPrefixOf "hp2any-manager/"
+    -}
+    -- hs-source-dirs:
+    --   .
+    , isPrefixOf "writer-cps-mtl/"
+    , isPrefixOf "writer-cps-monads-tf/"
+    , isPrefixOf "writer-cps-transformers/"
+    -- unexpected character in input '\194' - nbsp
+    , eq "Octree/0.5/Octree.cabal"
+    , eq "hermit/0.1.8.0/hermit.cabal"
+    , eq "oeis/0.3.0/oeis.cabal"
+    , eq "oeis/0.3.1/oeis.cabal"
+    , eq "oeis/0.3.2/oeis.cabal"
+    , eq "oeis/0.3.3/oeis.cabal"
+    , eq "oeis/0.3.4/oeis.cabal"
+    , eq "oeis/0.3.5/oeis.cabal"
+    , eq "oeis/0.3.6/oeis.cabal"
+    , eq "oeis/0.3.7/oeis.cabal"
+    -- colon : after section header
+    , eq "ds-kanren/0.2.0.0/ds-kanren.cabal"
+    , eq "ds-kanren/0.2.0.1/ds-kanren.cabal"
+    , eq "metric/0.1.4/metric.cabal"
+    , eq "metric/0.2.0/metric.cabal"
+    , eq "phasechange/0.1/phasechange.cabal"
+    , eq "shelltestrunner/1.3/shelltestrunner.cabal"
+    , eq "smartword/0.0.0.5/smartword.cabal"
+    -- \DEL
+    , eq "vacuum-opengl/0.0/vacuum-opengl.cabal"
+    , eq "vacuum-opengl/0.0.1/vacuum-opengl.cabal"
+    -- dashes in version, not even tag
+    , isPrefixOf "free-theorems-webui/"
+    -- whitespace difference in x-fields
+    {-
+    , isPrefixOf "gtk/"
+    , isPrefixOf "hsqml/"
+    , isPrefixOf "hsqml-datamodel/"
+    , isPrefixOf "lhae/"
+    , isPrefixOf "vte/"
+    -}
+    -- hs-source-dirs ".", old parser broken
+    , isPrefixOf "hledger-ui/"
+    , eq "hspec-expectations-pretty/0.1/hspec-expectations-pretty.cabal"
+    -- {- comment -}
+    , eq "ixset/1.0.4/ixset.cabal"
+    ]
+  where
+    eq = (==)
+
+main :: IO ()
+main = do
+    args <- getArgs
+    case args of
+        ["read-field"]   -> parseIndex readFieldTest
+        ["parse-readp"]  -> parseIndex parseReadpTest
+        ["parse-parsec"] -> parseIndex parseParsecTest
+        [pfx]            -> defaultMain pfx
+        _                -> defaultMain ""
+  where
+    defaultMain pfx = do
+        (Sum readpCount, Sum parsecCount, M warn) <- parseIndex (compareTest pfx)
+        putStrLn $ "readp warnings: " ++ show readpCount
+        putStrLn $ "parsec count:   " ++ show parsecCount
+        for_ (Map.toList warn) $ \(t, Sum c) ->
+            putStrLn $ " - " ++ show t ++ " : " ++ show c
+
+-------------------------------------------------------------------------------
+-- Index shuffling
+-------------------------------------------------------------------------------
+
+-- TODO: Use 'Cabal' for this?
+reposFromConfig :: String -> [String]
+reposFromConfig = map (takeWhile (/= ':')) . lookupInConfig "remote-repo"
+
+-- | Looks up the given key in the cabal configuration file
+lookupInConfig :: String -> String -> [String]
+lookupInConfig key = map trim . catMaybes . map (dropPrefix prefix) . lines
+  where
+    prefix = key ++ ":"
+
+-- | Utility: drop leading and trailing spaces from a string
+trim :: String -> String
+trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace
+
+dropPrefix :: (Eq a) => [a] -> [a] -> Maybe [a]
+dropPrefix prefix s =
+  if prefix `isPrefixOf` s
+  then Just . drop (length prefix) $ s
+  else Nothing

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -10,7 +10,7 @@ import           Data.List                              (isPrefixOf, isSuffixOf)
 import           Data.Maybe                             (mapMaybe, listToMaybe)
 import           Data.Monoid                            (Monoid (..), Sum (..))
 import           Data.Traversable                       (traverse)
-import           Distribution.Simple.Utils              (fromUTF8LBS)
+import           Distribution.Simple.Utils              (fromUTF8LBS, ignoreBOM)
 import           System.Directory
                  (getAppUserDataDirectory)
 import           System.Environment                     (getArgs)
@@ -93,7 +93,7 @@ compareTest pfx fpath bsl
     | any ($ fpath) problematicFiles = mempty
     | not $ pfx `isPrefixOf` fpath   = mempty
     | otherwise = do
-    let str = fromUTF8LBS bsl
+    let str = ignoreBOM $ fromUTF8LBS bsl
 
     putStrLn $ "::: " ++ fpath
     (readp, readpWarnings)  <- case ReadP.parsePackageDescription str of
@@ -194,10 +194,6 @@ problematicFiles =
     , eq "ixset/1.0.4/ixset.cabal"
     -- comments in braces
     , isPrefixOf "hint/"
-    -- something weird: FromString "unrecognised field or section: \"\\65279\"" (Just 1)
-    , eq "Workflow/0.8.3/Workflow.cabal"
-    , eq "dictionary-sharing/0.1.0.0/dictionary-sharing.cabal"
-    , eq "testing-type-modifiers/0.1.0.0/testing-type-modifiers.cabal"
     ]
   where
     eq = (==)

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -30,8 +30,10 @@ import qualified Distribution.Parsec.Types.Common       as Parsec
 import qualified Distribution.Parsec.Types.ParseResult  as Parsec
 import qualified Distribution.ParseUtils                as ReadP
 
+#ifdef HAS_STRUCT_DIFF
 import           DiffInstances ()
 import           StructDiff
+#endif
 
 parseIndex :: Monoid a => (FilePath -> BSL.ByteString -> IO a) -> IO a
 parseIndex action = do
@@ -100,14 +102,15 @@ compareTest pfx fpath bsl
     if readp0 == parsec0
         then return ()
         else do
-            {-
-            putStrLn "<<<<<<"
-            print readp
-            putStrLn "======"
-            print parsec
-            putStrLn ">>>>>>"
-            -}
+#if HAS_STRUCT_DIFF
             prettyResultIO $ diff readp parsec
+#else
+            putStrLn "<<<<<<"
+            print readp0
+            putStrLn "======"
+            print parsec0
+            putStrLn ">>>>>>"
+#endif
             exitFailure
 
     let readpWarnCount  = Sum (length readpWarnings)

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -1,365 +1,43 @@
-{-# LANGUAGE Rank2Types #-}
-module Main where
+{-# LANGUAGE DeriveDataTypeable #-}
+module Main
+    ( main
+    ) where
 
-import           Control.Applicative
-                 (Applicative (..), (<$>), Const (..))
-import           Control.Monad                          (when)
-import           Data.Foldable
-                 (foldMap, for_, traverse_)
-import           Data.List                              (isPrefixOf, isSuffixOf)
-import           Data.Maybe                             (mapMaybe, listToMaybe)
-import           Data.Monoid                            (Monoid (..), Sum (..))
-import           Data.Traversable                       (traverse)
-import           Distribution.Simple.Utils              (fromUTF8LBS, ignoreBOM)
-import           System.Directory
-                 (getAppUserDataDirectory)
-import           System.Environment                     (getArgs)
-import           System.Exit                            (exitFailure)
-import           System.FilePath                        ((</>))
+import Test.Tasty
+import Test.Tasty.HUnit
 
-import           Distribution.Package (Dependency)
-import           Distribution.PackageDescription
+import Data.Maybe (isJust)
+import Distribution.PackageDescription.Parsec (parseGenericPackageDescription)
+import Distribution.Parsec.Types.Common (PWarnType (..), PWarning (..))
+import Distribution.Parsec.Types.ParseResult (runParseResult)
+import System.FilePath ((</>))
 
-import qualified Codec.Archive.Tar                      as Tar
-import qualified Data.ByteString                        as B
-import qualified Data.ByteString.Char8                  as B8
-import qualified Data.ByteString.Lazy                   as BSL
-import qualified Data.Map                               as Map
-import qualified Distribution.PackageDescription.Parse  as ReadP
-import qualified Distribution.PackageDescription.Parsec as Parsec
-import qualified Distribution.Parsec.Parser             as Parsec
-import qualified Distribution.Parsec.Types.Common       as Parsec
-import qualified Distribution.Parsec.Types.ParseResult  as Parsec
-import qualified Distribution.ParseUtils                as ReadP
-import qualified Distribution.Compat.DList              as DList
+import qualified Data.ByteString as BS
 
-#if __GLASGOW_HASKELL__ >= 708
-import Data.Coerce
-#else
-import Unsafe.Coerce
-#endif
-
-#ifdef HAS_STRUCT_DIFF
-import           DiffInstances ()
-import           StructDiff
-#endif
-
-parseIndex :: Monoid a => (FilePath -> BSL.ByteString -> IO a) -> IO a
-parseIndex action = do
-    cabalDir  <- getAppUserDataDirectory "cabal"
-    cfg       <- B.readFile (cabalDir </> "config")
-    cfgFields <- either (fail . show) pure $ Parsec.readFields cfg
-    let repos        = reposFromConfig cfgFields
-        repoCache    = case lookupInConfig "remote-repo-cache" cfgFields of
-            []        -> cabalDir </> "packages"  -- Default
-            (rrc : _) -> rrc                      -- User-specified
-        tarName repo = repoCache </> repo </> "01-index.tar"
-    mconcat <$> traverse (parseIndex' action . tarName) repos
-
-
-parseIndex' :: Monoid a => (FilePath -> BSL.ByteString -> IO a) -> FilePath -> IO a
-parseIndex' action path = do
-    putStrLn $ "Reading index from: " ++ path
-    contents <- BSL.readFile path
-    let entries = Tar.read contents
-    Tar.foldEntries (\e m -> mappend <$> f e <*> m) (return mempty) (fail . show) entries
-
-  where
-    f entry = case Tar.entryContent entry of
-        Tar.NormalFile contents _
-            | ".cabal" `isSuffixOf` fpath -> action fpath contents
-            | otherwise                   -> return mempty
-        Tar.Directory -> return mempty
-        _             -> putStrLn ("Unknown content in " ++ fpath) >> return mempty
-     where
-       fpath = Tar.entryPath entry
-
-readFieldTest :: FilePath -> BSL.ByteString -> IO ()
-readFieldTest fpath bsl = case Parsec.readFields $ BSL.toStrict bsl of
-    Right _  -> return ()
-    Left err -> putStrLn $ fpath ++ "\n" ++ show err
-
--- | Map with unionWith monoid
-newtype M k v = M (Map.Map k v)
-    deriving (Show)
-instance (Ord k, Monoid v) => Monoid (M k v) where
-    mempty = M Map.empty
-    mappend (M a) (M b) = M (Map.unionWith mappend a b)
-
-compareTest
-    :: String  -- ^ prefix of first packages to start traversal
-    -> FilePath -> BSL.ByteString -> IO (Sum Int, Sum Int, M Parsec.PWarnType (Sum Int))
-compareTest pfx fpath bsl
-    | any ($ fpath) problematicFiles = mempty
-    | not $ pfx `isPrefixOf` fpath   = mempty
-    | otherwise = do
-    let str = ignoreBOM $ fromUTF8LBS bsl
-
-    putStrLn $ "::: " ++ fpath
-    (readp, readpWarnings)  <- case ReadP.parsePackageDescription str of
-        ReadP.ParseOk ws x    -> return (x, ws)
-        ReadP.ParseFailed err -> print err >> exitFailure
-    traverse_ (putStrLn . ReadP.showPWarning fpath) readpWarnings
-
-    let (warnings, errors, parsec') = Parsec.runParseResult $ Parsec.parseGenericPackageDescription (BSL.toStrict bsl)
-    traverse_ (putStrLn . Parsec.showPWarning fpath) warnings
-    traverse_ (putStrLn . Parsec.showPError fpath) errors
-    parsec <- maybe (print readp >> exitFailure) return parsec'
-
-    -- Old parser is broken for many descriptions, and other free text fields
-    let readp0  = readp
-            & set (packageDescription_ .  description_) ""
-            & set (packageDescription_ .  synopsis_)    ""
-            & set (packageDescription_ .  maintainer_)  ""
-    let parsec0  = parsec
-            & set (packageDescription_ .  description_) ""
-            & set (packageDescription_ .  synopsis_)    ""
-            & set (packageDescription_ .  maintainer_)  ""
-
-    -- hs-source-dirs ".", old parser broken
-    -- See e.g. http://hackage.haskell.org/package/hledger-ui-0.27/hledger-ui.cabal executable
-    let parsecHsSrcDirs = parsec0 & toListOf (buildInfos_ . hsSourceDirs_)
-    let readpHsSrcDirs  = readp0  & toListOf (buildInfos_ . hsSourceDirs_)
-    let filterDotDirs   = filter (/= ".")
-
-    let parsec1 = if parsecHsSrcDirs /= readpHsSrcDirs && fmap filterDotDirs parsecHsSrcDirs == readpHsSrcDirs
-        then parsec0 & over (buildInfos_ . hsSourceDirs_) filterDotDirs
-        else parsec0
-
-    -- Compare two parse results
-    if readp0 == parsec1
-        then return ()
-        else do
-#if HAS_STRUCT_DIFF
-            prettyResultIO $ diff readp parsec
-#else
-            putStrLn "<<<<<<"
-            print readp
-            putStrLn "======"
-            print parsec
-            putStrLn ">>>>>>"
-#endif
-            exitFailure
-
-    let readpWarnCount  = Sum (length readpWarnings)
-    let parsecWarnCount = Sum (length warnings)
-
-    when (readpWarnCount > parsecWarnCount) $ do
-        putStrLn "There are more readpWarnings"
-        exitFailure
-
-    let parsecWarnMap   = foldMap (\(Parsec.PWarning t _ _) -> M $ Map.singleton t 1) warnings
-    return (readpWarnCount, parsecWarnCount, parsecWarnMap)
-
-parseReadpTest :: FilePath -> BSL.ByteString -> IO ()
-parseReadpTest fpath bsl = when (not $ any ($ fpath) problematicFiles) $ do
-    let str = fromUTF8LBS bsl
-    case ReadP.parsePackageDescription str of
-        ReadP.ParseOk _ _     -> return ()
-        ReadP.ParseFailed err -> print err >> exitFailure
-
-parseParsecTest :: FilePath -> BSL.ByteString -> IO ()
-parseParsecTest fpath bsl = when (not $ any ($ fpath) problematicFiles) $ do
-    let bs = BSL.toStrict bsl
-    let (_warnings, errors, parsec) = Parsec.runParseResult $ Parsec.parseGenericPackageDescription bs
-    case parsec of
-        Just _ -> return ()
-        Nothing -> do
-            traverse_ (putStrLn . Parsec.showPError fpath) errors
-            exitFailure
-
-problematicFiles :: [FilePath -> Bool]
-problematicFiles =
-    [
-    -- Indent failure
-      eq "control-monad-exception-mtl/0.10.3/control-monad-exception-mtl.cabal"
-    -- Other modules <- no dash
-    , eq "DSTM/0.1/DSTM.cabal"
-    , eq "DSTM/0.1.1/DSTM.cabal"
-    , eq "DSTM/0.1.2/DSTM.cabal"
-    -- colon : after section header
-    , eq "ds-kanren/0.2.0.0/ds-kanren.cabal"
-    , eq "ds-kanren/0.2.0.1/ds-kanren.cabal"
-    , eq "metric/0.1.4/metric.cabal"
-    , eq "metric/0.2.0/metric.cabal"
-    , eq "phasechange/0.1/phasechange.cabal"
-    , eq "shelltestrunner/1.3/shelltestrunner.cabal"
-    , eq "smartword/0.0.0.5/smartword.cabal"
-    -- \DEL
-    , eq "vacuum-opengl/0.0/vacuum-opengl.cabal"
-    , eq "vacuum-opengl/0.0.1/vacuum-opengl.cabal"
-    -- dashes in version, not even tag
-    , isPrefixOf "free-theorems-webui/"
-    -- {- comment -}
-    , eq "ixset/1.0.4/ixset.cabal"
-    -- comments in braces
-    , isPrefixOf "hint/"
+tests :: TestTree
+tests = testGroup "parsec tests"
+    [ warningTests
     ]
-  where
-    eq = (==)
+
+-- Verify that we trigger warnings
+warningTests :: TestTree
+warningTests = testGroup "warnings triggered"
+    [ warningTest PWTLexBOM "bom.cabal"
+    ]
+
+warningTest :: PWarnType -> FilePath -> TestTree
+warningTest wt fp = testCase (show wt) $ do
+    contents <- BS.readFile $ "tests" </> "ParserTests" </> "warnings" </> fp
+    let res =  parseGenericPackageDescription contents
+    let (warns, errs, x) = runParseResult res
+    
+    assertBool "parses successfully" $ isJust x
+    assertBool "parses without errors" $ null errs
+
+    case warns of
+        [PWarning wt' _ _] -> assertEqual "warning type" wt wt'
+        []                 -> assertFailure "got no warnings"
+        _                  -> assertFailure $ "got multiple warnings: " ++ show warns
 
 main :: IO ()
-main = do
-    args <- getArgs
-    case args of
-        ["read-field"]   -> parseIndex readFieldTest
-        ["parse-readp"]  -> parseIndex parseReadpTest
-        ["parse-parsec"] -> parseIndex parseParsecTest
-        [pfx]            -> defaultMain pfx
-        _                -> defaultMain ""
-  where
-    defaultMain pfx = do
-        (Sum readpCount, Sum parsecCount, M warn) <- parseIndex (compareTest pfx)
-        putStrLn $ "readp warnings: " ++ show readpCount
-        putStrLn $ "parsec count:   " ++ show parsecCount
-        for_ (Map.toList warn) $ \(t, Sum c) ->
-            putStrLn $ " - " ++ show t ++ " : " ++ show c
-
--------------------------------------------------------------------------------
--- Index shuffling
--------------------------------------------------------------------------------
-
--- TODO: Use 'Cabal' for this?
-reposFromConfig :: [Parsec.Field ann] -> [String]
-reposFromConfig fields = takeWhile (/= ':') <$> mapMaybe f fields
-  where
-    f (Parsec.Field (Parsec.Name _ name) fieldLines)
-        | B8.unpack name == "remote-repo" =
-            Just $ fieldLinesToString fieldLines
-    f (Parsec.Section (Parsec.Name _ name) [Parsec.SecArgName _ secName] _fieldLines)
-        | B8.unpack name == "repository" =
-            Just $ B8.unpack secName
-    f _ = Nothing
-
--- | Looks up the given key in the cabal configuration file
-lookupInConfig :: String -> [Parsec.Field ann] -> [String]
-lookupInConfig key = mapMaybe f
-  where
-    f (Parsec.Field (Parsec.Name _ name) fieldLines)
-        | B8.unpack name == key =
-            Just $ fieldLinesToString fieldLines
-    f _ = Nothing
-
-fieldLinesToString :: [Parsec.FieldLine ann] -> String
-fieldLinesToString fieldLines =
-    B8.unpack $ B.concat $ bsFromFieldLine <$> fieldLines
-  where
-    bsFromFieldLine (Parsec.FieldLine _ bs) = bs
-
--------------------------------------------------------------------------------
--- Distribution.Compat.Lens
--------------------------------------------------------------------------------
-
-type Lens' s a = forall f. Functor f => (a -> f a) -> s -> f s
-type Traversal' s a = forall f. Applicative f => (a -> f a) -> s -> f s
-
-type Getting r s a = (a -> Const r a) -> s -> Const r s
-type ASetter' s a = (a -> I a) -> s -> I s
-
-
-
--- | View the value pointed to by a 'Getting' or 'Lens' or the
--- result of folding over all the results of a 'Control.Lens.Fold.Fold' or
--- 'Control.Lens.Traversal.Traversal' that points at a monoidal values.
-view :: s -> Getting a s a -> a
-view s l = getConst (l Const s)
-
--- | Replace the target of a 'Lens'' or 'Traversal'' with a constant value.
-set :: ASetter' s a -> a -> s -> s
-set l x = over l (const x)
-
--- | Modify the target of a 'Lens'' or all the targets of a 'Traversal''
--- with a function.
-over :: ASetter' s a -> (a -> a) -> s -> s
-#if __GLASGOW_HASKELL__ >= 708
-over l f = coerce . l (coerce . f)
-#else
-over l f = unsafeCoerce . l (unsafeCoerce . f)
-#endif
-
--- | Build a 'Lens'' from a getter and a setter.
-lens :: (s -> a) -> (s -> a -> s) -> Lens' s a
-lens sa sbt afb s = sbt s <$> afb (sa s)
-
--- | Build an 'Getting' from an arbitrary Haskell function.
-to :: (s -> a) -> Getting r s a
-to f g a = Const $ getConst $ g (f a)
-
--- | Extract a list of the targets of a 'Lens'' or 'Traversal''.
-toListOf :: Getting (DList.DList a) s a -> s -> [a]
-toListOf l = DList.runDList . getConst . l (Const . DList.singleton)
-
--- | Retrieve the first entry of a 'Traversal'' or retrieve 'Just' the result
--- from a 'Getting' or 'Lens''.
-firstOf :: Getting (DList.DList a) s a -> s -> Maybe a
-firstOf l = listToMaybe . toListOf l
-
--- | '&' is a reverse application operator
-(&) :: a -> (a -> b) -> b
-(&) = flip ($)
-{-# INLINE (&) #-}
-infixl 1 &
-
--------------------------------------------------------------------------------
--- Distribution.Compat.BasicFunctors
--------------------------------------------------------------------------------
-
-newtype I a = I a
-
-unI :: I a -> a
-unI (I x) = x
-
-instance Functor I where
-    fmap f (I x) = I (f x)
-
-instance Applicative I where
-    pure        = I
-    I f <*> I x = I (f x)
-    _ *> x      = x
-
-_2 :: Lens' (a, b) b
-_2 = lens snd $ \(a, _) b -> (a, b)
-
--------------------------------------------------------------------------------
--- Distribution.PackageDescription.Lens
--------------------------------------------------------------------------------
-
-packageDescription_ :: Lens' GenericPackageDescription PackageDescription
-packageDescription_ = lens packageDescription $ \s a -> s { packageDescription = a }
-
-condLibrary_ :: Lens' GenericPackageDescription (Maybe (CondTree ConfVar [Dependency] Library))
-condLibrary_ = lens condLibrary $ \s a -> s { condLibrary = a}
-
-condExecutables_ :: Lens' GenericPackageDescription [(String, CondTree ConfVar [Dependency] Executable)]
-condExecutables_ = lens condExecutables $ \s a -> s { condExecutables = a }
-
-condTreeData_ :: Lens' (CondTree v c a) a
-condTreeData_ = lens condTreeData $ \s a -> s { condTreeData = a }
-
-description_, synopsis_, maintainer_ :: Lens' PackageDescription String
-description_ = lens description $ \s a -> s { description = a }
-synopsis_    = lens synopsis    $ \s a -> s { synopsis    = a }
-maintainer_  = lens maintainer  $ \s a -> s { maintainer  = a }
-
-class HasBuildInfo a where
-    buildInfo_ :: Lens' a BuildInfo
-
-instance HasBuildInfo Library where
-    buildInfo_ = lens libBuildInfo $ \s a -> s { libBuildInfo = a }
-
-instance HasBuildInfo Executable where
-    buildInfo_ = lens buildInfo $ \s a -> s { buildInfo = a }
-
--- | This forgets a lot of structure, but might be nice for some stuff
-buildInfos_ :: Traversal' GenericPackageDescription BuildInfo
-buildInfos_ f gpd = mkGpd
-    <$> (traverse . traverse . buildInfo_) f (condLibrary gpd)
-    <*> (traverse . _2 . traverse . buildInfo_) f (condExecutables gpd)
-  where
-      mkGpd lib exe = gpd
-          { condLibrary     = lib
-          , condExecutables = exe
-          }
-
-hsSourceDirs_ :: Lens' BuildInfo [FilePath]
-hsSourceDirs_ = lens hsSourceDirs $ \s a -> s { hsSourceDirs = a }
+main = defaultMain tests

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -154,35 +154,6 @@ problematicFiles =
     , eq "DSTM/0.1/DSTM.cabal"
     , eq "DSTM/0.1.1/DSTM.cabal"
     , eq "DSTM/0.1.2/DSTM.cabal"
-    -- executable
-    {-
-    , eq "DefendTheKing/0.1/DefendTheKing.cabal"
-    , eq "DefendTheKing/0.2/DefendTheKing.cabal"
-    , eq "DefendTheKing/0.2.1/DefendTheKing.cabal"
-    , isPrefixOf "HaLeX/"
-    , isPrefixOf "PerfectHash/"
-    , isPrefixOf "hburg/"
-    , isPrefixOf "hemkay/"
-    , isPrefixOf "historian/"
-    , isPrefixOf "hp2any-graph/"
-    , isPrefixOf "hp2any-manager/"
-    -}
-    -- hs-source-dirs:
-    --   .
-    , isPrefixOf "writer-cps-mtl/"
-    , isPrefixOf "writer-cps-monads-tf/"
-    , isPrefixOf "writer-cps-transformers/"
-    -- unexpected character in input '\194' - nbsp
-    , eq "Octree/0.5/Octree.cabal"
-    , eq "hermit/0.1.8.0/hermit.cabal"
-    , eq "oeis/0.3.0/oeis.cabal"
-    , eq "oeis/0.3.1/oeis.cabal"
-    , eq "oeis/0.3.2/oeis.cabal"
-    , eq "oeis/0.3.3/oeis.cabal"
-    , eq "oeis/0.3.4/oeis.cabal"
-    , eq "oeis/0.3.5/oeis.cabal"
-    , eq "oeis/0.3.6/oeis.cabal"
-    , eq "oeis/0.3.7/oeis.cabal"
     -- colon : after section header
     , eq "ds-kanren/0.2.0.0/ds-kanren.cabal"
     , eq "ds-kanren/0.2.0.1/ds-kanren.cabal"
@@ -207,6 +178,9 @@ problematicFiles =
     -- hs-source-dirs ".", old parser broken
     , isPrefixOf "hledger-ui/"
     , eq "hspec-expectations-pretty/0.1/hspec-expectations-pretty.cabal"
+    , isPrefixOf "writer-cps-mtl/"
+    , isPrefixOf "writer-cps-monads-tf/"
+    , isPrefixOf "writer-cps-transformers/"
     -- {- comment -}
     , eq "ixset/1.0.4/ixset.cabal"
     ]

--- a/Cabal/tests/ParserTests/warnings/bom.cabal
+++ b/Cabal/tests/ParserTests/warnings/bom.cabal
@@ -1,0 +1,7 @@
+﻿name: bom
+version: 1
+cabal-version: >= 1.6
+
+library
+    build-depends: base >= 4.9 && <4.10
+    hs-source-dirs: .

--- a/Cabal/tests/ParserTests/warnings/bool.cabal
+++ b/Cabal/tests/ParserTests/warnings/bool.cabal
@@ -1,0 +1,12 @@
+name: bool
+version: 1
+cabal-version: >= 1.6
+
+flag foo
+  manual: true
+
+library
+    build-depends: base >= 4.9 && <4.10
+    if flag(foo)
+      build-depends: containers
+    hs-source-dirs: .

--- a/Cabal/tests/ParserTests/warnings/deprecatedfield.cabal
+++ b/Cabal/tests/ParserTests/warnings/deprecatedfield.cabal
@@ -1,0 +1,7 @@
+name: deprecatedfield
+version: 1
+cabal-version: >= 1.6
+
+library
+    build-depends: base >= 4.9 && <4.10
+    hs-source-dir: .

--- a/Cabal/tests/ParserTests/warnings/extratestmodule.cabal
+++ b/Cabal/tests/ParserTests/warnings/extratestmodule.cabal
@@ -1,0 +1,11 @@
+name: extramainis
+version: 1
+cabal-version: >= 1.6
+
+library
+    build-depends: base >= 4.9 && <4.10
+    hs-source-dirs: .
+
+test-suite tests
+    type: exitcode-stdio-1.0
+    test-module: Tests

--- a/Cabal/tests/ParserTests/warnings/gluedop.cabal
+++ b/Cabal/tests/ParserTests/warnings/gluedop.cabal
@@ -1,0 +1,9 @@
+name: gluedop
+version: 1
+cabal-version: >= 1.6
+
+library
+    build-depends: base >= 4.9 && <4.10
+    if os(windows) &&!impl(ghc)
+      build-depends: containers
+    hs-source-dirs: .

--- a/Cabal/tests/ParserTests/warnings/nbsp.cabal
+++ b/Cabal/tests/ParserTests/warnings/nbsp.cabal
@@ -1,0 +1,7 @@
+name: nbsp
+version: 1
+cabal-version: >= 1.6
+
+library
+    build-depends: base >= 4.9 && <4.10
+    hs-source-dirs: .

--- a/Cabal/tests/ParserTests/warnings/newsyntax.cabal
+++ b/Cabal/tests/ParserTests/warnings/newsyntax.cabal
@@ -1,0 +1,6 @@
+name: newsyntax
+version: 1
+
+library
+    build-depends: base >= 4.9 && <4.10
+    hs-source-dirs: .

--- a/Cabal/tests/ParserTests/warnings/oldsyntax.cabal
+++ b/Cabal/tests/ParserTests/warnings/oldsyntax.cabal
@@ -1,0 +1,6 @@
+name: oldsyntax
+version: 1
+cabal-version: >= 1.6
+
+build-depends: base >= 4.9 && <4.10
+hs-source-dirs: .

--- a/Cabal/tests/ParserTests/warnings/subsection.cabal
+++ b/Cabal/tests/ParserTests/warnings/subsection.cabal
@@ -1,0 +1,9 @@
+name: subsection
+version: 1
+cabal-version: >= 1.6
+
+library
+    build-depends: base >= 4.9 && <4.10
+    hs-source-dirs: .
+    iff os(windows)
+    	build-depends: containers

--- a/Cabal/tests/ParserTests/warnings/trailingfield.cabal
+++ b/Cabal/tests/ParserTests/warnings/trailingfield.cabal
@@ -1,0 +1,9 @@
+name: trailingfield
+version: 1
+cabal-version: >= 1.6
+
+library
+    build-depends: base >= 4.9 && <4.10
+    hs-source-dirs: .
+
+description: No fields after sections

--- a/Cabal/tests/ParserTests/warnings/unknownfield.cabal
+++ b/Cabal/tests/ParserTests/warnings/unknownfield.cabal
@@ -1,0 +1,8 @@
+name: unknownfield
+version: 1
+cabal-version: >= 1.6
+
+library
+    build-depends: base >= 4.9 && <4.10
+    hs-source-dirs: .
+    z-field: z

--- a/Cabal/tests/ParserTests/warnings/unknownfield.cabal
+++ b/Cabal/tests/ParserTests/warnings/unknownfield.cabal
@@ -5,4 +5,4 @@ cabal-version: >= 1.6
 library
     build-depends: base >= 4.9 && <4.10
     hs-source-dirs: .
-    z-field: z
+    xfield: x

--- a/Cabal/tests/ParserTests/warnings/unknownsection.cabal
+++ b/Cabal/tests/ParserTests/warnings/unknownsection.cabal
@@ -1,0 +1,10 @@
+name: unknownsection
+version: 1
+cabal-version: >= 1.6
+
+library
+    build-depends: base >= 4.9 && <4.10
+    hs-source-dirs: .
+
+z
+    z-field: z

--- a/Cabal/tests/ParserTests/warnings/utf8.cabal
+++ b/Cabal/tests/ParserTests/warnings/utf8.cabal
@@ -1,0 +1,8 @@
+name: utf8
+author: Oleg Grönroos
+version: 1
+cabal-version: >= 1.6
+
+library
+    build-depends: base >= 4.9 && <4.10
+    hs-source-dirs: .

--- a/Cabal/tests/ParserTests/warnings/versiontag.cabal
+++ b/Cabal/tests/ParserTests/warnings/versiontag.cabal
@@ -1,0 +1,7 @@
+name: versiontag
+version: 1
+cabal-version: >= 1.6
+
+library
+    build-depends: base >= 4.9 && <4.10-rc1
+    hs-source-dirs: .

--- a/Cabal/tests/StructDiff.hs
+++ b/Cabal/tests/StructDiff.hs
@@ -1,0 +1,162 @@
+{- |
+
+At the ZuriHac 2016 I worked on the new parsec-based parser for the *.cabal files.
+The obvious test case is to compare new and old parser results for all of Hackage.
+Traversing the Hackage is quite trivial. The difficult part is inspecting
+the result 'GenericPackageDescription's to spot the difference.
+
+In the same event, Andres Löh showed his library @generics-sop@. Obvious choice
+to quickly put something together for the repetetive task. After all you can
+compare records field-wise. And if sum constructors are different, that's
+enough for our case as well!
+
+Generic programming ftw.
+-}
+
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DefaultSignatures     #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
+-- | TODO: package as a library? is this useful elsewhere?
+module StructDiff where
+
+import           Control.Applicative  (liftA2)
+import           Data.Align.Key       (AlignWithKey (..))
+import           Data.Foldable        (Foldable, fold, traverse_)
+import           Data.Key             (Key)
+import           Data.List            (intercalate)
+import           Data.Map             (Map)
+import           Data.Monoid          (Monoid (..), (<>))
+import           Data.Singletons.Bool (SBool (..), SBoolI (..), eqToRefl)
+import           Data.These           (These (..))
+import           Data.Type.Equality
+import           Generics.SOP
+
+-- | Because @'Data.Proxy.Proxy' :: 'Data.Proxy.Proxy' a@ is so long.
+data P a = P
+
+-------------------------------------------------------------------------------
+-- Structure diffs
+-------------------------------------------------------------------------------
+
+-- | Each thunk has a path, removed and added "stuff"
+data DiffThunk = DiffThunk { dtPath :: [String], dtA :: String, dtB :: String }
+    deriving Show
+
+-- | Diff result is a collection of thunks
+data DiffResult = DiffResult [DiffThunk]
+    deriving Show
+
+prefixThunk :: String -> DiffThunk -> DiffThunk
+prefixThunk pfx (DiffThunk path a b) = DiffThunk (pfx : path) a b
+
+prefixResult :: String -> DiffResult -> DiffResult
+prefixResult name (DiffResult thunks) = DiffResult $ map (prefixThunk name) thunks
+
+-- | Pretty print a result
+prettyResultIO :: DiffResult -> IO ()
+prettyResultIO (DiffResult []) = putStrLn "Equal"
+prettyResultIO (DiffResult xs) = traverse_ p xs
+  where
+    p (DiffThunk paths a b) = do
+        putStrLn $ intercalate " " paths ++ " : "
+        putStrLn $ "- " ++ a
+        putStrLn $ "+ " ++ b
+
+-- | We can join diff results
+instance Monoid DiffResult where
+    mempty = DiffResult mempty
+    mappend (DiffResult x) (DiffResult y) = DiffResult (mappend x y)
+
+-- | And we have a class for things we can diff
+class Diff a where
+    diff :: a -> a -> DiffResult
+    default diff
+        :: (Generic a, HasDatatypeInfo a, All2 Diff (Code a))
+        => a -> a -> DiffResult
+    diff = gdiff
+
+-- | And generic implementation!
+gdiff :: forall a. (Generic a, HasDatatypeInfo a, All2 Diff (Code a)) => a -> a -> DiffResult
+gdiff x y  = gdiffS (constructorInfo (P :: P a)) (unSOP $ from x) (unSOP $ from y)
+
+gdiffS :: All2 Diff xss => NP ConstructorInfo xss -> NS (NP I) xss -> NS (NP I) xss -> DiffResult
+gdiffS (c :* _) (Z xs) (Z ys) = mconcat $ hcollapse $ hczipWith3 (P :: P Diff) f (fieldNames c) xs ys
+  where
+    f :: Diff a => K FieldName a -> I a -> I a -> K DiffResult a
+    f (K fieldName) x y = K . prefixResult fieldName . unI $ liftA2 diff x y
+gdiffS (_ :* cs) (S xss) (S yss) = gdiffS cs xss yss
+gdiffS cs xs ys = DiffResult [DiffThunk [] (constructorNameOf cs xs) (constructorNameOf cs ys)]
+
+eqDiff :: (Eq a, Show a) => a -> a -> DiffResult
+eqDiff x y
+    | x == y    = DiffResult []
+    | otherwise = DiffResult [DiffThunk [] (show x) (show y)]
+
+alignDiff
+    :: (Show (Key f), Show a, Diff a, AlignWithKey f, Foldable f)
+    => f a -> f a -> DiffResult
+alignDiff x y = fold $ alignWithKey (\k -> prefixResult (show k) . f) x y
+  where
+    f (These a b) = diff a b
+    f (This a)    = DiffResult [DiffThunk [] (show a) "<none>"]
+    f (That b)    = DiffResult [DiffThunk [] "<none>" (show b)]
+
+instance Diff Char where diff = eqDiff
+instance Diff Bool
+instance Diff a => Diff (Maybe a)
+instance Diff Int where diff = eqDiff
+instance (Diff a, Diff b) => Diff (Either a b)
+
+instance (Diff a, Diff b) => Diff (a, b) where
+    diff (a, b) (a', b') =
+        prefixResult "_1" (diff a a') <>
+        prefixResult "_2" (diff b b')
+
+instance (Diff a, Diff b, Diff c) => Diff (a, b, c) where
+    diff (a, b, c) (a', b', c') =
+        prefixResult "_1" (diff a a') <>
+        prefixResult "_2" (diff b b') <>
+        prefixResult "_3" (diff c c')
+
+instance (SBoolI (a == Char), Show a, Diff a) => Diff [a] where
+    diff = case sbool :: SBool (a == Char) of
+        STrue  -> case eqToRefl :: a :~: Char of
+            Refl -> eqDiff
+        SFalse -> alignDiff
+
+instance (Ord k, Show k, Diff v, Show v) => Diff (Map k v) where diff = alignDiff
+
+-------------------------------------------------------------------------------
+-- SOP helpers
+-------------------------------------------------------------------------------
+
+constructorInfo :: (HasDatatypeInfo a, xss ~ Code a) => proxy a -> NP ConstructorInfo xss
+constructorInfo p = case datatypeInfo p of
+    ADT _ _ cs    -> cs
+    Newtype _ _ c -> c :* Nil
+
+constructorNameOf :: NP ConstructorInfo xss -> NS f xss -> ConstructorName
+constructorNameOf (c :* _)  (Z _)  = constructorName c
+constructorNameOf (_ :* cs) (S xs) = constructorNameOf cs xs
+#if __GLASGOW_HASKELL__ < 800
+constructorNameOf _ _ = error "Should never happen"
+#endif
+
+constructorName :: ConstructorInfo xs -> ConstructorName
+constructorName (Constructor name) = name
+constructorName (Infix name _ _)   = "(" ++ name ++ ")"
+constructorName (Record name _)    = name
+
+-- | This is a little lie.
+fieldNames :: ConstructorInfo xs -> NP (K FieldName) xs
+fieldNames (Constructor name) = hpure (K name) -- TODO: add .1 .2 etc.
+fieldNames (Infix name _ _) = K ("-(" ++ name ++ ")") :* K ("(" ++ name ++ ")-") :* Nil
+fieldNames (Record _ fis) = hmap (\(FieldInfo fieldName) -> K fieldName) fis

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -15,7 +15,7 @@ if [ -z ${STACKAGE_RESOLVER+x} ]; then
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         travis_retry sudo add-apt-repository -y ppa:hvr/ghc
         travis_retry sudo apt-get update
-        travis_retry sudo apt-get install --force-yes cabal-install-1.24 happy-1.19.5 ghc-$GHCVER-prof ghc-$GHCVER-dyn
+        travis_retry sudo apt-get install --force-yes cabal-install-1.24 happy-1.19.5 alex-3.1.7 ghc-$GHCVER-prof ghc-$GHCVER-dyn
         if [ "x$TEST_OTHER_VERSIONS" = "xYES" ]; then travis_retry sudo apt-get install --force-yes ghc-7.0.4-prof ghc-7.0.4-dyn ghc-7.2.2-prof ghc-7.2.2-dyn ghc-head-prof ghc-head-dyn; fi
 
     elif [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -63,7 +63,7 @@ fi
 (cd Cabal && timed ${CABAL_BDIR}/build/unit-tests/unit-tests       $TEST_OPTIONS) || exit $?
 
 if [ "x$PARSEC" = "xYES" ]; then
-    (cd Cabal && timed ${CABAL_BDIR}/build/parser-tests/parser-tests $TEST_OPTIONS) || exit $?
+    (cd Cabal && timed ${CABAL_BDIR}/build/parser-tests/parser-tests $TEST_OPTIONS) | tail || exit $?
 fi
 
 # Run haddock (hack: use the Setup script from package-tests!)

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -49,7 +49,7 @@ export CABAL_BUILDDIR="${CABAL_BDIR}"
 # more efficient (since new-build will uselessly try to rebuild
 # Cabal otherwise).
 if [ "x$PARSEC" = "xYES" ]; then
-  timed cabal new-build -fparsec Cabal Cabal:package-tests Cabal:unit-tests Cabal:parser-tests
+  timed cabal new-build -fparsec Cabal Cabal:package-tests Cabal:unit-tests Cabal:parser-tests Cabal:parser-hackage-tests
 else
   timed cabal new-build Cabal Cabal:package-tests Cabal:unit-tests
 fi
@@ -63,7 +63,11 @@ fi
 (cd Cabal && timed ${CABAL_BDIR}/build/unit-tests/unit-tests       $TEST_OPTIONS) || exit $?
 
 if [ "x$PARSEC" = "xYES" ]; then
-    (cd Cabal && timed ${CABAL_BDIR}/build/parser-tests/parser-tests $TEST_OPTIONS) | tail || exit $?
+    # Parser unit tests
+    (cd Cabal && timed ${CABAL_BDIR}/build/parser-tests/parser-tests $TEST_OPTIONS) || exit $?
+
+    # Test we can parse Hackage
+    (cd Cabal && timed ${CABAL_BDIR}/build/parser-tests/parser-hackage-tests $TEST_OPTIONS) | tail || exit $?
 fi
 
 # Run haddock (hack: use the Setup script from package-tests!)

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -48,7 +48,11 @@ export CABAL_BUILDDIR="${CABAL_BDIR}"
 # NB: Best to do everything for a single package together as it's
 # more efficient (since new-build will uselessly try to rebuild
 # Cabal otherwise).
-timed cabal new-build Cabal Cabal:package-tests Cabal:unit-tests
+if [ "x$PARSEC" = "xYES" ]; then
+  timed cabal new-build -fparsec Cabal Cabal:package-tests Cabal:unit-tests Cabal:parser-tests
+else
+  timed cabal new-build Cabal Cabal:package-tests Cabal:unit-tests
+fi
 
 # NB: the '|| exit $?' workaround is required on old broken versions of bash
 # that ship with OS X. See https://github.com/haskell/cabal/pull/3624 and
@@ -57,6 +61,10 @@ timed cabal new-build Cabal Cabal:package-tests Cabal:unit-tests
 # Run tests
 (export CABAL_PACKAGETESTS_DB_STACK="clear:global:${CABAL_STORE_DB}:${CABAL_LOCAL_DB}"; cd Cabal && timed ${CABAL_BDIR}/build/package-tests/package-tests $TEST_OPTIONS) || exit $?
 (cd Cabal && timed ${CABAL_BDIR}/build/unit-tests/unit-tests       $TEST_OPTIONS) || exit $?
+
+if [ "x$PARSEC" = "xYES" ]; then
+    (cd Cabal && timed ${CABAL_BDIR}/build/parser-tests/parser-tests $TEST_OPTIONS) || exit $?
+fi
 
 # Run haddock (hack: use the Setup script from package-tests!)
 (cd Cabal && timed cabal act-as-setup --build-type=Simple -- haddock --builddir=${CABAL_BDIR}) || exit $?


### PR DESCRIPTION
types are in places, values are `undefined`.

TODO (not exhaustive):
- [x] test for tab warning (wont do in this PR)
- [x] test for bom warning
- [x] parse but warn about nbsp (`\194`)
- [x] test about nbsp
- [x] lots of tests for invalid fields, we want this parser to be as strict as it could be. Relaxing it is easier.
- [x] warn if flag declration doesn't specify `default` and `manual` fields (wont do in this PR)
- [x] add classier to `PWarning`
- [x] equip `PWarning` / `ParseResult` with severity, some warnings are recoverable (e.g. tags in versions), but we don't want them into Hackage. Do we?
- [x] amend `parser-test` to count warnings for both `readp` and `parsec`