### PR TITLE
Refactor Backpack data structures to be less flexible.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -208,6 +208,7 @@ library
     Distribution.Types.BenchmarkType
     Distribution.Types.BuildInfo
     Distribution.Types.BuildType
+    Distribution.Types.ComponentInclude
     Distribution.Types.Dependency
     Distribution.Types.LegacyExeDependency
     Distribution.Types.PkgconfigDependency

--- a/Cabal/Distribution/Backpack/Configure.hs
+++ b/Cabal/Distribution/Backpack/Configure.hs
@@ -38,6 +38,7 @@ import Distribution.ModuleName
 import Distribution.Simple.Setup as Setup
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Types.ComponentRequestedSpec
+import Distribution.Types.ComponentInclude
 import Distribution.Verbosity
 import qualified Distribution.Compat.Graph as Graph
 import Distribution.Compat.Graph (Graph, IsNode(..))
@@ -334,11 +335,13 @@ mkLinkedComponentsLocalBuildInfo comp rcs = map go rcs
             Left _ -> True
             Right _ -> False
       includes =
-        case rc_i rc of
-            Left indefc ->
-                indefc_includes indefc
-            Right instc ->
-                map (\(x,y) -> (DefiniteUnitId x,y)) (instc_includes instc)
+        map (\ci -> (ci_id ci, ci_renaming ci)) $
+            case rc_i rc of
+                Left indefc ->
+                    indefc_includes indefc
+                Right instc ->
+                    map (\ci -> ci { ci_id = DefiniteUnitId (ci_id ci) })
+                        (instc_includes instc)
       internal_deps =
               filter isInternal (nodeNeighbors rc)
            ++ map unDefUnitId (rc_internal_build_tools rc)

--- a/Cabal/Distribution/Backpack/UnifyM.hs
+++ b/Cabal/Distribution/Backpack/UnifyM.hs
@@ -53,6 +53,7 @@ import Distribution.Package
 import Distribution.PackageDescription
 import Distribution.Text
 import Distribution.Types.IncludeRenaming
+import Distribution.Types.ComponentInclude
 import Distribution.Verbosity
 
 import Data.STRef
@@ -361,9 +362,13 @@ data ModuleSourceU s =
 -- | Convert a 'ModuleShape' into a 'ModuleScopeU', so we can do
 -- unification on it.
 convertInclude
-    :: ((OpenUnitId, ModuleShape), PackageId, IncludeRenaming)
-    -> UnifyM s (ModuleScopeU s, (UnitIdU s, PackageId, ModuleRenaming))
-convertInclude ((uid, ModuleShape provs reqs), pid, incl@(IncludeRenaming prov_rns req_rns)) = do
+    :: ComponentInclude (OpenUnitId, ModuleShape) IncludeRenaming
+    -> UnifyM s (ModuleScopeU s, ComponentInclude (UnitIdU s) ModuleRenaming)
+convertInclude (ComponentInclude {
+                    ci_id = (uid, ModuleShape provs reqs),
+                    ci_pkgid = pid,
+                    ci_renaming = incl@(IncludeRenaming prov_rns req_rns)
+               }) = do
     let pn = packageName pid
 
     -- Suppose our package has two requirements A and B, and
@@ -467,7 +472,7 @@ convertInclude ((uid, ModuleShape provs reqs), pid, incl@(IncludeRenaming prov_r
 
     provs_u <- convertModuleProvides prov_scope
 
-    return ((provs_u, reqs_u), (uid_u, pid, prov_rns'))
+    return ((provs_u, reqs_u), ComponentInclude uid_u pid prov_rns')
 
 -- | Convert a 'ModuleScopeU' to a 'ModuleScope'.
 convertModuleScopeU :: ModuleScopeU s -> UnifyM s ModuleScope

--- a/Cabal/Distribution/Types/ComponentInclude.hs
+++ b/Cabal/Distribution/Types/ComponentInclude.hs
@@ -1,0 +1,15 @@
+module Distribution.Types.ComponentInclude (
+    ComponentInclude(..)
+) where
+
+import Distribution.Package
+
+-- Once ci_id is refined to an 'OpenUnitId' or 'DefUnitId',
+-- the 'includeRequiresRn' is not so useful (because it
+-- includes the requirements renaming that is no longer
+-- needed); use 'ci_prov_renaming' instead.
+data ComponentInclude id rn = ComponentInclude {
+        ci_id       :: id,
+        ci_pkgid    :: PackageId,
+        ci_renaming :: rn
+    }

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -124,6 +124,7 @@ import           Distribution.Backpack.ComponentsGraph
 import           Distribution.Backpack.ModuleShape
 import           Distribution.Backpack.FullUnitId
 import           Distribution.Backpack
+import           Distribution.Types.ComponentInclude
 
 import           Distribution.Simple.Utils hiding (matchFileGlob)
 import           Distribution.Version
@@ -1208,9 +1209,9 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                     elabComponentId = lc_cid lc,
                     elabLinkedInstantiatedWith = Map.fromList (lc_insts lc),
                     elabPkgOrComp = ElabComponent $ elab_comp {
-                        compLinkedLibDependencies = map fst (lc_depends lc),
+                        compLinkedLibDependencies = ordNub (map ci_id (lc_includes lc)),
                         compNonSetupDependencies =
-                            ordNub (map (abstractUnitId . fst) (lc_depends lc))
+                            ordNub (map (abstractUnitId . ci_id) (lc_includes lc))
                       }
                    }
                 inplace_bin_dir
@@ -1263,7 +1264,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
             -- 'elab'.
             compLibDependencies =
                 -- concatMap (elaborateLibSolverId mapDep) external_lib_dep_sids
-                ordNub (map (\(dep_cid, dep_pid, _) -> ConfiguredId dep_pid dep_cid) (cc_includes cc))
+                ordNub (map (\ci -> ConfiguredId (ci_pkgid ci) (ci_id ci)) (cc_includes cc))
             compExeDependencies =
                 map confInstId
                     (concatMap (elaborateExeSolverId mapDep) external_exe_dep_sids) ++


### PR DESCRIPTION
There were a number of fields in 'LinkedComponent' which
were "too" flexible, in that they were fully determined by
other fields in the structure.  This refactor deletes those
fields and replaces them with functions that refer to the
fields directly.

I also introduce a new type, ComponentInclude, to take
the place of tuples which were used to represent includes
(mixins) in Backpack.

There's also more documentation for lots of bits.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>