### PR TITLE
Allow empty set of input modules.

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -1268,7 +1268,11 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
     runGhcProg compileTHOpts { ghcOptNoLink  = toFlag True
                              , ghcOptNumJobs = numJobs }
 
-  unless (gbuildIsRepl bm) $
+  -- Do not try to build anything if there are no input files.
+  -- This can happen if the cabal file ends up with only cSrcs
+  -- but no Haskell modules.
+  unless ((null inputFiles && null inputModules)
+          || gbuildIsRepl bm) $
     runGhcProg compileOpts { ghcOptNoLink  = toFlag True
                            , ghcOptNumJobs = numJobs }
 

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -1,6 +1,7 @@
 -*-change-log-*-
 
 2.2.0.0 (current development version)
+	* Cabal does not try to build an empty set of `inputModules` (#4890).
 	* Add `HexFloatLiterals` to `KnownExtension`
 	* Added `virtual-module` field, to allow modules that are not built
 	  but registered (#4875).

--- a/cabal-testsuite/PackageTests/COnlyMain/foo.c
+++ b/cabal-testsuite/PackageTests/COnlyMain/foo.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    printf("Hello world!");
+    return 0;
+}

--- a/cabal-testsuite/PackageTests/COnlyMain/my.cabal
+++ b/cabal-testsuite/PackageTests/COnlyMain/my.cabal
@@ -1,0 +1,10 @@
+name:           my
+version:        0.1
+license:        BSD3
+cabal-version:  >= 2.1
+build-type:     Simple
+
+executable foo
+    -- default-language is required by cabal-version >= 1.10
+    default-language: Haskell2010
+    main-is:    foo.c

--- a/cabal-testsuite/PackageTests/COnlyMain/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/COnlyMain/setup.cabal.out
@@ -1,0 +1,6 @@
+# Setup configure
+Resolving dependencies...
+Configuring my-0.1...
+# Setup build
+Preprocessing executable 'foo' for my-0.1..
+Building executable 'foo' for my-0.1..

--- a/cabal-testsuite/PackageTests/COnlyMain/setup.out
+++ b/cabal-testsuite/PackageTests/COnlyMain/setup.out
@@ -1,0 +1,5 @@
+# Setup configure
+Configuring my-0.1...
+# Setup build
+Preprocessing executable 'foo' for my-0.1..
+Building executable 'foo' for my-0.1..

--- a/cabal-testsuite/PackageTests/COnlyMain/setup.test.hs
+++ b/cabal-testsuite/PackageTests/COnlyMain/setup.test.hs
@@ -1,0 +1,4 @@
+import Test.Cabal.Prelude
+-- Test building an executable whose main() function is defined in a C
+-- file
+main = setupAndCabalTest $ setup_build []


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

Do not try to call GHC on an empty set of `inputModules`.

Fixes #4890 