### PR TITLE
Relax bounds for aeson and optparse-applicative in test-suite

### DIFF
--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -33,13 +33,13 @@ library
     Test.Cabal.Monad
     Test.Cabal.CheckArMetadata
   build-depends:
-    aeson == 1.1.*,
+    aeson >= 1.1 && <1.3,
     attoparsec,
     async,
     base,
     bytestring,
     transformers,
-    optparse-applicative ==0.13.*,
+    optparse-applicative >=0.13 && <0.15,
     process,
     directory,
     filepath,


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
