### PR TITLE
Force gen-extra-source-files to use pre-installed library.

### DIFF
--- a/Cabal/misc/gen-extra-source-files.hs
+++ b/Cabal/misc/gen-extra-source-files.hs
@@ -1,14 +1,19 @@
 #!/usr/bin/env runhaskell
+{-# LANGUAGE PackageImports #-}
+
+-- NB: Force an installed Cabal package to be used, NOT
+-- some local files which have these names (as would be
+-- the case if we were in the Cabal source directory.)
+import "Cabal" Distribution.PackageDescription
+import "Cabal" Distribution.PackageDescription.Parse (ParseResult (..), parsePackageDescription)
+import "Cabal" Distribution.Verbosity                (silent)
+import qualified "Cabal" Distribution.ModuleName as ModuleName
 
 import Data.List                             (isPrefixOf, isSuffixOf, sort)
-import Distribution.PackageDescription
-import Distribution.PackageDescription.Parse (ParseResult (..), parsePackageDescription)
-import Distribution.Verbosity                (silent)
 import System.Environment                    (getArgs, getProgName)
 import System.FilePath                       (takeExtension, takeFileName)
 import System.Process                        (readProcess)
 
-import qualified Distribution.ModuleName as ModuleName
 import qualified System.IO               as IO
 
 main' :: FilePath -> IO ()


### PR DESCRIPTION
Without a package qualified import, runhaskell will attempt to
load all of Cabal from source, because the files happen to
be named in the same way as the import requests.  That leads
to very slow runtimes.

Fixes #4007.

CC @phadej

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>