### PR TITLE
Project orchestration preparatory work

### DIFF
--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -26,6 +26,7 @@ module Distribution.Simple.Utils (
         -- * logging and errors
         die,
         dieWithLocation,
+        dieMsg, dieMsgNoWrap,
         topHandler, topHandlerWith,
         warn, notice, noticeNoWrap, setupMessage, info, debug,
         debugNoWrap, chattyTry,
@@ -332,6 +333,28 @@ hPutCallStackPrefix h verbosity = withFrozenCallStack $ do
     hPutStr h parentSrcLocPrefix
   when (isVerboseCallStack verbosity) $
     hPutStr h ("----\n" ++ prettyCallStack callStack ++ "\n")
+
+-- | This can be used to help produce formatted messages as part of a fatal
+-- error condition, prior to using 'die' or 'exitFailure'.
+--
+-- For fatal conditions we normally simply use 'die' which throws an
+-- exception. Sometimes however 'die' is not sufficiently flexible to
+-- produce the desired output.
+--
+-- Like 'die', these messages are always displayed on @stderr@, irrespective
+-- of the 'Verbosity' level.
+--
+dieMsg :: String -> NoCallStackIO ()
+dieMsg msg = do
+    hFlush stdout
+    hPutStr stderr (wrapText msg)
+
+-- | As 'dieMsg' but with pre-formatted text.
+--
+dieMsgNoWrap :: String -> NoCallStackIO ()
+dieMsgNoWrap msg = do
+    hFlush stdout
+    hPutStr stderr msg
 
 -- | Non fatal conditions that may be indicative of an error or problem.
 --

--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -8,9 +8,6 @@ module Distribution.Client.CmdBuild (
   ) where
 
 import Distribution.Client.ProjectOrchestration
-         ( PreBuildHooks(..), runProjectPreBuildPhase, selectTargets
-         , ProjectBuildContext(..), runProjectBuildPhase
-         , printPlan, reportBuildFailures )
 import Distribution.Client.ProjectConfig
          ( BuildTimeSettings(..) )
 import Distribution.Client.ProjectPlanning
@@ -24,8 +21,6 @@ import Distribution.Simple.Setup
          ( HaddockFlags, fromFlagOrDefault )
 import Distribution.Verbosity
          ( normal )
-
-import Control.Monad (unless)
 
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
@@ -69,7 +64,7 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     userTargets <- readUserBuildTargets targetStrings
 
-    buildCtx@ProjectBuildContext{buildSettings, elaboratedPlan} <-
+    buildCtx <-
       runProjectPreBuildPhase
         verbosity
         ( globalFlags, configFlags, configExFlags
@@ -91,9 +86,8 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     printPlan verbosity buildCtx
 
-    unless (buildSettingDryRun buildSettings) $ do
-      buildResults <- runProjectBuildPhase verbosity buildCtx
-      reportBuildFailures verbosity elaboratedPlan buildResults
+    buildOutcomes <- runProjectBuildPhase verbosity buildCtx
+    runProjectPostBuildPhase verbosity buildCtx buildOutcomes
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
 

--- a/cabal-install/Distribution/Client/CmdConfigure.hs
+++ b/cabal-install/Distribution/Client/CmdConfigure.hs
@@ -66,16 +66,16 @@ configureAction (configFlags, configExFlags, installFlags, haddockFlags)
           hookSelectPlanSubset = \_ -> return
         }
 
+    let buildCtx' = buildCtx {
+                      buildSettings = (buildSettings buildCtx) {
+                        buildSettingDryRun = True
+                      }
+                    }
+
     --TODO: Hmm, but we don't have any targets. Currently this prints what we
     -- would build if we were to build everything. Could pick implicit target like "."
     --TODO: should we say what's in the project (+deps) as a whole?
-    printPlan
-      verbosity
-      buildCtx {
-        buildSettings = (buildSettings buildCtx) {
-          buildSettingDryRun = True
-        }
-      }
+    printPlan verbosity buildCtx'
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
 

--- a/cabal-install/Distribution/Client/CmdConfigure.hs
+++ b/cabal-install/Distribution/Client/CmdConfigure.hs
@@ -58,10 +58,10 @@ configureAction (configFlags, configExFlags, installFlags, haddockFlags)
         ( globalFlags, configFlags, configExFlags
         , installFlags, haddockFlags )
         PreBuildHooks {
-          hookPrePlanning = \projectRootDir _ cliConfig ->
+          hookPrePlanning = \rootDir _ cliConfig ->
             -- Write out the @cabal.project.local@ so it gets picked up by the
             -- planning phase.
-            writeProjectLocalExtraConfig projectRootDir cliConfig,
+            writeProjectLocalExtraConfig rootDir cliConfig,
 
           hookSelectPlanSubset = \_ -> return
         }

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -8,9 +8,6 @@ module Distribution.Client.CmdRepl (
   ) where
 
 import Distribution.Client.ProjectOrchestration
-         ( PreBuildHooks(..), runProjectPreBuildPhase, selectTargets
-         , ProjectBuildContext(..), runProjectBuildPhase
-         , printPlan, reportBuildFailures )
 import Distribution.Client.ProjectConfig
          ( BuildTimeSettings(..) )
 import Distribution.Client.ProjectPlanning
@@ -25,7 +22,7 @@ import Distribution.Simple.Setup
 import Distribution.Verbosity
          ( normal )
 
-import Control.Monad (when, unless)
+import Control.Monad (when)
 
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
@@ -66,7 +63,7 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     userTargets <- readUserBuildTargets targetStrings
 
-    buildCtx@ProjectBuildContext{buildSettings, elaboratedPlan} <-
+    buildCtx <-
       runProjectPreBuildPhase
         verbosity
         ( globalFlags, configFlags, configExFlags
@@ -96,9 +93,8 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags)
 
     printPlan verbosity buildCtx
 
-    unless (buildSettingDryRun buildSettings) $ do
-      buildResults <- runProjectBuildPhase verbosity buildCtx
-      reportBuildFailures verbosity elaboratedPlan buildResults
+    buildOutcomes <- runProjectBuildPhase verbosity buildCtx
+    runProjectPostBuildPhase verbosity buildCtx buildOutcomes
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
 

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -717,6 +717,11 @@ lookupBuildOutcome = Map.lookup . installedUnitId
 -- (using the 'JobControl' to try to cancel in-progress tasks). This behaviour
 -- can be reversed to keep going and build as many packages as possible.
 --
+-- Note that the 'BuildOutcomes' is /not/ guaranteed to cover all the packages
+-- in the plan. In particular in the default mode where we stop as soon as
+-- possible after a failure then there may be packages which are skipped and
+-- these will have no 'BuildOutcome'.
+--
 execute :: forall m ipkg srcpkg result failure.
            (IsUnit ipkg, IsUnit srcpkg,
             Monad m)

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -132,6 +132,14 @@ import           System.Directory
 -- errors (ie rebuilding too much or too little), since all the rebuild
 -- decisions are made without making any state changes at the same time
 -- (that would make it harder to reproduce the problem situation).
+--
+-- Finally, we can use the dry run build status and the build outcomes to
+-- give us some information on the overall status of packages in the project.
+-- This includes limited information about the status of things that were
+-- not actually in the subset of the plan that was used for the dry run or
+-- execution phases. In particular we may know that some packages are now
+-- definitely out of date. See "Distribution.Client.ProjectPlanOutput" for
+-- details.
 
 
 ------------------------------------------------------------------------------
@@ -212,7 +220,7 @@ data BuildStatusRebuild =
      -- rerun. We record the reason the (re)build is needed.
      --
      -- The optional registration info here tells us if we've registered the
-     -- package already, or if we stil need to do that after building.
+     -- package already, or if we still need to do that after building.
      -- @Just Nothing@ indicates that we know that no registration is
      -- necessary (e.g., executable.)
      --
@@ -221,9 +229,6 @@ data BuildStatusRebuild =
 data BuildReason =
      -- | The dependencies of this package have been (re)built so the build
      -- phase needs to be rerun.
-     --
-     -- The optional registration info here tells us if we've registered the
-     -- package already, or if we stil need to do that after building.
      --
      BuildReasonDepsRebuilt
 

--- a/cabal-install/Distribution/Client/ProjectBuilding/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding/Types.hs
@@ -1,0 +1,216 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+-- | Types for the "Distribution.Client.ProjectBuilding"
+--
+-- Moved out to avoid module cycles.
+--
+module Distribution.Client.ProjectBuilding.Types (
+    -- * Pre-build status
+    BuildStatusMap,
+    BuildStatus(..),
+    buildStatusRequiresBuild,
+    buildStatusToString,
+    BuildStatusRebuild(..),
+    BuildReason(..),
+    MonitorChangedReason(..),
+
+    -- * Build outcomes
+    BuildOutcomes,
+    BuildOutcome,
+    BuildResult(..),
+    BuildFailure(..),
+    BuildFailureReason(..),
+  ) where
+
+import Distribution.Client.Types          (DocsResult, TestsResult)
+import Distribution.Client.FileMonitor    (MonitorChangedReason(..))
+
+import Distribution.Package               (UnitId, PackageId)
+import Distribution.InstalledPackageInfo  (InstalledPackageInfo)
+import Distribution.Simple.LocalBuildInfo (ComponentName)
+
+import Data.Map          (Map)
+import Data.Set          (Set)
+import Data.Typeable     (Typeable)
+import Control.Exception (Exception, SomeException)
+
+
+------------------------------------------------------------------------------
+-- Pre-build status: result of the dry run
+--
+
+-- | The 'BuildStatus' of every package in the 'ElaboratedInstallPlan'.
+--
+-- This is used as the result of the dry-run of building an install plan.
+--
+type BuildStatusMap = Map UnitId BuildStatus
+
+-- | The build status for an individual package is the state that the
+-- package is in /prior/ to initiating a (re)build.
+--
+-- This should not be confused with a 'BuildResult' which is the result
+-- /after/ successfully building a package.
+--
+-- It serves two purposes:
+--
+--  * For dry-run output, it lets us explain to the user if and why a package
+--    is going to be (re)built.
+--
+--  * It tell us what step to start or resume building from, and carries
+--    enough information for us to be able to do so.
+--
+data BuildStatus =
+
+     -- | The package is in the 'InstallPlan.PreExisting' state, so does not
+     --   need building.
+     BuildStatusPreExisting
+
+     -- | The package is in the 'InstallPlan.Installed' state, so does not
+     --   need building.
+   | BuildStatusInstalled
+
+     -- | The package has not been downloaded yet, so it will have to be
+     --   downloaded, unpacked and built.
+   | BuildStatusDownload
+
+     -- | The package has not been unpacked yet, so it will have to be
+     --   unpacked and built.
+   | BuildStatusUnpack FilePath
+
+     -- | The package exists in a local dir already, and just needs building
+     --   or rebuilding. So this can only happen for 'BuildInplaceOnly' style
+     --   packages.
+   | BuildStatusRebuild FilePath BuildStatusRebuild
+
+     -- | The package exists in a local dir already, and is fully up to date.
+     --   So this package can be put into the 'InstallPlan.Installed' state
+     --   and it does not need to be built.
+   | BuildStatusUpToDate BuildResult
+
+
+-- | Which 'BuildStatus' values indicate we'll have to do some build work of
+-- some sort. In particular we use this as part of checking if any of a
+-- package's deps have changed.
+--
+buildStatusRequiresBuild :: BuildStatus -> Bool
+buildStatusRequiresBuild BuildStatusPreExisting = False
+buildStatusRequiresBuild BuildStatusInstalled   = False
+buildStatusRequiresBuild BuildStatusUpToDate {} = False
+buildStatusRequiresBuild _                      = True
+
+-- | This is primarily here for debugging. It's not actually used anywhere.
+--
+buildStatusToString :: BuildStatus -> String
+buildStatusToString BuildStatusPreExisting    = "BuildStatusPreExisting"
+buildStatusToString BuildStatusInstalled      = "BuildStatusInstalled"
+buildStatusToString BuildStatusDownload       = "BuildStatusDownload"
+buildStatusToString (BuildStatusUnpack fp)    = "BuildStatusUnpack " ++ show fp
+buildStatusToString (BuildStatusRebuild fp _) = "BuildStatusRebuild " ++ show fp
+buildStatusToString (BuildStatusUpToDate _)   = "BuildStatusUpToDate"
+
+
+-- | For a package that is going to be built or rebuilt, the state it's in now.
+--
+-- So again, this tells us why a package needs to be rebuilt and what build
+-- phases need to be run. The 'MonitorChangedReason' gives us details like
+-- which file changed, which is mainly for high verbosity debug output.
+--
+data BuildStatusRebuild =
+
+     -- | The package configuration changed, so the configure and build phases
+     --   needs to be (re)run.
+     BuildStatusConfigure (MonitorChangedReason ())
+
+     -- | The configuration has not changed but the build phase needs to be
+     -- rerun. We record the reason the (re)build is needed.
+     --
+     -- The optional registration info here tells us if we've registered the
+     -- package already, or if we still need to do that after building.
+     -- @Just Nothing@ indicates that we know that no registration is
+     -- necessary (e.g., executable.)
+     --
+   | BuildStatusBuild (Maybe (Maybe InstalledPackageInfo)) BuildReason
+
+data BuildReason =
+     -- | The dependencies of this package have been (re)built so the build
+     -- phase needs to be rerun.
+     --
+     BuildReasonDepsRebuilt
+
+     -- | Changes in files within the package (or first run or corrupt cache)
+   | BuildReasonFilesChanged (MonitorChangedReason ())
+
+     -- | An important special case is that no files have changed but the
+     -- set of components the /user asked to build/ has changed. We track the
+     -- set of components /we have built/, which of course only grows (until
+     -- some other change resets it).
+     --
+     -- The @Set 'ComponentName'@ is the set of components we have built
+     -- previously. When we update the monitor we take the union of the ones
+     -- we have built previously with the ones the user has asked for this
+     -- time and save those. See 'updatePackageBuildFileMonitor'.
+     --
+   | BuildReasonExtraTargets (Set ComponentName)
+
+     -- | Although we're not going to build any additional targets as a whole,
+     -- we're going to build some part of a component or run a repl or any
+     -- other action that does not result in additional persistent artifacts.
+     --
+   | BuildReasonEphemeralTargets
+
+
+------------------------------------------------------------------------------
+-- Build outcomes: result of the build
+--
+
+-- | A summary of the outcome for building a whole set of packages.
+--
+type BuildOutcomes = Map UnitId BuildOutcome
+
+-- | A summary of the outcome for building a single package: either success
+-- or failure.
+--
+type BuildOutcome  = Either BuildFailure BuildResult
+
+-- | Information arising from successfully building a single package.
+--
+data BuildResult = BuildResult {
+       buildResultDocs    :: DocsResult,
+       buildResultTests   :: TestsResult,
+       buildResultLogFile :: Maybe FilePath,
+       -- | If the build was for a library, this field will be @Just@;
+       -- otherwise, it will be @Nothing@.  What about internal
+       -- libraries?  This never occurs, because a build result is either
+       -- for a per-component build (in which case there won't
+       -- be multiple libraries), or a package with no internal
+       -- libraries (internal libraries with Custom setups are NOT
+       -- supported, and even if they were supported, we could
+       -- assume the Cabal library version was recent enough to
+       -- support per-component build.).
+       buildResultLibInfo :: Maybe InstalledPackageInfo
+     }
+  deriving Show
+
+-- | Information arising from the failure to build a single package.
+--
+data BuildFailure = BuildFailure {
+       buildFailureLogFile :: Maybe FilePath,
+       buildFailureReason  :: BuildFailureReason
+     }
+  deriving (Show, Typeable)
+
+instance Exception BuildFailure
+
+-- | Detail on the reason that a package failed to build.
+--
+data BuildFailureReason = DependentFailed PackageId
+                        | DownloadFailed  SomeException
+                        | UnpackFailed    SomeException
+                        | ConfigureFailed SomeException
+                        | BuildFailed     SomeException
+                        | ReplFailed      SomeException
+                        | HaddocksFailed  SomeException
+                        | TestsFailed     SomeException
+                        | InstallFailed   SomeException
+  deriving Show
+

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -128,6 +128,7 @@ data PreBuildHooks = PreBuildHooks {
 -- | This holds the context between the pre-build, build and post-build phases.
 --
 data ProjectBuildContext = ProjectBuildContext {
+      projectRootDir   :: FilePath,
       distDirLayout    :: DistDirLayout,
       elaboratedPlan   :: ElaboratedInstallPlan,
       elaboratedShared :: ElaboratedSharedConfig,
@@ -195,6 +196,7 @@ runProjectPreBuildPhase
                            elaboratedPlan'
 
     return ProjectBuildContext {
+      projectRootDir,
       distDirLayout,
       elaboratedPlan = elaboratedPlan'',
       elaboratedShared,

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -68,6 +68,10 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
         InstallPlan.PreExisting ipi -> installedPackageInfoToJ ipi
         InstallPlan.Configured elab -> elaboratedPackageToJ False elab
         InstallPlan.Installed  elab -> elaboratedPackageToJ True  elab
+        -- Note that the plan.json currently only uses the elaborated plan,
+        -- not the improved plan. So we will not get the Installed state for
+        -- that case, but the code supports it in case we want to use this
+        -- later in some use case where we want the status of the build.
 
     installedPackageInfoToJ :: InstalledPackageInfo -> J.Value
     installedPackageInfoToJ ipi =

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -310,14 +310,13 @@ rebuildInstallPlan verbosity
                                                    solverPlan
                                                    localPackages
 
+          phaseMaintainPlanOutputs elaboratedPlan elaboratedShared
           return (elaboratedPlan, elaboratedShared, projectConfig)
 
       -- The improved plan changes each time we install something, whereas
       -- the underlying elaborated plan only changes when input config
       -- changes, so it's worth caching them separately.
       improvedPlan <- phaseImprovePlan elaboratedPlan elaboratedShared
-
-      phaseMaintainPlanOutputs improvedPlan elaboratedPlan elaboratedShared
 
       return (improvedPlan, elaboratedPlan, elaboratedShared, projectConfig)
 
@@ -568,21 +567,18 @@ rebuildInstallPlan verbosity
 
     -- Update the files we maintain that reflect our current build environment.
     -- In particular we maintain a JSON representation of the elaborated
-    -- install plan.
-    --
-    -- TODO: [required eventually] maintain the ghc environment file reflecting
-    -- the libs available. This will need to be after plan improvement phase.
+    -- install plan (but not the improved plan since that reflects the state
+    -- of the build rather than just the input environment).
     --
     phaseMaintainPlanOutputs :: ElaboratedInstallPlan
-                             -> ElaboratedInstallPlan
                              -> ElaboratedSharedConfig
                              -> Rebuild ()
-    phaseMaintainPlanOutputs _improvedPlan elaboratedPlan elaboratedShared = do
-        liftIO $ debug verbosity "Updating plan.json"
-        liftIO $ writePlanExternalRepresentation
-                   distDirLayout
-                   elaboratedPlan
-                   elaboratedShared
+    phaseMaintainPlanOutputs elaboratedPlan elaboratedShared = liftIO $ do
+        debug verbosity "Updating plan.json"
+        writePlanExternalRepresentation
+          distDirLayout
+          elaboratedPlan
+          elaboratedShared
 
 
     -- Improve the elaborated install plan. The elaborated plan consists

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -278,6 +278,7 @@ executable cabal
         Distribution.Client.PackageUtils
         Distribution.Client.ParseUtils
         Distribution.Client.ProjectBuilding
+        Distribution.Client.ProjectBuilding.Types
         Distribution.Client.ProjectConfig
         Distribution.Client.ProjectConfig.Types
         Distribution.Client.ProjectConfig.Legacy

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -256,9 +256,12 @@ planProject testdir cliConfig = do
             , elabBuildStyle elab == BuildInplaceOnly ]
         elaboratedPlan' = pruneInstallPlanToTargets targets elaboratedPlan
 
-    (elaboratedPlan'', pkgsBuildStatus) <-
-      rebuildTargetsDryRun verbosity distDirLayout elaboratedShared
+    pkgsBuildStatus <-
+      rebuildTargetsDryRun distDirLayout elaboratedShared
                            elaboratedPlan'
+
+    let elaboratedPlan'' = improveInstallPlanWithUpToDatePackages
+                             pkgsBuildStatus elaboratedPlan'
 
     let buildSettings = resolveBuildTimeSettings
                           verbosity cabalDirLayout


### PR DESCRIPTION
This is a bunch of changes leading up to adding better support for tracking the status of the project, which leads on to maintaining a .ghc.environment and other similar outputs.

So this is mostly about rearranging things in the project orchestration and the modules it touches.