### PR TITLE
Add fingerprint of Generic representation when serializing.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -235,6 +235,7 @@ library
     Distribution.Utils.NubList
     Distribution.Utils.ShortText
     Distribution.Utils.Progress
+    Distribution.Utils.BinaryWithFingerprint
     Distribution.Verbosity
     Distribution.Version
     Language.Haskell.Extension

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -----------------------------------------------------------------------------
@@ -119,7 +120,7 @@ data InstalledPackageInfo
         haddockHTMLs      :: [FilePath],
         pkgRoot           :: Maybe FilePath
     }
-    deriving (Eq, Generic, Read, Show)
+    deriving (Eq, Generic, Typeable, Read, Show)
 
 installedComponentId :: InstalledPackageInfo -> ComponentId
 installedComponentId ipi =

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -97,7 +98,7 @@ data Compiler = Compiler {
         compilerProperties      :: Map String String
         -- ^ A key-value map for properties not covered by the above fields.
     }
-    deriving (Eq, Generic, Show, Read)
+    deriving (Eq, Generic, Typeable, Show, Read)
 
 instance Binary Compiler
 

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -106,7 +106,7 @@ import qualified Distribution.Simple.HaskellSuite as HaskellSuite
 
 import Control.Exception
     ( ErrorCall, Exception, evaluate, throw, throwIO, try )
-import Distribution.Compat.Binary ( decodeOrFailIO, encode )
+import Distribution.Utils.BinaryWithFingerprint
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy.Char8 as BLC8
@@ -195,7 +195,7 @@ getConfigStateFile filename = do
               Right x -> x
 
     let getStoredValue = do
-          result <- decodeOrFailIO (BLC8.tail body)
+          result <- decodeWithFingerprintOrFailIO (BLC8.tail body)
           case result of
             Left _ -> throw ConfigStateFileNoParse
             Right x -> return x
@@ -240,7 +240,7 @@ writePersistBuildConfig :: FilePath -- ^ The @dist@ directory path.
 writePersistBuildConfig distPref lbi = do
     createDirectoryIfMissing False distPref
     writeFileAtomic (localBuildInfoFile distPref) $
-      BLC8.unlines [showHeader pkgId, encode lbi]
+      BLC8.unlines [showHeader pkgId, encodeWithFingerprint lbi]
   where
     pkgId = localPackage lbi
 

--- a/Cabal/Distribution/Simple/Program/Db.hs
+++ b/Cabal/Distribution/Simple/Program/Db.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -90,6 +91,7 @@ data ProgramDb = ProgramDb {
         progSearchPath    :: ProgramSearchPath,
         configuredProgs   :: ConfiguredProgs
     }
+  deriving (Typeable)
 
 type UnconfiguredProgram = (Program, Maybe FilePath, [ProgArg])
 type UnconfiguredProgs   = Map.Map String UnconfiguredProgram

--- a/Cabal/Distribution/Simple/Program/Types.hs
+++ b/Cabal/Distribution/Simple/Program/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -122,7 +123,7 @@ data ConfiguredProgram = ConfiguredProgram {
        --
        programMonitorFiles :: [FilePath]
      }
-  deriving (Eq, Generic, Read, Show)
+  deriving (Eq, Generic, Read, Show, Typeable)
 
 instance Binary ConfiguredProgram
 

--- a/Cabal/Distribution/Types/ComponentName.hs
+++ b/Cabal/Distribution/Types/ComponentName.hs
@@ -25,7 +25,7 @@ data ComponentName = CLibName
                    | CExeName   UnqualComponentName
                    | CTestName  UnqualComponentName
                    | CBenchName UnqualComponentName
-                   deriving (Eq, Generic, Ord, Read, Show)
+                   deriving (Eq, Generic, Ord, Read, Show, Typeable)
 
 instance Binary ComponentName
 

--- a/Cabal/Distribution/Utils/BinaryWithFingerprint.hs
+++ b/Cabal/Distribution/Utils/BinaryWithFingerprint.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
+-- | Support for binary serialization with a fingerprint.
+module Distribution.Utils.BinaryWithFingerprint (
+    encodeWithFingerprint,
+    decodeWithFingerprint,
+    decodeWithFingerprintOrFailIO,
+) where
+
+#if MIN_VERSION_base(4,8,0)
+
+import Distribution.Compat.Binary
+import Data.ByteString.Lazy (ByteString)
+import Control.Exception
+
+import Data.Binary.Get
+import Data.Binary.Put
+
+import GHC.Generics
+import GHC.Fingerprint
+import Data.Typeable
+import Control.Monad
+
+-- | Private wrapper type so we can give 'Binary' instance for
+-- 'Fingerprint'
+newtype FP = FP Fingerprint
+
+instance Binary FP where
+    put (FP (Fingerprint a b)) = put a >> put b
+    get = do
+        a <- get
+        b <- get
+        return (FP (Fingerprint a b))
+
+fingerprintRep :: forall a. Typeable (Rep a) => Proxy a -> Fingerprint
+fingerprintRep _ = typeRepFingerprint (typeRep (Proxy :: Proxy (Rep a)))
+
+-- | Encode a value, recording a fingerprint in the header.
+--
+-- The fingerprint is GHC's Typeable fingerprint associated with
+-- the Generic Rep of a type: this fingerprint is better than
+-- the fingerprint of the type itself, as it changes when the
+-- representation changes (and thus the binary serialization format
+-- changes.)
+--
+encodeWithFingerprint :: forall a. (Binary a, Typeable (Rep a)) => a -> ByteString
+encodeWithFingerprint x = runPut $ do
+    put (FP (fingerprintRep (Proxy :: Proxy a)))
+    put x
+
+-- | Decode a value, verifying the fingerprint in the header.
+--
+decodeWithFingerprint :: forall a. (Binary a, Typeable (Rep a)) => ByteString -> a
+decodeWithFingerprint = runGet $ do
+    FP fp <- get
+    let expect_fp = fingerprintRep (Proxy :: Proxy a)
+    when (expect_fp /= fp) $
+        fail $ "Expected fingerprint " ++ show expect_fp ++
+               " but got " ++ show fp
+    get
+
+-- | Decode a value, forcing the decoded value to discover decoding errors
+-- and report them.
+--
+decodeWithFingerprintOrFailIO :: (Binary a, Typeable (Rep a)) => ByteString -> IO (Either String a)
+decodeWithFingerprintOrFailIO bs =
+  catch (evaluate (decodeWithFingerprint bs) >>= return . Right)
+  $ \(ErrorCall str) -> return $ Left str
+
+#else
+
+import Distribution.Compat.Binary
+import Data.ByteString.Lazy (ByteString)
+
+-- Dummy implementations that don't actually save fingerprints
+
+encodeWithFingerprint :: Binary a => a -> ByteString
+encodeWithFingerprint = encode
+
+decodeWithFingerprint :: Binary a => ByteString -> a
+decodeWithFingerprint = decode
+
+decodeWithFingerprintOrFailIO :: Binary a => ByteString -> IO (Either String a)
+decodeWithFingerprintOrFailIO = decodeOrFailIO
+
+#endif

--- a/Cabal/Distribution/Utils/NubList.hs
+++ b/Cabal/Distribution/Utils/NubList.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 module Distribution.Utils.NubList
     ( NubList    -- opaque
     , toNubList  -- smart construtor
@@ -20,7 +21,7 @@ import qualified Text.Read as R
 -- | NubList : A de-duplicated list that maintains the original order.
 newtype NubList a =
     NubList { fromNubList :: [a] }
-    deriving Eq
+    deriving (Eq, Typeable)
 
 -- NubList assumes that nub retains the list order while removing duplicate
 -- elements (keeping the first occurence). Documentation for "Data.List.nub"

--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -45,7 +45,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Map        as Map
 #endif
 import qualified Data.ByteString.Lazy as BS
-import qualified Distribution.Compat.Binary as Binary
+import qualified Distribution.Utils.BinaryWithFingerprint as Binary
 import qualified Data.Hashable as Hashable
 
 import           Control.Monad
@@ -403,7 +403,7 @@ data MonitorChangedReason a =
 -- See 'FileMonitor' for a full explanation.
 --
 checkFileMonitorChanged
-  :: (Binary a, Binary b)
+  :: (Binary a, Binary b, Typeable a, Typeable b)
   => FileMonitor a b            -- ^ cache file path
   -> FilePath                   -- ^ root directory
   -> a                          -- ^ guard or key value
@@ -481,23 +481,23 @@ checkFileMonitorChanged
 --
 -- This determines the type and format of the binary cache file.
 --
-readCacheFile :: (Binary a, Binary b)
+readCacheFile :: (Binary a, Binary b, Typeable a, Typeable b)
               => FileMonitor a b
               -> IO (Either String (MonitorStateFileSet, a, b))
 readCacheFile FileMonitor {fileMonitorCacheFile} =
     withBinaryFile fileMonitorCacheFile ReadMode $ \hnd ->
-      Binary.decodeOrFailIO =<< BS.hGetContents hnd
+      Binary.decodeWithFingerprintOrFailIO =<< BS.hGetContents hnd
 
 -- | Helper for writing the cache file.
 --
 -- This determines the type and format of the binary cache file.
 --
-rewriteCacheFile :: (Binary a, Binary b)
+rewriteCacheFile :: (Binary a, Binary b, Typeable a, Typeable b)
                  => FileMonitor a b
                  -> MonitorStateFileSet -> a -> b -> IO ()
 rewriteCacheFile FileMonitor {fileMonitorCacheFile} fileset key result =
     writeFileAtomic fileMonitorCacheFile $
-      Binary.encode (fileset, key, result)
+      Binary.encodeWithFingerprint (fileset, key, result)
 
 -- | Probe the file system to see if any of the monitored files have changed.
 --
@@ -758,7 +758,7 @@ probeMonitorStateGlobRel _ _ _ _ MonitorStateGlobDirTrailing =
 -- any files then you can use @Nothing@ for the timestamp parameter.
 --
 updateFileMonitor
-  :: (Binary a, Binary b)
+  :: (Binary a, Binary b, Typeable a, Typeable b)
   => FileMonitor a b          -- ^ cache file path
   -> FilePath                 -- ^ root directory
   -> Maybe MonitorTimestamp   -- ^ timestamp when the update action started
@@ -965,7 +965,7 @@ getFileHash hashcache relfile absfile mtime =
 -- that the set of files to monitor can change then it's simpler just to throw
 -- away the structure and use a finite map.
 --
-readCacheFileHashes :: (Binary a, Binary b)
+readCacheFileHashes :: (Binary a, Binary b, Typeable a, Typeable b)
                     => FileMonitor a b -> IO FileHashCache
 readCacheFileHashes monitor =
     handleDoesNotExist Map.empty $

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -100,6 +101,7 @@ import qualified Distribution.Compat.Graph as Graph
 import Distribution.Compat.Graph (Graph, IsNode(..))
 import Distribution.Compat.Binary (Binary(..))
 import GHC.Generics
+import Data.Typeable
 import Control.Monad
 import Control.Exception
          ( assert )
@@ -216,6 +218,7 @@ data GenericInstallPlan ipkg srcpkg = GenericInstallPlan {
     planGraph      :: !(Graph (GenericPlanPackage ipkg srcpkg)),
     planIndepGoals :: !IndependentGoals
   }
+  deriving (Typeable)
 
 -- | 'GenericInstallPlan' specialised to most commonly used types.
 type InstallPlan = GenericInstallPlan

--- a/cabal-install/Distribution/Client/PackageHash.hs
+++ b/cabal-install/Distribution/Client/PackageHash.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards, NamedFieldPuns, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 -- | Functions to calculate nix-style hashes for package ids.
 --
@@ -57,6 +58,7 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import           Data.Set (Set)
 
+import Data.Typeable
 import Data.Maybe        (catMaybes)
 import Data.List         (sortBy, intercalate)
 import Data.Map          (Map)
@@ -280,7 +282,7 @@ renderPackageHashInputs PackageHashInputs{
 -- package ids.
 
 newtype HashValue = HashValue BS.ByteString
-  deriving (Eq, Show)
+  deriving (Eq, Show, Typeable)
 
 instance Binary HashValue where
   put (HashValue digest) = put digest

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -61,6 +61,7 @@ import Data.Set (Set)
 import Distribution.Compat.Binary (Binary)
 import Distribution.Compat.Semigroup
 import GHC.Generics (Generic)
+import Data.Typeable
 
 
 -------------------------------
@@ -116,7 +117,7 @@ data ProjectConfig
        projectConfigLocalPackages   :: PackageConfig,
        projectConfigSpecificPackage :: MapMappend PackageName PackageConfig
      }
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Typeable)
 
 -- | That part of the project configuration that only affects /how/ we build
 -- and not the /value/ of the things we build. This means this information
@@ -269,7 +270,7 @@ instance Binary PackageConfig
 -- | Newtype wrapper for 'Map' that provides a 'Monoid' instance that takes
 -- the last value rather than the first value for overlapping keys.
 newtype MapLast k v = MapLast { getMapLast :: Map k v }
-  deriving (Eq, Show, Functor, Generic, Binary)
+  deriving (Eq, Show, Functor, Generic, Binary, Typeable)
 
 instance Ord k => Monoid (MapLast k v) where
   mempty  = MapLast Map.empty
@@ -283,7 +284,7 @@ instance Ord k => Semigroup (MapLast k v) where
 -- | Newtype wrapper for 'Map' that provides a 'Monoid' instance that
 -- 'mappend's values of overlapping keys rather than taking the first.
 newtype MapMappend k v = MapMappend { getMapMappend :: Map k v }
-  deriving (Eq, Show, Functor, Generic, Binary)
+  deriving (Eq, Show, Functor, Generic, Binary, Typeable)
 
 instance (Semigroup v, Ord k) => Monoid (MapMappend k v) where
   mempty  = MapMappend Map.empty
@@ -363,7 +364,7 @@ data SolverSettings
      --solverSettingOverrideReinstall :: Bool,
      --solverSettingUpgradeDeps       :: Bool
      }
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Typeable)
 
 instance Binary SolverSettings
 

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -81,6 +81,7 @@ import qualified Data.ByteString.Lazy as LBS
 import           Distribution.Compat.Binary
 import           GHC.Generics (Generic)
 import qualified Data.Monoid as Mon
+import           Data.Typeable
 
 
 
@@ -112,7 +113,7 @@ data ElaboratedSharedConfig
        -- used.
        pkgConfigCompilerProgs :: ProgramDb
      }
-  deriving (Show, Generic)
+  deriving (Show, Generic, Typeable)
   --TODO: [code cleanup] no Eq instance
 
 instance Binary ElaboratedSharedConfig
@@ -264,7 +265,7 @@ data ElaboratedConfiguredPackage
        -- | Component/package specific information
        elabPkgOrComp :: ElaboratedPackageOrComponent
    }
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Typeable)
 
 instance Package ElaboratedConfiguredPackage where
   packageId = elabPkgSourceId
@@ -571,7 +572,7 @@ data SetupScriptStyle = SetupCustomExplicitDeps
                       | SetupCustomImplicitDeps
                       | SetupNonCustomExternalLib
                       | SetupNonCustomInternalLib
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Typeable)
 
 instance Binary SetupScriptStyle
 

--- a/cabal-install/Distribution/Client/RebuildMonad.hs
+++ b/cabal-install/Distribution/Client/RebuildMonad.hs
@@ -112,7 +112,7 @@ askRoot = Rebuild Reader.ask
 --
 -- Do not share 'FileMonitor's between different uses of 'rerunIfChanged'.
 --
-rerunIfChanged :: (Binary a, Binary b)
+rerunIfChanged :: (Binary a, Binary b, Typeable a, Typeable b)
                => Verbosity
                -> FileMonitor a b
                -> a

--- a/cabal-install/Distribution/Client/SolverInstallPlan.hs
+++ b/cabal-install/Distribution/Client/SolverInstallPlan.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
 -----------------------------------------------------------------------------
 -- |
@@ -77,6 +78,7 @@ import qualified Distribution.Compat.Graph as Graph
 import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Array ((!))
+import Data.Typeable
 
 type SolverPlanPackage = ResolverPackage UnresolvedPkgLoc
 
@@ -86,6 +88,7 @@ data SolverInstallPlan = SolverInstallPlan {
     planIndex      :: !SolverPlanIndex,
     planIndepGoals :: !IndependentGoals
   }
+  deriving (Typeable)
 
 {-
 -- | Much like 'planPkgIdOf', but mapping back to full packages.

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -211,7 +211,7 @@ data PackageLocation local =
 --TODO:
 --  * add support for darcs and other SCM style remote repos with a local cache
 --  | ScmPackage
-  deriving (Show, Functor, Eq, Ord, Generic)
+  deriving (Show, Functor, Eq, Ord, Generic, Typeable)
 
 instance Binary local => Binary (PackageLocation local)
 
@@ -332,9 +332,9 @@ data BuildResult = BuildResult DocsResult TestsResult
   deriving (Show, Generic)
 
 data DocsResult  = DocsNotTried  | DocsFailed  | DocsOk
-  deriving (Show, Generic)
+  deriving (Show, Generic, Typeable)
 data TestsResult = TestsNotTried | TestsOk
-  deriving (Show, Generic)
+  deriving (Show, Generic, Typeable)
 
 instance Binary BuildFailure
 instance Binary BuildResult

--- a/cabal-install/Distribution/Solver/Types/OptionalStanza.hs
+++ b/cabal-install/Distribution/Solver/Types/OptionalStanza.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 module Distribution.Solver.Types.OptionalStanza
     ( OptionalStanza(..)
     , enableStanzas
     ) where
 
 import GHC.Generics (Generic)
+import Data.Typeable
 import Distribution.Compat.Binary (Binary(..))
 import Distribution.Types.ComponentRequestedSpec
             (ComponentRequestedSpec(..), defaultComponentRequestedSpec)
@@ -13,7 +15,7 @@ import Data.List (foldl')
 data OptionalStanza
     = TestStanzas
     | BenchStanzas
-  deriving (Eq, Ord, Enum, Bounded, Show, Generic)
+  deriving (Eq, Ord, Enum, Bounded, Show, Generic, Typeable)
 
 -- | Convert a list of 'OptionalStanza' into the corresponding
 -- 'ComponentRequestedSpec' which records what components are enabled.

--- a/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Solver.Types.PkgConfigDb
@@ -52,7 +53,7 @@ data PkgConfigDb =  PkgConfigDb (M.Map PkgconfigName (Maybe Version))
                  -- number failed).
                  | NoPkgConfigDb
                  -- ^ For when we could not run pkg-config successfully.
-     deriving (Show, Generic)
+     deriving (Show, Generic, Typeable)
 
 instance Binary PkgConfigDb
 

--- a/cabal-install/Distribution/Solver/Types/SourcePackage.hs
+++ b/cabal-install/Distribution/Solver/Types/SourcePackage.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 module Distribution.Solver.Types.SourcePackage
     ( PackageDescriptionOverride
     , SourcePackage(..)
@@ -12,6 +13,7 @@ import Distribution.PackageDescription
 import Data.ByteString.Lazy (ByteString)
 import GHC.Generics (Generic)
 import Distribution.Compat.Binary (Binary(..))
+import Data.Typeable
 
 -- | A package description along with the location of the package sources.
 --
@@ -21,7 +23,7 @@ data SourcePackage loc = SourcePackage {
     packageSource        :: loc,
     packageDescrOverride :: PackageDescriptionOverride
   }
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Typeable)
 
 instance (Binary loc) => Binary (SourcePackage loc)
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/FileMonitor.hs
@@ -1,5 +1,6 @@
 module UnitTests.Distribution.Client.FileMonitor (tests) where
 
+import Data.Typeable
 import Control.Monad
 import Control.Exception
 import Control.Concurrent (threadDelay)
@@ -811,7 +812,7 @@ monitorFileGlobStr globstr
   | otherwise                        = error $ "Failed to parse " ++ globstr
 
 
-expectMonitorChanged :: (Binary a, Binary b)
+expectMonitorChanged :: (Binary a, Binary b, Typeable a, Typeable b)
                      => RootPath -> FileMonitor a b -> a
                      -> IO (MonitorChangedReason a)
 expectMonitorChanged root monitor key = do
@@ -820,7 +821,7 @@ expectMonitorChanged root monitor key = do
     MonitorChanged reason -> return reason
     MonitorUnchanged _ _  -> throwIO $ HUnitFailure "expected change"
 
-expectMonitorUnchanged :: (Binary a, Binary b)
+expectMonitorUnchanged :: (Binary a, Binary b, Typeable a, Typeable b)
                         => RootPath -> FileMonitor a b -> a
                         -> IO (b, [MonitorFilePath])
 expectMonitorUnchanged root monitor key = do
@@ -829,19 +830,19 @@ expectMonitorUnchanged root monitor key = do
     MonitorChanged _reason   -> throwIO $ HUnitFailure "expected no change"
     MonitorUnchanged b files -> return (b, files)
 
-checkChanged :: (Binary a, Binary b)
+checkChanged :: (Binary a, Binary b, Typeable a, Typeable b)
              => RootPath -> FileMonitor a b
              -> a -> IO (MonitorChanged a b)
 checkChanged (RootPath root) monitor key =
   checkFileMonitorChanged monitor root key
 
-updateMonitor :: (Binary a, Binary b)
+updateMonitor :: (Binary a, Binary b, Typeable a, Typeable b)
               => RootPath -> FileMonitor a b
               -> [MonitorFilePath] -> a -> b -> IO ()
 updateMonitor (RootPath root) monitor files key result =
   updateFileMonitor monitor root Nothing files key result
 
-updateMonitorWithTimestamp :: (Binary a, Binary b)
+updateMonitorWithTimestamp :: (Binary a, Binary b, Typeable a, Typeable b)
               => RootPath -> FileMonitor a b -> MonitorTimestamp
               -> [MonitorFilePath] -> a -> b -> IO ()
 updateMonitorWithTimestamp (RootPath root) monitor timestamp files key result =


### PR DESCRIPTION
The idea is we can use Rep to get a full, structural representation
of a type, and the fingerprint it using Typeable.  This gives
us a very concise way of fingerprinting our Binary representation.

This patch is not completely correct; the fingerprint needs
to be overridable when someone writes a custom Binary instance.
But this should be "good enough" in practice; we're not using
these fingerprints to check anything security critical.

TODO: Not sure if I have tagged all the call-sites which could
profit from this.

Fixes #4059.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>