### PR TITLE
Don't specify hs-libraries when none exists!

### DIFF
--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -462,9 +462,10 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     (absinc, relinc) = partition isAbsolute (includeDirs bi)
     hasModules = not $ null (allLibModules lib clbi)
     comp = compiler lbi
-    hasLibrary = hasModules || not (null (cSources bi))
-                            || (not (null (jsSources bi)) &&
-                                compilerFlavor comp == GHCJS)
+    hasLibrary = (hasModules || not (null (cSources bi))
+                             || (not (null (jsSources bi)) &&
+                                compilerFlavor comp == GHCJS))
+               && not (componentIsIndefinite clbi)
     (libdirs, dynlibdirs)
       | not hasLibrary
       = (extraLibDirs bi, [])

--- a/cabal-testsuite/PackageTests/Backpack/TemplateHaskell/A.hsig
+++ b/cabal-testsuite/PackageTests/Backpack/TemplateHaskell/A.hsig
@@ -1,0 +1,1 @@
+signature A where

--- a/cabal-testsuite/PackageTests/Backpack/TemplateHaskell/M.hs
+++ b/cabal-testsuite/PackageTests/Backpack/TemplateHaskell/M.hs
@@ -1,0 +1,3 @@
+{-# LANGUAGE TemplateHaskell #-}
+module M where
+$( [d| x = True |] )

--- a/cabal-testsuite/PackageTests/Backpack/TemplateHaskell/bkpth.cabal
+++ b/cabal-testsuite/PackageTests/Backpack/TemplateHaskell/bkpth.cabal
@@ -1,0 +1,14 @@
+name: bkpth
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.25
+
+library helper
+    signatures: A
+    build-depends: base
+    default-language: Haskell2010
+
+library
+    exposed-modules: M
+    build-depends: base, helper
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/Backpack/TemplateHaskell/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/TemplateHaskell/setup.out
@@ -1,0 +1,9 @@
+# Setup configure
+Configuring bkpth-1.0...
+# Setup build
+Preprocessing library 'helper' for bkpth-1.0..
+Building library 'helper' instantiated with A = <A>
+for bkpth-1.0..
+Preprocessing library for bkpth-1.0..
+Building library instantiated with A = <A>
+for bkpth-1.0..

--- a/cabal-testsuite/PackageTests/Backpack/TemplateHaskell/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/TemplateHaskell/setup.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+main = setupAndCabalTest $ do
+    skipUnless =<< ghcVersionIs (>= mkVersion [8,1])
+    setup "configure" []
+    setup "build" []


### PR DESCRIPTION
This fixes GHC bug
https://ghc.haskell.org/trac/ghc/ticket/13268

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>