### PR TITLE
Add missing separator in solver fallback message

### DIFF
--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -137,7 +137,7 @@ configure verbosity packageDBs repoCtxt comp platform progdb
       warn verbosity $
            "solver failed to find a solution:\n"
         ++ message
-        ++ "Trying configure anyway."
+        ++ "\nTrying configure anyway."
       setupWrapper verbosity (setupScriptOptions installedPkgIndex Nothing)
         Nothing configureCommand (const configFlags) extraArgs
 

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-external.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-external.cabal.out
@@ -103,7 +103,8 @@ trying: exe-0.1.0.0 (user goal)
 next goal: src (dependency of exe-0.1.0.0)
 rejecting: src-<VERSION>/installed-<HASH>... (conflict: src => mylib==0.1.0.0/installed-0.1..., src => mylib==0.1.0.0/installed-0.1...)
 fail (backjumping, conflict set: exe, src)
-After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: exe (2), src (2)Trying configure anyway.
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: exe (2), src (2)
+Trying configure anyway.
 Configuring exe-0.1.0.0...
 # Setup build
 Preprocessing executable 'exe' for exe-0.1.0.0..

--- a/cabal-testsuite/PackageTests/ConfigureComponent/Exe/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/ConfigureComponent/Exe/setup.cabal.out
@@ -5,7 +5,8 @@ Could not resolve dependencies:
 trying: Exe-0.1.0.0 (user goal)
 unknown package: totally-impossible-dependency-to-fill (dependency of Exe-0.1.0.0)
 fail (backjumping, conflict set: Exe, totally-impossible-dependency-to-fill)
-After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: Exe (2), totally-impossible-dependency-to-fill (1)Trying configure anyway.
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: Exe (2), totally-impossible-dependency-to-fill (1)
+Trying configure anyway.
 Configuring executable 'goodexe' for Exe-0.1.0.0..
 # Setup build
 Preprocessing executable 'goodexe' for Exe-0.1.0.0..

--- a/cabal-testsuite/PackageTests/InternalVersions/BuildDependsBad/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/InternalVersions/BuildDependsBad/setup.cabal.out
@@ -4,6 +4,7 @@ Warning: solver failed to find a solution:
 Could not resolve dependencies:
 next goal: build-depends-bad-version (user goal)
 rejecting: build-depends-bad-version-0.1.0.0 (conflict: build-depends-bad-version => build-depends-bad-version>=2)
-After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: build-depends-bad-version (2)Trying configure anyway.
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: build-depends-bad-version (2)
+Trying configure anyway.
 Configuring build-depends-bad-version-0.1.0.0...
 cabal: The package has an impossible version range for a dependency on an internal library: build-depends-bad-version >=2. This version range does not include the current package, and must be removed as the current package's library will always be used.


### PR DESCRIPTION
Before, it would print a list of packages and append
`Trying configure anyway.`
without any separator between the list and the new sentence.