### PR TITLE
Nix integration

### DIFF
--- a/Cabal.nix
+++ b/Cabal.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, array, base, binary, bytestring, containers
+, deepseq, directory, exceptions, filepath, old-time, pretty
+, process, QuickCheck, regex-posix, stdenv, tagged, tasty
+, tasty-hunit, tasty-quickcheck, time, transformers, unix
+}:
+mkDerivation {
+  pname = "Cabal";
+  version = "1.25.0.0";
+  src = ./Cabal;
+  libraryHaskellDepends = [
+    array base binary bytestring containers deepseq directory filepath
+    pretty process time unix
+  ];
+  testHaskellDepends = [
+    array base bytestring containers directory exceptions filepath
+    old-time pretty process QuickCheck regex-posix tagged tasty
+    tasty-hunit tasty-quickcheck time transformers unix
+  ];
+  doCheck = false;
+  homepage = "http://www.haskell.org/cabal/";
+  description = "A framework for packaging Haskell software";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/Cabal/doc/index.rst
+++ b/Cabal/doc/index.rst
@@ -11,3 +11,4 @@ Welcome to the Cabal User Guide
    concepts-and-development
    bugs-and-stability
    nix-local-build-overview
+   nix-integration

--- a/Cabal/doc/nix-integration.rst
+++ b/Cabal/doc/nix-integration.rst
@@ -1,0 +1,40 @@
+Nix Integration
+===============
+
+`Nix <http://nixos.org/nix/>`_ is a package manager popular with some Haskell developers due to its focus on reliability and reproducibility. ``cabal`` now has the ability to integrate with Nix for dependency management during local package development.
+
+Enabling Nix Integration
+------------------------
+
+To enable Nix integration, simply pass the ``--enable-nix`` global option when you call ``cabal``. To use this option everywhere, edit your ``$HOME/.cabal/config`` file to include:
+
+.. code-block:: cabal
+
+    nix: True
+
+If the package (which must be locally unpacked) provides a ``shell.nix`` file, this flag will cause ``cabal`` to run most commands through ``nix-shell``. The following commands are affected:
+
+- ``cabal configure``
+- ``cabal build``
+- ``cabal repl``
+- ``cabal install`` (only if installing into a sandbox)
+- ``cabal haddock``
+- ``cabal freeze``
+- ``cabal gen-bounds``
+- ``cabal run``
+
+If the package does not provide a ``shell.nix``, ``cabal`` runs normally.
+
+Creating Nix Expressions
+------------------------
+
+The Nix package manager is based on a lazy, pure, functional programming language; packages are defined by expressions in this language. The fastest way to create a Nix expression for a Cabal package is with the `cabal2nix <https://github.com/NixOS/cabal2nix>`_ tool. To create a ``shell.nix`` expression for the package in the current directory, run this command:
+
+.. code-block:: console
+
+    $ cabal2nix --shell ./. >shell.nix
+
+Further Reading
+----------------
+
+The `Nix manual <http://nixos.org/nix/manual/#chap-writing-nix-expressions>`_ provides further instructions for writing Nix expressions. The `Nixpkgs manual <http://nixos.org/nixpkgs/manual/#users-guide-to-the-haskell-infrastructure>`_ describes the infrastructure provided for Haskell packages.

--- a/cabal-install.nix
+++ b/cabal-install.nix
@@ -1,0 +1,35 @@
+{ mkDerivation, array, async, base, base16-bytestring, binary
+, bytestring, Cabal, containers, cryptohash-sha256, deepseq
+, directory, filepath, hackage-security, hashable, HTTP, mtl
+, network, network-uri, pretty, pretty-show, process, QuickCheck
+, random, regex-posix, stdenv, stm, tagged, tar, tasty, tasty-hunit
+, tasty-quickcheck, time, unix, zlib
+}:
+mkDerivation {
+  pname = "cabal-install";
+  version = "1.25.0.0";
+  src = ./cabal-install;
+  isLibrary = false;
+  isExecutable = true;
+  setupHaskellDepends = [ base Cabal filepath process ];
+  executableHaskellDepends = [
+    array async base base16-bytestring binary bytestring Cabal
+    containers cryptohash-sha256 deepseq directory filepath
+    hackage-security hashable HTTP mtl network network-uri pretty
+    process random stm tar time unix zlib
+  ];
+  testHaskellDepends = [
+    array async base base16-bytestring binary bytestring Cabal
+    containers cryptohash-sha256 deepseq directory filepath
+    hackage-security hashable HTTP mtl network network-uri pretty
+    pretty-show process QuickCheck random regex-posix stm tagged tar
+    tasty tasty-hunit tasty-quickcheck time unix zlib
+  ];
+  postInstall = ''
+    mkdir $out/etc
+    mv bash-completion $out/etc/bash_completion.d
+  '';
+  homepage = "http://www.haskell.org/cabal/";
+  description = "The command-line interface for Cabal and Hackage";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -227,7 +227,8 @@ instance Semigroup SavedConfig where
         globalRequireSandbox    = combine globalRequireSandbox,
         globalIgnoreSandbox     = combine globalIgnoreSandbox,
         globalIgnoreExpiry      = combine globalIgnoreExpiry,
-        globalHttpTransport     = combine globalHttpTransport
+        globalHttpTransport     = combine globalHttpTransport,
+        globalNix               = combine globalNix
         }
         where
           combine        = combine'        savedGlobalFlags

--- a/cabal-install/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/Distribution/Client/GlobalFlags.hs
@@ -67,7 +67,8 @@ data GlobalFlags = GlobalFlags {
     globalRequireSandbox    :: Flag Bool,
     globalIgnoreSandbox     :: Flag Bool,
     globalIgnoreExpiry      :: Flag Bool,    -- ^ Ignore security expiry dates
-    globalHttpTransport     :: Flag String
+    globalHttpTransport     :: Flag String,
+    globalNix               :: Flag Bool  -- ^ Integrate with Nix
   } deriving Generic
 
 defaultGlobalFlags :: GlobalFlags
@@ -85,7 +86,8 @@ defaultGlobalFlags  = GlobalFlags {
     globalRequireSandbox    = Flag False,
     globalIgnoreSandbox     = Flag False,
     globalIgnoreExpiry      = Flag False,
-    globalHttpTransport     = mempty
+    globalHttpTransport     = mempty,
+    globalNix               = Flag False
   }
 
 instance Monoid GlobalFlags where

--- a/cabal-install/Distribution/Client/Nix.hs
+++ b/cabal-install/Distribution/Client/Nix.hs
@@ -1,0 +1,179 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Distribution.Client.Nix
+       ( findNixExpr
+       , inNixShell
+       , nixInstantiate
+       , nixShell
+       , nixShellIfSandboxed
+       ) where
+
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative ((<$>))
+#endif
+
+import Control.Exception (catch)
+import Control.Monad (filterM, when, unless)
+import System.Directory
+       ( createDirectoryIfMissing, doesDirectoryExist, doesFileExist
+       , makeAbsolute, removeDirectoryRecursive, removeFile )
+import System.Environment (getExecutablePath, getArgs, lookupEnv)
+import System.FilePath
+       ( (</>), (<.>), replaceExtension, takeDirectory, takeFileName )
+import System.IO (IOMode(..), hClose, openFile)
+import System.IO.Error (isDoesNotExistError)
+import System.Process (showCommandForUser)
+
+import Distribution.Compat.Semigroup
+
+import Distribution.Verbosity
+
+import Distribution.Simple.Program
+       ( Program(..), ProgramDb
+       , addKnownProgram, configureProgram, emptyProgramDb, getDbProgramOutput
+       , runDbProgram, simpleProgram )
+import Distribution.Simple.Setup (fromFlagOrDefault)
+import Distribution.Simple.Utils (debug, existsAndIsMoreRecentThan)
+
+import Distribution.Client.Config (SavedConfig(..))
+import Distribution.Client.GlobalFlags (GlobalFlags(..))
+import Distribution.Client.Sandbox.Types (UseSandbox(..))
+
+
+configureOneProgram :: Verbosity -> Program -> IO ProgramDb
+configureOneProgram verb prog =
+  configureProgram verb prog (addKnownProgram prog emptyProgramDb)
+
+
+touchFile :: FilePath -> IO ()
+touchFile path = do
+  catch (removeFile path) (\e -> when (isDoesNotExistError e) (return ()))
+  createDirectoryIfMissing True (takeDirectory path)
+  openFile path WriteMode >>= hClose
+
+
+findNixExpr :: GlobalFlags -> SavedConfig -> IO (Maybe FilePath)
+findNixExpr globalFlags config = do
+  -- criteria for deciding to run nix-shell
+  let nixEnabled =
+        fromFlagOrDefault False
+        (globalNix (savedGlobalFlags config) <> globalNix globalFlags)
+
+  if nixEnabled
+    then do
+      let exprPaths = [ "shell.nix", "default.nix" ]
+      filterM doesFileExist exprPaths >>= \case
+        [] -> return Nothing
+        (path : _) -> return (Just path)
+    else return Nothing
+
+
+nixInstantiate
+  :: Verbosity
+  -> FilePath
+  -> Bool
+  -> GlobalFlags
+  -> SavedConfig
+  -> IO ()
+nixInstantiate verb dist force globalFlags config =
+  findNixExpr globalFlags config >>= \case
+    Nothing -> return ()
+    Just shellNix -> do
+      alreadyInShell <- inNixShell
+      shellDrv <- drvPath dist shellNix
+      instantiated <- doesFileExist shellDrv
+      -- an extra timestamp file is necessary because the derivation lives in
+      -- the store so its mtime is always 1.
+      let timestamp = shellDrv <.> "timestamp"
+      upToDate <- existsAndIsMoreRecentThan timestamp shellNix
+
+      let ready = alreadyInShell || (instantiated && upToDate && not force)
+      unless ready $ do
+
+        let prog = simpleProgram "nix-instantiate"
+        progdb <- configureOneProgram verb prog
+
+        removeGCRoots verb dist
+        touchFile timestamp
+
+        _ <- getDbProgramOutput verb prog progdb
+             [ "--add-root", shellDrv, "--indirect", shellNix ]
+        return ()
+
+
+nixShell
+  :: Verbosity
+  -> FilePath
+  -> GlobalFlags
+  -> SavedConfig
+  -> IO ()
+     -- ^ The action to perform inside a nix-shell. This is also the action
+     -- that will be performed immediately if Nix is disabled.
+  -> IO ()
+nixShell verb dist globalFlags config go = do
+
+  alreadyInShell <- inNixShell
+
+  if alreadyInShell
+    then go
+    else do
+      findNixExpr globalFlags config >>= \case
+        Nothing -> go
+        Just shellNix -> do
+
+          let prog = simpleProgram "nix-shell"
+          progdb <- configureOneProgram verb prog
+
+          cabal <- getExecutablePath
+
+          -- Run cabal with the same arguments inside nix-shell.
+          -- When the child process reaches the top of nixShell, it will
+          -- detect that it is running inside the shell and fall back
+          -- automatically.
+          shellDrv <- drvPath dist shellNix
+          args <- getArgs
+          runDbProgram verb prog progdb
+            [ "--add-root", gcrootPath dist </> "result", "--indirect", shellDrv
+            , "--run", showCommandForUser cabal args
+            ]
+
+
+drvPath :: FilePath -> FilePath -> IO FilePath
+drvPath dist path =
+  -- Nix garbage collector roots must be absolute paths
+  makeAbsolute (dist </> "nix" </> replaceExtension (takeFileName path) "drv")
+
+
+gcrootPath :: FilePath -> FilePath
+gcrootPath dist = dist </> "nix" </> "gcroots"
+
+
+inNixShell :: IO Bool
+inNixShell = maybe False (const True) <$> lookupEnv "IN_NIX_SHELL"
+
+
+removeGCRoots :: Verbosity -> FilePath -> IO ()
+removeGCRoots verb dist = do
+  let tgt = gcrootPath dist
+  exists <- doesDirectoryExist tgt
+  when exists $ do
+    debug verb ("removing Nix gcroots from " ++ tgt)
+    removeDirectoryRecursive tgt
+
+
+nixShellIfSandboxed
+  :: Verbosity
+  -> FilePath
+  -> GlobalFlags
+  -> SavedConfig
+  -> UseSandbox
+  -> IO ()
+     -- ^ The action to perform inside a nix-shell. This is also the action
+     -- that will be performed immediately if Nix is disabled.
+  -> IO ()
+nixShellIfSandboxed verb dist globalFlags config useSandbox go =
+  case useSandbox of
+    NoSandbox -> go
+    UseSandbox _ -> nixShell verb dist globalFlags config go

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -472,7 +472,8 @@ convertToLegacySharedConfig
       globalRequireSandbox    = mempty,
       globalIgnoreSandbox     = mempty,
       globalIgnoreExpiry      = projectConfigIgnoreExpiry,
-      globalHttpTransport     = projectConfigHttpTransport
+      globalHttpTransport     = projectConfigHttpTransport,
+      globalNix               = mempty
     }
 
     configFlags = mempty {

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -298,6 +298,10 @@ globalCommand commands = CommandUI {
          "Set a transport for http(s) requests. Accepts 'curl', 'wget', 'powershell', and 'plain-http'. (default: 'curl')"
          globalHttpTransport (\v flags -> flags { globalHttpTransport = v })
          (reqArgFlag "HttpTransport")
+      ,option [] ["nix"]
+         "Nix integration: run commands through nix-shell if a 'shell.nix' file exists"
+         globalNix (\v flags -> flags { globalNix = v })
+         (boolOpt [] [])
       ]
 
     -- arguments we don't want shown in the help

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -243,6 +243,7 @@ executable cabal
         Distribution.Client.JobControl
         Distribution.Client.List
         Distribution.Client.Manpage
+        Distribution.Client.Nix
         Distribution.Client.PackageHash
         Distribution.Client.PackageUtils
         Distribution.Client.ParseUtils

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -29,6 +29,7 @@
 	* Support for building Backpack packages.  See
 	https://github.com/ezyang/ghc-proposals/blob/backpack/proposals/0000-backpack.rst
 	for more details.
+	* Support the Nix package manager (#3651).
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* If there are multiple remote repos, 'cabal update' now updates

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,22 @@
+with (import <nixpkgs> {});
+let
+  inherit (haskell) lib;
+  filterSource = drv:  # only copy required source files to build directory
+    let
+      omitDirs = [ ".cabal-sandbox" ".git" "dist" ];
+      omitExts = [ ".o" ".hi" ];
+      hasExt = path: ext: stdenv.lib.hasSuffix ext path;
+      predicate = path: type:
+        if type == "directory"
+          then !(stdenv.lib.elem (baseNameOf path) omitDirs)
+          else !(stdenv.lib.any (hasExt path) omitExts);
+    in
+      lib.overrideCabal drv
+      (args: args // { src = builtins.filterSource predicate args.src; });
+in
+haskellPackages.override {
+  overrides = self: super: {
+    Cabal = filterSource (self.callPackage ./Cabal.nix {});
+    cabal-install = filterSource (lib.dontCheck (self.callPackage ./cabal-install.nix {}));
+  };
+}


### PR DESCRIPTION
These commits add Nix integration to `cabal-install`. If the global `--enable-nix` option is specified and a `shell.nix` file exists, `cabal` will run the affected commands in a `nix-shell` instance.