### PR TITLE
Pass extra dirs to http transport

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -234,7 +234,8 @@ instance Semigroup SavedConfig where
         globalIgnoreExpiry      = combine globalIgnoreExpiry,
         globalHttpTransport     = combine globalHttpTransport,
         globalNix               = combine globalNix,
-        globalStoreDir          = combine globalStoreDir
+        globalStoreDir          = combine globalStoreDir,
+        globalProgPathExtra     = lastNonEmptyNL globalProgPathExtra
         }
         where
           combine        = combine'        savedGlobalFlags
@@ -973,7 +974,9 @@ parseConfig src initial = \str -> do
 
   return config {
     savedGlobalFlags       = (savedGlobalFlags config) {
-       globalRemoteRepos   = toNubList remoteRepoSections
+       globalRemoteRepos   = toNubList remoteRepoSections,
+       -- the global extra prog path comes from the configure flag prog path
+       globalProgPathExtra = configProgramPathExtra (savedConfigureFlags config)
        },
     savedConfigureFlags    = (savedConfigureFlags config) {
        configProgramPaths  = paths,

--- a/cabal-install/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/Distribution/Client/GlobalFlags.hs
@@ -70,7 +70,7 @@ data GlobalFlags = GlobalFlags {
     globalHttpTransport     :: Flag String,
     globalNix               :: Flag Bool,  -- ^ Integrate with Nix
     globalStoreDir          :: Flag FilePath,
-    globalProgPathExtra     :: NubList FilePath
+    globalProgPathExtra     :: NubList FilePath -- ^ Extra program path used for packagedb lookups in a global context (i.e. for http transports)
   } deriving Generic
 
 defaultGlobalFlags :: GlobalFlags

--- a/cabal-install/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/Distribution/Client/GlobalFlags.hs
@@ -69,7 +69,8 @@ data GlobalFlags = GlobalFlags {
     globalIgnoreExpiry      :: Flag Bool,    -- ^ Ignore security expiry dates
     globalHttpTransport     :: Flag String,
     globalNix               :: Flag Bool,  -- ^ Integrate with Nix
-    globalStoreDir          :: Flag FilePath
+    globalStoreDir          :: Flag FilePath,
+    globalProgPathExtra     :: NubList FilePath
   } deriving Generic
 
 defaultGlobalFlags :: GlobalFlags
@@ -89,7 +90,8 @@ defaultGlobalFlags  = GlobalFlags {
     globalIgnoreExpiry      = Flag False,
     globalHttpTransport     = mempty,
     globalNix               = Flag False,
-    globalStoreDir          = mempty
+    globalStoreDir          = mempty,
+    globalProgPathExtra     = mempty
   }
 
 instance Monoid GlobalFlags where
@@ -139,18 +141,20 @@ withRepoContext :: Verbosity -> GlobalFlags -> (RepoContext -> IO a) -> IO a
 withRepoContext verbosity globalFlags =
     withRepoContext'
       verbosity
-      (fromNubList (globalRemoteRepos   globalFlags))
-      (fromNubList (globalLocalRepos    globalFlags))
-      (fromFlag    (globalCacheDir      globalFlags))
-      (flagToMaybe (globalHttpTransport globalFlags))
-      (flagToMaybe (globalIgnoreExpiry  globalFlags))
+      (fromNubList (globalRemoteRepos    globalFlags))
+      (fromNubList (globalLocalRepos     globalFlags))
+      (fromFlag    (globalCacheDir       globalFlags))
+      (flagToMaybe (globalHttpTransport  globalFlags))
+      (flagToMaybe (globalIgnoreExpiry   globalFlags))
+      (fromNubList (globalProgPathExtra globalFlags))
 
 withRepoContext' :: Verbosity -> [RemoteRepo] -> [FilePath]
                  -> FilePath  -> Maybe String -> Maybe Bool
+                 -> [FilePath]
                  -> (RepoContext -> IO a)
                  -> IO a
 withRepoContext' verbosity remoteRepos localRepos
-                 sharedCacheDir httpTransport ignoreExpiry = \callback -> do
+                 sharedCacheDir httpTransport ignoreExpiry extraPaths = \callback -> do
     transportRef <- newMVar Nothing
     let httpLib = Sec.HTTP.transportAdapter
                     verbosity
@@ -178,7 +182,7 @@ withRepoContext' verbosity remoteRepos localRepos
       modifyMVar transportRef $ \mTransport -> do
         transport <- case mTransport of
           Just tr -> return tr
-          Nothing -> configureTransport verbosity httpTransport
+          Nothing -> configureTransport verbosity extraPaths httpTransport
         return (Just transport, transport)
 
     withSecureRepo :: Map Repo SecureRepo

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -152,6 +152,7 @@ projectConfigWithBuilderRepoContext verbosity BuildTimeSettings{..} =
       buildSettingCacheDir
       buildSettingHttpTransport
       (Just buildSettingIgnoreExpiry)
+      buildSettingProgPathExtra
 
 
 -- | Use a 'RepoContext', but only for the solver. The solver does not use the
@@ -174,6 +175,7 @@ projectConfigWithSolverRepoContext verbosity
                          projectConfigCacheDir)
       (flagToMaybe projectConfigHttpTransport)
       (flagToMaybe projectConfigIgnoreExpiry)
+      (fromNubList projectConfigProgPathExtra)
 
 
 -- | Resolve the project configuration, with all its optional fields, into
@@ -249,7 +251,8 @@ resolveBuildTimeSettings verbosity
                          ProjectConfig {
                            projectConfigShared = ProjectConfigShared {
                              projectConfigRemoteRepos,
-                             projectConfigLocalRepos
+                             projectConfigLocalRepos,
+                             projectConfigProgPathExtra
                            },
                            projectConfigBuildOnly
                          } =
@@ -274,6 +277,7 @@ resolveBuildTimeSettings verbosity
     buildSettingIgnoreExpiry  = fromFlag    projectConfigIgnoreExpiry
     buildSettingReportPlanningFailure
                               = fromFlag projectConfigReportPlanningFailure
+    buildSettingProgPathExtra = fromNubList projectConfigProgPathExtra
 
     ProjectConfigBuildOnly{..} = defaults
                               <> projectConfigBuildOnly

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -817,7 +817,11 @@ legacySharedConfigFieldDescrs =
       [ newLineListField "local-repo"
           showTokenQ parseTokenQ
           (fromNubList . globalLocalRepos)
-          (\v conf -> conf { globalLocalRepos = toNubList v })
+          (\v conf -> conf { globalLocalRepos = toNubList v }),
+         newLineListField "extra-prog-path-shared-only"
+          showTokenQ parseTokenQ
+          (fromNubList . globalProgPathExtra)
+          (\v conf -> conf { globalProgPathExtra = toNubList v })
       ]
   . filterFields
       [ "remote-repo-cache"

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -278,15 +278,16 @@ convertLegacyAllPackageFlags globalFlags configFlags
       globalConfigFile        = projectConfigConfigFile,
       globalSandboxConfigFile = _, -- ??
       globalRemoteRepos       = projectConfigRemoteRepos,
-      globalLocalRepos        = projectConfigLocalRepos
+      globalLocalRepos        = projectConfigLocalRepos,
+      globalProgPathExtra     = projectConfigProgPathExtra
     } = globalFlags
 
     ConfigFlags {
       configDistPref            = projectConfigDistDir,
       configHcFlavor            = projectConfigHcFlavor,
       configHcPath              = projectConfigHcPath,
-      configHcPkg               = projectConfigHcPkg,
-      configProgramPathExtra    = projectConfigProgPathExtra
+      configHcPkg               = projectConfigHcPkg
+    --configProgramPathExtra    = projectConfigProgPathExtra DELETE ME
     --configInstallDirs         = projectConfigInstallDirs,
     --configUserInstall         = projectConfigUserInstall,
     --configPackageDBs          = projectConfigPackageDBs,

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -285,7 +285,8 @@ convertLegacyAllPackageFlags globalFlags configFlags
       configDistPref            = projectConfigDistDir,
       configHcFlavor            = projectConfigHcFlavor,
       configHcPath              = projectConfigHcPath,
-      configHcPkg               = projectConfigHcPkg
+      configHcPkg               = projectConfigHcPkg,
+      configProgramPathExtra    = projectConfigProgPathExtra
     --configInstallDirs         = projectConfigInstallDirs,
     --configUserInstall         = projectConfigUserInstall,
     --configPackageDBs          = projectConfigPackageDBs,
@@ -490,7 +491,8 @@ convertToLegacySharedConfig
       globalIgnoreExpiry      = projectConfigIgnoreExpiry,
       globalHttpTransport     = projectConfigHttpTransport,
       globalNix               = mempty,
-      globalStoreDir          = projectConfigStoreDir
+      globalStoreDir          = projectConfigStoreDir,
+      globalProgPathExtra     = projectConfigProgPathExtra
     }
 
     configFlags = mempty {

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -192,7 +192,9 @@ data ProjectConfigShared
        projectConfigStrongFlags       :: Flag StrongFlags,
        projectConfigAllowBootLibInstalls :: Flag AllowBootLibInstalls,
        projectConfigPerComponent      :: Flag Bool,
-       projectConfigIndependentGoals  :: Flag IndependentGoals
+       projectConfigIndependentGoals  :: Flag IndependentGoals,
+
+       projectConfigProgPathExtra     :: NubList FilePath
 
        -- More things that only make sense for manual mode, not --local mode
        -- too much control!
@@ -414,6 +416,6 @@ data BuildTimeSettings
        buildSettingLocalRepos            :: [FilePath],
        buildSettingCacheDir              :: FilePath,
        buildSettingHttpTransport         :: Maybe String,
-       buildSettingIgnoreExpiry          :: Bool
+       buildSettingIgnoreExpiry          :: Bool,
+       buildSettingProgPathExtra         :: [FilePath]
      }
-

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -436,6 +436,7 @@ instance Arbitrary ProjectConfigShared where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
+        <*> arbitrary
       where
         arbitraryConstraints :: Gen [(UserConstraint, ConstraintSource)]
         arbitraryConstraints =
@@ -463,7 +464,8 @@ instance Arbitrary ProjectConfigShared where
                                , projectConfigAllowBootLibInstalls = x19
                                , projectConfigPerComponent = x20
                                , projectConfigIndependentGoals = x21
-                               , projectConfigConfigFile = x22 } =
+                               , projectConfigConfigFile = x22
+                               , projectConfigProgPathExtra = x23} =
       [ ProjectConfigShared { projectConfigDistDir = x00'
                             , projectConfigProjectFile = x01'
                             , projectConfigHcFlavor = x02'
@@ -486,18 +488,19 @@ instance Arbitrary ProjectConfigShared where
                             , projectConfigAllowBootLibInstalls = x19'
                             , projectConfigPerComponent = x20'
                             , projectConfigIndependentGoals = x21'
-                            , projectConfigConfigFile = x22' }
+                            , projectConfigConfigFile = x22'
+                            , projectConfigProgPathExtra = x23'}
       | ((x00', x01', x02', x03', x04'),
          (x05', x06', x07', x08', x09'),
          (x10', x11', x12', x13', x14'),
          (x15', x16', x17', x18', x19'),
-          x20', x21', x22')
+          x20', x21', x22', x23')
           <- shrink
                ((x00, x01, x02, fmap NonEmpty x03, fmap NonEmpty x04),
                 (x05, x06, x07, x08, preShrink_Constraints x09),
                 (x10, x11, x12, x13, x14),
                 (x15, x16, x17, x18, x19),
-                 x20, x21, x22)
+                 x20, x21, x22, x23)
       ]
       where
         preShrink_Constraints  = map fst

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -204,7 +204,7 @@ hackProjectConfigShared :: ProjectConfigShared -> ProjectConfigShared
 hackProjectConfigShared config =
     config {
       projectConfigProjectFile = mempty, -- not present within project files
-      projectConfigConfigFile  = mempty, -- dito
+      projectConfigConfigFile  = mempty, -- ditto
       projectConfigConstraints =
       --TODO: [required eventually] parse ambiguity in constraint
       -- "pkgname -any" as either any version or disabled flag "any".
@@ -436,7 +436,7 @@ instance Arbitrary ProjectConfigShared where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
-        <*> arbitrary
+        <*> (toNubList <$> listOf arbitraryShortToken)
       where
         arbitraryConstraints :: Gen [(UserConstraint, ConstraintSource)]
         arbitraryConstraints =


### PR DESCRIPTION

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.

This should resolve half of #4995 -- as usual, two lines of straightforward changes, and 20x as many lines to make sure the data gets threaded to where it needs to go. In this case I've added an extra prog path field to the GlobalFlags object so it can thread through to be used in looking up binaries for the http transport. It is automatically derived from the setting in the config file.