### PR TITLE
Disable -fmonolithic for cabal-install by default.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 packages: Cabal/ cabal-testsuite/ cabal-install/ solver-benchmarks/ pretty-show-1.6.16/
 constraints: unix >= 2.7.1.0
-           , cabal-install +lib +monolithic
+           , cabal-install +lib
 
 -- Uncomment to allow picking up extra local unpacked deps:
 --optional-packages: */


### PR DESCRIPTION
Please don't merge yet. This is just to see what is going to break.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
