### PR TITLE
A few bug fixes to our CI setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,12 +102,6 @@ before_install:
  - export PATH=/opt/alex/3.1.7/bin:$PATH
  - ./travis-install.sh
 
- # Set up deployment to the haskell/cabal-website repo.
- # NB: these commands MUST be in .travis.yml, otherwise the secret key can be
- # leaked! See https://github.com/travis-ci/travis.rb/issues/423.
- # umask to get the permissions to be 400.
- - if [ "x$TRAVIS_REPO_SLUG" = "xhaskell/cabal" -a "x$TRAVIS_PULL_REQUEST" = "xfalse" -a "x$TRAVIS_BRANCH" = "xmaster" -a "x$DEPLOY_DOCS" = "xYES"  ]; then (umask 377 && openssl aes-256-cbc -K $encrypted_edaf6551664d_key -iv $encrypted_edaf6551664d_iv -in id_rsa_cabal_website.aes256.enc -out ~/.ssh/id_rsa -d); fi
-
 install:
  # We intentionally do not install anything before trying to build Cabal because
  # it should build with each supported GHC version out-of-the-box.
@@ -143,6 +137,11 @@ before_cache:
 
 # Deploy Haddocks to the haskell/cabal-website repo.
 after_success:
+ # Set up deployment to the haskell/cabal-website repo.
+ # NB: these commands MUST be in .travis.yml, otherwise the secret key can be
+ # leaked! See https://github.com/travis-ci/travis.rb/issues/423.
+ # umask to get the permissions to be 600.
+ - if [ "x$TRAVIS_REPO_SLUG" = "xhaskell/cabal" -a "x$TRAVIS_PULL_REQUEST" = "xfalse" -a "x$TRAVIS_BRANCH" = "xmaster" -a "x$DEPLOY_DOCS" = "xYES"  ]; then (umask 177 && openssl aes-256-cbc -K $encrypted_edaf6551664d_key -iv $encrypted_edaf6551664d_iv -in id_rsa_cabal_website.aes256.enc -out ~/.ssh/id_rsa -d); fi
  - ./travis-deploy.sh
 
 notifications:

--- a/travis-common.sh
+++ b/travis-common.sh
@@ -32,3 +32,7 @@ timed() {
 	fi
     echo "----"
 }
+
+travis_retry () {
+    $*  || (sleep 1 && $*) || (sleep 2 && $*)
+}

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 set -ex
 
-travis_retry () {
-    $*  || (sleep 1 && $*) || (sleep 2 && $*)
-}
+. ./travis-common.sh
 
 if [ "$GHCVER" = "none" ]; then
     travis_retry sudo add-apt-repository -y ppa:hvr/ghc

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -7,6 +7,10 @@
 # If you make a separate matrix entry in .travis.yml it can
 # be run in parallel.
 
+# NB: the '|| exit $?' workaround is required on old broken versions of bash
+# that ship with OS X. See https://github.com/haskell/cabal/pull/3624 and
+# http://stackoverflow.com/questions/14970663/why-doesnt-bash-flag-e-exit-when-a-subshell-fails
+
 . ./travis-common.sh
 
 CABAL_STORE_DB="${HOME}/.cabal/store/ghc-${GHCVER}/package.db"

--- a/travis/README.md
+++ b/travis/README.md
@@ -9,7 +9,8 @@ There are two reasons we do this:
 
 1. On our slowest configuration (GHC 8 on Mac OS X), the time to
    build and run tests was easily bumping up against the Travis time
-   limit.  By uploading our build products to a separate account
+   limit.  By uploading our build products to a separate account,
+   we get twice as much time to run our builds.
 
 2. Travis parallelism is limited on a per-account basis; if we
    upload build products to another account, we get more parallelism!


### PR DESCRIPTION
- Setup the ssh key for cabal-website deploy right before we use
  it, so it doesn't get clobbered by our pushbot deploy script.
  Furthermore, umask the key to 600, so that we can override it.

- Add some more helpful information to the Pushbot commit messages,
  including what branch/PR the build was for, and a link to the
  relevant GitHub page.

- Have Travis spoof the author and email of the original committer,
  so that Travis sends the build notification message to the right place.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>