### PR TITLE
InstallPlan fixes and misc housekeeping

### DIFF
--- a/Cabal/Distribution/Compat/Graph.hs
+++ b/Cabal/Distribution/Compat/Graph.hs
@@ -46,6 +46,7 @@ module Distribution.Compat.Graph (
     -- * Query
     null,
     size,
+    member,
     lookup,
     -- * Construction
     empty,
@@ -206,6 +207,10 @@ null = Map.null . toMap
 -- | /O(1)/. The number of nodes in the graph.
 size :: Graph a -> Int
 size = Map.size . toMap
+
+-- | /O(log V)/. Check if the key is in the graph.
+member :: IsNode a => Key a -> Graph a -> Bool
+member k g = Map.member k (toMap g)
 
 -- | /O(log V)/. Lookup the node at a key in the graph.
 lookup :: IsNode a => Key a -> Graph a -> Maybe a

--- a/Cabal/Distribution/Compat/Graph.hs
+++ b/Cabal/Distribution/Compat/Graph.hs
@@ -74,6 +74,8 @@ module Distribution.Compat.Graph (
     fromList,
     toList,
     keys,
+    -- ** Sets
+    keysSet,
     -- ** Graphs
     toGraph,
     -- * Node type
@@ -88,6 +90,7 @@ import Distribution.Compat.Prelude hiding (lookup, null, empty)
 import Data.Graph (SCC(..))
 import qualified Data.Graph as G
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import qualified Data.Array as Array
 import Data.Array ((!))
 import qualified Data.Tree as Tree
@@ -381,6 +384,10 @@ toList g = Map.elems (toMap g)
 -- | /O(V)/. Convert a graph into a list of keys.
 keys :: Graph a -> [Key a]
 keys g = Map.keys (toMap g)
+
+-- | /O(V)/. Convert a graph into a set of keys.
+keysSet :: Graph a -> Set.Set (Key a)
+keysSet g = Map.keysSet (toMap g)
 
 -- | /O(1)/. Convert a graph into a map from keys to nodes.
 -- The resulting map @m@ is guaranteed to have the property that

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -26,7 +26,11 @@ module Distribution.Client.InstallPlan (
 
   -- * Operations on 'InstallPlan's
   new,
+  toGraph,
   toList,
+  toMap,
+  keys,
+  keysSet,
   planIndepGoals,
   depends,
 
@@ -268,9 +272,23 @@ new :: IndependentGoals
     -> GenericInstallPlan ipkg srcpkg
 new indepGoals index = mkInstallPlan index indepGoals
 
+toGraph :: GenericInstallPlan ipkg srcpkg
+        -> Graph (GenericPlanPackage ipkg srcpkg)
+toGraph = planGraph
+
 toList :: GenericInstallPlan ipkg srcpkg
        -> [GenericPlanPackage ipkg srcpkg]
 toList = Graph.toList . planGraph
+
+toMap :: GenericInstallPlan ipkg srcpkg
+      -> Map UnitId (GenericPlanPackage ipkg srcpkg)
+toMap = Graph.toMap . planGraph
+
+keys :: GenericInstallPlan ipkg srcpkg -> [UnitId]
+keys = Graph.keys . planGraph
+
+keysSet :: GenericInstallPlan ipkg srcpkg -> Set UnitId
+keysSet = Graph.keysSet . planGraph
 
 -- | Remove packages from the install plan. This will result in an
 -- error if there are remaining packages that depend on any matching

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -571,7 +571,9 @@ failed plan (Processing processingSet completedSet failedSet) pkgid =
     assert (pkgid `Set.member` processingSet) $
     assert (all (`Set.notMember` processingSet) (tail newlyFailedIds)) $
     assert (all (`Set.notMember` completedSet)  (tail newlyFailedIds)) $
-    assert (all (`Set.notMember` failedSet)     (tail newlyFailedIds)) $
+    -- but note that some newlyFailed may already be in the failed set
+    -- since one package can depend on two packages that both fail and
+    -- so would be in the rev-dep closure for both.
     assert (processingInvariant plan processing') $
 
     ( map asConfiguredPackage (tail newlyFailed)

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -596,9 +596,9 @@ processingInvariant plan (Processing processingSet completedSet failedSet) =
  && all (isJust . flip Graph.lookup (planIndex plan)) (Set.toList failedSet)
  && noIntersection processingSet completedSet
  && noIntersection processingSet failedSet
+ --   intersection processingClosure failedSet is quite possible however
  && noIntersection failedSet     completedSet
  && noIntersection processingClosure completedSet
- && noIntersection processingClosure failedSet
  && and [ case Graph.lookup pkgid (planIndex plan) of
             Just (Configured  _) -> True
             Just (PreExisting _) -> False


### PR DESCRIPTION
This subsumes PR #3888 and fixes issue #3889.

We worked out what the actual problem with the InstallPlan processing invariant failures were. The invariant was wrong. See the discussion in #3889 for details.

This PR fixes the invariant, and adds a couple other parts to the invariant that we think are true. Also add commentary on the invariant and do something similar to what PR #3888 does (but a bit more lightweight) so we get more informative assertion violations in future.

Finally, do a bit of housekeeping, rename some things and export a few more utils that are going to be useful in other upcoming PRs.