### PR TITLE
Make interactive setup delegate CTRL+C

### DIFF
--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -220,6 +220,7 @@ configureSetupScript packageDBs
     , useDependencies          = fromMaybe [] explicitSetupDeps
     , useDependenciesExclusive = not defaultSetupDeps && isJust explicitSetupDeps
     , useVersionMacros         = not defaultSetupDeps && isJust explicitSetupDeps
+    , isInteractive            = False
     }
   where
     -- When we are compiling a legacy setup script without an explicit

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -1233,7 +1233,7 @@ buildInplaceUnpackedPackage verbosity
         --
         whenRepl $
           annotateFailureNoLog ReplFailed $
-          setup replCommand replFlags replArgs
+          setupInteractive replCommand replFlags replArgs
 
         -- Haddock phase
         whenHaddock $
@@ -1299,6 +1299,14 @@ buildInplaceUnpackedPackage verbosity
     scriptOptions    = setupHsScriptOptions rpkg pkgshared
                                             srcdir builddir
                                             isParallelBuild cacheLock
+
+    setupInteractive :: CommandUI flags
+                     -> (Version -> flags) -> [String] -> IO ()
+    setupInteractive cmd flags args =
+      setupWrapper verbosity
+                   scriptOptions { isInteractive = True }
+                   (Just (elabPkgDescription pkg))
+                   cmd flags args
 
     setup :: CommandUI flags -> (Version -> flags) -> [String] -> IO ()
     setup cmd flags args =

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2296,7 +2296,8 @@ setupHsScriptOptions (ReadyPackage elab@ElaboratedConfiguredPackage{..})
       useExtraPathEnv          = elabExeDependencyPaths elab,
       useWin32CleanHack        = False,   --TODO: [required eventually]
       forceExternalSetupMethod = isParallelBuild,
-      setupCacheLock           = Just cacheLock
+      setupCacheLock           = Just cacheLock,
+      isInteractive            = False
     }
 
 


### PR DESCRIPTION
Fixes #3899

When cabal new-repl spawns ghci, it spawns this as a subprocess.
In UNIX like systems, if a CTRL+C is sent to this child process
it also bubbles up to the parent process, causing it to terminate.
Also see https://hackage.haskell.org/package/process-1.4.2.0/docs/System-Process.html#g:4.

However, this is not what we want for interactive subprocesses.
Interactive processes usually define their own handlers for CTRL+C,
for example GHCi uses CTRL+C to reset the input buffer. So instead
of terminating on CTRL+C we want to delegate CTRL+C to GHCi
and let it do its thing.

Luckily, we can enable CTRL+C delegation such that the parent
process ignores the CTRL+C and instead delegates it to the
child process.