### PR TITLE
WGET doesn't support range requests, so we should ignore them when using it

### DIFF
--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -413,10 +413,20 @@ curlTransport prog =
 
 wgetTransport :: ConfiguredProgram -> HttpTransport
 wgetTransport prog =
-    HttpTransport gethttp posthttp posthttpfile puthttpfile True False
+  HttpTransport gethttp posthttp posthttpfile puthttpfile True False
   where
-    gethttp verbosity uri etag destPath reqHeaders = do
+    gethttp verbosity uri etag destPath reqHeaders =  do
         resp <- runWGet verbosity uri args
+
+        -- wget doesn't support range requests.
+        -- so, we not only ignore range request headers,
+        -- but we also dispay a warning message when we see them.
+        let hasRangeHeader =  any (\hdr -> isRangeHeader hdr) reqHeaders
+            warningMsg =    "the 'wget' transport currently doesn't support range requests, which wastes network bandwidth."
+                            ++ " To fix this, set 'http-transport' to 'curl' or 'plain-http' in '~/.cabal/config'."
+                            ++ " Note that the 'plain-http' transport doesn't support HTTPS.\n"
+
+        when (hasRangeHeader) $ warn verbosity warningMsg
         (code, etag') <- parseOutput uri resp
         return (code, etag')
       where
@@ -429,7 +439,13 @@ wgetTransport prog =
                [ ["--header", "If-None-Match: " ++ t]
                | t <- maybeToList etag ]
             ++ [ "--header=" ++ show name ++ ": " ++ value
-               | Header name value <- reqHeaders ]
+               | hdr@(Header name value) <- reqHeaders, (not (isRangeHeader hdr)) ]
+
+        -- wget doesn't support range requests.
+        -- so, we ignore range request headers, lest we get errors.
+        isRangeHeader :: Header -> Bool
+        isRangeHeader (Header HdrRange _) = True
+        isRangeHeader _ = False
 
     posthttp = noPostYet
 


### PR DESCRIPTION
Ignore HTTP range requests when using 'wget', as it doesn't support them and would instead fail.