### PR TITLE
Fix minor regression in flag assignment marshalling to custom-setup

### DIFF
--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -674,7 +674,7 @@ configureOptions showOrParseArgs =
          configConfigurationsFlags (\v flags -> flags { configConfigurationsFlags = v })
          (reqArg "FLAGS"
               (readP_to_E (\err -> "Invalid flag assignment: " ++ err) parseFlagAssignment)
-              (map showFlagValue))
+              (map showFlagValue'))
 
       ,option "" ["extra-include-dirs"]
          "A list of directories to search for header files"
@@ -777,6 +777,13 @@ configureOptions showOrParseArgs =
     reqPathTemplateArgFlag title _sf _lf d get set =
       reqArgFlag title _sf _lf d
         (fmap fromPathTemplate . get) (set . fmap toPathTemplate)
+
+    -- We can't use 'showFlagValue' because legacy custom-setups don't
+    -- support the '+' prefix in --flags; so we omit the (redundant) + prefix;
+    -- NB: we assume that we never have to set/enable '-'-prefixed flags here.
+    showFlagValue' :: (FlagName, Bool) -> String
+    showFlagValue' (f, True)   =       unFlagName f
+    showFlagValue' (f, False)  = '-' : unFlagName f
 
 readPackageDbList :: String -> [Maybe PackageDB]
 readPackageDbList "clear"  = [Nothing]


### PR DESCRIPTION
This was introduced by f8dc46a0fe68e35ec0397da92d7e9d4f168aa126 which
resulted in passing `--flags=+foo` to older custom setup scripts which
wouldn't recognize the `+` prefix.

This was reported by @cocreature

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
