### PR TITLE
Don't solve for executables in legacy code path.

### DIFF
--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -39,6 +39,7 @@ import Distribution.Package (PackageId)
 import Distribution.Client.JobControl (Lock)
 
 import qualified Distribution.Solver.Types.ComponentDeps as CD
+import           Distribution.Solver.Types.Settings
 import           Distribution.Solver.Types.ConstraintSource
 import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
@@ -348,8 +349,16 @@ planLocalPackage verbosity comp platform configFlags configExFlags
               in LabeledPackageConstraint pc ConstraintSourceConfigFlagOrTarget
             ]
 
+            -- Don't solve for executables, since we use an empty source
+            -- package database and executables never show up in the
+            -- installed package index
+        . setSolveExecutables (SolveExecutables False)
+
         $ standardInstallPolicy
             installedPkgIndex
+            -- NB: We pass in an *empty* source package database,
+            -- because cabal configure assumes that all dependencies
+            -- have already been installed
             (SourcePackageDb mempty packagePrefs)
             [SpecificSourcePackage localPkg]
 

--- a/cabal-install/Distribution/Solver/Modular.hs
+++ b/cabal-install/Distribution/Solver/Modular.hs
@@ -38,7 +38,7 @@ modularResolver sc (Platform arch os) cinfo iidx sidx pkgConfigDB pprefs pcs pns
   solve sc cinfo idx pkgConfigDB pprefs gcs pns
     where
       -- Indices have to be converted into solver-specific uniform index.
-      idx    = convPIs os arch cinfo (shadowPkgs sc) (strongFlags sc) iidx sidx
+      idx    = convPIs os arch cinfo (shadowPkgs sc) (strongFlags sc) (solveExecutables sc) iidx sidx
       -- Constraints have to be converted into a finite map indexed by PN.
       gcs    = M.fromListWith (++) (map pair pcs)
         where

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -61,6 +61,7 @@ data SolverConfig = SolverConfig {
   strongFlags           :: StrongFlags,
   maxBackjumps          :: Maybe Int,
   enableBackjumping     :: EnableBackjumping,
+  solveExecutables      :: SolveExecutables,
   goalOrder             :: Maybe (Variable QPN -> Variable QPN -> Ordering)
 }
 

--- a/cabal-install/Distribution/Solver/Types/Settings.hs
+++ b/cabal-install/Distribution/Solver/Types/Settings.hs
@@ -8,6 +8,7 @@ module Distribution.Solver.Types.Settings
     , StrongFlags(..)
     , EnableBackjumping(..)
     , CountConflicts(..)
+    , SolveExecutables(..)
     ) where
 
 import Distribution.Simple.Setup ( BooleanFlag(..) )
@@ -35,9 +36,13 @@ newtype StrongFlags = StrongFlags Bool
 newtype EnableBackjumping = EnableBackjumping Bool
   deriving (BooleanFlag, Eq, Generic, Show)
 
+newtype SolveExecutables = SolveExecutables Bool
+  deriving (BooleanFlag, Eq, Generic, Show)
+
 instance Binary ReorderGoals
 instance Binary CountConflicts
 instance Binary IndependentGoals
 instance Binary AvoidReinstalls
 instance Binary ShadowPkgs
 instance Binary StrongFlags
+instance Binary SolveExecutables


### PR DESCRIPTION
There is a bug in `cabal configure`'s invocation of the solver in
Distribution/Client/Configure.hs:

    standardInstallPolicy
        installedPkgIndex
        (SourcePackageDb mempty packagePrefs)
        [SpecificSourcePackage localPkg]

We can see that the solver is given an EMPTY source package database.
This is because we assume that everything you need from cabal configure
is taken from the installed package index.

But this is NOT true for executables, which never have an entry in the
installed package index. So we SHOULD NOT solve for
executables in the legacy codepath, since there isn't anything useful we
can do with the info anyway.  This gets toggled using a new solver
parameter SolveExecutables.

I didn't bother with a test because this will be obsoleted by
nix-local-build.

Fixes #3875

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>