### PR TITLE
Put libraries into $store/lib

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2944,7 +2944,8 @@ storePackageInstallDirs StoreDirLayout{ storePackageDirectory
     bindir       = prefix </> "bin"
     libdir       = prefix </> "lib"
     libsubdir    = ""
-    dynlibdir    = store </> "lib" 
+    dynlibdir    | buildOS == OSX = store </> "lib"
+                 | otherwise      = libdir
     flibdir      = libdir
     libexecdir   = prefix </> "libexec"
     libexecsubdir= ""

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2944,6 +2944,10 @@ storePackageInstallDirs StoreDirLayout{ storePackageDirectory
     bindir       = prefix </> "bin"
     libdir       = prefix </> "lib"
     libsubdir    = ""
+    -- Note: on macOS, we place libraries into
+    --       @store/lib@ to work around the load
+    --       command size limit of macOSs mach-o linker.
+    --       See also @PackageHash.hashedInstalledPackageIdVeryShort@
     dynlibdir    | buildOS == OSX = store </> "lib"
                  | otherwise      = libdir
     flibdir      = libdir

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2934,15 +2934,17 @@ storePackageInstallDirs :: StoreDirLayout
                         -> CompilerId
                         -> InstalledPackageId
                         -> InstallDirs.InstallDirs FilePath
-storePackageInstallDirs StoreDirLayout{storePackageDirectory}
+storePackageInstallDirs StoreDirLayout{ storePackageDirectory
+                                      , storeDirectory }
                         compid ipkgid =
     InstallDirs.InstallDirs {..}
   where
+    store        = storeDirectory compid
     prefix       = storePackageDirectory compid (newSimpleUnitId ipkgid)
     bindir       = prefix </> "bin"
     libdir       = prefix </> "lib"
     libsubdir    = ""
-    dynlibdir    = libdir
+    dynlibdir    = store </> "lib" 
     flibdir      = libdir
     libexecdir   = prefix </> "libexec"
     libexecsubdir= ""

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -17,6 +17,9 @@
 	dependencies (#4575, #4669).
 	* `--store-dir` option can be used to configure the location of
 	the build global build store.
+	* On macOS, `new-build` will place dynamic libraries into
+	`store/lib` and aggressively shorten their names in an effort to
+	stay within the load command size limits of macOSs mach-o linker.
 
 2.0.TBD
 	* Turn `allow-{newer,older}` in `cabal.project` files into an

--- a/cabal-install/tests/UnitTests/Distribution/Client/Store.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Store.hs
@@ -51,7 +51,7 @@ testInstallSerial =
           let destprefix = dir </> "prefix"
           createDirectory destprefix
           writeFile (destprefix </> file) content
-          return destprefix
+          return (destprefix,[])
 
     assertNewStoreEntry tmp storeDirLayout compid unitid1
                         (copyFiles "file1" "content-foo") (return ())
@@ -137,7 +137,7 @@ testInstallParallel =
 
 assertNewStoreEntry :: FilePath -> StoreDirLayout
                     -> CompilerId -> UnitId
-                    -> (FilePath -> IO FilePath) -> IO ()
+                    -> (FilePath -> IO (FilePath,[FilePath])) -> IO ()
                     -> NewStoreEntryOutcome
                     -> Assertion
 assertNewStoreEntry tmp storeDirLayout compid unitid


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

This is a stab at #4263 as an alternative to #4426.

The general strategy is:
- put all libraries into `$store/lib`. This though makes them not prefix relocatable anymore.
   I'm fine with that for macOS.
- As that is not enough to stay under the load command limit for my tiny sample app, we
  mutilate the package name as well. We cut the abi hash to 4 byte 😱 and drop vowels.
  We can not drop the `-ghcX.Y.Z` suffix it seems as GHC seems to append that on it's own.

This then produces only one `@rpath` entry to `$HOME/.cabal/store/ghc-x.y.z/lib`. And thus
saving quite a bit already.

The alternative strategy I though of was to rename only the dynamic library to `libHS-ghcX.Y.Z.dylib`, and try to turn the reference to `@rpath/name-version-hash/lib/libHS-ghcX.Y.Z.dylib`. That would also
reduce the `@rpath` entry to one, but suffer from the same long filename issue.