### PR TITLE
Rework new-build failure reporting to include build logs

### DIFF
--- a/cabal-install/Distribution/Client/BuildReports/Anonymous.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Anonymous.hs
@@ -27,7 +27,7 @@ module Distribution.Client.BuildReports.Anonymous (
   ) where
 
 import qualified Distribution.Client.Types as BR
-         ( BuildResult, BuildFailure(..), BuildSuccess(..)
+         ( BuildOutcome, BuildFailure(..), BuildResult(..)
          , DocsResult(..), TestsResult(..) )
 import Distribution.Client.Utils
          ( mergeBy, MergeResult(..) )
@@ -120,7 +120,7 @@ data Outcome = NotTried | Failed | Ok
   deriving Eq
 
 new :: OS -> Arch -> CompilerId -> PackageIdentifier -> FlagAssignment
-    -> [PackageIdentifier] -> BR.BuildResult -> BuildReport
+    -> [PackageIdentifier] -> BR.BuildOutcome -> BuildReport
 new os' arch' comp pkgid flags deps result =
   BuildReport {
     package               = pkgid,
@@ -145,17 +145,17 @@ new os' arch' comp pkgid flags deps result =
       Left  (BR.BuildFailed     _) -> BuildFailed
       Left  (BR.TestsFailed     _) -> TestsFailed
       Left  (BR.InstallFailed   _) -> InstallFailed
-      Right (BR.BuildOk       _ _ _) -> InstallOk
+      Right (BR.BuildResult _ _ _) -> InstallOk
     convertDocsOutcome = case result of
-      Left _                                -> NotTried
-      Right (BR.BuildOk BR.DocsNotTried _ _)  -> NotTried
-      Right (BR.BuildOk BR.DocsFailed _ _)    -> Failed
-      Right (BR.BuildOk BR.DocsOk _ _)        -> Ok
+      Left _                                      -> NotTried
+      Right (BR.BuildResult BR.DocsNotTried _ _)  -> NotTried
+      Right (BR.BuildResult BR.DocsFailed _ _)    -> Failed
+      Right (BR.BuildResult BR.DocsOk _ _)        -> Ok
     convertTestsOutcome = case result of
-      Left  (BR.TestsFailed _)              -> Failed
-      Left _                                -> NotTried
-      Right (BR.BuildOk _ BR.TestsNotTried _) -> NotTried
-      Right (BR.BuildOk _ BR.TestsOk _)       -> Ok
+      Left  (BR.TestsFailed _)                    -> Failed
+      Left _                                      -> NotTried
+      Right (BR.BuildResult _ BR.TestsNotTried _) -> NotTried
+      Right (BR.BuildResult _ BR.TestsOk _)       -> Ok
 
 cabalInstallID :: PackageIdentifier
 cabalInstallID =

--- a/cabal-install/Distribution/Client/BuildReports/Storage.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Storage.hs
@@ -123,19 +123,19 @@ storeLocal cinfo templates reports platform = sequence_
 
 fromInstallPlan :: Platform -> CompilerId
                 -> InstallPlan
-                -> BuildResults
+                -> BuildOutcomes
                 -> [(BuildReport, Maybe Repo)]
-fromInstallPlan platform comp plan buildResults =
+fromInstallPlan platform comp plan buildOutcomes =
      catMaybes
    . map (\pkg -> fromPlanPackage
                     platform comp pkg
-                    (InstallPlan.lookupBuildResult pkg buildResults))
+                    (InstallPlan.lookupBuildOutcome pkg buildOutcomes))
    . InstallPlan.toList
    $ plan
 
 fromPlanPackage :: Platform -> CompilerId
                 -> InstallPlan.PlanPackage
-                -> Maybe BuildResult
+                -> Maybe BuildOutcome
                 -> Maybe (BuildReport, Maybe Repo)
 fromPlanPackage (Platform arch os) comp
                 (InstallPlan.Configured (ConfiguredPackage _ srcPkg flags _ deps))

--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -55,7 +55,7 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     unless (buildSettingDryRun buildSettings) $ do
       buildResults <- runProjectBuildPhase verbosity buildCtx
-      reportBuildFailures elaboratedPlan buildResults
+      reportBuildFailures verbosity elaboratedPlan buildResults
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
 

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -59,7 +59,7 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     unless (buildSettingDryRun buildSettings) $ do
       buildResults <- runProjectBuildPhase verbosity buildCtx
-      reportBuildFailures elaboratedPlan buildResults
+      reportBuildFailures verbosity elaboratedPlan buildResults
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
 

--- a/cabal-install/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/Distribution/Client/InstallSymlink.hs
@@ -20,7 +20,7 @@ module Distribution.Client.InstallSymlink (
 
 import Distribution.Package (PackageIdentifier)
 import Distribution.Client.InstallPlan (InstallPlan)
-import Distribution.Client.Types (BuildResults)
+import Distribution.Client.Types (BuildOutcomes)
 import Distribution.Client.Setup (InstallFlags)
 import Distribution.Simple.Setup (ConfigFlags)
 import Distribution.Simple.Compiler
@@ -30,7 +30,7 @@ symlinkBinaries :: Platform -> Compiler
                 -> ConfigFlags
                 -> InstallFlags
                 -> InstallPlan
-                -> BuildResults
+                -> BuildOutcomes
                 -> IO [(PackageIdentifier, String, FilePath)]
 symlinkBinaries _ _ _ _ _ _ = return []
 
@@ -40,7 +40,7 @@ symlinkBinary _ _ _ _ = fail "Symlinking feature not available on Windows"
 #else
 
 import Distribution.Client.Types
-         ( ConfiguredPackage(..), BuildResults )
+         ( ConfiguredPackage(..), BuildOutcomes )
 import Distribution.Client.Setup
          ( InstallFlags(installSymlinkBinDir) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
@@ -107,9 +107,9 @@ symlinkBinaries :: Platform -> Compiler
                 -> ConfigFlags
                 -> InstallFlags
                 -> InstallPlan
-                -> BuildResults
+                -> BuildOutcomes
                 -> IO [(PackageIdentifier, String, FilePath)]
-symlinkBinaries platform comp configFlags installFlags plan buildResults =
+symlinkBinaries platform comp configFlags installFlags plan buildOutcomes =
   case flagToMaybe (installSymlinkBinDir installFlags) of
     Nothing            -> return []
     Just symlinkBinDir
@@ -139,7 +139,7 @@ symlinkBinaries platform comp configFlags installFlags plan buildResults =
     exes =
       [ (cpkg, pkg, exe)
       | InstallPlan.Configured cpkg <- InstallPlan.toList plan
-      , case InstallPlan.lookupBuildResult cpkg buildResults of
+      , case InstallPlan.lookupBuildOutcome cpkg buildOutcomes of
           Just (Right _success) -> True
           _                     -> False
       , let pkg :: PackageDescription

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -609,12 +609,13 @@ instance Exception BuildFailure
 
 -- | Detail on the reason that a package failed to build.
 --
-data BuildFailureReason = PlanningFailed
-                        | DependentFailed PackageId
+data BuildFailureReason = DependentFailed PackageId
                         | DownloadFailed  SomeException
                         | UnpackFailed    SomeException
                         | ConfigureFailed SomeException
                         | BuildFailed     SomeException
+                        | ReplFailed      SomeException
+                        | HaddocksFailed  SomeException
                         | TestsFailed     SomeException
                         | InstallFailed   SomeException
   deriving Show
@@ -1240,12 +1241,12 @@ buildInplaceUnpackedPackage verbosity
         -- Repl phase
         --
         whenRepl $
-          annotateFailure (BuildFailure Nothing . BuildFailed) $
+          annotateFailure (BuildFailure Nothing . ReplFailed) $
           setup replCommand replFlags replArgs
 
         -- Haddock phase
         whenHaddock $
-          annotateFailure (BuildFailure Nothing . BuildFailed) $
+          annotateFailure (BuildFailure Nothing . HaddocksFailed) $
           setup haddockCommand haddockFlags []
 
         return BuildResult {

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -503,6 +503,7 @@ reportBuildFailures verbosity plan buildOutcomes
 
                | otherwise
               -> renderFailureSummary mentionDepOf pkg reason
+              ++ ". See the build log above for details."
 
              ShowBuildSummaryOnly reason ->
                renderFailureDetail mentionDepOf pkg reason

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -554,6 +554,10 @@ reportBuildFailures plan buildOutcomes
                             ++ showException e
           BuildFailed     e -> "failed to build " ++ pkgstr ++ "."
                             ++ showException e
+          ReplFailed      e -> "repl failed for " ++ pkgstr ++ "."
+                            ++ showException e
+          HaddocksFailed  e -> "failed to build documentation for " ++ pkgstr ++ "."
+                            ++ showException e
           TestsFailed     e -> "tests failed for " ++ pkgstr ++ "."
                             ++ showException e
           InstallFailed   e -> "failed to build " ++ pkgstr ++ ". The failure"
@@ -563,7 +567,6 @@ reportBuildFailures plan buildOutcomes
           -- This will never happen, but we include it for completeness
           DependentFailed pkgid -> " depends on " ++ display pkgid
                                 ++ " which failed to install."
-          PlanningFailed -> " failed during the planning phase."
       where
         pkgstr = display (packageId pkg)
               ++ renderDependencyOf (installedUnitId pkg)

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -484,19 +484,19 @@ reportBuildFailures plan buildOutcomes
 
   | otherwise
   = case failuresPrimary of
-     [(pkg, reason)] -> die $ renderFailure pkg reason
+     [(pkg, failure)] -> die $ renderFailure pkg (buildFailureReason failure)
      multiple        -> die $ "multiple failures:\n"
-                           ++ unlines
-                                [ renderFailure pkg reason
-                                | (pkg, reason) <- multiple ]
+                            ++ unlines
+                                 [ renderFailure pkg (buildFailureReason failure)
+                                 | (pkg, failure) <- multiple ]
   where
-    failures =  [ (pkgid, reason)
-                | (pkgid, Left reason) <- Map.toList buildOutcomes ]
+    failures =  [ (pkgid, failure)
+                | (pkgid, Left failure) <- Map.toList buildOutcomes ]
 
     failuresPrimary =
-      [ (pkg, reason)
-      | (pkgid, reason) <- failures
-      , case reason of
+      [ (pkg, failure)
+      | (pkgid, failure) <- failures
+      , case buildFailureReason failure of
           DependentFailed {} -> False
           _                  -> True
       , InstallPlan.Configured pkg <-
@@ -515,10 +515,10 @@ reportBuildFailures plan buildOutcomes
     --  - then we do not report additional error detail or context.
     --
     isSimpleCase
-      | [(pkgid, reason)] <- failures
-      , [pkg]             <- rootpkgs
+      | [(pkgid, failure)] <- failures
+      , [pkg]              <- rootpkgs
       , installedUnitId pkg == pkgid
-      , isFailureSelfExplanatory reason
+      , isFailureSelfExplanatory (buildFailureReason failure)
       = True
       | otherwise
       = False

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -199,9 +199,9 @@ runProjectPreBuildPhase
 --
 runProjectBuildPhase :: Verbosity
                      -> ProjectBuildContext
-                     -> IO BuildResults
+                     -> IO BuildOutcomes
 runProjectBuildPhase verbosity ProjectBuildContext {..} =
-    fmap (Map.union (previousBuildResults pkgsBuildStatus)) $
+    fmap (Map.union (previousBuildOutcomes pkgsBuildStatus)) $
     rebuildTargets verbosity
                    distDirLayout
                    elaboratedPlan
@@ -209,8 +209,8 @@ runProjectBuildPhase verbosity ProjectBuildContext {..} =
                    pkgsBuildStatus
                    buildSettings
   where
-    previousBuildResults :: BuildStatusMap -> BuildResults
-    previousBuildResults =
+    previousBuildOutcomes :: BuildStatusMap -> BuildOutcomes
+    previousBuildOutcomes =
       Map.mapMaybe $ \status -> case status of
         BuildStatusUpToDate buildSuccess -> Just (Right buildSuccess)
         --TODO: [nice to have] record build failures persistently
@@ -472,8 +472,8 @@ printPlan verbosity
     showMonitorChangedReason  MonitorCorruptCache = "cannot read state cache"
 
 
-reportBuildFailures :: ElaboratedInstallPlan -> BuildResults -> IO ()
-reportBuildFailures plan buildResults
+reportBuildFailures :: ElaboratedInstallPlan -> BuildOutcomes -> IO ()
+reportBuildFailures plan buildOutcomes
   | null failures
   = return ()
 
@@ -489,7 +489,7 @@ reportBuildFailures plan buildResults
                                 | (pkg, reason) <- multiple ]
   where
     failures =  [ (pkgid, reason)
-                | (pkgid, Left reason) <- Map.toList buildResults ]
+                | (pkgid, Left reason) <- Map.toList buildOutcomes ]
 
     failuresPrimary =
       [ (pkg, reason)

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -61,6 +61,8 @@ import           Distribution.Client.ProjectPlanning
 import           Distribution.Client.ProjectBuilding
 
 import           Distribution.Client.Types
+                   ( InstalledPackageId, installedPackageId
+                   , GenericReadyPackage(..), PackageLocation(..) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import           Distribution.Client.BuildTarget
                    ( UserBuildTarget, resolveUserBuildTargets

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -28,8 +28,6 @@ module Distribution.Client.ProjectPlanning.Types (
 import           Distribution.Client.PackageHash
 
 import           Distribution.Client.Types
-                   hiding ( BuildResult, BuildResults, BuildSuccess(..)
-                          , BuildFailure(..), DocsResult(..), TestsResult(..) )
 import           Distribution.Client.InstallPlan
                    ( GenericInstallPlan, GenericPlanPackage )
 import           Distribution.Client.SolverInstallPlan

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -269,11 +269,11 @@ maybeRepoRemote (RepoSecure r _localDir) = Just r
 
 -- | A summary of the outcome for building a single package.
 --
-type BuildResult  = Either BuildFailure BuildSuccess
+type BuildOutcome = Either BuildFailure BuildResult
 
 -- | A summary of the outcome for building a whole set of packages.
 --
-type BuildResults = Map UnitId BuildResult
+type BuildOutcomes = Map UnitId BuildOutcome
 
 data BuildFailure = PlanningFailed
                   | DependentFailed PackageId
@@ -287,8 +287,8 @@ data BuildFailure = PlanningFailed
 
 instance Exception BuildFailure
 
-data BuildSuccess = BuildOk         DocsResult TestsResult
-                                    [InstalledPackageInfo]
+data BuildResult = BuildResult DocsResult TestsResult
+                               [InstalledPackageInfo]
   deriving (Show, Generic)
 
 data DocsResult  = DocsNotTried  | DocsFailed  | DocsOk
@@ -297,7 +297,7 @@ data TestsResult = TestsNotTried | TestsOk
   deriving (Show, Generic)
 
 instance Binary BuildFailure
-instance Binary BuildSuccess
+instance Binary BuildResult
 instance Binary DocsResult
 instance Binary TestsResult
 

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -263,7 +263,7 @@ type PlanDetails = (DistDirLayout,
                     BuildStatusMap,
                     BuildTimeSettings)
 
-executePlan :: PlanDetails -> IO (ElaboratedInstallPlan, BuildResults)
+executePlan :: PlanDetails -> IO (ElaboratedInstallPlan, BuildOutcomes)
 executePlan (distDirLayout,
              elaboratedPlan,
              elaboratedShared,
@@ -340,44 +340,44 @@ expectException expected action = do
       Left  e -> return e
       Right _ -> throwIO $ HUnitFailure $ "expected an exception " ++ expected
 
-expectPackagePreExisting :: ElaboratedInstallPlan -> BuildResults -> PackageId
+expectPackagePreExisting :: ElaboratedInstallPlan -> BuildOutcomes -> PackageId
                          -> IO InstalledPackageInfo
-expectPackagePreExisting plan buildResults pkgid = do
+expectPackagePreExisting plan buildOutcomes pkgid = do
     planpkg <- expectPlanPackage plan pkgid
-    case (planpkg, InstallPlan.lookupBuildResult planpkg buildResults) of
+    case (planpkg, InstallPlan.lookupBuildOutcome planpkg buildOutcomes) of
       (InstallPlan.PreExisting pkg, Nothing)
                        -> return pkg
       (_, buildResult) -> unexpectedBuildResult "PreExisting" planpkg buildResult
 
-expectPackageConfigured :: ElaboratedInstallPlan -> BuildResults -> PackageId
+expectPackageConfigured :: ElaboratedInstallPlan -> BuildOutcomes -> PackageId
                         -> IO ElaboratedConfiguredPackage
-expectPackageConfigured plan buildResults pkgid = do
+expectPackageConfigured plan buildOutcomes pkgid = do
     planpkg <- expectPlanPackage plan pkgid
-    case (planpkg, InstallPlan.lookupBuildResult planpkg buildResults) of
+    case (planpkg, InstallPlan.lookupBuildOutcome planpkg buildOutcomes) of
       (InstallPlan.Configured pkg, Nothing)
                        -> return pkg
       (_, buildResult) -> unexpectedBuildResult "Configured" planpkg buildResult
 
-expectPackageInstalled :: ElaboratedInstallPlan -> BuildResults -> PackageId
-                       -> IO (ElaboratedConfiguredPackage, BuildSuccess)
-expectPackageInstalled plan buildResults pkgid = do
+expectPackageInstalled :: ElaboratedInstallPlan -> BuildOutcomes -> PackageId
+                       -> IO (ElaboratedConfiguredPackage, BuildResult)
+expectPackageInstalled plan buildOutcomes pkgid = do
     planpkg <- expectPlanPackage plan pkgid
-    case (planpkg, InstallPlan.lookupBuildResult planpkg buildResults) of
+    case (planpkg, InstallPlan.lookupBuildOutcome planpkg buildOutcomes) of
       (InstallPlan.Configured pkg, Just (Right result))
                        -> return (pkg, result)
       (_, buildResult) -> unexpectedBuildResult "Installed" planpkg buildResult
 
-expectPackageFailed :: ElaboratedInstallPlan -> BuildResults -> PackageId
+expectPackageFailed :: ElaboratedInstallPlan -> BuildOutcomes -> PackageId
                     -> IO (ElaboratedConfiguredPackage, BuildFailure)
-expectPackageFailed plan buildResults pkgid = do
+expectPackageFailed plan buildOutcomes pkgid = do
     planpkg <- expectPlanPackage plan pkgid
-    case (planpkg, InstallPlan.lookupBuildResult planpkg buildResults) of
+    case (planpkg, InstallPlan.lookupBuildOutcome planpkg buildOutcomes) of
       (InstallPlan.Configured pkg, Just (Left failure))
                        -> return (pkg, failure)
       (_, buildResult) -> unexpectedBuildResult "Failed" planpkg buildResult
 
 unexpectedBuildResult :: String -> ElaboratedPlanPackage
-                      -> Maybe (Either BuildFailure BuildSuccess) -> IO a
+                      -> Maybe (Either BuildFailure BuildResult) -> IO a
 unexpectedBuildResult expected planpkg buildResult =
     throwIO $ HUnitFailure $
          "expected to find " ++ display (packageId planpkg) ++ " in the "

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -94,8 +94,8 @@ testExceptionInConfigureStep :: ProjectConfig -> Assertion
 testExceptionInConfigureStep config = do
     (plan, res) <- executePlan =<< planProject testdir config
     (_pkga1, failure) <- expectPackageFailed plan res pkgidA1
-    case failure of
-      ConfigureFailed _str -> return ()
+    case buildFailureReason failure of
+      ConfigureFailed _ -> return ()
       _ -> assertFailure $ "expected ConfigureFailed, got " ++ show failure 
     cleanProject testdir
   where
@@ -405,9 +405,9 @@ expectPlanPackage plan pkgid =
                 ++ " in the install plan but there's several"
 
 expectBuildFailed :: BuildFailure -> IO ()
-expectBuildFailed (BuildFailed _str) = return ()
-expectBuildFailed failure = assertFailure $ "expected BuildFailed, got "
-                                         ++ show failure
+expectBuildFailed (BuildFailure _ (BuildFailed _)) = return ()
+expectBuildFailed (BuildFailure _ reason) =
+    assertFailure $ "expected BuildFailed, got " ++ show reason
 
 ---------------------------------------
 -- Other utils


### PR DESCRIPTION
This is the follow-up to #3665 and should address all the issues raised there.

Reporting build logs is important as we otherwise have no real info for why deps failed to build. It does make the presentation more difficult however because build logs can be long and in principle there can be several, which means it can take up more than a single screen in a console. The first thing users notice is typically the last few messages, so in the case that we're presenting long build logs then its important to also include a short summary at the end.
    
So our approach is this: for packages where we want to show a build log, we dump those first, in full, each with a header to indicate which package it is, log file name (for later reference), plus any extra detail we have from the phase of the failure or the exception. Then after all build logs we end with a short summary of the failure(s). For packages where we do not show a build log (e.g. local packages that dump live to the console) we only present a summary at the end, but we include a little more detail than for the packages that had a build log since this is the only thing we report for them. So we include details of the exception.

The PR starts with a few patches to rename things and rearrange the plumbing to get the info to the right place.