### PR TITLE
D.S.GHCJS.libAbiHash: exclude trailing newline.

### DIFF
--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -790,8 +790,9 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
            else error "libAbiHash: Can't find an enabled library way"
   --
   (ghcjsProg, _) <- requireProgram verbosity ghcjsProgram (withPrograms lbi)
-  getProgramInvocationOutput verbosity
-    (ghcInvocation ghcjsProg comp platform ghcArgs)
+  hash <- getProgramInvocationOutput verbosity
+          (ghcInvocation ghcjsProg comp platform ghcArgs)
+  return (takeWhile (not . isSpace) hash)
 
 adjustExts :: String -> String -> GhcOptions -> GhcOptions
 adjustExts hiSuf objSuf opts =

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -397,9 +397,9 @@ filterConfigureFlags flags cabalLibVersion
     flags_1_23_0 = flags_latest { configProfDetail    = NoFlag
                                 , configProfLibDetail = NoFlag
                                 , configIPID          = NoFlag
-                                , configProf = mempty
-                                , configProfExe = Flag tryExeProfiling
-                                , configProfLib = Flag tryLibProfiling
+                                , configProf          = NoFlag
+                                , configProfExe       = Flag tryExeProfiling
+                                , configProfLib       = Flag tryLibProfiling
                                 }
 
     -- Cabal < 1.22 doesn't know about '--disable-debug-info'.


### PR DESCRIPTION
Same as #3957, but for `master`. Also includes an unrelated formatting patch.

Fixes #3915.