### PR TITLE
Fix the SPDX spec version number

### DIFF
--- a/Cabal/Distribution/SPDX.hs
+++ b/Cabal/Distribution/SPDX.hs
@@ -1,4 +1,4 @@
--- | This module contains a SPDX data from specification version 2.1
+-- | This module implements SPDX specification version 2.1 with a version 3.0 license list.
 --
 -- Specification is available on <https://spdx.org/specifications>
 module Distribution.SPDX (


### PR DESCRIPTION
We implement version 3.0, not 2.1.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
