### PR TITLE
Cabal: Bump Win32 version bounds for GHC 8.4

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -111,7 +111,7 @@ library
 
   if os(windows)
     build-depends:
-      Win32 >= 2.2 && < 2.6
+      Win32 >= 2.2 && < 2.7
 
   ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs
   if impl(ghc >= 8.0)

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -17,7 +17,8 @@
 	* Added '.Lens' modules, with optics for package description data
 	  types. (#4701)
 	* Support for GHC's numeric -g debug levels (#4673).
-	* Added elif-conditionals to .cabal syntax (#4750)
+	* Added elif-conditionals to .cabal syntax (#4750).
+	* Support for building with Win32 version 2.6 (#4835).
 	* TODO
 
 


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Tested using a bootstrap of GHC. I couldn't find a changelog file so don't know where to add the version bump.
