### PR TITLE
Outputable typeclass

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -250,6 +250,7 @@ library
     Distribution.TestSuite
     Distribution.Text
     Distribution.Pretty
+    Distribution.Outputable
     Distribution.Types.AbiHash
     Distribution.Types.AnnotatedId
     Distribution.Types.Benchmark

--- a/Cabal/Distribution/Backpack.hs
+++ b/Cabal/Distribution/Backpack.hs
@@ -45,6 +45,7 @@ import qualified Distribution.Compat.ReadP as Parse
 import qualified Text.PrettyPrint as Disp
 import Text.PrettyPrint (hcat)
 
+import Distribution.Pretty
 import Distribution.ModuleName
 import Distribution.Text
 import Distribution.Types.ComponentId
@@ -103,13 +104,15 @@ instance NFData OpenUnitId where
     rnf (IndefFullUnitId cid subst) = rnf cid `seq` rnf subst
     rnf (DefiniteUnitId uid) = rnf uid
 
-instance Text OpenUnitId where
-    disp (IndefFullUnitId cid insts)
+instance Pretty OpenUnitId where
+    pretty (IndefFullUnitId cid insts)
         -- TODO: arguably a smart constructor to enforce invariant would be
         -- better
         | Map.null insts = disp cid
         | otherwise      = disp cid <<>> Disp.brackets (dispOpenModuleSubst insts)
-    disp (DefiniteUnitId uid) = disp uid
+    pretty (DefiniteUnitId uid) = disp uid
+
+instance Text OpenUnitId where
     parse = parseOpenUnitId <++ fmap DefiniteUnitId parse
       where
         parseOpenUnitId = do
@@ -160,11 +163,13 @@ instance NFData OpenModule where
     rnf (OpenModule uid mod_name) = rnf uid `seq` rnf mod_name
     rnf (OpenModuleVar mod_name) = rnf mod_name
 
-instance Text OpenModule where
-    disp (OpenModule uid mod_name) =
+instance Pretty OpenModule where
+    pretty (OpenModule uid mod_name) =
         hcat [disp uid, Disp.text ":", disp mod_name]
-    disp (OpenModuleVar mod_name) =
+    pretty (OpenModuleVar mod_name) =
         hcat [Disp.char '<', disp mod_name, Disp.char '>']
+
+instance Text OpenModule where
     parse = parseModuleVar <++ parseOpenModule
       where
         parseOpenModule = do

--- a/Cabal/Distribution/Backpack/ComponentsGraph.hs
+++ b/Cabal/Distribution/Backpack/ComponentsGraph.hs
@@ -4,7 +4,7 @@ module Distribution.Backpack.ComponentsGraph (
     ComponentsWithDeps,
     mkComponentsGraph,
     componentsGraphToList,
-    dispComponentsWithDeps,
+    pprComponentsWithDeps,
     componentCycleMsg
 ) where
 
@@ -19,10 +19,7 @@ import Distribution.Types.ComponentRequestedSpec
 import Distribution.Types.UnqualComponentName
 import Distribution.Compat.Graph (Graph, Node(..))
 import qualified Distribution.Compat.Graph as Graph
-
-import Distribution.Text
-    ( Text(disp) )
-import Text.PrettyPrint
+import Distribution.Outputable
 
 ------------------------------------------------------------------------------
 -- Components graph
@@ -40,10 +37,10 @@ type ComponentsWithDeps = [(Component, [ComponentName])]
 
 -- | Pretty-print 'ComponentsWithDeps'.
 --
-dispComponentsWithDeps :: ComponentsWithDeps -> Doc
-dispComponentsWithDeps graph =
-    vcat [ hang (text "component" <+> disp (componentName c)) 4
-                (vcat [ text "dependency" <+> disp cdep | cdep <- cdeps ])
+pprComponentsWithDeps :: ComponentsWithDeps -> SDoc
+pprComponentsWithDeps graph =
+    vcat [ hang (text "component" <+> ppr (componentName c)) 4
+                (vcat [ text "dependency" <+> ppr cdep | cdep <- cdeps ])
          | (c, cdeps) <- graph ]
 
 -- | Create a 'Graph' of 'Component', or report a cycle if there is a
@@ -89,7 +86,7 @@ componentsGraphToList =
     map (\(N c _ cs) -> (c, cs)) . Graph.revTopSort
 
 -- | Error message when there is a cycle; takes the SCC of components.
-componentCycleMsg :: [ComponentName] -> Doc
+componentCycleMsg :: [ComponentName] -> SDoc
 componentCycleMsg cnames =
     text $ "Components in the package depend on each other in a cyclic way:\n  "
        ++ intercalate " depends on "

--- a/Cabal/Distribution/Backpack/Configure.hs
+++ b/Cabal/Distribution/Backpack/Configure.hs
@@ -45,13 +45,13 @@ import Distribution.Verbosity
 import qualified Distribution.Compat.Graph as Graph
 import Distribution.Compat.Graph (Graph, IsNode(..))
 import Distribution.Utils.LogProgress
+import Distribution.Outputable
+import Distribution.Text (display)
 
 import Data.Either
     ( lefts )
 import qualified Data.Set as Set
 import qualified Data.Map as Map
-import Distribution.Text
-import Text.PrettyPrint
 
 ------------------------------------------------------------------------------
 -- Pipeline
@@ -80,7 +80,7 @@ configureComponentLocalBuildInfos
                 Left ccycle -> dieProgress (componentCycleMsg ccycle)
                 Right g -> return (componentsGraphToList g)
     infoProgress $ hang (text "Source component graph:") 4
-                        (dispComponentsWithDeps graph0)
+                        (pprComponentsWithDeps graph0)
 
     let conf_pkg_map = Map.fromListWith Map.union
             [(pc_pkgname pkg,
@@ -96,7 +96,7 @@ configureComponentLocalBuildInfos
                     deterministic ipid_flag cid_flag pkg_descr
                     conf_pkg_map (map fst graph0)
     infoProgress $ hang (text "Configured component graph:") 4
-                        (vcat (map dispConfiguredComponent graph1))
+                        (vcat (map ppr graph1))
 
     let shape_pkg_map = Map.fromList
             [ (pc_cid pkg, (pc_open_uid pkg, pc_shape pkg))
@@ -112,7 +112,7 @@ configureComponentLocalBuildInfos
 
     infoProgress $
         hang (text "Linked component graph:") 4
-             (vcat (map dispLinkedComponent graph2))
+             (vcat (map ppr graph2))
 
     let pid_map = Map.fromList $
             [ (pc_uid pkg, pc_munged_id pkg)
@@ -126,7 +126,7 @@ configureComponentLocalBuildInfos
         graph4 = Graph.revTopSort (Graph.fromDistinctList graph3)
 
     infoProgress $ hang (text "Ready component graph:") 4
-                        (vcat (map dispReadyComponent graph4))
+                        (vcat (map ppr graph4))
 
     toComponentLocalBuildInfos comp installedPackageSet pkg_descr prePkgDeps graph4
 
@@ -224,9 +224,9 @@ toComponentLocalBuildInfos
         warnProgress $
           hang (text "This package indirectly depends on multiple versions of the same" <+>
                 text "package. This is very likely to cause a compile failure.") 2
-               (vcat [ text "package" <+> disp (packageName user) <+>
-                       parens (disp (installedUnitId user)) <+> text "requires" <+>
-                       disp inst
+               (vcat [ text "package" <+> ppr (packageName user) <+>
+                       parens (ppr (installedUnitId user)) <+> text "requires" <+>
+                       ppr inst
                      | (_dep_key, insts) <- inconsistencies
                      , (inst, users) <- insts
                      , user <- users ])

--- a/Cabal/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/Distribution/Backpack/ConfiguredComponent.hs
@@ -40,6 +40,7 @@ import Distribution.Simple.LocalBuildInfo
 import Distribution.Version
 import Distribution.Utils.LogProgress
 import Distribution.Utils.MapAccum
+import Distribution.Utils.Generic
 
 import Control.Monad
 import qualified Data.Set as Set
@@ -191,7 +192,11 @@ toConfiguredComponent pkg_descr this_cid dep_map component = do
                          , pn /= packageName pkg_descr
                          , (cn, e) <- Map.toList comp_map
                          , cn == CLibName ]
-    exe_deps =
+    -- We have to nub here, because 'getAllToolDependencies' may return
+    -- duplicates (see #4986).  (NB: This is not needed for lib_deps,
+    -- since those elaborate into includes, for which there explicitly
+    -- may be multiple instances of a package)
+    exe_deps = ordNub $
         [ exe
         | ExeDependency pn cn _ <- getAllToolDependencies pkg_descr bi
         -- The error suppression here is important, because in general

--- a/Cabal/Distribution/Backpack/MixLink.hs
+++ b/Cabal/Distribution/Backpack/MixLink.hs
@@ -14,10 +14,9 @@ import Distribution.Backpack.ModuleScope
 
 import qualified Distribution.Utils.UnionFind as UnionFind
 import Distribution.ModuleName
-import Distribution.Text
 import Distribution.Types.ComponentId
+import Distribution.Outputable
 
-import Text.PrettyPrint
 import Control.Monad
 import qualified Data.Map as Map
 import qualified Data.Foldable as F
@@ -56,10 +55,10 @@ linkProvision mod_name ret@(prov:provs) (req:reqs) = do
             Just () -> return ()
             Nothing -> do
                 addErr $
-                  text "Ambiguous module" <+> quotes (disp mod_name) $$
+                  text "Ambiguous module" <+> quotes (ppr mod_name) $$
                   text "It could refer to" <+>
-                    ( text "  " <+> (quotes (disp mod)  $$ in_scope_by (getSource prov)) $$
-                      text "or" <+> (quotes (disp mod') $$ in_scope_by (getSource prov')) ) $$
+                    ( text "  " <+> (quotes (ppr mod)  $$ in_scope_by (getSource prov)) $$
+                      text "or" <+> (quotes (ppr mod') $$ in_scope_by (getSource prov')) ) $$
                   link_doc
     mod <- convertModuleU (unWithSource prov)
     req_mod <- convertModuleU (unWithSource req)
@@ -67,7 +66,7 @@ linkProvision mod_name ret@(prov:provs) (req:reqs) = do
     case mod of
       OpenModule (IndefFullUnitId cid _) _
         | cid == self_cid -> addErr $
-            text "Cannot instantiate requirement" <+> quotes (disp mod_name) <+>
+            text "Cannot instantiate requirement" <+> quotes (ppr mod_name) <+>
                 in_scope_by (getSource req) $$
             text "with locally defined module" <+> in_scope_by (getSource prov) $$
             text "as this would create a cyclic dependency, which GHC does not support." $$
@@ -79,9 +78,9 @@ linkProvision mod_name ret@(prov:provs) (req:reqs) = do
         Just () -> return ()
         Nothing -> do
             -- TODO: Record and report WHERE the bad constraint came from
-            addErr $ text "Could not instantiate requirement" <+> quotes (disp mod_name) $$
-                     nest 4 (text "Expected:" <+> disp mod $$
-                             text "Actual:  " <+> disp req_mod) $$
+            addErr $ text "Could not instantiate requirement" <+> quotes (ppr mod_name) $$
+                     nest 4 (text "Expected:" <+> ppr mod $$
+                             text "Actual:  " <+> ppr req_mod) $$
                      parens (text "This can occur if an exposed module of" <+>
                              text "a libraries shares a name with another module.") $$
                      link_doc
@@ -89,13 +88,13 @@ linkProvision mod_name ret@(prov:provs) (req:reqs) = do
   where
     unify s1 s2 = tryM $ addErrContext short_link_doc
                        $ unifyModule (unWithSource s1) (unWithSource s2)
-    in_scope_by s = text "brought into scope by" <+> dispModuleSource s
-    short_link_doc = text "While filling requirement" <+> quotes (disp mod_name)
+    in_scope_by s = text "brought into scope by" <+> ppr s
+    short_link_doc = text "While filling requirement" <+> quotes (ppr mod_name)
     link_doc = text "While filling requirements of" <+> reqs_doc
     reqs_doc
-      | null reqs = dispModuleSource (getSource req)
-      | otherwise =  (       text "   " <+> dispModuleSource (getSource req)  $$
-                      vcat [ text "and" <+> dispModuleSource (getSource r) | r <- reqs])
+      | null reqs = ppr (getSource req)
+      | otherwise =  (       text "   " <+> ppr (getSource req)  $$
+                      vcat [ text "and" <+> ppr (getSource r) | r <- reqs])
 linkProvision _ _ _ = error "linkProvision"
 
 
@@ -117,8 +116,8 @@ unifyUnitId uid1_u uid2_u
                 | u1 == u2  -> return ()
                 | otherwise ->
                     failWith $ hang (text "Couldn't match unit IDs:") 4
-                               (text "   " <+> disp u1 $$
-                                text "and" <+> disp u2)
+                               (text "   " <+> ppr u1 $$
+                                text "and" <+> ppr u2)
             (UnitIdThunkU uid1, UnitIdU _ cid2 insts2)
                 -> unifyThunkWith cid2 insts2 uid2_u uid1 uid1_u
             (UnitIdU _ cid1 insts1, UnitIdThunkU uid2)
@@ -151,8 +150,8 @@ unifyInner cid1 insts1 uid1_u cid2 insts2 uid2_u = do
         -- easier to understand error message.
         failWith $
             hang (text "Couldn't match component IDs:") 4
-                 (text "   " <+> disp cid1 $$
-                  text "and" <+> disp cid2)
+                 (text "   " <+> ppr cid1 $$
+                  text "and" <+> ppr cid2)
     -- The KEY STEP which makes this a Huet-style unification
     -- algorithm.  (Also a payoff of using union-find.)
     -- We can build infinite unit IDs this way, which is necessary
@@ -176,8 +175,8 @@ unifyModule mod1_u mod2_u
                 when (mod_name1 /= mod_name2) $
                     failWith $
                         hang (text "Cannot match module names") 4 $
-                            text "   " <+> disp mod_name1 $$
-                            text "and" <+> disp mod_name2
+                            text "   " <+> ppr mod_name1 $$
+                            text "and" <+> ppr mod_name2
                 -- NB: this is not actually necessary (because we'll
                 -- detect loops eventually in 'unifyUnitId'), but it
                 -- seems harmless enough

--- a/Cabal/Distribution/Backpack/ModuleScope.hs
+++ b/Cabal/Distribution/Backpack/ModuleScope.hs
@@ -8,7 +8,6 @@ module Distribution.Backpack.ModuleScope (
     ModuleProvides,
     ModuleRequires,
     ModuleSource(..),
-    dispModuleSource,
     WithSource(..),
     unWithSource,
     getSource,
@@ -26,10 +25,9 @@ import Distribution.Types.ComponentName
 
 import Distribution.Backpack
 import Distribution.Backpack.ModSubst
-import Distribution.Text
+import Distribution.Outputable
 
 import qualified Data.Map as Map
-import Text.PrettyPrint
 
 
 -----------------------------------------------------------------------
@@ -94,29 +92,29 @@ data ModuleSource
 -- too
 
 -- TODO: Deduplicate this with Distribution.Backpack.UnifyM.ci_msg
-dispModuleSource :: ModuleSource -> Doc
-dispModuleSource (FromMixins pn cn incls)
-  = text "mixins:" <+> dispComponent pn cn <+> disp incls
-dispModuleSource (FromBuildDepends pn cn)
-  = text "build-depends:" <+> dispComponent pn cn
-dispModuleSource (FromExposedModules m)
-  = text "exposed-modules:" <+> disp m
-dispModuleSource (FromOtherModules m)
-  = text "other-modules:" <+> disp m
-dispModuleSource (FromSignatures m)
-  = text "signatures:" <+> disp m
+instance Outputable ModuleSource where
+    ppr (FromMixins pn cn incls)
+      = text "mixins:" <+> pprComponent pn cn <+> ppr incls
+    ppr (FromBuildDepends pn cn)
+      = text "build-depends:" <+> pprComponent pn cn
+    ppr (FromExposedModules m)
+      = text "exposed-modules:" <+> ppr m
+    ppr (FromOtherModules m)
+      = text "other-modules:" <+> ppr m
+    ppr (FromSignatures m)
+      = text "signatures:" <+> ppr m
 
 -- Dependency
-dispComponent :: PackageName -> ComponentName -> Doc
-dispComponent pn cn =
+pprComponent :: PackageName -> ComponentName -> SDoc
+pprComponent pn cn =
     -- NB: This syntax isn't quite the source syntax, but it
     -- should be clear enough.  To do source syntax, we'd
     -- need to know what the package we're linking is.
     case cn of
-        CLibName -> disp pn
-        CSubLibName ucn -> disp pn <<>> colon <<>> disp ucn
+        CLibName -> ppr pn
+        CSubLibName ucn -> ppr pn <> colon <> ppr ucn
         -- Case below shouldn't happen
-        _ -> disp pn <+> parens (disp cn)
+        _ -> ppr pn <+> parens (ppr cn)
 
 -- | An 'OpenModule', annotated with where it came from in a Cabal file.
 data WithSource a = WithSource ModuleSource a

--- a/Cabal/Distribution/Backpack/ReadyComponent.hs
+++ b/Cabal/Distribution/Backpack/ReadyComponent.hs
@@ -8,7 +8,6 @@ module Distribution.Backpack.ReadyComponent (
     rc_depends,
     rc_uid,
     rc_pkgid,
-    dispReadyComponent,
     toReadyComponents,
 ) where
 
@@ -36,12 +35,12 @@ import Distribution.Types.Library
 import Distribution.ModuleName
 import Distribution.Package
 import Distribution.Simple.Utils
+import Distribution.Outputable
 
 import qualified Control.Applicative as A
 import qualified Data.Traversable as T
 
 import Control.Monad
-import Text.PrettyPrint
 import qualified Data.Map as Map
 
 import Distribution.Version
@@ -173,14 +172,14 @@ instance IsNode ReadyComponent where
       ordNub (map fst (rc_depends rc)) ++
       map ann_id (rc_exe_deps rc)
 
-dispReadyComponent :: ReadyComponent -> Doc
-dispReadyComponent rc =
+instance Outputable ReadyComponent where
+  ppr rc =
     hang (text (case rc_i rc of
                     Left  _ -> "indefinite"
                     Right _ -> "definite")
-            <+> disp (nodeKey rc)
+            <+> ppr (nodeKey rc)
             {- <+> dispModSubst (Map.fromList (lc_insts lc)) -} ) 4 $
-        vcat [ text "depends" <+> disp uid
+        vcat [ text "depends" <+> ppr uid
              | uid <- nodeNeighbors rc ]
 
 -- | The state of 'InstM'; a mapping from 'UnitId's to their

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -58,6 +58,7 @@ import qualified Distribution.Package as Package
 import Distribution.ModuleName
 import Distribution.Version
 import Distribution.Text
+import Distribution.Pretty
 import qualified Distribution.Compat.ReadP as Parse
 import Distribution.Compat.Graph
 import Distribution.Types.MungedPackageId
@@ -129,6 +130,9 @@ data InstalledPackageInfo
         pkgRoot           :: Maybe FilePath
     }
     deriving (Eq, Generic, Typeable, Read, Show)
+
+instance Pretty InstalledPackageInfo where
+    pretty = ppFields fieldsInstalledPackageInfo
 
 installedComponentId :: InstalledPackageInfo -> ComponentId
 installedComponentId ipi =

--- a/Cabal/Distribution/Outputable.hs
+++ b/Cabal/Distribution/Outputable.hs
@@ -1,0 +1,313 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Distribution.Outputable (
+    -- * Type class
+    Outputable(..),
+
+    -- * Pretty printing combinators
+    SDoc,
+    showSDoc,
+    showPpr,
+    docToSDoc,
+    sdocWithVerbosity,
+
+    -- No empty to avoid conflict with Applicative
+    nest,
+    char,
+    text,
+    int, integer, float, double, rational,
+    parens, brackets, braces, quotes,
+    doubleQuotes, angleBrackets, paBrackets,
+    semi, comma, colon, space, equals, dot, vbar,
+    lparen, rparen, lbrack, rbrack, lbrace, rbrace, underscore,
+    blankLine,
+    (<>), (<+>), hcat, hsep,
+    ($$), ($+$), vcat,
+    sep, cat,
+    fsep, fcat,
+    hang, punctuate, ppWhen, ppUnless,
+) where
+
+import Distribution.Verbosity
+import Distribution.Pretty
+import Distribution.Compat.Semigroup
+
+import Data.Int
+import Data.Word
+import Data.Set (Set)
+import Data.Map (Map)
+import Data.IntMap (IntMap)
+import qualified Data.Map as Map
+import qualified Data.IntMap as IntMap
+import qualified Data.Set as Set
+
+import Text.PrettyPrint (Doc)
+import qualified Text.PrettyPrint as Pretty
+
+newtype SDoc = SDoc { runSDoc :: SDocContext -> Doc }
+
+instance Semigroup SDoc where
+    (<>) = (<<>>)
+
+instance Monoid SDoc where
+    mempty = empty
+    mappend = (<>)
+
+showSDoc :: Verbosity -> SDoc -> String
+showSDoc verbosity sdoc = Pretty.render $ runSDoc sdoc (SDC verbosity)
+
+showPpr :: Outputable a => Verbosity -> a -> String
+showPpr verbosity = showSDoc verbosity . ppr
+
+data SDocContext = SDC
+  { sdocVerbosity :: Verbosity
+  }
+
+sdocWithVerbosity :: (Verbosity -> SDoc) -> SDoc
+sdocWithVerbosity f = SDoc $ \ctx -> runSDoc (f (sdocVerbosity ctx)) ctx
+
+docToSDoc :: Doc -> SDoc
+docToSDoc d = SDoc (\_ -> d)
+
+empty    :: SDoc
+char     :: Char       -> SDoc
+text     :: String     -> SDoc
+int      :: Int        -> SDoc
+integer  :: Integer    -> SDoc
+float    :: Float      -> SDoc
+double   :: Double     -> SDoc
+rational :: Rational   -> SDoc
+
+empty       = docToSDoc $ Pretty.empty
+char c      = docToSDoc $ Pretty.char c
+
+text s      = docToSDoc $ Pretty.text s
+{-# INLINE text #-}   -- Inline so that the RULE Pretty.text will fire
+
+int n       = docToSDoc $ Pretty.int n
+integer n   = docToSDoc $ Pretty.integer n
+float n     = docToSDoc $ Pretty.float n
+double n    = docToSDoc $ Pretty.double n
+rational n  = docToSDoc $ Pretty.rational n
+
+parens, braces, brackets, quotes,
+        paBrackets, doubleQuotes, angleBrackets :: SDoc -> SDoc
+
+parens d        = SDoc $ Pretty.parens . runSDoc d
+braces d        = SDoc $ Pretty.braces . runSDoc d
+brackets d      = SDoc $ Pretty.brackets . runSDoc d
+doubleQuotes d  = SDoc $ Pretty.doubleQuotes . runSDoc d
+angleBrackets d = char '<' <> d <> char '>'
+paBrackets d    = text "[:" <> d <> text ":]"
+
+quotes d = SDoc $ Pretty.quotes . runSDoc d
+
+semi, comma, colon, equals, space, underscore, dot, vbar :: SDoc
+lparen, rparen, lbrack, rbrack, lbrace, rbrace, blankLine :: SDoc
+
+blankLine  = docToSDoc $ Pretty.text ""
+semi       = docToSDoc $ Pretty.semi
+comma      = docToSDoc $ Pretty.comma
+colon      = docToSDoc $ Pretty.colon
+equals     = docToSDoc $ Pretty.equals
+space      = docToSDoc $ Pretty.space
+underscore = char '_'
+dot        = char '.'
+vbar       = char '|'
+lparen     = docToSDoc $ Pretty.lparen
+rparen     = docToSDoc $ Pretty.rparen
+lbrack     = docToSDoc $ Pretty.lbrack
+rbrack     = docToSDoc $ Pretty.rbrack
+lbrace     = docToSDoc $ Pretty.lbrace
+rbrace     = docToSDoc $ Pretty.rbrace
+
+nest :: Int -> SDoc -> SDoc
+-- ^ Indent 'SDoc' some specified amount
+(<<>>) :: SDoc -> SDoc -> SDoc
+-- ^ Join two 'SDoc' together horizontally without a gap
+(<+>) :: SDoc -> SDoc -> SDoc
+-- ^ Join two 'SDoc' together horizontally with a gap between them
+($$) :: SDoc -> SDoc -> SDoc
+-- ^ Join two 'SDoc' together vertically; if there is
+-- no vertical overlap it "dovetails" the two onto one line
+($+$) :: SDoc -> SDoc -> SDoc
+-- ^ Join two 'SDoc' together vertically
+
+nest n d    = SDoc $ Pretty.nest n . runSDoc d
+(<<>>) d1 d2  = SDoc $ \sty -> (Pretty.<>)  (runSDoc d1 sty) (runSDoc d2 sty)
+(<+>) d1 d2 = SDoc $ \sty -> (Pretty.<+>) (runSDoc d1 sty) (runSDoc d2 sty)
+($$) d1 d2  = SDoc $ \sty -> (Pretty.$$)  (runSDoc d1 sty) (runSDoc d2 sty)
+($+$) d1 d2 = SDoc $ \sty -> (Pretty.$+$) (runSDoc d1 sty) (runSDoc d2 sty)
+
+hcat :: [SDoc] -> SDoc
+-- ^ Concatenate 'SDoc' horizontally
+hsep :: [SDoc] -> SDoc
+-- ^ Concatenate 'SDoc' horizontally with a space between each one
+vcat :: [SDoc] -> SDoc
+-- ^ Concatenate 'SDoc' vertically with dovetailing
+sep :: [SDoc] -> SDoc
+-- ^ Separate: is either like 'hsep' or like 'vcat', depending on what fits
+cat :: [SDoc] -> SDoc
+-- ^ Catenate: is either like 'hcat' or like 'vcat', depending on what fits
+fsep :: [SDoc] -> SDoc
+-- ^ A paragraph-fill combinator. It's much like sep, only it
+-- keeps fitting things on one line until it can't fit any more.
+fcat :: [SDoc] -> SDoc
+-- ^ This behaves like 'fsep', but it uses '<>' for horizontal conposition rather than '<+>'
+
+
+hcat ds = SDoc $ \sty -> Pretty.hcat [runSDoc d sty | d <- ds]
+hsep ds = SDoc $ \sty -> Pretty.hsep [runSDoc d sty | d <- ds]
+vcat ds = SDoc $ \sty -> Pretty.vcat [runSDoc d sty | d <- ds]
+sep ds  = SDoc $ \sty -> Pretty.sep  [runSDoc d sty | d <- ds]
+cat ds  = SDoc $ \sty -> Pretty.cat  [runSDoc d sty | d <- ds]
+fsep ds = SDoc $ \sty -> Pretty.fsep [runSDoc d sty | d <- ds]
+fcat ds = SDoc $ \sty -> Pretty.fcat [runSDoc d sty | d <- ds]
+
+hang :: SDoc  -- ^ The header
+      -> Int  -- ^ Amount to indent the hung body
+      -> SDoc -- ^ The hung body, indented and placed below the header
+      -> SDoc
+hang d1 n d2   = SDoc $ \sty -> Pretty.hang (runSDoc d1 sty) n (runSDoc d2 sty)
+
+punctuate :: SDoc   -- ^ The punctuation
+          -> [SDoc] -- ^ The list that will have punctuation added between every adjacent pair of elements
+          -> [SDoc] -- ^ Punctuated list
+punctuate _ []     = []
+punctuate p (d0:ds) = go d0 ds
+                   where
+                     go d [] = [d]
+                     go d (e:es) = (d <> p) : go e es
+
+ppWhen, ppUnless :: Bool -> SDoc -> SDoc
+ppWhen True  doc = doc
+ppWhen False _   = empty
+
+ppUnless True  _   = empty
+ppUnless False doc = doc
+
+-- | Debug-printable entity.
+class Outputable a where
+    ppr :: a -> SDoc
+
+-- The usual objection against overlapping instances is that
+-- introducing extra instances can cause behavior change.  But
+-- this is fairly benign for Outputable, which intended primarily
+-- for debugging.  Also, this is an undecidable instance, but
+-- you should NEVER define a Pretty depending on an Outputable.
+instance {-# OVERLAPPABLE #-} Pretty a => Outputable a where
+    ppr x = SDoc $ \_ -> pretty x
+
+-- You really ought not to use this instance, but it is convenient
+instance Outputable SDoc where
+    ppr = id
+
+instance Outputable Doc where
+    ppr = docToSDoc
+
+instance Outputable Char where
+    ppr c = text [c]
+
+instance {-# OVERLAPPING #-} Outputable [Char] where
+    ppr s = text s
+
+instance Outputable Bool where
+    ppr True  = text "True"
+    ppr False = text "False"
+
+instance Outputable Ordering where
+    ppr LT = text "LT"
+    ppr EQ = text "EQ"
+    ppr GT = text "GT"
+
+instance Outputable Int32 where
+   ppr n = integer $ fromIntegral n
+
+instance Outputable Int64 where
+   ppr n = integer $ fromIntegral n
+
+instance Outputable Int where
+    ppr n = int n
+
+instance Outputable Integer where
+    ppr n = integer n
+
+instance Outputable Word16 where
+    ppr n = integer $ fromIntegral n
+
+instance Outputable Word32 where
+    ppr n = integer $ fromIntegral n
+
+instance Outputable Word where
+    ppr n = integer $ fromIntegral n
+
+instance Outputable () where
+    ppr _ = text "()"
+
+instance (Outputable a) => Outputable [a] where
+    ppr xs = brackets (fsep (punctuate comma (map ppr xs)))
+
+instance (Outputable a) => Outputable (Set a) where
+    ppr s = braces (fsep (punctuate comma (map ppr (Set.toList s))))
+
+instance (Outputable a, Outputable b) => Outputable (a, b) where
+    ppr (x,y) = parens (sep [ppr x <> comma, ppr y])
+
+instance Outputable a => Outputable (Maybe a) where
+    ppr Nothing  = text "Nothing"
+    ppr (Just x) = text "Just" <+> ppr x
+
+instance (Outputable a, Outputable b) => Outputable (Either a b) where
+    ppr (Left x)  = text "Left"  <+> ppr x
+    ppr (Right y) = text "Right" <+> ppr y
+
+-- ToDo: may not be used
+instance (Outputable a, Outputable b, Outputable c) => Outputable (a, b, c) where
+    ppr (x,y,z) =
+      parens (sep [ppr x <> comma,
+                   ppr y <> comma,
+                   ppr z ])
+
+instance (Outputable a, Outputable b, Outputable c, Outputable d) =>
+         Outputable (a, b, c, d) where
+    ppr (a,b,c,d) =
+      parens (sep [ppr a <> comma,
+                   ppr b <> comma,
+                   ppr c <> comma,
+                   ppr d])
+
+instance (Outputable a, Outputable b, Outputable c, Outputable d, Outputable e) =>
+         Outputable (a, b, c, d, e) where
+    ppr (a,b,c,d,e) =
+      parens (sep [ppr a <> comma,
+                   ppr b <> comma,
+                   ppr c <> comma,
+                   ppr d <> comma,
+                   ppr e])
+
+instance (Outputable a, Outputable b, Outputable c, Outputable d, Outputable e, Outputable f) =>
+         Outputable (a, b, c, d, e, f) where
+    ppr (a,b,c,d,e,f) =
+      parens (sep [ppr a <> comma,
+                   ppr b <> comma,
+                   ppr c <> comma,
+                   ppr d <> comma,
+                   ppr e <> comma,
+                   ppr f])
+
+instance (Outputable a, Outputable b, Outputable c, Outputable d, Outputable e, Outputable f, Outputable g) =>
+         Outputable (a, b, c, d, e, f, g) where
+    ppr (a,b,c,d,e,f,g) =
+      parens (sep [ppr a <> comma,
+                   ppr b <> comma,
+                   ppr c <> comma,
+                   ppr d <> comma,
+                   ppr e <> comma,
+                   ppr f <> comma,
+                   ppr g])
+
+instance (Outputable key, Outputable elt) => Outputable (Map key elt) where
+    ppr m = ppr (Map.toList m)
+instance (Outputable elt) => Outputable (IntMap elt) where
+    ppr m = ppr (IntMap.toList m)

--- a/Cabal/Distribution/Pretty.hs
+++ b/Cabal/Distribution/Pretty.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances #-}
 module Distribution.Pretty (
     Pretty (..),
     prettyShow,
@@ -15,9 +16,18 @@ module Distribution.Pretty (
 import Prelude ()
 import Distribution.Compat.Prelude
 import Data.Functor.Identity (Identity (..))
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Map (Map)
+import qualified Data.Map as Map
 
 import qualified Text.PrettyPrint as PP
 
+-- | A pretty-printable type is one which can be printed and
+-- then parsed via 'Parsec' losslessly.
+--
+-- If you are looking for a "debug-printable" type, see
+-- 'Outputable'
 class Pretty a where
     pretty :: a -> PP.Doc
 

--- a/Cabal/Distribution/Types/AnnotatedId.hs
+++ b/Cabal/Distribution/Types/AnnotatedId.hs
@@ -11,12 +11,21 @@ import Distribution.Types.ComponentName
 -- | An 'AnnotatedId' is a 'ComponentId', 'UnitId', etc.
 -- which is annotated with some other useful information
 -- that is useful for printing to users, etc.
+--
+-- Invariant: if ann_id x == ann_id y, then ann_pid x == ann_pid y
+-- and ann_cname x == ann_cname y
 data AnnotatedId id = AnnotatedId {
         ann_pid   :: PackageId,
         ann_cname :: ComponentName,
         ann_id    :: id
     }
     deriving (Show)
+
+instance Eq id => Eq (AnnotatedId id) where
+    x == y = ann_id x == ann_id y
+
+instance Ord id => Ord (AnnotatedId id) where
+    compare x y = compare (ann_id x) (ann_id y)
 
 instance Package (AnnotatedId id) where
     packageId = ann_pid

--- a/Cabal/Distribution/Types/UnqualComponentName.hs
+++ b/Cabal/Distribution/Types/UnqualComponentName.hs
@@ -14,6 +14,7 @@ import Distribution.Parsec.Class
 import Distribution.ParseUtils        (parsePackageName)
 import Distribution.Pretty
 import Distribution.Text
+import Distribution.Outputable
 import Distribution.Types.PackageName
 
 -- | An unqualified component name, for any kind of component.

--- a/Cabal/Distribution/Utils/LogProgress.hs
+++ b/Cabal/Distribution/Utils/LogProgress.hs
@@ -13,14 +13,14 @@ module Distribution.Utils.LogProgress (
 import Prelude ()
 import Distribution.Compat.Prelude
 
+import Distribution.Outputable
 import Distribution.Utils.Progress
 import Distribution.Verbosity
 import Distribution.Simple.Utils
-import Text.PrettyPrint
 
-type CtxMsg = Doc
-type LogMsg = Doc
-type ErrMsg = Doc
+type CtxMsg = SDoc
+type LogMsg = SDoc
+type ErrMsg = SDoc
 
 data LogEnv = LogEnv {
         le_verbosity :: Verbosity,
@@ -54,33 +54,33 @@ runLogProgress verbosity (LogProgress m) =
       }
     step_fn :: LogMsg -> NoCallStackIO a -> NoCallStackIO a
     step_fn doc go = do
-        putStrLn (render doc)
+        putStrLn (showSDoc verbosity doc)
         go
-    fail_fn :: Doc -> NoCallStackIO a
+    fail_fn :: SDoc -> NoCallStackIO a
     fail_fn doc = do
-        dieNoWrap verbosity (render doc)
+        dieNoWrap verbosity (showSDoc verbosity doc)
 
 -- | Output a warning trace message in 'LogProgress'.
-warnProgress :: Doc -> LogProgress ()
+warnProgress :: SDoc -> LogProgress ()
 warnProgress s = LogProgress $ \env ->
     when (le_verbosity env >= normal) $
         stepProgress $
             hang (text "Warning:") 4 (formatMsg (le_context env) s)
 
 -- | Output an informational trace message in 'LogProgress'.
-infoProgress :: Doc -> LogProgress ()
+infoProgress :: SDoc -> LogProgress ()
 infoProgress s = LogProgress $ \env ->
     when (le_verbosity env >= verbose) $
         stepProgress s
 
 -- | Fail the computation with an error message.
-dieProgress :: Doc -> LogProgress a
+dieProgress :: SDoc -> LogProgress a
 dieProgress s = LogProgress $ \env ->
     failProgress $
         hang (text "Error:") 4 (formatMsg (le_context env) s)
 
 -- | Format a message with context. (Something simple for now.)
-formatMsg :: [CtxMsg] -> Doc -> Doc
+formatMsg :: [CtxMsg] -> SDoc -> SDoc
 formatMsg ctx doc = doc $$ vcat ctx
 
 -- | Add a message to the error/warning context.

--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -27,7 +27,8 @@ import Distribution.Simple.Command
 import Distribution.Verbosity
          ( Verbosity, normal )
 import Distribution.Simple.Utils
-         ( wrapText, die' )
+         ( wrapText, die', debugNoWrap )
+import Distribution.Outputable
 
 import qualified Data.Map as Map
 
@@ -100,6 +101,10 @@ buildAction (applyFlagDefaults -> (configFlags, configExFlags, installFlags, had
                                     TargetActionBuild
                                     targets
                                     elaboratedPlan
+
+            debugNoWrap verbosity "==================== pruneInstallPlanToTargets ===================="
+            debugNoWrap verbosity (showPpr verbosity elaboratedPlan')
+
             elaboratedPlan'' <-
               if buildSettingOnlyDeps (buildSettings baseCtx)
                 then either (reportCannotPruneDependencies verbosity) return $

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -126,6 +126,7 @@ import           Distribution.Simple.LocalBuildInfo
                    ( ComponentName(..), pkgComponents )
 import qualified Distribution.Simple.Setup as Setup
 import           Distribution.Simple.Command (commandShowOptions)
+import           Distribution.Simple.Configure (computeEffectiveProfiling)
 
 import           Distribution.Simple.Utils
                    ( die'
@@ -750,12 +751,7 @@ printPlan verbosity
             nubFlag :: Eq a => a -> Setup.Flag a -> Setup.Flag a
             nubFlag x (Setup.Flag x') | x == x' = Setup.NoFlag
             nubFlag _ f = f
-            -- TODO: Closely logic from 'configureProfiling'.
-            tryExeProfiling = Setup.fromFlagOrDefault False
-                                (configProf fullConfigureFlags)
-            tryLibProfiling = Setup.fromFlagOrDefault False
-                                (Mon.mappend (configProf    fullConfigureFlags)
-                                             (configProfExe fullConfigureFlags))
+            (tryLibProfiling, tryExeProfiling) = computeEffectiveProfiling fullConfigureFlags
             partialConfigureFlags
               = Mon.mempty {
                 configProf    =

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -117,6 +117,7 @@ import           Distribution.Client.Setup hiding (packageName)
 
 import           Distribution.Solver.Types.OptionalStanza
 
+import           Distribution.Text (display)
 import           Distribution.Package
                    hiding (InstalledPackageId, installedPackageId)
 import           Distribution.PackageDescription
@@ -128,11 +129,11 @@ import qualified Distribution.Simple.Setup as Setup
 import           Distribution.Simple.Command (commandShowOptions)
 import           Distribution.Simple.Configure (computeEffectiveProfiling)
 
+import           Distribution.Outputable
 import           Distribution.Simple.Utils
                    ( die'
                    , notice, noticeNoWrap, debugNoWrap )
 import           Distribution.Verbosity
-import           Distribution.Text
 import           Distribution.Simple.Compiler
                    ( showCompilerId
                    , OptimisationLevel(..))
@@ -265,12 +266,17 @@ runProjectPreBuildPhase
                          projectConfig
                          localPackages
 
+    debugNoWrap verbosity "=================== rebuildInstallPlan ==================="
+    debugNoWrap verbosity (showPpr verbosity elaboratedPlan)
+
     -- The plan for what to do is represented by an 'ElaboratedInstallPlan'
 
     -- Now given the specific targets the user has asked for, decide
     -- which bits of the plan we will want to execute.
     --
     (elaboratedPlan', targets) <- selectPlanSubset elaboratedPlan
+    debugNoWrap verbosity "==================== selectPlanSubset ===================="
+    debugNoWrap verbosity (showPpr verbosity elaboratedPlan')
 
     -- Check which packages need rebuilding.
     -- This also gives us more accurate reasons for the --dry-run output.
@@ -282,7 +288,8 @@ runProjectPreBuildPhase
     --
     let elaboratedPlan'' = improveInstallPlanWithUpToDatePackages
                              pkgsBuildStatus elaboratedPlan'
-    debugNoWrap verbosity (InstallPlan.showInstallPlan elaboratedPlan'')
+    debugNoWrap verbosity "============== improveInstallPlanWithUpToDatePackages ==============="
+    debugNoWrap verbosity (showPpr verbosity elaboratedPlan'')
 
     return ProjectBuildContext {
       elaboratedPlanOriginal = elaboratedPlan,

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1563,8 +1563,14 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                             } <- comps
                           ]
 
-        -- Filled in later
-        pkgStanzasEnabled  = Set.empty
+        -- NB: This is not the final setting of 'pkgStanzasEnabled'.
+        -- See [Sticky enabled testsuites]; we may enable some extra
+        -- stanzas opportunistically when it is cheap to do so.
+        --
+        -- However, we start off by enabling everything that was
+        -- requested, so that we can maintain an invariant that
+        -- pkgStanzasEnabled is a superset of elabStanzasRequested
+        pkgStanzasEnabled  = Map.keysSet (Map.filter (id :: Bool -> Bool) elabStanzasRequested)
 
         install_dirs
           | shouldBuildInplaceOnly pkg
@@ -2393,6 +2399,10 @@ data TargetAction = TargetActionBuild
 -- to specify which optional stanzas to enable, and which targets within each
 -- package to build.
 --
+-- NB: Pruning happens after improvement, which is important because we
+-- will prune differently depending on what is already installed (to
+-- implement "sticky" test suite enabling behavior).
+--
 pruneInstallPlanToTargets :: TargetAction
                           -> Map UnitId [ComponentTarget]
                           -> ElaboratedInstallPlan -> ElaboratedInstallPlan
@@ -2479,7 +2489,7 @@ pruneInstallPlanPass1 pkgs =
     roots = mapMaybe find_root pkgs'
 
     prune elab = PrunedPackage elab' (pruneOptionalDependencies elab')
-      where elab' = pruneOptionalStanzas elab
+      where elab' = addOptionalStanzas elab
 
     find_root (InstallPlan.Configured (PrunedPackage elab _)) =
         if not (null (elabBuildTargets elab)
@@ -2491,8 +2501,8 @@ pruneInstallPlanPass1 pkgs =
             else Nothing
     find_root _ = Nothing
 
-    -- Decide whether or not to enable testsuites and benchmarks
-    --
+    -- Note [Sticky enabled testsuites]
+    -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     -- The testsuite and benchmark targets are somewhat special in that we need
     -- to configure the packages with them enabled, and we need to do that even
     -- if we only want to build one of several testsuites.
@@ -2506,18 +2516,31 @@ pruneInstallPlanPass1 pkgs =
     -- would involve unnecessarily reconfiguring the package with testsuites
     -- disabled. Technically this introduces a little bit of stateful
     -- behaviour to make this "sticky", but it should be benign.
-    --
-    pruneOptionalStanzas :: ElaboratedConfiguredPackage -> ElaboratedConfiguredPackage
-    pruneOptionalStanzas elab@ElaboratedConfiguredPackage{ elabPkgOrComp = ElabPackage pkg } =
+
+    -- Decide whether or not to enable testsuites and benchmarks.
+    -- See [Sticky enabled testsuites]
+    addOptionalStanzas :: ElaboratedConfiguredPackage -> ElaboratedConfiguredPackage
+    addOptionalStanzas elab@ElaboratedConfiguredPackage{ elabPkgOrComp = ElabPackage pkg } =
         elab {
             elabPkgOrComp = ElabPackage (pkg { pkgStanzasEnabled = stanzas })
         }
       where
         stanzas :: Set OptionalStanza
-        stanzas = optionalStanzasRequiredByTargets  elab
-               <> optionalStanzasRequestedByDefault elab
+               -- By default, we enabled all stanzas requested by the user,
+               -- as per elabStanzasRequested, done in
+               -- 'elaborateSolverToPackage'
+        stanzas = pkgStanzasEnabled pkg
+               -- optionalStanzasRequiredByTargets has to be done at
+               -- prune-time because it depends on 'elabTestTargets'
+               -- et al, which is done by 'setRootTargets' at the
+               -- beginning of pruning.
+               <> optionalStanzasRequiredByTargets elab
+               -- optionalStanzasWithDepsAvailable has to be done at
+               -- prune-time because it depends on what packages are
+               -- installed, which is not known until after improvement
+               -- (pruning is done after improvement)
                <> optionalStanzasWithDepsAvailable availablePkgs elab pkg
-    pruneOptionalStanzas elab = elab
+    addOptionalStanzas elab = elab
 
     -- Calculate package dependencies but cut out those needed only by
     -- optional stanzas that we've determined we will not enable.
@@ -2547,13 +2570,6 @@ pruneInstallPlanPass1 pkgs =
                                   ++ maybeToList (elabReplTarget pkg)
         , stanza <- maybeToList (componentOptionalStanza cname)
         ]
-
-    optionalStanzasRequestedByDefault :: ElaboratedConfiguredPackage
-                                      -> Set OptionalStanza
-    optionalStanzasRequestedByDefault =
-        Map.keysSet
-      . Map.filter (id :: Bool -> Bool)
-      . elabStanzasRequested
 
     availablePkgs =
       Set.fromList

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -540,6 +540,18 @@ data ElaboratedComponent
     -- | The paths all our executable dependencies will be installed
     -- to once they are installed.
     compExeDependencyPaths :: [(ConfiguredId, FilePath)],
+    -- | UnitId dependencies specifying what order we need to build
+    -- things, in the install plan.  This is distinct from:
+    --    * compLinkedLibDependencies - suppose you have an indefinite
+    --      package that partially instantiates one of its dependencies.
+    --      A partially instantiated package never shows up in the
+    --      install plan; rather, GHC knows how to instantiate it
+    --      "on-the-fly".  So compOrderLibDependencies will record
+    --      the fully uninstantiated UnitId for that package, while
+    --      compLinkedLibDependencies will carry the actual partially
+    --      instantiated OpenUnitId.
+    --    * compLibDependencies - this doesn't know anything about
+    --      instantiations; this is post dep-solving dependencies.
     compOrderLibDependencies :: [UnitId]
    }
   deriving (Eq, Show, Generic)
@@ -547,6 +559,8 @@ data ElaboratedComponent
 instance Binary ElaboratedComponent
 
 -- | See 'elabOrderDependencies'.
+--
+-- Invariant: the list has no duplicates
 compOrderDependencies :: ElaboratedComponent -> [UnitId]
 compOrderDependencies comp =
     compOrderLibDependencies comp

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -89,6 +90,7 @@ import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Compat.Graph (IsNode(..))
 import           Distribution.Simple.Utils (ordNub)
+import           Distribution.Outputable
 
 import           Data.Map (Map)
 import           Data.Set (Set)
@@ -299,6 +301,12 @@ data ElaboratedConfiguredPackage
    }
   deriving (Eq, Show, Generic, Typeable)
 
+instance Outputable ElaboratedConfiguredPackage where
+    ppr ElaboratedConfiguredPackage{..}  =
+        vcat [ text "elabUnitId =" <+> ppr elabUnitId
+             , ppr elabPkgOrComp
+             ]
+
 -- | The package/component contains/is a library and so must be registered
 elabRequiresRegistration :: ElaboratedConfiguredPackage -> Bool
 elabRequiresRegistration elab =
@@ -358,6 +366,10 @@ data ElaboratedPackageOrComponent
     = ElabPackage   ElaboratedPackage
     | ElabComponent ElaboratedComponent
   deriving (Eq, Show, Generic)
+
+instance Outputable ElaboratedPackageOrComponent where
+    ppr (ElabPackage x) = hang (text "ElabPackage") 2 (ppr x)
+    ppr (ElabComponent x) = hang (text "ElabComponent") 2 (ppr x)
 
 instance Binary ElaboratedPackageOrComponent
 
@@ -556,6 +568,18 @@ data ElaboratedComponent
    }
   deriving (Eq, Show, Generic)
 
+instance Outputable ElaboratedComponent where
+    ppr ElaboratedComponent{..} =
+      vcat [ text "compSolverName" <+> ppr compSolverName
+           , text "compComponentName" <+> ppr compComponentName
+           , text "compLibDependencies" <+> ppr compLibDependencies
+           , text "compLinkedLibDependencies" <+> ppr compLinkedLibDependencies
+           , text "compExeDependencies" <+> ppr compExeDependencies
+           , text "compPkgConfigDependencies" <+> ppr compPkgConfigDependencies
+           , text "compExeDependencyPaths" <+> ppr compExeDependencyPaths
+           , text "compOrderLibDependencies" <+> ppr compOrderLibDependencies
+           ]
+
 instance Binary ElaboratedComponent
 
 -- | See 'elabOrderDependencies'.
@@ -605,6 +629,17 @@ data ElaboratedPackage
        pkgStanzasEnabled :: Set OptionalStanza
      }
   deriving (Eq, Show, Generic)
+
+instance Outputable ElaboratedPackage where
+    ppr ElaboratedPackage{..} =
+      vcat [ text "pkgInstalledId" <+> ppr pkgInstalledId
+           , text "pkgLibDependencies" <+> ppr pkgLibDependencies
+           , text "pkgDependsOnSelfLib" <+> ppr pkgDependsOnSelfLib
+           , text "pkgExeDependencies" <+> ppr pkgExeDependencies
+           , text "pkgExeDependencyPaths" <+> ppr pkgExeDependencyPaths
+           , text "pkgPkgConfigDependencies" <+> ppr pkgPkgConfigDependencies
+           , text "pkgStanzasEnabled" <+> ppr pkgStanzasEnabled
+           ]
 
 instance Binary ElaboratedPackage
 

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -23,6 +23,7 @@ module Distribution.Client.Types where
 import Prelude ()
 import Distribution.Client.Compat.Prelude
 
+import Distribution.Outputable
 import Distribution.Package
          ( Package(..), HasMungedPackageId(..), HasUnitId(..)
          , PackageIdentifier(..), packageVersion, packageName
@@ -122,6 +123,10 @@ data ConfiguredPackage loc = ConfiguredPackage {
     }
   deriving (Eq, Show, Generic)
 
+instance Outputable (ConfiguredPackage loc) where
+    -- TODO: consider more info
+    ppr pkg = ppr (confPkgId pkg)
+
 -- | 'HasConfiguredId' indicates data types which have a 'ConfiguredId'.
 -- This type class is mostly used to conveniently finesse between
 -- 'ElaboratedPackage' and 'ElaboratedComponent'.
@@ -166,6 +171,10 @@ annotatedIdToConfiguredId aid = ConfiguredId {
         confCompName = Just (ann_cname aid),
         confInstId   = ann_id aid
     }
+
+instance Outputable ConfiguredId where
+    ppr (ConfiguredId pid mb_cn cid)
+      = ppr cid <> braces (ppr pid <+> ppr mb_cn)
 
 instance Binary ConfiguredId
 

--- a/cabal-install/Distribution/Client/Utils/Assertion.hs
+++ b/cabal-install/Distribution/Client/Utils/Assertion.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE CPP #-}
-module Distribution.Client.Utils.Assertion (expensiveAssert) where
+module Distribution.Client.Utils.Assertion (
+  expensiveAssert,
+  pprAssert
+) where
 
-#ifdef DEBUG_EXPENSIVE_ASSERTIONS
-import Control.Exception (assert)
+import Distribution.Verbosity
+import Distribution.Outputable
+import Control.Exception (assert, throw, AssertionFailed(..))
 import Distribution.Compat.Stack
-#endif
 
 -- | Like 'assert', but only enabled with -fdebug-expensive-assertions. This
 -- function can be used for expensive assertions that should only be turned on
@@ -16,3 +19,26 @@ expensiveAssert = assert
 expensiveAssert :: Bool -> a -> a
 expensiveAssert _ = id
 #endif
+
+callStackDoc :: WithCallStack SDoc
+callStackDoc =
+    hang (text "Call stack:")
+       4 (vcat $ map text $ lines (prettyCallStack callStack))
+
+panicDoc :: String -> SDoc -> a
+-- TODO: Either take verbosity as an argument here (threading it
+-- through), or unsafely stash it in a global
+panicDoc x doc = throw (AssertionFailed (x ++ "\n\n" ++ showSDoc normal doc))
+
+pprPanic :: WithCallStack (String -> SDoc -> a)
+pprPanic s doc = panicDoc s (doc $$ callStackDoc)
+
+assertPprPanic :: WithCallStack (SDoc -> a)
+assertPprPanic doc = pprPanic "ASSERT failed!" doc
+
+-- NB: This is a little hack to make sure we respect -fignore-assert,
+-- while taking over the actual assert generation so we can put in the
+-- information we care about.  We are throwing away file/line
+-- information, but we can recover this information from the call stack.
+pprAssert :: WithCallStack (Bool -> SDoc -> a -> a)
+pprAssert b doc r = withFrozenCallStack (assert (if b then True else assertPprPanic doc) r)

--- a/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
@@ -39,6 +39,7 @@ module Distribution.Solver.Types.ComponentDeps (
 import Prelude ()
 import Distribution.Types.UnqualComponentName
 import Distribution.Solver.Compat.Prelude hiding (empty,zip)
+import Distribution.Outputable hiding (empty)
 
 import qualified Data.Map as Map
 import Data.Foldable (fold)
@@ -60,6 +61,15 @@ data Component =
   | ComponentSetup
   deriving (Show, Eq, Ord, Generic)
 
+instance Outputable Component where
+    ppr ComponentLib = text "lib"
+    ppr (ComponentSubLib s) = text "sublib:" <> ppr s
+    ppr (ComponentFLib s) = text "flib:" <> ppr s
+    ppr (ComponentExe s) = text "exe:" <> ppr s
+    ppr (ComponentTest s) = text "test:" <> ppr s
+    ppr (ComponentBench s) = text "bench:" <> ppr s
+    ppr ComponentSetup = text "setup"
+
 instance Binary Component
 
 -- | Dependency for a single component.
@@ -72,6 +82,9 @@ type ComponentDep a = (Component, a)
 --
 newtype ComponentDeps a = ComponentDeps { unComponentDeps :: Map Component a }
   deriving (Show, Functor, Eq, Ord, Generic)
+
+instance Outputable a => Outputable (ComponentDeps a) where
+  ppr (ComponentDeps c) = ppr c
 
 instance Semigroup a => Monoid (ComponentDeps a) where
   mempty = ComponentDeps Map.empty

--- a/cabal-install/Distribution/Solver/Types/OptionalStanza.hs
+++ b/cabal-install/Distribution/Solver/Types/OptionalStanza.hs
@@ -8,6 +8,7 @@ module Distribution.Solver.Types.OptionalStanza
 
 import GHC.Generics (Generic)
 import Data.Typeable
+import Distribution.Outputable
 import Distribution.Compat.Binary (Binary(..))
 import Distribution.Types.ComponentRequestedSpec
             (ComponentRequestedSpec(..), defaultComponentRequestedSpec)
@@ -17,6 +18,9 @@ data OptionalStanza
     = TestStanzas
     | BenchStanzas
   deriving (Eq, Ord, Enum, Bounded, Show, Generic, Typeable)
+
+instance Outputable OptionalStanza where
+  ppr = text . showStanza
 
 -- | String representation of an OptionalStanza.
 showStanza :: OptionalStanza -> String

--- a/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/InstallPlan.hs
@@ -14,6 +14,8 @@ import           Distribution.Solver.Types.PackageFixedDeps
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Client.Types
 import           Distribution.Client.JobControl
+import           Distribution.Outputable
+import           Distribution.Verbosity
 
 import Data.Graph
 import Data.Array hiding (index)
@@ -145,10 +147,14 @@ data TestInstallPlan = TestInstallPlan
                          (Vertex -> UnitId)
 
 instance Show TestInstallPlan where
-  show (TestInstallPlan plan _ _ _) = InstallPlan.showInstallPlan plan
+  -- TODO: hardcoded normal here is a hack
+  show (TestInstallPlan plan _ _ _) = showPpr normal plan
 
 data TestPkg = TestPkg PackageId UnitId [UnitId]
   deriving (Eq, Show)
+
+instance Outputable TestPkg where
+  ppr (TestPkg _ ipkgid _) = ppr ipkgid
 
 instance IsNode TestPkg where
   type Key TestPkg = UnitId

--- a/cabal-testsuite/PackageTests/NewBuild/T3827/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/T3827/cabal.out
@@ -2,7 +2,7 @@
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
- - p-1.0 (lib) --enable-library-profiling (first run)
+ - p-1.0 (lib) (first run)
  - q-1.0 (exe:q) --enable-profiling (first run)
 Configuring library for p-1.0..
 Preprocessing library for p-1.0..

--- a/cabal-testsuite/PackageTests/Regression/T4986/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T4986/cabal.out
@@ -1,0 +1,6 @@
+# cabal new-configure
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - happy-999.999.999 (exe:happy) (first run)
+ - client-0.1.0.0 (exe:hello-world) (first run)

--- a/cabal-testsuite/PackageTests/Regression/T4986/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T4986/cabal.project
@@ -1,0 +1,1 @@
+packages: client, happy

--- a/cabal-testsuite/PackageTests/Regression/T4986/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4986/cabal.test.hs
@@ -1,0 +1,4 @@
+import Test.Cabal.Prelude
+main = cabalTest $
+    withSourceCopy $
+        cabal "new-configure" []

--- a/cabal-testsuite/PackageTests/Regression/T4986/client/Hello.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4986/client/Hello.hs
@@ -1,0 +1,1 @@
+main = return ()

--- a/cabal-testsuite/PackageTests/Regression/T4986/client/client.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T4986/client/client.cabal
@@ -1,0 +1,14 @@
+name:                client
+version:             0.1.0.0
+synopsis:            Checks build-tools are put in PATH
+license:             BSD3
+category:            Testing
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable             hello-world
+  main-is:             Hello.hs
+  build-depends:       base
+  build-tools:         happy
+  build-tool-depends:  happy:happy
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/Regression/T4986/happy/Main.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4986/happy/Main.hs
@@ -1,0 +1,1 @@
+main = return ()

--- a/cabal-testsuite/PackageTests/Regression/T4986/happy/happy.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T4986/happy/happy.cabal
@@ -1,0 +1,12 @@
+name:                happy
+version:             999.999.999
+synopsis:            Checks double-dependency on build-tool works correctly
+license:             BSD3
+category:            Testing
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable             happy
+  main-is:             Main.hs
+  build-depends:       base
+  default-language:    Haskell2010


### PR DESCRIPTION
This PR adds a GHC-style Outputable type class for debug/user-visible pretty printing, and rewrites everything to use it. It also adds `pprAssert` and rewrites/adds some asserts for it.

Stacked on top of #4991

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!