### PR TITLE
Installplan installed state (V2)

### DIFF
--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -159,6 +159,7 @@ import Prelude hiding (lookup)
 data GenericPlanPackage ipkg srcpkg
    = PreExisting ipkg
    | Configured  srcpkg
+   | Installed   srcpkg
   deriving (Eq, Show, Generic)
 
 type IsUnit a = (IsNode a, Key a ~ UnitId)
@@ -172,9 +173,11 @@ instance (IsNode ipkg, IsNode srcpkg, Key ipkg ~ UnitId, Key srcpkg ~ UnitId)
          => IsNode (GenericPlanPackage ipkg srcpkg) where
     type Key (GenericPlanPackage ipkg srcpkg) = UnitId
     nodeKey (PreExisting ipkg) = nodeKey ipkg
-    nodeKey (Configured spkg) = nodeKey spkg
+    nodeKey (Configured  spkg) = nodeKey spkg
+    nodeKey (Installed   spkg) = nodeKey spkg
     nodeNeighbors (PreExisting ipkg) = nodeNeighbors ipkg
-    nodeNeighbors (Configured spkg) = nodeNeighbors spkg
+    nodeNeighbors (Configured  spkg) = nodeNeighbors spkg
+    nodeNeighbors (Installed   spkg) = nodeNeighbors spkg
 
 instance (Binary ipkg, Binary srcpkg)
       => Binary (GenericPlanPackage ipkg srcpkg)
@@ -186,17 +189,20 @@ instance (Package ipkg, Package srcpkg) =>
          Package (GenericPlanPackage ipkg srcpkg) where
   packageId (PreExisting ipkg)     = packageId ipkg
   packageId (Configured  spkg)     = packageId spkg
+  packageId (Installed   spkg)     = packageId spkg
 
 instance (HasUnitId ipkg, HasUnitId srcpkg) =>
          HasUnitId
          (GenericPlanPackage ipkg srcpkg) where
   installedUnitId (PreExisting ipkg) = installedUnitId ipkg
   installedUnitId (Configured  spkg) = installedUnitId spkg
+  installedUnitId (Installed   spkg) = installedUnitId spkg
 
 instance (HasConfiguredId ipkg, HasConfiguredId srcpkg) =>
           HasConfiguredId (GenericPlanPackage ipkg srcpkg) where
     configuredId (PreExisting ipkg) = configuredId ipkg
-    configuredId (Configured pkg) = configuredId pkg
+    configuredId (Configured  spkg) = configuredId spkg
+    configuredId (Installed   spkg) = configuredId spkg
 
 data GenericInstallPlan ipkg srcpkg = GenericInstallPlan {
     planIndex      :: !(PlanIndex ipkg srcpkg),
@@ -255,6 +261,7 @@ showInstallPlan = showPlanIndex . planIndex
 showPlanPackageTag :: GenericPlanPackage ipkg srcpkg -> String
 showPlanPackageTag (PreExisting _)   = "PreExisting"
 showPlanPackageTag (Configured  _)   = "Configured"
+showPlanPackageTag (Installed   _)   = "Installed"
 
 -- | Build an installation plan from a valid set of resolved packages.
 --
@@ -509,17 +516,18 @@ ready plan =
     !processing =
       Processing
         (Set.fromList [ nodeKey pkg | pkg <- readyPackages ])
-        (Set.fromList [ nodeKey pkg | PreExisting pkg <- toList plan ])
+        (Set.fromList [ nodeKey pkg | pkg <- toList plan, isInstalled pkg ])
         Set.empty
     readyPackages =
       [ ReadyPackage pkg
       | Configured pkg <- toList plan
-      , all isPreExisting (directDeps plan (nodeKey pkg))
+      , all isInstalled (directDeps plan (nodeKey pkg))
       ]
 
-    isPreExisting (PreExisting {}) = True
-    isPreExisting _                = False
-
+isInstalled :: GenericPlanPackage a b -> Bool
+isInstalled (PreExisting {}) = True
+isInstalled (Installed   {}) = True
+isInstalled _                = False
 
 -- | Given a package in the processing state, mark the package as completed
 -- and return any packages that are newly in the processing state (ie ready to
@@ -592,6 +600,7 @@ processingInvariant plan (Processing processingSet completedSet failedSet) =
  && and [ case Graph.lookup pkgid (planIndex plan) of
             Just (Configured  _) -> True
             Just (PreExisting _) -> False
+            Just (Installed   _) -> False
             Nothing              -> False 
         | pkgid <- Set.toList processingSet ++ Set.toList failedSet ]
   where

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -33,7 +33,6 @@ module Distribution.Client.InstallPlan (
   fromSolverInstallPlan,
   configureInstallPlan,
   remove,
-  preexisting,
   installed,
   lookup,
   directDeps,
@@ -290,26 +289,6 @@ remove shouldRemove plan =
   where
     newIndex = Graph.fromList $
                  filter (not . shouldRemove) (toList plan)
-
--- | Replace a ready package with a pre-existing one. The pre-existing one
--- must have exactly the same dependencies as the source one was configured
--- with.
---
-preexisting :: (IsUnit ipkg,
-                IsUnit srcpkg)
-            => UnitId
-            -> ipkg
-            -> GenericInstallPlan ipkg srcpkg
-            -> GenericInstallPlan ipkg srcpkg
-preexisting pkgid ipkg plan = plan'
-  where
-    plan' = plan {
-      planIndex   = Graph.insert (PreExisting ipkg)
-                    -- ...but be sure to use the *old* IPID for the lookup for
-                    -- the preexisting record
-                  . Graph.deleteKey pkgid
-                  $ planIndex plan
-    }
 
 -- | Change a package in a 'Configured' state to an 'Installed' state.
 --

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -262,6 +262,9 @@ rebuildTargetsDryRun verbosity distDirLayout@DistDirLayout{..} shared = \install
     dryRunPkg (InstallPlan.PreExisting _pkg) _depsBuildStatus =
       return BuildStatusPreExisting
 
+    dryRunPkg (InstallPlan.Installed _pkg) _depsBuildStatus =
+      return BuildStatusPreExisting --TODO: distinguish installed state
+
     dryRunPkg (InstallPlan.Configured pkg) depsBuildStatus = do
       mloc <- checkFetched (elabPkgSourceLocation pkg)
       case mloc of

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -534,7 +534,8 @@ printPlan verbosity
             partialConfigureFlags
 
     showBuildStatus status = case status of
-      BuildStatusPreExisting -> "already installed"
+      BuildStatusPreExisting -> "existing package"
+      BuildStatusInstalled   -> "already installed"
       BuildStatusDownload {} -> "requires download & build"
       BuildStatusUnpack   {} -> "requires build"
       BuildStatusRebuild _ rebuild -> case rebuild of

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2705,13 +2705,11 @@ packageHashConfigInputs
 improveInstallPlanWithInstalledPackages :: Set UnitId
                                         -> ElaboratedInstallPlan
                                         -> ElaboratedInstallPlan
-improveInstallPlanWithInstalledPackages installedPkgIdSet installPlan =
-    replaceWithInstalled installPlan
-      [ installedUnitId pkg
-      | InstallPlan.Configured pkg
-          <- InstallPlan.reverseTopologicalOrder installPlan
-      , canPackageBeImproved pkg ]
+improveInstallPlanWithInstalledPackages installedPkgIdSet =
+    InstallPlan.installed canPackageBeImproved
   where
+    canPackageBeImproved pkg =
+      installedUnitId pkg `Set.member` installedPkgIdSet
     --TODO: sanity checks:
     -- * the installed package must have the expected deps etc
     -- * the installed package must not be broken, valid dep closure
@@ -2719,9 +2717,3 @@ improveInstallPlanWithInstalledPackages installedPkgIdSet installPlan =
     --TODO: decide what to do if we encounter broken installed packages,
     -- since overwriting is never safe.
 
-    canPackageBeImproved pkg =
-      installedUnitId pkg `Set.member` installedPkgIdSet
-
-    replaceWithInstalled :: ElaboratedInstallPlan -> [UnitId]
-                         -> ElaboratedInstallPlan
-    replaceWithInstalled = foldl' (flip InstallPlan.installed)

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -91,7 +91,6 @@ import qualified Distribution.PackageDescription as Cabal
 import qualified Distribution.PackageDescription as PD
 import qualified Distribution.PackageDescription.Configuration as PD
 import           Distribution.Simple.PackageIndex (InstalledPackageIndex)
-import qualified Distribution.Simple.PackageIndex as PackageIndex
 import           Distribution.Simple.Compiler hiding (Flag)
 import qualified Distribution.Simple.GHC   as GHC   --TODO: [code cleanup] eliminate
 import qualified Distribution.Simple.GHCJS as GHCJS --TODO: [code cleanup] eliminate
@@ -605,22 +604,23 @@ rebuildInstallPlan verbosity
 
         liftIO $ debug verbosity "Improving the install plan..."
         createDirectoryMonitored True storeDirectory
-        storePkgIndex <- getPackageDBContents verbosity
-                                              compiler progdb platform
-                                              storePackageDb
-        storeExeIndex <- getExecutableDBContents storeDirectory
+        liftIO $ createPackageDBIfMissing verbosity
+                                          compiler progdb
+                                          storePackageDb
+        storePkgIdSet <- getInstalledStorePackages storeDirectory
         let improvedPlan = improveInstallPlanWithInstalledPackages
-                             storePkgIndex
-                             storeExeIndex
+                             storePkgIdSet
                              elaboratedPlan
         liftIO $ debugNoWrap verbosity (InstallPlan.showInstallPlan improvedPlan)
+        -- TODO: [nice to have] having checked which packages from the store
+        -- we're using, it may be sensible to sanity check those packages
+        -- by loading up the compiler package db and checking everything
+        -- matches up as expected, e.g. no dangling deps, files deleted.
         return improvedPlan
-
       where
         storeDirectory  = cabalStoreDirectory (compilerId compiler)
         storePackageDb  = cabalStorePackageDB (compilerId compiler)
         ElaboratedSharedConfig {
-          pkgConfigPlatform      = platform,
           pkgConfigCompiler      = compiler,
           pkgConfigCompilerProgs = progdb
         } = elaboratedShared
@@ -657,6 +657,8 @@ getInstalledPackages verbosity compiler progdb platform packagedbs = do
                verbosity compiler
                packagedbs progdb
 
+{-
+--TODO: [nice to have] use this but for sanity / consistency checking
 getPackageDBContents :: Verbosity
                      -> Compiler -> ProgramDb -> Platform
                      -> PackageDB
@@ -670,19 +672,21 @@ getPackageDBContents verbosity compiler progdb platform packagedb = do
       createPackageDBIfMissing verbosity compiler progdb packagedb
       Cabal.getPackageDBContents verbosity compiler
                                  packagedb progdb
+-}
 
--- | Return the list of all already installed executables
-getExecutableDBContents
-    :: FilePath -- store directory
-    -> Rebuild (Set ComponentId)
-getExecutableDBContents storeDirectory = do
+-- | Return the 'UnitId's of all packages\/components already installed in the
+-- store.
+--
+getInstalledStorePackages :: FilePath -- ^ store directory
+                          -> Rebuild (Set UnitId)
+getInstalledStorePackages storeDirectory = do
     paths <- getDirectoryContentsMonitored storeDirectory
-    return (Set.fromList (map ComponentId (filter valid paths)))
+    return $ Set.fromList [ SimpleUnitId (ComponentId path)
+                          | path <- paths, valid path ]
   where
-    valid "." = False
-    valid ".." = False
+    valid ('.':_)      = False
     valid "package.db" = False
-    valid _ = True
+    valid _            = True
 
 getSourcePackages :: Verbosity -> (forall a. (RepoContext -> IO a) -> IO a)
                   -> Rebuild SourcePackageDb
@@ -2698,11 +2702,10 @@ packageHashConfigInputs
 -- 'ElaboratedInstallPlan', replace configured source packages by installed
 -- packages from the store whenever they exist.
 --
-improveInstallPlanWithInstalledPackages :: InstalledPackageIndex
-                                        -> Set ComponentId
+improveInstallPlanWithInstalledPackages :: Set UnitId
                                         -> ElaboratedInstallPlan
                                         -> ElaboratedInstallPlan
-improveInstallPlanWithInstalledPackages installedPkgIndex installedExes installPlan =
+improveInstallPlanWithInstalledPackages installedPkgIdSet installPlan =
     replaceWithInstalled installPlan
       [ installedUnitId pkg
       | InstallPlan.Configured pkg
@@ -2717,14 +2720,7 @@ improveInstallPlanWithInstalledPackages installedPkgIndex installedExes installP
     -- since overwriting is never safe.
 
     canPackageBeImproved pkg =
-      case PackageIndex.lookupUnitId
-            installedPkgIndex (installedUnitId pkg) of
-        Just _ -> True
-        Nothing | SimpleUnitId cid <- installedUnitId pkg
-                , cid `Set.member` installedExes
-                -- Same hack as replacewithPrePreExisting
-                -> True
-                | otherwise -> False
+      installedUnitId pkg `Set.member` installedPkgIdSet
 
     replaceWithInstalled :: ElaboratedInstallPlan -> [UnitId]
                          -> ElaboratedInstallPlan

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1221,6 +1221,7 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
                 case elabPkgOrComp elab of
                     ElabPackage _ -> True
                     ElabComponent comp -> compSolverName comp == CD.ComponentLib
+            is_lib (InstallPlan.Installed _) = unexpectedState
 
     elaborateExeSolverId :: (SolverId -> [ElaboratedPlanPackage])
                       -> SolverId -> [ConfiguredId]
@@ -1233,6 +1234,7 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
                         case compSolverName comp of
                             CD.ComponentExe _ -> True
                             _ -> False
+            is_exe (InstallPlan.Installed _) = unexpectedState
 
     elaborateExePath :: (SolverId -> [ElaboratedPlanPackage])
                      -> SolverId -> [FilePath]
@@ -1255,6 +1257,9 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
                                     Just (Just n) -> n
                                     _ -> ""
               else InstallDirs.bindir (elabInstallDirs elab)]
+        get_exe_path (InstallPlan.Installed _) = unexpectedState
+
+    unexpectedState = error "elaborateInstallPlan: unexpected Installed state"
 
     elaborateSolverToPackage :: (SolverId -> [ElaboratedPlanPackage])
                              -> SolverPackage UnresolvedPkgLoc
@@ -1980,6 +1985,8 @@ mapConfiguredPackage :: (srcpkg -> srcpkg')
                      -> InstallPlan.GenericPlanPackage ipkg srcpkg'
 mapConfiguredPackage f (InstallPlan.Configured pkg) =
   InstallPlan.Configured (f pkg)
+mapConfiguredPackage f (InstallPlan.Installed pkg) =
+  InstallPlan.Installed (f pkg)
 mapConfiguredPackage _ (InstallPlan.PreExisting pkg) =
   InstallPlan.PreExisting pkg
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -87,7 +87,6 @@ import           Distribution.Solver.Types.SourcePackage
 import           Distribution.Package hiding
   (InstalledPackageId, installedPackageId)
 import           Distribution.System
-import qualified Distribution.InstalledPackageInfo as Installed
 import qualified Distribution.PackageDescription as Cabal
 import qualified Distribution.PackageDescription as PD
 import qualified Distribution.PackageDescription.Configuration as PD
@@ -610,7 +609,7 @@ rebuildInstallPlan verbosity
                                               compiler progdb platform
                                               storePackageDb
         storeExeIndex <- getExecutableDBContents storeDirectory
-        let improvedPlan = improveInstallPlanWithPreExistingPackages
+        let improvedPlan = improveInstallPlanWithInstalledPackages
                              storePkgIndex
                              storeExeIndex
                              elaboratedPlan
@@ -2696,19 +2695,19 @@ packageHashConfigInputs
 
 
 -- | Given the 'InstalledPackageIndex' for a nix-style package store, and an
--- 'ElaboratedInstallPlan', replace configured source packages by pre-existing
--- installed packages whenever they exist.
+-- 'ElaboratedInstallPlan', replace configured source packages by installed
+-- packages from the store whenever they exist.
 --
-improveInstallPlanWithPreExistingPackages :: InstalledPackageIndex
-                                          -> Set ComponentId
-                                          -> ElaboratedInstallPlan
-                                          -> ElaboratedInstallPlan
-improveInstallPlanWithPreExistingPackages installedPkgIndex installedExes installPlan =
-    replaceWithPreExisting installPlan
-      [ ipkg
+improveInstallPlanWithInstalledPackages :: InstalledPackageIndex
+                                        -> Set ComponentId
+                                        -> ElaboratedInstallPlan
+                                        -> ElaboratedInstallPlan
+improveInstallPlanWithInstalledPackages installedPkgIndex installedExes installPlan =
+    replaceWithInstalled installPlan
+      [ installedUnitId pkg
       | InstallPlan.Configured pkg
           <- InstallPlan.reverseTopologicalOrder installPlan
-      , ipkg <- maybeToList (canPackageBeImproved pkg) ]
+      , canPackageBeImproved pkg ]
   where
     --TODO: sanity checks:
     -- * the installed package must have the expected deps etc
@@ -2720,15 +2719,13 @@ improveInstallPlanWithPreExistingPackages installedPkgIndex installedExes instal
     canPackageBeImproved pkg =
       case PackageIndex.lookupUnitId
             installedPkgIndex (installedUnitId pkg) of
-        Just x -> Just x
+        Just _ -> True
         Nothing | SimpleUnitId cid <- installedUnitId pkg
                 , cid `Set.member` installedExes
                 -- Same hack as replacewithPrePreExisting
-                -> Just (Installed.emptyInstalledPackageInfo {
-                            Installed.installedUnitId = installedUnitId pkg
-                        })
-                | otherwise -> Nothing
+                -> True
+                | otherwise -> False
 
-    replaceWithPreExisting =
-      foldl' (\plan ipkg -> InstallPlan.preexisting
-                              (installedUnitId ipkg) ipkg plan)
+    replaceWithInstalled :: ElaboratedInstallPlan -> [UnitId]
+                         -> ElaboratedInstallPlan
+    replaceWithInstalled = foldl' (flip InstallPlan.installed)

--- a/cabal-install/tests/UnitTests/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/FileMonitor.hs
@@ -24,6 +24,7 @@ import Test.Tasty.HUnit
 tests :: Int -> [TestTree]
 tests mtimeChange =
   [ testCase "sanity check mtimes"   $ testFileMTimeSanity mtimeChange
+  , testCase "sanity check dirs"     $ testDirChangeSanity mtimeChange
   , testCase "no monitor cache"      testNoMonitorCache
   , testCase "corrupt monitor cache" testCorruptMonitorCache
   , testCase "empty monitor"         testEmptyMonitor
@@ -70,6 +71,8 @@ tests mtimeChange =
   , testCase "value updated"         testValueUpdated
   ]
 
+-- Check the file system behaves the way we expect it to
+
 -- we rely on file mtimes having a reasonable resolution
 testFileMTimeSanity :: Int -> Assertion
 testFileMTimeSanity mtimeChange =
@@ -81,6 +84,62 @@ testFileMTimeSanity mtimeChange =
       IO.writeFile (dir </> "a") "content"
       t2 <- getModTime (dir </> "a")
       assertBool "expected different file mtimes" (t2 > t1)
+
+-- We rely on directories changing mtime when entries are added or removed
+testDirChangeSanity :: Int -> Assertion
+testDirChangeSanity mtimeChange =
+  withTempDirectory silent "." "dir-mtime-" $ \dir -> do
+
+    expectMTimeChange dir "file add" $
+      IO.writeFile (dir </> "file") "content"
+
+    expectMTimeSame dir "file content change" $
+      IO.writeFile (dir </> "file") "new content"
+
+    expectMTimeChange dir "file del" $
+      IO.removeFile (dir </> "file")
+
+    expectMTimeChange dir "subdir add" $
+      IO.createDirectory (dir </> "dir")
+
+    expectMTimeSame dir "subdir file add" $
+      IO.writeFile (dir </> "dir" </> "file") "content"
+
+    expectMTimeChange dir "subdir file move in" $
+      IO.renameFile (dir </> "dir" </> "file") (dir </> "file")
+
+    expectMTimeChange dir "subdir file move out" $
+      IO.renameFile (dir </> "file") (dir </> "dir" </> "file")
+
+    expectMTimeSame dir "subdir dir add" $
+      IO.createDirectory (dir </> "dir" </> "subdir")
+
+    expectMTimeChange dir "subdir dir move in" $
+      IO.renameDirectory (dir </> "dir" </> "subdir") (dir </> "subdir")
+
+    expectMTimeChange dir "subdir dir move out" $
+      IO.renameDirectory (dir </> "subdir") (dir </> "dir" </> "subdir")
+
+  where
+    expectMTimeChange, expectMTimeSame :: FilePath -> String -> IO ()
+                                       -> Assertion
+
+    expectMTimeChange dir descr action = do
+      t  <- getModTime dir
+      threadDelay mtimeChange
+      action
+      t' <- getModTime dir
+      assertBool ("expected dir mtime change on " ++ descr) (t' > t)
+
+    expectMTimeSame dir descr action = do
+      t  <- getModTime dir
+      threadDelay mtimeChange
+      action
+      t' <- getModTime dir
+      assertBool ("expected same dir mtime on " ++ descr) (t' == t)
+
+
+-- Now for the FileMonitor tests proper...
 
 -- first run, where we don't even call updateMonitor
 testNoMonitorCache :: Assertion


### PR DESCRIPTION
PR #3863 got merged but then had to be reverted due to a latent bug in the FileMonitor code.

PR #3887 fixes the FileMonitor stuff (as yet unmerged).

So this PR is just the original one, but rebased on top of the FileMonitor fixes. So ignore the first 3 patches (or go comment on them in #3887).

Note it's difficult to have an integration test for install plan improvement at the moment because we don't have an easy way to get non-hackage packages into the store. Once we add support for local tarballs then this will be easier to test automatically.