### PR TITLE
Add test for foreign libs to depend on Haskell libs

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -1806,8 +1806,8 @@ checkForeignLibSupported comp platform flib = go (compilerFlavor comp)
   where
     go :: CompilerFlavor -> Maybe String
     go GHC
-      | compilerVersion comp < mkVersion [7,4] = unsupported [
-        "Building foreign libraires is only supported with GHC >= 7.4"
+      | compilerVersion comp < mkVersion [7,8] = unsupported [
+        "Building foreign libraires is only supported with GHC >= 7.8"
       ]
       | otherwise = goGhcPlatform platform
     go _   = unsupported [
@@ -1826,10 +1826,6 @@ checkForeignLibSupported comp platform flib = go (compilerFlavor comp)
       ]
 
     goGhcOsx :: ForeignLibType -> Maybe String
-    goGhcOsx _ | compilerVersion comp < mkVersion [7,8] = unsupported [
-        "Building foreign libraries on OSX is only supported with GHC >= 7.8"
-      ]
-
     goGhcOsx ForeignLibNativeShared
       | standalone = unsupported [
             "We cannot build standalone libraries on OSX"

--- a/cabal-testsuite/PackageTests/ForeignLibs/Check.hs
+++ b/cabal-testsuite/PackageTests/ForeignLibs/Check.hs
@@ -41,10 +41,11 @@ suite = whenGhcVersion (>= mkVersion [7,4]) . withPackageDb $ do
                    Platform _ _other  -> "LD_LIBRARY_PATH"
     oldLdPath <- liftIO $ getEnv' ldPath
     withEnv [ (ldPath, Just $ flibdir installDirs ++ [searchPathSeparator] ++ oldLdPath) ] $ do
-        run (Just pkg_dir)
-            (pkg_dir </> "uselib")
-            []
-            >>= assertOutputContains "5678"
+        result <- run (Just pkg_dir)
+                      (pkg_dir </> "uselib")
+                      []
+        assertOutputContains "5678" result
+        assertOutputContains "189" result
 
 getEnv' :: String -> IO String
 getEnv' = handle handler . getEnv

--- a/cabal-testsuite/PackageTests/ForeignLibs/my-foreign-lib.cabal
+++ b/cabal-testsuite/PackageTests/ForeignLibs/my-foreign-lib.cabal
@@ -6,6 +6,12 @@ maintainer:          edsko@well-typed.com
 build-type:          Simple
 cabal-version:       >=1.10
 
+library
+  exposed-modules:     MyForeignLib.AnotherVal
+  build-depends:       base
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+
 foreign-library myforeignlib
   type:                native-shared
 
@@ -14,7 +20,7 @@ foreign-library myforeignlib
 
   other-modules:       MyForeignLib.Hello
                        MyForeignLib.SomeBindings
-  build-depends:       base
+  build-depends:       base, my-foreign-lib
   hs-source-dirs:      src
   c-sources:           csrc/MyForeignLibWrapper.c
   default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/ForeignLibs/src/MyForeignLib/AnotherVal.hs
+++ b/cabal-testsuite/PackageTests/ForeignLibs/src/MyForeignLib/AnotherVal.hs
@@ -1,0 +1,3 @@
+module MyForeignLib.AnotherVal where
+
+anotherVal = 189

--- a/cabal-testsuite/PackageTests/ForeignLibs/src/MyForeignLib/Hello.hs
+++ b/cabal-testsuite/PackageTests/ForeignLibs/src/MyForeignLib/Hello.hs
@@ -2,9 +2,12 @@
 module MyForeignLib.Hello (sayHi) where
 
 import MyForeignLib.SomeBindings
+import MyForeignLib.AnotherVal
 
 foreign export ccall sayHi :: IO ()
 
 -- | Say hi!
 sayHi :: IO ()
-sayHi = putStrLn $ "Hi from a foreign library! Foo has value " ++ show valueOfFoo
+sayHi = putStrLn $
+     "Hi from a foreign library! Foo has value " ++ show valueOfFoo
+  ++ " and anotherVal has value " ++ show anotherVal

--- a/cabal-testsuite/PackageTests/Tests.hs
+++ b/cabal-testsuite/PackageTests/Tests.hs
@@ -58,7 +58,8 @@ tests config = do
   tc "AutogenModules/SrcDist" PackageTests.AutogenModules.SrcDist.Check.suite
 
   -- Test that foreign libraries work
-  tc "ForeignLibs" PackageTests.ForeignLibs.Check.suite
+  tc "ForeignLibs" . whenGhcVersion (>= mkVersion [7,8]) $
+    PackageTests.ForeignLibs.Check.suite
 
   ---------------------------------------------------------------------
   -- * Test suite tests

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -182,6 +182,7 @@ extra-source-files:
   PackageTests/ForeignLibs/UseLib.c
   PackageTests/ForeignLibs/csrc/MyForeignLibWrapper.c
   PackageTests/ForeignLibs/my-foreign-lib.cabal
+  PackageTests/ForeignLibs/src/MyForeignLib/AnotherVal.hs
   PackageTests/ForeignLibs/src/MyForeignLib/Hello.hs
   PackageTests/ForeignLibs/src/MyForeignLib/SomeBindings.hsc
   PackageTests/GhcPkgGuess/SameDirectory/SameDirectory.cabal


### PR DESCRIPTION
This is supposed to test if a foreign library can depend on Haskell code in the same project but in a different binary object.
