### PR TITLE
Remove extra space from ChangeLog generation

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -699,7 +699,7 @@ writeChangeLog flags = when ((defaultChangeLog `elem`) $ fromMaybe [] (extraSrc 
   changeLog = unlines
     [ "# Revision history for " ++ pname
     , ""
-    , "## " ++ pver ++ "  -- YYYY-mm-dd"
+    , "## " ++ pver ++ " -- YYYY-mm-dd"
     , ""
     , "* First version. Released on an unsuspecting world."
     ]


### PR DESCRIPTION
I don't know if it was there for a reason, but it looks like it wasn't.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
