### PR TITLE
Don't ignore goal order parameter when generating summarized solver log.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular.hs
+++ b/cabal-install/Distribution/Solver/Modular.hs
@@ -9,7 +9,9 @@ module Distribution.Solver.Modular
 -- and finally, we have to convert back the resulting install
 -- plan.
 
-import Data.Map (Map)
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import qualified Data.Map as M
 import Data.Set (Set)
 import Data.Ord
@@ -143,9 +145,14 @@ solve' sc cinfo idx pkgConfigDB pprefs gcs pns =
     rerunSolverForErrorMsg :: ConflictSet -> String -> String
     rerunSolverForErrorMsg cs finalMsg =
       let sc' = sc {
-                    goalOrder = Just (preferGoalsFromConflictSet cs)
+                    goalOrder = Just goalOrder'
                   , maxBackjumps = Just 0
                   }
+
+          -- Preferring goals from the conflict set takes precedence over the
+          -- original goal order.
+          goalOrder' = preferGoalsFromConflictSet cs <> fromMaybe mempty (goalOrder sc)
+
       in unlines ("Could not resolve dependencies:" : messages (runSolver sc'))
           ++ finalMsg
 

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -1491,7 +1491,7 @@ chooseExeAfterBuildToolsPackage shouldSucceed name =
     goals = [
         P QualNone "A"
       , P (QualExe "A" "B") "B"
-      , F QualNone "A" "flag"
+      , F QualNone "A" "flagA"
       ]
 
 -- | Test that when one package depends on two executables from another package,


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

_____________________________________________________________________

After #5012, the solver generated the summarized log by using a goal order that
preferred goals from the final conflict set.  It completely ignored the original
goal order parameter.  This caused a failure in one of the unit tests that set a
goal order and then checked the summarized log, when the solver's goal order
changed for other reasons (See #5012).

This commit combines the two goal orders, with the goal order that prefers goals
from the conflict set taking precedence over the original goal order.

_____________________________________________________________________

This should fix the solver unit test failure on master.  I think it was caused by the combination of #5012 and #5035.