### PR TITLE
Respect ghc-options and with-gcc when compiling C sources

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -70,6 +70,8 @@
     ([#5386](https://github.com/haskell/cabal/issues/5386)).
   * `Distribution.PackageDescription.Check.checkPackageFiles` now
     accepts a `Verbosity` argument.
+  * `ghc-options` and `--with-gcc` are now passed to GHC when compiling
+    C and C++ sources ([#4439](https://github.com/haskell/cabal/issues/4439)).
 
 ----
 

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -293,7 +293,10 @@ componentCcGhcOptions verbosity _implInfo lbi bi clbi odir filename =
                                   NormalDebugInfo  -> ["-g"]
                                   MaximalDebugInfo -> ["-g3"]) ++
                                   PD.ccOptions bi,
-      ghcOptObjDir         = toFlag odir
+      ghcOptCcProgram      = maybeToFlag $ programPath <$>
+                                 lookupProgram gccProgram (withPrograms lbi),
+      ghcOptObjDir         = toFlag odir,
+      ghcOptExtra          = hcOptions GHC bi
     }
 
 
@@ -329,7 +332,10 @@ componentCxxGhcOptions verbosity _implInfo lbi bi clbi odir filename =
                                   NormalDebugInfo  -> ["-g"]
                                   MaximalDebugInfo -> ["-g3"]) ++
                                   PD.cxxOptions bi,
-      ghcOptObjDir         = toFlag odir
+      ghcOptCcProgram      = maybeToFlag $ programPath <$>
+                                 lookupProgram gccProgram (withPrograms lbi),
+      ghcOptObjDir         = toFlag odir,
+      ghcOptExtra          = hcOptions GHC bi
     }
 
 

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -355,6 +355,9 @@ data GhcOptions = GhcOptions {
   -- | Extra header files to include for old-style FFI; the @ghc -#include@ flag.
   ghcOptFfiIncludes    :: NubListR FilePath,
 
+  -- | Program to use for the C and C++ compiler; the @ghc -pgmc@ flag.
+  ghcOptCcProgram      :: Flag FilePath,
+
   ----------------------------
   -- Language and extensions
 
@@ -595,6 +598,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
            | inc <- flags ghcOptCppIncludes ]
   , [ "-optc" ++ opt | opt <- ghcOptCcOptions opts]
   , [ "-optc" ++ opt | opt <- ghcOptCxxOptions opts]
+  , concat [ ["-pgmc", cc] | cc <- flag ghcOptCcProgram ]
 
   -----------------
   -- Linker stuff


### PR DESCRIPTION
This fix allows users to override the C/C++ compiler, either by passing
--with-gcc to configure or adding -pgmc to ghc-options in their Cabal
file.

Tested manually with a project using C++ sources that require a more
recent version of clang than the default install (macOS). Inspected the
output of `Setup.hs build -v` to confirm that the correct arguments are
being passed to GHC when compiling the C++ sources.

Resolves: #4439 

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.
