### PR TITLE
Adds `new-update`

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -291,6 +291,20 @@ to happen if a flag actually applied to every transitive dependency). To
 apply options to an external package, use a ``package`` stanza in a
 ``cabal.project`` file.
 
+cabal new-update
+----------------
+
+``cabal new-update`` updates the state of the package index. If the
+project contains multiple remote package repositories it will update
+the index of all of them (e.g. when using overlays).
+
+Seom examples:
+
+::
+
+    $ cabal new-update                  # update all remote repos
+    $ cabal new-update head.hackage     # update only head.hackage
+
 cabal new-build
 ---------------
 

--- a/cabal-install/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/Distribution/Client/CmdUpdate.hs
@@ -72,8 +72,8 @@ updateCommand = Client.installCommand {
   }
 
 data UpdateRequest = UpdateRequest
-  { updateRequestRepoName :: String
-  , updateRequestRepoState :: IndexState
+  { _updateRequestRepoName :: String
+  , _updateRequestRepoState :: IndexState
   } deriving (Show)
 
 instance Text UpdateRequest where
@@ -117,7 +117,7 @@ updateAction (applyFlagDefaults -> (configFlags, configExFlags, installFlags, ha
 
     let reposToUpdate = case updateRepoRequests of
           [] -> repos
-          updateRequests -> let repoNames = map updateRequestRepoName updateRequests
+          updateRequests -> let repoNames = map _updateRequestRepoName updateRequests
                             in filter (\r-> repoName r `elem` repoNames) repos
 
     case reposToUpdate of

--- a/cabal-install/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/Distribution/Client/CmdUpdate.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE CPP, NamedFieldPuns, RecordWildCards, ViewPatterns #-}
+
+-- | cabal-install CLI command: update
+--
+module Distribution.Client.CmdUpdate (
+    updateCommand,
+    updateAction,
+  ) where
+
+import Distribution.Client.ProjectOrchestration
+import Distribution.Client.ProjectConfig
+         ( ProjectConfig(..)
+         , projectConfigWithSolverRepoContext )
+import Distribution.Client.Types
+         ( Repo(..), RemoteRepo(..), maybeRepoRemote )
+import Distribution.Client.HttpUtils
+         ( DownloadResult(..) )
+import Distribution.Client.FetchUtils
+         ( downloadIndex )
+import Distribution.Client.JobControl
+         ( newParallelJobControl, spawnJob, collectJob )
+import Distribution.Client.Setup
+         ( GlobalFlags, ConfigFlags(..), ConfigExFlags, InstallFlags, UpdateFlags (updateIndexState)
+         , applyFlagDefaults, defaultUpdateFlags, RepoContext(..) )
+import Distribution.Simple.Setup
+         ( HaddockFlags, fromFlagOrDefault, fromFlag )
+import Distribution.Simple.Utils
+         ( die', notice, wrapText, writeFileAtomic, noticeNoWrap )
+import Distribution.Verbosity
+         ( Verbosity, normal, lessVerbose )
+import Distribution.Client.IndexUtils.Timestamp
+import Distribution.Client.IndexUtils
+         ( updateRepoIndexCache, Index(..), writeIndexTimestamp
+         , currentIndexTimestamp )
+import Distribution.Text
+         ( display )
+
+import Data.Maybe (mapMaybe)
+import Control.Monad (unless, when)
+import qualified Data.ByteString.Lazy       as BS
+import Distribution.Client.GZipUtils (maybeDecompress)
+import System.FilePath (dropExtension)
+import Data.Time (getCurrentTime)
+import Distribution.Simple.Command
+         ( CommandUI(..), usageAlternatives )
+import qualified Distribution.Client.Setup as Client
+
+import qualified Hackage.Security.Client as Sec
+
+updateCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags)
+updateCommand = Client.installCommand {
+  commandName         = "new-update",
+  commandSynopsis     = "Updates list of known packages.",
+  commandUsage        = usageAlternatives "new-update" [ "[FLAGS]" ],
+  commandDescription  = Just $ \_ -> wrapText $
+        "For all known remote repositories, download the package list.",
+  commandNotes        = Just $ \pname ->
+        "Examples:\n"
+     ++ "  " ++ pname ++ " new-update\n"
+     ++ "    Download the package list for all known remote repositories.\n\n"
+     ++ "Note: this command is part of the new project-based system (aka "
+     ++ "nix-style\nlocal builds). These features are currently in beta. "
+     ++ "Please see\n"
+     ++ "http://cabal.readthedocs.io/en/latest/nix-local-build-overview.html "
+     ++ "for\ndetails and advice on what you can expect to work. If you "
+     ++ "encounter problems\nplease file issues at "
+     ++ "https://github.com/haskell/cabal/issues and if you\nhave any time "
+     ++ "to get involved and help with testing, fixing bugs etc then\nthat "
+     ++ "is very much appreciated.\n"
+  }
+
+updateAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags)
+             -> [String] -> GlobalFlags -> IO ()
+updateAction (applyFlagDefaults -> (configFlags, configExFlags, installFlags, haddockFlags))
+             extraArgs globalFlags = do
+  unless (null extraArgs) $
+    die' verbosity $ "'update' doesn't take any extra arguments: " ++ unwords extraArgs
+
+  ProjectBaseContext {
+    projectConfig
+  } <- establishProjectBaseContext verbosity cliConfig
+
+  projectConfigWithSolverRepoContext verbosity (projectConfigShared projectConfig) (projectConfigBuildOnly projectConfig)
+    $ \repoCtxt -> do
+    let repos       = repoContextRepos repoCtxt
+        remoteRepos = mapMaybe maybeRepoRemote repos
+
+    case remoteRepos of
+      [] -> return ()
+      [remoteRepo] ->
+        notice verbosity $ "Downloading the latest package list from "
+                        ++ remoteRepoName remoteRepo
+      _ -> notice verbosity . unlines
+              $ "Downloading the latest package lists from: "
+              : map (("- " ++) . remoteRepoName) remoteRepos
+    jobCtrl <- newParallelJobControl (length repos)
+    mapM_ (spawnJob jobCtrl . updateRepo verbosity defaultUpdateFlags repoCtxt) repos
+    mapM_ (\_ -> collectJob jobCtrl) repos
+
+  where
+    verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
+    cliConfig = commandLineFlagsToProjectConfig
+                  globalFlags configFlags configExFlags
+                  installFlags haddockFlags
+
+updateRepo :: Verbosity -> UpdateFlags -> RepoContext -> Repo -> IO ()
+updateRepo verbosity updateFlags repoCtxt repo = do
+  transport <- repoContextGetTransport repoCtxt
+  case repo of
+    RepoLocal{..} -> return ()
+    RepoRemote{..} -> do
+      downloadResult <- downloadIndex transport verbosity repoRemote repoLocalDir
+      case downloadResult of
+        FileAlreadyInCache -> return ()
+        FileDownloaded indexPath -> do
+          writeFileAtomic (dropExtension indexPath) . maybeDecompress
+                                                  =<< BS.readFile indexPath
+          updateRepoIndexCache verbosity (RepoIndex repoCtxt repo)
+    RepoSecure{} -> repoContextWithSecureRepo repoCtxt repo $ \repoSecure -> do
+      let index = RepoIndex repoCtxt repo
+      -- NB: This may be a nullTimestamp if we've never updated before
+      current_ts <- currentIndexTimestamp (lessVerbose verbosity) repoCtxt repo
+      -- NB: always update the timestamp, even if we didn't actually
+      -- download anything
+      writeIndexTimestamp index (fromFlag (updateIndexState updateFlags))
+      ce <- if repoContextIgnoreExpiry repoCtxt
+              then Just `fmap` getCurrentTime
+              else return Nothing
+      updated <- Sec.uncheckClientErrors $ Sec.checkForUpdates repoSecure ce
+      -- Update cabal's internal index as well so that it's not out of sync
+      -- (If all access to the cache goes through hackage-security this can go)
+      case updated of
+        Sec.NoUpdates  ->
+          return ()
+        Sec.HasUpdates ->
+          updateRepoIndexCache verbosity index
+      -- TODO: This will print multiple times if there are multiple
+      -- repositories: main problem is we don't have a way of updating
+      -- a specific repo.  Once we implement that, update this.
+      when (current_ts /= nullTimestamp) $
+        noticeNoWrap verbosity $
+          "To revert to previous state run:\n" ++
+          "    cabal update --index-state='" ++ display current_ts ++ "'\n"

--- a/cabal-install/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/Distribution/Client/CmdUpdate.hs
@@ -77,15 +77,15 @@ data UpdateRequest = UpdateRequest
   } deriving (Show)
 
 instance Text UpdateRequest where
-  disp (UpdateRequest n s) = Disp.text n Disp.<> Disp.char '@' Disp.<> disp s
+  disp (UpdateRequest n s) = Disp.text n Disp.<> Disp.char ',' Disp.<> disp s
   parse = parseWithState ReadP.+++ parseHEAD
     where parseWithState = do
-            name <- ReadP.many1 (ReadP.satisfy (\c -> c /= '@'))
-            _ <- ReadP.char '@'
+            name <- ReadP.many1 (ReadP.satisfy (\c -> c /= ','))
+            _ <- ReadP.char ','
             state <- parse
             return (UpdateRequest name state)
           parseHEAD = do
-            name <- ReadP.manyTill (ReadP.satisfy (\c -> c /= '@')) ReadP.eof
+            name <- ReadP.manyTill (ReadP.satisfy (\c -> c /= ',')) ReadP.eof
             return (UpdateRequest name IndexStateHead)
 
 updateAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags)
@@ -175,5 +175,5 @@ updateRepo verbosity updateFlags repoCtxt repo = do
       when (current_ts /= nullTimestamp) $
         noticeNoWrap verbosity $
           "To revert to previous state run:\n" ++
-          "    cabal new-update '" ++ remoteRepoName (repoRemote repo) ++ "@" ++ display current_ts ++ "'\n"
+          "    cabal new-update '" ++ remoteRepoName (repoRemote repo) ++ "," ++ display current_ts ++ "'\n"
  

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -26,7 +26,7 @@ module Distribution.Client.Setup
     , installCommand, InstallFlags(..), installOptions, defaultInstallFlags
     , defaultSolver, defaultMaxBackjumps
     , listCommand, ListFlags(..)
-    , updateCommand, UpdateFlags(..)
+    , updateCommand, UpdateFlags(..), defaultUpdateFlags
     , upgradeCommand
     , uninstallCommand
     , infoCommand, InfoFlags(..)

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -322,6 +322,11 @@ data Repo =
 instance Binary Repo
 
 -- | Check if this is a remote repo
+isRepoRemote :: Repo -> Bool
+isRepoRemote RepoLocal{} = False
+isRepoRemote _           = True
+
+-- | Extract @RemoteRepo@ from @Repo@ if remote.
 maybeRepoRemote :: Repo -> Maybe RemoteRepo
 maybeRepoRemote (RepoLocal    _localDir) = Nothing
 maybeRepoRemote (RepoRemote r _localDir) = Just r

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -154,6 +154,7 @@ library
         Distribution.Client.CmdBench
         Distribution.Client.CmdBuild
         Distribution.Client.CmdConfigure
+        Distribution.Client.CmdUpdate
         Distribution.Client.CmdErrorMessages
         Distribution.Client.CmdExec
         Distribution.Client.CmdFreeze
@@ -415,6 +416,7 @@ executable cabal
             Distribution.Client.CmdBench
             Distribution.Client.CmdBuild
             Distribution.Client.CmdConfigure
+            Distribution.Client.CmdUpdate
             Distribution.Client.CmdErrorMessages
             Distribution.Client.CmdExec
             Distribution.Client.CmdFreeze

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,9 @@
 -*-change-log-*-
 
 2.2.0.0 (current development version)
+	* Completed the 'new-update' command (#4809), which respects nix-style
+	cabal.project(.local) files and allows to update from
+	multiple repositories when using overlays.
 	* New config file field: 'cxx-options' to specify which options to be
 	passed to the compiler when compiling C++ sources specified by the
 	'cxx-sources' field. (#3700)

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -75,7 +75,9 @@ import Distribution.Client.Targets
 import qualified Distribution.Client.List as List
          ( list, info )
 
+
 import qualified Distribution.Client.CmdConfigure as CmdConfigure
+import qualified Distribution.Client.CmdUpdate    as CmdUpdate
 import qualified Distribution.Client.CmdBuild     as CmdBuild
 import qualified Distribution.Client.CmdRepl      as CmdRepl
 import qualified Distribution.Client.CmdFreeze    as CmdFreeze
@@ -311,6 +313,7 @@ mainWorker args = topHandler $
       , hiddenCmd  manpageCommand (manpageAction commandSpecs)
 
       , regularCmd  CmdConfigure.configureCommand CmdConfigure.configureAction
+      , regularCmd  CmdUpdate.updateCommand       CmdUpdate.updateAction
       , regularCmd  CmdBuild.buildCommand         CmdBuild.buildAction
       , regularCmd  CmdRepl.replCommand           CmdRepl.replAction
       , regularCmd  CmdFreeze.freezeCommand       CmdFreeze.freezeAction


### PR DESCRIPTION
new-update uses the new-style logic to update the repositories.  As such it
respects `repository` fields in the `cabal.project(.local)` file and updates
them as well.  This is essential when working with hackage overlays, where
the overlay repositories are specified as `repository` fields in the
`cabal.project(.local)` file.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
