### PR TITLE
Add staticlib

### DIFF
--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -81,6 +81,7 @@ module Distribution.PackageDescription (
         hcOptions,
         hcProfOptions,
         hcSharedOptions,
+        hcStaticOptions,
 
         -- ** Supplementary build information
         ComponentName(..),

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -510,6 +510,8 @@ binfoFieldDescrs =
            sharedOptions      (\val binfo -> binfo{sharedOptions=val})
  , optsField   "ghcjs-shared-options" GHCJS
            sharedOptions      (\val binfo -> binfo{sharedOptions=val})
+ , optsField   "ghc-static-options" GHC
+           staticOptions      (\val binfo -> binfo{staticOptions=val})
  , optsField   "ghc-options"  GHC
            options            (\path  binfo -> binfo{options=path})
  , optsField   "ghcjs-options" GHCJS

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -510,8 +510,6 @@ binfoFieldDescrs =
            sharedOptions      (\val binfo -> binfo{sharedOptions=val})
  , optsField   "ghcjs-shared-options" GHCJS
            sharedOptions      (\val binfo -> binfo{sharedOptions=val})
- , optsField   "ghc-static-options" GHC
-           staticOptions      (\val binfo -> binfo{staticOptions=val})
  , optsField   "ghc-options"  GHC
            options            (\path  binfo -> binfo{options=path})
  , optsField   "ghcjs-options" GHCJS

--- a/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
@@ -514,8 +514,6 @@ binfoFieldDescrs =
            sharedOptions      (\val binfo -> binfo{sharedOptions=val})
  , optsField   "ghcjs-shared-options" GHCJS
            sharedOptions      (\val binfo -> binfo{sharedOptions=val})
- , optsField   "ghc-static-options" GHC
-           staticOptions      (\val binfo -> binfo{staticOptions=val})
  , optsField   "ghc-options"  GHC
         options            (\path  binfo -> binfo{options=path})
  , optsField   "ghcjs-options" GHCJS

--- a/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec/FieldDescr.hs
@@ -514,7 +514,9 @@ binfoFieldDescrs =
            sharedOptions      (\val binfo -> binfo{sharedOptions=val})
  , optsField   "ghcjs-shared-options" GHCJS
            sharedOptions      (\val binfo -> binfo{sharedOptions=val})
-   , optsField   "ghc-options"  GHC
+ , optsField   "ghc-static-options" GHC
+           staticOptions      (\val binfo -> binfo{staticOptions=val})
+ , optsField   "ghc-options"  GHC
         options            (\path  binfo -> binfo{options=path})
  , optsField   "ghcjs-options" GHCJS
            options            (\path  binfo -> binfo{options=path})

--- a/Cabal/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/Distribution/Simple/BuildPaths.hs
@@ -199,6 +199,8 @@ mkSharedLibName (CompilerId compilerFlavor compilerVersion) lib
   = "lib" ++ getHSLibraryName lib ++ "-" ++ comp <.> dllExtension
   where comp = display compilerFlavor ++ display compilerVersion
 
+-- Static libs are named the same as shared libraries, only with
+-- a different extension.
 mkStaticLibName :: CompilerId -> UnitId -> String
 mkStaticLibName (CompilerId compilerFlavor compilerVersion) lib
   = "lib" ++ getHSLibraryName lib ++ "-" ++ comp <.> staticLibExtension

--- a/Cabal/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/Distribution/Simple/BuildPaths.hs
@@ -28,7 +28,8 @@ module Distribution.Simple.BuildPaths (
     mkLibName,
     mkProfLibName,
     mkSharedLibName,
-
+    mkStaticLibName,
+    
     exeExtension,
     objExtension,
     dllExtension,
@@ -196,6 +197,11 @@ mkProfLibName lib =  "lib" ++ getHSLibraryName lib ++ "_p" <.> "a"
 mkSharedLibName :: CompilerId -> UnitId -> String
 mkSharedLibName (CompilerId compilerFlavor compilerVersion) lib
   = "lib" ++ getHSLibraryName lib ++ "-" ++ comp <.> dllExtension
+  where comp = display compilerFlavor ++ display compilerVersion
+
+mkStaticLibName :: CompilerId -> UnitId -> String
+mkStaticLibName (CompilerId compilerFlavor compilerVersion) lib
+  = "lib" ++ getHSLibraryName lib ++ "-" ++ comp <.> staticLibExtension
   where comp = display compilerFlavor ++ display compilerVersion
 
 -- ------------------------------------------------------------

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -667,8 +667,6 @@ configure (pkg_descr0, pbi) cfg = do
            "Executables will use dynamic linking, but a shared library "
         ++ "is not being built. Linking will fail if any executables "
         ++ "depend on the library."
-    when withStaticLib_ $ warn verbosity $ "Static lib enabled"
-    when (not withStaticLib_) $ warn verbosity $ "Static lib disabled!"
 
     setProfLBI <- configureProfiling verbosity cfg comp
 

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -655,11 +655,20 @@ configure (pkg_descr0, pbi) cfg = do
             -- building only static library archives with
             -- --disable-shared.
             fromFlagOrDefault sharedLibsByDefault $ configSharedLib cfg
+
+        -- FIXME: this should ideally be set per target, e.g.
+        --        cabal new-build -staticlib should produce the
+        --        final library as static library.
+        withStaticLib_ =
+            fromFlagOrDefault False $ configStaticLib cfg
+
         withDynExe_ = fromFlag $ configDynExe cfg
     when (withDynExe_ && not withSharedLib_) $ warn verbosity $
            "Executables will use dynamic linking, but a shared library "
         ++ "is not being built. Linking will fail if any executables "
         ++ "depend on the library."
+    when withStaticLib_ $ warn verbosity $ "Static lib enabled"
+    when (not withStaticLib_) $ warn verbosity $ "Static lib disabled!"
 
     setProfLBI <- configureProfiling verbosity cfg comp
 
@@ -692,6 +701,7 @@ configure (pkg_descr0, pbi) cfg = do
                 withPrograms        = programDb'',
                 withVanillaLib      = fromFlag $ configVanillaLib cfg,
                 withSharedLib       = withSharedLib_,
+                withStaticLib       = withStaticLib_,
                 withDynExe          = withDynExe_,
                 withProfLib         = False,
                 withProfLibDetail   = ProfDetailNone,

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -656,10 +656,9 @@ configure (pkg_descr0, pbi) cfg = do
             -- --disable-shared.
             fromFlagOrDefault sharedLibsByDefault $ configSharedLib cfg
 
-        -- FIXME: this should ideally be set per target, e.g.
-        --        cabal new-build -staticlib should produce the
-        --        final library as static library.
         withStaticLib_ =
+            -- build a static library (all dependent libraries rolled
+            -- into a huge .a archive) via GHCs -staticlib flag.
             fromFlagOrDefault False $ configStaticLib cfg
 
         withDynExe_ = fromFlag $ configDynExe cfg

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -299,6 +299,7 @@ data ConfigFlags = ConfigFlags {
     configVanillaLib    :: Flag Bool,     -- ^Enable vanilla library
     configProfLib       :: Flag Bool,     -- ^Enable profiling in the library
     configSharedLib     :: Flag Bool,     -- ^Build shared library
+    configStaticLib     :: Flag Bool,     -- ^Build static library
     configDynExe        :: Flag Bool,     -- ^Enable dynamic linking of the
                                           -- executables.
     configProfExe       :: Flag Bool,     -- ^Enable profiling in the
@@ -377,6 +378,7 @@ instance Eq ConfigFlags where
     && equal configVanillaLib
     && equal configProfLib
     && equal configSharedLib
+    && equal configStaticLib
     && equal configDynExe
     && equal configProfExe
     && equal configProf
@@ -428,6 +430,7 @@ defaultConfigFlags progDb = emptyConfigFlags {
     configVanillaLib   = Flag True,
     configProfLib      = NoFlag,
     configSharedLib    = NoFlag,
+    configStaticLib    = NoFlag,
     configDynExe       = Flag False,
     configProfExe      = NoFlag,
     configProf         = NoFlag,
@@ -557,6 +560,11 @@ configureOptions showOrParseArgs =
          configSharedLib (\v flags -> flags { configSharedLib = v })
          (boolOpt [] [])
 
+      ,option "" ["static"]
+         "Static library"
+         configStaticLib (\v flags -> flags { configStaticLib = v })
+         (boolOpt [] [])
+      
       ,option "" ["executable-dynamic"]
          "Executable dynamic linking"
          configDynExe (\v flags -> flags { configDynExe = v })

--- a/Cabal/Distribution/Types/BuildInfo.hs
+++ b/Cabal/Distribution/Types/BuildInfo.hs
@@ -13,6 +13,7 @@ module Distribution.Types.BuildInfo (
     hcOptions,
     hcProfOptions,
     hcSharedOptions,
+    hcStaticOptions,
 ) where
 
 import Prelude ()
@@ -75,6 +76,7 @@ data BuildInfo = BuildInfo {
         options           :: [(CompilerFlavor,[String])],
         profOptions       :: [(CompilerFlavor,[String])],
         sharedOptions     :: [(CompilerFlavor,[String])],
+        staticOptions     :: [(CompilerFlavor,[String])],
         customFieldsBI    :: [(String,String)], -- ^Custom fields starting
                                                 -- with x-, stored in a
                                                 -- simple assoc-list.
@@ -115,6 +117,7 @@ instance Monoid BuildInfo where
     options             = [],
     profOptions         = [],
     sharedOptions       = [],
+    staticOptions       = [],
     customFieldsBI      = [],
     targetBuildDepends  = [],
     mixins    = []
@@ -151,6 +154,7 @@ instance Semigroup BuildInfo where
     options             = combine    options,
     profOptions         = combine    profOptions,
     sharedOptions       = combine    sharedOptions,
+    staticOptions       = combine    staticOptions,
     customFieldsBI      = combine    customFieldsBI,
     targetBuildDepends  = combineNub targetBuildDepends,
     mixins    = combine mixins
@@ -198,6 +202,9 @@ hcProfOptions = lookupHcOptions profOptions
 
 hcSharedOptions :: CompilerFlavor -> BuildInfo -> [String]
 hcSharedOptions = lookupHcOptions sharedOptions
+
+hcStaticOptions :: CompilerFlavor -> BuildInfo -> [String]
+hcStaticOptions = lookupHcOptions staticOptions
 
 lookupHcOptions :: (BuildInfo -> [(CompilerFlavor,[String])])
                 -> CompilerFlavor -> BuildInfo -> [String]

--- a/Cabal/Distribution/Types/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Types/LocalBuildInfo.hs
@@ -142,6 +142,7 @@ data LocalBuildInfo = LocalBuildInfo {
         withVanillaLib:: Bool,  -- ^Whether to build normal libs.
         withProfLib   :: Bool,  -- ^Whether to build profiling versions of libs.
         withSharedLib :: Bool,  -- ^Whether to build shared versions of libs.
+        withStaticLib :: Bool,  -- ^Whether to build static versions of libs (with all other libs rolled in)
         withDynExe    :: Bool,  -- ^Whether to link executables dynamically
         withProfExe   :: Bool,  -- ^Whether to build executables for profiling.
         withProfLibDetail :: ProfDetailLevel, -- ^Level of automatic profile detail.

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -1135,6 +1135,16 @@ Miscellaneous options
 
     (default) Do not build shared library.
 
+.. option:: --enable-static
+
+   Build a static library. This passes ``-staticlib`` to GHC (avaiable
+   for iOS, and with 8.4 more platforms).  The result is an archive ``.a``
+   containing all dependent haskell libararies combined.
+
+.. option:: --disable-static
+
+    (default) Do not build a static library.
+
 .. option:: --enable-executable-dynamic
 
     Link executables dynamically. The executable's library dependencies

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -1205,6 +1205,21 @@ Dynamic linking options
 
     The command line variant of this flag is ``--relocatable``.
 
+Static linking options
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. cfg-field:: static: boolean
+               --enable-static
+               --disable-static
+    :synopsis: Build static library.
+
+
+    :default: False
+
+    Roll this and all dependent libraries into a combined ``.a`` archive.
+    This uses GHCs ``-staticlib`` flag, which is avaiable for iOS and with
+    GHC 8.4 and later for other platforms as well.
+
 Foreign function interface options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -285,6 +285,7 @@ instance Semigroup SavedConfig where
         configProfLib             = combine configProfLib,
         configProf                = combine configProf,
         configSharedLib           = combine configSharedLib,
+        configStaticLib           = combine configStaticLib,
         configDynExe              = combine configDynExe,
         configProfExe             = combine configProfExe,
         configProfDetail          = combine configProfDetail,

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -330,6 +330,7 @@ convertLegacyPerPackageFlags configFlags installFlags haddockFlags =
       configVanillaLib          = packageConfigVanillaLib,
       configProfLib             = packageConfigProfLib,
       configSharedLib           = packageConfigSharedLib,
+      configStaticLib           = packageConfigStaticLib,
       configDynExe              = packageConfigDynExe,
       configProfExe             = packageConfigProfExe,
       configProf                = packageConfigProf,
@@ -556,6 +557,7 @@ convertToLegacyAllPackageConfig
       configVanillaLib          = mempty,
       configProfLib             = mempty,
       configSharedLib           = mempty,
+      configStaticLib           = mempty,
       configDynExe              = mempty,
       configProfExe             = mempty,
       configProf                = mempty,
@@ -621,6 +623,7 @@ convertToLegacyPerPackageConfig PackageConfig {..} =
       configVanillaLib          = packageConfigVanillaLib,
       configProfLib             = packageConfigProfLib,
       configSharedLib           = packageConfigSharedLib,
+      configStaticLib           = packageConfigStaticLib,
       configDynExe              = packageConfigDynExe,
       configProfExe             = packageConfigProfExe,
       configProf                = packageConfigProf,
@@ -913,7 +916,7 @@ legacyPackageConfigFieldDescrs =
       [ "with-compiler", "with-hc-pkg"
       , "program-prefix", "program-suffix"
       , "library-vanilla", "library-profiling"
-      , "shared", "executable-dynamic"
+      , "shared", "static", "executable-dynamic"
       , "profiling", "executable-profiling"
       , "profiling-detail", "library-profiling-detail"
       , "library-for-ghci", "split-objs"

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -226,6 +226,7 @@ data PackageConfig
        packageConfigFlagAssignment      :: FlagAssignment,
        packageConfigVanillaLib          :: Flag Bool,
        packageConfigSharedLib           :: Flag Bool,
+       packageConfigStaticLib           :: Flag Bool,
        packageConfigDynExe              :: Flag Bool,
        packageConfigProf                :: Flag Bool, --TODO: [code cleanup] sort out
        packageConfigProfLib             :: Flag Bool, --      this duplication

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1664,6 +1664,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
 
         elabVanillaLib    = perPkgOptionFlag pkgid True packageConfigVanillaLib --TODO: [required feature]: also needs to be handled recursively
         elabSharedLib     = pkgid `Set.member` pkgsUseSharedLibrary
+        elabStaticLib     = perPkgOptionFlag pkgid False packageConfigStaticLib
         elabDynExe        = perPkgOptionFlag pkgid False packageConfigDynExe
         elabGHCiLib       = perPkgOptionFlag pkgid False packageConfigGHCiLib --TODO: [required feature] needs to default to enabled on windows still
 
@@ -3001,6 +3002,8 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
 
     configVanillaLib          = toFlag elabVanillaLib
     configSharedLib           = toFlag elabSharedLib
+    configStaticLib           = toFlag elabStaticLib
+    
     configDynExe              = toFlag elabDynExe
     configGHCiLib             = toFlag elabGHCiLib
     configProfExe             = mempty

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -230,6 +230,7 @@ data ElaboratedConfiguredPackage
        -- TODO: make per-component variants of these flags
        elabVanillaLib           :: Bool,
        elabSharedLib            :: Bool,
+       elabStaticLib            :: Bool,
        elabDynExe               :: Bool,
        elabGHCiLib              :: Bool,
        elabProfLib              :: Bool,

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -422,7 +422,9 @@ filterConfigureFlags flags cabalLibVersion
 
     flags_2_1_0 = flags_latest {
       -- Cabal < 2.1 doesn't know about -v +timestamp modifier
-      configVerbosity   = fmap verboseNoTimestamp (configVerbosity flags_latest)
+        configVerbosity   = fmap verboseNoTimestamp (configVerbosity flags_latest)
+      -- Cabal < 2.1 doesn't know about --<enable|disable>-static
+      , configStaticLib   = NoFlag
       }
 
     flags_1_25_0 = flags_2_1_0 {

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,8 @@
 -*-change-log-*-
 
 2.2.0.0 (current development version)
+	* 'cabal configure' now supports '--enable-static' which can be
+	used to build static libaries with GHC via GHCs `-staticlib` flag.
 	* 'cabal update' now supports '--index-state' which can be used to
 	roll back the index to an earlier state.
 	* 'cabal new-configure' now backs up the old 'cabal.project.local'

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -490,7 +490,7 @@ instance Arbitrary PackageConfig where
                    <*> listOf arbitraryShortToken))
         <*> (toNubList <$> listOf arbitraryShortToken)
         <*> arbitrary
-        <*> arbitrary <*> arbitrary
+        <*> arbitrary <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary
@@ -529,6 +529,7 @@ instance Arbitrary PackageConfig where
                          , packageConfigFlagAssignment = x03
                          , packageConfigVanillaLib = x04
                          , packageConfigSharedLib = x05
+                         , packageConfigStaticLib = x42
                          , packageConfigDynExe = x06
                          , packageConfigProf = x07
                          , packageConfigProfLib = x08
@@ -572,6 +573,7 @@ instance Arbitrary PackageConfig where
                       , packageConfigFlagAssignment = x03'
                       , packageConfigVanillaLib = x04'
                       , packageConfigSharedLib = x05'
+                      , packageConfigStaticLib = x42'
                       , packageConfigDynExe = x06'
                       , packageConfigProf = x07'
                       , packageConfigProfLib = x08'
@@ -610,7 +612,7 @@ instance Arbitrary PackageConfig where
                       , packageConfigHaddockContents = x40'
                       , packageConfigHaddockForHackage = x41' }
       |  (((x00', x01', x02', x03', x04'),
-          (x05', x06', x07', x08', x09'),
+          (x05', x42', x06', x07', x08', x09'),
           (x10', x11', x12', x13', x14'),
           (x15', x16', x17', x18', x19')),
          ((x20', x21', x22', x23', x24'),
@@ -620,7 +622,7 @@ instance Arbitrary PackageConfig where
           (x40', x41')))
           <- shrink
              (((preShrink_Paths x00, preShrink_Args x01, x02, x03, x04),
-                (x05, x06, x07, x08, x09),
+                (x05, x42, x06, x07, x08, x09),
                 (x10, x11, map NonEmpty x12, x13, x14),
                 (x15, map NonEmpty x16,
                   map NonEmpty x17,


### PR DESCRIPTION
This adds support for GHCs `-staticlib` flag, which produces a static library that has all dependencies rolled into a massive archive.  This is rather useful when building libraries that are supposed to be deployed and linked. `-staticlib` is only available for macOS/iOS in GHC 8.2 and earlier, due to the reliance on `libtool`. With [D3721](https://phabricator.haskell.org/D3721), this will be available in GHC 8.4+ for all platforms.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!