### PR TITLE
Turn gen-extra-source-files into proper package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY : all lexer lib exe doctest
+.PHONY : all lexer lib exe doctest gen-extra-source-files
 
 LEXER_HS:=Cabal/Distribution/Parsec/Lexer.hs
 
@@ -13,7 +13,11 @@ lib : $(LEXER_HS)
 	cabal new-build --enable-tests Cabal
 
 exe : $(LEXER_HS)
-	cabal new-build  --enable-tests cabal
+	cabal new-build --enable-tests cabal
 
 doctest :
 	doctest --fast Cabal/Distribution Cabal/Language
+
+gen-extra-source-files:
+	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-extra-source-files -- Cabal/Cabal.cabal
+	cabal new-run --builddir=dist-newstyle=meta --project-file=cabal.project.meta gen-extra-source-files -- cabal-install/cabal-install.cabal

--- a/cabal-dev-scripts/LICENSE
+++ b/cabal-dev-scripts/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2017, Cabal Development Team
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Cabal Development Team nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cabal-dev-scripts/Setup.hs
+++ b/cabal-dev-scripts/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -1,0 +1,23 @@
+name:                cabal-dev-scripts
+version:             0
+synopsis:            Dev scripts for cabal development
+description:         
+  This package provides a tools for Cabal development
+homepage:            http://www.haskell.org/cabal/
+license:             BSD3
+license-file:        LICENSE
+author:              Cabal Development Team <cabal-devel@haskell.org>
+category:            Distribution
+build-type:          Simple
+cabal-version:       >=2.0
+
+executable gen-extra-source-files
+  default-language:    Haskell2010
+  main-is:             GenExtraSourceFiles.hs
+  hs-source-dirs:      src
+  build-depends:
+    base                 >=4.10    && <4.11,
+    Cabal                >=2.0     && <2.2,
+    directory,
+    filepath,
+    process

--- a/cabal-dev-scripts/src/GenExtraSourceFiles.hs
+++ b/cabal-dev-scripts/src/GenExtraSourceFiles.hs
@@ -1,27 +1,22 @@
-#!/usr/bin/env runhaskell
-{-# LANGUAGE CPP, PackageImports #-}
+import qualified Distribution.ModuleName               as ModuleName
+import           Distribution.PackageDescription
+import           Distribution.PackageDescription.Parse
+                 (ParseResult (..), parseGenericPackageDescription)
+import           Distribution.Verbosity                (silent)
 
-#if !MIN_VERSION_Cabal(2,0,0)
-#error "Run this with Cabal >= 2.0"
-#endif
+import Data.List          (isPrefixOf, isSuffixOf, sort)
+import System.Directory   (canonicalizePath, setCurrentDirectory)
+import System.Environment (getArgs, getProgName)
+import System.FilePath    (takeDirectory, takeExtension, takeFileName)
+import System.Process     (readProcess)
 
--- NB: Force an installed Cabal package to be used, NOT
--- some local files which have these names (as would be
--- the case if we were in the Cabal source directory.)
-import "Cabal" Distribution.PackageDescription
-import "Cabal" Distribution.PackageDescription.Parse (ParseResult (..), parseGenericPackageDescription)
-import "Cabal" Distribution.Verbosity                (silent)
-import qualified "Cabal" Distribution.ModuleName as ModuleName
-
-import Data.List                             (isPrefixOf, isSuffixOf, sort)
-import System.Environment                    (getArgs, getProgName)
-import System.FilePath                       (takeExtension, takeFileName)
-import System.Process                        (readProcess)
-
-import qualified System.IO               as IO
+import qualified System.IO as IO
 
 main' :: FilePath -> IO ()
-main' fp = do
+main' fp' = do
+    fp <- canonicalizePath fp'
+    setCurrentDirectory (takeDirectory fp)
+
     -- Read cabal file, so we can determine test modules
     contents <- strictReadFile fp
     cabal <- case parseGenericPackageDescription contents of

--- a/cabal.project.meta
+++ b/cabal.project.meta
@@ -1,0 +1,1 @@
+packages: cabal-dev-scripts

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -13,7 +13,7 @@ if [ -z ${STACKAGE_RESOLVER+x} ]; then
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         travis_retry sudo add-apt-repository -y ppa:hvr/ghc
         travis_retry sudo apt-get update
-        travis_retry sudo apt-get install --force-yes cabal-install-2.0 happy-1.19.5 alex-3.1.7 ghc-$GHCVER-prof ghc-$GHCVER-dyn
+        travis_retry sudo apt-get install --force-yes cabal-install-head cabal-install-2.0 happy-1.19.5 alex-3.1.7 ghc-$GHCVER-prof ghc-$GHCVER-dyn
         if [ "x$TEST_OTHER_VERSIONS" = "xYES" ]; then travis_retry sudo apt-get install --force-yes ghc-7.0.4-prof ghc-7.0.4-dyn ghc-7.2.2-prof ghc-7.2.2-dyn ghc-head-prof ghc-head-dyn; fi
 
     elif [ "$TRAVIS_OS_NAME" = "osx" ]; then

--- a/travis-meta.sh
+++ b/travis-meta.sh
@@ -2,6 +2,8 @@
 
 . ./travis-common.sh
 
+export PATH=/opt/cabal/head/bin:$PATH
+
 # ---------------------------------------------------------------------
 # Check that auto-generated files/fields are up to date.
 # ---------------------------------------------------------------------
@@ -10,11 +12,8 @@
 # Currently doesn't work because Travis uses --depth=50 when cloning.
 #./Cabal/misc/gen-authors.sh > AUTHORS
 
-# Regenerate the 'extra-source-files' field in Cabal.cabal.
-(cd Cabal && timed ./misc/gen-extra-source-files.hs Cabal.cabal) || exit $?
-
-# Regenerate the 'extra-source-files' field in cabal-install.cabal.
-(cd cabal-install && ../Cabal/misc/gen-extra-source-files.hs cabal-install.cabal) || exit $?
+# Regenerate files
+timed make gen-extra-source-files
 
 # Fail if the diff is not empty.
 timed ./Cabal/misc/travis-diff-files.sh


### PR DESCRIPTION
this way we have proper bounds, and `make gen-extra-source-files`.

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
