### PR TITLE
Use platform independant isRelative.

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -1903,25 +1903,3 @@ fileExtensionSupportedLanguage path =
     extension = takeExtension path
     isHaskell = extension `elem` [".hs", ".lhs"]
     isC       = isJust (filenameCDialect extension)
-
--- Don't use System.FilePath.isRelative. The System.FilePath exists in two
--- versions, Windows and Posix. The two versions don't agree on what is a
--- relative path and we don't know if we're given Windows or Posix paths.
--- This results in false positives when running on Posix and inspecting Windows
--- paths, like the hackage server does.
-isRelative :: FilePath -> Bool
-isRelative = not . isAbsolute
-
--- | Platform independent heuristic. Why we don't use the filepath package;
--- System.FilePath.Posix.isAbsolute \"C:\\hello\" == False
--- System.FilePath.Windows.isAbsolute \"/hello\" == False
--- This means that we would treat paths that start with \"/\" to be absolute.
--- On Posix they are indeed absolute, while on Windows they are not.
-isAbsolute :: FilePath -> Bool
--- C:\\
-isAbsolute (drive:':':'\\':_) = isAlpha drive
--- UNC
-isAbsolute ('\\':'\\':_) = True
--- Posix root
-isAbsolute ('/':_) = True
-isAbsolute _ = False

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -113,7 +113,7 @@ import Numeric ( showIntAtBase )
 import System.Directory
     ( doesFileExist, createDirectoryIfMissing, getTemporaryDirectory )
 import System.FilePath
-    ( (</>), isAbsolute )
+    ( (</>) )
 import qualified System.Info
     ( compilerName, compilerVersion )
 import System.IO

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -94,7 +94,7 @@ import System.Directory
          , canonicalizePath, removeFile )
 import System.FilePath          ( (</>), (<.>), takeExtension
                                 , takeDirectory, replaceExtension
-                                , isRelative, searchPathSeparator )
+                                , searchPathSeparator )
 import qualified System.Info
 
 -- -----------------------------------------------------------------------------

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -57,8 +57,7 @@ import Distribution.Compat.Semigroup (All (..), Any (..))
 import Data.Either      ( rights )
 
 import System.Directory (doesFileExist)
-import System.FilePath  ( (</>), (<.>)
-                        , normalise, splitPath, joinPath, isAbsolute )
+import System.FilePath  ( (</>), (<.>), normalise, splitPath, joinPath )
 import System.IO        (hClose, hPutStr, hPutStrLn, hSetEncoding, utf8)
 
 -- ------------------------------------------------------------------------------

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -29,7 +29,7 @@ import Distribution.Simple.BuildPaths (haddockName, haddockPref)
 import Distribution.Simple.Utils
          ( createDirectoryIfMissingVerbose
          , installDirectoryContents, installOrdinaryFile, isInSearchPath
-         , die, info, notice, warn, matchDirFileGlob )
+         , die, info, notice, warn, matchDirFileGlob, isRelative )
 import Distribution.Simple.Compiler
          ( CompilerFlavor(..), compilerFlavor )
 import Distribution.Simple.Setup
@@ -47,7 +47,7 @@ import Distribution.Compat.Graph (IsNode(..))
 import System.Directory
          ( doesDirectoryExist, doesFileExist )
 import System.FilePath
-         ( takeFileName, takeDirectory, (</>), isAbsolute )
+         ( takeFileName, takeDirectory, (</>) )
 
 import Distribution.Verbosity
 import Distribution.Text
@@ -241,7 +241,7 @@ installDataFiles verbosity pkg_descr destDataDir =
 --
 installIncludeFiles :: Verbosity -> Library -> FilePath -> IO ()
 installIncludeFiles verbosity lib destIncludeDir = do
-    let relincdirs = "." : filter (not.isAbsolute) (includeDirs lbi)
+    let relincdirs = "." : filter isRelative (includeDirs lbi)
         lbi = libBuildInfo lib
     incs <- traverse (findInc relincdirs) (installIncludes lbi)
     sequence_

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -75,7 +75,7 @@ import Distribution.Text
 import Distribution.Verbosity as Verbosity
 import Distribution.Compat.Graph (IsNode(nodeKey))
 
-import System.FilePath ((</>), (<.>), isAbsolute)
+import System.FilePath ((</>), (<.>))
 import System.Directory
 
 import Data.Version

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -63,8 +63,7 @@ import qualified Data.Map as Map
 import Data.Time (UTCTime, getCurrentTime, toGregorian, utctDay)
 import System.Directory ( doesFileExist )
 import System.IO (IOMode(WriteMode), hPutStrLn, withFile)
-import System.FilePath
-         ( (</>), (<.>), dropExtension, isAbsolute )
+import System.FilePath ((</>), (<.>), dropExtension)
 
 -- |Create a source distribution.
 sdist :: PackageDescription     -- ^information from the tarball
@@ -217,7 +216,7 @@ listPackageSourcesOrdinary verbosity pkg_descr pps =
   , fmap concat
     . withAllLib $ \ l -> do
        let lbi = libBuildInfo l
-           relincdirs = "." : filter (not.isAbsolute) (includeDirs lbi)
+           relincdirs = "." : filter isRelative (includeDirs lbi)
        traverse (fmap snd . findIncludeFile relincdirs) (installIncludes lbi)
 
     -- Setup script, if it exists.

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -1581,7 +1581,7 @@ unintersperse mark = unfoldr unintersperse1 where
 -- This means that we would treat paths that start with \"/\" to be absolute.
 -- On Posix they are indeed absolute, while on Windows they are not.
 isAbsolute :: FilePath -> Bool
--- C:\\
+-- C:\\directory
 isAbsolute (drive:':':'\\':_) = isAlpha drive
 -- UNC
 isAbsolute ('\\':'\\':_) = True

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -143,6 +143,10 @@ module Distribution.Simple.Utils (
         unintersperse,
         wrapText,
         wrapLine,
+
+        -- * FilePath stuff
+        isAbsolute,
+        isRelative,
   ) where
 
 import Prelude ()
@@ -1561,3 +1565,30 @@ unintersperse mark = unfoldr unintersperse1 where
     | otherwise =
         let (this, rest) = break (== mark) str in
         Just (this, safeTail rest)
+
+-- ------------------------------------------------------------
+-- * FilePath stuff
+-- ------------------------------------------------------------
+
+-- | 'isAbsolute' and 'isRelative' has platform independent heuristic.
+-- The System.FilePath exists in two versions, Windows and Posix. The two
+-- versions don't agree on what is a relative path and we don't know if we're
+-- given Windows or Posix paths.
+-- This results in false positives when running on Posix and inspecting
+-- Windows paths, like the hackage server does.
+-- System.FilePath.Posix.isAbsolute \"C:\\hello\" == False
+-- System.FilePath.Windows.isAbsolute \"/hello\" == False
+-- This means that we would treat paths that start with \"/\" to be absolute.
+-- On Posix they are indeed absolute, while on Windows they are not.
+isAbsolute :: FilePath -> Bool
+-- C:\\
+isAbsolute (drive:':':'\\':_) = isAlpha drive
+-- UNC
+isAbsolute ('\\':'\\':_) = True
+-- Posix root
+isAbsolute ('/':_) = True
+isAbsolute _ = False
+
+-- | @isRelative = not . 'isAbsolute'@
+isRelative :: FilePath -> Bool
+isRelative = not . isAbsolute


### PR DESCRIPTION
We can't use the one from System.FilePath since we don't know if we're
dealing with Windows or Posix paths. See comments in code for more
detail.

This was discovered while working on haskell/hackage-server#533.