### PR TITLE
Update some dependency solver comments

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2116,11 +2116,12 @@ optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg getcc setcc _getig _
       (fmap asBool . getcc)
       (setcc . fmap CountConflicts)
       (yesNoOpt showOrParseArgs)
-  -- TODO: Disabled for now because it does not work as advertised (yet).
+  -- TODO: Disabled for now because it may not be necessary
 {-
   , option [] ["independent-goals"]
       "Treat several goals on the command line as independent. If several goals depend on the same package, different versions can be chosen."
-      getig setig
+      (fmap asBool . getig)
+      (setig . fmap IndependentGoals)
       (yesNoOpt showOrParseArgs)
 -}
   , option [] ["shadow-installed-packages"]

--- a/cabal-install/Distribution/Solver/Modular/Cycles.hs
+++ b/cabal-install/Distribution/Solver/Modular/Cycles.hs
@@ -32,10 +32,9 @@ detectCyclesPhase = cata go
         Nothing     -> Done revDeps
         Just relSet -> Fail relSet CyclicDependencies
 
--- | Given the reverse dependency map from a 'Done' node in the tree, as well
--- as the full conflict set containing all decisions that led to that 'Done'
--- node, check if the solution is cyclic. If it is, return the conflict set
--- containing all decisions that could potentially break the cycle.
+-- | Given the reverse dependency map from a 'Done' node in the tree, check
+-- if the solution is cyclic. If it is, return the conflict set containing
+-- all decisions that could potentially break the cycle.
 findCycles :: RevDepMap -> Maybe (ConflictSet QPN)
 findCycles revDeps =
     case cycles of

--- a/cabal-install/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install/Distribution/Solver/Modular/Explore.hs
@@ -152,8 +152,9 @@ exploreLog enableBj (CountConflicts countConflicts) = cata go
 -- if an unknown package is requested), the initial conflict set becomes the
 -- actual conflict set.
 --
--- - In a situation where we backjump past the current node, the goal reason
--- of the current node will be added to the conflict set.
+-- - In a situation where all of the children's conflict sets contain the
+-- current variable, the goal reason of the current node will be added to the
+-- conflict set.
 --
 avoidSet :: Var QPN -> QGoalReason -> ConflictSet QPN
 avoidSet var gr =

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -173,7 +173,6 @@ tests = [
 
 -- | Combinator to turn on --independent-goals behavior, i.e. solve
 -- for the goals as if we were solving for each goal independently.
--- (This doesn't really work well at the moment, see #2842)
 indep :: SolverTest -> SolverTest
 indep test = test { testIndepGoals = IndependentGoals True }
 


### PR DESCRIPTION
I removed the comments about --independent-goals not being ready, because #2842 was fixed, and @kosmikus said that the other comment was added before setup dependencies were finished.  I tried the option just now, and it seemed to work.  It seems like we don't really need it with new-build, though.