### PR TITLE
ProjectPlanning refactor

### DIFF
--- a/Cabal/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/Distribution/Backpack/ConfiguredComponent.hs
@@ -20,6 +20,7 @@ import Distribution.Compat.Prelude hiding ((<>))
 import Distribution.Backpack.Id
 
 import Distribution.Types.Dependency
+import Distribution.Types.ExeDependency
 import Distribution.Types.IncludeRenaming
 import Distribution.Types.ComponentId
 import Distribution.Types.PackageId
@@ -34,11 +35,12 @@ import Distribution.Simple.BuildToolDepends
 import Distribution.Simple.Setup as Setup
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Version
+import Distribution.Utils.LogProgress
+import Distribution.Utils.MapAccum
 
+import Control.Monad
 import qualified Data.Set as Set
 import qualified Data.Map as Map
-import Data.Traversable
-    ( mapAccumL )
 import Distribution.Text
 import Text.PrettyPrint
 
@@ -59,8 +61,9 @@ data ConfiguredComponent
         -- Note that in one-component configure mode, this is
         -- always True, because any component is the "public" one.)
         cc_public :: Bool,
-        -- | Dependencies on internal executables from @build-tools@.
-        cc_internal_build_tools :: [ComponentId],
+        -- | Dependencies on executables from @build-tools@ and
+        -- @build-tool-depends@.
+        cc_exe_deps :: [(ComponentId, PackageId)],
         -- | The mixins of this package, including both explicit (from
         -- the @mixins@ field) and implicit (from @build-depends@).  Not
         -- mix-in linked yet; component configuration only looks at
@@ -89,98 +92,106 @@ mkConfiguredComponent
     :: PackageDescription
     -> ComponentId
     -> [((PackageName, ComponentName), (ComponentId, PackageId))]
-    -> [ComponentId]
+    -> [(ComponentId, PackageId)]
     -> Component
-    -> ConfiguredComponent
-mkConfiguredComponent pkg_decr this_cid lib_deps exe_deps component =
-    ConfiguredComponent {
-        cc_cid = this_cid,
-        cc_pkgid = package pkg_decr,
-        cc_component = component,
-        cc_public = is_public,
-        cc_internal_build_tools = exe_deps,
-        cc_includes = explicit_includes ++ implicit_includes
-    }
-  where
-    bi = componentBuildInfo component
-    deps_map = Map.fromList lib_deps
-
+    -> LogProgress ConfiguredComponent
+mkConfiguredComponent pkg_decr this_cid lib_deps exe_deps component = do
     -- Resolve each @mixins@ into the actual dependency
     -- from @lib_deps@.
-    explicit_includes
-        = [ let keys@(_, cname) = fixFakePkgName pkg_decr name
-                (cid, pid) =
-                    case Map.lookup keys deps_map of
-                        Nothing ->
-                            error $ "Mix-in refers to non-existent package " ++ display name ++
-                                    " (did you forget to add the package to build-depends?)"
-                        Just r  -> r
-            in ComponentInclude {
+    explicit_includes <- forM (mixins bi) $ \(Mixin name rns) -> do
+        let keys@(_, cname) = fixFakePkgName pkg_decr name
+        (cid, pid) <-
+            case Map.lookup keys deps_map of
+                Nothing ->
+                    dieProgress $
+                        text "Mix-in refers to non-existent package" <+>
+                        quotes (disp name) $$
+                        text "(did you forget to add the package to build-depends?)"
+                Just r  -> return r
+        return ComponentInclude {
                 ci_id       = cid,
                 ci_pkgid    = pid,
                 ci_compname = cname,
                 ci_renaming = rns,
                 ci_implicit = False
-               }
-          | Mixin name rns <- mixins bi ]
+            }
 
-    -- Any @build-depends@ which is not explicitly mentioned in
-    -- @backpack-include@ is converted into an "implicit" include.
-    used_explicitly = Set.fromList (map ci_id explicit_includes)
-    implicit_includes
-        = map (\((_, cn), (cid, pid)) -> ComponentInclude {
-                                ci_id = cid,
-                                ci_pkgid = pid,
-                                ci_compname = cn,
-                                ci_renaming = defaultIncludeRenaming,
-                                ci_implicit = True
-                              })
-        $ filter (flip Set.notMember used_explicitly . fst . snd) lib_deps
+        -- Any @build-depends@ which is not explicitly mentioned in
+        -- @backpack-include@ is converted into an "implicit" include.
+    let used_explicitly = Set.fromList (map ci_id explicit_includes)
+        implicit_includes
+            = map (\((_, cn), (cid, pid)) -> ComponentInclude {
+                                    ci_id = cid,
+                                    ci_pkgid = pid,
+                                    ci_compname = cn,
+                                    ci_renaming = defaultIncludeRenaming,
+                                    ci_implicit = True
+                                  })
+            $ filter (flip Set.notMember used_explicitly . fst . snd) lib_deps
 
+    return ConfiguredComponent {
+            cc_cid = this_cid,
+            cc_pkgid = package pkg_decr,
+            cc_component = component,
+            cc_public = is_public,
+            cc_exe_deps = exe_deps,
+            cc_includes = explicit_includes ++ implicit_includes
+        }
+  where
+    bi = componentBuildInfo component
+    deps_map = Map.fromList lib_deps
     is_public = componentName component == CLibName
 
 type ConfiguredComponentMap =
-        (Map (PackageName, ComponentName) (ComponentId, PackageId), -- libraries
-         Map UnqualComponentName ComponentId)      -- executables
-
--- Executable map must be different because an executable can
--- have the same name as a library. Ew.
+        Map PackageName (Map ComponentName (ComponentId, PackageId))
 
 toConfiguredComponent
     :: PackageDescription
     -> ComponentId
     -> ConfiguredComponentMap
     -> Component
-    -> ConfiguredComponent
-toConfiguredComponent pkg_descr this_cid (lib_map, exe_map) component =
+    -> LogProgress ConfiguredComponent
+toConfiguredComponent pkg_descr this_cid dep_map component = do
+    lib_deps <-
+        if newPackageDepsBehaviour pkg_descr
+            then forM (targetBuildDepends bi) $ \(Dependency name _) -> do
+                    let keys@(pn, cn) = fixFakePkgName pkg_descr name
+                    value <- case Map.lookup cn =<< Map.lookup pn dep_map of
+                        Nothing ->
+                            dieProgress $
+                                text "Dependency on unbuildable" <+>
+                                text (showComponentName cn) <+>
+                                text "from" <+> disp pn
+                        Just v -> return v
+                    return (keys, value)
+            else return old_style_lib_deps
     mkConfiguredComponent
        pkg_descr this_cid
        lib_deps exe_deps component
   where
     bi = componentBuildInfo component
-    lib_deps
-        | newPackageDepsBehaviour pkg_descr
-        = [ (keys, value)
-          | Dependency name _ <- targetBuildDepends bi
-          , let keys@(pn, cn) = fixFakePkgName pkg_descr name
-                value = flip fromMaybe (Map.lookup keys lib_map) $ error $
-                  "toConfiguredComponent: " ++ display (packageName pkg_descr)
-                  ++ " " ++ display pn ++ ":" ++ display cn ]
-        | otherwise
-        -- lib_map contains a mix of internal and external deps.
-        -- We want all the public libraries (dep_cn == CLibName)
-        -- of all external deps (dep /= pn).  Note that this
-        -- excludes the public library of the current package:
-        -- this is not supported by old-style deps behavior
-        -- because it would imply a cyclic dependency for the
-        -- library itself.
-        = [ e
-          | e@((pn,cn), _) <- Map.toList lib_map
-          , pn /=  packageName pkg_descr
-          , cn == CLibName ]
-    exe_deps = [ cid
-               | toolName <- getAllInternalToolDependencies pkg_descr bi
-               , Just cid <- [ Map.lookup toolName exe_map ] ]
+    -- dep_map contains a mix of internal and external deps.
+    -- We want all the public libraries (dep_cn == CLibName)
+    -- of all external deps (dep /= pn).  Note that this
+    -- excludes the public library of the current package:
+    -- this is not supported by old-style deps behavior
+    -- because it would imply a cyclic dependency for the
+    -- library itself.
+    old_style_lib_deps = [ ((pn, cn), e)
+                         | (pn, comp_map) <- Map.toList dep_map
+                         , pn /= packageName pkg_descr
+                         , (cn, e) <- Map.toList comp_map
+                         , cn == CLibName ]
+    exe_deps =
+        [ exe
+        | ExeDependency pn cn _ <- getAllToolDependencies pkg_descr bi
+        -- The error suppression here is important, because in general
+        -- we won't know about external dependencies (e.g., 'happy')
+        -- which the package is attempting to use (those deps are only
+        -- fed in when cabal-install uses this codepath.)
+        -- TODO: Let cabal-install request errors here
+        , Just exe <- [Map.lookup (CExeName cn) =<< Map.lookup pn dep_map]
+        ]
 
 -- | Also computes the 'ComponentId', and sets cc_public if necessary.
 -- This is Cabal-only; cabal-install won't use this.
@@ -193,35 +204,30 @@ toConfiguredComponent'
     -> Flag ComponentId -- configCID
     -> ConfiguredComponentMap
     -> Component
-    -> ConfiguredComponent
+    -> LogProgress ConfiguredComponent
 toConfiguredComponent' use_external_internal_deps flags
                 pkg_descr deterministic ipid_flag cid_flag
-                (lib_map, exe_map) component =
-    let cc = toConfiguredComponent
+                dep_map component = do
+    cc <- toConfiguredComponent
                 pkg_descr this_cid
-                (lib_map, exe_map) component
-    in if use_external_internal_deps
-        then cc { cc_public = True }
-        else cc
+                dep_map component
+    return $ if use_external_internal_deps
+                then cc { cc_public = True }
+                else cc
   where
     this_cid = computeComponentId deterministic ipid_flag cid_flag (package pkg_descr)
                 (componentName component) (Just (deps, flags))
-    deps = [ cid | (_, (cid, _)) <- Map.toList lib_map ]
+    deps = [ cid | m <- Map.elems dep_map
+                 , (cid, _) <- Map.elems m ]
 
 extendConfiguredComponentMap
     :: ConfiguredComponent
     -> ConfiguredComponentMap
     -> ConfiguredComponentMap
-extendConfiguredComponentMap cc (lib_map, exe_map) =
-    (lib_map', exe_map')
-  where
-    lib_map'
-      = Map.insert (pkgName (cc_pkgid cc), cc_name cc) (cc_cid cc, cc_pkgid cc) lib_map
-    exe_map'
-      = case cc_name cc of
-          CExeName str ->
-            Map.insert str (cc_cid cc) exe_map
-          _ -> exe_map
+extendConfiguredComponentMap cc =
+    Map.insertWith Map.union
+        (pkgName (cc_pkgid cc))
+        (Map.singleton (cc_name cc) (cc_cid cc, cc_pkgid cc))
 
 -- Compute the 'ComponentId's for a graph of 'Component's.  The
 -- list of internal components must be topologically sorted
@@ -234,20 +240,20 @@ toConfiguredComponents
     -> Flag String -- configIPID
     -> Flag ComponentId -- configCID
     -> PackageDescription
-    -> Map (PackageName, ComponentName) (ComponentId, PackageId)
+    -> ConfiguredComponentMap
     -> [Component]
-    -> [ConfiguredComponent]
+    -> LogProgress [ConfiguredComponent]
 toConfiguredComponents
     use_external_internal_deps flags deterministic ipid_flag cid_flag pkg_descr
-    external_lib_map comps
-    = snd (mapAccumL go (external_lib_map, Map.empty) comps)
+    dep_map comps
+    = fmap snd (mapAccumM go dep_map comps)
   where
-    go m component = (extendConfiguredComponentMap cc m, cc)
-      where cc = toConfiguredComponent'
+    go m component = do
+        cc <- toConfiguredComponent'
                         use_external_internal_deps flags pkg_descr
                         deterministic ipid_flag cid_flag
                         m component
-
+        return (extendConfiguredComponentMap cc m, cc)
 
 newPackageDepsBehaviourMinVersion :: Version
 newPackageDepsBehaviourMinVersion = mkVersion [1,7,1]

--- a/Cabal/Distribution/Backpack/LinkedComponent.hs
+++ b/Cabal/Distribution/Backpack/LinkedComponent.hs
@@ -61,10 +61,9 @@ data LinkedComponent
         lc_pkgid :: PackageId,
         -- | Corresponds to 'cc_component'.
         lc_component :: Component,
-        -- | Local @build-tools@ and @build-tool-depends@ dependencies on
-        -- executables from the same package.  Corresponds to
-        -- 'cc_internal_build_tools'.
-        lc_internal_build_tools :: [OpenUnitId],
+        -- | @build-tools@ and @build-tool-depends@ dependencies.
+        -- Corresponds to 'cc_exe_deps'.
+        lc_exe_deps :: [(OpenUnitId, PackageId)],
         -- | Is this the public library of a package?  Corresponds to
         -- 'cc_public'.
         lc_public :: Bool,
@@ -122,7 +121,7 @@ toLinkedComponent verbosity db this_pid pkg_map ConfiguredComponent {
     cc_cid = this_cid,
     cc_pkgid = pkgid,
     cc_component = component,
-    cc_internal_build_tools = btools,
+    cc_exe_deps = exe_deps,
     cc_public = is_public,
     cc_includes = cid_includes
    } = do
@@ -289,7 +288,8 @@ toLinkedComponent verbosity db this_pid pkg_map ConfiguredComponent {
                 lc_component = component,
                 lc_public = is_public,
                 -- These must be executables
-                lc_internal_build_tools = map (\cid -> IndefFullUnitId cid Map.empty) btools,
+                lc_exe_deps =
+                    map (\(cid, pid) -> (IndefFullUnitId cid Map.empty, pid)) exe_deps,
                 lc_shape = final_linked_shape,
                 lc_includes = linked_includes,
                 lc_sig_includes = linked_sig_includes

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -23,6 +23,7 @@ module Distribution.Client.InstallPlan (
   GenericInstallPlan,
   PlanPackage,
   GenericPlanPackage(..),
+  foldPlanPackage,
   IsUnit,
 
   -- * Operations on 'InstallPlan's
@@ -171,6 +172,18 @@ data GenericPlanPackage ipkg srcpkg
    | Configured  srcpkg
    | Installed   srcpkg
   deriving (Eq, Show, Generic)
+
+-- | Convenience combinator for destructing 'GenericPlanPackage'.
+-- This is handy because if you case manually, you have to handle
+-- 'Configured' and 'Installed' separately (where often you want
+-- them to be the same.)
+foldPlanPackage :: (ipkg -> a)
+                -> (srcpkg -> a)
+                -> GenericPlanPackage ipkg srcpkg
+                -> a
+foldPlanPackage f _ (PreExisting ipkg)  = f ipkg
+foldPlanPackage _ g (Configured srcpkg) = g srcpkg
+foldPlanPackage _ g (Installed  srcpkg) = g srcpkg
 
 type IsUnit a = (IsNode a, Key a ~ UnitId)
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -105,14 +105,12 @@ import           Distribution.Package hiding
   (InstalledPackageId, installedPackageId)
 import           Distribution.Types.ComponentName
 import           Distribution.Types.Dependency
-import           Distribution.Types.ExeDependency
 import           Distribution.Types.PkgconfigDependency
 import           Distribution.Types.UnqualComponentName
 import           Distribution.System
 import qualified Distribution.PackageDescription as Cabal
 import qualified Distribution.PackageDescription as PD
 import qualified Distribution.PackageDescription.Configuration as PD
-import           Distribution.Simple.BuildToolDepends
 import           Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import           Distribution.Simple.Compiler hiding (Flag)
 import qualified Distribution.Simple.GHC   as GHC   --TODO: [code cleanup] eliminate
@@ -1227,16 +1225,12 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
             infoProgress $ hang (text "Component graph for" <+> disp pkgid <<>> colon)
                             4 (dispComponentsGraph g)
             (_, comps) <- mapAccumM buildComponent
-                            ((Map.empty, Map.empty), Map.empty, Map.empty)
+                            (Map.empty, Map.empty, Map.empty)
                             (map fst g)
-            let modShape = case find (matchElabPkg (== CLibName)) comps of
-                                Nothing -> emptyModuleShape
-                                Just ElaboratedConfiguredPackage{..} -> elabModuleShape
             return $ if eligible g
                 then comps
-                else [(elaborateSolverToPackage mapDep spkg) {
-                        elabModuleShape = modShape
-                     }]
+                else [elaborateSolverToPackage mapDep spkg $
+                        comps ++ maybeToList setupComponent]
            Left cns ->
             dieProgress $
                 hang (text "Dependency cycle between the following components:") 4
@@ -1270,6 +1264,43 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
         pkgid = elabPkgSourceId    elab0
         pd    = elabPkgDescription elab0
 
+        -- TODO: This is just a skeleton to get elaborateSolverToPackage
+        -- working correctly
+        -- TODO: When we actually support building these components, we
+        -- have to add dependencies on this from all other components
+        setupComponent :: Maybe ElaboratedConfiguredPackage
+        setupComponent
+            | fromMaybe PD.Custom (PD.buildType (elabPkgDescription elab0)) == PD.Custom
+            = Just elab0 {
+                elabModuleShape = emptyModuleShape,
+                elabUnitId = notImpl "elabUnitId",
+                elabComponentId = notImpl "elabComponentId",
+                elabLinkedInstantiatedWith = Map.empty,
+                elabInstallDirs = notImpl "elabInstallDirs",
+                elabPkgOrComp = ElabComponent (ElaboratedComponent {..})
+              }
+            | otherwise
+            = Nothing
+          where
+            compSolverName      = CD.ComponentSetup
+            compComponentName   = Nothing
+            dep_pkgs = elaborateLibSolverId mapDep =<< CD.setupDeps deps0
+            compLibDependencies
+                = map configuredId dep_pkgs
+            compInplaceDependencyBuildCacheFiles
+                = planPackageCacheFile =<< dep_pkgs
+            compLinkedLibDependencies = notImpl "compLinkedLibDependencies"
+            compOrderLibDependencies = notImpl "compOrderLibDependencies"
+            -- Not supported:
+            compExeDependencies         = []
+            compExeDependencyPaths      = []
+            compPkgConfigDependencies   = []
+
+            notImpl f =
+                error $ "Distribution.Client.ProjectPlanning.setupComponent: " ++
+                        f ++ " not implemented yet"
+
+
         buildComponent
             :: (ConfiguredComponentMap,
                 LinkedComponentMap,
@@ -1280,148 +1311,125 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                   LinkedComponentMap,
                   Map ComponentId FilePath),
                 ElaboratedConfiguredPackage)
-        buildComponent (cc_map0, lc_map, exe_map) comp =
+        buildComponent (cc_map, lc_map, exe_map) comp =
           addProgressCtx (text "In the stanza" <+>
                           quotes (text (componentNameStanza cname))) $ do
-            -- Before we get too far, check if we depended on something
-            -- unbuildable.  If we did, give a good error.  (If we don't
-            -- check, the 'toConfiguredComponent' will assert fail, see #3978).
-            case unbuildable_external_lib_deps of
-                [] -> return ()
-                deps -> dieProgress $
-                            text "Dependency on unbuildable libraries:" <+>
-                            hsep (punctuate comma (map (disp.solverSrcId) deps))
-            case unbuildable_external_exe_deps of
-                [] -> return ()
-                deps -> dieProgress $
-                            text "Dependency on unbuildable executables:" <+>
-                            hsep (punctuate comma (map (disp.solverSrcId) deps))
+
+            -- 1. Configure the component, but with a place holder ComponentId.
+            cc0 <- toConfiguredComponent pd
+                    (error "Distribution.Client.ProjectPlanning.cc_cid: filled in later")
+                    (Map.unionWith Map.union external_cc_map cc_map) comp
+
+            -- 2. Read out the dependencies from the ConfiguredComponent cc0
+            let compLibDependencies =
+                    -- Nub because includes can show up multiple times
+                    ordNub (map (\ci -> ConfiguredId (ci_pkgid ci) (ci_id ci))
+                                (cc_includes cc0))
+                compExeDependencies =
+                    map (\(x, y) -> ConfiguredId y x)
+                        (cc_exe_deps cc0)
+                compExeDependencyPaths =
+                    [ path
+                    | (cid', _) <- cc_exe_deps cc0
+                    , Just path <- [Map.lookup cid' exe_map1]]
+                elab_comp = ElaboratedComponent {..}
+
+            -- 3. Construct a preliminary ElaboratedConfiguredPackage,
+            -- and use this to compute the component ID.  Fix up cc_id
+            -- correctly.
+            let elab1 = elab0 {
+                        elabPkgOrComp = ElabComponent $ elab_comp
+                     }
+                cid = case elabBuildStyle elab0 of
+                        BuildInplaceOnly ->
+                          mkComponentId $
+                            display pkgid ++ "-inplace" ++
+                              (case Cabal.componentNameString cname of
+                                  Nothing -> ""
+                                  Just s -> "-" ++ display s)
+                        BuildAndInstall ->
+                          hashedInstalledPackageId
+                            (packageHashInputs
+                                elaboratedSharedConfig
+                                elab1) -- knot tied
+                cc = cc0 { cc_cid = cid }
             infoProgress $ dispConfiguredComponent cc
-            let -- Use of invariant: DefUnitId indicates that if
-                -- there is no hash, it must have an empty
-                -- instantiation.
-                lookup_uid def_uid =
+
+            -- 4. Perform mix-in linking
+            let lookup_uid def_uid =
                     case Map.lookup (unDefUnitId def_uid) preexistingInstantiatedPkgs of
                         Just full -> full
                         Nothing -> error ("lookup_uid: " ++ display def_uid)
             lc <- toLinkedComponent verbosity lookup_uid (elabPkgSourceId elab0)
                         (Map.union external_lc_map lc_map) cc
-            let lc_map' = extendLinkedComponentMap lc lc_map
             infoProgress $ dispLinkedComponent lc
-            -- NB: For inplace NOT InstallPaths.bindir installDirs; for an
-            -- inplace build those values are utter nonsense.  So we
-            -- have to guess where the directory is going to be.
-            -- Fortunately this is "stable" part of Cabal API.
-            -- But the way we get the build directory is A HORRIBLE
-            -- HACK.
             -- NB: elab is setup to be the correct form for an
             -- indefinite library, or a definite library with no holes.
             -- We will modify it in 'instantiateInstallPlan' to handle
             -- instantiated packages.
-            let elab = elab1 {
+
+            -- 5. Construct the final ElaboratedConfiguredPackage
+            let
+                elab = elab1 {
                     elabModuleShape = lc_shape lc,
                     elabUnitId      = abstractUnitId (lc_uid lc),
                     elabComponentId = lc_cid lc,
                     elabLinkedInstantiatedWith = Map.fromList (lc_insts lc),
                     elabPkgOrComp = ElabComponent $ elab_comp {
                         compLinkedLibDependencies = ordNub (map ci_id (lc_includes lc)),
-                        compNonSetupDependencies =
+                        compOrderLibDependencies =
                           ordNub (map (abstractUnitId . ci_id)
                                       (lc_includes lc ++ lc_sig_includes lc))
-                      }
+                      },
+                    elabInstallDirs = install_dirs cid
                    }
-                inplace_bin_dir
-                  | shouldBuildInplaceOnly spkg
-                  = distBuildDirectory
-                        (elabDistDirParams elaboratedSharedConfig elab) </>
-                        "build" </> case Cabal.componentNameString cname of
-                                        Just n -> display n
-                                        Nothing -> ""
-                  | otherwise
-                  = InstallDirs.bindir install_dirs
-                exe_map' = Map.insert cid inplace_bin_dir exe_map
-            return ((cc_map2, lc_map', exe_map'), elab)
+
+            -- 6. Construct the updated local maps
+            let cc_map'  = extendConfiguredComponentMap cc cc_map
+                lc_map'  = extendLinkedComponentMap lc lc_map
+                exe_map' = Map.insert cid (inplace_bin_dir elab) exe_map
+
+            return ((cc_map', lc_map', exe_map'), elab)
           where
-            elab1 = elab0 {
-                    elabInstallDirs = install_dirs,
-                    elabPkgOrComp = ElabComponent $ elab_comp
-                 }
-            elab_comp = ElaboratedComponent {..}
             compLinkedLibDependencies = error "buildComponent: compLinkedLibDependencies"
-            compNonSetupDependencies = error "buildComponent: compNonSetupDependencies"
-
-            cc_map1 = (external_cc_map `Map.union` lib_map0, exe_map0)
-              where (lib_map0, exe_map0) = cc_map0
-            cc = toConfiguredComponent pd cid cc_map1 comp
-            cc_map2 = extendConfiguredComponentMap cc cc_map1
-
-            cid :: ComponentId
-            cid = case elabBuildStyle elab0 of
-                    BuildInplaceOnly ->
-                      mkComponentId $
-                        display pkgid ++ "-inplace" ++
-                          (case Cabal.componentNameString cname of
-                              Nothing -> ""
-                              Just s -> "-" ++ display s)
-                    BuildAndInstall ->
-                      hashedInstalledPackageId
-                        (packageHashInputs
-                            elaboratedSharedConfig
-                            elab1) -- knot tied
+            compOrderLibDependencies = error "buildComponent: compOrderLibDependencies"
 
             cname = Cabal.componentName comp
             compComponentName = Just cname
             compSolverName = CD.componentNameToComponent cname
 
             -- NB: compLinkedLibDependencies and
-            -- compNonSetupDependencies are defined when we define
+            -- compOrderLibDependencies are defined when we define
             -- 'elab'.
             external_lib_dep_sids = CD.select (== compSolverName) deps0
-            external_lib_dep_pkgs =
-                external_lib_dep_sids >>= elaborateLibSolverId mapDep
-            compInplaceDependencyBuildCacheFiles =
-                external_lib_dep_pkgs >>= planPackageCacheFile
-            compLibDependencies =
-                -- In principle, external_lib_dep_pkgs should also be good
-                -- enough to compute this...
-                ordNub (map (\ci -> ConfiguredId (ci_pkgid ci) (ci_id ci)) (cc_includes cc))
-
-            exeMapDep = filterExeMapDep mapDep pd [Cabal.componentBuildInfo comp]
             external_exe_dep_sids = CD.select (== compSolverName) exe_deps0
-            external_exe_dep_pkgs =
-                external_exe_dep_sids >>= elaborateExeSolverId exeMapDep
-            external_exe_dep_cids =
-                external_exe_dep_pkgs >>= return . confInstId . configuredId
-            external_exe_dep_paths =
-                external_exe_dep_pkgs >>= planPackageExePath
-            compExeDependencies = external_exe_dep_cids ++ cc_internal_build_tools cc
-            compExeDependencyPaths =
-                external_exe_dep_paths ++
-                [ path
-                | cid' <- cc_internal_build_tools cc
-                , Just path <- [Map.lookup cid' exe_map]]
+            -- TODO: The fact that lib SolverIds and exe SolverIds are
+            -- jammed together here means that we're losing information!
+            external_dep_sids = external_lib_dep_sids ++ external_exe_dep_sids
+            external_dep_pkgs = concatMap mapDep external_dep_sids
 
-            compSetupDependencies =
-                CD.setupDeps deps0 >>= elaborateLibSolverId mapDep
-                                   >>= return . configuredId
+            compInplaceDependencyBuildCacheFiles =
+                external_dep_pkgs >>= planPackageCacheFile
 
-            external_cc_map = Map.fromList (map mkPkgNameMapping external_lib_dep_pkgs)
-            external_lc_map = Map.fromList (map mkShapeMapping external_lib_dep_pkgs)
+            external_exe_map = Map.fromList $
+                [ (getComponentId pkg, path)
+                | pkg <- external_dep_pkgs
+                , Just path <- [planPackageExePath pkg] ]
+            exe_map1 = Map.union external_exe_map exe_map
 
-            unbuildable_external_lib_deps =
-                filter (null . elaborateLibSolverId mapDep) external_lib_dep_sids
-            unbuildable_external_exe_deps =
-                filter (null . elaborateExeSolverId exeMapDep) external_exe_dep_sids
+            external_cc_map = Map.fromListWith Map.union
+                            $ map mkCCMapping external_dep_pkgs
+            external_lc_map = Map.fromList (map mkShapeMapping external_dep_pkgs)
 
             compPkgConfigDependencies =
                 [ (pn, fromMaybe (error $ "compPkgConfigDependencies: impossible! "
                                             ++ display pn ++ " from "
-                                            ++ display (elabPkgSourceId elab1))
+                                            ++ display (elabPkgSourceId elab0))
                                  (pkgConfigDbPkgVersion pkgConfigDB pn))
                 | PkgconfigDependency pn _ <- PD.pkgconfigDepends
                                                 (Cabal.componentBuildInfo comp) ]
 
-            install_dirs
+            install_dirs cid
               | shouldBuildInplaceOnly spkg
               -- use the ordinary default install dirs
               = (InstallDirs.absoluteInstallDirs
@@ -1443,42 +1451,21 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                   (compilerId compiler)
                   cid
 
-    -- TODO: Refactor me
-    filterExeMapDep :: (SolverId -> [ElaboratedPlanPackage])
-                    -> PD.PackageDescription -> [PD.BuildInfo]
-                    -> SolverId -> [ElaboratedPlanPackage]
-    filterExeMapDep mapDep pd bis = filter go . mapDep
-      where
-        toolDeps = getAllToolDependencies pd =<< bis
-        exeKV :: [(PackageName, Set UnqualComponentName)]
-        exeKV = map go' toolDeps where
-          go' (ExeDependency p n _) = (p, Set.singleton n)
-
-        -- Nothing means wildcard, the complete subset
-        exeMap :: Map PackageName (Set UnqualComponentName)
-        exeMap = Map.fromListWith mappend exeKV
-
-        go (InstallPlan.Installed _) = unexpectedState
-        go (InstallPlan.PreExisting _) = True
-        go (InstallPlan.Configured (ElaboratedConfiguredPackage {
-              elabPkgSourceId = PackageIdentifier { pkgName, .. },
-              elabPkgOrComp,
-              ..
-            })) = case elabPkgOrComp of
-          -- If we can only build the whole package or none of it, then we have
-          -- no choice and must build it all.
-          ElabPackage   _     -> True
-          -- If we can build specific components, lets just build the ones we
-          -- actually need.
-          ElabComponent comp' ->
-            case Ty.compSolverName comp' of
-              CD.ComponentExe n -> case Map.lookup pkgName exeMap of
-                Just set -> Set.member n set
-                -- We may get unwanted components, but they should be from
-                -- packages we at least depended on.
-                Nothing  -> unexpectedState
-              -- If it's not an exe component, it won't satisfy an exe dep
-              _  -> False
+            -- NB: For inplace NOT InstallPaths.bindir installDirs; for an
+            -- inplace build those values are utter nonsense.  So we
+            -- have to guess where the directory is going to be.
+            -- Fortunately this is "stable" part of Cabal API.
+            -- But the way we get the build directory is A HORRIBLE
+            -- HACK.
+            inplace_bin_dir elab
+              | shouldBuildInplaceOnly spkg
+              = distBuildDirectory
+                    (elabDistDirParams elaboratedSharedConfig elab) </>
+                    "build" </> case Cabal.componentNameString cname of
+                                    Just n -> display n
+                                    Nothing -> ""
+              | otherwise
+              = InstallDirs.bindir (elabInstallDirs elab)
 
     -- | Given a 'SolverId' referencing a dependency on a library, return
     -- the 'ElaboratedPlanPackage' corresponding to the library.  This
@@ -1497,23 +1484,15 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                     (elabDistDirParams elaboratedSharedConfig elab)
                     "build"
 
-    -- | Given a 'SolverId' referencing a dependency on an executable,
-    -- return the 'ElaboratedPlanPackage' corresponding to the executable.
-    -- This may return more than one result.
-    elaborateExeSolverId :: (SolverId -> [ElaboratedPlanPackage])
-                         -> SolverId -> [ElaboratedPlanPackage]
-    elaborateExeSolverId mapDep = filter (matchPlanPkg isExeName) . mapDep
-
     -- | Given an 'ElaboratedPlanPackage', return the path to where the
     -- executable that this package represents would be installed.
-    -- This returns at most one result.
-    planPackageExePath :: ElaboratedPlanPackage -> [FilePath]
+    planPackageExePath :: ElaboratedPlanPackage -> Maybe FilePath
     planPackageExePath =
         -- Pre-existing executables are assumed to be in PATH
         -- already.  In fact, this should be impossible.
         -- Modest duplication with 'inplace_bin_dir'
-        InstallPlan.foldPlanPackage (const []) $ \elab ->
-            [if elabBuildStyle elab == BuildInplaceOnly
+        InstallPlan.foldPlanPackage (const Nothing) $ \elab -> Just $
+            if elabBuildStyle elab == BuildInplaceOnly
               then distBuildDirectory
                     (elabDistDirParams elaboratedSharedConfig elab) </>
                     "build" </>
@@ -1524,17 +1503,16 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                                           (compComponentName comp) of
                                     Just (Just n) -> display n
                                     _ -> ""
-              else InstallDirs.bindir (elabInstallDirs elab)]
-
-    unexpectedState = error "elaborateInstallPlan: unexpected Installed state"
+              else InstallDirs.bindir (elabInstallDirs elab)
 
     elaborateSolverToPackage :: (SolverId -> [ElaboratedPlanPackage])
                              -> SolverPackage UnresolvedPkgLoc
+                             -> [ElaboratedConfiguredPackage]
                              -> ElaboratedConfiguredPackage
     elaborateSolverToPackage
         mapDep
         pkg@(SolverPackage (SourcePackage pkgid _gdesc _srcloc _descOverride)
-                           _flags _stanzas deps0 exe_deps0) =
+                           _flags _stanzas _deps0 _exe_deps0) comps =
         -- Knot tying: the final elab includes the
         -- pkgInstalledId, which is calculated by hashing many
         -- of the other fields of the elaboratedPackage.
@@ -1546,8 +1524,13 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                 elabComponentId = pkgInstalledId,
                 elabLinkedInstantiatedWith = Map.empty,
                 elabInstallDirs = install_dirs,
-                elabPkgOrComp = ElabPackage $ ElaboratedPackage {..}
+                elabPkgOrComp = ElabPackage $ ElaboratedPackage {..},
+                elabModuleShape = modShape
             }
+
+        modShape = case find (matchElabPkg (== CLibName)) comps of
+                        Nothing -> emptyModuleShape
+                        Just e -> Ty.elabModuleShape e
 
         pkgInstalledId
           | shouldBuildInplaceOnly pkg
@@ -1564,24 +1547,24 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
           = error $ "elaborateInstallPlan: non-inplace package "
                  ++ " is missing a source hash: " ++ display pkgid
 
-        buildInfos = PD.allBuildInfo elabPkgDescription
-        exeMapDep = filterExeMapDep mapDep elabPkgDescription buildInfos
+        pkgLibDependencies
+            = buildComponentDeps compLibDependencies
+        pkgInplaceDependencyBuildCacheFiles
+            = buildComponentDeps compInplaceDependencyBuildCacheFiles
+        pkgExeDependencies
+            = buildComponentDeps compExeDependencies
+        pkgExeDependencyPaths
+            = buildComponentDeps compExeDependencyPaths
+        -- TODO: Why is this flat?
+        pkgPkgConfigDependencies
+            = CD.flatDeps $ buildComponentDeps compPkgConfigDependencies
 
-        pkgLibDependencies  =
-            fmap (concatMap (map configuredId . elaborateLibSolverId mapDep)) deps0
-        pkgInplaceDependencyBuildCacheFiles =
-            fmap (concatMap (planPackageCacheFile <=< elaborateLibSolverId mapDep)) deps0
-        pkgExeDependencies  =
-            fmap (concatMap (map configuredId . elaborateExeSolverId exeMapDep)) exe_deps0
-        pkgExeDependencyPaths =
-            fmap (concatMap (planPackageExePath <=< elaborateExeSolverId exeMapDep)) exe_deps0
-        pkgPkgConfigDependencies =
-              ordNub
-            $ [ (pn, fromMaybe (error $ "pkgPkgConfigDependencies: impossible! "
-                                          ++ display pn ++ " from " ++ display pkgid)
-                               (pkgConfigDbPkgVersion pkgConfigDB pn))
-              | PkgconfigDependency pn _ <- concatMap PD.pkgconfigDepends buildInfos
-              ]
+        buildComponentDeps f
+            = CD.fromList [ (compSolverName comp, f comp)
+                          | ElaboratedConfiguredPackage{
+                                elabPkgOrComp = ElabComponent comp
+                            } <- comps
+                          ]
 
         -- Filled in later
         pkgStanzasEnabled  = Set.empty
@@ -1867,18 +1850,19 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
       -- + vanilla libs & exes, exe needs lib, recursive
       -- + ghci or shared lib needed by TH, recursive, ghc version dependent
 
--- | Test if a 'ComponentName' identifies an executable.
-isExeName :: ComponentName -> Bool
-isExeName (CExeName _) = True
-isExeName _            = False
+-- TODO: Drop matchPlanPkg/matchElabPkg in favor of mkCCMapping
 
 -- | Given a 'ElaboratedPlanPackage', report if it matches a 'ComponentName'.
 matchPlanPkg :: (ComponentName -> Bool) -> ElaboratedPlanPackage -> Bool
-matchPlanPkg p = InstallPlan.foldPlanPackage matchIPI (matchElabPkg p)
-  where
-    matchIPI ipkg = case IPI.sourceLibName ipkg of
-                        Nothing -> p CLibName
-                        Just n  -> p (CSubLibName n)
+matchPlanPkg p = InstallPlan.foldPlanPackage (p . ipiComponentName) (matchElabPkg p)
+
+-- | Get the appropriate 'ComponentName' which identifies an installed
+-- component.
+ipiComponentName :: IPI.InstalledPackageInfo -> ComponentName
+ipiComponentName ipkg =
+    case IPI.sourceLibName ipkg of
+        Nothing -> CLibName
+        Just n  -> (CSubLibName n)
 
 -- | Given a 'ElaboratedConfiguredPackage', report if it matches a
 -- 'ComponentName'.
@@ -1899,11 +1883,27 @@ matchElabPkg p elab =
                 (Cabal.pkgBuildableComponents (elabPkgDescription elab))
 
 -- | Given an 'ElaboratedPlanPackage', generate the mapping from 'PackageName'
--- and 'ComponentName' to the 'ComponentId' that this package represents.
-mkPkgNameMapping :: ElaboratedPlanPackage
-                 -> ((PackageName, ComponentName), (ComponentId, PackageId))
-mkPkgNameMapping dpkg =
-    ((packageName dpkg, CLibName), (getComponentId dpkg, packageId dpkg))
+-- and 'ComponentName' to the 'ComponentId' that that should be used
+-- in this case.
+mkCCMapping :: ElaboratedPlanPackage
+            -> (PackageName, Map ComponentName (ComponentId, PackageId))
+mkCCMapping =
+    InstallPlan.foldPlanPackage
+       (\ipkg -> (packageName ipkg,
+                    Map.singleton (ipiComponentName ipkg)
+                                  (IPI.installedComponentId ipkg, packageId ipkg)))
+      $ \elab ->
+        let v = (elabComponentId elab, packageId elab)
+        in (packageName elab,
+            case elabPkgOrComp elab of
+                ElabComponent comp ->
+                    case compComponentName comp of
+                        Nothing -> Map.empty
+                        Just n  -> Map.singleton n v
+                ElabPackage _ ->
+                    Map.fromList $
+                        map (\comp -> (Cabal.componentName comp, v))
+                            (Cabal.pkgBuildableComponents (elabPkgDescription elab)))
 
 -- | Given an 'ElaboratedPlanPackage', generate the mapping from 'ComponentId'
 -- to the shape of this package, as per mix-in linking.
@@ -1988,7 +1988,7 @@ instantiateInstallPlan plan =
                     elabComponentId = cid,
                     elabInstantiatedWith = insts,
                     elabPkgOrComp = ElabComponent comp {
-                        compNonSetupDependencies =
+                        compOrderLibDependencies =
                             (if Map.null insts then [] else [newSimpleUnitId cid]) ++
                             ordNub (map unDefUnitId
                                 (deps ++ concatMap getDep (Map.elems insts)))
@@ -3264,8 +3264,8 @@ packageHashInputs
              [ confInstId dep
              | dep <- CD.select relevantDeps pkgExeDependencies ]
           ElabComponent comp ->
-            Set.fromList (map confInstId (compLibDependencies comp)
-                                       ++ compExeDependencies comp),
+            Set.fromList (map confInstId (compLibDependencies comp
+                                       ++ compExeDependencies comp)),
       pkgHashOtherConfig = packageHashConfigInputs pkgshared elab
     }
   where

--- a/cabal-testsuite/PackageTests/NewBuild/T3978/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/T3978/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
 Error:
-    Dependency on unbuildable libraries: p-1.0
+    Dependency on unbuildable library from p
     In the stanza 'library'
     In the inplace package 'q-1.0'


### PR DESCRIPTION
* toConfiguredComponents and friends are now monadic.  This means
  we can report a user-friendly error when we fail to find a
  dependency in the dependency map.  I had to rejigger a bit
  of the logic in ProjectPlanning since we were knot-tying through
  this function, but it all worked out.  This means
  that unbuildable_external_lib_deps is no more.

* cc_internal_build_tools is no more; instead it's cc_exe_deps,
  which tracks ALL dependencies.  It also comes with a PackageId
  so we can build ConfiguredId cabal-install side.  This change
  propagates all the way to 'ReadyComponent'

* ProjectPlanning: Instead of recomputing dependencies from scratch,
  we instead use the ElaboratedConfiguredPackages we just finished
  making to build the ComponentDeps.

* ProjectPlanning now constructs a skeletal setupComponent.  This
  is used to setup the above with correct setup dependencies.
  In principle this component might also be used for building, but
  lots of functionality isn't written in yet.

* filterExeMapDep is no more; it's all handled by Cabal now.

* The ConfiguredComponentMap now handles both libraries and
  executables in one data structure.  This is nice.

* compSetupDependencies is no more, because elaborated components
  never have custom setup.