### PR TITLE
Bump parsec and text lower-bounds

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -362,8 +362,8 @@ library
   build-depends:
     transformers,
     mtl >= 2.1 && <2.3,
-    text >= 1.2.2.2 && <1.3,
-    parsec >= 3.1.9 && <3.2
+    text >= 1.2.3.0 && <1.3,
+    parsec >= 3.1.13.0 && <3.2
   exposed-modules:
     Distribution.Compat.Parsing
     Distribution.Compat.CharParsing

--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -209,14 +209,14 @@ PREFIX=${PREFIX:-${DEFAULT_PREFIX}}
 
 # Versions of the packages to install.
 # The version regex says what existing installed versions are ok.
-PARSEC_VER="3.1.9";    PARSEC_VER_REGEXP="[3]\.[01]\."
-                       # >= 3.0 && < 3.2
+PARSEC_VER="3.1.13.0"; PARSEC_VER_REGEXP="[3]\.[1]\."
+                       # >= 3.1 && < 3.2
 DEEPSEQ_VER="1.4.2.0"; DEEPSEQ_VER_REGEXP="1\.[1-9]\."
                        # >= 1.1 && < 2
 BINARY_VER="0.8.3.0";  BINARY_VER_REGEXP="[0]\.[78]\."
                        # >= 0.7 && < 0.9
-TEXT_VER="1.2.2.2";    TEXT_VER_REGEXP="((1\.[012]\.)|(0\.([2-9]|(1[0-1]))\.))"
-                       # >= 0.2 && < 1.3
+TEXT_VER="1.2.3.0";    TEXT_VER_REGEXP="[1]\.[2]\."
+                       # >= 1.2 && < 1.3
 NETWORK_VER="2.6.3.2"; NETWORK_VER_REGEXP="2\.[0-6]\."
                        # >= 2.0 && < 2.7
 NETWORK_URI_VER="2.6.1.0"; NETWORK_URI_VER_REGEXP="2\.6\."

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -67,6 +67,7 @@ executable cabal-tests
     process,
     optparse-applicative,
     cabal-testsuite,
+    transformers,
     exceptions
   default-language: Haskell2010
 


### PR DESCRIPTION
the versions are bundled with GHC-8.4.1, no need to support older.

some tool to make regexps in `bootstrap.sh` would be great, so I leave them as they are for now. (FWIW I have a library in cooking which can be used for that)

---

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
