### PR TITLE
Print that we are building all due to Custom setup.

### DIFF
--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -1005,8 +1005,9 @@ buildAndInstallUnpackedPackage verbosity
 
     let dispname = case elabPkgOrComp pkg of
             ElabPackage _ -> display pkgid
-            ElabComponent comp -> display pkgid ++ " "
-                ++ maybe "custom" display (compComponentName comp)
+                ++ " (all, due to Custom setup)"
+            ElabComponent comp -> display pkgid
+                ++ " (" ++ maybe "custom" display (compComponentName comp) ++ ")"
 
     -- Configure phase
     when isParallelBuild $


### PR DESCRIPTION
Previously the output was:

    Building profunctors-5.2 lib...
    Building semigroupoids-5.1...

Now it is:

    Building profunctors-5.2 (lib)...
    Building semigroupoids-5.1 (all, due to Custom setup)...

Fixes #3808.

CC @phadej

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>