### PR TITLE
Refine "doingTH" check to include checking for QuasiQuotes

### DIFF
--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -77,6 +77,7 @@ module Distribution.PackageDescription (
         allLanguages,
         allExtensions,
         usedExtensions,
+        usesTemplateHaskellOrQQ,
         hcOptions,
         hcProfOptions,
         hcSharedOptions,

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -535,7 +535,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
 
   let isGhcDynamic        = isDynamic comp
       dynamicTooSupported = supportsDynamicToo comp
-      doingTH = EnableExtension TemplateHaskell `elem` allExtensions libBi
+      doingTH = usesTemplateHaskellOrQQ libBi
       forceVanillaLib = doingTH && not isGhcDynamic
       forceSharedLib  = doingTH &&     isGhcDynamic
       -- TH always needs default libs, even when building for profiling
@@ -1184,7 +1184,7 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
       -- by the compiler.
       -- With dynamic-by-default GHC the TH object files loaded at compile-time
       -- need to be .dyn_o instead of .o.
-      doingTH = EnableExtension TemplateHaskell `elem` allExtensions bnfo
+      doingTH = usesTemplateHaskellOrQQ bnfo
       -- Should we use -dynamic-too instead of compiling twice?
       useDynToo = dynamicTooSupported && isGhcDynamic
                   && doingTH && withStaticExe

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -46,7 +46,6 @@ import Distribution.Verbosity
 import Distribution.Utils.NubList
 import Distribution.Text
 import Distribution.Types.UnitId
-import Language.Haskell.Extension
 
 import qualified Data.Map as Map
 import System.Directory         ( doesFileExist )
@@ -289,7 +288,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
       libBi               = libBuildInfo lib
       isGhcjsDynamic      = isDynamic comp
       dynamicTooSupported = supportsDynamicToo comp
-      doingTH = EnableExtension TemplateHaskell `elem` allExtensions libBi
+      doingTH = usesTemplateHaskellOrQQ libBi
       forceVanillaLib = doingTH && not isGhcjsDynamic
       forceSharedLib  = doingTH &&     isGhcjsDynamic
       -- TH always needs default libs, even when building for profiling
@@ -624,7 +623,7 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
       -- by the compiler.
       -- With dynamic-by-default GHC the TH object files loaded at compile-time
       -- need to be .dyn_o instead of .o.
-      doingTH = EnableExtension TemplateHaskell `elem` allExtensions exeBi
+      doingTH = usesTemplateHaskellOrQQ exeBi
       -- Should we use -dynamic-too instead of compiling twice?
       useDynToo = dynamicTooSupported && isGhcjsDynamic
                   && doingTH && withStaticExe && null (ghcjsSharedOptions exeBi)

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -306,7 +306,7 @@ buildLib verbosity pkg_descr lbi lib clbi = do
              (compiler lbi) (withProfLib lbi) (libBuildInfo lib)
 
   let libTargetDir = pref
-      forceVanillaLib = EnableExtension TemplateHaskell `elem` allExtensions libBi
+      forceVanillaLib = usesTemplateHaskellOrQQ libBi
       -- TH always needs vanilla libs, even when building for profiling
 
   createDirectoryIfMissingVerbose verbosity True libTargetDir
@@ -515,7 +515,7 @@ buildExe verbosity _pkg_descr lbi
   -- with profiling. This is because the code that TH needs to
   -- run at compile time needs to be the vanilla ABI so it can
   -- be loaded up and run by the compiler.
-  when (withProfExe lbi && EnableExtension TemplateHaskell `elem` allExtensions exeBi)
+  when (withProfExe lbi && usesTemplateHaskellOrQQ exeBi)
      (runGhcProg $ lhcWrap (binArgs False False))
 
   runGhcProg (binArgs True (withProfExe lbi))

--- a/Cabal/Distribution/Types/BuildInfo.hs
+++ b/Cabal/Distribution/Types/BuildInfo.hs
@@ -8,6 +8,7 @@ module Distribution.Types.BuildInfo (
     allLanguages,
     allExtensions,
     usedExtensions,
+    usesTemplateHaskellOrQQ,
 
     hcOptions,
     hcProfOptions,
@@ -179,6 +180,14 @@ allExtensions bi = usedExtensions bi
 usedExtensions :: BuildInfo -> [Extension]
 usedExtensions bi = oldExtensions bi
                  ++ defaultExtensions bi
+
+-- | Whether any modules in this component use Template Haskell or
+-- Quasi Quotes
+usesTemplateHaskellOrQQ :: BuildInfo -> Bool
+usesTemplateHaskellOrQQ bi = any p (allExtensions bi)
+  where
+    p ex = ex `elem`
+      [EnableExtension TemplateHaskell, EnableExtension QuasiQuotes]
 
 -- |Select options for a particular Haskell compiler.
 hcOptions :: CompilerFlavor -> BuildInfo -> [String]

--- a/Cabal/Language/Haskell/Extension.hs
+++ b/Cabal/Language/Haskell/Extension.hs
@@ -777,7 +777,7 @@ data KnownExtension =
   -- code will compile with the new planned desugaring of fail.
   | MonadFailDesugaring
 
-  -- | A subset of @TemplateHaskell@ including only quasi-quoting.
+  -- | A subset of @TemplateHaskell@ including only quoting.
   | TemplateHaskellQuotes
 
   -- | Allows use of the @#label@ syntax.

--- a/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/Exe.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/Exe.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Main where
+
+import QQ
+
+main = putStrLn [myq|hello|]

--- a/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/Lib.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/Lib.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Lib where
+
+import QQ
+
+val = [myq|hello|]

--- a/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/QQ.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/QQ.hs
@@ -1,0 +1,6 @@
+module QQ where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+
+myq = QuasiQuoter { quoteExp = \s -> litE $ stringL $ s ++ " world"}

--- a/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/my.cabal
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/my.cabal
@@ -1,0 +1,15 @@
+Name: quasiQuotes
+Version: 0.1
+Build-Type: Simple
+Cabal-Version: >= 1.2
+
+Library
+    Exposed-Modules: Lib
+    Other-Modules: QQ
+    Build-Depends: base, template-haskell
+    Extensions: QuasiQuotes
+
+Executable main
+    Main-is: Exe.hs
+    Build-Depends: base, template-haskell
+    Extensions: QuasiQuotes

--- a/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/setup.cabal.out
@@ -1,0 +1,8 @@
+# Setup configure
+Resolving dependencies...
+Configuring quasiQuotes-0.1...
+# Setup build
+Preprocessing executable 'main' for quasiQuotes-0.1..
+Building executable 'main' for quasiQuotes-0.1..
+Preprocessing library for quasiQuotes-0.1..
+Building library for quasiQuotes-0.1..

--- a/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/setup.out
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/setup.out
@@ -1,0 +1,7 @@
+# Setup configure
+Configuring quasiQuotes-0.1...
+# Setup build
+Preprocessing executable 'main' for quasiQuotes-0.1..
+Building executable 'main' for quasiQuotes-0.1..
+Preprocessing library for quasiQuotes-0.1..
+Building library for quasiQuotes-0.1..

--- a/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/setup.test.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/dynamic/setup.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+-- Test building a dynamic library/executable which uses QuasiQuotes
+main = setupAndCabalTest $ do
+    skipUnless =<< hasSharedLibraries
+    setup_build ["--enable-shared", "--enable-executable-dynamic"]

--- a/cabal-testsuite/PackageTests/QuasiQuotes/profiling/Exe.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/profiling/Exe.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Main where
+
+import QQ
+
+main = putStrLn [myq|hello|]

--- a/cabal-testsuite/PackageTests/QuasiQuotes/profiling/Lib.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/profiling/Lib.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Lib where
+
+import QQ
+
+val = [myq|hello|]

--- a/cabal-testsuite/PackageTests/QuasiQuotes/profiling/QQ.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/profiling/QQ.hs
@@ -1,0 +1,6 @@
+module QQ where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+
+myq = QuasiQuoter { quoteExp = \s -> litE $ stringL $ s ++ " world"}

--- a/cabal-testsuite/PackageTests/QuasiQuotes/profiling/my.cabal
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/profiling/my.cabal
@@ -1,0 +1,15 @@
+Name: quasiQuotes
+Version: 0.1
+Build-Type: Simple
+Cabal-Version: >= 1.2
+
+Library
+    Exposed-Modules: Lib
+    Other-Modules: QQ
+    Build-Depends: base, template-haskell
+    Extensions: QuasiQuotes
+
+Executable main
+    Main-is: Exe.hs
+    Build-Depends: base, template-haskell
+    Extensions: QuasiQuotes

--- a/cabal-testsuite/PackageTests/QuasiQuotes/profiling/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/profiling/setup.cabal.out
@@ -1,0 +1,8 @@
+# Setup configure
+Resolving dependencies...
+Configuring quasiQuotes-0.1...
+# Setup build
+Preprocessing executable 'main' for quasiQuotes-0.1..
+Building executable 'main' for quasiQuotes-0.1..
+Preprocessing library for quasiQuotes-0.1..
+Building library for quasiQuotes-0.1..

--- a/cabal-testsuite/PackageTests/QuasiQuotes/profiling/setup.out
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/profiling/setup.out
@@ -1,0 +1,7 @@
+# Setup configure
+Configuring quasiQuotes-0.1...
+# Setup build
+Preprocessing executable 'main' for quasiQuotes-0.1..
+Building executable 'main' for quasiQuotes-0.1..
+Preprocessing library for quasiQuotes-0.1..
+Building library for quasiQuotes-0.1..

--- a/cabal-testsuite/PackageTests/QuasiQuotes/profiling/setup.test.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/profiling/setup.test.hs
@@ -1,0 +1,7 @@
+import Test.Cabal.Prelude
+-- Test building a profiled library/executable which uses QuasiQuotes
+-- (setup has to build the non-profiled version first)
+main = setupAndCabalTest $ do
+    skipUnless =<< hasProfiledLibraries
+    setup_build ["--enable-library-profiling",
+                 "--enable-profiling"]

--- a/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/Exe.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/Exe.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Main where
+
+import QQ
+
+main = putStrLn [myq|hello|]

--- a/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/Lib.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/Lib.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Lib where
+
+import QQ
+
+val = [myq|hello|]

--- a/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/QQ.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/QQ.hs
@@ -1,0 +1,6 @@
+module QQ where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+
+myq = QuasiQuoter { quoteExp = \s -> litE $ stringL $ s ++ " world"}

--- a/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/my.cabal
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/my.cabal
@@ -1,0 +1,15 @@
+Name: quasiQuotes
+Version: 0.1
+Build-Type: Simple
+Cabal-Version: >= 1.2
+
+Library
+    Exposed-Modules: Lib
+    Other-Modules: QQ
+    Build-Depends: base, template-haskell
+    Extensions: QuasiQuotes
+
+Executable main
+    Main-is: Exe.hs
+    Build-Depends: base, template-haskell
+    Extensions: QuasiQuotes

--- a/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/setup.cabal.out
@@ -1,0 +1,8 @@
+# Setup configure
+Resolving dependencies...
+Configuring quasiQuotes-0.1...
+# Setup build
+Preprocessing executable 'main' for quasiQuotes-0.1..
+Building executable 'main' for quasiQuotes-0.1..
+Preprocessing library for quasiQuotes-0.1..
+Building library for quasiQuotes-0.1..

--- a/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/setup.out
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/setup.out
@@ -1,0 +1,7 @@
+# Setup configure
+Configuring quasiQuotes-0.1...
+# Setup build
+Preprocessing executable 'main' for quasiQuotes-0.1..
+Building executable 'main' for quasiQuotes-0.1..
+Preprocessing library for quasiQuotes-0.1..
+Building library for quasiQuotes-0.1..

--- a/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/setup.test.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/setup.test.hs
@@ -1,0 +1,3 @@
+import Test.Cabal.Prelude
+-- Test building a vanilla library/executable which uses QuasiQuotes
+main = setupAndCabalTest $ setup_build []


### PR DESCRIPTION
Addresses #4580. I have not added a test for this. I could easily modify or duplicate the tests in cabal-tests/PackageTests/TemplateHaskell if you think it worthwhile.
Note that ghc-8.2 is smart enough to not need this logic, I'm not sure when those smarts were added.
I verified this works by modifying those tests to have QuasiQuotes in their cabal files, and running them with ghc-7.6.3.