### PR TITLE
New 'abi-depends' field which tracks 'depends' plus 'abi'

### DIFF
--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -212,7 +212,9 @@ buildComponent verbosity numJobs pkg_descr lbi suffixes
         pwd <- getCurrentDirectory
         let -- The in place registration uses the "-inplace" suffix, not an ABI hash
             installedPkgInfo = inplaceInstalledPackageInfo pwd distPref pkg_descr
-                                                           (mkAbiHash "") lib' lbi clbi
+                                    -- NB: Use a fake ABI hash to avoid
+                                    -- needing to recompute it every build.
+                                    (mkAbiHash "inplace") lib' lbi clbi
 
         debug verbosity $ "Registering inplace:\n" ++ (IPI.showInstalledPackageInfo installedPkgInfo)
         registerPackage verbosity (compiler lbi) (withPrograms lbi) HcPkg.MultiInstance

--- a/Cabal/Distribution/Simple/GHC/IPI642.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI642.hs
@@ -99,6 +99,7 @@ toCurrent ipi@InstalledPackageInfo{} =
     Current.includeDirs        = includeDirs ipi,
     Current.includes           = includes ipi,
     Current.depends            = map (Current.mkLegacyUnitId . convertPackageId) (depends ipi),
+    Current.abiDepends         = [],
     Current.ccOptions          = ccOptions ipi,
     Current.ldOptions          = ldOptions ipi,
     Current.frameworkDirs      = frameworkDirs ipi,


### PR DESCRIPTION
Last two commits only.

GHC will make use of this to do more accurate shadowing computation,
because now we can tell if something is ABI-compatible, even if the 'id'
matches.
