### PR TITLE
Fix reexported-modules display mangling.

### DIFF
--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -181,11 +181,11 @@ data ExposedModule
 
 instance Text ExposedModule where
     disp (ExposedModule m reexport) =
-        Disp.sep [ disp m
-                 , case reexport of
-                    Just m' -> Disp.sep [Disp.text "from", disp m']
-                    Nothing -> Disp.empty
-                 ]
+        Disp.hsep [ disp m
+                  , case reexport of
+                     Just m' -> Disp.hsep [Disp.text "from", disp m']
+                     Nothing -> Disp.empty
+                  ]
     parse = do
         m <- parseModuleNameQ
         Parse.skipSpaces


### PR DESCRIPTION
sep allows for horizontal separation, which is absolutely
not what we want.  Use hcat instead.  Thanks @stepcut
for reporting.

I'd like this to merge to 1.24 too, if the bug is present there.