### PR TITLE
Fix path redundancy new-build output folders.

### DIFF
--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -59,7 +59,7 @@ import Distribution.Text
 import System.Directory (getAppUserDataDirectory)
 import System.FilePath
   ( (</>), isPathSeparator
-  , pathSeparator, dropDrive )
+  , pathSeparator, takeBaseName )
 
 #ifdef mingw32_HOST_OS
 import qualified Prelude
@@ -286,7 +286,7 @@ absoluteInstallDirs :: PackageIdentifier
                     -> InstallDirs FilePath
 absoluteInstallDirs pkgId libname compilerId copydest platform dirs =
     (case copydest of
-       CopyTo destdir -> fmap ((destdir </>) . dropDrive)
+       CopyTo destdir -> fmap ((destdir </>) . takeBaseName)
        _              -> id)
   . appendSubdirs (</>)
   . fmap fromPathTemplate

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -940,12 +940,10 @@ buildAndInstallUnpackedPackage verbosity
     annotateFailure mlogFile InstallFailed $ do
 
       let copyPkgFiles tmpDir = do
-            setup Cabal.copyCommand (copyFlags tmpDir)
-            -- Note that the copy command has put the files into
-            -- @$tmpDir/$prefix@ so we need to return this dir so
-            -- the store knows which dir will be the final store entry.
-            let prefix   = dropDrive (InstallDirs.prefix (elabInstallDirs pkg))
+            let prefix   = let path = InstallDirs.prefix (elabInstallDirs pkg)
+                           in takeBaseName path
                 entryDir = tmpDir </> prefix
+            setup Cabal.copyCommand (copyFlags entryDir)
             LBS.writeFile
               (entryDir </> "cabal-hash.txt")
               (renderPackageHashInputs (packageHashInputs pkgshared pkg))
@@ -954,7 +952,7 @@ buildAndInstallUnpackedPackage verbosity
             -- While this breaks the prefix-relocatable property of the lirbaries
             -- it is necessary on macOS to stay under the load command limit of the
             -- macOS mach-o linker. See also @PackageHash.hashedInstalledPackageIdVeryShort@.
-            otherFiles <- filter (not . isPrefixOf entryDir) <$> listFilesRecursive tmpDir 
+            otherFiles <- filter (not . isPrefixOf entryDir) <$> listFilesRecursive tmpDir
             -- here's where we could keep track of the installed files ourselves
             -- if we wanted to by making a manifest of the files in the tmp dir
             return (entryDir, otherFiles)

--- a/cabal-install/Distribution/Client/Store.hs
+++ b/cabal-install/Distribution/Client/Store.hs
@@ -209,7 +209,10 @@ newStoreEntry verbosity storeDirLayout@StoreDirLayout{..}
             -- Atomically rename the temp dir to the final store entry location.
             renameDirectory incomingEntryDir finalEntryDir
             forM_ otherFiles $ \file -> do
-              let finalStoreFile = storeDirectory compid </> makeRelative (incomingTmpDir </> (dropDrive (storeDirectory compid))) file
+              let finalStoreFile = storeDirectory compid
+                                </> makeRelative (incomingTmpDir
+                                     </> (takeBaseName (storeDirectory compid)))
+                                     file
               createDirectoryIfMissing True (takeDirectory finalStoreFile)
               renameFile file finalStoreFile
 

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -46,6 +46,8 @@
 	* Added support for '--enable-tests' and '--enable-benchmarks' to
 	'cabal fetch' (#4948).
 	* Removed support for building cabal-install with GHC < 7.10.
+	* Redundancy in new-build incoming store paths removed. This makes incoming
+	tmp paths much shorter. (#4515, #3972)
 
 2.0.0.1 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> December 2017
 	* Support for GHC's numeric -g debug levels (#4673).


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested it by compiling Cabal itself using the Makefile on a long path.

Fixes #4515, #3972.

The `setup` call with `copyCommand` doesn't do what the comment in `ProjectBuilding.hs` suggested. It literally only assigns the path you specified. So you can choose any format you want as long as you pass it to `copyCommand`. So instead of using `@$tmpDir/$prefix@` we now use `@$tmpDir/$packageName-$version@`. Because `prefix` is a prefix to `tmpDir` this means that before this patch cabal was halving the Windows MAX_PATH. Effectively meaning `new-build` would only work on paths shorter than 125 characters.

The consistency is maintained with `absoluteInstallDirs` by also taking the `base name` instead of dropping the `drive` when combing the paths. Proof that this is all consistent is that the build succeeds. Cabal only issues `createDirectory` calls in one place. So if the paths did not end up being the same the build would fail because it can't find the specified path.


