### PR TITLE
Add sandbox lib dir to environment during cabal exec

### DIFF
--- a/cabal-install/Distribution/Client/Exec.hs
+++ b/cabal-install/Distribution/Client/Exec.hs
@@ -95,8 +95,9 @@ sandboxEnvironment verbosity sandboxDir comp platform programDb =
         unless exists $ warn verbosity $ "Package database is not a directory: "
                                            ++ sandboxPackagePath
         let ldPath = case os of
-                       OSX -> "DYLD_LIBRARY_PATH"
-                       _   -> "LD_LIBRARY_PATH"
+                       OSX     -> "DYLD_LIBRARY_PATH"
+                       Windows -> "PATH"
+                       _       -> "LD_LIBRARY_PATH"
         currentLibraryPath <- lookupEnv ldPath
         let newLibraryPath = case currentLibraryPath of
                                Nothing -> sandboxDir </> "lib"

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -47,7 +47,6 @@ import System.Exit
          ( ExitCode(..) )
 import Distribution.Compat.Exception
          ( catchIO, catchExit )
-import Control.Exception ( assert )
 import Control.Monad
          ( forM_, mapM )
 import System.Directory
@@ -1427,9 +1426,7 @@ installUnpackedPackage verbosity installLock numJobs
             ipkgs <- genPkgConfs mLogPath
             let ipkgs' = case ipkgs of
                             [ipkg] -> [ipkg { Installed.installedUnitId = uid }]
-                            _ -> assert (any ((== uid)
-                                              . Installed.installedUnitId)
-                                             ipkgs) ipkgs
+                            _ -> ipkgs
             let packageDBs = interpretPackageDbFlags
                                 (fromFlag (configUserInstall configFlags))
                                 (configPackageDBs configFlags)

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -80,6 +80,12 @@ Extra-Source-Files:
   tests/IntegrationTests/custom/segfault/plain.cabal
   tests/IntegrationTests/exec/Foo.hs
   tests/IntegrationTests/exec/My.hs
+  tests/IntegrationTests/exec/T4049.sh
+  tests/IntegrationTests/exec/T4049/UseLib.c
+  tests/IntegrationTests/exec/T4049/csrc/MyForeignLibWrapper.c
+  tests/IntegrationTests/exec/T4049/my-foreign-lib.cabal
+  tests/IntegrationTests/exec/T4049/src/MyForeignLib/Hello.hs
+  tests/IntegrationTests/exec/T4049/src/MyForeignLib/SomeBindings.hsc
   tests/IntegrationTests/exec/adds_sandbox_bin_directory_to_path.out
   tests/IntegrationTests/exec/adds_sandbox_bin_directory_to_path.sh
   tests/IntegrationTests/exec/auto_configures_on_exec.out

--- a/cabal-install/tests/IntegrationTests.hs
+++ b/cabal-install/tests/IntegrationTests.hs
@@ -12,9 +12,9 @@ import Distribution.Compat.CreatePipe (createPipe)
 import Distribution.Compat.Environment (setEnv, getEnvironment)
 import Distribution.Compat.Internal.TempFile (createTempDirectory)
 import Distribution.Simple.Configure (findDistPrefOrDefault)
-import Distribution.Simple.Program.Builtin (ghcPkgProgram)
+import Distribution.Simple.Program.Builtin (ghcPkgProgram, gccProgram, ghcProgram)
 import Distribution.Simple.Program.Db
-        (defaultProgramDb, requireProgram, setProgramSearchPath)
+        (defaultProgramDb, requireProgram, setProgramSearchPath, lookupProgramVersion)
 import Distribution.Simple.Program.Find
         (ProgramSearchPathEntry(ProgramSearchPathDir), defaultProgramSearchPath)
 import Distribution.Simple.Program.Types
@@ -22,6 +22,7 @@ import Distribution.Simple.Program.Types
 import Distribution.Simple.Setup ( Flag(..) )
 import Distribution.Simple.Utils ( findProgramVersion, copyDirectoryRecursive, installOrdinaryFile )
 import Distribution.Verbosity (normal)
+import Distribution.Version (anyVersion)
 
 -- Third party modules.
 import Control.Concurrent.Async (withAsync, wait)
@@ -294,6 +295,15 @@ main = do
   setEnv "CABAL_ARGS_NO_CONFIG_FILE" " "
   -- Don't get Unicode output from GHC
   setEnv "LC_ALL" "C"
+  -- Try to find something that can compile C programs
+  findGcc <- lookupProgramVersion normal gccProgram anyVersion defaultProgramDb
+  case findGcc of
+    Left _ -> do
+      -- set CC to GHC blabla
+      (ghc, _) <- requireProgram normal ghcProgram defaultProgramDb
+      setEnv "CCOMP" $ programPath ghc ++ " -no-hs-main"
+    Right (gcc, _, _) -> do
+      setEnv "CCOMP" (programPath gcc)
   -- Discover all the test categories
   categories <- discoverTestCategories baseDirectory
   -- Discover tests in each category

--- a/cabal-install/tests/IntegrationTests/exec/T4049.sh
+++ b/cabal-install/tests/IntegrationTests/exec/T4049.sh
@@ -1,0 +1,9 @@
+. ./common.sh
+
+require_ghc_ge 708
+
+cd T4049
+cabal sandbox init > /dev/null
+cabal install --enable-shared > /dev/null
+sh -c "$CCOMP UseLib.c -o UseLib -l myforeignlib -L \"$PWD/.cabal-sandbox/lib\" > /dev/null"
+cabal exec "$PWD/UseLib"

--- a/cabal-install/tests/IntegrationTests/exec/T4049/UseLib.c
+++ b/cabal-install/tests/IntegrationTests/exec/T4049/UseLib.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int main()
+{
+  myForeignLibInit();
+  sayHi();
+  myForeignLibExit();
+  return 0;
+}

--- a/cabal-install/tests/IntegrationTests/exec/T4049/csrc/MyForeignLibWrapper.c
+++ b/cabal-install/tests/IntegrationTests/exec/T4049/csrc/MyForeignLibWrapper.c
@@ -1,0 +1,23 @@
+#include <stdlib.h>
+#include "HsFFI.h"
+
+HsBool myForeignLibInit(void){
+  int argc = 2;
+  char *argv[] = { "+RTS", "-A32m", NULL };
+  char **pargv = argv;
+
+  // Initialize Haskell runtime
+  hs_init(&argc, &pargv);
+
+  // do any other initialization here and
+  // return false if there was a problem
+  return HS_BOOL_TRUE;
+}
+
+void myForeignLibExit(void){
+  hs_exit();
+}
+
+int cFoo2() {
+   return 1234;
+}

--- a/cabal-install/tests/IntegrationTests/exec/T4049/my-foreign-lib.cabal
+++ b/cabal-install/tests/IntegrationTests/exec/T4049/my-foreign-lib.cabal
@@ -1,0 +1,19 @@
+name:                my-foreign-lib
+version:             0.1.0.0
+author:              Edsko de Vries
+maintainer:          edsko@well-typed.com
+build-type:          Simple
+cabal-version:       >=1.10
+
+foreign-library myforeignlib
+  type:                native-shared
+
+  if os(windows)
+    options: standalone
+
+  other-modules:       MyForeignLib.Hello
+                       MyForeignLib.SomeBindings
+  build-depends:       base
+  hs-source-dirs:      src
+  c-sources:           csrc/MyForeignLibWrapper.c
+  default-language:    Haskell2010

--- a/cabal-install/tests/IntegrationTests/exec/T4049/src/MyForeignLib/Hello.hs
+++ b/cabal-install/tests/IntegrationTests/exec/T4049/src/MyForeignLib/Hello.hs
@@ -1,0 +1,10 @@
+-- | Module with single foreign export
+module MyForeignLib.Hello (sayHi) where
+
+import MyForeignLib.SomeBindings
+
+foreign export ccall sayHi :: IO ()
+
+-- | Say hi!
+sayHi :: IO ()
+sayHi = putStrLn $ "Hi from a foreign library! Foo has value " ++ show valueOfFoo

--- a/cabal-install/tests/IntegrationTests/exec/T4049/src/MyForeignLib/SomeBindings.hsc
+++ b/cabal-install/tests/IntegrationTests/exec/T4049/src/MyForeignLib/SomeBindings.hsc
@@ -1,0 +1,10 @@
+-- | Module that needs the hsc2hs preprocessor
+module MyForeignLib.SomeBindings where
+
+#define FOO 1
+
+#ifdef FOO
+-- | Value guarded by a CPP flag
+valueOfFoo :: Int
+valueOfFoo = 5678
+#endif


### PR DESCRIPTION
See #4049

Adding the sandbox lib dir means that foreign libraries are found by random executables after installing those foreign libraries, even if they are installed to the sandbox. Without this, LD_LIBRARY_PATH needs to be set manually if using sandboxes.
