### PR TITLE
Respect GHC_PACKAGE_PATH

### DIFF
--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -140,6 +140,7 @@ module Distribution.Simple.Utils (
         ordNub,
         ordNubRight,
         safeTail,
+        unintersperse,
         wrapText,
         wrapLine,
   ) where
@@ -1547,3 +1548,11 @@ equating p x y = p x == p y
 
 lowercase :: String -> String
 lowercase = map toLower
+
+unintersperse :: Char -> String -> [String]
+unintersperse mark = unfoldr unintersperse1 where
+  unintersperse1 str
+    | null str = Nothing
+    | otherwise =
+        let (this, rest) = break (== mark) str in
+        Just (this, safeTail rest)

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -73,6 +73,9 @@
 	* Internal 'build-tools' dependencies are now added to PATH
 	  upon invocation of GHC, so that they can be conveniently
 	  used via `-pgmF`. (#1541)
+	* Respect the environment variables 'GHC_PACKAGE_PATH' and
+	'GHCJS_PACKAGE_PATH', lifting the restriction that they be unset.
+	(#3728,#2711).
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* Support GHC 8.


### PR DESCRIPTION
Look for package databases on GHC_PACKAGE_PATH or GHCJS_PACKAGE_PATH as necessary, lifting the restriction that these variables be unset.

Fixes #3728 and #2711.