### PR TITLE
Make Backpack work with profiling.

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -642,7 +642,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
           else if isGhcDynamic
             then do shared;  vanilla
             else do vanilla; shared
-       when has_code $ whenProfLib (runGhcProg profOpts)
+       whenProfLib (runGhcProg profOpts)
 
   -- build any C sources
   unless (not has_code || null (cSources libBi)) $ do

--- a/cabal-testsuite/PackageTests/Backpack/T4754/P.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T4754/P.hs
@@ -1,0 +1,3 @@
+module P where
+import Sig
+

--- a/cabal-testsuite/PackageTests/Backpack/T4754/Sig.hsig
+++ b/cabal-testsuite/PackageTests/Backpack/T4754/Sig.hsig
@@ -1,0 +1,1 @@
+signature Sig where

--- a/cabal-testsuite/PackageTests/Backpack/T4754/p.cabal
+++ b/cabal-testsuite/PackageTests/Backpack/T4754/p.cabal
@@ -1,0 +1,15 @@
+name: p
+version: 0.1
+cabal-version: >= 2.0
+build-type: Simple
+
+library
+    exposed-modules: P
+    signatures: Sig
+    build-depends: base
+
+executable pexe
+    build-depends: p, base
+    mixins: base, base (Prelude as Sig)
+    main-is: PExe.hs
+    hs-source-dirs: pexe

--- a/cabal-testsuite/PackageTests/Backpack/T4754/pexe/PExe.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T4754/pexe/PExe.hs
@@ -1,0 +1,2 @@
+import P
+main = return ()

--- a/cabal-testsuite/PackageTests/Backpack/T4754/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/T4754/setup.cabal.out
@@ -1,0 +1,13 @@
+# Setup configure
+Resolving dependencies...
+Configuring p-0.1...
+Warning: Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.
+# Setup build
+Preprocessing library for p-0.1..
+Building library instantiated with Sig = <Sig>
+for p-0.1..
+Preprocessing library for p-0.1..
+Building library instantiated with Sig = base-<VERSION>:Prelude
+for p-0.1..
+Preprocessing executable 'pexe' for p-0.1..
+Building executable 'pexe' for p-0.1..

--- a/cabal-testsuite/PackageTests/Backpack/T4754/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/T4754/setup.out
@@ -1,0 +1,12 @@
+# Setup configure
+Configuring p-0.1...
+Warning: Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.
+# Setup build
+Preprocessing library for p-0.1..
+Building library instantiated with Sig = <Sig>
+for p-0.1..
+Preprocessing library for p-0.1..
+Building library instantiated with Sig = base-<VERSION>:Prelude
+for p-0.1..
+Preprocessing executable 'pexe' for p-0.1..
+Building executable 'pexe' for p-0.1..

--- a/cabal-testsuite/PackageTests/Backpack/T4754/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T4754/setup.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+main = setupAndCabalTest $ do
+    skipUnless =<< ghcVersionIs (>= mkVersion [8,1])
+    skipUnless =<< hasProfiledLibraries
+    setup "configure" ["--enable-profiling"]
+    setup "build" []


### PR DESCRIPTION
I am not sure what I was thinking when I modified the
code to skip profiling builds if there was no code,
but this is surely wrong!  Comes with a test.

Fixes #4754.

Signed-off-by: Edward Z. Yang <ezyang@cs.stanford.edu>

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
