### PR TITLE
Implement cabal new-build --only-dependencies

### DIFF
--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -76,7 +76,17 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
         , installFlags, haddockFlags )
         PreBuildHooks {
           hookPrePlanning      = \_ _ _ -> return (),
-          hookSelectPlanSubset = selectBuildTargets userTargets
+
+          hookSelectPlanSubset = \buildSettings elaboratedPlan -> do
+            -- Interpret the targets on the command line as build targets
+            -- (as opposed to say repl or haddock targets).
+            selectTargets
+              verbosity
+              BuildDefaultComponents
+              BuildSpecificComponent
+              userTargets
+              (buildSettingOnlyDeps buildSettings)
+              elaboratedPlan
         }
 
     printPlan verbosity buildCtx
@@ -86,12 +96,4 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
       reportBuildFailures verbosity elaboratedPlan buildResults
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
-
-    -- When we interpret the targets on the command line, interpret them as
-    -- repl targets (as opposed to say repl or haddock targets).
-    selectBuildTargets =
-      selectTargets
-        verbosity
-        BuildDefaultComponents
-        BuildSpecificComponent
 

--- a/cabal-install/Distribution/Client/CmdConfigure.hs
+++ b/cabal-install/Distribution/Client/CmdConfigure.hs
@@ -63,7 +63,7 @@ configureAction (configFlags, configExFlags, installFlags, haddockFlags)
             -- planning phase.
             writeProjectLocalExtraConfig projectRootDir cliConfig,
 
-          hookSelectPlanSubset = return
+          hookSelectPlanSubset = \_ -> return
         }
 
     --TODO: Hmm, but we don't have any targets. Currently this prints what we

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -86,7 +86,7 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags)
               ReplDefaultComponent
               ReplSpecificComponent
               userTargets
-              False -- onlyDepencencies, always False for repl
+              False -- onlyDependencies, always False for repl
               elaboratedPlan
             --TODO: [required eventually] reject multiple targets, or at least
             -- targets spanning multiple components. ie it's ok to have two

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -25,12 +25,12 @@ import Distribution.Simple.Setup
 import Distribution.Verbosity
          ( normal )
 
-import Control.Monad (unless)
+import Control.Monad (when, unless)
 
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
 import Distribution.Simple.Utils
-         ( wrapText )
+         ( wrapText, die )
 import qualified Distribution.Client.Setup as Client
 
 replCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags)
@@ -73,7 +73,25 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags)
         , installFlags, haddockFlags )
         PreBuildHooks {
           hookPrePlanning      = \_ _ _ -> return (),
-          hookSelectPlanSubset = selectReplTargets userTargets
+
+          hookSelectPlanSubset = \buildSettings elaboratedPlan -> do
+            when (buildSettingOnlyDeps buildSettings) $
+              die $ "The repl command does not support '--only-dependencies'. "
+                 ++ "You may wish to use 'build --only-dependencies' and then "
+                 ++ "use 'repl'."
+            -- Interpret the targets on the command line as repl targets
+            -- (as opposed to say build or haddock targets).
+            selectTargets
+              verbosity
+              ReplDefaultComponent
+              ReplSpecificComponent
+              userTargets
+              False -- onlyDepencencies, always False for repl
+              elaboratedPlan
+            --TODO: [required eventually] reject multiple targets, or at least
+            -- targets spanning multiple components. ie it's ok to have two
+            -- module/file targets in the same component, but not two that live
+            -- in different components.
         }
 
     printPlan verbosity buildCtx
@@ -83,12 +101,4 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags)
       reportBuildFailures verbosity elaboratedPlan buildResults
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
-
-    -- When we interpret the targets on the command line, interpret them as
-    -- repl targets (as opposed to say build or haddock targets).
-    selectReplTargets =
-      selectTargets
-        verbosity
-        ReplDefaultComponent
-        ReplSpecificComponent
 

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -311,7 +311,7 @@ lookup :: (IsUnit ipkg, IsUnit srcpkg)
        -> Maybe (GenericPlanPackage ipkg srcpkg)
 lookup plan pkgid = Graph.lookup pkgid (planIndex plan)
 
--- | Find all the direct depencencies of the given package.
+-- | Find all the direct dependencies of the given package.
 --
 -- Note that the package must exist in the plan or it is an error.
 --
@@ -323,7 +323,7 @@ directDeps plan pkgid =
     Just deps -> deps
     Nothing   -> internalError "directDeps: package not in graph"
 
--- | Find all the direct reverse depencencies of the given package.
+-- | Find all the direct reverse dependencies of the given package.
 --
 -- Note that the package must exist in the plan or it is an error.
 --
@@ -342,7 +342,7 @@ revDirectDeps plan pkgid =
 
 
 -- | Return all the packages in the 'InstallPlan' in reverse topological order.
--- That is, for each package, all depencencies of the package appear first.
+-- That is, for each package, all dependencies of the package appear first.
 --
 -- Compared to 'executionOrder', this function returns all the installed and
 -- source packages rather than just the source ones. Also, while both this

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -194,7 +194,7 @@ data BuildStatusRebuild =
    | BuildStatusBuild (Maybe (Maybe InstalledPackageInfo)) BuildReason
 
 data BuildReason =
-     -- | The depencencies of this package have been (re)built so the build
+     -- | The dependencies of this package have been (re)built so the build
      -- phase needs to be rerun.
      --
      -- The optional registration info here tells us if we've registered the
@@ -325,10 +325,10 @@ rebuildTargetsDryRun verbosity distDirLayout@DistDirLayout{..} shared = \install
 -- | A specialised traversal over the packages in an install plan.
 --
 -- The packages are visited in dependency order, starting with packages with no
--- depencencies. The result for each package is accumulated into a 'Map' and
+-- dependencies. The result for each package is accumulated into a 'Map' and
 -- returned as the final result. In addition, when visting a package, the
 -- visiting function is passed the results for all the immediate package
--- depencencies. This can be used to propagate information from depencencies.
+-- dependencies. This can be used to propagate information from dependencies.
 --
 foldMInstallPlanDepOrder
   :: forall m ipkg srcpkg b.
@@ -480,7 +480,7 @@ checkPackageFileMonitorChanged PackageFileMonitor{..}
       MonitorUnchanged () _
           -- The configChanged here includes the identity of the dependencies,
           -- so depsBuildStatus is just needed for the changes in the content
-          -- of depencencies.
+          -- of dependencies.
         | any buildStatusRequiresBuild depsBuildStatus -> do
             regChanged <- checkFileMonitorChanged pkgFileMonitorReg srcdir ()
             let mreg = changedToMaybe regChanged

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -273,7 +273,7 @@ selectTargets :: Verbosity -> PackageTarget
               -> ElaboratedInstallPlan
               -> IO ElaboratedInstallPlan
 selectTargets verbosity targetDefaultComponents targetSpecificComponent
-              userBuildTargets onlyDepencencies installPlan = do
+              userBuildTargets onlyDependencies installPlan = do
 
     -- Match the user targets against the available targets. If no targets are
     -- given this uses the package in the current directory, if any.
@@ -306,7 +306,7 @@ selectTargets verbosity targetDefaultComponents targetSpecificComponent
     --
     let installPlan' = pruneInstallPlanToTargets
                          buildTargets' installPlan
-    if onlyDepencencies
+    if onlyDependencies
       then either throwIO return $
              pruneInstallPlanToDependencies
                (Map.keysSet buildTargets') installPlan'

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -77,7 +77,6 @@ import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PkgConfigDb
 import           Distribution.Solver.Types.ResolverPackage
-import           Distribution.Solver.Types.Settings
 import           Distribution.Solver.Types.SolverId
 import           Distribution.Solver.Types.SolverPackage
 import           Distribution.Solver.Types.InstSolverPackage
@@ -1722,13 +1721,14 @@ elabBuildTargetWholeComponents elab =
 --
 pruneInstallPlanToTargets :: Map UnitId [PackageTarget]
                           -> ElaboratedInstallPlan -> ElaboratedInstallPlan
-pruneInstallPlanToTargets perPkgTargetsMap =
-    InstallPlan.new (IndependentGoals False)
+pruneInstallPlanToTargets perPkgTargetsMap elaboratedPlan =
+    InstallPlan.new (InstallPlan.planIndepGoals elaboratedPlan)
   . Graph.fromList
     -- We have to do this in two passes
   . pruneInstallPlanPass2
   . pruneInstallPlanPass1 perPkgTargetsMap
   . InstallPlan.toList
+  $ elaboratedPlan
 
 -- | This is a temporary data type, where we temporarily
 -- override the graph dependencies of an 'ElaboratedPackage',

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -333,7 +333,7 @@ preferBaseGoalChoice = trav go
     isBase _                       = False
 
 -- | Deal with setup dependencies after regular dependencies, so that we can
--- will link setup depencencies against package dependencies when possible
+-- will link setup dependencies against package dependencies when possible
 deferSetupChoices :: Tree a -> Tree a
 deferSetupChoices = trav go
   where

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -487,6 +487,8 @@ Test-Suite unit-tests
   else
     build-depends: unix
 
+  ghc-options: -fno-ignore-asserts
+
   if !(arch(arm) && impl(ghc < 7.6))
     ghc-options: -threaded
 
@@ -505,7 +507,7 @@ Test-Suite solver-quickcheck
   type: exitcode-stdio-1.0
   main-is: SolverQuickCheck.hs
   hs-source-dirs: tests, .
-  ghc-options: -Wall -fwarn-tabs
+  ghc-options: -Wall -fwarn-tabs -fno-ignore-asserts
   other-modules:
     UnitTests.Distribution.Solver.Modular.DSL
     UnitTests.Distribution.Solver.Modular.QuickCheck
@@ -589,7 +591,7 @@ test-suite integration-tests
   if !(arch(arm) && impl(ghc < 7.6))
     ghc-options: -threaded
 
-  ghc-options: -Wall
+  ghc-options: -Wall -fwarn-tabs -fno-ignore-asserts
   default-language: Haskell2010
 
 -- Integration tests that use the cabal-install code directly

--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,7 @@ packages: Cabal/ cabal-install/
 
 -- Uncomment to allow picking up extra local unpacked deps:
 --optional-packages: */
+
+program-options
+  -- So us hackers get all the assertion failures early:
+  ghc-options: -fno-ignore-asserts


### PR DESCRIPTION
The flag was already there, this just hooks it up with the logic.

It works in the obvious way given how new-build works. That is, it does not affect solving, it's just a matter of changing what bits we chose to build, much like the logic for selecting which bits of the install plan to execute based on the targets to build.

The difference from pruning for the selected targets (which is just taking a dep closure) is that for `--only-dependencies` it does not always make sense so it can fail. The logic for this already existed in the old `cabal install` code path, so this just ports it over. It's a little different since it works on the `ElaboratedInstallPlan` rather than the `SolverInstallPlan`.

If it fails it gives us something like:

    $ cabal new-build --dry network ./hackage-repo-tool/ --dry --only-dependencies
    Cannot select only the dependencies (as requested by the '--only-dependencies'
    flag), the package network-2.6.2.1 is required by a dependency of one of the
    other targets.

I've only lightly tested this but it appears to work. I'm relying on @hvr to test it properly. If anyone would like to contribute some unit tests that'd be nice :-). We'd want one that checks fewer packages are built, and one that checks that the corner case where it cannot work is handled properly (ie throws an exception).