### PR TITLE
Validate InstallPlan in solver quickcheck tests, and update tests to handle executables.

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -516,6 +516,7 @@ Test-Suite solver-quickcheck
         bytestring,
         Cabal,
         containers,
+        deepseq >= 1.2,
         mtl,
         pretty,
         process,

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -274,8 +274,6 @@ exAvSrcPkg ex =
                                                      (Buildable libraryDeps))
              , C.condSubLibraries = []
              , C.condExecutables =
-                 -- Executables not presently disableable.  We can't
-                 -- error in the disable case
                  let mkTree = mkCondTree mempty disableExe . Buildable
                  in map (\(t, deps) -> (t, mkTree deps)) executables
              , C.condTestSuites  =


### PR DESCRIPTION
This PR ensures that randomly-generated ComponentDeps don't have tests and exes with the same name.  It also evaluates the solver result to force install plan validation.  Previously, the tests only evaluated enough of the result to determine whether the solver found an install plan, but that install plan could be invalid.