### PR TITLE
Cherry-pick #4352 into master

### DIFF
--- a/Cabal/Distribution/Types/DependencyMap.hs
+++ b/Cabal/Distribution/Types/DependencyMap.hs
@@ -1,3 +1,17 @@
+{-# LANGUAGE CPP #-}
+
+#ifdef MIN_VERSION_containers
+#if MIN_VERSION_containers(0,5,0)
+#define MIN_VERSION_containers_0_5_0
+#endif
+#endif
+
+#ifndef MIN_VERSION_containers
+#if __GLASGOW_HASKELL__ >= 706
+#define MIN_VERSION_containers_0_5_0
+#endif
+#endif
+
 module Distribution.Types.DependencyMap (
     DependencyMap,
     toDepMap,
@@ -12,7 +26,11 @@ import Distribution.Types.Dependency
 import Distribution.Version
 import Distribution.Package
 
+#ifdef MIN_VERSION_containers_0_5_0
 import qualified Data.Map.Lazy as Map
+#else
+import qualified Data.Map as Map
+#endif
 
 -- | A map of dependencies.  Newtyped since the default monoid instance is not
 --   appropriate.  The monoid instance uses 'intersectVersionRanges'.
@@ -43,8 +61,13 @@ constrainBy :: DependencyMap  -- ^ Input map
             -> DependencyMap
 constrainBy left extra =
     DependencyMap $
+#ifdef MIN_VERSION_containers_0_5_0
       Map.foldrWithKey tightenConstraint (unDependencyMap left)
                                          (unDependencyMap extra)
+#else
+      Map.foldWithKey tightenConstraint (unDependencyMap left)
+                                        (unDependencyMap extra)
+#endif
   where tightenConstraint n c l =
             case Map.lookup n l of
               Nothing -> l

--- a/Cabal/Distribution/Types/DependencyMap.hs
+++ b/Cabal/Distribution/Types/DependencyMap.hs
@@ -12,7 +12,7 @@ import Distribution.Types.Dependency
 import Distribution.Version
 import Distribution.Package
 
-import qualified Data.Map as Map
+import qualified Data.Map.Lazy as Map
 
 -- | A map of dependencies.  Newtyped since the default monoid instance is not
 --   appropriate.  The monoid instance uses 'intersectVersionRanges'.
@@ -43,8 +43,8 @@ constrainBy :: DependencyMap  -- ^ Input map
             -> DependencyMap
 constrainBy left extra =
     DependencyMap $
-      Map.foldWithKey tightenConstraint (unDependencyMap left)
-                                        (unDependencyMap extra)
+      Map.foldrWithKey tightenConstraint (unDependencyMap left)
+                                         (unDependencyMap extra)
   where tightenConstraint n c l =
             case Map.lookup n l of
               Nothing -> l


### PR DESCRIPTION
DependencyMap: Replace usage of Data.Map with Data.Map.Lazy

The former has been deprecated for quite some time.

(cherry picked from commit e4c36b9dd51820f2380ce7a66f980c4e7b2e96fc)