### PR TITLE
Timer osx pr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
    # We axed GHC 7.6 and earlier because it's not worth the trouble to
    # make older GHC work with clang's cpp.  See
    # https://ghc.haskell.org/trac/ghc/ticket/8493
-   - env: GHCVER=7.8.4 SCRIPT=script CABAL_LIB_ONLY=YES
+   - env: GHCVER=7.8.4 SCRIPT=script
      os: osx
      osx_image: xcode6.4 # We need 10.10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,9 @@ matrix:
    # We axed GHC 7.6 and earlier because it's not worth the trouble to
    # make older GHC work with clang's cpp.  See
    # https://ghc.haskell.org/trac/ghc/ticket/8493
-
-   # We axed GHC 7.8 on Mac OS X because (1) we're afflicted by the
-   # ar: permission denied bug (#2653) and also the xcode7.1 image
-   # doesn't have enough disk space to actually do our build.
-   #- env: GHCVER=7.8.4 SCRIPT=script
-   #  os: osx
-   #  osx_image: xcode7.1
+   - env: GHCVER=7.8.4 SCRIPT=script CABAL_LIB_ONLY=YES
+     os: osx
+     osx_image: xcode6.4 # We need 10.10
 
    # TODO: We might want to specify OSX version
    # https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version

--- a/travis-common.sh
+++ b/travis-common.sh
@@ -6,12 +6,28 @@ CABAL_VERSION="1.25.0.0"
 # Timing / diagnostic output
 # ---------------------------------------------------------------------
 
+JOB_START_TIME=$(date +%s)
+
 timed() {
     echo "\$ $*"
     start_time=$(date +%s)
+
+	# Run the job
     $* || exit $?
+
+	# Calculate the durations
     end_time=$(date +%s)
     duration=$((end_time - start_time))
+	total_duration=$((end_time - JOB_START_TIME))
+
+	# Print them
     echo "$* took $duration seconds."
+    echo "whole job took $total_duration seconds so far."
+
+	# Terminate on OSX
+	if [ $total_duration -ge 2400 -a $(uname) = "Darwin" ]; then
+		echo "Job taking over 40 minutes. Terminating"
+		exit 1
+	fi
     echo "----"
 }


### PR DESCRIPTION
if osx build is too slow, it will cut it down, making the cache populate. So restarting the job would help!