### PR TITLE
Fix #4270: make detailed-0.9 test suites work with dynamic exes

### DIFF
--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -37,7 +37,7 @@ import qualified Control.Exception as CE
 import System.Directory
     ( createDirectoryIfMissing, doesDirectoryExist, doesFileExist
     , getCurrentDirectory, removeDirectoryRecursive, removeFile
-    , setCurrentDirectory )
+    , setCurrentDirectory, makeAbsolute )
 import System.Exit ( ExitCode(..), exitWith )
 import System.FilePath ( (</>), (<.>) )
 import System.IO ( hClose, hGetContents, hPutStr )
@@ -94,7 +94,8 @@ runTest pkg_descr lbi clbi flags suite = do
                                   let (Platform _ os) = LBI.hostPlatform lbi
                                   paths <- LBI.depLibraryPaths
                                              True False lbi clbi
-                                  return (addLibraryPath os paths shellEnv)
+                                  cpath <- makeAbsolute $ LBI.componentBuildDir lbi clbi
+                                  return (addLibraryPath os (cpath : paths) shellEnv)
                                 else return shellEnv
                 createProcessWithEnv verbosity cmd opts Nothing (Just shellEnv')
                                      -- these handles are closed automatically

--- a/cabal-testsuite/PackageTests/Regression/T4270/Lib.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4270/Lib.hs
@@ -1,0 +1,4 @@
+module Lib where
+
+foo :: Bool
+foo = True

--- a/cabal-testsuite/PackageTests/Regression/T4270/T4270.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T4270/T4270.cabal
@@ -1,0 +1,20 @@
+name: T4270
+version: 0.1
+cabal-version: >= 1.2
+license: BSD3
+author: Benno Fünfstück
+stability: stable
+category: PackageTests
+build-type: Simple
+cabal-version: >= 1.9.2
+
+description: Check type detailed-0.9 test suites with dynamic linking.
+
+library
+  exposed-modules: Lib
+  build-depends: base
+
+test-suite test
+  type: detailed-0.9
+  test-module: Test
+  build-depends: base, Cabal, T4270

--- a/cabal-testsuite/PackageTests/Regression/T4270/Test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4270/Test.hs
@@ -1,0 +1,17 @@
+module Test where
+
+import Lib
+
+import Distribution.TestSuite
+
+tests :: IO [Test]
+tests = return [Test bar]
+  where
+    bar = TestInstance
+        { run = return $ Finished run
+        , name = "test"
+        , tags = []
+        , options = []
+        , setOption = \_ _ -> Right bar
+        }
+    run = if foo then Pass else Fail "should pass"

--- a/cabal-testsuite/PackageTests/Regression/T4270/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4270/setup.test.hs
@@ -1,0 +1,9 @@
+import Test.Cabal.Prelude
+-- Test if detailed-0.9 builds correctly and runs
+-- when linked dynamically
+-- See https://github.com/haskell/cabal/issues/4270
+main = setupAndCabalTest $ do
+  skipUnless =<< hasSharedLibraries
+  skipUnless =<< hasCabalShared
+  setup_build ["--enable-tests", "--enable-executable-dynamic"]
+  setup "test" []

--- a/cabal-testsuite/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/Test/Cabal/Monad.hs
@@ -283,6 +283,7 @@ runTestM m = do
                     testScriptEnv = senv,
                     testSetupPath = dist_dir </> "setup" </> "setup",
                     testSkipSetupTests =  argSkipSetupTests (testCommonArgs args),
+                    testHaveCabalShared = withSharedLib lbi,
                     testEnvironment =
                         -- Try to avoid Unicode output
                         [ ("LC_ALL", Just "C")
@@ -368,6 +369,10 @@ data TestEnv = TestEnv
     , testSetupPath :: FilePath
     -- | Skip Setup tests?
     , testSkipSetupTests :: Bool
+    -- | Do we have shared libraries for the Cabal-under-tests?
+    -- This is used for example to determine whether we can build
+    -- detailed-0.9 tests dynamically, since they link against Cabal-under-test.
+    , testHaveCabalShared :: Bool
 
     -- CHANGING:
 

--- a/cabal-testsuite/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/Test/Cabal/Prelude.hs
@@ -573,6 +573,16 @@ hasSharedLibraries = do
     shared_libs_were_removed <- ghcVersionIs (>= mkVersion [7,8])
     return (not (buildOS == Windows && shared_libs_were_removed))
 
+-- | Check if the GHC that is used for compiling package tests has
+-- a shared library of the cabal library under test in its database.
+--
+-- An example where this is needed is if you want to dynamically link
+-- detailed-0.9 test suites, since those depend on the Cabal library unde rtest.
+hasCabalShared :: TestM Bool
+hasCabalShared = do
+  env <- getTestEnv
+  return (testHaveCabalShared env)
+
 ghcVersionIs :: WithCallStack ((Version -> Bool) -> TestM Bool)
 ghcVersionIs f = do
     ghc_program <- requireProgramM ghcProgram


### PR DESCRIPTION
The detailed-0.9 test suite type compiles the test module into a shared library,
so for running the tests, we need to include the directory where the shared
library is stored in LD_LIBRARY_PATH.