### PR TITLE
--extra-*-dirs were not being passed to all components

### DIFF
--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -970,14 +970,24 @@ configureFinalizedPackage verbosity cfg enabled
         let extraBi = mempty { extraLibDirs = configExtraLibDirs cfg
                              , extraFrameworkDirs = configExtraFrameworkDirs cfg
                              , PD.includeDirs = configExtraIncludeDirs cfg}
-            modifyLib l        = l{ libBuildInfo = libBuildInfo l
-                                                   `mappend` extraBi }
-            modifyExecutable e = e{ buildInfo    = buildInfo e
-                                                   `mappend` extraBi}
-        in pkg_descr{ library = modifyLib `fmap` library pkg_descr
-                    , subLibraries = modifyLib `map` subLibraries pkg_descr
-                    , executables = modifyExecutable  `map`
-                                      executables pkg_descr}
+            modifyLib l        = l{ libBuildInfo        = libBuildInfo l
+                                                          `mappend` extraBi }
+            modifyExecutable e = e{ buildInfo           = buildInfo e
+                                                          `mappend` extraBi}
+            modifyForeignLib f = f{ foreignLibBuildInfo = foreignLibBuildInfo f
+                                                          `mappend` extraBi}
+            modifyTestsuite  t = t{ testBuildInfo      = testBuildInfo t
+                                                          `mappend` extraBi}
+            modifyBenchmark  b = b{ benchmarkBuildInfo  = benchmarkBuildInfo b
+                                                          `mappend` extraBi}
+        in pkg_descr
+             { library      = modifyLib        `fmap` library      pkg_descr
+             , subLibraries = modifyLib        `map`  subLibraries pkg_descr
+             , executables  = modifyExecutable `map`  executables  pkg_descr
+             , foreignLibs  = modifyForeignLib `map`  foreignLibs  pkg_descr
+             , testSuites   = modifyTestsuite  `map`  testSuites   pkg_descr
+             , benchmarks   = modifyBenchmark  `map`  benchmarks   pkg_descr
+             }
 
 -- | Check for use of Cabal features which require compiler support
 checkCompilerProblems :: Verbosity -> Compiler -> PackageDescription -> ComponentRequestedSpec -> IO ()

--- a/cabal-testsuite/PackageTests/Regression/T4720/bug/Main.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4720/bug/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = return ()

--- a/cabal-testsuite/PackageTests/Regression/T4720/bug/bug.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T4720/bug/bug.cabal
@@ -1,0 +1,12 @@
+cabal-version: 1.12
+
+name: bug
+version: 0
+build-type: Simple
+
+test-suite test
+  default-language: Haskell2010
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+  build-depends: base
+  c-sources: cbits/bug.c

--- a/cabal-testsuite/PackageTests/Regression/T4720/bug/cbits/bug.c
+++ b/cabal-testsuite/PackageTests/Regression/T4720/bug/cbits/bug.c
@@ -1,0 +1,2 @@
+#include <stdlib.h>
+#include <bug-extra-inc.h>

--- a/cabal-testsuite/PackageTests/Regression/T4720/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T4720/cabal.out
@@ -1,0 +1,8 @@
+# cabal new-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - bug-0 (test:test) (first run)
+Configuring test suite 'test' for bug-0..
+Preprocessing test suite 'test' for bug-0..
+Building test suite 'test' for bug-0..

--- a/cabal-testsuite/PackageTests/Regression/T4720/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T4720/cabal.project
@@ -1,0 +1,4 @@
+packages: ./bug
+
+package bug
+  extra-include-dirs: ./extra-inc

--- a/cabal-testsuite/PackageTests/Regression/T4720/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4720/cabal.test.hs
@@ -1,0 +1,3 @@
+import Test.Cabal.Prelude
+main = cabalTest $ do
+    expectBroken 4720 $ cabal "new-build" ["test"]

--- a/cabal-testsuite/PackageTests/Regression/T4720/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4720/cabal.test.hs
@@ -1,3 +1,3 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
-    expectBroken 4720 $ cabal "new-build" ["test"]
+    cabal "new-build" ["test"]


### PR DESCRIPTION
Only to libraries and executables before this.

Fixes #4720

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
