### PR TITLE
Print all test output when running solver-quickcheck on AppVeyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,5 +52,5 @@ build_script:
   - cd ..\cabal-install
   - cabal test unit-tests --show-details=streaming --test-option="--pattern=! /FileMonitor/" --test-option=--hide-successes
   - cabal test integration-tests2 --show-details=streaming --test-option=--hide-successes
-  - cabal test solver-quickcheck --show-details=streaming --test-option=--hide-successes --test-option=--quickcheck-tests=1000
+  - cabal test solver-quickcheck --show-details=streaming --test-option=--quickcheck-tests=1000
   - cabal test memory-usage-tests --show-details=streaming


### PR DESCRIPTION
Previously, --hide-successes caused solver-quickcheck to only print the seed
that was added in 4d83212fbec3f990f3d90801077da05e5133bd99.  This commit removes
--hide-successes so that the test suite prints the test names with the seeds.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
