### PR TITLE
Allocate different ComponentId for lib and exe.

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2824,7 +2824,10 @@ packageHashInputs
     }) =
     PackageHashInputs {
       pkgHashPkgId       = packageId elab,
-      pkgHashComponent   = Nothing,
+      pkgHashComponent   =
+        case elabPkgOrComp elab of
+          ElabPackage _ -> Nothing
+          ElabComponent comp -> Just (compSolverName comp),
       pkgHashSourceHash  = srchash,
       pkgHashPkgConfigDeps = Set.fromList (elabPkgConfigDependencies elab),
       pkgHashDirectDeps  =


### PR DESCRIPTION
In the old code, we assumed that only libraries could get
installed, but with executable dependencies this is no
longer true.  Handle it correctly.

This bug caused cycles in the elaborated install plan which
could cause dependency closure to fail, resulting in
weird errors.

Fixes #3996.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>