### PR TITLE
Target package names

### DIFF
--- a/cabal-install/Distribution/Client/CmdBench.hs
+++ b/cabal-install/Distribution/Client/CmdBench.hs
@@ -222,10 +222,6 @@ renderTargetProblem (TargetProblemNoTargets targetSelector) =
            ++ renderTargetSelector targetSelector ++ "."
 
       _ -> renderTargetProblemNoTargets "benchmark" targetSelector
-  where
-    targetSelectorFilter (TargetAllPackages  mkfilter) = mkfilter
-    targetSelectorFilter (TargetPackage  _ _ mkfilter) = mkfilter
-    targetSelectorFilter (TargetComponent _ _ _)       = Nothing
 
 renderTargetProblem (TargetProblemComponentNotBenchmark pkgid cname) =
     "The bench command is for running benchmarks, but the target '"

--- a/cabal-install/Distribution/Client/CmdErrorMessages.hs
+++ b/cabal-install/Distribution/Client/CmdErrorMessages.hs
@@ -111,6 +111,9 @@ renderTargetSelector (TargetComponent _pkgid cname (FileTarget filename)) =
 renderTargetSelector (TargetComponent _pkgid cname (ModuleTarget modname)) =
     "the module " ++ display modname ++ " in the " ++ showComponentName cname
 
+renderTargetSelector (TargetPackageName pkgname) =
+    "the package " ++ display pkgname
+
 
 renderOptionalStanza :: Plural -> OptionalStanza -> String
 renderOptionalStanza Singular TestStanzas  = "test suite"
@@ -130,17 +133,20 @@ targetSelectorPluralPkgs :: TargetSelector a -> Plural
 targetSelectorPluralPkgs (TargetAllPackages _)     = Plural
 targetSelectorPluralPkgs (TargetPackage _ _ _)     = Singular
 targetSelectorPluralPkgs (TargetComponent _ _ _)   = Singular
+targetSelectorPluralPkgs (TargetPackageName _)     = Singular
 
 -- | Does the 'TargetSelector' refer to 
 targetSelectorRefersToPkgs :: TargetSelector a -> Bool
 targetSelectorRefersToPkgs (TargetAllPackages  mkfilter) = isNothing mkfilter
 targetSelectorRefersToPkgs (TargetPackage  _ _ mkfilter) = isNothing mkfilter
 targetSelectorRefersToPkgs (TargetComponent _ _ _)       = False
+targetSelectorRefersToPkgs (TargetPackageName _)         = True
 
 targetSelectorFilter :: TargetSelector a -> Maybe ComponentKindFilter
 targetSelectorFilter (TargetPackage  _ _ mkfilter) = mkfilter
 targetSelectorFilter (TargetAllPackages  mkfilter) = mkfilter
 targetSelectorFilter (TargetComponent _ _ _)       = Nothing
+targetSelectorFilter (TargetPackageName _)         = Nothing
 
 renderComponentKind :: Plural -> ComponentKind -> String
 renderComponentKind Singular ckind = case ckind of
@@ -315,6 +321,8 @@ renderTargetProblemNoTargets verb targetSelector =
      ++ renderComponentKind Plural kfilter
     reason ts@TargetComponent{} =
         error $ "renderTargetProblemNoTargets: " ++ show ts
+    reason (TargetPackageName _) =
+        "it does not contain any components at all"
 
 -----------------------------------------------------------
 -- Renderering error messages for CannotPruneDependencies

--- a/cabal-install/Distribution/Client/CmdErrorMessages.hs
+++ b/cabal-install/Distribution/Client/CmdErrorMessages.hs
@@ -9,7 +9,7 @@ module Distribution.Client.CmdErrorMessages (
 
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.TargetSelector
-         ( componentKind, showTargetSelector )
+         ( ComponentKindFilter, componentKind, showTargetSelector )
 
 import Distribution.Package
          ( packageId, packageName )
@@ -124,7 +124,6 @@ optionalStanza (CTestName  _) = Just TestStanzas
 optionalStanza (CBenchName _) = Just BenchStanzas
 optionalStanza _              = Nothing
 
-
 -- | Does the 'TargetSelector' potentially refer to one package or many?
 --
 targetSelectorPluralPkgs :: TargetSelector a -> Plural
@@ -137,6 +136,11 @@ targetSelectorRefersToPkgs :: TargetSelector a -> Bool
 targetSelectorRefersToPkgs (TargetAllPackages  mkfilter) = isNothing mkfilter
 targetSelectorRefersToPkgs (TargetPackage  _ _ mkfilter) = isNothing mkfilter
 targetSelectorRefersToPkgs (TargetComponent _ _ _)       = False
+
+targetSelectorFilter :: TargetSelector a -> Maybe ComponentKindFilter
+targetSelectorFilter (TargetPackage  _ _ mkfilter) = mkfilter
+targetSelectorFilter (TargetAllPackages  mkfilter) = mkfilter
+targetSelectorFilter (TargetComponent _ _ _)       = Nothing
 
 renderComponentKind :: Plural -> ComponentKind -> String
 renderComponentKind Singular ckind = case ckind of

--- a/cabal-install/Distribution/Client/CmdRun.hs
+++ b/cabal-install/Distribution/Client/CmdRun.hs
@@ -388,11 +388,6 @@ renderTargetProblem (TargetProblemNoTargets targetSelector) =
            ++ renderTargetSelector targetSelector ++ "."
 
       _ -> renderTargetProblemNoTargets "run" targetSelector
-  where
-    targetSelectorFilter (TargetPackage  _ _ mkfilter) = mkfilter
-    targetSelectorFilter (TargetAllPackages  mkfilter) = mkfilter
-    targetSelectorFilter (TargetComponent _ _ _)       = Nothing
-
 
 renderTargetProblem (TargetProblemMatchesMultiple targetSelector targets) =
     "The run command is for running a single executable at once. The target '"

--- a/cabal-install/Distribution/Client/CmdTest.hs
+++ b/cabal-install/Distribution/Client/CmdTest.hs
@@ -225,10 +225,6 @@ renderTargetProblem (TargetProblemNoTargets targetSelector) =
            ++ renderTargetSelector targetSelector ++ "."
 
       _ -> renderTargetProblemNoTargets "test" targetSelector
-  where
-    targetSelectorFilter (TargetPackage  _ _ mkfilter) = mkfilter
-    targetSelectorFilter (TargetAllPackages  mkfilter) = mkfilter
-    targetSelectorFilter (TargetComponent _ _ _)       = Nothing
 
 renderTargetProblem (TargetProblemComponentNotTest pkgid cname) =
     "The test command is for running test suites, but the target '"

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -71,6 +71,7 @@ import Distribution.Client.SolverInstallPlan (SolverInstallPlan)
 import qualified Distribution.Client.SolverInstallPlan as SolverInstallPlan
 import Distribution.Client.Types
          ( SourcePackageDb(SourcePackageDb)
+         , PackageSpecifier(..), pkgSpecifierTarget, pkgSpecifierConstraints
          , UnresolvedPkgLoc, UnresolvedSourcePackage
          , AllowNewer(..), AllowOlder(..), RelaxDeps(..), RelaxedDep(..)
          , RelaxDepScope(..), RelaxDepMod(..), RelaxDepSubject(..), isRelaxDeps
@@ -80,7 +81,6 @@ import Distribution.Client.Dependency.Types
          , PackagesPreferenceDefault(..) )
 import Distribution.Client.Sandbox.Types
          ( SandboxPackageInfo(..) )
-import Distribution.Client.Targets
 import Distribution.Package
          ( PackageName, mkPackageName, PackageIdentifier(PackageIdentifier), PackageId
          , Package(..), packageName, packageVersion )

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -47,10 +47,9 @@ import qualified Distribution.Solver.Types.PackageIndex as PackageIndex
 import           Distribution.Solver.Types.SourcePackage
 
 import Distribution.Client.Types
-         ( SourcePackageDb(..)
-         , UnresolvedSourcePackage )
+         ( SourcePackageDb(..), PackageSpecifier(..), UnresolvedSourcePackage )
 import Distribution.Client.Targets
-         ( UserTarget, resolveUserTargets, PackageSpecifier(..) )
+         ( UserTarget, resolveUserTargets )
 import Distribution.Client.Setup
          ( GlobalFlags(..), ListFlags(..), InfoFlags(..)
          , RepoContext(..) )

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -69,6 +69,8 @@ import Distribution.Client.Config
 
 import Distribution.Solver.Types.SourcePackage
 import Distribution.Solver.Types.Settings
+import Distribution.Solver.Types.PackageConstraint
+         ( PackageProperty(..) )
 
 import Distribution.Package
          ( PackageName, PackageId, packageId, UnitId )
@@ -884,7 +886,7 @@ mplusMaybeT ma mb = do
 -- paths.
 --
 readSourcePackage :: Verbosity -> ProjectPackageLocation
-                  -> Rebuild UnresolvedSourcePackage
+                  -> Rebuild (PackageSpecifier UnresolvedSourcePackage)
 readSourcePackage verbosity (ProjectPackageLocalCabalFile cabalFile) =
     readSourcePackage verbosity (ProjectPackageLocalDirectory dir cabalFile)
   where
@@ -894,15 +896,27 @@ readSourcePackage verbosity (ProjectPackageLocalDirectory dir cabalFile) = do
     monitorFiles [monitorFileHashed cabalFile]
     root <- askRoot
     pkgdesc <- liftIO $ readGenericPackageDescription verbosity (root </> cabalFile)
-    return SourcePackage {
+    return $ SpecificSourcePackage SourcePackage {
       packageInfoId        = packageId pkgdesc,
       packageDescription   = pkgdesc,
       packageSource        = LocalUnpackedPackage (root </> dir),
       packageDescrOverride = Nothing
     }
+
+readSourcePackage _ (ProjectPackageNamed (Dependency pkgname verrange)) =
+    return $ NamedPackage pkgname [PackagePropertyVersion verrange]
+
 readSourcePackage _verbosity _ =
     fail $ "TODO: add support for fetching and reading local tarballs, remote "
         ++ "tarballs, remote repos and passing named packages through"
+
+
+-- TODO: add something like this, here or in the project planning
+-- Based on the package location, which packages will be built inplace in the
+-- build tree vs placed in the store. This has various implications on what we
+-- can do with the package, e.g. can we run tests, ghci etc.
+--
+-- packageIsLocalToProject :: ProjectPackageLocation -> Bool
 
 
 ---------------------------------------------

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -104,7 +104,8 @@ import           Distribution.Client.ProjectBuilding
 import           Distribution.Client.ProjectPlanOutput
 
 import           Distribution.Client.Types
-                   ( GenericReadyPackage(..), UnresolvedSourcePackage )
+                   ( GenericReadyPackage(..), UnresolvedSourcePackage
+                   , PackageSpecifier(..) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import           Distribution.Client.TargetSelector
                    ( TargetSelector(..)
@@ -154,7 +155,7 @@ data ProjectBaseContext = ProjectBaseContext {
        distDirLayout  :: DistDirLayout,
        cabalDirLayout :: CabalDirLayout,
        projectConfig  :: ProjectConfig,
-       localPackages  :: [UnresolvedSourcePackage],
+       localPackages  :: [PackageSpecifier UnresolvedSourcePackage],
        buildSettings  :: BuildTimeSettings
      }
 

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -496,19 +496,31 @@ resolveTargets selectPackageTargets selectComponentTarget liftProblem
       | otherwise
       = Left (liftProblem (TargetProblemNoSuchPackage pkgid))
 
-    checkTarget (TargetPackageName pkgname)
+    checkTarget bt@(TargetPackageName pkgname)
+      | Just ats <- Map.lookup pkgname availableTargetsByPackageName
+      = case selectPackageTargets bt ats of
+          Left  e  -> Left e
+          Right ts -> Right [ (unitid, ComponentTarget cname WholeComponent)
+                            | (unitid, cname) <- ts ]
+
+      | otherwise
       = Left (liftProblem (TargetNotInProject pkgname))
     --TODO: check if the package is in the plan, even if it's not local
     --TODO: check if the package is in hackage and return different
     -- error cases here so the commands can handle things appropriately
 
-    availableTargetsByPackage   :: Map PackageId                  [AvailableTarget (UnitId, ComponentName)]
-    availableTargetsByComponent :: Map (PackageId, ComponentName) [AvailableTarget (UnitId, ComponentName)]
-    availableTargetsByComponent = availableTargets installPlan
-    availableTargetsByPackage   = Map.mapKeysWith
-                                    (++) (\(pkgid, _cname) -> pkgid)
-                                    availableTargetsByComponent
-                      `Map.union` availableTargetsEmptyPackages
+    availableTargetsByPackage     :: Map PackageId                  [AvailableTarget (UnitId, ComponentName)]
+    availableTargetsByPackageName :: Map PackageName                [AvailableTarget (UnitId, ComponentName)]
+    availableTargetsByComponent   :: Map (PackageId, ComponentName) [AvailableTarget (UnitId, ComponentName)]
+
+    availableTargetsByComponent   = availableTargets installPlan
+    availableTargetsByPackage     = Map.mapKeysWith
+                                      (++) (\(pkgid, _cname) -> pkgid)
+                                      availableTargetsByComponent
+                        `Map.union` availableTargetsEmptyPackages
+    availableTargetsByPackageName = Map.mapKeysWith
+                                    (++) packageName
+                                    availableTargetsByPackage
 
     -- Add in all the empty packages. These do not appear in the
     -- availableTargetsByComponent map, since that only contains components

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -496,6 +496,8 @@ resolveTargets selectPackageTargets selectComponentTarget liftProblem
       | otherwise
       = Left (liftProblem (TargetProblemNoSuchPackage pkgid))
 
+    checkTarget (TargetPackageName pkgname)
+      = Left (liftProblem (TargetNotInProject pkgname))
     --TODO: check if the package is in the plan, even if it's not local
     --TODO: check if the package is in hackage and return different
     -- error cases here so the commands can handle things appropriately

--- a/cabal-install/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/Distribution/Client/TargetSelector.hs
@@ -961,7 +961,6 @@ dummyPackageInfo =
       pinfoId          = PackageIdentifier
                            (mkPackageName "dummyPackageInfo")
                            (mkVersion []),
-      pinfoLocation    = unused,
       pinfoDirectory   = unused,
       pinfoPackageFile = unused,
       pinfoComponents  = unused
@@ -1561,7 +1560,6 @@ dispM = display
 
 data PackageInfo = PackageInfo {
        pinfoId          :: PackageId,
-       pinfoLocation    :: PackageLocation (),
        pinfoDirectory   :: Maybe (FilePath, FilePath),
        pinfoPackageFile :: Maybe (FilePath, FilePath),
        pinfoComponents  :: [ComponentInfo]
@@ -1609,7 +1607,6 @@ selectPackageInfo dirActions@DirActions{..}
     let pinfo =
           PackageInfo {
             pinfoId          = packageId pkg,
-            pinfoLocation    = fmap (const ()) loc,
             pinfoDirectory   = pkgdir,
             pinfoPackageFile = pkgfile,
             pinfoComponents  = selectComponentInfo pinfo
@@ -2202,14 +2199,12 @@ ex1pinfo =
   [ addComponent (CExeName (mkUnqualComponentName "foo-exe")) [] ["Data.Foo"] $
     PackageInfo {
       pinfoId          = PackageIdentifier (mkPackageName "foo") (mkVersion [1]),
-      pinfoLocation    = LocalUnpackedPackage "/the/foo",
       pinfoDirectory   = Just ("/the/foo", "foo"),
       pinfoPackageFile = Just ("/the/foo/foo.cabal", "foo/foo.cabal"),
       pinfoComponents  = []
     }
   , PackageInfo {
       pinfoId          = PackageIdentifier (mkPackageName "bar") (mkVersion [1]),
-      pinfoLocation    = LocalUnpackedPackage "/the/foo",
       pinfoDirectory   = Just ("/the/bar", "bar"),
       pinfoPackageFile = Just ("/the/bar/bar.cabal", "bar/bar.cabal"),
       pinfoComponents  = []

--- a/cabal-install/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/Distribution/Client/TargetSelector.hs
@@ -16,6 +16,7 @@ module Distribution.Client.TargetSelector (
     TargetSelector(..),
     TargetImplicitCwd(..),
     ComponentKind(..),
+    ComponentKindFilter,
     SubComponentTarget(..),
     QualLevel(..),
     componentKind,

--- a/cabal-install/Distribution/Client/Targets.hs
+++ b/cabal-install/Distribution/Client/Targets.hs
@@ -18,11 +18,6 @@ module Distribution.Client.Targets (
   UserTarget(..),
   readUserTargets,
 
-  -- * Package specifiers
-  PackageSpecifier(..),
-  pkgSpecifierTarget,
-  pkgSpecifierConstraints,
-
   -- * Resolving user targets to package specifiers
   resolveUserTargets,
 
@@ -60,11 +55,9 @@ import Distribution.Package
          , PackageIdentifier(..), packageName, packageVersion )
 import Distribution.Types.Dependency
 import Distribution.Client.Types
-         ( PackageLocation(..)
-         , ResolvedPkgLoc, UnresolvedSourcePackage )
+         ( PackageLocation(..), ResolvedPkgLoc, UnresolvedSourcePackage
+         , PackageSpecifier(..) )
 
-import           Distribution.Solver.Types.ConstraintSource
-import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PackageConstraint
 import           Distribution.Solver.Types.PackagePath
@@ -169,46 +162,6 @@ data UserTarget =
    | UserTargetRemoteTarball URI
   deriving (Show,Eq)
 
-
--- ------------------------------------------------------------
--- * Package specifier
--- ------------------------------------------------------------
-
--- | A fully or partially resolved reference to a package.
---
-data PackageSpecifier pkg =
-
-     -- | A partially specified reference to a package (either source or
-     -- installed). It is specified by package name and optionally some
-     -- required properties. Use a dependency resolver to pick a specific
-     -- package satisfying these properties.
-     --
-     NamedPackage PackageName [PackageProperty]
-
-     -- | A fully specified source package.
-     --
-   | SpecificSourcePackage pkg
-  deriving (Eq, Show, Generic)
-
-instance Binary pkg => Binary (PackageSpecifier pkg)
-
-pkgSpecifierTarget :: Package pkg => PackageSpecifier pkg -> PackageName
-pkgSpecifierTarget (NamedPackage name _)       = name
-pkgSpecifierTarget (SpecificSourcePackage pkg) = packageName pkg
-
-pkgSpecifierConstraints :: Package pkg
-                        => PackageSpecifier pkg -> [LabeledPackageConstraint]
-pkgSpecifierConstraints (NamedPackage name props) = map toLpc props
-  where
-    toLpc prop = LabeledPackageConstraint
-                 (PackageConstraint (scopeToplevel name) prop)
-                 ConstraintSourceUserTarget
-pkgSpecifierConstraints (SpecificSourcePackage pkg)  =
-    [LabeledPackageConstraint pc ConstraintSourceUserTarget]
-  where
-    pc = PackageConstraint
-         (ScopeTarget $ packageName pkg)
-         (PackagePropertyVersion $ thisVersion (packageVersion pkg))
 
 -- ------------------------------------------------------------
 -- * Parsing and checking user targets

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -18,7 +18,8 @@ import Distribution.Client.ProjectBuilding
 import Distribution.Client.ProjectOrchestration
          ( resolveTargets, TargetProblemCommon(..), distinctTargetComponents )
 import Distribution.Client.Types
-         ( PackageLocation(..), UnresolvedSourcePackage )
+         ( PackageLocation(..), UnresolvedSourcePackage
+         , PackageSpecifier(..) )
 import Distribution.Client.Targets
          ( UserConstraint(..), UserConstraintScope(UserAnyQualifier) )
 import qualified Distribution.Client.InstallPlan as InstallPlan
@@ -370,7 +371,10 @@ testTargetSelectorAmbiguous reportSubCase = do
                     -> [SourcePackage (PackageLocation a)]
                     -> Assertion
     assertAmbiguous str tss pkgs = do
-      res <- readTargetSelectorsWith fakeDirActions pkgs [str]
+      res <- readTargetSelectorsWith
+               fakeDirActions
+               (map SpecificSourcePackage pkgs)
+               [str]
       case res of
         Left [TargetSelectorAmbiguous _ tss'] ->
           sort (map snd tss') @?= sort tss
@@ -382,7 +386,10 @@ testTargetSelectorAmbiguous reportSubCase = do
                       -> [SourcePackage (PackageLocation a)]
                       -> Assertion
     assertUnambiguous str ts pkgs = do
-      res <- readTargetSelectorsWith fakeDirActions pkgs [str]
+      res <- readTargetSelectorsWith
+               fakeDirActions
+               (map SpecificSourcePackage pkgs)
+               [str]
       case res of
         Right [ts'] -> ts' @?= ts
         _ -> assertFailure $ "expected Right [Target...], "
@@ -1478,7 +1485,7 @@ dirActions testdir =
 type ProjDetails = (DistDirLayout,
                     CabalDirLayout,
                     ProjectConfig,
-                    [UnresolvedSourcePackage],
+                    [PackageSpecifier UnresolvedSourcePackage],
                     BuildTimeSettings)
 
 configureProject :: FilePath -> ProjectConfig -> IO ProjDetails

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Single/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Single/cabal.out
@@ -15,7 +15,5 @@ Up to date
 # cabal new-run
 Up to date
 # cabal new-run
-cabal: Unknown target 'bar'.
-There is no component 'bar'.
-The project has no package 'bar'.
+cabal: Cannot run the package bar, it is not in this project (either directly or indirectly). If you want to add it to the project then edit the cabal.project file.
 


### PR DESCRIPTION
Add CLI target support for package names. Ultimately this will be able to be used for referring to out-of-project packages, or packages that are deps of things in the project.

At the moment there is nothing except for syntax support.

For the moment, when used, it will report:

    cabal: Cannot build the package foobar, it is not in this project
    (either directly or indirectly). If you want to add it to the
    project then edit the cabal.project file.

This is also intended to help @fgaz with his work. It may make sense to rebase the wip/extra-packages on these changes.

The integration-tests2 cover the new syntax to the extent that it checks ambiguity. What is missing is positive tests for the new syntax.

In addition this PR includes two simple clean-up patches.