### PR TITLE
Fix conflict counting bug

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install/Distribution/Solver/Modular/Explore.hs
@@ -60,7 +60,10 @@ backjump (EnableBackjumping enableBj) var initial xs =
           | otherwise                            = f (csAcc `CS.union` cs) cm'
 
     logBackjump :: ConflictSet QPN -> ConflictMap -> ConflictSetLog a
-    logBackjump cs cm = failWith (Failure cs Backjump) (cs, cm)
+    logBackjump cs cm = failWith (Failure cs Backjump) (cs, updateCM initial cm)
+                                   -- 'intial' instead of 'cs' here ---^
+                                   -- since we do not want to double-count the
+                                   -- additionally accumulated conflicts.
 
 type ConflictSetLog = RetryLog Message (ConflictSet QPN, ConflictMap)
 


### PR DESCRIPTION
Encountered during the implementation of #3570.

We used to miss a lot of conflicts during counting in `logBackjump`.
Counting initial conflicts here drastically reduces search time in some
cases.
Not sure whether counting the current conflicts (`cs`) may be even
better than counting the initial conflicts (`initial`) ⇒ Benchmarking by @kosmikus?