### PR TITLE
Fix Stack build

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ extra-deps:
 - ansi-wl-pprint-0.6.7.3
 - async-2.1.0
 - attoparsec-0.13.1.0
-- base-compat-0.9.1
+- base-compat-0.9.3
 - base16-bytestring-0.1.1.6
 - base64-bytestring-1.0.0.1
 - clock-0.7.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -54,10 +54,6 @@ extra-deps:
 - vector-0.12.0.0
 - zlib-0.6.1.1
 flags:
-  Cabal:
-    parsec: true
-  cabal-install:
-    parsec: true
   time-locale-compat:
     old-locale: false
 nix:

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,7 @@ extra-deps:
 - async-2.1.0
 - attoparsec-0.13.1.0
 - base-compat-0.9.3
+- base-orphans-0.6
 - base16-bytestring-0.1.1.6
 - base64-bytestring-1.0.0.1
 - clock-0.7.2


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

This pull request fixes #4691. It removes the obsolete `parsec` flags, upgrades an outdated dependency, and adds a new required dependency. I tested it by running `stack test`. 