### PR TITLE
issue #3933: skip the --global deprecation warning when installing to a sandbox

### DIFF
--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -214,7 +214,9 @@ install verbosity packageDBs repos comp platform progdb useSandbox mSandboxPkgIn
         ++ "see https://github.com/haskell/cabal/issues/3353"
         ++ " (if you didn't type --root-cmd, comment out root-cmd"
         ++ " in your ~/.cabal/config file)"
-    unless (fromFlag (configUserInstall configFlags)) $
+    let userOrSandbox = fromFlag (configUserInstall configFlags)
+                     || isUseSandbox useSandbox
+    unless userOrSandbox $
         warn verbosity $ "the --global flag is deprecated -- "
         ++ "it is generally considered a bad idea to install packages "
         ++ "into the global store"


### PR DESCRIPTION
Previously `cabal install foo` in a sandbox would say

    Warning: the --global flag is deprecated -- it is generally considered a bad
    idea to install packages into the global store

even though the user didn't actually specify `--global`. That's because sandbox configs specify `--global` by default in their local configs for technical reasons. So this patch just skips the warning if we're going to install into a sandbox.