### PR TITLE
implement a new-exec command

### DIFF
--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -531,13 +531,15 @@ simpleGhcEnvironmentFile packageDBs pkgids =
 --
 -- The 'Platform' and GHC 'Version' are needed as part of the file name.
 --
+-- Returns the name of the file written.
 writeGhcEnvironmentFile :: FilePath  -- ^ directory in which to put it
                         -> Platform  -- ^ the GHC target platform
                         -> Version   -- ^ the GHC version
                         -> [GhcEnvironmentFileEntry] -- ^ the content
-                        -> NoCallStackIO ()
-writeGhcEnvironmentFile directory platform ghcversion =
-    writeFileAtomic envfile . BS.pack . renderGhcEnvironmentFile
+                        -> NoCallStackIO FilePath
+writeGhcEnvironmentFile directory platform ghcversion entries = do
+    writeFileAtomic envfile . BS.pack . renderGhcEnvironmentFile $ entries
+    return envfile
   where
     envfile = directory </> ghcEnvironmentFileName platform ghcversion
 

--- a/cabal-install/Distribution/Client/CmdExec.hs
+++ b/cabal-install/Distribution/Client/CmdExec.hs
@@ -37,11 +37,10 @@ import Distribution.Client.ProjectPlanOutput
   ( updatePostBuildProjectStatus
   , createPackageEnvironment
   )
+import qualified Distribution.Client.ProjectPlanning as Planning
 import Distribution.Client.ProjectPlanning
-  ( ElaboratedConfiguredPackage(elabPkgDescription)
-  , ElaboratedInstallPlan
+  ( ElaboratedInstallPlan
   , ElaboratedSharedConfig(..)
-  , binDirectory
   )
 import Distribution.Simple.Command
   ( CommandUI(..)
@@ -70,9 +69,6 @@ import Distribution.Simple.Utils
   , info
   , withTempDirectory
   , wrapText
-  )
-import Distribution.Types.PackageDescription
-  ( executables
   )
 import Distribution.Verbosity
   ( Verbosity
@@ -188,13 +184,8 @@ binDirectories
 binDirectories layout config = fromElaboratedInstallPlan where
   fromElaboratedInstallPlan = fromGraph . toGraph
   fromGraph = foldMap fromPlan
-  fromSrcPkg pkg = if hasExecutable pkg
-    then S.singleton (binDirectory layout config pkg)
-    else mempty
+  fromSrcPkg = S.fromList . Planning.binDirectories layout config
 
   fromPlan (PreExisting _) = mempty
   fromPlan (Configured pkg) = fromSrcPkg pkg
   fromPlan (Installed pkg) = fromSrcPkg pkg
-
-hasExecutable :: ElaboratedConfiguredPackage -> Bool
-hasExecutable = not . null . executables . elabPkgDescription

--- a/cabal-install/Distribution/Client/CmdExec.hs
+++ b/cabal-install/Distribution/Client/CmdExec.hs
@@ -88,8 +88,20 @@ execCommand = CommandUI
   , commandSynopsis = "Give a command access to the store."
   , commandUsage = \pname ->
     "Usage: " ++ pname ++ " new-exec [FLAGS] [--] COMMAND [--] [ARGS]\n"
-  , commandDescription = Just $ \_pname -> wrapText $
-    "TODO"
+  , commandDescription = Just $ \pname -> wrapText $
+       "During development it is often useful to run build tasks and perform"
+    ++ " one-off program executions to experiment with the behavior of build"
+    ++ " tools. It is convenient to run these tools in the same way " ++ pname
+    ++ " itself would. The `" ++ pname ++ " new-exec` command provides a way to"
+    ++ " do so.\n"
+    ++ "\n"
+    ++ "Compiler tools will be configured to see the same subset of the store"
+    ++ " that builds would see. The PATH is modified to make all executables in"
+    ++ " the dependency tree available (provided they have been built already)."
+    ++ " Commands are also rewritten in the way cabal itself would. For"
+    ++ " example, `" ++ pname ++ " new-exec ghc` will consult the configuration"
+    ++ " to choose an appropriate version of ghc and to include any"
+    ++ " ghc-specific flags requested."
   , commandNotes = Nothing
   , commandDefaultFlags = defaultExecFlags
   , commandOptions = \showOrParseArgs ->

--- a/cabal-install/Distribution/Client/CmdExec.hs
+++ b/cabal-install/Distribution/Client/CmdExec.hs
@@ -1,0 +1,132 @@
+-------------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Client.Exec
+-- Maintainer  :  cabal-devel@haskell.org
+-- Portability :  portable
+--
+-- Implementation of the 'new-exec' command for running an arbitrary executable
+-- in an environment suited to the part of the store built for a project.
+-------------------------------------------------------------------------------
+
+{-# LANGUAGE StandaloneDeriving #-}
+module Distribution.Client.CmdExec
+  ( execAction
+  , execCommand
+  ) where
+
+import Distribution.Client.DistDirLayout
+  ( distTempDirectory
+  )
+import Distribution.Client.Setup
+  ( GlobalFlags(..)
+  , ExecFlags(..)
+  , defaultExecFlags
+  )
+import Distribution.Client.ProjectOrchestration
+  ( ProjectBuildContext(..)
+  , PreBuildHooks(..)
+  , runProjectPreBuildPhase
+  )
+import Distribution.Client.ProjectPlanOutput
+  ( updatePostBuildProjectStatus
+  , createPackageEnvironment
+  )
+import Distribution.Simple.Command
+  ( CommandUI(..)
+  )
+import Distribution.Simple.Program.Run
+  ( ProgramInvocation(..)
+  , runProgramInvocation
+  , simpleProgramInvocation
+  )
+import Distribution.Simple.Setup
+  ( fromFlag
+  ,  optionDistPref,  optionVerbosity
+  ,  configDistPref,  configVerbosity
+  , haddockDistPref, haddockVerbosity
+  )
+import Distribution.Simple.Utils
+  ( die
+  , withTempDirectory
+  , wrapText
+  )
+
+execCommand :: CommandUI ExecFlags
+execCommand = CommandUI
+  { commandName = "new-exec"
+  , commandSynopsis = "Give a command access to the store."
+  , commandUsage = \pname ->
+    "Usage: " ++ pname ++ " new-exec [FLAGS] [--] COMMAND [--] [ARGS]\n"
+  , commandDescription = Just $ \_pname -> wrapText $
+    "TODO"
+  , commandNotes = Nothing
+  , commandDefaultFlags = defaultExecFlags
+  , commandOptions = \showOrParseArgs ->
+    [ optionVerbosity execVerbosity (\v flags -> flags { execVerbosity = v })
+    , optionDistPref
+        execDistPref (\v flags -> flags { execDistPref = v })
+        showOrParseArgs
+    ]
+  }
+
+execAction :: ExecFlags -> [String] -> GlobalFlags -> IO ()
+execAction execFlags extraArgs globalFlags = do
+  let verbosity = fromFlag (execVerbosity execFlags)
+
+  -- To set up the environment, we'd like to select the libraries in our
+  -- dependency tree that we've already built. So first we set up an install
+  -- plan, but we walk the dependency tree without first executing the plan.
+  --
+  -- TODO: We set a lot of default settings here (with mempty). It might be
+  -- worth walking through each of the settings we default and making sure they
+  -- shouldn't become ExecFlags.
+  buildCtx <- runProjectPreBuildPhase
+    verbosity
+    ( globalFlags
+    , mempty
+        { configDistPref = execDistPref execFlags
+        , configVerbosity = execVerbosity execFlags
+        }
+    , mempty
+    , mempty
+    , mempty
+        { haddockDistPref = execDistPref execFlags
+        , haddockVerbosity = execVerbosity execFlags
+        }
+    )
+    PreBuildHooks
+      { hookPrePlanning = \_ _ _ -> return ()
+      , hookSelectPlanSubset = \_ -> return
+      }
+  buildStatus <- updatePostBuildProjectStatus
+    verbosity
+    (distDirLayout buildCtx)
+    (elaboratedPlanToExecute buildCtx)
+    (pkgsBuildStatus buildCtx)
+    mempty
+
+  -- Now that we have the packages, set up the environment. We accomplish this
+  -- by creating an environment file that selects the databases and packages we
+  -- computed in the previous step, and setting an environment variable to
+  -- point at the file.
+  withTempDirectory
+    verbosity
+    (distTempDirectory (distDirLayout buildCtx))
+    "environment."
+    $ \tmpDir -> do
+      envOverrides <- createPackageEnvironment
+        verbosity
+        tmpDir
+        (elaboratedPlanToExecute buildCtx)
+        (elaboratedShared buildCtx)
+        buildStatus
+
+      -- TODO: discuss PATH munging with #hackage
+
+      case extraArgs of
+        exe:args -> runProgramInvocation
+          verbosity
+          (simpleProgramInvocation exe args)
+            { progInvokeEnv = envOverrides
+            }
+        [] -> die "Please specify an executable to run"

--- a/cabal-install/Distribution/Client/CmdExec.hs
+++ b/cabal-install/Distribution/Client/CmdExec.hs
@@ -143,6 +143,11 @@ execAction execFlags extraArgs globalFlags = do
       { hookPrePlanning = \_ _ _ -> return ()
       , hookSelectPlanSubset = \_ -> return
       }
+
+  -- We use the build status below to decide what libraries to include in the
+  -- compiler environment, but we don't want to actually build anything. So we
+  -- pass mempty to indicate that nothing happened and we just want the current
+  -- status.
   buildStatus <- updatePostBuildProjectStatus
     verbosity
     (distDirLayout buildCtx)

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -277,17 +277,19 @@ runProjectPostBuildPhase verbosity ProjectBuildContext {..} buildOutcomes = do
     --        - delete stale lib registrations
     --        - delete stale package dirs
 
-    postBuildStatus <- updatePostBuildProjectStatus
+    _postBuildStatus <- updatePostBuildProjectStatus
                          verbosity
                          distDirLayout
                          elaboratedPlanOriginal
                          pkgsBuildStatus
                          buildOutcomes
 
+    {-TODO: This feature is temporarily disabled due to #4010
     writePlanGhcEnvironment projectRootDir
                             elaboratedPlanOriginal
                             elaboratedShared
                             postBuildStatus
+    -}
 
     -- Finally if there were any build failures then report them and throw
     -- an exception to terminate the program

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -678,21 +678,21 @@ writePlanGhcEnvironment projectRootDir
   = writeGhcEnvironmentFile
       projectRootDir
       platform (compilerVersion compiler)
-      (renderGhcEnviromentFile projectRootDir
-                               elaboratedInstallPlan
-                               postBuildStatus)
+      (renderGhcEnvironmentFile projectRootDir
+                                elaboratedInstallPlan
+                                postBuildStatus)
     --TODO: [required eventually] support for writing user-wide package
     -- environments, e.g. like a global project, but we would not put the
     -- env file in the home dir, rather it lives under ~/.ghc/
 
 writePlanGhcEnvironment _ _ _ _ = return ()
 
-renderGhcEnviromentFile :: FilePath
-                        -> ElaboratedInstallPlan
-                        -> PostBuildProjectStatus
-                        -> [GhcEnvironmentFileEntry]
-renderGhcEnviromentFile projectRootDir elaboratedInstallPlan
-                        postBuildStatus =
+renderGhcEnvironmentFile :: FilePath
+                         -> ElaboratedInstallPlan
+                         -> PostBuildProjectStatus
+                         -> [GhcEnvironmentFileEntry]
+renderGhcEnvironmentFile projectRootDir elaboratedInstallPlan
+                         postBuildStatus =
     headerComment
   : simpleGhcEnvironmentFile packageDBs unitIds
   where
@@ -703,9 +703,9 @@ renderGhcEnviromentFile projectRootDir elaboratedInstallPlan
      ++ "But you still need to use cabal repl $target to get the environment\n"
      ++ "of specific components (libs, exes, tests etc) because each one can\n"
      ++ "have its own source dirs, cpp flags etc.\n\n"
-    unitIds    = selectGhcEnviromentFileLibraries postBuildStatus
+    unitIds    = selectGhcEnvironmentFileLibraries postBuildStatus
     packageDBs = relativePackageDBPaths projectRootDir $
-                 selectGhcEnviromentFilePackageDbs elaboratedInstallPlan
+                 selectGhcEnvironmentFilePackageDbs elaboratedInstallPlan
 
 
 -- We're producing an environment for users to use in ghci, so of course
@@ -740,10 +740,10 @@ renderGhcEnviromentFile projectRootDir elaboratedInstallPlan
 -- to find the libs) then those exes still end up in our list so we have
 -- to filter them out at the end.
 --
-selectGhcEnviromentFileLibraries :: PostBuildProjectStatus -> [UnitId]
-selectGhcEnviromentFileLibraries PostBuildProjectStatus{..} =
+selectGhcEnvironmentFileLibraries :: PostBuildProjectStatus -> [UnitId]
+selectGhcEnvironmentFileLibraries PostBuildProjectStatus{..} =
     case Graph.closure packagesLibDepGraph (Set.toList packagesBuildLocal) of
-      Nothing    -> error "renderGhcEnviromentFile: broken dep closure"
+      Nothing    -> error "renderGhcEnvironmentFile: broken dep closure"
       Just nodes -> [ pkgid | Graph.N pkg pkgid _ <- nodes
                             , hasUpToDateLib pkg ]
   where
@@ -761,8 +761,8 @@ selectGhcEnviromentFileLibraries PostBuildProjectStatus{..} =
        && installedUnitId pkg `Set.member` packagesProbablyUpToDate
 
 
-selectGhcEnviromentFilePackageDbs :: ElaboratedInstallPlan -> PackageDBStack
-selectGhcEnviromentFilePackageDbs elaboratedInstallPlan =
+selectGhcEnvironmentFilePackageDbs :: ElaboratedInstallPlan -> PackageDBStack
+selectGhcEnvironmentFilePackageDbs elaboratedInstallPlan =
     -- If we have any inplace packages then their package db stack is the
     -- one we should use since it'll include the store + the local db but
     -- it's certainly possible to have no local inplace packages
@@ -775,7 +775,7 @@ selectGhcEnviromentFilePackageDbs elaboratedInstallPlan =
       case ordNub (map elabBuildPackageDBStack pkgs) of
         [packageDbs] -> packageDbs
         []           -> []
-        _            -> error $ "renderGhcEnviromentFile: packages with "
+        _            -> error $ "renderGhcEnvironmentFile: packages with "
                              ++ "different package db stacks"
         -- This should not happen at the moment but will happen as soon
         -- as we support projects where we build packages with different

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -673,8 +673,6 @@ writePlanGhcEnvironment projectRootDir
   | compilerFlavor compiler == GHC
   , supportsPkgEnvFiles (getImplInfo compiler)
   --TODO: check ghcjs compat
-  --TODO: This feature is temporarily disabled due to #4010
-  , False
   = writeGhcEnvironmentFile
       projectRootDir
       platform (compilerVersion compiler)

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -45,7 +45,7 @@ module Distribution.Client.Setup
     , win32SelfUpgradeCommand, Win32SelfUpgradeFlags(..)
     , actAsSetupCommand, ActAsSetupFlags(..)
     , sandboxCommand, defaultSandboxLocation, SandboxFlags(..)
-    , execCommand, ExecFlags(..)
+    , execCommand, ExecFlags(..), defaultExecFlags
     , userConfigCommand, UserConfigFlags(..)
     , manpageCommand
 

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -234,6 +234,7 @@ library
         Distribution.Client.CmdHaddock
         Distribution.Client.CmdTest
         Distribution.Client.CmdRepl
+        Distribution.Client.CmdExec
         Distribution.Client.Config
         Distribution.Client.Configure
         Distribution.Client.Dependency

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -80,6 +80,7 @@ import qualified Distribution.Client.CmdFreeze    as CmdFreeze
 import qualified Distribution.Client.CmdHaddock   as CmdHaddock
 import qualified Distribution.Client.CmdRepl      as CmdRepl
 import qualified Distribution.Client.CmdTest      as CmdTest
+import qualified Distribution.Client.CmdExec      as CmdExec
 
 import Distribution.Client.Install            (install)
 import Distribution.Client.Configure          (configure, writeConfigFlags)
@@ -292,6 +293,7 @@ mainWorker args = topHandler $
       , hiddenCmd   CmdTest.testCommand           CmdTest.testAction
       , regularCmd  CmdFreeze.freezeCommand       CmdFreeze.freezeAction
       , regularCmd  CmdHaddock.haddockCommand     CmdHaddock.haddockAction
+      , regularCmd  CmdExec.execCommand           CmdExec.execAction
       ]
 
 type Action = GlobalFlags -> IO ()


### PR DESCRIPTION
This patch set implements a new-exec command for running compiler tools and dependency executables in an environment set up to match the set of packages cabal-install would choose for its builds. This is useful for debugging broken builds and during development for running one-off tests and build tasks by hand.

The implementation here has some oddities worth calling out:

* It relies on the `GHC_ENVIRONMENT` variable to choose an appropriate subset of packages from the store. This only works with GHC 8.0.2 and later. It also doesn't interact very cleanly with ghc-pkg, but I'm having a hard time succinctly describing the exact failure mode. To be sure `cabal new-exec ghc-pkg list` does not show all and only the packages in the current dependency tree. Perhaps this could be considered a GHC bug, though, and not an issue to solve within cabal-install itself.
* It uses the same strategy that `cabal exec` does for rewriting commands, namely, going via a `ProgramDb`. While testing I discovered that this leads to some strange behavior. For example, `cabal new-configure -w ghc-8.0.2` followed by `cabal new-exec ghc -- --version` will correctly report version 8.0.2 even if another `ghc` is on the `PATH`; but `cabal new-exec ghci -- --version` will not. (A similar caveat applies to `cabal configure` followed by `cabal exec ghci`.) Additionally, scripts which execute `ghc` will see whatever is on the `PATH` and not the correct compiler.

I am open to suggestions for mitigating these issues.