### PR TITLE
Put command line --with-PROG into AllPackages

### DIFF
--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -166,10 +166,23 @@ commandLineFlagsToProjectConfig globalFlags configFlags configExFlags
       projectConfigShared        = convertLegacyAllPackageFlags
                                      globalFlags configFlags
                                      configExFlags installFlags,
-      projectConfigLocalPackages = convertLegacyPerPackageFlags
-                                     configFlags installFlags haddockFlags
+      projectConfigLocalPackages = localConfig,
+      projectConfigAllPackages   = allConfig
     }
-
+  where (localConfig, allConfig) = splitConfig
+                                 (convertLegacyPerPackageFlags
+                                    configFlags installFlags haddockFlags)
+        -- split the package config (from command line arguments) into
+        -- those applied to all packages and those to local only.
+        --
+        -- for now we will just copy over the ProgramPaths/Args/Extra into
+        -- the AllPackages.  The LocalPackages do not inherit them from
+        -- AllPackages, and as such need to retain them.
+        splitConfig :: PackageConfig -> (PackageConfig, PackageConfig)
+        splitConfig pc = (pc
+                         , mempty { packageConfigProgramPaths = packageConfigProgramPaths pc
+                                  , packageConfigProgramArgs  = packageConfigProgramArgs  pc
+                                  , packageConfigProgramPathExtra = packageConfigProgramPathExtra pc })
 
 -- | Convert from the types currently used for the user-wide @~/.cabal/config@
 -- file into the 'ProjectConfig' type.

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -178,6 +178,17 @@ commandLineFlagsToProjectConfig globalFlags configFlags configExFlags
         -- for now we will just copy over the ProgramPaths/Args/Extra into
         -- the AllPackages.  The LocalPackages do not inherit them from
         -- AllPackages, and as such need to retain them.
+        --
+        -- The general decision rule for what to put into allConfig
+        -- into localConfig is the following:
+        --
+        -- - anything that is host/toolchain/env specific should be applied
+        --   to all packages, as packagesets have to be host/toolchain/env
+        --   consistent.
+        -- - anything else should be in the local config and could potentially
+        --   be lifted into all-packages vial the `package *` cabal.project
+        --   section.
+        --
         splitConfig :: PackageConfig -> (PackageConfig, PackageConfig)
         splitConfig pc = (pc
                          , mempty { packageConfigProgramPaths = packageConfigProgramPaths pc

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,8 @@
 -*-change-log-*-
 
 2.2.0.0 (current development version)
+        * '--with-PROG' and '--PROG-options' are applied to all packages
+	and not local packages only (#5019).
 	* Completed the 'new-update' command (#4809), which respects nix-style
 	cabal.project(.local) files and allows to update from
 	multiple repositories when using overlays.


### PR DESCRIPTION
This should help with #4939. `--with-PROG` flags should be applied to every
package.  If we change hsc2hs via `--with-hsc2hs=` or any other program and
similarly `--hsc2hs-options` should also be provided to that program.  Same
holds for `--PROG-options`.  Because we do no inherit the properties from
AllPackages for LocalPackages, we need to have the set of programs and options
in both.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
