### PR TITLE
Move Distribution.Client.Compat.Prelude to Distribution.Compat.Prelude

### DIFF
--- a/cabal-install/Distribution/Solver/Compat/Prelude.hs
+++ b/cabal-install/Distribution/Solver/Compat/Prelude.hs
@@ -1,0 +1,19 @@
+-- to suppress WARNING in "Distribution.Compat.Prelude.Internal"
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+
+-- | This module does two things:
+--
+-- * Acts as a compatiblity layer, like @base-compat@.
+--
+-- * Provides commonly used imports.
+--
+-- This module is a superset of "Distribution.Compat.Prelude" (which
+-- this module re-exports)
+--
+module Distribution.Solver.Compat.Prelude
+  ( module Distribution.Compat.Prelude.Internal
+  , Prelude.IO
+  ) where
+
+import Prelude (IO)
+import Distribution.Compat.Prelude.Internal hiding (IO)

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -5,7 +5,7 @@ module Distribution.Solver.Modular.Linking (
   ) where
 
 import Prelude ()
-import Distribution.Client.Compat.Prelude hiding (get,put)
+import Distribution.Solver.Compat.Prelude hiding (get,put)
 
 import Control.Exception (assert)
 import Control.Monad.Reader

--- a/cabal-install/Distribution/Solver/Modular/Log.hs
+++ b/cabal-install/Distribution/Solver/Modular/Log.hs
@@ -4,7 +4,7 @@ module Distribution.Solver.Modular.Log
     ) where
 
 import Prelude ()
-import Distribution.Client.Compat.Prelude
+import Distribution.Solver.Compat.Prelude
 
 import Data.List as L
 

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -17,7 +17,7 @@ module Distribution.Solver.Modular.Preference
     ) where
 
 import Prelude ()
-import Distribution.Client.Compat.Prelude
+import Distribution.Solver.Compat.Prelude
 
 import Data.Function (on)
 import qualified Data.List as L

--- a/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
@@ -38,7 +38,7 @@ module Distribution.Solver.Types.ComponentDeps (
 
 import Prelude ()
 import Distribution.Types.UnqualComponentName
-import Distribution.Client.Compat.Prelude hiding (empty,zip)
+import Distribution.Solver.Compat.Prelude hiding (empty,zip)
 
 import qualified Data.Map as Map
 import Data.Foldable (fold)

--- a/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
@@ -24,7 +24,7 @@ import Distribution.PackageDescription (FlagAssignment, dispFlagAssignment)
 import Distribution.Types.Dependency   (Dependency(..))
 import Distribution.Version            (VersionRange, simplifyVersionRange)
 
-import Distribution.Client.Compat.Prelude ((<<>>))
+import Distribution.Solver.Compat.Prelude ((<<>>))
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PackagePath
 

--- a/cabal-install/Distribution/Solver/Types/PackageIndex.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageIndex.hs
@@ -46,7 +46,7 @@ module Distribution.Solver.Types.PackageIndex (
   ) where
 
 import Prelude ()
-import Distribution.Client.Compat.Prelude hiding (lookup)
+import Distribution.Solver.Compat.Prelude hiding (lookup)
 
 import Control.Exception (assert)
 import qualified Data.Map as Map

--- a/cabal-install/Distribution/Solver/Types/PackagePath.hs
+++ b/cabal-install/Distribution/Solver/Types/PackagePath.hs
@@ -12,7 +12,7 @@ module Distribution.Solver.Types.PackagePath
 import Distribution.Package
 import Distribution.Text
 import qualified Text.PrettyPrint as Disp
-import Distribution.Client.Compat.Prelude ((<<>>))
+import Distribution.Solver.Compat.Prelude ((<<>>))
 
 -- | A package path consists of a namespace and a package path inside that
 -- namespace.

--- a/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
@@ -21,7 +21,7 @@ module Distribution.Solver.Types.PkgConfigDb
     ) where
 
 import Prelude ()
-import Distribution.Client.Compat.Prelude
+import Distribution.Solver.Compat.Prelude
 
 import Control.Exception (IOException, handle)
 import qualified Data.Map as M

--- a/cabal-install/Distribution/Solver/Types/Progress.hs
+++ b/cabal-install/Distribution/Solver/Types/Progress.hs
@@ -4,7 +4,7 @@ module Distribution.Solver.Types.Progress
     ) where
 
 import Prelude ()
-import Distribution.Client.Compat.Prelude hiding (fail)
+import Distribution.Solver.Compat.Prelude hiding (fail)
 
 -- | A type to represent the unfolding of an expensive long running
 -- calculation that may fail. We may get intermediate steps before the final

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -242,6 +242,7 @@ library
         Distribution.Client.Compat.Prelude
         Distribution.Client.Compat.Process
         Distribution.Client.Compat.Semaphore
+        Distribution.Solver.Compat.Prelude
         Distribution.Solver.Types.ComponentDeps
         Distribution.Solver.Types.ConstraintSource
         Distribution.Solver.Types.DependencyResolver

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -63,7 +63,7 @@ import Distribution.Simple.Setup
          )
 
 import Prelude ()
-import Distribution.Client.Compat.Prelude hiding (get)
+import Distribution.Solver.Compat.Prelude hiding (get)
 
 import Distribution.Client.SetupWrapper
          ( setupWrapper, SetupScriptOptions(..), defaultSetupScriptOptions )

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -37,7 +37,7 @@ module UnitTests.Distribution.Solver.Modular.DSL (
   ) where
 
 import Prelude ()
-import Distribution.Client.Compat.Prelude
+import Distribution.Solver.Compat.Prelude
 
 -- base
 import Data.Either (partitionEithers)

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
@@ -22,7 +22,7 @@ module UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils (
   ) where
 
 import Prelude ()
-import Distribution.Client.Compat.Prelude
+import Distribution.Solver.Compat.Prelude
 
 import Data.List (elemIndex)
 import Data.Ord (comparing)


### PR DESCRIPTION
The idea here is to break the dependency that has crept in from the
"Solver" into the "Client". (If there's ever going to be a separate
solver then the dependency would become a big problem.)

----
Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
