### PR TITLE
Suggest fix for missing deps in error message

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -910,6 +910,7 @@ configureFinalizedPackage verbosity cfg enabled
                      ++ (render . nest 4 . sep . punctuate comma
                                 . map (disp . simplifyDependency)
                                 $ missing)
+                     ++ "\nHave you run 'cabal install'?"
 
     -- add extra include/lib dirs as specified in cfg
     -- we do it here so that those get checked too

--- a/cabal-testsuite/PackageTests/ConfigureComponent/SubLib/setup-explicit-fail.out
+++ b/cabal-testsuite/PackageTests/ConfigureComponent/SubLib/setup-explicit-fail.out
@@ -11,3 +11,4 @@ Registering library 'sublib' for Lib-0.1.0.0..
 Configuring executable 'exe' for Lib-0.1.0.0..
 setup: Encountered missing dependencies:
     sublib -any
+Have you run 'cabal install'?


### PR DESCRIPTION
A common reason for `cabal configure` to fail with the "Encountered missing dependencies: ..." error is forgetting to run `cabal install` beforehand. This change improves the error message by suggesting a fix for the problem.

**Previous error:**

```
$ cabal configure
Resolving dependencies...
<snip>
cabal: Encountered missing dependencies:
turtle -any
```

**New error:**

```
$ cabal configure
Resolving dependencies...
<snip>
cabal: Encountered missing dependencies:
turtle -any
Have you run 'cabal install'?
```

**Testing:**
* cabal-testsuite/PackageTests/ConfigureComponent/SubLib/setup-explicit-fail.out has been updated for the new error message.

