### PR TITLE
Backport "Add `--dynlibdir`" to 1.24

### DIFF
--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -83,6 +83,7 @@ data InstalledPackageInfo
         trusted           :: Bool,
         importDirs        :: [FilePath],
         libraryDirs       :: [FilePath],
+        libraryDynDirs    :: [FilePath],
         dataDir           :: FilePath,
         hsLibraries       :: [String],
         extraLibraries    :: [String],
@@ -143,6 +144,7 @@ emptyInstalledPackageInfo
         trusted           = False,
         importDirs        = [],
         libraryDirs       = [],
+        libraryDynDirs    = [],
         dataDir           = "",
         hsLibraries       = [],
         extraLibraries    = [],
@@ -315,6 +317,9 @@ installedFieldDescrs = [
  , listField   "library-dirs"
         showFilePath       parseFilePathQ
         libraryDirs        (\xs pkg -> pkg{libraryDirs=xs})
+ , listField   "dynamic-library-dirs"
+        showFilePath       parseFilePathQ
+        libraryDynDirs     (\xs pkg -> pkg{libraryDynDirs=xs})
  , simpleField "data-dir"
         showFilePath       (parseFilePathQ Parse.<++ return "")
         dataDir            (\val pkg -> pkg{dataDir=val})

--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -71,7 +71,7 @@ generate pkg_descr lbi =
         pragmas++
         "module " ++ display paths_modulename ++ " (\n"++
         "    version,\n"++
-        "    getBinDir, getLibDir, getDataDir, getLibexecDir,\n"++
+        "    getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,\n"++
         "    getDataFileName, getSysconfDir\n"++
         "  ) where\n"++
         "\n"++
@@ -108,9 +108,10 @@ generate pkg_descr lbi =
           "\n\nbindirrel :: FilePath\n" ++
           "bindirrel = " ++ show flat_bindirreloc ++
           "\n"++
-          "\ngetBinDir, getLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
+          "\ngetBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
           "getBinDir = "++mkGetEnvOrReloc "bindir" flat_bindirreloc++"\n"++
           "getLibDir = "++mkGetEnvOrReloc "libdir" flat_libdirreloc++"\n"++
+          "getDynLibDir = "++mkGetEnvOrReloc "dynlibdir" flat_dynlibdirreloc++"\n"++
           "getDataDir = "++mkGetEnvOrReloc "datadir" flat_datadirreloc++"\n"++
           "getLibexecDir = "++mkGetEnvOrReloc "libexecdir" flat_libexecdirreloc++"\n"++
           "getSysconfDir = "++mkGetEnvOrReloc "sysconfdir" flat_sysconfdirreloc++"\n"++
@@ -124,16 +125,18 @@ generate pkg_descr lbi =
           "\n"++
           filename_stuff
         | absolute =
-          "\nbindir, libdir, datadir, libexecdir, sysconfdir :: FilePath\n"++
+          "\nbindir, libdir, dynlibdir, datadir, libexecdir, sysconfdir :: FilePath\n"++
           "\nbindir     = " ++ show flat_bindir ++
           "\nlibdir     = " ++ show flat_libdir ++
+          "\ndynlibdir  = " ++ show flat_dynlibdir ++
           "\ndatadir    = " ++ show flat_datadir ++
           "\nlibexecdir = " ++ show flat_libexecdir ++
           "\nsysconfdir = " ++ show flat_sysconfdir ++
           "\n"++
-          "\ngetBinDir, getLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
+          "\ngetBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"++
           "getBinDir = "++mkGetEnvOr "bindir" "return bindir"++"\n"++
           "getLibDir = "++mkGetEnvOr "libdir" "return libdir"++"\n"++
+          "getDynLibDir = "++mkGetEnvOr "dynlibdir" "return dynlibdir"++"\n"++
           "getDataDir = "++mkGetEnvOr "datadir" "return datadir"++"\n"++
           "getLibexecDir = "++mkGetEnvOr "libexecdir" "return libexecdir"++"\n"++
           "getSysconfDir = "++mkGetEnvOr "sysconfdir" "return sysconfdir"++"\n"++
@@ -151,6 +154,8 @@ generate pkg_descr lbi =
           "getBinDir = getPrefixDirRel bindirrel\n\n"++
           "getLibDir :: IO FilePath\n"++
           "getLibDir = "++mkGetDir flat_libdir flat_libdirrel++"\n\n"++
+          "getDynLibDir :: IO FilePath\n"++
+          "getDynLibDir = "++mkGetDir flat_dynlibdir flat_dynlibdirrel++"\n\n"++
           "getDataDir :: IO FilePath\n"++
           "getDataDir =  "++ mkGetEnvOr "datadir"
                               (mkGetDir flat_datadir flat_datadirrel)++"\n\n"++
@@ -173,6 +178,7 @@ generate pkg_descr lbi =
           prefix     = flat_prefix,
           bindir     = flat_bindir,
           libdir     = flat_libdir,
+          dynlibdir  = flat_dynlibdir,
           datadir    = flat_datadir,
           libexecdir = flat_libexecdir,
           sysconfdir = flat_sysconfdir
@@ -180,6 +186,7 @@ generate pkg_descr lbi =
         InstallDirs {
           bindir     = flat_bindirrel,
           libdir     = flat_libdirrel,
+          dynlibdir  = flat_dynlibdirrel,
           datadir    = flat_datadirrel,
           libexecdir = flat_libexecdirrel,
           sysconfdir = flat_sysconfdirrel
@@ -187,6 +194,7 @@ generate pkg_descr lbi =
 
         flat_bindirreloc = shortRelativePath flat_prefix flat_bindir
         flat_libdirreloc = shortRelativePath flat_prefix flat_libdir
+        flat_dynlibdirreloc = shortRelativePath flat_prefix flat_dynlibdir
         flat_datadirreloc = shortRelativePath flat_prefix flat_datadir
         flat_libexecdirreloc = shortRelativePath flat_prefix flat_libexecdir
         flat_sysconfdirreloc = shortRelativePath flat_prefix flat_sysconfdir

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -56,6 +56,7 @@ module Distribution.Simple.Compiler (
         unifiedIPIDRequired,
         packageKeySupported,
         unitIdSupported,
+        libraryDynDirSupported,
 
         -- * Support for profiling detail levels
         ProfDetailLevel(..),
@@ -290,6 +291,13 @@ packageKeySupported = ghcSupported "Uses package keys"
 -- | Does this compiler support unit IDs?
 unitIdSupported :: Compiler -> Bool
 unitIdSupported = ghcSupported "Uses unit IDs"
+
+-- | Does this compiler support a package database entry with:
+-- "dynamic-library-dirs"?
+libraryDynDirSupported :: Compiler -> Bool
+libraryDynDirSupported comp = case compilerFlavor comp of
+  GHC -> compilerVersion comp >= Version [8,0,1,20161021] []
+  _   -> False
 
 -- | Utility function for GHC only features
 ghcSupported :: String -> Compiler -> Bool

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -684,6 +684,7 @@ configure (pkg_descr0', pbi) cfg = do
 
     dirinfo "Binaries"         (bindir dirs)     (bindir relative)
     dirinfo "Libraries"        (libdir dirs)     (libdir relative)
+    dirinfo "Dynamic libraries" (dynlibdir dirs) (dynlibdir relative)
     dirinfo "Private binaries" (libexecdir dirs) (libexecdir relative)
     dirinfo "Data files"       (datadir dirs)    (datadir relative)
     dirinfo "Documentation"    (docdir dirs)     (docdir relative)

--- a/Cabal/Distribution/Simple/GHC/IPI642.hs
+++ b/Cabal/Distribution/Simple/GHC/IPI642.hs
@@ -84,6 +84,7 @@ toCurrent ipi@InstalledPackageInfo{} =
     Current.trusted            = Current.trusted Current.emptyInstalledPackageInfo,
     Current.importDirs         = importDirs ipi,
     Current.libraryDirs        = libraryDirs ipi,
+    Current.libraryDynDirs     = [],
     Current.dataDir            = "",
     Current.hsLibraries        = hsLibraries ipi,
     Current.extraLibraries     = extraLibraries ipi,

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -60,7 +60,7 @@ install pkg_descr lbi flags = do
       installDirs@(InstallDirs {
          bindir     = binPref,
          libdir     = libPref,
---         dynlibdir  = dynlibPref, --see TODO below
+         dynlibdir  = dynlibPref,
          datadir    = dataPref,
          docdir     = docPref,
          htmldir    = htmlPref,
@@ -70,11 +70,6 @@ install pkg_descr lbi flags = do
              -- binPref should be computed per executable
              = absoluteInstallDirs pkg_descr lbi copydest
 
-      --TODO: decide if we need the user to be able to control the libdir
-      -- for shared libs independently of the one for static libs. If so
-      -- it should also have a flag in the command line UI
-      -- For the moment use dynlibdir = libdir
-      dynlibPref = libPref
       progPrefixPref = substPathTemplate (packageId pkg_descr) lbi (progPrefix lbi)
       progSuffixPref = substPathTemplate (packageId pkg_descr) lbi (progSuffix lbi)
 

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -182,7 +182,11 @@ defaultInstallDirs comp userInstall _hasLibs = do
            LHC    -> "$compiler"
            UHC    -> "$pkgid"
            _other -> "$abi" </> "$libname",
-      dynlibdir    = "$libdir",
+      dynlibdir    = "$libdir" </> case comp of
+           JHC    -> "$compiler"
+           LHC    -> "$compiler"
+           UHC    -> "$pkgid"
+           _other -> "$abi",
       libexecdir   = case buildOS of
         Windows   -> "$prefix" </> "$libname"
         _other    -> "$prefix" </> "libexec",
@@ -331,6 +335,7 @@ data PathTemplateVariable =
      | BindirVar     -- ^ The @$bindir@ path variable
      | LibdirVar     -- ^ The @$libdir@ path variable
      | LibsubdirVar  -- ^ The @$libsubdir@ path variable
+     | DynlibdirVar  -- ^ The @$dynlibdir@ path variable
      | DatadirVar    -- ^ The @$datadir@ path variable
      | DatasubdirVar -- ^ The @$datasubdir@ path variable
      | DocdirVar     -- ^ The @$docdir@ path variable
@@ -426,6 +431,7 @@ installDirsTemplateEnv dirs =
   ,(BindirVar,     bindir     dirs)
   ,(LibdirVar,     libdir     dirs)
   ,(LibsubdirVar,  libsubdir  dirs)
+  ,(DynlibdirVar,  dynlibdir  dirs)
   ,(DatadirVar,    datadir    dirs)
   ,(DatasubdirVar, datasubdir dirs)
   ,(DocdirVar,     docdir     dirs)
@@ -448,6 +454,7 @@ instance Show PathTemplateVariable where
   show BindirVar     = "bindir"
   show LibdirVar     = "libdir"
   show LibsubdirVar  = "libsubdir"
+  show DynlibdirVar  = "dynlibdir"
   show DatadirVar    = "datadir"
   show DatasubdirVar = "datasubdir"
   show DocdirVar     = "docdir"
@@ -476,6 +483,7 @@ instance Read PathTemplateVariable where
                  ,("bindir",     BindirVar)
                  ,("libdir",     LibdirVar)
                  ,("libsubdir",  LibsubdirVar)
+                 ,("dynlibdir",  DynlibdirVar)
                  ,("datadir",    DatadirVar)
                  ,("datasubdir", DatasubdirVar)
                  ,("docdir",     DocdirVar)

--- a/Cabal/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Simple/LocalBuildInfo.hs
@@ -441,10 +441,15 @@ depLibraryPaths inplace relative lbi clbi = do
                           ]
 
     let ipkgs          = allPackages (installedPkgs lbi)
-        allDepLibDirs  = concatMap Installed.libraryDirs ipkgs
+        -- First look for dynamic libraries in `dynamic-library-dirs`, and use
+        -- `library-dirs` as a fall back.
+        getDynDir pkg  = case Installed.libraryDynDirs pkg of
+                           [] -> Installed.libraryDirs pkg
+                           d  -> d
+        allDepLibDirs  = concatMap getDynDir ipkgs
         internalLib
           | inplace    = buildDir lbi
-          | otherwise  = libdir installDirs
+          | otherwise  = dynlibdir installDirs
         allDepLibDirs' = if hasInternalDeps
                             then internalLib : allDepLibDirs
                             else allDepLibDirs

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -767,6 +767,11 @@ installDirsOptions =
       libsubdir (\v flags -> flags { libsubdir = v })
       installDirArg
 
+  , option "" ["dynlibdir"]
+      "installation directory for dynamic libraries"
+      dynlibdir (\v flags -> flags { dynlibdir = v })
+      installDirArg
+
   , option "" ["libexecdir"]
       "installation directory for program executables"
       libexecdir (\v flags -> flags { libexecdir = v })

--- a/Cabal/doc/developing-packages.markdown
+++ b/Cabal/doc/developing-packages.markdown
@@ -1952,6 +1952,7 @@ version :: Version
 
 getBinDir :: IO FilePath
 getLibDir :: IO FilePath
+getDynLibDir :: IO FilePath
 getDataDir :: IO FilePath
 getLibexecDir :: IO FilePath
 getSysconfDir :: IO FilePath
@@ -2185,7 +2186,7 @@ a few options:
     `unregister`, `clean`, `dist` and `docs`. Some options to commands
     are passed through as follows:
 
-      * The `--with-hc-pkg`, `--prefix`, `--bindir`, `--libdir`, `--datadir`,
+      * The `--with-hc-pkg`, `--prefix`, `--bindir`, `--libdir`, `--dynlibdir`, `--datadir`,
         `--libexecdir` and `--sysconfdir` options to the `configure` command are
         passed on to the `configure` script. In addition the value of the
         `--with-compiler` option is passed in a `--with-hc` option and all
@@ -2201,6 +2202,7 @@ a few options:
                 $(MAKE) install prefix=$(destdir)/$(prefix) \
                                 bindir=$(destdir)/$(bindir) \
                                 libdir=$(destdir)/$(libdir) \
+                                dynlibdir=$(destdir)/$(dynlibdir) \
                                 datadir=$(destdir)/$(datadir) \
                                 libexecdir=$(destdir)/$(libexecdir) \
                                 sysconfdir=$(destdir)/$(sysconfdir) \

--- a/Cabal/doc/installing-packages.markdown
+++ b/Cabal/doc/installing-packages.markdown
@@ -405,7 +405,7 @@ If a user-supplied `configure` script is run (see the section on
 [system-dependent
 parameters](developing-packages.html#system-dependent-parameters) or on
 [complex packages](developing-packages.html#more-complex-packages)), it
-is passed the `--with-hc-pkg`, `--prefix`, `--bindir`, `--libdir`,
+is passed the `--with-hc-pkg`, `--prefix`, `--bindir`, `--libdir`, `--dynlibdir`,
 `--datadir`, `--libexecdir` and `--sysconfdir` options. In addition the
 value of the `--with-compiler` option is passed in a `--with-hc` option
 and all options specified with `--configure-option=` are passed on.
@@ -497,6 +497,17 @@ package:
     In the simple build system, _dir_ may contain the following path
     variables: `$prefix`, `$bindir`, `$pkgid`, `$pkg`, `$version`,
     `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
+
+`--dynlibdir=`_dir_
+:   Dynamic libraries are installed here.
+
+    By default, this is set to `$libdir/$abi`, which is usually not equal to
+    `$libdir/$libsubdir`.
+
+    In the simple build system, _dir_ may contain the following path
+    variables: `$prefix`, `$bindir`, `$libdir`, `$pkgid`, `$pkg`, `$version`,
+    `$compiler`, `$os`, `$arch`, `$abi`, `$abitag`
+
 
 `--libexecdir=`_dir_
 :   Executables that are not expected to be invoked directly by the user
@@ -590,6 +601,9 @@ independence](#prefix-independence)).
 `$libdir`
 :   As above but for `--libdir`
 
+`$dynlibdir`
+:   As above but for `--dynlibdir`
+
 `$libsubdir`
 :   As above but for `--libsubdir`
 
@@ -643,6 +657,7 @@ Option                     Windows Default                                      
 `--bindir`                 `$prefix\bin`                                             `$prefix/bin`
 `--libdir`                 `$prefix`                                                 `$prefix/lib`
 `--libsubdir` (others)     `$pkgid\$compiler`                                        `$pkgid/$compiler`
+`--dynlibdir`              `$libdir\$abi`                                            `$libdir/$abi`
 `--libexecdir`             `$prefix\$pkgid`                                          `$prefix/libexec`
 `--datadir` (executable)   `$prefix`                                                 `$prefix/share`
 `--datadir` (library)      `C:\Program Files\Haskell`                                `$prefix/share`
@@ -666,7 +681,7 @@ install-time, rather than having to bake the path into the binary when it is
 built.
 
 In order to achieve this, we require that for an executable on Windows,
-all of `$bindir`, `$libdir`, `$datadir` and `$libexecdir` begin with
+all of `$bindir`, `$libdir`, `$dynlibdir`, `$datadir` and `$libexecdir` begin with
 `$prefix`. If this is not the case then the compiled executable will
 have baked-in all absolute paths.
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -84,7 +84,7 @@ import Distribution.Simple.Setup
          , optionVerbosity, boolOpt, boolOpt', trueArg, falseArg
          , readPToMaybe, optionNumJobs )
 import Distribution.Simple.InstallDirs
-         ( PathTemplate, InstallDirs(sysconfdir)
+         ( PathTemplate, InstallDirs(dynlibdir, sysconfdir)
          , toPathTemplate, fromPathTemplate )
 import Distribution.Version
          ( Version(Version), anyVersion, thisVersion )
@@ -350,7 +350,7 @@ configureOptions = commandOptions configureCommand
 
 filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
-  | cabalLibVersion >= Version [1,23,0] [] = flags_latest
+  | cabalLibVersion >= Version [1,24,1] [] = flags_latest
   -- ^ NB: we expect the latest version to be the most common case.
   | cabalLibVersion <  Version [1,3,10] [] = flags_1_3_10
   | cabalLibVersion <  Version [1,10,0] [] = flags_1_10_0
@@ -362,6 +362,7 @@ filterConfigureFlags flags cabalLibVersion
   | cabalLibVersion <  Version [1,21,1] [] = flags_1_20_0
   | cabalLibVersion <  Version [1,22,0] [] = flags_1_21_0
   | cabalLibVersion <  Version [1,23,0] [] = flags_1_22_0
+  | cabalLibVersion <  Version [1,24,1] [] = flags_1_24_0
   | otherwise = flags_latest
   where
     (profEnabledLib, profEnabledExe) = computeEffectiveProfiling flags
@@ -373,10 +374,14 @@ filterConfigureFlags flags cabalLibVersion
       configAllowNewer  = Just Cabal.AllowNewerNone
       }
 
+    -- Cabal < 1.24.1 doesn't know about --dynlibdir.
+    flags_1_24_0 = flags_latest { configInstallDirs = configInstallDirs_1_24_0}
+    configInstallDirs_1_24_0 = (configInstallDirs flags) { dynlibdir = NoFlag }
+
     -- Cabal < 1.23 doesn't know about '--profiling-detail'.
     -- Cabal < 1.23 has a hacked up version of 'enable-profiling'
     -- which we shouldn't use.
-    flags_1_22_0 = flags_latest { configProfDetail    = NoFlag
+    flags_1_22_0 = flags_1_24_0 { configProfDetail    = NoFlag
                                 , configProfLibDetail = NoFlag
                                 , configIPID          = NoFlag
                                 , configProf          = NoFlag
@@ -405,7 +410,7 @@ filterConfigureFlags flags cabalLibVersion
     -- Cabal < 1.18.0 doesn't know about --extra-prog-path and --sysconfdir.
     flags_1_18_0 = flags_1_19_0 { configProgramPathExtra = toNubList []
                                 , configInstallDirs = configInstallDirs_1_18_0}
-    configInstallDirs_1_18_0 = (configInstallDirs flags) { sysconfdir = NoFlag }
+    configInstallDirs_1_18_0 = (configInstallDirs flags_1_19_0) { sysconfdir = NoFlag }
     -- Cabal < 1.14.0 doesn't know about '--disable-benchmarks'.
     flags_1_14_0 = flags_1_18_0 { configBenchmarks  = NoFlag }
     -- Cabal < 1.12.0 doesn't know about '--enable/disable-executable-dynamic'


### PR DESCRIPTION
--dynlibdir indicates the directory in which dynamic libraries
are installed. By default this setting is equal to:

$libdir/$abi

The static libraries will still end up in:

$libdir/$libsubdir

With $libsubdir/$abi as the default directory for dynamic
libraries, dynamic libraries will by default end up in a
single shared directory (per package database). This has the
potential to reduce start-up times for dynamically linked
executable as only one RPATH per package database will be
needed.

This commit uses the functionality defined in

https://phabricator.haskell.org/D2611

to tell GHC's > 8.0.1 package database that dynamic libraries
are copied to the directories mentioned in the

`dynamic-library-dirs`

field.