### PR TITLE
Add --only-explicit-packages to restrict the solver to a closed set.

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -1032,6 +1032,22 @@ The following settings control the behavior of the dependency solver:
       index-state: 2016-09-24T17:47:48Z
 
 
+.. cfg-field:: reject-unconstrained-dependencies: all, none
+               --reject-unconstrained-dependencies=[all|none]
+   :synopsis: Restrict the solver to packages that have constraints on them.
+
+   :default: none
+   :since: 2.6
+
+   By default, the dependency solver can include any package that it's
+   aware of in a build plan. If you wish to restrict the build plan to
+   a closed set of packages (e.g., from a freeze file), use this flag.
+
+   When set to `all`, all non-local packages that aren't goals must be
+   explicitly constrained. When set to `none`, the solver will
+   consider all packages.
+
+
 Package configuration options
 -----------------------------
 

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -253,6 +253,7 @@ instance Semigroup SavedConfig where
         installShadowPkgs            = combine installShadowPkgs,
         installStrongFlags           = combine installStrongFlags,
         installAllowBootLibInstalls  = combine installAllowBootLibInstalls,
+        installOnlyConstrained       = combine installOnlyConstrained,
         installReinstall             = combine installReinstall,
         installAvoidReinstalls       = combine installAvoidReinstalls,
         installOverrideReinstall     = combine installOverrideReinstall,

--- a/cabal-install/Distribution/Client/Fetch.hs
+++ b/cabal-install/Distribution/Client/Fetch.hs
@@ -168,6 +168,8 @@ planPackages verbosity comp platform fetchFlags
 
       . setAllowBootLibInstalls allowBootLibInstalls
 
+      . setOnlyConstrained onlyConstrained
+
       . setSolverVerbosity verbosity
 
       . addConstraints
@@ -200,6 +202,7 @@ planPackages verbosity comp platform fetchFlags
     strongFlags      = fromFlag (fetchStrongFlags      fetchFlags)
     maxBackjumps     = fromFlag (fetchMaxBackjumps     fetchFlags)
     allowBootLibInstalls = fromFlag (fetchAllowBootLibInstalls fetchFlags)
+    onlyConstrained  = fromFlag (fetchOnlyConstrained  fetchFlags)
 
 
 checkTarget :: Verbosity -> UserTarget -> IO ()

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -181,6 +181,8 @@ planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
 
       . setAllowBootLibInstalls allowBootLibInstalls
 
+      . setOnlyConstrained onlyConstrained
+
       . setSolverVerbosity verbosity
 
       . addConstraints
@@ -208,6 +210,7 @@ planPackages verbosity comp platform mSandboxPkgInfo freezeFlags
     strongFlags      = fromFlag (freezeStrongFlags      freezeFlags)
     maxBackjumps     = fromFlag (freezeMaxBackjumps     freezeFlags)
     allowBootLibInstalls = fromFlag (freezeAllowBootLibInstalls freezeFlags)
+    onlyConstrained  = fromFlag (freezeOnlyConstrained  freezeFlags)
 
 
 -- | Remove all unneeded packages from an install plan.

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -392,6 +392,8 @@ planPackages verbosity comp platform mSandboxPkgInfo solver
 
       . setAllowBootLibInstalls allowBootLibInstalls
 
+      . setOnlyConstrained onlyConstrained
+
       . setSolverVerbosity verbosity
 
       . setPreferenceDefault (if upgradeDeps then PreferAllLatest
@@ -454,6 +456,7 @@ planPackages verbosity comp platform mSandboxPkgInfo solver
     strongFlags      = fromFlag (installStrongFlags       installFlags)
     maxBackjumps     = fromFlag (installMaxBackjumps      installFlags)
     allowBootLibInstalls = fromFlag (installAllowBootLibInstalls installFlags)
+    onlyConstrained  = fromFlag (installOnlyConstrained   installFlags)
     upgradeDeps      = fromFlag (installUpgradeDeps       installFlags)
     onlyDeps         = fromFlag (installOnlyDeps          installFlags)
 

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -237,6 +237,7 @@ resolveSolverSettings ProjectConfig{
     solverSettingCountConflicts    = fromFlag projectConfigCountConflicts
     solverSettingStrongFlags       = fromFlag projectConfigStrongFlags
     solverSettingAllowBootLibInstalls = fromFlag projectConfigAllowBootLibInstalls
+    solverSettingOnlyConstrained   = fromFlag projectConfigOnlyConstrained
     solverSettingIndexState        = flagToMaybe projectConfigIndexState
     solverSettingIndependentGoals  = fromFlag projectConfigIndependentGoals
   --solverSettingShadowPkgs        = fromFlag projectConfigShadowPkgs
@@ -256,6 +257,7 @@ resolveSolverSettings ProjectConfig{
        projectConfigCountConflicts    = Flag (CountConflicts True),
        projectConfigStrongFlags       = Flag (StrongFlags False),
        projectConfigAllowBootLibInstalls = Flag (AllowBootLibInstalls False),
+       projectConfigOnlyConstrained   = Flag OnlyConstrainedNone,
        projectConfigIndependentGoals  = Flag (IndependentGoals False)
      --projectConfigShadowPkgs        = Flag False,
      --projectConfigReinstall         = Flag False,

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -342,7 +342,8 @@ convertLegacyAllPackageFlags globalFlags configFlags
       installIndependentGoals   = projectConfigIndependentGoals,
     --installShadowPkgs         = projectConfigShadowPkgs,
       installStrongFlags        = projectConfigStrongFlags,
-      installAllowBootLibInstalls = projectConfigAllowBootLibInstalls
+      installAllowBootLibInstalls = projectConfigAllowBootLibInstalls,
+      installOnlyConstrained    = projectConfigOnlyConstrained
     } = installFlags
 
 
@@ -556,6 +557,7 @@ convertToLegacySharedConfig
       installShadowPkgs        = mempty, --projectConfigShadowPkgs,
       installStrongFlags       = projectConfigStrongFlags,
       installAllowBootLibInstalls = projectConfigAllowBootLibInstalls,
+      installOnlyConstrained   = projectConfigOnlyConstrained,
       installOnly              = mempty,
       installOnlyDeps          = projectConfigOnlyDeps,
       installIndexState        = projectConfigIndexState,
@@ -916,7 +918,7 @@ legacySharedConfigFieldDescrs =
       , "one-shot", "jobs", "keep-going", "offline", "per-component"
         -- solver flags:
       , "max-backjumps", "reorder-goals", "count-conflicts", "independent-goals"
-      , "strong-flags" , "allow-boot-library-installs", "index-state"
+      , "strong-flags" , "allow-boot-library-installs", "reject-unconstrained-dependencies", "index-state"
       ]
   . commandOptionsToFields
   ) (installOptions ParseArgs)

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -191,6 +191,7 @@ data ProjectConfigShared
        projectConfigCountConflicts    :: Flag CountConflicts,
        projectConfigStrongFlags       :: Flag StrongFlags,
        projectConfigAllowBootLibInstalls :: Flag AllowBootLibInstalls,
+       projectConfigOnlyConstrained   :: Flag OnlyConstrained,
        projectConfigPerComponent      :: Flag Bool,
        projectConfigIndependentGoals  :: Flag IndependentGoals,
 
@@ -372,6 +373,7 @@ data SolverSettings
        solverSettingCountConflicts    :: CountConflicts,
        solverSettingStrongFlags       :: StrongFlags,
        solverSettingAllowBootLibInstalls :: AllowBootLibInstalls,
+       solverSettingOnlyConstrained   :: OnlyConstrained,
        solverSettingIndexState        :: Maybe IndexState,
        solverSettingIndependentGoals  :: IndependentGoals
        -- Things that only make sense for manual mode, not --local mode

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -960,6 +960,8 @@ planPackages verbosity comp platform solver SolverSettings{..}
 
       . setAllowBootLibInstalls solverSettingAllowBootLibInstalls
 
+      . setOnlyConstrained solverSettingOnlyConstrained
+
       . setSolverVerbosity verbosity
 
         --TODO: [required eventually] decide if we need to prefer

--- a/cabal-install/Distribution/Solver/Modular.hs
+++ b/cabal-install/Distribution/Solver/Modular.hs
@@ -1,5 +1,5 @@
 module Distribution.Solver.Modular
-         ( modularResolver, SolverConfig(..), PruneAfterFirstSuccess(..)) where
+         ( modularResolver, SolverConfig(..), PruneAfterFirstSuccess(..) ) where
 
 -- Here, we try to map between the external cabal-install solver
 -- interface and the internal interface that the solver actually

--- a/cabal-install/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install/Distribution/Solver/Modular/Message.hs
@@ -115,6 +115,7 @@ showFR _ (PackageRequiresMissingComponent qpn comp) = " (requires " ++ showExpos
 showFR _ (PackageRequiresUnbuildableComponent qpn comp) = " (requires " ++ showExposedComponent comp ++ " from " ++ showQPN qpn ++ ", but the component is not buildable in the current environment)"
 showFR _ CannotInstall                    = " (only already installed instances can be used)"
 showFR _ CannotReinstall                  = " (avoiding to reinstall a package with same version but new dependencies)"
+showFR _ NotExplicit                      = " (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set)"
 showFR _ Shadowed                         = " (shadowed by another installed package with same version)"
 showFR _ Broken                           = " (package is broken)"
 showFR _ (GlobalConstraintVersion vr src) = " (" ++ constraintSource src ++ " requires " ++ display vr ++ ")"

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -13,6 +13,7 @@ module Distribution.Solver.Modular.Preference
     , preferPackagePreferences
     , preferReallyEasyGoalChoices
     , requireInstalled
+    , onlyConstrained
     , sortGoals
     , pruneAfterFirstSuccess
     ) where
@@ -336,6 +337,15 @@ avoidReinstalls p = trav go
         notReinstall _ _ x =
           x
     go x          = x
+
+-- | Require all packages to be mentioned in a constraint or as a goal.
+onlyConstrained :: (PN -> Bool) -> Tree d QGoalReason -> Tree d QGoalReason
+onlyConstrained p = trav go
+  where
+    go (PChoiceF v@(Q _ pn) _ gr _) | not (p pn)
+      = FailF (varToConflictSet (P v) `CS.union` goalReasonToCS gr) NotExplicit
+    go x
+      = x
 
 -- | Sort all goals using the provided function.
 sortGoals :: (Variable QPN -> Variable QPN -> Ordering) -> Tree d c -> Tree d c

--- a/cabal-install/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install/Distribution/Solver/Modular/Tree.hs
@@ -106,6 +106,7 @@ data FailReason = UnsupportedExtension Extension
                 | PackageRequiresUnbuildableComponent QPN ExposedComponent
                 | CannotInstall
                 | CannotReinstall
+                | NotExplicit
                 | Shadowed
                 | Broken
                 | GlobalConstraintVersion VR ConstraintSource

--- a/cabal-install/Distribution/Solver/Types/Settings.hs
+++ b/cabal-install/Distribution/Solver/Types/Settings.hs
@@ -7,6 +7,7 @@ module Distribution.Solver.Types.Settings
     , ShadowPkgs(..)
     , StrongFlags(..)
     , AllowBootLibInstalls(..)
+    , OnlyConstrained(..)
     , EnableBackjumping(..)
     , CountConflicts(..)
     , SolveExecutables(..)
@@ -14,7 +15,12 @@ module Distribution.Solver.Types.Settings
 
 import Distribution.Simple.Setup ( BooleanFlag(..) )
 import Distribution.Compat.Binary (Binary(..))
+import Distribution.Pretty ( Pretty(pretty) )
+import Distribution.Text ( Text(parse) )
 import GHC.Generics (Generic)
+
+import qualified Distribution.Compat.ReadP as Parse
+import qualified Text.PrettyPrint as PP
 
 newtype ReorderGoals = ReorderGoals Bool
   deriving (BooleanFlag, Eq, Generic, Show)
@@ -37,6 +43,13 @@ newtype StrongFlags = StrongFlags Bool
 newtype AllowBootLibInstalls = AllowBootLibInstalls Bool
   deriving (BooleanFlag, Eq, Generic, Show)
 
+-- | Should we consider all packages we know about, or only those that
+-- have constraints explicitly placed on them or which are goals?
+data OnlyConstrained
+  = OnlyConstrainedNone
+  | OnlyConstrainedAll
+  deriving (Eq, Generic, Show)
+
 newtype EnableBackjumping = EnableBackjumping Bool
   deriving (BooleanFlag, Eq, Generic, Show)
 
@@ -50,4 +63,16 @@ instance Binary AvoidReinstalls
 instance Binary ShadowPkgs
 instance Binary StrongFlags
 instance Binary AllowBootLibInstalls
+instance Binary OnlyConstrained
 instance Binary SolveExecutables
+
+instance Pretty OnlyConstrained where
+  pretty OnlyConstrainedAll = PP.text "all"
+  pretty OnlyConstrainedNone = PP.text "none"
+
+instance Text OnlyConstrained where
+  parse = Parse.choice
+    [ Parse.string "all" >> return OnlyConstrainedAll
+    , Parse.string "none" >> return OnlyConstrainedNone
+    ]
+

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,9 @@
 -*-change-log-*-
 
-2.4.0.0 (current development version)
+2.6.0.0 (current development version)
+	* New solver flag: '--reject-unconstrained-dependencies'. (#2568)
+
+2.4.0.0
 	* 'new-run' now allows the user to run scripts that use a special block
 	  to define their requirements (as in the executable stanza) in place
 	  of a target. This also allows the use of 'cabal' as an interpreter

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -436,6 +436,7 @@ instance Arbitrary ProjectConfigShared where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
+        <*> arbitrary
         <*> (toNubList <$> listOf arbitraryShortToken)
       where
         arbitraryConstraints :: Gen [(UserConstraint, ConstraintSource)]
@@ -462,10 +463,11 @@ instance Arbitrary ProjectConfigShared where
                                , projectConfigCountConflicts = x17
                                , projectConfigStrongFlags = x18
                                , projectConfigAllowBootLibInstalls = x19
-                               , projectConfigPerComponent = x20
-                               , projectConfigIndependentGoals = x21
-                               , projectConfigConfigFile = x22
-                               , projectConfigProgPathExtra = x23} =
+                               , projectConfigOnlyConstrained = x20
+                               , projectConfigPerComponent = x21
+                               , projectConfigIndependentGoals = x22
+                               , projectConfigConfigFile = x23
+                               , projectConfigProgPathExtra = x24} =
       [ ProjectConfigShared { projectConfigDistDir = x00'
                             , projectConfigProjectFile = x01'
                             , projectConfigHcFlavor = x02'
@@ -486,21 +488,22 @@ instance Arbitrary ProjectConfigShared where
                             , projectConfigCountConflicts = x17'
                             , projectConfigStrongFlags = x18'
                             , projectConfigAllowBootLibInstalls = x19'
-                            , projectConfigPerComponent = x20'
-                            , projectConfigIndependentGoals = x21'
-                            , projectConfigConfigFile = x22'
-                            , projectConfigProgPathExtra = x23'}
+                            , projectConfigOnlyConstrained = x20'
+                            , projectConfigPerComponent = x21'
+                            , projectConfigIndependentGoals = x22'
+                            , projectConfigConfigFile = x23'
+                            , projectConfigProgPathExtra = x24'}
       | ((x00', x01', x02', x03', x04'),
          (x05', x06', x07', x08', x09'),
          (x10', x11', x12', x13', x14'),
          (x15', x16', x17', x18', x19'),
-          x20', x21', x22', x23')
+          x20', x21', x22', x23', x24')
           <- shrink
                ((x00, x01, x02, fmap NonEmpty x03, fmap NonEmpty x04),
                 (x05, x06, x07, x08, preShrink_Constraints x09),
                 (x10, x11, x12, x13, x14),
                 (x15, x16, x17, x18, x19),
-                 x20, x21, x22, x23)
+                 x20, x21, x22, x23, x24)
       ]
       where
         preShrink_Constraints  = map fst
@@ -810,6 +813,11 @@ instance Arbitrary StrongFlags where
 
 instance Arbitrary AllowBootLibInstalls where
     arbitrary = AllowBootLibInstalls <$> arbitrary
+
+instance Arbitrary OnlyConstrained where
+    arbitrary = oneof [ pure OnlyConstrainedAll
+                      , pure OnlyConstrainedNone
+                      ]
 
 instance Arbitrary AllowNewer where
     arbitrary = AllowNewer <$> arbitrary

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -648,6 +648,7 @@ exResolve :: ExampleDb
           -> IndependentGoals
           -> ReorderGoals
           -> AllowBootLibInstalls
+          -> OnlyConstrained
           -> EnableBackjumping
           -> SolveExecutables
           -> Maybe (Variable P.QPN -> Variable P.QPN -> Ordering)
@@ -657,7 +658,7 @@ exResolve :: ExampleDb
           -> EnableAllTests
           -> Progress String String CI.SolverInstallPlan.SolverInstallPlan
 exResolve db exts langs pkgConfigDb targets mbj countConflicts indepGoals
-          reorder allowBootLibInstalls enableBj solveExes goalOrder constraints
+          reorder allowBootLibInstalls onlyConstrained enableBj solveExes goalOrder constraints
           prefs verbosity enableAllTests
     = resolveDependencies C.buildPlatform compiler pkgConfigDb Modular params
   where
@@ -686,6 +687,7 @@ exResolve db exts langs pkgConfigDb targets mbj countConflicts indepGoals
                    $ setReorderGoals reorder
                    $ setMaxBackjumps mbj
                    $ setAllowBootLibInstalls allowBootLibInstalls
+                   $ setOnlyConstrained onlyConstrained
                    $ setEnableBackjumping enableBj
                    $ setSolveExecutables solveExes
                    $ setGoalOrder goalOrder

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
@@ -6,6 +6,7 @@ module UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils (
   , maxBackjumps
   , independentGoals
   , allowBootLibInstalls
+  , onlyConstrained
   , disableBackjumping
   , disableSolveExecutables
   , goalOrder
@@ -61,6 +62,10 @@ allowBootLibInstalls :: SolverTest -> SolverTest
 allowBootLibInstalls test =
     test { testAllowBootLibInstalls = AllowBootLibInstalls True }
 
+onlyConstrained :: SolverTest -> SolverTest
+onlyConstrained test =
+    test { testOnlyConstrained = OnlyConstrainedAll }
+
 disableBackjumping :: SolverTest -> SolverTest
 disableBackjumping test =
     test { testEnableBackjumping = EnableBackjumping False }
@@ -97,6 +102,7 @@ data SolverTest = SolverTest {
   , testMaxBackjumps         :: Maybe Int
   , testIndepGoals           :: IndependentGoals
   , testAllowBootLibInstalls :: AllowBootLibInstalls
+  , testOnlyConstrained      :: OnlyConstrained
   , testEnableBackjumping    :: EnableBackjumping
   , testSolveExecutables     :: SolveExecutables
   , testGoalOrder            :: Maybe [ExampleVar]
@@ -191,6 +197,7 @@ mkTestExtLangPC exts langs pkgConfigDb db label targets result = SolverTest {
   , testMaxBackjumps         = Nothing
   , testIndepGoals           = IndependentGoals False
   , testAllowBootLibInstalls = AllowBootLibInstalls False
+  , testOnlyConstrained      = OnlyConstrainedNone
   , testEnableBackjumping    = EnableBackjumping True
   , testSolveExecutables     = SolveExecutables True
   , testGoalOrder            = Nothing
@@ -211,7 +218,7 @@ runTest SolverTest{..} = askOption $ \(OptionShowSolverLog showSolverLog) ->
                      testSupportedLangs testPkgConfigDb testTargets
                      testMaxBackjumps (CountConflicts True) testIndepGoals
                      (ReorderGoals False) testAllowBootLibInstalls
-                     testEnableBackjumping testSolveExecutables
+                     testOnlyConstrained testEnableBackjumping testSolveExecutables
                      (sortGoals <$> testGoalOrder) testConstraints
                      testSoftConstraints testVerbosity testEnableAllTests
           printMsg msg = when showSolverLog $ putStrLn msg

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -144,7 +144,7 @@ solve enableBj reorder countConflicts indep goalOrder test =
                   -- too much time and memory.
                   (Just defaultMaxBackjumps)
                   countConflicts indep reorder (AllowBootLibInstalls False)
-                  enableBj (SolveExecutables True) (unVarOrdering <$> goalOrder)
+                  OnlyConstrainedNone enableBj (SolveExecutables True) (unVarOrdering <$> goalOrder)
                   (testConstraints test) (testPreferences test) normal
                   (EnableAllTests False)
 

--- a/cabal-testsuite/PackageTests/RequireExplicit/FlagInProject/a.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/FlagInProject/a.cabal
@@ -1,0 +1,7 @@
+cabal-version: 2.2
+name: a
+version: 0
+
+library
+  build-depends:
+    some-lib

--- a/cabal-testsuite/PackageTests/RequireExplicit/FlagInProject/cabal.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/FlagInProject/cabal.project
@@ -1,0 +1,3 @@
+packages:
+  ./
+reject-unconstrained-dependencies: all

--- a/cabal-testsuite/PackageTests/RequireExplicit/FlagInProject/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/RequireExplicit/FlagInProject/cabal.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+-- See #4332, dep solving output is not deterministic
+main = cabalTest . recordMode DoNotRecord $ withRepo "../repo" $ do
+  -- other-lib is a dependency, but it's not listed in cabal.project
+  res <- fails $ cabal' "new-build" ["all", "--dry-run"]
+  assertOutputContains "not a user-provided goal" res

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/a/a.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/a/a.cabal
@@ -1,0 +1,8 @@
+cabal-version: 2.2
+name: a
+version: 0
+
+library
+  build-depends:
+    some-lib,
+    b

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/b/b.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/b/b.cabal
@@ -1,0 +1,10 @@
+cabal-version: 2.2
+name: b
+version: 0
+
+library
+  build-tool-depends:
+    some-exe:some-exe -any
+  build-depends:
+    some-lib,
+    other-lib

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.project
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.project
@@ -1,0 +1,6 @@
+packages:
+  ./a
+  ./b
+
+constraints:
+  some-lib -any

--- a/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/RequireExplicit/MultiPkg/cabal.test.hs
@@ -1,0 +1,16 @@
+import Test.Cabal.Prelude
+-- See #4332, dep solving output is not deterministic
+main = cabalTest . recordMode DoNotRecord $ withRepo "../repo" $ do
+  -- other-lib is a dependency of b, but it's not listed in cabal.project
+  res <- fails $ cabal' "new-build" ["all", "--dry-run", "--reject-unconstrained-dependencies", "all", "--constraint", "some-exe -any"]
+  assertOutputContains "not a user-provided goal" res
+
+  -- and some-exe is a build-tool dependency of b, again not listed
+  res <- fails $ cabal' "new-build" ["all", "--dry-run", "--reject-unconstrained-dependencies", "all", "--constraint", "other-lib -any"]
+  assertOutputContains "not a user-provided goal" res
+
+  -- everything's listed, good to go
+  cabal "new-build" ["all", "--dry-run", "--reject-unconstrained-dependencies", "all", "--constraint", "other-lib -any", "--constraint", "some-exe -any"]
+
+  -- a depends on b, but b is a local dependency, so it gets a pass
+  cabal "new-build" ["a", "--dry-run", "--reject-unconstrained-dependencies", "all", "--constraint", "other-lib -any", "--constraint", "some-exe -any"]

--- a/cabal-testsuite/PackageTests/RequireExplicit/repo/other-lib-1.0/other-lib.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/repo/other-lib-1.0/other-lib.cabal
@@ -1,0 +1,7 @@
+cabal-version: 2.2
+name: other-lib
+version: 1.0
+
+library
+  exposed-modules:
+    Foo

--- a/cabal-testsuite/PackageTests/RequireExplicit/repo/some-exe-1.0/some-exe.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/repo/some-exe-1.0/some-exe.cabal
@@ -1,0 +1,6 @@
+cabal-version: 2.2
+name: some-exe
+version: 1.0
+
+executable some-exe
+  main-is: Foo.hs

--- a/cabal-testsuite/PackageTests/RequireExplicit/repo/some-lib-1.0/some-lib.cabal
+++ b/cabal-testsuite/PackageTests/RequireExplicit/repo/some-lib-1.0/some-lib.cabal
@@ -1,0 +1,7 @@
+cabal-version: 2.2
+name: some-lib
+version: 1.0
+
+library
+  exposed-modules:
+    Foo


### PR DESCRIPTION
Previously, even with freeze files, there was no good way to instruct
cabal-install to avoid pulling in extra, unconstrained
packages. `--only-explicit-packages` forces the solver to stay within
the set of packages that are either explicit goals, or which are
explicitly constrained in configuration files or via the
`--constraint` flag.

Closes #2568.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
