### PR TITLE
Fix base compat files so they work with GHC < 7.8

### DIFF
--- a/Cabal/Distribution/Compat/Environment.hs
+++ b/Cabal/Distribution/Compat/Environment.hs
@@ -31,6 +31,9 @@ import Distribution.Compat.Stack
 
 #ifdef mingw32_HOST_OS
 import Foreign.C
+#if __GLASGOW_HASKELL__ < 708
+import Foreign.Ptr (nullPtr)
+#endif
 import GHC.Windows
 #else
 import Foreign.C.Types
@@ -123,6 +126,12 @@ unsetEnv key = withCWString key $ \k -> do
     err <- c_GetLastError
     unless (err == eRROR_ENVVAR_NOT_FOUND) $ do
       throwGetLastError "unsetEnv"
+
+eRROR_ENVVAR_NOT_FOUND :: DWORD
+eRROR_ENVVAR_NOT_FOUND = 203
+
+foreign import WINDOWS_CCONV unsafe "windows.h GetLastError"
+    c_GetLastError:: IO DWORD
 #else
 unsetEnv key = withFilePath key (throwErrnoIf_ (/= 0) "unsetEnv" . c_unsetenv)
 #if __GLASGOW_HASKELL__ > 706


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Fixes #5181, tested with `cabal new-build Cabal.cabal` on `master` and `Cabal-v2.0.1.1` branch with GHC `8.2.2` and `7.6.3`.
