### PR TITLE
D.S.Program.Hpc: Use relative .mix search paths

### DIFF
--- a/Cabal/Distribution/Simple/Program/Hpc.hs
+++ b/Cabal/Distribution/Simple/Program/Hpc.hs
@@ -19,6 +19,9 @@ module Distribution.Simple.Program.Hpc
 import Prelude ()
 import Distribution.Compat.Prelude
 
+import Control.Monad (mapM)
+import System.Directory (makeRelativeToCurrentDirectory)
+
 import Distribution.ModuleName
 import Distribution.Simple.Program.Run
 import Distribution.Simple.Program.Types
@@ -57,8 +60,11 @@ markup hpc hpcVer verbosity tixFile hpcDirs destDir excluded = do
                         ++ show droppedDirs
             return passedDirs
 
+    -- Prior to GHC 8.0, hpc assumes all .mix paths are relative.
+    hpcDirs'' <- mapM makeRelativeToCurrentDirectory hpcDirs'
+
     runProgramInvocation verbosity
-      (markupInvocation hpc tixFile hpcDirs' destDir excluded)
+      (markupInvocation hpc tixFile hpcDirs'' destDir excluded)
   where
     version07 = mkVersion [0, 7]
     (passedDirs, droppedDirs) = splitAt 1 hpcDirs


### PR DESCRIPTION
Prior to GHC 8.0, hpc requires relative search paths. We now pass relative paths
in all cases; we do not want to separately condition on GHC and HPC versions.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] ~Any changes that could be relevant to users have been recorded in the changelog.~
* [ ] ~The documentation has been updated, if necessary.~
* [ ] ~If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.~

If necessary, I can backport this further, but I don't know that we make bugfix releases for older branches.
