### PR TITLE
Improve file globbing logic (fixes #5057)

### DIFF
--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -1148,7 +1148,7 @@ matchDirFileGlob dir filepath = case parseFileGlob filepath of
     case   [ dir' </> file
            | file <- files
            , let (name, ext') = splitExtensions file
-           , not (null name) && ext' == ext ] of
+           , not (null name) && ext `isSuffixOf` ext' ] of
       []      -> die $ "filepath wildcard '" ++ filepath
                     ++ "' does not match any files."
       matches -> return matches


### PR DESCRIPTION
I tested this change manually by running `cabal sdist` on https://github.com/RyanGlScott/cabal-sdist-bug/tree/910078306b4e127996bd7c9208a7e741b9f74351:

```
$ cabal sdist
Building source dist for cabal-sdist-bug-0.1.0...
Source tarball created: dist/cabal-sdist-bug-0.1.0.tar.gz
```