### PR TITLE
Fix strict reading of package index

### DIFF
--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE GADTs #-}
 
 -----------------------------------------------------------------------------

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -676,12 +676,10 @@ packageListFromCache mkPkg hnd Cache{..} mode = accum mempty [] mempty cacheEntr
         pkgtxt <- getEntryContent blockno
         pkg    <- readPackageDescription pkgtxt
         return (pkg, pkgtxt)
-      let srcpkg = case mode of
-            ReadPackageIndexLazyIO ->
-              mkPkg (NormalPackage pkgid pkg pkgtxt blockno)
-            ReadPackageIndexStrict ->
-              pkg `seq` pkgtxt `seq` mkPkg (NormalPackage pkgid pkg
-                                            pkgtxt blockno)
+      case mode of
+        ReadPackageIndexLazyIO -> pure ()
+        ReadPackageIndexStrict -> evaluate pkg *> evaluate pkgtxt *> pure ()
+      let srcpkg = mkPkg (NormalPackage pkgid pkg pkgtxt blockno)
       accum (Map.insert pkgid srcpkg srcpkgs) btrs prefs entries
 
     accum srcpkgs btrs prefs (CacheBuildTreeRef refType blockno : entries) = do


### PR DESCRIPTION
I was having issue with this piece in cabal-install-1.24.0.2 when using local package repository. The issue was manifesting itself as error from `hSeek` being called on a closed handle.

The issue was caused by misplaced `seq`s that were not having any effect. This resulted in `readFile` call at  https://github.com/haskell/cabal/blob/master/cabal-install/Distribution/Client/IndexUtils.hs#L273 to
end before actual data was ready, which was causing `hSeek` error later.

I believe `master` also has this problem since even though `srcpkgs` argument of type `Map` is forced through bang pattern, the map itself is lazy. I believe `seq`ing against monadic action is appropriate here to force the values.

However, this issue was biting cabal built from branch `1.24`. Should I submit this change there as well?