### PR TITLE
Allow the solver to toggle manual flags to match constraints that have any qualifier.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Builder.hs
+++ b/cabal-install/Distribution/Solver/Modular/Builder.hs
@@ -160,10 +160,8 @@ addChildren bs@(BS { rdeps = rdm, index = idx, next = OneGoal (OpenGoal (Simple 
 
 -- For a flag, we create only two subtrees, and we create them in the order
 -- that is indicated by the flag default.
---
--- TODO: Should we include the flag default in the tree?
 addChildren bs@(BS { rdeps = rdm, next = OneGoal (OpenGoal (Flagged qfn@(FN (PI qpn _) _) (FInfo b m w) t f) gr) }) =
-  FChoiceF qfn rdm gr weak m (W.fromList
+  FChoiceF qfn rdm gr weak m b (W.fromList
     [([if b then 0 else 1], True,  (extendOpen qpn (L.map (flip OpenGoal (FDependency qfn True )) t) bs) { next = Goals }),
      ([if b then 1 else 0], False, (extendOpen qpn (L.map (flip OpenGoal (FDependency qfn False)) f) bs) { next = Goals })])
   where

--- a/cabal-install/Distribution/Solver/Modular/Cycles.hs
+++ b/cabal-install/Distribution/Solver/Modular/Cycles.hs
@@ -23,21 +23,21 @@ detectCyclesPhase = cata go
   where
     -- Only check children of choice nodes.
     go :: TreeF d c (Tree d c) -> Tree d c
-    go (PChoiceF qpn rdm gr     cs)                   =
-        PChoice qpn rdm gr     $ fmap (checkChild qpn) cs
-    go (FChoiceF qfn@(FN (PI qpn _) _) rdm gr w m cs) =
-        FChoice qfn rdm gr w m $ fmap (checkChild qpn) cs
-    go (SChoiceF qsn@(SN (PI qpn _) _) rdm gr w   cs) =
-        SChoice qsn rdm gr w   $ fmap (checkChild qpn) cs
-    go x                            = inn x
+    go (PChoiceF qpn rdm gr                         cs) =
+        PChoice qpn rdm gr     $ fmap (checkChild qpn)   cs
+    go (FChoiceF qfn@(FN (PI qpn _) _) rdm gr w m d cs) =
+        FChoice qfn rdm gr w m d $ fmap (checkChild qpn) cs
+    go (SChoiceF qsn@(SN (PI qpn _) _) rdm gr w     cs) =
+        SChoice qsn rdm gr w   $ fmap (checkChild qpn)   cs
+    go x                                                = inn x
 
     checkChild :: QPN -> Tree d c -> Tree d c
-    checkChild qpn x@(PChoice _  rdm _     _) = failIfCycle qpn rdm x
-    checkChild qpn x@(FChoice _  rdm _ _ _ _) = failIfCycle qpn rdm x
-    checkChild qpn x@(SChoice _  rdm _ _   _) = failIfCycle qpn rdm x
-    checkChild qpn x@(GoalChoice rdm       _) = failIfCycle qpn rdm x
-    checkChild _   x@(Fail _ _)               = x
-    checkChild qpn x@(Done       rdm _)       = failIfCycle qpn rdm x
+    checkChild qpn x@(PChoice _  rdm _       _) = failIfCycle qpn rdm x
+    checkChild qpn x@(FChoice _  rdm _ _ _ _ _) = failIfCycle qpn rdm x
+    checkChild qpn x@(SChoice _  rdm _ _     _) = failIfCycle qpn rdm x
+    checkChild qpn x@(GoalChoice rdm         _) = failIfCycle qpn rdm x
+    checkChild _   x@(Fail _ _)                 = x
+    checkChild qpn x@(Done       rdm _)         = failIfCycle qpn rdm x
 
     failIfCycle :: QPN -> RevDepMap -> Tree d c -> Tree d c
     failIfCycle qpn rdm x =

--- a/cabal-install/Distribution/Solver/Modular/Flag.hs
+++ b/cabal-install/Distribution/Solver/Modular/Flag.hs
@@ -22,6 +22,7 @@ import Prelude hiding (pi)
 import Distribution.PackageDescription hiding (Flag) -- from Cabal
 
 import Distribution.Solver.Modular.Package
+import Distribution.Solver.Types.Flag
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PackagePath
 
@@ -41,8 +42,8 @@ mkFlag = mkFlagName
 -- | Flag info. Default value, whether the flag is manual, and
 -- whether the flag is weak. Manual flags can only be set explicitly.
 -- Weak flags are typically deferred by the solver.
-data FInfo = FInfo { fdefault :: Bool, fmanual :: Bool, fweak :: WeakOrTrivial }
-  deriving (Eq, Ord, Show)
+data FInfo = FInfo { fdefault :: Bool, fmanual :: FlagType, fweak :: WeakOrTrivial }
+  deriving (Eq, Show)
 
 -- | Flag defaults.
 type FlagInfo = Map Flag FInfo

--- a/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
@@ -25,6 +25,7 @@ import Distribution.System
 import Distribution.Types.ForeignLib
 
 import           Distribution.Solver.Types.ComponentDeps (Component(..))
+import           Distribution.Solver.Types.Flag
 import           Distribution.Solver.Types.OptionalStanza
 import qualified Distribution.Solver.Types.PackageIndex as CI
 import           Distribution.Solver.Types.Settings
@@ -162,9 +163,10 @@ prefix f fds = [f (concat fds)]
 -- unless strong flags have been selected explicitly.
 flagInfo :: StrongFlags -> [PD.Flag] -> FlagInfo
 flagInfo (StrongFlags strfl) =
-    M.fromList . L.map (\ (MkFlag fn _ b m) -> (fn, FInfo b m (weak m)))
+    M.fromList . L.map (\ (MkFlag fn _ b m) -> (fn, FInfo b (flagType m) (weak m)))
   where
     weak m = WeakOrTrivial $ not (strfl || m)
+    flagType m = if m then Manual else Automatic
 
 -- | Internal package names, which should not be interpreted as true
 -- dependencies.

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -75,15 +75,15 @@ validateLinking index = (`runReader` initVS) . cata go
   where
     go :: TreeF d c (Validate (Tree d c)) -> Validate (Tree d c)
 
-    go (PChoiceF qpn rdm gr cs) =
-      PChoice qpn rdm gr     <$> T.sequence (W.mapWithKey (goP qpn) cs)
-    go (FChoiceF qfn rdm gr t m cs) =
-      FChoice qfn rdm gr t m <$> T.sequence (W.mapWithKey (goF qfn) cs)
-    go (SChoiceF qsn rdm gr t cs) =
-      SChoice qsn rdm gr t   <$> T.sequence (W.mapWithKey (goS qsn) cs)
+    go (PChoiceF qpn rdm gr       cs) =
+      PChoice qpn rdm gr       <$> T.sequence (W.mapWithKey (goP qpn) cs)
+    go (FChoiceF qfn rdm gr t m d cs) =
+      FChoice qfn rdm gr t m d <$> T.sequence (W.mapWithKey (goF qfn) cs)
+    go (SChoiceF qsn rdm gr t     cs) =
+      SChoice qsn rdm gr t     <$> T.sequence (W.mapWithKey (goS qsn) cs)
 
     -- For the other nodes we just recurse
-    go (GoalChoiceF rdm       cs)     = GoalChoice rdm <$> T.sequence cs
+    go (GoalChoiceF rdm           cs) = GoalChoice rdm <$> T.sequence cs
     go (DoneF revDepMap s)            = return $ Done revDepMap s
     go (FailF conflictSet failReason) = return $ Fail conflictSet failReason
 

--- a/cabal-install/Distribution/Solver/Modular/Validate.hs
+++ b/cabal-install/Distribution/Solver/Modular/Validate.hs
@@ -106,8 +106,8 @@ validate = cata go
   where
     go :: TreeF d c (Validate (Tree d c)) -> Validate (Tree d c)
 
-    go (PChoiceF qpn rdm gr     ts) = PChoice qpn rdm gr <$> sequence (W.mapWithKey (goP qpn) ts)
-    go (FChoiceF qfn rdm gr b m ts) =
+    go (PChoiceF qpn rdm gr       ts) = PChoice qpn rdm gr <$> sequence (W.mapWithKey (goP qpn) ts)
+    go (FChoiceF qfn rdm gr b m d ts) =
       do
         -- Flag choices may occur repeatedly (because they can introduce new constraints
         -- in various places). However, subsequent choices must be consistent. We thereby
@@ -119,7 +119,7 @@ validate = cata go
                        Just t  -> goF qfn rb t
                        Nothing -> return $ Fail (varToConflictSet (F qfn)) (MalformedFlagChoice qfn)
           Nothing -> -- flag choice is new, follow both branches
-                     FChoice qfn rdm gr b m <$> sequence (W.mapWithKey (goF qfn) ts)
+                     FChoice qfn rdm gr b m d <$> sequence (W.mapWithKey (goF qfn) ts)
     go (SChoiceF qsn rdm gr b   ts) =
       do
         -- Optional stanza choices are very similar to flag choices.
@@ -133,9 +133,9 @@ validate = cata go
                      SChoice qsn rdm gr b <$> sequence (W.mapWithKey (goS qsn) ts)
 
     -- We don't need to do anything for goal choices or failure nodes.
-    go (GoalChoiceF rdm            ts) = GoalChoice rdm <$> sequence ts
-    go (DoneF       rdm s            ) = pure (Done rdm s)
-    go (FailF    c fr                ) = pure (Fail c fr)
+    go (GoalChoiceF rdm           ts) = GoalChoice rdm <$> sequence ts
+    go (DoneF       rdm s           ) = pure (Done rdm s)
+    go (FailF    c fr               ) = pure (Fail c fr)
 
     -- What to do for package nodes ...
     goP :: QPN -> POption -> Validate (Tree d c) -> Validate (Tree d c)

--- a/cabal-install/Distribution/Solver/Types/Flag.hs
+++ b/cabal-install/Distribution/Solver/Types/Flag.hs
@@ -1,0 +1,6 @@
+module Distribution.Solver.Types.Flag
+    ( FlagType(..)
+    ) where
+
+data FlagType = Manual | Automatic
+  deriving (Eq, Show)

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -297,6 +297,7 @@ executable cabal
         Distribution.Solver.Types.ComponentDeps
         Distribution.Solver.Types.ConstraintSource
         Distribution.Solver.Types.DependencyResolver
+        Distribution.Solver.Types.Flag
         Distribution.Solver.Types.InstalledPreference
         Distribution.Solver.Types.InstSolverPackage
         Distribution.Solver.Types.LabeledPackageConstraint

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/MemoryUsage.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/MemoryUsage.hs
@@ -46,10 +46,10 @@ flagsTest name =
 
     pkgs :: ExampleDb
     pkgs = [Right $ exAv "pkg" 1 $
-                [exFlag (flagName n) [ExAny "unknown1"] [ExAny "unknown2"]]
+                [exFlagged (flagName n) [ExAny "unknown1"] [ExAny "unknown2"]]
 
                 -- The remaining flags have no effect:
-             ++ [exFlag (flagName i) [] [] | i <- [1..n - 1]]
+             ++ [exFlagged (flagName i) [] [] | i <- [1..n - 1]]
            ]
 
     flagName :: Int -> ExampleFlagName

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -116,19 +116,19 @@ tests = [
           runTest $ mkTest dbConstraints "install latest versions without constraints" ["A", "B", "C"] $
           solverSuccess [("A", 7), ("B", 8), ("C", 9), ("D", 7), ("D", 8), ("D", 9)]
 
-        , let cs = [ ExConstraint (ScopeAnyQualifier "D") $ mkVersionRange 1 4 ]
+        , let cs = [ ExVersionConstraint (ScopeAnyQualifier "D") $ mkVersionRange 1 4 ]
           in runTest $ constraints cs $
              mkTest dbConstraints "force older versions with unqualified constraint" ["A", "B", "C"] $
              solverSuccess [("A", 1), ("B", 2), ("C", 3), ("D", 1), ("D", 2), ("D", 3)]
 
-        , let cs = [ ExConstraint (ScopeQualified QualToplevel    "D") $ mkVersionRange 1 4
-                   , ExConstraint (ScopeQualified (QualSetup "B") "D") $ mkVersionRange 4 7
+        , let cs = [ ExVersionConstraint (ScopeQualified QualToplevel    "D") $ mkVersionRange 1 4
+                   , ExVersionConstraint (ScopeQualified (QualSetup "B") "D") $ mkVersionRange 4 7
                    ]
           in runTest $ constraints cs $
              mkTest dbConstraints "force multiple versions with qualified constraints" ["A", "B", "C"] $
              solverSuccess [("A", 1), ("B", 5), ("C", 9), ("D", 1), ("D", 5), ("D", 9)]
 
-        , let cs = [ ExConstraint (ScopeAnySetupQualifier "D") $ mkVersionRange 1 4 ]
+        , let cs = [ ExVersionConstraint (ScopeAnySetupQualifier "D") $ mkVersionRange 1 4 ]
           in runTest $ constraints cs $
              mkTest dbConstraints "constrain package across setup scripts" ["A", "B", "C"] $
              solverSuccess [("A", 7), ("B", 2), ("C", 3), ("D", 2), ("D", 3), ("D", 7)]
@@ -264,7 +264,7 @@ db3 :: ExampleDb
 db3 = [
      Right $ exAv "A" 1 []
    , Right $ exAv "A" 2 []
-   , Right $ exAv "B" 1 [exFlag "flagB" [ExFix "A" 1] [ExFix "A" 2]]
+   , Right $ exAv "B" 1 [exFlagged "flagB" [ExFix "A" 1] [ExFix "A" 2]]
    , Right $ exAv "C" 1 [ExFix "A" 1, ExAny "B"]
    , Right $ exAv "D" 1 [ExFix "A" 2, ExAny "B"]
    ]
@@ -307,7 +307,7 @@ db4 = [
    , Right $ exAv "Ax" 2 []
    , Right $ exAv "Ay" 1 []
    , Right $ exAv "Ay" 2 []
-   , Right $ exAv "B"  1 [exFlag "flagB" [ExFix "Ax" 1] [ExFix "Ay" 1]]
+   , Right $ exAv "B"  1 [exFlagged "flagB" [ExFix "Ax" 1] [ExFix "Ay" 1]]
    , Right $ exAv "C"  1 [ExFix "Ax" 2, ExAny "B"]
    , Right $ exAv "D"  1 [ExFix "Ay" 2, ExAny "B"]
    ]
@@ -533,7 +533,7 @@ db14 :: ExampleDb
 db14 = [
     Right $ exAv "A" 1 [ExAny "B"]
   , Right $ exAv "B" 1 [ExAny "A"]
-  , Right $ exAv "C" 1 [exFlag "flagC" [ExAny "D"] [ExAny "E"]]
+  , Right $ exAv "C" 1 [exFlagged "flagC" [ExAny "D"] [ExAny "E"]]
   , Right $ exAv "D" 1 [ExAny "C"]
   , Right $ exAv "E" 1 []
   ]
@@ -615,9 +615,9 @@ db16 :: ExampleDb
 db16 = [
     Right $ exAv "A" 1 [ExAny "C", ExFix "D" 1]
   , Right $ exAv "B" 1 [ ExFix "D" 2
-                       , exFlag "flagA"
+                       , exFlagged "flagA"
                              [ExAny "C"]
-                             [exFlag "flagB"
+                             [exFlagged "flagB"
                                  [ExAny "E"]
                                  [ExAny "C"]]]
   , Right $ exAv "C" 1 [ExAny "D"]
@@ -682,9 +682,9 @@ db18 :: ExampleDb
 db18 = [
     Right $ exAv "A" 1 [ExAny "C", ExFix "D" 1]
   , Right $ exAv "B" 1 [ExAny "C", ExFix "D" 2]
-  , Right $ exAv "C" 1 [exFlag "flagA"
+  , Right $ exAv "C" 1 [exFlagged "flagA"
                            [ExFix "D" 1, ExAny "E"]
-                           [exFlag "flagB"
+                           [exFlagged "flagB"
                                [ExAny "F"]
                                [ExFix "D" 2, ExAny "G"]]]
   , Right $ exAv "D" 1 []
@@ -923,12 +923,12 @@ testBuildable testName unavailableDep =
   where
     expected = solverSuccess [("false-dep", 1), ("pkg", 1)]
     db = [
-        Right $ exAv "pkg" 1 [exFlag "enable-exe"
+        Right $ exAv "pkg" 1 [exFlagged "enable-exe"
                                  [ExAny "true-dep"]
                                  [ExAny "false-dep"]]
          `withExe`
             ExExe "exe" [ unavailableDep
-                        , ExFlag "enable-exe" (Buildable []) NotBuildable ]
+                        , ExFlagged "enable-exe" (Buildable []) NotBuildable ]
       , Right $ exAv "true-dep" 1 []
       , Right $ exAv "false-dep" 1 []
       ]
@@ -938,18 +938,18 @@ testBuildable testName unavailableDep =
 dbBuildable1 :: ExampleDb
 dbBuildable1 = [
     Right $ exAv "pkg" 1
-        [ exFlag "flag1" [ExAny "flag1-true"] [ExAny "flag1-false"]
-        , exFlag "flag2" [ExAny "flag2-true"] [ExAny "flag2-false"]]
+        [ exFlagged "flag1" [ExAny "flag1-true"] [ExAny "flag1-false"]
+        , exFlagged "flag2" [ExAny "flag2-true"] [ExAny "flag2-false"]]
      `withExes`
         [ ExExe "exe1"
             [ ExAny "unknown"
-            , ExFlag "flag1" (Buildable []) NotBuildable
-            , ExFlag "flag2" (Buildable []) NotBuildable]
+            , ExFlagged "flag1" (Buildable []) NotBuildable
+            , ExFlagged "flag2" (Buildable []) NotBuildable]
         , ExExe "exe2"
             [ ExAny "unknown"
-            , ExFlag "flag1"
+            , ExFlagged "flag1"
                   (Buildable [])
-                  (Buildable [ExFlag "flag2" NotBuildable (Buildable [])])]
+                  (Buildable [ExFlagged "flag2" NotBuildable (Buildable [])])]
          ]
   , Right $ exAv "flag1-true" 1 []
   , Right $ exAv "flag1-false" 1 []
@@ -966,7 +966,7 @@ dbBuildable2 = [
      `withExe`
         ExExe "exe"
         [ ExAny "unknown"
-        , ExFlag "disable-exe" NotBuildable (Buildable [])
+        , ExFlagged "disable-exe" NotBuildable (Buildable [])
         ]
   , Right $ exAv "B" 3 [ExAny "unknown"]
   ]
@@ -1044,7 +1044,7 @@ dbBJ4 = [
 -- bug report (#3409)
 dbBJ5 :: ExampleDb
 dbBJ5 = [
-    Right $ exAv "A" 1 [exFlag "flagA" [ExFix "B" 1] [ExFix "C" 1]]
+    Right $ exAv "A" 1 [exFlagged "flagA" [ExFix "B" 1] [ExFix "C" 1]]
   , Right $ exAv "B" 1 [ExFix "D" 1]
   , Right $ exAv "C" 1 [ExFix "D" 2]
   , Right $ exAv "D" 1 []


### PR DESCRIPTION
Three commits:

#### Allow the solver to toggle manual flags to match constraints that have any qualifier.

This fixes #4299. The change gives the dependency solver the flexibility to link
dependencies when the user has only set a manual flag on one of them.
Previously, the solver would force the constrained dependency to have the
flag value from the constraint and force the unconstrained dependency to have
the default flag value. In cases where the single instance restriction required
the dependencies to be linked, the solver couldn't find a solution.

Qualified constraints can still be used to force different dependencies on a
package to use different flag values. For example,
`--constraint 'pkg +flag' --constraint 'pkg2:setup.pkg -flag'` turns the flag on
for the top-level dependency and off for the setup dependency.

I also stored flag default values in the search tree to simplify the code.

#### Add manual flags to the solver DSL.

Tests can now declare flags before using them, in order to specify non-default
values for the fields in `D.Types.GenericPackageDescription.Flag`.

####  Add tests for manual flags.

_______________

@23Skidoo Do you think we could add this to the release branch?  I wanted to fix #4299 because it's a regression.

@ezyang What do you think of this solution?

/cc @kosmikus 