### PR TITLE
Include foreign libs in allBuildInfo (fixes #4763)

### DIFF
--- a/Cabal/Distribution/Types/PackageDescription.hs
+++ b/Cabal/Distribution/Types/PackageDescription.hs
@@ -314,6 +314,9 @@ allBuildInfo :: PackageDescription -> [BuildInfo]
 allBuildInfo pkg_descr = [ bi | lib <- allLibraries pkg_descr
                               , let bi = libBuildInfo lib
                               , buildable bi ]
+                      ++ [ bi | flib <- foreignLibs pkg_descr
+                              , let bi = foreignLibBuildInfo flib
+                              , buildable bi ]
                       ++ [ bi | exe <- executables pkg_descr
                               , let bi = buildInfo exe
                               , buildable bi ]

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -15,6 +15,7 @@
 	* Added '.Lens' modules, with optics for package description data
 	  types. (#4701)
 	* Support for GHC's numeric -g debug levels (#4673).
+	* Modify `allBuildInfo` to include foreign library info (#4763).
 	* TODO
 
 2.0.1.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> TBD 2017


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

This is the same modification I just made to the Stack codebase, which caused an integration test to pass.