### PR TITLE
Re-enable Travis testing other versions of GHC.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
    - env: GHCVER=7.10.3 SCRIPT=script
      os: linux
      sudo: required
-   - env: GHCVER=8.0.1 SCRIPT=script DEPLOY_DOCS=YES
+   - env: GHCVER=8.0.1 SCRIPT=script DEPLOY_DOCS=YES TEST_OTHER_VERSIONS=YES
      sudo: required
      os: linux
    - env: GHCVER=8.0.1 SCRIPT=solver-debug-flags

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -42,8 +42,11 @@ tests config = do
   -- Test that Cabal parses 'test' sections correctly
   tc "TestStanza"       PackageTests.TestStanza.Check.suite
 
-  -- Test that Cabal parses '^>=' operator correctly
-  tc "CaretOperator"    PackageTests.CaretOperator.Check.suite
+  -- Test that Cabal parses '^>=' operator correctly.
+  -- Don't run this for GHC 7.0/7.2, which doesn't have a recent
+  -- enough version of pretty. (But this is pretty dumb.)
+  tc "CaretOperator" . whenGhcVersion (>= mkVersion [7,3])$
+    PackageTests.CaretOperator.Check.suite
 
   -- Test that Cabal determinstically generates object archives
   tc "DeterministicAr"  PackageTests.DeterministicAr.Check.suite

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -16,7 +16,7 @@ if [ -z ${STACKAGE_RESOLVER+x} ]; then
         travis_retry sudo add-apt-repository -y ppa:hvr/ghc
         travis_retry sudo apt-get update
         travis_retry sudo apt-get install --force-yes cabal-install-1.24 happy-1.19.5 ghc-$GHCVER-prof ghc-$GHCVER-dyn
-        if [ "$TEST_OLDER" == "YES" ]; then travis_retry sudo apt-get install --force-yes ghc-7.0.4-prof ghc-7.0.4-dyn ghc-7.2.2-prof ghc-7.2.2-dyn; fi
+        if [ "x$TEST_OTHER_VERSIONS" = "xYES" ]; then travis_retry sudo apt-get install --force-yes ghc-7.0.4-prof ghc-7.0.4-dyn ghc-7.2.2-prof ghc-7.2.2-dyn ghc-head-prof ghc-head-dyn; fi
 
     elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
 

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -62,13 +62,14 @@ timed cabal new-build Cabal Cabal:package-tests Cabal:unit-tests
 (cd Cabal && timed cabal act-as-setup --build-type=Simple -- haddock --builddir=${CABAL_BDIR}) || exit $?
 
 # Redo the package tests with different versions of GHC
-# TODO: reenable me
-#   if [ "x$TEST_OLDER" = "xYES" -a "x$TRAVIS_OS_NAME" = "xlinux" ]; then
-#       CABAL_PACKAGETESTS_WITH_GHC=/opt/ghc/7.0.4/bin/ghc \
-#           ./dist/setup/setup test package-tests --show-details=streaming
-#       CABAL_PACKAGETESTS_WITH_GHC=/opt/ghc/7.2.2/bin/ghc \
-#           ./dist/setup/setup test package-tests --show-details=streaming
-#   fi
+if [ "x$TEST_OTHER_VERSIONS" = "xYES" ]; then
+    (export CABAL_PACKAGETESTS_WITH_GHC="/opt/ghc/7.0.4/bin/ghc"; \
+        cd Cabal && timed ${CABAL_BDIR}/build/package-tests/package-tests $TEST_OPTIONS)
+    (export CABAL_PACKAGETESTS_WITH_GHC="/opt/ghc/7.2.2/bin/ghc"; \
+        cd Cabal && timed ${CABAL_BDIR}/build/package-tests/package-tests $TEST_OPTIONS)
+    (export CABAL_PACKAGETESTS_WITH_GHC="/opt/ghc/head/bin/ghc"; \
+        cd Cabal && timed ${CABAL_BDIR}/build/package-tests/package-tests $TEST_OPTIONS)
+fi
 
 # Check for package warnings
 (cd Cabal && timed cabal check) || exit $?


### PR DESCRIPTION
This increases our test coverage for using Cabal with GHC 7.0, 7.2
and HEAD.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>