### PR TITLE
Issue 5086b

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -84,6 +84,8 @@ extra-source-files:
   tests/ParserTests/regressions/encoding-0.8.cabal
   tests/ParserTests/regressions/encoding-0.8.expr
   tests/ParserTests/regressions/encoding-0.8.format
+  tests/ParserTests/regressions/extensions-paths-5054.cabal
+  tests/ParserTests/regressions/extensions-paths-5054.check
   tests/ParserTests/regressions/generics-sop.cabal
   tests/ParserTests/regressions/generics-sop.expr
   tests/ParserTests/regressions/generics-sop.format

--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -41,7 +41,6 @@ generate :: PackageDescription -> LocalBuildInfo -> ComponentLocalBuildInfo -> S
 generate pkg_descr lbi clbi =
    let pragmas =
             cpp_pragma
-         ++ no_overloaded_strings_pragma
          ++ no_rebindable_syntax_pragma
          ++ ffi_pragmas
          ++ warning_pragmas
@@ -50,14 +49,10 @@ generate pkg_descr lbi clbi =
          | supports_cpp = "{-# LANGUAGE CPP #-}\n"
          | otherwise    = ""
 
-       -- -XOverloadedStrings is problematic because 'fromString' is not
-       -- in scope, so disable it.
-       no_overloaded_strings_pragma
-         | supports_overloaded_strings = "{-# LANGUAGE NoOverloadedStrings #-}\n"
-         | otherwise                   = ""
-
        -- -XRebindableSyntax is problematic because when paired with
-       -- -XOverloadedLists, 'fromListN' is not in scope, so disable it.
+       -- -XOverloadedLists, 'fromListN' is not in scope,
+       -- or -XOverloadedStrings 'fromString' is not in scope,
+       -- so we disable 'RebindableSyntax'.
        no_rebindable_syntax_pragma
          | supports_rebindable_syntax = "{-# LANGUAGE NoRebindableSyntax #-}\n"
          | otherwise                  = ""
@@ -253,7 +248,6 @@ generate pkg_descr lbi clbi =
         path_sep = show [pathSeparator]
 
         supports_cpp = supports_language_pragma
-        supports_overloaded_strings = supports_language_pragma
         supports_rebindable_syntax= ghc_newer_than (mkVersion [7,0,1])
         supports_language_pragma = ghc_newer_than (mkVersion [6,6,1])
 

--- a/Cabal/Distribution/Types/PackageDescription.hs
+++ b/Cabal/Distribution/Types/PackageDescription.hs
@@ -364,27 +364,21 @@ withForeignLib pkg_descr f =
 -- ---------------------------------------------------------------------------
 -- The BuildInfo type
 
--- | The 'BuildInfo' for the library (if there is one and it's buildable), and
--- all buildable executables, test suites and benchmarks.  Useful for gathering
--- dependencies.
+-- | All 'BuildInfo' in the 'PackageDescription':
+-- libraries, executables, test-suites and benchmarks.
+--
+-- Useful for implementing package checks.
 allBuildInfo :: PackageDescription -> [BuildInfo]
 allBuildInfo pkg_descr = [ bi | lib <- allLibraries pkg_descr
-                              , let bi = libBuildInfo lib
-                              , buildable bi ]
-                      ++ [ bi | flib <- foreignLibs pkg_descr
-                              , let bi = foreignLibBuildInfo flib
-                              , buildable bi ]
-                      ++ [ bi | exe <- executables pkg_descr
-                              , let bi = buildInfo exe
-                              , buildable bi ]
-                      ++ [ bi | tst <- testSuites pkg_descr
-                              , let bi = testBuildInfo tst
-                              , buildable bi ]
-                      ++ [ bi | tst <- benchmarks pkg_descr
-                              , let bi = benchmarkBuildInfo tst
-                              , buildable bi ]
-  --FIXME: many of the places where this is used, we actually want to look at
-  --       unbuildable bits too, probably need separate functions
+                               , let bi = libBuildInfo lib ]
+                       ++ [ bi | flib <- foreignLibs pkg_descr
+                               , let bi = foreignLibBuildInfo flib ]
+                       ++ [ bi | exe <- executables pkg_descr
+                               , let bi = buildInfo exe ]
+                       ++ [ bi | tst <- testSuites pkg_descr
+                               , let bi = testBuildInfo tst ]
+                       ++ [ bi | tst <- benchmarks pkg_descr
+                               , let bi = benchmarkBuildInfo tst ]
 
 -- | Return all of the 'BuildInfo's of enabled components, i.e., all of
 -- the ones that would be built if you run @./Setup build@.

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -16,6 +16,8 @@
 	* Use better defaulting for `build-type`; rename `PackageDescription`'s
 	  `buildType` field to `buildTypeRaw` and introduce new `buildType`
 	  function (#4958)
+	* `D.T.PackageDescription.allBuildInfo` returns all build infos, not
+	  only for buildable components (#5087)
 	* Removed `UnknownBuildType` constructor from `BuildType` (#5003).
 	* Added `HexFloatLiterals` to `KnownExtension`.
 	* Cabal will no longer try to build an empty set of `inputModules`

--- a/Cabal/tests/CheckTests.hs
+++ b/Cabal/tests/CheckTests.hs
@@ -29,6 +29,7 @@ checkTests = testGroup "regressions"
     , checkTest "haddock-api-2.18.1-check.cabal"
     , checkTest "issue-774.cabal"
     , checkTest "MiniAgda.cabal"
+    , checkTest "extensions-paths-5054.cabal"
     ]
 
 checkTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests/regressions/extensions-paths-5054.cabal
+++ b/Cabal/tests/ParserTests/regressions/extensions-paths-5054.cabal
@@ -1,0 +1,39 @@
+name:         extensions-paths
+version:      5054
+category:     Test
+maintainer:   Oleg Grenrus
+license:      BSD3
+license-file: LICENSe
+synopsis:     Paths_pkg module + "bad" extensions + old cabal
+description:
+  Only cabal-version: 2.2 or later will build Paths_pkg ok with
+
+  * RebindableSyntax and
+
+  * OverloadedLists or OverloadedStrings
+
+  `fromList` or `fromString` will be out-of-scope when compiling Paths_ module.
+
+  Other extensions (like NoImplicitPrelude) were handled before
+build-type:    Simple
+cabal-version: 1.12
+
+library
+  default-language: Haskell2010
+  exposed-modules:  Issue Paths_extensions_paths
+  default-extensions:
+    RebindableSyntax
+    OverloadedStrings
+
+test-suite tests
+  default-language: Haskell2010
+  main-is: Test.hs
+  type: exitcode-stdio-1.0
+  if os(linux)
+    other-modules: Paths_extensions_paths
+  else
+    buildable: False
+
+  default-extensions:
+    OverloadedLists
+    RebindableSyntax

--- a/Cabal/tests/ParserTests/regressions/extensions-paths-5054.check
+++ b/Cabal/tests/ParserTests/regressions/extensions-paths-5054.check
@@ -1,0 +1,1 @@
+The package uses RebindableSyntax with OverloadedStrings or OverloadedLists in default-extensions, and also Paths_ autogen module. That configuration is known to cause compile failures with Cabal < 2.2. To use these default-extensions with Paths_ autogen module specify at least 'cabal-version: 2.2'.

--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,6 @@ gen-extra-source-files:
 	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-extra-source-files -- cabal-install/cabal-install.cabal
 
 cabal-install-test:
-	cabal new-build cabal cabal-tests
-	cd cabal-testsuite && `cabal-plan list-bin cabal-tests` --with-cabal=`cabal-plan list-bin cabal` --hide-successes -j3
+	cabal new-build -j3 all --disable-tests --disable-benchmarks
+	rm -rf .ghc.environment.*
+	cd cabal-testsuite && `cabal-plan list-bin cabal-tests` --with-cabal=`cabal-plan list-bin cabal` --hide-successes -j3 ${TEST}

--- a/cabal-testsuite/PackageTests/PathsModule/Library/my.cabal
+++ b/cabal-testsuite/PackageTests/PathsModule/Library/my.cabal
@@ -1,11 +1,11 @@
+Cabal-version: 2.1
 name: PathsModule
 version: 0.1
-license: BSD3
+license: BSD-3-Clause
 author: Johan Tibell
 stability: stable
 category: PackageTests
 build-type: Simple
-Cabal-version: >= 1.10
 
 description:
     Check that the generated paths module compiles.


### PR DESCRIPTION
A variant of #5087, which does check on `cabal-version: 2.1`

Let's see if appveyor is more happy with this one.