### PR TITLE
Use GHC 8.2.2 and new-build for solver-debug-flags Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
      os: linux
      sudo: required
 
-   - env: GHCVER=8.4.1 SCRIPT=solver-debug-flags USE_GOLD=YES
+   - env: GHCVER=8.2.2 SCRIPT=solver-debug-flags USE_GOLD=YES
      sudo: required
      os: linux
    - env: GHCVER=8.4.1 SCRIPT=script DEBUG_EXPENSIVE_ASSERTIONS=YES TAGSUFFIX="-fdebug-expensive-assertions" USE_GOLD=YES

--- a/travis-solver-debug-flags.sh
+++ b/travis-solver-debug-flags.sh
@@ -1,16 +1,9 @@
 #!/bin/sh
 
 # Build cabal with solver debug flags enabled.
-#
-# We use a sandbox, because cabal-install-1.24.0.0's new-build command tries to
-# build tracetree's dependencies with the inplace Cabal, which leads to compile
-# errors. We also need to skip the tests, because debug-tracetree prints the
-# whole solver tree as JSON.
+# We need to skip the tests, because debug-tracetree prints the whole solver
+# tree as JSON.
 
 cabal update
-cd cabal-install
-cabal sandbox init
-cabal sandbox add-source ../Cabal
-cabal install --dependencies-only --constraint "cabal-install +debug-tracetree +debug-conflict-sets"
-cabal configure --ghc-option=-Werror --constraint "cabal-install +debug-tracetree +debug-conflict-sets"
-cabal build
+cabal install happy
+cabal new-build exe:cabal --constraint "cabal-install +debug-tracetree +debug-conflict-sets"


### PR DESCRIPTION
I think https://github.com/haskell/cabal/pull/5235/commits/668825dcbe3e26e73c7b8fad411ceecefab7b97a broke the solver-debug-flags Travis job because `tracetree` hasn't been updated for GHC 8.4.1.  This PR uses GHC 8.2.2 again and also updates the script to use new-build.

____________________________________________________________________

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
