### PR TITLE
Filter `+timestamp` out when invoking Cabal-2.0.0 custom-setups

### DIFF
--- a/Cabal/Distribution/Verbosity.hs
+++ b/Cabal/Distribution/Verbosity.hs
@@ -44,7 +44,8 @@ module Distribution.Verbosity (
   verboseNoWrap, isVerboseNoWrap,
 
   -- * timestamps
-  verboseTimestamp, isVerboseTimestamp
+  verboseTimestamp, isVerboseTimestamp,
+  verboseNoTimestamp,
   ) where
 
 import Prelude ()
@@ -217,7 +218,7 @@ verboseMarkOutput = verboseFlag VMarkOutput
 
 -- | Turn off marking; useful for suppressing nondeterministic output.
 verboseUnmarkOutput :: Verbosity -> Verbosity
-verboseUnmarkOutput v = v { vFlags = Set.delete VMarkOutput (vFlags v) }
+verboseUnmarkOutput = verboseNoFlag VMarkOutput
 
 -- | Disable line-wrapping for log messages.
 verboseNoWrap :: Verbosity -> Verbosity
@@ -231,10 +232,19 @@ verboseQuiet v = v { vQuiet = True }
 verboseTimestamp :: Verbosity -> Verbosity
 verboseTimestamp = verboseFlag VTimestamp
 
--- | Helper function for flag toggling functions
+-- | Turn off timestamps for log messages.
+verboseNoTimestamp :: Verbosity -> Verbosity
+verboseNoTimestamp = verboseNoFlag VTimestamp
+
+-- | Helper function for flag enabling functions
 verboseFlag :: VerbosityFlag -> (Verbosity -> Verbosity)
 verboseFlag flag v = v { vFlags = Set.insert flag (vFlags v) }
 
+-- | Helper function for flag disabling functions
+verboseNoFlag :: VerbosityFlag -> (Verbosity -> Verbosity)
+verboseNoFlag flag v = v { vFlags = Set.delete flag (vFlags v) }
+
+-- | Turn off all flags
 verboseNoFlags :: Verbosity -> Verbosity
 verboseNoFlags v = v { vFlags = Set.empty }
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -115,7 +115,7 @@ import qualified Distribution.Compat.ReadP as Parse
 import Distribution.ParseUtils
          ( readPToMaybe )
 import Distribution.Verbosity
-         ( Verbosity, lessVerbose, normal, verboseNoFlags )
+         ( Verbosity, lessVerbose, normal, verboseNoFlags, verboseNoTimestamp )
 import Distribution.Simple.Utils
          ( wrapText, wrapLine )
 import Distribution.Client.GlobalFlags
@@ -395,7 +395,7 @@ filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
   -- NB: we expect the latest version to be the most common case,
   -- so test it first.
-  | cabalLibVersion >= mkVersion [1,25,0] = flags_latest
+  | cabalLibVersion >= mkVersion [2,1,0]  = flags_latest
   -- The naming convention is that flags_version gives flags with
   -- all flags *introduced* in version eliminated.
   -- It is NOT the latest version of Cabal library that
@@ -412,6 +412,7 @@ filterConfigureFlags flags cabalLibVersion
   | cabalLibVersion < mkVersion [1,22,0] = flags_1_22_0
   | cabalLibVersion < mkVersion [1,23,0] = flags_1_23_0
   | cabalLibVersion < mkVersion [1,25,0] = flags_1_25_0
+  | cabalLibVersion < mkVersion [2,1,0]  = flags_2_1_0
   | otherwise = flags_latest
   where
     flags_latest = flags        {
@@ -419,11 +420,16 @@ filterConfigureFlags flags cabalLibVersion
       configConstraints = []
       }
 
-    flags_1_25_0 = flags_latest {
+    flags_2_1_0 = flags_latest {
+      -- Cabal < 2.1 doesn't know about -v +timestamp modifier
+      configVerbosity   = fmap verboseNoTimestamp (configVerbosity flags_latest)
+      }
+
+    flags_1_25_0 = flags_2_1_0 {
       -- Cabal < 1.25.0 doesn't know about --dynlibdir.
       configInstallDirs = configInstallDirs_1_25_0,
       -- Cabal < 1.25 doesn't have extended verbosity syntax
-      configVerbosity   = fmap verboseNoFlags (configVerbosity flags_latest),
+      configVerbosity   = fmap verboseNoFlags (configVerbosity flags_2_1_0),
       -- Cabal < 1.25 doesn't support --deterministic
       configDeterministic = mempty
       }

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -365,7 +365,7 @@ runSetup verbosity setup args0 = do
 -- verbosity applies to ALL commands.
 verbosityHack :: Version -> [String] -> [String]
 verbosityHack ver args0
-    | ver >= mkVersion [1,25] = args0
+    | ver >= mkVersion [2,1]  = args0
     | otherwise = go args0
   where
     go (('-':'v':rest) : args)
@@ -380,11 +380,15 @@ verbosityHack ver args0
 
     munch rest =
         case runReadE flagToVerbosity rest of
-            Right v | verboseHasFlags v
+            Right v
+              | ver < mkVersion [2,0], verboseHasFlags v
               -- We could preserve the prefix, but since we're assuming
               -- it's Cabal's verbosity flag, we can assume that
               -- any format is OK
               -> Just (showForCabal (verboseNoFlags v))
+              | ver < mkVersion [2,1], isVerboseTimestamp v
+              -- +timestamp wasn't yet available in Cabal-2.0.0
+              -> Just (showForCabal (verboseNoTimestamp v))
             _ -> Nothing
 
 -- | Run a command through a configured 'Setup'.


### PR DESCRIPTION
This is is a follow-up to #4518 