### PR TITLE
Solver: Check for cycles after every step.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Cycles.hs
+++ b/cabal-install/Distribution/Solver/Modular/Cycles.hs
@@ -87,7 +87,7 @@ findCycles pkg rdm =
     else Nothing
   where
     hasCycle :: Bool
-    hasCycle = pkg `elem` closure (neighbors pkg)
+    hasCycle = pkg `S.member` closure (neighbors pkg)
 
     closure :: [QPN] -> S.Set QPN
     closure = foldl go S.empty

--- a/cabal-install/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install/Distribution/Solver/Modular/Explore.hs
@@ -94,15 +94,15 @@ assign tree = cata go tree $ A M.empty M.empty M.empty
   where
     go :: TreeF d c (Assignment -> Tree Assignment c)
                  -> (Assignment -> Tree Assignment c)
-    go (FailF c fr)            _            = Fail c fr
-    go (DoneF rdm _)           a            = Done rdm a
-    go (PChoiceF qpn y     ts) (A pa fa sa) = PChoice qpn y     $ W.mapWithKey f ts
+    go (FailF c fr)            _                = Fail c fr
+    go (DoneF rdm _)           a                = Done rdm a
+    go (PChoiceF qpn rdm y     ts) (A pa fa sa) = PChoice qpn rdm y     $ W.mapWithKey f ts
         where f (POption k _) r = r (A (M.insert qpn k pa) fa sa)
-    go (FChoiceF qfn y t m ts) (A pa fa sa) = FChoice qfn y t m $ W.mapWithKey f ts
+    go (FChoiceF qfn rdm y t m ts) (A pa fa sa) = FChoice qfn rdm y t m $ W.mapWithKey f ts
         where f k             r = r (A pa (M.insert qfn k fa) sa)
-    go (SChoiceF qsn y t   ts) (A pa fa sa) = SChoice qsn y t   $ W.mapWithKey f ts
+    go (SChoiceF qsn rdm y t   ts) (A pa fa sa) = SChoice qsn rdm y t   $ W.mapWithKey f ts
         where f k             r = r (A pa fa (M.insert qsn k sa))
-    go (GoalChoiceF        ts) a            = GoalChoice $ fmap ($ a) ts
+    go (GoalChoiceF  rdm       ts) a            = GoalChoice  rdm $ fmap ($ a) ts
 
 -- | A tree traversal that simultaneously propagates conflict sets up
 -- the tree from the leaves and creates a log.
@@ -120,22 +120,22 @@ exploreLog enableBj (CountConflicts countConflicts) t = cata go t M.empty
     go (FailF c fr)                          = \ !cm -> failWith (Failure c fr)
                                                                  (c, updateCM c cm)
     go (DoneF rdm a)                         = \ _   -> succeedWith Success (a, rdm)
-    go (PChoiceF qpn gr     ts)              =
+    go (PChoiceF qpn _ gr     ts)            =
       backjump enableBj (P qpn) (avoidSet (P qpn) gr) $ -- try children in order,
         W.mapWithKey                                -- when descending ...
           (\ k r cm -> tryWith (TryP qpn k) (r cm))
           ts
-    go (FChoiceF qfn gr _ _ ts)              =
+    go (FChoiceF qfn _ gr _ _ ts)            =
       backjump enableBj (F qfn) (avoidSet (F qfn) gr) $ -- try children in order,
         W.mapWithKey                                -- when descending ...
           (\ k r cm -> tryWith (TryF qfn k) (r cm))
           ts
-    go (SChoiceF qsn gr _   ts)              =
+    go (SChoiceF qsn _ gr _   ts)            =
       backjump enableBj (S qsn) (avoidSet (S qsn) gr) $ -- try children in order,
         W.mapWithKey                                -- when descending ...
           (\ k r cm -> tryWith (TryS qsn k) (r cm))
           ts
-    go (GoalChoiceF         ts)              = \ cm ->
+    go (GoalChoiceF _       ts)              = \ cm ->
       let (k, v) = getBestGoal' ts cm
       in continueWith (Next k) (v cm)
 

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -74,15 +74,15 @@ validateLinking index = (`runReader` initVS) . cata go
   where
     go :: TreeF d c (Validate (Tree d c)) -> Validate (Tree d c)
 
-    go (PChoiceF qpn gr cs) =
-      PChoice qpn gr     <$> T.sequence (W.mapWithKey (goP qpn) cs)
-    go (FChoiceF qfn gr t m cs) =
-      FChoice qfn gr t m <$> T.sequence (W.mapWithKey (goF qfn) cs)
-    go (SChoiceF qsn gr t cs) =
-      SChoice qsn gr t   <$> T.sequence (W.mapWithKey (goS qsn) cs)
+    go (PChoiceF qpn rdm gr cs) =
+      PChoice qpn rdm gr     <$> T.sequence (W.mapWithKey (goP qpn) cs)
+    go (FChoiceF qfn rdm gr t m cs) =
+      FChoice qfn rdm gr t m <$> T.sequence (W.mapWithKey (goF qfn) cs)
+    go (SChoiceF qsn rdm gr t cs) =
+      SChoice qsn rdm gr t   <$> T.sequence (W.mapWithKey (goS qsn) cs)
 
     -- For the other nodes we just recurse
-    go (GoalChoiceF         cs)       = GoalChoice          <$> T.sequence cs
+    go (GoalChoiceF rdm       cs)     = GoalChoice rdm <$> T.sequence cs
     go (DoneF revDepMap s)            = return $ Done revDepMap s
     go (FailF conflictSet failReason) = return $ Fail conflictSet failReason
 

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -173,10 +173,10 @@ traceTree _ _ = id
 #endif
 
 #ifdef DEBUG_TRACETREE
-instance GSimpleTree (Tree d QGoalReason) where
+instance GSimpleTree (Tree d c) where
   fromGeneric = go
     where
-      go :: Tree d QGoalReason -> SimpleTree
+      go :: Tree d c -> SimpleTree
       go (PChoice qpn _     psq) = Node "P" $ Assoc $ L.map (uncurry (goP qpn)) $ psqToList  psq
       go (FChoice _   _ _ _ psq) = Node "F" $ Assoc $ L.map (uncurry goFS)      $ psqToList  psq
       go (SChoice _   _ _   psq) = Node "S" $ Assoc $ L.map (uncurry goFS)      $ psqToList  psq
@@ -188,16 +188,16 @@ instance GSimpleTree (Tree d QGoalReason) where
       psqToList = L.map (\(_, k, v) -> (k, v)) . W.toList
 
       -- Show package choice
-      goP :: QPN -> POption -> Tree d QGoalReason -> (String, SimpleTree)
+      goP :: QPN -> POption -> Tree d c -> (String, SimpleTree)
       goP _        (POption (I ver _loc) Nothing)  subtree = (T.display ver, go subtree)
       goP (Q _ pn) (POption _           (Just pp)) subtree = (showQPN (Q pp pn), go subtree)
 
       -- Show flag or stanza choice
-      goFS :: Bool -> Tree d QGoalReason -> (String, SimpleTree)
+      goFS :: Bool -> Tree d c -> (String, SimpleTree)
       goFS val subtree = (show val, go subtree)
 
       -- Show goal choice
-      goG :: Goal QPN -> Tree d QGoalReason -> (String, SimpleTree)
+      goG :: Goal QPN -> Tree d c -> (String, SimpleTree)
       goG (Goal var gr) subtree = (showVar var ++ " (" ++ shortGR gr ++ ")", go subtree)
 
       -- Variation on 'showGR' that produces shorter strings
@@ -218,10 +218,10 @@ instance GSimpleTree (Tree d QGoalReason) where
 -- | Replace all goal reasons with a dummy goal reason in the tree
 --
 -- This is useful for debugging (when experimenting with the impact of GRs)
-_removeGR :: Tree d QGoalReason -> Tree d QGoalReason
+_removeGR :: Tree d c -> Tree d QGoalReason
 _removeGR = trav go
   where
-   go :: TreeF d QGoalReason (Tree d QGoalReason) -> TreeF d QGoalReason (Tree d QGoalReason)
+   go :: TreeF d c (Tree d QGoalReason) -> TreeF d QGoalReason (Tree d QGoalReason)
    go (PChoiceF qpn _     psq) = PChoiceF qpn dummy     psq
    go (FChoiceF qfn _ a b psq) = FChoiceF qfn dummy a b psq
    go (SChoiceF qsn _ a   psq) = SChoiceF qsn dummy a   psq

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -75,22 +75,6 @@ data SolverConfig = SolverConfig {
 -- has been added relatively recently. Cycles are only removed directly
 -- before exploration.
 --
--- Semantically, there is no difference. Cycle detection, as implemented
--- now, only occurs for 'Done' nodes we encounter during exploration,
--- and cycle detection itself does not change the shape of the tree,
--- it only marks some 'Done' nodes as 'Fail', if they contain cyclic
--- solutions.
---
--- There is a tiny performance impact, however, in doing cycle detection
--- directly after validation. Probably because cycle detection maintains
--- some information, and the various reorderings implemented by
--- 'preferencesPhase' and 'heuristicsPhase' are ever so slightly more
--- costly if that information is already around during the reorderings.
---
--- With the current positioning directly before the 'explorePhase', there
--- seems to be no statistically significant performance impact of cycle
--- detection in the common case where there are no cycles.
---
 solve :: SolverConfig                         -- ^ solver parameters
       -> CompilerInfo
       -> Index                                -- ^ all available packages as an index
@@ -177,12 +161,12 @@ instance GSimpleTree (Tree d c) where
   fromGeneric = go
     where
       go :: Tree d c -> SimpleTree
-      go (PChoice qpn _     psq) = Node "P" $ Assoc $ L.map (uncurry (goP qpn)) $ psqToList  psq
-      go (FChoice _   _ _ _ psq) = Node "F" $ Assoc $ L.map (uncurry goFS)      $ psqToList  psq
-      go (SChoice _   _ _   psq) = Node "S" $ Assoc $ L.map (uncurry goFS)      $ psqToList  psq
-      go (GoalChoice        psq) = Node "G" $ Assoc $ L.map (uncurry goG)       $ PSQ.toList psq
-      go (Done _rdm _s)          = Node "D" $ Assoc []
-      go (Fail cs _reason)       = Node "X" $ Assoc [("CS", Leaf $ goCS cs)]
+      go (PChoice qpn _ _     psq) = Node "P" $ Assoc $ L.map (uncurry (goP qpn)) $ psqToList  psq
+      go (FChoice _   _ _ _ _ psq) = Node "F" $ Assoc $ L.map (uncurry goFS)      $ psqToList  psq
+      go (SChoice _   _ _ _   psq) = Node "S" $ Assoc $ L.map (uncurry goFS)      $ psqToList  psq
+      go (GoalChoice  _       psq) = Node "G" $ Assoc $ L.map (uncurry goG)       $ PSQ.toList psq
+      go (Done _rdm _s)            = Node "D" $ Assoc []
+      go (Fail cs _reason)         = Node "X" $ Assoc [("CS", Leaf $ goCS cs)]
 
       psqToList :: W.WeightedPSQ w k v -> [(k, v)]
       psqToList = L.map (\(_, k, v) -> (k, v)) . W.toList
@@ -222,12 +206,12 @@ _removeGR :: Tree d c -> Tree d QGoalReason
 _removeGR = trav go
   where
    go :: TreeF d c (Tree d QGoalReason) -> TreeF d QGoalReason (Tree d QGoalReason)
-   go (PChoiceF qpn _     psq) = PChoiceF qpn dummy     psq
-   go (FChoiceF qfn _ a b psq) = FChoiceF qfn dummy a b psq
-   go (SChoiceF qsn _ a   psq) = SChoiceF qsn dummy a   psq
-   go (GoalChoiceF        psq) = GoalChoiceF            (goG psq)
-   go (DoneF rdm s)            = DoneF rdm s
-   go (FailF cs reason)        = FailF cs reason
+   go (PChoiceF qpn rdm _     psq) = PChoiceF qpn rdm dummy     psq
+   go (FChoiceF qfn rdm _ a b psq) = FChoiceF qfn rdm dummy a b psq
+   go (SChoiceF qsn rdm _ a   psq) = SChoiceF qsn rdm dummy a   psq
+   go (GoalChoiceF  rdm       psq) = GoalChoiceF  rdm           (goG psq)
+   go (DoneF rdm s)                = DoneF rdm s
+   go (FailF cs reason)            = FailF cs reason
 
    goG :: PSQ (Goal QPN) (Tree d QGoalReason) -> PSQ (Goal QPN) (Tree d QGoalReason)
    goG = PSQ.fromList

--- a/cabal-install/Distribution/Solver/Modular/Validate.hs
+++ b/cabal-install/Distribution/Solver/Modular/Validate.hs
@@ -106,8 +106,8 @@ validate = cata go
   where
     go :: TreeF d c (Validate (Tree d c)) -> Validate (Tree d c)
 
-    go (PChoiceF qpn gr     ts) = PChoice qpn gr <$> sequence (W.mapWithKey (goP qpn) ts)
-    go (FChoiceF qfn gr b m ts) =
+    go (PChoiceF qpn rdm gr     ts) = PChoice qpn rdm gr <$> sequence (W.mapWithKey (goP qpn) ts)
+    go (FChoiceF qfn rdm gr b m ts) =
       do
         -- Flag choices may occur repeatedly (because they can introduce new constraints
         -- in various places). However, subsequent choices must be consistent. We thereby
@@ -119,8 +119,8 @@ validate = cata go
                        Just t  -> goF qfn rb t
                        Nothing -> return $ Fail (varToConflictSet (F qfn)) (MalformedFlagChoice qfn)
           Nothing -> -- flag choice is new, follow both branches
-                     FChoice qfn gr b m <$> sequence (W.mapWithKey (goF qfn) ts)
-    go (SChoiceF qsn gr b   ts) =
+                     FChoice qfn rdm gr b m <$> sequence (W.mapWithKey (goF qfn) ts)
+    go (SChoiceF qsn rdm gr b   ts) =
       do
         -- Optional stanza choices are very similar to flag choices.
         PA _ _ psa <- asks pa -- obtain current stanza-preassignment
@@ -130,12 +130,12 @@ validate = cata go
                        Just t  -> goS qsn rb t
                        Nothing -> return $ Fail (varToConflictSet (S qsn)) (MalformedStanzaChoice qsn)
           Nothing -> -- stanza choice is new, follow both branches
-                     SChoice qsn gr b <$> sequence (W.mapWithKey (goS qsn) ts)
+                     SChoice qsn rdm gr b <$> sequence (W.mapWithKey (goS qsn) ts)
 
     -- We don't need to do anything for goal choices or failure nodes.
-    go (GoalChoiceF              ts) = GoalChoice <$> sequence ts
-    go (DoneF    rdm s             ) = pure (Done rdm s)
-    go (FailF    c fr              ) = pure (Fail c fr)
+    go (GoalChoiceF rdm            ts) = GoalChoice rdm <$> sequence ts
+    go (DoneF       rdm s            ) = pure (Done rdm s)
+    go (FailF    c fr                ) = pure (Fail c fr)
 
     -- What to do for package nodes ...
     goP :: QPN -> POption -> Validate (Tree d c) -> Validate (Tree d c)


### PR DESCRIPTION
Previously, the solver only checked for cycles after it had already found a
solution. That reduced the number of times that it performed the check in the
common case where there were no cycles. However, when there was a cycle, the
solver could spend a lot of time searching subtrees that already had a cyclic
dependency and therefore could not lead to a solution. This is part of
#3824.

Changes in this commit:
- Store the reverse dependency map on all choice nodes in the search tree, so
  that 'detectCyclesPhase' can access it at every step.
- Check for cycles incrementally at every step. Any new cycle must contain the
  current package, so we just check whether the current package is reachable
  from its neighbors.
- If there is a cycle, we convert the map to a graph and find a strongly
  connected component, as before.
- Instead of using the whole strongly connected component as the conflict set,
  we select one cycle. Smaller conflict sets are better for backjumping.
- The incremental cycle detection automatically fixes a bug where the solver
  filtered out the message about cyclic dependencies when it summarized the full
  log. The bug occurred when the failure message was not immediately after the
  line where the solver chose one of the packages involved in the conflict. See
  #4154.

I tried several approaches and compared performance when solving for
packages with different numbers of dependencies. Here are the results. None of
these runs involved any cycles, so they should have only tested the overhead of
cycle checking. I turned off assertions when building cabal.

Index state: index-state(hackage.haskell.org) = 2016-12-03T17:22:05Z
GHC 8.0.1

Runtime in seconds:

Packages        |            Search tree depth  | Trials |  master  | This PR |  #1 |     #2
------------------|----------------------------------|---------|------------|------------|------|-------
yesod            |           343     |            3  |      2.00  |   2.00  |    2.13 |   2.02
yesod gi-glib leksah     |   744  |               3    |    3.21  |   3.31   |   4.10  |  3.48
phooey              |        66      |            3  |      3.48  |   3.54 |     3.56  |  3.57
Stackage nightly snapshot  | 6791   |             1    |    186   |   193  |     357  |   191

Total memory usage in MB, with '+RTS -s':

Packages                   |                     Trials |  master  |  This PR  | #1  |   #2
----------------------------|------------------------|------------|-------------|------|--------
yesod                                     |      1    |     189  |     188    |   188   |  198
yesod gi-glib leksah                |            1    |     257    |   257    |   263   |  306
Stackage nightly snapshot       |                1    |    1288   |   1338   |   1432 |  12699

#1 - Same as master, but with cycle checking (Data.Graph.stronglyConnComp) after
     every step.
#2 - Store dependencies in Distribution.Compat.Graph in the search tree, and
     check for cycles containing the current package at every step.

/cc @kosmikus 