### PR TITLE
Add showFullInstalledPackageInfo

### DIFF
--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -41,6 +41,7 @@ module Distribution.InstalledPackageInfo (
         emptyInstalledPackageInfo,
         parseInstalledPackageInfo,
         showInstalledPackageInfo,
+        showFullInstalledPackageInfo,
         showInstalledPackageInfoField,
         showSimpleInstalledPackageInfoField,
         fieldsInstalledPackageInfo,
@@ -359,8 +360,16 @@ parseInstalledPackageInfo =
 -- -----------------------------------------------------------------------------
 -- Pretty-printing
 
+-- | Pretty print 'InstalledPackageInfo'.
+--
+-- @pkgRoot@ isn't printed, as ghc-pkg prints it's manually (as GHC-8.4).
 showInstalledPackageInfo :: InstalledPackageInfo -> String
-showInstalledPackageInfo = showFields fieldsInstalledPackageInfo
+showInstalledPackageInfo ipi =
+    showFullInstalledPackageInfo ipi { pkgRoot = Nothing }
+
+-- | The variant of 'showInstalledPackageInfo' which outputs @pkgroot@ field too.
+showFullInstalledPackageInfo :: InstalledPackageInfo -> String
+showFullInstalledPackageInfo = showFields fieldsInstalledPackageInfo
 
 showInstalledPackageInfoField :: String -> Maybe (InstalledPackageInfo -> String)
 showInstalledPackageInfoField = showSingleNamedField fieldsInstalledPackageInfo
@@ -505,8 +514,8 @@ installedFieldDescrs = [
         showFilePath       parseFilePathQ
         haddockHTMLs       (\xs pkg -> pkg{haddockHTMLs=xs})
  , simpleField "pkgroot"
-        (const Disp.empty)        parseFilePathQ
-        (fromMaybe "" . pkgRoot)  (\xs pkg -> pkg{pkgRoot=Just xs})
+        (maybe mempty showFilePath)  (fmap Just parseFilePathQ)
+        pkgRoot                      (\xs pkg -> pkg{pkgRoot=xs})
  ]
 
 deprecatedFieldDescrs :: [FieldDescr InstalledPackageInfo]

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -362,7 +362,7 @@ parseInstalledPackageInfo =
 
 -- | Pretty print 'InstalledPackageInfo'.
 --
--- @pkgRoot@ isn't printed, as ghc-pkg prints it's manually (as GHC-8.4).
+-- @pkgRoot@ isn't printed, as ghc-pkg prints it manually (as GHC-8.4).
 showInstalledPackageInfo :: InstalledPackageInfo -> String
 showInstalledPackageInfo ipi =
     showFullInstalledPackageInfo ipi { pkgRoot = Nothing }

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -8,7 +8,7 @@ import Test.Tasty.HUnit
 
 import Control.Monad                               (void)
 import Data.Algorithm.Diff                         (Diff (..), getGroupedDiff)
-import Data.Maybe                                  (isJust)
+import Data.Maybe                                  (isJust, isNothing)
 import Distribution.License                        (License (..))
 import Distribution.PackageDescription             (GenericPackageDescription)
 import Distribution.PackageDescription.Parsec      (parseGenericPackageDescription)
@@ -205,11 +205,17 @@ ipiFormatRoundTripTest fp = testCase "roundtrip" $ do
     let contents' = IPI.showInstalledPackageInfo x
     y <- parse contents'
 
-    -- TODO: pkgRoot doesn't seem to be shown!
+    -- ghc-pkg prints pkgroot itself, based on cli arguments!
     let x' = x { IPI.pkgRoot = Nothing }
-    let y' = y { IPI.pkgRoot = Nothing }
-
+    let y' = y
+    assertBool "pkgRoot isn't shown" (isNothing (IPI.pkgRoot y))
     assertEqual "re-parsed doesn't match" x' y'
+
+    -- Complete round-trip
+    let contents2 = IPI.showFullInstalledPackageInfo x
+    z <- parse contents2
+    assertEqual "re-parsed doesn't match" x z
+
   where
     parse :: String -> IO IPI.InstalledPackageInfo
     parse c = do


### PR DESCRIPTION
@hvr I chose to go more BC way, I'm afraid we will out of run to test ghc-pkg changes properly.
`showFullInstalledPackageInfo` could be removed for next Cabal / GHC-8.6 when we have better time.

---

showInstalledPackageInfo uses full variant, but with pkgroot set to
Nothing. This way we field descriptions have roundtrip property (wo it's
simpler to proceed with reworking the parsing using parsec framework).

We introduce new name, so no (coordinated) changes to ghc-pkg are needed.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
