### PR TITLE
Warn on leading zeros in version digits for old cabal spec

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -64,6 +64,8 @@ extra-source-files:
   tests/ParserTests/ipi/transformers.cabal
   tests/ParserTests/ipi/transformers.expr
   tests/ParserTests/ipi/transformers.format
+  tests/ParserTests/regressions/MiniAgda.cabal
+  tests/ParserTests/regressions/MiniAgda.check
   tests/ParserTests/regressions/Octree-0.5.cabal
   tests/ParserTests/regressions/Octree-0.5.expr
   tests/ParserTests/regressions/Octree-0.5.format

--- a/Cabal/Distribution/CabalSpecVersion.hs
+++ b/Cabal/Distribution/CabalSpecVersion.hs
@@ -12,33 +12,36 @@ import qualified Data.Set as Set
 --
 data CabalSpecVersion
     = CabalSpecOld
-    | CabalSpecV20
-    | CabalSpecV22
+    | CabalSpecV1_24
+    | CabalSpecV2_0
+    | CabalSpecV2_2
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable, Data, Generic)
 
 cabalSpecLatest :: CabalSpecVersion
-cabalSpecLatest = CabalSpecV22
+cabalSpecLatest = CabalSpecV2_2
 
 cabalSpecFeatures :: CabalSpecVersion -> Set.Set CabalFeature
-cabalSpecFeatures CabalSpecOld = Set.empty
-cabalSpecFeatures CabalSpecV20 = Set.empty
-cabalSpecFeatures CabalSpecV22 = Set.fromList
+cabalSpecFeatures CabalSpecOld   = Set.empty
+cabalSpecFeatures CabalSpecV1_24 = Set.empty
+cabalSpecFeatures CabalSpecV2_0  = Set.empty
+cabalSpecFeatures CabalSpecV2_2  = Set.fromList
     [ Elif
     , CommonStanzas
     ]
 
 cabalSpecSupports :: CabalSpecVersion -> [Int] -> Bool
-cabalSpecSupports CabalSpecOld v = v < [1,25]
-cabalSpecSupports CabalSpecV20 v = v < [2,1]
-cabalSpecSupports CabalSpecV22 _ = True
+cabalSpecSupports CabalSpecOld v   = v < [1,23]
+cabalSpecSupports CabalSpecV1_24 v = v < [1,25]
+cabalSpecSupports CabalSpecV2_0 v  = v < [2,1]
+cabalSpecSupports CabalSpecV2_2 _  = True
 
 specHasCommonStanzas :: CabalSpecVersion -> HasCommonStanzas
-specHasCommonStanzas CabalSpecV22 = HasCommonStanzas
-specHasCommonStanzas _            = NoCommonStanzas
+specHasCommonStanzas CabalSpecV2_2 = HasCommonStanzas
+specHasCommonStanzas _             = NoCommonStanzas
 
 specHasElif :: CabalSpecVersion -> HasElif
-specHasElif CabalSpecV22 = HasElif
-specHasElif _            = NoElif
+specHasElif CabalSpecV2_2 = HasElif
+specHasElif _             = NoElif
 
 -------------------------------------------------------------------------------
 -- Features

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -200,8 +200,9 @@ parseGenericPackageDescription' cabalVerM lexWarnings utf8WarnPos fs = do
                 return v
 
     let specVer
-          | cabalVer >= mkVersion [2,1]  = CabalSpecV22
-          | cabalVer >= mkVersion [1,25] = CabalSpecV20
+          | cabalVer >= mkVersion [2,1]  = CabalSpecV2_2
+          | cabalVer >= mkVersion [1,25] = CabalSpecV2_0
+          | cabalVer >= mkVersion [1,23] = CabalSpecV1_24
           | otherwise = CabalSpecOld
 
     -- reset cabal version

--- a/Cabal/Distribution/Parsec/Common.hs
+++ b/Cabal/Distribution/Parsec/Common.hs
@@ -51,6 +51,7 @@ data PWarnType
     | PWTDoubleDash            -- ^ Double dash token, most likely it's a mistake - it's not a comment
     | PWTMultipleSingularField -- ^ e.g. name or version should be specified only once.
     | PWTBuildTypeDefault      -- ^ Workaround for derive-package having build-type: Default. See <https://github.com/haskell/cabal/issues/5020>.
+    | PWTVersionLeadingZeros   -- ^ See https://github.com/haskell-infra/hackage-trustees/issues/128
     deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 instance Binary PWarnType

--- a/Cabal/Distribution/Parsec/Newtypes.hs
+++ b/Cabal/Distribution/Parsec/Newtypes.hs
@@ -74,12 +74,12 @@ instance Sep CommaVCat where
     prettySep  _ = vcat . punctuate comma
     parseSep   _ p = do
         v <- askCabalSpecVersion
-        if v >= CabalSpecV22 then parsecLeadingCommaList p else parsecCommaList p
+        if v >= CabalSpecV2_2 then parsecLeadingCommaList p else parsecCommaList p
 instance Sep CommaFSep where
     prettySep _ = fsep . punctuate comma
     parseSep   _ p = do
         v <- askCabalSpecVersion
-        if v >= CabalSpecV22 then parsecLeadingCommaList p else parsecCommaList p
+        if v >= CabalSpecV2_2 then parsecLeadingCommaList p else parsecCommaList p
 instance Sep VCat where
     prettySep _  = vcat
     parseSep  _  = parsecOptCommaList
@@ -202,7 +202,7 @@ instance Newtype SpecLicense (Either SPDX.License License) where
 instance Parsec SpecLicense where
     parsec = do
         v <- askCabalSpecVersion
-        if v >= CabalSpecV22
+        if v >= CabalSpecV2_2
         then SpecLicense . Left <$> parsec
         else SpecLicense . Right <$> parsec
 

--- a/Cabal/Distribution/Types/Version.hs
+++ b/Cabal/Distribution/Types/Version.hs
@@ -102,13 +102,13 @@ instance Parsec Version where
         mkVersion <$> P.sepBy1 digit (P.char '.') <* tags
       where
         digitParser v
-            | v >= CabalSpecV1_24 = P.integral
-            | otherwise           = (some d >>= toNumber) P.<?> "non-leading-zero integral"
+            | v >= CabalSpecV2_0 = P.integral
+            | otherwise          = (some d >>= toNumber) P.<?> "non-leading-zero integral"
           where
             toNumber :: CabalParsing m => [Int] -> m Int
             toNumber [0] = return 0
             toNumber xs@(0:_) = do
-                parsecWarning PWTVersionLeadingZeros "Version digit with leading zero. Use cabal-version: 1.24 or later to write such versions. For more information see https://github.com/haskell/cabal/issues/5092"
+                parsecWarning PWTVersionLeadingZeros "Version digit with leading zero. Use cabal-version: 2.0 or later to write such versions. For more information see https://github.com/haskell/cabal/issues/5092"
                 return $ foldl' (\a b -> a * 10 + b) 0 xs
             toNumber xs = return $ foldl' (\a b -> a * 10 + b) 0 xs
 

--- a/Cabal/tests/CheckTests.hs
+++ b/Cabal/tests/CheckTests.hs
@@ -8,6 +8,7 @@ import Test.Tasty.Golden.Advanced (goldenTest)
 import Data.Algorithm.Diff                    (Diff (..), getGroupedDiff)
 import Distribution.PackageDescription.Check  (checkPackage)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescription)
+import Distribution.Parsec.Common             (showPError, showPWarning)
 import Distribution.Parsec.ParseResult        (runParseResult)
 import Distribution.Utils.Generic             (fromUTF8BS, toUTF8BS)
 import System.FilePath                        (replaceExtension, (</>))
@@ -27,17 +28,22 @@ checkTests = testGroup "regressions"
     [ checkTest "nothing-unicode.cabal"
     , checkTest "haddock-api-2.18.1-check.cabal"
     , checkTest "issue-774.cabal"
+    , checkTest "MiniAgda.cabal"
     ]
 
 checkTest :: FilePath -> TestTree
 checkTest fp = cabalGoldenTest fp correct $ do
     contents <- BS.readFile input
     let res =  parseGenericPackageDescription contents
-    let (_, x) = runParseResult res
+    let (ws, x) = runParseResult res
 
     return $ toUTF8BS $ case x of
-        Right gpd      -> unlines $ map show (checkPackage gpd Nothing)
-        Left (_, errs) -> unlines $ "ERROR" : map show errs
+        Right gpd      ->
+            -- Note: parser warnings are reported by `cabal check`, but not by
+            -- D.PD.Check functionality.
+            unlines (map (showPWarning fp) ws) ++
+            unlines (map show (checkPackage gpd Nothing))
+        Left (_, errs) -> unlines $ map (("ERROR: " ++) . showPError fp) errs
   where
     input = "tests" </> "ParserTests" </> "regressions" </> fp
     correct = replaceExtension input "check"

--- a/Cabal/tests/ParserTests/regressions/MiniAgda.cabal
+++ b/Cabal/tests/ParserTests/regressions/MiniAgda.cabal
@@ -1,0 +1,89 @@
+name:            MiniAgda
+version:         0.2017.02.18
+build-type:      Simple
+cabal-version:   1.22
+license:         OtherLicense
+license-file:    LICENSE
+author:          Andreas Abel and Karl Mehltretter
+maintainer:      Andreas Abel <andreas.abel@ifi.lmu.de>
+homepage:        http://www.tcs.ifi.lmu.de/~abel/miniagda/
+bug-reports:     https://github.com/andreasabel/miniagda/issues
+category:        Dependent types
+synopsis:        A toy dependently typed programming language with type-based termination.
+description:
+  MiniAgda is a tiny dependently-typed programming language in the style
+  of Agda. It serves as a laboratory to test potential additions to the
+  language and type system of Agda. MiniAgda's termination checker is a
+  fusion of sized types and size-change termination and supports
+  coinduction. Equality incorporates eta-expansion at record and
+  singleton types. Function arguments can be declared as static; such
+  arguments are discarded during equality checking and compilation.
+
+  Recent features include bounded size quantification and destructor
+  patterns for a more general handling of coinduction.
+
+tested-with:        GHC == 7.6.3
+                    GHC == 7.8.4
+                    GHC == 7.10.3
+                    GHC == 8.0.1
+
+extra-source-files: Makefile
+
+data-files:         test/succeed/Makefile
+                    test/succeed/*.ma
+                    test/fail/Makefile
+                    test/fail/*.ma
+                    test/fail/*.err
+                    test/fail/adm/*.ma
+                    test/fail/adm/*.err
+                    lib/*.ma
+source-repository head
+  type:     git
+  location: https://github.com/andreasabel/miniagda
+
+executable miniagda
+  hs-source-dirs:   src
+  build-depends:    array >= 0.3 && < 0.6,
+                    base >= 4.6 && < 4.11,
+                    containers >= 0.3 && < 0.6,
+                    haskell-src-exts >= 1.17 && < 1.18,
+                    mtl >= 2.2.0.1 && < 2.3,
+                    pretty >= 1.0 && < 1.2
+  build-tools:      happy >= 1.15 && < 2,
+                    alex >= 3.0 && < 4
+  default-language: Haskell98
+  default-extensions: CPP
+                    MultiParamTypeClasses
+                    TypeSynonymInstances
+                    FlexibleInstances
+                    FlexibleContexts
+                    GeneralizedNewtypeDeriving
+                    NoMonomorphismRestriction
+                    PatternGuards
+                    TupleSections
+                    NamedFieldPuns
+  main-is:          Main.hs
+  other-modules:    Abstract
+                    Collection
+                    Concrete
+                    Eval
+                    Extract
+                    HsSyntax
+                    Lexer
+                    Main
+                    Parser
+                    Polarity
+                    PrettyTCM
+                    ScopeChecker
+                    Semiring
+                    SparseMatrix
+                    TCM
+                    Termination
+                    ToHaskell
+                    Tokens
+                    TraceError
+                    TreeShapedOrder
+                    TypeChecker
+                    Util
+                    Value
+                    Warshall

--- a/Cabal/tests/ParserTests/regressions/MiniAgda.check
+++ b/Cabal/tests/ParserTests/regressions/MiniAgda.check
@@ -1,0 +1,1 @@
+MiniAgda.cabal:0:0: Version digit with leading zero. Use cabal-version: 1.24 or later to write such versions. For more information see https://github.com/haskell/cabal/issues/5092

--- a/Cabal/tests/ParserTests/regressions/MiniAgda.check
+++ b/Cabal/tests/ParserTests/regressions/MiniAgda.check
@@ -1,1 +1,1 @@
-MiniAgda.cabal:0:0: Version digit with leading zero. Use cabal-version: 1.24 or later to write such versions. For more information see https://github.com/haskell/cabal/issues/5092
+MiniAgda.cabal:0:0: Version digit with leading zero. Use cabal-version: 2.0 or later to write such versions. For more information see https://github.com/haskell/cabal/issues/5092


### PR DESCRIPTION
Fixes https://github.com/haskell/cabal/issues/5092

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
