### PR TITLE
bootstrap.sh: do not use -j on ghc-7.8

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -164,9 +164,9 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-# Do not try to use -j with GHC older than 7.8
+# Do not try to use -j with GHC 7.8 or older
 case $GHC_VER in
-    7.4*|7.6*)
+    7.4*|7.6*|7.8*)
         JOBS=""
         ;;
     *)


### PR DESCRIPTION
Cabal-1.18 in ghc-7.8 does not support -j