### PR TITLE
Remove a '*' kind annotation

### DIFF
--- a/Cabal/Distribution/Compat/Graph.hs
+++ b/Cabal/Distribution/Compat/Graph.hs
@@ -169,7 +169,7 @@ instance (NFData a, NFData (Key a)) => NFData (Graph a) where
 -- type @'Key' a@; given a node we can determine its key ('nodeKey')
 -- and the keys of its neighbors ('nodeNeighbors').
 class Ord (Key a) => IsNode a where
-    type Key a :: *
+    type Key a
     nodeKey :: a -> Key a
     nodeNeighbors :: a -> [Key a]
 


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

This is required to compile Cabal with `-Wcompat` under https://phabricator.haskell.org/D5044
