### PR TITLE
Don't put VQuiet in VFlags; that's reserved for user-toggles.

### DIFF
--- a/Cabal/Distribution/Verbosity.hs
+++ b/Cabal/Distribution/Verbosity.hs
@@ -56,11 +56,12 @@ import qualified Data.Set as Set
 
 data Verbosity = Verbosity {
     vLevel :: VerbosityLevel,
-    vFlags :: Set VerbosityFlag
+    vFlags :: Set VerbosityFlag,
+    vQuiet :: Bool
   } deriving (Generic)
 
 mkVerbosity :: VerbosityLevel -> Verbosity
-mkVerbosity l = Verbosity { vLevel = l, vFlags = Set.empty }
+mkVerbosity l = Verbosity { vLevel = l, vFlags = Set.empty, vQuiet = False }
 
 instance Show Verbosity where
     showsPrec n = showsPrec n . vLevel
@@ -182,7 +183,6 @@ showForCabal v
     showFlag VCallStack  = ["+callstack"]
     showFlag VNoWrap     = ["+nowrap"]
     showFlag VMarkOutput = ["+markoutput"]
-    showFlag VQuiet      = []
 showForGHC   v = maybe (error "unknown verbosity") show $
     elemIndex v [silent,normal,__,verbose,deafening]
         where __ = silent -- this will be always ignored by elemIndex
@@ -192,9 +192,6 @@ data VerbosityFlag
     | VCallSite
     | VNoWrap
     | VMarkOutput
-    -- | 'VQuiet' gets set when 'lessVerbose' is called on
-    -- a 'Verbosity'.  It is not user toggleable.
-    | VQuiet
     deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded)
 
 instance Binary VerbosityFlag
@@ -222,7 +219,7 @@ verboseNoWrap = verboseFlag VNoWrap
 
 -- | Mark the verbosity as quiet
 verboseQuiet :: Verbosity -> Verbosity
-verboseQuiet = verboseFlag VQuiet
+verboseQuiet v = v { vQuiet = True }
 
 -- | Helper function for flag toggling functions
 verboseFlag :: VerbosityFlag -> (Verbosity -> Verbosity)
@@ -252,7 +249,7 @@ isVerboseNoWrap = isVerboseFlag VNoWrap
 
 -- | Test if we had called 'lessVerbose' on the verbosity
 isVerboseQuiet :: Verbosity -> Bool
-isVerboseQuiet = isVerboseFlag VQuiet
+isVerboseQuiet = vQuiet
 
 -- | Helper function for flag testing functions.
 isVerboseFlag :: VerbosityFlag -> Verbosity -> Bool

--- a/cabal-testsuite/PackageTests/CustomPlain/cabal.project
+++ b/cabal-testsuite/PackageTests/CustomPlain/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/CustomPlain/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/CustomPlain/cabal.test.hs
@@ -1,0 +1,9 @@
+import Test.Cabal.Prelude
+main = cabalTest $ do
+    -- Regression test for #4393
+    recordMode DoNotRecord $ do
+        -- TODO: Hack; see also CustomDep/cabal.test.hs
+        withEnvFilter (/= "HOME") $ do
+            -- On -v2, we don't have vQuiet set, which suppressed
+            -- the error
+            cabal "new-build" ["-v1"]


### PR DESCRIPTION
Since VQuiet is set programmatically, it's inappropriate
for it to be propagated to the command line.  But unfortunately,
if it was set, we were accidentally using the fancy flag format.
This patch moves VQuiet to its own field in Verbosity so we
don't get confused.

Fixes #4393.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>