### PR TITLE
Add hidir setting - master branch

### DIFF
--- a/Cabal/Distribution/Make.hs
+++ b/Cabal/Distribution/Make.hs
@@ -31,7 +31,8 @@
 --              @--bindir@,
 --              @--libdir@,
 --              @--libexecdir@,
---              @--datadir@.
+--              @--datadir@,
+--              @--hidir@.
 --
 -- [BuildCmd] We assume that the default Makefile target will build everything.
 --

--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -71,7 +71,7 @@ generate pkg_descr lbi clbi =
         pragmas++
         "module " ++ display paths_modulename ++ " (\n"++
         "    version,\n"++
-        "    getBinDir, getLibDir, getDataDir, getLibexecDir,\n"++
+        "    getBinDir, getLibDir, getDataDir, getHiDir, getLibexecDir,\n"++
         "    getDataFileName, getSysconfDir\n"++
         "  ) where\n"++
         "\n"++
@@ -111,6 +111,7 @@ generate pkg_descr lbi clbi =
           "\ngetBinDir, getLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
           "getBinDir = "++mkGetEnvOrReloc "bindir" flat_bindirreloc++"\n"++
           "getLibDir = "++mkGetEnvOrReloc "libdir" flat_libdirreloc++"\n"++
+          "getHiDir = "++mkGetEnvOrReloc "hidir" flat_hidirreloc++"\n"++
           "getDataDir = "++mkGetEnvOrReloc "datadir" flat_datadirreloc++"\n"++
           "getLibexecDir = "++mkGetEnvOrReloc "libexecdir" flat_libexecdirreloc++"\n"++
           "getSysconfDir = "++mkGetEnvOrReloc "sysconfdir" flat_sysconfdirreloc++"\n"++
@@ -124,17 +125,19 @@ generate pkg_descr lbi clbi =
           "\n"++
           filename_stuff
         | absolute =
-          "\nbindir, libdir, datadir, libexecdir, sysconfdir :: FilePath\n"++
+          "\nbindir, libdir, datadir, hidir, libexecdir, sysconfdir :: FilePath\n"++
           "\nbindir     = " ++ show flat_bindir ++
           "\nlibdir     = " ++ show flat_libdir ++
           "\ndatadir    = " ++ show flat_datadir ++
+          "\nhidir      = " ++ show flat_hidir ++
           "\nlibexecdir = " ++ show flat_libexecdir ++
           "\nsysconfdir = " ++ show flat_sysconfdir ++
           "\n"++
-          "\ngetBinDir, getLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
+          "\ngetBinDir, getLibDir, getDataDir, getHiDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
           "getBinDir = "++mkGetEnvOr "bindir" "return bindir"++"\n"++
           "getLibDir = "++mkGetEnvOr "libdir" "return libdir"++"\n"++
           "getDataDir = "++mkGetEnvOr "datadir" "return datadir"++"\n"++
+          "getHiDir = "++mkGetEnvOr "hidir" "return hidir"++"\n"++
           "getLibexecDir = "++mkGetEnvOr "libexecdir" "return libexecdir"++"\n"++
           "getSysconfDir = "++mkGetEnvOr "sysconfdir" "return sysconfdir"++"\n"++
           "\n"++
@@ -154,6 +157,8 @@ generate pkg_descr lbi clbi =
           "getDataDir :: IO FilePath\n"++
           "getDataDir =  "++ mkGetEnvOr "datadir"
                               (mkGetDir flat_datadir flat_datadirrel)++"\n\n"++
+          "getHiDir :: IO FilePath\n"++
+          "getHiDir = "++mkGetDir flat_libdir flat_hidirrel++"\n\n"++
           "getLibexecDir :: IO FilePath\n"++
           "getLibexecDir = "++mkGetDir flat_libexecdir flat_libexecdirrel++"\n\n"++
           "getSysconfDir :: IO FilePath\n"++
@@ -176,6 +181,7 @@ generate pkg_descr lbi clbi =
           bindir     = flat_bindir,
           libdir     = flat_libdir,
           datadir    = flat_datadir,
+          hidir      = flat_hidir,
           libexecdir = flat_libexecdir,
           sysconfdir = flat_sysconfdir
         } = absoluteComponentInstallDirs pkg_descr lbi cid NoCopyDest
@@ -183,6 +189,7 @@ generate pkg_descr lbi clbi =
           bindir     = flat_bindirrel,
           libdir     = flat_libdirrel,
           datadir    = flat_datadirrel,
+          hidir      = flat_hidirrel,
           libexecdir = flat_libexecdirrel,
           sysconfdir = flat_sysconfdirrel
         } = prefixRelativeComponentInstallDirs (packageId pkg_descr) lbi cid
@@ -190,6 +197,7 @@ generate pkg_descr lbi clbi =
         flat_bindirreloc = shortRelativePath flat_prefix flat_bindir
         flat_libdirreloc = shortRelativePath flat_prefix flat_libdir
         flat_datadirreloc = shortRelativePath flat_prefix flat_datadir
+        flat_hidirreloc = shortRelativePath flat_prefix flat_hidir
         flat_libexecdirreloc = shortRelativePath flat_prefix flat_libexecdir
         flat_sysconfdirreloc = shortRelativePath flat_prefix flat_sysconfdir
 

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -734,6 +734,7 @@ configure (pkg_descr0', pbi) cfg = do
 
     dirinfo "Binaries"         (bindir dirs)     (bindir relative)
     dirinfo "Libraries"        (libdir dirs)     (libdir relative)
+    dirinfo "Interfaces"       (hidir dirs)      (hidir relative)
     dirinfo "Private binaries" (libexecdir dirs) (libexecdir relative)
     dirinfo "Data files"       (datadir dirs)    (datadir relative)
     dirinfo "Documentation"    (docdir dirs)     (docdir relative)
@@ -1766,7 +1767,7 @@ checkRelocatable verbosity pkg lbi
           all isJust
               (fmap (stripPrefix p)
                     [ bindir, libdir, dynlibdir, libexecdir, includedir, datadir
-                    , docdir, mandir, htmldir, haddockdir, sysconfdir] )
+                    , hidir, docdir, mandir, htmldir, haddockdir, sysconfdir] )
 
     -- Check if the library dirs of the dependencies that are in the package
     -- database to which the package is installed are relative to the

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1151,13 +1151,14 @@ installExe verbosity lbi installDirs buildPref
 installLib    :: Verbosity
               -> LocalBuildInfo
               -> FilePath  -- ^install location
+              -> FilePath  -- ^install location for interface files
               -> FilePath  -- ^install location for dynamic libraries
               -> FilePath  -- ^Build location
               -> PackageDescription
               -> Library
               -> ComponentLocalBuildInfo
               -> IO ()
-installLib verbosity lbi targetDir dynlibTargetDir _builtDir _pkg lib clbi = do
+installLib verbosity lbi targetDir dynlibTargetDir hiTargetDir _builtDir _pkg lib clbi = do
   -- copy .hi files over:
   whenVanilla $ copyModuleFiles "hi"
   whenProf    $ copyModuleFiles "p_hi"
@@ -1190,7 +1191,7 @@ installLib verbosity lbi targetDir dynlibTargetDir _builtDir _pkg lib clbi = do
 
     copyModuleFiles ext =
       findModuleFiles [builtDir] [ext] (allLibModules lib clbi)
-      >>= installOrdinaryFiles verbosity targetDir
+      >>= installOrdinaryFiles verbosity hiTargetDir
 
     compiler_id = compilerId (compiler lbi)
     uid = componentUnitId clbi

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -169,6 +169,7 @@ copyComponent :: Verbosity -> PackageDescription
 copyComponent verbosity pkg_descr lbi (CLib lib) clbi copydest = do
     let InstallDirs{
             libdir = libPref,
+            hidir = hiPref,
             includedir = incPref
             } = absoluteComponentInstallDirs pkg_descr lbi (componentUnitId clbi) copydest
         buildPref = componentBuildDir lbi clbi
@@ -187,7 +188,7 @@ copyComponent verbosity pkg_descr lbi (CLib lib) clbi copydest = do
     installIncludeFiles verbosity lib incPref
 
     case compilerFlavor (compiler lbi) of
-      GHC   -> GHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr lib clbi
+      GHC   -> GHC.installLib   verbosity lbi libPref dynlibPref hiPref    buildPref pkg_descr lib clbi
       GHCJS -> GHCJS.installLib verbosity lbi libPref dynlibPref buildPref pkg_descr lib clbi
       LHC   -> LHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr lib clbi
       JHC   -> JHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr lib clbi

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -193,7 +193,9 @@ defaultInstallDirs' False comp userInstall _hasLibs = do
            JHC    -> "$compiler"
            LHC    -> "$compiler"
            UHC    -> "$pkgid"
-           _other -> "$abi" </> "$libname",
+           _other -> case buildOS of
+                        OSX      -> "$abi" -- OSX libs go into a single directory
+                        _otherOS -> "$abi" </> "$libname",
       dynlibdir    = "$libdir",
       libexecdir   = case buildOS of
         Windows   -> "$prefix" </> "$libname"

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -27,6 +27,8 @@ module Distribution.Simple.InstallDirs (
         InstallDirTemplates,
         defaultInstallDirs,
         defaultInstallDirs',
+        defaultLibSubDir,
+        defaultLibSubDir',
         combineInstallDirs,
         absoluteInstallDirs,
         CopyDest(..),
@@ -189,14 +191,7 @@ defaultInstallDirs' False comp userInstall _hasLibs = do
       prefix       = installPrefix,
       bindir       = "$prefix" </> "bin",
       libdir       = installLibDir,
-      libsubdir    = case comp of
-           JHC    -> "$compiler"
-           LHC    -> "$compiler"
-           UHC    -> "$pkgid"
-           _other -> case buildOS of
-                        OSX      -> "$abi" -- OSX libs go into a single directory
-                                           -- See: https://ghc.haskell.org/trac/ghc/ticket/12479
-                        _otherOS -> "$abi" </> "$libname",
+      libsubdir    = defaultLibSubDir comp,
       dynlibdir    = "$libdir",
       libexecdir   = case buildOS of
         Windows   -> "$prefix" </> "$libname"
@@ -217,6 +212,25 @@ defaultInstallDirs' False comp userInstall _hasLibs = do
       haddockdir   = "$htmldir",
       sysconfdir   = "$prefix" </> "etc"
   }
+
+-- | Default $libsubdir
+defaultLibSubDir :: CompilerFlavor -> FilePath
+defaultLibSubDir comp = case comp of
+  JHC    -> "$compiler"
+  LHC    -> "$compiler"
+  UHC    -> "$pkgid"
+  _other -> case buildOS of
+               OSX      -> "$abi" -- OSX libs go into a single directory
+                                  -- See: https://ghc.haskell.org/trac/ghc/ticket/12479
+               _otherOS -> "$abi" </> "$libname"
+
+-- | Default $libsubdir for Cabal < 1.25
+defaultLibSubDir' :: CompilerFlavor -> FilePath
+defaultLibSubDir' comp = case comp of
+  JHC    -> "$compiler"
+  LHC    -> "$compiler"
+  UHC    -> "$pkgid"
+  _other -> "$abi" </> "$libname"
 
 -- ---------------------------------------------------------------------------
 -- Converting directories, absolute or prefix-relative

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -86,6 +86,7 @@ data InstallDirs dir = InstallDirs {
         includedir   :: dir,
         datadir      :: dir,
         datasubdir   :: dir,
+        hidir        :: dir,
         docdir       :: dir,
         mandir       :: dir,
         htmldir      :: dir,
@@ -116,6 +117,7 @@ combineInstallDirs combine a b = InstallDirs {
     includedir   = includedir a `combine` includedir b,
     datadir      = datadir a    `combine` datadir b,
     datasubdir   = datasubdir a `combine` datasubdir b,
+    hidir        = hidir a      `combine` hidir b,
     docdir       = docdir a     `combine` docdir b,
     mandir       = mandir a     `combine` mandir b,
     htmldir      = htmldir a    `combine` htmldir b,
@@ -201,6 +203,11 @@ defaultInstallDirs' False comp userInstall _hasLibs = do
         Windows   -> "$prefix"
         _other    -> "$prefix" </> "share",
       datasubdir   = "$abi" </> "$pkgid",
+      hidir        = installLibDir </> case comp of
+           JHC    -> "$compiler"
+           LHC    -> "$compiler"
+           UHC    -> "$pkgid"
+           _other -> "$abi" </> "$libname",
       docdir       = "$datadir" </> "doc" </> "$abi" </> "$pkgid",
       mandir       = "$datadir" </> "man",
       htmldir      = "$docdir"  </> "html",
@@ -238,6 +245,7 @@ substituteInstallDirTemplates env dirs = dirs'
       includedir = subst includedir prefixBinLibVars,
       datadir    = subst datadir    prefixBinLibVars,
       datasubdir = subst datasubdir [],
+      hidir      = subst hidir      prefixBinLibVars,
       docdir     = subst docdir     prefixBinLibDataVars,
       mandir     = subst mandir     (prefixBinLibDataVars ++ [docdirVar]),
       htmldir    = subst htmldir    (prefixBinLibDataVars ++ [docdirVar]),
@@ -343,6 +351,7 @@ data PathTemplateVariable =
      | LibsubdirVar  -- ^ The @$libsubdir@ path variable
      | DatadirVar    -- ^ The @$datadir@ path variable
      | DatasubdirVar -- ^ The @$datasubdir@ path variable
+     | HidirVar      -- ^ The @$hidir@ path variable
      | DocdirVar     -- ^ The @$docdir@ path variable
      | HtmldirVar    -- ^ The @$htmldir@ path variable
      | PkgNameVar    -- ^ The @$pkg@ package name path variable
@@ -440,6 +449,7 @@ installDirsTemplateEnv dirs =
   ,(LibsubdirVar,  libsubdir  dirs)
   ,(DatadirVar,    datadir    dirs)
   ,(DatasubdirVar, datasubdir dirs)
+  ,(HidirVar,      hidir      dirs)
   ,(DocdirVar,     docdir     dirs)
   ,(HtmldirVar,    htmldir    dirs)
   ]
@@ -462,6 +472,7 @@ instance Show PathTemplateVariable where
   show LibsubdirVar  = "libsubdir"
   show DatadirVar    = "datadir"
   show DatasubdirVar = "datasubdir"
+  show HidirVar      = "hidir"
   show DocdirVar     = "docdir"
   show HtmldirVar    = "htmldir"
   show PkgNameVar    = "pkg"
@@ -490,6 +501,7 @@ instance Read PathTemplateVariable where
                  ,("libsubdir",  LibsubdirVar)
                  ,("datadir",    DatadirVar)
                  ,("datasubdir", DatasubdirVar)
+                 ,("hidir",      HidirVar)
                  ,("docdir",     DocdirVar)
                  ,("htmldir",    HtmldirVar)
                  ,("pkgid",      PkgIdVar)

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -195,6 +195,7 @@ defaultInstallDirs' False comp userInstall _hasLibs = do
            UHC    -> "$pkgid"
            _other -> case buildOS of
                         OSX      -> "$abi" -- OSX libs go into a single directory
+                                           -- See: https://ghc.haskell.org/trac/ghc/ticket/12479
                         _otherOS -> "$abi" </> "$libname",
       dynlibdir    = "$libdir",
       libexecdir   = case buildOS of

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -206,7 +206,7 @@ defaultInstallDirs' False comp userInstall _hasLibs = do
         Windows   -> "$prefix"
         _other    -> "$prefix" </> "share",
       datasubdir   = "$abi" </> "$pkgid",
-      hidir        = installLibDir </> case comp of
+      hidir        = "$libdir" </> case comp of
            JHC    -> "$compiler"
            LHC    -> "$compiler"
            UHC    -> "$pkgid"

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -408,7 +408,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     IPI.exposedModules     = componentExposedModules clbi,
     IPI.hiddenModules      = otherModules bi,
     IPI.trusted            = IPI.trusted IPI.emptyInstalledPackageInfo,
-    IPI.importDirs         = [ libdir installDirs | hasModules ],
+    IPI.importDirs         = [ hidir installDirs | hasModules ],
     -- Note. the libsubdir and datasubdir templates have already been expanded
     -- into libdir and datadir.
     IPI.libraryDirs        = if hasLibrary
@@ -466,6 +466,7 @@ inplaceInstalledPackageInfo inplaceDir distPref pkg abi_hash lib lbi clbi =
       (absoluteComponentInstallDirs pkg lbi (componentUnitId clbi) NoCopyDest) {
         libdir     = inplaceDir </> libTargetDir,
         datadir    = inplaceDir </> dataDir pkg,
+        hidir      = inplaceDir </> libTargetDir,
         docdir     = inplaceDocdir,
         htmldir    = inplaceHtmldir,
         haddockdir = inplaceHtmldir

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -917,6 +917,11 @@ installDirsOptions =
       datasubdir (\v flags -> flags { datasubdir = v })
       installDirArg
 
+  , option "" ["hidir"]
+      "installation directory for library interface files"
+      hidir (\v flags -> flags { hidir = v })
+      installDirArg
+
   , option "" ["docdir"]
       "installation directory for documentation"
       docdir (\v flags -> flags { docdir = v })

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2304,7 +2304,7 @@ The actual location of all these directories can be individually
 overridden at runtime using environment variables of the form
 ``pkg_name_var``, where ``pkg_name`` is the name of the package with all
 hyphens converted into underscores, and ``var`` is either ``bindir``,
-``libdir``, ``datadir``, ``libexedir`` or ``sysconfdir``. For example,
+``libdir``, ``hidir``, ``datadir``, ``libexedir`` or ``sysconfdir``. For example,
 the configured data directory for ``pretty-show`` is controlled with the
 ``pretty_show_datadir`` environment variable.
 
@@ -2550,7 +2550,7 @@ a few options:
    ``unregister``, ``clean``, ``dist`` and ``docs``. Some options to
    commands are passed through as follows:
 
-   -  The ``--with-hc-pkg``, ``--prefix``, ``--bindir``, ``--libdir``,
+   -  The ``--with-hc-pkg``, ``--prefix``, ``--bindir``, ``--libdir``, ``--hidir``,
       ``--datadir``, ``--libexecdir`` and ``--sysconfdir`` options to
       the ``configure`` command are passed on to the ``configure``
       script. In addition the value of the ``--with-compiler`` option is
@@ -2568,6 +2568,7 @@ a few options:
                   $(MAKE) install prefix=$(destdir)/$(prefix) \
                                   bindir=$(destdir)/$(bindir) \
                                   libdir=$(destdir)/$(libdir) \
+                                  hidir=$(destdir)/$(hidir) \
                                   datadir=$(destdir)/$(datadir) \
                                   libexecdir=$(destdir)/$(libexecdir) \
                                   sysconfdir=$(destdir)/$(sysconfdir) \

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -604,6 +604,9 @@ package:
 
     Interfaces of libraries are installed here.
 
+    By default, this is the same as `$libdir/$libsubdir`; except on OS X, where
+    `$libsubdir` is set to `$abi`, but this setting is `$libdir/$abi/$libname`.
+
     In the simple build system, *dir* may contain the following path
     variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$libsubdir``,
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
@@ -780,8 +783,8 @@ For the simple build system, the following defaults apply:
       - ``$pkgid/$compiler``
       - ``$pkgid\$compiler``
     * - :option:`--hidir`
-      - ``$prefix/lib/$pkgid/$compiler``
-      - ``$prefix\$pkgid\$compiler``
+      - ``$libdir/$pkgid/$compiler``
+      - ``$libdir\$pkgid\$compiler``
     * - :option:`--libexecdir`
       - ``$prefix/libexec``
       - ``$prefix\$pkgid``

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -465,7 +465,7 @@ parameters <developing-packages.html#system-dependent-parameters>`__ or
 on `complex
 packages <developing-packages.html#more-complex-packages>`__), it is
 passed the :option:`--with-hc-pkg`, :option:`--prefix`, :option:`--bindir`,
-:option:`--libdir`, :option:`--datadir`, :option:`--libexecdir` and
+:option:`--libdir`, :option:`--hidir`, :option:`--datadir`, :option:`--libexecdir` and
 :option:`--sysconfdir` options. In addition the value of the
 :option:`--with-compiler` option is passed in a :option:`--with-hc-pkg` option
 and all options specified with :option:`--configure-option` are passed on.
@@ -600,6 +600,15 @@ package:
     ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
+.. option:: --hidir=dir
+
+    Interfaces of libraries are installed here.
+
+    In the simple build system, *dir* may contain the following path
+    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$libsubdir``,
+    ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
+    ``$arch``, ``$abi``, ``$abitag``
+
 .. option:: --libexecdir=dir
 
     Executables that are not expected to be invoked directly by the user
@@ -712,6 +721,8 @@ $libdir
     As above but for :option:`--libdir`
 $libsubdir
     As above but for :option:`--libsubdir`
+$hidir
+    As above but for :option:`--hidir`
 $datadir
     As above but for :option:`--datadir`
 $datasubdir
@@ -768,6 +779,9 @@ For the simple build system, the following defaults apply:
     * - :option:`--libsubdir` (others)
       - ``$pkgid/$compiler``
       - ``$pkgid\$compiler``
+    * - :option:`--hidir`
+      - ``$prefix/lib/$pkgid/$compiler``
+      - ``$prefix\$pkgid\$compiler``
     * - :option:`--libexecdir`
       - ``$prefix/libexec``
       - ``$prefix\$pkgid``
@@ -809,7 +823,7 @@ particularly useful: it means the user can choose the install location
 bake the path into the binary when it is built.
 
 In order to achieve this, we require that for an executable on Windows,
-all of ``$bindir``, ``$libdir``, ``$datadir`` and ``$libexecdir`` begin
+all of ``$bindir``, ``$libdir``, ``$hidir``, ``$datadir`` and ``$libexecdir`` begin
 with ``$prefix``. If this is not the case then the compiled executable
 will have baked-in all absolute paths.
 

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -15,7 +15,7 @@ import Distribution.Types.LocalBuildInfo
 
 import Distribution.Simple.LocalBuildInfo
   ( absoluteComponentInstallDirs
-  , InstallDirs(libdir)
+  , InstallDirs(libdir,hidir)
   , ComponentLocalBuildInfo(componentUnitId), ComponentName(..) )
 import Distribution.Simple.InstallDirs ( CopyDest(NoCopyDest) )
 import Distribution.Simple.BuildPaths  ( mkLibName, mkSharedLibName )
@@ -779,8 +779,10 @@ tests config = do
                 uid = componentUnitId (targetCLBI target)
                 dir = libdir (absoluteComponentInstallDirs pkg_descr lbi uid
                               NoCopyDest)
+                hdir = hidir (absoluteComponentInstallDirs pkg_descr lbi uid
+                              NoCopyDest)
             assertBool "interface files should be installed"
-                =<< liftIO (doesFileExist (dir </> "Foo.hi"))
+                =<< liftIO (doesFileExist (hdir </> "Foo.hi"))
             assertBool "static library should be installed"
                 =<< liftIO (doesFileExist (dir </> mkLibName uid))
             if is_dynamic

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2526,6 +2526,7 @@ storePackageInstallDirs CabalDirLayout{cabalStorePackageDirectory}
     includedir   = libdir </> "include"
     datadir      = prefix </> "share"
     datasubdir   = ""
+    hidir        = prefix </> "lib"
     docdir       = datadir </> "doc"
     mandir       = datadir </> "man"
     htmldir      = docdir  </> "html"

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -95,7 +95,7 @@ import Distribution.Simple.Setup
          , boolOpt, boolOpt', trueArg, falseArg
          , readPToMaybe, optionNumJobs )
 import Distribution.Simple.InstallDirs
-         ( PathTemplate, InstallDirs(sysconfdir)
+         ( PathTemplate, InstallDirs(hidir, sysconfdir)
          , toPathTemplate, fromPathTemplate )
 import Distribution.Version
          ( Version, mkVersion, nullVersion, anyVersion, thisVersion )
@@ -363,7 +363,7 @@ filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
   -- NB: we expect the latest version to be the most common case,
   -- so test it first.
-  | cabalLibVersion >= mkVersion [1,23,0] = flags_latest
+  | cabalLibVersion >= mkVersion [1,25,0] = flags_latest
   -- The naming convention is that flags_version gives flags with
   -- all flags *introduced* in version eliminated.
   -- It is NOT the latest version of Cabal library that
@@ -379,6 +379,7 @@ filterConfigureFlags flags cabalLibVersion
   | cabalLibVersion < mkVersion [1,21,1] = flags_1_21_1
   | cabalLibVersion < mkVersion [1,22,0] = flags_1_22_0
   | cabalLibVersion < mkVersion [1,23,0] = flags_1_23_0
+  | cabalLibVersion < mkVersion [1,25,0] = flags_1_25_0
   | otherwise = flags_latest
   where
     flags_latest = flags        {
@@ -390,11 +391,15 @@ filterConfigureFlags flags cabalLibVersion
       configAllowNewer  = Just (Cabal.AllowNewer Cabal.RelaxDepsNone)
       }
 
+    -- Cabal < 1.25 doesn't know about '--hidir'
+    flags_1_25_0 = flags_latest { configInstallDirs = configInstallDirs_1_25_0 }
+    configInstallDirs_1_25_0 = (configInstallDirs flags) { hidir = NoFlag }
+
     -- Cabal < 1.23 doesn't know about '--profiling-detail'.
     -- Cabal < 1.23 has a hacked up version of 'enable-profiling'
     -- which we shouldn't use.
     (tryLibProfiling, tryExeProfiling) = computeEffectiveProfiling flags
-    flags_1_23_0 = flags_latest { configProfDetail    = NoFlag
+    flags_1_23_0 = flags_1_25_0 { configProfDetail    = NoFlag
                                 , configProfLibDetail = NoFlag
                                 , configIPID          = NoFlag
                                 , configProf          = NoFlag
@@ -423,7 +428,7 @@ filterConfigureFlags flags cabalLibVersion
     -- Cabal < 1.18.0 doesn't know about --extra-prog-path and --sysconfdir.
     flags_1_18_0 = flags_1_19_1 { configProgramPathExtra = toNubList []
                                 , configInstallDirs = configInstallDirs_1_18_0}
-    configInstallDirs_1_18_0 = (configInstallDirs flags) { sysconfdir = NoFlag }
+    configInstallDirs_1_18_0 = (configInstallDirs flags_1_19_1) { sysconfdir = NoFlag }
     -- Cabal < 1.14.0 doesn't know about '--disable-benchmarks'.
     flags_1_14_0 = flags_1_18_0 { configBenchmarks  = NoFlag }
     -- Cabal < 1.12.0 doesn't know about '--enable/disable-executable-dynamic'

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -539,7 +539,7 @@ instance Arbitrary a => Arbitrary (InstallDirs a) where
         <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  4
         <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  8
         <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary -- 12
-        <*> arbitrary <*> arbitrary                             -- 14
+        <*> arbitrary <*> arbitrary <*> arbitrary               -- 15
 
 instance Arbitrary PackageDB where
     arbitrary = oneof [ pure GlobalPackageDB


### PR DESCRIPTION
This is the version of https://github.com/haskell/cabal/pull/3955 based against master (instead of v1.24.0.0)

This pull request:
* Adds a setting to indicate the directory for .hi interface files.
* On OSX, by default, puts library files (`.dylib`/`.a`) in a single shared directory in order to solve https://ghc.haskell.org/trac/ghc/ticket/12479