### PR TITLE
Fix #5164 by overriding environment variables when new-building custom Setups

### DIFF
--- a/cabal-install/Distribution/Client/CmdRun.hs
+++ b/cabal-install/Distribution/Client/CmdRun.hs
@@ -35,23 +35,19 @@ import Distribution.Verbosity
 import Distribution.Simple.Utils
          ( wrapText, die', ordNub, info )
 import Distribution.Client.ProjectPlanning
-         ( ElaboratedConfiguredPackage(..), BuildStyle(..)
+         ( ElaboratedConfiguredPackage(..)
          , ElaboratedInstallPlan, binDirectoryFor )
+import Distribution.Client.ProjectPlanning.Types
+         ( dataDirsEnvironmentForPlan )
 import Distribution.Client.InstallPlan
          ( toList, foldPlanPackage )
 import Distribution.Types.UnqualComponentName
          ( UnqualComponentName, unUnqualComponentName )
-import Distribution.Types.PackageDescription
-         ( PackageDescription(dataDir) )
 import Distribution.Simple.Program.Run
          ( runProgramInvocation, ProgramInvocation(..),
            emptyProgramInvocation )
-import Distribution.Simple.Build.PathsModule
-         ( pkgPathEnvVar )
 import Distribution.Types.UnitId
          ( UnitId )
-import Distribution.Client.Types
-         ( PackageLocation(..) )
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -221,39 +217,6 @@ runAction (configFlags, configExFlags, installFlags, haddockFlags)
     cliConfig = commandLineFlagsToProjectConfig
                   globalFlags configFlags configExFlags
                   installFlags haddockFlags
-
-
--- | Construct the environment needed for the data files to work.
--- This consists of a separate @*_datadir@ variable for each
--- inplace package in the plan.
-dataDirsEnvironmentForPlan :: ElaboratedInstallPlan
-                           -> [(String, Maybe FilePath)]
-dataDirsEnvironmentForPlan = catMaybes
-                           . fmap (foldPlanPackage
-                               (const Nothing)
-                               dataDirEnvVarForPackage)
-                           . toList
-
--- | Construct an environment variable that points
--- the package's datadir to its correct location.
--- This might be:
--- * 'Just' the package's source directory plus the data subdirectory
---   for inplace packages.
--- * 'Nothing' for packages installed in the store (the path was
---   already included in the package at install/build time).
--- * The other cases are not handled yet. See below.
-dataDirEnvVarForPackage :: ElaboratedConfiguredPackage
-                        -> Maybe (String, Maybe FilePath)
-dataDirEnvVarForPackage pkg =
-  case (elabBuildStyle pkg, elabPkgSourceLocation pkg)
-  of (BuildAndInstall, _) -> Nothing
-     (BuildInplaceOnly, LocalUnpackedPackage path) -> Just
-       (pkgPathEnvVar (elabPkgDescription pkg) "datadir",
-        Just $ path </> dataDir (elabPkgDescription pkg))
-     -- TODO: handle the other cases for PackageLocation.
-     -- We will only need this when we add support for
-     -- remote/local tarballs.
-     (BuildInplaceOnly, _) -> Nothing
 
 singleExeOrElse :: IO (UnitId, UnqualComponentName) -> TargetsMap -> IO (UnitId, UnqualComponentName)
 singleExeOrElse action targetsMap =

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -204,6 +204,7 @@ configureSetupScript packageDBs
     , useLoggingHandle         = Nothing
     , useWorkingDir            = Nothing
     , useExtraPathEnv          = []
+    , useExtraEnvOverrides     = []
     , setupCacheLock           = lock
     , useWin32CleanHack        = False
     , forceExternalSetupMethod = forceExternal

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -3020,6 +3020,7 @@ legacyCustomSetupPkgs compiler (Platform _ os) =
 -- in the store and local dbs.
 
 setupHsScriptOptions :: ElaboratedReadyPackage
+                     -> ElaboratedInstallPlan
                      -> ElaboratedSharedConfig
                      -> FilePath
                      -> FilePath
@@ -3029,7 +3030,7 @@ setupHsScriptOptions :: ElaboratedReadyPackage
 -- TODO: Fix this so custom is a separate component.  Custom can ALWAYS
 -- be a separate component!!!
 setupHsScriptOptions (ReadyPackage elab@ElaboratedConfiguredPackage{..})
-                     ElaboratedSharedConfig{..} srcdir builddir
+                     plan ElaboratedSharedConfig{..} srcdir builddir
                      isParallelBuild cacheLock =
     SetupScriptOptions {
       useCabalVersion          = thisVersion elabSetupScriptCliVersion,
@@ -3048,6 +3049,7 @@ setupHsScriptOptions (ReadyPackage elab@ElaboratedConfiguredPackage{..})
       useLoggingHandle         = Nothing, -- this gets set later
       useWorkingDir            = Just srcdir,
       useExtraPathEnv          = elabExeDependencyPaths elab,
+      useExtraEnvOverrides     = dataDirsEnvironmentForPlan plan,
       useWin32CleanHack        = False,   --TODO: [required eventually]
       forceExternalSetupMethod = isParallelBuild,
       setupCacheLock           = Just cacheLock,
@@ -3159,7 +3161,7 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
     configVanillaLib          = toFlag elabVanillaLib
     configSharedLib           = toFlag elabSharedLib
     configStaticLib           = toFlag elabStaticLib
-    
+
     configDynExe              = toFlag elabDynExe
     configGHCiLib             = toFlag elabGHCiLib
     configProfExe             = mempty

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -66,6 +66,8 @@
 	* Paths_ autogen modules now compile when `RebindableSyntax` or
 	`OverloadedStrings` is used in `default-extensions`.
 	[stack#3789](https://github.com/commercialhaskell/stack/issues/3789)
+    * getDataDir` and other `Paths_autogen` functions now work correctly
+    when compiling a custom `Setup.hs` script using `new-build` (#5164).
 
 2.0.0.1 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> December 2017
 	* Support for GHC's numeric -g debug levels (#4673).

--- a/cabal-testsuite/PackageTests/NewBuild/T5164/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/T5164/cabal.project
@@ -1,0 +1,2 @@
+packages: ./setup-lib
+          ./uses-custom-setup

--- a/cabal-testsuite/PackageTests/NewBuild/T5164/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T5164/cabal.test.hs
@@ -1,0 +1,3 @@
+import Test.Cabal.Prelude
+main = cabalTest $ do
+    cabal' "new-build" ["all"] >>= assertOutputContains "Example data file"

--- a/cabal-testsuite/PackageTests/NewBuild/T5164/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T5164/cabal.test.hs
@@ -1,3 +1,4 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
-    cabal' "new-build" ["all"] >>= assertOutputContains "Example data file"
+    r1 <- recordMode DoNotRecord $ cabal' "new-build" ["all"]
+    assertOutputContains "Example data file" r1

--- a/cabal-testsuite/PackageTests/NewBuild/T5164/setup-lib/SetupLib.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T5164/setup-lib/SetupLib.hs
@@ -1,0 +1,9 @@
+module SetupLib (printExampleTxt) where
+
+import Paths_setup_lib
+
+printExampleTxt :: IO ()
+printExampleTxt = do
+  ex <- getDataFileName "example.txt"
+  exContents <- readFile ex
+  putStrLn exContents

--- a/cabal-testsuite/PackageTests/NewBuild/T5164/setup-lib/example.txt
+++ b/cabal-testsuite/PackageTests/NewBuild/T5164/setup-lib/example.txt
@@ -1,0 +1,1 @@
+Example data file

--- a/cabal-testsuite/PackageTests/NewBuild/T5164/setup-lib/setup-lib.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/T5164/setup-lib/setup-lib.cabal
@@ -6,5 +6,6 @@ data-files: example.txt
 
 library
     exposed-modules: SetupLib
+    other-modules: Paths_setup_lib
     build-depends: base
     default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/T5164/setup-lib/setup-lib.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/T5164/setup-lib/setup-lib.cabal
@@ -1,0 +1,10 @@
+name: setup-lib
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+data-files: example.txt
+
+library
+    exposed-modules: SetupLib
+    build-depends: base
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/T5164/uses-custom-setup/Setup.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T5164/uses-custom-setup/Setup.hs
@@ -1,0 +1,7 @@
+import Distribution.Simple (defaultMain)
+import SetupLib (printExampleTxt)
+
+main :: IO ()
+main = do
+  printExampleTxt
+  defaultMain

--- a/cabal-testsuite/PackageTests/NewBuild/T5164/uses-custom-setup/UsesCustomSetup.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T5164/uses-custom-setup/UsesCustomSetup.hs
@@ -1,0 +1,4 @@
+module UsesCustomSetup (foo) where
+
+foo :: Int
+foo = 42

--- a/cabal-testsuite/PackageTests/NewBuild/T5164/uses-custom-setup/uses-custom-setup.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/T5164/uses-custom-setup/uses-custom-setup.cabal
@@ -1,0 +1,13 @@
+name: uses-custom-setup
+version: 1.0
+build-type: Custom
+cabal-version: >= 1.10
+data-files: example.txt
+
+custom-setup
+  setup-depends: base, Cabal, setup-lib
+
+library
+    exposed-modules: UsesCustomSetup
+    build-depends: base
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/T5164/uses-custom-setup/uses-custom-setup.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/T5164/uses-custom-setup/uses-custom-setup.cabal
@@ -2,7 +2,6 @@ name: uses-custom-setup
 version: 1.0
 build-type: Custom
 cabal-version: >= 1.10
-data-files: example.txt
 
 custom-setup
   setup-depends: base, Cabal, setup-lib


### PR DESCRIPTION
This is accomplished by adding a `useExtraEnvOverrides` field to `SetupScriptOptions`, which allows for setting (or unsetting) any environment variables you wish. This is used when invoking a custom `Setup` script executable to set the values of variables like `<component>_datadir` when using `new-build`. (Not doing this before led to #5164).

Along the way, I moved `dataDirsEnvironmentForPlan` into `Distribution.Client.ProjectPlanning.Types` (as that seemed like the most logical place to put it) so that it could be used in `Distribution.Client.ProjectPlanning` as well, where we also need to initialize `useExtraEnvOverrides`.

I attempted to add a test, but I failed miserably at actually running the test suite, so I have no idea if it actually works or not. Fingers crossed.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
