### PR TITLE
Introduce Distribution.Compat.Lens

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -265,6 +265,7 @@ library
     Language.Haskell.Extension
     Distribution.Compat.Binary
 
+  -- Parsec parser relatedmodules
   build-depends:
     transformers,
     parsec >= 3.1.9 && <3.2
@@ -282,6 +283,13 @@ library
     Distribution.Parsec.Types.Field
     Distribution.Parsec.Types.FieldDescr
     Distribution.Parsec.Types.ParseResult
+
+  -- Lens functionality
+  exposed-modules:
+    Distribution.Compat.Lens
+    Distribution.Types.BuildInfo.Lens
+    Distribution.Types.PackageDescription.Lens
+    Distribution.Types.GenericPackageDescription.Lens
 
   other-modules:
     Distribution.Backpack.PreExistingComponent

--- a/Cabal/Distribution/Compat/Lens.hs
+++ b/Cabal/Distribution/Compat/Lens.hs
@@ -26,6 +26,7 @@ module Distribution.Compat.Lens (
     -- * Operators
     (&),
     (.~), (%~),
+    (?~),
     -- * Cabal developer info
     -- $development
     ) where
@@ -112,11 +113,15 @@ _2 f (c, a) = (,) c <$> f a
 {-# INLINE (&) #-}
 infixl 1 &
 
-infixr 4 .~, %~
+infixr 4 .~, %~, ?~
 
 (.~) :: ASetter s t a b -> b -> s -> t
 (.~) = set
 {-# INLINE (.~) #-}
+
+(?~) :: ASetter s t a (Maybe b) -> b -> s -> t
+l ?~ b = set l (Just b)
+{-# INLINE (?~) #-}
 
 (%~) :: ASetter s t a b -> (a -> b) -> s -> t
 (%~) = over

--- a/Cabal/Distribution/Compat/Lens.hs
+++ b/Cabal/Distribution/Compat/Lens.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE RankNTypes #-}
+-- | This module provides very basic lens functionality, without extra dependencies.
+--
+-- For the documentation of the combinators see <http://hackage.haskell.org/package/lens lens> package.
+-- This module uses the same vocabulary.
+module Distribution.Compat.Lens (
+    -- * Types
+    Lens,
+    Lens',
+    Traversal,
+    Traversal',
+    -- ** rank-1 types
+    Getting,
+    ASetter,
+    -- * Folds
+    toDListOf,
+    toListOf,
+    toSetOf,
+    -- * Common lenses
+    _2,
+    -- * Cabal developer info
+    -- $development
+    ) where
+
+import Prelude()
+import Distribution.Compat.Prelude
+
+import Control.Applicative (Const (..))
+import Data.Functor.Identity (Identity (..))
+
+import qualified Distribution.Compat.DList as DList
+import qualified Data.Set as Set
+
+-------------------------------------------------------------------------------
+-- Types
+-------------------------------------------------------------------------------
+
+type Lens      s t a b = forall f. Functor f     => (a -> f b) -> s -> f t
+type Traversal s t a b = forall f. Applicative f => (a -> f b) -> s -> f t
+
+type Lens'      s a = forall f. Functor f     => (a -> f a) -> s -> f s
+type Traversal' s a = forall f. Applicative f => (a -> f a) -> s -> f s
+
+type Getting r s a = (a -> Const r a) -> s -> Const r s
+type ASetter s t a b = (a -> Identity b) -> s -> Identity t
+
+-------------------------------------------------------------------------------
+-- Folds
+-------------------------------------------------------------------------------
+
+toDListOf :: Getting (DList.DList a) s a -> s -> DList.DList a
+toDListOf l s = getConst (l (\x -> Const (DList.singleton x)) s)
+
+toListOf :: Getting (DList.DList a) s a -> s -> [a]
+toListOf l = DList.runDList . toDListOf l
+
+toSetOf  :: Getting (Set.Set a) s a -> s -> Set.Set a
+toSetOf l s = getConst (l (\x -> Const (Set.singleton x)) s)
+
+-------------------------------------------------------------------------------
+-- Common
+-------------------------------------------------------------------------------
+
+_2 ::  Functor f => (a -> f b) -> (c, a) -> f (c, b)
+_2 f (c, a) = (,) c <$> f a
+
+-------------------------------------------------------------------------------
+-- Documentation
+-------------------------------------------------------------------------------
+
+-- $development
+--
+-- We cannot depend on @template-haskell@, because Cabal is a boot library.
+-- This fact makes defining optics a manual task. Here is a small recipe to
+-- make the process less tedious.
+--
+-- First start a repl with proper-lens dependency
+--
+-- > cabal new-repl Cabal:lib:Cabal ???
+--
+-- or
+--
+-- > stack ghci Cabal:lib --package lens
+--
+-- Then enable Template Haskell and the dumping of splices:
+--
+-- > :set -XTemplateHaskell -ddump-slices
+--
+-- Now we can derive lenses, load appropriate modules:
+--
+-- > :m Control.Lens Distribution.PackageDescription
+--
+-- and let Template Haskell do the job:
+--
+-- >  ; makeLensesWith (lensRules & lensField .~ mappingNamer return) ''GenericPackageDescription
+--
+-- At this point, we will get unfancy splices looking like
+--
+-- @
+-- condBenchmarks ::
+--   'Lens'' GenericPackageDescription [(UnqualComponentName,
+--                                     CondTree ConfVar [Dependency] Benchmark)]
+-- condBenchmarks
+--   f_a2UEg
+--   (GenericPackageDescription x1_a2UEh
+--                              x2_a2UEi
+--                              x3_a2UEj
+--                              x4_a2UEk
+--                              x5_a2UEl
+--                              x6_a2UEm
+--                              x7_a2UEn
+--                              x8_a2UEo)
+--   = fmap
+--       (\\ y1_a2UEp
+--          -> GenericPackageDescription
+--               x1_a2UEh
+--               x2_a2UEi
+--               x3_a2UEj
+--               x4_a2UEk
+--               x5_a2UEl
+--               x6_a2UEm
+--               x7_a2UEn
+--               y1_a2UEp)
+--       (f_a2UEg x8_a2UEo)
+-- {-\# INLINE condBenchmarks \#-}
+-- @
+--
+-- yet they can be cleaned up with e.g. VIM magic regexp and @hindent@:
+--
+-- > :%s/\v(\w+)_\w+/\1/g
+-- > :%!hindent --indent-size 4 --line-length 200
+--
+-- Resulting into
+--
+-- @
+-- condBenchmarks :: 'Lens'' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] Benchmark)]
+-- condBenchmarks f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) =
+--     fmap (\\y1 -> GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 y1) (f x8)
+-- {-\# INLINE condBenchmarks \#-}
+-- @

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -1655,13 +1655,8 @@ checkUnicodeXFields gpd
 
     xfields :: [(String,String)]
     xfields = DList.runDList $ mconcat
-        [ toDListOf (L.packageDescription                          . L.customFieldsPD . traverse) gpd
-        , toDListOf (L.condLibrary      . traverse      . traverse . L.customFieldsBI . traverse) gpd
-        , toDListOf (L.condSubLibraries . traverse . _2 . traverse . L.customFieldsBI . traverse) gpd
-        , toDListOf (L.condForeignLibs  . traverse . _2 . traverse . L.customFieldsBI . traverse) gpd
-        , toDListOf (L.condExecutables  . traverse . _2 . traverse . L.customFieldsBI . traverse) gpd
-        , toDListOf (L.condTestSuites   . traverse . _2 . traverse . L.customFieldsBI . traverse) gpd
-        , toDListOf (L.condBenchmarks   . traverse . _2 . traverse . L.customFieldsBI . traverse) gpd
+        [ toDListOf (L.packageDescription . L.customFieldsPD . traverse) gpd
+        , toDListOf (L.buildInfos         . L.customFieldsBI . traverse) gpd
         ]
 
 checkDevelopmentOnlyFlagsBuildInfo :: BuildInfo -> [PackageCheck]

--- a/Cabal/Distribution/Types/Benchmark.hs
+++ b/Cabal/Distribution/Types/Benchmark.hs
@@ -19,6 +19,8 @@ import Distribution.Types.UnqualComponentName
 
 import Distribution.ModuleName
 
+import qualified Distribution.Types.BuildInfo.Lens as L
+
 -- | A \"benchmark\" stanza in a cabal file.
 --
 data Benchmark = Benchmark {
@@ -28,10 +30,10 @@ data Benchmark = Benchmark {
     }
     deriving (Generic, Show, Read, Eq, Typeable, Data)
 
-instance HasBuildInfo Benchmark where
-    buildInfo_ f l = (\x -> l { benchmarkBuildInfo = x }) <$> f (benchmarkBuildInfo l)
-
 instance Binary Benchmark
+
+instance L.HasBuildInfo Benchmark where
+    buildInfo f (Benchmark x1 x2 x3) = fmap (\y1 -> Benchmark x1 x2 y1) (f x3)
 
 instance Monoid Benchmark where
     mempty = Benchmark {

--- a/Cabal/Distribution/Types/BuildInfo.hs
+++ b/Cabal/Distribution/Types/BuildInfo.hs
@@ -14,8 +14,6 @@ module Distribution.Types.BuildInfo (
     hcProfOptions,
     hcSharedOptions,
     hcStaticOptions,
-
-    HasBuildInfo (..),
 ) where
 
 import Prelude ()
@@ -214,17 +212,3 @@ lookupHcOptions :: (BuildInfo -> [(CompilerFlavor,[String])])
 lookupHcOptions f hc bi = [ opt | (hc',opts) <- f bi
                           , hc' == hc
                           , opt <- opts ]
-
--------------------------------------------------------------------------------
--- Classy lenses
--------------------------------------------------------------------------------
-
--- | Types with 'BuildInfo'.
---
--- @since 2.2.0.0
-class HasBuildInfo a where
-    -- | @Lens' a 'BuildInfo'@
-    buildInfo_ :: Functor f => (BuildInfo -> f BuildInfo) -> a -> f a
-
-instance HasBuildInfo BuildInfo where
-    buildInfo_ = id

--- a/Cabal/Distribution/Types/BuildInfo/Lens.hs
+++ b/Cabal/Distribution/Types/BuildInfo/Lens.hs
@@ -1,0 +1,23 @@
+module Distribution.Types.BuildInfo.Lens (
+    BuildInfo,
+    HasBuildInfo (..),
+    ) where
+
+import Prelude()
+import Distribution.Compat.Prelude
+import Distribution.Compat.Lens
+
+import Distribution.Types.BuildInfo (BuildInfo)
+import qualified Distribution.Types.BuildInfo as T
+
+-- | Classy lenses for 'BuildInfo'.
+class HasBuildInfo a where
+    buildInfo :: Lens' a BuildInfo
+
+    customFieldsBI :: Lens' a [(String,String)]
+    customFieldsBI = buildInfo . customFieldsBI
+
+instance HasBuildInfo BuildInfo where
+    buildInfo = id
+    customFieldsBI f bi =
+        fmap (\x -> bi { T.customFieldsBI = x }) (f (T.customFieldsBI bi))

--- a/Cabal/Distribution/Types/BuildInfo/Lens.hs
+++ b/Cabal/Distribution/Types/BuildInfo/Lens.hs
@@ -17,7 +17,11 @@ class HasBuildInfo a where
     customFieldsBI :: Lens' a [(String,String)]
     customFieldsBI = buildInfo . customFieldsBI
 
+    hsSourceDirs :: Lens' a [FilePath]
+    hsSourceDirs = buildInfo . hsSourceDirs
+
 instance HasBuildInfo BuildInfo where
     buildInfo = id
-    customFieldsBI f bi =
-        fmap (\x -> bi { T.customFieldsBI = x }) (f (T.customFieldsBI bi))
+
+    customFieldsBI f bi = fmap (\x -> bi { T.customFieldsBI = x }) (f (T.customFieldsBI bi))
+    hsSourceDirs   f bi = fmap (\x -> bi { T.hsSourceDirs   = x }) (f (T.hsSourceDirs bi))

--- a/Cabal/Distribution/Types/Component.hs
+++ b/Cabal/Distribution/Types/Component.hs
@@ -21,6 +21,8 @@ import Distribution.Types.Benchmark
 import Distribution.Types.ComponentName
 import Distribution.Types.BuildInfo
 
+import qualified Distribution.Types.BuildInfo.Lens as L
+
 data Component = CLib   Library
                | CFLib  ForeignLib
                | CExe   Executable
@@ -36,12 +38,12 @@ instance Semigroup Component where
     CBench b <> CBench b' = CBench (b <> b')
     _        <> _         = error "Cannot merge Component"
 
-instance HasBuildInfo Component where
-    buildInfo_ f (CLib l)   = CLib <$> buildInfo_ f l
-    buildInfo_ f (CFLib l)  = CFLib <$> buildInfo_ f l
-    buildInfo_ f (CExe e)   = CExe <$> buildInfo_ f e
-    buildInfo_ f (CTest t)  = CTest <$> buildInfo_ f t
-    buildInfo_ f (CBench b) = CBench <$> buildInfo_ f b
+instance L.HasBuildInfo Component where
+    buildInfo f (CLib l)   = CLib <$> L.buildInfo f l
+    buildInfo f (CFLib l)  = CFLib <$> L.buildInfo f l
+    buildInfo f (CExe e)   = CExe <$> L.buildInfo f e
+    buildInfo f (CTest t)  = CTest <$> L.buildInfo f t
+    buildInfo f (CBench b) = CBench <$> L.buildInfo f b
 
 foldComponent :: (Library -> a)
               -> (ForeignLib -> a)

--- a/Cabal/Distribution/Types/Executable.hs
+++ b/Cabal/Distribution/Types/Executable.hs
@@ -16,6 +16,8 @@ import Distribution.Types.UnqualComponentName
 import Distribution.Types.ExecutableScope
 import Distribution.ModuleName
 
+import qualified Distribution.Types.BuildInfo.Lens as L
+
 data Executable = Executable {
         exeName    :: UnqualComponentName,
         modulePath :: FilePath,
@@ -24,8 +26,8 @@ data Executable = Executable {
     }
     deriving (Generic, Show, Read, Eq, Typeable, Data)
 
-instance HasBuildInfo Executable where
-    buildInfo_ f l = (\x -> l { buildInfo = x }) <$> f (buildInfo l)
+instance L.HasBuildInfo Executable where
+    buildInfo f l = (\x -> l { buildInfo = x }) <$> f (buildInfo l)
 
 instance Binary Executable
 

--- a/Cabal/Distribution/Types/ForeignLib.hs
+++ b/Cabal/Distribution/Types/ForeignLib.hs
@@ -33,6 +33,8 @@ import Distribution.Types.UnqualComponentName
 import qualified Text.PrettyPrint as Disp
 import qualified Text.Read as Read
 
+import qualified Distribution.Types.BuildInfo.Lens as L
+
 -- | A foreign library stanza is like a library stanza, except that
 -- the built code is intended for consumption by a non-Haskell client.
 data ForeignLib = ForeignLib {
@@ -125,8 +127,8 @@ libVersionNumberShow v =
 libVersionMajor :: LibVersionInfo -> Int
 libVersionMajor (LibVersionInfo c _ a) = c-a
 
-instance HasBuildInfo ForeignLib where
-    buildInfo_ f l = (\x -> l { foreignLibBuildInfo = x }) <$> f (foreignLibBuildInfo l)
+instance L.HasBuildInfo ForeignLib where
+    buildInfo f l = (\x -> l { foreignLibBuildInfo = x }) <$> f (foreignLibBuildInfo l)
 
 instance Binary ForeignLib
 

--- a/Cabal/Distribution/Types/GenericPackageDescription/Lens.hs
+++ b/Cabal/Distribution/Types/GenericPackageDescription/Lens.hs
@@ -12,6 +12,9 @@ import Distribution.Compat.Lens
 
 import Distribution.Types.GenericPackageDescription (GenericPackageDescription(GenericPackageDescription), Flag(MkFlag), FlagName, ConfVar (..))
 
+-- lens
+import Distribution.Types.BuildInfo.Lens
+
 -- We import types from their packages, so we can remove unused imports
 -- and have wider inter-module dependency graph
 import Distribution.Types.CondTree (CondTree)
@@ -62,6 +65,20 @@ genPackageFlags f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y
 packageDescription :: Lens' GenericPackageDescription PackageDescription
 packageDescription f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription y1 x2 x3 x4 x5 x6 x7 x8) (f x1)
 {-# INLINE packageDescription #-}
+
+-------------------------------------------------------------------------------
+-- BuildInfos
+-------------------------------------------------------------------------------
+
+buildInfos :: Traversal' GenericPackageDescription BuildInfo
+buildInfos f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) =
+    GenericPackageDescription x1 x2
+        <$> (traverse . traverse . buildInfo) f x3
+        <*> (traverse . _2 . traverse . buildInfo) f x4
+        <*> (traverse . _2 . traverse . buildInfo) f x5
+        <*> (traverse . _2 . traverse . buildInfo) f x6
+        <*> (traverse . _2 . traverse . buildInfo) f x7
+        <*> (traverse . _2 . traverse . buildInfo) f x8
 
 -------------------------------------------------------------------------------
 -- Flag

--- a/Cabal/Distribution/Types/GenericPackageDescription/Lens.hs
+++ b/Cabal/Distribution/Types/GenericPackageDescription/Lens.hs
@@ -1,0 +1,104 @@
+module Distribution.Types.GenericPackageDescription.Lens (
+    GenericPackageDescription,
+    Flag,
+    FlagName,
+    ConfVar (..),
+    module Distribution.Types.GenericPackageDescription.Lens,
+    ) where
+
+import Prelude()
+import Distribution.Compat.Prelude
+import Distribution.Compat.Lens
+
+import Distribution.Types.GenericPackageDescription (GenericPackageDescription(GenericPackageDescription), Flag(MkFlag), FlagName, ConfVar (..))
+
+-- We import types from their packages, so we can remove unused imports
+-- and have wider inter-module dependency graph
+import Distribution.Types.CondTree (CondTree)
+import Distribution.Types.Dependency (Dependency)
+import Distribution.Types.Executable (Executable)
+import Distribution.Types.PackageDescription (PackageDescription)
+import Distribution.Types.Benchmark (Benchmark)
+import Distribution.Types.ForeignLib (ForeignLib)
+import Distribution.Types.Library (Library)
+import Distribution.Types.TestSuite (TestSuite)
+import Distribution.Types.UnqualComponentName (UnqualComponentName)
+import Distribution.System (Arch, OS)
+import Distribution.Compiler (CompilerFlavor)
+import Distribution.Version (VersionRange)
+
+-------------------------------------------------------------------------------
+-- GenericPackageDescription
+-------------------------------------------------------------------------------
+
+condBenchmarks :: Lens' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] Benchmark)]
+condBenchmarks f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 y1) (f x8)
+{-# INLINE condBenchmarks #-}
+
+condExecutables :: Lens' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] Executable)]
+condExecutables f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 x3 x4 x5 y1 x7 x8) (f x6)
+{-# INLINE condExecutables #-}
+
+condForeignLibs :: Lens' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] Distribution.Types.ForeignLib.ForeignLib)]
+condForeignLibs f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 x3 x4 y1 x6 x7 x8) (f x5)
+{-# INLINE condForeignLibs #-}
+
+condLibrary :: Lens' GenericPackageDescription (Maybe (CondTree ConfVar [Dependency] Library))
+condLibrary f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 y1 x4 x5 x6 x7 x8) (f x3)
+{-# INLINE condLibrary #-}
+
+condSubLibraries :: Lens' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] Library)]
+condSubLibraries f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 x3 y1 x5 x6 x7 x8) (f x4)
+{-# INLINE condSubLibraries #-}
+
+condTestSuites :: Lens' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] TestSuite)]
+condTestSuites f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 x3 x4 x5 x6 y1 x8) (f x7)
+{-# INLINE condTestSuites #-}
+
+genPackageFlags :: Lens' GenericPackageDescription [Flag]
+genPackageFlags f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 y1 x3 x4 x5 x6 x7 x8) (f x2)
+{-# INLINE genPackageFlags #-}
+
+packageDescription :: Lens' GenericPackageDescription PackageDescription
+packageDescription f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription y1 x2 x3 x4 x5 x6 x7 x8) (f x1)
+{-# INLINE packageDescription #-}
+
+-------------------------------------------------------------------------------
+-- Flag
+-------------------------------------------------------------------------------
+
+flagName :: Lens' Flag FlagName
+flagName f (MkFlag x1 x2 x3 x4) = fmap (\y1 -> MkFlag y1 x2 x3 x4) (f x1)
+{-# INLINE flagName #-}
+
+flagDescription :: Lens' Flag String
+flagDescription f (MkFlag x1 x2 x3 x4) = fmap (\y1 -> MkFlag x1 y1 x3 x4) (f x2)
+{-# INLINE flagDescription #-}
+
+flagDefault :: Lens' Flag Bool
+flagDefault f (MkFlag x1 x2 x3 x4) = fmap (\y1 -> MkFlag x1 x2 y1 x4) (f x3)
+{-# INLINE flagDefault #-}
+
+flagManual :: Lens' Flag Bool
+flagManual f (MkFlag x1 x2 x3 x4) = fmap (\y1 -> MkFlag x1 x2 x3 y1) (f x4)
+{-# INLINE flagManual #-}
+
+-------------------------------------------------------------------------------
+-- ConfVar
+-------------------------------------------------------------------------------
+
+_OS :: Traversal' ConfVar OS
+_OS f (OS os) = OS <$> f os
+_OS _ x       = pure x
+
+_Arch :: Traversal' ConfVar Arch
+_Arch f (Arch arch) = Arch <$> f arch
+_Arch _ x           = pure x
+
+_Flag :: Traversal' ConfVar FlagName
+_Flag f (Flag flag) = Flag <$> f flag
+_Flag _ x           = pure x
+
+_Impl :: Traversal' ConfVar (CompilerFlavor, VersionRange)
+_Impl f (Impl cf vr) = uncurry Impl <$> f (cf, vr)
+_Impl _ x            = pure x

--- a/Cabal/Distribution/Types/Library.hs
+++ b/Cabal/Distribution/Types/Library.hs
@@ -17,6 +17,8 @@ import Distribution.Types.ModuleReexport
 import Distribution.Types.UnqualComponentName
 import Distribution.ModuleName
 
+import qualified Distribution.Types.BuildInfo.Lens as L
+
 data Library = Library {
         libName :: Maybe UnqualComponentName,
         exposedModules    :: [ModuleName],
@@ -27,8 +29,8 @@ data Library = Library {
     }
     deriving (Generic, Show, Eq, Read, Typeable, Data)
 
-instance HasBuildInfo Library where
-    buildInfo_ f l = (\x -> l { libBuildInfo = x }) <$> f (libBuildInfo l)
+instance L.HasBuildInfo Library where
+    buildInfo f l = (\x -> l { libBuildInfo = x }) <$> f (libBuildInfo l)
 
 instance Binary Library
 

--- a/Cabal/Distribution/Types/PackageDescription/Lens.hs
+++ b/Cabal/Distribution/Types/PackageDescription/Lens.hs
@@ -1,0 +1,15 @@
+module Distribution.Types.PackageDescription.Lens (
+    PackageDescription,
+    module Distribution.Types.PackageDescription.Lens,
+    ) where
+
+import Prelude()
+import Distribution.Compat.Prelude
+import Distribution.Compat.Lens
+
+import Distribution.Types.PackageDescription (PackageDescription)
+import qualified Distribution.Types.PackageDescription as T
+
+customFieldsPD :: Lens' PackageDescription [(String,String)]
+customFieldsPD f pd =
+    fmap (\x -> pd { T.customFieldsPD = x }) (f (T.customFieldsPD pd))

--- a/Cabal/Distribution/Types/PackageDescription/Lens.hs
+++ b/Cabal/Distribution/Types/PackageDescription/Lens.hs
@@ -11,5 +11,13 @@ import Distribution.Types.PackageDescription (PackageDescription)
 import qualified Distribution.Types.PackageDescription as T
 
 customFieldsPD :: Lens' PackageDescription [(String,String)]
-customFieldsPD f pd =
-    fmap (\x -> pd { T.customFieldsPD = x }) (f (T.customFieldsPD pd))
+customFieldsPD f pd = fmap (\x -> pd { T.customFieldsPD = x }) (f (T.customFieldsPD pd))
+
+description :: Lens' PackageDescription String
+description f pd = fmap (\x -> pd { T.description = x }) (f (T.description pd))
+
+synopsis :: Lens' PackageDescription String
+synopsis f pd = fmap (\x -> pd { T.synopsis = x }) (f (T.synopsis pd))
+
+maintainer :: Lens' PackageDescription String
+maintainer f pd = fmap (\x -> pd { T.maintainer = x }) (f (T.maintainer pd))

--- a/Cabal/Distribution/Types/PackageDescription/Lens.hs
+++ b/Cabal/Distribution/Types/PackageDescription/Lens.hs
@@ -10,6 +10,9 @@ import Distribution.Compat.Lens
 import Distribution.Types.PackageDescription (PackageDescription)
 import qualified Distribution.Types.PackageDescription as T
 
+import Distribution.Types.SetupBuildInfo (SetupBuildInfo)
+import Distribution.Types.SourceRepo (SourceRepo)
+
 customFieldsPD :: Lens' PackageDescription [(String,String)]
 customFieldsPD f pd = fmap (\x -> pd { T.customFieldsPD = x }) (f (T.customFieldsPD pd))
 
@@ -21,3 +24,9 @@ synopsis f pd = fmap (\x -> pd { T.synopsis = x }) (f (T.synopsis pd))
 
 maintainer :: Lens' PackageDescription String
 maintainer f pd = fmap (\x -> pd { T.maintainer = x }) (f (T.maintainer pd))
+
+setupBuildInfo :: Lens' PackageDescription (Maybe SetupBuildInfo)
+setupBuildInfo f pd = fmap (\x -> pd { T.setupBuildInfo = x }) (f (T.setupBuildInfo pd))
+
+sourceRepos :: Lens' PackageDescription [SourceRepo]
+sourceRepos f pd = fmap (\x -> pd { T.sourceRepos = x }) (f (T.sourceRepos pd))

--- a/Cabal/Distribution/Types/TestSuite.hs
+++ b/Cabal/Distribution/Types/TestSuite.hs
@@ -19,6 +19,8 @@ import Distribution.Types.UnqualComponentName
 
 import Distribution.ModuleName
 
+import qualified Distribution.Types.BuildInfo.Lens as L
+
 -- | A \"test-suite\" stanza in a cabal file.
 --
 data TestSuite = TestSuite {
@@ -28,8 +30,8 @@ data TestSuite = TestSuite {
     }
     deriving (Generic, Show, Read, Eq, Typeable, Data)
 
-instance HasBuildInfo TestSuite where
-    buildInfo_ f l = (\x -> l { testBuildInfo = x }) <$> f (testBuildInfo l)
+instance L.HasBuildInfo TestSuite where
+    buildInfo f l = (\x -> l { testBuildInfo = x }) <$> f (testBuildInfo l)
 
 instance Binary TestSuite
 

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -10,11 +10,13 @@
 	* Warn about `.cabal` file-name not matching package name
 	  in 'cabal check' (#4592)
 	* By default 'ar' program receives arguments via '@file' format.
-	Old behavior can be restored with '--ar-does-not-support-at-arguments'
-	argument to 'configure' or 'install'. (#4596)
+	  Old behavior can be restored with '--ar-does-not-support-at-arguments'
+	  argument to 'configure' or 'install'. (#4596)
 	* Check warns about unused, undeclared or non-unicode flags.
 	  Also it warns about leading dash, which is unusable but accepted if
-	  it's unused in conditionals.(#4687)
+	  it's unused in conditionals. (#4687)
+	* Add '.Lens' modules, with optics for package description data
+	  types. (#4701)
 	* TODO
 
 2.0.0.2 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> July 2017


### PR DESCRIPTION
This patch introduces `Distribution.Compat.Lens`, a small portion of `lens`. The need is two fold:
- to provide lenses to users of `Cabal`
- to use it internally in places where lenses shine (subjectively, see `Check.hs`)

The design is simple:
- `Distribution.Compat.Lens` have some definitions from `lens`.
- type modules have sibling `.Lens` module which exports the type and lenses, with the same name as fields. Users can either

```haskell
import Distribution.Types.PackageDescription
import qualified Distribution.Types.PackageDescription.Lens as L
```

or

```haskell
import Distribution.Types.PackageDescription.Lens
```

Latter variant is not yet viable, as not everything is lensified. But we can make progress there quite easily.

To better compare lens and "old-school" Haskell approaches see e.g. (I realized later, these are essentially same checks):
- lens `checkUnusedFlags` https://github.com/phadej/cabal/blob/2dbd57a4aba07828c9520c7692c63138cfcda658/Cabal/Distribution/PackageDescription/Check.hs#L1620-L1642
- vanilla `checkConditionals` https://github.com/phadej/cabal/blob/2dbd57a4aba07828c9520c7692c63138cfcda658/Cabal/Distribution/PackageDescription/Check.hs#L1561-L1597

--- 

This commit includes some lens defintions to show up, how the Cabal-lens
framework could look like.

As an example checks which used ad-hoc lenses use newly introduced
lens-framework.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
