### PR TITLE
[#5503] Add filterHaddockFlags for new-haddock

### DIFF
--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -1070,7 +1070,8 @@ buildAndInstallUnpackedPackage verbosity
     buildFlags   _   = setupHsBuildFlags pkg pkgshared verbosity builddir
 
     haddockCommand   = Cabal.haddockCommand
-    haddockFlags _   = setupHsHaddockFlags pkg pkgshared
+    haddockFlags v   = flip filterHaddockFlags v $
+                       setupHsHaddockFlags pkg pkgshared
                                            verbosity builddir
 
     generateInstalledPackageInfo :: IO InstalledPackageInfo

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -2,9 +2,10 @@
 
 2.6.0.0 (current development version)
 	* New solver flag: '--reject-unconstrained-dependencies'. (#2568)
+	* Fix 'cabal new-haddock' for build-type:configure (#5503).
 
 2.4.0.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> September 2018
-        * Bugfix: "cabal new-build --ghc-option '--bogus' --ghc-option '-O1'"
+	* Bugfix: "cabal new-build --ghc-option '--bogus' --ghc-option '-O1'"
 	  no longer ignores all arguments except the last one (#5512).
 	* Add the following option aliases for '-dir'-suffixed options:
 	  'storedir', 'logsdir', 'packagedir', 'sourcedir', 'outputdir' (#5484).


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

I've tried to add additional logic suggested by the issue. But I still see the error:

```
Build profile: -w ghc-8.4.3 -O1
In order, the following will be built (use -v for more details):
 - network-2.7.0.2 (first run)
cabal: Unrecognised flags: lib:network
Warning: Failed to build documentation for network-2.7.0.2.
```
