### PR TITLE
cabal-testsuite: check return code of `runghc Setup.hs`

### DIFF
--- a/cabal-testsuite/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/Test/Cabal/Prelude.hs
@@ -143,11 +143,14 @@ setup' cmd args = do
             if buildType (packageDescription pdesc) == Just Simple
                 then runM (testSetupPath env) full_args
                 -- Run the Custom script!
-                else liftIO $ runghc (testScriptEnv env)
-                                (Just (testCurrentDir env))
-                                (testEnvironment env)
-                                (testCurrentDir env </> "Setup.hs")
-                                full_args
+                else do
+                  r <- liftIO $ runghc (testScriptEnv env)
+                                       (Just (testCurrentDir env))
+                                       (testEnvironment env)
+                                       (testCurrentDir env </> "Setup.hs")
+                                       full_args
+                  record r
+                  requireSuccess r
     -- This code is very tempting (and in principle should be quick:
     -- after all we are loading the built version of Cabal), but
     -- actually it costs quite a bit in wallclock time (e.g. 54sec to

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -64,7 +64,8 @@ executable cabal-tests
     filepath,
     process,
     optparse-applicative,
-    cabal-testsuite
+    cabal-testsuite,
+    exceptions
   default-language: Haskell2010
 
 custom-setup

--- a/cabal-testsuite/tests/Setup.hs
+++ b/cabal-testsuite/tests/Setup.hs
@@ -1,0 +1,4 @@
+import System.Exit
+
+main :: IO ()
+main = exitFailure

--- a/cabal-testsuite/tests/fail.test.hs
+++ b/cabal-testsuite/tests/fail.test.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+import Test.Cabal.Prelude
+import Data.IORef
+import Control.Monad.IO.Class
+import Control.Monad.Catch
+import Control.Exception (ErrorCall)
+
+main = setupTest $ do
+  -- the following is a hack to check that `setup configure` indeed
+  -- fails: all tests use `assertFailure` which uses `error` if the fail
+  --
+  -- note: we cannot use `fails $ do ...` here since that only checks that all
+  -- assertions fail. If there is no assertion in `m`, then `fails m` will *succeed*.
+  -- That's not what we want. So `fails (return ())` for example succeeds, even though
+  -- `return ()` doesn't fail.
+  succeededRef <- liftIO $ newIORef True
+  setup "configure" [] `catch` \(_ :: ErrorCall) ->
+    liftIO $ writeIORef succeededRef False
+  succeeded <- liftIO $ readIORef succeededRef
+  assertBool "test should have failed, but succeeded instead (configure exits with failure)" $ not succeeded

--- a/cabal-testsuite/tests/fail.test.hs
+++ b/cabal-testsuite/tests/fail.test.hs
@@ -2,8 +2,9 @@
 import Test.Cabal.Prelude
 import Data.IORef
 import Control.Monad.IO.Class
-import Control.Monad.Catch
 import Control.Exception (ErrorCall)
+
+import qualified Control.Monad.Catch as Catch
 
 main = setupTest $ do
   -- the following is a hack to check that `setup configure` indeed
@@ -14,7 +15,7 @@ main = setupTest $ do
   -- That's not what we want. So `fails (return ())` for example succeeds, even though
   -- `return ()` doesn't fail.
   succeededRef <- liftIO $ newIORef True
-  setup "configure" [] `catch` \(_ :: ErrorCall) ->
+  setup "configure" [] `Catch.catch` \(_ :: ErrorCall) ->
     liftIO $ writeIORef succeededRef False
   succeeded <- liftIO $ readIORef succeededRef
   assertBool "test should have failed, but succeeded instead (configure exits with failure)" $ not succeeded

--- a/cabal-testsuite/tests/tests.cabal
+++ b/cabal-testsuite/tests/tests.cabal
@@ -1,0 +1,4 @@
+name: foo
+version: 0.1
+build-type: Custom
+


### PR DESCRIPTION
This PR fixes a bug in the cabal-testsuite, where the result of calling `runghc Setup.hs`
wasn't checked for failure.

I also wrote a regression test for this, however that test depends on the fact that failing
tests throw `ErrorCall`, and I'm not sure if it's good to rely on that in a test. I haven't
found any other way to check whether a test fails though, since `fails` only checks that all
assertions fail, while in this case I want to check that there actually is an assertion. In
other words, `fails (return ())` succeeds, which is not what we need in this case.