### PR TITLE
Differentiate letter for the dist-dir layout of components

### DIFF
--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -185,10 +185,14 @@ defaultDistDirLayout projectRoot mdistDirectory =
         display (distParamPlatform params) </>
         display (distParamCompilerId params) </>
         display (distParamPackageId params) </>
-        (case fmap componentNameString (distParamComponentName params) of
-            Nothing          -> ""
-            Just Nothing     -> ""
-            Just (Just name) -> "c" </> display name) </>
+        (case distParamComponentName params of
+            Nothing                  -> ""
+            Just CLibName            -> ""
+            Just (CSubLibName name)  -> "l" </> display name
+            Just (CFLibName name)    -> "f" </> display name
+            Just (CExeName name)     -> "x" </> display name
+            Just (CTestName name)    -> "t" </> display name
+            Just (CBenchName name)   -> "b" </> display name) </>
         (case distParamOptimization params of
             NoOptimisation -> "noopt"
             NormalOptimisation -> ""

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -18,6 +18,8 @@
 	* On macOS, `new-build` will now place dynamic libraries into
 	`store/lib` and aggressively shorten their names in an effort to
 	stay within the load command size limits of macOSs mach-o linker.
+	* Use [lfxtb] letters to differentiate component kind instead of
+	opaque "c" in dist-dir layout.
 
 2.0.0.1 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> TBD 2017
 	* Support for GHC's numeric -g debug levels (#4673).

--- a/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/cabal.out
+++ b/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/cabal.out
@@ -14,7 +14,7 @@ Building test suite 'test-Short' for my-0.1..
 Running 1 test suites...
 Test suite test-Short: RUNNING...
 Test suite test-Short: PASS
-Test suite logged to: <ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/my-0.1/c/test-Short/test/my-0.1-test-Short.log
+Test suite logged to: <ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/my-0.1/t/test-Short/test/my-0.1-test-Short.log
 1 of 1 test suites (1 of 1 test cases) passed.
 Configuring test suite 'test-Foo' for my-0.1..
 Preprocessing test suite 'test-Foo' for my-0.1..
@@ -22,5 +22,5 @@ Building test suite 'test-Foo' for my-0.1..
 Running 1 test suites...
 Test suite test-Foo: RUNNING...
 Test suite test-Foo: PASS
-Test suite logged to: <ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/my-0.1/c/test-Foo/test/my-0.1-test-Foo.log
+Test suite logged to: <ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/my-0.1/t/test-Foo/test/my-0.1-test-Foo.log
 1 of 1 test suites (1 of 1 test cases) passed.


### PR DESCRIPTION
This has been a pet-peeve of mine since 1.24 but I forgot to address
this in time for the 2.0 release, as it conflates all the component
kinds into an opaque single "c" namespace thereby losing information,
rather than encoding the component type in a more expressive single
letter path component.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
