### PR TITLE
WIP: concurrent store updates

### DIFF
--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -220,8 +220,11 @@ buildComponent verbosity numJobs pkg_descr lbi suffixes
                                     (mkAbiHash "inplace") lib' lbi clbi
 
         debug verbosity $ "Registering inplace:\n" ++ (IPI.showInstalledPackageInfo installedPkgInfo)
-        registerPackage verbosity (compiler lbi) (withPrograms lbi) HcPkg.MultiInstance
+        registerPackage verbosity (compiler lbi) (withPrograms lbi)
                         (withPackageDB lbi) installedPkgInfo
+                        HcPkg.defaultRegisterOptions {
+                          HcPkg.registerMultiInstance = True
+                        }
         return (Just installedPkgInfo)
       else return Nothing
 
@@ -279,8 +282,11 @@ buildComponent verbosity numJobs pkg_descr lbi0 suffixes
     -- NB: need to enable multiple instances here, because on 7.10+
     -- the package name is the same as the library, and we still
     -- want the registration to go through.
-    registerPackage verbosity (compiler lbi) (withPrograms lbi) HcPkg.MultiInstance
+    registerPackage verbosity (compiler lbi) (withPrograms lbi)
                     (withPackageDB lbi) ipi
+                    HcPkg.defaultRegisterOptions {
+                      HcPkg.registerMultiInstance = True
+                    }
     let ebi = buildInfo exe
         exe' = exe { buildInfo = addExtraCSources ebi extras }
     buildExe verbosity numJobs pkg_descr lbi exe' exeClbi

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1626,18 +1626,13 @@ hcPkgInfo progdb = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcPkgProg
 registerPackage
   :: Verbosity
   -> ProgramDb
-  -> HcPkg.MultiInstance
   -> PackageDBStack
   -> InstalledPackageInfo
+  -> HcPkg.RegisterOptions
   -> IO ()
-registerPackage verbosity progdb multiInstance packageDbs installedPkgInfo
-  | HcPkg.MultiInstance <- multiInstance
-  = HcPkg.registerMultiInstance (hcPkgInfo progdb) verbosity
-      packageDbs installedPkgInfo
-
-  | otherwise
-  = HcPkg.reregister (hcPkgInfo progdb) verbosity
-      packageDbs (Right installedPkgInfo)
+registerPackage verbosity progdb packageDbs installedPkgInfo registerOptions =
+    HcPkg.register (hcPkgInfo progdb) verbosity packageDbs
+                   installedPkgInfo registerOptions
 
 pkgRoot :: Verbosity -> LocalBuildInfo -> PackageDB -> IO FilePath
 pkgRoot verbosity lbi = pkgRoot'

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1617,6 +1617,7 @@ hcPkgInfo progdb = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcPkgProg
                                    , HcPkg.requiresDirDbs  = v >= [7,10]
                                    , HcPkg.nativeMultiInstance  = v >= [7,10]
                                    , HcPkg.recacheMultiInstance = v >= [6,12]
+                                   , HcPkg.suppressFilesCheck   = v >= [6,6]
                                    }
   where
     v               = versionNumbers ver

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -859,6 +859,7 @@ hcPkgInfo progdb = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcjsPkgProg
                                    , HcPkg.requiresDirDbs  = ver >= v7_10
                                    , HcPkg.nativeMultiInstance  = ver >= v7_10
                                    , HcPkg.recacheMultiInstance = True
+                                   , HcPkg.suppressFilesCheck   = True
                                    }
   where
     v7_10 = mkVersion [7,10]

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -806,18 +806,13 @@ adjustExts hiSuf objSuf opts =
 
 registerPackage :: Verbosity
                 -> ProgramDb
-                -> HcPkg.MultiInstance
                 -> PackageDBStack
                 -> InstalledPackageInfo
+                -> HcPkg.RegisterOptions
                 -> IO ()
-registerPackage verbosity progdb multiInstance packageDbs installedPkgInfo
-  | HcPkg.MultiInstance <- multiInstance
-  = HcPkg.registerMultiInstance (hcPkgInfo progdb) verbosity
-      packageDbs installedPkgInfo
-
-  | otherwise
-  = HcPkg.reregister (hcPkgInfo progdb) verbosity
-      packageDbs (Right installedPkgInfo)
+registerPackage verbosity progdb packageDbs installedPkgInfo registerOptions =
+    HcPkg.register (hcPkgInfo progdb) verbosity packageDbs
+                   installedPkgInfo registerOptions
 
 componentGhcOptions :: Verbosity -> LocalBuildInfo
                     -> BuildInfo -> ComponentLocalBuildInfo -> FilePath

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -758,10 +758,11 @@ registerPackage
   -> ProgramDb
   -> PackageDBStack
   -> InstalledPackageInfo
+  -> HcPkg.RegisterOptions
   -> IO ()
-registerPackage verbosity progdb packageDbs installedPkgInfo =
-  HcPkg.reregister (hcPkgInfo progdb) verbosity packageDbs
-    (Right installedPkgInfo)
+registerPackage verbosity progdb packageDbs installedPkgInfo registerOptions =
+    HcPkg.register (hcPkgInfo progdb) verbosity packageDbs
+                   installedPkgInfo registerOptions
 
 hcPkgInfo :: ProgramDb -> HcPkg.HcPkgInfo
 hcPkgInfo progdb = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = lhcPkgProg

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -773,6 +773,7 @@ hcPkgInfo progdb = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = lhcPkgProg
                                    , HcPkg.requiresDirDbs  = True
                                    , HcPkg.nativeMultiInstance  = False -- ?
                                    , HcPkg.recacheMultiInstance = False -- ?
+                                   , HcPkg.suppressFilesCheck   = True
                                    }
   where
     Just lhcPkgProg = lookupProgram lhcPkgProgram progdb

--- a/Cabal/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/Distribution/Simple/Program/HcPkg.hs
@@ -13,14 +13,15 @@
 -- Currently only GHC, GHCJS and LHC have hc-pkg programs.
 
 module Distribution.Simple.Program.HcPkg (
+    -- * Types
     HcPkgInfo(..),
-    MultiInstance(..),
+    RegisterOptions(..),
+    defaultRegisterOptions,
 
+    -- * Actions
     init,
     invoke,
     register,
-    reregister,
-    registerMultiInstance,
     unregister,
     recache,
     expose,
@@ -32,8 +33,6 @@ module Distribution.Simple.Program.HcPkg (
     -- * Program invocations
     initInvocation,
     registerInvocation,
-    reregisterInvocation,
-    registerMultiInstanceInvocation,
     unregisterInvocation,
     recacheInvocation,
     exposeInvocation,
@@ -80,9 +79,6 @@ data HcPkgInfo = HcPkgInfo
   , recacheMultiInstance :: Bool -- ^ supports multi-instance via recache
   }
 
--- | Whether or not use multi-instance functionality.
-data MultiInstance = MultiInstance | NoMultiInstance
-  deriving (Show, Read, Eq, Ord)
 
 -- | Call @hc-pkg@ to initialise a package database at the location {path}.
 --
@@ -106,39 +102,38 @@ invoke hpi verbosity dbStack extraArgs =
     args       = packageDbStackOpts hpi dbStack ++ extraArgs
     invocation = programInvocation (hcPkgProgram hpi) args
 
+-- | Additional variations in the behaviour for 'register'.
+data RegisterOptions = RegisterOptions {
+       -- | Allows re-registering \/ overwriting an existing package
+       registerAllowOverwrite     :: Bool,
+
+       -- | Insist on the ability to register multiple instances of a
+       -- single version of a single package. This will fail if the @hc-pkg@
+       -- does not support it, see 'nativeMultiInstance' and
+       -- 'recacheMultiInstance'.
+       registerMultiInstance      :: Bool
+     }
+
+-- | Defaults are @True@, @False@ and @False@
+defaultRegisterOptions :: RegisterOptions
+defaultRegisterOptions = RegisterOptions {
+    registerAllowOverwrite     = True,
+    registerMultiInstance      = False
+  }
+
 -- | Call @hc-pkg@ to register a package.
 --
 -- > hc-pkg register {filename | -} [--user | --global | --package-db]
 --
 register :: HcPkgInfo -> Verbosity -> PackageDBStack
-         -> Either FilePath
-                   InstalledPackageInfo
+         -> InstalledPackageInfo
+         -> RegisterOptions
          -> IO ()
-register hpi verbosity packagedb pkgFile =
-  runProgramInvocation verbosity
-    (registerInvocation hpi verbosity packagedb pkgFile)
-
-
--- | Call @hc-pkg@ to re-register a package.
---
--- > hc-pkg register {filename | -} [--user | --global | --package-db]
---
-reregister :: HcPkgInfo -> Verbosity -> PackageDBStack
-           -> Either FilePath
-                     InstalledPackageInfo
-           -> IO ()
-reregister hpi verbosity packagedb pkgFile =
-  runProgramInvocation verbosity
-    (reregisterInvocation hpi verbosity packagedb pkgFile)
-
-registerMultiInstance :: HcPkgInfo -> Verbosity
-                      -> PackageDBStack
-                      -> InstalledPackageInfo
-                      -> IO ()
-registerMultiInstance hpi verbosity packagedbs pkgInfo
-  | nativeMultiInstance hpi
-  = runProgramInvocation verbosity
-      (registerMultiInstanceInvocation hpi verbosity packagedbs (Right pkgInfo))
+register hpi verbosity packagedbs pkgInfo registerOptions
+  | registerMultiInstance registerOptions
+  , not (nativeMultiInstance hpi || recacheMultiInstance hpi)
+  = die' verbosity $ "HcPkg.register: the compiler does not support "
+       ++ "registering multiple instances of packages."
 
     -- This is a trick. Older versions of GHC do not support the
     -- --enable-multi-instance flag for ghc-pkg register but it turns out that
@@ -149,14 +144,15 @@ registerMultiInstance hpi verbosity packagedbs pkgInfo
     -- to write the package registration file directly into the package db and
     -- then call hc-pkg recache.
     --
-  | recacheMultiInstance hpi
+  | registerMultiInstance registerOptions
+  , recacheMultiInstance hpi
   = do let pkgdb = last packagedbs
        writeRegistrationFileDirectly verbosity hpi pkgdb pkgInfo
        recache hpi verbosity pkgdb
 
   | otherwise
-  = die' verbosity $ "HcPkg.registerMultiInstance: the compiler does not support "
-       ++ "registering multiple instances of packages."
+  = runProgramInvocation verbosity
+      (registerInvocation hpi verbosity packagedbs pkgInfo registerOptions)
 
 writeRegistrationFileDirectly :: Verbosity
                               -> HcPkgInfo
@@ -363,35 +359,28 @@ initInvocation hpi verbosity path =
     args = ["init", path]
         ++ verbosityOpts hpi verbosity
 
-registerInvocation, reregisterInvocation, registerMultiInstanceInvocation
+registerInvocation
   :: HcPkgInfo -> Verbosity -> PackageDBStack
-  -> Either FilePath InstalledPackageInfo
+  -> InstalledPackageInfo
+  -> RegisterOptions
   -> ProgramInvocation
-registerInvocation   = registerInvocation' "register" NoMultiInstance
-reregisterInvocation = registerInvocation' "update"   NoMultiInstance
-registerMultiInstanceInvocation = registerInvocation' "update" MultiInstance
-
-registerInvocation' :: String -> MultiInstance
-                    -> HcPkgInfo -> Verbosity -> PackageDBStack
-                    -> Either FilePath InstalledPackageInfo
-                    -> ProgramInvocation
-registerInvocation' cmdname multiInstance hpi
-                    verbosity packagedbs pkgFileOrInfo =
-    case pkgFileOrInfo of
-      Left pkgFile ->
-        programInvocation (hcPkgProgram hpi) (args pkgFile)
-
-      Right pkgInfo ->
-        (programInvocation (hcPkgProgram hpi) (args "-")) {
-          progInvokeInput         = Just (showInstalledPackageInfo pkgInfo),
-          progInvokeInputEncoding = IOEncodingUTF8
-        }
+registerInvocation hpi verbosity packagedbs pkgInfo registerOptions =
+    (programInvocation (hcPkgProgram hpi) (args "-")) {
+      progInvokeInput         = Just (showInstalledPackageInfo pkgInfo),
+      progInvokeInputEncoding = IOEncodingUTF8
+    }
   where
+    cmdname
+      | registerAllowOverwrite registerOptions = "update"
+      | registerMultiInstance  registerOptions = "update"
+      | otherwise                              = "register"
+
     args file = [cmdname, file]
              ++ (if noPkgDbStack hpi
                    then [packageDbOpts hpi (last packagedbs)]
                    else packageDbStackOpts hpi packagedbs)
-             ++ [ "--enable-multi-instance" | multiInstance == MultiInstance ]
+             ++ [ "--enable-multi-instance"
+                | registerMultiInstance registerOptions ]
              ++ verbosityOpts hpi verbosity
 
 unregisterInvocation :: HcPkgInfo -> Verbosity -> PackageDB -> PackageId

--- a/cabal-install/Distribution/Client/Compat/FileLock.hsc
+++ b/cabal-install/Distribution/Client/Compat/FileLock.hsc
@@ -1,0 +1,204 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE InterruptibleFFI #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+
+-- | This compat module can be removed once base-4.10 (ghc-8.2) is the minimum
+-- required version. Though note that the locking functionality is not in
+-- public modules in base-4.10, just in the "GHC.IO.Handle.Lock" module.
+module Distribution.Client.Compat.FileLock (
+    FileLockingNotSupported(..)
+  , LockMode(..)
+  , hLock
+  , hTryLock
+  ) where
+
+#if MIN_VERSION_base(4,10,0)
+
+import GHC.IO.Handle.Lock
+
+#else
+
+-- The remainder of this file is a modified copy
+-- of GHC.IO.Handle.Lock from ghc-8.2.x
+--
+-- The modifications were just to the imports and the CPP, since we do not have
+-- access to the HAVE_FLOCK from the ./configure script. We approximate the
+-- lack of HAVE_FLOCK with defined(solaris2_HOST_OS) instead since that is the
+-- only known major Unix platform lacking flock().
+
+import Control.Exception (Exception)
+import Data.Typeable
+
+#if defined(solaris2_HOST_OS)
+
+import Control.Exception (throwIO)
+import System.IO (Handle)
+
+#else
+
+import Data.Bits
+import Data.Function
+import Control.Concurrent.MVar
+
+import Foreign.C.Error
+import Foreign.C.Types
+
+import GHC.IO.Handle.Types
+import GHC.IO.FD
+import GHC.IO.Exception
+
+#if defined(mingw32_HOST_OS)
+
+#if defined(i386_HOST_ARCH)
+## define WINDOWS_CCONV stdcall
+#elif defined(x86_64_HOST_ARCH)
+## define WINDOWS_CCONV ccall
+#else
+# error Unknown mingw32 arch
+#endif
+
+#include <windows.h>
+
+import Foreign.Marshal.Alloc
+import Foreign.Marshal.Utils
+import Foreign.Ptr
+import GHC.Windows
+
+#else /* !defined(mingw32_HOST_OS), so assume unix with flock() */
+
+#include <sys/file.h>
+
+#endif /* !defined(mingw32_HOST_OS) */
+
+#endif /* !defined(solaris2_HOST_OS) */
+
+#endif /* MIN_VERSION_base */
+
+
+-- | Exception thrown by 'hLock' on non-Windows platforms that don't support
+-- 'flock'.
+data FileLockingNotSupported = FileLockingNotSupported
+  deriving (Typeable, Show)
+
+instance Exception FileLockingNotSupported
+
+#if !(MIN_VERSION_base(4,10,0))
+
+-- | Indicates a mode in which a file should be locked.
+data LockMode = SharedLock | ExclusiveLock
+
+-- | If a 'Handle' references a file descriptor, attempt to lock contents of the
+-- underlying file in appropriate mode. If the file is already locked in
+-- incompatible mode, this function blocks until the lock is established. The
+-- lock is automatically released upon closing a 'Handle'.
+--
+-- Things to be aware of:
+--
+-- 1) This function may block inside a C call. If it does, in order to be able
+-- to interrupt it with asynchronous exceptions and/or for other threads to
+-- continue working, you MUST use threaded version of the runtime system.
+--
+-- 2) The implementation uses 'LockFileEx' on Windows and 'flock' otherwise,
+-- hence all of their caveats also apply here.
+--
+-- 3) On non-Windows plaftorms that don't support 'flock' (e.g. Solaris) this
+-- function throws 'FileLockingNotImplemented'. We deliberately choose to not
+-- provide fcntl based locking instead because of its broken semantics.
+--
+-- @since 4.10.0.0
+hLock :: Handle -> LockMode -> IO ()
+hLock h mode = lockImpl h "hLock" mode True >> return ()
+
+-- | Non-blocking version of 'hLock'.
+--
+-- @since 4.10.0.0
+hTryLock :: Handle -> LockMode -> IO Bool
+hTryLock h mode = lockImpl h "hTryLock" mode False
+
+----------------------------------------
+
+#if defined(solaris2_HOST_OS)
+
+-- | No-op implementation.
+lockImpl :: Handle -> String -> LockMode -> Bool -> IO Bool
+lockImpl _ _ _ _ = throwIO FileLockingNotSupported
+
+#else /* !defined(solaris2_HOST_OS) */
+
+#if defined(mingw32_HOST_OS)
+
+lockImpl :: Handle -> String -> LockMode -> Bool -> IO Bool
+lockImpl h ctx mode block = do
+  FD{fdFD = fd} <- handleToFd h
+  wh <- throwErrnoIf (== iNVALID_HANDLE_VALUE) ctx $ c_get_osfhandle fd
+  allocaBytes sizeof_OVERLAPPED $ \ovrlpd -> do
+    fillBytes ovrlpd (fromIntegral sizeof_OVERLAPPED) 0
+    let flags = cmode .|. (if block then 0 else #{const LOCKFILE_FAIL_IMMEDIATELY})
+    -- We want to lock the whole file without looking up its size to be
+    -- consistent with what flock does. According to documentation of LockFileEx
+    -- "locking a region that goes beyond the current end-of-file position is
+    -- not an error", however e.g. Windows 10 doesn't accept maximum possible
+    -- value (a pair of MAXDWORDs) for mysterious reasons. Work around that by
+    -- trying 2^32-1.
+    fix $ \retry -> c_LockFileEx wh flags 0 0xffffffff 0x0 ovrlpd >>= \case
+      True  -> return True
+      False -> getLastError >>= \err -> if
+        | not block && err == #{const ERROR_LOCK_VIOLATION} -> return False
+        | err == #{const ERROR_OPERATION_ABORTED} -> retry
+        | otherwise -> failWith ctx err
+  where
+    sizeof_OVERLAPPED = #{size OVERLAPPED}
+
+    cmode = case mode of
+      SharedLock    -> 0
+      ExclusiveLock -> #{const LOCKFILE_EXCLUSIVE_LOCK}
+
+-- https://msdn.microsoft.com/en-us/library/aa297958.aspx
+foreign import ccall unsafe "_get_osfhandle"
+  c_get_osfhandle :: CInt -> IO HANDLE
+
+-- https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203.aspx
+foreign import WINDOWS_CCONV interruptible "LockFileEx"
+  c_LockFileEx :: HANDLE -> DWORD -> DWORD -> DWORD -> DWORD -> Ptr () -> IO BOOL
+
+#else /* !defined(mingw32_HOST_OS), so assume unix with flock() */
+
+lockImpl :: Handle -> String -> LockMode -> Bool -> IO Bool
+lockImpl h ctx mode block = do
+  FD{fdFD = fd} <- handleToFd h
+  let flags = cmode .|. (if block then 0 else #{const LOCK_NB})
+  fix $ \retry -> c_flock fd flags >>= \case
+    0 -> return True
+    _ -> getErrno >>= \errno -> if
+      | not block && errno == eWOULDBLOCK -> return False
+      | errno == eINTR -> retry
+      | otherwise -> ioException $ errnoToIOError ctx errno (Just h) Nothing
+  where
+    cmode = case mode of
+      SharedLock    -> #{const LOCK_SH}
+      ExclusiveLock -> #{const LOCK_EX}
+
+foreign import ccall interruptible "flock"
+  c_flock :: CInt -> CInt -> IO CInt
+
+#endif /* !defined(mingw32_HOST_OS) */
+
+-- | Turn an existing Handle into a file descriptor. This function throws an
+-- IOError if the Handle does not reference a file descriptor.
+handleToFd :: Handle -> IO FD
+handleToFd h = case h of
+  FileHandle _ mv -> do
+    Handle__{haDevice = dev} <- readMVar mv
+    case cast dev of
+      Just fd -> return fd
+      Nothing -> throwErr "not a file descriptor"
+  DuplexHandle{} -> throwErr "not a file handle"
+  where
+    throwErr msg = ioException $ IOError (Just h)
+      InappropriateType "handleToFd" msg Nothing Nothing
+
+#endif /* defined(solaris2_HOST_OS) */
+
+#endif /* MIN_VERSION_base */

--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -6,11 +6,15 @@
 -- and build artifacts.
 --
 module Distribution.Client.DistDirLayout (
-    -- 'DistDirLayout'
+    -- * 'DistDirLayout'
     DistDirLayout(..),
     DistDirParams(..),
     defaultDistDirLayout,
     ProjectRoot(..),
+
+    -- * 'StoreDirLayout'
+    StoreDirLayout(..),
+    defaultStoreDirLayout,
 
     -- * 'CabalDirLayout'
     CabalDirLayout(..),
@@ -23,12 +27,12 @@ import System.FilePath
 import Distribution.Package
          ( PackageId, ComponentId, UnitId )
 import Distribution.Compiler
-import Distribution.Simple.Compiler (PackageDB(..), OptimisationLevel(..))
+import Distribution.Simple.Compiler
+         ( PackageDB(..), PackageDBStack, OptimisationLevel(..) )
 import Distribution.Text
 import Distribution.Types.ComponentName
 import Distribution.System
-import Distribution.Client.Types
-         ( InstalledPackageId )
+
 
 -- | Information which can be used to construct the path to
 -- the build directory of a build.  This is LESS fine-grained
@@ -107,14 +111,28 @@ data DistDirLayout = DistDirLayout {
      }
 
 
+-- | The layout of a cabal nix-style store.
+--
+data StoreDirLayout = StoreDirLayout {
+       storeDirectory         :: CompilerId -> FilePath,
+       storePackageDirectory  :: CompilerId -> UnitId -> FilePath,
+       storePackageDBPath     :: CompilerId -> FilePath,
+       storePackageDB         :: CompilerId -> PackageDB,
+       storePackageDBStack    :: CompilerId -> PackageDBStack
+     }
+
 
 --TODO: move to another module, e.g. CabalDirLayout?
+-- or perhaps rename this module to DirLayouts.
+
+-- | The layout of the user-wide cabal directory, that is the @~/.cabal@ dir
+-- on unix, and equivalents on other systems.
+--
+-- At the moment this is just a partial specification, but the idea is
+-- eventually to cover it all.
+--
 data CabalDirLayout = CabalDirLayout {
-       cabalStoreDirectory        :: CompilerId -> FilePath,
-       cabalStorePackageDirectory :: CompilerId -> InstalledPackageId
-                                                -> FilePath,
-       cabalStorePackageDBPath    :: CompilerId -> FilePath,
-       cabalStorePackageDB        :: CompilerId -> PackageDB,
+       cabalStoreDirLayout        :: StoreDirLayout,
 
        cabalLogsDirectory         :: FilePath,
        cabalWorldFile             :: FilePath
@@ -195,23 +213,32 @@ defaultDistDirLayout projectRoot mdistDirectory =
     distPackageDB = SpecificPackageDB . distPackageDBPath
 
 
+defaultStoreDirLayout :: FilePath -> StoreDirLayout
+defaultStoreDirLayout storeRoot =
+    StoreDirLayout {..}
+  where
+    storeDirectory compid =
+      storeRoot </> display compid
+
+    storePackageDirectory compid ipkgid =
+      storeDirectory compid </> display ipkgid
+
+    storePackageDBPath compid =
+      storeDirectory compid </> "package.db"
+
+    storePackageDB compid =
+      SpecificPackageDB (storePackageDBPath compid)
+
+    storePackageDBStack compid =
+      [GlobalPackageDB, storePackageDB compid]
+
 
 defaultCabalDirLayout :: FilePath -> CabalDirLayout
 defaultCabalDirLayout cabalDir =
     CabalDirLayout {..}
   where
 
-    cabalStoreDirectory compid =
-      cabalDir </> "store" </> display compid
-
-    cabalStorePackageDirectory compid ipkgid = 
-      cabalStoreDirectory compid </> display ipkgid
-
-    cabalStorePackageDBPath compid =
-      cabalStoreDirectory compid </> "package.db"
-
-    cabalStorePackageDB =
-      SpecificPackageDB . cabalStorePackageDBPath
+    cabalStoreDirLayout = defaultStoreDirLayout (cabalDir </> "store")
 
     cabalLogsDirectory = cabalDir </> "logs"
 

--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -118,7 +118,9 @@ data StoreDirLayout = StoreDirLayout {
        storePackageDirectory  :: CompilerId -> UnitId -> FilePath,
        storePackageDBPath     :: CompilerId -> FilePath,
        storePackageDB         :: CompilerId -> PackageDB,
-       storePackageDBStack    :: CompilerId -> PackageDBStack
+       storePackageDBStack    :: CompilerId -> PackageDBStack,
+       storeIncomingDirectory :: CompilerId -> FilePath,
+       storeIncomingLock      :: CompilerId -> UnitId -> FilePath
      }
 
 
@@ -231,6 +233,12 @@ defaultStoreDirLayout storeRoot =
 
     storePackageDBStack compid =
       [GlobalPackageDB, storePackageDB compid]
+
+    storeIncomingDirectory compid =
+      storeDirectory compid </> "incoming"
+
+    storeIncomingLock compid unitid =
+      storeIncomingDirectory compid </> display unitid <.> "lock"
 
 
 defaultCabalDirLayout :: FilePath -> CabalDirLayout

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -139,8 +139,7 @@ import Distribution.Simple.InstallDirs as InstallDirs
          ( PathTemplate, fromPathTemplate, toPathTemplate, substPathTemplate
          , initialPathTemplateEnv, installDirsTemplateEnv )
 import Distribution.Simple.Configure (interpretPackageDbFlags)
-import Distribution.Simple.Register (registerPackage)
-import Distribution.Simple.Program.HcPkg (MultiInstance(..))
+import Distribution.Simple.Register (registerPackage, defaultRegisterOptions)
 import Distribution.Package
          ( PackageIdentifier(..), PackageId, packageName, packageVersion
          , Package(..), HasMungedPackageId(..), HasUnitId(..)
@@ -1442,8 +1441,8 @@ installUnpackedPackage verbosity installLock numJobs
                                 (configPackageDBs configFlags)
             forM_ ipkgs' $ \ipkg' ->
                 registerPackage verbosity comp progdb
-                                      NoMultiInstance
-                                      packageDBs ipkg'
+                                packageDBs ipkg'
+                                defaultRegisterOptions
 
             return (Right (BuildResult docsResult testsResult (find ((==uid).installedUnitId) ipkgs')))
 

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -41,6 +41,7 @@ import           Distribution.Client.ProjectConfig
 import           Distribution.Client.ProjectPlanning
 import           Distribution.Client.ProjectPlanning.Types
 import           Distribution.Client.ProjectBuilding.Types
+import           Distribution.Client.Store
 
 import           Distribution.Client.Types
                    hiding (BuildOutcomes, BuildOutcome,
@@ -64,15 +65,15 @@ import           Distribution.Package hiding (InstalledPackageId, installedPacka
 import qualified Distribution.PackageDescription as PD
 import           Distribution.InstalledPackageInfo (InstalledPackageInfo)
 import qualified Distribution.InstalledPackageInfo as Installed
+import qualified Distribution.Simple.InstallDirs as InstallDirs
 import           Distribution.Types.BuildType
 import           Distribution.Simple.Program
 import qualified Distribution.Simple.Setup as Cabal
 import           Distribution.Simple.Command (CommandUI)
 import qualified Distribution.Simple.Register as Cabal
-import qualified Distribution.Simple.InstallDirs as InstallDirs
 import           Distribution.Simple.LocalBuildInfo (ComponentName)
 import           Distribution.Simple.Compiler
-                   ( Compiler, PackageDB(..) )
+                   ( Compiler, compilerId, PackageDB(..) )
 
 import           Distribution.Simple.Utils hiding (matchFileGlob)
 import           Distribution.Version
@@ -512,6 +513,7 @@ invalidatePackageRegFileMonitor PackageFileMonitor{pkgFileMonitorReg} =
 --
 rebuildTargets :: Verbosity
                -> DistDirLayout
+               -> StoreDirLayout
                -> ElaboratedInstallPlan
                -> ElaboratedSharedConfig
                -> BuildStatusMap
@@ -519,6 +521,7 @@ rebuildTargets :: Verbosity
                -> IO BuildOutcomes
 rebuildTargets verbosity
                distDirLayout@DistDirLayout{..}
+               storeDirLayout
                installPlan
                sharedPackageConfig@ElaboratedSharedConfig {
                  pkgConfigCompiler      = compiler,
@@ -567,6 +570,7 @@ rebuildTargets verbosity
         rebuildTarget
           verbosity
           distDirLayout
+          storeDirLayout
           buildSettings downloadMap
           registerLock cacheLock
           sharedPackageConfig
@@ -605,6 +609,7 @@ createPackageDBIfMissing _ _ _ _ = return ()
 --
 rebuildTarget :: Verbosity
               -> DistDirLayout
+              -> StoreDirLayout
               -> BuildTimeSettings
               -> AsyncFetchMap
               -> Lock -> Lock
@@ -615,6 +620,7 @@ rebuildTarget :: Verbosity
               -> IO BuildResult
 rebuildTarget verbosity
               distDirLayout@DistDirLayout{distBuildDirectory}
+              storeDirLayout
               buildSettings downloadMap
               registerLock cacheLock
               sharedPackageConfig
@@ -667,7 +673,7 @@ rebuildTarget verbosity
 
     buildAndInstall srcdir builddir =
         buildAndInstallUnpackedPackage
-          verbosity distDirLayout
+          verbosity distDirLayout storeDirLayout
           buildSettings registerLock cacheLock
           sharedPackageConfig
           rpkg
@@ -861,6 +867,7 @@ moveTarballShippedDistDirectory verbosity DistDirLayout{distBuildDirectory}
 
 buildAndInstallUnpackedPackage :: Verbosity
                                -> DistDirLayout
+                               -> StoreDirLayout
                                -> BuildTimeSettings -> Lock -> Lock
                                -> ElaboratedSharedConfig
                                -> ElaboratedReadyPackage
@@ -868,6 +875,9 @@ buildAndInstallUnpackedPackage :: Verbosity
                                -> IO BuildResult
 buildAndInstallUnpackedPackage verbosity
                                DistDirLayout{distTempDirectory}
+                               storeDirLayout@StoreDirLayout {
+                                 storePackageDBStack
+                               }
                                BuildTimeSettings {
                                  buildSettingNumJobs,
                                  buildSettingLogFile
@@ -914,43 +924,54 @@ buildAndInstallUnpackedPackage verbosity
 
     -- Install phase
     annotateFailure mlogFile InstallFailed $ do
-      --TODO: [required eventually] need to lock installing this ipkig so other processes don't
-      -- stomp on our files, since we don't have ABI compat, not safe to replace
 
-      -- TODO: [required eventually] note that for nix-style installations it is not necessary to do
-      -- the 'withWin32SelfUpgrade' dance, but it would be necessary for a
-      -- shared bin dir.
+      let copyPkgFiles tmpDir = do
+            setup Cabal.copyCommand (copyFlags tmpDir)
+            -- Note that the copy command has put the files into
+            -- @$tmpDir/$prefix@ so we need to return this dir so
+            -- the store knows which dir will be the final store entry.
+            let prefix   = dropDrive (InstallDirs.prefix (elabInstallDirs pkg))
+                entryDir = tmpDir </> prefix
+            LBS.writeFile
+              (entryDir </> "cabal-hash.txt")
+              (renderPackageHashInputs (packageHashInputs pkgshared pkg))
+            -- here's where we could keep track of the installed files ourselves
+            -- if we wanted to by making a manifest of the files in the tmp dir
+            return entryDir
+
+          registerPkg
+            | not (elabRequiresRegistration pkg) = return ()
+            | otherwise = do
+            -- We register ourselves rather than via Setup.hs. We need to
+            -- grab and modify the InstalledPackageInfo. We decide what
+            -- the installed package id is, not the build system.
+            ipkg0 <- generateInstalledPackageInfo
+            let ipkg = ipkg0 { Installed.installedUnitId = uid }
+            assert (   elabRegisterPackageDBStack pkg
+                    == storePackageDBStack compid) (return ())
+            criticalSection registerLock $
+              Cabal.registerPackage
+                verbosity compiler progdb
+                (storePackageDBStack compid) ipkg
+                Cabal.defaultRegisterOptions {
+                  Cabal.registerMultiInstance      = True,
+                  Cabal.registerSuppressFilesCheck = True
+                }
+
 
       -- Actual installation
-      setup Cabal.copyCommand copyFlags
+      void $ newStoreEntry verbosity storeDirLayout
+                           compid uid
+                           copyPkgFiles registerPkg
 
-      LBS.writeFile
-        (InstallDirs.prefix (elabInstallDirs pkg) </> "cabal-hash.txt") $
-        (renderPackageHashInputs (packageHashInputs pkgshared pkg))
+    --TODO: [nice to have] we currently rely on Setup.hs copy to do the right
+    -- thing. Although we do copy into an image dir and do the move into the
+    -- final location ourselves, perhaps we ought to do some sanity checks on
+    -- the image dir first.
 
-      -- here's where we could keep track of the installed files ourselves if
-      -- we wanted by calling copy to an image dir and then we would make a
-      -- manifest and move it to its final location
-
-      --TODO: [nice to have] we should actually have it make an image in store/incomming and
-      -- then when it's done, move it to its final location, to reduce problems
-      -- with installs failing half-way. Could also register and then move.
-
-      if elabRequiresRegistration pkg
-        then do
-          -- We register ourselves rather than via Setup.hs. We need to
-          -- grab and modify the InstalledPackageInfo. We decide what
-          -- the installed package id is, not the build system.
-          ipkg0 <- generateInstalledPackageInfo
-          let ipkg = ipkg0 { Installed.installedUnitId = uid }
-
-          criticalSection registerLock $
-              Cabal.registerPackage verbosity compiler progdb
-                                    (elabRegisterPackageDBStack pkg) ipkg
-                                    Cabal.defaultRegisterOptions {
-                                      Cabal.registerMultiInstance = True
-                                    }
-        else return ()
+    -- TODO: [required eventually] note that for nix-style installations it is not necessary to do
+    -- the 'withWin32SelfUpgrade' dance, but it would be necessary for a
+    -- shared bin dir.
 
     --TODO: [required feature] docs and test phases
     let docsResult  = DocsNotTried
@@ -964,7 +985,8 @@ buildAndInstallUnpackedPackage verbosity
 
   where
     pkgid  = packageId rpkg
-    uid = installedUnitId rpkg
+    uid    = installedUnitId rpkg
+    compid = compilerId compiler
 
     isParallelBuild = buildSettingNumJobs >= 2
 
@@ -987,7 +1009,8 @@ buildAndInstallUnpackedPackage verbosity
                                 pkgConfDest
         setup Cabal.registerCommand registerFlags
 
-    copyFlags _ = setupHsCopyFlags pkg pkgshared verbosity builddir
+    copyFlags destdir _ = setupHsCopyFlags pkg pkgshared verbosity
+                                           builddir destdir
 
     scriptOptions = setupHsScriptOptions rpkg pkgshared srcdir builddir
                                          isParallelBuild cacheLock

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -71,7 +71,6 @@ import           Distribution.Simple.Command (CommandUI)
 import qualified Distribution.Simple.Register as Cabal
 import qualified Distribution.Simple.InstallDirs as InstallDirs
 import           Distribution.Simple.LocalBuildInfo (ComponentName)
-import qualified Distribution.Simple.Program.HcPkg as HcPkg
 
 import           Distribution.Simple.Utils hiding (matchFileGlob)
 import           Distribution.Version
@@ -930,8 +929,10 @@ buildAndInstallUnpackedPackage verbosity
 
           criticalSection registerLock $
               Cabal.registerPackage verbosity compiler progdb
-                                    HcPkg.MultiInstance
                                     (elabRegisterPackageDBStack pkg) ipkg
+                                    Cabal.defaultRegisterOptions {
+                                      Cabal.registerMultiInstance = True
+                                    }
         else return ()
 
     --TODO: [required feature] docs and test phases
@@ -1102,9 +1103,9 @@ buildInplaceUnpackedPackage verbosity
                 -- the installed package id is, not the build system.
                 let ipkg = ipkg0 { Installed.installedUnitId = ipkgid }
                 criticalSection registerLock $
-                    Cabal.registerPackage verbosity compiler progdb HcPkg.NoMultiInstance
+                    Cabal.registerPackage verbosity compiler progdb
                                           (elabRegisterPackageDBStack pkg)
-                                          ipkg
+                                          ipkg Cabal.defaultRegisterOptions
                 return (Just ipkg)
 
            else return Nothing

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -290,6 +290,7 @@ runProjectBuildPhase verbosity
     fmap (Map.union (previousBuildOutcomes pkgsBuildStatus)) $
     rebuildTargets verbosity
                    distDirLayout
+                   (cabalStoreDirLayout cabalDirLayout)
                    elaboratedPlanToExecute
                    elaboratedShared
                    pkgsBuildStatus

--- a/cabal-install/Distribution/Client/RebuildMonad.hs
+++ b/cabal-install/Distribution/Client/RebuildMonad.hs
@@ -160,8 +160,10 @@ matchFileGlob glob = do
 
 getDirectoryContentsMonitored :: FilePath -> Rebuild [FilePath]
 getDirectoryContentsMonitored dir = do
-    monitorFiles [monitorDirectory dir]
-    liftIO $ getDirectoryContents dir
+    exists <- monitorDirectoryStatus dir
+    if exists
+      then liftIO $ getDirectoryContents dir
+      else return []
 
 createDirectoryMonitored :: Bool -> FilePath -> Rebuild ()
 createDirectoryMonitored createParents dir = do
@@ -170,12 +172,13 @@ createDirectoryMonitored createParents dir = do
 
 -- | Monitor a directory as in 'monitorDirectory' if it currently exists or
 -- as 'monitorNonExistentDirectory' if it does not.
-monitorDirectoryStatus :: FilePath -> Rebuild ()
+monitorDirectoryStatus :: FilePath -> Rebuild Bool
 monitorDirectoryStatus dir = do
     exists <- liftIO $ doesDirectoryExist dir
     monitorFiles [if exists
                     then monitorDirectory dir
                     else monitorNonExistentDirectory dir]
+    return exists
 
 -- | Like 'doesFileExist', but in the 'Rebuild' monad.  This does
 -- NOT track the contents of 'FilePath'; use 'need' in that case.

--- a/cabal-install/Distribution/Client/Store.hs
+++ b/cabal-install/Distribution/Client/Store.hs
@@ -1,0 +1,246 @@
+{-# LANGUAGE RecordWildCards, NamedFieldPuns #-}
+
+
+-- | Management for the installed package store.
+--
+module Distribution.Client.Store (
+
+    -- * The store layout
+    StoreDirLayout(..),
+    defaultStoreDirLayout,
+
+    -- * Reading store entries
+    getStoreEntries,
+    doesStoreEntryExist,
+
+    -- * Creating store entries
+    newStoreEntry,
+    NewStoreEntryOutcome(..),
+
+    -- * Concurrency strategy
+    -- $concurrency
+  ) where
+
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+import Distribution.Client.Compat.FileLock
+
+import           Distribution.Client.DistDirLayout
+import           Distribution.Client.RebuildMonad
+
+import           Distribution.Package (UnitId, mkUnitId)
+import           Distribution.Compiler (CompilerId)
+
+import           Distribution.Simple.Utils
+                   ( withTempDirectory, debug, info )
+import           Distribution.Verbosity
+import           Distribution.Text
+
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Control.Exception
+import           System.FilePath
+import           System.Directory
+import           System.IO
+
+
+-- $concurrency
+--
+-- We access and update the store concurrently. Our strategy to do that safely
+-- is as follows.
+--
+-- The store entries once created are immutable. This alone simplifies matters
+-- considerably.
+--
+-- Additionally, the way 'UnitId' hashes are constructed means that if a store
+-- entry exists already then we can assume its content is ok to reuse, rather
+-- than having to re-recreate. This is the nix-style input hashing concept.
+--
+-- A consequence of this is that with a little care it is /safe/ to race
+-- updates against each other. Consider two independent concurrent builds that
+-- both want to build a particular 'UnitId', where that entry does not yet
+-- exist in the store. It is safe for both to build and try to install this
+-- entry into the store provided that:
+--
+-- * only one succeeds
+-- * the looser discovers that they lost, they abandon their own build and
+--   re-use the store entry installed by the winner.
+--
+-- Note that because builds are not reproducible in general (nor even
+-- necessarily ABI compatible) then it is essential that the loser abandon
+-- their build and use the one installed by the winner, so that subsequent
+-- packages are built against the exact package from the store rather than some
+-- morally equivalent package that may not be ABI compatible.
+--
+-- Our overriding goal is that store reads be simple, cheap and not require
+-- locking. We will derive our write-side protocol to make this possible.
+--
+-- The read-side protocol is simply:
+--
+-- * check for the existence of a directory entry named after the 'UnitId' in
+--   question. That is, if the dir entry @$root/foo-1.0-fe56a...@ exists then
+--   the store entry can be assumed to be complete and immutable.
+--
+-- Given our read-side protocol, the final step on the write side must be to
+-- atomically rename a fully-formed store entry directory into its final
+-- location. While this will indeed be the final step, the preparatory steps
+-- are more complicated. The tricky aspect is that the store also contains a
+-- number of shared package databases (one per compiler version). Our read
+-- strategy means that by the time we install the store dir entry the package
+-- db must already have been updated. We cannot do the package db update
+-- as part of atomically renaming the store entry directory however. Furthermore
+-- it is not safe to allow either package db update because the db entry
+-- contains the ABI hash and this is not guaranteed to be deterministic. So we
+-- must register the new package prior to the atomic dir rename. Since this
+-- combination of steps are not atomic then we need locking.
+--
+-- The write-side protocol is:
+--
+-- * Create a unique temp dir and write all store entry files into it.
+--
+-- * Take a lock named after the 'UnitId' in question.
+--
+-- * Once holding the lock, check again for the existence of the final store
+--   entry directory. If the entry exists then the process lost the race and it
+--   must abandon, unlock and re-use the existing store entry. If the entry
+--   does not exist then the process won the race and it can proceed.
+--
+-- * Register the package into the package db. Note that the files are not in
+--   their final location at this stage so registration file checks may need
+--   to be disabled.
+--
+-- * Atomically rename the temp dir to the final store entry location.
+--
+-- * Release the previously-acquired lock.
+--
+-- Obviously this means it is possible to fail after registering but before
+-- installing the store entry, leaving a dangling package db entry. This is not
+-- much of a problem because this entry does not determine package existence
+-- for cabal. It does mean however that the package db update should be insert
+-- or replace, i.e. not failing if the db entry already exists.
+
+
+-- | Check if a particular 'UnitId' exists in the store.
+--
+doesStoreEntryExist :: StoreDirLayout -> CompilerId -> UnitId -> IO Bool
+doesStoreEntryExist StoreDirLayout{storePackageDirectory} compid unitid =
+    doesDirectoryExist (storePackageDirectory compid unitid)
+
+
+-- | Return the 'UnitId's of all packages\/components already installed in the
+-- store.
+--
+getStoreEntries :: StoreDirLayout -> CompilerId -> Rebuild (Set UnitId)
+getStoreEntries StoreDirLayout{storeDirectory} compid = do
+    paths <- getDirectoryContentsMonitored (storeDirectory compid)
+    return $! mkEntries paths
+  where
+    mkEntries     = Set.delete (mkUnitId "package.db")
+                  . Set.delete (mkUnitId "incoming")
+                  . Set.fromList
+                  . map mkUnitId
+                  . filter valid
+    valid ('.':_) = False
+    valid _       = True
+
+
+-- | The outcome of 'newStoreEntry': either the store entry was newly created
+-- or it existed already. The latter case happens if there was a race between
+-- two builds of the same store entry.
+--
+data NewStoreEntryOutcome = UseNewStoreEntry
+                          | UseExistingStoreEntry
+  deriving (Eq, Show)
+
+-- | Place a new entry into the store. See the concurrency strategy description
+-- for full details.
+--
+-- In particular, it takes two actions: one to place files into a temporary
+-- location, and a second to perform any necessary registration. The first
+-- action is executed without any locks held (the temp dir is unique). The
+-- second action holds a lock that guarantees that only one cabal process is
+-- able to install this store entry. This means it is safe to register into
+-- the compiler package DB or do other similar actions.
+--
+-- Note that if you need to use the registration information later then you
+-- /must/ check the 'NewStoreEntryOutcome' and if it's'UseExistingStoreEntry'
+-- then you must read the existing registration information (unless your
+-- registration information is constructed fully deterministically).
+--
+newStoreEntry :: Verbosity
+              -> StoreDirLayout
+              -> CompilerId
+              -> UnitId
+              -> (FilePath -> IO FilePath) -- ^ Action to place files.
+              -> IO ()                     -- ^ Register action, if necessary.
+              -> IO NewStoreEntryOutcome
+newStoreEntry verbosity storeDirLayout@StoreDirLayout{..}
+              compid unitid
+              copyFiles register =
+    -- See $concurrency above for an explanation of the concurrency protocol
+
+    withTempIncomingDir storeDirLayout compid $ \incomingTmpDir -> do
+
+      -- Write all store entry files within the temp dir and return the prefix.
+      incomingEntryDir <- copyFiles incomingTmpDir
+
+      -- Take a lock named after the 'UnitId' in question.
+      withIncomingUnitIdLock verbosity storeDirLayout compid unitid $ do
+
+        -- Check for the existence of the final store entry directory.
+        exists <- doesStoreEntryExist storeDirLayout compid unitid
+
+        if exists
+          -- If the entry exists then we lost the race and we must abandon,
+          -- unlock and re-use the existing store entry.
+          then do
+            info verbosity $
+                "Concurrent build race: abandoning build in favour of existing "
+             ++ "store entry " ++ display compid </> display unitid
+            return UseExistingStoreEntry
+
+          -- If the entry does not exist then we won the race and can proceed.
+          else do
+
+            -- Register the package into the package db (if appropriate).
+            register
+
+            -- Atomically rename the temp dir to the final store entry location.
+            renameDirectory incomingEntryDir finalEntryDir
+
+            debug verbosity $
+              "Installed store entry " ++ display compid </> display unitid
+            return UseNewStoreEntry
+  where
+    finalEntryDir = storePackageDirectory compid unitid
+
+
+withTempIncomingDir :: StoreDirLayout -> CompilerId
+                    -> (FilePath -> IO a) -> IO a
+withTempIncomingDir StoreDirLayout{storeIncomingDirectory} compid action = do
+    createDirectoryIfMissing True incomingDir
+    withTempDirectory silent incomingDir "new" action
+  where
+    incomingDir = storeIncomingDirectory compid
+
+
+withIncomingUnitIdLock :: Verbosity -> StoreDirLayout
+                       -> CompilerId -> UnitId
+                       -> IO a -> IO a
+withIncomingUnitIdLock verbosity StoreDirLayout{storeIncomingLock}
+                       compid unitid action =
+    bracket takeLock releaseLock (\_hnd -> action)
+  where
+    takeLock = do
+      h <- openFile (storeIncomingLock compid unitid) ReadWriteMode
+      -- First try non-blocking, but if we would have to wait then
+      -- log an explanation and do it again in blocking mode.
+      gotlock <- hTryLock h ExclusiveLock
+      unless gotlock $ do
+        info verbosity $ "Waiting for file lock on store entry "
+                      ++ display compid </> display unitid
+        hLock h ExclusiveLock
+      return h
+
+    releaseLock = hClose
+

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -211,6 +211,7 @@ library
         Distribution.Client.SrcDist
         Distribution.Client.SolverInstallPlan
         Distribution.Client.SourceFiles
+        Distribution.Client.Store
         Distribution.Client.Tar
         Distribution.Client.Targets
         Distribution.Client.TargetSelector

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -464,6 +464,7 @@ Test-Suite unit-tests
     UnitTests.Distribution.Client.GZipUtils
     UnitTests.Distribution.Client.Sandbox
     UnitTests.Distribution.Client.Sandbox.Timestamp
+    UnitTests.Distribution.Client.Store
     UnitTests.Distribution.Client.Tar
     UnitTests.Distribution.Client.UserConfig
     UnitTests.Distribution.Client.ProjectConfig

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -223,6 +223,7 @@ library
         Distribution.Client.World
         Distribution.Client.Win32SelfUpgrade
         Distribution.Client.Compat.ExecutablePath
+        Distribution.Client.Compat.FileLock
         Distribution.Client.Compat.FilePerms
         Distribution.Client.Compat.Prelude
         Distribution.Client.Compat.Process
@@ -394,6 +395,8 @@ executable cabal
             time       >= 1.4      && < 1.8,
             zlib       >= 0.5.3    && < 0.7,
             hackage-security >= 0.5.2.2 && < 0.6
+
+        other-modules:  Distribution.Client.Compat.FileLock
 
         if flag(old-bytestring)
           build-depends: bytestring <  0.10.2, bytestring-builder >= 0.10 && < 1

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -1538,7 +1538,7 @@ planProject testdir cliConfig = do
             elaboratedShared)
 
 executePlan :: PlanDetails -> IO (ElaboratedInstallPlan, BuildOutcomes)
-executePlan ((distDirLayout, _, _, _, buildSettings),
+executePlan ((distDirLayout, cabalDirLayout, _, _, buildSettings),
              elaboratedPlan,
              elaboratedShared) = do
 
@@ -1565,6 +1565,7 @@ executePlan ((distDirLayout, _, _, _, buildSettings),
     buildOutcomes <-
       rebuildTargets verbosity
                      distDirLayout
+                     (cabalStoreDirLayout cabalDirLayout)
                      elaboratedPlan''
                      elaboratedShared
                      pkgsBuildStatus

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -19,6 +19,7 @@ import qualified UnitTests.Distribution.Client.Glob
 import qualified UnitTests.Distribution.Client.GZipUtils
 import qualified UnitTests.Distribution.Client.Sandbox
 import qualified UnitTests.Distribution.Client.Sandbox.Timestamp
+import qualified UnitTests.Distribution.Client.Store
 import qualified UnitTests.Distribution.Client.Tar
 import qualified UnitTests.Distribution.Client.Targets
 import qualified UnitTests.Distribution.Client.UserConfig
@@ -56,6 +57,8 @@ tests mtimeChangeCalibrated =
        UnitTests.Distribution.Client.Sandbox.tests
   , testGroup "Distribution.Client.Sandbox.Timestamp"
        UnitTests.Distribution.Client.Sandbox.Timestamp.tests
+  , testGroup "Distribution.Client.Store"
+       UnitTests.Distribution.Client.Store.tests
   , testGroup "Distribution.Client.Tar"
        UnitTests.Distribution.Client.Tar.tests
   , testGroup "Distribution.Client.Targets"

--- a/cabal-install/tests/UnitTests/Distribution/Client/Store.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Store.hs
@@ -1,0 +1,181 @@
+module UnitTests.Distribution.Client.Store (tests) where
+
+--import Control.Monad
+--import Control.Concurrent (forkIO, threadDelay)
+--import Control.Concurrent.MVar
+import qualified Data.Set as Set
+import System.FilePath
+import System.Directory
+--import System.Random
+
+import Distribution.Package (UnitId, mkUnitId)
+import Distribution.Compiler (CompilerId(..), CompilerFlavor(..))
+import Distribution.Version  (mkVersion)
+import Distribution.Verbosity (Verbosity, silent)
+import Distribution.Simple.Utils (withTempDirectory)
+
+import Distribution.Client.Store
+import Distribution.Client.RebuildMonad
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+
+tests :: [TestTree]
+tests =
+  [ testCase "list content empty"  testListEmpty
+  , testCase "install serial"      testInstallSerial
+--, testCase "install parallel"    testInstallParallel
+    --TODO: figure out some way to do a parallel test, see issue below
+  ]
+
+
+testListEmpty :: Assertion
+testListEmpty =
+  withTempDirectory verbosity "." "store-" $ \tmp -> do
+    let storeDirLayout = defaultStoreDirLayout (tmp </> "store")
+
+    assertStoreEntryExists storeDirLayout compid unitid False
+    assertStoreContent tmp storeDirLayout compid        Set.empty
+  where
+    compid = CompilerId GHC (mkVersion [1,0])
+    unitid = mkUnitId "foo-1.0-xyz"
+
+
+testInstallSerial :: Assertion
+testInstallSerial =
+  withTempDirectory verbosity "." "store-" $ \tmp -> do
+    let storeDirLayout = defaultStoreDirLayout (tmp </> "store")
+        copyFiles file content dir = do
+          -- we copy into a prefix inside the tmp dir and return the prefix
+          let destprefix = dir </> "prefix"
+          createDirectory destprefix
+          writeFile (destprefix </> file) content
+          return destprefix
+
+    assertNewStoreEntry tmp storeDirLayout compid unitid1
+                        (copyFiles "file1" "content-foo") (return ())
+                        UseNewStoreEntry
+
+    assertNewStoreEntry tmp storeDirLayout compid unitid1
+                        (copyFiles "file1" "content-foo") (return ())
+                        UseExistingStoreEntry
+
+    assertNewStoreEntry tmp storeDirLayout compid unitid2
+                        (copyFiles "file2" "content-bar") (return ())
+                        UseNewStoreEntry
+
+    let pkgDir :: UnitId -> FilePath
+        pkgDir = storePackageDirectory storeDirLayout compid
+    assertFileEqual (pkgDir unitid1 </> "file1") "content-foo"
+    assertFileEqual (pkgDir unitid2 </> "file2") "content-bar"
+  where
+    compid  = CompilerId GHC (mkVersion [1,0])
+    unitid1 = mkUnitId "foo-1.0-xyz"
+    unitid2 = mkUnitId "bar-2.0-xyz"
+
+
+{-
+-- unfortunately a parallel test like the one below is thwarted by the normal
+-- process-internal file locking. If that locking were not in place then we
+-- ought to get the blocking behaviour, but due to the normal Handle locking
+-- it just fails instead.
+
+testInstallParallel :: Assertion
+testInstallParallel =
+  withTempDirectory verbosity "." "store-" $ \tmp -> do
+    let storeDirLayout = defaultStoreDirLayout (tmp </> "store")
+
+    sync1 <- newEmptyMVar
+    sync2 <- newEmptyMVar
+    outv  <- newEmptyMVar
+    regv  <- newMVar (0 :: Int)
+
+    sequence_
+      [ do forkIO $ do
+             let copyFiles dir = do
+                   delay <- randomRIO (1,100000)
+                   writeFile (dir </> "file") (show n)
+                   putMVar  sync1 ()
+                   readMVar sync2
+                   threadDelay delay
+                 register = do
+                   modifyMVar_ regv (return . (+1))
+                   threadDelay 200000
+             o <- newStoreEntry verbosity storeDirLayout
+                                compid unitid
+                                copyFiles register
+             putMVar outv (n, o)
+      | n <- [0..9 :: Int] ]
+
+    replicateM_ 10 (takeMVar sync1)
+    -- all threads are in the copyFiles action concurrently, release them:
+    putMVar  sync2 ()
+
+    outcomes <- replicateM 10 (takeMVar outv)
+    regcount <- readMVar regv
+    let regcount' = length [ () | (_, UseNewStoreEntry) <- outcomes ]
+
+    assertEqual "num registrations" 1 regcount
+    assertEqual "num registrations" 1 regcount'
+
+    assertStoreContent tmp storeDirLayout compid (Set.singleton unitid)
+
+    let pkgDir :: UnitId -> FilePath
+        pkgDir = storePackageDirectory storeDirLayout compid
+    case [ n | (n, UseNewStoreEntry) <- outcomes ] of
+      [n] -> assertFileEqual (pkgDir unitid </> "file") (show n)
+      _   -> assertFailure "impossible"
+
+  where
+    compid  = CompilerId GHC (mkVersion [1,0])
+    unitid = mkUnitId "foo-1.0-xyz"
+-}
+
+-------------
+-- Utils
+
+assertNewStoreEntry :: FilePath -> StoreDirLayout
+                    -> CompilerId -> UnitId
+                    -> (FilePath -> IO FilePath) -> IO ()
+                    -> NewStoreEntryOutcome
+                    -> Assertion
+assertNewStoreEntry tmp storeDirLayout compid unitid
+                    copyFiles register expectedOutcome = do
+    entries <- runRebuild tmp $ getStoreEntries storeDirLayout compid
+    outcome <- newStoreEntry verbosity storeDirLayout
+                             compid unitid
+                             copyFiles register
+    assertEqual "newStoreEntry outcome" expectedOutcome outcome
+    assertStoreEntryExists storeDirLayout compid unitid True
+    let expected = Set.insert unitid entries
+    assertStoreContent tmp storeDirLayout compid expected
+
+
+assertStoreEntryExists :: StoreDirLayout
+                       -> CompilerId -> UnitId -> Bool
+                       -> Assertion
+assertStoreEntryExists storeDirLayout compid unitid expected = do
+    actual <- doesStoreEntryExist storeDirLayout compid unitid
+    assertEqual "store entry exists" expected actual
+
+
+assertStoreContent :: FilePath -> StoreDirLayout
+                   -> CompilerId -> Set.Set UnitId
+                   -> Assertion
+assertStoreContent tmp storeDirLayout compid expected = do
+    actual <- runRebuild tmp $ getStoreEntries storeDirLayout compid
+    assertEqual "store content" actual expected
+
+
+assertFileEqual :: FilePath -> String -> Assertion
+assertFileEqual path expected = do
+    exists <- doesFileExist path
+    assertBool ("file does not exist:\n" ++ path) exists
+    actual <- readFile path
+    assertEqual ("file content for:\n" ++ path) expected actual
+
+
+verbosity :: Verbosity
+verbosity = silent
+


### PR DESCRIPTION
We need to be able to safely do concurrent builds of different projects that share the store. This code documents and implements a concurrency strategy for reading and writing entries in the store.

This patch includes new compat code for file locks, taken from the base library from ghc-8.2.x.

It is not yet used or indeed tested. This PR is here for feedback on the concurrency strategy (which is clearly documents in the haddock docs in the module) and to check that the locking code does indeed build on windows.