### PR TITLE
More accurately determine monitors to monitor.

### DIFF
--- a/cabal-testsuite/PackageTests/NewBuild/T4405/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/T4405/cabal.out
@@ -1,0 +1,13 @@
+# cabal new-build
+Resolving dependencies...
+In order, the following will be built:
+ - p-1.0 (lib) (first run)
+ - q-1.0 (lib) (first run)
+Configuring library for p-1.0..
+Preprocessing library for p-1.0..
+Building library for p-1.0..
+Configuring library for q-1.0..
+Preprocessing library for q-1.0..
+Building library for q-1.0..
+# cabal new-build
+Up to date

--- a/cabal-testsuite/PackageTests/NewBuild/T4405/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/T4405/cabal.project
@@ -1,0 +1,1 @@
+packages: p q

--- a/cabal-testsuite/PackageTests/NewBuild/T4405/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4405/cabal.test.hs
@@ -1,0 +1,4 @@
+import Test.Cabal.Prelude
+main = cabalTest $ do
+    cabal "new-build" ["q"]
+    cabal "new-build" ["q"]

--- a/cabal-testsuite/PackageTests/NewBuild/T4405/p/P.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4405/p/P.hs
@@ -1,0 +1,1 @@
+module P where

--- a/cabal-testsuite/PackageTests/NewBuild/T4405/p/PTest.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4405/p/PTest.hs
@@ -1,0 +1,1 @@
+main = return ()

--- a/cabal-testsuite/PackageTests/NewBuild/T4405/p/p.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/T4405/p/p.cabal
@@ -1,0 +1,15 @@
+name: p
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    exposed-modules: P
+    build-depends: base
+    default-language: Haskell2010
+
+test-suite ptest
+    main-is: PTest.hs
+    type: exitcode-stdio-1.0
+    build-depends: base
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/T4405/q/Q.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4405/q/Q.hs
@@ -1,0 +1,2 @@
+module Q where
+import P

--- a/cabal-testsuite/PackageTests/NewBuild/T4405/q/q.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/T4405/q/q.cabal
@@ -1,0 +1,9 @@
+name: q
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    build-depends: p, base
+    exposed-modules: Q
+    default-language: Haskell2010


### PR DESCRIPTION
Previously, we used the solver dependencies to figure out
what to monitor, but this lead to a failure mode where we
would also monitor the monitor files associated with the
test suite, which we really shouldn't do.

This patch pushes the monitor file calculation later until
the build step, at which point we know exactly what our
dependencies are, and monitor those precisely.

Fixes #4405.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>