### PR TITLE
Allow 2.4-spec files to be parsed.

### DIFF
--- a/Cabal/Distribution/CabalSpecVersion.hs
+++ b/Cabal/Distribution/CabalSpecVersion.hs
@@ -34,6 +34,7 @@ cabalSpecFeatures CabalSpecV2_2  = Set.fromList
 cabalSpecFeatures CabalSpecV2_4  = Set.fromList
     [ Elif
     , CommonStanzas
+    , Globstar
     ]
 
 cabalSpecSupports :: CabalSpecVersion -> [Int] -> Bool
@@ -61,6 +62,9 @@ specHasElif _             = NoElif
 data CabalFeature
     = Elif
     | CommonStanzas
+    | Globstar
+      -- ^ Implemented in #5284. Not actually a change to the parser,
+      -- as filename patterns are opaque to it currently.
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable, Data, Generic)
 
 -------------------------------------------------------------------------------
@@ -72,3 +76,5 @@ data HasElif = HasElif | NoElif
 
 data HasCommonStanzas = HasCommonStanzas | NoCommonStanzas
   deriving (Eq, Show)
+
+data HasGlobstar = HasGlobstar | NoGlobstar

--- a/Cabal/Distribution/CabalSpecVersion.hs
+++ b/Cabal/Distribution/CabalSpecVersion.hs
@@ -20,7 +20,7 @@ data CabalSpecVersion
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable, Data, Generic)
 
 cabalSpecLatest :: CabalSpecVersion
-cabalSpecLatest = CabalSpecV2_2
+cabalSpecLatest = CabalSpecV2_4
 
 cabalSpecFeatures :: CabalSpecVersion -> Set.Set CabalFeature
 cabalSpecFeatures CabalSpecOld   = Set.empty

--- a/Cabal/Distribution/CabalSpecVersion.hs
+++ b/Cabal/Distribution/CabalSpecVersion.hs
@@ -16,6 +16,7 @@ data CabalSpecVersion
     | CabalSpecV1_24
     | CabalSpecV2_0
     | CabalSpecV2_2
+    | CabalSpecV2_4
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable, Data, Generic)
 
 cabalSpecLatest :: CabalSpecVersion
@@ -30,20 +31,27 @@ cabalSpecFeatures CabalSpecV2_2  = Set.fromList
     [ Elif
     , CommonStanzas
     ]
+cabalSpecFeatures CabalSpecV2_4  = Set.fromList
+    [ Elif
+    , CommonStanzas
+    ]
 
 cabalSpecSupports :: CabalSpecVersion -> [Int] -> Bool
 cabalSpecSupports CabalSpecOld v   = v < [1,21]
 cabalSpecSupports CabalSpecV1_22 v = v < [1,23]
 cabalSpecSupports CabalSpecV1_24 v = v < [1,25]
 cabalSpecSupports CabalSpecV2_0 v  = v < [2,1]
-cabalSpecSupports CabalSpecV2_2 _  = True
+cabalSpecSupports CabalSpecV2_2 v  = v < [2,3]
+cabalSpecSupports CabalSpecV2_4 _  = True
 
 specHasCommonStanzas :: CabalSpecVersion -> HasCommonStanzas
 specHasCommonStanzas CabalSpecV2_2 = HasCommonStanzas
+specHasCommonStanzas CabalSpecV2_4 = HasCommonStanzas
 specHasCommonStanzas _             = NoCommonStanzas
 
 specHasElif :: CabalSpecVersion -> HasElif
 specHasElif CabalSpecV2_2 = HasElif
+specHasElif CabalSpecV2_4 = HasElif
 specHasElif _             = NoElif
 
 -------------------------------------------------------------------------------

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -125,7 +125,7 @@ parseGenericPackageDescription bs = do
     setCabalSpecVersion ver
     -- if we get too new version, fail right away
     case ver of
-        Just v | v > mkVersion [2,2] -> parseFailure zeroPos
+        Just v | v > mkVersion [2,4] -> parseFailure zeroPos
             "Unsupported cabal-version. See https://github.com/haskell/cabal/issues/4899."
         _ -> pure ()
 
@@ -200,6 +200,7 @@ parseGenericPackageDescription' cabalVerM lexWarnings utf8WarnPos fs = do
                 return v
 
     let specVer
+          | cabalVer >= mkVersion [2,3]  = CabalSpecV2_4
           | cabalVer >= mkVersion [2,1]  = CabalSpecV2_2
           | cabalVer >= mkVersion [1,25] = CabalSpecV2_0
           | cabalVer >= mkVersion [1,23] = CabalSpecV1_24


### PR DESCRIPTION
Lexically, they're identical to 2.2, but the semantics of globs have
changed slightly.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

cc @phadej. I grepped for `CabalSpecV2_2` and put in an analogous `CabalSpecV2_4` wherever I found it. Is there anything else that needs doing?