### PR TITLE
Treat parse errors as errors instead of warnings

### DIFF
--- a/Cabal/Distribution/Parsec/ParseResult.hs
+++ b/Cabal/Distribution/Parsec/ParseResult.hs
@@ -180,5 +180,4 @@ parseString parser verbosity name bs = do
     case result of
         Right x -> return x
         Left (_, errors) -> do
-            traverse_ (warn verbosity . showPError name) errors
-            die' verbosity $ "Failed parsing \"" ++ name ++ "\"."
+            die' verbosity $ unlines $ ("Failed parsing \"" ++ name ++ "\".") : map (showPError name) errors

--- a/cabal-install/Distribution/Client/Check.hs
+++ b/cabal-install/Distribution/Client/Check.hs
@@ -40,10 +40,9 @@ readGenericPackageDescriptionCheck verbosity fpath = do
     bs <- BS.readFile fpath
     let (warnings, result) = runParseResult (parseGenericPackageDescription bs)
     case result of
-        Left (_, errors) -> do
-            traverse_ (warn verbosity . showPError fpath) errors
-            die' verbosity $ "Failed parsing \"" ++ fpath ++ "\"."
         Right x  -> return (warnings, x)
+        Left (_, errors) -> do
+            die' verbosity $ unlines $ ("Failed parsing \"" ++ fpath ++ "\".") : map (showPError fpath) errors
 
 -- | Note: must be called with the CWD set to the directory containing
 -- the '.cabal' file.


### PR DESCRIPTION
This produces error messages of the form:

    cabal: Failed parsing "./foo.cabal".
    foo.cabal:0:0: "version" field missing