### PR TITLE
Initial feature add: create both Library and Executable on cabal init

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -743,6 +743,7 @@ createMainHs flags =
   where
     Flag mainFile = mainIs flags
 
+--- | Write a main file if it doesn't already exist.
 writeMainHs :: InitFlags -> FilePath -> IO ()
 writeMainHs flags mainPath = do
   dir <- maybe getCurrentDirectory return (flagToMaybe $ packageDir flags)
@@ -752,7 +753,7 @@ writeMainHs flags mainPath = do
       message flags $ "Generating " ++ mainPath ++ "..."
       writeFileSafe flags mainFullPath mainHs
 
--- | Checks to see if a main file should exist
+-- | Checks to see if a main file shoulcd exist
 hasMainHs :: InitFlags -> Bool
 hasMainHs flags = case mainIs flags of
   Flag _ -> (packageType flags == Flag Executable || packageType flags == Flag LibraryAndExecutable)

--- a/cabal-install/Distribution/Client/Init/Types.hs
+++ b/cabal-install/Distribution/Client/Init/Types.hs
@@ -78,12 +78,14 @@ data InitFlags =
   -- ones, which is why we want Maybe [foo] for collecting foo values,
   -- not Flag [foo].
 
-data PackageType = Library | Executable
+data BuildType = LibBuild | ExecBuild
+
+data PackageType = Library | Executable | LibraryAndExecutable
   deriving (Show, Read, Eq)
 
 instance Text PackageType where
   disp = Disp.text . show
-  parse = Parse.choice $ map (fmap read . Parse.string . show) [Library, Executable] -- TODO: eradicateNoParse
+  parse = Parse.choice $ map (fmap read . Parse.string . show) [Library, Executable, LibraryAndExecutable] -- TODO: eradicateNoParse
 
 instance Monoid InitFlags where
   mempty = gmempty

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2012,6 +2012,12 @@ initCommand = CommandUI {
         (\v flags -> flags { IT.packageType = v })
         (noArg (Flag IT.Executable))
 
+        , option [] ["is-libandexec"]
+        "Build a library and an executable."
+        IT.packageType
+        (\v flags -> flags { IT.packageType = v })
+        (noArg (Flag IT.LibraryAndExecutable))
+
       , option [] ["main-is"]
         "Specify the main module."
         IT.mainIs

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2012,7 +2012,7 @@ initCommand = CommandUI {
         (\v flags -> flags { IT.packageType = v })
         (noArg (Flag IT.Executable))
 
-        , option [] ["is-libandexec"]
+        , option [] ["is-libandexe"]
         "Build a library and an executable."
         IT.packageType
         (\v flags -> flags { IT.packageType = v })


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

@cartazio @hvr This is the initial proposed change for allowing users to initialize their .cabal to have both a library and executables. I will be adding the changelog in a following commit.