### PR TITLE
Do an early check for unbuildable deps, and give good error.

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -134,6 +134,11 @@ Extra-Source-Files:
   tests/IntegrationTests/new-build/T3460/sub-package-B/B.hs
   tests/IntegrationTests/new-build/T3460/sub-package-B/Setup.hs
   tests/IntegrationTests/new-build/T3460/sub-package-B/sub-package-B.cabal
+  tests/IntegrationTests/new-build/T3978.err
+  tests/IntegrationTests/new-build/T3978.sh
+  tests/IntegrationTests/new-build/T3978/cabal.project
+  tests/IntegrationTests/new-build/T3978/p/p.cabal
+  tests/IntegrationTests/new-build/T3978/q/q.cabal
   tests/IntegrationTests/new-build/executable/Main.hs
   tests/IntegrationTests/new-build/executable/Setup.hs
   tests/IntegrationTests/new-build/executable/Test.hs

--- a/cabal-install/tests/IntegrationTests/new-build/T3978.err
+++ b/cabal-install/tests/IntegrationTests/new-build/T3978.err
@@ -1,0 +1,1 @@
+RE:^cabal(\.exe)?: The package q-1.0 depends on unbuildable libraries: p-1.0

--- a/cabal-install/tests/IntegrationTests/new-build/T3978.sh
+++ b/cabal-install/tests/IntegrationTests/new-build/T3978.sh
@@ -1,0 +1,3 @@
+. ./common.sh
+cd T3978
+! cabal new-build q

--- a/cabal-install/tests/IntegrationTests/new-build/T3978/cabal.project
+++ b/cabal-install/tests/IntegrationTests/new-build/T3978/cabal.project
@@ -1,0 +1,2 @@
+packages: p q
+allow-older: p:base

--- a/cabal-install/tests/IntegrationTests/new-build/T3978/p/p.cabal
+++ b/cabal-install/tests/IntegrationTests/new-build/T3978/p/p.cabal
@@ -1,0 +1,7 @@
+name: p
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    buildable: False

--- a/cabal-install/tests/IntegrationTests/new-build/T3978/q/q.cabal
+++ b/cabal-install/tests/IntegrationTests/new-build/T3978/q/q.cabal
@@ -1,0 +1,7 @@
+name: q
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    build-depends: p


### PR DESCRIPTION
When a library/executable is unbuildable, the solver may still
return a reference to it.  Handle this gracefully in ProjectPlanning
with a nice error message, rather than an assert failure.

Fixes #3978.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>