### PR TITLE
Change cabal new-build to unconditionally build all packages.

### DIFF
--- a/cabal-install/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/Distribution/Client/TargetSelector.hs
@@ -446,12 +446,8 @@ resolveTargetSelectors :: [PackageInfo]     -- any pkg in the cur dir
 resolveTargetSelectors [] [] [] =
     ([TargetSelectorNoTargetsInProject], [])
 
-resolveTargetSelectors [] _opinfo [] =
-    ([TargetSelectorNoTargetsInCwd], [])
-
-resolveTargetSelectors ppinfo _opinfo [] =
-    ([], [TargetPackage TargetImplicitCwd (head ppinfo) Nothing])
-    --TODO: in future allow multiple packages in the same dir
+resolveTargetSelectors _ppinfo _opinfo [] =
+    ([], [TargetAllPackages Nothing])
 
 resolveTargetSelectors ppinfo opinfo targetStrs =
     partitionEithers

--- a/cabal-install/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/Distribution/Client/TargetSelector.hs
@@ -446,8 +446,12 @@ resolveTargetSelectors :: [PackageInfo]     -- any pkg in the cur dir
 resolveTargetSelectors [] [] [] =
     ([TargetSelectorNoTargetsInProject], [])
 
-resolveTargetSelectors _ppinfo _opinfo [] =
+resolveTargetSelectors [] _opinfo [] =
     ([], [TargetAllPackages Nothing])
+
+resolveTargetSelectors ppinfo _opinfo [] =
+    ([], [TargetPackage TargetImplicitCwd (head ppinfo) Nothing])
+    --TODO: in future allow multiple packages in the same dir
 
 resolveTargetSelectors ppinfo opinfo targetStrs =
     partitionEithers


### PR DESCRIPTION
This changes the behavior to NOT look at the current working
directory to decide what to build.  Instead it always goes
and builds everything, if you don't specify any arguments.

Requested by @cocreature.

Please discuss!

I haven't adjusted the tests in integration-tests2 yet.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>