### PR TITLE
Allow arguments to be passed to `Setup.hs haddock` for `build-type:configure`

### DIFF
--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -668,7 +668,7 @@ autoconfUserHooks
        preClean    = readHook cleanVerbosity cleanDistPref,
        preInst     = readHook installVerbosity installDistPref,
        preHscolour = readHook hscolourVerbosity hscolourDistPref,
-       preHaddock  = readHook haddockVerbosity haddockDistPref,
+       preHaddock  = readHookWithArgs haddockVerbosity haddockDistPref,
        preReg      = readHook regVerbosity regDistPref,
        preUnreg    = readHook regVerbosity regDistPref
       }


### PR DESCRIPTION
In the course of 4466310e48e8c401ca2492d0fc2c5018ad8de961 (see #5526) the
`Setup.hs haddock` CLI was extended to allow component ids to be passed
as positional arguments. However, `autoconfUserHooks` which is used in
case of `build-type: Configure` wasn't updated accordingly, and consequently
this caused `new-haddock` to break for packages using `Configure`.

cc @alexbiehl

Fixes #5503


