### PR TITLE
Delete cabal-install/.ghci

### DIFF
--- a/cabal-install/.ghci
+++ b/cabal-install/.ghci
@@ -1,1 +1,0 @@
-:set -idist/build/autogen -optP-include -optPdist/build/autogen/cabal_macros.h


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

The .ghci file was added 5 years ago. It prevents cabal new-repl from working:
```
<command-line>:11:0: error:
     fatal error: dist/build/autogen/cabal_macros.h: No such file or directory
compilation terminated.
`cc' failed in phase `C pre-processor'. (Exit code: 1)
```
If someone wants that file to stay, feel free to close the PR.