### PR TITLE
append option for user-config command

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2403,14 +2403,16 @@ instance Semigroup ExecFlags where
 -- ------------------------------------------------------------
 
 data UserConfigFlags = UserConfigFlags {
-  userConfigVerbosity :: Flag Verbosity,
-  userConfigForce     :: Flag Bool
-} deriving Generic
+  userConfigVerbosity   :: Flag Verbosity,
+  userConfigForce       :: Flag Bool,
+  userConfigAppendLines :: Flag [String]
+  } deriving Generic
 
 instance Monoid UserConfigFlags where
   mempty = UserConfigFlags {
-    userConfigVerbosity = toFlag normal,
-    userConfigForce     = toFlag False
+    userConfigVerbosity   = toFlag normal,
+    userConfigForce       = toFlag False,
+    userConfigAppendLines = toFlag []
     }
   mappend = (<>)
 
@@ -2446,6 +2448,12 @@ userConfigCommand = CommandUI {
      "Overwrite the config file if it already exists."
      userConfigForce (\v flags -> flags { userConfigForce = v })
      trueArg
+ , option ['a'] ["append"]
+     "Additional line to append to the config file."
+     userConfigAppendLines (\v flags -> flags
+                               {userConfigAppendLines =
+                                   Flag $ concat (flagToList (userConfigAppendLines flags) ++ flagToList v)})
+     (reqArg' "CONFIGLINE" (Flag . (:[])) (fromMaybe [] . flagToMaybe))
    ]
   }
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2448,8 +2448,8 @@ userConfigCommand = CommandUI {
      "Overwrite the config file if it already exists."
      userConfigForce (\v flags -> flags { userConfigForce = v })
      trueArg
- , option ['a'] ["append"]
-     "Additional line to append to the config file."
+ , option ['a'] ["augment"]
+     "Additional setting to augment the config file (replacing a previous setting if it existed)."
      userConfigAppendLines (\v flags -> flags
                                {userConfigAppendLines =
                                    Flag $ concat (flagToList (userConfigAppendLines flags) ++ flagToList v)})

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -29,7 +29,7 @@
 	* 'cabal configure' now supports '--enable-static', which can be
 	used to build static libaries with GHC via GHC's `-staticlib`
 	flag.
-	* 'cabal user-config now supports '--append' which can append
+	* 'cabal user-config now supports '--augment' which can append
 	additional lines to a new or updated cabal config file.
 	* Added support for '--enable-tests' and '--enable-benchmarks' to
 	'cabal fetch' (#4948).

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -29,6 +29,8 @@
 	* 'cabal configure' now supports '--enable-static', which can be
 	used to build static libaries with GHC via GHC's `-staticlib`
 	flag.
+	* 'cabal user-config now supports '--append' which can append
+	additional lines to a new or updated cabal config file.
 	* Added support for '--enable-tests' and '--enable-benchmarks' to
 	'cabal fetch' (#4948).
 	* Misspelled package-names on CLI will no longer be silently

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -1179,17 +1179,18 @@ execAction execFlags extraArgs globalFlags = do
 
 userConfigAction :: UserConfigFlags -> [String] -> Action
 userConfigAction ucflags extraArgs globalFlags = do
-  let verbosity = fromFlag (userConfigVerbosity ucflags)
-      force     = fromFlag (userConfigForce ucflags)
+  let verbosity  = fromFlag (userConfigVerbosity ucflags)
+      force      = fromFlag (userConfigForce ucflags)
+      extraLines = fromFlag (userConfigAppendLines ucflags)
   case extraArgs of
     ("init":_) -> do
       path       <- configFile
       fileExists <- doesFileExist path
       if (not fileExists || (fileExists && force))
-      then void $ createDefaultConfigFile verbosity path
+      then void $ createDefaultConfigFile verbosity extraLines path
       else die' verbosity $ path ++ " already exists."
-    ("diff":_) -> mapM_ putStrLn =<< userConfigDiff globalFlags
-    ("update":_) -> userConfigUpdate verbosity globalFlags
+    ("diff":_) -> mapM_ putStrLn =<< userConfigDiff verbosity globalFlags extraLines
+    ("update":_) -> userConfigUpdate verbosity globalFlags extraLines
     -- Error handling.
     [] -> die' verbosity $ "Please specify a subcommand (see 'help user-config')"
     _  -> die' verbosity $ "Unknown 'user-config' subcommand: " ++ unwords extraArgs

--- a/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
@@ -37,7 +37,7 @@ nullDiffOnCreateTest = bracketTest $ \configFile -> do
     -- Create a new default config file in our test directory.
     _ <- loadConfig silent (Flag configFile)
     -- Now we read it in and compare it against the default.
-    diff <- userConfigDiff $ globalFlags configFile
+    diff <- userConfigDiff silent (globalFlags configFile) []
     assertBool (unlines $ "Following diff should be empty:" : diff) $ null diff
 
 
@@ -46,7 +46,7 @@ canDetectDifference = bracketTest $ \configFile -> do
     -- Create a new default config file in our test directory.
     _ <- loadConfig silent (Flag configFile)
     appendFile configFile "verbose: 0\n"
-    diff <- userConfigDiff $ globalFlags configFile
+    diff <- userConfigDiff silent (globalFlags configFile) []
     assertBool (unlines $ "Should detect a difference:" : diff) $
         diff == [ "+ verbose: 0" ]
 
@@ -56,7 +56,7 @@ canUpdateConfig = bracketTest $ \configFile -> do
     -- Write a trivial cabal file.
     writeFile configFile "tests: True\n"
     -- Update the config file.
-    userConfigUpdate silent $ globalFlags configFile
+    userConfigUpdate silent (globalFlags configFile) []
     -- Load it again.
     updated <- loadConfig silent (Flag configFile)
     assertBool ("Field 'tests' should be True") $
@@ -68,7 +68,7 @@ doubleUpdateConfig = bracketTest $ \configFile -> do
     -- Create a new default config file in our test directory.
     _ <- loadConfig silent (Flag configFile)
     -- Update it twice.
-    replicateM_ 2 . userConfigUpdate silent $ globalFlags configFile
+    replicateM_ 2 $ userConfigUpdate silent (globalFlags configFile) []
     -- Load it again.
     updated <- loadConfig silent (Flag configFile)
 
@@ -85,7 +85,7 @@ newDefaultConfig = do
     sysTmpDir <- getTemporaryDirectory
     withTempDirectory silent sysTmpDir "cabal-test" $ \tmpDir -> do
         let configFile  = tmpDir </> "tmp.config"
-        _ <- createDefaultConfigFile silent configFile
+        _ <- createDefaultConfigFile silent [] configFile
         exists <- doesFileExist configFile
         assertBool ("Config file should be written to " ++ configFile) exists
 


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions (https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.

Should resolve https://github.com/haskell/cabal/issues/4901

This adds an additional option for `user-config`, as `--append=` or `-a`. This can be used multiple times, each time adding a new line to the delta on `user-config` files for `init` `update` or `diff`. This lets tools like the platform installer pass in, e.g. msys directories for `extra-prog-path` and `extra-lib-dirs` etc.

Tested on some example files, and new-test passes.