### PR TITLE
bootstrap: Pass SCOPE_OF_INSTALL to ghc when building Setup.hs

### DIFF
--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -354,7 +354,12 @@ install_pkg () {
   [ -x Setup ] && ./Setup clean
   [ -f Setup ] && rm Setup
 
-  ${GHC} --make ${JOBS} Setup -o Setup -XRank2Types -XFlexibleContexts ||
+  PKG_DBS=$(printf '%s\n' "${SCOPE_OF_INSTALLATION}" \
+             | sed -e 's/--package-db/-package-db/' \
+                   -e 's/--global/-global-package-db/' \
+                   -e 's/--user/-user-package-db/')
+
+  ${GHC} --make ${JOBS} ${PKG_DBS} Setup -o Setup -XRank2Types -XFlexibleContexts ||
     die "Compiling the Setup script failed."
 
   [ -x Setup ] || die "The Setup script does not exist or cannot be run"


### PR DESCRIPTION
Now that Cabal depends on parsec bootstrap.sh should compile its `Setup.hs` with the bootstrapping libraries' package-db in scope, otherwise users will be forced to manually install the correct version of parsec etc. to even get the bootstrap script to work!