### PR TITLE
Foreign lib names not parsed by readp

### DIFF
--- a/Cabal/Distribution/PackageDescription/PrettyPrint.hs
+++ b/Cabal/Distribution/PackageDescription/PrettyPrint.hs
@@ -147,7 +147,7 @@ ppCondSubLibraries libs = vcat
 
 ppCondForeignLibs :: [(UnqualComponentName, CondTree ConfVar [Dependency] ForeignLib)] -> Doc
 ppCondForeignLibs flibs = vcat
-    [ emptyLine $ (text "library" <+> disp n) $+$
+    [ emptyLine $ (text "foreign-library" <+> disp n) $+$
       nest indentWith (ppCondTree2 (foreignLibFieldGrammar n) condTree)
     | (n, condTree) <- flibs
     ]

--- a/Cabal/tests/ParserHackageTests.hs
+++ b/Cabal/tests/ParserHackageTests.hs
@@ -35,6 +35,7 @@ import qualified Distribution.ParseUtils                as ReadP
 import           Distribution.Compat.Lens
 import qualified Distribution.Types.BuildInfo.Lens                 as L
 import qualified Distribution.Types.Executable.Lens                as L
+import qualified Distribution.Types.ForeignLib.Lens                as L
 import qualified Distribution.Types.GenericPackageDescription.Lens as L
 import qualified Distribution.Types.Library.Lens                   as L
 import qualified Distribution.Types.PackageDescription.Lens        as L
@@ -123,9 +124,10 @@ compareTest pfx fpath bsl
             & L.packageDescription . L.description .~ ""
             & L.packageDescription . L.synopsis    .~ ""
             & L.packageDescription . L.maintainer  .~ ""
-            -- ReadP doesn't (always) parse sublibrary or executable names
+            -- ReadP doesn't (always) parse sublibrary or executable or other component names
             & L.condSubLibraries . traverse . _2 . traverse . L.libName .~ Nothing
             & L.condExecutables  . traverse . _2 . traverse . L.exeName .~ fromString ""
+            & L.condForeignLibs  . traverse . _2 . traverse . L.foreignLibName .~ fromString ""
             -- custom fields: no order. TODO: see if we can preserve it.
             & L.buildInfos . L.customFieldsBI %~ sort
 


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
