### PR TITLE
Fix bug in conflict counting.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install/Distribution/Solver/Modular/Explore.hs
@@ -22,10 +22,9 @@ import Distribution.Solver.Types.PackagePath
 import Distribution.Solver.Types.Settings (EnableBackjumping(..), CountConflicts(..))
 
 -- | This function takes the variable we're currently considering, a
--- last conflict set and a
--- list of children's logs. Each log yields either a solution or a
--- conflict set. The result is a combined log for the parent node that
--- has explored a prefix of the children.
+-- last conflict set and a list of children's logs. Each log yields
+-- either a solution or a conflict set. The result is a combined log for
+-- the parent node that has explored a prefix of the children.
 --
 -- We can stop traversing the children's logs if we find an individual
 -- conflict set that does not contain the current variable. In this
@@ -151,7 +150,7 @@ exploreLog enableBj (CountConflicts countConflicts) t = cata go t M.empty
 -- always have to consider that we could perhaps make choices that would
 -- avoid the existence of the goal completely.
 --
--- Whenever we actual introduce a choice in the tree, we have already established
+-- Whenever we actually introduce a choice in the tree, we have already established
 -- that the goal cannot be avoided. This is tracked in the "goal reason".
 -- The choice to avoid the goal therefore is a conflict between the goal itself
 -- and its goal reason. We build this set here, and pass it to the 'backjump'

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-external.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-external.cabal.out
@@ -103,7 +103,7 @@ trying: exe-0.1.0.0 (user goal)
 next goal: src (dependency of exe-0.1.0.0)
 rejecting: src-<VERSION>/installed-<HASH>... (conflict: src => mylib==0.1.0.0/installed-0.1..., src => mylib==0.1.0.0/installed-0.1...)
 fail (backjumping, conflict set: exe, src)
-After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: exe (3), src (2)Trying configure anyway.
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: exe (2), src (2)Trying configure anyway.
 Configuring exe-0.1.0.0...
 # Setup build
 Preprocessing executable 'exe' for exe-0.1.0.0..

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.out
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.out
@@ -8,6 +8,6 @@ next goal: setup-dep (user goal)
 rejecting: setup-dep-2.0 (conflict: pkg => setup-dep==1.*)
 rejecting: setup-dep-1.0 (constraint from user target requires ==2.0)
 fail (backjumping, conflict set: pkg, setup-dep)
-After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: pkg (4), setup-dep (3)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: setup-dep (3), pkg (2)
 # pkg my-exe
 Main.hs: setup-dep from repo

--- a/cabal-testsuite/PackageTests/ConfigureComponent/Exe/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/ConfigureComponent/Exe/setup.cabal.out
@@ -5,7 +5,7 @@ Could not resolve dependencies:
 trying: Exe-0.1.0.0 (user goal)
 unknown package: totally-impossible-dependency-to-fill (dependency of Exe-0.1.0.0)
 fail (backjumping, conflict set: Exe, totally-impossible-dependency-to-fill)
-After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: Exe (3), totally-impossible-dependency-to-fill (1)Trying configure anyway.
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: Exe (2), totally-impossible-dependency-to-fill (1)Trying configure anyway.
 Configuring executable 'goodexe' for Exe-0.1.0.0..
 # Setup build
 Preprocessing executable 'goodexe' for Exe-0.1.0.0..


### PR DESCRIPTION
Two main commits:

####    Fix bug in conflict counting.
    
In Explore.hs, the solver calculates a conflict set corresponding to the option
to not choose a value for each goal, called `initial`.  That conflict set should
be added to the ConflictMap when the current goal causes a conflict.  However,
there was a bug, and the solver added `initial` to the ConflictMap at every
level.
    
The bug meant that the solver preferred all goals that it had already chosen.
If a new goal started to cause conflicts, it would take a while for the solver
to start preferring the new goal over the ones that it had previously seen.
See #4595 for an example where this problem caused longer backjumps and slowed
down the solver.

####    Refactor handling of conflict set representing option to not choose a goal.
    
The conflict set that represents the option to not choose a value for a goal,
`initial`, has two purposes:
    
1. `initial` contributes to a node's conflict set, because it is unioned with
   the other conflict sets under the same choice node, if the current variable
   is contained in all of them.
2. `initial` contributes to the conflict count.  When it is unioned with the
   other conflict sets, it is also added to the ConflictMap.
    
Previously, `initial` was treated as the first of a node's children for (1) and
the last of the children for (2).  This refactoring treats `initial` as the last
child in both cases, to make the code clearer, and renames it to `lastCS`.
There should be no change in behavior.

____________________________________________________________

/cc @kosmikus 

#### Testing

I ran `cabal install --dry-run` for all packages on Hackage with master and the branch with a 90 second timeout, GHC 8.0.1, and index state `2017-07-08T04:20:18Z`.  Then I filtered out all packages where both runs had the same result (success or failure) and the times were within 10%.  I repeated that process three times to eliminate packages that had different run times due to noise.  Then I ran `cabal install --dry-run --max-backjumps=-1` on the remaining packages and averaged three runs.

Since this branch changes a goal-ordering heuristic, I expected a lot of changes in run time in either direction.  Out of 105 changes, 83 were faster, 20 were slower, and 2 involved a timeout on both branches.  (The two that timed out had different run times before I removed the backjump limit.)

package | master result | master time (seconds) | branch result | branch time (seconds) | speedup
--------|---------------|-----------------------|---------------|-----------------------|--------
AesonBson	|	solution	|	3.06	|	solution	|	2.59	|	1.18
DisTract	|	no solution	|	1.48	|	no solution	|	1.34	|	1.1
GPipe-Examples	|	timeout	|	90.01	|	no solution	|	2.11	|	-
GuiTV	|	solution	|	2.54	|	solution	|	16.05	|	0.16
Phsu	|	solution	|	3.49	|	solution	|	1.83	|	1.9
Ranka	|	no solution	|	2.05	|	no solution	|	1.65	|	1.25
Rlang-QQ	|	no solution	|	2.97	|	no solution	|	1.89	|	1.57
SourceGraph	|	timeout	|	90.04	|	no solution	|	11.53	|	-
Validation	|	no solution	|	2.1	|	no solution	|	6.59	|	0.32
WebCont	|	no solution	|	2.04	|	no solution	|	1.6	|	1.28
acme-everything	|	timeout	|	90.02	|	timeout	|	90	|	-
aeson-t	|	solution	|	2.04	|	solution	|	1.81	|	1.13
alsa-gui	|	no solution	|	1.62	|	no solution	|	1.86	|	0.87
aviation-cessna172-diagrams	|	no solution	|	2.56	|	no solution	|	2.29	|	1.12
aws-dynamodb-conduit	|	no solution	|	2.22	|	no solution	|	1.83	|	1.22
azure-servicebus	|	no solution	|	5.18	|	no solution	|	2.87	|	1.8
bamboo-theme-mini-html5	|	no solution	|	2.51	|	no solution	|	2	|	1.26
bitcoin-payment-channel	|	solution	|	3.42	|	solution	|	2.73	|	1.25
bittorrent	|	no solution	|	2.75	|	no solution	|	2.4	|	1.15
blaze-builder-enumerator	|	no solution	|	1.62	|	no solution	|	1.88	|	0.86
blunt	|	solution	|	2.99	|	solution	|	2.5	|	1.19
cash	|	no solution	|	1.33	|	no solution	|	1.53	|	0.87
cheapskate-terminal	|	no solution	|	2.04	|	no solution	|	1.62	|	1.26
clckwrks-plugin-bugs	|	no solution	|	3.85	|	no solution	|	5.78	|	0.67
cmdtheline	|	no solution	|	1.96	|	no solution	|	1.63	|	1.2
colchis	|	no solution	|	1.99	|	no solution	|	2.23	|	0.89
collada-types	|	no solution	|	1.86	|	no solution	|	1.66	|	1.12
convertible-text	|	solution	|	1.61	|	solution	|	1.83	|	0.88
cqrs-example	|	no solution	|	2.64	|	no solution	|	2.32	|	1.14
dixi	|	solution	|	4.44	|	solution	|	4.03	|	1.1
ethereum-client-haskell	|	no solution	|	1.84	|	no solution	|	2.45	|	0.75
flowdock	|	no solution	|	2.46	|	no solution	|	3.19	|	0.77
geniserver	|	no solution	|	5.34	|	no solution	|	4.84	|	1.1
ghc-imported-from	|	solution	|	4.59	|	solution	|	2.9	|	1.58
gps2htmlReport	|	solution	|	3.08	|	solution	|	5.58	|	0.55
guarded-rewriting	|	solution	|	1.54	|	solution	|	1.34	|	1.14
hack2-handler-happstack-server	|	no solution	|	1.76	|	no solution	|	2	|	0.88
halma-telegram-bot	|	solution	|	4.27	|	solution	|	3.37	|	1.27
happs-tutorial	|	no solution	|	2.08	|	no solution	|	1.86	|	1.12
happstack	|	no solution	|	3.08	|	no solution	|	5.86	|	0.53
happstack-facebook	|	timeout	|	90.01	|	timeout	|	90.03	|	-
haskelldb-hsql-mysql	|	no solution	|	1.73	|	no solution	|	1.5	|	1.16
hdbi	|	no solution	|	1.92	|	no solution	|	1.66	|	1.15
hdbi-postgresql	|	no solution	|	3.05	|	no solution	|	1.95	|	1.56
hdbi-sqlite	|	no solution	|	1.91	|	no solution	|	1.69	|	1.13
hexpat-iteratee	|	no solution	|	2.61	|	no solution	|	1.84	|	1.42
hist-pl	|	no solution	|	2.69	|	no solution	|	2.36	|	1.14
hscd	|	no solution	|	2.53	|	no solution	|	1.59	|	1.59
http-client-lens	|	no solution	|	3.63	|	no solution	|	1.96	|	1.85
hubris	|	no solution	|	3.62	|	no solution	|	1.63	|	2.22
infinity	|	no solution	|	1.34	|	no solution	|	1.5	|	0.89
iteratee-parsec	|	no solution	|	2.01	|	no solution	|	1.74	|	1.16
json-togo	|	no solution	|	1.86	|	no solution	|	1.65	|	1.13
lat	|	no solution	|	2.87	|	no solution	|	1.86	|	1.55
liquidhaskell	|	solution	|	3.34	|	solution	|	2.25	|	1.48
manatee-core	|	no solution	|	1.79	|	no solution	|	1.6	|	1.12
manatee-curl	|	no solution	|	8.44	|	no solution	|	2.73	|	3.09
manatee-editor	|	no solution	|	5.05	|	no solution	|	2.81	|	1.8
manatee-filemanager	|	no solution	|	29.09	|	no solution	|	2.96	|	9.82
manatee-imageviewer	|	no solution	|	1.78	|	no solution	|	1.57	|	1.13
manatee-mplayer	|	no solution	|	8.98	|	no solution	|	4.05	|	2.22
manatee-terminal	|	no solution	|	3.19	|	no solution	|	2.41	|	1.32
minimung	|	no solution	|	1.86	|	no solution	|	1.57	|	1.19
monoids	|	no solution	|	3.02	|	no solution	|	2.68	|	1.13
mprover	|	no solution	|	1.89	|	no solution	|	1.54	|	1.23
ms	|	no solution	|	8.04	|	no solution	|	4.35	|	1.85
music-sibelius	|	solution	|	3.1	|	solution	|	2.5	|	1.24
nerf	|	solution	|	22.54	|	solution	|	3.09	|	7.29
nomyx-api	|	solution	|	5.46	|	solution	|	4.39	|	1.24
nomyx-library	|	solution	|	2.08	|	solution	|	1.86	|	1.11
nomyx-server	|	no solution	|	4.83	|	no solution	|	3.92	|	1.23
opaleye-classy	|	no solution	|	2.07	|	no solution	|	3.58	|	0.58
openflow	|	no solution	|	1.95	|	no solution	|	1.66	|	1.18
ot	|	no solution	|	3.37	|	no solution	|	1.95	|	1.73
paypal-api	|	no solution	|	1.89	|	no solution	|	1.64	|	1.15
pdf-slave-server	|	no solution	|	3.21	|	no solution	|	2.15	|	1.49
phooey	|	solution	|	2.55	|	solution	|	16.24	|	0.16
pipes-cereal-plus	|	solution	|	1.85	|	solution	|	1.65	|	1.12
pocket-dns	|	no solution	|	2.71	|	no solution	|	2.08	|	1.3
pontarius-mediaserver	|	no solution	|	2.29	|	no solution	|	2.7	|	0.85
precis	|	no solution	|	2.53	|	no solution	|	3.23	|	0.78
prove-everywhere-server	|	no solution	|	2.19	|	no solution	|	1.92	|	1.14
quickbooks	|	no solution	|	5.86	|	no solution	|	5.17	|	1.13
rbpcp-api	|	solution	|	2.35	|	solution	|	2.13	|	1.11
react-haskell	|	timeout	|	90.02	|	no solution	|	71.21	|	-
regex-xmlschema	|	no solution	|	1.34	|	no solution	|	1.51	|	0.89
remote-json-server	|	solution	|	2.1	|	solution	|	1.8	|	1.16
scholdoc-citeproc	|	no solution	|	3	|	no solution	|	1.92	|	1.57
scion-browser	|	no solution	|	5.21	|	no solution	|	4.65	|	1.12
semdoc	|	no solution	|	4.21	|	no solution	|	3.04	|	1.39
servant-auth-token-rocksdb	|	no solution	|	4.68	|	no solution	|	2.32	|	2.02
snaplet-auth-acid	|	no solution	|	2.25	|	no solution	|	1.99	|	1.13
snaplet-stripe	|	no solution	|	3.46	|	no solution	|	2.97	|	1.16
sssp	|	no solution	|	3.3	|	no solution	|	2.79	|	1.18
target	|	solution	|	2.8	|	solution	|	2.11	|	1.32
tls-extra	|	no solution	|	2.74	|	no solution	|	2.36	|	1.16
twentefp-rosetree	|	no solution	|	1.69	|	no solution	|	1.97	|	0.86
twitter-enumerator	|	no solution	|	28.39	|	no solution	|	2.16	|	13.15
wai-middleware-cache	|	no solution	|	1.95	|	no solution	|	1.56	|	1.25
wai-middleware-catch	|	no solution	|	1.9	|	no solution	|	1.54	|	1.24
wai-middleware-route	|	solution	|	11.9	|	solution	|	1.62	|	7.34
xml2json	|	no solution	|	2.27	|	no solution	|	1.68	|	1.35
yesod-auth-account-fork	|	solution	|	3.33	|	solution	|	2.87	|	1.16
yesod-comments	|	no solution	|	25.6	|	no solution	|	14.44	|	1.77
yesod-pure	|	solution	|	7.99	|	solution	|	4.45	|	1.79
