### PR TITLE
Extend packages in plan.json with pkg-src field

### DIFF
--- a/Cabal/doc/conf.py
+++ b/Cabal/doc/conf.py
@@ -15,7 +15,7 @@ import cabaldomain
 
 version = "2.5.0.0"
 
-extensions = ['sphinx.ext.extlinks']
+extensions = ['sphinx.ext.extlinks', 'sphinx.ext.todo']
 
 templates_path = ['_templates']
 source_suffix = '.rst'
@@ -120,6 +120,8 @@ latex_logo = 'images/logo.pdf'
 # If true, show page references after internal links.
 latex_show_pagerefs = True
 
+# http://www.sphinx-doc.org/en/master/usage/extensions/todo.html
+todo_include_todos = True
 
 # -- Options for manual page output ---------------------------------------
 

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -235,12 +235,28 @@ this folder (the most important two are first):
 ``improved-plan`` (binary)
     Like ``solver-plan``, but with all non-inplace packages improved
     into pre-existing copies from the store.
+``plan.json`` (JSON)
+    A JSON serialization of the computed install plan intended
+    for integrating ``cabal`` with external tooling.
+    The `cabal-plan <http://hackage.haskell.org/package/cabal-plan>`__
+    package provides a library for parsing ``plan.json`` files into a
+    Haskell data structure as well as an example tool showing possible
+    applications.
+
+    .. todo::
+
+        Document JSON schema (including version history of schema)
+
 
 Note that every package also has a local cache managed by the Cabal
 build system, e.g., in ``$distdir/cache``.
 
-There is another useful file in ``dist-newstyle/cache``, ``plan.json``,
-which is a JSON serialization of the computed install plan. (TODO: docs)
+There is another useful file in ``dist-newstyle/cache``,
+``plan.json``, which is a JSON serialization of the computed install
+plan and is intended for integrating with external tooling.
+
+
+
 
 Commands
 ========

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -211,8 +211,7 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
 
       sourceRepoToJ :: PD.SourceRepo -> J.Value
       sourceRepoToJ PD.SourceRepo{..} =
-        J.object [ "kind"     J..= jdisplay repoKind
-                 , "type"     J..= fmap jdisplay repoType
+        J.object [ "type"     J..= fmap jdisplay repoType
                  , "location" J..= fmap J.String repoLocation
                  , "module"   J..= fmap J.String repoModule
                  , "branch"   J..= fmap J.String repoBranch

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -211,13 +211,14 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
 
       sourceRepoToJ :: PD.SourceRepo -> J.Value
       sourceRepoToJ PD.SourceRepo{..} =
-        J.object [ "type"     J..= fmap jdisplay repoType
-                 , "location" J..= fmap J.String repoLocation
-                 , "module"   J..= fmap J.String repoModule
-                 , "branch"   J..= fmap J.String repoBranch
-                 , "tag"      J..= fmap J.String repoTag
-                 , "subdir"   J..= fmap J.String repoSubdir
-                 ]
+        J.object $ filter ((/= J.Null) . snd) $
+          [ "type"     J..= fmap jdisplay repoType
+          , "location" J..= fmap J.String repoLocation
+          , "module"   J..= fmap J.String repoModule
+          , "branch"   J..= fmap J.String repoBranch
+          , "tag"      J..= fmap J.String repoTag
+          , "subdir"   J..= fmap J.String repoSubdir
+          ]
 
       dist_dir = distBuildDirectory distDirLayout
                     (elabDistDirParams elaboratedSharedConfig elab)

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -198,17 +198,16 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
         case repo of
           RepoLocal{..} ->
             J.object [ "type" J..= J.String "local-repo"
-                     , "path" J..= J.String repoLocalDir
                      ]
           RepoRemote{..} ->
-            J.object [ "type"   J..= J.String "remote-repo"
-                     , "path"   J..= J.String repoLocalDir
-                     , "remote" J..= J.String (remoteRepoName repoRemote)
+            J.object [ "type" J..= J.String "remote-repo"
+                     , "name" J..= J.String (remoteRepoName repoRemote)
+                     , "uri"  J..= J.String (show (remoteRepoURI repoRemote))
                      ]
           RepoSecure{..} ->
-            J.object [ "type"   J..= J.String "secure-repo"
-                     , "path"   J..= J.String repoLocalDir
-                     , "remote" J..= J.String (remoteRepoName repoRemote)
+            J.object [ "type" J..= J.String "secure-repo"
+                     , "name" J..= J.String (remoteRepoName repoRemote)
+                     , "uri"  J..= J.String (show (remoteRepoURI repoRemote))
                      ]
 
       sourceRepoToJ :: PD.SourceRepo -> J.Value

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -177,15 +177,15 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
                      , "path" J..= J.String local
                      ]
           LocalTarballPackage local ->
-            J.object [ "type" J..= J.String "local-tarball"
+            J.object [ "type" J..= J.String "local-tar"
                      , "path" J..= J.String local
                      ]
           RemoteTarballPackage uri _ ->
-            J.object [ "type" J..= J.String "remote-tarball"
+            J.object [ "type" J..= J.String "remote-tar"
                      , "uri"  J..= J.String (show uri)
                      ]
           RepoTarballPackage repo _ _ ->
-            J.object [ "type" J..= J.String "repo-tarball"
+            J.object [ "type" J..= J.String "repo-tar"
                      , "repo" J..= repoToJ repo
                      ]
           RemoteSourceRepoPackage srcRepo _ ->

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -18,7 +18,7 @@ module Distribution.Client.ProjectPlanOutput (
 import           Distribution.Client.ProjectPlanning.Types
 import           Distribution.Client.ProjectBuilding.Types
 import           Distribution.Client.DistDirLayout
-import           Distribution.Client.Types (confInstId)
+import           Distribution.Client.Types (Repo(..), RemoteRepo(..), PackageLocation(..), confInstId)
 import           Distribution.Client.PackageHash (showHashValue)
 
 import qualified Distribution.Client.InstallPlan as InstallPlan
@@ -139,6 +139,7 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
         , "flags"      J..= J.object [ PD.unFlagName fn J..= v
                                      | (fn,v) <- PD.unFlagAssignment (elabFlagAssignment elab) ]
         , "style"      J..= J.String (style2str (elabLocalToProject elab) (elabBuildStyle elab))
+        , "pkg-src"    J..= packageLocationToJ (elabPkgSourceLocation elab)
         ] ++
         [ "pkg-src-sha256" J..= J.String (showHashValue hash)
         | Just hash <- [elabPkgSourceHash elab] ] ++
@@ -168,6 +169,59 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
             ] ++
             bin_file (compSolverName comp)
      where
+      packageLocationToJ :: PackageLocation (Maybe FilePath) -> J.Value
+      packageLocationToJ pkgloc =
+        case pkgloc of
+          LocalUnpackedPackage local ->
+            J.object [ "type" J..= J.String "local"
+                     , "path" J..= J.String local
+                     ]
+          LocalTarballPackage local ->
+            J.object [ "type" J..= J.String "local-tarball"
+                     , "path" J..= J.String local
+                     ]
+          RemoteTarballPackage uri _ ->
+            J.object [ "type" J..= J.String "remote-tarball"
+                     , "uri"  J..= J.String (show uri)
+                     ]
+          RepoTarballPackage repo _ _ ->
+            J.object [ "type" J..= J.String "repo-tarball"
+                     , "repo" J..= repoToJ repo
+                     ]
+          RemoteSourceRepoPackage srcRepo _ ->
+            J.object [ "type" J..= J.String "source-repo"
+                     , "source-repo" J..= sourceRepoToJ srcRepo
+                     ]
+
+      repoToJ :: Repo -> J.Value
+      repoToJ repo =
+        case repo of
+          RepoLocal{..} ->
+            J.object [ "type" J..= J.String "local-repo"
+                     , "path" J..= J.String repoLocalDir
+                     ]
+          RepoRemote{..} ->
+            J.object [ "type"   J..= J.String "remote-repo"
+                     , "path"   J..= J.String repoLocalDir
+                     , "remote" J..= J.String (remoteRepoName repoRemote)
+                     ]
+          RepoSecure{..} ->
+            J.object [ "type"   J..= J.String "secure-repo"
+                     , "path"   J..= J.String repoLocalDir
+                     , "remote" J..= J.String (remoteRepoName repoRemote)
+                     ]
+
+      sourceRepoToJ :: PD.SourceRepo -> J.Value
+      sourceRepoToJ PD.SourceRepo{..} =
+        J.object [ "kind"     J..= jdisplay repoKind
+                 , "type"     J..= fmap jdisplay repoType
+                 , "location" J..= fmap J.String repoLocation
+                 , "module"   J..= fmap J.String repoModule
+                 , "branch"   J..= fmap J.String repoBranch
+                 , "tag"      J..= fmap J.String repoTag
+                 , "subdir"   J..= fmap J.String repoSubdir
+                 ]
+
       dist_dir = distBuildDirectory distDirLayout
                     (elabDistDirParams elaboratedSharedConfig elab)
 
@@ -510,7 +564,7 @@ postBuildProjectStatus plan previousPackagesUpToDate
       Graph.revClosure packagesLibDepGraph
         ( Map.keys
         . Map.filter (uncurry buildAttempted)
-        $ Map.intersectionWith (,) pkgBuildStatus buildOutcomes 
+        $ Map.intersectionWith (,) pkgBuildStatus buildOutcomes
         )
 
     -- The plan graph but only counting dependency-on-library edges
@@ -881,4 +935,3 @@ relativePackageDBPath relroot pkgdb =
       UserPackageDB          -> UserPackageDB
       SpecificPackageDB path -> SpecificPackageDB relpath
         where relpath = makeRelative relroot path
-

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -198,15 +198,14 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
         case repo of
           RepoLocal{..} ->
             J.object [ "type" J..= J.String "local-repo"
+                     , "path" J..= J.String repoLocalDir
                      ]
           RepoRemote{..} ->
             J.object [ "type" J..= J.String "remote-repo"
-                     , "name" J..= J.String (remoteRepoName repoRemote)
                      , "uri"  J..= J.String (show (remoteRepoURI repoRemote))
                      ]
           RepoSecure{..} ->
             J.object [ "type" J..= J.String "secure-repo"
-                     , "name" J..= J.String (remoteRepoName repoRemote)
                      , "uri"  J..= J.String (show (remoteRepoURI repoRemote))
                      ]
 

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -22,6 +22,7 @@
 	* Drop support for GHC 7.4, since it is out of our support window
 	  (and has been for over a year!).
 	* 'new-update' now works outside of projects. (#5096)
+	* Extend `plan.json` with `pkg-src` provenance information. (#5487)
 	* Add 'new-sdist' command (#5389). Creates stable archives based on
 	  cabal projects in '.zip' and '.tar.gz' formats.
 	* Add '--repl-options' flag to 'cabal repl' and 'cabal new-repl'


### PR DESCRIPTION
This PR extends packages in the `plan.json` file with a `pkg-src` field. This is really helpful for third-party tooling to find the paths to all the project local packages including source repositories and such.

/cc @hvr @shlevy