### PR TITLE
Don't compile signature packages with instantiations.

### DIFF
--- a/Cabal/Distribution/Backpack/ReadyComponent.hs
+++ b/Cabal/Distribution/Backpack/ReadyComponent.hs
@@ -317,7 +317,7 @@ toReadyComponents pid_map subst0 comps
             let indefc = IndefiniteComponent {
                         indefc_requires = map fst (lc_insts lc),
                         indefc_provides = modShapeProvides (lc_shape lc),
-                        indefc_includes = lc_includes lc
+                        indefc_includes = lc_includes lc ++ lc_sig_includes lc
                     }
             return $ Just ReadyComponent {
                     rc_uid          = uid,

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -336,10 +336,7 @@ rebuildInstallPlan verbosity
                                                    localPackages
 
           phaseMaintainPlanOutputs elaboratedPlan elaboratedShared
-          let instantiatedPlan = phaseInstantiatePlan elaboratedPlan
-          liftIO $ debugNoWrap verbosity (InstallPlan.showInstallPlan instantiatedPlan)
-
-          return (instantiatedPlan, elaboratedShared, projectConfig)
+          return (elaboratedPlan, elaboratedShared, projectConfig)
 
       -- The improved plan changes each time we install something, whereas
       -- the underlying elaborated plan only changes when input config
@@ -588,16 +585,13 @@ rebuildInstallPlan verbosity
                 projectConfigShared
                 projectConfigLocalPackages
                 (getMapMappend projectConfigSpecificPackage)
-        liftIO $ debugNoWrap verbosity (InstallPlan.showInstallPlan elaboratedPlan)
-        return (elaboratedPlan, elaboratedShared)
+        let instantiatedPlan = instantiateInstallPlan elaboratedPlan
+        liftIO $ debugNoWrap verbosity (InstallPlan.showInstallPlan instantiatedPlan)
+        return (instantiatedPlan, elaboratedShared)
       where
         withRepoCtx = projectConfigWithSolverRepoContext verbosity
                         projectConfigShared
                         projectConfigBuildOnly
-
-    phaseInstantiatePlan :: ElaboratedInstallPlan
-                         -> ElaboratedInstallPlan
-    phaseInstantiatePlan plan = instantiateInstallPlan plan
 
     -- Update the files we maintain that reflect our current build environment.
     -- In particular we maintain a JSON representation of the elaborated
@@ -1203,6 +1197,10 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
             -- Fortunately this is "stable" part of Cabal API.
             -- But the way we get the build directory is A HORRIBLE
             -- HACK.
+            -- NB: elab is setup to be the correct form for an
+            -- indefinite library, or a definite library with no holes.
+            -- We will modify it in 'instantiateInstallPlan' to handle
+            -- instantiated packages.
             let elab = elab1 {
                     elabModuleShape = lc_shape lc,
                     elabUnitId      = abstractUnitId (lc_uid lc),
@@ -1211,7 +1209,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                     elabPkgOrComp = ElabComponent $ elab_comp {
                         compLinkedLibDependencies = ordNub (map ci_id (lc_includes lc)),
                         compNonSetupDependencies =
-                            ordNub (map (abstractUnitId . ci_id) (lc_includes lc))
+                          ordNub (map (abstractUnitId . ci_id) (lc_includes lc ++ lc_sig_includes lc))
                       }
                    }
                 inplace_bin_dir
@@ -1831,16 +1829,7 @@ instantiateInstallPlan plan =
     indefiniteComponent :: UnitId -> ComponentId -> InstM ElaboratedPlanPackage
     indefiniteComponent _uid cid
       | Just planpkg <- Map.lookup cid cmap
-      = case planpkg of
-          InstallPlan.Configured elab@ElaboratedConfiguredPackage
-                { elabPkgOrComp = ElabComponent comp } ->
-            return $ InstallPlan.Configured elab {
-                    elabPkgOrComp = ElabComponent comp {
-                            compNonSetupDependencies =
-                                ordNub (map abstractUnitId (compLinkedLibDependencies comp))
-                        }
-                }
-          _ -> return planpkg -- shouldn't happen
+      = return planpkg
       | otherwise = error ("indefiniteComponent: " ++ display cid)
 
     ready_map = execState work Map.empty

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -425,11 +425,15 @@ data ElaboratedComponent
     -- | The *external* library dependencies of this component.  We
     -- pass this to the configure script.
     compLibDependencies :: [ConfiguredId],
-    -- | The linked dependencies of the component which combined with the
-    -- substitution in 'elabComponentId' specify the dependencies we
-    -- care about from the perspective of ORDERING builds.  It's more
-    -- precise than 'compLibDependencies', and also stores information
-    -- about internal dependencies.
+    -- | In a component prior to instantiation, this list specifies
+    -- the 'OpenUnitId's which, after instantiation, are the
+    -- actual dependencies of this package.  Note that this does
+    -- NOT include signature packages, which do not turn into real
+    -- ordering dependencies when we instantiate.  This is intended to be
+    -- a purely temporary field, to carry some information to the
+    -- instantiation phase. It's more precise than
+    -- 'compLibDependencies', and also stores information about internal
+    -- dependencies.
     compLinkedLibDependencies :: [OpenUnitId],
     -- | The executable dependencies of this component (including
     -- internal executables).


### PR DESCRIPTION
A signature package is a package that contains only signatures but no
modules (equivalently, it is a package that has no provisions.)

Previously, we did not treat signature packages any differently from
normal packages, which, in particular, meant that when we instantiated a
package using a signature package, we also instantiated the signature
package.  This is actually pretty useless, because we never actually use
the instantiated signature (there's no code that actually gets compiled
in this case).

This patch treats signature packages specially, so that we don't
actually instantiate dependencies on them.  This means we have
to compile less packages when handling signatures.  Good!

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>