### PR TITLE
Disable per-components mode for cabal-spec version < 1.8

### DIFF
--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -872,7 +872,7 @@ buildAndInstallUnpackedPackage verbosity
 
     let dispname = case elabPkgOrComp pkg of
             ElabPackage _ -> display pkgid
-                ++ " (all, due to Custom setup)"
+                ++ " (all, legacy fallback)"
             ElabComponent comp -> display pkgid
                 ++ " (" ++ maybe "custom" display (compComponentName comp) ++ ")"
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1142,6 +1142,11 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
             -- type, and teach all of the code paths how to handle it.
             -- Once you've implemented this, swap it for the code below.
             = fromMaybe PD.Custom (PD.buildType (elabPkgDescription elab0)) /= PD.Custom
+            -- cabal-format versions prior to 1.8 have different build-depends semantics
+            -- for now it's easier to just fallback to legacy-mode when specVersion < 1.8
+            -- see, https://github.com/haskell/cabal/issues/4121
+              && PD.specVersion pd >= mkVersion [1,8]
+
             {-
             -- Only non-Custom or sufficiently recent Custom
             -- scripts can be build per-component.


### PR DESCRIPTION
cabal-version semantics prior to 1.8 joined all `build-depends`;
as suggested by @ezyang it's easier for now to just fallback to
legacy mode, than to add proper support for per-components builds
for ancient cabal-spec versions

Fixes #4121