### PR TITLE
Drop version check when resolving package names.

### DIFF
--- a/Cabal/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/Distribution/Backpack/ConfiguredComponent.hs
@@ -126,22 +126,16 @@ toConfiguredComponent pkg_descr this_cid
        lib_deps exe_deps component
   where
     bi = componentBuildInfo component
-    find_it :: PackageName -> VersionRange -> (ComponentId, PackageId)
-    find_it name reqVer =
-        fromMaybe (error ("toConfiguredComponent: " ++ display name)) $
-            lookup_name lib_map <|>
-            lookup_name external_lib_map
-      where
-        lookup_name m =
-            case Map.lookup name m of
-                Just (cid, pkgid)
-                    | packageVersion pkgid `withinRange` reqVer
-                    -> Just (cid, pkgid)
-                _ -> Nothing
+    find_it :: PackageName -> (ComponentId, PackageId)
+    find_it name =
+        fromMaybe (error ("toConfiguredComponent: " ++ display (packageName pkg_descr) ++
+                            " " ++ display name)) $
+            Map.lookup name lib_map <|>
+            Map.lookup name external_lib_map
     lib_deps
         | newPackageDepsBehaviour pkg_descr
-        = [ (name, find_it name reqVer)
-          | Dependency name reqVer <- targetBuildDepends bi ]
+        = [ (name, find_it name)
+          | Dependency name _ <- targetBuildDepends bi ]
         | otherwise
         = Map.toList external_lib_map
     exe_deps = [ cid

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -98,6 +98,10 @@
 	  or greater, respectively).
 	* New `Distribution.Utils.ShortText.ShortText` type for representing
 	  short text strings compactly (#3898)
+	* Cabal no longer supports using a version bound to disambiguate
+	  between an internal and external package (#4020).  This should
+	  not affect many people, as this mode of use already did not
+	  work with the dependency solver.
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* Support GHC 8.

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -120,9 +120,17 @@ tests config = do
   -- with the same name and LATER version
   tc "BuildDeps/InternalLibrary3" $ internal_lib_test "internal"
 
-  -- Test that an explicit dependency constraint which doesn't
-  -- match the internal library causes us to use external library
-  tc "BuildDeps/InternalLibrary4" $ internal_lib_test "installed"
+  -- On old versions of Cabal, an explicit dependency constraint which
+  -- doesn't match the internal library causes us to use external
+  -- library.  We got rid of this functionality in 1.25; now, we always
+  -- use internal, and just emit an error if you check.
+  tcs "BuildDeps/InternalLibrary4" "external" $ internal_lib_test "internal"
+
+  -- On a previous buggy version of my patch, the test above passed only
+  -- because the installed library caused Cabal to think that the
+  -- dependency was fulfilled.  Make sure we ignore the dependency
+  -- entirely.
+  tcs "BuildDeps/InternalLibrary4" "ignore" $ cabal_build []
 
   -- Test "old build-dep behavior", where we should get the
   -- same package dependencies on all targets if cabal-version

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1096,6 +1096,8 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
         -> LogProgress [ElaboratedConfiguredPackage]
     elaborateSolverToComponents mapDep spkg@(SolverPackage _ _ _ deps0 exe_deps0)
         | Right g <- toComponentsGraph (elabEnabledSpec elab0) pd = do
+            infoProgress $ hang (text "Component graph for" <+> disp pkgid <<>> colon)
+                            4 (dispComponentsGraph g)
             (_, comps) <- mapAccumM buildComponent
                             ((Map.empty, Map.empty), Map.empty, Map.empty)
                             (map fst g)

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -139,6 +139,10 @@ Extra-Source-Files:
   tests/IntegrationTests/new-build/T3978/cabal.project
   tests/IntegrationTests/new-build/T3978/p/p.cabal
   tests/IntegrationTests/new-build/T3978/q/q.cabal
+  tests/IntegrationTests/new-build/T4017.sh
+  tests/IntegrationTests/new-build/T4017/cabal.project
+  tests/IntegrationTests/new-build/T4017/p/p.cabal
+  tests/IntegrationTests/new-build/T4017/q/q.cabal
   tests/IntegrationTests/new-build/executable/Main.hs
   tests/IntegrationTests/new-build/executable/Setup.hs
   tests/IntegrationTests/new-build/executable/Test.hs

--- a/cabal-install/tests/IntegrationTests/new-build/T4017.sh
+++ b/cabal-install/tests/IntegrationTests/new-build/T4017.sh
@@ -1,0 +1,3 @@
+. ./common.sh
+cd T4017
+cabal new-build q

--- a/cabal-install/tests/IntegrationTests/new-build/T4017/cabal.project
+++ b/cabal-install/tests/IntegrationTests/new-build/T4017/cabal.project
@@ -1,0 +1,2 @@
+packages: p q
+allow-older: p:base

--- a/cabal-install/tests/IntegrationTests/new-build/T4017/p/p.cabal
+++ b/cabal-install/tests/IntegrationTests/new-build/T4017/p/p.cabal
@@ -1,0 +1,7 @@
+name: p
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    build-depends: base >= 99999

--- a/cabal-install/tests/IntegrationTests/new-build/T4017/q/q.cabal
+++ b/cabal-install/tests/IntegrationTests/new-build/T4017/q/q.cabal
@@ -1,0 +1,7 @@
+name: q
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    build-depends: p


### PR DESCRIPTION
In #4017, hvr reported that when he used --allow-older/--allow-newer,
there was an assert failure in toConfiguredComponent.  Indeed
the problem was that toConfiguredComponent was testing version
ranges of build-depends to determine which package to select, but
there was no satisfying one (since the build-depends field had
not been updated.)

After thinking about this for a bit, it seemed a bit bogus for
us to be doing another version check at this late phase; we
already picked dependencies earlier in the configuration process.
So I decided to drop it.

To drop it, however, I needed to remove support for a feature (discussed
in #4020), which uses version ranges to disambiguate whether or not a
dependency is on an external package or an internal package.  This
feature doesn't seem to be very useful.  If someone asks, I'll
check on Hackage to see if anyone is using it.

Also added some useful extra debug info.

Fixes #4020 and #4017

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>