### PR TITLE
Document that Cabal passes -O2 to C compilers

### DIFF
--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -980,6 +980,8 @@ Miscellaneous options
     if the compiler supports it. Level 2 is likely to lead to longer
     compile times and bigger generated code.
 
+    When optimizations are enabled, Cabal passes ``-O2`` to the C compiler.
+
 .. option:: --disable-optimization
 
     Build without optimization. This is suited for development: building

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -967,6 +967,8 @@ feature was added.
     planning to run code, turning off optimization will lead to better
     build times and less code to be rebuilt when a module changes.
 
+    When optimizations are enabled, Cabal passes ``-O2`` to the C compiler.
+
     We also accept ``True`` (equivalent to 1) and ``False`` (equivalent
     to 0).
 


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

The relevant code for this can be found in https://github.com/haskell/cabal/blob/master/Cabal/Distribution/Simple/GHC/Internal.hs#L280. Thanks to @hvr for pointing me to it.
