### PR TITLE
Change license :: License to Either SPDX.License License

### DIFF
--- a/Cabal/Distribution/License.hs
+++ b/Cabal/Distribution/License.hs
@@ -45,6 +45,8 @@
 module Distribution.License (
     License(..),
     knownLicenses,
+    licenseToSPDX,
+    licenseFromSPDX,
   ) where
 
 import Distribution.Compat.Prelude
@@ -56,7 +58,9 @@ import Distribution.Text
 import Distribution.Version
 
 import qualified Distribution.Compat.CharParsing as P
+import qualified Distribution.Compat.Map.Strict  as Map
 import qualified Distribution.Compat.ReadP       as Parse
+import qualified Distribution.SPDX               as SPDX
 import qualified Text.PrettyPrint                as Disp
 
 -- | Indicates the license under which a package's source code is released.
@@ -138,9 +142,79 @@ knownLicenses = [ GPL  unversioned, GPL  (version [2]),    GPL  (version [3])
                 , MPL (mkVersion [2, 0])
                 , Apache unversioned, Apache (version [2, 0])
                 , PublicDomain, AllRightsReserved, OtherLicense]
- where
-   unversioned = Nothing
-   version     = Just . mkVersion
+  where
+    unversioned = Nothing
+    version     = Just . mkVersion
+
+-- | Convert old 'License' to SPDX 'SPDX.License'.
+-- Non-SPDX licenses are converted to 'SPDX.LicenseRef'.
+--
+-- @since 2.2.0.0
+licenseToSPDX :: License -> SPDX.License
+licenseToSPDX l = case l of
+    GPL v | v == version [2]      -> spdx SPDX.GPL_2_0
+    GPL v | v == version [3]      -> spdx SPDX.GPL_3_0
+    LGPL v | v == version [2,1]   -> spdx SPDX.LGPL_2_1
+    LGPL v | v == version [3]     -> spdx SPDX.LGPL_3_0
+    AGPL v | v == version [3]     -> spdx SPDX.AGPL_3_0
+    BSD2                          -> spdx SPDX.BSD_2_Clause
+    BSD3                          -> spdx SPDX.BSD_3_Clause
+    BSD4                          -> spdx SPDX.BSD_4_Clause
+    MIT                           -> spdx SPDX.MIT
+    ISC                           -> spdx SPDX.ISC
+    MPL v | v == mkVersion [2,0]  -> spdx SPDX.MPL_2_0
+    Apache v | v == version [2,0] -> spdx SPDX.Apache_2_0
+    AllRightsReserved             -> SPDX.NONE
+    UnspecifiedLicense            -> SPDX.NONE
+    OtherLicense                  -> ref (SPDX.mkLicenseRef' Nothing "OtherLicense")
+    PublicDomain                  -> ref (SPDX.mkLicenseRef' Nothing "PublicDomain")
+    UnknownLicense str            -> ref (SPDX.mkLicenseRef' Nothing str)
+    _                             -> ref (SPDX.mkLicenseRef' Nothing $ prettyShow l)
+  where
+    version = Just . mkVersion
+    spdx    = SPDX.License . SPDX.simpleLicenseExpression
+    ref  r  = SPDX.License $ SPDX.ELicense (SPDX.ELicenseRef r) Nothing
+
+-- | Convert 'SPDX.License' to 'License',
+--
+-- This is lossy conversion. We try our best.
+--
+-- >>> licenseFromSPDX . licenseToSPDX $ BSD3
+-- BSD3
+--
+-- >>> licenseFromSPDX . licenseToSPDX $ GPL (Just (mkVersion [3]))
+-- GPL (Just (mkVersion [3]))
+--
+-- >>> licenseFromSPDX . licenseToSPDX $ PublicDomain
+-- UnknownLicense "LicenseRefPublicDomain"
+--
+-- >>> licenseFromSPDX $ SPDX.License $ SPDX.simpleLicenseExpression SPDX.EUPL_1_1
+-- UnknownLicense "EUPL-1.1"
+--
+-- >>> licenseFromSPDX . licenseToSPDX $ AllRightsReserved
+-- AllRightsReserved
+--
+-- >>> licenseFromSPDX <$> simpleParsec "BSD-3-Clause OR GPL-3.0"
+-- Just (UnknownLicense "BSD3ClauseORGPL30")
+--
+-- @since 2.2.0.0
+licenseFromSPDX :: SPDX.License -> License
+licenseFromSPDX SPDX.NONE = AllRightsReserved
+licenseFromSPDX l =
+    fromMaybe (mungle $ prettyShow l) $ Map.lookup l m
+  where
+    m :: Map.Map SPDX.License License
+    m = Map.fromList $ filter (isSimple . fst ) $
+        map (\x -> (licenseToSPDX x, x)) knownLicenses
+
+    isSimple (SPDX.License (SPDX.ELicense (SPDX.ELicenseId _) Nothing)) = True
+    isSimple _ = False
+
+    mungle name = fromMaybe (UnknownLicense (mapMaybe mangle name)) (simpleParsec name)
+
+    mangle c
+        | isAlphaNum c = Just c
+        | otherwise = Nothing
 
 instance Pretty License where
   pretty (GPL  version)         = Disp.text "GPL"    <<>> dispOptVersion version

--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveGeneric #-}
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.PackageDescription
@@ -19,6 +16,7 @@ module Distribution.PackageDescription (
         emptyPackageDescription,
         specVersion,
         buildType,
+        license,
         descCabalVersion,
         BuildType(..),
         knownBuildTypes,

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -45,7 +45,6 @@ import Prelude ()
 
 import Distribution.Compiler                  (CompilerFlavor (..))
 import Distribution.FieldGrammar
-import Distribution.License                   (License (..))
 import Distribution.ModuleName                (ModuleName)
 import Distribution.Package
 import Distribution.PackageDescription
@@ -57,6 +56,8 @@ import Distribution.Types.ForeignLib
 import Distribution.Types.ForeignLibType
 import Distribution.Types.UnqualComponentName
 import Distribution.Version                   (anyVersion)
+
+import qualified Distribution.SPDX as SPDX
 
 import qualified Distribution.Types.Lens as L
 
@@ -70,7 +71,7 @@ packageDescriptionFieldGrammar
 packageDescriptionFieldGrammar = PackageDescription
     <$> optionalFieldDefAla "cabal-version" SpecVersion                L.specVersionRaw (Right anyVersion)
     <*> blurFieldGrammar L.package packageIdentifierGrammar
-    <*> optionalFieldDef    "license"                                  L.license UnspecifiedLicense
+    <*> optionalFieldDefAla "license"       SpecLicense                L.licenseRaw (Left SPDX.NONE)
     <*> licenseFilesGrammar
     <*> optionalFieldDefAla "copyright"     FreeText                   L.copyright ""
     <*> optionalFieldDefAla "maintainer"    FreeText                   L.maintainer ""

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -99,8 +99,9 @@ pkgDescrFieldDescrs =
            (maybe mempty disp)  (fmap Just parse)
            buildTypeRaw           (\t pkg -> pkg{buildTypeRaw=t})
  , simpleField "license"
-           disp                   parseLicenseQ
-           license                (\l pkg -> pkg{license=l})
+           (either (error "pretty spdx expr") disp)
+                                  (fmap Right parseLicenseQ)
+           licenseRaw             (\l pkg -> pkg{licenseRaw=l})
    -- We have both 'license-file' and 'license-files' fields.
    -- Rather than declaring license-file to be deprecated, we will continue
    -- to allow both. The 'license-file' will continue to only allow single

--- a/Cabal/Distribution/SPDX.hs
+++ b/Cabal/Distribution/SPDX.hs
@@ -6,8 +6,8 @@ module Distribution.SPDX (
     License (..),
     -- * License expression
     LicenseExpression (..),
+    SimpleLicenseExpression (..),
     simpleLicenseExpression,
-    OnlyOrAnyLater (..),
     -- * License identifier
     LicenseId (..),
     licenseId,
@@ -25,7 +25,6 @@ module Distribution.SPDX (
     licenseDocumentRef,
     mkLicenseRef,
     mkLicenseRef',
-    unsafeMkLicenseRef,
     ) where
 
 import Distribution.SPDX.LicenseExceptionId

--- a/Cabal/Distribution/SPDX/License.hs
+++ b/Cabal/Distribution/SPDX/License.hs
@@ -41,7 +41,7 @@ data License
       -- ^ if the package contains no license information whatsoever; or
     | License LicenseExpression
       -- ^ A valid SPDX License Expression as defined in Appendix IV.
-  deriving (Show, Read, Eq, Typeable, Data, Generic)
+  deriving (Show, Read, Eq, Ord, Typeable, Data, Generic)
 
 instance Binary License
 

--- a/Cabal/Distribution/SPDX/LicenseReference.hs
+++ b/Cabal/Distribution/SPDX/LicenseReference.hs
@@ -6,7 +6,6 @@ module Distribution.SPDX.LicenseReference (
     licenseDocumentRef,
     mkLicenseRef,
     mkLicenseRef',
-    unsafeMkLicenseRef,
     ) where
 
 import Prelude ()
@@ -24,7 +23,7 @@ data LicenseRef = LicenseRef
     { _lrDocument :: !(Maybe String)
     , _lrLicense  :: !String
     }
-  deriving (Show, Read, Eq, Typeable, Data, Generic)
+  deriving (Show, Read, Eq, Ord, Typeable, Data, Generic)
 
 -- | License reference.
 licenseRef :: LicenseRef -> String
@@ -78,9 +77,3 @@ mkLicenseRef' d l = LicenseRef (fmap f d) (f l)
     f = map g
     g c | isAsciiAlphaNum c || c == '-' || c == '.' = c
         | otherwise                                 = '-'
-
--- | Unsafe 'mkLicenseRef'. Consider using 'mkLicenseRef''.
-unsafeMkLicenseRef :: Maybe String -> String -> LicenseRef
-unsafeMkLicenseRef d l = case mkLicenseRef d l of
-    Nothing -> error $ "unsafeMkLicenseRef: panic" ++ show (d, l)
-    Just x  -> x

--- a/Cabal/Distribution/Simple/GHC/IPIConvert.hs
+++ b/Cabal/Distribution/Simple/GHC/IPIConvert.hs
@@ -20,6 +20,7 @@ import Distribution.Compat.Prelude
 import qualified Distribution.Types.PackageId as Current
 import qualified Distribution.Types.PackageName as Current
 import qualified Distribution.License as Current
+import qualified Distribution.SPDX as SPDX
 
 import Distribution.Version
 import Distribution.ModuleName
@@ -44,11 +45,11 @@ data License = GPL | LGPL | BSD3 | BSD4
 convertModuleName :: String -> ModuleName
 convertModuleName s = fromMaybe (error "convertModuleName") $ simpleParse s
 
-convertLicense :: License -> Current.License
-convertLicense GPL  = Current.GPL  Nothing
-convertLicense LGPL = Current.LGPL Nothing
-convertLicense BSD3 = Current.BSD3
-convertLicense BSD4 = Current.BSD4
-convertLicense PublicDomain = Current.PublicDomain
-convertLicense AllRightsReserved = Current.AllRightsReserved
-convertLicense OtherLicense = Current.OtherLicense
+convertLicense :: License -> Either SPDX.License Current.License
+convertLicense GPL               = Right $ Current.GPL  Nothing
+convertLicense LGPL              = Right $ Current.LGPL Nothing
+convertLicense BSD3              = Right $ Current.BSD3
+convertLicense BSD4              = Right $ Current.BSD4
+convertLicense PublicDomain      = Right $ Current.PublicDomain
+convertLicense AllRightsReserved = Right $ Current.AllRightsReserved
+convertLicense OtherLicense      = Right $ Current.OtherLicense

--- a/Cabal/Distribution/Types/AbiDependency.hs
+++ b/Cabal/Distribution/Types/AbiDependency.hs
@@ -49,4 +49,4 @@ instance Text AbiDependency where
 
 instance Binary AbiDependency
 
-
+instance NFData AbiDependency where rnf = genericRnf

--- a/Cabal/Distribution/Types/AbiHash.hs
+++ b/Cabal/Distribution/Types/AbiHash.hs
@@ -54,6 +54,8 @@ instance IsString AbiHash where
 
 instance Binary AbiHash
 
+instance NFData AbiHash where rnf = genericRnf
+
 instance Pretty AbiHash where
     pretty = text . unAbiHash
 

--- a/Cabal/Distribution/Types/ExposedModule.hs
+++ b/Cabal/Distribution/Types/ExposedModule.hs
@@ -53,3 +53,5 @@ instance Text ExposedModule where
         return (ExposedModule m reexport)
 
 instance Binary ExposedModule
+
+instance NFData ExposedModule where rnf = genericRnf

--- a/Cabal/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/Types/InstalledPackageInfo.hs
@@ -26,6 +26,7 @@ import Distribution.Types.UnqualComponentName
 import Distribution.Version                   (nullVersion)
 
 import qualified Distribution.Package as Package
+import qualified Distribution.SPDX    as SPDX
 
 -- -----------------------------------------------------------------------------
 -- The InstalledPackageInfo type
@@ -46,7 +47,7 @@ data InstalledPackageInfo
         -- with the same ModuleName as the key.
         instantiatedWith  :: [(ModuleName, OpenModule)],
         compatPackageKey  :: String,
-        license           :: License,
+        license           :: Either SPDX.License License,
         copyright         :: String,
         maintainer        :: String,
         author            :: String,
@@ -90,6 +91,8 @@ data InstalledPackageInfo
 
 instance Binary InstalledPackageInfo
 
+instance NFData InstalledPackageInfo where rnf = genericRnf
+
 instance Package.HasMungedPackageId InstalledPackageInfo where
    mungedId = mungedPackageId
 
@@ -128,7 +131,7 @@ emptyInstalledPackageInfo
         installedUnitId   = mkUnitId "",
         instantiatedWith  = [],
         compatPackageKey  = "",
-        license           = UnspecifiedLicense,
+        license           = Left SPDX.NONE,
         copyright         = "",
         maintainer        = "",
         author            = "",

--- a/Cabal/Distribution/Types/InstalledPackageInfo/Lens.hs
+++ b/Cabal/Distribution/Types/InstalledPackageInfo/Lens.hs
@@ -14,6 +14,7 @@ import Distribution.Package                    (AbiHash, ComponentId, PackageIde
 import Distribution.Types.InstalledPackageInfo (AbiDependency, ExposedModule, InstalledPackageInfo)
 import Distribution.Types.UnqualComponentName  (UnqualComponentName)
 
+import qualified Distribution.SPDX                       as SPDX
 import qualified Distribution.Types.InstalledPackageInfo as T
 
 sourcePackageId :: Lens' InstalledPackageInfo PackageIdentifier
@@ -40,7 +41,7 @@ compatPackageKey :: Lens' InstalledPackageInfo String
 compatPackageKey f s = fmap (\x -> s { T.compatPackageKey = x }) (f (T.compatPackageKey s))
 {-# INLINE compatPackageKey #-}
 
-license :: Lens' InstalledPackageInfo License
+license :: Lens' InstalledPackageInfo (Either SPDX.License License)
 license f s = fmap (\x -> s { T.license = x }) (f (T.license s))
 {-# INLINE license #-}
 

--- a/Cabal/Distribution/Types/PackageDescription/Lens.hs
+++ b/Cabal/Distribution/Types/PackageDescription/Lens.hs
@@ -3,9 +3,9 @@ module Distribution.Types.PackageDescription.Lens (
     module Distribution.Types.PackageDescription.Lens,
     ) where
 
-import Prelude ()
-import Distribution.Compat.Prelude
 import Distribution.Compat.Lens
+import Distribution.Compat.Prelude
+import Prelude ()
 
 import Distribution.Compiler                 (CompilerFlavor)
 import Distribution.License                  (License)
@@ -22,15 +22,16 @@ import Distribution.Types.SourceRepo         (SourceRepo)
 import Distribution.Types.TestSuite          (TestSuite)
 import Distribution.Version                  (Version, VersionRange)
 
+import qualified Distribution.SPDX                     as SPDX
 import qualified Distribution.Types.PackageDescription as T
 
 package :: Lens' PackageDescription PackageIdentifier
 package f s = fmap (\x -> s { T.package = x }) (f (T.package s))
 {-# INLINE package #-}
 
-license :: Lens' PackageDescription License
-license f s = fmap (\x -> s { T.license = x }) (f (T.license s))
-{-# INLINE license #-}
+licenseRaw :: Lens' PackageDescription (Either SPDX.License License)
+licenseRaw f s = fmap (\x -> s { T.licenseRaw = x }) (f (T.licenseRaw s))
+{-# INLINE licenseRaw #-}
 
 licenseFiles :: Lens' PackageDescription [String]
 licenseFiles f s = fmap (\x -> s { T.licenseFiles = x }) (f (T.licenseFiles s))

--- a/Cabal/tests/Instances/TreeDiff.hs
+++ b/Cabal/tests/Instances/TreeDiff.hs
@@ -40,7 +40,6 @@ import Distribution.Types.UnqualComponentName
 -- instances
 -------------------------------------------------------------------------------
 
-
 instance (Eq a, Show a) => ToExpr (Condition a) where toExpr = defaultExprViaShow
 instance (Show a, ToExpr b, ToExpr c, Show b, Show c, Eq a, Eq c, Eq b) => ToExpr (CondTree a b c)
 instance (Show a, ToExpr b, ToExpr c, Show b, Show c, Eq a, Eq c, Eq b) => ToExpr (CondBranch a b c)

--- a/Cabal/tests/Instances/TreeDiff/SPDX.hs
+++ b/Cabal/tests/Instances/TreeDiff/SPDX.hs
@@ -12,6 +12,17 @@ import Distribution.License (License)
 
 import Instances.TreeDiff.Version ()
 
+import qualified Distribution.SPDX as SPDX
+
 -- 'License' almost belongs here.
 
 instance ToExpr License
+
+-- Generics instance is too heavy
+instance ToExpr SPDX.LicenseId where toExpr = defaultExprViaShow
+instance ToExpr SPDX.LicenseExceptionId where toExpr = defaultExprViaShow
+
+instance ToExpr SPDX.License
+instance ToExpr SPDX.LicenseExpression
+instance ToExpr SPDX.LicenseRef
+instance ToExpr SPDX.SimpleLicenseExpression

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -13,7 +13,6 @@ import Test.Tasty.HUnit
 import Control.Monad                               (void)
 import Data.Algorithm.Diff                         (Diff (..), getGroupedDiff)
 import Data.Maybe                                  (isNothing)
-import Distribution.License                        (License (..))
 import Distribution.PackageDescription             (GenericPackageDescription)
 import Distribution.PackageDescription.Parsec      (parseGenericPackageDescription)
 import Distribution.PackageDescription.PrettyPrint (showGenericPackageDescription)
@@ -24,10 +23,6 @@ import System.FilePath                             (replaceExtension, (</>))
 
 import qualified Data.ByteString       as BS
 import qualified Data.ByteString.Char8 as BS8
-
-import           Distribution.Compat.Lens
-import qualified Distribution.Types.GenericPackageDescription.Lens as L
-import qualified Distribution.Types.PackageDescription.Lens        as L
 
 import qualified Distribution.InstalledPackageInfo as IPI
 import qualified Distribution.ParseUtils           as ReadP
@@ -187,12 +182,8 @@ formatRoundTripTest fp = testCase "roundtrip" $ do
     x <- parse contents
     let contents' = showGenericPackageDescription x
     y <- parse (toUTF8BS contents')
-    -- 'License' type doesn't support parse . pretty roundrip (yet).
-    -- Will be fixed when we refactor to SPDX
-    let y' = if x ^. L.packageDescription . L.license == UnspecifiedLicense
-                && y ^. L.packageDescription . L.license == UnknownLicense "UnspecifiedLicense"
-             then y & L.packageDescription . L.license .~ UnspecifiedLicense
-             else y
+    -- previously we mangled licenses a bit
+    let y' = y
     assertEqual "re-parsed doesn't match" x y'
   where
     parse :: BS.ByteString -> IO GenericPackageDescription

--- a/Cabal/tests/ParserTests/ipi/Includes2.expr
+++ b/Cabal/tests/ParserTests/ipi/Includes2.expr
@@ -37,7 +37,7 @@ InstalledPackageInfo
    ldOptions = [],
    libraryDirs = ["/home/travis/build/haskell/cabal/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.dist/work/./dist/build/x86_64-linux/ghc-8.2.2/Includes2-0.1.0.0/l/mylib/Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n/build/Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n"],
    libraryDynDirs = ["/home/travis/build/haskell/cabal/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.dist/work/./dist/build/x86_64-linux/ghc-8.2.2/Includes2-0.1.0.0/l/mylib/Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n/build/Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n"],
-   license = BSD3,
+   license = Right BSD3,
    maintainer = "ezyang@cs.stanford.edu",
    pkgRoot = Nothing,
    pkgUrl = "",

--- a/Cabal/tests/ParserTests/ipi/internal-preprocessor-test.expr
+++ b/Cabal/tests/ParserTests/ipi/internal-preprocessor-test.expr
@@ -31,7 +31,7 @@ InstalledPackageInfo
    libraryDirs = ["/home/ogre/Documents/other-haskell/cabal/cabal-testsuite/PackageTests/CustomPreProcess/setup.dist/work/dist/build",
                   "/home/ogre/Documents/other-haskell/cabal/cabal-testsuite/PackageTests/CustomPreProcess/setup.dist/work/dist/build"],
    libraryDynDirs = [],
-   license = GPL (Just `mkVersion [3]`),
+   license = Right (GPL (Just `mkVersion [3]`)),
    maintainer = "mikhail.glushenkov@gmail.com",
    pkgRoot = Just
                "/home/ogre/Documents/other-haskell/cabal/cabal-testsuite/PackageTests/CustomPreProcess/setup.dist/work/dist",

--- a/Cabal/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
+++ b/Cabal/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
@@ -2072,7 +2072,7 @@ InstalledPackageInfo
                 "-lm"],
    libraryDirs = ["/opt/ghc/8.2.2/lib/ghc-8.2.2/transformers-0.5.2.0"],
    libraryDynDirs = ["/opt/ghc/8.2.2/lib/ghc-8.2.2/transformers-0.5.2.0"],
-   license = BSD3,
+   license = Right BSD3,
    maintainer = "Ross Paterson <R.Paterson@city.ac.uk>",
    pkgRoot = Nothing,
    pkgUrl = "",

--- a/Cabal/tests/ParserTests/ipi/transformers.expr
+++ b/Cabal/tests/ParserTests/ipi/transformers.expr
@@ -72,7 +72,7 @@ InstalledPackageInfo
    ldOptions = [],
    libraryDirs = ["/opt/ghc/8.2.2/lib/ghc-8.2.2/transformers-0.5.2.0"],
    libraryDynDirs = ["/opt/ghc/8.2.2/lib/ghc-8.2.2/transformers-0.5.2.0"],
-   license = BSD3,
+   license = Right BSD3,
    maintainer = "Ross Paterson <R.Paterson@city.ac.uk>",
    pkgRoot = Just "/opt/ghc/8.2.2/lib/ghc-8.2.2",
    pkgUrl = "",

--- a/Cabal/tests/ParserTests/regressions/Octree-0.5.expr
+++ b/Cabal/tests/ParserTests/regressions/Octree-0.5.expr
@@ -259,8 +259,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "https://github.com/mgajda/octree",
                            library = Nothing,
-                           license = BSD3,
                            licenseFiles = ["LICENSE"],
+                           licenseRaw = Right BSD3,
                            maintainer = "mjgajda@googlemail.com",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "Octree"`,

--- a/Cabal/tests/ParserTests/regressions/common.expr
+++ b/Cabal/tests/ParserTests/regressions/common.expr
@@ -132,8 +132,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "",
                            library = Nothing,
-                           license = UnspecifiedLicense,
                            licenseFiles = [],
+                           licenseRaw = Left NONE,
                            maintainer = "",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "common"`,

--- a/Cabal/tests/ParserTests/regressions/common2.expr
+++ b/Cabal/tests/ParserTests/regressions/common2.expr
@@ -388,8 +388,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "",
                            library = Nothing,
-                           license = UnspecifiedLicense,
                            licenseFiles = [],
+                           licenseRaw = Left NONE,
                            maintainer = "",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "common"`,

--- a/Cabal/tests/ParserTests/regressions/elif.expr
+++ b/Cabal/tests/ParserTests/regressions/elif.expr
@@ -133,8 +133,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "",
                            library = Nothing,
-                           license = UnspecifiedLicense,
                            licenseFiles = [],
+                           licenseRaw = Left NONE,
                            maintainer = "",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "elif"`,

--- a/Cabal/tests/ParserTests/regressions/elif2.expr
+++ b/Cabal/tests/ParserTests/regressions/elif2.expr
@@ -292,8 +292,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "",
                            library = Nothing,
-                           license = UnspecifiedLicense,
                            licenseFiles = [],
+                           licenseRaw = Left NONE,
                            maintainer = "",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "elif"`,

--- a/Cabal/tests/ParserTests/regressions/encoding-0.8.expr
+++ b/Cabal/tests/ParserTests/regressions/encoding-0.8.expr
@@ -94,8 +94,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "",
                            library = Nothing,
-                           license = UnspecifiedLicense,
                            licenseFiles = [],
+                           licenseRaw = Left NONE,
                            maintainer = "",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "encoding"`,

--- a/Cabal/tests/ParserTests/regressions/generics-sop.expr
+++ b/Cabal/tests/ParserTests/regressions/generics-sop.expr
@@ -595,8 +595,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "",
                            library = Nothing,
-                           license = BSD3,
                            licenseFiles = ["LICENSE"],
+                           licenseRaw = Right BSD3,
                            maintainer = "andres@well-typed.com",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "generics-sop"`,

--- a/Cabal/tests/ParserTests/regressions/issue-774.check
+++ b/Cabal/tests/ParserTests/regressions/issue-774.check
@@ -1,6 +1,6 @@
 No 'category' field.
 No 'maintainer' field.
-The 'license' field is missing.
+The 'license' field is missing or is NONE.
 'ghc-options: -threaded' has no effect for libraries. It should only be used for executables.
 'ghc-options: -rtsopts' has no effect for libraries. It should only be used for executables.
 'ghc-options: -with-rtsopts' has no effect for libraries. It should only be used for executables.

--- a/Cabal/tests/ParserTests/regressions/issue-774.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-774.expr
@@ -88,8 +88,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "",
                            library = Nothing,
-                           license = UnspecifiedLicense,
                            licenseFiles = [],
+                           licenseRaw = Left NONE,
                            maintainer = "",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "issue"`,

--- a/Cabal/tests/ParserTests/regressions/leading-comma.expr
+++ b/Cabal/tests/ParserTests/regressions/leading-comma.expr
@@ -98,8 +98,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "",
                            library = Nothing,
-                           license = UnspecifiedLicense,
                            licenseFiles = [],
+                           licenseRaw = Left NONE,
                            maintainer = "",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "leading-comma"`,

--- a/Cabal/tests/ParserTests/regressions/nothing-unicode.check
+++ b/Cabal/tests/ParserTests/regressions/nothing-unicode.check
@@ -1,6 +1,6 @@
 No 'category' field.
 No 'maintainer' field.
 No 'description' field.
-The 'license' field is missing.
+The 'license' field is missing or is NONE.
 Suspicious flag names: 無. To avoid ambiguity in command line interfaces, flag shouldn't start with a dash. Also for better compatibility, flag names shouldn't contain non-ascii characters.
 Non ascii custom fields: x-無. For better compatibility, custom field names shouldn't contain non-ascii characters.

--- a/Cabal/tests/ParserTests/regressions/nothing-unicode.expr
+++ b/Cabal/tests/ParserTests/regressions/nothing-unicode.expr
@@ -133,8 +133,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "",
                            library = Nothing,
-                           license = UnspecifiedLicense,
                            licenseFiles = [],
+                           licenseRaw = Left NONE,
                            maintainer = "",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "\\28961"`,

--- a/Cabal/tests/ParserTests/regressions/shake.expr
+++ b/Cabal/tests/ParserTests/regressions/shake.expr
@@ -1692,8 +1692,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "http://shakebuild.com",
                            library = Nothing,
-                           license = BSD3,
                            licenseFiles = ["LICENSE"],
+                           licenseRaw = Right BSD3,
                            maintainer = "Neil Mitchell <ndmitchell@gmail.com>",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "shake"`,

--- a/Cabal/tests/ParserTests/regressions/th-lift-instances.expr
+++ b/Cabal/tests/ParserTests/regressions/th-lift-instances.expr
@@ -407,8 +407,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "http://github.com/bennofs/th-lift-instances/",
                            library = Nothing,
-                           license = BSD3,
                            licenseFiles = ["LICENSE"],
+                           licenseRaw = Right BSD3,
                            maintainer = "Benno F\252nfst\252ck <benno.fuenfstueck@gmail.com>",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "th-lift-instances"`,

--- a/Cabal/tests/ParserTests/regressions/wl-pprint-indef.expr
+++ b/Cabal/tests/ParserTests/regressions/wl-pprint-indef.expr
@@ -158,8 +158,8 @@ GenericPackageDescription
                            foreignLibs = [],
                            homepage = "",
                            library = Nothing,
-                           license = BSD3,
                            licenseFiles = ["LICENSE"],
+                           licenseRaw = Right BSD3,
                            maintainer = "Noam Lewis <jones.noamle@gmail.com>",
                            package = PackageIdentifier
                                        {pkgName = `PackageName "wl-pprint-indef"`,

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -349,7 +349,7 @@ exAvSrcPkg ex =
                 C.packageDescription = C.emptyPackageDescription {
                     C.package        = pkgId
                   , C.setupBuildInfo = setup
-                  , C.license = BSD3
+                  , C.licenseRaw = Right BSD3
                   , C.buildTypeRaw = if isNothing setup
                                      then Just C.Simple
                                      else Just C.Custom

--- a/cabal-testsuite/PackageTests/COnlyMain/my.cabal
+++ b/cabal-testsuite/PackageTests/COnlyMain/my.cabal
@@ -1,7 +1,7 @@
 cabal-version:  2.1
 name:           my
 version:        0.1
-license:        BSD3
+license:        BSD-3-Clause
 build-type:     Simple
 
 executable foo

--- a/cabal-testsuite/PackageTests/SPDX/M.hs
+++ b/cabal-testsuite/PackageTests/SPDX/M.hs
@@ -1,0 +1,1 @@
+module M where

--- a/cabal-testsuite/PackageTests/SPDX/Setup.hs
+++ b/cabal-testsuite/PackageTests/SPDX/Setup.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = fail "Setup called despite `build-type:Simple`"

--- a/cabal-testsuite/PackageTests/SPDX/cabal-old-build.cabal.out
+++ b/cabal-testsuite/PackageTests/SPDX/cabal-old-build.cabal.out
@@ -1,0 +1,10 @@
+# Setup configure
+Resolving dependencies...
+Configuring my-0...
+# Setup build
+Preprocessing library for my-0..
+Building library for my-0..
+# Setup copy
+Installing library in <PATH>
+# Setup register
+Registering library for my-0..

--- a/cabal-testsuite/PackageTests/SPDX/cabal-old-build.out
+++ b/cabal-testsuite/PackageTests/SPDX/cabal-old-build.out
@@ -1,0 +1,9 @@
+# Setup configure
+Configuring my-0...
+# Setup build
+Preprocessing library for my-0..
+Building library for my-0..
+# Setup copy
+Installing library in <PATH>
+# Setup register
+Registering library for my-0..

--- a/cabal-testsuite/PackageTests/SPDX/cabal-old-build.test.hs
+++ b/cabal-testsuite/PackageTests/SPDX/cabal-old-build.test.hs
@@ -1,0 +1,10 @@
+import Test.Cabal.Prelude
+main = setupAndCabalTest $ withPackageDb $ do
+    -- skip for GHC-8.4 and GHC-head until their Cabal modules are updated.
+    skipUnless =<< ghcVersionIs (< mkVersion [8,3])
+
+    setup_install []
+    recordMode DoNotRecord $ do
+        ghc84 <- ghcVersionIs (>= mkVersion [8,4])
+        let lic = if ghc84 then "BSD-3-Clause" else "BSD3"
+        ghcPkg' "field" ["my", "license"] >>= assertOutputContains lic

--- a/cabal-testsuite/PackageTests/SPDX/cabal.project
+++ b/cabal-testsuite/PackageTests/SPDX/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/SPDX/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/SPDX/cabal.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+main = cabalTest $ do
+    recordMode DoNotRecord $ do
+        -- TODO: Hack; see also CustomDep/cabal.test.hs
+        withEnvFilter (/= "HOME") $ do
+            cabal "new-build" ["all"]

--- a/cabal-testsuite/PackageTests/SPDX/my.cabal
+++ b/cabal-testsuite/PackageTests/SPDX/my.cabal
@@ -1,0 +1,10 @@
+cabal-version:       2.1
+name:                my
+version:             0
+build-type:          Simple
+license:             BSD-3-Clause
+
+library
+  exposed-modules:     M
+  build-depends:       base
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/cabal-with-hpc.multitest.hs
+++ b/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/cabal-with-hpc.multitest.hs
@@ -1,7 +1,7 @@
 import qualified Control.Exception as E (IOException, catch)
 import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Reader (ask)
+import Control.Monad.Trans.Reader (ask)
 import Data.Maybe (catMaybes)
 
 import qualified Distribution.Verbosity as Verbosity


### PR DESCRIPTION
~WIP: [ci skip] Have to fix cabal-tests and check that we don't break
older (i.e all) ghc-pkgs~

Resolves #2547

I introduce SimpleLicenseExpression to make "OrAnyLater LicenseRef"
unrepresentable. That also simplifies types.

license field is parsed as old License when cabal-version <2.2,
and as SPDX expression otherwise. NONE is recognised.

There are also IPI changes, there both old and SPDX license expressions
are accepted, as both can occur in package database.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
