### PR TITLE
Add hidir setting

### DIFF
--- a/Cabal/Distribution/Make.hs
+++ b/Cabal/Distribution/Make.hs
@@ -28,7 +28,8 @@
 --              @--bindir@,
 --              @--libdir@,
 --              @--libexecdir@,
---              @--datadir@.
+--              @--datadir@,
+--              @--hidir@.
 --
 -- [BuildCmd] We assume that the default Makefile target will build everything.
 --

--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -71,7 +71,7 @@ generate pkg_descr lbi =
         pragmas++
         "module " ++ display paths_modulename ++ " (\n"++
         "    version,\n"++
-        "    getBinDir, getLibDir, getDataDir, getLibexecDir,\n"++
+        "    getBinDir, getLibDir, getDataDir, getHiDir, getLibexecDir,\n"++
         "    getDataFileName, getSysconfDir\n"++
         "  ) where\n"++
         "\n"++
@@ -111,6 +111,7 @@ generate pkg_descr lbi =
           "\ngetBinDir, getLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
           "getBinDir = "++mkGetEnvOrReloc "bindir" flat_bindirreloc++"\n"++
           "getLibDir = "++mkGetEnvOrReloc "libdir" flat_libdirreloc++"\n"++
+          "getHiDir = "++mkGetEnvOrReloc "hidir" flat_hidirreloc++"\n"++
           "getDataDir = "++mkGetEnvOrReloc "datadir" flat_datadirreloc++"\n"++
           "getLibexecDir = "++mkGetEnvOrReloc "libexecdir" flat_libexecdirreloc++"\n"++
           "getSysconfDir = "++mkGetEnvOrReloc "sysconfdir" flat_sysconfdirreloc++"\n"++
@@ -124,17 +125,19 @@ generate pkg_descr lbi =
           "\n"++
           filename_stuff
         | absolute =
-          "\nbindir, libdir, datadir, libexecdir, sysconfdir :: FilePath\n"++
+          "\nbindir, libdir, datadir, hidir, libexecdir, sysconfdir :: FilePath\n"++
           "\nbindir     = " ++ show flat_bindir ++
           "\nlibdir     = " ++ show flat_libdir ++
           "\ndatadir    = " ++ show flat_datadir ++
+          "\nhidir      = " ++ show flat_hidir ++
           "\nlibexecdir = " ++ show flat_libexecdir ++
           "\nsysconfdir = " ++ show flat_sysconfdir ++
           "\n"++
-          "\ngetBinDir, getLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
+          "\ngetBinDir, getLibDir, getDataDir, getHiDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
           "getBinDir = "++mkGetEnvOr "bindir" "return bindir"++"\n"++
           "getLibDir = "++mkGetEnvOr "libdir" "return libdir"++"\n"++
           "getDataDir = "++mkGetEnvOr "datadir" "return datadir"++"\n"++
+          "getHiDir = "++mkGetEnvOr "hidir" "return hidir"++"\n"++
           "getLibexecDir = "++mkGetEnvOr "libexecdir" "return libexecdir"++"\n"++
           "getSysconfDir = "++mkGetEnvOr "sysconfdir" "return sysconfdir"++"\n"++
           "\n"++
@@ -154,6 +157,8 @@ generate pkg_descr lbi =
           "getDataDir :: IO FilePath\n"++
           "getDataDir =  "++ mkGetEnvOr "datadir"
                               (mkGetDir flat_datadir flat_datadirrel)++"\n\n"++
+          "getHiDir :: IO FilePath\n"++
+          "getHiDir = "++mkGetDir flat_libdir flat_hidirrel++"\n\n"++
           "getLibexecDir :: IO FilePath\n"++
           "getLibexecDir = "++mkGetDir flat_libexecdir flat_libexecdirrel++"\n\n"++
           "getSysconfDir :: IO FilePath\n"++
@@ -174,6 +179,7 @@ generate pkg_descr lbi =
           bindir     = flat_bindir,
           libdir     = flat_libdir,
           datadir    = flat_datadir,
+          hidir      = flat_hidir,
           libexecdir = flat_libexecdir,
           sysconfdir = flat_sysconfdir
         } = absoluteInstallDirs pkg_descr lbi NoCopyDest
@@ -181,6 +187,7 @@ generate pkg_descr lbi =
           bindir     = flat_bindirrel,
           libdir     = flat_libdirrel,
           datadir    = flat_datadirrel,
+          hidir      = flat_hidirrel,
           libexecdir = flat_libexecdirrel,
           sysconfdir = flat_sysconfdirrel
         } = prefixRelativeInstallDirs (packageId pkg_descr) lbi
@@ -188,6 +195,7 @@ generate pkg_descr lbi =
         flat_bindirreloc = shortRelativePath flat_prefix flat_bindir
         flat_libdirreloc = shortRelativePath flat_prefix flat_libdir
         flat_datadirreloc = shortRelativePath flat_prefix flat_datadir
+        flat_hidirreloc = shortRelativePath flat_prefix flat_hidir
         flat_libexecdirreloc = shortRelativePath flat_prefix flat_libexecdir
         flat_sysconfdirreloc = shortRelativePath flat_prefix flat_sysconfdir
 

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -684,6 +684,7 @@ configure (pkg_descr0', pbi) cfg = do
 
     dirinfo "Binaries"         (bindir dirs)     (bindir relative)
     dirinfo "Libraries"        (libdir dirs)     (libdir relative)
+    dirinfo "Interfaces"       (hidir dirs)      (hidir relative)
     dirinfo "Private binaries" (libexecdir dirs) (libexecdir relative)
     dirinfo "Data files"       (datadir dirs)    (datadir relative)
     dirinfo "Documentation"    (docdir dirs)     (docdir relative)
@@ -2013,7 +2014,7 @@ checkRelocatable verbosity pkg lbi
           all isJust
               (fmap (stripPrefix p)
                     [ bindir, libdir, dynlibdir, libexecdir, includedir, datadir
-                    , docdir, mandir, htmldir, haddockdir, sysconfdir] )
+                    , hidir, docdir, mandir, htmldir, haddockdir, sysconfdir] )
 
     -- Check if the library dirs of the dependencies that are in the package
     -- database to which the package is installed are relative to the

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1115,13 +1115,14 @@ installExe verbosity lbi installDirs buildPref
 installLib    :: Verbosity
               -> LocalBuildInfo
               -> FilePath  -- ^install location
+              -> FilePath  -- ^install location for interface files
               -> FilePath  -- ^install location for dynamic libraries
               -> FilePath  -- ^Build location
               -> PackageDescription
               -> Library
               -> ComponentLocalBuildInfo
               -> IO ()
-installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
+installLib verbosity lbi targetDir dynlibTargetDir hiTargetDir builtDir _pkg lib clbi = do
   -- copy .hi files over:
   whenVanilla $ copyModuleFiles "hi"
   whenProf    $ copyModuleFiles "p_hi"
@@ -1151,7 +1152,7 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
 
     copyModuleFiles ext =
       findModuleFiles [builtDir] [ext] (libModules lib)
-      >>= installOrdinaryFiles verbosity targetDir
+      >>= installOrdinaryFiles verbosity hiTargetDir
 
     cid = compilerId (compiler lbi)
     libName = componentUnitId clbi

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -60,6 +60,7 @@ install pkg_descr lbi flags = do
       installDirs@(InstallDirs {
          bindir     = binPref,
          libdir     = libPref,
+         hidir      = hiPref,
 --         dynlibdir  = dynlibPref, --see TODO below
          datadir    = dataPref,
          docdir     = docPref,
@@ -114,8 +115,9 @@ install pkg_descr lbi flags = do
       | lfile <- lfiles ]
 
   let buildPref = buildDir lbi
-  when (hasLibs pkg_descr) $
+  when (hasLibs pkg_descr) $ do
     notice verbosity ("Installing library in " ++ libPref)
+    notice verbosity ("Installing library interface files in " ++ hiPref)
   when (hasExes pkg_descr) $ do
     notice verbosity ("Installing executable(s) in " ++ binPref)
     inPath <- isInSearchPath binPref
@@ -130,7 +132,7 @@ install pkg_descr lbi flags = do
 
   withLibLBI pkg_descr lbi $
     case compilerFlavor (compiler lbi) of
-      GHC   -> GHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr
+      GHC   -> GHC.installLib   verbosity lbi libPref dynlibPref hiPref    buildPref pkg_descr
       GHCJS -> GHCJS.installLib verbosity lbi libPref dynlibPref buildPref pkg_descr
       LHC   -> LHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr
       JHC   -> JHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -196,7 +196,7 @@ defaultInstallDirs comp userInstall _hasLibs = do
         Windows   -> "$prefix"
         _other    -> "$prefix" </> "share",
       datasubdir   = "$abi" </> "$pkgid",
-      hidir        = installLibDir </> case comp of
+      hidir        = "$libdir" </> case comp of
            JHC    -> "$compiler"
            LHC    -> "$compiler"
            UHC    -> "$pkgid"

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -86,6 +86,7 @@ data InstallDirs dir = InstallDirs {
         includedir   :: dir,
         datadir      :: dir,
         datasubdir   :: dir,
+        hidir        :: dir,
         docdir       :: dir,
         mandir       :: dir,
         htmldir      :: dir,
@@ -116,6 +117,7 @@ combineInstallDirs combine a b = InstallDirs {
     includedir   = includedir a `combine` includedir b,
     datadir      = datadir a    `combine` datadir b,
     datasubdir   = datasubdir a `combine` datasubdir b,
+    hidir        = hidir a      `combine` hidir b,
     docdir       = docdir a     `combine` docdir b,
     mandir       = mandir a     `combine` mandir b,
     htmldir      = htmldir a    `combine` htmldir b,
@@ -191,6 +193,11 @@ defaultInstallDirs comp userInstall _hasLibs = do
         Windows   -> "$prefix"
         _other    -> "$prefix" </> "share",
       datasubdir   = "$abi" </> "$pkgid",
+      hidir        = installLibDir </> case comp of
+           JHC    -> "$compiler"
+           LHC    -> "$compiler"
+           UHC    -> "$pkgid"
+           _other -> "$abi" </> "$libname",
       docdir       = "$datadir" </> "doc" </> "$abi" </> "$pkgid",
       mandir       = "$datadir" </> "man",
       htmldir      = "$docdir"  </> "html",
@@ -228,6 +235,7 @@ substituteInstallDirTemplates env dirs = dirs'
       includedir = subst includedir prefixBinLibVars,
       datadir    = subst datadir    prefixBinLibVars,
       datasubdir = subst datasubdir [],
+      hidir      = subst hidir      prefixBinLibVars,
       docdir     = subst docdir     prefixBinLibDataVars,
       mandir     = subst mandir     (prefixBinLibDataVars ++ [docdirVar]),
       htmldir    = subst htmldir    (prefixBinLibDataVars ++ [docdirVar]),
@@ -333,6 +341,7 @@ data PathTemplateVariable =
      | LibsubdirVar  -- ^ The @$libsubdir@ path variable
      | DatadirVar    -- ^ The @$datadir@ path variable
      | DatasubdirVar -- ^ The @$datasubdir@ path variable
+     | HidirVar      -- ^ The @$hidir@ path variable
      | DocdirVar     -- ^ The @$docdir@ path variable
      | HtmldirVar    -- ^ The @$htmldir@ path variable
      | PkgNameVar    -- ^ The @$pkg@ package name path variable
@@ -428,6 +437,7 @@ installDirsTemplateEnv dirs =
   ,(LibsubdirVar,  libsubdir  dirs)
   ,(DatadirVar,    datadir    dirs)
   ,(DatasubdirVar, datasubdir dirs)
+  ,(HidirVar,      hidir      dirs)
   ,(DocdirVar,     docdir     dirs)
   ,(HtmldirVar,    htmldir    dirs)
   ]
@@ -450,6 +460,7 @@ instance Show PathTemplateVariable where
   show LibsubdirVar  = "libsubdir"
   show DatadirVar    = "datadir"
   show DatasubdirVar = "datasubdir"
+  show HidirVar      = "hidir"
   show DocdirVar     = "docdir"
   show HtmldirVar    = "htmldir"
   show PkgNameVar    = "pkg"
@@ -478,6 +489,7 @@ instance Read PathTemplateVariable where
                  ,("libsubdir",  LibsubdirVar)
                  ,("datadir",    DatadirVar)
                  ,("datasubdir", DatasubdirVar)
+                 ,("hidir",      HidirVar)
                  ,("docdir",     DocdirVar)
                  ,("htmldir",    HtmldirVar)
                  ,("pkgid",      PkgIdVar)

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -183,7 +183,9 @@ defaultInstallDirs comp userInstall _hasLibs = do
            JHC    -> "$compiler"
            LHC    -> "$compiler"
            UHC    -> "$pkgid"
-           _other -> "$abi" </> "$libname",
+           _other -> case buildOS of
+                        OSX      -> "$abi" -- OSX libs go into a single directory
+                        _otherOS -> "$abi" </> "$libname",
       dynlibdir    = "$libdir",
       libexecdir   = case buildOS of
         Windows   -> "$prefix" </> "$libname"

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -185,6 +185,7 @@ defaultInstallDirs comp userInstall _hasLibs = do
            UHC    -> "$pkgid"
            _other -> case buildOS of
                         OSX      -> "$abi" -- OSX libs go into a single directory
+                                           -- See: https://ghc.haskell.org/trac/ghc/ticket/12479
                         _otherOS -> "$abi" </> "$libname",
       dynlibdir    = "$libdir",
       libexecdir   = case buildOS of

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -320,7 +320,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     IPI.exposedModules     = componentExposedModules clbi,
     IPI.hiddenModules      = otherModules bi,
     IPI.trusted            = IPI.trusted IPI.emptyInstalledPackageInfo,
-    IPI.importDirs         = [ libdir installDirs | hasModules ],
+    IPI.importDirs         = [ hidir installDirs | hasModules ],
     -- Note. the libsubdir and datasubdir templates have already been expanded
     -- into libdir and datadir.
     IPI.libraryDirs        = if hasLibrary
@@ -378,6 +378,7 @@ inplaceInstalledPackageInfo inplaceDir distPref pkg abi_hash lib lbi clbi =
       (absoluteInstallDirs pkg lbi NoCopyDest) {
         libdir     = inplaceDir </> libTargetDir,
         datadir    = inplaceDir </> dataDir pkg,
+        hidir      = inplaceDir </> libTargetDir,
         docdir     = inplaceDocdir,
         htmldir    = inplaceHtmldir,
         haddockdir = inplaceHtmldir

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -782,6 +782,11 @@ installDirsOptions =
       datasubdir (\v flags -> flags { datasubdir = v })
       installDirArg
 
+  , option "" ["hidir"]
+      "installation directory for library interface files"
+      hidir (\v flags -> flags { hidir = v })
+      installDirArg
+
   , option "" ["docdir"]
       "installation directory for documentation"
       docdir (\v flags -> flags { docdir = v })

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -6,6 +6,7 @@
 	extra-doc-files field is present (#3825).
 	* Fixed an incorrect invocation of GetShortPathName that was
 	causing build failures on Windows (#3649).
+	* Add '--hidir' option to indicate the location of interface files (#3955)
 
 1.24.0.1 Ryan Thomas <ryan@ryant.org> May 2016
 	* Linker flags are now set correctly on GHC >= 7.8 (#3443).

--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -1952,6 +1952,7 @@ version :: Version
 
 getBinDir :: IO FilePath
 getLibDir :: IO FilePath
+getHiDir :: IO FilePath
 getDataDir :: IO FilePath
 getLibexecDir :: IO FilePath
 getSysconfDir :: IO FilePath
@@ -2185,7 +2186,7 @@ a few options:
     `unregister`, `clean`, `dist` and `docs`. Some options to commands
     are passed through as follows:
 
-      * The `--with-hc-pkg`, `--prefix`, `--bindir`, `--libdir`, `--datadir`,
+      * The `--with-hc-pkg`, `--prefix`, `--bindir`, `--libdir`, `--hidir`, `--datadir`,
         `--libexecdir` and `--sysconfdir` options to the `configure` command are
         passed on to the `configure` script. In addition the value of the
         `--with-compiler` option is passed in a `--with-hc` option and all
@@ -2201,6 +2202,7 @@ a few options:
                 $(MAKE) install prefix=$(destdir)/$(prefix) \
                                 bindir=$(destdir)/$(bindir) \
                                 libdir=$(destdir)/$(libdir) \
+                                hidir=$(destdir)/$(hidir) \
                                 datadir=$(destdir)/$(datadir) \
                                 libexecdir=$(destdir)/$(libexecdir) \
                                 sysconfdir=$(destdir)/$(sysconfdir) \

--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -405,7 +405,7 @@ If a user-supplied `configure` script is run (see the section on
 [system-dependent
 parameters](developing-packages.html#system-dependent-parameters) or on
 [complex packages](developing-packages.html#more-complex-packages)), it
-is passed the `--with-hc-pkg`, `--prefix`, `--bindir`, `--libdir`,
+is passed the `--with-hc-pkg`, `--prefix`, `--bindir`, `--libdir`, `--hidir`,
 `--datadir`, `--libexecdir` and `--sysconfdir` options. In addition the
 value of the `--with-compiler` option is passed in a `--with-hc` option
 and all options specified with `--configure-option=` are passed on.
@@ -497,6 +497,13 @@ package:
     In the simple build system, _dir_ may contain the following path
     variables: `$prefix`, `$bindir`, `$pkgid`, `$pkg`, `$version`,
     `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
+
+`--hidir=`_dir_
+:   Interfaces of libraries are installed here.
+
+    _dir_ may contain the following path variables: `$prefix`, `$bindir`,
+    `$libdir`, `$libsubdir`, `$datadir`, `$datasubdir`, `$docdir`, `$pkgid`,
+    `$pkg`, `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 `--libexecdir=`_dir_
 :   Executables that are not expected to be invoked directly by the user
@@ -599,6 +606,9 @@ independence](#prefix-independence)).
 `$datasubdir`
 :   As above but for `--datasubdir`
 
+`$hidir`
+:   As above but for `--hidir`
+
 `$docdir`
 :   As above but for `--docdir`
 
@@ -647,6 +657,7 @@ Option                     Windows Default                                      
 `--datadir` (executable)   `$prefix`                                                 `$prefix/share`
 `--datadir` (library)      `C:\Program Files\Haskell`                                `$prefix/share`
 `--datasubdir`             `$pkgid`                                                  `$pkgid`
+`--hidir`                  `$prefix\$abi\$libname`                                   `$prefix/lib/$abi/$libname`
 `--docdir`                 `$prefix\doc\$pkgid`                                      `$datadir/doc/$pkgid`
 `--sysconfdir`             `$prefix\etc`                                             `$prefix/etc`
 `--htmldir`                `$docdir\html`                                            `$docdir/html`
@@ -666,7 +677,7 @@ install-time, rather than having to bake the path into the binary when it is
 built.
 
 In order to achieve this, we require that for an executable on Windows,
-all of `$bindir`, `$libdir`, `$datadir` and `$libexecdir` begin with
+all of `$bindir`, `$libdir`, `$hidir`, `$datadir` and `$libexecdir` begin with
 `$prefix`. If this is not the case then the compiled executable will
 have baked-in all absolute paths.
 

--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -501,8 +501,11 @@ package:
 `--hidir=`_dir_
 :   Interfaces of libraries are installed here.
 
-    _dir_ may contain the following path variables: `$prefix`, `$bindir`,
-    `$libdir`, `$libsubdir`, `$datadir`, `$datasubdir`, `$docdir`, `$pkgid`,
+    By default, this is the same as `$libdir/$libsubdir`; except on OS X, where
+    `$libsubdir` is set to `$abi`, but this setting is `$libdir/$abi/$libname`.
+
+    In the simple build system, _dir_ may contain the following path
+    variables: `$prefix`, `$bindir`, `$libdir`, `$libsubdir`, `$pkgid`,
     `$pkg`, `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 `--libexecdir=`_dir_
@@ -657,7 +660,7 @@ Option                     Windows Default                                      
 `--datadir` (executable)   `$prefix`                                                 `$prefix/share`
 `--datadir` (library)      `C:\Program Files\Haskell`                                `$prefix/share`
 `--datasubdir`             `$pkgid`                                                  `$pkgid`
-`--hidir`                  `$prefix\$abi\$libname`                                   `$prefix/lib/$abi/$libname`
+`--hidir`                  `$libdir\$abi\$libname`                                   `$libdir/lib/$abi/$libname`
 `--docdir`                 `$prefix\doc\$pkgid`                                      `$datadir/doc/$pkgid`
 `--sysconfdir`             `$prefix\etc`                                             `$prefix/etc`
 `--htmldir`                `$docdir\html`                                            `$docdir/html`

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1920,6 +1920,7 @@ storePackageInstallDirs CabalDirLayout{cabalStorePackageDirectory}
     includedir   = libdir </> "include"
     datadir      = prefix </> "share"
     datasubdir   = ""
+    hidir        = prefix </> "lib"
     docdir       = datadir </> "doc"
     mandir       = datadir </> "man"
     htmldir      = docdir  </> "html"

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -84,7 +84,7 @@ import Distribution.Simple.Setup
          , optionVerbosity, boolOpt, boolOpt', trueArg, falseArg
          , readPToMaybe, optionNumJobs )
 import Distribution.Simple.InstallDirs
-         ( PathTemplate, InstallDirs(sysconfdir)
+         ( PathTemplate, InstallDirs(hidir, sysconfdir)
          , toPathTemplate, fromPathTemplate )
 import Distribution.Version
          ( Version(Version), anyVersion, thisVersion )
@@ -350,7 +350,7 @@ configureOptions = commandOptions configureCommand
 
 filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
-  | cabalLibVersion >= Version [1,23,0] [] = flags_latest
+  | cabalLibVersion >= Version [1,24,1] [] = flags_latest
   -- ^ NB: we expect the latest version to be the most common case.
   | cabalLibVersion <  Version [1,3,10] [] = flags_1_3_10
   | cabalLibVersion <  Version [1,10,0] [] = flags_1_10_0
@@ -362,6 +362,7 @@ filterConfigureFlags flags cabalLibVersion
   | cabalLibVersion <  Version [1,21,1] [] = flags_1_20_0
   | cabalLibVersion <  Version [1,22,0] [] = flags_1_21_0
   | cabalLibVersion <  Version [1,23,0] [] = flags_1_22_0
+  | cabalLibVersion <  Version [1,24,1] [] = flags_1_24_0
   | otherwise = flags_latest
   where
     (profEnabledLib, profEnabledExe) = computeEffectiveProfiling flags
@@ -373,10 +374,14 @@ filterConfigureFlags flags cabalLibVersion
       configAllowNewer  = Just Cabal.AllowNewerNone
       }
 
+    -- Cabal < 1.24.1 doesn't know about '--hidir'.
+    flags_1_24_0 = flags_latest { configInstallDirs = configInstallDirs_1_24_0}
+    configInstallDirs_1_24_0 = (configInstallDirs flags) { hidir = NoFlag }
+
     -- Cabal < 1.23 doesn't know about '--profiling-detail'.
     -- Cabal < 1.23 has a hacked up version of 'enable-profiling'
     -- which we shouldn't use.
-    flags_1_22_0 = flags_latest { configProfDetail    = NoFlag
+    flags_1_22_0 = flags_1_24_0 { configProfDetail    = NoFlag
                                 , configProfLibDetail = NoFlag
                                 , configIPID          = NoFlag
                                 , configProf          = NoFlag
@@ -405,7 +410,7 @@ filterConfigureFlags flags cabalLibVersion
     -- Cabal < 1.18.0 doesn't know about --extra-prog-path and --sysconfdir.
     flags_1_18_0 = flags_1_19_0 { configProgramPathExtra = toNubList []
                                 , configInstallDirs = configInstallDirs_1_18_0}
-    configInstallDirs_1_18_0 = (configInstallDirs flags) { sysconfdir = NoFlag }
+    configInstallDirs_1_18_0 = (configInstallDirs flags_1_19_0) { sysconfdir = NoFlag }
     -- Cabal < 1.14.0 doesn't know about '--disable-benchmarks'.
     flags_1_14_0 = flags_1_18_0 { configBenchmarks  = NoFlag }
     -- Cabal < 1.12.0 doesn't know about '--enable/disable-executable-dynamic'

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -527,7 +527,7 @@ instance Arbitrary a => Arbitrary (InstallDirs a) where
         <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  4
         <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  8
         <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary -- 12
-        <*> arbitrary <*> arbitrary                             -- 14
+        <*> arbitrary <*> arbitrary <*> arbitrary               -- 15
 
 instance Arbitrary PackageDB where
     arbitrary = oneof [ pure GlobalPackageDB


### PR DESCRIPTION
This pull request:
* Adds a setting to indicate the directory for .hi interface files.
* On OSX, by default, puts library files (`.dylib`/`.a`) in a single shared directory in order to solve https://ghc.haskell.org/trac/ghc/ticket/12479