### PR TITLE
CompilerId: add NFData instance (based on genericRnf)

### DIFF
--- a/Cabal/Distribution/Compiler.hs
+++ b/Cabal/Distribution/Compiler.hs
@@ -151,6 +151,8 @@ data CompilerId = CompilerId CompilerFlavor Version
 
 instance Binary CompilerId
 
+instance NFData CompilerId where rnf = genericRnf
+
 instance Text CompilerId where
   disp (CompilerId f v)
     | v == nullVersion = disp f


### PR DESCRIPTION
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [X] Any changes that could be relevant to users have been recorded in the changelog.
* [X] The documentation has been updated, if necessary.
* [X] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

I have code that depends on the NFData instance (previously defined locally as an orphan), and I verified that code still works properly.