### PR TITLE
Do not create folders when failing on no .project or .cabal file

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -328,9 +328,6 @@ rebuildProjectConfig verbosity
     phaseReadProjectConfig = do
       liftIO $ do
         info verbosity "Project settings changed, reconfiguring..."
-        createDirectoryIfMissingVerbose verbosity True distDirectory
-        createDirectoryIfMissingVerbose verbosity True distProjectCacheDirectory
-
       readProjectConfig verbosity projectConfigConfigFile distDirLayout
 
     -- Look for all the cabal packages in the project
@@ -340,6 +337,13 @@ rebuildProjectConfig verbosity
                            -> Rebuild [PackageSpecifier UnresolvedSourcePackage]
     phaseReadLocalPackages projectConfig = do
       localCabalFiles <- findProjectPackages distDirLayout projectConfig
+
+      -- Create folder only if findProjectPackages did not throw a
+      -- Badpackagelocations exception
+      liftIO $ do
+        createDirectoryIfMissingVerbose verbosity True distDirectory
+        createDirectoryIfMissingVerbose verbosity True distProjectCacheDirectory
+
       mapM (readSourcePackage verbosity) localCabalFiles
 
 


### PR DESCRIPTION
Sent by `f-a` on IRC (#hackage) http://www.ariis.it/link/t/0001-Do-not-create-folders-when-failing-on-no-.project-or.patch

```
12:55 < f-a> btw, I am doing this to fix a minor annoyance of mine with cabal-install
12:55 < f-a> if you run, say, `cabal new-build` in an unrelated folder
12:55 < f-a> cabal creates dist-newstyle folder before exiting with error
12:56 < hvr> even if there isn't any .cabal file around?
12:56 < f-a> yup
12:56 < hvr> ok, that's nasty
12:56 < f-a> f@x60s:~$ cd ~/
12:56 < f-a> f@x60s:~$ cabal new-build
12:56 < f-a> No cabal.project file or cabal file matching the default glob './*.cabal' was found.
12:56 < f-a> Please create a package description file <pkgname>.cabal or a cabal.project file referencing the packages you want to 
             build.
12:56 < f-a> f@x60s:~$ lsc
12:56 < f-a> cfg  dist-newstyle  downloads  francesco  mail  media  spool
12:57 < f-a> hvr: if I manage to compile this, I plan to write a small patch
```

/cc @hvr

---

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
