### PR TITLE
Avoid generating redundant constraints in new-freeze

### DIFF
--- a/cabal-install/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/Distribution/Client/CmdFreeze.hs
@@ -26,7 +26,8 @@ import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Package
          ( PackageName, packageName, packageVersion )
 import Distribution.Version
-         ( VersionRange, thisVersion, unionVersionRanges )
+         ( VersionRange, thisVersion
+         , unionVersionRanges, simplifyVersionRange )
 import Distribution.PackageDescription
          ( FlagAssignment )
 import Distribution.Client.Setup
@@ -151,6 +152,7 @@ projectFreezeConstraints plan =
 
     versionRanges :: Map PackageName VersionRange
     versionRanges =
+      Map.map simplifyVersionRange $
       Map.fromListWith unionVersionRanges $
           [ (packageName pkg, thisVersion (packageVersion pkg))
           | InstallPlan.PreExisting pkg <- InstallPlan.toList plan


### PR DESCRIPTION
We sometimes have to union constraints from different places, but we should simplify those before rendering so we don't add needless redundancy like "aeson-pretty ==0.8.1 || ==0.8.1". So we just use
simplifyVersionRange after unioning things.

Fixes #4002