### PR TITLE
Derive NFData instance for GenericPackageDescription.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -445,6 +445,7 @@ test-suite unit-tests
     UnitTests.Distribution.Simple.Utils
     UnitTests.Distribution.SPDX
     UnitTests.Distribution.System
+    UnitTests.Distribution.Types.GenericPackageDescription
     UnitTests.Distribution.Utils.Generic
     UnitTests.Distribution.Utils.NubList
     UnitTests.Distribution.Utils.ShortText

--- a/Cabal/Distribution/Compiler.hs
+++ b/Cabal/Distribution/Compiler.hs
@@ -66,6 +66,8 @@ data CompilerFlavor =
 
 instance Binary CompilerFlavor
 
+instance NFData CompilerFlavor where rnf = genericRnf
+
 knownCompilerFlavors :: [CompilerFlavor]
 knownCompilerFlavors = [GHC, GHCJS, NHC, YHC, Hugs, HBC, Helium, JHC, LHC, UHC]
 

--- a/Cabal/Distribution/License.hs
+++ b/Cabal/Distribution/License.hs
@@ -127,6 +127,8 @@ data License =
 
 instance Binary License
 
+instance NFData License where rnf = genericRnf
+
 -- | The list of all currently recognised licenses.
 knownLicenses :: [License]
 knownLicenses = [ GPL  unversioned, GPL  (version [2]),    GPL  (version [3])

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -56,6 +56,7 @@ import Distribution.Text                            (display)
 import Distribution.Types.CondTree
 import Distribution.Types.Dependency                (Dependency)
 import Distribution.Types.ForeignLib
+import Distribution.Types.GenericPackageDescription (emptyGenericPackageDescription)
 import Distribution.Types.PackageDescription        (specVersion')
 import Distribution.Types.UnqualComponentName       (UnqualComponentName, mkUnqualComponentName)
 import Distribution.Utils.Generic                   (breakMaybe, unfoldrM)
@@ -178,15 +179,12 @@ parseGenericPackageDescription' lexWarnings fs = do
     maybeWarnCabalVersion syntax pd
 
     -- Sections
-    let gpd = emptyGpd & L.packageDescription .~ pd
+    let gpd = emptyGenericPackageDescription & L.packageDescription .~ pd
 
     view stateGpd <$> execStateT (goSections specVer sectionFields) (SectionS gpd Map.empty)
   where
     safeLast :: [a] -> Maybe a
     safeLast = listToMaybe . reverse
-
-    emptyGpd :: GenericPackageDescription
-    emptyGpd = GenericPackageDescription emptyPackageDescription [] Nothing [] [] [] [] []
 
     newSyntaxVersion :: Version
     newSyntaxVersion = mkVersion [1, 2]

--- a/Cabal/Distribution/System.hs
+++ b/Cabal/Distribution/System.hs
@@ -104,6 +104,8 @@ data OS = Linux | Windows | OSX        -- tier 1 desktop OSs
 
 instance Binary OS
 
+instance NFData OS where rnf = genericRnf
+
 knownOSs :: [OS]
 knownOSs = [Linux, Windows, OSX
            ,FreeBSD, OpenBSD, NetBSD, DragonFly
@@ -171,6 +173,8 @@ data Arch = I386  | X86_64 | PPC | PPC64 | Sparc
 
 instance Binary Arch
 
+instance NFData Arch where rnf = genericRnf
+
 knownArches :: [Arch]
 knownArches = [I386, X86_64, PPC, PPC64, Sparc
               ,Arm, Mips, SH
@@ -218,6 +222,8 @@ data Platform = Platform Arch OS
   deriving (Eq, Generic, Ord, Show, Read, Typeable, Data)
 
 instance Binary Platform
+
+instance NFData Platform where rnf = genericRnf
 
 instance Pretty Platform where
   pretty (Platform arch os) = pretty arch <<>> Disp.char '-' <<>> pretty os

--- a/Cabal/Distribution/Types/Benchmark.hs
+++ b/Cabal/Distribution/Types/Benchmark.hs
@@ -32,6 +32,8 @@ data Benchmark = Benchmark {
 
 instance Binary Benchmark
 
+instance NFData Benchmark where rnf = genericRnf
+
 instance L.HasBuildInfo Benchmark where
     buildInfo f (Benchmark x1 x2 x3) = fmap (\y1 -> Benchmark x1 x2 y1) (f x3)
 

--- a/Cabal/Distribution/Types/BenchmarkInterface.hs
+++ b/Cabal/Distribution/Types/BenchmarkInterface.hs
@@ -35,6 +35,8 @@ data BenchmarkInterface =
 
 instance Binary BenchmarkInterface
 
+instance NFData BenchmarkInterface where rnf = genericRnf
+
 instance Monoid BenchmarkInterface where
     mempty  =  BenchmarkUnsupported (BenchmarkTypeUnknown mempty nullVersion)
     mappend = (<>)

--- a/Cabal/Distribution/Types/BenchmarkType.hs
+++ b/Cabal/Distribution/Types/BenchmarkType.hs
@@ -25,6 +25,8 @@ data BenchmarkType = BenchmarkTypeExe Version
 
 instance Binary BenchmarkType
 
+instance NFData BenchmarkType where rnf = genericRnf
+
 knownBenchmarkTypes :: [BenchmarkType]
 knownBenchmarkTypes = [ BenchmarkTypeExe (mkVersion [1,0]) ]
 

--- a/Cabal/Distribution/Types/BuildInfo.hs
+++ b/Cabal/Distribution/Types/BuildInfo.hs
@@ -106,6 +106,8 @@ data BuildInfo = BuildInfo {
 
 instance Binary BuildInfo
 
+instance NFData BuildInfo where rnf = genericRnf
+
 instance Monoid BuildInfo where
   mempty = BuildInfo {
     buildable           = True,

--- a/Cabal/Distribution/Types/BuildType.hs
+++ b/Cabal/Distribution/Types/BuildType.hs
@@ -30,6 +30,8 @@ data BuildType
 
 instance Binary BuildType
 
+instance NFData BuildType where rnf = genericRnf
+
 knownBuildTypes :: [BuildType]
 knownBuildTypes = [Simple, Configure, Make, Custom]
 

--- a/Cabal/Distribution/Types/CondTree.hs
+++ b/Cabal/Distribution/Types/CondTree.hs
@@ -59,6 +59,8 @@ data CondTree v c a = CondNode
 
 instance (Binary v, Binary c, Binary a) => Binary (CondTree v c a)
 
+instance (NFData v, NFData c, NFData a) => NFData (CondTree v c a) where rnf = genericRnf
+
 -- | A 'CondBranch' represents a conditional branch, e.g., @if
 -- flag(foo)@ on some syntax @a@.  It also has an optional false
 -- branch.
@@ -78,6 +80,8 @@ instance Foldable (CondBranch v c) where
     foldMap f (CondBranch _ c (Just a)) = foldMap f c `mappend` foldMap f a
 
 instance (Binary v, Binary c, Binary a) => Binary (CondBranch v c a)
+
+instance (NFData v, NFData c, NFData a) => NFData (CondBranch v c a) where rnf = genericRnf
 
 condIfThen :: Condition v -> CondTree v c a -> CondBranch v c a
 condIfThen c t = CondBranch c t Nothing

--- a/Cabal/Distribution/Types/Condition.hs
+++ b/Cabal/Distribution/Types/Condition.hs
@@ -98,6 +98,8 @@ instance MonadPlus Condition where
 
 instance Binary c => Binary (Condition c)
 
+instance NFData c => NFData (Condition c) where rnf = genericRnf
+
 -- | Simplify the condition and return its free variables.
 simplifyCondition :: Condition c
                   -> (c -> Either d Bool)   -- ^ (partial) variable assignment

--- a/Cabal/Distribution/Types/Executable.hs
+++ b/Cabal/Distribution/Types/Executable.hs
@@ -31,6 +31,8 @@ instance L.HasBuildInfo Executable where
 
 instance Binary Executable
 
+instance NFData Executable where rnf = genericRnf
+
 instance Monoid Executable where
   mempty = gmempty
   mappend = (<>)

--- a/Cabal/Distribution/Types/ExecutableScope.hs
+++ b/Cabal/Distribution/Types/ExecutableScope.hs
@@ -42,6 +42,8 @@ instance Text ExecutableScope where
 
 instance Binary ExecutableScope
 
+instance NFData ExecutableScope where rnf = genericRnf
+
 instance Monoid ExecutableScope where
     mempty = ExecutableScopeUnknown
     mappend = (<>)

--- a/Cabal/Distribution/Types/ForeignLib.hs
+++ b/Cabal/Distribution/Types/ForeignLib.hs
@@ -85,6 +85,8 @@ instance Read LibVersionInfo where
 
 instance Binary LibVersionInfo
 
+instance NFData LibVersionInfo where rnf = genericRnf
+
 instance Pretty LibVersionInfo where
     pretty (LibVersionInfo c r a)
       = Disp.hcat $ Disp.punctuate (Disp.char ':') $ map Disp.int [c,r,a]
@@ -147,6 +149,8 @@ instance L.HasBuildInfo ForeignLib where
     buildInfo f l = (\x -> l { foreignLibBuildInfo = x }) <$> f (foreignLibBuildInfo l)
 
 instance Binary ForeignLib
+
+instance NFData ForeignLib where rnf = genericRnf
 
 instance Semigroup ForeignLib where
   a <> b = ForeignLib {

--- a/Cabal/Distribution/Types/ForeignLibOption.hs
+++ b/Cabal/Distribution/Types/ForeignLibOption.hs
@@ -41,3 +41,5 @@ instance Text ForeignLibOption where
     ]
 
 instance Binary ForeignLibOption
+
+instance NFData ForeignLibOption where rnf = genericRnf

--- a/Cabal/Distribution/Types/ForeignLibType.hs
+++ b/Cabal/Distribution/Types/ForeignLibType.hs
@@ -51,6 +51,8 @@ instance Text ForeignLibType where
 
 instance Binary ForeignLibType
 
+instance NFData ForeignLibType where rnf = genericRnf
+
 instance Semigroup ForeignLibType where
   ForeignLibTypeUnknown <> b = b
   a <> ForeignLibTypeUnknown = a

--- a/Cabal/Distribution/Types/GenericPackageDescription.hs
+++ b/Cabal/Distribution/Types/GenericPackageDescription.hs
@@ -5,6 +5,7 @@
 
 module Distribution.Types.GenericPackageDescription (
     GenericPackageDescription(..),
+    emptyGenericPackageDescription,
     Flag(..),
     emptyFlag,
     FlagName,
@@ -322,3 +323,6 @@ data ConfVar = OS OS
 instance Binary ConfVar
 
 instance NFData ConfVar where rnf = genericRnf
+
+emptyGenericPackageDescription :: GenericPackageDescription
+emptyGenericPackageDescription = GenericPackageDescription emptyPackageDescription [] Nothing [] [] [] [] []

--- a/Cabal/Distribution/Types/GenericPackageDescription.hs
+++ b/Cabal/Distribution/Types/GenericPackageDescription.hs
@@ -80,6 +80,8 @@ instance Package GenericPackageDescription where
 
 instance Binary GenericPackageDescription
 
+instance NFData GenericPackageDescription where rnf = genericRnf
+
 -- | A flag can represent a feature to be included, or a way of linking
 --   a target against its dependencies, or in fact whatever you can think of.
 data Flag = MkFlag
@@ -91,6 +93,8 @@ data Flag = MkFlag
     deriving (Show, Eq, Typeable, Data, Generic)
 
 instance Binary Flag
+
+instance NFData Flag where rnf = genericRnf
 
 -- | A 'Flag' initialized with default parameters.
 emptyFlag :: FlagName -> Flag
@@ -316,3 +320,5 @@ data ConfVar = OS OS
     deriving (Eq, Show, Typeable, Data, Generic)
 
 instance Binary ConfVar
+
+instance NFData ConfVar where rnf = genericRnf

--- a/Cabal/Distribution/Types/IncludeRenaming.hs
+++ b/Cabal/Distribution/Types/IncludeRenaming.hs
@@ -34,6 +34,8 @@ data IncludeRenaming
 
 instance Binary IncludeRenaming
 
+instance NFData IncludeRenaming where rnf = genericRnf
+
 -- | The 'defaultIncludeRenaming' applied when you only @build-depends@
 -- on a package.
 defaultIncludeRenaming :: IncludeRenaming

--- a/Cabal/Distribution/Types/Library.hs
+++ b/Cabal/Distribution/Types/Library.hs
@@ -34,6 +34,8 @@ instance L.HasBuildInfo Library where
 
 instance Binary Library
 
+instance NFData Library where rnf = genericRnf
+
 instance Monoid Library where
   mempty = Library {
     libName = mempty,

--- a/Cabal/Distribution/Types/Mixin.hs
+++ b/Cabal/Distribution/Types/Mixin.hs
@@ -25,6 +25,8 @@ data Mixin = Mixin { mixinPackageName :: PackageName
 
 instance Binary Mixin
 
+instance NFData Mixin where rnf = genericRnf
+
 instance Pretty Mixin where
     pretty (Mixin pkg_name incl) = pretty pkg_name <+> pretty incl
 

--- a/Cabal/Distribution/Types/ModuleReexport.hs
+++ b/Cabal/Distribution/Types/ModuleReexport.hs
@@ -31,6 +31,8 @@ data ModuleReexport = ModuleReexport {
 
 instance Binary ModuleReexport
 
+instance NFData ModuleReexport where rnf = genericRnf
+
 instance Pretty ModuleReexport where
     pretty (ModuleReexport mpkgname origname newname) =
           maybe Disp.empty (\pkgname -> pretty pkgname <<>> Disp.char ':') mpkgname

--- a/Cabal/Distribution/Types/ModuleRenaming.hs
+++ b/Cabal/Distribution/Types/ModuleRenaming.hs
@@ -69,6 +69,8 @@ isDefaultRenaming _ = False
 
 instance Binary ModuleRenaming where
 
+instance NFData ModuleRenaming where rnf = genericRnf
+
 -- NB: parentheses are mandatory, because later we may extend this syntax
 -- to allow "hiding (A, B)" or other modifier words.
 instance Pretty ModuleRenaming where

--- a/Cabal/Distribution/Types/PackageDescription.hs
+++ b/Cabal/Distribution/Types/PackageDescription.hs
@@ -154,6 +154,8 @@ data PackageDescription
 
 instance Binary PackageDescription
 
+instance NFData PackageDescription where rnf = genericRnf
+
 instance Package PackageDescription where
   packageId = package
 

--- a/Cabal/Distribution/Types/SetupBuildInfo.hs
+++ b/Cabal/Distribution/Types/SetupBuildInfo.hs
@@ -29,6 +29,8 @@ data SetupBuildInfo = SetupBuildInfo
 
 instance Binary SetupBuildInfo
 
+instance NFData SetupBuildInfo where rnf = genericRnf
+
 instance Monoid SetupBuildInfo where
     mempty  = SetupBuildInfo [] False
     mappend = (<>)

--- a/Cabal/Distribution/Types/SourceRepo.hs
+++ b/Cabal/Distribution/Types/SourceRepo.hs
@@ -98,6 +98,8 @@ emptySourceRepo kind = SourceRepo
 
 instance Binary SourceRepo
 
+instance NFData SourceRepo where rnf = genericRnf
+
 -- | What this repo info is for, what it represents.
 --
 data RepoKind =
@@ -116,6 +118,8 @@ data RepoKind =
 
 instance Binary RepoKind
 
+instance NFData RepoKind where rnf = genericRnf
+
 -- | An enumeration of common source control systems. The fields used in the
 -- 'SourceRepo' depend on the type of repo. The tools and methods used to
 -- obtain and track the repo depend on the repo type.
@@ -126,6 +130,8 @@ data RepoType = Darcs | Git | SVN | CVS
   deriving (Eq, Generic, Ord, Read, Show, Typeable, Data)
 
 instance Binary RepoType
+
+instance NFData RepoType where rnf = genericRnf
 
 knownRepoTypes :: [RepoType]
 knownRepoTypes = [Darcs, Git, SVN, CVS

--- a/Cabal/Distribution/Types/TestSuite.hs
+++ b/Cabal/Distribution/Types/TestSuite.hs
@@ -35,6 +35,8 @@ instance L.HasBuildInfo TestSuite where
 
 instance Binary TestSuite
 
+instance NFData TestSuite where rnf = genericRnf
+
 instance Monoid TestSuite where
     mempty = TestSuite {
         testName      = mempty,

--- a/Cabal/Distribution/Types/TestSuiteInterface.hs
+++ b/Cabal/Distribution/Types/TestSuiteInterface.hs
@@ -40,6 +40,7 @@ data TestSuiteInterface =
 
 instance Binary TestSuiteInterface
 
+instance NFData TestSuiteInterface where rnf = genericRnf
 
 instance Monoid TestSuiteInterface where
     mempty  =  TestSuiteUnsupported (TestTypeUnknown mempty nullVersion)

--- a/Cabal/Distribution/Types/TestType.hs
+++ b/Cabal/Distribution/Types/TestType.hs
@@ -24,6 +24,8 @@ data TestType = TestTypeExe Version     -- ^ \"type: exitcode-stdio-x.y\"
 
 instance Binary TestType
 
+instance NFData TestType where rnf = genericRnf
+
 knownTestTypes :: [TestType]
 knownTestTypes = [ TestTypeExe (mkVersion [1,0])
                  , TestTypeLib (mkVersion [0,9]) ]

--- a/Cabal/Language/Haskell/Extension.hs
+++ b/Cabal/Language/Haskell/Extension.hs
@@ -62,6 +62,8 @@ data Language =
 
 instance Binary Language
 
+instance NFData Language where rnf = genericRnf
+
 knownLanguages :: [Language]
 knownLanguages = [Haskell98, Haskell2010]
 
@@ -115,6 +117,8 @@ data Extension =
   deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
 
 instance Binary Extension
+
+instance NFData Extension where rnf = genericRnf
 
 data KnownExtension =
 
@@ -808,6 +812,8 @@ data KnownExtension =
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable, Data)
 
 instance Binary KnownExtension
+
+instance NFData KnownExtension where rnf = genericRnf
 
 {-# DEPRECATED knownExtensions
    "KnownExtension is an instance of Enum and Bounded, use those instead. This symbol will be removed in Cabal-3.0 (est. Oct 2018)." #-}

--- a/Cabal/tests/UnitTests.hs
+++ b/Cabal/tests/UnitTests.hs
@@ -25,6 +25,7 @@ import qualified UnitTests.Distribution.Utils.NubList
 import qualified UnitTests.Distribution.Utils.ShortText
 import qualified UnitTests.Distribution.Version (versionTests)
 import qualified UnitTests.Distribution.SPDX (spdxTests)
+import qualified UnitTests.Distribution.Types.GenericPackageDescription
 
 tests :: Int -> TestTree
 tests mtimeChangeCalibrated =
@@ -54,6 +55,8 @@ tests mtimeChangeCalibrated =
         UnitTests.Distribution.Utils.ShortText.tests
     , testGroup "Distribution.System"
         UnitTests.Distribution.System.tests
+    , testGroup "Distribution.Types.GenericPackageDescription"
+        UnitTests.Distribution.Types.GenericPackageDescription.tests
     , testGroup "Distribution.Version"
         UnitTests.Distribution.Version.versionTests
     , testGroup "Distribution.SPDX"

--- a/Cabal/tests/UnitTests/Distribution/Types/GenericPackageDescription.hs
+++ b/Cabal/tests/UnitTests/Distribution/Types/GenericPackageDescription.hs
@@ -1,0 +1,37 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}   -- for importing "Distribution.Compat.Prelude.Internal"
+
+module UnitTests.Distribution.Types.GenericPackageDescription where
+
+import Prelude ()
+import Distribution.Compat.Prelude.Internal
+import Distribution.Types.GenericPackageDescription
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Control.Exception
+
+tests :: [TestTree]
+tests =
+  [ testCase "GenericPackageDescription deepseq" gpdDeepseq
+  ]
+
+gpdFields :: [(String, GenericPackageDescription -> GenericPackageDescription)]
+gpdFields =
+  [ ("packageDescription", \gpd -> gpd { packageDescription = undefined })
+  , ("genPackageFlags",    \gpd -> gpd { genPackageFlags    = undefined })
+  , ("condLibrary",        \gpd -> gpd { condLibrary        = undefined })
+  , ("condSubLibraries",   \gpd -> gpd { condSubLibraries   = undefined })
+  , ("condForeignLibs",    \gpd -> gpd { condForeignLibs    = undefined })
+  , ("condExecutables",    \gpd -> gpd { condExecutables    = undefined })
+  , ("condTestSuites",     \gpd -> gpd { condTestSuites     = undefined })
+  , ("condBenchmarks",     \gpd -> gpd { condBenchmarks     = undefined })
+  ]
+
+gpdDeepseq :: Assertion
+gpdDeepseq = sequence_
+  [ throwsUndefined msg (f emptyGenericPackageDescription) | (msg, f) <- gpdFields ]
+
+throwsUndefined :: NFData a => String -> a -> Assertion
+throwsUndefined field a =
+  catch (evaluate (rnf a) >> assertFailure ("Deepseq failed to evaluate " ++ show field))
+        (\(ErrorCall _) -> return ())

--- a/Cabal/tests/UnitTests/Distribution/Types/GenericPackageDescription.hs
+++ b/Cabal/tests/UnitTests/Distribution/Types/GenericPackageDescription.hs
@@ -8,7 +8,7 @@ import Distribution.Types.GenericPackageDescription
 
 import Test.Tasty
 import Test.Tasty.HUnit
-import Control.Exception
+import qualified Control.Exception as C
 
 tests :: [TestTree]
 tests =
@@ -33,5 +33,5 @@ gpdDeepseq = sequence_
 
 throwsUndefined :: NFData a => String -> a -> Assertion
 throwsUndefined field a =
-  catch (evaluate (rnf a) >> assertFailure ("Deepseq failed to evaluate " ++ show field))
-        (\(ErrorCall _) -> return ())
+  C.catch (C.evaluate (rnf a) >> assertFailure ("Deepseq failed to evaluate " ++ show field))
+          (\(C.ErrorCall _) -> return ())


### PR DESCRIPTION
Define NFData instance for GenericPackageDescription. GenericPackageDescription contains a whole lot of other types, each of which requires NFData instances, too. All the definitions rely on the respective Generic instance via `genericRnf`.

A unit test to verify that the NFData instance can find bottoms in GPD has been added.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.
