### PR TITLE
WIP: Add BlockArguments to KnownExtension

### DIFF
--- a/Cabal/Language/Haskell/Extension.hs
+++ b/Cabal/Language/Haskell/Extension.hs
@@ -809,6 +809,9 @@ data KnownExtension =
   -- | Allow use of hexadecimal literal notation for floating-point values.
   | HexFloatLiterals
 
+  -- | Allow @do@ blocks etc. in argument position.
+  | BlockArguments
+
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable, Data)
 
 instance Binary KnownExtension

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -53,6 +53,7 @@
 	  uselessly hanging about as top-level build-depends already got put
 	  into per-component condition trees anyway. Now it's finally been put
 	  out of its misery.
+	* Add `BlockArguments` to `KnownExtension`.
 	* TODO
 
 2.0.1.1 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> December 2017


### PR DESCRIPTION
GHC 8.6 will support this extension.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

No test has been done locally.