### PR TITLE
Fix new-install symlink location

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -463,6 +463,7 @@ initialSavedConfig = do
   logsDir    <- defaultLogsDir
   worldFile  <- defaultWorldFile
   extraPath  <- defaultExtraPath
+  symlinkPath <- defaultSymlinkPath
   return mempty {
     savedGlobalFlags     = mempty {
       globalCacheDir     = toFlag cacheDir,
@@ -475,7 +476,8 @@ initialSavedConfig = do
     savedInstallFlags    = mempty {
       installSummaryFile = toNubList [toPathTemplate (logsDir </> "build.log")],
       installBuildReports= toFlag AnonymousReports,
-      installNumJobs     = toFlag Nothing
+      installNumJobs     = toFlag Nothing,
+      installSymlinkBinDir = toFlag symlinkPath
     }
   }
 
@@ -509,6 +511,11 @@ defaultExtraPath :: IO [FilePath]
 defaultExtraPath = do
   dir <- defaultCabalDir
   return [dir </> "bin"]
+
+defaultSymlinkPath :: IO FilePath
+defaultSymlinkPath = do
+  dir <- defaultCabalDir
+  return (dir </> "bin")
 
 defaultCompiler :: CompilerFlavor
 defaultCompiler = fromMaybe GHC defaultCompilerFlavor

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -15,6 +15,8 @@
 	* Completed the 'new-exec' command (#3638). Same as above.
 	* Added a preliminary 'new-install' command (#4558, nonlocal exes
 	part) which allows to quickly install executables from Hackage.
+	* Set symlink-bindir (used by new-install) to .cabal/bin by default on
+	.cabal/config initialization.
 	* 'cabal update' now supports '--index-state' which can be used to
 	roll back the index to an earlier state.
 	* '--allow-{newer,older}' syntax has been enhanced. Dependency


### PR DESCRIPTION
Now new-install(-nonlocal-exes) should work without issues (if the ~/.cabal/config was generated with this)

Closes #5000 (yay!)

@23Skidoo can we cherry-pick it on 2.2 too?

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
  * [x] the symlink-bindir default
* [x] The documentation has been updated, if necessary.
  * [x] https://cabal.readthedocs.io/en/latest/installing-packages.html#installation-paths
    * Not necessary since those are Cabal/Setup.hs paths
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
