### PR TITLE
Improve "Preprocessing library" messages.

### DIFF
--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -377,7 +377,7 @@ noticeDoc verbosity msg = withFrozenCallStack $ do
 
 setupMessage :: Verbosity -> String -> PackageIdentifier -> IO ()
 setupMessage verbosity msg pkgid = withFrozenCallStack $ do
-    notice verbosity (msg ++ ' ': display pkgid ++ "...")
+    noticeNoWrap verbosity (msg ++ ' ': display pkgid ++ "...\n")
 
 -- | More detail on the operation of some action.
 --


### PR DESCRIPTION
Before:

    Preprocessing library for reflex-backpack-0.5.0...

After:

    Preprocessing library 'host' instantiated with
      Reflex.Host.Sig = reflex-backpack-0.5.0-inplace-spider:Reflex.Spider.Backpack
      Reflex.Sig = reflex-backpack-0.5.0-inplace-spider:Reflex.Spider.Backpack
    for reflex-backpack-0.5.0...

(The bug was that in single-component mode, we never output the
library name.  I fixed that, and added more output.)

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>