### PR TITLE
Make `Version` type opaque

### DIFF
--- a/Cabal/Distribution/Compiler.hs
+++ b/Cabal/Distribution/Compiler.hs
@@ -48,7 +48,7 @@ import Distribution.Compat.Prelude
 
 import Language.Haskell.Extension
 
-import Distribution.Version (Version, mkVersion', nullVersion, mkNullVersion)
+import Distribution.Version (Version, mkVersion', nullVersion)
 
 import qualified System.Info (compilerName, compilerVersion)
 import Distribution.Text (Text(..), display)
@@ -139,12 +139,12 @@ instance Binary CompilerId
 
 instance Text CompilerId where
   disp (CompilerId f v)
-    | nullVersion v = disp f
-    | otherwise     = disp f <<>> Disp.char '-' <<>> disp v
+    | v == nullVersion = disp f
+    | otherwise        = disp f <<>> Disp.char '-' <<>> disp v
 
   parse = do
     flavour <- parse
-    version <- (Parse.char '-' >> parse) Parse.<++ return mkNullVersion
+    version <- (Parse.char '-' >> parse) Parse.<++ return nullVersion
     return (CompilerId flavour version)
 
 lowercase :: String -> String

--- a/Cabal/Distribution/Compiler.hs
+++ b/Cabal/Distribution/Compiler.hs
@@ -48,7 +48,7 @@ import Distribution.Compat.Prelude
 
 import Language.Haskell.Extension
 
-import Distribution.Version (Version(..))
+import Distribution.Version (Version, mkVersion', nullVersion, mkNullVersion)
 
 import qualified System.Info (compilerName, compilerVersion)
 import Distribution.Text (Text(..), display)
@@ -112,7 +112,7 @@ buildCompilerFlavor :: CompilerFlavor
 buildCompilerFlavor = classifyCompilerFlavor System.Info.compilerName
 
 buildCompilerVersion :: Version
-buildCompilerVersion = System.Info.compilerVersion
+buildCompilerVersion = mkVersion' System.Info.compilerVersion
 
 buildCompilerId :: CompilerId
 buildCompilerId = CompilerId buildCompilerFlavor buildCompilerVersion
@@ -138,12 +138,13 @@ data CompilerId = CompilerId CompilerFlavor Version
 instance Binary CompilerId
 
 instance Text CompilerId where
-  disp (CompilerId f (Version [] _)) = disp f
-  disp (CompilerId f v) = disp f <<>> Disp.char '-' <<>> disp v
+  disp (CompilerId f v)
+    | nullVersion v = disp f
+    | otherwise     = disp f <<>> Disp.char '-' <<>> disp v
 
   parse = do
     flavour <- parse
-    version <- (Parse.char '-' >> parse) Parse.<++ return (Version [] [])
+    version <- (Parse.char '-' >> parse) Parse.<++ return mkNullVersion
     return (CompilerId flavour version)
 
 lowercase :: String -> String

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -133,7 +133,7 @@ instance IsNode InstalledPackageInfo where
 emptyInstalledPackageInfo :: InstalledPackageInfo
 emptyInstalledPackageInfo
    = InstalledPackageInfo {
-        sourcePackageId   = PackageIdentifier (mkPackageName "") (Version [] []),
+        sourcePackageId   = PackageIdentifier (mkPackageName "") mkNullVersion,
         installedUnitId   = mkUnitId "",
         compatPackageKey  = "",
         license           = UnspecifiedLicense,

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -133,7 +133,7 @@ instance IsNode InstalledPackageInfo where
 emptyInstalledPackageInfo :: InstalledPackageInfo
 emptyInstalledPackageInfo
    = InstalledPackageInfo {
-        sourcePackageId   = PackageIdentifier (mkPackageName "") mkNullVersion,
+        sourcePackageId   = PackageIdentifier (mkPackageName "") nullVersion,
         installedUnitId   = mkUnitId "",
         compatPackageKey  = "",
         license           = UnspecifiedLicense,

--- a/Cabal/Distribution/License.hs
+++ b/Cabal/Distribution/License.hs
@@ -129,12 +129,12 @@ knownLicenses = [ GPL  unversioned, GPL  (version [2]),    GPL  (version [3])
                 , LGPL unversioned, LGPL (version [2, 1]), LGPL (version [3])
                 , AGPL unversioned,                        AGPL (version [3])
                 , BSD2, BSD3, MIT, ISC
-                , MPL (Version [2, 0] [])
+                , MPL (mkVersion [2, 0])
                 , Apache unversioned, Apache (version [2, 0])
                 , PublicDomain, AllRightsReserved, OtherLicense]
  where
    unversioned = Nothing
-   version   v = Just (Version v [])
+   version     = Just . mkVersion
 
 instance Text License where
   disp (GPL  version)         = Disp.text "GPL"    <<>> dispOptVersion version

--- a/Cabal/Distribution/Make.hs
+++ b/Cabal/Distribution/Make.hs
@@ -59,7 +59,7 @@
 
 module Distribution.Make (
         module Distribution.Package,
-        License(..), Version(..),
+        License(..), Version,
         defaultMain, defaultMainArgs, defaultMainNoRead
   ) where
 

--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -56,7 +56,7 @@ import Distribution.Compat.Prelude
 import Distribution.Version
          ( Version, VersionRange, anyVersion, thisVersion
          , notThisVersion, simplifyVersionRange
-         , mkNullVersion, nullVersion )
+         , nullVersion )
 
 import qualified Distribution.Compat.ReadP as Parse
 import qualified Text.PrettyPrint as Disp
@@ -124,12 +124,12 @@ instance Binary PackageIdentifier
 
 instance Text PackageIdentifier where
   disp (PackageIdentifier n v)
-    | nullVersion v = disp n -- if no version, don't show version.
-    | otherwise     = disp n <<>> Disp.char '-' <<>> disp v
+    | v == nullVersion = disp n -- if no version, don't show version.
+    | otherwise        = disp n <<>> Disp.char '-' <<>> disp v
 
   parse = do
     n <- parse
-    v <- (Parse.char '-' >> parse) <++ return mkNullVersion
+    v <- (Parse.char '-' >> parse) <++ return nullVersion
     return (PackageIdentifier n v)
 
 instance NFData PackageIdentifier where

--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -54,8 +54,9 @@ import Prelude ()
 import Distribution.Compat.Prelude
 
 import Distribution.Version
-         ( Version(..), VersionRange, anyVersion, thisVersion
-         , notThisVersion, simplifyVersionRange )
+         ( Version, VersionRange, anyVersion, thisVersion
+         , notThisVersion, simplifyVersionRange
+         , mkNullVersion, nullVersion )
 
 import qualified Distribution.Compat.ReadP as Parse
 import qualified Text.PrettyPrint as Disp
@@ -122,13 +123,13 @@ data PackageIdentifier
 instance Binary PackageIdentifier
 
 instance Text PackageIdentifier where
-  disp (PackageIdentifier n v) = case v of
-    Version [] _ -> disp n -- if no version, don't show version.
-    _            -> disp n <<>> Disp.char '-' <<>> disp v
+  disp (PackageIdentifier n v)
+    | nullVersion v = disp n -- if no version, don't show version.
+    | otherwise     = disp n <<>> Disp.char '-' <<>> disp v
 
   parse = do
     n <- parse
-    v <- (Parse.char '-' >> parse) <++ return (Version [] [])
+    v <- (Parse.char '-' >> parse) <++ return mkNullVersion
     return (PackageIdentifier n v)
 
 instance NFData PackageIdentifier where

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -169,7 +169,7 @@ checkSanity pkg =
     check (null . unPackageName . packageName $ pkg) $
       PackageBuildImpossible "No 'name' field."
 
-  , check (nullVersion . packageVersion $ pkg) $
+  , check (nullVersion == packageVersion pkg) $
       PackageBuildImpossible "No 'version' field."
 
   , check (all ($ pkg) [ null . executables
@@ -1375,7 +1375,7 @@ displayRawVersionRange =
   where
     dispWild v =
            Disp.hcat (Disp.punctuate (Disp.char '.')
-                                     (map Disp.int $ unVersion v))
+                                     (map Disp.int $ versionNumbers v))
         <<>> Disp.text ".*"
     punct p p' | p < p'    = Disp.parens
                | otherwise = id
@@ -1425,7 +1425,7 @@ checkPackageVersions pkg =
                               [] defaultComponentRequestedSpec (const True)
                               buildPlatform
                               (unknownCompilerInfo
-                                (CompilerId buildCompilerFlavor mkNullVersion)
+                                (CompilerId buildCompilerFlavor nullVersion)
                                 NoAbiTag)
                               [] pkg
     baseDependency = case finalised of

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -113,7 +113,7 @@ check True  pc = Just pc
 checkSpecVersion :: PackageDescription -> [Int] -> Bool -> PackageCheck
                  -> Maybe PackageCheck
 checkSpecVersion pkg specver cond pc
-  | specVersion pkg >= Version specver [] = Nothing
+  | specVersion pkg >= mkVersion specver  = Nothing
   | otherwise                             = check cond pc
 
 -- ------------------------------------------------------------
@@ -169,7 +169,7 @@ checkSanity pkg =
     check (null . unPackageName . packageName $ pkg) $
       PackageBuildImpossible "No 'name' field."
 
-  , check (null . versionBranch . packageVersion $ pkg) $
+  , check (nullVersion . packageVersion $ pkg) $
       PackageBuildImpossible "No 'version' field."
 
   , check (all ($ pkg) [ null . executables
@@ -258,7 +258,7 @@ checkLibrary pkg lib =
   where
     checkVersion :: [Int] -> Bool -> PackageCheck -> Maybe PackageCheck
     checkVersion ver cond pc
-      | specVersion pkg >= Version ver []      = Nothing
+      | specVersion pkg >= mkVersion ver       = Nothing
       | otherwise                              = check cond pc
 
     moduleDuplicates = dups (libModules lib ++
@@ -937,7 +937,7 @@ checkCabalVersion pkg =
   catMaybes [
 
     -- check syntax of cabal-version field
-    check (specVersion pkg >= Version [1,10] []
+    check (specVersion pkg >= mkVersion [1,10]
            && not simpleSpecVersionRangeSyntax) $
       PackageBuildWarning $
            "Packages relying on Cabal 1.10 or later must only specify a "
@@ -945,7 +945,7 @@ checkCabalVersion pkg =
         ++ "'cabal-version: >= " ++ display (specVersion pkg) ++ "'."
 
     -- check syntax of cabal-version field
-  , check (specVersion pkg < Version [1,9] []
+  , check (specVersion pkg < mkVersion [1,9]
            && not simpleSpecVersionRangeSyntax) $
       PackageDistSuspicious $
            "It is recommended that the 'cabal-version' field only specify a "
@@ -976,7 +976,7 @@ checkCabalVersion pkg =
            "To use the 'default-language' field the package needs to specify "
         ++ "at least 'cabal-version: >= 1.10'."
 
-  , check (specVersion pkg >= Version [1,10] []
+  , check (specVersion pkg >= mkVersion [1,10]
            && (any isNothing (buildInfoField defaultLanguage))) $
       PackageBuildWarning $
            "Packages using 'cabal-version: >= 1.10' must specify the "
@@ -1028,7 +1028,7 @@ checkCabalVersion pkg =
         ++ "at least 'cabal-version: >= 1.10'."
 
     -- check use of extensions field
-  , check (specVersion pkg >= Version [1,10] []
+  , check (specVersion pkg >= mkVersion [1,10]
            && (any (not . null) (buildInfoField oldExtensions))) $
       PackageBuildWarning $
            "For packages using 'cabal-version: >= 1.10' the 'extensions' "
@@ -1144,7 +1144,7 @@ checkCabalVersion pkg =
         ++ "compatibility with earlier Cabal versions then you may be able to "
         ++ "use an equivalent compiler-specific flag."
 
-  , check (specVersion pkg >= Version [1,23] []
+  , check (specVersion pkg >= mkVersion [1,23]
            && isNothing (setupBuildInfo pkg)
            && buildType pkg == Just Custom) $
       PackageBuildWarning $
@@ -1154,7 +1154,7 @@ checkCabalVersion pkg =
         ++ "The 'setup-depends' field uses the same syntax as 'build-depends', "
         ++ "so a simple example would be 'setup-depends: base, Cabal'."
 
-  , check (specVersion pkg < Version [1,23] []
+  , check (specVersion pkg < mkVersion [1,23]
            && isNothing (setupBuildInfo pkg)
            && buildType pkg == Just Custom) $
       PackageDistSuspiciousWarn $
@@ -1165,7 +1165,7 @@ checkCabalVersion pkg =
         ++ "The 'setup-depends' field uses the same syntax as 'build-depends', "
         ++ "so a simple example would be 'setup-depends: base, Cabal'."
 
-  , check (specVersion pkg >= Version [1,25] []
+  , check (specVersion pkg >= mkVersion [1,25]
            && elem (autogenPathsModuleName pkg) allModuleNames
            && not (elem (autogenPathsModuleName pkg) allModuleNamesAutogen) ) $
       PackageDistInexcusable $
@@ -1184,7 +1184,7 @@ checkCabalVersion pkg =
     -- version.
     checkVersion :: [Int] -> Bool -> PackageCheck -> Maybe PackageCheck
     checkVersion ver cond pc
-      | specVersion pkg >= Version ver []      = Nothing
+      | specVersion pkg >= mkVersion ver       = Nothing
       | otherwise                              = check cond pc
 
     buildInfoField field         = map field (allBuildInfo pkg)
@@ -1373,8 +1373,9 @@ displayRawVersionRange =
      (\(r,  _ )          -> (Disp.parens r, 0)) -- parens
 
   where
-    dispWild (Version b _) =
-           Disp.hcat (Disp.punctuate (Disp.char '.') (map Disp.int b))
+    dispWild v =
+           Disp.hcat (Disp.punctuate (Disp.char '.')
+                                     (map Disp.int $ unVersion v))
         <<>> Disp.text ".*"
     punct p p' | p < p'    = Disp.parens
                | otherwise = id
@@ -1424,7 +1425,7 @@ checkPackageVersions pkg =
                               [] defaultComponentRequestedSpec (const True)
                               buildPlatform
                               (unknownCompilerInfo
-                                (CompilerId buildCompilerFlavor (Version [] []))
+                                (CompilerId buildCompilerFlavor mkNullVersion)
                                 NoAbiTag)
                               [] pkg
     baseDependency = case finalised of

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -697,10 +697,10 @@ parsePackageDescription file = do
           head $ [ minVersionBound versionRange
                  | Just versionRange <- [ simpleParse v
                                         | F _ "cabal-version" v <- fields0 ] ]
-              ++ [Version [0] []]
+              ++ [mkVersion [0]]
         minVersionBound versionRange =
           case asVersionIntervals versionRange of
-            []                            -> Version [0] []
+            []                            -> mkVersion [0]
             ((LowerBound version _, _):_) -> version
 
     handleFutureVersionParseFailure cabalVersionNeeded $ do
@@ -753,13 +753,13 @@ parsePackageDescription file = do
           ++ "  Tabs were used at (line,column): " ++ show tabs
 
     maybeWarnCabalVersion newsyntax pkg
-      | newsyntax && specVersion pkg < Version [1,2] []
+      | newsyntax && specVersion pkg < mkVersion [1,2]
       = lift $ warning $
              "A package using section syntax must specify at least\n"
           ++ "'cabal-version: >= 1.2'."
 
     maybeWarnCabalVersion newsyntax pkg
-      | not newsyntax && specVersion pkg >= Version [1,2] []
+      | not newsyntax && specVersion pkg >= mkVersion [1,2]
       = lift $ warning $
              "A package using 'cabal-version: "
           ++ displaySpecVersion (specVersionRaw pkg)

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -660,7 +660,7 @@ parseVersionRangeQ = parseQuoted parse <++ parse
 parseOptVersion :: ReadP r Version
 parseOptVersion = parseQuoted ver <++ ver
   where ver :: ReadP r Version
-        ver = parse <++ return mkNullVersion
+        ver = parse <++ return nullVersion
 
 parseTestedWithQ :: ReadP r (CompilerFlavor,VersionRange)
 parseTestedWithQ = parseQuoted tw <++ tw

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -660,7 +660,7 @@ parseVersionRangeQ = parseQuoted parse <++ parse
 parseOptVersion :: ReadP r Version
 parseOptVersion = parseQuoted ver <++ ver
   where ver :: ReadP r Version
-        ver = parse <++ return (Version [] [])
+        ver = parse <++ return mkNullVersion
 
 parseTestedWithQ :: ReadP r (CompilerFlavor,VersionRange)
 parseTestedWithQ = parseQuoted tw <++ tw

--- a/Cabal/Distribution/Simple/Build/Macros.hs
+++ b/Cabal/Distribution/Simple/Build/Macros.hs
@@ -120,7 +120,7 @@ generateMacros macro_prefix name version =
     ]
   ,"\n"]
   where
-    (major1:major2:minor:_) = map show (versionBranch version ++ repeat 0)
+    (major1:major2:minor:_) = map show (unVersion version ++ repeat 0)
 
 -- | Generate the @CURRENT_COMPONENT_ID@ definition for the component ID
 --   of the current package.

--- a/Cabal/Distribution/Simple/Build/Macros.hs
+++ b/Cabal/Distribution/Simple/Build/Macros.hs
@@ -120,7 +120,7 @@ generateMacros macro_prefix name version =
     ]
   ,"\n"]
   where
-    (major1:major2:minor:_) = map show (unVersion version ++ repeat 0)
+    (major1:major2:minor:_) = map show (versionNumbers version ++ repeat 0)
 
 -- | Generate the @CURRENT_COMPONENT_ID@ definition for the component ID
 --   of the current package.

--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -100,8 +100,8 @@ generate pkg_descr lbi clbi =
         "catchIO = Exception.catch\n" ++
         "\n"++
         "version :: Version"++
-        "\nversion = Version " ++ show branch ++ " " ++ show tags
-          where Version branch tags = packageVersion pkg_descr
+        "\nversion = Version " ++ show branch ++ " []"
+          where branch = unVersion $ packageVersion pkg_descr
 
        body
         | reloc =
@@ -237,7 +237,7 @@ generate pkg_descr lbi clbi =
         supports_language_pragma =
           (compilerFlavor (compiler lbi) == GHC &&
             (compilerVersion (compiler lbi)
-              `withinRange` orLaterVersion (Version [6,6,1] []))) ||
+              `withinRange` orLaterVersion (mkVersion [6,6,1]))) ||
            compilerFlavor (compiler lbi) == GHCJS
 
 -- | Generates the name of the environment variable controlling the path

--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -101,7 +101,7 @@ generate pkg_descr lbi clbi =
         "\n"++
         "version :: Version"++
         "\nversion = Version " ++ show branch ++ " []"
-          where branch = unVersion $ packageVersion pkg_descr
+          where branch = versionNumbers $ packageVersion pkg_descr
 
        body
         | reloc =

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -249,7 +249,7 @@ currentCabalId = PackageIdentifier (mkPackageName "Cabal") cabalVersion
 -- | Identifier of the current compiler package.
 currentCompilerId :: PackageIdentifier
 currentCompilerId = PackageIdentifier (mkPackageName System.Info.compilerName)
-                                      System.Info.compilerVersion
+                                      (mkVersion' System.Info.compilerVersion)
 
 -- | Parse the @setup-config@ file header, returning the package identifiers
 -- for Cabal and the compiler.
@@ -650,7 +650,7 @@ configure (pkg_descr0', pbi) cfg = do
        if not (fromFlag $ configSplitObjs cfg)
             then return False
             else case compilerFlavor comp of
-                        GHC | compilerVersion comp >= Version [6,5] []
+                        GHC | compilerVersion comp >= mkVersion [6,5]
                           -> return True
                         GHCJS
                           -> return True
@@ -1346,7 +1346,7 @@ interpretPackageDbFlags userInstall specificDBs =
     extra dbs' (Just db:dbs) = extra (dbs' ++ [db]) dbs
 
 newPackageDepsBehaviourMinVersion :: Version
-newPackageDepsBehaviourMinVersion = Version [1,7,1] []
+newPackageDepsBehaviourMinVersion = mkVersion [1,7,1]
 
 -- In older cabal versions, there was only one set of package dependencies for
 -- the whole package. In this version, we can have separate dependencies per
@@ -1456,7 +1456,7 @@ configurePkgconfigPackages verbosity pkg_descr progdb enabled
   | otherwise    = do
     (_, _, progdb') <- requireProgramVersion
                        (lessVerbose verbosity) pkgConfigProgram
-                       (orLaterVersion $ Version [0,9,0] []) progdb
+                       (orLaterVersion $ mkVersion [0,9,0]) progdb
     traverse_ requirePkg allpkgs
     mlib' <- traverse addPkgConfigBILib (library pkg_descr)
     libs' <- traverse addPkgConfigBILib (subLibraries pkg_descr)

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -88,7 +88,6 @@ import Distribution.Utils.NubList
 import Language.Haskell.Extension
 
 import qualified Data.Map as Map
-import Data.Version             ( showVersion )
 import System.Directory
          ( doesFileExist, getAppUserDataDirectory, createDirectoryIfMissing
          , canonicalizePath, removeFile )
@@ -107,7 +106,7 @@ configure verbosity hcPath hcPkgPath conf0 = do
 
   (ghcProg, ghcVersion, progdb1) <-
     requireProgramVersion verbosity ghcProgram
-      (orLaterVersion (Version [6,11] []))
+      (orLaterVersion (mkVersion [6,11]))
       (userMaybeSpecifyPath "ghc" hcPath conf0)
   let implInfo = ghcVersionImplInfo ghcVersion
 
@@ -149,7 +148,7 @@ configure verbosity hcPath hcPkgPath conf0 = do
       -- `--supported-extensions` when it's not available.
       -- for older GHCs we can use the "Have interpreter" property to
       -- filter out `TemplateHaskell`
-      extensions | ghcVersion < Version [8] []
+      extensions | ghcVersion < mkVersion [8]
                  , Just "NO" <- Map.lookup "Have interpreter" ghcInfoMap
                    = filter ((/= EnableExtension TemplateHaskell) . fst)
                      extensions0
@@ -348,7 +347,7 @@ getUserPackageDB _verbosity ghcProg (Platform arch os) = do
                                          , Internal.showOsString os
                                          , display ghcVersion ]
     packageConfFileName
-      | ghcVersion >= Version [6,12] []  = "package.conf.d"
+      | ghcVersion >= mkVersion [6,12]   = "package.conf.d"
       | otherwise                        = "package.conf"
     Just ghcVersion = programVersion ghcProg
 
@@ -397,7 +396,7 @@ removeMingwIncludeDir pkg =
 getInstalledPackages' :: Verbosity -> [PackageDB] -> ProgramDb
                      -> IO [(PackageDB, [InstalledPackageInfo])]
 getInstalledPackages' verbosity packagedbs progdb
-  | ghcVersion >= Version [6,9] [] =
+  | ghcVersion >= mkVersion [6,9] =
   sequenceA
     [ do pkgs <- HcPkg.dump (hcPkgInfo progdb) verbosity packagedb
          return (packagedb, pkgs)
@@ -426,7 +425,7 @@ getInstalledPackages' verbosity packagedbs progdb = do
     -- instance to parse the package file and then convert.
     -- It's a bit yuck. But that's what we get for using Read/Show.
     readPackages
-      | ghcVersion >= Version [6,4,2] []
+      | ghcVersion >= mkVersion [6,4,2]
       = \file content -> case reads content of
           [(pkgs, _)] -> return (map IPI642.toCurrent pkgs)
           _           -> failToRead file
@@ -663,17 +662,17 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
     stubObjs <- catMaybes <$> sequenceA
       [ findFileWithExtension [objExtension] [libTargetDir]
           (ModuleName.toFilePath x ++"_stub")
-      | ghcVersion < Version [7,2] [] -- ghc-7.2+ does not make _stub.o files
+      | ghcVersion < mkVersion [7,2] -- ghc-7.2+ does not make _stub.o files
       , x <- libModules lib ]
     stubProfObjs <- catMaybes <$> sequenceA
       [ findFileWithExtension ["p_" ++ objExtension] [libTargetDir]
           (ModuleName.toFilePath x ++"_stub")
-      | ghcVersion < Version [7,2] [] -- ghc-7.2+ does not make _stub.o files
+      | ghcVersion < mkVersion [7,2] -- ghc-7.2+ does not make _stub.o files
       , x <- libModules lib ]
     stubSharedObjs <- catMaybes <$> sequenceA
       [ findFileWithExtension ["dyn_" ++ objExtension] [libTargetDir]
           (ModuleName.toFilePath x ++"_stub")
-      | ghcVersion < Version [7,2] [] -- ghc-7.2+ does not make _stub.o files
+      | ghcVersion < mkVersion [7,2] -- ghc-7.2+ does not make _stub.o files
       , x <- libModules lib ]
 
     hObjs     <- Internal.getHaskellObjects implInfo lib lbi
@@ -723,7 +722,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
                 -- at build time. This only applies to GHC < 7.8 - see the
                 -- discussion in #1660.
                 ghcOptDylibName          = if hostOS == OSX
-                                              && ghcVersion < Version [7,8] []
+                                              && ghcVersion < mkVersion [7,8]
                                             then toFlag sharedLibInstallPath
                                             else mempty,
                 ghcOptNoAutoLinkPackages = toFlag True,
@@ -957,7 +956,7 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
     -- Work around old GHCs not relinking in this
     -- situation, see #3294
     let target = targetDir </> exeNameReal
-    when (compilerVersion comp < Version [7,7] []) $ do
+    when (compilerVersion comp < mkVersion [7,7]) $ do
       e <- doesFileExist target
       when e (removeFile target)
     runGhcProg linkOpts { ghcOptOutputFile = toFlag target }
@@ -1031,7 +1030,7 @@ hackThreadedFlag verbosity comp prof bi
                   ++ "profiling in ghc-6.8 and older. It will be disabled."
     return bi { options = filterHcOptions (/= "-threaded") (options bi) }
   where
-    mustFilterThreaded = prof && compilerVersion comp < Version [6, 10] []
+    mustFilterThreaded = prof && compilerVersion comp < mkVersion [6, 10]
                       && "-threaded" `elem` hcOptions GHC bi
     filterHcOptions p hcoptss =
       [ (hc, if hc == GHC then filter p opts else opts)
@@ -1201,7 +1200,7 @@ hcPkgInfo progdb = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcPkgProg
                                    , HcPkg.recacheMultiInstance = v >= [6,12]
                                    }
   where
-    v               = versionBranch ver
+    v               = unVersion ver
     Just ghcPkgProg = lookupProgram ghcPkgProgram progdb
     Just ver        = programVersion ghcPkgProg
 
@@ -1231,7 +1230,7 @@ pkgRoot verbosity lbi = pkgRoot'
       appDir <- getAppUserDataDirectory "ghc"
       let ver      = compilerVersion (compiler lbi)
           subdir   = System.Info.arch ++ '-':System.Info.os
-                     ++ '-':showVersion ver
+                     ++ '-':display ver
           rootDir  = appDir </> subdir
       -- We must create the root directory for the user package database if it
       -- does not yet exists. Otherwise '${pkgroot}' will resolve to a

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1200,7 +1200,7 @@ hcPkgInfo progdb = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcPkgProg
                                    , HcPkg.recacheMultiInstance = v >= [6,12]
                                    }
   where
-    v               = unVersion ver
+    v               = versionNumbers ver
     Just ghcPkgProg = lookupProgram ghcPkgProgram progdb
     Just ver        = programVersion ghcPkgProg
 

--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -57,7 +57,7 @@ getImplInfo comp =
                     ", but found " ++ show x)
 
 ghcVersionImplInfo :: Version -> GhcImplInfo
-ghcVersionImplInfo (Version v _) = GhcImplInfo
+ghcVersionImplInfo ver = GhcImplInfo
   { supportsHaskell2010  = v >= [7]
   , reportsNoExt         = v >= [7]
   , alwaysNondecIndent   = v <  [7,1]
@@ -66,6 +66,8 @@ ghcVersionImplInfo (Version v _) = GhcImplInfo
   , flagPackageConf      = v <  [7,5]
   , flagDebugInfo        = v >= [7,10]
   }
+  where
+    v = unVersion ver
 
 ghcjsVersionImplInfo :: Version -> Version -> GhcImplInfo
 ghcjsVersionImplInfo _ghcjsVer _ghcVer = GhcImplInfo

--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -67,7 +67,7 @@ ghcVersionImplInfo ver = GhcImplInfo
   , flagDebugInfo        = v >= [7,10]
   }
   where
-    v = unVersion ver
+    v = versionNumbers ver
 
 ghcjsVersionImplInfo :: Version -> Version -> GhcImplInfo
 ghcjsVersionImplInfo _ghcjsVer _ghcVer = GhcImplInfo

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -58,7 +58,7 @@ configure :: Verbosity -> Maybe FilePath -> Maybe FilePath
 configure verbosity hcPath hcPkgPath progdb0 = do
   (ghcjsProg, ghcjsVersion, progdb1) <-
     requireProgramVersion verbosity ghcjsProgram
-      (orLaterVersion (Version [0,1] []))
+      (orLaterVersion (mkVersion [0,1]))
       (userMaybeSpecifyPath "ghcjs" hcPath progdb0)
   Just ghcjsGhcVersion <- findGhcjsGhcVersion verbosity (programPath ghcjsProg)
   let implInfo = ghcjsVersionImplInfo ghcjsVersion ghcjsGhcVersion
@@ -109,7 +109,7 @@ configure verbosity hcPath hcPkgPath progdb0 = do
   let comp = Compiler {
         compilerId         = CompilerId GHCJS ghcjsVersion,
         compilerAbiTag     = AbiTag $
-          "ghc" ++ intercalate "_" (map show . versionBranch $ ghcjsGhcVersion),
+          "ghc" ++ intercalate "_" (map show . unVersion $ ghcjsGhcVersion),
         compilerCompat     = [CompilerId GHC ghcjsGhcVersion],
         compilerLanguages  = languages,
         compilerExtensions = extensions,
@@ -855,12 +855,12 @@ hcPkgInfo progdb = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcjsPkgProg
                                    , HcPkg.noVerboseFlag   = False
                                    , HcPkg.flagPackageConf = False
                                    , HcPkg.supportsDirDbs  = True
-                                   , HcPkg.requiresDirDbs  = v >= [7,10]
-                                   , HcPkg.nativeMultiInstance  = v >= [7,10]
+                                   , HcPkg.requiresDirDbs  = ver >= v7_10
+                                   , HcPkg.nativeMultiInstance  = ver >= v7_10
                                    , HcPkg.recacheMultiInstance = True
                                    }
   where
-    v                 = versionBranch ver
+    v7_10 = mkVersion [7,10]
     Just ghcjsPkgProg = lookupProgram ghcjsPkgProgram progdb
     Just ver          = programVersion ghcjsPkgProg
 

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -109,7 +109,7 @@ configure verbosity hcPath hcPkgPath progdb0 = do
   let comp = Compiler {
         compilerId         = CompilerId GHCJS ghcjsVersion,
         compilerAbiTag     = AbiTag $
-          "ghc" ++ intercalate "_" (map show . unVersion $ ghcjsGhcVersion),
+          "ghc" ++ intercalate "_" (map show . versionNumbers $ ghcjsGhcVersion),
         compilerCompat     = [CompilerId GHC ghcjsGhcVersion],
         compilerLanguages  = languages,
         compilerExtensions = extensions,

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -157,11 +157,11 @@ haddock pkg_descr lbi suffixes flags' = do
     setupMessage verbosity "Running Haddock for" (packageId pkg_descr)
     (haddockProg, version, _) <-
       requireProgramVersion verbosity haddockProgram
-        (orLaterVersion (Version [2,0] [])) (withPrograms lbi)
+        (orLaterVersion (mkVersion [2,0])) (withPrograms lbi)
 
     -- various sanity checks
     when ( flag haddockHoogle
-           && version < Version [2,2] []) $
+           && version < mkVersion [2,2]) $
          die "haddock 2.0 and 2.1 do not support the --hoogle flag."
 
     haddockGhcVersionStr <- getProgramOutput verbosity haddockProg
@@ -410,7 +410,7 @@ getGhcCppOpts haddockVersion bi =
     haddockVersionMacro  = "-D__HADDOCK_VERSION__="
                            ++ show (v1 * 1000 + v2 * 10 + v3)
       where
-        [v1, v2, v3] = take 3 $ versionBranch haddockVersion ++ [0,0]
+        [v1, v2, v3] = take 3 $ unVersion haddockVersion ++ [0,0]
 
 getGhcLibDir :: Verbosity -> LocalBuildInfo
              -> IO HaddockArgs
@@ -450,8 +450,8 @@ renderArgs :: Verbosity
               -> (([String], FilePath) -> IO a)
               -> IO a
 renderArgs verbosity tmpFileOpts version comp platform args k = do
-  let haddockSupportsUTF8          = version >= Version [2,14,4] []
-      haddockSupportsResponseFiles = version >  Version [2,16,2] []
+  let haddockSupportsUTF8          = version >= mkVersion [2,14,4]
+      haddockSupportsResponseFiles = version >  mkVersion [2,16,2]
   createDirectoryIfMissingVerbose verbosity True outputDir
   withTempFileEx tmpFileOpts outputDir "haddock-prologue.txt" $
     \prologueFileName h -> do
@@ -558,7 +558,7 @@ renderPureArgs version comp platform args = concat
         map (\(i,mh) -> "--read-interface=" ++
           maybe "" (++",") mh ++ i)
       bool a b c = if c then a else b
-      isVersion major minor  = version >= Version [major,minor]  []
+      isVersion major minor  = version >= mkVersion [major,minor]
       verbosityFlag
        | isVersion 2 5 = "--verbosity=1"
        | otherwise     = "--verbose"
@@ -658,7 +658,7 @@ hscolour' :: (String -> IO ()) -- ^ Called when the 'hscolour' exe is not found.
 hscolour' onNoHsColour haddockTarget pkg_descr lbi suffixes flags =
     either onNoHsColour (\(hscolourProg, _, _) -> go hscolourProg) =<<
       lookupProgramVersion verbosity hscolourProgram
-      (orLaterVersion (Version [1,8] [])) (withPrograms lbi)
+      (orLaterVersion (mkVersion [1,8])) (withPrograms lbi)
   where
     go :: ConfiguredProgram -> IO ()
     go hscolourProg = do
@@ -696,7 +696,7 @@ hscolour' onNoHsColour haddockTarget pkg_descr lbi suffixes flags =
          createDirectoryIfMissingVerbose verbosity True outputDir
 
          case stylesheet of -- copy the CSS file
-           Nothing | programVersion prog >= Just (Version [1,9] []) ->
+           Nothing | programVersion prog >= Just (mkVersion [1,9]) ->
                        runProgram verbosity prog
                           ["-print-css", "-o" ++ outputDir </> "hscolour.css"]
                    | otherwise -> return ()

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -410,7 +410,7 @@ getGhcCppOpts haddockVersion bi =
     haddockVersionMacro  = "-D__HADDOCK_VERSION__="
                            ++ show (v1 * 1000 + v2 * 10 + v3)
       where
-        [v1, v2, v3] = take 3 $ unVersion haddockVersion ++ [0,0]
+        [v1, v2, v3] = take 3 $ versionNumbers haddockVersion ++ [0,0]
 
 getGhcLibDir :: Verbosity -> LocalBuildInfo
              -> IO HaddockArgs

--- a/Cabal/Distribution/Simple/HaskellSuite.hs
+++ b/Cabal/Distribution/Simple/HaskellSuite.hs
@@ -6,7 +6,6 @@ module Distribution.Simple.HaskellSuite where
 import Prelude ()
 import Distribution.Compat.Prelude
 
-import Data.Version
 import qualified Data.Map as Map (empty)
 
 import Distribution.Simple.Program
@@ -14,6 +13,7 @@ import Distribution.Simple.Compiler as Compiler
 import Distribution.Simple.Utils
 import Distribution.Simple.BuildPaths
 import Distribution.Verbosity
+import Distribution.Version
 import Distribution.Text
 import Distribution.Package
 import Distribution.InstalledPackageInfo hiding (includeDirs)

--- a/Cabal/Distribution/Simple/JHC.hs
+++ b/Cabal/Distribution/Simple/JHC.hs
@@ -56,7 +56,7 @@ configure :: Verbosity -> Maybe FilePath -> Maybe FilePath
 configure verbosity hcPath _hcPkgPath progdb = do
 
   (jhcProg, _, progdb') <- requireProgramVersion verbosity
-                           jhcProgram (orLaterVersion (Version [0,7,2] []))
+                           jhcProgram (orLaterVersion (mkVersion [0,7,2]))
                            (userMaybeSpecifyPath "jhc" hcPath progdb)
 
   let Just version = programVersion jhcProg

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -83,12 +83,12 @@ configure verbosity hcPath hcPkgPath progdb = do
 
   (lhcProg, lhcVersion, progdb') <-
     requireProgramVersion verbosity lhcProgram
-      (orLaterVersion (Version [0,7] []))
+      (orLaterVersion (mkVersion [0,7]))
       (userMaybeSpecifyPath "lhc" hcPath progdb)
 
   (lhcPkgProg, lhcPkgVersion, progdb'') <-
     requireProgramVersion verbosity lhcPkgProgram
-      (orLaterVersion (Version [0,7] []))
+      (orLaterVersion (mkVersion [0,7]))
       (userMaybeSpecifyPath "lhc-pkg" hcPkgPath progdb')
 
   when (lhcVersion /= lhcPkgVersion) $ die $
@@ -258,7 +258,7 @@ getInstalledPackages' lhcPkg verbosity packagedbs progdb
     packageDbGhcPkgFlag (SpecificPackageDB path) = "--" ++ packageDbFlag ++ "=" ++ path
 
     packageDbFlag
-      | programVersion lhcPkg < Just (Version [7,5] [])
+      | programVersion lhcPkg < Just (mkVersion [7,5])
       = "package-conf"
       | otherwise
       = "package-db"
@@ -527,7 +527,7 @@ hackThreadedFlag verbosity comp prof bi
                   ++ "profiling in ghc-6.8 and older. It will be disabled."
     return bi { options = filterHcOptions (/= "-threaded") (options bi) }
   where
-    mustFilterThreaded = prof && compilerVersion comp < Version [6, 10] []
+    mustFilterThreaded = prof && compilerVersion comp < mkVersion [6, 10]
                       && "-threaded" `elem` hcOptions GHC bi
     filterHcOptions p hcoptss =
       [ (hc, if hc == GHC then filter p opts else opts)
@@ -590,7 +590,7 @@ ghcOptions lbi bi clbi odir
      ++ [ "-optP-include", "-optP"++ (autogenComponentModulesDir lbi clbi </> cppHeaderName) ]
      ++ [ "-#include \"" ++ inc ++ "\"" | inc <- PD.includes bi ]
      ++ [ "-odir",  odir, "-hidir", odir ]
-     ++ (if compilerVersion c >= Version [6,8] []
+     ++ (if compilerVersion c >= mkVersion [6,8]
            then ["-stubdir", odir] else [])
      ++ ghcPackageFlags lbi clbi
      ++ (case withOptimization lbi of
@@ -604,7 +604,7 @@ ghcOptions lbi bi clbi odir
 
 ghcPackageFlags :: LocalBuildInfo -> ComponentLocalBuildInfo -> [String]
 ghcPackageFlags lbi clbi
-  | ghcVer >= Version [6,11] []
+  | ghcVer >= mkVersion [6,11]
               = concat [ ["-package-id", display ipkgid]
                        | (ipkgid, _) <- componentPackageDeps clbi ]
 
@@ -626,7 +626,7 @@ ghcPackageDbOptions lbi = case dbstack of
 
     dbstack = withPackageDB lbi
     packageDbFlag
-      | compilerVersion (compiler lbi) < Version [7,5] []
+      | compilerVersion (compiler lbi) < mkVersion [7,5]
       = "package-conf"
       | otherwise
       = "package-db"
@@ -634,7 +634,7 @@ ghcPackageDbOptions lbi = case dbstack of
 constructCcCmdLine :: LocalBuildInfo -> BuildInfo -> ComponentLocalBuildInfo
                    -> FilePath -> FilePath -> Verbosity -> (FilePath,[String])
 constructCcCmdLine lbi bi clbi pref filename verbosity
-  =  let odir | compilerVersion (compiler lbi) >= Version [6,4,1] []  = pref
+  =  let odir | compilerVersion (compiler lbi) >= mkVersion [6,4,1] = pref
               | otherwise = pref </> takeDirectory filename
                         -- ghc 6.4.1 fixed a bug in -odir handling
                         -- for C compilations.

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -327,7 +327,7 @@ ppCpp = ppCpp' []
 ppCpp' :: [String] -> BuildInfo -> LocalBuildInfo -> ComponentLocalBuildInfo -> PreProcessor
 ppCpp' extraArgs bi lbi clbi =
   case compilerFlavor (compiler lbi) of
-    GHC   -> ppGhcCpp ghcProgram   (>= Version [6,6] []) args bi lbi clbi
+    GHC   -> ppGhcCpp ghcProgram   (>= mkVersion [6,6])  args bi lbi clbi
     GHCJS -> ppGhcCpp ghcjsProgram (const True)          args bi lbi clbi
     _     -> ppCpphs  args bi lbi clbi
   where cppArgs = getCppOptions bi lbi
@@ -364,7 +364,7 @@ ppCpphs extraArgs _bi lbi clbi =
       runProgram verbosity cpphsProg $
           ("-O" ++ outFile) : inFile
         : "--noline" : "--strip"
-        : (if cpphsVersion >= Version [1,6] []
+        : (if cpphsVersion >= mkVersion [1,6]
              then ["--include="++ (autogenComponentModulesDir lbi clbi </> cppHeaderName)]
              else [])
         ++ extraArgs
@@ -466,7 +466,7 @@ ppC2hs bi lbi clbi =
     runPreProcessor = \(inBaseDir, inRelativeFile)
                        (outBaseDir, outRelativeFile) verbosity -> do
       (c2hsProg, _, _) <- requireProgramVersion verbosity
-                            c2hsProgram (orLaterVersion (Version [0,15] []))
+                            c2hsProgram (orLaterVersion (mkVersion [0,15]))
                             (withPrograms lbi)
       (gccProg, _) <- requireProgram verbosity gccProgram (withPrograms lbi)
       runProgram verbosity c2hsProg $
@@ -540,10 +540,11 @@ platformDefines lbi =
     -- FIXME: this forces GHC's crazy 4.8.2 -> 408 convention on all
     -- the other compilers. Check if that's really what they want.
     versionInt :: Version -> String
-    versionInt (Version { versionBranch = [] }) = "1"
-    versionInt (Version { versionBranch = [n] }) = show n
-    versionInt (Version { versionBranch = n1:n2:_ })
-      = -- 6.8.x -> 608
+    versionInt v = case unVersion v of
+      [] -> "1"
+      [n] -> show n
+      n1:n2:_ ->
+        -- 6.8.x -> 608
         -- 6.10.x -> 610
         let s1 = show n1
             s2 = show n2
@@ -551,6 +552,7 @@ platformDefines lbi =
                      _ : _ : _ -> ""
                      _         -> "0"
         in s1 ++ middle ++ s2
+
     osStr = case hostOS of
       Linux     -> ["linux"]
       Windows   -> ["mingw32"]

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -540,7 +540,7 @@ platformDefines lbi =
     -- FIXME: this forces GHC's crazy 4.8.2 -> 408 convention on all
     -- the other compilers. Check if that's really what they want.
     versionInt :: Version -> String
-    versionInt v = case unVersion v of
+    versionInt v = case versionNumbers v of
       [] -> "1"
       [n] -> show n
       n1:n2:_ ->

--- a/Cabal/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/Distribution/Simple/Program/Builtin.hs
@@ -113,8 +113,8 @@ ghcProgram = (simpleProgram "ghc") {
              }
            -- Only the 7.8 branch seems to be affected. Fixed in 7.8.4.
            affectedVersionRange = intersectVersionRanges
-                                  (laterVersion   $ Version [7,8,0] [])
-                                  (earlierVersion $ Version [7,8,4] [])
+                                  (laterVersion   $ mkVersion [7,8,0])
+                                  (earlierVersion $ mkVersion [7,8,4])
        return $ maybe ghcProg
          (\v -> if withinRange v affectedVersionRange
                 then ghcProg' else ghcProg)

--- a/Cabal/Distribution/Simple/Program/Hpc.hs
+++ b/Cabal/Distribution/Simple/Program/Hpc.hs
@@ -60,7 +60,7 @@ markup hpc hpcVer verbosity tixFile hpcDirs destDir excluded = do
     runProgramInvocation verbosity
       (markupInvocation hpc tixFile hpcDirs' destDir excluded)
   where
-    version07 = Version [0, 7] []
+    version07 = mkVersion [0, 7]
     (passedDirs, droppedDirs) = splitAt 1 hpcDirs
 
 markupInvocation :: ConfiguredProgram

--- a/Cabal/Distribution/Simple/Program/Strip.hs
+++ b/Cabal/Distribution/Simple/Program/Strip.hs
@@ -62,7 +62,7 @@ stripLib verbosity (Platform arch os) progdb path = do
     Linux | arch == I386 ->
       -- Versions of 'strip' on 32-bit Linux older than 2.18 are
       -- broken. See #2339.
-      let okVersion = orLaterVersion (Version [2,18] [])
+      let okVersion = orLaterVersion (mkVersion [2,18])
       in case programVersion =<< lookupProgram stripProgram progdb of
           Just v | withinRange v okVersion ->
             runStrip verbosity progdb path args

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -75,12 +75,12 @@ import Distribution.Simple.Utils
 import Distribution.System
 import Distribution.Text
 import Distribution.Verbosity as Verbosity
+import Distribution.Version
 import Distribution.Compat.Graph (IsNode(nodeKey))
 
 import System.FilePath ((</>), (<.>), isAbsolute)
 import System.Directory
 
-import Data.Version
 import Data.List (partition)
 import qualified Data.ByteString.Lazy.Char8 as BS.Char8
 
@@ -236,7 +236,7 @@ generateRegistrationInfo verbosity pkg lib lbi clbi inplace reloc distPref packa
              }
   abi_hash <-
     case compilerFlavor comp of
-     GHC | compilerVersion comp >= Version [6,11] [] -> do
+     GHC | compilerVersion comp >= mkVersion [6,11] -> do
             fmap AbiHash $ GHC.libAbiHash verbosity pkg lbi' lib clbi
      GHCJS -> do
             fmap AbiHash $ GHCJS.libAbiHash verbosity pkg lbi' lib clbi

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -374,8 +374,7 @@ snapshotPackage date pkg =
 -- to the given date.
 --
 snapshotVersion :: UTCTime -> Version -> Version
-snapshotVersion date ver
-  = mkVersion (unVersion ver ++ [dateToSnapshotNumber date])
+snapshotVersion date = alterVersion (++ [dateToSnapshotNumber date])
 
 -- | Given a date produce a corresponding integer representation.
 -- For example given a date @18/03/2008@ produce the number @20080318@.

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -374,10 +374,8 @@ snapshotPackage date pkg =
 -- to the given date.
 --
 snapshotVersion :: UTCTime -> Version -> Version
-snapshotVersion date version = version {
-    versionBranch = versionBranch version
-                 ++ [dateToSnapshotNumber date]
-  }
+snapshotVersion date ver
+  = mkVersion (unVersion ver ++ [dateToSnapshotNumber date])
 
 -- | Given a date produce a corresponding integer representation.
 -- For example given a date @18/03/2008@ produce the number @20080318@.

--- a/Cabal/Distribution/Simple/UHC.hs
+++ b/Cabal/Distribution/Simple/UHC.hs
@@ -54,7 +54,7 @@ configure verbosity hcPath _hcPkgPath progdb = do
 
   (_uhcProg, uhcVersion, progdb') <-
     requireProgramVersion verbosity uhcProgram
-    (orLaterVersion (Version [1,0,2] []))
+    (orLaterVersion (mkVersion [1,0,2]))
     (userMaybeSpecifyPath "uhc" hcPath progdb)
 
   let comp = Compiler {

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -236,11 +236,11 @@ import System.Process
 -- We only get our own version number when we're building with ourselves
 cabalVersion :: Version
 #if defined(BOOTSTRAPPED_CABAL)
-cabalVersion = Paths_Cabal.version
+cabalVersion = mkVersion' Paths_Cabal.version
 #elif defined(CABAL_VERSION)
-cabalVersion = Version [CABAL_VERSION] []
+cabalVersion = mkVersion [CABAL_VERSION]
 #else
-cabalVersion = Version [1,9999] []  --used when bootstrapping
+cabalVersion = mkVersion [1,9999]  --used when bootstrapping
 #endif
 
 -- ----------------------------------------------------------------------------

--- a/Cabal/Distribution/Types/BenchmarkInterface.hs
+++ b/Cabal/Distribution/Types/BenchmarkInterface.hs
@@ -36,7 +36,7 @@ data BenchmarkInterface =
 instance Binary BenchmarkInterface
 
 instance Monoid BenchmarkInterface where
-    mempty  =  BenchmarkUnsupported (BenchmarkTypeUnknown mempty (Version [] []))
+    mempty  =  BenchmarkUnsupported (BenchmarkTypeUnknown mempty mkNullVersion)
     mappend = (<>)
 
 instance Semigroup BenchmarkInterface where

--- a/Cabal/Distribution/Types/BenchmarkInterface.hs
+++ b/Cabal/Distribution/Types/BenchmarkInterface.hs
@@ -36,7 +36,7 @@ data BenchmarkInterface =
 instance Binary BenchmarkInterface
 
 instance Monoid BenchmarkInterface where
-    mempty  =  BenchmarkUnsupported (BenchmarkTypeUnknown mempty mkNullVersion)
+    mempty  =  BenchmarkUnsupported (BenchmarkTypeUnknown mempty nullVersion)
     mappend = (<>)
 
 instance Semigroup BenchmarkInterface where

--- a/Cabal/Distribution/Types/BenchmarkType.hs
+++ b/Cabal/Distribution/Types/BenchmarkType.hs
@@ -25,7 +25,7 @@ data BenchmarkType = BenchmarkTypeExe Version
 instance Binary BenchmarkType
 
 knownBenchmarkTypes :: [BenchmarkType]
-knownBenchmarkTypes = [ BenchmarkTypeExe (Version [1,0] []) ]
+knownBenchmarkTypes = [ BenchmarkTypeExe (mkVersion [1,0]) ]
 
 instance Text BenchmarkType where
   disp (BenchmarkTypeExe ver)          = text "exitcode-stdio-" <<>> disp ver

--- a/Cabal/Distribution/Types/PackageDescription.hs
+++ b/Cabal/Distribution/Types/PackageDescription.hs
@@ -153,7 +153,7 @@ specVersion :: PackageDescription -> Version
 specVersion pkg = case specVersionRaw pkg of
   Left  version      -> version
   Right versionRange -> case asVersionIntervals versionRange of
-                          []                            -> Version [0] []
+                          []                            -> mkVersion [0]
                           ((LowerBound version _, _):_) -> version
 
 -- | The range of versions of the Cabal tools that this package is intended to
@@ -172,7 +172,7 @@ emptyPackageDescription :: PackageDescription
 emptyPackageDescription
     =  PackageDescription {
                       package      = PackageIdentifier (mkPackageName "")
-                                                       (Version [] []),
+                                                       mkNullVersion,
                       license      = UnspecifiedLicense,
                       licenseFiles = [],
                       specVersionRaw = Right anyVersion,

--- a/Cabal/Distribution/Types/PackageDescription.hs
+++ b/Cabal/Distribution/Types/PackageDescription.hs
@@ -172,7 +172,7 @@ emptyPackageDescription :: PackageDescription
 emptyPackageDescription
     =  PackageDescription {
                       package      = PackageIdentifier (mkPackageName "")
-                                                       mkNullVersion,
+                                                       nullVersion,
                       license      = UnspecifiedLicense,
                       licenseFiles = [],
                       specVersionRaw = Right anyVersion,

--- a/Cabal/Distribution/Types/TestSuiteInterface.hs
+++ b/Cabal/Distribution/Types/TestSuiteInterface.hs
@@ -42,7 +42,7 @@ instance Binary TestSuiteInterface
 
 
 instance Monoid TestSuiteInterface where
-    mempty  =  TestSuiteUnsupported (TestTypeUnknown mempty mkNullVersion)
+    mempty  =  TestSuiteUnsupported (TestTypeUnknown mempty nullVersion)
     mappend = (<>)
 
 instance Semigroup TestSuiteInterface where

--- a/Cabal/Distribution/Types/TestSuiteInterface.hs
+++ b/Cabal/Distribution/Types/TestSuiteInterface.hs
@@ -42,7 +42,7 @@ instance Binary TestSuiteInterface
 
 
 instance Monoid TestSuiteInterface where
-    mempty  =  TestSuiteUnsupported (TestTypeUnknown mempty (Version [] []))
+    mempty  =  TestSuiteUnsupported (TestTypeUnknown mempty mkNullVersion)
     mappend = (<>)
 
 instance Semigroup TestSuiteInterface where

--- a/Cabal/Distribution/Types/TestType.hs
+++ b/Cabal/Distribution/Types/TestType.hs
@@ -24,8 +24,8 @@ data TestType = TestTypeExe Version     -- ^ \"type: exitcode-stdio-x.y\"
 instance Binary TestType
 
 knownTestTypes :: [TestType]
-knownTestTypes = [ TestTypeExe (Version [1,0] [])
-                 , TestTypeLib (Version [0,9] []) ]
+knownTestTypes = [ TestTypeExe (mkVersion [1,0])
+                 , TestTypeLib (mkVersion [0,9]) ]
 
 instance Text TestType where
   disp (TestTypeExe ver)          = text "exitcode-stdio-" <<>> disp ver

--- a/Cabal/Distribution/Version.hs
+++ b/Cabal/Distribution/Version.hs
@@ -1,32 +1,5 @@
-{-# LANGUAGE CPP, DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
-#if __GLASGOW_HASKELL__ < 707
-{-# LANGUAGE StandaloneDeriving #-}
-#endif
-
--- Hack approach to support bootstrapping.
--- When MIN_VERSION_binary macro is available, use it. But it's not available
--- during bootstrapping (or anyone else building Setup.hs directly). If the
--- builder specifies -DMIN_VERSION_binary_0_8_0=1 or =0 then we respect that.
--- Otherwise we pick a default based on GHC version: assume binary <0.8 when
--- GHC < 8.0, and binary >=0.8 when GHC >= 8.0.
-#ifdef MIN_VERSION_binary
-#define MIN_VERSION_binary_0_8_0 MIN_VERSION_binary(0,8,0)
-#else
-#ifndef MIN_VERSION_binary_0_8_0
-#if __GLASGOW_HASKELL__ >= 800
-#define MIN_VERSION_binary_0_8_0 1
-#else
-#define MIN_VERSION_binary_0_8_0 0
-#endif
-#endif
-#endif
-
-#if !MIN_VERSION_binary_0_8_0 || __GLASGOW_HASKELL__ < 707
--- instance Binary Version for !MIN_VERSION_binary_0_8_0
--- instance Data Version for __GLASGOW_HASKELL__ < 707
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -44,7 +17,12 @@
 
 module Distribution.Version (
   -- * Package versions
-  Version(..),
+  Version,
+  mkVersion,
+  mkVersion',
+  unVersion,
+  mkNullVersion,
+  nullVersion,
 
   -- * Version ranges
   VersionRange(..),
@@ -103,8 +81,7 @@ module Distribution.Version (
 
 import Prelude ()
 import Distribution.Compat.Prelude
-
-import Data.Version     ( Version(..) )
+import qualified Data.Version as Base
 
 import Distribution.Text
 import qualified Distribution.Compat.ReadP as Parse
@@ -113,6 +90,95 @@ import Distribution.Compat.ReadP hiding (get)
 import qualified Text.PrettyPrint as Disp
 import Text.PrettyPrint ((<+>))
 import Control.Exception (assert)
+
+-- -----------------------------------------------------------------------------
+-- Versions
+
+-- | A 'Version' represents the version of a software entity.
+--
+-- Instances of 'Eq' and 'Ord' are provided, which gives exact
+-- equality and lexicographic ordering of the version number
+-- components (i.e. 2.1 > 2.0, 1.2.3 > 1.2.2, etc.).
+--
+-- This type is opaque and distinct from the 'Base.Version' type in
+-- "Data.Version" since @Cabal-2.0@. The difference extends to the
+-- 'Binary' instance using a different (and more compact) encoding.
+--
+-- @since 2.0
+data Version = Version [Int]
+             deriving (Data,Eq,Ord,Generic,Show,Read,Typeable)
+
+instance Binary Version
+
+instance NFData Version where
+    rnf = rnf . unVersion
+
+instance Text Version where
+  disp ver
+    = Disp.hcat (Disp.punctuate (Disp.char '.')
+                                (map Disp.int $ unVersion ver))
+
+  parse = do
+      branch <- Parse.sepBy1 parseNat (Parse.char '.')
+                -- allow but ignore tags:
+      _tags  <- Parse.many (Parse.char '-' >> Parse.munch1 isAlphaNum)
+      return (mkVersion branch)
+    where
+      parseNat = read `fmap` Parse.munch1 isDigit
+
+-- | Construct 'Version' from list of version number components.
+--
+-- For instance, @mkVersion [3,2,1]@ constructs a 'Version'
+-- representing the version @3.2.1@.
+--
+-- All version components must be non-negative. @mkVersion []@
+-- represents the special /null/ version; see also 'mkNullVersion' and
+-- 'nullVersion'.
+--
+-- @since 2.0
+mkVersion :: [Int] -> Version
+-- TODO: add validity check; disallow 'mkVersion []' (we have
+-- 'mkNullVersion' for that)
+mkVersion = Version
+
+-- | Variant of 'Version' which converts a "Data.Version" 'Version'
+-- into Cabal's 'Version' type.
+--
+-- @since 2.0
+mkVersion' :: Base.Version -> Version
+mkVersion' = mkVersion . Base.versionBranch
+
+-- | Unpack 'Version' into list of version number components.
+--
+-- This is the inverse to 'mkVersion', so the following holds:
+--
+-- > (unVersion . mkVersion) vs == vs
+--
+-- @since 2.0
+unVersion :: Version -> [Int]
+unVersion (Version vs) = vs
+
+-- | Constant representing the /null/ 'Version'
+--
+-- @since 2.0
+mkNullVersion :: Version
+-- TODO: at some point, 'mkVersion' may disallow creating /null/
+-- 'Version's
+mkNullVersion = Version []
+
+-- | Test whether 'Version' value is /null/ 'Version'
+--
+-- @since 2.0
+nullVersion :: Version -> Bool
+nullVersion = null . unVersion
+
+-- functor-like helper
+withVersion :: ([Int] -> [Int]) -> Version -> Version
+withVersion f = mkVersion . f . unVersion
+
+-- internal helper
+validVersion :: Version -> Bool
+validVersion v = not (nullVersion v) && all (>=0) (unVersion v)
 
 -- -----------------------------------------------------------------------------
 -- Version ranges
@@ -135,24 +201,6 @@ data VersionRange
 instance Binary VersionRange
 
 instance NFData VersionRange where rnf = genericRnf
-
-#if __GLASGOW_HASKELL__ < 707
--- starting with ghc-7.7/base-4.7 this instance is provided in "Data.Data"
-deriving instance Data Version
-#endif
-
-#if !(MIN_VERSION_binary_0_8_0)
--- Deriving this instance from Generic gives trouble on GHC 7.2 because the
--- Generic instance has to be standalone-derived. So, we hand-roll our own.
--- We can't use a generic Binary instance on later versions because we must
--- maintain compatibility between compiler versions.
-instance Binary Version where
-    get = do
-        br <- get
-        tags <- get
-        return $ Version br tags
-    put (Version br tags) = put br >> put tags
-#endif
 
 {-# DeprecateD AnyVersion
     "Use 'anyVersion', 'foldVersionRange' or 'asVersionIntervals'" #-}
@@ -186,7 +234,7 @@ anyVersion = AnyVersion
 --
 noVersion :: VersionRange
 noVersion = IntersectVersionRanges (LaterVersion v) (EarlierVersion v)
-  where v = Version [1] []
+  where v = mkVersion [1]
 
 -- | The version range @== v@
 --
@@ -417,9 +465,9 @@ foldVersionRange' anyv this later earlier orLater orEarlier
 withinRange :: Version -> VersionRange -> Bool
 withinRange v = foldVersionRange
                    True
-                   (\v'  -> versionBranch v == versionBranch v')
-                   (\v'  -> versionBranch v >  versionBranch v')
-                   (\v'  -> versionBranch v <  versionBranch v')
+                   (\v'  -> v == v')
+                   (\v'  -> v >  v')
+                   (\v'  -> v <  v')
                    (||)
                    (&&)
 
@@ -516,12 +564,11 @@ simplifyVersionRange vr
 --
 
 wildcardUpperBound :: Version -> Version
-wildcardUpperBound (Version lowerBound ts) = Version upperBound ts
-  where
-    upperBound = init lowerBound ++ [last lowerBound + 1]
+wildcardUpperBound = withVersion $
+    \lowerBound -> init lowerBound ++ [last lowerBound + 1]
 
 isWildcardRange :: Version -> Version -> Bool
-isWildcardRange (Version branch1 _) (Version branch2 _) = check branch1 branch2
+isWildcardRange ver1 ver2 = check (unVersion ver1) (unVersion ver2)
   where check (n:[]) (m:[]) | n+1 == m = True
         check (n:ns) (m:ms) | n   == m = check ns ms
         check _      _                 = False
@@ -531,12 +578,10 @@ isWildcardRange (Version branch1 _) (Version branch2 _) = check branch1 branch2
 -- Example: @0.4.1@ produces the version @0.5@ which then can be used
 -- to construct a range @>= 0.4.1 && < 0.5@
 majorUpperBound :: Version -> Version
-majorUpperBound version = version { versionBranch = upperBound }
-  where
-    upperBound = case versionBranch version of
-      []        -> [0,1] -- should not happen
-      [m1]      -> [m1,1] -- e.g. version '1'
-      (m1:m2:_) -> [m1,m2+1]
+majorUpperBound = withVersion $ \ver -> case ver of
+    []        -> [0,1] -- should not happen
+    [m1]      -> [m1,1] -- e.g. version '1'
+    (m1:m2:_) -> [m1,m2+1]
 
 ------------------
 -- Intervals view
@@ -568,11 +613,10 @@ data UpperBound = NoUpperBound | UpperBound Version !Bound deriving (Eq, Show)
 data Bound      = ExclusiveBound | InclusiveBound          deriving (Eq, Show)
 
 minLowerBound :: LowerBound
-minLowerBound = LowerBound (Version [0] []) InclusiveBound
+minLowerBound = LowerBound (mkVersion [0]) InclusiveBound
 
 isVersion0 :: Version -> Bool
-isVersion0 (Version [0] _) = True
-isVersion0 _               = False
+isVersion0 = (== mkVersion [0])
 
 instance Ord LowerBound where
   LowerBound ver bound <= LowerBound ver' bound' = case compare ver ver' of
@@ -613,10 +657,6 @@ mkVersionIntervals :: [VersionInterval] -> Maybe VersionIntervals
 mkVersionIntervals intervals
   | invariant (VersionIntervals intervals) = Just (VersionIntervals intervals)
   | otherwise                              = Nothing
-
-validVersion :: Version -> Bool
-validVersion (Version [] _) = False
-validVersion (Version vs _) = all (>=0) vs
 
 validInterval :: (LowerBound, UpperBound) -> Bool
 validInterval i@(l, u) = validLower l && validUpper u && nonEmpty i
@@ -823,7 +863,7 @@ invertVersionIntervals (VersionIntervals xs) =
       invertBound InclusiveBound = ExclusiveBound
 
       noLowerBound :: LowerBound
-      noLowerBound = LowerBound (Version [0] []) InclusiveBound
+      noLowerBound = LowerBound (mkVersion [0]) InclusiveBound
 
 -------------------------------
 -- Parsing and pretty printing
@@ -846,8 +886,9 @@ instance Text VersionRange where
              (punct 1 p1 r1 <+> Disp.text "&&" <+> punct 1 p2 r2 , 1))
            (\(r, _)   -> (Disp.parens r, 0))
 
-    where dispWild (Version b _) =
-               Disp.hcat (Disp.punctuate (Disp.char '.') (map Disp.int b))
+    where dispWild ver =
+               Disp.hcat (Disp.punctuate (Disp.char '.')
+                                         (map Disp.int $ unVersion ver))
             <<>> Disp.text ".*"
           punct p p' | p < p'    = Disp.parens
                      | otherwise = id
@@ -885,7 +926,7 @@ instance Text VersionRange where
           branch <- Parse.sepBy1 digits (Parse.char '.')
           _ <- Parse.char '.'
           _ <- Parse.char '*'
-          return (WildcardVersion (Version branch []))
+          return (WildcardVersion (mkVersion branch))
 
         parens p = Parse.between (Parse.char '(' >> Parse.skipSpaces)
                                  (Parse.char ')' >> Parse.skipSpaces)

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -49,6 +49,9 @@
 	* Backwards incompatible change to 'PackageName' (#3896):
 	  'PackageName' is now opaque; conversion to/from 'String' now works
 	  via (old) 'unPackageName' and (new) 'mkPackageName' functions.
+	* Backwards incompatible change to 'Version' (#3905):
+	  Version is now opaque; conversion to/from '[Int]' now works
+	  via 'versionNumbers' and 'mkVersion' functions.
 	* Add support for `--allow-older` (dual to `--allow-newer`) (#3466)
 	* Improved an error message for process output decoding errors
 	(#3408).

--- a/Cabal/tests/PackageTests/BenchmarkStanza/Check.hs
+++ b/Cabal/tests/PackageTests/BenchmarkStanza/Check.hs
@@ -15,7 +15,7 @@ suite = do
     lbi <- liftIO $ getPersistBuildConfig dist_dir
     let anticipatedBenchmark = emptyBenchmark
             { benchmarkName = "dummy"
-            , benchmarkInterface = BenchmarkExeV10 (Version [1,0] [])
+            , benchmarkInterface = BenchmarkExeV10 (mkVersion [1,0])
                                                    "dummy.hs"
             , benchmarkBuildInfo = emptyBuildInfo
                     { targetBuildDepends =

--- a/Cabal/tests/PackageTests/CaretOperator/Check.hs
+++ b/Cabal/tests/PackageTests/CaretOperator/Check.hs
@@ -21,9 +21,9 @@ suite = do
                { defaultLanguage = Just Haskell2010
                , targetBuildDepends =
                      [ Dependency (mkPackageName "base")
-                       (withinVersion (Version [4] []))
+                       (withinVersion (mkVersion [4]))
                      , Dependency (mkPackageName "pretty")
-                       (majorBoundVersion (Version [1,1,1,0] []))
+                       (majorBoundVersion (mkVersion [1,1,1,0]))
                      ]
                , hsSourceDirs = ["."]
                }

--- a/Cabal/tests/PackageTests/DeterministicAr/Check.hs
+++ b/Cabal/tests/PackageTests/DeterministicAr/Check.hs
@@ -12,7 +12,7 @@ import System.IO
 
 import Distribution.Compiler              (CompilerFlavor(..), CompilerId(..))
 import Distribution.Package               (getHSLibraryName)
-import Distribution.Version               (Version(..))
+import Distribution.Version               (mkVersion)
 import Distribution.Simple.Compiler       (compilerId)
 import Distribution.Simple.LocalBuildInfo (LocalBuildInfo, compiler, localUnitId)
 
@@ -31,7 +31,7 @@ checkMetadata lbi dir = withBinaryFile path ReadMode $ \ h -> do
     path = dir </> "lib" ++ getHSLibraryName (localUnitId lbi) ++ ".a"
 
     _ghc_7_10 = case compilerId (compiler lbi) of
-      CompilerId GHC version | version >= Version [7, 10] [] -> True
+      CompilerId GHC version | version >= mkVersion [7, 10]  -> True
       _                                                      -> False
 
     checkError msg = assertFailure (

--- a/Cabal/tests/PackageTests/PackageTester.hs
+++ b/Cabal/tests/PackageTests/PackageTester.hs
@@ -99,6 +99,8 @@ import Distribution.Simple.Utils
 import Distribution.Simple.Configure
     ( getPersistBuildConfig )
 import Distribution.Verbosity (Verbosity)
+import Distribution.Version
+
 import Distribution.Simple.BuildPaths (exeExtension)
 
 import Distribution.Simple.Utils (cabalVersion)
@@ -115,7 +117,6 @@ import Control.Monad.Trans.Writer
 import Control.Monad.IO.Class
 import qualified Data.ByteString.Char8 as C
 import Data.List
-import Data.Version
 import System.Directory
     ( doesFileExist, canonicalizePath, createDirectoryIfMissing
     , removeDirectoryRecursive, getPermissions, setPermissions
@@ -481,7 +482,7 @@ rawCompileSetup verbosity suite e path = do
 
 ghcPackageDBParams :: Version -> PackageDBStack -> [String]
 ghcPackageDBParams ghc_version dbs
-    | ghc_version >= Version [7,6] []
+    | ghc_version >= mkVersion [7,6]
     = "-clear-package-db" : map convert dbs
     | otherwise
     = concatMap convertLegacy dbs
@@ -519,7 +520,7 @@ ghcPkgPackageDBParams version dbs = concatMap convert dbs where
     convert  GlobalPackageDB         = []
     convert  UserPackageDB           = []
     convert (SpecificPackageDB path)
-        | version >= Version [7,6] []
+        | version >= mkVersion [7,6]
         = ["--package-db=" ++ path]
         | otherwise
         = ["--package-conf=" ++ path]
@@ -733,7 +734,7 @@ ghcFileModDelay = do
     -- the granularity of the underlying filesystem.
     -- TODO: cite commit when GHC got better precision; this
     -- version bound was empirically generated.
-    let delay | withGhcVersion suite < Version [7,7] []
+    let delay | withGhcVersion suite < mkVersion [7,7]
               = 1000000 -- 1s
               | otherwise
               = mtimeChangeDelay suite
@@ -808,7 +809,7 @@ unlessWindows = testUnless (buildOS == Windows)
 
 hasSharedLibraries :: SuiteConfig -> Bool
 hasSharedLibraries config =
-    buildOS /= Windows || withGhcVersion config < Version [7,8] []
+    buildOS /= Windows || withGhcVersion config < mkVersion [7,8]
 
 hasCabalForGhc :: SuiteConfig -> Bool
 hasCabalForGhc config =

--- a/Cabal/tests/PackageTests/TestStanza/Check.hs
+++ b/Cabal/tests/PackageTests/TestStanza/Check.hs
@@ -15,7 +15,7 @@ suite = do
     lbi <- liftIO $ getPersistBuildConfig dist_dir
     let anticipatedTestSuite = emptyTestSuite
             { testName = "dummy"
-            , testInterface = TestSuiteExeV10 (Version [1,0] []) "dummy.hs"
+            , testInterface = TestSuiteExeV10 (mkVersion [1,0]) "dummy.hs"
             , testBuildInfo = emptyBuildInfo
                     { targetBuildDepends =
                             [ Dependency (mkPackageName "base") anyVersion ]

--- a/Cabal/tests/PackageTests/TestSuiteTests/ExeV10/Check.hs
+++ b/Cabal/tests/PackageTests/TestSuiteTests/ExeV10/Check.hs
@@ -16,7 +16,7 @@ import Distribution.Simple.Program.Db
     ( emptyProgramDb, configureProgram, requireProgramVersion )
 import Distribution.Text (display)
 import qualified Distribution.Verbosity as Verbosity
-import Distribution.Version (Version(..), orLaterVersion)
+import Distribution.Version (mkVersion, orLaterVersion)
 
 import PackageTests.PackageTester
 
@@ -96,7 +96,7 @@ hpcTestMatrix config = forM_ (choose4 [True, False]) $
             let way = guessWay lbi
                 CompilerId comp version = compilerId (compiler lbi)
                 subdir
-                  | comp == GHC && version >= Version [7, 10] [] =
+                  | comp == GHC && version >= mkVersion [7, 10] =
                       localCompatPackageKey lbi
                   | otherwise = display (localPackage lbi)
             mapM_ shouldExist
@@ -119,7 +119,7 @@ correctHpcVersion :: IO Bool
 correctHpcVersion = do
     let programDb' = emptyProgramDb
     let verbosity = Verbosity.normal
-    let verRange  = orLaterVersion (Version [0,7] [])
+    let verRange  = orLaterVersion (mkVersion [0,7])
     programDb <- configureProgram verbosity hpcProgram programDb'
     (requireProgramVersion verbosity hpcProgram verRange programDb
      >> return True) `catchIO` (\_ -> return False)

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -21,11 +21,11 @@ import Distribution.Simple.InstallDirs ( CopyDest(NoCopyDest) )
 import Distribution.Simple.BuildPaths  ( mkLibName, mkSharedLibName )
 import Distribution.Simple.Compiler    ( compilerId )
 import Distribution.System (buildOS, OS(Windows))
+import Distribution.Version
 
 import Control.Monad
 
 import System.Directory
-import Data.Version
 import Test.Tasty (mkTimeout, localOption)
 
 tests :: SuiteConfig -> TestTreeM ()
@@ -206,7 +206,7 @@ tests config = do
   tc "OrderFlags" $ cabal_build []
 
   -- Test that reexported modules build correctly
-  tc "ReexportedModules" . whenGhcVersion (>= Version [7,9] []) $ do
+  tc "ReexportedModules" . whenGhcVersion (>= mkVersion [7,9]) $ do
       withPackageDb $ do
         withPackage "p" $ cabal_install []
         withPackage "q" $ do

--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -580,7 +580,7 @@ equivalentVersionRange vr1 vr2 =
   let allVersionsUsed = nub (sort (versionsUsed vr1 ++ versionsUsed vr2))
       minPoint = mkVersion [0]
       maxPoint | null allVersionsUsed = minPoint
-               | otherwise = mkVersion . (++[1]) . versionNumbers . maximum $ allVersionsUsed
+               | otherwise = alterVersion (++[1]) (maximum allVersionsUsed)
       probeVersions = minPoint : maxPoint
                     : intermediateVersions allVersionsUsed
 

--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -104,7 +104,9 @@ versionTests =
 --     -- , property prop_parse_disp5
 --   ]
 
-#if !MIN_VERSION_QuickCheck(2,9,0)
+adjustSize :: (Int -> Int) -> Gen a -> Gen a
+adjustSize adjust gen = sized (\n -> resize (adjust n) gen)
+
 instance Arbitrary Version where
   arbitrary = do
     branch <- smallListOf1 $
@@ -112,15 +114,12 @@ instance Arbitrary Version where
                           ,(3, return 1)
                           ,(2, return 2)
                           ,(1, return 3)]
-    return (Version branch []) -- deliberate []
+    return (mkVersion branch) -- deliberate []
     where
       smallListOf1 = adjustSize (\n -> min 5 (n `div` 3)) . listOf1
 
-  shrink (Version branch []) =
-    [ Version branch' [] | branch' <- shrink branch, not (null branch') ]
-  shrink (Version branch _tags) =
-    [ Version branch [] ]
-#endif
+  shrink ver = [ mkVersion branch' | branch' <- shrink (unVersion ver)
+                                   , not (null branch') ]
 
 instance Arbitrary VersionRange where
   arbitrary = sized verRangeExp
@@ -153,7 +152,7 @@ instance Arbitrary VersionRange where
 --
 
 prop_nonNull :: Version -> Bool
-prop_nonNull = not . null . versionBranch
+prop_nonNull = not . nullVersion
 
 prop_anyVersion :: Version -> Bool
 prop_anyVersion v' =
@@ -218,7 +217,9 @@ prop_withinVersion v v' =
      withinRange v' (withinVersion v)
   == (v' >= v && v' < upper v)
   where
-    upper (Version lower t) = Version (init lower ++ [last lower + 1]) t
+    upper vlower = mkVersion (init lower ++ [last lower + 1])
+      where
+        lower = unVersion vlower
 
 prop_foldVersionRange :: VersionRange -> Bool
 prop_foldVersionRange range =
@@ -231,7 +232,9 @@ prop_foldVersionRange range =
     expandWildcard (WildcardVersion v) =
         intersectVersionRanges (orLaterVersion v) (earlierVersion (upper v))
       where
-        upper (Version lower t) = Version (init lower ++ [last lower + 1]) t
+        upper vlower = mkVersion (init lower ++ [last lower + 1])
+          where
+            lower = unVersion vlower
 
     expandWildcard (UnionVersionRanges     v1 v2) =
       UnionVersionRanges (expandWildcard v1) (expandWildcard v2)
@@ -581,10 +584,9 @@ prop_equivalentVersionRange range range' version =
 equivalentVersionRange :: VersionRange -> VersionRange -> Bool
 equivalentVersionRange vr1 vr2 =
   let allVersionsUsed = nub (sort (versionsUsed vr1 ++ versionsUsed vr2))
-      minPoint = Version [0] []
+      minPoint = mkVersion [0]
       maxPoint | null allVersionsUsed = minPoint
-               | otherwise = case maximum allVersionsUsed of
-                   Version vs _ -> Version (vs ++ [1]) []
+               | otherwise = mkVersion . (++[1]) . unVersion . maximum $ allVersionsUsed
       probeVersions = minPoint : maxPoint
                     : intermediateVersions allVersionsUsed
 
@@ -598,8 +600,8 @@ equivalentVersionRange vr1 vr2 =
 
 intermediateVersion :: Version -> Version -> Version
 intermediateVersion v1 v2 | v1 >= v2 = error "intermediateVersion: v1 >= v2"
-intermediateVersion (Version v1 _) (Version v2 _) =
-  Version (intermediateList v1 v2) []
+intermediateVersion v1 v2 =
+  mkVersion (intermediateList (unVersion v1) (unVersion v2))
   where
     intermediateList :: [Int] -> [Int] -> [Int]
     intermediateList []     (_:_) = [0]
@@ -617,8 +619,10 @@ prop_intermediateVersion v1 v2 =
           in v1 > v && v > v2
 
 adjacentVersions :: Version -> Version -> Bool
-adjacentVersions (Version v1 _) (Version v2 _) = v1 ++ [0] == v2
-                                              || v2 ++ [0] == v1
+adjacentVersions ver1 ver2 = v1 ++ [0] == v2 || v2 ++ [0] == v1
+  where
+    v1 = unVersion ver1
+    v2 = unVersion ver2
 
 --------------------------------
 -- Parsing and pretty printing
@@ -721,6 +725,7 @@ displayRaw =
      (\r     -> Disp.parens r) -- parens
 
   where
-    dispWild (Version b _) =
-           Disp.hcat (Disp.punctuate (Disp.char '.') (map Disp.int b))
+    dispWild v =
+           Disp.hcat (Disp.punctuate (Disp.char '.')
+                                     (map Disp.int (unVersion v)))
         <> Disp.text ".*"

--- a/cabal-install/Distribution/Client/BuildReports/Anonymous.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Anonymous.hs
@@ -37,8 +37,8 @@ import Distribution.Package
          ( PackageIdentifier(..), mkPackageName )
 import Distribution.PackageDescription
          ( FlagName(..), FlagAssignment )
---import Distribution.Version
---         ( Version )
+import Distribution.Version
+         ( mkVersion' )
 import Distribution.System
          ( OS, Arch )
 import Distribution.Compiler
@@ -159,7 +159,8 @@ new os' arch' comp pkgid flags deps result =
 
 cabalInstallID :: PackageIdentifier
 cabalInstallID =
-  PackageIdentifier (mkPackageName "cabal-install") Paths_cabal_install.version
+  PackageIdentifier (mkPackageName "cabal-install")
+                    (mkVersion' Paths_cabal_install.version)
 
 -- ------------------------------------------------------------
 -- * External format

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -84,7 +84,7 @@ import Distribution.Client.HttpUtils
 import qualified Distribution.ParseUtils as ParseUtils
          ( Field(..) )
 import qualified Distribution.Text as Text
-         ( Text(..) )
+         ( Text(..), display )
 import Distribution.Simple.Command
          ( CommandUI(commandOptions), commandDefaultFlags, ShowOrParseArgs(..)
          , viewAsFieldDescr )
@@ -676,7 +676,7 @@ writeConfigFile file comments vals = do
       ,"-- Be careful with spaces and indentation because they are"
       ,"-- used to indicate layout for nested sections."
       ,""
-      ,"-- Cabal library version: " ++ showVersion cabalVersion
+      ,"-- Cabal library version: " ++ Text.display cabalVersion
       ,"-- cabal-install version: " ++ showVersion Paths_cabal_install.version
       ,"",""
       ]

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -72,7 +72,8 @@ import Distribution.PackageDescription.Parse
 import Distribution.PackageDescription.Configuration
          ( finalizePD )
 import Distribution.Version
-         ( anyVersion, thisVersion )
+         ( Version, mkVersion, anyVersion, thisVersion
+         , VersionRange, orLaterVersion )
 import Distribution.Simple.Utils as Utils
          ( warn, notice, debug, die )
 import Distribution.Simple.Setup
@@ -82,8 +83,6 @@ import Distribution.System
 import Distribution.Text ( display )
 import Distribution.Verbosity as Verbosity
          ( Verbosity )
-import Distribution.Version
-         ( Version(..), VersionRange, orLaterVersion )
 
 import System.FilePath ( (</>) )
 
@@ -101,7 +100,7 @@ chooseCabalVersion configFlags maybeVersion =
                  (maybe RelaxDepsNone unAllowOlder $ configAllowOlder configFlags)
 
     defaultVersionRange = if allowOlder || allowNewer
-                          then orLaterVersion (Version [1,19,2] [])
+                          then orLaterVersion (mkVersion [1,19,2])
                           else anyVersion
 
 -- | Configure the package found in the local directory

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -84,7 +84,7 @@ import Distribution.PackageDescription.Configuration
 import Distribution.Client.PackageUtils
          ( externalBuildDepends )
 import Distribution.Version
-         ( Version(..), VersionRange, anyVersion, thisVersion, orLaterVersion
+         ( mkVersion, VersionRange, anyVersion, thisVersion, orLaterVersion
          , withinRange, simplifyVersionRange
          , removeLowerBound, removeUpperBound )
 import Distribution.Compiler
@@ -521,7 +521,7 @@ standardInstallPolicy installedPkgIndex sourcePkgDb pkgSpecifiers
       mkDefaultSetupDeps :: UnresolvedSourcePackage -> Maybe [Dependency]
       mkDefaultSetupDeps srcpkg | affected        =
         Just [Dependency (mkPackageName "Cabal")
-              (orLaterVersion $ Version [1,24] [])]
+              (orLaterVersion $ mkVersion [1,24])]
                                 | otherwise       = Nothing
         where
           gpkgdesc = packageDescription srcpkg

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -61,8 +61,6 @@ import Distribution.Verbosity
          ( Verbosity )
 
 import qualified Data.ByteString.Lazy.Char8 as BS.Char8
-import Data.Version
-         ( showVersion )
 import Distribution.Version
          ( thisVersion )
 
@@ -260,4 +258,4 @@ formatPkgs = map $ showPkg . packageId
   where
     showPkg pid = name pid ++ " == " ++ version pid
     name = display . packageName
-    version = showVersion . packageVersion
+    version = display . packageVersion

--- a/cabal-install/Distribution/Client/GenBounds.hs
+++ b/cabal-install/Distribution/Client/GenBounds.hs
@@ -14,8 +14,6 @@ module Distribution.Client.GenBounds (
     genBounds
   ) where
 
-import Data.Version
-         ( Version(..), showVersion )
 import Distribution.Client.Init
          ( incVersion )
 import Distribution.Client.Freeze
@@ -43,10 +41,13 @@ import Distribution.Simple.Utils
          ( tryFindPackageDesc )
 import Distribution.System
          ( Platform )
+import Distribution.Text
+         ( display )
 import Distribution.Verbosity
          ( Verbosity )
 import Distribution.Version
-         ( LowerBound(..), UpperBound(..), VersionRange(..), asVersionIntervals
+         ( Version, mkVersion, unVersion
+         , LowerBound(..), UpperBound(..), VersionRange(..), asVersionIntervals
          , orLaterVersion, earlierVersion, intersectVersionRanges )
 import System.Directory
          ( getCurrentDirectory )
@@ -71,7 +72,7 @@ pvpize v = orLaterVersion (vn 3)
            `intersectVersionRanges`
            earlierVersion (incVersion 1 (vn 2))
   where
-    vn n = (v { versionBranch = take n (versionBranch v) })
+    vn n = mkVersion . take n . unVersion $ v
 
 -- | Show the PVP-mandated version range for this package. The @padTo@ parameter
 -- specifies the width of the package name column.
@@ -87,7 +88,7 @@ showBounds padTo p = unwords $
     showInterval (LowerBound _ _, NoUpperBound) =
       error "Error: expected upper bound...this should never happen!"
     showInterval (LowerBound l _, UpperBound u _) =
-      unwords [">=", showVersion l, "&& <", showVersion u]
+      unwords [">=", display l, "&& <", display u]
 
 -- | Entry point for the @gen-bounds@ command.
 genBounds

--- a/cabal-install/Distribution/Client/GenBounds.hs
+++ b/cabal-install/Distribution/Client/GenBounds.hs
@@ -46,7 +46,7 @@ import Distribution.Text
 import Distribution.Verbosity
          ( Verbosity )
 import Distribution.Version
-         ( Version, mkVersion, unVersion
+         ( Version, alterVersion
          , LowerBound(..), UpperBound(..), VersionRange(..), asVersionIntervals
          , orLaterVersion, earlierVersion, intersectVersionRanges )
 import System.Directory
@@ -72,7 +72,7 @@ pvpize v = orLaterVersion (vn 3)
            `intersectVersionRanges`
            earlierVersion (incVersion 1 (vn 2))
   where
-    vn n = mkVersion . take n . unVersion $ v
+    vn n = alterVersion (take n) v
 
 -- | Show the PVP-mandated version range for this package. The @padTo@ parameter
 -- specifies the width of the package name column.

--- a/cabal-install/Distribution/Client/Haddock.hs
+++ b/cabal-install/Distribution/Client/Haddock.hs
@@ -25,7 +25,7 @@ import Distribution.Package
 import Distribution.Simple.Haddock (haddockPackagePaths)
 import Distribution.Simple.Program (haddockProgram, ProgramDb
                                    , runProgram, requireProgramVersion)
-import Distribution.Version (Version(Version), orLaterVersion)
+import Distribution.Version (mkVersion, orLaterVersion)
 import Distribution.Verbosity (Verbosity)
 import Distribution.Simple.PackageIndex
          ( InstalledPackageIndex, allPackagesByName )
@@ -45,7 +45,7 @@ regenerateHaddockIndex verbosity pkgs progdb index = do
 
       (confHaddock, _, _) <-
           requireProgramVersion verbosity haddockProgram
-                                    (orLaterVersion (Version [0,6] [])) progdb
+                                    (orLaterVersion (mkVersion [0,6])) progdb
 
       createDirectoryIfMissing True destDir
 

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -65,7 +65,7 @@ import qualified Distribution.Simple.Configure as Configure
 import Distribution.ParseUtils
          ( ParseResult(..) )
 import Distribution.Version
-         ( Version(Version), intersectVersionRanges )
+         ( mkVersion, intersectVersionRanges )
 import Distribution.Text
          ( display, simpleParse )
 import Distribution.Verbosity
@@ -880,7 +880,7 @@ read00IndexCacheEntry = \line ->
         Just (v, str') -> case BSS.uncons str' of
           Just ('.', str'') -> parseVer str'' (v:vs)
           Just _            -> Nothing
-          Nothing           -> Just (Version (reverse (v:vs)) [])
+          Nothing           -> Just (mkVersion (reverse (v:vs)))
 
     parseBlockNo str =
       case BSS.readInt str of

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -47,10 +47,9 @@ import Control.Arrow
 
 import Text.PrettyPrint hiding (mode, cat)
 
-import Data.Version
-  ( Version(..) )
 import Distribution.Version
-  ( orLaterVersion, earlierVersion, intersectVersionRanges, VersionRange )
+  ( Version, mkVersion, unVersion
+  , orLaterVersion, earlierVersion, intersectVersionRanges, VersionRange )
 import Distribution.Verbosity
   ( Verbosity )
 import Distribution.ModuleName
@@ -195,7 +194,7 @@ getPackageName sourcePkgDb flags = do
 --  if possible.
 getVersion :: InitFlags -> IO InitFlags
 getVersion flags = do
-  let v = Just $ Version [0,1,0,0] []
+  let v = Just $ mkVersion [0,1,0,0]
   v' <-     return (flagToMaybe $ version flags)
         ?>> maybePrompt flags (prompt "Package version" v)
         ?>> return v
@@ -477,11 +476,11 @@ pvpize :: Version -> VersionRange
 pvpize v = orLaterVersion v'
            `intersectVersionRanges`
            earlierVersion (incVersion 1 v')
-  where v' = (v { versionBranch = take 2 (versionBranch v) })
+  where v' = mkVersion . take 2 . unVersion $ v
 
 -- | Increment the nth version component (counting from 0).
 incVersion :: Int -> Version -> Version
-incVersion n (Version vlist tags) = Version (incVersion' n vlist) tags
+incVersion n = mkVersion . incVersion' n . unVersion
   where
     incVersion' 0 []     = [1]
     incVersion' 0 (v:_)  = [v+1]
@@ -620,28 +619,28 @@ writeLicense flags = do
           Flag BSD3
             -> Just $ bsd3 authors year
 
-          Flag (GPL (Just (Version {versionBranch = [2]})))
+          Flag (GPL (Just v)) | v == mkVersion [2]
             -> Just gplv2
 
-          Flag (GPL (Just (Version {versionBranch = [3]})))
+          Flag (GPL (Just v)) | v == mkVersion [2]
             -> Just gplv3
 
-          Flag (LGPL (Just (Version {versionBranch = [2, 1]})))
+          Flag (LGPL (Just v)) | v == mkVersion [2,1]
             -> Just lgpl21
 
-          Flag (LGPL (Just (Version {versionBranch = [3]})))
+          Flag (LGPL (Just v)) | v == mkVersion [3]
             -> Just lgpl3
 
-          Flag (AGPL (Just (Version {versionBranch = [3]})))
+          Flag (AGPL (Just v)) | v == mkVersion [3]
             -> Just agplv3
 
-          Flag (Apache (Just (Version {versionBranch = [2, 0]})))
+          Flag (Apache (Just v)) | v == mkVersion [2,0]
             -> Just apache20
 
           Flag MIT
             -> Just $ mit authors year
 
-          Flag (MPL (Version {versionBranch = [2, 0]}))
+          Flag (MPL v) | v == mkVersion [2,0]
             -> Just mpl20
 
           Flag ISC
@@ -845,7 +844,7 @@ generateCabalFile fileName c =
                 (Just "Extra files to be distributed with the package, such as examples or a README.")
                 True
 
-       , field  "cabal-version" (Flag $ orLaterVersion (Version [1,10] []))
+       , field  "cabal-version" (Flag $ orLaterVersion (mkVersion [1,10]))
                 (Just "Constraint on the version of Cabal needed to build this package.")
                 False
 

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -48,7 +48,7 @@ import Control.Arrow
 import Text.PrettyPrint hiding (mode, cat)
 
 import Distribution.Version
-  ( Version, mkVersion, unVersion
+  ( Version, mkVersion, alterVersion
   , orLaterVersion, earlierVersion, intersectVersionRanges, VersionRange )
 import Distribution.Verbosity
   ( Verbosity )
@@ -476,11 +476,11 @@ pvpize :: Version -> VersionRange
 pvpize v = orLaterVersion v'
            `intersectVersionRanges`
            earlierVersion (incVersion 1 v')
-  where v' = mkVersion . take 2 . unVersion $ v
+  where v' = alterVersion (take 2) v
 
 -- | Increment the nth version component (counting from 0).
 incVersion :: Int -> Version -> Version
-incVersion n = mkVersion . incVersion' n . unVersion
+incVersion n = alterVersion (incVersion' n)
   where
     incVersion' 0 []     = [1]
     incVersion' 0 (v:_)  = [v+1]

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -35,7 +35,7 @@ import Distribution.Simple.Setup (fromFlag)
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import qualified Distribution.Simple.PackageIndex as InstalledPackageIndex
 import Distribution.Version
-         ( Version, mkVersion, unVersion, VersionRange, withinRange, anyVersion
+         ( Version, mkVersion, versionNumbers, VersionRange, withinRange, anyVersion
          , intersectVersionRanges, simplifyVersionRange )
 import Distribution.Verbosity (Verbosity)
 import Distribution.Text
@@ -576,7 +576,7 @@ interestingVersions pref =
     . reorderTree (\(Node (v,_) _) -> pref (mkVersion v))
     . reverseTree
     . mkTree
-    . map unVersion
+    . map versionNumbers
 
   where
     swizzleTree = unfoldTree (spine [])

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -35,7 +35,7 @@ import Distribution.Simple.Setup (fromFlag)
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import qualified Distribution.Simple.PackageIndex as InstalledPackageIndex
 import Distribution.Version
-         ( Version(..), VersionRange, withinRange, anyVersion
+         ( Version, mkVersion, unVersion, VersionRange, withinRange, anyVersion
          , intersectVersionRanges, simplifyVersionRange )
 import Distribution.Verbosity (Verbosity)
 import Distribution.Text
@@ -570,13 +570,13 @@ dispTopVersions n pref vs =
 --
 interestingVersions :: (Version -> Bool) -> [Version] -> [Version]
 interestingVersions pref =
-      map ((\ns -> Version ns []) . fst) . filter snd
+      map (mkVersion . fst) . filter snd
     . concat  . Tree.levels
     . swizzleTree
-    . reorderTree (\(Node (v,_) _) -> pref (Version v []))
+    . reorderTree (\(Node (v,_) _) -> pref (mkVersion v))
     . reverseTree
     . mkTree
-    . map versionBranch
+    . map unVersion
 
   where
     swizzleTree = unfoldTree (spine [])

--- a/cabal-install/Distribution/Client/PackageHash.hs
+++ b/cabal-install/Distribution/Client/PackageHash.hs
@@ -41,6 +41,7 @@ import Distribution.Simple.InstallDirs
          ( PathTemplate, fromPathTemplate )
 import Distribution.Text
          ( display )
+import Distribution.Version
 import Distribution.Client.Types
          ( InstalledPackageId )
 import qualified Distribution.Solver.Types.ComponentDeps as CD
@@ -59,7 +60,6 @@ import Data.Maybe        (catMaybes)
 import Data.List         (sortBy, intercalate)
 import Data.Map          (Map)
 import Data.Function     (on)
-import Data.Version      (Version)
 import Distribution.Compat.Binary (Binary(..))
 import Control.Exception (evaluate)
 import System.IO         (withBinaryFile, IOMode(..))

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -1195,7 +1195,7 @@ buildInplaceUnpackedPackage verbosity
                         "back on recursive file scan."
                     filter (not . ("dist" `isPrefixOf`))
                         `fmap` getDirectoryContentsRecursive srcdir
-            in if elabSetupScriptCliVersion pkg >= Version [1,17] []
+            in if elabSetupScriptCliVersion pkg >= mkVersion [1,17]
                   then do r <- trySdist
                           if null r
                             then tryFallback

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1072,9 +1072,9 @@ elaborateInstallPlan platform compiler compilerprogdb pkgConfigDB
                        -- per component (instead of glomming them altogether
                        -- and distributing to everything.)  I didn't feel
                        -- like implementing the legacy behavior.
-                       && PD.specVersion pd >= Version [1,7,1] []
+                       && PD.specVersion pd >= mkVersion [1,7,1]
                       )
-                    || PD.specVersion pd >= Version [2,0,0] []
+                    || PD.specVersion pd >= mkVersion [2,0,0]
             in map InstallPlan.Configured $ if eligible
                 then elaborateSolverToComponents mapDep pkg
                 else [elaborateSolverToPackage mapDep pkg]
@@ -2178,13 +2178,13 @@ defaultSetupDeps compiler platform pkg =
           -- constraints, we constrain them to use a compatible Cabal version.
           -- The exact version where we'll make this API break has not yet been
           -- decided, so for the meantime we guess at 2.x.
-          cabalCompatMaxVer = Version [2] []
+          cabalCompatMaxVer = mkVersion [2]
           -- In principle we can talk to any old Cabal version, and we need to
           -- be able to do that for custom Setup scripts that require older
           -- Cabal lib versions. However in practice we have currently have
           -- problems with Cabal-1.16. (1.16 does not know about build targets)
           -- If this is fixed we can relax this constraint.
-          cabalCompatMinVer = Version [1,18] []
+          cabalCompatMinVer = mkVersion [1,18]
 
       -- For other build types (like Simple) if we still need to compile an
       -- external Setup.hs, it'll be one of the simple ones that only depends
@@ -2470,7 +2470,7 @@ setupHsBuildFlags _ _ verbosity builddir =
 setupHsBuildArgs :: ElaboratedConfiguredPackage -> [String]
 setupHsBuildArgs elab@(ElaboratedConfiguredPackage { elabPkgOrComp = ElabPackage _ })
     -- Fix for #3335, don't pass build arguments if it's not supported
-    | elabSetupScriptCliVersion elab >= Version [1,17] []
+    | elabSetupScriptCliVersion elab >= mkVersion [1,17]
     = map (showComponentTarget (packageId elab)) (elabBuildTargets elab)
     | otherwise
     = []

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -98,7 +98,7 @@ import Distribution.Simple.InstallDirs
          ( PathTemplate, InstallDirs(sysconfdir)
          , toPathTemplate, fromPathTemplate )
 import Distribution.Version
-         ( Version(Version), anyVersion, thisVersion )
+         ( Version, mkVersion, nullVersion, anyVersion, thisVersion )
 import Distribution.Package
          ( PackageIdentifier, packageName, packageVersion, Dependency(..) )
 import Distribution.PackageDescription
@@ -363,22 +363,22 @@ filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
   -- NB: we expect the latest version to be the most common case,
   -- so test it first.
-  | cabalLibVersion >= Version [1,23,0] [] = flags_latest
+  | cabalLibVersion >= mkVersion [1,23,0] = flags_latest
   -- The naming convention is that flags_version gives flags with
   -- all flags *introduced* in version eliminated.
   -- It is NOT the latest version of Cabal library that
   -- these flags work for; version of introduction is a more
   -- natural metric.
-  | cabalLibVersion <  Version [1,3,10] [] = flags_1_3_10
-  | cabalLibVersion <  Version [1,10,0] [] = flags_1_10_0
-  | cabalLibVersion <  Version [1,12,0] [] = flags_1_12_0
-  | cabalLibVersion <  Version [1,14,0] [] = flags_1_14_0
-  | cabalLibVersion <  Version [1,18,0] [] = flags_1_18_0
-  | cabalLibVersion <  Version [1,19,1] [] = flags_1_19_1
-  | cabalLibVersion <  Version [1,19,2] [] = flags_1_19_2
-  | cabalLibVersion <  Version [1,21,1] [] = flags_1_21_1
-  | cabalLibVersion <  Version [1,22,0] [] = flags_1_22_0
-  | cabalLibVersion <  Version [1,23,0] [] = flags_1_23_0
+  | cabalLibVersion < mkVersion [1,3,10] = flags_1_3_10
+  | cabalLibVersion < mkVersion [1,10,0] = flags_1_10_0
+  | cabalLibVersion < mkVersion [1,12,0] = flags_1_12_0
+  | cabalLibVersion < mkVersion [1,14,0] = flags_1_14_0
+  | cabalLibVersion < mkVersion [1,18,0] = flags_1_18_0
+  | cabalLibVersion < mkVersion [1,19,1] = flags_1_19_1
+  | cabalLibVersion < mkVersion [1,19,2] = flags_1_19_2
+  | cabalLibVersion < mkVersion [1,21,1] = flags_1_21_1
+  | cabalLibVersion < mkVersion [1,22,0] = flags_1_22_0
+  | cabalLibVersion < mkVersion [1,23,0] = flags_1_23_0
   | otherwise = flags_latest
   where
     flags_latest = flags        {
@@ -2233,8 +2233,8 @@ parseDependencyOrPackageId = parse Parse.+++ liftM pkgidToDependency parse
   where
     pkgidToDependency :: PackageIdentifier -> Dependency
     pkgidToDependency p = case packageVersion p of
-      Version [] _ -> Dependency (packageName p) anyVersion
-      version      -> Dependency (packageName p) (thisVersion version)
+      v | nullVersion v -> Dependency (packageName p) anyVersion
+        | otherwise     -> Dependency (packageName p) (thisVersion v)
 
 showRepo :: RemoteRepo -> String
 showRepo repo = remoteRepoName repo ++ ":"

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2233,8 +2233,8 @@ parseDependencyOrPackageId = parse Parse.+++ liftM pkgidToDependency parse
   where
     pkgidToDependency :: PackageIdentifier -> Dependency
     pkgidToDependency p = case packageVersion p of
-      v | nullVersion v -> Dependency (packageName p) anyVersion
-        | otherwise     -> Dependency (packageName p) (thisVersion v)
+      v | v == nullVersion -> Dependency (packageName p) anyVersion
+        | otherwise        -> Dependency (packageName p) (thisVersion v)
 
 showRepo :: RemoteRepo -> String
 showRepo repo = remoteRepoName repo ++ ":"

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -27,7 +27,7 @@ import Distribution.Client.Compat.Prelude
 import qualified Distribution.Make as Make
 import qualified Distribution.Simple as Simple
 import Distribution.Version
-         ( Version, mkVersion, unVersion, VersionRange, anyVersion
+         ( Version, mkVersion, versionNumbers, VersionRange, anyVersion
          , intersectVersionRanges, orLaterVersion
          , withinRange )
 import Distribution.Package
@@ -701,8 +701,8 @@ getExternalSetupMethod verbosity options pkg bt = do
         where
           sameVersion      = version == cabalVersion
           sameMajorVersion = majorVersion version == majorVersion cabalVersion
-          majorVersion     = take 2 . unVersion
-          stableVersion    = case unVersion version of
+          majorVersion     = take 2 . versionNumbers
+          stableVersion    = case versionNumbers version of
                                (_:x:_) -> even x
                                _       -> False
           latestVersion    = version

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -27,7 +27,7 @@ import Distribution.Client.Compat.Prelude
 import qualified Distribution.Make as Make
 import qualified Distribution.Simple as Simple
 import Distribution.Version
-         ( Version(..), VersionRange, anyVersion
+         ( Version, mkVersion, unVersion, VersionRange, anyVersion
          , intersectVersionRanges, orLaterVersion
          , withinRange )
 import Distribution.Package
@@ -654,7 +654,7 @@ getExternalSetupMethod verbosity options pkg bt = do
   buildTypeScript cabalLibVersion = case bt of
     Simple    -> "import Distribution.Simple; main = defaultMain\n"
     Configure -> "import Distribution.Simple; main = defaultMainWithHooks "
-              ++ if cabalLibVersion >= Version [1,3,10] []
+              ++ if cabalLibVersion >= mkVersion [1,3,10]
                    then "autoconfUserHooks\n"
                    else "defaultUserHooks\n"
     Make      -> "import Distribution.Make; main = defaultMain\n"
@@ -701,8 +701,8 @@ getExternalSetupMethod verbosity options pkg bt = do
         where
           sameVersion      = version == cabalVersion
           sameMajorVersion = majorVersion version == majorVersion cabalVersion
-          majorVersion     = take 2 . versionBranch
-          stableVersion    = case versionBranch version of
+          majorVersion     = take 2 . unVersion
+          stableVersion    = case unVersion version of
                                (_:x:_) -> even x
                                _       -> False
           latestVersion    = version

--- a/cabal-install/Distribution/Client/SrcDist.hs
+++ b/cabal-install/Distribution/Client/SrcDist.hs
@@ -34,7 +34,7 @@ import Distribution.Simple.Program (requireProgram, simpleProgram, programPath)
 import Distribution.Simple.Program.Db (emptyProgramDb)
 import Distribution.Text ( display )
 import Distribution.Verbosity (Verbosity, normal, lessVerbose)
-import Distribution.Version   (Version(..), orLaterVersion, intersectVersionRanges)
+import Distribution.Version   (mkVersion, orLaterVersion, intersectVersionRanges)
 
 import Distribution.Client.Utils
   (tryFindAddSourcePackageDesc)
@@ -96,8 +96,8 @@ sdist flags exflags = do
       -- The '--output-directory' sdist flag was introduced in Cabal 1.12, and
       -- '--list-sources' in 1.17.
       useCabalVersion = if isListSources
-                        then orLaterVersion $ Version [1,17,0] []
-                        else orLaterVersion $ Version [1,12,0] []
+                        then orLaterVersion $ mkVersion [1,17,0]
+                        else orLaterVersion $ mkVersion [1,12,0]
       }
     format        = fromFlag (sDistFormat exflags)
     createArchive = case format of
@@ -168,7 +168,7 @@ allPackageSourceFiles verbosity setupOpts0 packageDir = do
       setupOpts = setupOpts0 {
         -- 'sdist --list-sources' was introduced in Cabal 1.18.
         useCabalVersion = intersectVersionRanges
-                            (orLaterVersion $ Version [1,18,0] [])
+                            (orLaterVersion $ mkVersion [1,18,0])
                             (useCabalVersion setupOpts0),
         useWorkingDir = Just packageDir
         }

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -83,7 +83,7 @@ import Distribution.PackageDescription
 import Distribution.PackageDescription.Parse
          ( readPackageDescription, parsePackageDescription, ParseResult(..) )
 import Distribution.Version
-         ( Version(Version), thisVersion, anyVersion, isAnyVersion
+         ( nullVersion, thisVersion, anyVersion, isAnyVersion
          , VersionRange )
 import Distribution.Text
          ( Text(..), display )
@@ -298,8 +298,8 @@ readUserTarget targetstr =
       where
         pkgidToDependency :: PackageIdentifier -> Dependency
         pkgidToDependency p = case packageVersion p of
-          Version [] _ -> Dependency (packageName p) anyVersion
-          version      -> Dependency (packageName p) (thisVersion version)
+          v | nullVersion v -> Dependency (packageName p) anyVersion
+            | otherwise     -> Dependency (packageName p) (thisVersion v)
 
 readPToMaybe :: Parse.ReadP a a -> String -> Maybe a
 readPToMaybe p str = listToMaybe [ r | (r,s) <- Parse.readP_to_S p str

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -298,8 +298,8 @@ readUserTarget targetstr =
       where
         pkgidToDependency :: PackageIdentifier -> Dependency
         pkgidToDependency p = case packageVersion p of
-          v | nullVersion v -> Dependency (packageName p) anyVersion
-            | otherwise     -> Dependency (packageName p) (thisVersion v)
+          v | v == nullVersion -> Dependency (packageName p) anyVersion
+            | otherwise        -> Dependency (packageName p) (thisVersion v)
 
 readPToMaybe :: Parse.ReadP a a -> String -> Maybe a
 readPToMaybe p str = listToMaybe [ r | (r,s) <- Parse.readP_to_S p str

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -11,7 +11,7 @@ module Distribution.Solver.Modular.Solver
 import Data.Map as M
 import Data.List as L
 import Data.Set as S
-import Data.Version
+import Distribution.Version
 
 import Distribution.Compiler (CompilerInfo)
 
@@ -249,4 +249,4 @@ _removeGR = trav go
    dummy :: QGoalReason
    dummy = PDependency
          $ PI (Q (PackagePath DefaultNamespace Unqualified) (mkPackageName "$"))
-              (I (Version [1] []) InRepo)
+              (I (mkVersion [1]) InRepo)

--- a/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
@@ -33,7 +33,7 @@ import Distribution.Package
 import Distribution.Verbosity
     ( Verbosity )
 import Distribution.Version
-    ( Version, VersionRange, withinRange )
+    ( Version, mkVersion', VersionRange, withinRange )
 
 import Distribution.Compat.Environment
     ( lookupEnv )
@@ -86,7 +86,7 @@ pkgConfigDbFromList pairs = (PkgConfigDb . M.fromList . map convert) pairs
       convert :: (String, String) -> (PackageName, Maybe Version)
       convert (n,vs) = (mkPackageName n,
                         case (reverse . readP_to_S parseVersion) vs of
-                          (v, "") : _ -> Just v
+                          (v, "") : _ -> Just (mkVersion' v)
                           _           -> Nothing -- Version not (fully)
                                                  -- understood.
                        )

--- a/cabal-install/Main.hs
+++ b/cabal-install/Main.hs
@@ -160,7 +160,7 @@ import Distribution.Text
 import Distribution.Verbosity as Verbosity
          ( Verbosity, normal )
 import Distribution.Version
-         ( Version(..), orLaterVersion )
+         ( Version, mkVersion, orLaterVersion )
 import qualified Paths_cabal_install (version)
 
 import System.Environment       (getArgs, getProgName)
@@ -425,7 +425,7 @@ build verbosity config distPref buildFlags extraArgs =
 -- old versions of Cabal.
 filterBuildFlags :: Version -> SavedConfig -> BuildFlags -> BuildFlags
 filterBuildFlags version config buildFlags
-  | version >= Version [1,19,1] [] = buildFlags_latest
+  | version >= mkVersion [1,19,1] = buildFlags_latest
   -- Cabal < 1.19.1 doesn't support 'build -j'.
   | otherwise                      = buildFlags_pre_1_19_1
   where
@@ -467,7 +467,7 @@ replAction (replFlags, buildExFlags) extraArgs globalFlags = do
         mempty [] globalFlags config
       let progDb = defaultProgramDb
           setupOptions = defaultSetupScriptOptions
-            { useCabalVersion = orLaterVersion $ Version [1,18,0] []
+            { useCabalVersion = orLaterVersion $ mkVersion [1,18,0]
             , useDistPref     = distPref
             }
           replFlags'   = replFlags

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -115,7 +115,7 @@ testExceptionInConfigureStep config = do
     cleanProject testdir
   where
     testdir = "exception/configure"
-    pkgidA1 = PackageIdentifier (mkPackageName "a") (Version [1] [])
+    pkgidA1 = PackageIdentifier (mkPackageName "a") (mkVersion [1])
 
 
 testExceptionInBuildStep :: ProjectConfig -> Assertion
@@ -125,7 +125,7 @@ testExceptionInBuildStep config = do
     expectBuildFailed failure
   where
     testdir = "exception/build"
-    pkgidA1 = PackageIdentifier (mkPackageName "a") (Version [1] [])
+    pkgidA1 = PackageIdentifier (mkPackageName "a") (mkVersion [1])
 
 testSetupScriptStyles :: ProjectConfig -> (String -> IO ()) -> Assertion
 testSetupScriptStyles config reportSubCase = do
@@ -167,7 +167,7 @@ testSetupScriptStyles config reportSubCase = do
     testdir1 = "build/setup-custom1"
     testdir2 = "build/setup-custom2"
     testdir3 = "build/setup-simple"
-    pkgidA   = PackageIdentifier (mkPackageName "a") (Version [0,1] [])
+    pkgidA   = PackageIdentifier (mkPackageName "a") (mkVersion [0,1])
     -- The solver fills in default setup deps explicitly, but marks them as such
     hasDefaultSetupDeps = fmap defaultSetupDepends
                         . setupBuildInfo . elabPkgDescription
@@ -192,8 +192,8 @@ testBuildKeepGoing config = do
     return ()
   where
     testdir = "build/keep-going"
-    pkgidP  = PackageIdentifier (mkPackageName "p") (Version [0,1] [])
-    pkgidQ  = PackageIdentifier (mkPackageName "q") (Version [0,1] [])
+    pkgidP  = PackageIdentifier (mkPackageName "p") (mkVersion [0,1])
+    pkgidQ  = PackageIdentifier (mkPackageName "q") (mkVersion [0,1])
     keepGoing kg =
       mempty {
         projectConfigBuildOnly = mempty {
@@ -220,8 +220,8 @@ testRegressionIssue3324 config = do
       return ()
   where
     testdir = "regression/3324"
-    pkgidP  = PackageIdentifier (mkPackageName "p") (Version [0,1] [])
-    pkgidQ  = PackageIdentifier (mkPackageName "q") (Version [0,1] [])
+    pkgidP  = PackageIdentifier (mkPackageName "p") (mkVersion [0,1])
+    pkgidQ  = PackageIdentifier (mkPackageName "q") (mkVersion [0,1])
 
 
 ---------------------------------

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -76,10 +76,10 @@ instance Arbitrary Version where
                           ,(3, return 1)
                           ,(2, return 2)
                           ,(1, return 3)]
-    return (mkVersion branch) -- deliberate []
+    return (mkVersion branch)
     where
 
-  shrink ver = [ mkVersion branch' | branch' <- shrink (unVersion ver)
+  shrink ver = [ mkVersion branch' | branch' <- shrink (versionNumbers ver)
                                    , not (null branch') ]
 
 instance Arbitrary VersionRange where

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -69,7 +69,6 @@ instance Arbitrary ShortToken where
 arbitraryShortToken :: Gen String
 arbitraryShortToken = getShortToken <$> arbitrary
 
-#if !MIN_VERSION_QuickCheck(2,9,0)
 instance Arbitrary Version where
   arbitrary = do
     branch <- shortListOf1 4 $
@@ -77,14 +76,11 @@ instance Arbitrary Version where
                           ,(3, return 1)
                           ,(2, return 2)
                           ,(1, return 3)]
-    return (Version branch []) -- deliberate []
+    return (mkVersion branch) -- deliberate []
     where
 
-  shrink (Version branch []) =
-    [ Version branch' [] | branch' <- shrink branch, not (null branch') ]
-  shrink (Version branch _tags) =
-    [ Version branch [] ]
-#endif
+  shrink ver = [ mkVersion branch' | branch' <- shrink (unVersion ver)
+                                   , not (null branch') ]
 
 instance Arbitrary VersionRange where
   arbitrary = canonicaliseVersionRange <$> sized verRangeExp

--- a/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
@@ -195,7 +195,7 @@ arbitraryTestInstallPlan = do
         deps   = map mkUnitIdV depvs
     mkUnitIdV = mkUnitId . show
     mkPkgId v = PackageIdentifier (mkPackageName ("pkg" ++ show v))
-                                  (Version [1] [])
+                                  (mkVersion [1])
 
 
 -- | Generate a random 'InstallPlan' following the structure of an existing

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -76,7 +76,7 @@ tests =
   where
     usingGhc76orOlder =
       case buildCompilerId of
-        CompilerId GHC v -> v < Version [7,7] []
+        CompilerId GHC v -> v < mkVersion [7,7]
         _                -> False
 
 

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -33,7 +33,6 @@ import Data.Maybe (catMaybes, isNothing)
 import Data.List (elemIndex, nub)
 import Data.Monoid
 import Data.Ord (comparing)
-import Data.Version
 import qualified Data.Map as Map
 
 -- Cabal
@@ -357,7 +356,7 @@ exAvSrcPkg ex =
     mkDirect (dep, Nothing) = C.Dependency (C.mkPackageName dep) C.anyVersion
     mkDirect (dep, Just n)  = C.Dependency (C.mkPackageName dep) (C.thisVersion v)
       where
-        v = Version [n, 0, 0] []
+        v = C.mkVersion [n, 0, 0]
 
     mkFlagged :: Monoid a
               => (a -> a)
@@ -432,7 +431,7 @@ exAvSrcPkg ex =
 exAvPkgId :: ExampleAvailable -> C.PackageIdentifier
 exAvPkgId ex = C.PackageIdentifier {
       pkgName    = C.mkPackageName (exAvName ex)
-    , pkgVersion = Version [exAvVersion ex, 0, 0] []
+    , pkgVersion = C.mkVersion [exAvVersion ex, 0, 0]
     }
 
 exInstInfo :: ExampleInstalled -> C.InstalledPackageInfo
@@ -445,7 +444,7 @@ exInstInfo ex = C.emptyInstalledPackageInfo {
 exInstPkgId :: ExampleInstalled -> C.PackageIdentifier
 exInstPkgId ex = C.PackageIdentifier {
       pkgName    = C.mkPackageName (exInstName ex)
-    , pkgVersion = Version [exInstVersion ex, 0, 0] []
+    , pkgVersion = C.mkVersion [exInstVersion ex, 0, 0]
     }
 
 exAvIdx :: [ExampleAvailable] -> CI.PackageIndex.PackageIndex UnresolvedSourcePackage
@@ -531,9 +530,9 @@ extractInstallPlan = catMaybes . map confPkg . CI.SolverInstallPlan.toList
 
     srcPkg :: SolverPackage UnresolvedPkgLoc -> (String, Int)
     srcPkg cpkg =
-      let C.PackageIdentifier pn (Version (n:_) _) =
+      let C.PackageIdentifier pn ver = -- (Version (n:_) _) =
             packageInfoId (solverPkgSource cpkg)
-      in (C.unPackageName pn, n)
+      in (C.unPackageName pn, head (C.unVersion ver))
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -530,9 +530,8 @@ extractInstallPlan = catMaybes . map confPkg . CI.SolverInstallPlan.toList
 
     srcPkg :: SolverPackage UnresolvedPkgLoc -> (String, Int)
     srcPkg cpkg =
-      let C.PackageIdentifier pn ver = -- (Version (n:_) _) =
-            packageInfoId (solverPkgSource cpkg)
-      in (C.unPackageName pn, head (C.unVersion ver))
+      let C.PackageIdentifier pn ver = packageInfoId (solverPkgSource cpkg)
+      in (C.unPackageName pn, head (C.versionNumbers ver))
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -8,7 +8,6 @@ module UnitTests.Distribution.Solver.Modular.Solver (tests)
 -- base
 import Data.List (isInfixOf)
 
-import qualified Data.Version         as V
 import qualified Distribution.Version as V
 
 -- test-framework
@@ -183,7 +182,7 @@ tests = [
     soft prefs test = test { testSoftConstraints = prefs }
     mkvrThis        = V.thisVersion . makeV
     mkvrOrEarlier   = V.orEarlierVersion . makeV
-    makeV v         = V.Version [v,0,0] []
+    makeV v         = V.mkVersion [v,0,0]
 
 -- | Combinator to turn on --independent-goals behavior, i.e. solve
 -- for the goals as if we were solving for each goal independently.


### PR DESCRIPTION
Similiar to dabd9d9837539dfb3a7647ace074a3e2df14cc3b which made
`PackageName` opaque, this makes `Distribution.Version.Version` opaque.

The most common version numbers occuring on Hackage are 3- and
4-component version. This results in significant Heap overhead due to
`Data.Version`'s inefficient internal representation.

So like the `PackageName` commit, this commit is a preparatory commit to
pave the way for replacing `Version`'s internal representation by a
representation with a memory footprint which can be an order of
magnitude smaller.