### PR TITLE
Bump upper bound on unix to < 2.9

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -188,7 +188,7 @@ library
   if os(windows)
     build-depends: Win32 >= 2.2.2 && < 2.7
   else
-    build-depends: unix  >= 2.5.1 && < 2.8
+    build-depends: unix  >= 2.5.1 && < 2.9
 
   ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs
   if impl(ghc >= 8.0)

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -326,7 +326,7 @@ library
     if os(windows)
       build-depends: Win32 >= 2 && < 3
     else
-      build-depends: unix >= 2.5 && < 2.8
+      build-depends: unix >= 2.5 && < 2.9
 
     if flag(debug-expensive-assertions)
       cpp-options: -DDEBUG_EXPENSIVE_ASSERTIONS
@@ -549,7 +549,7 @@ executable cabal
         if os(windows)
           build-depends: Win32 >= 2 && < 3
         else
-          build-depends: unix >= 2.5 && < 2.8
+          build-depends: unix >= 2.5 && < 2.9
 
         if flag(debug-expensive-assertions)
           cpp-options: -DDEBUG_EXPENSIVE_ASSERTIONS


### PR DESCRIPTION
See https://ghc.haskell.org/trac/ghc/ticket/15042.

I ran the `Cabal` test suites against `unix-2.8`, and they all passed.