### PR TITLE
Revert "Solver: Add missing call to 'simplifyVar'."

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install/Distribution/Solver/Modular/Explore.hs
@@ -72,7 +72,7 @@ getBestGoal :: ConflictMap -> P.PSQ (Goal QPN) a -> (Goal QPN, a)
 getBestGoal cm =
   P.maximumBy
     ( flip (M.findWithDefault 0) cm
-    . (\ (Goal v _) -> simplifyVar v)
+    . (\ (Goal v _) -> v)
     )
 
 getFirstGoal :: P.PSQ (Goal QPN) a -> (Goal QPN, a)


### PR DESCRIPTION
This reverts commit adc1fe96e06a652f798c7f1ed62b60b9809df383.

See #4152.