### PR TITLE
Do not pass -js-lib-src to ghcjs

### DIFF
--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -320,7 +320,7 @@ buildOrReplLib mReplFlags verbosity numJobs pkg_descr lbi lib clbi = do
                         ghcOptExtra =
                           [ "-link-js-lib"     , getHSLibraryName uid
                           , "-js-lib-outputdir", libTargetDir ] ++
-                          concatMap (\x -> ["-js-lib-src",x]) jsSrcs
+                          jsSrcs
                       }
       vanillaOptsNoJsLib = baseOpts `mappend` mempty {
                       ghcOptMode         = toFlag GhcModeMake,


### PR DESCRIPTION
because ghcjs does not like if the flag appears more than once, and it
seems it was happy before with the `jsSrc` files to be passed without a
flag.
This works-round https://github.com/ghcjs/ghcjs/issues/678 and
fixes #5442