### PR TITLE
outdated: accept v1/v2 aliases for freeze-file flags

### DIFF
--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -1333,10 +1333,12 @@ The following flags are supported by the ``outdated`` command:
 ``--freeze-file``
     Read dependency version bounds from the freeze file (``cabal.config``)
     instead of the package description file (``$PACKAGENAME.cabal``).
+    ``--v1-freeze-file`` is an alias for this flag starting in Cabal 2.4.
 ``--new-freeze-file``
     Read dependency version bounds from the new-style freeze file
     (by default, ``cabal.project.freeze``) instead of the package
-    description file.
+    description file. ``--v2-freeze-file`` is an alias for this flag
+    starting in Cabal 2.4.
 ``--project-file`` *PROJECTFILE*
     :since: 2.4
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1166,12 +1166,12 @@ outdatedCommand = CommandUI {
     optionVerbosity outdatedVerbosity
       (\v flags -> flags { outdatedVerbosity = v })
 
-    ,option [] ["freeze-file"]
+    ,option [] ["freeze-file", "v1-freeze-file"]
      "Act on the freeze file"
      outdatedFreezeFile (\v flags -> flags { outdatedFreezeFile = v })
      trueArg
 
-    ,option [] ["new-freeze-file"]
+    ,option [] ["new-freeze-file", "v2-freeze-file"]
      "Act on the new-style freeze file (default: cabal.project.freeze)"
      outdatedNewFreezeFile (\v flags -> flags { outdatedNewFreezeFile = v })
      trueArg

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -31,6 +31,8 @@
 	* Add 'v1-' prefixes for the commands that will be replaced in the
 	new-build universe, in preparation for it becoming the default.
 	(#5358)
+	* 'outdated' accepts '--v1-freeze-file' and '--v2-freeze-file'
+	in the same spirit.
 	* Completed the 'new-clean' command (#5357). The functionality is
 	equivalent to old-style clean, but for nix-style builds.
 	* Ensure that each package selected for a build-depends dependency


### PR DESCRIPTION
As suggested in #5474.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
