### PR TITLE
Added documentation for Backpack-related fields.

### DIFF
--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2292,6 +2292,13 @@ system-dependent values for these fields.
           mixins:
             foo (Foo.Bar as AnotherFoo.Bar, Foo.Baz as AnotherFoo.Baz)
 
+    .. Note::
+
+       The current version of Cabal suffers from an infelicity in how the
+       entries of :pkg-field:`mixins` are parsed: an entry will fail to parse
+       if the provided renaming clause has whitespace after the opening
+       parenthesis. This will be fixed in future versions of Cabal.
+
     There can be multiple mixin entries for a given package, in effect creating
     multiple copies of the dependency:
 


### PR DESCRIPTION
I added descriptions for the Backpack-related `signatures:` and `mixins:` fields, which were missing according to issue #4761.

The new entries don't explain Backpack in detail, but give the basic syntax and link to the [GHC Wiki entry](https://ghc.haskell.org/trac/ghc/wiki/Backpack) and to the [GHC user guide](https://downloads.haskell.org/~ghc/master/users-guide/separate_compilation.html#module-signatures) for more information.
