### PR TITLE
Fix stack configuration and improve travis stack setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,15 +85,13 @@ matrix:
    - env: GHCVER=8.0.2 SCRIPT=bootstrap
      os: osx
 
-   - env: GHCVER=via-stack SCRIPT=stack STACKAGE_RESOLVER=lts
+   - env: GHCVER=via-stack SCRIPT=stack STACK_CONFIG=stack.yaml
      os: linux
-     addons:
-        apt:
-            packages:
-                - libgmp-dev
 
+   # See https://github.com/haskell/cabal/pull/4667#issuecomment-321036564
+   # for why failures are allowed.
   allow_failures:
-   - env: GHCVER=via-stack SCRIPT=stack STACKAGE_RESOLVER=lts
+   - env: GHCVER=via-stack SCRIPT=stack STACK_CONFIG=stack.yaml
 
  # TODO add PARSEC_BUNDLED=YES when it's so
  # It seems pointless to run head if we're going to ignore the results.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,11 @@
-resolver: nightly-2017-11-01
+resolver: nightly-2018-01-17
 packages:
 - Cabal/
 - cabal-install/
 - cabal-testsuite/
 extra-deps:
   - resolv-0.1.1.1
+  - QuickCheck-2.11.3
 nix:
   packages:
   - autoconf

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -9,7 +9,7 @@ if [ "$GHCVER" = "none" ]; then
     travis_retry sudo apt-get install --force-yes ghc-$GHCVER
 fi
 
-if [ -z ${STACKAGE_RESOLVER+x} ]; then
+if [ -z ${STACK_CONFIG+x} ]; then
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then
         travis_retry sudo add-apt-repository -y ppa:hvr/ghc
         travis_retry sudo apt-get update
@@ -73,7 +73,7 @@ else # Stack-based builds
     mkdir -p ~/.local/bin
     travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 \
         | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-    stack setup --resolver "$STACKAGE_RESOLVER"
+    stack setup --stack-yaml "$STACK_CONFIG"
 
 fi
 

--- a/travis-stack.sh
+++ b/travis-stack.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-if [ -z ${STACKAGE_RESOLVER+x} ]; then
-    echo "STACKAGE_RESOLVER environment variable not set."
+if [ -z ${STACK_CONFIG+x} ]; then
+    echo "STACK_CONFIG environment variable not set."
     echo "This build case is not configured correctly."
     exit 1
 fi
@@ -14,4 +14,6 @@ fi
 
 stack build \
     --no-terminal \
-    --resolver "$STACKAGE_RESOLVER"
+    --stack-yaml "$STACK_CONFIG" \
+    --test \
+    --bench --no-run-benchmarks


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested by running `stack build --test` in the repo.  Travis changes not yet tested, we'll see once it checks this PR.  Previously it would immediately yield the following error:

```
Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for Cabal-2.1.0.0:
    QuickCheck-2.10.1 from stack configuration does not match >=2.11.3 && <2.12 (latest matching
                      version is 2.11.3)
    tree-diff must match >=0.0.1 && <0.1, but the stack configuration has no specified version
              (latest matching version is 0.0.1)
needed since Cabal is a build target.

Some different approaches to resolving this:

  * Consider trying 'stack solver', which uses the cabal-install solver to attempt to find some
    working build configuration. This can be convenient when dealing with many complicated
    constraint errors, but results may be unpredictable.

  * Recommended action: try adding the following to your extra-deps
    in /home/mgsloan/fpco/stack/cabal/stack.yaml:

- QuickCheck-2.11.3
- tree-diff-0.0.1

Plan construction failed.
```