### PR TITLE
Restrict flag names to ASCII

### DIFF
--- a/Cabal/Distribution/Parsec/Class.hs
+++ b/Cabal/Distribution/Parsec/Class.hs
@@ -20,7 +20,7 @@ import           Data.Functor.Identity                        (Identity)
 import qualified Distribution.Compat.Parsec                   as P
 import           Distribution.Parsec.Types.Common
                  (PWarnType (..), PWarning (..), Position (..))
-import           Distribution.Utils.Generic                   (lowercase)
+import           Distribution.Utils.Generic                   (isAsciiAlphaNum, lowercase)
 import qualified Text.Parsec                                  as Parsec
 import qualified Text.Parsec.Language                         as Parsec
 import qualified Text.Parsec.Token                            as Parsec
@@ -130,8 +130,8 @@ instance Parsec FlagName where
     parsec = mkFlagName . lowercase <$> parsec'
       where
         parsec' = (:) <$> lead <*> rest
-        lead = P.satisfy (\c ->  isAlphaNum c || c == '_')
-        rest = P.munch (\c -> isAlphaNum c ||  c == '_' || c == '-')
+        lead = P.satisfy (\c -> isAsciiAlphaNum c || c == '_')
+        rest = P.munch (\c -> isAsciiAlphaNum c ||  c == '_' || c == '-')
 
 instance Parsec Dependency where
     parsec = do

--- a/Cabal/Distribution/Types/GenericPackageDescription.hs
+++ b/Cabal/Distribution/Types/GenericPackageDescription.hs
@@ -18,7 +18,7 @@ module Distribution.Types.GenericPackageDescription (
 import Prelude ()
 import Distribution.Compat.Prelude
 import Distribution.Utils.ShortText
-import Distribution.Utils.Generic (lowercase)
+import Distribution.Utils.Generic (isAsciiAlphaNum, lowercase)
 import qualified Text.PrettyPrint as Disp
 import qualified Distribution.Compat.ReadP as Parse
 import Distribution.Compat.ReadP ((+++))
@@ -119,13 +119,11 @@ instance Binary FlagName
 
 instance Text FlagName where
     disp = Disp.text . unFlagName
-    -- Note:  we don't check that FlagName doesn't have leading dash,
-    -- cabal check will do that.
     parse = mkFlagName . lowercase <$> parse'
       where
         parse' = (:) <$> lead <*> rest
-        lead = Parse.satisfy (\c ->  isAlphaNum c || c == '_')
-        rest = Parse.munch (\c -> isAlphaNum c ||  c == '_' || c == '-')
+        lead = Parse.satisfy (\c -> isAsciiAlphaNum c || c == '_')
+        rest = Parse.munch (\c -> isAsciiAlphaNum c ||  c == '_' || c == '-')
 
 -- | A 'FlagAssignment' is a total or partial mapping of 'FlagName's to
 -- 'Bool' flag values. It represents the flags chosen by the user or


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

This pull request restricts flag names to ASCII (see #4686). It's not done yet, though. I have a few issues with it:

- There's both a `ReadP`-based parser and a `Parsec`-based parser. Having both seems like a good way for them to get out of sync with each other. I don't know enough about Haskell's parsers to be able to combine them.
- Even with these changes, I couldn't get flags with leading hyphens to fail parsing. It seems like they should fail, so I must be missing something.
- Trying to parse a Unicode flag fails for an unrelated reason.

For an example of the second point, consider this Cabal file:

``` cabal
name: example
version: 1
build-type: Simple
cabal-version: >= 1.2
flag -leading-hyphen
library
```

It build successfully even though I expected it to fail to parse.

For an example of the third point, consider this Cabal file:

``` cabal
name: example
version: 1
build-type: Simple
cabal-version: >= 1.2
flag unicode-letter-א
flag unicode-number-⓪
library
```

It fails, but the error isn't quite what I expected:

```
Warning: example.cabal:0:0: "the input" (line 5, column 6):
unexpected character in input '\215'
expecting section parameter, "{", field or section name or end of file
cabal: Failing parsing "./example.cabal".
```

I am not familiar enough with Cabal's code base to quickly diagnose these problems. I'd appreciate some help sorting them out. 