### PR TITLE
Fix cases where "it's" was used as a possessive

### DIFF
--- a/Cabal/Distribution/Parsec/Parser.hs
+++ b/Cabal/Distribution/Parsec/Parser.hs
@@ -221,7 +221,7 @@ elements ilevel = many (element ilevel)
 
 -- An individual element, ie a field or a section. These can either use
 -- layout style or braces style. For layout style then it must start on
--- a line on it's own (so that we know its indentation level).
+-- a line on its own (so that we know its indentation level).
 --
 -- element ::= '\n' name elementInLayoutContext
 --           |      name elementInNonLayoutContext

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -11,7 +11,7 @@
 -- Portability :  portable
 --
 -- This should be a much more sophisticated abstraction than it is. Currently
--- it's just a bit of data about the compiler, like it's flavour and name and
+-- it's just a bit of data about the compiler, like its flavour and name and
 -- version. The reason it's just data is because currently it has to be in
 -- 'Read' and 'Show' so it can be saved along with the 'LocalBuildInfo'. The
 -- only interesting bit of info it contains is a mapping between language

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -499,7 +499,7 @@ profDetailLevelFlag forLib mpl =
 -- -----------------------------------------------------------------------------
 -- GHC platform and version strings
 
--- | GHC's rendering of it's host or target 'Arch' as used in its platform
+-- | GHC's rendering of its host or target 'Arch' as used in its platform
 -- strings and certain file locations (such as user package db location).
 --
 ghcArchString :: Arch -> String
@@ -507,7 +507,7 @@ ghcArchString PPC   = "powerpc"
 ghcArchString PPC64 = "powerpc64"
 ghcArchString other = display other
 
--- | GHC's rendering of it's host or target 'OS' as used in its platform
+-- | GHC's rendering of its host or target 'OS' as used in its platform
 -- strings and certain file locations (such as user package db location).
 --
 ghcOsString :: OS -> String
@@ -516,7 +516,7 @@ ghcOsString OSX     = "darwin"
 ghcOsString Solaris = "solaris2"
 ghcOsString other   = display other
 
--- | GHC's rendering of it's platform and compiler version string as used in
+-- | GHC's rendering of its platform and compiler version string as used in
 -- certain file locations (such as user package db location).
 -- For example @x86_64-linux-7.10.4@
 --

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -466,7 +466,7 @@ ppHsc2hs bi lbi clbi =
       _     -> id
     -- We don't link in the actual Haskell libraries of our dependencies, so
     -- the -u flags in the ldOptions of the rts package mean linking fails on
-    -- OS X (it's ld is a tad stricter than gnu ld). Thus we remove the
+    -- OS X (its ld is a tad stricter than gnu ld). Thus we remove the
     -- ldOptions for GHC's rts package:
     hackRtsPackage index =
       case PackageIndex.lookupPackageName index (mkPackageName "rts") of

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -70,7 +70,7 @@ data GhcOptions = GhcOptions {
   ghcOptOutputDynFile :: Flag FilePath,
 
   -- | Start with an empty search path for Haskell source files;
-  -- the @ghc -i@ flag (@-i@ on it's own with no path argument).
+  -- the @ghc -i@ flag (@-i@ on its own with no path argument).
   ghcOptSourcePathClear :: Flag Bool,
 
   -- | Search path for Haskell source files; the @ghc -i@ flag.

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -999,7 +999,7 @@ Library
     :synopsis: Library build information.
 
     Build information for libraries. There can be only one library in a
-    package, and it's name is the same as package name set by global
+    package, and its name is the same as package name set by global
     :pkg-field:`name` field.
 
 The library section should contain the following fields:

--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -2,7 +2,7 @@
 
 -- |
 --
--- The layout of the .\/dist\/ directory where cabal keeps all of it's state
+-- The layout of the .\/dist\/ directory where cabal keeps all of its state
 -- and build artifacts.
 --
 module Distribution.Client.DistDirLayout (

--- a/cabal-install/Distribution/Client/PackageHash.hs
+++ b/cabal-install/Distribution/Client/PackageHash.hs
@@ -136,7 +136,7 @@ hashedInstalledPackageIdShort pkghashinputs@PackageHashInputs{pkgHashPkgId} =
 
 -- | On macOS we shorten the name very aggressively.  The mach-o linker on
 -- macOS has a limited load command size, to which the name of the lirbary
--- as well as it's relative path (\@rpath) entry count.  To circumvent this,
+-- as well as its relative path (\@rpath) entry count.  To circumvent this,
 -- on macOS the libraries are not stored as
 --  @store/<libraryname>/libHS<libraryname>.dylib@
 -- where libraryname contains the librarys name, version and abi hash, but in

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -147,11 +147,11 @@ instance (Binary loc) => Binary (ConfiguredPackage loc)
 
 -- | A ConfiguredId is a package ID for a configured package.
 --
--- Once we configure a source package we know it's UnitId. It is still
+-- Once we configure a source package we know its UnitId. It is still
 -- however useful in lots of places to also know the source ID for the package.
 -- We therefore bundle the two.
 --
--- An already installed package of course is also "configured" (all it's
+-- An already installed package of course is also "configured" (all its
 -- configuration parameters and dependencies have been specified).
 data ConfiguredId = ConfiguredId {
     confSrcId  :: PackageId

--- a/cabal-install/Distribution/Client/Win32SelfUpgrade.hs
+++ b/cabal-install/Distribution/Client/Win32SelfUpgrade.hs
@@ -17,7 +17,7 @@ module Distribution.Client.Win32SelfUpgrade (
 -- | Windows inherited a design choice from DOS that while initially innocuous
 -- has rather unfortunate consequences. It maintains the invariant that every
 -- open file has a corresponding name on disk. One positive consequence of this
--- is that an executable can always find it's own executable file. The downside
+-- is that an executable can always find its own executable file. The downside
 -- is that a program cannot be deleted or upgraded while it is running without
 -- hideous workarounds. This module implements one such hideous workaround.
 --


### PR DESCRIPTION
[ci skip]

Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [X] Any changes that could be relevant to users have been recorded in the changelog.
* [X] The documentation has been updated, if necessary.
* [X] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
No tests were added.