### PR TITLE
Revert "D.PD.Check: extra-doc-files only allowed when Cabal >= 1.18."

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -904,13 +904,6 @@ checkCabalVersion pkg =
         ++ "different modules then list the other ones in the "
         ++ "'other-languages' field."
 
-  , checkVersion [1,18]
-    (not . null $ extraDocFiles pkg) $
-      PackageDistInexcusable $
-           "To use the 'extra-doc-files' field the package needs to specify "
-        ++ "at least 'cabal-version: >= 1.18'."
-
-
     -- check use of reexported-modules sections
   , checkVersion [1,21]
     (maybe False (not.null.reexportedModules) (library pkg)) $


### PR DESCRIPTION
This causes filepath to not validate, which means GHC build doesn't
work. Annoying. Let's not for 8.0 series.

This reverts commit 0b458361e7a1af485e74354bad74b8ae02e0f5f4.