### PR TITLE
Add --build-depends flag, associated support to new-repl

### DIFF
--- a/Cabal/Distribution/Compat/Lens.hs
+++ b/Cabal/Distribution/Compat/Lens.hs
@@ -30,8 +30,8 @@ module Distribution.Compat.Lens (
     toListOf,
     toSetOf,
     -- * Traversal
-    filtered,
     traversed,
+    filtered,
     -- * Lens
     cloneLens,
     aview,
@@ -133,6 +133,7 @@ filtered p f s = if p s then f s else pure s
 traversed :: Traversable f => Traversal (f a) (f b) a b
 traversed = traverse
 {-# INLINE [0] traversed #-}
+
 
 -------------------------------------------------------------------------------
 -- Lens

--- a/Cabal/Distribution/Simple/Flag.hs
+++ b/Cabal/Distribution/Simple/Flag.hs
@@ -59,6 +59,11 @@ instance Functor Flag where
   fmap f (Flag x) = Flag (f x)
   fmap _ NoFlag  = NoFlag
 
+instance Applicative Flag where
+  (Flag x) <*> y = x <$> y
+  NoFlag   <*> _ = NoFlag
+  pure = Flag
+
 instance Monoid (Flag a) where
   mempty = NoFlag
   mappend = (<>)

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -117,6 +117,7 @@ module Distribution.Simple.Utils (
         TempFileOptions(..), defaultTempFileOptions,
         withTempFile, withTempFileEx,
         withTempDirectory, withTempDirectoryEx,
+        createTempDirectory,
 
         -- * .cabal and .buildinfo files
         defaultPackageDesc,

--- a/Cabal/Distribution/Types/Executable/Lens.hs
+++ b/Cabal/Distribution/Types/Executable/Lens.hs
@@ -7,6 +7,7 @@ import Distribution.Compat.Lens
 import Distribution.Compat.Prelude
 import Prelude ()
 
+import Distribution.Types.BuildInfo           (BuildInfo)
 import Distribution.Types.Executable          (Executable)
 import Distribution.Types.ExecutableScope     (ExecutableScope)
 import Distribution.Types.UnqualComponentName (UnqualComponentName)
@@ -25,8 +26,6 @@ exeScope :: Lens' Executable ExecutableScope
 exeScope f s = fmap (\x -> s { T.exeScope = x }) (f (T.exeScope s))
 {-# INLINE exeScope #-}
 
-{-
-buildInfo :: Lens' Executable BuildInfo
-buildInfo f s = fmap (\x -> s { T.buildInfo = x }) (f (T.buildInfo s))
-{-# INLINE buildInfo #-}
--}
+exeBuildInfo :: Lens' Executable BuildInfo
+exeBuildInfo f s = fmap (\x -> s { T.buildInfo = x }) (f (T.buildInfo s))
+{-# INLINE exeBuildInfo #-}

--- a/Cabal/Distribution/Types/PackageId.hs
+++ b/Cabal/Distribution/Types/PackageId.hs
@@ -13,9 +13,12 @@ import Distribution.Version
          ( Version, nullVersion )
 
 import qualified Distribution.Compat.ReadP as Parse
+import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint as Disp
 import Distribution.Compat.ReadP
 import Distribution.Text
+import Distribution.Parsec.Class
+    ( Parsec(..) )
 import Distribution.Pretty
 import Distribution.Types.PackageName
 
@@ -42,6 +45,10 @@ instance Text PackageIdentifier where
     n <- parse
     v <- (Parse.char '-' >> parse) <++ return nullVersion
     return (PackageIdentifier n v)
+
+instance Parsec PackageIdentifier where
+  parsec = PackageIdentifier <$> 
+    parsec <*> (P.char '-' *> parsec <|> pure nullVersion)
 
 instance NFData PackageIdentifier where
     rnf (PackageIdentifier name version) = rnf name `seq` rnf version

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -371,6 +371,33 @@ Currently, it is not supported to pass multiple targets to ``new-repl``
 (``new-repl`` will just successively open a separate GHCi session for
 each target.)
 
+It also provides a way to experiment with libraries without needing to download
+them manually or to install them globally.
+
+This command opens a REPL with the current default target loaded, and a version
+of the ``vector`` package matching that specification exposed.
+
+:: 
+
+    $ cabal new-repl --build-depends "vector >= 0.12 && < 0.13"
+
+Both of these commands do the same thing as the above, but only exposes ``base``,
+``vector``, and the``vector`` package's transitive dependencies even if the user
+is in a project context.
+
+::
+
+    $ cabal new-repl --ignore-project --build-depends "vector >= 0.12 && < 0.13"
+    $ cabal new-repl --project='' --build-depends "vector >= 0.12 && < 0.13"
+
+This command would add ``vector``, but not (for example) ``primitive``, because
+it only includes the packages specified on the command line (and ``base``, which
+cannot be excluded for technical reasons).
+
+::
+
+    $ cabal new-repl --build-depends vector --no-transitive-deps
+
 cabal new-run
 -------------
 

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -14,7 +14,8 @@ module Distribution.Client.CmdInstall (
     -- * Internals exposed for testing
     TargetProblem(..),
     selectPackageTargets,
-    selectComponentTarget
+    selectComponentTarget,
+    establishDummyProjectBaseContext
   ) where
 
 import Prelude ()

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -272,7 +272,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, newInstal
           targetSelectors <- either (reportTargetSelectorProblems verbosity) return
                         =<< readTargetSelectors (localPackages localBaseCtx) Nothing targetStrings'
         
-          (specs, selectors) <- withInstallPlan verbosity' localBaseCtx $ \elaboratedPlan -> do
+          (specs, selectors) <- withInstallPlan verbosity' localBaseCtx $ \elaboratedPlan _ -> do
             -- Split into known targets and hackage packages.
             (targets, hackageNames) <- case
               resolveTargets

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -119,7 +119,7 @@ defaultEnvFlags = EnvFlags
 
 envOptions :: ShowOrParseArgs -> [OptionField EnvFlags]
 envOptions _ =
-  [ option ['p'] ["package"]
+  [ option ['b'] ["build-depends"]
     "Include an additional package in the environment presented to GHCi."
     envPackages (\p flags -> flags { envPackages = p ++ envPackages flags })
     (reqArg "DEPENDENCY" dependencyReadE (fmap prettyShow :: [Dependency] -> [String]))
@@ -127,7 +127,7 @@ envOptions _ =
     "Don't automatically include transitive dependencies of requested packages."
     envIncludeTransitive (\p flags -> flags { envIncludeTransitive = p })
     falseArg
-  , option ['z'] ["only-specified"]
+  , option ['z'] ["ignore-project"]
     "Only include explicitly specified packages (and 'base'). This implies '--no-transitive-deps'."
     envOnlySpecified (\p flags -> flags { envOnlySpecified = p, envIncludeTransitive = not <$> p})
     trueArg

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -17,6 +17,9 @@ module Distribution.Client.CmdRepl (
     selectComponentTarget
   ) where
 
+import Prelude ()
+import Distribution.Client.Compat.Prelude
+
 import Distribution.Compat.Lens
 import qualified Distribution.Types.Lens as L
 
@@ -63,7 +66,7 @@ import Distribution.Solver.Types.SourcePackage
 import Distribution.Types.BuildInfo
          ( BuildInfo(..), emptyBuildInfo )
 import Distribution.Types.ComponentName
-         ( ComponentName(..), componentNameString )
+         ( componentNameString )
 import Distribution.Types.CondTree
          ( CondTree(..), traverseCondTreeC )
 import Distribution.Types.Dependency

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -371,18 +371,18 @@ withoutProject cliConfig verbosity extraArgs = do
       }
     genericPackageDescription = emptyGenericPackageDescription 
       & L.packageDescription .~ packageDescription
-      & L.condLibrary        .~ Just (CondNode library [] [])
+      & L.condLibrary        .~ Just (CondNode library [baseDep] [])
     packageDescription = emptyPackageDescription
       { package = pkgId
       , specVersionRaw = Left (mkVersion [2, 2])
-      , library = Just library
       , licenseRaw = Left SPDX.NONE
       }
     library = emptyLibrary { libBuildInfo = buildInfo }
     buildInfo = emptyBuildInfo
-      { targetBuildDepends = [Dependency "base" anyVersion]
+      { targetBuildDepends = [baseDep]
       , defaultLanguage = Just Haskell2010
       }
+    baseDep = Dependency "base" anyVersion
     pkgId = PackageIdentifier "fake-package" version0
 
   putStrLn $ showGenericPackageDescription genericPackageDescription

--- a/cabal-install/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/Distribution/Client/FetchUtils.hs
@@ -82,6 +82,7 @@ isFetched loc = case loc of
     RemoteTarballPackage _uri local -> return (isJust local)
     RepoTarballPackage repo pkgid _ -> doesFileExist (packageFile repo pkgid)
     RemoteSourceRepoPackage _ local -> return (isJust local)
+    
 
 -- | Checks if the package has already been fetched (or does not need
 -- fetching) and if so returns evidence in the form of a 'PackageLocation'
@@ -106,7 +107,6 @@ checkFetched loc = case loc of
     RepoTarballPackage repo pkgid Nothing ->
       fmap (fmap (RepoTarballPackage repo pkgid))
            (checkRepoTarballFetched repo pkgid)
-
 
 -- | Like 'checkFetched' but for the specific case of a 'RepoTarballPackage'.
 --

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1300,7 +1300,6 @@ installLocalPackage verbosity pkgid location distPref installPkg =
       installLocalTarballPackage verbosity
         pkgid tarballPath distPref installPkg
 
-
 installLocalTarballPackage
   :: Verbosity
   -> PackageIdentifier -> FilePath -> FilePath

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -62,6 +62,7 @@ module Distribution.Client.InstallPlan (
   showInstallPlan,
 
   -- * Graph-like operations
+  dependencyClosure,
   reverseTopologicalOrder,
   reverseDependencyClosure,
   ) where
@@ -402,6 +403,15 @@ reverseTopologicalOrder :: GenericInstallPlan ipkg srcpkg
                         -> [GenericPlanPackage ipkg srcpkg]
 reverseTopologicalOrder plan = Graph.revTopSort (planGraph plan)
 
+
+-- | Return the packages in the plan that are direct or indirect dependencies of
+-- the given packages.
+--
+dependencyClosure :: GenericInstallPlan ipkg srcpkg
+                  -> [UnitId]
+                  -> [GenericPlanPackage ipkg srcpkg]
+dependencyClosure plan = fromMaybe []
+                       . Graph.closure (planGraph plan)
 
 -- | Return the packages in the plan that depend directly or indirectly on the
 -- given packages.

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -249,7 +249,7 @@ data ProjectBuildContext = ProjectBuildContext {
 withInstallPlan
     :: Verbosity
     -> ProjectBaseContext
-    -> (ElaboratedInstallPlan -> IO a)
+    -> (ElaboratedInstallPlan -> ElaboratedSharedConfig -> IO a)
     -> IO a
 withInstallPlan
     verbosity
@@ -264,12 +264,12 @@ withInstallPlan
     -- everything in the project. This is independent of any specific targets
     -- the user has asked for.
     --
-    (elaboratedPlan, _, _) <-
+    (elaboratedPlan, _, elaboratedShared) <-
       rebuildInstallPlan verbosity
                          distDirLayout cabalDirLayout
                          projectConfig
                          localPackages
-    action (elaboratedPlan)
+    action elaboratedPlan elaboratedShared
 
 runProjectPreBuildPhase
     :: Verbosity

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -57,6 +57,7 @@ module Distribution.Client.ProjectOrchestration (
     resolveTargets,
     TargetsMap,
     TargetSelector(..),
+    TargetImplicitCwd(..),
     PackageId,
     AvailableTarget(..),
     AvailableTargetStatus(..),
@@ -115,7 +116,7 @@ import           Distribution.Solver.Types.PackageIndex
                    ( lookupPackageName )
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import           Distribution.Client.TargetSelector
-                   ( TargetSelector(..)
+                   ( TargetSelector(..), TargetImplicitCwd(..)
                    , ComponentKind(..), componentKind
                    , readTargetSelectors, reportTargetSelectorProblems )
 import           Distribution.Client.DistDirLayout

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -236,7 +236,7 @@ data PackageSpecifier pkg =
      -- | A fully specified source package.
      --
    | SpecificSourcePackage pkg
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Functor, Generic)
 
 instance Binary pkg => Binary (PackageSpecifier pkg)
 
@@ -286,7 +286,6 @@ data PackageLocation local =
 
     -- | A package available from a version control system source repository
   | RemoteSourceRepoPackage SourceRepo local
-
   deriving (Show, Functor, Eq, Ord, Generic, Typeable)
 
 instance Binary local => Binary (PackageLocation local)

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,10 @@
 -*-change-log-*-
 
 2.4.0.0 (current development version)
+	* 'new-repl' now accepts a '--build-depends' flag which accepts the
+	  same syntax as is used in .cabal files to add additional dependencies
+	  to the environment when developing in the REPL. It is now usable outside
+	  of projects. (#5425, #5454)
 	* 'new-build' now treats Haddock errors non-fatally. In addition,
 	  it attempts to avoid trying to generate Haddocks when there is
 	  nothing to generate them from. (#5232, #5459)


### PR DESCRIPTION
Closes #5425. Adds `--package` flag, allows `new-repl` use outside of project folders.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.