### PR TITLE
Solver: Improve handling of failures involving whole packages, such as unknown packages.

### DIFF
--- a/cabal-install/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install/Distribution/Solver/Modular/Explore.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module Distribution.Solver.Modular.Explore
-    ( backjump
-    , backjumpAndExplore
-    ) where
+module Distribution.Solver.Modular.Explore (backjumpAndExplore) where
 
 import qualified Distribution.Solver.Types.Progress as P
 
@@ -54,39 +52,50 @@ backjump mbj (EnableBackjumping enableBj) var lastCS xs =
     combine :: forall a . (ExploreState -> ConflictSetLog a)
             -> (ConflictSet -> ExploreState -> ConflictSetLog a)
             ->  ConflictSet -> ExploreState -> ConflictSetLog a
-    combine x f csAcc es = retry (x es) next
+    combine x f csAcc es = retryNoSolution (x es) next
       where
-        next :: IntermediateFailure -> ConflictSetLog a
-        next BackjumpLimit = fromProgress (P.Fail BackjumpLimit)
-        next (NoSolution !cs es')
-          | enableBj && not (var `CS.member` cs) = skipLoggingBackjump cs es'
-          | otherwise                            = f (csAcc `CS.union` cs) es'
+        next :: ConflictSet -> ExploreState -> ConflictSetLog a
+        next !cs es' = if enableBj && not (var `CS.member` cs)
+                       then skipLoggingBackjump cs es'
+                       else f (csAcc `CS.union` cs) es'
 
     -- This function represents the option to not choose a value for this goal.
     avoidGoal :: ConflictSet -> ExploreState -> ConflictSetLog a
     avoidGoal cs !es =
-        logBackjump (cs `CS.union` lastCS) $
+        logBackjump mbj (cs `CS.union` lastCS) $
 
         -- Use 'lastCS' below instead of 'cs' since we do not want to
         -- double-count the additionally accumulated conflicts.
         es { esConflictMap = updateCM lastCS (esConflictMap es) }
-
-    logBackjump :: ConflictSet -> ExploreState -> ConflictSetLog a
-    logBackjump cs es =
-        failWith (Failure cs Backjump) $
-            if reachedBjLimit (esBackjumps es)
-            then BackjumpLimit
-            else NoSolution cs es { esBackjumps = esBackjumps es + 1 }
-      where
-        reachedBjLimit = case mbj of
-                           Nothing    -> const False
-                           Just limit -> (== limit)
 
     -- The solver does not count or log backjumps at levels where the conflict
     -- set does not contain the current variable. Otherwise, there would be many
     -- consecutive log messages about backjumping with the same conflict set.
     skipLoggingBackjump :: ConflictSet -> ExploreState -> ConflictSetLog a
     skipLoggingBackjump cs es = fromProgress $ P.Fail (NoSolution cs es)
+
+-- | Creates a failing ConflictSetLog representing a backjump. It inserts a
+-- "backjumping" message, checks whether the backjump limit has been reached,
+-- and increments the backjump count.
+logBackjump :: Maybe Int -> ConflictSet -> ExploreState -> ConflictSetLog a
+logBackjump mbj cs es =
+    failWith (Failure cs Backjump) $
+        if reachedBjLimit (esBackjumps es)
+        then BackjumpLimit
+        else NoSolution cs es { esBackjumps = esBackjumps es + 1 }
+  where
+    reachedBjLimit = case mbj of
+                       Nothing    -> const False
+                       Just limit -> (== limit)
+
+-- | Like 'retry', except that it only applies the input function when the
+-- backjump limit has not been reached.
+retryNoSolution :: ConflictSetLog a
+                -> (ConflictSet -> ExploreState -> ConflictSetLog a)
+                -> ConflictSetLog a
+retryNoSolution lg f = retry lg $ \case
+    BackjumpLimit    -> fromProgress (P.Fail BackjumpLimit)
+    NoSolution cs es -> f cs es
 
 -- | The state that is read and written while exploring the search tree.
 data ExploreState = ES {

--- a/cabal-install/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install/Distribution/Solver/Modular/Message.hs
@@ -53,7 +53,7 @@ showMessages = go 0
         (atLevel l $ "rejecting: " ++ showQSNBool qsn b ++ showFR c fr) (go l ms)
     go !l (Step (Next (Goal (P _  ) gr)) (Step (TryP qpn' i) ms@(Step Enter (Step (Next _) _)))) =
         (atLevel l $ "trying: " ++ showQPNPOpt qpn' i ++ showGR gr) (go l ms)
-    go !l (Step (Next (Goal (P qpn) gr)) ms@(Step (Failure _c Backjump) _)) =
+    go !l (Step (Next (Goal (P qpn) gr)) (Step (Failure _c UnknownPackage) ms)) =
         (atLevel l $ "unknown package: " ++ showQPN qpn ++ showGR gr) $ go l ms
     -- standard display
     go !l (Step Enter                    ms) = go (l+1) ms
@@ -116,6 +116,7 @@ showFR _ CannotReinstall                  = " (avoiding to reinstall a package w
 showFR _ NotExplicit                      = " (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set)"
 showFR _ Shadowed                         = " (shadowed by another installed package with same version)"
 showFR _ Broken                           = " (package is broken)"
+showFR _ UnknownPackage                   = " (unknown package)"
 showFR _ (GlobalConstraintVersion vr src) = " (" ++ constraintSource src ++ " requires " ++ display vr ++ ")"
 showFR _ (GlobalConstraintInstalled src)  = " (" ++ constraintSource src ++ " requires installed instance)"
 showFR _ (GlobalConstraintSource src)     = " (" ++ constraintSource src ++ " requires source instance)"

--- a/cabal-install/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install/Distribution/Solver/Modular/Message.hs
@@ -55,8 +55,6 @@ showMessages = go 0
         (atLevel l $ "trying: " ++ showQPNPOpt qpn' i ++ showGR gr) (go l ms)
     go !l (Step (Next (Goal (P qpn) gr)) ms@(Step (Failure _c Backjump) _)) =
         (atLevel l $ "unknown package: " ++ showQPN qpn ++ showGR gr) $ go l ms
-    go !l (Step (Next (Goal (P qpn) gr)) (Step (Failure c fr) ms)) =
-        (atLevel l $ showPackageGoal qpn gr) $ (atLevel l $ showFailure c fr) (go l ms)
     -- standard display
     go !l (Step Enter                    ms) = go (l+1) ms
     go !l (Step Leave                    ms) = go (l-1) ms

--- a/cabal-install/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install/Distribution/Solver/Modular/Tree.hs
@@ -109,6 +109,7 @@ data FailReason = UnsupportedExtension Extension
                 | NotExplicit
                 | Shadowed
                 | Broken
+                | UnknownPackage
                 | GlobalConstraintVersion VR ConstraintSource
                 | GlobalConstraintInstalled ConstraintSource
                 | GlobalConstraintSource ConstraintSource

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -159,6 +159,16 @@ tests = [
             solverSuccess [("E", 1), ("syb", 2)]
         , runTest $ onlyConstrained $ mkTest db17 "backtracking" ["A", "B"] $
             solverSuccess [("A", 2), ("B", 1)]
+        , runTest $ onlyConstrained $ mkTest db17 "failure message" ["A"] $
+            solverFailure $ isInfixOf $
+                  "Could not resolve dependencies:\n"
+               ++ "[__0] trying: A-3.0.0 (user goal)\n"
+               ++ "[__1] next goal: C (dependency of A)\n"
+               ++ "[__1] fail (not a user-provided goal nor mentioned as a constraint, "
+                      ++ "but reject-unconstrained-dependencies was set)\n"
+               ++ "[__1] fail (backjumping, conflict set: A, C)\n"
+               ++ "After searching the rest of the dependency tree exhaustively, "
+                      ++ "these were the goals I've had most trouble fulfilling: A, C, B"
         ]
     , testGroup "Cycles" [
           runTest $ mkTest db14 "simpleCycle1"          ["A"]      anySolverFailure


### PR DESCRIPTION
Two main commits:

#### Solver: Represent an unknown package with a failure node.

Previously, the solver represented an unknown package with an empty PChoice
node, because an unknown package is like a package with no versions.  Now that
--reject-unconstrained-dependencies also needs to reject whole packages, it is
simpler to handle both types of failures similarly, and use a failure node for
both.  Another advantage of using a failure node now is that the node can store
more information about why the package was rejected.  The explicit node also
simplifies generating the solver log.

This commit treats a failure node under a goal choice as a backjump in
D.S.Modular.Explore.exploreLog, which fixes #5502.

#### Solver: Print package rejection message on a single line.

The one-line error message is more similar to the message for rejecting a
package version.

Closes #5501.

Before:

```
[__0] trying: A-3.0.0 (user goal)
[__1] next goal: C (dependency of A)
[__1] fail (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set)
[__1] fail (backjumping, conflict set: A, C)
```

After:

```
[__0] trying: A-3.0.0 (user goal)
[__1] rejecting: C (not a user-provided goal nor mentioned as a constraint, but reject-unconstrained-dependencies was set) (dependency of A)
[__1] fail (backjumping, conflict set: A, C)
```

This commit also expands the tests for the error message for
--reject-unconstrained-dependencies.

_______________________________________________________

I'm not sure that putting the rejected package message on one line is an improvement, now that I've seen it, since that message contains more information than the rejected version message.  Let me know if you have any suggestions for improving it or prefer the original format.

/cc @kosmikus @quasicomputational 

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
