### PR TITLE
Make Paths_ autogen module work with default-extensions (stack 3789)

### DIFF
--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -59,6 +59,9 @@
 	* Removed support for building cabal-install with GHC < 7.10 (#4870).
 	* New 'all-packages' section in 'cabal.project' files that applies
 	options to all packages, not just those local to the project.
+	* Paths_ autogen modules now compile when `RebindableSyntax` or
+	`OverloadedStrings` is used in `default-extensions`.
+	[stack#3789](https://github.com/commercialhaskell/stack/issues/3789)
 
 2.0.0.1 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> December 2017
 	* Support for GHC's numeric -g debug levels (#4673).

--- a/cabal-testsuite/PackageTests/PathsModule/Library/my.cabal
+++ b/cabal-testsuite/PackageTests/PathsModule/Library/my.cabal
@@ -5,7 +5,7 @@ author: Johan Tibell
 stability: stable
 category: PackageTests
 build-type: Simple
-Cabal-version: >= 1.2
+Cabal-version: >= 1.10
 
 description:
     Check that the generated paths module compiles.
@@ -13,3 +13,22 @@ description:
 Library
     exposed-modules: Paths_PathsModule
     build-depends: base
+    default-language: Haskell2010
+    default-extensions:
+        -- This is a non-exhaustive list of extensions that can cause code to
+        -- not compile when it would if the extension was disabled. This ensures
+        -- that autogen modules are compatible with default extensions.
+        NoImplicitPrelude
+        CPP
+        TemplateHaskell
+        QuasiQuotes
+        Arrows
+        OverloadedStrings
+    if impl(ghc >= 6.12)
+       default-extensions: MonoLocalBinds
+    if impl(ghc >= 7.0.1)
+       default-extensions: RebindableSyntax
+    if impl(ghc >= 7.4.1)
+       default-extensions: NoTraditionalRecordSyntax
+    if impl(ghc >= 7.8.1)
+       default-extensions: OverloadedLists


### PR DESCRIPTION
Fixes https://github.com/commercialhaskell/stack/issues/3789

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

I couldn't get the tests working for me, so instead I interacted with `cabal-testsuite/PacakgeTests/AutogenModules/SrcDist` manually.  Running `cabal install` there yielded

```
Warning: The package list for 'hackage.haskell.org' does not exist. Run 'cabal
update' to download it.
Resolving dependencies...
In order, the following will be installed:
AutogenModules-0.1 (reinstall)
Warning: Note that reinstalls are always dangerous. Continuing anyway...
Configuring AutogenModules-0.1...
Building AutogenModules-0.1...
Failed to install AutogenModules-0.1
Build log ( /home/mgsloan/.cabal/logs/ghc-8.2.2/AutogenModules-0.1-7iTLfhgxOYB4FmH7GTg4PZ.log ):
cabal: Entering directory '.'
Configuring AutogenModules-0.1...
Preprocessing executable 'Exe' for AutogenModules-0.1..
cabal: can't find source for MyExeHelperModule in ., dist/build/Exe/autogen,
dist/build/global-autogen

cabal: Leaving directory '.'
cabal: Error: some packages failed to install:
AutogenModules-0.1-7iTLfhgxOYB4FmH7GTg4PZ failed during the building phase.
The exception was:
ExitFailure 1
```

So, instead I commented out all the stanzas but the library, and commented out the `*HelperModule` stuff.  Then I tested that this new test cabal file reproduced https://github.com/commercialhaskell/stack/issues/3789 .  Then, I made the change to fix the Paths_ file generation.  Then I did `stack build` and `stack exec bash` to enter the stack environment with this modified version of `cabal`.  Then I ran `unset GHC_PACKAGE_PATH` to prevent it from crashing. 
 Then I used `cabal install` in the dir and observed that it now builds after the modifications.