### PR TITLE
Prototype flag normalisation for GHC 8.0-8.4

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -254,6 +254,7 @@ library
     Distribution.Simple.Command
     Distribution.Simple.Compiler
     Distribution.Simple.Configure
+    Distribution.Simple.Flag
     Distribution.Simple.GHC
     Distribution.Simple.GHCJS
     Distribution.Simple.Haddock

--- a/Cabal/Distribution/Simple/Flag.hs
+++ b/Cabal/Distribution/Simple/Flag.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Simple.Flag

--- a/Cabal/Distribution/Simple/Flag.hs
+++ b/Cabal/Distribution/Simple/Flag.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE DeriveGeneric #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.Simple.Flag
+-- Copyright   :  Isaac Jones 2003-2004
+--                Duncan Coutts 2007
+-- License     :  BSD3
+--
+-- Maintainer  :  cabal-devel@haskell.org
+-- Portability :  portable
+--
+-- Defines the 'Flag' type and it's 'Monoid' instance,  see
+-- <http://www.haskell.org/pipermail/cabal-devel/2007-December/001509.html>
+-- for an explanation.
+--
+-- Split off from "Distribution.Simple.Setup" to break import cycles.
+module Distribution.Simple.Flag (
+  Flag(..),
+  allFlags,
+  toFlag,
+  fromFlag,
+  fromFlagOrDefault,
+  flagToMaybe,
+  flagToList,
+  maybeToFlag,
+  BooleanFlag(..) ) where
+
+import Prelude ()
+import Distribution.Compat.Prelude hiding (get)
+import Distribution.Compat.Stack
+
+-- ------------------------------------------------------------
+-- * Flag type
+-- ------------------------------------------------------------
+
+-- | All flags are monoids, they come in two flavours:
+--
+-- 1. list flags eg
+--
+-- > --ghc-option=foo --ghc-option=bar
+--
+-- gives us all the values ["foo", "bar"]
+--
+-- 2. singular value flags, eg:
+--
+-- > --enable-foo --disable-foo
+--
+-- gives us Just False
+-- So this Flag type is for the latter singular kind of flag.
+-- Its monoid instance gives us the behaviour where it starts out as
+-- 'NoFlag' and later flags override earlier ones.
+--
+data Flag a = Flag a | NoFlag deriving (Eq, Generic, Show, Read)
+
+instance Binary a => Binary (Flag a)
+
+instance Functor Flag where
+  fmap f (Flag x) = Flag (f x)
+  fmap _ NoFlag  = NoFlag
+
+instance Monoid (Flag a) where
+  mempty = NoFlag
+  mappend = (<>)
+
+instance Semigroup (Flag a) where
+  _ <> f@(Flag _) = f
+  f <> NoFlag     = f
+
+instance Bounded a => Bounded (Flag a) where
+  minBound = toFlag minBound
+  maxBound = toFlag maxBound
+
+instance Enum a => Enum (Flag a) where
+  fromEnum = fromEnum . fromFlag
+  toEnum   = toFlag   . toEnum
+  enumFrom (Flag a) = map toFlag . enumFrom $ a
+  enumFrom _        = []
+  enumFromThen (Flag a) (Flag b) = toFlag `map` enumFromThen a b
+  enumFromThen _        _        = []
+  enumFromTo   (Flag a) (Flag b) = toFlag `map` enumFromTo a b
+  enumFromTo   _        _        = []
+  enumFromThenTo (Flag a) (Flag b) (Flag c) = toFlag `map` enumFromThenTo a b c
+  enumFromThenTo _        _        _        = []
+
+toFlag :: a -> Flag a
+toFlag = Flag
+
+fromFlag :: WithCallStack (Flag a -> a)
+fromFlag (Flag x) = x
+fromFlag NoFlag   = error "fromFlag NoFlag. Use fromFlagOrDefault"
+
+fromFlagOrDefault :: a -> Flag a -> a
+fromFlagOrDefault _   (Flag x) = x
+fromFlagOrDefault def NoFlag   = def
+
+flagToMaybe :: Flag a -> Maybe a
+flagToMaybe (Flag x) = Just x
+flagToMaybe NoFlag   = Nothing
+
+flagToList :: Flag a -> [a]
+flagToList (Flag x) = [x]
+flagToList NoFlag   = []
+
+allFlags :: [Flag Bool] -> Flag Bool
+allFlags flags = if all (\f -> fromFlagOrDefault False f) flags
+                 then Flag True
+                 else NoFlag
+
+maybeToFlag :: Maybe a -> Flag a
+maybeToFlag Nothing  = NoFlag
+maybeToFlag (Just x) = Flag x
+
+-- | Types that represent boolean flags.
+class BooleanFlag a where
+    asBool :: a -> Bool
+
+instance BooleanFlag Bool where
+  asBool = id

--- a/Cabal/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/Distribution/Simple/Program/Builtin.hs
@@ -48,6 +48,7 @@ module Distribution.Simple.Program.Builtin (
 import Prelude ()
 import Distribution.Compat.Prelude
 
+import Distribution.Simple.Program.GHC
 import Distribution.Simple.Program.Find
 import Distribution.Simple.Program.Internal
 import Distribution.Simple.Program.Run
@@ -118,7 +119,9 @@ ghcProgram = (simpleProgram "ghc") {
        return $ maybe ghcProg
          (\v -> if withinRange v affectedVersionRange
                 then ghcProg' else ghcProg)
-         (programVersion ghcProg)
+         (programVersion ghcProg),
+
+    programNormaliseArgs = normaliseGhcArgs
   }
 
 runghcProgram :: Program
@@ -311,7 +314,9 @@ haddockProgram = (simpleProgram "haddock") {
       -- "Haddock version 0.8, (c) Simon Marlow 2006"
       case words str of
         (_:_:ver:_) -> takeWhile (`elem` ('.':['0'..'9'])) ver
-        _           -> ""
+        _           -> "",
+
+    programNormaliseArgs = \_ _ _ -> []
   }
 
 greencardProgram :: Program

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -50,13 +50,13 @@ import Text.Read (readMaybe)
 
 normaliseGhcArgs :: Maybe Version -> PackageDescription -> [String] -> [String]
 normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
-   | ghcVersion `withinRange` supportedGHCVersions =
-     argumentFilters $ filter simpleFilters ghcArgs
+   | ghcVersion `withinRange` supportedGHCVersions
+   = argumentFilters $ filter simpleFilters ghcArgs
   where
     supportedGHCVersions :: VersionRange
     supportedGHCVersions = intersectVersionRanges
         (orLaterVersion (mkVersion [8,0]))
-        (orEarlierVersion (mkVersion [8,4]))
+        (earlierVersion (mkVersion [8,5]))
 
     from :: Monoid m => [Int] -> m -> m
     from version flags

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -46,7 +46,6 @@ import qualified Data.Map as Map
 import Data.Monoid (All(..), Any(..), Endo(..), First(..))
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Text.Read (readMaybe)
 
 normaliseGhcArgs :: Maybe Version -> PackageDescription -> [String] -> [String]
 normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
@@ -152,7 +151,7 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
       , isOptIntFlag
       , isIntFlag
       , if safeToFilterWarnings
-           then isWarning <> Any . ("-w"==)
+           then isWarning <> (Any . ("-w"==))
            else mempty
       ]
 
@@ -204,6 +203,11 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
       where
         parseInt :: String -> Maybe Int
         parseInt = readMaybe . dropEq
+
+        readMaybe :: Read a => String -> Maybe a
+        readMaybe s = case reads s of
+            [(x, "")] -> Just x
+            _ -> Nothing
 
     dropEq :: String -> String
     dropEq ('=':s) = s

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -43,7 +43,7 @@ import Language.Haskell.Extension
 
 import Data.List (stripPrefix)
 import qualified Data.Map as Map
-import Data.Monoid (Any(..), Endo(..), First(..))
+import Data.Monoid (All(..), Any(..), Endo(..), First(..))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Text.Read (readMaybe)
@@ -63,10 +63,10 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
       | ghcVersion `withinRange` orLaterVersion (mkVersion version) = flags
       | otherwise = mempty
 
-    checkComponentWarnings :: (a -> BuildInfo) -> [a] -> Any
+    checkComponentWarnings :: (a -> BuildInfo) -> [a] -> All
     checkComponentWarnings getInfo = foldMap $ checkComponent . getInfo
       where
-        checkComponent :: BuildInfo -> Any
+        checkComponent :: BuildInfo -> All
         checkComponent =
           foldMap checkWarnings . filterGhcOptions . allBuildInfoOptions
 
@@ -77,7 +77,7 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
         filterGhcOptions :: [(CompilerFlavor, [String])] -> [[String]]
         filterGhcOptions l = [opts | (GHC, opts) <- l]
 
-    libs, exes, tests, benches :: Any
+    libs, exes, tests, benches :: All
     libs = checkComponentWarnings libBuildInfo $
                 maybeToList library ++ subLibraries
 
@@ -86,11 +86,11 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
     benches = checkComponentWarnings benchmarkBuildInfo $ benchmarks
 
     safeToFilterWarnings :: Bool
-    safeToFilterWarnings = getAny $ mconcat
+    safeToFilterWarnings = getAll $ mconcat
         [checkWarnings ghcArgs, libs, exes, tests, benches]
 
-    checkWarnings :: [String] -> Any
-    checkWarnings = Any . Set.null . foldr alter Set.empty
+    checkWarnings :: [String] -> All
+    checkWarnings = All . Set.null . foldr alter Set.empty
       where
         alter :: String -> Set String -> Set String
         alter flag = appEndo $ mconcat

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -35,7 +35,6 @@ import Distribution.Simple.Program.Run
 import Distribution.System
 import Distribution.Text
 import Distribution.Types.ComponentId
-import Distribution.Types.Library (libBuildInfo)
 import Distribution.Verbosity
 import Distribution.Version
 import Distribution.Utils.NubList


### PR DESCRIPTION
Uses the just merged infrastructure to normalise commandline arguments to filter out any GHC flags that don't affect the build products. Currently only filters commandline arguments for GHC >=8.0 && <8.5 as those are the only versions I checked the flags for.

I went through the GHC DynFlags source for all those version to figure out which flags can be filtered and to follow the right format. Anything I wasn't sure about is left alone, some flags I'm still unsure about are documented in #4247.

Also filters out all haddock arguments, as those should never affect GHC build products.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
