### PR TITLE
Make `PackageName` type opaque

### DIFF
--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -133,7 +133,7 @@ instance IsNode InstalledPackageInfo where
 emptyInstalledPackageInfo :: InstalledPackageInfo
 emptyInstalledPackageInfo
    = InstalledPackageInfo {
-        sourcePackageId   = PackageIdentifier (PackageName "") (Version [] []),
+        sourcePackageId   = PackageIdentifier (mkPackageName "") (Version [] []),
         installedUnitId   = mkUnitId "",
         compatPackageKey  = "",
         license           = UnspecifiedLicense,

--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -18,7 +18,7 @@
 
 module Distribution.Package (
         -- * Package ids
-        PackageName(..),
+        PackageName, unPackageName, mkPackageName,
         PackageIdentifier(..),
         PackageId,
 
@@ -65,16 +65,33 @@ import Distribution.ModuleName
 
 import Text.PrettyPrint ((<+>), text)
 
-newtype PackageName = PackageName { unPackageName :: String }
+-- | A package name.
+--
+-- Use 'mkPackageName' and 'unPackageName' to convert from/to a
+-- 'String'.
+newtype PackageName = PackageName String
     deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
+
+-- | Convert 'PackageName' to 'String'
+unPackageName :: PackageName -> String
+unPackageName (PackageName s) = s
+
+-- | Construct a 'PackageName' from a 'String'
+--
+-- 'mkPackageName' is the inverse to 'unPackageName'
+--
+-- Note: No validations are performed to ensure that the resulting
+-- 'PackageName' is valid
+mkPackageName :: String -> PackageName
+mkPackageName = PackageName
 
 instance Binary PackageName
 
 instance Text PackageName where
-  disp (PackageName n) = Disp.text n
+  disp = Disp.text . unPackageName
   parse = do
     ns <- Parse.sepBy1 component (Parse.char '-')
-    return (PackageName (intercalate "-" ns))
+    return (mkPackageName (intercalate "-" ns))
     where
       component = do
         cs <- Parse.munch1 isAlphaNum

--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -69,6 +69,10 @@ import Text.PrettyPrint ((<+>), text)
 --
 -- Use 'mkPackageName' and 'unPackageName' to convert from/to a
 -- 'String'.
+--
+-- This type is opaque since @Cabal-2.0@
+--
+-- @since 2.0
 newtype PackageName = PackageName String
     deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
 
@@ -82,6 +86,8 @@ unPackageName (PackageName s) = s
 --
 -- Note: No validations are performed to ensure that the resulting
 -- 'PackageName' is valid
+--
+-- @since 2.0
 mkPackageName :: String -> PackageName
 mkPackageName = PackageName
 

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -166,7 +166,7 @@ checkSanity :: PackageDescription -> [PackageCheck]
 checkSanity pkg =
   catMaybes [
 
-    check (null . (\(PackageName n) -> n) . packageName $ pkg) $
+    check (null . unPackageName . packageName $ pkg) $
       PackageBuildImpossible "No 'name' field."
 
   , check (null . versionBranch . packageVersion $ pkg) $
@@ -536,7 +536,7 @@ checkFields pkg =
              , name `elem` map display knownLanguages ]
 
     testedWithImpossibleRanges =
-      [ Dependency (PackageName (display compiler)) vr
+      [ Dependency (mkPackageName (display compiler)) vr
       | (compiler, vr) <- testedWith pkg
       , isNoVersion vr ]
 
@@ -1199,7 +1199,7 @@ checkCabalVersion pkg =
               , usesNewVersionRangeSyntax vr ]
 
     testedWithVersionRangeExpressions =
-        [ Dependency (PackageName (display compiler)) vr
+        [ Dependency (mkPackageName (display compiler)) vr
         | (compiler, vr) <- testedWith pkg
         , usesNewVersionRangeSyntax vr ]
 
@@ -1249,7 +1249,7 @@ checkCabalVersion pkg =
       , (name, _) <- Map.toList (targetBuildRenaming bi) ]
 
     testedWithUsingWildcardSyntax =
-      [ Dependency (PackageName (display compiler)) vr
+      [ Dependency (mkPackageName (display compiler)) vr
       | (compiler, vr) <- testedWith pkg
       , usesWildcardSyntax vr ]
 
@@ -1432,7 +1432,8 @@ checkPackageVersions pkg =
           foldr intersectVersionRanges anyVersion baseDeps
         where
           baseDeps =
-            [ vr | Dependency (PackageName "base") vr <- buildDepends pkg' ]
+            [ vr | Dependency pname vr <- buildDepends pkg'
+                 , pname == mkPackageName "base" ]
 
       -- Just in case finalizePD fails for any reason,
       -- or if the package doesn't depend on the base package at all,

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -636,7 +636,7 @@ parseBuildToolNameQ = parseQuoted parseBuildToolName <++ parseBuildToolName
 -- like parsePackageName but accepts symbols in components
 parseBuildToolName :: ReadP r PackageName
 parseBuildToolName = do ns <- sepBy1 component (ReadP.char '-')
-                        return (PackageName (intercalate "-" ns))
+                        return (mkPackageName (intercalate "-" ns))
   where component = do
           cs <- munch1 (\c -> isAlphaNum c || c == '+' || c == '_')
           if all isDigit cs then pfail else return cs
@@ -649,7 +649,7 @@ parsePkgconfigDependency = do name <- munch1
                                       (\c -> isAlphaNum c || c `elem` "+-._")
                               ver <- betweenSpaces $
                                      parseVersionRangeQ <++ return anyVersion
-                              return $ Dependency (PackageName name) ver
+                              return $ Dependency (mkPackageName name) ver
 
 parsePackageNameQ :: ReadP r PackageName
 parsePackageNameQ = parseQuoted parse <++ parse

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -461,7 +461,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
     -- | The stub executable needs a new 'ComponentLocalBuildInfo'
     -- that exposes the relevant test suite library.
     deps = (IPI.installedUnitId ipi, packageId ipi)
-         : (filter (\(_, x) -> let PackageName name = pkgName x
+         : (filter (\(_, x) -> let name = unPackageName $ pkgName x
                                in name == "Cabal" || name == "base")
                    (componentPackageDeps clbi))
     exeClbi = ExeComponentLocalBuildInfo {
@@ -512,7 +512,7 @@ addInternalBuildTools pkg lbi bi progs =
     internalExeNames = map exeName (executables pkg)
     buildToolNames   = map buildToolName (buildTools bi)
       where
-        buildToolName (Dependency (PackageName name) _ ) = name
+        buildToolName (Dependency pname _ ) = unPackageName pname
 
 
 -- TODO: build separate libs in separate dirs so that we can build

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -292,7 +292,7 @@ getInstalledPackages verbosity comp packagedbs progdb = do
 
   where
     hackRtsPackage index =
-      case PackageIndex.lookupPackageName index (PackageName "rts") of
+      case PackageIndex.lookupPackageName index (mkPackageName "rts") of
         [(_,[rts])]
            -> PackageIndex.insert (removeMingwIncludeDir rts) index
         _  -> index -- No (or multiple) ghc rts package is registered!!

--- a/Cabal/Distribution/Simple/GHC/IPIConvert.hs
+++ b/Cabal/Distribution/Simple/GHC/IPIConvert.hs
@@ -32,7 +32,7 @@ data PackageIdentifier = PackageIdentifier {
 
 convertPackageId :: PackageIdentifier -> Current.PackageIdentifier
 convertPackageId PackageIdentifier { pkgName = n, pkgVersion = v } =
-  Current.PackageIdentifier (Current.PackageName n) v
+  Current.PackageIdentifier (Current.mkPackageName n) v
 
 data License = GPL | LGPL | BSD3 | BSD4
              | PublicDomain | AllRightsReserved | OtherLicense

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -593,7 +593,7 @@ haddockPackagePaths ipkgs mkHtmlPath = do
 
   where
     -- Don't warn about missing documentation for these packages. See #1231.
-    noHaddockWhitelist = map PackageName [ "rts" ]
+    noHaddockWhitelist = map mkPackageName [ "rts" ]
 
     -- Actually extract interface and HTML paths from an 'InstalledPackageInfo'.
     interfaceAndHtmlPath :: InstalledPackageInfo

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -467,11 +467,11 @@ lookupDependency index (Dependency name versionRange) =
 --
 searchByName :: PackageIndex a -> String -> SearchResult [a]
 searchByName index name =
-  case [ pkgs | pkgs@(PackageName name',_) <- Map.toList (packageIdIndex index)
-              , lowercase name' == lname ] of
+  case [ pkgs | pkgs@(pname,_) <- Map.toList (packageIdIndex index)
+              , lowercase (unPackageName pname) == lname ] of
     []               -> None
     [(_,pvers)]      -> Unambiguous (concat (Map.elems pvers))
-    pkgss            -> case find ((PackageName name==) . fst) pkgss of
+    pkgss            -> case find ((mkPackageName name ==) . fst) pkgss of
       Just (_,pvers) -> Unambiguous (concat (Map.elems pvers))
       Nothing        -> Ambiguous (map (concat . Map.elems . snd) pkgss)
   where lname = lowercase name
@@ -485,8 +485,8 @@ data SearchResult a = None | Unambiguous a | Ambiguous [a]
 searchByNameSubstring :: PackageIndex a -> String -> [a]
 searchByNameSubstring index searchterm =
   [ pkg
-  | (PackageName name, pvers) <- Map.toList (packageIdIndex index)
-  , lsearchterm `isInfixOf` lowercase name
+  | (pname, pvers) <- Map.toList (packageIdIndex index)
+  , lsearchterm `isInfixOf` lowercase (unPackageName pname)
   , pkgs <- Map.elems pvers
   , pkg <- pkgs ]
   where lsearchterm = lowercase searchterm

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -450,7 +450,7 @@ ppHsc2hs bi lbi clbi =
     -- OS X (it's ld is a tad stricter than gnu ld). Thus we remove the
     -- ldOptions for GHC's rts package:
     hackRtsPackage index =
-      case PackageIndex.lookupPackageName index (PackageName "rts") of
+      case PackageIndex.lookupPackageName index (mkPackageName "rts") of
         [(_, [rts])]
            -> PackageIndex.insert rts { Installed.ldOptions = [] } index
         _  -> error "No (or multiple) ghc rts package is registered!!"

--- a/Cabal/Distribution/Types/PackageDescription.hs
+++ b/Cabal/Distribution/Types/PackageDescription.hs
@@ -171,7 +171,7 @@ descCabalVersion pkg = case specVersionRaw pkg of
 emptyPackageDescription :: PackageDescription
 emptyPackageDescription
     =  PackageDescription {
-                      package      = PackageIdentifier (PackageName "")
+                      package      = PackageIdentifier (mkPackageName "")
                                                        (Version [] []),
                       license      = UnspecifiedLicense,
                       licenseFiles = [],

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -46,6 +46,9 @@
 	  If you only need to test if a component is buildable
 	  (i.e., it is marked buildable in the Cabal file)
 	  use the new function 'componentBuildable'.
+	* Backwards incompatible change to 'PackageName' (#3896):
+	  'PackageName' is now opaque; conversion to/from 'String' now works
+	  via (old) 'unPackageName' and (new) 'mkPackageName' functions.
 	* Add support for `--allow-older` (dual to `--allow-newer`) (#3466)
 	* Improved an error message for process output decoding errors
 	(#3408).

--- a/Cabal/tests/PackageTests/BenchmarkStanza/Check.hs
+++ b/Cabal/tests/PackageTests/BenchmarkStanza/Check.hs
@@ -19,7 +19,7 @@ suite = do
                                                    "dummy.hs"
             , benchmarkBuildInfo = emptyBuildInfo
                     { targetBuildDepends =
-                            [ Dependency (PackageName "base") anyVersion ]
+                            [ Dependency (mkPackageName "base") anyVersion ]
                     , hsSourceDirs = ["."]
                     }
             }

--- a/Cabal/tests/PackageTests/CaretOperator/Check.hs
+++ b/Cabal/tests/PackageTests/CaretOperator/Check.hs
@@ -20,9 +20,9 @@ suite = do
            { libBuildInfo = emptyBuildInfo
                { defaultLanguage = Just Haskell2010
                , targetBuildDepends =
-                     [ Dependency (PackageName{unPackageName = "base"})
+                     [ Dependency (mkPackageName "base")
                        (withinVersion (Version [4] []))
-                     , Dependency (PackageName{unPackageName = "pretty"})
+                     , Dependency (mkPackageName "pretty")
                        (majorBoundVersion (Version [1,1,1,0] []))
                      ]
                , hsSourceDirs = ["."]

--- a/Cabal/tests/PackageTests/TestStanza/Check.hs
+++ b/Cabal/tests/PackageTests/TestStanza/Check.hs
@@ -18,7 +18,7 @@ suite = do
             , testInterface = TestSuiteExeV10 (Version [1,0] []) "dummy.hs"
             , testBuildInfo = emptyBuildInfo
                     { targetBuildDepends =
-                            [ Dependency (PackageName "base") anyVersion ]
+                            [ Dependency (mkPackageName "base") anyVersion ]
                     , hsSourceDirs = ["."]
                     }
             }

--- a/cabal-install/Distribution/Client/BuildReports/Anonymous.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Anonymous.hs
@@ -34,7 +34,7 @@ import Distribution.Client.Utils
 import qualified Paths_cabal_install (version)
 
 import Distribution.Package
-         ( PackageIdentifier(..), PackageName(..) )
+         ( PackageIdentifier(..), mkPackageName )
 import Distribution.PackageDescription
          ( FlagName(..), FlagAssignment )
 --import Distribution.Version
@@ -159,7 +159,7 @@ new os' arch' comp pkgid flags deps result =
 
 cabalInstallID :: PackageIdentifier
 cabalInstallID =
-  PackageIdentifier (PackageName "cabal-install") Paths_cabal_install.version
+  PackageIdentifier (mkPackageName "cabal-install") Paths_cabal_install.version
 
 -- ------------------------------------------------------------
 -- * External format

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -74,7 +74,7 @@ import Distribution.Client.Sandbox.Types
          ( SandboxPackageInfo(..) )
 import Distribution.Client.Targets
 import Distribution.Package
-         ( PackageName(..), PackageIdentifier(PackageIdentifier), PackageId
+         ( PackageName, mkPackageName, PackageIdentifier(PackageIdentifier), PackageId
          , Package(..), packageName, packageVersion
          , Dependency(Dependency))
 import qualified Distribution.PackageDescription as PD
@@ -347,9 +347,9 @@ dontUpgradeNonUpgradeablePackages params =
       [ LabeledPackageConstraint
         (PackageConstraintInstalled pkgname)
         ConstraintSourceNonUpgradeablePackage
-      | Set.notMember (PackageName "base") (depResolverTargets params)
-      , pkgname <- map PackageName [ "base", "ghc-prim", "integer-gmp"
-                                   , "integer-simple" ]
+      | Set.notMember (mkPackageName "base") (depResolverTargets params)
+      , pkgname <- map mkPackageName [ "base", "ghc-prim", "integer-gmp"
+                                     , "integer-simple" ]
       , isInstalled pkgname ]
 
     isInstalled = not . null
@@ -520,7 +520,7 @@ standardInstallPolicy installedPkgIndex sourcePkgDb pkgSpecifiers
       -- Force Cabal >= 1.24 dep when the package is affected by #3199.
       mkDefaultSetupDeps :: UnresolvedSourcePackage -> Maybe [Dependency]
       mkDefaultSetupDeps srcpkg | affected        =
-        Just [Dependency (PackageName "Cabal")
+        Just [Dependency (mkPackageName "Cabal")
               (orLaterVersion $ Version [1,24] [])]
                                 | otherwise       = Nothing
         where

--- a/cabal-install/Distribution/Client/GenBounds.hs
+++ b/cabal-install/Distribution/Client/GenBounds.hs
@@ -25,7 +25,7 @@ import Distribution.Client.Sandbox.Types
 import Distribution.Client.Setup
          ( GlobalFlags(..), FreezeFlags(..), RepoContext )
 import Distribution.Package
-         ( Package(..), Dependency(..), PackageName(..)
+         ( Package(..), Dependency(..), unPackageName
          , packageName, packageVersion )
 import Distribution.PackageDescription
          ( buildDepends )
@@ -139,7 +139,7 @@ genBounds verbosity packageDBs repoCtxt comp platform progdb mSandboxPkgInfo
        mapM_ (putStrLn . (++",") . showBounds padTo) thePkgs
 
      depName :: Dependency -> String
-     depName (Dependency (PackageName nm) _) = nm
+     depName (Dependency pn _) = unPackageName pn
 
      depVersion :: Dependency -> VersionRange
      depVersion (Dependency _ vr) = vr

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -45,7 +45,7 @@ import Distribution.Client.IndexUtils.Timestamp
 import Distribution.Client.Types
 
 import Distribution.Package
-         ( PackageId, PackageIdentifier(..), PackageName(..)
+         ( PackageId, PackageIdentifier(..), mkPackageName
          , Package(..), packageVersion, packageName
          , Dependency(Dependency) )
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
@@ -441,7 +441,7 @@ extractPkg entry blockNo = case Tar.entryContent entry of
         [pkgname,vers,_] -> case simpleParse vers of
           Just ver -> Just . return $ Just (NormalPackage pkgid descr content blockNo)
             where
-              pkgid  = PackageIdentifier (PackageName pkgname) ver
+              pkgid  = PackageIdentifier (mkPackageName pkgname) ver
               parsed = parsePackageDescription . ignoreBOM . fromUTF8 . BS.Char8.unpack
                                                $ content
               descr  = case parsed of
@@ -878,7 +878,7 @@ read00IndexCacheEntry = \line ->
   where
     parseName str
       | BSS.all (\c -> isAlphaNum c || c == '-') str
-                  = Just (PackageName (BSS.unpack str))
+                  = Just (mkPackageName (BSS.unpack str))
       | otherwise = Nothing
 
     parseVer str vs =

--- a/cabal-install/Distribution/Client/Init/Heuristics.hs
+++ b/cabal-install/Distribution/Client/Init/Heuristics.hs
@@ -91,7 +91,7 @@ guessMainFileCandidates flags = do
 
 -- | Guess the package name based on the given root directory.
 guessPackageName :: FilePath -> IO P.PackageName
-guessPackageName = liftM (P.PackageName . repair . last . splitDirectories)
+guessPackageName = liftM (P.mkPackageName . repair . last . splitDirectories)
                  . tryCanonicalizePath
   where
     -- Treat each span of non-alphanumeric characters as a hyphen. Each

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -14,7 +14,7 @@ module Distribution.Client.List (
   ) where
 
 import Distribution.Package
-         ( PackageName(..), Package(..), packageName, packageVersion
+         ( PackageName, Package(..), packageName, packageVersion
          , Dependency(..), simplifyDependency
          , UnitId )
 import Distribution.ModuleName (ModuleName)

--- a/cabal-install/Distribution/Client/PackageUtils.hs
+++ b/cabal-install/Distribution/Client/PackageUtils.hs
@@ -15,7 +15,7 @@ module Distribution.Client.PackageUtils (
   ) where
 
 import Distribution.Package
-         ( packageVersion, packageName, Dependency(..), PackageName(..) )
+         ( packageVersion, packageName, Dependency(..), unPackageName )
 import Distribution.PackageDescription
          ( PackageDescription(..), libName )
 import Distribution.Version

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1175,7 +1175,7 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
             (internal_exe_deps, internal_exe_paths)
                 = unzip $
                   [ (confInstId confid', path)
-                  | Dependency (PackageName toolname) _ <- PD.buildTools bi
+                  | Dependency (unPackageName -> toolname) _ <- PD.buildTools bi
                   , toolname `elem` map PD.exeName (PD.executables elabPkgDescription)
                   , Just (confid', path) <- [Map.lookup toolname exe_map]
                   ]
@@ -1184,7 +1184,7 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
                 CLibName
                     -> Map.insert (packageName elabPkgSourceId) confid internal_map
                 CSubLibName libname
-                    -> Map.insert (PackageName libname) confid internal_map
+                    -> Map.insert (mkPackageName libname) confid internal_map
                 _   -> internal_map
             exe_map' = case cname of
                 CExeName exename
@@ -2246,13 +2246,13 @@ packageSetupScriptSpecVersion _ pkg deps =
 
 
 cabalPkgname, basePkgname :: PackageName
-cabalPkgname = PackageName "Cabal"
-basePkgname  = PackageName "base"
+cabalPkgname = mkPackageName "Cabal"
+basePkgname  = mkPackageName "base"
 
 
 legacyCustomSetupPkgs :: Compiler -> Platform -> [PackageName]
 legacyCustomSetupPkgs compiler (Platform _ os) =
-    map PackageName $
+    map mkPackageName $
         [ "array", "base", "binary", "bytestring", "containers"
         , "deepseq", "directory", "filepath", "old-time", "pretty"
         , "process", "time", "transformers" ]

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -28,9 +28,8 @@ import Distribution.Version
          , intersectVersionRanges, orLaterVersion
          , withinRange )
 import Distribution.Package
-         ( UnitId(..), ComponentId, PackageIdentifier(..), PackageId,
-           PackageName(..), packageName
-         , packageVersion, Dependency(..) )
+         ( UnitId(..), ComponentId, PackageId, mkPackageName
+         , PackageIdentifier(..), packageVersion, packageName, Dependency(..) )
 import Distribution.PackageDescription
          ( GenericPackageDescription(packageDescription)
          , PackageDescription(..), specVersion
@@ -538,7 +537,7 @@ getExternalSetupMethod verbosity options pkg bt = do
   cabalLibVersionToUse :: IO (Version, Maybe ComponentId
                              ,SetupScriptOptions)
   cabalLibVersionToUse =
-    case find (hasCabal . snd) (useDependencies options) of
+    case find (isCabalPkgId . snd) (useDependencies options) of
       Just (unitId, pkgId) -> do
         let version = pkgVersion pkgId
         updateSetupScript version bt
@@ -580,9 +579,6 @@ getExternalSetupMethod verbosity options pkg bt = do
       writeSetupVersionFile :: Version -> IO ()
       writeSetupVersionFile version =
           writeFile setupVersionFile (show version ++ "\n")
-
-      hasCabal (PackageIdentifier (PackageName "Cabal") _) = True
-      hasCabal _                                           = False
 
       installedVersion :: IO (Version, Maybe InstalledPackageId
                              ,SetupScriptOptions)
@@ -635,7 +631,7 @@ getExternalSetupMethod verbosity options pkg bt = do
                               ,SetupScriptOptions)
   installedCabalVersion options' compiler progdb = do
     index <- maybeGetInstalledPackages options' compiler progdb
-    let cabalDep   = Dependency (PackageName "Cabal") (useCabalVersion options')
+    let cabalDep   = Dependency (mkPackageName "Cabal") (useCabalVersion options')
         options''  = options' { usePackageIndex = Just index }
     case PackageIndex.lookupDependency index cabalDep of
       []   -> die $ "The package '" ++ display (packageName pkg)
@@ -762,7 +758,7 @@ getExternalSetupMethod verbosity options pkg bt = do
     when (outOfDate || forceCompile) $ do
       debug verbosity "Setup executable needs to be updated, compiling..."
       (compiler, progdb, options'') <- configureCompiler options'
-      let cabalPkgid = PackageIdentifier (PackageName "Cabal") cabalLibVersion
+      let cabalPkgid = PackageIdentifier (mkPackageName "Cabal") cabalLibVersion
           (program, extraOpts)
             = case compilerFlavor compiler of
                       GHCJS -> (ghcjsProgram, ["-build-runner"])
@@ -780,13 +776,10 @@ getExternalSetupMethod verbosity options pkg bt = do
           -- Both of these options should be enabled for packages that have
           -- opted-in and declared a custom-settup stanza.
           --
-          hasCabal (_, PackageIdentifier (PackageName "Cabal") _) = True
-          hasCabal _                                              = False
-
           selectedDeps | useDependenciesExclusive options'
                                    = useDependencies options'
                        | otherwise = useDependencies options' ++
-                                     if any hasCabal (useDependencies options')
+                                     if any (isCabalPkgId . snd) (useDependencies options')
                                      then []
                                      else cabalDep
           addRenaming (ipid, _) = (SimpleUnitId ipid, defaultRenaming)
@@ -824,3 +817,7 @@ getExternalSetupMethod verbosity options pkg bt = do
                                          progdb ghcCmdLine
                                hPutStr logHandle output
     return setupProgFile
+
+
+isCabalPkgId :: PackageIdentifier -> Bool
+isCabalPkgId (PackageIdentifier pname _) = pname == mkPackageName "Cabal"

--- a/cabal-install/Distribution/Client/SolverInstallPlan.hs
+++ b/cabal-install/Distribution/Client/SolverInstallPlan.hs
@@ -51,7 +51,7 @@ module Distribution.Client.SolverInstallPlan(
 ) where
 
 import Distribution.Package
-         ( PackageIdentifier(..), Package(..), PackageName(..)
+         ( PackageIdentifier(..), Package(..), PackageName
          , HasUnitId(..), PackageId, packageVersion, packageName )
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import Distribution.Text

--- a/cabal-install/Distribution/Client/SolverPlanIndex.hs
+++ b/cabal-install/Distribution/Client/SolverPlanIndex.hs
@@ -25,7 +25,7 @@ import Data.Monoid (Monoid(..))
 #endif
 
 import Distribution.Package
-         ( PackageName(..), PackageIdentifier(..), UnitId(..)
+         ( PackageName, PackageIdentifier(..), UnitId(..)
          , Package(..), packageName, packageVersion
          )
 import Distribution.Version

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Targets
@@ -51,7 +52,7 @@ module Distribution.Client.Targets (
   ) where
 
 import Distribution.Package
-         ( Package(..), PackageName(..)
+         ( Package(..), PackageName, unPackageName, mkPackageName
          , PackageIdentifier(..), packageName, packageVersion
          , Dependency(Dependency) )
 import Distribution.Client.Types
@@ -240,10 +241,12 @@ data UserTargetProblem
 readUserTarget :: String -> IO (Either UserTargetProblem UserTarget)
 readUserTarget targetstr =
     case testNamedTargets targetstr of
-      Just (Dependency (PackageName "world") verrange)
-        | verrange == anyVersion -> return (Right UserTargetWorld)
-        | otherwise              -> return (Left  UserTargetBadWorldPkg)
-      Just dep                   -> return (Right (UserTargetNamed dep))
+      Just (Dependency pkgn verrange)
+        | pkgn == mkPackageName "world"
+          -> return $ if verrange == anyVersion
+                      then Right UserTargetWorld
+                      else Left  UserTargetBadWorldPkg
+      Just dep -> return (Right (UserTargetNamed dep))
       Nothing -> do
         fileTarget <- testFileTargets targetstr
         case fileTarget of
@@ -692,17 +695,17 @@ instance Semi.Semigroup PackageNameEnv where
 indexPackageNameEnv :: PackageIndex pkg -> PackageNameEnv
 indexPackageNameEnv pkgIndex = PackageNameEnv pkgNameLookup
   where
-    pkgNameLookup (PackageName name) =
-      map fst (PackageIndex.searchByName pkgIndex name)
+    pkgNameLookup pname =
+      map fst (PackageIndex.searchByName pkgIndex $ unPackageName pname)
 
 extraPackageNameEnv :: [PackageName] -> PackageNameEnv
 extraPackageNameEnv names = PackageNameEnv pkgNameLookup
   where
-    pkgNameLookup (PackageName name) =
-      [ PackageName name'
-      | let lname = lowercase name
-      , PackageName name' <- names
-      , lowercase name' == lname ]
+    pkgNameLookup pname =
+      [ pname'
+      | let lname = lowercase (unPackageName pname)
+      , pname' <- names
+      , lowercase (unPackageName pname') == lname ]
 
 
 -- ------------------------------------------------------------

--- a/cabal-install/Distribution/Solver/Modular/Index.hs
+++ b/cabal-install/Distribution/Solver/Modular/Index.hs
@@ -49,4 +49,4 @@ defaultQualifyOptions idx = QO {
     , qoSetupIndependent = True
     }
   where
-    base = PackageName "base"
+    base = mkPackageName "base"

--- a/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
@@ -120,7 +120,7 @@ convGPD os arch cinfo strfl sexes pi
     -- and thus cannot actually be solved over.  We'll do this
     -- by creating a set of package names which are "internal"
     -- and dropping them as we convert.
-    ipns = S.fromList $ [ PackageName nm
+    ipns = S.fromList $ [ mkPackageName nm
                         | (nm, _) <- sub_libs ]
 
     conv :: Mon.Monoid a => Component -> (a -> BuildInfo) ->
@@ -192,8 +192,8 @@ convCondTree os arch cinfo pi@(PI pn _) fds comp getInfo ipns sexes@(SolveExecut
               -- an executable we need.
               ++ (if sexes'
                    then concatMap
-                    (\(Dependency (PackageName exe) vr) ->
-                        case packageProvidingBuildTool exe of
+                    (\(Dependency exe vr) ->
+                        case packageProvidingBuildTool (unPackageName exe) of
                             Nothing -> []
                             Just pn' -> [D.Simple (convExeDep pn (Dependency pn' vr)) comp])
                     (PD.buildTools bi)
@@ -212,7 +212,7 @@ packageProvidingBuildTool :: String -> Maybe PackageName
 packageProvidingBuildTool s =
     if s `elem` ["hscolour", "haddock", "happy", "alex", "hsc2hs",
                  "c2hs", "cpphs", "greencard"]
-        then Just (PackageName s)
+        then Just (mkPackageName s)
         else Nothing
 
 -- | Branch interpreter.  Mutually recursive with 'convCondTree'.

--- a/cabal-install/Distribution/Solver/Modular/Package.hs
+++ b/cabal-install/Distribution/Solver/Modular/Package.hs
@@ -4,7 +4,7 @@ module Distribution.Solver.Modular.Package
   , Loc(..)
   , PackageId
   , PackageIdentifier(..)
-  , PackageName(..)
+  , PackageName, mkPackageName, unPackageName
   , PI(..)
   , PN
   , QPV
@@ -28,7 +28,7 @@ type PN = PackageName
 
 -- | Unpacking a package name.
 unPN :: PN -> String
-unPN (PackageName pn) = pn
+unPN = unPackageName
 
 -- | Package version. A package name plus a version number.
 type PV = PackageId

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -130,10 +130,10 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
                        validateTree cinfo idx pkgConfigDB
     prunePhase       = (if asBool (avoidReinstalls sc) then P.avoidReinstalls (const True) else id) .
                        -- packages that can never be "upgraded":
-                       P.requireInstalled (`elem` [ PackageName "base"
-                                                  , PackageName "ghc-prim"
-                                                  , PackageName "integer-gmp"
-                                                  , PackageName "integer-simple"
+                       P.requireInstalled (`elem` [ mkPackageName "base"
+                                                  , mkPackageName "ghc-prim"
+                                                  , mkPackageName "integer-gmp"
+                                                  , mkPackageName "integer-simple"
                                                   ])
     buildPhase       = traceTree "build.json" id
                      $ addLinking
@@ -248,5 +248,5 @@ _removeGR = trav go
 
    dummy :: QGoalReason
    dummy = PDependency
-         $ PI (Q (PackagePath DefaultNamespace Unqualified) (PackageName "$"))
+         $ PI (Q (PackagePath DefaultNamespace Unqualified) (mkPackageName "$"))
               (I (Version [1] []) InRepo)

--- a/cabal-install/Distribution/Solver/Types/PackageIndex.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageIndex.hs
@@ -60,7 +60,7 @@ import Distribution.Compat.Binary (Binary)
 import Distribution.Compat.Semigroup (Semigroup((<>)))
 
 import Distribution.Package
-         ( PackageName(..), PackageIdentifier(..)
+         ( PackageName, unPackageName, PackageIdentifier(..)
          , Package(..), packageName, packageVersion
          , Dependency(Dependency) )
 import Distribution.Version
@@ -297,8 +297,8 @@ searchByName :: PackageIndex pkg
              -> String -> [(PackageName, [pkg])]
 searchByName (PackageIndex m) name =
     [ pkgs
-    | pkgs@(PackageName name',_) <- Map.toList m
-    , lowercase name' == lname ]
+    | pkgs@(pname,_) <- Map.toList m
+    , lowercase (unPackageName pname) == lname ]
   where
     lname = lowercase name
 
@@ -312,7 +312,7 @@ searchByNameSubstring :: PackageIndex pkg
                       -> String -> [(PackageName, [pkg])]
 searchByNameSubstring (PackageIndex m) searchterm =
     [ pkgs
-    | pkgs@(PackageName name, _) <- Map.toList m
-    , lsearchterm `isInfixOf` lowercase name ]
+    | pkgs@(pname, _) <- Map.toList m
+    , lsearchterm `isInfixOf` lowercase (unPackageName pname) ]
   where
     lsearchterm = lowercase searchterm

--- a/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
@@ -32,7 +32,7 @@ import Text.ParserCombinators.ReadP (readP_to_S)
 import System.FilePath (splitSearchPath)
 
 import Distribution.Package
-    ( PackageName(..) )
+    ( PackageName, mkPackageName )
 import Distribution.Verbosity
     ( Verbosity )
 import Distribution.Version
@@ -89,7 +89,7 @@ pkgConfigDbFromList :: [(String, String)] -> PkgConfigDb
 pkgConfigDbFromList pairs = (PkgConfigDb . M.fromList . map convert) pairs
     where
       convert :: (String, String) -> (PackageName, Maybe Version)
-      convert (n,vs) = (PackageName n,
+      convert (n,vs) = (mkPackageName n,
                         case (reverse . readP_to_S parseVersion) vs of
                           (v, "") : _ -> Just v
                           _           -> Nothing -- Version not (fully)

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP, DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+
 module Main where
 
 import Distribution.Client.DistDirLayout
@@ -96,7 +97,7 @@ testExceptionInProjectConfig config = do
     BadPerPackageCompilerPaths ps <- expectException "BadPerPackageCompilerPaths" $
       void $ planProject testdir config
     case ps of
-      [(PackageName "foo","ghc")] -> return ()
+      [(pn,"ghc")] | mkPackageName "foo" == pn -> return ()
       _ -> assertFailure $ "expected (PackageName \"foo\",\"ghc\"), got "
                         ++ show ps
     cleanProject testdir
@@ -114,7 +115,7 @@ testExceptionInConfigureStep config = do
     cleanProject testdir
   where
     testdir = "exception/configure"
-    pkgidA1 = PackageIdentifier (PackageName "a") (Version [1] [])
+    pkgidA1 = PackageIdentifier (mkPackageName "a") (Version [1] [])
 
 
 testExceptionInBuildStep :: ProjectConfig -> Assertion
@@ -124,7 +125,7 @@ testExceptionInBuildStep config = do
     expectBuildFailed failure
   where
     testdir = "exception/build"
-    pkgidA1 = PackageIdentifier (PackageName "a") (Version [1] [])
+    pkgidA1 = PackageIdentifier (mkPackageName "a") (Version [1] [])
 
 testSetupScriptStyles :: ProjectConfig -> (String -> IO ()) -> Assertion
 testSetupScriptStyles config reportSubCase = do
@@ -166,7 +167,7 @@ testSetupScriptStyles config reportSubCase = do
     testdir1 = "build/setup-custom1"
     testdir2 = "build/setup-custom2"
     testdir3 = "build/setup-simple"
-    pkgidA   = PackageIdentifier (PackageName "a") (Version [0,1] [])
+    pkgidA   = PackageIdentifier (mkPackageName "a") (Version [0,1] [])
     -- The solver fills in default setup deps explicitly, but marks them as such
     hasDefaultSetupDeps = fmap defaultSetupDepends
                         . setupBuildInfo . elabPkgDescription
@@ -191,8 +192,8 @@ testBuildKeepGoing config = do
     return ()
   where
     testdir = "build/keep-going"
-    pkgidP  = PackageIdentifier (PackageName "p") (Version [0,1] [])
-    pkgidQ  = PackageIdentifier (PackageName "q") (Version [0,1] [])
+    pkgidP  = PackageIdentifier (mkPackageName "p") (Version [0,1] [])
+    pkgidQ  = PackageIdentifier (mkPackageName "q") (Version [0,1] [])
     keepGoing kg =
       mempty {
         projectConfigBuildOnly = mempty {
@@ -219,8 +220,8 @@ testRegressionIssue3324 config = do
       return ()
   where
     testdir = "regression/3324"
-    pkgidP  = PackageIdentifier (PackageName "p") (Version [0,1] [])
-    pkgidQ  = PackageIdentifier (PackageName "q") (Version [0,1] [])
+    pkgidP  = PackageIdentifier (mkPackageName "p") (Version [0,1] [])
+    pkgidQ  = PackageIdentifier (mkPackageName "q") (Version [0,1] [])
 
 
 ---------------------------------

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -115,7 +115,7 @@ instance Arbitrary VersionRange where
       canonicaliseVersionRange = fromVersionIntervals . toVersionIntervals
 
 instance Arbitrary PackageName where
-    arbitrary = PackageName . intercalate "-" <$> shortListOf1 2 nameComponent
+    arbitrary = mkPackageName . intercalate "-" <$> shortListOf1 2 nameComponent
       where
         nameComponent = shortListOf1 5 (elements packageChars)
                         `suchThat` (not . all isDigit)

--- a/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
@@ -194,7 +194,7 @@ arbitraryTestInstallPlan = do
         ipkgid = mkUnitIdV pkgv
         deps   = map mkUnitIdV depvs
     mkUnitIdV = mkUnitId . show
-    mkPkgId v = PackageIdentifier (PackageName ("pkg" ++ show v))
+    mkPkgId v = PackageIdentifier (mkPackageName ("pkg" ++ show v))
                                   (Version [1] [])
 
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
@@ -4,7 +4,7 @@ module UnitTests.Distribution.Client.Targets (
 
 import Distribution.Client.Targets     (UserConstraint (..), readUserConstraint)
 import Distribution.Compat.ReadP       (ReadP, readP_to_S)
-import Distribution.Package            (PackageName (..))
+import Distribution.Package            (mkPackageName)
 import Distribution.ParseUtils         (parseCommaList)
 import Distribution.Text               (parse)
 
@@ -26,7 +26,7 @@ readUserConstraintTest =
     pkgName  = "template-haskell"
     constr   = pkgName ++ " installed"
 
-    expected = UserConstraintInstalled (PackageName pkgName)
+    expected = UserConstraintInstalled (mkPackageName pkgName)
     actual   = let (Right r) = readUserConstraint constr in r
 
 parseUserConstraintTest :: Assertion
@@ -36,7 +36,7 @@ parseUserConstraintTest =
     pkgName  = "template-haskell"
     constr   = pkgName ++ " installed"
 
-    expected = [UserConstraintInstalled (PackageName pkgName)]
+    expected = [UserConstraintInstalled (mkPackageName pkgName)]
     actual   = [ x | (x, ys) <- readP_to_S parseUserConstraint constr
                    , all isSpace ys]
 
@@ -50,7 +50,7 @@ readUserConstraintsTest =
     pkgName  = "template-haskell"
     constr   = pkgName ++ " installed"
 
-    expected = [[UserConstraintInstalled (PackageName pkgName)]]
+    expected = [[UserConstraintInstalled (mkPackageName pkgName)]]
     actual   = [ x | (x, ys) <- readP_to_S parseUserConstraints constr
                    , all isSpace ys]
 


### PR DESCRIPTION
When looking at heap-profiles of `cabal-install`, the `(:)` constructor
stands out as the most-allocated constructor on the heap.

Having to handle 10k+ package names contributes to the allocation
numbers, especially on 64bit archs where ascii `String`s have a 24 byte
per character footprint.

This commit is a preparatory commit to pave the way for changing
`PackageName`'s internal representation to something like
`ShortByteString` (which is essentially a thin wrapper around primitive
`ByteArray#`s which themselves have have an overhead of 2 words + one
byte per ascii character rounded up to nearest word) which would allow
to reduce the memory footprint by a full order of magnitude, as well as
reduce pointer chasing and GC overhead.