### PR TITLE
Further compact build profile output in new-build

### DIFF
--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -767,10 +767,14 @@ printPlan verbosity
     showMonitorChangedReason  MonitorFirstRun     = "first run"
     showMonitorChangedReason  MonitorCorruptCache = "cannot read state cache"
 
-    showBuildProfile = "Build profile: " ++ (intercalate ", " [
-      "with-compiler: " ++ (showCompilerId . pkgConfigCompiler) elaboratedShared,
-      "optimisation: " ++ (show (fromMaybe NormalOptimisation (Setup.flagToMaybe packageConfigOptimization)))]
-      ) ++ "\n"
+    showBuildProfile = "Build profile: " ++ unwords [
+      "-w " ++ (showCompilerId . pkgConfigCompiler) elaboratedShared,
+      "-O" ++  (case packageConfigOptimization of
+                Setup.Flag NoOptimisation      -> "0"
+                Setup.Flag NormalOptimisation  -> "1"
+                Setup.Flag MaximumOptimisation -> "2"
+                _                              -> "1")]
+      ++ "\n"
 
 -- | If there are build failures then report them and throw an exception.
 --

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external-target.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external-target.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - mylib-0.1.0.0 (lib) (first run)
 Configuring library for mylib-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-external.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - mylib-0.1.0.0 (lib) (first run)
  - mysql-0.1.0.0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal-target.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal-target.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - Includes2-0.1.0.0 (lib:mylib) (first run)
 Configuring library 'mylib' for Includes2-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - Includes2-0.1.0.0 (lib:mylib) (first run)
  - Includes2-0.1.0.0 (lib:mysql) (first run)

--- a/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-external.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-external.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - sigs-0.1.0.0 (lib) (first run)
  - indef-0.1.0.0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-internal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-internal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - Includes3-0.1.0.0 (lib:sigs) (first run)
  - Includes3-0.1.0.0 (lib:indef) (first run)

--- a/cabal-testsuite/PackageTests/BuildDeps/InternalLibrary1/cabal.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/InternalLibrary1/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - InternalLibrary1-0.1 (exe:lemon) (first run)
 Configuring InternalLibrary1-0.1...

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/use-local-version-of-package.out
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/use-local-version-of-package.out
@@ -2,7 +2,7 @@
 Downloading the latest package list from test-local-repo
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - pkg-1.0 (exe:my-exe) (first run)
 Configuring pkg-1.0...

--- a/cabal-testsuite/PackageTests/BuildToolDepends/setup.out
+++ b/cabal-testsuite/PackageTests/BuildToolDepends/setup.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - pre-proc-999.999.999 (exe:zero-to-one) (first run)
  - client-0.1.0.0 (exe:hello-world) (first run)

--- a/cabal-testsuite/PackageTests/BuildTools/External/cabal.out
+++ b/cabal-testsuite/PackageTests/BuildTools/External/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - happy-999.999.999 (exe:happy) (first run)
  - client-0.1.0.0 (exe:hello-world) (first run)

--- a/cabal-testsuite/PackageTests/BuildTools/Internal/cabal.out
+++ b/cabal-testsuite/PackageTests/BuildTools/Internal/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - foo-0.1.0.0 (exe:my-cpp) (first run)
  - foo-0.1.0.0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/CustomSegfault/cabal.out
+++ b/cabal-testsuite/PackageTests/CustomSegfault/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - plain-0.1.0.0 (lib:plain) (first run)
 cabal: Failed to build plain-0.1.0.0-inplace. The failure occurred during the configure step. The build process segfaulted (i.e. SIGSEGV).

--- a/cabal-testsuite/PackageTests/CustomWithoutCabal/cabal.out
+++ b/cabal-testsuite/PackageTests/CustomWithoutCabal/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Warning: <ROOT>/custom-setup-without-cabal.cabal: This package requires at least Cabal version 99999
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - custom-setup-without-cabal-1.0 (lib:custom-setup-without-cabal) (first run)

--- a/cabal-testsuite/PackageTests/CustomWithoutCabalDefaultMain/cabal.out
+++ b/cabal-testsuite/PackageTests/CustomWithoutCabalDefaultMain/cabal.out
@@ -1,5 +1,5 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - custom-setup-without-cabal-defaultMain-1.0 (lib:custom-setup-without-cabal-defaultMain) (first run)

--- a/cabal-testsuite/PackageTests/Exec/cabal.out
+++ b/cabal-testsuite/PackageTests/Exec/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - my-0.1 (exe:my-executable) (first run)
 Configuring my-0.1...

--- a/cabal-testsuite/PackageTests/ExecModern/cabal.out
+++ b/cabal-testsuite/PackageTests/ExecModern/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - my-0.1 (exe:my-executable) (first run)
 Configuring executable 'my-executable' for my-0.1..

--- a/cabal-testsuite/PackageTests/InternalLibraries/cabal.out
+++ b/cabal-testsuite/PackageTests/InternalLibraries/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - p-0.1.0.0 (lib:q) (first run)
  - p-0.1.0.0 (exe:foo) (first run)

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Datafiles/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-run
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - Datafiles-1.0 (exe:foo) (first run)
 Configuring executable 'foo' for Datafiles-1.0..

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/ExeAndLib/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/ExeAndLib/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-run
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - ExeAndLib-1.0 (exe:foo) (first run)
 Configuring executable 'foo' for ExeAndLib-1.0..

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/ExitCodePropagation/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/ExitCodePropagation/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-run
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - ExitCodePropagation-1.0 (exe:foo) (first run)
 Configuring executable 'foo' for ExitCodePropagation-1.0..

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/MultipleExes/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/MultipleExes/cabal.out
@@ -1,13 +1,13 @@
 # cabal new-run
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - MultipleExes-1.0 (exe:foo) (first run)
 Configuring executable 'foo' for MultipleExes-1.0..
 Preprocessing executable 'foo' for MultipleExes-1.0..
 Building executable 'foo' for MultipleExes-1.0..
 # cabal new-run
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - MultipleExes-1.0 (exe:bar) (first run)
 Configuring executable 'bar' for MultipleExes-1.0..

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/MultiplePackages/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/MultiplePackages/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-run
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - bar-1.0 (exe:bar-exe) (first run)
 Configuring executable 'bar-exe' for bar-1.0..
@@ -9,14 +9,14 @@ Building executable 'bar-exe' for bar-1.0..
 # cabal new-run
 Up to date
 # cabal new-run
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - foo-1.0 (exe:foo-exe) (first run)
 Configuring executable 'foo-exe' for foo-1.0..
 Preprocessing executable 'foo-exe' for foo-1.0..
 Building executable 'foo-exe' for foo-1.0..
 # cabal new-run
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - bar-1.0 (exe:foo-exe) (first run)
 Configuring executable 'foo-exe' for bar-1.0..

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Single/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Single/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-run
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - Single-1.0 (exe:foo) (first run)
 Configuring executable 'foo' for Single-1.0..

--- a/cabal-testsuite/PackageTests/NewBuild/MonitorCabalFiles/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/MonitorCabalFiles/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - q-0.1.0.0 (exe:q) (first run)
 Configuring executable 'q' for q-0.1.0.0..
@@ -8,7 +8,7 @@ Preprocessing executable 'q' for q-0.1.0.0..
 Building executable 'q' for q-0.1.0.0..
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - p-1.0 (lib) (first run)
  - q-0.1.0.0 (exe:q) (configuration changed)

--- a/cabal-testsuite/PackageTests/NewBuild/T3827/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/T3827/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - p-1.0 (lib) --enable-library-profiling (first run)
  - q-1.0 (exe:q) --enable-profiling (first run)

--- a/cabal-testsuite/PackageTests/NewBuild/T4017/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/T4017/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - p-1.0 (lib) (first run)
  - q-1.0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/NewBuild/T4375/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/T4375/cabal.out
@@ -2,7 +2,7 @@
 Downloading the latest package list from test-local-repo
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - old-locale-1.0.0.7 (lib) (requires download & build)
  - old-time-1.1.0.3 (lib) (requires download & build)

--- a/cabal-testsuite/PackageTests/NewBuild/T4405/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/T4405/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - p-1.0 (lib) (first run)
  - q-1.0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/NewBuild/T4477/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/T4477/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-run
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - T4477-1.0 (exe:foo) (first run)
 Configuring executable 'foo' for T4477-1.0..

--- a/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/cabal.out
+++ b/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-configure
 'cabal.project.local' file already exists. Now overwriting it.
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following would be built:
  - NewConfigure-0.1.0.0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/Regression/T3436/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T3436/cabal.out
@@ -1,7 +1,7 @@
 # cabal new-build
 Warning: <ROOT>/custom-setup/custom-setup.cabal: This package requires at least Cabal version 99999
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - Cabal-99999 (lib:Cabal) (first run)
  - custom-setup-1.0 (lib:custom-setup) (first run)

--- a/cabal-testsuite/PackageTests/Regression/T4154/install-time-with-constraint.out
+++ b/cabal-testsuite/PackageTests/Regression/T4154/install-time-with-constraint.out
@@ -2,7 +2,7 @@
 Downloading the latest package list from test-local-repo
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following would be built:
  - Cabal-99999 (lib) (requires download & build)
  - time-99999 (lib:time) (first run)

--- a/cabal-testsuite/PackageTests/Regression/T4202/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T4202/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-build
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - p-1.0 (lib) (first run)
  - q-1.0 (exe:qexe) (first run)
@@ -11,13 +11,13 @@ Configuring executable 'qexe' for q-1.0..
 Preprocessing executable 'qexe' for q-1.0..
 Building executable 'qexe' for q-1.0..
 # cabal new-build
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - p-1.0 (lib) (file P.hs changed)
 Preprocessing library for p-1.0..
 Building library for p-1.0..
 # cabal new-build
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - q-1.0 (exe:qexe) (file <ROOT>/cabal.dist/work/dist/build/<ARCH>/ghc-<GHCVER>/p-1.0/cache/build changed)
 Preprocessing executable 'qexe' for q-1.0..

--- a/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/cabal.out
+++ b/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/cabal.out
@@ -1,6 +1,6 @@
 # cabal new-test
 Resolving dependencies...
-Build profile: with-compiler: ghc-<GHCVER>, optimisation: NormalOptimisation
+Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - my-0.1 (lib) (first run)
  - my-0.1 (test:test-Short) (first run)


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

This change will further compact the newly added Build Profile to new-build command in #4605 per @hvr's comment: https://github.com/haskell/cabal/pull/4605#issuecomment-315975829

Before this change:
```
Build profile: with-compiler: ghc-7.10.3, optimization: MaximumOptimisation
```

And after this change:
```
Build profile: -w ghc-7.10.3 -O2
```