### PR TITLE
Add Semigroup instance to fix CI test failures

### DIFF
--- a/Cabal/tests/HackageTests.hs
+++ b/Cabal/tests/HackageTests.hs
@@ -95,9 +95,11 @@ readFieldTest fpath bsl = case Parsec.readFields $ bslToStrict bsl of
 -- | Map with unionWith monoid
 newtype M k v = M (Map.Map k v)
     deriving (Show)
+instance (Ord k, Monoid v) => Semigroup (M k v) where
+    M a <> M b = M (Map.unionWith mappend a b)
 instance (Ord k, Monoid v) => Monoid (M k v) where
     mempty = M Map.empty
-    mappend (M a) (M b) = M (Map.unionWith mappend a b)
+    mappend = (<>)
 instance (NFData k, NFData v) => NFData (M k v) where
     rnf (M m) = rnf m
 


### PR DESCRIPTION
I use a `Monoid` constraint on `v` since I think else it breaks on pre-8.4 compilers where `Semigroup` is not a superclass of `Monoid`. Should fix the trivial test failure that's been bugging me for ages.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
