### PR TITLE
Store secure repo index data as 01-index.*

### DIFF
--- a/cabal-install/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/Distribution/Client/GlobalFlags.hs
@@ -250,8 +250,15 @@ initSecureRepo verbosity httpLib RemoteRepo{..} cachePath = \callback -> do
     cache :: Sec.Cache
     cache = Sec.Cache {
         cacheRoot   = cachePath
-      , cacheLayout = Sec.cabalCacheLayout
+      , cacheLayout = Sec.cabalCacheLayout {
+            Sec.cacheLayoutIndexTar   = cacheFn "01-index.tar"
+          , Sec.cacheLayoutIndexIdx   = cacheFn "01-index.tar.idx"
+          , Sec.cacheLayoutIndexTarGz = cacheFn "01-index.tar.gz"
+          }
       }
+
+    cacheFn :: FilePath -> Sec.CachePath
+    cacheFn = Sec.rootPath . Sec.fragment
 
     -- We display any TUF progress only in verbose mode, including any transient
     -- verification errors. If verification fails, then the final exception that


### PR DESCRIPTION
"Secure" cabal repositories use a new extended & incremental
`01-index.tar`. In order to avoid issues resulting from clobbering
new/old-style index data, we save them locally to different names.

With this patch, secure repos generate/update the files below on `cabal update`

- `01-index.cache`
- `01-index.tar`
- `01-index.tar.gz`
- `01-index.tar.idx`
- `mirrors.json`
- `root.json`
- `snapshot.json`
- `timestamp.json`

...while the legacy codepaths for non-secure repos operate on the files

- `00-index.cache`
- `00-index.tar`
- `00-index.tar.gz`
- `00-index.tar.gz.etag`

This way the old/new codepaths don't interfere with each other anymore.

Note: The format of `01-index.cache` file will be extended by the upcoming `--index-state` feature

This trivially addresses #3854