### PR TITLE
Disallow transformers-0.4.0.0

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -365,10 +365,12 @@ library
 
   -- Parsec parser-related modules
   build-depends:
-    transformers >= 0.3      && < 0.6,
-    mtl          >= 2.1      && < 2.3,
-    text         >= 1.2.3.0  && < 1.3,
-    parsec       >= 3.1.13.0 && < 3.2
+    -- transformers-0.4.0.0 doesn't have record syntax e.g. for Identity
+    -- See also https://github.com/ekmett/transformers-compat/issues/35
+    transformers (>= 0.3      && < 0.4) || (>=0.4.1.0 && <0.6),
+    mtl           >= 2.1      && < 2.3,
+    text          >= 1.2.3.0  && < 1.3,
+    parsec        >= 3.1.13.0 && < 3.2
   exposed-modules:
     Distribution.Compat.Parsing
     Distribution.Compat.CharParsing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
   - cabal --version
   - cabal update
   # Install parsec, text and mtl, also alex and happy
-  - echo "" | appveyor-retry cabal install parsec-3.1.11 text-1.2.2.2 mtl-2.2.1 alex-3.1.7 happy-1.19.5
+  - echo "" | appveyor-retry cabal install parsec-3.1.13.0 text-1.2.3.0 mtl-2.2.2 alex-3.2.4 happy-1.19.9
 
 build_script:
   - cd Cabal


### PR DESCRIPTION
I'm tempted to make revisions to Cabal-2.2.0.0 and Cabal-2.2.0.1 also (at least the D.C.Newtype module breaks). OTOH `transformers-0.4.0.0` is deprecated, so I have to adjust my tooling anyway (https://github.com/phadej/trustee/issues/4)