### PR TITLE
Set upper bound for unbounded-delays

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,6 @@
 packages: Cabal/ cabal-testsuite/ cabal-install/
 constraints: unix >= 2.7.1.0,
+             unbounded-delays < 0.1.1.0,
              cabal-install +lib
 
 -- Uncomment to allow picking up extra local unpacked deps:


### PR DESCRIPTION
See #4497 for more details. We'll have to set this bound
until tasty fixes the bug.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>