### PR TITLE
Revert "Try top-level -Werror."

### DIFF
--- a/cabal.project.travis
+++ b/cabal.project.travis
@@ -3,4 +3,11 @@
 -- Turn off parallelization to get good errors.
 jobs: 1
 
-ghc-options: -Werror
+-- The -fno-warn-orphans is a hack to make Cabal-1.24
+-- build properly (unfortunately the flags here get applied
+-- to the dependencies too!)
+package Cabal
+  ghc-options: -Werror -fno-warn-orphans
+
+package cabal-install
+  ghc-options: -Werror


### PR DESCRIPTION
From Travis:

    Warning: /Users/travis/build/haskell/cabal/cabal.project.local: Unrecognized
    field 'ghc-options' on line 6

This reverts commit 6b7ff81978a91fd8999edf56730d305bc32aaa50.