### PR TITLE
Ensure proper case-less handling of FlagName

### DIFF
--- a/Cabal/Distribution/Types/GenericPackageDescription.hs
+++ b/Cabal/Distribution/Types/GenericPackageDescription.hs
@@ -131,9 +131,14 @@ emptyFlag name = MkFlag
     , flagManual      = False
     }
 
--- | A 'FlagName' is the name of a user-defined configuration flag
+-- | A 'FlagName' is the name of a user-defined configuration flag. Use
+-- 'mkFlagName' and 'unFlagName' to convert from/to a 'String'.
 --
--- Use 'mkFlagName' and 'unFlagName' to convert from/to a 'String'.
+-- Flag names are converted to lower-case spelling internally by the 'mkFlag'
+-- constructor function. This makes flag name comparisons case-insensitive:
+--
+-- >>> mkFlagName "foo" == mkFlagName "FOO"
+-- True
 --
 -- This type is opaque since @Cabal-2.0@
 --
@@ -150,7 +155,7 @@ newtype FlagName = FlagName ShortText
 --
 -- @since 2.0.0.2
 mkFlagName :: String -> FlagName
-mkFlagName = FlagName . toShortText
+mkFlagName = FlagName . toShortText . lowercase
 
 -- | 'mkFlagName'
 --
@@ -170,7 +175,7 @@ instance Pretty FlagName where
     pretty = Disp.text . unFlagName
 
 instance Parsec FlagName where
-    parsec = mkFlagName . lowercase <$> parsec'
+    parsec = mkFlagName <$> parsec'
       where
         parsec' = (:) <$> lead <*> rest
         lead = P.satisfy (\c ->  isAlphaNum c || c == '_')
@@ -179,7 +184,7 @@ instance Parsec FlagName where
 instance Text FlagName where
     -- Note:  we don't check that FlagName doesn't have leading dash,
     -- cabal check will do that.
-    parse = mkFlagName . lowercase <$> parse'
+    parse = mkFlagName <$> parse'
       where
         parse' = (:) <$> lead <*> rest
         lead = Parse.satisfy (\c ->  isAlphaNum c || c == '_')

--- a/Cabal/tests/UnitTests/Distribution/Types/GenericPackageDescription.hs
+++ b/Cabal/tests/UnitTests/Distribution/Types/GenericPackageDescription.hs
@@ -6,14 +6,18 @@ import Prelude ()
 import Distribution.Compat.Prelude.Internal
 import Distribution.Types.GenericPackageDescription
 
+import qualified Control.Exception as C
+import Control.Monad
 import Test.Tasty
 import Test.Tasty.HUnit
-import qualified Control.Exception as C
 
 tests :: [TestTree]
 tests =
   [ testCase "GenericPackageDescription deepseq" gpdDeepseq
+  , testCase "findDuplicateFlagAssignments" testFindDuplicateFlagAssignments
   ]
+
+----- Verify "NFData GenericPackageDescription" instance ----------------------
 
 gpdFields :: [(String, GenericPackageDescription -> GenericPackageDescription)]
 gpdFields =
@@ -35,3 +39,13 @@ throwsUndefined :: NFData a => String -> a -> Assertion
 throwsUndefined field a =
   C.catch (C.evaluate (rnf a) >> assertFailure ("Deepseq failed to evaluate " ++ show field))
           (\(C.ErrorCall _) -> return ())
+
+----- Verify duplicate flag recognition in "FlagAssignment" -------------------
+
+testFindDuplicateFlagAssignments :: Assertion
+testFindDuplicateFlagAssignments = do
+  let flag n v = (mkFlagName n, v)
+      findDuplicates = findDuplicateFlagAssignments . mkFlagAssignment
+  forM_ [ (b1,b2) | b1 <- [True,False], b2 <- [True,False] ] $ \(v1,v2) -> do
+    assertEqual "" [] (findDuplicates [flag "foo" v1, flag "bar" v2])
+    assertEqual "" [mkFlagName "foo"] (findDuplicates [flag "foo" v1, flag "FOO" v2])

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -285,7 +285,7 @@ tests = [
           solverFailure (isInfixOf "unknown package: E:unknown-pkg:exe.unknown-pkg (dependency of E)")
 
         , runTest $ mkTest dbBuildTools "unknown flagged exe" ["F"] $
-          solverFailure (isInfixOf "does not contain executable unknown-exe, which is required by F +flagF")
+          solverFailure (isInfixOf "does not contain executable unknown-exe, which is required by F +flagf")
 
         , runTest $ enableAllTests $ mkTest dbBuildTools "unknown test suite exe" ["G"] $
           solverFailure (isInfixOf "does not contain executable unknown-exe, which is required by G *test")
@@ -971,8 +971,8 @@ commonDependencyLogMessage :: String -> SolverTest
 commonDependencyLogMessage name =
     mkTest db name ["A"] $ solverFailure $ isInfixOf $
         "[__0] trying: A-1.0.0 (user goal)\n"
-     ++ "[__1] next goal: B (dependency of A +/-flagA)\n"
-     ++ "[__1] rejecting: B-2.0.0 (conflict: A +/-flagA => B==1.0.0 || ==3.0.0)"
+     ++ "[__1] next goal: B (dependency of A +/-flaga)\n"
+     ++ "[__1] rejecting: B-2.0.0 (conflict: A +/-flaga => B==1.0.0 || ==3.0.0)"
   where
     db :: ExampleDb
     db = [
@@ -986,7 +986,7 @@ commonDependencyLogMessage name =
 twoLevelDeepCommonDependencyLogMessage :: String -> SolverTest
 twoLevelDeepCommonDependencyLogMessage name =
     mkTest db name ["A"] $ solverFailure $ isInfixOf $
-        "unknown package: B (dependency of A +/-flagA +/-flagB)"
+        "unknown package: B (dependency of A +/-flaga +/-flagb)"
   where
     db :: ExampleDb
     db = [
@@ -1477,7 +1477,7 @@ chooseExeAfterBuildToolsPackage shouldSucceed name =
       if shouldSucceed
       then solverSuccess [("A", 1), ("B", 1)]
       else solverFailure $ isInfixOf $
-           "rejecting: A:+flagA (requires executable exe2 from A:B:exe.B, "
+           "rejecting: A:+flaga (requires executable exe2 from A:B:exe.B, "
             ++ "but the executable does not exist)"
   where
     db :: ExampleDb


### PR DESCRIPTION
This patch moves the conversion to all-lower-case out of the `FlagName` parser instances and into the `mkFlagName` constructor function. 

Fixes https://github.com/haskell/cabal/issues/5043.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
