### PR TITLE
Implement +timestamp verbosity flag

### DIFF
--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -492,12 +492,13 @@ printRawCommandAndArgsAndEnv :: Verbosity
                              -> IO ()
 printRawCommandAndArgsAndEnv verbosity path args menv
  | verbosity >= deafening = do
-       traverse_ (putStrLn . ("Environment: " ++) . show) menv
-       hPutCallStackPrefix stdout verbosity
-       print (path, args)
+    flip traverse_ menv $ \env ->
+      putStrLn =<< formatMsgNoWrap verbosity ("Environment: " ++ (show env))
+    hPutCallStackPrefix stdout verbosity
+    putStrLn =<< formatMsgNoWrap verbosity (show (path, args))
  | verbosity >= verbose   = do
     hPutCallStackPrefix stdout verbosity
-    putStrLn $ showCommandForUser path args
+    putStrLn =<< formatMsgNoWrap verbosity (showCommandForUser path args)
  | otherwise              = return ()
 
 

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -228,8 +228,10 @@ import System.IO.Unsafe
     ( unsafeInterleaveIO )
 import qualified Control.Exception as Exception
 
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import Control.Exception (IOException, evaluate, throwIO)
 import Control.Concurrent (forkIO)
+import Numeric (showFFloat)
 import qualified System.Process as Process
          ( CreateProcess(..), StdStream(..), proc)
 import System.Process
@@ -332,14 +334,14 @@ hPutCallStackPrefix h verbosity = withFrozenCallStack $ do
 dieMsg :: Verbosity -> String -> NoCallStackIO ()
 dieMsg verbosity msg = do
     hFlush stdout
-    hPutStr stderr (wrapTextVerbosity verbosity msg)
+    hPutStr stderr =<< formatLogMsg verbosity msg
 
 -- | As 'dieMsg' but with pre-formatted text.
 --
-dieMsgNoWrap :: String -> NoCallStackIO ()
-dieMsgNoWrap msg = do
+dieMsgNoWrap :: Verbosity -> String -> NoCallStackIO ()
+dieMsgNoWrap verbosity msg = do
     hFlush stdout
-    hPutStr stderr msg
+    hPutStr stderr =<< formatMsgNoWrap verbosity msg
 
 -- | Non fatal conditions that may be indicative of an error or problem.
 --
@@ -350,7 +352,7 @@ warn verbosity msg = withFrozenCallStack $ do
   when (verbosity >= normal) $ do
     hFlush stdout
     hPutCallStackPrefix stderr verbosity
-    hPutStr stderr (wrapTextVerbosity verbosity ("Warning: " ++ msg))
+    hPutStr stderr =<< formatLogMsg verbosity ("Warning: " ++ msg)
 
 -- | Useful status messages.
 --
@@ -363,13 +365,13 @@ notice :: Verbosity -> String -> IO ()
 notice verbosity msg = withFrozenCallStack $ do
   when (verbosity >= normal) $ do
     hPutCallStackPrefix stdout verbosity
-    putStr (wrapTextVerbosity verbosity msg)
+    putStr =<< formatLogMsg verbosity msg
 
 noticeNoWrap :: Verbosity -> String -> IO ()
 noticeNoWrap verbosity msg = withFrozenCallStack $ do
   when (verbosity >= normal) $ do
     hPutCallStackPrefix stdout verbosity
-    putStr msg
+    putStr =<< formatMsgNoWrap verbosity msg
 
 setupMessage :: Verbosity -> String -> PackageIdentifier -> IO ()
 setupMessage verbosity msg pkgid = withFrozenCallStack $ do
@@ -383,7 +385,7 @@ info :: Verbosity -> String -> IO ()
 info verbosity msg = withFrozenCallStack $
   when (verbosity >= verbose) $ do
     hPutCallStackPrefix stdout verbosity
-    putStr (wrapTextVerbosity verbosity msg)
+    putStr =<< formatLogMsg verbosity msg
 
 -- | Detailed internal debugging information
 --
@@ -393,7 +395,7 @@ debug :: Verbosity -> String -> IO ()
 debug verbosity msg = withFrozenCallStack $
   when (verbosity >= deafening) $ do
     hPutCallStackPrefix stdout verbosity
-    putStr (wrapTextVerbosity verbosity msg)
+    putStr =<< formatLogMsg verbosity msg
     hFlush stdout
 
 -- | A variant of 'debug' that doesn't perform the automatic line
@@ -402,7 +404,7 @@ debugNoWrap :: Verbosity -> String -> IO ()
 debugNoWrap verbosity msg = withFrozenCallStack $
   when (verbosity >= deafening) $ do
     hPutCallStackPrefix stdout verbosity
-    putStrLn msg
+    putStrLn =<< formatMsgNoWrap verbosity msg
     hFlush stdout
 
 -- | Perform an IO action, catching any IO exceptions and printing an error
@@ -437,8 +439,24 @@ wrapText = unlines
 -- | Wraps text unless the @+nowrap@ verbosity flag is active
 wrapTextVerbosity :: Verbosity -> String -> String
 wrapTextVerbosity verb
-  | isVerboseNoWrap verb = unlines . lines -- makes sure there's a trailing LF
+  | isVerboseNoWrap verb = unlines . lines
   | otherwise            = wrapText
+
+-- | Prepend timestamp and/or wrap log message depending on
+-- 'Verbosity' settings.
+formatLogMsg :: Verbosity -> String -> NoCallStackIO String
+formatLogMsg verbosity msg =
+    wrapTextVerbosity verbosity `fmap` formatMsgNoWrap verbosity msg
+
+-- | Prepends timestamp when the @+timestamp@ verbosity flag is active
+formatMsgNoWrap :: Verbosity -> String -> NoCallStackIO String
+formatMsgNoWrap verbosity msg
+  | isVerboseTimestamp verbosity = do
+        now <- getPOSIXTime
+        -- format with msec precision
+        let tsstr = showFFloat (Just 3) (realToFrac now :: Double)
+        return (tsstr (' ':msg))
+  | otherwise = pure msg
 
 -- | Wraps a list of words to a list of lines of words of a particular width.
 wrapLine :: Int -> [String] -> [[String]]

--- a/Cabal/Distribution/Verbosity.hs
+++ b/Cabal/Distribution/Verbosity.hs
@@ -37,6 +37,9 @@ module Distribution.Verbosity (
 
   -- * line-wrapping
   verboseNoWrap, isVerboseNoWrap,
+
+  -- * Timestamps
+  verboseTimestamp, isVerboseTimestamp
  ) where
 
 import Prelude ()
@@ -144,6 +147,7 @@ parseVerbosity = parseIntVerbosity <++ parseStringVerbosity
         [ string "callsite"  >> return verboseCallSite
         , string "callstack" >> return verboseCallStack
         , string "nowrap"    >> return verboseNoWrap
+        , string "timestamp" >> return verboseTimestamp
         ]
 
 flagToVerbosity :: ReadE Verbosity
@@ -169,6 +173,7 @@ data VerbosityFlag
     = VCallStack
     | VCallSite
     | VNoWrap
+    | VTimestamp
     deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded)
 
 instance Binary VerbosityFlag
@@ -196,3 +201,11 @@ verboseNoWrap v = v { vFlags = Set.insert VNoWrap (vFlags v) }
 -- | Test if line-wrapping is disabled for log messages.
 isVerboseNoWrap :: Verbosity -> Bool
 isVerboseNoWrap = (Set.member VNoWrap) . vFlags
+
+-- | Turn on timestamps for log messages.
+verboseTimestamp :: Verbosity -> Verbosity
+verboseTimestamp v = v { vFlags = Set.insert VTimestamp (vFlags v) }
+
+-- | Test if if we should output timestamps when we log.
+isVerboseTimestamp :: Verbosity -> Bool
+isVerboseTimestamp = (Set.member VTimestamp) . vFlags

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -639,7 +639,7 @@ dieOnBuildFailures verbosity plan buildOutcomes
          [ do dieMsg verbosity $
                 '\n' : renderFailureDetail False pkg reason
                     ++ "\nBuild log ( " ++ logfile ++ " ):"
-              readFile logfile >>= dieMsgNoWrap
+              readFile logfile >>= dieMsgNoWrap verbosity
          | verbosity >= normal
          ,  (pkg, ShowBuildSummaryAndLog reason logfile)
              <- failuresClassification

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -111,7 +111,7 @@ import Distribution.ReadE
 import qualified Distribution.Compat.ReadP as Parse
          ( ReadP, char, munch1, pfail,  (+++) )
 import Distribution.Verbosity
-         ( Verbosity, lessVerbose, normal )
+         ( Verbosity, lessVerbose, normal, dropVerbosityFlags )
 import Distribution.Simple.Utils
          ( wrapText, wrapLine )
 import Distribution.Client.GlobalFlags
@@ -392,8 +392,12 @@ filterConfigureFlags flags cabalLibVersion
       }
 
     -- Cabal < 1.25.0 doesn't know about --dynlibdir.
-    flags_1_25_0 = flags_latest { configInstallDirs = configInstallDirs_1_25_0}
+    -- Cabal < 1.25.0 doesn't know about verbosity flags (e.g. @+callstack)
+    flags_1_25_0 = flags_latest { configInstallDirs = configInstallDirs_1_25_0
+                                , configVerbosity   = configVerbosity_1_25_0
+                                }
     configInstallDirs_1_25_0 = (configInstallDirs flags) { dynlibdir = NoFlag }
+    configVerbosity_1_25_0 = fmap dropVerbosityFlags (configVerbosity flags)
 
     -- Cabal < 1.23 doesn't know about '--profiling-detail'.
     -- Cabal < 1.23 has a hacked up version of 'enable-profiling'


### PR DESCRIPTION
This prepends a posix timestamp (with milliseconds precision) to log
messages (before any wrapping is applied)

Example output:

    $ cabal update  --verbose=verbose+timestamp
    1478941945.027 Downloading the latest package list from hackage.haskell.org
    1478941945.029 Selected mirror http://hackage.haskell.org/
    1478941945.036 Downloading timestamp
    ...

This is quite useful for debugging & profiling cabal, as well as for
buildbots (such as matrix.hho) which want to record timings in their
buildlogs for later analysis.