### PR TITLE
Fix how the timestamps of add-source packages are updated.

### DIFF
--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -38,6 +38,9 @@
 	* 'new-build' now checks for the existence of executables for
 	build-tools and build-tool-depends dependencies in the solver
 	(#4884).
+	* Packages installed in sandboxes via 'add-source' now have 
+	  their timestamps updated correctly and so will not be reinstalled 
+	  unncecessarily if the main install command fails (#1375).
 
 2.0.0.1 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> December 2017
 	* Support for GHC's numeric -g debug levels (#4673).


### PR DESCRIPTION
This is to address #1375.

Previously they were updated in the post install phase, which
would mean that the sources did not have their timestamps
updated unless the package being installed completed successfully.

This change moves the updating of the timestamps to the end of
the install phase, so that the add-source packages that are
successfully installed get their timestamps updated regardless of
the overall outcome of the installation.

This was tested locally with a setup mirroring that in the issue.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
