### PR TITLE
Error messages for package locations

### DIFF
--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -603,7 +603,7 @@ renderBadPackageLocationMatch bplm = case bplm of
     BadLocUnexpectedFile pkglocstr ->
         "The package location '" ++ pkglocstr ++ "' is not recognised. The "
      ++ "supported file targets are .cabal files, .tar.gz tarballs or package "
-     ++ "directories (ie directories containing a .cabal file)."
+     ++ "directories (i.e. directories containing a .cabal file)."
     BadLocNonexistantFile pkglocstr ->
         "The package location '" ++ pkglocstr ++ "' does not exist."
     BadLocDirNoCabalFile pkglocstr ->
@@ -839,7 +839,7 @@ renderBadPerPackageCompilerPaths
   (BadPerPackageCompilerPaths ((pkgname, progname) : _)) =
     "The path to the compiler program (or programs used by the compiler) "
  ++ "cannot be specified on a per-package basis in the cabal.project file "
- ++ "(ie setting the '" ++ progname ++ "-location' for package '"
+ ++ "(i.e. setting the '" ++ progname ++ "-location' for package '"
  ++ display pkgname ++ "'). All packages have to use the same compiler, so "
  ++ "specify the path in a global 'program-locations' section."
  --TODO: [nice to have] better format control so we can pretty-print the

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -174,6 +174,7 @@ Extra-Source-Files:
   tests/IntegrationTests2/exception/configure/a.cabal
   tests/IntegrationTests2/exception/no-pkg/empty.in
   tests/IntegrationTests2/exception/no-pkg2/cabal.project
+  tests/IntegrationTests2/exception/bad-config/cabal.project
   tests/IntegrationTests2/regression/3324/cabal.project
   tests/IntegrationTests2/regression/3324/p/P.hs
   tests/IntegrationTests2/regression/3324/p/p.cabal

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -169,12 +169,12 @@ Extra-Source-Files:
   tests/IntegrationTests2/build/setup-simple/A.hs
   tests/IntegrationTests2/build/setup-simple/Setup.hs
   tests/IntegrationTests2/build/setup-simple/a.cabal
+  tests/IntegrationTests2/exception/bad-config/cabal.project
   tests/IntegrationTests2/exception/build/Main.hs
   tests/IntegrationTests2/exception/build/a.cabal
   tests/IntegrationTests2/exception/configure/a.cabal
   tests/IntegrationTests2/exception/no-pkg/empty.in
   tests/IntegrationTests2/exception/no-pkg2/cabal.project
-  tests/IntegrationTests2/exception/bad-config/cabal.project
   tests/IntegrationTests2/regression/3324/cabal.project
   tests/IntegrationTests2/regression/3324/p/P.hs
   tests/IntegrationTests2/regression/3324/p/p.cabal

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -48,6 +48,7 @@ tests config =
   [ testGroup "Exceptions during discovey and planning" $
     [ testCase "no package"  (testExceptionInFindingPackage config)
     , testCase "no package2" (testExceptionInFindingPackage2 config)
+    , testCase "proj conf1"  (testExceptionInProjectConfig config)
     ]
   , testGroup "Exceptions during building (local inplace)" $
     [ testCase "configure"   (testExceptionInConfigureStep config)
@@ -88,6 +89,19 @@ testExceptionInFindingPackage2 config = do
     cleanProject testdir
   where
     testdir = "exception/no-pkg2"
+
+
+testExceptionInProjectConfig :: ProjectConfig -> Assertion
+testExceptionInProjectConfig config = do
+    BadPerPackageCompilerPaths ps <- expectException "BadPerPackageCompilerPaths" $
+      void $ planProject testdir config
+    case ps of
+      [(PackageName "foo","ghc")] -> return ()
+      _ -> assertFailure $ "expected (PackageName \"foo\",\"ghc\"), got "
+                        ++ show ps
+    cleanProject testdir
+  where
+    testdir = "exception/bad-config"
 
 
 testExceptionInConfigureStep :: ProjectConfig -> Assertion

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -83,8 +83,8 @@ testExceptionInFindingPackage2 config = do
     BadPackageLocations locs <- expectException "BadPackageLocations" $
       void $ planProject testdir config
     case locs of
-      [BadLocGlobBadMatches "./" [BadLocDirNoCabalFile "."]] -> return ()
-      _ -> assertFailure $ "expected BadLocGlobBadMatches, got " ++ show locs
+      [BadPackageLocationFile (BadLocDirNoCabalFile ".")] -> return ()
+      _ -> assertFailure $ "expected BadLocDirNoCabalFile, got " ++ show locs
     cleanProject testdir
   where
     testdir = "exception/no-pkg2"

--- a/cabal-install/tests/IntegrationTests2/exception/bad-config/cabal.project
+++ b/cabal-install/tests/IntegrationTests2/exception/bad-config/cabal.project
@@ -1,0 +1,4 @@
+packages:
+
+package foo
+  ghc-location: bar


### PR DESCRIPTION
This is for the "packages: blah/*/" locations in cabal.project files, when they don't match anything or match crazy unrecognised stuff. Previously we just used the derived Show.

Also improve classification of project package problems in a couple cases so we get more accurate helpful error messages in those cases.

Should improve #3636, but that one could be better since it's for the special case of an implicit project file.