### PR TITLE
Fix warning message for `cabal-version` field (see #5108)

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -1115,12 +1115,14 @@ checkCabalVersion pkg =
         ++ "range syntax rather than a simple version number. Use "
         ++ "'cabal-version: >= " ++ display (specVersion pkg) ++ "'."
 
+    -- check syntax of cabal-version field
   , check (specVersion pkg >= mkVersion [1,12]
            && not simpleSpecVersionSyntax) $
       (if specVersion pkg >= mkVersion [2,0] then PackageDistSuspicious else PackageDistSuspiciousWarn) $
            "Packages relying on Cabal 1.12 or later should specify a "
-        ++ "version range of the form 'cabal-version: x.y'. Use "
-        ++ "'cabal-version: " ++ display (specVersion pkg) ++ "'."
+        ++ "specific version of the Cabal spec of the form "
+        ++ "'cabal-version: x.y'. "
+        ++ "Use 'cabal-version: " ++ display (specVersion pkg) ++ "'."
 
     -- check use of test suite sections
   , checkVersion [1,8] (not (null $ testSuites pkg)) $

--- a/Cabal/tests/ParserTests/regressions/issue-774.check
+++ b/Cabal/tests/ParserTests/regressions/issue-774.check
@@ -4,4 +4,4 @@ The 'license' field is missing or is NONE.
 'ghc-options: -threaded' has no effect for libraries. It should only be used for executables.
 'ghc-options: -rtsopts' has no effect for libraries. It should only be used for executables.
 'ghc-options: -with-rtsopts' has no effect for libraries. It should only be used for executables.
-Packages relying on Cabal 1.12 or later should specify a version range of the form 'cabal-version: x.y'. Use 'cabal-version: 1.12'.
+Packages relying on Cabal 1.12 or later should specify a specific version of the Cabal spec of the form 'cabal-version: x.y'. Use 'cabal-version: 1.12'.


### PR DESCRIPTION
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
