### PR TITLE
Change order of hsLibraries

### DIFF
--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -430,10 +430,9 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     IPI.libraryDirs        = libdirs,
     IPI.libraryDynDirs     = dynlibdirs,
     IPI.dataDir            = datadir installDirs,
-    IPI.hsLibraries        = extraBundledLibs bi
-                             ++ if hasLibrary
-                                then [getHSLibraryName (componentUnitId clbi)]
-                                else [],
+    IPI.hsLibraries        = (if hasLibrary
+                              then [getHSLibraryName (componentUnitId clbi)]
+                              else []) ++ extraBundledLibs bi,
     IPI.extraLibraries     = extraLibs bi,
     IPI.extraGHCiLibraries = extraGHCiLibs bi,
     IPI.includeDirs        = absinc ++ adjustRelIncDirs relinc,


### PR DESCRIPTION
After using this for a while. It occured to me that due to linker ordering, and GHC just forwarding the libraries as specified in the `hsLibraries` field, we should put the `extraBundledLibs` at the end. As such the haskell library can reference the `extraBundledLibs`.

This still leave the question of recursively linked libs. But getting that linked right should rather be deal with in GHC, which optimally would use being and end groups for the libraries to link.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
