### PR TITLE
Report build failures with reasonably formatted messages

### DIFF
--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -41,7 +41,7 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     userTargets <- readUserBuildTargets targetStrings
 
-    buildCtx@ProjectBuildContext{buildSettings} <-
+    buildCtx@ProjectBuildContext{buildSettings, elaboratedPlan} <-
       runProjectPreBuildPhase
         verbosity
         ( globalFlags, configFlags, configExFlags
@@ -54,10 +54,8 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
     printPlan verbosity buildCtx
 
     unless (buildSettingDryRun buildSettings) $ do
-      plan <- runProjectBuildPhase
-                verbosity
-                buildCtx
-      reportBuildFailures plan
+      buildResults <- runProjectBuildPhase verbosity buildCtx
+      reportBuildFailures elaboratedPlan buildResults
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
 

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -45,7 +45,7 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     userTargets <- readUserBuildTargets targetStrings
 
-    buildCtx@ProjectBuildContext{buildSettings} <-
+    buildCtx@ProjectBuildContext{buildSettings, elaboratedPlan} <-
       runProjectPreBuildPhase
         verbosity
         ( globalFlags, configFlags, configExFlags
@@ -58,10 +58,8 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags)
     printPlan verbosity buildCtx
 
     unless (buildSettingDryRun buildSettings) $ do
-      plan <- runProjectBuildPhase
-                verbosity
-                buildCtx
-      reportBuildFailures plan
+      buildResults <- runProjectBuildPhase verbosity buildCtx
+      reportBuildFailures elaboratedPlan buildResults
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
 


### PR DESCRIPTION
This should fix issue #3394

Previous patches had made the changes to collect the detailed error info all in one place. So this patch is just about deciding what to report and how to report it.

Still TODO is mentioning log files, ie when the package build was being logged to a file, we should include a snippet and say where the log file can be found for full details.