### PR TITLE
Split TreeDiffInstances to lower memory pressure

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -508,7 +508,10 @@ test-suite parser-tests
     build-depends:
       tree-diff      >= 0.0.1 && <0.1
     other-modules:
-      TreeDiffInstances
+      Instances.TreeDiff
+      Instances.TreeDiff.Language
+      Instances.TreeDiff.SPDX
+      Instances.TreeDiff.Version
 
 test-suite check-tests
   type: exitcode-stdio-1.0
@@ -564,7 +567,10 @@ test-suite parser-hackage-tests
     build-depends:
       tree-diff      >= 0.0.1 && <0.1
     other-modules:
-      TreeDiffInstances
+      Instances.TreeDiff
+      Instances.TreeDiff.Language
+      Instances.TreeDiff.SPDX
+      Instances.TreeDiff.Version
 
   ghc-options: -Wall -rtsopts
   default-extensions: CPP

--- a/Cabal/tests/Instances/TreeDiff.hs
+++ b/Cabal/tests/Instances/TreeDiff.hs
@@ -1,20 +1,23 @@
 {-# LANGUAGE CPP #-}
 #if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -freduction-depth=0 #-} 
+{-# OPTIONS_GHC -freduction-depth=0 #-}
 #else
-{-# OPTIONS_GHC -fcontext-stack=151 #-} 
+{-# OPTIONS_GHC -fcontext-stack=151 #-}
 #endif
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module TreeDiffInstances where
+module Instances.TreeDiff where
 
 import Data.TreeDiff
+
+import Instances.TreeDiff.Language ()
+import Instances.TreeDiff.SPDX ()
+import Instances.TreeDiff.Version ()
 
 -------------------------------------------------------------------------------
 
 import Distribution.Backpack                  (OpenModule, OpenUnitId)
 import Distribution.Compiler                  (CompilerFlavor)
 import Distribution.InstalledPackageInfo      (AbiDependency, ExposedModule, InstalledPackageInfo)
-import Distribution.License                   (License)
 import Distribution.ModuleName                (ModuleName)
 import Distribution.Package                   (Dependency, PackageIdentifier, PackageName)
 import Distribution.PackageDescription
@@ -32,8 +35,6 @@ import Distribution.Types.Mixin
 import Distribution.Types.PkgconfigDependency
 import Distribution.Types.UnitId              (DefUnitId, UnitId)
 import Distribution.Types.UnqualComponentName
-import Distribution.Version                   (Version, VersionRange)
-import Language.Haskell.Extension             (Extension, KnownExtension, Language)
 
 -------------------------------------------------------------------------------
 -- instances
@@ -59,7 +60,6 @@ instance ToExpr ExeDependency where toExpr = defaultExprViaShow
 instance ToExpr Executable
 instance ToExpr ExecutableScope where toExpr = defaultExprViaShow
 instance ToExpr ExposedModule where toExpr = defaultExprViaShow
-instance ToExpr Extension
 instance ToExpr Flag
 instance ToExpr FlagName where toExpr = defaultExprViaShow
 instance ToExpr ForeignLib
@@ -68,12 +68,9 @@ instance ToExpr ForeignLibType
 instance ToExpr GenericPackageDescription
 instance ToExpr IncludeRenaming
 instance ToExpr InstalledPackageInfo
-instance ToExpr KnownExtension
-instance ToExpr Language
 instance ToExpr LegacyExeDependency where toExpr = defaultExprViaShow
 instance ToExpr LibVersionInfo where toExpr = defaultExprViaShow
 instance ToExpr Library
-instance ToExpr License
 instance ToExpr Mixin where toExpr = defaultExprViaShow
 instance ToExpr ModuleName where toExpr = defaultExprViaShow
 instance ToExpr ModuleReexport
@@ -93,5 +90,3 @@ instance ToExpr TestSuiteInterface
 instance ToExpr TestType
 instance ToExpr UnitId where toExpr = defaultExprViaShow
 instance ToExpr UnqualComponentName where toExpr = defaultExprViaShow
-instance ToExpr Version where toExpr = defaultExprViaShow
-instance ToExpr VersionRange

--- a/Cabal/tests/Instances/TreeDiff/Language.hs
+++ b/Cabal/tests/Instances/TreeDiff/Language.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -freduction-depth=0 #-}
+#else
+{-# OPTIONS_GHC -fcontext-stack=151 #-}
+#endif
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Instances.TreeDiff.Language where
+
+import Data.TreeDiff
+import Language.Haskell.Extension (Extension, KnownExtension, Language)
+
+-- This are big enums, so they are in separate file.
+--
+instance ToExpr Extension
+instance ToExpr KnownExtension
+instance ToExpr Language

--- a/Cabal/tests/Instances/TreeDiff/SPDX.hs
+++ b/Cabal/tests/Instances/TreeDiff/SPDX.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -freduction-depth=0 #-}
+#else
+{-# OPTIONS_GHC -fcontext-stack=151 #-}
+#endif
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Instances.TreeDiff.SPDX where
+
+import Data.TreeDiff
+import Distribution.License (License)
+
+import Instances.TreeDiff.Version ()
+
+-- 'License' almost belongs here.
+
+instance ToExpr License

--- a/Cabal/tests/Instances/TreeDiff/Version.hs
+++ b/Cabal/tests/Instances/TreeDiff/Version.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -freduction-depth=0 #-}
+#else
+{-# OPTIONS_GHC -fcontext-stack=151 #-}
+#endif
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Instances.TreeDiff.Version where
+
+import Data.TreeDiff
+import Distribution.Version (Version, VersionRange)
+
+instance ToExpr Version where toExpr = defaultExprViaShow
+instance ToExpr VersionRange

--- a/Cabal/tests/ParserHackageTests.hs
+++ b/Cabal/tests/ParserHackageTests.hs
@@ -43,7 +43,7 @@ import qualified Distribution.Types.SourceRepo.Lens                as L
 
 #ifdef MIN_VERSION_tree_diff
 import Data.TreeDiff     (ansiWlEditExpr, ediff)
-import TreeDiffInstances ()
+import Instances.TreeDiff ()
 #endif
 
 parseIndex :: Monoid a => (FilePath -> BSL.ByteString -> IO a) -> IO a

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -35,7 +35,7 @@ import qualified Distribution.ParseUtils           as ReadP
 #ifdef MIN_VERSION_tree_diff
 import Data.TreeDiff        (toExpr)
 import Data.TreeDiff.Golden (ediffGolden)
-import TreeDiffInstances ()
+import Instances.TreeDiff ()
 #endif
 
 tests :: TestTree


### PR DESCRIPTION
I saw GHC-7.10.3 randomly failing when compiling TreeDiffInstances. hopefully this help, or we can split the file further.

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
