### PR TITLE
Enforce the backjump limit before creating the solver log. 

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install/Distribution/Solver/Modular/Explore.hs
@@ -211,9 +211,10 @@ avoidSet var gr =
 backjumpAndExplore :: Maybe Int
                    -> EnableBackjumping
                    -> CountConflicts
-                   -> Tree d QGoalReason -> Log Message (Assignment, RevDepMap)
+                   -> Tree d QGoalReason
+                   -> RetryLog Message SolverFailure (Assignment, RevDepMap)
 backjumpAndExplore mbj enableBj countConflicts =
-    toProgress . mapFailure convertFailure . exploreLog mbj enableBj countConflicts . assign
+    mapFailure convertFailure . exploreLog mbj enableBj countConflicts . assign
   where
     convertFailure (NoSolution cs es) = ExhaustiveSearch cs (esConflictMap es)
     convertFailure BackjumpLimit      = BackjumpLimitReached

--- a/cabal-install/Distribution/Solver/Modular/Log.hs
+++ b/cabal-install/Distribution/Solver/Modular/Log.hs
@@ -11,7 +11,6 @@ import Distribution.Solver.Types.Progress
 
 import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Message
-import Distribution.Solver.Modular.Tree (FailReason(..))
 import qualified Distribution.Solver.Modular.ConflictSet as CS
 import Distribution.Verbosity
 
@@ -20,54 +19,36 @@ import Distribution.Verbosity
 -- Represents the progress of a computation lazily.
 --
 -- Parameterized over the type of actual messages and the final result.
-type Log m a = Progress m (ConflictSet, ConflictMap) a
+type Log m a = Progress m SolverFailure a
 
-data Exhaustiveness = Exhaustive | BackjumpLimit
-
--- | Information about a dependency solver failure. It includes an error message
--- and a final conflict set, if available.
+-- | Information about a dependency solver failure.
 data SolverFailure =
-    NoSolution ConflictSet String
-  | BackjumpLimitReached String
+    ExhaustiveSearch ConflictSet ConflictMap
+  | BackjumpLimitReached
 
--- | Postprocesses a log file. Takes as an argument a limit on allowed backjumps.
--- If the limit is 'Nothing', then infinitely many backjumps are allowed. If the
--- limit is 'Just 0', backtracking is completely disabled.
-logToProgress :: Verbosity -> Maybe Int -> Log Message a -> Progress String SolverFailure a
-logToProgress verbosity mbj l =
-    let ms = proc mbj l
-        mapFailure f = foldProgress Step (Fail . f) Done
-    in mapFailure finalError (showMessages ms) -- run with backjump limit applied
+-- | Postprocesses a log file. When the dependency solver fails to find a
+-- solution, the log ends with a SolverFailure and a message describing the
+-- failure.
+logToProgress :: Verbosity
+              -> Maybe Int
+              -> Log Message a
+              -> Progress String (SolverFailure, String) a
+logToProgress verbosity mbj lg =
+    let mapFailure f = foldProgress Step (Fail . f) Done
+    in mapFailure (\failure -> (failure, finalErrorMsg failure))
+                  (showMessages lg)
   where
-    -- Proc takes the allowed number of backjumps and a 'Progress' and explores the
-    -- messages until the maximum number of backjumps has been reached. It filters out
-    -- and ignores repeated backjumps. If proc reaches the backjump limit, it truncates
-    -- the 'Progress' and ends it with the last conflict set. Otherwise, it leaves the
-    -- original result.
-    proc :: Maybe Int -> Log Message b -> Progress Message (Exhaustiveness, ConflictSet, ConflictMap) b
-    proc _        (Done x)                          = Done x
-    proc _        (Fail (cs, cm))                   = Fail (Exhaustive, cs, cm)
-    proc mbj'     (Step x@(Failure cs Backjump) xs@(Step Leave (Step (Failure cs' Backjump) _)))
-      | cs == cs'                                   = Step x (proc mbj'           xs) -- repeated backjumps count as one
-    proc (Just 0) (Step   (Failure cs Backjump)  _) = Fail (BackjumpLimit, cs, mempty) -- No final conflict map available
-    proc (Just n) (Step x@(Failure _  Backjump) xs) = Step x (proc (Just (n - 1)) xs)
-    proc mbj'     (Step x                       xs) = Step x (proc mbj'           xs)
-
-    finalError :: (Exhaustiveness, ConflictSet, ConflictMap) -> SolverFailure
-    finalError (exh, cs, cm) =
-        case exh of
-            Exhaustive ->
-                NoSolution cs $
-                "After searching the rest of the dependency tree exhaustively, "
-                ++ "these were the goals I've had most trouble fulfilling: "
-                ++ showCS cm cs
-              where
-                showCS = if verbosity > normal
-                         then CS.showCSWithFrequency
-                         else CS.showCSSortedByFrequency
-            BackjumpLimit ->
-                BackjumpLimitReached $
-                "Backjump limit reached (" ++ currlimit mbj ++
-                "change with --max-backjumps or try to run with --reorder-goals).\n"
-              where currlimit (Just n) = "currently " ++ show n ++ ", "
-                    currlimit Nothing  = ""
+    finalErrorMsg :: SolverFailure -> String
+    finalErrorMsg (ExhaustiveSearch cs cm) =
+        "After searching the rest of the dependency tree exhaustively, "
+        ++ "these were the goals I've had most trouble fulfilling: "
+        ++ showCS cm cs
+      where
+        showCS = if verbosity > normal
+                 then CS.showCSWithFrequency
+                 else CS.showCSSortedByFrequency
+    finalErrorMsg BackjumpLimitReached =
+        "Backjump limit reached (" ++ currlimit mbj ++
+        "change with --max-backjumps or try to run with --reorder-goals).\n"
+      where currlimit (Just n) = "currently " ++ show n ++ ", "
+            currlimit Nothing  = ""

--- a/cabal-install/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install/Distribution/Solver/Modular/Message.hs
@@ -53,16 +53,10 @@ showMessages = go 0
         (atLevel l $ "rejecting: " ++ showQSNBool qsn b ++ showFR c fr) (go l ms)
     go !l (Step (Next (Goal (P _  ) gr)) (Step (TryP qpn' i) ms@(Step Enter (Step (Next _) _)))) =
         (atLevel l $ "trying: " ++ showQPNPOpt qpn' i ++ showGR gr) (go l ms)
-    go !l (Step (Next (Goal (P qpn) gr)) ms@(Fail _)) =
-        (atLevel l $ "unknown package: " ++ showQPN qpn ++ showGR gr) $ go l ms
-        -- the previous case potentially arises in the error output, because we remove the backjump itself
-        -- if we cut the log after the first error
     go !l (Step (Next (Goal (P qpn) gr)) ms@(Step (Failure _c Backjump) _)) =
         (atLevel l $ "unknown package: " ++ showQPN qpn ++ showGR gr) $ go l ms
     go !l (Step (Next (Goal (P qpn) gr)) (Step (Failure c fr) ms)) =
         (atLevel l $ showPackageGoal qpn gr) $ (atLevel l $ showFailure c fr) (go l ms)
-    go !l (Step (Failure c Backjump) ms@(Step Leave (Step (Failure c' Backjump) _)))
-        | c == c' = go l ms
     -- standard display
     go !l (Step Enter                    ms) = go (l+1) ms
     go !l (Step Leave                    ms) = go (l-1) ms

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -99,7 +99,9 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
   prunePhase       $
   buildPhase
   where
-    explorePhase     = backjumpAndExplore (enableBackjumping sc) (countConflicts sc)
+    explorePhase     = backjumpAndExplore (maxBackjumps sc)
+                                          (enableBackjumping sc)
+                                          (countConflicts sc)
     detectCycles     = traceTree "cycles.json" id . detectCyclesPhase
     heuristicsPhase  =
       let heuristicsTree = traceTree "heuristics.json" id

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -36,6 +36,7 @@ import qualified Distribution.Solver.Modular.Preference as P
 import Distribution.Solver.Modular.Validate
 import Distribution.Solver.Modular.Linking
 import Distribution.Solver.Modular.PSQ (PSQ)
+import Distribution.Solver.Modular.RetryLog
 import Distribution.Solver.Modular.Tree
 import qualified Distribution.Solver.Modular.PSQ as PSQ
 
@@ -89,7 +90,7 @@ solve :: SolverConfig                         -- ^ solver parameters
       -> (PN -> PackagePreferences)           -- ^ preferences
       -> Map PN [LabeledPackageConstraint]    -- ^ global constraints
       -> Set PN                               -- ^ global goals
-      -> Log Message (Assignment, RevDepMap)
+      -> RetryLog Message SolverFailure (Assignment, RevDepMap)
 solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
   explorePhase     $
   detectCycles     $

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -61,6 +61,7 @@ import qualified Distribution.Simple.PackageIndex       as C.PackageIndex
 import           Distribution.Simple.Setup (BooleanFlag(..))
 import qualified Distribution.System                    as C
 import           Distribution.Text (display)
+import qualified Distribution.Verbosity                 as C
 import qualified Distribution.Version                   as C
 import Language.Haskell.Extension (Extension(..), Language(..))
 
@@ -624,11 +625,12 @@ exResolve :: ExampleDb
           -> Maybe (Variable P.QPN -> Variable P.QPN -> Ordering)
           -> [ExConstraint]
           -> [ExPreference]
+          -> C.Verbosity
           -> EnableAllTests
           -> Progress String String CI.SolverInstallPlan.SolverInstallPlan
 exResolve db exts langs pkgConfigDb targets mbj countConflicts indepGoals
           reorder allowBootLibInstalls enableBj solveExes goalOrder constraints
-          prefs enableAllTests
+          prefs verbosity enableAllTests
     = resolveDependencies C.buildPlatform compiler pkgConfigDb Modular params
   where
     defaultCompiler = C.unknownCompilerInfo C.buildCompilerId C.NoAbiTag
@@ -659,6 +661,7 @@ exResolve db exts langs pkgConfigDb targets mbj countConflicts indepGoals
                    $ setEnableBackjumping enableBj
                    $ setSolveExecutables solveExes
                    $ setGoalOrder goalOrder
+                   $ setSolverVerbosity verbosity
                    $ standardInstallPolicy instIdx avaiIdx targets'
     toLpc     pc = LabeledPackageConstraint pc ConstraintSourceUnknown
 

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
@@ -78,7 +78,8 @@ constraints cs test = test { testConstraints = cs }
 preferences :: [ExPreference] -> SolverTest -> SolverTest
 preferences prefs test = test { testSoftConstraints = prefs }
 
--- | Increase the solver's verbosity.
+-- | Increase the solver's verbosity. This is necessary for test cases that
+-- check the contents of the verbose log.
 setVerbose :: SolverTest -> SolverTest
 setVerbose test = test { testVerbosity = verbose }
 

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -39,6 +39,7 @@ import           Distribution.Solver.Types.PkgConfigDb
                    (pkgConfigDbFromList)
 import           Distribution.Solver.Types.Settings
 import           Distribution.Solver.Types.Variable
+import           Distribution.Verbosity
 import           Distribution.Version
 
 import UnitTests.Distribution.Solver.Modular.DSL
@@ -144,7 +145,7 @@ solve enableBj reorder countConflicts indep goalOrder test =
                   (Just defaultMaxBackjumps)
                   countConflicts indep reorder (AllowBootLibInstalls False)
                   enableBj (SolveExecutables True) (unVarOrdering <$> goalOrder)
-                  (testConstraints test) (testPreferences test)
+                  (testConstraints test) (testPreferences test) normal
                   (EnableAllTests False)
 
       failure :: String -> Failure

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -63,7 +63,8 @@ tests = [
 
         , let checkFullLog =
                   any $ isInfixOf "rejecting: pkg:-flag (manual flag can only be changed explicitly)"
-          in runTest $ constraints [ExVersionConstraint (ScopeAnyQualifier "true-dep") V.noVersion] $
+          in runTest $ setVerbose $
+             constraints [ExVersionConstraint (ScopeAnyQualifier "true-dep") V.noVersion] $
              mkTest dbManualFlags "Don't toggle manual flag to avoid conflict" ["pkg"] $
              -- TODO: We should check the summarized log instead of the full log
              -- for the manual flags error message, but it currently only
@@ -110,7 +111,7 @@ tests = [
                   all (\msg -> any (msg `isInfixOf`) lns)
                   [ "rejecting: B:-flag "         ++ failureReason
                   , "rejecting: A:setup.B:+flag " ++ failureReason ]
-          in runTest $ constraints cs $
+          in runTest $ constraints cs $ setVerbose $
              mkTest dbLinkedSetupDepWithManualFlag name ["A"] $
              SolverResult checkFullLog (Left $ const True)
         ]
@@ -339,7 +340,7 @@ tests = [
                   p :: [String] -> Bool
                   p lg =    elem "targets: A" lg
                          && length (filter ("trying: A" `isInfixOf`) lg) == 1
-              in mkTest db "deduplicate targets" ["A", "A"] $
+              in setVerbose $ mkTest db "deduplicate targets" ["A", "A"] $
                  SolverResult p $ Right [("A", 1)]
         , runTest $
               let db = [Right $ exAv "A" 1 [ExAny "B"]]
@@ -814,7 +815,7 @@ db15 = [
 -- package and then choose a different version for the setup dependency.
 issue4161 :: String -> SolverTest
 issue4161 name =
-    mkTest db name ["target"] $
+    setVerbose $ mkTest db name ["target"] $
     SolverResult checkFullLog $ Right [("target", 1), ("time", 1), ("time", 2)]
   where
     db :: ExampleDb

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -354,13 +354,14 @@ tests = [
              ++ "[__1] fail (backjumping, conflict set: A, D)\n"
              ++ "After searching the rest of the dependency tree exhaustively, "
              ++ "these were the goals I've had most trouble fulfilling: A, D"
-        , testSummarizedLog "show first conflicts after inexhaustive search" (Just 2) $
+        , testSummarizedLog "show first conflicts after inexhaustive search" (Just 3) $
                 "Could not resolve dependencies:\n"
              ++ "[__0] trying: A-1.0.0 (user goal)\n"
              ++ "[__1] trying: B-3.0.0 (dependency of A)\n"
              ++ "[__2] next goal: C (dependency of B)\n"
              ++ "[__2] rejecting: C-1.0.0 (conflict: B => C==3.0.0)\n"
-             ++ "Backjump limit reached (currently 2, change with --max-backjumps "
+             ++ "[__2] fail (backjumping, conflict set: B, C)\n"
+             ++ "Backjump limit reached (currently 3, change with --max-backjumps "
              ++ "or try to run with --reorder-goals).\n"
         , testSummarizedLog "don't show summarized log when backjump limit is too low" (Just 1) $
                 "Backjump limit reached (currently 1, change with --max-backjumps "

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -43,6 +43,7 @@ tests = [
         , runTest $         mkTest db21 "unknownPackage1"   ["A"]      (solverSuccess [("A", 1), ("B", 1)])
         , runTest $         mkTest db22 "unknownPackage2"   ["A"]      (solverFailure (isInfixOf "unknown package: C"))
         , runTest $         mkTest db23 "unknownPackage3"   ["A"]      (solverFailure (isInfixOf "unknown package: B"))
+        , runTest $         mkTest []   "unknown target"    ["A"]      (solverFailure (isInfixOf "unknown package: A"))
         ]
     , testGroup "Flagged dependencies" [
           runTest $         mkTest db3 "forceFlagOn"  ["C"]      (solverSuccess [("A", 1), ("B", 1), ("C", 1)])

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/use-local-version-of-package.out
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/use-local-version-of-package.out
@@ -16,4 +16,5 @@ cabal: Could not resolve dependencies:
 [__0] next goal: pkg (user goal)
 [__0] rejecting: pkg-2.0 (constraint from user target requires ==1.0)
 [__0] rejecting: pkg-1.0 (constraint from command line flag requires ==2.0)
+[__0] fail (backjumping, conflict set: pkg)
 After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: pkg (3)

--- a/cabal-testsuite/PackageTests/InternalVersions/BuildDependsBad/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/InternalVersions/BuildDependsBad/setup.cabal.out
@@ -4,6 +4,7 @@ Warning: solver failed to find a solution:
 Could not resolve dependencies:
 [__0] next goal: build-depends-bad-version (user goal)
 [__0] rejecting: build-depends-bad-version-0.1.0.0 (conflict: build-depends-bad-version==0.1.0.0, build-depends-bad-version => build-depends-bad-version>=2)
+[__0] fail (backjumping, conflict set: build-depends-bad-version)
 After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: build-depends-bad-version (2)
 Trying configure anyway.
 Configuring build-depends-bad-version-0.1.0.0...


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

________________________________________________________________________

This PR enforces the backjump limit when the solver explores the search tree, which could simplify implementing features such as #2860 or #4594.  It also skips processing the log when the log doesn't need to be printed, since the log is no longer needed for enforcing the backjump limit.  The main commits are:

#### Enforce the backjump limit before creating the solver log.

Previously, the solver enforced the backjump limit by counting `Backjump`
messages during log processing.  This commit instead enforces the backjump limit
when the solver explores the search tree.  This change simplifies the log
processing step and allows us to skip creating the log when we don't need to
print it, though that's not implemented in this commit.

This commit changes the meaning of the backjump count slightly.  Previously the
solver counted a backjump every time it backtracked and added at least one
variable to the conflict set.  Now it counts a backjump every time it unions all
conflict sets at the current level, even if the union is the same as the
conflict set from the level below.  That means that more steps count as
backjumps, and the solver can reach the backjump limit slightly earlier.

This commit also changes the log messages.  Previously, the solver sometimes
omitted the last `Backjump` message, but this commit always prints a `Backjump`
message when the solver fails.  Additionally, the level numbers for some
`Backjump` messages changed to match the levels where the conflict sets were
unioned.

#### Skip processing the solver log when the log isn't needed.

I tested this change by comparing performance with both
c01d92f (before any refactoring needed to
implement this change) and 4d28102 (the
previous commit), using hackage-benchmark.  Since the refactoring changed the
meaning of the backjump count, I only timed "install" commands that didn't reach
the backjump limit.  I chose several commands that ran for different amounts of
time, including the long running example from issue #4976.

Comparing c01d92f (cabal1) and this commit (cabal2):

compiler: GHC 8.2.1
index state: `2018-02-16T02:47:32Z`
extra hackage-benchmark flags:
`--packages="aeson yesod wolf" --pvalue=0.01 --trials=50 --print-skipped-packages`

```
package result1       result2             mean1       mean2     stddev1     stddev2     speedup
aeson   (not significant)
yesod   Solution      Solution           2.270s      2.258s      0.027s      0.031s      1.005
wolf    Solution      Solution           7.337s      7.234s      0.056s      0.047s      1.014
```

Comparing 4d28102 (cabal1) and this commit (cabal2) with the same environment
and flags as above:

```
package result1       result2             mean1       mean2     stddev1     stddev2     speedup
aeson   (not significant)
yesod   (not significant)
wolf    Solution      Solution           7.297s      7.245s      0.045s      0.048s      1.007
```

hackage-benchmark currently doesn't print the results when they aren't
significant, so I reran "`cabal install --dry-run aeson`", and it ran for about
1.6 seconds and found a solution.

Comparing c01d92f (cabal1) and this commit (cabal2) on issue #4976:

compiler: GHC 7.10.3
extra hackage-benchmark flags:
`--cabal1-flags="--index-state='2017-12-25T17:31:19Z' --enable-tests --max-backjumps=-1"
--cabal2-flags="--index-state='2017-12-25T17:31:19Z' --enable-tests --max-backjumps=-1"
--packages=servant-mock --pvalue=0.01 --trials=50 --print-skipped-packages --print-trials`

```
trial/summary    package      result1       result2             mean1       mean2     stddev1     stddev2     speedup
...
summary          servant-mock Solution      Solution          39.693s     38.863s      0.181s      0.174s      1.021
```

Comparing 4d28102 (cabal1) and this commit (cabal2) on issue #4976 with the
same environment and flags as above:

```
trial/summary    package      result1       result2             mean1       mean2     stddev1     stddev2     speedup
...
summary          servant-mock Solution      Solution          39.659s     38.960s      0.195s      0.162s      1.018
```

Overall, this seems like a very small performance improvement.