### PR TITLE
Make more dependency types

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -143,6 +143,7 @@ library
     Distribution.Make
     Distribution.ModuleName
     Distribution.Package
+    Distribution.Package.TextClass
     Distribution.PackageDescription
     Distribution.PackageDescription.Check
     Distribution.PackageDescription.Configuration

--- a/Cabal/Distribution/Backpack/ComponentsGraph.hs
+++ b/Cabal/Distribution/Backpack/ComponentsGraph.hs
@@ -52,8 +52,8 @@ toComponentsGraph enabled pkg_descr =
     -- The dependencies for the given component
     componentDeps component =
          [ CExeName toolname
-         | Dependency pkgname _ <- buildTools bi
-         , let toolname = packageNameToUnqualComponentName pkgname
+         | LegacyExeDependency name _ <- buildTools bi
+         , let toolname = mkUnqualComponentName name
          , toolname `elem` map exeName (executables pkg_descr) ]
 
       ++ [ if pkgname == packageName pkg_descr

--- a/Cabal/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/Distribution/Backpack/ConfiguredComponent.hs
@@ -140,9 +140,8 @@ toConfiguredComponent pkg_descr this_cid
         | otherwise
         = Map.toList external_lib_map
     exe_deps = [ cid
-               | Dependency pkgname _ <- buildTools bi
-               , let name = packageNameToUnqualComponentName pkgname
-               , Just cid <- [ Map.lookup name exe_map ] ]
+               | LegacyExeDependency name _ <- buildTools bi
+               , Just cid <- [ Map.lookup (mkUnqualComponentName name) exe_map ] ]
 
 -- | Also computes the 'ComponentId', and sets cc_public if necessary.
 -- This is Cabal-only; cabal-install won't use this.

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -49,6 +49,7 @@ import Distribution.Compat.Prelude
 import Distribution.ParseUtils
 import Distribution.License
 import Distribution.Package hiding (installedUnitId, installedPackageId)
+import Distribution.Package.TextClass ()
 import Distribution.Backpack
 import qualified Distribution.Package as Package
 import Distribution.ModuleName

--- a/Cabal/Distribution/Package/TextClass.hs
+++ b/Cabal/Distribution/Package/TextClass.hs
@@ -1,0 +1,56 @@
+-- | *Dependency Text instances moved from Distribution.Package
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Distribution.Package.TextClass () where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+import Distribution.Package
+import Distribution.ParseUtils
+import Distribution.Version (anyVersion)
+
+import qualified Distribution.Compat.ReadP as Parse
+import qualified Text.PrettyPrint as Disp
+import Distribution.Compat.ReadP
+import Distribution.Text
+
+import Text.PrettyPrint ((<+>))
+
+
+instance Text Dependency where
+  disp (Dependency name ver) =
+    disp name <+> disp ver
+
+  parse = do name <- parse
+             Parse.skipSpaces
+             ver <- parse <++ return anyVersion
+             Parse.skipSpaces
+             return (Dependency name ver)
+
+instance Text LegacyExeDependency where
+  disp (LegacyExeDependency name ver) =
+    Disp.text name <+> disp ver
+
+  parse = do name <- parseMaybeQuoted parseBuildToolName
+             Parse.skipSpaces
+             ver <- parse <++ return anyVersion
+             Parse.skipSpaces
+             return $ LegacyExeDependency name ver
+    where
+      -- like parsePackageName but accepts symbols in components
+      parseBuildToolName :: Parse.ReadP r String
+      parseBuildToolName = do ns <- sepBy1 component (Parse.char '-')
+                              return (intercalate "-" ns)
+        where component = do
+                cs <- munch1 (\c -> isAlphaNum c || c == '+' || c == '_')
+                if all isDigit cs then pfail else return cs
+
+instance Text PkgconfigDependency where
+  disp (PkgconfigDependency name ver) =
+    disp name <+> disp ver
+
+  parse = do name <- parse
+             Parse.skipSpaces
+             ver <- parse <++ return anyVersion
+             Parse.skipSpaces
+             return $ PkgconfigDependency name ver

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -55,6 +55,7 @@ import Distribution.ParseUtils hiding (parseFields)
 import Distribution.PackageDescription
 import Distribution.PackageDescription.Utils
 import Distribution.Package
+import Distribution.Package.TextClass ()
 import Distribution.ModuleName
 import Distribution.Version
 import Distribution.Verbosity
@@ -407,7 +408,7 @@ binfoFieldDescrs =
  [ boolField "buildable"
            buildable          (\val binfo -> binfo{buildable=val})
  , commaListField  "build-tools"
-           disp               parseBuildTool
+           disp               parse
            buildTools         (\xs  binfo -> binfo{buildTools=xs})
  , commaListFieldWithSep vcat "build-depends"
            disp                   parse
@@ -425,7 +426,7 @@ binfoFieldDescrs =
            showToken          parseTokenQ'
            ldOptions          (\val binfo -> binfo{ldOptions=val})
  , commaListField  "pkgconfig-depends"
-           disp               parsePkgconfigDependency
+           disp               parse
            pkgconfigDepends   (\xs  binfo -> binfo{pkgconfigDepends=xs})
  , listField "frameworks"
            showToken          parseTokenQ

--- a/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
@@ -41,6 +41,7 @@ import qualified Distribution.Compat.Parsec            as Parsec
 import           Distribution.Compiler                 (CompilerFlavor (..))
 import           Distribution.ModuleName               (ModuleName)
 import           Distribution.Package
+import           Distribution.Package.TextClass        ()
 import           Distribution.PackageDescription
 import           Distribution.Types.ForeignLib
 import           Distribution.Parsec.Class
@@ -415,7 +416,7 @@ binfoFieldDescrs =
  [ boolField "buildable"
            buildable          (\val binfo -> binfo{buildable=val})
  , commaListField  "build-tools"
-           disp               parsecBuildTool
+           disp               parsec
            buildTools         (\xs  binfo -> binfo{buildTools=xs})
  , commaListFieldWithSep vcat "build-depends"
        disp               parsec
@@ -433,7 +434,7 @@ binfoFieldDescrs =
            showToken          parsecToken'
            ldOptions          (\val binfo -> binfo{ldOptions=val})
  , commaListField  "pkgconfig-depends"
-           disp               parsecPkgconfigDependency
+           disp               parsec
            pkgconfigDepends   (\xs  binfo -> binfo{pkgconfigDepends=xs})
  , listField "frameworks"
            showToken          parsecToken

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -28,14 +28,14 @@ module Distribution.ParseUtils (
         showFields, showSingleNamedField, showSimpleSingleNamedField,
         parseFields, parseFieldsFlat,
         parseFilePathQ, parseTokenQ, parseTokenQ',
-        parseModuleNameQ, parseBuildTool, parsePkgconfigDependency,
+        parseModuleNameQ,
         parseOptVersion, parsePackageNameQ,
         parseTestedWithQ, parseLicenseQ, parseLanguageQ, parseExtensionQ,
         parseSepList, parseCommaList, parseOptCommaList,
         showFilePath, showToken, showTestedWith, showFreeText, parseFreeText,
         field, simpleField, listField, listFieldWithSep, spaceListField,
         commaListField, commaListFieldWithSep, commaNewLineListField,
-        optsField, liftField, boolField, parseQuoted, indentWith,
+        optsField, liftField, boolField, parseQuoted, parseMaybeQuoted, indentWith,
 
         UnrecFieldParser, warnUnrec, ignoreUnrec,
   ) where
@@ -624,33 +624,6 @@ betweenSpaces act = do skipSpaces
                        res <- act
                        skipSpaces
                        return res
-
-parseBuildTool :: ReadP r Dependency
-parseBuildTool = do name <- parseBuildToolNameQ
-                    ver <- betweenSpaces $
-                           parse <++ return anyVersion
-                    return $ Dependency name ver
-
-parseBuildToolNameQ :: ReadP r PackageName
-parseBuildToolNameQ = parseMaybeQuoted parseBuildToolName
-
--- like parsePackageName but accepts symbols in components
-parseBuildToolName :: ReadP r PackageName
-parseBuildToolName = do ns <- sepBy1 component (ReadP.char '-')
-                        return (mkPackageName (intercalate "-" ns))
-  where component = do
-          cs <- munch1 (\c -> isAlphaNum c || c == '+' || c == '_')
-          if all isDigit cs then pfail else return cs
-
--- pkg-config allows versions and other letters in package names,
--- eg "gtk+-2.0" is a valid pkg-config package _name_.
--- It then has a package version number like 2.10.13
-parsePkgconfigDependency :: ReadP r Dependency
-parsePkgconfigDependency = do name <- munch1
-                                      (\c -> isAlphaNum c || c `elem` "+-._")
-                              ver <- betweenSpaces $
-                                     parse <++ return anyVersion
-                              return $ Dependency (mkPackageName name) ver
 
 parsePackageNameQ :: ReadP r PackageName
 parsePackageNameQ = parseMaybeQuoted parse

--- a/Cabal/Distribution/Parsec/Class.hs
+++ b/Cabal/Distribution/Parsec/Class.hs
@@ -357,7 +357,7 @@ parsecBuildTool :: P.Stream s Identity Char => P.Parsec s [PWarning] Dependency
 parsecBuildTool = do
     name <- parsecMaybeQuoted nameP
     P.spaces
-    verRange <- parsec <|> pure anyVersion
+    verRange <- parsecMaybeQuoted parsec <|> pure anyVersion
     pure $ Dependency (mkPackageName name) verRange
   where
     nameP = intercalate "-" <$> P.sepBy1 component (P.char '-')

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -538,7 +538,7 @@ addInternalBuildTools pkg lbi bi progs =
     internalExeNames = map (unUnqualComponentName . exeName) (executables pkg)
     buildToolNames   = map buildToolName (buildTools bi)
       where
-        buildToolName (Dependency pname _ ) = unPackageName pname
+        buildToolName (LegacyExeDependency pname _) = pname
 
 
 -- TODO: build separate libs in separate dirs so that we can build

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -85,6 +85,7 @@ import qualified Distribution.Compat.ReadP as Parse
 import qualified Text.PrettyPrint as Disp
 import Distribution.ModuleName
 import Distribution.Package
+import Distribution.Package.TextClass ()
 import Distribution.PackageDescription hiding (Flag)
 import Distribution.Simple.Command hiding (boolOpt, boolOpt')
 import qualified Distribution.Simple.Command as Command

--- a/Cabal/Distribution/Types/BuildInfo.hs
+++ b/Cabal/Distribution/Types/BuildInfo.hs
@@ -27,11 +27,11 @@ import Language.Haskell.Extension
 -- Consider refactoring into executable and library versions.
 data BuildInfo = BuildInfo {
         buildable         :: Bool,      -- ^ component is buildable here
-        buildTools        :: [Dependency], -- ^ tools needed to build this bit
+        buildTools        :: [LegacyExeDependency], -- ^ tools needed to build this bit
         cppOptions        :: [String],  -- ^ options for pre-processing Haskell code
         ccOptions         :: [String],  -- ^ options for C compiler
         ldOptions         :: [String],  -- ^ options for linker
-        pkgconfigDepends  :: [Dependency], -- ^ pkg-config packages that are used
+        pkgconfigDepends  :: [PkgconfigDependency], -- ^ pkg-config packages that are used
         frameworks        :: [String], -- ^support frameworks for Mac OS X
         extraFrameworkDirs:: [String], -- ^ extra locations to find frameworks.
         cSources          :: [FilePath],

--- a/cabal-install/Distribution/Client/PackageHash.hs
+++ b/cabal-install/Distribution/Client/PackageHash.hs
@@ -29,7 +29,8 @@ module Distribution.Client.PackageHash (
   ) where
 
 import Distribution.Package
-         ( PackageId, PackageName, PackageIdentifier(..), mkComponentId )
+         ( PackageId, PackageIdentifier(..), mkComponentId
+         , PkgconfigName )
 import Distribution.System
          ( Platform, OS(Windows), buildOS )
 import Distribution.PackageDescription
@@ -139,7 +140,7 @@ data PackageHashInputs = PackageHashInputs {
        pkgHashPkgId         :: PackageId,
        pkgHashComponent     :: Maybe CD.Component,
        pkgHashSourceHash    :: PackageSourceHash,
-       pkgHashPkgConfigDeps :: Set (PackageName, Maybe Version),
+       pkgHashPkgConfigDeps :: Set (PkgconfigName, Maybe Version),
        pkgHashDirectDeps    :: Set InstalledPackageId,
        pkgHashOtherConfig   :: PackageHashConfigInputs
      }

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1270,7 +1270,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                                             ++ display pn ++ " from "
                                             ++ display (elabPkgSourceId elab1))
                                  (pkgConfigDbPkgVersion pkgConfigDB pn))
-                | Dependency pn _ <- PD.pkgconfigDepends bi ]
+                | PkgconfigDependency pn _ <- PD.pkgconfigDepends bi ]
 
             compSetupDependencies = concatMap (elaborateLibSolverId mapDep) (CD.setupDeps deps0)
 
@@ -1429,8 +1429,8 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
             $ [ (pn, fromMaybe (error $ "pkgPkgConfigDependencies: impossible! "
                                           ++ display pn ++ " from " ++ display pkgid)
                                (pkgConfigDbPkgVersion pkgConfigDB pn))
-              | Dependency pn _ <- concatMap PD.pkgconfigDepends
-                                        (PD.allBuildInfo elabPkgDescription)
+              | PkgconfigDependency pn _ <- concatMap PD.pkgconfigDepends
+                                                (PD.allBuildInfo elabPkgDescription)
               ]
 
         -- Filled in later

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -371,7 +371,7 @@ elabSetupDependencies elab =
         ElabPackage pkg    -> CD.setupDeps (pkgLibDependencies pkg)
         ElabComponent comp -> compSetupDependencies comp
 
-elabPkgConfigDependencies :: ElaboratedConfiguredPackage -> [(PackageName, Maybe Version)]
+elabPkgConfigDependencies :: ElaboratedConfiguredPackage -> [(PkgconfigName, Maybe Version)]
 elabPkgConfigDependencies ElaboratedConfiguredPackage { elabPkgOrComp = ElabPackage pkg }
     = pkgPkgConfigDependencies pkg
 elabPkgConfigDependencies ElaboratedConfiguredPackage { elabPkgOrComp = ElabComponent comp }
@@ -404,7 +404,7 @@ data ElaboratedComponent
     -- internal executables).
     compExeDependencies :: [ComponentId],
     -- | The @pkg-config@ dependencies of the component
-    compPkgConfigDependencies :: [(PackageName, Maybe Version)],
+    compPkgConfigDependencies :: [(PkgconfigName, Maybe Version)],
     -- | The paths all our executable dependencies will be installed
     -- to once they are installed.
     compExeDependencyPaths :: [FilePath],
@@ -454,7 +454,7 @@ data ElaboratedPackage
        -- because Cabal library does not track per-component
        -- pkg-config depends; it always does them all at once.
        --
-       pkgPkgConfigDependencies :: [(PackageName, Maybe Version)],
+       pkgPkgConfigDependencies :: [(PkgconfigName, Maybe Version)],
 
        -- | Which optional stanzas (ie testsuites, benchmarks) will actually
        -- be enabled during the package configure step.

--- a/cabal-install/Distribution/Client/World.hs
+++ b/cabal-install/Distribution/Client/World.hs
@@ -31,6 +31,8 @@ module Distribution.Client.World (
 
 import Distribution.Package
          ( Dependency(..) )
+import Distribution.Package.TextClass
+         ()
 import Distribution.PackageDescription
          ( FlagAssignment, mkFlagName, unFlagName )
 import Distribution.Verbosity

--- a/cabal-install/Distribution/Solver/Modular/Assignment.hs
+++ b/cabal-install/Distribution/Solver/Modular/Assignment.hs
@@ -65,7 +65,7 @@ data PreAssignment = PA PPreAssignment FAssignment SAssignment
 -- or the successfully extended assignment.
 extend :: (Extension -> Bool) -- ^ is a given extension supported
        -> (Language  -> Bool) -- ^ is a given language supported
-       -> (PN -> VR  -> Bool) -- ^ is a given pkg-config requirement satisfiable
+       -> (PkgconfigName -> VR  -> Bool) -- ^ is a given pkg-config requirement satisfiable
        -> Var QPN
        -> PPreAssignment -> [Dep QPN] -> Either (ConflictSet QPN, [Dep QPN]) PPreAssignment
 extend extSupported langSupported pkgPresent var = foldM extendSingle

--- a/cabal-install/Distribution/Solver/Modular/Dependency.hs
+++ b/cabal-install/Distribution/Solver/Modular/Dependency.hs
@@ -175,10 +175,10 @@ type IsExe = Bool
 -- is used both to record the dependencies as well as who's doing the
 -- depending; having a 'Functor' instance makes bugs where we don't distinguish
 -- these two far too likely. (By rights 'Dep' ought to have two type variables.)
-data Dep qpn = Dep IsExe qpn (CI qpn)  -- dependency on a package (possibly for executable
-             | Ext  Extension     -- dependency on a language extension
-             | Lang Language      -- dependency on a language version
-             | Pkg  PN VR         -- dependency on a pkg-config package
+data Dep qpn = Dep IsExe qpn (CI qpn)  -- ^ dependency on a package (possibly for executable
+             | Ext  Extension          -- ^ dependency on a language extension
+             | Lang Language           -- ^ dependency on a language version
+             | Pkg  PkgconfigName VR   -- ^ dependency on a pkg-config package
   deriving (Eq, Show)
 
 showDep :: Dep QPN -> String

--- a/cabal-install/Distribution/Solver/Modular/Package.hs
+++ b/cabal-install/Distribution/Solver/Modular/Package.hs
@@ -5,6 +5,7 @@ module Distribution.Solver.Modular.Package
   , PackageId
   , PackageIdentifier(..)
   , PackageName, mkPackageName, unPackageName
+  , PkgconfigName, mkPkgconfigName, unPkgconfigName
   , PI(..)
   , PN
   , QPV

--- a/cabal-install/Distribution/Solver/Modular/Validate.hs
+++ b/cabal-install/Distribution/Solver/Modular/Validate.hs
@@ -88,7 +88,7 @@ import Distribution.Solver.Types.PkgConfigDb (PkgConfigDb, pkgConfigPkgIsPresent
 data ValidateState = VS {
   supportedExt  :: Extension -> Bool,
   supportedLang :: Language  -> Bool,
-  presentPkgs   :: PN -> VR  -> Bool,
+  presentPkgs   :: PkgconfigName -> VR  -> Bool,
   index :: Index,
   saved :: Map QPN (FlaggedDeps Component QPN), -- saved, scoped, dependencies
   pa    :: PreAssignment,

--- a/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
@@ -29,7 +29,7 @@ import Text.ParserCombinators.ReadP (readP_to_S)
 import System.FilePath (splitSearchPath)
 
 import Distribution.Package
-    ( PackageName, mkPackageName )
+    ( PkgconfigName, mkPkgconfigName )
 import Distribution.Verbosity
     ( Verbosity )
 import Distribution.Version
@@ -45,7 +45,7 @@ import Distribution.Simple.Utils
 -- | The list of packages installed in the system visible to
 -- @pkg-config@. This is an opaque datatype, to be constructed with
 -- `readPkgConfigDb` and queried with `pkgConfigPkgPresent`.
-data PkgConfigDb =  PkgConfigDb (M.Map PackageName (Maybe Version))
+data PkgConfigDb =  PkgConfigDb (M.Map PkgconfigName (Maybe Version))
                  -- ^ If an entry is `Nothing`, this means that the
                  -- package seems to be present, but we don't know the
                  -- exact version (because parsing of the version
@@ -83,8 +83,8 @@ readPkgConfigDb verbosity progdb = handle ioErrorHandler $ do
 pkgConfigDbFromList :: [(String, String)] -> PkgConfigDb
 pkgConfigDbFromList pairs = (PkgConfigDb . M.fromList . map convert) pairs
     where
-      convert :: (String, String) -> (PackageName, Maybe Version)
-      convert (n,vs) = (mkPackageName n,
+      convert :: (String, String) -> (PkgconfigName, Maybe Version)
+      convert (n,vs) = (mkPkgconfigName n,
                         case (reverse . readP_to_S parseVersion) vs of
                           (v, "") : _ -> Just (mkVersion' v)
                           _           -> Nothing -- Version not (fully)
@@ -93,7 +93,7 @@ pkgConfigDbFromList pairs = (PkgConfigDb . M.fromList . map convert) pairs
 
 -- | Check whether a given package range is satisfiable in the given
 -- @pkg-config@ database.
-pkgConfigPkgIsPresent :: PkgConfigDb -> PackageName -> VersionRange -> Bool
+pkgConfigPkgIsPresent :: PkgConfigDb -> PkgconfigName -> VersionRange -> Bool
 pkgConfigPkgIsPresent (PkgConfigDb db) pn vr =
     case M.lookup pn db of
       Nothing       -> False    -- Package not present in the DB.
@@ -110,7 +110,7 @@ pkgConfigPkgIsPresent NoPkgConfigDb _ _ = True
 -- @Nothing@ indicates the package is not in the database, while
 -- @Just Nothing@ indicates that the package is in the database,
 -- but its version is not known.
-pkgConfigDbPkgVersion :: PkgConfigDb -> PackageName -> Maybe (Maybe Version)
+pkgConfigDbPkgVersion :: PkgConfigDb -> PkgconfigName -> Maybe (Maybe Version)
 pkgConfigDbPkgVersion (PkgConfigDb db) pn = M.lookup pn db
 -- NB: Since the solver allows solving to succeed if there is
 -- NoPkgConfigDb, we should report that we *guess* that there


### PR DESCRIPTION
This is a follow-up to https://github.com/haskell/cabal/pull/4057, so until that is dealt with this diff will also be humongous and unreviewable.
 
This PR makes separate types for different types of dependencies:
 - `Dependency` is now just for regular (usually library) dependencies on haskell packages
 - `LegacyExeDependecy` for legacy `build-tools` dependencies 
 - `PkgconfigDependecy` for pkg-config dependencies

Additionally, there is a newtype `PkgconfigName` for pkg-config library names. For Cabal's uses alone this wouldn't be worth it, but cabal-install already distinguishes these libraries widely with `PackageName`. Continuing to use `PackageName` seemed inconsistent with the newly-rigorous use of `Dependecy`, while going back to `String` seemed like a step backwards.

Plain `String` is used for legacy built tool names, as those can mean quite different things, and very little code was using `PackageName` and not `String` for them.

Note I had to make some orphan instances (module-wise, not package-wise) in order to avoid a `Distribution.ParserUtils` <-> `Distribution.Package` cyclic dep. This can go away once the old parser is removed.
