### PR TITLE
Clean up PreExistingComponent

### DIFF
--- a/Cabal/Distribution/Backpack/Configure.hs
+++ b/Cabal/Distribution/Backpack/Configure.hs
@@ -81,7 +81,7 @@ configureComponentLocalBuildInfos
                         (dispComponentsGraph graph0)
 
     let conf_pkg_map = Map.fromList
-            [(pc_pkgname pkg, (pc_cid pkg, pc_pkgid pkg))
+            [((pc_pkgname pkg, pc_compname pkg), (pc_cid pkg, pc_pkgid pkg))
             | pkg <- prePkgDeps]
         graph1 = toConfiguredComponents use_external_internal_deps
                     flagAssignment

--- a/Cabal/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/Distribution/Backpack/ConfiguredComponent.hs
@@ -207,8 +207,7 @@ toConfiguredComponent' use_external_internal_deps flags
   where
     this_cid = computeComponentId deterministic ipid_flag cid_flag (package pkg_descr)
                 (componentName component) (Just (deps, flags))
-    deps = [ cid | ((dep_pn, _), (cid, _)) <- Map.toList lib_map
-                 , dep_pn /= packageName pkg_descr ]
+    deps = [ cid | (_, (cid, _)) <- Map.toList lib_map ]
 
 extendConfiguredComponentMap
     :: ConfiguredComponent

--- a/Cabal/Distribution/Backpack/PreExistingComponent.hs
+++ b/Cabal/Distribution/Backpack/PreExistingComponent.hs
@@ -14,6 +14,7 @@ import Distribution.Types.PackageId
 import Distribution.Types.UnitId
 import Distribution.Types.ComponentName
 import Distribution.Types.PackageName
+import Distribution.Package
 
 import qualified Data.Map as Map
 import qualified Distribution.InstalledPackageInfo as Installed
@@ -55,3 +56,9 @@ ipiToPreExistingComponent ipi =
                             (Map.fromList (Installed.instantiatedWith ipi)),
         pc_shape = shapeInstalledPackage ipi
     }
+
+instance Package PreExistingComponent where
+  packageId = pc_pkgid
+
+instance HasUnitId PreExistingComponent where
+  installedUnitId = pc_uid

--- a/Cabal/Distribution/Backpack/PreExistingComponent.hs
+++ b/Cabal/Distribution/Backpack/PreExistingComponent.hs
@@ -5,12 +5,14 @@ module Distribution.Backpack.PreExistingComponent (
 ) where
 
 import Prelude ()
+import Distribution.Compat.Prelude
 
 import Distribution.Backpack.ModuleShape
 import Distribution.Backpack
 import Distribution.Types.ComponentId
 import Distribution.Types.PackageId
 import Distribution.Types.UnitId
+import Distribution.Types.ComponentName
 import Distribution.Types.PackageName
 
 import qualified Data.Map as Map
@@ -21,12 +23,13 @@ import Distribution.InstalledPackageInfo (InstalledPackageInfo)
 -- we don't need to know how to build.
 data PreExistingComponent
     = PreExistingComponent {
-        -- | The 'PackageName' that, when we see it in 'PackageDescription',
-        -- we should map this to.  This may DISAGREE with 'pc_pkgid' for
-        -- internal dependencies: e.g., an internal component @lib@
-        -- may be munged to @z-pkg-z-lib@, but we still want to use
-        -- it when we see @lib@ in @build-depends@
+        -- | The actual name of the package. This may DISAGREE with 'pc_pkgid'
+        -- for internal dependencies: e.g., an internal component @lib@ may be
+        -- munged to @z-pkg-z-lib@, but we still want to use it when we see
+        -- @lib@ in @build-depends@
         pc_pkgname :: PackageName,
+        -- | The actual name of the component.
+        pc_compname :: ComponentName,
         pc_pkgid :: PackageId,
         pc_uid   :: UnitId,
         pc_cid   :: ComponentId,
@@ -37,10 +40,13 @@ data PreExistingComponent
 -- | Convert an 'InstalledPackageInfo' into a 'PreExistingComponent',
 -- which was brought into scope under the 'PackageName' (important for
 -- a package qualified reference.)
-ipiToPreExistingComponent :: (PackageName, InstalledPackageInfo) -> PreExistingComponent
-ipiToPreExistingComponent (pn, ipi) =
+ipiToPreExistingComponent :: InstalledPackageInfo -> PreExistingComponent
+ipiToPreExistingComponent ipi =
     PreExistingComponent {
-        pc_pkgname = pn,
+        pc_pkgname = case Installed.sourcePackageName ipi of
+            Just n -> n
+            Nothing -> pkgName $ Installed.sourcePackageId ipi,
+        pc_compname = libraryComponentName $ Installed.sourceLibName ipi,
         pc_pkgid = Installed.sourcePackageId ipi,
         pc_uid   = Installed.installedUnitId ipi,
         pc_cid   = Installed.installedComponentId ipi,
@@ -49,4 +55,3 @@ ipiToPreExistingComponent (pn, ipi) =
                             (Map.fromList (Installed.instantiatedWith ipi)),
         pc_shape = shapeInstalledPackage ipi
     }
-

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -517,7 +517,7 @@ configure (pkg_descr0', pbi) cfg = do
     -- For one it's deterministic; for two, we need to associate
     -- them with renamings which would require a far more complicated
     -- input scheme than what we have today.)
-    externalPkgDeps :: [(PackageName, InstalledPackageInfo)]
+    externalPkgDeps :: [InstalledPackageInfo]
         <- configureDependencies
                 verbosity
                 use_external_internal_deps
@@ -1008,27 +1008,25 @@ configureDependencies
     -> InstalledPackageIndex -- ^ installed packages
     -> Map PackageName InstalledPackageInfo -- ^ required deps
     -> PackageDescription
-    -> IO [(PackageName, InstalledPackageInfo)]
+    -> IO [InstalledPackageInfo]
 configureDependencies verbosity use_external_internal_deps
   internalPackageSet installedPackageSet requiredDepsMap pkg_descr = do
-    let selectDependencies :: [Dependency] ->
-                              ([FailedDependency], [ResolvedDependency])
-        selectDependencies =
-            partitionEithers
-          . map (selectDependency (package pkg_descr)
-                                  internalPackageSet installedPackageSet
-                                  requiredDepsMap use_external_internal_deps)
-
-        (failedDeps, allPkgDeps) =
-          selectDependencies (buildDepends pkg_descr)
+    let failedDeps :: [FailedDependency]
+        allPkgDeps :: [ResolvedDependency]
+        (failedDeps, allPkgDeps) = partitionEithers
+          [ (\s -> (dep, s)) <$> status
+          | dep <- buildDepends pkg_descr
+          , let status = selectDependency (package pkg_descr)
+                  internalPackageSet installedPackageSet
+                  requiredDepsMap use_external_internal_deps dep ]
 
         internalPkgDeps = [ pkgid
-                          | InternalDependency _ pkgid <- allPkgDeps ]
+                          | (_, InternalDependency pkgid) <- allPkgDeps ]
         -- NB: we have to SAVE the package name, because this is the only
         -- way we can be able to resolve package names in the package
         -- description.
-        externalPkgDeps = [ (pn, pkg)
-                          | ExternalDependency (Dependency pn _) pkg   <- allPkgDeps ]
+        externalPkgDeps = [ pkg
+                          | (_, ExternalDependency pkg)   <- allPkgDeps ]
 
     when (not (null internalPkgDeps)
           && not (newPackageDepsBehaviour pkg_descr)) $
@@ -1160,16 +1158,18 @@ reportProgram verbosity prog (Just configuredProg)
 hackageUrl :: String
 hackageUrl = "http://hackage.haskell.org/package/"
 
-data ResolvedDependency
+type ResolvedDependency = (Dependency, DependencyResolution)
+
+data DependencyResolution
     -- | An external dependency from the package database, OR an
     -- internal dependency which we are getting from the package
     -- database.
-    = ExternalDependency Dependency InstalledPackageInfo
+    = ExternalDependency InstalledPackageInfo
     -- | An internal dependency ('PackageId' should be a library name)
     -- which we are going to have to build.  (The
     -- 'PackageId' here is a hack to get a modest amount of
     -- polymorphism out of the 'Package' typeclass.)
-    | InternalDependency Dependency PackageId
+    | InternalDependency PackageId
 
 data FailedDependency = DependencyNotExists PackageName
                       | DependencyMissingInternal PackageName PackageName
@@ -1185,7 +1185,7 @@ selectDependency :: PackageId -- ^ Package id of current package
                  -> UseExternalInternalDeps -- ^ Are we configuring a
                                             -- single component?
                  -> Dependency
-                 -> Either FailedDependency ResolvedDependency
+                 -> Either FailedDependency DependencyResolution
 selectDependency pkgid internalIndex installedIndex requiredDepsMap
   use_external_internal_deps
   dep@(Dependency dep_pkgname vr) =
@@ -1208,21 +1208,24 @@ selectDependency pkgid internalIndex installedIndex requiredDepsMap
                     else do_internal
     _          -> do_external Nothing
   where
-    do_internal = Right (InternalDependency dep
-                    (PackageIdentifier dep_pkgname (packageVersion pkgid)))
-    do_external is_internal = case Map.lookup dep_pkgname requiredDepsMap of
-      -- If we know the exact pkg to use, then use it.
-      Just pkginstance -> Right (ExternalDependency dep pkginstance)
-      -- Otherwise we just pick an arbitrary instance of the latest version.
-      Nothing -> case PackageIndex.lookupDependency installedIndex dep' of
-        []   -> Left  $
-                  case is_internal of
-                    Just cname -> DependencyMissingInternal dep_pkgname
-                                    (computeCompatPackageName (packageName pkgid) cname)
-                    Nothing -> DependencyNotExists dep_pkgname
-        pkgs -> Right $ ExternalDependency dep $
-                case last pkgs of
-                  (_ver, pkginstances) -> head pkginstances
+    do_internal = Right $ InternalDependency
+                    $ PackageIdentifier dep_pkgname $ packageVersion pkgid
+    do_external is_internal = do
+      ipi <- case Map.lookup dep_pkgname requiredDepsMap of
+        -- If we know the exact pkg to use, then use it.
+        Just pkginstance -> Right pkginstance
+        -- Otherwise we just pick an arbitrary instance of the latest version.
+        Nothing -> case PackageIndex.lookupDependency installedIndex dep' of
+          []   -> Left $ case is_internal of
+            Just cname -> DependencyMissingInternal dep_pkgname
+                   (computeCompatPackageName (packageName pkgid) cname)
+            Nothing -> DependencyNotExists dep_pkgname
+          pkgs -> Right $ head $ snd $ last pkgs
+      -- Fix metadata that may be stripped by old ghc-pkg
+      return $ ExternalDependency $ ipi {
+        Installed.sourcePackageName = (const $ pkgName pkgid) <$> is_internal,
+        Installed.sourceLibName = componentNameString =<< is_internal
+      }
      where
       dep' | Just cname <- is_internal
            = Dependency (computeCompatPackageName (packageName pkgid) cname) vr
@@ -1236,10 +1239,10 @@ reportSelectedDependencies verbosity deps =
   info verbosity $ unlines
     [ "Dependency " ++ display (simplifyDependency dep)
                     ++ ": using " ++ display pkgid
-    | resolved <- deps
-    , let (dep, pkgid) = case resolved of
-            ExternalDependency dep' pkg'   -> (dep', packageId pkg')
-            InternalDependency dep' pkgid' -> (dep', pkgid') ]
+    | (dep, resolution) <- deps
+    , let pkgid = case resolution of
+            ExternalDependency pkg'   -> packageId pkg'
+            InternalDependency pkgid' -> pkgid' ]
 
 reportFailedDependencies :: Verbosity -> [FailedDependency] -> IO ()
 reportFailedDependencies _ []     = return ()


### PR DESCRIPTION
It no longer hacks around build-depends: that code has been moved to Backpack.Configure, and will be removed altogether with LibDependency

@ezyang I suppose as the foundation this should be reviewed carefully?