### PR TITLE
Elif

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -274,6 +274,7 @@ library
   -- Parsec parser relatedmodules
   build-depends:
     transformers,
+    mtl >= 2.1 && <2.3,
     parsec >= 3.1.9 && <3.2
   exposed-modules:
     Distribution.Compat.Parsec

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -34,6 +34,7 @@ extra-source-files:
   -- BEGIN gen-extra-source-files
   tests/ParserTests/regressions/Octree-0.5.cabal
   tests/ParserTests/regressions/elif.cabal
+  tests/ParserTests/regressions/elif2.cabal
   tests/ParserTests/regressions/encoding-0.8.cabal
   tests/ParserTests/regressions/generics-sop.cabal
   tests/ParserTests/regressions/issue-774.cabal

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -17,6 +17,7 @@
 	* Added '.Lens' modules, with optics for package description data
 	  types. (#4701)
 	* Support for GHC's numeric -g debug levels (#4673).
+	* Added elif-conditionals to .cabal syntax (#4750)
 	* TODO
 
 2.0.1.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> TBD 2017

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2284,6 +2284,17 @@ or
 
 Note that the ``if`` and the condition have to be all on the same line.
 
+Since Cabal 2.2 conditional blocks support ``elif`` construct.
+
+::
+
+      if condition1
+           property-descriptions-or-conditionals
+      elif condition2
+           property-descriptions-or-conditionals
+      else
+           property-descriptions-or-conditionals
+
 Conditions
 """"""""""
 

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -80,6 +80,7 @@ regressionTests = testGroup "regressions"
     , regressionTest "issue-774.cabal"
     , regressionTest "generics-sop.cabal"
     , regressionTest "elif.cabal"
+    , regressionTest "elif2.cabal"
     , regressionTest "shake.cabal"
     ]
 

--- a/Cabal/tests/ParserTests/regressions/elif2.cabal
+++ b/Cabal/tests/ParserTests/regressions/elif2.cabal
@@ -1,0 +1,20 @@
+name:                elif
+version:             0
+synopsis:            The elif demo
+build-type:          Simple
+cabal-version:       >=2.1
+
+source-repository head
+  Type:     git
+  Location: https://github.com/hvr/-.git
+
+library
+  default-language: Haskell2010
+  exposed-modules:  ElseIf
+
+  if os(linux)
+    build-depends: unix
+  elif os(windows)
+    build-depends: Win32
+  else
+    buildable: False

--- a/Cabal/tests/ParserTests/regressions/elif2.format
+++ b/Cabal/tests/ParserTests/regressions/elif2.format
@@ -1,0 +1,25 @@
+name: elif
+version: 0
+synopsis: The elif demo
+cabal-version: >=2.1
+build-type: Simple
+
+source-repository head
+    type: git
+    location: https://github.com/hvr/-.git
+
+library
+    exposed-modules:
+        ElseIf
+    default-language: Haskell2010
+    
+    if os(linux)
+        build-depends:
+            unix -any
+    else
+        
+        if os(windows)
+            build-depends:
+                Win32 -any
+        else
+            buildable: False


### PR DESCRIPTION
Based on #4702. I didn't do magic in pretty-printer atm. The `CondTree` structure doesn't know about `elif`, it's all just nested `if`s.

```diff
% diff -u elif.cabal elif2.cabal 
--- elif.cabal	2017-09-04 19:57:56.638670788 +0300
+++ elif2.cabal	2017-09-08 12:38:29.434630099 +0300
@@ -2,7 +2,7 @@
 version:             0
 synopsis:            The elif demo
 build-type:          Simple
-cabal-version:       >=1.10
+cabal-version:       >=2.1
 
 source-repository head
   Type:     git

% diff -u elif.format elif2.format
--- elif.format	2017-09-04 19:57:56.638670788 +0300
+++ elif2.format	2017-09-08 12:39:28.931204559 +0300
@@ -1,7 +1,7 @@
 name: elif
 version: 0
 synopsis: The elif demo
-cabal-version: >=1.10
+cabal-version: >=2.1
 build-type: Simple
 
 source-repository head
@@ -15,4 +15,11 @@
     
     if os(linux)
         build-depends:
-            unix -any
+            unix -any
+    else
+        
+        if os(windows)
+            build-depends:
+                Win32 -any
+        else
+            buildable: False
```

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
