### PR TITLE
Don't throw away any program args in new-style commands

### DIFF
--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -391,7 +391,7 @@ convertLegacyPerPackageFlags configFlags installFlags haddockFlags =
       configRelocatable         = packageConfigRelocatable
     } = configFlags
     packageConfigProgramPaths   = MapLast    (Map.fromList configProgramPaths)
-    packageConfigProgramArgs    = MapMappend (Map.fromList configProgramArgs)
+    packageConfigProgramArgs    = MapMappend (Map.fromListWith (++) configProgramArgs)
 
     packageConfigCoverage       = coverage <> libcoverage
     --TODO: defer this merging to the resolve phase


### PR DESCRIPTION
Before this change, only the last set of program args would be kept in new-style commands. For example, the following wouldn't complain about the bogus GHC option `--bogus`, because only `-O1` got passed to GHC.

    cabal new-build --ghc-option '--bogus' --ghc-option '-O1'

Now, all program args are kept.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
