### PR TITLE
Have path as the last argument

### DIFF
--- a/Cabal/Distribution/Simple/Program/Strip.hs
+++ b/Cabal/Distribution/Simple/Program/Strip.hs
@@ -27,7 +27,7 @@ import System.FilePath             (takeBaseName)
 runStrip :: Verbosity -> ProgramDb -> FilePath -> [String] -> IO ()
 runStrip verbosity progDb path args =
   case lookupProgram stripProgram progDb of
-    Just strip -> runProgram verbosity strip (path:args)
+    Just strip -> runProgram verbosity strip (args ++ [path])
     Nothing    -> unless (buildOS == Windows) $
                   -- Don't bother warning on windows, we don't expect them to
                   -- have the strip program anyway.


### PR DESCRIPTION
I'm weird person, and sometimes use `POSIX_CORRECTLY`:

```
    /usr/bin/strip: '--strip-unneeded': No such file
```
