### PR TITLE
Skip PackageTests/Configure/setup.test.hs if autoreconf is not in $PATH

### DIFF
--- a/cabal-testsuite/PackageTests/Configure/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Configure/setup.test.hs
@@ -1,8 +1,10 @@
 import Test.Cabal.Prelude
+import Control.Monad.IO.Class
+import Data.Maybe
+import System.Directory
 -- Test for 'build-type: Configure' example from the setup manual.
--- Disabled on Windows since MingW doesn't ship with autoreconf by
--- default.
 main = setupAndCabalTest $ do
-    skipIf =<< isWindows
+    hasAutoreconf <- liftIO $ fmap isJust $ findExecutable "autoreconf"
+    skipUnless hasAutoreconf
     _ <- shell "autoreconf" ["-i"]
     setup_build []


### PR DESCRIPTION
Fixes #5051

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
