### PR TITLE
Applying flag normalisation to local packages.

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -3,6 +3,10 @@
     `new-sdist`, since they violate key invariants of the new-build
     ecosystem. Use `autogen-modules` and `build-tool-depends` instead.
     ([#5389](https://github.com/haskell/cabal/pull/5389)).
+  * Added `--repl-options` flag to `Setup repl` used to pass flags to the
+    underlying repl without affecting the `LocalBuildInfo`
+    ([#4247](https://github.com/haskell/cabal/issues/4247),
+    [#5287](https://github.com/haskell/cabal/pull/5287))
   * Added `BlockArguments` to `KnownExtension`
     ([#5101](https://github.com/haskell/cabal/issues/5101)).
   * Added `NumericUnderscores` to `KnownExtension`

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -61,6 +61,7 @@ module Distribution.Simple.Setup (
   programDbOptions, programDbPaths',
   programConfigurationOptions, programConfigurationPaths',
   programFlagsDescription,
+  replOptions,
   splitArgs,
 
   defaultDistPref, optionDistPref,
@@ -1708,7 +1709,8 @@ data ReplFlags = ReplFlags {
     replProgramArgs :: [(String, [String])],
     replDistPref    :: Flag FilePath,
     replVerbosity   :: Flag Verbosity,
-    replReload      :: Flag Bool
+    replReload      :: Flag Bool,
+    replReplOptions :: [String]
   }
   deriving (Show, Generic)
 
@@ -1718,7 +1720,8 @@ defaultReplFlags  = ReplFlags {
     replProgramArgs = [],
     replDistPref    = NoFlag,
     replVerbosity   = Flag normal,
-    replReload      = Flag False
+    replReload      = Flag False,
+    replReplOptions = []
   }
 
 instance Monoid ReplFlags where
@@ -1794,7 +1797,14 @@ replCommand progDb = CommandUI
               trueArg
             ]
           _ -> []
+     ++ map liftReplOption (replOptions showOrParseArgs)
   }
+  where
+    liftReplOption = liftOption replReplOptions (\v flags -> flags { replReplOptions = v })
+
+replOptions :: ShowOrParseArgs -> [OptionField [String]]
+replOptions _ = [ option [] ["repl-options"] "use this option for the repl" id
+              const (reqArg "FLAG" (succeedReadE (:[])) id) ]
 
 -- ------------------------------------------------------------
 -- * Test flags

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -1761,7 +1761,7 @@ replCommand progDb = CommandUI
       ++ "    The first component in the package\n"
       ++ "  " ++ pname ++ " repl foo       "
       ++ "    A named component (i.e. lib, exe, test suite)\n"
-      ++ "  " ++ pname ++ " repl --ghc-options=\"-lstdc++\""
+      ++ "  " ++ pname ++ " repl --repl-options=\"-lstdc++\""
       ++ "  Specifying flags for interpreter\n"
 --TODO: re-enable once we have support for module/file targets
 --        ++ "  " ++ pname ++ " repl Foo.Bar   "

--- a/Cabal/Distribution/Types/GenericPackageDescription.hs
+++ b/Cabal/Distribution/Types/GenericPackageDescription.hs
@@ -192,7 +192,7 @@ instance Text FlagName where
 --
 newtype FlagAssignment
   = FlagAssignment { getFlagAssignment :: Map.Map FlagName (Int, Bool) }
-  deriving (Binary, NFData)
+  deriving (Binary, Generic, NFData)
 
 instance Eq FlagAssignment where
   (==) (FlagAssignment m1) (FlagAssignment m2)

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -362,15 +362,15 @@ cabal new-repl
 --------------
 
 ``cabal new-repl TARGET`` loads all of the modules of the target into
-GHCi as interpreted bytecode. In addition to the ``cabal new-build``'s flags,
-it takes an additional ``--repl-options`` flags.
+GHCi as interpreted bytecode. In addition to ``cabal new-build``'s flags,
+it takes an additional ``--repl-options`` flag.
 
 To avoid ``ghci`` specific flags from triggering unneeded global rebuilds these
-flags are now stripped from ``ghc-options``. As a result ``--ghc-options`` will
-no longer (reliably) work to pass flags to ``ghci`` (or other repls). Instead,
-you should use the new ``--repl-options`` flag to specify these options to the
-invoked repl. (This flags also works on ``cabal repl`` and ``Setup repl`` on
-sufficiently new versions)
+flags are now stripped from the internal configuration. As a result
+``--ghc-options`` will no longer (reliably) work to pass flags to ``ghci`` (or
+other repls). Instead, you should use the new ``--repl-options`` flag to
+specify these options to the invoked repl. (This flag also works on ``cabal
+repl`` and ``Setup repl`` on sufficiently new versions of Cabal.)
 
 Currently, it is not supported to pass multiple targets to ``new-repl``
 (``new-repl`` will just successively open a separate GHCi session for

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -362,8 +362,15 @@ cabal new-repl
 --------------
 
 ``cabal new-repl TARGET`` loads all of the modules of the target into
-GHCi as interpreted bytecode. It takes the same flags as
-``cabal new-build``.
+GHCi as interpreted bytecode. In addition to the ``cabal new-build``'s flags,
+it takes an additional ``--repl-options`` flags.
+
+To avoid ``ghci`` specific flags from triggering unneeded global rebuilds these
+flags are now stripped from ``ghc-options``. As a result ``--ghc-options`` will
+no longer (reliably) work to pass flags to ``ghci`` (or other repls). Instead,
+you should use the new ``--repl-options`` flag to specify these options to the
+invoked repl. (This flags also works on ``cabal repl`` and ``Setup repl`` on
+sufficiently new versions)
 
 Currently, it is not supported to pass multiple targets to ``new-repl``
 (``new-repl`` will just successively open a separate GHCi session for

--- a/cabal-install/Distribution/Client/PackageHash.hs
+++ b/cabal-install/Distribution/Client/PackageHash.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE RecordWildCards, NamedFieldPuns, GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
 
 -- | Functions to calculate nix-style hashes for package ids.
 --
@@ -315,7 +315,7 @@ renderPackageHashInputs PackageHashInputs{
 -- package ids.
 
 newtype HashValue = HashValue BS.ByteString
-  deriving (Eq, Show, Typeable)
+  deriving (Eq, Generic, Show, Typeable)
 
 instance Binary HashValue where
   put (HashValue digest) = put digest

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -3559,10 +3559,7 @@ packageHashInputs _ pkg =
 packageHashConfigInputs :: ElaboratedSharedConfig
                         -> ElaboratedConfiguredPackage
                         -> PackageHashConfigInputs
-packageHashConfigInputs
-    ElaboratedSharedConfig{..}
-    ElaboratedConfiguredPackage{..} =
-
+packageHashConfigInputs shared@ElaboratedSharedConfig{..} pkg =
     PackageHashConfigInputs {
       pkgHashCompilerId          = compilerId pkgConfigCompiler,
       pkgHashPlatform            = pkgConfigPlatform,
@@ -3583,7 +3580,7 @@ packageHashConfigInputs
       pkgHashStripLibs           = elabStripLibs,
       pkgHashStripExes           = elabStripExes,
       pkgHashDebugInfo           = elabDebugInfo,
-      pkgHashProgramArgs         = Map.mapWithKey lookupFilter elabProgramArgs,
+      pkgHashProgramArgs         = elabProgramArgs,
       pkgHashExtraLibDirs        = elabExtraLibDirs,
       pkgHashExtraFrameworkDirs  = elabExtraFrameworkDirs,
       pkgHashExtraIncludeDirs    = elabExtraIncludeDirs,
@@ -3591,16 +3588,7 @@ packageHashConfigInputs
       pkgHashProgSuffix          = elabProgSuffix
     }
   where
-    knownProgramDb = addKnownPrograms builtinPrograms pkgConfigCompilerProgs
-
-    lookupFilter :: String -> [String] -> [String]
-    lookupFilter n flags = case lookupKnownProgram n knownProgramDb of
-        Just p -> programNormaliseArgs p (getVersion p) elabPkgDescription flags
-        Nothing -> flags
-
-    getVersion :: Program -> Maybe Version
-    getVersion p = lookupProgram p knownProgramDb >>= programVersion
-
+    ElaboratedConfiguredPackage{..} = normaliseConfiguredPackage shared pkg
 
 -- | Given the 'InstalledPackageIndex' for a nix-style package store, and an
 -- 'ElaboratedInstallPlan', replace configured source packages by installed

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1237,7 +1237,8 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
       ElaboratedSharedConfig {
         pkgConfigPlatform      = platform,
         pkgConfigCompiler      = compiler,
-        pkgConfigCompilerProgs = compilerprogdb
+        pkgConfigCompilerProgs = compilerprogdb,
+        pkgConfigReplOptions   = []
       }
 
     preexistingInstantiatedPkgs =
@@ -3369,13 +3370,14 @@ setupHsReplFlags :: ElaboratedConfiguredPackage
                  -> Verbosity
                  -> FilePath
                  -> Cabal.ReplFlags
-setupHsReplFlags _ _ verbosity builddir =
+setupHsReplFlags _ sharedConfig verbosity builddir =
     Cabal.ReplFlags {
       replProgramPaths = mempty, --unused, set at configure time
       replProgramArgs  = mempty, --unused, set at configure time
       replVerbosity    = toFlag verbosity,
       replDistPref     = toFlag builddir,
-      replReload       = mempty  --only used as callback from repl
+      replReload       = mempty, --only used as callback from repl
+      replReplOptions  = pkgConfigReplOptions sharedConfig       --runtime override for repl flags
     }
 
 

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -317,15 +317,19 @@ normaliseConfiguredPackage :: ElaboratedSharedConfig
                            -> ElaboratedConfiguredPackage
                            -> ElaboratedConfiguredPackage
 normaliseConfiguredPackage ElaboratedSharedConfig{pkgConfigCompilerProgs} pkg =
-    pkg { elabProgramArgs = Map.mapWithKey lookupFilter (elabProgramArgs pkg) }
+    pkg { elabProgramArgs = Map.mapMaybeWithKey lookupFilter (elabProgramArgs pkg) }
   where
     knownProgramDb = addKnownPrograms builtinPrograms pkgConfigCompilerProgs
 
     pkgDesc :: PackageDescription
     pkgDesc = elabPkgDescription pkg
 
-    lookupFilter :: String -> [String] -> [String]
-    lookupFilter n args = case lookupKnownProgram n knownProgramDb of
+    removeEmpty :: [String] -> Maybe [String]
+    removeEmpty [] = Nothing
+    removeEmpty xs = Just xs
+
+    lookupFilter :: String -> [String] -> Maybe [String]
+    lookupFilter n args = removeEmpty $ case lookupKnownProgram n knownProgramDb of
         Just p -> programNormaliseArgs p (getVersion p) pkgDesc args
         Nothing -> args
 

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -148,7 +148,8 @@ data ElaboratedSharedConfig
        -- | The programs that the compiler configured (e.g. for GHC, the progs
        -- ghc & ghc-pkg). Once constructed, only the 'configuredPrograms' are
        -- used.
-       pkgConfigCompilerProgs :: ProgramDb
+       pkgConfigCompilerProgs :: ProgramDb,
+       pkgConfigReplOptions :: [String]
      }
   deriving (Show, Generic, Typeable)
   --TODO: [code cleanup] no Eq instance

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Types used while planning how to build everything in a project.
@@ -11,6 +12,7 @@ module Distribution.Client.ProjectPlanning.Types (
 
     -- * Elaborated install plan types
     ElaboratedInstallPlan,
+    normaliseConfiguredPackage,
     ElaboratedConfiguredPackage(..),
 
     elabDistDirParams,
@@ -83,7 +85,7 @@ import           Distribution.InstalledPackageInfo (InstalledPackageInfo)
 import           Distribution.Simple.Compiler
 import           Distribution.Simple.Build.PathsModule (pkgPathEnvVar)
 import qualified Distribution.Simple.BuildTarget as Cabal
-import           Distribution.Simple.Program.Db
+import           Distribution.Simple.Program
 import           Distribution.ModuleName (ModuleName)
 import           Distribution.Simple.LocalBuildInfo (ComponentName(..))
 import qualified Distribution.Simple.InstallDirs as InstallDirs
@@ -98,6 +100,7 @@ import           Distribution.Compat.Graph (IsNode(..))
 import           Distribution.Simple.Utils (ordNub)
 
 import           Data.Map (Map)
+import qualified Data.Map as Map
 import           Data.Maybe (catMaybes)
 import           Data.Set (Set)
 import qualified Data.ByteString.Lazy as LBS
@@ -309,6 +312,25 @@ data ElaboratedConfiguredPackage
        elabPkgOrComp :: ElaboratedPackageOrComponent
    }
   deriving (Eq, Show, Generic, Typeable)
+
+normaliseConfiguredPackage :: ElaboratedSharedConfig
+                           -> ElaboratedConfiguredPackage
+                           -> ElaboratedConfiguredPackage
+normaliseConfiguredPackage ElaboratedSharedConfig{pkgConfigCompilerProgs} pkg =
+    pkg { elabProgramArgs = Map.mapWithKey lookupFilter (elabProgramArgs pkg) }
+  where
+    knownProgramDb = addKnownPrograms builtinPrograms pkgConfigCompilerProgs
+
+    pkgDesc :: PackageDescription
+    pkgDesc = elabPkgDescription pkg
+
+    lookupFilter :: String -> [String] -> [String]
+    lookupFilter n args = case lookupKnownProgram n knownProgramDb of
+        Just p -> programNormaliseArgs p (getVersion p) pkgDesc args
+        Nothing -> args
+
+    getVersion :: Program -> Maybe Version
+    getVersion p = lookupProgram p knownProgramDb >>= programVersion
 
 -- | The package/component contains/is a library and so must be registered
 elabRequiresRegistration :: ElaboratedConfiguredPackage -> Bool

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -3,6 +3,10 @@
 2.4.0.0 (current development version)
 	* Add 'new-sdist' command (#5389). Creates stable archives based on
 	  cabal projects in '.zip' and '.tar.gz' formats.
+	* Add '--repl-options' flag to 'cabal repl' and 'cabal new-repl'
+	commands. Passes it's arguments to the invoked repl, bypassing the
+	new-build's cached configurations. This assures they don't trigger
+	useless rebuilds and are always applied within the repl. (#4247,#5287)
 	* Add 'v1-' prefixes for the commands that will be replaced in the 
 	new-build universe, in preparation for it becoming the default. 
 	(#5358)

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -4,7 +4,7 @@
 	* Add 'new-sdist' command (#5389). Creates stable archives based on
 	  cabal projects in '.zip' and '.tar.gz' formats.
 	* Add '--repl-options' flag to 'cabal repl' and 'cabal new-repl'
-	commands. Passes it's arguments to the invoked repl, bypassing the
+	commands. Passes its arguments to the invoked repl, bypassing the
 	new-build's cached configurations. This assures they don't trigger
 	useless rebuilds and are always applied within the repl. (#4247,#5287)
 	* Add 'v1-' prefixes for the commands that will be replaced in the 


### PR DESCRIPTION
Continuing efforts from #4247, apply similar recompilation avoidance to local packages as well. Need to look into how this interacts with new-haddock.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
