### PR TITLE
Add helper for Generic NFData instances

### DIFF
--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -202,6 +202,8 @@ instance Text Dependency where
              Parse.skipSpaces
              return (Dependency name ver)
 
+instance NFData Dependency where rnf = genericRnf
+
 thisPackageVersion :: PackageIdentifier -> Dependency
 thisPackageVersion (PackageIdentifier n v) =
   Dependency n (thisVersion v)

--- a/Cabal/Distribution/Version.hs
+++ b/Cabal/Distribution/Version.hs
@@ -134,6 +134,8 @@ data VersionRange
 
 instance Binary VersionRange
 
+instance NFData VersionRange where rnf = genericRnf
+
 #if __GLASGOW_HASKELL__ < 707
 -- starting with ghc-7.7/base-4.7 this instance is provided in "Data.Data"
 deriving instance Data Version


### PR DESCRIPTION
I needed the `NFData` instance for `Dependency`... which made me realise that
writing the implementation for the also needed `VersionRange` instance by hand
was too tedious, so here we are with a `genericRnf` compat helper...