### PR TITLE
Remove matchFileGlob.

### DIFF
--- a/Cabal/Distribution/Simple/Glob.hs
+++ b/Cabal/Distribution/Simple/Glob.hs
@@ -18,7 +18,6 @@ module Distribution.Simple.Glob (
         GlobSyntaxError(..),
         GlobResult(..),
         globMatches,
-        matchFileGlob,
         matchDirFileGlob,
         matchDirFileGlob',
         fileGlobMatches,
@@ -192,9 +191,6 @@ parseFileGlob version filepath = case reverse (splitDirectories filepath) of
     multidot
       | version >= mkVersion [2,4] = MultiDotEnabled
       | otherwise = MultiDotDisabled
-
-matchFileGlob :: Verbosity -> Version -> FilePath -> IO [GlobResult FilePath]
-matchFileGlob verbosity version = matchDirFileGlob verbosity version "."
 
 -- | Like 'matchDirFileGlob'', but will 'die'' when the glob matches
 -- no files.

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -306,7 +306,7 @@ haddock pkg_descr lbi suffixes flags' = do
         CBench _ -> (when (flag haddockBenchmarks)  $ smsg >> doExe component) >> return index
 
     for_ (extraDocFiles pkg_descr) $ \ fpath -> do
-      files <- fmap globMatches $ matchFileGlob verbosity (specVersion pkg_descr) fpath
+      files <- fmap globMatches $ matchDirFileGlob verbosity (specVersion pkg_descr) "." fpath
       for_ files $ copyFileTo verbosity (unDir $ argOutputDir commonArgs)
 
 -- ------------------------------------------------------------------------------

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -149,7 +149,7 @@ listPackageSourcesMaybeExecutable verbosity pkg_descr =
   -- Extra source files.
   fmap concat . for (extraSrcFiles pkg_descr) $ \fpath ->
     fmap globMatches $
-      matchFileGlob verbosity (specVersion pkg_descr) fpath
+      matchDirFileGlob verbosity (specVersion pkg_descr) "." fpath
 
 -- | List those source files that should be copied with ordinary permissions.
 listPackageSourcesOrdinary :: Verbosity
@@ -223,7 +223,7 @@ listPackageSourcesOrdinary verbosity pkg_descr pps =
   , fmap concat
     . for (extraDocFiles pkg_descr) $ \ filename ->
       fmap globMatches $
-        matchFileGlob verbosity (specVersion pkg_descr) filename
+        matchDirFileGlob verbosity (specVersion pkg_descr) "." filename
 
     -- License file(s).
   , return (licenseFiles pkg_descr)


### PR DESCRIPTION
This was only a convenience function, but its use could obscure how it
is introducing a dependency on the CWD. By removing it, the "."
argument to `matchDirFileGlob` is explicit.

Any external code using `matchFileGlob` would have needed to be
changed as #5284 changed its signature and the module it lives in; it
is not much more of a burden to switch to `matchDirFileGlob` at the
same time.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
