### PR TITLE
Add the start of a changelog for the Cabal file format

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -27,7 +27,8 @@ extra-source-files:
   doc/conf.py doc/config-and-install.rst doc/developing-packages.rst
   doc/images/Cabal-dark.png doc/index.rst doc/installing-packages.rst
   doc/intro.rst doc/misc.rst doc/nix-local-build-overview.rst
-  doc/nix-local-build.rst doc/README.md doc/references.inc
+  doc/nix-local-build.rst doc/file-format-changelog.rst doc/README.md
+  doc/references.inc
 
   -- Generated with 'make gen-extra-source-files'
   -- Do NOT edit this section manually; instead, run the script.

--- a/Cabal/doc/file-format-changelog.rst
+++ b/Cabal/doc/file-format-changelog.rst
@@ -1,0 +1,22 @@
+Cabal file format changelog
+===========================
+
+Changes in 2.4
+--------------
+
+* Wildcard matching has been expanded. All previous wildcard
+  expressions are still valid; some will match strictly more files
+  than before. Specifically:
+
+  * Double-star (``**``) wildcards are now accepted for recursive
+    matching immediately before the final slash; they must be followed
+    by a filename wildcard (e.g., ``foo/**/*.html`` is valid;
+    ``foo/**/bar/*.html`` and ``foo/**/**/*.html``,
+    ``foo/**/bar.html`` are all invalid). As ``**`` was an error in
+    globs before, this does not affect any existing ``.cabal`` files
+    that previously worked.
+
+  * Wildcards now match when the pattern's extensions form a suffix of
+    the candidate file's extension, rather than requiring strict
+    equality (e.g., previously ``*.html`` did not match
+    ``foo.en.html``, but now it does).

--- a/Cabal/doc/index.rst
+++ b/Cabal/doc/index.rst
@@ -12,3 +12,4 @@ Welcome to the Cabal User Guide
    bugs-and-stability
    nix-local-build-overview
    nix-integration
+   file-format-changelog


### PR DESCRIPTION
As suggested in #5401.

[skip ci]

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

cc @phadej