### PR TITLE
Revert "Fix getExecutablePath on *BSD."

### DIFF
--- a/cabal-install/Distribution/Client/Compat/ExecutablePath.hs
+++ b/cabal-install/Distribution/Client/Compat/ExecutablePath.hs
@@ -33,7 +33,6 @@ import Foreign.Marshal.Alloc
 import Foreign.Ptr
 import Foreign.Storable
 import System.Posix.Internals
-import System.Directory
 #endif
 
 -- GHC 7.0.* compatibility. 'System.Posix.Internals' in base-4.3.* doesn't
@@ -175,7 +174,6 @@ getExecutablePath =
             -- If argc > 0 then argv[0] is guaranteed by the standard
             -- to be a pointer to a null-terminated string.
             then peek p_argv >>= peek >>= peekFilePath
-                 >>= canonicalizePath
             else error $ "getExecutablePath: " ++ msg
   where msg = "no OS specific implementation and program name couldn't be " ++
               "found in argv"


### PR DESCRIPTION
Reverts haskell/cabal#3531 (and reopens haskell/cabal#3512)

See also explaination in https://ghc.haskell.org/trac/ghc/ticket/12377#comment:4