### PR TITLE
Use 'assertBool' instead of 'assert' to avoid deprecation warning.

### DIFF
--- a/solver-benchmarks/tests/HackageBenchmarkTest.hs
+++ b/solver-benchmarks/tests/HackageBenchmarkTest.hs
@@ -1,7 +1,7 @@
 import HackageBenchmark
 import Statistics.Types (mkPValue)
 import Test.Tasty (TestTree, defaultMain, testGroup)
-import Test.Tasty.HUnit (assert, testCase, (@?=))
+import Test.Tasty.HUnit (assertBool, testCase, (@?=))
 
 main :: IO ()
 main = defaultMain tests
@@ -11,19 +11,19 @@ tests = testGroup "unit tests" [
 
     testGroup "isSignificantTimeDifference" [
 
-        testCase "detect increase in distribution" $ assert $
+        testCase "detect increase in distribution" $ assertBool "" $
             isSignificantTimeDifference (mkPValue 0.05) [1,2..7] [4,5..10]
 
-      , testCase "detect decrease in distribution" $ assert $
+      , testCase "detect decrease in distribution" $ assertBool "" $
             isSignificantTimeDifference (mkPValue 0.05) [1,2..7] [-2,-1..4]
 
-      , testCase "ignore same data" $ assert $
+      , testCase "ignore same data" $ assertBool "" $
             not $ isSignificantTimeDifference (mkPValue 0.05) [1,2..10] [1,2..10]
 
-      , testCase "same data with high p-value is significant" $ assert $
+      , testCase "same data with high p-value is significant" $ assertBool "" $
             isSignificantTimeDifference (mkPValue 0.9) [1,2..10] [1,2..10]
 
-      , testCase "ignore outlier" $ assert $
+      , testCase "ignore outlier" $ assertBool "" $
             not $ isSignificantTimeDifference (mkPValue 0.05) [1, 2, 1, 1, 1] [2, 1, 50, 1, 1]
       ]
 
@@ -47,43 +47,44 @@ tests = testGroup "unit tests" [
 
   , testGroup "isSignificantResult" [
 
-        testCase "different results are significant" $ assert $
+        testCase "different results are significant" $ assertBool "" $
             isSignificantResult NoInstallPlan BackjumpLimit
 
-      , testCase "unknown result is significant" $ assert $
+      , testCase "unknown result is significant" $ assertBool "" $
             isSignificantResult Unknown Unknown
 
-      , testCase "PkgNotFound is significant" $ assert $
+      , testCase "PkgNotFound is significant" $ assertBool "" $
             isSignificantResult PkgNotFound PkgNotFound
 
-      , testCase "same expected error is not significant" $ assert $
+      , testCase "same expected error is not significant" $ assertBool "" $
             not $ isSignificantResult NoInstallPlan NoInstallPlan
 
-      , testCase "success is not significant" $ assert $
+      , testCase "success is not significant" $ assertBool "" $
             not $ isSignificantResult Solution Solution
     ]
 
   , testGroup "shouldContinueAfterFirstTrial" [
 
-        testCase "rerun when min difference is zero" $ assert $
+        testCase "rerun when min difference is zero" $ assertBool "" $
                   shouldContinueAfterFirstTrial 0 1.0 1.0 Solution Solution
 
-      , testCase "rerun when min difference is zero, even with timeout" $ assert $
+      , testCase "rerun when min difference is zero, even with timeout" $
+                  assertBool "" $
                   shouldContinueAfterFirstTrial 0 1.0 1.0 Timeout Timeout
 
-      , testCase "treat timeouts as the same time" $ assert $
+      , testCase "treat timeouts as the same time" $ assertBool "" $
             not $ shouldContinueAfterFirstTrial 0.000001 89.9 92.0 Timeout Timeout
 
-      , testCase "skip when times are too close - 1" $ assert $
+      , testCase "skip when times are too close - 1" $ assertBool "" $
             not $ shouldContinueAfterFirstTrial 10 1.0 0.91  Solution Solution
 
-      , testCase "skip when times are too close - 2" $ assert $
+      , testCase "skip when times are too close - 2" $ assertBool "" $
             not $ shouldContinueAfterFirstTrial 10 1.0 1.09  Solution Solution
 
-      , testCase "rerun when times aren't too close - 1" $ assert $
+      , testCase "rerun when times aren't too close - 1" $ assertBool "" $
                   shouldContinueAfterFirstTrial 10 1.0 0.905 Solution Solution
 
-      , testCase "rerun when times aren't too close - 2" $ assert $
+      , testCase "rerun when times aren't too close - 2" $ assertBool "" $
                   shouldContinueAfterFirstTrial 10 1.0 1.1   Solution Solution
     ]
   ]


### PR DESCRIPTION
tasty-hunit deprecated the Assertable typeclass in version 0.10, so this commit
updates the solver-benchmarks unit tests.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
