### PR TITLE
Fix CPP usage

### DIFF
--- a/Cabal/Distribution/Compat/CreatePipe.hs
+++ b/Cabal/Distribution/Compat/CreatePipe.hs
@@ -11,7 +11,7 @@ import Distribution.Compat.Prelude
 import Distribution.Compat.Stack
 
 -- The mingw32_HOST_OS CPP macro is GHC-specific
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
 import qualified Prelude
 import Control.Exception (onException)
 import Foreign.C.Error (throwErrnoIfMinus1_)
@@ -31,7 +31,7 @@ import qualified System.Posix.IO as Posix
 
 createPipe :: IO (Handle, Handle)
 -- The mingw32_HOST_OS CPP macro is GHC-specific
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
 createPipe = do
     (readfd, writefd) <- allocaArray 2 $ \ pfds -> do
         throwErrnoIfMinus1_ "_pipe" $ c__pipe pfds 2 ({- _O_BINARY -} 32768)

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -59,7 +59,7 @@ import System.Directory (getAppUserDataDirectory)
 import System.FilePath ((</>), isPathSeparator, pathSeparator)
 import System.FilePath (dropDrive)
 
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
 import qualified Prelude
 import Foreign
 import Foreign.C
@@ -553,14 +553,14 @@ instance Read PathTemplate where
 
 getWindowsProgramFilesDir :: NoCallStackIO FilePath
 getWindowsProgramFilesDir = do
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
   m <- shGetFolderPath csidl_PROGRAM_FILES
 #else
   let m = Nothing
 #endif
   return (fromMaybe "C:\\Program Files" m)
 
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
 shGetFolderPath :: CInt -> NoCallStackIO (Maybe FilePath)
 shGetFolderPath n =
   allocaArray long_path_size $ \pPath -> do

--- a/cabal-install/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/Distribution/Client/InstallSymlink.hs
@@ -16,7 +16,7 @@ module Distribution.Client.InstallSymlink (
     symlinkBinary,
   ) where
 
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
 
 import Distribution.Package (PackageIdentifier)
 import Distribution.Client.InstallPlan (InstallPlan)

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -85,7 +85,7 @@ import Distribution.Simple.Utils
 import Distribution.Client.Utils
          ( inDir, tryCanonicalizePath, withExtraPathEnv
          , existsAndIsMoreRecentThan, moreRecentFile, withEnv
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
          , canonicalizePathNoThrow
 #endif
          )
@@ -462,7 +462,7 @@ externalSetupMethod path verbosity options _ args = do
                                     ++ show logHandle
 
   -- See 'Note: win32 clean hack' above.
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
   if useWin32CleanHack options then doWin32CleanHack path else doInvoke path
 #else
   doInvoke path
@@ -483,7 +483,7 @@ externalSetupMethod path verbosity options _ args = do
       exitCode <- waitForProcess process
       unless (exitCode == ExitSuccess) $ exitWith exitCode
 
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
     doWin32CleanHack path' = do
       info verbosity $ "Using the Win32 clean hack."
       -- Recursively removes the temp dir on exit.
@@ -528,7 +528,7 @@ getExternalSetupMethod verbosity options pkg bt = do
   path' <- tryCanonicalizePath path
 
   -- See 'Note: win32 clean hack' above.
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
   -- setupProgFile may not exist if we're using a cached program
   setupProgFile' <- canonicalizePathNoThrow setupProgFile
   let win32CleanHackNeeded = (useWin32CleanHack options)

--- a/cabal-install/Distribution/Client/Win32SelfUpgrade.hs
+++ b/cabal-install/Distribution/Client/Win32SelfUpgrade.hs
@@ -42,7 +42,7 @@ module Distribution.Client.Win32SelfUpgrade (
     deleteOldExeFile,
   ) where
 
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
 
 import qualified System.Win32 as Win32
 import System.Win32 (DWORD, BOOL, HANDLE, LPCTSTR)


### PR DESCRIPTION
The code had a mixtire of `#ifdef mingw32_HOST_OS` and `#if`. The later
works but is not really correct. GHC HEAD has just got a new warning flag
`-Wcpp-undef` which will warn on `#if` used with an undefined identifier.
Since we want to turn that on in the GHC build system we need to fix cabal
first.