### PR TITLE
new-configure: Select the same plan subset as new-build.

### DIFF
--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -90,4 +90,3 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
     runProjectPostBuildPhase verbosity buildCtx buildOutcomes
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
-

--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 -- | cabal-install CLI command: build
 --
 module Distribution.Client.CmdBuild (
@@ -72,7 +70,7 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
         PreBuildHooks {
           hookPrePlanning      = \_ _ _ -> return (),
 
-          hookSelectPlanSubset = \buildSettings elaboratedPlan -> do
+          hookSelectPlanSubset = \buildSettings' elaboratedPlan -> do
             -- Interpret the targets on the command line as build targets
             -- (as opposed to say repl or haddock targets).
             selectTargets
@@ -80,7 +78,7 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
               BuildDefaultComponents
               BuildSpecificComponent
               userTargets
-              (buildSettingOnlyDeps buildSettings)
+              (buildSettingOnlyDeps buildSettings')
               elaboratedPlan
         }
 

--- a/cabal-install/Distribution/Client/CmdConfigure.hs
+++ b/cabal-install/Distribution/Client/CmdConfigure.hs
@@ -21,7 +21,8 @@ import Distribution.Simple.Utils
          ( wrapText )
 import qualified Distribution.Client.Setup as Client
 
-configureCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags)
+configureCommand :: CommandUI (ConfigFlags, ConfigExFlags
+                              ,InstallFlags, HaddockFlags)
 configureCommand = Client.installCommand {
   commandName         = "new-configure",
   commandSynopsis     = "Write out a cabal.project.local file.",
@@ -29,7 +30,8 @@ configureCommand = Client.installCommand {
   commandDescription  = Just $ \_ -> wrapText $
         "Configures a Nix-local build project, downloading source from"
      ++ " the network and writing out a cabal.project.local file which"
-     ++ " saves any FLAGS, to be reapplied on subsequent invocations to new-build.",
+     ++ " saves any FLAGS, to be reapplied on subsequent invocations to "
+     ++ "new-build.",
   commandNotes        = Just $ \pname ->
         "Examples:\n"
      ++ "  " ++ pname ++ " new-configure           "
@@ -72,10 +74,11 @@ configureAction (configFlags, configExFlags, installFlags, haddockFlags)
                       }
                     }
 
-    --TODO: Hmm, but we don't have any targets. Currently this prints what we
-    -- would build if we were to build everything. Could pick implicit target like "."
-    --TODO: should we say what's in the project (+deps) as a whole?
+    -- TODO: Hmm, but we don't have any targets. Currently this prints
+    -- what we would build if we were to build everything. Could pick
+    -- implicit target like "."
+    --
+    -- TODO: should we say what's in the project (+deps) as a whole?
     printPlan verbosity buildCtx'
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
-

--- a/cabal-install/Distribution/Client/CmdConfigure.hs
+++ b/cabal-install/Distribution/Client/CmdConfigure.hs
@@ -7,6 +7,8 @@ module Distribution.Client.CmdConfigure (
 
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.ProjectConfig
+import Distribution.Client.ProjectPlanning
+         ( PackageTarget(..) )
 
 import Distribution.Client.Setup
          ( GlobalFlags, ConfigFlags(..), ConfigExFlags, InstallFlags )
@@ -65,7 +67,18 @@ configureAction (configFlags, configExFlags, installFlags, haddockFlags)
             -- planning phase.
             writeProjectLocalExtraConfig rootDir cliConfig,
 
-          hookSelectPlanSubset = \_ -> return
+          hookSelectPlanSubset = \buildSettings' elaboratedPlan -> do
+            -- Select the same subset of targets as 'CmdBuild' would
+            -- pick (ignoring, for example, executables in libraries
+            -- we depend on).
+            selectTargets
+              verbosity
+              BuildDefaultComponents
+              BuildSpecificComponent
+              []
+              (buildSettingOnlyDeps buildSettings')
+              elaboratedPlan
+
         }
 
     let buildCtx' = buildCtx {


### PR DESCRIPTION
So that exes and other unnecessary components in dependencies are ignored.

Before:

```
$ cabal new-configure
Resolving dependencies...
In order, the following would be built (use -v for more details):
 - Crypto-4.2.5.1 (exe:SymmetricTest) (requires build)
 - Crypto-4.2.5.1 (exe:WordListTest) (requires build)
 - Crypto-4.2.5.1 (exe:SHA1Test) (requires build)
 - Crypto-4.2.5.1 (exe:QuickTest) (requires build)
 - Crypto-4.2.5.1 (exe:RSATest) (requires build)
 - Crypto-4.2.5.1 (exe:HMACTest) (requires build)
 - HaXml-1.25.3 (exe:Xtract) (requires build)
 - HaXml-1.25.3 (exe:Validate) (requires build)
 - HaXml-1.25.3 (exe:MkOneOf) (requires build)
 - HaXml-1.25.3 (exe:CanonicaliseLazy) (requires build)
 - HaXml-1.25.3 (exe:Canonicalise) (requires build)
 - HaXml-1.25.3 (exe:XsdToHaskell) (requires build)
 - HaXml-1.25.3 (exe:DtdToHaskell) (requires build)
 - HaXml-1.25.3 (exe:FpMLToHaskell) (requires build)
 - aeson-pretty-0.8.1 (exe:aeson-pretty) (requires build)
 - cpphs-1.20.2 (exe:cpphs) (requires build)
 - hS3-0.5.9 (exe:hs3) (requires build)
 - yaml-0.8.18 (exe:json2yaml) (requires build)
 - yaml-0.8.18 (exe:yaml2json) (requires build)

$ cabal new-build
Resolving dependencies...
Up to date
```
After:

```
$ cabal new-configure
Resolving dependencies...
Up to date

$ cabal new-build
Resolving dependencies...
Up to date
```