### PR TITLE
Cherry-pick #4094 onto 1.24.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -80,6 +80,8 @@ extra-source-files:
   tests/PackageTests/BuildDeps/TargetSpecificDeps3/MyLibrary.hs
   tests/PackageTests/BuildDeps/TargetSpecificDeps3/lemon.hs
   tests/PackageTests/BuildDeps/TargetSpecificDeps3/my.cabal
+  tests/PackageTests/BuildTargetErrors/BuildTargetErrors.cabal
+  tests/PackageTests/BuildTargetErrors/Main.hs
   tests/PackageTests/BuildTestSuiteDetailedV09/Dummy2.hs
   tests/PackageTests/BuildableField/BuildableField.cabal
   tests/PackageTests/BuildableField/Main.hs

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -1,4 +1,7 @@
 -*-change-log-*-
+1.24.1.1 Ryan Thomas <ryan@ryant.org> ??? 2016
+	* Fixed a bug in the handling of non-buildable components (#4094).
+
 1.24.1.0 Ryan Thomas <ryan@ryant.org> October 2016
 	* API addition: 'differenceVersionRanges' (#3519).
 	* Fixed reexported-modules display mangling (#3928).

--- a/Cabal/tests/PackageTests/BuildTargetErrors/BuildTargetErrors.cabal
+++ b/Cabal/tests/PackageTests/BuildTargetErrors/BuildTargetErrors.cabal
@@ -1,0 +1,10 @@
+name: BuildTargetErrors
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.9
+
+library
+
+executable not-buildable-exe
+    main-is: Main.hs
+    buildable: False

--- a/Cabal/tests/PackageTests/BuildTargetErrors/Main.hs
+++ b/Cabal/tests/PackageTests/BuildTargetErrors/Main.hs
@@ -1,0 +1,1 @@
+main = return ()

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -279,6 +279,14 @@ tests config = do
                     "tests/PackageTests/GhcPkgGuess/SymlinkGhcVersion/ghc" $
                     ghc_pkg_guess "ghc"
 
+  -- Test error message we report when a non-buildable target is
+  -- requested to be built
+  -- TODO: We can give a better error message here, see #3858.
+  tc "BuildTargetErrors" $ do
+    cabal "configure" []
+    assertOutputContains "There is no component"
+        =<< shouldFail (cabal' "build" ["not-buildable-exe"])
+
   where
     ghc_pkg_guess bin_name = do
         cwd <- packageDir

--- a/Cabal/tests/PackageTests/Tests.hs
+++ b/Cabal/tests/PackageTests/Tests.hs
@@ -281,10 +281,9 @@ tests config = do
 
   -- Test error message we report when a non-buildable target is
   -- requested to be built
-  -- TODO: We can give a better error message here, see #3858.
   tc "BuildTargetErrors" $ do
     cabal "configure" []
-    assertOutputContains "There is no component"
+    assertOutputContains "the component is marked as disabled"
         =<< shouldFail (cabal' "build" ["not-buildable-exe"])
 
   where


### PR DESCRIPTION
I added an entry to the changelog, but I'm not sure if the version is correct.  Will there be a Cabal 1.24.1.1?  I also had to copy the test for this issue in a separate commit.