### PR TITLE
Add make doctest [ci skip]

### DIFF
--- a/Cabal/Distribution/Compat/Newtype.hs
+++ b/Cabal/Distribution/Compat/Newtype.hs
@@ -55,7 +55,7 @@ ala pa hof = alaf pa hof id
 -- |
 --
 -- >>> alaf Sum foldMap length ["cabal", "install"]
--- 11
+-- 12
 --
 -- /Note:/ as with 'ala', the user supplied function for the newtype is /ignored/.
 alaf :: (Newtype n o, Newtype n' o') => (o -> n) -> ((a -> n) -> b -> n') -> (a -> o) -> (b -> o')

--- a/Cabal/Distribution/Verbosity.hs
+++ b/Cabal/Distribution/Verbosity.hs
@@ -291,3 +291,8 @@ isVerboseTimestamp = isVerboseFlag VTimestamp
 -- | Helper function for flag testing functions.
 isVerboseFlag :: VerbosityFlag -> Verbosity -> Bool
 isVerboseFlag flag = (Set.member flag) . vFlags
+
+-- $setup
+-- >>> import Test.QuickCheck (Arbitrary (..), arbitraryBoundedEnum)
+-- >>> instance Arbitrary VerbosityLevel where arbitrary = arbitraryBoundedEnum
+-- >>> instance Arbitrary Verbosity where arbitrary = fmap mkVerbosity arbitrary

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY : all lexer lib exe
+.PHONY : all lexer lib exe doctest
 
 LEXER_HS:=Cabal/Distribution/Parsec/Lexer.hs
 
@@ -14,3 +14,6 @@ lib : $(LEXER_HS)
 
 exe : $(LEXER_HS)
 	cabal new-build  --enable-tests cabal
+
+doctest :
+	doctest --fast Cabal/Distribution Cabal/Language


### PR DESCRIPTION
This is poor man doctest.

ping @hvr @23Skidoo 

Prerequisites:
- `doctest` executable is in `$PATH`, compiled with GHC used to
  new-build the Cabal
- `.ghc.environment` file is generated

As GHC picks up dependencies from `.ghc.environment` file, a simple
`doctest MODULES` works.

As you see, I had a bug in doctests. For now, I don't add this to CI,
as it's enough to run doctests occasionally (there are only 4 examples
atm).

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
