### PR TITLE
Add datadir env var before running the exe

### DIFF
--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/Datafiles.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/Datafiles.cabal
@@ -1,0 +1,11 @@
+name: Datafiles
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+data-dir: data
+data-files: hello.txt
+
+executable foo
+    main-is: Main.hs
+    build-depends: base
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/Main.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/Main.hs
@@ -1,0 +1,4 @@
+import Paths_Datafiles
+
+main = putStrLn =<< readFile =<< getDataFileName "hello.txt"
+

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/cabal.out
@@ -1,0 +1,8 @@
+# cabal new-run
+Resolving dependencies...
+Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+In order, the following will be built:
+ - Datafiles-1.0 (exe:foo) (first run)
+Configuring executable 'foo' for Datafiles-1.0..
+Preprocessing executable 'foo' for Datafiles-1.0..
+Building executable 'foo' for Datafiles-1.0..

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/cabal.test.hs
@@ -1,0 +1,4 @@
+import Test.Cabal.Prelude
+main = cabalTest $
+    cabal' "new-run" ["foo"] >>= assertOutputContains "Hello World"
+

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/data/hello.txt
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/data/hello.txt
@@ -1,0 +1,1 @@
+Hello World


### PR DESCRIPTION
This enables the executale to find the datafiles in inplace builds.

Fixes #4120 

* [x] Any changes that could be relevant to users have been recorded in the changelog. (this is part of new-run)
* [x] Added a test for this.