### PR TITLE
Avoid leaving leftover files in the source tree in tests.

### DIFF
--- a/cabal-testsuite/PackageTests/NewBuild/CmdExec/GhcInvocation/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdExec/GhcInvocation/cabal.test.hs
@@ -5,7 +5,10 @@ main = cabalTest $ do
     cabal "new-build" ["inplace-dep"]
     env <- getTestEnv
     liftIO $ removeEnvFiles $ testSourceDir env -- we don't want existing env files to interfere
-    cabal "new-exec" ["ghc", "Main.hs"]
+    -- Drop the compiled executable into the temporary directory, to avoid cluttering the tree. If compilation succeeds, we've tested what we need to!
+    tmpdir <- fmap testTmpDir getTestEnv
+    let dest = tmpdir </> "a.out"
+    cabal "new-exec" ["ghc", "--", "Main.hs", "-o", dest]
     -- TODO external (store) deps, once new-install is working
 
 removeEnvFiles :: FilePath -> IO ()

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -45,6 +45,7 @@ library
     filepath,
     regex-compat-tdfa,
     regex-tdfa,
+    temporary,
     text,
     Cabal >= 2.3
   ghc-options: -Wall -fwarn-tabs


### PR DESCRIPTION
This test was leaving a 'Main' executable behind. Since we don't ever
actually run it, just check that the compilation succeeds, we can send
it straight to /dev/null.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
