### PR TITLE
Warn about leading tabs

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -85,6 +85,9 @@ extra-source-files:
   tests/ParserTests/regressions/shake.cabal
   tests/ParserTests/regressions/shake.expr
   tests/ParserTests/regressions/shake.format
+  tests/ParserTests/regressions/th-lift-instances.cabal
+  tests/ParserTests/regressions/th-lift-instances.expr
+  tests/ParserTests/regressions/th-lift-instances.format
   tests/ParserTests/regressions/wl-pprint-indef.cabal
   tests/ParserTests/regressions/wl-pprint-indef.expr
   tests/ParserTests/regressions/wl-pprint-indef.format
@@ -99,6 +102,7 @@ extra-source-files:
   tests/ParserTests/warnings/newsyntax.cabal
   tests/ParserTests/warnings/oldsyntax.cabal
   tests/ParserTests/warnings/subsection.cabal
+  tests/ParserTests/warnings/tab.cabal
   tests/ParserTests/warnings/trailingfield.cabal
   tests/ParserTests/warnings/unknownfield.cabal
   tests/ParserTests/warnings/unknownsection.cabal

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -47,7 +47,7 @@ import Distribution.Parsec.Class                    (parsec)
 import Distribution.Parsec.Common
 import Distribution.Parsec.ConfVar                  (parseConditionConfVar)
 import Distribution.Parsec.Field                    (FieldName, getName)
-import Distribution.Parsec.LexerMonad               (LexWarning, toPWarning)
+import Distribution.Parsec.LexerMonad               (LexWarning, toPWarnings)
 import Distribution.Parsec.Newtypes                 (CommaFSep, List, SpecVersion (..), Token)
 import Distribution.Parsec.Parser
 import Distribution.Parsec.ParseResult
@@ -156,7 +156,7 @@ parseGenericPackageDescription'
     -> [Field Position]
     -> ParseResult GenericPackageDescription
 parseGenericPackageDescription' lexWarnings fs = do
-    parseWarnings (fmap toPWarning lexWarnings)
+    parseWarnings (toPWarnings lexWarnings)
     let (syntax, fs') = sectionizeFields fs
     let (fields, sectionFields) = takeFields fs'
 
@@ -652,7 +652,7 @@ parseHookedBuildInfo'
     -> [Field Position]
     -> ParseResult HookedBuildInfo
 parseHookedBuildInfo' lexWarnings fs = do
-    parseWarnings (fmap toPWarning lexWarnings)
+    parseWarnings (toPWarnings lexWarnings)
     (mLibFields, exes) <- stanzas fs
     mLib <- parseLib mLibFields
     biExes <- traverse parseExe exes

--- a/Cabal/Distribution/Parsec/Common.hs
+++ b/Cabal/Distribution/Parsec/Common.hs
@@ -42,6 +42,7 @@ data PWarnType
     | PWTExtraBenchmarkModule  -- ^ extra benchmark-module field
     | PWTLexNBSP
     | PWTLexBOM
+    | PWTLexTab
     | PWTQuirkyCabalFile       -- ^ legacy cabal file that we know how to patch
     | PWTDoubleDash            -- ^ Double dash token, most likely it's a mistake - it's not a comment
     | PWTMultipleSingularField -- ^ e.g. name or version should be specified only once.

--- a/Cabal/Distribution/Parsec/LexerMonad.hs
+++ b/Cabal/Distribution/Parsec/LexerMonad.hs
@@ -27,14 +27,16 @@ module Distribution.Parsec.LexerMonad (
     LexWarning(..),
     LexWarningType(..),
     addWarning,
-    toPWarning,
+    toPWarnings,
 
   ) where
 
 import qualified Data.ByteString             as B
 import           Distribution.Compat.Prelude
-import           Distribution.Parsec.Common  (PWarnType (..), PWarning (..), Position (..))
+import           Distribution.Parsec.Common  (PWarnType (..), PWarning (..), Position (..), showPos)
 import           Prelude ()
+
+import qualified Distribution.Compat.Map.Strict as Map
 
 #ifdef CABAL_PARSEC_DEBUG
 -- testing only:
@@ -62,19 +64,26 @@ data LexResult a = LexResult {-# UNPACK #-} !LexState a
 data LexWarningType
     = LexWarningNBSP  -- ^ Encountered non breaking space
     | LexWarningBOM   -- ^ BOM at the start of the cabal file
-  deriving (Show)
+    | LexWarningTab   -- ^ Leading tags
+  deriving (Eq, Ord, Show)
 
 data LexWarning = LexWarning                !LexWarningType
                              {-# UNPACK #-} !Position
-                                            !String
   deriving (Show)
 
-toPWarning :: LexWarning -> PWarning
-toPWarning (LexWarning t p s) = PWarning t' p s
+toPWarnings :: [LexWarning] -> [PWarning]
+toPWarnings
+    = map (uncurry toWarning)
+    . Map.toList
+    . Map.fromListWith (++)
+    . map (\(LexWarning t p) -> (t, [p]))
   where
-    t' = case t of
-        LexWarningNBSP -> PWTLexNBSP
-        LexWarningBOM  -> PWTLexBOM
+    toWarning LexWarningBOM poss =
+        PWarning PWTLexBOM (head poss) "Byte-order mark found at the beginning of the file"
+    toWarning LexWarningNBSP poss =
+        PWarning PWTLexNBSP (head poss) $ "Non breaking spaces at " ++ intercalate ", " (map showPos poss)
+    toWarning LexWarningTab poss =
+        PWarning PWTLexTab (head poss) $ "Tabs used as indentation at " ++ intercalate ", " (map showPos poss)
 
 data LexState = LexState {
         curPos   :: {-# UNPACK #-} !Position,        -- ^ position at current input location
@@ -139,6 +148,6 @@ setStartCode :: Int -> Lex ()
 setStartCode c = Lex $ \s -> LexResult s{ curCode = c } ()
 
 -- | Add warning at the current position
-addWarning :: LexWarningType -> String -> Lex ()
-addWarning wt msg = Lex $ \s@LexState{ curPos = pos, warnings = ws  } ->
-    LexResult s{ warnings = LexWarning wt pos msg : ws } ()
+addWarning :: LexWarningType -> Lex ()
+addWarning wt = Lex $ \s@LexState{ curPos = pos, warnings = ws  } ->
+    LexResult s{ warnings = LexWarning wt pos : ws } ()

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -55,6 +55,7 @@ warningTests :: TestTree
 warningTests = testGroup "warnings triggered"
     [ warningTest PWTLexBOM            "bom.cabal"
     , warningTest PWTLexNBSP           "nbsp.cabal"
+    , warningTest PWTLexTab            "tab.cabal"
     , warningTest PWTUTF               "utf8.cabal"
     , warningTest PWTBoolCase          "bool.cabal"
     , warningTest PWTVersionTag        "versiontag.cabal"
@@ -82,9 +83,9 @@ warningTest wt fp = testCase (show wt) $ do
     assertBool ("should parse without errors:  " ++  show errs) $ null errs
 
     case warns of
-        [PWarning wt' _ _] -> assertEqual "warning type" wt wt'
-        []                 -> assertFailure "got no warnings"
-        _                  -> assertFailure $ "got multiple warnings: " ++ show warns
+        [PWarning wt' _ _ ] -> assertEqual "warning type" wt wt'
+        []                  -> assertFailure "got no warnings"
+        _                   -> assertFailure $ "got multiple warnings: " ++ show warns
 
 -------------------------------------------------------------------------------
 -- Errors
@@ -133,6 +134,7 @@ regressionTests = testGroup "regressions"
     , regressionTest "common2.cabal"
     , regressionTest "leading-comma.cabal"
     , regressionTest "wl-pprint-indef.cabal"
+    , regressionTest "th-lift-instances.cabal"
     ]
 
 regressionTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests/regressions/Octree-0.5.format
+++ b/Cabal/tests/ParserTests/regressions/Octree-0.5.format
@@ -1,6 +1,4 @@
-PWarning PWTLexNBSP (Position 43 3) "Non-breaking space found"
-PWarning PWTLexNBSP (Position 41 3) "Non-breaking space found"
-PWarning PWTLexNBSP (Position 39 3) "Non-breaking space found"
+PWarning PWTLexNBSP (Position 39 3) "Non breaking spaces at 39:3, 41:3, 43:3"
 name: Octree
 version: 0.5
 license: BSD3

--- a/Cabal/tests/ParserTests/regressions/th-lift-instances.cabal
+++ b/Cabal/tests/ParserTests/regressions/th-lift-instances.cabal
@@ -1,0 +1,76 @@
+name:          th-lift-instances
+version:       0.1.4
+x-revision: 1
+license:       BSD3
+cabal-version: >= 1.10
+license-file:  LICENSE
+author:        Benno Fünfstück
+maintainer:    Benno Fünfstück <benno.fuenfstueck@gmail.com>
+stability:     experimental
+homepage:      http://github.com/bennofs/th-lift-instances/
+bug-reports:   http://github.com/bennofs/th-lift-instances/issues
+copyright:     Copyright (C) 2013-2014 Benno Fünfstück
+synopsis:      Lift instances for template-haskell for common data types.
+description:   Most data types in haskell platform do not have Lift instances. This package provides orphan instances
+	       for containers, text, bytestring and vector.
+build-type:    Custom
+category:      Template Haskell
+
+extra-source-files:
+  .ghci
+  .gitignore
+  .travis.yml
+  .vim.custom
+  README.md
+
+source-repository head
+  type: git
+  location: https://github.com/bennofs/th-lift-instances.git
+
+library
+  hs-source-dirs: src
+  default-language: Haskell2010
+  ghc-options: -Wall -fwarn-tabs
+  build-depends:
+      base >= 4.4 && < 5
+    , template-haskell < 2.10
+    , th-lift
+    , containers >= 0.4 && < 0.6
+    , vector >= 0.9 && < 0.11
+    , text >= 0.11 && < 1.3
+    , bytestring >= 0.9 && < 0.11
+  exposed-modules:
+    Instances.TH.Lift
+  other-extensions: TemplateHaskell
+
+test-suite tests
+  type:    exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+    Data
+  default-language: Haskell2010
+  build-depends:
+      base
+    , template-haskell <2.10
+    , containers >= 0.4 && < 0.6
+    , vector >= 0.9 && < 0.11
+    , text >= 0.11 && < 1.2
+    , bytestring >= 0.9 && < 0.11
+    , th-lift-instances
+    , QuickCheck >= 2.6 && < 2.8
+  hs-source-dirs: tests
+  other-extensions: TemplateHaskell
+
+test-suite doctests
+  type:    exitcode-stdio-1.0
+  main-is: doctests.hs
+  default-language: Haskell2010
+  build-depends:
+      base
+    , directory >= 1.0
+    , doctest >= 0.9.1
+    , filepath
+  ghc-options: -Wall -threaded
+  if impl(ghc<7.6.1)
+    ghc-options: -Werror
+  hs-source-dirs: tests

--- a/Cabal/tests/ParserTests/regressions/th-lift-instances.expr
+++ b/Cabal/tests/ParserTests/regressions/th-lift-instances.expr
@@ -1,0 +1,432 @@
+GenericPackageDescription
+  {condBenchmarks = [],
+   condExecutables = [],
+   condForeignLibs = [],
+   condLibrary = Just
+                   CondNode
+                     {condTreeComponents = [],
+                      condTreeConstraints = [Dependency
+                                               `PackageName "base"`
+                                               (IntersectVersionRanges
+                                                  (OrLaterVersion `mkVersion [4,4]`)
+                                                  (EarlierVersion `mkVersion [5]`)),
+                                             Dependency
+                                               `PackageName "template-haskell"`
+                                               (EarlierVersion `mkVersion [2,10]`),
+                                             Dependency `PackageName "th-lift"` AnyVersion,
+                                             Dependency
+                                               `PackageName "containers"`
+                                               (IntersectVersionRanges
+                                                  (OrLaterVersion `mkVersion [0,4]`)
+                                                  (EarlierVersion `mkVersion [0,6]`)),
+                                             Dependency
+                                               `PackageName "vector"`
+                                               (IntersectVersionRanges
+                                                  (OrLaterVersion `mkVersion [0,9]`)
+                                                  (EarlierVersion `mkVersion [0,11]`)),
+                                             Dependency
+                                               `PackageName "text"`
+                                               (IntersectVersionRanges
+                                                  (OrLaterVersion `mkVersion [0,11]`)
+                                                  (EarlierVersion `mkVersion [1,3]`)),
+                                             Dependency
+                                               `PackageName "bytestring"`
+                                               (IntersectVersionRanges
+                                                  (OrLaterVersion `mkVersion [0,9]`)
+                                                  (EarlierVersion `mkVersion [0,11]`))],
+                      condTreeData = Library
+                                       {exposedModules = [`ModuleName ["Instances","TH","Lift"]`],
+                                        libBuildInfo = BuildInfo
+                                                         {asmOptions = [],
+                                                          asmSources = [],
+                                                          autogenModules = [],
+                                                          buildToolDepends = [],
+                                                          buildTools = [],
+                                                          buildable = True,
+                                                          cSources = [],
+                                                          ccOptions = [],
+                                                          cmmOptions = [],
+                                                          cmmSources = [],
+                                                          cppOptions = [],
+                                                          customFieldsBI = [],
+                                                          cxxOptions = [],
+                                                          cxxSources = [],
+                                                          defaultExtensions = [],
+                                                          defaultLanguage = Just Haskell2010,
+                                                          extraBundledLibs = [],
+                                                          extraFrameworkDirs = [],
+                                                          extraGHCiLibs = [],
+                                                          extraLibDirs = [],
+                                                          extraLibFlavours = [],
+                                                          extraLibs = [],
+                                                          frameworks = [],
+                                                          hsSourceDirs = ["src"],
+                                                          includeDirs = [],
+                                                          includes = [],
+                                                          installIncludes = [],
+                                                          jsSources = [],
+                                                          ldOptions = [],
+                                                          mixins = [],
+                                                          oldExtensions = [],
+                                                          options = [_×_
+                                                                       GHC
+                                                                       ["-Wall", "-fwarn-tabs"]],
+                                                          otherExtensions = [EnableExtension
+                                                                               TemplateHaskell],
+                                                          otherLanguages = [],
+                                                          otherModules = [],
+                                                          pkgconfigDepends = [],
+                                                          profOptions = [],
+                                                          sharedOptions = [],
+                                                          staticOptions = [],
+                                                          targetBuildDepends = [Dependency
+                                                                                  `PackageName "base"`
+                                                                                  (IntersectVersionRanges
+                                                                                     (OrLaterVersion
+                                                                                        `mkVersion [4,4]`)
+                                                                                     (EarlierVersion
+                                                                                        `mkVersion [5]`)),
+                                                                                Dependency
+                                                                                  `PackageName "template-haskell"`
+                                                                                  (EarlierVersion
+                                                                                     `mkVersion [2,10]`),
+                                                                                Dependency
+                                                                                  `PackageName "th-lift"`
+                                                                                  AnyVersion,
+                                                                                Dependency
+                                                                                  `PackageName "containers"`
+                                                                                  (IntersectVersionRanges
+                                                                                     (OrLaterVersion
+                                                                                        `mkVersion [0,4]`)
+                                                                                     (EarlierVersion
+                                                                                        `mkVersion [0,6]`)),
+                                                                                Dependency
+                                                                                  `PackageName "vector"`
+                                                                                  (IntersectVersionRanges
+                                                                                     (OrLaterVersion
+                                                                                        `mkVersion [0,9]`)
+                                                                                     (EarlierVersion
+                                                                                        `mkVersion [0,11]`)),
+                                                                                Dependency
+                                                                                  `PackageName "text"`
+                                                                                  (IntersectVersionRanges
+                                                                                     (OrLaterVersion
+                                                                                        `mkVersion [0,11]`)
+                                                                                     (EarlierVersion
+                                                                                        `mkVersion [1,3]`)),
+                                                                                Dependency
+                                                                                  `PackageName "bytestring"`
+                                                                                  (IntersectVersionRanges
+                                                                                     (OrLaterVersion
+                                                                                        `mkVersion [0,9]`)
+                                                                                     (EarlierVersion
+                                                                                        `mkVersion [0,11]`))],
+                                                          virtualModules = []},
+                                        libExposed = True,
+                                        libName = Nothing,
+                                        reexportedModules = [],
+                                        signatures = []}},
+   condSubLibraries = [],
+   condTestSuites = [_×_
+                       `UnqualComponentName "tests"`
+                       CondNode
+                         {condTreeComponents = [],
+                          condTreeConstraints = [Dependency `PackageName "base"` AnyVersion,
+                                                 Dependency
+                                                   `PackageName "template-haskell"`
+                                                   (EarlierVersion `mkVersion [2,10]`),
+                                                 Dependency
+                                                   `PackageName "containers"`
+                                                   (IntersectVersionRanges
+                                                      (OrLaterVersion `mkVersion [0,4]`)
+                                                      (EarlierVersion `mkVersion [0,6]`)),
+                                                 Dependency
+                                                   `PackageName "vector"`
+                                                   (IntersectVersionRanges
+                                                      (OrLaterVersion `mkVersion [0,9]`)
+                                                      (EarlierVersion `mkVersion [0,11]`)),
+                                                 Dependency
+                                                   `PackageName "text"`
+                                                   (IntersectVersionRanges
+                                                      (OrLaterVersion `mkVersion [0,11]`)
+                                                      (EarlierVersion `mkVersion [1,2]`)),
+                                                 Dependency
+                                                   `PackageName "bytestring"`
+                                                   (IntersectVersionRanges
+                                                      (OrLaterVersion `mkVersion [0,9]`)
+                                                      (EarlierVersion `mkVersion [0,11]`)),
+                                                 Dependency
+                                                   `PackageName "th-lift-instances"` AnyVersion,
+                                                 Dependency
+                                                   `PackageName "QuickCheck"`
+                                                   (IntersectVersionRanges
+                                                      (OrLaterVersion `mkVersion [2,6]`)
+                                                      (EarlierVersion `mkVersion [2,8]`))],
+                          condTreeData = TestSuite
+                                           {testBuildInfo = BuildInfo
+                                                              {asmOptions = [],
+                                                               asmSources = [],
+                                                               autogenModules = [],
+                                                               buildToolDepends = [],
+                                                               buildTools = [],
+                                                               buildable = True,
+                                                               cSources = [],
+                                                               ccOptions = [],
+                                                               cmmOptions = [],
+                                                               cmmSources = [],
+                                                               cppOptions = [],
+                                                               customFieldsBI = [],
+                                                               cxxOptions = [],
+                                                               cxxSources = [],
+                                                               defaultExtensions = [],
+                                                               defaultLanguage = Just Haskell2010,
+                                                               extraBundledLibs = [],
+                                                               extraFrameworkDirs = [],
+                                                               extraGHCiLibs = [],
+                                                               extraLibDirs = [],
+                                                               extraLibFlavours = [],
+                                                               extraLibs = [],
+                                                               frameworks = [],
+                                                               hsSourceDirs = ["tests"],
+                                                               includeDirs = [],
+                                                               includes = [],
+                                                               installIncludes = [],
+                                                               jsSources = [],
+                                                               ldOptions = [],
+                                                               mixins = [],
+                                                               oldExtensions = [],
+                                                               options = [],
+                                                               otherExtensions = [EnableExtension
+                                                                                    TemplateHaskell],
+                                                               otherLanguages = [],
+                                                               otherModules = [`ModuleName ["Data"]`],
+                                                               pkgconfigDepends = [],
+                                                               profOptions = [],
+                                                               sharedOptions = [],
+                                                               staticOptions = [],
+                                                               targetBuildDepends = [Dependency
+                                                                                       `PackageName "base"`
+                                                                                       AnyVersion,
+                                                                                     Dependency
+                                                                                       `PackageName "template-haskell"`
+                                                                                       (EarlierVersion
+                                                                                          `mkVersion [2,10]`),
+                                                                                     Dependency
+                                                                                       `PackageName "containers"`
+                                                                                       (IntersectVersionRanges
+                                                                                          (OrLaterVersion
+                                                                                             `mkVersion [0,4]`)
+                                                                                          (EarlierVersion
+                                                                                             `mkVersion [0,6]`)),
+                                                                                     Dependency
+                                                                                       `PackageName "vector"`
+                                                                                       (IntersectVersionRanges
+                                                                                          (OrLaterVersion
+                                                                                             `mkVersion [0,9]`)
+                                                                                          (EarlierVersion
+                                                                                             `mkVersion [0,11]`)),
+                                                                                     Dependency
+                                                                                       `PackageName "text"`
+                                                                                       (IntersectVersionRanges
+                                                                                          (OrLaterVersion
+                                                                                             `mkVersion [0,11]`)
+                                                                                          (EarlierVersion
+                                                                                             `mkVersion [1,2]`)),
+                                                                                     Dependency
+                                                                                       `PackageName "bytestring"`
+                                                                                       (IntersectVersionRanges
+                                                                                          (OrLaterVersion
+                                                                                             `mkVersion [0,9]`)
+                                                                                          (EarlierVersion
+                                                                                             `mkVersion [0,11]`)),
+                                                                                     Dependency
+                                                                                       `PackageName "th-lift-instances"`
+                                                                                       AnyVersion,
+                                                                                     Dependency
+                                                                                       `PackageName "QuickCheck"`
+                                                                                       (IntersectVersionRanges
+                                                                                          (OrLaterVersion
+                                                                                             `mkVersion [2,6]`)
+                                                                                          (EarlierVersion
+                                                                                             `mkVersion [2,8]`))],
+                                                               virtualModules = []},
+                                            testInterface = TestSuiteExeV10
+                                                              `mkVersion [1,0]` "Main.hs",
+                                            testName = `UnqualComponentName ""`}},
+                     _×_
+                       `UnqualComponentName "doctests"`
+                       CondNode
+                         {condTreeComponents = [CondBranch
+                                                  {condBranchCondition = `Var (Impl GHC (EarlierVersion (mkVersion [7,6,1])))`,
+                                                   condBranchIfFalse = Nothing,
+                                                   condBranchIfTrue = CondNode
+                                                                        {condTreeComponents = [],
+                                                                         condTreeConstraints = [],
+                                                                         condTreeData = TestSuite
+                                                                                          {testBuildInfo = BuildInfo
+                                                                                                             {asmOptions = [],
+                                                                                                              asmSources = [],
+                                                                                                              autogenModules = [],
+                                                                                                              buildToolDepends = [],
+                                                                                                              buildTools = [],
+                                                                                                              buildable = True,
+                                                                                                              cSources = [],
+                                                                                                              ccOptions = [],
+                                                                                                              cmmOptions = [],
+                                                                                                              cmmSources = [],
+                                                                                                              cppOptions = [],
+                                                                                                              customFieldsBI = [],
+                                                                                                              cxxOptions = [],
+                                                                                                              cxxSources = [],
+                                                                                                              defaultExtensions = [],
+                                                                                                              defaultLanguage = Nothing,
+                                                                                                              extraBundledLibs = [],
+                                                                                                              extraFrameworkDirs = [],
+                                                                                                              extraGHCiLibs = [],
+                                                                                                              extraLibDirs = [],
+                                                                                                              extraLibFlavours = [],
+                                                                                                              extraLibs = [],
+                                                                                                              frameworks = [],
+                                                                                                              hsSourceDirs = [],
+                                                                                                              includeDirs = [],
+                                                                                                              includes = [],
+                                                                                                              installIncludes = [],
+                                                                                                              jsSources = [],
+                                                                                                              ldOptions = [],
+                                                                                                              mixins = [],
+                                                                                                              oldExtensions = [],
+                                                                                                              options = [_×_
+                                                                                                                           GHC
+                                                                                                                           ["-Werror"]],
+                                                                                                              otherExtensions = [],
+                                                                                                              otherLanguages = [],
+                                                                                                              otherModules = [],
+                                                                                                              pkgconfigDepends = [],
+                                                                                                              profOptions = [],
+                                                                                                              sharedOptions = [],
+                                                                                                              staticOptions = [],
+                                                                                                              targetBuildDepends = [],
+                                                                                                              virtualModules = []},
+                                                                                           testInterface = TestSuiteUnsupported
+                                                                                                             (TestTypeUnknown
+                                                                                                                ""
+                                                                                                                `mkVersion []`),
+                                                                                           testName = `UnqualComponentName ""`}}}],
+                          condTreeConstraints = [Dependency `PackageName "base"` AnyVersion,
+                                                 Dependency
+                                                   `PackageName "directory"`
+                                                   (OrLaterVersion `mkVersion [1,0]`),
+                                                 Dependency
+                                                   `PackageName "doctest"`
+                                                   (OrLaterVersion `mkVersion [0,9,1]`),
+                                                 Dependency `PackageName "filepath"` AnyVersion],
+                          condTreeData = TestSuite
+                                           {testBuildInfo = BuildInfo
+                                                              {asmOptions = [],
+                                                               asmSources = [],
+                                                               autogenModules = [],
+                                                               buildToolDepends = [],
+                                                               buildTools = [],
+                                                               buildable = True,
+                                                               cSources = [],
+                                                               ccOptions = [],
+                                                               cmmOptions = [],
+                                                               cmmSources = [],
+                                                               cppOptions = [],
+                                                               customFieldsBI = [],
+                                                               cxxOptions = [],
+                                                               cxxSources = [],
+                                                               defaultExtensions = [],
+                                                               defaultLanguage = Just Haskell2010,
+                                                               extraBundledLibs = [],
+                                                               extraFrameworkDirs = [],
+                                                               extraGHCiLibs = [],
+                                                               extraLibDirs = [],
+                                                               extraLibFlavours = [],
+                                                               extraLibs = [],
+                                                               frameworks = [],
+                                                               hsSourceDirs = ["tests"],
+                                                               includeDirs = [],
+                                                               includes = [],
+                                                               installIncludes = [],
+                                                               jsSources = [],
+                                                               ldOptions = [],
+                                                               mixins = [],
+                                                               oldExtensions = [],
+                                                               options = [_×_
+                                                                            GHC
+                                                                            ["-Wall", "-threaded"]],
+                                                               otherExtensions = [],
+                                                               otherLanguages = [],
+                                                               otherModules = [],
+                                                               pkgconfigDepends = [],
+                                                               profOptions = [],
+                                                               sharedOptions = [],
+                                                               staticOptions = [],
+                                                               targetBuildDepends = [Dependency
+                                                                                       `PackageName "base"`
+                                                                                       AnyVersion,
+                                                                                     Dependency
+                                                                                       `PackageName "directory"`
+                                                                                       (OrLaterVersion
+                                                                                          `mkVersion [1,0]`),
+                                                                                     Dependency
+                                                                                       `PackageName "doctest"`
+                                                                                       (OrLaterVersion
+                                                                                          `mkVersion [0,9,1]`),
+                                                                                     Dependency
+                                                                                       `PackageName "filepath"`
+                                                                                       AnyVersion],
+                                                               virtualModules = []},
+                                            testInterface = TestSuiteExeV10
+                                                              `mkVersion [1,0]` "doctests.hs",
+                                            testName = `UnqualComponentName ""`}}],
+   genPackageFlags = [],
+   packageDescription = PackageDescription
+                          {author = "Benno F\252nfst\252ck",
+                           benchmarks = [],
+                           bugReports = "http://github.com/bennofs/th-lift-instances/issues",
+                           buildDepends = [],
+                           buildTypeRaw = Just Custom,
+                           category = "Template Haskell",
+                           copyright = "Copyright (C) 2013-2014 Benno F\252nfst\252ck",
+                           customFieldsPD = [_×_ "x-revision" "1"],
+                           dataDir = "",
+                           dataFiles = [],
+                           description = concat
+                                           ["Most data types in haskell platform do not have Lift instances. This package provides orphan instances\n",
+                                            "for containers, text, bytestring and vector."],
+                           executables = [],
+                           extraDocFiles = [],
+                           extraSrcFiles = [".ghci",
+                                            ".gitignore",
+                                            ".travis.yml",
+                                            ".vim.custom",
+                                            "README.md"],
+                           extraTmpFiles = [],
+                           foreignLibs = [],
+                           homepage = "http://github.com/bennofs/th-lift-instances/",
+                           library = Nothing,
+                           license = BSD3,
+                           licenseFiles = ["LICENSE"],
+                           maintainer = "Benno F\252nfst\252ck <benno.fuenfstueck@gmail.com>",
+                           package = PackageIdentifier
+                                       {pkgName = `PackageName "th-lift-instances"`,
+                                        pkgVersion = `mkVersion [0,1,4]`},
+                           pkgUrl = "",
+                           setupBuildInfo = Nothing,
+                           sourceRepos = [SourceRepo
+                                            {repoBranch = Nothing,
+                                             repoKind = RepoHead,
+                                             repoLocation = Just
+                                                              "https://github.com/bennofs/th-lift-instances.git",
+                                             repoModule = Nothing,
+                                             repoSubdir = Nothing,
+                                             repoTag = Nothing,
+                                             repoType = Just Git}],
+                           specVersionRaw = Right (OrLaterVersion `mkVersion [1,10]`),
+                           stability = "experimental",
+                           subLibraries = [],
+                           synopsis = "Lift instances for template-haskell for common data types.",
+                           testSuites = [],
+                           testedWith = []}}

--- a/Cabal/tests/ParserTests/regressions/th-lift-instances.format
+++ b/Cabal/tests/ParserTests/regressions/th-lift-instances.format
@@ -1,0 +1,78 @@
+PWarning PWTLexTab (Position 15 9) "Tabs used as indentation at 15:9"
+name: th-lift-instances
+version: 0.1.4
+license: BSD3
+license-file: LICENSE
+copyright: Copyright (C) 2013-2014 Benno Fünfstück
+maintainer: Benno Fünfstück <benno.fuenfstueck@gmail.com>
+author: Benno Fünfstück
+stability: experimental
+homepage: http://github.com/bennofs/th-lift-instances/
+bug-reports: http://github.com/bennofs/th-lift-instances/issues
+synopsis: Lift instances for template-haskell for common data types.
+description:
+    Most data types in haskell platform do not have Lift instances. This package provides orphan instances
+    for containers, text, bytestring and vector.
+category: Template Haskell
+x-revision: 1
+cabal-version: >=1.10
+build-type: Custom
+extra-source-files:
+    .ghci
+    .gitignore
+    .travis.yml
+    .vim.custom
+    README.md
+
+source-repository head
+    type: git
+    location: https://github.com/bennofs/th-lift-instances.git
+
+library
+    exposed-modules:
+        Instances.TH.Lift
+    hs-source-dirs: src
+    default-language: Haskell2010
+    other-extensions: TemplateHaskell
+    ghc-options: -Wall -fwarn-tabs
+    build-depends:
+        base >=4.4 && <5,
+        template-haskell <2.10,
+        th-lift -any,
+        containers >=0.4 && <0.6,
+        vector >=0.9 && <0.11,
+        text >=0.11 && <1.3,
+        bytestring >=0.9 && <0.11
+
+test-suite tests
+    type: exitcode-stdio-1.0
+    main-is: Main.hs
+    hs-source-dirs: tests
+    other-modules:
+        Data
+    default-language: Haskell2010
+    other-extensions: TemplateHaskell
+    build-depends:
+        base -any,
+        template-haskell <2.10,
+        containers >=0.4 && <0.6,
+        vector >=0.9 && <0.11,
+        text >=0.11 && <1.2,
+        bytestring >=0.9 && <0.11,
+        th-lift-instances -any,
+        QuickCheck >=2.6 && <2.8
+
+test-suite doctests
+    type: exitcode-stdio-1.0
+    main-is: doctests.hs
+    hs-source-dirs: tests
+    default-language: Haskell2010
+    ghc-options: -Wall -threaded
+    build-depends:
+        base -any,
+        directory >=1.0,
+        doctest >=0.9.1,
+        filepath -any
+    
+    if impl(ghc <7.6.1)
+        ghc-options: -Werror

--- a/Cabal/tests/ParserTests/warnings/subsection.cabal
+++ b/Cabal/tests/ParserTests/warnings/subsection.cabal
@@ -6,4 +6,4 @@ library
     build-depends: base >= 4.9 && <4.10
     hs-source-dirs: .
     iff os(windows)
-    	build-depends: containers
+        build-depends: containers

--- a/Cabal/tests/ParserTests/warnings/tab.cabal
+++ b/Cabal/tests/ParserTests/warnings/tab.cabal
@@ -1,0 +1,12 @@
+name: tab
+version: 1
+cabal-version: >= 1.6
+
+library 		
+	build-depends: 		{ 	 base >= 4.9 	&& <4.10 } 
+	hs-source-dirs:		.
+
+test-suite 	 tests 	 	 { 	
+	type: exitcode-stdio-1.0
+	main-is: Main.hs
+}


### PR DESCRIPTION
There are 3957 warned files atm in Hackage index.
All of them have tab "inside the field", thus old parser acceps them.

See e.g added th-lift-instances file. The warning comes from the description field.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
