### PR TITLE
stubMain now catches exceptions

### DIFF
--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -29,7 +29,8 @@ import Distribution.TestSuite
 import Distribution.Text
 import Distribution.Verbosity
 
-import Control.Exception ( bracket )
+import Control.Exception ( bracket, catch, displayException,
+                           SomeException )
 import System.Directory
     ( createDirectoryIfMissing, doesDirectoryExist, doesFileExist
     , getCurrentDirectory, removeDirectoryRecursive, removeFile
@@ -212,7 +213,12 @@ stubMain :: IO [Test] -> IO ()
 stubMain tests = do
     (f, n) <- fmap read getContents
     dir <- getCurrentDirectory
-    results <- tests >>= stubRunTests
+    let errhandler :: SomeException -> IO TestLogs
+        errhandler e = do
+          return $ TestLog { testName = "Cabal test suite exception",
+                             testOptionsReturned = [],
+                             testResult = Error $ displayException e }
+    results <- ((tests >>= stubRunTests) `catch` errhandler)
     setCurrentDirectory dir
     stubWriteLog f n results
 

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -29,8 +29,7 @@ import Distribution.TestSuite
 import Distribution.Text
 import Distribution.Verbosity
 
-import Control.Exception ( bracket, catch, displayException,
-                           SomeException )
+import Control.Exception ( bracket, catch , SomeException, displayException)
 import System.Directory
     ( createDirectoryIfMissing, doesDirectoryExist, doesFileExist
     , getCurrentDirectory, removeDirectoryRecursive, removeFile
@@ -213,14 +212,14 @@ stubMain :: IO [Test] -> IO ()
 stubMain tests = do
     (f, n) <- fmap read getContents
     dir <- getCurrentDirectory
-    let errhandler :: SomeException -> IO TestLogs
-        errhandler e = do
-          return $ TestLog { testName = "Cabal test suite exception",
-                             testOptionsReturned = [],
-                             testResult = Error $ displayException e }
     results <- ((tests >>= stubRunTests) `catch` errhandler)
     setCurrentDirectory dir
     stubWriteLog f n results
+  where 
+    errhandler :: SomeException -> IO TestLogs
+    errhandler e = return $ TestLog { testName = "Cabal test suite exception",
+                                      testOptionsReturned = [],
+                                      testResult = Error $ displayException e }
 
 -- | The test runner used in library "TestSuite" stub executables.  Runs a list
 -- of 'Test's.  An executable calling this function is meant to be invoked as

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -30,7 +30,6 @@ import Distribution.Text
 import Distribution.Verbosity
 
 import qualified Control.Exception as CE
-import Control.Exception.Base ( throwIO )
 import System.Directory
     ( createDirectoryIfMissing, doesDirectoryExist, doesFileExist
     , getCurrentDirectory, removeDirectoryRecursive, removeFile

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -29,7 +29,7 @@ import Distribution.TestSuite
 import Distribution.Text
 import Distribution.Verbosity
 
-import Control.Exception ( bracket, catch , SomeException, displayException)
+import Control.Exception ( bracket, catch, SomeException )
 import System.Directory
     ( createDirectoryIfMissing, doesDirectoryExist, doesFileExist
     , getCurrentDirectory, removeDirectoryRecursive, removeFile
@@ -212,14 +212,14 @@ stubMain :: IO [Test] -> IO ()
 stubMain tests = do
     (f, n) <- fmap read getContents
     dir <- getCurrentDirectory
-    results <- ((tests >>= stubRunTests) `catch` errhandler)
+    results <- ((tests >>= stubRunTests) `catch` errHandler)
     setCurrentDirectory dir
     stubWriteLog f n results
   where 
-    errhandler :: SomeException -> IO TestLogs
-    errhandler e = return $ TestLog { testName = "Cabal test suite exception",
+    errHandler :: SomeException -> IO TestLogs
+    errHandler e = return $ TestLog { testName = "Cabal test suite exception",
                                       testOptionsReturned = [],
-                                      testResult = Error $ displayException e }
+                                      testResult = Error $ show e }
 
 -- | The test runner used in library "TestSuite" stub executables.  Runs a list
 -- of 'Test's.  An executable calling this function is meant to be invoked as


### PR DESCRIPTION
Currently, when a detailed-0.9 test suite raises an exception, it fails to write its `TestLogs` data to a log file, and cabal experiences a parse error when trying to read it.  This patch adds exception catching code to `Distribution.Simple.Test.LibV09.stubMain`.

Really, there should be another per-test exception handler in `stubRunTests'`.  This one will still be necessary to handle exceptions that occur outside of a test suite, like in the `tests :: IO [Test]` computation.

I think this will fix #1426 