### PR TITLE
More accurate "registration needed?" calculation for packages.

### DIFF
--- a/Cabal/Distribution/Backpack/Configure.hs
+++ b/Cabal/Distribution/Backpack/Configure.hs
@@ -76,11 +76,11 @@ configureComponentLocalBuildInfos
     prePkgDeps flagAssignment instantiate_with installedPackageSet comp = do
     -- NB: In single component mode, this returns a *single* component.
     -- In this graph, the graph is NOT closed.
-    graph0 <- case toComponentsGraph enabled pkg_descr of
+    graph0 <- case mkComponentsGraph enabled pkg_descr of
                 Left ccycle -> dieProgress (componentCycleMsg ccycle)
-                Right comps -> return comps
+                Right g -> return (componentsGraphToList g)
     infoProgress $ hang (text "Source component graph:") 4
-                        (dispComponentsGraph graph0)
+                        (dispComponentsWithDeps graph0)
 
     let conf_pkg_map = Map.fromListWith Map.union
             [(pc_pkgname pkg,

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -940,7 +940,9 @@ buildAndInstallUnpackedPackage verbosity
             return entryDir
 
           registerPkg
-            | not (elabRequiresRegistration pkg) = return ()
+            | not (elabRequiresRegistration pkg) =
+              debug verbosity $
+                "registerPkg: elab does NOT require registration for " ++ display uid
             | otherwise = do
             -- We register ourselves rather than via Setup.hs. We need to
             -- grab and modify the InstalledPackageInfo. We decide what
@@ -1206,9 +1208,9 @@ buildInplaceUnpackedPackage verbosity
     whenReRegister  action
       = case buildStatus of
           -- We registered the package already
-          BuildStatusBuild (Just _) _     -> return ()
+          BuildStatusBuild (Just _) _     -> info verbosity "whenReRegister: previously registered"
           -- There is nothing to register
-          _ | null (elabBuildTargets pkg) -> return ()
+          _ | null (elabBuildTargets pkg) -> info verbosity "whenReRegister: nothing to register"
             | otherwise                   -> action
 
     configureCommand = Cabal.configureCommand defaultProgramDb

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -301,8 +301,21 @@ elabRequiresRegistration elab =
             case compComponentName comp of
                 Just cn -> is_lib cn && build_target
                 _ -> False
-        ElabPackage _ -> build_target
+        ElabPackage pkg ->
+            -- Tricky! Not only do we have to test if the user selected
+            -- a library as a build target, we also have to test if
+            -- the library was TRANSITIVELY depended upon, since we will
+            -- also require a register in this case.
+            --
+            -- NB: It would have been far nicer to just unconditionally
+            -- register in all cases, but some Custom Setups will fall
+            -- over if you try to do that, ESPECIALLY if there actually is
+            -- a library but they hadn't built it.
+            build_target || any (depends_on_lib pkg) (elabBuildTargets elab)
   where
+    depends_on_lib pkg (ComponentTarget cn _) =
+        not (null (CD.select (== CD.componentNameToComponent cn)
+                             (pkgDependsOnSelfLib pkg)))
     build_target =
         if not (null (elabBuildTargets elab))
             then any is_lib_target (elabBuildTargets elab)
@@ -543,6 +556,13 @@ data ElaboratedPackage
        -- | The exact dependencies (on other plan packages)
        --
        pkgLibDependencies :: ComponentDeps [ConfiguredId],
+
+       -- | Components which depend (transitively) on an internally
+       -- defined library.  These are used by 'elabRequiresRegistration',
+       -- to determine if a user-requested build is going to need
+       -- a library registration
+       --
+       pkgDependsOnSelfLib :: ComponentDeps [()],
 
        -- | Dependencies on executable packages.
        --

--- a/cabal-testsuite/PackageTests/NewBuild/T4450/A.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4450/A.hs
@@ -1,0 +1,1 @@
+module A where

--- a/cabal-testsuite/PackageTests/NewBuild/T4450/Main.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4450/Main.hs
@@ -1,0 +1,1 @@
+main = return ()

--- a/cabal-testsuite/PackageTests/NewBuild/T4450/Setup.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4450/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple
+main :: IO ()
+main = defaultMain

--- a/cabal-testsuite/PackageTests/NewBuild/T4450/T4450.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/T4450/T4450.cabal
@@ -1,0 +1,17 @@
+name: T4450
+version: 1.0
+build-type: Custom
+cabal-version: >= 1.10
+
+library
+    exposed-modules: A
+    build-depends: base
+    default-language: Haskell2010
+
+executable foo
+    main-is: Main.hs
+    build-depends: base, T4450
+    default-language: Haskell2010
+
+custom-setup
+    setup-depends: base, Cabal

--- a/cabal-testsuite/PackageTests/NewBuild/T4450/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/T4450/cabal.out
@@ -1,0 +1,11 @@
+# cabal new-build
+Resolving dependencies...
+In order, the following will be built:
+ - T4450-1.0 (exe:foo) (first run)
+# cabal new-build
+In order, the following will be built:
+ - T4450-1.0 (lib:T4450) (additional components to build)
+ - dep-1.0 (lib) (first run)
+Configuring library for dep-1.0..
+Preprocessing library for dep-1.0..
+Building library for dep-1.0..

--- a/cabal-testsuite/PackageTests/NewBuild/T4450/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/T4450/cabal.project
@@ -1,0 +1,1 @@
+packages: . dep

--- a/cabal-testsuite/PackageTests/NewBuild/T4450/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4450/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+main = cabalTest $ do
+    skipUnless =<< hasNewBuildCompatBootCabal
+    cabal "new-build" ["foo"]
+    cabal "new-build" ["dep"]

--- a/cabal-testsuite/PackageTests/NewBuild/T4450/dep/Dep.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4450/dep/Dep.hs
@@ -1,0 +1,1 @@
+module Dep where

--- a/cabal-testsuite/PackageTests/NewBuild/T4450/dep/dep.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/T4450/dep/dep.cabal
@@ -1,0 +1,9 @@
+name: dep
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    exposed-modules: Dep
+    build-depends: T4450, base
+    default-language: Haskell2010

--- a/cabal-testsuite/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/Test/Cabal/Prelude.hs
@@ -757,6 +757,17 @@ hasCabalForGhc = do
     -- will be picked up by the package db stack of ghc-program
     return (programPath ghc_program == programPath runner_ghc_program)
 
+-- | If you want to use a Custom setup with new-build, it needs to
+-- be 1.20 or later.  Ordinarily, Cabal can go off and build a
+-- sufficiently recent Cabal if necessary, but in our test suite,
+-- by default, we try to avoid doing so (since that involves a
+-- rather lengthy build process), instead using the boot Cabal if
+-- possible.  But some GHCs don't have a recent enough boot Cabal!
+-- You'll want to exclude them in that case.
+--
+hasNewBuildCompatBootCabal :: TestM Bool
+hasNewBuildCompatBootCabal = ghcVersionIs (>= mkVersion [7,9])
+
 ------------------------------------------------------------------------
 -- * Broken tests
 


### PR DESCRIPTION
Previously, we stated that registration was needed if any build target
was a library.  Actually, this is not enough: if we have a build target
on an executable which in turn depends on the library, we must register
it.

To actually get this information, I had to refactor ComponentsGraph to
return the actual *graph*, so I could do a reverse closure on it, giving
me the set of components that actually depend on the library.  That info
then gets plumbed through ElaboratedPackage and then used to determine
if registration is necessary.

Fixes #4450, but it's possible there is another variant of the bug
that occurs if the executable to be built does NOT depend on the
library.

I also needed to add a new hasNewBuildCompatBootCabal helper to the
test suite to check if we can actually build the Custom setup
with the boot Cabal.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>