### PR TITLE
Split sections support

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -811,6 +811,11 @@ checkGhcOptions pkg =
       ++ "Check that it is giving a real benefit "
       ++ "and not just imposing longer compile times on your users."
 
+  , checkFlags ["-split-sections"] $
+      PackageBuildWarning $
+        "'ghc-options: -split-sections' is not needed. "
+        ++ "Use the --enable-split-sections configure flag."
+
   , checkFlags ["-split-objs"] $
       PackageBuildWarning $
         "'ghc-options: -split-objs' is not needed. "

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -354,6 +354,7 @@ componentGhcOptions verbosity implInfo lbi bi clbi odir =
       ghcOptWarnMissingHomeModules = toFlag $ flagWarnMissingHomeModules implInfo,
       ghcOptPackageDBs      = withPackageDB lbi,
       ghcOptPackages        = toNubListR $ mkGhcOptPackages clbi,
+      ghcOptSplitSections   = toFlag (splitSections lbi),
       ghcOptSplitObjs       = toFlag (splitObjs lbi),
       ghcOptSourcePathClear = toFlag True,
       ghcOptSourcePath      = toNubListR $ [odir] ++ (hsSourceDirs bi)

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -197,6 +197,9 @@ data GhcOptions = GhcOptions {
   -- | Automatically add profiling cost centers; the @ghc -fprof-auto*@ flags.
   ghcOptProfilingAuto :: Flag GhcProfAuto,
 
+  -- | Use the \"split sections\" feature; the @ghc -split-sections@ flag.
+  ghcOptSplitSections :: Flag Bool,
+
   -- | Use the \"split object files\" feature; the @ghc -split-objs@ flag.
   ghcOptSplitObjs     :: Flag Bool,
 
@@ -350,6 +353,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
         | flagProfAuto implInfo -> ["-fprof-auto-exported"]
         | otherwise             -> ["-auto"]
 
+  , [ "-split-sections" | flagBool ghcOptSplitObjs ]
   , [ "-split-objs" | flagBool ghcOptSplitObjs ]
 
   , case flagToMaybe (ghcOptHPCDir opts) of

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -336,6 +336,7 @@ data ConfigFlags = ConfigFlags {
     configUserInstall :: Flag Bool,    -- ^The --user\/--global flag
     configPackageDBs :: [Maybe PackageDB], -- ^Which package DBs to use
     configGHCiLib   :: Flag Bool,      -- ^Enable compiling library for GHCi
+    configSplitSections :: Flag Bool,      -- ^Enable -split-sections with GHC
     configSplitObjs :: Flag Bool,      -- ^Enable -split-objs with GHC
     configStripExes :: Flag Bool,      -- ^Enable executable stripping
     configStripLibs :: Flag Bool,      -- ^Enable library stripping
@@ -405,6 +406,7 @@ instance Eq ConfigFlags where
     && equal configUserInstall
     && equal configPackageDBs
     && equal configGHCiLib
+    && equal configSplitSections
     && equal configSplitObjs
     && equal configStripExes
     && equal configStripLibs
@@ -456,6 +458,7 @@ defaultConfigFlags progDb = emptyConfigFlags {
 #else
     configGHCiLib      = NoFlag,
 #endif
+    configSplitSections = Flag False,
     configSplitObjs    = Flag False, -- takes longer, so turn off by default
     configStripExes    = Flag True,
     configStripLibs    = Flag True,
@@ -635,6 +638,11 @@ configureOptions showOrParseArgs =
       ,option "" ["library-for-ghci"]
          "compile library for use with GHCi"
          configGHCiLib (\v flags -> flags { configGHCiLib = v })
+         (boolOpt [] [])
+
+      ,option "" ["split-sections"]
+         "compile library code such that unneeded definitions can be dropped from the final executable (GHC 7.8+)"
+         configSplitSections (\v flags -> flags { configSplitSections = v })
          (boolOpt [] [])
 
       ,option "" ["split-objs"]

--- a/Cabal/Distribution/Types/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Types/LocalBuildInfo.hs
@@ -150,6 +150,7 @@ data LocalBuildInfo = LocalBuildInfo {
         withOptimization :: OptimisationLevel, -- ^Whether to build with optimization (if available).
         withDebugInfo :: DebugInfoLevel, -- ^Whether to emit debug info (if available).
         withGHCiLib   :: Bool,  -- ^Whether to build libs suitable for use with GHCi.
+        splitSections :: Bool,  -- ^Use -split-sections with GHC, if available
         splitObjs     :: Bool,  -- ^Use -split-objs with GHC, if available
         stripExes     :: Bool,  -- ^Whether to strip executables during install
         stripLibs     :: Bool,  -- ^Whether to strip libraries during install

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -20,6 +20,7 @@
 	* Support for GHC's numeric -g debug levels (#4673).
 	* Added elif-conditionals to .cabal syntax (#4750).
 	* Support for building with Win32 version 2.6 (#4835).
+	* Compilation with section splitting is now supported via the '--enable-split-sections' flag (#4819)
 	* TODO
 
 

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -1101,8 +1101,8 @@ feature was added.
 Object code options
 ^^^^^^^^^^^^^^^^^^^
 
-.. cfg-field:: debug-info: boolean
-               --enable-debug-info
+.. cfg-field:: debug-info: integer
+               --enable-debug-info=<n>
                --disable-debug-info
     :synopsis: Build with debug info enabled.
     :since: 1.22
@@ -1114,8 +1114,8 @@ Object code options
     instruct it to do so. See the GHC wiki page on :ghc-wiki:`DWARF`
     for more information about this feature.
 
-    (This field also accepts numeric syntax, but as of GHC 8.0 this
-    doesn't do anything.)
+    (This field also accepts numeric syntax, but until GHC 8.2 this didn't
+    do anything.)
 
     The command line variant of this flag is ``--enable-debug-info`` and
     ``--disable-debug-info``.

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -1120,10 +1120,29 @@ Object code options
     The command line variant of this flag is ``--enable-debug-info`` and
     ``--disable-debug-info``.
 
+.. cfg-field:: split-sections: boolean
+               --enable-split-sections
+               --disable-split-sections
+    :synopsis: Use GHC's split sections feature.
+    :since: 2.1
+
+    :default: False
+
+    Use the GHC ``-split-sections`` feature when building the library. This
+    reduces the final size of the executables that use the library by
+    allowing them to link with only the bits that they use rather than
+    the entire library. The downside is that building the library takes
+    longer and uses a bit more memory.
+
+    This feature is supported by GHC 8.0 and later.
+
+    The command line variant of this flag is ``--enable-split-sections`` and
+    ``--disable-split-sections``.
+
 .. cfg-field:: split-objs: boolean
                --enable-split-objs
                --disable-split-objs
-    :synopsis: Use GHC split objects feature.
+    :synopsis: Use GHC's split objects feature.
 
     :default: False
 
@@ -1132,6 +1151,9 @@ Object code options
     allowing them to link with only the bits that they use rather than
     the entire library. The downside is that building the library takes
     longer and uses considerably more memory.
+
+    It is generally recommend that you use ``split-sections`` instead
+    of ``split-objs`` where possible.
 
     The command line variant of this flag is ``--enable-split-objs`` and
     ``--disable-split-objs``.

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -324,6 +324,7 @@ instance Semigroup SavedConfig where
         -- TODO: NubListify
         configPackageDBs          = lastNonEmpty configPackageDBs,
         configGHCiLib             = combine configGHCiLib,
+        configSplitSections       = combine configSplitSections,
         configSplitObjs           = combine configSplitObjs,
         configStripExes           = combine configStripExes,
         configStripLibs           = combine configStripLibs,

--- a/cabal-install/Distribution/Client/PackageHash.hs
+++ b/cabal-install/Distribution/Client/PackageHash.hs
@@ -202,6 +202,7 @@ data PackageHashConfigInputs = PackageHashConfigInputs {
        pkgHashCoverage            :: Bool,
        pkgHashOptimization        :: OptimisationLevel,
        pkgHashSplitObjs           :: Bool,
+       pkgHashSplitSections       :: Bool,
        pkgHashStripLibs           :: Bool,
        pkgHashStripExes           :: Bool,
        pkgHashDebugInfo           :: DebugInfoLevel,
@@ -280,6 +281,7 @@ renderPackageHashInputs PackageHashInputs{
       , opt   "hpc"          False display pkgHashCoverage
       , opt   "optimisation" NormalOptimisation (show . fromEnum) pkgHashOptimization
       , opt   "split-objs"   False display pkgHashSplitObjs
+      , opt   "split-sections" False display pkgHashSplitSections
       , opt   "stripped-lib" False display pkgHashStripLibs
       , opt   "stripped-exe" True  display pkgHashStripExes
       , opt   "debug-info"   NormalDebugInfo (show . fromEnum) pkgHashDebugInfo

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -341,6 +341,7 @@ convertLegacyPerPackageFlags configFlags installFlags haddockFlags =
       configProgPrefix          = packageConfigProgPrefix,
       configProgSuffix          = packageConfigProgSuffix,
       configGHCiLib             = packageConfigGHCiLib,
+      configSplitSections       = packageConfigSplitSections,
       configSplitObjs           = packageConfigSplitObjs,
       configStripExes           = packageConfigStripExes,
       configStripLibs           = packageConfigStripLibs,
@@ -577,6 +578,7 @@ convertToLegacyAllPackageConfig
       configUserInstall         = mempty, --projectConfigUserInstall,
       configPackageDBs          = mempty, --projectConfigPackageDBs,
       configGHCiLib             = mempty,
+      configSplitSections       = mempty,
       configSplitObjs           = mempty,
       configStripExes           = mempty,
       configStripLibs           = mempty,
@@ -644,6 +646,7 @@ convertToLegacyPerPackageConfig PackageConfig {..} =
       configUserInstall         = mempty,
       configPackageDBs          = mempty,
       configGHCiLib             = packageConfigGHCiLib,
+      configSplitSections       = packageConfigSplitSections,
       configSplitObjs           = packageConfigSplitObjs,
       configStripExes           = packageConfigStripExes,
       configStripLibs           = packageConfigStripLibs,
@@ -911,7 +914,7 @@ legacyPackageConfigFieldDescrs =
       , "shared", "static", "executable-dynamic"
       , "profiling", "executable-profiling"
       , "profiling-detail", "library-profiling-detail"
-      , "library-for-ghci", "split-objs"
+      , "library-for-ghci", "split-objs", "split-sections"
       , "executable-stripping", "library-stripping"
       , "tests", "benchmarks"
       , "coverage", "library-coverage"

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -243,6 +243,7 @@ data PackageConfig
        packageConfigExtraFrameworkDirs  :: [FilePath],
        packageConfigExtraIncludeDirs    :: [FilePath],
        packageConfigGHCiLib             :: Flag Bool,
+       packageConfigSplitSections       :: Flag Bool,
        packageConfigSplitObjs           :: Flag Bool,
        packageConfigStripExes           :: Flag Bool,
        packageConfigStripLibs           :: Flag Bool,

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1690,6 +1690,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
 
         elabOptimization  = perPkgOptionFlag pkgid NormalOptimisation packageConfigOptimization
         elabSplitObjs     = perPkgOptionFlag pkgid False packageConfigSplitObjs
+        elabSplitSections = perPkgOptionFlag pkgid False packageConfigSplitSections
         elabStripLibs     = perPkgOptionFlag pkgid False packageConfigStripLibs
         elabStripExes     = perPkgOptionFlag pkgid False packageConfigStripExes
         elabDebugInfo     = perPkgOptionFlag pkgid NoDebugInfo packageConfigDebugInfo
@@ -3081,6 +3082,7 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
     configLibCoverage         = mempty
 
     configOptimization        = toFlag elabOptimization
+    configSplitSections       = toFlag elabSplitSections
     configSplitObjs           = toFlag elabSplitObjs
     configStripExes           = toFlag elabStripExes
     configStripLibs           = toFlag elabStripLibs
@@ -3416,6 +3418,7 @@ packageHashConfigInputs
       pkgHashProfExeDetail       = elabProfExeDetail,
       pkgHashCoverage            = elabCoverage,
       pkgHashOptimization        = elabOptimization,
+      pkgHashSplitSections       = elabSplitSections,
       pkgHashSplitObjs           = elabSplitObjs,
       pkgHashStripLibs           = elabStripLibs,
       pkgHashStripExes           = elabStripExes,

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -241,6 +241,7 @@ data ElaboratedConfiguredPackage
        elabCoverage             :: Bool,
        elabOptimization         :: OptimisationLevel,
        elabSplitObjs            :: Bool,
+       elabSplitSections        :: Bool,
        elabStripLibs            :: Bool,
        elabStripExes            :: Bool,
        elabDebugInfo            :: DebugInfoLevel,

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -440,6 +440,7 @@ filterConfigureFlags flags cabalLibVersion
         configVerbosity   = fmap verboseNoTimestamp (configVerbosity flags_latest)
       -- Cabal < 2.1 doesn't know about --<enable|disable>-static
       , configStaticLib   = NoFlag
+      , configSplitSections = NoFlag
       }
 
     flags_1_25_0 = flags_2_1_0 {

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -531,7 +531,7 @@ instance Arbitrary PackageConfig where
         <*> shortListOf 5 arbitraryShortToken
         <*> shortListOf 5 arbitraryShortToken
         <*> shortListOf 5 arbitraryShortToken
-        <*> arbitrary
+        <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary
@@ -575,7 +575,8 @@ instance Arbitrary PackageConfig where
                          , packageConfigExtraFrameworkDirs = x17
                          , packageConfigExtraIncludeDirs = x18
                          , packageConfigGHCiLib = x19
-                         , packageConfigSplitObjs = x20
+                         , packageConfigSplitSections = x20
+                         , packageConfigSplitObjs = x20_1
                          , packageConfigStripExes = x21
                          , packageConfigStripLibs = x22
                          , packageConfigTests = x23
@@ -619,7 +620,8 @@ instance Arbitrary PackageConfig where
                       , packageConfigExtraFrameworkDirs = map getNonEmpty x17'
                       , packageConfigExtraIncludeDirs = map getNonEmpty x18'
                       , packageConfigGHCiLib = x19'
-                      , packageConfigSplitObjs = x20'
+                      , packageConfigSplitSections = x20'
+                      , packageConfigSplitObjs = x20_1'
                       , packageConfigStripExes = x21'
                       , packageConfigStripLibs = x22'
                       , packageConfigTests = x23'
@@ -646,7 +648,7 @@ instance Arbitrary PackageConfig where
           (x05', x42', x06', x07', x08', x09'),
           (x10', x11', x12', x13', x14'),
           (x15', x16', x17', x18', x19')),
-         ((x20', x21', x22', x23', x24'),
+         ((x20', x20_1', x21', x22', x23', x24'),
           (x25', x26', x27', x28', x29'),
           (x30', x31', x32', (x33', x33_1'), x34'),
           (x35', x36', x37', x38', x39'),
@@ -659,7 +661,7 @@ instance Arbitrary PackageConfig where
                   map NonEmpty x17,
                   map NonEmpty x18,
                   x19)),
-               ((x20, x21, x22, x23, x24),
+               ((x20, x20_1, x21, x22, x23, x24),
                  (x25, x26, x27, x28, x29),
                  (x30, x31, x32, (x33, x33_1), x34),
                  (x35, x36, fmap NonEmpty x37, x38, fmap NonEmpty x39),


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Add --enable-split-sections flag and pipe it through to the GHC backend. Note
that some of the implementation here could be made a bit more precise:
-split-sections and -split-objs are mutually exlusive yet the types don't
currently reflect this.

Fixes #4819.

