### PR TITLE
Implement ghc/cabal compatiblity matrix

### DIFF
--- a/cabal-testsuite/PackageTests/CustomDep/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/CustomDep/cabal.test.hs
@@ -2,6 +2,8 @@ import Test.Cabal.Prelude
 main = cabalTest $ do
     -- NB: This variant seems to use the bootstrapped Cabal?
     skipUnless =<< hasCabalForGhc
+    -- implicit setup-depends conflict with GHC >= 8.2; c.f. #415
+    skipIf =<< (ghcVersionIs (>= mkVersion [8,2]))
     -- This test depends heavily on what packages are in the global
     -- database, don't record the output
     recordMode DoNotRecord $ do

--- a/cabal-testsuite/PackageTests/CustomPlain/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/CustomPlain/cabal.test.hs
@@ -1,5 +1,7 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
+    -- implicit setup-depends conflict with GHC >= 8.2; c.f. #415
+    skipIf =<< (ghcVersionIs (>= mkVersion [8,2]))
     -- Regression test for #4393
     recordMode DoNotRecord $ do
         -- TODO: Hack; see also CustomDep/cabal.test.hs

--- a/cabal-testsuite/PackageTests/Regression/T3932/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T3932/cabal.test.hs
@@ -5,8 +5,11 @@ main = cabalTest $
     -- extra constraint that setup Cabal must be 1.20.  If we don't
     -- have a choice like this available, the unsatisfied constraint
     -- won't be reported.
+    --
+    -- Due to #415, the lower bound may be even higher based on GHC
+    -- version
     withRepo "repo" $ do
         -- Don't record because output wobbles based on installed database.
         recordMode DoNotRecord $ do
             fails (cabal' "new-build" []) >>=
-                assertOutputContains "Setup.hs requires >=1.20"
+                assertOutputContains "Setup.hs requires >="


### PR DESCRIPTION
This addresses #415

This injects lower-bound constraints on Cabal for custom setup
dependencies to prevent the solver from selecting unsupported
configurations.

Previously we already added an absolute lower bound `Cabal >= 1.20`
for nix-local builds, as that's the minimum version we need to be able
to interact with custom Setup.hs scripts. This refines with logic by
restricting that lower bound even more based on GHC version.

This patch augments this with the following rules:

- GHC 8.4+   constrains  `Cabal >= 2.2`
- GHC 8.2    constrains  `Cabal >= 2.0`
- GHC 8.0    constrains  `Cabal >= 1.24`
- GHC 7.10   constrains  `Cabal >= 1.22`
- (default   constraint `Cabal >= 1.20`)

This only affects nix-style local builds codepaths.

----

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
