### PR TITLE
WIP: use sudo: true on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: c
 
 dist: trusty
 
+# This sets the default config for each job to use full VMs.
+# The VMs have 2 cores and 8 gigs of ram. Larger VMs are also available.
 sudo: true
 
 # We whitelist branches, as we don't really need to build dev-branches.

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: c
 
 dist: trusty
 
-sudo: false
+sudo: true
 
 # We whitelist branches, as we don't really need to build dev-branches.
 # Remember to add release branches, both here and to appveyor.yml.


### PR DESCRIPTION
Josh here from Travis CI

Our `sudo: true` infrastructure are full VMs and are generally faster build environments than the `false` counterpart.

Additionally, we can enable 4 core VMs, giving you faster compile times.

This change will allow me to enable the 4 core feature for testing.
