### PR TITLE
Store interfaces files separately from library object files 

### DIFF
--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -71,7 +71,7 @@ generate pkg_descr lbi clbi =
         pragmas++
         "module " ++ display paths_modulename ++ " (\n"++
         "    version,\n"++
-        "    getBinDir, getLibDir, getDataDir, getLibexecDir,\n"++
+        "    getBinDir, getLibDir, getHiDir, getDataDir, getLibexecDir,\n"++
         "    getDataFileName, getSysconfDir\n"++
         "  ) where\n"++
         "\n"++
@@ -108,9 +108,10 @@ generate pkg_descr lbi clbi =
           "\n\nbindirrel :: FilePath\n" ++
           "bindirrel = " ++ show flat_bindirreloc ++
           "\n"++
-          "\ngetBinDir, getLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
+          "\ngetBinDir, getLibDir, getHiDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
           "getBinDir = "++mkGetEnvOrReloc "bindir" flat_bindirreloc++"\n"++
           "getLibDir = "++mkGetEnvOrReloc "libdir" flat_libdirreloc++"\n"++
+          "getHiDir = "++mkGetEnvOrReloc "libdir" flat_hidirreloc++"\n"++
           "getDataDir = "++mkGetEnvOrReloc "datadir" flat_datadirreloc++"\n"++
           "getLibexecDir = "++mkGetEnvOrReloc "libexecdir" flat_libexecdirreloc++"\n"++
           "getSysconfDir = "++mkGetEnvOrReloc "sysconfdir" flat_sysconfdirreloc++"\n"++
@@ -124,16 +125,18 @@ generate pkg_descr lbi clbi =
           "\n"++
           filename_stuff
         | absolute =
-          "\nbindir, libdir, datadir, libexecdir, sysconfdir :: FilePath\n"++
+          "\nbindir, libdir, hidir, datadir, libexecdir, sysconfdir :: FilePath\n"++
           "\nbindir     = " ++ show flat_bindir ++
           "\nlibdir     = " ++ show flat_libdir ++
+          "\nhidir      = " ++ show flat_hidir ++
           "\ndatadir    = " ++ show flat_datadir ++
           "\nlibexecdir = " ++ show flat_libexecdir ++
           "\nsysconfdir = " ++ show flat_sysconfdir ++
           "\n"++
-          "\ngetBinDir, getLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
+          "\ngetBinDir, getLibDir, getHiDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
           "getBinDir = "++mkGetEnvOr "bindir" "return bindir"++"\n"++
           "getLibDir = "++mkGetEnvOr "libdir" "return libdir"++"\n"++
+          "getHiDir = "++mkGetEnvOr "hidir" "return hidir"++"\n"++
           "getDataDir = "++mkGetEnvOr "datadir" "return datadir"++"\n"++
           "getLibexecDir = "++mkGetEnvOr "libexecdir" "return libexecdir"++"\n"++
           "getSysconfDir = "++mkGetEnvOr "sysconfdir" "return sysconfdir"++"\n"++
@@ -151,6 +154,8 @@ generate pkg_descr lbi clbi =
           "getBinDir = getPrefixDirRel bindirrel\n\n"++
           "getLibDir :: IO FilePath\n"++
           "getLibDir = "++mkGetDir flat_libdir flat_libdirrel++"\n\n"++
+          "getHiDir :: IO FilePath\n"++
+          "getHiDir = "++mkGetDir flat_hidir flat_hidirrel++"\n\n"++
           "getDataDir :: IO FilePath\n"++
           "getDataDir =  "++ mkGetEnvOr "datadir"
                               (mkGetDir flat_datadir flat_datadirrel)++"\n\n"++
@@ -175,6 +180,7 @@ generate pkg_descr lbi clbi =
           prefix     = flat_prefix,
           bindir     = flat_bindir,
           libdir     = flat_libdir,
+          hidir      = flat_hidir,
           datadir    = flat_datadir,
           libexecdir = flat_libexecdir,
           sysconfdir = flat_sysconfdir
@@ -182,6 +188,7 @@ generate pkg_descr lbi clbi =
         InstallDirs {
           bindir     = flat_bindirrel,
           libdir     = flat_libdirrel,
+          hidir      = flat_hidirrel,
           datadir    = flat_datadirrel,
           libexecdir = flat_libexecdirrel,
           sysconfdir = flat_sysconfdirrel
@@ -189,6 +196,7 @@ generate pkg_descr lbi clbi =
 
         flat_bindirreloc = shortRelativePath flat_prefix flat_bindir
         flat_libdirreloc = shortRelativePath flat_prefix flat_libdir
+        flat_hidirreloc = shortRelativePath flat_prefix flat_hidir
         flat_datadirreloc = shortRelativePath flat_prefix flat_datadir
         flat_libexecdirreloc = shortRelativePath flat_prefix flat_libexecdir
         flat_sysconfdirreloc = shortRelativePath flat_prefix flat_sysconfdir

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -734,6 +734,7 @@ configure (pkg_descr0', pbi) cfg = do
 
     dirinfo "Binaries"         (bindir dirs)     (bindir relative)
     dirinfo "Libraries"        (libdir dirs)     (libdir relative)
+    dirinfo "Interfaces"       (hidir dirs)      (hidir relative)
     dirinfo "Private binaries" (libexecdir dirs) (libexecdir relative)
     dirinfo "Data files"       (datadir dirs)    (datadir relative)
     dirinfo "Documentation"    (docdir dirs)     (docdir relative)
@@ -1770,7 +1771,7 @@ checkRelocatable verbosity pkg lbi
           all isJust
               (fmap (stripPrefix p)
                     [ bindir, libdir, dynlibdir, libexecdir, includedir, datadir
-                    , docdir, mandir, htmldir, haddockdir, sysconfdir] )
+                    , hidir, docdir, mandir, htmldir, haddockdir, sysconfdir] )
 
     -- Check if the library dirs of the dependencies that are in the package
     -- database to which the package is installed are relative to the

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1152,12 +1152,13 @@ installLib    :: Verbosity
               -> LocalBuildInfo
               -> FilePath  -- ^install location
               -> FilePath  -- ^install location for dynamic libraries
+              -> FilePath  -- ^install location for interfaces
               -> FilePath  -- ^Build location
               -> PackageDescription
               -> Library
               -> ComponentLocalBuildInfo
               -> IO ()
-installLib verbosity lbi targetDir dynlibTargetDir _builtDir _pkg lib clbi = do
+installLib verbosity lbi targetDir dynlibTargetDir hiTargetDir _builtDir _pkg lib clbi = do
   -- copy .hi files over:
   whenVanilla $ copyModuleFiles "hi"
   whenProf    $ copyModuleFiles "p_hi"
@@ -1190,7 +1191,7 @@ installLib verbosity lbi targetDir dynlibTargetDir _builtDir _pkg lib clbi = do
 
     copyModuleFiles ext =
       findModuleFiles [builtDir] [ext] (allLibModules lib clbi)
-      >>= installOrdinaryFiles verbosity targetDir
+      >>= installOrdinaryFiles verbosity hiTargetDir
 
     compiler_id = compilerId (compiler lbi)
     uid = componentUnitId clbi

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -169,6 +169,7 @@ copyComponent :: Verbosity -> PackageDescription
 copyComponent verbosity pkg_descr lbi (CLib lib) clbi copydest = do
     let InstallDirs{
             libdir = libPref,
+            hidir = hiPref,
             includedir = incPref
             } = absoluteComponentInstallDirs pkg_descr lbi (componentUnitId clbi) copydest
         buildPref = componentBuildDir lbi clbi
@@ -187,7 +188,7 @@ copyComponent verbosity pkg_descr lbi (CLib lib) clbi copydest = do
     installIncludeFiles verbosity lib incPref
 
     case compilerFlavor (compiler lbi) of
-      GHC   -> GHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr lib clbi
+      GHC   -> GHC.installLib   verbosity lbi libPref dynlibPref hiPref buildPref pkg_descr lib clbi
       GHCJS -> GHCJS.installLib verbosity lbi libPref dynlibPref buildPref pkg_descr lib clbi
       LHC   -> LHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr lib clbi
       JHC   -> JHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr lib clbi

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -80,7 +80,17 @@ data InstallDirs dir = InstallDirs {
         prefix       :: dir,
         bindir       :: dir,
         libdir       :: dir,
-        libsubdir    :: dir,
+        commonlibdir :: dir,
+        hidir        :: dir,
+        libsubdir    :: dir, -- This field is basically deprecated by the
+                             -- introduction of commonlibdir and hidir. However,
+                             -- We must keep it so that we can still work with
+                             -- Setup executables build against an older version
+                             -- of Cabal. For the same reason, we cannot
+                             -- simply use libsubdir as the commonlibdir,
+                             -- because then Setup's build against an older
+                             -- Cabal would put .hi files in the same directory
+                             -- as the library object files
         dynlibdir    :: dir,
         libexecdir   :: dir,
         includedir   :: dir,
@@ -110,6 +120,8 @@ combineInstallDirs combine a b = InstallDirs {
     prefix       = prefix a     `combine` prefix b,
     bindir       = bindir a     `combine` bindir b,
     libdir       = libdir a     `combine` libdir b,
+    commonlibdir = commonlibdir a `combine` commonlibdir b,
+    hidir        = hidir a      `combine` hidir b,
     libsubdir    = libsubdir a  `combine` libsubdir b,
     dynlibdir    = dynlibdir a  `combine` dynlibdir b,
     libexecdir   = libexecdir a `combine` libexecdir b,
@@ -125,9 +137,9 @@ combineInstallDirs combine a b = InstallDirs {
 
 appendSubdirs :: (a -> a -> a) -> InstallDirs a -> InstallDirs a
 appendSubdirs append dirs = dirs {
-    libdir     = libdir dirs `append` libsubdir dirs,
+    libdir     = libdir dirs `append` commonlibdir dirs,
     datadir    = datadir dirs `append` datasubdir dirs,
-    libsubdir  = error "internal error InstallDirs.libsubdir",
+    commonlibdir = error "internal error InstallDirs.commonlibdir",
     datasubdir = error "internal error InstallDirs.datasubdir"
   }
 
@@ -148,7 +160,7 @@ appendSubdirs append dirs = dirs {
 -- users to be able to configure @--libdir=\/usr\/lib64@ for example but
 -- because by default we want to support installing multiple versions of
 -- packages and building the same package for multiple compilers we append the
--- libsubdir to get: @\/usr\/lib64\/$libname\/$compiler@.
+-- commonlibdir to get: @\/usr\/lib64\/$libname\/$compiler@.
 --
 -- An additional complication is the need to support relocatable packages on
 -- systems which support such things, like Windows.
@@ -187,6 +199,16 @@ defaultInstallDirs' False comp userInstall _hasLibs = do
       prefix       = installPrefix,
       bindir       = "$prefix" </> "bin",
       libdir       = installLibDir,
+      commonlibdir = case comp of
+           JHC    -> "$compiler"
+           LHC    -> "$compiler"
+           UHC    -> "$pkgid"
+           _other -> "$abi",
+      hidir        = "$libdir" </> case comp of
+           JHC    -> "$compiler"
+           LHC    -> "$compiler"
+           UHC    -> "$pkgid"
+           _other -> "$abi" </> "$libname",
       libsubdir    = case comp of
            JHC    -> "$compiler"
            LHC    -> "$compiler"
@@ -196,7 +218,7 @@ defaultInstallDirs' False comp userInstall _hasLibs = do
       libexecdir   = case buildOS of
         Windows   -> "$prefix" </> "$libname"
         _other    -> "$prefix" </> "libexec",
-      includedir   = "$libdir" </> "$libsubdir" </> "include",
+      includedir   = "$hidir" </> "include",
       datadir      = case buildOS of
         Windows   -> "$prefix"
         _other    -> "$prefix" </> "share",
@@ -232,10 +254,12 @@ substituteInstallDirTemplates env dirs = dirs'
       prefix     = subst prefix     [],
       bindir     = subst bindir     [prefixVar],
       libdir     = subst libdir     [prefixVar, bindirVar],
+      commonlibdir = subst commonlibdir [],
+      hidir      = subst hidir      prefixBinLibVars,
       libsubdir  = subst libsubdir  [],
       dynlibdir  = subst dynlibdir  [prefixVar, bindirVar, libdirVar],
       libexecdir = subst libexecdir prefixBinLibVars,
-      includedir = subst includedir prefixBinLibVars,
+      includedir = subst includedir (prefixBinLibVars ++ [hidirVar]),
       datadir    = subst datadir    prefixBinLibVars,
       datasubdir = subst datasubdir [],
       docdir     = subst docdir     prefixBinLibDataVars,
@@ -250,12 +274,13 @@ substituteInstallDirTemplates env dirs = dirs'
     prefixVar        = (PrefixVar,     prefix     dirs')
     bindirVar        = (BindirVar,     bindir     dirs')
     libdirVar        = (LibdirVar,     libdir     dirs')
-    libsubdirVar     = (LibsubdirVar,  libsubdir  dirs')
+    commonlibdirVar  = (CommonlibdirVar, commonlibdir dirs')
+    hidirVar         = (HidirVar,      hidir      dirs')
     datadirVar       = (DatadirVar,    datadir    dirs')
     datasubdirVar    = (DatasubdirVar, datasubdir dirs')
     docdirVar        = (DocdirVar,     docdir     dirs')
     htmldirVar       = (HtmldirVar,    htmldir    dirs')
-    prefixBinLibVars = [prefixVar, bindirVar, libdirVar, libsubdirVar]
+    prefixBinLibVars = [prefixVar, bindirVar, libdirVar, commonlibdirVar]
     prefixBinLibDataVars = prefixBinLibVars ++ [datadirVar, datasubdirVar]
 
 -- | Convert from abstract install directories to actual absolute ones by
@@ -340,6 +365,8 @@ data PathTemplateVariable =
        PrefixVar     -- ^ The @$prefix@ path variable
      | BindirVar     -- ^ The @$bindir@ path variable
      | LibdirVar     -- ^ The @$libdir@ path variable
+     | CommonlibdirVar -- ^ The @$commonlibdir@ path variable
+     | HidirVar      -- ^ The @$hidir@ path variable
      | LibsubdirVar  -- ^ The @$libsubdir@ path variable
      | DatadirVar    -- ^ The @$datadir@ path variable
      | DatasubdirVar -- ^ The @$datasubdir@ path variable
@@ -437,7 +464,10 @@ installDirsTemplateEnv dirs =
   [(PrefixVar,     prefix     dirs)
   ,(BindirVar,     bindir     dirs)
   ,(LibdirVar,     libdir     dirs)
-  ,(LibsubdirVar,  libsubdir  dirs)
+  ,(CommonlibdirVar, commonlibdir dirs)
+  ,(HidirVar,      hidir      dirs)
+  ,(LibsubdirVar,  libsubdir  dirs) -- We need to keep this around for Setup's
+                                    -- build against older versions of Cabal
   ,(DatadirVar,    datadir    dirs)
   ,(DatasubdirVar, datasubdir dirs)
   ,(DocdirVar,     docdir     dirs)
@@ -459,6 +489,8 @@ instance Show PathTemplateVariable where
   show LibNameVar    = "libname"
   show BindirVar     = "bindir"
   show LibdirVar     = "libdir"
+  show CommonlibdirVar = "commonlibdir"
+  show HidirVar      = "hidir"
   show LibsubdirVar  = "libsubdir"
   show DatadirVar    = "datadir"
   show DatasubdirVar = "datasubdir"
@@ -487,6 +519,8 @@ instance Read PathTemplateVariable where
     where vars = [("prefix",     PrefixVar)
                  ,("bindir",     BindirVar)
                  ,("libdir",     LibdirVar)
+                 ,("commonlibdir", CommonlibdirVar)
+                 ,("hidir",      HidirVar)
                  ,("libsubdir",  LibsubdirVar)
                  ,("datadir",    DatadirVar)
                  ,("datasubdir", DatasubdirVar)

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -80,14 +80,14 @@ data InstallDirs dir = InstallDirs {
         prefix       :: dir,
         bindir       :: dir,
         libdir       :: dir,
-        commonlibdir :: dir,
+        binlibsubdir :: dir,
         hidir        :: dir,
         libsubdir    :: dir, -- This field is deprecated by the introduction of
-                             -- commonlibdir and hidir. However,
+                             -- binlibsubdir and hidir. However,
                              -- we must keep it so that we can still work with
                              -- Setup executables build against an older version
                              -- of Cabal. For the same reason, we cannot
-                             -- simply use libsubdir as the commonlibdir,
+                             -- simply use libsubdir as the binlibsubdir,
                              -- because then Setup's build against an older
                              -- Cabal would put .hi files in the same directory
                              -- as the library object files
@@ -120,7 +120,7 @@ combineInstallDirs combine a b = InstallDirs {
     prefix       = prefix a     `combine` prefix b,
     bindir       = bindir a     `combine` bindir b,
     libdir       = libdir a     `combine` libdir b,
-    commonlibdir = commonlibdir a `combine` commonlibdir b,
+    binlibsubdir = binlibsubdir a `combine` binlibsubdir b,
     hidir        = hidir a      `combine` hidir b,
     libsubdir    = libsubdir a  `combine` libsubdir b,
     dynlibdir    = dynlibdir a  `combine` dynlibdir b,
@@ -137,9 +137,9 @@ combineInstallDirs combine a b = InstallDirs {
 
 appendSubdirs :: (a -> a -> a) -> InstallDirs a -> InstallDirs a
 appendSubdirs append dirs = dirs {
-    libdir     = libdir dirs `append` commonlibdir dirs,
+    libdir     = libdir dirs `append` binlibsubdir dirs,
     datadir    = datadir dirs `append` datasubdir dirs,
-    commonlibdir = error "internal error InstallDirs.commonlibdir",
+    binlibsubdir = error "internal error InstallDirs.binlibsubdir",
     datasubdir = error "internal error InstallDirs.datasubdir"
   }
 
@@ -160,7 +160,7 @@ appendSubdirs append dirs = dirs {
 -- users to be able to configure @--libdir=\/usr\/lib64@ for example but
 -- because by default we want to support installing multiple versions of
 -- packages and building the same package for multiple compilers we append the
--- commonlibdir to get: @\/usr\/lib64\/$libname\/$compiler@.
+-- binlibsubdir to get: @\/usr\/lib64\/$libname\/$compiler@.
 --
 -- An additional complication is the need to support relocatable packages on
 -- systems which support such things, like Windows.
@@ -199,7 +199,7 @@ defaultInstallDirs' False comp userInstall _hasLibs = do
       prefix       = installPrefix,
       bindir       = "$prefix" </> "bin",
       libdir       = installLibDir,
-      commonlibdir = case comp of
+      binlibsubdir = case comp of
            JHC    -> "$compiler"
            LHC    -> "$compiler"
            UHC    -> "$pkgid"
@@ -254,7 +254,7 @@ substituteInstallDirTemplates env dirs = dirs'
       prefix     = subst prefix     [],
       bindir     = subst bindir     [prefixVar],
       libdir     = subst libdir     [prefixVar, bindirVar],
-      commonlibdir = subst commonlibdir [],
+      binlibsubdir = subst binlibsubdir [],
       hidir      = subst hidir      prefixBinLibVars,
       libsubdir  = subst libsubdir  [],
       dynlibdir  = subst dynlibdir  [prefixVar, bindirVar, libdirVar],
@@ -274,13 +274,13 @@ substituteInstallDirTemplates env dirs = dirs'
     prefixVar        = (PrefixVar,     prefix     dirs')
     bindirVar        = (BindirVar,     bindir     dirs')
     libdirVar        = (LibdirVar,     libdir     dirs')
-    commonlibdirVar  = (CommonlibdirVar, commonlibdir dirs')
+    binlibsubdirVar  = (BinlibsubdirVar, binlibsubdir dirs')
     hidirVar         = (HidirVar,      hidir      dirs')
     datadirVar       = (DatadirVar,    datadir    dirs')
     datasubdirVar    = (DatasubdirVar, datasubdir dirs')
     docdirVar        = (DocdirVar,     docdir     dirs')
     htmldirVar       = (HtmldirVar,    htmldir    dirs')
-    prefixBinLibVars = [prefixVar, bindirVar, libdirVar, commonlibdirVar]
+    prefixBinLibVars = [prefixVar, bindirVar, libdirVar, binlibsubdirVar]
     prefixBinLibDataVars = prefixBinLibVars ++ [datadirVar, datasubdirVar]
 
 -- | Convert from abstract install directories to actual absolute ones by
@@ -365,7 +365,7 @@ data PathTemplateVariable =
        PrefixVar     -- ^ The @$prefix@ path variable
      | BindirVar     -- ^ The @$bindir@ path variable
      | LibdirVar     -- ^ The @$libdir@ path variable
-     | CommonlibdirVar -- ^ The @$commonlibdir@ path variable
+     | BinlibsubdirVar -- ^ The @$binlibsubdir@ path variable
      | HidirVar      -- ^ The @$hidir@ path variable
      | LibsubdirVar  -- ^ The @$libsubdir@ path variable
      | DatadirVar    -- ^ The @$datadir@ path variable
@@ -464,7 +464,7 @@ installDirsTemplateEnv dirs =
   [(PrefixVar,     prefix     dirs)
   ,(BindirVar,     bindir     dirs)
   ,(LibdirVar,     libdir     dirs)
-  ,(CommonlibdirVar, commonlibdir dirs)
+  ,(BinlibsubdirVar, binlibsubdir dirs)
   ,(HidirVar,      hidir      dirs)
   ,(LibsubdirVar,  libsubdir  dirs) -- We need to keep this around for Setup's
                                     -- build against older versions of Cabal
@@ -489,7 +489,7 @@ instance Show PathTemplateVariable where
   show LibNameVar    = "libname"
   show BindirVar     = "bindir"
   show LibdirVar     = "libdir"
-  show CommonlibdirVar = "commonlibdir"
+  show BinlibsubdirVar = "binlibsubdir"
   show HidirVar      = "hidir"
   show LibsubdirVar  = "libsubdir"
   show DatadirVar    = "datadir"
@@ -519,7 +519,7 @@ instance Read PathTemplateVariable where
     where vars = [("prefix",     PrefixVar)
                  ,("bindir",     BindirVar)
                  ,("libdir",     LibdirVar)
-                 ,("commonlibdir", CommonlibdirVar)
+                 ,("binlibsubdir", BinlibsubdirVar)
                  ,("hidir",      HidirVar)
                  ,("libsubdir",  LibsubdirVar)
                  ,("datadir",    DatadirVar)

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -82,9 +82,9 @@ data InstallDirs dir = InstallDirs {
         libdir       :: dir,
         commonlibdir :: dir,
         hidir        :: dir,
-        libsubdir    :: dir, -- This field is basically deprecated by the
-                             -- introduction of commonlibdir and hidir. However,
-                             -- We must keep it so that we can still work with
+        libsubdir    :: dir, -- This field is deprecated by the introduction of
+                             -- commonlibdir and hidir. However,
+                             -- we must keep it so that we can still work with
                              -- Setup executables build against an older version
                              -- of Cabal. For the same reason, we cannot
                              -- simply use libsubdir as the commonlibdir,

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -409,7 +409,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     IPI.hiddenModules      = otherModules bi,
     IPI.trusted            = IPI.trusted IPI.emptyInstalledPackageInfo,
     IPI.importDirs         = [ hidir installDirs | hasModules ],
-    -- Note. the commonlibdir and datasubdir templates have already been expanded
+    -- Note. the binlibsubdir and datasubdir templates have already been expanded
     -- into libdir and datadir.
     IPI.libraryDirs        = if hasLibrary
                                then libdir installDirs : extraLibDirs bi

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -408,8 +408,8 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     IPI.exposedModules     = componentExposedModules clbi,
     IPI.hiddenModules      = otherModules bi,
     IPI.trusted            = IPI.trusted IPI.emptyInstalledPackageInfo,
-    IPI.importDirs         = [ libdir installDirs | hasModules ],
-    -- Note. the libsubdir and datasubdir templates have already been expanded
+    IPI.importDirs         = [ hidir installDirs | hasModules ],
+    -- Note. the commonlibdir and datasubdir templates have already been expanded
     -- into libdir and datadir.
     IPI.libraryDirs        = if hasLibrary
                                then libdir installDirs : extraLibDirs bi
@@ -466,6 +466,7 @@ inplaceInstalledPackageInfo inplaceDir distPref pkg abi_hash lib lbi clbi =
       (absoluteComponentInstallDirs pkg lbi (componentUnitId clbi) NoCopyDest) {
         libdir     = inplaceDir </> libTargetDir,
         datadir    = inplaceDir </> dataDir pkg,
+        hidir      = inplaceDir </> libTargetDir,
         docdir     = inplaceDocdir,
         htmldir    = inplaceHtmldir,
         haddockdir = inplaceHtmldir

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -897,9 +897,9 @@ installDirsOptions =
       libdir (\v flags -> flags { libdir = v })
       installDirArg
 
-  , option "" ["commonlibdir"]
+  , option "" ["binlibsubdir"]
       "subdirectory of libdir in which binary libraries are installed"
-      commonlibdir (\v flags -> flags { commonlibdir = v })
+      binlibsubdir (\v flags -> flags { binlibsubdir = v })
       installDirArg
 
   , option "" ["hidir"]

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -897,9 +897,14 @@ installDirsOptions =
       libdir (\v flags -> flags { libdir = v })
       installDirArg
 
-  , option "" ["libsubdir"]
-      "subdirectory of libdir in which libs are installed"
-      libsubdir (\v flags -> flags { libsubdir = v })
+  , option "" ["commonlibdir"]
+      "subdirectory of libdir in which the object files of libs are installed"
+      commonlibdir (\v flags -> flags { commonlibdir = v })
+      installDirArg
+
+  , option "" ["hidir"]
+      "installation directory for library interface files"
+      hidir (\v flags -> flags { hidir = v })
       installDirArg
 
   , option "" ["libexecdir"]
@@ -935,6 +940,13 @@ installDirsOptions =
   , option "" ["sysconfdir"]
       "installation directory for configuration files"
       sysconfdir (\v flags -> flags { sysconfdir = v })
+      installDirArg
+
+  , option "" ["libsubdir"]
+      ("subdirectory of libdir in which libs are installed." ++
+       "Only has an effect on Setup files build against Cabal < 1.25"
+      )
+      libsubdir (\v flags -> flags { libsubdir = v })
       installDirArg
   ]
   where

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -898,7 +898,7 @@ installDirsOptions =
       installDirArg
 
   , option "" ["commonlibdir"]
-      "subdirectory of libdir in which the object files of libs are installed"
+      "subdirectory of libdir in which binary libraries are installed"
       commonlibdir (\v flags -> flags { commonlibdir = v })
       installDirArg
 
@@ -944,7 +944,7 @@ installDirsOptions =
 
   , option "" ["libsubdir"]
       ("subdirectory of libdir in which libs are installed." ++
-       "Only has an effect on Setup files build against Cabal < 1.25"
+       "Only has an effect on Setup files built against Cabal < 1.25"
       )
       libsubdir (\v flags -> flags { libsubdir = v })
       installDirArg

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2296,6 +2296,7 @@ into (e.g. data files live in ``getDataDir``):
 
     getBinDir :: IO FilePath
     getLibDir :: IO FilePath
+    getHiDir :: IO FilePath
     getDataDir :: IO FilePath
     getLibexecDir :: IO FilePath
     getSysconfDir :: IO FilePath
@@ -2304,7 +2305,7 @@ The actual location of all these directories can be individually
 overridden at runtime using environment variables of the form
 ``pkg_name_var``, where ``pkg_name`` is the name of the package with all
 hyphens converted into underscores, and ``var`` is either ``bindir``,
-``libdir``, ``datadir``, ``libexedir`` or ``sysconfdir``. For example,
+``libdir``, ``hidir``, ``datadir``, ``libexedir`` or ``sysconfdir``. For example,
 the configured data directory for ``pretty-show`` is controlled with the
 ``pretty_show_datadir`` environment variable.
 

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -600,13 +600,22 @@ package:
     ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
+.. option:: --hidir=dir
+
+    Interface files (.hi) of libraries are installed here.
+
+    In the simple build system, *dir* may contain the following path
+    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$commonlibdir``,
+    ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
+    ``$arch``, ``$abi``, ``$abitag``
+
 .. option:: --libexecdir=dir
 
     Executables that are not expected to be invoked directly by the user
     are installed here.
 
     In the simple build system, *dir* may contain the following path
-    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$libsubdir``,
+    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$commonlibdir``,
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``
 
@@ -615,7 +624,7 @@ package:
     Architecture-independent data files are installed here.
 
     In the simple build system, *dir* may contain the following path
-    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$libsubdir``,
+    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$commonlibdir``,
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``
 
@@ -624,21 +633,20 @@ package:
     Installation directory for the configuration files.
 
     In the simple build system, *dir* may contain the following path
-    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$libsubdir``,
+    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$commonlibdir``,
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``
 
 In addition the simple build system supports the following installation
 path options:
 
-.. option:: --libsubdir=dir
+.. option:: --commonlibdir=dir
 
     A subdirectory of *libdir* in which libraries are actually
     installed. For example, in the simple build system on Unix, the
-    default *libdir* is ``/usr/local/lib``, and *libsubdir* contains the
-    package identifier and compiler, e.g. ``mypkg-0.2/ghc-6.4``, so
-    libraries would be installed in
-    ``/usr/local/lib/mypkg-0.2/ghc-6.4``.
+    default *libdir* is ``/usr/local/lib``, and *commonlibdir* contains the
+    ABI, e.g. ``x86_64-linux-8.0.1``, so libraries would be installed in
+    ``/usr/local/lib/x86_64-linux-8.0.1``.
 
     *dir* may contain the following path variables: ``$pkgid``,
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
@@ -658,7 +666,7 @@ path options:
     Documentation files are installed relative to this directory.
 
     *dir* may contain the following path variables: ``$prefix``,
-    ``$bindir``, ``$libdir``, ``$libsubdir``, ``$datadir``,
+    ``$bindir``, ``$libdir``, ``$commonlibdir``, ``$datadir``,
     ``$datasubdir``, ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``,
     ``$os``, ``$arch``, ``$abi``, ``$abitag``
 
@@ -667,7 +675,7 @@ path options:
     HTML documentation files are installed relative to this directory.
 
     *dir* may contain the following path variables: ``$prefix``,
-    ``$bindir``, ``$libdir``, ``$libsubdir``, ``$datadir``,
+    ``$bindir``, ``$libdir``, ``$commonlibdir``, ``$datadir``,
     ``$datasubdir``, ``$docdir``, ``$pkgid``, ``$pkg``, ``$version``,
     ``$compiler``, ``$os``, ``$arch``, ``$abi``, ``$abitag``
 
@@ -687,6 +695,22 @@ path options:
     ``--program-suffix='$version'``.
 
     *suffix* may contain the following path variables: ``$pkgid``,
+    ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
+    ``$abitag``
+
+.. option:: --libsubdir=dir
+
+    For use with Setup.hs files build against a version of Cabal prior to 1.25.
+    For later versions of Cabal, this flag is basically deprecated, and you
+    should use ``--commonlibdir=dir``.
+
+    A subdirectory of *libdir* in which libraries and interfaces are actually
+    installed. For example, in the simple build system on Unix, the
+    default *libdir* is ``/usr/local/lib``, and *libsubdir* contains the
+    ABI, e.g. ``x86_64-linux-8.0.1``, so libraries would be installed in
+    ``/usr/local/lib/x86_64-linux-8.0.1``.
+
+    *dir* may contain the following path variables: ``$pkgid``,
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
@@ -710,14 +734,18 @@ $bindir
     configure option (or the default).
 $libdir
     As above but for :option:`--libdir`
-$libsubdir
-    As above but for :option:`--libsubdir`
+$commonlibdir
+    As above but for :option:`--commonlibdir`
+$hidir
+    As above but for :option:`--hidir`
 $datadir
     As above but for :option:`--datadir`
 $datasubdir
     As above but for :option:`--datasubdir`
 $docdir
     As above but for :option:`--docdir`
+$libsubdir
+    As above but for :option:`--libsubdir`
 $pkgid
     The name and version of the package, e.g. ``mypkg-0.2``
 $pkg
@@ -765,9 +793,12 @@ For the simple build system, the following defaults apply:
     * - :option:`--libdir`
       - ``$prefix/lib``
       - ``$prefix``
-    * - :option:`--libsubdir` (others)
-      - ``$pkgid/$compiler``
-      - ``$pkgid\$compiler``
+    * - :option:`--commonlibdir` (others)
+      - ``$abi``
+      - ``$abi``
+    * - :option:`--hidir` (others)
+      - ``$libdir/$abi/$libname``
+      - ``$libdir\$abi\$libname``
     * - :option:`--libexecdir`
       - ``$prefix/libexec``
       - ``$prefix\$pkgid``
@@ -795,6 +826,9 @@ For the simple build system, the following defaults apply:
     * - :option:`--program-suffix`
       - (empty)
       - (empty)
+    * - :option:`--libsubdir` (others)
+      - ``$abi/$libname``
+      - ``$abi\$libname``
 
 Prefix-independence
 """""""""""""""""""

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -605,7 +605,7 @@ package:
     Interface files (.hi) of libraries are installed here.
 
     In the simple build system, *dir* may contain the following path
-    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$commonlibdir``,
+    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$binlibsubdir``,
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``
 
@@ -615,7 +615,7 @@ package:
     are installed here.
 
     In the simple build system, *dir* may contain the following path
-    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$commonlibdir``,
+    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$binlibsubdir``,
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``
 
@@ -624,7 +624,7 @@ package:
     Architecture-independent data files are installed here.
 
     In the simple build system, *dir* may contain the following path
-    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$commonlibdir``,
+    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$binlibsubdir``,
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``
 
@@ -633,14 +633,14 @@ package:
     Installation directory for the configuration files.
 
     In the simple build system, *dir* may contain the following path
-    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$commonlibdir``,
+    variables: ``$prefix``, ``$bindir``, ``$libdir``, ``$binlibsubdir``,
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``
 
 In addition the simple build system supports the following installation
 path options:
 
-.. option:: --commonlibdir=dir
+.. option:: --binlibsubdir=dir
 
     A subdirectory of *libdir* in which binary libraries are actually
     installed. It is recommended that a single, common directory to be used to
@@ -667,7 +667,7 @@ path options:
     Documentation files are installed relative to this directory.
 
     *dir* may contain the following path variables: ``$prefix``,
-    ``$bindir``, ``$libdir``, ``$commonlibdir``, ``$datadir``,
+    ``$bindir``, ``$libdir``, ``$binlibsubdir``, ``$datadir``,
     ``$datasubdir``, ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``,
     ``$os``, ``$arch``, ``$abi``, ``$abitag``
 
@@ -676,7 +676,7 @@ path options:
     HTML documentation files are installed relative to this directory.
 
     *dir* may contain the following path variables: ``$prefix``,
-    ``$bindir``, ``$libdir``, ``$commonlibdir``, ``$datadir``,
+    ``$bindir``, ``$libdir``, ``$binlibsubdir``, ``$datadir``,
     ``$datasubdir``, ``$docdir``, ``$pkgid``, ``$pkg``, ``$version``,
     ``$compiler``, ``$os``, ``$arch``, ``$abi``, ``$abitag``
 
@@ -702,7 +702,7 @@ path options:
 .. option:: --libsubdir=dir
 
     For use with Setup.hs files built against a version of Cabal prior to 1.25.
-    With later versions of Cabal, you should prefer :option:`--commonlibdir` and
+    With later versions of Cabal, you should prefer :option:`--binlibsubdir` and
     :option:`--hidir`, which let you separately specify where binary libraries
     and interface files get installed, so that binary libraries can be
     installed to a shared directory..
@@ -737,8 +737,8 @@ $bindir
     configure option (or the default).
 $libdir
     As above but for :option:`--libdir`
-$commonlibdir
-    As above but for :option:`--commonlibdir`
+$binlibsubdir
+    As above but for :option:`--binlibsubdir`
 $hidir
     As above but for :option:`--hidir`
 $datadir
@@ -796,7 +796,7 @@ For the simple build system, the following defaults apply:
     * - :option:`--libdir`
       - ``$prefix/lib``
       - ``$prefix``
-    * - :option:`--commonlibdir` (others)
+    * - :option:`--binlibsubdir` (others)
       - ``$abi``
       - ``$abi``
     * - :option:`--hidir` (others)

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -642,11 +642,12 @@ path options:
 
 .. option:: --commonlibdir=dir
 
-    A subdirectory of *libdir* in which libraries are actually
-    installed. For example, in the simple build system on Unix, the
-    default *libdir* is ``/usr/local/lib``, and *commonlibdir* contains the
-    ABI, e.g. ``x86_64-linux-8.0.1``, so libraries would be installed in
-    ``/usr/local/lib/x86_64-linux-8.0.1``.
+    A subdirectory of *libdir* in which binary libraries are actually
+    installed. It is recommended that a single, common directory to be used to
+    store all installed libraries (as opposed to using ``$pkgid`` or similar
+    variables to create a directory per installed library), as this helps reduce
+    the size of rpath in executables built against dynamic libraries.
+    See <https://github.com/haskell/cabal/pull/3982> for more details.
 
     *dir* may contain the following path variables: ``$pkgid``,
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
@@ -700,9 +701,11 @@ path options:
 
 .. option:: --libsubdir=dir
 
-    For use with Setup.hs files build against a version of Cabal prior to 1.25.
-    For later versions of Cabal, this flag is basically deprecated, and you
-    should use ``--commonlibdir=dir``.
+    For use with Setup.hs files built against a version of Cabal prior to 1.25.
+    With later versions of Cabal, you should prefer :option:`--commonlibdir` and
+    :option:`--hidir`, which let you separately specify where binary libraries
+    and interface files get installed, so that binary libraries can be
+    installed to a shared directory..
 
     A subdirectory of *libdir* in which libraries and interfaces are actually
     installed. For example, in the simple build system on Unix, the

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -15,7 +15,7 @@ import Distribution.Types.LocalBuildInfo
 
 import Distribution.Simple.LocalBuildInfo
   ( absoluteComponentInstallDirs
-  , InstallDirs(libdir)
+  , InstallDirs(libdir, hidir)
   , ComponentLocalBuildInfo(componentUnitId), ComponentName(..) )
 import Distribution.Simple.InstallDirs ( CopyDest(NoCopyDest) )
 import Distribution.Simple.BuildPaths  ( mkLibName, mkSharedLibName )
@@ -779,8 +779,10 @@ tests config = do
                 uid = componentUnitId (targetCLBI target)
                 dir = libdir (absoluteComponentInstallDirs pkg_descr lbi uid
                               NoCopyDest)
+                hdir = hidir (absoluteComponentInstallDirs pkg_descr lbi uid
+                              NoCopyDest)
             assertBool "interface files should be installed"
-                =<< liftIO (doesFileExist (dir </> "Foo.hi"))
+                =<< liftIO (doesFileExist (hdir </> "Foo.hi"))
             assertBool "static library should be installed"
                 =<< liftIO (doesFileExist (dir </> mkLibName uid))
             if is_dynamic

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1253,7 +1253,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                    platform
                    defaultInstallDirs) {
 
-                  InstallDirs.commonlibdir = "", -- absoluteInstallDirs sets these as
+                  InstallDirs.binlibsubdir = "", -- absoluteInstallDirs sets these as
                   InstallDirs.datasubdir = ""  -- 'undefined' but we have to use
                 }                              -- them as "Setup.hs configure" args
 
@@ -1410,7 +1410,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                platform
                defaultInstallDirs) {
 
-              InstallDirs.commonlibdir = "", -- absoluteInstallDirs sets these as
+              InstallDirs.binlibsubdir = "", -- absoluteInstallDirs sets these as
               InstallDirs.datasubdir = ""  -- 'undefined' but we have to use
             }                              -- them as "Setup.hs configure" args
 
@@ -2520,7 +2520,7 @@ storePackageInstallDirs CabalDirLayout{cabalStorePackageDirectory}
     prefix       = cabalStorePackageDirectory compid ipkgid
     bindir       = prefix </> "bin"
     libdir       = prefix </> "lib"
-    commonlibdir = ""
+    binlibsubdir = ""
     hidir        = libdir
     libsubdir    = ""
     dynlibdir    = libdir

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1253,7 +1253,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                    platform
                    defaultInstallDirs) {
 
-                  InstallDirs.libsubdir  = "", -- absoluteInstallDirs sets these as
+                  InstallDirs.commonlibdir = "", -- absoluteInstallDirs sets these as
                   InstallDirs.datasubdir = ""  -- 'undefined' but we have to use
                 }                              -- them as "Setup.hs configure" args
 
@@ -1410,7 +1410,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                platform
                defaultInstallDirs) {
 
-              InstallDirs.libsubdir  = "", -- absoluteInstallDirs sets these as
+              InstallDirs.commonlibdir = "", -- absoluteInstallDirs sets these as
               InstallDirs.datasubdir = ""  -- 'undefined' but we have to use
             }                              -- them as "Setup.hs configure" args
 
@@ -2520,6 +2520,8 @@ storePackageInstallDirs CabalDirLayout{cabalStorePackageDirectory}
     prefix       = cabalStorePackageDirectory compid ipkgid
     bindir       = prefix </> "bin"
     libdir       = prefix </> "lib"
+    commonlibdir = ""
+    hidir        = libdir
     libsubdir    = ""
     dynlibdir    = libdir
     libexecdir   = prefix </> "libexec"

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -95,7 +95,7 @@ import Distribution.Simple.Setup
          , boolOpt, boolOpt', trueArg, falseArg
          , readPToMaybe, optionNumJobs )
 import Distribution.Simple.InstallDirs
-         ( PathTemplate, InstallDirs(commonlibdir, hidir, sysconfdir)
+         ( PathTemplate, InstallDirs(binlibsubdir, hidir, sysconfdir)
          , toPathTemplate, fromPathTemplate )
 import Distribution.Version
          ( Version, mkVersion, nullVersion, anyVersion, thisVersion )
@@ -391,10 +391,10 @@ filterConfigureFlags flags cabalLibVersion
       configAllowNewer  = Just (Cabal.AllowNewer Cabal.RelaxDepsNone)
       }
 
-    -- Cabal < 1.25.0 doesn't know about --commonlibdir and --hidir.
+    -- Cabal < 1.25.0 doesn't know about --binlibsubdir and --hidir.
     flags_1_25_0 = flags_latest { configInstallDirs = configInstallDirs_1_25_0}
     configInstallDirs_1_25_0 = (configInstallDirs flags)
-                                  { commonlibdir = NoFlag
+                                  { binlibsubdir = NoFlag
                                   , hidir        = NoFlag
                                   }
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -95,7 +95,7 @@ import Distribution.Simple.Setup
          , boolOpt, boolOpt', trueArg, falseArg
          , readPToMaybe, optionNumJobs )
 import Distribution.Simple.InstallDirs
-         ( PathTemplate, InstallDirs(sysconfdir)
+         ( PathTemplate, InstallDirs(commonlibdir, hidir, sysconfdir)
          , toPathTemplate, fromPathTemplate )
 import Distribution.Version
          ( Version, mkVersion, nullVersion, anyVersion, thisVersion )
@@ -363,7 +363,7 @@ filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
   -- NB: we expect the latest version to be the most common case,
   -- so test it first.
-  | cabalLibVersion >= mkVersion [1,23,0] = flags_latest
+  | cabalLibVersion >= mkVersion [1,25,0] = flags_latest
   -- The naming convention is that flags_version gives flags with
   -- all flags *introduced* in version eliminated.
   -- It is NOT the latest version of Cabal library that
@@ -379,6 +379,7 @@ filterConfigureFlags flags cabalLibVersion
   | cabalLibVersion < mkVersion [1,21,1] = flags_1_21_1
   | cabalLibVersion < mkVersion [1,22,0] = flags_1_22_0
   | cabalLibVersion < mkVersion [1,23,0] = flags_1_23_0
+  | cabalLibVersion < mkVersion [1,25,0] = flags_1_25_0
   | otherwise = flags_latest
   where
     flags_latest = flags        {
@@ -390,11 +391,18 @@ filterConfigureFlags flags cabalLibVersion
       configAllowNewer  = Just (Cabal.AllowNewer Cabal.RelaxDepsNone)
       }
 
+    -- Cabal < 1.25.0 doesn't know about --commonlibdir and --hidir.
+    flags_1_25_0 = flags_latest { configInstallDirs = configInstallDirs_1_25_0}
+    configInstallDirs_1_25_0 = (configInstallDirs flags)
+                                  { commonlibdir = NoFlag
+                                  , hidir        = NoFlag
+                                  }
+
     -- Cabal < 1.23 doesn't know about '--profiling-detail'.
     -- Cabal < 1.23 has a hacked up version of 'enable-profiling'
     -- which we shouldn't use.
     (tryLibProfiling, tryExeProfiling) = computeEffectiveProfiling flags
-    flags_1_23_0 = flags_latest { configProfDetail    = NoFlag
+    flags_1_23_0 = flags_1_25_0 { configProfDetail    = NoFlag
                                 , configProfLibDetail = NoFlag
                                 , configIPID          = NoFlag
                                 , configProf          = NoFlag
@@ -423,7 +431,7 @@ filterConfigureFlags flags cabalLibVersion
     -- Cabal < 1.18.0 doesn't know about --extra-prog-path and --sysconfdir.
     flags_1_18_0 = flags_1_19_1 { configProgramPathExtra = toNubList []
                                 , configInstallDirs = configInstallDirs_1_18_0}
-    configInstallDirs_1_18_0 = (configInstallDirs flags) { sysconfdir = NoFlag }
+    configInstallDirs_1_18_0 = (configInstallDirs flags_1_19_1) { sysconfdir = NoFlag }
     -- Cabal < 1.14.0 doesn't know about '--disable-benchmarks'.
     flags_1_14_0 = flags_1_18_0 { configBenchmarks  = NoFlag }
     -- Cabal < 1.12.0 doesn't know about '--enable/disable-executable-dynamic'

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -539,7 +539,7 @@ instance Arbitrary a => Arbitrary (InstallDirs a) where
         <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  4
         <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  8
         <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary -- 12
-        <*> arbitrary <*> arbitrary                             -- 14
+        <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary -- 16
 
 instance Arbitrary PackageDB where
     arbitrary = oneof [ pure GlobalPackageDB


### PR DESCRIPTION
These two flags indicate where the two distinct aspects of a
Haskell library end up.

`--binlibsubdir`: The subdirectory of `--libdir` where the binary library files (.so/.a/.dll/.dylib) get installed.
`--hidir`: The directory where the interface files (.hi) get installed.

The reason we want to do this is because we want dynamic libraries
to all end up in a shared directory to reduce start-up times of
the run-time linker. However, we still want the .hi to end up
in one directory per package.

We cannot repurpose --libsubdir to take over the role of what
--commonlibdir is doing because then we would run into trouble
with Setup.hs files build against an older Cabal. If we were
to repurpose --libsubdir, then all the object and interface
files would end up in a single shared directory for all
packages when using an older Cabal.

After several attempts (#3955,#3968,#3979), this should be the definitive solution for: https://ghc.haskell.org/trac/ghc/ticket/12479

EDIT: `--binlibsubdir` was originally called `--commonsubdir` when this PR was first created.