### PR TITLE
Remove 'ExecutableScopeUnknown'.

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -53,7 +53,6 @@ import Distribution.System
 import Distribution.Text
 import Distribution.Types.ComponentRequestedSpec
 import Distribution.Types.CondTree
-import Distribution.Types.ExecutableScope
 import Distribution.Types.ExeDependency
 import Distribution.Types.UnqualComponentName
 import Distribution.Utils.Generic                    (isAscii)
@@ -315,12 +314,6 @@ checkExecutable pkg exe =
       PackageBuildImpossible $
            "On executable '" ++ display (exeName exe) ++ "' an 'autogen-module' is not "
         ++ "on 'other-modules'"
-
-  , checkSpecVersion pkg [2,0] (exeScope exe /= ExecutableScopeUnknown) $
-      PackageDistSuspiciousWarn $
-           "To use the 'scope' field the package needs to specify "
-        ++ "at least 'cabal-version: >= 2.0'."
-
   ]
   where
     moduleDuplicates = dups (exeModules exe)

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -52,6 +52,7 @@ import Distribution.Parsec.Common
 import Distribution.Parsec.Newtypes
 import Distribution.Parsec.ParseResult
 import Distribution.Text                      (display)
+import Distribution.Types.ExecutableScope
 import Distribution.Types.ForeignLib
 import Distribution.Types.ForeignLibType
 import Distribution.Types.UnqualComponentName
@@ -159,7 +160,8 @@ executableFieldGrammar
 executableFieldGrammar n = Executable n
     -- main-is is optional as conditional blocks don't have it
     <$> optionalFieldDefAla "main-is" FilePathNT L.modulePath ""
-    <*> monoidalField       "scope"              L.exeScope
+    <*> optionalFieldDef    "scope"              L.exeScope ExecutablePublic
+        ^^^ availableSince [2,0] ExecutablePublic
     <*> blurFieldGrammar L.buildInfo buildInfoFieldGrammar
 {-# SPECIALIZE executableFieldGrammar :: UnqualComponentName -> ParsecFieldGrammar' Executable #-}
 {-# SPECIALIZE executableFieldGrammar :: UnqualComponentName -> PrettyFieldGrammar' Executable #-}

--- a/Cabal/tests/ParserTests/regressions/issue-5055.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-5055.expr
@@ -59,7 +59,7 @@ GenericPackageDescription
                                                                                           `mkVersion [5]`))],
                                                             virtualModules = []},
                                              exeName = `UnqualComponentName "flag-test-exe"`,
-                                             exeScope = ExecutableScopeUnknown,
+                                             exeScope = ExecutablePublic,
                                              modulePath = "FirstMain.hs"}}],
    condForeignLibs = [],
    condLibrary = Nothing,

--- a/Cabal/tests/ParserTests/regressions/issue-5055.format
+++ b/Cabal/tests/ParserTests/regressions/issue-5055.format
@@ -10,7 +10,6 @@ build-type: Simple
 
 executable flag-test-exe
     main-is: FirstMain.hs
-    scope: unknown
     default-language: Haskell2010
     build-depends:
         base >=4.8 && <5

--- a/Cabal/tests/ParserTests/regressions/shake.expr
+++ b/Cabal/tests/ParserTests/regressions/shake.expr
@@ -56,7 +56,7 @@ GenericPackageDescription
                                                                                                            targetBuildDepends = [],
                                                                                                            virtualModules = []},
                                                                                             exeName = `UnqualComponentName "shake"`,
-                                                                                            exeScope = ExecutableScopeUnknown,
+                                                                                            exeScope = ExecutablePublic,
                                                                                             modulePath = ""}}},
                                                  CondBranch
                                                    {condBranchCondition = `Var (Flag (FlagName "portable"))`,
@@ -118,7 +118,7 @@ GenericPackageDescription
                                                                                                                                                                                         `mkVersion [2,5,1]`)],
                                                                                                                                                              virtualModules = []},
                                                                                                                                               exeName = `UnqualComponentName "shake"`,
-                                                                                                                                              exeScope = ExecutableScopeUnknown,
+                                                                                                                                              exeScope = ExecutablePublic,
                                                                                                                                               modulePath = ""}}}],
                                                                              condTreeConstraints = [],
                                                                              condTreeData = Executable
@@ -165,7 +165,7 @@ GenericPackageDescription
                                                                                                               targetBuildDepends = [],
                                                                                                               virtualModules = []},
                                                                                                exeName = `UnqualComponentName "shake"`,
-                                                                                               exeScope = ExecutableScopeUnknown,
+                                                                                               exeScope = ExecutablePublic,
                                                                                                modulePath = ""}},
                                                     condBranchIfTrue = CondNode
                                                                          {condTreeComponents = [CondBranch
@@ -222,7 +222,7 @@ GenericPackageDescription
                                                                                                                                                                                   AnyVersion],
                                                                                                                                                           virtualModules = []},
                                                                                                                                            exeName = `UnqualComponentName "shake"`,
-                                                                                                                                           exeScope = ExecutableScopeUnknown,
+                                                                                                                                           exeScope = ExecutablePublic,
                                                                                                                                            modulePath = ""}}}],
                                                                           condTreeConstraints = [],
                                                                           condTreeData = Executable
@@ -269,7 +269,7 @@ GenericPackageDescription
                                                                                                            targetBuildDepends = [],
                                                                                                            virtualModules = []},
                                                                                             exeName = `UnqualComponentName "shake"`,
-                                                                                            exeScope = ExecutableScopeUnknown,
+                                                                                            exeScope = ExecutablePublic,
                                                                                             modulePath = ""}}},
                                                  CondBranch
                                                    {condBranchCondition = `CNot (Var (OS Windows))`,
@@ -325,7 +325,7 @@ GenericPackageDescription
                                                                                                                                    AnyVersion],
                                                                                                            virtualModules = []},
                                                                                             exeName = `UnqualComponentName "shake"`,
-                                                                                            exeScope = ExecutableScopeUnknown,
+                                                                                            exeScope = ExecutablePublic,
                                                                                             modulePath = ""}}}],
                            condTreeConstraints = [Dependency
                                                     `PackageName "base"`
@@ -520,7 +520,7 @@ GenericPackageDescription
                                                                                     AnyVersion],
                                                             virtualModules = []},
                                              exeName = `UnqualComponentName "shake"`,
-                                             exeScope = ExecutableScopeUnknown,
+                                             exeScope = ExecutablePublic,
                                              modulePath = "Run.hs"}}],
    condForeignLibs = [],
    condLibrary = Just

--- a/Cabal/tests/ParserTests/regressions/shake.format
+++ b/Cabal/tests/ParserTests/regressions/shake.format
@@ -169,7 +169,6 @@ library
 
 executable shake
     main-is: Run.hs
-    scope: unknown
     hs-source-dirs: src
     other-modules:
         Development.Make.All
@@ -249,27 +248,21 @@ executable shake
         primitive -any
     
     if impl(ghc >=7.8)
-        scope: unknown
         ghc-options: -threaded "-with-rtsopts=-I0 -qg -qb"
     
     if flag(portable)
-        scope: unknown
         cpp-options: -DPORTABLE
         
         if impl(ghc <7.6)
-            scope: unknown
             build-depends:
                 old-time -any
     else
-        scope: unknown
         
         if !os(windows)
-            scope: unknown
             build-depends:
                 unix >=2.5.1
     
     if !os(windows)
-        scope: unknown
         build-depends:
             unix -any
 

--- a/Cabal/tests/ParserTests/regressions/wl-pprint-indef.expr
+++ b/Cabal/tests/ParserTests/regressions/wl-pprint-indef.expr
@@ -66,7 +66,7 @@ GenericPackageDescription
                                                                                     AnyVersion],
                                                             virtualModules = []},
                                              exeName = `UnqualComponentName "wl-pprint-string-example"`,
-                                             exeScope = ExecutableScopeUnknown,
+                                             exeScope = ExecutablePublic,
                                              modulePath = "Main.hs"}}],
    condForeignLibs = [],
    condLibrary = Just

--- a/Cabal/tests/ParserTests/regressions/wl-pprint-indef.format
+++ b/Cabal/tests/ParserTests/regressions/wl-pprint-indef.format
@@ -29,7 +29,6 @@ library
 
 executable wl-pprint-string-example
     main-is: Main.hs
-    scope: unknown
     hs-source-dirs: example-string
     other-modules:
         StringImpl

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,7 @@ doctest :
 gen-extra-source-files:
 	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-extra-source-files -- Cabal/Cabal.cabal
 	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-extra-source-files -- cabal-install/cabal-install.cabal
+
+cabal-install-test:
+	cabal new-build cabal cabal-tests
+	cd cabal-testsuite && `cabal-plan list-bin cabal-tests` --with-cabal=`cabal-plan list-bin cabal` --hide-successes -j3


### PR DESCRIPTION
Fixes #5083
Related to #5003

Note: `buildable: ` field has `All` semantics. `scope: ` has
`AnyPrivate` semantics. Both might be surprising, but are "logical".

https://hackage.haskell.org/package/Cabal-2.0.1.1/docs/src/Distribution.PackageDescription.Parse.html#line-248

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
