### PR TITLE
Pass -this-component-id to GHC when necessary.

### DIFF
--- a/Cabal/Distribution/Backpack/LinkedComponent.hs
+++ b/Cabal/Distribution/Backpack/LinkedComponent.hs
@@ -3,7 +3,6 @@
 -- | See <https://github.com/ezyang/ghc-proposals/blob/backpack/proposals/0000-backpack.rst>
 module Distribution.Backpack.LinkedComponent (
     LinkedComponent(..),
-    lc_cid,
     toLinkedComponent,
     toLinkedComponents,
     dispLinkedComponent,
@@ -47,6 +46,7 @@ import Text.PrettyPrint
 data LinkedComponent
     = LinkedComponent {
         lc_uid :: OpenUnitId,
+        lc_cid :: ComponentId,
         lc_pkgid :: PackageId,
         lc_insts :: [(ModuleName, OpenModule)],
         lc_component :: Component,
@@ -59,9 +59,6 @@ data LinkedComponent
         -- BC so it shouldn't matter.
         lc_depends :: [(OpenUnitId, PackageId)]
       }
-
-lc_cid :: LinkedComponent -> ComponentId
-lc_cid = openUnitIdComponentId . lc_uid
 
 dispLinkedComponent :: LinkedComponent -> Doc
 dispLinkedComponent lc =
@@ -238,6 +235,7 @@ toLinkedComponent verbosity db this_pid pkg_map ConfiguredComponent {
 
     return $ LinkedComponent {
                 lc_uid = this_uid,
+                lc_cid = this_cid,
                 lc_insts = insts,
                 lc_pkgid = pkgid,
                 lc_component = component,

--- a/Cabal/Distribution/Backpack/PreExistingComponent.hs
+++ b/Cabal/Distribution/Backpack/PreExistingComponent.hs
@@ -1,7 +1,6 @@
 -- | See <https://github.com/ezyang/ghc-proposals/blob/backpack/proposals/0000-backpack.rst>
 module Distribution.Backpack.PreExistingComponent (
     PreExistingComponent(..),
-    pc_cid,
     ipiToPreExistingComponent,
 ) where
 
@@ -27,13 +26,10 @@ data PreExistingComponent
         pc_pkgname :: PackageName,
         pc_pkgid :: PackageId,
         pc_uid   :: UnitId,
+        pc_cid   :: ComponentId,
         pc_open_uid :: OpenUnitId,
         pc_shape :: ModuleShape
     }
-
--- | The 'ComponentId' of a 'PreExistingComponent'.
-pc_cid :: PreExistingComponent -> ComponentId
-pc_cid pc = unitIdComponentId (pc_uid pc)
 
 -- | Convert an 'InstalledPackageInfo' into a 'PreExistingComponent',
 -- which was brought into scope under the 'PackageName' (important for
@@ -44,6 +40,7 @@ ipiToPreExistingComponent (pn, ipi) =
         pc_pkgname = pn,
         pc_pkgid = Installed.sourcePackageId ipi,
         pc_uid   = Installed.installedUnitId ipi,
+        pc_cid   = Installed.installedComponentId ipi,
         pc_open_uid =
             IndefFullUnitId (Installed.installedComponentId ipi)
                             (Map.fromList (Installed.instantiatedWith ipi)),

--- a/Cabal/Distribution/Backpack/UnifyM.hs
+++ b/Cabal/Distribution/Backpack/UnifyM.hs
@@ -443,7 +443,7 @@ convertInclude ((uid, ModuleShape provs reqs), pid, incl@(IncludeRenaming prov_r
                 let hides_set = Set.fromList hides
                 in let r = [ (k,v)
                            | (k,v) <- Map.toList provs
-                           , k `Set.member` hides_set ]
+                           , not (k `Set.member` hides_set) ]
                    -- GHC doesn't understand hiding, so expand it out!
                    in return (r, ModuleRenaming (map ((\x -> (x,x)).fst) r))
             ModuleRenaming rns -> do

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -424,7 +424,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
     -- This is, like, the one place where we use a CTestName for a library.
     -- Should NOT use library name, since that could conflict!
     PackageIdentifier pkg_name pkg_ver = package pkg_descr
-    compat_name = computeCompatPackageName pkg_name (CTestName (testName test)) (Just (componentUnitId clbi))
+    compat_name = computeCompatPackageName pkg_name (CTestName (testName test))
     compat_key = computeCompatPackageKey (compiler lbi) compat_name pkg_ver (componentUnitId clbi)
     libClbi = LibComponentLocalBuildInfo
                 { componentPackageDeps = componentPackageDeps clbi
@@ -435,6 +435,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
                 , componentIsPublic = False
                 , componentIncludes = componentIncludes clbi
                 , componentUnitId = componentUnitId clbi
+                , componentComponentId = componentComponentId clbi
                 , componentInstantiatedWith = []
                 , componentCompatPackageName = compat_name
                 , componentCompatPackageKey = compat_key
@@ -470,6 +471,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
                 -- TODO: this is a hack, but as long as this is unique
                 -- (doesn't clobber something) we won't run into trouble
                 componentUnitId = mkUnitId (stubName test),
+                componentComponentId = mkComponentId (stubName test),
                 componentInternalDeps = [componentUnitId clbi],
                 componentExeDeps = [],
                 componentLocalName = CExeName (stubName test),
@@ -497,6 +499,7 @@ benchmarkExeV10asExe bm@Benchmark { benchmarkInterface = BenchmarkExeV10 _ f }
           }
     exeClbi = ExeComponentLocalBuildInfo {
                 componentUnitId = componentUnitId clbi,
+                componentComponentId = componentComponentId clbi,
                 componentLocalName = CExeName (benchmarkName bm),
                 componentInternalDeps = componentInternalDeps clbi,
                 componentExeDeps = componentExeDeps clbi,

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -59,6 +59,7 @@ module Distribution.Simple.Compiler (
         unitIdSupported,
         coverageSupported,
         profilingSupported,
+        backpackSupported,
 
         -- * Support for profiling detail levels
         ProfDetailLevel(..),
@@ -315,6 +316,10 @@ packageKeySupported = ghcSupported "Uses package keys"
 -- | Does this compiler support unit IDs?
 unitIdSupported :: Compiler -> Bool
 unitIdSupported = ghcSupported "Uses unit IDs"
+
+-- | Does this compiler support Backpack?
+backpackSupported :: Compiler -> Bool
+backpackSupported = ghcSupported "Support Backpack"
 
 -- | Does this compiler support Haskell program coverage?
 coverageSupported :: Compiler -> Bool

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -1182,15 +1182,14 @@ selectDependency pkgid internalIndex installedIndex requiredDepsMap
         []   -> Left  $
                   case is_internal of
                     Just cname -> DependencyMissingInternal dep_pkgname
-                                    (computeCompatPackageName
-                                     (packageName pkgid) cname Nothing)
+                                    (computeCompatPackageName (packageName pkgid) cname)
                     Nothing -> DependencyNotExists dep_pkgname
         pkgs -> Right $ ExternalDependency dep $
                 case last pkgs of
                   (_ver, pkginstances) -> head pkginstances
      where
       dep' | Just cname <- is_internal
-           = Dependency (computeCompatPackageName (packageName pkgid) cname Nothing) vr
+           = Dependency (computeCompatPackageName (packageName pkgid) cname) vr
            | otherwise = dep
     -- NB: here computeCompatPackageName we want to pick up the INDEFINITE ones
     -- which is why we pass 'Nothing' as 'UnitId'

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -954,13 +954,18 @@ checkCompilerProblems comp pkg_descr enabled = do
                 all (all (isDefaultIncludeRenaming . snd) . backpackIncludes)
                          (enabledBuildInfos pkg_descr enabled)) $
         die $ "Your compiler does not support thinning and renaming on "
-           ++ "package flags.  To use this feature you probably must use "
+           ++ "package flags.  To use this feature you must use "
            ++ "GHC 7.9 or later."
 
     when (any (not.null.PD.reexportedModules) (PD.allLibraries pkg_descr)
           && not (reexportedModulesSupported comp)) $ do
         die $ "Your compiler does not support module re-exports. To use "
-           ++ "this feature you probably must use GHC 7.9 or later."
+           ++ "this feature you must use GHC 7.9 or later."
+
+    when (any (not.null.PD.signatures) (PD.allLibraries pkg_descr)
+          && not (backpackSupported comp)) $ do
+        die $ "Your compiler does not support Backpack. To use "
+           ++ "this feature you must use GHC 8.1 or later."
 
 -- | Select dependencies for the package.
 configureDependencies

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -736,6 +736,13 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
                     LibComponentLocalBuildInfo { componentCompatPackageKey = pk }
                       -> toFlag pk
                     _ -> mempty,
+                ghcOptThisComponentId = case clbi of
+                    LibComponentLocalBuildInfo { componentUnitId = lib_uid
+                                               , componentInstantiatedWith = insts } ->
+                        if null insts
+                            then mempty
+                            else toFlag (unitIdComponentId lib_uid)
+                    _ -> mempty,
                 ghcOptInstantiatedWith = case clbi of
                     LibComponentLocalBuildInfo { componentInstantiatedWith = insts }
                       -> insts

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -737,11 +737,10 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
                       -> toFlag pk
                     _ -> mempty,
                 ghcOptThisComponentId = case clbi of
-                    LibComponentLocalBuildInfo { componentUnitId = lib_uid
-                                               , componentInstantiatedWith = insts } ->
+                    LibComponentLocalBuildInfo { componentInstantiatedWith = insts } ->
                         if null insts
                             then mempty
-                            else toFlag (unitIdComponentId lib_uid)
+                            else toFlag (componentComponentId clbi)
                     _ -> mempty,
                 ghcOptInstantiatedWith = case clbi of
                     LibComponentLocalBuildInfo { componentInstantiatedWith = insts }

--- a/Cabal/Distribution/Simple/GHC/IPI642.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI642.hs
@@ -19,6 +19,7 @@ import Distribution.Compat.Prelude
 import qualified Distribution.InstalledPackageInfo as Current
 import qualified Distribution.Package as Current hiding (installedUnitId)
 import Distribution.Simple.GHC.IPIConvert
+import Distribution.Text
 
 -- | This is the InstalledPackageInfo type used by ghc-6.4.2 and later.
 --
@@ -69,6 +70,7 @@ toCurrent ipi@InstalledPackageInfo{} =
   in Current.InstalledPackageInfo {
     Current.sourcePackageId    = pid,
     Current.installedUnitId    = Current.mkLegacyUnitId pid,
+    Current.installedComponentId_ = Current.mkComponentId (display pid),
     Current.instantiatedWith   = [],
     Current.compatPackageKey   = "",
     Current.abiHash            = Current.mkAbiHash "", -- bogus but old GHCs don't care.

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -289,6 +289,13 @@ componentGhcOptions verbosity lbi bi clbi odir =
         LibComponentLocalBuildInfo { componentCompatPackageKey = pk }
           -> toFlag pk
         _ -> mempty,
+      ghcOptThisComponentId = case clbi of
+          LibComponentLocalBuildInfo { componentUnitId = uid
+                                     , componentInstantiatedWith = insts } ->
+              if null insts
+                  then mempty
+                  else toFlag (unitIdComponentId uid)
+          _ -> mempty,
       ghcOptInstantiatedWith = case clbi of
         LibComponentLocalBuildInfo { componentInstantiatedWith = insts }
           -> insts

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -290,11 +290,11 @@ componentGhcOptions verbosity lbi bi clbi odir =
           -> toFlag pk
         _ -> mempty,
       ghcOptThisComponentId = case clbi of
-          LibComponentLocalBuildInfo { componentUnitId = uid
+          LibComponentLocalBuildInfo { componentComponentId = cid
                                      , componentInstantiatedWith = insts } ->
               if null insts
                   then mempty
-                  else toFlag (unitIdComponentId uid)
+                  else toFlag cid
           _ -> mempty,
       ghcOptInstantiatedWith = case clbi of
         LibComponentLocalBuildInfo { componentInstantiatedWith = insts }

--- a/Cabal/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Simple/LocalBuildInfo.hs
@@ -33,7 +33,6 @@ module Distribution.Simple.LocalBuildInfo (
         showComponentName,
         componentNameString,
         ComponentLocalBuildInfo(..),
-        componentComponentId,
         componentBuildDir,
         foldComponent,
         componentName,
@@ -106,12 +105,14 @@ componentBuildDir :: LocalBuildInfo -> ComponentLocalBuildInfo -> FilePath
 componentBuildDir lbi clbi
     = buildDir lbi </>
         case componentLocalName clbi of
-            CLibName      -> case unitIdHash (componentUnitId clbi) of
-                               Just hash -> hash
-                               Nothing   -> ""
-            CSubLibName s -> case unitIdHash (componentUnitId clbi) of
-                               Just hash -> s ++ "-" ++ hash
-                               Nothing   -> s
+            CLibName      ->
+                if display (componentUnitId clbi) == display (componentComponentId clbi)
+                    then ""
+                    else display (componentUnitId clbi)
+            CSubLibName s ->
+                if display (componentUnitId clbi) == display (componentComponentId clbi)
+                    then s
+                    else display (componentUnitId clbi)
             CExeName s   -> s
             CTestName s  -> s
             CBenchName s -> s

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -90,6 +90,10 @@ data GhcOptions = GhcOptions {
   -- is.  This only gets set when 'ghcOptInstantiatedWith' is non-empty
   ghcOptThisComponentId :: Flag ComponentId,
 
+  -- | How the requirements of the package being compiled are to
+  -- be filled.  When typechecking an indefinite package, the 'OpenModule'
+  -- is always a 'OpenModuleVar'; otherwise, it specifies the installed module
+  -- that instantiates a package.
   ghcOptInstantiatedWith :: [(ModuleName, OpenModule)],
 
   -- | No code? (But we turn on interface writing

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -19,6 +19,7 @@ module Distribution.Simple.Program.GHC (
 import Prelude ()
 import Distribution.Compat.Prelude
 
+import Distribution.Package
 import Distribution.Backpack
 import Distribution.Simple.GHC.ImplInfo
 import Distribution.PackageDescription hiding (Flag)
@@ -82,6 +83,12 @@ data GhcOptions = GhcOptions {
   -- already figured out what the correct format for this string is
   -- (we need to handle backwards compatibility.)
   ghcOptThisUnitId   :: Flag String,
+
+  -- | GHC doesn't make any assumptions about the format of
+  -- definite unit ids, so when we are instantiating a package it
+  -- needs to be told explicitly what the component being instantiated
+  -- is.  This only gets set when 'ghcOptInstantiatedWith' is non-empty
+  ghcOptThisComponentId :: Flag ComponentId,
 
   ghcOptInstantiatedWith :: [(ModuleName, OpenModule)],
 
@@ -402,6 +409,9 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
                   | otherwise                -> "-package-name"
              , this_arg ]
              | this_arg <- flag ghcOptThisUnitId ]
+
+  , concat [ ["-this-component-id", display this_cid ]
+           | this_cid <- flag ghcOptThisComponentId ]
 
   , if null (ghcOptInstantiatedWith opts)
         then []

--- a/Cabal/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/Distribution/Simple/Program/HcPkg.hs
@@ -315,11 +315,12 @@ mungePackagePaths pkgroot pkginfo =
 -- field, so if it is missing then we fill it as the source package ID.
 setUnitId :: InstalledPackageInfo -> InstalledPackageInfo
 setUnitId pkginfo@InstalledPackageInfo {
-                        installedUnitId = UnitId cid _,
+                        installedUnitId = uid,
                         sourcePackageId = pkgid
-                      } | cid == mkComponentId ""
+                      } | unUnitId uid == ""
                     = pkginfo {
-                        installedUnitId = mkLegacyUnitId pkgid
+                        installedUnitId = mkLegacyUnitId pkgid,
+                        installedComponentId_ = mkComponentId (display pkgid)
                       }
 setUnitId pkginfo = pkginfo
 

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -389,6 +389,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
                                 pkgName = componentCompatPackageName clbi
                              },
     IPI.installedUnitId    = componentUnitId clbi,
+    IPI.installedComponentId_ = componentComponentId clbi,
     IPI.instantiatedWith   = componentInstantiatedWith clbi,
     IPI.compatPackageKey   = componentCompatPackageKey clbi,
     IPI.license            = license     pkg,

--- a/Cabal/Distribution/Types/ComponentLocalBuildInfo.hs
+++ b/Cabal/Distribution/Types/ComponentLocalBuildInfo.hs
@@ -4,7 +4,6 @@
 module Distribution.Types.ComponentLocalBuildInfo (
   ComponentLocalBuildInfo(..),
   componentIsIndefinite,
-  componentComponentId,
   ) where
 
 import Prelude ()
@@ -29,6 +28,8 @@ data ComponentLocalBuildInfo
     -- PackageDescription.  NB: eventually, this will NOT uniquely
     -- identify the ComponentLocalBuildInfo.
     componentLocalName :: ComponentName,
+    -- | The computed 'ComponentId' of this component.
+    componentComponentId :: ComponentId,
     -- | The computed 'UnitId' which uniquely identifies this
     -- component.  Might be hashed.
     componentUnitId :: UnitId,
@@ -67,6 +68,7 @@ data ComponentLocalBuildInfo
   }
   | ExeComponentLocalBuildInfo {
     componentLocalName :: ComponentName,
+    componentComponentId :: ComponentId,
     componentUnitId :: UnitId,
     componentPackageDeps :: [(UnitId, PackageId)],
     componentIncludes :: [(OpenUnitId, ModuleRenaming)],
@@ -75,6 +77,7 @@ data ComponentLocalBuildInfo
   }
   | TestComponentLocalBuildInfo {
     componentLocalName :: ComponentName,
+    componentComponentId :: ComponentId,
     componentUnitId :: UnitId,
     componentPackageDeps :: [(UnitId, PackageId)],
     componentIncludes :: [(OpenUnitId, ModuleRenaming)],
@@ -84,6 +87,7 @@ data ComponentLocalBuildInfo
   }
   | BenchComponentLocalBuildInfo {
     componentLocalName :: ComponentName,
+    componentComponentId :: ComponentId,
     componentUnitId :: UnitId,
     componentPackageDeps :: [(UnitId, PackageId)],
     componentIncludes :: [(OpenUnitId, ModuleRenaming)],
@@ -98,9 +102,6 @@ instance IsNode ComponentLocalBuildInfo where
     type Key ComponentLocalBuildInfo = UnitId
     nodeKey = componentUnitId
     nodeNeighbors = componentInternalDeps
-
-componentComponentId :: ComponentLocalBuildInfo -> ComponentId
-componentComponentId clbi = unitIdComponentId (componentUnitId clbi)
 
 componentIsIndefinite :: ComponentLocalBuildInfo -> Bool
 componentIsIndefinite LibComponentLocalBuildInfo{ componentIsIndefinite_ = b } = b

--- a/Cabal/Distribution/Types/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Types/LocalBuildInfo.hs
@@ -162,7 +162,11 @@ instance Binary LocalBuildInfo
 -- 'LocalBuildInfo' if it exists, or make a fake component ID based
 -- on the package ID.
 localComponentId :: LocalBuildInfo -> ComponentId
-localComponentId lbi = unitIdComponentId (localUnitId lbi)
+localComponentId lbi =
+    case componentNameCLBIs lbi CLibName of
+        [LibComponentLocalBuildInfo { componentComponentId = cid }]
+          -> cid
+        _ -> mkComponentId (display (localPackage lbi))
 
 -- | Extract the 'PackageIdentifier' of a 'LocalBuildInfo'.
 -- This is a "safe" use of 'localPkgDescr'

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -731,7 +731,7 @@ tests config = do
       cabal "configure" []
       r <- shouldFail $ cabal' "build" []
       assertOutputContains "Foobar" r
-      assertOutputContains "Failed to load" r
+      assertOutputContains "Could not find" r
       return ()
 
   tc "Backpack/Reexport1" . whenGhcVersion (>= mkVersion [8,1]) $ do

--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -18,7 +18,7 @@ module Distribution.Client.DistDirLayout (
 
 import System.FilePath
 import Distribution.Package
-         ( PackageId, UnitId(..) )
+         ( PackageId, ComponentId, UnitId )
 import Distribution.Compiler
 import Distribution.Simple.Compiler (PackageDB(..), OptimisationLevel(..))
 import Distribution.Text
@@ -35,6 +35,7 @@ import Distribution.Client.Types
 data DistDirParams = DistDirParams {
     distParamUnitId         :: UnitId,
     distParamPackageId      :: PackageId,
+    distParamComponentId    :: ComponentId,
     distParamComponentName  :: Maybe ComponentName,
     distParamCompilerId     :: CompilerId,
     distParamPlatform       :: Platform,
@@ -127,9 +128,10 @@ defaultDistDirLayout projectRootDirectory =
             NoOptimisation -> "noopt"
             NormalOptimisation -> ""
             MaximumOptimisation -> "opt") </>
-        (case distParamUnitId params of
-            UnitId _ (Just hash) -> hash
-            UnitId _ Nothing     -> "")
+        (let uid_str = display (distParamUnitId params)
+         in if uid_str == display (distParamComponentId params)
+                then ""
+                else uid_str)
 
     distUnpackedSrcRootDirectory   = distDirectory </> "src"
     distUnpackedSrcDirectory pkgid = distUnpackedSrcRootDirectory

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -146,7 +146,7 @@ import Distribution.Package
          ( PackageIdentifier(..), PackageId, packageName, packageVersion
          , Package(..), HasUnitId(..)
          , Dependency(..), thisPackageVersion
-         , UnitId(..) )
+         , UnitId )
 import qualified Distribution.PackageDescription as PackageDescription
 import Distribution.PackageDescription
          ( PackageDescription, GenericPackageDescription(..), Flag(..)

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -73,7 +73,7 @@ import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo )
 import Distribution.Package
          ( Package(..)
-         , HasUnitId(..), UnitId(..) )
+         , HasUnitId(..), UnitId )
 import Distribution.Solver.Types.SolverPackage
 import Distribution.Client.JobControl
 import Distribution.Text

--- a/cabal-install/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/Distribution/Client/InstallSymlink.hs
@@ -50,7 +50,7 @@ import Distribution.Solver.Types.SourcePackage
 import Distribution.Solver.Types.OptionalStanza
 
 import Distribution.Package
-         ( PackageIdentifier, Package(packageId), UnitId(..), installedUnitId )
+         ( PackageIdentifier, Package(packageId), UnitId, installedUnitId )
 import Distribution.Compiler
          ( CompilerId(..) )
 import qualified Distribution.PackageDescription as PackageDescription

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -122,6 +122,7 @@ data ElaboratedConfiguredPackage
        -- | The 'UnitId' which uniquely identifies this item in a build plan
        elabUnitId        :: UnitId,
 
+       elabComponentId :: ComponentId,
        elabInstantiatedWith :: Map ModuleName Module,
        elabLinkedInstantiatedWith :: Map ModuleName OpenModule,
 
@@ -268,7 +269,7 @@ instance Package ElaboratedConfiguredPackage where
   packageId = elabPkgSourceId
 
 instance HasConfiguredId ElaboratedConfiguredPackage where
-  configuredId elab = ConfiguredId (packageId elab) (unitIdComponentId (elabUnitId elab))
+  configuredId elab = ConfiguredId (packageId elab) (elabComponentId elab)
 
 instance HasUnitId ElaboratedConfiguredPackage where
   installedUnitId = elabUnitId
@@ -290,6 +291,7 @@ instance Binary ElaboratedPackageOrComponent
 elabDistDirParams :: ElaboratedSharedConfig -> ElaboratedConfiguredPackage -> DistDirParams
 elabDistDirParams shared elab = DistDirParams {
         distParamUnitId = installedUnitId elab,
+        distParamComponentId = elabComponentId elab,
         distParamPackageId = elabPkgSourceId elab,
         distParamComponentName = case elabPkgOrComp elab of
             ElabComponent comp -> compComponentName comp

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -23,9 +23,9 @@ module Distribution.Client.Types where
 import Distribution.Package
          ( PackageName, PackageId, Package(..)
          , UnitId, ComponentId, HasUnitId(..)
-         , PackageInstalled(..), unitIdComponentId, newSimpleUnitId )
+         , PackageInstalled(..), newSimpleUnitId )
 import Distribution.InstalledPackageInfo
-         ( InstalledPackageInfo )
+         ( InstalledPackageInfo, installedComponentId )
 import Distribution.PackageDescription
          ( FlagAssignment )
 import Distribution.Version
@@ -164,7 +164,7 @@ class HasConfiguredId a where
 -- NB: This instance is slightly dangerous, in that you'll lose
 -- information about the specific UnitId you depended on.
 instance HasConfiguredId InstalledPackageInfo where
-    configuredId ipkg = ConfiguredId (packageId ipkg) (unitIdComponentId (installedUnitId ipkg))
+    configuredId ipkg = ConfiguredId (packageId ipkg) (installedComponentId ipkg)
 
 -- | Like 'ConfiguredPackage', but with all dependencies guaranteed to be
 -- installed already, hence itself ready to be installed.

--- a/cabal-install/Distribution/Solver/Types/PackageFixedDeps.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageFixedDeps.hs
@@ -4,7 +4,7 @@ module Distribution.Solver.Types.PackageFixedDeps
 
 import           Distribution.InstalledPackageInfo ( InstalledPackageInfo )
 import           Distribution.Package
-                   ( Package(..), UnitId(..), installedDepends)
+                   ( Package(..), UnitId, installedDepends)
 import           Distribution.Solver.Types.ComponentDeps ( ComponentDeps )
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 

--- a/cabal-install/Distribution/Solver/Types/SolverId.hs
+++ b/cabal-install/Distribution/Solver/Types/SolverId.hs
@@ -6,7 +6,7 @@ module Distribution.Solver.Types.SolverId
 where
 
 import Distribution.Compat.Binary (Binary(..))
-import Distribution.Package (PackageId, Package(..), UnitId(..))
+import Distribution.Package (PackageId, Package(..), UnitId)
 import GHC.Generics (Generic)
 
 -- | The solver can produce references to existing packages or


### PR DESCRIPTION
Previously GHC inferred it off of -this-unit-id but we've
modified things so that GHC makes no assumptions about the
format of instantiated unit ids. In that case, pass it in
explicitly!

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>