### PR TITLE
[GSoC2018] Add support for multiple public libraries in a single package

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -367,6 +367,7 @@ library
     Distribution.Types.Version
     Distribution.Types.VersionRange
     Distribution.Types.VersionInterval
+    Distribution.Types.GivenComponent
     Distribution.Utils.Generic
     Distribution.Utils.NubList
     Distribution.Utils.ShortText

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -343,6 +343,7 @@ library
     Distribution.Types.ModuleReexport
     Distribution.Types.ModuleRenaming
     Distribution.Types.ComponentName
+    Distribution.Types.LibraryName
     Distribution.Types.MungedPackageName
     Distribution.Types.PackageName
     Distribution.Types.PkgconfigName

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -369,6 +369,7 @@ library
     Distribution.Types.VersionRange
     Distribution.Types.VersionInterval
     Distribution.Types.GivenComponent
+    Distribution.Types.PackageVersionConstraint
     Distribution.Utils.Generic
     Distribution.Utils.NubList
     Distribution.Utils.ShortText

--- a/Cabal/Distribution/Backpack/ComponentsGraph.hs
+++ b/Cabal/Distribution/Backpack/ComponentsGraph.hs
@@ -66,8 +66,8 @@ mkComponentsGraph enabled pkg_descr =
       (CExeName <$> getAllInternalToolDependencies pkg_descr bi)
 
       ++ [ if pkgname == packageName pkg_descr
-           then CLibName
-           else CSubLibName toolname
+           then CLibName LMainLibName
+           else CLibName (LSubLibName toolname)
          | Dependency pkgname _ <- targetBuildDepends bi
          , let toolname = packageNameToUnqualComponentName pkgname
          , toolname `elem` internalPkgDeps ]

--- a/Cabal/Distribution/Backpack/ComponentsGraph.hs
+++ b/Cabal/Distribution/Backpack/ComponentsGraph.hs
@@ -68,7 +68,7 @@ mkComponentsGraph enabled pkg_descr =
       ++ [ if pkgname == packageName pkg_descr
            then CLibName LMainLibName
            else CLibName (LSubLibName toolname)
-         | Dependency pkgname _ <- targetBuildDepends bi
+         | Dependency pkgname _ _ <- targetBuildDepends bi
          , let toolname = packageNameToUnqualComponentName pkgname
          , toolname `elem` internalPkgDeps ]
       where

--- a/Cabal/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/Distribution/Backpack/ConfiguredComponent.hs
@@ -150,7 +150,7 @@ mkConfiguredComponent pkg_descr this_cid lib_deps exe_deps component = do
     bi = componentBuildInfo component
     deps_map = Map.fromList [ ((packageName dep, ann_cname dep), dep)
                             | dep <- lib_deps ]
-    is_public = componentName component == CLibName
+    is_public = componentName component == CLibName LMainLibName
 
 type ConfiguredComponentMap =
         Map PackageName (Map ComponentName (AnnotatedId ComponentId))
@@ -192,7 +192,7 @@ toConfiguredComponent pkg_descr this_cid lib_dep_map exe_dep_map component = do
                          | (pn, comp_map) <- Map.toList lib_dep_map
                          , pn /= packageName pkg_descr
                          , (cn, e) <- Map.toList comp_map
-                         , cn == CLibName ]
+                         , cn == CLibName LMainLibName ]
     -- We have to nub here, because 'getAllToolDependencies' may return
     -- duplicates (see #4986).  (NB: This is not needed for lib_deps,
     -- since those elaborate into includes, for which there explicitly
@@ -296,8 +296,8 @@ newPackageDepsBehaviour pkg =
 fixFakePkgName :: PackageDescription -> PackageName -> (PackageName, ComponentName)
 fixFakePkgName pkg_descr pn =
   if subLibName `elem` internalLibraries
-  then (packageName pkg_descr, CSubLibName subLibName)
-  else (pn,                    CLibName)
+  then (packageName pkg_descr, CLibName (LSubLibName subLibName))
+  else (pn,                    CLibName LMainLibName            )
   where
     subLibName = packageNameToUnqualComponentName pn
     internalLibraries = mapMaybe libName (allLibraries pkg_descr)

--- a/Cabal/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/Distribution/Backpack/ConfiguredComponent.hs
@@ -306,6 +306,8 @@ newPackageDepsBehaviour pkg =
 -- and internal libraries are specified the same. For now, we assume internal
 -- libraries shadow, and this function disambiguates accordingly, but soon the
 -- underlying ambiguity will be addressed.
+-- Multiple public libraries (cabal 3.0) added an unambiguous way of specifying
+-- sublibraries, but we still have to support the old syntax for bc reasons.
 fixFakePkgName :: PackageDescription -> PackageName -> (PackageName, ComponentName)
 fixFakePkgName pkg_descr pn =
   if subLibName `elem` internalLibraries

--- a/Cabal/Distribution/Backpack/ConfiguredComponent.hs
+++ b/Cabal/Distribution/Backpack/ConfiguredComponent.hs
@@ -30,6 +30,7 @@ import Distribution.Types.PackageId
 import Distribution.Types.PackageName
 import Distribution.Types.Mixin
 import Distribution.Types.ComponentName
+import Distribution.Types.LibraryName
 import Distribution.Types.UnqualComponentName
 import Distribution.Types.ComponentInclude
 import Distribution.Package
@@ -165,16 +166,40 @@ toConfiguredComponent
 toConfiguredComponent pkg_descr this_cid lib_dep_map exe_dep_map component = do
     lib_deps <-
         if newPackageDepsBehaviour pkg_descr
-            then forM (targetBuildDepends bi) $ \(Dependency name _) -> do
+            then fmap concat $ forM (targetBuildDepends bi) $ \(Dependency name _ sublibs) -> do
                     let (pn, cn) = fixFakePkgName pkg_descr name
-                    value <- case Map.lookup cn =<< Map.lookup pn lib_dep_map of
+                    pkg <- case Map.lookup pn lib_dep_map of
+                        Nothing ->
+                            dieProgress $
+                                text "Dependency on unbuildable" <+>
+                                text "package" <+> disp pn
+                        Just p -> return p
+                    mainLibraryComponent <-
+                      if sublibs /= Set.singleton LMainLibName
+                      then pure Nothing
+                      -- No sublibraries were specified, so we may be in the
+                      -- legacy case where the package name is used as library
+                      -- name
+                      else Just <$>
+                        case Map.lookup cn pkg of
                         Nothing ->
                             dieProgress $
                                 text "Dependency on unbuildable (i.e. 'buildable: False')" <+>
                                 text (showComponentName cn) <+>
                                 text "from" <+> disp pn
                         Just v -> return v
-                    return value
+                    subLibrariesComponents <- forM (Set.toList sublibs) $ \lib ->
+                        let comp = CLibName lib in
+                        case Map.lookup (CLibName $ LSubLibName $ packageNameToUnqualComponentName name) pkg
+                         <|> Map.lookup comp pkg
+                        of
+                            Nothing ->
+                                dieProgress $
+                                    text "Dependency on unbuildable" <+>
+                                    text (showLibraryName lib) <+>
+                                    text "from" <+> disp pn
+                            Just v -> return v
+                    return (maybeToList mainLibraryComponent ++ subLibrariesComponents)
             else return old_style_lib_deps
     mkConfiguredComponent
        pkg_descr this_cid

--- a/Cabal/Distribution/Backpack/ModuleScope.hs
+++ b/Cabal/Distribution/Backpack/ModuleScope.hs
@@ -23,6 +23,7 @@ import Distribution.ModuleName
 import Distribution.Types.IncludeRenaming
 import Distribution.Types.PackageName
 import Distribution.Types.ComponentName
+import Distribution.Types.LibraryName
 
 import Distribution.Backpack
 import Distribution.Backpack.ModSubst
@@ -113,8 +114,8 @@ dispComponent pn cn =
     -- should be clear enough.  To do source syntax, we'd
     -- need to know what the package we're linking is.
     case cn of
-        CLibName -> disp pn
-        CSubLibName ucn -> disp pn <<>> colon <<>> disp ucn
+        CLibName LMainLibName -> disp pn
+        CLibName (LSubLibName ucn) -> disp pn <<>> colon <<>> disp ucn
         -- Case below shouldn't happen
         _ -> disp pn <+> parens (disp cn)
 

--- a/Cabal/Distribution/Backpack/ReadyComponent.hs
+++ b/Cabal/Distribution/Backpack/ReadyComponent.hs
@@ -25,6 +25,7 @@ import Distribution.Types.Component
 import Distribution.Types.ComponentInclude
 import Distribution.Types.ComponentId
 import Distribution.Types.ComponentName
+import Distribution.Types.LibraryName
 import Distribution.Types.PackageId
 import Distribution.Types.UnitId
 import Distribution.Compat.Graph (IsNode(..))
@@ -139,8 +140,8 @@ rc_depends rc = ordNub $
         computeCompatPackageId
             (ci_pkgid ci)
             (case ci_cname ci of
-                CLibName -> Nothing
-                CSubLibName uqn -> Just uqn
+                CLibName LMainLibName -> Nothing
+                CLibName (LSubLibName uqn) -> Just uqn
                 _ -> error $ display (rc_cid rc) ++
                         " depends on non-library " ++ display (ci_id ci))
 

--- a/Cabal/Distribution/Backpack/UnifyM.hs
+++ b/Cabal/Distribution/Backpack/UnifyM.hs
@@ -441,8 +441,8 @@ ci_msg ci
     pn = pkgName (ci_pkgid ci)
     pp_pn =
         case ci_cname ci of
-            CLibName -> disp pn
-            CSubLibName cn -> disp pn <<>> colon <<>> disp cn
+            CLibName LMainLibName -> disp pn
+            CLibName (LSubLibName cn) -> disp pn <<>> colon <<>> disp cn
             -- Shouldn't happen
             cn -> disp pn <+> parens (disp cn)
 

--- a/Cabal/Distribution/CabalSpecVersion.hs
+++ b/Cabal/Distribution/CabalSpecVersion.hs
@@ -17,10 +17,11 @@ data CabalSpecVersion
     | CabalSpecV2_0
     | CabalSpecV2_2
     | CabalSpecV2_4
+    | CabalSpecV3_0
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable, Data, Generic)
 
 cabalSpecLatest :: CabalSpecVersion
-cabalSpecLatest = CabalSpecV2_4
+cabalSpecLatest = CabalSpecV3_0
 
 cabalSpecFeatures :: CabalSpecVersion -> Set.Set CabalFeature
 cabalSpecFeatures CabalSpecOld   = Set.empty
@@ -36,6 +37,12 @@ cabalSpecFeatures CabalSpecV2_4  = Set.fromList
     , CommonStanzas
     , Globstar
     ]
+cabalSpecFeatures CabalSpecV3_0  = Set.fromList
+    [ Elif
+    , CommonStanzas
+    , Globstar
+    , MultipleLibraries
+    ]
 
 cabalSpecSupports :: CabalSpecVersion -> [Int] -> Bool
 cabalSpecSupports CabalSpecOld v   = v < [1,21]
@@ -44,15 +51,18 @@ cabalSpecSupports CabalSpecV1_24 v = v < [1,25]
 cabalSpecSupports CabalSpecV2_0 v  = v < [2,1]
 cabalSpecSupports CabalSpecV2_2 v  = v < [2,3]
 cabalSpecSupports CabalSpecV2_4 _  = True
+cabalSpecSupports CabalSpecV3_0 _  = True
 
 specHasCommonStanzas :: CabalSpecVersion -> HasCommonStanzas
 specHasCommonStanzas CabalSpecV2_2 = HasCommonStanzas
 specHasCommonStanzas CabalSpecV2_4 = HasCommonStanzas
+specHasCommonStanzas CabalSpecV3_0 = HasCommonStanzas
 specHasCommonStanzas _             = NoCommonStanzas
 
 specHasElif :: CabalSpecVersion -> HasElif
 specHasElif CabalSpecV2_2 = HasElif
 specHasElif CabalSpecV2_4 = HasElif
+specHasElif CabalSpecV3_0 = HasElif
 specHasElif _             = NoElif
 
 -------------------------------------------------------------------------------
@@ -65,6 +75,8 @@ data CabalFeature
     | Globstar
       -- ^ Implemented in #5284. Not actually a change to the parser,
       -- as filename patterns are opaque to it currently.
+    | MultipleLibraries
+      -- ^ Multiple public libraries in a package. Implemented in #5526.
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable, Data, Generic)
 
 -------------------------------------------------------------------------------

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -54,6 +54,7 @@ import Distribution.ModuleName
 import Distribution.Package                  hiding (installedPackageId, installedUnitId)
 import Distribution.ParseUtils
 import Distribution.Types.ComponentName
+import Distribution.Types.LibraryName
 import Distribution.Utils.Generic            (toUTF8BS)
 
 import qualified Data.Map                        as Map
@@ -104,8 +105,8 @@ installedPackageId = installedUnitId
 sourceComponentName :: InstalledPackageInfo -> ComponentName
 sourceComponentName ipi =
     case sourceLibName ipi of
-        Nothing -> CLibName
-        Just qn -> CSubLibName qn
+        Nothing -> CLibName LMainLibName
+        Just qn -> CLibName $ LSubLibName qn
 
 -- -----------------------------------------------------------------------------
 -- Parsing

--- a/Cabal/Distribution/PackageDescription.hs
+++ b/Cabal/Distribution/PackageDescription.hs
@@ -86,6 +86,7 @@ module Distribution.PackageDescription (
         allBuildDepends,
         enabledBuildDepends,
         ComponentName(..),
+        LibraryName(..),
         defaultLibName,
         HookedBuildInfo,
         emptyHookedBuildInfo,
@@ -135,5 +136,6 @@ import Distribution.Types.CondTree
 import Distribution.Types.Condition
 import Distribution.Types.PackageDescription
 import Distribution.Types.ComponentName
+import Distribution.Types.LibraryName
 import Distribution.Types.HookedBuildInfo
 import Distribution.Types.SourceRepo

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -585,7 +585,7 @@ checkFields pkg =
              , name `elem` map display knownLanguages ]
 
     testedWithImpossibleRanges =
-      [ Dependency (mkPackageName (display compiler)) vr
+      [ Dependency (mkPackageName (display compiler)) vr Set.empty
       | (compiler, vr) <- testedWith pkg
       , isNoVersion vr ]
 
@@ -598,7 +598,7 @@ checkFields pkg =
     internalLibDeps =
       [ dep
       | bi <- allBuildInfo pkg
-      , dep@(Dependency name _) <- targetBuildDepends bi
+      , dep@(Dependency name _ _) <- targetBuildDepends bi
       , name `elem` internalLibraries
       ]
 
@@ -611,14 +611,14 @@ checkFields pkg =
 
     depInternalLibraryWithExtraVersion =
       [ dep
-      | dep@(Dependency _ versionRange) <- internalLibDeps
+      | dep@(Dependency _ versionRange _) <- internalLibDeps
       , not $ isAnyVersion versionRange
       , packageVersion pkg `withinRange` versionRange
       ]
 
     depInternalLibraryWithImpossibleVersion =
       [ dep
-      | dep@(Dependency _ versionRange) <- internalLibDeps
+      | dep@(Dependency _ versionRange _) <- internalLibDeps
       , not $ packageVersion pkg `withinRange` versionRange
       ]
 
@@ -1243,8 +1243,8 @@ checkCabalVersion pkg =
         ++ ". To use this new syntax the package need to specify at least "
         ++ "'cabal-version: >= 1.6'. Alternatively, if broader compatibility "
         ++ "is important then use: " ++ commaSep
-           [ display (Dependency name (eliminateWildcardSyntax versionRange))
-           | Dependency name versionRange <- depsUsingWildcardSyntax ]
+           [ display (Dependency name (eliminateWildcardSyntax versionRange) Set.empty)
+           | Dependency name versionRange _ <- depsUsingWildcardSyntax ]
 
     -- check use of "build-depends: foo ^>= 1.2.3" syntax
   , checkVersion [2,0] (not (null depsUsingMajorBoundSyntax)) $
@@ -1255,8 +1255,8 @@ checkCabalVersion pkg =
         ++ ". To use this new syntax the package need to specify at least "
         ++ "'cabal-version: 2.0'. Alternatively, if broader compatibility "
         ++ "is important then use: " ++ commaSep
-           [ display (Dependency name (eliminateMajorBoundSyntax versionRange))
-           | Dependency name versionRange <- depsUsingMajorBoundSyntax ]
+           [ display (Dependency name (eliminateMajorBoundSyntax versionRange) Set.empty)
+           | Dependency name versionRange _ <- depsUsingMajorBoundSyntax ]
 
   , checkVersion [2,1] (any (not . null)
                         (concatMap buildInfoField
@@ -1292,8 +1292,8 @@ checkCabalVersion pkg =
         ++ ". To use this new syntax the package need to specify at least "
         ++ "'cabal-version: >= 1.6'. Alternatively, if broader compatibility "
         ++ "is important then use: " ++ commaSep
-           [ display (Dependency name (eliminateWildcardSyntax versionRange))
-           | Dependency name versionRange <- testedWithUsingWildcardSyntax ]
+           [ display (Dependency name (eliminateWildcardSyntax versionRange) Set.empty)
+           | Dependency name versionRange _ <- testedWithUsingWildcardSyntax ]
 
     -- check use of "source-repository" section
   , checkVersion [1,6] (not (null (sourceRepos pkg))) $
@@ -1367,11 +1367,11 @@ checkCabalVersion pkg =
     buildInfoField field         = map field (allBuildInfo pkg)
 
     versionRangeExpressions =
-        [ dep | dep@(Dependency _ vr) <- allBuildDepends pkg
+        [ dep | dep@(Dependency _ vr _) <- allBuildDepends pkg
               , usesNewVersionRangeSyntax vr ]
 
     testedWithVersionRangeExpressions =
-        [ Dependency (mkPackageName (display compiler)) vr
+        [ Dependency (mkPackageName (display compiler)) vr Set.empty
         | (compiler, vr) <- testedWith pkg
         , usesNewVersionRangeSyntax vr ]
 
@@ -1395,16 +1395,16 @@ checkCabalVersion pkg =
         alg (VersionRangeParensF _) = 3
         alg _ = 1 :: Int
 
-    depsUsingWildcardSyntax = [ dep | dep@(Dependency _ vr) <- allBuildDepends pkg
+    depsUsingWildcardSyntax = [ dep | dep@(Dependency _ vr _) <- allBuildDepends pkg
                                     , usesWildcardSyntax vr ]
 
-    depsUsingMajorBoundSyntax = [ dep | dep@(Dependency _ vr) <- allBuildDepends pkg
+    depsUsingMajorBoundSyntax = [ dep | dep@(Dependency _ vr _) <- allBuildDepends pkg
                                       , usesMajorBoundSyntax vr ]
 
     usesBackpackIncludes = any (not . null . mixins) (allBuildInfo pkg)
 
     testedWithUsingWildcardSyntax =
-      [ Dependency (mkPackageName (display compiler)) vr
+      [ Dependency (mkPackageName (display compiler)) vr Set.empty
       | (compiler, vr) <- testedWith pkg
       , usesWildcardSyntax vr ]
 
@@ -1493,7 +1493,7 @@ checkCabalVersion pkg =
     allModuleNamesAutogen = concatMap autogenModules (allBuildInfo pkg)
 
 displayRawDependency :: Dependency -> String
-displayRawDependency (Dependency pkg vr) =
+displayRawDependency (Dependency pkg vr _sublibs) =
   display pkg ++ " " ++ display vr
 
 
@@ -1545,7 +1545,7 @@ checkPackageVersions pkg =
           foldr intersectVersionRanges anyVersion baseDeps
         where
           baseDeps =
-            [ vr | Dependency pname vr <- allBuildDepends pkg'
+            [ vr | Dependency pname vr _ <- allBuildDepends pkg'
                  , pname == mkPackageName "base" ]
 
       -- Just in case finalizePD fails for any reason,

--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -344,12 +344,14 @@ overallDependencies enabled (TargetSet targets) = mconcat depss
     -- UGH. The embedded componentName in the 'Component's here is
     -- BLANK.  I don't know whose fault this is but I'll use the tag
     -- instead. -- ezyang
-    removeDisabledSections (Lib _)     = componentNameRequested enabled CLibName
+    removeDisabledSections (Lib _)     = componentNameRequested
+                                           enabled
+                                           (CLibName LMainLibName)
     removeDisabledSections (SubComp t c)
         -- Do NOT use componentName
         = componentNameRequested enabled
         $ case c of
-            CLib  _ -> CSubLibName t
+            CLib  _ -> CLibName (LSubLibName t)
             CFLib _ -> CFLibName   t
             CExe  _ -> CExeName    t
             CTest _ -> CTestName   t

--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -65,6 +65,8 @@ import Distribution.Types.DependencyMap
 
 import qualified Data.Map.Strict as Map.Strict
 import qualified Data.Map.Lazy   as Map
+import Data.Set ( Set )
+import qualified Data.Set as Set
 import Data.Tree ( Tree(Node) )
 
 ------------------------------------------------------------------------------
@@ -229,7 +231,7 @@ resolveWithFlags dom enabled os arch impl constrs trees checkDeps =
     mp (Left xs)   (Left ys)   =
         let union = Map.foldrWithKey (Map.Strict.insertWith combine)
                     (unDepMapUnion xs) (unDepMapUnion ys)
-            combine x y = simplifyVersionRange $ unionVersionRanges x y
+            combine x y = (\(vr, cs) -> (simplifyVersionRange vr,cs)) $ unionVersionRanges' x y
         in union `seq` Left (DepMapUnion union)
 
     -- `mzero'
@@ -307,14 +309,22 @@ extractConditions f gpkg =
 
 
 -- | A map of dependencies that combines version ranges using 'unionVersionRanges'.
-newtype DepMapUnion = DepMapUnion { unDepMapUnion :: Map PackageName VersionRange }
+newtype DepMapUnion = DepMapUnion { unDepMapUnion :: Map PackageName (VersionRange, Set LibraryName) }
+
+-- An union of versions should correspond to an intersection of the components.
+-- The intersection may not be necessary.
+unionVersionRanges' :: (VersionRange, Set LibraryName)
+                    -> (VersionRange, Set LibraryName)
+                    -> (VersionRange, Set LibraryName)
+unionVersionRanges' (vra, csa) (vrb, csb) =
+  (unionVersionRanges vra vrb, Set.intersection csa csb)
 
 toDepMapUnion :: [Dependency] -> DepMapUnion
 toDepMapUnion ds =
-  DepMapUnion $ Map.fromListWith unionVersionRanges [ (p,vr) | Dependency p vr <- ds ]
+  DepMapUnion $ Map.fromListWith unionVersionRanges' [ (p,(vr,cs)) | Dependency p vr cs <- ds ]
 
 fromDepMapUnion :: DepMapUnion -> [Dependency]
-fromDepMapUnion m = [ Dependency p vr | (p,vr) <- Map.toList (unDepMapUnion m) ]
+fromDepMapUnion m = [ Dependency p vr cs | (p,(vr,cs)) <- Map.toList (unDepMapUnion m) ]
 
 freeVars :: CondTree ConfVar c a  -> [FlagName]
 freeVars t = [ f | Flag f <- freeVars' t ]

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -100,7 +100,7 @@ parseGenericPackageDescription bs = do
     setCabalSpecVersion ver
     -- if we get too new version, fail right away
     case ver of
-        Just v | v > mkVersion [2,4] -> parseFailure zeroPos
+        Just v | v > mkVersion [3,0] -> parseFailure zeroPos
             "Unsupported cabal-version. See https://github.com/haskell/cabal/issues/4899."
         _ -> pure ()
 
@@ -175,6 +175,7 @@ parseGenericPackageDescription' cabalVerM lexWarnings utf8WarnPos fs = do
                 return v
 
     let specVer
+          | cabalVer >= mkVersion [2,5]  = CabalSpecV3_0
           | cabalVer >= mkVersion [2,3]  = CabalSpecV2_4
           | cabalVer >= mkVersion [2,1]  = CabalSpecV2_2
           | cabalVer >= mkVersion [1,25] = CabalSpecV2_0

--- a/Cabal/Distribution/SPDX/LicenseListVersion.hs
+++ b/Cabal/Distribution/SPDX/LicenseListVersion.hs
@@ -12,5 +12,6 @@ data LicenseListVersion
   deriving (Eq, Ord, Show, Enum, Bounded)
 
 cabalSpecVersionToSPDXListVersion :: CabalSpecVersion -> LicenseListVersion
+cabalSpecVersionToSPDXListVersion CabalSpecV3_0 = LicenseListVersion_3_2
 cabalSpecVersionToSPDXListVersion CabalSpecV2_4 = LicenseListVersion_3_2
 cabalSpecVersionToSPDXListVersion _             = LicenseListVersion_3_0

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -470,7 +470,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
                 , componentInternalDeps = componentInternalDeps clbi
                 , componentIsIndefinite_ = False
                 , componentExeDeps = componentExeDeps clbi
-                , componentLocalName = CSubLibName (testName test)
+                , componentLocalName = CLibName $ LSubLibName $ testName test
                 , componentIsPublic = False
                 , componentIncludes = componentIncludes clbi
                 , componentUnitId = componentUnitId clbi

--- a/Cabal/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/Distribution/Simple/BuildTarget.hs
@@ -502,8 +502,8 @@ pkgComponentInfo pkg =
     , let bi = componentBuildInfo c ]
 
 componentStringName :: Package pkg => pkg -> ComponentName -> ComponentStringName
-componentStringName pkg CLibName          = prettyShow (packageName pkg)
-componentStringName _   (CSubLibName name) = unUnqualComponentName name
+componentStringName pkg (CLibName LMainLibName      ) = prettyShow (packageName pkg)
+componentStringName _   (CLibName (LSubLibName name)) = unUnqualComponentName name
 componentStringName _   (CFLibName  name) = unUnqualComponentName name
 componentStringName _   (CExeName   name) = unUnqualComponentName name
 componentStringName _   (CTestName  name) = unUnqualComponentName name
@@ -555,8 +555,7 @@ data ComponentKind = LibKind | FLibKind | ExeKind | TestKind | BenchKind
   deriving (Eq, Ord, Show)
 
 componentKind :: ComponentName -> ComponentKind
-componentKind CLibName = LibKind
-componentKind (CSubLibName _) = LibKind
+componentKind (CLibName   _) = LibKind
 componentKind (CFLibName  _) = FLibKind
 componentKind (CExeName   _) = ExeKind
 componentKind (CTestName  _) = TestKind

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -88,6 +88,7 @@ import Distribution.Types.ComponentRequestedSpec
 import Distribution.Types.ForeignLib
 import Distribution.Types.ForeignLibType
 import Distribution.Types.ForeignLibOption
+import Distribution.Types.GivenComponent
 import Distribution.Types.Mixin
 import Distribution.Types.UnqualComponentName
 import Distribution.Simple.Utils
@@ -1377,7 +1378,7 @@ interpretPackageDbFlags userInstall specificDBs =
 -- deps in the end. So we still need to remember which installed packages to
 -- pick.
 combinedConstraints :: [Dependency] ->
-                       [(PackageName, ComponentName, ComponentId)] ->
+                       [GivenComponent] ->
                        InstalledPackageIndex ->
                        Either String ([Dependency],
                                       Map (PackageName, ComponentName) InstalledPackageInfo)
@@ -1410,7 +1411,7 @@ combinedConstraints constraints dependencies installedPackages = do
                              Maybe InstalledPackageInfo)]
     dependenciesPkgInfo =
       [ (pkgname, cname, cid, mpkg)
-      | (pkgname, cname, cid) <- dependencies
+      | GivenComponent pkgname cname cid <- dependencies
       , let mpkg = PackageIndex.lookupComponentId
                      installedPackages cid
       ]

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -918,7 +918,7 @@ dependencySatisfiable
            | otherwise
            -- Reinterpret the "package name" as an unqualified component
            -- name
-           = Just (mkUnqualComponentName (unPackageName depName))
+           = Just $ packageNameToUnqualComponentName depName
 
 -- | Finalize a generic package description.  The workhorse is
 -- 'finalizePD' but there's a bit of other nattering

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -889,7 +889,7 @@ dependencySatisfiable
         -- Except for internal deps, when we're NOT per-component mode;
         -- those are just True.
         then True
-        else (depName, CLibName) `Map.member` requiredDepsMap
+        else (depName, CLibName LMainLibName) `Map.member` requiredDepsMap
 
     | isInternalDep
     = if use_external_internal_deps
@@ -1227,7 +1227,7 @@ selectDependency pkgid internalIndex installedIndex requiredDepsMap
 
     -- We have to look it up externally
     do_external is_internal = do
-      ipi <- case Map.lookup (dep_pkgname, CLibName) requiredDepsMap of
+      ipi <- case Map.lookup (dep_pkgname, CLibName LMainLibName) requiredDepsMap of
         -- If we know the exact pkg to use, then use it.
         Just pkginstance -> Right pkginstance
         -- Otherwise we just pick an arbitrary instance of the latest version.
@@ -1410,8 +1410,8 @@ combinedConstraints constraints dependencies installedPackages = do
     dependenciesPkgInfo :: [(PackageName, ComponentName, ComponentId,
                              Maybe InstalledPackageInfo)]
     dependenciesPkgInfo =
-      [ (pkgname, cname, cid, mpkg)
-      | GivenComponent pkgname cname cid <- dependencies
+      [ (pkgname, CLibName lname, cid, mpkg)
+      | GivenComponent pkgname lname cid <- dependencies
       , let mpkg = PackageIndex.lookupComponentId
                      installedPackages cid
       ]
@@ -1427,8 +1427,8 @@ combinedConstraints constraints dependencies installedPackages = do
       hsep [    text "--dependency="
              <<>> quotes
                     (pretty pkgname
-                    <<>> case cname of CLibName -> ""
-                                       CSubLibName n -> ":" <<>> pretty n
+                    <<>> case cname of CLibName LMainLibName -> ""
+                                       CLibName (LSubLibName n) -> ":" <<>> pretty n
                                        _ -> ":" <<>> pretty cname
                     <<>> char '='
                     <<>> pretty cid)

--- a/Cabal/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Simple/LocalBuildInfo.hs
@@ -29,6 +29,7 @@ module Distribution.Simple.LocalBuildInfo (
         -- * Buildable package components
         Component(..),
         ComponentName(..),
+        LibraryName(..),
         defaultLibName,
         showComponentName,
         componentNameString,
@@ -108,11 +109,11 @@ componentBuildDir :: LocalBuildInfo -> ComponentLocalBuildInfo -> FilePath
 componentBuildDir lbi clbi
     = buildDir lbi </>
         case componentLocalName clbi of
-            CLibName      ->
+            CLibName LMainLibName ->
                 if prettyShow (componentUnitId clbi) == prettyShow (componentComponentId clbi)
                     then ""
                     else prettyShow (componentUnitId clbi)
-            CSubLibName s ->
+            CLibName (LSubLibName s) ->
                 if prettyShow (componentUnitId clbi) == prettyShow (componentComponentId clbi)
                     then unUnqualComponentName s
                     else prettyShow (componentUnitId clbi)

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -469,11 +469,11 @@ lookupPackageName index name =
 --
 -- INVARIANT: List of eligible 'IPI.InstalledPackageInfo' is non-empty.
 --
-lookupDependency :: InstalledPackageIndex -> Dependency
+lookupDependency :: InstalledPackageIndex -> PackageName -> VersionRange
                  -> [(Version, [IPI.InstalledPackageInfo])]
-lookupDependency index dep =
+lookupDependency index pn vr =
     -- Yes, a little bit of a misnomer here!
-    lookupInternalDependency index dep Nothing
+    lookupInternalDependency index pn vr Nothing
 
 -- | Does a lookup by source package name and a range of versions.
 --
@@ -482,10 +482,10 @@ lookupDependency index dep =
 --
 -- INVARIANT: List of eligible 'IPI.InstalledPackageInfo' is non-empty.
 --
-lookupInternalDependency :: InstalledPackageIndex -> Dependency
+lookupInternalDependency :: InstalledPackageIndex -> PackageName -> VersionRange
                  -> Maybe UnqualComponentName
                  -> [(Version, [IPI.InstalledPackageInfo])]
-lookupInternalDependency index (Dependency name versionRange) libn =
+lookupInternalDependency index name versionRange libn =
   case Map.lookup (name, libn) (packageIdIndex index) of
     Nothing    -> []
     Just pvers -> [ (ver, pkgs')

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -101,6 +101,7 @@ import Distribution.Types.Dependency
 import Distribution.Types.ComponentId
 import Distribution.Types.Module
 import Distribution.Types.PackageName
+import Distribution.Types.UnqualComponentName (unUnqualComponentName)
 
 import Distribution.Compat.Stack
 import Distribution.Compat.Semigroup (Last' (..))
@@ -257,7 +258,7 @@ data ConfigFlags = ConfigFlags {
     configStripLibs :: Flag Bool,      -- ^Enable library stripping
     configConstraints :: [Dependency], -- ^Additional constraints for
                                        -- dependencies.
-    configDependencies :: [(PackageName, ComponentId)],
+    configDependencies :: [(PackageName, ComponentName, ComponentId)],
       -- ^The packages depended on.
     configInstantiateWith :: [(ModuleName, Module)],
       -- ^ The requested Backpack instantiation.  If empty, either this
@@ -646,9 +647,14 @@ configureOptions showOrParseArgs =
       ,option "" ["dependency"]
          "A list of exact dependencies. E.g., --dependency=\"void=void-0.5.8-177d5cdf20962d0581fe2e4932a6c309\""
          configDependencies (\v flags -> flags { configDependencies = v})
-         (reqArg "NAME=CID"
+         (reqArg "NAME[:COMPONENT_NAME]=CID"
                  (parsecToReadE (const "dependency expected") ((\x -> [x]) `fmap` parsecDependency))
-                 (map (\x -> prettyShow (fst x) ++ "=" ++ prettyShow (snd x))))
+                 (map (\(pn, cn, cid) ->
+                     prettyShow pn
+                     ++ case cn of CLibName -> ""
+                                   CSubLibName n -> ":" ++ prettyShow n
+                                   _ -> ":" ++ prettyShow cn
+                     ++ "=" ++ prettyShow cid)))
 
       ,option "" ["instantiate-with"]
         "A mapping of signature names to concrete module instantiations."
@@ -730,12 +736,18 @@ showProfDetailLevelFlag :: Flag ProfDetailLevel -> [String]
 showProfDetailLevelFlag NoFlag    = []
 showProfDetailLevelFlag (Flag dl) = [showProfDetailLevel dl]
 
-parsecDependency :: ParsecParser (PackageName, ComponentId)
+parsecDependency :: ParsecParser (PackageName, ComponentName, ComponentId)
 parsecDependency = do
-  x <- parsec
+  pn <- parsec
+  cn <- P.option CLibName $ do
+    _ <- P.char ':'
+    ucn <- parsec
+    return $ if unUnqualComponentName ucn == unPackageName pn
+             then CLibName
+             else CSubLibName ucn
   _ <- P.char '='
-  y <- parsec
-  return (x, y)
+  cid <- parsec
+  return (pn, cn, cid)
 
 installDirsOptions :: [OptionField (InstallDirs (Flag PathTemplate))]
 installDirsOptions =

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -652,9 +652,8 @@ configureOptions showOrParseArgs =
                  (parsecToReadE (const "dependency expected") ((\x -> [x]) `fmap` parsecGivenComponent))
                  (map (\(GivenComponent pn cn cid) ->
                      prettyShow pn
-                     ++ case cn of CLibName -> ""
-                                   CSubLibName n -> ":" ++ prettyShow n
-                                   _ -> ":" ++ prettyShow cn
+                     ++ case cn of LMainLibName -> ""
+                                   LSubLibName n -> ":" ++ prettyShow n
                      ++ "=" ++ prettyShow cid)))
 
       ,option "" ["instantiate-with"]
@@ -740,15 +739,15 @@ showProfDetailLevelFlag (Flag dl) = [showProfDetailLevel dl]
 parsecGivenComponent :: ParsecParser GivenComponent
 parsecGivenComponent = do
   pn <- parsec
-  cn <- P.option CLibName $ do
+  ln <- P.option LMainLibName $ do
     _ <- P.char ':'
     ucn <- parsec
     return $ if unUnqualComponentName ucn == unPackageName pn
-             then CLibName
-             else CSubLibName ucn
+             then LMainLibName
+             else LSubLibName ucn
   _ <- P.char '='
   cid <- parsec
-  return $ GivenComponent pn cn cid
+  return $ GivenComponent pn ln cid
 
 installDirsOptions :: [OptionField (InstallDirs (Flag PathTemplate))]
 installDirsOptions =

--- a/Cabal/Distribution/Types/ComponentName.hs
+++ b/Cabal/Distribution/Types/ComponentName.hs
@@ -3,7 +3,6 @@
 
 module Distribution.Types.ComponentName (
   ComponentName(..),
-  defaultLibName,
   libraryComponentName,
   showComponentName,
   componentNameStanza,
@@ -16,14 +15,14 @@ import Distribution.Compat.Prelude
 import qualified Distribution.Compat.ReadP as Parse
 import Distribution.Compat.ReadP   ((<++))
 import Distribution.Types.UnqualComponentName
+import Distribution.Types.LibraryName
 import Distribution.Pretty
 import Distribution.Text
 
 import Text.PrettyPrint as Disp
 
 -- Libraries live in a separate namespace, so must distinguish
-data ComponentName = CLibName
-                   | CSubLibName UnqualComponentName
+data ComponentName = CLibName   LibraryName
                    | CFLibName  UnqualComponentName
                    | CExeName   UnqualComponentName
                    | CTestName  UnqualComponentName
@@ -34,39 +33,32 @@ instance Binary ComponentName
 
 -- Build-target-ish syntax
 instance Pretty ComponentName where
-    pretty CLibName = Disp.text "lib"
-    pretty (CSubLibName str) = Disp.text "lib:" <<>> pretty str
+    pretty (CLibName lib)    = pretty lib
     pretty (CFLibName str)   = Disp.text "flib:" <<>> pretty str
     pretty (CExeName str)    = Disp.text "exe:" <<>> pretty str
     pretty (CTestName str)   = Disp.text "test:" <<>> pretty str
     pretty (CBenchName str)  = Disp.text "bench:" <<>> pretty str
 
 instance Text ComponentName where
-    parse = parseComposite <++ parseSingle
+    parse = parseComposite <++ parseLib
      where
-      parseSingle = Parse.string "lib" >> return CLibName
+      parseLib = CLibName <$> parse
       parseComposite = do
-        ctor <- Parse.choice [ Parse.string "lib:" >> return CSubLibName
-                             , Parse.string "flib:" >> return CFLibName
+        ctor <- Parse.choice [ Parse.string "flib:" >> return CFLibName
                              , Parse.string "exe:" >> return CExeName
                              , Parse.string "bench:" >> return CBenchName
                              , Parse.string "test:" >> return CTestName ]
         ctor <$> parse
 
-defaultLibName :: ComponentName
-defaultLibName = CLibName
-
 showComponentName :: ComponentName -> String
-showComponentName CLibName          = "library"
-showComponentName (CSubLibName name) = "library '" ++ display name ++ "'"
+showComponentName (CLibName lib)    = showLibraryName lib
 showComponentName (CFLibName  name) = "foreign library '" ++ display name ++ "'"
 showComponentName (CExeName   name) = "executable '" ++ display name ++ "'"
 showComponentName (CTestName  name) = "test suite '" ++ display name ++ "'"
 showComponentName (CBenchName name) = "benchmark '" ++ display name ++ "'"
 
 componentNameStanza :: ComponentName -> String
-componentNameStanza CLibName          = "library"
-componentNameStanza (CSubLibName name) = "library " ++ display name
+componentNameStanza (CLibName lib)    = libraryNameStanza lib
 componentNameStanza (CFLibName  name) = "foreign-library " ++ display name
 componentNameStanza (CExeName   name) = "executable " ++ display name
 componentNameStanza (CTestName  name) = "test-suite " ++ display name
@@ -77,8 +69,7 @@ componentNameStanza (CBenchName name) = "benchmark " ++ display name
 -- @Nothing@ if the 'ComponentName' was for the public
 -- library.
 componentNameString :: ComponentName -> Maybe UnqualComponentName
-componentNameString CLibName = Nothing
-componentNameString (CSubLibName n) = Just n
+componentNameString (CLibName lib) = libraryNameString lib
 componentNameString (CFLibName  n) = Just n
 componentNameString (CExeName   n) = Just n
 componentNameString (CTestName  n) = Just n
@@ -87,5 +78,5 @@ componentNameString (CBenchName n) = Just n
 -- | Convert the 'UnqualComponentName' of a library into a
 -- 'ComponentName'.
 libraryComponentName :: Maybe UnqualComponentName -> ComponentName
-libraryComponentName Nothing = CLibName
-libraryComponentName (Just n) = CSubLibName n
+libraryComponentName Nothing = CLibName LMainLibName
+libraryComponentName (Just n) = CLibName $ LSubLibName n

--- a/Cabal/Distribution/Types/Dependency.hs
+++ b/Cabal/Distribution/Types/Dependency.hs
@@ -4,6 +4,7 @@ module Distribution.Types.Dependency
   ( Dependency(..)
   , depPkgName
   , depVerRange
+  , depLibraries
   , thisPackageVersion
   , notThisPackageVersion
   , simplifyDependency
@@ -20,53 +21,95 @@ import qualified Distribution.Compat.ReadP as Parse
 
 import Distribution.Text
 import Distribution.Pretty
+import qualified Text.PrettyPrint as PP
 import Distribution.Parsec.Class
+import Distribution.Compat.CharParsing (char, spaces)
+import Distribution.Compat.Parsing (between, option)
 import Distribution.Types.PackageId
 import Distribution.Types.PackageName
+import Distribution.Types.LibraryName
+import Distribution.Types.UnqualComponentName
 
 import Text.PrettyPrint ((<+>))
+import Data.Set (Set)
+import qualified Data.Set as Set
 
 -- | Describes a dependency on a source package (API)
 --
-data Dependency = Dependency PackageName VersionRange
+data Dependency = Dependency
+                    PackageName
+                    VersionRange
+                    (Set LibraryName)
+                    -- ^ The set of libraries required from the package.
+                    -- Only the selected libraries will be built.
+                    -- It does not affect the cabal-install solver yet.
                   deriving (Generic, Read, Show, Eq, Typeable, Data)
 
 depPkgName :: Dependency -> PackageName
-depPkgName (Dependency pn _) = pn
+depPkgName (Dependency pn _ _) = pn
 
 depVerRange :: Dependency -> VersionRange
-depVerRange (Dependency _ vr) = vr
+depVerRange (Dependency _ vr _) = vr
+
+depLibraries :: Dependency -> Set LibraryName
+depLibraries (Dependency _ _ cs) = cs
 
 instance Binary Dependency
 instance NFData Dependency where rnf = genericRnf
 
 instance Pretty Dependency where
-    pretty (Dependency name ver) = pretty name <+> pretty ver
+    pretty (Dependency name ver sublibs) = pretty name
+                                       <+> optionalMonoid
+                                             (sublibs /= Set.singleton LMainLibName)
+                                             (PP.colon <+> PP.braces prettySublibs)
+                                       <+> pretty ver
+      where
+        optionalMonoid True x = x
+        optionalMonoid False _ = mempty
+        prettySublibs = PP.hsep $ PP.punctuate PP.comma $ prettySublib <$> Set.toList sublibs
+        prettySublib LMainLibName = PP.text $ unPackageName name
+        prettySublib (LSubLibName un) = PP.text $ unUnqualComponentName un
 
 instance Parsec Dependency where
     parsec = do
         name <- lexemeParsec
+        libs <- option [LMainLibName]
+              $ (char ':' *> spaces *>)
+              $ between (char '{' *> spaces) (spaces <* char '}')
+              $ parsecCommaList (makeLib name <$> parsecUnqualComponentName)
         ver  <- parsec <|> pure anyVersion
-        return (Dependency name ver)
+        return $ Dependency name ver $ Set.fromList libs
+      where makeLib pn ln | unPackageName pn == ln = LMainLibName
+                          | otherwise = LSubLibName $ mkUnqualComponentName ln
 
 instance Text Dependency where
   parse = do name <- parse
              Parse.skipSpaces
+             libs <- option [LMainLibName]
+                   $ (char ':' *>)
+                   $ between (char '{') (char '}')
+                   $ parsecCommaList (makeLib name <$> parsecUnqualComponentName)
+             Parse.skipSpaces
              ver <- parse Parse.<++ return anyVersion
              Parse.skipSpaces
-             return (Dependency name ver)
+             return $ Dependency name ver $ Set.fromList libs
+    where makeLib pn ln | unPackageName pn == ln = LMainLibName
+                        | otherwise = LSubLibName $ mkUnqualComponentName ln
 
+-- mempty should never be in a Dependency-as-dependency.
+-- This is only here until the Dependency-as-constraint problem is solved #5570.
+-- Same for below.
 thisPackageVersion :: PackageIdentifier -> Dependency
 thisPackageVersion (PackageIdentifier n v) =
-  Dependency n (thisVersion v)
+  Dependency n (thisVersion v) Set.empty
 
 notThisPackageVersion :: PackageIdentifier -> Dependency
 notThisPackageVersion (PackageIdentifier n v) =
-  Dependency n (notThisVersion v)
+  Dependency n (notThisVersion v) Set.empty
 
 -- | Simplify the 'VersionRange' expression in a 'Dependency'.
 -- See 'simplifyVersionRange'.
 --
 simplifyDependency :: Dependency -> Dependency
-simplifyDependency (Dependency name range) =
-  Dependency name (simplifyVersionRange range)
+simplifyDependency (Dependency name range comps) =
+  Dependency name (simplifyVersionRange range) comps

--- a/Cabal/Distribution/Types/DependencyMap.hs
+++ b/Cabal/Distribution/Types/DependencyMap.hs
@@ -10,13 +10,15 @@ import Distribution.Compat.Prelude
 
 import Distribution.Types.Dependency
 import Distribution.Types.PackageName
+import Distribution.Types.LibraryName
 import Distribution.Version
 
+import Data.Set (Set)
 import qualified Data.Map.Lazy as Map
 
 -- | A map of dependencies.  Newtyped since the default monoid instance is not
 --   appropriate.  The monoid instance uses 'intersectVersionRanges'.
-newtype DependencyMap = DependencyMap { unDependencyMap :: Map PackageName VersionRange }
+newtype DependencyMap = DependencyMap { unDependencyMap :: Map PackageName (VersionRange, Set LibraryName) }
   deriving (Show, Read)
 
 instance Monoid DependencyMap where
@@ -25,14 +27,20 @@ instance Monoid DependencyMap where
 
 instance Semigroup DependencyMap where
     (DependencyMap a) <> (DependencyMap b) =
-        DependencyMap (Map.unionWith intersectVersionRanges a b)
+        DependencyMap (Map.unionWith intersectVersionRangesAndJoinComponents a b)
+
+intersectVersionRangesAndJoinComponents :: (VersionRange, Set LibraryName)
+                                        -> (VersionRange, Set LibraryName)
+                                        -> (VersionRange, Set LibraryName)
+intersectVersionRangesAndJoinComponents (va, ca) (vb, cb) =
+  (intersectVersionRanges va vb, ca <> cb)
 
 toDepMap :: [Dependency] -> DependencyMap
 toDepMap ds =
-  DependencyMap $ Map.fromListWith intersectVersionRanges [ (p,vr) | Dependency p vr <- ds ]
+  DependencyMap $ Map.fromListWith intersectVersionRangesAndJoinComponents [ (p,(vr,cs)) | Dependency p vr cs <- ds ]
 
 fromDepMap :: DependencyMap -> [Dependency]
-fromDepMap m = [ Dependency p vr | (p,vr) <- Map.toList (unDependencyMap m) ]
+fromDepMap m = [ Dependency p vr cs | (p,(vr,cs)) <- Map.toList (unDependencyMap m) ]
 
 -- Apply extra constraints to a dependency map.
 -- Combines dependencies where the result will only contain keys from the left
@@ -48,4 +56,4 @@ constrainBy left extra =
   where tightenConstraint n c l =
             case Map.lookup n l of
               Nothing -> l
-              Just vr -> Map.insert n (intersectVersionRanges vr c) l
+              Just vrcs -> Map.insert n (intersectVersionRangesAndJoinComponents vrcs c) l

--- a/Cabal/Distribution/Types/GivenComponent.hs
+++ b/Cabal/Distribution/Types/GivenComponent.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+module Distribution.Types.GivenComponent (
+  GivenComponent(..)
+) where
+
+import Distribution.Compat.Prelude
+
+import Distribution.Types.ComponentId
+import Distribution.Types.ComponentName
+import Distribution.Types.PackageName
+
+-- | A 'GivenComponent' represents a component depended on and explicitly
+-- specified by the user/client with @--dependency@
+--
+-- It enables Cabal to know which 'ComponentId' to associate with a component
+--
+-- @since 2.3.0.0
+data GivenComponent =
+  GivenComponent
+    { givenComponentPackage :: PackageName
+    , givenComponentName    :: ComponentName
+    , givenComponentId      :: ComponentId }
+  deriving (Generic, Read, Show, Eq, Typeable)
+
+instance Binary GivenComponent
+

--- a/Cabal/Distribution/Types/GivenComponent.hs
+++ b/Cabal/Distribution/Types/GivenComponent.hs
@@ -7,19 +7,20 @@ module Distribution.Types.GivenComponent (
 import Distribution.Compat.Prelude
 
 import Distribution.Types.ComponentId
-import Distribution.Types.ComponentName
+import Distribution.Types.LibraryName
 import Distribution.Types.PackageName
 
--- | A 'GivenComponent' represents a component depended on and explicitly
+-- | A 'GivenComponent' represents a library depended on and explicitly
 -- specified by the user/client with @--dependency@
 --
--- It enables Cabal to know which 'ComponentId' to associate with a component
+-- It enables Cabal to know which 'ComponentId' to associate with a library
 --
 -- @since 2.3.0.0
 data GivenComponent =
   GivenComponent
     { givenComponentPackage :: PackageName
-    , givenComponentName    :: ComponentName
+    , givenComponentName    :: LibraryName -- --dependency is for libraries
+                                           -- only, not for any component
     , givenComponentId      :: ComponentId }
   deriving (Generic, Read, Show, Eq, Typeable)
 

--- a/Cabal/Distribution/Types/LibraryName.hs
+++ b/Cabal/Distribution/Types/LibraryName.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Distribution.Types.LibraryName (
+  LibraryName(..),
+  defaultLibName,
+  maybeToLibraryName,
+  showLibraryName,
+  libraryNameStanza,
+  libraryNameString,
+  ) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+import qualified Distribution.Compat.ReadP as Parse
+import Distribution.Compat.ReadP   ((<++))
+import Distribution.Types.UnqualComponentName
+import Distribution.Pretty
+import Distribution.Text
+
+import Text.PrettyPrint as Disp
+
+data LibraryName = LMainLibName
+                 | LSubLibName UnqualComponentName
+                 deriving (Eq, Generic, Ord, Read, Show, Typeable)
+
+instance Binary LibraryName
+
+-- Build-target-ish syntax
+instance Pretty LibraryName where
+    pretty LMainLibName = Disp.text "lib"
+    pretty (LSubLibName str) = Disp.text "lib:" <<>> pretty str
+
+instance Text LibraryName where
+    parse = parseComposite <++ parseSingle
+     where
+      parseSingle = Parse.string "lib" >> return LMainLibName
+      parseComposite = do
+        ctor <- Parse.string "lib:" >> return LSubLibName
+        ctor <$> parse
+
+defaultLibName :: LibraryName
+defaultLibName = LMainLibName
+
+showLibraryName :: LibraryName -> String
+showLibraryName LMainLibName          = "library"
+showLibraryName (LSubLibName name) = "library '" ++ display name ++ "'"
+
+libraryNameStanza :: LibraryName -> String
+libraryNameStanza LMainLibName          = "library"
+libraryNameStanza (LSubLibName name) = "library " ++ display name
+
+libraryNameString :: LibraryName -> Maybe UnqualComponentName
+libraryNameString LMainLibName = Nothing
+libraryNameString (LSubLibName n) = Just n
+
+-- | Convert the 'UnqualComponentName' of a library into a
+-- 'LibraryName'.
+maybeToLibraryName :: Maybe UnqualComponentName -> LibraryName
+maybeToLibraryName Nothing = LMainLibName
+maybeToLibraryName (Just n) = LSubLibName n
+

--- a/Cabal/Distribution/Types/LibraryName.hs
+++ b/Cabal/Distribution/Types/LibraryName.hs
@@ -23,9 +23,10 @@ import Text.PrettyPrint as Disp
 
 data LibraryName = LMainLibName
                  | LSubLibName UnqualComponentName
-                 deriving (Eq, Generic, Ord, Read, Show, Typeable)
+                 deriving (Eq, Generic, Ord, Read, Show, Typeable, Data)
 
 instance Binary LibraryName
+instance NFData LibraryName where rnf = genericRnf
 
 -- Build-target-ish syntax
 instance Pretty LibraryName where

--- a/Cabal/Distribution/Types/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Types/LocalBuildInfo.hs
@@ -176,7 +176,7 @@ instance Binary LocalBuildInfo
 -- on the package ID.
 localComponentId :: LocalBuildInfo -> ComponentId
 localComponentId lbi =
-    case componentNameCLBIs lbi CLibName of
+    case componentNameCLBIs lbi (CLibName LMainLibName) of
         [LibComponentLocalBuildInfo { componentComponentId = cid }]
           -> cid
         _ -> mkComponentId (display (localPackage lbi))
@@ -191,7 +191,7 @@ localPackage lbi = package (localPkgDescr lbi)
 -- the package ID.
 localUnitId :: LocalBuildInfo -> UnitId
 localUnitId lbi =
-    case componentNameCLBIs lbi CLibName of
+    case componentNameCLBIs lbi (CLibName LMainLibName) of
         [LibComponentLocalBuildInfo { componentUnitId = uid }]
           -> uid
         _ -> mkLegacyUnitId $ localPackage lbi
@@ -201,7 +201,7 @@ localUnitId lbi =
 -- on the package ID.
 localCompatPackageKey :: LocalBuildInfo -> String
 localCompatPackageKey lbi =
-    case componentNameCLBIs lbi CLibName of
+    case componentNameCLBIs lbi (CLibName LMainLibName) of
         [LibComponentLocalBuildInfo { componentCompatPackageKey = pk }]
           -> pk
         _ -> display (localPackage lbi)

--- a/Cabal/Distribution/Types/PackageDescription.hs
+++ b/Cabal/Distribution/Types/PackageDescription.hs
@@ -77,6 +77,7 @@ import Distribution.Types.ComponentRequestedSpec
 import Distribution.Types.Dependency
 import Distribution.Types.PackageId
 import Distribution.Types.ComponentName
+import Distribution.Types.LibraryName
 import Distribution.Types.PackageName
 import Distribution.Types.UnqualComponentName
 import Distribution.Types.SetupBuildInfo
@@ -449,8 +450,8 @@ enabledComponents :: PackageDescription -> ComponentRequestedSpec -> [Component]
 enabledComponents pkg enabled = filter (componentEnabled enabled) $ pkgBuildableComponents pkg
 
 lookupComponent :: PackageDescription -> ComponentName -> Maybe Component
-lookupComponent pkg CLibName = fmap CLib (library pkg)
-lookupComponent pkg (CSubLibName name) =
+lookupComponent pkg (CLibName LMainLibName) = fmap CLib (library pkg)
+lookupComponent pkg (CLibName (LSubLibName name)) =
     fmap CLib $ find ((Just name ==) . libName) (subLibraries pkg)
 lookupComponent pkg (CFLibName name) =
     fmap CFLib $ find ((name ==) . foreignLibName) (foreignLibs pkg)

--- a/Cabal/Distribution/Types/PackageDescription/Lens.hs
+++ b/Cabal/Distribution/Types/PackageDescription/Lens.hs
@@ -23,6 +23,7 @@ import Distribution.Types.ForeignLib          (ForeignLib, foreignLibModules)
 import Distribution.Types.ForeignLib.Lens     (foreignLibName, foreignLibBuildInfo)
 import Distribution.Types.Library             (Library, explicitLibModules)
 import Distribution.Types.Library.Lens        (libName, libBuildInfo)
+import Distribution.Types.LibraryName         (LibraryName(..))
 import Distribution.Types.PackageDescription  (PackageDescription)
 import Distribution.Types.PackageId           (PackageIdentifier)
 import Distribution.Types.SetupBuildInfo      (SetupBuildInfo)
@@ -158,8 +159,8 @@ extraDocFiles f s = fmap (\x -> s { T.extraDocFiles = x }) (f (T.extraDocFiles s
 -- | @since 2.4
 componentModules :: Monoid r => ComponentName -> Getting r PackageDescription [ModuleName]
 componentModules cname = case cname of
-    CLibName         -> library  . traverse . getting explicitLibModules
-    CSubLibName name -> 
+    CLibName LMainLibName -> library  . traverse . getting explicitLibModules
+    CLibName (LSubLibName name) -> 
       componentModules' name subLibraries (libName . non "") explicitLibModules
     CFLibName   name -> 
       componentModules' name foreignLibs  foreignLibName     foreignLibModules
@@ -194,9 +195,9 @@ componentModules cname = case cname of
 -- | @since 2.4
 componentBuildInfo :: ComponentName -> Traversal' PackageDescription BuildInfo
 componentBuildInfo cname = case cname of
-    CLibName         -> 
+    CLibName LMainLibName -> 
       library  . traverse . libBuildInfo
-    CSubLibName name -> 
+    CLibName (LSubLibName name) -> 
       componentBuildInfo' name subLibraries (libName . non "") libBuildInfo
     CFLibName   name -> 
       componentBuildInfo' name foreignLibs  foreignLibName     foreignLibBuildInfo

--- a/Cabal/Distribution/Types/PackageVersionConstraint.hs
+++ b/Cabal/Distribution/Types/PackageVersionConstraint.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+module Distribution.Types.PackageVersionConstraint
+  ( PackageVersionConstraint(..)
+  ) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+import qualified Distribution.Compat.ReadP as Parse
+import Distribution.Text
+import Distribution.Pretty
+import Text.PrettyPrint ((<+>))
+
+import Distribution.Types.VersionRange
+import Distribution.Types.PackageName
+
+
+-- | A version constraint on a package. Different from 'ExeDependency' and
+-- 'Dependency' since it does not specify the need for a component, not even
+-- the main library.
+-- There are a few places in the codebase where 'Dependency' is used where
+-- 'PackageVersionConstraint' should be used instead (#5570).
+data PackageVersionConstraint = PackageVersionConstraint PackageName VersionRange
+                  deriving (Generic, Read, Show, Eq, Typeable, Data)
+
+instance Binary PackageVersionConstraint
+instance NFData PackageVersionConstraint where rnf = genericRnf
+
+instance Pretty PackageVersionConstraint where
+  pretty (PackageVersionConstraint name ver) = pretty name <+> pretty ver
+
+instance Text PackageVersionConstraint where
+  parse = do name <- parse
+             Parse.skipSpaces
+             ver <- parse Parse.<++ return anyVersion
+             Parse.skipSpaces
+             return (PackageVersionConstraint name ver)
+

--- a/Cabal/tests/Instances/TreeDiff.hs
+++ b/Cabal/tests/Instances/TreeDiff.hs
@@ -70,6 +70,7 @@ instance ToExpr InstalledPackageInfo
 instance ToExpr LegacyExeDependency where toExpr = defaultExprViaShow
 instance ToExpr LibVersionInfo where toExpr = defaultExprViaShow
 instance ToExpr Library
+instance ToExpr LibraryName
 instance ToExpr Mixin where toExpr = defaultExprViaShow
 instance ToExpr ModuleName where toExpr = defaultExprViaShow
 instance ToExpr ModuleReexport

--- a/Cabal/tests/ParserTests/regressions/Octree-0.5.expr
+++ b/Cabal/tests/ParserTests/regressions/Octree-0.5.expr
@@ -9,13 +9,16 @@ GenericPackageDescription
                                                `PackageName "base"`
                                                (IntersectVersionRanges
                                                   (OrLaterVersion `mkVersion [4,0]`)
-                                                  (EarlierVersion `mkVersion [4,7]`)),
+                                                  (EarlierVersion `mkVersion [4,7]`))
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "AC-Vector"`
-                                               (OrLaterVersion `mkVersion [2,3,0]`),
+                                               (OrLaterVersion `mkVersion [2,3,0]`)
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "QuickCheck"`
-                                               (OrLaterVersion `mkVersion [2,4,0]`)],
+                                               (OrLaterVersion `mkVersion [2,4,0]`)
+                                               (Set.fromList [LMainLibName])],
                       condTreeData = Library
                                        {exposedModules = [`ModuleName ["Data","Octree"]`],
                                         libBuildInfo = BuildInfo
@@ -65,15 +68,21 @@ GenericPackageDescription
                                                                                      (OrLaterVersion
                                                                                         `mkVersion [4,0]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [4,7]`)),
+                                                                                        `mkVersion [4,7]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "AC-Vector"`
                                                                                   (OrLaterVersion
-                                                                                     `mkVersion [2,3,0]`),
+                                                                                     `mkVersion [2,3,0]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "QuickCheck"`
                                                                                   (OrLaterVersion
-                                                                                     `mkVersion [2,4,0]`)],
+                                                                                     `mkVersion [2,4,0]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName])],
                                                           virtualModules = []},
                                         libExposed = True,
                                         libName = Nothing,
@@ -88,13 +97,16 @@ GenericPackageDescription
                                                    `PackageName "base"`
                                                    (IntersectVersionRanges
                                                       (OrLaterVersion `mkVersion [4,0]`)
-                                                      (EarlierVersion `mkVersion [4,7]`)),
+                                                      (EarlierVersion `mkVersion [4,7]`))
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "AC-Vector"`
-                                                   (OrLaterVersion `mkVersion [2,3,0]`),
+                                                   (OrLaterVersion `mkVersion [2,3,0]`)
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "QuickCheck"`
-                                                   (OrLaterVersion `mkVersion [2,4,0]`)],
+                                                   (OrLaterVersion `mkVersion [2,4,0]`)
+                                                   (Set.fromList [LMainLibName])],
                           condTreeData = TestSuite
                                            {testBuildInfo = BuildInfo
                                                               {asmOptions = [],
@@ -142,15 +154,21 @@ GenericPackageDescription
                                                                                           (OrLaterVersion
                                                                                              `mkVersion [4,0]`)
                                                                                           (EarlierVersion
-                                                                                             `mkVersion [4,7]`)),
+                                                                                             `mkVersion [4,7]`))
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "AC-Vector"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [2,3,0]`),
+                                                                                          `mkVersion [2,3,0]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "QuickCheck"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [2,4,0]`)],
+                                                                                          `mkVersion [2,4,0]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName])],
                                                                virtualModules = []},
                                             testInterface = TestSuiteExeV10
                                                               `mkVersion [1,0]`
@@ -164,15 +182,20 @@ GenericPackageDescription
                                                    `PackageName "base"`
                                                    (IntersectVersionRanges
                                                       (OrLaterVersion `mkVersion [4,0]`)
-                                                      (EarlierVersion `mkVersion [4,7]`)),
+                                                      (EarlierVersion `mkVersion [4,7]`))
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "AC-Vector"`
-                                                   (OrLaterVersion `mkVersion [2,3,0]`),
+                                                   (OrLaterVersion `mkVersion [2,3,0]`)
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "QuickCheck"`
-                                                   (OrLaterVersion `mkVersion [2,4,0]`),
+                                                   (OrLaterVersion `mkVersion [2,4,0]`)
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
-                                                   `PackageName "markdown-unlit"` AnyVersion],
+                                                   `PackageName "markdown-unlit"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName])],
                           condTreeData = TestSuite
                                            {testBuildInfo = BuildInfo
                                                               {asmOptions = [],
@@ -223,18 +246,26 @@ GenericPackageDescription
                                                                                           (OrLaterVersion
                                                                                              `mkVersion [4,0]`)
                                                                                           (EarlierVersion
-                                                                                             `mkVersion [4,7]`)),
+                                                                                             `mkVersion [4,7]`))
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "AC-Vector"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [2,3,0]`),
+                                                                                          `mkVersion [2,3,0]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "QuickCheck"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [2,4,0]`),
+                                                                                          `mkVersion [2,4,0]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "markdown-unlit"`
-                                                                                       AnyVersion],
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName])],
                                                                virtualModules = []},
                                             testInterface = TestSuiteExeV10
                                                               `mkVersion [1,0]` "README.lhs",

--- a/Cabal/tests/ParserTests/regressions/common.expr
+++ b/Cabal/tests/ParserTests/regressions/common.expr
@@ -6,7 +6,9 @@ GenericPackageDescription
                    CondNode
                      {condTreeComponents = [],
                       condTreeConstraints = [Dependency
-                                               `PackageName "ghc-prim"` AnyVersion],
+                                               `PackageName "ghc-prim"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName])],
                       condTreeData = Library
                                        {exposedModules = [`ModuleName ["ElseIf"]`],
                                         libBuildInfo = BuildInfo
@@ -51,7 +53,9 @@ GenericPackageDescription
                                                           staticOptions = [],
                                                           targetBuildDepends = [Dependency
                                                                                   `PackageName "ghc-prim"`
-                                                                                  AnyVersion],
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName])],
                                                           virtualModules = []},
                                         libExposed = True,
                                         libName = Nothing,
@@ -63,7 +67,9 @@ GenericPackageDescription
                        CondNode
                          {condTreeComponents = [],
                           condTreeConstraints = [Dependency
-                                                   `PackageName "HUnit"` AnyVersion],
+                                                   `PackageName "HUnit"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName])],
                           condTreeData = TestSuite
                                            {testBuildInfo = BuildInfo
                                                               {asmOptions = [],
@@ -107,7 +113,9 @@ GenericPackageDescription
                                                                staticOptions = [],
                                                                targetBuildDepends = [Dependency
                                                                                        `PackageName "HUnit"`
-                                                                                       AnyVersion],
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName])],
                                                                virtualModules = []},
                                             testInterface = TestSuiteExeV10
                                                               `mkVersion [1,0]` "Tests.hs",

--- a/Cabal/tests/ParserTests/regressions/common2.expr
+++ b/Cabal/tests/ParserTests/regressions/common2.expr
@@ -11,7 +11,9 @@ GenericPackageDescription
                                                                     {condTreeComponents = [],
                                                                      condTreeConstraints = [Dependency
                                                                                               `PackageName "Win32"`
-                                                                                              AnyVersion],
+                                                                                              AnyVersion
+                                                                                              (Set.fromList
+                                                                                                 [LMainLibName])],
                                                                      condTreeData = Library
                                                                                       {exposedModules = [],
                                                                                        libBuildInfo = BuildInfo
@@ -56,7 +58,9 @@ GenericPackageDescription
                                                                                                          staticOptions = [],
                                                                                                          targetBuildDepends = [Dependency
                                                                                                                                  `PackageName "Win32"`
-                                                                                                                                 AnyVersion],
+                                                                                                                                 AnyVersion
+                                                                                                                                 (Set.fromList
+                                                                                                                                    [LMainLibName])],
                                                                                                          virtualModules = []},
                                                                                        libExposed = True,
                                                                                        libName = Nothing,
@@ -66,9 +70,16 @@ GenericPackageDescription
                                                `PackageName "base"`
                                                (IntersectVersionRanges
                                                   (OrLaterVersion `mkVersion [4,10]`)
-                                                  (EarlierVersion `mkVersion [4,11]`)),
-                                             Dependency `PackageName "containers"` AnyVersion,
-                                             Dependency `PackageName "ghc-prim"` AnyVersion],
+                                                  (EarlierVersion `mkVersion [4,11]`))
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "containers"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "ghc-prim"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName])],
                       condTreeData = Library
                                        {exposedModules = [`ModuleName ["ElseIf"]`],
                                         libBuildInfo = BuildInfo
@@ -117,13 +128,19 @@ GenericPackageDescription
                                                                                      (OrLaterVersion
                                                                                         `mkVersion [4,10]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [4,11]`)),
+                                                                                        `mkVersion [4,11]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "containers"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "ghc-prim"`
-                                                                                  AnyVersion],
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName])],
                                                           virtualModules = []},
                                         libExposed = True,
                                         libName = Nothing,
@@ -140,7 +157,9 @@ GenericPackageDescription
                                                                         {condTreeComponents = [],
                                                                          condTreeConstraints = [Dependency
                                                                                                   `PackageName "Win32"`
-                                                                                                  AnyVersion],
+                                                                                                  AnyVersion
+                                                                                                  (Set.fromList
+                                                                                                     [LMainLibName])],
                                                                          condTreeData = TestSuite
                                                                                           {testBuildInfo = BuildInfo
                                                                                                              {asmOptions = [],
@@ -184,7 +203,9 @@ GenericPackageDescription
                                                                                                               staticOptions = [],
                                                                                                               targetBuildDepends = [Dependency
                                                                                                                                       `PackageName "Win32"`
-                                                                                                                                      AnyVersion],
+                                                                                                                                      AnyVersion
+                                                                                                                                      (Set.fromList
+                                                                                                                                         [LMainLibName])],
                                                                                                               virtualModules = []},
                                                                                            testInterface = TestSuiteUnsupported
                                                                                                              (TestTypeUnknown
@@ -198,7 +219,9 @@ GenericPackageDescription
                                                                         {condTreeComponents = [],
                                                                          condTreeConstraints = [Dependency
                                                                                                   `PackageName "Win32"`
-                                                                                                  AnyVersion],
+                                                                                                  AnyVersion
+                                                                                                  (Set.fromList
+                                                                                                     [LMainLibName])],
                                                                          condTreeData = TestSuite
                                                                                           {testBuildInfo = BuildInfo
                                                                                                              {asmOptions = [],
@@ -242,7 +265,9 @@ GenericPackageDescription
                                                                                                               staticOptions = [],
                                                                                                               targetBuildDepends = [Dependency
                                                                                                                                       `PackageName "Win32"`
-                                                                                                                                      AnyVersion],
+                                                                                                                                      AnyVersion
+                                                                                                                                      (Set.fromList
+                                                                                                                                         [LMainLibName])],
                                                                                                               virtualModules = []},
                                                                                            testInterface = TestSuiteUnsupported
                                                                                                              (TestTypeUnknown
@@ -307,9 +332,16 @@ GenericPackageDescription
                                                    `PackageName "base"`
                                                    (IntersectVersionRanges
                                                       (OrLaterVersion `mkVersion [4,10]`)
-                                                      (EarlierVersion `mkVersion [4,11]`)),
-                                                 Dependency `PackageName "containers"` AnyVersion,
-                                                 Dependency `PackageName "HUnit"` AnyVersion],
+                                                      (EarlierVersion `mkVersion [4,11]`))
+                                                   (Set.fromList [LMainLibName]),
+                                                 Dependency
+                                                   `PackageName "containers"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
+                                                 Dependency
+                                                   `PackageName "HUnit"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName])],
                           condTreeData = TestSuite
                                            {testBuildInfo = BuildInfo
                                                               {asmOptions = [],
@@ -357,13 +389,19 @@ GenericPackageDescription
                                                                                           (OrLaterVersion
                                                                                              `mkVersion [4,10]`)
                                                                                           (EarlierVersion
-                                                                                             `mkVersion [4,11]`)),
+                                                                                             `mkVersion [4,11]`))
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "containers"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "HUnit"`
-                                                                                       AnyVersion],
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName])],
                                                                virtualModules = []},
                                             testInterface = TestSuiteExeV10
                                                               `mkVersion [1,0]` "Tests.hs",

--- a/Cabal/tests/ParserTests/regressions/elif.expr
+++ b/Cabal/tests/ParserTests/regressions/elif.expr
@@ -11,7 +11,9 @@ GenericPackageDescription
                                                                     {condTreeComponents = [],
                                                                      condTreeConstraints = [Dependency
                                                                                               `PackageName "unix"`
-                                                                                              AnyVersion],
+                                                                                              AnyVersion
+                                                                                              (Set.fromList
+                                                                                                 [LMainLibName])],
                                                                      condTreeData = Library
                                                                                       {exposedModules = [],
                                                                                        libBuildInfo = BuildInfo
@@ -56,7 +58,9 @@ GenericPackageDescription
                                                                                                          staticOptions = [],
                                                                                                          targetBuildDepends = [Dependency
                                                                                                                                  `PackageName "unix"`
-                                                                                                                                 AnyVersion],
+                                                                                                                                 AnyVersion
+                                                                                                                                 (Set.fromList
+                                                                                                                                    [LMainLibName])],
                                                                                                          virtualModules = []},
                                                                                        libExposed = True,
                                                                                        libName = Nothing,

--- a/Cabal/tests/ParserTests/regressions/elif2.expr
+++ b/Cabal/tests/ParserTests/regressions/elif2.expr
@@ -66,7 +66,9 @@ GenericPackageDescription
                                                                                                                       {condTreeComponents = [],
                                                                                                                        condTreeConstraints = [Dependency
                                                                                                                                                 `PackageName "Win32"`
-                                                                                                                                                AnyVersion],
+                                                                                                                                                AnyVersion
+                                                                                                                                                (Set.fromList
+                                                                                                                                                   [LMainLibName])],
                                                                                                                        condTreeData = Library
                                                                                                                                         {exposedModules = [],
                                                                                                                                          libBuildInfo = BuildInfo
@@ -111,7 +113,9 @@ GenericPackageDescription
                                                                                                                                                            staticOptions = [],
                                                                                                                                                            targetBuildDepends = [Dependency
                                                                                                                                                                                    `PackageName "Win32"`
-                                                                                                                                                                                   AnyVersion],
+                                                                                                                                                                                   AnyVersion
+                                                                                                                                                                                   (Set.fromList
+                                                                                                                                                                                      [LMainLibName])],
                                                                                                                                                            virtualModules = []},
                                                                                                                                          libExposed = True,
                                                                                                                                          libName = Nothing,
@@ -170,7 +174,9 @@ GenericPackageDescription
                                                                     {condTreeComponents = [],
                                                                      condTreeConstraints = [Dependency
                                                                                               `PackageName "unix"`
-                                                                                              AnyVersion],
+                                                                                              AnyVersion
+                                                                                              (Set.fromList
+                                                                                                 [LMainLibName])],
                                                                      condTreeData = Library
                                                                                       {exposedModules = [],
                                                                                        libBuildInfo = BuildInfo
@@ -215,7 +221,9 @@ GenericPackageDescription
                                                                                                          staticOptions = [],
                                                                                                          targetBuildDepends = [Dependency
                                                                                                                                  `PackageName "unix"`
-                                                                                                                                 AnyVersion],
+                                                                                                                                 AnyVersion
+                                                                                                                                 (Set.fromList
+                                                                                                                                    [LMainLibName])],
                                                                                                          virtualModules = []},
                                                                                        libExposed = True,
                                                                                        libName = Nothing,

--- a/Cabal/tests/ParserTests/regressions/encoding-0.8.expr
+++ b/Cabal/tests/ParserTests/regressions/encoding-0.8.expr
@@ -10,7 +10,8 @@ GenericPackageDescription
                                                (VersionRangeParens
                                                   (UnionVersionRanges
                                                      (LaterVersion `mkVersion [4,4]`)
-                                                     (ThisVersion `mkVersion [4,4]`)))],
+                                                     (ThisVersion `mkVersion [4,4]`)))
+                                               (Set.fromList [LMainLibName])],
                       condTreeData = Library
                                        {exposedModules = [`ModuleName ["Data","Encoding"]`],
                                         libBuildInfo = BuildInfo
@@ -66,7 +67,9 @@ GenericPackageDescription
                                                                                         (LaterVersion
                                                                                            `mkVersion [4,4]`)
                                                                                         (ThisVersion
-                                                                                           `mkVersion [4,4]`)))],
+                                                                                           `mkVersion [4,4]`)))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName])],
                                                           virtualModules = []},
                                         libExposed = True,
                                         libName = Nothing,
@@ -105,10 +108,12 @@ GenericPackageDescription
                                                 {defaultSetupDepends = False,
                                                  setupDepends = [Dependency
                                                                    `PackageName "base"`
-                                                                   (EarlierVersion `mkVersion [5]`),
+                                                                   (EarlierVersion `mkVersion [5]`)
+                                                                   (Set.fromList [LMainLibName]),
                                                                  Dependency
                                                                    `PackageName "ghc-prim"`
-                                                                   AnyVersion]},
+                                                                   AnyVersion
+                                                                   (Set.fromList [LMainLibName])]},
                            sourceRepos = [],
                            specVersionRaw = Right (OrLaterVersion `mkVersion [1,12]`),
                            stability = "",

--- a/Cabal/tests/ParserTests/regressions/generics-sop.expr
+++ b/Cabal/tests/ParserTests/regressions/generics-sop.expr
@@ -15,7 +15,9 @@ GenericPackageDescription
                                                                                                  (OrLaterVersion
                                                                                                     `mkVersion [0,7]`)
                                                                                                  (EarlierVersion
-                                                                                                    `mkVersion [0,9]`))],
+                                                                                                    `mkVersion [0,9]`))
+                                                                                              (Set.fromList
+                                                                                                 [LMainLibName])],
                                                                      condTreeData = Library
                                                                                       {exposedModules = [],
                                                                                        libBuildInfo = BuildInfo
@@ -64,7 +66,9 @@ GenericPackageDescription
                                                                                                                                     (OrLaterVersion
                                                                                                                                        `mkVersion [0,7]`)
                                                                                                                                     (EarlierVersion
-                                                                                                                                       `mkVersion [0,9]`))],
+                                                                                                                                       `mkVersion [0,9]`))
+                                                                                                                                 (Set.fromList
+                                                                                                                                    [LMainLibName])],
                                                                                                          virtualModules = []},
                                                                                        libExposed = True,
                                                                                        libName = Nothing,
@@ -81,14 +85,18 @@ GenericPackageDescription
                                                                                                  (OrLaterVersion
                                                                                                     `mkVersion [0,3]`)
                                                                                                  (EarlierVersion
-                                                                                                    `mkVersion [0,6]`)),
+                                                                                                    `mkVersion [0,6]`))
+                                                                                              (Set.fromList
+                                                                                                 [LMainLibName]),
                                                                                             Dependency
                                                                                               `PackageName "transformers"`
                                                                                               (IntersectVersionRanges
                                                                                                  (OrLaterVersion
                                                                                                     `mkVersion [0,3]`)
                                                                                                  (EarlierVersion
-                                                                                                    `mkVersion [0,6]`))],
+                                                                                                    `mkVersion [0,6]`))
+                                                                                              (Set.fromList
+                                                                                                 [LMainLibName])],
                                                                      condTreeData = Library
                                                                                       {exposedModules = [],
                                                                                        libBuildInfo = BuildInfo
@@ -137,14 +145,18 @@ GenericPackageDescription
                                                                                                                                     (OrLaterVersion
                                                                                                                                        `mkVersion [0,3]`)
                                                                                                                                     (EarlierVersion
-                                                                                                                                       `mkVersion [0,6]`)),
+                                                                                                                                       `mkVersion [0,6]`))
+                                                                                                                                 (Set.fromList
+                                                                                                                                    [LMainLibName]),
                                                                                                                                Dependency
                                                                                                                                  `PackageName "transformers"`
                                                                                                                                  (IntersectVersionRanges
                                                                                                                                     (OrLaterVersion
                                                                                                                                        `mkVersion [0,3]`)
                                                                                                                                     (EarlierVersion
-                                                                                                                                       `mkVersion [0,6]`))],
+                                                                                                                                       `mkVersion [0,6]`))
+                                                                                                                                 (Set.fromList
+                                                                                                                                    [LMainLibName])],
                                                                                                          virtualModules = []},
                                                                                        libExposed = True,
                                                                                        libName = Nothing,
@@ -264,22 +276,26 @@ GenericPackageDescription
                                                `PackageName "base"`
                                                (IntersectVersionRanges
                                                   (OrLaterVersion `mkVersion [4,7]`)
-                                                  (EarlierVersion `mkVersion [5]`)),
+                                                  (EarlierVersion `mkVersion [5]`))
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "template-haskell"`
                                                (IntersectVersionRanges
                                                   (OrLaterVersion `mkVersion [2,8]`)
-                                                  (EarlierVersion `mkVersion [2,13]`)),
+                                                  (EarlierVersion `mkVersion [2,13]`))
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "ghc-prim"`
                                                (IntersectVersionRanges
                                                   (OrLaterVersion `mkVersion [0,3]`)
-                                                  (EarlierVersion `mkVersion [0,6]`)),
+                                                  (EarlierVersion `mkVersion [0,6]`))
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "deepseq"`
                                                (IntersectVersionRanges
                                                   (OrLaterVersion `mkVersion [1,3]`)
-                                                  (EarlierVersion `mkVersion [1,5]`))],
+                                                  (EarlierVersion `mkVersion [1,5]`))
+                                               (Set.fromList [LMainLibName])],
                       condTreeData = Library
                                        {exposedModules = [`ModuleName ["Generics","SOP"]`,
                                                           `ModuleName ["Generics","SOP","GGP"]`,
@@ -386,28 +402,36 @@ GenericPackageDescription
                                                                                      (OrLaterVersion
                                                                                         `mkVersion [4,7]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [5]`)),
+                                                                                        `mkVersion [5]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "template-haskell"`
                                                                                   (IntersectVersionRanges
                                                                                      (OrLaterVersion
                                                                                         `mkVersion [2,8]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [2,13]`)),
+                                                                                        `mkVersion [2,13]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "ghc-prim"`
                                                                                   (IntersectVersionRanges
                                                                                      (OrLaterVersion
                                                                                         `mkVersion [0,3]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [0,6]`)),
+                                                                                        `mkVersion [0,6]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "deepseq"`
                                                                                   (IntersectVersionRanges
                                                                                      (OrLaterVersion
                                                                                         `mkVersion [1,3]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [1,5]`))],
+                                                                                        `mkVersion [1,5]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName])],
                                                           virtualModules = []},
                                         libExposed = True,
                                         libName = Nothing,
@@ -418,12 +442,16 @@ GenericPackageDescription
                        `UnqualComponentName "doctests"`
                        CondNode
                          {condTreeComponents = [],
-                          condTreeConstraints = [Dependency `PackageName "base"` AnyVersion,
+                          condTreeConstraints = [Dependency
+                                                   `PackageName "base"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "doctest"`
                                                    (IntersectVersionRanges
                                                       (OrLaterVersion `mkVersion [0,13]`)
-                                                      (EarlierVersion `mkVersion [0,14]`))],
+                                                      (EarlierVersion `mkVersion [0,14]`))
+                                                   (Set.fromList [LMainLibName])],
                           condTreeData = TestSuite
                                            {testBuildInfo = BuildInfo
                                                               {asmOptions = [],
@@ -471,14 +499,18 @@ GenericPackageDescription
                                                                staticOptions = [],
                                                                targetBuildDepends = [Dependency
                                                                                        `PackageName "base"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "doctest"`
                                                                                        (IntersectVersionRanges
                                                                                           (OrLaterVersion
                                                                                              `mkVersion [0,13]`)
                                                                                           (EarlierVersion
-                                                                                             `mkVersion [0,14]`))],
+                                                                                             `mkVersion [0,14]`))
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName])],
                                                                virtualModules = []},
                                             testInterface = TestSuiteExeV10
                                                               `mkVersion [1,0]` "doctests.hs",
@@ -491,9 +523,12 @@ GenericPackageDescription
                                                    `PackageName "base"`
                                                    (IntersectVersionRanges
                                                       (OrLaterVersion `mkVersion [4,6]`)
-                                                      (EarlierVersion `mkVersion [5]`)),
+                                                      (EarlierVersion `mkVersion [5]`))
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
-                                                   `PackageName "generics-sop"` AnyVersion],
+                                                   `PackageName "generics-sop"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName])],
                           condTreeData = TestSuite
                                            {testBuildInfo = BuildInfo
                                                               {asmOptions = [],
@@ -541,10 +576,14 @@ GenericPackageDescription
                                                                                           (OrLaterVersion
                                                                                              `mkVersion [4,6]`)
                                                                                           (EarlierVersion
-                                                                                             `mkVersion [5]`)),
+                                                                                             `mkVersion [5]`))
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "generics-sop"`
-                                                                                       AnyVersion],
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName])],
                                                                virtualModules = []},
                                             testInterface = TestSuiteExeV10
                                                               `mkVersion [1,0]` "Example.hs",
@@ -605,16 +644,21 @@ GenericPackageDescription
                                               SetupBuildInfo
                                                 {defaultSetupDepends = False,
                                                  setupDepends = [Dependency
-                                                                   `PackageName "base"` AnyVersion,
+                                                                   `PackageName "base"`
+                                                                   AnyVersion
+                                                                   (Set.fromList [LMainLibName]),
                                                                  Dependency
-                                                                   `PackageName "Cabal"` AnyVersion,
+                                                                   `PackageName "Cabal"`
+                                                                   AnyVersion
+                                                                   (Set.fromList [LMainLibName]),
                                                                  Dependency
                                                                    `PackageName "cabal-doctest"`
                                                                    (IntersectVersionRanges
                                                                       (OrLaterVersion
                                                                          `mkVersion [1,0,2]`)
                                                                       (EarlierVersion
-                                                                         `mkVersion [1,1]`))]},
+                                                                         `mkVersion [1,1]`))
+                                                                   (Set.fromList [LMainLibName])]},
                            sourceRepos = [SourceRepo
                                             {repoBranch = Nothing,
                                              repoKind = RepoHead,

--- a/Cabal/tests/ParserTests/regressions/issue-5055.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-5055.expr
@@ -8,7 +8,8 @@ GenericPackageDescription
                                                     `PackageName "base"`
                                                     (IntersectVersionRanges
                                                        (OrLaterVersion `mkVersion [4,8]`)
-                                                       (EarlierVersion `mkVersion [5]`))],
+                                                       (EarlierVersion `mkVersion [5]`))
+                                                    (Set.fromList [LMainLibName])],
                            condTreeData = Executable
                                             {buildInfo = BuildInfo
                                                            {asmOptions = [],
@@ -56,7 +57,9 @@ GenericPackageDescription
                                                                                        (OrLaterVersion
                                                                                           `mkVersion [4,8]`)
                                                                                        (EarlierVersion
-                                                                                          `mkVersion [5]`))],
+                                                                                          `mkVersion [5]`))
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName])],
                                                             virtualModules = []},
                                              exeName = `UnqualComponentName "flag-test-exe"`,
                                              exeScope = ExecutablePublic,
@@ -125,7 +128,8 @@ GenericPackageDescription
                                                    `PackageName "base"`
                                                    (IntersectVersionRanges
                                                       (OrLaterVersion `mkVersion [4,8]`)
-                                                      (EarlierVersion `mkVersion [5]`))],
+                                                      (EarlierVersion `mkVersion [5]`))
+                                                   (Set.fromList [LMainLibName])],
                           condTreeData = TestSuite
                                            {testBuildInfo = BuildInfo
                                                               {asmOptions = [],
@@ -173,7 +177,9 @@ GenericPackageDescription
                                                                                           (OrLaterVersion
                                                                                              `mkVersion [4,8]`)
                                                                                           (EarlierVersion
-                                                                                             `mkVersion [5]`))],
+                                                                                             `mkVersion [5]`))
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName])],
                                                                virtualModules = []},
                                             testInterface = TestSuiteExeV10
                                                               `mkVersion [1,0]` "SecondMain.hs",

--- a/Cabal/tests/ParserTests/regressions/leading-comma.expr
+++ b/Cabal/tests/ParserTests/regressions/leading-comma.expr
@@ -5,12 +5,30 @@ GenericPackageDescription
    condLibrary = Just
                    CondNode
                      {condTreeComponents = [],
-                      condTreeConstraints = [Dependency `PackageName "base"` AnyVersion,
-                                             Dependency `PackageName "containers"` AnyVersion,
-                                             Dependency `PackageName "deepseq"` AnyVersion,
-                                             Dependency `PackageName "transformers"` AnyVersion,
-                                             Dependency `PackageName "filepath"` AnyVersion,
-                                             Dependency `PackageName "directory"` AnyVersion],
+                      condTreeConstraints = [Dependency
+                                               `PackageName "base"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "containers"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "deepseq"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "transformers"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "filepath"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "directory"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName])],
                       condTreeData = Library
                                        {exposedModules = [`ModuleName ["LeadingComma"]`],
                                         libBuildInfo = BuildInfo
@@ -55,22 +73,34 @@ GenericPackageDescription
                                                           staticOptions = [],
                                                           targetBuildDepends = [Dependency
                                                                                   `PackageName "base"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "containers"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "deepseq"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "transformers"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "filepath"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "directory"`
-                                                                                  AnyVersion],
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName])],
                                                           virtualModules = []},
                                         libExposed = True,
                                         libName = Nothing,

--- a/Cabal/tests/ParserTests/regressions/noVersion.expr
+++ b/Cabal/tests/ParserTests/regressions/noVersion.expr
@@ -9,7 +9,8 @@ GenericPackageDescription
                                                `PackageName "bad-package"`
                                                (IntersectVersionRanges
                                                   (LaterVersion `mkVersion [1]`)
-                                                  (EarlierVersion `mkVersion [1]`))],
+                                                  (EarlierVersion `mkVersion [1]`))
+                                               (Set.fromList [LMainLibName])],
                       condTreeData = Library
                                        {exposedModules = [`ModuleName ["ElseIf"]`],
                                         libBuildInfo = BuildInfo
@@ -58,7 +59,9 @@ GenericPackageDescription
                                                                                      (LaterVersion
                                                                                         `mkVersion [1]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [1]`))],
+                                                                                        `mkVersion [1]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName])],
                                                           virtualModules = []},
                                         libExposed = True,
                                         libName = Nothing,

--- a/Cabal/tests/ParserTests/regressions/shake.expr
+++ b/Cabal/tests/ParserTests/regressions/shake.expr
@@ -70,7 +70,9 @@ GenericPackageDescription
                                                                                                                             condTreeConstraints = [Dependency
                                                                                                                                                      `PackageName "unix"`
                                                                                                                                                      (OrLaterVersion
-                                                                                                                                                        `mkVersion [2,5,1]`)],
+                                                                                                                                                        `mkVersion [2,5,1]`)
+                                                                                                                                                     (Set.fromList
+                                                                                                                                                        [LMainLibName])],
                                                                                                                             condTreeData = Executable
                                                                                                                                              {buildInfo = BuildInfo
                                                                                                                                                             {asmOptions = [],
@@ -115,7 +117,9 @@ GenericPackageDescription
                                                                                                                                                              targetBuildDepends = [Dependency
                                                                                                                                                                                      `PackageName "unix"`
                                                                                                                                                                                      (OrLaterVersion
-                                                                                                                                                                                        `mkVersion [2,5,1]`)],
+                                                                                                                                                                                        `mkVersion [2,5,1]`)
+                                                                                                                                                                                     (Set.fromList
+                                                                                                                                                                                        [LMainLibName])],
                                                                                                                                                              virtualModules = []},
                                                                                                                                               exeName = `UnqualComponentName "shake"`,
                                                                                                                                               exeScope = ExecutablePublic,
@@ -175,7 +179,9 @@ GenericPackageDescription
                                                                                                                         {condTreeComponents = [],
                                                                                                                          condTreeConstraints = [Dependency
                                                                                                                                                   `PackageName "old-time"`
-                                                                                                                                                  AnyVersion],
+                                                                                                                                                  AnyVersion
+                                                                                                                                                  (Set.fromList
+                                                                                                                                                     [LMainLibName])],
                                                                                                                          condTreeData = Executable
                                                                                                                                           {buildInfo = BuildInfo
                                                                                                                                                          {asmOptions = [],
@@ -219,7 +225,9 @@ GenericPackageDescription
                                                                                                                                                           staticOptions = [],
                                                                                                                                                           targetBuildDepends = [Dependency
                                                                                                                                                                                   `PackageName "old-time"`
-                                                                                                                                                                                  AnyVersion],
+                                                                                                                                                                                  AnyVersion
+                                                                                                                                                                                  (Set.fromList
+                                                                                                                                                                                     [LMainLibName])],
                                                                                                                                                           virtualModules = []},
                                                                                                                                            exeName = `UnqualComponentName "shake"`,
                                                                                                                                            exeScope = ExecutablePublic,
@@ -278,7 +286,9 @@ GenericPackageDescription
                                                                          {condTreeComponents = [],
                                                                           condTreeConstraints = [Dependency
                                                                                                    `PackageName "unix"`
-                                                                                                   AnyVersion],
+                                                                                                   AnyVersion
+                                                                                                   (Set.fromList
+                                                                                                      [LMainLibName])],
                                                                           condTreeData = Executable
                                                                                            {buildInfo = BuildInfo
                                                                                                           {asmOptions = [],
@@ -322,44 +332,81 @@ GenericPackageDescription
                                                                                                            staticOptions = [],
                                                                                                            targetBuildDepends = [Dependency
                                                                                                                                    `PackageName "unix"`
-                                                                                                                                   AnyVersion],
+                                                                                                                                   AnyVersion
+                                                                                                                                   (Set.fromList
+                                                                                                                                      [LMainLibName])],
                                                                                                            virtualModules = []},
                                                                                             exeName = `UnqualComponentName "shake"`,
                                                                                             exeScope = ExecutablePublic,
                                                                                             modulePath = ""}}}],
                            condTreeConstraints = [Dependency
                                                     `PackageName "base"`
-                                                    (WildcardVersion `mkVersion [4]`),
-                                                  Dependency `PackageName "directory"` AnyVersion,
+                                                    (WildcardVersion `mkVersion [4]`)
+                                                    (Set.fromList [LMainLibName]),
+                                                  Dependency
+                                                    `PackageName "directory"`
+                                                    AnyVersion
+                                                    (Set.fromList [LMainLibName]),
                                                   Dependency
                                                     `PackageName "hashable"`
-                                                    (OrLaterVersion `mkVersion [1,1,2,3]`),
-                                                  Dependency `PackageName "binary"` AnyVersion,
-                                                  Dependency `PackageName "filepath"` AnyVersion,
+                                                    (OrLaterVersion `mkVersion [1,1,2,3]`)
+                                                    (Set.fromList [LMainLibName]),
+                                                  Dependency
+                                                    `PackageName "binary"`
+                                                    AnyVersion
+                                                    (Set.fromList [LMainLibName]),
+                                                  Dependency
+                                                    `PackageName "filepath"`
+                                                    AnyVersion
+                                                    (Set.fromList [LMainLibName]),
                                                   Dependency
                                                     `PackageName "process"`
-                                                    (OrLaterVersion `mkVersion [1,1]`),
+                                                    (OrLaterVersion `mkVersion [1,1]`)
+                                                    (Set.fromList [LMainLibName]),
                                                   Dependency
                                                     `PackageName "unordered-containers"`
-                                                    (OrLaterVersion `mkVersion [0,2,1]`),
-                                                  Dependency `PackageName "bytestring"` AnyVersion,
+                                                    (OrLaterVersion `mkVersion [0,2,1]`)
+                                                    (Set.fromList [LMainLibName]),
+                                                  Dependency
+                                                    `PackageName "bytestring"`
+                                                    AnyVersion
+                                                    (Set.fromList [LMainLibName]),
                                                   Dependency
                                                     `PackageName "utf8-string"`
-                                                    (OrLaterVersion `mkVersion [0,3]`),
-                                                  Dependency `PackageName "time"` AnyVersion,
-                                                  Dependency `PackageName "random"` AnyVersion,
-                                                  Dependency `PackageName "js-jquery"` AnyVersion,
-                                                  Dependency `PackageName "js-flot"` AnyVersion,
+                                                    (OrLaterVersion `mkVersion [0,3]`)
+                                                    (Set.fromList [LMainLibName]),
+                                                  Dependency
+                                                    `PackageName "time"`
+                                                    AnyVersion
+                                                    (Set.fromList [LMainLibName]),
+                                                  Dependency
+                                                    `PackageName "random"`
+                                                    AnyVersion
+                                                    (Set.fromList [LMainLibName]),
+                                                  Dependency
+                                                    `PackageName "js-jquery"`
+                                                    AnyVersion
+                                                    (Set.fromList [LMainLibName]),
+                                                  Dependency
+                                                    `PackageName "js-flot"`
+                                                    AnyVersion
+                                                    (Set.fromList [LMainLibName]),
                                                   Dependency
                                                     `PackageName "transformers"`
-                                                    (OrLaterVersion `mkVersion [0,2]`),
+                                                    (OrLaterVersion `mkVersion [0,2]`)
+                                                    (Set.fromList [LMainLibName]),
                                                   Dependency
                                                     `PackageName "extra"`
-                                                    (OrLaterVersion `mkVersion [1,4,8]`),
+                                                    (OrLaterVersion `mkVersion [1,4,8]`)
+                                                    (Set.fromList [LMainLibName]),
                                                   Dependency
                                                     `PackageName "deepseq"`
-                                                    (OrLaterVersion `mkVersion [1,1]`),
-                                                  Dependency `PackageName "primitive"` AnyVersion],
+                                                    (OrLaterVersion `mkVersion [1,1]`)
+                                                    (Set.fromList [LMainLibName]),
+                                                  Dependency
+                                                    `PackageName "primitive"`
+                                                    AnyVersion
+                                                    (Set.fromList [LMainLibName])],
                            condTreeData = Executable
                                             {buildInfo = BuildInfo
                                                            {asmOptions = [],
@@ -462,62 +509,96 @@ GenericPackageDescription
                                                             targetBuildDepends = [Dependency
                                                                                     `PackageName "base"`
                                                                                     (WildcardVersion
-                                                                                       `mkVersion [4]`),
+                                                                                       `mkVersion [4]`)
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "directory"`
-                                                                                    AnyVersion,
+                                                                                    AnyVersion
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "hashable"`
                                                                                     (OrLaterVersion
-                                                                                       `mkVersion [1,1,2,3]`),
+                                                                                       `mkVersion [1,1,2,3]`)
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "binary"`
-                                                                                    AnyVersion,
+                                                                                    AnyVersion
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "filepath"`
-                                                                                    AnyVersion,
+                                                                                    AnyVersion
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "process"`
                                                                                     (OrLaterVersion
-                                                                                       `mkVersion [1,1]`),
+                                                                                       `mkVersion [1,1]`)
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "unordered-containers"`
                                                                                     (OrLaterVersion
-                                                                                       `mkVersion [0,2,1]`),
+                                                                                       `mkVersion [0,2,1]`)
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "bytestring"`
-                                                                                    AnyVersion,
+                                                                                    AnyVersion
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "utf8-string"`
                                                                                     (OrLaterVersion
-                                                                                       `mkVersion [0,3]`),
+                                                                                       `mkVersion [0,3]`)
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "time"`
-                                                                                    AnyVersion,
+                                                                                    AnyVersion
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "random"`
-                                                                                    AnyVersion,
+                                                                                    AnyVersion
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "js-jquery"`
-                                                                                    AnyVersion,
+                                                                                    AnyVersion
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "js-flot"`
-                                                                                    AnyVersion,
+                                                                                    AnyVersion
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "transformers"`
                                                                                     (OrLaterVersion
-                                                                                       `mkVersion [0,2]`),
+                                                                                       `mkVersion [0,2]`)
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "extra"`
                                                                                     (OrLaterVersion
-                                                                                       `mkVersion [1,4,8]`),
+                                                                                       `mkVersion [1,4,8]`)
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "deepseq"`
                                                                                     (OrLaterVersion
-                                                                                       `mkVersion [1,1]`),
+                                                                                       `mkVersion [1,1]`)
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "primitive"`
-                                                                                    AnyVersion],
+                                                                                    AnyVersion
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName])],
                                                             virtualModules = []},
                                              exeName = `UnqualComponentName "shake"`,
                                              exeScope = ExecutablePublic,
@@ -537,7 +618,9 @@ GenericPackageDescription
                                                                                                                        condTreeConstraints = [Dependency
                                                                                                                                                 `PackageName "unix"`
                                                                                                                                                 (OrLaterVersion
-                                                                                                                                                   `mkVersion [2,5,1]`)],
+                                                                                                                                                   `mkVersion [2,5,1]`)
+                                                                                                                                                (Set.fromList
+                                                                                                                                                   [LMainLibName])],
                                                                                                                        condTreeData = Library
                                                                                                                                         {exposedModules = [],
                                                                                                                                          libBuildInfo = BuildInfo
@@ -583,7 +666,9 @@ GenericPackageDescription
                                                                                                                                                            targetBuildDepends = [Dependency
                                                                                                                                                                                    `PackageName "unix"`
                                                                                                                                                                                    (OrLaterVersion
-                                                                                                                                                                                      `mkVersion [2,5,1]`)],
+                                                                                                                                                                                      `mkVersion [2,5,1]`)
+                                                                                                                                                                                   (Set.fromList
+                                                                                                                                                                                      [LMainLibName])],
                                                                                                                                                            virtualModules = []},
                                                                                                                                          libExposed = True,
                                                                                                                                          libName = Nothing,
@@ -646,7 +731,9 @@ GenericPackageDescription
                                                                                                                    {condTreeComponents = [],
                                                                                                                     condTreeConstraints = [Dependency
                                                                                                                                              `PackageName "old-time"`
-                                                                                                                                             AnyVersion],
+                                                                                                                                             AnyVersion
+                                                                                                                                             (Set.fromList
+                                                                                                                                                [LMainLibName])],
                                                                                                                     condTreeData = Library
                                                                                                                                      {exposedModules = [],
                                                                                                                                       libBuildInfo = BuildInfo
@@ -691,7 +778,9 @@ GenericPackageDescription
                                                                                                                                                         staticOptions = [],
                                                                                                                                                         targetBuildDepends = [Dependency
                                                                                                                                                                                 `PackageName "old-time"`
-                                                                                                                                                                                AnyVersion],
+                                                                                                                                                                                AnyVersion
+                                                                                                                                                                                (Set.fromList
+                                                                                                                                                                                   [LMainLibName])],
                                                                                                                                                         virtualModules = []},
                                                                                                                                       libExposed = True,
                                                                                                                                       libName = Nothing,
@@ -753,7 +842,9 @@ GenericPackageDescription
                                                                     {condTreeComponents = [],
                                                                      condTreeConstraints = [Dependency
                                                                                               `PackageName "unix"`
-                                                                                              AnyVersion],
+                                                                                              AnyVersion
+                                                                                              (Set.fromList
+                                                                                                 [LMainLibName])],
                                                                      condTreeData = Library
                                                                                       {exposedModules = [],
                                                                                        libBuildInfo = BuildInfo
@@ -798,7 +889,9 @@ GenericPackageDescription
                                                                                                          staticOptions = [],
                                                                                                          targetBuildDepends = [Dependency
                                                                                                                                  `PackageName "unix"`
-                                                                                                                                 AnyVersion],
+                                                                                                                                 AnyVersion
+                                                                                                                                 (Set.fromList
+                                                                                                                                    [LMainLibName])],
                                                                                                          virtualModules = []},
                                                                                        libExposed = True,
                                                                                        libName = Nothing,
@@ -806,36 +899,68 @@ GenericPackageDescription
                                                                                        signatures = []}}}],
                       condTreeConstraints = [Dependency
                                                `PackageName "base"`
-                                               (OrLaterVersion `mkVersion [4,5]`),
-                                             Dependency `PackageName "directory"` AnyVersion,
+                                               (OrLaterVersion `mkVersion [4,5]`)
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "directory"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "hashable"`
-                                               (OrLaterVersion `mkVersion [1,1,2,3]`),
-                                             Dependency `PackageName "binary"` AnyVersion,
-                                             Dependency `PackageName "filepath"` AnyVersion,
+                                               (OrLaterVersion `mkVersion [1,1,2,3]`)
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "binary"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "filepath"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "process"`
-                                               (OrLaterVersion `mkVersion [1,1]`),
+                                               (OrLaterVersion `mkVersion [1,1]`)
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "unordered-containers"`
-                                               (OrLaterVersion `mkVersion [0,2,1]`),
-                                             Dependency `PackageName "bytestring"` AnyVersion,
+                                               (OrLaterVersion `mkVersion [0,2,1]`)
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "bytestring"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "utf8-string"`
-                                               (OrLaterVersion `mkVersion [0,3]`),
-                                             Dependency `PackageName "time"` AnyVersion,
-                                             Dependency `PackageName "random"` AnyVersion,
-                                             Dependency `PackageName "js-jquery"` AnyVersion,
-                                             Dependency `PackageName "js-flot"` AnyVersion,
+                                               (OrLaterVersion `mkVersion [0,3]`)
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "time"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "random"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "js-jquery"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "js-flot"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "transformers"`
-                                               (OrLaterVersion `mkVersion [0,2]`),
+                                               (OrLaterVersion `mkVersion [0,2]`)
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "extra"`
-                                               (OrLaterVersion `mkVersion [1,4,8]`),
+                                               (OrLaterVersion `mkVersion [1,4,8]`)
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "deepseq"`
-                                               (OrLaterVersion `mkVersion [1,1]`)],
+                                               (OrLaterVersion `mkVersion [1,1]`)
+                                               (Set.fromList [LMainLibName])],
                       condTreeData = Library
                                        {exposedModules = [`ModuleName ["Development","Shake"]`,
                                                           `ModuleName ["Development","Shake","Classes"]`,
@@ -929,59 +1054,91 @@ GenericPackageDescription
                                                           targetBuildDepends = [Dependency
                                                                                   `PackageName "base"`
                                                                                   (OrLaterVersion
-                                                                                     `mkVersion [4,5]`),
+                                                                                     `mkVersion [4,5]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "directory"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "hashable"`
                                                                                   (OrLaterVersion
-                                                                                     `mkVersion [1,1,2,3]`),
+                                                                                     `mkVersion [1,1,2,3]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "binary"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "filepath"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "process"`
                                                                                   (OrLaterVersion
-                                                                                     `mkVersion [1,1]`),
+                                                                                     `mkVersion [1,1]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "unordered-containers"`
                                                                                   (OrLaterVersion
-                                                                                     `mkVersion [0,2,1]`),
+                                                                                     `mkVersion [0,2,1]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "bytestring"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "utf8-string"`
                                                                                   (OrLaterVersion
-                                                                                     `mkVersion [0,3]`),
+                                                                                     `mkVersion [0,3]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "time"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "random"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "js-jquery"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "js-flot"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "transformers"`
                                                                                   (OrLaterVersion
-                                                                                     `mkVersion [0,2]`),
+                                                                                     `mkVersion [0,2]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "extra"`
                                                                                   (OrLaterVersion
-                                                                                     `mkVersion [1,4,8]`),
+                                                                                     `mkVersion [1,4,8]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "deepseq"`
                                                                                   (OrLaterVersion
-                                                                                     `mkVersion [1,1]`)],
+                                                                                     `mkVersion [1,1]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName])],
                                                           virtualModules = []},
                                         libExposed = True,
                                         libName = Nothing,
@@ -1115,7 +1272,9 @@ GenericPackageDescription
                                                                                                                            condTreeConstraints = [Dependency
                                                                                                                                                     `PackageName "unix"`
                                                                                                                                                     (OrLaterVersion
-                                                                                                                                                       `mkVersion [2,5,1]`)],
+                                                                                                                                                       `mkVersion [2,5,1]`)
+                                                                                                                                                    (Set.fromList
+                                                                                                                                                       [LMainLibName])],
                                                                                                                            condTreeData = TestSuite
                                                                                                                                             {testBuildInfo = BuildInfo
                                                                                                                                                                {asmOptions = [],
@@ -1160,7 +1319,9 @@ GenericPackageDescription
                                                                                                                                                                 targetBuildDepends = [Dependency
                                                                                                                                                                                         `PackageName "unix"`
                                                                                                                                                                                         (OrLaterVersion
-                                                                                                                                                                                           `mkVersion [2,5,1]`)],
+                                                                                                                                                                                           `mkVersion [2,5,1]`)
+                                                                                                                                                                                        (Set.fromList
+                                                                                                                                                                                           [LMainLibName])],
                                                                                                                                                                 virtualModules = []},
                                                                                                                                              testInterface = TestSuiteUnsupported
                                                                                                                                                                (TestTypeUnknown
@@ -1224,7 +1385,9 @@ GenericPackageDescription
                                                                                                                        {condTreeComponents = [],
                                                                                                                         condTreeConstraints = [Dependency
                                                                                                                                                  `PackageName "old-time"`
-                                                                                                                                                 AnyVersion],
+                                                                                                                                                 AnyVersion
+                                                                                                                                                 (Set.fromList
+                                                                                                                                                    [LMainLibName])],
                                                                                                                         condTreeData = TestSuite
                                                                                                                                          {testBuildInfo = BuildInfo
                                                                                                                                                             {asmOptions = [],
@@ -1268,7 +1431,9 @@ GenericPackageDescription
                                                                                                                                                              staticOptions = [],
                                                                                                                                                              targetBuildDepends = [Dependency
                                                                                                                                                                                      `PackageName "old-time"`
-                                                                                                                                                                                     AnyVersion],
+                                                                                                                                                                                     AnyVersion
+                                                                                                                                                                                     (Set.fromList
+                                                                                                                                                                                        [LMainLibName])],
                                                                                                                                                              virtualModules = []},
                                                                                                                                           testInterface = TestSuiteUnsupported
                                                                                                                                                             (TestTypeUnknown
@@ -1331,7 +1496,9 @@ GenericPackageDescription
                                                                         {condTreeComponents = [],
                                                                          condTreeConstraints = [Dependency
                                                                                                   `PackageName "unix"`
-                                                                                                  AnyVersion],
+                                                                                                  AnyVersion
+                                                                                                  (Set.fromList
+                                                                                                     [LMainLibName])],
                                                                          condTreeData = TestSuite
                                                                                           {testBuildInfo = BuildInfo
                                                                                                              {asmOptions = [],
@@ -1375,7 +1542,9 @@ GenericPackageDescription
                                                                                                               staticOptions = [],
                                                                                                               targetBuildDepends = [Dependency
                                                                                                                                       `PackageName "unix"`
-                                                                                                                                      AnyVersion],
+                                                                                                                                      AnyVersion
+                                                                                                                                      (Set.fromList
+                                                                                                                                         [LMainLibName])],
                                                                                                               virtualModules = []},
                                                                                            testInterface = TestSuiteUnsupported
                                                                                                              (TestTypeUnknown
@@ -1384,39 +1553,72 @@ GenericPackageDescription
                                                                                            testName = `UnqualComponentName ""`}}}],
                           condTreeConstraints = [Dependency
                                                    `PackageName "base"`
-                                                   (WildcardVersion `mkVersion [4]`),
-                                                 Dependency `PackageName "directory"` AnyVersion,
+                                                   (WildcardVersion `mkVersion [4]`)
+                                                   (Set.fromList [LMainLibName]),
+                                                 Dependency
+                                                   `PackageName "directory"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "hashable"`
-                                                   (OrLaterVersion `mkVersion [1,1,2,3]`),
-                                                 Dependency `PackageName "binary"` AnyVersion,
-                                                 Dependency `PackageName "filepath"` AnyVersion,
+                                                   (OrLaterVersion `mkVersion [1,1,2,3]`)
+                                                   (Set.fromList [LMainLibName]),
+                                                 Dependency
+                                                   `PackageName "binary"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
+                                                 Dependency
+                                                   `PackageName "filepath"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "process"`
-                                                   (OrLaterVersion `mkVersion [1,1]`),
+                                                   (OrLaterVersion `mkVersion [1,1]`)
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "unordered-containers"`
-                                                   (OrLaterVersion `mkVersion [0,2,1]`),
-                                                 Dependency `PackageName "bytestring"` AnyVersion,
+                                                   (OrLaterVersion `mkVersion [0,2,1]`)
+                                                   (Set.fromList [LMainLibName]),
+                                                 Dependency
+                                                   `PackageName "bytestring"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "utf8-string"`
-                                                   (OrLaterVersion `mkVersion [0,3]`),
-                                                 Dependency `PackageName "time"` AnyVersion,
-                                                 Dependency `PackageName "random"` AnyVersion,
-                                                 Dependency `PackageName "js-jquery"` AnyVersion,
-                                                 Dependency `PackageName "js-flot"` AnyVersion,
+                                                   (OrLaterVersion `mkVersion [0,3]`)
+                                                   (Set.fromList [LMainLibName]),
+                                                 Dependency
+                                                   `PackageName "time"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
+                                                 Dependency
+                                                   `PackageName "random"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
+                                                 Dependency
+                                                   `PackageName "js-jquery"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
+                                                 Dependency
+                                                   `PackageName "js-flot"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "transformers"`
-                                                   (OrLaterVersion `mkVersion [0,2]`),
+                                                   (OrLaterVersion `mkVersion [0,2]`)
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "deepseq"`
-                                                   (OrLaterVersion `mkVersion [1,1]`),
+                                                   (OrLaterVersion `mkVersion [1,1]`)
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "extra"`
-                                                   (OrLaterVersion `mkVersion [1,4,8]`),
+                                                   (OrLaterVersion `mkVersion [1,4,8]`)
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "QuickCheck"`
-                                                   (OrLaterVersion `mkVersion [2,0]`)],
+                                                   (OrLaterVersion `mkVersion [2,0]`)
+                                                   (Set.fromList [LMainLibName])],
                           condTreeData = TestSuite
                                            {testBuildInfo = BuildInfo
                                                               {asmOptions = [],
@@ -1560,63 +1762,97 @@ GenericPackageDescription
                                                                targetBuildDepends = [Dependency
                                                                                        `PackageName "base"`
                                                                                        (WildcardVersion
-                                                                                          `mkVersion [4]`),
+                                                                                          `mkVersion [4]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "directory"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "hashable"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [1,1,2,3]`),
+                                                                                          `mkVersion [1,1,2,3]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "binary"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "filepath"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "process"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [1,1]`),
+                                                                                          `mkVersion [1,1]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "unordered-containers"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [0,2,1]`),
+                                                                                          `mkVersion [0,2,1]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "bytestring"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "utf8-string"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [0,3]`),
+                                                                                          `mkVersion [0,3]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "time"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "random"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "js-jquery"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "js-flot"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "transformers"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [0,2]`),
+                                                                                          `mkVersion [0,2]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "deepseq"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [1,1]`),
+                                                                                          `mkVersion [1,1]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "extra"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [1,4,8]`),
+                                                                                          `mkVersion [1,4,8]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "QuickCheck"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [2,0]`)],
+                                                                                          `mkVersion [2,0]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName])],
                                                                virtualModules = []},
                                             testInterface = TestSuiteExeV10
                                                               `mkVersion [1,0]` "Test.hs",

--- a/Cabal/tests/ParserTests/regressions/th-lift-instances.expr
+++ b/Cabal/tests/ParserTests/regressions/th-lift-instances.expr
@@ -9,31 +9,40 @@ GenericPackageDescription
                                                `PackageName "base"`
                                                (IntersectVersionRanges
                                                   (OrLaterVersion `mkVersion [4,4]`)
-                                                  (EarlierVersion `mkVersion [5]`)),
+                                                  (EarlierVersion `mkVersion [5]`))
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "template-haskell"`
-                                               (EarlierVersion `mkVersion [2,10]`),
-                                             Dependency `PackageName "th-lift"` AnyVersion,
+                                               (EarlierVersion `mkVersion [2,10]`)
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "th-lift"`
+                                               AnyVersion
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "containers"`
                                                (IntersectVersionRanges
                                                   (OrLaterVersion `mkVersion [0,4]`)
-                                                  (EarlierVersion `mkVersion [0,6]`)),
+                                                  (EarlierVersion `mkVersion [0,6]`))
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "vector"`
                                                (IntersectVersionRanges
                                                   (OrLaterVersion `mkVersion [0,9]`)
-                                                  (EarlierVersion `mkVersion [0,11]`)),
+                                                  (EarlierVersion `mkVersion [0,11]`))
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "text"`
                                                (IntersectVersionRanges
                                                   (OrLaterVersion `mkVersion [0,11]`)
-                                                  (EarlierVersion `mkVersion [1,3]`)),
+                                                  (EarlierVersion `mkVersion [1,3]`))
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "bytestring"`
                                                (IntersectVersionRanges
                                                   (OrLaterVersion `mkVersion [0,9]`)
-                                                  (EarlierVersion `mkVersion [0,11]`))],
+                                                  (EarlierVersion `mkVersion [0,11]`))
+                                               (Set.fromList [LMainLibName])],
                       condTreeData = Library
                                        {exposedModules = [`ModuleName ["Instances","TH","Lift"]`],
                                         libBuildInfo = BuildInfo
@@ -85,42 +94,56 @@ GenericPackageDescription
                                                                                      (OrLaterVersion
                                                                                         `mkVersion [4,4]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [5]`)),
+                                                                                        `mkVersion [5]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "template-haskell"`
                                                                                   (EarlierVersion
-                                                                                     `mkVersion [2,10]`),
+                                                                                     `mkVersion [2,10]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "th-lift"`
-                                                                                  AnyVersion,
+                                                                                  AnyVersion
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "containers"`
                                                                                   (IntersectVersionRanges
                                                                                      (OrLaterVersion
                                                                                         `mkVersion [0,4]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [0,6]`)),
+                                                                                        `mkVersion [0,6]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "vector"`
                                                                                   (IntersectVersionRanges
                                                                                      (OrLaterVersion
                                                                                         `mkVersion [0,9]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [0,11]`)),
+                                                                                        `mkVersion [0,11]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "text"`
                                                                                   (IntersectVersionRanges
                                                                                      (OrLaterVersion
                                                                                         `mkVersion [0,11]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [1,3]`)),
+                                                                                        `mkVersion [1,3]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "bytestring"`
                                                                                   (IntersectVersionRanges
                                                                                      (OrLaterVersion
                                                                                         `mkVersion [0,9]`)
                                                                                      (EarlierVersion
-                                                                                        `mkVersion [0,11]`))],
+                                                                                        `mkVersion [0,11]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName])],
                                                           virtualModules = []},
                                         libExposed = True,
                                         libName = Nothing,
@@ -131,37 +154,48 @@ GenericPackageDescription
                        `UnqualComponentName "tests"`
                        CondNode
                          {condTreeComponents = [],
-                          condTreeConstraints = [Dependency `PackageName "base"` AnyVersion,
+                          condTreeConstraints = [Dependency
+                                                   `PackageName "base"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "template-haskell"`
-                                                   (EarlierVersion `mkVersion [2,10]`),
+                                                   (EarlierVersion `mkVersion [2,10]`)
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "containers"`
                                                    (IntersectVersionRanges
                                                       (OrLaterVersion `mkVersion [0,4]`)
-                                                      (EarlierVersion `mkVersion [0,6]`)),
+                                                      (EarlierVersion `mkVersion [0,6]`))
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "vector"`
                                                    (IntersectVersionRanges
                                                       (OrLaterVersion `mkVersion [0,9]`)
-                                                      (EarlierVersion `mkVersion [0,11]`)),
+                                                      (EarlierVersion `mkVersion [0,11]`))
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "text"`
                                                    (IntersectVersionRanges
                                                       (OrLaterVersion `mkVersion [0,11]`)
-                                                      (EarlierVersion `mkVersion [1,2]`)),
+                                                      (EarlierVersion `mkVersion [1,2]`))
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "bytestring"`
                                                    (IntersectVersionRanges
                                                       (OrLaterVersion `mkVersion [0,9]`)
-                                                      (EarlierVersion `mkVersion [0,11]`)),
+                                                      (EarlierVersion `mkVersion [0,11]`))
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
-                                                   `PackageName "th-lift-instances"` AnyVersion,
+                                                   `PackageName "th-lift-instances"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "QuickCheck"`
                                                    (IntersectVersionRanges
                                                       (OrLaterVersion `mkVersion [2,6]`)
-                                                      (EarlierVersion `mkVersion [2,8]`))],
+                                                      (EarlierVersion `mkVersion [2,8]`))
+                                                   (Set.fromList [LMainLibName])],
                           condTreeData = TestSuite
                                            {testBuildInfo = BuildInfo
                                                               {asmOptions = [],
@@ -206,49 +240,65 @@ GenericPackageDescription
                                                                staticOptions = [],
                                                                targetBuildDepends = [Dependency
                                                                                        `PackageName "base"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "template-haskell"`
                                                                                        (EarlierVersion
-                                                                                          `mkVersion [2,10]`),
+                                                                                          `mkVersion [2,10]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "containers"`
                                                                                        (IntersectVersionRanges
                                                                                           (OrLaterVersion
                                                                                              `mkVersion [0,4]`)
                                                                                           (EarlierVersion
-                                                                                             `mkVersion [0,6]`)),
+                                                                                             `mkVersion [0,6]`))
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "vector"`
                                                                                        (IntersectVersionRanges
                                                                                           (OrLaterVersion
                                                                                              `mkVersion [0,9]`)
                                                                                           (EarlierVersion
-                                                                                             `mkVersion [0,11]`)),
+                                                                                             `mkVersion [0,11]`))
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "text"`
                                                                                        (IntersectVersionRanges
                                                                                           (OrLaterVersion
                                                                                              `mkVersion [0,11]`)
                                                                                           (EarlierVersion
-                                                                                             `mkVersion [1,2]`)),
+                                                                                             `mkVersion [1,2]`))
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "bytestring"`
                                                                                        (IntersectVersionRanges
                                                                                           (OrLaterVersion
                                                                                              `mkVersion [0,9]`)
                                                                                           (EarlierVersion
-                                                                                             `mkVersion [0,11]`)),
+                                                                                             `mkVersion [0,11]`))
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "th-lift-instances"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "QuickCheck"`
                                                                                        (IntersectVersionRanges
                                                                                           (OrLaterVersion
                                                                                              `mkVersion [2,6]`)
                                                                                           (EarlierVersion
-                                                                                             `mkVersion [2,8]`))],
+                                                                                             `mkVersion [2,8]`))
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName])],
                                                                virtualModules = []},
                                             testInterface = TestSuiteExeV10
                                                               `mkVersion [1,0]` "Main.hs",
@@ -312,14 +362,22 @@ GenericPackageDescription
                                                                                                                 ""
                                                                                                                 `mkVersion []`),
                                                                                            testName = `UnqualComponentName ""`}}}],
-                          condTreeConstraints = [Dependency `PackageName "base"` AnyVersion,
+                          condTreeConstraints = [Dependency
+                                                   `PackageName "base"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "directory"`
-                                                   (OrLaterVersion `mkVersion [1,0]`),
+                                                   (OrLaterVersion `mkVersion [1,0]`)
+                                                   (Set.fromList [LMainLibName]),
                                                  Dependency
                                                    `PackageName "doctest"`
-                                                   (OrLaterVersion `mkVersion [0,9,1]`),
-                                                 Dependency `PackageName "filepath"` AnyVersion],
+                                                   (OrLaterVersion `mkVersion [0,9,1]`)
+                                                   (Set.fromList [LMainLibName]),
+                                                 Dependency
+                                                   `PackageName "filepath"`
+                                                   AnyVersion
+                                                   (Set.fromList [LMainLibName])],
                           condTreeData = TestSuite
                                            {testBuildInfo = BuildInfo
                                                               {asmOptions = [],
@@ -365,18 +423,26 @@ GenericPackageDescription
                                                                staticOptions = [],
                                                                targetBuildDepends = [Dependency
                                                                                        `PackageName "base"`
-                                                                                       AnyVersion,
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "directory"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [1,0]`),
+                                                                                          `mkVersion [1,0]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "doctest"`
                                                                                        (OrLaterVersion
-                                                                                          `mkVersion [0,9,1]`),
+                                                                                          `mkVersion [0,9,1]`)
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName]),
                                                                                      Dependency
                                                                                        `PackageName "filepath"`
-                                                                                       AnyVersion],
+                                                                                       AnyVersion
+                                                                                       (Set.fromList
+                                                                                          [LMainLibName])],
                                                                virtualModules = []},
                                             testInterface = TestSuiteExeV10
                                                               `mkVersion [1,0]` "doctests.hs",

--- a/Cabal/tests/ParserTests/regressions/wl-pprint-indef.expr
+++ b/Cabal/tests/ParserTests/regressions/wl-pprint-indef.expr
@@ -6,12 +6,16 @@ GenericPackageDescription
                           {condTreeComponents = [],
                            condTreeConstraints = [Dependency
                                                     `PackageName "base"`
-                                                    (EarlierVersion `mkVersion [5]`),
+                                                    (EarlierVersion `mkVersion [5]`)
+                                                    (Set.fromList [LMainLibName]),
                                                   Dependency
                                                     `PackageName "str-string"`
-                                                    (OrLaterVersion `mkVersion [0,1,0,0]`),
+                                                    (OrLaterVersion `mkVersion [0,1,0,0]`)
+                                                    (Set.fromList [LMainLibName]),
                                                   Dependency
-                                                    `PackageName "wl-pprint-indef"` AnyVersion],
+                                                    `PackageName "wl-pprint-indef"`
+                                                    AnyVersion
+                                                    (Set.fromList [LMainLibName])],
                            condTreeData = Executable
                                             {buildInfo = BuildInfo
                                                            {asmOptions = [],
@@ -56,14 +60,20 @@ GenericPackageDescription
                                                             targetBuildDepends = [Dependency
                                                                                     `PackageName "base"`
                                                                                     (EarlierVersion
-                                                                                       `mkVersion [5]`),
+                                                                                       `mkVersion [5]`)
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "str-string"`
                                                                                     (OrLaterVersion
-                                                                                       `mkVersion [0,1,0,0]`),
+                                                                                       `mkVersion [0,1,0,0]`)
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName]),
                                                                                   Dependency
                                                                                     `PackageName "wl-pprint-indef"`
-                                                                                    AnyVersion],
+                                                                                    AnyVersion
+                                                                                    (Set.fromList
+                                                                                       [LMainLibName])],
                                                             virtualModules = []},
                                              exeName = `UnqualComponentName "wl-pprint-string-example"`,
                                              exeScope = ExecutablePublic,
@@ -74,10 +84,12 @@ GenericPackageDescription
                      {condTreeComponents = [],
                       condTreeConstraints = [Dependency
                                                `PackageName "base"`
-                                               (EarlierVersion `mkVersion [5]`),
+                                               (EarlierVersion `mkVersion [5]`)
+                                               (Set.fromList [LMainLibName]),
                                              Dependency
                                                `PackageName "str-sig"`
-                                               (OrLaterVersion `mkVersion [0,1,0,0]`)],
+                                               (OrLaterVersion `mkVersion [0,1,0,0]`)
+                                               (Set.fromList [LMainLibName])],
                       condTreeData = Library
                                        {exposedModules = [`ModuleName ["Text","PrettyPrint","Leijen"]`],
                                         libBuildInfo = BuildInfo
@@ -123,11 +135,15 @@ GenericPackageDescription
                                                           targetBuildDepends = [Dependency
                                                                                   `PackageName "base"`
                                                                                   (EarlierVersion
-                                                                                     `mkVersion [5]`),
+                                                                                     `mkVersion [5]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
                                                                                 Dependency
                                                                                   `PackageName "str-sig"`
                                                                                   (OrLaterVersion
-                                                                                     `mkVersion [0,1,0,0]`)],
+                                                                                     `mkVersion [0,1,0,0]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName])],
                                                           virtualModules = []},
                                         libExposed = True,
                                         libName = Nothing,

--- a/cabal-install/Distribution/Client/CmdErrorMessages.hs
+++ b/cabal-install/Distribution/Client/CmdErrorMessages.hs
@@ -15,6 +15,8 @@ import Distribution.Package
          ( packageId, PackageName, packageName )
 import Distribution.Types.ComponentName
          ( showComponentName )
+import Distribution.Types.LibraryName
+         ( LibraryName(..) )
 import Distribution.Solver.Types.OptionalStanza
          ( OptionalStanza(..) )
 import Distribution.Text
@@ -165,8 +167,8 @@ targetSelectorFilter  TargetComponent{}              = Nothing
 targetSelectorFilter  TargetComponentUnknown{}       = Nothing
 
 renderComponentName :: PackageName -> ComponentName -> String
-renderComponentName pkgname CLibName     = "library " ++ display pkgname
-renderComponentName _ (CSubLibName name) = "library " ++ display name
+renderComponentName pkgname (CLibName LMainLibName) = "library " ++ display pkgname
+renderComponentName _ (CLibName (LSubLibName name)) = "library " ++ display name
 renderComponentName _ (CFLibName   name) = "foreign library " ++ display name
 renderComponentName _ (CExeName    name) = "executable " ++ display name
 renderComponentName _ (CTestName   name) = "test suite " ++ display name

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -651,10 +651,9 @@ entriesForLibraryComponents :: TargetsMap -> [GhcEnvironmentFileEntry]
 entriesForLibraryComponents = Map.foldrWithKey' (\k v -> mappend (go k v)) []
   where
     hasLib :: (ComponentTarget, [TargetSelector]) -> Bool
-    hasLib (ComponentTarget CLibName _,        _) = True
-    hasLib (ComponentTarget (CSubLibName _) _, _) = True
-    hasLib _                                      = False
-
+    hasLib (ComponentTarget (CLibName _) _, _) = True
+    hasLib _                                   = False
+    
     go :: UnitId -> [(ComponentTarget, [TargetSelector])] -> [GhcEnvironmentFileEntry]
     go unitId targets
       | any hasLib targets = [GhcEnvFilePackageId unitId]

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -72,6 +72,8 @@ import Distribution.Types.Dependency
          ( Dependency(..) )
 import Distribution.Types.GenericPackageDescription
          ( emptyGenericPackageDescription )
+import Distribution.Types.LibraryName
+         ( LibraryName(..) )
 import Distribution.Types.PackageDescription
          ( PackageDescription(..), emptyPackageDescription )
 import Distribution.Types.Library
@@ -370,7 +372,7 @@ withoutProject config verbosity extraArgs = do
       { targetBuildDepends = [baseDep]
       , defaultLanguage = Just Haskell2010
       }
-    baseDep = Dependency "base" anyVersion
+    baseDep = Dependency "base" anyVersion (Set.singleton LMainLibName)
     pkgId = PackageIdentifier "fake-package" version0
 
   writeGenericPackageDescription (tempDir </> "fake-package.cabal") genericPackageDescription

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -278,7 +278,7 @@ checkConfigExFlags verbosity installedPkgIndex sourcePkgIndex flags = do
   where
     unknownConstraints = filter (unknown . userConstraintPackageName . fst) $
                          configExConstraints flags
-    unknownPreferences = filter (unknown . \(Dependency name _) -> name) $
+    unknownPreferences = filter (unknown . \(Dependency name _ _) -> name) $
                          configPreferences flags
     unknown pkg = null (lookupPackageName installedPkgIndex pkg)
                && not (elemByPackageName sourcePkgIndex pkg)
@@ -325,7 +325,7 @@ planLocalPackage verbosity comp platform configFlags configExFlags
         . addPreferences
             -- preferences from the config file or command line
             [ PackageVersionPreference name ver
-            | Dependency name ver <- configPreferences configExFlags ]
+            | Dependency name ver _ <- configPreferences configExFlags ]
 
         . addConstraints
             -- version constraints from the config file or command line

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -64,6 +64,8 @@ import Distribution.Package
          ( Package(..), packageName, PackageId )
 import Distribution.Types.Dependency
          ( Dependency(..), thisPackageVersion )
+import Distribution.Types.GivenComponent
+         ( GivenComponent(..) )
 import qualified Distribution.PackageDescription as PkgDesc
 import Distribution.PackageDescription.Parsec
          ( readGenericPackageDescription )
@@ -402,7 +404,7 @@ configurePackage verbosity platform comp scriptOptions configFlags
       -- depending on the Cabal version we are talking to.
       configConstraints  = [ thisPackageVersion srcid
                            | ConfiguredId srcid (Just PkgDesc.CLibName) _uid <- CD.nonSetupDeps deps ],
-      configDependencies = [ (packageName srcid, PkgDesc.CLibName, uid)
+      configDependencies = [ GivenComponent (packageName srcid) (PkgDesc.CLibName) uid
                            | ConfiguredId srcid (Just PkgDesc.CLibName) uid <- CD.nonSetupDeps deps ],
       -- Use '--exact-configuration' if supported.
       configExactConfiguration = toFlag True,

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -402,7 +402,7 @@ configurePackage verbosity platform comp scriptOptions configFlags
       -- depending on the Cabal version we are talking to.
       configConstraints  = [ thisPackageVersion srcid
                            | ConfiguredId srcid (Just PkgDesc.CLibName) _uid <- CD.nonSetupDeps deps ],
-      configDependencies = [ (packageName srcid, uid)
+      configDependencies = [ (packageName srcid, PkgDesc.CLibName, uid)
                            | ConfiguredId srcid (Just PkgDesc.CLibName) uid <- CD.nonSetupDeps deps ],
       -- Use '--exact-configuration' if supported.
       configExactConfiguration = toFlag True,

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -404,8 +404,8 @@ configurePackage verbosity platform comp scriptOptions configFlags
       -- depending on the Cabal version we are talking to.
       configConstraints  = [ thisPackageVersion srcid
                            | ConfiguredId srcid (Just PkgDesc.CLibName) _uid <- CD.nonSetupDeps deps ],
-      configDependencies = [ GivenComponent (packageName srcid) (PkgDesc.CLibName) uid
-                           | ConfiguredId srcid (Just PkgDesc.CLibName) uid <- CD.nonSetupDeps deps ],
+      configDependencies = [ GivenComponent (packageName srcid) cname uid
+                           | ConfiguredId srcid (Just cname) uid <- CD.nonSetupDeps deps ],
       -- Use '--exact-configuration' if supported.
       configExactConfiguration = toFlag True,
       configVerbosity          = toFlag verbosity,

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -256,7 +256,8 @@ configureSetupScript packageDBs
       -- Return the setup dependencies computed by the solver
       ReadyPackage cpkg <- mpkg
       return [ ( cid, srcid )
-             | ConfiguredId srcid (Just PkgDesc.CLibName) cid <- CD.setupDeps (confPkgDeps cpkg)
+             | ConfiguredId srcid (Just (PkgDesc.CLibName PkgDesc.LMainLibName)) cid
+                 <- CD.setupDeps (confPkgDeps cpkg)
              ]
 
 -- | Warn if any constraints or preferences name packages that are not in the
@@ -403,9 +404,11 @@ configurePackage verbosity platform comp scriptOptions configFlags
       -- deps.  In the end only one set gets passed to Setup.hs configure,
       -- depending on the Cabal version we are talking to.
       configConstraints  = [ thisPackageVersion srcid
-                           | ConfiguredId srcid (Just PkgDesc.CLibName) _uid <- CD.nonSetupDeps deps ],
+                           | ConfiguredId srcid (Just (PkgDesc.CLibName PkgDesc.LMainLibName)) _uid
+                               <- CD.nonSetupDeps deps ],
       configDependencies = [ GivenComponent (packageName srcid) cname uid
-                           | ConfiguredId srcid (Just cname) uid <- CD.nonSetupDeps deps ],
+                           | ConfiguredId srcid (Just (PkgDesc.CLibName cname)) uid
+                               <- CD.nonSetupDeps deps ],
       -- Use '--exact-configuration' if supported.
       configExactConfiguration = toFlag True,
       configVerbosity          = toFlag verbosity,

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -63,9 +63,11 @@ import Distribution.Simple.PackageIndex
 import Distribution.Package
          ( Package(..), packageName, PackageId )
 import Distribution.Types.Dependency
-         ( Dependency(..), thisPackageVersion )
+         ( thisPackageVersion )
 import Distribution.Types.GivenComponent
          ( GivenComponent(..) )
+import Distribution.Types.PackageVersionConstraint
+         ( PackageVersionConstraint(..) )
 import qualified Distribution.PackageDescription as PkgDesc
 import Distribution.PackageDescription.Parsec
          ( readGenericPackageDescription )
@@ -278,7 +280,7 @@ checkConfigExFlags verbosity installedPkgIndex sourcePkgIndex flags = do
   where
     unknownConstraints = filter (unknown . userConstraintPackageName . fst) $
                          configExConstraints flags
-    unknownPreferences = filter (unknown . \(Dependency name _ _) -> name) $
+    unknownPreferences = filter (unknown . \(PackageVersionConstraint name _) -> name) $
                          configPreferences flags
     unknown pkg = null (lookupPackageName installedPkgIndex pkg)
                && not (elemByPackageName sourcePkgIndex pkg)
@@ -325,7 +327,7 @@ planLocalPackage verbosity comp platform configFlags configExFlags
         . addPreferences
             -- preferences from the config file or command line
             [ PackageVersionPreference name ver
-            | Dependency name ver _ <- configPreferences configExFlags ]
+            | PackageVersionConstraint name ver <- configPreferences configExFlags ]
 
         . addConstraints
             -- version constraints from the config file or command line

--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -36,6 +36,7 @@ import Distribution.Text
 import Distribution.Pretty
          ( prettyShow )
 import Distribution.Types.ComponentName
+import Distribution.Types.LibraryName
 import Distribution.System
 
 
@@ -199,8 +200,8 @@ defaultDistDirLayout projectRoot mdistDirectory =
         display (distParamPackageId params) </>
         (case distParamComponentName params of
             Nothing                  -> ""
-            Just CLibName            -> ""
-            Just (CSubLibName name)  -> "l" </> display name
+            Just (CLibName LMainLibName) -> ""
+            Just (CLibName (LSubLibName name)) -> "l" </> display name
             Just (CFLibName name)    -> "f" </> display name
             Just (CExeName name)     -> "x" </> display name
             Just (CTestName name)    -> "t" </> display name

--- a/cabal-install/Distribution/Client/GenBounds.hs
+++ b/cabal-install/Distribution/Client/GenBounds.hs
@@ -144,10 +144,10 @@ genBounds verbosity packageDBs repoCtxt comp platform progdb mSandboxPkgInfo
        traverse_ (putStrLn . (++",") . showBounds padTo) thePkgs
 
      depName :: Dependency -> String
-     depName (Dependency pn _) = unPackageName pn
+     depName (Dependency pn _ _) = unPackageName pn
 
      depVersion :: Dependency -> VersionRange
-     depVersion (Dependency _ vr) = vr
+     depVersion (Dependency _ vr _) = vr
 
 -- | The message printed when some dependencies are found to be lacking proper
 -- PVP-mandated bounds.

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -275,7 +275,7 @@ getSourcePackagesAtIndexState verbosity repoCtxt mb_idxState = do
 
   let (pkgs, prefs) = mconcat pkgss
       prefs' = Map.fromListWith intersectVersionRanges
-                 [ (name, range) | Dependency name range <- prefs ]
+                 [ (name, range) | Dependency name range _ <- prefs ]
   _ <- evaluate pkgs
   _ <- evaluate prefs'
   return SourcePackageDb {
@@ -703,7 +703,7 @@ packageListFromCache verbosity mkPkg hnd Cache{..} = accum mempty [] mempty cach
       let srcpkg = mkPkg (BuildTreeRef refType (packageId pkg) pkg path blockno)
       accum srcpkgs (srcpkg:btrs) prefs entries
 
-    accum srcpkgs btrs prefs (CachePreference pref@(Dependency pn _) _ _ : entries) =
+    accum srcpkgs btrs prefs (CachePreference pref@(Dependency pn _ _) _ _ : entries) =
       accum srcpkgs btrs (Map.insert pn pref prefs) entries
 
     getEntryContent :: BlockNo -> IO ByteString

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -39,6 +39,7 @@ import Data.List
 import Data.Function
   ( on )
 import qualified Data.Map as M
+import qualified Data.Set as Set
 import Control.Monad
   ( (>=>), join, forM_, mapM, mapM_ )
 import Control.Arrow
@@ -56,6 +57,8 @@ import Distribution.ModuleName
 import Distribution.InstalledPackageInfo
   ( InstalledPackageInfo, exposed )
 import qualified Distribution.Package as P
+import Distribution.Types.LibraryName
+  ( LibraryName(..) )
 import Language.Haskell.Extension ( Language(..) )
 
 import Distribution.Client.Init.Types
@@ -527,13 +530,14 @@ chooseDep flags (m, Just ps)
     toDep :: [P.PackageIdentifier] -> IO P.Dependency
 
     -- If only one version, easy.  We change e.g. 0.4.2  into  0.4.*
-    toDep [pid] = return $ P.Dependency (P.pkgName pid) (pvpize desugar . P.pkgVersion $ pid)
+    toDep [pid] = return $ P.Dependency (P.pkgName pid) (pvpize desugar . P.pkgVersion $ pid) (Set.singleton LMainLibName) --TODO sublibraries
 
     -- Otherwise, choose the latest version and issue a warning.
     toDep pids  = do
       message flags ("\nWarning: multiple versions of " ++ display (P.pkgName . head $ pids) ++ " provide " ++ display m ++ ", choosing the latest.")
       return $ P.Dependency (P.pkgName . head $ pids)
                             (pvpize desugar . maximum . map P.pkgVersion $ pids)
+                            (Set.singleton LMainLibName) --TODO take into account sublibraries
 
 -- | Given a version, return an API-compatible (according to PVP) version range.
 --

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -727,7 +727,12 @@ printPlan dryRun verbosity plan sourcePkgDb = case plan of
     revDepGraphEdges :: [(PackageId, PackageId)]
     revDepGraphEdges = [ (rpid, packageId cpkg)
                        | (ReadyPackage cpkg, _) <- plan
-                       , ConfiguredId rpid (Just PackageDescription.CLibName) _
+                       , ConfiguredId
+                           rpid
+                           (Just
+                             (PackageDescription.CLibName
+                               PackageDescription.LMainLibName))
+                           _
                         <- CD.flatDeps (confPkgDeps cpkg) ]
 
     revDeps :: Map.Map PackageId [PackageId]
@@ -1245,10 +1250,15 @@ installReadyPackage platform cinfo configFlags
     -- In the end only one set gets passed to Setup.hs configure, depending on
     -- the Cabal version we are talking to.
     configConstraints  = [ thisPackageVersion srcid
-                         | ConfiguredId srcid (Just PackageDescription.CLibName) _ipid
+                         | ConfiguredId
+                             srcid
+                             (Just
+                               (PackageDescription.CLibName
+                                 PackageDescription.LMainLibName))
+                             _ipid
                             <- CD.nonSetupDeps deps ],
     configDependencies = [ GivenComponent (packageName srcid) cname dep_ipid
-                         | ConfiguredId srcid (Just cname) dep_ipid
+                         | ConfiguredId srcid (Just (PackageDescription.CLibName cname)) dep_ipid
                             <- CD.nonSetupDeps deps ],
     -- Use '--exact-configuration' if supported.
     configExactConfiguration = toFlag True,

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1245,7 +1245,7 @@ installReadyPackage platform cinfo configFlags
     configConstraints  = [ thisPackageVersion srcid
                          | ConfiguredId srcid (Just PackageDescription.CLibName) _ipid
                             <- CD.nonSetupDeps deps ],
-    configDependencies = [ (packageName srcid, dep_ipid)
+    configDependencies = [ (packageName srcid, PackageDescription.CLibName, dep_ipid)
                          | ConfiguredId srcid (Just PackageDescription.CLibName) dep_ipid
                             <- CD.nonSetupDeps deps ],
     -- Use '--exact-configuration' if supported.

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -1247,8 +1247,8 @@ installReadyPackage platform cinfo configFlags
     configConstraints  = [ thisPackageVersion srcid
                          | ConfiguredId srcid (Just PackageDescription.CLibName) _ipid
                             <- CD.nonSetupDeps deps ],
-    configDependencies = [ GivenComponent (packageName srcid) PackageDescription.CLibName dep_ipid
-                         | ConfiguredId srcid (Just PackageDescription.CLibName) dep_ipid
+    configDependencies = [ GivenComponent (packageName srcid) cname dep_ipid
+                         | ConfiguredId srcid (Just cname) dep_ipid
                             <- CD.nonSetupDeps deps ],
     -- Use '--exact-configuration' if supported.
     configExactConfiguration = toFlag True,

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -407,7 +407,7 @@ planPackages verbosity comp platform mSandboxPkgInfo solver
       . addPreferences
           -- preferences from the config file or command line
           [ PackageVersionPreference name ver
-          | Dependency name ver <- configPreferences configExFlags ]
+          | Dependency name ver _ <- configPreferences configExFlags ]
 
       . addConstraints
           -- version constraints from the config file or command line

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -142,9 +142,11 @@ import Distribution.Package
          , Package(..), HasMungedPackageId(..), HasUnitId(..)
          , UnitId )
 import Distribution.Types.Dependency
-         ( Dependency(..), thisPackageVersion )
+         ( thisPackageVersion )
 import Distribution.Types.GivenComponent
          ( GivenComponent(..) )
+import Distribution.Types.PackageVersionConstraint
+         ( PackageVersionConstraint(..) )
 import Distribution.Types.MungedPackageId
 import qualified Distribution.PackageDescription as PackageDescription
 import Distribution.PackageDescription
@@ -407,7 +409,7 @@ planPackages verbosity comp platform mSandboxPkgInfo solver
       . addPreferences
           -- preferences from the config file or command line
           [ PackageVersionPreference name ver
-          | Dependency name ver _ <- configPreferences configExFlags ]
+          | PackageVersionConstraint name ver <- configPreferences configExFlags ]
 
       . addConstraints
           -- version constraints from the config file or command line

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -143,6 +143,8 @@ import Distribution.Package
          , UnitId )
 import Distribution.Types.Dependency
          ( Dependency(..), thisPackageVersion )
+import Distribution.Types.GivenComponent
+         ( GivenComponent(..) )
 import Distribution.Types.MungedPackageId
 import qualified Distribution.PackageDescription as PackageDescription
 import Distribution.PackageDescription
@@ -1245,7 +1247,7 @@ installReadyPackage platform cinfo configFlags
     configConstraints  = [ thisPackageVersion srcid
                          | ConfiguredId srcid (Just PackageDescription.CLibName) _ipid
                             <- CD.nonSetupDeps deps ],
-    configDependencies = [ (packageName srcid, PackageDescription.CLibName, dep_ipid)
+    configDependencies = [ GivenComponent (packageName srcid) PackageDescription.CLibName dep_ipid
                          | ConfiguredId srcid (Just PackageDescription.CLibName) dep_ipid
                             <- CD.nonSetupDeps deps ],
     -- Use '--exact-configuration' if supported.

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -527,7 +527,7 @@ configureInstallPlan configFlags solverPlan =
                         Cabal.NoFlag
                         Cabal.NoFlag
                         (packageId spkg)
-                        PD.CLibName
+                        (PD.CLibName PD.LMainLibName)
                         (Just (map confInstId (CD.libraryDeps deps),
                                solverPkgFlags spkg)),
         confPkgSource = solverPkgSource spkg,

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -231,9 +231,9 @@ info verbosity packageDBs repoCtxt comp progdb
 
         selectedInstalledPkgs = InstalledPackageIndex.lookupDependency
                                 installedPkgIndex
-                                (Dependency name verConstraint)
+                                name verConstraint
         selectedSourcePkgs    = PackageIndex.lookupDependency sourcePkgIndex
-                                (Dependency name verConstraint)
+                                name verConstraint
         selectedSourcePkg'    = latestWithPref pref selectedSourcePkgs
 
                          -- display a specific package version if the user

--- a/cabal-install/Distribution/Client/Outdated.hs
+++ b/cabal-install/Distribution/Client/Outdated.hs
@@ -43,7 +43,7 @@ import Distribution.Types.Dependency
        (Dependency(..), depPkgName, simplifyDependency)
 import Distribution.Verbosity                        (Verbosity, silent)
 import Distribution.Version
-       (Version, LowerBound(..), UpperBound(..)
+       (Version, VersionRange, LowerBound(..), UpperBound(..)
        ,asVersionIntervals, majorBoundVersion)
 import Distribution.PackageDescription.Parsec
        (readGenericPackageDescription)
@@ -107,7 +107,7 @@ showResult verbosity outdatedDeps simpleOutput =
     then
     do when (not simpleOutput) $
          notice verbosity "Outdated dependencies:"
-       for_ outdatedDeps $ \(d@(Dependency pn _), v) ->
+       for_ outdatedDeps $ \(d@(Dependency pn _ _), v) ->
          let outdatedDep = if simpleOutput then display pn
                            else display d ++ " (latest: " ++ display v ++ ")"
          in notice verbosity outdatedDep
@@ -179,10 +179,10 @@ listOutdated deps pkgIndex (ListOutdatedSettings ignorePred minorPred) =
   mapMaybe isOutdated $ map simplifyDependency deps
   where
     isOutdated :: Dependency -> Maybe (Dependency, Version)
-    isOutdated dep
+    isOutdated dep@(Dependency pname vr _)
       | ignorePred (depPkgName dep) = Nothing
       | otherwise                   =
-          let this   = map packageVersion $ lookupDependency pkgIndex dep
+          let this   = map packageVersion $ lookupDependency pkgIndex pname vr
               latest = lookupLatest dep
           in (\v -> (dep, v)) `fmap` isOutdated' this latest
 
@@ -195,17 +195,16 @@ listOutdated deps pkgIndex (ListOutdatedSettings ignorePred minorPred) =
       in if this' < latest' then Just latest' else Nothing
 
     lookupLatest :: Dependency -> [Version]
-    lookupLatest dep
+    lookupLatest dep@(Dependency pname vr _)
       | minorPred (depPkgName dep) =
-        map packageVersion $ lookupDependency pkgIndex  (relaxMinor dep)
+        map packageVersion $ lookupDependency pkgIndex  pname (relaxMinor vr)
       | otherwise                  =
         map packageVersion $ lookupPackageName pkgIndex (depPkgName dep)
 
-    relaxMinor :: Dependency -> Dependency
-    relaxMinor (Dependency pn vr) = (Dependency pn vr')
-      where
-        vr' = let vis = asVersionIntervals vr
-                  (LowerBound v0 _,upper) = last vis
-              in case upper of
-                   NoUpperBound     -> vr
-                   UpperBound _v1 _ -> majorBoundVersion v0
+    relaxMinor :: VersionRange -> VersionRange
+    relaxMinor vr =
+      let vis = asVersionIntervals vr
+          (LowerBound v0 _,upper) = last vis
+      in case upper of
+           NoUpperBound     -> vr
+           UpperBound _v1 _ -> majorBoundVersion v0

--- a/cabal-install/Distribution/Client/PackageUtils.hs
+++ b/cabal-install/Distribution/Client/PackageUtils.hs
@@ -33,7 +33,7 @@ externalBuildDepends pkg spec = filter (not . internal) (enabledBuildDepends pkg
   where
     -- True if this dependency is an internal one (depends on a library
     -- defined in the same package).
-    internal (Dependency depName versionRange) =
+    internal (Dependency depName versionRange _) =
            (depName == packageName pkg &&
             packageVersion pkg `withinRange` versionRange) ||
            (Just (packageNameToUnqualComponentName depName) `elem` map libName (subLibraries pkg) &&

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -85,7 +85,8 @@ import           Distribution.Simple.Program
 import qualified Distribution.Simple.Setup as Cabal
 import           Distribution.Simple.Command (CommandUI)
 import qualified Distribution.Simple.Register as Cabal
-import           Distribution.Simple.LocalBuildInfo (ComponentName(..))
+import           Distribution.Simple.LocalBuildInfo
+                   ( ComponentName(..), LibraryName(..) )
 import           Distribution.Simple.Compiler
                    ( Compiler, compilerId, PackageDB(..) )
 
@@ -1162,12 +1163,12 @@ hasValidHaddockTargets ElaboratedConfiguredPackage{..}
     componentHasHaddocks :: ComponentTarget -> Bool
     componentHasHaddocks (ComponentTarget name _) =
       case name of
-        CLibName      ->                           hasHaddocks
-        CSubLibName _ -> elabHaddockInternal    && hasHaddocks
-        CFLibName   _ -> elabHaddockForeignLibs && hasHaddocks
-        CExeName    _ -> elabHaddockExecutables && hasHaddocks
-        CTestName   _ -> elabHaddockTestSuites  && hasHaddocks
-        CBenchName  _ -> elabHaddockBenchmarks  && hasHaddocks
+        CLibName LMainLibName    ->                           hasHaddocks
+        CLibName (LSubLibName _) -> elabHaddockInternal    && hasHaddocks
+        CFLibName              _ -> elabHaddockForeignLibs && hasHaddocks
+        CExeName               _ -> elabHaddockExecutables && hasHaddocks
+        CTestName              _ -> elabHaddockTestSuites  && hasHaddocks
+        CBenchName             _ -> elabHaddockBenchmarks  && hasHaddocks
       where
         hasHaddocks = not (null (elabPkgDescription ^. componentModules name))
 

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -82,7 +82,8 @@ import Distribution.Solver.Types.PackageConstraint
 
 import Distribution.Package
          ( PackageName, PackageId, packageId, UnitId )
-import Distribution.Types.Dependency
+import Distribution.Types.PackageVersionConstraint
+         ( PackageVersionConstraint(..) )
 import Distribution.System
          ( Platform )
 import Distribution.Types.GenericPackageDescription
@@ -638,7 +639,7 @@ data ProjectPackageLocation =
    | ProjectPackageLocalTarball   FilePath
    | ProjectPackageRemoteTarball  URI
    | ProjectPackageRemoteRepo     SourceRepo
-   | ProjectPackageNamed          Dependency
+   | ProjectPackageNamed          PackageVersionConstraint
   deriving Show
 
 
@@ -992,7 +993,7 @@ fetchAndReadSourcePackages verbosity distDirLayout
 
     let pkgsNamed =
           [ NamedPackage pkgname [PackagePropertyVersion verrange]
-          | ProjectPackageNamed (Dependency pkgname verrange _) <- pkgLocations ]
+          | ProjectPackageNamed (PackageVersionConstraint pkgname verrange) <- pkgLocations ]
 
     return $ concat
       [ pkgsLocalDirectory

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -992,7 +992,7 @@ fetchAndReadSourcePackages verbosity distDirLayout
 
     let pkgsNamed =
           [ NamedPackage pkgname [PackagePropertyVersion verrange]
-          | ProjectPackageNamed (Dependency pkgname verrange) <- pkgLocations ]
+          | ProjectPackageNamed (Dependency pkgname verrange _) <- pkgLocations ]
 
     return $ concat
       [ pkgsLocalDirectory

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -80,6 +80,8 @@ import Distribution.Client.ParseUtils
 import Distribution.Simple.Command
          ( CommandUI(commandOptions), ShowOrParseArgs(..)
          , OptionField, option, reqArg' )
+import Distribution.Types.PackageVersionConstraint
+         ( PackageVersionConstraint )
 
 import qualified Data.Map as Map
 ------------------------------------------------------------------
@@ -99,7 +101,7 @@ data LegacyProjectConfig = LegacyProjectConfig {
        legacyPackages          :: [String],
        legacyPackagesOptional  :: [String],
        legacyPackagesRepo      :: [SourceRepo],
-       legacyPackagesNamed     :: [Dependency],
+       legacyPackagesNamed     :: [PackageVersionConstraint],
 
        legacySharedConfig      :: LegacySharedConfig,
        legacyAllConfig         :: LegacyPackageConfig,

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -37,7 +37,8 @@ import Distribution.Solver.Types.ConstraintSource
 
 import Distribution.Package
          ( PackageName, PackageId, UnitId )
-import Distribution.Types.Dependency
+import Distribution.Types.PackageVersionConstraint
+         ( PackageVersionConstraint )
 import Distribution.Version
          ( Version )
 import Distribution.System
@@ -105,7 +106,7 @@ data ProjectConfig
        projectPackagesRepo          :: [SourceRepo],
 
        -- | Packages in this project from hackage repositories.
-       projectPackagesNamed         :: [Dependency],
+       projectPackagesNamed         :: [PackageVersionConstraint],
 
        -- See respective types for an explanation of what these
        -- values are about:
@@ -181,7 +182,7 @@ data ProjectConfigShared
 
        -- solver configuration
        projectConfigConstraints       :: [(UserConstraint, ConstraintSource)],
-       projectConfigPreferences       :: [Dependency],
+       projectConfigPreferences       :: [PackageVersionConstraint],
        projectConfigCabalVersion      :: Flag Version,  --TODO: [required eventually] unused
        projectConfigSolver            :: Flag PreSolver,
        projectConfigAllowOlder        :: Maybe AllowOlder,
@@ -361,7 +362,7 @@ data SolverSettings
        solverSettingRemoteRepos       :: [RemoteRepo],     -- ^ Available Hackage servers.
        solverSettingLocalRepos        :: [FilePath],
        solverSettingConstraints       :: [(UserConstraint, ConstraintSource)],
-       solverSettingPreferences       :: [Dependency],
+       solverSettingPreferences       :: [PackageVersionConstraint],
        solverSettingFlagAssignment    :: FlagAssignment, -- ^ For all local packages
        solverSettingFlagAssignments   :: Map PackageName FlagAssignment,
        solverSettingCabalVersion      :: Maybe Version,  --TODO: [required eventually] unused

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -115,6 +115,7 @@ import           Distribution.Types.ComponentName
 import           Distribution.Types.LibraryName
 import           Distribution.Types.GivenComponent
   (GivenComponent(..))
+import           Distribution.Types.PackageVersionConstraint
 import           Distribution.Types.PkgconfigDependency
 import           Distribution.Types.UnqualComponentName
 import           Distribution.System
@@ -988,7 +989,7 @@ planPackages verbosity comp platform solver SolverSettings{..}
       . addPreferences
           -- preferences from the config file or command line
           [ PackageVersionPreference name ver
-          | Dependency name ver _ <- solverSettingPreferences ]
+          | PackageVersionConstraint name ver <- solverSettingPreferences ]
 
       . addConstraints
           -- version constraints from the config file or command line

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -112,6 +112,8 @@ import           Distribution.Package hiding
   (InstalledPackageId, installedPackageId)
 import           Distribution.Types.AnnotatedId
 import           Distribution.Types.ComponentName
+import           Distribution.Types.GivenComponent
+  (GivenComponent(..))
 import           Distribution.Types.PkgconfigDependency
 import           Distribution.Types.UnqualComponentName
 import           Distribution.System
@@ -3298,14 +3300,15 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
     -- NB: This does NOT use InstallPlan.depends, which includes executable
     -- dependencies which should NOT be fed in here (also you don't have
     -- enough info anyway)
-    configDependencies        = [ (case mb_cn of
-                                    -- Special case for internal libraries
-                                    Just (CSubLibName uqn)
-                                        | packageId elab == srcid
-                                        -> mkPackageName (unUnqualComponentName uqn)
-                                    _ -> packageName srcid,
-                                   CLibName,
-                                   cid)
+    configDependencies        = [ GivenComponent
+                                    (case mb_cn of
+                                       -- Special case for internal libraries
+                                       Just (CSubLibName uqn)
+                                           | packageId elab == srcid
+                                           -> mkPackageName (unUnqualComponentName uqn)
+                                       _ -> packageName srcid)
+                                     CLibName
+                                     cid
                                 | ConfiguredId srcid mb_cn cid <- elabLibDependencies elab ]
     configConstraints         =
         case elabPkgOrComp of

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -988,7 +988,7 @@ planPackages verbosity comp platform solver SolverSettings{..}
       . addPreferences
           -- preferences from the config file or command line
           [ PackageVersionPreference name ver
-          | Dependency name ver <- solverSettingPreferences ]
+          | Dependency name ver _ <- solverSettingPreferences ]
 
       . addConstraints
           -- version constraints from the config file or command line
@@ -3013,9 +3013,9 @@ defaultSetupDeps compiler platform pkg =
       -- of other packages.
       SetupCustomImplicitDeps ->
         Just $
-        [ Dependency depPkgname anyVersion
+        [ Dependency depPkgname anyVersion (Set.singleton LMainLibName)
         | depPkgname <- legacyCustomSetupPkgs compiler platform ] ++
-        [ Dependency cabalPkgname cabalConstraint
+        [ Dependency cabalPkgname cabalConstraint (Set.singleton LMainLibName)
         | packageName pkg /= cabalPkgname ]
         where
           -- The Cabal dep is slightly special:
@@ -3038,8 +3038,8 @@ defaultSetupDeps compiler platform pkg =
       -- external Setup.hs, it'll be one of the simple ones that only depends
       -- on Cabal and base.
       SetupNonCustomExternalLib ->
-        Just [ Dependency cabalPkgname cabalConstraint
-             , Dependency basePkgname  anyVersion ]
+        Just [ Dependency cabalPkgname cabalConstraint (Set.singleton LMainLibName)
+             , Dependency basePkgname  anyVersion (Set.singleton LMainLibName)]
         where
           cabalConstraint = orLaterVersion (PD.specVersion pkg)
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -3301,14 +3301,9 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
     -- dependencies which should NOT be fed in here (also you don't have
     -- enough info anyway)
     configDependencies        = [ GivenComponent
-                                    (case mb_cn of
-                                       -- Special case for internal libraries
-                                       Just (CSubLibName uqn)
-                                           | packageId elab == srcid
-                                           -> mkPackageName (unUnqualComponentName uqn)
-                                       _ -> packageName srcid)
-                                     CLibName
-                                     cid
+                                    (packageName srcid)
+                                    (fromMaybe CLibName mb_cn)
+                                    cid
                                 | ConfiguredId srcid mb_cn cid <- elabLibDependencies elab ]
     configConstraints         =
         case elabPkgOrComp of

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -3304,6 +3304,7 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
                                         | packageId elab == srcid
                                         -> mkPackageName (unUnqualComponentName uqn)
                                     _ -> packageName srcid,
+                                   CLibName,
                                    cid)
                                 | ConfiguredId srcid mb_cn cid <- elabLibDependencies elab ]
     configConstraints         =

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -87,7 +87,8 @@ import           Distribution.Simple.Build.PathsModule (pkgPathEnvVar)
 import qualified Distribution.Simple.BuildTarget as Cabal
 import           Distribution.Simple.Program
 import           Distribution.ModuleName (ModuleName)
-import           Distribution.Simple.LocalBuildInfo (ComponentName(..))
+import           Distribution.Simple.LocalBuildInfo
+                   ( ComponentName(..), LibraryName(..) )
 import qualified Distribution.Simple.InstallDirs as InstallDirs
 import           Distribution.Simple.InstallDirs (PathTemplate)
 import           Distribution.Simple.Setup (HaddockTarget)
@@ -388,8 +389,7 @@ elabRequiresRegistration elab =
     -- single file
     is_lib_target (ComponentTarget cn WholeComponent) = is_lib cn
     is_lib_target _ = False
-    is_lib CLibName = True
-    is_lib (CSubLibName _) = True
+    is_lib (CLibName _) = True
     is_lib _ = False
 
 -- | Construct the environment needed for the data files to work.
@@ -460,7 +460,7 @@ instance Binary ElaboratedPackageOrComponent
 elabComponentName :: ElaboratedConfiguredPackage -> Maybe ComponentName
 elabComponentName elab =
     case elabPkgOrComp elab of
-        ElabPackage _      -> Just CLibName -- there could be more, but default this
+        ElabPackage _      -> Just $ CLibName LMainLibName -- there could be more, but default this
         ElabComponent comp -> compComponentName comp
 
 -- | A user-friendly descriptor for an 'ElaboratedConfiguredPackage'.
@@ -472,7 +472,7 @@ elabConfiguredName verbosity elab
         ElabComponent comp ->
             case compComponentName comp of
                 Nothing -> "setup from "
-                Just CLibName -> ""
+                Just (CLibName LMainLibName) -> ""
                 Just cname -> display cname ++ " from ")
       ++ display (packageId elab)
     | otherwise
@@ -776,8 +776,8 @@ isExeComponentTarget (ComponentTarget (CExeName _) _ ) = True
 isExeComponentTarget _                                 = False
 
 isSubLibComponentTarget :: ComponentTarget -> Bool
-isSubLibComponentTarget (ComponentTarget (CSubLibName _) _) = True
-isSubLibComponentTarget _                                   = False
+isSubLibComponentTarget (ComponentTarget (CLibName (LSubLibName _)) _) = True
+isSubLibComponentTarget _                                              = False
 
 ---------------------------
 -- Setup.hs script policy

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -118,7 +118,7 @@ import Distribution.Types.GivenComponent
 import Distribution.Types.UnqualComponentName
          ( unUnqualComponentName )
 import Distribution.PackageDescription
-         ( BuildType(..), RepoKind(..), ComponentName(..) )
+         ( BuildType(..), RepoKind(..), LibraryName(..) )
 import Distribution.System ( Platform )
 import Distribution.Text
          ( Text(..), display )
@@ -533,14 +533,13 @@ filterConfigureFlags flags cabalLibVersion
       -- Cabal < 2.5.0 does not understand --dependency=pkg:COMPONENT=cid
       --                                   (public sublibraries)
       configDependencies =
-        let convertToLegacyInternalDep (GivenComponent _ (CSubLibName cn) cid) =
+        let convertToLegacyInternalDep (GivenComponent _ (LSubLibName cn) cid) =
               Just $ GivenComponent
                        (mkPackageName $ unUnqualComponentName cn)
-                       CLibName
+                       LMainLibName
                        cid
-            convertToLegacyInternalDep (GivenComponent pn CLibName cid) =
-              Just $ GivenComponent pn CLibName cid
-            convertToLegacyInternalDep _ = Nothing
+            convertToLegacyInternalDep (GivenComponent pn LMainLibName cid) =
+              Just $ GivenComponent pn LMainLibName cid
         in catMaybes $ convertToLegacyInternalDep <$> configDependencies flags
       }
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -110,8 +110,13 @@ import Distribution.Simple.InstallDirs
 import Distribution.Version
          ( Version, mkVersion, nullVersion, anyVersion, thisVersion )
 import Distribution.Package
-         ( PackageIdentifier, PackageName, packageName, packageVersion )
+         ( PackageIdentifier, PackageName, packageName, mkPackageName
+         , packageVersion )
 import Distribution.Types.Dependency
+import Distribution.Types.GivenComponent
+         ( GivenComponent(..) )
+import Distribution.Types.UnqualComponentName
+         ( unUnqualComponentName )
 import Distribution.PackageDescription
          ( BuildType(..), RepoKind(..), ComponentName(..) )
 import Distribution.System ( Platform )
@@ -528,9 +533,15 @@ filterConfigureFlags flags cabalLibVersion
       -- Cabal < 2.5.0 does not understand --dependency=pkg:COMPONENT=cid
       --                                   (public sublibraries)
       configDependencies =
-        let isMainLib CLibName = True
-            isMainLib _        = False
-        in filter (\(_, c, _) -> isMainLib c) $ configDependencies flags
+        let convertToLegacyInternalDep (GivenComponent _ (CSubLibName cn) cid) =
+              Just $ GivenComponent
+                       (mkPackageName $ unUnqualComponentName cn)
+                       CLibName
+                       cid
+            convertToLegacyInternalDep (GivenComponent pn CLibName cid) =
+              Just $ GivenComponent pn CLibName cid
+            convertToLegacyInternalDep _ = Nothing
+        in catMaybes $ convertToLegacyInternalDep <$> configDependencies flags
       }
 
     flags_2_1_0 = flags_2_5_0 {

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -113,7 +113,7 @@ import Distribution.Package
          ( PackageIdentifier, PackageName, packageName, packageVersion )
 import Distribution.Types.Dependency
 import Distribution.PackageDescription
-         ( BuildType(..), RepoKind(..) )
+         ( BuildType(..), RepoKind(..), ComponentName(..) )
 import Distribution.System ( Platform )
 import Distribution.Text
          ( Text(..), display )
@@ -495,7 +495,7 @@ filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
   -- NB: we expect the latest version to be the most common case,
   -- so test it first.
-  | cabalLibVersion >= mkVersion [2,1,0]  = flags_latest
+  | cabalLibVersion >= mkVersion [2,3,0]  = flags_latest
   -- The naming convention is that flags_version gives flags with
   -- all flags *introduced* in version eliminated.
   -- It is NOT the latest version of Cabal library that
@@ -513,6 +513,7 @@ filterConfigureFlags flags cabalLibVersion
   | cabalLibVersion < mkVersion [1,23,0] = flags_1_23_0
   | cabalLibVersion < mkVersion [1,25,0] = flags_1_25_0
   | cabalLibVersion < mkVersion [2,1,0]  = flags_2_1_0
+  | cabalLibVersion < mkVersion [2,5,0]  = flags_2_5_0
   | otherwise = flags_latest
   where
     flags_latest = flags        {
@@ -523,7 +524,16 @@ filterConfigureFlags flags cabalLibVersion
       configConstraints = []
       }
 
-    flags_2_1_0 = flags_latest {
+    flags_2_5_0 = flags_latest {
+      -- Cabal < 2.5.0 does not understand --dependency=pkg:COMPONENT=cid
+      --                                   (public sublibraries)
+      configDependencies =
+        let isMainLib CLibName = True
+            isMainLib _        = False
+        in filter (\(_, c, _) -> isMainLib c) $ configDependencies flags
+      }
+
+    flags_2_1_0 = flags_2_5_0 {
       -- Cabal < 2.1 doesn't know about -v +timestamp modifier
         configVerbosity   = fmap verboseNoTimestamp (configVerbosity flags_latest)
       -- Cabal < 2.1 doesn't know about --<enable|disable>-static

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -114,6 +114,8 @@ import Distribution.Package
 import Distribution.Types.Dependency
 import Distribution.Types.GivenComponent
          ( GivenComponent(..) )
+import Distribution.Types.PackageVersionConstraint
+         ( PackageVersionConstraint(..) )
 import Distribution.Types.UnqualComponentName
          ( unqualComponentNameToPackageName )
 import Distribution.PackageDescription
@@ -636,7 +638,7 @@ configCompilerAux' configFlags =
 data ConfigExFlags = ConfigExFlags {
     configCabalVersion :: Flag Version,
     configExConstraints:: [(UserConstraint, ConstraintSource)],
-    configPreferences  :: [Dependency],
+    configPreferences  :: [PackageVersionConstraint],
     configSolver       :: Flag PreSolver,
     configAllowNewer   :: Maybe AllowNewer,
     configAllowOlder   :: Maybe AllowOlder

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -36,7 +36,6 @@ import Distribution.Package
          ( newSimpleUnitId, unsafeMkDefUnitId, ComponentId
          , PackageId, mkPackageName
          , PackageIdentifier(..), packageVersion, packageName )
-import Distribution.Types.Dependency
 import Distribution.PackageDescription
          ( GenericPackageDescription(packageDescription)
          , PackageDescription(..), specVersion, buildType
@@ -719,10 +718,10 @@ getExternalSetupMethod verbosity options pkg bt = do
     return (packageVersion pkg, Nothing, options')
   installedCabalVersion options' compiler progdb = do
     index <- maybeGetInstalledPackages options' compiler progdb
-    let cabalDep   = Dependency (mkPackageName "Cabal")
-                                (useCabalVersion options')
-        options''  = options' { usePackageIndex = Just index }
-    case PackageIndex.lookupDependency index cabalDep of
+    let cabalDepName    = mkPackageName "Cabal"
+        cabalDepVersion = useCabalVersion options'
+        options''       = options' { usePackageIndex = Just index }
+    case PackageIndex.lookupDependency index cabalDepName cabalDepVersion of
       []   -> die' verbosity $ "The package '" ++ display (packageName pkg)
                  ++ "' requires Cabal library version "
                  ++ display (useCabalVersion options)

--- a/cabal-install/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/Distribution/Client/TargetSelector.hs
@@ -61,7 +61,7 @@ import Distribution.Solver.Types.SourcePackage
 import Distribution.ModuleName
          ( ModuleName, toFilePath )
 import Distribution.Simple.LocalBuildInfo
-         ( Component(..), ComponentName(..)
+         ( Component(..), ComponentName(..), LibraryName(..)
          , pkgComponents, componentName, componentBuildInfo )
 import Distribution.Types.ForeignLib
 
@@ -552,8 +552,7 @@ resolveTargetSelector knowntargets@KnownTargets{..} mfilter targetStrStatus =
         go (TargetPackageNamed _   (Just filter')) = kfilter == filter'
         go (TargetAllPackages      (Just filter')) = kfilter == filter'
         go (TargetComponent _ cname _)
-          | CLibName      <- cname                 = kfilter == LibKind
-          | CSubLibName _ <- cname                 = kfilter == LibKind
+          | CLibName    _ <- cname                 = kfilter == LibKind
           | CFLibName   _ <- cname                 = kfilter == FLibKind
           | CExeName    _ <- cname                 = kfilter == ExeKind
           | CTestName   _ <- cname                 = kfilter == TestKind
@@ -1183,7 +1182,7 @@ syntaxForm2PackageModule ps =
       KnownPackageName pn -> do
         m <- matchModuleNameUnknown str2
         -- We assume the primary library component of the package:
-        return (TargetComponentUnknown pn (Right CLibName) (ModuleTarget m))
+        return (TargetComponentUnknown pn (Right $ CLibName LMainLibName) (ModuleTarget m))
   where
     render (TargetComponent p _c (ModuleTarget m)) =
       [TargetStringFileStatus2 (dispP p) noFileStatus (dispM m)]
@@ -1228,7 +1227,7 @@ syntaxForm2PackageFile ps =
       KnownPackageName pn ->
         let filepath = str2 in
         -- We assume the primary library component of the package:
-        return (TargetComponentUnknown pn (Right CLibName) (FileTarget filepath))
+        return (TargetComponentUnknown pn (Right $ CLibName LMainLibName) (FileTarget filepath))
   where
     render (TargetComponent p _c (FileTarget f)) =
       [TargetStringFileStatus2 (dispP p) noFileStatus f]
@@ -1799,8 +1798,8 @@ collectKnownComponentInfo pkg =
 
 
 componentStringName :: PackageName -> ComponentName -> ComponentStringName
-componentStringName pkgname CLibName    = display pkgname
-componentStringName _ (CSubLibName name) = unUnqualComponentName name
+componentStringName pkgname (CLibName LMainLibName) = display pkgname
+componentStringName _ (CLibName (LSubLibName name)) = unUnqualComponentName name
 componentStringName _ (CFLibName name)  = unUnqualComponentName name
 componentStringName _ (CExeName   name) = unUnqualComponentName name
 componentStringName _ (CTestName  name) = unUnqualComponentName name
@@ -1859,8 +1858,7 @@ guardToken tokens msg s
 --
 
 componentKind :: ComponentName -> ComponentKind
-componentKind  CLibName      = LibKind
-componentKind (CSubLibName _) = LibKind
+componentKind (CLibName _)   = LibKind
 componentKind (CFLibName _)  = FLibKind
 componentKind (CExeName   _) = ExeKind
 componentKind (CTestName  _) = TestKind
@@ -2390,8 +2388,8 @@ mkComponentName pkgname ckind ucname =
   case ckind of
     LibKind
       | packageNameToUnqualComponentName pkgname == ucname
-                  -> CLibName
-      | otherwise -> CSubLibName ucname
+                  -> CLibName LMainLibName
+      | otherwise -> CLibName $ LSubLibName ucname
     FLibKind      -> CFLibName   ucname
     ExeKind       -> CExeName    ucname
     TestKind      -> CTestName   ucname

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -46,6 +46,8 @@ import Distribution.Types.PackageName
          ( PackageName, mkPackageName )
 import Distribution.Types.ComponentName
          ( ComponentName(..) )
+import Distribution.Types.LibraryName
+         ( LibraryName(..) )
 import Distribution.Types.SourceRepo
          ( SourceRepo )
 
@@ -129,7 +131,7 @@ data ConfiguredPackage loc = ConfiguredPackage {
 -- 'ElaboratedPackage' and 'ElaboratedComponent'.
 --
 instance HasConfiguredId (ConfiguredPackage loc) where
-    configuredId pkg = ConfiguredId (packageId pkg) (Just CLibName) (confPkgId pkg)
+    configuredId pkg = ConfiguredId (packageId pkg) (Just (CLibName LMainLibName)) (confPkgId pkg)
 
 -- 'ConfiguredPackage' is the legacy codepath, we are guaranteed
 -- to never have a nontrivial 'UnitId'

--- a/cabal-install/Distribution/Client/World.hs
+++ b/cabal-install/Distribution/Client/World.hs
@@ -74,8 +74,8 @@ delete = modifyWorld $ flip (deleteFirstsBy equalUDep)
 -- | WorldPkgInfo values are considered equal if they refer to
 -- the same package, i.e., we don't care about differing versions or flags.
 equalUDep :: WorldPkgInfo -> WorldPkgInfo -> Bool
-equalUDep (WorldPkgInfo (Dependency pkg1 _) _)
-          (WorldPkgInfo (Dependency pkg2 _) _) = pkg1 == pkg2
+equalUDep (WorldPkgInfo (Dependency pkg1 _ _) _)
+          (WorldPkgInfo (Dependency pkg2 _ _) _) = pkg1 == pkg2
 
 -- | Modifies the world file by applying an update-function ('unionBy'
 -- for 'insert', 'deleteFirstsBy' for 'delete') to the given list of

--- a/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
@@ -335,7 +335,7 @@ type IPNs = Set PN
 -- | Convenience function to delete a 'Dependency' if it's
 -- for a 'PN' that isn't actually real.
 filterIPNs :: IPNs -> Dependency -> Maybe Dependency
-filterIPNs ipns d@(Dependency pn _)
+filterIPNs ipns d@(Dependency pn _ _)
     | S.notMember pn ipns = Just d
     | otherwise           = Nothing
 
@@ -562,7 +562,7 @@ unionDRs (DependencyReason pn' fs1 ss1) (DependencyReason _ fs2 ss2) =
 
 -- | Convert a Cabal dependency on a library to a solver-specific dependency.
 convLibDep :: DependencyReason PN -> Dependency -> LDep PN
-convLibDep dr (Dependency pn vr) = LDep dr $ Dep (PkgComponent pn ExposedLib) (Constrained vr)
+convLibDep dr (Dependency pn vr _) = LDep dr $ Dep (PkgComponent pn ExposedLib) (Constrained vr)
 
 -- | Convert a Cabal dependency on an executable (build-tools) to a solver-specific dependency.
 convExeDep :: DependencyReason PN -> ExeDependency -> LDep PN

--- a/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
@@ -44,6 +44,7 @@ import qualified Data.Map as Map
 import Data.Foldable (fold)
 
 import qualified Distribution.Types.ComponentName as CN
+import qualified Distribution.Types.LibraryName as LN
 
 {-------------------------------------------------------------------------------
   Types
@@ -90,8 +91,8 @@ instance Traversable ComponentDeps where
 instance Binary a => Binary (ComponentDeps a)
 
 componentNameToComponent :: CN.ComponentName -> Component
-componentNameToComponent (CN.CLibName)      = ComponentLib
-componentNameToComponent (CN.CSubLibName s) = ComponentSubLib s
+componentNameToComponent (CN.CLibName LN.LMainLibName   ) = ComponentLib
+componentNameToComponent (CN.CLibName (LN.LSubLibName s)) = ComponentSubLib s
 componentNameToComponent (CN.CFLibName s)   = ComponentFLib s
 componentNameToComponent (CN.CExeName s)    = ComponentExe s
 componentNameToComponent (CN.CTestName s)   = ComponentTest s

--- a/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
@@ -22,6 +22,7 @@ import Distribution.Compat.Binary      (Binary(..))
 import Distribution.Package            (PackageName)
 import Distribution.PackageDescription (FlagAssignment, dispFlagAssignment)
 import Distribution.Types.Dependency   (Dependency(..))
+import Distribution.Types.LibraryName  (LibraryName(..))
 import Distribution.Version            (VersionRange, simplifyVersionRange)
 
 import Distribution.Solver.Compat.Prelude ((<<>>))
@@ -32,6 +33,7 @@ import Distribution.Text                  (disp, flatStyle)
 import GHC.Generics                       (Generic)
 import Text.PrettyPrint                   ((<+>))
 import qualified Text.PrettyPrint as Disp
+import qualified Data.Set as Set
 
 
 -- | Determines to what packages and in what contexts a
@@ -142,7 +144,7 @@ packageConstraintToDependency :: PackageConstraint -> Maybe Dependency
 packageConstraintToDependency (PackageConstraint scope prop) = toDep prop
   where
     toDep (PackagePropertyVersion vr) = 
-        Just $ Dependency (scopeToPackageName scope) vr
+        Just $ Dependency (scopeToPackageName scope) vr (Set.singleton LMainLibName)
     toDep (PackagePropertyInstalled)  = Nothing
     toDep (PackagePropertySource)     = Nothing
     toDep (PackagePropertyFlags _)    = Nothing

--- a/cabal-install/Distribution/Solver/Types/PackageIndex.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageIndex.hs
@@ -55,9 +55,8 @@ import Data.List (groupBy, isInfixOf)
 import Distribution.Package
          ( PackageName, unPackageName, PackageIdentifier(..)
          , Package(..), packageName, packageVersion )
-import Distribution.Types.Dependency
 import Distribution.Version
-         ( withinRange )
+         ( VersionRange, withinRange )
 import Distribution.Simple.Utils
          ( lowercase, comparing )
 
@@ -210,10 +209,10 @@ deletePackageName name =
   delete name (\pkg -> packageName pkg == name)
 
 -- | Removes all packages satisfying this dependency from the index.
---
-deleteDependency :: Package pkg => Dependency -> PackageIndex pkg
+deleteDependency :: Package pkg
+                 => PackageName -> VersionRange -> PackageIndex pkg
                  -> PackageIndex pkg
-deleteDependency (Dependency name verstionRange) =
+deleteDependency name verstionRange =
   delete name (\pkg -> packageVersion pkg `withinRange` verstionRange)
 
 --
@@ -269,8 +268,11 @@ lookupPackageName index name =
 -- We get back any number of versions of the specified package name, all
 -- satisfying the version range constraint.
 --
-lookupDependency :: Package pkg => PackageIndex pkg -> Dependency -> [pkg]
-lookupDependency index (Dependency name versionRange) =
+lookupDependency :: Package pkg
+                 => PackageIndex pkg
+                 -> PackageName -> VersionRange
+                 -> [pkg]
+lookupDependency index name versionRange =
   [ pkg | pkg <- lookup index name
         , packageName pkg == name
         , packageVersion pkg `withinRange` versionRange ]

--- a/cabal-install/solver-dsl/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/solver-dsl/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -44,6 +44,7 @@ import Distribution.Solver.Compat.Prelude
 import Control.Arrow (second)
 import Data.Either (partitionEithers)
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 
 -- Cabal
 import qualified Distribution.Compiler                  as C
@@ -545,7 +546,7 @@ exAvSrcPkg ex =
            }
 
     mkDirect :: (ExamplePkgName, C.VersionRange) -> C.Dependency
-    mkDirect (dep, vr) = C.Dependency (C.mkPackageName dep) vr
+    mkDirect (dep, vr) = C.Dependency (C.mkPackageName dep) vr (Set.singleton C.LMainLibName)
 
     mkFlagged :: (ExampleFlagName, Dependencies, Dependencies)
               -> DependencyComponent C.BuildInfo

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -216,8 +216,8 @@ testTargetSelectors reportSubCase = do
     do Right ts <- readTargetSelectors'
                      [ "p", "lib:p", "p:lib:p", ":pkg:p:lib:p"
                      ,      "lib:q", "q:lib:q", ":pkg:q:lib:q" ]
-       ts @?= replicate 4 (TargetComponent "p-0.1" CLibName WholeComponent)
-           ++ replicate 3 (TargetComponent "q-0.1" CLibName WholeComponent)
+       ts @?= replicate 4 (TargetComponent "p-0.1" (CLibName LMainLibName) WholeComponent)
+           ++ replicate 3 (TargetComponent "q-0.1" (CLibName LMainLibName) WholeComponent)
 
     reportSubCase "module"
     do Right ts <- readTargetSelectors'
@@ -226,8 +226,8 @@ testTargetSelectors reportSubCase = do
                      , "pexe:PMain" -- p:P or q:QQ would be ambiguous here
                      , "qexe:QMain" -- package p vs component p
                      ]
-       ts @?= replicate 4 (TargetComponent "p-0.1" CLibName (ModuleTarget "P"))
-           ++ replicate 4 (TargetComponent "q-0.1" CLibName (ModuleTarget "QQ"))
+       ts @?= replicate 4 (TargetComponent "p-0.1" (CLibName LMainLibName) (ModuleTarget "P"))
+           ++ replicate 4 (TargetComponent "q-0.1" (CLibName LMainLibName) (ModuleTarget "QQ"))
            ++ [ TargetComponent "p-0.1" (CExeName "pexe") (ModuleTarget "PMain")
               , TargetComponent "q-0.1" (CExeName "qexe") (ModuleTarget "QMain")
               ]
@@ -239,8 +239,8 @@ testTargetSelectors reportSubCase = do
                      , "q/QQ.hs", "q:QQ.lhs", "lib:q:QQ.hsc", "q:q:QQ.hsc",
                                   ":pkg:q:lib:q:file:QQ.y"
                      ]
-       ts @?= replicate 5 (TargetComponent "p-0.1" CLibName (FileTarget "P"))
-           ++ replicate 5 (TargetComponent "q-0.1" CLibName (FileTarget "QQ"))
+       ts @?= replicate 5 (TargetComponent "p-0.1" (CLibName LMainLibName) (FileTarget "P"))
+           ++ replicate 5 (TargetComponent "q-0.1" (CLibName LMainLibName) (FileTarget "QQ"))
        -- Note there's a bit of an inconsistency here: for the single-part
        -- syntax the target has to point to a file that exists, whereas for
        -- all the other forms we don't require that.
@@ -624,7 +624,7 @@ testTargetProblemsBuild config reportSubCase = do
                                  TargetDisabledBySolver True
                , AvailableTarget "p-0.1" (CExeName "buildable-false")
                                  TargetNotBuildable True
-               , AvailableTarget "p-0.1" CLibName
+               , AvailableTarget "p-0.1" (CLibName LMainLibName)
                                  TargetNotBuildable True
                ]
         , mkTargetPackage "p-0.1" )
@@ -645,7 +645,7 @@ testTargetProblemsBuild config reportSubCase = do
          CmdBuild.selectComponentTarget
          CmdBuild.TargetProblemCommon
          [ mkTargetPackage "p-0.1" ]
-         [ ("p-0.1-inplace",             CLibName)
+         [ ("p-0.1-inplace",             (CLibName LMainLibName))
          , ("p-0.1-inplace-a-benchmark", CBenchName "a-benchmark")
          , ("p-0.1-inplace-a-testsuite", CTestName  "a-testsuite")
          , ("p-0.1-inplace-an-exe",      CExeName   "an-exe")
@@ -667,7 +667,7 @@ testTargetProblemsBuild config reportSubCase = do
          CmdBuild.selectComponentTarget
          CmdBuild.TargetProblemCommon
          [ mkTargetPackage "p-0.1" ]
-         [ ("p-0.1-inplace",        CLibName)
+         [ ("p-0.1-inplace",        (CLibName LMainLibName))
          , ("p-0.1-inplace-an-exe", CExeName  "an-exe")
          , ("p-0.1-inplace-libp",   CFLibName "libp")
          ]
@@ -699,9 +699,9 @@ testTargetProblemsRepl config reportSubCase = do
       CmdRepl.selectComponentTarget
       CmdRepl.TargetProblemCommon
       [ ( flip CmdRepl.TargetProblemMatchesMultiple
-               [ AvailableTarget "p-0.1" CLibName
+               [ AvailableTarget "p-0.1" (CLibName LMainLibName)
                    (TargetBuildable () TargetRequestedByDefault) True
-               , AvailableTarget "q-0.1" CLibName
+               , AvailableTarget "q-0.1" (CLibName LMainLibName)
                    (TargetBuildable () TargetRequestedByDefault) True
                ]
         , mkTargetAllPackages )
@@ -758,7 +758,7 @@ testTargetProblemsRepl config reportSubCase = do
       CmdRepl.selectComponentTarget
       CmdRepl.TargetProblemCommon
       [ ( flip CmdRepl.TargetProblemNoneEnabled
-               [ AvailableTarget "p-0.1" CLibName TargetNotBuildable True ]
+               [ AvailableTarget "p-0.1" (CLibName LMainLibName) TargetNotBuildable True ]
         , mkTargetPackage "p-0.1" )
       ]
 
@@ -805,7 +805,7 @@ testTargetProblemsRepl config reportSubCase = do
          CmdRepl.selectComponentTarget
          CmdRepl.TargetProblemCommon
          [ TargetPackage TargetExplicitNamed ["p-0.1"] Nothing ]
-         [ ("p-0.1-inplace", CLibName) ]
+         [ ("p-0.1-inplace", (CLibName LMainLibName)) ]
        -- When we select the package with an explicit filter then we get those
        -- components even though we did not explicitly enable tests/benchmarks
        assertProjectDistinctTargets
@@ -960,8 +960,8 @@ testTargetProblemsTest config reportSubCase = do
       CmdTest.selectComponentTarget
       CmdTest.TargetProblemCommon $
       [ ( const (CmdTest.TargetProblemComponentNotTest
-                  "p-0.1" CLibName)
-        , mkTargetComponent "p-0.1" CLibName )
+                  "p-0.1" (CLibName LMainLibName))
+        , mkTargetComponent "p-0.1" (CLibName LMainLibName) )
 
       , ( const (CmdTest.TargetProblemComponentNotTest
                   "p-0.1" (CExeName "an-exe"))
@@ -981,7 +981,7 @@ testTargetProblemsTest config reportSubCase = do
       | (cname, modname) <- [ (CTestName  "a-testsuite", "TestModule")
                             , (CBenchName "a-benchmark", "BenchModule")
                             , (CExeName   "an-exe",      "ExeModule")
-                            , (CLibName,                 "P")
+                            , ((CLibName LMainLibName),                 "P")
                             ]
       ] ++
       [ ( const (CmdTest.TargetProblemIsSubComponent
@@ -1067,8 +1067,8 @@ testTargetProblemsBench config reportSubCase = do
       CmdBench.selectComponentTarget
       CmdBench.TargetProblemCommon $
       [ ( const (CmdBench.TargetProblemComponentNotBenchmark
-                  "p-0.1" CLibName)
-        , mkTargetComponent "p-0.1" CLibName )
+                  "p-0.1" (CLibName LMainLibName))
+        , mkTargetComponent "p-0.1" (CLibName LMainLibName) )
 
       , ( const (CmdBench.TargetProblemComponentNotBenchmark
                   "p-0.1" (CExeName "an-exe"))
@@ -1088,7 +1088,7 @@ testTargetProblemsBench config reportSubCase = do
       | (cname, modname) <- [ (CTestName  "a-testsuite", "TestModule")
                             , (CBenchName "a-benchmark", "BenchModule")
                             , (CExeName   "an-exe",      "ExeModule")
-                            , (CLibName,                 "P")
+                            , ((CLibName LMainLibName),                 "P")
                             ]
       ] ++
       [ ( const (CmdBench.TargetProblemIsSubComponent
@@ -1119,7 +1119,7 @@ testTargetProblemsHaddock config reportSubCase = do
                                  TargetDisabledBySolver True
                , AvailableTarget "p-0.1" (CExeName "buildable-false")
                                  TargetNotBuildable True
-               , AvailableTarget "p-0.1" CLibName
+               , AvailableTarget "p-0.1" (CLibName LMainLibName)
                                  TargetNotBuildable True
                ]
         , mkTargetPackage "p-0.1" )
@@ -1146,7 +1146,7 @@ testTargetProblemsHaddock config reportSubCase = do
           CmdHaddock.selectComponentTarget
           CmdHaddock.TargetProblemCommon
           [ mkTargetPackage "p-0.1" ]
-          [ ("p-0.1-inplace",             CLibName)
+          [ ("p-0.1-inplace",             (CLibName LMainLibName))
           , ("p-0.1-inplace-a-benchmark", CBenchName "a-benchmark")
           , ("p-0.1-inplace-a-testsuite", CTestName  "a-testsuite")
           , ("p-0.1-inplace-an-exe",      CExeName   "an-exe")
@@ -1163,7 +1163,7 @@ testTargetProblemsHaddock config reportSubCase = do
           CmdHaddock.selectComponentTarget
           CmdHaddock.TargetProblemCommon
           [ mkTargetPackage "p-0.1" ]
-          [ ("p-0.1-inplace", CLibName) ]
+          [ ("p-0.1-inplace", (CLibName LMainLibName)) ]
 
     reportSubCase "requested component kinds"
     -- When we selecting the package with an explicit filter then it does not

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -22,6 +22,7 @@ import Control.Monad
 
 import Distribution.Version
 import Distribution.Types.Dependency
+import Distribution.Types.PackageVersionConstraint
 import Distribution.Types.UnqualComponentName
 import Distribution.Types.LibraryName
 import Distribution.Package
@@ -122,6 +123,9 @@ instance Arbitrary PackageName where
 
 instance Arbitrary Dependency where
     arbitrary = Dependency <$> arbitrary <*> arbitrary <*> fmap getNonMEmpty arbitrary
+
+instance Arbitrary PackageVersionConstraint where
+    arbitrary = PackageVersionConstraint <$> arbitrary <*> arbitrary
 
 instance Arbitrary UnqualComponentName where
     -- same rules as package names

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -22,6 +22,8 @@ import Control.Monad
 
 import Distribution.Version
 import Distribution.Types.Dependency
+import Distribution.Types.UnqualComponentName
+import Distribution.Types.LibraryName
 import Distribution.Package
 import Distribution.System
 import Distribution.Verbosity
@@ -119,7 +121,14 @@ instance Arbitrary PackageName where
         packageChars  = filter isAlphaNum ['\0'..'\127']
 
 instance Arbitrary Dependency where
-    arbitrary = Dependency <$> arbitrary <*> arbitrary
+    arbitrary = Dependency <$> arbitrary <*> arbitrary <*> fmap getNonMEmpty arbitrary
+
+instance Arbitrary UnqualComponentName where
+    -- same rules as package names
+    arbitrary = packageNameToUnqualComponentName <$> arbitrary
+
+instance Arbitrary LibraryName where
+    arbitrary = elements =<< sequenceA [LSubLibName <$> arbitrary, pure LMainLibName]
 
 instance Arbitrary OS where
     arbitrary = elements knownOSs

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -24,6 +24,7 @@ import qualified Distribution.Compat.ReadP as Parse
 import Distribution.Simple.Utils
 import Distribution.Simple.Program.Types
 import Distribution.Simple.Program.Db
+import Distribution.Types.PackageVersionConstraint
 
 import Distribution.Client.Types
 import Distribution.Client.Dependency.Types
@@ -166,7 +167,7 @@ prop_roundtrip_printparse_all config =
 prop_roundtrip_printparse_packages :: [PackageLocationString]
                                    -> [PackageLocationString]
                                    -> [SourceRepo]
-                                   -> [Dependency]
+                                   -> [PackageVersionConstraint]
                                    -> Bool
 prop_roundtrip_printparse_packages pkglocstrs1 pkglocstrs2 repos named =
     roundtrip_printparse

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
@@ -12,5 +12,6 @@ Error:
                            brought into scope by mixins: fail:mysql (Database.MySQL as Database)
                         or 'fail-0.1.0.0-postgresql:Database.PostgreSQL'
                            brought into scope by mixins: fail:postgresql (Database.PostgreSQL as Database)
-      While filling requirements of build-depends: fail:mylib
+      While filling requirements of     build-depends: fail:mylib
+                                    and build-depends: fail:mylib
     In the stanza library

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.cabal.out
@@ -12,6 +12,5 @@ Error:
                            brought into scope by mixins: fail:mysql (Database.MySQL as Database)
                         or 'fail-0.1.0.0-postgresql:Database.PostgreSQL'
                            brought into scope by mixins: fail:postgresql (Database.PostgreSQL as Database)
-      While filling requirements of     build-depends: fail:mylib
-                                    and build-depends: fail:mylib
+      While filling requirements of build-depends: fail:mylib
     In the stanza library

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
@@ -11,5 +11,6 @@ Error:
                            brought into scope by mixins: fail:mysql (Database.MySQL as Database)
                         or 'fail-0.1.0.0-postgresql:Database.PostgreSQL'
                            brought into scope by mixins: fail:postgresql (Database.PostgreSQL as Database)
-      While filling requirements of build-depends: fail:mylib
+      While filling requirements of     build-depends: fail:mylib
+                                    and build-depends: fail:mylib
     In the stanza library

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal-fail.out
@@ -11,6 +11,5 @@ Error:
                            brought into scope by mixins: fail:mysql (Database.MySQL as Database)
                         or 'fail-0.1.0.0-postgresql:Database.PostgreSQL'
                            brought into scope by mixins: fail:postgresql (Database.PostgreSQL as Database)
-      While filling requirements of     build-depends: fail:mylib
-                                    and build-depends: fail:mylib
+      While filling requirements of build-depends: fail:mylib
     In the stanza library

--- a/cabal-testsuite/PackageTests/CaretOperator/setup.test.hs
+++ b/cabal-testsuite/PackageTests/CaretOperator/setup.test.hs
@@ -22,7 +22,7 @@ main = setupTest $ do
     let Just gotLib = library (localPkgDescr lbi)
         bi = libBuildInfo gotLib
     assertEqual "defaultLanguage" (Just Haskell2010) (defaultLanguage bi)
-    forM_ (targetBuildDepends bi) $ \(Dependency pn vr) ->
+    forM_ (targetBuildDepends bi) $ \(Dependency pn vr _) ->
         when (pn == mkPackageName "pretty") $
             assertEqual "targetBuildDepends/pretty"
                          vr (majorBoundVersion (mkVersion [1,1,1,0]))

--- a/cabal-testsuite/PackageTests/InternalLibraries/Executable/setup-static.test.hs
+++ b/cabal-testsuite/PackageTests/InternalLibraries/Executable/setup-static.test.hs
@@ -29,7 +29,7 @@ main = setupAndCabalTest $ do
             lbi <- liftIO $ getPersistBuildConfig dist_dir
             let pkg_descr = localPkgDescr lbi
                 compiler_id = compilerId (compiler lbi)
-                cname = CSubLibName $ mkUnqualComponentName "foo-internal"
+                cname = CLibName $ LSubLibName $ mkUnqualComponentName "foo-internal"
                 [target] = componentNameTargets' pkg_descr lbi cname
                 uid = componentUnitId (targetCLBI target)
                 InstallDirs{libdir=dir,dynlibdir=dyndir} =

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
@@ -17,6 +17,10 @@ Error:
         It could refer to either:
              'containers-<VERSION>:Data.Map'
              brought into scope by build-depends: containers
+          or 'containers-<VERSION>:Data.Map'
+             brought into scope by build-depends: containers
+          or 'containers-dupe-0.1.0.0:Data.Map'
+             brought into scope by build-depends: containers-dupe
           or 'containers-dupe-0.1.0.0:Data.Map'
              brought into scope by build-depends: containers-dupe
         The ambiguity can be resolved by qualifying the

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.cabal.out
@@ -17,10 +17,6 @@ Error:
         It could refer to either:
              'containers-<VERSION>:Data.Map'
              brought into scope by build-depends: containers
-          or 'containers-<VERSION>:Data.Map'
-             brought into scope by build-depends: containers
-          or 'containers-dupe-0.1.0.0:Data.Map'
-             brought into scope by build-depends: containers-dupe
           or 'containers-dupe-0.1.0.0:Data.Map'
              brought into scope by build-depends: containers-dupe
         The ambiguity can be resolved by qualifying the

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
@@ -15,6 +15,10 @@ Error:
         It could refer to either:
              'containers-<VERSION>:Data.Map'
              brought into scope by build-depends: containers
+          or 'containers-<VERSION>:Data.Map'
+             brought into scope by build-depends: containers
+          or 'containers-dupe-0.1.0.0:Data.Map'
+             brought into scope by build-depends: containers-dupe
           or 'containers-dupe-0.1.0.0:Data.Map'
              brought into scope by build-depends: containers-dupe
         The ambiguity can be resolved by qualifying the

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.out
@@ -15,10 +15,6 @@ Error:
         It could refer to either:
              'containers-<VERSION>:Data.Map'
              brought into scope by build-depends: containers
-          or 'containers-<VERSION>:Data.Map'
-             brought into scope by build-depends: containers
-          or 'containers-dupe-0.1.0.0:Data.Map'
-             brought into scope by build-depends: containers-dupe
           or 'containers-dupe-0.1.0.0:Data.Map'
              brought into scope by build-depends: containers-dupe
         The ambiguity can be resolved by qualifying the


### PR DESCRIPTION
This is my work for Google Summer of Code 2018.

It adds support for multiple public libraries, as described in #4206.

See https://github.com/fgaz/gsoc/blob/master/2018/final-report.md for a more detailed report. I'll expand a bit this description shortly.

**~~There are still a few nonessential things to do and some things to clean, so don't review yet! (see the link above or the checklist below). It should all work though.~~ Go ahead!**

Closes #4206 

/cc @ezyang @23Skidoo 

Things to fix/clean/update before merging:
* [x] Add a few comments in crucial places
* [x] Unbreak the few tests that still fail
  * [x] Adapt tests to new output
  * [x] Legit breakages
    * [x] Duplicate output on some tests
* [x] Clean the history
* [x] Make sure roundtripping works
  * [x] Generate only LMainLibName libraries in ProjectConfig's extra-packages and show them as pkg-only syntax, either in Dependency itself or only in ProjectConfig
  * [x] and/or remove Dependency from there
* [x] Clean up in a few places (memptys and todos)
* [x] Version guard the new functionality

After merging (better to merge soon and avoid to let it rot)
* [ ] Add a visibility field to sublibraries
* [ ] Maybe: remove all the bits of code that handle the old syntax (there's lots of them) and do it all in a single spot (hint: grep for `packageNameToUnqualComponentName`)
* [ ] Add tests
* [ ] Update changelog
* [ ] Update docs
* [ ] Maybe more source comments
* [ ] Deprecate old syntax
* [ ] Update `cabal init` to take into account sublibraries when populating build-depends