### PR TITLE
Issue 4899 forward compat scheme

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -42,6 +42,8 @@ extra-source-files:
   tests/ParserTests/errors/forward-compat.errors
   tests/ParserTests/errors/forward-compat2.cabal
   tests/ParserTests/errors/forward-compat2.errors
+  tests/ParserTests/errors/forward-compat3.cabal
+  tests/ParserTests/errors/forward-compat3.errors
   tests/ParserTests/errors/leading-comma.cabal
   tests/ParserTests/errors/leading-comma.errors
   tests/ParserTests/errors/range-ge-wild.cabal

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -38,6 +38,10 @@ extra-source-files:
   tests/ParserTests/errors/common2.errors
   tests/ParserTests/errors/common3.cabal
   tests/ParserTests/errors/common3.errors
+  tests/ParserTests/errors/forward-compat.cabal
+  tests/ParserTests/errors/forward-compat.errors
+  tests/ParserTests/errors/forward-compat2.cabal
+  tests/ParserTests/errors/forward-compat2.errors
   tests/ParserTests/errors/leading-comma.cabal
   tests/ParserTests/errors/leading-comma.errors
   tests/ParserTests/errors/range-ge-wild.cabal

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -228,9 +228,9 @@ parseInstalledPackageInfo s = case P.readFields (toUTF8BS s) of
     Left err -> ParseFailed (NoParse (show err) $ Parsec.sourceLine $ Parsec.errorPos err)
     Right fs -> case partitionFields fs of
         (fs', _) -> case P.runParseResult $ parseFieldGrammar cabalSpecLatest fs' ipiFieldGrammar of
-            (ws, errs,    Just x) | null errs -> ParseOk ws' x where
+            (ws, Right x)        -> ParseOk ws' x where
                 ws' = map (PWarning . P.showPWarning "") ws
-            (_,  errs, _)                     -> ParseFailed (NoParse errs' 0) where
+            (_,  Left (_, errs)) -> ParseFailed (NoParse errs' 0) where
                 errs' = intercalate "; " $ map (\(P.PError _ msg) -> msg) errs
 
 -- -----------------------------------------------------------------------------

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -1097,6 +1097,13 @@ checkCabalVersion pkg =
         ++ "range syntax rather than a simple version number. Use "
         ++ "'cabal-version: >= " ++ display (specVersion pkg) ++ "'."
 
+  , check (specVersion pkg >= mkVersion [1,12]
+           && not simpleSpecVersionSyntax) $
+      (if specVersion pkg >= mkVersion [2,0] then PackageDistSuspicious else PackageDistSuspiciousWarn) $
+           "Packages relying on Cabal 1.12 or later should specify a "
+        ++ "version range of the form 'cabal-version: x.y'. Use "
+        ++ "'cabal-version: " ++ display (specVersion pkg) ++ "'."
+
     -- check use of test suite sections
   , checkVersion [1,8] (not (null $ testSuites pkg)) $
       PackageDistInexcusable $

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -68,7 +68,8 @@ packageDescriptionFieldGrammar
     :: (FieldGrammar g, Applicative (g PackageDescription), Applicative (g PackageIdentifier))
     => g PackageDescription PackageDescription
 packageDescriptionFieldGrammar = PackageDescription
-    <$> blurFieldGrammar L.package packageIdentifierGrammar
+    <$> optionalFieldDefAla "cabal-version" SpecVersion                L.specVersionRaw (Right anyVersion)
+    <*> blurFieldGrammar L.package packageIdentifierGrammar
     <*> optionalFieldDef    "license"                                  L.license UnspecifiedLicense
     <*> licenseFilesGrammar
     <*> optionalFieldDefAla "copyright"     FreeText                   L.copyright ""
@@ -85,7 +86,6 @@ packageDescriptionFieldGrammar = PackageDescription
     <*> optionalFieldDefAla "category"      FreeText                   L.category ""
     <*> prefixedFields      "x-"                                       L.customFieldsPD
     <*> pure [] -- build-depends
-    <*> optionalFieldDefAla "cabal-version" SpecVersion                L.specVersionRaw (Right anyVersion)
     <*> optionalField       "build-type"                               L.buildTypeRaw
     <*> pure Nothing -- custom-setup
     -- components

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -117,7 +117,14 @@ readGenericPackageDescription = readAndParseFile parseGenericPackageDescription
 --
 parseGenericPackageDescription :: BS.ByteString -> ParseResult GenericPackageDescription
 parseGenericPackageDescription bs = do
+    -- set scanned version
     setCabalSpecVersion ver
+    -- if we get too new version, fail right away
+    case ver of
+        Just v | v > mkVersion [2,2] -> parseFailure zeroPos
+            "Unsupported cabal-version. See https://github.com/haskell/cabal/issues/4899."
+        _ -> pure ()
+
     case readFields' bs' of
         Right (fs, lexWarnings) -> do
             when patched $

--- a/Cabal/Distribution/Parsec/ParseResult.hs
+++ b/Cabal/Distribution/Parsec/ParseResult.hs
@@ -16,6 +16,7 @@ module Distribution.Parsec.ParseResult (
 import Distribution.Compat.Prelude
 import Distribution.Parsec.Common
        (PError (..), PWarnType (..), PWarning (..), Position (..), zeroPos)
+import Distribution.Version        (Version)
 import Prelude ()
 
 #if MIN_VERSION_base(4,10,0)
@@ -26,25 +27,26 @@ import Control.Applicative (Applicative (..))
 newtype ParseResult a = PR
     { unPR
         :: forall r. PRState
-        -> (PRState -> r)       -- failure
-        -> (PRState -> a -> r)  -- success
+        -> (PRState -> r) -- failure, but we were able to recover a new-style spec-version declaration
+        -> (PRState -> a -> r)             -- success
         -> r
     }
 
-data PRState = PRState ![PWarning] ![PError]
+data PRState = PRState ![PWarning] ![PError] !(Maybe Version)
 
 emptyPRState :: PRState
-emptyPRState = PRState [] []
+emptyPRState = PRState [] [] Nothing
 
--- | Destruct a 'ParseResult' into the emitted warnings and errors, and
--- possibly the final result if there were no errors.
-runParseResult :: ParseResult a -> ([PWarning], [PError], Maybe a)
+-- | Destruct a 'ParseResult' into the emitted warnings and either
+-- a successful value or
+-- list of errors and possibly recovered a spec-version declaration.
+runParseResult :: ParseResult a -> ([PWarning], Either (Maybe Version, [PError]) a)
 runParseResult pr = unPR pr emptyPRState failure success
   where
-    failure (PRState warns errs)   = (warns, errs, Nothing)
-    success (PRState warns [])   x = (warns, [], Just x)
+    failure (PRState warns errs v)   = (warns, Left (v, errs))
+    success (PRState warns [] _)   x = (warns, Right x)
     -- If there are any errors, don't return the result
-    success (PRState warns errs) _ = (warns, errs, Nothing)
+    success (PRState warns errs v) _ = (warns, Left (v, errs))
 
 instance Functor ParseResult where
     fmap f (PR pr) = PR $ \ !s failure success ->
@@ -98,31 +100,31 @@ recoverWith (PR pr) x = PR $ \ !s _failure success ->
 
 -- | Add a warning. This doesn't fail the parsing process.
 parseWarning :: Position -> PWarnType -> String -> ParseResult ()
-parseWarning pos t msg = PR $ \(PRState warns errs) _failure success ->
-    success (PRState (PWarning t pos msg : warns) errs) ()
+parseWarning pos t msg = PR $ \(PRState warns errs v) _failure success ->
+    success (PRState (PWarning t pos msg : warns) errs v) ()
 
 -- | Add multiple warnings at once.
 parseWarnings :: [PWarning] -> ParseResult ()
-parseWarnings newWarns = PR $ \(PRState warns errs) _failure success ->
-    success (PRState (newWarns ++ warns) errs) ()
+parseWarnings newWarns = PR $ \(PRState warns errs v) _failure success ->
+    success (PRState (newWarns ++ warns) errs v) ()
 
 -- | Add an error, but not fail the parser yet.
 --
 -- For fatal failure use 'parseFatalFailure'
 parseFailure :: Position -> String -> ParseResult ()
-parseFailure pos msg = PR $ \(PRState warns errs) _failure success ->
-    success (PRState warns (PError pos msg : errs)) ()
+parseFailure pos msg = PR $ \(PRState warns errs v) _failure success ->
+    success (PRState warns (PError pos msg : errs) v) ()
 
 -- | Add an fatal error.
 parseFatalFailure :: Position -> String -> ParseResult a
-parseFatalFailure pos msg = PR $ \(PRState warns errs) failure _success ->
-    failure (PRState warns (PError pos msg : errs))
+parseFatalFailure pos msg = PR $ \(PRState warns errs v) failure _success ->
+    failure (PRState warns (PError pos msg : errs) v)
 
 -- | A 'mzero'.
 parseFatalFailure' :: ParseResult a
 parseFatalFailure' = PR pr
   where
-    pr (PRState warns []) failure _success = failure (PRState warns [err])
-    pr s                  failure _success = failure s
+    pr (PRState warns [] v) failure _success = failure (PRState warns [err] v)
+    pr s                    failure _success = failure s
 
     err = PError zeroPos "Unknown fatal error"

--- a/Cabal/Distribution/Parsec/ParseResult.hs
+++ b/Cabal/Distribution/Parsec/ParseResult.hs
@@ -11,6 +11,8 @@ module Distribution.Parsec.ParseResult (
     parseFailure,
     parseFatalFailure,
     parseFatalFailure',
+    getCabalSpecVersion,
+    setCabalSpecVersion,
     ) where
 
 import Distribution.Compat.Prelude
@@ -97,6 +99,16 @@ instance Monad ParseResult where
 recoverWith :: ParseResult a -> a -> ParseResult a
 recoverWith (PR pr) x = PR $ \ !s _failure success ->
     pr s (\ !s' -> success s' x) success
+
+-- | Set cabal spec version.
+setCabalSpecVersion :: Maybe Version -> ParseResult ()
+setCabalSpecVersion v = PR $ \(PRState warns errs _) _failure success ->
+    success (PRState warns errs v) ()
+
+-- | Get cabal spec version.
+getCabalSpecVersion :: ParseResult (Maybe Version)
+getCabalSpecVersion = PR $ \s@(PRState _ _ v) _failure success ->
+    success s v
 
 -- | Add a warning. This doesn't fail the parsing process.
 parseWarning :: Position -> PWarnType -> String -> ParseResult ()

--- a/Cabal/Distribution/Types/PackageDescription.hs
+++ b/Cabal/Distribution/Types/PackageDescription.hs
@@ -94,6 +94,13 @@ import Distribution.Compiler
 data PackageDescription
     =  PackageDescription {
         -- the following are required by all packages:
+
+        -- | The version of the Cabal spec that this package description uses.
+        -- For historical reasons this is specified with a version range but
+        -- only ranges of the form @>= v@ make sense. We are in the process of
+        -- transitioning to specifying just a single version, not a range.
+        -- See also 'specVersion'.
+        specVersionRaw :: Either Version VersionRange,
         package        :: PackageIdentifier,
         license        :: License,
         licenseFiles   :: [FilePath],
@@ -125,11 +132,6 @@ data PackageDescription
         -- 'BuildInfo' and this field.  This is all horrible, and #2066
         -- tracks progress to get rid of this field.
         buildDepends   :: [Dependency],
-        -- | The version of the Cabal spec that this package description uses.
-        -- For historical reasons this is specified with a version range but
-        -- only ranges of the form @>= v@ make sense. We are in the process of
-        -- transitioning to specifying just a single version, not a range.
-        specVersionRaw :: Either Version VersionRange,
         -- | The original @build-type@ value as parsed from the
         -- @.cabal@ file without defaulting. See also 'buildType'.
         --

--- a/Cabal/tests/CheckTests.hs
+++ b/Cabal/tests/CheckTests.hs
@@ -32,13 +32,11 @@ checkTest :: FilePath -> TestTree
 checkTest fp = cabalGoldenTest fp correct $ do
     contents <- BS.readFile input
     let res =  parseGenericPackageDescription contents
-    let (_, errs, x) = runParseResult res
+    let (_, x) = runParseResult res
 
     return $ toUTF8BS $ case x of
-        Just gpd | null errs ->
-            unlines $ map show (checkPackage gpd Nothing)
-        _ ->
-            unlines $ "ERROR" : map show errs
+        Right gpd      -> unlines $ map show (checkPackage gpd Nothing)
+        Left (_, errs) -> unlines $ "ERROR" : map show errs
   where
     input = "tests" </> "ParserTests" </> "regressions" </> fp
     correct = replaceExtension input "check"

--- a/Cabal/tests/CheckTests.hs
+++ b/Cabal/tests/CheckTests.hs
@@ -26,6 +26,7 @@ checkTests :: TestTree
 checkTests = testGroup "regressions"
     [ checkTest "nothing-unicode.cabal"
     , checkTest "haddock-api-2.18.1-check.cabal"
+    , checkTest "issue-774.cabal"
     ]
 
 checkTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -101,6 +101,7 @@ errorTests = testGroup "errors"
     , errorTest "range-ge-wild.cabal"
     , errorTest "forward-compat.cabal"
     , errorTest "forward-compat2.cabal"
+    , errorTest "forward-compat3.cabal"
     ]
 
 errorTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -100,6 +100,7 @@ errorTests = testGroup "errors"
     , errorTest "leading-comma.cabal"
     , errorTest "range-ge-wild.cabal"
     , errorTest "forward-compat.cabal"
+    , errorTest "forward-compat2.cabal"
     ]
 
 errorTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -99,6 +99,7 @@ errorTests = testGroup "errors"
     , errorTest "common3.cabal"
     , errorTest "leading-comma.cabal"
     , errorTest "range-ge-wild.cabal"
+    , errorTest "forward-compat.cabal"
     ]
 
 errorTest :: FilePath -> TestTree
@@ -111,8 +112,8 @@ errorTest fp = cabalGoldenTest fp correct $ do
         Right gpd -> 
             "UNXPECTED SUCCESS\n" ++
             showGenericPackageDescription gpd
-        Left (_, errs) ->
-            unlines $ map show errs
+        Left (v, errs) ->
+            unlines $ ("VERSION: " ++ show v) : map show errs
   where
     input = "tests" </> "ParserTests" </> "errors" </> fp
     correct = replaceExtension input "errors"

--- a/Cabal/tests/ParserTests/errors/common1.cabal
+++ b/Cabal/tests/ParserTests/errors/common1.cabal
@@ -1,8 +1,8 @@
+cabal-version:       2.1
 name:                common
 version:             0
 synopsis:            Common-stanza demo demo
 build-type:          Simple
-cabal-version:       >=2.1
 
 source-repository head
   Type:     git

--- a/Cabal/tests/ParserTests/errors/common1.errors
+++ b/Cabal/tests/ParserTests/errors/common1.errors
@@ -1,1 +1,2 @@
+VERSION: Just (mkVersion [2,1])
 PError (Position 17 3) "Undefined common stanza imported: windo"

--- a/Cabal/tests/ParserTests/errors/common2.cabal
+++ b/Cabal/tests/ParserTests/errors/common2.cabal
@@ -1,8 +1,8 @@
+cabal-version:       2.1
 name:                common
 version:             0
 synopsis:            Common-stanza demo demo
 build-type:          Simple
-cabal-version:       >=2.1
 
 source-repository head
   Type:     git

--- a/Cabal/tests/ParserTests/errors/common2.errors
+++ b/Cabal/tests/ParserTests/errors/common2.errors
@@ -1,1 +1,2 @@
+VERSION: Just (mkVersion [2,1])
 PError (Position 13 3) "Undefined common stanza imported: windows"

--- a/Cabal/tests/ParserTests/errors/common3.errors
+++ b/Cabal/tests/ParserTests/errors/common3.errors
@@ -1,1 +1,2 @@
+VERSION: Just (mkVersion [2,1])
 PError (Position 22 1) "Duplicate common stanza: deps"

--- a/Cabal/tests/ParserTests/errors/forward-compat.cabal
+++ b/Cabal/tests/ParserTests/errors/forward-compat.cabal
@@ -1,0 +1,4 @@
+cabal-version: 99999.9
+name: future
+============
+Lexically completely changed future

--- a/Cabal/tests/ParserTests/errors/forward-compat.errors
+++ b/Cabal/tests/ParserTests/errors/forward-compat.errors
@@ -1,0 +1,2 @@
+VERSION: Just (mkVersion [99999,9])
+PError (Position 0 0) "\"the input\" (line 3, column 1):\nunexpected operator \"============\"\nexpecting field or section name"

--- a/Cabal/tests/ParserTests/errors/forward-compat.errors
+++ b/Cabal/tests/ParserTests/errors/forward-compat.errors
@@ -1,2 +1,3 @@
 VERSION: Just (mkVersion [99999,9])
 PError (Position 0 0) "\"the input\" (line 3, column 1):\nunexpected operator \"============\"\nexpecting field or section name"
+PError (Position 0 0) "Unsupported cabal-version. See https://github.com/haskell/cabal/issues/4899."

--- a/Cabal/tests/ParserTests/errors/forward-compat2.cabal
+++ b/Cabal/tests/ParserTests/errors/forward-compat2.cabal
@@ -1,29 +1,14 @@
-cabal-version:       2.1
 name:                common
 version:             0
 synopsis:            Common-stanza demo demo
 build-type:          Simple
+cabal-version:       2.1
 
 source-repository head
   Type:     git
   Location: https://github.com/hvr/-.git
 
-common windows
-  if os(windows)
-    build-depends: Win32
-
-common deps
-  import: windows
-  build-depends:
-    base >=4.10 && <4.11,
-    containers
-
--- Duplicate
-common deps
-
 library
-  import: deps
-
   default-language: Haskell2010
   exposed-modules:  ElseIf
 

--- a/Cabal/tests/ParserTests/errors/forward-compat2.errors
+++ b/Cabal/tests/ParserTests/errors/forward-compat2.errors
@@ -1,0 +1,2 @@
+VERSION: Just (mkVersion [2,1])
+PError (Position 5 1) "cabal-version should be at the beginning of the file starting with spec version 2.2. See https://github.com/haskell/cabal/issues/4899"

--- a/Cabal/tests/ParserTests/errors/forward-compat3.cabal
+++ b/Cabal/tests/ParserTests/errors/forward-compat3.cabal
@@ -1,0 +1,16 @@
+cabal-version:       99999.99
+name:                forward-compat
+version:             0
+synopsis:            Forward compat, too new cabal-version: we fail.
+build-type:          Simple
+
+source-repository head
+  Type:     git
+  Location: https://github.com/hvr/-.git
+
+library
+  default-language: Haskell2010
+  exposed-modules:  ElseIf
+
+  build-depends:
+    ghc-prim

--- a/Cabal/tests/ParserTests/errors/forward-compat3.errors
+++ b/Cabal/tests/ParserTests/errors/forward-compat3.errors
@@ -1,0 +1,2 @@
+VERSION: Just (mkVersion [99999,99])
+PError (Position 0 0) "Unsupported cabal-version. See https://github.com/haskell/cabal/issues/4899."

--- a/Cabal/tests/ParserTests/errors/leading-comma.errors
+++ b/Cabal/tests/ParserTests/errors/leading-comma.errors
@@ -1,1 +1,2 @@
+VERSION: Just (mkVersion [2,0])
 PError (Position 16 18) "\nunexpected end of input\nexpecting white space: \"deepseq,\\ntransformers,\""

--- a/Cabal/tests/ParserTests/errors/range-ge-wild.errors
+++ b/Cabal/tests/ParserTests/errors/range-ge-wild.errors
@@ -1,1 +1,2 @@
+VERSION: Just (mkVersion [1,10])
 PError (Position 8 29) "\nunexpected wild-card version after non-== operator: \">=\": \"base >= 4.*\""

--- a/Cabal/tests/ParserTests/regressions/Octree-0.5.format
+++ b/Cabal/tests/ParserTests/regressions/Octree-0.5.format
@@ -1,6 +1,7 @@
 PWarning PWTLexNBSP (Position 43 3) "Non-breaking space found"
 PWarning PWTLexNBSP (Position 41 3) "Non-breaking space found"
 PWarning PWTLexNBSP (Position 39 3) "Non-breaking space found"
+cabal-version: >=1.8
 name: Octree
 version: 0.5
 license: BSD3
@@ -17,7 +18,6 @@ synopsis: Simple unbalanced Octree for storing data about 3D points
 description:
     Octree data structure is relatively shallow data structure for space partitioning.
 category: Data
-cabal-version: >=1.8
 build-type: Simple
 
 source-repository head

--- a/Cabal/tests/ParserTests/regressions/common.format
+++ b/Cabal/tests/ParserTests/regressions/common.format
@@ -1,10 +1,10 @@
 PWarning PWTUnknownField (Position 26 3) "Unknown field: import. You should set cabal-version: 2.2 or larger to use common stanzas"
 PWarning PWTUnknownField (Position 17 3) "Unknown field: import. You should set cabal-version: 2.2 or larger to use common stanzas"
 PWarning PWTUnknownSection (Position 11 1) "Ignoring section: common. You should set cabal-version: 2.2 or larger to use common stanzas."
+cabal-version: >=1.10
 name: common
 version: 0
 synopsis: Common-stanza demo demo
-cabal-version: >=1.10
 build-type: Simple
 
 source-repository head

--- a/Cabal/tests/ParserTests/regressions/common2.cabal
+++ b/Cabal/tests/ParserTests/regressions/common2.cabal
@@ -1,8 +1,8 @@
+cabal-version:       2.1
 name:                common
 version:             0
 synopsis:            Common-stanza demo demo
 build-type:          Simple
-cabal-version:       >=2.1
 
 source-repository head
   Type:     git

--- a/Cabal/tests/ParserTests/regressions/common2.expr
+++ b/Cabal/tests/ParserTests/regressions/common2.expr
@@ -404,7 +404,7 @@ GenericPackageDescription
                                              repoSubdir = Nothing,
                                              repoTag = Nothing,
                                              repoType = Just Git}],
-                           specVersionRaw = Right (OrLaterVersion `mkVersion [2,1]`),
+                           specVersionRaw = Left `mkVersion [2,1]`,
                            stability = "",
                            subLibraries = [],
                            synopsis = "Common-stanza demo demo",

--- a/Cabal/tests/ParserTests/regressions/common2.format
+++ b/Cabal/tests/ParserTests/regressions/common2.format
@@ -1,7 +1,7 @@
+cabal-version: 2.1
 name: common
 version: 0
 synopsis: Common-stanza demo demo
-cabal-version: >=2.1
 build-type: Simple
 
 source-repository head

--- a/Cabal/tests/ParserTests/regressions/elif.format
+++ b/Cabal/tests/ParserTests/regressions/elif.format
@@ -1,9 +1,9 @@
 PWarning PWTInvalidSubsection (Position 19 3) "invalid subsection \"else\""
 PWarning PWTInvalidSubsection (Position 17 3) "invalid subsection \"elif\". You should set cabal-version: 2.2 or larger to use elif-conditionals."
+cabal-version: >=1.10
 name: elif
 version: 0
 synopsis: The elif demo
-cabal-version: >=1.10
 build-type: Simple
 
 source-repository head

--- a/Cabal/tests/ParserTests/regressions/elif2.cabal
+++ b/Cabal/tests/ParserTests/regressions/elif2.cabal
@@ -1,8 +1,8 @@
+cabal-version:       2.1
 name:                elif
 version:             0
 synopsis:            The elif demo
 build-type:          Simple
-cabal-version:       >=2.1
 
 source-repository head
   Type:     git

--- a/Cabal/tests/ParserTests/regressions/elif2.expr
+++ b/Cabal/tests/ParserTests/regressions/elif2.expr
@@ -308,7 +308,7 @@ GenericPackageDescription
                                              repoSubdir = Nothing,
                                              repoTag = Nothing,
                                              repoType = Just Git}],
-                           specVersionRaw = Right (OrLaterVersion `mkVersion [2,1]`),
+                           specVersionRaw = Left `mkVersion [2,1]`,
                            stability = "",
                            subLibraries = [],
                            synopsis = "The elif demo",

--- a/Cabal/tests/ParserTests/regressions/elif2.format
+++ b/Cabal/tests/ParserTests/regressions/elif2.format
@@ -1,7 +1,7 @@
+cabal-version: 2.1
 name: elif
 version: 0
 synopsis: The elif demo
-cabal-version: >=2.1
 build-type: Simple
 
 source-repository head

--- a/Cabal/tests/ParserTests/regressions/encoding-0.8.format
+++ b/Cabal/tests/ParserTests/regressions/encoding-0.8.format
@@ -1,7 +1,7 @@
 PWarning PWTMultipleSingularField (Position 1 1) "The field \"name\" is specified more than once at positions 1:1, 2:1"
+cabal-version: >=1.12
 name: encoding
 version: 0.8
-cabal-version: >=1.12
 extra-source-files:
     README.md
     "--"

--- a/Cabal/tests/ParserTests/regressions/generics-sop.format
+++ b/Cabal/tests/ParserTests/regressions/generics-sop.format
@@ -1,3 +1,4 @@
+cabal-version: >=1.10
 name: generics-sop
 version: 0.3.1.0
 license: BSD3
@@ -36,7 +37,6 @@ description:
     Workshop on Generic Programming (WGP) 2014.
     .
 category: Generics
-cabal-version: >=1.10
 build-type: Custom
 extra-source-files:
     CHANGELOG.md

--- a/Cabal/tests/ParserTests/regressions/issue-774.cabal
+++ b/Cabal/tests/ParserTests/regressions/issue-774.cabal
@@ -9,7 +9,8 @@ description: Here is some C code:
              .
              What does it look like?
 build-type:    Simple
-cabal-version: >=1.10
+-- we test that check warns about this
+cabal-version: >=1.12
 
 library
   default-language: Haskell2010

--- a/Cabal/tests/ParserTests/regressions/issue-774.check
+++ b/Cabal/tests/ParserTests/regressions/issue-774.check
@@ -1,0 +1,7 @@
+No 'category' field.
+No 'maintainer' field.
+The 'license' field is missing.
+'ghc-options: -threaded' has no effect for libraries. It should only be used for executables.
+'ghc-options: -rtsopts' has no effect for libraries. It should only be used for executables.
+'ghc-options: -with-rtsopts' has no effect for libraries. It should only be used for executables.
+Packages relying on Cabal 1.12 or later should specify a version range of the form 'cabal-version: x.y'. Use 'cabal-version: 1.12'.

--- a/Cabal/tests/ParserTests/regressions/issue-774.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-774.expr
@@ -97,7 +97,7 @@ GenericPackageDescription
                            pkgUrl = "",
                            setupBuildInfo = Nothing,
                            sourceRepos = [],
-                           specVersionRaw = Right (OrLaterVersion `mkVersion [1,10]`),
+                           specVersionRaw = Right (OrLaterVersion `mkVersion [1,12]`),
                            stability = "",
                            subLibraries = [],
                            synopsis = "Package description parser interprets curly braces in the description field",

--- a/Cabal/tests/ParserTests/regressions/issue-774.format
+++ b/Cabal/tests/ParserTests/regressions/issue-774.format
@@ -1,3 +1,4 @@
+cabal-version: >=1.12
 name: issue
 version: 744
 synopsis: Package description parser interprets curly braces in the description field
@@ -9,7 +10,6 @@ description:
     > }
     .
     What does it look like?
-cabal-version: >=1.10
 build-type: Simple
 
 library

--- a/Cabal/tests/ParserTests/regressions/leading-comma.cabal
+++ b/Cabal/tests/ParserTests/regressions/leading-comma.cabal
@@ -1,8 +1,8 @@
+cabal-version:       2.1
 name:                leading-comma
 version:             0
 synopsis:            leading comma, trailing comma, or ordinary
 build-type:          Simple
-cabal-version:       2.1
 
 library
   default-language: Haskell2010

--- a/Cabal/tests/ParserTests/regressions/leading-comma.format
+++ b/Cabal/tests/ParserTests/regressions/leading-comma.format
@@ -1,7 +1,7 @@
+cabal-version: 2.1
 name: leading-comma
 version: 0
 synopsis: leading comma, trailing comma, or ordinary
-cabal-version: 2.1
 build-type: Simple
 
 library

--- a/Cabal/tests/ParserTests/regressions/nothing-unicode.format
+++ b/Cabal/tests/ParserTests/regressions/nothing-unicode.format
@@ -1,8 +1,8 @@
+cabal-version: >=1.10
 name: 無
 version: 0
 synopsis: The canonical non-package 無
 x-無: 無
-cabal-version: >=1.10
 build-type: Simple
 
 source-repository head

--- a/Cabal/tests/ParserTests/regressions/shake.format
+++ b/Cabal/tests/ParserTests/regressions/shake.format
@@ -1,3 +1,4 @@
+cabal-version: >=1.18
 name: shake
 version: 0.15.11
 license: BSD3
@@ -31,7 +32,6 @@ description:
     support for generated files, and dependencies on system information
     (e.g. compiler version).
 category: Development, Shake
-cabal-version: >=1.18
 build-type: Simple
 data-files:
     html/viz.js

--- a/Cabal/tests/ParserTests/regressions/wl-pprint-indef.format
+++ b/Cabal/tests/ParserTests/regressions/wl-pprint-indef.format
@@ -1,6 +1,7 @@
 PWarning PWTUnknownField (Position 28 3) "The field \"mixins\" is available since Cabal [2,0]"
 PWarning PWTUnknownField (Position 27 3) "The field \"signatures\" is available since Cabal [2,0]"
 PWarning PWTUnknownField (Position 23 3) "The field \"mixins\" is available since Cabal [2,0]"
+cabal-version: >=1.6
 name: wl-pprint-indef
 version: 1.2
 license: BSD3
@@ -13,7 +14,6 @@ description:
     Printer".  See the haddocks for full info.  This version allows the
     library user to declare overlapping instances of the 'Pretty' class.
 category: Text
-cabal-version: >=1.6
 build-type: Simple
 
 source-repository head

--- a/cabal-install/Distribution/Client/Check.hs
+++ b/cabal-install/Distribution/Client/Check.hs
@@ -38,11 +38,12 @@ readGenericPackageDescriptionCheck verbosity fpath = do
       die' verbosity $
         "Error Parsing: file \"" ++ fpath ++ "\" doesn't exist. Cannot continue."
     bs <- BS.readFile fpath
-    let (warnings, errors, result) = runParseResult (parseGenericPackageDescription bs)
-    traverse_ (warn verbosity . showPError fpath) errors
+    let (warnings, result) = runParseResult (parseGenericPackageDescription bs)
     case result of
-        Nothing -> die' verbosity $ "Failed parsing \"" ++ fpath ++ "\"."
-        Just x  -> return (warnings, x)
+        Left (_, errors) -> do
+            traverse_ (warn verbosity . showPError fpath) errors
+            die' verbosity $ "Failed parsing \"" ++ fpath ++ "\"."
+        Right x  -> return (warnings, x)
 
 check :: Verbosity -> IO Bool
 check verbosity = do

--- a/cabal-testsuite/PackageTests/AutogenModules/Package/my.cabal
+++ b/cabal-testsuite/PackageTests/AutogenModules/Package/my.cabal
@@ -7,7 +7,7 @@ maintainer: Federico Mastellone
 synopsis: AutogenModules
 category: PackageTests
 build-type: Simple
-cabal-version: >= 1.25
+cabal-version: 1.25
 
 description:
     Check that Cabal recognizes the autogen-modules fields below.

--- a/cabal-testsuite/PackageTests/AutogenModules/SrcDist/AutogenModules.cabal
+++ b/cabal-testsuite/PackageTests/AutogenModules/SrcDist/AutogenModules.cabal
@@ -7,7 +7,7 @@ maintainer: Federico Mastellone
 synopsis: AutogenModules
 category: PackageTests
 build-type: Simple
-cabal-version: >= 1.24
+cabal-version: 1.24
 
 description:
     Check that Cabal recognizes the autogen-modules fields below.

--- a/cabal-testsuite/PackageTests/Backpack/Includes3/Includes3.cabal
+++ b/cabal-testsuite/PackageTests/Backpack/Includes3/Includes3.cabal
@@ -4,7 +4,7 @@ license:             BSD3
 author:              Edward Z. Yang
 maintainer:          ezyang@cs.stanford.edu
 build-type:          Simple
-cabal-version:       >=1.25
+cabal-version:       1.25
 
 library sigs
   build-depends:       base

--- a/cabal-testsuite/PackageTests/COnlyMain/my.cabal
+++ b/cabal-testsuite/PackageTests/COnlyMain/my.cabal
@@ -1,7 +1,7 @@
+cabal-version:  2.2
 name:           my
 version:        0.1
 license:        BSD3
-cabal-version:  >= 2.1
 build-type:     Simple
 
 executable foo

--- a/cabal-testsuite/PackageTests/COnlyMain/my.cabal
+++ b/cabal-testsuite/PackageTests/COnlyMain/my.cabal
@@ -1,4 +1,4 @@
-cabal-version:  2.2
+cabal-version:  2.1
 name:           my
 version:        0.1
 license:        BSD3


### PR DESCRIPTION
@hvr should cabal-version: 2.2 parser **fail** if scanned version is `Nothing`?
i.e. require that it's recognised by scanner?

/Note:/ thsi doesn't solve #4899 fully, as spec have to be clarified a bit: no tabs and `\n or \r` ending.

---

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
