### PR TITLE
travis: Move the 8.4.1 builders to 8.4.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,20 +55,20 @@ matrix:
    - env: GHCVER=8.2.2 SCRIPT=script USE_GOLD=YES
      os: linux
      sudo: required
-   - env: GHCVER=8.4.1 SCRIPT=script USE_GOLD=YES DEPLOY_DOCS=YES
+   - env: GHCVER=8.4.2 SCRIPT=script USE_GOLD=YES DEPLOY_DOCS=YES
      os: linux
      sudo: required
 
-   - env: GHCVER=8.4.1 SCRIPT=solver-debug-flags USE_GOLD=YES
+   - env: GHCVER=8.4.2 SCRIPT=solver-debug-flags USE_GOLD=YES
      sudo: required
      os: linux
-   - env: GHCVER=8.4.1 SCRIPT=script DEBUG_EXPENSIVE_ASSERTIONS=YES TAGSUFFIX="-fdebug-expensive-assertions" USE_GOLD=YES
+   - env: GHCVER=8.4.2 SCRIPT=script DEBUG_EXPENSIVE_ASSERTIONS=YES TAGSUFFIX="-fdebug-expensive-assertions" USE_GOLD=YES
      os: linux
      sudo: required
    - env: GHCVER=8.0.2 SCRIPT=bootstrap USE_GOLD=YES
      sudo: required
      os: linux
-   - env: GHCVER=8.4.1 SCRIPT=bootstrap USE_GOLD=YES
+   - env: GHCVER=8.4.2 SCRIPT=bootstrap USE_GOLD=YES
      sudo: required
      os: linux
 


### PR DESCRIPTION
This ought to fix the build matrix. I believe the issue is GHC trac
5129, where evaluate is being miscompiled: in cabal-testsuite's
Test.Cabal.Server, in the function readUntilEnd, the 'read' function
is protected by an 'if' to ensure that it doesn't result in the
dreaded 'no parse'. However, some sophisticated putStrLn
debugging has revealed that it is being called in *both* branches, not
just the safe one; this is the worst sort of heisenbug because it
vanished when I put a putStrLn before the evaluate!

Since the evaluate function is fixed in 8.4.2 and bumping to 8.4.2
has a patch for trac 5129, this is as fixed as it can get.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested locally, found it failed on 8.4.1 and succeeded on 8.4.2.