### PR TITLE
Fix architecture mismatch of the Paths_ modules on Windows

### DIFF
--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -243,13 +243,13 @@ generate pkg_descr lbi clbi =
 
         paths_modulename = autogenPathsModuleName pkg_descr
 
-        get_prefix_stuff = get_prefix_win32 buildArch
+        get_prefix_stuff = get_prefix_win32 supports_cpp buildArch
 
         path_sep = show [pathSeparator]
 
         supports_cpp = supports_language_pragma
-        supports_rebindable_syntax= ghc_newer_than (mkVersion [7,0,1])
         supports_language_pragma = ghc_newer_than (mkVersion [6,6,1])
+        supports_rebindable_syntax= ghc_newer_than (mkVersion [7,0,1])
 
         ghc_newer_than minVersion =
           case compilerCompatVersion GHC (compiler lbi) of
@@ -280,8 +280,8 @@ get_prefix_reloc_stuff =
   "  let (bindir,_) = splitFileName exePath\n"++
   "  return ((bindir `minusFileName` bindirrel) `joinFileName` dirRel)\n"
 
-get_prefix_win32 :: Arch -> String
-get_prefix_win32 arch =
+get_prefix_win32 :: Bool -> Arch -> String
+get_prefix_win32 supports_cpp arch =
   "getPrefixDirRel :: FilePath -> IO FilePath\n"++
   "getPrefixDirRel dirRel = try_size 2048 -- plenty, PATH_MAX is 512 under Win32.\n"++
   "  where\n"++
@@ -295,12 +295,23 @@ get_prefix_win32 arch =
   "              return ((bindir `minusFileName` bindirrel) `joinFileName` dirRel)\n"++
   "            | otherwise  -> try_size (size * 2)\n"++
   "\n"++
+  (case supports_cpp of
+    False -> ""
+    True  -> "#if defined(i386_HOST_ARCH)\n"++
+             "# define WINDOWS_CCONV stdcall\n"++
+             "#elif defined(x86_64_HOST_ARCH)\n"++
+             "# define WINDOWS_CCONV ccall\n"++
+             "#else\n"++
+             "# error Unknown mingw32 arch\n"++
+             "#endif\n")++
   "foreign import " ++ cconv ++ " unsafe \"windows.h GetModuleFileNameW\"\n"++
   "  c_GetModuleFileName :: Ptr () -> CWString -> Int32 -> IO Int32\n"
-    where cconv = case arch of
-                  I386 -> "stdcall"
-                  X86_64 -> "ccall"
-                  _ -> error "win32 supported only with I386, X86_64"
+    where cconv = if supports_cpp
+                     then "WINDOWS_CCONV"
+                     else case arch of
+                            I386 -> "stdcall"
+                            X86_64 -> "ccall"
+                            _ -> error "win32 supported only with I386, X86_64"
 
 filename_stuff :: String
 filename_stuff =

--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -248,8 +248,8 @@ generate pkg_descr lbi clbi =
         path_sep = show [pathSeparator]
 
         supports_cpp = supports_language_pragma
-        supports_language_pragma = ghc_newer_than (mkVersion [6,6,1])
         supports_rebindable_syntax= ghc_newer_than (mkVersion [7,0,1])
+        supports_language_pragma = ghc_newer_than (mkVersion [6,6,1])
 
         ghc_newer_than minVersion =
           case compilerCompatVersion GHC (compiler lbi) of


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Cabal is causing an abi issue by forcing it's own architecture's calling convention on each module it creates in the `Path_` modules on Windows.
Compiling a 64 bit executable with a 32 bit cabal happens to work because the linker can perform fixups, adding an indirection to to correct the calling convention. However compiling a 32 bit executable from a 64 bit cabal will fail since the linker can't change the callee.

This corrects that by if cpp is enabled to use predefines from the compiler to determine what to do. Unfortunately due to a bug in GHC I have to rely on macro GHC puts out instead of the standard platform macros. So this only works for GHC code.

It has the old method as fallback for if cpp is not supported. Fixes #5254

Tested it by building a cabal-install, then using it to build cabal-install again.