### PR TITLE
Warn if -- token is found. Don't warn if it's "--".

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -68,6 +68,7 @@ extra-source-files:
   tests/ParserTests/warnings/bom.cabal
   tests/ParserTests/warnings/bool.cabal
   tests/ParserTests/warnings/deprecatedfield.cabal
+  tests/ParserTests/warnings/doubledash.cabal
   tests/ParserTests/warnings/extratestmodule.cabal
   tests/ParserTests/warnings/gluedop.cabal
   tests/ParserTests/warnings/nbsp.cabal

--- a/Cabal/Distribution/Parsec/Common.hs
+++ b/Cabal/Distribution/Parsec/Common.hs
@@ -43,6 +43,7 @@ data PWarnType
     | PWTLexNBSP
     | PWTLexBOM
     | PWTQuirkyCabalFile       -- ^ legacy cabal file that we know how to patch
+    | PWTDoubleDash            -- ^ Double dash token, most likely it's a mistake - it's not a comment
     deriving (Eq, Ord, Show, Enum, Bounded)
 
 -- | Parser warning.

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -51,6 +51,7 @@ warningTests = testGroup "warnings triggered"
     , warningTest PWTUnknownField      "unknownfield.cabal"
     , warningTest PWTUnknownSection    "unknownsection.cabal"
     , warningTest PWTTrailingFields    "trailingfield.cabal"
+    , warningTest PWTDoubleDash        "doubledash.cabal"
     -- TODO: not implemented yet
     -- , warningTest PWTExtraTestModule   "extratestmodule.cabal"
     ]

--- a/Cabal/tests/ParserTests/regressions/encoding-0.8.cabal
+++ b/Cabal/tests/ParserTests/regressions/encoding-0.8.cabal
@@ -1,6 +1,11 @@
 Name:   encoding
 Version:  0.8
 cabal-version: >=1.12
+-- double-dash files
+extra-source-files:
+  -- this is comment
+  README.md "--"
+  "--"
 
 custom-setup
   setup-depends:

--- a/Cabal/tests/ParserTests/regressions/encoding-0.8.format
+++ b/Cabal/tests/ParserTests/regressions/encoding-0.8.format
@@ -1,6 +1,10 @@
 name: encoding
 version: 0.8
 cabal-version: >=1.12
+extra-source-files:
+    README.md
+    "--"
+    "--"
 
 custom-setup
     setup-depends: base <5,

--- a/Cabal/tests/ParserTests/warnings/doubledash.cabal
+++ b/Cabal/tests/ParserTests/warnings/doubledash.cabal
@@ -1,0 +1,9 @@
+name: bool
+version: 1
+cabal-version: >= 1.6
+extra-source-files:
+  README.md -- we include it
+
+library
+    build-depends: base >= 4.9 && <4.10
+    hs-source-dirs: .


### PR DESCRIPTION
Resolves #2681

Cabal files don't have trailing line comments. In many fields they
simply cause parse errors, but e.g. in extra-source-files
virtually everything is accepted. As there is simple
work around if people actually want double-dash, let's warn
about bare one.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
