### PR TITLE
Use a handwritten Parsec instance for DefUnitId.

### DIFF
--- a/Cabal/Distribution/Types/UnitId.hs
+++ b/Cabal/Distribution/Types/UnitId.hs
@@ -121,7 +121,12 @@ getHSLibraryName uid = "HS" ++ display uid
 -- that a 'UnitId' identified this way is definite; i.e., it has no
 -- unfilled holes.
 newtype DefUnitId = DefUnitId { unDefUnitId :: UnitId }
-  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data, Binary, NFData, Parsec, Pretty, Text)
+  deriving (Generic, Read, Show, Eq, Ord, Typeable, Data, Binary, NFData, Pretty, Text)
+
+-- Workaround for a GHC 8.0.1 bug, see
+-- https://github.com/haskell/cabal/issues/4793#issuecomment-334258288
+instance Parsec DefUnitId where
+  parsec = DefUnitId <$> parsec
 
 -- | Unsafely create a 'DefUnitId' from a 'UnitId'.  Your responsibility
 -- is to ensure that the 'DefUnitId' invariant holds.


### PR DESCRIPTION
Fixes #4793.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
