### PR TITLE
Look for transitive setup dependency on Cabal when choosing Cabal spec version. (2.2)

### DIFF
--- a/cabal-testsuite/PackageTests/NewBuild/T4288/CustomIssue.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4288/CustomIssue.hs
@@ -1,0 +1,3 @@
+module CustomIssue where
+
+f x = x + 1

--- a/cabal-testsuite/PackageTests/NewBuild/T4288/Setup.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4288/Setup.hs
@@ -1,0 +1,3 @@
+import SetupHelper (setupHelperDefaultMain)
+
+main = setupHelperDefaultMain

--- a/cabal-testsuite/PackageTests/NewBuild/T4288/T4288.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/T4288/T4288.cabal
@@ -1,0 +1,16 @@
+name: T4288
+version: 1.0
+build-type: Custom
+
+-- cabal-version is lower than the version of Cabal that will be chosen for the
+-- setup script.
+cabal-version: >=1.10
+
+-- Setup script only has a transitive dependency on Cabal.
+custom-setup
+  setup-depends: base, setup-helper
+
+library
+  exposed-modules: CustomIssue
+  build-depends: base
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/T4288/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/T4288/cabal.project
@@ -1,0 +1,1 @@
+packages: . setup-helper/

--- a/cabal-testsuite/PackageTests/NewBuild/T4288/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4288/cabal.test.hs
@@ -1,0 +1,17 @@
+import Test.Cabal.Prelude
+
+-- This test is similar to the simplified example in issue #4288. The package's
+-- setup script only depends on base and setup-helper. setup-helper exposes a
+-- function that is a wrapper for Cabal's defaultMain (similar to
+-- cabal-doctest). This test builds the package to check that the flags passed
+-- to the setup script are compatible with the version of Cabal that it depends
+-- on, even though Cabal is only a transitive dependency.
+main = cabalTest $ do
+  skipUnless =<< hasNewBuildCompatBootCabal
+  r <- recordMode DoNotRecord $ cabal' "new-build" ["T4288"]
+  assertOutputContains "This is setup-helper-1.0." r
+  assertOutputContains
+      ("In order, the following will be built: "
+       ++ " - setup-helper-1.0 (lib:setup-helper) (first run) "
+       ++ " - T4288-1.0 (lib:T4288) (first run)")
+      r

--- a/cabal-testsuite/PackageTests/NewBuild/T4288/setup-helper/SetupHelper.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4288/setup-helper/SetupHelper.hs
@@ -1,0 +1,5 @@
+module SetupHelper (setupHelperDefaultMain) where
+
+import Distribution.Simple
+
+setupHelperDefaultMain = putStrLn "This is setup-helper-1.0." >> defaultMain

--- a/cabal-testsuite/PackageTests/NewBuild/T4288/setup-helper/setup-helper.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/T4288/setup-helper/setup-helper.cabal
@@ -1,0 +1,9 @@
+name: setup-helper
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.2
+
+library
+  exposed-modules: SetupHelper
+  build-depends: base, Cabal
+  default-language: Haskell2010


### PR DESCRIPTION
#5170 cherry-picked onto 2.2.

@23Skidoo Do you think we should apply this to 2.2?  It only affects new-build.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
