### PR TITLE
Fix Haddock syntax in cabal-install.

### DIFF
--- a/cabal-install/Distribution/Client/Init/Heuristics.hs
+++ b/cabal-install/Distribution/Client/Init/Heuristics.hs
@@ -254,7 +254,11 @@ guessAuthorNameMail = fmap authorGuessPure authorGuessIO
 -- Ordered in increasing preference, since Flag-as-monoid is identical to
 -- Last.
 authorGuessPure :: AuthorGuessIO -> AuthorGuess
-authorGuessPure (AuthorGuessIO env darcsLocalF darcsGlobalF gitLocal gitGlobal)
+authorGuessPure (AuthorGuessIO { authorGuessEnv = env
+                               , authorGuessLocalDarcs = darcsLocalF
+                               , authorGuessGlobalDarcs = darcsGlobalF
+                               , authorGuessLocalGit = gitLocal
+                               , authorGuessGlobalGit = gitGlobal })
     = mconcat
         [ emailEnv env
         , gitGlobal
@@ -278,12 +282,13 @@ authorGuessIO = AuthorGuessIO
 type AuthorGuess   = (Flag String, Flag String)
 type Enviro        = [(String, String)]
 data GitLoc        = Local | Global
-data AuthorGuessIO = AuthorGuessIO
-    Enviro         -- ^ Environment lookup table
-    (Maybe String) -- ^ Contents of local darcs author info
-    (Maybe String) -- ^ Contents of global darcs author info
-    AuthorGuess    -- ^ Git config --local
-    AuthorGuess    -- ^ Git config --global
+data AuthorGuessIO = AuthorGuessIO {
+    authorGuessEnv         :: Enviro,         -- ^ Environment lookup table
+    authorGuessLocalDarcs  :: (Maybe String), -- ^ Contents of local darcs author info
+    authorGuessGlobalDarcs :: (Maybe String), -- ^ Contents of global darcs author info
+    authorGuessLocalGit    :: AuthorGuess,   -- ^ Git config --local
+    authorGuessGlobalGit   :: AuthorGuess    -- ^ Git config --global
+  }
 
 darcsEnv :: Enviro -> AuthorGuess
 darcsEnv = maybe mempty nameAndMail . lookup "DARCS_EMAIL"

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1301,10 +1301,10 @@ elaborateInstallPlan platform compiler compilerprogdb
       -- package config validation/resolution pass.
 
       --TODO: [nice to have] config consistency checking:
-      -- * profiling libs & exes, exe needs lib, recursive
-      -- * shared libs & exes, exe needs lib, recursive
-      -- * vanilla libs & exes, exe needs lib, recursive
-      -- * ghci or shared lib needed by TH, recursive, ghc version dependent
+      -- + profiling libs & exes, exe needs lib, recursive
+      -- + shared libs & exes, exe needs lib, recursive
+      -- + vanilla libs & exes, exe needs lib, recursive
+      -- + ghci or shared lib needed by TH, recursive, ghc version dependent
 
 
 ---------------------------

--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -598,7 +598,7 @@ loadConfigOrSandboxConfig verbosity globalFlags = do
     -- A @cabal.sandbox.config@ file (and possibly @cabal.config@) is present.
     SandboxPackageEnvironment -> do
       (sandboxDir, pkgEnv) <- tryLoadSandboxConfig verbosity globalFlags
-                              -- ^ Prints an error message and exits on error.
+                              -- Prints an error message and exits on error.
       let config = pkgEnvSavedConfig pkgEnv
       return (UseSandbox sandboxDir, config)
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -353,7 +353,7 @@ configureOptions = commandOptions configureCommand
 filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
   | cabalLibVersion >= Version [1,23,0] [] = flags_latest
-  -- ^ NB: we expect the latest version to be the most common case.
+  -- NB: we expect the latest version to be the most common case.
   | cabalLibVersion <  Version [1,3,10] [] = flags_1_3_10
   | cabalLibVersion <  Version [1,10,0] [] = flags_1_10_0
   | cabalLibVersion <  Version [1,12,0] [] = flags_1_12_0
@@ -1717,7 +1717,7 @@ data SDistExFlags = SDistExFlags {
   }
   deriving (Show, Generic)
 
-data ArchiveFormat = TargzFormat | ZipFormat -- | ...
+data ArchiveFormat = TargzFormat | ZipFormat -- ...
   deriving (Show, Eq)
 
 defaultSDistExFlags :: SDistExFlags

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -87,14 +87,14 @@ data SolverConfig = SolverConfig {
 -- seems to be no statistically significant performance impact of cycle
 -- detection in the common case where there are no cycles.
 --
-solve :: SolverConfig ->                      -- ^ solver parameters
-         CompilerInfo ->
-         Index ->                             -- ^ all available packages as an index
-         PkgConfigDb ->                       -- ^ available pkg-config pkgs
-         (PN -> PackagePreferences) ->        -- ^ preferences
-         Map PN [LabeledPackageConstraint] -> -- ^ global constraints
-         [PN] ->                              -- ^ global goals
-         Log Message (Assignment, RevDepMap)
+solve :: SolverConfig                         -- ^ solver parameters
+      -> CompilerInfo
+      -> Index                                -- ^ all available packages as an index
+      -> PkgConfigDb                          -- ^ available pkg-config pkgs
+      -> (PN -> PackagePreferences)           -- ^ preferences
+      -> Map PN [LabeledPackageConstraint]    -- ^ global constraints
+      -> [PN]                                 -- ^ global goals
+      -> Log Message (Assignment, RevDepMap)
 solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
   explorePhase     $
   detectCycles     $


### PR DESCRIPTION
If we were generating Haddock for cabal-install (we're not
currently) these would cause errors.  Make them stop causing
errors.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>