### PR TITLE
Avoid filtering the solver log before 'showMessages'.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Log.hs
+++ b/cabal-install/Distribution/Solver/Modular/Log.hs
@@ -47,8 +47,8 @@ logToProgress mbj l = let
     proc :: Maybe Int -> Progress Message a b -> Progress Message (Maybe (ConflictSet QPN)) b
     proc _        (Done x)                          = Done x
     proc _        (Fail _)                          = Fail Nothing
-    proc mbj'     (Step   (Failure cs Backjump) xs@(Step Leave (Step (Failure cs' Backjump) _)))
-      | cs == cs'                                   = proc mbj' xs -- repeated backjumps count as one
+    proc mbj'     (Step x@(Failure cs Backjump) xs@(Step Leave (Step (Failure cs' Backjump) _)))
+      | cs == cs'                                   = Step x (proc mbj'           xs) -- repeated backjumps count as one
     proc (Just 0) (Step   (Failure cs Backjump)  _) = Fail (Just cs)
     proc (Just n) (Step x@(Failure _  Backjump) xs) = Step x (proc (Just (n - 1)) xs)
     proc mbj'     (Step x                       xs) = Step x (proc mbj'           xs)

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -43,6 +43,7 @@ tests = [
         , runTest $ indep $ mkTest db1 "multipleInstances"  ["F", "G"] anySolverFailure
         , runTest $         mkTest db21 "unknownPackage1"   ["A"]      (SolverSuccess [("A", 1), ("B", 1)])
         , runTest $         mkTest db22 "unknownPackage2"   ["A"]      (SolverFailure (isInfixOf "unknown package: C"))
+        , runTest $         mkTest db23 "unknownPackage3"   ["A"]      (SolverFailure (isInfixOf "unknown package: B"))
         ]
     , testGroup "Flagged dependencies" [
           runTest $         mkTest db3 "forceFlagOn"  ["C"]      (SolverSuccess [("A", 1), ("B", 1), ("C", 1)])
@@ -796,6 +797,17 @@ db22 :: ExampleDb
 db22 = [
     Right $ exAv "A" 1 [ExAny "B"]
   , Right $ exAv "A" 2 [ExAny "C"]
+  ]
+
+-- | Another test for the unknown package message.  This database tests that
+-- filtering out redundant conflict set messages in the solver log doesn't
+-- interfere with generating a message about a missing package (part of issue
+-- #3617). The conflict set for the missing package is {A, B}. That conflict set
+-- is propagated up the tree to the level of A. Since the conflict set is the
+-- same at both levels, the solver only keeps one of the backjumping messages.
+db23 :: ExampleDb
+db23 = [
+    Right $ exAv "A" 1 [ExAny "B"]
   ]
 
 -- | Database for (unsuccessfully) trying to expose a bug in the handling


### PR DESCRIPTION
Previously, the solver filtered out redundant backjumping messages twice, once in `Log.logToProgress` and again in `Message.showMessages`. However, `showMessages` relied on the backjumping messages to determine where to insert messages about missing packages. This led to missing "unknown package" messages (part of issue #3617).

This commit removes the filtering in `logToProgress`, because it was redundant.