### PR TITLE
Issue 989 range op wild

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -40,6 +40,8 @@ extra-source-files:
   tests/ParserTests/errors/common3.errors
   tests/ParserTests/errors/leading-comma.cabal
   tests/ParserTests/errors/leading-comma.errors
+  tests/ParserTests/errors/range-ge-wild.cabal
+  tests/ParserTests/errors/range-ge-wild.errors
   tests/ParserTests/ipi/transformers.cabal
   tests/ParserTests/ipi/transformers.format
   tests/ParserTests/regressions/Octree-0.5.cabal

--- a/Cabal/Distribution/Compat/DList.hs
+++ b/Cabal/Distribution/Compat/DList.hs
@@ -14,6 +14,7 @@ module Distribution.Compat.DList (
     runDList,
     singleton,
     fromList,
+    toList,
     snoc,
 ) where
 
@@ -32,6 +33,9 @@ singleton a = DList (a:)
 
 fromList :: [a] -> DList a
 fromList as = DList (as ++)
+
+toList :: DList a -> [a]
+toList = runDList
 
 snoc :: DList a -> a -> DList a
 snoc xs x = xs <> singleton x

--- a/Cabal/Distribution/Parsec/Class.hs
+++ b/Cabal/Distribution/Parsec/Class.hs
@@ -100,6 +100,12 @@ instance Alternative ParsecParser where
     a <|> b = PP $ \v -> unPP a v <|> unPP b v
     {-# INLINE (<|>) #-}
 
+    many p = PP $ \v -> many (unPP p v)
+    {-# INLINE many #-}
+
+    some p = PP $ \v -> some (unPP p v)
+    {-# INLINE some #-}
+
 instance Monad ParsecParser where
     return = pure
 

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -85,6 +85,7 @@ errorTests = testGroup "errors"
     , errorTest "common2.cabal"
     , errorTest "common3.cabal"
     , errorTest "leading-comma.cabal"
+    , errorTest "range-ge-wild.cabal"
     ]
 
 errorTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests/errors/range-ge-wild.cabal
+++ b/Cabal/tests/ParserTests/errors/range-ge-wild.cabal
@@ -1,0 +1,8 @@
+name:                range-ge-wild
+version:             0
+synopsis:            Wild range after non-== op
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  build-depends: base >= 4.*

--- a/Cabal/tests/ParserTests/errors/range-ge-wild.errors
+++ b/Cabal/tests/ParserTests/errors/range-ge-wild.errors
@@ -1,0 +1,1 @@
+PError (Position 8 29) "\nunexpected wild-card version after non-== operator: \">=\": \"base >= 4.*\""


### PR DESCRIPTION
- No more `try`
- It recognises wild-card version after all operators,
  but fails with more descriptive warning after non-==
  Fixes #989

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
