### PR TITLE
Cabal: Allow binary 0.10

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -196,7 +196,7 @@ library
   if flag(bundled-binary-generic)
     build-depends: binary >= 0.5.1.1 && < 0.7
   else
-    build-depends: binary >= 0.7 && < 0.9
+    build-depends: binary >= 0.7 && < 0.11
 
   if os(windows)
     build-depends: Win32 >= 2.3.0.0 && < 2.9


### PR DESCRIPTION
This will be necessary for GHC 8.6. Please do cherry-pick into the stable branch.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
