### PR TITLE
Emit warning when an unknown GHC version is encountered (2.0 backport)

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -131,6 +131,13 @@ configure verbosity hcPath hcPkgPath conf0 = do
       (userMaybeSpecifyPath "ghc" hcPath conf0)
   let implInfo = ghcVersionImplInfo ghcVersion
 
+  -- Cabal 2.0 supports ghc >= 6.11 && < 8.3
+  unless (ghcVersion < mkVersion [8,3]) $
+    warn verbosity $
+         "Unknown/unsupported 'ghc' version detected "
+      ++ "(Cabal " ++ display cabalVersion ++ " supports 'ghc' version < 8.3): "
+      ++ programPath ghcProg ++ " is version " ++ display ghcVersion
+
   -- This is slightly tricky, we have to configure ghc first, then we use the
   -- location of ghc to help find ghc-pkg in the case that the user did not
   -- specify the location of ghc-pkg directly:

--- a/cabal.project.travis
+++ b/cabal.project.travis
@@ -16,6 +16,7 @@ allow-newer: hackage-repo-tool:Cabal, hackage-repo-tool:time, hackage-repo-tool:
 -- build properly (unfortunately the flags here get applied
 -- to the dependencies too!)
 package Cabal
+  tests: True
   ghc-options: -Werror -fno-warn-orphans
 
 package cabal-install


### PR DESCRIPTION
This finally addresses the long-standing ticket #415

(cherry picked from commit 5339b36e7408b022abb7eeff4f8f1c7de54b8e50)