### PR TITLE
Fix verbosity flags getting removed before being passed to `printPlan`

### DIFF
--- a/Cabal/Distribution/Verbosity.hs
+++ b/Cabal/Distribution/Verbosity.hs
@@ -31,6 +31,7 @@ module Distribution.Verbosity (
   intToVerbosity, flagToVerbosity,
   showForCabal, showForGHC,
   verboseNoFlags, verboseHasFlags,
+  modifyVerbosity,
 
   -- * Call stacks
   verboseCallSite, verboseCallStack,
@@ -127,6 +128,18 @@ lessVerbose v =
         Verbose   -> v { vLevel = Normal }
         Normal    -> v { vLevel = Silent }
         Silent    -> v
+
+-- | Combinator for transforming verbosity level while retaining the original hidden state.
+--
+-- For instance, the following property holds
+--
+-- prop> isVerboseNoWrap (modifyVerbosity (max verbose) v) == isVerboseNoWrap v
+--
+-- __Note__: you can use @modifyVerbosity (const v1) v0@ to overwrite @v1@'s flags with @v0@'s flags.
+--
+-- @since 2.0.1
+modifyVerbosity :: (Verbosity -> Verbosity) -> Verbosity -> Verbosity
+modifyVerbosity f v = v { vLevel = vLevel (f v) }
 
 intToVerbosity :: Int -> Maybe Verbosity
 intToVerbosity 0 = Just (mkVerbosity Silent)

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1148,7 +1148,7 @@ performInstallations verbosity
         -- If the user has specified --remote-build-reporting=detailed or
         -- --build-log, use more verbose logging.
         loggingVerbosity :: Verbosity
-        loggingVerbosity | overrideVerbosity = max Verbosity.verbose verbosity
+        loggingVerbosity | overrideVerbosity = modifyVerbosity (max verbose) verbosity
                          | otherwise         = verbosity
 
         useDefaultTemplate :: Bool

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -167,7 +167,7 @@ import Distribution.System
 import Distribution.Text
          ( display )
 import Distribution.Verbosity as Verbosity
-         ( Verbosity, normal, verbose )
+         ( Verbosity, modifyVerbosity, normal, verbose )
 import Distribution.Simple.BuildPaths ( exeExtension )
 
 --TODO:
@@ -549,8 +549,9 @@ checkPrintPlan verbosity installed installPlan sourcePkgDb
   let breaksPkgs         = not (null newBrokenPkgs)
 
   let adaptedVerbosity
-        | containsReinstalls && not overrideReinstall = verbosity `max` verbose
-        | otherwise                                   = verbosity
+        | containsReinstalls
+        , not overrideReinstall  = modifyVerbosity (max verbose) verbosity
+        | otherwise              = verbosity
 
   -- We print the install plan if we are in a dry-run or if we are confronted
   -- with a dangerous install plan.

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -98,7 +98,7 @@ import Distribution.Client.Utils
 import Distribution.Utils.NubList
          ( fromNubList )
 import Distribution.Verbosity
-         ( Verbosity, verbose )
+         ( Verbosity, modifyVerbosity, verbose )
 import Distribution.Text
 import Distribution.ParseUtils
          ( ParseResult(..), locatedErrorMsg, showPWarning )
@@ -326,7 +326,7 @@ resolveBuildTimeSettings verbosity
     -- --build-log, use more verbose logging.
     --
     buildSettingLogVerbosity
-      | overrideVerbosity = max verbose verbosity
+      | overrideVerbosity = modifyVerbosity (max verbose) verbosity
       | otherwise         = verbosity
 
     overrideVerbosity


### PR DESCRIPTION
This fixes a case where the log-output "In order, the following would be
installed: ..." would fail to honor verbosity flags.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
