### PR TITLE
Improve exe `scope` docs

### DIFF
--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -114,9 +114,12 @@
 	  Foreign libraries only work with GHC 7.8 and later.
 	* Added a technical preview version of integrated doctest support (#4480).
 	* Added a new 'scope' field to the executable stanza. Executables
-	with 'scope: private' get installed into $libexecsubdir. Private
-	executables are those that are expected to be run by other
-	programs rather than users, like ghc-mod helpers. (#3461)
+	  with 'scope: private' get installed into
+	  $libexecdir/$libexecsubdir. Additionally $libexecdir now has a
+	  subdir structure simmilar to $lib(sub)dir to allow installing
+	  private executables of different packages and package versions
+	  alongside one another.  Private executables are those that are
+	  expected to be run by other programs rather than users. (#3461)
 
 1.24.0.0 Ryan Thomas <ryan@ryant.org> March 2016
 	* Support GHC 8.

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -1248,10 +1248,9 @@ build information fields (see the section on `build information`_).
 
 .. pkg-field:: scope: token
 
-    Whether the executable is public (default) or private, i.e. meant
-    to be run by other programs rather than user (for example, a
-    `ghc-mod` helper). Private executables are installed into
-    `$libexecsubdir`.
+    Whether the executable is ``public`` (default) or ``private``, i.e. meant to
+    be run by other programs rather than the user. Private executables are
+    installed into `$libexecdir/$libexecsubdir`.
 
 Running executables
 """""""""""""""""""

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -658,7 +658,11 @@ path options:
 
 .. option:: --libexecsubdir=dir
 
-    A subdirectory of *libexecdir* in which private executables are installed.
+    A subdirectory of *libexecdir* in which private executables are
+    installed. For example, in the simple build system on Unix, the default
+    *libexecdir* is ``/usr/local/libexec``, and *libsubdir* is
+    ``x86_64-linux-ghc-8.0.2/mypkg-0.1.0``, so private executables would be
+    installed in ``/usr/local/libexec/x86_64-linux-ghc-8.0.2/mypkg-0.1.0/``
 
     *dir* may contain the following path variables: ``$pkgid``,
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -645,12 +645,13 @@ path options:
 
 .. option:: --libsubdir=dir
 
-    A subdirectory of *libdir* in which libraries are actually
-    installed. For example, in the simple build system on Unix, the
-    default *libdir* is ``/usr/local/lib``, and *libsubdir* contains the
-    package identifier and compiler, e.g. ``mypkg-0.2/ghc-6.4``, so
+    A subdirectory of *libdir* in which libraries are actually installed. For
+    example, in the simple build system on Unix, the default *libdir* is
+    ``/usr/local/lib``, and *libsubdir* contains the compiler ABI and package
+    identifier,
+    e.g. ``x86_64-linux-ghc-8.0.2/mypkg-0.1.0-IxQNmCA7qrSEQNkoHSF7A``, so
     libraries would be installed in
-    ``/usr/local/lib/mypkg-0.2/ghc-6.4``.
+    ``/usr/local/lib/x86_64-linux-ghc-8.0.2/mypkg-0.1.0-IxQNmCA7qrSEQNkoHSF7A/``.
 
     *dir* may contain the following path variables: ``$pkgid``,
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,


### PR DESCRIPTION
I clarified that $libexecsubdir is a sub-directory of $libexecdir, added some motivation for the subdir change to the changelog and added an example to the docs.