### PR TITLE
Compute profiling/shared based on library deps only.

### DIFF
--- a/cabal-install/Distribution/Client/SolverInstallPlan.hs
+++ b/cabal-install/Distribution/Client/SolverInstallPlan.hs
@@ -25,6 +25,7 @@ module Distribution.Client.SolverInstallPlan(
   -- * Operations on 'SolverInstallPlan's
   new,
   toList,
+  toMap,
 
   remove,
 
@@ -142,6 +143,9 @@ new indepGoals index =
 
 toList :: SolverInstallPlan -> [SolverPlanPackage]
 toList = Graph.toList . planIndex
+
+toMap :: SolverInstallPlan -> Map SolverId SolverPlanPackage
+toMap = Graph.toMap . planIndex
 
 -- | Remove packages from the install plan. This will result in an
 -- error if there are remaining packages that depend on any matching


### PR DESCRIPTION
Previously we'd build Cabal and custom setup dependencies
with profiling even though it wasn't necessary. Using a
refined dependency graph fixes the problem.

If looking at a Graph with different set of neighbors becomes
a common op, maybe we should add some functions to handle
this specific case.

Fixes #3789.
