### PR TITLE
CPSise ParseResult

### DIFF
--- a/Cabal/Distribution/Parsec/Types/ParseResult.hs
+++ b/Cabal/Distribution/Parsec/Types/ParseResult.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE BangPatterns #-}
 -- | A parse result type for parsers from AST to Haskell types.
 module Distribution.Parsec.Types.ParseResult (
     ParseResult,
@@ -17,7 +19,13 @@ import           Distribution.Parsec.Types.Common
                  (PError (..), PWarnType (..), PWarning (..), Position (..))
 
 -- | A monad with failure and accumulating errors and warnings.
-newtype ParseResult a = PR { runPR :: PRState -> (Maybe a, PRState) }
+newtype ParseResult a = PR
+    { unPR
+        :: forall r. PRState
+        -> (PRState -> r)       -- failure
+        -> (PRState -> a -> r)  -- success
+        -> r
+    }
 
 data PRState = PRState ![PWarning] ![PError]
 
@@ -27,61 +35,66 @@ emptyPRState = PRState [] []
 -- | Destruct a 'ParseResult' into the emitted warnings and errors, and
 -- possibly the final result if there were no errors.
 runParseResult :: ParseResult a -> ([PWarning], [PError], Maybe a)
-runParseResult pr = case runPR pr emptyPRState of
-    (res, PRState warns errs)
-        -- If there are any errors, don't return the result
-        | null errs -> (warns, [], res)
-        | otherwise -> (warns, errs, Nothing)
+runParseResult pr = unPR pr emptyPRState failure success
+  where
+    failure (PRState warns errs)   = (warns, errs, Nothing)
+    success (PRState warns [])   x = (warns, [], Just x)
+    -- If there are any errors, don't return the result
+    success (PRState warns errs) _ = (warns, errs, Nothing)
 
 instance Functor ParseResult where
-    fmap f (PR pr) = PR $ \s -> case pr s of
-        (r, s') -> (fmap f r, s')
+    fmap f (PR pr) = PR $ \ !s failure success ->
+        pr s failure $ \ !s' a ->
+        success s' (f a)
 
 instance Applicative ParseResult where
-    pure x = PR $ \s -> (Just x, s)
+    pure x = PR $ \ !s _ success ->  success s x
     -- | Make it concat perrors
     (<*>) = ap
+{-
     PR a *> PR b = PR $ \s0 -> case a s0 of
         (x, s1) -> case b s1 of
             (y, s2) -> (x *> y, s2)
+-}
 
 instance Monad ParseResult where
     return = pure
     (>>) = (*>)
-    PR m >>= k = PR $ \s -> case m s of
-        (Nothing, s') -> (Nothing, s')
-        (Just x,  s') -> runPR (k x) s'
+
+    m >>= k = PR $ \ !s failure success ->
+        unPR m s failure $ \ !s' a ->
+        unPR (k a) s' failure success
 
 -- | "Recover" the parse result, so we can proceed parsing.
 -- 'runParseResult' will still result in 'Nothing', if there are recorded errors.
 recoverWith :: ParseResult a -> a -> ParseResult a
-recoverWith (PR f) x = PR $ \s -> case f s of
-    (Nothing, s') -> (Just x, s')
-    r             -> r
+recoverWith (PR pr) x = PR $ \ !s _failure success ->
+    pr s (\ !s' -> success s' x) success
 
 parseWarning :: Position -> PWarnType -> String -> ParseResult ()
-parseWarning pos t msg = PR $ \(PRState warns errs) ->
-    (Just (), PRState (PWarning t pos msg : warns) errs)
+parseWarning pos t msg = PR $ \(PRState warns errs) _failure success ->
+    success (PRState (PWarning t pos msg : warns) errs) ()
 
 parseWarnings' :: [PWarning] -> ParseResult ()
-parseWarnings' newWarns = PR $ \(PRState warns errs) ->
-    (Just (), PRState (warns ++ newWarns) errs)
+parseWarnings' newWarns = PR $ \(PRState warns errs) _failure success ->
+    success (PRState (newWarns ++ warns) errs) ()
 
 -- | Add an error, but not fail the parser yet.
 --
 -- For fatal failure use 'parseFatalFailure'
 parseFailure :: Position -> String -> ParseResult ()
-parseFailure pos msg = PR $ \(PRState warns errs) ->
-    (Just (), PRState warns (PError pos msg : errs))
+parseFailure pos msg = PR $ \(PRState warns errs) _failure success ->
+    success (PRState warns (PError pos msg : errs)) ()
 
 -- | Add an fatal error.
 parseFatalFailure :: Position -> String -> ParseResult a
-parseFatalFailure pos msg = PR $ \(PRState warns errs) ->
-    (Nothing, PRState warns (PError pos msg : errs))
+parseFatalFailure pos msg = PR $ \(PRState warns errs) failure _success ->
+    failure (PRState warns (PError pos msg : errs))
 
 parseFatalFailure' :: ParseResult a
-parseFatalFailure' = PR f
+parseFatalFailure' = PR pr
   where
-    f s@(PRState warns errs)
-        | null errs = (Nothing, PRState warns [PError (Position 0 0) "Unknown failure"])
-        | otherwise = (Nothing, s)
+    pr (PRState warns []) failure _success = failure (PRState warns [err])
+    pr s                  failure _success = failure s
+
+    err = PError (Position 0 0) "Unknown fatal error"


### PR DESCRIPTION
Noticed one (possibly) low-hanging fruit.

Try to parse whole Hackage (`index-01.tar`)
```
parser-hackage-tests parse-parsec +RTS s
```

In short: with CPS it takes less memory, but seems that a bit more time. Though memory measurement is exact, time isn't.

`ParseResult` is a monad where parsing from outer-format `[Field]` (think `Value`), is elaborated into `GenericPackageDescription`

Note: I really have to profile, but atm I'm out of time. This is very local change, so could wait.

## Before

```
 294,510,120,352 bytes allocated in the heap
  24,907,645,200 bytes copied during GC
      12,271,240 bytes maximum residency (5899 sample(s))
         976,336 bytes maximum slop
              25 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     565906 colls,     0 par   28.432s  28.368s     0.0001s    0.0013s
  Gen  1      5899 colls,     0 par    7.260s   7.253s     0.0012s    0.0106s

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time   56.992s  ( 56.959s elapsed)
  GC      time   35.692s  ( 35.621s elapsed)
  EXIT    time    0.001s  (  0.001s elapsed)
  Total   time   92.685s  ( 92.580s elapsed)

  %GC     time      38.5%  (38.5% elapsed)

  Alloc rate    5,167,554,498 bytes per MUT second

  Productivity  61.5% of total user, 61.5% of total elapsed

 parse-parsec +RTS -s  91,63s user 1,05s system 100% cpu 1:32,58 total
```


## After

```
 294,544,884,216 bytes allocated in the heap
  24,812,509,368 bytes copied during GC
       8,863,192 bytes maximum residency (5891 sample(s))
         789,032 bytes maximum slop
              20 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     565948 colls,     0 par   29.588s  29.538s     0.0001s    0.0062s
  Gen  1      5891 colls,     0 par    7.833s   7.826s     0.0013s    0.0113s

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time   59.884s  ( 59.847s elapsed)
  GC      time   37.420s  ( 37.364s elapsed)
  EXIT    time    0.001s  (  0.001s elapsed)
  Total   time   97.307s  ( 97.213s elapsed)

  %GC     time      38.5%  (38.4% elapsed)

  Alloc rate    4,918,563,537 bytes per MUT second

  Productivity  61.5% of total user, 61.6% of total elapsed

 parse-parsec +RTS -s  96,16s user 1,15s system 100% cpu 1:37,22 total
```

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
