### PR TITLE
Disambiguate selectors by the command being used

### DIFF
--- a/cabal-install/Distribution/Client/CmdBench.hs
+++ b/cabal-install/Distribution/Client/CmdBench.hs
@@ -81,7 +81,7 @@ benchAction (configFlags, configExFlags, installFlags, haddockFlags)
     baseCtx <- establishProjectBaseContext verbosity cliConfig
 
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-                   =<< readTargetSelectors (localPackages baseCtx) targetStrings
+                   =<< readTargetSelectors (localPackages baseCtx) (Just BenchKind) targetStrings
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do

--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -78,7 +78,7 @@ buildAction (configFlags, configExFlags, installFlags, haddockFlags)
     baseCtx <- establishProjectBaseContext verbosity cliConfig
 
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-                   =<< readTargetSelectors (localPackages baseCtx) targetStrings
+                   =<< readTargetSelectors (localPackages baseCtx) Nothing targetStrings
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do

--- a/cabal-install/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/Distribution/Client/CmdHaddock.hs
@@ -77,7 +77,7 @@ haddockAction (configFlags, configExFlags, installFlags, haddockFlags)
     baseCtx <- establishProjectBaseContext verbosity cliConfig
 
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-                   =<< readTargetSelectors (localPackages baseCtx) targetStrings
+                   =<< readTargetSelectors (localPackages baseCtx) Nothing targetStrings
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -269,7 +269,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, newInstal
         then return (packageSpecifiers, packageTargets, projectConfig localBaseCtx)
         else do
           targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-                        =<< readTargetSelectors (localPackages localBaseCtx) targetStrings'
+                        =<< readTargetSelectors (localPackages localBaseCtx) Nothing targetStrings'
         
           (specs, selectors) <- withInstallPlan verbosity' localBaseCtx $ \elaboratedPlan -> do
             -- Split into known targets and hackage packages.

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -108,7 +108,7 @@ replAction (configFlags, configExFlags, installFlags, haddockFlags, replArgs)
     baseCtx <- establishProjectBaseContext verbosity cliConfig
 
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-                   =<< readTargetSelectors (localPackages baseCtx) targetStrings
+                   =<< readTargetSelectors (localPackages baseCtx) Nothing targetStrings
 
     buildCtx' <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do

--- a/cabal-install/Distribution/Client/CmdRun.hs
+++ b/cabal-install/Distribution/Client/CmdRun.hs
@@ -110,7 +110,7 @@ runAction (configFlags, configExFlags, installFlags, haddockFlags)
     baseCtx <- establishProjectBaseContext verbosity cliConfig
 
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-                   =<< readTargetSelectors (localPackages baseCtx)
+                   =<< readTargetSelectors (localPackages baseCtx) (Just ExeKind)
                          (take 1 targetStrings) -- Drop the exe's args.
 
     buildCtx <-

--- a/cabal-install/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/Distribution/Client/CmdSdist.hs
@@ -171,7 +171,7 @@ sdistAction SdistFlags{..} targetStrings globalFlags = do
     let localPkgs = localPackages baseCtx
 
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-        =<< readTargetSelectors localPkgs targetStrings
+        =<< readTargetSelectors localPkgs Nothing targetStrings
     
     mOutputPath' <- case mOutputPath of
         Just "-"  -> return (Just "-")

--- a/cabal-install/Distribution/Client/CmdTest.hs
+++ b/cabal-install/Distribution/Client/CmdTest.hs
@@ -87,7 +87,7 @@ testAction (configFlags, configExFlags, installFlags, haddockFlags)
     baseCtx <- establishProjectBaseContext verbosity cliConfig
 
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-                   =<< readTargetSelectors (localPackages baseCtx) targetStrings
+                   =<< readTargetSelectors (localPackages baseCtx) (Just TestKind) targetStrings
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do

--- a/cabal-install/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/Distribution/Client/TargetSelector.hs
@@ -203,6 +203,11 @@ instance Binary SubComponentTarget
 --
 readTargetSelectors :: [PackageSpecifier (SourcePackage (PackageLocation a))]
                     -> Maybe ComponentKindFilter
+                    -- ^ This parameter is used when there are ambiguous selectors.
+                    --   If it is 'Just', then we attempt to resolve ambiguitiy
+                    --   by applying it, since otherwise there is no way to allow
+                    --   contextually valid yet syntactically ambiguous selectors.
+                    --   (#4676, #5461)
                     -> [String]
                     -> IO (Either [TargetSelectorProblem] [TargetSelector])
 readTargetSelectors = readTargetSelectorsWith defaultDirActions

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,9 @@
 -*-change-log-*-
 
 2.4.0.0 (current development version)
+	* 'new-run', 'new-test', and 'new-bench' now will attempt to resolve
+	  ambiguous selectors by filtering out selectors that would be invalid.
+	  (#4679, #5460)
 	* 'new-install' now supports installing libraries and local
 	  components. (#5399)
 	* Drop support for GHC 7.4, since it is out of our support window

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -3,7 +3,7 @@
 2.4.0.0 (current development version)
 	* 'new-run', 'new-test', and 'new-bench' now will attempt to resolve
 	  ambiguous selectors by filtering out selectors that would be invalid.
-	  (#4679, #5460)
+	  (#4679, #5461)
 	* 'new-install' now supports installing libraries and local
 	  components. (#5399)
 	* Drop support for GHC 7.4, since it is out of our support window

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -150,6 +150,7 @@ testTargetSelectors reportSubCase = do
     (_, _, _, localPackages, _) <- configureProject testdir config
     let readTargetSelectors' = readTargetSelectorsWith (dirActions testdir)
                                                        localPackages
+                                                       Nothing
 
     reportSubCase "cwd"
     do Right ts <- readTargetSelectors' []
@@ -257,7 +258,7 @@ testTargetSelectorBadSyntax = do
                   , "foo:", "foo::bar"
                   , "foo: ", "foo: :bar"
                   , "a:b:c:d:e:f", "a:b:c:d:e:f:g:h" ]
-    Left errs <- readTargetSelectors localPackages targets
+    Left errs <- readTargetSelectors localPackages Nothing targets
     zipWithM_ (@?=) errs (map TargetSelectorUnrecognised targets)
     cleanProject testdir
   where
@@ -378,6 +379,7 @@ testTargetSelectorAmbiguous reportSubCase = do
       res <- readTargetSelectorsWith
                fakeDirActions
                (map SpecificSourcePackage pkgs)
+               Nothing
                [str]
       case res of
         Left [TargetSelectorAmbiguous _ tss'] ->
@@ -393,6 +395,7 @@ testTargetSelectorAmbiguous reportSubCase = do
       res <- readTargetSelectorsWith
                fakeDirActions
                (map SpecificSourcePackage pkgs)
+               Nothing
                [str]
       case res of
         Right [ts'] -> ts' @?= ts
@@ -472,6 +475,7 @@ testTargetSelectorNoCurrentPackage = do
     (_, _, _, localPackages, _) <- configureProject testdir config
     let readTargetSelectors' = readTargetSelectorsWith (dirActions testdir)
                                                        localPackages
+                                                       Nothing
         targets = [ "libs",  ":cwd:libs"
                   , "flibs", ":cwd:flibs"
                   , "exes",  ":cwd:exes"
@@ -492,7 +496,7 @@ testTargetSelectorNoCurrentPackage = do
 testTargetSelectorNoTargets :: Assertion
 testTargetSelectorNoTargets = do
     (_, _, _, localPackages, _) <- configureProject testdir config
-    Left errs <- readTargetSelectors localPackages []
+    Left errs <- readTargetSelectors localPackages Nothing []
     errs @?= [TargetSelectorNoTargetsInCwd]
     cleanProject testdir
   where
@@ -503,7 +507,7 @@ testTargetSelectorNoTargets = do
 testTargetSelectorProjectEmpty :: Assertion
 testTargetSelectorProjectEmpty = do
     (_, _, _, localPackages, _) <- configureProject testdir config
-    Left errs <- readTargetSelectors localPackages []
+    Left errs <- readTargetSelectors localPackages Nothing []
     errs @?= [TargetSelectorNoTargetsInProject]
     cleanProject testdir
   where


### PR DESCRIPTION
Closes #4676.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
