### PR TITLE
Fix Stack build

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ extra-deps:
 - cryptohash-sha256-0.11.100.1
 - ed25519-0.0.5.0
 - exceptions-0.8.2.1
-- hackage-security-0.5.2.1
+- hackage-security-0.5.2.2
 - hashable-1.2.4.0
 - haskell-lexer-1.0
 - HTTP-4000.3.3


### PR DESCRIPTION
The hackage-security dependency in stack.yaml (0.5.2.1) is incompatible with what cabal-install requires (>=0.5.2.2). Bumping the version to that lower bound resolves the dependency issue.