### PR TITLE
Make Cabal-1.24 compile with ghc-8.2.2

### DIFF
--- a/Cabal/Distribution/Compiler.hs
+++ b/Cabal/Distribution/Compiler.hs
@@ -60,6 +60,8 @@ import Text.PrettyPrint ((<>))
 import qualified Data.Char as Char (toLower, isDigit, isAlphaNum)
 import Control.Monad (when)
 
+import Prelude hiding ((<>))
+
 data CompilerFlavor = GHC | GHCJS | NHC | YHC | Hugs | HBC | Helium | JHC | LHC | UHC
                     | HaskellSuite String -- string is the id of the actual compiler
                     | OtherCompiler String

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -54,6 +54,8 @@ import Text.PrettyPrint as Disp
 import Data.Maybe   (fromMaybe)
 import GHC.Generics (Generic)
 
+import Prelude hiding ((<>))
+
 -- -----------------------------------------------------------------------------
 -- The InstalledPackageInfo type
 

--- a/Cabal/Distribution/License.hs
+++ b/Cabal/Distribution/License.hs
@@ -59,6 +59,8 @@ import Data.Data (Data)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 
+import Prelude hiding ((<>))
+
 -- | Indicates the license under which a package's source code is released.
 -- Versions of the licenses not listed here will be rejected by Hackage and
 -- cause @cabal check@ to issue a warning.

--- a/Cabal/Distribution/Package.hs
+++ b/Cabal/Distribution/Package.hs
@@ -65,6 +65,8 @@ import Data.Typeable ( Typeable )
 import GHC.Generics (Generic)
 import Text.PrettyPrint ((<>), (<+>), text)
 
+import Prelude hiding ((<>))
+
 newtype PackageName = PackageName { unPackageName :: String }
     deriving (Generic, Read, Show, Eq, Ord, Typeable, Data)
 

--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -138,6 +138,8 @@ import qualified Data.Char as Char (isAlphaNum, isDigit, toLower)
 import qualified Data.Map as Map
 import Data.Map                    (Map)
 
+import Prelude hiding ((<>))
+
 -- -----------------------------------------------------------------------------
 -- The PackageDescription type
 

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -65,6 +65,8 @@ import System.FilePath
 import System.FilePath.Windows as FilePath.Windows
          ( isValid )
 
+import Prelude hiding ((<>))
+
 -- | Results of some kind of failed package check.
 --
 -- There are a range of severities, from merely dubious to totally insane.

--- a/Cabal/Distribution/PackageDescription/Parse.hs
+++ b/Cabal/Distribution/PackageDescription/Parse.hs
@@ -69,6 +69,8 @@ import qualified Data.ByteString.Lazy.Char8 as BS.Char8
 
 import Text.PrettyPrint
 
+import Prelude hiding ((<>))
+
 
 -- -----------------------------------------------------------------------------
 -- The PackageDescription type

--- a/Cabal/Distribution/PackageDescription/PrettyPrint.hs
+++ b/Cabal/Distribution/PackageDescription/PrettyPrint.hs
@@ -30,6 +30,8 @@ import Text.PrettyPrint
        (hsep, parens, char, nest, empty, isEmpty, ($$), (<+>),
         colon, (<>), text, vcat, ($+$), Doc, render)
 
+import Prelude hiding ((<>))
+
 -- | Recompile with false for regression testing
 simplifiedPrinting :: Bool
 simplifiedPrinting = False

--- a/Cabal/Distribution/ParseUtils.hs
+++ b/Cabal/Distribution/ParseUtils.hs
@@ -61,6 +61,8 @@ import Control.Applicative as AP (Applicative(..))
 import System.FilePath (normalise)
 import Data.List (sortBy)
 
+import Prelude hiding ((<>))
+
 -- -----------------------------------------------------------------------------
 
 type LineNo    = Int

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -85,7 +85,6 @@ import qualified Distribution.Simple.UHC   as UHC
 import qualified Distribution.Simple.HaskellSuite as HaskellSuite
 
 -- Prefer the more generic Data.Traversable.mapM to Prelude.mapM
-import Prelude hiding ( mapM )
 import Control.Exception
     ( Exception, evaluate, throw, throwIO, try )
 import Control.Exception ( ErrorCall )
@@ -126,6 +125,8 @@ import Text.PrettyPrint
     , punctuate, quotes, render, renderStyle, sep, text )
 import Distribution.Compat.Environment ( lookupEnv )
 import Distribution.Compat.Exception ( catchExit, catchIO )
+
+import Prelude hiding ( (<>), mapM )
 
 -- | The errors that can be thrown when reading the @setup-config@ file.
 data ConfigStateFileError


### PR DESCRIPTION
No semantic changes, just added the necessary `import Prelude hiding ((<>))` lines where needed. Compiles now with ghc-8.2.2 and ghc-7.10.3.