### PR TITLE
RFC: Relax coding guideline regarding module imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ Conventions
 
 * For local imports (Cabal module importing Cabal module), import lists
   are NOT required (although you may use them at your discretion.)  For
-  third-party and standard library imports, please use explicit import
-  lists.
+  third-party and standard library imports, please use either qualified imports
+  or explicit import lists.
 
 * You can use basically any GHC extension supported by a GHC in our
   support window, except Template Haskell, which would cause


### PR DESCRIPTION
I notice imports like

    import qualified Text.PrettyPrint as Disp
          ( Doc, render, char, text )

which seem overly precise to me, when `Disp.` is only used
locally as a module prefix, and there's no other imports sharing
the same module prefix.

Instead, it should suffice to either use

    import qualified Text.PrettyPrint as Disp

or

    import Text.PrettyPrint
          ( Doc, render, char, text )

or in rare cases even

    import Text.PrettyPrint as Disp
          ( Doc, render, char, text )

Hence this relaxes the coding guidelines to allow these simpler forms
to be used.
