### PR TITLE
Fix bug in converting SolverInstallPlan to ElaboratedInstallPlan (fixes #5409).

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -77,6 +77,9 @@
     ([#5386](https://github.com/haskell/cabal/issues/5386)).
   * `Distribution.PackageDescription.Check.checkPackageFiles` now
     accepts a `Verbosity` argument.
+  * Added a parameter to
+    `Distribution.Backpack.ConfiguredComponent.toConfiguredComponent` in order to fix
+    [#5409](https://github.com/haskell/cabal/issues/5409).
 
 ----
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1199,12 +1199,12 @@ planPackages verbosity comp platform solver SolverSettings{..}
 -- By the way, we can tell that SolverInstallPlan is not the "right" type
 -- because a SolverId cannot adequately represent all possible dependency
 -- solver states: we may need to record foo-0.1 multiple times in
--- the solver install plan with different dependencies.  The solver probably
--- doesn't handle this correctly... but it should.  The right way to solve
--- this is to come up with something very much like a 'ConfiguredId', in that
--- it incorporates the version choices of its dependencies, but less
--- fine grained.  Fortunately, this doesn't seem to have affected anyone,
--- but it is good to watch out about.
+-- the solver install plan with different dependencies.  This imprecision in the
+-- type currently doesn't cause any problems because the dependency solver
+-- continues to enforce the single instance restriction regardless of compiler
+-- version.  The right way to solve this is to come up with something very much
+-- like a 'ConfiguredId', in that it incorporates the version choices of its
+-- dependencies, but less fine grained.
 
 
 -- | Produce an elaborated install plan using the policy for local builds with

--- a/cabal-testsuite/PackageTests/Regression/T5409/Main.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5409/Main.hs
@@ -1,0 +1,11 @@
+{-# OPTIONS_GHC -F -pgmF build-tool-exe #-}
+
+import BuildToolLibrary (buildToolLibraryVersion)
+
+main = do
+  putStrLn $ "build-tool library version: " ++ show buildToolLibraryVersion ++ ","
+  putStrLn $ "build-tool exe version: " ++ show buildToolExeVersion
+
+buildToolExeVersion :: Int
+buildToolExeVersion =
+    BUILD_TOOL_VERSION

--- a/cabal-testsuite/PackageTests/Regression/T5409/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T5409/cabal.project
@@ -1,0 +1,1 @@
+packages: *.cabal

--- a/cabal-testsuite/PackageTests/Regression/T5409/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T5409/pkg.cabal
@@ -1,0 +1,10 @@
+cabal-version: 2.2
+name: pkg
+version: 1.0
+build-type: Simple
+
+executable my-exe
+  main-is: Main.hs
+  build-depends: base, build-tool-pkg == 1
+  build-tool-depends: build-tool-pkg:build-tool-exe == 2
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-1/build-tool-pkg.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-1/build-tool-pkg.cabal
@@ -1,0 +1,15 @@
+name: build-tool-pkg
+version: 1
+build-type: Simple
+cabal-version: >= 1.20
+
+library
+  hs-source-dirs: src/
+  build-depends: base
+  exposed-modules: BuildToolLibrary
+  default-language: Haskell2010
+
+executable build-tool-exe
+  main-is: main/Main.hs
+  build-depends: base, build-tool-pkg
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-1/main/Main.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-1/main/Main.hs
@@ -1,0 +1,11 @@
+module Main where
+
+import BuildToolLibrary (buildToolLibraryVersion)
+import System.Environment
+
+main = do
+  (_:source:target:_) <- getArgs
+  writeFile target . unlines . map replaceVersion . lines =<< readFile source
+
+replaceVersion "    BUILD_TOOL_VERSION" = "    " ++ show buildToolLibraryVersion
+replaceVersion line                     = line

--- a/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-1/src/BuildToolLibrary.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-1/src/BuildToolLibrary.hs
@@ -1,0 +1,4 @@
+module BuildToolLibrary where
+
+buildToolLibraryVersion :: Int
+buildToolLibraryVersion = 1

--- a/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-2/build-tool-pkg.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-2/build-tool-pkg.cabal
@@ -1,0 +1,15 @@
+name: build-tool-pkg
+version: 2
+build-type: Simple
+cabal-version: >= 1.20
+
+library
+  hs-source-dirs: src/
+  build-depends: base
+  exposed-modules: BuildToolLibrary
+  default-language: Haskell2010
+
+executable build-tool-exe
+  main-is: main/Main.hs
+  build-depends: base, build-tool-pkg
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-2/main/Main.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-2/main/Main.hs
@@ -1,0 +1,11 @@
+module Main where
+
+import BuildToolLibrary (buildToolLibraryVersion)
+import System.Environment
+
+main = do
+  (_:source:target:_) <- getArgs
+  writeFile target . unlines . map replaceVersion . lines =<< readFile source
+
+replaceVersion "    BUILD_TOOL_VERSION" = "    " ++ show buildToolLibraryVersion
+replaceVersion line                     = line

--- a/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-2/src/BuildToolLibrary.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5409/repo/build-tool-pkg-2/src/BuildToolLibrary.hs
@@ -1,0 +1,4 @@
+module BuildToolLibrary where
+
+buildToolLibraryVersion :: Int
+buildToolLibraryVersion = 2

--- a/cabal-testsuite/PackageTests/Regression/T5409/use-different-versions-of-dependency-for-library-and-build-tool.out
+++ b/cabal-testsuite/PackageTests/Regression/T5409/use-different-versions-of-dependency-for-library-and-build-tool.out
@@ -1,0 +1,5 @@
+# cabal v1-update
+Downloading the latest package list from test-local-repo
+# pkg my-exe
+build-tool library version: 1,
+build-tool exe version: 2

--- a/cabal-testsuite/PackageTests/Regression/T5409/use-different-versions-of-dependency-for-library-and-build-tool.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5409/use-different-versions-of-dependency-for-library-and-build-tool.test.hs
@@ -1,0 +1,28 @@
+import Test.Cabal.Prelude
+
+-- The local package, pkg-1.0, depends on build-tool-pkg-1 as a library and
+-- build-tool-pkg-2 as a build-tool.  This test checks that cabal uses the
+-- correct version of build-tool-pkg for each purpose.  pkg imports a version
+-- number from the build-tool-pkg library and uses the build-tool-pkg executable
+-- as a preprocessor to insert the executable's version number into the source
+-- code.  Then the pkg executable prints out both versions.
+--
+-- Issue #5409 caused new-build to use the same instance of build-tool-pkg for
+-- the build-depends and build-tool-depends dependencies, even though it
+-- violated the version constraints.
+main = withShorterPathForNewBuildStore $ \storeDir ->
+  cabalTest $ do
+    skipUnless =<< hasNewBuildCompatBootCabal
+    withRepo "repo" $ do
+      r1 <- recordMode DoNotRecord $
+            cabalG' ["--store-dir=" ++ storeDir] "new-build" ["pkg:my-exe"]
+      let msg = "In order, the following will be built:"
+             ++ "  - build-tool-pkg-1 (lib) (requires download & build)"
+             ++ "  - build-tool-pkg-2 (lib) (requires download & build)"  -- dependency of build-tool-exe
+             ++ "  - build-tool-pkg-2 (exe:build-tool-exe) (requires download & build)"
+             ++ "  - pkg-1.0 (exe:my-exe) (first run)"
+      assertOutputContains msg r1
+      withPlan $ do
+        r2 <- runPlanExe' "pkg" "my-exe" []
+        assertOutputContains
+            "build-tool library version: 1, build-tool exe version: 2" r2


### PR DESCRIPTION
new-build had assumed that each component could only directly depend on one
version of each package.  However, a component can depend on two different
versions of a package by listing it as a build-depends and build-tool-depends
dependency.  The incorrect assumption caused new-build to mix up the two
instances of the dependency when converting the solver's package-based install
plan (SolverInstallPlan) to the component-based install plan
(ElaboratedInstallPlan).  This commit fixes the bug by keeping build-depends and
build-tool-depends dependencies separate between reading them from the
SolverPackage and passing them to
D.Backpack.ConfiguredComponent.toConfiguredComponent.

This commit changes the signature of
D.Backpack.ConfiguredComponent.toConfiguredComponent to allow distinguishing
between the two types of dependencies.


Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

________________________________________________________________________

/cc @ezyang @23Skidoo 

I'm not completely sure I understood the logic in D.C.ProjectPlanning.elaborateInstallPlan.  I also wasn't sure whether I should create a new function instead of adding a parameter to D.Backpack.ConfiguredComponent.toConfiguredComponent, for backwards compatibility.