### PR TITLE
Refine the fix for requiring Cabal > 1.20 for Setup.hs

### DIFF
--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -56,6 +56,7 @@ module Distribution.Client.Dependency (
     removeLowerBounds,
     removeUpperBounds,
     addDefaultSetupDependencies,
+    addSetupCabalMinVersionConstraint,
   ) where
 
 import Distribution.Solver.Modular
@@ -84,9 +85,9 @@ import Distribution.PackageDescription.Configuration
 import Distribution.Client.PackageUtils
          ( externalBuildDepends )
 import Distribution.Version
-         ( mkVersion, VersionRange, anyVersion, thisVersion, orLaterVersion
-         , withinRange, simplifyVersionRange
-         , removeLowerBound, removeUpperBound )
+         ( Version, mkVersion
+         , VersionRange, anyVersion, thisVersion, orLaterVersion, withinRange
+         , simplifyVersionRange, removeLowerBound, removeUpperBound )
 import Distribution.Compiler
          ( CompilerInfo(..) )
 import Distribution.System
@@ -465,6 +466,22 @@ addDefaultSetupDependencies defaultSetupDeps params =
       where
         gpkgdesc = packageDescription srcpkg
         pkgdesc  = PD.packageDescription gpkgdesc
+
+-- | There If a package has a custom setup then we need to add a setup-depends
+-- on Cabal. For now it's easier to add this unconditionally.  Once
+-- qualified constraints land we can turn this into a custom setup
+-- only constraint.
+--
+addSetupCabalMinVersionConstraint :: Version
+                                  -> DepResolverParams -> DepResolverParams
+addSetupCabalMinVersionConstraint minVersion =
+    addConstraints
+      [ LabeledPackageConstraint
+          (PackageConstraintVersion cabalPkgname (orLaterVersion minVersion))
+          ConstraintSetupCabalMinVersion
+      ]
+  where
+    cabalPkgname = mkPackageName "Cabal"
 
 
 upgradeDependencies :: DepResolverParams -> DepResolverParams

--- a/cabal-install/Distribution/Solver/Modular/Package.hs
+++ b/cabal-install/Distribution/Solver/Modular/Package.hs
@@ -12,6 +12,7 @@ module Distribution.Solver.Modular.Package
   , instI
   , makeIndependent
   , primaryPP
+  , setupPP
   , showI
   , showPI
   , unPN
@@ -91,6 +92,14 @@ primaryPP (PackagePath _ns q) = go q
     go (Base  _)   = True
     go (Setup _)   = False
     go (Exe _ _)   = False
+
+-- | Is the package a dependency of a setup script. This is used establish
+-- whether or not certain constraints should apply to this dependency
+-- (grep 'setupPP' to see the use sites).
+--
+setupPP :: PackagePath -> Bool
+setupPP (PackagePath _ns (Setup _)) = True
+setupPP (PackagePath _ns _)         = False
 
 -- | Create artificial parents for each of the package names, making
 -- them all independent.

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -156,6 +156,9 @@ processPackageConstraintP pp _ _ (LabeledPackageConstraint _ src) r
   | src == ConstraintSourceUserTarget && not (primaryPP pp)         = r
     -- the constraints arising from targets, like "foo-1.0" only apply to
     -- the main packages in the solution, they don't constrain setup deps
+  | src == ConstraintSetupCabalMinVersion && not (setupPP pp)       = r
+    -- the internal constraints on the Setup.hs CLI version don't apply to
+    -- the main packages in the solution, they only constrain setup deps
 
 processPackageConstraintP _ c i (LabeledPackageConstraint pc src) r = go i pc
   where

--- a/cabal-install/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install/Distribution/Solver/Types/ConstraintSource.hs
@@ -46,8 +46,9 @@ data ConstraintSource =
   -- | The source of the constraint is not specified.
   | ConstraintSourceUnknown
 
-  -- | Custom setup requires a minimum lower bound on Cabal
-  | ConstraintNewBuildCustomSetupLowerBoundCabal
+  -- | An internal constraint due to compatability issues with the Setup.hs
+  -- command line interface requires a minimum lower bound on Cabal
+  | ConstraintSetupCabalMinVersion
   deriving (Eq, Show, Generic)
 
 instance Binary ConstraintSource
@@ -71,4 +72,5 @@ showConstraintSource ConstraintSourceFreeze = "cabal freeze"
 showConstraintSource ConstraintSourceConfigFlagOrTarget =
     "config file, command line flag, or user target"
 showConstraintSource ConstraintSourceUnknown = "unknown source"
-showConstraintSource ConstraintNewBuildCustomSetupLowerBoundCabal = "new-build's support of Custom Setup (issue #3932)"
+showConstraintSource ConstraintSetupCabalMinVersion =
+    "minimum version of Cabal used by Setup.hs"

--- a/cabal-testsuite/PackageTests/Regression/T3932/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T3932/cabal.test.hs
@@ -7,4 +7,4 @@ main = cabalTest $
     -- won't be reported.
     withRepo "repo" $ do
         fails (cabal' "new-build" []) >>=
-            assertOutputContains "(issue #3932) requires >=1.20"
+            assertOutputContains "Setup.hs requires >=1.20"


### PR DESCRIPTION
Going along with the existing approach of using a constraint rather than altering the deps of custom Setup.hs scripts, but make the constraint only apply to Cabal instances that are dependencies of Setup.hs scripts not all instances of Cabal.

Also rearrange things a little with a dedicated solver policy function for adding a min dep on Cabal versions for setup scripts.

This is a follow-up to #4051. @ezyang @dagit 

@kosmikus @grayjay could you have a look at my use of `setupPP` and let us know if this will make sure the constraint applies to all setup deps. I'm not quite sure about the linking and whether this will catch all cases of Cabal instances occurring as deps of Setup scripts.
