### PR TITLE
GHC environments (v2)

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -736,6 +736,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
                                               && ghcVersion < mkVersion [7,8]
                                             then toFlag sharedLibInstallPath
                                             else mempty,
+                ghcOptHideAllPackages    = toFlag True,
                 ghcOptNoAutoLinkPackages = toFlag True,
                 ghcOptPackageDBs         = withPackageDB lbi,
                 ghcOptThisUnitId = case clbi of

--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -66,7 +66,7 @@ ghcVersionImplInfo ver = GhcImplInfo
   , flagProfAuto         = v >= [7,4]
   , flagPackageConf      = v <  [7,5]
   , flagDebugInfo        = v >= [7,10]
-  , supportsPkgEnvFiles  = v >= [8,0,2] -- broken in 8.0.1, fixed in 8.0.2
+  , supportsPkgEnvFiles  = v >= [8,0,1,20160901] -- broken in 8.0.1, fixed in 8.0.2
   }
   where
     v = versionNumbers ver

--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -41,6 +41,7 @@ data GhcImplInfo = GhcImplInfo
   , flagProfAuto         :: Bool -- ^ new style -fprof-auto* flags
   , flagPackageConf      :: Bool -- ^ use package-conf instead of package-db
   , flagDebugInfo        :: Bool -- ^ -g flag supported
+  , supportsPkgEnvFiles  :: Bool -- ^ picks up @.ghc.environment@ files
   }
 
 getImplInfo :: Compiler -> GhcImplInfo
@@ -65,12 +66,15 @@ ghcVersionImplInfo ver = GhcImplInfo
   , flagProfAuto         = v >= [7,4]
   , flagPackageConf      = v <  [7,5]
   , flagDebugInfo        = v >= [7,10]
+  , supportsPkgEnvFiles  = v >= [8,0,2] -- broken in 8.0.1, fixed in 8.0.2
   }
   where
     v = versionNumbers ver
 
-ghcjsVersionImplInfo :: Version -> Version -> GhcImplInfo
-ghcjsVersionImplInfo _ghcjsVer _ghcVer = GhcImplInfo
+ghcjsVersionImplInfo :: Version  -- ^ The GHCJS version
+                     -> Version  -- ^ The GHC version
+                     -> GhcImplInfo
+ghcjsVersionImplInfo _ghcjsver ghcver = GhcImplInfo
   { supportsHaskell2010  = True
   , reportsNoExt         = True
   , alwaysNondecIndent   = False
@@ -78,7 +82,10 @@ ghcjsVersionImplInfo _ghcjsVer _ghcVer = GhcImplInfo
   , flagProfAuto         = True
   , flagPackageConf      = False
   , flagDebugInfo        = False
+  , supportsPkgEnvFiles  = ghcv >= [8,0,2] --TODO: check this works in ghcjs
   }
+  where
+    ghcv = versionNumbers ghcver
 
 lhcVersionImplInfo :: Version -> GhcImplInfo
 lhcVersionImplInfo = ghcVersionImplInfo

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -193,8 +193,11 @@ configureToolchain _implInfo ghcProg ghcInfo =
              withTempFile tempDir ".o" $ \testofile testohnd -> do
                hPutStrLn testchnd "int foo() { return 0; }"
                hClose testchnd; hClose testohnd
-               runProgram verbosity ghcProg ["-c", testcfile,
-                                             "-o", testofile]
+               runProgram verbosity ghcProg
+                          [ "-hide-all-packages"
+                          , "-c", testcfile
+                          , "-o", testofile
+                          ]
                withTempFile tempDir ".o" $ \testofile' testohnd' ->
                  do
                    hClose testohnd'
@@ -271,6 +274,7 @@ componentCcGhcOptions verbosity _implInfo lbi bi clbi odir filename =
                                           ,autogenPackageModulesDir lbi
                                           ,odir]
                                           ++ PD.includeDirs bi,
+      ghcOptHideAllPackages= toFlag True,
       ghcOptPackageDBs     = withPackageDB lbi,
       ghcOptPackages       = toNubListR $ mkGhcOptPackages clbi,
       ghcOptCcOptions      = toNubListR $
@@ -294,7 +298,6 @@ componentGhcOptions verbosity lbi bi clbi odir =
       -- Respect -v0, but don't crank up verbosity on GHC if
       -- Cabal verbosity is requested. For that, use --ghc-option=-v instead!
       ghcOptVerbosity       = toFlag (min verbosity normal),
-      ghcOptHideAllPackages = toFlag True,
       ghcOptCabal           = toFlag True,
       ghcOptThisUnitId      = case clbi of
         LibComponentLocalBuildInfo { componentCompatPackageKey = pk }
@@ -312,6 +315,7 @@ componentGhcOptions verbosity lbi bi clbi odir =
           -> insts
         _ -> [],
       ghcOptNoCode          = toFlag $ componentIsIndefinite clbi,
+      ghcOptHideAllPackages = toFlag True,
       ghcOptPackageDBs      = withPackageDB lbi,
       ghcOptPackages        = toNubListR $ mkGhcOptPackages clbi,
       ghcOptSplitObjs       = toFlag (splitObjs lbi),

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -273,18 +273,22 @@ runProjectPostBuildPhase _ ProjectBuildContext {buildSettings} _
 runProjectPostBuildPhase verbosity ProjectBuildContext {..} buildOutcomes = do
     -- Update other build artefacts
     -- TODO: currently none, but could include:
-    --        - .ghc.environment
     --        - bin symlinks/wrappers
     --        - haddock/hoogle/ctags indexes
     --        - delete stale lib registrations
     --        - delete stale package dirs
 
-    _postBuildStatus <- updatePostBuildProjectStatus
+    postBuildStatus <- updatePostBuildProjectStatus
                          verbosity
                          distDirLayout
                          elaboratedPlanOriginal
                          pkgsBuildStatus
                          buildOutcomes
+
+    writePlanGhcEnvironment projectRootDir
+                            elaboratedPlanOriginal
+                            elaboratedShared
+                            postBuildStatus
 
     -- Finally if there were any build failures then report them and throw
     -- an exception to terminate the program


### PR DESCRIPTION
New version of the ghc environments stuff, now based on the project build status infrastructure. This makes the implementation simpler and should also be much more accurate and useful.

What this really needs is testing with ghc-8.0.2. There's only so much I can do with looking at what the output would look like for older ghc versions.

Ignore the first patch, it's covered by PR #3920.