### PR TITLE
Augment `--allow-{newer,older}` syntax to support wildcards

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -754,15 +754,35 @@ The following settings control the behavior of the dependency solver:
         -- Disregard all upper bounds when dependency solving
         allow-newer: all
 
+        -- Disregard all `^>=`-style upper bounds when dependency solving
+        allow-newer: ^all
+
 
     For consistency, there is also the explicit wildcard scope syntax
-    ``*`` (or its alphabetic synonym ``all``). Consequently, the first
-    part of the example above is equivalent to the explicitly scoped
-    variant:
+    ``*`` (or its alphabetic synonym ``all``). Consequently, the
+    examples above are equivalent to the explicitly scoped variants:
 
     ::
 
         allow-newer: all:bar, *:baz, *:^quux
+
+        allow-newer: *:*
+        allow-newer: all:all
+
+        allow-newer: *:^*
+        allow-newer: all:^all
+
+    In order to ignore all bounds specified by a package ``pkg-1.2.3``
+    you can combine scoping with a right-hand-side wildcard like so
+
+    ::
+
+        -- Disregard any upper bounds specified by pkg-1.2.3
+        allow-newer: pkg-1.2.3:*
+
+        -- Disregard only `^>=`-style upper bounds in pkg-1.2.3
+        allow-newer: pkg-1.2.3:^*
+
 
     :cfg-field:`allow-newer` is often used in conjunction with a constraint
     (in the cfg-field:`constraints` field) forcing the usage of a specific,

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -46,7 +46,7 @@ module Distribution.Client.Config (
 
 import Distribution.Client.Types
          ( RemoteRepo(..), Username(..), Password(..), emptyRemoteRepo
-         , AllowOlder(..), AllowNewer(..), RelaxDeps(..)
+         , AllowOlder(..), AllowNewer(..), RelaxDeps(..), isRelaxDeps
          )
 import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
@@ -704,8 +704,8 @@ commentSavedConfig = do
             },
         savedInstallFlags      = defaultInstallFlags,
         savedConfigureExFlags  = defaultConfigExFlags {
-            configAllowNewer     = Just (AllowNewer RelaxDepsNone),
-            configAllowOlder     = Just (AllowOlder RelaxDepsNone)
+            configAllowNewer     = Just (AllowNewer mempty),
+            configAllowOlder     = Just (AllowOlder mempty)
             },
         savedConfigureFlags    = (defaultConfigFlags defaultProgramDb) {
             configUserInstall    = toFlag defaultUserInstall
@@ -862,12 +862,12 @@ configFieldDescriptions src =
     optional = Parse.option mempty . fmap toFlag
 
 
-    showRelaxDeps Nothing              = mempty
-    showRelaxDeps (Just RelaxDepsNone) = Disp.text "False"
-    showRelaxDeps (Just _)             = Disp.text "True"
+    showRelaxDeps Nothing                     = mempty
+    showRelaxDeps (Just rd) | isRelaxDeps rd  = Disp.text "True"
+                            | otherwise       = Disp.text "False"
 
     toRelaxDeps True  = RelaxDepsAll
-    toRelaxDeps False = RelaxDepsNone
+    toRelaxDeps False = mempty
 
 
 -- TODO: next step, make the deprecated fields elicit a warning.

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -97,19 +97,13 @@ chooseCabalVersion configExFlags maybeVersion =
     -- Cabal < 1.19.2 doesn't support '--exact-configuration' which is needed
     -- for '--allow-newer' to work.
     allowNewer = isRelaxDeps
-                 (maybe RelaxDepsNone unAllowNewer $ configAllowNewer configExFlags)
+                 (maybe mempty unAllowNewer $ configAllowNewer configExFlags)
     allowOlder = isRelaxDeps
-                 (maybe RelaxDepsNone unAllowOlder $ configAllowOlder configExFlags)
+                 (maybe mempty unAllowOlder $ configAllowOlder configExFlags)
 
     defaultVersionRange = if allowOlder || allowNewer
                           then orLaterVersion (mkVersion [1,19,2])
                           else anyVersion
-
--- | Convert 'RelaxDeps' to a boolean.
-isRelaxDeps :: RelaxDeps -> Bool
-isRelaxDeps RelaxDepsNone     = False
-isRelaxDeps (RelaxDepsSome _) = True
-isRelaxDeps RelaxDepsAll      = True
 
 -- | Configure the package found in the local directory
 configure :: Verbosity
@@ -325,9 +319,9 @@ planLocalPackage verbosity comp platform configFlags configExFlags
 
       resolverParams =
           removeLowerBounds
-          (fromMaybe (AllowOlder RelaxDepsNone) $ configAllowOlder configExFlags)
+          (fromMaybe (AllowOlder mempty) $ configAllowOlder configExFlags)
         . removeUpperBounds
-          (fromMaybe (AllowNewer RelaxDepsNone) $ configAllowNewer configExFlags)
+          (fromMaybe (AllowNewer mempty) $ configAllowNewer configExFlags)
 
         . addPreferences
             -- preferences from the config file or command line

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -73,7 +73,7 @@ import Distribution.Client.Types
          ( SourcePackageDb(SourcePackageDb)
          , UnresolvedPkgLoc, UnresolvedSourcePackage
          , AllowNewer(..), AllowOlder(..), RelaxDeps(..), RelaxedDep(..)
-         , RelaxDepScope(..), RelaxDepMod(..)
+         , RelaxDepScope(..), RelaxDepMod(..), isRelaxDeps
          )
 import Distribution.Client.Dependency.Types
          ( PreSolver(..), Solver(..)
@@ -434,8 +434,8 @@ data RelaxKind = RelaxLower | RelaxUpper
 
 -- | Common internal implementation of 'removeLowerBounds'/'removeUpperBounds'
 removeBounds :: RelaxKind -> RelaxDeps -> DepResolverParams -> DepResolverParams
-removeBounds _relKind RelaxDepsNone params = params -- no-op optimisation
-removeBounds  relKind relDeps       params =
+removeBounds _ rd params | not (isRelaxDeps rd) = params -- no-op optimisation
+removeBounds  relKind relDeps            params =
     params {
       depResolverSourcePkgIndex = sourcePkgIndex'
     }
@@ -454,7 +454,7 @@ removeBounds  relKind relDeps       params =
 relaxPackageDeps :: RelaxKind
                  -> RelaxDeps
                  -> PD.GenericPackageDescription -> PD.GenericPackageDescription
-relaxPackageDeps _ RelaxDepsNone gpd = gpd -- subsumed by no-op case in 'removeBounds'
+relaxPackageDeps _ rd gpd | not (isRelaxDeps rd) = gpd -- subsumed by no-op case in 'removeBounds'
 relaxPackageDeps relKind RelaxDepsAll  gpd = PD.transformAllBuildDepends relaxAll gpd
   where
     relaxAll (Dependency pkgName verRange) =

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -458,9 +458,9 @@ planPackages verbosity comp platform mSandboxPkgInfo solver
     upgradeDeps      = fromFlag (installUpgradeDeps       installFlags)
     onlyDeps         = fromFlag (installOnlyDeps          installFlags)
 
-    allowOlder       = fromMaybe (AllowOlder RelaxDepsNone)
+    allowOlder       = fromMaybe (AllowOlder mempty)
                                  (configAllowOlder configExFlags)
-    allowNewer       = fromMaybe (AllowNewer RelaxDepsNone)
+    allowNewer       = fromMaybe (AllowNewer mempty)
                                  (configAllowNewer configExFlags)
 
 -- | Remove the provided targets from the install plan.

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -221,8 +221,8 @@ resolveSolverSettings ProjectConfig{
 
     defaults = mempty {
        projectConfigSolver            = Flag defaultSolver,
-       projectConfigAllowOlder        = Just (AllowOlder RelaxDepsNone),
-       projectConfigAllowNewer        = Just (AllowNewer RelaxDepsNone),
+       projectConfigAllowOlder        = Just (AllowOlder mempty),
+       projectConfigAllowNewer        = Just (AllowNewer mempty),
        projectConfigMaxBackjumps      = Flag defaultMaxBackjumps,
        projectConfigReorderGoals      = Flag (ReorderGoals False),
        projectConfigCountConflicts    = Flag (CountConflicts True),

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -25,7 +25,7 @@ import Distribution.Client.Compat.Prelude
 
 import Distribution.Client.ProjectConfig.Types
 import Distribution.Client.Types
-         ( RemoteRepo(..), emptyRemoteRepo
+         ( RemoteRepo(..), emptyRemoteRepo, isRelaxDeps
          , AllowNewer(..), AllowOlder(..), RelaxDeps(..) )
 
 import Distribution.Client.Config
@@ -872,12 +872,12 @@ legacySharedConfigFieldDescrs =
 
 parseRelaxDeps :: ReadP r RelaxDeps
 parseRelaxDeps =
-     ((const RelaxDepsNone <$> (Parse.string "none" +++ Parse.string "None"))
+     ((const mempty        <$> (Parse.string "none" +++ Parse.string "None"))
   +++ (const RelaxDepsAll  <$> (Parse.string "all"  +++ Parse.string "All")))
   <++ (      RelaxDepsSome <$> parseOptCommaList parse)
 
 dispRelaxDeps :: RelaxDeps -> Doc
-dispRelaxDeps  RelaxDepsNone       = Disp.text "None"
+dispRelaxDeps rd | not (isRelaxDeps rd) = Disp.text "None"
 dispRelaxDeps (RelaxDepsSome pkgs) = Disp.fsep . Disp.punctuate Disp.comma
                                                . map disp $ pkgs
 dispRelaxDeps  RelaxDepsAll        = Disp.text "All"

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -25,8 +25,8 @@ import Distribution.Client.Compat.Prelude
 
 import Distribution.Client.ProjectConfig.Types
 import Distribution.Client.Types
-         ( RemoteRepo(..), emptyRemoteRepo, isRelaxDeps
-         , AllowNewer(..), AllowOlder(..), RelaxDeps(..) )
+         ( RemoteRepo(..), emptyRemoteRepo
+         , AllowNewer(..), AllowOlder(..) )
 
 import Distribution.Client.Config
          ( SavedConfig(..), remoteRepoFields )
@@ -830,12 +830,12 @@ legacySharedConfigFieldDescrs =
         configPreferences (\v conf -> conf { configPreferences = v })
 
       , simpleField "allow-older"
-        (maybe mempty dispRelaxDeps) (fmap Just parseRelaxDeps)
+        (maybe mempty disp) (fmap Just parse)
         (fmap unAllowOlder . configAllowOlder)
         (\v conf -> conf { configAllowOlder = fmap AllowOlder v })
 
       , simpleField "allow-newer"
-        (maybe mempty dispRelaxDeps) (fmap Just parseRelaxDeps)
+        (maybe mempty disp) (fmap Just parse)
         (fmap unAllowNewer . configAllowNewer)
         (\v conf -> conf { configAllowNewer = fmap AllowNewer v })
       ]
@@ -869,18 +869,6 @@ legacySharedConfigFieldDescrs =
   ) (installOptions ParseArgs)
   where
     constraintSrc = ConstraintSourceProjectConfig "TODO"
-
-parseRelaxDeps :: ReadP r RelaxDeps
-parseRelaxDeps =
-     ((const mempty        <$> (Parse.string "none" +++ Parse.string "None"))
-  +++ (const RelaxDepsAll  <$> (Parse.string "all"  +++ Parse.string "All")))
-  <++ (      RelaxDepsSome <$> parseOptCommaList parse)
-
-dispRelaxDeps :: RelaxDeps -> Doc
-dispRelaxDeps rd | not (isRelaxDeps rd) = Disp.text "None"
-dispRelaxDeps (RelaxDepsSome pkgs) = Disp.fsep . Disp.punctuate Disp.comma
-                                               . map disp $ pkgs
-dispRelaxDeps  RelaxDepsAll        = Disp.text "All"
 
 
 legacyPackageConfigFieldDescrs :: [FieldDescr LegacyPackageConfig]

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -598,7 +598,6 @@ relaxDepsParser =
 
 relaxDepsPrinter :: (Maybe RelaxDeps) -> [Maybe String]
 relaxDepsPrinter Nothing                     = []
-relaxDepsPrinter (Just RelaxDepsNone)        = []
 relaxDepsPrinter (Just RelaxDepsAll)         = [Nothing]
 relaxDepsPrinter (Just (RelaxDepsSome pkgs)) = map (Just . display) $ pkgs
 

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -13,8 +13,8 @@
 	* Completed the 'new-bench' command. Same as above.
 	* '--allow-{newer,older}' syntax has been enhanced. Dependency
 	relaxation can be now limited to a specific release of a package,
-	plus there's a now syntax for relaxing only caret dependencies
-	(#4575).
+	plus there's a now syntax for relaxing only caret-style (i.e. '^>=')
+	dependencies (#4575, #4669).
 
 2.0.0.0 Ryan Thomas <ryan@ryant.org> July 2017
 	* Removed the '--root-cmd' parameter of the 'install' command

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -65,6 +65,8 @@ tests =
   , testGroup "individual parser tests"
     [ testProperty "package location"  prop_parsePackageLocationTokenQ
     , testProperty "RelaxedDep"        prop_roundtrip_printparse_RelaxedDep
+    , testProperty "RelaxDeps"         prop_roundtrip_printparse_RelaxDeps
+    , testProperty "RelaxDeps'"        prop_roundtrip_printparse_RelaxDeps'
     ]
 
   , testGroup "ProjectConfig printing/parsing round trip"
@@ -234,19 +236,38 @@ prop_roundtrip_printparse_specific config =
 -- Individual Parser tests
 --
 
+-- | Helper to parse a given string
+--
+-- Succeeds only if there is a unique complete parse
+runReadP :: Parse.ReadP a a -> String -> Maybe a
+runReadP parser s = case [ x | (x,"") <- Parse.readP_to_S parser s ] of
+                      [x'] -> Just x'
+                      _    -> Nothing
+
 prop_parsePackageLocationTokenQ :: PackageLocationString -> Bool
 prop_parsePackageLocationTokenQ (PackageLocationString str) =
-    case [ x | (x,"") <- Parse.readP_to_S parsePackageLocationTokenQ
-                                         (renderPackageLocationToken str) ] of
-      [str'] -> str' == str
-      _      -> False
-
+    runReadP parsePackageLocationTokenQ (renderPackageLocationToken str) == Just str
 
 prop_roundtrip_printparse_RelaxedDep :: RelaxedDep -> Bool
 prop_roundtrip_printparse_RelaxedDep rdep =
-    case [ x | (x,"") <- Parse.readP_to_S Text.parse (Text.display rdep) ] of
-      [rdep'] -> rdep' == rdep
-      _       -> False
+    runReadP Text.parse (Text.display rdep) == Just rdep
+
+prop_roundtrip_printparse_RelaxDeps :: RelaxDeps -> Bool
+prop_roundtrip_printparse_RelaxDeps rdep =
+    runReadP Text.parse (Text.display rdep) == Just rdep
+
+prop_roundtrip_printparse_RelaxDeps' :: RelaxDeps -> Bool
+prop_roundtrip_printparse_RelaxDeps' rdep =
+    runReadP Text.parse (go $ Text.display rdep) == Just rdep
+  where
+    -- replace 'all' tokens by '*'
+    go :: String -> String
+    go [] = []
+    go "all" = "*"
+    go ('a':'l':'l':c:rest) | c `elem` ":," = '*' : go (c:rest)
+    go rest = let (x,y) = break (`elem` ":,") rest
+                  (x',y') = span (`elem` ":,^") y
+              in x++x'++go y'
 
 ------------------------
 -- Arbitrary instances
@@ -797,6 +818,11 @@ instance Arbitrary RelaxDepScope where
     arbitrary = oneof [ pure RelaxDepScopeAll
                       , RelaxDepScopePackage <$> arbitrary
                       , RelaxDepScopePackageId <$> (PackageIdentifier <$> arbitrary <*> arbitrary)
+                      ]
+
+instance Arbitrary RelaxDepSubject where
+    arbitrary = oneof [ pure RelaxDepSubjectAll
+                      , RelaxDepSubjectPkg <$> arbitrary
                       ]
 
 instance Arbitrary RelaxedDep where

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -785,7 +785,7 @@ instance Arbitrary AllowOlder where
     arbitrary = AllowOlder <$> arbitrary
 
 instance Arbitrary RelaxDeps where
-    arbitrary = oneof [ pure RelaxDepsNone
+    arbitrary = oneof [ pure mempty
                       , RelaxDepsSome <$> shortListOf1 3 arbitrary
                       , pure RelaxDepsAll
                       ]


### PR DESCRIPTION
This continues the work started in  a0d8035 (#4575)

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
