### PR TITLE
FileMonitor fix

### DIFF
--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -201,6 +201,11 @@ monitorFileHashedSearchPath notFoundAtPaths foundAtPath =
 data MonitorStateFileSet
    = MonitorStateFileSet ![MonitorStateFile]
                          ![MonitorStateGlob]
+     -- Morally this is not actually a set but a bag (represented by lists).
+     -- There is no principled reason to use a bag here rather than a set, but
+     -- there is also no particular gain either. That said, we do preserve the
+     -- order of the lists just to reduce confusion (and have predictable I/O
+     -- patterns).
   deriving Show
 
 type Hash = Int

--- a/cabal-install/tests/UnitTests/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/FileMonitor.hs
@@ -24,6 +24,7 @@ import Test.Tasty.HUnit
 tests :: Int -> [TestTree]
 tests mtimeChange =
   [ testCase "sanity check mtimes"   $ testFileMTimeSanity mtimeChange
+  , testCase "sanity check dirs"     $ testDirChangeSanity mtimeChange
   , testCase "no monitor cache"      testNoMonitorCache
   , testCase "corrupt monitor cache" testCorruptMonitorCache
   , testCase "empty monitor"         testEmptyMonitor
@@ -70,6 +71,8 @@ tests mtimeChange =
   , testCase "value updated"         testValueUpdated
   ]
 
+-- Check the file system behaves the way we expect it to
+
 -- we rely on file mtimes having a reasonable resolution
 testFileMTimeSanity :: Int -> Assertion
 testFileMTimeSanity mtimeChange =
@@ -81,6 +84,62 @@ testFileMTimeSanity mtimeChange =
       IO.writeFile (dir </> "a") "content"
       t2 <- getModTime (dir </> "a")
       assertBool "expected different file mtimes" (t2 > t1)
+
+-- We rely on directories changing mtime when entries are added or removed
+testDirChangeSanity :: Int -> Assertion
+testDirChangeSanity mtimeChange =
+  withTempDirectory silent "." "dir-mtime-" $ \dir -> do
+
+    expectMTimeChange dir "file add" $
+      IO.writeFile (dir </> "file") "content"
+
+    expectMTimeSame dir "file content change" $
+      IO.writeFile (dir </> "file") "new content"
+
+    expectMTimeChange dir "file del" $
+      IO.removeFile (dir </> "file")
+
+    expectMTimeChange dir "subdir add" $
+      IO.createDirectory (dir </> "dir")
+
+    expectMTimeSame dir "subdir file add" $
+      IO.writeFile (dir </> "dir" </> "file") "content"
+
+    expectMTimeChange dir "subdir file move in" $
+      IO.renameFile (dir </> "dir" </> "file") (dir </> "file")
+
+    expectMTimeChange dir "subdir file move out" $
+      IO.renameFile (dir </> "file") (dir </> "dir" </> "file")
+
+    expectMTimeSame dir "subdir dir add" $
+      IO.createDirectory (dir </> "dir" </> "subdir")
+
+    expectMTimeChange dir "subdir dir move in" $
+      IO.renameDirectory (dir </> "dir" </> "subdir") (dir </> "subdir")
+
+    expectMTimeChange dir "subdir dir move out" $
+      IO.renameDirectory (dir </> "subdir") (dir </> "dir" </> "subdir")
+
+  where
+    expectMTimeChange, expectMTimeSame :: FilePath -> String -> IO ()
+                                       -> Assertion
+
+    expectMTimeChange dir descr action = do
+      t  <- getModTime dir
+      threadDelay mtimeChange
+      action
+      t' <- getModTime dir
+      assertBool ("expected dir mtime change on " ++ descr) (t' > t)
+
+    expectMTimeSame dir descr action = do
+      t  <- getModTime dir
+      threadDelay mtimeChange
+      action
+      t' <- getModTime dir
+      assertBool ("expected same dir mtime on " ++ descr) (t' == t)
+
+
+-- Now for the FileMonitor tests proper...
 
 -- first run, where we don't even call updateMonitor
 testNoMonitorCache :: Assertion


### PR DESCRIPTION
This fixes the bug that @ezyang identified previously https://github.com/haskell/cabal/pull/3863#issuecomment-248495178

> What seems to happen is that the mtime monitor is overwritten, so that we now only test directory existence. I guess monitors should be a monoid and accumulate?

The fix is that rather than doing any fancy merging of monitor kinds, we just do the simple thing and keep each monitor spec separately, so each one will be checked when the file system is probed. Internally, rather than keeping a Map indexed by FilePath we just keep a list.

Also add a unit test for this fix.

For belt & braces we add a check on the posix specified behaviour of directory modification times that we rely on.

While we're at it follow another of @ezyang's suggestions to use more `Rebuild` monad wrappers so we make fewer mistakes with `monitorFiles` (though that wasn't actually our mistake this time).