### PR TITLE
Remove 7.4 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ matrix:
    # These don't have -dyn/-prof whitelisted yet, so we have to
    # do the old-style installation
    # NB: TEST_OTHER_VERSIONS doesn't work with USE_GOLD=YES.
-   - env: GHCVER=7.4.2 SCRIPT=script CABAL_LIB_ONLY=YES TEST_OTHER_VERSIONS=YES
-     os: linux
-     sudo: required
    - env: GHCVER=7.6.3 SCRIPT=script CABAL_LIB_ONLY=YES TEST_OTHER_VERSIONS=YES
      os: linux
      sudo: required


### PR DESCRIPTION
7.4 is out of our support window, so it's not really important to consider for the status of a PR (and can contribute to error fatigue)