### PR TITLE
Improvements to reexported module message:

### DIFF
--- a/Cabal/Distribution/Utils/LogProgress.hs
+++ b/Cabal/Distribution/Utils/LogProgress.hs
@@ -30,7 +30,9 @@ runLogProgress verbosity = foldProgress step_fn fail_fn return
             putStrLn (render doc)
         go
     fail_fn :: Doc -> IO a
-    fail_fn doc = die (render doc)
+    fail_fn doc = do
+        dieMsgNoWrap (render doc ++ "\n")
+        die "Configuration failed"
 
 -- | Output a warning trace message in 'LogProgress'.
 warnProgress :: Doc -> LogProgress ()

--- a/cabal-install/tests/IntegrationTests/new-build/T3978.err
+++ b/cabal-install/tests/IntegrationTests/new-build/T3978.err
@@ -1,1 +1,2 @@
-RE:^cabal(\.exe)?: The package q-1.0 depends on unbuildable libraries: p-1.0
+The package q-1.0 depends on unbuildable libraries: p-1.0
+RE:^cabal(\.exe)?: Configuration failed


### PR DESCRIPTION
- Report all reexport errors, not just the first one
- Give more information about how the modules are different
- Add quotes and prettify the foramt
- Preserve spaces when reporting errors

The new message looks like this:

Problem with module re-exports:
  - Ambiguous reexport 'Data.Map'
    It could refer to either:
         'containers-0.5.6.2-59326c33e30ec8f6afd574cbac625bbb:Data.Map'
         brought into scope by the build dependency on containers
      or 'containers-dupe-0.1.0.0-2AdbRP7BsOEKELRWSQejuE:Data.Map'
         brought into scope by the build dependency on containers-dupe
    The ambiguity can be resolved by qualifying the
    re-export with a package name.
    The syntax is 'packagename:ModuleName [as NewName]'.
  - The module 'Missing'
    is not exported by any suitable package.
    It occurs in neither the 'exposed-modules' of this package,
    nor any of its 'build-depends' dependencies.
  - The module 'Private'
    is not exported by any suitable package.
    It occurs in neither the 'exposed-modules' of this package,
    nor any of its 'build-depends' dependencies
setup: Configuration failed

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>