### PR TITLE
`--haddock-for-hackage` works with older Haddock

### DIFF
--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -153,6 +153,7 @@ haddock pkg_descr lbi suffixes flags' = do
         comp          = compiler lbi
         platform      = hostPlatform lbi
 
+        quickJmpFlag  = haddockQuickJump flags'
         flags = case haddockTarget of
           ForDevelopment -> flags'
           ForHackage -> flags'
@@ -185,9 +186,9 @@ haddock pkg_descr lbi suffixes flags' = do
     when (flag haddockQuickJump && version < mkVersion [2,19]) $ do
       let msg = "Haddock prior to 2.19 does not support the --quickjump flag."
           alt = "The generated documentation won't have the QuickJump feature."
-      case haddockTarget of
-        ForDevelopment -> die' verbosity msg
-        ForHackage -> warn verbosity (msg ++ "\n" ++ alt) 
+      if Flag True == quickJmpFlag
+        then die' verbosity msg
+        else warn verbosity (msg ++ "\n" ++ alt)
 
     haddockGhcVersionStr <- getProgramOutput verbosity haddockProg
                               ["--ghc-version"]

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -178,13 +178,16 @@ haddock pkg_descr lbi suffixes flags' = do
         (orLaterVersion (mkVersion [2,0])) (withPrograms lbi)
 
     -- various sanity checks
-    when ( flag haddockHoogle
-           && version < mkVersion [2,2]) $
-         die' verbosity "haddock 2.0 and 2.1 do not support the --hoogle flag."
+    when (flag haddockHoogle && version < mkVersion [2,2]) $
+      die' verbosity "Haddock 2.0 and 2.1 do not support the --hoogle flag."
 
-    when ( flag haddockQuickJump
-           && version < mkVersion [2,19]) $
-         die' verbosity "haddock prior to 2.19 does not support the --quickjump flag."
+
+    when (flag haddockQuickJump && version < mkVersion [2,19]) $ do
+      let msg = "Haddock prior to 2.19 does not support the --quickjump flag."
+          alt = "The generated documentation won't have the QuickJump feature."
+      case haddockTarget of
+        ForDevelopment -> die' verbosity msg
+        ForHackage -> warn verbosity (msg ++ "\n" ++ alt) 
 
     haddockGhcVersionStr <- getProgramOutput verbosity haddockProg
                               ["--ghc-version"]

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1810,7 +1810,7 @@ haddockOptions showOrParseArgs
     , let name = optionName opt
     , name `elem` ["hoogle", "html", "html-location"
                   ,"executables", "tests", "benchmarks", "all", "internal", "css"
-                  ,"hyperlink-source", "hscolour-css"
+                  ,"hyperlink-source", "quickjump", "hscolour-css"
                   ,"contents-location", "for-hackage"]
     ]
   where


### PR DESCRIPTION
We error-out when `--quickjump` is specified on a version of Haddock that
doesn't support it. However, if `--quickjump` was implied by
`--haddock-for-hackage`, we should just warn.

Fixes #5494.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
