### PR TITLE
WIP: --index-snapshot <posix-time>

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -249,6 +249,7 @@ instance Semigroup SavedConfig where
         installUpgradeDeps           = combine installUpgradeDeps,
         installOnly                  = combine installOnly,
         installOnlyDeps              = combine installOnlyDeps,
+        installIndexSnapshot         = combine installIndexSnapshot,
         installRootCmd               = combine installRootCmd,
         installSummaryFile           = lastNonEmptyNL installSummaryFile,
         installLogFile               = combine installLogFile,

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -115,7 +115,7 @@ configure verbosity packageDBs repoCtxt comp platform conf
   configFlags configExFlags extraArgs = do
 
   installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-  sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
+  sourcePkgDb       <- getSourcePackages    verbosity repoCtxt Nothing
   pkgConfigDb       <- readPkgConfigDb      verbosity conf
 
   checkConfigExFlags verbosity installedPkgIndex

--- a/cabal-install/Distribution/Client/Fetch.hs
+++ b/cabal-install/Distribution/Client/Fetch.hs
@@ -85,7 +85,7 @@ fetch verbosity packageDBs repoCtxt comp platform conf
     mapM_ checkTarget userTargets
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
+    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt Nothing
     pkgConfigDb       <- readPkgConfigDb      verbosity conf
 
     pkgSpecifiers <- resolveUserTargets verbosity repoCtxt

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -123,7 +123,7 @@ getFreezePkgs verbosity packageDBs repoCtxt comp platform conf mSandboxPkgInfo
       globalFlags freezeFlags = do
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
+    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt Nothing -- FIXME
     pkgConfigDb       <- readPkgConfigDb      verbosity conf
 
     pkgSpecifiers <- resolveUserTargets verbosity repoCtxt

--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -90,7 +90,7 @@ get verbosity repoCtxt globalFlags getFlags userTargets = do
   unless useFork $
     mapM_ checkTarget userTargets
 
-  sourcePkgDb <- getSourcePackages verbosity repoCtxt
+  sourcePkgDb <- getSourcePackages verbosity repoCtxt Nothing
 
   pkgSpecifiers <- resolveUserTargets verbosity repoCtxt
                    (fromFlag $ globalWorldFile globalFlags)

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -115,7 +115,7 @@ initCabal :: Verbosity
 initCabal verbosity packageDBs repoCtxt comp conf initFlags = do
 
   installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-  sourcePkgDb <- getSourcePackages verbosity repoCtxt
+  sourcePkgDb <- getSourcePackages verbosity repoCtxt Nothing
 
   hSetBuffering stdout NoBuffering
 

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -278,10 +278,12 @@ makeInstallContext :: Verbosity -> InstallArgs -> Maybe [UserTarget]
                       -> IO InstallContext
 makeInstallContext verbosity
   (packageDBs, repoCtxt, comp, _, conf,_,_,
-   globalFlags, _, configExFlags, _, _) mUserTargets = do
+   globalFlags, _, configExFlags, installFlags, _) mUserTargets = do
+
+    let indexSnapSpec = fmap fromIntegral $ flagToMaybe $ installIndexSnapshot installFlags
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
+    sourcePkgDb       <- getSourcePackages    verbosity repoCtxt indexSnapSpec
     pkgConfigDb       <- readPkgConfigDb      verbosity conf
 
     checkConfigExFlags verbosity installedPkgIndex

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -86,7 +86,7 @@ getPkgList :: Verbosity
            -> IO [PackageDisplayInfo]
 getPkgList verbosity packageDBs repoCtxt comp conf listFlags pats = do
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages verbosity repoCtxt
+    sourcePkgDb       <- getSourcePackages verbosity repoCtxt Nothing
     let sourcePkgIndex = packageIndex sourcePkgDb
         prefs name = fromMaybe anyVersion
                        (Map.lookup name (packagePreferences sourcePkgDb))
@@ -178,7 +178,7 @@ info verbosity packageDBs repoCtxt comp conf
      globalFlags _listFlags userTargets = do
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs conf
-    sourcePkgDb       <- getSourcePackages verbosity repoCtxt
+    sourcePkgDb       <- getSourcePackages verbosity repoCtxt Nothing -- FIXME?
     let sourcePkgIndex = packageIndex sourcePkgDb
         prefs name = fromMaybe anyVersion
                        (Map.lookup name (packagePreferences sourcePkgDb))

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -199,6 +199,8 @@ resolveSolverSettings ProjectConfig{
     solverSettingReorderGoals      = fromFlag projectConfigReorderGoals
     solverSettingCountConflicts    = fromFlag projectConfigCountConflicts
     solverSettingStrongFlags       = fromFlag projectConfigStrongFlags
+    solverSettingIndexSnapshot     = fmap fromIntegral
+                                          (flagToMaybe projectConfigIndexSnapshot)
   --solverSettingIndependentGoals  = fromFlag projectConfigIndependentGoals
   --solverSettingShadowPkgs        = fromFlag projectConfigShadowPkgs
   --solverSettingReinstall         = fromFlag projectConfigReinstall

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -301,6 +301,7 @@ convertLegacyAllPackageFlags globalFlags configFlags
     --installReinstall          = projectConfigReinstall,
     --installAvoidReinstalls    = projectConfigAvoidReinstalls,
     --installOverrideReinstall  = projectConfigOverrideReinstall,
+      installIndexSnapshot        = projectConfigIndexSnapshot,
       installMaxBackjumps       = projectConfigMaxBackjumps,
     --installUpgradeDeps        = projectConfigUpgradeDeps,
       installReorderGoals       = projectConfigReorderGoals,
@@ -504,6 +505,7 @@ convertToLegacySharedConfig
       installStrongFlags       = projectConfigStrongFlags,
       installOnly              = mempty,
       installOnlyDeps          = projectConfigOnlyDeps,
+      installIndexSnapshot       = projectConfigIndexSnapshot,
       installRootCmd           = mempty, --no longer supported
       installSummaryFile       = projectConfigSummaryFile,
       installLogFile           = projectConfigLogFile,
@@ -841,6 +843,7 @@ legacySharedConfigFieldDescrs =
       , "one-shot", "jobs", "keep-going", "offline"
         -- solver flags:
       , "max-backjumps", "reorder-goals", "count-conflicts", "strong-flags"
+      , "index-snapshot"
       ]
   . commandOptionsToFields
   ) (installOptions ParseArgs)

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -51,6 +51,7 @@ import Distribution.Utils.NubList
 import Distribution.Verbosity
          ( Verbosity )
 
+import Data.Int (Int64)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Distribution.Compat.Binary (Binary)
@@ -156,6 +157,9 @@ data ProjectConfigShared
        -- configuration used both by the solver and other phases
        projectConfigRemoteRepos       :: NubList RemoteRepo,     -- ^ Available Hackage servers.
        projectConfigLocalRepos        :: NubList FilePath,
+
+       -- TODO/FIXME
+       projectConfigIndexSnapshot     :: Flag Int,
 
        -- solver configuration
        projectConfigConstraints       :: [(UserConstraint, ConstraintSource)],
@@ -323,7 +327,8 @@ data SolverSettings
        solverSettingMaxBackjumps      :: Maybe Int,
        solverSettingReorderGoals      :: ReorderGoals,
        solverSettingCountConflicts    :: CountConflicts,
-       solverSettingStrongFlags       :: StrongFlags
+       solverSettingStrongFlags       :: StrongFlags,
+       solverSettingIndexSnapshot     :: Maybe Int64
        -- Things that only make sense for manual mode, not --local mode
        -- too much control!
      --solverSettingIndependentGoals  :: Bool,

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -457,6 +457,10 @@ rebuildInstallPlan verbosity
                                                     compiler progdb platform
                                                     corePackageDbs
           sourcePkgDb       <- getSourcePackages    verbosity withRepoCtx
+                                                    (fmap fromIntegral
+                                                     . flagToMaybe
+                                                     . projectConfigIndexSnapshot
+                                                     $ projectConfigShared)
           pkgConfigDB       <- getPkgConfigDb      verbosity progdb
 
           --TODO: [code cleanup] it'd be better if the Compiler contained the
@@ -646,12 +650,13 @@ getPackageDBContents verbosity compiler progdb platform packagedb = do
                                  packagedb progdb
 
 getSourcePackages :: Verbosity -> (forall a. (RepoContext -> IO a) -> IO a)
+                  -> IndexUtils.IndexSnapshotSpec
                   -> Rebuild SourcePackageDb
-getSourcePackages verbosity withRepoCtx = do
+getSourcePackages verbosity withRepoCtx idxSnapSpec = do
     (sourcePkgDb, repos) <-
       liftIO $
         withRepoCtx $ \repoctx -> do
-          sourcePkgDb <- IndexUtils.getSourcePackages verbosity repoctx
+          sourcePkgDb <- IndexUtils.getSourcePackages verbosity repoctx idxSnapSpec
           return (sourcePkgDb, repoContextRepos repoctx)
 
     monitorFiles . map monitorFile

--- a/cabal-install/Distribution/Client/Sandbox/Index.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Index.hs
@@ -95,7 +95,7 @@ readBuildTreeRefsFromFile = liftM (readBuildTreeRefs . Tar.read) . BS.readFile
 -- | Read build tree references from an index cache
 readBuildTreeRefsFromCache :: Verbosity -> FilePath -> IO [BuildTreeRef]
 readBuildTreeRefsFromCache verbosity indexPath = do
-    (mRefs, _prefs) <- readCacheStrict verbosity (SandboxIndex indexPath) buildTreeRef
+    (mRefs, _prefs) <- readCacheStrict verbosity (SandboxIndex indexPath) buildTreeRef Nothing
     return (catMaybes mRefs)
   where
     buildTreeRef pkgEntry =

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1161,6 +1161,7 @@ data InstallFlags = InstallFlags {
     installUpgradeDeps      :: Flag Bool,
     installOnly             :: Flag Bool,
     installOnlyDeps         :: Flag Bool,
+    installIndexSnapshot    :: Flag Int,
     installRootCmd          :: Flag String,
     installSummaryFile      :: NubList PathTemplate,
     installLogFile          :: Flag PathTemplate,
@@ -1194,6 +1195,7 @@ defaultInstallFlags = InstallFlags {
     installUpgradeDeps     = Flag False,
     installOnly            = Flag False,
     installOnlyDeps        = Flag False,
+    installIndexSnapshot   = mempty,
     installRootCmd         = mempty,
     installSummaryFile     = mempty,
     installLogFile         = mempty,
@@ -1365,6 +1367,13 @@ installOptions showOrParseArgs =
           "A synonym for --only-dependencies"
           installOnlyDeps (\v flags -> flags { installOnlyDeps = v })
           (yesNoOpt showOrParseArgs)
+
+      , option [] ["index-snapshot"]
+          "Operate on package index state rolled back to given unix-timestamp"
+          installIndexSnapshot (\v flags -> flags { installIndexSnapshot = v })
+          (reqArg "NUM" (readP_to_E ("Cannot parse number: "++)
+                         (fmap toFlag parse))
+           (map show . flagToList))
 
       , option [] ["root-cmd"]
           "(No longer supported, do not use.)"


### PR DESCRIPTION
This is an early *working* proof-of-concept

This is a continuation of #3378, since GitHub doesn't support retargetting the branch for a PR

----

I'm coming more and more to the conclusion that this feature is more accurately described as a "Package Index Filter" facility.

I'm currently refactoring the `IndexSnapshotSpec` type into a `IndexFilterSpec` data-type.

I want it to be able to represent the following basic filtering/addressing modes:

 - absolute index number: include all event-entries up to given entry number (this counts .cabal & preferred-version entries as index "events")
 - timestamp: include all event-entries up to a given timestamp (with seconds granularity)
 - entry-relative: include all events up to (including) the specified package version release

One possible syntax would be


```
<index-filter> ::= <base-filter> [ <filter-offset> ] [ <filter-revision-modifier> ] [ <filter-pref-modifier> ]
```

```
<base-filter> ::= "<=" <timestamp>
                     | "HEAD"    (* denotes last recorded event in 01-index.tar.gz *)
                     | <pkg-version>
                     | "@" <event-number>
```

```
<timestamp> ::= <iso-8601-ish-format>
                        | <unix-timestamps>   (* i.e. integral seconds since 1970 epoch *)
```

In addition to that, I want to allow for offsets:

```
<filter-offset> ::= ("+"|"-") (<time-delta> | <event-delta>)

<time-delta> ::= [ [<nat> "d"]  <nat> "h" ] <nat> "m" [ <nat> "s" ]
                        | <nat> ":" <nat> ":" <nat>     (* HH:MM:SS *)

<event-delta> ::= <nat>
```

and finally I'd like to allow at least 3 modes of filtering `.cabal`-revisions:

 - drop *all* `.cabal` revisions
 - include `.cabal` revisions subject to the base-filter
 - include *all* `.cabal` revisions for packages which were selected by the base-filter

These 3 modes would be representable by simply having a 2nd filter specification for revisions. However, there's a more complex filter mode which one couldn't represent that way:

 - "round up" to patch-level or minor releases. I.e. the filter-cutoff would result in a virtual upper version bound. E.g. if version 2.1.1.2 was within the filter-cutoff range, then, all  versions < 2.2 would be be included as well into the snapshot

So I guess the revision mode is more like an enumerated list of modes. Hence, e.g.

```
<filter-revision-modifier> ::= "rev:none" | "rev:normal" | "rev:all" | "rev:minor" | "rev:major"
```

A similiar modifier would make sense for `preferred-version` events:

```
<filter-pref-modifier> ::= "pref:none" | "pref:normal" | "pref:all"
```

I'm not planning to implement all that at once, but I want to get specify the syntax roadmap