### PR TITLE
Refactor/cleanup of `String`/`ByteString` usage

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -126,6 +126,7 @@ library
     Distribution.Backpack.ModSubst
     Distribution.Backpack.ModuleShape
     Distribution.Backpack.PreModuleShape
+    Distribution.Utils.IOData
     Distribution.Utils.LogProgress
     Distribution.Utils.MapAccum
     Distribution.Compat.CreatePipe

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -132,6 +132,8 @@ module Distribution.Simple.Utils (
         fromUTF8BS,
         fromUTF8LBS,
         toUTF8,
+        toUTF8BS,
+        toUTF8LBS,
         readUTF8File,
         withUTF8FileContents,
         writeUTF8File,

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -136,10 +136,8 @@ module Distribution.Simple.Utils (
         rewriteFile,
 
         -- * Unicode
-        fromUTF8,
         fromUTF8BS,
         fromUTF8LBS,
-        toUTF8,
         toUTF8BS,
         toUTF8LBS,
         readUTF8File,
@@ -148,8 +146,6 @@ module Distribution.Simple.Utils (
         normaliseLineEndings,
 
         -- * BOM
-        startsWithBOM,
-        fileHasBOM,
         ignoreBOM,
 
         -- * generic utils

--- a/Cabal/Distribution/Utils/Generic.hs
+++ b/Cabal/Distribution/Utils/Generic.hs
@@ -27,19 +27,28 @@ module Distribution.Utils.Generic (
         writeFileAtomic,
 
         -- * Unicode
+
+        -- ** Conversions
         fromUTF8,
         fromUTF8BS,
         fromUTF8LBS,
+
         toUTF8,
+        toUTF8BS,
+        toUTF8LBS,
+
+        -- ** File I/O
         readUTF8File,
         withUTF8FileContents,
         writeUTF8File,
-        normaliseLineEndings,
 
-        -- * BOM
+        -- ** BOM
         startsWithBOM,
         fileHasBOM,
         ignoreBOM,
+
+        -- ** Misc
+        normaliseLineEndings,
 
         -- * generic utils
         dropWhileEndLE,
@@ -222,6 +231,13 @@ toUTF8 (c:cs)
                  : chr (0x80 .|.  (w .&. 0x3F))
                  : toUTF8 cs
   where w = ord c
+
+
+toUTF8BS :: String -> SBS.ByteString
+toUTF8BS = SBS.pack . encodeStringUtf8
+
+toUTF8LBS :: String -> BS.ByteString
+toUTF8LBS = BS.pack . encodeStringUtf8
 
 -- | Whether BOM is at the beginning of the input
 startsWithBOM :: String -> Bool

--- a/Cabal/Distribution/Utils/Generic.hs
+++ b/Cabal/Distribution/Utils/Generic.hs
@@ -29,11 +29,9 @@ module Distribution.Utils.Generic (
         -- * Unicode
 
         -- ** Conversions
-        fromUTF8,
         fromUTF8BS,
         fromUTF8LBS,
 
-        toUTF8,
         toUTF8BS,
         toUTF8LBS,
 
@@ -43,8 +41,6 @@ module Distribution.Utils.Generic (
         writeUTF8File,
 
         -- ** BOM
-        startsWithBOM,
-        fileHasBOM,
         ignoreBOM,
 
         -- ** Misc
@@ -161,40 +157,17 @@ writeFileAtomic targetPath content = do
 -- * Unicode stuff
 -- ------------------------------------------------------------
 
--- This is a modification of the UTF8 code from gtk2hs and the
--- utf8-string package.
-
-{-# DEPRECATED fromUTF8 "Please use 'decodeStringUtf8', 'fromUTF8BS', or 'fromUTF8BS'" #-}
-fromUTF8 :: String -> String
-fromUTF8 = decodeStringUtf8 . map c2w
-  where
-    c2w c | c > '\xFF' = error "fromUTF8: invalid input data"
-          | otherwise  = fromIntegral (ord c)
-
 fromUTF8BS :: SBS.ByteString -> String
 fromUTF8BS = decodeStringUtf8 . SBS.unpack
 
 fromUTF8LBS :: BS.ByteString -> String
 fromUTF8LBS = decodeStringUtf8 . BS.unpack
 
-{-# DEPRECATED toUTF8 "Please use 'encodeStringUtf8', 'toUTF8BS', or 'toUTF8BS'" #-}
-toUTF8 :: String -> String
-toUTF8 = map (chr . fromIntegral) . encodeStringUtf8
-
 toUTF8BS :: String -> SBS.ByteString
 toUTF8BS = SBS.pack . encodeStringUtf8
 
 toUTF8LBS :: String -> BS.ByteString
 toUTF8LBS = BS.pack . encodeStringUtf8
-
--- | Whether BOM is at the beginning of the input
-startsWithBOM :: String -> Bool
-startsWithBOM ('\xFEFF':_) = True
-startsWithBOM _            = False
-
--- | Check whether a file has Unicode byte order mark (BOM).
-fileHasBOM :: FilePath -> NoCallStackIO Bool
-fileHasBOM f = (startsWithBOM . fromUTF8LBS) <$> BS.readFile f
 
 -- | Ignore a Unicode byte order mark (BOM) at the beginning of the input
 --

--- a/Cabal/Distribution/Utils/IOData.hs
+++ b/Cabal/Distribution/Utils/IOData.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE CPP #-}
+
+-- | @since 2.2.0
+module Distribution.Utils.IOData
+    ( -- * 'IOData' & 'IODataMode' type
+      IOData(..)
+    , IODataMode(..)
+    , null
+    , hGetContents
+    , hPutContents
+    ) where
+
+import qualified Data.ByteString.Lazy as BS
+import           Distribution.Compat.Prelude hiding (null)
+import qualified Prelude
+import qualified System.IO
+
+-- | Represents either textual or binary data passed via I/O functions
+-- which support binary/text mode
+--
+-- @since 2.2.0
+data IOData = IODataText    String
+              -- ^ How Text gets encoded is usually locale-dependent.
+            | IODataBinary  BS.ByteString
+              -- ^ Raw binary which gets read/written in binary mode.
+
+-- | Test whether 'IOData' is empty
+--
+-- @since 2.2.0
+null :: IOData -> Bool
+null (IODataText s) = Prelude.null s
+null (IODataBinary b) = BS.null b
+
+instance NFData IOData where
+    rnf (IODataText s) = rnf s
+#if MIN_VERSION_bytestring(0,10,0)
+    rnf (IODataBinary bs) = rnf bs
+#else
+    rnf (IODataBinary bs) = rnf (BS.length bs)
+#endif
+
+data IODataMode = IODataModeText | IODataModeBinary
+
+-- | 'IOData' Wrapper for 'System.IO.hGetContents'
+--
+-- __Note__: This operation uses lazy I/O. Use 'NFData' to force all
+-- data to be read and consequently the internal file handle to be
+-- closed.
+--
+-- @since 2.2.0
+hGetContents :: System.IO.Handle -> IODataMode -> Prelude.IO IOData
+hGetContents h IODataModeText = do
+    System.IO.hSetBinaryMode h False
+    IODataText <$> System.IO.hGetContents h
+hGetContents h IODataModeBinary = do
+    System.IO.hSetBinaryMode h True
+    IODataBinary <$> BS.hGetContents h
+
+-- | 'IOData' Wrapper for 'System.IO.hPutStr' and 'System.IO.hClose'
+--
+-- This is the dual operation ot 'ioDataHGetContents',
+-- and consequently the handle is closed with `hClose`.
+--
+-- @since 2.2.0
+hPutContents :: System.IO.Handle -> IOData -> Prelude.IO ()
+hPutContents h (IODataText c) = do
+    System.IO.hSetBinaryMode h False
+    System.IO.hPutStr h c
+    System.IO.hClose h
+hPutContents h (IODataBinary c) = do
+    System.IO.hSetBinaryMode h True
+    BS.hPutStr h c
+    System.IO.hClose h

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -2,6 +2,11 @@
 
 2.2.0.0 (current development version)
 	* Remove unused '--allow-newer'/'--allow-older' support (#4527)
+	* Change `rawSystemStdInOut` to use proper type to represent
+	  binary and textual data; new 'Distribution.Utils.IOData' module;
+	  removed obsolete 'startsWithBOM', 'fileHasBOM', 'fromUTF8',
+	  and 'toUTF8' functions; add new `toUTF8BS`/`toUTF8LBS`
+	  encoding functions. (#4666)
 	* Warn about `.cabal` file-name not matching package name
 	  in 'cabal check' (#4592)
 	* By default 'ar' program receives arguments via '@file' format.

--- a/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
+++ b/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
@@ -66,20 +66,21 @@ rawSystemStdInOutTextDecodingTest
       hClose handleExe
 
       -- Compile
-      compilationResult <- rawSystemStdInOut normal
+      (IODataText resOutput, resErrors, resExitCode) <- rawSystemStdInOut normal
          "ghc" ["-o", filenameExe, filenameHs]
          Nothing Nothing Nothing
-        False
-      print compilationResult
+         IODataModeText
+      print (resOutput, resErrors, resExitCode)
 
       -- Execute
       Exception.try $ do
         rawSystemStdInOut normal
            filenameExe []
            Nothing Nothing Nothing
-           False -- not binary mode output, ie utf8 text mode so try to decode
+           IODataModeText -- not binary mode output, ie utf8 text mode so try to decode
   case res of
-    Right x -> assertFailure $ "expected IO decoding exception: " ++ show x
+    Right (IODataText x1, x2, x3) -> assertFailure $ "expected IO decoding exception: " ++ show (x1,x2,x3)
+    Right (IODataBinary _, _, _)  -> assertFailure "internal error"
     Left err | isDoesNotExistError err -> Exception.throwIO err -- no ghc!
              | otherwise               -> return ()
 

--- a/cabal-install/Distribution/Client/Check.hs
+++ b/cabal-install/Distribution/Client/Check.hs
@@ -30,7 +30,7 @@ import Distribution.PackageDescription.Configuration
 import Distribution.Verbosity
          ( Verbosity )
 import Distribution.Simple.Utils
-         ( defaultPackageDesc, toUTF8, wrapText )
+         ( defaultPackageDesc, wrapText )
 
 check :: Verbosity -> IO Bool
 check verbosity = do
@@ -91,4 +91,4 @@ check verbosity = do
 
   where
     printCheckMessages = mapM_ (putStrLn . format . explanation)
-    format = toUTF8 . wrapText . ("* "++)
+    format = wrapText . ("* "++)

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -81,7 +81,7 @@ import Distribution.ParseUtils
 import Distribution.PackageDescription.Parse
          ( parseGenericPackageDescription )
 import Distribution.Simple.Utils
-         ( fromUTF8, ignoreBOM )
+         ( fromUTF8LBS, ignoreBOM )
 import qualified Distribution.PackageDescription.Parse as PackageDesc.Parse
 #endif
 
@@ -477,8 +477,7 @@ extractPkg verbosity entry blockNo = case Tar.entryContent entry of
                   Nothing -> error $ "Couldn't read cabal file "
                                     ++ show fileName
 #else
-              parsed = parseGenericPackageDescription . ignoreBOM . fromUTF8 . BS.Char8.unpack
-                                               $ content
+              parsed = parseGenericPackageDescription . ignoreBOM . fromUTF8LBS $ content
               descr  = case parsed of
                 ParseOk _ d -> d
                 _           -> error $ "Couldn't read cabal file "
@@ -746,7 +745,7 @@ packageListFromCache verbosity mkPkg hnd Cache{..} mode = accum mempty [] mempty
         Just gpd -> return gpd
         Nothing  -> interror "failed to parse .cabal file"
 #else
-      case parseGenericPackageDescription . ignoreBOM . fromUTF8 . BS.Char8.unpack $ content of
+      case parseGenericPackageDescription . ignoreBOM . fromUTF8LBS $ content of
         ParseOk _ d -> return d
         _           -> interror "failed to parse .cabal file"
 #endif

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -98,8 +98,7 @@ import Distribution.PackageDescription.Parsec
 import Distribution.PackageDescription.Parse
          ( readGenericPackageDescription, parseGenericPackageDescription, ParseResult(..) )
 import Distribution.Simple.Utils
-         ( fromUTF8, ignoreBOM )
-import qualified Data.ByteString.Lazy.Char8 as BS.Char8
+         ( fromUTF8LBS, ignoreBOM )
 #endif
 
 -- import Data.List ( find, nub )
@@ -563,7 +562,7 @@ readPackageTarget verbosity = traverse modifyLocation
         parseGenericPackageDescriptionMaybe (BS.toStrict bs)
 #else
     parsePackageDescription' content =
-      case parseGenericPackageDescription . ignoreBOM . fromUTF8 . BS.Char8.unpack $ content of
+      case parseGenericPackageDescription . ignoreBOM . fromUTF8LBS $ content of
         ParseOk _ pkg -> Just pkg
         _             -> Nothing
 #endif


### PR DESCRIPTION
This refactoring is intended to clean-up various instances where `[Char]` is used to convey
something other than Unicode text. This picks up unfinished yak-shaving that was put aside when working
on #3913 ... ;-)

Note: this PR has been carefully split into self-contained commits to ease reviewing