### PR TITLE
Add unit tests for solver stanza preferences.

### DIFF
--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -153,7 +153,9 @@ exFlag :: ExampleFlagName -> [ExampleDependency] -> [ExampleDependency]
        -> ExampleDependency
 exFlag n t e = ExFlag n (Buildable t) (Buildable e)
 
-data ExPreference = ExPref String ExampleVersionRange
+data ExPreference =
+    ExPkgPref ExamplePkgName ExampleVersionRange
+  | ExStanzaPref ExamplePkgName [OptionalStanza]
 
 data ExampleAvailable = ExAv {
     exAvName    :: ExamplePkgName
@@ -502,7 +504,9 @@ exResolve db exts langs pkgConfigDb targets solver mbj indepGoals reorder
                    $ setGoalOrder goalOrder
                    $ standardInstallPolicy instIdx avaiIdx targets'
     toLpc     pc = LabeledPackageConstraint pc ConstraintSourceUnknown
-    toPref (ExPref n v) = PackageVersionPreference (C.mkPackageName n) v
+
+    toPref (ExPkgPref n v)          = PackageVersionPreference (C.mkPackageName n) v
+    toPref (ExStanzaPref n stanzas) = PackageStanzasPreference (C.mkPackageName n) stanzas
 
     goalOrder :: Maybe (Variable P.QPN -> Variable P.QPN -> Ordering)
     goalOrder = (orderFromList . map toVariable) `fmap` vars

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -106,7 +106,7 @@ solve enableBj reorder indep solver targets (TestDb db) =
                   -- The backjump limit prevents individual tests from using
                   -- too much time and memory.
                   (Just defaultMaxBackjumps)
-                  indep reorder enableBj Nothing []
+                  indep reorder enableBj Nothing [] (EnableAllTests True)
 
       failure :: String -> Failure
       failure msg

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -110,7 +110,7 @@ tests = [
         , runTest $ mkTestLangs [Haskell98, Haskell2010, UnknownLanguage "Haskell3000"] dbLangs1 "supportedUnknown" ["C"] (solverSuccess [("A",1),("B",1),("C",1)])
         ]
 
-     , testGroup "Soft Constraints" [
+     , testGroup "Package Preferences" [
           runTest $ preferences [ ExPkgPref "A" $ mkvrThis 1]      $ mkTest db13 "selectPreferredVersionSimple" ["A"] (solverSuccess [("A", 1)])
         , runTest $ preferences [ ExPkgPref "A" $ mkvrOrEarlier 2] $ mkTest db13 "selectPreferredVersionSimple2" ["A"] (solverSuccess [("A", 2)])
         , runTest $ preferences [ ExPkgPref "A" $ mkvrOrEarlier 2
@@ -121,6 +121,19 @@ tests = [
                                 , ExPkgPref "A" $ mkvrThis 2] $ mkTest db13 "selectPreferredVersionMultiple3" ["A"] (solverSuccess [("A", 2)])
         , runTest $ preferences [ ExPkgPref "A" $ mkvrThis 1
                                 , ExPkgPref "A" $ mkvrOrEarlier 2] $ mkTest db13 "selectPreferredVersionMultiple4" ["A"] (solverSuccess [("A", 1)])
+        ]
+     , testGroup "Stanza Preferences" [
+          runTest $
+          mkTest dbStanzaPreferences1 "disable tests by default" ["pkg"] $
+          solverSuccess [("pkg", 1)]
+
+        , runTest $ preferences [ExStanzaPref "pkg" [TestStanzas]] $
+          mkTest dbStanzaPreferences1 "enable tests with testing preference" ["pkg"] $
+          solverSuccess [("pkg", 1), ("test-dep", 1)]
+
+        , runTest $ preferences [ExStanzaPref "pkg" [TestStanzas]] $
+          mkTest dbStanzaPreferences2 "disable testing when it's not possible" ["pkg"] $
+          solverSuccess [("pkg", 1)]
         ]
      , testGroup "Buildable Field" [
           testBuildable "avoid building component with unknown dependency" (ExAny "unknown")
@@ -609,6 +622,17 @@ db13 = [
     Right $ exAv "A" 1 []
   , Right $ exAv "A" 2 []
   , Right $ exAv "A" 3 []
+  ]
+
+dbStanzaPreferences1 :: ExampleDb
+dbStanzaPreferences1 = [
+    Right $ exAv "pkg" 1 [] `withTest` ExTest "test" [ExAny "test-dep"]
+  , Right $ exAv "test-dep" 1 []
+  ]
+
+dbStanzaPreferences2 :: ExampleDb
+dbStanzaPreferences2 = [
+    Right $ exAv "pkg" 1 [] `withTest` ExTest "test" [ExAny "unknown"]
   ]
 
 -- | Database with some cycles

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -111,16 +111,16 @@ tests = [
         ]
 
      , testGroup "Soft Constraints" [
-          runTest $ soft [ ExPref "A" $ mkvrThis 1]      $ mkTest db13 "selectPreferredVersionSimple" ["A"] (solverSuccess [("A", 1)])
-        , runTest $ soft [ ExPref "A" $ mkvrOrEarlier 2] $ mkTest db13 "selectPreferredVersionSimple2" ["A"] (solverSuccess [("A", 2)])
-        , runTest $ soft [ ExPref "A" $ mkvrOrEarlier 2
-                         , ExPref "A" $ mkvrOrEarlier 1] $ mkTest db13 "selectPreferredVersionMultiple" ["A"] (solverSuccess [("A", 1)])
-        , runTest $ soft [ ExPref "A" $ mkvrOrEarlier 1
-                         , ExPref "A" $ mkvrOrEarlier 2] $ mkTest db13 "selectPreferredVersionMultiple2" ["A"] (solverSuccess [("A", 1)])
-        , runTest $ soft [ ExPref "A" $ mkvrThis 1
-                         , ExPref "A" $ mkvrThis 2] $ mkTest db13 "selectPreferredVersionMultiple3" ["A"] (solverSuccess [("A", 2)])
-        , runTest $ soft [ ExPref "A" $ mkvrThis 1
-                         , ExPref "A" $ mkvrOrEarlier 2] $ mkTest db13 "selectPreferredVersionMultiple4" ["A"] (solverSuccess [("A", 1)])
+          runTest $ preferences [ ExPkgPref "A" $ mkvrThis 1]      $ mkTest db13 "selectPreferredVersionSimple" ["A"] (solverSuccess [("A", 1)])
+        , runTest $ preferences [ ExPkgPref "A" $ mkvrOrEarlier 2] $ mkTest db13 "selectPreferredVersionSimple2" ["A"] (solverSuccess [("A", 2)])
+        , runTest $ preferences [ ExPkgPref "A" $ mkvrOrEarlier 2
+                                , ExPkgPref "A" $ mkvrOrEarlier 1] $ mkTest db13 "selectPreferredVersionMultiple" ["A"] (solverSuccess [("A", 1)])
+        , runTest $ preferences [ ExPkgPref "A" $ mkvrOrEarlier 1
+                                , ExPkgPref "A" $ mkvrOrEarlier 2] $ mkTest db13 "selectPreferredVersionMultiple2" ["A"] (solverSuccess [("A", 1)])
+        , runTest $ preferences [ ExPkgPref "A" $ mkvrThis 1
+                                , ExPkgPref "A" $ mkvrThis 2] $ mkTest db13 "selectPreferredVersionMultiple3" ["A"] (solverSuccess [("A", 2)])
+        , runTest $ preferences [ ExPkgPref "A" $ mkvrThis 1
+                                , ExPkgPref "A" $ mkvrOrEarlier 2] $ mkTest db13 "selectPreferredVersionMultiple4" ["A"] (solverSuccess [("A", 1)])
         ]
      , testGroup "Buildable Field" [
           testBuildable "avoid building component with unknown dependency" (ExAny "unknown")
@@ -179,7 +179,6 @@ tests = [
         ]
     ]
   where
-    soft prefs test = test { testSoftConstraints = prefs }
     mkvrThis        = V.thisVersion . makeV
     mkvrOrEarlier   = V.orEarlierVersion . makeV
     makeV v         = V.mkVersion [v,0,0]
@@ -191,6 +190,9 @@ indep test = test { testIndepGoals = IndependentGoals True }
 
 goalOrder :: [ExampleVar] -> SolverTest -> SolverTest
 goalOrder order test = test { testGoalOrder = Just order }
+
+preferences :: [ExPreference] -> SolverTest -> SolverTest
+preferences prefs test = test { testSoftConstraints = prefs }
 
 data GoalOrder = FixedGoalOrder | DefaultGoalOrder
 


### PR DESCRIPTION
I added some unit tests while trying to reproduce a bug.

I also had to change the solver DSL so that it no longer enables all packages' tests by default.  I added a function (mkTestEnableAllTests) to enable tests in the existing unit tests that relied on that behavior.