### PR TITLE
Don't solve for executables in legacy install codepath.

### DIFF
--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -107,6 +107,7 @@ import Distribution.Client.JobControl
 
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ConstraintSource
+import           Distribution.Solver.Types.Settings
 import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import qualified Distribution.Solver.Types.PackageIndex as SourcePackageIndex
@@ -422,6 +423,10 @@ planPackages comp platform mSandboxPkgInfo solver
       . maybe id applySandboxInstallPolicy mSandboxPkgInfo
 
       . (if reinstall then reinstallTargets else id)
+
+        -- Don't solve for executables, the legacy install codepath
+        -- doesn't understand how to install them
+      . setSolveExecutables (SolveExecutables False)
 
       $ standardInstallPolicy
         installedPkgIndex sourcePkgDb pkgSpecifiers


### PR DESCRIPTION
In 9e99b3f49911028edc1c2be8152002a6a3b7ad3c I turned of executable
solving for legacy configure, but I forgot to turn it off for legacy
install too, which lead to assertion failures.

Fixes #3912.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>