### PR TITLE
Add `Distribution.Simple.Utils.ShortText` type

### DIFF
--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -205,7 +205,13 @@ import qualified Data.Set as Set
 
 import qualified Data.ByteString as SBS
 
-#if MIN_VERSION_bytestring(0,10,4)
+#if defined(MIN_VERSION_bytestring)
+# if MIN_VERSION_bytestring(0,10,4)
+# define HAVE_SHORTBYTESTRING 1
+# endif
+#endif
+
+#if HAVE_SHORTBYTESTRING
 import qualified Data.ByteString.Short as BS.Short
 #endif
 
@@ -1663,6 +1669,11 @@ isRelativeOnAnyPlatform = not . isAbsoluteOnAnyPlatform
 -- * 'ShortText' type
 -- ------------------------------------------------------------
 
+-- TODO: if we start using this internally for more opaque types in
+-- Cabal then we will likely need to promote it to it's own module in
+-- Distribution.* to avoid cycles, or just to maintain the sanity of
+-- the Distribution.* vs Distribution.Simple.* distinction.
+
 -- | Construct 'ShortText' from 'String'
 toShortText :: String -> ShortText
 
@@ -1676,8 +1687,11 @@ fromShortText :: ShortText -> String
 -- 0.10.4@, and otherwise the fallback is to use plain old non-compat
 -- '[Char]'.
 --
+-- Note: This type is for internal uses (such as e.g. 'PackageName')
+-- and shall not be exposed in Cabal's API
+--
 -- @since 2.0.0
-#if MIN_VERSION_bytestring(0,10,4)
+#if HAVE_SHORTBYTESTRING
 newtype ShortText = ST { unST :: BS.Short.ShortByteString }
                   deriving (Eq,Ord,Generic)
 

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -84,6 +84,8 @@
 	  call site/stack of a logging output respectively (these
 	  are only supported if Cabal is built with GHC 8.0/7.10.2
 	  or greater, respectively).
+	* New `Distribution.Simple.Utils.ShortText` type for representing
+	  short text strings compactly (#3898)
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* Support GHC 8.

--- a/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
+++ b/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
@@ -18,6 +18,8 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 
+import Distribution.Compat.Binary (encode, decode)
+
 withTempFileTest :: Assertion
 withTempFileTest = do
   fileName <- newIORef ""
@@ -96,6 +98,11 @@ prop_ShortTextMonoid a b = Mon.mappend a b == fromShortText (mappend (toShortTex
 prop_ShortTextId :: String -> Bool
 prop_ShortTextId a = (fromShortText . toShortText) a == a
 
+prop_ShortTextBinaryId :: String -> Bool
+prop_ShortTextBinaryId a = (decode . encode) a' == a'
+  where
+    a' = toShortText a
+
 tests :: [TestTree]
 tests =
     [ testCase "withTempFile works as expected" $
@@ -112,4 +119,5 @@ tests =
     , testProperty "ShortText Id" prop_ShortTextId
     , testProperty "ShortText Ord" prop_ShortTextOrd
     , testProperty "ShortText Monoid" prop_ShortTextMonoid
+    , testProperty "ShortText BinaryId" prop_ShortTextBinaryId
     ]


### PR DESCRIPTION
This implements a compact representation of `[Char]`.

The data is stored internally as UTF8 in an `ShortByteString`
when compiled against `bytestring >= 0.10.4`, and otherwise in a
(strict) `ByteString`.