### PR TITLE
Remove makeAbsolute

### DIFF
--- a/Cabal/shell.nix
+++ b/Cabal/shell.nix
@@ -1,0 +1,1 @@
+(import ../.).Cabal.env

--- a/cabal-install/shell.nix
+++ b/cabal-install/shell.nix
@@ -1,0 +1,1 @@
+(import ../.).cabal-install.env


### PR DESCRIPTION
Replaces #4208. We do not actually care about canonicity of paths, but
makeAbsolute is not available in older versions of directory.