### PR TITLE
Enhance `--allow-{newer,older}` syntax

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -670,7 +670,7 @@ The following settings control the behavior of the dependency solver:
     the flag multiple times.
 
 .. cfg-field:: allow-newer: none, all or list of scoped package names (space or comma separated)
-               --allow-newer, --allow-newer=[none,all,pkg]
+               --allow-newer, --allow-newer=[none,all,[scope:][^]pkg]
     :synopsis: Lift dependencies upper bound constaints.
 
     :default: ``none``
@@ -687,10 +687,27 @@ The following settings control the behavior of the dependency solver:
 
         allow-newer: pkg:dep-pkg
 
-    This syntax is recommended, as it is often only a single package
+    If the scope shall be limited to specific releases of ``pkg``, the
+    extended form as in
+
+    ::
+
+        allow-newer: pkg-1.2.3:dep-pkg, pkg-1.1.2:dep-pkg
+
+    can be used to limit the relaxation of dependencies on
+    ``dep-pkg`` by the ``pkg-1.2.3`` and ``pkg-1.1.2`` releases only.
+
+    The scoped syntax is recommended, as it is often only a single package
     whose upper bound is misbehaving. In this case, the upper bounds of
     other packages should still be respected; indeed, relaxing the bound
     can break some packages which test the selected version of packages.
+
+    The syntax also allows to prefix the dependee package with a
+    modifier symbol to modify the scope/semantic of the relaxation
+    transformation in a additional ways. Currently only one modifier
+    symbol is defined, i.e. ``^`` (i.e. caret) which causes the
+    relaxation to be applied only to ``^>=`` operators and leave all other
+    version operators untouched.
 
     However, in some situations (e.g., when attempting to build packages
     on a new version of GHC), it is useful to disregard *all*
@@ -701,21 +718,32 @@ The following settings control the behavior of the dependency solver:
     ::
 
         -- Disregard upper bounds involving the dependencies on
-        -- packages bar, baz and quux
-        allow-newer: bar, baz, quux
+        -- packages bar, baz. For quux only, relax
+        -- 'quux ^>= ...'-style constraints only.
+        allow-newer: bar, baz, ^quux
 
         -- Disregard all upper bounds when dependency solving
         allow-newer: all
+
+
+    For consistency, there is also the explicit wildcard scope syntax
+    ``*`` (or its alphabetic synonym ``all``). Consequently, the first
+    part of the example above is equivalent to the explicitly scoped
+    variant:
+
+    ::
+
+        allow-newer: all:bar, *:baz, *:^quux
 
     :cfg-field:`allow-newer` is often used in conjunction with a constraint
     (in the cfg-field:`constraints` field) forcing the usage of a specific,
     newer version of a package.
 
-    The command line variant of this field is ``--allow-newer=bar``. A
+    The command line variant of this field is e.g. ``--allow-newer=bar``. A
     bare ``--allow-newer`` is equivalent to ``--allow-newer=all``.
 
 .. cfg-field:: allow-older: none, all, list of scoped package names (space or comma separated)
-               --allow-older, --allow-older=[none,all,pkg]
+               --allow-older, --allow-older=[none,all,[scope:][^]pkg]
     :synopsis: Lift dependency lower bound constaints.
 
     :default: ``none``

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -25,13 +25,13 @@ import Distribution.Client.Compat.Prelude
 
 import Distribution.Package
          ( Package(..), HasMungedPackageId(..), HasUnitId(..)
-         , PackageInstalled(..), newSimpleUnitId )
+         , PackageIdentifier(..), PackageInstalled(..), newSimpleUnitId )
 import Distribution.InstalledPackageInfo
          ( InstalledPackageInfo, installedComponentId, sourceComponentName )
 import Distribution.PackageDescription
          ( FlagAssignment )
 import Distribution.Version
-         ( VersionRange )
+         ( VersionRange, nullVersion )
 import Distribution.Types.ComponentId
          ( ComponentId )
 import Distribution.Types.MungedPackageId
@@ -401,6 +401,9 @@ data RelaxDeps =
   RelaxDepsNone
 
   -- | Ignore upper bounds in dependencies on the given packages.
+  --
+  -- Note that 'RelaxDepsNone' and @RelaxDepsSome []@ are equivalent
+  -- (TODO: change @[RelaxedDep]@ to @NonEmpty RelaxDep@ or remove 'RelaxDepsNone')
   | RelaxDepsSome [RelaxedDep]
 
   -- | Ignore upper bounds in dependencies on all packages.
@@ -409,20 +412,55 @@ data RelaxDeps =
 
 -- | Dependencies can be relaxed either for all packages in the install plan, or
 -- only for some packages.
-data RelaxedDep = RelaxedDep PackageName
-                | RelaxedDepScoped PackageName PackageName
+data RelaxedDep = RelaxedDep !RelaxDepScope !RelaxDepMod !PackageName
                 deriving (Eq, Read, Show, Generic)
 
-instance Text RelaxedDep where
-  disp (RelaxedDep p0)          = disp p0
-  disp (RelaxedDepScoped p0 p1) = disp p0 Disp.<> Disp.colon Disp.<> disp p1
+-- | Specify the scope of a relaxation, i.e. limit which depending
+-- packages are allowed to have their version constraints relaxed.
+data RelaxDepScope = RelaxDepScopeAll
+                     -- ^ Apply relaxation in any package
+                   | RelaxDepScopePackage !PackageName
+                     -- ^ Apply relaxation to in all versions of a package
+                   | RelaxDepScopePackageId !PackageId
+                     -- ^ Apply relaxation to a specific version of a package only
+                   deriving (Eq, Read, Show, Generic)
 
-  parse = scopedP Parse.<++ normalP
+-- | Modifier for dependency relaxation
+data RelaxDepMod = RelaxDepModNone  -- ^ Default semantics
+                 | RelaxDepModCaret -- ^ Apply relaxation only to @^>=@ constraints
+                 deriving (Eq, Read, Show, Generic)
+
+instance Text RelaxedDep where
+  disp (RelaxedDep scope rdmod dep) = case scope of
+      RelaxDepScopeAll          -> modDep
+      RelaxDepScopePackage   p0 -> disp p0 Disp.<> Disp.colon Disp.<> modDep
+      RelaxDepScopePackageId p0 -> disp p0 Disp.<> Disp.colon Disp.<> modDep
     where
-      scopedP = RelaxedDepScoped `fmap` parse <* Parse.char ':' <*> parse
-      normalP = RelaxedDep       `fmap` parse
+      modDep = case rdmod of
+               RelaxDepModNone  -> disp dep
+               RelaxDepModCaret -> Disp.char '^' Disp.<> disp dep
+
+  parse = RelaxedDep <$> scopeP <*> modP <*> parse
+    where
+      -- "greedy" choices
+      scopeP =           (pure RelaxDepScopeAll  <* Parse.char '*' <* Parse.char ':')
+               Parse.<++ (pure RelaxDepScopeAll  <* Parse.string "all:")
+               Parse.<++ (RelaxDepScopePackageId <$> pidP  <* Parse.char ':')
+               Parse.<++ (RelaxDepScopePackage   <$> parse <* Parse.char ':')
+               Parse.<++ (pure RelaxDepScopeAll)
+
+      modP =           (pure RelaxDepModCaret <* Parse.char '^')
+             Parse.<++ (pure RelaxDepModNone)
+
+      -- | Stricter 'PackageId' parser which doesn't overlap with 'PackageName' parser
+      pidP = do
+          p0 <- parse
+          when (pkgVersion p0 == nullVersion) Parse.pfail
+          pure p0
 
 instance Binary RelaxDeps
+instance Binary RelaxDepMod
+instance Binary RelaxDepScope
 instance Binary RelaxedDep
 instance Binary AllowNewer
 instance Binary AllowOlder

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -5,6 +5,8 @@
 	roll back the index to an earlier state.
 	* 'cabal new-configure' now backs up the old 'cabal.project.local'
 	file if it exists (#4460).
+	* Enhance '--allow-newer' syntax to allow more fine-grained scoping
+	control (#4575).
 
 2.0.0.0 Ryan Thomas <ryan@ryant.org> May 2017
 	* Removed the '--root-cmd' parameter of the 'install' command


### PR DESCRIPTION
This extends the capabilities of `--allow-{newer,older}` to allow for more
fine-grained scoping to control more precisely which packages and constraints
a relaxation is applied to. See updated documentation for more details.
