### PR TITLE
Solver: Clean up log messages about inconsistent flags and stanzas.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Flag.hs
+++ b/cabal-install/Distribution/Solver/Modular/Flag.hs
@@ -88,4 +88,4 @@ showQFN :: QFN -> String
 showQFN (FN pi f) = showPI pi ++ ":" ++ unFlag f
 
 showQSN :: QSN -> String
-showQSN (SN pi f) = showPI pi ++ ":" ++ showStanza f
+showQSN (SN pi s) = showPI pi ++ ":" ++ showStanza s

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -28,6 +28,7 @@ import qualified Distribution.Solver.Modular.WeightedPSQ as W
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PackagePath
 import Distribution.Solver.Types.ComponentDeps (Component)
+import Distribution.Types.GenericPackageDescription (unFlagName)
 
 {-------------------------------------------------------------------------------
   Validation
@@ -375,7 +376,7 @@ verifyFlag' (FN (PI pn i) fn) lg = do
     if allEqual (catMaybes vals) -- We ignore not-yet assigned flags
       then return ()
       else conflict ( CS.fromList (map F flags) `CS.union` lgConflictSet lg
-                    , "flag " ++ show fn ++ " incompatible"
+                    , "flag \"" ++ unFlagName fn ++ "\" incompatible"
                     )
 
 -- | Verify that all packages in the link group agree on stanza assignments
@@ -393,7 +394,7 @@ verifyStanza' (SN (PI pn i) sn) lg = do
     if allEqual (catMaybes vals) -- We ignore not-yet assigned stanzas
       then return ()
       else conflict ( CS.fromList (map S stanzas) `CS.union` lgConflictSet lg
-                    , "stanza " ++ show sn ++ " incompatible"
+                    , "stanza \"" ++ showStanza sn ++ "\" incompatible"
                     )
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
Old output:
dependencies not linked: stanza TestStanzas incompatible;
dependencies not linked: flag FlagName "parsec" incompatible

New output:
dependencies not linked: stanza "test" incompatible;
dependencies not linked: flag "parsec" incompatible;