### PR TITLE
Output old config before rewriting `cabal.project.local`

### DIFF
--- a/cabal-install/Distribution/Client/CmdConfigure.hs
+++ b/cabal-install/Distribution/Client/CmdConfigure.hs
@@ -5,6 +5,9 @@ module Distribution.Client.CmdConfigure (
     configureAction,
   ) where
 
+import System.Directory
+import Control.Monad
+
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.ProjectConfig
          ( writeProjectLocalExtraConfig )
@@ -19,7 +22,7 @@ import Distribution.Verbosity
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
 import Distribution.Simple.Utils
-         ( wrapText )
+         ( wrapText, notice )
 import qualified Distribution.Client.Setup as Client
 
 configureCommand :: CommandUI (ConfigFlags, ConfigExFlags
@@ -83,7 +86,12 @@ configureAction (configFlags, configExFlags, installFlags, haddockFlags)
     baseCtx <- establishProjectBaseContext verbosity cliConfig
 
     -- Write out the @cabal.project.local@ so it gets picked up by the
-    -- planning phase.
+    -- planning phase. If old config exists, then print the contents
+    -- before overwriting
+    exists <- doesFileExist "cabal.project.local"
+    when exists $ do
+        notice verbosity "'cabal.project.local' file already exists. Now overwriting it."
+        copyFile "cabal.project.local" "cabal.project.local~"
     writeProjectLocalExtraConfig (distDirLayout baseCtx)
                                  cliConfig
 

--- a/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/NewConfigure.cabal
+++ b/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/NewConfigure.cabal
@@ -1,0 +1,11 @@
+name:                NewConfigure
+version:             0.1.0.0
+author:              Foo Bar
+maintainer:          cabal-dev@haskell.org
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  exposed-modules:   Foo
+  build-depends:     base
+  default-language:  Haskell2010

--- a/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/Setup.hs
+++ b/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/cabal.out
+++ b/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/cabal.out
@@ -1,0 +1,5 @@
+# cabal new-configure
+'cabal.project.local' file already exists. Now overwriting it.
+Resolving dependencies...
+In order, the following would be built:
+ - NewConfigure-0.1.0.0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/cabal.project
+++ b/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/cabal.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $
+    withSourceCopy $ do
+        r <- cabal' "new-configure" []
+        assertOutputContains "Now overwriting it" r


### PR DESCRIPTION
The new-configure blows away the old `cabal.project.local`, even if
you've tweaked it by hand and it has some sort of substantial changes.
To prevents accidents like this from happening, we should print the old
local file if we overwrite it.

This fixes #3943 .