### PR TITLE
Don't pass -package-db and -package flags to --abi-hash.

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1048,12 +1048,16 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
   let
       comp        = compiler lbi
       platform    = hostPlatform lbi
-      vanillaArgs =
+      vanillaArgs0 =
         (componentGhcOptions verbosity lbi libBi clbi (componentBuildDir lbi clbi))
         `mappend` mempty {
           ghcOptMode         = toFlag GhcModeAbiHash,
           ghcOptInputModules = toNubListR $ exposedModules lib
         }
+      vanillaArgs =
+          -- Package DBs unnecessary, and break ghc-cabal. See #3633
+          vanillaArgs0 { ghcOptPackageDBs = []
+                       , ghcOptPackages = mempty }
       sharedArgs = vanillaArgs `mappend` mempty {
                        ghcOptDynLinkMode = toFlag GhcDynamicOnly,
                        ghcOptFPic        = toFlag True,

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1056,7 +1056,9 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
         }
       vanillaArgs =
           -- Package DBs unnecessary, and break ghc-cabal. See #3633
-          vanillaArgs0 { ghcOptPackageDBs = []
+          -- BUT, put at least the global database so that 7.4 doesn't
+          -- break.
+          vanillaArgs0 { ghcOptPackageDBs = [GlobalPackageDB]
                        , ghcOptPackages = mempty }
       sharedArgs = vanillaArgs `mappend` mempty {
                        ghcOptDynLinkMode = toFlag GhcDynamicOnly,


### PR DESCRIPTION
Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>