### PR TITLE
cross compile exe extension

### DIFF
--- a/Cabal/Distribution/Simple/Bench.hs
+++ b/Cabal/Distribution/Simple/Bench.hs
@@ -53,7 +53,7 @@ bench args pkg_descr lbi flags = do
         doBench bm =
             case PD.benchmarkInterface bm of
               PD.BenchmarkExeV10 _ _ -> do
-                  let cmd = LBI.buildDir lbi </> name </> name <.> exeExtension
+                  let cmd = LBI.buildDir lbi </> name </> name <.> exeExtension (LBI.hostPlatform lbi)
                       options = map (benchOption pkg_descr lbi bm) $
                                 benchmarkOptions flags
                   -- Check that the benchmark executable exists.

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -568,7 +568,7 @@ addInternalBuildTools pkg lbi bi progs =
       [ simpleConfiguredProgram toolName' (FoundOnSystem toolLocation)
       | toolName <- getAllInternalToolDependencies pkg bi
       , let toolName' = unUnqualComponentName toolName
-      , let toolLocation = buildDir lbi </> toolName' </> toolName' <.> exeExtension ]
+      , let toolLocation = buildDir lbi </> toolName' </> toolName' <.> exeExtension (hostPlatform lbi) ]
 
 
 -- TODO: build separate libs in separate dirs so that we can build

--- a/Cabal/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/Distribution/Simple/BuildPaths.hs
@@ -224,8 +224,8 @@ mkStaticLibName (CompilerId compilerFlavor compilerVersion) lib
 
 -- | Default extension for executable files on the current platform.
 -- (typically @\"\"@ on Unix and @\"exe\"@ on Windows or OS\/2)
-exeExtension :: String
-exeExtension = case buildOS of
+exeExtension :: Platform -> String
+exeExtension (Platform _arch os) = case os of
                    Windows -> "exe"
                    _       -> ""
 

--- a/Cabal/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/Distribution/Simple/BuildPaths.hs
@@ -199,23 +199,23 @@ mkProfLibName lib =  mkGenericStaticLibName (getHSLibraryName lib ++ "_p")
 -- | Create a library name for a shared lirbary from a given name.
 -- Prepends 'lib' and appends the '-<compilerFlavour><compilerVersion>'
 -- as well as the shared library extension.
-mkGenericSharedLibName :: CompilerId -> String -> String
-mkGenericSharedLibName (CompilerId compilerFlavor compilerVersion) lib
-  = mconcat [ "lib", lib, "-", comp <.> dllExtension ]
+mkGenericSharedLibName :: Platform -> CompilerId -> String -> String
+mkGenericSharedLibName platform (CompilerId compilerFlavor compilerVersion) lib
+  = mconcat [ "lib", lib, "-", comp <.> dllExtension platform ]
   where comp = display compilerFlavor ++ display compilerVersion
 
 -- Implement proper name mangling for dynamical shared objects
 -- libHS<packagename>-<compilerFlavour><compilerVersion>
 -- e.g. libHSbase-2.1-ghc6.6.1.so
-mkSharedLibName :: CompilerId -> UnitId -> String
-mkSharedLibName comp lib
-  = mkGenericSharedLibName comp (getHSLibraryName lib)
+mkSharedLibName :: Platform -> CompilerId -> UnitId -> String
+mkSharedLibName platform comp lib
+  = mkGenericSharedLibName platform comp (getHSLibraryName lib)
 
 -- Static libs are named the same as shared libraries, only with
 -- a different extension.
-mkStaticLibName :: CompilerId -> UnitId -> String
-mkStaticLibName (CompilerId compilerFlavor compilerVersion) lib
-  = "lib" ++ getHSLibraryName lib ++ "-" ++ comp <.> staticLibExtension
+mkStaticLibName :: Platform -> CompilerId -> UnitId -> String
+mkStaticLibName platform (CompilerId compilerFlavor compilerVersion) lib
+  = "lib" ++ getHSLibraryName lib ++ "-" ++ comp <.> staticLibExtension platform
   where comp = display compilerFlavor ++ display compilerVersion
 
 -- ------------------------------------------------------------
@@ -235,8 +235,8 @@ objExtension = "o"
 
 -- | Extension for dynamically linked (or shared) libraries
 -- (typically @\"so\"@ on Unix and @\"dll\"@ on Windows)
-dllExtension :: String
-dllExtension = case buildOS of
+dllExtension :: Platform -> String
+dllExtension (Platform _arch os)= case os of
                    Windows -> "dll"
                    OSX     -> "dylib"
                    _       -> "so"
@@ -245,7 +245,7 @@ dllExtension = case buildOS of
 --
 -- TODO: Here, as well as in dllExtension, it's really the target OS that we're
 -- interested in, not the build OS.
-staticLibExtension :: String
-staticLibExtension = case buildOS of
+staticLibExtension :: Platform -> String
+staticLibExtension (Platform _arch os) = case os of
                        Windows -> "lib"
                        _       -> "a"

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -731,11 +731,11 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
         compiler_id = compilerId (compiler lbi)
         vanillaLibFilePath = libTargetDir </> mkLibName uid
         profileLibFilePath = libTargetDir </> mkProfLibName uid
-        sharedLibFilePath  = libTargetDir </> mkSharedLibName compiler_id uid
-        staticLibFilePath  = libTargetDir </> mkStaticLibName compiler_id uid
+        sharedLibFilePath  = libTargetDir </> mkSharedLibName (hostPlatform lbi) compiler_id uid
+        staticLibFilePath  = libTargetDir </> mkStaticLibName (hostPlatform lbi) compiler_id uid
         ghciLibFilePath    = libTargetDir </> Internal.mkGHCiLibName uid
         libInstallPath = libdir $ absoluteComponentInstallDirs pkg_descr lbi uid NoCopyDest
-        sharedLibInstallPath = libInstallPath </> mkSharedLibName compiler_id uid
+        sharedLibInstallPath = libInstallPath </> mkSharedLibName (hostPlatform lbi) compiler_id uid
 
     stubObjs <- catMaybes <$> sequenceA
       [ findFileWithExtension [objExtension] [libTargetDir]
@@ -955,8 +955,8 @@ flibTargetName lbi flib =
       (Windows, ForeignLibNativeShared) -> nm <.> "dll"
       (Windows, ForeignLibNativeStatic) -> nm <.> "lib"
       (Linux,   ForeignLibNativeShared) -> "lib" ++ nm <.> versionedExt
-      (_other,  ForeignLibNativeShared) -> "lib" ++ nm <.> dllExtension
-      (_other,  ForeignLibNativeStatic) -> "lib" ++ nm <.> staticLibExtension
+      (_other,  ForeignLibNativeShared) -> "lib" ++ nm <.> dllExtension (hostPlatform lbi)
+      (_other,  ForeignLibNativeStatic) -> "lib" ++ nm <.> staticLibExtension (hostPlatform lbi)
       (_any,    ForeignLibTypeUnknown)  -> cabalBug "unknown foreign lib type"
   where
     nm :: String
@@ -1753,7 +1753,7 @@ installLib verbosity lbi targetDir dynlibTargetDir _builtDir _pkg lib clbi = do
     uid = componentUnitId clbi
     profileLibName = mkProfLibName          uid
     ghciLibName    = Internal.mkGHCiLibName uid
-    sharedLibName  = (mkSharedLibName compiler_id) uid
+    sharedLibName  = (mkSharedLibName (hostPlatform lbi) compiler_id) uid
 
     hasLib    = not $ null (allLibModules lib clbi)
                    && null (cSources (libBuildInfo lib))

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -150,12 +150,12 @@ guessToolFromGhcjsPath tool ghcjsProg verbosity searchpath
            path              = programPath ghcjsProg
            dir               = takeDirectory path
            versionSuffix     = takeVersionSuffix (dropExeExtension path)
-           guessNormal       = dir </> toolname <.> exeExtension
+           guessNormal       = dir </> toolname <.> exeExtension buildPlatform
            guessGhcjsVersioned = dir </> (toolname ++ "-ghcjs" ++ versionSuffix)
-                                 <.> exeExtension
+                                 <.> exeExtension buildPlatform
            guessGhcjs        = dir </> (toolname ++ "-ghcjs")
-                               <.> exeExtension
-           guessVersioned    = dir </> (toolname ++ versionSuffix) <.> exeExtension
+                               <.> exeExtension buildPlatform
+           guessVersioned    = dir </> (toolname ++ versionSuffix) <.> exeExtension buildPlatform
            guesses | null versionSuffix = [guessGhcjs, guessNormal]
                    | otherwise          = [guessGhcjsVersioned,
                                            guessGhcjs,
@@ -524,8 +524,8 @@ buildOrReplExe forRepl verbosity numJobs _pkg_descr lbi
   let exeName'' = unUnqualComponentName exeName'
   -- exeNameReal, the name that GHC really uses (with .exe on Windows)
   let exeNameReal = exeName'' <.>
-                    (if takeExtension exeName'' /= ('.':exeExtension)
-                       then exeExtension
+                    (if takeExtension exeName'' /= ('.':exeExtension buildPlatform)
+                       then exeExtension buildPlatform
                        else "")
 
   let targetDir = (buildDir lbi) </> exeName''

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -427,7 +427,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
         compiler_id = compilerId (compiler lbi)
         vanillaLibFilePath = libTargetDir </> mkLibName            uid
         profileLibFilePath = libTargetDir </> mkProfLibName        uid
-        sharedLibFilePath  = libTargetDir </> mkSharedLibName compiler_id uid
+        sharedLibFilePath  = libTargetDir </> mkSharedLibName (hostPlatform lbi) compiler_id uid
         ghciLibFilePath    = libTargetDir </> Internal.mkGHCiLibName uid
 
     hObjs     <- Internal.getHaskellObjects implInfo lib lbi clbi
@@ -735,7 +735,7 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
     vanillaLibName = mkLibName              uid
     profileLibName = mkProfLibName          uid
     ghciLibName    = Internal.mkGHCiLibName uid
-    sharedLibName  = (mkSharedLibName compiler_id)  uid
+    sharedLibName  = (mkSharedLibName (hostPlatform lbi) compiler_id)  uid
 
     hasLib    = not $ null (allLibModules lib clbi)
                    && null (cSources (libBuildInfo lib))

--- a/Cabal/Distribution/Simple/JHC.hs
+++ b/Cabal/Distribution/Simple/JHC.hs
@@ -44,7 +44,7 @@ import Distribution.Text
 import System.FilePath          ( (</>) )
 import Distribution.Compat.ReadP
     ( readP_to_S, string, skipSpaces )
-import Distribution.System ( Platform )
+import Distribution.System ( Platform, buildPlatform )
 
 import qualified Data.Map as Map  ( empty )
 
@@ -189,7 +189,7 @@ installLib verb _lbi dest _dyn_dest build_dir pkg_descr _lib _clbi = do
 installExe :: Verbosity -> FilePath -> FilePath -> (FilePath,FilePath) -> PackageDescription -> Executable -> IO ()
 installExe verb dest build_dir (progprefix,progsuffix) _ exe = do
     let exe_name = display $ exeName exe
-        src = exe_name </> exeExtension
-        out   = (progprefix ++ exe_name ++ progsuffix) </> exeExtension
+        src = exe_name </> exeExtension buildPlatform
+        out   = (progprefix ++ exe_name ++ progsuffix) </> exeExtension buildPlatform
     createDirectoryIfMissingVerbose verb True dest
     installExecutableFile verb (build_dir </> src) (dest </> out)

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -348,10 +348,10 @@ buildLib verbosity pkg_descr lbi lib clbi = do
   let cObjs = map (`replaceExtension` objExtension) (cSources libBi)
       cSharedObjs = map (`replaceExtension` ("dyn_" ++ objExtension)) (cSources libBi)
       cid = compilerId (compiler lbi)
-      vanillaLibFilePath = libTargetDir </> mkLibName           lib_name
-      profileLibFilePath = libTargetDir </> mkProfLibName       lib_name
-      sharedLibFilePath  = libTargetDir </> mkSharedLibName cid lib_name
-      ghciLibFilePath    = libTargetDir </> mkGHCiLibName       lib_name
+      vanillaLibFilePath = libTargetDir </> mkLibName                              lib_name
+      profileLibFilePath = libTargetDir </> mkProfLibName                          lib_name
+      sharedLibFilePath  = libTargetDir </> mkSharedLibName (hostPlatform lbi) cid lib_name
+      ghciLibFilePath    = libTargetDir </> mkGHCiLibName                          lib_name
 
   stubObjs <- fmap catMaybes $ sequenceA
     [ findFileWithExtension [objExtension] [libTargetDir]
@@ -735,10 +735,10 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
   where
     cid = compilerId (compiler lbi)
     lib_name = componentUnitId clbi
-    vanillaLibName = mkLibName           lib_name
-    profileLibName = mkProfLibName       lib_name
-    ghciLibName    = mkGHCiLibName       lib_name
-    sharedLibName  = mkSharedLibName cid lib_name
+    vanillaLibName = mkLibName                              lib_name
+    profileLibName = mkProfLibName                          lib_name
+    ghciLibName    = mkGHCiLibName                          lib_name
+    sharedLibName  = mkSharedLibName (hostPlatform lbi) cid lib_name
 
     hasLib    = not $ null (allLibModules lib clbi)
                    && null (cSources (libBuildInfo lib))

--- a/Cabal/Distribution/Simple/LHC.hs
+++ b/Cabal/Distribution/Simple/LHC.hs
@@ -470,7 +470,7 @@ buildExe verbosity _pkg_descr lbi
 
   -- exeNameReal, the name that GHC really uses (with .exe on Windows)
   let exeNameReal = exeName'' <.>
-                    (if null $ takeExtension exeName'' then exeExtension else "")
+                    (if null $ takeExtension exeName'' then exeExtension buildPlatform else "")
 
   let targetDir = pref </> exeName''
   let exeDir    = targetDir </> (exeName'' ++ "-tmp")
@@ -677,13 +677,13 @@ installExe :: Verbosity
            -> IO ()
 installExe verbosity lbi binDir buildPref (progprefix, progsuffix) _pkg exe = do
   createDirectoryIfMissingVerbose verbosity True binDir
-  let exeFileName = unUnqualComponentName (exeName exe) <.> exeExtension
+  let exeFileName = unUnqualComponentName (exeName exe) <.> exeExtension (hostPlatform lbi)
       fixedExeBaseName = progprefix ++ unUnqualComponentName (exeName exe) ++ progsuffix
       installBinary dest = do
           installExecutableFile verbosity
             (buildPref </> unUnqualComponentName (exeName exe) </> exeFileName)
-            (dest <.> exeExtension)
-          stripExe verbosity lbi exeFileName (dest <.> exeExtension)
+            (dest <.> exeExtension (hostPlatform lbi))
+          stripExe verbosity lbi exeFileName (dest <.> exeExtension (hostPlatform lbi))
   installBinary (binDir </> fixedExeBaseName)
 
 stripExe :: Verbosity -> LocalBuildInfo -> FilePath -> FilePath -> IO ()

--- a/Cabal/Distribution/Simple/Test/ExeV10.hs
+++ b/Cabal/Distribution/Simple/Test/ExeV10.hs
@@ -50,7 +50,7 @@ runTest pkg_descr lbi clbi flags suite = do
     existingEnv <- getEnvironment
 
     let cmd = LBI.buildDir lbi </> testName'
-                  </> testName' <.> exeExtension
+                  </> testName' <.> exeExtension (LBI.hostPlatform lbi)
     -- Check that the test executable exists.
     exists <- doesFileExist cmd
     unless exists $ die' verbosity $ "Error: Could not find test program \"" ++ cmd

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -58,7 +58,7 @@ runTest pkg_descr lbi clbi flags suite = do
     existingEnv <- getEnvironment
 
     let cmd = LBI.buildDir lbi </> stubName suite
-                  </> stubName suite <.> exeExtension
+                  </> stubName suite <.> exeExtension (LBI.hostPlatform lbi)
     -- Check that the test executable exists.
     exists <- doesFileExist cmd
     unless exists $

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1593,7 +1593,7 @@ withWin32SelfUpgrade verbosity uid configFlags cinfo platform pkg action = do
     (CompilerId compFlavor _) = compilerInfoId cinfo
 
     exeInstallPaths defaultDirs =
-      [ InstallDirs.bindir absoluteDirs </> exeName <.> exeExtension
+      [ InstallDirs.bindir absoluteDirs </> exeName <.> exeExtension buildPlatform
       | exe <- PackageDescription.executables pkg
       , PackageDescription.buildable (PackageDescription.buildInfo exe)
       , let exeName = prefix ++ display (PackageDescription.exeName exe) ++ suffix

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -162,7 +162,7 @@ import Distribution.Client.Utils
          ( determineNumJobs, logDirChange, mergeBy, MergeResult(..)
          , tryCanonicalizePath )
 import Distribution.System
-         ( Platform, OS(Windows), buildOS )
+         ( Platform, OS(Windows), buildOS, buildPlatform )
 import Distribution.Text
          ( display )
 import Distribution.Verbosity as Verbosity

--- a/cabal-install/Distribution/Client/Run.hs
+++ b/cabal-install/Distribution/Client/Run.hs
@@ -125,7 +125,7 @@ run verbosity lbi exe exeArgs = do
         return (cmd, cmdArgs ++ [script'])
       _     -> do
          p <- tryCanonicalizePath $
-            buildPref </> exeName' </> (exeName' <.> exeExtension)
+            buildPref </> exeName' </> (exeName' <.> exeExtension (hostPlatform lbi))
          return (p, [])
 
   env  <- (dataDirEnvVar:) <$> getEnvironment

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -526,7 +526,7 @@ externalSetupMethod path verbosity options _ args = do
                   doInvoke
 
     moveOutOfTheWay tmpDir path' = do
-      let newPath = tmpDir </> "setup" <.> exeExtension
+      let newPath = tmpDir </> "setup" <.> exeExtension buildPlatform
       Win32.moveFile path' newPath
       return newPath
 
@@ -578,7 +578,7 @@ getExternalSetupMethod verbosity options pkg bt = do
   setupDir         = workingDir options </> useDistPref options </> "setup"
   setupVersionFile = setupDir   </> "setup" <.> "version"
   setupHs          = setupDir   </> "setup" <.> "hs"
-  setupProgFile    = setupDir   </> "setup" <.> exeExtension
+  setupProgFile    = setupDir   </> "setup" <.> exeExtension buildPlatform
   platform         = fromMaybe buildPlatform (usePlatform options)
 
   useCachedSetupExecutable = (bt == Simple || bt == Configure || bt == Make)
@@ -771,7 +771,7 @@ getExternalSetupMethod verbosity options pkg bt = do
                                    ++ cabalVersionString ++ "-"
                                    ++ platformString ++ "-"
                                    ++ compilerVersionString)
-                              <.> exeExtension
+                              <.> exeExtension buildPlatform
     return (setupCacheDir, cachedSetupProgFile)
       where
         buildTypeString       = show bt

--- a/cabal-testsuite/PackageTests/InternalLibraries/Executable/setup-static.test.hs
+++ b/cabal-testsuite/PackageTests/InternalLibraries/Executable/setup-static.test.hs
@@ -1,6 +1,7 @@
 import Test.Cabal.Prelude
 import Control.Monad.IO.Class
 import Control.Monad
+import Distribution.System (buildPlatform)
 import Distribution.Package
 import Distribution.Simple.Configure
 import Distribution.Simple.BuildPaths

--- a/cabal-testsuite/PackageTests/InternalLibraries/Executable/setup-static.test.hs
+++ b/cabal-testsuite/PackageTests/InternalLibraries/Executable/setup-static.test.hs
@@ -41,11 +41,11 @@ main = setupAndCabalTest $ do
               then
                 assertBool "dynamic library MUST be installed"
                     =<< liftIO (doesFileExist (dyndir </> mkSharedLibName
-                                               compiler_id uid))
+                                               buildPlatform compiler_id uid))
               else
                 assertBool "dynamic library should be installed"
                     =<< liftIO (doesFileExist (dyndir </> mkSharedLibName
-                                               compiler_id uid))
+                                               buildPlatform compiler_id uid))
             fails $ ghcPkg "describe" ["foo"]
             -- clean away the dist directory so that we catch accidental
             -- dependence on the inplace files


### PR DESCRIPTION
When building *for* a host, we do *not* want to rely on the *buildOS*, which is in almost all
cross-compilation cases the wrong OS.  The local build info however knows the right OS
if it was able to extract it from the compiler.  This however will only work until the compiler
gains multi-target support. But that's so far out that this patch should be sufficient for the
time being.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
