### PR TITLE
Apply 'any' qualifier to new-freeze constraints (fixes #4832).

### DIFF
--- a/cabal-install/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/Distribution/Client/CmdFreeze.hs
@@ -173,7 +173,7 @@ projectFreezeConstraints plan =
     versionConstraints :: Map PackageName [(UserConstraint, ConstraintSource)]
     versionConstraints =
       Map.mapWithKey
-        (\p v -> [(UserConstraint (UserQualified UserQualToplevel p) (PackagePropertyVersion v),
+        (\p v -> [(UserConstraint (UserAnyQualifier p) (PackagePropertyVersion v),
                    ConstraintSourceFreeze)])
         versionRanges
 

--- a/cabal-testsuite/PackageTests/NewFreeze/cabal.project
+++ b/cabal-testsuite/PackageTests/NewFreeze/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/NewFreeze/my-local-package.cabal
+++ b/cabal-testsuite/PackageTests/NewFreeze/my-local-package.cabal
@@ -1,0 +1,9 @@
+name: my-local-package
+version: 1.0
+cabal-version: >= 1.20
+build-type: Simple
+
+library
+  build-depends: base, my-library-dep
+  build-tool-depends: my-build-tool-dep:my-build-tool >= 2
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewFreeze/new_freeze.out
+++ b/cabal-testsuite/PackageTests/NewFreeze/new_freeze.out
@@ -1,0 +1,29 @@
+# cabal update
+Downloading the latest package list from test-local-repo
+# cabal new-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - my-build-tool-dep-1.0 (exe:my-build-tool) (requires download & build)
+ - my-build-tool-dep-3.0 (exe:my-build-tool) (requires download & build)
+ - my-library-dep-1.0 (lib) (requires download & build)
+ - my-local-package-1.0 (lib) (first run)
+# cabal new-freeze
+Resolving dependencies...
+Wrote freeze file: <ROOT>/new_freeze.dist/source/cabal.project.freeze
+# cabal new-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - my-build-tool-dep-1.0 (exe:my-build-tool) (requires download & build)
+ - my-build-tool-dep-2.0 (exe:my-build-tool) (requires download & build)
+ - my-library-dep-1.0 (lib) (requires download & build)
+ - my-local-package-1.0 (lib) (first run)
+# cabal new-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - my-build-tool-dep-1.0 (exe:my-build-tool) (requires download & build)
+ - my-build-tool-dep-3.0 (exe:my-build-tool) (requires download & build)
+ - my-library-dep-1.0 (lib) (requires download & build)
+ - my-local-package-1.0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/NewFreeze/new_freeze.test.hs
+++ b/cabal-testsuite/PackageTests/NewFreeze/new_freeze.test.hs
@@ -1,0 +1,49 @@
+import Test.Cabal.Prelude
+import Control.Monad.IO.Class
+import System.Directory
+
+-- Test that 'cabal new-freeze' works with multiple versions of a build tool
+-- dependency.
+--
+-- The repository contains versions 1.0, 2.0, and 3.0 of the build tool. There
+-- is one local package, which requires >= 2, and a library dependency of the
+-- local package, which requires < 2, so cabal should pick versions 1.0 and 3.0
+-- of the build tool when there are no constraints.
+main = cabalTest $ withSourceCopy $ do
+  withRepo "repo" $ do
+    cabal' "new-build" ["--dry-run"] >>= assertUsesLatestBuildTool
+
+    -- Force the project to use versions 1.0 and 2.0 of the build tool.
+    cabal "new-freeze" ["--constraint=any.my-build-tool-dep < 3"]
+
+    cwd <- fmap testCurrentDir getTestEnv
+    let freezeFile = cwd </> "cabal.project.freeze"
+
+    -- The freeze file should specify a version range that includes both
+    -- versions of the build tool from the install plan. (This constraint will
+    -- be replaced with two exe qualified constraints once #3502 is fully
+    -- implemented).
+    assertFileDoesContain freezeFile "any.my-build-tool-dep ==1.0 || ==2.0"
+
+    -- The library dependency should have a constraint on an exact version.
+    assertFileDoesContain freezeFile "any.my-library-dep ==1.0"
+
+    -- The local package should be unconstrained.
+    assertFileDoesNotContain freezeFile "my-local-package"
+
+    -- cabal should be able to find an install plan that fits the constraints
+    -- from the freeze file.
+    cabal' "new-build" ["--dry-run"] >>= assertDoesNotUseLatestBuildTool
+
+    -- cabal should choose the latest version again after the freeze file is
+    -- removed.
+    liftIO $ removeFile freezeFile
+    cabal' "new-build" ["--dry-run"] >>= assertUsesLatestBuildTool
+  where
+    assertUsesLatestBuildTool out = do
+      assertOutputContains "my-build-tool-dep-3.0 (exe:my-build-tool)" out
+      assertOutputDoesNotContain "my-build-tool-dep-2.0" out
+
+    assertDoesNotUseLatestBuildTool out = do
+      assertOutputContains "my-build-tool-dep-2.0 (exe:my-build-tool)" out
+      assertOutputDoesNotContain "my-build-tool-dep-3.0" out

--- a/cabal-testsuite/PackageTests/NewFreeze/repo/my-build-tool-dep-1.0/my-build-tool-dep.cabal
+++ b/cabal-testsuite/PackageTests/NewFreeze/repo/my-build-tool-dep-1.0/my-build-tool-dep.cabal
@@ -1,0 +1,9 @@
+name: my-build-tool-dep
+version: 1.0
+cabal-version: >= 1.20
+build-type: Simple
+
+executable my-build-tool
+  main-is: Main.hs
+  build-depends: base
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewFreeze/repo/my-build-tool-dep-2.0/my-build-tool-dep.cabal
+++ b/cabal-testsuite/PackageTests/NewFreeze/repo/my-build-tool-dep-2.0/my-build-tool-dep.cabal
@@ -1,0 +1,9 @@
+name: my-build-tool-dep
+version: 2.0
+cabal-version: >= 1.20
+build-type: Simple
+
+executable my-build-tool
+  main-is: Main.hs
+  build-depends: base
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewFreeze/repo/my-build-tool-dep-3.0/my-build-tool-dep.cabal
+++ b/cabal-testsuite/PackageTests/NewFreeze/repo/my-build-tool-dep-3.0/my-build-tool-dep.cabal
@@ -1,0 +1,9 @@
+name: my-build-tool-dep
+version: 3.0
+cabal-version: >= 1.20
+build-type: Simple
+
+executable my-build-tool
+  main-is: Main.hs
+  build-depends: base
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewFreeze/repo/my-library-dep-1.0/my-library-dep.cabal
+++ b/cabal-testsuite/PackageTests/NewFreeze/repo/my-library-dep-1.0/my-library-dep.cabal
@@ -1,0 +1,9 @@
+name: my-library-dep
+version: 1.0
+cabal-version: >= 1.20
+build-type: Simple
+
+library
+  build-depends: base
+  build-tool-depends: my-build-tool-dep:my-build-tool < 2
+  default-language: Haskell2010


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

new-freeze produces constraints that allow all versions of each package from the
install plan, in order to constrain setup and build tool dependencies without
using qualified constraints. Since the constraints should apply to top-level,
setup, and build tool dependencies, they should use an 'any' qualifier.

I also added a package test for new-freeze.