### PR TITLE
Solver: Add a 'SimpleVar' type for representing variables in conflict sets.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/ConflictSet.hs
+++ b/cabal-install/Distribution/Solver/Modular/ConflictSet.hs
@@ -24,11 +24,9 @@ module Distribution.Solver.Modular.ConflictSet (
   , empty
   , singleton
   , member
-  , filter
   , fromList
   ) where
 
-import Prelude hiding (filter)
 import Data.List (intercalate, sortBy)
 import Data.Map (Map)
 import Data.Set (Set)
@@ -59,7 +57,7 @@ data ConflictSet = CS {
     -- we record the origin of every conflict set. For new conflict sets
     -- ('empty', 'fromVars', ..) we just record the 'CallStack'; for operations
     -- that construct new conflict sets from existing conflict sets ('union',
-    -- 'filter', ..)  we record the 'CallStack' to the call to the combinator
+    -- 'unions', ..)  we record the 'CallStack' to the call to the combinator
     -- as well as the 'CallStack's of the input conflict sets.
     --
     -- Requires @GHC >= 7.10@.
@@ -154,18 +152,6 @@ singleton var = CS {
 
 member :: Var QPN -> ConflictSet -> Bool
 member var = S.member (simplifyVar var) . conflictSetToSet
-
-filter ::
-#ifdef DEBUG_CONFLICT_SETS
-  (?loc :: CallStack) =>
-#endif
-  (Var QPN -> Bool) -> ConflictSet -> ConflictSet
-filter p cs = CS {
-      conflictSetToSet = S.filter p (conflictSetToSet cs)
-#ifdef DEBUG_CONFLICT_SETS
-    , conflictSetOrigin = Node ?loc [conflictSetOrigin cs]
-#endif
-    }
 
 fromList ::
 #ifdef DEBUG_CONFLICT_SETS

--- a/cabal-install/Distribution/Solver/Modular/ConflictSet.hs
+++ b/cabal-install/Distribution/Solver/Modular/ConflictSet.hs
@@ -48,7 +48,7 @@ import Distribution.Solver.Types.PackagePath
 -- kept abstract.
 data ConflictSet = CS {
     -- | The set of variables involved on the conflict
-    conflictSetToSet :: Set (Var QPN)
+    conflictSetToSet :: Set SimpleVar
 
 #ifdef DEBUG_CONFLICT_SETS
     -- | The origin of the conflict set
@@ -73,21 +73,21 @@ instance Ord ConflictSet where
   compare = compare `on` conflictSetToSet
 
 showCS :: ConflictSet -> String
-showCS = intercalate ", " . map showVar . toList
+showCS = intercalate ", " . map showSimpleVar . toList
 
 showCSWithFrequency :: ConflictMap -> ConflictSet -> String
 showCSWithFrequency cm = intercalate ", " . map showWithFrequency . indexByFrequency
   where
     indexByFrequency = sortBy (flip compare `on` snd) . map (\c -> (c, M.lookup c cm)) . toList
     showWithFrequency (conflict, maybeFrequency) = case maybeFrequency of
-      Just frequency -> showVar conflict ++ " (" ++ show frequency ++ ")"
-      Nothing        -> showVar conflict
+      Just frequency -> showSimpleVar conflict ++ " (" ++ show frequency ++ ")"
+      Nothing        -> showSimpleVar conflict
 
 {-------------------------------------------------------------------------------
   Set-like operations
 -------------------------------------------------------------------------------}
 
-toList :: ConflictSet -> [Var QPN]
+toList :: ConflictSet -> [SimpleVar]
 toList = S.toList . conflictSetToSet
 
 union ::
@@ -165,5 +165,4 @@ fromList vars = CS {
 #endif
     }
 
-type ConflictMap = Map (Var QPN) Int
-
+type ConflictMap = Map SimpleVar Int

--- a/cabal-install/Distribution/Solver/Modular/Dependency.hs
+++ b/cabal-install/Distribution/Solver/Modular/Dependency.hs
@@ -10,6 +10,7 @@ module Distribution.Solver.Modular.Dependency (
   , simplifyVar
   , varPI
   , showVar
+  , showSimpleVar
     -- * Conflict sets
   , ConflictSet
   , ConflictMap

--- a/cabal-install/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install/Distribution/Solver/Modular/Message.hs
@@ -92,7 +92,7 @@ showMessages p sl = go [] 0
     showFailure c fr = "fail" ++ showFR c fr
 
     add :: Var QPN -> [Var QPN] -> [Var QPN]
-    add v vs = simplifyVar v : vs
+    add v vs = v : vs
 
     -- special handler for many subsequent package rejections
     goPReject :: [Var QPN]

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -212,7 +212,7 @@ instance GSimpleTree (Tree d QGoalReason) where
 
       -- Show conflict set
       goCS :: ConflictSet -> String
-      goCS cs = "{" ++ (intercalate "," . L.map showVar . CS.toList $ cs) ++ "}"
+      goCS cs = "{" ++ (intercalate "," . L.map showSimpleVar . CS.toList $ cs) ++ "}"
 #endif
 
 -- | Replace all goal reasons with a dummy goal reason in the tree

--- a/cabal-install/Distribution/Solver/Modular/Var.hs
+++ b/cabal-install/Distribution/Solver/Modular/Var.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DeriveFunctor #-}
 module Distribution.Solver.Modular.Var (
     Var(..)
+  , SimpleVar
   , simplifyVar
   , showVar
+  , showSimpleVar
   , varPI
   ) where
 
@@ -29,15 +31,24 @@ data Var qpn = P qpn | F (FN qpn) | S (SN qpn)
 -- as interdependent. So if one flag of a package ends up in a
 -- conflict set, then all flags are being treated as being part of
 -- the conflict set.
-simplifyVar :: Var qpn -> Var qpn
-simplifyVar (P qpn)       = P qpn
-simplifyVar (F (FN pi _)) = F (FN pi (mkFlag "flag"))
-simplifyVar (S qsn)       = S qsn
+simplifyVar :: Var QPN -> SimpleVar
+simplifyVar (P qpn)       = SimpleP qpn
+simplifyVar (F (FN pi _)) = SimpleF pi
+simplifyVar (S qsn)       = SimpleS qsn
+
+-- | Variables used in conflict sets.
+data SimpleVar = SimpleP QPN | SimpleF (PI QPN) | SimpleS (SN QPN)
+  deriving (Eq, Ord, Show)
 
 showVar :: Var QPN -> String
 showVar (P qpn) = showQPN qpn
 showVar (F qfn) = showQFN qfn
 showVar (S qsn) = showQSN qsn
+
+showSimpleVar :: SimpleVar -> String
+showSimpleVar (SimpleP qpn) = showQPN qpn
+showSimpleVar (SimpleF pi)  = showQFN $ FN pi (mkFlag "flag")
+showSimpleVar (SimpleS qsn) = showQSN qsn
 
 -- | Extract the package instance from a Var
 varPI :: Var QPN -> (QPN, Maybe I)


### PR DESCRIPTION
The solver currently treats all flags in a package as the same variable during
backjumping, in order to simplify the backjumping logic. It does that by
removing the flag names from variables when they are added to conflict sets.

The 'SimpleVar' type should prevent bugs related to mixing up variables with
flag names and variables without flag names.

I also removed a redundant call to 'simplifyVar'.

See #4147.
/cc @kosmikus @fmthoma 