### PR TITLE
Use stderr for Cabal's diagnostic messages instead of stdout

### DIFF
--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -566,7 +566,8 @@ ghcInvocation :: ConfiguredProgram -> Compiler -> Platform -> GhcOptions
               -> ProgramInvocation
 ghcInvocation prog comp platform opts =
     (programInvocation prog (renderGhcOptions comp platform opts)) {
-        progInvokePathEnv = fromNubListR (ghcOptExtraPath opts)
+        progInvokePathEnv = fromNubListR (ghcOptExtraPath opts),
+        progInvokeOutAsErr = True
     }
 
 renderGhcOptions :: Compiler -> Platform -> GhcOptions -> [String]

--- a/Cabal/Distribution/Utils/LogProgress.hs
+++ b/Cabal/Distribution/Utils/LogProgress.hs
@@ -17,6 +17,7 @@ import Distribution.Utils.Progress
 import Distribution.Verbosity
 import Distribution.Simple.Utils
 import Text.PrettyPrint
+import System.IO (hPutStrLn, stderr)
 
 type CtxMsg = Doc
 type LogMsg = Doc
@@ -54,7 +55,7 @@ runLogProgress verbosity (LogProgress m) =
       }
     step_fn :: LogMsg -> NoCallStackIO a -> NoCallStackIO a
     step_fn doc go = do
-        putStrLn (render doc)
+        hPutStrLn stderr (render doc)
         go
     fail_fn :: Doc -> NoCallStackIO a
     fail_fn doc = do

--- a/cabal-install/Distribution/Client/GenBounds.hs
+++ b/cabal-install/Distribution/Client/GenBounds.hs
@@ -43,7 +43,7 @@ import Distribution.Simple.Compiler
 import Distribution.Simple.Program
          ( ProgramDb )
 import Distribution.Simple.Utils
-         ( tryFindPackageDesc )
+         ( notice, tryFindPackageDesc, warn )
 import Distribution.System
          ( Platform )
 import Distribution.Deprecated.Text
@@ -120,13 +120,13 @@ genBounds verbosity packageDBs repoCtxt comp platform progdb mSandboxPkgInfo
     let epd = finalizePD mempty defaultComponentRequestedSpec
                     (const True) platform cinfo [] gpd
     case epd of
-      Left _ -> putStrLn "finalizePD failed"
+      Left _ -> warn verbosity "finalizePD failed"
       Right (pd,_) -> do
         let needBounds = filter (not . hasUpperBound . depVersion) $
                          enabledBuildDepends pd defaultComponentRequestedSpec
 
         if (null needBounds)
-          then putStrLn
+          then notice verbosity
                "Congratulations, all your dependencies have upper bounds!"
           else go needBounds
   where
@@ -135,7 +135,7 @@ genBounds verbosity packageDBs repoCtxt comp platform progdb mSandboxPkgInfo
                   verbosity packageDBs repoCtxt comp platform progdb
                   mSandboxPkgInfo globalFlags freezeFlags
 
-       putStrLn boundsNeededMsg
+       notice verbosity boundsNeededMsg
 
        let isNeeded pkg = unPackageName (packageName pkg)
                           `elem` map depName needBounds

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -56,7 +56,7 @@ import System.Directory
 import System.FilePath
          ( (</>), (<.>), equalFilePath, takeDirectory )
 import System.IO
-         ( openFile, IOMode(AppendMode), hClose )
+         ( openFile, IOMode(AppendMode), hPutStr, hClose, stderr )
 import System.IO.Error
          ( isDoesNotExistError, ioeGetFileName )
 
@@ -1230,11 +1230,11 @@ executeInstallPlan verbosity jobCtl keepGoing useLogFile plan0 installPkg =
               Nothing                 -> return ()
               Just (mkLogFileName, _) -> do
                 let logName = mkLogFileName pkgid uid
-                putStr $ "Build log ( " ++ logName ++ " ):\n"
+                hPutStr stderr $ "Build log ( " ++ logName ++ " ):\n"
                 printFile logName
 
     printFile :: FilePath -> IO ()
-    printFile path = readFile path >>= putStr
+    printFile path = readFile path >>= hPutStr stderr
 
 -- | Call an installer for an 'SourcePackage' but override the configure
 -- flags with the ones given by the 'ReadyPackage'. In particular the


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

> Please also shortly describe how you tested your change. Bonus points for added tests!

Manually tested on a minimal Cabal project.  `cabal build 2>/dev/null` shows nothing.

Fixes #4652.