### PR TITLE
check: correct an error message to use the real field name.

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -1056,12 +1056,12 @@ checkPaths pkg =
       _            -> False
     -- paths that must be relative
     relPaths =
-         [ (path, "extra-src-files") | path <- extraSrcFiles pkg ]
-      ++ [ (path, "extra-tmp-files") | path <- extraTmpFiles pkg ]
-      ++ [ (path, "extra-doc-files") | path <- extraDocFiles pkg ]
-      ++ [ (path, "data-files")      | path <- dataFiles     pkg ]
-      ++ [ (path, "data-dir")        | path <- [dataDir      pkg]]
-      ++ [ (path, "license-file")    | path <- licenseFiles  pkg ]
+         [ (path, "extra-source-files") | path <- extraSrcFiles pkg ]
+      ++ [ (path, "extra-tmp-files")    | path <- extraTmpFiles pkg ]
+      ++ [ (path, "extra-doc-files")    | path <- extraDocFiles pkg ]
+      ++ [ (path, "data-files")         | path <- dataFiles     pkg ]
+      ++ [ (path, "data-dir")           | path <- [dataDir      pkg]]
+      ++ [ (path, "license-file")       | path <- licenseFiles  pkg ]
       ++ concat
          [    [ (path, "asm-sources")      | path <- asmSources      bi ]
            ++ [ (path, "cmm-sources")      | path <- cmmSources      bi ]


### PR DESCRIPTION
It's 'extra-source-files', not 'extra-src-files'.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
