### PR TITLE
Don't automatically case-correct mispelled package-names

### DIFF
--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -3,6 +3,8 @@
 2.2.0.0 (current development version)
 	* 'cabal configure' now supports '--enable-static' which can be
 	used to build static libaries with GHC via GHC's `-staticlib` flag.
+	* Don't automatically/silently case-correct mispelled package-names
+	on CLI (#4778)
 	* 'cabal update' now supports '--index-state' which can be used to
 	roll back the index to an earlier state.
 	* 'cabal new-configure' now backs up the old 'cabal.project.local'


### PR DESCRIPTION
Previously, a command like

    cabal install uHttpc

would silently auto-correct this to

    cabal install uhttpc

However, this is inconsistent as `build-depends` or `constraints`
are not case-insensitive.

So with this patch,

    cabal install VULKAN uHttpc

result in the following error(s) instead:

    There is no package named 'VULKAN'. However, the following package names exist: 'Vulkan', 'vulkan'.

    There is no package named 'uHttpc'. However, the following package name exists: 'uhttpc'.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
