### PR TITLE
Pass other-modules to `ghc --make` for exe components

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -977,7 +977,7 @@ gbuildSources tmpDir bm =
     exeSources exe@Executable{buildInfo = bnfo, modulePath = modPath} = do
       main <- findFile (tmpDir : hsSourceDirs bnfo) modPath
       return $ if isHaskell main
-                 then (cSources bnfo        , [main] , []            )
+                 then (cSources bnfo        , [main] , exeModules exe)
                  else (main : cSources bnfo , []     , exeModules exe)
 
     flibSources :: ForeignLib -> ([FilePath], [FilePath], [ModuleName])


### PR DESCRIPTION
`gbuildSources` was introduced by a refactoring in
382143aa7322605d1a9f0480e383490e186c7ea0 but there
doesn't appear to be a good reason why the modules are
only passed for a non-haskell main module.

So this patch consistently passes `other-modules` to
`ghc --make` for both variants of executables.

Addresses part of #4528