### PR TITLE
Drop support for network < 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,25 +49,28 @@ matrix:
    - env: GHCVER=7.10.3 SCRIPT=script USE_GOLD=YES
      os: linux
      sudo: required
-   - env: GHCVER=8.0.2 SCRIPT=script DEPLOY_DOCS=YES USE_GOLD=YES TEST_SOLVER_BENCHMARKS=YES
+   - env: GHCVER=8.0.2 SCRIPT=script USE_GOLD=YES TEST_SOLVER_BENCHMARKS=YES
      sudo: required
      os: linux
+   - env: GHCVER=8.2.2 SCRIPT=script USE_GOLD=YES
+     os: linux
+     sudo: required
+   - env: GHCVER=8.4.1 SCRIPT=script USE_GOLD=YES DEPLOY_DOCS=YES
+     os: linux
+     sudo: required
 
-   - env: GHCVER=8.2.2 SCRIPT=solver-debug-flags USE_GOLD=YES
+   - env: GHCVER=8.4.1 SCRIPT=solver-debug-flags USE_GOLD=YES
      sudo: required
      os: linux
-   - env: GHCVER=8.2.2 SCRIPT=script DEBUG_EXPENSIVE_ASSERTIONS=YES TAGSUFFIX="-fdebug-expensive-assertions" USE_GOLD=YES
+   - env: GHCVER=8.4.1 SCRIPT=script DEBUG_EXPENSIVE_ASSERTIONS=YES TAGSUFFIX="-fdebug-expensive-assertions" USE_GOLD=YES
      os: linux
      sudo: required
    - env: GHCVER=8.0.2 SCRIPT=bootstrap USE_GOLD=YES
      sudo: required
      os: linux
-   - env: GHCVER=8.2.2 SCRIPT=bootstrap USE_GOLD=YES
+   - env: GHCVER=8.4.1 SCRIPT=bootstrap USE_GOLD=YES
      sudo: required
      os: linux
-   - env: GHCVER=8.2.2 SCRIPT=script
-     os: linux
-     sudo: required
 
    # We axed GHC 7.6 and earlier because it's not worth the trouble to
    # make older GHC work with clang's cpp.  See

--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -312,11 +312,8 @@ fetch_pkg () {
   URL_PKGDESC=${HACKAGE_URL}/${PKG}-${VER}/${PKG}.cabal
   if which ${CURL} > /dev/null
   then
-    # TODO: switch back to resuming curl command once
-    #       https://github.com/haskell/hackage-server/issues/111 is resolved
-    #${CURL} -L --fail -C - -O ${URL_PKG} || die "Failed to download ${PKG}."
-    ${CURL} -L --fail -O ${URL_PKG} || die "Failed to download ${PKG}."
-    ${CURL} -L --fail -O ${URL_PKGDESC} \
+    ${CURL} -L --fail -C - -O ${URL_PKG} || die "Failed to download ${PKG}."
+    ${CURL} -L --fail -C - -O ${URL_PKGDESC} \
         || die "Failed to download '${PKG}.cabal'."
   elif which ${WGET} > /dev/null
   then

--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -259,7 +259,6 @@ ED25519_VER="0.0.5.0"; ED25519_VER_REGEXP="0\.0\.?"
                        # 0.0.*
 HACKAGE_SECURITY_VER="0.5.3.0"; HACKAGE_SECURITY_VER_REGEXP="0\.5\.((2\.[2-9]|[3-9])|3)"
                        # >= 0.5.2 && < 0.6
-BYTESTRING_BUILDER_VER="0.10.8.1.0"; BYTESTRING_BUILDER_VER_REGEXP="0\.10\.?"
 TAR_VER="0.5.1.0";     TAR_VER_REGEXP="0\.5\.([1-9]|1[0-9]|0\.[3-9]|0\.1[0-9])\.?"
                        # >= 0.5.0.3  && < 0.6
 
@@ -427,17 +426,6 @@ do_Cabal_pkg () {
     fi
 }
 
-# Conditionally install bytestring-builder if bytestring is < 0.10.2.
-do_bytestring_builder_pkg () {
-  if egrep "bytestring-0\.(9|10\.[0,1])\.?" ghc-pkg-stage2.list > /dev/null 2>&1
-  then
-      info_pkg "bytestring-builder" ${BYTESTRING_BUILDER_VER} \
-               ${BYTESTRING_BUILDER_VER_REGEXP}
-      do_pkg   "bytestring-builder" ${BYTESTRING_BUILDER_VER} \
-               ${BYTESTRING_BUILDER_VER_REGEXP}
-  fi
-}
-
 # Actually do something!
 
 info_pkg "deepseq"      ${DEEPSEQ_VER} ${DEEPSEQ_VER_REGEXP}
@@ -502,11 +490,6 @@ do_pkg "mintty"        ${MINTTY_VER}        ${MINTTY_VER_REGEXP}
 do_pkg "echo"          ${ECHO_VER}          ${ECHO_VER_REGEXP}
 do_pkg "edit-distance" ${EDIT_DISTANCE_VER} ${EDIT_DISTANCE_VER_REGEXP}
 do_pkg   "ed25519"           ${ED25519_VER}          ${ED25519_VER_REGEXP}
-
-# We conditionally install bytestring-builder, depending on the bytestring
-# version.
-do_bytestring_builder_pkg
-
 do_pkg   "tar"               ${TAR_VER}              ${TAR_VER_REGEXP}
 do_pkg   "hackage-security"  ${HACKAGE_SECURITY_VER} \
     ${HACKAGE_SECURITY_VER_REGEXP}

--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -217,10 +217,10 @@ BINARY_VER="0.8.3.0";  BINARY_VER_REGEXP="[0]\.[78]\."
                        # >= 0.7 && < 0.9
 TEXT_VER="1.2.3.0";    TEXT_VER_REGEXP="[1]\.[2]\."
                        # >= 1.2 && < 1.3
+NETWORK_URI_VER="2.6.1.0"; NETWORK_URI_VER_REGEXP="2\.6\.(0\.[2-9]|[1-9])"
+                       # >= 2.6.0.2 && < 2.7
 NETWORK_VER="2.6.3.4"; NETWORK_VER_REGEXP="2\.[0-6]\."
                        # >= 2.0 && < 2.7
-NETWORK_URI_VER="2.6.1.0"; NETWORK_URI_VER_REGEXP="2\.6\."
-                       # >= 2.6 && < 2.7
 CABAL_VER="2.3.0.0";   CABAL_VER_REGEXP="2\.3\.[0-9]"
                        # >= 2.3 && < 2.4
 TRANS_VER="0.5.5.0";   TRANS_VER_REGEXP="0\.[45]\."
@@ -265,9 +265,9 @@ TAR_VER="0.5.1.0";     TAR_VER_REGEXP="0\.5\.([1-9]|1[0-9]|0\.[3-9]|0\.1[0-9])\.
 
 HACKAGE_URL="https://hackage.haskell.org/package"
 
-# Haddock fails for network-2.5.0.0, and for hackage-security for
-# GHC <8, c.f. https://github.com/well-typed/hackage-security/issues/149
-NO_DOCS_PACKAGES_VER_REGEXP="network-uri-2\.5\.[0-9]+\.[0-9]+|hackage-security-0\.5\.[0-9]+\.[0-9]+"
+# Haddock fails for hackage-security for GHC <8,
+# c.f. https://github.com/well-typed/hackage-security/issues/149
+NO_DOCS_PACKAGES_VER_REGEXP="hackage-security-0\.5\.[0-9]+\.[0-9]+"
 
 # Cache the list of packages:
 echo "Checking installed packages for ghc-${GHC_VER}..."
@@ -427,27 +427,6 @@ do_Cabal_pkg () {
     fi
 }
 
-# Replicate the flag selection logic for network-uri in the .cabal file.
-do_network_uri_pkg () {
-  # Refresh installed package list.
-  ${GHC_PKG} list --global ${SCOPE_OF_INSTALLATION} > ghc-pkg-stage2.list \
-    || die "running '${GHC_PKG} list' failed"
-
-  NETWORK_URI_DUMMY_VER="2.5.0.0"; NETWORK_URI_DUMMY_VER_REGEXP="2\.5\." # < 2.6
-  if egrep " network-2\.[6-9]\." ghc-pkg-stage2.list > /dev/null 2>&1
-  then
-    # Use network >= 2.6 && network-uri >= 2.6
-    info_pkg "network-uri" ${NETWORK_URI_VER} ${NETWORK_URI_VER_REGEXP}
-    do_pkg   "network-uri" ${NETWORK_URI_VER} ${NETWORK_URI_VER_REGEXP}
-  else
-    # Use network < 2.6 && network-uri < 2.6
-    info_pkg "network-uri" ${NETWORK_URI_DUMMY_VER} \
-        ${NETWORK_URI_DUMMY_VER_REGEXP}
-    do_pkg   "network-uri" ${NETWORK_URI_DUMMY_VER} \
-        ${NETWORK_URI_DUMMY_VER_REGEXP}
-  fi
-}
-
 # Conditionally install bytestring-builder if bytestring is < 0.10.2.
 do_bytestring_builder_pkg () {
   if egrep "bytestring-0\.(9|10\.[0,1])\.?" ghc-pkg-stage2.list > /dev/null 2>&1
@@ -468,6 +447,7 @@ info_pkg "transformers" ${TRANS_VER}   ${TRANS_VER_REGEXP}
 info_pkg "mtl"          ${MTL_VER}     ${MTL_VER_REGEXP}
 info_pkg "text"         ${TEXT_VER}    ${TEXT_VER_REGEXP}
 info_pkg "parsec"       ${PARSEC_VER}  ${PARSEC_VER_REGEXP}
+info_pkg "network-uri"  ${NETWORK_URI_VER} ${NETWORK_URI_VER_REGEXP}
 info_pkg "network"      ${NETWORK_VER} ${NETWORK_VER_REGEXP}
 info_pkg "HTTP"         ${HTTP_VER}    ${HTTP_VER_REGEXP}
 info_pkg "zlib"         ${ZLIB_VER}    ${ZLIB_VER_REGEXP}
@@ -503,11 +483,8 @@ do_pkg   "parsec"       ${PARSEC_VER}  ${PARSEC_VER_REGEXP}
 # Install the Cabal library from the local Git clone if possible.
 do_Cabal_pkg
 
+do_pkg   "network-uri"  ${NETWORK_URI_VER} ${NETWORK_URI_VER_REGEXP}
 do_pkg   "network"      ${NETWORK_VER} ${NETWORK_VER_REGEXP}
-
-# We conditionally install network-uri, depending on the network version.
-do_network_uri_pkg
-
 do_pkg   "HTTP"         ${HTTP_VER}       ${HTTP_VER_REGEXP}
 do_pkg   "zlib"         ${ZLIB_VER}       ${ZLIB_VER_REGEXP}
 do_pkg   "random"       ${RANDOM_VER}     ${RANDOM_VER_REGEXP}

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -94,10 +94,6 @@ source-repository head
   location: https://github.com/haskell/cabal/
   subdir:   cabal-install
 
-Flag network-uri
-  description:  Get Network.URI from the network-uri package
-  default:      True
-
 Flag native-dns
   description:  Enable use of the [resolv](https://hackage.haskell.org/package/resolv) & [windns](https://hackage.haskell.org/package/windns) packages for performing DNS lookups
   default:      True
@@ -310,6 +306,8 @@ library
         hashable   >= 1.0      && < 2,
         HTTP       >= 4000.1.5 && < 4000.4,
         mtl        >= 2.0      && < 3,
+        network-uri >= 2.6.0.2 && < 2.7,
+        network    >= 2.6      && < 2.7,
         pretty     >= 1.1      && < 1.2,
         process    >= 1.1.0.2  && < 1.7,
         random     >= 1        && < 1.2,
@@ -318,14 +316,6 @@ library
         time       >= 1.4      && < 1.9,
         zlib       >= 0.5.3    && < 0.7,
         hackage-security >= 0.5.2.2 && < 0.6
-
-    -- NOTE: you MUST include the network dependency even when network-uri
-    -- is pulled in, otherwise the constraint solver doesn't have enough
-    -- information
-    if flag(network-uri)
-      build-depends: network-uri >= 2.6 && < 2.7, network >= 2.6 && < 2.7
-    else
-      build-depends: network     >= 2.4 && < 2.6
 
     if flag(native-dns)
       if os(windows)
@@ -393,6 +383,8 @@ executable cabal
             hashable   >= 1.0      && < 2,
             HTTP       >= 4000.1.5 && < 4000.4,
             mtl        >= 2.0      && < 3,
+            network    >= 2.6      && < 2.7,
+            network-uri >= 2.6     && < 2.7,
             pretty     >= 1.1      && < 1.2,
             process    >= 1.2      && < 1.7,
             random     >= 1        && < 1.2,
@@ -547,14 +539,6 @@ executable cabal
             Distribution.Solver.Types.SolverPackage
             Distribution.Solver.Types.SourcePackage
             Distribution.Solver.Types.Variable
-
-        -- NOTE: you MUST include the network dependency even when network-uri
-        -- is pulled in, otherwise the constraint solver doesn't have enough
-        -- information
-        if flag(network-uri)
-          build-depends: network-uri >= 2.6 && < 2.7, network >= 2.6 && < 2.7
-        else
-          build-depends: network     >= 2.4 && < 2.6
 
         if flag(native-dns)
           if os(windows)


### PR DESCRIPTION
Also drop `bytestring-builder` from the bootstrap script, cabal-install no longer supports `bytestring < 0.10.2` anyway.

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
