### PR TITLE
Reenable GHC environment file support

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -673,8 +673,6 @@ writePlanGhcEnvironment DistDirLayout{distProjectRootDirectory}
   | compilerFlavor compiler == GHC
   , supportsPkgEnvFiles (getImplInfo compiler)
   --TODO: check ghcjs compat
-  --TODO: This feature is temporarily disabled due to #4010
-  , False
   = writeGhcEnvironmentFile
       distProjectRootDirectory
       platform (compilerVersion compiler)


### PR DESCRIPTION
This was temporarily disabled via
3033776a742022693917d05ce18440c560e721e7 due to #4010
but it turns out that we can easily workaround this for
older Cabal versions.

All we need to do is inject `--ghc-options=-hide-all-packages` into
the flags passed to Setup.hs when an old `Cabal` version is detected
(this was suggested by @dcoutts in
https://github.com/haskell/cabal/issues/4010#issuecomment-254958478)

Luckily, `-hide-all-packages` is idempotent in GHC, so we can place it
anywhere on the GHC command-line as well as multiple times with the
same result.

This would close #4010