### PR TITLE
Enforce qualified constraints in the dependency solver.

### DIFF
--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -1315,6 +1315,12 @@ Miscellaneous options
 
     ::
 
+        # Example use of the 'any' qualifier. This constraint
+        # applies to package bar anywhere in the dependency graph.
+        $ cabal install --constraint="any.bar == 1.0"
+
+    ::
+
         # Example use of the 'setup' qualifier. This constraint
         # applies to package bar when it is a dependency of the
         # Setup.hs script of package foo.

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -1321,9 +1321,14 @@ Miscellaneous options
 
     ::
 
-        # Example use of the 'setup' qualifier. This constraint
-        # applies to package bar when it is a dependency of the
-        # Setup.hs script of package foo.
+        # Example uses of 'setup' qualifiers.
+
+        # This constraint applies to package bar when it is a
+        # dependency of any Setup.hs script.
+        $ cabal install --constraint="setup.bar == 1.0"
+
+        # This constraint applies to package bar when it is a
+        # dependency of the Setup.hs script of package foo.
         $ cabal install --constraint="foo:setup.bar == 1.0"
 
     ..  TODO: Uncomment this example once we decide on a syntax for 'exe'.

--- a/cabal-install/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/Distribution/Client/CmdFreeze.hs
@@ -13,7 +13,7 @@ import Distribution.Client.ProjectConfig
          , commandLineFlagsToProjectConfig, writeProjectLocalFreezeConfig
          , findProjectRoot, getProjectFileName )
 import Distribution.Client.Targets
-         ( UserQualifier(..), UserConstraint(..) )
+         ( UserQualifier(..), UserConstraintScope(..), UserConstraint(..) )
 import Distribution.Solver.Types.PackageConstraint
          ( PackageProperty(..) )
 import Distribution.Solver.Types.ConstraintSource
@@ -150,7 +150,7 @@ projectFreezeConstraints plan =
     versionConstraints :: Map PackageName [(UserConstraint, ConstraintSource)]
     versionConstraints =
       Map.mapWithKey
-        (\p v -> [(UserConstraint UserToplevel p (PackagePropertyVersion v),
+        (\p v -> [(UserConstraint (UserQualified UserQualToplevel p) (PackagePropertyVersion v),
                    ConstraintSourceFreeze)])
         versionRanges
 
@@ -168,7 +168,7 @@ projectFreezeConstraints plan =
     flagConstraints :: Map PackageName [(UserConstraint, ConstraintSource)]
     flagConstraints =
       Map.mapWithKey
-        (\p f -> [(UserConstraint UserToplevel p (PackagePropertyFlags f),
+        (\p f -> [(UserConstraint (UserQualified UserQualToplevel p) (PackagePropertyFlags f),
                    ConstraintSourceFreeze)])
         flagAssignments
 
@@ -205,8 +205,8 @@ projectFreezeConstraints plan =
               else Just constraints)
 #endif
 
-    isVersionConstraint (UserConstraint _ _ (PackagePropertyVersion _)) = True
-    isVersionConstraint _                       = False
+    isVersionConstraint (UserConstraint _ (PackagePropertyVersion _)) = True
+    isVersionConstraint _                                             = False
 
     localPackages :: Map PackageName ()
     localPackages =

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -483,16 +483,14 @@ addDefaultSetupDependencies defaultSetupDeps params =
         pkgdesc  = PD.packageDescription gpkgdesc
 
 -- | If a package has a custom setup then we need to add a setup-depends
--- on Cabal. For now it's easier to add this unconditionally.  Once
--- qualified constraints land we can turn this into a custom setup
--- only constraint.
+-- on Cabal.
 --
 addSetupCabalMinVersionConstraint :: Version
                                   -> DepResolverParams -> DepResolverParams
 addSetupCabalMinVersionConstraint minVersion =
     addConstraints
       [ LabeledPackageConstraint
-          (PackageConstraint (scopeToplevel cabalPkgname)
+          (PackageConstraint (ScopeAnySetupQualifier cabalPkgname)
                              (PackagePropertyVersion $ orLaterVersion minVersion))
           ConstraintSetupCabalMinVersion
       ]

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -253,7 +253,7 @@ freezePackages verbosity globalFlags pkgs = do
         ,ConstraintSourceUserConfig userPackageEnvironmentFile)
       where
         pkgIdToConstraint pkgId =
-            UserConstraint UserToplevel (packageName pkgId)
+            UserConstraint (UserQualified UserQualToplevel (packageName pkgId))
                            (PackagePropertyVersion $ thisVersion (packageVersion pkgId))
     createPkgEnv config = mempty { pkgEnvSavedConfig = config }
     showPkgEnv = BS.Char8.pack . showPackageEnvironment

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -731,9 +731,7 @@ userConstraintPackageName (UserConstraint _ name _) = name
 
 userToPackageConstraint :: UserConstraint -> PackageConstraint
 userToPackageConstraint (UserConstraint qual name prop) =
-  PackageConstraint (ScopeQualified $ Q path name) prop
-  where
-    path = PackagePath DefaultNamespace (fromUserQualifier qual)
+  PackageConstraint (ScopeQualified (fromUserQualifier qual) name) prop
 
 readUserConstraint :: String -> Either String UserConstraint
 readUserConstraint str =

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -719,6 +719,9 @@ data UserConstraintScope =
   -- | Scope that applies to the package when it has the specified qualifier.
   UserQualified UserQualifier PackageName
 
+  -- | Scope that applies to the package when it has a setup qualifier.
+  | UserAnySetupQualifier PackageName
+
   -- | Scope that applies to the package when it has any qualifier.
   | UserAnyQualifier PackageName
   deriving (Eq, Show, Generic)
@@ -733,6 +736,7 @@ fromUserQualifier (UserQualExe name1 name2) = QualExe name1 name2
 fromUserConstraintScope :: UserConstraintScope -> ConstraintScope
 fromUserConstraintScope (UserQualified q pn) =
     ScopeQualified (fromUserQualifier q) pn
+fromUserConstraintScope (UserAnySetupQualifier pn) = ScopeAnySetupQualifier pn
 fromUserConstraintScope (UserAnyQualifier pn) = ScopeAnyQualifier pn
 
 -- | Version of 'PackageConstraint' that the user can specify on
@@ -748,6 +752,7 @@ userConstraintPackageName (UserConstraint scope _) = scopePN scope
   where
     scopePN (UserQualified _ pn) = pn
     scopePN (UserAnyQualifier pn) = pn
+    scopePN (UserAnySetupQualifier pn) = pn
 
 userToPackageConstraint :: UserConstraint -> PackageConstraint
 userToPackageConstraint (UserConstraint scope prop) =
@@ -775,6 +780,11 @@ instance Text UserConstraint where
              _ <- Parse.string "any."
              pn <- parse
              return (UserAnyQualifier pn)
+          +++
+          do
+             _ <- Parse.string "setup."
+             pn <- parse
+             return (UserAnySetupQualifier pn)
           +++
           do
              -- Qualified name

--- a/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
@@ -36,8 +36,8 @@ import qualified Text.PrettyPrint as Disp
 -- | Determines to what packages and in what contexts a
 -- constraint applies.
 data ConstraintScope
-     -- | The package with the specified qualified name.
-   = ScopeQualified QPN
+     -- | The package with the specified name and qualifier.
+   = ScopeQualified Qualifier PackageName
      -- | The package with the specified name regardless of
      -- qualifier.
    | ScopeAnyQualifier PackageName
@@ -47,16 +47,16 @@ data ConstraintScope
 -- the package with the specified name when that package is a
 -- top-level dependency in the default namespace.
 scopeToplevel :: PackageName -> ConstraintScope
-scopeToplevel = ScopeQualified . Q (PackagePath DefaultNamespace QualToplevel)
+scopeToplevel = ScopeQualified QualToplevel
 
 -- | Returns the package name associated with a constraint scope.
 scopeToPackageName :: ConstraintScope -> PackageName
-scopeToPackageName (ScopeQualified (Q _ pn)) = pn
+scopeToPackageName (ScopeQualified _ pn) = pn
 scopeToPackageName (ScopeAnyQualifier pn) = pn
 
 -- | Pretty-prints a constraint scope.
 dispConstraintScope :: ConstraintScope -> Disp.Doc
-dispConstraintScope (ScopeQualified qpn) = dispQPN qpn
+dispConstraintScope (ScopeQualified q pn) = dispQualifier q <<>> disp pn
 dispConstraintScope (ScopeAnyQualifier pn) = Disp.text "any." <<>> disp pn
 
 -- | A package property is a logical predicate on packages.

--- a/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
@@ -38,6 +38,9 @@ import qualified Text.PrettyPrint as Disp
 data ConstraintScope
      -- | The package with the specified name and qualifier.
    = ScopeQualified Qualifier PackageName
+     -- | The package with the specified name when it has a
+     -- setup qualifier.
+   | ScopeAnySetupQualifier PackageName
      -- | The package with the specified name regardless of
      -- qualifier.
    | ScopeAnyQualifier PackageName
@@ -52,11 +55,13 @@ scopeToplevel = ScopeQualified QualToplevel
 -- | Returns the package name associated with a constraint scope.
 scopeToPackageName :: ConstraintScope -> PackageName
 scopeToPackageName (ScopeQualified _ pn) = pn
+scopeToPackageName (ScopeAnySetupQualifier pn) = pn
 scopeToPackageName (ScopeAnyQualifier pn) = pn
 
 -- | Pretty-prints a constraint scope.
 dispConstraintScope :: ConstraintScope -> Disp.Doc
 dispConstraintScope (ScopeQualified q pn) = dispQualifier q <<>> disp pn
+dispConstraintScope (ScopeAnySetupQualifier pn) = Disp.text "setup." <<>> disp pn
 dispConstraintScope (ScopeAnyQualifier pn) = Disp.text "any." <<>> disp pn
 
 -- | A package property is a logical predicate on packages.

--- a/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
@@ -9,6 +9,7 @@ module Distribution.Solver.Types.PackageConstraint (
     ConstraintScope(..),
     scopeToplevel,
     scopeToPackageName,
+    constraintScopeMatches,
     PackageProperty(..),
     dispPackageProperty,
     PackageConstraint(..),
@@ -57,6 +58,15 @@ scopeToPackageName :: ConstraintScope -> PackageName
 scopeToPackageName (ScopeQualified _ pn) = pn
 scopeToPackageName (ScopeAnySetupQualifier pn) = pn
 scopeToPackageName (ScopeAnyQualifier pn) = pn
+
+constraintScopeMatches :: ConstraintScope -> QPN -> Bool
+constraintScopeMatches (ScopeQualified q pn) (Q (PackagePath _ q') pn') =
+    q == q' && pn == pn'
+constraintScopeMatches (ScopeAnySetupQualifier pn) (Q pp pn') =
+  let setup (PackagePath _ (QualSetup _)) = True
+      setup _                             = False
+  in setup pp && pn == pn'
+constraintScopeMatches (ScopeAnyQualifier pn) (Q _ pn') = pn == pn'
 
 -- | Pretty-prints a constraint scope.
 dispConstraintScope :: ConstraintScope -> Disp.Doc

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -41,7 +41,8 @@
 	on bar (part of #3502).
 	* Non-qualified constraints, such as --constraint="bar == 1.0", now
 	only apply to top-level dependencies. They don't constrain setup or
-	build-tool dependencies.
+	build-tool dependencies. The new syntax --constraint="any.bar == 1.0"
+	constrains all uses of bar.
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* If there are multiple remote repos, 'cabal update' now updates

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -37,8 +37,9 @@
 	* New 'cabal-install' command: 'outdated', for listing outdated
 	version bounds in a .cabal file or a freeze file (#4207).
 	* Added qualified constraints for setup dependencies. For example,
-	--constraint="foo:setup.bar == 1.0" constrains foo's setup dependency
-	on bar (part of #3502).
+	--constraint="setup.bar == 1.0" constrains all setup dependencies on
+	bar, and --constraint="foo:setup.bar == 1.0" constrains foo's setup
+	dependency on bar (part of #3502).
 	* Non-qualified constraints, such as --constraint="bar == 1.0", now
 	only apply to top-level dependencies. They don't constrain setup or
 	build-tool dependencies. The new syntax --constraint="any.bar == 1.0"

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -36,6 +36,12 @@
 	any package to be installed or upgraded (#4209).
 	* New 'cabal-install' command: 'outdated', for listing outdated
 	version bounds in a .cabal file or a freeze file (#4207).
+	* Added qualified constraints for setup dependencies. For example,
+	--constraint="foo:setup.bar == 1.0" constrains foo's setup dependency
+	on bar (part of #3502).
+	* Non-qualified constraints, such as --constraint="bar == 1.0", now
+	only apply to top-level dependencies. They don't constrain setup or
+	build-tool dependencies.
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* If there are multiple remote repos, 'cabal update' now updates

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -567,6 +567,7 @@ instance Arbitrary RemoteRepo where
 
 instance Arbitrary UserConstraintScope where
     arbitrary = oneof [ UserQualified <$> arbitrary <*> arbitrary
+                      , UserAnySetupQualifier <$> arbitrary
                       , UserAnyQualifier <$> arbitrary
                       ]
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -203,7 +203,7 @@ hackProjectConfigShared config =
       projectConfigConstraints =
       --TODO: [required eventually] parse ambiguity in constraint
       -- "pkgname -any" as either any version or disabled flag "any".
-        let ambiguous (UserConstraint _ _ (PackagePropertyFlags flags), _) =
+        let ambiguous (UserConstraint _ (PackagePropertyFlags flags), _) =
               (not . null) [ () | (name, False) <- flags
                                 , "any" `isPrefixOf` unFlagName name ]
             ambiguous _ = False
@@ -565,16 +565,21 @@ instance Arbitrary RemoteRepo where
           shortListOf1 5 (oneof [ choose ('0', '9')
                                 , choose ('a', 'f') ])
 
-instance Arbitrary UserQualifier where
-    arbitrary = oneof [ pure UserToplevel
-                      , UserSetup <$> arbitrary
+instance Arbitrary UserConstraintScope where
+    arbitrary = oneof [ UserQualified <$> arbitrary <*> arbitrary
+                      , UserAnyQualifier <$> arbitrary
+                      ]
 
-                      -- -- TODO: Re-enable UserExe tests once we decide on a syntax.
-                      -- , UserExe <$> arbitrary <*> arbitrary
+instance Arbitrary UserQualifier where
+    arbitrary = oneof [ pure UserQualToplevel
+                      , UserQualSetup <$> arbitrary
+
+                      -- -- TODO: Re-enable UserQualExe tests once we decide on a syntax.
+                      -- , UserQualExe <$> arbitrary <*> arbitrary
                       ]
 
 instance Arbitrary UserConstraint where
-    arbitrary = UserConstraint <$> arbitrary <*> arbitrary <*> arbitrary
+    arbitrary = UserConstraint <$> arbitrary <*> arbitrary
 
 instance Arbitrary PackageProperty where
     arbitrary = oneof [ PackagePropertyVersion <$> arbitrary

--- a/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
@@ -2,8 +2,9 @@ module UnitTests.Distribution.Client.Targets (
   tests
   ) where
 
-import Distribution.Client.Targets     (UserQualifier(..), UserConstraint(..)
-                                       ,readUserConstraint)
+import Distribution.Client.Targets     (UserQualifier(..)
+                                       ,UserConstraintScope(..)
+                                       ,UserConstraint(..), readUserConstraint)
 import Distribution.Compat.ReadP       (readP_to_S)
 import Distribution.Package            (mkPackageName)
 import Distribution.PackageDescription (mkFlagName)
@@ -12,6 +13,7 @@ import Distribution.ParseUtils         (parseCommaList)
 import Distribution.Text               (parse)
 
 import Distribution.Solver.Types.PackageConstraint (PackageProperty(..))
+import Distribution.Solver.Types.OptionalStanza (OptionalStanza(..))
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -45,27 +47,31 @@ tests =
 exampleConstraints :: [(String, UserConstraint)]
 exampleConstraints =
   [ ("template-haskell installed",
-     UserConstraint UserToplevel (pn "template-haskell")
+     UserConstraint (UserQualified UserQualToplevel (pn "template-haskell"))
                     PackagePropertyInstalled)
     
   , ("bytestring -any",
-     UserConstraint UserToplevel (pn "bytestring")
+     UserConstraint (UserQualified UserQualToplevel (pn "bytestring"))
                     (PackagePropertyVersion anyVersion))
-  
+
+  , ("any.directory test",
+     UserConstraint (UserAnyQualifier (pn "directory"))
+                    (PackagePropertyStanzas [TestStanzas]))
+
   , ("process:setup.bytestring ==5.2",
-     UserConstraint (UserSetup (pn "process")) (pn "bytestring")
+     UserConstraint (UserQualified (UserQualSetup (pn "process")) (pn "bytestring"))
                     (PackagePropertyVersion (thisVersion (mkVersion [5, 2]))))
     
   , ("network:setup.containers +foo -bar baz",
-     UserConstraint (UserSetup (pn "network")) (pn "containers")
+     UserConstraint (UserQualified (UserQualSetup (pn "network")) (pn "containers"))
                     (PackagePropertyFlags [(fn "foo", True),
                                            (fn "bar", False),
                                            (fn "baz", True)]))
     
-  -- -- TODO: Re-enable UserExe tests once we decide on a syntax.
+  -- -- TODO: Re-enable UserQualExe tests once we decide on a syntax.
   --
   -- , ("foo:happy:exe.template-haskell test",
-  --    UserConstraint (UserExe (pn "foo") (pn "happy")) (pn "template-haskell")
+  --    UserConstraint (UserQualified (UserQualExe (pn "foo") (pn "happy")) (pn "template-haskell"))
   --                   (PackagePropertyStanzas [TestStanzas]))
   ]
   where

--- a/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
@@ -58,6 +58,10 @@ exampleConstraints =
      UserConstraint (UserAnyQualifier (pn "directory"))
                     (PackagePropertyStanzas [TestStanzas]))
 
+  , ("setup.Cabal installed",
+     UserConstraint (UserAnySetupQualifier (pn "Cabal"))
+                    PackagePropertyInstalled)
+
   , ("process:setup.bytestring ==5.2",
      UserConstraint (UserQualified (UserQualSetup (pn "process")) (pn "bytestring"))
                     (PackagePropertyVersion (thisVersion (mkVersion [5, 2]))))

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -30,6 +30,7 @@ module UnitTests.Distribution.Solver.Modular.DSL (
   , withExe
   , withExes
   , runProgress
+  , mkVersionRange
   ) where
 
 import Prelude ()

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
@@ -7,6 +7,7 @@ module UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils (
   , allowBootLibInstalls
   , disableBackjumping
   , goalOrder
+  , constraints
   , preferences
   , enableAllTests
   , solverSuccess
@@ -52,6 +53,9 @@ disableBackjumping test =
 goalOrder :: [ExampleVar] -> SolverTest -> SolverTest
 goalOrder order test = test { testGoalOrder = Just order }
 
+constraints :: [ExConstraint] -> SolverTest -> SolverTest
+constraints cs test = test { testConstraints = cs }
+
 preferences :: [ExPreference] -> SolverTest -> SolverTest
 preferences prefs test = test { testSoftConstraints = prefs }
 
@@ -70,6 +74,7 @@ data SolverTest = SolverTest {
   , testAllowBootLibInstalls :: AllowBootLibInstalls
   , testEnableBackjumping :: EnableBackjumping
   , testGoalOrder      :: Maybe [ExampleVar]
+  , testConstraints    :: [ExConstraint]
   , testSoftConstraints :: [ExPreference]
   , testDb             :: ExampleDb
   , testSupportedExts  :: Maybe [Extension]
@@ -160,6 +165,7 @@ mkTestExtLangPC exts langs pkgConfigDb db label targets result = SolverTest {
   , testAllowBootLibInstalls = AllowBootLibInstalls False
   , testEnableBackjumping = EnableBackjumping True
   , testGoalOrder      = Nothing
+  , testConstraints    = []
   , testSoftConstraints = []
   , testDb             = db
   , testSupportedExts  = exts
@@ -175,7 +181,7 @@ runTest SolverTest{..} = askOption $ \(OptionShowSolverLog showSolverLog) ->
                      testSupportedLangs testPkgConfigDb testTargets
                      Modular Nothing testIndepGoals (ReorderGoals False)
                      testAllowBootLibInstalls testEnableBackjumping testGoalOrder
-                     testSoftConstraints testEnableAllTests
+                     testConstraints testSoftConstraints testEnableAllTests
           printMsg msg = if showSolverLog
                          then putStrLn msg
                          else return ()

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -108,7 +108,7 @@ solve enableBj reorder indep solver targets (TestDb db) =
                   -- The backjump limit prevents individual tests from using
                   -- too much time and memory.
                   (Just defaultMaxBackjumps)
-                  indep reorder (AllowBootLibInstalls False) enableBj Nothing []
+                  indep reorder (AllowBootLibInstalls False) enableBj Nothing [] []
                   (EnableAllTests True)
 
       failure :: String -> Failure

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 -- | This is a set of unit tests for the dependency solver,
 -- which uses the solver DSL ("UnitTests.Distribution.Solver.Modular.DSL")
 -- to more conveniently create package databases to run the solver tests on.
@@ -18,6 +19,8 @@ import Language.Haskell.Extension ( Extension(..)
 
 -- cabal-install
 import Distribution.Solver.Types.OptionalStanza
+import Distribution.Solver.Types.PackageConstraint
+import Distribution.Solver.Types.PackagePath
 import UnitTests.Distribution.Solver.Modular.DSL
 import UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils
 
@@ -109,7 +112,27 @@ tests = [
         , runTest $ mkTestLangs [Haskell98] dbLangs1 "unsupportedIndirect" ["B"] anySolverFailure
         , runTest $ mkTestLangs [Haskell98, Haskell2010, UnknownLanguage "Haskell3000"] dbLangs1 "supportedUnknown" ["C"] (solverSuccess [("A",1),("B",1),("C",1)])
         ]
+     , testGroup "Qualified Package Constraints" [
+          runTest $ mkTest dbConstraints "install latest versions without constraints" ["A", "B", "C"] $
+          solverSuccess [("A", 7), ("B", 8), ("C", 9), ("D", 7), ("D", 8), ("D", 9)]
 
+        , let cs = [ ExConstraint (ScopeAnyQualifier "D") $ mkVersionRange 1 4 ]
+          in runTest $ constraints cs $
+             mkTest dbConstraints "force older versions with unqualified constraint" ["A", "B", "C"] $
+             solverSuccess [("A", 1), ("B", 2), ("C", 3), ("D", 1), ("D", 2), ("D", 3)]
+
+        , let cs = [ ExConstraint (ScopeQualified QualToplevel    "D") $ mkVersionRange 1 4
+                   , ExConstraint (ScopeQualified (QualSetup "B") "D") $ mkVersionRange 4 7
+                   ]
+          in runTest $ constraints cs $
+             mkTest dbConstraints "force multiple versions with qualified constraints" ["A", "B", "C"] $
+             solverSuccess [("A", 1), ("B", 5), ("C", 9), ("D", 1), ("D", 5), ("D", 9)]
+
+        , let cs = [ ExConstraint (ScopeAnySetupQualifier "D") $ mkVersionRange 1 4 ]
+          in runTest $ constraints cs $
+             mkTest dbConstraints "constrain package across setup scripts" ["A", "B", "C"] $
+             solverSuccess [("A", 7), ("B", 2), ("C", 3), ("D", 2), ("D", 3), ("D", 7)]
+        ]
      , testGroup "Package Preferences" [
           runTest $ preferences [ ExPkgPref "A" $ mkvrThis 1]      $ mkTest db13 "selectPreferredVersionSimple" ["A"] (solverSuccess [("A", 1)])
         , runTest $ preferences [ ExPkgPref "A" $ mkvrOrEarlier 2] $ mkTest db13 "selectPreferredVersionSimple2" ["A"] (solverSuccess [("A", 2)])
@@ -185,6 +208,8 @@ tests = [
           -- See issue #3203. The solver should only choose a version for A once.
           runTest $
               let db = [Right $ exAv "A" 1 []]
+
+                  p :: [String] -> Bool
                   p lg =    elem "targets: A" lg
                          && length (filter ("trying: A" `isInfixOf`) lg) == 1
               in mkTest db "deduplicate targets" ["A", "A"] $
@@ -467,6 +492,20 @@ db13 = [
   , Right $ exAv "A" 2 []
   , Right $ exAv "A" 3 []
   ]
+
+-- | A, B, and C have three different dependencies on D that can be set to
+-- different versions with qualified constraints. Each version of D can only
+-- be depended upon by one version of A, B, or C, so that the versions of A, B,
+-- and C in the install plan indicate which version of D was chosen for each
+-- dependency. The one-to-one correspondence between versions of A, B, and C and
+-- versions of D also prevents linking, which would complicate the solver's
+-- behavior.
+dbConstraints :: ExampleDb
+dbConstraints =
+    [Right $ exAv "A" v [ExFix "D" v] | v <- [1, 4, 7]]
+ ++ [Right $ exAv "B" v [] `withSetupDeps` [ExFix "D" v] | v <- [2, 5, 8]]
+ ++ [Right $ exAv "C" v [] `withSetupDeps` [ExFix "D" v] | v <- [3, 6, 9]]
+ ++ [Right $ exAv "D" v [] | v <- [1..9]]
 
 dbStanzaPreferences1 :: ExampleDb
 dbStanzaPreferences1 = [

--- a/cabal-testsuite/PackageTests/Regression/T4154/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T4154/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/Regression/T4154/install-time-with-constraint.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4154/install-time-with-constraint.test.hs
@@ -1,0 +1,8 @@
+import Test.Cabal.Prelude
+
+-- Test that unqualified command line constraints do not constrain setup
+-- dependencies. cabal should be able to install the local time-99999 by
+-- building its setup script with the installed time, even though the installed
+-- time doesn't fit the constraint.
+main = cabalTest $ withRepo "repo" $
+       cabal "new-build" ["time", "--constraint=time==99999", "--dry-run"]

--- a/cabal-testsuite/PackageTests/Regression/T4154/install-time-with-constraint.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4154/install-time-with-constraint.test.hs
@@ -4,5 +4,10 @@ import Test.Cabal.Prelude
 -- dependencies. cabal should be able to install the local time-99999 by
 -- building its setup script with the installed time, even though the installed
 -- time doesn't fit the constraint.
-main = cabalTest $ withRepo "repo" $
-       cabal "new-build" ["time", "--constraint=time==99999", "--dry-run"]
+main = cabalTest $ withRepo "repo" $ do
+  cabal "new-build" ["time", "--constraint=time==99999", "--dry-run"]
+
+  -- Constraining all uses of 'time' results in a cyclic dependency
+  -- between 'Cabal' and the new 'time'.
+  r <- fails $ cabal' "new-build" ["time", "--constraint=any.time==99999", "--dry-run"]
+  assertOutputContains "cyclic dependencies; conflict set: time:setup.Cabal, time:setup.time" r

--- a/cabal-testsuite/PackageTests/Regression/T4154/repo/Cabal-99999/Cabal.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T4154/repo/Cabal-99999/Cabal.cabal
@@ -1,0 +1,7 @@
+name:            Cabal
+version:         99999
+cabal-version:   >=1.8
+build-type:      Simple
+
+library
+  build-depends: base, time

--- a/cabal-testsuite/PackageTests/Regression/T4154/time.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T4154/time.cabal
@@ -1,0 +1,10 @@
+name:            time
+version:         99999
+cabal-version:   >=1.8
+build-type:      Custom
+
+custom-setup
+  setup-depends: base, Cabal == 99999
+
+library
+  build-depends: base


### PR DESCRIPTION
This PR is a continuation of #4236.  I made two changes to `ConstraintScope` before enforcing the constraints in the solver:
* I removed the `Namespace` from the `ScopeQualified` constructor.  This change doesn't affect the behavior of the solver, because we currently don't use `Namespace` anywhere.
* I added a `ScopeAnySetupQualifier` constructor to allow constraints to apply to all setup scripts.  The new constructor is only used internally in this PR.

This PR also adds dependencies with version ranges to the solver DSL.  I ended up not needing the version ranges for these unit tests, but I left them because I think they could be useful.

/cc @robjhen @kosmikus 


EDIT:

/cc @dcoutts @23Skidoo @ezyang @Ericson2314 @hvr @phadej 

Here is a summary of the changes, from the changelog:

* Added qualified constraints for setup dependencies. For example,
--constraint="setup.bar == 1.0" constrains all setup dependencies on
bar, and --constraint="foo:setup.bar == 1.0" constrains foo's setup
dependency on bar (part of #3502).
* Non-qualified constraints, such as --constraint="bar == 1.0", now
only apply to top-level dependencies. They don't constrain setup or
build-tool dependencies. The new syntax --constraint="any.bar == 1.0"
constrains all uses of bar.
