### PR TITLE
Add flags to --version output

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -377,6 +377,25 @@ executable cabal
             base,
             directory,
             filepath
+
+    if flag(debug-expensive-assertions)
+      cpp-options: -DDEBUG_EXPENSIVE_ASSERTIONS
+
+    if flag(debug-conflict-sets)
+      cpp-options: -DDEBUG_CONFLICT_SETS
+
+    if flag(debug-tracetree)
+      cpp-options: -DDEBUG_TRACETREE
+
+    if flag(lib)
+      cpp-options: -DCABAL_FLAG_LIB
+
+    if flag(monolithic)
+      cpp-options: -DCABAL_FLAG_MONOLITHIC
+
+    if flag(native-dns)
+      cpp-options: -DCABAL_FLAG_NATIVEDNS
+
     else
         hs-source-dirs: .
         build-depends:
@@ -582,6 +601,12 @@ executable cabal
         if flag(debug-tracetree)
           cpp-options: -DDEBUG_TRACETREE
           build-depends: tracetree >= 0.1 && < 0.2
+
+        if flag(monolithic)
+          cpp-options: -DCABAL_FLAG_MONOLITHIC
+
+        if flag(native-dns)
+          cpp-options: -DCABAL_FLAG_NATIVEDNS
 
     if flag(monolithic)
       hs-source-dirs: tests

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -288,6 +288,30 @@ mainWorker args = do
                                   ++ "\ncompiled using version "
                                   ++ display cabalVersion
                                   ++ " of the Cabal library "
+                                  ++ flags_enabled
+      where
+        flags_enabled | null enabledFlags   = "\nall flags disabled"
+                      | otherwise = "\nflags enabled: " ++ intercalate ", " enabledFlags
+        enabledFlags =
+#ifdef CABAL_FLAG_NATIVEDNS
+            "native-dns" :
+#endif
+#ifdef CABAL_FLAG_LIB
+            "lib" :
+#endif
+#ifdef CABAL_FLAG_MONOLITHIC
+            "monolithic" :
+#endif
+#ifdef DEBUG_TRACETREE
+            "debug-tracetree" :
+#endif
+#ifdef DEBUG_CONFLICT_SETS
+            "debug-conflict-sets" :
+#endif
+#ifdef DEBUG_EXPENSIVE_ASSERTIONS
+            "debug-expensive-assertions" :
+#endif
+            []
 
     commands = map commandFromSpec commandSpecs
     commandSpecs =


### PR DESCRIPTION
```
% .../cabal --version
cabal-install version 2.4.0.0
compiled using version 2.4.0.0 of the Cabal library 
flags enabled: native-dns, lib, monolithic
```