### PR TITLE
 Add the new hackage root keys for distribution with cabal (v2)

### DIFF
--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -182,7 +182,7 @@ import Data.Monoid              (Monoid(..))
 import Control.Applicative      (pure, (<$>))
 #endif
 import Control.Exception        (SomeException(..), try)
-import Control.Monad            (when, unless)
+import Control.Monad            (when, unless, void)
 
 -- | Entry point
 --
@@ -1283,7 +1283,7 @@ userConfigAction ucflags extraArgs globalFlags = do
       path       <- configFile
       fileExists <- doesFileExist path
       if (not fileExists || (fileExists && force))
-      then createDefaultConfigFile verbosity path
+      then void $ createDefaultConfigFile verbosity path
       else die $ path ++ " already exists."
     ("diff":_) -> mapM_ putStrLn =<< userConfigDiff globalFlags
     ("update":_) -> userConfigUpdate verbosity globalFlags

--- a/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
@@ -48,7 +48,7 @@ canDetectDifference = bracketTest $ \configFile -> do
     appendFile configFile "verbose: 0\n"
     diff <- userConfigDiff $ globalFlags configFile
     assertBool (unlines $ "Should detect a difference:" : diff) $
-        diff == [ "- verbose: 1", "+ verbose: 0" ]
+        diff == [ "+ verbose: 0" ]
 
 
 canUpdateConfig :: Assertion
@@ -85,7 +85,7 @@ newDefaultConfig = do
     sysTmpDir <- getTemporaryDirectory
     withTempDirectory silent sysTmpDir "cabal-test" $ \tmpDir -> do
         let configFile  = tmpDir </> "tmp.config"
-        createDefaultConfigFile silent configFile
+        _ <- createDefaultConfigFile silent configFile
         exists <- doesFileExist configFile
         assertBool ("Config file should be written to " ++ configFile) exists
 


### PR DESCRIPTION
Update on #3714. Fixes #3710. Two changes:

Firstly, fix the distinction between raw config and effective config. The raw config is what is actually in the config file. The effective config is the raw config plus defaults and other adjustments. Normally we want the effctive config, but commands like config update and diff need to work with raw config. The first patch sorts that out. We need to do that so that we can add more defaults without having those written to the initial config file, or breaking the config update and diff commands.

Secondly, we add new hackage root keys. To simplify bootstrapping the hackage security, clients like cabal-install should ship the root keys. These are the initial root keys. Note that there is crypographic evidence that these are the right keys that any 3rd part can check.

This patch does not yet enable the security by default, though that is easily changed when we're ready. For now one can opt-in by using `secure: True` in the `~/.cabal/config` file.

Note that the server is not yet using these keys, but it will shortly. The new signed root info is currently available from git clone http://code.haskell.org/~duncan/trusted-root-keys/