### PR TITLE
travis-ci: bootstrap on 8.2.2 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,9 @@ matrix:
    - env: GHCVER=8.0.2 SCRIPT=bootstrap USE_GOLD=YES
      sudo: required
      os: linux
+   - env: GHCVER=8.2.2 SCRIPT=bootstrap USE_GOLD=YES
+     sudo: required
+     os: linux
    - env: GHCVER=8.2.1 SCRIPT=script
      os: linux
      sudo: required

--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -227,29 +227,29 @@ case "$GHC_VER" in
 esac
 
 
-TEXT_VER="1.2.2.1";    TEXT_VER_REGEXP="((1\.[012]\.)|(0\.([2-9]|(1[0-1]))\.))"
+TEXT_VER="1.2.2.2";    TEXT_VER_REGEXP="((1\.[012]\.)|(0\.([2-9]|(1[0-1]))\.))"
                        # >= 0.2 && < 1.3
-NETWORK_VER="2.6.3.1"; NETWORK_VER_REGEXP="2\.[0-6]\."
+NETWORK_VER="2.6.3.2"; NETWORK_VER_REGEXP="2\.[0-6]\."
                        # >= 2.0 && < 2.7
 NETWORK_URI_VER="2.6.1.0"; NETWORK_URI_VER_REGEXP="2\.6\."
                        # >= 2.6 && < 2.7
-CABAL_VER="2.1.0.0";  CABAL_VER_REGEXP="2\.1\.[0-9]"
+CABAL_VER="2.1.0.0";   CABAL_VER_REGEXP="2\.1\.[0-9]"
                        # >= 2.1 && < 2.2
-TRANS_VER="0.5.2.0";   TRANS_VER_REGEXP="0\.[45]\."
+TRANS_VER="0.5.5.0";   TRANS_VER_REGEXP="0\.[45]\."
                        # >= 0.2.* && < 0.6
 MTL_VER="2.2.1";       MTL_VER_REGEXP="[2]\."
                        #  >= 2.0 && < 3
-HTTP_VER="4000.3.3";   HTTP_VER_REGEXP="4000\.(2\.([5-9]|1[0-9]|2[0-9])|3\.?)"
+HTTP_VER="4000.3.8";   HTTP_VER_REGEXP="4000\.(2\.([5-9]|1[0-9]|2[0-9])|3\.?)"
                        # >= 4000.2.5 < 4000.4
 ZLIB_VER="0.6.1.2";    ZLIB_VER_REGEXP="(0\.5\.([3-9]|1[0-9])|0\.6)"
                        # >= 0.5.3 && <= 0.7
-TIME_VER="1.7"         TIME_VER_REGEXP="1\.[1-7]\.?"
-                       # >= 1.1 && < 1.8
+TIME_VER="1.8.0.3"     TIME_VER_REGEXP="1\.[1-8]\.?"
+                       # >= 1.1 && < 1.9
 RANDOM_VER="1.1"       RANDOM_VER_REGEXP="1\.[01]\.?"
                        # >= 1 && < 1.2
 STM_VER="2.4.4.1";     STM_VER_REGEXP="2\."
                        # == 2.*
-ASYNC_VER="2.1.0";     ASYNC_VER_REGEXP="2\."
+ASYNC_VER="2.1.1.1";   ASYNC_VER_REGEXP="2\."
                        # 2.*
 OLD_TIME_VER="1.1.0.3"; OLD_TIME_VER_REGEXP="1\.[01]\.?"
                        # >=1.0.0.0 && <1.2
@@ -259,11 +259,11 @@ BASE16_BYTESTRING_VER="0.1.1.6"; BASE16_BYTESTRING_VER_REGEXP="0\.1"
                        # 0.1.*
 BASE64_BYTESTRING_VER="1.0.0.1"; BASE64_BYTESTRING_VER_REGEXP="1\."
                        # >=1.0
-CRYPTOHASH_SHA256_VER="0.11.100.1"; CRYPTOHASH_SHA256_VER_REGEXP="0\.11\.?"
+CRYPTOHASH_SHA256_VER="0.11.101.0"; CRYPTOHASH_SHA256_VER_REGEXP="0\.11\.?"
                        # 0.11.*
-RESOLV_VER="0.1.1.0";  RESOLV_VER_REGEXP="0\.1\.[1-9]"
+RESOLV_VER="0.1.1.1";  RESOLV_VER_REGEXP="0\.1\.[1-9]"
                        # >= 0.1.1 && < 0.2
-MINTTY_VER="0.1";      MINTTY_VER_REGEXP="0\.1\.?"
+MINTTY_VER="0.1.1";    MINTTY_VER_REGEXP="0\.1\.?"
                        # 0.1.*
 ECHO_VER="0.1.3";      ECHO_VER_REGEXP="0\.1\.[3-9]"
                        # >= 0.1.3 && < 0.2
@@ -276,7 +276,7 @@ HACKAGE_SECURITY_VER="0.5.2.2"; HACKAGE_SECURITY_VER_REGEXP="0\.5\.(2\.[2-9]|[3-
 BYTESTRING_BUILDER_VER="0.10.8.1.0"; BYTESTRING_BUILDER_VER_REGEXP="0\.10\.?"
 TAR_VER="0.5.0.3";     TAR_VER_REGEXP="0\.5\.([1-9]|1[0-9]|0\.[3-9]|0\.1[0-9])\.?"
                        # >= 0.5.0.3  && < 0.6
-HASHABLE_VER="1.2.4.0"; HASHABLE_VER_REGEXP="1\."
+HASHABLE_VER="1.2.6.1"; HASHABLE_VER_REGEXP="1\."
                        # 1.*
 
 HACKAGE_URL="https://hackage.haskell.org/package"


### PR DESCRIPTION
As per discussion in #4932.