### PR TITLE
[#5484] Add 'storedir' alias for 'store-dir'

### DIFF
--- a/cabal-install/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/Distribution/Client/CmdSdist.hs
@@ -122,7 +122,7 @@ sdistCommand = CommandUI
                         "Produce a '.zip' format archive")
                 ]
             )
-        , option ['o'] ["output-dir"]
+        , option ['o'] ["outputdir", "output-dir"]
             "Choose the output directory of this command. '-' sends all output to stdout"
             sdistOutputPath (\o flags -> flags { sdistOutputPath = o })
             (reqArg "PATH" (succeedReadE Flag) flagToList)

--- a/cabal-install/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/Distribution/Client/CmdSdist.hs
@@ -122,7 +122,7 @@ sdistCommand = CommandUI
                         "Produce a '.zip' format archive")
                 ]
             )
-        , option ['o'] ["outputdir", "output-dir"]
+        , option ['o'] ["output-dir", "outputdir"]
             "Choose the output directory of this command. '-' sends all output to stdout"
             sdistOutputPath (\o flags -> flags { sdistOutputPath = o })
             (reqArg "PATH" (succeedReadE Flag) flagToList)

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -436,7 +436,7 @@ globalCommand commands = CommandUI {
          globalLocalRepos (\v flags -> flags { globalLocalRepos = v })
          (reqArg' "DIR" (\x -> toNubList [x]) fromNubList)
 
-      ,option [] ["logs-dir"]
+      ,option [] ["logsdir", "logs-dir"]
          "The location to put log files"
          globalLogsDir (\v flags -> flags { globalLogsDir = v })
          (reqArgFlag "DIR")
@@ -446,7 +446,7 @@ globalCommand commands = CommandUI {
          globalWorldFile (\v flags -> flags { globalWorldFile = v })
          (reqArgFlag "FILE")
 
-      ,option [] ["store-dir"]
+      ,option [] ["storedir", "store-dir"]
          "The location of the nix-local-build store"
          globalStoreDir (\v flags -> flags { globalStoreDir = v })
          (reqArgFlag "DIR")
@@ -468,7 +468,7 @@ configureCommand = c
       ++ "including v1-build, v1-test, v1-bench, v1-run, v1-repl.\n"
   , commandUsage        = \pname ->
     "Usage: " ++ pname ++ " v1-configure [FLAGS]\n"
-  , commandNotes = Just $ \pname -> 
+  , commandNotes = Just $ \pname ->
     (Cabal.programFlagsDescription defaultProgramDb ++ "\n")
       ++ "Examples:\n"
       ++ "  " ++ pname ++ " v1-configure\n"
@@ -1293,9 +1293,9 @@ upgradeCommand = configureCommand {
   }
 
 cleanCommand :: CommandUI CleanFlags
-cleanCommand = Cabal.cleanCommand 
+cleanCommand = Cabal.cleanCommand
   { commandUsage = \pname ->
-    "Usage: " ++ pname ++ " v1-clean [FLAGS]\n" 
+    "Usage: " ++ pname ++ " v1-clean [FLAGS]\n"
   }
 
 checkCommand  :: CommandUI (Flag Verbosity)
@@ -2164,7 +2164,7 @@ initCommand = CommandUI {
         IT.overwrite (\v flags -> flags { IT.overwrite = v })
         trueArg
 
-      , option [] ["package-dir"]
+      , option [] ["packagedir", "package-dir"]
         "Root directory of the package (default = current directory)."
         IT.packageDir (\v flags -> flags { IT.packageDir = v })
         (reqArgFlag "DIRECTORY")
@@ -2283,7 +2283,7 @@ initCommand = CommandUI {
                                       ((Just . (:[])) `fmap` parse))
                           (maybe [] (fmap display)))
 
-      , option [] ["source-dir"]
+      , option [] ["sourcedir", "source-dir"]
         "Directory containing package source."
         IT.sourceDirs (\v flags -> flags { IT.sourceDirs = v })
         (reqArg' "DIR" (Just . (:[]))

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -436,7 +436,7 @@ globalCommand commands = CommandUI {
          globalLocalRepos (\v flags -> flags { globalLocalRepos = v })
          (reqArg' "DIR" (\x -> toNubList [x]) fromNubList)
 
-      ,option [] ["logsdir", "logs-dir"]
+      ,option [] ["logs-dir", "logsdir"]
          "The location to put log files"
          globalLogsDir (\v flags -> flags { globalLogsDir = v })
          (reqArgFlag "DIR")
@@ -446,7 +446,7 @@ globalCommand commands = CommandUI {
          globalWorldFile (\v flags -> flags { globalWorldFile = v })
          (reqArgFlag "FILE")
 
-      ,option [] ["storedir", "store-dir"]
+      ,option [] ["store-dir", "storedir"]
          "The location of the nix-local-build store"
          globalStoreDir (\v flags -> flags { globalStoreDir = v })
          (reqArgFlag "DIR")
@@ -2164,7 +2164,7 @@ initCommand = CommandUI {
         IT.overwrite (\v flags -> flags { IT.overwrite = v })
         trueArg
 
-      , option [] ["packagedir", "package-dir"]
+      , option [] ["package-dir", "packagedir"]
         "Root directory of the package (default = current directory)."
         IT.packageDir (\v flags -> flags { IT.packageDir = v })
         (reqArgFlag "DIRECTORY")
@@ -2283,7 +2283,7 @@ initCommand = CommandUI {
                                       ((Just . (:[])) `fmap` parse))
                           (maybe [] (fmap display)))
 
-      , option [] ["sourcedir", "source-dir"]
+      , option [] ["source-dir", "sourcedir"]
         "Directory containing package source."
         IT.sourceDirs (\v flags -> flags { IT.sourceDirs = v })
         (reqArg' "DIR" (Just . (:[]))

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -2,6 +2,8 @@
 
 2.6.0.0 (current development version)
 	* New solver flag: '--reject-unconstrained-dependencies'. (#2568)
+	* Add the following option aliases for '-dir'-suffixed options:
+	  'storedir', 'logsdir', 'packagedir', 'sourcedir', 'outputdir' (#5484).
 
 2.4.0.0
 	* 'new-run' now allows the user to run scripts that use a special block


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

I've executed the following command:

```
$ cabal --storedir foo/ new-build cabal-install
```

And got this error:

```
ghc-pkg: foo/ghc-8.4.3/package.db: getDirectoryContents:openDirStream: does
not exist (No such file or directory)
```

Without change in this PR it produces some error regarding parsing CLI arguments.

Maybe I should change some existing test to make sure that `storedir` option won't disappear? But I don't know which one and whether I should do this or not...
