### PR TITLE
Backport #3873 to the 1.24 branch

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -329,10 +329,9 @@ computeEffectiveProfiling cfg =
     --
     -- The --profiling-detail and --library-profiling-detail flags behave
     -- similarly
-    let profEnabledLibOnly = configProfLib cfg
-        profEnabledBoth    = fromFlagOrDefault False (configProf cfg)
-        profEnabledLib = fromFlagOrDefault profEnabledBoth profEnabledLibOnly
-        profEnabledExe = fromFlagOrDefault profEnabledBoth (configProfExe cfg)
+    let profEnabledBoth = fromFlagOrDefault False (configProf cfg)
+        profEnabledLib  = fromFlagOrDefault profEnabledBoth (configProfLib cfg)
+        profEnabledExe  = fromFlagOrDefault profEnabledBoth (configProfExe cfg)
     in (profEnabledLib, profEnabledExe)
 
 -- |Perform the \"@.\/setup configure@\" action.

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -1,5 +1,5 @@
 Name:               cabal-install
-Version:            1.24.0.0
+Version:            1.24.0.1
 Synopsis:           The command-line interface for Cabal and Hackage.
 Description:
     The \'cabal\' command-line program simplifies the process of managing

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,5 +1,7 @@
 -*-change-log-*-
-1.24.0.1 Ryan Thomas <ryan@ryant.org> June 2016
+1.24.0.1 Ryan Thomas <ryan@ryant.org> October 2016
+	* Fixed issue with passing '--enable-profiling' when invoking
+	Setup scripts built with older versions of Cabal (#3873).
 	* Fixed various behaviour differences between network transports
 	(#3429).
 	* Updated to depend on the latest hackage-security that fixes


### PR DESCRIPTION
Testing protocol:

```
$ cabal-1.24 sandbox init
$ cabal-1.24 install --enable-profiling -w /opt/ghc/7.4.2/bin/ghc trivia
```

`trivia` depends on `distributive`, which has a Custom build-type.