### PR TITLE
Add Eta compiler

### DIFF
--- a/Cabal/Distribution/Compiler.hs
+++ b/Cabal/Distribution/Compiler.hs
@@ -59,7 +59,7 @@ import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint as Disp
 
 data CompilerFlavor =
-  GHC | GHCJS | NHC | YHC | Hugs | HBC | Helium | JHC | LHC | UHC
+  GHC | GHCJS | NHC | YHC | Hugs | HBC | Helium | JHC | LHC | UHC | Eta
   | HaskellSuite String -- string is the id of the actual compiler
   | OtherCompiler String
   deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
@@ -69,7 +69,8 @@ instance Binary CompilerFlavor
 instance NFData CompilerFlavor where rnf = genericRnf
 
 knownCompilerFlavors :: [CompilerFlavor]
-knownCompilerFlavors = [GHC, GHCJS, NHC, YHC, Hugs, HBC, Helium, JHC, LHC, UHC]
+knownCompilerFlavors =
+  [GHC, GHCJS, NHC, YHC, Hugs, HBC, Helium, JHC, LHC, UHC, Eta]
 
 instance Pretty CompilerFlavor where
   pretty (OtherCompiler name) = Disp.text name

--- a/Cabal/changelog
+++ b/Cabal/changelog
@@ -7,6 +7,7 @@
 	  uselessly hanging about as top-level build-depends already got put
 	  into per-component condition trees anyway. Now it's finally been put
 	  out of its misery (#4383).
+	* Added `Eta` to `CompilerFlavor` and to known compilers.
 
 2.2.0.0 (TODO)
 	* The 2.2 migration guide gives advice on adapting Custom setup


### PR DESCRIPTION
fix haskell/hackage-server#674

----

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

tested with `cabal build`