### PR TITLE
Fix GHC bootstrapping

### DIFF
--- a/Cabal/Distribution/Compat/Graph.hs
+++ b/Cabal/Distribution/Compat/Graph.hs
@@ -83,13 +83,21 @@ module Distribution.Compat.Graph (
     nodeValue,
 ) where
 
+-- For bootstrapping GHC
+#ifdef MIN_VERSION_containers
+#if MIN_VERSION_containers(0,5,0)
+#define HAVE_containers_050
+#endif
+#endif
+
 import Prelude ()
 import qualified Distribution.Compat.Prelude as Prelude
 import Distribution.Compat.Prelude hiding (lookup, null, empty)
 
 import Data.Graph (SCC(..))
 import qualified Data.Graph as G
-#if MIN_VERSION_containers(0,5,0)
+
+#ifdef HAVE_containers_050
 import qualified Data.Map.Strict as Map
 #else
 import qualified Data.Map as Map

--- a/Cabal/Distribution/Compat/Map/Strict.hs
+++ b/Cabal/Distribution/Compat/Map/Strict.hs
@@ -1,14 +1,21 @@
 {-# LANGUAGE CPP #-}
 
+-- For bootstrapping GHC
+#ifdef MIN_VERSION_containers
+#if MIN_VERSION_containers(0,5,0)
+#define HAVE_containers_050
+#endif
+#endif
+
 module Distribution.Compat.Map.Strict
     ( module X
-#if MIN_VERSION_containers(0,5,0)
+#ifdef HAVE_containers_050
 #else
     , insertWith
 #endif
     ) where
 
-#if MIN_VERSION_containers(0,5,0)
+#ifdef HAVE_containers_050
 import Data.Map.Strict as X
 #else
 import Data.Map as X hiding (insertWith, insertWith')


### PR DESCRIPTION
GHC's stage0 build doesn't provide MIN_VERSION_* macros. We need to take care to
provide appropriate version check macros by hand in GHC's build system.