### PR TITLE
Drop support for GHC 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ matrix:
      os: linux
    # These don't have -dyn/-prof whitelisted yet, so we have to
    # do the old-style installation
-   - env: GHCVER=7.4.2 SCRIPT=script
-     os: linux
-     sudo: required
    - env: GHCVER=7.6.3 SCRIPT=script
      os: linux
      sudo: required

--- a/Cabal/Distribution/Compat/Binary.hs
+++ b/Cabal/Distribution/Compat/Binary.hs
@@ -17,10 +17,6 @@ module Distribution.Compat.Binary
 #endif
        ) where
 
-#if __GLASGOW_HASKELL__ < 706
-import Prelude hiding (catch)
-#endif
-
 import Control.Exception (catch, evaluate)
 #if __GLASGOW_HASKELL__ >= 711
 import Control.Exception (pattern ErrorCall)

--- a/Cabal/Distribution/Compat/Environment.hs
+++ b/Cabal/Distribution/Compat/Environment.hs
@@ -51,13 +51,6 @@ getEnvironment = fmap upcaseVars System.getEnvironment
 getEnvironment = System.getEnvironment
 #endif
 
-#if __GLASGOW_HASKELL__ < 706
--- | @lookupEnv var@ returns the value of the environment variable @var@, or
--- @Nothing@ if there is no such value.
-lookupEnv :: String -> IO (Maybe String)
-lookupEnv name = (Just `fmap` System.getEnv name) `catchIO` const (return Nothing)
-#endif /* __GLASGOW_HASKELL__ < 706 */
-
 -- | @setEnv name value@ sets the specified environment variable to @value@.
 --
 -- Throws `Control.Exception.IOException` if either @name@ or @value@ is the

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -1,7 +1,7 @@
 -*-change-log-*-
 
 1.25.x.x (current development version)
-	* Dropped support for versions of GHC earlier than 6.12 (#3111).
+	* Dropped support for versions of GHC earlier than 7.6 (#3833).
 	* Convenience/internal libraries are now supported (#269).
 	  An internal library is declared using the stanza "library
 	  'libname'".  Packages which use internal libraries can


### PR DESCRIPTION
GHC 7.4 is more than four years old now, well outside our three-year
support window. (Actually, GHC 7.6 is outside our support window too,
but I don't have any pending patches which are broken with that
version.)

Attn. @23Skidoo @rthomas