### PR TITLE
Add `--index-state` support to `cabal get`

### DIFF
--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2274,6 +2274,15 @@ The ``get`` command supports the following options:
     Fork the package's source repository using the appropriate version
     control system. The optional argument allows to choose a specific
     repository kind.
+``--index-state`` *[HEAD\|@<unix-timestamp>\|<iso8601-utc-timestamp>]*
+    Use source package index state as it existed at a previous time. Accepts
+    unix-timestamps (e.g. ``@1474732068``), ISO8601 UTC timestamps (e.g.
+    ``2016-09-24T17:47:48Z``), or ``HEAD`` (default).
+    This determines which package versions are available as well as which
+    ``.cabal`` file revision is selected (unless ``--pristine`` is used).
+``--pristine``
+    Unpack the original pristine tarball, rather than updating the
+    ``.cabal`` file with the latest revision from the package archive.
 
 Custom setup scripts
 --------------------

--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -39,7 +39,7 @@ import Distribution.Client.Dependency
 import Distribution.Client.FetchUtils
 import qualified Distribution.Client.Tar as Tar (extractTarGzFile)
 import Distribution.Client.IndexUtils as IndexUtils
-        ( getSourcePackages )
+        ( getSourcePackagesAtIndexState, IndexState(..) )
 import Distribution.Client.Compat.Process
         ( readProcessWithExitCode )
 import Distribution.Compat.Exception
@@ -82,7 +82,10 @@ get verbosity repoCtxt globalFlags getFlags userTargets = do
   unless useFork $
     mapM_ checkTarget userTargets
 
-  sourcePkgDb <- getSourcePackages verbosity repoCtxt
+  let idxState = fromFlagOrDefault IndexStateHead $
+                       getIndexState getFlags
+
+  sourcePkgDb <- getSourcePackagesAtIndexState verbosity repoCtxt idxState
 
   pkgSpecifiers <- resolveUserTargets verbosity repoCtxt
                    (fromFlag $ globalWorldFile globalFlags)

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1013,6 +1013,7 @@ instance Semigroup ReportFlags where
 data GetFlags = GetFlags {
     getDestDir          :: Flag FilePath,
     getPristine         :: Flag Bool,
+    getIndexState       :: Flag IndexState,
     getSourceRepository :: Flag (Maybe RepoKind),
     getVerbosity        :: Flag Verbosity
   } deriving Generic
@@ -1021,6 +1022,7 @@ defaultGetFlags :: GetFlags
 defaultGetFlags = GetFlags {
     getDestDir          = mempty,
     getPristine         = mempty,
+    getIndexState       = mempty,
     getSourceRepository = mempty,
     getVerbosity        = toFlag normal
    }
@@ -1057,6 +1059,20 @@ getCommand = CommandUI {
                                               (fmap (toFlag . Just) parse))
                                   (Flag Nothing)
                                   (map (fmap show) . flagToList))
+
+      , option [] ["index-state"]
+          ("Use source package index state as it existed at a previous time. " ++
+           "Accepts unix-timestamps (e.g. '@1474732068'), ISO8601 UTC timestamps " ++
+           "(e.g. '2016-09-24T17:47:48Z'), or 'HEAD' (default: 'HEAD'). " ++
+           "This determines which package versions are available as well as " ++
+           ".cabal file revision is selected (unless --pristine is used).")
+          getIndexState (\v flags -> flags { getIndexState = v })
+          (reqArg "STATE" (readP_to_E (const $ "index-state must be a  " ++
+                                       "unix-timestamps (e.g. '@1474732068'), " ++
+                                       "a ISO8601 UTC timestamp " ++
+                                       "(e.g. '2016-09-24T17:47:48Z'), or 'HEAD'")
+                                      (toFlag `fmap` parse))
+                          (flagToList . fmap display))
 
        , option [] ["pristine"]
            ("Unpack the original pristine tarball, rather than updating the "

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -24,6 +24,8 @@
 	'.../$pkgid.log' to '.../$compiler/$libname.log' (#3807).
 	* Added a new command, 'cabal reconfigure', which re-runs 'configure'
 	with the most recently used flags (#2214).
+	* Added add the '--index-state' flag for requesting a specific
+	version of the package index (#3893, #4115).
 	* Support for building Backpack packages.  See
 	https://github.com/ezyang/ghc-proposals/blob/backpack/proposals/0000-backpack.rst
 	for more details.


### PR DESCRIPTION
With this `cabal get` gains the ability to

 a) unpack and update with the .cabal revision which was
    active at the given index-state, as well as

 b) allow to unpack the most recent package version
    (while satisfying imposed version constraints) as of
    the given index-state

The `--index-state` flag can be combined with `--pristine` if only b) is
desired.