### PR TITLE
Correctly propagate profiling for ALL library dependencies.

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1573,7 +1573,7 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
             profLibFlag  = lookupPerPkgOption pkgid packageConfigProfLib
             --TODO: [code cleanup] unused: the old deprecated packageConfigProfExe
 
-    libDepGraph = Graph.fromList (map LibDepSolverPlanPackage
+    libDepGraph = Graph.fromList (map NonSetupLibDepSolverPlanPackage
                                       (SolverInstallPlan.toList solverPlan))
 
     packagesWithLibDepsDownwardClosedProperty property =
@@ -1597,20 +1597,21 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
       -- + ghci or shared lib needed by TH, recursive, ghc version dependent
 
 -- | A newtype for 'SolverInstallPlan.SolverPlanPackage' for which the
--- dependency graph considers only library dependencies (so, no setup
--- dependencies or executable dependencies.)  Used to compute the set
+-- dependency graph considers only dependencies on libraries which are
+-- NOT from setup dependencies.  Used to compute the set
 -- of packages needed for profiling and dynamic libraries.
-newtype LibDepSolverPlanPackage
-    = LibDepSolverPlanPackage { unLibDepSolverPlanPackage :: SolverInstallPlan.SolverPlanPackage }
+newtype NonSetupLibDepSolverPlanPackage
+    = NonSetupLibDepSolverPlanPackage
+    { unNonSetupLibDepSolverPlanPackage :: SolverInstallPlan.SolverPlanPackage }
 
-instance Package LibDepSolverPlanPackage where
-    packageId = packageId . unLibDepSolverPlanPackage
+instance Package NonSetupLibDepSolverPlanPackage where
+    packageId = packageId . unNonSetupLibDepSolverPlanPackage
 
-instance IsNode LibDepSolverPlanPackage where
-    type Key LibDepSolverPlanPackage = SolverId
-    nodeKey = nodeKey . unLibDepSolverPlanPackage
-    nodeNeighbors (LibDepSolverPlanPackage spkg)
-        = ordNub $ CD.libraryDeps (resolverPackageLibDeps spkg)
+instance IsNode NonSetupLibDepSolverPlanPackage where
+    type Key NonSetupLibDepSolverPlanPackage = SolverId
+    nodeKey = nodeKey . unNonSetupLibDepSolverPlanPackage
+    nodeNeighbors (NonSetupLibDepSolverPlanPackage spkg)
+        = ordNub $ CD.nonSetupDeps (resolverPackageLibDeps spkg)
 
 ---------------------------
 -- Build targets

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -144,6 +144,12 @@ Extra-Source-Files:
   tests/IntegrationTests/regression/t3335/Setup.hs
   tests/IntegrationTests/regression/t3335/cabal.project
   tests/IntegrationTests/regression/t3335/t3335.cabal
+  tests/IntegrationTests/regression/t3827.sh
+  tests/IntegrationTests/regression/t3827/cabal.project
+  tests/IntegrationTests/regression/t3827/p/P.hs
+  tests/IntegrationTests/regression/t3827/p/p.cabal
+  tests/IntegrationTests/regression/t3827/q/Main.hs
+  tests/IntegrationTests/regression/t3827/q/q.cabal
   tests/IntegrationTests/sandbox-reinstalls/p/Main.hs
   tests/IntegrationTests/sandbox-reinstalls/p/p.cabal
   tests/IntegrationTests/sandbox-reinstalls/q/Q.hs

--- a/cabal-install/tests/IntegrationTests/regression/t3827.sh
+++ b/cabal-install/tests/IntegrationTests/regression/t3827.sh
@@ -1,0 +1,4 @@
+. ./common.sh
+
+cd t3827
+cabal new-build exe:q

--- a/cabal-install/tests/IntegrationTests/regression/t3827/cabal.project
+++ b/cabal-install/tests/IntegrationTests/regression/t3827/cabal.project
@@ -1,0 +1,4 @@
+packages: p q
+profiling-detail: all-functions
+package q
+    profiling: True

--- a/cabal-install/tests/IntegrationTests/regression/t3827/p/P.hs
+++ b/cabal-install/tests/IntegrationTests/regression/t3827/p/P.hs
@@ -1,0 +1,2 @@
+module P where
+p = True

--- a/cabal-install/tests/IntegrationTests/regression/t3827/p/p.cabal
+++ b/cabal-install/tests/IntegrationTests/regression/t3827/p/p.cabal
@@ -1,0 +1,8 @@
+name:           p
+version:        1.0
+build-type:     Simple
+cabal-version:  >= 1.10
+
+library
+    build-depends: base
+    exposed-modules: P

--- a/cabal-install/tests/IntegrationTests/regression/t3827/q/Main.hs
+++ b/cabal-install/tests/IntegrationTests/regression/t3827/q/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+import P
+main = print p

--- a/cabal-install/tests/IntegrationTests/regression/t3827/q/q.cabal
+++ b/cabal-install/tests/IntegrationTests/regression/t3827/q/q.cabal
@@ -1,0 +1,8 @@
+name:           q
+version:        1.0
+build-type:     Simple
+cabal-version:  >= 1.10
+
+executable q
+    build-depends: base, p
+    main-is: Main.hs


### PR DESCRIPTION
Previously, we were only doing library dependencies of the libraries,
which is wrong if we try to profile an executable.

Fixes #3827. CC @grayjay.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>