### PR TITLE
Better error messages

### DIFF
--- a/cabal-install/Distribution/Client/BuildTarget.hs
+++ b/cabal-install/Distribution/Client/BuildTarget.hs
@@ -507,7 +507,8 @@ resolveBuildTarget ppinfo opinfo userTarget =
         -- retaining only at most three most similar (by edit distance) ones.
         nosuch   = Map.foldrWithKey genResults [] $ Map.fromListWith Set.union $
           [ ((inside, thing, got), Set.fromList alts)
-          | (inside, MatchErrorNoSuch thing got alts) <- map (innerErr Nothing) errs
+          | (inside, MatchErrorNoSuch thing got alts)
+            <- map (innerErr Nothing) errs
           ]
 
         genResults (inside, thing, got) alts acc = (
@@ -522,7 +523,8 @@ resolveBuildTarget ppinfo opinfo userTarget =
             $ Set.toList alts
           ) : acc
           where
-            addLevDist = id &&& restrictedDamerauLevenshteinDistance defaultEditCosts got
+            addLevDist = id &&& restrictedDamerauLevenshteinDistance
+                                defaultEditCosts got
 
             distanceLow (_, dist) = dist < length got `div` 2
 
@@ -563,7 +565,8 @@ disambiguateBuildTargets matcher matchInput exactMatch matchResults =
     -- So, here's the strategy. We take the original match results, and make a
     -- table of all their renderings at all qualification levels.
     -- Note there can be multiple renderings at each qualification level.
-    matchResultsRenderings :: [(BuildTarget PackageInfo, [UserBuildTargetFileStatus])]
+    matchResultsRenderings :: [(BuildTarget PackageInfo,
+                                [UserBuildTargetFileStatus])]
     matchResultsRenderings =
       [ (matchResult, matchRenderings)
       | matchResult <- matchResults

--- a/cabal-install/Distribution/Client/BuildTarget.hs
+++ b/cabal-install/Distribution/Client/BuildTarget.hs
@@ -206,7 +206,7 @@ data UserBuildTarget =
 --
 data BuildTarget pkg =
 
-     -- | A package as a whole 
+     -- | A package as a whole
      --
      BuildTargetPackage pkg
 
@@ -500,7 +500,7 @@ resolveBuildTarget ppinfo opinfo userTarget =
       | otherwise
       = internalError $ "classifyMatchErrors: " ++ show errs
       where
-        expected = [ (thing, got) 
+        expected = [ (thing, got)
                    | (_, MatchErrorExpected thing got)
                            <- map (innerErr Nothing) errs ]
         nosuch   = Map.foldrWithKey genResults [] $ Map.fromListWith Set.union $
@@ -605,7 +605,7 @@ disambiguateBuildTargets matcher matchInput exactMatch matchResults =
                   , [ (forgetFileStatus rendering, matches)
                     | rendering <- matchRenderings
                     , let (ExactMatch _ matches) =
-                            memoisedMatches Map.! rendering 
+                            memoisedMatches Map.! rendering
                     ] )
 
       | (originalMatch, matchRenderings) <- matchResultsRenderings ]
@@ -827,7 +827,7 @@ matchBuildTarget2 pinfo str1 fstatus1 str2 =
 matchBuildTarget3 :: [PackageInfo] -> String -> FileStatus -> String -> String
                   -> Match (BuildTarget PackageInfo)
 matchBuildTarget3 pinfo str1 fstatus1 str2 str3 =
-        match3PkgKndCmp pinfo str1 fstatus1 str2 str3 
+        match3PkgKndCmp pinfo str1 fstatus1 str2 str3
    <//> match3PkgCmpMod pinfo str1 fstatus1 str2 str3
    <//> match3PkgCmpFil pinfo str1 fstatus1 str2 str3
    <//> match3KndCmpMod cinfo str1          str2 str3
@@ -1074,7 +1074,7 @@ selectPackageInfo pkg loc = do
     (pkgdir, pkgfile) <-
       case loc of
         --TODO: local tarballs, remote tarballs etc
-        LocalUnpackedPackage dir -> do 
+        LocalUnpackedPackage dir -> do
           dirabs <- canonicalizePath dir
           dirrel <- makeRelativeToCwd dirabs
           --TODO: ought to get this earlier in project reading
@@ -1239,7 +1239,7 @@ matchPackageDir :: [PackageInfo]
                 -> String -> FileStatus -> Match PackageInfo
 matchPackageDir ps = \str fstatus ->
     case fstatus of
-      FileStatusExistsDir canondir -> 
+      FileStatusExistsDir canondir ->
         orNoSuchThing "package directory" str (map (snd . fst) dirs) $
           increaseConfidenceFor $
             fmap snd $ matchExactly (fst . fst) dirs canondir
@@ -1252,7 +1252,7 @@ matchPackageDir ps = \str fstatus ->
 matchPackageFile :: [PackageInfo] -> String -> FileStatus -> Match PackageInfo
 matchPackageFile ps = \str fstatus -> do
     case fstatus of
-      FileStatusExistsFile canonfile -> 
+      FileStatusExistsFile canonfile ->
         orNoSuchThing "package .cabal file" str (map (snd . fst) files) $
           increaseConfidenceFor $
             fmap snd $ matchExactly (fst . fst) files canonfile
@@ -1656,4 +1656,3 @@ ex_cs =
     pkgid :: PackageIdentifier
     Just pkgid = simpleParse "thelib"
 -}
-

--- a/cabal-install/Distribution/Client/BuildTarget.hs
+++ b/cabal-install/Distribution/Client/BuildTarget.hs
@@ -503,6 +503,8 @@ resolveBuildTarget ppinfo opinfo userTarget =
         expected = [ (thing, got)
                    | (_, MatchErrorExpected thing got)
                            <- map (innerErr Nothing) errs ]
+        -- Trim the list of alternatives by dropping duplicates and
+        -- retaining only at most three most similar (by edit distance) ones.
         nosuch   = Map.foldrWithKey genResults [] $ Map.fromListWith Set.union $
           [ ((inside, thing, got), Set.fromList alts)
           | (inside, MatchErrorNoSuch thing got alts) <- map (innerErr Nothing) errs

--- a/cabal-install/Distribution/Client/BuildTarget.hs
+++ b/cabal-install/Distribution/Client/BuildTarget.hs
@@ -65,14 +65,16 @@ import Distribution.Simple.Utils
 import Distribution.Client.Utils
          ( makeRelativeToCwd )
 
-import Data.List
-         ( nubBy, stripPrefix, partition, intercalate, sortBy, sortOn, groupBy )
-import Data.Maybe
-         ( listToMaybe, maybeToList )
 import Data.Either
          ( partitionEithers )
 import Data.Function
          ( on )
+import Data.List
+         ( nubBy, stripPrefix, partition, intercalate, sortBy, groupBy )
+import Data.Maybe
+         ( listToMaybe, maybeToList )
+import Data.Ord
+         ( comparing )
 import GHC.Generics (Generic)
 #if MIN_VERSION_containers(0,5,0)
 import qualified Data.Map.Lazy   as Map.Lazy
@@ -513,7 +515,7 @@ resolveBuildTarget ppinfo opinfo userTarget =
           , take maxResults
             $ map fst
             $ takeWhile distanceLow
-            $ sortOn snd
+            $ sortBy (comparing snd)
             $ map addLevDist
             $ Set.toList alts
           ) : acc

--- a/cabal-install/Distribution/Client/BuildTarget.hs
+++ b/cabal-install/Distribution/Client/BuildTarget.hs
@@ -741,7 +741,7 @@ reportBuildTargetProblems problems = do
                  | (thing, alts) <- alternatives ]
             | (inside, nosuch') <- groupByContainer nosuch
             , let alternatives =
-                    [ (thing, take 10 alts) --TODO: select best ones
+                    [ (thing, alts)
                     | (thing,_got,alts@(_:_)) <- nosuch' ]
             ]
           | (target, nosuch) <- targets

--- a/cabal-install/Distribution/Client/BuildTarget.hs
+++ b/cabal-install/Distribution/Client/BuildTarget.hs
@@ -737,7 +737,7 @@ reportBuildTargetProblems problems = do
                                     | (thing, got, _alts) <- nosuch' ] ++ "."
               ++ if null alternatives then "" else
                  "\nPerhaps you meant " ++ intercalate ";\nor "
-                 [ "the " ++ thing ++ " " ++ intercalate " or " alts
+                 [ "the " ++ thing ++ " '" ++ intercalate "' or '" alts ++ "'?"
                  | (thing, alts) <- alternatives ]
             | (inside, nosuch') <- groupByContainer nosuch
             , let alternatives =

--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -259,6 +259,8 @@ BASE64_BYTESTRING_VER="1.0.0.1"; BASE64_BYTESTRING_VER_REGEXP="1\."
                        # >=1.0
 CRYPTOHASH_SHA256_VER="0.11.7.1"; CRYPTOHASH_SHA256_VER_REGEXP="0\.11\.?"
                        # 0.11.*
+EDIT_DISTANCE_VER="0.2.2.1"; EDIT_DISTANCE_VER_REGEXP="0\.2\.2\.?"
+                       # 0.2.2.*
 ED25519_VER="0.0.5.0"; ED25519_VER_REGEXP="0\.0\.?"
                        # 0.0.*
 HACKAGE_SECURITY_VER="0.5.2.2"; HACKAGE_SECURITY_VER_REGEXP="0\.5\.(2\.[2-9]|[3-9])"
@@ -483,6 +485,7 @@ info_pkg "base64-bytestring" ${BASE64_BYTESTRING_VER} \
     ${BASE64_BYTESTRING_VER_REGEXP}
 info_pkg "cryptohash-sha256" ${CRYPTOHASH_SHA256_VER} \
     ${CRYPTOHASH_SHA256_VER_REGEXP}
+info_pkg "edit-distance" ${EDIT_DISTANCE_VER} ${EDIT_DISTANCE_VER_REGEXP}
 info_pkg "ed25519"           ${ED25519_VER}          ${ED25519_VER_REGEXP}
 info_pkg "tar"               ${TAR_VER}              ${TAR_VER_REGEXP}
 info_pkg "hashable"          ${HASHABLE_VER}         ${HASHABLE_VER_REGEXP}
@@ -518,6 +521,7 @@ do_pkg   "base64-bytestring" ${BASE64_BYTESTRING_VER} \
     ${BASE64_BYTESTRING_VER_REGEXP}
 do_pkg   "cryptohash-sha256" ${CRYPTOHASH_SHA256_VER} \
     ${CRYPTOHASH_SHA256_VER_REGEXP}
+do_pkg "edit-distance" ${EDIT_DISTANCE_VER} ${EDIT_DISTANCE_VER_REGEXP}
 do_pkg   "ed25519"           ${ED25519_VER}          ${ED25519_VER_REGEXP}
 
 # We conditionally install bytestring-builder, depending on the bytestring

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -410,6 +410,7 @@ executable cabal
         containers >= 0.4      && < 0.6,
         cryptohash-sha256 >= 0.11 && < 0.12,
         deepseq    >= 1.3      && < 1.5,
+        edit-distance >= 0.2.2 && < 0.2.3,
         filepath   >= 1.3      && < 1.5,
         hashable   >= 1.0      && < 2,
         HTTP       >= 4000.1.5 && < 4000.4,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -410,7 +410,7 @@ executable cabal
         containers >= 0.4      && < 0.6,
         cryptohash-sha256 >= 0.11 && < 0.12,
         deepseq    >= 1.3      && < 1.5,
-        edit-distance >= 0.2.2 && < 0.2.3,
+        edit-distance >= 0.2.2 && < 0.3,
         filepath   >= 1.3      && < 1.5,
         hashable   >= 1.0      && < 2,
         HTTP       >= 4000.1.5 && < 4000.4,


### PR DESCRIPTION
This implements the changes identified in PR #3969.

@ezyang @23Skidoo @dcoutts 

I even tested it:
```sh
cabal new-build thing
cabal: Unknown build target 'thing'.
There is no component 'thing'.
Perhaps you meant the component 'thing1' or 'thing2' or 'thing3'?
The project has no package 'thing'.
```