### PR TITLE
Fix a bug in building local setup dependencies.

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -411,7 +411,8 @@ elabOrderDependencies elab =
 elabOrderLibDependencies :: ElaboratedConfiguredPackage -> [UnitId]
 elabOrderLibDependencies elab =
     case elabPkgOrComp elab of
-        ElabPackage _      -> map (newSimpleUnitId . confInstId) (elabLibDependencies elab)
+        ElabPackage pkg    -> map (newSimpleUnitId . confInstId) $
+                              ordNub $ CD.flatDeps (pkgLibDependencies pkg)
         ElabComponent comp -> compOrderLibDependencies comp
 
 -- | The library dependencies (i.e., the libraries we depend on, NOT

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/pkg/Main.hs
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/pkg/Main.hs
@@ -1,0 +1,3 @@
+import Module (message)
+
+main = putStrLn $ "Main.hs: " ++ message

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/pkg/Setup.hs
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/pkg/Setup.hs
@@ -1,0 +1,4 @@
+import Module (message)
+import Distribution.Simple
+
+main = putStrLn ("Setup.hs: " ++ message) >> defaultMain

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/pkg/pkg.cabal
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/pkg/pkg.cabal
@@ -1,7 +1,7 @@
 name: pkg
 version: 1.0
 build-type: Custom
-cabal-version: >= 1.2
+cabal-version: >= 1.20
 
 custom-setup
   setup-depends: base, Cabal, setup-dep == 2.*
@@ -9,3 +9,4 @@ custom-setup
 executable my-exe
   main-is: Main.hs
   build-depends: base, setup-dep == 1.*
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/pkg/pkg.cabal
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/pkg/pkg.cabal
@@ -1,10 +1,11 @@
 name: pkg
 version: 1.0
 build-type: Custom
-cabal-version: >= 1.24
+cabal-version: >= 1.2
 
 custom-setup
-  setup-depends: setup-dep == 2.*
+  setup-depends: base, Cabal, setup-dep == 2.*
 
-library
-  build-depends: setup-dep == 1.*
+executable my-exe
+  main-is: Main.hs
+  build-depends: base, setup-dep == 1.*

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/repo/setup-dep-1.0/Module.hs
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/repo/setup-dep-1.0/Module.hs
@@ -1,0 +1,3 @@
+module Module (message) where
+
+message = "setup-dep from repo"

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/repo/setup-dep-1.0/setup-dep.cabal
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/repo/setup-dep-1.0/setup-dep.cabal
@@ -1,8 +1,9 @@
 name: setup-dep
 version: 1.0
 build-type: Simple
-cabal-version: >= 1.2
+cabal-version: >= 1.20
 
 library
   build-depends: base
   exposed-modules: Module
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/repo/setup-dep-1.0/setup-dep.cabal
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/repo/setup-dep-1.0/setup-dep.cabal
@@ -4,3 +4,5 @@ build-type: Simple
 cabal-version: >= 1.2
 
 library
+  build-depends: base
+  exposed-modules: Module

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/setup-dep/Module.hs
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/setup-dep/Module.hs
@@ -1,0 +1,3 @@
+module Module (message) where
+
+message = "setup-dep from project"

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/setup-dep/setup-dep.cabal
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/setup-dep/setup-dep.cabal
@@ -1,8 +1,9 @@
 name: setup-dep
 version: 2.0
 build-type: Simple
-cabal-version: >= 1.2
+cabal-version: >= 1.20
 
 library
   build-depends: base
   exposed-modules: Module
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/setup-dep/setup-dep.cabal
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/setup-dep/setup-dep.cabal
@@ -4,3 +4,5 @@ build-type: Simple
 cabal-version: >= 1.2
 
 library
+  build-depends: base
+  exposed-modules: Module

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.out
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.out
@@ -12,14 +12,14 @@ After searching the rest of the dependency tree exhaustively, these were the goa
 # cabal new-build
 Resolving dependencies...
 In order, the following will be built:
- - setup-dep-1.0 (lib:setup-dep) (requires download & build)
- - setup-dep-2.0 (lib:setup-dep) (first run)
+ - setup-dep-1.0 (lib) (requires download & build)
+ - setup-dep-2.0 (lib) (first run)
  - pkg-1.0 (exe:my-exe) (first run)
-Configuring setup-dep-1.0...
+Configuring library for setup-dep-1.0..
 Preprocessing library for setup-dep-1.0..
 Building library for setup-dep-1.0..
 Installing library in <PATH>
-Configuring setup-dep-2.0...
+Configuring library for setup-dep-2.0..
 Preprocessing library for setup-dep-2.0..
 Building library for setup-dep-2.0..
 # pkg my-exe

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.out
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.out
@@ -8,10 +8,19 @@ next goal: setup-dep (user goal)
 rejecting: setup-dep-2.0 (conflict: pkg => setup-dep==1.*)
 rejecting: setup-dep-1.0 (constraint from user target requires ==2.0)
 fail (backjumping, conflict set: pkg, setup-dep)
-After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: setup-dep (3), pkg (2)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: pkg (4), setup-dep (3)
 # cabal new-build
 Resolving dependencies...
-In order, the following would be built:
+In order, the following will be built:
  - setup-dep-1.0 (lib:setup-dep) (requires download & build)
- - setup-dep-2.0 (first run)
- - pkg-1.0 (lib:pkg) (first run)
+ - setup-dep-2.0 (lib:setup-dep) (first run)
+ - pkg-1.0 (exe:my-exe) (first run)
+Configuring setup-dep-1.0...
+Preprocessing library for setup-dep-1.0..
+Building library for setup-dep-1.0..
+Installing library in <PATH>
+Configuring setup-dep-2.0...
+Preprocessing library for setup-dep-2.0..
+Building library for setup-dep-2.0..
+# pkg my-exe
+Main.hs: setup-dep from repo

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.test.hs
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.test.hs
@@ -10,6 +10,12 @@ import Test.Cabal.Prelude
 -- qualifier as pkg, even though they are both build targets of the project.
 -- The solution must use --independent-goals to give pkg and setup-dep different
 -- qualifiers.
-main = cabalTest $ withRepo "repo" $ do
-  fails $ cabal "new-build" ["pkg", "--dry-run"]
-  cabal "new-build" ["pkg", "--dry-run", "--independent-goals"]
+main = cabalTest $ do
+  skipUnless =<< hasNewBuildCompatBootCabal
+  withRepo "repo" $ do
+    fails $ cabal "new-build" ["pkg:my-exe", "--dry-run"]
+    r1 <- cabal' "new-build" ["pkg:my-exe", "--independent-goals"]
+    assertOutputContains "Setup.hs: setup-dep from project" r1
+    withPlan $ do
+      r2 <- runPlanExe' "pkg" "my-exe" []
+      assertOutputContains "Main.hs: setup-dep from repo" r2

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/Setup.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/Setup.hs
@@ -1,0 +1,4 @@
+import SetupDep (message)
+import Distribution.Simple
+
+main = putStrLn ("pkg Setup.hs: " ++ message) >> defaultMain

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/build-local-package-with-custom-setup.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/build-local-package-with-custom-setup.out
@@ -3,9 +3,9 @@ Downloading the latest package list from test-local-repo
 # cabal new-build
 Resolving dependencies...
 In order, the following will be built:
- - setup-dep-2.0 (lib:setup-dep) (requires download & build)
+ - setup-dep-2.0 (lib) (requires download & build)
  - pkg-1.0 (lib:pkg) (first run)
-Configuring setup-dep-2.0...
+Configuring library for setup-dep-2.0..
 Preprocessing library for setup-dep-2.0..
 Building library for setup-dep-2.0..
 Installing library in <PATH>

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/build-local-package-with-custom-setup.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/build-local-package-with-custom-setup.out
@@ -1,0 +1,11 @@
+# cabal update
+Downloading the latest package list from test-local-repo
+# cabal new-build
+Resolving dependencies...
+In order, the following will be built:
+ - setup-dep-2.0 (lib:setup-dep) (requires download & build)
+ - pkg-1.0 (lib:pkg) (first run)
+Configuring setup-dep-2.0...
+Preprocessing library for setup-dep-2.0..
+Building library for setup-dep-2.0..
+Installing library in <PATH>

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/build-local-package-with-custom-setup.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/build-local-package-with-custom-setup.test.hs
@@ -1,0 +1,11 @@
+import Test.Cabal.Prelude
+
+-- The one local package, pkg, has a setup dependency on setup-dep-2.0, which is
+-- in the repository.
+main = cabalTest $ do
+  skipUnless =<< hasNewBuildCompatBootCabal
+  withRepo "repo" $ do
+    r <- cabal' "new-build" ["pkg"]
+    -- pkg's setup script should print out a message that it imported from
+    -- setup-dep:
+    assertOutputContains "pkg Setup.hs: setup-dep-2.0" r

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/cabal.project
@@ -1,0 +1,1 @@
+packages: *.cabal

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/pkg.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/pkg.cabal
@@ -1,7 +1,7 @@
 name: pkg
 version: 1.0
 build-type: Custom
-cabal-version: >= 1.2
+cabal-version: >= 1.20
 
 custom-setup
   setup-depends: base, Cabal, setup-dep

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/pkg.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/pkg.cabal
@@ -1,0 +1,9 @@
+name: pkg
+version: 1.0
+build-type: Custom
+cabal-version: >= 1.2
+
+custom-setup
+  setup-depends: base, Cabal, setup-dep
+
+library

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/repo/setup-dep-2.0/SetupDep.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/repo/setup-dep-2.0/SetupDep.hs
@@ -1,0 +1,3 @@
+module SetupDep (message) where
+
+message = "setup-dep-2.0"

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/repo/setup-dep-2.0/setup-dep.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/repo/setup-dep-2.0/setup-dep.cabal
@@ -1,8 +1,9 @@
 name: setup-dep
 version: 2.0
 build-type: Simple
-cabal-version: >= 1.2
+cabal-version: >= 1.20
 
 library
   build-depends: base
   exposed-modules: SetupDep
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/repo/setup-dep-2.0/setup-dep.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/repo/setup-dep-2.0/setup-dep.cabal
@@ -1,0 +1,8 @@
+name: setup-dep
+version: 2.0
+build-type: Simple
+cabal-version: >= 1.2
+
+library
+  build-depends: base
+  exposed-modules: SetupDep

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/Main.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/Main.hs
@@ -1,0 +1,3 @@
+import RemotePkg (message)
+
+main = putStrLn $ "pkg Main.hs: " ++ message

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/build-package-from-repo-with-custom-setup.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/build-package-from-repo-with-custom-setup.out
@@ -3,10 +3,10 @@ Downloading the latest package list from test-local-repo
 # cabal new-build
 Resolving dependencies...
 In order, the following will be built:
- - remote-setup-dep-3.0 (lib:remote-setup-dep) (requires download & build)
+ - remote-setup-dep-3.0 (lib) (requires download & build)
  - remote-pkg-2.0 (lib:remote-pkg) (requires download & build)
  - pkg-1.0 (exe:my-exe) (first run)
-Configuring remote-setup-dep-3.0...
+Configuring library for remote-setup-dep-3.0..
 Preprocessing library for remote-setup-dep-3.0..
 Building library for remote-setup-dep-3.0..
 Installing library in <PATH>

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/build-package-from-repo-with-custom-setup.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/build-package-from-repo-with-custom-setup.out
@@ -1,0 +1,17 @@
+# cabal update
+Downloading the latest package list from test-local-repo
+# cabal new-build
+Resolving dependencies...
+In order, the following will be built:
+ - remote-setup-dep-3.0 (lib:remote-setup-dep) (requires download & build)
+ - remote-pkg-2.0 (lib:remote-pkg) (requires download & build)
+ - pkg-1.0 (exe:my-exe) (first run)
+Configuring remote-setup-dep-3.0...
+Preprocessing library for remote-setup-dep-3.0..
+Building library for remote-setup-dep-3.0..
+Installing library in <PATH>
+Configuring executable 'my-exe' for pkg-1.0..
+Preprocessing executable 'my-exe' for pkg-1.0..
+Building executable 'my-exe' for pkg-1.0..
+# pkg my-exe
+pkg Main.hs: remote-pkg-2.0

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/build-package-from-repo-with-custom-setup.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/build-package-from-repo-with-custom-setup.test.hs
@@ -1,0 +1,15 @@
+import Test.Cabal.Prelude
+
+-- The one local package, pkg, has a dependency on remote-pkg-2.0, which has a
+-- setup dependency on remote-setup-dep-3.0.
+main = cabalTest $ do
+  skipUnless =<< hasNewBuildCompatBootCabal
+  withRepo "repo" $ do
+    r1 <- cabal' "new-build" ["pkg:my-exe"]
+    -- remote-pkg's setup script should print out a message that it imported from
+    -- remote-setup-dep:
+    assertOutputContains "remote-pkg Setup.hs: remote-setup-dep-3.0" r1
+    withPlan $ do
+      r2 <- runPlanExe' "pkg" "my-exe" []
+      -- pkg's executable should print a message that it imported from remote-pkg:
+      assertOutputContains "pkg Main.hs: remote-pkg-2.0" r2

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/cabal.project
@@ -1,0 +1,1 @@
+packages: *.cabal

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/pkg.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/pkg.cabal
@@ -1,7 +1,7 @@
 name: pkg
 version: 1.0
 build-type: Simple
-cabal-version: >= 1.2
+cabal-version: >= 1.20
 
 executable my-exe
   main-is: Main.hs

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/pkg.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/pkg.cabal
@@ -1,0 +1,9 @@
+name: pkg
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.2
+
+executable my-exe
+  main-is: Main.hs
+  build-depends: base, remote-pkg
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-pkg-2.0/RemotePkg.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-pkg-2.0/RemotePkg.hs
@@ -1,0 +1,3 @@
+module RemotePkg (message) where
+
+message = "remote-pkg-2.0"

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-pkg-2.0/Setup.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-pkg-2.0/Setup.hs
@@ -1,0 +1,4 @@
+import Distribution.Simple
+import RemoteSetupDep (message)
+
+main = putStrLn ("remote-pkg Setup.hs: " ++ message) >> defaultMain

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-pkg-2.0/remote-pkg.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-pkg-2.0/remote-pkg.cabal
@@ -1,7 +1,7 @@
 name: remote-pkg
 version: 2.0
 build-type: Custom
-cabal-version: >= 1.2
+cabal-version: >= 1.20
 
 custom-setup
   setup-depends: base, Cabal, remote-setup-dep
@@ -9,3 +9,4 @@ custom-setup
 library
   build-depends: base
   exposed-modules: RemotePkg
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-pkg-2.0/remote-pkg.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-pkg-2.0/remote-pkg.cabal
@@ -1,0 +1,11 @@
+name: remote-pkg
+version: 2.0
+build-type: Custom
+cabal-version: >= 1.2
+
+custom-setup
+  setup-depends: base, Cabal, remote-setup-dep
+
+library
+  build-depends: base
+  exposed-modules: RemotePkg

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-setup-dep-3.0/RemoteSetupDep.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-setup-dep-3.0/RemoteSetupDep.hs
@@ -1,0 +1,3 @@
+module RemoteSetupDep (message) where
+
+message = "remote-setup-dep-3.0"

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-setup-dep-3.0/remote-setup-dep.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-setup-dep-3.0/remote-setup-dep.cabal
@@ -1,8 +1,9 @@
 name: remote-setup-dep
 version: 3.0
 build-type: Simple
-cabal-version: >= 1.2
+cabal-version: >= 1.20
 
 library
   build-depends: base
   exposed-modules: RemoteSetupDep
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-setup-dep-3.0/remote-setup-dep.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/repo/remote-setup-dep-3.0/remote-setup-dep.cabal
@@ -1,0 +1,8 @@
+name: remote-setup-dep
+version: 3.0
+build-type: Simple
+cabal-version: >= 1.2
+
+library
+  build-depends: base
+  exposed-modules: RemoteSetupDep

--- a/cabal-testsuite/Test/Cabal/Plan.hs
+++ b/cabal-testsuite/Test/Cabal/Plan.hs
@@ -19,12 +19,14 @@ data Plan = Plan { planInstallPlan :: [InstallItem] }
 
 data InstallItem
     = APreExisting
-    | AConfigured Configured
+    | AConfiguredGlobal
+    | AConfiguredInplace ConfiguredInplace
 
-data Configured = Configured
-    { configuredDistDir       :: FilePath
-    , configuredPackageName   :: PackageName
-    , configuredComponentName :: Maybe ComponentName }
+-- local or inplace package
+data ConfiguredInplace = ConfiguredInplace
+    { configuredInplaceDistDir       :: FilePath
+    , configuredInplacePackageName   :: PackageName
+    , configuredInplaceComponentName :: Maybe ComponentName }
 
 instance FromJSON Plan where
     parseJSON (Object v) = fmap Plan (v .: "install-plan")
@@ -35,17 +37,23 @@ instance FromJSON InstallItem where
         t <- v .: "type"
         case t :: String of
             "pre-existing" -> return APreExisting
-            "configured"   -> AConfigured `fmap` parseJSON obj
+            "configured"   -> do
+                s <- v .: "style"
+                case s :: String of
+                  "global"  -> return AConfiguredGlobal
+                  "inplace" -> AConfiguredInplace `fmap` parseJSON obj
+                  "local"   -> AConfiguredInplace `fmap` parseJSON obj
+                  _         -> fail $ "unrecognized value of 'style' field: " ++ s
             _              -> fail "unrecognized value of 'type' field"
     parseJSON invalid = typeMismatch "InstallItem" invalid
 
-instance FromJSON Configured where
+instance FromJSON ConfiguredInplace where
     parseJSON (Object v) = do
         dist_dir <- v .: "dist-dir"
         pkg_name <- v .: "pkg-name"
         component_name <- v .:? "component-name"
-        return (Configured dist_dir pkg_name component_name)
-    parseJSON invalid = typeMismatch "Configured" invalid
+        return (ConfiguredInplace dist_dir pkg_name component_name)
+    parseJSON invalid = typeMismatch "ConfiguredInplace" invalid
 
 instance FromJSON PackageName where
     parseJSON (String t) = return (mkPackageName (Text.unpack t))
@@ -63,15 +71,17 @@ planDistDir :: Plan -> PackageName -> ComponentName -> FilePath
 planDistDir plan pkg_name cname =
     case concatMap p (planInstallPlan plan) of
         [x] -> x
-        []  -> error $ "planDistDir: could not find component " ++ display cname
-                    ++ " of package " ++ display pkg_name ++ " in install plan"
+        []  -> error $ "planDistDir: component " ++ display cname
+                    ++ " of package " ++ display pkg_name ++ " either does not"
+                    ++ " exist in the install plan or does not have a dist-dir"
         _   -> error $ "planDistDir: found multiple copies of component " ++ display cname
                     ++ " of package " ++ display pkg_name ++ " in install plan"
   where
-    p APreExisting = []
-    p (AConfigured conf) = do
-        guard (configuredPackageName conf == pkg_name)
-        guard $ case configuredComponentName conf of
+    p APreExisting      = []
+    p AConfiguredGlobal = []
+    p (AConfiguredInplace conf) = do
+        guard (configuredInplacePackageName conf == pkg_name)
+        guard $ case configuredInplaceComponentName conf of
                     Nothing     -> True
                     Just cname' -> cname == cname'
-        return (configuredDistDir conf)
+        return (configuredInplaceDistDir conf)


### PR DESCRIPTION
I tried to make the integration test from #4481 ([PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.test.hs](https://github.com/haskell/cabal/blob/81396cd1d3eb3af73cbea23526b61c5908dc44c2/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.test.hs)) more thorough by removing --dry-run from the build command, and I ran into a bug.  The bug prevented cabal from building local packages if they were only needed as setup dependencies.  That meant that cabal didn't build the library for setup-dep-2.0 in the test.

Changes in this PR:
- Fix the bug by modifying D.C.ProjectPlanning.Types.elabOrderLibDependencies.
- Support parsing global packages in plan.json in cabal-testsuite/Test/Cabal/Plan.hs to allow the test to pass.
- Remove --dry-run from the test added in #4481.
- Add two more tests for setup dependencies.  I couldn't find any integration tests that build setup dependencies from a repository using new-build, but let me know if I missed any.

I'm not sure if this is the right way to fix these issues.

/cc @ezyang 