### PR TITLE
Use default flags rather than mempty.

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1046,7 +1046,10 @@ upgradeCommand = configureCommand {
     commandSynopsis     = "(command disabled, use install instead)",
     commandDescription  = Nothing,
     commandUsage        = usageFlagsOrPackages "upgrade",
-    commandDefaultFlags = (mempty, mempty, mempty, mempty),
+    commandDefaultFlags = (commandDefaultFlags configureCommand,
+                           defaultConfigExFlags,
+                           defaultInstallFlags,
+                           Cabal.defaultHaddockFlags),
     commandOptions      = commandOptions installCommand
   }
 
@@ -1553,7 +1556,10 @@ installCommand = CommandUI {
      ++ "  " ++ (map (const ' ') pname)
                       ++ "                         "
      ++ "    Change installation destination\n",
-  commandDefaultFlags = (mempty, mempty, mempty, mempty),
+  commandDefaultFlags = (commandDefaultFlags configureCommand,
+                         defaultConfigExFlags,
+                         defaultInstallFlags,
+                         Cabal.defaultHaddockFlags),
   commandOptions      = \showOrParseArgs ->
        liftOptions get1 set1
        (filter ((`notElem` ["constraint", "dependency"


### PR DESCRIPTION
In particular, the Cmd* modules don't mappend in the defaults
before using the flags, so ensuring they're setup correctly from
the start helps avoid errors.

This default flag business is extremely dodgy and I wish we had a better
story for it.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>