### PR TITLE
Fix deprecation warnings from containers

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -131,6 +131,7 @@ library
     Distribution.Compat.Exception
     Distribution.Compat.Graph
     Distribution.Compat.Internal.TempFile
+    Distribution.Compat.Map.Strict
     Distribution.Compat.Prelude.Internal
     Distribution.Compat.ReadP
     Distribution.Compat.Semigroup

--- a/Cabal/Distribution/Compat/Map/Strict.hs
+++ b/Cabal/Distribution/Compat/Map/Strict.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE CPP #-}
+
+module Distribution.Compat.Map.Strict
+    ( module X
+#if MIN_VERSION_containers(0,5,0)
+#else
+    , insertWith
+#endif
+    ) where
+
+#if MIN_VERSION_containers(0,5,0)
+import Data.Map.Strict as X
+#else
+import Data.Map as X hiding (insertWith, insertWith')
+import qualified Data.Map
+
+insertWith :: Ord k => (a -> a -> a) -> k -> a -> Map k a -> Map k a
+insertWith = Data.Map.insertWith'
+#endif

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -111,6 +111,7 @@ module Distribution.Simple.PackageIndex (
 
 import Prelude ()
 import Distribution.Compat.Prelude hiding (lookup)
+import qualified Distribution.Compat.Map.Strict as Map
 
 import Distribution.Package
 import Distribution.Backpack
@@ -125,7 +126,6 @@ import Data.Array ((!))
 import qualified Data.Array as Array
 import qualified Data.Graph as Graph
 import Data.List as List ( groupBy,  deleteBy, deleteFirstsBy )
-import qualified Data.Map.Strict as Map
 import qualified Data.Tree  as Tree
 
 -- | The collection of information about packages from one or more 'PackageDB's.

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -125,7 +125,7 @@ import Data.Array ((!))
 import qualified Data.Array as Array
 import qualified Data.Graph as Graph
 import Data.List as List ( groupBy,  deleteBy, deleteFirstsBy )
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import qualified Data.Tree  as Tree
 
 -- | The collection of information about packages from one or more 'PackageDB's.
@@ -271,12 +271,12 @@ insert pkg (PackageIndex pids pnames) =
     pids'   = Map.insert (installedUnitId pkg) pkg pids
     pnames' = insertPackageName pnames
     insertPackageName =
-      Map.insertWith' (\_ -> insertPackageVersion)
+      Map.insertWith (\_ -> insertPackageVersion)
                      (packageName pkg)
                      (Map.singleton (packageVersion pkg) [pkg])
 
     insertPackageVersion =
-      Map.insertWith' (\_ -> insertPackageInstance)
+      Map.insertWith (\_ -> insertPackageInstance)
                      (packageVersion pkg) [pkg]
 
     insertPackageInstance pkgs =


### PR DESCRIPTION
This also bumps the lower bound on containers to `>= 0.5` which
should be fine since that was released in May 2012. This change
should work therefore fine with the last 4 major GHC releases.