### PR TITLE
Set abiDepends field in IPI to []

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -80,6 +80,8 @@
   * Added a parameter to
     `Distribution.Backpack.ConfiguredComponent.toConfiguredComponent` in order to fix
     [#5409](https://github.com/haskell/cabal/issues/5409).
+  * Partially silence `abi-depends` warnings
+    ([#5465](https://github.com/haskell/cabal/issues/5465)).
 
 ----
 

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -437,7 +437,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     IPI.includeDirs        = absinc ++ adjustRelIncDirs relinc,
     IPI.includes           = includes bi,
     IPI.depends            = depends,
-    IPI.abiDepends         = abi_depends,
+    IPI.abiDepends         = [], -- due to #5465
     IPI.ccOptions          = [], -- Note. NOT ccOptions bi!
                                  -- We don't want cc-options to be propagated
                                  -- to C compilations in other packages.
@@ -458,13 +458,6 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     --TODO: unclear what the root cause of the
     -- duplication is, but we nub it here for now:
     depends = ordNub $ map fst (componentPackageDeps clbi)
-    abi_depends = map add_abi depends
-    add_abi uid = IPI.AbiDependency uid abi
-      where
-        abi = case Index.lookupUnitId (installedPkgs lbi) uid of
-                Nothing -> error $
-                  "generalInstalledPackageInfo: missing IPI for " ++ display uid
-                Just ipi -> IPI.abiHash ipi
     (absinc, relinc) = partition isAbsolute (includeDirs bi)
     hasModules = not $ null (allLibModules lib clbi)
     comp = compiler lbi


### PR DESCRIPTION
Resolves #5465

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

I have tried to `new-build` one personal package, and the output was without any `abi-depends` related warnings. However, when I was using `new-install` on the same package, the warnings were still printed out. So this is not the complete fix of the task, but I don't know what can be done about that.