### PR TITLE
Temporarily disallow constraints that have build tool dependency qualifiers.

### DIFF
--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -1320,7 +1320,8 @@ Miscellaneous options
         # Setup.hs script of package foo.
         $ cabal install --constraint="foo:setup.bar == 1.0"
 
-        # Example use of the 'exe' (executable build tool)
+    ..  TODO: Uncomment this example once we decide on a syntax for 'exe'.
+    ..  # Example use of the 'exe' (executable build tool)
         # qualifier. This constraint applies to package baz when it
         # is a dependency of the build tool bar being used to
         # build package foo.

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -746,12 +746,15 @@ instance Text UserConstraint where
                     do _ <- Parse.string ":setup."
                        pn2 <- parse
                        return (UserSetup pn, pn2)
-                    +++
-                    do _ <- Parse.string ":"
-                       pn2 <- parse
-                       _ <- Parse.string ":exe."
-                       pn3 <- parse
-                       return (UserExe pn pn2, pn3)
+
+                    -- -- TODO: Re-enable parsing of UserExe once we decide on a syntax.
+                    --
+                    -- +++
+                    -- do _ <- Parse.string ":"
+                    --    pn2 <- parse
+                    --    _ <- Parse.string ":exe."
+                    --    pn3 <- parse
+                    --    return (UserExe pn pn2, pn3)
                        
     -- Package property
     let keyword str x = Parse.skipSpaces1 >> Parse.string str >> return x

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -568,7 +568,9 @@ instance Arbitrary RemoteRepo where
 instance Arbitrary UserQualifier where
     arbitrary = oneof [ pure UserToplevel
                       , UserSetup <$> arbitrary
-                      , UserExe <$> arbitrary <*> arbitrary
+
+                      -- -- TODO: Re-enable UserExe tests once we decide on a syntax.
+                      -- , UserExe <$> arbitrary <*> arbitrary
                       ]
 
 instance Arbitrary UserConstraint where

--- a/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
@@ -12,7 +12,6 @@ import Distribution.ParseUtils         (parseCommaList)
 import Distribution.Text               (parse)
 
 import Distribution.Solver.Types.PackageConstraint (PackageProperty(..))
-import Distribution.Solver.Types.OptionalStanza (OptionalStanza(..))
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -63,9 +62,11 @@ exampleConstraints =
                                            (fn "bar", False),
                                            (fn "baz", True)]))
     
-  , ("foo:happy:exe.template-haskell test",
-     UserConstraint (UserExe (pn "foo") (pn "happy")) (pn "template-haskell")
-                    (PackagePropertyStanzas [TestStanzas]))
+  -- -- TODO: Re-enable UserExe tests once we decide on a syntax.
+  --
+  -- , ("foo:happy:exe.template-haskell test",
+  --    UserConstraint (UserExe (pn "foo") (pn "happy")) (pn "template-haskell")
+  --                   (PackagePropertyStanzas [TestStanzas]))
   ]
   where
     pn = mkPackageName


### PR DESCRIPTION
This commit comments out the part of #4219 that parses build tool dependency
qualifiers, to disable the feature until we finalize the syntax. It also comments
out the part of #4236 that tests the parsing.

See https://github.com/haskell/cabal/pull/4236#issuecomment-272771170.

/cc @robjhen @ezyang 