### PR TITLE
Solver: Add missing call to 'simplifyVar'.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install/Distribution/Solver/Modular/Explore.hs
@@ -74,7 +74,7 @@ getBestGoal :: ConflictMap -> P.PSQ (Goal QPN) a -> (Goal QPN, a)
 getBestGoal cm =
   P.maximumBy
     ( flip (M.findWithDefault 0) cm
-    . (\ (Goal v _) -> v)
+    . (\ (Goal v _) -> simplifyVar v)
     )
 
 getFirstGoal :: P.PSQ (Goal QPN) a -> (Goal QPN, a)


### PR DESCRIPTION
`simplifyVar` removes flag names from the `Var` type, so that all flags within a
package are treated as one during backjumping. A more complete fix would involve
creating a `SimpleVar` type.

The bug caused the conflict counting heuristic to never prefer flag goals. Flag
variables in the tree's goals had the flags' original names, and the flag
variables in the conflict map did not have names, so they could never be equal.

Since this fix changes the goal order, I wanted to test for an unexpected large
negative impact on solver runtime. I ran the solver on all packages on Hackage
individually with GHC 8.0.1 and looked for differences of more than 10% between
master and the branch. There were twelve packages. I reran those packages three
times and found ten with a significant difference in runtime. Here are the
average runtimes. None of them hit the backjump limit.

package               |          master (seconds)  | branch (seconds) |  ratio
-----------------------|--------------------------------|------------------------|-----
clash-ghc              |          2.60     |         3.99       |        1.54
hack-middleware-clientsession  |  8.22      |        2.54       |        0.31
hackage-server          |         1.46      |        1.85      |         1.26
hamusic                 |         5.47        |      4.55         |      0.83
haskore-synthesizer      |       10.13       |       7.64        |       0.75
language-gcl             |        2.54       |       2.03       |        0.80
ms               |               36.98       |       8.02        |       0.22
pipes-cereal-plus      |          1.51       |       1.66      |         1.10
thorn                |            8.28       |       3.08         |      0.37
wai-handler-devel        |        1.72      |       1.91    |           1.11

I looked at the diff in the -v3 log for several of them and saw that the solver
was making some flag choices earlier, as expected.

This isn't much of an improvement, but it at least looks like a safe change.