### PR TITLE
get last update timestamp from XX-index.timestamp's modification time

### DIFF
--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -17,7 +17,7 @@
 -- Extra utils related to the package indexes.
 -----------------------------------------------------------------------------
 module Distribution.Client.IndexUtils (
-  getIndexFileAge,
+  getIndexTimestampFileAge,
   getInstalledPackages,
   Configure.getInstalledPackagesMonitorFiles,
   getSourcePackages,
@@ -308,7 +308,7 @@ readRepoIndex :: Verbosity -> RepoContext -> Repo -> IndexState
               -> IO (PackageIndex UnresolvedSourcePackage, [Dependency], IndexStateInfo)
 readRepoIndex verbosity repoCtxt repo idxState =
   handleNotFound $ do
-    warnIfIndexIsOld =<< getIndexFileAge repo
+    warnIfIndexIsOld =<< getIndexTimestampFileAge repo
     updateRepoIndexCache verbosity (RepoIndex repoCtxt repo)
     readPackageIndexCacheFile verbosity mkAvailablePackage
                               (RepoIndex repoCtxt repo)
@@ -355,9 +355,9 @@ readRepoIndex verbosity repoCtxt repo idxState =
       ++ "' is " ++ shows (floor dt :: Int) " days old.\nRun "
       ++ "'cabal update' to get the latest list of available packages."
 
--- | Return the age of the index file in days (as a Double).
-getIndexFileAge :: Repo -> IO Double
-getIndexFileAge repo = getFileAge $ indexBaseName repo <.> "tar"
+-- | Return the age of the index timestamp file in days (as a Double).
+getIndexTimestampFileAge :: Repo -> IO Double
+getIndexTimestampFileAge repo = getFileAge $ indexBaseName repo <.> "timestamp"
 
 -- | A set of files (or directories) that can be monitored to detect when
 -- there might have been a change in the source packages.


### PR DESCRIPTION
The reason we cannot the timestamp of the last update it from
XX-index.tar is because it's modification time is not updated unless
there is a newer version available in the repository.

On the other hand, XX-index.timestamp's modification time is always
updated, even if there are no new updates. That means that the
modifiation time of file will correspond to the last update attemp. So,
to decide whether to warn about having an old index we can use the last
modification time of that file.

One could also have the modification time of XX-index.tar updated even
thought there aren't any updates, but to do that I think we'd need to
modify checkForUpdates in Hackage.Security.Client.

Signed-off-by: Tomas Vestelind <tomas.vestelind@gmail.com>

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

This fixes #4444 and I tested this by following the steps to reproduce described in that issue. But to summarize, I did:
1. Add next-hackage to my `.cabal/config`
2. Built the latest cabal-install from master
3. Ran `./dist/build/cabal/cabal update` (I'll exclude the `./dist/.../` part from now one, it's just to show that I really used what I build)
4. Went to `cabal/packages/next-hackage` and used `touch` to set the modification date on all files to one year ago
5. Ran `cabal install` and verified that I got the error `Warning: The package list for 'next-hackage' is 365 days old.`
6. Ran `cabal update && cabal install` and verified that the error was still there.
7. Implemented my suggested solution
8. Ran `cabal update && cabal install` and verified that the error was gone.


