### PR TITLE
Initialize globalCacheDir in baseSavedConfig

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -421,6 +421,7 @@ instance Semigroup SavedConfig where
 baseSavedConfig :: IO SavedConfig
 baseSavedConfig = do
   userPrefix <- defaultCabalDir
+  cacheDir   <- defaultCacheDir
   logsDir    <- defaultLogsDir
   worldFile  <- defaultWorldFile
   return mempty {
@@ -433,6 +434,7 @@ baseSavedConfig = do
       prefix             = toFlag (toPathTemplate userPrefix)
     },
     savedGlobalFlags = mempty {
+      globalCacheDir     = toFlag cacheDir,
       globalLogsDir      = toFlag logsDir,
       globalWorldFile    = toFlag worldFile
     }


### PR DESCRIPTION
globalCacheDir (remote-repo-cache) is now initialized by default because only
cabal-install can determine the correct default location relative to
defaultCabalDir. The globalLogsDir (build-logs) and globalWorldFile (world-file)
already had the same behavior.

Resolves: #4845.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

I tested this change by removing the `remote-repo-cache` line from my `$HOME/.cabal/config` and confirming that a simple `cabal update` works. (This command requires `remote-repo-cache` to be set.)
