### PR TITLE
cabal check improvements for globs

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -65,6 +65,8 @@
     ([#5386](https://github.com/haskell/cabal/issues/5386)).
   * `Distribution.PackageDescription.Check.checkPackageFiles` now
     accepts a `Verbosity` argument.
+  * `cabal check` now warns about globs that refer to missing
+    directories.
 
 ----
 

--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -21,18 +21,30 @@
   * Added `Eta` to `CompilerFlavor` and to known compilers.
   * `cabal haddock` now generates per-component documentation
     ([#5226](https://github.com/haskell/cabal/issues/5226)).
-  * Allow `**` wildcards in `data-files`, `extra-source-files` and
-    `extra-doc-files`. These allow a limited form of recursive
-    matching, and require `cabal-version: 2.4`.
-
-    Wildcard syntax errors (misplaced `*`, etc) are also now detected
-    by `cabal check`.
-
-    `FileGlob`, `parseFileGlob`, `matchFileGlob` and `matchDirFileGlob`
-    have beem moved from `Distribution.Simple.Utils` to a new file,
-    `Distribution.Simple.Glob` and `FileGlob` has been made abstract.
-
-    ([#5284](https://github.com/haskell/cabal/issues/5284), [#3178](https://github.com/haskell/cabal/issues/3178), et al.)
+  * Wildcard improvements:
+    * Allow `**` wildcards in `data-files`, `extra-source-files` and
+      `extra-doc-files`. These allow a limited form of recursive
+      matching, and require `cabal-version: 2.4`.
+      ([#5284](https://github.com/haskell/cabal/issues/5284),
+      [#3178](https://github.com/haskell/cabal/issues/3178), et al.)
+    * With `cabal-version: 2.4`, when matching a wildcard, the
+      requirement for the full extension to match exactly has been
+      loosened. Instead, if the wildcard's extension is a suffix of the
+      file's extension, the file will be selected. For example,
+      previously `foo.en.html` would not match `*.html`, and
+      `foo.solaris.tar.gz` would not match `*.tar.gz`, but now both
+      do. This may lead to files unexpectedly being included by `sdist`;
+      please audit your package descriptions if you rely on this
+      behaviour to keep sensitive data out of distributed packages
+      ([#5372](https://github.com/haskell/cabal/pull/5372),
+      [#784](https://github.com/haskell/cabal/issues/784),
+      [#5057](https://github.com/haskell/cabal/issues/5057)).
+    * Wildcard syntax errors (misplaced `*`, etc), wildcards that
+      refer to missing directoies, and wildcards that do not match
+      anything are now all detected by `cabal check`.
+    * Wildcard ('globbing') functions have been moved from
+      `Distribution.Simple.Utils` to `Distribution.Simple.Glob` and
+      have been refactored.
   * Fixed `cxx-options` and `cxx-sources` buildinfo fields for
     separate compilation of C++ source files to correctly build and link
     non-library components ([#5309](https://github.com/haskell/cabal/issues/5309)).
@@ -47,15 +59,6 @@
     `cxx-options`, `cpp-options` are not deduplicated anymore
     ([#4449](https://github.com/haskell/cabal/issues/4449)).
   * Deprecated `cabal hscolour` in favour of `cabal haddock --hyperlink-source` ([#5236](https://github.com/haskell/cabal/pull/5236/)).
-  * With `cabal-version: 2.4`, when matching a wildcard, the
-    requirement for the full extension to match exactly has been
-    loosened. Instead, if the wildcard's extension is a suffix of the
-    file's extension, the file will be selected. For example,
-    previously `foo.en.html` would not match `*.html`, and
-    `foo.solaris.tar.gz` would not match `*.tar.gz`, but now both
-    do. This may lead to files unexpectedly being included by `sdist`;
-    please audit your package descriptions if you rely on this
-    behaviour to keep sensitive data out of distributed packages.
   * Recognize `powerpc64le` as architecture PPC64.
   * Cabal now deduplicates more `-I` and `-L` and flags to avoid `E2BIG`
     ([#5356](https://github.com/haskell/cabal/issues/5356)).
@@ -65,9 +68,6 @@
     ([#5386](https://github.com/haskell/cabal/issues/5386)).
   * `Distribution.PackageDescription.Check.checkPackageFiles` now
     accepts a `Verbosity` argument.
-  * `cabal check` now warns about globs that refer to missing
-    directories.
-  * `cabal check` now warns about globs that do not match any files.
 
 ----
 

--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -67,6 +67,7 @@
     accepts a `Verbosity` argument.
   * `cabal check` now warns about globs that refer to missing
     directories.
+  * `cabal check` now warns about globs that do not match any files.
 
 ----
 

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -306,7 +306,7 @@ haddock pkg_descr lbi suffixes flags' = do
         CBench _ -> (when (flag haddockBenchmarks)  $ smsg >> doExe component) >> return index
 
     for_ (extraDocFiles pkg_descr) $ \ fpath -> do
-      files <- fmap globMatches $ matchDirFileGlob verbosity (specVersion pkg_descr) "." fpath
+      files <- matchDirFileGlob verbosity (specVersion pkg_descr) "." fpath
       for_ files $ copyFileTo verbosity (unDir $ argOutputDir commonArgs)
 
 -- ------------------------------------------------------------------------------

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -33,7 +33,7 @@ import Distribution.Package
 import Distribution.PackageDescription
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.BuildPaths (haddockName, haddockPref)
-import Distribution.Simple.Glob (matchDirFileGlob, globMatches)
+import Distribution.Simple.Glob (matchDirFileGlob)
 import Distribution.Simple.Utils
          ( createDirectoryIfMissingVerbose
          , installDirectoryContents, installOrdinaryFile, isInSearchPath
@@ -238,7 +238,7 @@ installDataFiles verbosity pkg_descr destDataDir =
         srcDataDir = if null srcDataDirRaw
           then "."
           else srcDataDirRaw
-    files <- globMatches <$> matchDirFileGlob verbosity (specVersion pkg_descr) srcDataDir file
+    files <- matchDirFileGlob verbosity (specVersion pkg_descr) srcDataDir file
     let dir = takeDirectory file
     createDirectoryIfMissingVerbose verbosity True (destDataDir </> dir)
     sequence_ [ installOrdinaryFile verbosity (srcDataDir  </> file')

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -148,8 +148,7 @@ listPackageSourcesMaybeExecutable :: Verbosity -> PackageDescription -> IO [File
 listPackageSourcesMaybeExecutable verbosity pkg_descr =
   -- Extra source files.
   fmap concat . for (extraSrcFiles pkg_descr) $ \fpath ->
-    fmap globMatches $
-      matchDirFileGlob verbosity (specVersion pkg_descr) "." fpath
+    matchDirFileGlob verbosity (specVersion pkg_descr) "." fpath
 
 -- | List those source files that should be copied with ordinary permissions.
 listPackageSourcesOrdinary :: Verbosity
@@ -216,13 +215,11 @@ listPackageSourcesOrdinary verbosity pkg_descr pps =
               then "."
               else srcDataDirRaw
         in fmap (fmap (srcDataDir </>)) $
-             fmap globMatches $
-               matchDirFileGlob verbosity (specVersion pkg_descr) srcDataDir filename
+             matchDirFileGlob verbosity (specVersion pkg_descr) srcDataDir filename
 
     -- Extra doc files.
   , fmap concat
     . for (extraDocFiles pkg_descr) $ \ filename ->
-      fmap globMatches $
         matchDirFileGlob verbosity (specVersion pkg_descr) "." filename
 
     -- License file(s).

--- a/cabal-testsuite/PackageTests/Check/InvalidGlob/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/InvalidGlob/cabal.out
@@ -1,0 +1,5 @@
+# cabal check
+Warning: The following errors will cause portability problems on other environments:
+Warning: No 'synopsis' or 'description' field.
+Warning: In the 'extra-doc-files' field: invalid file glob '***.html'. Wildcards '*' may only totally replace the file's base name, not only parts of it.
+Warning: Hackage would reject this package.

--- a/cabal-testsuite/PackageTests/Check/InvalidGlob/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/InvalidGlob/cabal.test.hs
@@ -1,0 +1,3 @@
+import Test.Cabal.Prelude
+main = cabalTest $
+  fails $ cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/InvalidGlob/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Check/InvalidGlob/pkg.cabal
@@ -1,0 +1,13 @@
+cabal-version: 2.2
+name: pkg
+version: 0
+extra-doc-files:
+  ***.html
+category: example
+maintainer: none@example.com
+license: BSD-3-Clause
+
+library
+  exposed-modules: Foo
+  default-language: Haskell2010
+  

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/Foo.hs
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/Foo.hs
@@ -1,0 +1,1 @@
+foo = True

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/cabal.out
@@ -1,0 +1,9 @@
+# cabal check
+Warning: The package will not build sanely due to these errors:
+Warning: This package description follows version 2.4 of the Cabal specification. This tool only supports up to version 2.3.0.0.
+Warning: The following errors will cause portability problems on other environments:
+Warning: In 'data-files': the pattern 'another-non-existent-directory/**/*.dat' attempts to match files in the directory 'another-non-existent-directory', but there is no directory by that name.
+Warning: In 'extra-doc-files': the pattern 'non-existent-directory/*.html' attempts to match files in the directory 'non-existent-directory', but there is no directory by that name.
+Warning: In 'extra-doc-files': the pattern 'present/present/missing/*.tex' attempts to match files in the directory 'present/present/missing', but there is no directory by that name.
+Warning: In 'extra-source-files': the pattern 'file-not-a-directory/*.js' attempts to match files in the directory 'file-not-a-directory', but there is no directory by that name.
+Warning: Hackage would reject this package.

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/cabal.out
@@ -1,7 +1,7 @@
 # cabal check
 Warning: The package will not build sanely due to these errors:
 Warning: This package description follows version 2.4 of the Cabal specification. This tool only supports up to version 2.3.0.0.
-Warning: The following errors will cause portability problems on other environments:
+Warning: These warnings may cause trouble when distributing the package:
 Warning: In 'data-files': the pattern 'another-non-existent-directory/**/*.dat' attempts to match files in the directory 'another-non-existent-directory', but there is no directory by that name.
 Warning: In 'extra-doc-files': the pattern 'non-existent-directory/*.html' attempts to match files in the directory 'non-existent-directory', but there is no directory by that name.
 Warning: In 'extra-doc-files': the pattern 'present/present/missing/*.tex' attempts to match files in the directory 'present/present/missing', but there is no directory by that name.

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/cabal.test.hs
@@ -1,0 +1,3 @@
+import Test.Cabal.Prelude
+main = cabalTest $
+  fails $ cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/data/hello.dat
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/data/hello.dat
@@ -1,0 +1,1 @@
+hello.dat

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/file-not-a-directory
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/file-not-a-directory
@@ -1,0 +1,1 @@
+This is not a directory.

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/pkg.cabal
@@ -1,0 +1,21 @@
+cabal-version: 2.4
+name: pkg
+version: 0
+extra-doc-files:
+  non-existent-directory/*.html
+  present/present/missing/*.tex
+extra-source-files:
+  file-not-a-directory/*.js
+data-dir:
+  data
+data-files:
+  another-non-existent-directory/**/*.dat
+category: example
+maintainer: none@example.com
+synopsis: synopsis
+description: description
+license: BSD-3-Clause
+
+library
+  exposed-modules: Foo
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/present/present/hello
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory/present/present/hello
@@ -1,0 +1,1 @@
+This file only exists so that Git will create its two parent directories.

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/Foo.hs
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/Foo.hs
@@ -1,0 +1,1 @@
+foo = True

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/cabal.out
@@ -1,4 +1,3 @@
 # cabal check
-Warning: The following errors will cause portability problems on other environments:
+Warning: These warnings may cause trouble when distributing the package:
 Warning: In 'data-files': the pattern 'non-existent-directory/*.dat' attempts to match files in the directory 'non-existent-directory', but there is no directory by that name.
-Warning: Hackage would reject this package.

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/cabal.out
@@ -1,6 +1,4 @@
 # cabal check
-Warning: The package will not build sanely due to these errors:
-Warning: This package description follows version 2.4 of the Cabal specification. This tool only supports up to version 2.3.0.0.
 Warning: The following errors will cause portability problems on other environments:
-Warning: In 'data-files': the pattern 'non-existent-directory/**/*.dat' attempts to match files in the directory 'non-existent-directory', but there is no directory by that name.
+Warning: In 'data-files': the pattern 'non-existent-directory/*.dat' attempts to match files in the directory 'non-existent-directory', but there is no directory by that name.
 Warning: Hackage would reject this package.

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/cabal.out
@@ -1,0 +1,6 @@
+# cabal check
+Warning: The package will not build sanely due to these errors:
+Warning: This package description follows version 2.4 of the Cabal specification. This tool only supports up to version 2.3.0.0.
+Warning: The following errors will cause portability problems on other environments:
+Warning: In 'data-files': the pattern 'non-existent-directory/**/*.dat' attempts to match files in the directory 'non-existent-directory', but there is no directory by that name.
+Warning: Hackage would reject this package.

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/cabal.test.hs
@@ -1,0 +1,3 @@
+import Test.Cabal.Prelude
+main = cabalTest $
+  fails $ cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/cabal.test.hs
@@ -1,3 +1,2 @@
 import Test.Cabal.Prelude
-main = cabalTest $
-  fails $ cabal "check" []
+main = cabalTest $ cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Check/MissingGlobDirectory2/pkg.cabal
@@ -1,0 +1,14 @@
+cabal-version: 2.4
+name: pkg
+version: 0
+data-files:
+  non-existent-directory/**/*.dat
+category: example
+maintainer: none@example.com
+synopsis: synopsis
+description: description
+license: BSD-3-Clause
+
+library
+  exposed-modules: Foo
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/Check/MultiDotGlob2.2/data/index.dat
+++ b/cabal-testsuite/PackageTests/Check/MultiDotGlob2.2/data/index.dat
@@ -1,0 +1,1 @@
+index.dat

--- a/cabal-testsuite/PackageTests/Check/MultiDotGlob2.2/doc/index.html
+++ b/cabal-testsuite/PackageTests/Check/MultiDotGlob2.2/doc/index.html
@@ -1,0 +1,1 @@
+index.html

--- a/cabal-testsuite/PackageTests/Check/MultiDotGlob2.2/src/index.js
+++ b/cabal-testsuite/PackageTests/Check/MultiDotGlob2.2/src/index.js
@@ -1,0 +1,1 @@
+index.js

--- a/cabal-testsuite/PackageTests/Check/NoGlobMatches/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/NoGlobMatches/cabal.out
@@ -1,4 +1,3 @@
 # cabal check
-Warning: The following errors will cause portability problems on other environments:
+Warning: These warnings may cause trouble when distributing the package:
 Warning: In 'extra-doc-files': the pattern '*.html' does not match any files.
-Warning: Hackage would reject this package.

--- a/cabal-testsuite/PackageTests/Check/NoGlobMatches/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/NoGlobMatches/cabal.out
@@ -1,0 +1,4 @@
+# cabal check
+Warning: The following errors will cause portability problems on other environments:
+Warning: In 'extra-doc-files': the pattern '*.html' does not match any files.
+Warning: Hackage would reject this package.

--- a/cabal-testsuite/PackageTests/Check/NoGlobMatches/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/NoGlobMatches/cabal.test.hs
@@ -1,0 +1,3 @@
+import Test.Cabal.Prelude
+main = cabalTest $
+  fails $ cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/NoGlobMatches/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/NoGlobMatches/cabal.test.hs
@@ -1,3 +1,2 @@
 import Test.Cabal.Prelude
-main = cabalTest $
-  fails $ cabal "check" []
+main = cabalTest $ cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/NoGlobMatches/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Check/NoGlobMatches/pkg.cabal
@@ -1,8 +1,8 @@
 cabal-version: 2.2
 name: pkg
 version: 0
-data-files:
-  non-existent-directory/*.dat
+extra-doc-files:
+  *.html
 category: example
 maintainer: none@example.com
 synopsis: synopsis


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tests added!

This PR is based on top of #5401 and #5402 (which explains today's PR frenzy: I didn't expect to need to do #5401 when I started!). I'll rebase on master once those two are merged. As noted in #5401, the `cabal-version` check in `Check.hs` is kind of weird; I have left it in the expected output of the relevant test on the basis that it's easy to remove later.