### PR TITLE
Include a prof subdirectory in dist-dir layout

### DIFF
--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -47,7 +47,8 @@ data DistDirParams = DistDirParams {
     distParamComponentName  :: Maybe ComponentName,
     distParamCompilerId     :: CompilerId,
     distParamPlatform       :: Platform,
-    distParamOptimization   :: OptimisationLevel
+    distParamOptimization   :: OptimisationLevel,
+    distParamProfiling      :: Bool
     -- TODO (see #3343):
     --  Flag assignments
     --  Optimization
@@ -197,6 +198,9 @@ defaultDistDirLayout projectRoot mdistDirectory =
             NoOptimisation -> "noopt"
             NormalOptimisation -> ""
             MaximumOptimisation -> "opt") </>
+        (if distParamProfiling params
+           then "prof"
+           else "") </>
         (let uid_str = display (distParamUnitId params)
          in if uid_str == display (distParamComponentId params)
                 then ""

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -434,7 +434,8 @@ elabDistDirParams shared elab = DistDirParams {
             ElabPackage _ -> Nothing,
         distParamCompilerId = compilerId (pkgConfigCompiler shared),
         distParamPlatform = pkgConfigPlatform shared,
-        distParamOptimization = elabOptimization elab
+        distParamOptimization = elabOptimization elab,
+        distParamProfiling = elabProfLib elab || elabProfExe elab
     }
 
 -- | The full set of dependencies which dictate what order we


### PR DESCRIPTION
Switch between profiling and non-profiling builds is a fairly common
usecase so supporting this without forcing a recompile is pretty
useful.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

I tested this both on a very simple project as well as a large project with a lot of vendored deps, where this makes a huge difference.

@hvr mentioned that eventually it might be nice to split prof/non-prof into separate units but that this is a useful low-hanging fruit in the meantime.
