### PR TITLE
Change default logfile template to use more unique name

### DIFF
--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1124,7 +1124,8 @@ performInstallations verbosity
                  logFileTemplate
       where
         installLogFile' = flagToMaybe $ installLogFile installFlags
-        defaultTemplate = toPathTemplate $ logsDir </> "$pkgid" <.> "log"
+        defaultTemplate = toPathTemplate $
+                            logsDir </> "$compiler" </> "$libname" <.> "log"
 
         -- If the user has specified --remote-build-reporting=detailed, use the
         -- default log file location. If the --build-log option is set, use the

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -296,7 +296,8 @@ resolveBuildTimeSettings verbosity
       | otherwise          = fmap  substLogFileName givenTemplate
 
     defaultTemplate = toPathTemplate $
-                        cabalLogsDirectory </> "$pkgid" <.> "log"
+                        cabalLogsDirectory </>
+                        "$compiler" </> "$libname" <.> "log"
     givenTemplate   = flagToMaybe projectConfigLogFile
 
     useDefaultTemplate

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -20,6 +20,8 @@
 	* The '-v/--verbosity' option no longer affects GHC verbosity
 	(except in the case of '-v0'). Use '--ghc-options=-v' to enable
 	verbose GHC output (#3540, #3671).
+	* Changed the default logfile template from
+	'.../$pkgid.log' to '.../$compiler/$libname.log' (#3807).
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* If there are multiple remote repos, 'cabal update' now updates


### PR DESCRIPTION
Specifically, this changes the default from `.../$pkgid.log`
to `.../$compiler/$libname.log`, which avoids logfiles overwriting
each other even though theyty refer to different artifacts, as well
as aligning the format with `~/.cabal/store`'s structure.

This addresses #3807