### PR TITLE
Enable `-rtsopts` for `cabal` executable

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -228,7 +228,7 @@ Flag debug-tracetree
 
 executable cabal
     main-is:        Main.hs
-    ghc-options:    -Wall -fwarn-tabs
+    ghc-options:    -Wall -fwarn-tabs -rtsopts
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances


### PR DESCRIPTION
Fwiw, the GHC executables are compiled with full `-rtsopts` as well.
The benefit is that one can use flags such as `-M1G` to limit the heap
space, or profile memory usage via `-hT`.