### PR TITLE
outdated: accept --project-file

### DIFF
--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -1336,10 +1336,12 @@ The following flags are supported by the ``outdated`` command:
 ``--new-freeze-file``
     Read dependency version bounds from the new-style freeze file
     (``cabal.project.freeze``) instead of the package description file.
+    This is equivalent to ``--project-file cabal.project``.
 ``--project-file`` *PROJECTFILE*
     Read dependendency version bounds from the new-style freeze file
     related to the named project file (i.e., ``$PROJECTFILE.freeze``)
-    instead of the package desctription file.
+    instead of the package desctription file. If multiple ``--project-file``
+    flags are provided, only the final one is considered.
 ``--simple-output``
     Print only the names of outdated dependencies, one per line.
 ``--exit-code``

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -1338,11 +1338,13 @@ The following flags are supported by the ``outdated`` command:
     (by default, ``cabal.project.freeze``) instead of the package
     description file.
 ``--project-file`` *PROJECTFILE*
+    :since: 2.4
+
     Read dependendency version bounds from the new-style freeze file
     related to the named project file (i.e., ``$PROJECTFILE.freeze``)
     instead of the package desctription file. If multiple ``--project-file``
     flags are provided, only the final one is considered. This flag
-    must be passed in conjunction with ``--new-freeze-file``.
+    must only be passed in when ``--new-freeze-file`` is present.
 ``--simple-output``
     Print only the names of outdated dependencies, one per line.
 ``--exit-code``

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -1335,13 +1335,14 @@ The following flags are supported by the ``outdated`` command:
     instead of the package description file (``$PACKAGENAME.cabal``).
 ``--new-freeze-file``
     Read dependency version bounds from the new-style freeze file
-    (``cabal.project.freeze``) instead of the package description file.
-    This is equivalent to ``--project-file cabal.project``.
+    (by default, ``cabal.project.freeze``) instead of the package
+    description file.
 ``--project-file`` *PROJECTFILE*
     Read dependendency version bounds from the new-style freeze file
     related to the named project file (i.e., ``$PROJECTFILE.freeze``)
     instead of the package desctription file. If multiple ``--project-file``
-    flags are provided, only the final one is considered.
+    flags are provided, only the final one is considered. This flag
+    must be passed in conjunction with ``--new-freeze-file``.
 ``--simple-output``
     Print only the names of outdated dependencies, one per line.
 ``--exit-code``

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -1336,6 +1336,10 @@ The following flags are supported by the ``outdated`` command:
 ``--new-freeze-file``
     Read dependency version bounds from the new-style freeze file
     (``cabal.project.freeze``) instead of the package description file.
+``--project-file`` *PROJECTFILE*
+    Read dependendency version bounds from the new-style freeze file
+    related to the named project file (i.e., ``$PROJECTFILE.freeze``)
+    instead of the package desctription file.
 ``--simple-output``
     Print only the names of outdated dependencies, one per line.
 ``--exit-code``

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1100,6 +1100,7 @@ instance Semigroup IgnoreMajorVersionBumps where
 data OutdatedFlags = OutdatedFlags {
   outdatedVerbosity     :: Flag Verbosity,
   outdatedFreezeFile    :: Flag Bool,
+  outdatedNewFreezeFile :: Flag Bool,
   outdatedProjectFile   :: Flag FilePath,
   outdatedSimpleOutput  :: Flag Bool,
   outdatedExitCode      :: Flag Bool,
@@ -1112,6 +1113,7 @@ defaultOutdatedFlags :: OutdatedFlags
 defaultOutdatedFlags = OutdatedFlags {
   outdatedVerbosity     = toFlag normal,
   outdatedFreezeFile    = mempty,
+  outdatedNewFreezeFile = mempty,
   outdatedProjectFile   = mempty,
   outdatedSimpleOutput  = mempty,
   outdatedExitCode      = mempty,
@@ -1140,12 +1142,12 @@ outdatedCommand = CommandUI {
      trueArg
 
     ,option [] ["new-freeze-file"]
-     "Act on the new-style freeze file named cabal.project.freeze"
-     outdatedProjectFile (\_ flags -> flags { outdatedProjectFile = pure "cabal.project" })
-     (noArg mempty)
+     "Act on the new-style freeze file (default: cabal.project.freeze)"
+     outdatedNewFreezeFile (\v flags -> flags { outdatedNewFreezeFile = v })
+     trueArg
 
     ,option [] ["project-file"]
-     "Act on the new-style freeze file named PROJECTFILE.freeze"
+     "Act on the new-style freeze file named PROJECTFILE.freeze rather than the default cabal.project.freeze"
      outdatedProjectFile (\v flags -> flags { outdatedProjectFile = v })
      (reqArgFlag "PROJECTFILE")
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1100,7 +1100,7 @@ instance Semigroup IgnoreMajorVersionBumps where
 data OutdatedFlags = OutdatedFlags {
   outdatedVerbosity     :: Flag Verbosity,
   outdatedFreezeFile    :: Flag Bool,
-  outdatedNewFreezeFile :: Flag Bool,
+  outdatedProjectFile   :: Flag FilePath,
   outdatedSimpleOutput  :: Flag Bool,
   outdatedExitCode      :: Flag Bool,
   outdatedQuiet         :: Flag Bool,
@@ -1112,7 +1112,7 @@ defaultOutdatedFlags :: OutdatedFlags
 defaultOutdatedFlags = OutdatedFlags {
   outdatedVerbosity     = toFlag normal,
   outdatedFreezeFile    = mempty,
-  outdatedNewFreezeFile = mempty,
+  outdatedProjectFile   = mempty,
   outdatedSimpleOutput  = mempty,
   outdatedExitCode      = mempty,
   outdatedQuiet         = mempty,
@@ -1140,9 +1140,14 @@ outdatedCommand = CommandUI {
      trueArg
 
     ,option [] ["new-freeze-file"]
-     "Act on the new-style freeze file"
-     outdatedNewFreezeFile (\v flags -> flags { outdatedNewFreezeFile = v })
-     trueArg
+     "Act on the new-style freeze file named cabal.project.freeze"
+     outdatedProjectFile (\_ flags -> flags { outdatedProjectFile = pure "cabal.project" })
+     (noArg mempty)
+
+    ,option [] ["project-file"]
+     "Act on the new-style freeze file named PROJECTFILE.freeze"
+     outdatedProjectFile (\v flags -> flags { outdatedProjectFile = v })
+     (reqArgFlag "PROJECTFILE")
 
     ,option [] ["simple-output"]
      "Only print names of outdated dependencies, one per line"

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,8 @@
 -*-change-log-*-
 
 2.4.0.0 (current development version)
+        * 'outdated' now accepts '--project-file FILE', which will look for bounds
+          from the new-style freeze file named FILE.freeze.
 	* 'new-repl' now accepts a '--build-depends' flag which accepts the
 	  same syntax as is used in .cabal files to add additional dependencies
 	  to the environment when developing in the REPL. It is now usable outside

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -2,7 +2,8 @@
 
 2.4.0.0 (current development version)
         * 'outdated' now accepts '--project-file FILE', which will look for bounds
-          from the new-style freeze file named FILE.freeze.
+          from the new-style freeze file named FILE.freeze. This is only
+          available when `--new-freeze-file` has been passed.
 	* 'new-repl' now accepts a '--build-depends' flag which accepts the
 	  same syntax as is used in .cabal files to add additional dependencies
 	  to the environment when developing in the REPL. It is now usable outside

--- a/cabal-testsuite/PackageTests/Outdated/outdated-project-file.out
+++ b/cabal-testsuite/PackageTests/Outdated/outdated-project-file.out
@@ -1,0 +1,5 @@
+# cabal v1-update
+Downloading the latest package list from test-local-repo
+# cabal outdated
+Outdated dependencies:
+base ==3.0.3.2 (latest: 4.0.0.0)

--- a/cabal-testsuite/PackageTests/Outdated/outdated-project-file.out
+++ b/cabal-testsuite/PackageTests/Outdated/outdated-project-file.out
@@ -7,9 +7,4 @@ base ==3.0.3.2 (latest: 4.0.0.0)
 Outdated dependencies:
 base ==3.0.3.2 (latest: 4.0.0.0)
 # cabal outdated
-Outdated dependencies:
-base ==3.0.3.2 (latest: 4.0.0.0)
-# cabal outdated
-Outdated dependencies:
-base ==3.0.3.2 (latest: 4.0.0.0)
-template-haskell ==2.3.0.0 (latest: 2.4.0.0)
+cabal: --project-file must only be used with --new-freeze-file.

--- a/cabal-testsuite/PackageTests/Outdated/outdated-project-file.out
+++ b/cabal-testsuite/PackageTests/Outdated/outdated-project-file.out
@@ -3,3 +3,13 @@ Downloading the latest package list from test-local-repo
 # cabal outdated
 Outdated dependencies:
 base ==3.0.3.2 (latest: 4.0.0.0)
+# cabal outdated
+Outdated dependencies:
+base ==3.0.3.2 (latest: 4.0.0.0)
+# cabal outdated
+Outdated dependencies:
+base ==3.0.3.2 (latest: 4.0.0.0)
+# cabal outdated
+Outdated dependencies:
+base ==3.0.3.2 (latest: 4.0.0.0)
+template-haskell ==2.3.0.0 (latest: 2.4.0.0)

--- a/cabal-testsuite/PackageTests/Outdated/outdated-project-file.test.hs
+++ b/cabal-testsuite/PackageTests/Outdated/outdated-project-file.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+main = cabalTest $ withRepo "repo" $ do
+  res <- cabal' "outdated" ["--project-file", "variant.project"]
+  assertOutputContains "base" res
+  assertOutputDoesNotContain "template-haskell" res
+

--- a/cabal-testsuite/PackageTests/Outdated/outdated-project-file.test.hs
+++ b/cabal-testsuite/PackageTests/Outdated/outdated-project-file.test.hs
@@ -4,3 +4,15 @@ main = cabalTest $ withRepo "repo" $ do
   assertOutputContains "base" res
   assertOutputDoesNotContain "template-haskell" res
 
+  -- Test last-one-wins behaviour.
+  res <- cabal' "outdated" ["--project-file", "cabal.project", "--project-file", "variant.project"]
+  assertOutputContains "base" res
+  assertOutputDoesNotContain "template-haskell" res
+
+  res <- cabal' "outdated" ["--new-freeze-file", "--project-file", "variant.project"]
+  assertOutputContains "base" res
+  assertOutputDoesNotContain "template-haskell" res
+
+  res <- cabal' "outdated" ["--project-file", "variant.project", "--new-freeze-file"]
+  assertOutputContains "base" res
+  assertOutputContains "template-haskell" res

--- a/cabal-testsuite/PackageTests/Outdated/outdated-project-file.test.hs
+++ b/cabal-testsuite/PackageTests/Outdated/outdated-project-file.test.hs
@@ -1,18 +1,13 @@
 import Test.Cabal.Prelude
 main = cabalTest $ withRepo "repo" $ do
-  res <- cabal' "outdated" ["--project-file", "variant.project"]
-  assertOutputContains "base" res
-  assertOutputDoesNotContain "template-haskell" res
-
-  -- Test last-one-wins behaviour.
-  res <- cabal' "outdated" ["--project-file", "cabal.project", "--project-file", "variant.project"]
-  assertOutputContains "base" res
-  assertOutputDoesNotContain "template-haskell" res
-
   res <- cabal' "outdated" ["--new-freeze-file", "--project-file", "variant.project"]
   assertOutputContains "base" res
   assertOutputDoesNotContain "template-haskell" res
 
-  res <- cabal' "outdated" ["--project-file", "variant.project", "--new-freeze-file"]
+  -- Test last-one-wins behaviour.
+  res <- cabal' "outdated" ["--new-freeze-file", "--project-file", "cabal.project", "--project-file", "variant.project"]
   assertOutputContains "base" res
-  assertOutputContains "template-haskell" res
+  assertOutputDoesNotContain "template-haskell" res
+
+  -- Test for erroring on --project-file without --new-freeze-file
+  fails $ cabal "outdated" ["--project-file", "variant.project"]

--- a/cabal-testsuite/PackageTests/Outdated/variant.project
+++ b/cabal-testsuite/PackageTests/Outdated/variant.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/Outdated/variant.project.freeze
+++ b/cabal-testsuite/PackageTests/Outdated/variant.project.freeze
@@ -1,0 +1,1 @@
+constraints: base == 3.0.3.2


### PR DESCRIPTION
This doesn't get anywhere near the improvements suggested in #4831,
but it's a very respectable improvement over the status-quo for not
much effort.

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

New test added for this.