### PR TITLE
Add support on Windows for copying to long paths.

### DIFF
--- a/Cabal/Distribution/Compat/CopyFile.hs
+++ b/Cabal/Distribution/Compat/CopyFile.hs
@@ -27,7 +27,7 @@ import System.IO.Error
 import System.Directory
          ( doesFileExist, renameFile, removeFile )
 import System.FilePath
-         ( isRelative, normalise )
+         ( isRelative, normalise, takeDirectory )
 import System.IO
          ( IOMode(ReadMode), hClose, hGetBuf, hPutBuf, hFileSize
          , withBinaryFile )

--- a/Cabal/Distribution/Compat/CopyFile.hs
+++ b/Cabal/Distribution/Compat/CopyFile.hs
@@ -15,6 +15,8 @@ import Prelude ()
 import Distribution.Compat.Prelude
 
 import Distribution.Compat.Exception
+
+#ifndef mingw32_HOST_OS
 import Distribution.Compat.Internal.TempFile
 
 import Control.Exception
@@ -25,20 +27,36 @@ import System.IO.Error
 import System.Directory
          ( doesFileExist, renameFile, removeFile )
 import System.FilePath
-         ( takeDirectory )
+         ( isRelative, normalise )
 import System.IO
          ( IOMode(ReadMode), hClose, hGetBuf, hPutBuf, hFileSize
          , withBinaryFile )
 import Foreign
          ( allocaBytes )
 
-#ifndef mingw32_HOST_OS
 import System.Posix.Types
          ( FileMode )
 import System.Posix.Internals
          ( c_chmod, withFilePath )
 import Foreign.C
          ( throwErrnoPathIfMinus1_ )
+
+#else /* else mingw32_HOST_OS */
+
+import Control.Exception
+  ( throwIO )
+import qualified Data.ByteString.Lazy as BSL
+import System.IO.Error
+  ( ioeSetLocation )
+import System.Directory
+  ( doesFileExist )
+import System.FilePath
+  ( isRelative, normalise )
+import System.IO
+  ( IOMode(ReadMode), hFileSize
+  , withBinaryFile )
+
+import qualified System.Win32.File as Win32 ( copyFile )
 #endif /* mingw32_HOST_OS */
 
 copyOrdinaryFile, copyExecutableFile :: FilePath -> FilePath -> NoCallStackIO ()
@@ -67,22 +85,29 @@ copyFile :: FilePath -> FilePath -> NoCallStackIO ()
 copyFile fromFPath toFPath =
   copy
     `catchIO` (\ioe -> throwIO (ioeSetLocation ioe "copyFile"))
-    where copy = withBinaryFile fromFPath ReadMode $ \hFrom ->
-                 bracketOnError openTmp cleanTmp $ \(tmpFPath, hTmp) ->
-                 do allocaBytes bufferSize $ copyContents hFrom hTmp
-                    hClose hTmp
-                    renameFile tmpFPath toFPath
-          openTmp = openBinaryTempFile (takeDirectory toFPath) ".copyFile.tmp"
-          cleanTmp (tmpFPath, hTmp) = do
-            hClose hTmp          `catchIO` \_ -> return ()
-            removeFile tmpFPath  `catchIO` \_ -> return ()
-          bufferSize = 4096
+    where
+#ifndef mingw32_HOST_OS
+      copy = withBinaryFile fromFPath ReadMode $ \hFrom ->
+             bracketOnError openTmp cleanTmp $ \(tmpFPath, hTmp) ->
+             do allocaBytes bufferSize $ copyContents hFrom hTmp
+                hClose hTmp
+                renameFile tmpFPath toFPath
+      openTmp = openBinaryTempFile (takeDirectory toFPath) ".copyFile.tmp"
+      cleanTmp (tmpFPath, hTmp) = do
+        hClose hTmp          `catchIO` \_ -> return ()
+        removeFile tmpFPath  `catchIO` \_ -> return ()
+      bufferSize = 4096
 
-          copyContents hFrom hTo buffer = do
-                  count <- hGetBuf hFrom buffer bufferSize
-                  when (count > 0) $ do
-                          hPutBuf hTo buffer count
-                          copyContents hFrom hTo buffer
+      copyContents hFrom hTo buffer = do
+              count <- hGetBuf hFrom buffer bufferSize
+              when (count > 0) $ do
+                      hPutBuf hTo buffer count
+                      copyContents hFrom hTo buffer
+#else
+      copy = Win32.copyFile (toExtendedLengthPath fromFPath)
+                            (toExtendedLengthPath toFPath)
+                            False
+#endif /* mingw32_HOST_OS */
 
 -- | Like `copyFile`, but does not touch the target if source and destination
 -- are already byte-identical. This is recommended as it is useful for
@@ -110,3 +135,19 @@ filesEqual f1 f2 = do
             c1 <- BSL.hGetContents h1
             c2 <- BSL.hGetContents h2
             return $! c1 == c2
+
+-- NOTE: Shamelessly lifted from System.Directory.Internal.Windows
+
+-- | Add the @"\\\\?\\"@ prefix if necessary or possible.  The path remains
+-- unchanged if the prefix is not added.  This function can sometimes be used
+-- to bypass the @MAX_PATH@ length restriction in Windows API calls.
+toExtendedLengthPath :: FilePath -> FilePath
+toExtendedLengthPath path
+  | isRelative path = path
+  | otherwise =
+      case normalise path of
+        '\\' : '?'  : '?' : '\\' : _ -> path
+        '\\' : '\\' : '?' : '\\' : _ -> path
+        '\\' : '\\' : '.' : '\\' : _ -> path
+        '\\' : subpath@('\\' : _) -> "\\\\?\\UNC" <> subpath
+        normalisedPath -> "\\\\?\\" <> normalisedPath

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -46,6 +46,9 @@
 	* Added support for '--enable-tests' and '--enable-benchmarks' to
 	'cabal fetch' (#4948).
 	* Removed support for building cabal-install with GHC < 7.10.
+	* Add Windows device path support for copyFile, renameFile. Allows cabal
+	new-build to use temporary store path of up to 32k length
+	(#3972, #4914, #4515).
 
 2.0.0.1 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> December 2017
 	* Support for GHC's numeric -g debug levels (#4673).


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested by trying to compile cabal itself on a long path.

Should fix partially #3972, #4914, #4515. The reason why partial is because any operation that hits the GHC I/O manager will destroy device path support. Because the GHC I/O manager is using non-native posix like APIs which are mapped to the old Win32 APIs that are bound by MAX_PATH.

This patch works because it avoids touching the I/O manager for doing the file copy and instead does a direct copy using the Win32 API. The Windows APIs do not have the same limitations as the posix ones and so do not require the file to be on the same drive before issuing a copy/move. So this should be much faster too.