### PR TITLE
Add flag to allow the dependency solver to install any package (issue #4209).

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -1710,6 +1710,21 @@ Most users generally won't need these.
 
     The command line variant of this field is ``--(no-)strong-flags``.
 
+.. cfg-field:: install-base-libraries: boolean
+               --install-base-libraries
+               --no-install-base-libraries
+    :synopsis: Allow cabal to install or upgrade any package.
+
+    :default: False
+
+    By default, the dependency solver doesn't allow ``base``,
+    ``ghc-prim``, ``integer-simple``, ``integer-gmp``, and
+    ``template-haskell`` to be installed or upgraded. This flag
+    removes the restriction.
+
+    The command line variant of this field is
+    ``--(no-)install-base-libraries``.
+
 .. cfg-field:: cabal-lib-version: version
                --cabal-lib-version=version
     :synopsis: Version of Cabal library used to build package.

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -244,6 +244,7 @@ instance Semigroup SavedConfig where
         installIndependentGoals      = combine installIndependentGoals,
         installShadowPkgs            = combine installShadowPkgs,
         installStrongFlags           = combine installStrongFlags,
+        installInstallBaseLibs       = combine installInstallBaseLibs,
         installReinstall             = combine installReinstall,
         installAvoidReinstalls       = combine installAvoidReinstalls,
         installOverrideReinstall     = combine installOverrideReinstall,

--- a/cabal-install/Distribution/Client/Fetch.hs
+++ b/cabal-install/Distribution/Client/Fetch.hs
@@ -164,6 +164,8 @@ planPackages verbosity comp platform fetchFlags
 
       . setStrongFlags strongFlags
 
+      . setInstallBaseLibs installBaseLibs
+
         -- Reinstall the targets given on the command line so that the dep
         -- resolver will decide that they need fetching, even if they're
         -- already installed. Since we want to get the source packages of
@@ -181,6 +183,7 @@ planPackages verbosity comp platform fetchFlags
     shadowPkgs       = fromFlag (fetchShadowPkgs       fetchFlags)
     strongFlags      = fromFlag (fetchStrongFlags      fetchFlags)
     maxBackjumps     = fromFlag (fetchMaxBackjumps     fetchFlags)
+    installBaseLibs  = fromFlag (fetchInstallBaseLibs  fetchFlags)
 
 
 checkTarget :: UserTarget -> IO ()

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -179,6 +179,8 @@ planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
 
       . setStrongFlags strongFlags
 
+      . setInstallBaseLibs installBaseLibs
+
       . addConstraints
           [ let pkg = pkgSpecifierTarget pkgSpecifier
                 pc = PackageConstraint (unqualified pkg)
@@ -203,6 +205,7 @@ planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
     shadowPkgs       = fromFlag (freezeShadowPkgs       freezeFlags)
     strongFlags      = fromFlag (freezeStrongFlags      freezeFlags)
     maxBackjumps     = fromFlag (freezeMaxBackjumps     freezeFlags)
+    installBaseLibs  = fromFlag (freezeInstallBaseLibs  freezeFlags)
 
 
 -- | Remove all unneeded packages from an install plan.

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -388,6 +388,8 @@ planPackages comp platform mSandboxPkgInfo solver
 
       . setStrongFlags strongFlags
 
+      . setInstallBaseLibs installBaseLibs
+
       . setPreferenceDefault (if upgradeDeps then PreferAllLatest
                                              else PreferLatestForSelected)
 
@@ -447,6 +449,7 @@ planPackages comp platform mSandboxPkgInfo solver
     shadowPkgs       = fromFlag (installShadowPkgs        installFlags)
     strongFlags      = fromFlag (installStrongFlags       installFlags)
     maxBackjumps     = fromFlag (installMaxBackjumps      installFlags)
+    installBaseLibs  = fromFlag (installInstallBaseLibs   installFlags)
     upgradeDeps      = fromFlag (installUpgradeDeps       installFlags)
     onlyDeps         = fromFlag (installOnlyDeps          installFlags)
     allowOlder       = fromMaybe (AllowOlder RelaxDepsNone)

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -202,6 +202,7 @@ resolveSolverSettings ProjectConfig{
     solverSettingReorderGoals      = fromFlag projectConfigReorderGoals
     solverSettingCountConflicts    = fromFlag projectConfigCountConflicts
     solverSettingStrongFlags       = fromFlag projectConfigStrongFlags
+    solverSettingInstallBaseLibs   = fromFlag projectConfigInstallBaseLibs
     solverSettingIndexState        = fromFlagOrDefault IndexStateHead projectConfigIndexState
   --solverSettingIndependentGoals  = fromFlag projectConfigIndependentGoals
   --solverSettingShadowPkgs        = fromFlag projectConfigShadowPkgs
@@ -219,7 +220,8 @@ resolveSolverSettings ProjectConfig{
        projectConfigMaxBackjumps      = Flag defaultMaxBackjumps,
        projectConfigReorderGoals      = Flag (ReorderGoals False),
        projectConfigCountConflicts    = Flag (CountConflicts True),
-       projectConfigStrongFlags       = Flag (StrongFlags False)
+       projectConfigStrongFlags       = Flag (StrongFlags False),
+       projectConfigInstallBaseLibs   = Flag (InstallBaseLibs False)
      --projectConfigIndependentGoals  = Flag False,
      --projectConfigShadowPkgs        = Flag False,
      --projectConfigReinstall         = Flag False,

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -305,7 +305,8 @@ convertLegacyAllPackageFlags globalFlags configFlags
       installCountConflicts     = projectConfigCountConflicts,
     --installIndependentGoals   = projectConfigIndependentGoals,
     --installShadowPkgs         = projectConfigShadowPkgs,
-      installStrongFlags        = projectConfigStrongFlags
+      installStrongFlags        = projectConfigStrongFlags,
+      installInstallBaseLibs    = projectConfigInstallBaseLibs
     } = installFlags
 
 
@@ -502,6 +503,7 @@ convertToLegacySharedConfig
       installIndependentGoals  = mempty, --projectConfigIndependentGoals,
       installShadowPkgs        = mempty, --projectConfigShadowPkgs,
       installStrongFlags       = projectConfigStrongFlags,
+      installInstallBaseLibs   = projectConfigInstallBaseLibs,
       installOnly              = mempty,
       installOnlyDeps          = projectConfigOnlyDeps,
       installIndexState        = projectConfigIndexState,
@@ -852,7 +854,7 @@ legacySharedConfigFieldDescrs =
       , "one-shot", "jobs", "keep-going", "offline"
         -- solver flags:
       , "max-backjumps", "reorder-goals", "count-conflicts", "strong-flags"
-      , "index-state"
+      , "install-base-libraries", "index-state"
       ]
   . commandOptionsToFields
   ) (installOptions ParseArgs)

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -181,7 +181,8 @@ data ProjectConfigShared
        projectConfigMaxBackjumps      :: Flag Int,
        projectConfigReorderGoals      :: Flag ReorderGoals,
        projectConfigCountConflicts    :: Flag CountConflicts,
-       projectConfigStrongFlags       :: Flag StrongFlags
+       projectConfigStrongFlags       :: Flag StrongFlags,
+       projectConfigInstallBaseLibs   :: Flag InstallBaseLibs
 
        -- More things that only make sense for manual mode, not --local mode
        -- too much control!
@@ -355,6 +356,7 @@ data SolverSettings
        solverSettingReorderGoals      :: ReorderGoals,
        solverSettingCountConflicts    :: CountConflicts,
        solverSettingStrongFlags       :: StrongFlags,
+       solverSettingInstallBaseLibs   :: InstallBaseLibs,
        solverSettingIndexState        :: IndexState
        -- Things that only make sense for manual mode, not --local mode
        -- too much control!

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -931,6 +931,8 @@ planPackages comp platform solver SolverSettings{..}
 
       . setStrongFlags solverSettingStrongFlags
 
+      . setInstallBaseLibs solverSettingInstallBaseLibs
+
         --TODO: [required eventually] decide if we need to prefer installed for
         -- global packages, or prefer latest even for global packages. Perhaps
         -- should be configurable but with a different name than "upgrade-dependencies".

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -679,6 +679,7 @@ data FetchFlags = FetchFlags {
       fetchIndependentGoals :: Flag IndependentGoals,
       fetchShadowPkgs       :: Flag ShadowPkgs,
       fetchStrongFlags      :: Flag StrongFlags,
+      fetchInstallBaseLibs  :: Flag InstallBaseLibs,
       fetchVerbosity :: Flag Verbosity
     }
 
@@ -694,6 +695,7 @@ defaultFetchFlags = FetchFlags {
     fetchIndependentGoals = Flag (IndependentGoals False),
     fetchShadowPkgs       = Flag (ShadowPkgs False),
     fetchStrongFlags      = Flag (StrongFlags False),
+    fetchInstallBaseLibs  = Flag (InstallBaseLibs False),
     fetchVerbosity = toFlag normal
    }
 
@@ -741,6 +743,7 @@ fetchCommand = CommandUI {
                          fetchIndependentGoals (\v flags -> flags { fetchIndependentGoals = v })
                          fetchShadowPkgs       (\v flags -> flags { fetchShadowPkgs       = v })
                          fetchStrongFlags      (\v flags -> flags { fetchStrongFlags      = v })
+                         fetchInstallBaseLibs  (\v flags -> flags { fetchInstallBaseLibs  = v })
 
   }
 
@@ -759,6 +762,7 @@ data FreezeFlags = FreezeFlags {
       freezeIndependentGoals :: Flag IndependentGoals,
       freezeShadowPkgs       :: Flag ShadowPkgs,
       freezeStrongFlags      :: Flag StrongFlags,
+      freezeInstallBaseLibs  :: Flag InstallBaseLibs,
       freezeVerbosity        :: Flag Verbosity
     }
 
@@ -774,6 +778,7 @@ defaultFreezeFlags = FreezeFlags {
     freezeIndependentGoals = Flag (IndependentGoals False),
     freezeShadowPkgs       = Flag (ShadowPkgs False),
     freezeStrongFlags      = Flag (StrongFlags False),
+    freezeInstallBaseLibs  = Flag (InstallBaseLibs False),
     freezeVerbosity        = toFlag normal
    }
 
@@ -820,6 +825,7 @@ freezeCommand = CommandUI {
                          freezeIndependentGoals (\v flags -> flags { freezeIndependentGoals = v })
                          freezeShadowPkgs       (\v flags -> flags { freezeShadowPkgs       = v })
                          freezeStrongFlags      (\v flags -> flags { freezeStrongFlags      = v })
+                         freezeInstallBaseLibs  (\v flags -> flags { freezeInstallBaseLibs  = v })
 
   }
 
@@ -1239,6 +1245,7 @@ data InstallFlags = InstallFlags {
     installIndependentGoals :: Flag IndependentGoals,
     installShadowPkgs       :: Flag ShadowPkgs,
     installStrongFlags      :: Flag StrongFlags,
+    installInstallBaseLibs  :: Flag InstallBaseLibs,
     installReinstall        :: Flag Bool,
     installAvoidReinstalls  :: Flag AvoidReinstalls,
     installOverrideReinstall :: Flag Bool,
@@ -1281,6 +1288,7 @@ defaultInstallFlags = InstallFlags {
     installIndependentGoals= Flag (IndependentGoals False),
     installShadowPkgs      = Flag (ShadowPkgs False),
     installStrongFlags     = Flag (StrongFlags False),
+    installInstallBaseLibs = Flag (InstallBaseLibs False),
     installReinstall       = Flag False,
     installAvoidReinstalls = Flag (AvoidReinstalls False),
     installOverrideReinstall = Flag False,
@@ -1428,7 +1436,8 @@ installOptions showOrParseArgs =
                         installCountConflicts   (\v flags -> flags { installCountConflicts   = v })
                         installIndependentGoals (\v flags -> flags { installIndependentGoals = v })
                         installShadowPkgs       (\v flags -> flags { installShadowPkgs       = v })
-                        installStrongFlags      (\v flags -> flags { installStrongFlags      = v }) ++
+                        installStrongFlags      (\v flags -> flags { installStrongFlags      = v })
+                        installInstallBaseLibs  (\v flags -> flags { installInstallBaseLibs  = v }) ++
 
       [ option [] ["reinstall"]
           "Install even if it means installing the same version again."
@@ -2213,8 +2222,10 @@ optionSolverFlags :: ShowOrParseArgs
                   -> (flags -> Flag IndependentGoals) -> (Flag IndependentGoals -> flags -> flags)
                   -> (flags -> Flag ShadowPkgs)       -> (Flag ShadowPkgs       -> flags -> flags)
                   -> (flags -> Flag StrongFlags)      -> (Flag StrongFlags      -> flags -> flags)
+                  -> (flags -> Flag InstallBaseLibs)  -> (Flag InstallBaseLibs  -> flags -> flags)
                   -> [OptionField flags]
-optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg getcc setcc _getig _setig getsip setsip getstrfl setstrfl =
+optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg getcc setcc _getig _setig
+                  getsip setsip getstrfl setstrfl getib setib =
   [ option [] ["max-backjumps"]
       ("Maximum number of backjumps allowed while solving (default: " ++ show defaultMaxBackjumps ++ "). Use a negative number to enable unlimited backtracking. Use 0 to disable backtracking completely.")
       getmbj setmbj
@@ -2247,6 +2258,11 @@ optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg getcc setcc _getig _
       "Do not defer flag choices (this used to be the default in cabal-install <= 1.20)."
       (fmap asBool . getstrfl)
       (setstrfl . fmap StrongFlags)
+      (yesNoOpt showOrParseArgs)
+  , option [] ["install-base-libraries"]
+      "Allow cabal to install base, ghc-prim, integer-simple, integer-gmp, and template-haskell."
+      (fmap asBool . getib)
+      (setib . fmap InstallBaseLibs)
       (yesNoOpt showOrParseArgs)
   ]
 

--- a/cabal-install/Distribution/Solver/Types/Settings.hs
+++ b/cabal-install/Distribution/Solver/Types/Settings.hs
@@ -6,6 +6,7 @@ module Distribution.Solver.Types.Settings
     , AvoidReinstalls(..)
     , ShadowPkgs(..)
     , StrongFlags(..)
+    , InstallBaseLibs(..)
     , EnableBackjumping(..)
     , CountConflicts(..)
     , SolveExecutables(..)
@@ -33,6 +34,9 @@ newtype ShadowPkgs = ShadowPkgs Bool
 newtype StrongFlags = StrongFlags Bool
   deriving (BooleanFlag, Eq, Generic, Show)
 
+newtype InstallBaseLibs = InstallBaseLibs Bool
+  deriving (BooleanFlag, Eq, Generic, Show)
+
 newtype EnableBackjumping = EnableBackjumping Bool
   deriving (BooleanFlag, Eq, Generic, Show)
 
@@ -45,4 +49,5 @@ instance Binary IndependentGoals
 instance Binary AvoidReinstalls
 instance Binary ShadowPkgs
 instance Binary StrongFlags
+instance Binary InstallBaseLibs
 instance Binary SolveExecutables

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -32,6 +32,8 @@
 	* Support the Nix package manager (#3651).
 	* Made the 'template-haskell' package non-upgradable again (#4185).
 	* Fixed password echoing on MinTTY (#4128).
+	* Added a new solver flag, '--install-base-libraries', that allows
+	any package to be installed or upgraded (#4209).
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* If there are multiple remote repos, 'cabal update' now updates

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -353,6 +353,7 @@ instance Arbitrary ProjectConfigShared where
         <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary
+        <*> arbitrary
       where
         arbitraryConstraints :: Gen [(UserConstraint, ConstraintSource)]
         arbitraryConstraints =
@@ -362,20 +363,20 @@ instance Arbitrary ProjectConfigShared where
               x00 x01 x02 x03 x04
               x05 x06 x07 x08 x09
               x10 x11 x12 x13 x14
-              x15 x16) =
+              x15 x16 x17) =
       [ ProjectConfigShared
           x00' (fmap getNonEmpty x01') (fmap getNonEmpty x02') x03' x04'
           x05' x06' (postShrink_Constraints x07') x08' x09'
-          x10' x11' x12' x13' x14' x15' x16'
+          x10' x11' x12' x13' x14' x15' x16' x17'
       | ((x00', x01', x02', x03', x04'),
          (x05', x06', x07', x08', x09'),
          (x10', x11', x12', x13', x14'),
-         (x15', x16'))
+         (x15', x16', x17'))
           <- shrink
                ((x00, fmap NonEmpty x01, fmap NonEmpty x02, x03, x04),
                 (x05, x06, preShrink_Constraints x07, x08, x09),
                 (x10, x11, x12, x13, x14),
-                (x15, x16))
+                (x15, x16, x17))
       ]
       where
         preShrink_Constraints  = map fst
@@ -595,6 +596,9 @@ instance Arbitrary CountConflicts where
 
 instance Arbitrary StrongFlags where
     arbitrary = StrongFlags <$> arbitrary
+
+instance Arbitrary InstallBaseLibs where
+    arbitrary = InstallBaseLibs <$> arbitrary
 
 instance Arbitrary AllowNewer where
     arbitrary = AllowNewer <$> arbitrary

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -523,13 +523,14 @@ exResolve :: ExampleDb
           -> Maybe Int
           -> IndependentGoals
           -> ReorderGoals
+          -> InstallBaseLibs
           -> EnableBackjumping
           -> Maybe [ExampleVar]
           -> [ExPreference]
           -> EnableAllTests
           -> Progress String String CI.SolverInstallPlan.SolverInstallPlan
 exResolve db exts langs pkgConfigDb targets solver mbj indepGoals reorder
-          enableBj vars prefs enableAllTests
+          installBaseLibs enableBj vars prefs enableAllTests
     = resolveDependencies C.buildPlatform compiler pkgConfigDb solver params
   where
     defaultCompiler = C.unknownCompilerInfo C.buildCompilerId C.NoAbiTag
@@ -554,6 +555,7 @@ exResolve db exts langs pkgConfigDb targets solver mbj indepGoals reorder
                    $ setIndependentGoals indepGoals
                    $ setReorderGoals reorder
                    $ setMaxBackjumps mbj
+                   $ setInstallBaseLibs installBaseLibs
                    $ setEnableBackjumping enableBj
                    $ setGoalOrder goalOrder
                    $ standardInstallPolicy instIdx avaiIdx targets'

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
@@ -4,6 +4,7 @@ module UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils (
     SolverTest
   , SolverResult(..)
   , independentGoals
+  , installBaseLibs
   , disableBackjumping
   , goalOrder
   , preferences
@@ -40,6 +41,9 @@ import UnitTests.Options
 independentGoals :: SolverTest -> SolverTest
 independentGoals test = test { testIndepGoals = IndependentGoals True }
 
+installBaseLibs :: SolverTest -> SolverTest
+installBaseLibs test = test { testInstallBaseLibs = InstallBaseLibs True }
+
 disableBackjumping :: SolverTest -> SolverTest
 disableBackjumping test =
     test { testEnableBackjumping = EnableBackjumping False }
@@ -62,6 +66,7 @@ data SolverTest = SolverTest {
   , testTargets        :: [String]
   , testResult         :: SolverResult
   , testIndepGoals     :: IndependentGoals
+  , testInstallBaseLibs :: InstallBaseLibs
   , testEnableBackjumping :: EnableBackjumping
   , testGoalOrder      :: Maybe [ExampleVar]
   , testSoftConstraints :: [ExPreference]
@@ -151,6 +156,7 @@ mkTestExtLangPC exts langs pkgConfigDb db label targets result = SolverTest {
   , testTargets        = targets
   , testResult         = result
   , testIndepGoals     = IndependentGoals False
+  , testInstallBaseLibs = InstallBaseLibs False
   , testEnableBackjumping = EnableBackjumping True
   , testGoalOrder      = Nothing
   , testSoftConstraints = []
@@ -167,8 +173,8 @@ runTest SolverTest{..} = askOption $ \(OptionShowSolverLog showSolverLog) ->
       let progress = exResolve testDb testSupportedExts
                      testSupportedLangs testPkgConfigDb testTargets
                      Modular Nothing testIndepGoals (ReorderGoals False)
-                     testEnableBackjumping testGoalOrder testSoftConstraints
-                     testEnableAllTests
+                     testInstallBaseLibs testEnableBackjumping testGoalOrder
+                     testSoftConstraints testEnableAllTests
           printMsg msg = if showSolverLog
                          then putStrLn msg
                          else return ()

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -108,7 +108,8 @@ solve enableBj reorder indep solver targets (TestDb db) =
                   -- The backjump limit prevents individual tests from using
                   -- too much time and memory.
                   (Just defaultMaxBackjumps)
-                  indep reorder enableBj Nothing [] (EnableAllTests True)
+                  indep reorder (InstallBaseLibs False) enableBj Nothing []
+                  (EnableAllTests True)
 
       failure :: String -> Failure
       failure msg

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -77,6 +77,12 @@ tests = [
         , runTest $ mkTest db12 "baseShim5" ["D"] anySolverFailure
         , runTest $ mkTest db12 "baseShim6" ["E"] (solverSuccess [("E", 1), ("syb", 2)])
         ]
+    , testGroup "Base" [
+          runTest $ mkTest dbBase "Refuse to install base without --install-base-libraries" ["base"] $
+                      solverFailure (isInfixOf "only already installed instances can be used")
+        , runTest $ installBaseLibs $ mkTest dbBase "Install base with --install-base-libraries" ["base"] $
+                      solverSuccess [("base", 1), ("ghc-prim", 1), ("integer-gmp", 1), ("integer-simple", 1)]
+        ]
     , testGroup "Cycles" [
           runTest $ mkTest db14 "simpleCycle1"          ["A"]      anySolverFailure
         , runTest $ mkTest db14 "simpleCycle2"          ["A", "B"] anySolverFailure
@@ -444,6 +450,15 @@ db12 =
     , Right $ exAv "C" 1 [ExAny "A", ExAny "B"]
     , Right $ exAv "D" 1 [ExFix "base" 3, ExFix "syb" 2]
     , Right $ exAv "E" 1 [ExFix "base" 4, ExFix "syb" 2]
+    ]
+
+dbBase :: ExampleDb
+dbBase = [
+      Right $ exAv "base" 1
+              [ExAny "ghc-prim", ExAny "integer-simple", ExAny "integer-gmp"]
+    , Right $ exAv "ghc-prim" 1 []
+    , Right $ exAv "integer-simple" 1 []
+    , Right $ exAv "integer-gmp" 1 []
     ]
 
 db13 :: ExampleDb


### PR DESCRIPTION
--install-base-libraries makes cabal ignore the list of packages that cannot be
installed or upgraded.

I haven't added documentation yet.