### PR TITLE
Add normaliseVersionRange

### DIFF
--- a/Cabal/Distribution/Compat/Parsec.hs
+++ b/Cabal/Distribution/Compat/Parsec.hs
@@ -16,6 +16,7 @@ module Distribution.Compat.Parsec (
     P.sepBy,
     P.sepBy1,
     P.choice,
+    P.eof,
 
     -- * Char
     integral,


### PR DESCRIPTION
foldVersionRange' recognises (> x || == v)  and (== x || > x) as
(>= v), and similarly for <=. Therefore `simpleParsec . display` isn't
structurally `id`, but `normalizeVersionRange`.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
