### PR TITLE
Refactor InstallPlan

### DIFF
--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -136,7 +136,7 @@ configure verbosity packageDBs repoCtxt comp platform conf
 
     Right installPlan0 ->
      let installPlan = InstallPlan.configureInstallPlan installPlan0
-     in case InstallPlan.ready installPlan of
+     in case fst (InstallPlan.ready' installPlan) of
       [pkg@(ReadyPackage
               (ConfiguredPackage _ (SourcePackage _ _ (LocalUnpackedPackage _) _)
                                  _ _ _))] -> do

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -136,7 +136,7 @@ configure verbosity packageDBs repoCtxt comp platform conf
 
     Right installPlan0 ->
      let installPlan = InstallPlan.configureInstallPlan installPlan0
-     in case fst (InstallPlan.ready' installPlan) of
+     in case fst (InstallPlan.ready installPlan) of
       [pkg@(ReadyPackage
               (ConfiguredPackage _ (SourcePackage _ _ (LocalUnpackedPackage _) _)
                                  _ _ _))] -> do

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -32,7 +32,7 @@ module Distribution.Client.Install (
 import Data.Foldable
          ( traverse_ )
 import Data.List
-         ( isPrefixOf, nub, sort, (\\), find )
+         ( isPrefixOf, nub, sort, (\\) )
 import qualified Data.Map as Map
 import qualified Data.Set as S
 import Data.Maybe
@@ -334,9 +334,9 @@ processInstallPlan verbosity
       installFlags pkgSpecifiers
 
     unless (dryRun || nothingToInstall) $ do
-      installPlan' <- performInstallations verbosity
-                      args installedPkgIndex installPlan
-      postInstallActions verbosity args userTargets installPlan'
+      buildResults <- performInstallations verbosity
+                        args installedPkgIndex installPlan
+      postInstallActions verbosity args userTargets installPlan buildResults
   where
     installPlan = InstallPlan.configureInstallPlan installPlan0
     dryRun = fromFlag (installDryRun installFlags)
@@ -798,11 +798,12 @@ postInstallActions :: Verbosity
                    -> InstallArgs
                    -> [UserTarget]
                    -> InstallPlan
+                   -> BuildResults
                    -> IO ()
 postInstallActions verbosity
   (packageDBs, _, comp, platform, conf, useSandbox, mSandboxPkgInfo
   ,globalFlags, configFlags, _, installFlags, _)
-  targets installPlan = do
+  targets installPlan buildResults = do
 
   unless oneShot $
     World.insert verbosity worldFile
@@ -811,7 +812,7 @@ postInstallActions verbosity
       | UserTargetNamed dep <- targets ]
 
   let buildReports = BuildReports.fromInstallPlan platform (compilerId comp)
-                                                  installPlan
+                                                  installPlan buildResults
   BuildReports.storeLocal (compilerInfo comp)
                           (fromNubList $ installSummaryFile installFlags)
                           buildReports
@@ -822,14 +823,15 @@ postInstallActions verbosity
     storeDetailedBuildReports verbosity logsDir buildReports
 
   regenerateHaddockIndex verbosity packageDBs comp platform conf useSandbox
-                         configFlags installFlags installPlan
+                         configFlags installFlags buildResults
 
-  symlinkBinaries verbosity platform comp configFlags installFlags installPlan
+  symlinkBinaries verbosity platform comp configFlags installFlags
+                  installPlan buildResults
 
-  printBuildFailures installPlan
+  printBuildFailures buildResults
 
   updateSandboxTimestampsFile useSandbox mSandboxPkgInfo
-                              comp platform installPlan
+                              comp platform installPlan buildResults
 
   where
     reportingLevel = fromFlag (installBuildReports installFlags)
@@ -879,10 +881,10 @@ regenerateHaddockIndex :: Verbosity
                        -> UseSandbox
                        -> ConfigFlags
                        -> InstallFlags
-                       -> InstallPlan
+                       -> BuildResults
                        -> IO ()
 regenerateHaddockIndex verbosity packageDBs comp platform conf useSandbox
-                       configFlags installFlags installPlan
+                       configFlags installFlags buildResults
   | haddockIndexFileIsRequested && shouldRegenerateHaddockIndex = do
 
   defaultDirs <- InstallDirs.defaultInstallDirs
@@ -910,14 +912,14 @@ regenerateHaddockIndex verbosity packageDBs comp platform conf useSandbox
     -- #1337), we don't do it for global installs or special cases where we're
     -- installing into a specific db.
     shouldRegenerateHaddockIndex = (isUseSandbox useSandbox || normalUserInstall)
-                                && someDocsWereInstalled installPlan
+                                && someDocsWereInstalled buildResults
       where
-        someDocsWereInstalled = any installedDocs . InstallPlan.toList
+        someDocsWereInstalled = any installedDocs . Map.elems
+        installedDocs (Right (BuildOk DocsOk _ _)) = True
+        installedDocs _                            = False
+
         normalUserInstall     = (UserPackageDB `elem` packageDBs)
                              && all (not . isSpecificPackageDB) packageDBs
-
-        installedDocs (InstallPlan.Installed _ _ (BuildOk DocsOk _ _)) = True
-        installedDocs _                                                = False
         isSpecificPackageDB (SpecificPackageDB _) = True
         isSpecificPackageDB _                     = False
 
@@ -939,11 +941,13 @@ symlinkBinaries :: Verbosity
                 -> ConfigFlags
                 -> InstallFlags
                 -> InstallPlan
+                -> BuildResults
                 -> IO ()
-symlinkBinaries verbosity platform comp configFlags installFlags plan = do
+symlinkBinaries verbosity platform comp configFlags installFlags
+                plan buildResults = do
   failed <- InstallSymlink.symlinkBinaries platform comp
                                            configFlags installFlags
-                                           plan
+                                           plan buildResults
   case failed of
     [] -> return ()
     [(_, exe, path)] ->
@@ -965,16 +969,15 @@ symlinkBinaries verbosity platform comp configFlags installFlags plan = do
     bindir = fromFlag (installSymlinkBinDir installFlags)
 
 
-printBuildFailures :: InstallPlan
-                   -> IO ()
-printBuildFailures plan =
-  case [ (pkg, reason)
-       | InstallPlan.Failed pkg reason <- InstallPlan.toList plan ] of
+printBuildFailures :: BuildResults -> IO ()
+printBuildFailures buildResults =
+  case [ (pkgid, failure)
+       | (pkgid, Left failure) <- Map.toList buildResults ] of
     []     -> return ()
     failed -> die . unlines
             $ "Error: some packages failed to install:"
-            : [ display (packageId pkg) ++ printFailureReason reason
-              | (pkg, reason) <- failed ]
+            : [ display pkgid ++ printFailureReason reason
+              | (pkgid, reason) <- failed ]
   where
     printFailureReason reason = case reason of
       DependentFailed pkgid -> " depends on " ++ display pkgid
@@ -1012,21 +1015,26 @@ printBuildFailures plan =
 updateSandboxTimestampsFile :: UseSandbox -> Maybe SandboxPackageInfo
                             -> Compiler -> Platform
                             -> InstallPlan
+                            -> BuildResults
                             -> IO ()
 updateSandboxTimestampsFile (UseSandbox sandboxDir)
                             (Just (SandboxPackageInfo _ _ _ allAddSourceDeps))
-                            comp platform installPlan =
+                            comp platform installPlan buildResults =
   withUpdateTimestamps sandboxDir (compilerId comp) platform $ \_ -> do
-    let allInstalled = [ pkg | InstallPlan.Installed pkg _ _
-                            <- InstallPlan.toList installPlan ]
-        allSrcPkgs   = [ confPkgSource cpkg | ReadyPackage cpkg
-                            <- allInstalled ]
+    let allInstalled = [ pkg
+                       | InstallPlan.Configured pkg
+                            <- InstallPlan.toList installPlan
+                       , case InstallPlan.lookupBuildResult pkg buildResults of
+                           Just (Right _success) -> True
+                           _                     -> False
+                       ]
+        allSrcPkgs   = [ confPkgSource cpkg | cpkg <- allInstalled ]
         allPaths     = [ pth | LocalUnpackedPackage pth
                             <- map packageSource allSrcPkgs]
     allPathsCanonical <- mapM tryCanonicalizePath allPaths
     return $! filter (`S.member` allAddSourceDeps) allPathsCanonical
 
-updateSandboxTimestampsFile _ _ _ _ _ = return ()
+updateSandboxTimestampsFile _ _ _ _ _ _ = return ()
 
 -- ------------------------------------------------------------
 -- * Actually do the installations
@@ -1044,7 +1052,7 @@ performInstallations :: Verbosity
                      -> InstallArgs
                      -> InstalledPackageIndex
                      -> InstallPlan
-                     -> IO InstallPlan
+                     -> IO BuildResults
 performInstallations verbosity
   (packageDBs, repoCtxt, comp, platform, conf, useSandbox, _,
    globalFlags, configFlags, configExFlags, installFlags, haddockFlags)
@@ -1152,71 +1160,21 @@ performInstallations verbosity
 
 
 executeInstallPlan :: Verbosity
-                   -> JobControl IO (PackageId, UnitId, BuildResult)
+                   -> JobControl IO (UnitId, BuildResult)
                    -> Bool
                    -> UseLogFile
                    -> InstallPlan
                    -> (ReadyPackage -> IO BuildResult)
-                   -> IO InstallPlan
+                   -> IO BuildResults
 executeInstallPlan verbosity jobCtl keepGoing useLogFile plan0 installPkg =
-    tryNewTasks False False plan0
+    InstallPlan.execute
+      jobCtl keepGoing depsFailure plan0 $ \pkg -> do
+        buildResult <- installPkg pkg
+        printBuildResult (packageId pkg) (installedPackageId pkg) buildResult
+        return buildResult
+
   where
-    tryNewTasks :: Bool -> Bool -> InstallPlan -> IO InstallPlan
-    tryNewTasks tasksFailed tasksRemaining plan
-      | tasksFailed && not keepGoing && not tasksRemaining
-      = return plan
-
-      | tasksFailed && not keepGoing && tasksRemaining
-      = waitForTasks tasksFailed plan
-
-    tryNewTasks tasksFailed tasksRemaining plan = do
-      case InstallPlan.ready plan of
-        [] | not tasksRemaining -> return plan
-           | otherwise          -> waitForTasks tasksFailed plan
-        pkgs                    -> do
-          sequence_
-            [ do info verbosity $ "Ready to install " ++ display pkgid
-                 spawnJob jobCtl $ do
-                   buildResult <- installPkg pkg
-                   return (packageId pkg, installedPackageId pkg, buildResult)
-            | pkg <- pkgs
-            , let pkgid = packageId pkg ]
-
-          let plan' = InstallPlan.processing pkgs plan
-          waitForTasks tasksFailed plan'
-
-    waitForTasks :: Bool -> InstallPlan -> IO InstallPlan
-    waitForTasks tasksFailed plan = do
-      info verbosity $ "Waiting for install task to finish..."
-      (pkgid, ipid, buildResult) <- collectJob jobCtl
-      printBuildResult pkgid ipid buildResult
-      let plan'        = updatePlan pkgid ipid buildResult plan
-          tasksFailed' = tasksFailed || isBuildFailure buildResult
-      -- if this is the first failure and we're not trying to keep going
-      -- then try to cancel as many of the remaining jobs as possible
-      when (not tasksFailed && isBuildFailure buildResult && not keepGoing) $
-        cancelJobs jobCtl
-      tasksRemaining <- remainingJobs jobCtl
-      tryNewTasks tasksFailed' tasksRemaining plan'
-
-    isBuildFailure (Left  _buildFailure) = True
-    isBuildFailure (Right _buildSuccess) = False
-
-    updatePlan :: PackageIdentifier -> InstalledPackageId
-               -> BuildResult -> InstallPlan
-               -> InstallPlan
-    updatePlan _pkgid ipid (Right buildSuccess@(BuildOk _ _ ipkgs)) =
-        InstallPlan.completed ipid
-            (find (\ipkg -> installedPackageId ipkg == ipid) ipkgs) buildSuccess
-
-    updatePlan pkgid ipid (Left buildFailure) =
-        InstallPlan.failed ipid buildFailure depsFailure
-      where
-        depsFailure = DependentFailed pkgid
-        -- So this first pkgid failed for whatever reason (buildFailure).
-        -- All the other packages that depended on this pkgid, which we
-        -- now cannot build, we mark as failing due to 'DependentFailed'
-        -- which kind of means it was not their fault.
+    depsFailure = DependentFailed . packageId
 
     -- Print build log if something went wrong, and 'Installed $PKGID'
     -- otherwise.

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -340,7 +340,7 @@ processInstallPlan verbosity
   where
     installPlan = InstallPlan.configureInstallPlan installPlan0
     dryRun = fromFlag (installDryRun installFlags)
-    nothingToInstall = null (InstallPlan.ready installPlan)
+    nothingToInstall = null (fst (InstallPlan.ready' installPlan))
 
 -- ------------------------------------------------------------
 -- * Installation planning
@@ -572,7 +572,7 @@ checkPrintPlan verbosity installed installPlan sourcePkgDb
       ++ "\nTry using 'cabal fetch'."
 
   where
-    nothingToInstall = null (InstallPlan.ready installPlan)
+    nothingToInstall = null (fst (InstallPlan.ready' installPlan))
 
     dryRun            = fromFlag (installDryRun            installFlags)
     overrideReinstall = fromFlag (installOverrideReinstall installFlags)

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -340,7 +340,7 @@ processInstallPlan verbosity
   where
     installPlan = InstallPlan.configureInstallPlan installPlan0
     dryRun = fromFlag (installDryRun installFlags)
-    nothingToInstall = null (fst (InstallPlan.ready' installPlan))
+    nothingToInstall = null (fst (InstallPlan.ready installPlan))
 
 -- ------------------------------------------------------------
 -- * Installation planning
@@ -572,7 +572,7 @@ checkPrintPlan verbosity installed installPlan sourcePkgDb
       ++ "\nTry using 'cabal fetch'."
 
   where
-    nothingToInstall = null (fst (InstallPlan.ready' installPlan))
+    nothingToInstall = null (fst (InstallPlan.ready installPlan))
 
     dryRun            = fromFlag (installDryRun            installFlags)
     overrideReinstall = fromFlag (installOverrideReinstall installFlags)

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -455,7 +455,7 @@ pruneInstallPlan pkgSpecifiers =
   either (Fail . explain) Done
   . InstallPlan.remove (\pkg -> packageName pkg `elem` targetnames)
   where
-    explain :: [InstallPlan.PlanProblem ipkg srcpkg iresult ifailure] -> String
+    explain :: [InstallPlan.PlanProblem ipkg srcpkg] -> String
     explain problems =
       "Cannot select only the dependencies (as requested by the "
       ++ "'--only-dependencies' flag), "

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -32,7 +32,7 @@ module Distribution.Client.Install (
 import Data.Foldable
          ( traverse_ )
 import Data.List
-         ( isPrefixOf, unfoldr, nub, sort, (\\), find )
+         ( isPrefixOf, nub, sort, (\\), find )
 import qualified Data.Map as Map
 import qualified Data.Set as S
 import Data.Maybe
@@ -503,9 +503,15 @@ checkPrintPlan verbosity installed installPlan sourcePkgDb
        : map (display . packageId) preExistingTargets
       ++ ["Use --reinstall if you want to reinstall anyway."]
 
-  let lPlan = linearizeInstallPlan installed installPlan
+  let lPlan =
+        [ (pkg, status)
+        | pkg <- InstallPlan.executionOrder installPlan
+        , let status = packageStatus installed pkg ]
   -- Are any packages classified as reinstalls?
-  let reinstalledPkgs = concatMap (extractReinstalls . snd) lPlan
+  let reinstalledPkgs =
+        [ ipkg
+        | (_pkg, status) <- lPlan
+        , ipkg <- extractReinstalls status ]
   -- Packages that are already broken.
   let oldBrokenPkgs =
           map Installed.installedUnitId
@@ -570,39 +576,6 @@ checkPrintPlan verbosity installed installPlan sourcePkgDb
 
     dryRun            = fromFlag (installDryRun            installFlags)
     overrideReinstall = fromFlag (installOverrideReinstall installFlags)
-
--- | Given an 'InstallPlan', perform a dry run, producing the sequence
--- of 'ReadyPackage's which would be compiled in order to carry
--- out this plan.  This function is not actually used to execute a plan;
--- presently, it is used only to (1) determine if the installation
--- plan would cause reinstalls and (2) to print out what would be
--- installed.
---
--- TODO: this type is too specific
-linearizeInstallPlan :: InstalledPackageIndex
-                     -> InstallPlan
-                     -> [(ReadyPackage, PackageStatus)]
-linearizeInstallPlan installedPkgIndex plan =
-    unfoldr next plan
-  where
-    next plan' = case InstallPlan.ready plan' of
-      []      -> Nothing
-      (pkg:_) -> Just ((pkg, status), plan'')
-        where
-          pkgid  = installedUnitId pkg
-          status = packageStatus installedPkgIndex pkg
-          ipkg   = Installed.emptyInstalledPackageInfo {
-                     Installed.sourcePackageId = packageId pkg,
-                     Installed.installedUnitId = pkgid
-                   }
-          plan'' = InstallPlan.completed pkgid (Just ipkg)
-                     (BuildOk DocsNotTried TestsNotTried [ipkg])
-                     (InstallPlan.processing [pkg] plan')
-          --FIXME: This is a bit of a hack,
-          -- pretending that each package is installed
-          -- It's doubly a hack because the installed package ID
-          -- didn't get updated.  But it doesn't really matter
-          -- because we're not going to use this for anything real.
 
 data PackageStatus = NewPackage
                    | NewVersion [Version]

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -29,12 +29,8 @@ module Distribution.Client.InstallPlan (
   configureInstallPlan,
 
   ready,
-  processing,
-  completed,
-  failed,
   remove,
   preexisting,
-  preinstalled,
 
   -- * Traversal
   executionOrder,
@@ -457,100 +453,6 @@ lookupReadyPackage plan pkg = do
                    ++ " depends on a non-library package "
                    ++ display dep
 
--- | Marks packages in the graph as currently processing (e.g. building).
---
--- * The package must exist in the graph and be in the configured state.
---
-processing :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
-               HasUnitId srcpkg, PackageFixedDeps srcpkg)
-           => [GenericReadyPackage srcpkg]
-           -> GenericInstallPlan ipkg srcpkg iresult ifailure
-           -> GenericInstallPlan ipkg srcpkg iresult ifailure
-processing pkgs plan = assert (invariant plan') plan'
-  where
-    plan' = plan {
-              planIndex = PackageIndex.merge (planIndex plan) processingPkgs
-            }
-    processingPkgs = PackageIndex.fromList [Processing pkg | pkg <- pkgs]
-
--- | Marks a package in the graph as completed. Also saves the build result for
--- the completed package in the plan.
---
--- * The package must exist in the graph and be in the processing state.
--- * The package must have had no uninstalled dependent packages.
---
-completed :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
-              HasUnitId srcpkg, PackageFixedDeps srcpkg)
-          => UnitId
-          -> Maybe ipkg -> iresult
-          -> GenericInstallPlan ipkg srcpkg iresult ifailure
-          -> GenericInstallPlan ipkg srcpkg iresult ifailure
-completed pkgid mipkg buildResult plan = assert (invariant plan') plan'
-  where
-    plan'     = plan {
-                  planIndex = PackageIndex.insert installed
-                            . PackageIndex.deleteUnitId pkgid
-                            $ planIndex plan
-                }
-    installed = Installed (lookupProcessingPackage plan pkgid) mipkg buildResult
-
--- | Marks a package in the graph as having failed. It also marks all the
--- packages that depended on it as having failed.
---
--- * The package must exist in the graph and be in the processing
--- state.
---
-failed :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
-           HasUnitId srcpkg, PackageFixedDeps srcpkg)
-       => UnitId         -- ^ The id of the package that failed to install
-       -> ifailure           -- ^ The build result to use for the failed package
-       -> ifailure           -- ^ The build result to use for its dependencies
-       -> GenericInstallPlan ipkg srcpkg iresult ifailure
-       -> GenericInstallPlan ipkg srcpkg iresult ifailure
-failed pkgid buildResult buildResult' plan = assert (invariant plan') plan'
-  where
-    -- NB: failures don't update IPIDs
-    plan'    = plan {
-                 planIndex = PackageIndex.merge (planIndex plan) failures
-               }
-    ReadyPackage srcpkg = lookupProcessingPackage plan pkgid
-    failures = PackageIndex.fromList
-             $ Failed srcpkg buildResult
-             : [ Failed pkg' buildResult'
-               | Just pkg' <- map checkConfiguredPackage
-                            $ packagesThatDependOn plan pkgid ]
-
--- | Lookup the reachable packages in the reverse dependency graph.
---
-packagesThatDependOn :: GenericInstallPlan ipkg srcpkg iresult ifailure
-                     -> UnitId
-                     -> [GenericPlanPackage ipkg srcpkg iresult ifailure]
-packagesThatDependOn plan pkgid = map (planPkgOf plan)
-                          . tail
-                          . Graph.reachable (planGraphRev plan)
-                          . planVertexOf plan
-                          $ pkgid
-
--- | Lookup a package that we expect to be in the processing state.
---
-lookupProcessingPackage :: GenericInstallPlan ipkg srcpkg iresult ifailure
-                        -> UnitId
-                        -> GenericReadyPackage srcpkg
-lookupProcessingPackage plan pkgid =
-  case PackageIndex.lookupUnitId (planIndex plan) pkgid of
-    Just (Processing pkg) -> pkg
-    _  -> internalError $ "not in processing state or no such pkg " ++
-                          display pkgid
-
--- | Check a package that we expect to be in the configured or failed state.
---
-checkConfiguredPackage :: (Package srcpkg, Package ipkg)
-                       => GenericPlanPackage ipkg srcpkg iresult ifailure
-                       -> Maybe srcpkg
-checkConfiguredPackage (Configured pkg) = Just pkg
-checkConfiguredPackage (Failed     _ _) = Nothing
-checkConfiguredPackage pkg                =
-  internalError $ "not configured or no such pkg " ++ display (packageId pkg)
 
 -- | Replace a ready package with a pre-existing one. The pre-existing one
 -- must have exactly the same dependencies as the source one was configured
@@ -571,24 +473,6 @@ preexisting pkgid ipkg plan = assert (invariant plan') plan'
                   . PackageIndex.deleteUnitId pkgid
                   $ planIndex plan
     }
-
--- | Replace a ready package with an installed one. The installed one
--- must have exactly the same dependencies as the source one was configured
--- with.
---
-preinstalled :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
-                 HasUnitId srcpkg, PackageFixedDeps srcpkg)
-             => UnitId
-             -> Maybe ipkg -> iresult
-             -> GenericInstallPlan ipkg srcpkg iresult ifailure
-             -> GenericInstallPlan ipkg srcpkg iresult ifailure
-preinstalled pkgid mipkg buildResult plan = assert (invariant plan') plan'
-  where
-    plan' = plan { planIndex = PackageIndex.insert installed (planIndex plan) }
-    Just installed = do
-      Configured pkg <- PackageIndex.lookupUnitId (planIndex plan) pkgid
-      rpkg <- lookupReadyPackage plan pkg
-      return (Installed rpkg mipkg buildResult)
 
 -- | Transform an install plan by mapping a function over all the packages in
 -- the plan. It can consistently change the 'UnitId' of all the packages,

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -27,8 +27,6 @@ module Distribution.Client.InstallPlan (
   toList,
   mapPreservingGraph,
   configureInstallPlan,
-
-  ready,
   remove,
   preexisting,
 
@@ -89,7 +87,6 @@ import           Distribution.Client.JobControl
 import Distribution.Text
          ( display )
 
-import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.PackageFixedDeps
 import           Distribution.Solver.Types.Settings
@@ -115,7 +112,6 @@ import qualified Data.Map as Map
 import           Data.Map (Map)
 import qualified Data.IntSet as IntSet
 import           Data.IntSet (IntSet)
-import qualified Data.Traversable as T
 
 
 -- When cabal tries to install a number of packages, including all their
@@ -404,55 +400,6 @@ remove shouldRemove plan =
   where
     newIndex = PackageIndex.fromList $
                  filter (not . shouldRemove) (toList plan)
-
--- | The packages that are ready to be installed. That is they are in the
--- configured state and have all their dependencies installed already.
--- The plan is complete if the result is @[]@.
---
-ready :: forall ipkg srcpkg iresult ifailure. PackageFixedDeps srcpkg
-      => GenericInstallPlan ipkg srcpkg iresult ifailure
-      -> [GenericReadyPackage srcpkg]
-ready plan = assert check readyPackages
-  where
-    check = if null readyPackages && null processingPackages
-              then null configuredPackages
-              else True
-    configuredPackages = [ pkg | Configured pkg <- toList plan ]
-    processingPackages = [ pkg | Processing pkg <- toList plan]
-
-    readyPackages :: [GenericReadyPackage srcpkg]
-    readyPackages = catMaybes (map (lookupReadyPackage plan) configuredPackages)
-
-lookupReadyPackage :: forall ipkg srcpkg iresult ifailure.
-                      PackageFixedDeps srcpkg
-                   => GenericInstallPlan ipkg srcpkg iresult ifailure
-                   -> srcpkg
-                   -> Maybe (GenericReadyPackage srcpkg)
-lookupReadyPackage plan pkg = do
-    _ <- hasAllInstalledDeps pkg
-    return (ReadyPackage pkg)
-  where
-
-    hasAllInstalledDeps :: srcpkg -> Maybe (ComponentDeps [ipkg])
-    hasAllInstalledDeps = T.mapM (mapM isInstalledDep) . depends
-
-    isInstalledDep :: UnitId -> Maybe ipkg
-    isInstalledDep pkgid =
-      case PackageIndex.lookupUnitId (planIndex plan) pkgid of
-        Just (PreExisting ipkg)            -> Just ipkg
-        Just (Configured  _)               -> Nothing
-        Just (Processing  _)               -> Nothing
-        Just (Installed   _ (Just ipkg) _) -> Just ipkg
-        Just (Installed   _ Nothing     _) -> internalError (depOnNonLib pkgid)
-        Just (Failed      _             _) -> internalError depOnFailed
-        Nothing                            -> internalError incomplete
-    incomplete  = "install plan is not closed"
-    depOnFailed = "configured package depends on failed package"
-    depOnNonLib dep = "the configured package "
-                   ++ display (packageId pkg)
-                   ++ " depends on a non-library package "
-                   ++ display dep
-
 
 -- | Replace a ready package with a pre-existing one. The pre-existing one
 -- must have exactly the same dependencies as the source one was configured

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -38,6 +38,9 @@ module Distribution.Client.InstallPlan (
 
   -- * Traversal
   executionOrder,
+  execute,
+  BuildResults,
+  lookupBuildResult,
   -- ** Traversal helpers
   -- $traversal
   Processing,
@@ -86,6 +89,7 @@ import qualified Distribution.Simple.Setup as Cabal
 import qualified Distribution.PackageDescription as PD
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import qualified Distribution.Client.PlanIndex as PlanIndex
+import           Distribution.Client.JobControl
 import Distribution.Text
          ( display )
 
@@ -108,9 +112,11 @@ import Data.Array ((!), inRange, bounds)
 import qualified Data.Tree as Tree
 import Distribution.Compat.Binary (Binary(..))
 import GHC.Generics
+import Control.Monad
 import Control.Exception
          ( assert )
 import qualified Data.Map as Map
+import           Data.Map (Map)
 import qualified Data.IntSet as IntSet
 import           Data.IntSet (IntSet)
 import qualified Data.Traversable as T
@@ -1000,6 +1006,10 @@ processingInvariant plan (Processing' processingSet completedSet failedSet) =
     noIntersection a b = IntSet.null (IntSet.intersection a b)
 
 
+-- ------------------------------------------------------------
+-- * Traversing plans
+-- ------------------------------------------------------------
+
 -- | Flatten an 'InstallPlan', producing the sequence of source packages in
 -- the order in which they would be processed when the plan is executed. This
 -- can be used for simultations or presenting execution dry-runs.
@@ -1023,3 +1033,104 @@ executionOrder plan =
         p : tryNewTasks processing' (todo++nextpkgs)
       where
         (nextpkgs, processing') = completed' plan processing (installedUnitId p)
+
+
+-- ------------------------------------------------------------
+-- * Executing plans
+-- ------------------------------------------------------------
+
+-- | The set of results we get from executing an install plan.
+--
+type BuildResults failure result = Map UnitId (Either failure result)
+
+-- | Lookup the build result for a single package.
+--
+lookupBuildResult :: HasUnitId pkg
+                  => pkg -> BuildResults failure result
+                  -> Maybe (Either failure result)
+lookupBuildResult = Map.lookup . installedUnitId
+
+-- | Execute an install plan. This traverses the plan in dependency order.
+--
+-- Executing each individual package can fail and if so all dependents fail
+-- too. The result for each package is collected as a 'BuildResults' map.
+--
+-- Visiting each package happens with optional parallelism, as determined by
+-- the 'JobControl'. By default, after any failure we stop as soon as possible
+-- (using the 'JobControl' to try to cancel in-progress tasks). This behaviour
+-- can be reversed to keep going and build as many packages as possible.
+--
+execute :: forall m ipkg srcpkg result failure unused1 unused2.
+           (HasUnitId ipkg,   PackageFixedDeps ipkg,
+            HasUnitId srcpkg, PackageFixedDeps srcpkg,
+            Monad m)
+        => JobControl m (UnitId, Either failure result)
+        -> Bool                -- ^ Keep going after failure
+        -> (srcpkg -> failure) -- ^ Value for dependents of failed packages
+        -> GenericInstallPlan ipkg srcpkg unused1 unused2
+        -> (GenericReadyPackage srcpkg -> m (Either failure result))
+        -> m (BuildResults failure result)
+execute jobCtl keepGoing depFailure plan installPkg =
+    let (newpkgs, processing) = ready' plan
+     in tryNewTasks Map.empty False False processing newpkgs
+  where
+    tryNewTasks :: BuildResults failure result
+                -> Bool -> Bool -> Processing
+                -> [GenericReadyPackage srcpkg]
+                -> m (BuildResults failure result)
+
+    tryNewTasks !results tasksFailed tasksRemaining !processing newpkgs
+      -- we were in the process of cancelling and now we're finished
+      | tasksFailed && not keepGoing && not tasksRemaining
+      = return results
+
+      -- we are still in the process of cancelling, wait for remaining tasks
+      | tasksFailed && not keepGoing && tasksRemaining
+      = waitForTasks results tasksFailed processing
+
+      -- no new tasks to do and all tasks are done so we're finished
+      | null newpkgs && not tasksRemaining
+      = return results
+
+      -- no new tasks to do, remaining tasks to wait for
+      | null newpkgs
+      = waitForTasks results tasksFailed processing
+
+      -- new tasks to do, spawn them, then wait for tasks to complete
+      | otherwise
+      = do sequence_ [ spawnJob jobCtl $ do
+                         result <- installPkg pkg
+                         return (installedUnitId pkg, result)
+                     | pkg <- newpkgs ]
+           waitForTasks results tasksFailed processing
+
+    waitForTasks :: BuildResults failure result
+                 -> Bool -> Processing
+                 -> m (BuildResults failure result)
+    waitForTasks !results tasksFailed !processing = do
+      (pkgid, result) <- collectJob jobCtl
+
+      case result of
+
+        Right _success -> do
+            tasksRemaining <- remainingJobs jobCtl
+            tryNewTasks results' tasksFailed tasksRemaining
+                        processing' nextpkgs
+          where
+            results' = Map.insert pkgid result results
+            (nextpkgs, processing') = completed' plan processing pkgid
+
+        Left _failure -> do
+            -- if this is the first failure and we're not trying to keep going
+            -- then try to cancel as many of the remaining jobs as possible
+            when (not tasksFailed && not keepGoing) $
+              cancelJobs jobCtl
+
+            tasksRemaining <- remainingJobs jobCtl
+            tryNewTasks results' True tasksRemaining processing' []
+          where
+            (depsfailed, processing') = failed' plan processing pkgid
+            results'   = Map.insert pkgid result results `Map.union` depResults
+            depResults = Map.fromList
+                           [ (installedUnitId deppkg, Left (depFailure deppkg))
+                           | deppkg <- depsfailed ]

--- a/cabal-install/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/Distribution/Client/InstallSymlink.hs
@@ -38,8 +38,7 @@ symlinkBinary _ _ _ _ = fail "Symlinking feature not available on Windows"
 #else
 
 import Distribution.Client.Types
-         ( GenericReadyPackage(..), ReadyPackage, enableStanzas
-         , ConfiguredPackage(..))
+         ( ConfiguredPackage(..), BuildResults, enableStanzas )
 import Distribution.Client.Setup
          ( InstallFlags(installSymlinkBinDir) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
@@ -105,8 +104,9 @@ symlinkBinaries :: Platform -> Compiler
                 -> ConfigFlags
                 -> InstallFlags
                 -> InstallPlan
+                -> BuildResults
                 -> IO [(PackageIdentifier, String, FilePath)]
-symlinkBinaries platform comp configFlags installFlags plan =
+symlinkBinaries platform comp configFlags installFlags plan buildResults =
   case flagToMaybe (installSymlinkBinDir installFlags) of
     Nothing            -> return []
     Just symlinkBinDir
@@ -135,15 +135,17 @@ symlinkBinaries platform comp configFlags installFlags plan =
   where
     exes =
       [ (cpkg, pkg, exe)
-      | InstallPlan.Installed cpkg _ _ <- InstallPlan.toList plan
-      , let pkg   = pkgDescription cpkg
+      | InstallPlan.Configured cpkg <- InstallPlan.toList plan
+      , case InstallPlan.lookupBuildResult cpkg buildResults of
+          Just (Right _success) -> True
+          _                     -> False
+      , let pkg :: PackageDescription
+            pkg = pkgDescription cpkg
       , exe <- PackageDescription.executables pkg
       , PackageDescription.buildable (PackageDescription.buildInfo exe) ]
 
-    pkgDescription :: ReadyPackage -> PackageDescription
-    pkgDescription (ReadyPackage (ConfiguredPackage
-                                    _ (SourcePackage _ pkg _ _)
-                                    flags stanzas _)) =
+    pkgDescription (ConfiguredPackage _ (SourcePackage _ pkg _ _)
+                                      flags stanzas _) =
       case finalizePackageDescription flags
              (const True)
              platform cinfo [] (enableStanzas stanzas pkg) of

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -262,12 +262,6 @@ rebuildTargetsDryRun distDirLayout@DistDirLayout{..} = \installPlan -> do
         Just (RepoTarballPackage _ _ tarball) ->
           dryRunTarballPkg pkg depsBuildStatus tarball
 
-    dryRunPkg (InstallPlan.Processing {}) _ = unexpectedState
-    dryRunPkg (InstallPlan.Installed  {}) _ = unexpectedState
-    dryRunPkg (InstallPlan.Failed     {}) _ = unexpectedState
-
-    unexpectedState = error "rebuildTargetsDryRun: unexpected package state"
-
     dryRunTarballPkg :: ElaboratedConfiguredPackage
                      -> ComponentDeps [BuildStatus]
                      -> FilePath

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -309,19 +309,19 @@ rebuildTargetsDryRun distDirLayout@DistDirLayout{..} = \installPlan -> do
 -- depencencies. This can be used to propagate information from depencencies.
 --
 foldMInstallPlanDepOrder
-  :: forall m ipkg srcpkg iresult ifailure b.
+  :: forall m ipkg srcpkg b.
      (Monad m,
       HasUnitId ipkg,   PackageFixedDeps ipkg,
       HasUnitId srcpkg, PackageFixedDeps srcpkg)
-  => GenericInstallPlan ipkg srcpkg iresult ifailure
-  -> (GenericPlanPackage ipkg srcpkg iresult ifailure ->
+  => GenericInstallPlan ipkg srcpkg
+  -> (GenericPlanPackage ipkg srcpkg ->
       ComponentDeps [b] -> m b)
   -> m (Map InstalledPackageId b)
 foldMInstallPlanDepOrder plan0 visit =
     go Map.empty (InstallPlan.reverseTopologicalOrder plan0)
   where
     go :: Map InstalledPackageId b
-       -> [GenericPlanPackage ipkg srcpkg iresult ifailure]
+       -> [GenericPlanPackage ipkg srcpkg]
        -> m (Map InstalledPackageId b)
     go !results [] = return results
 

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -346,20 +346,22 @@ improveInstallPlanWithUpToDatePackages :: ElaboratedInstallPlan
                                        -> BuildStatusMap
                                        -> ElaboratedInstallPlan
 improveInstallPlanWithUpToDatePackages installPlan pkgsBuildStatus =
-    replaceWithPreInstalled installPlan
-      [ (installedPackageId pkg, ipkgs, buildSuccess)
+    replaceWithPrePreExisting installPlan
+      [ (installedPackageId pkg, ipkgs)
       | InstallPlan.Configured pkg
           <- InstallPlan.reverseTopologicalOrder installPlan
       , let ipkgid = installedPackageId pkg
             Just pkgBuildStatus = Map.lookup ipkgid pkgsBuildStatus
-      , BuildStatusUpToDate ipkgs buildSuccess <- [pkgBuildStatus]
+      , BuildStatusUpToDate ipkgs _buildSuccess <- [pkgBuildStatus]
       ]
   where
-    replaceWithPreInstalled =
-      foldl' (\plan (ipkgid, ipkgs, buildSuccess) ->
-                InstallPlan.preinstalled ipkgid
-                    (find (\ipkg -> installedPackageId ipkg == ipkgid) ipkgs)
-                    buildSuccess plan)
+    replaceWithPrePreExisting =
+      foldl' (\plan (ipkgid, ipkgs) ->
+                case find (\ipkg -> installedPackageId ipkg == ipkgid) ipkgs of
+                  Just ipkg -> InstallPlan.preexisting ipkgid ipkg plan
+                  Nothing   -> unexpected)
+    unexpected =
+      error "improveInstallPlanWithUpToDatePackages: dep on non lib package"
 
 
 -----------------------------
@@ -571,7 +573,7 @@ rebuildTargets :: Verbosity
                -> ElaboratedSharedConfig
                -> BuildStatusMap
                -> BuildTimeSettings
-               -> IO ElaboratedInstallPlan
+               -> IO BuildResults
 rebuildTargets verbosity
                distDirLayout@DistDirLayout{..}
                installPlan
@@ -604,7 +606,10 @@ rebuildTargets verbosity
                           installPlan pkgsBuildStatus $ \downloadMap ->
 
       -- For each package in the plan, in dependency order, but in parallel...
-      executeInstallPlan verbosity jobControl keepGoing installPlan $ \pkg ->
+      InstallPlan.execute jobControl keepGoing (DependentFailed . packageId)
+                          installPlan $ \pkg ->
+        fmap (\x -> case x of BuildFailure f   -> Left f
+                              BuildSuccess _ s -> Right s) $
         handle (return . BuildFailure) $ --TODO: review exception handling
 
         let ipkgid = installedPackageId pkg
@@ -792,94 +797,6 @@ waitAsyncPackageDownload verbosity downloadMap pkg =
         fail "waitAsyncPackageDownload: package not being download"
 
 
-executeInstallPlan
-  :: forall ipkg srcpkg iresult.
-     (HasUnitId ipkg,   PackageFixedDeps ipkg,
-      HasUnitId srcpkg, PackageFixedDeps srcpkg)
-  => Verbosity
-  -> JobControl IO ( GenericReadyPackage srcpkg
-                   , GenericBuildResult ipkg iresult BuildFailure )
-  -> Bool
-  -> GenericInstallPlan ipkg srcpkg iresult BuildFailure
-  -> (    GenericReadyPackage srcpkg
-       -> IO (GenericBuildResult ipkg iresult BuildFailure))
-  -> IO (GenericInstallPlan ipkg srcpkg iresult BuildFailure)
-executeInstallPlan verbosity jobCtl keepGoing plan0 installPkg =
-    tryNewTasks False False plan0
-  where
-    tryNewTasks :: Bool -> Bool
-                ->     GenericInstallPlan ipkg srcpkg iresult BuildFailure
-                -> IO (GenericInstallPlan ipkg srcpkg iresult BuildFailure)
-    tryNewTasks tasksFailed tasksRemaining plan
-      | tasksFailed && not keepGoing && not tasksRemaining
-      = return plan
-
-      | tasksFailed && not keepGoing && tasksRemaining
-      = waitForTasks tasksFailed plan
-
-    tryNewTasks tasksFailed tasksRemaining plan = do
-      case InstallPlan.ready plan of
-        [] | not tasksRemaining -> return plan
-           | otherwise          -> waitForTasks tasksFailed plan
-        pkgs                    -> do
-          sequence_
-            [ do debug verbosity $ "Ready to install " ++ display pkgid
-                 spawnJob jobCtl $ do
-                   buildResult <- installPkg pkg
-                   return (pkg, buildResult)
-            | pkg <- pkgs
-            , let pkgid = packageId pkg
-            ]
-
-          let plan' = InstallPlan.processing pkgs plan
-          waitForTasks tasksFailed plan'
-
-    waitForTasks :: Bool
-                ->     GenericInstallPlan ipkg srcpkg iresult BuildFailure
-                -> IO (GenericInstallPlan ipkg srcpkg iresult BuildFailure)
-    waitForTasks tasksFailed plan = do
-      debug verbosity $ "Waiting for install task to finish..."
-      (pkg, buildResult) <- collectJob jobCtl
-      let plan'         = updatePlan pkg buildResult plan
-          tasksFailed'  = tasksFailed || isBuildFailure buildResult
-      -- if this is the first failure and we're not trying to keep going
-      -- then try to cancel as many of the remaining jobs as possible
-      when (not tasksFailed && isBuildFailure buildResult && not keepGoing) $
-        cancelJobs jobCtl
-      tasksRemaining <- remainingJobs jobCtl
-      tryNewTasks tasksFailed' tasksRemaining plan'
-
-    isBuildFailure (BuildFailure _) = True
-    isBuildFailure _                = False
-
-    updatePlan :: GenericReadyPackage srcpkg
-               -> GenericBuildResult ipkg iresult BuildFailure
-               -> GenericInstallPlan ipkg srcpkg iresult BuildFailure
-               -> GenericInstallPlan ipkg srcpkg iresult BuildFailure
-    updatePlan pkg (BuildSuccess ipkgs buildSuccess) =
-        InstallPlan.completed (installedPackageId pkg)
-            mipkg
-            buildSuccess
-      where
-        mipkg = case (ipkgs, find (\ipkg -> installedPackageId ipkg
-                                         == installedPackageId pkg) ipkgs) of
-          ([],    _)         -> Nothing
-          ((_:_), Just ipkg) -> Just ipkg
-          ((_:_), Nothing)   ->
-            error $ "executeInstallPlan: package " ++ display (packageId pkg)
-                 ++ " was expected to register the unit "
-                 ++ display (installedPackageId pkg)
-                 ++ " but is actually registering the unit(s) "
-                 ++ intercalate ", " (map (display . installedPackageId) ipkgs)
-
-    updatePlan pkg (BuildFailure buildFailure) =
-        InstallPlan.failed (installedPackageId pkg) buildFailure depsFailure
-      where
-        depsFailure = DependentFailed (packageId pkg)
-        -- So this first pkgid failed for whatever reason (buildFailure).
-        -- All the other packages that depended on this pkgid, which we
-        -- now cannot build, we mark as failing due to 'DependentFailed'
-        -- which kind of means it was not their fault.
 
 
 -- | Ensure that the package is unpacked in an appropriate directory, either

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -85,8 +85,6 @@ encodePlanAsJson elaboratedInstallPlan _elaboratedSharedConfig =
             [ "depends" J..= map (jdisplay . installedUnitId) v ]
           | (c,v) <- ComponentDeps.toList (pkgDependencies ecp) ]
 
-    toJ _ = error "encodePlanToJson: only expecting PreExisting and Configured"
-
     -- TODO: maybe move this helper to "ComponentDeps" module?
     --       Or maybe define a 'Text' instance?
     comp2str c = case c of

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1025,8 +1025,6 @@ elaborateInstallPlan platform compiler compilerprogdb
             InstallPlan.Configured
               (elaborateSolverPackage mapDep pkg)
 
-          _ -> error "elaborateInstallPlan: unexpected package state"
-
     elaborateSolverPackage :: (UnitId -> UnitId)
                            -> SolverPackage UnresolvedPkgLoc
                            -> ElaboratedConfiguredPackage

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -16,6 +16,7 @@ module Distribution.Client.ProjectPlanning (
     --      plan definition. Need to better separate InstallPlan definition.
     GenericBuildResult(..),
     BuildResult,
+    BuildResults,
     BuildSuccess(..),
     BuildFailure(..),
     DocsResult(..),
@@ -61,8 +62,8 @@ import           Distribution.Client.ProjectConfig
 import           Distribution.Client.ProjectPlanOutput
 
 import           Distribution.Client.Types
-                   hiding ( BuildResult, BuildSuccess(..), BuildFailure(..)
-                          , DocsResult(..), TestsResult(..) )
+                   hiding ( BuildResult, BuildResults, BuildSuccess(..)
+                          , BuildFailure(..), DocsResult(..), TestsResult(..) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import           Distribution.Client.Dependency
 import           Distribution.Client.Dependency.Types

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -81,12 +81,10 @@ import           Control.Exception
 type ElaboratedInstallPlan
    = GenericInstallPlan InstalledPackageInfo
                         ElaboratedConfiguredPackage
-                        BuildSuccess BuildFailure
 
 type ElaboratedPlanPackage
    = GenericPlanPackage InstalledPackageInfo
                         ElaboratedConfiguredPackage
-                        BuildSuccess BuildFailure
 
 --TODO: [code cleanup] decide if we really need this, there's not much in it, and in principle
 --      even platform and compiler could be different if we're building things

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -21,6 +21,7 @@ module Distribution.Client.ProjectPlanning.Types (
     --      plan definition. Need to better separate InstallPlan definition.
     GenericBuildResult(..),
     BuildResult,
+    BuildResults,
     BuildSuccess(..),
     BuildFailure(..),
     DocsResult(..),
@@ -38,8 +39,8 @@ module Distribution.Client.ProjectPlanning.Types (
 import           Distribution.Client.PackageHash
 
 import           Distribution.Client.Types
-                   hiding ( BuildResult, BuildSuccess(..), BuildFailure(..)
-                          , DocsResult(..), TestsResult(..) )
+                   hiding ( BuildResult, BuildResults, BuildSuccess(..)
+                          , BuildFailure(..), DocsResult(..), TestsResult(..) )
 import           Distribution.Client.InstallPlan
                    ( GenericInstallPlan, SolverInstallPlan, GenericPlanPackage )
 
@@ -294,6 +295,7 @@ instance (Binary ipkg, Binary iresult, Binary ifailure) =>
 
 type BuildResult  = GenericBuildResult InstalledPackageInfo
                                        BuildSuccess BuildFailure
+type BuildResults = Map UnitId (Either BuildFailure BuildSuccess)
 
 data BuildSuccess = BuildOk DocsResult TestsResult
   deriving (Eq, Show, Generic)

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -283,6 +283,8 @@ maybeRepoRemote (RepoSecure r _localDir) = Just r
 -- ------------------------------------------------------------
 
 type BuildResult  = Either BuildFailure BuildSuccess
+type BuildResults = Map UnitId (Either BuildFailure BuildSuccess)
+
 data BuildFailure = PlanningFailed
                   | DependentFailed PackageId
                   | DownloadFailed  SomeException

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -392,6 +392,7 @@ Test-Suite unit-tests
     UnitTests.Distribution.Client.UserConfig
     UnitTests.Distribution.Client.ProjectConfig
     UnitTests.Distribution.Client.JobControl
+    UnitTests.Distribution.Client.InstallPlan
     UnitTests.Distribution.Solver.Modular.PSQ
     UnitTests.Distribution.Solver.Modular.Solver
     UnitTests.Distribution.Solver.Modular.DSL

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -22,6 +22,7 @@ import qualified UnitTests.Distribution.Client.Targets
 import qualified UnitTests.Distribution.Client.UserConfig
 import qualified UnitTests.Distribution.Client.ProjectConfig
 import qualified UnitTests.Distribution.Client.JobControl
+import qualified UnitTests.Distribution.Client.InstallPlan
 
 import UnitTests.Options
 
@@ -58,6 +59,8 @@ tests mtimeChangeCalibrated =
        UnitTests.Distribution.Client.ProjectConfig.tests
   , testGroup "UnitTests.Distribution.Client.JobControl"
        UnitTests.Distribution.Client.JobControl.tests
+  , testGroup "UnitTests.Distribution.Client.InstallPlan"
+       UnitTests.Distribution.Client.InstallPlan.tests
   ]
 
 main :: IO ()

--- a/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
@@ -1,0 +1,235 @@
+module UnitTests.Distribution.Client.InstallPlan (tests) where
+
+import           Distribution.Package
+import           Distribution.Version
+import qualified Distribution.Client.InstallPlan as InstallPlan
+import           Distribution.Client.InstallPlan (GenericInstallPlan)
+import qualified Distribution.Simple.PackageIndex as PackageIndex
+import           Distribution.Solver.Types.Settings
+import           Distribution.Solver.Types.PackageFixedDeps
+import           Distribution.Solver.Types.ComponentDeps as CD
+import           Distribution.Text
+
+import Data.Graph
+import Data.Array hiding (index)
+import Data.List
+import qualified Data.Map as Map
+import Control.Monad
+import Test.QuickCheck
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+
+tests :: [TestTree]
+tests =
+  [ testProperty "topologicalOrder"        prop_topologicalOrder
+  , testProperty "reverseTopologicalOrder" prop_reverseTopologicalOrder
+  ]
+
+prop_topologicalOrder :: TestInstallPlan -> Bool
+prop_topologicalOrder (TestInstallPlan plan graph toVertex _) =
+    isTopologicalOrder
+      graph
+      (map (toVertex . installedUnitId)
+           (InstallPlan.topologicalOrder plan))
+
+prop_reverseTopologicalOrder :: TestInstallPlan -> Bool
+prop_reverseTopologicalOrder (TestInstallPlan plan graph toVertex _) =
+    isReverseTopologicalOrder
+      graph
+      (map (toVertex . installedUnitId)
+           (InstallPlan.reverseTopologicalOrder plan))
+
+
+--------------------------
+-- Property helper utils
+--
+
+-- | A graph topological ordering is a linear ordering of its vertices such
+-- that for every directed edge uv from vertex u to vertex v, u comes before v
+-- in the ordering.
+--
+isTopologicalOrder :: Graph -> [Vertex] -> Bool
+isTopologicalOrder g vs =
+    and [ ixs ! u < ixs ! v
+        | let ixs = array (bounds g) (zip vs [0::Int ..])
+        , (u,v) <- edges g ]
+
+isReverseTopologicalOrder :: Graph -> [Vertex] -> Bool
+isReverseTopologicalOrder g vs =
+    and [ ixs ! u > ixs ! v
+        | let ixs = array (bounds g) (zip vs [0::Int ..])
+        , (u,v) <- edges g ]
+
+
+--------------------
+-- Test generators
+--
+
+data TestInstallPlan = TestInstallPlan
+                         (GenericInstallPlan TestPkg TestPkg () ())
+                         Graph
+                         (UnitId -> Vertex)
+                         (Vertex -> UnitId)
+
+instance Show TestInstallPlan where
+  show (TestInstallPlan plan _ _ _) = InstallPlan.showInstallPlan plan
+
+data TestPkg = TestPkg PackageId UnitId [UnitId]
+  deriving (Eq, Show)
+
+instance Package TestPkg where
+  packageId (TestPkg pkgid _ _) = pkgid
+
+instance HasUnitId TestPkg where
+  installedUnitId (TestPkg _ ipkgid _) = ipkgid
+
+instance PackageFixedDeps TestPkg where
+  depends (TestPkg pkgid _ deps) =
+    CD.singleton (CD.ComponentLib (display (packageName pkgid))) deps
+
+instance Arbitrary TestInstallPlan where
+  arbitrary = arbitraryTestInstallPlan
+
+arbitraryTestInstallPlan :: Gen TestInstallPlan
+arbitraryTestInstallPlan = do
+    graph <- arbitraryAcyclicGraph
+               (choose (2,5))
+               (choose (1,5))
+               0.3
+
+    plan  <- arbitraryInstallPlan mkTestPkg mkTestPkg 0.5 graph
+
+    let toVertexMap   = Map.fromList [ (mkUnitIdV v, v) | v <- vertices graph ]
+        fromVertexMap = Map.fromList [ (v, mkUnitIdV v) | v <- vertices graph ]
+        toVertex      = (toVertexMap   Map.!)
+        fromVertex    = (fromVertexMap Map.!)
+
+    return (TestInstallPlan plan graph toVertex fromVertex)
+  where
+    mkTestPkg pkgv depvs =
+        return (TestPkg pkgid ipkgid deps)
+      where
+        pkgid  = mkPkgId pkgv
+        ipkgid = mkUnitIdV pkgv
+        deps   = map mkUnitIdV depvs
+    mkUnitIdV = mkUnitId . show
+    mkPkgId v = PackageIdentifier (PackageName ("pkg" ++ show v))
+                                  (Version [1] [])
+
+
+-- | Generate a random 'InstallPlan' following the structure of an existing
+-- 'Graph'.
+--
+-- It takes generators for installed and source packages and the chance that
+-- each package is installed (for those packages with no prerequisites).
+--
+arbitraryInstallPlan :: (HasUnitId ipkg,   PackageFixedDeps ipkg,
+                         HasUnitId srcpkg, PackageFixedDeps srcpkg)
+                     => (Vertex -> [Vertex] -> Gen ipkg)
+                     -> (Vertex -> [Vertex] -> Gen srcpkg)
+                     -> Float
+                     -> Graph
+                     -> Gen (InstallPlan.GenericInstallPlan ipkg srcpkg () ())
+arbitraryInstallPlan mkIPkg mkSrcPkg ipkgProportion graph = do
+
+    (ipkgvs, srcpkgvs) <-
+      fmap ((\(ipkgs, srcpkgs) -> (map fst ipkgs, map fst srcpkgs))
+            . partition snd) $
+      sequence
+        [ do isipkg <- if isRoot then pick ipkgProportion
+                                 else return False
+             return (v, isipkg)
+        | (v,n) <- assocs (outdegree graph)
+        , let isRoot = n == 0 ]
+
+    ipkgs   <- sequence
+                 [ mkIPkg pkgv depvs
+                 | pkgv <- ipkgvs
+                 , let depvs  = graph ! pkgv
+                 ]
+    srcpkgs <- sequence
+                 [ mkSrcPkg pkgv depvs
+                 | pkgv <- srcpkgvs
+                 , let depvs  = graph ! pkgv
+                 ]
+    let index = PackageIndex.fromList (map InstallPlan.PreExisting ipkgs
+                                    ++ map InstallPlan.Configured  srcpkgs)
+    case InstallPlan.new (IndependentGoals False) index of
+      Right plan -> return plan
+      Left  problems -> fail $ unlines $
+                          map InstallPlan.showPlanProblem problems
+
+
+-- | Generate a random directed acyclic graph, based on the algorithm presented
+-- here <http://stackoverflow.com/questions/12790337/generating-a-random-dag>
+--
+-- It generates a DAG based on ranks of nodes. Nodes in each rank can only
+-- have edges to nodes in subsequent ranks.
+--
+-- The generator is paramterised by a generator for the number of ranks and
+-- the number of nodes within each rank. It is also paramterised by the
+-- chance that each node in each rank will have an edge from each node in
+-- each previous rank. Thus a higher chance will produce a more densely
+-- connected graph.
+--
+arbitraryAcyclicGraph :: Gen Int -> Gen Int -> Float -> Gen Graph
+arbitraryAcyclicGraph genNRanks genNPerRank edgeChance = do
+    nranks    <- genNRanks
+    rankSizes <- replicateM nranks genNPerRank
+    let rankStarts = scanl (+) 0 rankSizes
+        rankRanges = drop 1 (zip rankStarts (tail rankStarts))
+        totalRange = sum rankSizes
+    rankEdges <- mapM (uncurry genRank) rankRanges
+    return $ buildG (0, totalRange-1) (concat rankEdges)
+  where
+    genRank :: Vertex -> Vertex -> Gen [Edge]
+    genRank rankStart rankEnd =
+      filterM (const (pick edgeChance))
+        [ (i,j)
+        | i <- [0..rankStart-1]
+        , j <- [rankStart..rankEnd-1]
+        ]
+
+pick :: Float -> Gen Bool
+pick chance = do
+    p <- choose (0,1)
+    return (p < chance)
+
+
+--------------------------------
+-- Inspecting generated graphs
+--
+
+{-
+-- Handy util for checking the generated graphs look sensible
+writeDotFile :: FilePath -> Graph -> IO ()
+writeDotFile file = writeFile file . renderDotGraph
+
+renderDotGraph :: Graph -> String
+renderDotGraph graph =
+  unlines (
+      [header
+      ,graphDefaultAtribs
+      ,nodeDefaultAtribs
+      ,edgeDefaultAtribs]
+    ++ map renderNode (vertices graph)
+    ++ map renderEdge (edges graph)
+    ++ [footer]
+  )
+  where
+    renderNode n = "\t" ++ show n ++ " [label=\"" ++ show n ++  "\"];"
+
+    renderEdge (n, n') = "\t" ++ show n ++ " -> " ++ show n' ++ "[];"
+
+
+header, footer, graphDefaultAtribs, nodeDefaultAtribs, edgeDefaultAtribs :: String
+
+header = "digraph packages {"
+footer = "}"
+
+graphDefaultAtribs = "\tgraph [fontsize=14, fontcolor=black, color=black];"
+nodeDefaultAtribs  = "\tnode [label=\"\\N\", width=\"0.75\", shape=ellipse];"
+edgeDefaultAtribs  = "\tedge [fontsize=10];"
+-}


### PR DESCRIPTION
Currently the `InstallPlan` structure keeps track of the state of execution of the plan. It does this by tracking the state of each package: Processing, Installed, Failed. So one way of looking at it is that the `InstallPlan` type itself is used as the state of a traversal over an `InstallPlan`.

It would be nicer to be able to traverse/execute an `InstallPlan` independently from modifying the `InstallPlan` itself, or equivalently to keep the state of the traversal of a plan separate from the plan. So that's what this patch set does.

The motivation is twofold:

 1. It is conceptually clearer to have the `InstallPlan` just be immutable, and have separate execute/traversals. It also reduces coupling, e.g. things that construct an `InstallPlan` no longer need to know what type of result or failure will be used by the code that traverses/executes the plan later.
 2. The current approach forces the install failure type to be serialisable (if the overall `InstallPlan` is to be serialisable). This means we cannot use `SomeException` as part of the failure type in the `new-build` code path. The `new-build` code needs the `InstallPlan` to be serialisable since it caches it on disk. By separating traversal from the plan type we can make the original `InstallPlan` serialisable since it never mentions anything about the failure type. In turn this will let use use `SomeException` for the failure type which will then let us do better exception handling in the `new-build` code path.

So this stuff is also a pre-requisite for some of the `new-build` exception handling improvements.