### PR TITLE
Nub build targets, prevent duplicate output of component.

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1936,7 +1936,8 @@ pruneInstallPlanPass2 pkgs =
   where
     setStanzasDepsAndTargets elab =
         elab {
-          elabBuildTargets = elabBuildTargets elab
+          elabBuildTargets = ordNub
+                           $ elabBuildTargets elab
                           ++ libTargetsRequiredForRevDeps
                           ++ exeTargetsRequiredForRevDeps,
           elabPkgOrComp =

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -448,12 +448,12 @@ data PackageTarget =
   deriving (Eq, Show, Generic)
 
 data ComponentTarget = ComponentTarget ComponentName SubComponentTarget
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 data SubComponentTarget = WholeComponent
                         | ModuleTarget ModuleName
                         | FileTarget   FilePath
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance Binary PackageTarget
 instance Binary ComponentTarget


### PR DESCRIPTION
@hvr reported that some component names were being reported
multiple times:

    ezyang@sabre:~/Dev/cabal-tmp$ cabal-shake new-build
    In order, the following will be built (use -v for more details):
     - Cabal-1.25.0.0 (lib) (file Cabal.cabal changed)
     - happy-1.19.5 (exe:happy, exe:happy) (dependency rebuilt)

This is because a build target was showing up multiple times in the
list, which can occur if we simultaneously build-depends and build-tools
on the same package.  So nub it out.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>