### PR TITLE
Use security by default for central hackage repo

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -532,13 +532,9 @@ addInfoForKnownRepos repo
                   remoteRepoKeyThreshold = 0
                 } | secure /= Just False
             = r {
-              --TODO: When we want to switch us from using opt-in to opt-out
-              -- security for the central hackage server, uncomment the
-              -- following line. That will cause the default (of unspecified)
-              -- to get interpreted as if it were "secure: True". For the
-              -- moment it means the keys get added but you have to manually
-              -- set "secure: True" to opt-in.
-              --remoteRepoSecure       = Just True,
+                -- Use hackage-security by default unless you opt-out with
+                -- secure: False
+                remoteRepoSecure       = Just True,
                 remoteRepoRootKeys     = defaultHackageRemoteRepoKeys,
                 remoteRepoKeyThreshold = defaultHackageRemoteRepoKeyThreshold
               }


### PR DESCRIPTION
Change the default from opt-in to opt-out, so if you're using the default config, ie no "secure: True/False" field set, then we now default to True rather than to False. So users can still opt-out by setting "secure: False" in the hackage repo section, like:

    repository hackage.haskell.org
      url: http://hackage.haskell.org/
      secure: False

So we should start to get all cabal head users using this, but we probably do not want to backport it to the 1.24 branch, at least not yet.