### PR TITLE
Target package names

### DIFF
--- a/cabal-install/Distribution/Client/CmdBench.hs
+++ b/cabal-install/Distribution/Client/CmdBench.hs
@@ -162,17 +162,20 @@ selectPackageTargets targetSelector targets
 -- For the @bench@ command we just need to check it is a benchmark, in addition
 -- to the basic checks on being buildable etc.
 --
-selectComponentTarget :: PackageId -> ComponentName -> SubComponentTarget
+selectComponentTarget :: SubComponentTarget
                       -> AvailableTarget k -> Either TargetProblem k
-selectComponentTarget pkgid cname subtarget@WholeComponent t
+selectComponentTarget subtarget@WholeComponent t
   | CBenchName _ <- availableTargetComponentName t
   = either (Left . TargetProblemCommon) return $
-           selectComponentTargetBasic pkgid cname subtarget t
+           selectComponentTargetBasic subtarget t
   | otherwise
-  = Left (TargetProblemComponentNotBenchmark pkgid cname)
+  = Left (TargetProblemComponentNotBenchmark (availableTargetPackageId t)
+                                             (availableTargetComponentName t))
 
-selectComponentTarget pkgid cname subtarget _
-  = Left (TargetProblemIsSubComponent pkgid cname subtarget)
+selectComponentTarget subtarget t
+  = Left (TargetProblemIsSubComponent (availableTargetPackageId t)
+                                      (availableTargetComponentName t)
+                                       subtarget)
 
 -- | The various error conditions that can occur when matching a
 -- 'TargetSelector' against 'AvailableTarget's for the @bench@ command.

--- a/cabal-install/Distribution/Client/CmdBench.hs
+++ b/cabal-install/Distribution/Client/CmdBench.hs
@@ -127,7 +127,7 @@ benchAction (applyFlagDefaults -> (configFlags, configExFlags, installFlags, had
 -- For the @bench@ command we select all buildable benchmarks,
 -- or fail if there are no benchmarks or no buildable benchmarks.
 --
-selectPackageTargets :: TargetSelector PackageId
+selectPackageTargets :: TargetSelector
                      -> [AvailableTarget k] -> Either TargetProblem [k]
 selectPackageTargets targetSelector targets
 
@@ -181,13 +181,13 @@ data TargetProblem =
      TargetProblemCommon        TargetProblemCommon
 
      -- | The 'TargetSelector' matches benchmarks but none are buildable
-   | TargetProblemNoneEnabled  (TargetSelector PackageId) [AvailableTarget ()]
+   | TargetProblemNoneEnabled  TargetSelector [AvailableTarget ()]
 
      -- | There are no targets at all
-   | TargetProblemNoTargets    (TargetSelector PackageId)
+   | TargetProblemNoTargets    TargetSelector
 
      -- | The 'TargetSelector' matches targets but no benchmarks
-   | TargetProblemNoBenchmarks (TargetSelector PackageId)
+   | TargetProblemNoBenchmarks TargetSelector
 
      -- | The 'TargetSelector' refers to a component that is not a benchmark
    | TargetProblemComponentNotBenchmark PackageId ComponentName

--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -159,11 +159,11 @@ selectPackageTargets targetSelector targets
 --
 -- For the @build@ command we just need the basic checks on being buildable etc.
 --
-selectComponentTarget :: PackageId -> ComponentName -> SubComponentTarget
+selectComponentTarget :: SubComponentTarget
                       -> AvailableTarget k -> Either TargetProblem k
-selectComponentTarget pkgid cname subtarget =
+selectComponentTarget subtarget =
     either (Left . TargetProblemCommon) Right
-  . selectComponentTargetBasic pkgid cname subtarget
+  . selectComponentTargetBasic subtarget
 
 
 -- | The various error conditions that can occur when matching a

--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -126,7 +126,7 @@ buildAction (applyFlagDefaults -> (configFlags, configExFlags, installFlags, had
 -- For the @build@ command select all components except non-buildable and disabled
 -- tests\/benchmarks, fail if there are no such components
 --
-selectPackageTargets :: TargetSelector PackageId
+selectPackageTargets :: TargetSelector
                      -> [AvailableTarget k] -> Either TargetProblem [k]
 selectPackageTargets targetSelector targets
 
@@ -173,10 +173,10 @@ data TargetProblem =
      TargetProblemCommon       TargetProblemCommon
 
      -- | The 'TargetSelector' matches targets but none are buildable
-   | TargetProblemNoneEnabled (TargetSelector PackageId) [AvailableTarget ()]
+   | TargetProblemNoneEnabled TargetSelector [AvailableTarget ()]
 
      -- | There are no targets at all
-   | TargetProblemNoTargets   (TargetSelector PackageId)
+   | TargetProblemNoTargets   TargetSelector
   deriving (Eq, Show)
 
 reportTargetProblems :: Verbosity -> [TargetProblem] -> IO a

--- a/cabal-install/Distribution/Client/CmdErrorMessages.hs
+++ b/cabal-install/Distribution/Client/CmdErrorMessages.hs
@@ -84,7 +84,7 @@ sortGroupOn key = map (\xs@(x:_) -> (key x, xs))
 -- Renderering for a few project and package types
 --
 
-renderTargetSelector :: TargetSelector PackageId -> String
+renderTargetSelector :: TargetSelector -> String
 renderTargetSelector (TargetPackage _ pkgid Nothing) =
     "the package " ++ display pkgid
 
@@ -129,20 +129,20 @@ optionalStanza _              = Nothing
 
 -- | Does the 'TargetSelector' potentially refer to one package or many?
 --
-targetSelectorPluralPkgs :: TargetSelector a -> Plural
+targetSelectorPluralPkgs :: TargetSelector -> Plural
 targetSelectorPluralPkgs (TargetAllPackages _)     = Plural
 targetSelectorPluralPkgs (TargetPackage _ _ _)     = Singular
 targetSelectorPluralPkgs (TargetComponent _ _ _)   = Singular
 targetSelectorPluralPkgs (TargetPackageName _)     = Singular
 
 -- | Does the 'TargetSelector' refer to 
-targetSelectorRefersToPkgs :: TargetSelector a -> Bool
+targetSelectorRefersToPkgs :: TargetSelector -> Bool
 targetSelectorRefersToPkgs (TargetAllPackages  mkfilter) = isNothing mkfilter
 targetSelectorRefersToPkgs (TargetPackage  _ _ mkfilter) = isNothing mkfilter
 targetSelectorRefersToPkgs (TargetComponent _ _ _)       = False
 targetSelectorRefersToPkgs (TargetPackageName _)         = True
 
-targetSelectorFilter :: TargetSelector a -> Maybe ComponentKindFilter
+targetSelectorFilter :: TargetSelector -> Maybe ComponentKindFilter
 targetSelectorFilter (TargetPackage  _ _ mkfilter) = mkfilter
 targetSelectorFilter (TargetAllPackages  mkfilter) = mkfilter
 targetSelectorFilter (TargetComponent _ _ _)       = Nothing
@@ -238,7 +238,7 @@ renderTargetProblemCommon verb (TargetProblemNoSuchComponent pkgid cname) =
 -- This renders an error message for those cases.
 --
 renderTargetProblemNoneEnabled :: String
-                               -> TargetSelector PackageId
+                               -> TargetSelector
                                -> [AvailableTarget ()]
                                -> String
 renderTargetProblemNoneEnabled verb targetSelector targets =
@@ -300,7 +300,7 @@ renderTargetProblemNoneEnabled verb targetSelector targets =
 -- | Several commands have a @TargetProblemNoTargets@ problem constructor.
 -- This renders an error message for those cases.
 --
-renderTargetProblemNoTargets :: String -> TargetSelector PackageId -> String
+renderTargetProblemNoTargets :: String -> TargetSelector -> String
 renderTargetProblemNoTargets verb targetSelector =
     "Cannot " ++ verb ++ " " ++ renderTargetSelector targetSelector
  ++ " because " ++ reason targetSelector ++ ". "

--- a/cabal-install/Distribution/Client/CmdErrorMessages.hs
+++ b/cabal-install/Distribution/Client/CmdErrorMessages.hs
@@ -85,12 +85,14 @@ sortGroupOn key = map (\xs@(x:_) -> (key x, xs))
 --
 
 renderTargetSelector :: TargetSelector -> String
-renderTargetSelector (TargetPackage _ pkgid Nothing) =
-    "the package " ++ display pkgid
+renderTargetSelector (TargetPackage _ pkgids Nothing) =
+    "the " ++ plural (listPlural pkgids) "package" "packages" ++ " "
+ ++ renderListCommaAnd (map display pkgids)
 
-renderTargetSelector (TargetPackage _ pkgid (Just kfilter)) =
+renderTargetSelector (TargetPackage _ pkgids (Just kfilter)) =
     "the " ++ renderComponentKind Plural kfilter
- ++ " in the package " ++ display pkgid
+ ++ " in the " ++ plural (listPlural pkgids) "package" "packages" ++ " "
+ ++ renderListCommaAnd (map display pkgids)
 
 renderTargetSelector (TargetAllPackages Nothing) =
     "all the packages in the project"
@@ -131,11 +133,11 @@ optionalStanza _              = Nothing
 --
 targetSelectorPluralPkgs :: TargetSelector -> Plural
 targetSelectorPluralPkgs (TargetAllPackages _)     = Plural
-targetSelectorPluralPkgs (TargetPackage _ _ _)     = Singular
+targetSelectorPluralPkgs (TargetPackage _ pids _)  = listPlural pids
 targetSelectorPluralPkgs (TargetComponent _ _ _)   = Singular
 targetSelectorPluralPkgs (TargetPackageName _)     = Singular
 
--- | Does the 'TargetSelector' refer to 
+-- | Does the 'TargetSelector' refer to packages or to components?
 targetSelectorRefersToPkgs :: TargetSelector -> Bool
 targetSelectorRefersToPkgs (TargetAllPackages  mkfilter) = isNothing mkfilter
 targetSelectorRefersToPkgs (TargetPackage  _ _ mkfilter) = isNothing mkfilter

--- a/cabal-install/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/Distribution/Client/CmdHaddock.hs
@@ -165,11 +165,11 @@ selectPackageTargets haddockFlags targetSelector targets
 -- For the @haddock@ command we just need the basic checks on being buildable
 -- etc.
 --
-selectComponentTarget :: PackageId -> ComponentName -> SubComponentTarget
+selectComponentTarget :: SubComponentTarget
                       -> AvailableTarget k -> Either TargetProblem k
-selectComponentTarget pkgid cname subtarget =
+selectComponentTarget subtarget =
     either (Left . TargetProblemCommon) Right
-  . selectComponentTargetBasic pkgid cname subtarget
+  . selectComponentTargetBasic subtarget
 
 
 -- | The various error conditions that can occur when matching a

--- a/cabal-install/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/Distribution/Client/CmdHaddock.hs
@@ -122,7 +122,7 @@ haddockAction (applyFlagDefaults -> (configFlags, configExFlags, installFlags, h
 -- depending on the @--executables@ flag we also select all the buildable exes.
 -- We do similarly for test-suites, benchmarks and foreign libs.
 --
-selectPackageTargets  :: HaddockFlags -> TargetSelector PackageId
+selectPackageTargets  :: HaddockFlags -> TargetSelector
                       -> [AvailableTarget k] -> Either TargetProblem [k]
 selectPackageTargets haddockFlags targetSelector targets
 
@@ -179,10 +179,10 @@ data TargetProblem =
      TargetProblemCommon       TargetProblemCommon
 
      -- | The 'TargetSelector' matches targets but none are buildable
-   | TargetProblemNoneEnabled (TargetSelector PackageId) [AvailableTarget ()]
+   | TargetProblemNoneEnabled TargetSelector [AvailableTarget ()]
 
      -- | There are no targets at all
-   | TargetProblemNoTargets   (TargetSelector PackageId)
+   | TargetProblemNoTargets   TargetSelector
   deriving (Eq, Show)
 
 reportTargetProblems :: Verbosity -> [TargetProblem] -> IO a

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -136,7 +136,8 @@ installAction (applyFlagDefaults -> (configFlags, configExFlags, installFlags, h
                  tmpDir
                  packageSpecifiers
 
-    let targetSelectors = TargetPackageName <$> packageNames
+    let targetSelectors = [ TargetPackageNamed pn Nothing
+                          | pn <- packageNames ]
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -299,11 +299,11 @@ selectPackageTargets targetSelector targets
 --
 -- For the @build@ command we just need the basic checks on being buildable etc.
 --
-selectComponentTarget :: PackageId -> ComponentName -> SubComponentTarget
+selectComponentTarget :: SubComponentTarget
                       -> AvailableTarget k -> Either TargetProblem k
-selectComponentTarget pkgid cname subtarget =
+selectComponentTarget subtarget =
     either (Left . TargetProblemCommon) Right
-  . selectComponentTargetBasic pkgid cname subtarget
+  . selectComponentTargetBasic subtarget
 
 
 -- | The various error conditions that can occur when matching a

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -191,7 +191,7 @@ symlinkBuiltPackage :: (UnitId -> FilePath) -- ^ A function to get an UnitId's
                                             -- store directory
                     -> FilePath -- ^ Where to put the symlink
                     -> ( UnitId
-                        , [(ComponentTarget, [TargetSelector PackageId])] )
+                        , [(ComponentTarget, [TargetSelector])] )
                      -> IO ()
 symlinkBuiltPackage mkSourceBinDir destDir (pkg, components) =
   traverse_ (symlinkBuiltExe (mkSourceBinDir pkg) destDir) exes
@@ -265,7 +265,7 @@ establishDummyProjectBaseContext verbosity cliConfig tmpDir localPackages = do
 -- For the @build@ command select all components except non-buildable and disabled
 -- tests\/benchmarks, fail if there are no such components
 --
-selectPackageTargets :: TargetSelector PackageId
+selectPackageTargets :: TargetSelector
                      -> [AvailableTarget k] -> Either TargetProblem [k]
 selectPackageTargets targetSelector targets
 
@@ -312,10 +312,10 @@ data TargetProblem =
      TargetProblemCommon       TargetProblemCommon
 
      -- | The 'TargetSelector' matches targets but none are buildable
-   | TargetProblemNoneEnabled (TargetSelector PackageId) [AvailableTarget ()]
+   | TargetProblemNoneEnabled TargetSelector [AvailableTarget ()]
 
      -- | There are no targets at all
-   | TargetProblemNoTargets   (TargetSelector PackageId)
+   | TargetProblemNoTargets   TargetSelector
   deriving (Eq, Show)
 
 reportTargetProblems :: Verbosity -> [TargetProblem] -> IO a

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -215,11 +215,11 @@ selectPackageTargets targetSelector targets
 --
 -- For the @repl@ command we just need the basic checks on being buildable etc.
 --
-selectComponentTarget :: PackageId -> ComponentName -> SubComponentTarget
+selectComponentTarget :: SubComponentTarget
                       -> AvailableTarget k -> Either TargetProblem k
-selectComponentTarget pkgid cname subtarget =
+selectComponentTarget subtarget =
     either (Left . TargetProblemCommon) Right
-  . selectComponentTargetBasic pkgid cname subtarget
+  . selectComponentTargetBasic subtarget
 
 
 -- | The various error conditions that can occur when matching a

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -153,7 +153,7 @@ replAction (applyFlagDefaults -> (configFlags, configExFlags, installFlags, hadd
 -- Fail if there are no buildable lib\/exe components, or if there are
 -- multiple libs or exes.
 --
-selectPackageTargets  :: TargetSelector PackageId
+selectPackageTargets  :: TargetSelector
                       -> [AvailableTarget k] -> Either TargetProblem [k]
 selectPackageTargets targetSelector targets
 
@@ -229,13 +229,13 @@ data TargetProblem =
      TargetProblemCommon       TargetProblemCommon
 
      -- | The 'TargetSelector' matches targets but none are buildable
-   | TargetProblemNoneEnabled (TargetSelector PackageId) [AvailableTarget ()]
+   | TargetProblemNoneEnabled TargetSelector [AvailableTarget ()]
 
      -- | There are no targets at all
-   | TargetProblemNoTargets   (TargetSelector PackageId)
+   | TargetProblemNoTargets   TargetSelector
 
      -- | A single 'TargetSelector' matches multiple targets
-   | TargetProblemMatchesMultiple (TargetSelector PackageId) [AvailableTarget ()]
+   | TargetProblemMatchesMultiple TargetSelector [AvailableTarget ()]
 
      -- | Multiple 'TargetSelector's match multiple targets
    | TargetProblemMultipleTargets TargetsMap

--- a/cabal-install/Distribution/Client/CmdRun.hs
+++ b/cabal-install/Distribution/Client/CmdRun.hs
@@ -323,17 +323,20 @@ selectPackageTargets targetSelector targets
 -- For the @run@ command we just need to check it is a executable, in addition
 -- to the basic checks on being buildable etc.
 --
-selectComponentTarget :: PackageId -> ComponentName -> SubComponentTarget
+selectComponentTarget :: SubComponentTarget
                       -> AvailableTarget k -> Either TargetProblem  k
-selectComponentTarget pkgid cname subtarget@WholeComponent t
+selectComponentTarget subtarget@WholeComponent t
   | CExeName _ <- availableTargetComponentName t
   = either (Left . TargetProblemCommon) return $
-           selectComponentTargetBasic pkgid cname subtarget t
+           selectComponentTargetBasic subtarget t
   | otherwise
-  = Left (TargetProblemComponentNotExe pkgid cname)
+  = Left (TargetProblemComponentNotExe (availableTargetPackageId t)
+                                       (availableTargetComponentName t))
 
-selectComponentTarget pkgid cname subtarget _
-  = Left (TargetProblemIsSubComponent pkgid cname subtarget)
+selectComponentTarget subtarget t
+  = Left (TargetProblemIsSubComponent (availableTargetPackageId t)
+                                      (availableTargetComponentName t)
+                                       subtarget)
 
 -- | The various error conditions that can occur when matching a
 -- 'TargetSelector' against 'AvailableTarget's for the @run@ command.

--- a/cabal-install/Distribution/Client/CmdRun.hs
+++ b/cabal-install/Distribution/Client/CmdRun.hs
@@ -283,7 +283,7 @@ matchingPackagesByUnitId uid =
 -- For the @run@ command we select the exe if there is only one and it's
 -- buildable. Fail if there are no or multiple buildable exe components.
 --
-selectPackageTargets :: TargetSelector PackageId
+selectPackageTargets :: TargetSelector
                      -> [AvailableTarget k] -> Either TargetProblem [k]
 selectPackageTargets targetSelector targets
 
@@ -341,16 +341,16 @@ selectComponentTarget pkgid cname subtarget _
 data TargetProblem =
      TargetProblemCommon       TargetProblemCommon
      -- | The 'TargetSelector' matches targets but none are buildable
-   | TargetProblemNoneEnabled (TargetSelector PackageId) [AvailableTarget ()]
+   | TargetProblemNoneEnabled TargetSelector [AvailableTarget ()]
 
      -- | There are no targets at all
-   | TargetProblemNoTargets   (TargetSelector PackageId)
+   | TargetProblemNoTargets   TargetSelector
 
      -- | The 'TargetSelector' matches targets but no executables
-   | TargetProblemNoExes      (TargetSelector PackageId)
+   | TargetProblemNoExes      TargetSelector
 
      -- | A single 'TargetSelector' matches multiple targets
-   | TargetProblemMatchesMultiple (TargetSelector PackageId) [AvailableTarget ()]
+   | TargetProblemMatchesMultiple TargetSelector [AvailableTarget ()]
 
      -- | Multiple 'TargetSelector's match multiple targets
    | TargetProblemMultipleTargets TargetsMap

--- a/cabal-install/Distribution/Client/CmdTest.hs
+++ b/cabal-install/Distribution/Client/CmdTest.hs
@@ -130,7 +130,7 @@ testAction (applyFlagDefaults -> (configFlags, configExFlags, installFlags, hadd
 -- For the @test@ command we select all buildable test-suites,
 -- or fail if there are no test-suites or no buildable test-suites.
 --
-selectPackageTargets  :: TargetSelector PackageId
+selectPackageTargets  :: TargetSelector
                       -> [AvailableTarget k] -> Either TargetProblem [k]
 selectPackageTargets targetSelector targets
 
@@ -184,13 +184,13 @@ data TargetProblem =
      TargetProblemCommon       TargetProblemCommon
 
      -- | The 'TargetSelector' matches targets but none are buildable
-   | TargetProblemNoneEnabled (TargetSelector PackageId) [AvailableTarget ()]
+   | TargetProblemNoneEnabled TargetSelector [AvailableTarget ()]
 
      -- | There are no targets at all
-   | TargetProblemNoTargets   (TargetSelector PackageId)
+   | TargetProblemNoTargets   TargetSelector
 
      -- | The 'TargetSelector' matches targets but no test-suites
-   | TargetProblemNoTests     (TargetSelector PackageId)
+   | TargetProblemNoTests     TargetSelector
 
      -- | The 'TargetSelector' refers to a component that is not a test-suite
    | TargetProblemComponentNotTest PackageId ComponentName

--- a/cabal-install/Distribution/Client/CmdTest.hs
+++ b/cabal-install/Distribution/Client/CmdTest.hs
@@ -165,17 +165,20 @@ selectPackageTargets targetSelector targets
 -- For the @test@ command we just need to check it is a test-suite, in addition
 -- to the basic checks on being buildable etc.
 --
-selectComponentTarget :: PackageId -> ComponentName -> SubComponentTarget
+selectComponentTarget :: SubComponentTarget
                       -> AvailableTarget k -> Either TargetProblem k
-selectComponentTarget pkgid cname subtarget@WholeComponent t
+selectComponentTarget subtarget@WholeComponent t
   | CTestName _ <- availableTargetComponentName t
   = either (Left . TargetProblemCommon) return $
-           selectComponentTargetBasic pkgid cname subtarget t
+           selectComponentTargetBasic subtarget t
   | otherwise
-  = Left (TargetProblemComponentNotTest pkgid cname)
+  = Left (TargetProblemComponentNotTest (availableTargetPackageId t)
+                                        (availableTargetComponentName t))
 
-selectComponentTarget pkgid cname subtarget _
-  = Left (TargetProblemIsSubComponent pkgid cname subtarget)
+selectComponentTarget subtarget t
+  = Left (TargetProblemIsSubComponent (availableTargetPackageId t)
+                                      (availableTargetComponentName t)
+                                       subtarget)
 
 -- | The various error conditions that can occur when matching a
 -- 'TargetSelector' against 'AvailableTarget's for the @test@ command.

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -393,7 +393,7 @@ runProjectPostBuildPhase verbosity
 -- possible to for different selectors to match the same target. This extra
 -- information is primarily to help make helpful error messages.
 --
-type TargetsMap = Map UnitId [(ComponentTarget, [TargetSelector PackageId])]
+type TargetsMap = Map UnitId [(ComponentTarget, [TargetSelector])]
 
 -- | Given a set of 'TargetSelector's, resolve which 'UnitId's and
 -- 'ComponentTarget's they ought to refer to.
@@ -428,7 +428,7 @@ type TargetsMap = Map UnitId [(ComponentTarget, [TargetSelector PackageId])]
 -- a basis for their own @selectComponentTarget@ implementation.
 --
 resolveTargets :: forall err.
-                  (forall k. TargetSelector PackageId
+                  (forall k. TargetSelector
                           -> [AvailableTarget k]
                           -> Either err [k])
                -> (forall k. PackageId -> ComponentName -> SubComponentTarget
@@ -436,7 +436,7 @@ resolveTargets :: forall err.
                           -> Either err  k )
                -> (TargetProblemCommon -> err)
                -> ElaboratedInstallPlan
-               -> [TargetSelector PackageId]
+               -> [TargetSelector]
                -> Either [err] TargetsMap
 resolveTargets selectPackageTargets selectComponentTarget liftProblem
                installPlan targetSelectors =
@@ -462,8 +462,7 @@ resolveTargets selectPackageTargets selectComponentTarget liftProblem
     -- TODO [required eventually] currently all build targets refer to packages
     -- inside the project. Ultimately this has to be generalised to allow
     -- referring to other packages and targets.
-    checkTarget :: TargetSelector PackageId
-                -> Either err [(UnitId, ComponentTarget)]
+    checkTarget :: TargetSelector -> Either err [(UnitId, ComponentTarget)]
 
     -- We can ask to build any whole package, project-local or a dependency
     checkTarget bt@(TargetPackage _ pkgid mkfilter)

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -465,7 +465,7 @@ resolveTargets selectPackageTargets selectComponentTarget liftProblem
     checkTarget :: TargetSelector -> Either err [(UnitId, ComponentTarget)]
 
     -- We can ask to build any whole package, project-local or a dependency
-    checkTarget bt@(TargetPackage _ pkgid mkfilter)
+    checkTarget bt@(TargetPackage _ [pkgid] mkfilter)
       | Just ats <- fmap (maybe id filterTargetsKind mkfilter)
                   $ Map.lookup pkgid availableTargetsByPackage
       = case selectPackageTargets bt ats of
@@ -475,6 +475,12 @@ resolveTargets selectPackageTargets selectComponentTarget liftProblem
 
       | otherwise
       = Left (liftProblem (TargetProblemNoSuchPackage pkgid))
+
+    checkTarget (TargetPackage _ _ _)
+      = error "TODO: add support for multiple packages in a directory"
+      -- For the moment this error cannot happen here, because it gets
+      -- detected when the package config is being constructed. This case
+      -- will need handling properly when we do add support.
 
     checkTarget bt@(TargetAllPackages mkfilter) =
       let ats = maybe id filterTargetsKind mkfilter

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -94,6 +94,9 @@ module Distribution.Client.ProjectOrchestration (
     cmdCommonHelpTextNewBuildBeta,
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import           Distribution.Client.ProjectConfig
 import           Distribution.Client.ProjectPlanning
                    hiding ( pruneInstallPlanToTargets )
@@ -143,11 +146,7 @@ import           Distribution.Simple.Compiler
 import qualified Data.Monoid as Mon
 import qualified Data.Set as Set
 import qualified Data.Map as Map
-import           Data.Map (Map)
-import           Data.List
-import           Data.Maybe
 import           Data.Either
-import           Control.Monad (void)
 import           Control.Exception (Exception(..), throwIO, assert)
 import           System.Exit (ExitCode(..), exitFailure)
 #ifdef MIN_VERSION_unix

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -465,9 +465,7 @@ resolveTargets selectPackageTargets selectComponentTarget liftProblem
           , (uid, ct) <- cts ]
 
     AvailableTargetIndexes{..} = availableTargetIndexes installPlan
-    -- TODO [required eventually] currently all build targets refer to packages
-    -- inside the project. Ultimately this has to be generalised to allow
-    -- referring to other packages and targets.
+
     checkTarget :: TargetSelector -> Either err [(UnitId, ComponentTarget)]
 
     -- We can ask to build any whole package, project-local or a dependency
@@ -531,7 +529,6 @@ resolveTargets selectPackageTargets selectComponentTarget liftProblem
 
       | otherwise
       = Left (liftProblem (TargetNotInProject pkgname))
-    --TODO: check if the package is in the plan, even if it's not local
     --TODO: check if the package is in hackage and return different
     -- error cases here so the commands can handle things appropriately
 

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -506,8 +506,9 @@ resolveTargets selectPackageTargets selectComponentTarget liftProblem
       | otherwise
       = Left (liftProblem (TargetProblemNoSuchPackage pkgid))
 
-    checkTarget bt@(TargetPackageName pkgname)
-      | Just ats <- Map.lookup pkgname availableTargetsByPackageName
+    checkTarget bt@(TargetPackageNamed pkgname mkfilter)
+      | Just ats <- fmap (maybe id filterTargetsKind mkfilter)
+                  $ Map.lookup pkgname availableTargetsByPackageName
       = case selectPackageTargets bt ats of
           Left  e  -> Left e
           Right ts -> Right [ (unitid, ComponentTarget cname WholeComponent)
@@ -529,8 +530,8 @@ resolveTargets selectPackageTargets selectComponentTarget liftProblem
                                       availableTargetsByComponent
                         `Map.union` availableTargetsEmptyPackages
     availableTargetsByPackageName = Map.mapKeysWith
-                                    (++) packageName
-                                    availableTargetsByPackage
+                                      (++) packageName
+                                      availableTargetsByPackage
 
     -- Add in all the empty packages. These do not appear in the
     -- availableTargetsByComponent map, since that only contains components

--- a/cabal-install/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/Distribution/Client/TargetSelector.hs
@@ -36,6 +36,9 @@ module Distribution.Client.TargetSelector (
     defaultDirActions,
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import Distribution.Package
          ( Package(..), PackageId, PackageName, packageName )
 import Distribution.Types.UnqualComponentName
@@ -74,36 +77,19 @@ import Data.Either
 import Data.Function
          ( on )
 import Data.List
-         ( nubBy, stripPrefix, partition, intercalate, sortBy, groupBy )
-import Data.Maybe
-         ( maybeToList )
+         ( stripPrefix, partition, groupBy )
 import Data.Ord
          ( comparing )
-import Distribution.Compat.Binary (Binary)
-import GHC.Generics (Generic)
-#if MIN_VERSION_containers(0,5,0)
 import qualified Data.Map.Lazy   as Map.Lazy
 import qualified Data.Map.Strict as Map
-import Data.Map.Strict (Map)
-#else
-import qualified Data.Map as Map.Lazy
-import qualified Data.Map as Map
-import Data.Map (Map)
-#endif
 import qualified Data.Set as Set
 import Control.Arrow ((&&&))
 import Control.Monad
-#if __GLASGOW_HASKELL__ < 710
-import Control.Applicative (Applicative(..), (<$>))
-#endif
-import Control.Applicative (Alternative(..))
 import qualified Distribution.Compat.ReadP as Parse
 import Distribution.Compat.ReadP
          ( (+++), (<++) )
 import Distribution.ParseUtils
          ( readPToMaybe )
-import Data.Char
-         ( isSpace, isAlphaNum )
 import System.FilePath as FilePath
          ( takeExtension, dropExtension
          , splitDirectories, joinPath, splitPath )
@@ -1014,7 +1000,8 @@ syntaxForm1File ps =
     -- all the other forms we don't require that.
   syntaxForm1 render $ \str1 fstatus1 ->
     expecting "file" str1 $ do
-    (pkgfile, KnownPackage{pinfoId, pinfoComponents})
+    (pkgfile, ~KnownPackage{pinfoId, pinfoComponents})
+      -- always returns the KnownPackage case
       <- matchPackageDirectoryPrefix ps fstatus1
     orNoThingIn "package" (display (packageName pinfoId)) $ do
       (filepath, c) <- matchComponentFile pinfoComponents pkgfile

--- a/cabal-install/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/Distribution/Client/TargetSelector.hs
@@ -1112,7 +1112,7 @@ syntaxForm2KindComponent cs =
     return (TargetComponent (cinfoPackageId c) (cinfoName c) WholeComponent)
   where
     render (TargetComponent p c WholeComponent) =
-      [TargetStringFileStatus2 (dispK c) noFileStatus (dispC p c)]
+      [TargetStringFileStatus2 (dispCK c) noFileStatus (dispC p c)]
     render _ = []
 
 -- | Syntax: package : module
@@ -1267,7 +1267,7 @@ syntaxForm3PackageKindComponent ps =
           return (TargetComponent pinfoId (cinfoName c) WholeComponent)
   where
     render (TargetComponent p c WholeComponent) =
-      [TargetStringFileStatus3 (dispP p) noFileStatus (dispK c) (dispC p c)]
+      [TargetStringFileStatus3 (dispP p) noFileStatus (dispCK c) (dispC p c)]
     render _ = []
 
 -- | Syntax: package : component : module
@@ -1314,7 +1314,7 @@ syntaxForm3KindComponentModule cs =
                               (ModuleTarget m))
   where
     render (TargetComponent p c (ModuleTarget m)) =
-      [TargetStringFileStatus3 (dispK c) noFileStatus (dispC p c) (dispM m)]
+      [TargetStringFileStatus3 (dispCK c) noFileStatus (dispC p c) (dispM m)]
     render _ = []
 
 -- | Syntax: package : component : filename
@@ -1357,7 +1357,7 @@ syntaxForm3KindComponentFile cs =
                               (FileTarget filepath))
   where
     render (TargetComponent p c (FileTarget f)) =
-      [TargetStringFileStatus3 (dispK c) noFileStatus (dispC p c) f]
+      [TargetStringFileStatus3 (dispCK c) noFileStatus (dispC p c) f]
     render _ = []
 
 syntaxForm3NamespacePackageFilter :: [KnownPackage] -> Syntax
@@ -1413,7 +1413,7 @@ syntaxForm5MetaNamespacePackageKindComponent ps =
           return (TargetComponent pinfoId (cinfoName c) WholeComponent)
   where
     render (TargetComponent p c WholeComponent) =
-      [TargetStringFileStatus5 "" "pkg" (dispP p) (dispK c) (dispC p c)]
+      [TargetStringFileStatus5 "" "pkg" (dispP p) (dispCK c) (dispC p c)]
     render _ = []
 
 -- | Syntax: :pkg : package : namespace : component : module : module
@@ -1442,7 +1442,7 @@ syntaxForm7MetaNamespacePackageKindComponentNamespaceModule ps =
   where
     render (TargetComponent p c (ModuleTarget m)) =
       [TargetStringFileStatus7 "" "pkg" (dispP p)
-                               (dispK c) (dispC p c)
+                               (dispCK c) (dispC p c)
                                "module" (dispM m)]
     render _ = []
 
@@ -1471,7 +1471,7 @@ syntaxForm7MetaNamespacePackageKindComponentNamespaceFile ps =
   where
     render (TargetComponent p c (FileTarget f)) =
       [TargetStringFileStatus7 "" "pkg" (dispP p)
-                               (dispK c) (dispC p c)
+                               (dispCK c) (dispC p c)
                                "file" f]
     render _ = []
 
@@ -1544,8 +1544,11 @@ dispP = display . packageName
 dispC :: Package p => p -> ComponentName -> String
 dispC = componentStringName
 
-dispK :: ComponentName -> String
-dispK = showComponentKindShort . componentKind
+dispK :: ComponentKind -> String
+dispK = showComponentKindShort
+
+dispCK :: ComponentName -> String
+dispCK = dispK . componentKind
 
 dispF :: ComponentKind -> String
 dispF = showComponentKindFilterShort

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -1218,7 +1218,7 @@ assertProjectDistinctTargets
   :: forall err. (Eq err, Show err) =>
      ElaboratedInstallPlan
   -> (forall k. TargetSelector -> [AvailableTarget k] -> Either err [k])
-  -> (forall k. PackageId -> ComponentName -> SubComponentTarget ->  AvailableTarget k  -> Either err  k )
+  -> (forall k. SubComponentTarget ->  AvailableTarget k  -> Either err  k )
   -> (TargetProblemCommon -> err)
   -> [TargetSelector]
   -> [(UnitId, ComponentName)]
@@ -1250,7 +1250,7 @@ assertProjectTargetProblems
   -> (forall k. TargetSelector
              -> [AvailableTarget k]
              -> Either err [k])
-  -> (forall k. PackageId -> ComponentName -> SubComponentTarget
+  -> (forall k. SubComponentTarget
              -> AvailableTarget k
              -> Either err k )
   -> (TargetProblemCommon -> err)
@@ -1274,7 +1274,7 @@ assertTargetProblems
   :: forall err. (Eq err, Show err) =>
      ElaboratedInstallPlan
   -> (forall k. TargetSelector -> [AvailableTarget k] -> Either err [k])
-  -> (forall k. PackageId -> ComponentName -> SubComponentTarget ->  AvailableTarget k  -> Either err  k )
+  -> (forall k. SubComponentTarget ->  AvailableTarget k  -> Either err  k )
   -> (TargetProblemCommon -> err)
   -> [(TargetSelector -> err, TargetSelector)]
   -> Assertion

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -289,13 +289,13 @@ testTargetSelectorAmbiguous reportSubCase = do
     reportSubCase "ambiguous: cwd-pkg filter vs pkg"
     assertAmbiguous "libs"
       [ mkTargetPackage "libs"
-      , TargetPackage TargetImplicitCwd "dummyPackageInfo" (Just LibKind) ]
+      , TargetPackage TargetImplicitCwd "dummyKnownPackage" (Just LibKind) ]
       [mkpkg "libs" []]
 
     reportSubCase "ambiguous: filter vs cwd component"
     assertAmbiguous "exes"
       [ mkTargetComponent "other" (CExeName "exes")
-      , TargetPackage TargetImplicitCwd "dummyPackageInfo" (Just ExeKind) ]
+      , TargetPackage TargetImplicitCwd "dummyKnownPackage" (Just ExeKind) ]
       [mkpkg "other" [mkexe "exes"]]
 
     -- but filters are not ambiguous with non-cwd components, modules or files
@@ -367,7 +367,7 @@ testTargetSelectorAmbiguous reportSubCase = do
       ]
   where
     assertAmbiguous :: String
-                    -> [TargetSelector PackageId]
+                    -> [TargetSelector]
                     -> [SourcePackage (PackageLocation a)]
                     -> Assertion
     assertAmbiguous str tss pkgs = do
@@ -382,7 +382,7 @@ testTargetSelectorAmbiguous reportSubCase = do
                           ++ "got " ++ show res
 
     assertUnambiguous :: String
-                      -> TargetSelector PackageId
+                      -> TargetSelector
                       -> [SourcePackage (PackageLocation a)]
                       -> Assertion
     assertUnambiguous str ts pkgs = do
@@ -439,23 +439,23 @@ testTargetSelectorAmbiguous reportSubCase = do
       exe { buildInfo = (buildInfo exe) { cSources = files } }
 
 
-mkTargetPackage :: PackageId -> TargetSelector PackageId
+mkTargetPackage :: PackageId -> TargetSelector
 mkTargetPackage pkgid =
     TargetPackage TargetExplicitNamed pkgid Nothing
 
-mkTargetComponent :: PackageId -> ComponentName -> TargetSelector PackageId
+mkTargetComponent :: PackageId -> ComponentName -> TargetSelector
 mkTargetComponent pkgid cname =
     TargetComponent pkgid cname WholeComponent
 
-mkTargetModule :: PackageId -> ComponentName -> ModuleName -> TargetSelector PackageId
+mkTargetModule :: PackageId -> ComponentName -> ModuleName -> TargetSelector
 mkTargetModule pkgid cname mname =
     TargetComponent pkgid cname (ModuleTarget mname)
 
-mkTargetFile :: PackageId -> ComponentName -> String -> TargetSelector PackageId
+mkTargetFile :: PackageId -> ComponentName -> String -> TargetSelector
 mkTargetFile pkgid cname fname =
     TargetComponent pkgid cname (FileTarget fname)
 
-mkTargetAllPackages :: TargetSelector PackageId
+mkTargetAllPackages :: TargetSelector
 mkTargetAllPackages = TargetAllPackages Nothing
 
 instance IsString PackageIdentifier where
@@ -516,8 +516,8 @@ testTargetProblemsCommon config0 = do
                      [ (packageName p, packageId p)
                      | p <- InstallPlan.toList elaboratedPlan ]
 
-        cases :: [( TargetSelector PackageId -> CmdBuild.TargetProblem
-                  , TargetSelector PackageId
+        cases :: [( TargetSelector -> CmdBuild.TargetProblem
+                  , TargetSelector
                   )]
         cases =
           [ -- Cannot resolve packages outside of the project
@@ -1217,10 +1217,10 @@ testTargetProblemsHaddock config reportSubCase = do
 assertProjectDistinctTargets
   :: forall err. (Eq err, Show err) =>
      ElaboratedInstallPlan
-  -> (forall k. TargetSelector PackageId -> [AvailableTarget k] -> Either err [k])
+  -> (forall k. TargetSelector -> [AvailableTarget k] -> Either err [k])
   -> (forall k. PackageId -> ComponentName -> SubComponentTarget ->  AvailableTarget k  -> Either err  k )
   -> (TargetProblemCommon -> err)
-  -> [TargetSelector PackageId]
+  -> [TargetSelector]
   -> [(UnitId, ComponentName)]
   -> Assertion
 assertProjectDistinctTargets elaboratedPlan
@@ -1247,14 +1247,14 @@ assertProjectDistinctTargets elaboratedPlan
 assertProjectTargetProblems
   :: forall err. (Eq err, Show err) =>
      FilePath -> ProjectConfig
-  -> (forall k. TargetSelector PackageId
+  -> (forall k. TargetSelector
              -> [AvailableTarget k]
              -> Either err [k])
   -> (forall k. PackageId -> ComponentName -> SubComponentTarget
              -> AvailableTarget k
              -> Either err k )
   -> (TargetProblemCommon -> err)
-  -> [(TargetSelector PackageId -> err, TargetSelector PackageId)]
+  -> [(TargetSelector -> err, TargetSelector)]
   -> Assertion
 assertProjectTargetProblems testdir config
                             selectPackageTargets
@@ -1273,10 +1273,10 @@ assertProjectTargetProblems testdir config
 assertTargetProblems
   :: forall err. (Eq err, Show err) =>
      ElaboratedInstallPlan
-  -> (forall k. TargetSelector PackageId -> [AvailableTarget k] -> Either err [k])
+  -> (forall k. TargetSelector -> [AvailableTarget k] -> Either err [k])
   -> (forall k. PackageId -> ComponentName -> SubComponentTarget ->  AvailableTarget k  -> Either err  k )
   -> (TargetProblemCommon -> err)
-  -> [(TargetSelector PackageId -> err, TargetSelector PackageId)]
+  -> [(TargetSelector -> err, TargetSelector)]
   -> Assertion
 assertTargetProblems elaboratedPlan
                      selectPackageTargets

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/ExeAndLib/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/ExeAndLib/cabal.out
@@ -7,4 +7,4 @@ Configuring executable 'foo' for ExeAndLib-1.0..
 Preprocessing executable 'foo' for ExeAndLib-1.0..
 Building executable 'foo' for ExeAndLib-1.0..
 # cabal new-run
-cabal: The run command is for running executables, but the target 'ExeAndLib' refers to the library in the package ExeAndLib-1.0 from the package ExeAndLib-1.0.
+cabal: The run command is for running executables, but the target 'ExeAndLib' refers to the library ExeAndLib from the package ExeAndLib-1.0.


### PR DESCRIPTION
Much improved support for named packages in the target selector syntax and resolution. Instead of just supporting syntax of a single unadorned package name, all the existing syntax that allow package names are extended to support named packages.

This includes packages from the `extra-packages` but also indirect deps and packages from hackage. The resolution for `extra-packages` and indirect deps should just work, while currently packages outside the project are reported as an error (but we're in a good position now to resolve to packages from hackage if we want).

So this should be a better basis for the target handling for the new install code, since any command should now be able to refer to packages outside of the project (or at least we're a short step from tha now).

This passes the existing target selector integration tests. New tests need to be added to cover the `extra-packages` and indirect deps within the project, and packages outside the project.

This does extend what the existing syntax can refer to so, docs & changelog will need to be updated.

BTW, this PR is designed to be read patch-by-patch, not all in one go. Each change is hopefully comprehensible on its own.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
