### PR TITLE
Try to make unbuildable error message more obvious

### DIFF
--- a/Cabal/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/Distribution/Backpack/ConfiguredComponent.hs
@@ -169,7 +169,7 @@ toConfiguredComponent pkg_descr this_cid dep_map component = do
                     value <- case Map.lookup cn =<< Map.lookup pn dep_map of
                         Nothing ->
                             dieProgress $
-                                text "Dependency on unbuildable" <+>
+                                text "Dependency on unbuildable (i.e. 'buildable: False')" <+>
                                 text (showComponentName cn) <+>
                                 text "from" <+> disp pn
                         Just v -> return v


### PR DESCRIPTION
@hsenag pointed out that "dependency on unbuildable library" isn't necessarily obviously related to `buildable: False`, and may be misinterpreted as a more general cause (like e.g. being unbuildable due to version constraints). This PR is a first suggestion to start the bikeshedding round...

----

Previously,

    Dependency on unbuildable library from darcs
    In the stanza 'test-suite darcs-test'
    In the inplace package 'darcs-2.11.0'

With this patch,

    Dependency on unbuildable (i.e. 'buildable: False') library from darcs
    In the stanza 'test-suite darcs-test'
    In the inplace package 'darcs-2.11.0'

