### PR TITLE
Tweak target selection semantics for indefinite packages.

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1625,6 +1625,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
         elabInstallDirs     = error "elaborateSolverToCommon: elabInstallDirs"
         elabModuleShape     = error "elaborateSolverToCommon: elabModuleShape"
 
+        elabIsCanonical     = True
         elabPkgSourceId     = pkgid
         elabPkgDescription  = let Right (desc, _) =
                                     PD.finalizePD
@@ -2010,6 +2011,7 @@ instantiateInstallPlan plan =
                     elabUnitId = uid,
                     elabComponentId = cid,
                     elabInstantiatedWith = insts,
+                    elabIsCanonical = False,
                     elabPkgOrComp = ElabComponent comp {
                         compOrderLibDependencies =
                             (if Map.null insts then [] else [newSimpleUnitId cid]) ++
@@ -2226,6 +2228,15 @@ availableSourceTargets elab =
                      availableTargetLocalToProject = elabLocalToProject elab
                    }
           fake   = isFakeTarget cname
+
+    -- TODO: The goal of this test is to exclude "instantiated"
+    -- packages as available targets. This means that you can't
+    -- ask for a particular instantiated component to be built;
+    -- it will only get built by a dependency.  Perhaps the
+    -- correct way to implement this is to run selection
+    -- *prior* to instantiating packages.  If you refactor
+    -- this, then you can delete this test.
+    , elabIsCanonical elab
 
       -- Filter out some bogus parts of the cross product that are never needed
     , case status of

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -151,6 +151,14 @@ data ElaboratedConfiguredPackage
        elabInstantiatedWith :: Map ModuleName Module,
        elabLinkedInstantiatedWith :: Map ModuleName OpenModule,
 
+       -- | This is true if this is an indefinite package, or this is a
+       -- package with no signatures.  (Notably, it's not true for instantiated
+       -- packages.)  The motivation for this is if you ask to build
+       -- @foo-indef@, this probably means that you want to typecheck
+       -- it, NOT that you want to rebuild all of the various
+       -- instantiations of it.
+       elabIsCanonical :: Bool,
+
        -- | The 'PackageId' of the originating package
        elabPkgSourceId    :: PackageId,
 

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external-target.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external-target.out
@@ -1,0 +1,8 @@
+# cabal new-build
+Resolving dependencies...
+In order, the following will be built:
+ - mylib-0.1.0.0 (lib) (first run)
+Configuring library for mylib-0.1.0.0..
+Preprocessing library for mylib-0.1.0.0..
+Building library instantiated with Database = <Database>
+for mylib-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external-target.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external-target.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    skipUnless =<< ghcVersionIs (>= mkVersion [8,1])
+    withProjectFile "cabal.external.project" $ do
+        cabal "new-build" ["mylib"]

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal-target.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal-target.out
@@ -1,0 +1,8 @@
+# cabal new-build
+Resolving dependencies...
+In order, the following will be built:
+ - Includes2-0.1.0.0 (lib:mylib) (first run)
+Configuring library 'mylib' for Includes2-0.1.0.0..
+Preprocessing library 'mylib' for Includes2-0.1.0.0..
+Building library 'mylib' instantiated with Database = <Database>
+for Includes2-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal-target.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal-target.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    skipUnless =<< ghcVersionIs (>= mkVersion [8,1])
+    withProjectFile "cabal.internal.project" $ do
+        cabal "new-build" ["mylib"]


### PR DESCRIPTION
Suppose you have a Backpack package foo-indef, which has
some signatures; furthermore, elsewhere in your install plan
ths packages gets instantiated. When you type
'cabal new-build foo-indef', what should get built?

Previously: foo-indef, as well as all of its instantiations,
get built.

Now: only the indefinite foo-indef is typechecked.

This is what you want!

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>