### PR TITLE
Fix #3752, don't specify compiler/optimization twice.

### DIFF
--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -898,13 +898,13 @@ legacyPackageConfigFieldDescrs =
           (\v conf -> conf { configConfigurationsFlags = v })
       ]
   . filterFields
-      [ "compiler", "with-compiler", "with-hc-pkg"
+      [ "with-compiler", "with-hc-pkg"
       , "program-prefix", "program-suffix"
       , "library-vanilla", "library-profiling"
       , "shared", "executable-dynamic"
       , "profiling", "executable-profiling"
       , "profiling-detail", "library-profiling-detail"
-      , "optimization", "debug-info", "library-for-ghci", "split-objs"
+      , "library-for-ghci", "split-objs"
       , "executable-stripping", "library-stripping"
       , "tests", "benchmarks"
       , "coverage", "library-coverage"


### PR DESCRIPTION
Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>