### PR TITLE
Track cabal.project provenance for error reporting

### DIFF
--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -242,6 +242,7 @@ convertLegacyProjectConfig
 
       projectConfigBuildOnly       = configBuildOnly,
       projectConfigShared          = configAllPackages,
+      projectConfigProvenance      = mempty,
       projectConfigLocalPackages   = configLocalPackages,
       projectConfigSpecificPackage = fmap perPackage legacySpecificConfig
     }

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -8,6 +8,7 @@ module Distribution.Client.ProjectConfig.Types (
     ProjectConfig(..),
     ProjectConfigBuildOnly(..),
     ProjectConfigShared(..),
+    ProjectConfigProvenance(..),
     PackageConfig(..),
 
     -- * Resolving configuration
@@ -53,6 +54,7 @@ import Distribution.Verbosity
 
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Set (Set)
 import Distribution.Compat.Binary (Binary)
 import Distribution.Compat.Semigroup
 import GHC.Generics (Generic)
@@ -104,6 +106,7 @@ data ProjectConfig
        -- values are about:
        projectConfigBuildOnly       :: ProjectConfigBuildOnly,
        projectConfigShared          :: ProjectConfigShared,
+       projectConfigProvenance      :: Set ProjectConfigProvenance,
 
        -- | Configuration to be applied to *local* packages; i.e.,
        -- any packages which are explicitly named in `cabal.project`.
@@ -186,6 +189,21 @@ data ProjectConfigShared
   deriving (Eq, Show, Generic)
 
 
+-- | Specifies the provenance of project configuration, whether defaults were
+-- used or if the configuration was read from an explicit file path.
+data ProjectConfigProvenance
+
+     -- | The configuration is implicit due to no explicit configuration
+     -- being found. See 'Distribution.Client.ProjectConfig.readProjectConfig'
+     -- for how implicit configuration is determined.
+   = Implicit
+
+     -- | The path the project configuration was explicitly read from.
+     -- | The configuration was explicitly read from the specified 'FilePath'.
+   | Explicit FilePath
+  deriving (Eq, Ord, Show, Generic)
+
+
 -- | Project configuration that is specific to each package, that is where we
 -- can in principle have different values for different packages in the same
 -- project.
@@ -239,6 +257,7 @@ data PackageConfig
 instance Binary ProjectConfig
 instance Binary ProjectConfigBuildOnly
 instance Binary ProjectConfigShared
+instance Binary ProjectConfigProvenance
 instance Binary PackageConfig
 
 

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -69,7 +69,7 @@ tests config =
 
 testExceptionInFindingPackage :: ProjectConfig -> Assertion
 testExceptionInFindingPackage config = do
-    BadPackageLocations locs <- expectException "BadPackageLocations" $
+    BadPackageLocations _ locs <- expectException "BadPackageLocations" $
       void $ planProject testdir config
     case locs of
       [BadLocGlobEmptyMatch "./*.cabal"] -> return ()
@@ -81,7 +81,7 @@ testExceptionInFindingPackage config = do
 
 testExceptionInFindingPackage2 :: ProjectConfig -> Assertion
 testExceptionInFindingPackage2 config = do
-    BadPackageLocations locs <- expectException "BadPackageLocations" $
+    BadPackageLocations _ locs <- expectException "BadPackageLocations" $
       void $ planProject testdir config
     case locs of
       [BadPackageLocationFile (BadLocDirNoCabalFile ".")] -> return ()


### PR DESCRIPTION
This changes the error when a `cabal.project` is missing from:

```
% cabal new-build
The package location glob 'foo./*.cabal' does not match any files or directories.
```

To (Implicit):

```
% cabal new-build
When using an implicit cabal.project configuration, the following errors were encountered:
The package location glob './*.cabal' does not match any files or directories.
```

Or (Explicit):

```
% cabal new-build
When using the configuration located at /home/bren/proj/cabal/cabal.project, the following errors were encountered:
The package location glob './*.cabal' does not match any files or directories.
```

This is done by tracking the provenance of the `cabal.project` file in `readProjectLocalConfig`, otherwise it defaults to `Implicit`.

The `ProjectConfig` is now also passed to `BadPackageLocations` and can be utilised in `renderBadPackageLocation`, although only the provenance is used currently to formulate a title specifying what configuration was used. This will hopefully allow individual calls to `renderBadPackageLocation` to be much more informative.

Note: I'm not certain the `Semigroup` and `Monoid` instances make sense for `ProjectConfigProvenance`.

Fixes #3636 