### PR TITLE
Hack around #5119 by disabling the warning.

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,4 +1,7 @@
 # 2.4.0.0 (current development version)
+  * Due to [#5119](https://github.com/haskell/cabal/issues/5119), the
+    `cabal check` warning for bounds on internal libraries has been
+    disabled.
   * `Distribution.Simple.Haddock` now checks to ensure that it
     does not erroneously call Haddock with no target modules.
     ([#5232](https://github.com/haskell/cabal/issues/5232),

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -531,7 +531,10 @@ checkFields pkg =
         ++ "for example 'tested-with: GHC==6.10.4, GHC==6.12.3' and not "
         ++ "'tested-with: GHC==6.10.4 && ==6.12.3'."
 
-  , check (not (null depInternalLibraryWithExtraVersion)) $
+  -- Disabled due to #5119: we generate loads of spurious instances of
+  -- this warning. Re-enabling this check should be part of the fix to
+  -- #5119.
+  , check (False && not (null depInternalLibraryWithExtraVersion)) $
       PackageBuildWarning $
            "The package has an extraneous version range for a dependency on an "
         ++ "internal library: "

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.out
@@ -34,11 +34,9 @@ Building library 'mylib' instantiated with
   Database = Includes2-0.1.0.0-inplace-postgresql:Database.PostgreSQL
 for Includes2-0.1.0.0..
 Configuring library for Includes2-0.1.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: Includes2 -any && ==0.1.0.0 && ==0.1.0.0 && ==0.1.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing library for Includes2-0.1.0.0..
 Building library for Includes2-0.1.0.0..
 Configuring executable 'exe' for Includes2-0.1.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: Includes2 -any && ==0.1.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'exe' for Includes2-0.1.0.0..
 Building executable 'exe' for Includes2-0.1.0.0..
 # Includes2 exe

--- a/cabal-testsuite/PackageTests/BuildTools/Internal/cabal.out
+++ b/cabal-testsuite/PackageTests/BuildTools/Internal/cabal.out
@@ -12,6 +12,5 @@ Configuring library for foo-0.1.0.0..
 Preprocessing library for foo-0.1.0.0..
 Building library for foo-0.1.0.0..
 Configuring executable 'hello-world' for foo-0.1.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: foo -any && ==0.1.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'hello-world' for foo-0.1.0.0..
 Building executable 'hello-world' for foo-0.1.0.0..

--- a/cabal-testsuite/PackageTests/InternalVersions/BuildDependsExtra/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/InternalVersions/BuildDependsExtra/setup.cabal.out
@@ -1,16 +1,3 @@
 # Setup configure
 Resolving dependencies...
 Configuring build-depends-extra-version-0.1.0.0...
-Warning: The package has an extraneous version range for a dependency on an internal library: build-depends-extra-version >=0.0.0.1. This version range includes the current package but isn't needed as the current package's library will always be used.
-# Setup sdist
-Distribution quality errors:
-The package has an extraneous version range for a dependency on an internal library: build-depends-extra-version >=0.0.0.1. This version range includes the current package but isn't needed as the current package's library will always be used.
-Distribution quality warnings:
-No 'maintainer' field.
-No 'description' field.
-A 'license-file' is not specified.
-Note: the public hackage server would reject this package.
-Building source dist for build-depends-extra-version-0.1.0.0...
-Preprocessing library for build-depends-extra-version-0.1.0.0..
-Preprocessing executable 'bar' for build-depends-extra-version-0.1.0.0..
-Source tarball created: setup.cabal.dist/work/dist/build-depends-extra-version-0.1.0.0.tar.gz

--- a/cabal-testsuite/PackageTests/InternalVersions/BuildDependsExtra/setup.out
+++ b/cabal-testsuite/PackageTests/InternalVersions/BuildDependsExtra/setup.out
@@ -1,15 +1,2 @@
 # Setup configure
 Configuring build-depends-extra-version-0.1.0.0...
-Warning: The package has an extraneous version range for a dependency on an internal library: build-depends-extra-version >=0.0.0.1. This version range includes the current package but isn't needed as the current package's library will always be used.
-# Setup sdist
-Distribution quality errors:
-The package has an extraneous version range for a dependency on an internal library: build-depends-extra-version >=0.0.0.1. This version range includes the current package but isn't needed as the current package's library will always be used.
-Distribution quality warnings:
-No 'maintainer' field.
-No 'description' field.
-A 'license-file' is not specified.
-Note: the public hackage server would reject this package.
-Building source dist for build-depends-extra-version-0.1.0.0...
-Preprocessing library for build-depends-extra-version-0.1.0.0..
-Preprocessing executable 'bar' for build-depends-extra-version-0.1.0.0..
-Source tarball created: setup.dist/work/dist/build-depends-extra-version-0.1.0.0.tar.gz

--- a/cabal-testsuite/PackageTests/InternalVersions/BuildDependsExtra/setup.test.hs
+++ b/cabal-testsuite/PackageTests/InternalVersions/BuildDependsExtra/setup.test.hs
@@ -2,5 +2,7 @@ import Test.Cabal.Prelude
 -- Test unneed version bound on internal build-tools deps
 main = setupAndCabalTest $ do
     setup' "configure" []
-    assertOutputContains "extraneous version range"
-        =<< setup' "sdist" []
+    -- Hack alert: had to squelch this warning because of #5119.
+--    assertOutputContains "extraneous version range"
+--        =<< setup' "sdist" []
+    return ()

--- a/cabal-testsuite/PackageTests/Regression/T5309/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T5309/cabal.out
@@ -12,7 +12,6 @@ Configuring executable 'exe-no-lib' for T5309-1.0.0.0..
 Preprocessing executable 'exe-no-lib' for T5309-1.0.0.0..
 Building executable 'exe-no-lib' for T5309-1.0.0.0..
 Configuring executable 'exe-with-lib' for T5309-1.0.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: T5309 -any && ==1.0.0.0, T5309 -any && ==1.0.0.0, T5309 -any && ==1.0.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'exe-with-lib' for T5309-1.0.0.0..
 Building executable 'exe-with-lib' for T5309-1.0.0.0..
 # cabal new-test
@@ -29,7 +28,6 @@ Test suite test-no-lib: PASS
 Test suite logged to: <ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/T5309-1.0.0.0/t/test-no-lib/test/T5309-1.0.0.0-test-no-lib.log
 1 of 1 test suites (1 of 1 test cases) passed.
 Configuring test suite 'test-with-lib' for T5309-1.0.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: T5309 -any && ==1.0.0.0, T5309 -any && ==1.0.0.0, T5309 -any && ==1.0.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing test suite 'test-with-lib' for T5309-1.0.0.0..
 Building test suite 'test-with-lib' for T5309-1.0.0.0..
 Running 1 test suites...
@@ -49,7 +47,6 @@ Running 1 benchmarks...
 Benchmark bench-no-lib: RUNNING...
 Benchmark bench-no-lib: FINISH
 Configuring benchmark 'bench-with-lib' for T5309-1.0.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: T5309 -any && ==1.0.0.0, T5309 -any && ==1.0.0.0, T5309 -any && ==1.0.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing benchmark 'bench-with-lib' for T5309-1.0.0.0..
 Building benchmark 'bench-with-lib' for T5309-1.0.0.0..
 Running 1 benchmarks...

--- a/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/cabal.out
+++ b/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/cabal.out
@@ -9,7 +9,6 @@ Configuring library for my-0.1..
 Preprocessing library for my-0.1..
 Building library for my-0.1..
 Configuring test suite 'test-Short' for my-0.1..
-Warning: The package has an extraneous version range for a dependency on an internal library: my -any && ==0.1, my -any && ==0.1. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing test suite 'test-Short' for my-0.1..
 Building test suite 'test-Short' for my-0.1..
 Running 1 test suites...
@@ -18,7 +17,6 @@ Test suite test-Short: PASS
 Test suite logged to: <ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/my-0.1/t/test-Short/test/my-0.1-test-Short.log
 1 of 1 test suites (1 of 1 test cases) passed.
 Configuring test suite 'test-Foo' for my-0.1..
-Warning: The package has an extraneous version range for a dependency on an internal library: my -any && ==0.1, my -any && ==0.1. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing test suite 'test-Foo' for my-0.1..
 Building test suite 'test-Foo' for my-0.1..
 Running 1 test suites...


### PR DESCRIPTION
Issue #5119 is tracking spurious generation of these warnings. There
are a lot of them! We can't release with so many false positives, so
just squelch the warning outright.

This is a hack and this commit should be reverted if we get a proper
fix that can be backported to the 2.4 branch.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
