### PR TITLE
Changed default changelog name to "changelog.md"

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -288,7 +288,7 @@ getExtraSourceFiles flags = do
   return $ flags { extraSrc = extraSrcFiles }
 
 defaultChangeLog :: FilePath
-defaultChangeLog = "changelog.md"
+defaultChangeLog = "CHANGELOG.md"
 
 -- | Try to guess things to include in the extra-source-files field.
 --   For now, we just look for things in the root directory named

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -288,7 +288,7 @@ getExtraSourceFiles flags = do
   return $ flags { extraSrc = extraSrcFiles }
 
 defaultChangeLog :: FilePath
-defaultChangeLog = "ChangeLog.md"
+defaultChangeLog = "changelog.md"
 
 -- | Try to guess things to include in the extra-source-files field.
 --   For now, we just look for things in the root directory named


### PR DESCRIPTION
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

---

Current changelog default name for new projects is ``ChangeLog.md``.

The word "Changelog" is nowadays [a single word](https://en.wikipedia.org/wiki/Changelog), so I lowercased the capital "L".

An alternative could have been "Changelog.md", but Pascal-cased name are usually restricted to source files in Haskell projects. Yet another alternative could have been "CHANGELOG.md", but all caps + .md extension is uncommon.