### PR TITLE
BUG/RFC: Fix `scope` field backwards compatibility

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -53,6 +53,7 @@ import Distribution.System
 import Distribution.Text
 import Distribution.Types.ComponentRequestedSpec
 import Distribution.Types.CondTree
+import Distribution.Types.ExecutableScope
 import Distribution.Types.ExeDependency
 import Distribution.Types.UnqualComponentName
 import Distribution.Utils.Generic                    (isAscii)
@@ -315,6 +316,12 @@ checkExecutable pkg exe =
       PackageBuildImpossible $
            "On executable '" ++ display (exeName exe) ++ "' an 'autogen-module' is not "
         ++ "on 'other-modules'"
+
+  , checkSpecVersion pkg [2,0] (exeScope exe /= ExecutableScopeUnknown) $
+      PackageDistSuspiciousWarn $
+           "To use the 'scope' field the package needs to specify "
+        ++ "at least 'cabal-version: >= 2.0'."
+
   ]
   where
     moduleDuplicates = dups (exeModules exe)

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -52,7 +52,6 @@ import Distribution.Parsec.Common
 import Distribution.Parsec.Newtypes
 import Distribution.Parsec.ParseResult
 import Distribution.Text                      (display)
-import Distribution.Types.ExecutableScope
 import Distribution.Types.ForeignLib
 import Distribution.Types.ForeignLibType
 import Distribution.Types.UnqualComponentName
@@ -159,8 +158,7 @@ executableFieldGrammar
 executableFieldGrammar n = Executable n
     -- main-is is optional as conditional blocks don't have it
     <$> optionalFieldDefAla "main-is" FilePathNT L.modulePath ""
-    <*> optionalFieldDef    "scope"              L.exeScope ExecutablePublic
-        ^^^ availableSince [2,0] ExecutablePublic
+    <*> monoidalField       "scope"              L.exeScope
     <*> blurFieldGrammar L.buildInfo buildInfoFieldGrammar
 {-# SPECIALIZE executableFieldGrammar :: UnqualComponentName -> ParsecFieldGrammar' Executable #-}
 {-# SPECIALIZE executableFieldGrammar :: UnqualComponentName -> PrettyFieldGrammar' Executable #-}

--- a/Cabal/Distribution/Types/ExecutableScope.hs
+++ b/Cabal/Distribution/Types/ExecutableScope.hs
@@ -16,18 +16,23 @@ import qualified Distribution.Compat.CharParsing as P
 import qualified Distribution.Compat.ReadP as Parse
 import qualified Text.PrettyPrint as Disp
 
-data ExecutableScope = ExecutablePublic
+data ExecutableScope = ExecutableScopeUnknown
+                     | ExecutablePublic
                      | ExecutablePrivate
     deriving (Generic, Show, Read, Eq, Typeable, Data)
 
 instance Pretty ExecutableScope where
     pretty ExecutablePublic       = Disp.text "public"
     pretty ExecutablePrivate      = Disp.text "private"
+    pretty ExecutableScopeUnknown = Disp.text "unknown"
 
 instance Parsec ExecutableScope where
-    parsec = P.try pub <|> pri where
-        pub = ExecutablePublic  <$ P.string "public"
-        pri = ExecutablePrivate <$ P.string "private"
+    parsec = do
+        name <- P.munch1 (\c -> isAlphaNum c || c == '-')
+        return $ case name of
+              "public"  -> ExecutablePublic
+              "private" -> ExecutablePrivate
+              _         -> ExecutableScopeUnknown
 
 instance Text ExecutableScope where
     parse = Parse.choice
@@ -39,12 +44,12 @@ instance Binary ExecutableScope
 
 instance NFData ExecutableScope where rnf = genericRnf
 
--- | 'Any' like semigroup, where 'ExecutablePrivate' is 'Any True'
-instance Semigroup ExecutableScope where
-    ExecutablePublic    <> x = x
-    x@ExecutablePrivate <> _ = x
-
--- | 'mempty' = 'ExecutablePublic'
 instance Monoid ExecutableScope where
-    mempty = ExecutablePublic
+    mempty = ExecutableScopeUnknown
     mappend = (<>)
+
+instance Semigroup ExecutableScope where
+    ExecutableScopeUnknown <> x = x
+    x <> ExecutableScopeUnknown = x
+    x <> y | x == y             = x
+           | otherwise          = error "Ambiguous executable scope"

--- a/Cabal/tests/ParserTests/regressions/issue-5055.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-5055.expr
@@ -59,7 +59,7 @@ GenericPackageDescription
                                                                                           `mkVersion [5]`))],
                                                             virtualModules = []},
                                              exeName = `UnqualComponentName "flag-test-exe"`,
-                                             exeScope = ExecutablePublic,
+                                             exeScope = ExecutableScopeUnknown,
                                              modulePath = "FirstMain.hs"}}],
    condForeignLibs = [],
    condLibrary = Nothing,

--- a/Cabal/tests/ParserTests/regressions/issue-5055.format
+++ b/Cabal/tests/ParserTests/regressions/issue-5055.format
@@ -10,6 +10,7 @@ build-type: Simple
 
 executable flag-test-exe
     main-is: FirstMain.hs
+    scope: unknown
     default-language: Haskell2010
     build-depends:
         base >=4.8 && <5

--- a/Cabal/tests/ParserTests/regressions/shake.expr
+++ b/Cabal/tests/ParserTests/regressions/shake.expr
@@ -56,7 +56,7 @@ GenericPackageDescription
                                                                                                            targetBuildDepends = [],
                                                                                                            virtualModules = []},
                                                                                             exeName = `UnqualComponentName "shake"`,
-                                                                                            exeScope = ExecutablePublic,
+                                                                                            exeScope = ExecutableScopeUnknown,
                                                                                             modulePath = ""}}},
                                                  CondBranch
                                                    {condBranchCondition = `Var (Flag (FlagName "portable"))`,
@@ -118,7 +118,7 @@ GenericPackageDescription
                                                                                                                                                                                         `mkVersion [2,5,1]`)],
                                                                                                                                                              virtualModules = []},
                                                                                                                                               exeName = `UnqualComponentName "shake"`,
-                                                                                                                                              exeScope = ExecutablePublic,
+                                                                                                                                              exeScope = ExecutableScopeUnknown,
                                                                                                                                               modulePath = ""}}}],
                                                                              condTreeConstraints = [],
                                                                              condTreeData = Executable
@@ -165,7 +165,7 @@ GenericPackageDescription
                                                                                                               targetBuildDepends = [],
                                                                                                               virtualModules = []},
                                                                                                exeName = `UnqualComponentName "shake"`,
-                                                                                               exeScope = ExecutablePublic,
+                                                                                               exeScope = ExecutableScopeUnknown,
                                                                                                modulePath = ""}},
                                                     condBranchIfTrue = CondNode
                                                                          {condTreeComponents = [CondBranch
@@ -222,7 +222,7 @@ GenericPackageDescription
                                                                                                                                                                                   AnyVersion],
                                                                                                                                                           virtualModules = []},
                                                                                                                                            exeName = `UnqualComponentName "shake"`,
-                                                                                                                                           exeScope = ExecutablePublic,
+                                                                                                                                           exeScope = ExecutableScopeUnknown,
                                                                                                                                            modulePath = ""}}}],
                                                                           condTreeConstraints = [],
                                                                           condTreeData = Executable
@@ -269,7 +269,7 @@ GenericPackageDescription
                                                                                                            targetBuildDepends = [],
                                                                                                            virtualModules = []},
                                                                                             exeName = `UnqualComponentName "shake"`,
-                                                                                            exeScope = ExecutablePublic,
+                                                                                            exeScope = ExecutableScopeUnknown,
                                                                                             modulePath = ""}}},
                                                  CondBranch
                                                    {condBranchCondition = `CNot (Var (OS Windows))`,
@@ -325,7 +325,7 @@ GenericPackageDescription
                                                                                                                                    AnyVersion],
                                                                                                            virtualModules = []},
                                                                                             exeName = `UnqualComponentName "shake"`,
-                                                                                            exeScope = ExecutablePublic,
+                                                                                            exeScope = ExecutableScopeUnknown,
                                                                                             modulePath = ""}}}],
                            condTreeConstraints = [Dependency
                                                     `PackageName "base"`
@@ -520,7 +520,7 @@ GenericPackageDescription
                                                                                     AnyVersion],
                                                             virtualModules = []},
                                              exeName = `UnqualComponentName "shake"`,
-                                             exeScope = ExecutablePublic,
+                                             exeScope = ExecutableScopeUnknown,
                                              modulePath = "Run.hs"}}],
    condForeignLibs = [],
    condLibrary = Just

--- a/Cabal/tests/ParserTests/regressions/shake.format
+++ b/Cabal/tests/ParserTests/regressions/shake.format
@@ -169,6 +169,7 @@ library
 
 executable shake
     main-is: Run.hs
+    scope: unknown
     hs-source-dirs: src
     other-modules:
         Development.Make.All
@@ -248,21 +249,27 @@ executable shake
         primitive -any
     
     if impl(ghc >=7.8)
+        scope: unknown
         ghc-options: -threaded "-with-rtsopts=-I0 -qg -qb"
     
     if flag(portable)
+        scope: unknown
         cpp-options: -DPORTABLE
         
         if impl(ghc <7.6)
+            scope: unknown
             build-depends:
                 old-time -any
     else
+        scope: unknown
         
         if !os(windows)
+            scope: unknown
             build-depends:
                 unix >=2.5.1
     
     if !os(windows)
+        scope: unknown
         build-depends:
             unix -any
 

--- a/Cabal/tests/ParserTests/regressions/wl-pprint-indef.expr
+++ b/Cabal/tests/ParserTests/regressions/wl-pprint-indef.expr
@@ -66,7 +66,7 @@ GenericPackageDescription
                                                                                     AnyVersion],
                                                             virtualModules = []},
                                              exeName = `UnqualComponentName "wl-pprint-string-example"`,
-                                             exeScope = ExecutablePublic,
+                                             exeScope = ExecutableScopeUnknown,
                                              modulePath = "Main.hs"}}],
    condForeignLibs = [],
    condLibrary = Just

--- a/Cabal/tests/ParserTests/regressions/wl-pprint-indef.format
+++ b/Cabal/tests/ParserTests/regressions/wl-pprint-indef.format
@@ -29,6 +29,7 @@ library
 
 executable wl-pprint-string-example
     main-is: Main.hs
+    scope: unknown
     hs-source-dirs: example-string
     other-modules:
         StringImpl


### PR DESCRIPTION
This reverts commit 442dcf88d809bcfa9c68818947683f02e7cde47d.

[cabal-helper](https://github.com/DanielG/cabal-helper/blob/master/cabal-helper.cabal#L34) declares a lower cabal spec version than would ordinarily be required for support for the `scope` field on purpose and then handles the fallout in [`Setup.hs`](https://github.com/DanielG/cabal-helper/blob/master/Setup.hs#L34) in order to support much older versions of Cabal.

The aforementioned commit broke the behavior of this package by introducing an `availableSince` declaration which forces the value of the `exeScope` field to `ExecutablePublic` in case the spec version is below the required version.

Now my initial instinct was to just remove the `availableSince` and leave it at that but since the associated `checkSpecVersion` was removed in favor of `availableSince` this won't do.

Hence I'm here to ask how this situation should be handled? Would it be acceptable to just add back the `checkSpecVersion` for the scope field and remove the `availableSince` declaration or is there some other way to fix this I'm not seeing?