### PR TITLE
Turn `allow-{newer,older}` into an accumulating field

### DIFF
--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -829,12 +829,12 @@ legacySharedConfigFieldDescrs =
         disp parse
         configPreferences (\v conf -> conf { configPreferences = v })
 
-      , simpleField "allow-older"
+      , monoidField "allow-older"
         (maybe mempty disp) (fmap Just parse)
         (fmap unAllowOlder . configAllowOlder)
         (\v conf -> conf { configAllowOlder = fmap AllowOlder v })
 
-      , simpleField "allow-newer"
+      , monoidField "allow-newer"
         (maybe mempty disp) (fmap Just parse)
         (fmap unAllowNewer . configAllowNewer)
         (\v conf -> conf { configAllowNewer = fmap AllowNewer v })
@@ -1252,6 +1252,13 @@ listFieldWithSep separator name showF readF get' set =
   where
     set' xs b = set (get' b ++ xs) b
     showF'    = separator . map showF
+
+monoidField :: Monoid a => String -> (a -> Doc) -> ReadP a a
+            -> (b -> a) -> (a -> b -> b) -> FieldDescr b
+monoidField name showF readF get' set =
+  liftField get' set' $ ParseUtils.field name showF readF
+  where
+    set' xs b = set (get' b `mappend` xs) b
 
 --TODO: [code cleanup] local redefinition that should replace the version in
 -- D.ParseUtils. This version avoid parse ambiguity for list element parsers

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1253,6 +1253,8 @@ listFieldWithSep separator name showF readF get' set =
     set' xs b = set (get' b ++ xs) b
     showF'    = separator . map showF
 
+-- | Parser combinator for simple fields which uses the field type's
+-- 'Monoid' instance for combining multiple occurences of the field.
 monoidField :: Monoid a => String -> (a -> Doc) -> ReadP a a
             -> (b -> a) -> (a -> b -> b) -> FieldDescr b
 monoidField name showF readF get' set =

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -16,7 +16,11 @@
 	plus there's a now syntax for relaxing only caret-style (i.e. '^>=')
 	dependencies (#4575, #4669).
 
-2.0.0.0 Ryan Thomas <ryan@ryant.org> July 2017
+2.0.TBD
+	* Turn `allow-{newer,older}` in `cabal.project` files into an
+	accumulating field to match CLI flag semantics (#4679).
+
+2.0.0.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> August 2017
 	* Removed the '--root-cmd' parameter of the 'install' command
 	(#3356).
 	* Deprecated 'cabal install --global' (#3356).


### PR DESCRIPTION
This fixes the inconvenience occuring in `cabal.project` files of
separate `allow-*` statements overwriting each other. Currently,
without this patch,

    allow-newer: base
    allow-newer: directory

is *NOT* equivalent to

    allow-newer: base, directory

but rather to the last occurence of `allow-newer`, i.e.

    allow-newer: directory

This behaviour has been present since cabal 1.24

----

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
