### PR TITLE
Add new v2-build flag '--only-configure'

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -368,6 +368,12 @@ cause extra store packages to be built (for example,
 ``--enable-profiling`` will automatically make sure profiling libraries
 for all transitive dependencies are built and installed.)
 
+In addition ``cabal new-build`` accepts these flags:
+
+- ``--only-configure``: When given we will forgoe performing a full build and
+  abort after running the configure phase of each target package.
+
+
 cabal new-repl
 --------------
 

--- a/cabal-install/Distribution/Client/CmdExec.hs
+++ b/cabal-install/Distribution/Client/CmdExec.hs
@@ -27,6 +27,7 @@ import Distribution.Client.Setup
   , GlobalFlags
   , InstallFlags
   )
+import qualified Distribution.Client.Setup as Client
 import Distribution.Client.ProjectOrchestration
   ( ProjectBuildContext(..)
   , runProjectPreBuildPhase
@@ -86,8 +87,6 @@ import Distribution.Verbosity
   , normal
   )
 
-import qualified Distribution.Client.CmdBuild as CmdBuild
-
 import Prelude ()
 import Distribution.Client.Compat.Prelude
 
@@ -116,8 +115,8 @@ execCommand = CommandUI
     ++ " to choose an appropriate version of ghc and to include any"
     ++ " ghc-specific flags requested."
   , commandNotes = Nothing
-  , commandOptions = commandOptions CmdBuild.buildCommand
-  , commandDefaultFlags = commandDefaultFlags CmdBuild.buildCommand
+  , commandOptions = commandOptions Client.installCommand
+  , commandDefaultFlags = commandDefaultFlags Client.installCommand
   }
 
 execAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags)

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -298,6 +298,7 @@ data ElaboratedConfiguredPackage
        elabSetupScriptCliVersion :: Version,
 
        -- Build time related:
+       elabConfigureTargets      :: [ComponentTarget],
        elabBuildTargets          :: [ComponentTarget],
        elabTestTargets           :: [ComponentTarget],
        elabBenchTargets          :: [ComponentTarget],

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -57,6 +57,7 @@ module Distribution.Client.Setup
 
     , parsePackageArgs
     , liftOptions
+    , yesNoOpt
     --TODO: stop exporting these:
     , showRepo
     , parseRepo

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -3,6 +3,7 @@
 2.6.0.0 (current development version)
 	* New solver flag: '--reject-unconstrained-dependencies'. (#2568)
 	* "cabal new-repl" now works for indefinite (in the Backpack sense) components.
+	* New v2-build flag: '--only-configure'. (#5578)
 
 2.4.0.1
 	* 'new-sdist' now generates tarballs with file modification

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/Bar.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/Bar.hs
@@ -1,0 +1,1 @@
+main = print "Bar"

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/Baz.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/Baz.hs
@@ -1,0 +1,1 @@
+main = print "Baz"

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/Foo.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/Foo.hs
@@ -1,0 +1,1 @@
+main = print "Foo"

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/Lib.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/Lib.hs
@@ -1,0 +1,2 @@
+module Lib where
+lib = 1

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/OnlyConfigure.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/OnlyConfigure.cabal
@@ -1,0 +1,26 @@
+name: OnlyConfigure
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    exposed-modules: Lib
+    build-depends: base
+    default-language: Haskell2010
+
+executable foo
+    main-is: Foo.hs
+    build-depends: base
+    default-language: Haskell2010
+
+test-suite bar
+    type: exitcode-stdio-1.0
+    main-is: Bar.hs
+    build-depends: base
+    default-language: Haskell2010
+
+benchmark baz
+    type: exitcode-stdio-1.0
+    main-is: Baz.hs
+    build-depends: base
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/cabal.out
@@ -1,0 +1,30 @@
+# cabal v2-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - OnlyConfigure-1.0 (lib) (first run)
+ - OnlyConfigure-1.0 (exe:foo) (first run)
+Configuring library for OnlyConfigure-1.0..
+Configuring executable 'foo' for OnlyConfigure-1.0..
+# cabal v2-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - OnlyConfigure-1.0 (lib) (configuration changed)
+ - OnlyConfigure-1.0 (test:bar) (first run)
+ - OnlyConfigure-1.0 (exe:foo) (configuration changed)
+Configuring library for OnlyConfigure-1.0..
+Configuring test suite 'bar' for OnlyConfigure-1.0..
+Configuring executable 'foo' for OnlyConfigure-1.0..
+# cabal v2-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - OnlyConfigure-1.0 (lib) (configuration changed)
+ - OnlyConfigure-1.0 (test:bar) (configuration changed)
+ - OnlyConfigure-1.0 (bench:baz) (first run)
+ - OnlyConfigure-1.0 (exe:foo) (configuration changed)
+Configuring library for OnlyConfigure-1.0..
+Configuring test suite 'bar' for OnlyConfigure-1.0..
+Configuring benchmark 'baz' for OnlyConfigure-1.0..
+Configuring executable 'foo' for OnlyConfigure-1.0..

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBuild/OnlyConfigure/cabal.test.hs
@@ -1,0 +1,24 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    res <- cabal' "v2-build" ["--only-configure"]
+    assertOutputContains       "Configuring library for" res
+    assertOutputContains       "Configuring executable 'foo' for" res
+    assertOutputDoesNotContain "Configuring test suite 'bar' for" res
+    assertOutputDoesNotContain "Configuring benchmark 'baz' for" res
+    assertOutputDoesNotContain "Building" res
+
+    res <- cabal' "v2-build" ["--only-configure", "--enable-tests"]
+    assertOutputContains       "Configuring library for" res
+    assertOutputContains       "Configuring executable 'foo' for" res
+    assertOutputContains       "Configuring test suite 'bar' for" res
+    assertOutputDoesNotContain "Configuring benchmark 'baz' for" res
+    assertOutputDoesNotContain "Building" res
+
+    res <- cabal' "v2-build"
+             [ "--only-configure", "--enable-tests", "--enable-benchmarks"]
+    assertOutputContains       "Configuring library for" res
+    assertOutputContains       "Configuring executable 'foo' for" res
+    assertOutputContains       "Configuring test suite 'bar' for" res
+    assertOutputContains       "Configuring benchmark 'baz' for" res
+    assertOutputDoesNotContain "Building" res


### PR DESCRIPTION
When this flag is active we only execute the Cabal build system's 'configure'
step for each local unit and nothing else. This allows (re)generating the Setup
configuration cache which is accessed directly by tooling like ghc-mod and HIE
through cabal-helper and allows such tooling to forgoe a full rebuild.

I've added a new `BuildFlags` type for `v2-build` specific options since don't think just sticking this in any of the other flags sets makes even a lick of sense.

It seems to me that for some reason the `defaultBuildFlags` are not being applied to the flags before being passed to `buildAction`, so I have worked around that by doing `fromFlag (buildOnlyConfigure defaultBuildFlags <> buildOnlyConfigure buildFlags)` which is kind of really ugly.

@hvr turns out combining `--only-depencencies` with `--only-configure` does kind of make sense for multi package projects, though I don't imagine it would be very useful, so I'm not bothering with a check for that.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
