### PR TITLE
Fix CPP in FileLock.hsc

### DIFF
--- a/cabal-install/Distribution/Client/Compat/FileLock.hsc
+++ b/cabal-install/Distribution/Client/Compat/FileLock.hsc
@@ -74,8 +74,6 @@ import GHC.Windows
 
 #endif /* !defined(solaris2_HOST_OS) */
 
-#endif /* MIN_VERSION_base */
-
 
 -- | Exception thrown by 'hLock' on non-Windows platforms that don't support
 -- 'flock'.
@@ -84,7 +82,6 @@ data FileLockingNotSupported = FileLockingNotSupported
 
 instance Exception FileLockingNotSupported
 
-#if !(MIN_VERSION_base(4,10,0))
 
 -- | Indicates a mode in which a file should be locked.
 data LockMode = SharedLock | ExclusiveLock


### PR DESCRIPTION
with this fix, `cabal` can be built with GHC 8.2.1RC via

```
cabal new-build -w ghc-8.2.1 exe:cabal \
    --allow-newer=hackage-security:time,HTTP:base,vector:base,cabal-install:time
```