### PR TITLE
Versioned grammars + leading comma support for build-depends

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -38,6 +38,8 @@ extra-source-files:
   tests/ParserTests/errors/common2.errors
   tests/ParserTests/errors/common3.cabal
   tests/ParserTests/errors/common3.errors
+  tests/ParserTests/errors/leading-comma.cabal
+  tests/ParserTests/errors/leading-comma.errors
   tests/ParserTests/regressions/Octree-0.5.cabal
   tests/ParserTests/regressions/Octree-0.5.format
   tests/ParserTests/regressions/common.cabal
@@ -55,6 +57,8 @@ extra-source-files:
   tests/ParserTests/regressions/haddock-api-2.18.1-check.cabal
   tests/ParserTests/regressions/issue-774.cabal
   tests/ParserTests/regressions/issue-774.format
+  tests/ParserTests/regressions/leading-comma.cabal
+  tests/ParserTests/regressions/leading-comma.format
   tests/ParserTests/regressions/nothing-unicode.cabal
   tests/ParserTests/regressions/nothing-unicode.format
   tests/ParserTests/regressions/shake.cabal
@@ -148,6 +152,7 @@ library
     Distribution.Backpack.ModSubst
     Distribution.Backpack.ModuleShape
     Distribution.Backpack.PreModuleShape
+    Distribution.CabalSpecVersion
     Distribution.Utils.IOData
     Distribution.Utils.LogProgress
     Distribution.Utils.MapAccum

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -63,6 +63,8 @@ extra-source-files:
   tests/ParserTests/regressions/nothing-unicode.format
   tests/ParserTests/regressions/shake.cabal
   tests/ParserTests/regressions/shake.format
+  tests/ParserTests/regressions/wl-pprint-indef.cabal
+  tests/ParserTests/regressions/wl-pprint-indef.format
   tests/ParserTests/warnings/bom.cabal
   tests/ParserTests/warnings/bool.cabal
   tests/ParserTests/warnings/deprecatedfield.cabal

--- a/Cabal/Distribution/CabalSpecVersion.hs
+++ b/Cabal/Distribution/CabalSpecVersion.hs
@@ -18,10 +18,18 @@ class CabalSpecVersion v where
     specHasCommonStanzas   :: v -> HasCommonStanzas
 
 data CabalSpecOld = CabalSpecOld
+data CabalSpecV20 = CabalSpecV20
 data CabalSpecV22 = CabalSpecV22
 
 instance CabalSpecVersion CabalSpecOld where
     cabalSpecVersion       = CabalSpecOld
+    specParsec _           = parsec
+    specKnows _ vs         = vs < [1,25]
+    specHasElif _          = NoElif
+    specHasCommonStanzas _ = NoCommonStanzas
+
+instance CabalSpecVersion CabalSpecV20  where
+    cabalSpecVersion       = CabalSpecV20
     specParsec _           = parsec
     specKnows _ vs         = vs < [2,1]
     specHasElif _          = NoElif

--- a/Cabal/Distribution/CabalSpecVersion.hs
+++ b/Cabal/Distribution/CabalSpecVersion.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE FlexibleContexts, RankNTypes #-}
+module Distribution.CabalSpecVersion where
+
+import Distribution.Parsec.Class (Parsec (..), ParsecParser)
+
+-- A class to select how to parse different fields.
+class CabalSpecVersion v where
+    -- | @v@ can act as own proxy
+    cabalSpecVersion   :: v
+
+    -- | Parsec parser according to the spec version
+    specParsec         :: Parsec a => v -> ParsecParser a
+
+    -- given a version, whether this spec knows about it's fields
+    specKnows              :: v -> [Int] -> Bool
+
+    specHasElif            :: v -> HasElif
+    specHasCommonStanzas   :: v -> HasCommonStanzas
+
+data CabalSpecOld = CabalSpecOld
+data CabalSpecV22 = CabalSpecV22
+
+instance CabalSpecVersion CabalSpecOld where
+    cabalSpecVersion       = CabalSpecOld
+    specParsec _           = parsec
+    specKnows _ vs         = vs < [2,1]
+    specHasElif _          = NoElif
+    specHasCommonStanzas _ = NoCommonStanzas
+
+instance CabalSpecVersion CabalSpecV22  where
+    cabalSpecVersion       = CabalSpecV22
+    specParsec _           = parsec22
+    specKnows _ _          = True
+    specHasElif _          = HasElif
+    specHasCommonStanzas _ = HasCommonStanzas
+
+type CabalSpecLatest = CabalSpecV22
+
+-------------------------------------------------------------------------------
+-- "Booleans"
+-------------------------------------------------------------------------------
+
+data HasElif = HasElif | NoElif
+  deriving (Eq, Show)
+
+data HasCommonStanzas = HasCommonStanzas | NoCommonStanzas
+  deriving (Eq, Show)

--- a/Cabal/Distribution/FieldGrammar.hs
+++ b/Cabal/Distribution/FieldGrammar.hs
@@ -40,8 +40,8 @@ import Distribution.FieldGrammar.Pretty
 import Distribution.Parsec.Field
 import Distribution.Utils.Generic (spanMaybe)
 
-type ParsecFieldGrammar' a = ParsecFieldGrammar a a
-type PrettyFieldGrammar' a = PrettyFieldGrammar a a
+type ParsecFieldGrammar' v a = ParsecFieldGrammar v a a
+type PrettyFieldGrammar'   a = PrettyFieldGrammar   a a
 
 infixl 5 ^^^
 

--- a/Cabal/Distribution/FieldGrammar/Class.hs
+++ b/Cabal/Distribution/FieldGrammar/Class.hs
@@ -90,6 +90,7 @@ class FieldGrammar g where
     -- | Annotate field with since spec-version.
     availableSince
         :: [Int]  -- ^ spec version
+        -> a      -- ^ default value
         -> g s a
         -> g s a
 

--- a/Cabal/Distribution/FieldGrammar/Pretty.hs
+++ b/Cabal/Distribution/FieldGrammar/Pretty.hs
@@ -66,5 +66,5 @@ instance FieldGrammar PrettyFieldGrammar where
     knownField _           = pure ()
     deprecatedSince [] _ _ = PrettyFG (\_ -> mempty)
     deprecatedSince _  _ x = x
-    availableSince _       = id
+    availableSince _ _     = id
     hiddenField _          = PrettyFG (\_ -> mempty)

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -43,6 +43,7 @@ import Distribution.Compat.Lens
 import Distribution.Compat.Prelude
 import Prelude ()
 
+import Distribution.CabalSpecVersion
 import Distribution.Compiler                  (CompilerFlavor (..))
 import Distribution.FieldGrammar
 import Distribution.License                   (License (..))
@@ -127,7 +128,8 @@ libraryFieldGrammar n = Library n
     <*> monoidalFieldAla  "signatures"         (alaList' VCat MQuoted) L.signatures
     <*> booleanFieldDef   "exposed"                                    L.libExposed True
     <*> blurFieldGrammar L.libBuildInfo buildInfoFieldGrammar
-{-# SPECIALIZE libraryFieldGrammar :: Maybe UnqualComponentName -> ParsecFieldGrammar' Library #-}
+{-# SPECIALIZE libraryFieldGrammar :: Maybe UnqualComponentName -> ParsecFieldGrammar' CabalSpecOld Library #-}
+{-# SPECIALIZE libraryFieldGrammar :: Maybe UnqualComponentName -> ParsecFieldGrammar' CabalSpecV22 Library #-}
 {-# SPECIALIZE libraryFieldGrammar :: Maybe UnqualComponentName -> PrettyFieldGrammar' Library #-}
 
 -------------------------------------------------------------------------------
@@ -144,7 +146,8 @@ foreignLibFieldGrammar n = ForeignLib n
     <*> optionalField    "lib-version-info"                             L.foreignLibVersionInfo
     <*> optionalField    "lib-version-linux"                            L.foreignLibVersionLinux
     <*> monoidalFieldAla "mod-def-file"      (alaList' FSep FilePathNT) L.foreignLibModDefFile
-{-# SPECIALIZE foreignLibFieldGrammar :: UnqualComponentName -> ParsecFieldGrammar' ForeignLib #-}
+{-# SPECIALIZE foreignLibFieldGrammar :: UnqualComponentName -> ParsecFieldGrammar' CabalSpecOld ForeignLib #-}
+{-# SPECIALIZE foreignLibFieldGrammar :: UnqualComponentName -> ParsecFieldGrammar' CabalSpecV22 ForeignLib #-}
 {-# SPECIALIZE foreignLibFieldGrammar :: UnqualComponentName -> PrettyFieldGrammar' ForeignLib #-}
 
 -------------------------------------------------------------------------------
@@ -159,7 +162,8 @@ executableFieldGrammar n = Executable n
     <$> optionalFieldDefAla "main-is" FilePathNT L.modulePath ""
     <*> monoidalField       "scope"              L.exeScope
     <*> blurFieldGrammar L.buildInfo buildInfoFieldGrammar
-{-# SPECIALIZE executableFieldGrammar :: UnqualComponentName -> ParsecFieldGrammar' Executable #-}
+{-# SPECIALIZE executableFieldGrammar :: UnqualComponentName -> ParsecFieldGrammar' CabalSpecOld Executable #-}
+{-# SPECIALIZE executableFieldGrammar :: UnqualComponentName -> ParsecFieldGrammar' CabalSpecV22 Executable #-}
 {-# SPECIALIZE executableFieldGrammar :: UnqualComponentName -> PrettyFieldGrammar' Executable #-}
 
 -------------------------------------------------------------------------------
@@ -404,7 +408,8 @@ buildInfoFieldGrammar = BuildInfo
     <*> prefixedFields   "x-"                                                 L.customFieldsBI
     <*> monoidalFieldAla "build-depends"        (alaList  CommaVCat)          L.targetBuildDepends
     <*> monoidalFieldAla "mixins"               (alaList  CommaVCat)          L.mixins
-{-# SPECIALIZE buildInfoFieldGrammar :: ParsecFieldGrammar' BuildInfo #-}
+{-# SPECIALIZE buildInfoFieldGrammar :: ParsecFieldGrammar' CabalSpecOld BuildInfo #-}
+{-# SPECIALIZE buildInfoFieldGrammar :: ParsecFieldGrammar' CabalSpecV22 BuildInfo #-}
 {-# SPECIALIZE buildInfoFieldGrammar :: PrettyFieldGrammar' BuildInfo #-}
 
 hsSourceDirsGrammar
@@ -487,7 +492,8 @@ flagFieldGrammar name = MkFlag name
     <$> optionalFieldDefAla "description" FreeText L.flagDescription ""
     <*> booleanFieldDef     "default"              L.flagDefault     True
     <*> booleanFieldDef     "manual"               L.flagManual      False
-{-# SPECIALIZE flagFieldGrammar :: FlagName -> ParsecFieldGrammar' Flag #-}
+{-# SPECIALIZE flagFieldGrammar :: FlagName -> ParsecFieldGrammar' CabalSpecOld Flag #-}
+{-# SPECIALIZE flagFieldGrammar :: FlagName -> ParsecFieldGrammar' CabalSpecV22 Flag #-}
 {-# SPECIALIZE flagFieldGrammar :: FlagName -> PrettyFieldGrammar' Flag #-}
 
 -------------------------------------------------------------------------------
@@ -504,7 +510,8 @@ sourceRepoFieldGrammar kind = SourceRepo kind
     <*> optionalFieldAla "branch"   Token      L.repoBranch
     <*> optionalFieldAla "tag"      Token      L.repoTag
     <*> optionalFieldAla "subdir"   FilePathNT L.repoSubdir
-{-# SPECIALIZE sourceRepoFieldGrammar :: RepoKind -> ParsecFieldGrammar' SourceRepo #-}
+{-# SPECIALIZE sourceRepoFieldGrammar :: RepoKind -> ParsecFieldGrammar' CabalSpecOld SourceRepo #-}
+{-# SPECIALIZE sourceRepoFieldGrammar :: RepoKind -> ParsecFieldGrammar' CabalSpecV22 SourceRepo #-}
 {-# SPECIALIZE sourceRepoFieldGrammar :: RepoKind ->PrettyFieldGrammar' SourceRepo #-}
 
 -------------------------------------------------------------------------------
@@ -516,5 +523,6 @@ setupBInfoFieldGrammar
     => Bool -> g SetupBuildInfo SetupBuildInfo
 setupBInfoFieldGrammar def = flip SetupBuildInfo def
     <$> monoidalFieldAla "setup-depends" (alaList CommaVCat) L.setupDepends
-{-# SPECIALIZE setupBInfoFieldGrammar :: Bool -> ParsecFieldGrammar' SetupBuildInfo #-}
+{-# SPECIALIZE setupBInfoFieldGrammar :: Bool -> ParsecFieldGrammar' CabalSpecOld SetupBuildInfo #-}
+{-# SPECIALIZE setupBInfoFieldGrammar :: Bool -> ParsecFieldGrammar' CabalSpecV22 SetupBuildInfo #-}
 {-# SPECIALIZE setupBInfoFieldGrammar :: Bool ->PrettyFieldGrammar' SetupBuildInfo #-}

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -126,6 +126,7 @@ libraryFieldGrammar n = Library n
     <$> monoidalFieldAla  "exposed-modules"    (alaList' VCat MQuoted) L.exposedModules
     <*> monoidalFieldAla  "reexported-modules" (alaList  CommaVCat)    L.reexportedModules
     <*> monoidalFieldAla  "signatures"         (alaList' VCat MQuoted) L.signatures
+        ^^^ availableSince [2,0] []
     <*> booleanFieldDef   "exposed"                                    L.libExposed True
     <*> blurFieldGrammar L.libBuildInfo buildInfoFieldGrammar
 {-# SPECIALIZE libraryFieldGrammar :: Maybe UnqualComponentName -> ParsecFieldGrammar' CabalSpecOld Library #-}
@@ -368,7 +369,11 @@ buildInfoFieldGrammar = BuildInfo
     <*> monoidalFieldAla "build-tools"          (alaList  CommaFSep)          L.buildTools
         ^^^ deprecatedSince [2,0] "Please use 'build-tool-depends' field"
     <*> monoidalFieldAla "build-tool-depends"   (alaList  CommaFSep)          L.buildToolDepends
-        ^^^ availableSince [2,0]
+        -- {- ^^^ availableSince [2,0] [] -}
+        -- here, we explicitly want to recognise build-tool-depends for all Cabal files
+        -- as otherwise cabal new-build cannot really work.
+        --
+        -- I.e. we don't want trigger unknown field warning
     <*> monoidalFieldAla "cpp-options"          (alaList' NoCommaFSep Token') L.cppOptions
     <*> monoidalFieldAla "asm-options"          (alaList' NoCommaFSep Token') L.asmOptions
     <*> monoidalFieldAla "cmm-options"          (alaList' NoCommaFSep Token') L.cmmOptions
@@ -408,6 +413,7 @@ buildInfoFieldGrammar = BuildInfo
     <*> prefixedFields   "x-"                                                 L.customFieldsBI
     <*> monoidalFieldAla "build-depends"        (alaList  CommaVCat)          L.targetBuildDepends
     <*> monoidalFieldAla "mixins"               (alaList  CommaVCat)          L.mixins
+        ^^^ availableSince [2,0] []
 {-# SPECIALIZE buildInfoFieldGrammar :: ParsecFieldGrammar' CabalSpecOld BuildInfo #-}
 {-# SPECIALIZE buildInfoFieldGrammar :: ParsecFieldGrammar' CabalSpecV22 BuildInfo #-}
 {-# SPECIALIZE buildInfoFieldGrammar :: PrettyFieldGrammar' BuildInfo #-}

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -168,6 +168,8 @@ parseGenericPackageDescription' lexWarnings fs = do
     let goSections'
           | specVersion pd >= mkVersion [2,1] =
               goSections (cabalSpecVersion :: CabalSpecV22)
+          | specVersion pd >= mkVersion [1,25] =
+              goSections (cabalSpecVersion :: CabalSpecV20)
           | otherwise =
               goSections (cabalSpecVersion :: CabalSpecOld)
 

--- a/Cabal/Distribution/Parsec/Class.hs
+++ b/Cabal/Distribution/Parsec/Class.hs
@@ -2,6 +2,7 @@
 module Distribution.Parsec.Class (
     Parsec(..),
     ParsecParser,
+    lexemeParsec,
     simpleParsec,
     -- * Warnings
     parsecWarning,
@@ -13,6 +14,7 @@ module Distribution.Parsec.Class (
     parsecQuoted,
     parsecMaybeQuoted,
     parsecCommaList,
+    parsecLeadingCommaList,
     parsecOptCommaList,
     parsecStandard,
     parsecUnqualComponentName,
@@ -31,17 +33,17 @@ import qualified Text.Parsec.Token           as Parsec
 -- Class
 -------------------------------------------------------------------------------
 
--- |
---
--- TODO: implementation details: should be careful about consuming
--- trailing whitespace?
--- Should we always consume it?
+-- | Class for parsing with @parsec@. Mainly used for @.cabal@ file fields.
 class Parsec a where
     parsec :: ParsecParser a
 
-    -- | 'parsec' /could/ consume trailing spaces, this function /must/ consume.
-    lexemeParsec :: ParsecParser a
-    lexemeParsec = parsec <* P.spaces
+    -- | A variant for @cabal-version: 2.2@
+    parsec22 :: ParsecParser a
+    parsec22 = parsec
+
+-- | 'parsec' /could/ consume trailing spaces, this function /will/ consume.
+lexemeParsec :: Parsec a => ParsecParser a
+lexemeParsec = parsec <* P.spaces
 
 type ParsecParser a = forall s. P.Stream s Identity Char => P.Parsec s [PWarning] a
 
@@ -105,6 +107,36 @@ parsecCommaList
     => P.Parsec s [PWarning] a
     -> P.Parsec s [PWarning] [a]
 parsecCommaList p = P.sepBy (p <* P.spaces) (P.char ',' *> P.spaces)
+
+-- | Like 'parsecCommaList' but accept leading or trailing comma.
+--
+-- @
+-- p (comma p)*  -- p `sepBy` comma
+-- (comma p)*    -- leading comma
+-- (p comma)*    -- trailing comma
+-- @
+parsecLeadingCommaList
+    :: P.Stream s Identity Char
+    => P.Parsec s [PWarning] a
+    -> P.Parsec s [PWarning] [a]
+parsecLeadingCommaList p = do
+    c <- Parsec.optionMaybe comma
+    case c of
+        Nothing -> trailing1 <|> pure []
+        Just _  -> P.sepBy1 lp comma
+  where
+    lp = p <* P.spaces
+    comma = P.char ',' *> P.spaces
+
+    -- Parsec.sepBy tries a parser after separator.
+    trailing1 = do
+        x <- p
+        c <- Parsec.optionMaybe comma
+        case c of
+            Nothing -> pure [x]
+            Just _  -> (x:) <$> trailing
+
+    trailing = trailing1 <|> pure []
 
 parsecOptCommaList
     :: P.Stream s Identity Char

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -35,6 +35,8 @@
 	* Use better defaulting for `build-type`; rename `PackageDescription`'s
 	  `buildType` field to `buildTypeRaw` and introduce new `buildType`
 	  function (#4958)
+	* Fields with mandatory commas (e.g. build-depends) may have
+	  leading or trailing comma (either one, not both) (#4953)
 	* TODO
 
 2.0.1.1 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> December 2017

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -115,6 +115,7 @@ regressionTests = testGroup "regressions"
     , regressionTest "common.cabal"
     , regressionTest "common2.cabal"
     , regressionTest "leading-comma.cabal"
+    , regressionTest "wl-pprint-indef.cabal"
     ]
 
 regressionTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -79,10 +79,11 @@ errorTests = testGroup "errors"
     [ errorTest "common1.cabal"
     , errorTest "common2.cabal"
     , errorTest "common3.cabal"
+    , errorTest "leading-comma.cabal"
     ]
 
 errorTest :: FilePath -> TestTree
-errorTest fp = cabalGoldenTest "errors" correct $ do
+errorTest fp = cabalGoldenTest fp correct $ do
     contents <- BS.readFile input
     let res =  parseGenericPackageDescription contents
     let (_, errs, x) = runParseResult res
@@ -113,6 +114,7 @@ regressionTests = testGroup "regressions"
     , regressionTest "shake.cabal"
     , regressionTest "common.cabal"
     , regressionTest "common2.cabal"
+    , regressionTest "leading-comma.cabal"
     ]
 
 regressionTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests/errors/leading-comma.cabal
+++ b/Cabal/tests/ParserTests/errors/leading-comma.cabal
@@ -1,0 +1,20 @@
+name:                leading-comma
+version:             0
+synopsis:            leading comma, trailing comma, or ordinary
+build-type:          Simple
+-- too small cabal-version
+cabal-version:       2.0
+
+library
+  default-language: Haskell2010
+  exposed-modules:  LeadingComma
+
+  build-depends: base, containers
+
+  build-depends:
+    deepseq,
+    transformers,
+
+  build-depends:
+    , filepath
+    , directory

--- a/Cabal/tests/ParserTests/errors/leading-comma.errors
+++ b/Cabal/tests/ParserTests/errors/leading-comma.errors
@@ -1,0 +1,1 @@
+PError (Position 16 18) "\nunexpected end of input\nexpecting white space: \"deepseq,\\ntransformers,\""

--- a/Cabal/tests/ParserTests/regressions/leading-comma.cabal
+++ b/Cabal/tests/ParserTests/regressions/leading-comma.cabal
@@ -1,0 +1,19 @@
+name:                leading-comma
+version:             0
+synopsis:            leading comma, trailing comma, or ordinary
+build-type:          Simple
+cabal-version:       2.1
+
+library
+  default-language: Haskell2010
+  exposed-modules:  LeadingComma
+
+  build-depends: base, containers
+
+  build-depends:
+    deepseq,
+    transformers,
+
+  build-depends:
+    , filepath
+    , directory

--- a/Cabal/tests/ParserTests/regressions/leading-comma.format
+++ b/Cabal/tests/ParserTests/regressions/leading-comma.format
@@ -1,0 +1,17 @@
+name: leading-comma
+version: 0
+synopsis: leading comma, trailing comma, or ordinary
+cabal-version: 2.1
+build-type: Simple
+
+library
+    exposed-modules:
+        LeadingComma
+    default-language: Haskell2010
+    build-depends:
+        base -any,
+        containers -any,
+        deepseq -any,
+        transformers -any,
+        filepath -any,
+        directory -any

--- a/Cabal/tests/ParserTests/regressions/wl-pprint-indef.cabal
+++ b/Cabal/tests/ParserTests/regressions/wl-pprint-indef.cabal
@@ -1,0 +1,34 @@
+Name:                wl-pprint-indef
+Version:             1.2
+Cabal-Version:       >=1.6
+Synopsis:            The Wadler/Leijen Pretty Printer
+Category:            Text
+Description:
+ This is a pretty printing library based on Wadler's paper "A Prettier
+ Printer".  See the haddocks for full info.  This version allows the
+ library user to declare overlapping instances of the 'Pretty' class.
+License:             BSD3
+License-file:        LICENSE
+Author:              Daan Leijen
+Maintainer:          Noam Lewis <jones.noamle@gmail.com>
+Build-Type:          Simple
+
+Executable           wl-pprint-string-example
+  Main-is:           Main.hs
+  Hs-Source-Dirs:    example-string
+  Other-Modules:     StringImpl
+  Build-Depends:     base < 5,
+                     str-string >= 0.1.0.0,
+                     wl-pprint-indef
+  Mixins:            wl-pprint-indef requires (Text.PrettyPrint.Leijen.Str as StringImpl)
+
+Library
+  Exposed-Modules:   Text.PrettyPrint.Leijen
+  Signatures:        Text.PrettyPrint.Leijen.Str
+  Mixins:            str-sig requires (Str as Text.PrettyPrint.Leijen.Str)
+  Build-Depends:     base < 5,
+                     str-sig >= 0.1.0.0
+
+source-repository head
+  type: git
+  location: git@github.com:danidiaz/wl-pprint-indef.git

--- a/Cabal/tests/ParserTests/regressions/wl-pprint-indef.format
+++ b/Cabal/tests/ParserTests/regressions/wl-pprint-indef.format
@@ -1,0 +1,42 @@
+PWarning PWTUnknownField (Position 28 3) "The field \"mixins\" is available since Cabal [2,0]"
+PWarning PWTUnknownField (Position 27 3) "The field \"signatures\" is available since Cabal [2,0]"
+PWarning PWTUnknownField (Position 27 3) "Unknown field: \"signatures\""
+PWarning PWTUnknownField (Position 28 3) "Unknown field: \"mixins\""
+PWarning PWTUnknownField (Position 23 3) "The field \"mixins\" is available since Cabal [2,0]"
+PWarning PWTUnknownField (Position 23 3) "Unknown field: \"mixins\""
+name: wl-pprint-indef
+version: 1.2
+license: BSD3
+license-file: LICENSE
+maintainer: Noam Lewis <jones.noamle@gmail.com>
+author: Daan Leijen
+synopsis: The Wadler/Leijen Pretty Printer
+description:
+    This is a pretty printing library based on Wadler's paper "A Prettier
+    Printer".  See the haddocks for full info.  This version allows the
+    library user to declare overlapping instances of the 'Pretty' class.
+category: Text
+cabal-version: >=1.6
+build-type: Simple
+
+source-repository head
+    type: git
+    location: git@github.com:danidiaz/wl-pprint-indef.git
+
+library
+    exposed-modules:
+        Text.PrettyPrint.Leijen
+    build-depends:
+        base <5,
+        str-sig >=0.1.0.0
+
+executable wl-pprint-string-example
+    main-is: Main.hs
+    scope: unknown
+    hs-source-dirs: example-string
+    other-modules:
+        StringImpl
+    build-depends:
+        base <5,
+        str-string >=0.1.0.0,
+        wl-pprint-indef -any


### PR DESCRIPTION
We need versioned grammars:

- `availableSince`, that would "fix" https://github.com/haskell/cabal/issues/4448 because backpack features won't be parsed. (User will get parse warnings about not-yet-supported spec version).
- SPDX license, how to parse `license:` field will change: https://github.com/haskell/cabal/issues/2547

Leading comma is just a simple extension to experiment with :)

I'm not 100% sure that `singletons`-ish approach is *the best*, but it has good features:
- we use dictionary as an argument, so the approach is at least as good (performance wise) as passing an argument:
  `Versioned v => ... -> a` vs. `Version -> ... -> a`.
- The dictionaries can be specialised (have to check the core if it actually works)
- Types are harder to change accidentally, a little like having `MonadReader Version => ... -> m a`.

It works, it's easy to see by changing `cabal-version` to `2.0` in `leading-comma.cabal`. Tests will fail. ~I'll add negative tests after common-stanza branch is merged.~ negative test added.

cc @23Skidoo @hvr

Surprisingly? this seems to be as performant as current `master`, parsing all Hackage packages starting with `a`: (including acme-everything :)

### this PR

```
 % /usr/bin/time -v .../parser-hackage-tests parse-parsec a +RTS -s
Reading index from: /home/ogre/.cabal/packages/hackage.haskell.org/01-index.tar
6714 files processed
  27,946,371,856 bytes allocated in the heap
   2,082,050,064 bytes copied during GC
       6,101,392 bytes maximum residency (970 sample(s))
       1,084,576 bytes maximum slop
              14 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     25627 colls,     0 par    2.304s   2.300s     0.0001s    0.0032s
  Gen  1       970 colls,     0 par    0.067s   0.067s     0.0001s    0.0009s

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    4.228s  (  4.225s elapsed)
  GC      time    2.371s  (  2.366s elapsed)
  EXIT    time   -0.000s  ( -0.000s elapsed)
  Total   time    6.598s  (  6.591s elapsed)

  %GC     time      35.9%  (35.9% elapsed)

  Alloc rate    6,610,560,408 bytes per MUT second

  Productivity  64.1% of total user, 64.1% of total elapsed
```

### this PR without SPECIALIZED in D.PD.FieldGrammar

```
6714 files processed
  27,921,069,992 bytes allocated in the heap
   2,105,778,208 bytes copied during GC
       7,756,992 bytes maximum residency (983 sample(s))
         731,304 bytes maximum slop
              17 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     25473 colls,     0 par    2.275s   2.271s     0.0001s    0.0057s
  Gen  1       983 colls,     0 par    0.067s   0.067s     0.0001s    0.0009s

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    4.188s  (  4.185s elapsed)
  GC      time    2.341s  (  2.338s elapsed)
  EXIT    time   -0.000s  ( -0.000s elapsed)
  Total   time    6.529s  (  6.522s elapsed)

  %GC     time      35.9%  (35.8% elapsed)

  Alloc rate    6,667,467,459 bytes per MUT second

  Productivity  64.1% of total user, 64.2% of total elapsed
```

### master

```
% /usr/bin/time -v .../parser-hackage-tests parse-parsec a +RTS -s
Reading index from: /home/ogre/.cabal/packages/hackage.haskell.org/01-index.tar
6714 files processed
  27,943,265,024 bytes allocated in the heap
   2,079,495,768 bytes copied during GC
       7,922,800 bytes maximum residency (974 sample(s))
         396,456 bytes maximum slop
              17 MB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     25618 colls,     0 par    2.246s   2.242s     0.0001s    0.0049s
  Gen  1       974 colls,     0 par    0.065s   0.065s     0.0001s    0.0010s

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time    4.277s  (  4.272s elapsed)
  GC      time    2.311s  (  2.307s elapsed)
  EXIT    time   -0.001s  ( -0.001s elapsed)
  Total   time    6.587s  (  6.578s elapsed)

  %GC     time      35.1%  (35.1% elapsed)

  Alloc rate    6,533,837,864 bytes per MUT second

  Productivity  64.9% of total user, 64.9% of total elapsed
```

---

leading comma for `CommaFSep`/`CommaVSep` fields, i.e. fields with mandatory comma are (atm):

- build-depends
- build-tool-depends
- build-tools
- mixins
- pkgconfig-depends
- reexported-modules
- setup-depends

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
