### PR TITLE
Haddock: Pass hyperlink source directory with --read-interface

### DIFF
--- a/cabal-install/Distribution/Client/Haddock.hs
+++ b/cabal-install/Distribution/Client/Haddock.hs
@@ -40,7 +40,7 @@ regenerateHaddockIndex :: Verbosity
                        -> IO ()
 regenerateHaddockIndex verbosity pkgs progdb index = do
       (paths, warns) <- haddockPackagePaths pkgs' Nothing
-      let paths' = [ (interface, html) | (interface, Just html) <- paths]
+      let paths' = [ (interface, html) | (interface, Just html, _) <- paths]
       forM_ warns (debug verbosity)
 
       (confHaddock, _, _) <-


### PR DESCRIPTION
With this patch Cabal passes the directory to hyperlinked sources for each package, if present. This helps for package cross-references in hyperlinked-sources. 

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
