### PR TITLE
fix exception handling of downloads in new-build

### DIFF
--- a/cabal-install/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/Distribution/Client/FetchUtils.hs
@@ -248,7 +248,7 @@ waitAsyncFetchPackage verbosity downloadMap srcloc =
       Just hnd -> do
         debug verbosity $ "Waiting for download of " ++ show srcloc
         either throwIO return =<< takeMVar hnd
-      Nothing -> fail "waitAsyncFetchPackage: package not being download"
+      Nothing -> fail "waitAsyncFetchPackage: package not being downloaded"
 
 
 -- ------------------------------------------------------------

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -114,12 +114,17 @@ import           System.Directory
 -- (that would make it harder to reproduce the problem sitation).
 
 
--- | The 'BuildStatus' of every package in the 'ElaboratedInstallPlan'
+-- | The 'BuildStatus' of every package in the 'ElaboratedInstallPlan'.
+--
+-- This is used as the result of the dry-run of building an install plan.
 --
 type BuildStatusMap = Map InstalledPackageId BuildStatus
 
--- | The build status for an individual package. That is, the state that the
--- package is in prior to initiating a (re)build.
+-- | The build status for an individual package is the state that the
+-- package is in /prior/ to initiating a (re)build.
+--
+-- This should not be confused with a 'BuildResult' which is the outcome
+-- /after/ building a package.
 --
 -- It serves two purposes:
 --

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -60,8 +60,6 @@ import           Distribution.Client.ProjectPlanning
 import           Distribution.Client.ProjectBuilding
 
 import           Distribution.Client.Types
-                   hiding ( BuildResult, BuildResults, BuildSuccess(..)
-                          , BuildFailure(..), DocsResult(..), TestsResult(..) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import           Distribution.Client.BuildTarget
                    ( UserBuildTarget, resolveUserBuildTargets
@@ -208,7 +206,7 @@ runProjectBuildPhase verbosity ProjectBuildContext {..} =
     previousBuildResults :: BuildStatusMap -> BuildResults
     previousBuildResults =
       Map.mapMaybe $ \status -> case status of
-        BuildStatusUpToDate _ buildSuccess -> Just (Right buildSuccess)
+        BuildStatusUpToDate buildSuccess -> Just (Right buildSuccess)
         --TODO: [nice to have] record build failures persistently
         _                                  -> Nothing
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -12,16 +12,6 @@ module Distribution.Client.ProjectPlanning (
     BuildStyle(..),
     CabalFileText,
 
-    --TODO: [code cleanup] these types should live with execution, not with
-    --      plan definition. Need to better separate InstallPlan definition.
-    GenericBuildResult(..),
-    BuildResult,
-    BuildResults,
-    BuildSuccess(..),
-    BuildFailure(..),
-    DocsResult(..),
-    TestsResult(..),
-
     -- * Producing the elaborated install plan
     rebuildInstallPlan,
 
@@ -62,8 +52,6 @@ import           Distribution.Client.ProjectConfig
 import           Distribution.Client.ProjectPlanOutput
 
 import           Distribution.Client.Types
-                   hiding ( BuildResult, BuildResults, BuildSuccess(..)
-                          , BuildFailure(..), DocsResult(..), TestsResult(..) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import qualified Distribution.Client.SolverInstallPlan as SolverInstallPlan
 import           Distribution.Client.Dependency

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -16,17 +16,6 @@ module Distribution.Client.ProjectPlanning.Types (
     BuildStyle(..),
     CabalFileText,
 
-    -- * Types used in executing an install plan
-    --TODO: [code cleanup] these types should live with execution, not with
-    --      plan definition. Need to better separate InstallPlan definition.
-    GenericBuildResult(..),
-    BuildResult,
-    BuildResults,
-    BuildSuccess(..),
-    BuildFailure(..),
-    DocsResult(..),
-    TestsResult(..),
-
     -- * Build targets
     PackageTarget(..),
     ComponentTarget(..),
@@ -68,8 +57,6 @@ import           Data.Set (Set)
 import qualified Data.ByteString.Lazy as LBS
 import           Distribution.Compat.Binary
 import           GHC.Generics (Generic)
-import           Data.Typeable (Typeable)
-import           Control.Exception
 
 
 
@@ -279,49 +266,6 @@ instance Binary BuildStyle
 type CabalFileText = LBS.ByteString
 
 type ElaboratedReadyPackage = GenericReadyPackage ElaboratedConfiguredPackage
-
---TODO: [code cleanup] this duplicates the InstalledPackageInfo quite a bit in an install plan
--- because the same ipkg is used by many packages. So the binary file will be big.
--- Could we keep just (ipkgid, deps) instead of the whole InstalledPackageInfo?
--- or transform to a shared form when serialising / deserialising
-
-data GenericBuildResult ipkg iresult ifailure
-                  = BuildFailure ifailure
-                  | BuildSuccess [ipkg] iresult
-  deriving (Eq, Show, Generic)
-
-instance (Binary ipkg, Binary iresult, Binary ifailure) =>
-         Binary (GenericBuildResult ipkg iresult ifailure)
-
-type BuildResult  = GenericBuildResult InstalledPackageInfo
-                                       BuildSuccess BuildFailure
-type BuildResults = Map UnitId (Either BuildFailure BuildSuccess)
-
-data BuildSuccess = BuildOk DocsResult TestsResult
-  deriving (Eq, Show, Generic)
-
-data DocsResult  = DocsNotTried  | DocsFailed  | DocsOk
-  deriving (Eq, Show, Generic)
-
-data TestsResult = TestsNotTried | TestsOk
-  deriving (Eq, Show, Generic)
-
-data BuildFailure = PlanningFailed              --TODO: [required eventually] not yet used
-                  | DependentFailed PackageId
-                  | DownloadFailed  String      --TODO: [required eventually] not yet used
-                  | UnpackFailed    String      --TODO: [required eventually] not yet used
-                  | ConfigureFailed String
-                  | BuildFailed     String
-                  | TestsFailed     String      --TODO: [required eventually] not yet used
-                  | InstallFailed   String
-  deriving (Eq, Show, Typeable, Generic)
-
-instance Exception BuildFailure
-
-instance Binary BuildFailure
-instance Binary BuildSuccess
-instance Binary DocsResult
-instance Binary TestsResult
 
 
 ---------------------------

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -39,7 +40,8 @@ import Distribution.Solver.Types.SourcePackage
 import Data.Map (Map)
 import Network.URI (URI(..), URIAuth(..), nullURI)
 import Control.Exception
-         ( SomeException )
+         ( Exception, SomeException )
+import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Distribution.Compat.Binary (Binary(..))
 
@@ -266,7 +268,7 @@ maybeRepoRemote (RepoSecure r _localDir) = Just r
 -- ------------------------------------------------------------
 
 type BuildResult  = Either BuildFailure BuildSuccess
-type BuildResults = Map UnitId (Either BuildFailure BuildSuccess)
+type BuildResults = Map UnitId BuildResult
 
 data BuildFailure = PlanningFailed
                   | DependentFailed PackageId
@@ -276,7 +278,10 @@ data BuildFailure = PlanningFailed
                   | BuildFailed     SomeException
                   | TestsFailed     SomeException
                   | InstallFailed   SomeException
-  deriving (Show, Generic)
+  deriving (Show, Typeable, Generic)
+
+instance Exception BuildFailure
+
 data BuildSuccess = BuildOk         DocsResult TestsResult
                                     [InstalledPackageInfo]
   deriving (Show, Generic)

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -267,7 +267,12 @@ maybeRepoRemote (RepoSecure r _localDir) = Just r
 -- * Build results
 -- ------------------------------------------------------------
 
+-- | A summary of the outcome for building a single package.
+--
 type BuildResult  = Either BuildFailure BuildSuccess
+
+-- | A summary of the outcome for building a whole set of packages.
+--
 type BuildResults = Map UnitId BuildResult
 
 data BuildFailure = PlanningFailed

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -396,6 +396,7 @@ Test-Suite unit-tests
     UnitTests.Options
   build-depends:
         base,
+        async,
         array,
         bytestring,
         Cabal,
@@ -460,6 +461,7 @@ Test-Suite solver-quickcheck
     UnitTests.Distribution.Solver.Modular.QuickCheck
   build-depends:
         base,
+        async,
         array,
         bytestring,
         Cabal,


### PR DESCRIPTION
Partly this is a continuation of the InstallPlan refactoring #3622, but also a related change to fix #3387, by handling exceptions during download properly.

These things are also a step towards finishing #3394 properly, since it means we now have all the `BuildResults` using proper exception types and so will be able to use that to report at the end what if anything when wrong.