### PR TITLE
[RFC] Allow v2-configure to actually run unit configure step

### DIFF
--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -7,6 +7,7 @@ module Distribution.Client.CmdBuild (
 
     -- * Internals exposed for testing
     TargetProblem(..),
+    reportTargetProblems,
     selectPackageTargets,
     selectComponentTarget
   ) where

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -298,6 +298,7 @@ data ElaboratedConfiguredPackage
        elabSetupScriptCliVersion :: Version,
 
        -- Build time related:
+       elabConfigureTargets      :: [ComponentTarget],
        elabBuildTargets          :: [ComponentTarget],
        elabTestTargets           :: [ComponentTarget],
        elabBenchTargets          :: [ComponentTarget],


### PR DESCRIPTION
This is a nice to have for cabal-helper and related tooling as it allows us to
(re)configure without also running a full build.

The idea is to 'runProjectBuildPhase' with the new 'TargetActionConfigure' if
and only if any target argument is given on the command line. This allows
v2-configure to continue functioning as before if no arguments are given but,
previously ignored, extra args are now interpreted as targets to configure right
now, this includes building dependencies obviously.

I don't actually care how exactly we implement this feature, I also considered something
like a `v2-build --only-configure` flag but that seemed kind of weird. If using
the target arguments as the deciding factor seems objectionable certainly
something like `v2-configure --actually-configure` could also work. Whatever you
guys think is best.

For simplicity's sake I'm just importing CmdBuild's
`select{Package,Component}Targets` functions for now since I want the same
behaviour as v2-build anyways. If this is not desired I can also factor these
out in a seperate module.

---
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
