### PR TITLE
Update Cabal/changelog with buildDepends removal

### DIFF
--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -49,6 +49,10 @@
 	* Pretty-printing of .cabal files is slightly different due to
 	  parser changes. For an example, see
 	  https://mail.haskell.org/pipermail/cabal-devel/2017-December/010414.html.
+	* `buildDepends` is removed from `PackageDescription`. It had long been
+	  uselessly hanging about as top-level build-depends already got put
+	  into per-component condition trees anyway. Now it's finally be put out
+	  of its misery.
 	* TODO
 
 2.0.1.1 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> December 2017


### PR DESCRIPTION
Forgot to do this in #4383 

[skip ci]

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
