### PR TITLE
D.S.GHCJS.libAbiHash: exclude trailing newline.

### DIFF
--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -789,8 +789,9 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
            else error "libAbiHash: Can't find an enabled library way"
   --
   (ghcjsProg, _) <- requireProgram verbosity ghcjsProgram (withPrograms lbi)
-  getProgramInvocationOutput verbosity
-    (ghcInvocation ghcjsProg comp platform ghcArgs)
+  hash <- getProgramInvocationOutput verbosity
+          (ghcInvocation ghcjsProg comp platform ghcArgs)
+  return (takeWhile (not . isSpace) hash)
 
 adjustExts :: String -> String -> GhcOptions -> GhcOptions
 adjustExts hiSuf objSuf opts =


### PR DESCRIPTION
Already fixed in the parent module in 20e35704299bc1a38e81b289800fa7cfd49ce8cf.

Fixes #3915.