### PR TITLE
LocalBuildInfo: combine profiling settings, track program coverage

### DIFF
--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -58,6 +58,7 @@ module Distribution.Simple.Compiler (
         packageKeySupported,
         unitIdSupported,
         coverageSupported,
+        profilingSupported,
 
         -- * Support for profiling detail levels
         ProfDetailLevel(..),
@@ -323,6 +324,15 @@ coverageSupported comp =
   case compilerFlavor comp of
     GHC -> True
     GHCJS -> True
+    _ -> False
+
+-- | Does this compiler support profiling?
+profilingSupported :: Compiler -> Bool
+profilingSupported comp =
+  case compilerFlavor comp of
+    GHC -> True
+    GHCJS -> True
+    LHC -> True
     _ -> False
 
 -- | Utility function for GHC only features

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -57,6 +57,7 @@ module Distribution.Simple.Compiler (
         unifiedIPIDRequired,
         packageKeySupported,
         unitIdSupported,
+        coverageSupported,
 
         -- * Support for profiling detail levels
         ProfDetailLevel(..),
@@ -315,6 +316,14 @@ packageKeySupported = ghcSupported "Uses package keys"
 -- | Does this compiler support unit IDs?
 unitIdSupported :: Compiler -> Bool
 unitIdSupported = ghcSupported "Uses unit IDs"
+
+-- | Does this compiler support Haskell program coverage?
+coverageSupported :: Compiler -> Bool
+coverageSupported comp =
+  case compilerFlavor comp of
+    GHC -> True
+    GHCJS -> True
+    _ -> False
 
 -- | Utility function for GHC only features
 ghcSupported :: String -> Compiler -> Bool

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -513,7 +513,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
 
   -- Determine if program coverage should be enabled and if so, what
   -- '-hpcdir' should be.
-  let isCoverageEnabled = fromFlag $ configCoverage $ configFlags lbi
+  let isCoverageEnabled = libCoverage lbi
       -- TODO: Historically HPC files have been put into a directory which
       -- has the package name.  I'm going to avoid changing this for
       -- now, but it would probably be better for this to be the
@@ -808,7 +808,7 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
 
   -- Determine if program coverage should be enabled and if so, what
   -- '-hpcdir' should be.
-  let isCoverageEnabled = fromFlag $ configCoverage $ configFlags lbi
+  let isCoverageEnabled = exeCoverage lbi
       distPref = fromFlag $ configDistPref $ configFlags lbi
       hpcdir way
         | forRepl = mempty  -- HPC is not supported in ghci

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -293,7 +293,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
 
   -- Determine if program coverage should be enabled and if so, what
   -- '-hpcdir' should be.
-  let isCoverageEnabled = fromFlag $ configCoverage $ configFlags lbi
+  let isCoverageEnabled = libCoverage lbi
       pkg_name = display $ PD.package pkg_descr
       distPref = fromFlag $ configDistPref $ configFlags lbi
       hpcdir way
@@ -534,7 +534,7 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
 
   -- Determine if program coverage should be enabled and if so, what
   -- '-hpcdir' should be.
-  let isCoverageEnabled = fromFlag $ configCoverage $ configFlags lbi
+  let isCoverageEnabled = exeCoverage lbi
       distPref = fromFlag $ configDistPref $ configFlags lbi
       hpcdir way
         | isCoverageEnabled = toFlag $ Hpc.mixDir distPref way exeName'

--- a/Cabal/Distribution/Simple/Test.hs
+++ b/Cabal/Distribution/Simple/Test.hs
@@ -20,6 +20,7 @@ import Distribution.Simple.Compiler
 import Distribution.Simple.Hpc
 import Distribution.Simple.InstallDirs
 import qualified Distribution.Simple.LocalBuildInfo as LBI
+import qualified Distribution.Types.LocalBuildInfo as LBI
 import Distribution.Simple.Setup
 import Distribution.Simple.UserHooks
 import qualified Distribution.Simple.Test.ExeV10 as ExeV10
@@ -110,8 +111,7 @@ test args pkg_descr lbi flags = do
     allOk <- summarizePackage verbosity packageLog
     writeFile packageLogFile $ show packageLog
 
-    let isCoverageEnabled = fromFlag $ configCoverage $ LBI.configFlags lbi
-    when isCoverageEnabled $
+    when (LBI.testCoverage lbi) $
         markupPackage verbosity lbi distPref (display $ PD.package pkg_descr) $
             map (fst . fst) testsToRun
 

--- a/Cabal/Distribution/Simple/Test/ExeV10.hs
+++ b/Cabal/Distribution/Simple/Test/ExeV10.hs
@@ -11,6 +11,7 @@ import Distribution.Simple.Compiler
 import Distribution.Simple.Hpc
 import Distribution.Simple.InstallDirs
 import qualified Distribution.Simple.LocalBuildInfo as LBI
+import qualified Distribution.Types.LocalBuildInfo as LBI
 import Distribution.Simple.Setup
 import Distribution.Simple.Test.Log
 import Distribution.Simple.Utils
@@ -35,7 +36,7 @@ runTest :: PD.PackageDescription
         -> PD.TestSuite
         -> IO TestSuiteLog
 runTest pkg_descr lbi clbi flags suite = do
-    let isCoverageEnabled = fromFlag $ configCoverage $ LBI.configFlags lbi
+    let isCoverageEnabled = LBI.testCoverage lbi
         way = guessWay lbi
         tixDir_ = tixDir distPref way $ PD.testName suite
 

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -17,6 +17,7 @@ import Distribution.Simple.Compiler
 import Distribution.Simple.Hpc
 import Distribution.Simple.InstallDirs
 import qualified Distribution.Simple.LocalBuildInfo as LBI
+import qualified Distribution.Types.LocalBuildInfo as LBI
 import Distribution.Simple.Setup
 import Distribution.Simple.Test.Log
 import Distribution.Simple.Utils
@@ -44,7 +45,7 @@ runTest :: PD.PackageDescription
         -> PD.TestSuite
         -> IO TestSuiteLog
 runTest pkg_descr lbi clbi flags suite = do
-    let isCoverageEnabled = fromFlag $ configCoverage $ LBI.configFlags lbi
+    let isCoverageEnabled = LBI.testCoverage lbi
         way = guessWay lbi
 
     pwd <- getCurrentDirectory

--- a/Cabal/Distribution/Types/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Types/LocalBuildInfo.hs
@@ -33,6 +33,7 @@ module Distribution.Types.LocalBuildInfo (
     withAllTargetsInBuildOrder',
     neededTargetsInBuildOrder',
     withNeededTargetsInBuildOrder',
+    testCoverage,
 
     -- * Functions you SHOULD NOT USE (yet), but are defined here to
     -- prevent someone from accidentally defining them
@@ -141,6 +142,8 @@ data LocalBuildInfo = LocalBuildInfo {
         splitObjs     :: Bool,  -- ^Use -split-objs with GHC, if available
         stripExes     :: Bool,  -- ^Whether to strip executables during install
         stripLibs     :: Bool,  -- ^Whether to strip libraries during install
+        exeCoverage :: Bool,  -- ^Whether to enable executable program coverage
+        libCoverage :: Bool,  -- ^Whether to enable library program coverage
         progPrefix    :: PathTemplate, -- ^Prefix to be prepended to installed executables
         progSuffix    :: PathTemplate, -- ^Suffix to be appended to installed executables
         relocatable   :: Bool --  ^Whether to build a relocatable package
@@ -252,6 +255,11 @@ neededTargetsInBuildOrder' pkg_descr lbi uids =
 withNeededTargetsInBuildOrder' :: PackageDescription -> LocalBuildInfo -> [UnitId] -> (TargetInfo -> IO ()) -> IO ()
 withNeededTargetsInBuildOrder' pkg_descr lbi uids f
     = sequence_ [ f target | target <- neededTargetsInBuildOrder' pkg_descr lbi uids ]
+
+-- | Is coverage enabled for test suites? In practice, this requires library
+-- and executable profiling to be enabled.
+testCoverage :: LocalBuildInfo -> Bool
+testCoverage lbi = exeCoverage lbi && libCoverage lbi
 
 -------------------------------------------------------------------------------
 -- Stub functions to prevent someone from accidentally defining them


### PR DESCRIPTION
The profiling settings in LocalBuildInfo are combined as discussed in #3597. Fields were added to track if program coverage is enabled. Both features are now disabled (and a warning emitted) if the compiler does not support them.