### PR TITLE
Don't pass `other-modules` to stub executable for detailed-0.9

### DIFF
--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -289,7 +289,10 @@ buildComponent verbosity numJobs pkg_descr lbi0 suffixes
                       HcPkg.registerMultiInstance = True
                     }
     let ebi = buildInfo exe
-        exe' = exe { buildInfo = addExtraCSources ebi extras }
+        -- NB: The stub executable is linked against the test-library
+        --     which already contains all `other-modules`, so we need
+        --     to remove those from the stub-exe's build-info
+        exe' = exe { buildInfo = (addExtraCSources ebi extras) { otherModules = [] } }
     buildExe verbosity numJobs pkg_descr lbi exe' exeClbi
     return Nothing -- Can't depend on test suite
 


### PR DESCRIPTION
The stub executable is linked against the test-library
which already contains all `other-modules`, so we need
to remove those from the stub-exe's build-info to avoid
build errors due to duplication.

This addresses #4918

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] Regression tests