### PR TITLE
Degrade root-cmd error to warning.

### DIFF
--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -210,8 +210,10 @@ install verbosity packageDBs repos comp platform progdb useSandbox mSandboxPkgIn
   userTargets0 = do
 
     unless (installRootCmd installFlags == Cabal.NoFlag) $
-        die $ "--root-cmd is no longer supported, "
+        warn verbosity $ "--root-cmd is no longer supported, "
         ++ "see https://github.com/haskell/cabal/issues/3353"
+        ++ " (if you didn't type --root-cmd, comment out root-cmd"
+        ++ " in your ~/.cabal/config file)"
     unless (fromFlag (configUserInstall configFlags)) $
         warn verbosity $ "the --global flag is deprecated -- "
         ++ "it is generally considered a bad idea to install packages "


### PR DESCRIPTION
shayan_ on IRC reported that if you had root-cmd set in your
.cabal/config, cabal install would always fail to run.  That's
bad, esp. because root-cmd would only have an effect when
--global was passed.  Downgrade the warning.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>