### PR TITLE
Support installing headers in foreign library target.

### DIFF
--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -170,7 +170,7 @@ copyComponent verbosity pkg_descr lbi (CLib lib) clbi copydest = do
 
     -- install include files for all compilers - they may be needed to compile
     -- haskell files (using the CPP extension)
-    installIncludeFiles verbosity lib lbi buildPref incPref
+    installIncludeFiles verbosity (libBuildInfo lib) lbi buildPref incPref
 
     case compilerFlavor (compiler lbi) of
       GHC   -> GHC.installLib   verbosity lbi libPref dynlibPref buildPref pkg_descr lib clbi
@@ -185,11 +185,13 @@ copyComponent verbosity pkg_descr lbi (CLib lib) clbi copydest = do
 
 copyComponent verbosity pkg_descr lbi (CFLib flib) clbi copydest = do
     let InstallDirs{
-            flibdir = flibPref
+            flibdir = flibPref,
+            includedir = incPref
             } = absoluteComponentInstallDirs pkg_descr lbi (componentUnitId clbi) copydest
         buildPref = componentBuildDir lbi clbi
 
     noticeNoWrap verbosity ("Installing foreign library " ++ unUnqualComponentName (foreignLibName flib) ++ " in " ++ flibPref)
+    installIncludeFiles verbosity (foreignLibBuildInfo flib) lbi buildPref incPref
 
     case compilerFlavor (compiler lbi) of
       GHC   -> GHC.installFLib   verbosity lbi flibPref buildPref pkg_descr flib
@@ -244,10 +246,9 @@ installDataFiles verbosity pkg_descr destDataDir =
 
 -- | Install the files listed in install-includes for a library
 --
-installIncludeFiles :: Verbosity -> Library -> LocalBuildInfo -> FilePath -> FilePath -> IO ()
-installIncludeFiles verbosity lib lbi buildPref destIncludeDir = do
+installIncludeFiles :: Verbosity -> BuildInfo -> LocalBuildInfo -> FilePath -> FilePath -> IO ()
+installIncludeFiles verbosity libBi lbi buildPref destIncludeDir = do
     let relincdirs = "." : filter isRelative (includeDirs libBi)
-        libBi = libBuildInfo lib
         incdirs = [ baseDir lbi </> dir | dir <- relincdirs ]
                   ++ [ buildPref </> dir | dir <- relincdirs ]
     incs <- traverse (findInc incdirs) (installIncludes libBi)

--- a/cabal-testsuite/PackageTests/ForeignLibs/my-foreign-lib.cabal
+++ b/cabal-testsuite/PackageTests/ForeignLibs/my-foreign-lib.cabal
@@ -38,3 +38,14 @@ foreign-library versionedlib
   hs-source-dirs:      src
   c-sources:           csrc/MyForeignLibWrapper.c
   default-language:    Haskell2010
+
+foreign-library includeslib
+  type:                native-shared
+  if os(windows)
+     options: standalone
+  other-modules:       MyForeignLib.Export
+  install-includes:    Export_stub.h
+  include-dirs:        includeslib-tmp/MyForeignLib
+  build-depends:       base, my-foreign-lib
+  hs-source-dirs:      src
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/ForeignLibs/src/MyForeignLib/Export.hs
+++ b/cabal-testsuite/PackageTests/ForeignLibs/src/MyForeignLib/Export.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module MyForeignLib.Export
+  ( foo ) where
+
+foo :: Int -> Int
+foo x = x + 1
+
+foreign export ccall foo :: Int -> Int


### PR DESCRIPTION
Do not ignore `install-includes stanza in the foreign-library.
And install headers.