### PR TITLE
Make docs less noisy and referenceable

### DIFF
--- a/Cabal/doc/_templates/layout.html
+++ b/Cabal/doc/_templates/layout.html
@@ -1,0 +1,7 @@
+{% extends "!layout.html" %}
+
+{% block menu %}
+  {{ super() }}
+  <a href="genindex.html">Index</a>
+{% endblock %}
+

--- a/Cabal/doc/conf.py
+++ b/Cabal/doc/conf.py
@@ -15,7 +15,7 @@ version = "1.25"
 
 extensions = ['sphinx.ext.extlinks']
 
-templates_path = ['.templates']
+templates_path = ['_templates']
 source_suffix = '.rst'
 source_encoding = 'utf-8-sig'
 master_doc = 'index'

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -210,7 +210,7 @@ Building and installing a user package
     $ runhaskell Setup.hs install
 
 The package is installed under the user's home directory and is
-registered in the user's package database (``--user``).
+registered in the user's package database (:option:`setup configure --user`).
 
 Installing packages from Hackage
 --------------------------------
@@ -417,9 +417,14 @@ Windows.
 
 The following options are understood by all commands:
 
-``--help``, ``-h`` or ``-?``
+.. program:: setup
+
+.. option:: --help, -h or -?
+
     List the available options for the command.
-``--verbose=``\ *n* or ``-v``\ *n*
+
+.. option:: --verbose=n or -v n
+
     Set the verbosity level (0-3). The normal level is 1; a missing *n*
     defaults to 2.
 
@@ -439,6 +444,8 @@ will be reported as errors.
 setup configure
 ---------------
 
+.. program:: setup configure
+
 Prepare to build the package. Typically, this step checks that the
 target platform is capable of building the package, and discovers
 platform-specific features that are needed during the build.
@@ -453,11 +460,11 @@ If a user-supplied ``configure`` script is run (see the section on
 parameters <developing-packages.html#system-dependent-parameters>`__ or
 on `complex
 packages <developing-packages.html#more-complex-packages>`__), it is
-passed the ``--with-hc-pkg``, ``--prefix``, ``--bindir``, ``--libdir``,
-``--datadir``, ``--libexecdir`` and ``--sysconfdir`` options. In
-addition the value of the ``--with-compiler`` option is passed in a
-``--with-hc`` option and all options specified with
-``--configure-option=`` are passed on.
+passed the :option:`--with-hc-pkg`, :option:`--prefix`, :option:`--bindir`,
+:option:`--libdir`, :option:`--datadir`, :option:`--libexecdir` and
+:option:`--sysconfdir` options. In addition the value of the
+:option:`--with-compiler` option is passed in a :option:`--with-hc-pkg` option
+and all options specified with :option:`--configure-option` are passed on.
 
 In Cabal 2.0, support for a single positional argument was added to
 ``setup configure`` This makes Cabal configure a the specific component
@@ -466,21 +473,21 @@ to be configured. Specified names can be qualified with ``lib:`` or
 package named ``p`` which has a library and an executable named ``p``.)
 This has the following effects:
 
--  Subsequent invocations of ``build``, ``register``, etc. operate only
+-  Subsequent invocations of ``cabal build``, ``register``, etc. operate only
    on the configured component.
 
 -  Cabal requires all "internal" dependencies (e.g., an executable
    depending on a library defined in the same package) must be found in
-   the set of databases via ``--package-db`` (and related flags): these
+   the set of databases via :option:`--package-db` (and related flags): these
    dependencies are assumed to be up-to-date. A dependency can be
-   explicitly specified using ``--dependency`` simply by giving the name
+   explicitly specified using :option:`--dependency` simply by giving the name
    of the internal library; e.g., the dependency for an internal library
    named ``foo`` is given as
    ``--dependency=pkg-internal=pkg-1.0-internal-abcd``.
 
 -  Only the dependencies needed for the requested component are
-   required. Similarly, when ``--exact-configuration`` is specified,
-   it's only necessary to specify ``--dependency`` for the component.
+   required. Similarly, when :option:`--exact-configuration` is specified,
+   it's only necessary to specify :option:`--dependency` for the component.
    (As mentioned previously, you *must* specify internal dependencies as
    well.)
 
@@ -496,27 +503,33 @@ Programs used for building
 The following options govern the programs used to process the source
 files of a package:
 
-``--ghc`` or ``-g``, ``--jhc``, ``--lhc``, ``--uhc``
+.. option:: --ghc or -g, --jhc, --lhc, --uhc
+
     Specify which Haskell implementation to use to build the package. At
     most one of these flags may be given. If none is given, the
     implementation under which the setup script was compiled or
     interpreted is used.
-``--with-compiler=``\ *path* or ``-w``\ *path*
+
+.. option:: --with-compiler=path or -w *path*
+
     Specify the path to a particular compiler. If given, this must match
     the implementation selected above. The default is to search for the
     usual name of the selected implementation.
 
-    This flag also sets the default value of the ``--with-hc-pkg``
+    This flag also sets the default value of the :option:`--with-hc-pkg`
     option to the package tool for this compiler. Check the output of
     ``setup configure -v`` to ensure that it finds the right package
-    tool (or use ``--with-hc-pkg`` explicitly).
+    tool (or use :option:`--with-hc-pkg` explicitly).
 
-``--with-hc-pkg=``\ *path*
+.. option:: --with-hc-pkg=path
+
     Specify the path to the package tool, e.g. ``ghc-pkg``. The package
     tool must be compatible with the compiler specified by
-    ``--with-compiler``. If this option is omitted, the default value is
+    :option:`--with-compiler`. If this option is omitted, the default value is
     determined from the compiler selected.
-``--with-``\ *``prog``*\ ``=``\ *path*
+
+.. option:: --with-prog=path
+
     Specify the path to the program *prog*. Any program known to Cabal
     can be used in place of *prog*. It can either be a fully path or the
     name of a program that can be found on the program search path. For
@@ -524,7 +537,9 @@ files of a package:
     ``--with-cpphs=/usr/local/bin/cpphs``. The full list of accepted
     programs is not enumerated in this user guide. Rather, run
     ``cabal install --help`` to view the list.
-``--``\ *``prog``*\ ``-options=``\ *options*
+
+.. option:: --prog-options=options
+
     Specify additional options to the program *prog*. Any program known
     to Cabal can be used in place of *prog*. For example:
     ``--alex-options="--template=mytemplatedir/"``. The *options* is
@@ -532,18 +547,19 @@ files of a package:
     embedded spaced need to be quoted, for example
     ``--foo-options='--bar="C:\Program File\Bar"'``. As an alternative
     that takes only one option at a time but avoids the need to quote,
-    use ``--``\ *``prog``*\ ``-option`` instead.
-``--``\ *``prog``*\ ``-option=``\ *option*
+    use :option:`--prog-option` instead.
+
+.. option:: --prog-option=option
+
     Specify a single additional option to the program *prog*. For
     passing an option that contain embedded spaces, such as a file name
-    with embedded spaces, using this rather than
-    ``--``\ *``prog``*\ ``-options`` means you do not need an additional
-    level of quoting. Of course if you are using a command shell you may
-    still need to quote, for example
+    with embedded spaces, using this rather than :option:`--prog-options`
+    means you do not need an additional level of quoting. Of course if you
+    are using a command shell you may still need to quote, for example
     ``--foo-options="--bar=C:\Program File\Bar"``.
 
-All of the options passed with either ``--``\ *``prog``*\ ``-options``
-or ``--``\ *``prog``*\ ``-option`` are passed in the order they were
+All of the options passed with either :option:`--prog-options`
+or :option:`--prog-option` are passed in the order they were
 specified on the configure command line.
 
 Installation paths
@@ -552,7 +568,8 @@ Installation paths
 The following options govern the location of installed files from a
 package:
 
-``--prefix=``\ *dir*
+.. option:: --prefix=dir
+
     The root of the installation. For example for a global install you
     might use ``/usr/local`` on a Unix system, or ``C:\Program Files``
     on a Windows system. The other installation paths are usually
@@ -562,14 +579,16 @@ package:
     variables: ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``,
     ``$os``, ``$arch``, ``$abi``, ``$abitag``
 
-``--bindir=``\ *dir*
+.. option:: --bindir=dir
+
     Executables that the user might invoke are installed here.
 
     In the simple build system, *dir* may contain the following path
     variables: ``$prefix``, ``$pkgid``, ``$pkg``, ``$version``,
     ``$compiler``, ``$os``, ``$arch``, ``$abi``, \`$abitag
 
-``--libdir=``\ *dir*
+.. option:: --libdir=dir
+
     Object-code libraries are installed here.
 
     In the simple build system, *dir* may contain the following path
@@ -577,7 +596,8 @@ package:
     ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
-``--libexecdir=``\ *dir*
+.. option:: --libexecdir=dir
+
     Executables that are not expected to be invoked directly by the user
     are installed here.
 
@@ -586,7 +606,8 @@ package:
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``
 
-``--datadir``\ =\ *dir*
+.. option:: --datadir=dir
+
     Architecture-independent data files are installed here.
 
     In the simple build system, *dir* may contain the following path
@@ -594,7 +615,8 @@ package:
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``
 
-``--sysconfdir=``\ *dir*
+.. option:: --sysconfdir=dir
+
     Installation directory for the configuration files.
 
     In the simple build system, *dir* may contain the following path
@@ -605,7 +627,8 @@ package:
 In addition the simple build system supports the following installation
 path options:
 
-``--libsubdir=``\ *dir*
+.. option:: --libsubdir=dir
+
     A subdirectory of *libdir* in which libraries are actually
     installed. For example, in the simple build system on Unix, the
     default *libdir* is ``/usr/local/lib``, and *libsubdir* contains the
@@ -617,7 +640,8 @@ path options:
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
-``--datasubdir=``\ *dir*
+.. option:: --datasubdir=dir
+
     A subdirectory of *datadir* in which data files are actually
     installed.
 
@@ -625,7 +649,8 @@ path options:
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
-``--docdir=``\ *dir*
+.. option:: --docdir=dir
+
     Documentation files are installed relative to this directory.
 
     *dir* may contain the following path variables: ``$prefix``,
@@ -633,7 +658,8 @@ path options:
     ``$datasubdir``, ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``,
     ``$os``, ``$arch``, ``$abi``, ``$abitag``
 
-``--htmldir=``\ *dir*
+.. option:: --htmldir=dir
+
     HTML documentation files are installed relative to this directory.
 
     *dir* may contain the following path variables: ``$prefix``,
@@ -641,14 +667,16 @@ path options:
     ``$datasubdir``, ``$docdir``, ``$pkgid``, ``$pkg``, ``$version``,
     ``$compiler``, ``$os``, ``$arch``, ``$abi``, ``$abitag``
 
-``--program-prefix=``\ *prefix*
+.. option:: --program-prefix=prefix
+
     Prepend *prefix* to installed program names.
 
     *prefix* may contain the following path variables: ``$pkgid``,
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
-``--program-suffix=``\ *suffix*
+.. option:: --program-suffix=suffix
+
     Append *suffix* to installed program names. The most obvious use for
     this is to append the program's version number to make it possible
     to install several versions of a program at once:
@@ -669,43 +697,43 @@ relative to each other rather than as absolute paths, which is important
 for building relocatable packages (see `prefix
 independence <#prefix-independence>`__).
 
-``$prefix``
+$prefix
     The path variable that stands for the root of the installation. For
     an installation to be relocatable, all other installation paths must
     be relative to the ``$prefix`` variable.
-``$bindir``
-    The path variable that expands to the path given by the ``--bindir``
+$bindir
+    The path variable that expands to the path given by the :option:`--bindir`
     configure option (or the default).
-``$libdir``
-    As above but for ``--libdir``
-``$libsubdir``
-    As above but for ``--libsubdir``
-``$datadir``
-    As above but for ``--datadir``
-``$datasubdir``
-    As above but for ``--datasubdir``
-``$docdir``
-    As above but for ``--docdir``
-``$pkgid``
+$libdir
+    As above but for :option:`--libdir`
+$libsubdir
+    As above but for :option:`--libsubdir`
+$datadir
+    As above but for :option:`--datadir`
+$datasubdir
+    As above but for :option:`--datasubdir`
+$docdir
+    As above but for :option:`--docdir`
+$pkgid
     The name and version of the package, e.g. ``mypkg-0.2``
-``$pkg``
+$pkg
     The name of the package, e.g. ``mypkg``
-``$version``
+$version
     The version of the package, e.g. ``0.2``
-``$compiler``
+$compiler
     The compiler being used to build the package, e.g. ``ghc-6.6.1``
-``$os``
+$os
     The operating system of the computer being used to build the
     package, e.g. ``linux``, ``windows``, ``osx``, ``freebsd`` or
     ``solaris``
-``$arch``
+$arch
     The architecture of the computer being used to build the package,
     e.g. ``i386``, ``x86_64``, ``ppc`` or ``sparc``
-``$abitag``
+$abitag
     An optional tag that a compiler can use for telling incompatible
     ABI's on the same architecture apart. GHCJS encodes the underlying
     GHC version in the ABI tag.
-``$abi``
+$abi
     A shortcut for getting a path that completely identifies the
     platform in terms of binary compatibility. Expands to the same value
     as ``$arch-$os-compiler-$abitag`` if the compiler uses an abi tag,
@@ -716,37 +744,53 @@ Paths in the simple build system
 
 For the simple build system, the following defaults apply:
 
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| Option                       | Windows Default                                             | Unix Default              |
-+==============================+=============================================================+===========================+
-| ``--prefix`` (global)        | ``C:\Program Files\Haskell``                                | ``/usr/local``            |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--prefix`` (per-user)      | ``C:\Documents And Settings\user\Application Data\cabal``   | ``$HOME/.cabal``          |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--bindir``                 | ``$prefix\bin``                                             | ``$prefix/bin``           |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--libdir``                 | ``$prefix``                                                 | ``$prefix/lib``           |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--libsubdir`` (others)     | ``$pkgid\$compiler``                                        | ``$pkgid/$compiler``      |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--libexecdir``             | ``$prefix\$pkgid``                                          | ``$prefix/libexec``       |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--datadir`` (executable)   | ``$prefix``                                                 | ``$prefix/share``         |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--datadir`` (library)      | ``C:\Program Files\Haskell``                                | ``$prefix/share``         |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--datasubdir``             | ``$pkgid``                                                  | ``$pkgid``                |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--docdir``                 | ``$prefix\doc\$pkgid``                                      | ``$datadir/doc/$pkgid``   |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--sysconfdir``             | ``$prefix\etc``                                             | ``$prefix/etc``           |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--htmldir``                | ``$docdir\html``                                            | ``$docdir/html``          |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--program-prefix``         | (empty)                                                     | (empty)                   |
-+------------------------------+-------------------------------------------------------------+---------------------------+
-| ``--program-suffix``         | (empty)                                                     | (empty)                   |
-+------------------------------+-------------------------------------------------------------+---------------------------+
+.. list-table:: Default installation paths
+
+    * - Option
+      - Windows Default
+      - Unix Default
+    * - :option:`--prefix` (global)
+      - ``C:\Program Files\Haskell``
+      - ``/usr/local``
+    * - :option:`--prefix` (per-user)
+      - ``C:\Documents And Settings\user\Application Data\cabal``
+      - ``$HOME/.cabal``
+    * - :option:`--bindir`
+      - ``$prefix\bin``
+      - ``$prefix/bin``
+    * - :option:`--libdir`
+      - ``$prefix``
+      - ``$prefix/lib``
+    * - :option:`--libsubdir` (others)
+      - ``$pkgid\$compiler``
+      - ``$pkgid/$compiler``
+    * - :option:`--libexecdir`
+      - ``$prefix\$pkgid``
+      - ``$prefix/libexec``
+    * - :option:`--datadir` (executable)
+      - ``$prefix``
+      - ``$prefix/share``
+    * - :option:`--datadir` (library)
+      - ``C:\Program Files\Haskell``
+      - ``$prefix/share``
+    * - :option:`--datasubdir`
+      - ``$pkgid``
+      - ``$pkgid``
+    * - :option:`--docdir`
+      - ``$prefix\doc\$pkgid``
+      - ``$datadir/doc/$pkgid``
+    * - :option:`--sysconfdir`
+      - ``$prefix\etc``
+      - ``$prefix/etc``
+    * - :option:`--htmldir`
+      - ``$docdir\html``
+      - ``$docdir/html``
+    * - :option:`--program-prefix`
+      - (empty)
+      - (empty)
+    * - :option:`--program-suffix`
+      - (empty)
+      - (empty)
 
 Prefix-independence
 """""""""""""""""""
@@ -783,12 +827,15 @@ Flag assignments (see the `resolution of conditions and
 flags <developing-packages.html#resolution-of-conditions-and-flags>`__)
 can be controlled with the following command line options.
 
-``-f`` *flagname* or ``-f`` ``-``\ *flagname*
+.. option:: -f flagname or -f -flagname
+
     Force the specified flag to ``true`` or ``false`` (if preceded with
     a ``-``). Later specifications for the same flags will override
     earlier, i.e., specifying ``-fdebug -f-debug`` is equivalent to
     ``-f-debug``
-``--flags=``\ *flagspecs*
+
+.. option:: --flags=flagspecs
+
     Same as ``-f``, but allows specifying multiple flag assignments at
     once. The parameter is a space-separated list of flag names (to
     force a flag to ``true``), optionally preceded by a ``-`` (to force
@@ -799,28 +846,36 @@ can be controlled with the following command line options.
 Building Test Suites
 ^^^^^^^^^^^^^^^^^^^^
 
-``--enable-tests``
+.. option:: --enable-tests
+
     Build the test suites defined in the package description file during
     the ``build`` stage. Check for dependencies required by the test
     suites. If the package is configured with this option, it will be
     possible to run the test suites with the ``test`` command after the
     package is built.
-``--disable-tests``
+
+.. option:: --disable-tests
+
     (default) Do not build any test suites during the ``build`` stage.
     Do not check for dependencies required only by the test suites. It
     will not be possible to invoke the ``test`` command without
     reconfiguring the package.
-``--enable-coverage``
+
+.. option:: --enable-coverage
+
     Build libraries and executables (including test suites) with Haskell
     Program Coverage enabled. Running the test suites will automatically
     generate coverage reports with HPC.
-``--disable-coverage``
+
+.. option:: --disable-coverage
+
     (default) Do not enable Haskell Program Coverage.
 
 Miscellaneous options
 ^^^^^^^^^^^^^^^^^^^^^
 
-``--user``
+.. option:: --user
+
     Does a per-user installation. This changes the `default installation
     prefix <#paths-in-the-simple-build-system>`__. It also allow
     dependencies to be satisfied by the user's package database, in
@@ -828,12 +883,16 @@ Miscellaneous options
     ``--user`` for any subsequent ``install`` command, as packages
     registered in the global database should not depend on packages
     registered in a user's database.
-``--global``
+
+.. option:: --global
+
     (default) Does a global installation. In this case package
     dependencies must be satisfied by the global package database. All
     packages in the user's package database will be ignored. Typically
     the final installation step will require administrative privileges.
-``--package-db=``\ *db*
+
+.. option:: --package-db=db
+
     Allows package dependencies to be satisfied from this additional
     package database *db* in addition to the global package database.
     All packages in the user's package database will be ignored. The
@@ -841,8 +900,8 @@ Miscellaneous options
     be a file or directory. Not all implementations support arbitrary
     package databases.
 
-    This pushes an extra db onto the db stack. The ``--global`` and
-    ``--user`` mode switches add the respective [Global] and [Global,
+    This pushes an extra db onto the db stack. The :option:`--global` and
+    :option:`--user` mode switches add the respective [Global] and [Global,
     User] dbs to the initial stack. There is a compiler-implementation
     constraint that the global db must appear first in the stack, and if
     the user one appears at all, it must appear immediately after the
@@ -850,7 +909,8 @@ Miscellaneous options
 
     To reset the stack, use ``--package-db=clear``.
 
-``--ipid=``\ *ipid*
+.. option:: --ipid=ipid
+
     Specifies the *installed package identifier* of the package to be
     built; this identifier is passed on to GHC and serves as the basis
     for linker symbols and the ``id`` field in a ``ghc-pkg``
@@ -858,33 +918,42 @@ Miscellaneous options
     component identifiers are derived off of this identifier (e.g., an
     internal library ``foo`` from package ``p-0.1-abcd`` will get the
     identifier ``p-0.1-abcd-foo``.
-``--cid=``\ *cid*
+
+.. option:: --cid=cid
+
     Specifies the *component identifier* of the component being built;
     this is only valid if you are configuring a single component.
-``--default-user-config=`` *file*
+
+.. option:: --default-user-config=file
+
     Allows a "default" ``cabal.config`` freeze file to be passed in
     manually. This file will only be used if one does not exist in the
     project directory already. Typically, this can be set from the
     global cabal ``config`` file so as to provide a default set of
     partial constraints to be used by projects, providing a way for
     users to peg themselves to stable package collections.
-``--enable-optimization``\ [=*n*] or ``-O``\ [*n*]
+
+.. option:: --enable-optimization[=n] or -O [n]
+
     (default) Build with optimization flags (if available). This is
     appropriate for production use, taking more time to build faster
     libraries and programs.
 
     The optional *n* value is the optimisation level. Some compilers
     support multiple optimisation levels. The range is 0 to 2. Level 0
-    is equivalent to ``--disable-optimization``, level 1 is the default
-    if no *n* parameter is given. Level 2 is higher optimisation if the
-    compiler supports it. Level 2 is likely to lead to longer compile
-    times and bigger generated code.
+    is equivalent to :option:`--disable-optimization`, level 1 is the
+    default if no *n* parameter is given. Level 2 is higher optimisation
+    if the compiler supports it. Level 2 is likely to lead to longer
+    compile times and bigger generated code.
 
-``--disable-optimization``
+.. option:: --disable-optimization
+
     Build without optimization. This is suited for development: building
     will be quicker, but the resulting library or programs will be
     slower.
-``--enable-profiling``
+
+.. option:: --enable-profiling
+
     Build libraries and executables with profiling enabled (for
     compilers that support profiling as a separate mode). For this to
     work, all libraries used by this package must also have been built
@@ -894,27 +963,32 @@ Miscellaneous options
     executable to be built in profiling mode.
 
     This flag covers both libraries and executables, but can be
-    overridden by the ``--enable-library-profiling`` flag.
+    overridden by the :option:`--enable-library-profiling` flag.
 
-    See also the ``--profiling-detail`` flag below.
+    See also the :option:`--profiling-detail` flag below.
 
-``--disable-profiling``
+.. option:: --disable-profiling
+
     (default) Do not enable profiling in generated libraries and
     executables.
-``--enable-library-profiling`` or ``-p``
-    As with ``--enable-profiling`` above, but it applies only for
+
+.. option:: --enable-library-profiling or -p
+
+    As with :option:`--enable-profiling` above, but it applies only for
     libraries. So this generates an additional profiling instance of the
     library in addition to the normal non-profiling instance.
 
-    The ``--enable-profiling`` flag controls the profiling mode for both
+    The :option:`--enable-profiling` flag controls the profiling mode for both
     libraries and executables, but if different modes are desired for
-    libraries versus executables then use ``--enable-library-profiling``
+    libraries versus executables then use :option:`--enable-library-profiling`
     as well.
 
-``--disable-library-profiling``
-    (default) Do not generate an additional profiling version of the
-    library.
-``--profiling-detail``\ [=*level*]
+.. option:: --disable-library-profiling
+
+    (default) Do not generate an additional profiling version of the library.
+
+.. option:: --profiling-detail[=level]
+
     Some compilers that support profiling, notably GHC, can allocate
     costs to different parts of the program and there are different
     levels of granularity or detail with which this can be done. In
@@ -922,26 +996,26 @@ Miscellaneous options
     can automatically add cost centers, and can do so in different ways.
 
     This flag covers both libraries and executables, but can be
-    overridden by the ``--library-profiling-detail`` flag.
+    overridden by the :option:`--library-profiling-detail` flag.
 
     Currently this setting is ignored for compilers other than GHC. The
     levels that cabal currently supports are:
 
-    ``default``
+    default
         For GHC this uses ``exported-functions`` for libraries and
         ``toplevel-functions`` for executables.
-    ``none``
+    none
         No costs will be assigned to any code within this component.
-    ``exported-functions``
+    exported-functions
         Costs will be assigned at the granularity of all top level
         functions exported from each module. In GHC specifically, this
         is for non-inline functions.
-    ``toplevel-functions``
+    toplevel-functions
         Costs will be assigned at the granularity of all top level
         functions in each module, whether they are exported from the
         module or not. In GHC specifically, this is for non-inline
         functions.
-    ``all-functions``
+    all-functions
         Costs will be assigned at the granularity of all functions in
         each module, whether top level or local. In GHC specifically,
         this is for non-inline toplevel or where-bound functions or
@@ -950,41 +1024,55 @@ Miscellaneous options
     This flag is new in Cabal-1.24. Prior versions used the equivalent
     of ``none`` above.
 
-``--library-profiling-detail``\ [=*level*]
-    As with ``--profiling-detail`` above, but it applies only for
+.. option:: --library-profiling-detail[=level]
+
+    As with :option:`--profiling-detail` above, but it applies only for
     libraries.
 
     The level for both libraries and executables is set by the
-    ``--profiling-detail`` flag, but if different levels are desired for
-    libraries versus executables then use ``--library-profiling-detail``
-    as well.
+    :option:`--profiling-detail` flag, but if different levels are desired
+    for libraries versus executables then use
+    :option:`--library-profiling-detail` as well.
 
-``--enable-library-vanilla``
+.. option:: --enable-library-vanilla
+
     (default) Build ordinary libraries (as opposed to profiling
     libraries). This is independent of the
-    ``--enable-library-profiling`` option. If you enable both, you get
+    :option:`--enable-library-profiling` option. If you enable both, you get
     both.
-``--disable-library-vanilla``
+
+.. option:: --disable-library-vanilla
+
     Do not build ordinary libraries. This is useful in conjunction with
-    ``--enable-library-profiling`` to build only profiling libraries,
+    :option:`--enable-library-profiling` to build only profiling libraries,
     rather than profiling and ordinary libraries.
-``--enable-library-for-ghci``
+
+.. option:: --enable-library-for-ghci
+
     (default) Build libraries suitable for use with GHCi.
-``--disable-library-for-ghci``
+
+.. option:: --disable-library-for-ghci
+
     Not all platforms support GHCi and indeed on some platforms, trying
     to build GHCi libs fails. In such cases this flag can be used as a
     workaround.
-``--enable-split-objs``
+
+.. option:: --enable-split-objs
+
     Use the GHC ``-split-objs`` feature when building the library. This
     reduces the final size of the executables that use the library by
     allowing them to link with only the bits that they use rather than
     the entire library. The downside is that building the library takes
     longer and uses considerably more memory.
-``--disable-split-objs``
+
+.. option:: --disable-split-objs
+
     (default) Do not use the GHC ``-split-objs`` feature. This makes
     building the library quicker but the final executables that use the
     library will be larger.
-``--enable-executable-stripping``
+
+.. option:: --enable-executable-stripping
+
     (default) When installing binary executable programs, run the
     ``strip`` program on the binary. This can considerably reduce the
     size of the executable binary file. It does this by removing
@@ -995,30 +1083,43 @@ Miscellaneous options
     Not all Haskell implementations generate native binaries. For such
     implementations this option has no effect.
 
-``--disable-executable-stripping``
+.. option:: --disable-executable-stripping
+
     Do not strip binary executables during installation. You might want
     to use this option if you need to debug a program using gdb, for
     example if you want to debug the C parts of a program containing
     both Haskell and C code. Another reason is if your are building a
     package for a system which has a policy of managing the stripping
     itself (such as some Linux distributions).
-``--enable-shared``
+
+.. option:: --enable-shared
+
     Build shared library. This implies a separate compiler run to
     generate position independent code as required on most platforms.
-``--disable-shared``
+
+.. option:: --disable-shared
+
     (default) Do not build shared library.
-``--enable-executable-dynamic``
+
+.. option:: --enable-executable-dynamic
+
     Link executables dynamically. The executable's library dependencies
-    should be built as shared objects. This implies ``--enable-shared``
-    unless ``--disable-shared`` is explicitly specified.
-``--disable-executable-dynamic``
-    (default) Link executables statically.
-``--configure-option=``\ *str*
+    should be built as shared objects. This implies :option:`--enable-shared`
+    unless :option:`--disable-shared` is explicitly specified.
+
+.. option:: --disable-executable-dynamic
+
+   (default) Link executables statically.
+
+.. option:: --configure-option=str
+
     An extra option to an external ``configure`` script, if one is used
     (see the section on `system-dependent
     parameters <developing-packages.html#system-dependent-parameters>`__).
     There can be several of these options.
-``--extra-include-dirs``\ [=*dir*]
+
+.. option:: --extra-include-dirs[=dir]
+
     An extra directory to search for C header files. You can use this
     flag multiple times to get a list of directories.
 
@@ -1032,10 +1133,13 @@ Miscellaneous options
     and for libraries it is also saved in the package registration
     information and used when compiling modules that use the library.
 
-``--extra-lib-dirs``\ [=*dir*]
+.. option:: --extra-lib-dirs[=dir]
+
     An extra directory to search for system libraries files. You can use
     this flag multiple times to get a list of directories.
-``--extra-framework-dirs``\ [=*dir*]
+
+.. option:: --extra-framework-dirs[=dir]
+
     An extra directory to search for frameworks (OS X only). You can use
     this flag multiple times to get a list of directories.
 
@@ -1049,24 +1153,29 @@ Miscellaneous options
     and for libraries it is also saved in the package registration
     information and used when compiling modules that use the library.
 
-``--dependency``\ [=*pkgname*\ =\ *ipid*]
+.. option:: --dependency[=pkgname=ipid]
+
     Specify that a particular dependency should used for a particular
     package name. In particular, it declares that any reference to
     *pkgname* in a ``build-depends`` should be resolved to *ipid*.
-``--exact-configuration``
+
+.. option:: --exact-configuration
+
     This changes Cabal to require every dependency be explicitly
-    specified using ``--dependency``, rather than use Cabal's (very
+    specified using :option:`--dependency`, rather than use Cabal's (very
     simple) dependency solver. This is useful for programmatic use of
     Cabal's API, where you want to error if you didn't specify enough
-    ``--dependency`` flags.
-``--allow-newer``\ [=*pkgs*], ``--allow-older``\ [=*pkgs*]
+    :option:`--dependency` flags.
+
+.. option:: --allow-newer[=pkgs], --allow-older[=pkgs]
+
     Selectively relax upper or lower bounds in dependencies without
     editing the package description respectively.
 
     The following description focuses on upper bounds and the
-    ``--allow-newer`` flag, but applies analogously to ``--allow-older``
-    and lower bounds. ``--allow-newer`` and ``--allow-older`` can be
-    used at the same time.
+    :option:`--allow-newer` flag, but applies analogously to
+    :option:`--allow-older` and lower bounds. :option:`--allow-newer`
+    and :option:`--allow-older` can be used at the same time.
 
     If you want to install a package A that depends on B >= 1.0 && <
     2.0, but you have the version 2.0 of B installed, you can compile A
@@ -1100,7 +1209,7 @@ Miscellaneous options
         # Relax the upper bound on bar and force bar==2.1.
         $ cabal install --allow-newer=bar --constraint="bar==2.1" foo
 
-    It's also possible to limit the scope of ``--allow-newer`` to single
+    It's also possible to limit the scope of :option:`--allow-newer` to single
     packages with the ``--allow-newer=scope:dep`` syntax. This means
     that the dependency on ``dep`` will be relaxed only for the package
     ``scope``.
@@ -1118,12 +1227,13 @@ Miscellaneous options
         # any package.
         $ cabal install --allow-newer=foo:base,lens --allow-newer=bar:time
 
-    Finally, one can enable ``--allow-newer`` permanently by setting
+    Finally, one can enable :option:`--allow-newer` permanently by setting
     ``allow-newer: True`` in the ``~/.cabal/config`` file. Enabling
     'allow-newer' selectively is also supported in the config file
     (``allow-newer: foo, bar, baz:base``).
 
-``--constraint=``\ *constraint*
+.. option:: --constraint=constraint
+
     Restrict solutions involving a package to a given version range. For
     example, ``cabal install --constraint="bar==2.1"`` will only
     consider install plans that do not use ``bar`` at all, or ``bar`` of
@@ -1137,7 +1247,8 @@ Miscellaneous options
     flag ``foo`` should be turned on and the ``baz`` flag should be
     turned off.
 
-``--preference=``\ *preference*
+.. option:: --preference=preference
+
     Specify a soft constraint on versions of a package. The solver will
     attempt to satisfy these preferences on a "best-effort" basis.
 
@@ -1149,7 +1260,10 @@ ready for installation.
 
 This command takes the following options:
 
---*prog*-options=*options*, --*prog*-option=*option*
+.. program:: setup build
+
+.. option:: --prog-options=options, --prog-option=option
+
     These are mostly the same as the `options configure
     step <#setup-configure>`__. Unlike the options specified at the
     configure step, any program options specified at the build step are
@@ -1160,18 +1274,23 @@ This command takes the following options:
 setup haddock
 -------------
 
+.. program:: setup haddock
+
 Build the documentation for the package using Haddock_.
 By default, only the documentation for the exposed modules is generated
-(but see the ``--executables`` and ``--internal`` flags below).
+(but see the :option:`--executables` and :option:`--internal` flags below).
 
 This command takes the following options:
 
-``--hoogle``
+.. option:: --hoogle
+
     Generate a file ``dist/doc/html/``\ *pkgid*\ ``.txt``, which can be
     converted by Hoogle_ into a
     database for searching. This is equivalent to running Haddock_
     with the ``--hoogle`` flag.
-``--html-location=``\ *url*
+
+.. option:: --html-location=url
+
     Specify a template for the location of HTML documentation for
     prerequisite packages. The substitutions (`see
     listing <#paths-in-the-simple-build-system>`__) are applied to the
@@ -1186,50 +1305,56 @@ This command takes the following options:
     this option is omitted, the location for each package is obtained
     using the package tool (e.g. ``ghc-pkg``).
 
-``--executables``
+.. option:: --executables
+
     Also run Haddock_ for the modules of all the executable programs. By default
     Haddock_ is run only on the exported modules.
-``--internal``
+
+.. option:: --internal
+
     Run Haddock_ for the all
     modules, including unexposed ones, and make
     Haddock_ generate documentation
     for unexported symbols as well.
-``--css=``\ *path*
+
+.. option:: --css=path
+
     The argument *path* denotes a CSS file, which is passed to
     Haddock_ and used to set the
     style of the generated documentation. This is only needed to
     override the default style that
     Haddock_ uses.
-``--hyperlink-source``
-    Generate Haddock_ documentation
-    integrated with
-    `HsColour <http://www.cs.york.ac.uk/fp/darcs/hscolour/>`__. First,
-    `HsColour <http://www.cs.york.ac.uk/fp/darcs/hscolour/>`__ is run to
-    generate colourised code. Then
-    Haddock_ is run to generate
-    HTML documentation. Each entity shown in the documentation is linked
-    to its definition in the colourised code.
-``--hscolour-css=``\ *path*
-    The argument *path* denotes a CSS file, which is passed to
-    `HsColour <http://www.cs.york.ac.uk/fp/darcs/hscolour/>`__ as in
+
+.. option:: --hyperlink-source
+
+    Generate Haddock_ documentation integrated with HsColour_ . First,
+    HsColour_ is run to generate colourised code. Then Haddock_ is run to
+    generate HTML documentation. Each entity shown in the documentation is
+    linked to its definition in the colourised code.
+
+.. option:: --hscolour-css=path
+
+    The argument *path* denotes a CSS file, which is passed to HsColour_ as in
 
         runhaskell Setup.hs hscolour --css=*path*
 
 setup hscolour
 --------------
 
-Produce colourised code in HTML format using
-`HsColour <http://www.cs.york.ac.uk/fp/darcs/hscolour/>`__. Colourised
-code for exported modules is put in
-``dist/doc/html/``\ *pkgid*\ ``/src``.
+Produce colourised code in HTML format using HsColour_. Colourised code for
+exported modules is put in ``dist/doc/html/``\ *pkgid*\ ``/src``.
 
 This command takes the following options:
 
-``--executables``
-    Also run `HsColour <http://www.cs.york.ac.uk/fp/darcs/hscolour/>`__
-    on the sources of all executable programs. Colourised code is put in
-    ``dist/doc/html/``\ *pkgid*/*executable*\ ``/src``.
-``--css=``\ *path*
+.. program:: setup hscolour
+
+.. option:: --executables
+
+    Also run HsColour_ on the sources of all executable programs. Colourised
+    code is put in ``dist/doc/html/``\ *pkgid*/*executable*\ ``/src``.
+
+.. option:: --css=path
+
     Use the given CSS file for the generated HTML files. The CSS file
     defines the colours used to colourise code. Note that this copies
     the given CSS file to the directory with the generated HTML files
@@ -1237,6 +1362,8 @@ This command takes the following options:
 
 setup install
 -------------
+
+.. program:: setup install
 
 Copy the files into the install locations and (for library packages)
 register the package with the compiler, i.e. make the modules it
@@ -1247,14 +1374,17 @@ options to ``setup configure``.
 
 This command takes the following options:
 
-``--global``
+.. option:: --global
+
     Register this package in the system-wide database. (This is the
-    default, unless the ``--user`` option was supplied to the
-    ``configure`` command.)
-``--user``
+    default, unless the :option:`setup configure --user` option was supplied
+    to the ``configure`` command.)
+
+.. option:: --user
+
     Register this package in the user's local package database. (This is
-    the default if the ``--user`` option was supplied to the
-    ``configure`` command.)
+    the default if the :option:`setup configure --user` option was supplied
+    to the ``configure`` command.)
 
 setup copy
 ----------
@@ -1264,10 +1394,12 @@ to those creating binary packages.
 
 This command takes the following option:
 
-``--destdir=``\ *path*
+.. program:: setup copy
 
-Specify the directory under which to place installed files. If this is
-not given, then the root directory is assumed.
+.. option:: --destdir=path
+
+   Specify the directory under which to place installed files. If this is
+   not given, then the root directory is assumed.
 
 setup register
 --------------
@@ -1280,24 +1412,33 @@ for a binary package.
 
 This command takes the following options:
 
-``--global``
+.. program:: setup register
+
+.. option:: --global
+
     Register this package in the system-wide database. (This is the
     default.)
-``--user``
+
+.. option:: --user
+
     Register this package in the user's local package database.
-``--gen-script``
+
+.. option:: --gen-script
+
     Instead of registering the package, generate a script containing
     commands to perform the registration. On Unix, this file is called
     ``register.sh``, on Windows, ``register.bat``. This script might be
     included in a binary bundle, to be run after the bundle is unpacked
     on the target system.
-``--gen-pkg-config``\ [=*path*]
+
+.. option:: --gen-pkg-config[=path]
+
     Instead of registering the package, generate a package registration
     file (or directory, in some circumstances). This only applies to
     compilers that support package registration files which at the
     moment is only GHC. The file should be used with the compiler's
     mechanism for registering packages. This option is mainly intended
-    for packaging systems. If possible use the ``--gen-script`` option
+    for packaging systems. If possible use the :option:`--gen-script` option
     instead since it is more portable across Haskell implementations.
     The *path* is optional and can be used to specify a particular
     output file to generate. Otherwise, by default the file is the
@@ -1308,7 +1449,8 @@ This command takes the following options:
     used. These configuration file names are sorted so that they can be
     registered in order.
 
-``--inplace``
+.. option:: --inplace
+
     Registers the package for use directly from the build tree, without
     needing to install it. This can be useful for testing: there's no
     need to install the package after modifying it, just recompile and
@@ -1325,16 +1467,23 @@ This command takes the following options:
 setup unregister
 ----------------
 
+.. program:: setup unregister
+
 Deregister this package with the compiler.
 
 This command takes the following options:
 
-``--global``
+.. option:: --global
+
     Deregister this package in the system-wide database. (This is the
     default.)
-``--user``
+
+.. option:: --user
+
     Deregister this package in the user's local package database.
-``--gen-script``
+
+.. option:: --gen-script
+
     Instead of deregistering the package, generate a script containing
     commands to perform the deregistration. On Unix, this file is called
     ``unregister.sh``, on Windows, ``unregister.bat``. This script might
@@ -1349,7 +1498,10 @@ and directories listed in the ``extra-tmp-files`` field.
 
 This command takes the following options:
 
-``--save-configure`` or ``-s``
+.. program:: setup clean
+
+.. option:: --save-configure, -s
+
     Keeps the configuration information so it is not necessary to run
     the configure step again before building.
 
@@ -1362,29 +1514,41 @@ suites on the command line after ``test``. When supplied, Cabal will run
 only the named test suites, otherwise, Cabal will run all test suites in
 the package.
 
-``--builddir=``\ *dir*
+.. program:: setup test
+
+.. option:: --builddir=dir
+
     The directory where Cabal puts generated build files (default:
     ``dist``). Test logs will be located in the ``test`` subdirectory.
-``--human-log=``\ *path*
+
+.. option:: --human-log=path
+
     The template used to name human-readable test logs; the path is
     relative to ``dist/test``. By default, logs are named according to
     the template ``$pkgid-$test-suite.log``, so that each test suite
     will be logged to its own human-readable log file. Template
     variables allowed are: ``$pkgid``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``, ``$test-suite``, and ``$result``.
-``--machine-log=``\ *path*
+
+.. option:: --machine-log=path
+
     The path to the machine-readable log, relative to ``dist/test``. The
     default template is ``$pkgid.log``. Template variables allowed are:
     ``$pkgid``, ``$compiler``, ``$os``, ``$arch``, ``$abi``, ``$abitag``
     and ``$result``.
-``--show-details=``\ *filter*
+
+.. option:: --show-details=filter
+
     Determines if the results of individual test cases are shown on the
     terminal. May be ``always`` (always show), ``never`` (never show),
     ``failures`` (show only failed results), or ``streaming`` (show all
     results in real time).
-``--test-options=``\ *options*
+
+.. option:: --test-options=options
     Give extra options to the test executables.
-``--test-option=``\ *option*
+
+.. option:: --test-option=option
+
     give an extra option to the test executables. There is no need to
     quote options containing spaces because a single option is assumed,
     so options will not be split on spaces.
@@ -1405,7 +1569,10 @@ and ``extra-doc-files`` fields.
 
 This command takes the following option:
 
-``--snapshot``
+.. program:: setup sdist
+
+.. option:: --snapshot
+
     Append today's date (in "YYYYMMDD" format) to the version number for
     the generated source package. The original package is unaffected.
 

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -747,44 +747,44 @@ For the simple build system, the following defaults apply:
 .. list-table:: Default installation paths
 
     * - Option
-      - Windows Default
       - Unix Default
+      - Windows Default
     * - :option:`--prefix` (global)
-      - ``C:\Program Files\Haskell``
       - ``/usr/local``
+      - ``%PROGRAMFILES%\Haskell``
     * - :option:`--prefix` (per-user)
-      - ``C:\Documents And Settings\user\Application Data\cabal``
       - ``$HOME/.cabal``
+      - ``%APPDATA%\cabal``
     * - :option:`--bindir`
-      - ``$prefix\bin``
       - ``$prefix/bin``
+      - ``$prefix\bin``
     * - :option:`--libdir`
-      - ``$prefix``
       - ``$prefix/lib``
-    * - :option:`--libsubdir` (others)
-      - ``$pkgid\$compiler``
-      - ``$pkgid/$compiler``
-    * - :option:`--libexecdir`
-      - ``$prefix\$pkgid``
-      - ``$prefix/libexec``
-    * - :option:`--datadir` (executable)
       - ``$prefix``
+    * - :option:`--libsubdir` (others)
+      - ``$pkgid/$compiler``
+      - ``$pkgid\$compiler``
+    * - :option:`--libexecdir`
+      - ``$prefix/libexec``
+      - ``$prefix\$pkgid``
+    * - :option:`--datadir` (executable)
       - ``$prefix/share``
+      - ``$prefix``
     * - :option:`--datadir` (library)
-      - ``C:\Program Files\Haskell``
       - ``$prefix/share``
+      - ``%PROGRAMFILES%\Haskell``
     * - :option:`--datasubdir`
       - ``$pkgid``
       - ``$pkgid``
     * - :option:`--docdir`
-      - ``$prefix\doc\$pkgid``
       - ``$datadir/doc/$pkgid``
+      - ``$prefix\doc\$pkgid``
     * - :option:`--sysconfdir`
-      - ``$prefix\etc``
       - ``$prefix/etc``
+      - ``$prefix\etc``
     * - :option:`--htmldir`
-      - ``$docdir\html``
       - ``$docdir/html``
+      - ``$docdir\html``
     * - :option:`--program-prefix`
       - (empty)
       - (empty)

--- a/Cabal/doc/references.inc
+++ b/Cabal/doc/references.inc
@@ -17,4 +17,6 @@
 
 .. _Hoogle: http://www.haskell.org/hoogle/
 
+.. _HsColour: http://www.cs.york.ac.uk/fp/darcs/hscolour/
+
 .. _cpphs: http://projects.haskell.org/cpphs/


### PR DESCRIPTION
Makes installing-packages.rst less noisy by replacing most of monospace
markup with `.. option::`. This makes it possible to reference options
from other parts of docs and adds them to index.

Index is no longer empty so it is added to nav menu via template
override in _template folder

[preview](https://sopvop.github.io/cabal/installing-packages.html#programs-used-for-building)
and [index](https://sopvop.github.io/cabal/genindex.html)