### PR TITLE
Haddock: add internal libraries to package index

### DIFF
--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -23,6 +23,7 @@ module Distribution.Simple.Build (
     startInterpreter,
 
     initialBuildSteps,
+    createInternalPackageDB,
     componentInitialBuildSteps,
     writeAutogenFiles,
   ) where


### PR DESCRIPTION
`setup haddock` now updates the package index with each internal library it haddocks. This fixes https://github.com/haskell/cabal/issues/4969 

(don't mind the commit from https://github.com/haskell/cabal/pull/5226 here)

/cc @shlevy

---

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
