### PR TITLE
Improve error display in top level handler.

### DIFF
--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -369,6 +369,8 @@ annotateIO verbosity = modifyIOError f
           . withMetadata NeverMark VerboseTrace verbosity
           $ ioeGetErrorString ioe
 
+
+{-# NOINLINE topHandlerWith #-}
 topHandlerWith :: forall a. (Exception.SomeException -> IO a) -> IO a -> IO a
 topHandlerWith cont prog = do
     -- By default, stderr to a terminal device is NoBuffering. But this
@@ -402,7 +404,7 @@ topHandlerWith cont prog = do
         Just ioe
          | ioeGetVerbatim ioe ->
             -- Use the message verbatim
-            ioeGetErrorString ioe
+            ioeGetErrorString ioe ++ "\n"
          | isUserError ioe ->
           let file         = case ioeGetFileName ioe of
                                Nothing   -> ""
@@ -413,7 +415,7 @@ topHandlerWith cont prog = do
               detail       = ioeGetErrorString ioe
           in wrapText (pname ++ ": " ++ file ++ detail)
         _ ->
-          displaySomeException se
+          displaySomeException se ++ "\n"
 
 -- | BC wrapper around 'Exception.displayException'.
 displaySomeException :: Exception.Exception e => e -> String
@@ -541,7 +543,7 @@ handleDoesNotExist e =
 wrapTextVerbosity :: Verbosity -> String -> String
 wrapTextVerbosity verb
   | isVerboseNoWrap verb = withTrailingNewline
-  | otherwise            = wrapText
+  | otherwise            = withTrailingNewline . wrapText
 
 -- | Wrap output with a marker if @+markoutput@ verbosity flag is set.
 --


### PR DESCRIPTION
I noticed that in some cases we weren't adding a trailing
newline to error messages arising from "error"; this
patch adds a few newlines where there were none to solve
the problem.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>