### PR TITLE
Installplan installed state

### DIFF
--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -159,6 +159,7 @@ import Prelude hiding (lookup)
 data GenericPlanPackage ipkg srcpkg
    = PreExisting ipkg
    | Configured  srcpkg
+   | Installed   srcpkg
   deriving (Eq, Show, Generic)
 
 type IsUnit a = (IsNode a, Key a ~ UnitId)
@@ -172,9 +173,11 @@ instance (IsNode ipkg, IsNode srcpkg, Key ipkg ~ UnitId, Key srcpkg ~ UnitId)
          => IsNode (GenericPlanPackage ipkg srcpkg) where
     type Key (GenericPlanPackage ipkg srcpkg) = UnitId
     nodeKey (PreExisting ipkg) = nodeKey ipkg
-    nodeKey (Configured spkg) = nodeKey spkg
+    nodeKey (Configured  spkg) = nodeKey spkg
+    nodeKey (Installed   spkg) = nodeKey spkg
     nodeNeighbors (PreExisting ipkg) = nodeNeighbors ipkg
-    nodeNeighbors (Configured spkg) = nodeNeighbors spkg
+    nodeNeighbors (Configured  spkg) = nodeNeighbors spkg
+    nodeNeighbors (Installed   spkg) = nodeNeighbors spkg
 
 instance (Binary ipkg, Binary srcpkg)
       => Binary (GenericPlanPackage ipkg srcpkg)
@@ -186,17 +189,20 @@ instance (Package ipkg, Package srcpkg) =>
          Package (GenericPlanPackage ipkg srcpkg) where
   packageId (PreExisting ipkg)     = packageId ipkg
   packageId (Configured  spkg)     = packageId spkg
+  packageId (Installed   spkg)     = packageId spkg
 
 instance (HasUnitId ipkg, HasUnitId srcpkg) =>
          HasUnitId
          (GenericPlanPackage ipkg srcpkg) where
   installedUnitId (PreExisting ipkg) = installedUnitId ipkg
   installedUnitId (Configured  spkg) = installedUnitId spkg
+  installedUnitId (Installed   spkg) = installedUnitId spkg
 
 instance (HasConfiguredId ipkg, HasConfiguredId srcpkg) =>
           HasConfiguredId (GenericPlanPackage ipkg srcpkg) where
     configuredId (PreExisting ipkg) = configuredId ipkg
-    configuredId (Configured pkg) = configuredId pkg
+    configuredId (Configured  spkg) = configuredId spkg
+    configuredId (Installed   spkg) = configuredId spkg
 
 data GenericInstallPlan ipkg srcpkg = GenericInstallPlan {
     planIndex      :: !(PlanIndex ipkg srcpkg),
@@ -255,6 +261,7 @@ showInstallPlan = showPlanIndex . planIndex
 showPlanPackageTag :: GenericPlanPackage ipkg srcpkg -> String
 showPlanPackageTag (PreExisting _)   = "PreExisting"
 showPlanPackageTag (Configured  _)   = "Configured"
+showPlanPackageTag (Installed   _)   = "Installed"
 
 -- | Build an installation plan from a valid set of resolved packages.
 --
@@ -509,17 +516,18 @@ ready plan =
     !processing =
       Processing
         (Set.fromList [ nodeKey pkg | pkg <- readyPackages ])
-        (Set.fromList [ nodeKey pkg | PreExisting pkg <- toList plan ])
+        (Set.fromList [ nodeKey pkg | pkg <- toList plan, isInstalled pkg ])
         Set.empty
     readyPackages =
       [ ReadyPackage pkg
       | Configured pkg <- toList plan
-      , all isPreExisting (directDeps plan (nodeKey pkg))
+      , all isInstalled (directDeps plan (nodeKey pkg))
       ]
 
-    isPreExisting (PreExisting {}) = True
-    isPreExisting _                = False
-
+isInstalled :: GenericPlanPackage a b -> Bool
+isInstalled (PreExisting {}) = True
+isInstalled (Installed   {}) = True
+isInstalled _                = False
 
 -- | Given a package in the processing state, mark the package as completed
 -- and return any packages that are newly in the processing state (ie ready to
@@ -592,6 +600,7 @@ processingInvariant plan (Processing processingSet completedSet failedSet) =
  && and [ case Graph.lookup pkgid (planIndex plan) of
             Just (Configured  _) -> True
             Just (PreExisting _) -> False
+            Just (Installed   _) -> False
             Nothing              -> False 
         | pkgid <- Set.toList processingSet ++ Set.toList failedSet ]
   where

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -33,7 +33,6 @@ module Distribution.Client.InstallPlan (
   fromSolverInstallPlan,
   configureInstallPlan,
   remove,
-  preexisting,
   installed,
   lookup,
   directDeps,
@@ -290,26 +289,6 @@ remove shouldRemove plan =
   where
     newIndex = Graph.fromList $
                  filter (not . shouldRemove) (toList plan)
-
--- | Replace a ready package with a pre-existing one. The pre-existing one
--- must have exactly the same dependencies as the source one was configured
--- with.
---
-preexisting :: (IsUnit ipkg,
-                IsUnit srcpkg)
-            => UnitId
-            -> ipkg
-            -> GenericInstallPlan ipkg srcpkg
-            -> GenericInstallPlan ipkg srcpkg
-preexisting pkgid ipkg plan = plan'
-  where
-    plan' = plan {
-      planIndex   = Graph.insert (PreExisting ipkg)
-                    -- ...but be sure to use the *old* IPID for the lookup for
-                    -- the preexisting record
-                  . Graph.deleteKey pkgid
-                  $ planIndex plan
-    }
 
 -- | Change a package in a 'Configured' state to an 'Installed' state.
 --

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -262,6 +262,9 @@ rebuildTargetsDryRun verbosity distDirLayout@DistDirLayout{..} shared = \install
     dryRunPkg (InstallPlan.PreExisting _pkg) _depsBuildStatus =
       return BuildStatusPreExisting
 
+    dryRunPkg (InstallPlan.Installed _pkg) _depsBuildStatus =
+      return BuildStatusPreExisting --TODO: distinguish installed state
+
     dryRunPkg (InstallPlan.Configured pkg) depsBuildStatus = do
       mloc <- checkFetched (elabPkgSourceLocation pkg)
       case mloc of

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -492,7 +492,8 @@ printPlan verbosity
     showFlagName (PD.FlagName f) = f
 
     showBuildStatus status = case status of
-      BuildStatusPreExisting -> "already installed"
+      BuildStatusPreExisting -> "existing package"
+      BuildStatusInstalled   -> "already installed"
       BuildStatusDownload {} -> "requires download & build"
       BuildStatusUnpack   {} -> "requires build"
       BuildStatusRebuild _ rebuild -> case rebuild of

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2723,13 +2723,11 @@ packageHashConfigInputs
 improveInstallPlanWithInstalledPackages :: Set UnitId
                                         -> ElaboratedInstallPlan
                                         -> ElaboratedInstallPlan
-improveInstallPlanWithInstalledPackages installedPkgIdSet installPlan =
-    replaceWithInstalled installPlan
-      [ installedUnitId pkg
-      | InstallPlan.Configured pkg
-          <- InstallPlan.reverseTopologicalOrder installPlan
-      , canPackageBeImproved pkg ]
+improveInstallPlanWithInstalledPackages installedPkgIdSet =
+    InstallPlan.installed canPackageBeImproved
   where
+    canPackageBeImproved pkg =
+      installedUnitId pkg `Set.member` installedPkgIdSet
     --TODO: sanity checks:
     -- * the installed package must have the expected deps etc
     -- * the installed package must not be broken, valid dep closure
@@ -2737,9 +2735,3 @@ improveInstallPlanWithInstalledPackages installedPkgIdSet installPlan =
     --TODO: decide what to do if we encounter broken installed packages,
     -- since overwriting is never safe.
 
-    canPackageBeImproved pkg =
-      installedUnitId pkg `Set.member` installedPkgIdSet
-
-    replaceWithInstalled :: ElaboratedInstallPlan -> [UnitId]
-                         -> ElaboratedInstallPlan
-    replaceWithInstalled = foldl' (flip InstallPlan.installed)

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1235,6 +1235,7 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
                 case elabPkgOrComp elab of
                     ElabPackage _ -> True
                     ElabComponent comp -> compSolverName comp == CD.ComponentLib
+            is_lib (InstallPlan.Installed _) = unexpectedState
 
     elaborateExeSolverId :: (SolverId -> [ElaboratedPlanPackage])
                       -> SolverId -> [ConfiguredId]
@@ -1247,6 +1248,7 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
                         case compSolverName comp of
                             CD.ComponentExe _ -> True
                             _ -> False
+            is_exe (InstallPlan.Installed _) = unexpectedState
 
     elaborateExePath :: (SolverId -> [ElaboratedPlanPackage])
                      -> SolverId -> [FilePath]
@@ -1269,6 +1271,9 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
                                     Just (Just n) -> n
                                     _ -> ""
               else InstallDirs.bindir (elabInstallDirs elab)]
+        get_exe_path (InstallPlan.Installed _) = unexpectedState
+
+    unexpectedState = error "elaborateInstallPlan: unexpected Installed state"
 
     elaborateSolverToPackage :: (SolverId -> [ElaboratedPlanPackage])
                              -> SolverPackage UnresolvedPkgLoc
@@ -1994,6 +1999,8 @@ mapConfiguredPackage :: (srcpkg -> srcpkg')
                      -> InstallPlan.GenericPlanPackage ipkg srcpkg'
 mapConfiguredPackage f (InstallPlan.Configured pkg) =
   InstallPlan.Configured (f pkg)
+mapConfiguredPackage f (InstallPlan.Installed pkg) =
+  InstallPlan.Installed (f pkg)
 mapConfiguredPackage _ (InstallPlan.PreExisting pkg) =
   InstallPlan.PreExisting pkg
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -91,7 +91,6 @@ import qualified Distribution.PackageDescription as Cabal
 import qualified Distribution.PackageDescription as PD
 import qualified Distribution.PackageDescription.Configuration as PD
 import           Distribution.Simple.PackageIndex (InstalledPackageIndex)
-import qualified Distribution.Simple.PackageIndex as PackageIndex
 import           Distribution.Simple.Compiler hiding (Flag)
 import qualified Distribution.Simple.GHC   as GHC   --TODO: [code cleanup] eliminate
 import qualified Distribution.Simple.GHCJS as GHCJS --TODO: [code cleanup] eliminate
@@ -606,22 +605,23 @@ rebuildInstallPlan verbosity
 
         liftIO $ debug verbosity "Improving the install plan..."
         recreateDirectory verbosity True storeDirectory
-        storePkgIndex <- getPackageDBContents verbosity
-                                              compiler progdb platform
-                                              storePackageDb
-        storeExeIndex <- getExecutableDBContents storeDirectory
+        liftIO $ createPackageDBIfMissing verbosity
+                                          compiler progdb
+                                          storePackageDb
+        storePkgIdSet <- getInstalledStorePackages storeDirectory
         let improvedPlan = improveInstallPlanWithInstalledPackages
-                             storePkgIndex
-                             storeExeIndex
+                             storePkgIdSet
                              elaboratedPlan
         liftIO $ debugNoWrap verbosity (InstallPlan.showInstallPlan improvedPlan)
+        -- TODO: [nice to have] having checked which packages from the store
+        -- we're using, it may be sensible to sanity check those packages
+        -- by loading up the compiler package db and checking everything
+        -- matches up as expected, e.g. no dangling deps, files deleted.
         return improvedPlan
-
       where
         storeDirectory  = cabalStoreDirectory (compilerId compiler)
         storePackageDb  = cabalStorePackageDB (compilerId compiler)
         ElaboratedSharedConfig {
-          pkgConfigPlatform      = platform,
           pkgConfigCompiler      = compiler,
           pkgConfigCompilerProgs = progdb
         } = elaboratedShared
@@ -658,6 +658,8 @@ getInstalledPackages verbosity compiler progdb platform packagedbs = do
                verbosity compiler
                packagedbs progdb
 
+{-
+--TODO: [nice to have] use this but for sanity / consistency checking
 getPackageDBContents :: Verbosity
                      -> Compiler -> ProgramDb -> Platform
                      -> PackageDB
@@ -671,20 +673,21 @@ getPackageDBContents verbosity compiler progdb platform packagedb = do
       createPackageDBIfMissing verbosity compiler progdb packagedb
       Cabal.getPackageDBContents verbosity compiler
                                  packagedb progdb
+-}
 
--- | Return the list of all already installed executables
-getExecutableDBContents
-    :: FilePath -- store directory
-    -> Rebuild (Set ComponentId)
-getExecutableDBContents storeDirectory = do
-    monitorFiles [monitorFileGlob (FilePathGlob (FilePathRoot storeDirectory) (GlobFile [WildCard]))]
-    paths <- liftIO $ getDirectoryContents storeDirectory
-    return (Set.fromList (map ComponentId (filter valid paths)))
+-- | Return the 'UnitId's of all packages\/components already installed in the
+-- store.
+--
+getInstalledStorePackages :: FilePath -- ^ store directory
+                          -> Rebuild (Set UnitId)
+getInstalledStorePackages storeDirectory = do
+    paths <- getDirectoryContentsMonitored storeDirectory
+    return $ Set.fromList [ SimpleUnitId (ComponentId path)
+                          | path <- paths, valid path ]
   where
-    valid "." = False
-    valid ".." = False
+    valid ('.':_)      = False
     valid "package.db" = False
-    valid _ = True
+    valid _            = True
 
 getSourcePackages :: Verbosity -> (forall a. (RepoContext -> IO a) -> IO a)
                   -> Rebuild SourcePackageDb
@@ -729,6 +732,11 @@ getPkgConfigDb verbosity progdb = do
 
     liftIO $ readPkgConfigDb verbosity progdb
 
+
+getDirectoryContentsMonitored :: FilePath -> Rebuild [FilePath]
+getDirectoryContentsMonitored dir = do
+    monitorFiles [monitorDirectory dir]
+    liftIO $ getDirectoryContents dir
 
 recreateDirectory :: Verbosity -> Bool -> FilePath -> Rebuild ()
 recreateDirectory verbosity createParents dir = do
@@ -2712,11 +2720,10 @@ packageHashConfigInputs
 -- 'ElaboratedInstallPlan', replace configured source packages by installed
 -- packages from the store whenever they exist.
 --
-improveInstallPlanWithInstalledPackages :: InstalledPackageIndex
-                                        -> Set ComponentId
+improveInstallPlanWithInstalledPackages :: Set UnitId
                                         -> ElaboratedInstallPlan
                                         -> ElaboratedInstallPlan
-improveInstallPlanWithInstalledPackages installedPkgIndex installedExes installPlan =
+improveInstallPlanWithInstalledPackages installedPkgIdSet installPlan =
     replaceWithInstalled installPlan
       [ installedUnitId pkg
       | InstallPlan.Configured pkg
@@ -2731,14 +2738,7 @@ improveInstallPlanWithInstalledPackages installedPkgIndex installedExes installP
     -- since overwriting is never safe.
 
     canPackageBeImproved pkg =
-      case PackageIndex.lookupUnitId
-            installedPkgIndex (installedUnitId pkg) of
-        Just _ -> True
-        Nothing | SimpleUnitId cid <- installedUnitId pkg
-                , cid `Set.member` installedExes
-                -- Same hack as replacewithPrePreExisting
-                -> True
-                | otherwise -> False
+      installedUnitId pkg `Set.member` installedPkgIdSet
 
     replaceWithInstalled :: ElaboratedInstallPlan -> [UnitId]
                          -> ElaboratedInstallPlan


### PR DESCRIPTION
So why add an Installed state? Didn't we just remove the `Installed`, `Processing` and `Failed` states? Those states were used when we followed the approach of updating the `InstallPlan` as a build progressed (whereas we now do traversals without altering the `InstallPlan`).

The idea of adding an Installed state now is that we can more usefully represent the state of the plan when we "improve" the plan with packages from the store or when we update the plan having checked if inplace packages are up to date. Currently in these two places we replace `Configured` source packages with `PreExisting` packages. There's a couple problems with this. Firstly the `PreExisting` state only contains an `InstalledPackageInfo` which means we loose information compared to all the detail in the Configured source package. This is relevant for things like plan.json output or other features that want to know the status of a project. Secondly we have to fake things for executables since they are not properly represented by `InstalledPackageInfo`. So this avoids the need for thos hacks.

Also simplify the way we do the improvement now that we no longer need the `InstalledPackageInfo`. Now rather than reading the ghc-pkg db we can just get the dir listing for the store and use that as a set of `UnitId`s.

This already helps the plan.json output and will also be needed for maintaining the .ghc.environment file sanely.