### PR TITLE
Backport "Store interfaces files separately from library object files #3982" to 1.24

### DIFF
--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -71,7 +71,7 @@ generate pkg_descr lbi =
         pragmas++
         "module " ++ display paths_modulename ++ " (\n"++
         "    version,\n"++
-        "    getBinDir, getLibDir, getDataDir, getLibexecDir,\n"++
+        "    getBinDir, getLibDir, getHiDir, getDataDir, getLibexecDir,\n"++
         "    getDataFileName, getSysconfDir\n"++
         "  ) where\n"++
         "\n"++
@@ -108,9 +108,10 @@ generate pkg_descr lbi =
           "\n\nbindirrel :: FilePath\n" ++
           "bindirrel = " ++ show flat_bindirreloc ++
           "\n"++
-          "\ngetBinDir, getLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
+          "\ngetBinDir, getLibDir, getHiDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
           "getBinDir = "++mkGetEnvOrReloc "bindir" flat_bindirreloc++"\n"++
           "getLibDir = "++mkGetEnvOrReloc "libdir" flat_libdirreloc++"\n"++
+          "getHiDir = "++mkGetEnvOrReloc "hidir" flat_hidirreloc++"\n"++
           "getDataDir = "++mkGetEnvOrReloc "datadir" flat_datadirreloc++"\n"++
           "getLibexecDir = "++mkGetEnvOrReloc "libexecdir" flat_libexecdirreloc++"\n"++
           "getSysconfDir = "++mkGetEnvOrReloc "sysconfdir" flat_sysconfdirreloc++"\n"++
@@ -124,16 +125,18 @@ generate pkg_descr lbi =
           "\n"++
           filename_stuff
         | absolute =
-          "\nbindir, libdir, datadir, libexecdir, sysconfdir :: FilePath\n"++
+          "\nbindir, libdir, hidir, datadir, libexecdir, sysconfdir :: FilePath\n"++
           "\nbindir     = " ++ show flat_bindir ++
           "\nlibdir     = " ++ show flat_libdir ++
+          "\nhidir      = " ++ show flat_hidir ++
           "\ndatadir    = " ++ show flat_datadir ++
           "\nlibexecdir = " ++ show flat_libexecdir ++
           "\nsysconfdir = " ++ show flat_sysconfdir ++
           "\n"++
-          "\ngetBinDir, getLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
+          "\ngetBinDir, getLibDir, getHiDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
           "getBinDir = "++mkGetEnvOr "bindir" "return bindir"++"\n"++
           "getLibDir = "++mkGetEnvOr "libdir" "return libdir"++"\n"++
+          "getHiDir = "++mkGetEnvOr "hidir" "return hidir"++"\n"++
           "getDataDir = "++mkGetEnvOr "datadir" "return datadir"++"\n"++
           "getLibexecDir = "++mkGetEnvOr "libexecdir" "return libexecdir"++"\n"++
           "getSysconfDir = "++mkGetEnvOr "sysconfdir" "return sysconfdir"++"\n"++
@@ -151,6 +154,8 @@ generate pkg_descr lbi =
           "getBinDir = getPrefixDirRel bindirrel\n\n"++
           "getLibDir :: IO FilePath\n"++
           "getLibDir = "++mkGetDir flat_libdir flat_libdirrel++"\n\n"++
+          "getHiDir :: IO FilePath\n"++
+          "getHiDir = "++mkGetDir flat_hidir flat_hidirrel++"\n\n"++
           "getDataDir :: IO FilePath\n"++
           "getDataDir =  "++ mkGetEnvOr "datadir"
                               (mkGetDir flat_datadir flat_datadirrel)++"\n\n"++
@@ -173,6 +178,7 @@ generate pkg_descr lbi =
           prefix     = flat_prefix,
           bindir     = flat_bindir,
           libdir     = flat_libdir,
+          hidir      = flat_hidir,
           datadir    = flat_datadir,
           libexecdir = flat_libexecdir,
           sysconfdir = flat_sysconfdir
@@ -180,6 +186,7 @@ generate pkg_descr lbi =
         InstallDirs {
           bindir     = flat_bindirrel,
           libdir     = flat_libdirrel,
+          hidir      = flat_hidirrel,
           datadir    = flat_datadirrel,
           libexecdir = flat_libexecdirrel,
           sysconfdir = flat_sysconfdirrel
@@ -187,6 +194,7 @@ generate pkg_descr lbi =
 
         flat_bindirreloc = shortRelativePath flat_prefix flat_bindir
         flat_libdirreloc = shortRelativePath flat_prefix flat_libdir
+        flat_hidirreloc  = shortRelativePath flat_prefix flat_hidir
         flat_datadirreloc = shortRelativePath flat_prefix flat_datadir
         flat_libexecdirreloc = shortRelativePath flat_prefix flat_libexecdir
         flat_sysconfdirreloc = shortRelativePath flat_prefix flat_sysconfdir

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -684,6 +684,7 @@ configure (pkg_descr0', pbi) cfg = do
 
     dirinfo "Binaries"         (bindir dirs)     (bindir relative)
     dirinfo "Libraries"        (libdir dirs)     (libdir relative)
+    dirinfo "Interfaces"       (hidir dirs)      (hidir relative)
     dirinfo "Private binaries" (libexecdir dirs) (libexecdir relative)
     dirinfo "Data files"       (datadir dirs)    (datadir relative)
     dirinfo "Documentation"    (docdir dirs)     (docdir relative)
@@ -2013,7 +2014,7 @@ checkRelocatable verbosity pkg lbi
           all isJust
               (fmap (stripPrefix p)
                     [ bindir, libdir, dynlibdir, libexecdir, includedir, datadir
-                    , docdir, mandir, htmldir, haddockdir, sysconfdir] )
+                    , hidir, docdir, mandir, htmldir, haddockdir, sysconfdir] )
 
     -- Check if the library dirs of the dependencies that are in the package
     -- database to which the package is installed are relative to the

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1116,12 +1116,13 @@ installLib    :: Verbosity
               -> LocalBuildInfo
               -> FilePath  -- ^install location
               -> FilePath  -- ^install location for dynamic libraries
+              -> FilePath  -- ^install location for interfaces
               -> FilePath  -- ^Build location
               -> PackageDescription
               -> Library
               -> ComponentLocalBuildInfo
               -> IO ()
-installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
+installLib verbosity lbi targetDir dynlibTargetDir hiTargetDir builtDir _pkg lib clbi = do
   -- copy .hi files over:
   whenVanilla $ copyModuleFiles "hi"
   whenProf    $ copyModuleFiles "p_hi"
@@ -1151,7 +1152,7 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
 
     copyModuleFiles ext =
       findModuleFiles [builtDir] [ext] (libModules lib)
-      >>= installOrdinaryFiles verbosity targetDir
+      >>= installOrdinaryFiles verbosity hiTargetDir
 
     cid = compilerId (compiler lbi)
     libName = componentUnitId clbi

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -60,6 +60,7 @@ install pkg_descr lbi flags = do
       installDirs@(InstallDirs {
          bindir     = binPref,
          libdir     = libPref,
+         hidir      = hiPref,
 --         dynlibdir  = dynlibPref, --see TODO below
          datadir    = dataPref,
          docdir     = docPref,
@@ -130,7 +131,7 @@ install pkg_descr lbi flags = do
 
   withLibLBI pkg_descr lbi $
     case compilerFlavor (compiler lbi) of
-      GHC   -> GHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr
+      GHC   -> GHC.installLib   verbosity lbi libPref dynlibPref hiPref buildPref pkg_descr
       GHCJS -> GHCJS.installLib verbosity lbi libPref dynlibPref buildPref pkg_descr
       LHC   -> LHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr
       JHC   -> JHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -320,8 +320,8 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     IPI.exposedModules     = componentExposedModules clbi,
     IPI.hiddenModules      = otherModules bi,
     IPI.trusted            = IPI.trusted IPI.emptyInstalledPackageInfo,
-    IPI.importDirs         = [ libdir installDirs | hasModules ],
-    -- Note. the libsubdir and datasubdir templates have already been expanded
+    IPI.importDirs         = [ hidir installDirs | hasModules ],
+    -- Note. the commonlibdir and datasubdir templates have already been expanded
     -- into libdir and datadir.
     IPI.libraryDirs        = if hasLibrary
                                then libdir installDirs : extraLibDirs bi
@@ -378,6 +378,7 @@ inplaceInstalledPackageInfo inplaceDir distPref pkg abi_hash lib lbi clbi =
       (absoluteInstallDirs pkg lbi NoCopyDest) {
         libdir     = inplaceDir </> libTargetDir,
         datadir    = inplaceDir </> dataDir pkg,
+        hidir      = inplaceDir </> libTargetDir,
         docdir     = inplaceDocdir,
         htmldir    = inplaceHtmldir,
         haddockdir = inplaceHtmldir

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -321,7 +321,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     IPI.hiddenModules      = otherModules bi,
     IPI.trusted            = IPI.trusted IPI.emptyInstalledPackageInfo,
     IPI.importDirs         = [ hidir installDirs | hasModules ],
-    -- Note. the commonlibdir and datasubdir templates have already been expanded
+    -- Note. the binlibsubdir and datasubdir templates have already been expanded
     -- into libdir and datadir.
     IPI.libraryDirs        = if hasLibrary
                                then libdir installDirs : extraLibDirs bi

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -762,9 +762,9 @@ installDirsOptions =
       libdir (\v flags -> flags { libdir = v })
       installDirArg
 
-  , option "" ["commonlibdir"]
-      "subdirectory of libdir in which the object files of libs are installed"
-      commonlibdir (\v flags -> flags { commonlibdir = v })
+  , option "" ["binlibsubdir"]
+      "subdirectory of libdir in which binary libraries are installed"
+      binlibsubdir (\v flags -> flags { binlibsubdir = v })
       installDirArg
 
   , option "" ["hidir"]
@@ -809,7 +809,7 @@ installDirsOptions =
 
   , option "" ["libsubdir"]
       ("subdirectory of libdir in which libs are installed." ++
-       "Only has an effect on Setup files build against Cabal < 1.24.1"
+       "Only has an effect on Setup files built against Cabal < 1.24.1"
       )
       libsubdir (\v flags -> flags { libsubdir = v })
       installDirArg

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -762,9 +762,14 @@ installDirsOptions =
       libdir (\v flags -> flags { libdir = v })
       installDirArg
 
-  , option "" ["libsubdir"]
-      "subdirectory of libdir in which libs are installed"
-      libsubdir (\v flags -> flags { libsubdir = v })
+  , option "" ["commonlibdir"]
+      "subdirectory of libdir in which the object files of libs are installed"
+      commonlibdir (\v flags -> flags { commonlibdir = v })
+      installDirArg
+
+  , option "" ["hidir"]
+      "installation directory for library interface files"
+      hidir (\v flags -> flags { hidir = v })
       installDirArg
 
   , option "" ["libexecdir"]
@@ -800,6 +805,13 @@ installDirsOptions =
   , option "" ["sysconfdir"]
       "installation directory for configuration files"
       sysconfdir (\v flags -> flags { sysconfdir = v })
+      installDirArg
+
+  , option "" ["libsubdir"]
+      ("subdirectory of libdir in which libs are installed." ++
+       "Only has an effect on Setup files build against Cabal < 1.24.1"
+      )
+      libsubdir (\v flags -> flags { libsubdir = v })
       installDirArg
   ]
   where

--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -1952,6 +1952,7 @@ version :: Version
 
 getBinDir :: IO FilePath
 getLibDir :: IO FilePath
+getHiDir :: IO FilePath
 getDataDir :: IO FilePath
 getLibexecDir :: IO FilePath
 getSysconfDir :: IO FilePath

--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -498,36 +498,44 @@ package:
     variables: `$prefix`, `$bindir`, `$pkgid`, `$pkg`, `$version`,
     `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
+`--hidir=`_dir_
+:  Interface files (.hi) of libraries are installed here.
+
+   In the simple build system, *dir* may contain the following path
+   variables: `$prefix`, `$bindir`, `$libdir`, `$commonlibdir`,
+   `$pkgid`, `$pkg`, `$version`, `$compiler`, `$os`,
+   `$arch`, `$abi`, `$abitag`
+
 `--libexecdir=`_dir_
 :   Executables that are not expected to be invoked directly by the user
     are installed here.
 
     In the simple build system, _dir_ may contain the following path
-    variables: `$prefix`, `$bindir`, `$libdir`, `$libsubdir`, `$pkgid`,
+    variables: `$prefix`, `$bindir`, `$libdir`, `$commonlibdir`, `$pkgid`,
     `$pkg`, `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 `--datadir`=_dir_
 :   Architecture-independent data files are installed here.
 
     In the simple build system, _dir_ may contain the following path
-    variables: `$prefix`, `$bindir`, `$libdir`, `$libsubdir`, `$pkgid`, `$pkg`,
+    variables: `$prefix`, `$bindir`, `$libdir`, `$commonlibdir`, `$pkgid`, `$pkg`,
     `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 `--sysconfdir=`_dir_
 :   Installation directory for the configuration files.
 
     In the simple build system, _dir_ may contain the following path variables:
-    `$prefix`, `$bindir`, `$libdir`, `$libsubdir`, `$pkgid`, `$pkg`, `$version`,
+    `$prefix`, `$bindir`, `$libdir`, `$commonlibdir`, `$pkgid`, `$pkg`, `$version`,
     `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 In addition the simple build system supports the following installation path options:
 
-`--libsubdir=`_dir_
+`--commonlibdir=`_dir_
 :   A subdirectory of _libdir_ in which libraries are actually
     installed. For example, in the simple build system on Unix, the
-    default _libdir_ is `/usr/local/lib`, and _libsubdir_ contains the
-    package identifier and compiler, e.g. `mypkg-0.2/ghc-6.4`, so
-    libraries would be installed in `/usr/local/lib/mypkg-0.2/ghc-6.4`.
+    default _libdir_ is `/usr/local/lib`, and _commonlibdir_ contains the
+    ABI, e.g. `x86_64-linux-ghc-8.0.1`, so
+    libraries would be installed in `/usr/local/lib/x86_64-linux-ghc-8.0.1`.
 
     _dir_ may contain the following path variables: `$pkgid`, `$pkg`,
     `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
@@ -543,14 +551,14 @@ In addition the simple build system supports the following installation path opt
 :   Documentation files are installed relative to this directory.
 
     _dir_ may contain the following path variables: `$prefix`, `$bindir`,
-    `$libdir`, `$libsubdir`, `$datadir`, `$datasubdir`, `$pkgid`, `$pkg`,
+    `$libdir`, `$commonlibdir`, `$datadir`, `$datasubdir`, `$pkgid`, `$pkg`,
     `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 `--htmldir=`_dir_
 :   HTML documentation files are installed relative to this directory.
 
     _dir_ may contain the following path variables: `$prefix`, `$bindir`,
-    `$libdir`, `$libsubdir`, `$datadir`, `$datasubdir`, `$docdir`, `$pkgid`,
+    `$libdir`, `$commonlibdir`, `$datadir`, `$datasubdir`, `$docdir`, `$pkgid`,
     `$pkg`, `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 `--program-prefix=`_prefix_
@@ -566,6 +574,20 @@ In addition the simple build system supports the following installation path opt
     `--program-suffix='$version'`.
 
     _suffix_ may contain the following path variables: `$pkgid`, `$pkg`,
+    `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
+
+`--commonlibdir=`_dir_
+:   For use with Setup.hs files build against a version of Cabal prior to 1.24.1.
+    For later versions of Cabal, this flag is basically deprecated, and you
+    should use `--commonlibdir=`_dir_.
+
+    A subdirectory of _libdir_ in which libraries are actually
+    installed. For example, in the simple build system on Unix, the
+    default _libdir_ is `/usr/local/lib`, and _commonlibdir_ contains the
+    ABI, e.g. `x86_64-linux-ghc-8.0.1`, so
+    libraries would be installed in `/usr/local/lib/x86_64-linux-ghc-8.0.1`.
+
+    _dir_ may contain the following path variables: `$pkgid`, `$pkg`,
     `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 #### Path variables in the simple build system ####
@@ -590,8 +612,11 @@ independence](#prefix-independence)).
 `$libdir`
 :   As above but for `--libdir`
 
-`$libsubdir`
-:   As above but for `--libsubdir`
+`$commonlibdir`
+:   As above but for `--commonlibdir`
+
+`$hidir`
+:   As above but for `--hidir`
 
 `$datadir`
 :   As above but for `--datadir`
@@ -601,6 +626,9 @@ independence](#prefix-independence)).
 
 `$docdir`
 :   As above but for `--docdir`
+
+`$libsubdir`
+:   As above but for `--libsubdir`
 
 `$pkgid`
 :   The name and version of the package, e.g. `mypkg-0.2`
@@ -642,7 +670,8 @@ Option                     Windows Default                                      
 `--prefix` (per-user)      `C:\Documents And Settings\user\Application Data\cabal`   `$HOME/.cabal`
 `--bindir`                 `$prefix\bin`                                             `$prefix/bin`
 `--libdir`                 `$prefix`                                                 `$prefix/lib`
-`--libsubdir` (others)     `$pkgid\$compiler`                                        `$pkgid/$compiler`
+`--commonlibdir` (others)  `$abi`                                                    `$abi`
+`--hidir`                  `$libdir\$abi\$libname`                                   `$libdir/$abi/$libname`
 `--libexecdir`             `$prefix\$pkgid`                                          `$prefix/libexec`
 `--datadir` (executable)   `$prefix`                                                 `$prefix/share`
 `--datadir` (library)      `C:\Program Files\Haskell`                                `$prefix/share`
@@ -652,6 +681,7 @@ Option                     Windows Default                                      
 `--htmldir`                `$docdir\html`                                            `$docdir/html`
 `--program-prefix`         (empty)                                                   (empty)
 `--program-suffix`         (empty)                                                   (empty)
+`--libsubdir`              `$abi\$libname`                                           `$abi/$libname`
 
 
 #### Prefix-independence ####

--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -502,7 +502,7 @@ package:
 :  Interface files (.hi) of libraries are installed here.
 
    In the simple build system, *dir* may contain the following path
-   variables: `$prefix`, `$bindir`, `$libdir`, `$commonlibdir`,
+   variables: `$prefix`, `$bindir`, `$libdir`, `$binlibsubdir`,
    `$pkgid`, `$pkg`, `$version`, `$compiler`, `$os`,
    `$arch`, `$abi`, `$abitag`
 
@@ -511,31 +511,32 @@ package:
     are installed here.
 
     In the simple build system, _dir_ may contain the following path
-    variables: `$prefix`, `$bindir`, `$libdir`, `$commonlibdir`, `$pkgid`,
+    variables: `$prefix`, `$bindir`, `$libdir`, `$binlibsubdir`, `$pkgid`,
     `$pkg`, `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 `--datadir`=_dir_
 :   Architecture-independent data files are installed here.
 
     In the simple build system, _dir_ may contain the following path
-    variables: `$prefix`, `$bindir`, `$libdir`, `$commonlibdir`, `$pkgid`, `$pkg`,
+    variables: `$prefix`, `$bindir`, `$libdir`, `$binlibsubdir`, `$pkgid`, `$pkg`,
     `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 `--sysconfdir=`_dir_
 :   Installation directory for the configuration files.
 
     In the simple build system, _dir_ may contain the following path variables:
-    `$prefix`, `$bindir`, `$libdir`, `$commonlibdir`, `$pkgid`, `$pkg`, `$version`,
+    `$prefix`, `$bindir`, `$libdir`, `$binlibsubdir`, `$pkgid`, `$pkg`, `$version`,
     `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 In addition the simple build system supports the following installation path options:
 
-`--commonlibdir=`_dir_
-:   A subdirectory of _libdir_ in which libraries are actually
-    installed. For example, in the simple build system on Unix, the
-    default _libdir_ is `/usr/local/lib`, and _commonlibdir_ contains the
-    ABI, e.g. `x86_64-linux-ghc-8.0.1`, so
-    libraries would be installed in `/usr/local/lib/x86_64-linux-ghc-8.0.1`.
+`--binlibsubdir=`_dir_
+:   A subdirectory of _libdir_ in which binary libraries are actually
+    installed. It is recommended that a single, common directory to be used to
+    store all installed libraries (as opposed to using `$pkgid` or similar
+    variables to create a directory per installed library), as this helps reduce
+    the size of rpath in executables built against dynamic libraries.
+    See [3982](https://github.com/haskell/cabal/pull/3982) for more details.
 
     _dir_ may contain the following path variables: `$pkgid`, `$pkg`,
     `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
@@ -551,14 +552,14 @@ In addition the simple build system supports the following installation path opt
 :   Documentation files are installed relative to this directory.
 
     _dir_ may contain the following path variables: `$prefix`, `$bindir`,
-    `$libdir`, `$commonlibdir`, `$datadir`, `$datasubdir`, `$pkgid`, `$pkg`,
+    `$libdir`, `$binlibsubdir`, `$datadir`, `$datasubdir`, `$pkgid`, `$pkg`,
     `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 `--htmldir=`_dir_
 :   HTML documentation files are installed relative to this directory.
 
     _dir_ may contain the following path variables: `$prefix`, `$bindir`,
-    `$libdir`, `$commonlibdir`, `$datadir`, `$datasubdir`, `$docdir`, `$pkgid`,
+    `$libdir`, `$binlibsubdir`, `$datadir`, `$datasubdir`, `$docdir`, `$pkgid`,
     `$pkg`, `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
 `--program-prefix=`_prefix_
@@ -576,14 +577,16 @@ In addition the simple build system supports the following installation path opt
     _suffix_ may contain the following path variables: `$pkgid`, `$pkg`,
     `$version`, `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
 
-`--commonlibdir=`_dir_
-:   For use with Setup.hs files build against a version of Cabal prior to 1.24.1.
-    For later versions of Cabal, this flag is basically deprecated, and you
-    should use `--commonlibdir=`_dir_.
+`--libsubdir=`_dir_
+:    For use with Setup.hs files built against a version of Cabal prior to 1.24.1.
+     With later versions of Cabal, you should prefer `--binlibsubdir` and
+     `--hidir`, which let you separately specify where binary libraries
+     and interface files get installed, so that binary libraries can be
+     installed to a shared directory..
 
     A subdirectory of _libdir_ in which libraries are actually
     installed. For example, in the simple build system on Unix, the
-    default _libdir_ is `/usr/local/lib`, and _commonlibdir_ contains the
+    default _libdir_ is `/usr/local/lib`, and _libsubdir_ contains the
     ABI, e.g. `x86_64-linux-ghc-8.0.1`, so
     libraries would be installed in `/usr/local/lib/x86_64-linux-ghc-8.0.1`.
 
@@ -612,8 +615,8 @@ independence](#prefix-independence)).
 `$libdir`
 :   As above but for `--libdir`
 
-`$commonlibdir`
-:   As above but for `--commonlibdir`
+`$binlibsubdir`
+:   As above but for `--binlibsubdir`
 
 `$hidir`
 :   As above but for `--hidir`
@@ -670,7 +673,7 @@ Option                     Windows Default                                      
 `--prefix` (per-user)      `C:\Documents And Settings\user\Application Data\cabal`   `$HOME/.cabal`
 `--bindir`                 `$prefix\bin`                                             `$prefix/bin`
 `--libdir`                 `$prefix`                                                 `$prefix/lib`
-`--commonlibdir` (others)  `$abi`                                                    `$abi`
+`--binlibsubdir` (others)  `$abi`                                                    `$abi`
 `--hidir`                  `$libdir\$abi\$libname`                                   `$libdir/$abi/$libname`
 `--libexecdir`             `$prefix\$pkgid`                                          `$prefix/libexec`
 `--datadir` (executable)   `$prefix`                                                 `$prefix/share`

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1128,7 +1128,7 @@ elaborateInstallPlan platform compiler compilerprogdb
                platform
                defaultInstallDirs) {
 
-              InstallDirs.libsubdir  = "", -- absoluteInstallDirs sets these as
+              InstallDirs.commonlibdir  = "", -- absoluteInstallDirs sets these as
               InstallDirs.datasubdir = ""  -- 'undefined' but we have to use
             }                              -- them as "Setup.hs configure" args
 
@@ -1914,6 +1914,8 @@ storePackageInstallDirs CabalDirLayout{cabalStorePackageDirectory}
     prefix       = cabalStorePackageDirectory compid ipkgid
     bindir       = prefix </> "bin"
     libdir       = prefix </> "lib"
+    commonlibdir = ""
+    hidir        = prefix </> "lib"
     libsubdir    = ""
     dynlibdir    = libdir
     libexecdir   = prefix </> "libexec"

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1128,7 +1128,7 @@ elaborateInstallPlan platform compiler compilerprogdb
                platform
                defaultInstallDirs) {
 
-              InstallDirs.commonlibdir  = "", -- absoluteInstallDirs sets these as
+              InstallDirs.binlibsubdir  = "", -- absoluteInstallDirs sets these as
               InstallDirs.datasubdir = ""  -- 'undefined' but we have to use
             }                              -- them as "Setup.hs configure" args
 
@@ -1914,7 +1914,7 @@ storePackageInstallDirs CabalDirLayout{cabalStorePackageDirectory}
     prefix       = cabalStorePackageDirectory compid ipkgid
     bindir       = prefix </> "bin"
     libdir       = prefix </> "lib"
-    commonlibdir = ""
+    binlibsubdir = ""
     hidir        = prefix </> "lib"
     libsubdir    = ""
     dynlibdir    = libdir

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -84,7 +84,7 @@ import Distribution.Simple.Setup
          , optionVerbosity, boolOpt, boolOpt', trueArg, falseArg
          , readPToMaybe, optionNumJobs )
 import Distribution.Simple.InstallDirs
-         ( PathTemplate, InstallDirs(sysconfdir)
+         ( PathTemplate, InstallDirs(commonlibdir, hidir, sysconfdir)
          , toPathTemplate, fromPathTemplate )
 import Distribution.Version
          ( Version(Version), anyVersion, thisVersion )
@@ -350,7 +350,7 @@ configureOptions = commandOptions configureCommand
 
 filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
-  | cabalLibVersion >= Version [1,23,0] [] = flags_latest
+  | cabalLibVersion >= Version [1,24,1] [] = flags_latest
   -- ^ NB: we expect the latest version to be the most common case.
   | cabalLibVersion <  Version [1,3,10] [] = flags_1_3_10
   | cabalLibVersion <  Version [1,10,0] [] = flags_1_10_0
@@ -362,6 +362,7 @@ filterConfigureFlags flags cabalLibVersion
   | cabalLibVersion <  Version [1,21,1] [] = flags_1_20_0
   | cabalLibVersion <  Version [1,22,0] [] = flags_1_21_0
   | cabalLibVersion <  Version [1,23,0] [] = flags_1_22_0
+  | cabalLibVersion <  Version [1,24,1] [] = flags_1_24_0
   | otherwise = flags_latest
   where
     (profEnabledLib, profEnabledExe) = computeEffectiveProfiling flags
@@ -373,10 +374,18 @@ filterConfigureFlags flags cabalLibVersion
       configAllowNewer  = Just Cabal.AllowNewerNone
       }
 
+    -- Cabal < 1.24.1 doesn't know about --extra-prog-path and --sysconfdir.
+    flags_1_24_0 = flags_latest { configInstallDirs = configInstallDirs_1_24_0}
+    configInstallDirs_1_24_0 = (configInstallDirs flags)
+                                  { commonlibdir = NoFlag
+                                  , hidir        = NoFlag
+                                  }
+
+
     -- Cabal < 1.23 doesn't know about '--profiling-detail'.
     -- Cabal < 1.23 has a hacked up version of 'enable-profiling'
     -- which we shouldn't use.
-    flags_1_22_0 = flags_latest { configProfDetail    = NoFlag
+    flags_1_22_0 = flags_1_24_0 { configProfDetail    = NoFlag
                                 , configProfLibDetail = NoFlag
                                 , configIPID          = NoFlag
                                 , configProf          = NoFlag
@@ -405,7 +414,7 @@ filterConfigureFlags flags cabalLibVersion
     -- Cabal < 1.18.0 doesn't know about --extra-prog-path and --sysconfdir.
     flags_1_18_0 = flags_1_19_0 { configProgramPathExtra = toNubList []
                                 , configInstallDirs = configInstallDirs_1_18_0}
-    configInstallDirs_1_18_0 = (configInstallDirs flags) { sysconfdir = NoFlag }
+    configInstallDirs_1_18_0 = (configInstallDirs flags_1_19_0) { sysconfdir = NoFlag }
     -- Cabal < 1.14.0 doesn't know about '--disable-benchmarks'.
     flags_1_14_0 = flags_1_18_0 { configBenchmarks  = NoFlag }
     -- Cabal < 1.12.0 doesn't know about '--enable/disable-executable-dynamic'

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -84,7 +84,7 @@ import Distribution.Simple.Setup
          , optionVerbosity, boolOpt, boolOpt', trueArg, falseArg
          , readPToMaybe, optionNumJobs )
 import Distribution.Simple.InstallDirs
-         ( PathTemplate, InstallDirs(commonlibdir, hidir, sysconfdir)
+         ( PathTemplate, InstallDirs(binlibsubdir, hidir, sysconfdir)
          , toPathTemplate, fromPathTemplate )
 import Distribution.Version
          ( Version(Version), anyVersion, thisVersion )
@@ -374,10 +374,10 @@ filterConfigureFlags flags cabalLibVersion
       configAllowNewer  = Just Cabal.AllowNewerNone
       }
 
-    -- Cabal < 1.24.1 doesn't know about --extra-prog-path and --sysconfdir.
+    -- Cabal < 1.24.1 doesn't know about --binlibsubdir and --hidir.
     flags_1_24_0 = flags_latest { configInstallDirs = configInstallDirs_1_24_0}
     configInstallDirs_1_24_0 = (configInstallDirs flags)
-                                  { commonlibdir = NoFlag
+                                  { binlibsubdir = NoFlag
                                   , hidir        = NoFlag
                                   }
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -527,7 +527,7 @@ instance Arbitrary a => Arbitrary (InstallDirs a) where
         <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  4
         <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary --  8
         <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary -- 12
-        <*> arbitrary <*> arbitrary                             -- 14
+        <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary -- 16
 
 instance Arbitrary PackageDB where
     arbitrary = oneof [ pure GlobalPackageDB


### PR DESCRIPTION
These two flags indicate where the two distinct aspects of a
Haskell library end up.

--commonlibdir: The subdirectory of --libdir where the object
                library files (.so/.a/.dll/.dylib) get installed.
--hidir:        The directory where the interface files (.hi)
                get installed.

The reason we want to do this is because we want dynamic libraries
to all end up in a shared directory to reduce start-up times of
the run-time linker. However, we still want the .hi to end up
in one directory per package.

We cannot repurpose --libsubdir to take over the role of what
--commonlibdir is doing because then we would run into trouble
with Setup.hs files build against an older Cabal. If we were
to repurpose --libsubdir, then all the object and interface
files would end up in a single shared directory for all
packages when using an older Cabal.

This PR backports #3982 to the 1.24 branch in order to solve https://ghc.haskell.org/trac/ghc/ticket/12479