### PR TITLE
Dedupe more includeDirs and extraLibDirs

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -47,7 +47,8 @@
     do. This may lead to files unexpectedly being included by `sdist`;
     please audit your package descriptions if you rely on this
     behaviour to keep sensitive data out of distributed packages.
-
+  * Cabal now deduplicates more `-I` and `-L` and flags to avoid `E2BIG`
+    ([#5356](https://github.com/haskell/cabal/issues/5356)).
 ----
 
 ## 2.2.0.1 (current 2.2 development version)

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -1712,12 +1712,12 @@ checkForeignDeps pkg lbi verbosity =
                      -- should NOT be glomming everything together.)
                      ++ [ "-I" ++ buildDir lbi </> "autogen" ]
                      -- `configure' may generate headers in the build directory
-                     ++ [ "-I" ++ buildDir lbi </> dir | dir <- collectField PD.includeDirs
+                     ++ [ "-I" ++ buildDir lbi </> dir | dir <- ordNub (collectField PD.includeDirs)
                                                        , not (isAbsolute dir)]
                      -- we might also reference headers from the packages directory.
-                     ++ [ "-I" ++ baseDir lbi </> dir | dir <- collectField PD.includeDirs
+                     ++ [ "-I" ++ baseDir lbi </> dir | dir <- ordNub (collectField PD.includeDirs)
                                                       , not (isAbsolute dir)]
-                     ++ [ "-I" ++ dir | dir <- collectField PD.includeDirs
+                     ++ [ "-I" ++ dir | dir <- ordNub (collectField PD.includeDirs)
                                       , isAbsolute dir]
                      ++ ["-I" ++ baseDir lbi]
                      ++ collectField PD.cppOptions
@@ -1739,7 +1739,7 @@ checkForeignDeps pkg lbi verbosity =
                         | dep <- deps
                         , opt <- Installed.ccOptions dep ]
 
-        commonLdArgs  = [ "-L" ++ dir | dir <- collectField PD.extraLibDirs ]
+        commonLdArgs  = [ "-L" ++ dir | dir <- ordNub (collectField PD.extraLibDirs) ]
                      ++ collectField PD.ldOptions
                      ++ [ "-L" ++ dir
                         | dir <- ordNub [ dir


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/41340.

Also see #3974 and #4105.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary (not necessary).
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots (it is not)

Haven't tested it yet, will do that tomorrow.

### TODO

* [x] test that it works for @nh2's use case
* ~[ ] investigate whether it's actually legitimate that cabal tries to combine the flags from these different sections into one (`ordNub`ed or not) -- maybe there might be flags across the different sections that are mutually exculsive~ filed https://github.com/haskell/cabal/issues/5360 instead