### PR TITLE
Kill trailing whitespaces in `.cabal` file emitted by `cabal init`

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -76,6 +76,8 @@ import Distribution.ReadE
   ( runReadE, readP_to_E )
 import Distribution.Simple.Setup
   ( Flag(..), flagToMaybe )
+import Distribution.Simple.Utils
+  ( dropWhileEndLE )
 import Distribution.Simple.Configure
   ( getInstalledPackages )
 import Distribution.Simple.Compiler
@@ -799,7 +801,7 @@ findNewName oldName = findNewName' 0
 --   structure onto a low-level AST structure and use the existing
 --   pretty-printing code to generate the file.
 generateCabalFile :: String -> InitFlags -> String
-generateCabalFile fileName c =
+generateCabalFile fileName c = trimTrailingWS $
   (++ "\n") .
   renderStyle style { lineLength = 79, ribbonsPerLine = 1.1 } $
   (if minimal c /= Flag True
@@ -958,6 +960,9 @@ generateCabalFile fileName c =
    breakLine  cs = case break (==' ') cs of (w,cs') -> w : breakLine' cs'
    breakLine' [] = []
    breakLine' cs = case span (==' ') cs of (w,cs') -> w : breakLine cs'
+
+   trimTrailingWS :: String -> String
+   trimTrailingWS = unlines . map (dropWhileEndLE isSpace) . lines
 
    executableStanza :: Doc
    executableStanza = text "\nexecutable" <+>


### PR DESCRIPTION
`cabal init` currently generates trailing whitespaces; this patch
simply adds a final post-processing step filtering out any such trailing
whitespace.

Below is an example (the red markers represent the annoying end-of-line trailing whitespace); with this patch, all those red areas are gone.

![whitespace_cabal_init](https://user-images.githubusercontent.com/285533/34293410-02d8a7ac-e705-11e7-9fc6-ac86b3b3e071.png)

----

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
