### PR TITLE
Use downloaded version of stack in travis CI

### DIFF
--- a/travis-install.sh
+++ b/travis-install.sh
@@ -73,7 +73,8 @@ else # Stack-based builds
     mkdir -p ~/.local/bin
     travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 \
         | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-    stack setup --stack-yaml "$STACK_CONFIG"
+    ~/.local/bin/stack --version
+    ~/.local/bin/stack setup --stack-yaml "$STACK_CONFIG"
 
 fi
 

--- a/travis-stack.sh
+++ b/travis-stack.sh
@@ -12,7 +12,9 @@ fi
 # Build Cabal via Stack(age).
 # ---------------------------------------------------------------------
 
-stack build \
+~/.local/bin/stack --version
+
+~/.local/bin/stack build \
     --no-terminal \
     --stack-yaml "$STACK_CONFIG" \
     --test \


### PR DESCRIPTION
In the log [here](https://travis-ci.org/haskell/cabal/jobs/333032268), stack is giving `InvalidAbsFile` when invoked with `--stack-yaml stack.yaml`.  I believe that this is quite old behavior.  Theory is that despite downloading stack, travis was not actually using the new stack since the PATH wasn't modified.  Instead of modifying the PATH I've gone with the approach of running stack via an absolute path to the install location.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Untested, lets see if it passes travis.