### PR TITLE
Deduplicate library directory arguments when testing libraries

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -1660,8 +1660,10 @@ checkForeignDeps pkg lbi verbosity = do
         commonLdArgs  = [ "-L" ++ dir | dir <- collectField PD.extraLibDirs ]
                      ++ collectField PD.ldOptions
                      ++ [ "-L" ++ dir
-                        | dep <- deps
-                        , dir <- Installed.libraryDirs dep ]
+                        | dir <- ordNub [ dir
+                                        | dep <- deps
+                                        , dir <- Installed.libraryDirs dep ]
+                        ]
                      --TODO: do we also need dependent packages' ld options?
         makeLdArgs libs = [ "-l"++lib | lib <- libs ] ++ commonLdArgs
 


### PR DESCRIPTION
See #3974. The same problem also affects the inherited library directories.