### PR TITLE
Add an integration test for choosing to build the local version of a package.

### DIFF
--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/Main.hs
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/Main.hs
@@ -1,0 +1,1 @@
+main = putStrLn "local pkg-1.0"

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/cabal.project
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/pkg.cabal
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/pkg.cabal
@@ -1,0 +1,8 @@
+name: pkg
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.2
+
+executable my-exe
+  main-is: Main.hs
+  build-depends: base

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/repo/pkg-1.0/pkg.cabal
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/repo/pkg-1.0/pkg.cabal
@@ -1,0 +1,8 @@
+name: pkg
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.2
+
+executable my-exe
+  main-is: Main.hs
+  build-depends: base

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/repo/pkg-2.0/pkg.cabal
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/repo/pkg-2.0/pkg.cabal
@@ -1,0 +1,8 @@
+name: pkg
+version: 2.0
+build-type: Simple
+cabal-version: >= 1.2
+
+executable my-exe
+  main-is: Main.hs
+  build-depends: base

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/use-local-version-of-package.out
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/use-local-version-of-package.out
@@ -1,0 +1,18 @@
+# cabal update
+Downloading the latest package list from test-local-repo
+# cabal new-build
+Resolving dependencies...
+In order, the following will be built:
+ - pkg-1.0 (exe:my-exe) (first run)
+Configuring pkg-1.0...
+Preprocessing executable 'my-exe' for pkg-1.0..
+Building executable 'my-exe' for pkg-1.0..
+# pkg my-exe
+local pkg-1.0
+# cabal new-build
+Resolving dependencies...
+cabal: Could not resolve dependencies:
+next goal: pkg (user goal)
+rejecting: pkg-2.0 (constraint from user target requires ==1.0)
+rejecting: pkg-1.0 (constraint from command line flag requires ==2.0)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: pkg (3)

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/use-local-version-of-package.test.hs
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/use-local-version-of-package.test.hs
@@ -1,0 +1,15 @@
+import Test.Cabal.Prelude
+
+-- Test that "cabal new-build pkg" builds the local pkg-1.0, which has an exe
+-- that prints a unique message. It should not build 1.0 or 2.0 from the
+-- repository.
+main = cabalTest $ withRepo "repo" $ do
+  cabal "new-build" ["pkg"]
+  withPlan $ do
+    r <- runPlanExe' "pkg" "my-exe" []
+    assertOutputContains "local pkg-1.0" r
+
+  -- cabal shouldn't build a package from the repo, even when given a constraint
+  -- that only matches a non-local package.
+  r <- fails $ cabal' "new-build" ["pkg", "--constraint=pkg==2.0"]
+  assertOutputContains "rejecting: pkg-2.0" r


### PR DESCRIPTION
While I was working on #4481 I noticed that we only test this behavior for internal libraries (PackageTests/BuildDeps/InternalLibrary3/setup.test.hs).