### PR TITLE
Add InstallPlan invariant assertion checking, revealing cyclic dep problem

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,3 +8,8 @@ program-options
   -- So us hackers get all the assertion failures early:
   -- NOTE: currently commented out, see https://github.com/haskell/cabal/issues/3911
   -- ghc-options: -fno-ignore-asserts
+  -- as a workaround we specify it for each package individually:
+package Cabal
+  ghc-options: -fno-ignore-asserts
+package cabal-install
+  ghc-options: -fno-ignore-asserts


### PR DESCRIPTION
It turns out that the install plan elaboration is constructing cyclic plans in some cases. The effect is that executing the plan simply misses out anything that depends on the packages involved in the cycle. This is probably the cause of #3996

With this patch such cases will fail with an assertion such as:

    internal error in InstallPlan.fromSolverInstallPlanWithProgress:
    The following packages are involved in a dependency cycle
    hspec-discover-2.3.1-da63d0b4e952e7949a113646e4af0aac925a4d864a1db650..

The cause is clearly in the caller of `fromSolverInstallPlanWithProgress` and the only caller of that is `ProjectPlanning.elaborateInstallPlan`. The problem appears to be to do with the intra-package dependencies. The hspec-discover-2.3.1 example is one where it has a lib and an exe and the exe depends on the lib. The resulting elaborated plan ends up with the lib component with a self-dependency which is clearly wrong.

@ezyang would you mind having a look?