### PR TITLE
Bumped network-uri versions

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -323,7 +323,7 @@ library
     -- is pulled in, otherwise the constraint solver doesn't have enough
     -- information
     if flag(network-uri)
-      build-depends: network-uri >= 2.6 && < 2.7, network >= 2.6 && < 2.7
+      build-depends: network-uri >= 2.6.0.2 && < 2.7, network >= 2.6 && < 2.7
     else
       build-depends: network     >= 2.4 && < 2.6
 
@@ -552,7 +552,7 @@ executable cabal
         -- is pulled in, otherwise the constraint solver doesn't have enough
         -- information
         if flag(network-uri)
-          build-depends: network-uri >= 2.6 && < 2.7, network >= 2.6 && < 2.7
+          build-depends: network-uri >= 2.6.0.2 && < 2.7, network >= 2.6 && < 2.7
         else
           build-depends: network     >= 2.4 && < 2.6
 


### PR DESCRIPTION
`Distribution/Client/Security/DNS.hs` requires `instance NFData URI`, which was only introduced in `network-uri-2.6.0.2`.