### PR TITLE
WIP: GHC environments

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -731,6 +731,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
                                               && ghcVersion < Version [7,8] []
                                             then toFlag sharedLibInstallPath
                                             else mempty,
+                ghcOptHideAllPackages    = toFlag True,
                 ghcOptNoAutoLinkPackages = toFlag True,
                 ghcOptPackageDBs         = withPackageDB lbi,
                 ghcOptPackages           = toNubListR $

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -50,7 +50,14 @@ module Distribution.Simple.GHC (
         getLibDir,
         isDynamic,
         getGlobalPackageDB,
-        pkgRoot
+        pkgRoot,
+        -- * Constructing GHC environment files
+        Internal.GhcEnvironmentFileEntry(..),
+        Internal.simpleGhcEnvironmentFile,
+        Internal.writeGhcEnvironmentFile,
+        -- * Version-specific implementation quirks
+        getImplInfo,
+        GhcImplInfo(..)
  ) where
 
 import Prelude ()
@@ -336,16 +343,15 @@ getGlobalPackageDB verbosity ghcProg =
 
 -- | Return the 'FilePath' to the per-user GHC package database.
 getUserPackageDB :: Verbosity -> ConfiguredProgram -> Platform -> NoCallStackIO FilePath
-getUserPackageDB _verbosity ghcProg (Platform arch os) = do
+getUserPackageDB _verbosity ghcProg platform = do
     -- It's rather annoying that we have to reconstruct this, because ghc
     -- hides this information from us otherwise. But for certain use cases
     -- like change monitoring it really can't remain hidden.
     appdir <- getAppUserDataDirectory "ghc"
     return (appdir </> platformAndVersion </> packageConfFileName)
   where
-    platformAndVersion = intercalate "-" [ Internal.showArchString arch
-                                         , Internal.showOsString os
-                                         , display ghcVersion ]
+    platformAndVersion = Internal.ghcPlatformAndVersionString
+                           platform ghcVersion
     packageConfFileName
       | ghcVersion >= Version [6,12] []  = "package.conf.d"
       | otherwise                        = "package.conf"

--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -41,6 +41,7 @@ data GhcImplInfo = GhcImplInfo
   , flagProfAuto         :: Bool -- ^ new style -fprof-auto* flags
   , flagPackageConf      :: Bool -- ^ use package-conf instead of package-db
   , flagDebugInfo        :: Bool -- ^ -g flag supported
+  , supportsPkgEnvFiles  :: Bool -- ^ picks up @.ghc.environment@ files
   }
 
 getImplInfo :: Compiler -> GhcImplInfo
@@ -65,10 +66,13 @@ ghcVersionImplInfo (Version v _) = GhcImplInfo
   , flagProfAuto         = v >= [7,4]
   , flagPackageConf      = v <  [7,5]
   , flagDebugInfo        = v >= [7,10]
+  , supportsPkgEnvFiles  = v >= [8,0,2] -- broken in 8.0.1, fixed in 8.0.2
   }
 
-ghcjsVersionImplInfo :: Version -> Version -> GhcImplInfo
-ghcjsVersionImplInfo _ghcjsVer _ghcVer = GhcImplInfo
+ghcjsVersionImplInfo :: Version  -- ^ The GHCJS version
+                     -> Version  -- ^ The GHC version
+                     -> GhcImplInfo
+ghcjsVersionImplInfo (Version _ghcjsv _) (Version ghcv _) = GhcImplInfo
   { supportsHaskell2010  = True
   , reportsNoExt         = True
   , alwaysNondecIndent   = False
@@ -76,6 +80,7 @@ ghcjsVersionImplInfo _ghcjsVer _ghcVer = GhcImplInfo
   , flagProfAuto         = True
   , flagPackageConf      = False
   , flagDebugInfo        = False
+  , supportsPkgEnvFiles  = ghcv >= [8,0,2] --TODO: check this works in ghcjs
   }
 
 lhcVersionImplInfo :: Version -> GhcImplInfo

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -26,8 +26,17 @@ module Distribution.Simple.GHC.Internal (
         substTopDir,
         checkPackageDbEnvVar,
         profDetailLevelFlag,
-        showArchString,
-        showOsString,
+        -- * GHC platform and version strings
+        ghcArchString,
+        ghcOsString,
+        ghcPlatformAndVersionString,
+        -- * Constructing GHC environment files
+        GhcEnvironmentFileEntry(..),
+        writeGhcEnvironmentFile,
+        simpleGhcEnvironmentFile,
+        ghcEnvironmentFileName,
+        renderGhcEnvironmentFile,
+        renderGhcEnvironmentFileEntry,
  ) where
 
 import Prelude ()
@@ -55,9 +64,11 @@ import Distribution.Text ( display, simpleParse )
 import Distribution.Utils.NubList ( toNubListR )
 import Distribution.Verbosity
 import Distribution.Compat.Stack
+import Distribution.Version (Version)
 import Language.Haskell.Extension
 
 import qualified Data.Map as Map
+import qualified Data.ByteString.Lazy.Char8 as BS
 import System.Directory         ( getDirectoryContents, getTemporaryDirectory )
 import System.Environment       ( getEnv )
 import System.FilePath          ( (</>), (<.>), takeExtension
@@ -432,19 +443,100 @@ profDetailLevelFlag forLib mpl =
       ProfDetailAllFunctions        -> toFlag GhcProfAutoAll
       ProfDetailOther _             -> mempty
 
+
+-- -----------------------------------------------------------------------------
+-- GHC platform and version strings
+
 -- | GHC's rendering of it's host or target 'Arch' as used in its platform
 -- strings and certain file locations (such as user package db location).
 --
-showArchString :: Arch -> String
-showArchString PPC   = "powerpc"
-showArchString PPC64 = "powerpc64"
-showArchString other = display other
+ghcArchString :: Arch -> String
+ghcArchString PPC   = "powerpc"
+ghcArchString PPC64 = "powerpc64"
+ghcArchString other = display other
 
 -- | GHC's rendering of it's host or target 'OS' as used in its platform
 -- strings and certain file locations (such as user package db location).
 --
-showOsString :: OS -> String
-showOsString Windows = "mingw32"
-showOsString OSX     = "darwin"
-showOsString Solaris = "solaris2"
-showOsString other   = display other
+ghcOsString :: OS -> String
+ghcOsString Windows = "mingw32"
+ghcOsString OSX     = "darwin"
+ghcOsString Solaris = "solaris2"
+ghcOsString other   = display other
+
+-- | GHC's rendering of it's platform and compiler version string as used in
+-- certain file locations (such as user package db location).
+-- For example @x86_64-linux-7.10.4@
+--
+ghcPlatformAndVersionString :: Platform -> Version -> String
+ghcPlatformAndVersionString (Platform arch os) version =
+    intercalate "-" [ ghcArchString arch, ghcOsString os, display version ]
+
+
+-- -----------------------------------------------------------------------------
+-- Constructing GHC environment files
+
+-- | The kinds of entries we can stick in a @.ghc.environment@ file.
+--
+data GhcEnvironmentFileEntry =
+       GhcEnvFileComment   String     -- ^ @-- a comment@
+     | GhcEnvFilePackageId UnitId     -- ^ @package-id foo-1.0-4fe301a...@
+     | GhcEnvFilePackageDb PackageDB  -- ^ @global-package-db@,
+                                      --   @user-package-db@ or
+                                      --   @package-db blah/package.conf.d/@
+     | GhcEnvFileClearPackageDbStack  -- ^ @clear-package-db@
+
+-- | Make entries for a GHC environment file based on a 'PackageDBStack' and
+-- a bunch of package (unit) ids.
+--
+-- If you need to do anything more complicated then either use this as a basis
+-- and add more entries, or just make all the entries directly.
+--
+simpleGhcEnvironmentFile :: PackageDBStack
+                         -> [UnitId]
+                         -> [GhcEnvironmentFileEntry]
+simpleGhcEnvironmentFile packageDBs pkgids =
+    GhcEnvFileClearPackageDbStack
+  : map GhcEnvFilePackageDb packageDBs
+ ++ map GhcEnvFilePackageId pkgids
+
+-- | Write a @.ghc.environment-$arch-$os-$ver@ file in the given directory.
+--
+-- The 'Platform' and GHC 'Version' are needed as part of the file name.
+--
+writeGhcEnvironmentFile :: FilePath  -- ^ directory in which to put it
+                        -> Platform  -- ^ the GHC target platform
+                        -> Version   -- ^ the GHC version
+                        -> [GhcEnvironmentFileEntry] -- ^ the content
+                        -> IO ()
+writeGhcEnvironmentFile directory platform ghcversion =
+    writeFileAtomic envfile . BS.pack . renderGhcEnvironmentFile
+  where
+    envfile = directory </> ghcEnvironmentFileName platform ghcversion
+
+-- | The @.ghc.environment-$arch-$os-$ver@ file name
+--
+ghcEnvironmentFileName :: Platform -> Version -> FilePath
+ghcEnvironmentFileName platform ghcversion =
+    ".ghc.environment." ++ ghcPlatformAndVersionString platform ghcversion
+
+-- | Render a bunch of GHC environment file entries
+--
+renderGhcEnvironmentFile :: [GhcEnvironmentFileEntry] -> String
+renderGhcEnvironmentFile =
+    unlines . map renderGhcEnvironmentFileEntry
+
+-- | Render an individual GHC environment file entry
+--
+renderGhcEnvironmentFileEntry :: GhcEnvironmentFileEntry -> String
+renderGhcEnvironmentFileEntry entry = case entry of
+    GhcEnvFileComment   comment   -> format comment
+      where format = intercalate "\n" . map ("-- " ++) . lines
+    GhcEnvFilePackageId pkgid     -> "package-id " ++ display pkgid
+    GhcEnvFilePackageDb pkgdb     ->
+      case pkgdb of
+        GlobalPackageDB           -> "global-package-db"
+        UserPackageDB             -> "user-package-db"
+        SpecificPackageDB dbfile  -> "package-db " ++ dbfile
+    GhcEnvFileClearPackageDbStack -> "clear-package-db"
+

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -189,8 +189,11 @@ configureToolchain _implInfo ghcProg ghcInfo =
              withTempFile tempDir ".o" $ \testofile testohnd -> do
                hPutStrLn testchnd "int foo() { return 0; }"
                hClose testchnd; hClose testohnd
-               runProgram verbosity ghcProg ["-c", testcfile,
-                                             "-o", testofile]
+               runProgram verbosity ghcProg
+                          [ "-hide-all-packages"
+                          , "-c", testcfile
+                          , "-o", testofile
+                          ]
                withTempFile tempDir ".o" $ \testofile' testohnd' ->
                  do
                    hClose testohnd'
@@ -267,6 +270,7 @@ componentCcGhcOptions verbosity _implInfo lbi bi clbi odir filename =
                                           ,autogenPackageModulesDir lbi
                                           ,odir]
                                           ++ PD.includeDirs bi,
+      ghcOptHideAllPackages= toFlag True,
       ghcOptPackageDBs     = withPackageDB lbi,
       ghcOptPackages       = toNubListR $ mkGhcOptPackages clbi,
       ghcOptCcOptions      = toNubListR $
@@ -290,12 +294,12 @@ componentGhcOptions verbosity lbi bi clbi odir =
       -- Respect -v0, but don't crank up verbosity on GHC if
       -- Cabal verbosity is requested. For that, use --ghc-option=-v instead!
       ghcOptVerbosity       = toFlag (min verbosity normal),
-      ghcOptHideAllPackages = toFlag True,
       ghcOptCabal           = toFlag True,
       ghcOptThisUnitId      = case clbi of
         LibComponentLocalBuildInfo { componentCompatPackageKey = pk }
           -> toFlag pk
         _ -> mempty,
+      ghcOptHideAllPackages = toFlag True,
       ghcOptPackageDBs      = withPackageDB lbi,
       ghcOptPackages        = toNubListR $ mkGhcOptPackages clbi,
       ghcOptSplitObjs       = toFlag (splitObjs lbi),

--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -8,9 +8,6 @@ module Distribution.Client.CmdBuild (
   ) where
 
 import Distribution.Client.ProjectOrchestration
-         ( PreBuildHooks(..), runProjectPreBuildPhase, selectTargets
-         , ProjectBuildContext(..), runProjectBuildPhase
-         , printPlan, reportBuildFailures )
 import Distribution.Client.ProjectConfig
          ( BuildTimeSettings(..) )
 import Distribution.Client.ProjectPlanning
@@ -24,8 +21,6 @@ import Distribution.Simple.Setup
          ( HaddockFlags, fromFlagOrDefault )
 import Distribution.Verbosity
          ( normal )
-
-import Control.Monad (unless)
 
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
@@ -69,7 +64,7 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     userTargets <- readUserBuildTargets targetStrings
 
-    buildCtx@ProjectBuildContext{buildSettings, elaboratedPlan} <-
+    buildCtx <-
       runProjectPreBuildPhase
         verbosity
         ( globalFlags, configFlags, configExFlags
@@ -91,9 +86,8 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     printPlan verbosity buildCtx
 
-    unless (buildSettingDryRun buildSettings) $ do
-      buildResults <- runProjectBuildPhase verbosity buildCtx
-      reportBuildFailures verbosity elaboratedPlan buildResults
+    buildOutcomes <- runProjectBuildPhase verbosity buildCtx
+    runProjectPostBuildPhase verbosity buildCtx buildOutcomes
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
 

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -8,9 +8,6 @@ module Distribution.Client.CmdRepl (
   ) where
 
 import Distribution.Client.ProjectOrchestration
-         ( PreBuildHooks(..), runProjectPreBuildPhase, selectTargets
-         , ProjectBuildContext(..), runProjectBuildPhase
-         , printPlan, reportBuildFailures )
 import Distribution.Client.ProjectConfig
          ( BuildTimeSettings(..) )
 import Distribution.Client.ProjectPlanning
@@ -25,7 +22,7 @@ import Distribution.Simple.Setup
 import Distribution.Verbosity
          ( normal )
 
-import Control.Monad (when, unless)
+import Control.Monad (when)
 
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
@@ -66,7 +63,7 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     userTargets <- readUserBuildTargets targetStrings
 
-    buildCtx@ProjectBuildContext{buildSettings, elaboratedPlan} <-
+    buildCtx <-
       runProjectPreBuildPhase
         verbosity
         ( globalFlags, configFlags, configExFlags
@@ -96,9 +93,8 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     printPlan verbosity buildCtx
 
-    unless (buildSettingDryRun buildSettings) $ do
-      buildResults <- runProjectBuildPhase verbosity buildCtx
-      reportBuildFailures verbosity elaboratedPlan buildResults
+    buildOutcomes <- runProjectBuildPhase verbosity buildCtx
+    runProjectPostBuildPhase verbosity buildCtx buildOutcomes
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
 

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -159,6 +159,7 @@ import Prelude hiding (lookup)
 data GenericPlanPackage ipkg srcpkg
    = PreExisting ipkg
    | Configured  srcpkg
+   | Installed   srcpkg
   deriving (Eq, Show, Generic)
 
 type IsUnit a = (IsNode a, Key a ~ UnitId)
@@ -172,9 +173,11 @@ instance (IsNode ipkg, IsNode srcpkg, Key ipkg ~ UnitId, Key srcpkg ~ UnitId)
          => IsNode (GenericPlanPackage ipkg srcpkg) where
     type Key (GenericPlanPackage ipkg srcpkg) = UnitId
     nodeKey (PreExisting ipkg) = nodeKey ipkg
-    nodeKey (Configured spkg) = nodeKey spkg
+    nodeKey (Configured  spkg) = nodeKey spkg
+    nodeKey (Installed   spkg) = nodeKey spkg
     nodeNeighbors (PreExisting ipkg) = nodeNeighbors ipkg
-    nodeNeighbors (Configured spkg) = nodeNeighbors spkg
+    nodeNeighbors (Configured  spkg) = nodeNeighbors spkg
+    nodeNeighbors (Installed   spkg) = nodeNeighbors spkg
 
 instance (Binary ipkg, Binary srcpkg)
       => Binary (GenericPlanPackage ipkg srcpkg)
@@ -186,17 +189,20 @@ instance (Package ipkg, Package srcpkg) =>
          Package (GenericPlanPackage ipkg srcpkg) where
   packageId (PreExisting ipkg)     = packageId ipkg
   packageId (Configured  spkg)     = packageId spkg
+  packageId (Installed   spkg)     = packageId spkg
 
 instance (HasUnitId ipkg, HasUnitId srcpkg) =>
          HasUnitId
          (GenericPlanPackage ipkg srcpkg) where
   installedUnitId (PreExisting ipkg) = installedUnitId ipkg
   installedUnitId (Configured  spkg) = installedUnitId spkg
+  installedUnitId (Installed   spkg) = installedUnitId spkg
 
 instance (HasConfiguredId ipkg, HasConfiguredId srcpkg) =>
           HasConfiguredId (GenericPlanPackage ipkg srcpkg) where
     configuredId (PreExisting ipkg) = configuredId ipkg
-    configuredId (Configured pkg) = configuredId pkg
+    configuredId (Configured  spkg) = configuredId spkg
+    configuredId (Installed   spkg) = configuredId spkg
 
 data GenericInstallPlan ipkg srcpkg = GenericInstallPlan {
     planIndex      :: !(PlanIndex ipkg srcpkg),
@@ -255,6 +261,7 @@ showInstallPlan = showPlanIndex . planIndex
 showPlanPackageTag :: GenericPlanPackage ipkg srcpkg -> String
 showPlanPackageTag (PreExisting _)   = "PreExisting"
 showPlanPackageTag (Configured  _)   = "Configured"
+showPlanPackageTag (Installed   _)   = "Installed"
 
 -- | Build an installation plan from a valid set of resolved packages.
 --
@@ -509,17 +516,18 @@ ready plan =
     !processing =
       Processing
         (Set.fromList [ nodeKey pkg | pkg <- readyPackages ])
-        (Set.fromList [ nodeKey pkg | PreExisting pkg <- toList plan ])
+        (Set.fromList [ nodeKey pkg | pkg <- toList plan, isInstalled pkg ])
         Set.empty
     readyPackages =
       [ ReadyPackage pkg
       | Configured pkg <- toList plan
-      , all isPreExisting (directDeps plan (nodeKey pkg))
+      , all isInstalled (directDeps plan (nodeKey pkg))
       ]
 
-    isPreExisting (PreExisting {}) = True
-    isPreExisting _                = False
-
+isInstalled :: GenericPlanPackage a b -> Bool
+isInstalled (PreExisting {}) = True
+isInstalled (Installed   {}) = True
+isInstalled _                = False
 
 -- | Given a package in the processing state, mark the package as completed
 -- and return any packages that are newly in the processing state (ie ready to
@@ -592,6 +600,7 @@ processingInvariant plan (Processing processingSet completedSet failedSet) =
  && and [ case Graph.lookup pkgid (planIndex plan) of
             Just (Configured  _) -> True
             Just (PreExisting _) -> False
+            Just (Installed   _) -> False
             Nothing              -> False 
         | pkgid <- Set.toList processingSet ++ Set.toList failedSet ]
   where

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -33,7 +33,6 @@ module Distribution.Client.InstallPlan (
   fromSolverInstallPlan,
   configureInstallPlan,
   remove,
-  preexisting,
   installed,
   lookup,
   directDeps,
@@ -290,26 +289,6 @@ remove shouldRemove plan =
   where
     newIndex = Graph.fromList $
                  filter (not . shouldRemove) (toList plan)
-
--- | Replace a ready package with a pre-existing one. The pre-existing one
--- must have exactly the same dependencies as the source one was configured
--- with.
---
-preexisting :: (IsUnit ipkg,
-                IsUnit srcpkg)
-            => UnitId
-            -> ipkg
-            -> GenericInstallPlan ipkg srcpkg
-            -> GenericInstallPlan ipkg srcpkg
-preexisting pkgid ipkg plan = plan'
-  where
-    plan' = plan {
-      planIndex   = Graph.insert (PreExisting ipkg)
-                    -- ...but be sure to use the *old* IPID for the lookup for
-                    -- the preexisting record
-                  . Graph.deleteKey pkgid
-                  $ planIndex plan
-    }
 
 -- | Change a package in a 'Configured' state to an 'Installed' state.
 --

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -32,7 +32,6 @@ module Distribution.Client.InstallPlan (
 
   fromSolverInstallPlan,
   configureInstallPlan,
-  remove,
   installed,
   lookup,
   directDeps,
@@ -274,12 +273,14 @@ toList :: GenericInstallPlan ipkg srcpkg
        -> [GenericPlanPackage ipkg srcpkg]
 toList = Graph.toList . planIndex
 
+{-
 -- | Remove packages from the install plan. This will result in an
 -- error if there are remaining packages that depend on any matching
 -- package. This is primarily useful for obtaining an install plan for
 -- the dependencies of a package or set of packages without actually
 -- installing the package itself, as when doing development.
 --
+--TODO: [code cleanup] use this in --only-depencencies impl
 remove :: (IsUnit ipkg, IsUnit srcpkg)
        => (GenericPlanPackage ipkg srcpkg -> Bool)
        -> GenericInstallPlan ipkg srcpkg
@@ -289,6 +290,7 @@ remove shouldRemove plan =
   where
     newIndex = Graph.fromList $
                  filter (not . shouldRemove) (toList plan)
+-}
 
 -- | Change a number of packages in the 'Configured' state to the 'Installed'
 -- state.

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -262,6 +262,9 @@ rebuildTargetsDryRun verbosity distDirLayout@DistDirLayout{..} shared = \install
     dryRunPkg (InstallPlan.PreExisting _pkg) _depsBuildStatus =
       return BuildStatusPreExisting
 
+    dryRunPkg (InstallPlan.Installed _pkg) _depsBuildStatus =
+      return BuildStatusPreExisting --TODO: distinguish installed state
+
     dryRunPkg (InstallPlan.Configured pkg) depsBuildStatus = do
       mloc <- checkFetched (elabPkgSourceLocation pkg)
       case mloc of

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -23,7 +23,8 @@ module Distribution.Client.ProjectBuilding (
     BuildResult(..),
     BuildFailure(..),
     BuildFailureReason(..),
-    rebuildTargets
+    rebuildTargets,
+    updateInstallPlanWithBuildOutcomes,
   ) where
 
 import           Distribution.Client.PackageHash (renderPackageHashInputs)
@@ -1316,6 +1317,18 @@ buildInplaceUnpackedPackage verbosity
                                 pkgConfDest
         setup Cabal.registerCommand registerFlags []
 
+
+updateInstallPlanWithBuildOutcomes :: BuildOutcomes
+                                   -> ElaboratedInstallPlan
+                                   -> ElaboratedInstallPlan
+updateInstallPlanWithBuildOutcomes buildOutcomes =
+    InstallPlan.installed canPackageBeImproved
+  where
+    canPackageBeImproved pkg =
+      case Map.lookup (installedUnitId pkg) buildOutcomes of
+        Just (Right _) -> True
+        Just (Left  _) -> False
+        Nothing        -> False
 
 -- helper
 annotateFailureNoLog :: (SomeException -> BuildFailureReason)

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -492,7 +492,8 @@ printPlan verbosity
     showFlagName (PD.FlagName f) = f
 
     showBuildStatus status = case status of
-      BuildStatusPreExisting -> "already installed"
+      BuildStatusPreExisting -> "existing package"
+      BuildStatusInstalled   -> "already installed"
       BuildStatusDownload {} -> "requires download & build"
       BuildStatusUnpack   {} -> "requires build"
       BuildStatusRebuild _ rebuild -> case rebuild of

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -60,6 +60,7 @@ import           Distribution.Client.ProjectConfig
 import           Distribution.Client.ProjectPlanning
 import           Distribution.Client.ProjectPlanning.Types
 import           Distribution.Client.ProjectBuilding
+import           Distribution.Client.ProjectPlanOutput
 
 import           Distribution.Client.Types
                    ( GenericReadyPackage(..), PackageLocation(..) )
@@ -186,6 +187,12 @@ runProjectPreBuildPhase
     (elaboratedPlan'', pkgsBuildStatus) <-
       rebuildTargetsDryRun verbosity distDirLayout elaboratedShared
                            elaboratedPlan'
+
+    debug verbosity "Updating GHC environment file"
+    writePlanGhcEnvironment
+      projectRootDir
+      elaboratedPlan''
+      elaboratedShared
 
     return ProjectBuildContext {
       distDirLayout,

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -4,6 +4,7 @@
 
 module Distribution.Client.ProjectPlanOutput (
     writePlanExternalRepresentation,
+    writePlanGhcEnvironment,
   ) where
 
 import           Distribution.Client.ProjectPlanning.Types
@@ -19,10 +20,20 @@ import qualified Distribution.Solver.Types.ComponentDeps as ComponentDeps
 import           Distribution.Package
 import           Distribution.InstalledPackageInfo (InstalledPackageInfo)
 import qualified Distribution.PackageDescription as PD
+import           Distribution.Compiler (CompilerFlavor(GHC))
+import           Distribution.Simple.Compiler
+                   ( PackageDBStack, PackageDB(..)
+                   , compilerVersion, compilerFlavor )
+import           Distribution.Simple.GHC
+                   ( getImplInfo, GhcImplInfo(supportsPkgEnvFiles)
+                   , GhcEnvironmentFileEntry(..), simpleGhcEnvironmentFile
+                   , writeGhcEnvironmentFile )
 import           Distribution.Text
+import qualified Distribution.Compat.Graph as Graph
 import           Distribution.Simple.Utils
 import qualified Paths_cabal_install as Our (version)
 
+import           Data.Maybe (maybeToList)
 import           Data.Monoid
 import qualified Data.ByteString.Builder as BB
 import           System.FilePath
@@ -152,4 +163,158 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
 
     jdisplay :: Text a => a -> J.Value
     jdisplay = J.String . display
+
+
+-----------------------------------------------------------------------------
+-- Writing .ghc.environment files
+--
+
+writePlanGhcEnvironment :: FilePath
+                        -> ElaboratedInstallPlan
+                        -> ElaboratedSharedConfig
+                        -> IO ()
+writePlanGhcEnvironment projectRootDir
+                        elaboratedInstallPlan
+                        ElaboratedSharedConfig {
+                          pkgConfigCompiler = compiler,
+                          pkgConfigPlatform = platform
+                        }
+  | compilerFlavor compiler == GHC
+  , supportsPkgEnvFiles (getImplInfo compiler)
+  --TODO: check ghcjs compat
+  = writeGhcEnvironmentFile
+      projectRootDir
+      platform (compilerVersion compiler)
+      (renderGhcEnviromentFile projectRootDir elaboratedInstallPlan)
+    --TODO: [required eventually] support for writing user-wide package
+    -- environments, e.g. like a global project, but we would not put the
+    -- env file in the home dir, rather it lives under ~/.ghc/
+
+writePlanGhcEnvironment _ _ _ = return ()
+
+renderGhcEnviromentFile :: FilePath
+                        -> ElaboratedInstallPlan
+                        -> [GhcEnvironmentFileEntry]
+renderGhcEnviromentFile projectRootDir elaboratedInstallPlan =
+    headerComment
+  : simpleGhcEnvironmentFile packageDBs unitIds
+  where
+    headerComment =
+        GhcEnvFileComment
+      $ "This is a GHC environment file written by cabal. This means you can\n"
+     ++ "run ghc or ghci and get the environment of the project as a whole.\n"
+     ++ "But you still need to use cabal repl $target to get the environment\n"
+     ++ "of specific components (libs, exes, tests etc) because each one can\n"
+     ++ "have its own source dirs, cpp flags etc.\n\n"
+    packageDBs =
+        relativePackageDBPaths projectRootDir $
+        -- If we have any inplace packages then their package db stack is the
+        -- one we should use since it'll include the store + the local db but
+        -- it's certainly possible to have no local inplace packages
+        -- e.g. just "extra" packages coming from the store.
+        case (inplacePackages, configuredPackages) of
+          ([], pkgs) -> checkSamePackageDBs pkgs
+          (pkgs, _)  -> checkSamePackageDBs pkgs
+      where
+        checkSamePackageDBs pkgs =
+          case ordNub (map elabBuildPackageDBStack pkgs) of
+            [packageDbs] -> packageDbs
+            []           -> []
+            _            -> error $ "renderGhcEnviromentFile: packages with "
+                                 ++ "different package db stacks"
+            -- This should not happen at the moment but will happen as soon
+            -- as we support projects where we build packages with different
+            -- compilers, at which point we have to consider how to adapt
+            -- this feature, e.g. write out multiple env files, one for each
+            -- compiler / project profile.
+
+        inplacePackages =
+          [ srcpkg
+          | srcpkg <- configuredPackages
+          , elabBuildStyle srcpkg == BuildInplaceOnly ]
+        configuredPackages =
+          [ srcpkg
+          | pkg <- InstallPlan.toList elaboratedInstallPlan
+          , srcpkg <- maybeToList $ case pkg of
+                        InstallPlan.Configured srcpkg -> Just srcpkg
+                        InstallPlan.Installed  srcpkg -> Just srcpkg
+                        InstallPlan.PreExisting _     -> Nothing
+          ]
+
+    -- We're producing an environment for users to use in ghci, so of course
+    -- that means libraries only (can't put exes into the ghc package env!).
+    -- The library environment should be /consistent/ with the environment
+    -- that each of the packages in the project use (ie same lib versions).
+    -- So that means all the normal library dependencies of all the things
+    -- in the project (including deps of exes that are local to the project).
+    -- We do not however want to include the depencencies of Setup.hs scripts,
+    -- since these are generally uninteresting but also they need not in
+    -- general be consistent with the library versions that packages local to
+    -- the project use (recall that Setup.hs script's deps can be picked
+    -- independently of other packages in the project).
+    --
+    -- So, our strategy is as follows:
+    --
+    -- produce a dependency graph of all the packages in the install plan,
+    -- but only consider normal library deps as edges in the graph. Thus we
+    -- exclude the depencencies on Setup.hs scripts (in the case of
+    -- per-component granularity) or of Setup.hs scripts (in the case of
+    -- per-package granularity). Then take a dependency closure, using as
+    -- roots all the packages/components local to the project. This will
+    -- exclude Setup scripts and their depencencies.
+    --
+    -- Note: this algorithm will have to be adapted if/when the install plan
+    -- is extended to cover multiple compilers at once, and may also have to
+    -- change if we start to treat unshared deps of test suites in a similar
+    -- way to how we treat Setup.hs script deps (ie being able to pick them
+    -- independently).
+    --
+    libdepgraph :: Graph.Graph (Graph.Node UnitId ElaboratedPlanPackage)
+    libdepgraph =
+      Graph.fromList
+        [ Graph.N pkg (installedUnitId pkg) libdeps
+        | pkg <- InstallPlan.toList elaboratedInstallPlan
+        , let libdeps = case pkg of
+                InstallPlan.PreExisting ipkg  -> installedDepends ipkg
+                InstallPlan.Configured srcpkg -> map (SimpleUnitId . confInstId)
+                                                 (elabLibDependencies srcpkg)
+                InstallPlan.Installed  srcpkg -> map (SimpleUnitId . confInstId)
+                                                 (elabLibDependencies srcpkg)
+        ]
+    localpkgs =
+      [ installedUnitId pkg
+      | pkg <- InstallPlan.toList elaboratedInstallPlan
+      , case pkg of
+          InstallPlan.PreExisting _ -> False
+          InstallPlan.Configured srcpkg -> elabLocalToProject srcpkg
+          InstallPlan.Installed  srcpkg -> elabLocalToProject srcpkg
+      ]
+
+    -- Since we had to use all the local packages, including exes, (as roots
+    -- to find the libs) then those exes still end up in our list so we have
+    -- to filter them out at the end.
+    unitIds =
+      case Graph.closure libdepgraph localpkgs of
+        Nothing    -> error "renderGhcEnviromentFile: broken dep closure"
+        Just nodes ->
+          [ pkgid
+          | Graph.N pkg pkgid _ <- nodes
+          , case pkg of
+              InstallPlan.PreExisting _    -> True
+              -- drop packages are not libs:
+              InstallPlan.Installed srcpkg -> elabRequiresRegistration srcpkg
+              -- and packages not yet built are not be included:
+              InstallPlan.Configured  _    -> False
+          ]
+
+relativePackageDBPaths :: FilePath -> PackageDBStack -> PackageDBStack
+relativePackageDBPaths relroot = map (relativePackageDBPath relroot)
+
+relativePackageDBPath :: FilePath -> PackageDB -> PackageDB
+relativePackageDBPath relroot pkgdb =
+    case pkgdb of
+      GlobalPackageDB        -> GlobalPackageDB
+      UserPackageDB          -> UserPackageDB
+      SpecificPackageDB path -> SpecificPackageDB relpath
+        where relpath = makeRelative relroot path
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1235,6 +1235,7 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
                 case elabPkgOrComp elab of
                     ElabPackage _ -> True
                     ElabComponent comp -> compSolverName comp == CD.ComponentLib
+            is_lib (InstallPlan.Installed _) = unexpectedState
 
     elaborateExeSolverId :: (SolverId -> [ElaboratedPlanPackage])
                       -> SolverId -> [ConfiguredId]
@@ -1247,6 +1248,7 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
                         case compSolverName comp of
                             CD.ComponentExe _ -> True
                             _ -> False
+            is_exe (InstallPlan.Installed _) = unexpectedState
 
     elaborateExePath :: (SolverId -> [ElaboratedPlanPackage])
                      -> SolverId -> [FilePath]
@@ -1269,6 +1271,9 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
                                     Just (Just n) -> n
                                     _ -> ""
               else InstallDirs.bindir (elabInstallDirs elab)]
+        get_exe_path (InstallPlan.Installed _) = unexpectedState
+
+    unexpectedState = error "elaborateInstallPlan: unexpected Installed state"
 
     elaborateSolverToPackage :: (SolverId -> [ElaboratedPlanPackage])
                              -> SolverPackage UnresolvedPkgLoc
@@ -1994,6 +1999,8 @@ mapConfiguredPackage :: (srcpkg -> srcpkg')
                      -> InstallPlan.GenericPlanPackage ipkg srcpkg'
 mapConfiguredPackage f (InstallPlan.Configured pkg) =
   InstallPlan.Configured (f pkg)
+mapConfiguredPackage f (InstallPlan.Installed pkg) =
+  InstallPlan.Installed (f pkg)
 mapConfiguredPackage _ (InstallPlan.PreExisting pkg) =
   InstallPlan.PreExisting pkg
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -91,7 +91,6 @@ import qualified Distribution.PackageDescription as Cabal
 import qualified Distribution.PackageDescription as PD
 import qualified Distribution.PackageDescription.Configuration as PD
 import           Distribution.Simple.PackageIndex (InstalledPackageIndex)
-import qualified Distribution.Simple.PackageIndex as PackageIndex
 import           Distribution.Simple.Compiler hiding (Flag)
 import qualified Distribution.Simple.GHC   as GHC   --TODO: [code cleanup] eliminate
 import qualified Distribution.Simple.GHCJS as GHCJS --TODO: [code cleanup] eliminate
@@ -283,8 +282,7 @@ rebuildInstallPlan verbosity
                      distProjectCacheDirectory
                    }
                    cabalDirLayout@CabalDirLayout {
-                     cabalStoreDirectory,
-                     cabalStorePackageDB
+                     cabalStoreDirectory
                    }
                    cliConfig =
     runRebuild projectRootDir $ do
@@ -606,25 +604,19 @@ rebuildInstallPlan verbosity
 
         liftIO $ debug verbosity "Improving the install plan..."
         recreateDirectory verbosity True storeDirectory
-        storePkgIndex <- getPackageDBContents verbosity
-                                              compiler progdb platform
-                                              storePackageDb
-        storeExeIndex <- getExecutableDBContents storeDirectory
+        storePkgIdSet <- getInstalledStorePackages storeDirectory
         let improvedPlan = improveInstallPlanWithInstalledPackages
-                             storePkgIndex
-                             storeExeIndex
+                             storePkgIdSet
                              elaboratedPlan
         liftIO $ debugNoWrap verbosity (InstallPlan.showInstallPlan improvedPlan)
+        -- TODO: [nice to have] having checked which packages from the store
+        -- we're using, it may be sensible to sanity check those packages
+        -- by loading up the compiler package db and checking everything
+        -- matches up as expected, e.g. no dangling deps, files deleted.
         return improvedPlan
-
       where
-        storeDirectory  = cabalStoreDirectory (compilerId compiler)
-        storePackageDb  = cabalStorePackageDB (compilerId compiler)
-        ElaboratedSharedConfig {
-          pkgConfigPlatform      = platform,
-          pkgConfigCompiler      = compiler,
-          pkgConfigCompilerProgs = progdb
-        } = elaboratedShared
+        storeDirectory = cabalStoreDirectory
+                           (compilerId (pkgConfigCompiler elaboratedShared))
 
 
 programsMonitorFiles :: ProgramDb -> [MonitorFilePath]
@@ -658,6 +650,8 @@ getInstalledPackages verbosity compiler progdb platform packagedbs = do
                verbosity compiler
                packagedbs progdb
 
+{-
+--TODO: [nice to have] use this but for sanity / consistency checking
 getPackageDBContents :: Verbosity
                      -> Compiler -> ProgramDb -> Platform
                      -> PackageDB
@@ -671,20 +665,21 @@ getPackageDBContents verbosity compiler progdb platform packagedb = do
       createPackageDBIfMissing verbosity compiler progdb packagedb
       Cabal.getPackageDBContents verbosity compiler
                                  packagedb progdb
+-}
 
--- | Return the list of all already installed executables
-getExecutableDBContents
-    :: FilePath -- store directory
-    -> Rebuild (Set ComponentId)
-getExecutableDBContents storeDirectory = do
-    monitorFiles [monitorFileGlob (FilePathGlob (FilePathRoot storeDirectory) (GlobFile [WildCard]))]
-    paths <- liftIO $ getDirectoryContents storeDirectory
-    return (Set.fromList (map ComponentId (filter valid paths)))
+-- | Return the 'UnitId's of all packages\/components already installed in the
+-- store.
+--
+getInstalledStorePackages :: FilePath -- ^ store directory
+                          -> Rebuild (Set UnitId)
+getInstalledStorePackages storeDirectory = do
+    paths <- getDirectoryContentsMonitored storeDirectory
+    return $ Set.fromList [ SimpleUnitId (ComponentId path)
+                          | path <- paths, valid path ]
   where
-    valid "." = False
-    valid ".." = False
+    valid ('.':_)      = False
     valid "package.db" = False
-    valid _ = True
+    valid _            = True
 
 getSourcePackages :: Verbosity -> (forall a. (RepoContext -> IO a) -> IO a)
                   -> Rebuild SourcePackageDb
@@ -729,6 +724,11 @@ getPkgConfigDb verbosity progdb = do
 
     liftIO $ readPkgConfigDb verbosity progdb
 
+
+getDirectoryContentsMonitored :: FilePath -> Rebuild [FilePath]
+getDirectoryContentsMonitored dir = do
+    monitorFiles [monitorDirectory dir]
+    liftIO $ getDirectoryContents dir
 
 recreateDirectory :: Verbosity -> Bool -> FilePath -> Rebuild ()
 recreateDirectory verbosity createParents dir = do
@@ -2712,11 +2712,10 @@ packageHashConfigInputs
 -- 'ElaboratedInstallPlan', replace configured source packages by installed
 -- packages from the store whenever they exist.
 --
-improveInstallPlanWithInstalledPackages :: InstalledPackageIndex
-                                        -> Set ComponentId
+improveInstallPlanWithInstalledPackages :: Set UnitId
                                         -> ElaboratedInstallPlan
                                         -> ElaboratedInstallPlan
-improveInstallPlanWithInstalledPackages installedPkgIndex installedExes installPlan =
+improveInstallPlanWithInstalledPackages installedPkgIdSet installPlan =
     replaceWithInstalled installPlan
       [ installedUnitId pkg
       | InstallPlan.Configured pkg
@@ -2731,14 +2730,7 @@ improveInstallPlanWithInstalledPackages installedPkgIndex installedExes installP
     -- since overwriting is never safe.
 
     canPackageBeImproved pkg =
-      case PackageIndex.lookupUnitId
-            installedPkgIndex (installedUnitId pkg) of
-        Just _ -> True
-        Nothing | SimpleUnitId cid <- installedUnitId pkg
-                , cid `Set.member` installedExes
-                -- Same hack as replacewithPrePreExisting
-                -> True
-                | otherwise -> False
+      installedUnitId pkg `Set.member` installedPkgIdSet
 
     replaceWithInstalled :: ElaboratedInstallPlan -> [UnitId]
                          -> ElaboratedInstallPlan

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2715,13 +2715,11 @@ packageHashConfigInputs
 improveInstallPlanWithInstalledPackages :: Set UnitId
                                         -> ElaboratedInstallPlan
                                         -> ElaboratedInstallPlan
-improveInstallPlanWithInstalledPackages installedPkgIdSet installPlan =
-    replaceWithInstalled installPlan
-      [ installedUnitId pkg
-      | InstallPlan.Configured pkg
-          <- InstallPlan.reverseTopologicalOrder installPlan
-      , canPackageBeImproved pkg ]
+improveInstallPlanWithInstalledPackages installedPkgIdSet =
+    InstallPlan.installed canPackageBeImproved
   where
+    canPackageBeImproved pkg =
+      installedUnitId pkg `Set.member` installedPkgIdSet
     --TODO: sanity checks:
     -- * the installed package must have the expected deps etc
     -- * the installed package must not be broken, valid dep closure
@@ -2729,9 +2727,3 @@ improveInstallPlanWithInstalledPackages installedPkgIdSet installPlan =
     --TODO: decide what to do if we encounter broken installed packages,
     -- since overwriting is never safe.
 
-    canPackageBeImproved pkg =
-      installedUnitId pkg `Set.member` installedPkgIdSet
-
-    replaceWithInstalled :: ElaboratedInstallPlan -> [UnitId]
-                         -> ElaboratedInstallPlan
-    replaceWithInstalled = foldl' (flip InstallPlan.installed)


### PR DESCRIPTION
Builds on #3863. So ignore the first 7 patches.

This maintains a `.ghc.environment.$arch-$os-$ghcver` file in the project root. The goal is to be able to just run `ghc` or `ghci` in/beneath the project dir and get the environment of the project, including any up-to-date libs local to the project.

Limitation: this only works with ghc-8.0.2 and later, which have non-buggy support for the `.ghc.environment` file feature.

This is not quite right yet:

 * We don't yet update the .ghc.environment file after building, just before (on new-build [--dry-run] or new-configure). This shouldn't be too much work to add.
 * We currently only include libraries that are deps of the current targets, so it's not a global view. This is a little tricky since we can only get a global view if we do the build status checks for all local packages rather than the current optimisation where we check only those packages that are deps of the targets we intend to build.