### PR TITLE
Make GenericPackageDescription lenses more maintainable

### DIFF
--- a/Cabal/Distribution/Types/GenericPackageDescription/Lens.hs
+++ b/Cabal/Distribution/Types/GenericPackageDescription/Lens.hs
@@ -11,6 +11,8 @@ import Prelude()
 import Distribution.Compat.Prelude
 import Distribution.Compat.Lens
 
+import qualified Distribution.Types.GenericPackageDescription as T
+
 -- We import types from their packages, so we can remove unused imports
 -- and have wider inter-module dependency graph
 import Distribution.Types.CondTree (CondTree)
@@ -33,37 +35,37 @@ import Distribution.Version (VersionRange)
 -- GenericPackageDescription
 -------------------------------------------------------------------------------
 
-condBenchmarks :: Lens' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] Benchmark)]
-condBenchmarks f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 y1) (f x8)
-{-# INLINE condBenchmarks #-}
-
-condExecutables :: Lens' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] Executable)]
-condExecutables f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 x3 x4 x5 y1 x7 x8) (f x6)
-{-# INLINE condExecutables #-}
-
-condForeignLibs :: Lens' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] Distribution.Types.ForeignLib.ForeignLib)]
-condForeignLibs f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 x3 x4 y1 x6 x7 x8) (f x5)
-{-# INLINE condForeignLibs #-}
-
-condLibrary :: Lens' GenericPackageDescription (Maybe (CondTree ConfVar [Dependency] Library))
-condLibrary f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 y1 x4 x5 x6 x7 x8) (f x3)
-{-# INLINE condLibrary #-}
-
-condSubLibraries :: Lens' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] Library)]
-condSubLibraries f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 x3 y1 x5 x6 x7 x8) (f x4)
-{-# INLINE condSubLibraries #-}
-
-condTestSuites :: Lens' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] TestSuite)]
-condTestSuites f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 x2 x3 x4 x5 x6 y1 x8) (f x7)
-{-# INLINE condTestSuites #-}
+packageDescription :: Lens' GenericPackageDescription PackageDescription
+packageDescription f s = fmap (\x -> s { T.packageDescription = x }) (f (T.packageDescription s))
+{-# INLINE packageDescription #-}
 
 genPackageFlags :: Lens' GenericPackageDescription [Flag]
-genPackageFlags f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription x1 y1 x3 x4 x5 x6 x7 x8) (f x2)
+genPackageFlags f s = fmap (\x -> s { T.genPackageFlags = x }) (f (T.genPackageFlags s))
 {-# INLINE genPackageFlags #-}
 
-packageDescription :: Lens' GenericPackageDescription PackageDescription
-packageDescription f (GenericPackageDescription x1 x2 x3 x4 x5 x6 x7 x8) = fmap (\y1 -> GenericPackageDescription y1 x2 x3 x4 x5 x6 x7 x8) (f x1)
-{-# INLINE packageDescription #-}
+condLibrary :: Lens' GenericPackageDescription (Maybe (CondTree ConfVar [Dependency] Library))
+condLibrary f s = fmap (\x -> s { T.condLibrary = x }) (f (T.condLibrary s))
+{-# INLINE condLibrary #-}
+
+condSubLibraries :: Lens' GenericPackageDescription [(UnqualComponentName,(CondTree ConfVar [Dependency] Library))]
+condSubLibraries f s = fmap (\x -> s { T.condSubLibraries = x }) (f (T.condSubLibraries s))
+{-# INLINE condSubLibraries #-}
+
+condForeignLibs :: Lens' GenericPackageDescription [(UnqualComponentName,(CondTree ConfVar [Dependency] ForeignLib))]
+condForeignLibs f s = fmap (\x -> s { T.condForeignLibs = x }) (f (T.condForeignLibs s))
+{-# INLINE condForeignLibs #-}
+
+condExecutables :: Lens' GenericPackageDescription [(UnqualComponentName,(CondTree ConfVar [Dependency] Executable))]
+condExecutables f s = fmap (\x -> s { T.condExecutables = x }) (f (T.condExecutables s))
+{-# INLINE condExecutables #-}
+
+condTestSuites :: Lens' GenericPackageDescription [(UnqualComponentName,(CondTree ConfVar [Dependency] TestSuite))]
+condTestSuites f s = fmap (\x -> s { T.condTestSuites = x }) (f (T.condTestSuites s))
+{-# INLINE condTestSuites #-}
+
+condBenchmarks :: Lens' GenericPackageDescription [(UnqualComponentName,(CondTree ConfVar [Dependency] Benchmark))]
+condBenchmarks f s = fmap (\x -> s { T.condBenchmarks = x }) (f (T.condBenchmarks s))
+{-# INLINE condBenchmarks #-}
 
 allCondTrees
   :: Applicative f


### PR DESCRIPTION
Record syntax is easier to read and more robust against refactors.

@phadej you were saying the old one was autogenerated, but is there a way to automatically regenerate it? If not, I think this is better.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
