### PR TITLE
Basic cabal lexer for docs

### DIFF
--- a/Cabal/doc/conf.py
+++ b/Cabal/doc/conf.py
@@ -190,6 +190,7 @@ def setup(app):
                         doc_field_types=[
                             Field('since', label='Introduced in GHC version', names=['since']),
                         ])
+    app.add_lexer('cabal', CabalLexer())
 
 def increase_python_stack():
     # Workaround sphinx-build recursion limit overflow:
@@ -198,3 +199,28 @@ def increase_python_stack():
     #
     # Default python allows recursion depth of 1000 calls.
     sys.setrecursionlimit(10000)
+
+
+import pygments.lexer as lexer
+import pygments.token as token
+import re
+
+class CabalLexer(lexer.RegexLexer):
+    name = 'Cabal'
+    aliases = ['cabal']
+    filenames = ['.cabal']
+    flags = re.MULTILINE# | re.DOTALL
+
+    tokens = {
+      'root' : [
+         (r'\n', token.Text),
+         (r'^\s*(--.*)$', token.Comment.Single),
+         (r'[^\S\n]+', token.Text),
+         (r'(\n\s*|\t)', token.Whitespace),
+         (r'&&|\|\||==|<=|>=|<|>|^=', token.Operator),
+         (r',', token.Punctuation),
+         (r'^\s*([\w\-_]+:)', token.Keyword),
+         (r'^\s*([\w\-_]+)(\s+)([\w\-_]+).*$', lexer.bygroups(token.Keyword, token.Whitespace, token.Name)),
+         (r'.', token.Text)
+      ],
+    }

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -1,3 +1,4 @@
+.. highlight:: shell
 
 Quickstart
 ==========
@@ -27,7 +28,7 @@ directory with a folder per package, e.g., the folders ``Cabal`` and
 ``cabal-install``. The ``cabal.project`` file specifies each folder as
 part of the project:
 
-::
+.. code-block:: cabal
 
     packages: Cabal/
               cabal-install/
@@ -320,8 +321,9 @@ solver under the current index and flags. A ``cabal.project.freeze``
 file has the same syntax as ``cabal.project`` and looks something like
 this:
 
-::
+.. highlight:: cabal
 
+::
     constraints: HTTP ==4000.3.3,
                  HTTP +warp-tests -warn-as-error -network23 +network-uri -mtl1 -conduit10,
                  QuickCheck ==2.9.1,
@@ -547,15 +549,15 @@ The following settings control the behavior of the dependency solver:
     Version bounds have the same syntax as ``build-depends``. You can
     also specify flag assignments:
 
-     .. code-block:: yaml
+    ::
 
-        # Require bar to be installed with the foo flag turned on and
-        # the baz flag turned off
+        -- Require bar to be installed with the foo flag turned on and
+        -- the baz flag turned off
         constraints: bar +foo -baz
 
-        # Require that bar NOT be present in the install plan. Note:
-        # this is just syntax sugar for '> 1 && < 1', and is supported
-        # by build-depends.
+        -- Require that bar NOT be present in the install plan. Note:
+        -- this is just syntax sugar for '> 1 && < 1', and is supported
+        -- by build-depends.
         constraints: bar -none
 
     A package can be specified multiple times in ``constraints``, in
@@ -574,20 +576,20 @@ The following settings control the behavior of the dependency solver:
 
     ::
 
-        # Require bar to be preinstalled in the global package database
-        # (this does NOT include the Nix-local build global store.)
+        -- Require bar to be preinstalled in the global package database
+        -- (this does NOT include the Nix-local build global store.)
         constraints: bar installed
 
-        # Require the local source copy of bar to be used
-        # (Note: By default, if we have a local package we will
-        # automatically use it, so it generally not be necessary to
-        # specify this)
+        -- Require the local source copy of bar to be used
+        -- (Note: By default, if we have a local package we will
+        -- automatically use it, so it generally not be necessary to
+        -- specify this)
         constraints: bar source
 
-        # Require that bar be solved with test suites and benchmarks enabled
-        # (Note: By default, new-build configures the solver to make
-        # a best-effort attempt to enable these stanzas, so this generally
-        # should not be necessary.)
+        -- Require that bar be solved with test suites and benchmarks enabled
+        -- (Note: By default, new-build configures the solver to make
+        -- a best-effort attempt to enable these stanzas, so this generally
+        -- should not be necessary.)
         constraints: bar test,
                      bar bench
 
@@ -643,11 +645,11 @@ The following settings control the behavior of the dependency solver:
 
     ::
 
-        # Disregard upper bounds involving the dependencies on
-        # packages bar, baz and quux
+        -- Disregard upper bounds involving the dependencies on
+        -- packages bar, baz and quux
         allow-newer: bar, baz, quux
 
-        # Disregard all upper bounds when dependency solving
+        -- Disregard all upper bounds when dependency solving
         allow-newer: all
 
     ``allow-newer`` is often used in conjunction with a constraint (in


### PR DESCRIPTION
A really basic cabal lexer, but makes code samples a little bit nicer.

I've only converted `nix-local-build.rst` so far.

![caballex](https://cloud.githubusercontent.com/assets/274341/18437623/e6b1e58a-790e-11e6-9f9e-93b8397ac51e.png)