### PR TITLE
Implement pre-mixin-linking, make local modules participate.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -125,6 +125,7 @@ library
     Distribution.Backpack.LinkedComponent
     Distribution.Backpack.ModSubst
     Distribution.Backpack.ModuleShape
+    Distribution.Backpack.PreModuleShape
     Distribution.Utils.LogProgress
     Distribution.Utils.MapAccum
     Distribution.Compat.CreatePipe

--- a/Cabal/Distribution/Backpack/MixLink.hs
+++ b/Cabal/Distribution/Backpack/MixLink.hs
@@ -10,12 +10,12 @@ import Distribution.Compat.Prelude hiding (mod)
 import Distribution.Backpack
 import Distribution.Backpack.UnifyM
 import Distribution.Backpack.FullUnitId
+import Distribution.Backpack.ModuleScope
 
 import qualified Distribution.Utils.UnionFind as UnionFind
 import Distribution.ModuleName
 import Distribution.Text
 import Distribution.Types.ComponentId
-import Distribution.Types.ComponentName
 
 import Text.PrettyPrint
 import Control.Monad
@@ -36,39 +36,21 @@ mixLink scopes = do
     let remaining = Map.difference reqs filled
     return (provs, remaining)
 
--- TODO: Deduplicate this with Distribution.Backpack.UnifyM.ci_msg
-dispSource :: ModuleSourceU s -> Doc
-dispSource src
- | usrc_implicit src
- = text "build-depends:" <+> pp_pn
- | otherwise
- = text "mixins:" <+> pp_pn <+> disp (usrc_renaming src)
- where
-  pp_pn =
-    -- NB: This syntax isn't quite the source syntax, but it
-    -- should be clear enough.  To do source syntax, we'd
-    -- need to know what the package we're linking is.
-    case usrc_compname src of
-        CLibName -> disp (usrc_pkgname src)
-        CSubLibName cn -> disp (usrc_pkgname src) <<>> colon <<>> disp cn
-        -- Shouldn't happen
-        cn -> disp (usrc_pkgname src) <+> parens (disp cn)
-
 -- | Link a list of possibly provided modules to a single
 -- requirement.  This applies a side-condition that all
 -- of the provided modules at the same name are *actually*
 -- the same module.
 linkProvision :: ModuleName
-              -> [ModuleSourceU s] -- provs
-              -> [ModuleSourceU s] -- reqs
-              -> UnifyM s [ModuleSourceU s]
+              -> [ModuleWithSourceU s] -- provs
+              -> [ModuleWithSourceU s] -- reqs
+              -> UnifyM s [ModuleWithSourceU s]
 linkProvision mod_name ret@(prov:provs) (req:reqs) = do
     -- TODO: coalesce all the non-unifying modules together
     forM_ provs $ \prov' -> do
         -- Careful: read it out BEFORE unifying, because the
         -- unification algorithm preemptively unifies modules
-        mod  <- convertModuleU (usrc_module prov)
-        mod' <- convertModuleU (usrc_module prov')
+        mod  <- convertModuleU (unWithSource prov)
+        mod' <- convertModuleU (unWithSource prov')
         r <- unify prov prov'
         case r of
             Just () -> return ()
@@ -76,11 +58,11 @@ linkProvision mod_name ret@(prov:provs) (req:reqs) = do
                 addErr $
                   text "Ambiguous module" <+> quotes (disp mod_name) $$
                   text "It could refer to" <+>
-                    ( text "  " <+> (quotes (disp mod)  $$ in_scope_by prov) $$
-                      text "or" <+> (quotes (disp mod') $$ in_scope_by prov') ) $$
+                    ( text "  " <+> (quotes (disp mod)  $$ in_scope_by (getSource prov)) $$
+                      text "or" <+> (quotes (disp mod') $$ in_scope_by (getSource prov')) ) $$
                   link_doc
-    mod <- convertModuleU (usrc_module prov)
-    req_mod <- convertModuleU (usrc_module req)
+    mod <- convertModuleU (unWithSource prov)
+    req_mod <- convertModuleU (unWithSource req)
     r <- unify prov req
     case r of
         Just () -> return ()
@@ -95,14 +77,14 @@ linkProvision mod_name ret@(prov:provs) (req:reqs) = do
     return ret
   where
     unify s1 s2 = tryM $ addErrContext short_link_doc
-                       $ unifyModule (usrc_module s1) (usrc_module s2)
-    in_scope_by s = text "brought into scope by" <+> dispSource s
+                       $ unifyModule (unWithSource s1) (unWithSource s2)
+    in_scope_by s = text "brought into scope by" <+> dispModuleSource s
     short_link_doc = text "While filling requirement" <+> quotes (disp mod_name)
     link_doc = text "While filling requirements of" <+> reqs_doc
     reqs_doc
-      | null reqs = dispSource req
-      | otherwise =  (       text "   " <+> dispSource req  $$
-                      vcat [ text "and" <+> dispSource r | r <- reqs])
+      | null reqs = dispModuleSource (getSource req)
+      | otherwise =  (       text "   " <+> dispModuleSource (getSource req)  $$
+                      vcat [ text "and" <+> dispModuleSource (getSource r) | r <- reqs])
 linkProvision _ _ _ = error "linkProvision"
 
 

--- a/Cabal/Distribution/Backpack/PreModuleShape.hs
+++ b/Cabal/Distribution/Backpack/PreModuleShape.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Distribution.Backpack.PreModuleShape (
+    PreModuleShape(..),
+    toPreModuleShape,
+    renamePreModuleShape,
+    mixLinkPreModuleShape,
+) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+import Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.Map as Map
+
+import Distribution.Backpack.ModuleShape
+import Distribution.Types.IncludeRenaming
+import Distribution.Types.ModuleRenaming
+import Distribution.ModuleName
+
+data PreModuleShape = PreModuleShape {
+        preModShapeProvides :: Set ModuleName,
+        preModShapeRequires :: Set ModuleName
+    }
+    deriving (Eq, Show, Generic)
+
+toPreModuleShape :: ModuleShape -> PreModuleShape
+toPreModuleShape (ModuleShape provs reqs) = PreModuleShape (Map.keysSet provs) reqs
+
+renamePreModuleShape :: PreModuleShape -> IncludeRenaming -> PreModuleShape
+renamePreModuleShape (PreModuleShape provs reqs) (IncludeRenaming prov_rn req_rn) =
+    PreModuleShape
+        (Set.fromList (mapMaybe prov_fn (Set.toList provs)))
+        (Set.map req_fn reqs)
+  where
+    prov_fn = interpModuleRenaming prov_rn
+    req_fn k = fromMaybe k (interpModuleRenaming req_rn k)
+
+mixLinkPreModuleShape :: [PreModuleShape] -> PreModuleShape
+mixLinkPreModuleShape shapes = PreModuleShape provs (Set.difference reqs provs)
+  where
+    provs = Set.unions (map preModShapeProvides shapes)
+    reqs  = Set.unions (map preModShapeRequires shapes)

--- a/cabal-testsuite/PackageTests/Backpack/T4447/A.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/A.hs
@@ -1,0 +1,1 @@
+module A where

--- a/cabal-testsuite/PackageTests/Backpack/T4447/Main.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/Main.hs
@@ -1,0 +1,2 @@
+module Main where
+main = return ()

--- a/cabal-testsuite/PackageTests/Backpack/T4447/T4447.cabal
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/T4447.cabal
@@ -1,0 +1,17 @@
+name: T4447
+version: 1.0
+cabal-version: >= 2.0
+build-type: Simple
+
+library foo-indef
+    exposed-modules: B
+    signatures: A
+    build-depends: base
+    hs-source-dirs: foo-indef
+    default-language: Haskell2010
+
+executable foo-exe
+    build-depends: foo-indef, base
+    other-modules: A
+    main-is: Main.hs
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/Backpack/T4447/cabal.project
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/Backpack/T4447/foo-indef/A.hsig
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/foo-indef/A.hsig
@@ -1,0 +1,1 @@
+signature A where

--- a/cabal-testsuite/PackageTests/Backpack/T4447/foo-indef/B.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/foo-indef/B.hs
@@ -1,0 +1,1 @@
+module B where

--- a/cabal-testsuite/PackageTests/Backpack/T4447/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/setup.out
@@ -1,0 +1,9 @@
+# Setup configure
+Configuring T4447-1.0...
+Error:
+    Cannot instantiate requirement 'A' brought into scope by build-depends: T4447:foo-indef
+    with locally defined module brought into scope by other-modules: A
+    as this would create a cyclic dependency, which GHC does not support.
+    Try moving this module to a separate library, e.g.,
+    create a new stanza: library 'sublib'.
+    In the stanza executable foo-exe

--- a/cabal-testsuite/PackageTests/Backpack/T4447/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T4447/setup.test.hs
@@ -1,0 +1,4 @@
+import Test.Cabal.Prelude
+main = setupAndCabalTest $ do
+    skipUnless =<< ghcVersionIs (>= mkVersion [8,1])
+    fails $ setup "configure" []

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
@@ -16,9 +16,9 @@ Error:
       - Ambiguous reexport 'Data.Map'
         It could refer to either:
              'containers-<VERSION>:Data.Map'
-             brought into scope by the build dependency on containers
+             brought into scope by build-depends: containers
           or 'containers-dupe-0.1.0.0:Data.Map'
-             brought into scope by the build dependency on containers-dupe
+             brought into scope by build-depends: containers-dupe
         The ambiguity can be resolved by qualifying the
         re-export with a package name.
         The syntax is 'packagename:ModuleName [as NewName]'.

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
@@ -14,9 +14,9 @@ Error:
       - Ambiguous reexport 'Data.Map'
         It could refer to either:
              'containers-<VERSION>:Data.Map'
-             brought into scope by the build dependency on containers
+             brought into scope by build-depends: containers
           or 'containers-dupe-0.1.0.0:Data.Map'
-             brought into scope by the build dependency on containers-dupe
+             brought into scope by build-depends: containers-dupe
         The ambiguity can be resolved by qualifying the
         re-export with a package name.
         The syntax is 'packagename:ModuleName [as NewName]'.


### PR DESCRIPTION
A few things:

- We now have a proper pre-mixin-linking pass which computes
  just the set of requirements we expect to see after mixin
  linking is done.  That lets us precompute the unit id
  for locally defined modules.

- Since we now know the correct module identities, we can
  make shapes for exposed-modules/other-modules and make
  them participate in mix-in linking.

- But we don't actually want to instantiate a requirement with
  a locally defined module, because GHC can't compile that!
  We want to error in this case.  Previously, we didn't notice
  that this had occurred at all; now it is caught, fixing #4447.
