### PR TITLE
Recognize `powerpc64le` as `PPC64`

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -47,6 +47,7 @@
     do. This may lead to files unexpectedly being included by `sdist`;
     please audit your package descriptions if you rely on this
     behaviour to keep sensitive data out of distributed packages.
+  * Recognize `powerpc64le` as architecture PPC64.
   * Cabal now deduplicates more `-I` and `-L` and flags to avoid `E2BIG`
     ([#5356](https://github.com/haskell/cabal/issues/5356)).
 ----

--- a/Cabal/Distribution/System.hs
+++ b/Cabal/Distribution/System.hs
@@ -158,7 +158,7 @@ buildOS = classifyOS Permissive System.Info.os
 --
 -- The following aliases can also be used:
 --    * PPC alias: powerpc
---    * PPC64 alias : powerpc64
+--    * PPC64 alias : powerpc64, powerpc64le
 --    * Sparc aliases: sparc64, sun4
 --    * Mips aliases: mipsel, mipseb
 --    * Arm aliases: armeb, armel
@@ -189,7 +189,7 @@ archAliases :: ClassificationStrictness -> Arch -> [String]
 archAliases Strict _       = []
 archAliases Compat _       = []
 archAliases _      PPC     = ["powerpc"]
-archAliases _      PPC64   = ["powerpc64"]
+archAliases _      PPC64   = ["powerpc64", "powerpc64le"]
 archAliases _      Sparc   = ["sparc64", "sun4"]
 archAliases _      Mips    = ["mipsel", "mipseb"]
 archAliases _      Arm     = ["armeb", "armel"]


### PR DESCRIPTION
Add powerpc64le to the list of aliases and document in haddock docs.

Tested by building store-core on a PowerPC 64-bit little endian and verified that `arch(PPC64)` in a conditional evaluates to true.

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.


