### PR TITLE
Deduplicate nodeNeighbors in legacy codepath.

### DIFF
--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -40,6 +40,7 @@ import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PackageFixedDeps
 import Distribution.Solver.Types.SourcePackage
 import Distribution.Compat.Graph (IsNode(..))
+import Distribution.Simple.Utils (ordNub)
 
 import Data.Map (Map)
 import Network.URI (URI(..), URIAuth(..), nullURI)
@@ -118,8 +119,9 @@ instance IsNode (ConfiguredPackage loc) where
     type Key (ConfiguredPackage loc) = UnitId
     nodeKey       = SimpleUnitId . confPkgId
     -- TODO: if we update ConfiguredPackage to support order-only
-    -- dependencies, need to include those here
-    nodeNeighbors = CD.flatDeps . depends
+    -- dependencies, need to include those here.
+    -- NB: have to deduplicate, otherwise the planner gets confused
+    nodeNeighbors = ordNub . CD.flatDeps . depends
 
 instance (Binary loc) => Binary (ConfiguredPackage loc)
 


### PR DESCRIPTION
Prevents us from trying to build a package multiple times,
when we should only build it once.

This is basically 15dd84559f3b957752e97dd7014758b7c17d5657 all
over again, but for the legacy codepath.

Fixes #3721.

CC @tuncer

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>