### PR TITLE
Speed up equal files check

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -665,10 +665,7 @@ configure (pkg_descr0, pbi) cfg = do
 
     setCoverageLBI <- configureCoverage verbosity cfg comp
 
-    reloc <-
-       if not (fromFlag $ configRelocatable cfg)
-            then return False
-            else return True
+    let reloc = fromFlagOrDefault False $ configRelocatable cfg
 
     let buildComponentsMap =
             foldl' (\m clbi -> Map.insertWith (++)


### PR DESCRIPTION
I noticed that `filesEqual` always compares files contents, but there's faster way to check whether files are different - just check their sizes.

I wrote small benchmarking suite that tested old and new `filesEqual` on both equal files containing letter 'a' replicated N times and on different files of different sizes with similar contents (the suite is (here)[https://github.com/sergv/benchmarks/blob/master/bench/CompareFileContents.hs]. The output suggests, that size check introduces negligible overhead in case files are equal, but makes comparison of different files independent of their size, thus gaining huge speedups on larger files:

```
benchmarking 10Kb/Equal/filesEqualCabal
time                 28.42 μs   (28.19 μs .. 28.66 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 28.54 μs   (28.33 μs .. 28.79 μs)
std dev              749.2 ns   (585.3 ns .. 1.083 μs)
variance introduced by outliers: 26% (moderately inflated)

benchmarking 10Kb/Equal/filesEqualWithSize
time                 29.01 μs   (28.83 μs .. 29.20 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 28.99 μs   (28.78 μs .. 29.27 μs)
std dev              803.6 ns   (598.6 ns .. 1.170 μs)
variance introduced by outliers: 28% (moderately inflated)

benchmarking 10Kb/Different/filesEqualCabal
time                 27.89 μs   (27.58 μs .. 28.22 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 28.08 μs   (27.85 μs .. 28.34 μs)
std dev              829.8 ns   (677.4 ns .. 1.067 μs)
variance introduced by outliers: 32% (moderately inflated)

benchmarking 10Kb/Different/filesEqualWithSize
time                 15.83 μs   (15.64 μs .. 16.07 μs)
                     0.997 R²   (0.993 R² .. 0.999 R²)
mean                 15.89 μs   (15.73 μs .. 16.30 μs)
std dev              815.7 ns   (397.4 ns .. 1.683 μs)
variance introduced by outliers: 60% (severely inflated)

benchmarking 100Kb/Equal/filesEqualCabal
time                 66.85 μs   (66.34 μs .. 67.61 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 66.85 μs   (66.58 μs .. 67.23 μs)
std dev              1.086 μs   (811.4 ns .. 1.600 μs)
variance introduced by outliers: 11% (moderately inflated)

benchmarking 100Kb/Equal/filesEqualWithSize
time                 67.83 μs   (67.46 μs .. 68.24 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 67.78 μs   (67.48 μs .. 68.10 μs)
std dev              1.067 μs   (843.2 ns .. 1.391 μs)
variance introduced by outliers: 11% (moderately inflated)

benchmarking 100Kb/Different/filesEqualCabal
time                 66.86 μs   (66.49 μs .. 67.22 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 67.73 μs   (67.20 μs .. 69.23 μs)
std dev              2.735 μs   (1.237 μs .. 5.609 μs)
variance introduced by outliers: 43% (moderately inflated)

benchmarking 100Kb/Different/filesEqualWithSize
time                 15.64 μs   (15.50 μs .. 15.78 μs)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 15.70 μs   (15.55 μs .. 15.89 μs)
std dev              569.3 ns   (438.6 ns .. 773.5 ns)
variance introduced by outliers: 43% (moderately inflated)

benchmarking 1Mb/Equal/filesEqualCabal
time                 411.7 μs   (409.7 μs .. 413.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 412.0 μs   (411.0 μs .. 413.1 μs)
std dev              3.655 μs   (3.083 μs .. 4.436 μs)

benchmarking 1Mb/Equal/filesEqualWithSize
time                 414.6 μs   (413.6 μs .. 415.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 415.2 μs   (414.4 μs .. 416.1 μs)
std dev              2.935 μs   (2.355 μs .. 3.891 μs)

benchmarking 1Mb/Different/filesEqualCabal
time                 439.7 μs   (438.6 μs .. 440.8 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 439.7 μs   (438.6 μs .. 440.8 μs)
std dev              3.681 μs   (3.123 μs .. 4.487 μs)

benchmarking 1Mb/Different/filesEqualWithSize
time                 15.58 μs   (15.45 μs .. 15.70 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 15.54 μs   (15.42 μs .. 15.68 μs)
std dev              430.0 ns   (344.8 ns .. 580.8 ns)
variance introduced by outliers: 30% (moderately inflated)
```

Check list per your request:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* N/A Any changes that could be relevant to users have been recorded in the changelog
* N/A The documentation has been updated, if necessary.
* No tests added since I'm not sure what to test for