### PR TITLE
Add support for GHC's numeric -g debug levels

### DIFF
--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -41,6 +41,7 @@ data GhcImplInfo = GhcImplInfo
   , flagProfAuto         :: Bool -- ^ new style -fprof-auto* flags
   , flagPackageConf      :: Bool -- ^ use package-conf instead of package-db
   , flagDebugInfo        :: Bool -- ^ -g flag supported
+  , supportsDebugLevels  :: Bool -- ^ supports numeric @-g@ levels
   , supportsPkgEnvFiles  :: Bool -- ^ picks up @.ghc.environment@ files
   , flagWarnMissingHomeModules :: Bool -- ^ -Wmissing-home-modules is supported
   }
@@ -67,6 +68,7 @@ ghcVersionImplInfo ver = GhcImplInfo
   , flagProfAuto         = v >= [7,4]
   , flagPackageConf      = v <  [7,5]
   , flagDebugInfo        = v >= [7,10]
+  , supportsDebugLevels  = v >= [8,0]
   , supportsPkgEnvFiles  = v >= [8,0,1,20160901] -- broken in 8.0.1, fixed in 8.0.2
   , flagWarnMissingHomeModules = v >= [8,2,1]
   }
@@ -84,6 +86,7 @@ ghcjsVersionImplInfo _ghcjsver ghcver = GhcImplInfo
   , flagProfAuto         = True
   , flagPackageConf      = False
   , flagDebugInfo        = False
+  , supportsDebugLevels  = ghcv >= [8,0]
   , supportsPkgEnvFiles  = ghcv >= [8,0,2] --TODO: check this works in ghcjs
   , flagWarnMissingHomeModules = False
   }

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -342,7 +342,7 @@ componentGhcOptions verbosity implInfo lbi bi clbi odir =
       ghcOptStubDir         = toFlag odir,
       ghcOptOutputDir       = toFlag odir,
       ghcOptOptimisation    = toGhcOptimisation (withOptimization lbi),
-      ghcOptDebugInfo       = toGhcDebugInfo (withDebugInfo lbi),
+      ghcOptDebugInfo       = toFlag (withDebugInfo lbi),
       ghcOptExtra           = toNubListR $ hcOptions GHC bi,
       ghcOptExtraPath       = toNubListR $ exe_paths,
       ghcOptLanguage        = toFlag (fromMaybe Haskell98 (defaultLanguage bi)),
@@ -354,12 +354,6 @@ componentGhcOptions verbosity implInfo lbi bi clbi odir =
     toGhcOptimisation NoOptimisation      = mempty --TODO perhaps override?
     toGhcOptimisation NormalOptimisation  = toFlag GhcNormalOptimisation
     toGhcOptimisation MaximumOptimisation = toFlag GhcMaximumOptimisation
-
-    -- GHC doesn't support debug info levels yet.
-    toGhcDebugInfo NoDebugInfo      = mempty
-    toGhcDebugInfo MinimalDebugInfo = toFlag True
-    toGhcDebugInfo NormalDebugInfo  = toFlag True
-    toGhcDebugInfo MaximalDebugInfo = toFlag True
 
     exe_paths = [ componentBuildDir lbi (targetCLBI exe_tgt)
                 | uid <- componentExeDeps clbi

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -184,7 +184,7 @@ data GhcOptions = GhcOptions {
   ghcOptOptimisation  :: Flag GhcOptimisation,
 
     -- | Emit debug info; the @ghc -g@ flag.
-  ghcOptDebugInfo  :: Flag Bool,
+  ghcOptDebugInfo     :: Flag DebugInfoLevel,
 
   -- | Compile in profiling mode; the @ghc -prof@ flag.
   ghcOptProfilingMode :: Flag Bool,
@@ -322,7 +322,12 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
       Just GhcMaximumOptimisation     -> ["-O2"]
       Just (GhcSpecialOptimisation s) -> ["-O" ++ s] -- eg -Odph
 
-  , [ "-g" | flagDebugInfo implInfo && flagBool ghcOptDebugInfo ]
+  , case flagToMaybe (ghcOptDebugInfo opts) of
+      Nothing                                -> []
+      Just NoDebugInfo                       -> []
+      Just MinimalDebugInfo                  -> ["-g1"]
+      Just NormalDebugInfo                   -> ["-g2"]
+      Just MaximalDebugInfo                  -> ["-g3"]
 
   , [ "-prof" | flagBool ghcOptProfilingMode ]
 


### PR DESCRIPTION
These are supported by GHC 8.0 and later and will soon (probably GHC 8.4)
actually affect the compiler's output.

Note that I haven't tested this yet but I'm putting it here so I don't forget about it.


Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
