### PR TITLE
Restore a few integration test comments and new-build package arguments.

### DIFF
--- a/cabal-testsuite/PackageTests/CustomWithoutCabal/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/CustomWithoutCabal/cabal.test.hs
@@ -1,4 +1,8 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
-    r <- fails $ cabal' "new-build" []
+
+    -- This package has explicit setup dependencies that do not include Cabal.
+    -- new-build should try to build it, but configure should fail because
+    -- Setup.hs just prints an error message and exits.
+    r <- fails $ cabal' "new-build" ["custom-setup-without-cabal"]
     assertOutputContains "My custom Setup" r

--- a/cabal-testsuite/PackageTests/CustomWithoutCabalDefaultMain/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/CustomWithoutCabalDefaultMain/cabal.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
-    r <- fails $ cabal' "new-build" []
+
+    -- This package has explicit setup dependencies that do not include Cabal.
+    -- Compilation should fail because Setup.hs imports Distribution.Simple.
+    r <- fails $ cabal' "new-build" ["custom-setup-without-cabal-defaultMain"]
     assertRegex "Should not have been able to import Cabal"
                 "(Could not find module|Failed to load interface for).*Distribution\\.Simple" r
     {-

--- a/cabal-testsuite/PackageTests/Regression/T3436/Cabal-1.2/Cabal.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T3436/Cabal-1.2/Cabal.cabal
@@ -1,5 +1,5 @@
 name: Cabal
-version: 99998
+version: 1.2
 build-type: Simple
 cabal-version: >= 1.2
 

--- a/cabal-testsuite/PackageTests/Regression/T3436/Cabal-1.2/CabalMessage.hs
+++ b/cabal-testsuite/PackageTests/Regression/T3436/Cabal-1.2/CabalMessage.hs
@@ -1,0 +1,3 @@
+module CabalMessage where
+
+message = "This is Cabal-1.2"

--- a/cabal-testsuite/PackageTests/Regression/T3436/Cabal-2.0/Cabal.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T3436/Cabal-2.0/Cabal.cabal
@@ -1,5 +1,5 @@
 name: Cabal
-version: 99999
+version: 2.0
 build-type: Simple
 cabal-version: >= 1.2
 

--- a/cabal-testsuite/PackageTests/Regression/T3436/Cabal-2.0/CabalMessage.hs
+++ b/cabal-testsuite/PackageTests/Regression/T3436/Cabal-2.0/CabalMessage.hs
@@ -1,0 +1,3 @@
+module CabalMessage where
+
+message = "This is Cabal-2.0"

--- a/cabal-testsuite/PackageTests/Regression/T3436/Cabal-99998/CabalMessage.hs
+++ b/cabal-testsuite/PackageTests/Regression/T3436/Cabal-99998/CabalMessage.hs
@@ -1,3 +1,0 @@
-module CabalMessage where
-
-message = "This is Cabal-99998"

--- a/cabal-testsuite/PackageTests/Regression/T3436/Cabal-99999/CabalMessage.hs
+++ b/cabal-testsuite/PackageTests/Regression/T3436/Cabal-99999/CabalMessage.hs
@@ -1,3 +1,0 @@
-module CabalMessage where
-
-message = "This is Cabal-99999"

--- a/cabal-testsuite/PackageTests/Regression/T3436/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T3436/cabal.out
@@ -2,8 +2,8 @@
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
- - Cabal-99999 (lib:Cabal) (first run)
+ - Cabal-2.0 (lib:Cabal) (first run)
  - custom-setup-1.0 (lib:custom-setup) (first run)
-Configuring Cabal-99999...
-Preprocessing library for Cabal-99999..
-Building library for Cabal-99999..
+Configuring Cabal-2.0...
+Preprocessing library for Cabal-2.0..
+Building library for Cabal-2.0..

--- a/cabal-testsuite/PackageTests/Regression/T3436/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T3436/cabal.project
@@ -1,1 +1,1 @@
-packages: custom-setup Cabal-99999
+packages: custom-setup Cabal-2.0

--- a/cabal-testsuite/PackageTests/Regression/T3436/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T3436/cabal.test.hs
@@ -4,5 +4,5 @@ main = cabalTest $ do
     -- isn't in the system database and thus we can't see if the
     -- depsolver incorrectly chooses it.  Worth fixing if we figure
     -- out how to simulate the "global" database without root.
-    r <- fails $ cabal' "new-build" ["all"]
+    r <- fails $ cabal' "new-build" ["custom-setup"]
     assertOutputContains "This is Cabal-99999" r

--- a/cabal-testsuite/PackageTests/Regression/T3436/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T3436/cabal.test.hs
@@ -1,8 +1,8 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
-    -- NB: This test doesn't really test #3436, because Cabal-99998
+    -- NB: This test doesn't really test #3436, because Cabal-1.2
     -- isn't in the system database and thus we can't see if the
     -- depsolver incorrectly chooses it.  Worth fixing if we figure
     -- out how to simulate the "global" database without root.
     r <- fails $ cabal' "new-build" ["custom-setup"]
-    assertOutputContains "This is Cabal-99999" r
+    assertOutputContains "This is Cabal-2.0" r

--- a/cabal-testsuite/PackageTests/Regression/T3436/custom-setup/custom-setup.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T3436/custom-setup/custom-setup.cabal
@@ -4,6 +4,6 @@ version: 1.0
 build-type: Custom
 
 custom-setup
-  setup-depends: base, Cabal >= 99999
+  setup-depends: base, Cabal >= 2.0
 
 library

--- a/cabal-testsuite/PackageTests/Regression/T3436/sandbox.out
+++ b/cabal-testsuite/PackageTests/Regression/T3436/sandbox.out
@@ -3,19 +3,19 @@ Writing a default package environment file to <ROOT>/sandbox.dist/cabal.sandbox.
 Creating a new sandbox at <ROOT>/sandbox.dist/sandbox
 # cabal install
 Resolving dependencies...
-Configuring Cabal-99998...
-Preprocessing library for Cabal-99998..
-Building library for Cabal-99998..
+Configuring Cabal-1.2...
+Preprocessing library for Cabal-1.2..
+Building library for Cabal-1.2..
 Installing library in <PATH>
-Installed Cabal-99998
+Installed Cabal-1.2
 # cabal sandbox add-source
 # cabal install
 Resolving dependencies...
-Configuring Cabal-99999...
-Preprocessing library for Cabal-99999..
-Building library for Cabal-99999..
+Configuring Cabal-2.0...
+Preprocessing library for Cabal-2.0..
+Building library for Cabal-2.0..
 Installing library in <PATH>
-Installed Cabal-99999
+Installed Cabal-2.0
 Failed to install custom-setup-1.0
 cabal: Error: some packages failed to install:
 custom-setup-1.0-92JpsxIMpiQHysxYdDtEVq failed during the configure step. The exception was:

--- a/cabal-testsuite/PackageTests/Regression/T3436/sandbox.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T3436/sandbox.test.hs
@@ -1,7 +1,14 @@
 import Test.Cabal.Prelude
+
+-- Regression test for issue #3436
 main = cabalTest $ do
     withSandbox $ do
         cabal "install" ["./Cabal-99998"]
         cabal_sandbox "add-source" ["Cabal-99999"]
+
+        -- Install custom-setup, which has a setup dependency on Cabal-99999.
+        -- cabal should build the setup script with Cabal-99999, but then
+        -- configure should fail because Setup just prints an error message
+        -- imported from Cabal and exits.
         r <- fails $ cabal' "install" ["custom-setup/"]
         assertOutputContains "This is Cabal-99999" r

--- a/cabal-testsuite/PackageTests/Regression/T3436/sandbox.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T3436/sandbox.test.hs
@@ -1,14 +1,21 @@
 import Test.Cabal.Prelude
 
 -- Regression test for issue #3436
+--
+-- #3436 occurred when a package with a custom setup specified a 'cabal-version'
+-- that was newer than the version of the installed Cabal library, even though
+-- the solver didn't choose the installed Cabal for the package's setup script.
+--
+-- This test installs a fake Cabal-1.2 and then tries to build the package
+-- custom-setup, which depends on a fake Cabal-2.0 (through cabal-version and
+-- setup-depends).
 main = cabalTest $ do
     withSandbox $ do
-        cabal "install" ["./Cabal-99998"]
-        cabal_sandbox "add-source" ["Cabal-99999"]
+        cabal "install" ["./Cabal-1.2"]
+        cabal_sandbox "add-source" ["Cabal-2.0"]
 
-        -- Install custom-setup, which has a setup dependency on Cabal-99999.
-        -- cabal should build the setup script with Cabal-99999, but then
-        -- configure should fail because Setup just prints an error message
+        -- cabal should build custom-setup's setup script with Cabal-2.0, but
+        -- then configure should fail because Setup just prints an error message
         -- imported from Cabal and exits.
         r <- fails $ cabal' "install" ["custom-setup/"]
-        assertOutputContains "This is Cabal-99999" r
+        assertOutputContains "This is Cabal-2.0" r


### PR DESCRIPTION
Some comments were lost in the migration to the new integration test suite.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
