### PR TITLE
Extend `cabal init` support for `cabal-version` selection

### DIFF
--- a/cabal-install/Distribution/Client/Init/Types.hs
+++ b/cabal-install/Distribution/Client/Init/Types.hs
@@ -47,7 +47,7 @@ data InitFlags =
 
               , packageName  :: Flag P.PackageName
               , version      :: Flag Version
-              , cabalVersion :: Flag VersionRange
+              , cabalVersion :: Flag Version
               , license      :: Flag License
               , author       :: Flag String
               , email        :: Flag String

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2184,9 +2184,9 @@ initCommand = CommandUI {
                           (flagToList . fmap display))
 
       , option [] ["cabal-version"]
-        "Required version of the Cabal library."
+        "Version of the CABAL specification."
         IT.cabalVersion (\v flags -> flags { IT.cabalVersion = v })
-        (reqArg "VERSION_RANGE" (readP_to_E ("Cannot parse Cabal version range: "++)
+        (reqArg "VERSION_RANGE" (readP_to_E ("Cannot parse CABAL specification version: "++)
                                             (toFlag `fmap` parse))
                                 (flagToList . fmap display))
 


### PR DESCRIPTION
This adds support to `cabal init` for selecting the CABAL spec
version (i.e. the `cabal-version:` field) and also takes care
of translating between pre-SPDX and SPDX license ids.