### PR TITLE
 Greatly reduce the amount of build product we upload.

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -130,6 +130,18 @@ flag lib
   Default:      False
   manual:       True
 
+-- When we do CI, we build our binaries on one machine, and then
+-- ship them to another machine for testing.  Because we use
+-- static linking (since it makes this sort of redeploy MUCH
+-- easier), if we build five executables, that means we
+-- need to ship ALL the Haskell libraries five times.  That's
+-- a waste of space!  A better strategy is to statically link
+-- everything into a single binary.  That's what this flag does.
+flag monolithic
+  description:  Build cabal-install also with all of its test and support code.  Used by our continuous integration.
+  default:      False
+  manual:       True
+
 library
     ghc-options:    -Wall -fwarn-tabs
     if impl(ghc >= 8.0)
@@ -442,6 +454,38 @@ executable cabal
         if flag(parsec)
           cpp-options: -DCABAL_PARSEC
 
+    if flag(monolithic)
+      hs-source-dirs: tests
+      other-modules:
+        UnitTests
+        MemoryUsageTests
+        SolverQuickCheck
+        IntegrationTests2
+      cpp-options: -DMONOLITHIC
+      build-depends:
+        Cabal      >= 2.1 && < 2.2,
+        QuickCheck >= 2.8.2,
+        array,
+        async,
+        bytestring,
+        containers,
+        deepseq,
+        directory,
+        edit-distance,
+        filepath,
+        mtl,
+        network,
+        network-uri,
+        pretty-show,
+        random,
+        tagged,
+        tar,
+        tasty,
+        tasty-hunit,
+        tasty-quickcheck,
+        time,
+        zlib
+
     if !(arch(arm) && impl(ghc < 7.6))
       ghc-options: -threaded
       
@@ -459,7 +503,7 @@ Test-Suite unit-tests
   type: exitcode-stdio-1.0
   main-is: UnitTests.hs
   hs-source-dirs: tests
-  ghc-options: -Wall -fwarn-tabs
+  ghc-options: -Wall -fwarn-tabs -main-is UnitTests
   other-modules:
     UnitTests.Distribution.Client.ArbitraryInstances
     UnitTests.Distribution.Client.Targets
@@ -519,7 +563,7 @@ Test-Suite memory-usage-tests
   type: exitcode-stdio-1.0
   main-is: MemoryUsageTests.hs
   hs-source-dirs: tests
-  ghc-options: -Wall -fwarn-tabs "-with-rtsopts=-M4M -K1K"
+  ghc-options: -Wall -fwarn-tabs "-with-rtsopts=-M4M -K1K" -main-is MemoryUsageTests
   other-modules:
     UnitTests.Distribution.Solver.Modular.DSL
     UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils
@@ -549,7 +593,7 @@ Test-Suite solver-quickcheck
   type: exitcode-stdio-1.0
   main-is: SolverQuickCheck.hs
   hs-source-dirs: tests
-  ghc-options: -Wall -fwarn-tabs
+  ghc-options: -Wall -fwarn-tabs -main-is=SolverQuickCheck
   other-modules:
     UnitTests.Distribution.Solver.Modular.DSL
     UnitTests.Distribution.Solver.Modular.QuickCheck
@@ -579,7 +623,7 @@ test-suite integration-tests2
   type: exitcode-stdio-1.0
   main-is: IntegrationTests2.hs
   hs-source-dirs: tests
-  ghc-options: -Wall -fwarn-tabs
+  ghc-options: -Wall -fwarn-tabs -main-is IntegrationTests2
   other-modules:
   build-depends:
         base,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -593,7 +593,7 @@ Test-Suite solver-quickcheck
   type: exitcode-stdio-1.0
   main-is: SolverQuickCheck.hs
   hs-source-dirs: tests
-  ghc-options: -Wall -fwarn-tabs -main-is=SolverQuickCheck
+  ghc-options: -Wall -fwarn-tabs -main-is SolverQuickCheck
   other-modules:
     UnitTests.Distribution.Solver.Modular.DSL
     UnitTests.Distribution.Solver.Modular.QuickCheck

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -192,10 +192,33 @@ import Data.Monoid              (Any(..))
 import Control.Exception        (SomeException(..), try)
 import Control.Monad            (mapM_)
 
+#ifdef MONOLITHIC
+import qualified UnitTests
+import qualified MemoryUsageTests
+import qualified SolverQuickCheck
+import qualified IntegrationTests2
+import qualified System.Environment as Monolithic
+#endif
+
 -- | Entry point
 --
 main :: IO ()
+#ifdef MONOLITHIC
 main = do
+    mb_exec <- Monolithic.lookupEnv "CABAL_INSTALL_MONOLITHIC_MODE"
+    case mb_exec of
+        Just "UnitTests"         -> UnitTests.main
+        Just "MemoryUsageTests"  -> MemoryUsageTests.main
+        Just "SolverQuickCheck"  -> SolverQuickCheck.main
+        Just "IntegrationTests2" -> IntegrationTests2.main
+        Just s -> error $ "Unrecognized mode '" ++ show s ++ "' in CABAL_INSTALL_MONOLITHIC_MODE"
+        Nothing -> main'
+#else
+main = main'
+#endif
+
+main' :: IO ()
+main' = do
   -- Enable line buffering so that we can get fast feedback even when piped.
   -- This is especially important for CI and build systems.
   hSetBuffering stdout LineBuffering

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -5,7 +5,7 @@
 -- For the handy instance IsString PackageIdentifier
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Main where
+module IntegrationTests2 where
 
 import Distribution.Client.DistDirLayout
 import Distribution.Client.ProjectConfig

--- a/cabal-install/tests/MemoryUsageTests.hs
+++ b/cabal-install/tests/MemoryUsageTests.hs
@@ -1,4 +1,4 @@
-module Main where
+module MemoryUsageTests where
 
 import Test.Tasty
 

--- a/cabal-install/tests/SolverQuickCheck.hs
+++ b/cabal-install/tests/SolverQuickCheck.hs
@@ -1,4 +1,4 @@
-module Main where
+module SolverQuickCheck where
 
 import Test.Tasty
 

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Main
-       where
+module UnitTests where
 
 import Test.Tasty
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 packages: Cabal/ cabal-testsuite/ cabal-install/
 constraints: unix >= 2.7.1.0,
-             cabal-install +lib
+             cabal-install +lib +monolithic
 
 -- Uncomment to allow picking up extra local unpacked deps:
 --optional-packages: */

--- a/cabal.project.travis
+++ b/cabal.project.travis
@@ -3,6 +3,8 @@
 -- Turn off parallelization to get good errors.
 jobs: 1
 
+constraints: cabal-install +monolithic
+
 -- We vendor a copy of hackage-repo-tool so that we can
 -- build it reliably.  If we eventually get new-install
 -- in the bootstrap, this can go away.

--- a/travis-common.sh
+++ b/travis-common.sh
@@ -3,6 +3,14 @@ set -e
 HACKAGE_REPO_TOOL_VERSION="0.1.1"
 CABAL_VERSION="2.1.0.0"
 
+CABAL_STORE_DB="${HOME}/.cabal/store/ghc-${GHCVER}/package.db"
+CABAL_LOCAL_DB="${TRAVIS_BUILD_DIR}/dist-newstyle/packagedb/ghc-${GHCVER}"
+CABAL_BDIR="${TRAVIS_BUILD_DIR}/dist-newstyle/build/Cabal-${CABAL_VERSION}"
+CABAL_TESTSUITE_BDIR="${TRAVIS_BUILD_DIR}/dist-newstyle/build/cabal-testsuite-${CABAL_VERSION}"
+CABAL_INSTALL_BDIR="${TRAVIS_BUILD_DIR}/dist-newstyle/build/cabal-install-${CABAL_VERSION}"
+CABAL_INSTALL_SETUP="${CABAL_INSTALL_BDIR}/setup/setup"
+HACKAGE_REPO_TOOL_BDIR="${TRAVIS_BUILD_DIR}/dist-newstyle/build/hackage-repo-tool-${HACKAGE_REPO_TOOL_VERSION}"
+
 # ---------------------------------------------------------------------
 # Timing / diagnostic output
 # ---------------------------------------------------------------------

--- a/travis/binaries/.travis.yml
+++ b/travis/binaries/.travis.yml
@@ -16,7 +16,6 @@ before_install:
  - export PATH=/opt/happy/1.19.5/bin:$PATH
  - export PATH=/opt/alex/3.1.7/bin:$PATH
  - ./travis-install.sh
- - mv .cabal $HOME
 script:
     - ./travis-test.sh
 notifications:

--- a/travis/binaries/.travis.yml
+++ b/travis/binaries/.travis.yml
@@ -18,6 +18,8 @@ before_install:
  - ./travis-install.sh
 script:
     - ./travis-test.sh
+after_success:
+    - ./travis-cleanup.sh
 notifications:
   webhooks:
     urls: https://sake-bot.herokuapp.com/

--- a/travis/binaries/travis-cleanup.sh
+++ b/travis/binaries/travis-cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# See travis/upload.sh for more documentation
+
+git remote set-url --push origin git@github.com:haskell-pushbot/cabal-binaries.git
+(umask 177 && cp id_rsa $HOME/.ssh/id_rsa)
+ssh-keyscan github.com >> $HOME/.ssh/known_hosts
+git push origin --delete "$(git rev-parse --abbrev-ref HEAD)"

--- a/travis/binaries/travis-test.sh
+++ b/travis/binaries/travis-test.sh
@@ -2,13 +2,6 @@
 
 . ./travis-common.sh
 
-CABAL_STORE_DB="${HOME}/.cabal/store/ghc-${GHCVER}/package.db"
-CABAL_LOCAL_DB="${PWD}/dist-newstyle/packagedb/ghc-${GHCVER}"
-CABAL_BDIR="${PWD}/dist-newstyle/build/Cabal-${CABAL_VERSION}"
-CABAL_TESTSUITE_BDIR="${PWD}/dist-newstyle/build/cabal-testsuite-${CABAL_VERSION}"
-CABAL_INSTALL_BDIR="${PWD}/dist-newstyle/build/cabal-install-${CABAL_VERSION}"
-CABAL_INSTALL_SETUP="${CABAL_INSTALL_BDIR}/setup/setup"
-HACKAGE_REPO_TOOL_BDIR="${PWD}/dist-newstyle/build/hackage-repo-tool-${HACKAGE_REPO_TOOL_VERSION}"
 # --hide-successes uses terminal control characters which mess up
 # Travis's log viewer.  So just print them all!
 TEST_OPTIONS=""
@@ -17,31 +10,16 @@ TEST_OPTIONS=""
 mkdir -p $(dirname $UPSTREAM_BUILD_DIR)
 ln -s $TRAVIS_BUILD_DIR $UPSTREAM_BUILD_DIR
 
-# Touch package database cache files, so we don't complain they're
-# stale (Git doesn't preserve modification times, so we'll end
-# up with something wrong.)
-touch "$CABAL_STORE_DB/package.cache"
-touch "$CABAL_LOCAL_DB/package.cache"
-
 # Run tests
-(timed ${CABAL_BDIR}/build/unit-tests/unit-tests $TEST_OPTIONS) || exit $?
+(timed Cabal/unit-tests $TEST_OPTIONS) || exit $?
 
    if [ "x$PARSEC" = "xYES" ]; then
        # Parser unit tests
-       (cd Cabal && timed ${CABAL_BDIR}/build/parser-tests/parser-tests $TEST_OPTIONS) || exit $?
+       (cd Cabal && timed ./parser-tests $TEST_OPTIONS) || exit $?
 
        # Test we can parse Hackage
-       (cd Cabal && timed ${CABAL_BDIR}/build/parser-tests/parser-hackage-tests $TEST_OPTIONS) | tail || exit $?
+       (cd Cabal && timed ./parser-hackage-tests $TEST_OPTIONS) | tail || exit $?
    fi
-
-(cd cabal-testsuite && timed ${CABAL_TESTSUITE_BDIR}/build/cabal-tests/cabal-tests --builddir=${CABAL_TESTSUITE_BDIR} -j3 $TEST_OPTIONS) || exit $?
-
-# Redo the package tests with different versions of GHC
-if [ "x$TEST_OTHER_VERSIONS" = "xYES" ]; then
-    (cd cabal-testsuite && timed ${CABAL_TESTSUITE_BDIR}/build/cabal-tests/cabal-tests --builddir=${CABAL_TESTSUITE_BDIR} $TEST_OPTIONS --with-ghc="/opt/ghc/7.0.4/bin/ghc")
-    (cd cabal-testsuite && timed ${CABAL_TESTSUITE_BDIR}/build/cabal-tests/cabal-tests --builddir=${CABAL_TESTSUITE_BDIR} $TEST_OPTIONS --with-ghc="/opt/ghc/7.2.2/bin/ghc")
-    (cd cabal-testsuite && timed ${CABAL_TESTSUITE_BDIR}/build/cabal-tests/cabal-tests --builddir=${CABAL_TESTSUITE_BDIR} $TEST_OPTIONS --with-ghc="/opt/ghc/head/bin/ghc")
-fi
 
 if [ "x$CABAL_LIB_ONLY" = "xYES" ]; then
     exit 0;
@@ -52,15 +30,12 @@ fi
 # ---------------------------------------------------------------------
 
 # Update index
-(timed ${CABAL_INSTALL_BDIR}/build/cabal/cabal update) || exit $?
+(timed cabal-install/cabal update) || exit $?
 
 # Run tests
-(timed ${CABAL_INSTALL_BDIR}/build/unit-tests/unit-tests         $TEST_OPTIONS) || exit $?
-(cd cabal-install && timed ${CABAL_INSTALL_BDIR}/build/solver-quickcheck/solver-quickcheck  $TEST_OPTIONS --quickcheck-tests=1000) || exit $?
-(timed ${CABAL_INSTALL_BDIR}/build/memory-usage-tests/memory-usage-tests $TEST_OPTIONS) || exit $?
+(timed env CABAL_INSTALL_MONOLITHIC_MODE=UnitTests        cabal-install/cabal $TEST_OPTIONS) || exit $?
+(timed env CABAL_INSTALL_MONOLITHIC_MODE=MemoryUsageTests cabal-install/cabal $TEST_OPTIONS) || exit $?
 
 # These need the cabal-install directory
-(cd cabal-install && timed ${CABAL_INSTALL_BDIR}/build/integration-tests2/integration-tests2 $TEST_OPTIONS) || exit $?
-
-# Big tests
-(cd cabal-testsuite && timed ${CABAL_TESTSUITE_BDIR}/build/cabal-tests/cabal-tests --builddir=${CABAL_TESTSUITE_BDIR} -j3 --skip-setup-tests --with-cabal ${CABAL_INSTALL_BDIR}/build/cabal/cabal --with-hackage-repo-tool ${HACKAGE_REPO_TOOL_BDIR}/build/hackage-repo-tool/hackage-repo-tool $TEST_OPTIONS) || exit $?
+(cd cabal-install && timed env CABAL_INSTALL_MONOLITHIC_MODE=SolverQuickCheck  ./cabal $TEST_OPTIONS --quickcheck-tests=1000) || exit $?
+(cd cabal-install && timed env CABAL_INSTALL_MONOLITHIC_MODE=IntegrationTests2 ./cabal $TEST_OPTIONS) || exit $?

--- a/travis/upload.sh
+++ b/travis/upload.sh
@@ -64,6 +64,8 @@ mkdir Cabal
 mkdir cabal-install
 cp -R $TRAVIS_BUILD_DIR/Cabal/tests                                  Cabal
 cp -R $TRAVIS_BUILD_DIR/cabal-install/tests                          cabal-install
+# Copy in credentials so we can delete branch when done
+cp $TRAVIS_BUILD_DIR/id_rsa .
 # Install all of the necessary files for testing
 cp $TRAVIS_BUILD_DIR/travis-install.sh .
 cp $TRAVIS_BUILD_DIR/travis-common.sh .

--- a/travis/upload.sh
+++ b/travis/upload.sh
@@ -65,7 +65,7 @@ mkdir cabal-install
 cp -R $TRAVIS_BUILD_DIR/Cabal/tests                                  Cabal
 cp -R $TRAVIS_BUILD_DIR/cabal-install/tests                          cabal-install
 # Copy in credentials so we can delete branch when done
-cp $TRAVIS_BUILD_DIR/id_rsa .
+cp $TRAVIS_BUILD_DIR/travis/id_rsa .
 # Install all of the necessary files for testing
 cp $TRAVIS_BUILD_DIR/travis-install.sh .
 cp $TRAVIS_BUILD_DIR/travis-common.sh .

--- a/travis/upload.sh
+++ b/travis/upload.sh
@@ -22,10 +22,10 @@ COMMIT=${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT}
 # This is just to help you correlate the build to what it's for
 if [ "x$TRAVIS_PULL_REQUEST" != "xfalse" ]; then
     ORIGIN="${TRAVIS_REPO_SLUG}/pull/$TRAVIS_PULL_REQUEST"
-    URL="https://github.com/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST}"
+    URL="pull/${TRAVIS_PULL_REQUEST}"
 else
     ORIGIN="${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}"
-    URL="https://github.com/${TRAVIS_REPO_SLUG}/commits/${TRAVIS_BRANCH}"
+    URL="commits/${TRAVIS_BRANCH}"
 fi
 
 # Git will complain if these fields don't work when committing,
@@ -59,21 +59,23 @@ if [ "x$GHCVER" = "x7.8.4" ] && [ "x$TRAVIS_OS_NAME" = "xosx" ]; then
     echo "osx_image: xcode6.4" >> .travis.yml
 fi
 
+# Make directory layout
+mkdir Cabal
+mkdir cabal-install
+cp -R $TRAVIS_BUILD_DIR/Cabal/tests                                  Cabal
+cp -R $TRAVIS_BUILD_DIR/cabal-install/tests                          cabal-install
 # Install all of the necessary files for testing
 cp $TRAVIS_BUILD_DIR/travis-install.sh .
 cp $TRAVIS_BUILD_DIR/travis-common.sh .
-cp -R $HOME/.cabal .
-# Index files are too big for Git
-rm -fv .cabal/packages/hackage.haskell.org/00-index*
-rm -fv .cabal/packages/hackage.haskell.org/01-index*
-rm -fv .cabal/packages/hackage.haskell.org/*.json
-cp -R $TRAVIS_BUILD_DIR/dist-newstyle .
-# Test files for test suites that rely on them
-cp -R $TRAVIS_BUILD_DIR/cabal-testsuite .
-mkdir Cabal
-cp -R $TRAVIS_BUILD_DIR/Cabal/tests Cabal
-mkdir cabal-install
-cp -R $TRAVIS_BUILD_DIR/cabal-install/tests cabal-install
+# The binaries to test (statically linked, of course!)
+cp ${CABAL_BDIR}/build/unit-tests/unit-tests                         Cabal
+if [ "x$PARSEC" = "xYES" ]; then
+    cp ${CABAL_BDIR}/build/parser-tests/parser-tests                 Cabal
+    cp ${CABAL_BDIR}/build/parser-hackage-tests/parser-hackage-tests Cabal
+fi
+if [ "x$CABAL_LIB_ONLY" != "xYES" ]; then
+    cp ${CABAL_INSTALL_BDIR}/build/cabal/cabal                       cabal-install
+fi
 
 # Add, commit, push
 git add .


### PR DESCRIPTION
Greatly reduce the amount of build product we upload.

See #4462 for the gory details.

Main things about this commit:

- New 'monolithic' flag on cabal-install, which combines
  all of the tests into a single binary.  It's not very
  much code, and you don't pay for any of it on a release
  build.  I quite like it.  The one downside is that
  we can't also pull in Cabal test suites this way.

- Env vars got moved into travis-common.sh

- travis-script.sh now runs the cabal-tests tests, because
  we aren't sending enough build product over to do them
  on the second Travis run
