### PR TITLE
Implement Caret-style version range operator

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -107,6 +107,7 @@ extra-source-files:
   tests/PackageTests/CMain/Bar.hs
   tests/PackageTests/CMain/foo.c
   tests/PackageTests/CMain/my.cabal
+  tests/PackageTests/CaretOperator/my.cabal
   tests/PackageTests/Configure/A.hs
   tests/PackageTests/Configure/Setup.hs
   tests/PackageTests/Configure/include/HsZlibConfig.h.in
@@ -467,6 +468,7 @@ test-suite package-tests
     PackageTests.AutogenModules.Package.Check
     PackageTests.AutogenModules.SrcDist.Check
     PackageTests.BenchmarkStanza.Check
+    PackageTests.CaretOperator.Check
     PackageTests.TestStanza.Check
     PackageTests.DeterministicAr.Check
     PackageTests.TestSuiteTests.ExeV10.Check

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -76,6 +76,7 @@
 	* Respect the environment variables 'GHC_PACKAGE_PATH' and
 	'GHCJS_PACKAGE_PATH', lifting the restriction that they be unset.
 	(#3728,#2711).
+	* Add support for new caret-style version range operator `^>=` (#3705)
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* Support GHC 8.

--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -1337,20 +1337,38 @@ for these fields.
     library
       build-depends:
         base >= 2,
-        foo >= 1.2 && < 1.3,
+        foo >= 1.2.3 && < 1.3,
         bar
     ~~~~~~~~~~~~~~~~
 
-    Dependencies like `foo >= 1.2 && < 1.3` turn out to be very common
+    Dependencies like `foo >= 1.2.3 && < 1.3` turn out to be very common
     because it is recommended practise for package versions to
-    correspond to API versions. As of Cabal 1.6, there is a special
-    syntax to support this use:
+    correspond to API versions (see [PVP][]).
+
+    Since Cabal 1.6, there is a special wildcard syntax to help with such ranges
 
     ~~~~~~~~~~~~~~~~
     build-depends: foo ==1.2.*
     ~~~~~~~~~~~~~~~~
 
     It is only syntactic sugar. It is exactly equivalent to `foo >= 1.2 && < 1.3`.
+
+    Starting with Cabal 2.0, there's a new syntactic sugar to
+    support [PVP][]-style major upper bounds conveniently, and is
+    inspired by similiar syntactic sugar found in other language
+    ecosystems where it's often called the "Caret" operator:
+
+    ~~~~~~~~~~~~~~~~
+    build-depends: foo ^>= 1.2.3.4,
+                   bar ^>= 1
+    ~~~~~~~~~~~~~~~~
+
+    The declaration above is exactly equivalent to
+
+    ~~~~~~~~~~~~~~~~
+    build-depends: foo >= 1.2.3.4 && < 1.3,
+                   bar >= 1 && < 1.1
+    ~~~~~~~~~~~~~~~~
 
     Note: Prior to Cabal 1.8, `build-depends` specified in each section
     were global to all sections. This was unintentional, but some packages

--- a/Cabal/tests/PackageTests/CaretOperator/Check.hs
+++ b/Cabal/tests/PackageTests/CaretOperator/Check.hs
@@ -1,0 +1,34 @@
+module PackageTests.CaretOperator.Check where
+
+import PackageTests.PackageTester
+
+import Distribution.Version
+import Distribution.Simple.LocalBuildInfo
+import Distribution.Package
+import Distribution.PackageDescription
+import Language.Haskell.Extension (Language(..))
+
+
+suite :: TestM ()
+suite = do
+    assertOutputDoesNotContain "Parse of field 'build-depends' failed"
+        =<< cabal' "configure" []
+    dist_dir <- distDir
+    lbi <- liftIO $ getPersistBuildConfig dist_dir
+
+    let anticipatedLib = emptyLibrary
+           { libBuildInfo = emptyBuildInfo
+               { defaultLanguage = Just Haskell2010
+               , targetBuildDepends =
+                     [ Dependency (PackageName{unPackageName = "base"})
+                       (withinVersion (Version [4] []))
+                     , Dependency (PackageName{unPackageName = "pretty"})
+                       (majorBoundVersion (Version [1,1,1,0] []))
+                     ]
+               , hsSourceDirs = ["."]
+               }
+           }
+        Just gotLib = library (localPkgDescr lbi)
+    assertEqual "parsed library component does not match anticipated"
+                            anticipatedLib gotLib
+    return ()

--- a/Cabal/tests/PackageTests/CaretOperator/my.cabal
+++ b/Cabal/tests/PackageTests/CaretOperator/my.cabal
@@ -1,0 +1,15 @@
+name: CaretOperator
+version: 0
+license: BSD3
+author: HVR
+category: PackageTests
+build-type: Simple
+cabal-version: >= 1.25
+
+description:
+    Check that Cabal recognizes the caret operator
+
+Library
+    default-language: Haskell2010
+    build-depends: base == 4.*
+                 , pretty ^>= 1.1.1.0

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -5,6 +5,7 @@ import PackageTests.PackageTester
 import qualified PackageTests.AutogenModules.Package.Check
 import qualified PackageTests.AutogenModules.SrcDist.Check
 import qualified PackageTests.BenchmarkStanza.Check
+import qualified PackageTests.CaretOperator.Check
 import qualified PackageTests.TestStanza.Check
 import qualified PackageTests.DeterministicAr.Check
 import qualified PackageTests.TestSuiteTests.ExeV10.Check
@@ -38,6 +39,9 @@ tests config = do
 
   -- Test that Cabal parses 'test' sections correctly
   tc "TestStanza"       PackageTests.TestStanza.Check.suite
+
+  -- Test that Cabal parses '^>=' operator correctly
+  tc "CaretOperator"    PackageTests.CaretOperator.Check.suite
 
   -- Test that Cabal determinstically generates object archives
   tc "DeterministicAr"  PackageTests.DeterministicAr.Check.suite

--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -248,6 +248,7 @@ prop_foldVersionRange' range =
                        laterVersion earlierVersion
                        orLaterVersion orEarlierVersion
                        (\v _ -> withinVersion v)
+                       (\v _ -> majorBoundVersion v)
                        unionVersionRanges intersectVersionRanges id
                        range
   where
@@ -655,6 +656,7 @@ prop_parse_disp1 vr =
                         laterVersion earlierVersion
                         orLaterVersion orEarlierVersion
                         (\v _ -> withinVersion v)
+                        (\v _ -> MajorBoundVersion v)
                         unionVersionRanges intersectVersionRanges id
 
     stripParens :: VersionRange -> VersionRange
@@ -713,6 +715,7 @@ displayRaw =
      (\v     -> Disp.text ">=" <> disp v)
      (\v     -> Disp.text "<=" <> disp v)
      (\v _   -> Disp.text "==" <> dispWild v)
+     (\v _   -> Disp.text "^>=" <> disp v)
      (\r1 r2 -> r1 <+> Disp.text "||" <+> r2)
      (\r1 r2 -> r1 <+> Disp.text "&&" <+> r2)
      (\r     -> Disp.parens r) -- parens


### PR DESCRIPTION
This implements a new syntactic sugar: The version range operator
`^>=` which is equivalent to `>=` intersected with an
automatically inferred major upper bound.

This new syntax is only allowed for `cabal-version: >=2.0`, and
allows to describe the most common use of version
bounds more conveniently:

    build-depends: foo ^>= 1.2.3.4,
                   bar ^>= 1

The declaration above is exactly equivalent to

    build-depends: foo >= 1.2.3.4 && < 1.3,
                   bar >= 1 && < 1.1

The `^`-symbol was chosen because it can serve as a mnemonic when the
`>` sign is rotated and interpreted as "less than ceiling"

Moreover, `^` appears to become a quasi-standard to denote morally
equivalent operator that way in other language ecosystems which similiar
to Haskell have adopted semantic versioning:

 - Node: https://nodesource.com/blog/semver-tilde-and-caret/
 - Bower: https://bower.io/docs/api/#install
 - PHP: https://getcomposer.org/doc/articles/versions.md#caret

Ruby, on the other hand, uses a Tilde operator (`~>`) for that
purpose (but with a less robust semantic):

 - https://blog.codeship.com/optimists-guide-pessimistic-library-versioning

And Python is currently planing to use an `~=` operator:

 - https://www.python.org/dev/peps/pep-0440/#compatible-release