### PR TITLE
Fix reexported-modules display mangling.

### DIFF
--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -187,11 +187,11 @@ instance Text OriginalModule where
 
 instance Text ExposedModule where
     disp (ExposedModule m reexport) =
-        Disp.sep [ disp m
-                 , case reexport of
-                    Just m' -> Disp.sep [Disp.text "from", disp m']
-                    Nothing -> Disp.empty
-                 ]
+        Disp.hsep [ disp m
+                  , case reexport of
+                     Just m' -> Disp.hsep [Disp.text "from", disp m']
+                     Nothing -> Disp.empty
+                  ]
     parse = do
         m <- parseModuleNameQ
         Parse.skipSpaces


### PR DESCRIPTION
sep allows for horizontal separation, which is absolutely
not what we want.  Use hcat instead.  Thanks @stepcut
for reporting.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>