### PR TITLE
bootstrap.sh: bump 1.24's minimum Cabal to 1.24.1

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -225,8 +225,8 @@ NETWORK_VER="2.6.2.1"; NETWORK_VER_REGEXP="2\.[0-6]\."
                        # >= 2.0 && < 2.7
 NETWORK_URI_VER="2.6.1.0"; NETWORK_URI_VER_REGEXP="2\.6\."
                        # >= 2.6 && < 2.7
-CABAL_VER="1.24.1.0";  CABAL_VER_REGEXP="1\.24\.[0-9]"
-                       # >= 1.24 && < 1.25
+CABAL_VER="1.24.1.0";  CABAL_VER_REGEXP="1\.24\.[1-9]"
+                       # >= 1.24.1 && < 1.25
 TRANS_VER="0.5.2.0";   TRANS_VER_REGEXP="0\.[45]\."
                        # >= 0.2.* && < 0.6
 MTL_VER="2.2.1";       MTL_VER_REGEXP="[2]\."


### PR DESCRIPTION
otherwise a local Cabal 1.24.0.0 will cause build failure

```
  Distribution/Client/Setup.hs:76:40: error:
      Module
      ‘Distribution.Simple.Configure’
      does not export
      ‘computeEffectiveProfiling’
```

due to haskell/cabal@fbfc811.