### PR TITLE
Ignore case when matching SPDX identifiers

### DIFF
--- a/Cabal/Distribution/SPDX/LicenseExceptionId.hs
+++ b/Cabal/Distribution/SPDX/LicenseExceptionId.hs
@@ -137,7 +137,7 @@ licenseExceptionName WxWindows_exception_3_1 = "WxWindows Library Exception 3.1"
 
 -- | Create a 'LicenseExceptionId' from a 'String'.
 mkLicenseExceptionId :: String -> Maybe LicenseExceptionId
-mkLicenseExceptionId s = Map.lookup s stringLookup
+mkLicenseExceptionId s = Map.lookup (map toLower s) stringLookup
 
 stringLookup :: Map String LicenseExceptionId
-stringLookup = Map.fromList $ map (\i -> (licenseExceptionId i, i)) $ [minBound .. maxBound]
+stringLookup = Map.fromList $ map (\i -> (map toLower (licenseExceptionId i), i)) $ [minBound .. maxBound]

--- a/Cabal/Distribution/SPDX/LicenseId.hs
+++ b/Cabal/Distribution/SPDX/LicenseId.hs
@@ -1479,7 +1479,7 @@ licenseIsOsiApproved ZPL_2_1 = False
 
 -- | Create a 'LicenseId' from a 'String'.
 mkLicenseId :: String -> Maybe LicenseId
-mkLicenseId s = Map.lookup s stringLookup
+mkLicenseId s = Map.lookup (map toLower s) stringLookup
 
 stringLookup :: Map String LicenseId
-stringLookup = Map.fromList $ map (\i -> (licenseId i, i)) $ [minBound .. maxBound]
+stringLookup = Map.fromList $ map (\i -> (map toLower (licenseId i), i)) $ [minBound .. maxBound]

--- a/Cabal/tests/UnitTests/Distribution/SPDX.hs
+++ b/Cabal/tests/UnitTests/Distribution/SPDX.hs
@@ -14,7 +14,9 @@ import Test.Tasty.QuickCheck
 spdxTests :: [TestTree]
 spdxTests =
     [ testProperty "LicenseId roundtrip" licenseIdRoundtrip
+    , testProperty "LicenseId roundtrip (lower case)" licenseIdRoundtripLowerCase
     , testProperty "LicenseExceptionId roundtrip" licenseExceptionIdRoundtrip
+    , testProperty "LicenseExceptionId roundtrip (lower case)" licenseExceptionIdRoundtripLowerCase
     , testProperty "LicenseRef roundtrip" licenseRefRoundtrip
     , testProperty "SimpleLicenseExpression roundtrip" simpleLicenseExpressionRoundtrip
     , testProperty "LicenseExpression roundtrip" licenseExpressionRoundtrip
@@ -27,10 +29,20 @@ licenseIdRoundtrip x =
     counterexample (prettyShow x) $
     Right x === eitherParsec (prettyShow x)
 
+licenseIdRoundtripLowerCase :: LicenseId -> Property
+licenseIdRoundtripLowerCase x =
+    counterexample (prettyShow x) $
+    Right x === eitherParsec (map toLower $ prettyShow x)
+
 licenseExceptionIdRoundtrip :: LicenseExceptionId -> Property
 licenseExceptionIdRoundtrip x =
     counterexample (prettyShow x) $
     Right x === eitherParsec (prettyShow x)
+
+licenseExceptionIdRoundtripLowerCase :: LicenseExceptionId -> Property
+licenseExceptionIdRoundtripLowerCase x =
+    counterexample (prettyShow x) $
+    Right x === eitherParsec (map toLower $ prettyShow x)
 
 licenseRefRoundtrip :: LicenseRef -> Property
 licenseRefRoundtrip x =


### PR DESCRIPTION
(as per the SPDX License List Matching Guidelines, v2.0)

https://spdx.org/spdx-license-list/matching-guidelines

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
