### PR TITLE
Re-export Dependency from Distribution.Package.

### DIFF
--- a/Cabal/Distribution/Backpack/ComponentsGraph.hs
+++ b/Cabal/Distribution/Backpack/ComponentsGraph.hs
@@ -14,7 +14,6 @@ import Distribution.PackageDescription as PD hiding (Flag)
 import Distribution.Simple.BuildToolDepends
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Types.ComponentRequestedSpec
-import Distribution.Types.Dependency
 import Distribution.Types.UnqualComponentName
 import Distribution.Compat.Graph (Node(..))
 import qualified Distribution.Compat.Graph as Graph

--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -24,6 +24,7 @@ module Distribution.Package
   , module Distribution.Types.Module
   , module Distribution.Types.PackageName
   , module Distribution.Types.PkgconfigName
+  , module Distribution.Types.Dependency
   , Package(..), packageName, packageVersion
   , HasMungedPackageId(..), mungedName', mungedVersion'
   , HasUnitId(..)
@@ -39,6 +40,7 @@ import Distribution.Version
 
 import Distribution.Types.AbiHash
 import Distribution.Types.ComponentId
+import Distribution.Types.Dependency
 import Distribution.Types.MungedPackageId
 import Distribution.Types.PackageId
 import Distribution.Types.UnitId

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -80,7 +80,6 @@ import Distribution.Simple.Program
 import Distribution.Simple.Setup as Setup
 import Distribution.Simple.BuildTarget
 import Distribution.Simple.LocalBuildInfo
-import Distribution.Types.Dependency
 import Distribution.Types.ExeDependency
 import Distribution.Types.LegacyExeDependency
 import Distribution.Types.PkgconfigDependency

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -109,7 +109,6 @@ import Distribution.ModuleName
 import qualified Distribution.InstalledPackageInfo as IPI
 import Distribution.Version
 import Distribution.Simple.Utils
-import Distribution.Types.Dependency
 import Distribution.Types.UnqualComponentName
 
 import Control.Exception (assert)

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -57,7 +57,6 @@ import Distribution.ModuleName
 import Distribution.InstalledPackageInfo
   ( InstalledPackageInfo, exposed )
 import qualified Distribution.Package as P
-import qualified Distribution.Types.Dependency as P
 import Language.Haskell.Extension ( Language(..) )
 
 import Distribution.Client.Init.Types

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -32,7 +32,6 @@ import Distribution.Client.Config
 import Distribution.Solver.Types.ConstraintSource
 
 import Distribution.Package
-import Distribution.Types.Dependency
 import Distribution.PackageDescription
          ( SourceRepo(..), RepoKind(..) 
          , dispFlagAssignment, parseFlagAssignment )

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -103,7 +103,6 @@ import           Distribution.Package hiding
   (InstalledPackageId, installedPackageId)
 import           Distribution.Types.AnnotatedId
 import           Distribution.Types.ComponentName
-import           Distribution.Types.Dependency
 import           Distribution.Types.PkgconfigDependency
 import           Distribution.Types.UnqualComponentName
 import           Distribution.System

--- a/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
@@ -13,7 +13,6 @@ import Distribution.Compiler
 import Distribution.InstalledPackageInfo as IPI
 import Distribution.Package                          -- from Cabal
 import Distribution.Simple.BuildToolDepends          -- from Cabal
-import Distribution.Types.Dependency                 -- from Cabal
 import Distribution.Types.ExeDependency              -- from Cabal
 import Distribution.Types.PkgconfigDependency        -- from Cabal
 import Distribution.Types.ComponentName              -- from Cabal

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -12,7 +12,6 @@ import qualified Data.Map as Map
 import Data.List
 
 import Distribution.Package
-import Distribution.Types.Dependency
 import Distribution.PackageDescription hiding (Flag)
 import Distribution.Compiler
 import Distribution.Version

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -51,7 +51,6 @@ import           Distribution.License (License(..))
 import qualified Distribution.ModuleName                as Module
 import qualified Distribution.Package                   as C
   hiding (HasUnitId(..))
-import qualified Distribution.Types.Dependency          as C
 import qualified Distribution.Types.LegacyExeDependency as C
 import qualified Distribution.Types.PkgconfigDependency as C
 import qualified Distribution.Types.UnqualComponentName as C


### PR DESCRIPTION
Fixes #4404.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>