### PR TITLE
adding ghc-prof-options to fprof warning

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -1539,7 +1539,7 @@ checkDevelopmentOnlyFlagsBuildInfo bi =
                "-fprof-cafs", "-fno-prof-count-entries",
                "-auto-all", "-auto", "-caf-all"] $
       PackageDistSuspicious $
-           "'ghc-options: -fprof*' profiling flags are typically not "
+           "'ghc-options/ghc-prof-options: -fprof*' profiling flags are typically not "
         ++ "appropriate for a distributed library package. These flags are "
         ++ "useful to profile this package, but when profiling other packages "
         ++ "that use this one these flags clutter the profile output with "


### PR DESCRIPTION
This PR contains an update to cabal check:

Since `-auto-all` is an alias for `-fprof` flag, then the `PackageDistSuspicious` warning should mention `ghc-prof-options` as well.

fixes #3718 
