### PR TITLE
Pass command line arguments to hsc2hs using response files

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -94,6 +94,8 @@
   * Foreign libraries are now linked against the threaded RTS when the
     'ghc-options: -threaded' flag is used
     ([#5431](https://github.com/haskell/cabal/pull/5431)).
+  * Pass command line arguments to `hsc2hs` using response files when possible
+    ([#3122](https://github.com/haskell/cabal/issues/3122)).
 
 ----
 


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Fixes #3122. Also see [Trac #13896](https://ghc.haskell.org/trac/ghc/ticket/13896).

`hsc2hs` has gained the ability to accept command line arguments via response files, which helps 
 to work around the limit on their length on Windows. This is the next step which updates Cabal to use a response file when invoking `hsc2hs`. Unfortunately, I have not yet tried to build the projects ([this gist](https://gist.github.com/mkscrg/18c560b8eb303c6ebcf2) and [ermine](https://github.com/ermine-language/ermine)) mentioned in the issue. I will do it as soon as I get access to a Windows machine (or once I setup Vagrant or something). Note that this patch only changes the invocation logic for `hsc2hs >= 0.68.4` which will be released with GHC 8.6.

re:testing -- I tested this by hand and ensured that the arguments are indeed passed via a response file, and `hsc2hs` can successfully process a `Foo.hsc` file. Also,

    $ cabal-tests cabal-testsuite/PackageTests/PreProcess/setup.test.hs

tests the `hsc2hs` pre-processor and doesn't fail. I'm not sure if I should add another test.

/cc @bgamari @RyanGlScott @hvr 