### PR TITLE
GHCJS on GHC 8.2+ supports -Wmissing-home-modules

### DIFF
--- a/Cabal/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/Distribution/Simple/GHC/ImplInfo.hs
@@ -87,7 +87,7 @@ ghcjsVersionImplInfo _ghcjsver ghcver = GhcImplInfo
   , flagDebugInfo        = False
   , supportsDebugLevels  = ghcv >= [8,0]
   , supportsPkgEnvFiles  = ghcv >= [8,0,2] --TODO: check this works in ghcjs
-  , flagWarnMissingHomeModules = False
+  , flagWarnMissingHomeModules = ghcv >= [8,2]
   }
   where
     ghcv = versionNumbers ghcver


### PR DESCRIPTION

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

If the underlying GHC version is 8.2 or higher, GHCJS supports `-Wmissing-home-modules`. Cabal not knowing this results in some incorrect warnings: ghcjs/ghcjs#658