### PR TITLE
Add some missing occurrences of flib in cabal-install.

### DIFF
--- a/Cabal/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/Distribution/Simple/BuildTarget.hs
@@ -540,7 +540,7 @@ cinfoKind = componentKind . cinfoName
 matchComponentKind :: String -> Match ComponentKind
 matchComponentKind s
   | s `elem` ["lib", "library"]                 = return' LibKind
-  | s `elem` ["foreign-lib", "foreign-library"] = return' FLibKind
+  | s `elem` ["flib", "foreign-lib", "foreign-library"] = return' FLibKind
   | s `elem` ["exe", "executable"]              = return' ExeKind
   | s `elem` ["tst", "test", "test-suite"]      = return' TestKind
   | s `elem` ["bench", "benchmark"]             = return' BenchKind

--- a/cabal-install/Distribution/Client/BuildTarget.hs
+++ b/cabal-install/Distribution/Client/BuildTarget.hs
@@ -432,7 +432,7 @@ reportUserBuildTargetProblems problems = do
            ++ " - build Data.Foo       -- module name\n"
            ++ " - build Data/Foo.hsc   -- file name\n\n"
            ++ "An ambigious target can be qualified by package, component\n"
-           ++ "and/or component kind (lib|exe|test|bench)\n"
+           ++ "and/or component kind (lib|exe|test|bench|flib)\n"
            ++ " - build foo:tests      -- component qualified by package\n"
            ++ " - build tests:Data.Foo -- module qualified by component\n"
            ++ " - build lib:foo        -- component qualified by kind"
@@ -1171,6 +1171,7 @@ cinfoKind = componentKind . cinfoName
 matchComponentKind :: String -> Match ComponentKind
 matchComponentKind s
   | s `elem` ["lib", "library"]            = increaseConfidence >> return LibKind
+  | s `elem` ["flib", "foreign-library"]   = increaseConfidence >> return FLibKind
   | s `elem` ["exe", "executable"]         = increaseConfidence >> return ExeKind
   | s `elem` ["tst", "test", "test-suite"] = increaseConfidence
                                              >> return TestKind

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -309,6 +309,7 @@ instance Arbitrary Component where
   arbitrary = oneof [ return ComponentLib
                     , ComponentSubLib <$> arbitrary
                     , ComponentExe <$> arbitrary
+                    , ComponentFLib <$> arbitrary
                     , ComponentTest <$> arbitrary
                     , ComponentBench <$> arbitrary
                     , return ComponentSetup


### PR DESCRIPTION
Fixes #4141.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>