### PR TITLE
Implement native DNS hackage-security bootstrap via resolv/windns packages

### DIFF
--- a/cabal-install/Distribution/Client/Security/DNS.hs
+++ b/cabal-install/Distribution/Client/Security/DNS.hs
@@ -14,7 +14,7 @@ import Control.Exception (SomeException, evaluate, try)
 import Distribution.Simple.Utils
 import Distribution.Compat.Exception (displayException)
 
-#if defined(MIN_VERSION_resolv)
+#if defined(MIN_VERSION_resolv) || defined(MIN_VERSION_windns)
 import Network.DNS (queryTXT, Name(..), CharStr(..))
 import qualified Data.ByteString.Char8 as BS.Char8
 #else
@@ -49,7 +49,7 @@ import Distribution.Simple.Program
 --
 queryBootstrapMirrors :: Verbosity -> URI -> IO [URI]
 
-#if defined(MIN_VERSION_resolv)
+#if defined(MIN_VERSION_resolv) || defined(MIN_VERSION_windns)
 -- use @resolv@ package for performing DNS queries
 queryBootstrapMirrors verbosity repoUri
   | Just auth <- uriAuthority repoUri = do

--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -261,6 +261,8 @@ BASE64_BYTESTRING_VER="1.0.0.1"; BASE64_BYTESTRING_VER_REGEXP="1\."
                        # >=1.0
 CRYPTOHASH_SHA256_VER="0.11.100.1"; CRYPTOHASH_SHA256_VER_REGEXP="0\.11\.?"
                        # 0.11.*
+RESOLV_VER="0.1.1.0";  RESOLV_VER_REGEXP="0\.1\.[1-9]"
+                       # >= 0.1.1 && < 0.2
 MINTTY_VER="0.1";      MINTTY_VER_REGEXP="0\.1\.?"
                        # 0.1.*
 ECHO_VER="0.1.3";      ECHO_VER_REGEXP="0\.1\.[3-9]"
@@ -491,6 +493,7 @@ info_pkg "base64-bytestring" ${BASE64_BYTESTRING_VER} \
     ${BASE64_BYTESTRING_VER_REGEXP}
 info_pkg "cryptohash-sha256" ${CRYPTOHASH_SHA256_VER} \
     ${CRYPTOHASH_SHA256_VER_REGEXP}
+info_pkg "resolv"        ${RESOLV_VER}        ${RESOLV_VER_REGEXP}
 info_pkg "mintty"        ${MINTTY_VER}        ${MINTTY_VER_REGEXP}
 info_pkg "echo"          ${ECHO_VER}          ${ECHO_VER_REGEXP}
 info_pkg "edit-distance" ${EDIT_DISTANCE_VER} ${EDIT_DISTANCE_VER_REGEXP}
@@ -531,6 +534,7 @@ do_pkg   "base64-bytestring" ${BASE64_BYTESTRING_VER} \
     ${BASE64_BYTESTRING_VER_REGEXP}
 do_pkg   "cryptohash-sha256" ${CRYPTOHASH_SHA256_VER} \
     ${CRYPTOHASH_SHA256_VER_REGEXP}
+do_pkg "resolv"        ${RESOLV_VER}        ${RESOLV_VER_REGEXP}
 do_pkg "mintty"        ${MINTTY_VER}        ${MINTTY_VER_REGEXP}
 do_pkg "echo"          ${ECHO_VER}          ${ECHO_VER_REGEXP}
 do_pkg "edit-distance" ${EDIT_DISTANCE_VER} ${EDIT_DISTANCE_VER_REGEXP}

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -107,7 +107,7 @@ Flag network-uri
 
 Flag native-dns
   description:  Enable use of the [resolv](https://hackage.haskell.org/package/resolv) & [windns](https://hackage.haskell.org/package/windns) packages for performing DNS lookups
-  default:      False
+  default:      True
   manual:       True
 
 Flag debug-expensive-assertions

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -105,8 +105,8 @@ Flag network-uri
   description:  Get Network.URI from the network-uri package
   default:      True
 
-Flag resolv
-  description:  Enable use of the [resolv](https://hackage.haskell.org/package/resolv) package for performing DNS lookups
+Flag native-dns
+  description:  Enable use of the [resolv](https://hackage.haskell.org/package/resolv) & [windns](https://hackage.haskell.org/package/windns) packages for performing DNS lookups
   default:      False
   manual:       True
 
@@ -341,8 +341,11 @@ library
     else
       build-depends: network     >= 2.4 && < 2.6
 
-    if flag(resolv)
-      build-depends: resolv      >= 0.1.1 && < 0.2
+    if flag(native-dns)
+      if os(windows)
+        build-depends: windns      >= 0.1.0 && < 0.2
+      else
+        build-depends: resolv      >= 0.1.1 && < 0.2
 
     -- Needed for GHC.Generics before GHC 7.6
     if impl(ghc < 7.6)
@@ -578,8 +581,11 @@ executable cabal
         else
           build-depends: network     >= 2.4 && < 2.6
 
-        if flag(resolv)
-          build-depends: resolv      >= 0.1 && < 0.2
+        if flag(native-dns)
+          if os(windows)
+            build-depends: windns      >= 0.1.0 && < 0.2
+          else
+            build-depends: resolv      >= 0.1.1 && < 0.2
 
         -- Needed for GHC.Generics before GHC 7.6
         if impl(ghc < 7.6)

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -105,6 +105,11 @@ Flag network-uri
   description:  Get Network.URI from the network-uri package
   default:      True
 
+Flag resolv
+  description:  Enable use of the [resolv](https://hackage.haskell.org/package/resolv) package for performing DNS lookups
+  default:      False
+  manual:       True
+
 Flag debug-expensive-assertions
   description:  Enable expensive assertions for testing or debugging
   default:      False
@@ -335,6 +340,9 @@ library
       build-depends: network-uri >= 2.6 && < 2.7, network >= 2.6 && < 2.7
     else
       build-depends: network     >= 2.4 && < 2.6
+
+    if flag(resolv)
+      build-depends: resolv      >= 0.1.1 && < 0.2
 
     -- Needed for GHC.Generics before GHC 7.6
     if impl(ghc < 7.6)
@@ -569,6 +577,9 @@ executable cabal
           build-depends: network-uri >= 2.6 && < 2.7, network >= 2.6 && < 2.7
         else
           build-depends: network     >= 2.4 && < 2.6
+
+        if flag(resolv)
+          build-depends: resolv      >= 0.1 && < 0.2
 
         -- Needed for GHC.Generics before GHC 7.6
         if impl(ghc < 7.6)


### PR DESCRIPTION
This avoids calling out to an external `nslookup` program and having
to screen scrape its output. The `resolv` library supports all
platforms which provide the ubiquitous `libresolv` API.

This is hidden behind the manual cabal flag `resolv` which is
currently disabled by default.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
