### PR TITLE
Fix #3775.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
@@ -121,9 +121,7 @@ convGPD os arch cinfo strfl pi
     -- by creating a set of package names which are "internal"
     -- and dropping them as we convert.
     ipns = S.fromList $ [ PackageName nm
-                        | (nm, _) <- sub_libs ] ++
-                        [ PackageName nm
-                        | (nm, _) <- exes ]
+                        | (nm, _) <- sub_libs ]
 
     conv :: Mon.Monoid a => Component -> (a -> BuildInfo) ->
             CondTree ConfVar [Dependency] a -> FlaggedDeps Component PN


### PR DESCRIPTION
This commit undoes a change from c0a4860202 that filtered out build-depends
entries that matched the names of executable components.