### PR TITLE
stack.yaml: add optional Nix dependency zlib

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -42,3 +42,5 @@ extra-deps:
 - unbounded-delays-0.1.0.9
 - zlib-0.6.1.1
 flags: {}
+nix:
+  packages: [zlib, zlib.out]


### PR DESCRIPTION
The external zlib package is required to build the zlib Haskell
library. This change will not affect Stack-using developers who do not
have Nix integration enabled globally. This change will not affect
non-Stack-using developers at all.