### PR TITLE
Test suite: cache the result of hasProfiledLibraries.

### DIFF
--- a/cabal-testsuite/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/Test/Cabal/Prelude.hs
@@ -717,12 +717,7 @@ hasSharedLibraries = do
 hasProfiledLibraries :: TestM Bool
 hasProfiledLibraries = do
     env <- getTestEnv
-    ghc_path <- programPathM ghcProgram
-    let prof_test_hs = testWorkDir env </> "Prof.hs"
-    liftIO $ writeFile prof_test_hs "module Prof where"
-    r <- liftIO $ run (testVerbosity env) (Just (testCurrentDir env))
-                      (testEnvironment env) ghc_path ["-prof", "-c", prof_test_hs]
-    return (resultExitCode r == ExitSuccess)
+    return (testCompilerHasProfiledLibraries env)
 
 -- | Check if the GHC that is used for compiling package tests has
 -- a shared library of the cabal library under test in its database.


### PR DESCRIPTION
What it says on the tin. No need to run this every time if the compiler stays fixed.

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

  