### PR TITLE
Prototype for source repository support in cabal.project

### DIFF
--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -15,6 +15,10 @@
 
 module Distribution.Client.Get (
     get
+  , findUsableBranchers
+  , findBranchCmd
+  , Brancher(..)
+  , BranchCmd(..)
   ) where
 
 import Prelude ()

--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -15,10 +15,6 @@
 
 module Distribution.Client.Get (
     get
-  , findUsableBranchers
-  , findBranchCmd
-  , Brancher(..)
-  , BranchCmd(..)
   ) where
 
 import Prelude ()
@@ -29,12 +25,14 @@ import Distribution.Package
 import Distribution.Simple.Setup
          ( Flag(..), fromFlag, fromFlagOrDefault )
 import Distribution.Simple.Utils
-         ( notice, die, info, rawSystemExitCode, writeFileAtomic )
+         ( notice, die, info, writeFileAtomic )
 import Distribution.Verbosity
          ( Verbosity )
 import Distribution.Text(display)
 import qualified Distribution.PackageDescription as PD
 
+import Distribution.Client.Get.Brancher
+         ( Brancher, BranchCmd(..), findBranchCmd, findUsableBranchers )
 import Distribution.Client.Setup
          ( GlobalFlags(..), GetFlags(..), RepoContext(..) )
 import Distribution.Client.Types
@@ -44,24 +42,13 @@ import Distribution.Client.FetchUtils
 import qualified Distribution.Client.Tar as Tar (extractTarGzFile)
 import Distribution.Client.IndexUtils as IndexUtils
         ( getSourcePackagesAtIndexState, IndexState(..) )
-import Distribution.Client.Compat.Process
-        ( readProcessWithExitCode )
-import Distribution.Compat.Exception
-        ( catchIO )
-
 import Distribution.Solver.Types.SourcePackage
 
-import Control.Exception
-         ( finally )
 import Control.Monad
          ( forM_, mapM_ )
 import qualified Data.Map
-import Data.Ord
-         ( comparing )
 import System.Directory
-         ( createDirectoryIfMissing, doesDirectoryExist, doesFileExist
-         , getCurrentDirectory, setCurrentDirectory
-         )
+         ( createDirectoryIfMissing, doesDirectoryExist, doesFileExist )
 import System.Exit
          ( ExitCode(..) )
 import System.FilePath
@@ -181,41 +168,9 @@ unpackPackage verbosity prefix pkgid descOverride pkgPath = do
                       ++ " with the latest revision from the index."
         writeFileAtomic descFilePath pkgtxt
 
-
 -- ------------------------------------------------------------
 -- * Forking the source repository
 -- ------------------------------------------------------------
-
-data BranchCmd = BranchCmd (Verbosity -> FilePath -> IO ExitCode)
-
-data Brancher = Brancher
-    { brancherBinary :: String
-    , brancherBuildCmd :: PD.SourceRepo -> Maybe BranchCmd
-    }
-
--- | The set of all supported branch drivers.
-allBranchers :: [(PD.RepoType, Brancher)]
-allBranchers =
-    [ (PD.Bazaar, branchBzr)
-    , (PD.Darcs, branchDarcs)
-    , (PD.Git, branchGit)
-    , (PD.Mercurial, branchHg)
-    , (PD.SVN, branchSvn)
-    ]
-
--- | Find which usable branch drivers (selected from 'allBranchers') are
--- available and usable on the local machine.
---
--- Each driver's main command is run with @--help@, and if the child process
--- exits successfully, that brancher is considered usable.
-findUsableBranchers :: IO (Data.Map.Map PD.RepoType Brancher)
-findUsableBranchers = do
-    let usable (_, brancher) = flip catchIO (const (return False)) $ do
-         let cmd = brancherBinary brancher
-         (exitCode, _, _) <- readProcessWithExitCode cmd ["--help"] ""
-         return (exitCode == ExitSuccess)
-    pairs <- filterM usable allBranchers
-    return (Data.Map.fromList pairs)
 
 -- | Fork a single package from a remote source repository to the local
 -- file system.
@@ -256,101 +211,3 @@ forkPackage verbosity branchers prefix kind src = do
                        ++ " does not have any source repositories.")
             _ -> die ("Package " ++ pkgid
                       ++ " does not have any usable source repositories.")
-
--- | Given a set of possible branchers, and a set of possible source
--- repositories, find a repository that is both 1) likely to be specific to
--- this source version and 2) is supported by the local machine.
-findBranchCmd :: Data.Map.Map PD.RepoType Brancher -> [PD.SourceRepo]
-                 -> (Maybe PD.RepoKind) -> Maybe BranchCmd
-findBranchCmd branchers allRepos maybeKind = cmd where
-    -- Sort repositories by kind, from This to Head to Unknown. Repositories
-    -- with equivalent kinds are selected based on the order they appear in
-    -- the Cabal description file.
-    repos' = sortBy (comparing thisFirst) allRepos
-    thisFirst r = case PD.repoKind r of
-        PD.RepoThis -> 0 :: Int
-        PD.RepoHead -> case PD.repoTag r of
-            -- If the type is 'head' but the author specified a tag, they
-            -- probably meant to create a 'this' repository but screwed up.
-            Just _ -> 0
-            Nothing -> 1
-        PD.RepoKindUnknown _ -> 2
-
-    -- If the user has specified the repo kind, filter out the repositories
-    -- she's not interested in.
-    repos = maybe repos' (\k -> filter ((==) k . PD.repoKind) repos') maybeKind
-
-    repoBranchCmd repo = do
-        t <- PD.repoType repo
-        brancher <- Data.Map.lookup t branchers
-        brancherBuildCmd brancher repo
-
-    cmd = listToMaybe (mapMaybe repoBranchCmd repos)
-
--- | Branch driver for Bazaar.
-branchBzr :: Brancher
-branchBzr = Brancher "bzr" $ \repo -> do
-    src <- PD.repoLocation repo
-    let args dst = case PD.repoTag repo of
-         Just tag -> ["branch", src, dst, "-r", "tag:" ++ tag]
-         Nothing -> ["branch", src, dst]
-    return $ BranchCmd $ \verbosity dst -> do
-        notice verbosity ("bzr: branch " ++ show src)
-        rawSystemExitCode verbosity "bzr" (args dst)
-
--- | Branch driver for Darcs.
-branchDarcs :: Brancher
-branchDarcs = Brancher "darcs" $ \repo -> do
-    src <- PD.repoLocation repo
-    let args dst = case PD.repoTag repo of
-         Just tag -> ["get", src, dst, "-t", tag]
-         Nothing -> ["get", src, dst]
-    return $ BranchCmd $ \verbosity dst -> do
-        notice verbosity ("darcs: get " ++ show src)
-        rawSystemExitCode verbosity "darcs" (args dst)
-
--- | Branch driver for Git.
-branchGit :: Brancher
-branchGit = Brancher "git" $ \repo -> do
-    src <- PD.repoLocation repo
-    let postClone verbosity dst = case PD.repoTag repo of
-         Just t -> do
-             cwd <- getCurrentDirectory
-             setCurrentDirectory dst
-             finally
-                 (rawSystemExitCode verbosity "git" ["checkout", t])
-                 (setCurrentDirectory cwd)
-         Nothing -> return ExitSuccess
-    return $ BranchCmd $ \verbosity dst -> do
-        notice verbosity ("git: clone " ++ show src)
-        code <- rawSystemExitCode verbosity "git" (["clone", src, dst] ++
-                    case PD.repoBranch repo of
-                        Nothing -> []
-                        Just b -> ["--branch", b])
-        case code of
-            ExitFailure _ -> return code
-            ExitSuccess -> postClone verbosity  dst
-
--- | Branch driver for Mercurial.
-branchHg :: Brancher
-branchHg = Brancher "hg" $ \repo -> do
-    src <- PD.repoLocation repo
-    let branchArgs = case PD.repoBranch repo of
-         Just b -> ["--branch", b]
-         Nothing -> []
-    let tagArgs = case PD.repoTag repo of
-         Just t -> ["--rev", t]
-         Nothing -> []
-    let args dst = ["clone", src, dst] ++ branchArgs ++ tagArgs
-    return $ BranchCmd $ \verbosity dst -> do
-        notice verbosity ("hg: clone " ++ show src)
-        rawSystemExitCode verbosity "hg" (args dst)
-
--- | Branch driver for Subversion.
-branchSvn :: Brancher
-branchSvn = Brancher "svn" $ \repo -> do
-    src <- PD.repoLocation repo
-    let args dst = ["checkout", src, dst]
-    return $ BranchCmd $ \verbosity dst -> do
-        notice verbosity ("svn: checkout " ++ show src)
-        rawSystemExitCode verbosity "svn" (args dst)

--- a/cabal-install/Distribution/Client/Get/Brancher.hs
+++ b/cabal-install/Distribution/Client/Get/Brancher.hs
@@ -1,0 +1,155 @@
+module Distribution.Client.Get.Brancher where
+
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
+import Distribution.Verbosity
+         ( Verbosity )
+import Distribution.Compat.Exception
+        ( catchIO )
+import qualified Distribution.PackageDescription as PD
+import Distribution.Simple.Utils
+         ( notice, rawSystemExitCode )
+
+import Distribution.Client.Compat.Process
+        ( readProcessWithExitCode )
+
+import Control.Exception
+         ( finally )
+import qualified Data.Map
+import Data.Ord
+         ( comparing )
+import System.Directory
+         ( getCurrentDirectory, setCurrentDirectory )
+import System.Exit
+         ( ExitCode(..) )
+
+
+data BranchCmd = BranchCmd (Verbosity -> FilePath -> IO ExitCode)
+
+data Brancher = Brancher
+    { brancherBinary :: String
+    , brancherBuildCmd :: PD.SourceRepo -> Maybe BranchCmd
+    }
+
+-- | The set of all supported branch drivers.
+allBranchers :: [(PD.RepoType, Brancher)]
+allBranchers =
+    [ (PD.Bazaar, branchBzr)
+    , (PD.Darcs, branchDarcs)
+    , (PD.Git, branchGit)
+    , (PD.Mercurial, branchHg)
+    , (PD.SVN, branchSvn)
+    ]
+
+-- | Find which usable branch drivers (selected from 'allBranchers') are
+-- available and usable on the local machine.
+--
+-- Each driver's main command is run with @--help@, and if the child process
+-- exits successfully, that brancher is considered usable.
+findUsableBranchers :: IO (Data.Map.Map PD.RepoType Brancher)
+findUsableBranchers = do
+    let usable (_, brancher) = flip catchIO (const (return False)) $ do
+         let cmd = brancherBinary brancher
+         (exitCode, _, _) <- readProcessWithExitCode cmd ["--help"] ""
+         return (exitCode == ExitSuccess)
+    pairs <- filterM usable allBranchers
+    return (Data.Map.fromList pairs)
+
+-- | Given a set of possible branchers, and a set of possible source
+-- repositories, find a repository that is both 1) likely to be specific to
+-- this source version and 2) is supported by the local machine.
+findBranchCmd :: Data.Map.Map PD.RepoType Brancher -> [PD.SourceRepo]
+                 -> (Maybe PD.RepoKind) -> Maybe BranchCmd
+findBranchCmd branchers allRepos maybeKind = cmd where
+    -- Sort repositories by kind, from This to Head to Unknown. Repositories
+    -- with equivalent kinds are selected based on the order they appear in
+    -- the Cabal description file.
+    repos' = sortBy (comparing thisFirst) allRepos
+    thisFirst r = case PD.repoKind r of
+        PD.RepoThis -> 0 :: Int
+        PD.RepoHead -> case PD.repoTag r of
+            -- If the type is 'head' but the author specified a tag, they
+            -- probably meant to create a 'this' repository but screwed up.
+            Just _ -> 0
+            Nothing -> 1
+        PD.RepoKindUnknown _ -> 2
+
+    -- If the user has specified the repo kind, filter out the repositories
+    -- she's not interested in.
+    repos = maybe repos' (\k -> filter ((==) k . PD.repoKind) repos') maybeKind
+
+    repoBranchCmd repo = do
+        t <- PD.repoType repo
+        brancher <- Data.Map.lookup t branchers
+        brancherBuildCmd brancher repo
+
+    cmd = listToMaybe (mapMaybe repoBranchCmd repos)
+
+-- | Branch driver for Bazaar.
+branchBzr :: Brancher
+branchBzr = Brancher "bzr" $ \repo -> do
+    src <- PD.repoLocation repo
+    let args dst = case PD.repoTag repo of
+         Just tag -> ["branch", src, dst, "-r", "tag:" ++ tag]
+         Nothing -> ["branch", src, dst]
+    return $ BranchCmd $ \verbosity dst -> do
+        notice verbosity ("bzr: branch " ++ show src)
+        rawSystemExitCode verbosity "bzr" (args dst)
+
+-- | Branch driver for Darcs.
+branchDarcs :: Brancher
+branchDarcs = Brancher "darcs" $ \repo -> do
+    src <- PD.repoLocation repo
+    let args dst = case PD.repoTag repo of
+         Just tag -> ["get", src, dst, "-t", tag]
+         Nothing -> ["get", src, dst]
+    return $ BranchCmd $ \verbosity dst -> do
+        notice verbosity ("darcs: get " ++ show src)
+        rawSystemExitCode verbosity "darcs" (args dst)
+
+-- | Branch driver for Git.
+branchGit :: Brancher
+branchGit = Brancher "git" $ \repo -> do
+    src <- PD.repoLocation repo
+    let postClone verbosity dst = case PD.repoTag repo of
+         Just t -> do
+             cwd <- getCurrentDirectory
+             setCurrentDirectory dst
+             finally
+                 (rawSystemExitCode verbosity "git" ["checkout", t])
+                 (setCurrentDirectory cwd)
+         Nothing -> return ExitSuccess
+    return $ BranchCmd $ \verbosity dst -> do
+        notice verbosity ("git: clone " ++ show src)
+        code <- rawSystemExitCode verbosity "git" (["clone", src, dst] ++
+                    case PD.repoBranch repo of
+                        Nothing -> []
+                        Just b -> ["--branch", b])
+        case code of
+            ExitFailure _ -> return code
+            ExitSuccess -> postClone verbosity  dst
+
+-- | Branch driver for Mercurial.
+branchHg :: Brancher
+branchHg = Brancher "hg" $ \repo -> do
+    src <- PD.repoLocation repo
+    let branchArgs = case PD.repoBranch repo of
+         Just b -> ["--branch", b]
+         Nothing -> []
+    let tagArgs = case PD.repoTag repo of
+         Just t -> ["--rev", t]
+         Nothing -> []
+    let args dst = ["clone", src, dst] ++ branchArgs ++ tagArgs
+    return $ BranchCmd $ \verbosity dst -> do
+        notice verbosity ("hg: clone " ++ show src)
+        rawSystemExitCode verbosity "hg" (args dst)
+
+-- | Branch driver for Subversion.
+branchSvn :: Brancher
+branchSvn = Brancher "svn" $ \repo -> do
+    src <- PD.repoLocation repo
+    let args dst = ["checkout", src, dst]
+    return $ BranchCmd $ \verbosity dst -> do
+        notice verbosity ("svn: checkout " ++ show src)
+        rawSystemExitCode verbosity "svn" (args dst)

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -48,7 +48,7 @@ module Distribution.Client.ProjectConfig (
 import Prelude ()
 import Distribution.Client.Compat.Prelude
 
-import Distribution.Client.Get
+import Distribution.Client.Get.Brancher
          ( BranchCmd(..), findUsableBranchers, findBranchCmd )
 import Distribution.Client.ProjectConfig.Types
 import Distribution.Client.ProjectConfig.Legacy

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -48,6 +48,8 @@ module Distribution.Client.ProjectConfig (
 import Prelude ()
 import Distribution.Client.Compat.Prelude
 
+import Distribution.Client.Get
+         ( BranchCmd(..), findUsableBranchers, findBranchCmd )
 import Distribution.Client.ProjectConfig.Types
 import Distribution.Client.ProjectConfig.Legacy
 import Distribution.Client.RebuildMonad
@@ -56,7 +58,7 @@ import Distribution.Client.Glob
 
 import Distribution.Client.Types
 import Distribution.Client.DistDirLayout
-         ( CabalDirLayout(..) )
+         ( CabalDirLayout(..), DistDirLayout(..) )
 import Distribution.Client.GlobalFlags
          ( RepoContext(..), withRepoContext' )
 import Distribution.Client.BuildReports.Types
@@ -115,6 +117,8 @@ import Data.Either
 import qualified Data.Map as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import System.Exit
+         ( ExitCode(..) )
 import System.FilePath hiding (combine)
 import System.Directory
 import Network.URI (URI(..), URIAuth(..), parseAbsoluteURI)
@@ -862,14 +866,17 @@ mplusMaybeT ma mb = do
 -- Note here is where we convert from project-root relative paths to absolute
 -- paths.
 --
-readSourcePackage :: Verbosity -> ProjectPackageLocation
+readSourcePackage :: Verbosity -> DistDirLayout -> ProjectPackageLocation
                   -> Rebuild UnresolvedSourcePackage
-readSourcePackage verbosity (ProjectPackageLocalCabalFile cabalFile) =
-    readSourcePackage verbosity (ProjectPackageLocalDirectory dir cabalFile)
+readSourcePackage verbosity distDirLayout (ProjectPackageLocalCabalFile cabalFile) =
+    readSourcePackage
+      verbosity
+      distDirLayout
+      (ProjectPackageLocalDirectory dir cabalFile)
   where
     dir = takeDirectory cabalFile
 
-readSourcePackage verbosity (ProjectPackageLocalDirectory dir cabalFile) = do
+readSourcePackage verbosity _ (ProjectPackageLocalDirectory dir cabalFile) = do
     monitorFiles [monitorFileHashed cabalFile]
     root <- askRoot
     pkgdesc <- liftIO $ readGenericPackageDescription verbosity (root </> cabalFile)
@@ -879,7 +886,45 @@ readSourcePackage verbosity (ProjectPackageLocalDirectory dir cabalFile) = do
       packageSource        = LocalUnpackedPackage (root </> dir),
       packageDescrOverride = Nothing
     }
-readSourcePackage _verbosity _ =
+
+readSourcePackage verbosity distDirLayout (ProjectPackageRemoteRepo repo) = do
+
+    when (isNothing (repoTag repo)) $ do
+        fail ("Source repository without tag are not allowed")
+
+    branchers <- liftIO findUsableBranchers
+    let
+      tag     = fromJust (repoTag repo)
+      destDir = distUnpackedSrcRootDirectory distDirLayout </> ("src-" ++ tag)
+      subdir  = fromMaybe "" (repoSubdir repo)
+      pkgdir  = destDir </> subdir
+      repoloc = fromMaybe "" (repoLocation repo)
+
+    repoExists <- liftIO $ doesDirectoryExist destDir
+    when (not repoExists) $ do
+      case findBranchCmd branchers [repo] Nothing of
+        Just (BranchCmd fork) -> do
+          exitCode <- liftIO $ fork verbosity destDir
+          case exitCode of
+            ExitSuccess   -> return ()
+            ExitFailure _ -> fail ("Couldn't fork package from " ++ repoloc)
+        Nothing -> fail ("No usable brancher found for " ++ repoloc)
+
+    pkgdirExists <- liftIO $ doesDirectoryExist pkgdir
+    when (not pkgdirExists) $ do
+      fail ("Subdirectory does not exists in repository " ++ repoloc)
+
+    matches <- matchFileGlob (globStarDotCabal pkgdir)
+    case matches of
+        [cabalFile]
+            -> readSourcePackage
+                verbosity
+                distDirLayout
+                (ProjectPackageLocalDirectory pkgdir cabalFile)
+        [] -> fail ("No cabal file found in source repository")
+        _  -> fail ("More than one cabal file found in source repository")
+
+readSourcePackage _verbosity _ _ =
     fail $ "TODO: add support for fetching and reading local tarballs, remote "
         ++ "tarballs, remote repos and passing named packages through"
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -392,8 +392,8 @@ rebuildInstallPlan verbosity
     phaseReadLocalPackages projectConfig = do
 
       localCabalFiles <- findProjectPackages projectRootDir projectConfig
-      mapM (readSourcePackage verbosity) localCabalFiles
 
+      mapM (readSourcePackage verbosity distDirLayout) localCabalFiles
 
     -- Configure the compiler we're using.
     --
@@ -2815,7 +2815,7 @@ setupHsTestFlags :: ElaboratedConfiguredPackage
                  -> ElaboratedSharedConfig
                  -> Verbosity
                  -> FilePath
-                 -> Cabal.TestFlags 
+                 -> Cabal.TestFlags
 setupHsTestFlags _ _ verbosity builddir = Cabal.TestFlags
     { testDistPref    = toFlag builddir
     , testVerbosity   = toFlag verbosity

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -232,6 +232,7 @@ executable cabal
         Distribution.Client.Freeze
         Distribution.Client.GenBounds
         Distribution.Client.Get
+        Distribution.Client.Get.Brancher
         Distribution.Client.Glob
         Distribution.Client.GlobalFlags
         Distribution.Client.GZipUtils


### PR DESCRIPTION
This is a try at https://github.com/haskell/cabal/issues/2189

Please lets have a discussion about this. I would like to have this feature!

This allows to write the following in your cabal.project file

```
source-repository-package
  type: git
  location: https://github.com/....
  subdir: somesubdirinyourrepository
  tag: 481cabcab15501f300728bfa4f6de517d4492777
```

And it gets picked up as a dependency to your project.