### PR TITLE
Revert "Use GHC 8.2.2 for solver-debug-flags Travis job."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
      os: linux
      sudo: required
 
-   - env: GHCVER=8.2.2 SCRIPT=solver-debug-flags USE_GOLD=YES
+   - env: GHCVER=8.4.1 SCRIPT=solver-debug-flags USE_GOLD=YES
      sudo: required
      os: linux
    - env: GHCVER=8.4.1 SCRIPT=script DEBUG_EXPENSIVE_ASSERTIONS=YES TAGSUFFIX="-fdebug-expensive-assertions" USE_GOLD=YES


### PR DESCRIPTION
This reverts commit 0e3718c496012a2b476529445c434438d1c6b71c.

tracetree was updated for GHC 8.4.1 in version 0.1.0.2.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
