### PR TITLE
fix infinite loop in D.Client.TargetSelector

### DIFF
--- a/cabal-install/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/Distribution/Client/TargetSelector.hs
@@ -611,8 +611,9 @@ disambiguateTargetSelectors matcher matchInput exactMatch matchResults =
             Left  ( originalMatch
                   , [ (forgetFileStatus rendering, matches)
                     | rendering <- matchRenderings
-                    , let (Match m _ matches) | m /= Inexact =
+                    , let Match m _ matches =
                             memoisedMatches Map.! rendering
+                    , m /= Inexact
                     ] )
 
       | (originalMatch, matchRenderings) <- matchResultsRenderings ]


### PR DESCRIPTION
The pattern guard was clearly meant as a list-comprehension filter,
but on a let-bound pattern, it instead caused a circular loop in which
whether the LHS variables are bound the the RHS values depends on the
values of the LHS variables.

fixes #5081

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

I tested this by running the problematic command from `#5081`. Result before the fix:

    $ cabal new-build test:unknown-test-suite
    cabal: Internal error in target matching. It should always be possible to find
    a syntax that's sufficiently qualified to give an unambiguous match. However
    when matching 'test:unknown-test-suite' we found test:unknown-test-suite
    (unknown-component) which does not have an unambiguous syntax. The possible
    syntax and the targets they match are as follows:
    cabal: <<loop>>

Result after the fix:

    $ cabal new-build test:unknown-test-suite
    cabal: Internal error in target matching. It should always be possible
    to find a syntax that's sufficiently qualified to give an unambiguous match.
    However when matching 'test:unknown-test-suite' we found
    test:unknown-test-suite (unknown-component) which does not have an unambiguous
    syntax. The possible syntax and the targets they match are as follows:
    'test:unknown-test-suite' which matches test:unknown-test-suite
    (unknown-component), :pkg:test:lib:test:file:unknown-test-suite (unknown-file)

I also tested with `all:test` (typo for `all:tests`), which has similar results before and after the fix.