### PR TITLE
Make cabal --host aware.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -280,6 +280,7 @@ instance Semigroup SavedConfig where
         configProgramPathExtra    = lastNonEmptyNL configProgramPathExtra,
         configInstantiateWith     = lastNonEmpty configInstantiateWith,
         configHcFlavor            = combine configHcFlavor,
+        configTarget              = combine configTarget,
         configHcPath              = combine configHcPath,
         configHcPkg               = combine configHcPkg,
         configVanillaLib          = combine configVanillaLib,

--- a/cabal-install/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/Distribution/Client/GlobalFlags.hs
@@ -69,7 +69,7 @@ data GlobalFlags = GlobalFlags {
     globalIgnoreExpiry      :: Flag Bool,    -- ^ Ignore security expiry dates
     globalHttpTransport     :: Flag String,
     globalNix               :: Flag Bool  -- ^ Integrate with Nix
-  } deriving Generic
+  } deriving (Generic, Show)
 
 defaultGlobalFlags :: GlobalFlags
 defaultGlobalFlags  = GlobalFlags {

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -277,6 +277,7 @@ convertLegacyAllPackageFlags globalFlags configFlags
     ConfigFlags {
       configDistPref            = projectConfigDistDir,
       configHcFlavor            = projectConfigHcFlavor,
+      configTarget              = _,
       configHcPath              = projectConfigHcPath,
       configHcPkg               = projectConfigHcPkg,
     --configInstallDirs         = projectConfigInstallDirs,
@@ -546,6 +547,7 @@ convertToLegacyAllPackageConfig
       configProgramArgs         = mempty,
       configProgramPathExtra    = mempty,
       configHcFlavor            = projectConfigHcFlavor,
+      configTarget              = mempty,
       configHcPath              = projectConfigHcPath,
       configHcPkg               = projectConfigHcPkg,
       configInstantiateWith     = mempty,
@@ -613,6 +615,7 @@ convertToLegacyPerPackageConfig PackageConfig {..} =
       configProgramArgs         = Map.toList (getMapMappend packageConfigProgramArgs),
       configProgramPathExtra    = packageConfigProgramPathExtra,
       configHcFlavor            = mempty,
+      configTarget              = mempty,
       configHcPath              = mempty,
       configHcPkg               = mempty,
       configInstantiateWith     = mempty,

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2961,6 +2961,7 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
     configProgramArgs         = Map.toList elabProgramArgs
     configProgramPathExtra    = toNubList elabProgramPathExtra
     configHcFlavor            = toFlag (compilerFlavor pkgConfigCompiler)
+    configTarget              = mempty
     configHcPath              = mempty -- we use configProgramPaths instead
     configHcPkg               = mempty -- we use configProgramPaths instead
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -3060,6 +3060,7 @@ setupHsBuildFlags _ _ verbosity builddir =
       buildProgramArgs  = mempty, --unused, set at configure time
       buildVerbosity    = toFlag verbosity,
       buildDistPref     = toFlag builddir,
+      buildTarget       = mempty,
       buildNumJobs      = mempty, --TODO: [nice to have] sometimes want to use toFlag (Just numBuildJobs),
       buildArgs         = mempty  -- unused, passed via args not flags
     }


### PR DESCRIPTION
This allows to invoke cabal with --target=`aarch64-none-linux-android`, and
will result in the `aarch64-none-linux-android-ghc` being picked. Also the
dist dir will be adjusted. And `--cross-compile` be passed to hsc2hs.

* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

This has been tested by configuring, building and installing the distributive package
(with modified `build-type: Simple`) with `--target=aarch64-apple-darwin14`.