### PR TITLE
Axe cabalPackageCacheDirectory, use projectConfigCacheDir, fixing #3392

### DIFF
--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -100,7 +100,6 @@ data CabalDirLayout = CabalDirLayout {
        cabalStorePackageDBPath    :: CompilerId -> FilePath,
        cabalStorePackageDB        :: CompilerId -> PackageDB,
 
-       cabalPackageCacheDirectory :: FilePath,
        cabalLogsDirectory         :: FilePath,
        cabalWorldFile             :: FilePath
      }
@@ -161,8 +160,6 @@ defaultCabalDirLayout cabalDir =
 
     cabalStorePackageDB =
       SpecificPackageDB . cabalStorePackageDBPath
-
-    cabalPackageCacheDirectory = cabalDir </> "packages"
 
     cabalLogsDirectory = cabalDir </> "logs"
 

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -75,7 +75,7 @@ import Distribution.Simple.Program
          ( ConfiguredProgram(..) )
 import Distribution.Simple.Setup
          ( Flag(Flag), toFlag, flagToMaybe, flagToList
-         , fromFlag, AllowNewer(..), AllowOlder(..), RelaxDeps(..) )
+         , fromFlag, fromFlagOrDefault, AllowNewer(..), AllowOlder(..), RelaxDeps(..) )
 import Distribution.Client.Setup
          ( defaultSolver, defaultMaxBackjumps, )
 import Distribution.Simple.InstallDirs
@@ -153,18 +153,18 @@ projectConfigWithBuilderRepoContext verbosity BuildTimeSettings{..} =
 -- to the 'BuildTimeSettings'
 --
 projectConfigWithSolverRepoContext :: Verbosity
-                                   -> FilePath
                                    -> ProjectConfigShared
                                    -> ProjectConfigBuildOnly
                                    -> (RepoContext -> IO a) -> IO a
-projectConfigWithSolverRepoContext verbosity downloadCacheRootDir
+projectConfigWithSolverRepoContext verbosity
                                    ProjectConfigShared{..}
                                    ProjectConfigBuildOnly{..} =
     withRepoContext'
       verbosity
       (fromNubList projectConfigRemoteRepos)
       (fromNubList projectConfigLocalRepos)
-      downloadCacheRootDir
+      (fromFlagOrDefault (error "projectConfigWithSolverRepoContext: projectConfigCacheDir")
+                         projectConfigCacheDir)
       (flagToMaybe projectConfigHttpTransport)
       (flagToMaybe projectConfigIgnoreExpiry)
 
@@ -236,8 +236,7 @@ resolveBuildTimeSettings :: Verbosity
                          -> BuildTimeSettings
 resolveBuildTimeSettings verbosity
                          CabalDirLayout {
-                           cabalLogsDirectory,
-                           cabalPackageCacheDirectory
+                           cabalLogsDirectory
                          }
                          ProjectConfigShared {
                            projectConfigRemoteRepos,
@@ -261,7 +260,7 @@ resolveBuildTimeSettings verbosity
     buildSettingKeepTempFiles = fromFlag    projectConfigKeepTempFiles
     buildSettingRemoteRepos   = fromNubList projectConfigRemoteRepos
     buildSettingLocalRepos    = fromNubList projectConfigLocalRepos
-    buildSettingCacheDir      = cabalPackageCacheDirectory
+    buildSettingCacheDir      = fromFlag    projectConfigCacheDir
     buildSettingHttpTransport = flagToMaybe projectConfigHttpTransport
     buildSettingIgnoreExpiry  = fromFlag    projectConfigIgnoreExpiry
     buildSettingReportPlanningFailure

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -281,7 +281,6 @@ rebuildInstallPlan verbosity
                      distProjectCacheDirectory
                    }
                    cabalDirLayout@CabalDirLayout {
-                     cabalPackageCacheDirectory,
                      cabalStoreDirectory,
                      cabalStorePackageDB
                    }
@@ -468,7 +467,7 @@ rebuildInstallPlan verbosity
                    (compiler, platform, progdb)
                    localPackages =
         rerunIfChanged verbosity fileMonitorSolverPlan
-                       (solverSettings, cabalPackageCacheDirectory,
+                       (solverSettings,
                         localPackages, localPackagesEnabledStanzas,
                         compiler, platform, programDbSignature progdb) $ do
 
@@ -496,7 +495,6 @@ rebuildInstallPlan verbosity
       where
         corePackageDbs = [GlobalPackageDB]
         withRepoCtx    = projectConfigWithSolverRepoContext verbosity
-                           cabalPackageCacheDirectory
                            projectConfigShared
                            projectConfigBuildOnly
         solverSettings = resolveSolverSettings projectConfig
@@ -563,7 +561,6 @@ rebuildInstallPlan verbosity
         return (elaboratedPlan, elaboratedShared)
       where
         withRepoCtx = projectConfigWithSolverRepoContext verbosity
-                        cabalPackageCacheDirectory
                         projectConfigShared
                         projectConfigBuildOnly
 


### PR DESCRIPTION
We went through all the trouble of populating projectConfigCacheDir... and then didn't use it. Stop doing something dumb.

I am not sure why the original code did something insane,
which may indicate a lurking bug.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>