### PR TITLE
Don't use installedPkgs for internal library library dirs.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -271,6 +271,9 @@ extra-source-files:
   tests/PackageTests/Regression/T3294/T3294.cabal
   tests/PackageTests/Regression/T3847/Main.hs
   tests/PackageTests/Regression/T3847/T3847.cabal
+  tests/PackageTests/Regression/T4025/A.hs
+  tests/PackageTests/Regression/T4025/T4025.cabal
+  tests/PackageTests/Regression/T4025/exe/Main.hs
   tests/PackageTests/TemplateHaskell/dynamic/Exe.hs
   tests/PackageTests/TemplateHaskell/dynamic/Lib.hs
   tests/PackageTests/TemplateHaskell/dynamic/TH.hs

--- a/Cabal/tests/PackageTests/Regression/T4025/A.hs
+++ b/Cabal/tests/PackageTests/Regression/T4025/A.hs
@@ -1,0 +1,4 @@
+module A where
+{-# NOINLINE a #-}
+a :: Int
+a = 23

--- a/Cabal/tests/PackageTests/Regression/T4025/T4025.cabal
+++ b/Cabal/tests/PackageTests/Regression/T4025/T4025.cabal
@@ -1,0 +1,13 @@
+name: T4025
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+  build-depends: base
+  exposed-modules: A
+
+executable exe
+  build-depends: T4025, base
+  hs-source-dirs: exe
+  main-is: Main.hs

--- a/Cabal/tests/PackageTests/Regression/T4025/exe/Main.hs
+++ b/Cabal/tests/PackageTests/Regression/T4025/exe/Main.hs
@@ -1,0 +1,2 @@
+import A
+main = print a

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -539,6 +539,19 @@ tests config = do
   -- Test that we pick up include dirs from internal library
   tc "Regression/T2971a" $ cabal_build []
 
+  -- Test that we don't accidentally add the inplace directory to
+  -- an executable RPATH.  Don't test on Windows, which doesn't
+  -- support RPATH.
+  unlessWindows $ do
+    tc "Regression/T4025" $ do
+      cabal "configure" ["--enable-executable-dynamic"]
+      cabal "build" []
+      -- This should fail as it we should NOT be able to find the
+      -- dynamic library for the internal library (since we didn't
+      -- install it).  If we incorrectly encoded our local dist
+      -- dir in the RPATH, this will succeed.
+      shouldFail $ runExe' "exe" []
+
   -- Test error message we report when a non-buildable target is
   -- requested to be built
   -- TODO: We can give a better error message here, see #3858.


### PR DESCRIPTION
In 1.24, installedPkgs contained only references to the external package
database, not any internal libraries. In particular, when we built a
dynamically linked executable, installedPkgs did NOT have a reference to
the internal library; instead, depLibraryPaths has a special case
(hasInternalDeps) to add the final libdir to the RPATH.

In HEAD, after 0d15ede, we started adding internal libraries (with the
INPLACE registrations) to installedPkgs to fix #2971.  But depLibraryPaths
was not updated, which means that the inplace registrations got picked
up and added to the RPATH, resulting in bad temporary directories
showing up in RPATHs.

In this commit, we just filter out internal entries from installedPkgs
and compute the library dirs for them from scratch (this code already
existed, so no loss!)

Fixes #4025.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>