### PR TITLE
Disable environment files due to #4010.

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -687,6 +687,8 @@ writePlanGhcEnvironment projectRootDir
   | compilerFlavor compiler == GHC
   , supportsPkgEnvFiles (getImplInfo compiler)
   --TODO: check ghcjs compat
+  --TODO: This feature is temporarily disabled due to #4010
+  , False
   = writeGhcEnvironmentFile
       projectRootDir
       platform (compilerVersion compiler)


### PR DESCRIPTION
As a fix for #4010 is nowhere in sight, I'm taking the initiative to disable this feature until we have a fix.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>