### PR TITLE
stack.yaml/nix: add required build and test tools

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -43,4 +43,9 @@ extra-deps:
 - zlib-0.6.1.1
 flags: {}
 nix:
-  packages: [zlib, zlib.out]
+  packages:
+  - autoconf
+  - automake
+  - haskellPackages.happy
+  - zlib
+  - zlib.out


### PR DESCRIPTION
Adding more tools for building with Stack on Nix.