### PR TITLE
Dedupe include dirs inherited from dependencies

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -1603,8 +1603,12 @@ checkForeignDeps pkg lbi verbosity = do
                      ++ collectField PD.cppOptions
                      ++ collectField PD.ccOptions
                      ++ [ "-I" ++ dir
-                        | dep <- deps
-                        , dir <- Installed.includeDirs dep ]
+                        | dir <- ordNub [ dir
+                                        | dep <- deps
+                                        , dir <- Installed.includeDirs dep ]
+                                 -- dedupe include dirs of dependencies
+                                 -- to prevent quadratic blow-up
+                        ]
                      ++ [ opt
                         | dep <- deps
                         , opt <- Installed.ccOptions dep ]


### PR DESCRIPTION
If you build a big number of packages, all with
the same extra -I flags, the flags get inherited
by the dependent packages and duplicated.
For big dependency trees it can exceed the
maximum command line length on some systems,
this happened to me with Linux and hoogle 5.

This patch decreases the redundancy by
dropping all but the first occurrence of
an include dir, preserving the semantics,
as they are processed left to right.