### PR TITLE
Some bugfixes I noticed from Backpacking

### DIFF
--- a/Cabal/Distribution/Backpack/ReadyComponent.hs
+++ b/Cabal/Distribution/Backpack/ReadyComponent.hs
@@ -258,6 +258,8 @@ toReadyComponents pid_map subst0 comps
     instantiateComponent uid cid insts
       | Just lc <- Map.lookup cid cmap = do
             provides <- T.mapM (substModule insts) (modShapeProvides (lc_shape lc))
+            -- NB: lc_sig_includes is omitted here, because we don't
+            -- need them to build
             includes <- forM (lc_includes lc) $ \ci -> do
                 uid' <- substUnitId insts (ci_id ci)
                 return ci { ci_ann_id = fmap (const uid') (ci_ann_id ci) }

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -220,7 +220,7 @@ fromList pkgs = mkPackageIndex pids pnames
       Map.fromList
         [ (liftM2 (,) packageName IPI.sourceLibName (head pkgsN), pvers)
         | pkgsN <- groupBy (equating  (liftM2 (,) packageName IPI.sourceLibName))
-                 . sortBy  (comparing (liftM2 (,) packageId IPI.sourceLibName))
+                 . sortBy  (comparing (liftM3 (,,) packageName IPI.sourceLibName packageVersion))
                  $ pkgs
         , let pvers =
                 Map.fromList

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1625,6 +1625,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
         elabInstallDirs     = error "elaborateSolverToCommon: elabInstallDirs"
         elabModuleShape     = error "elaborateSolverToCommon: elabModuleShape"
 
+        elabIsCanonical     = True
         elabPkgSourceId     = pkgid
         elabPkgDescription  = let Right (desc, _) =
                                     PD.finalizePD
@@ -2010,6 +2011,7 @@ instantiateInstallPlan plan =
                     elabUnitId = uid,
                     elabComponentId = cid,
                     elabInstantiatedWith = insts,
+                    elabIsCanonical = Map.null insts,
                     elabPkgOrComp = ElabComponent comp {
                         compOrderLibDependencies =
                             (if Map.null insts then [] else [newSimpleUnitId cid]) ++
@@ -2226,6 +2228,15 @@ availableSourceTargets elab =
                      availableTargetLocalToProject = elabLocalToProject elab
                    }
           fake   = isFakeTarget cname
+
+    -- TODO: The goal of this test is to exclude "instantiated"
+    -- packages as available targets. This means that you can't
+    -- ask for a particular instantiated component to be built;
+    -- it will only get built by a dependency.  Perhaps the
+    -- correct way to implement this is to run selection
+    -- prior to instantiating packages.  If you refactor
+    -- this, then you can delete this test.
+    , elabIsCanonical elab
 
       -- Filter out some bogus parts of the cross product that are never needed
     , case status of

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -151,6 +151,14 @@ data ElaboratedConfiguredPackage
        elabInstantiatedWith :: Map ModuleName Module,
        elabLinkedInstantiatedWith :: Map ModuleName OpenModule,
 
+       -- | This is true if this is an indefinite package, or this is a
+       -- package with no signatures.  (Notably, it's not true for instantiated
+       -- packages.)  The motivation for this is if you ask to build
+       -- @foo-indef@, this probably means that you want to typecheck
+       -- it, NOT that you want to rebuild all of the various
+       -- instantiations of it.
+       elabIsCanonical :: Bool,
+
        -- | The 'PackageId' of the originating package
        elabPkgSourceId    :: PackageId,
 

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external-target.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external-target.out
@@ -1,0 +1,8 @@
+# cabal new-build
+Resolving dependencies...
+In order, the following will be built:
+ - mylib-0.1.0.0 (lib) (first run)
+Configuring library for mylib-0.1.0.0..
+Preprocessing library for mylib-0.1.0.0..
+Building library instantiated with Database = <Database>
+for mylib-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external-target.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external-target.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    skipUnless =<< ghcVersionIs (>= mkVersion [8,1])
+    withProjectFile "cabal.external.project" $ do
+        cabal "new-build" ["mylib"]

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal-target.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal-target.out
@@ -1,0 +1,8 @@
+# cabal new-build
+Resolving dependencies...
+In order, the following will be built:
+ - Includes2-0.1.0.0 (lib:mylib) (first run)
+Configuring library 'mylib' for Includes2-0.1.0.0..
+Preprocessing library 'mylib' for Includes2-0.1.0.0..
+Building library 'mylib' instantiated with Database = <Database>
+for Includes2-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal-target.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal-target.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    skipUnless =<< ghcVersionIs (>= mkVersion [8,1])
+    withProjectFile "cabal.internal.project" $ do
+        cabal "new-build" ["mylib"]


### PR DESCRIPTION
Three bugs:

* `mkPackageIndex` still wasn't quite right, resulting in assert failures when using internal libraries in some situations. I think I've finally nailed it.
* When I say `cabal new-build foo-indef`, I only want to typecheck an indefinite package, not also build all of its instantiations. This is now done.
* When I say `build-depends: str-sig, str-string`, I'm saying, "please verify str-string matches str-sig." But this check will only be done if we build the instantiated signature package, which we were not doing previously.