### PR TITLE
Extension: Add NumericUnderscores

### DIFF
--- a/Cabal/Language/Haskell/Extension.hs
+++ b/Cabal/Language/Haskell/Extension.hs
@@ -812,6 +812,9 @@ data KnownExtension =
   -- | Allow @do@ blocks etc. in argument position.
   | BlockArguments
 
+  -- | Allow use of underscores in numeric literals.
+  | NumericUnderscores
+
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable, Data)
 
 instance Binary KnownExtension

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -54,6 +54,7 @@
 	  into per-component condition trees anyway. Now it's finally been put
 	  out of its misery.
 	* Add `BlockArguments` to `KnownExtension`.
+	* Added `NumericUnderscores` to `KnownExtension`.
 	* TODO
 
 2.0.1.1 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> December 2017


### PR DESCRIPTION
GHC 8.6 will support this extension.
This extension has already landed in ghc master branch.
(https://phabricator.haskell.org/D4235)

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

No testing performed.