### PR TITLE
more liberal white space parsing in the the mixin field

### DIFF
--- a/Cabal/Distribution/CabalSpecVersion.hs
+++ b/Cabal/Distribution/CabalSpecVersion.hs
@@ -16,10 +16,11 @@ data CabalSpecVersion
     | CabalSpecV1_24
     | CabalSpecV2_0
     | CabalSpecV2_2
+    | CabalSpecV3_0
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable, Data, Generic)
 
 cabalSpecLatest :: CabalSpecVersion
-cabalSpecLatest = CabalSpecV2_2
+cabalSpecLatest = CabalSpecV3_0
 
 cabalSpecFeatures :: CabalSpecVersion -> Set.Set CabalFeature
 cabalSpecFeatures CabalSpecOld   = Set.empty
@@ -30,13 +31,15 @@ cabalSpecFeatures CabalSpecV2_2  = Set.fromList
     [ Elif
     , CommonStanzas
     ]
+cabalSpecFeatures CabalSpecV3_0 = cabalSpecFeatures CabalSpecV2_2
 
 cabalSpecSupports :: CabalSpecVersion -> [Int] -> Bool
 cabalSpecSupports CabalSpecOld v   = v < [1,21]
 cabalSpecSupports CabalSpecV1_22 v = v < [1,23]
 cabalSpecSupports CabalSpecV1_24 v = v < [1,25]
 cabalSpecSupports CabalSpecV2_0 v  = v < [2,1]
-cabalSpecSupports CabalSpecV2_2 _  = True
+cabalSpecSupports CabalSpecV2_2 v  = v < [2,3]
+cabalSpecSupports CabalSpecV3_0 _  = True
 
 specHasCommonStanzas :: CabalSpecVersion -> HasCommonStanzas
 specHasCommonStanzas CabalSpecV2_2 = HasCommonStanzas

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -125,7 +125,7 @@ parseGenericPackageDescription bs = do
     setCabalSpecVersion ver
     -- if we get too new version, fail right away
     case ver of
-        Just v | v > mkVersion [2,2] -> parseFailure zeroPos
+        Just v | v > mkVersion [3,0] -> parseFailure zeroPos
             "Unsupported cabal-version. See https://github.com/haskell/cabal/issues/4899."
         _ -> pure ()
 


### PR DESCRIPTION
This is not yet complete. It is sent for review.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

I will add the test cases when I get a go ahead on the commits so far.
