### PR TITLE
project.cabal -> cabal.project

### DIFF
--- a/Cabal/doc/cabaldomain.py
+++ b/Cabal/doc/cabaldomain.py
@@ -54,7 +54,7 @@ Added directives
 
 .. rst:directive:: .. cabal:cfg-field::
 
-   Describes a project.cabal field.
+   Describes a cabal.project field.
 
    Can have multiple arguments, if arguments start with '-' then it is treated
    as a cabal flag.
@@ -522,7 +522,7 @@ class CabalFieldXRef(XRefRole):
 
 class CabalPackageFieldXRef(CabalFieldXRef):
     '''
-    Role referencing project.cabal section
+    Role referencing cabal.project section
     '''
     section_key = 'cabal:pkg-section'
 
@@ -530,7 +530,7 @@ class CabalConfigSection(CabalSection):
     """
     Marks section in package.cabal file
     """
-    indextemplate = '%s; project.cabal section'
+    indextemplate = '%s; cabal.project section'
     section_key = 'cabal:cfg-section'
     target_prefix = 'cfg-section-'
 
@@ -638,7 +638,7 @@ class ConfigFieldIndex(Index):
         '''
 
         # (title, section store, fields store)
-        entries = [('project.cabal fields', 'cfg-section', 'cfg-field'),
+        entries = [('cabal.project fields', 'cfg-section', 'cfg-field'),
                    ('cabal project flags', 'cfg-section', 'cfg-flag'),
                    ('package.cabal fields', 'pkg-section', 'pkg-field')]
 
@@ -742,11 +742,11 @@ def make_title(typ, key, meta):
         return base + render_meta_title(meta)
 
     elif typ == 'cfg-section':
-        return "project.cabal " + key + " section " + render_meta_title(meta)
+        return "cabal.project " + key + " section " + render_meta_title(meta)
 
     elif typ == 'cfg-field':
         section, name = key
-        return "project.cabal " + name + " field " + render_meta_title(meta)
+        return "cabal.project " + name + " field " + render_meta_title(meta)
 
     elif typ == 'cfg-flag':
         section, name = key


### PR DESCRIPTION
At least it's not just me who is confused by the naming scheme.  `project.cabal` seems much more logical to me as it's a `cabal` file. However, cabal expects the file to be called `cabal.project`, so let's make the documentation less confusing.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
