### PR TITLE
Have the solver reject packages with a too-new/unsupported spec-version

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
@@ -13,6 +13,7 @@ import Distribution.Compiler
 import Distribution.InstalledPackageInfo as IPI
 import Distribution.Package                          -- from Cabal
 import Distribution.Simple.BuildToolDepends          -- from Cabal
+import Distribution.Simple.Utils (cabalVersion)      -- from Cabal
 import Distribution.Types.ExeDependency              -- from Cabal
 import Distribution.Types.PkgconfigDependency        -- from Cabal
 import Distribution.Types.ComponentName              -- from Cabal
@@ -186,8 +187,36 @@ convGPD os arch cinfo strfl sexes pi
             (L.map  (\(nm, ds) -> conv (ComponentBench nm) benchmarkBuildInfo ds) benchs)
        ++ maybe []    (convSetupBuildInfo pi)    (setupBuildInfo pkg)
 
+    -- | We infer the maximally supported spec-version from @lib:Cabal@'s version
+    --
+    -- As we cannot predict the future, we can only properly support
+    -- spec-versions predating (and including) the @lib:Cabal@ version
+    -- used by @cabal-install@.
+    --
+    -- This relies on 'cabalVersion' having always at least 3 components to avoid
+    -- comparisons like @2.0.0 > 2.0@ which would result in confusing results.
+    --
+    -- NOTE: Before we can switch to a /normalised/ spec-version
+    -- comparison (e.g. by truncating to 3 components, and removing
+    -- trailing zeroes) we'd have to make sure all other places where
+    -- the spec-version is compared against a bound do it
+    -- consistently.
+    maxSpecVer = cabalVersion
+
+    -- | Required/declared spec-version of the package
+    --
+    -- We don't truncate patch-levels, as specifying a patch-level
+    -- spec-version is discouraged and not supported anymore starting
+    -- with spec-version 2.2.
+    reqSpecVer = specVersion pkg
+
+    -- | A too-new specVersion is turned into a global 'FailReason'
+    -- which prevents the solver from selecting this release (and if
+    -- forced to, emit a meaningful solver error message).
+    fr | reqSpecVer > maxSpecVer = Just (UnsupportedSpecVer reqSpecVer)
+       | otherwise               = Nothing
   in
-    PInfo flagged_deps fds Nothing
+    PInfo flagged_deps fds fr
 
 -- | Create a flagged dependency tree from a list @fds@ of flagged
 -- dependencies, using @f@ to form the tree node (@f@ will be

--- a/cabal-install/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install/Distribution/Solver/Modular/Message.hs
@@ -144,6 +144,7 @@ showFR c Backjump                         = " (backjumping, conflict set: " ++ s
 showFR _ MultipleInstances                = " (multiple instances)"
 showFR c (DependenciesNotLinked msg)      = " (dependencies not linked: " ++ msg ++ "; conflict set: " ++ showConflictSet c ++ ")"
 showFR c CyclicDependencies               = " (cyclic dependencies; conflict set: " ++ showConflictSet c ++ ")"
+showFR _ (UnsupportedSpecVer ver)         = " (unsupported spec-version " ++ display ver ++ ")"
 -- The following are internal failures. They should not occur. In the
 -- interest of not crashing unnecessarily, we still just print an error
 -- message though.

--- a/cabal-install/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install/Distribution/Solver/Modular/Tree.hs
@@ -111,6 +111,7 @@ data FailReason = InconsistentInitialConstraints
                 | MultipleInstances
                 | DependenciesNotLinked String
                 | CyclicDependencies
+                | UnsupportedSpecVer Ver
   deriving (Eq, Show)
 
 -- | Functor for the tree type. 'a' is the type of nodes' children. 'd' and 'c'

--- a/cabal-testsuite/PackageTests/CustomWithoutCabal/cabal.out
+++ b/cabal-testsuite/PackageTests/CustomWithoutCabal/cabal.out
@@ -1,5 +1,4 @@
 # cabal new-build
-Warning: <ROOT>/custom-setup-without-cabal.cabal: This package requires at least Cabal version 99999
 Resolving dependencies...
 In order, the following will be built:
  - custom-setup-without-cabal-1.0 (lib:custom-setup-without-cabal) (first run)

--- a/cabal-testsuite/PackageTests/CustomWithoutCabal/custom-setup-without-cabal.cabal
+++ b/cabal-testsuite/PackageTests/CustomWithoutCabal/custom-setup-without-cabal.cabal
@@ -1,7 +1,7 @@
+cabal-version: 2.0
 name: custom-setup-without-cabal
 version: 1.0
 build-type: Custom
-cabal-version: >= 99999
 
 custom-setup
   setup-depends: base

--- a/cabal-testsuite/PackageTests/Regression/T3436/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T3436/cabal.out
@@ -1,5 +1,4 @@
 # cabal new-build
-Warning: <ROOT>/custom-setup/custom-setup.cabal: This package requires at least Cabal version 99999
 Resolving dependencies...
 In order, the following will be built:
  - Cabal-99999 (lib:Cabal) (first run)

--- a/cabal-testsuite/PackageTests/Regression/T3436/custom-setup/custom-setup.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T3436/custom-setup/custom-setup.cabal
@@ -1,7 +1,7 @@
+cabal-version: 2.0
 name: custom-setup
 version: 1.0
 build-type: Custom
-cabal-version: >= 99999
 
 custom-setup
   setup-depends: base, Cabal >= 99999

--- a/cabal-testsuite/PackageTests/Regression/T3436/sandbox.out
+++ b/cabal-testsuite/PackageTests/Regression/T3436/sandbox.out
@@ -10,7 +10,6 @@ Installing library in <PATH>
 Installed Cabal-99998
 # cabal sandbox add-source
 # cabal install
-Warning: custom-setup/custom-setup.cabal: This package requires at least Cabal version 99999
 Resolving dependencies...
 Configuring Cabal-99999...
 Preprocessing library for Cabal-99999..


### PR DESCRIPTION
This compares the request spec-version to the lib:Cabal's version in order to
determine whether cabal is able to properly understand the package. If it's
newer than the currently linked lib:Cabal version it's turned into a global
`FailResult` which the solver treats as desired in terms of backtracking and
error reporting.

This is related to the new spec-version forward-compat scheme (see #4899).

This is complements #4900 for the 2.0 branch.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
