### PR TITLE
Pass -Wmissing-home-modules to all component types

### DIFF
--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -316,12 +316,7 @@ componentGhcOptions verbosity implInfo lbi bi clbi odir =
         _ -> [],
       ghcOptNoCode          = toFlag $ componentIsIndefinite clbi,
       ghcOptHideAllPackages = toFlag True,
-      ghcOptWarnMissingHomeModules = case clbi of
-        LibComponentLocalBuildInfo{} ->
-          if flagWarnMissingHomeModules implInfo
-            then toFlag True
-            else mempty
-        _ -> mempty,
+      ghcOptWarnMissingHomeModules = toFlag $ flagWarnMissingHomeModules implInfo,
       ghcOptPackageDBs      = withPackageDB lbi,
       ghcOptPackages        = toNubListR $ mkGhcOptPackages clbi,
       ghcOptSplitObjs       = toFlag (splitObjs lbi),


### PR DESCRIPTION
i.e. not only library components, but also executables, tests and benchmarks.

(With GHC-8.2.1 snapshot 8.2.0.20170521 or earlier, this emits a harmless warning about `Main`;
the next upcoming snapshot build of GHC-8.2.1 will already omit the spurious warning)

This addresses the other half of #4528