### PR TITLE
Correct formatting of the legacy command name warning

### DIFF
--- a/cabal-install/Distribution/Client/CmdLegacy.hs
+++ b/cabal-install/Distribution/Client/CmdLegacy.hs
@@ -113,9 +113,9 @@ deprecationNote cmd =
     "The " ++ cmd ++ " command is a part of the legacy v1 style of cabal usage.\n\n" ++
 
     "Please switch to using either the new project style and the new-" ++ cmd ++ 
-    " command or the legacy v1-" ++ cmd ++ "alias as new-style projects will" ++
-    "become the default in the next version of cabal-install. Please file a" ++
-    "bug if you cannot replicate a working v1- use case with the new-style commands.\n\n" ++
+    " command or the legacy v1-" ++ cmd ++ " alias as new-style projects will" ++
+    " become the default in the next version of cabal-install. Please file a" ++
+    " bug if you cannot replicate a working v1- use case with the new-style commands.\n\n" ++
 
     "For more information, see: https://wiki.haskell.org/Cabal/NewBuild\n"
 

--- a/cabal-install/Distribution/Client/CmdLegacy.hs
+++ b/cabal-install/Distribution/Client/CmdLegacy.hs
@@ -15,7 +15,7 @@ import Distribution.Client.SetupWrapper
 import qualified Distribution.Simple.Setup as Setup
 import Distribution.Simple.Command
 import Distribution.Simple.Utils
-    ( warn )
+    ( warn, wrapText )
 import Distribution.Verbosity 
     ( Verbosity, normal )
 
@@ -109,7 +109,7 @@ instance HasVerbosity Setup.DoctestFlags where
 --
 
 deprecationNote :: String -> String
-deprecationNote cmd =
+deprecationNote cmd = wrapText $
     "The " ++ cmd ++ " command is a part of the legacy v1 style of cabal usage.\n\n" ++
 
     "Please switch to using either the new project style and the new-" ++ cmd ++ 
@@ -120,7 +120,7 @@ deprecationNote cmd =
     "For more information, see: https://wiki.haskell.org/Cabal/NewBuild\n"
 
 legacyNote :: String -> String
-legacyNote cmd =
+legacyNote cmd = wrapText $
     "The v1-" ++ cmd ++ " command is a part of the legacy v1 style of cabal usage.\n\n" ++
 
     "It is a legacy feature and will be removed in a future release of cabal-install." ++

--- a/cabal-install/Distribution/Client/CmdLegacy.hs
+++ b/cabal-install/Distribution/Client/CmdLegacy.hs
@@ -112,9 +112,9 @@ deprecationNote :: String -> String
 deprecationNote cmd =
     "The " ++ cmd ++ " command is a part of the legacy v1 style of cabal usage.\n\n" ++
 
-    "Please switch to using either the new project style and the ++ new-" ++ cmd ++ 
-    "command or the legacy v1-" ++ cmd ++ "\nalias as new-style projects will\n" ++
-    "become the default in the next version of cabal-install. Please file a\n" ++
+    "Please switch to using either the new project style and the new-" ++ cmd ++ 
+    " command or the legacy v1-" ++ cmd ++ "alias as new-style projects will" ++
+    "become the default in the next version of cabal-install. Please file a" ++
     "bug if you cannot replicate a working v1- use case with the new-style commands.\n\n" ++
 
     "For more information, see: https://wiki.haskell.org/Cabal/NewBuild\n"
@@ -123,8 +123,8 @@ legacyNote :: String -> String
 legacyNote cmd =
     "The v1-" ++ cmd ++ " command is a part of the legacy v1 style of cabal usage.\n\n" ++
 
-    "It is a legacy feature and will be removed in a future release of cabal-install.\n" ++
-    "Please file a bug if you cannot replicate a working v1- use case with the new-style\n" ++
+    "It is a legacy feature and will be removed in a future release of cabal-install." ++
+    "Please file a bug if you cannot replicate a working v1- use case with the new-style" ++
     "commands.\n\n" ++
 
     "For more information, see: https://wiki.haskell.org/Cabal/NewBuild\n"

--- a/cabal-install/Distribution/Client/CmdLegacy.hs
+++ b/cabal-install/Distribution/Client/CmdLegacy.hs
@@ -124,8 +124,8 @@ legacyNote cmd =
     "The v1-" ++ cmd ++ " command is a part of the legacy v1 style of cabal usage.\n\n" ++
 
     "It is a legacy feature and will be removed in a future release of cabal-install." ++
-    "Please file a bug if you cannot replicate a working v1- use case with the new-style" ++
-    "commands.\n\n" ++
+    " Please file a bug if you cannot replicate a working v1- use case with the new-style" ++
+    " commands.\n\n" ++
 
     "For more information, see: https://wiki.haskell.org/Cabal/NewBuild\n"
 


### PR DESCRIPTION
We don't need to hard-wrap the message as we originate it, since
that's handled elsewhere.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
