### PR TITLE
Corrected version lower bound on 'directory' dependency.

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -372,7 +372,7 @@ executable cabal
       build-depends: directory >= 1.1 && < 1.2, old-time >= 1 && < 1.2,
                      process   >= 1.0.1.1  && < 1.1.0.2
     else
-      build-depends: directory >= 1.2 && < 1.4,
+      build-depends: directory >= 1.2.2.0 && < 1.4,
                      process   >= 1.1.0.2  && < 1.5
 
     -- NOTE: you MUST include the network dependency even when network-uri


### PR DESCRIPTION
Needed for the use of System.Directory.makeAbsolute in Distribution.Client.Nix.

I have not modified bootstrap.sh, as it did not appear to contain any reference to the directory package. Have I missed anything here?