### PR TITLE
Mark `template-haskell` non-upgradable (again)

### DIFF
--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -348,8 +348,14 @@ dontUpgradeNonUpgradeablePackages params =
         (PackageConstraintInstalled pkgname)
         ConstraintSourceNonUpgradeablePackage
       | Set.notMember (mkPackageName "base") (depResolverTargets params)
-      , pkgname <- map mkPackageName [ "base", "ghc-prim", "integer-gmp"
-                                     , "integer-simple" ]
+      -- If you change this enumeration, make sure to update the list in
+      -- "Distribution.Solver.Modular.Solver" as well
+      , pkgname <- [ mkPackageName "base"
+                   , mkPackageName "ghc-prim"
+                   , mkPackageName "integer-gmp"
+                   , mkPackageName "integer-simple"
+                   , mkPackageName "template-haskell"
+                   ]
       , isInstalled pkgname ]
 
     isInstalled = not . null

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -130,11 +130,14 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
                        validateLinking idx .
                        validateTree cinfo idx pkgConfigDB
     prunePhase       = (if asBool (avoidReinstalls sc) then P.avoidReinstalls (const True) else id) .
-                       -- packages that can never be "upgraded":
+                       -- packages that can never be "upgraded"
+                       -- If you change this enumeration, make sure to update the list in
+                       -- "Distribution.Client.Dependency" as well
                        P.requireInstalled (`elem` [ mkPackageName "base"
                                                   , mkPackageName "ghc-prim"
                                                   , mkPackageName "integer-gmp"
                                                   , mkPackageName "integer-simple"
+                                                  , mkPackageName "template-haskell"
                                                   ])
     buildPhase       = traceTree "build.json" id
                      $ buildTree idx (independentGoals sc) (S.toList userGoals)


### PR DESCRIPTION
65e9b88bc849e76040ed7947591ea7172cd02db5 made template-haskell non-upgradable

65ae95c191b19ec1884a4d80afbdaba9c3d477d1 made it upgradable again

...and this commit makes it non-upgradable again

While there may be a few cases when `template-haskell` can be
reinstalled, it's generally not advisable, and causes more harm than the
benefit in the few cases where we'd gain install-plan
flexibility (e.g. when only template-haskell's API is needed for
compile, but no actual TH evaluation takes place).

Closes #4098