### PR TITLE
globbing: improve test coverage.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -510,6 +510,7 @@ test-suite unit-tests
     tasty-hunit,
     tasty-quickcheck,
     tagged,
+    temporary,
     text,
     pretty,
     QuickCheck >= 2.11.3 && < 2.12,


### PR DESCRIPTION
For efficiency reasons, matchDirFileGlob isn't a simple call to
getDirectoryContentsRecursive and then a filter with
fileGlobMatches. So test both that naive approach and the actual
approach to make sure they are both correct.

I only realised this was a problem right after #5284 was merged!

Since this is tests-only, I'll merge once Travis and AppVeyor are green.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
