### PR TITLE
Implement +timestamp verbosity flag

### DIFF
--- a/Cabal/Distribution/Verbosity.hs
+++ b/Cabal/Distribution/Verbosity.hs
@@ -42,7 +42,10 @@ module Distribution.Verbosity (
 
   -- * line-wrapping
   verboseNoWrap, isVerboseNoWrap,
- ) where
+
+  -- * timestamps
+  verboseTimestamp, isVerboseTimestamp
+  ) where
 
 import Prelude ()
 import Distribution.Compat.Prelude
@@ -152,6 +155,7 @@ parseVerbosity = parseIntVerbosity <++ parseStringVerbosity
         , string "callstack" >> return verboseCallStack
         , string "nowrap"    >> return verboseNoWrap
         , string "markoutput" >> return verboseMarkOutput
+        , string "timestamp" >> return verboseTimestamp
         ]
 
 flagToVerbosity :: ReadE Verbosity
@@ -183,6 +187,7 @@ showForCabal v
     showFlag VCallStack  = ["+callstack"]
     showFlag VNoWrap     = ["+nowrap"]
     showFlag VMarkOutput = ["+markoutput"]
+    showFlag VTimestamp  = ["+timestamp"]
 showForGHC   v = maybe (error "unknown verbosity") show $
     elemIndex v [silent,normal,__,verbose,deafening]
         where __ = silent -- this will be always ignored by elemIndex
@@ -192,6 +197,7 @@ data VerbosityFlag
     | VCallSite
     | VNoWrap
     | VMarkOutput
+    | VTimestamp
     deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded)
 
 instance Binary VerbosityFlag
@@ -220,6 +226,10 @@ verboseNoWrap = verboseFlag VNoWrap
 -- | Mark the verbosity as quiet
 verboseQuiet :: Verbosity -> Verbosity
 verboseQuiet v = v { vQuiet = True }
+
+-- | Turn on timestamps for log messages.
+verboseTimestamp :: Verbosity -> Verbosity
+verboseTimestamp = verboseFlag VTimestamp
 
 -- | Helper function for flag toggling functions
 verboseFlag :: VerbosityFlag -> (Verbosity -> Verbosity)
@@ -250,6 +260,10 @@ isVerboseNoWrap = isVerboseFlag VNoWrap
 -- | Test if we had called 'lessVerbose' on the verbosity
 isVerboseQuiet :: Verbosity -> Bool
 isVerboseQuiet = vQuiet
+
+-- | Test if if we should output timestamps when we log.
+isVerboseTimestamp :: Verbosity -> Bool
+isVerboseTimestamp = isVerboseFlag VTimestamp
 
 -- | Helper function for flag testing functions.
 isVerboseFlag :: VerbosityFlag -> Verbosity -> Bool


### PR DESCRIPTION
This prepends a posix timestamp (with milliseconds precision) to log
messages (before any wrapping is applied)

Example output:

    $ cabal update --verbose=verbose+timestamp
    1478941945.027 Downloading the latest package list from hackage.haskell.org
    1478941945.029 Selected mirror http://hackage.haskell.org/
    1478941945.036 Downloading timestamp
    ...

    $ cabal --verbose=normal+timestamp new-build --dry --enable-tests
    1478947448.519 Resolving dependencies...
    1478947450.887 In order, the following would be built (use -v for more details):
                    - Cabal-1.25.0.0 (lib) (configuration changed)
                    - hackage-security-0.5.2.2 (lib) (dependency rebuilt)
                    - cabal-testsuite-1.25.0.0 (test:package-tests) (dependency rebuilt)
                    - Cabal-1.25.0.0 (test:unit-tests) (dependency rebuilt)
                    - cabal-install-1.25.0.0 (exe:cabal, test:integration-tests, test:integration-tests2, test:solver-quickcheck, test:unit-tests) (configuration changed)

This is quite useful for debugging & profiling cabal, as well as for
buildbots (such as matrix.hho) which want to record timings in their
buildlogs for later analysis.

This is the 2nd attempt to (re)implement PR #4103 which suffered severe bitrot