### PR TITLE
Quick proof of concept refactoring of `VersionRange`

### DIFF
--- a/Cabal/Distribution/Version.hs
+++ b/Cabal/Distribution/Version.hs
@@ -26,7 +26,8 @@ module Distribution.Version (
   showVersion,
 
   -- * Version ranges
-  VersionRange(..),
+  VersionRange,
+  VersionRangeOver (..),
 
   -- ** Constructing
   anyVersion, noVersion,
@@ -54,7 +55,8 @@ module Distribution.Version (
   hasLowerBound,
 
   -- ** Cata & ana
-  VersionRangeF (..),
+  VersionRangeF,
+  VersionRangeOverF (..),
   cataVersionRange,
   anaVersionRange,
   hyloVersionRange,


### PR DESCRIPTION
This is a preparatory refactoring for exploring/evaluation how to handle introducing a separate `Version` type for `pkg-config` version numbers (which have a richer syntax/grammar, such as `openssl-1.0.2j` and according to the `pkg-config` docs uses RPM-style version comparision semantics, see http://blog.jasonantman.com/2014/07/how-yum-and-rpm-compare-versions/ for the details).

The current refactoring is effectively limited to modifications in a single file, by introducing `type` syns for compatiblity. I've only tried compiling `lib:Cabal`, which did build fine. I'd expect the heap-representation and the `Binary` instances to be unaffected by this refactoring.

The ugliest part is for me is the current ad-hoc `IsVersion` class hack that factors out the `Version`-specific logic.


The reason we need this, is because of

```hs
-- | Describes a dependency on a pkg-config library
--
-- @since 2.0.0.2
data PkgconfigDependency = PkgconfigDependency
                           PkgconfigName
                           VersionRange
                         deriving (Generic, Read, Show, Eq, Typeable, Data)
```

which currently uses a `VersionRange`; but if we want to introduce a `PkgconfigVersion` type, we'd have to 

 1. either duplicate `VersionRange` (into a `PkgconfigVersionRange`) or 
 2. abstract the current one over the "version field".

And this refactoring explores the 2nd option, which tries to reduce code duplication (think also of e.g. how the solver code would be affected).

Any suggestions/ideas?