### PR TITLE
Control expensive assertion in Distribution.Solver.Modular.Linking with a build flag.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,9 @@ matrix:
    - env: GHCVER=8.0.1 SCRIPT=script PARSEC=YES TAGSUFFIX="-parsec"
      os: linux
      sudo: required
+   - env: GHCVER=8.0.1 SCRIPT=script DEBUG_ASSERTIONS=YES TAGSUFFIX="-fdebug-assertions"
+     os: linux
+     sudo: required
    - env: GHCVER=8.0.1 SCRIPT=bootstrap
      sudo: required
      os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
    - env: GHCVER=8.0.1 SCRIPT=script PARSEC=YES TAGSUFFIX="-parsec"
      os: linux
      sudo: required
-   - env: GHCVER=8.0.1 SCRIPT=script DEBUG_ASSERTIONS=YES TAGSUFFIX="-fdebug-assertions"
+   - env: GHCVER=8.0.1 SCRIPT=script DEBUG_EXPENSIVE_ASSERTIONS=YES TAGSUFFIX="-fdebug-expensive-assertions"
      os: linux
      sudo: required
    - env: GHCVER=8.0.1 SCRIPT=bootstrap

--- a/cabal-install/Distribution/Client/Utils/Assertion.hs
+++ b/cabal-install/Distribution/Client/Utils/Assertion.hs
@@ -5,10 +5,12 @@ module Distribution.Client.Utils.Assertion (debugAssert) where
 import Control.Exception (assert)
 #endif
 
+import Distribution.Compat.Stack
+
 -- | Like 'assert', but only enabled with -fdebug-assertions. This function can
 -- be used for expensive assertions that should only be turned on during testing
 -- or debugging.
-debugAssert :: Bool -> a -> a
+debugAssert :: WithCallStack (Bool -> a -> a)
 #ifdef DEBUG_ASSERTIONS
 debugAssert = assert
 #else

--- a/cabal-install/Distribution/Client/Utils/Assertion.hs
+++ b/cabal-install/Distribution/Client/Utils/Assertion.hs
@@ -1,18 +1,18 @@
 {-# LANGUAGE CPP #-}
-module Distribution.Client.Utils.Assertion (debugAssert) where
+module Distribution.Client.Utils.Assertion (expensiveAssert) where
 
-#ifdef DEBUG_ASSERTIONS
+#ifdef DEBUG_EXPENSIVE_ASSERTIONS
 import Control.Exception (assert)
 import Distribution.Compat.Stack
 #endif
 
--- | Like 'assert', but only enabled with -fdebug-assertions. This function can
--- be used for expensive assertions that should only be turned on during testing
--- or debugging.
-#ifdef DEBUG_ASSERTIONS
-debugAssert :: WithCallStack (Bool -> a -> a)
-debugAssert = assert
+-- | Like 'assert', but only enabled with -fdebug-expensive-assertions. This
+-- function can be used for expensive assertions that should only be turned on
+-- during testing or debugging.
+#ifdef DEBUG_EXPENSIVE_ASSERTIONS
+expensiveAssert :: WithCallStack (Bool -> a -> a)
+expensiveAssert = assert
 #else
-debugAssert :: Bool -> a -> a
-debugAssert _ = id
+expensiveAssert :: Bool -> a -> a
+expensiveAssert _ = id
 #endif

--- a/cabal-install/Distribution/Client/Utils/Assertion.hs
+++ b/cabal-install/Distribution/Client/Utils/Assertion.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE CPP #-}
+module Distribution.Client.Utils.Assertion (debugAssert) where
+
+#ifdef DEBUG_ASSERTIONS
+import Control.Exception (assert)
+#endif
+
+-- | Like 'assert', but only enabled with -fdebug-assertions. This function can
+-- be used for expensive assertions that should only be turned on during testing
+-- or debugging.
+debugAssert :: Bool -> a -> a
+#ifdef DEBUG_ASSERTIONS
+debugAssert = assert
+#else
+debugAssert _ = id
+#endif

--- a/cabal-install/Distribution/Client/Utils/Assertion.hs
+++ b/cabal-install/Distribution/Client/Utils/Assertion.hs
@@ -3,16 +3,16 @@ module Distribution.Client.Utils.Assertion (debugAssert) where
 
 #ifdef DEBUG_ASSERTIONS
 import Control.Exception (assert)
-#endif
-
 import Distribution.Compat.Stack
+#endif
 
 -- | Like 'assert', but only enabled with -fdebug-assertions. This function can
 -- be used for expensive assertions that should only be turned on during testing
 -- or debugging.
-debugAssert :: WithCallStack (Bool -> a -> a)
 #ifdef DEBUG_ASSERTIONS
+debugAssert :: WithCallStack (Bool -> a -> a)
 debugAssert = assert
 #else
+debugAssert :: Bool -> a -> a
 debugAssert _ = id
 #endif

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -137,7 +137,7 @@ newtype UpdateState a = UpdateState {
 instance MonadState ValidateState UpdateState where
   get    = UpdateState $ get
   put st = UpdateState $ do
-             debugAssert (lgInvariant $ vsLinks st) $ return ()
+             expensiveAssert (lgInvariant $ vsLinks st) $ return ()
              put st
 
 lift' :: Either Conflict a -> UpdateState a

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -16,6 +16,7 @@ import qualified Data.Map         as M
 import qualified Data.Set         as S
 import qualified Data.Traversable as T
 
+import Distribution.Client.Utils.Assertion
 import Distribution.Solver.Modular.Assignment
 import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Flag
@@ -136,7 +137,7 @@ newtype UpdateState a = UpdateState {
 instance MonadState ValidateState UpdateState where
   get    = UpdateState $ get
   put st = UpdateState $ do
-             assert (lgInvariant $ vsLinks st) $ return ()
+             debugAssert (lgInvariant $ vsLinks st) $ return ()
              put st
 
 lift' :: Either Conflict a -> UpdateState a

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -189,7 +189,7 @@ Flag network-uri
   description:  Get Network.URI from the network-uri package
   default:      True
 
-Flag debug-assertions
+Flag debug-expensive-assertions
   description:  Enable expensive assertions for testing or debugging
   default:      False
   manual:       True
@@ -414,8 +414,8 @@ library
     else
       build-depends: unix >= 2.5 && < 2.8
 
-    if flag(debug-assertions)
-      cpp-options: -DDEBUG_ASSERTIONS
+    if flag(debug-expensive-assertions)
+      cpp-options: -DDEBUG_EXPENSIVE_ASSERTIONS
 
     if flag(debug-conflict-sets)
       cpp-options: -DDEBUG_CONFLICT_SETS
@@ -506,8 +506,8 @@ executable cabal
         else
           build-depends: unix >= 2.5 && < 2.8
 
-        if flag(debug-assertions)
-          cpp-options: -DDEBUG_ASSERTIONS
+        if flag(debug-expensive-assertions)
+          cpp-options: -DDEBUG_EXPENSIVE_ASSERTIONS
 
         if flag(debug-conflict-sets)
           cpp-options: -DDEBUG_CONFLICT_SETS

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -189,6 +189,11 @@ Flag network-uri
   description:  Get Network.URI from the network-uri package
   default:      True
 
+Flag debug-assertions
+  description:  Enable expensive assertions for testing or debugging
+  default:      False
+  manual:       True
+
 Flag debug-conflict-sets
   description:  Add additional information to ConflictSets
   default:      False
@@ -295,6 +300,7 @@ library
         Distribution.Client.Update
         Distribution.Client.Upload
         Distribution.Client.Utils
+        Distribution.Client.Utils.Assertion
         Distribution.Client.Utils.Json
         Distribution.Client.World
         Distribution.Client.Win32SelfUpgrade
@@ -408,6 +414,9 @@ library
     else
       build-depends: unix >= 2.5 && < 2.8
 
+    if flag(debug-assertions)
+      cpp-options: -DDEBUG_ASSERTIONS
+
     if flag(debug-conflict-sets)
       cpp-options: -DDEBUG_CONFLICT_SETS
       build-depends: base >= 4.8
@@ -496,6 +505,9 @@ executable cabal
           build-depends: Win32 >= 2 && < 3
         else
           build-depends: unix >= 2.5 && < 2.8
+
+        if flag(debug-assertions)
+          cpp-options: -DDEBUG_ASSERTIONS
 
         if flag(debug-conflict-sets)
           cpp-options: -DDEBUG_CONFLICT_SETS

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -192,10 +192,12 @@ Flag network-uri
 Flag debug-conflict-sets
   description:  Add additional information to ConflictSets
   default:      False
+  manual:       True
 
 Flag debug-tracetree
   description:  Compile in support for tracetree (used to debug the solver)
   default:      False
+  manual:       True
 
 flag parsec
   description:  Use parsec parser. This requires 'Cabal' library built with its parsec flag enabled.

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -139,8 +139,8 @@ fi
 # Needed to work around some bugs in nix-local-build code.
 export CABAL_BUILDDIR="${CABAL_INSTALL_BDIR}"
 
-if [ "x$DEBUG_ASSERTIONS" = "xYES" ]; then
-    CABAL_INSTALL_FLAGS=-fdebug-assertions
+if [ "x$DEBUG_EXPENSIVE_ASSERTIONS" = "xYES" ]; then
+    CABAL_INSTALL_FLAGS=-fdebug-expensive-assertions
 fi
 
 timed cabal new-build $jobs $CABAL_INSTALL_FLAGS \

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -139,7 +139,12 @@ fi
 # Needed to work around some bugs in nix-local-build code.
 export CABAL_BUILDDIR="${CABAL_INSTALL_BDIR}"
 
-timed cabal new-build $jobs cabal-install:cabal \
+if [ "x$DEBUG_ASSERTIONS" = "xYES" ]; then
+    CABAL_INSTALL_FLAGS=-fdebug-assertions
+fi
+
+timed cabal new-build $jobs $CABAL_INSTALL_FLAGS \
+                      cabal-install:cabal \
                       cabal-install:integration-tests \
                       cabal-install:integration-tests2 \
                       cabal-install:unit-tests \


### PR DESCRIPTION
I added a function, `debugAssert`, that wraps `assert` and only calls it when
the build flag `debug-assertions` is enabled.  The flag defaults to false. I
only replaced one call to `assert` so far (in Distribution.Solver.Modular.Linking)
in order to resolve #4258.
__________________________

I enabled `debug-assertions` in a new GHC 8.0.1 build job, because I figured that it is important to continue testing with the default flag settings in all of the other matrix entries.  I could set `-fdebug-assertions` in one of the existing jobs instead, if it's not worth creating a separate job.

I can also make a PR for the 2.0 branch.