### PR TITLE
Fix doc link to --constraint option

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -723,7 +723,7 @@ The following settings control the behavior of the dependency solver:
 
     Valid constraints take the same form as for the `constraint
     command line option
-    <installing-packages.html#cmdoption-setup-configure--constraint>`__.
+    <installing-packages.html#cmdoption-setup-configure-constraint>`__.
 
 .. cfg-field:: preferences: preference (comma separated)
                --preference="pkg >= 2.0"


### PR DESCRIPTION
The correct link:

https://www.haskell.org/cabal/users-guide/installing-packages.html#cmdoption-setup-configure-constraint

previously was `...configure--constraint` instead of `...configure-constraint`.

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!