### PR TITLE
Remove `UnknownBuildType` from `BuildType`

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -453,14 +453,6 @@ checkFields pkg =
            "No 'build-type' specified. If you do not need a custom Setup.hs or "
         ++ "./configure script then use 'build-type: Simple'."
 
-  , case buildType pkg of
-      UnknownBuildType unknown -> Just $
-        PackageBuildWarning $
-             quote unknown ++ " is not a known 'build-type'. "
-          ++ "The known build types are: "
-          ++ commaSep (map display knownBuildTypes)
-      _ -> Nothing
-
   , check (isJust (setupBuildInfo pkg) && buildType pkg /= Custom) $
       PackageBuildWarning $
            "Ignoring the 'custom-setup' section because the 'build-type' is "

--- a/Cabal/Distribution/Types/BuildType.hs
+++ b/Cabal/Distribution/Types/BuildType.hs
@@ -25,11 +25,6 @@ data BuildType
                 -- information used by later phases.
   | Make        -- ^ calls @Distribution.Make.defaultMain@
   | Custom      -- ^ uses user-supplied @Setup.hs@ or @Setup.lhs@ (default)
-  | UnknownBuildType String
-                -- ^ a package that uses an unknown build type cannot actually
-                --   be built. Doing it this way rather than just giving a
-                --   parse error means we get better error messages and allows
-                --   you to inspect the rest of the package description.
                 deriving (Generic, Show, Read, Eq, Typeable, Data)
 
 instance Binary BuildType
@@ -38,25 +33,24 @@ knownBuildTypes :: [BuildType]
 knownBuildTypes = [Simple, Configure, Make, Custom]
 
 instance Pretty BuildType where
-  pretty (UnknownBuildType other) = Disp.text other
-  pretty other                    = Disp.text (show other)
+  pretty = Disp.text . show
 
 instance Parsec BuildType where
   parsec = do
     name <- P.munch1 isAlphaNum
-    return $ case name of
-      "Simple"    -> Simple
-      "Configure" -> Configure
-      "Custom"    -> Custom
-      "Make"      -> Make
-      _           -> UnknownBuildType name
+    case name of
+      "Simple"    -> return Simple
+      "Configure" -> return Configure
+      "Custom"    -> return Custom
+      "Make"      -> return Make
+      _           -> fail ("unknown build-type: '" ++ name ++ "'")
 
 instance Text BuildType where
   parse = do
     name <- Parse.munch1 isAlphaNum
-    return $ case name of
-      "Simple"    -> Simple
-      "Configure" -> Configure
-      "Custom"    -> Custom
-      "Make"      -> Make
-      _           -> UnknownBuildType name
+    case name of
+      "Simple"    -> return Simple
+      "Configure" -> return Configure
+      "Custom"    -> return Custom
+      "Make"      -> return Make
+      _           -> fail ("unknown build-type: '" ++ name ++ "'")

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -16,6 +16,7 @@
 	* Use better defaulting for `build-type`; rename `PackageDescription`'s
 	  `buildType` field to `buildTypeRaw` and introduce new `buildType`
 	  function (#4958)
+	* Removed `UnknownBuildType` constructor from `BuildType` (#5003).
 	* Added `HexFloatLiterals` to `KnownExtension`.
 	* Cabal will no longer try to build an empty set of `inputModules`
 	  (#4890).

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -39,7 +39,7 @@ import Distribution.Types.Dependency
 import Distribution.PackageDescription
          ( GenericPackageDescription(packageDescription)
          , PackageDescription(..), specVersion, buildType
-         , BuildType(..), knownBuildTypes, defaultRenaming )
+         , BuildType(..), defaultRenaming )
 import Distribution.PackageDescription.Parsec
          ( readGenericPackageDescription )
 import Distribution.Simple.Configure
@@ -294,7 +294,6 @@ getSetup verbosity options mpkg = do
                                           (orLaterVersion (specVersion pkg))
                     }
       buildType'  = buildType pkg
-  checkBuildType buildType'
   (version, method, options'') <-
     getSetupMethod verbosity options' pkg buildType'
   return Setup { setupMethod = method
@@ -307,12 +306,6 @@ getSetup verbosity options mpkg = do
     getPkg = tryFindPackageDesc (fromMaybe "." (useWorkingDir options))
          >>= readGenericPackageDescription verbosity
          >>= return . packageDescription
-
-    checkBuildType (UnknownBuildType name) =
-      die' verbosity $ "The build-type '" ++ name ++ "' is not known. Use one of: "
-         ++ intercalate ", " (map display knownBuildTypes) ++ "."
-    checkBuildType _ = return ()
-
 
 -- | Decide if we're going to be able to do a direct internal call to the
 -- entry point in the Cabal library or if we're going to have to compile
@@ -429,7 +422,6 @@ buildTypeAction Configure = Simple.defaultMainWithHooksArgs
                               Simple.autoconfUserHooks
 buildTypeAction Make      = Make.defaultMainArgs
 buildTypeAction Custom               = error "buildTypeAction Custom"
-buildTypeAction (UnknownBuildType _) = error "buildTypeAction UnknownBuildType"
 
 
 -- | @runProcess'@ is a version of @runProcess@ where we have
@@ -699,8 +691,7 @@ getExternalSetupMethod verbosity options pkg bt = do
                    then "autoconfUserHooks\n"
                    else "defaultUserHooks\n"
     Make      -> "import Distribution.Make; main = defaultMain\n"
-    Custom             -> error "buildTypeScript Custom"
-    UnknownBuildType _ -> error "buildTypeScript UnknownBuildType"
+    Custom    -> error "buildTypeScript Custom"
 
   installedCabalVersion :: SetupScriptOptions -> Compiler -> ProgramDb
                         -> IO (Version, Maybe InstalledPackageId

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -1214,8 +1214,7 @@ actAsSetupAction actAsSetupFlags args _globalFlags =
     Configure -> Simple.defaultMainWithHooksArgs
                   Simple.autoconfUserHooks args
     Make      -> Make.defaultMainArgs args
-    Custom               -> error "actAsSetupAction Custom"
-    (UnknownBuildType _) -> error "actAsSetupAction UnknownBuildType"
+    Custom    -> error "actAsSetupAction Custom"
 
 manpageAction :: [CommandSpec action] -> Flag Verbosity -> [String] -> Action
 manpageAction commands flagVerbosity extraArgs _ = do


### PR DESCRIPTION
This is a follow-up to #4958 which opened up the opportunity to do
this make-illegal-states-unrepresentable refactoring as well.