### PR TITLE
Reorganize constraints in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,27 @@
 packages: Cabal/ cabal-testsuite/ cabal-install/ solver-benchmarks/ pretty-show-1.6.16/
+
+-- Build monolithic cabal-install (for downstream travis)
+-- See https://github.com/haskell/cabal/commit/bed3e5ca12751496e5882a7ca55b4b63ac2a6882#diff-72cbbeadf0579ad394cea550eabd9512
+constraints:
+  cabal-install +lib +monolithic
+
+-- We want to be sure we can build Cabal with dependencies bundled with GHC
+constraints:
+  array        installed,
+  base         installed,
+  bytestring   installed,
+  containers   installed,
+  deepseq      installed,
+  directory    installed,
+  filepath     installed,
+  pretty       installed,
+  process      installed,
+  time         installed,
+  transformers installed
+
+-- This fixes CI build with GHC-7.8 and earlier on macOS.
+-- https://github.com/haskell/cabal/commit/2ed454ee70e2d900d7ed13c2950a3bb4af3b08c7#diff-72cbbeadf0579ad394cea550eabd9512
 constraints: unix >= 2.7.1.0
-           , cabal-install +lib +monolithic
 
 -- Uncomment to allow picking up extra local unpacked deps:
 --optional-packages: */


### PR DESCRIPTION
Add `installed` constraints for dependencies of Cabal,
then we don't accidentally bump a lower bound in Cabal.

Also comment why we have +monolithic, or why we have unix lower bound.

---

Can we drop GHC-7.8 macOS support. On recent macs you cannot get GHC-7.8 to work anyway (we use old image in CI).

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
