### PR TITLE
Move DependencyMap to its own module.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -213,6 +213,7 @@ library
     Distribution.Types.ComponentInclude
     Distribution.Types.Dependency
     Distribution.Types.ExeDependency
+    Distribution.Types.DependencyMap
     Distribution.Types.LegacyExeDependency
     Distribution.Types.PkgconfigDependency
     Distribution.Types.Executable

--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -54,6 +54,7 @@ import Distribution.Types.Dependency
 import Distribution.Types.UnqualComponentName
 import Distribution.Types.CondTree
 import Distribution.Types.Condition
+import Distribution.Types.DependencyMap
 
 import qualified Data.Map as Map
 import Data.Tree ( Tree(Node) )
@@ -307,26 +308,6 @@ toDepMapUnion ds =
 fromDepMapUnion :: DepMapUnion -> [Dependency]
 fromDepMapUnion m = [ Dependency p vr | (p,vr) <- Map.toList (unDepMapUnion m) ]
 
--- | A map of dependencies.  Newtyped since the default monoid instance is not
---   appropriate.  The monoid instance uses 'intersectVersionRanges'.
-newtype DependencyMap = DependencyMap { unDependencyMap :: Map PackageName VersionRange }
-  deriving (Show, Read)
-
-instance Monoid DependencyMap where
-    mempty = DependencyMap Map.empty
-    mappend = (<>)
-
-instance Semigroup DependencyMap where
-    (DependencyMap a) <> (DependencyMap b) =
-        DependencyMap (Map.unionWith intersectVersionRanges a b)
-
-toDepMap :: [Dependency] -> DependencyMap
-toDepMap ds =
-  DependencyMap $ Map.fromListWith intersectVersionRanges [ (p,vr) | Dependency p vr <- ds ]
-
-fromDepMap :: DependencyMap -> [Dependency]
-fromDepMap m = [ Dependency p vr | (p,vr) <- Map.toList (unDependencyMap m) ]
-
 freeVars :: CondTree ConfVar c a  -> [FlagName]
 freeVars t = [ f | Flag f <- freeVars' t ]
   where
@@ -366,22 +347,6 @@ overallDependencies enabled (TargetSet targets) = mconcat depss
             CTest _ -> CTestName   t
             CBench _ -> CBenchName t
     removeDisabledSections PDNull      = True
-
--- Apply extra constraints to a dependency map.
--- Combines dependencies where the result will only contain keys from the left
--- (first) map.  If a key also exists in the right map, both constraints will
--- be intersected.
-constrainBy :: DependencyMap  -- ^ Input map
-            -> DependencyMap  -- ^ Extra constraints
-            -> DependencyMap
-constrainBy left extra =
-    DependencyMap $
-      Map.foldWithKey tightenConstraint (unDependencyMap left)
-                                        (unDependencyMap extra)
-  where tightenConstraint n c l =
-            case Map.lookup n l of
-              Nothing -> l
-              Just vr -> Map.insert n (intersectVersionRanges vr c) l
 
 -- | Collect up the targets in a TargetSet of tagged targets, storing the
 -- dependencies as we go.

--- a/Cabal/Distribution/Types/DependencyMap.hs
+++ b/Cabal/Distribution/Types/DependencyMap.hs
@@ -1,0 +1,51 @@
+module Distribution.Types.DependencyMap (
+    DependencyMap,
+    toDepMap,
+    fromDepMap,
+    constrainBy,
+) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+import Distribution.Types.Dependency
+import Distribution.Version
+import Distribution.Package
+
+import qualified Data.Map as Map
+
+-- | A map of dependencies.  Newtyped since the default monoid instance is not
+--   appropriate.  The monoid instance uses 'intersectVersionRanges'.
+newtype DependencyMap = DependencyMap { unDependencyMap :: Map PackageName VersionRange }
+  deriving (Show, Read)
+
+instance Monoid DependencyMap where
+    mempty = DependencyMap Map.empty
+    mappend = (<>)
+
+instance Semigroup DependencyMap where
+    (DependencyMap a) <> (DependencyMap b) =
+        DependencyMap (Map.unionWith intersectVersionRanges a b)
+
+toDepMap :: [Dependency] -> DependencyMap
+toDepMap ds =
+  DependencyMap $ Map.fromListWith intersectVersionRanges [ (p,vr) | Dependency p vr <- ds ]
+
+fromDepMap :: DependencyMap -> [Dependency]
+fromDepMap m = [ Dependency p vr | (p,vr) <- Map.toList (unDependencyMap m) ]
+
+-- Apply extra constraints to a dependency map.
+-- Combines dependencies where the result will only contain keys from the left
+-- (first) map.  If a key also exists in the right map, both constraints will
+-- be intersected.
+constrainBy :: DependencyMap  -- ^ Input map
+            -> DependencyMap  -- ^ Extra constraints
+            -> DependencyMap
+constrainBy left extra =
+    DependencyMap $
+      Map.foldWithKey tightenConstraint (unDependencyMap left)
+                                        (unDependencyMap extra)
+  where tightenConstraint n c l =
+            case Map.lookup n l of
+              Nothing -> l
+              Just vr -> Map.insert n (intersectVersionRanges vr c) l


### PR DESCRIPTION
This is a tiny part of https://github.com/haskell/cabal/pull/4265, which I'm really interested in getting merged before 2.0 is cut so we aren't stuck with a bad anti-component syntax. I'm hoping merging it piecemeal will help! (But also I'm going to be super busy until Monday).