### PR TITLE
Fix install of packages bundling generated source in dist/

### DIFF
--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -749,7 +749,7 @@ withTarballLocalDirectory verbosity distDirLayout@DistDirLayout{..}
         -- compatibility we put the dist dir within it
         -- (i.e. tmp/src2345/foo-1.0/dist/).
         --
-        -- Unfortunately. a few custom Setup.hs scripts do not respect
+        -- Unfortunately, a few custom Setup.hs scripts do not respect
         -- the --builddir flag and always look for it at ./dist/ so
         -- this way we avoid breaking those packages
         BuildAndInstall ->

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -744,16 +744,21 @@ withTarballLocalDirectory verbosity distDirLayout@DistDirLayout{..}
                           tarball pkgid dparams buildstyle pkgTextOverride
                           buildPkg  =
       case buildstyle of
-        -- In this case we make a couple temp dirs, unpack the tarball to one
-        -- and build and install it from the other. We avoid nesting the
-        -- builddir under the tarball src dir to keep path name lengths down.
+        -- In this case we make a temp dir (e.g. tmp/src2345/), unpack
+        -- the tarball to it (e.g. tmp/src2345/foo-1.0/), and for
+        -- compatibility we put the dist dir within it
+        -- (i.e. tmp/src2345/foo-1.0/dist/).
+        --
+        -- Unfortunately. a few custom Setup.hs scripts do not respect
+        -- the --builddir flag and always look for it at ./dist/ so
+        -- this way we avoid breaking those packages
         BuildAndInstall ->
           let tmpdir = distTempDirectory in
-          withTempDirectory verbosity tmpdir "src"   $ \unpackdir ->
-          withTempDirectory verbosity tmpdir "build" $ \builddir -> do
+          withTempDirectory verbosity tmpdir "src"   $ \unpackdir -> do
             unpackPackageTarball verbosity tarball unpackdir
                                  pkgid pkgTextOverride
             let srcdir   = unpackdir </> display pkgid
+                builddir = srcdir </> "dist"
             buildPkg srcdir builddir
 
         -- In this case we make sure the tarball has been unpacked to the


### PR DESCRIPTION
Packages like `alex` include pre-generated lexer/parser source
in their source tarball as e.g.

  dist/build/alex/alex-tmp/Scan.hs
  dist/build/alex/alex-tmp/Parser.hs

to avoid having to have alex already installed before building
alex...

Unfortunately, 8dc39db73dc40e3ca84116f6915ff8d1cc78f584 broke
packages relying on this accidental feature by changing where the
distdir points to. This patch partly reverts that commit and
therefore addresses the regression aspect of #4009.