### PR TITLE
Fix bogus prop_foldVersionRange': strip parens

### DIFF
--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -355,14 +355,16 @@ prop_foldVersionRange range =
 
 prop_foldVersionRange' :: VersionRange -> Property
 prop_foldVersionRange' range =
-     normaliseVersionRange (stripParensVersionRange range)
+     normaliseVersionRange srange
   === foldVersionRange' anyVersion thisVersion
                        laterVersion earlierVersion
                        orLaterVersion orEarlierVersion
                        (\v _ -> withinVersion v)
                        (\v _ -> majorBoundVersion v)
                        unionVersionRanges intersectVersionRanges id
-                       range
+                       srange
+  where
+    srange = stripParensVersionRange range
 
 prop_isAnyVersion1 :: VersionRange -> Version -> Property
 prop_isAnyVersion1 range version =


### PR DESCRIPTION
Fixes #4957 

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
