### PR TITLE
Solver: Deduplicate flags and stanzas in DependencyReason.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Builder.hs
+++ b/cabal-install/Distribution/Solver/Modular/Builder.hs
@@ -21,6 +21,7 @@ module Distribution.Solver.Modular.Builder (
 
 import Data.List as L
 import Data.Map as M
+import Data.Set as S
 import Prelude hiding (sequence, mapM)
 
 import Distribution.Solver.Modular.Dependency
@@ -86,7 +87,7 @@ extendOpen qpn' gs s@(BS { rdeps = gs', open = o' }) = go gs' o' gs
     -- GoalReason for a flag or stanza. Each flag/stanza is introduced only by
     -- its containing package.
     flagGR :: qpn -> GoalReason qpn
-    flagGR qpn = DependencyGoal (DependencyReason qpn [] [])
+    flagGR qpn = DependencyGoal (DependencyReason qpn M.empty S.empty)
 
 -- | Given the current scope, qualify all the package names in the given set of
 -- dependencies and then extend the set of open goals accordingly.

--- a/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
@@ -172,7 +172,7 @@ convGPD os arch cinfo strfl solveExes pn
     conv :: Mon.Monoid a => Component -> (a -> BuildInfo) -> DependencyReason PN ->
             CondTree ConfVar [Dependency] a -> FlaggedDeps PN
     conv comp getInfo dr =
-        convCondTree dr pkg os arch cinfo pn fds comp getInfo ipns solveExes .
+        convCondTree M.empty dr pkg os arch cinfo pn fds comp getInfo ipns solveExes .
         PDC.addBuildableCondition getInfo
 
     initDR = DependencyReason pn M.empty S.empty
@@ -255,19 +255,19 @@ filterIPNs ipns (Dependency pn _) fd
 -- | Convert condition trees to flagged dependencies.  Mutually
 -- recursive with 'convBranch'.  See 'convBranch' for an explanation
 -- of all arguments preceeding the input 'CondTree'.
-convCondTree :: DependencyReason PN -> PackageDescription -> OS -> Arch -> CompilerInfo -> PN -> FlagInfo ->
+convCondTree :: Map FlagName Bool -> DependencyReason PN -> PackageDescription -> OS -> Arch -> CompilerInfo -> PN -> FlagInfo ->
                 Component ->
                 (a -> BuildInfo) ->
                 IPNs ->
                 SolveExecutables ->
                 CondTree ConfVar [Dependency] a -> FlaggedDeps PN
-convCondTree dr pkg os arch cinfo pn fds comp getInfo ipns solveExes@(SolveExecutables solveExes') (CondNode info ds branches) =
+convCondTree flags dr pkg os arch cinfo pn fds comp getInfo ipns solveExes@(SolveExecutables solveExes') (CondNode info ds branches) =
                  concatMap
                     (\d -> filterIPNs ipns d (D.Simple (convLibDep dr d) comp))             ds  -- unconditional package dependencies
               ++ L.map (\e -> D.Simple (LDep dr (Ext  e)) comp) (PD.allExtensions bi) -- unconditional extension dependencies
               ++ L.map (\l -> D.Simple (LDep dr (Lang l)) comp) (PD.allLanguages  bi) -- unconditional language dependencies
               ++ L.map (\(PkgconfigDependency pkn vr) -> D.Simple (LDep dr (Pkg pkn vr)) comp) (PD.pkgconfigDepends bi) -- unconditional pkg-config dependencies
-              ++ concatMap (convBranch dr pkg os arch cinfo pn fds comp getInfo ipns solveExes) branches
+              ++ concatMap (convBranch flags dr pkg os arch cinfo pn fds comp getInfo ipns solveExes) branches
               -- build-tools dependencies
               -- NB: Only include these dependencies if SolveExecutables
               -- is True.  It might be false in the legacy solver
@@ -292,61 +292,81 @@ convCondTree dr pkg os arch cinfo pn fds comp getInfo ipns solveExes@(SolveExecu
 --
 -- This function takes a number of arguments:
 --
---      1. Some pre dependency-solving known information ('OS', 'Arch',
+--      1. A map of flag values that have already been chosen. It allows
+--         convBranch to avoid creating nested FlaggedDeps that are
+--         controlled by the same flag and avoid creating DependencyReasons with
+--         conflicting values for the same flag.
+--
+--      2. The DependencyReason calculated at this point in the tree of
+--         conditionals. The flag values in the DependencyReason are similar to
+--         the values in the map above, except for the use of FlagBoth.
+--
+--      3. Some pre dependency-solving known information ('OS', 'Arch',
 --         'CompilerInfo') for @os()@, @arch()@ and @impl()@ variables,
 --
---      2. The package name @'PN'@ which this condition tree
+--      4. The package name @'PN'@ which this condition tree
 --         came from, so that we can correctly associate @flag()@
 --         variables with the correct package name qualifier,
 --
---      3. The flag defaults 'FlagInfo' so that we can populate
+--      5. The flag defaults 'FlagInfo' so that we can populate
 --         'Flagged' dependencies with 'FInfo',
 --
---      4. The name of the component 'Component' so we can record where
+--      6. The name of the component 'Component' so we can record where
 --         the fine-grained information about where the component came
 --         from (see 'convCondTree'), and
 --
---      5. A selector to extract the 'BuildInfo' from the leaves of
+--      7. A selector to extract the 'BuildInfo' from the leaves of
 --         the 'CondTree' (which actually contains the needed
 --         dependency information.)
 --
---      6. The set of package names which should be considered internal
+--      8. The set of package names which should be considered internal
 --         dependencies, and thus not handled as dependencies.
-convBranch :: DependencyReason PN -> PackageDescription -> OS -> Arch -> CompilerInfo ->
-              PN -> FlagInfo ->
-              Component ->
-              (a -> BuildInfo) ->
-              IPNs ->
-              SolveExecutables ->
-              CondBranch ConfVar [Dependency] a ->
-              FlaggedDeps PN
-convBranch dr pkg os arch cinfo pn fds comp getInfo ipns solveExes (CondBranch c' t' mf') =
+convBranch :: Map FlagName Bool
+           -> DependencyReason PN
+           -> PackageDescription
+           -> OS
+           -> Arch
+           -> CompilerInfo
+           -> PN
+           -> FlagInfo
+           -> Component
+           -> (a -> BuildInfo)
+           -> IPNs
+           -> SolveExecutables
+           -> CondBranch ConfVar [Dependency] a
+           -> FlaggedDeps PN
+convBranch flags dr pkg os arch cinfo pn fds comp getInfo ipns solveExes (CondBranch c' t' mf') =
     go c'
-       (\dr' ->           convCondTree dr' pkg os arch cinfo pn fds comp getInfo ipns solveExes  t')
-       (\dr' -> maybe [] (convCondTree dr' pkg os arch cinfo pn fds comp getInfo ipns solveExes) mf')
-       dr
+       (\flags' dr' ->           convCondTree flags' dr' pkg os arch cinfo pn fds comp getInfo ipns solveExes  t')
+       (\flags' dr' -> maybe [] (convCondTree flags' dr' pkg os arch cinfo pn fds comp getInfo ipns solveExes) mf')
+       flags dr
   where
     go :: Condition ConfVar
-       -> (DependencyReason PN -> FlaggedDeps PN)
-       -> (DependencyReason PN -> FlaggedDeps PN)
-       ->  DependencyReason PN -> FlaggedDeps PN
+       -> (Map FlagName Bool -> DependencyReason PN -> FlaggedDeps PN)
+       -> (Map FlagName Bool -> DependencyReason PN -> FlaggedDeps PN)
+       ->  Map FlagName Bool -> DependencyReason PN -> FlaggedDeps PN
     go (Lit True)  t _ = t
     go (Lit False) _ f = f
     go (CNot c)    t f = go c f t
     go (CAnd c d)  t f = go c (go d t f) f
     go (COr  c d)  t f = go c t (go d t f)
-    go (Var (Flag fn)) t f = \dr' ->
-         -- Add each flag to the DependencyReason for all dependencies below,
-         -- including any extracted dependencies. Extracted dependencies are
-         -- introduced by both flag values (FlagBoth). Note that we don't
-         -- actually need to add the flag to the extracted dependencies for
-         -- correct backjumping; the information only improves log messages by
-         -- giving the user the full reason for each dependency.
-         let addFlagVal v = addFlag fn v dr'
-         in extractCommon (t (addFlagVal FlagBoth))
-                          (f (addFlagVal FlagBoth))
-             ++ [ Flagged (FN pn fn) (fds ! fn) (t (addFlagVal FlagTrue))
-                                                (f (addFlagVal FlagFalse)) ]
+    go (Var (Flag fn)) t f = \flags' ->
+        case M.lookup fn flags' of
+          Just True  -> t flags'
+          Just False -> f flags'
+          Nothing    -> \dr' ->
+            -- Add each flag to the DependencyReason for all dependencies below,
+            -- including any extracted dependencies. Extracted dependencies are
+            -- introduced by both flag values (FlagBoth). Note that we don't
+            -- actually need to add the flag to the extracted dependencies for
+            -- correct backjumping; the information only improves log messages
+            -- by giving the user the full reason for each dependency.
+            let addFlagValue v = addFlagToDependencyReason fn v dr'
+                addFlag v = M.insert fn v flags'
+            in extractCommon (t (addFlag True)  (addFlagValue FlagBoth))
+                             (f (addFlag False) (addFlagValue FlagBoth))
+                ++ [ Flagged (FN pn fn) (fds ! fn) (t (addFlag True)  (addFlagValue FlagTrue))
+                                                   (f (addFlag False) (addFlagValue FlagFalse)) ]
     go (Var (OS os')) t f
       | os == os'      = t
       | otherwise      = f
@@ -364,9 +384,9 @@ convBranch dr pkg os arch cinfo pn fds comp getInfo ipns solveExes (CondBranch c
       where
         matchImpl (CompilerId cf' cv) = cf == cf' && checkVR cvr cv
 
-    addFlag :: FlagName -> FlagValue -> DependencyReason pn -> DependencyReason pn
-    addFlag fn v (DependencyReason pn' flags stanzas) =
-        DependencyReason pn' (M.insert fn v flags) stanzas
+    addFlagToDependencyReason :: FlagName -> FlagValue -> DependencyReason pn -> DependencyReason pn
+    addFlagToDependencyReason fn v (DependencyReason pn' fs ss) =
+        DependencyReason pn' (M.insert fn v fs) ss
 
     -- If both branches contain the same package as a simple dep, we lift it to
     -- the next higher-level, but with the union of version ranges. This

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -232,4 +232,4 @@ _removeGR = trav go
        DependencyGoal $
        DependencyReason
            (Q (PackagePath DefaultNamespace QualToplevel) (mkPackageName "$"))
-           [] []
+           M.empty S.empty

--- a/cabal-install/Distribution/Solver/Modular/Validate.hs
+++ b/cabal-install/Distribution/Solver/Modular/Validate.hs
@@ -397,7 +397,7 @@ extend extSupported langSupported pkgPresent newactives ppa = foldM extendSingle
 extendWithPackageChoice :: PI QPN -> PPreAssignment -> Either Conflict PPreAssignment
 extendWithPackageChoice (PI qpn i) ppa =
   let mergedDep = M.findWithDefault (MergedDepConstrained []) qpn ppa
-      newChoice = PkgDep (DependencyReason qpn [] []) Nothing qpn (Fixed i)
+      newChoice = PkgDep (DependencyReason qpn M.empty S.empty) Nothing qpn (Fixed i)
   in  case (\ x -> M.insert qpn x ppa) <$> merge mergedDep newChoice of
         Left (c, (d, _d')) -> -- Don't include the package choice in the
                               -- FailReason, because it is redundant.

--- a/cabal-install/Distribution/Solver/Modular/Version.hs
+++ b/cabal-install/Distribution/Solver/Modular/Version.hs
@@ -38,11 +38,11 @@ eqVR = CV.thisVersion
 
 -- | Intersect two version ranges.
 (.&&.) :: VR -> VR -> VR
-(.&&.) = CV.intersectVersionRanges
+v1 .&&. v2 = simplifyVR $ CV.intersectVersionRanges v1 v2
 
 -- | Union of two version ranges.
 (.||.) :: VR -> VR -> VR
-(.||.) = CV.unionVersionRanges
+v1 .||. v2 = simplifyVR $ CV.unionVersionRanges v1 v2
 
 -- | Simplify a version range.
 simplifyVR :: VR -> VR

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/MemoryUsage.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/MemoryUsage.hs
@@ -11,6 +11,7 @@ tests = [
       runTest $ basicTest "basic space leak test"
     , runTest $ flagsTest "package with many flags"
     , runTest $ issue2899 "issue #2899"
+    , runTest $ duplicateDependencies "duplicate dependencies"
     ]
 
 -- | This test solves for n packages that each have two versions. There is no
@@ -95,3 +96,68 @@ issue2899 name =
 
     goals :: [ExampleVar]
     goals = [P QualNone "setup-dep", P (QualSetup "target") "setup-dep"]
+
+-- | Test for an issue related to lifting dependencies out of conditionals when
+-- converting a PackageDescription to the solver's internal representation.
+--
+-- Issue:
+-- For each conditional and each package B, the solver combined each dependency
+-- on B in the true branch with each dependency on B in the false branch. It
+-- added the combined dependencies to the build-depends outside of the
+-- conditional. Since dependencies could be lifted out of multiple levels of
+-- conditionals, the number of new dependencies could grow exponentially in the
+-- number of levels. For example, the following package generated 4 copies of B
+-- under flag-2=False, 8 copies under flag-1=False, and 16 copies at the top
+-- level:
+--
+-- if flag(flag-1)
+--   build-depends: B, B
+-- else
+--   if flag(flag-2)
+--     build-depends: B, B
+--   else
+--     if flag(flag-3)
+--       build-depends: B, B
+--     else
+--       build-depends: B, B
+--
+-- This issue caused the quickcheck tests to start frequently running out of
+-- memory after an optimization that pruned unreachable branches (See PR #4929).
+-- Each problematic test case contained at least one build-depends field with
+-- duplicate dependencies, which was then duplicated under multiple levels of
+-- conditionals by the solver's "buildable: False" transformation, when
+-- "buildable: False" was under multiple flags. Finally, the branch pruning
+-- feature put all build-depends fields in consecutive levels of the condition
+-- tree, causing the solver's representation of the package to follow the
+-- pattern in the example above.
+--
+-- Now the solver avoids this issue by combining all dependencies on the same
+-- package within a build-depends field before lifting them out of conditionals.
+--
+-- This test case is an expanded version of the example above, with library and
+-- build-tool dependencies.
+duplicateDependencies :: String -> SolverTest
+duplicateDependencies name =
+    mkTest pkgs name ["A"] $ solverSuccess [("A", 1), ("B", 1)]
+  where
+    copies, depth :: Int
+    copies = 50
+    depth = 50
+
+    pkgs :: ExampleDb
+    pkgs = [
+        Right $ exAv "A" 1 (flaggedDependencies 1)
+      , Right $ exAv "B" 1 [] `withExe` ExExe "exe" []
+      ]
+
+    flaggedDependencies :: Int -> [ExampleDependency]
+    flaggedDependencies n
+        | n > depth = buildDepends
+        | otherwise = [exFlagged (flagName n) buildDepends
+                                              (flaggedDependencies (n + 1))]
+      where
+        buildDepends = replicate copies (ExFix "B" 1)
+                    ++ replicate copies (ExBuildToolFix "B" "exe" 1)
+
+    flagName :: Int -> ExampleFlagName
+    flagName x = "flag-" ++ show x


### PR DESCRIPTION
This commit changes DependencyReason's list fields to maps and sets. Duplicate
flags were possible when a flag appeared multiple times in nested conditionals
or a flag controlled a "Buildable: False" field. The duplicate flag could show
up in log messages:

Before:
```
[__5] trying: json-rpc-client:+demo
[__6] trying: process-1.6.1.0/installed-1.6... (dependency of json-rpc-client +demo +demo)
```

After:
```
[__5] trying: json-rpc-client:+demo
[__6] trying: process-1.6.1.0/installed-1.6... (dependency of json-rpc-client +demo)
```

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
