### PR TITLE
Refactor cabal-install with custom Prelude

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -315,6 +315,7 @@ library
     Distribution.Compat.Exception
     Distribution.Compat.Graph
     Distribution.Compat.Internal.TempFile
+    Distribution.Compat.Prelude
     Distribution.Compat.ReadP
     Distribution.Compat.Semigroup
     Distribution.Compat.Stack
@@ -415,7 +416,6 @@ library
     Distribution.Compat.Binary
 
   other-modules:
-    Distribution.Compat.Prelude
     Distribution.Compat.CopyFile
     Distribution.Compat.GetShortPathName
     Distribution.Compat.MonadFail

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -315,7 +315,7 @@ library
     Distribution.Compat.Exception
     Distribution.Compat.Graph
     Distribution.Compat.Internal.TempFile
-    Distribution.Compat.Prelude
+    Distribution.Compat.Prelude.Internal
     Distribution.Compat.ReadP
     Distribution.Compat.Semigroup
     Distribution.Compat.Stack
@@ -419,6 +419,7 @@ library
     Distribution.Compat.CopyFile
     Distribution.Compat.GetShortPathName
     Distribution.Compat.MonadFail
+    Distribution.Compat.Prelude
     Distribution.GetOpt
     Distribution.Lex
     Distribution.Simple.GHC.Internal

--- a/Cabal/Distribution/Compat/Prelude/Internal.hs
+++ b/Cabal/Distribution/Compat/Prelude/Internal.hs
@@ -1,0 +1,14 @@
+-- | This module re-exports the non-exposed
+-- "Distribution.Compat.Prelude" module for
+-- reuse by @cabal-install@'s
+-- "Distribution.Client.Compat.Prelude" module.
+--
+-- It is highly discouraged to rely on this module
+-- for @Setup.hs@ scripts since its API is /not/
+-- stable.
+module Distribution.Compat.Prelude.Internal
+    {-# WARNING "This modules' API is not stable. Use at your own risk, or better yet, use @base-compat@!" #-}
+    ( module Distribution.Compat.Prelude
+    ) where
+
+import Distribution.Compat.Prelude

--- a/cabal-install/Distribution/Client/Compat/Prelude.hs
+++ b/cabal-install/Distribution/Client/Compat/Prelude.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- | This module does two things:
 --
 -- * Acts as a compatiblity layer, like @base-compat@.
@@ -10,7 +12,21 @@
 module Distribution.Client.Compat.Prelude
   ( module Distribution.Compat.Prelude
   , Prelude.IO
+  , readMaybe
   ) where
 
 import Prelude (IO)
 import Distribution.Compat.Prelude hiding (IO)
+
+#if MIN_VERSION_base(4,6,0)
+import Text.Read
+         ( readMaybe )
+#endif
+
+#if !MIN_VERSION_base(4,6,0)
+-- | An implementation of readMaybe, for compatability with older base versions.
+readMaybe :: Read a => String -> Maybe a
+readMaybe s = case reads s of
+                [(x,"")] -> Just x
+                _        -> Nothing
+#endif

--- a/cabal-install/Distribution/Client/Compat/Prelude.hs
+++ b/cabal-install/Distribution/Client/Compat/Prelude.hs
@@ -1,0 +1,16 @@
+-- | This module does two things:
+--
+-- * Acts as a compatiblity layer, like @base-compat@.
+--
+-- * Provides commonly used imports.
+--
+-- This module is a superset of "Distribution.Compat.Prelude" (which
+-- this module re-exports)
+--
+module Distribution.Client.Compat.Prelude
+  ( module Distribution.Compat.Prelude
+  , Prelude.IO
+  ) where
+
+import Prelude (IO)
+import Distribution.Compat.Prelude hiding (IO)

--- a/cabal-install/Distribution/Client/Compat/Prelude.hs
+++ b/cabal-install/Distribution/Client/Compat/Prelude.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE CPP #-}
 
+-- to suppress WARNING in "Distribution.Compat.Prelude.Internal"
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
 -- | This module does two things:
 --
 -- * Acts as a compatiblity layer, like @base-compat@.
@@ -10,13 +13,13 @@
 -- this module re-exports)
 --
 module Distribution.Client.Compat.Prelude
-  ( module Distribution.Compat.Prelude
+  ( module Distribution.Compat.Prelude.Internal
   , Prelude.IO
   , readMaybe
   ) where
 
 import Prelude (IO)
-import Distribution.Compat.Prelude hiding (IO)
+import Distribution.Compat.Prelude.Internal hiding (IO)
 
 #if MIN_VERSION_base(4,6,0)
 import Text.Read

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Configure
@@ -21,6 +20,9 @@ module Distribution.Client.Configure (
     cabalConfigFlagsFile,
     writeConfigFlagsTo, writeConfigFlags,
   ) where
+
+import Prelude ()
+import Distribution.Client.Compat.Prelude
 
 import Distribution.Client.Dependency
 import qualified Distribution.Client.InstallPlan as InstallPlan
@@ -83,11 +85,6 @@ import Distribution.Verbosity as Verbosity
 import Distribution.Version
          ( Version(..), VersionRange, orLaterVersion )
 
-import Control.Monad (unless)
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (Monoid(..))
-#endif
-import Data.Maybe (isJust, fromMaybe)
 import System.FilePath ( (</>) )
 
 -- | Choose the Cabal version such that the setup scripts compiled against this

--- a/cabal-install/Distribution/Client/Exec.hs
+++ b/cabal-install/Distribution/Client/Exec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Exec
@@ -12,7 +11,8 @@
 module Distribution.Client.Exec ( exec
                                 ) where
 
-import Control.Monad (unless)
+import Prelude ()
+import Distribution.Client.Compat.Prelude
 
 import qualified Distribution.Simple.GHC   as GHC
 import qualified Distribution.Simple.GHCJS as GHCJS
@@ -34,10 +34,6 @@ import Distribution.Verbosity (Verbosity)
 
 import System.Directory ( doesDirectoryExist )
 import System.FilePath (searchPathSeparator, (</>))
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ((<$>))
-import Data.Monoid (mempty)
-#endif
 
 
 -- | Execute the given command in the package's environment.

--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -35,23 +35,18 @@ module Distribution.Client.FileMonitor (
   beginUpdateFileMonitor,
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
 
 #if MIN_VERSION_containers(0,5,0)
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 #else
-import           Data.Map        (Map)
 import qualified Data.Map        as Map
 #endif
 import qualified Data.ByteString.Lazy as BS
-import           Distribution.Compat.Binary
 import qualified Distribution.Compat.Binary as Binary
 import qualified Data.Hashable as Hashable
-import           Data.List (sort)
 
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative
-#endif
 import           Control.Monad
 import           Control.Monad.Trans (MonadIO, liftIO)
 import           Control.Monad.State (StateT, mapStateT)
@@ -68,8 +63,6 @@ import           Distribution.Client.Utils (mergeBy, MergeResult(..))
 import           System.FilePath
 import           System.Directory
 import           System.IO
-import           GHC.Generics (Generic)
-
 
 ------------------------------------------------------------------------------
 -- Types for specifying files to monitor

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Freeze
@@ -15,6 +14,9 @@
 module Distribution.Client.Freeze (
     freeze, getFreezePkgs
   ) where
+
+import Prelude ()
+import Distribution.Client.Compat.Prelude
 
 import Distribution.Client.Config ( SavedConfig(..) )
 import Distribution.Client.Types
@@ -58,13 +60,7 @@ import Distribution.Text
 import Distribution.Verbosity
          ( Verbosity )
 
-import Control.Monad
-         ( when )
 import qualified Data.ByteString.Lazy.Char8 as BS.Char8
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid
-         ( mempty )
-#endif
 import Data.Version
          ( showVersion )
 import Distribution.Version

--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Get
@@ -17,6 +16,9 @@
 module Distribution.Client.Get (
     get
   ) where
+
+import Prelude ()
+import Distribution.Client.Compat.Prelude hiding (get)
 
 import Distribution.Package
          ( PackageId, packageId, packageName )
@@ -48,16 +50,8 @@ import Distribution.Solver.Types.SourcePackage
 import Control.Exception
          ( finally )
 import Control.Monad
-         ( filterM, forM_, unless, when )
-import Data.List
-         ( sortBy )
+         ( forM_, mapM_ )
 import qualified Data.Map
-import Data.Maybe
-         ( listToMaybe, mapMaybe )
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid
-         ( mempty )
-#endif
 import Data.Ord
          ( comparing )
 import System.Directory

--- a/cabal-install/Distribution/Client/Glob.hs
+++ b/cabal-install/Distribution/Client/Glob.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 --TODO: [code cleanup] plausibly much of this module should be merged with
 -- similar functionality in Cabal.
@@ -15,14 +15,11 @@ module Distribution.Client.Glob
     , getFilePathRootDirectory
     ) where
 
-import           Data.Char (toUpper)
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import           Data.List (stripPrefix)
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative
-#endif
-import           Control.Monad
-import           Distribution.Compat.Binary
-import           GHC.Generics (Generic)
+import           Control.Monad (mapM)
 
 import           Distribution.Text
 import           Distribution.Compat.ReadP (ReadP, (<++), (+++))

--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -41,7 +41,7 @@ import Distribution.Simple.Utils
          , copyFileVerbose,  withTempFile
          , rawSystemStdInOut, toUTF8, fromUTF8, normaliseLineEndings )
 import Distribution.Client.Utils
-         ( readMaybe, withTempFileName )
+         ( withTempFileName )
 import Distribution.Client.Types
          ( RemoteRepo(..) )
 import Distribution.System

--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, BangPatterns #-}
+{-# LANGUAGE BangPatterns #-}
 -----------------------------------------------------------------------------
 -- | Separate module for HTTP actions, using a proxy server if one exists.
 -----------------------------------------------------------------------------
@@ -14,6 +14,9 @@ module Distribution.Client.HttpUtils (
     isOldHackageURI
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import Network.HTTP
          ( Request (..), Response (..), RequestMethod (..)
          , Header(..), HeaderName(..), lookupHeader )
@@ -23,21 +26,14 @@ import Network.URI
 import Network.Browser
          ( browse, setOutHandler, setErrHandler, setProxy
          , setAuthorityGen, request, setAllowBasicAuth, setUserAgent )
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
 import qualified Control.Exception as Exception
 import Control.Exception
          ( evaluate )
 import Control.DeepSeq
          ( force )
 import Control.Monad
-         ( when, guard )
+         ( guard )
 import qualified Data.ByteString.Lazy.Char8 as BS
-import Data.List
-         ( isPrefixOf, find, intercalate )
-import Data.Maybe
-         ( listToMaybe, maybeToList, fromMaybe )
 import qualified Paths_cabal_install (version)
 import Distribution.Verbosity (Verbosity)
 import Distribution.Simple.Utils
@@ -52,8 +48,6 @@ import Distribution.System
          ( buildOS, buildArch )
 import Distribution.Text
          ( display )
-import Data.Char
-         ( isSpace )
 import qualified System.FilePath.Posix as FilePath.Posix
          ( splitDirectories )
 import System.FilePath

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE BangPatterns #-}
@@ -36,6 +35,9 @@ module Distribution.Client.IndexUtils (
 
   BuildTreeRefType(..), refTypeFromTypeCode, typeCodeFromRefType
   ) where
+
+import Prelude ()
+import Distribution.Client.Compat.Prelude
 
 import qualified Codec.Archive.Tar       as Tar
 import qualified Codec.Archive.Tar.Entry as Tar
@@ -77,16 +79,7 @@ import           Distribution.Solver.Types.PackageIndex (PackageIndex)
 import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
 import           Distribution.Solver.Types.SourcePackage
 
-import GHC.Generics (Generic)
-
-import Data.Char   (isAlphaNum)
-import Data.Maybe  (mapMaybe, catMaybes, maybeToList, fromMaybe)
-import Data.List   (isPrefixOf)
 import Data.Word
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (Monoid(..))
-import Control.Applicative
-#endif
 import qualified Data.Map as Map
 import Control.DeepSeq
 import Control.Monad

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Init
@@ -23,6 +22,9 @@ module Distribution.Client.Init (
 
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude hiding (empty)
+
 import System.IO
   ( hSetBuffering, stdout, BufferMode(..) )
 import System.Directory
@@ -33,23 +35,13 @@ import System.FilePath
 import Data.Time
   ( getCurrentTime, utcToLocalTime, toGregorian, localDay, getCurrentTimeZone )
 
-import Data.Char
-  ( toUpper )
 import Data.List
-  ( intercalate, nub, groupBy, (\\) )
-import Data.Maybe
-  ( fromMaybe, isJust, catMaybes, listToMaybe )
+  ( groupBy, (\\) )
 import Data.Function
   ( on )
 import qualified Data.Map as M
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-  ( (<$>) )
-import Data.Traversable
-  ( traverse )
-#endif
 import Control.Monad
-  ( when, unless, (>=>), join, forM_ )
+  ( (>=>), join, forM_, mapM, mapM_ )
 import Control.Arrow
   ( (&&&), (***) )
 
@@ -932,9 +924,9 @@ generateCabalFile fileName c =
                         (True, _, _)      -> (showComment com $$) . ($$ text "")
                         (False, _, _)     -> ($$ text "")
                       $
-                      comment f <> text s <> colon
-                                <> text (replicate (20 - length s) ' ')
-                                <> text (fromMaybe "" . flagToMaybe $ f)
+                      comment f <<>> text s <<>> colon
+                                <<>> text (replicate (20 - length s) ' ')
+                                <<>> text (fromMaybe "" . flagToMaybe $ f)
    comment NoFlag    = text "-- "
    comment (Flag "") = text "-- "
    comment _         = text ""

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -603,11 +603,6 @@ promptList' displayItem numChoices choices def other = do
                                   = return . Right $ choices !! (n-1)
                    | otherwise    = Left `fmap` promptStr "Please specify" Nothing
 
-readMaybe :: (Read a) => String -> Maybe a
-readMaybe s = case reads s of
-                [(a,"")] -> Just a
-                _        -> Nothing
-
 ---------------------------------------------------------------------------
 --  File generation  ------------------------------------------------------
 ---------------------------------------------------------------------------

--- a/cabal-install/Distribution/Client/Init/Heuristics.hs
+++ b/cabal-install/Distribution/Client/Init/Heuristics.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Init.Heuristics
@@ -20,6 +19,10 @@ module Distribution.Client.Init.Heuristics (
     guessAuthorNameMail,
     knownCategories,
 ) where
+
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import Distribution.Text         (simpleParse)
 import Distribution.Simple.Setup (Flag(..), flagToMaybe)
 import Distribution.ModuleName
@@ -27,8 +30,6 @@ import Distribution.ModuleName
 import qualified Distribution.Package as P
 import qualified Distribution.PackageDescription as PD
     ( category, packageDescription )
-import Distribution.Simple.Utils
-         ( intercalate )
 import Distribution.Client.Utils
          ( tryCanonicalizePath )
 import Language.Haskell.Extension ( Extension )
@@ -39,16 +40,10 @@ import Distribution.Solver.Types.SourcePackage
     ( packageDescription )
 
 import Distribution.Client.Types ( SourcePackageDb(..) )
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ( pure, (<$>), (<*>) )
-import Data.Monoid         ( mempty, mappend, mconcat )
-#endif
-import Control.Arrow ( first )
-import Control.Monad ( liftM )
-import Data.Char   ( isAlphaNum, isNumber, isUpper, isLower, isSpace )
+import Control.Monad ( mapM )
+import Data.Char   ( isNumber, isLower )
 import Data.Either ( partitionEithers )
-import Data.List   ( isInfixOf, isPrefixOf, isSuffixOf, sortBy )
-import Data.Maybe  ( mapMaybe, catMaybes, maybeToList )
+import Data.List   ( isInfixOf )
 import Data.Ord    ( comparing )
 import qualified Data.Set as Set ( fromList, toList )
 import System.Directory ( getCurrentDirectory, getDirectoryContents,

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -29,14 +29,13 @@ module Distribution.Client.Install (
     pruneInstallPlan
   ) where
 
-import Data.Foldable
-         ( traverse_ )
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import Data.List
-         ( isPrefixOf, nub, sort, (\\), find )
+         ( (\\) )
 import qualified Data.Map as Map
 import qualified Data.Set as S
-import Data.Maybe
-         ( catMaybes, isJust, isNothing, fromMaybe, mapMaybe )
 import Control.Exception as Exception
          ( Exception(toException), bracket, catches
          , Handler(Handler), handleJust, IOException, SomeException )
@@ -48,15 +47,9 @@ import System.Exit
          ( ExitCode(..) )
 import Distribution.Compat.Exception
          ( catchIO, catchExit )
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-         ( (<$>) )
-import Data.Traversable
-         ( traverse )
-#endif
 import Control.Exception ( assert )
 import Control.Monad
-         ( filterM, forM_, when, unless )
+         ( forM_, mapM )
 import System.Directory
          ( getTemporaryDirectory, doesDirectoryExist, doesFileExist,
            createDirectoryIfMissing, removeFile, renameDirectory,
@@ -165,7 +158,7 @@ import Distribution.Version
          ( Version, VersionRange, foldVersionRange )
 import Distribution.Simple.Utils as Utils
          ( notice, info, warn, debug, debugNoWrap, die
-         , intercalate, withTempDirectory )
+         , withTempDirectory )
 import Distribution.Client.Utils
          ( determineNumJobs, logDirChange, mergeBy, MergeResult(..)
          , tryCanonicalizePath )

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -43,6 +43,9 @@ module Distribution.Client.ProjectConfig (
     BadPerPackageCompilerPaths(..)
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import Distribution.Client.ProjectConfig.Types
 import Distribution.Client.ProjectConfig.Legacy
 import Distribution.Client.RebuildMonad
@@ -96,21 +99,14 @@ import Distribution.Text
 import Distribution.ParseUtils
          ( ParseResult(..), locatedErrorMsg, showPWarning )
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
 import Control.Monad
 import Control.Monad.Trans (liftIO)
 import Control.Exception
-import Data.Typeable
-import Data.List (intercalate)
 import Data.Maybe
 import Data.Either
-import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Distribution.Compat.Semigroup
 import System.FilePath hiding (combine)
 import System.Directory
 import Network.URI (URI(..), URIAuth(..), parseAbsoluteURI)

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -51,6 +51,9 @@ module Distribution.Client.ProjectPlanning (
     createPackageDBIfMissing
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import           Distribution.Client.ProjectPlanning.Types
 import           Distribution.Client.PackageHash
 import           Distribution.Client.RebuildMonad
@@ -116,21 +119,14 @@ import           Distribution.Text
 import qualified Distribution.Compat.Graph as Graph
 import           Distribution.Compat.Graph(IsNode(..))
 
-import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative
-#endif
 import           Control.Monad
 import           Control.Monad.State as State
 import           Control.Exception
-import           Data.Typeable
-import           Data.List
-import           Data.Maybe
+import           Data.List (groupBy, mapAccumL)
 import           Data.Either
-import           Data.Monoid
 import           Data.Function
 import           System.FilePath
 import           System.Directory (doesDirectoryExist, getDirectoryContents)
@@ -1508,8 +1504,8 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
       -- the project config specifies values that apply to packages local to
       -- but by default non-local packages get all default config values
       -- the project, and can specify per-package values for any package,
-      | isLocalToProject pkg = local <> perpkg
-      | otherwise            =          perpkg
+      | isLocalToProject pkg = local `mappend` perpkg
+      | otherwise            =                 perpkg
       where
         local  = f localPackagesConfig
         perpkg = maybe mempty f (Map.lookup (packageName pkg) perPackageConfig)

--- a/cabal-install/Distribution/Client/RebuildMonad.hs
+++ b/cabal-install/Distribution/Client/RebuildMonad.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- | An abstraction for re-running actions if values or files have changed.
@@ -44,6 +43,9 @@ module Distribution.Client.RebuildMonad (
     matchFileGlob,
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import Distribution.Client.FileMonitor
 import Distribution.Client.Glob hiding (matchFileGlob)
 import qualified Distribution.Client.Glob as Glob (matchFileGlob)
@@ -51,12 +53,8 @@ import qualified Distribution.Client.Glob as Glob (matchFileGlob)
 import Distribution.Simple.Utils (debug)
 import Distribution.Verbosity    (Verbosity)
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
 import Control.Monad.State as State
 import Control.Monad.Reader as Reader
-import Distribution.Compat.Binary     (Binary)
 import System.FilePath (takeFileName)
 
 

--- a/cabal-install/Distribution/Client/Run.hs
+++ b/cabal-install/Distribution/Client/Run.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Run
@@ -10,6 +9,9 @@
 
 module Distribution.Client.Run ( run, splitRunArgs )
        where
+
+import Prelude ()
+import Distribution.Client.Compat.Prelude
 
 import Distribution.Types.TargetInfo     (targetCLBI)
 import Distribution.Types.LocalBuildInfo (componentNameTargets')
@@ -35,11 +37,6 @@ import Distribution.Verbosity                (Verbosity)
 
 import qualified Distribution.Simple.GHCJS as GHCJS
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Functor                          ((<$>))
-#endif
-import Data.List                             (find)
-import Data.Foldable                         (traverse_)
 import System.Directory                      (getCurrentDirectory)
 import Distribution.Compat.Environment       (getEnvironment)
 import System.FilePath                       ((<.>), (</>))

--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 -----------------------------------------------------------------------------
 -- |
@@ -41,6 +40,9 @@ module Distribution.Client.Sandbox (
 
     getPersistOrConfigCompiler
   ) where
+
+import Prelude ()
+import Distribution.Client.Compat.Prelude
 
 import Distribution.Client.Setup
   ( SandboxFlags(..), ConfigFlags(..), ConfigExFlags(..), InstallFlags(..)
@@ -92,7 +94,7 @@ import Distribution.Simple.Setup              ( Flag(..), HaddockFlags(..)
 import Distribution.Simple.SrcDist            ( prepareTree )
 import Distribution.Simple.Utils              ( die, debug, notice, info, warn
                                               , debugNoWrap, defaultPackageDesc
-                                              , intercalate, topHandlerWith
+                                              , topHandlerWith
                                               , createDirectoryIfMissingVerbose )
 import Distribution.Package                   ( Package(..) )
 import Distribution.System                    ( Platform )
@@ -111,19 +113,12 @@ import qualified Data.Map                          as M
 import qualified Data.Set                          as S
 import Data.Either                            (partitionEithers)
 import Control.Exception                      ( assert, bracket_ )
-import Control.Monad                          ( forM, liftM, liftM2, unless, when )
+import Control.Monad                          ( forM, mapM, mapM_ )
 import Data.Bits                              ( shiftL, shiftR, xor )
-import Data.Char                              ( ord )
 import Data.IORef                             ( newIORef, writeIORef, readIORef )
 import Data.List                              ( delete
-                                              , foldl'
-                                              , intersperse
-                                              , isPrefixOf
                                               , groupBy )
 import Data.Maybe                             ( fromJust )
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid                            ( mempty, mappend )
-#endif
 import Data.Word                              ( Word32 )
 import Numeric                                ( showHex )
 import System.Directory                       ( canonicalizePath

--- a/cabal-install/Distribution/Client/Sandbox/Types.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Sandbox.Types
@@ -13,13 +12,12 @@ module Distribution.Client.Sandbox.Types (
   SandboxPackageInfo(..)
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import qualified Distribution.Simple.PackageIndex as InstalledPackageIndex
 import Distribution.Client.Types (UnresolvedSourcePackage)
-import Distribution.Compat.Semigroup (Semigroup((<>)))
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (Monoid(..))
-#endif
 import qualified Data.Set as S
 
 -- | Are we using a sandbox?

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1772,9 +1772,6 @@ initCommand = CommandUI {
       , optionVerbosity IT.initVerbosity (\v flags -> flags { IT.initVerbosity = v })
       ]
   }
-  where readMaybe s = case reads s of
-                        [(x,"")]  -> Just x
-                        _         -> Nothing
 
 -- ------------------------------------------------------------
 -- * SDist flags

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -55,6 +55,9 @@ module Distribution.Client.Setup
     , readRepo
     ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude hiding (get)
+
 import Distribution.Client.Types
          ( Username(..), Password(..), RemoteRepo(..) )
 import Distribution.Client.BuildReports.Types
@@ -107,7 +110,6 @@ import Distribution.ReadE
          ( ReadE(..), readP_to_E, succeedReadE )
 import qualified Distribution.Compat.ReadP as Parse
          ( ReadP, char, munch1, pfail,  (+++) )
-import Distribution.Compat.Semigroup
 import Distribution.Verbosity
          ( Verbosity, lessVerbose, normal )
 import Distribution.Simple.Utils
@@ -117,16 +119,8 @@ import Distribution.Client.GlobalFlags
          , RepoContext(..), withRepoContext
          )
 
-import Data.Char
-         ( isAlphaNum )
 import Data.List
-         ( intercalate, deleteFirstsBy )
-import Data.Maybe
-         ( maybeToList, fromMaybe )
-import GHC.Generics (Generic)
-import Distribution.Compat.Binary (Binary)
-import Control.Monad
-         ( liftM )
+         ( deleteFirstsBy )
 import System.FilePath
          ( (</>) )
 import Network.URI

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -21,6 +21,9 @@ module Distribution.Client.SetupWrapper (
     defaultSetupScriptOptions,
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import qualified Distribution.Make as Make
 import qualified Distribution.Simple as Simple
 import Distribution.Version
@@ -78,7 +81,7 @@ import Distribution.Simple.Setup
 import Distribution.Simple.Utils
          ( die, debug, info, cabalVersion, tryFindPackageDesc, comparing
          , createDirectoryIfMissingVerbose, installExecutableFile
-         , copyFileVerbose, rewriteFile, intercalate )
+         , copyFileVerbose, rewriteFile )
 import Distribution.Client.Utils
          ( inDir, tryCanonicalizePath, withExtraPathEnv
          , existsAndIsMoreRecentThan, moreRecentFile, withEnv
@@ -101,14 +104,7 @@ import System.FilePath     ( (</>), (<.>) )
 import System.IO           ( Handle, hPutStr )
 import System.Exit         ( ExitCode(..), exitWith )
 import System.Process      ( runProcess, waitForProcess )
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ( (<$>), (<*>) )
-import Data.Monoid         ( mempty )
-#endif
-import Control.Monad       ( when, unless )
-import Data.List           ( find, foldl1' )
-import Data.Maybe          ( fromMaybe, isJust )
-import Data.Char           ( isSpace )
+import Data.List           ( foldl1' )
 import Distribution.Client.Compat.ExecutablePath  ( getExecutablePath )
 
 #ifdef mingw32_HOST_OS

--- a/cabal-install/Distribution/Client/SolverPlanIndex.hs
+++ b/cabal-install/Distribution/Client/SolverPlanIndex.hs
@@ -1,9 +1,9 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- | These graph traversal functions mirror the ones in Cabal, but work with
 -- the more complete (and fine-grained) set of dependencies provided by
 -- PackageFixedDeps rather than only the library dependencies provided by
 -- PackageInstalled.
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE CPP #-}
 module Distribution.Client.SolverPlanIndex (
     -- * Graph traversal functions
     brokenPackages
@@ -12,17 +12,16 @@ module Distribution.Client.SolverPlanIndex (
   , dependencyInconsistencies
   ) where
 
-import Prelude hiding (lookup)
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
+-- import Prelude hiding (lookup)
 import qualified Data.Map as Map
 import qualified Data.Graph as Graph
 import Data.Array ((!))
 import Data.Map (Map)
-import Data.Maybe (isNothing)
+-- import Data.Maybe (isNothing)
 import Data.Either (rights)
-
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (Monoid(..))
-#endif
 
 import Distribution.Package
          ( PackageName(..), PackageIdentifier(..), UnitId(..)

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
 -----------------------------------------------------------------------------
@@ -50,6 +49,9 @@ module Distribution.Client.Targets (
 
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import Distribution.Package
          ( Package(..), PackageName(..)
          , PackageIdentifier(..), packageName, packageVersion
@@ -86,41 +88,28 @@ import Distribution.Text
          ( Text(..), display )
 import Distribution.Verbosity (Verbosity)
 import Distribution.Simple.Utils
-         ( die, warn, intercalate, fromUTF8, lowercase, ignoreBOM )
+         ( die, warn, fromUTF8, lowercase, ignoreBOM )
 
-import Data.List
-         ( find, nub )
-import Data.Maybe
-         ( listToMaybe )
+-- import Data.List ( find, nub )
 import Data.Either
          ( partitionEithers )
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid
-         ( Monoid(..) )
-#endif
 import qualified Data.Map as Map
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Lazy.Char8 as BS.Char8
 import qualified Distribution.Client.GZipUtils as GZipUtils
-import Control.Monad (liftM)
+import Control.Monad (mapM)
 import qualified Distribution.Compat.ReadP as Parse
 import Distribution.Compat.ReadP
          ( (+++), (<++) )
-import qualified Distribution.Compat.Semigroup as Semi
-         ( Semigroup((<>)) )
 import qualified Text.PrettyPrint as Disp
 import Text.PrettyPrint
-         ( (<>), (<+>) )
-import Data.Char
-         ( isSpace, isAlphaNum )
+         ( (<+>) )
 import System.FilePath
          ( takeExtension, dropExtension, takeDirectory, splitPath )
 import System.Directory
          ( doesFileExist, doesDirectoryExist )
 import Network.URI
          ( URI(..), URIAuth(..), parseAbsoluteURI )
-import GHC.Generics (Generic)
-import Distribution.Compat.Binary (Binary)
 
 -- ------------------------------------------------------------
 -- * User targets
@@ -683,9 +672,9 @@ newtype PackageNameEnv = PackageNameEnv (PackageName -> [PackageName])
 
 instance Monoid PackageNameEnv where
   mempty = PackageNameEnv (const [])
-  mappend = (Semi.<>)
+  mappend = (<>)
 
-instance Semi.Semigroup PackageNameEnv where
+instance Semigroup PackageNameEnv where
   PackageNameEnv lookupA <> PackageNameEnv lookupB =
     PackageNameEnv (\name -> lookupA name ++ lookupB name)
 
@@ -794,8 +783,8 @@ instance Text UserConstraint where
 dispFlagAssignment :: FlagAssignment -> Disp.Doc
 dispFlagAssignment = Disp.hsep . map dispFlagValue
   where
-    dispFlagValue (f, True)   = Disp.char '+' <> dispFlagName f
-    dispFlagValue (f, False)  = Disp.char '-' <> dispFlagName f
+    dispFlagValue (f, True)   = Disp.char '+' <<>> dispFlagName f
+    dispFlagValue (f, False)  = Disp.char '-' <<>> dispFlagName f
     dispFlagName (FlagName f) = Disp.text f
 
 parseFlagAssignment :: Parse.ReadP r FlagAssignment

--- a/cabal-install/Distribution/Client/Utils.hs
+++ b/cabal-install/Distribution/Client/Utils.hs
@@ -19,28 +19,24 @@ module Distribution.Client.Utils ( MergeResult(..)
                                  , relaxEncodingErrors)
        where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import Distribution.Compat.Environment
 import Distribution.Compat.Exception   ( catchIO )
 import Distribution.Compat.Time ( getModTime )
 import Distribution.Simple.Setup       ( Flag(..) )
 import Distribution.Simple.Utils       ( die, findPackageDesc )
 import qualified Data.ByteString.Lazy as BS
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
-import Control.Monad
-         ( when )
 import Data.Bits
          ( (.|.), shiftL, shiftR )
 import System.FilePath
-import Data.Char
-         ( ord, chr )
 #if MIN_VERSION_base(4,6,0)
 import Text.Read
          ( readMaybe )
 #endif
 import Data.List
-         ( isPrefixOf, sortBy, groupBy, intercalate )
+         ( groupBy )
 import Data.Word
          ( Word8, Word32)
 import Foreign.C.Types ( CInt(..) )
@@ -66,7 +62,6 @@ import GHC.IO.Encoding.Failure
 
 #if defined(mingw32_HOST_OS) || MIN_VERSION_directory(1,2,3)
 import Prelude hiding (ioError)
-import Control.Monad (liftM2, unless)
 import System.Directory (doesDirectoryExist)
 import System.IO.Error (ioError, mkIOError, doesNotExistErrorType)
 #endif

--- a/cabal-install/Distribution/Client/Utils.hs
+++ b/cabal-install/Distribution/Client/Utils.hs
@@ -31,10 +31,6 @@ import qualified Data.ByteString.Lazy as BS
 import Data.Bits
          ( (.|.), shiftL, shiftR )
 import System.FilePath
-#if MIN_VERSION_base(4,6,0)
-import Text.Read
-         ( readMaybe )
-#endif
 import Data.List
          ( groupBy )
 import Data.Word
@@ -92,14 +88,6 @@ duplicatesBy cmp = filter moreThanOne . groupBy eq . sortBy cmp
                _  -> False
     moreThanOne (_:_:_) = True
     moreThanOne _       = False
-
-#if !MIN_VERSION_base(4,6,0)
--- | An implementation of readMaybe, for compatability with older base versions.
-readMaybe :: Read a => String -> Maybe a
-readMaybe s = case reads s of
-                [(x,"")] -> Just x
-                _        -> Nothing
-#endif
 
 -- | Like 'removeFile', but does not throw an exception when the file does not
 -- exist.

--- a/cabal-install/Distribution/Solver/Modular/Builder.hs
+++ b/cabal-install/Distribution/Solver/Modular/Builder.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 module Distribution.Solver.Modular.Builder (buildTree) where
 
 -- Building the search tree.

--- a/cabal-install/Distribution/Solver/Modular/Cycles.hs
+++ b/cabal-install/Distribution/Solver/Modular/Cycles.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 module Distribution.Solver.Modular.Cycles (
     detectCyclesPhase
   ) where

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -7,21 +6,17 @@ module Distribution.Solver.Modular.Linking (
   , validateLinking
   ) where
 
-import Prelude hiding (pi)
+import Prelude ()
+import Distribution.Client.Compat.Prelude hiding (get,put)
+
 import Control.Exception (assert)
 import Control.Monad.Reader
 import Control.Monad.State
-import Data.Maybe (catMaybes)
-import Data.Map (Map, (!))
-import Data.List (intercalate)
+import Data.Map ((!))
 import Data.Set (Set)
 import qualified Data.Map         as M
 import qualified Data.Set         as S
 import qualified Data.Traversable as T
-
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
 
 import Distribution.Solver.Modular.Assignment
 import Distribution.Solver.Modular.Dependency

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+-- | Reordering or pruning the tree in order to prefer or make certain choices.
 module Distribution.Solver.Modular.Preference
     ( avoidReinstalls
     , deferSetupChoices
@@ -16,18 +16,13 @@ module Distribution.Solver.Modular.Preference
     , sortGoals
     ) where
 
--- Reordering or pruning the tree in order to prefer or make certain choices.
+import Prelude ()
+import Distribution.Client.Compat.Prelude
 
 import Data.Function (on)
 import qualified Data.List as L
 import qualified Data.Map as M
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
-import Prelude hiding (sequence)
 import Control.Monad.Reader hiding (sequence)
-import Data.Map (Map)
-import Data.Maybe (fromMaybe)
 import Data.Traversable (sequence)
 
 import Distribution.Solver.Types.ConstraintSource

--- a/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+
 -- | Fine-grained package dependencies
 --
 -- Like many others, this module is meant to be "double-imported":
@@ -8,9 +11,6 @@
 -- >   , ComponentDeps
 -- >   )
 -- > import qualified Distribution.Solver.Types.ComponentDeps as CD
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveGeneric #-}
 module Distribution.Solver.Types.ComponentDeps (
     -- * Fine-grained package dependencies
     Component(..)
@@ -36,21 +36,13 @@ module Distribution.Solver.Types.ComponentDeps (
   , select
   ) where
 
-import Prelude hiding (zip)
-import Data.Map (Map)
+import Prelude ()
+import Distribution.Client.Compat.Prelude hiding (empty,zip)
+
 import qualified Data.Map as Map
-import Distribution.Compat.Binary (Binary)
-import Distribution.Compat.Semigroup (Semigroup((<>)))
-import GHC.Generics
 import Data.Foldable (fold)
 
 import qualified Distribution.Types.ComponentName as CN
-
-#if !MIN_VERSION_base(4,8,0)
-import Data.Foldable (Foldable(foldMap))
-import Data.Monoid (Monoid(..))
-import Data.Traversable (Traversable(traverse))
-#endif
 
 {-------------------------------------------------------------------------------
   Types

--- a/cabal-install/Distribution/Solver/Types/PackageIndex.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageIndex.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 -----------------------------------------------------------------------------
@@ -46,18 +45,12 @@ module Distribution.Solver.Types.PackageIndex (
   allPackagesByName,
   ) where
 
-import Prelude hiding (lookup)
+import Prelude ()
+import Distribution.Client.Compat.Prelude hiding (lookup)
+
 import Control.Exception (assert)
 import qualified Data.Map as Map
-import Data.Map (Map)
-import Data.List (groupBy, sortBy, isInfixOf)
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (Monoid(..))
-#endif
-import Data.Maybe (isJust, fromMaybe)
-import GHC.Generics (Generic)
-import Distribution.Compat.Binary (Binary)
-import Distribution.Compat.Semigroup (Semigroup((<>)))
+import Data.List (groupBy, isInfixOf)
 
 import Distribution.Package
          ( PackageName(..), PackageIdentifier(..)

--- a/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Solver.Types.PkgConfigDb
@@ -20,12 +19,10 @@ module Distribution.Solver.Types.PkgConfigDb
     , getPkgConfigDbDirs
     ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ((<$>), (<*>))
-#endif
+import Prelude ()
+import Distribution.Client.Compat.Prelude
 
 import Control.Exception (IOException, handle)
-import Data.Char (isSpace)
 import qualified Data.Map as M
 import Data.Version (parseVersion)
 import Text.ParserCombinators.ReadP (readP_to_S)
@@ -44,8 +41,6 @@ import Distribution.Simple.Program
     ( ProgramDb, pkgConfigProgram, getProgramOutput, requireProgram )
 import Distribution.Simple.Utils
     ( info )
-import Distribution.Compat.Binary (Binary(..))
-import GHC.Generics (Generic)
 
 -- | The list of packages installed in the system visible to
 -- @pkg-config@. This is an opaque datatype, to be constructed with

--- a/cabal-install/Distribution/Solver/Types/Progress.hs
+++ b/cabal-install/Distribution/Solver/Types/Progress.hs
@@ -1,23 +1,11 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 module Distribution.Solver.Types.Progress
     ( Progress(..)
     , foldProgress
     ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-         ( Applicative(..) )
-#endif
-import Control.Applicative
-         ( Alternative(..) )
-
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid
-         ( Monoid(..) )
-#endif
-
-import Prelude hiding (fail)
+import Prelude ()
+import Distribution.Client.Compat.Prelude hiding (fail)
 
 -- | A type to represent the unfolding of an expensive long running
 -- calculation that may fail. We may get intermediate steps before the final

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -60,6 +60,9 @@ import Distribution.Simple.Setup
          , configAbsolutePaths
          )
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude hiding (get)
+
 import Distribution.Client.SetupWrapper
          ( setupWrapper, SetupScriptOptions(..), defaultSetupScriptOptions )
 import Distribution.Client.Config
@@ -170,16 +173,9 @@ import System.IO                ( BufferMode(LineBuffering), hSetBuffering
 #endif
                                 , stdout )
 import System.Directory         (doesFileExist, getCurrentDirectory)
-import Data.List                (intercalate)
-import Data.Maybe               (listToMaybe)
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid              (Monoid(..))
-import Control.Applicative      (pure, (<$>))
-#endif
 import Data.Monoid              (Any(..))
-import Distribution.Compat.Semigroup ((<>))
 import Control.Exception        (SomeException(..), try)
-import Control.Monad            (when, unless, void)
+import Control.Monad            (mapM_)
 
 -- | Entry point
 --

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -311,6 +311,7 @@ executable cabal
         Distribution.Client.Win32SelfUpgrade
         Distribution.Client.Compat.ExecutablePath
         Distribution.Client.Compat.FilePerms
+        Distribution.Client.Compat.Prelude
         Distribution.Client.Compat.Process
         Distribution.Client.Compat.Semaphore
         Distribution.Solver.Types.ComponentDeps


### PR DESCRIPTION
This helps avoid 95% of CPP uses, and also helps reduce a bit of the `import`-boilerplate
for `Data.Maybe` et al.

But most importantly, this should reduce the risk of wasting time when a PR works for
GHC 8.0.1, but then Travis complains that some pre-AMP `import` needs to be added
for e.g. GHC 7.8.4