### PR TITLE
Revert "Generalize HookedBuildInfo to work with any type of component."

### DIFF
--- a/Cabal/Distribution/PackageDescription/PrettyPrint.hs
+++ b/Cabal/Distribution/PackageDescription/PrettyPrint.hs
@@ -299,16 +299,14 @@ writeHookedBuildInfo fpath = writeFileAtomic fpath . BS.Char8.pack
 
 -- | @since 1.26.0.0@
 showHookedBuildInfo :: HookedBuildInfo -> String
-showHookedBuildInfo bis = render $
-     vcat [    space
-            $$ ppName name
-            $$ ppBuildInfo bi
-          | (name, bi) <- bis ]
+showHookedBuildInfo (mb_lib_bi, ex_bis) = render $
+     (case mb_lib_bi of
+        Nothing -> mempty
+        Just bi -> ppBuildInfo bi)
+   $$ vcat [    space
+             $$ text "executable:" <+> text name
+             $$ ppBuildInfo bi
+           | (name, bi) <- ex_bis ]
   where
-    ppName CLibName = text "library"
-    ppName (CSubLibName name) = text "library:" <+> text name
-    ppName (CExeName name) = text "executable:" <+> text name
-    ppName (CTestName name) = text "test-suite:" <+> text name
-    ppName (CBenchName name) = text "benchmark:" <+> text name
-    ppBuildInfo bi = ppFields binfoFieldDescrs bi
-                  $$ ppCustomFields (customFieldsBI bi)
+     ppBuildInfo bi = ppFields binfoFieldDescrs bi
+                   $$ ppCustomFields (customFieldsBI bi)

--- a/Cabal/Distribution/Types/HookedBuildInfo.hs
+++ b/Cabal/Distribution/Types/HookedBuildInfo.hs
@@ -6,10 +6,7 @@ module Distribution.Types.HookedBuildInfo (
     emptyHookedBuildInfo,
   ) where
 
-import Prelude ()
---import Distribution.Compat.Prelude
-
-import Distribution.Types.ComponentName
+-- import Distribution.Compat.Prelude
 import Distribution.Types.BuildInfo
 
 -- | 'HookedBuildInfo' is mechanism that hooks can use to
@@ -62,7 +59,7 @@ import Distribution.Types.BuildInfo
 -- are obligated to apply any new 'HookedBuildInfo' and then we'd
 -- get the effect twice.  But this does mean we have to re-apply
 -- it every time. Hey, it's more flexibility.
-type HookedBuildInfo = [(ComponentName, BuildInfo)]
+type HookedBuildInfo = (Maybe BuildInfo, [(String, BuildInfo)])
 
 emptyHookedBuildInfo :: HookedBuildInfo
-emptyHookedBuildInfo = []
+emptyHookedBuildInfo = (Nothing, [])


### PR DESCRIPTION
This reverts commit af7bb5371a1ac776f93ab075d7e945cefefe0928,
restoring 'HookedBuildInfo' backwards compatibility.