### PR TITLE
Refactoring removing `data ReadPackageIndexMode`

### DIFF
--- a/cabal-install/Distribution/Client/Sandbox/Index.hs
+++ b/cabal-install/Distribution/Client/Sandbox/Index.hs
@@ -39,6 +39,7 @@ import Distribution.Compat.Exception   ( tryIO )
 import Distribution.Verbosity    ( Verbosity )
 
 import qualified Data.ByteString.Lazy as BS
+import Control.DeepSeq           ( NFData(rnf) )
 import Control.Exception         ( evaluate, throw, Exception )
 import Control.Monad             ( liftM, unless )
 import Control.Monad.Writer.Lazy (WriterT(..), runWriterT, tell)
@@ -56,6 +57,9 @@ data BuildTreeRef = BuildTreeRef {
   buildTreeRefType :: !BuildTreeRefType,
   buildTreePath     :: !FilePath
   }
+
+instance NFData BuildTreeRef where
+  rnf (BuildTreeRef _ fp) = rnf fp
 
 defaultIndexFileName :: FilePath
 defaultIndexFileName = "00-index.tar"


### PR DESCRIPTION
This is anticipated refactoring (since `readCacheStrict` will
be removed anyway once we remove the `cabal sandbox` code) is
motivated by workarounding a GHC 8.4.1 caused regression
(see https://ghc.haskell.org/trac/ghc/ticket/13930 for details)

Addresses #5201
