### PR TITLE
Enable -Wmissing-home-modules when building a library

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1450,7 +1450,11 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
 componentGhcOptions :: Verbosity -> LocalBuildInfo
                     -> BuildInfo -> ComponentLocalBuildInfo -> FilePath
                     -> GhcOptions
-componentGhcOptions = Internal.componentGhcOptions
+componentGhcOptions verbosity lbi =
+  Internal.componentGhcOptions verbosity implInfo lbi
+  where
+    comp     = compiler lbi
+    implInfo = getImplInfo comp
 
 componentCcGhcOptions :: Verbosity -> LocalBuildInfo
                       -> BuildInfo -> ComponentLocalBuildInfo

--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -42,6 +42,7 @@ data GhcImplInfo = GhcImplInfo
   , flagPackageConf      :: Bool -- ^ use package-conf instead of package-db
   , flagDebugInfo        :: Bool -- ^ -g flag supported
   , supportsPkgEnvFiles  :: Bool -- ^ picks up @.ghc.environment@ files
+  , flagWarnMissingHomeModules :: Bool -- ^ -Wmissing-home-modules is supported
   }
 
 getImplInfo :: Compiler -> GhcImplInfo
@@ -67,6 +68,7 @@ ghcVersionImplInfo ver = GhcImplInfo
   , flagPackageConf      = v <  [7,5]
   , flagDebugInfo        = v >= [7,10]
   , supportsPkgEnvFiles  = v >= [8,0,1,20160901] -- broken in 8.0.1, fixed in 8.0.2
+  , flagWarnMissingHomeModules = v >= [8,2,1]
   }
   where
     v = versionNumbers ver
@@ -83,6 +85,7 @@ ghcjsVersionImplInfo _ghcjsver ghcver = GhcImplInfo
   , flagPackageConf      = False
   , flagDebugInfo        = False
   , supportsPkgEnvFiles  = ghcv >= [8,0,2] --TODO: check this works in ghcjs
+  , flagWarnMissingHomeModules = False
   }
   where
     ghcv = versionNumbers ghcver

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -290,10 +290,10 @@ componentCcGhcOptions verbosity _implInfo lbi bi clbi odir filename =
       ghcOptObjDir         = toFlag odir
     }
 
-componentGhcOptions :: Verbosity -> LocalBuildInfo
+componentGhcOptions :: Verbosity -> GhcImplInfo -> LocalBuildInfo
                     -> BuildInfo -> ComponentLocalBuildInfo -> FilePath
                     -> GhcOptions
-componentGhcOptions verbosity lbi bi clbi odir =
+componentGhcOptions verbosity implInfo lbi bi clbi odir =
     mempty {
       -- Respect -v0, but don't crank up verbosity on GHC if
       -- Cabal verbosity is requested. For that, use --ghc-option=-v instead!
@@ -316,6 +316,12 @@ componentGhcOptions verbosity lbi bi clbi odir =
         _ -> [],
       ghcOptNoCode          = toFlag $ componentIsIndefinite clbi,
       ghcOptHideAllPackages = toFlag True,
+      ghcOptWarnMissingHomeModules = case clbi of
+        LibComponentLocalBuildInfo{} ->
+          if flagWarnMissingHomeModules implInfo
+            then toFlag True
+            else mempty
+        _ -> mempty,
       ghcOptPackageDBs      = withPackageDB lbi,
       ghcOptPackages        = toNubListR $ mkGhcOptPackages clbi,
       ghcOptSplitObjs       = toFlag (splitObjs lbi),

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -823,7 +823,9 @@ componentGhcOptions :: Verbosity -> LocalBuildInfo
                     -> BuildInfo -> ComponentLocalBuildInfo -> FilePath
                     -> GhcOptions
 componentGhcOptions verbosity lbi bi clbi odir =
-  let opts = Internal.componentGhcOptions verbosity lbi bi clbi odir
+  let opts = Internal.componentGhcOptions verbosity implInfo lbi bi clbi odir
+      comp = compiler lbi
+      implInfo = getImplInfo comp
   in  opts { ghcOptExtra = ghcOptExtra opts `mappend` toNubListR
                              (hcOptions GHCJS bi)
            }

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -110,6 +110,9 @@ data GhcOptions = GhcOptions {
   -- | Start with a clean package set; the @ghc -hide-all-packages@ flag
   ghcOptHideAllPackages :: Flag Bool,
 
+  -- | Warn about modules, not listed in command line
+  ghcOptWarnMissingHomeModules :: Flag Bool,
+
   -- | Don't automatically link in Haskell98 etc; the @ghc
   -- -no-auto-link-packages@ flag.
   ghcOptNoAutoLinkPackages :: Flag Bool,
@@ -434,6 +437,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
   , concat [ ["-fno-code", "-fwrite-interface"] | flagBool ghcOptNoCode ]
 
   , [ "-hide-all-packages"     | flagBool ghcOptHideAllPackages ]
+  , [ "-Wmissing-home-modules" | flagBool ghcOptWarnMissingHomeModules ]
   , [ "-no-auto-link-packages" | flagBool ghcOptNoAutoLinkPackages ]
 
   , packageDbArgs implInfo (ghcOptPackageDBs opts)


### PR DESCRIPTION
Use `-Wmissing-home-modules` starting from `ghc-8.2.1` when building a library. The relevant Trac issue: https://ghc.haskell.org/trac/ghc/ticket/13129

The idea is to warn user about modules, not listed neither in `exposed-modules`, nor in `other-modules`.

See  #1746 for details.