### PR TITLE
Lower implicit setup-depends bound

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2174,7 +2174,7 @@ defaultSetupDeps compiler platform pkg =
           -- constraints, we constrain them to use a compatible Cabal version.
           -- The exact version where we'll make this API break has not yet been
           -- decided, so for the meantime we guess at 2.x.
-          cabalCompatMaxVer = mkVersion [2]
+          cabalCompatMaxVer = mkVersion [1,25] -- TODO: Bump to [2] before 2.0 release
           -- In principle we can talk to any old Cabal version, and we need to
           -- be able to do that for custom Setup scripts that require older
           -- Cabal lib versions. However in practice we have currently have


### PR DESCRIPTION
As long as the tree contains Cabal-1.25 the implicit setup-depends bound
should be Cabal<1.25 to ensure that we don't attempt to build custom
Setup.hs's against the new Cabal, which is at this point thoroughly
incompatible with 1.24 and earlier.

This bound should likely be again lifted to Cabal<2.0 once the in-tree
Cabal version has been bumped to 2.0.