### PR TITLE
Update process bounds.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -83,7 +83,7 @@ library
     deepseq    >= 1.3 && < 1.5,
     filepath   >= 1.3 && < 1.5,
     pretty     >= 1.1 && < 1.2,
-    process    >= 1.1.0.1 && < 1.5,
+    process    >= 1.1.0.1 && < 1.6,
     time       >= 1.4 && < 1.8
 
   if flag(old-directory)
@@ -91,7 +91,7 @@ library
                    process   >= 1.0.1.1  && < 1.1.0.2
   else
     build-depends: directory >= 1.2 && < 1.4,
-                   process   >= 1.1.0.2  && < 1.5
+                   process   >= 1.1.0.2  && < 1.6
 
   if flag(bundled-binary-generic)
     build-depends: binary >= 0.5 && < 0.7

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -379,7 +379,7 @@ executable cabal
                      process   >= 1.0.1.1  && < 1.1.0.2
     else
       build-depends: directory >= 1.2 && < 1.4,
-                     process   >= 1.1.0.2  && < 1.5
+                     process   >= 1.1.0.2  && < 1.6
 
     -- NOTE: you MUST include the network dependency even when network-uri
     -- is pulled in, otherwise the constraint solver doesn't have enough
@@ -722,5 +722,5 @@ test-suite integration-tests2
 custom-setup
   setup-depends: Cabal >= 2.1,
                  base,
-                 process   >= 1.1.0.1  && < 1.5,
+                 process   >= 1.1.0.1  && < 1.6,
                  filepath   >= 1.3      && < 1.5


### PR DESCRIPTION
I'd like to bump the version of `process` in the GHC tree, but need to bump it in Cabal first.

Bumped the rest just to be consistent with versions of `process` used.

https://github.com/haskell/process/blob/master/changelog.md

This is being bumped for a new `process` API in Windows that is off by default.