### PR TITLE
Demote 'scope' field version check to a warning

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -322,10 +322,10 @@ checkExecutable pkg exe =
            "On executable '" ++ display (exeName exe) ++ "' an 'autogen-module' is not "
         ++ "on 'other-modules'"
 
-  , checkSpecVersion pkg [1,25] (exeScope exe /= ExecutableScopeUnknown) $
-      PackageDistInexcusable $
+  , checkSpecVersion pkg [2,0] (exeScope exe /= ExecutableScopeUnknown) $
+      PackageDistSuspiciousWarn $
            "To use the 'scope' field the package needs to specify "
-        ++ "at least 'cabal-version: >= 1.25'."
+        ++ "at least 'cabal-version: >= 2.0'."
 
   ]
   where


### PR DESCRIPTION
In order to migrate from pre `scope` Setup.hs hacks to 2.0 we would like
to specify both `scope` and `x-scope` (as just `scope` can't be accessed
from Setup.hs AFAIK) and handle Cabal<2.0 with custom logic. However
this check makes this undistributable as hackage rejects such packages.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.