### PR TITLE
Remove the package instance from D.Solver.Modular.Var (closes #4142).

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Assignment.hs
+++ b/cabal-install/Distribution/Solver/Modular/Assignment.hs
@@ -65,13 +65,13 @@ toCPs (A pa fa sa) rdm =
     -- complete flag assignment by package.
     fapp :: Map QPN FlagAssignment
     fapp = M.fromListWith (++) $
-           L.map (\ ((FN (PI qpn _) fn), b) -> (qpn, [(fn, b)])) $
+           L.map (\ ((FN qpn fn), b) -> (qpn, [(fn, b)])) $
            M.toList $
            fa
     -- Stanzas per package.
     sapp :: Map QPN [OptionalStanza]
     sapp = M.fromListWith (++) $
-           L.map (\ ((SN (PI qpn _) sn), b) -> (qpn, if b then [sn] else [])) $
+           L.map (\ ((SN qpn sn), b) -> (qpn, if b then [sn] else [])) $
            M.toList $
            sa
     -- Dependencies per package.

--- a/cabal-install/Distribution/Solver/Modular/Cycles.hs
+++ b/cabal-install/Distribution/Solver/Modular/Cycles.hs
@@ -11,7 +11,6 @@ import qualified Distribution.Compat.Graph as G
 import Distribution.Simple.Utils (ordNub)
 import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Flag
-import Distribution.Solver.Modular.Package
 import Distribution.Solver.Modular.Tree
 import qualified Distribution.Solver.Modular.ConflictSet as CS
 import Distribution.Solver.Types.ComponentDeps (Component)
@@ -25,9 +24,9 @@ detectCyclesPhase = cata go
     go :: TreeF d c (Tree d c) -> Tree d c
     go (PChoiceF qpn rdm gr                         cs) =
         PChoice qpn rdm gr     $ fmap (checkChild qpn)   cs
-    go (FChoiceF qfn@(FN (PI qpn _) _) rdm gr w m d cs) =
+    go (FChoiceF qfn@(FN qpn _) rdm gr w m d cs) =
         FChoice qfn rdm gr w m d $ fmap (checkChild qpn) cs
-    go (SChoiceF qsn@(SN (PI qpn _) _) rdm gr w     cs) =
+    go (SChoiceF qsn@(SN qpn _) rdm gr w     cs) =
         SChoice qsn rdm gr w   $ fmap (checkChild qpn)   cs
     go x                                                = inn x
 

--- a/cabal-install/Distribution/Solver/Modular/Dependency.hs
+++ b/cabal-install/Distribution/Solver/Modular/Dependency.hs
@@ -3,8 +3,8 @@
 module Distribution.Solver.Modular.Dependency (
     -- * Variables
     Var(..)
-  , varPI
   , showVar
+  , varPN
     -- * Conflict sets
   , ConflictSet
   , ConflictMap

--- a/cabal-install/Distribution/Solver/Modular/Dependency.hs
+++ b/cabal-install/Distribution/Solver/Modular/Dependency.hs
@@ -128,32 +128,30 @@ data Dep qpn = Dep  IsExe qpn CI       -- ^ dependency on a package (possibly fo
 -- flag and stanza choices that introduced the dependency. It contains
 -- everything needed for creating ConflictSets or describing conflicts in solver
 -- log messages.
-data DependencyReason qpn = DependencyReason (PI qpn) [(Flag, FlagValue)] [Stanza]
+data DependencyReason qpn = DependencyReason qpn [(Flag, FlagValue)] [Stanza]
   deriving (Functor, Eq, Show)
 
--- | Print a dependency. The first parameter determines how to print the package
--- instance of the dependent package.
-showDep :: (PI QPN -> String) -> LDep QPN -> String
-showDep showPI' (LDep dr (Dep (IsExe is_exe) qpn (Fixed i)       )) =
-  let DependencyReason (PI qpn' _) _ _ = dr
-  in (if qpn /= qpn' then showDependencyReason showPI' dr ++ " => " else "") ++
+-- | Print a dependency.
+showDep :: LDep QPN -> String
+showDep (LDep dr (Dep (IsExe is_exe) qpn (Fixed i)       )) =
+  let DependencyReason qpn' _ _ = dr
+  in (if qpn /= qpn' then showDependencyReason dr ++ " => " else "") ++
      showQPN qpn ++
      (if is_exe then " (exe) " else "") ++ "==" ++ showI i
-showDep showPI' (LDep dr (Dep (IsExe is_exe) qpn (Constrained vr))) =
-  showDependencyReason showPI' dr ++ " => " ++ showQPN qpn ++
+showDep (LDep dr (Dep (IsExe is_exe) qpn (Constrained vr))) =
+  showDependencyReason dr ++ " => " ++ showQPN qpn ++
   (if is_exe then " (exe) " else "") ++ showVR vr
-showDep _ (LDep _ (Ext ext))   = "requires " ++ display ext
-showDep _ (LDep _ (Lang lang)) = "requires " ++ display lang
-showDep _ (LDep _ (Pkg pn vr)) = "requires pkg-config package "
+showDep (LDep _ (Ext ext))   = "requires " ++ display ext
+showDep (LDep _ (Lang lang)) = "requires " ++ display lang
+showDep (LDep _ (Pkg pn vr)) = "requires pkg-config package "
                       ++ display pn ++ display vr
                       ++ ", not found in the pkg-config database"
 
--- | Print the reason that a dependency was introduced. The first parameter
--- determines how to print the package instance.
-showDependencyReason :: (PI QPN -> String) -> DependencyReason QPN -> String
-showDependencyReason showPI' (DependencyReason pi flags stanzas) =
+-- | Print the reason that a dependency was introduced.
+showDependencyReason :: DependencyReason QPN -> String
+showDependencyReason (DependencyReason qpn flags stanzas) =
     intercalate " " $
-        showPI' pi
+        showQPN qpn
       : map (uncurry showFlagValue) flags ++ map (\s -> showSBool s True) stanzas
 
 -- | Options for goal qualification (used in 'qualifyDeps')
@@ -297,14 +295,14 @@ goalReasonToCS (DependencyGoal dr) = dependencyReasonToCS dr
 -- | This function returns the solver variables responsible for the dependency.
 -- It drops the flag and stanza values, which are only needed for log messages.
 dependencyReasonToCS :: DependencyReason QPN -> ConflictSet
-dependencyReasonToCS (DependencyReason pi@(PI qpn _) flags stanzas) =
+dependencyReasonToCS (DependencyReason qpn flags stanzas) =
     CS.fromList $ P qpn : flagVars ++ map stanzaToVar stanzas
   where
     -- Filter out any flags that introduced the dependency with both values.
     -- They don't need to be included in the conflict set, because changing the
     -- flag value can't remove the dependency.
     flagVars :: [Var QPN]
-    flagVars = [F (FN pi fn) | (fn, fv) <- flags, fv /= FlagBoth]
+    flagVars = [F (FN qpn fn) | (fn, fv) <- flags, fv /= FlagBoth]
 
     stanzaToVar :: Stanza -> Var QPN
-    stanzaToVar = S . SN pi
+    stanzaToVar = S . SN qpn

--- a/cabal-install/Distribution/Solver/Modular/Flag.hs
+++ b/cabal-install/Distribution/Solver/Modular/Flag.hs
@@ -24,13 +24,12 @@ import Prelude hiding (pi)
 
 import qualified Distribution.PackageDescription as P -- from Cabal
 
-import Distribution.Solver.Modular.Package
 import Distribution.Solver.Types.Flag
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PackagePath
 
 -- | Flag name. Consists of a package instance and the flag identifier itself.
-data FN qpn = FN (PI qpn) Flag
+data FN qpn = FN qpn Flag
   deriving (Eq, Ord, Show, Functor)
 
 -- | Flag identifier. Just a string.
@@ -58,7 +57,7 @@ type FlagInfo = Map Flag FInfo
 type QFN = FN QPN
 
 -- | Stanza name. Paired with a package name, much like a flag.
-data SN qpn = SN (PI qpn) Stanza
+data SN qpn = SN qpn Stanza
   deriving (Eq, Ord, Show, Functor)
 
 -- | Qualified stanza name.
@@ -84,10 +83,10 @@ data FlagValue = FlagTrue | FlagFalse | FlagBoth
   deriving (Eq, Show)
 
 showQFNBool :: QFN -> Bool -> String
-showQFNBool qfn@(FN pi _f) b = showPI pi ++ ":" ++ showFBool qfn b
+showQFNBool qfn@(FN qpn _f) b = showQPN qpn ++ ":" ++ showFBool qfn b
 
 showQSNBool :: QSN -> Bool -> String
-showQSNBool (SN pi f) b = showPI pi ++ ":" ++ showSBool f b
+showQSNBool (SN qpn s) b = showQPN qpn ++ ":" ++ showSBool s b
 
 showFBool :: FN qpn -> Bool -> String
 showFBool (FN _ f) v = P.showFlagValue (f, v)
@@ -103,7 +102,7 @@ showSBool s True  = "*" ++ showStanza s
 showSBool s False = "!" ++ showStanza s
 
 showQFN :: QFN -> String
-showQFN (FN pi f) = showPI pi ++ ":" ++ unFlag f
+showQFN (FN qpn f) = showQPN qpn ++ ":" ++ unFlag f
 
 showQSN :: QSN -> String
-showQSN (SN pi s) = showPI pi ++ ":" ++ showStanza s
+showQSN (SN qpn s) = showQPN qpn ++ ":" ++ showStanza s

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -350,23 +350,23 @@ verifyLinkGroup lg =
             flags   = M.keys finfo
             stanzas = [TestStanzas, BenchStanzas]
         forM_ flags $ \fn -> do
-          let flag = FN (PI (lgPackage lg) i) fn
+          let flag = FN (lgPackage lg) fn
           verifyFlag' flag lg
         forM_ stanzas $ \sn -> do
-          let stanza = SN (PI (lgPackage lg) i) sn
+          let stanza = SN (lgPackage lg) sn
           verifyStanza' stanza lg
 
 verifyFlag :: QFN -> UpdateState ()
-verifyFlag (FN (PI qpn@(Q _pp pn) i) fn) = do
+verifyFlag (FN qpn@(Q _pp pn) fn) = do
     vs <- get
     -- We can only pick a flag after picking an instance; link group must exist
-    verifyFlag' (FN (PI pn i) fn) (vsLinks vs ! qpn)
+    verifyFlag' (FN pn fn) (vsLinks vs ! qpn)
 
 verifyStanza :: QSN -> UpdateState ()
-verifyStanza (SN (PI qpn@(Q _pp pn) i) sn) = do
+verifyStanza (SN qpn@(Q _pp pn) sn) = do
     vs <- get
     -- We can only pick a stanza after picking an instance; link group must exist
-    verifyStanza' (SN (PI pn i) sn) (vsLinks vs ! qpn)
+    verifyStanza' (SN pn sn) (vsLinks vs ! qpn)
 
 -- | Verify that all packages in the link group agree on flag assignments
 --
@@ -374,9 +374,9 @@ verifyStanza (SN (PI qpn@(Q _pp pn) i) sn) = do
 -- that have already been made for link group members, and check that they are
 -- equal.
 verifyFlag' :: FN PN -> LinkGroup -> UpdateState ()
-verifyFlag' (FN (PI pn i) fn) lg = do
+verifyFlag' (FN pn fn) lg = do
     vs <- get
-    let flags = map (\pp' -> FN (PI (Q pp' pn) i) fn) (S.toList (lgMembers lg))
+    let flags = map (\pp' -> FN (Q pp' pn) fn) (S.toList (lgMembers lg))
         vals  = map (`M.lookup` vsFlags vs) flags
     if allEqual (catMaybes vals) -- We ignore not-yet assigned flags
       then return ()
@@ -392,9 +392,9 @@ verifyFlag' (FN (PI pn i) fn) lg = do
 --
 -- This function closely mirrors 'verifyFlag''.
 verifyStanza' :: SN PN -> LinkGroup -> UpdateState ()
-verifyStanza' (SN (PI pn i) sn) lg = do
+verifyStanza' (SN pn sn) lg = do
     vs <- get
-    let stanzas = map (\pp' -> SN (PI (Q pp' pn) i) sn) (S.toList (lgMembers lg))
+    let stanzas = map (\pp' -> SN (Q pp' pn) sn) (S.toList (lgMembers lg))
         vals    = map (`M.lookup` vsStanzas vs) stanzas
     if allEqual (catMaybes vals) -- We ignore not-yet assigned stanzas
       then return ()

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -128,7 +128,7 @@ preferPackagePreferences pcs =
 preferPackageStanzaPreferences :: (PN -> PackagePreferences) -> Tree d c -> Tree d c
 preferPackageStanzaPreferences pcs = trav go
   where
-    go (SChoiceF qsn@(SN (PI (Q pp pn) _) s) rdm gr _tr ts)
+    go (SChoiceF qsn@(SN (Q pp pn) s) rdm gr _tr ts)
       | primaryPP pp && enableStanzaPref pn s =
           -- move True case first to try enabling the stanza
           let ts' = W.mapWeightsWithKey (\k w -> weight k : w) ts
@@ -230,14 +230,14 @@ enforcePackageConstraints pcs = trav go
                                        id
                                        (M.findWithDefault [] pn pcs)
       in PChoiceF qpn rdm gr        (W.mapWithKey g ts)
-    go (FChoiceF qfn@(FN (PI qpn@(Q _ pn) _) f) rdm gr tr m d ts) =
+    go (FChoiceF qfn@(FN qpn@(Q _ pn) f) rdm gr tr m d ts) =
       let c = varToConflictSet (F qfn)
           -- compose the transformation functions for each of the relevant constraint
           g = \ b -> foldl (\ h pc -> h . processPackageConstraintF qpn f c b pc)
                            id
                            (M.findWithDefault [] pn pcs)
       in FChoiceF qfn rdm gr tr m d (W.mapWithKey g ts)
-    go (SChoiceF qsn@(SN (PI qpn@(Q _ pn) _) f) rdm gr tr   ts) =
+    go (SChoiceF qsn@(SN qpn@(Q _ pn) f) rdm gr tr   ts) =
       let c = varToConflictSet (S qsn)
           -- compose the transformation functions for each of the relevant constraint
           g = \ b -> foldl (\ h pc -> h . processPackageConstraintS qpn f c b pc)
@@ -269,7 +269,7 @@ enforcePackageConstraints pcs = trav go
 enforceManualFlags :: M.Map PN [LabeledPackageConstraint] -> Tree d c -> Tree d c
 enforceManualFlags pcs = trav go
   where
-    go (FChoiceF qfn@(FN (PI (Q _ pn) _) fn) rdm gr tr Manual d ts) =
+    go (FChoiceF qfn@(FN (Q _ pn) fn) rdm gr tr Manual d ts) =
         FChoiceF qfn rdm gr tr Manual d $
           let -- A list of all values specified by constraints on 'fn'.
               -- We ignore the constraint scope in order to handle issue #4299.
@@ -346,8 +346,8 @@ sortGoals variableOrder = trav go
 
     varToVariable :: Var QPN -> Variable QPN
     varToVariable (P qpn)                    = PackageVar qpn
-    varToVariable (F (FN (PI qpn _) fn))     = FlagVar qpn fn
-    varToVariable (S (SN (PI qpn _) stanza)) = StanzaVar qpn stanza
+    varToVariable (F (FN qpn fn))     = FlagVar qpn fn
+    varToVariable (S (SN qpn stanza)) = StanzaVar qpn stanza
 
 -- | Always choose the first goal in the list next, abandoning all
 -- other choices.

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -12,7 +12,6 @@ import Data.Map as M
 import Data.List as L
 import Data.Set as S
 import Distribution.Verbosity
-import Distribution.Version
 
 import Distribution.Compiler (CompilerInfo)
 
@@ -202,7 +201,7 @@ instance GSimpleTree (Tree d c) where
       -- to that variable)
       shortGR :: QGoalReason -> String
       shortGR UserGoal            = "user"
-      shortGR (DependencyGoal dr) = showDependencyReason (\(PI nm _) -> showQPN nm) dr
+      shortGR (DependencyGoal dr) = showDependencyReason dr
 
       -- Show conflict set
       goCS :: ConflictSet -> String
@@ -232,6 +231,5 @@ _removeGR = trav go
    dummy =
        DependencyGoal $
        DependencyReason
-           (PI (Q (PackagePath DefaultNamespace QualToplevel) (mkPackageName "$"))
-               (I (mkVersion [1]) InRepo))
+           (Q (PackagePath DefaultNamespace QualToplevel) (mkPackageName "$"))
            [] []

--- a/cabal-install/Distribution/Solver/Modular/Validate.hs
+++ b/cabal-install/Distribution/Solver/Modular/Validate.hs
@@ -193,7 +193,7 @@ validate = cata go
       let newactives =
               -- Add a self-dependency to constrain the package to the instance
               -- that we just chose.
-              LDep (DependencyReason (PI qpn i) [] []) (Dep (IsExe False) qpn (Fixed i))
+              LDep (DependencyReason qpn [] []) (Dep (IsExe False) qpn (Fixed i))
                 : extractAllDeps pfa psa qdeps
       -- We now try to extend the partial assignment with the new active constraints.
       let mnppa = extend extSupported langSupported pkgPresent (P qpn) ppa newactives
@@ -210,7 +210,7 @@ validate = cata go
 
     -- What to do for flag nodes ...
     goF :: QFN -> Bool -> Validate (Tree d c) -> Validate (Tree d c)
-    goF qfn@(FN (PI qpn _i) _f) b r = do
+    goF qfn@(FN qpn _f) b r = do
       PA ppa pfa psa <- asks pa -- obtain current preassignment
       extSupported   <- asks supportedExt  -- obtain the supported extensions
       langSupported  <- asks supportedLang -- obtain the supported languages
@@ -235,7 +235,7 @@ validate = cata go
 
     -- What to do for stanza nodes (similar to flag nodes) ...
     goS :: QSN -> Bool -> Validate (Tree d c) -> Validate (Tree d c)
-    goS qsn@(SN (PI qpn _i) _f) b r = do
+    goS qsn@(SN qpn _f) b r = do
       PA ppa pfa psa <- asks pa -- obtain current preassignment
       extSupported   <- asks supportedExt  -- obtain the supported extensions
       langSupported  <- asks supportedLang -- obtain the supported languages
@@ -344,7 +344,7 @@ extend extSupported langSupported pkgPresent var = foldM extendSingle
     simplify v = L.filter (not . isSimpleDep v)
 
     isSimpleDep :: Var QPN -> LDep QPN -> Bool
-    isSimpleDep v (LDep (DependencyReason (PI qpn _) [] []) (Dep _ _ (Fixed _))) =
+    isSimpleDep v (LDep (DependencyReason qpn [] []) (Dep _ _ (Fixed _))) =
         v == var && P qpn == var
     isSimpleDep _ _ = False
 

--- a/cabal-install/Distribution/Solver/Modular/Var.hs
+++ b/cabal-install/Distribution/Solver/Modular/Var.hs
@@ -8,7 +8,6 @@ module Distribution.Solver.Modular.Var (
 import Prelude hiding (pi)
 
 import Distribution.Solver.Modular.Flag
-import Distribution.Solver.Modular.Package
 import Distribution.Solver.Types.PackagePath
 
 {-------------------------------------------------------------------------------
@@ -30,6 +29,6 @@ showVar (S qsn) = showQSN qsn
 
 -- | Extract the package name from a Var
 varPN :: Var qpn -> qpn
-varPN (P qpn)               = qpn
-varPN (F (FN (PI qpn _) _)) = qpn
-varPN (S (SN (PI qpn _) _)) = qpn
+varPN (P qpn)        = qpn
+varPN (F (FN qpn _)) = qpn
+varPN (S (SN qpn _)) = qpn

--- a/cabal-install/Distribution/Solver/Modular/Var.hs
+++ b/cabal-install/Distribution/Solver/Modular/Var.hs
@@ -2,7 +2,7 @@
 module Distribution.Solver.Modular.Var (
     Var(..)
   , showVar
-  , varPI
+  , varPN
   ) where
 
 import Prelude hiding (pi)
@@ -28,8 +28,8 @@ showVar (P qpn) = showQPN qpn
 showVar (F qfn) = showQFN qfn
 showVar (S qsn) = showQSN qsn
 
--- | Extract the package instance from a Var
-varPI :: Var QPN -> (QPN, Maybe I)
-varPI (P qpn)               = (qpn, Nothing)
-varPI (F (FN (PI qpn i) _)) = (qpn, Just i)
-varPI (S (SN (PI qpn i) _)) = (qpn, Just i)
+-- | Extract the package name from a Var
+varPN :: Var qpn -> qpn
+varPN (P qpn)               = qpn
+varPN (F (FN (PI qpn _) _)) = qpn
+varPN (S (SN (PI qpn _) _)) = qpn

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -56,7 +56,7 @@ tests = [
           solverSuccess [("pkg", 1), ("true-dep", 1)]
 
         , let checkFullLog =
-                  any $ isInfixOf "rejecting: pkg-1.0.0:-flag (manual flag can only be changed explicitly)"
+                  any $ isInfixOf "rejecting: pkg:-flag (manual flag can only be changed explicitly)"
           in runTest $ constraints [ExVersionConstraint (ScopeAnyQualifier "true-dep") V.noVersion] $
              mkTest dbManualFlags "Don't toggle manual flag to avoid conflict" ["pkg"] $
              -- TODO: We should check the summarized log instead of the full log
@@ -102,8 +102,8 @@ tests = [
               failureReason = "(constraint from unknown source requires opposite flag selection)"
               checkFullLog lns =
                   all (\msg -> any (msg `isInfixOf`) lns)
-                  [ "rejecting: B-1.0.0:-flag "         ++ failureReason
-                  , "rejecting: A:setup.B-1.0.0:+flag " ++ failureReason ]
+                  [ "rejecting: B:-flag "         ++ failureReason
+                  , "rejecting: A:setup.B:+flag " ++ failureReason ]
           in runTest $ constraints cs $
              mkTest dbLinkedSetupDepWithManualFlag name ["A"] $
              SolverResult checkFullLog (Left $ const True)

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-external.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-external.cabal.out
@@ -100,7 +100,7 @@ Resolving dependencies...
 Warning: solver failed to find a solution:
 Could not resolve dependencies:
 trying: exe-0.1.0.0 (user goal)
-next goal: src (dependency of exe-0.1.0.0)
+next goal: src (dependency of exe)
 rejecting: src-<VERSION>/installed-<HASH>... (conflict: src => mylib==0.1.0.0/installed-0.1..., src => mylib==0.1.0.0/installed-0.1...)
 fail (backjumping, conflict set: exe, src)
 After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: exe (2), src (2)

--- a/cabal-testsuite/PackageTests/ConfigureComponent/Exe/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/ConfigureComponent/Exe/setup.cabal.out
@@ -3,7 +3,7 @@ Resolving dependencies...
 Warning: solver failed to find a solution:
 Could not resolve dependencies:
 trying: Exe-0.1.0.0 (user goal)
-unknown package: totally-impossible-dependency-to-fill (dependency of Exe-0.1.0.0)
+unknown package: totally-impossible-dependency-to-fill (dependency of Exe)
 fail (backjumping, conflict set: Exe, totally-impossible-dependency-to-fill)
 After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: Exe (2), totally-impossible-dependency-to-fill (1)
 Trying configure anyway.


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

_____________________________________________________________________________________________________

#### Remove D.Solver.Modular.Var.varPI.

This change is necessary to remove the package instance (I) from Var
(issue #4142).  One of the main uses of the package instance is when varPI is
called by the linking phase in order to get the dependencies introduced by flags
and stanzas.  The validation phase also needs to look up dependencies introduced
by flags and stanzas, but it does so by looking up the dependencies once when it
chooses a package and then storing the dependencies in a map.  I refactored the
linking phase to also store dependencies in a map.


#### Remove the package instance from D.Solver.Modular.Var (closes #4142).

This change has several effects:

- The solver no longer includes the package version in messages that relate to
  a package's flags, stanzas, or dependencies.  However, the solver always
  chooses the package version before choosing any flags, stanzas, or
  dependencies for the package, so it should be easy to find the version
  by looking earlier in the log.
- In conflict counting, the solver treats flags with the same name in different
  versions of a package as the same flag.  This change in the conflict counting
  heuristic can improve the solver's efficiency when the same flag causes the
  same conflicts in different versions of a package.  The same applies to
  enabling tests or benchmarks.
- Each flag or stanza can only appear once in a conflict set.  This has no
  effect on behavior, but it simplifies the message containing the final
  conflict set.

Here is an example of the change in a log message.  It only prints
hackage-server's version once, when it first chooses the package.  The conflict
set also has one fewer variable, but that is probably due to the change in
conflict counting.

```diff
 Resolving dependencies...
 cabal: Could not resolve dependencies:
 trying: hackage-server-0.5.0 (user goal)
-trying: hackage-server-0.5.0:+build-hackage-build
-trying: unix-2.7.2.1/installed-2.7... (dependency of hackage-server-0.5.0
+trying: hackage-server:+build-hackage-build
+trying: unix-2.7.2.1/installed-2.7... (dependency of hackage-server
 +build-hackage-build)
-next goal: aeson (dependency of hackage-server-0.5.0 +build-hackage-build)
+next goal: aeson (dependency of hackage-server +build-hackage-build)
 rejecting: aeson-1.2.2.0, aeson-1.2.1.0, aeson-1.2.0.0, aeson-1.1.2.0,
 aeson-1.1.1.0, aeson-1.1.0.0, aeson-1.0.2.1, aeson-1.0.2.0, aeson-1.0.1.0,
 aeson-1.0.0.0, aeson-0.11.3.0, aeson-0.11.2.1, aeson-0.11.2.0, aeson-0.11.1.4,
 aeson-0.11.1.3, aeson-0.11.1.2, aeson-0.11.1.1, aeson-0.11.1.0,
 aeson-0.11.0.0, aeson-0.9.0.1, aeson-0.9.0.0, aeson-0.8.1.1, aeson-0.8.1.0,
 aeson-0.8.0.2, aeson-0.7.0.6, aeson-0.7.0.4, aeson-0.6.2.1, aeson-0.6.2.0
 (conflict: hackage-server +build-hackage-build => aeson==0.6.1.*)
 rejecting: aeson-0.6.1.0 (conflict: unix => time==1.6.0.1/installed-1.6...,
 aeson => time<1.5)
 rejecting: aeson-0.6.0.2, aeson-0.6.0.1, aeson-0.6.0.0, aeson-0.5.0.0,
 aeson-0.4.0.1, aeson-0.4.0.0, aeson-0.3.2.14, aeson-0.3.2.13, aeson-0.3.2.12,
 aeson-0.3.2.11, aeson-0.3.2.10, aeson-0.3.2.9, aeson-0.3.2.8, aeson-0.3.2.7,
 aeson-0.3.2.6, aeson-0.3.2.5, aeson-0.3.2.4, aeson-0.3.2.3, aeson-0.3.2.2,
 aeson-0.3.2.1, aeson-0.3.2.0, aeson-0.3.1.1, aeson-0.3.1.0, aeson-0.3.0.0,
 aeson-0.2.0.0, aeson-0.1.0.0, aeson-0.10.0.0, aeson-0.8.0.1, aeson-0.8.0.0,
 aeson-0.7.0.5, aeson-0.7.0.3, aeson-0.7.0.2, aeson-0.7.0.1, aeson-0.7.0.0
 (conflict: hackage-server +build-hackage-build => aeson==0.6.1.*)
 After searching the rest of the dependency tree exhaustively, these were the
-goals I've had most trouble fulfilling: aeson, hackage-server,
-hackage-server-0.5.0:build-hackage-build,
-hackage-server-0.4:build-hackage-mirror, template-haskell
+goals I've had most trouble fulfilling: aeson,
+hackage-server:build-hackage-build, hackage-server, template-haskell
```

I ran hackage-benchmark to compare this commit with master (two commits
earlier).  I used --min-run-time-percentage-difference-to-rerun=10 to only rerun
packages if the run times differed by more than 10% in the first trial, and
defaults for the rest of the options (10 trials, p-value of 0.05, 90 second
timeout). The index state was "2017-09-24T03:35:06Z".

1 is master, and 2 is this commit:

package      |      result1  |     result2     |        mean1   |    mean2  |   stddev1  |   stddev2   |  speedup
----------------|----------------|-----------------|------------------|--------------|---------------|---------------|--------------------
CC-delcont-ref   |  Solution   |   Solution     |      1.467s    |  1.505s   |   0.019s   |   0.100s   |   0.975
ascii-cows    |     Solution   |   Solution      |     1.827s   |   1.758s   |   0.159s   |   0.012s   |   1.040
opaleye-classy  |   NoInstallPlan | NoInstallPlan   |   4.588s  |    4.070s   |   0.043s   |   0.032s   |   1.127
range-space    |    NoInstallPlan | NoInstallPlan   |   2.642s   |   2.299s   |   0.016s   |   0.016s   |   1.149
rts         |       PkgNotFound |  PkgNotFound    |    1.323s   |   1.327s  |    0.032s  |    0.033s   |   0.997
servant-auth-docs | Solution   |   Solution       |    1.968s   |   1.998s   |   0.017s   |   0.074s   |   0.985
thorn       |       BackjumpLimit | NoInstallPlan   |   4.793s  |    3.141s   |   0.050s   |   0.034s   |   1.526
unordered-intmap |  Solution   |   Solution      |     1.502s   |   1.511s   |   0.081s   |   0.047s   |   0.994

I looked at the solver logs for the three packages with the largest changes in
run time, opaleye-classy, range-space, and thorn.  Each one showed that the
solver started preferring a flag in an older version of a package after it had
caused conflicts in a newer version of the package.

/cc @kosmikus 
