### PR TITLE
travis: Build hackage-tests with -O0 on 7.10.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -168,6 +168,12 @@ flag old-directory
   description:  Use directory < 1.2 and old-time
   default:      False
 
+flag less-memory
+  description:
+    Try to use less memory while building. This is primarily for Cabal's CI use.
+  default: False
+  manual: True
+
 library
   build-depends:
     array      >= 0.4     && < 0.6,
@@ -617,3 +623,6 @@ test-suite hackage-tests
   ghc-options: -Wall -rtsopts -threaded
   default-extensions: CPP
   default-language: Haskell2010
+
+  if flag(less-memory)
+    ghc-options: -O0

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -99,10 +99,22 @@ export CABAL_BUILDDIR="${CABAL_BDIR}"
 if [ "x$CABAL_INSTALL_ONLY" != "xYES" ] ; then
     # We're doing a full build and test of Cabal
 
+    # The 7.10 builder on Travis has been having trouble with OOMing
+    # while building hackage-tests. This sets -O0 to try and relieve
+    # that.
+    case $GHCVER in
+        7.10*)
+            CABAL_TEST_FLAGS='-fless-memory'
+            ;;
+        *)
+            CABAL_TEST_FLAGS=''
+            ;;
+    esac
+
     # NB: Best to do everything for a single package together as it's
     # more efficient (since new-build will uselessly try to rebuild
     # Cabal otherwise).
-    timed cabal new-build $jobs Cabal Cabal:unit-tests Cabal:check-tests Cabal:parser-tests Cabal:hackage-tests --enable-tests
+    timed cabal new-build $jobs Cabal Cabal:unit-tests Cabal:check-tests Cabal:parser-tests Cabal:hackage-tests --enable-tests $CABAL_TEST_FLAGS
 
     # Run haddock.
     if [ "$TRAVIS_OS_NAME" = "linux" ]; then


### PR DESCRIPTION
Building hackage-tests has been sporadically OOMing on the 7.10
builder only, so try building them with -O0 to see if that helps
matters.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
