### PR TITLE
add support for the aarch64 architecture

### DIFF
--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -598,6 +598,7 @@ platformDefines lbi =
       PPC64       -> ["powerpc64"]
       Sparc       -> ["sparc"]
       Arm         -> ["arm"]
+      AArch64     -> ["aarch64"]
       Mips        -> ["mips"]
       SH          -> []
       IA64        -> ["ia64"]

--- a/Cabal/Distribution/System.hs
+++ b/Cabal/Distribution/System.hs
@@ -151,9 +151,9 @@ buildOS = classifyOS Permissive System.Info.os
 -- * Machine Architecture
 -- ------------------------------------------------------------
 
--- | These are the known Arches: I386, X86_64, PPC, PPC64, Sparc
--- ,Arm, Mips, SH, IA64, S39, Alpha, Hppa, Rs6000, M68k, Vax
--- and JavaScript.
+-- | These are the known Arches: I386, X86_64, PPC, PPC64, Sparc,
+-- Arm, AArch64, Mips, SH, IA64, S39, Alpha, Hppa, Rs6000, M68k,
+-- Vax, and JavaScript.
 --
 -- The following aliases can also be used:
 --    * PPC alias: powerpc
@@ -161,11 +161,12 @@ buildOS = classifyOS Permissive System.Info.os
 --    * Sparc aliases: sparc64, sun4
 --    * Mips aliases: mipsel, mipseb
 --    * Arm aliases: armeb, armel
+--    * AArch64 aliases: arm64
 --
-data Arch = I386  | X86_64 | PPC | PPC64 | Sparc
-          | Arm   | Mips   | SH
+data Arch = I386  | X86_64  | PPC  | PPC64 | Sparc
+          | Arm   | AArch64 | Mips | SH
           | IA64  | S390
-          | Alpha | Hppa   | Rs6000
+          | Alpha | Hppa    | Rs6000
           | M68k  | Vax
           | JavaScript
           | OtherArch String
@@ -177,21 +178,22 @@ instance NFData Arch where rnf = genericRnf
 
 knownArches :: [Arch]
 knownArches = [I386, X86_64, PPC, PPC64, Sparc
-              ,Arm, Mips, SH
+              ,Arm, AArch64, Mips, SH
               ,IA64, S390
               ,Alpha, Hppa, Rs6000
               ,M68k, Vax
               ,JavaScript]
 
 archAliases :: ClassificationStrictness -> Arch -> [String]
-archAliases Strict _     = []
-archAliases Compat _     = []
-archAliases _      PPC   = ["powerpc"]
-archAliases _      PPC64 = ["powerpc64"]
-archAliases _      Sparc = ["sparc64", "sun4"]
-archAliases _      Mips  = ["mipsel", "mipseb"]
-archAliases _      Arm   = ["armeb", "armel"]
-archAliases _      _     = []
+archAliases Strict _       = []
+archAliases Compat _       = []
+archAliases _      PPC     = ["powerpc"]
+archAliases _      PPC64   = ["powerpc64"]
+archAliases _      Sparc   = ["sparc64", "sun4"]
+archAliases _      Mips    = ["mipsel", "mipseb"]
+archAliases _      Arm     = ["armeb", "armel"]
+archAliases _      AArch64 = ["arm64"]
+archAliases _      _       = []
 
 instance Pretty Arch where
   pretty (OtherArch name) = Disp.text name


### PR DESCRIPTION
We recognize arm64 as an alias.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
