### PR TITLE
Make `--enable-documentation` work for non-local packages

### DIFF
--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -936,6 +936,13 @@ buildAndInstallUnpackedPackage verbosity
     annotateFailure mlogFile BuildFailed $
       setup buildCommand buildFlags
 
+    -- Haddock phase
+    whenHaddock $ do
+      when isParallelBuild $
+        notice verbosity $ "Building " ++ dispname ++ " documentation..."
+      annotateFailureNoLog HaddocksFailed $
+        setup haddockCommand haddockFlags
+
     -- Install phase
     annotateFailure mlogFile InstallFailed $ do
 
@@ -1022,6 +1029,10 @@ buildAndInstallUnpackedPackage verbosity
 
     isParallelBuild = buildSettingNumJobs >= 2
 
+    whenHaddock action
+      | elabBuildHaddocks pkg = action
+      | otherwise             = return ()
+
     configureCommand = Cabal.configureCommand defaultProgramDb
     configureFlags v = flip filterConfigureFlags v $
                        setupHsConfigureFlags rpkg pkgshared
@@ -1030,6 +1041,10 @@ buildAndInstallUnpackedPackage verbosity
 
     buildCommand     = Cabal.buildCommand defaultProgramDb
     buildFlags   _   = setupHsBuildFlags pkg pkgshared verbosity builddir
+
+    haddockCommand   = Cabal.haddockCommand
+    haddockFlags _   = setupHsHaddockFlags pkg pkgshared
+                                           verbosity builddir
 
     generateInstalledPackageInfo :: IO InstalledPackageInfo
     generateInstalledPackageInfo =

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -166,7 +166,9 @@ commandLineFlagsToProjectConfig globalFlags configFlags configExFlags
                                      globalFlags configFlags
                                      configExFlags installFlags,
       projectConfigLocalPackages = convertLegacyPerPackageFlags
-                                     configFlags installFlags haddockFlags
+                                     configFlags installFlags haddockFlags,
+      projectConfigNonLocalPackages = convertLegacyPerPackageFlags
+                                       configFlags installFlags haddockFlags
     }
 
 
@@ -194,6 +196,7 @@ convertLegacyGlobalConfig
     mempty {
       projectConfigShared        = configAllPackages,
       projectConfigLocalPackages = configLocalPackages,
+      projectConfigNonLocalPackages = configNonLocalPackages,
       projectConfigBuildOnly     = configBuildOnly
     }
   where
@@ -205,6 +208,7 @@ convertLegacyGlobalConfig
 
     configLocalPackages = convertLegacyPerPackageFlags
                             configFlags installFlags' haddockFlags'
+    configNonLocalPackages = configLocalPackages
     configAllPackages   = convertLegacyAllPackageFlags
                             globalFlags configFlags
                             configExFlags' installFlags'
@@ -241,6 +245,7 @@ convertLegacyProjectConfig
       projectConfigShared          = configAllPackages,
       projectConfigProvenance      = mempty,
       projectConfigLocalPackages   = configLocalPackages,
+      projectConfigNonLocalPackages = configLocalPackages,
       projectConfigSpecificPackage = fmap perPackage legacySpecificConfig
     }
   where

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -113,10 +113,14 @@ data ProjectConfig
        projectConfigShared          :: ProjectConfigShared,
        projectConfigProvenance      :: Set ProjectConfigProvenance,
 
-       -- | Configuration to be applied to *local* packages; i.e.,
-       -- any packages which are explicitly named in `cabal.project`.
-       projectConfigLocalPackages   :: PackageConfig,
-       projectConfigSpecificPackage :: MapMappend PackageName PackageConfig
+       -- | Configuration to be applied to *local* packages
+       projectConfigLocalPackages    :: PackageConfig,
+
+       -- | Configuration to be applied to non-local packages
+       projectConfigNonLocalPackages :: PackageConfig,
+
+       -- | Configuration for any packages which are explicitly named in `cabal.project`.
+       projectConfigSpecificPackage  :: MapMappend PackageName PackageConfig
      }
   deriving (Eq, Show, Generic, Typeable)
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -585,6 +585,7 @@ rebuildInstallPlan verbosity
     phaseElaboratePlan ProjectConfig {
                          projectConfigShared,
                          projectConfigLocalPackages,
+                         projectConfigNonLocalPackages,
                          projectConfigSpecificPackage,
                          projectConfigBuildOnly
                        }
@@ -612,6 +613,7 @@ rebuildInstallPlan verbosity
                 defaultInstallDirs
                 projectConfigShared
                 projectConfigLocalPackages
+                projectConfigNonLocalPackages
                 (getMapMappend projectConfigSpecificPackage)
         let instantiatedPlan = instantiateInstallPlan elaboratedPlan
         liftIO $ debugNoWrap verbosity (InstallPlan.showInstallPlan instantiatedPlan)
@@ -1136,6 +1138,7 @@ elaborateInstallPlan
   -> InstallDirs.InstallDirTemplates
   -> ProjectConfigShared
   -> PackageConfig
+  -> PackageConfig
   -> Map PackageName PackageConfig
   -> LogProgress (ElaboratedInstallPlan, ElaboratedSharedConfig)
 elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
@@ -1146,6 +1149,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                      defaultInstallDirs
                      sharedPackageConfig
                      localPackagesConfig
+                     nonLocalPackagesConfig
                      perPackageConfig = do
     x <- elaboratedInstallPlan
     return (x, elaboratedSharedConfig)
@@ -1647,7 +1651,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
         elabTestTargets     = []
         elabBenchTargets    = []
         elabReplTarget      = Nothing
-        elabBuildHaddocks   = False
+        elabBuildHaddocks   = perPkgOptionFlag pkgid False packageConfigDocumentation
 
         elabPkgSourceLocation = srcloc
         elabPkgSourceHash   = Map.lookup pkgid sourcePackageHashes
@@ -1756,9 +1760,11 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
       -- but by default non-local packages get all default config values
       -- the project, and can specify per-package values for any package,
       | isLocalToProject pkg = local `mappend` perpkg
-      | otherwise            =                 perpkg
+      | otherwise            = nonLocal `mappend` perpkg
       where
         local  = f localPackagesConfig
+        nonLocal = f nonLocalPackagesConfig
+
         perpkg = maybe mempty f (Map.lookup (packageName pkg) perPackageConfig)
 
     inplacePackageDbs = storePackageDbs
@@ -3052,7 +3058,7 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
     configVanillaLib          = toFlag elabVanillaLib
     configSharedLib           = toFlag elabSharedLib
     configStaticLib           = toFlag elabStaticLib
-    
+
     configDynExe              = toFlag elabDynExe
     configGHCiLib             = toFlag elabGHCiLib
     configProfExe             = mempty

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -284,6 +284,7 @@ instance Arbitrary ProjectConfig where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
+        <*> arbitrary
         <*> (MapMappend . fmap getNonMEmpty . Map.fromList
                <$> shortListOf 3 arbitrary)
         -- package entries with no content are equivalent to
@@ -297,7 +298,8 @@ instance Arbitrary ProjectConfig where
                          , projectConfigShared = x5
                          , projectConfigProvenance = x6
                          , projectConfigLocalPackages = x7
-                         , projectConfigSpecificPackage = x8 } =
+                         , projectConfigNonLocalPackages = x8
+                         , projectConfigSpecificPackage = x9 } =
       [ ProjectConfig { projectPackages = x0'
                       , projectPackagesOptional = x1'
                       , projectPackagesRepo = x2'
@@ -306,11 +308,12 @@ instance Arbitrary ProjectConfig where
                       , projectConfigShared = x5'
                       , projectConfigProvenance = x6'
                       , projectConfigLocalPackages = x7'
+                      , projectConfigNonLocalPackages = x8'
                       , projectConfigSpecificPackage = (MapMappend
-                                                         (fmap getNonMEmpty x8')) }
-      | ((x0', x1', x2', x3'), (x4', x5', x6', x7', x8'))
+                                                         (fmap getNonMEmpty x9')) }
+      | ((x0', x1', x2', x3'), (x4', x5', x6', x7', x8', x9'))
           <- shrink ((x0, x1, x2, x3),
-                      (x4, x5, x6, x7, fmap NonMEmpty (getMapMappend x8)))
+                      (x4, x5, x6, x7, x8, fmap NonMEmpty (getMapMappend x9)))
       ]
 
 newtype PackageLocationString


### PR DESCRIPTION
Before non-local packages would receive all their configuration like this:

```
  perpkg = maybe mempty f (Map.lookup (packageName pkg) perPackageConfig)
```

If there is no explicit configuration for a package the default `mempty` is used.

We add `projectConfigNonLocalPackages :: PackageConfig` field to `ProjectConfig`. `projectConfigNonLocalPackages` reflects cabals global configuration. Instead of falling back back to `mempty` directly we lookup up the desigured configuration in this new field.

- Currently `projectConfigNonLocalPackages` is the same as `projectConfigLocalPackages`. We need to sort out what we want here.
- Building with `documentation: True` does not work yet. But it will once we sort out https://github.com/haskell/cabal/issues/4737
- Find a suitable verb: "Haddocking package-x.y (lib)..." sounds strange


Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
