### PR TITLE
Fix powershell transport

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ build_script:
 
   # 'echo "" |' works around an AppVeyor issue:
   # https://github.com/commercialhaskell/stack/issues/1097#issuecomment-145747849
-  - echo "" | ..\appveyor-retry ..\cabal install --only-dependencies --enable-tests
+  - echo "" | ..\appveyor-retry cabal install --only-dependencies --enable-tests
 
   - Setup configure --user --ghc-option=-Werror --enable-tests
   - Setup build
@@ -26,10 +26,10 @@ build_script:
   - Setup install
   # hackage-repo-tool doesn't build on Windows:
   # https://github.com/well-typed/hackage-security/issues/175
-  # - echo "" | ..\cabal install hackage-repo-tool --allow-newer=Cabal,time --constraint="Cabal == 2.3.0.0"
+  # - echo "" | cabal install hackage-repo-tool --allow-newer=Cabal,time --constraint="Cabal == 2.3.0.0"
   - cd ..\cabal-testsuite
   - ghc --make -threaded -i Setup.hs -package Cabal-2.3.0.0
-  - echo "" | ..\appveyor-retry ..\cabal install --only-dependencies --enable-tests
+  - echo "" | ..\appveyor-retry cabal install --only-dependencies --enable-tests
   - Setup configure --user --ghc-option=-Werror --enable-tests
   - Setup build
   # Must install the test suite, so that our GHCi invocation picks it up
@@ -41,7 +41,7 @@ build_script:
   # - Setup test --show-details=streaming --test-option=--hide-successes
   - cd ..\cabal-install
   - ghc --make -threaded -i -i. Setup.hs -Wall -Werror
-  - echo "" | ..\appveyor-retry ..\cabal install --only-dependencies --enable-tests -flib
+  - echo "" | ..\appveyor-retry cabal install --only-dependencies --enable-tests -flib
   - cabal configure --user --ghc-option=-Werror --enable-tests -flib
   - cabal build
   # update package index again, this time for the cabal under test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,14 +2,11 @@ install:
   # Using '-y' and 'refreshenv' as a workaround to:
   # https://github.com/haskell/cabal/issues/3687
   - choco install -y ghc --version 8.0.2
+  - choco install -y cabal
   - refreshenv
   # See http://help.appveyor.com/discussions/problems/6312-curl-command-not-found#comment_42195491
   # NB: Do this after refreshenv, otherwise it will be clobbered!
   - set PATH=%APPDATA%\cabal\bin;C:\Program Files\Git\mingw64\bin;%PATH%
-  # TODO: remove --insecure, this is to workaround haskell.org
-  # failing to send intermediate cert; see https://github.com/haskell/cabal/pull/4172
-  - curl -o cabal.zip --insecure --progress-bar https://www.haskell.org/cabal/release/cabal-install-2.0.0.0/cabal-install-2.0.0.0-x86_64-unknown-mingw32.zip
-  - 7z x -bd cabal.zip
   - cabal --version
   - cabal update
   # Install parsec, text and mtl, also alex and happy
@@ -48,7 +45,7 @@ build_script:
   - ..\cabal configure --user --ghc-option=-Werror --enable-tests -flib
   - ..\cabal build
   # update package index again, this time for the cabal under test
-  - dist\build\cabal\cabal.exe update
+  - dist\build\cabal\cabal.exe --http-transport=powershell update -v
   # run cabal-testsuite first as it has better logging
   - cd ..\cabal-testsuite
   - dist\build\cabal-tests\cabal-tests.exe -j3 --skip-setup-tests --with-cabal=..\cabal-install\dist\build\cabal\cabal.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 install:
   # Using '-y' and 'refreshenv' as a workaround to:
   # https://github.com/haskell/cabal/issues/3687
-  - choco install -y ghc --version 8.0.2
   - choco install -y cabal
+  - choco install -y ghc --version 8.0.2
   - refreshenv
   # See http://help.appveyor.com/discussions/problems/6312-curl-command-not-found#comment_42195491
   # NB: Do this after refreshenv, otherwise it will be clobbered!
@@ -42,15 +42,15 @@ build_script:
   - cd ..\cabal-install
   - ghc --make -threaded -i -i. Setup.hs -Wall -Werror
   - echo "" | ..\appveyor-retry ..\cabal install --only-dependencies --enable-tests -flib
-  - ..\cabal configure --user --ghc-option=-Werror --enable-tests -flib
-  - ..\cabal build
+  - cabal configure --user --ghc-option=-Werror --enable-tests -flib
+  - cabal build
   # update package index again, this time for the cabal under test
   - dist\build\cabal\cabal.exe --http-transport=powershell update -v
   # run cabal-testsuite first as it has better logging
   - cd ..\cabal-testsuite
   - dist\build\cabal-tests\cabal-tests.exe -j3 --skip-setup-tests --with-cabal=..\cabal-install\dist\build\cabal\cabal.exe
   - cd ..\cabal-install
-  - ..\cabal test unit-tests --show-details=streaming --test-option="--pattern=! /FileMonitor/" --test-option=--hide-successes
-  - ..\cabal test integration-tests2 --show-details=streaming --test-option=--hide-successes
-  - ..\cabal test solver-quickcheck --show-details=streaming --test-option=--hide-successes --test-option=--quickcheck-tests=1000
-  - ..\cabal test memory-usage-tests --show-details=streaming
+  - cabal test unit-tests --show-details=streaming --test-option="--pattern=! /FileMonitor/" --test-option=--hide-successes
+  - cabal test integration-tests2 --show-details=streaming --test-option=--hide-successes
+  - cabal test solver-quickcheck --show-details=streaming --test-option=--hide-successes --test-option=--quickcheck-tests=1000
+  - cabal test memory-usage-tests --show-details=streaming

--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -642,7 +642,7 @@ powershellTransport prog =
                                              then break (== '-') value'
                                              else error $ "Could not decode range: " ++ value
                                          value' = drop 6 value
-                                     in "AddRange(" ++ escape start ++ ", " ++ escape end ++ ");"
+                                     in "AddRange(\"bytes\", " ++ escape start ++ ", " ++ escape end ++ ");"
               name                -> "Headers.Add(" ++ escape (show name) ++ "," ++ escape value ++ ");"
 
     setupAuth auth =

--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -665,7 +665,8 @@ powershellTransport prog =
       , ""
       , "$responseStream = $request.getresponse()"
       , "Write-Host \"200\";"
-      , "Write-Host (-join [System.Text.Encoding]::UTF8.GetChars($bodyBytes));"
+      , "$responseReader = new-object System.IO.StreamReader $responseStream.GetResponseStream()"
+      , "Write-Host $responseReader.ReadToEnd()"
       ]
 
     uploadFileCleanup =
@@ -683,7 +684,7 @@ powershellTransport prog =
       [ "[Net.ServicePointManager]::SecurityProtocol = \"tls12, tls11, tls\""
       , "$uri = New-Object \"System.Uri\" " ++ uri
       , "$request = [System.Net.HttpWebRequest]::Create($uri)"
-      , unlines (map ("  " ++) setup)
+      , unlines setup
       , "Try {"
       , unlines (map ("  " ++) action)
       , "} Catch [System.Net.WebException] {"

--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -671,8 +671,12 @@ powershellTransport prog =
       , "}"
       , ""
       , "$responseStream = $request.getresponse()"
-      , "Write-Host ($response.StatusCode -as [int]);"
       , "$responseReader = new-object System.IO.StreamReader $responseStream.GetResponseStream()"
+      , "$code = $response.StatusCode -as [int]"
+      , "if ($code -eq 0) {"
+      , "  $code = 200;"
+      , "}"
+      , "Write-Host $code"
       , "Write-Host $responseReader.ReadToEnd()"
       ]
 

--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -557,7 +557,7 @@ powershellTransport prog =
           , "    $targetStream.Write($buffer, 0, $count)"
           , "    $count = $responseStream.Read($buffer, 0, $buffer.length)"
           , "}"
-          , "Write-Host \"200\";"
+          , "Write-Host ($response.StatusCode -as [int]);"
           , "Write-Host $response.GetResponseHeader(\"ETag\").Trim('\"')"
           ]
           [ "$targetStream.Flush()"

--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -671,7 +671,7 @@ powershellTransport prog =
       , "}"
       , ""
       , "$responseStream = $request.getresponse()"
-      , "Write-Host \"200\";"
+      , "Write-Host ($response.StatusCode -as [int]);"
       , "$responseReader = new-object System.IO.StreamReader $responseStream.GetResponseStream()"
       , "Write-Host $responseReader.ReadToEnd()"
       ]


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

This fixes the powershell transport protocol. The reason for the breakage is because certain headers like
"Range" are protected in the .NET framework https://msdn.microsoft.com/en-us/library/system.net.httpwebrequest(v=vs.110).aspx which means you can't set them purely as metadata and need to go through the proper getter/setters.
