### PR TITLE
Infrastructure to filter commandline arguments

### DIFF
--- a/Cabal/Distribution/Simple/Program/Types.hs
+++ b/Cabal/Distribution/Simple/Program/Types.hs
@@ -38,6 +38,7 @@ module Distribution.Simple.Program.Types (
 import Prelude ()
 import Distribution.Compat.Prelude
 
+import Distribution.PackageDescription
 import Distribution.Simple.Program.Find
 import Distribution.Version
 import Distribution.Verbosity
@@ -78,7 +79,7 @@ data Program = Program {
        -- | A function that filters any arguments that don't impact the output
        -- from a commandline. Used to limit the volatility of dependency hashes
        -- when using new-build.
-       programFilterArgs :: Maybe Version -> [String] -> [String]
+       programNormaliseArgs :: Maybe Version -> PackageDescription -> [String] -> [String]
      }
 instance Show Program where
   show (Program name _ _ _ _) = "Program: " ++ name
@@ -166,7 +167,7 @@ simpleProgram name = Program {
     programFindLocation = \v p -> findProgramOnSearchPath v p name,
     programFindVersion  = \_ _ -> return Nothing,
     programPostConf     = \_ p -> return p,
-    programFilterArgs   = const id
+    programNormaliseArgs   = \_ _ -> id
   }
 
 -- | Make a simple 'ConfiguredProgram'.

--- a/Cabal/Distribution/Simple/Program/Types.hs
+++ b/Cabal/Distribution/Simple/Program/Types.hs
@@ -74,10 +74,14 @@ data Program = Program {
        -- | A function to do any additional configuration after we have
        -- located the program (and perhaps identified its version). For example
        -- it could add args, or environment vars.
-       programPostConf :: Verbosity -> ConfiguredProgram -> IO ConfiguredProgram
+       programPostConf :: Verbosity -> ConfiguredProgram -> IO ConfiguredProgram,
+       -- | A function that filters any arguments that don't impact the output
+       -- from a commandline. Used to limit the volatility of dependency hashes
+       -- when using new-build.
+       programFilterArgs :: Maybe Version -> [String] -> [String]
      }
 instance Show Program where
-  show (Program name _ _ _) = "Program: " ++ name
+  show (Program name _ _ _ _) = "Program: " ++ name
 
 type ProgArg = String
 
@@ -161,7 +165,8 @@ simpleProgram name = Program {
     programName         = name,
     programFindLocation = \v p -> findProgramOnSearchPath v p name,
     programFindVersion  = \_ _ -> return Nothing,
-    programPostConf     = \_ p -> return p
+    programPostConf     = \_ p -> return p,
+    programFilterArgs   = const id
   }
 
 -- | Make a simple 'ConfiguredProgram'.

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -3566,13 +3566,21 @@ packageHashConfigInputs
       pkgHashStripLibs           = elabStripLibs,
       pkgHashStripExes           = elabStripExes,
       pkgHashDebugInfo           = elabDebugInfo,
-      pkgHashProgramArgs         = elabProgramArgs,
+      pkgHashProgramArgs         = Map.mapWithKey lookupFilter elabProgramArgs,
       pkgHashExtraLibDirs        = elabExtraLibDirs,
       pkgHashExtraFrameworkDirs  = elabExtraFrameworkDirs,
       pkgHashExtraIncludeDirs    = elabExtraIncludeDirs,
       pkgHashProgPrefix          = elabProgPrefix,
       pkgHashProgSuffix          = elabProgSuffix
     }
+  where
+    lookupFilter :: String -> [String] -> [String]
+    lookupFilter n = case lookupKnownProgram n pkgConfigCompilerProgs of
+        Just p -> programFilterArgs p (getVersion p)
+        Nothing -> id
+
+    getVersion :: Program -> Maybe Version
+    getVersion p = lookupProgram p pkgConfigCompilerProgs >>= programVersion
 
 
 -- | Given the 'InstalledPackageIndex' for a nix-style package store, and an

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -3574,13 +3574,15 @@ packageHashConfigInputs
       pkgHashProgSuffix          = elabProgSuffix
     }
   where
+    knownProgramDb = addKnownPrograms builtinPrograms pkgConfigCompilerProgs
+
     lookupFilter :: String -> [String] -> [String]
-    lookupFilter n flags = case lookupKnownProgram n pkgConfigCompilerProgs of
+    lookupFilter n flags = case lookupKnownProgram n knownProgramDb of
         Just p -> programNormaliseArgs p (getVersion p) elabPkgDescription flags
         Nothing -> flags
 
     getVersion :: Program -> Maybe Version
-    getVersion p = lookupProgram p pkgConfigCompilerProgs >>= programVersion
+    getVersion p = lookupProgram p knownProgramDb >>= programVersion
 
 
 -- | Given the 'InstalledPackageIndex' for a nix-style package store, and an

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -3575,9 +3575,9 @@ packageHashConfigInputs
     }
   where
     lookupFilter :: String -> [String] -> [String]
-    lookupFilter n = case lookupKnownProgram n pkgConfigCompilerProgs of
-        Just p -> programFilterArgs p (getVersion p)
-        Nothing -> id
+    lookupFilter n flags = case lookupKnownProgram n pkgConfigCompilerProgs of
+        Just p -> programNormaliseArgs p (getVersion p) elabPkgDescription flags
+        Nothing -> flags
 
     getVersion :: Program -> Maybe Version
     getVersion p = lookupProgram p pkgConfigCompilerProgs >>= programVersion


### PR DESCRIPTION
This piggybacks any filters on Cabal's support for known programs, it allows us to specify a version specific argument filtering function for each program Cabal knows about.

See #4247.