### PR TITLE
Qualified constraints (issue #3502)

### DIFF
--- a/cabal-install/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/Distribution/Client/CmdFreeze.hs
@@ -13,7 +13,9 @@ import Distribution.Client.ProjectConfig
          , commandLineFlagsToProjectConfig, writeProjectLocalFreezeConfig
          , findProjectRoot, getProjectFileName )
 import Distribution.Client.Targets
-         ( UserConstraint(..) )
+         ( UserQualifier(..), UserConstraint(..) )
+import Distribution.Solver.Types.PackageConstraint
+         ( PackageProperty(..) )
 import Distribution.Solver.Types.ConstraintSource
          ( ConstraintSource(..) )
 import Distribution.Client.DistDirLayout
@@ -148,7 +150,8 @@ projectFreezeConstraints plan =
     versionConstraints :: Map PackageName [(UserConstraint, ConstraintSource)]
     versionConstraints =
       Map.mapWithKey
-        (\p v -> [(UserConstraintVersion p v, ConstraintSourceFreeze)])
+        (\p v -> [(UserConstraint UserUnqualified p (PackagePropertyVersion v),
+                   ConstraintSourceFreeze)])
         versionRanges
 
     versionRanges :: Map PackageName VersionRange
@@ -165,7 +168,8 @@ projectFreezeConstraints plan =
     flagConstraints :: Map PackageName [(UserConstraint, ConstraintSource)]
     flagConstraints =
       Map.mapWithKey
-        (\p f -> [(UserConstraintFlags p f, ConstraintSourceFreeze)])
+        (\p f -> [(UserConstraint UserUnqualified p (PackagePropertyFlags f),
+                   ConstraintSourceFreeze)])
         flagAssignments
 
     flagAssignments :: Map PackageName FlagAssignment
@@ -201,7 +205,7 @@ projectFreezeConstraints plan =
               else Just constraints)
 #endif
 
-    isVersionConstraint UserConstraintVersion{} = True
+    isVersionConstraint (UserConstraint _ _ (PackagePropertyVersion _)) = True
     isVersionConstraint _                       = False
 
     localPackages :: Map PackageName ()

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -335,15 +335,17 @@ planLocalPackage verbosity comp platform configFlags configExFlags
 
         . addConstraints
             -- package flags from the config file or command line
-            [ let pc = PackageConstraintFlags (packageName pkg)
-                       (configConfigurationsFlags configFlags)
+            [ let pc = PackageConstraint
+                       (unqualified $ packageName pkg)
+                       (PackagePropertyFlags $ configConfigurationsFlags configFlags)
               in LabeledPackageConstraint pc ConstraintSourceConfigFlagOrTarget
             ]
 
         . addConstraints
             -- '--enable-tests' and '--enable-benchmarks' constraints from
             -- the config file or command line
-            [ let pc = PackageConstraintStanzas (packageName pkg) $
+            [ let pc = PackageConstraint (unqualified $ packageName pkg) .
+                       PackagePropertyStanzas $
                        [ TestStanzas  | testsEnabled ] ++
                        [ BenchStanzas | benchmarksEnabled ]
               in LabeledPackageConstraint pc ConstraintSourceConfigFlagOrTarget

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -248,8 +248,8 @@ freezePackages verbosity globalFlags pkgs = do
         (pkgIdToConstraint $ packageId pkg, ConstraintSourceUserConfig userPackageEnvironmentFile)
       where
         pkgIdToConstraint pkgId =
-            UserConstraintVersion (packageName pkgId)
-                                  (thisVersion $ packageVersion pkgId)
+            UserConstraint UserUnqualified (packageName pkgId)
+                           (PackagePropertyVersion $ thisVersion (packageVersion pkgId))
     createPkgEnv config = mempty { pkgEnvSavedConfig = config }
     showPkgEnv = BS.Char8.pack . showPackageEnvironment
 

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -181,7 +181,8 @@ planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
 
       . addConstraints
           [ let pkg = pkgSpecifierTarget pkgSpecifier
-                pc = PackageConstraintStanzas pkg stanzas
+                pc = PackageConstraint (unqualified pkg)
+                                       (PackagePropertyStanzas stanzas)
             in LabeledPackageConstraint pc ConstraintSourceFreeze
           | pkgSpecifier <- pkgSpecifiers ]
 

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -407,16 +407,18 @@ planPackages comp platform mSandboxPkgInfo solver
       . addConstraints
           --FIXME: this just applies all flags to all targets which
           -- is silly. We should check if the flags are appropriate
-          [ let pc = PackageConstraintFlags
-                     (pkgSpecifierTarget pkgSpecifier) flags
+          [ let pc = PackageConstraint
+                     (unqualified $ pkgSpecifierTarget pkgSpecifier)
+                     (PackagePropertyFlags flags)
             in LabeledPackageConstraint pc ConstraintSourceConfigFlagOrTarget
           | let flags = configConfigurationsFlags configFlags
           , not (null flags)
           , pkgSpecifier <- pkgSpecifiers ]
 
       . addConstraints
-          [ let pc = PackageConstraintStanzas
-                     (pkgSpecifierTarget pkgSpecifier) stanzas
+          [ let pc = PackageConstraint
+                     (unqualified $ pkgSpecifierTarget pkgSpecifier)
+                     (PackagePropertyStanzas stanzas)
             in LabeledPackageConstraint pc ConstraintSourceConfigFlagOrTarget
           | pkgSpecifier <- pkgSpecifiers ]
 
@@ -775,8 +777,8 @@ reportPlanningFailure verbosity
 theSpecifiedPackage :: Package pkg => PackageSpecifier pkg -> Maybe PackageId
 theSpecifiedPackage pkgSpec =
   case pkgSpec of
-    NamedPackage name [PackageConstraintVersion name' version]
-      | name == name' -> PackageIdentifier name <$> trivialRange version
+    NamedPackage name [PackageConstraint name' (PackagePropertyVersion version)]
+      | name' == unqualified name -> PackageIdentifier name <$> trivialRange version
     NamedPackage _ _ -> Nothing
     SpecificSourcePackage pkg -> Just $ packageId pkg
   where

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -777,8 +777,8 @@ reportPlanningFailure verbosity
 theSpecifiedPackage :: Package pkg => PackageSpecifier pkg -> Maybe PackageId
 theSpecifiedPackage pkgSpec =
   case pkgSpec of
-    NamedPackage name [PackageConstraint name' (PackagePropertyVersion version)]
-      | name' == unqualified name -> PackageIdentifier name <$> trivialRange version
+    NamedPackage name [PackagePropertyVersion version]
+      -> PackageIdentifier name <$> trivialRange version
     NamedPackage _ _ -> Nothing
     SpecificSourcePackage pkg -> Just $ packageId pkg
   where

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -238,7 +238,7 @@ info verbosity packageDBs repoCtxt comp progdb
                          -- supplied a non-trivial version constraint
         showPkgVersion = not (null verConstraints)
         verConstraint  = foldr intersectVersionRanges anyVersion verConstraints
-        verConstraints = [ vr | PackageConstraintVersion _ vr <- constraints ]
+        verConstraints = [ vr | PackageConstraint _ (PackagePropertyVersion vr) <- constraints ]
 
     gatherPkgInfo prefs installedPkgIndex sourcePkgIndex
       (SpecificSourcePackage pkg) =

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -213,7 +213,7 @@ info verbosity packageDBs repoCtxt comp progdb
                      PackageSpecifier UnresolvedSourcePackage ->
                      Either String PackageDisplayInfo
     gatherPkgInfo prefs installedPkgIndex sourcePkgIndex
-      (NamedPackage name constraints)
+      (NamedPackage name props)
       | null (selectedInstalledPkgs) && null (selectedSourcePkgs)
       = Left $ "There is no available version of " ++ display name
             ++ " that satisfies "
@@ -238,7 +238,7 @@ info verbosity packageDBs repoCtxt comp progdb
                          -- supplied a non-trivial version constraint
         showPkgVersion = not (null verConstraints)
         verConstraint  = foldr intersectVersionRanges anyVersion verConstraints
-        verConstraints = [ vr | PackageConstraint _ (PackagePropertyVersion vr) <- constraints ]
+        verConstraints = [ vr | PackagePropertyVersion vr <- props ]
 
     gatherPkgInfo prefs installedPkgIndex sourcePkgIndex
       (SpecificSourcePackage pkg) =

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -983,7 +983,8 @@ planPackages comp platform solver SolverSettings{..}
       . addConstraints
           -- enable stanza constraints where the user asked to enable
           [ LabeledPackageConstraint
-              (PackageConstraintStanzas pkgname stanzas)
+              (PackageConstraint (unqualified pkgname)
+                                 (PackagePropertyStanzas stanzas))
               ConstraintSourceConfigFlagOrTarget
           | pkg <- localPackages
           , let pkgname = packageName pkg
@@ -997,7 +998,8 @@ planPackages comp platform solver SolverSettings{..}
           --TODO: [nice to have] should have checked at some point that the
           -- package in question actually has these flags.
           [ LabeledPackageConstraint
-              (PackageConstraintFlags pkgname flags)
+              (PackageConstraint (unqualified pkgname)
+                                 (PackagePropertyFlags flags))
               ConstraintSourceConfigFlagOrTarget
           | (pkgname, flags) <- Map.toList solverSettingFlagAssignments ]
 
@@ -1007,7 +1009,8 @@ planPackages comp platform solver SolverSettings{..}
           -- former we just apply all these flags to all local targets which
           -- is silly. We should check if the flags are appropriate.
           [ LabeledPackageConstraint
-              (PackageConstraintFlags pkgname flags)
+              (PackageConstraint (unqualified pkgname) 
+                                 (PackagePropertyFlags flags))
               ConstraintSourceConfigFlagOrTarget
           | let flags = solverSettingFlagAssignment
           , not (null flags)

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -754,15 +754,18 @@ instance Text UserConstraint where
                        
     -- Package property
     let keyword str x = Parse.skipSpaces1 >> Parse.string str >> return x
-    prop <- (parse >>= return . PackagePropertyVersion)
-            +++
-            keyword "installed" PackagePropertyInstalled
-            +++
-            keyword "source" PackagePropertySource
-            +++
-            keyword "test" (PackagePropertyStanzas [TestStanzas])
-            +++
-            keyword "bench" (PackagePropertyStanzas [BenchStanzas])
+    prop <- ((parse >>= return . PackagePropertyVersion)
+             +++
+             keyword "installed" PackagePropertyInstalled
+             +++
+             keyword "source" PackagePropertySource
+             +++
+             keyword "test" (PackagePropertyStanzas [TestStanzas])
+             +++
+             keyword "bench" (PackagePropertyStanzas [BenchStanzas]))
+            -- Note: the parser is left-biased here so that we
+            -- don't get an ambiguous parse from 'installed',
+            -- 'source', etc. being regarded as flags.
             <++
             (Parse.skipSpaces1 >> parseFlagAssignment
              >>= return . PackagePropertyFlags)

--- a/cabal-install/Distribution/Solver/Modular.hs
+++ b/cabal-install/Distribution/Solver/Modular.hs
@@ -31,6 +31,7 @@ import Distribution.Solver.Modular.Solver
          ( SolverConfig(..), solve )
 import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.PackageConstraint
+import Distribution.Solver.Types.PackagePath
 import Distribution.Solver.Types.DependencyResolver
 import Distribution.System
          ( Platform(..) )
@@ -59,8 +60,4 @@ modularResolver sc (Platform arch os) cinfo iidx sidx pkgConfigDB pprefs pcs pns
 
       -- Helper function to extract the PN from a constraint.
       pcName :: PackageConstraint -> PN
-      pcName (PackageConstraintVersion   pn _) = pn
-      pcName (PackageConstraintInstalled pn  ) = pn
-      pcName (PackageConstraintSource    pn  ) = pn
-      pcName (PackageConstraintFlags     pn _) = pn
-      pcName (PackageConstraintStanzas   pn _) = pn
+      pcName (PackageConstraint (Q _ pn) _) = pn

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -162,13 +162,13 @@ processPackageConstraintP pp _ _ (LabeledPackageConstraint _ src) r
 
 processPackageConstraintP _ c i (LabeledPackageConstraint pc src) r = go i pc
   where
-    go (I v _) (PackageConstraintVersion _ vr)
+    go (I v _) (PackageConstraint _ (PackagePropertyVersion vr))
         | checkVR vr v  = r
         | otherwise     = Fail c (GlobalConstraintVersion vr src)
-    go _       (PackageConstraintInstalled _)
+    go _       (PackageConstraint _ PackagePropertyInstalled)
         | instI i       = r
         | otherwise     = Fail c (GlobalConstraintInstalled src)
-    go _       (PackageConstraintSource    _)
+    go _       (PackageConstraint _ PackagePropertySource)
         | not (instI i) = r
         | otherwise     = Fail c (GlobalConstraintSource src)
     go _       _ = r
@@ -185,7 +185,7 @@ processPackageConstraintF :: Flag
                           -> Tree d c
 processPackageConstraintF f c b' (LabeledPackageConstraint pc src) r = go pc
   where
-    go (PackageConstraintFlags _ fa) =
+    go (PackageConstraint _ (PackagePropertyFlags fa)) =
         case L.lookup f fa of
           Nothing            -> r
           Just b | b == b'   -> r
@@ -204,7 +204,7 @@ processPackageConstraintS :: OptionalStanza
                           -> Tree d c
 processPackageConstraintS s c b' (LabeledPackageConstraint pc src) r = go pc
   where
-    go (PackageConstraintStanzas _ ss) =
+    go (PackageConstraint _ (PackagePropertyStanzas ss)) =
         if not b' && s `elem` ss then Fail c (GlobalConstraintFlag src)
                                  else r
     go _                               = r

--- a/cabal-install/Distribution/Solver/Types/PackagePath.hs
+++ b/cabal-install/Distribution/Solver/Types/PackagePath.hs
@@ -2,13 +2,18 @@ module Distribution.Solver.Types.PackagePath
     ( PackagePath(..)
     , Namespace(..)
     , Qualifier(..)
-    , QPN
+    , dispQualifier
     , Qualified(..)
+    , unqualified
+    , QPN
+    , dispQPN
     , showQPN
     ) where
 
 import Distribution.Package
 import Distribution.Text
+import qualified Text.PrettyPrint as Disp
+import Distribution.Client.Compat.Prelude ((<<>>))
 
 -- | A package path consists of a namespace and a package path inside that
 -- namespace.
@@ -28,6 +33,12 @@ data Namespace =
     -- For now we just number these (rather than giving them more structure).
   | Independent Int
   deriving (Eq, Ord, Show)
+
+-- | Pretty-prints a namespace. The result is either empty or
+-- ends in a period, so it can be prepended onto a package name.
+dispNamespace :: Namespace -> Disp.Doc
+dispNamespace DefaultNamespace = Disp.empty
+dispNamespace (Independent i) = Disp.int i <<>> Disp.text "."
 
 -- | Qualifier of a package within a namespace (see 'PackagePath')
 data Qualifier =
@@ -61,39 +72,37 @@ data Qualifier =
   | Exe PackageName PackageName
   deriving (Eq, Ord, Show)
 
--- | String representation of a package path.
+-- | Pretty-prints a qualifier. The result is either empty or
+-- ends in a period, so it can be prepended onto a package name.
 --
--- NOTE: The result of 'showPP' is either empty or results in a period, so that
--- it can be prepended to a package name.
-showPP :: PackagePath -> String
-showPP (PackagePath ns q) =
-    case ns of
-      DefaultNamespace -> go q
-      Independent i    -> show i ++ "." ++ go q
-  where
-    -- Print the qualifier
-    --
-    -- NOTE: the base qualifier is for a dependency _on_ base; the qualifier is
-    -- there to make sure different dependencies on base are all independent.
-    -- So we want to print something like @"A.base"@, where the @"A."@ part
-    -- is the qualifier and @"base"@ is the actual dependency (which, for the
-    -- 'Base' qualifier, will always be @base@).
-    go Unqualified = ""
-    go (Setup pn)  = display pn ++ "-setup."
-    go (Exe   pn pn2) = display pn ++ "-" ++ display pn2 ++ "-exe."
-    go (Base  pn)  = display pn ++ "."
+-- NOTE: the base qualifier is for a dependency _on_ base; the qualifier is
+-- there to make sure different dependencies on base are all independent.
+-- So we want to print something like @"A.base"@, where the @"A."@ part
+-- is the qualifier and @"base"@ is the actual dependency (which, for the
+-- 'Base' qualifier, will always be @base@).
+dispQualifier :: Qualifier -> Disp.Doc
+dispQualifier Unqualified = Disp.empty
+dispQualifier (Setup pn)  = disp pn <<>> Disp.text ":setup."
+dispQualifier (Exe pn pn2) = disp pn <<>> Disp.text ":" <<>>
+                             disp pn2 <<>> Disp.text ":exe."
+dispQualifier (Base pn)  = disp pn <<>> Disp.text "."
 
 -- | A qualified entity. Pairs a package path with the entity.
 data Qualified a = Q PackagePath a
   deriving (Eq, Ord, Show)
 
--- | Standard string representation of a qualified entity.
-showQ :: (a -> String) -> (Qualified a -> String)
-showQ showa (Q pp x) = showPP pp ++ showa x
+-- | Marks the entity as a top-level dependency in the default namespace.
+unqualified :: a -> Qualified a
+unqualified = Q (PackagePath DefaultNamespace Unqualified)
 
 -- | Qualified package name.
 type QPN = Qualified PackageName
 
--- | String representation of a qualified package path.
+-- | Pretty-prints a qualified package name.
+dispQPN :: QPN -> Disp.Doc
+dispQPN (Q (PackagePath ns qual) pn) =
+  dispNamespace ns <<>> dispQualifier qual <<>> disp pn
+
+-- | String representation of a qualified package name.
 showQPN :: QPN -> String
-showQPN = showQ display
+showQPN = Disp.renderStyle flatStyle . dispQPN

--- a/cabal-install/Distribution/Solver/Types/PackagePath.hs
+++ b/cabal-install/Distribution/Solver/Types/PackagePath.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Distribution.Solver.Types.PackagePath
     ( PackagePath(..)
     , Namespace(..)
@@ -14,11 +15,15 @@ import Distribution.Package
 import Distribution.Text
 import qualified Text.PrettyPrint as Disp
 import Distribution.Client.Compat.Prelude ((<<>>))
+import GHC.Generics (Generic)
+import Distribution.Compat.Binary (Binary)
 
 -- | A package path consists of a namespace and a package path inside that
 -- namespace.
 data PackagePath = PackagePath Namespace Qualifier
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+           
+instance Binary PackagePath
 
 -- | Top-level namespace
 --
@@ -32,7 +37,9 @@ data Namespace =
     --
     -- For now we just number these (rather than giving them more structure).
   | Independent Int
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+           
+instance Binary Namespace
 
 -- | Pretty-prints a namespace. The result is either empty or
 -- ends in a period, so it can be prepended onto a package name.
@@ -70,7 +77,9 @@ data Qualifier =
     -- tracked only @pn2@, that would require us to pick only one
     -- version of an executable over the entire install plan.)
   | Exe PackageName PackageName
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+           
+instance Binary Qualifier
 
 -- | Pretty-prints a qualifier. The result is either empty or
 -- ends in a period, so it can be prepended onto a package name.
@@ -89,7 +98,9 @@ dispQualifier (Base pn)  = disp pn <<>> Disp.text "."
 
 -- | A qualified entity. Pairs a package path with the entity.
 data Qualified a = Q PackagePath a
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+           
+instance Binary a => Binary (Qualified a)
 
 -- | Marks the entity as a top-level dependency in the default namespace.
 unqualified :: a -> Qualified a

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -566,16 +566,6 @@ instance Arbitrary RemoteRepo where
 
 instance Arbitrary UserConstraint where
     arbitrary =
-      oneof
-        [ UserConstraintVersion   <$> arbitrary <*> arbitrary
-        , UserConstraintInstalled <$> arbitrary
-        , UserConstraintSource    <$> arbitrary
-        , UserConstraintFlags     <$> arbitrary <*> shortListOf1 3 arbitrary
-        , UserConstraintStanzas   <$> arbitrary <*> ((\x->[x]) <$> arbitrary)
-        ]
-
-instance Arbitrary UserConstraint where
-    arbitrary =
       oneof [ UserConstraint UserUnqualified <$> arbitrary <*> prop
             | prop <- [ PackagePropertyVersion <$> arbitrary
                       , pure PackagePropertyInstalled

--- a/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
@@ -2,11 +2,14 @@ module UnitTests.Distribution.Client.Targets (
   tests
   ) where
 
-import Distribution.Client.Targets     (UserConstraint (..), readUserConstraint)
+import Distribution.Client.Targets     (UserQualifier(..), UserConstraint(..)
+                                       ,readUserConstraint)
 import Distribution.Compat.ReadP       (ReadP, readP_to_S)
 import Distribution.Package            (mkPackageName)
 import Distribution.ParseUtils         (parseCommaList)
 import Distribution.Text               (parse)
+
+import Distribution.Solver.Types.PackageConstraint (PackageProperty(..))
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -26,7 +29,8 @@ readUserConstraintTest =
     pkgName  = "template-haskell"
     constr   = pkgName ++ " installed"
 
-    expected = UserConstraintInstalled (mkPackageName pkgName)
+    expected = UserConstraint UserUnqualified (mkPackageName pkgName)
+                              PackagePropertyInstalled
     actual   = let (Right r) = readUserConstraint constr in r
 
 parseUserConstraintTest :: Assertion
@@ -36,7 +40,8 @@ parseUserConstraintTest =
     pkgName  = "template-haskell"
     constr   = pkgName ++ " installed"
 
-    expected = [UserConstraintInstalled (mkPackageName pkgName)]
+    expected = [UserConstraint UserUnqualified (mkPackageName pkgName)
+                               PackagePropertyInstalled]
     actual   = [ x | (x, ys) <- readP_to_S parseUserConstraint constr
                    , all isSpace ys]
 
@@ -50,7 +55,8 @@ readUserConstraintsTest =
     pkgName  = "template-haskell"
     constr   = pkgName ++ " installed"
 
-    expected = [[UserConstraintInstalled (mkPackageName pkgName)]]
+    expected = [[UserConstraint UserUnqualified (mkPackageName pkgName)
+                                PackagePropertyInstalled]]
     actual   = [ x | (x, ys) <- readP_to_S parseUserConstraints constr
                    , all isSpace ys]
 

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -546,8 +546,9 @@ exResolve db exts langs pkgConfigDb targets solver mbj indepGoals reorder
                      , packagePreferences = Map.empty
                      }
     enableTests
-        | asBool enableAllTests = fmap (\p -> PackageConstraintStanzas
-                                              (C.mkPackageName p) [TestStanzas])
+        | asBool enableAllTests = fmap (\p -> PackageConstraint
+                                              (unqualified (C.mkPackageName p))
+                                              (PackagePropertyStanzas [TestStanzas]))
                                        (exDbPkgs db)
         | otherwise             = []
     targets'     = fmap (\p -> NamedPackage (C.mkPackageName p) []) targets


### PR DESCRIPTION
The main changes are:

1. Updated the syntax of qualifiers in PackagePath.hs to use colon as a separator rather than hyphen.
2. Changed PackageName to QPN in PackageConstraint.
3. Added 'UserQualifier' into UserConstraint.

The only difference to the overall behaviour of cabal due to this patch is that qualified constraints will be parsed on the command line. Currently the solver etc. just ignores these qualifiers, however everything should be all set now to make the solver act on them.

One last thing: I'm going to add some new unit tests for the UserConstraint parser, but if it's okay I'll leave that till the next submission to stop this one getting too big.