### PR TITLE
Add `reconfigure` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ progress.txt
 # test files
 dist-test
 register.sh
+/Cabal/tests/PackageTests/Configure/include/HsZlibConfig.h
+/Cabal/tests/PackageTests/Configure/zlib.buildinfo

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -94,6 +94,8 @@ import Distribution.Utils.NubList
 
 import Distribution.Compat.Semigroup (Last' (..))
 
+import Data.Function (on)
+
 -- FIXME Not sure where this should live
 defaultDistPref :: FilePath
 defaultDistPref = "dist"
@@ -347,6 +349,7 @@ relaxDepsPrinter (Just (RelaxDepsSome pkgs)) = map (Just . display) $ pkgs
 --
 -- IMPORTANT: every time a new flag is added, 'D.C.Setup.filterConfigureFlags'
 -- should be updated.
+-- IMPORTANT: every time a new flag is added, it should be added to the Eq instance
 data ConfigFlags = ConfigFlags {
     -- This is the same hack as in 'buildArgs' and 'copyArgs'.
     -- TODO: Stop using this eventually when 'UserHooks' gets changed
@@ -432,6 +435,54 @@ instance Binary ConfigFlags
 -- 'error' if internal invariant is violated.
 configPrograms :: ConfigFlags -> ProgramDb
 configPrograms = maybe (error "FIXME: remove configPrograms") id . getLast' . configPrograms_
+
+instance Eq ConfigFlags where
+  (==) a b =
+    -- configPrograms skipped: not user specified, has no Eq instance
+    equal configProgramPaths
+    && equal configProgramArgs
+    && equal configProgramPathExtra
+    && equal configHcFlavor
+    && equal configHcPath
+    && equal configHcPkg
+    && equal configVanillaLib
+    && equal configProfLib
+    && equal configSharedLib
+    && equal configDynExe
+    && equal configProfExe
+    && equal configProf
+    && equal configProfDetail
+    && equal configProfLibDetail
+    && equal configConfigureArgs
+    && equal configOptimization
+    && equal configProgPrefix
+    && equal configProgSuffix
+    && equal configInstallDirs
+    && equal configScratchDir
+    && equal configExtraLibDirs
+    && equal configExtraIncludeDirs
+    && equal configIPID
+    && equal configDistPref
+    && equal configVerbosity
+    && equal configUserInstall
+    && equal configPackageDBs
+    && equal configGHCiLib
+    && equal configSplitObjs
+    && equal configStripExes
+    && equal configStripLibs
+    && equal configConstraints
+    && equal configDependencies
+    && equal configConfigurationsFlags
+    && equal configTests
+    && equal configBenchmarks
+    && equal configCoverage
+    && equal configLibCoverage
+    && equal configExactConfiguration
+    && equal configFlagError
+    && equal configRelocatable
+    && equal configDebugInfo
+    where
+      equal f = on (==) f a b
 
 configAbsolutePaths :: ConfigFlags -> NoCallStackIO ConfigFlags
 configAbsolutePaths f =

--- a/cabal-install/Distribution/Client/Reconfigure.hs
+++ b/cabal-install/Distribution/Client/Reconfigure.hs
@@ -1,0 +1,212 @@
+module Distribution.Client.Reconfigure ( Check(..), reconfigure ) where
+
+import Control.Monad ( unless, when )
+import Data.Monoid hiding ( (<>) )
+import System.Directory ( doesFileExist )
+
+import Distribution.Compat.Semigroup
+
+import Distribution.Verbosity
+
+import Distribution.Simple.Configure ( localBuildInfoFile )
+import Distribution.Simple.Setup ( Flag, flagToMaybe, toFlag )
+import Distribution.Simple.Utils
+       ( existsAndIsMoreRecentThan, defaultPackageDesc, info )
+
+import Distribution.Client.Config ( SavedConfig(..) )
+import Distribution.Client.Configure ( readConfigFlags )
+import Distribution.Client.Sandbox
+       ( WereDepsReinstalled(..), findSavedDistPref, getSandboxConfigFilePath
+       , maybeReinstallAddSourceDeps, updateInstallDirs )
+import Distribution.Client.Sandbox.PackageEnvironment
+       ( userPackageEnvironmentFile )
+import Distribution.Client.Sandbox.Types ( UseSandbox(..) )
+import Distribution.Client.Setup
+       ( ConfigFlags(..), ConfigExFlags, GlobalFlags(..)
+       , SkipAddSourceDepsCheck(..) )
+
+
+-- | @Check@ represents a function to check some condition on type @a@. The
+-- returned 'Any' is 'True' if any part of the condition failed.
+newtype Check a = Check {
+  runCheck :: Any  -- ^ Did any previous check fail?
+           -> a  -- ^ value returned by previous checks
+           -> IO (Any, a)  -- ^ Did this check fail? What value is returned?
+}
+
+instance Semigroup (Check a) where
+  (<>) c d = Check $ \any0 a0 -> do
+    (any1, a1) <- runCheck c any0 a0
+    (any2, a2) <- runCheck d (any0 <> any1) a1
+    return (any0 <> any1 <> any2, a2)
+
+instance Monoid (Check a) where
+  mempty = Check $ \_ a -> return (mempty, a)
+  mappend = (<>)
+
+
+-- | Re-configure the package in the current directory if needed. Deciding
+-- when to reconfigure and with which options is convoluted:
+--
+-- If we are reconfiguring, we must always run @configure@ with the
+-- verbosity option we are given; however, that a previous configuration
+-- uses a different verbosity setting is not reason enough to reconfigure.
+--
+-- The package should be configured to use the same \"dist\" prefix as
+-- given to the @build@ command, otherwise the build will probably
+-- fail. Not only does this determine the \"dist\" prefix setting if we
+-- need to reconfigure anyway, but an existing configuration should be
+-- invalidated if its \"dist\" prefix differs.
+--
+-- If the package has never been configured (i.e., there is no
+-- LocalBuildInfo), we must configure first, using the default options.
+--
+-- If the package has been configured, there will be a 'LocalBuildInfo'.
+-- If there no package description file, we assume that the
+-- 'PackageDescription' is up to date, though the configuration may need
+-- to be updated for other reasons (see above). If there is a package
+-- description file, and it has been modified since the 'LocalBuildInfo'
+-- was generated, then we need to reconfigure.
+--
+-- The caller of this function may also have specific requirements
+-- regarding the flags the last configuration used. For example,
+-- 'testAction' requires that the package be configured with test suites
+-- enabled. The caller may pass the required settings to this function
+-- along with a function to check the validity of the saved 'ConfigFlags';
+-- these required settings will be checked first upon determining that
+-- a previous configuration exists.
+reconfigure
+  :: ((ConfigFlags, ConfigExFlags) -> [String] -> GlobalFlags -> IO ())
+     -- ^ configure action
+  -> Verbosity
+     -- ^ Verbosity setting
+  -> FilePath
+     -- ^ \"dist\" prefix
+  -> UseSandbox
+  -> SkipAddSourceDepsCheck
+     -- ^ Should we skip the timestamp check for modified
+     -- add-source dependencies?
+  -> Flag (Maybe Int)
+     -- ^ -j flag for reinstalling add-source deps.
+  -> Check (ConfigFlags, ConfigExFlags)
+     -- ^ Check that the required flags are set.
+     -- If they are not set, provide a message explaining the
+     -- reason for reconfiguration.
+  -> [String]     -- ^ Extra arguments
+  -> GlobalFlags  -- ^ Global flags
+  -> SavedConfig
+  -> IO SavedConfig
+reconfigure
+  configureAction
+  verbosity
+  dist
+  useSandbox
+  skipAddSourceDepsCheck
+  numJobsFlag
+  check
+  extraArgs
+  globalFlags
+  config
+  = do
+
+  savedFlags@(_, _) <- readConfigFlags dist
+
+  let checks =
+        checkVerb
+        <> checkDist
+        <> checkOutdated
+        <> check
+        <> checkAddSourceDeps
+  (Any force, flags@(configFlags, _)) <- runCheck checks mempty savedFlags
+
+  let (_, config') =
+        updateInstallDirs
+        (configUserInstall configFlags)
+        (useSandbox, config)
+
+  when force $ configureAction flags extraArgs globalFlags
+  return config'
+
+  where
+
+    -- Changing the verbosity does not require reconfiguration, but the new
+    -- verbosity should be used if reconfiguring.
+    checkVerb = Check $ \_ (configFlags, configExFlags) -> do
+      let configFlags' = configFlags { configVerbosity = toFlag verbosity}
+      return (mempty, (configFlags', configExFlags))
+
+    -- Reconfiguration is required if @--build-dir@ changes.
+    checkDist = Check $ \_ (configFlags, configExFlags) -> do
+      -- Always set the chosen @--build-dir@ before saving the flags,
+      -- or bad things could happen.
+      savedDist <- findSavedDistPref config (configDistPref configFlags)
+      let distChanged = dist /= savedDist
+      when distChanged $ info verbosity "build directory changed"
+      let configFlags' = configFlags { configDistPref = toFlag dist }
+      return (Any distChanged, (configFlags', configExFlags))
+
+    checkOutdated = Check $ \_ flags@(configFlags, _) -> do
+      let buildConfig = localBuildInfoFile dist
+
+      -- Has the package ever been configured? If not, reconfiguration is
+      -- required.
+      configured <- doesFileExist buildConfig
+      unless configured $ info verbosity "package has never been configured"
+
+      -- Is the configuration older than the sandbox configuration file?
+      -- If so, reconfiguration is required.
+      sandboxConfig <- getSandboxConfigFilePath globalFlags
+      sandboxConfigNewer <- existsAndIsMoreRecentThan sandboxConfig buildConfig
+      when sandboxConfigNewer $
+        info verbosity "sandbox was created after the package was configured"
+
+      -- Is the @cabal.config@ file newer than @dist/setup.config@? Then we need
+      -- to force reconfigure. Note that it's possible to use @cabal.config@
+      -- even without sandboxes.
+      userPackageEnvironmentFileModified <-
+        existsAndIsMoreRecentThan userPackageEnvironmentFile buildConfig
+      when userPackageEnvironmentFileModified $
+        info verbosity ("user package environment file ('"
+        ++ userPackageEnvironmentFile ++ "') was modified")
+
+      -- Is the configuration older than the package description?
+      descrFile <- maybe (defaultPackageDesc verbosity) return
+                   (flagToMaybe (configCabalFilePath configFlags))
+      outdated <- existsAndIsMoreRecentThan descrFile buildConfig
+      when outdated $ info verbosity (descrFile ++ " was changed")
+
+      let failed =
+            Any outdated
+            <> Any userPackageEnvironmentFileModified
+            <> Any sandboxConfigNewer
+            <> Any (not configured)
+      return (failed, flags)
+
+    checkAddSourceDeps = Check $ \(Any force') flags@(configFlags, _) -> do
+      let (_, config') =
+            updateInstallDirs
+            (configUserInstall configFlags)
+            (useSandbox, config)
+
+          skipAddSourceDepsCheck'
+            | force'    = SkipAddSourceDepsCheck
+            | otherwise = skipAddSourceDepsCheck
+
+      when (skipAddSourceDepsCheck' == SkipAddSourceDepsCheck) $
+        info verbosity "skipping add-source deps check"
+
+      -- Were any add-source dependencies reinstalled in the sandbox?
+      depsReinstalled <-
+        case skipAddSourceDepsCheck' of
+          DontSkipAddSourceDepsCheck ->
+            maybeReinstallAddSourceDeps
+            verbosity numJobsFlag configFlags globalFlags
+            (useSandbox, config')
+          SkipAddSourceDepsCheck -> do
+            return NoDepsReinstalled
+
+      case depsReinstalled of
+        NoDepsReinstalled -> return (mempty, flags)
+        ReinstalledSomeDeps -> do
+          info verbosity "some add-source dependencies were reinstalled"
+          return (Any True, flags)

--- a/cabal-install/Distribution/Client/SavedFlags.hs
+++ b/cabal-install/Distribution/Client/SavedFlags.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Distribution.Client.SavedFlags
+       ( readCommandFlags, writeCommandFlags
+       , readSavedArgs, writeSavedArgs
+       ) where
+
+import Distribution.Simple.Command
+import Distribution.Simple.UserHooks ( Args )
+import Distribution.Simple.Utils
+       ( createDirectoryIfMissingVerbose, unintersperse )
+import Distribution.Verbosity
+
+import Control.Exception ( Exception, throwIO )
+import Control.Monad ( liftM )
+import Data.List ( intercalate )
+import Data.Maybe ( fromMaybe )
+import Data.Typeable
+import System.Directory ( doesFileExist )
+import System.FilePath ( takeDirectory )
+
+
+writeSavedArgs :: Verbosity -> FilePath -> [String] -> IO ()
+writeSavedArgs verbosity path args = do
+  createDirectoryIfMissingVerbose
+    (lessVerbose verbosity) True (takeDirectory path)
+  writeFile path (intercalate "\0" args)
+
+
+-- | Write command-line flags to a file, separated by null characters. This
+-- format is also suitable for the @xargs -0@ command. Using the null
+-- character also avoids the problem of escaping newlines or spaces,
+-- because unlike other whitespace characters, the null character is
+-- not valid in command-line arguments.
+writeCommandFlags :: Verbosity -> FilePath -> CommandUI flags -> flags -> IO ()
+writeCommandFlags verbosity path command flags =
+  writeSavedArgs verbosity path (commandShowOptions command flags)
+
+
+readSavedArgs :: FilePath -> IO (Maybe [String])
+readSavedArgs path = do
+  exists <- doesFileExist path
+  if exists
+     then liftM (Just . unintersperse '\0') (readFile path)
+    else return Nothing
+
+
+-- | Read command-line arguments, separated by null characters, from a file.
+-- Returns the default flags if the file does not exist.
+readCommandFlags :: FilePath -> CommandUI flags -> IO flags
+readCommandFlags path command = do
+  savedArgs <- liftM (fromMaybe []) (readSavedArgs path)
+  case (commandParseArgs command True savedArgs) of
+    CommandHelp _ -> throwIO (SavedArgsErrorHelp savedArgs)
+    CommandList _ -> throwIO (SavedArgsErrorList savedArgs)
+    CommandErrors errs -> throwIO (SavedArgsErrorOther savedArgs errs)
+    CommandReadyToGo (mkFlags, _) ->
+      return (mkFlags (commandDefaultFlags command))
+
+-- -----------------------------------------------------------------------------
+-- * Exceptions
+-- -----------------------------------------------------------------------------
+
+data SavedArgsError
+    = SavedArgsErrorHelp Args
+    | SavedArgsErrorList Args
+    | SavedArgsErrorOther Args [String]
+  deriving (Typeable)
+
+instance Show SavedArgsError where
+  show (SavedArgsErrorHelp args) =
+    "unexpected flag '--help', saved command line was:\n"
+    ++ intercalate " " args
+  show (SavedArgsErrorList args) =
+    "unexpected flag '--list-options', saved command line was:\n"
+    ++ intercalate " " args
+  show (SavedArgsErrorOther args errs) =
+    "saved command line was:\n"
+    ++ intercalate " " args ++ "\n"
+    ++ "encountered errors:\n"
+    ++ intercalate "\n" errs
+
+instance Exception SavedArgsError

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -419,12 +419,15 @@ filterConfigureFlags flags cabalLibVersion
     -- Cabal < 1.3.10 does not grok the '--constraints' flag.
     flags_1_3_10 = flags_1_10_0 { configConstraints = [] }
 
+-- | Get the package database settings from 'ConfigFlags', accounting for
+-- @--package-db@ and @--user@ flags.
 configPackageDB' :: ConfigFlags -> PackageDBStack
 configPackageDB' cfg =
     interpretPackageDbFlags userInstall (configPackageDBs cfg)
   where
     userInstall = Cabal.fromFlagOrDefault True (configUserInstall cfg)
 
+-- | Configure the compiler, but reduce verbosity during this step.
 configCompilerAux' :: ConfigFlags -> IO (Compiler, Platform, ProgramDb)
 configCompilerAux' configFlags =
   configCompilerAuxEx configFlags

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -20,9 +20,9 @@ module Distribution.Client.Setup
     , configureCommand, ConfigFlags(..), filterConfigureFlags
     , configPackageDB', configCompilerAux'
     , configureExCommand, ConfigExFlags(..), defaultConfigExFlags
-                        , configureExOptions
     , buildCommand, BuildFlags(..), BuildExFlags(..), SkipAddSourceDepsCheck(..)
     , replCommand, testCommand, benchmarkCommand
+                        , configureExOptions, reconfigureCommand
     , installCommand, InstallFlags(..), installOptions, defaultInstallFlags
     , defaultSolver, defaultMaxBackjumps
     , listCommand, ListFlags(..)
@@ -498,6 +498,21 @@ instance Monoid ConfigExFlags where
 
 instance Semigroup ConfigExFlags where
   (<>) = gmappend
+
+reconfigureCommand :: CommandUI (ConfigFlags, ConfigExFlags)
+reconfigureCommand
+  = configureExCommand
+    { commandName         = "reconfigure"
+    , commandSynopsis     = "Reconfigure the package if necessary."
+    , commandDescription  = Just $ \pname -> wrapText $
+         "Run `configure` with the most recently used flags and append FLAGS. "
+         ++ "Accepts the same flags as `" ++ pname ++ " configure'. "
+         ++ "If the package has never been configured, this has the same "
+         ++ "effect as calling `configure`."
+    , commandNotes        = Nothing
+    , commandUsage        = usageAlternatives "reconfigure" [ "[FLAGS]" ]
+    , commandDefaultFlags = mempty
+    }
 
 -- ------------------------------------------------------------
 -- * Build flags

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -19,6 +19,7 @@ import Distribution.Client.Setup
          ( GlobalFlags(..), globalCommand, withRepoContext
          , ConfigFlags(..)
          , ConfigExFlags(..), defaultConfigExFlags, configureExCommand
+         , configCompilerAux', configPackageDB'
          , BuildFlags(..), BuildExFlags(..), SkipAddSourceDepsCheck(..)
          , buildCommand, replCommand, testCommand, benchmarkCommand
          , InstallFlags(..), defaultInstallFlags
@@ -107,9 +108,7 @@ import Distribution.Client.Sandbox            (sandboxInit
                                               ,updateSandboxConfigFileFlag
                                               ,updateInstallDirs
 
-                                              ,configCompilerAux'
-                                              ,getPersistOrConfigCompiler
-                                              ,configPackageDB')
+                                              ,getPersistOrConfigCompiler)
 import Distribution.Client.Sandbox.PackageEnvironment
                                               (setPackageDB
                                               ,userPackageEnvironmentFile)

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -19,6 +19,7 @@ import Distribution.Client.Setup
          ( GlobalFlags(..), globalCommand, withRepoContext
          , ConfigFlags(..)
          , ConfigExFlags(..), defaultConfigExFlags, configureExCommand
+         , reconfigureCommand
          , configCompilerAux', configPackageDB'
          , BuildFlags(..), BuildExFlags(..), SkipAddSourceDepsCheck(..)
          , buildCommand, replCommand, testCommand, benchmarkCommand
@@ -75,7 +76,7 @@ import qualified Distribution.Client.CmdRepl      as CmdRepl
 import qualified Distribution.Client.CmdFreeze    as CmdFreeze
 
 import Distribution.Client.Install            (install)
-import Distribution.Client.Configure          (configure)
+import Distribution.Client.Configure          (configure, writeConfigFlags)
 import Distribution.Client.Update             (update)
 import Distribution.Client.Exec               (exec)
 import Distribution.Client.Fetch              (fetch)
@@ -87,6 +88,7 @@ import qualified Distribution.Client.Upload as Upload
 import Distribution.Client.Run                (run, splitRunArgs)
 import Distribution.Client.SrcDist            (sdist)
 import Distribution.Client.Get                (get)
+import Distribution.Client.Reconfigure        (Check(..), reconfigure)
 import Distribution.Client.Sandbox            (sandboxInit
                                               ,sandboxAddSource
                                               ,sandboxDelete
@@ -95,23 +97,18 @@ import Distribution.Client.Sandbox            (sandboxInit
                                               ,sandboxHcPkg
                                               ,dumpPackageEnvironment
 
-                                              ,getSandboxConfigFilePath
                                               ,loadConfigOrSandboxConfig
                                               ,findSavedDistPref
                                               ,initPackageDBIfNeeded
                                               ,maybeWithSandboxDirOnSearchPath
                                               ,maybeWithSandboxPackageInfo
-                                              ,WereDepsReinstalled(..)
-                                              ,maybeReinstallAddSourceDeps
                                               ,tryGetIndexFilePath
                                               ,sandboxBuildDir
                                               ,updateSandboxConfigFileFlag
                                               ,updateInstallDirs
 
                                               ,getPersistOrConfigCompiler)
-import Distribution.Client.Sandbox.PackageEnvironment
-                                              (setPackageDB
-                                              ,userPackageEnvironmentFile)
+import Distribution.Client.Sandbox.PackageEnvironment (setPackageDB)
 import Distribution.Client.Sandbox.Timestamp  (maybeAddCompilerTimestampRecord)
 import Distribution.Client.Sandbox.Types      (UseSandbox(..), whenUsingSandbox)
 import Distribution.Client.Tar                (createTarGzFile)
@@ -123,7 +120,7 @@ import Distribution.Client.Utils              (determineNumJobs
 #if defined(mingw32_HOST_OS)
                                               ,relaxEncodingErrors
 #endif
-                                              ,existsAndIsMoreRecentThan)
+                                              )
 
 import Distribution.Package (packageId)
 import Distribution.PackageDescription
@@ -139,13 +136,12 @@ import Distribution.Simple.Build
 import Distribution.Simple.Command
          ( CommandParse(..), CommandUI(..), Command, CommandSpec(..)
          , CommandType(..), commandsRun, commandAddAction, hiddenCommand
-         , commandFromSpec)
-import Distribution.Simple.Compiler
-         ( Compiler(..) )
+         , commandFromSpec, commandShowOptions )
+import Distribution.Simple.Compiler (Compiler(..), PackageDBStack)
 import Distribution.Simple.Configure
-         ( checkPersistBuildConfigOutdated, configCompilerAuxEx
-         , ConfigStateFileError(..), localBuildInfoFile
-         , getPersistBuildConfig, tryGetPersistBuildConfig )
+         ( configCompilerAuxEx, ConfigStateFileError(..)
+         , getPersistBuildConfig, interpretPackageDbFlags
+         , tryGetPersistBuildConfig )
 import qualified Distribution.Simple.LocalBuildInfo as LBI
 import Distribution.Simple.Program (defaultProgramDb
                                    ,configureAllKnownPrograms
@@ -154,7 +150,7 @@ import Distribution.Simple.Program (defaultProgramDb
 import Distribution.Simple.Program.Db (reconfigurePrograms)
 import qualified Distribution.Simple.Setup as Cabal
 import Distribution.Simple.Utils
-         ( cabalVersion, die, notice, info, topHandler
+         ( cabalVersion, die, info, notice, topHandler
          , findPackageDesc, tryFindPackageDesc )
 import Distribution.Text
          ( display )
@@ -180,6 +176,8 @@ import Data.Maybe               (listToMaybe)
 import Data.Monoid              (Monoid(..))
 import Control.Applicative      (pure, (<$>))
 #endif
+import Data.Monoid              (Any(..))
+import Distribution.Compat.Semigroup ((<>))
 import Control.Exception        (SomeException(..), try)
 import Control.Monad            (when, unless)
 
@@ -258,6 +256,7 @@ mainWorker args = topHandler $
       , regularCmd runCommand runAction
       , regularCmd initCommand initAction
       , regularCmd configureExCommand configureAction
+      , regularCmd reconfigureCommand reconfigureAction
       , regularCmd buildCommand buildAction
       , regularCmd replCommand replAction
       , regularCmd sandboxCommand sandboxAction
@@ -326,6 +325,7 @@ configureAction (configFlags, configExFlags) extraArgs globalFlags = do
   (useSandbox, config) <- fmap
                           (updateInstallDirs (configUserInstall configFlags))
                           (loadConfigOrSandboxConfig verbosity globalFlags)
+  distPref <- findSavedDistPref config (configDistPref configFlags)
   let configFlags'   = savedConfigureFlags   config `mappend` configFlags
       configExFlags' = savedConfigureExFlags config `mappend` configExFlags
       globalFlags'   = savedGlobalFlags      config `mappend` globalFlags
@@ -339,6 +339,15 @@ configureAction (configFlags, configExFlags) extraArgs globalFlags = do
         (UseSandbox sandboxDir) -> setPackageDB sandboxDir
                                    comp platform configFlags'
 
+  writeConfigFlags verbosity distPref (configFlags'', configExFlags')
+
+  -- What package database(s) to use
+  let packageDBs :: PackageDBStack
+      packageDBs
+        = interpretPackageDbFlags
+          (fromFlag (configUserInstall configFlags''))
+          (configPackageDBs configFlags'')
+
   whenUsingSandbox useSandbox $ \sandboxDir -> do
     initPackageDBIfNeeded verbosity configFlags'' comp progdb
     -- NOTE: We do not write the new sandbox package DB location to
@@ -351,10 +360,32 @@ configureAction (configFlags, configExFlags) extraArgs globalFlags = do
 
   maybeWithSandboxDirOnSearchPath useSandbox $
    withRepoContext verbosity globalFlags' $ \repoContext ->
-    configure verbosity
-              (configPackageDB' configFlags'')
-              repoContext
+    configure verbosity packageDBs repoContext
               comp platform progdb configFlags'' configExFlags' extraArgs
+
+reconfigureAction :: (ConfigFlags, ConfigExFlags)
+                  -> [String] -> Action
+reconfigureAction flags _ globalFlags = do
+  let (configFlags, _) = flags
+      verbosity = fromFlag (configVerbosity configFlags)
+  (useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags
+  dist <- findSavedDistPref config (configDistPref configFlags)
+  let checkFlags = Check $ \_ saved -> do
+        let flags' = saved <> flags
+        unless (saved == flags') $ info verbosity message
+        pure (Any True, flags')
+        where
+          -- This message is correct, but not very specific: it will list all
+          -- of the new flags, even if some have not actually changed. The
+          -- *minimal* set of changes is more difficult to determine.
+          message =
+            "flags changed: "
+            ++ unwords (commandShowOptions configureExCommand flags)
+  _ <-
+    reconfigure configureAction
+    verbosity dist useSandbox DontSkipAddSourceDepsCheck NoFlag
+    checkFlags [] globalFlags config
+  pure ()
 
 buildAction :: (BuildFlags, BuildExFlags) -> [String] -> Action
 buildAction (buildFlags, buildExFlags) extraArgs globalFlags = do
@@ -362,15 +393,19 @@ buildAction (buildFlags, buildExFlags) extraArgs globalFlags = do
       noAddSource = fromFlagOrDefault DontSkipAddSourceDepsCheck
                     (buildOnly buildExFlags)
 
+  (useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags
+  distPref <- findSavedDistPref config (buildDistPref buildFlags)
+
   -- Calls 'configureAction' to do the real work, so nothing special has to be
   -- done to support sandboxes.
-  (useSandbox, config, distPref) <- reconfigure verbosity
-                                    (buildDistPref buildFlags)
-                                    mempty [] globalFlags noAddSource
-                                    (buildNumJobs buildFlags) (const Nothing)
+  config' <-
+    reconfigure configureAction
+    verbosity distPref useSandbox noAddSource (buildNumJobs buildFlags)
+    mempty [] globalFlags config
+
 
   maybeWithSandboxDirOnSearchPath useSandbox $
-    build verbosity config distPref buildFlags extraArgs
+    build verbosity config' distPref buildFlags extraArgs
 
 
 -- | Actually do the work of building the package. This is separate from
@@ -425,13 +460,16 @@ replAction (replFlags, buildExFlags) extraArgs globalFlags = do
             Flag True -> SkipAddSourceDepsCheck
             _         -> fromFlagOrDefault DontSkipAddSourceDepsCheck
                          (buildOnly buildExFlags)
+      (useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags
+      distPref <- findSavedDistPref config (replDistPref replFlags)
+
       -- Calls 'configureAction' to do the real work, so nothing special has to
       -- be done to support sandboxes.
-      (useSandbox, _config, distPref) <-
-        reconfigure verbosity (replDistPref replFlags)
-                    mempty [] globalFlags noAddSource NoFlag
-                    (const Nothing)
-      let progDb       = defaultProgramDb
+      _ <-
+        reconfigure configureAction
+        verbosity distPref useSandbox noAddSource NoFlag
+        mempty [] globalFlags config
+      let progDb = defaultProgramDb
           setupOptions = defaultSetupScriptOptions
             { useCabalVersion = orLaterVersion $ Version [1,18,0] []
             , useDistPref     = distPref
@@ -457,239 +495,6 @@ replAction (replFlags, buildExFlags) extraArgs globalFlags = do
                                         programDb
       startInterpreter verbosity programDb' comp platform
                        (configPackageDB' configFlags)
-
--- | Re-configure the package in the current directory if needed. Deciding
--- when to reconfigure and with which options is convoluted:
---
--- If we are reconfiguring, we must always run @configure@ with the
--- verbosity option we are given; however, that a previous configuration
--- uses a different verbosity setting is not reason enough to reconfigure.
---
--- The package should be configured to use the same \"dist\" prefix as
--- given to the @build@ command, otherwise the build will probably
--- fail. Not only does this determine the \"dist\" prefix setting if we
--- need to reconfigure anyway, but an existing configuration should be
--- invalidated if its \"dist\" prefix differs.
---
--- If the package has never been configured (i.e., there is no
--- LocalBuildInfo), we must configure first, using the default options.
---
--- If the package has been configured, there will be a 'LocalBuildInfo'.
--- If there no package description file, we assume that the
--- 'PackageDescription' is up to date, though the configuration may need
--- to be updated for other reasons (see above). If there is a package
--- description file, and it has been modified since the 'LocalBuildInfo'
--- was generated, then we need to reconfigure.
---
--- The caller of this function may also have specific requirements
--- regarding the flags the last configuration used. For example,
--- 'testAction' requires that the package be configured with test suites
--- enabled. The caller may pass the required settings to this function
--- along with a function to check the validity of the saved 'ConfigFlags';
--- these required settings will be checked first upon determining that
--- a previous configuration exists.
-reconfigure :: Verbosity    -- ^ Verbosity setting
-            -> Flag FilePath  -- ^ \"dist\" prefix
-            -> ConfigFlags  -- ^ Additional config flags to set. These flags
-                            -- will be 'mappend'ed to the last used or
-                            -- default 'ConfigFlags' as appropriate, so
-                            -- this value should be 'mempty' with only the
-                            -- required flags set. The required verbosity
-                            -- and \"dist\" prefix flags will be set
-                            -- automatically because they are always
-                            -- required; therefore, it is not necessary to
-                            -- set them here.
-            -> [String]     -- ^ Extra arguments
-            -> GlobalFlags  -- ^ Global flags
-            -> SkipAddSourceDepsCheck
-                            -- ^ Should we skip the timestamp check for modified
-                            -- add-source dependencies?
-            -> Flag (Maybe Int)
-                            -- ^ -j flag for reinstalling add-source deps.
-            -> (ConfigFlags -> Maybe String)
-                            -- ^ Check that the required flags are set in
-                            -- the last used 'ConfigFlags'. If the required
-                            -- flags are not set, provide a message to the
-                            -- user explaining the reason for
-                            -- reconfiguration. Because the correct \"dist\"
-                            -- prefix setting is always required, it is checked
-                            -- automatically; this function need not check
-                            -- for it.
-            -> IO (UseSandbox, SavedConfig, FilePath)
-reconfigure verbosity flagDistPref addConfigFlags extraArgs globalFlags
-            skipAddSourceDepsCheck numJobsFlag    checkFlags = do
-  (useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags
-  distPref <- findSavedDistPref config flagDistPref
-  eLbi <- tryGetPersistBuildConfig distPref
-  config' <- case eLbi of
-    Left err  -> onNoBuildConfig (useSandbox, config) distPref err
-    Right lbi -> onBuildConfig (useSandbox, config) distPref lbi
-  return (useSandbox, config', distPref)
-
-  where
-
-    -- We couldn't load the saved package config file.
-    --
-    -- If we're in a sandbox: add-source deps don't have to be reinstalled
-    -- (since we don't know the compiler & platform).
-    onNoBuildConfig :: (UseSandbox, SavedConfig) -> FilePath
-                    -> ConfigStateFileError -> IO SavedConfig
-    onNoBuildConfig (_, config) distPref err = do
-      let msg = case err of
-            ConfigStateFileMissing -> "Package has never been configured."
-            ConfigStateFileNoParse -> "Saved package config file seems "
-                                      ++ "to be corrupt."
-            _ -> show err
-      case err of
-        -- Note: the build config could have been generated by a custom setup
-        -- script built against a different Cabal version, so it's crucial that
-        -- we ignore the bad version error here.
-        ConfigStateFileBadVersion _ _ _ -> info verbosity msg
-        _                               -> do
-          let distVerbFlags = mempty
-                { configVerbosity = toFlag verbosity
-                , configDistPref  = toFlag distPref
-                }
-              defaultFlags = mappend addConfigFlags distVerbFlags
-          notice verbosity
-            $ msg ++ " Configuring with default flags." ++ configureManually
-          configureAction (defaultFlags, defaultConfigExFlags)
-            extraArgs globalFlags
-      return config
-
-    -- Package has been configured, but the configuration may be out of
-    -- date or required flags may not be set.
-    --
-    -- If we're in a sandbox: reinstall the modified add-source deps and
-    -- force reconfigure if we did.
-    onBuildConfig :: (UseSandbox, SavedConfig) -> FilePath
-                  -> LBI.LocalBuildInfo -> IO SavedConfig
-    onBuildConfig (useSandbox, config) distPref lbi = do
-      let configFlags = LBI.configFlags lbi
-          distVerbFlags = mempty
-            { configVerbosity = toFlag verbosity
-            , configDistPref  = toFlag distPref
-            }
-          flags       = mconcat [configFlags, addConfigFlags, distVerbFlags]
-
-      -- Was the sandbox created after the package was already configured? We
-      -- may need to skip reinstallation of add-source deps and force
-      -- reconfigure.
-      let buildConfig       = localBuildInfoFile distPref
-      sandboxConfig        <- getSandboxConfigFilePath globalFlags
-      isSandboxConfigNewer <-
-        sandboxConfig `existsAndIsMoreRecentThan` buildConfig
-
-      let skipAddSourceDepsCheck'
-            | isSandboxConfigNewer = SkipAddSourceDepsCheck
-            | otherwise            = skipAddSourceDepsCheck
-
-      when (skipAddSourceDepsCheck' == SkipAddSourceDepsCheck) $
-        info verbosity "Skipping add-source deps check..."
-
-      let (_, config') = updateInstallDirs
-                         (configUserInstall flags)
-                         (useSandbox, config)
-
-      depsReinstalled <-
-        case skipAddSourceDepsCheck' of
-          DontSkipAddSourceDepsCheck ->
-            maybeReinstallAddSourceDeps
-              verbosity numJobsFlag flags globalFlags
-              (useSandbox, config')
-          SkipAddSourceDepsCheck -> do
-            return NoDepsReinstalled
-
-      -- Is the @cabal.config@ file newer than @dist/setup.config@? Then we need
-      -- to force reconfigure. Note that it's possible to use @cabal.config@
-      -- even without sandboxes.
-      isUserPackageEnvironmentFileNewer <-
-        userPackageEnvironmentFile `existsAndIsMoreRecentThan` buildConfig
-
-      -- Determine whether we need to reconfigure and which message to show to
-      -- the user if that is the case.
-      mMsg <- determineMessageToShow distPref lbi configFlags
-                                     depsReinstalled isSandboxConfigNewer
-                                     isUserPackageEnvironmentFileNewer
-      case mMsg of
-
-        -- No message for the user indicates that reconfiguration
-        -- is not required.
-        Nothing -> return config'
-
-        -- Show the message and reconfigure.
-        Just msg -> do
-          notice verbosity msg
-          configureAction (flags, defaultConfigExFlags)
-            extraArgs globalFlags
-          return config'
-
-    -- Determine what message, if any, to display to the user if reconfiguration
-    -- is required.
-    determineMessageToShow :: FilePath -> LBI.LocalBuildInfo -> ConfigFlags
-                            -> WereDepsReinstalled -> Bool -> Bool
-                            -> IO (Maybe String)
-    determineMessageToShow _ _   _           _               True  _     =
-      -- The sandbox was created after the package was already configured.
-      return $! Just $! sandboxConfigNewerMessage
-
-    determineMessageToShow _ _   _           _               False True  =
-      -- The user package environment file was modified.
-      return $! Just $! userPackageEnvironmentFileModifiedMessage
-
-    determineMessageToShow distPref lbi configFlags depsReinstalled
-                           False False = do
-      let savedDistPref = fromFlagOrDefault
-                          (useDistPref defaultSetupScriptOptions)
-                          (configDistPref configFlags)
-      case depsReinstalled of
-        ReinstalledSomeDeps ->
-          -- Some add-source deps were reinstalled.
-          return $! Just $! reinstalledDepsMessage
-        NoDepsReinstalled ->
-          case checkFlags configFlags of
-            -- Flag required by the caller is not set.
-            Just msg -> return $! Just $! msg ++ configureManually
-
-            Nothing
-              -- Required "dist" prefix is not set.
-              | savedDistPref /= distPref ->
-                return $! Just distPrefMessage
-
-              -- All required flags are set, but the configuration
-              -- may be outdated.
-              | otherwise -> case LBI.pkgDescrFile lbi of
-                Nothing -> return Nothing
-                Just pdFile -> do
-                  outdated <- checkPersistBuildConfigOutdated
-                              distPref pdFile
-                  return $! if outdated
-                            then Just $! outdatedMessage pdFile
-                            else Nothing
-
-    reconfiguringMostRecent = " Re-configuring with most recently used options."
-    configureManually       = " If this fails, please run configure manually."
-    sandboxConfigNewerMessage =
-        "The sandbox was created after the package was already configured."
-        ++ reconfiguringMostRecent
-        ++ configureManually
-    userPackageEnvironmentFileModifiedMessage =
-        "The user package environment file ('"
-        ++ userPackageEnvironmentFile ++ "') was modified."
-        ++ reconfiguringMostRecent
-        ++ configureManually
-    distPrefMessage =
-        "Package previously configured with different \"dist\" prefix."
-        ++ reconfiguringMostRecent
-        ++ configureManually
-    outdatedMessage pdFile =
-        pdFile ++ " has been changed."
-        ++ reconfiguringMostRecent
-        ++ configureManually
-    reinstalledDepsMessage =
-        "Some add-source dependencies have been reinstalled."
-        ++ reconfiguringMostRecent
-        ++ configureManually
 
 installAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags)
               -> [String] -> Action
@@ -786,21 +591,29 @@ testAction :: (TestFlags, BuildFlags, BuildExFlags) -> [String] -> GlobalFlags
            -> IO ()
 testAction (testFlags, buildFlags, buildExFlags) extraArgs globalFlags = do
   let verbosity      = fromFlagOrDefault normal (testVerbosity testFlags)
-      addConfigFlags = mempty { configTests = toFlag True }
-      noAddSource    = fromFlagOrDefault DontSkipAddSourceDepsCheck
+  (useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags
+  distPref <- findSavedDistPref config (testDistPref testFlags)
+  let noAddSource    = fromFlagOrDefault DontSkipAddSourceDepsCheck
                        (buildOnly buildExFlags)
       buildFlags'    = buildFlags
                        { buildVerbosity = testVerbosity testFlags }
-      checkFlags flags
-        | fromFlagOrDefault False (configTests flags) = Nothing
-        | otherwise  = Just "Re-configuring with test suites enabled."
+      checkFlags = Check $ \_ flags@(configFlags, configExFlags) ->
+        if fromFlagOrDefault False (configTests configFlags)
+          then pure (mempty, flags)
+          else do
+            info verbosity "reconfiguring to enable tests"
+            let flags' = ( configFlags { configTests = toFlag True }
+                         , configExFlags
+                         )
+            pure (Any True, flags')
 
   -- reconfigure also checks if we're in a sandbox and reinstalls add-source
   -- deps if needed.
-  (useSandbox, config, distPref) <-
-    reconfigure verbosity (testDistPref testFlags)
-                addConfigFlags [] globalFlags noAddSource
-                (buildNumJobs buildFlags') checkFlags
+  _ <-
+    reconfigure configureAction
+    verbosity distPref useSandbox noAddSource (buildNumJobs buildFlags')
+    checkFlags [] globalFlags config
+
   let setupOptions   = defaultSetupScriptOptions { useDistPref = distPref }
       testFlags'     = testFlags { testDistPref = toFlag distPref }
 
@@ -856,21 +669,33 @@ benchmarkAction (benchmarkFlags, buildFlags, buildExFlags)
                 extraArgs globalFlags = do
   let verbosity      = fromFlagOrDefault normal
                        (benchmarkVerbosity benchmarkFlags)
-      addConfigFlags = mempty { configBenchmarks = toFlag True }
-      buildFlags'    = buildFlags
+
+  (useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags
+  distPref <- findSavedDistPref config (benchmarkDistPref benchmarkFlags)
+
+  let buildFlags'    = buildFlags
                        { buildVerbosity = benchmarkVerbosity benchmarkFlags }
-      checkFlags flags
-        | fromFlagOrDefault False (configBenchmarks flags) = Nothing
-        | otherwise = Just "Re-configuring with benchmarks enabled."
       noAddSource   = fromFlagOrDefault DontSkipAddSourceDepsCheck
                       (buildOnly buildExFlags)
 
+  let checkFlags = Check $ \_ flags@(configFlags, configExFlags) ->
+        if fromFlagOrDefault False (configBenchmarks configFlags)
+          then pure (mempty, flags)
+          else do
+            info verbosity "reconfiguring to enable benchmarks"
+            let flags' = ( configFlags { configBenchmarks = toFlag True }
+                         , configExFlags
+                         )
+            pure (Any True, flags')
+
+
   -- reconfigure also checks if we're in a sandbox and reinstalls add-source
   -- deps if needed.
-  (useSandbox, config, distPref) <-
-    reconfigure verbosity (benchmarkDistPref benchmarkFlags)
-                addConfigFlags [] globalFlags noAddSource
-                (buildNumJobs buildFlags') checkFlags
+  config' <-
+    reconfigure configureAction
+    verbosity distPref useSandbox noAddSource (buildNumJobs buildFlags')
+    checkFlags [] globalFlags config
+
   let setupOptions   = defaultSetupScriptOptions { useDistPref = distPref }
       benchmarkFlags'= benchmarkFlags { benchmarkDistPref = toFlag distPref }
 
@@ -884,7 +709,7 @@ benchmarkAction (benchmarkFlags, buildFlags, buildExFlags)
         | otherwise      = extraArgs
 
   maybeWithSandboxDirOnSearchPath useSandbox $
-    build verbosity config distPref buildFlags' extraArgs'
+    build verbosity config' distPref buildFlags' extraArgs'
 
   maybeWithSandboxDirOnSearchPath useSandbox $
     setupWrapper verbosity setupOptions Nothing
@@ -893,12 +718,14 @@ benchmarkAction (benchmarkFlags, buildFlags, buildExFlags)
 haddockAction :: HaddockFlags -> [String] -> Action
 haddockAction haddockFlags extraArgs globalFlags = do
   let verbosity = fromFlag (haddockVerbosity haddockFlags)
-  (_useSandbox, config, distPref) <-
-    reconfigure verbosity (haddockDistPref haddockFlags)
-                mempty [] globalFlags DontSkipAddSourceDepsCheck
-                NoFlag (const Nothing)
+  (useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags
+  distPref <- findSavedDistPref config (haddockDistPref haddockFlags)
+  config' <-
+    reconfigure configureAction
+    verbosity distPref useSandbox DontSkipAddSourceDepsCheck NoFlag
+    mempty [] globalFlags config
   let haddockFlags' = defaultHaddockFlags      `mappend`
-                      savedHaddockFlags config `mappend`
+                      savedHaddockFlags config' `mappend`
                       haddockFlags { haddockDistPref = toFlag distPref }
       setupScriptOptions = defaultSetupScriptOptions { useDistPref = distPref }
   setupWrapper verbosity setupScriptOptions Nothing
@@ -1171,21 +998,23 @@ reportAction reportFlags extraArgs globalFlags = do
 runAction :: (BuildFlags, BuildExFlags) -> [String] -> Action
 runAction (buildFlags, buildExFlags) extraArgs globalFlags = do
   let verbosity   = fromFlagOrDefault normal (buildVerbosity buildFlags)
+  (useSandbox, config) <- loadConfigOrSandboxConfig verbosity globalFlags
+  distPref <- findSavedDistPref config (buildDistPref buildFlags)
   let noAddSource = fromFlagOrDefault DontSkipAddSourceDepsCheck
                     (buildOnly buildExFlags)
 
   -- reconfigure also checks if we're in a sandbox and reinstalls add-source
   -- deps if needed.
-  (useSandbox, config, distPref) <-
-    reconfigure verbosity (buildDistPref buildFlags) mempty []
-                globalFlags noAddSource (buildNumJobs buildFlags)
-                (const Nothing)
+  config' <-
+    reconfigure configureAction
+    verbosity distPref useSandbox noAddSource (buildNumJobs buildFlags)
+    mempty [] globalFlags config
 
   lbi <- getPersistBuildConfig distPref
   (exe, exeArgs) <- splitRunArgs verbosity lbi extraArgs
 
   maybeWithSandboxDirOnSearchPath useSandbox $
-    build verbosity config distPref buildFlags ["exe:" ++ exeName exe]
+    build verbosity config' distPref buildFlags ["exe:" ++ exeName exe]
 
   maybeWithSandboxDirOnSearchPath useSandbox $
     run verbosity lbi exe exeArgs

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -278,13 +278,15 @@ executable cabal
         Distribution.Client.ProjectPlanning
         Distribution.Client.ProjectPlanning.Types
         Distribution.Client.ProjectPlanOutput
-        Distribution.Client.Run
         Distribution.Client.RebuildMonad
+        Distribution.Client.Reconfigure
+        Distribution.Client.Run
         Distribution.Client.Sandbox
         Distribution.Client.Sandbox.Index
         Distribution.Client.Sandbox.PackageEnvironment
         Distribution.Client.Sandbox.Timestamp
         Distribution.Client.Sandbox.Types
+        Distribution.Client.SavedFlags
         Distribution.Client.Security.HTTP
         Distribution.Client.Setup
         Distribution.Client.SetupWrapper

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -22,7 +22,8 @@
 	verbose GHC output (#3540, #3671).
 	* Changed the default logfile template from
 	'.../$pkgid.log' to '.../$compiler/$libname.log' (#3807).
-	* Added a new command, 'cabal reconfigure' (#2214).
+	* Added a new command, 'cabal reconfigure', which re-runs 'configure'
+	with the most recently used flags (#2214).
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* If there are multiple remote repos, 'cabal update' now updates

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -22,6 +22,7 @@
 	verbose GHC output (#3540, #3671).
 	* Changed the default logfile template from
 	'.../$pkgid.log' to '.../$compiler/$libname.log' (#3807).
+	* Added a new command, 'cabal reconfigure' (#2214).
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* If there are multiple remote repos, 'cabal update' now updates


### PR DESCRIPTION
Fixes #2214 by adding a `reconfigure` command and invoking it whenever necessary. The last configure flags used are saved in a version-independent format so it should never be necessary for the user to reconfigure manually.