### PR TITLE
Look for install includes in buildpref as well

### DIFF
--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -171,7 +171,7 @@ copyComponent verbosity pkg_descr lbi (CLib lib) clbi copydest = do
 
     -- install include files for all compilers - they may be needed to compile
     -- haskell files (using the CPP extension)
-    installIncludeFiles verbosity lib incPref
+    installIncludeFiles verbosity lib buildPref incPref
 
     case compilerFlavor (compiler lbi) of
       GHC   -> GHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr lib clbi
@@ -247,11 +247,12 @@ installDataFiles verbosity pkg_descr destDataDir =
 
 -- | Install the files listed in install-includes for a library
 --
-installIncludeFiles :: Verbosity -> Library -> FilePath -> IO ()
-installIncludeFiles verbosity lib destIncludeDir = do
+installIncludeFiles :: Verbosity -> Library -> FilePath -> FilePath -> IO ()
+installIncludeFiles verbosity lib buildPref destIncludeDir = do
     let relincdirs = "." : filter isRelative (includeDirs lbi)
         lbi = libBuildInfo lib
-    incs <- traverse (findInc relincdirs) (installIncludes lbi)
+        incdirs = relincdirs ++ [ buildPref </> dir | dir <- relincdirs ]
+    incs <- traverse (findInc incdirs) (installIncludes lbi)
     sequence_
       [ do createDirectoryIfMissingVerbose verbosity True destDir
            installOrdinaryFile verbosity srcFile destFile

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -1,6 +1,8 @@
 -*-change-log-*-
 
 2.2.0.0 (current development version)
+	* `copyCompoment` and `installIncludeFiles` will look for include
+	  headers in the build preference as well.
 	* Added cxx-options and cxx-sources build info fields for seperate
 	  compilation of C++ source files (#3700)
 	* Remove unused '--allow-newer'/'--allow-older' support (#4527)

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -1,8 +1,9 @@
 -*-change-log-*-
 
 2.2.0.0 (current development version)
-	* `copyCompoment` and `installIncludeFiles` will look for include
-	  headers in the build preference as well.
+	* `copyCompomenti` and `installIncludeFiles` will look for include
+	  headers in the build preference dir ('dist/build/...' by default)
+	  as well.
 	* Added cxx-options and cxx-sources build info fields for seperate
 	  compilation of C++ source files (#3700)
 	* Remove unused '--allow-newer'/'--allow-older' support (#4527)


### PR DESCRIPTION
When installing a lirbary, we should look for it's headers in it's 'build' preference first, then relative to the current path.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
