### PR TITLE
DeriveRead for BuildFlags

### DIFF
--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -1631,7 +1631,7 @@ data BuildFlags = BuildFlags {
     -- UserHooks stop us from passing extra info in other ways
     buildArgs :: [String]
   }
-  deriving (Show, Generic)
+  deriving (Read, Show, Generic)
 
 {-# DEPRECATED buildVerbose "Use buildVerbosity instead" #-}
 buildVerbose :: BuildFlags -> Verbosity


### PR DESCRIPTION
Just a humble, simple and "free" request to add `deriving (Read)` to `BuildFlags` -- simplifies things slightly for a handful of current/future tool writers / Setup.hs integrations where you dump the buildflags (and other Hook args) in a temp file, invoke your tool (or `--frontend`) to then read that dump in again to get Cabal's rich project/lib/pkg contextual info-collection about the current build.

Of course `StandaloneDeriving` works fine too for this for me right now, but hey, maybe you guys won't mind adding the `Read`, if not no biggie =)