### PR TITLE
Global configuration for project commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cabal-sandbox/
 cabal.sandbox.config
 cabal.project.local
+cabal.config.local
 .ghc.environment.*
 cabal-dev/
 .hpc/

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -481,11 +481,17 @@ following sources (later entries override earlier ones):
 
 1. ``~/.cabal/config`` (the user-wide global configuration)
 
-2. ``cabal.project`` (the project configuratoin)
+2. ``cabal.config.local`` (the project-wide global configuration)
 
-3. ``cabal.project.freeze`` (the output of ``cabal new-freeze``)
+3. ``cabal.project`` (the project configuration)
 
-4. ``cabal.project.local`` (the output of ``cabal new-configure``)
+4. ``cabal.project.freeze`` (the output of ``cabal new-freeze``)
+
+5. ``cabal.project.local`` (the output of ``cabal new-configure``)
+
+The project configuration files ``cabal.project`` and ``cabal.project.local``
+specify options for project packages only, while the global configuration files
+``~/.cabal/config`` and ``cabal.config.local`` affect *all* packages.
 
 
 Specifying the local packages

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -242,7 +242,7 @@ establishDummyProjectBaseContext verbosity cliConfig tmpDir localPackages = do
     createDirectoryIfMissingVerbose verbosity True $ distProjectCacheDirectory distDirLayout
 
     globalConfig <- runRebuild ""
-                  $ readGlobalConfig verbosity
+                  $ readGlobalConfig verbosity distDirLayout
                   $ projectConfigConfigFile
                   $ projectConfigShared cliConfig
     let projectConfig = globalConfig <> cliConfig

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -93,7 +93,7 @@ import Distribution.Simple.Command
 import Distribution.Simple.Program
          ( defaultProgramDb )
 import Distribution.Simple.Utils
-         ( die', notice, warn, lowercase, cabalVersion )
+         ( debug, die', notice, warn, lowercase, cabalVersion )
 import Distribution.Compiler
          ( CompilerFlavor(..), defaultCompilerFlavor )
 import Distribution.Verbosity
@@ -614,7 +614,7 @@ extendToEffectiveConfig config = do
 loadRawConfig :: Verbosity -> Flag FilePath -> IO SavedConfig
 loadRawConfig verbosity configFileFlag = do
   (source, configFile) <- getConfigFilePathAndSource configFileFlag
-  notice verbosity $ "Global config file path source is " ++ sourceMsg source ++ "."
+  debug verbosity $ "Global config file path source is " ++ sourceMsg source ++ "."
   minp <- loadExactConfig verbosity configFile
   case minp of
     Nothing -> createDefaultConfigFile verbosity configFile
@@ -636,10 +636,10 @@ loadExactConfig verbosity configFile = do
   minp <- readConfigFile mempty configFile
   case minp of
     Nothing -> do
-      notice verbosity $ "Config file " ++ configFile ++ " not found."
+      debug verbosity $ "Config file " ++ configFile ++ " not found."
       return Nothing
     Just (ParseOk ws conf) -> do
-      notice verbosity $ "Config file " ++ configFile ++ " loaded."
+      debug verbosity $ "Config file " ++ configFile ++ " loaded."
       unless (null ws) $ warn verbosity $
         unlines (map (showPWarning configFile) ws)
       return (Just conf)

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -192,9 +192,9 @@ convertLegacyGlobalConfig
       savedHaddockFlags      = haddockFlags
     } =
     mempty {
-      projectConfigShared        = configAllPackages,
-      projectConfigLocalPackages = configLocalPackages,
-      projectConfigBuildOnly     = configBuildOnly
+      projectConfigShared         = configAllPackages,
+      projectConfigGlobalPackages = configLocalPackages,
+      projectConfigBuildOnly      = configBuildOnly
     }
   where
     --TODO: [code cleanup] eliminate use of default*Flags here and specify the
@@ -240,6 +240,7 @@ convertLegacyProjectConfig
       projectConfigBuildOnly       = configBuildOnly,
       projectConfigShared          = configAllPackages,
       projectConfigProvenance      = mempty,
+      projectConfigGlobalPackages  = mempty,
       projectConfigLocalPackages   = configLocalPackages,
       projectConfigSpecificPackage = fmap perPackage legacySpecificConfig
     }

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -113,6 +113,10 @@ data ProjectConfig
        projectConfigShared          :: ProjectConfigShared,
        projectConfigProvenance      :: Set ProjectConfigProvenance,
 
+       -- | Configuration to be applied to all packages,
+       -- whether named in `cabal.project` or not.
+       projectConfigGlobalPackages  :: PackageConfig,
+
        -- | Configuration to be applied to *local* packages; i.e.,
        -- any packages which are explicitly named in `cabal.project`.
        projectConfigLocalPackages   :: PackageConfig,

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -35,6 +35,8 @@
 	stay within the load command size limits of macOSs mach-o linker.
 	* Use [lfxtb] letters to differentiate component kind instead of
 	opaque "c" in dist-dir layout.
+	* New config file 'cabal.config.local' to specify project-wide
+	global options for project commands.
 
 2.0.0.1 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> October 2017
 	* Support for GHC's numeric -g debug levels (#4673).

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -284,6 +284,7 @@ instance Arbitrary ProjectConfig where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
+        <*> arbitrary
         <*> (MapMappend . fmap getNonMEmpty . Map.fromList
                <$> shortListOf 3 arbitrary)
         -- package entries with no content are equivalent to
@@ -297,7 +298,8 @@ instance Arbitrary ProjectConfig where
                          , projectConfigShared = x5
                          , projectConfigProvenance = x6
                          , projectConfigLocalPackages = x7
-                         , projectConfigSpecificPackage = x8 } =
+                         , projectConfigSpecificPackage = x8
+                         , projectConfigGlobalPackages = x9 } =
       [ ProjectConfig { projectPackages = x0'
                       , projectPackagesOptional = x1'
                       , projectPackagesRepo = x2'
@@ -306,11 +308,12 @@ instance Arbitrary ProjectConfig where
                       , projectConfigShared = x5'
                       , projectConfigProvenance = x6'
                       , projectConfigLocalPackages = x7'
-                      , projectConfigSpecificPackage = (MapMappend
-                                                         (fmap getNonMEmpty x8')) }
-      | ((x0', x1', x2', x3'), (x4', x5', x6', x7', x8'))
+                      , projectConfigSpecificPackage =
+                          MapMappend (fmap getNonMEmpty x8')
+                      , projectConfigGlobalPackages = x9' }
+      | ((x0', x1', x2', x3'), (x4', x5', x6', x7', x8', x9'))
           <- shrink ((x0, x1, x2, x3),
-                      (x4, x5, x6, x7, fmap NonMEmpty (getMapMappend x8)))
+                      (x4, x5, x6, x7, fmap NonMEmpty (getMapMappend x8), x9))
       ]
 
 newtype PackageLocationString


### PR DESCRIPTION
## Commits 

Two deficiencies described in #3883 are corrected:

1. Global configuration options are not correctly applied to all packages when using project commands. 
2. `cabal.project` offers no mechanism to specify project-wide global options.

### Apply global configuration to all packages in project commands 

The global configuration in ~/.cabal/config or CABAL_CONFIG should be applied to
all packages, even in the project (new-*) commands. Previously, package
configuration fields applied only to packages in the actual project. A new
field (projectConfigGlobalPackages) is added to ProjectConfig to track the
global package configuration.

See also: #3883 #4646

### readGlobalConfig: Also consider cabal.config files in project root

If there is a cabal.config.local file in the project root directory,
readGlobalConfig reads it after ~/.cabal/config. This is intended to allow the
user to specify site-specific global options on a per-project basis. Global
options cannot be specified in cabal.project.local, which applies options only
to packages in the project.

See also: #3883 #4646

## Checklist

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [ ] ~If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.~

## Testing

I tested these changes by implementing #4646 in terms of global configuration files.