### PR TITLE
Introduce checks for upper dependencies in setup.

### DIFF
--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -659,9 +659,9 @@ db7 :: ExampleDb
 db7 = [
     Right $ exAv "A" 1 []
   , Right $ exAv "A" 2 []
-  , Right $ exAv "B" 1 []            `withSetupDeps` [ExAny "A"]
-  , Right $ exAv "C" 1 [ExAny "A"  ] `withSetupDeps` [ExAny "A"  ]
-  , Right $ exAv "D" 1 [ExFix "A" 1] `withSetupDeps` [ExAny "A"  ]
+  , Right $ exAv "B" 1 []            `withSetupDeps` [ExRange "A" 0 100 ]
+  , Right $ exAv "C" 1 [ExAny "A"  ] `withSetupDeps` [ExRange "A" 0 100 ]
+  , Right $ exAv "D" 1 [ExFix "A" 1] `withSetupDeps` [ExRange "A" 0 100 ]
   , Right $ exAv "E" 1 [ExAny "A"  ] `withSetupDeps` [ExFix "A" 1]
   , Right $ exAv "F" 1 [ExFix "A" 2] `withSetupDeps` [ExFix "A" 1]
   ]
@@ -856,11 +856,11 @@ db14 = [
 db15 :: ExampleDb
 db15 = [
     -- First example (real cycle, no solution)
-    Right $ exAv   "A" 1            []            `withSetupDeps` [ExAny "B"]
+    Right $ exAv   "A" 1            []            `withSetupDeps` [ExRange "B" 0 100]
   , Right $ exAv   "B" 1            [ExAny "A"]
     -- Second example (cycle can be broken by picking versions carefully)
   , Left  $ exInst "C" 1 "C-1-inst" []
-  , Right $ exAv   "C" 2            []            `withSetupDeps` [ExAny "D"]
+  , Right $ exAv   "C" 2            []            `withSetupDeps` [ExRange "D" 0 100]
   , Right $ exAv   "D" 1            [ExAny "C"  ]
   , Right $ exAv   "E" 1            [ExFix "C" 2]
   ]
@@ -880,7 +880,7 @@ issue4161 name =
     db :: ExampleDb
     db = [
         Right $ exAv "target" 1 [ExFix "time" 2]
-      , Right $ exAv "time"   2 []               `withSetupDeps` [ExAny "time"]
+      , Right $ exAv "time"   2 []               `withSetupDeps` [ExRange "time" 0 100]
       , Right $ exAv "time"   1 []
       ]
 

--- a/cabal-testsuite/PackageTests/CheckSetup/LICENSE
+++ b/cabal-testsuite/PackageTests/CheckSetup/LICENSE
@@ -1,0 +1,1 @@
+LICENSE

--- a/cabal-testsuite/PackageTests/CheckSetup/MyLibrary.hs
+++ b/cabal-testsuite/PackageTests/CheckSetup/MyLibrary.hs
@@ -1,0 +1,1 @@
+module MyLibrary () where

--- a/cabal-testsuite/PackageTests/CheckSetup/Setup.hs
+++ b/cabal-testsuite/PackageTests/CheckSetup/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/cabal-testsuite/PackageTests/CheckSetup/my.cabal
+++ b/cabal-testsuite/PackageTests/CheckSetup/my.cabal
@@ -1,0 +1,25 @@
+name: CheckSetup
+version: 0.1
+license: BSD3
+license-file: LICENSE
+author: Alexander Vershilov
+maintainer: Alexander Vershilov
+synopsis: Check setup
+category: PackageTests
+build-type: Custom
+cabal-version: 2.0
+
+description:
+    Check that Cabal recognizes problems with setup module.
+
+custom-setup
+  setup-depends:
+    base,
+    Cabal,
+    bytestring
+
+Library
+    default-language: Haskell2010
+    build-depends: base <5.0
+    exposed-modules:
+        MyLibrary

--- a/cabal-testsuite/PackageTests/CheckSetup/setup.test.hs
+++ b/cabal-testsuite/PackageTests/CheckSetup/setup.test.hs
@@ -1,0 +1,24 @@
+import Test.Cabal.Prelude
+
+-- Test that setup shows all the 'autogen-modules' warnings.
+main = cabalTest $ do
+
+        checkResult <- fails $ cabal_raw' ["check"]
+
+        -- Package check messages.
+        let libWarning=
+              "The dependency 'build-depends: 'bytestring' does not "
+              ++ "specify an upper bound on the version number."
+            libError1 =
+              "The dependency 'setup-depends: 'Cabal' does not specify "
+              ++ "an upper bound on the version number"
+            libError2 =
+              "The dependency 'setup-depends: 'base' does not specify "
+              ++ "an upper bound on the version number"
+
+        -- Asserts for the desired check messages after configure.
+        assertOutputContains libWarning checkResult
+        assertOutputContains libError1 checkResult
+        assertOutputContains libError2 checkResult
+
+        return ()


### PR DESCRIPTION
setup depends are now checked for having upper dependencies.
Upper bounds are mandatory for base and Cabal libraries, and
are optional (but emit warning) for other libraries.
Implicit dependencies are not being checked.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
