### PR TITLE
Make default install plan printing more chatty

### DIFF
--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -22,7 +22,7 @@ module Distribution.Simple.Utils (
         die,
         dieWithLocation,
         topHandler, topHandlerWith,
-        warn, notice, setupMessage, info, debug,
+        warn, notice, noticeNoWrap, setupMessage, info, debug,
         debugNoWrap, chattyTry,
         printRawCommandAndArgs, printRawCommandAndArgsAndEnv,
 
@@ -317,6 +317,11 @@ notice :: Verbosity -> String -> IO ()
 notice verbosity msg =
   when (verbosity >= normal) $
     putStr (wrapText msg)
+
+noticeNoWrap :: Verbosity -> String -> IO ()
+noticeNoWrap verbosity msg =
+  when (verbosity >= normal) $
+    putStr msg
 
 setupMessage :: Verbosity -> String -> PackageIdentifier -> IO ()
 setupMessage verbosity msg pkgid =

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -492,8 +492,6 @@ printPlan verbosity
         BuildStatusBuild _ buildreason -> case buildreason of
           BuildReasonDepsRebuilt      -> "dependency rebuilt"
           BuildReasonFilesChanged
-            (MonitoredFileChanged _)  -> "files changed"
-          BuildReasonFilesChanged
             mreason                   -> showMonitorChangedReason mreason
           BuildReasonExtraTargets _   -> "additional components to build"
           BuildReasonEphemeralTargets -> "ephemeral targets"


### PR DESCRIPTION
COMMIT 1:
Now if you cabal new-build -v, it will tell you which file
changed that caused us to rebuild.  This is not a full fix
for #3352 because we still don't output this info by default,
but it's a start.

COMMIT 2:
Make default install plan printing more chatty, fixes #3352.
    
Now it looks something like this by default:
    
```
    In order, the following will be built (use -v for more details):
     - Cabal-1.25.0.0 (test:package-tests) (file Cabal.cabal changed)
     - Cabal-1.25.0.0 (test:unit-tests) (cannot read state cache)
     - cabal-install-1.25.0.0 (exe:cabal, test:integration-tests, test:integration-tests2, test:solver-quickcheck, test:unit-tests) (file tests/UnitTests/Distribution/Solver/Modular/DSL.hs changed)
     - pretty-show-1.6.12 (exe:ppsh) (first run)
```

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>