### PR TITLE
Compile profiling library for use with GHCi

### DIFF
--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -22,6 +22,7 @@ module Distribution.Simple.GHC.Internal (
         componentCxxGhcOptions,
         componentGhcOptions,
         mkGHCiLibName,
+        mkGHCiProfLibName,
         filterGhciFlags,
         ghcLookupProperty,
         getHaskellObjects,
@@ -419,6 +420,9 @@ filterGhciFlags = filter supported
 
 mkGHCiLibName :: UnitId -> String
 mkGHCiLibName lib = getHSLibraryName lib <.> "o"
+
+mkGHCiProfLibName :: UnitId -> String
+mkGHCiProfLibName lib = getHSLibraryName lib <.> "p_o"
 
 ghcLookupProperty :: String -> Compiler -> Bool
 ghcLookupProperty prop comp =

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -282,7 +282,7 @@ buildOrReplLib mReplFlags verbosity numJobs pkg_descr lbi lib clbi = do
       whenProfLib = when (not forRepl && withProfLib lbi)
       whenSharedLib forceShared =
         when (not forRepl &&  (forceShared || withSharedLib lbi))
-      whenGHCiLib = when (not forRepl && withGHCiLib lbi && withVanillaLib lbi)
+      whenGHCiLib = when (not forRepl && withGHCiLib lbi)
       forRepl = maybe False (const True) mReplFlags
       ifReplLib = when forRepl
       replFlags = fromMaybe mempty mReplFlags
@@ -435,6 +435,7 @@ buildOrReplLib mReplFlags verbosity numJobs pkg_descr lbi lib clbi = do
         profileLibFilePath = libTargetDir </> mkProfLibName        uid
         sharedLibFilePath  = libTargetDir </> mkSharedLibName (hostPlatform lbi) compiler_id uid
         ghciLibFilePath    = libTargetDir </> Internal.mkGHCiLibName uid
+        ghciProfLibFilePath = libTargetDir </> Internal.mkGHCiProfLibName uid
 
     hObjs     <- Internal.getHaskellObjects implInfo lib lbi clbi
                       libTargetDir objExtension True
@@ -457,9 +458,6 @@ buildOrReplLib mReplFlags verbosity numJobs pkg_descr lbi lib clbi = do
           profObjectFiles =
                  hProfObjs
               ++ map (libTargetDir </>) cProfObjs
-          ghciObjFiles =
-                 hObjs
-              ++ map (libTargetDir </>) cObjs
           dynamicObjectFiles =
                  hSharedObjs
               ++ map (libTargetDir </>) cSharedObjs
@@ -483,14 +481,17 @@ buildOrReplLib mReplFlags verbosity numJobs pkg_descr lbi lib clbi = do
 
       whenVanillaLib False $ do
         Ar.createArLibArchive verbosity lbi vanillaLibFilePath staticObjectFiles
+        whenGHCiLib $ do
+          (ldProg, _) <- requireProgram verbosity ldProgram (withPrograms lbi)
+          Ld.combineObjectFiles verbosity lbi ldProg
+            ghciLibFilePath staticObjectFiles
 
       whenProfLib $ do
         Ar.createArLibArchive verbosity lbi profileLibFilePath profObjectFiles
-
-      whenGHCiLib $ do
-        (ldProg, _) <- requireProgram verbosity ldProgram (withPrograms lbi)
-        Ld.combineObjectFiles verbosity lbi ldProg
-          ghciLibFilePath ghciObjFiles
+        whenGHCiLib $ do
+          (ldProg, _) <- requireProgram verbosity ldProgram (withPrograms lbi)
+          Ld.combineObjectFiles verbosity lbi ldProg
+            ghciProfLibFilePath profObjectFiles
 
       whenSharedLib False $
         runGhcjsProg ghcSharedLinkArgs
@@ -713,10 +714,13 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
     whenShared  $ copyModuleFiles "dyn_hi"
 
     -- copy the built library files over:
-    whenVanilla $ installOrdinaryNative builtDir targetDir       vanillaLibName
-    whenProf    $ installOrdinaryNative builtDir targetDir       profileLibName
-    whenGHCi    $ installOrdinaryNative builtDir targetDir       ghciLibName
-    whenShared  $ installSharedNative   builtDir dynlibTargetDir sharedLibName
+    whenVanilla $ do
+      installOrdinaryNative builtDir targetDir vanillaLibName
+      whenGHCi $ installOrdinaryNative builtDir targetDir ghciLibName
+    whenProf $ do
+      installOrdinaryNative builtDir targetDir profileLibName
+      whenGHCi $ installOrdinaryNative builtDir targetDir ghciProfLibName
+    whenShared $ installSharedNative builtDir dynlibTargetDir sharedLibName
 
   where
     install isShared isJS srcDir dstDir name = do
@@ -747,6 +751,7 @@ installLib verbosity lbi targetDir dynlibTargetDir builtDir _pkg lib clbi = do
     vanillaLibName = mkLibName              uid
     profileLibName = mkProfLibName          uid
     ghciLibName    = Internal.mkGHCiLibName uid
+    ghciProfLibName = Internal.mkGHCiProfLibName uid
     sharedLibName  = (mkSharedLibName (hostPlatform lbi) compiler_id)  uid
 
     hasLib    = not $ null (allLibModules lib clbi)


### PR DESCRIPTION
Compile profiling library for use with GHCi when both
`--enable-profiling` and `--enable-library-for-ghci` are passed.

The merged `HS${package}.p_o` file can be loaded instead of
`libHS${package}_p.a` when we run GHCi with
`-prof -fexternal-interpreter` to speed up the linking time.

This depends on the change in ghc side:
https://phabricator.haskell.org/D5169

This will produce a new `.p_o` file which will get picked up by
new ghc and ignored by older version. It's backward compatible.

# Test Plan

```bash
# build base64-bytestring using local build of ghc and cabal
$HOME/gao/cabal/cabal-install/dist/build/cabal/cabal install --with-ghc=$HOME/gao/ghc/inplace/bin/ghc-stage2 --enable-profiling --enable-library-for-ghci --reinstall
# run ghci with profiling external interpreter
$HOME/gao/ghc/inplace/bin/ghc-stage2 -prof -fexternal-interpreter -package-db=base64-bytestring-1.0.0.1/.cabal-sandbox/x86_64-linux-ghc-8.7.20180920-packages.conf.d/ --interactive
# verify things in ghci
Prelude> Data.ByteString.Base64.encode "test"
"dGVzdA=="
Prelude> System.Posix.Process.getProcessID
2047
Prelude> :!grep HSbase /proc/2047/maps
40119000-4011e000 rwxp 00015000 00:29 585468                             /tmp/xxx/base64-bytestring-1.0.0.1/.cabal-sandbox/lib/x86_64-linux-ghc-8.7.20180920/base64-bytestring-1.0.0.1-G3Br32Wzx6yIe8CvhfIHtS/HSbase64-bytestring-1.0.0.1-G3Br32Wzx6yIe8CvhfIHtS.p_o
40b07000-40b1d000 rwxp 00000000 00:29 585468                             /tmp/xxx/base64-bytestring-1.0.0.1/.cabal-sandbox/lib/x86_64-linux-ghc-8.7.20180920/base64-bytestring-1.0.0.1-G3Br32Wzx6yIe8CvhfIHtS/HSbase64-bytestring-1.0.0.1-G3Br32Wzx6yIe8CvhfIHtS.p_o
40d1d000-40d1f000 rwxp 00969000 08:01 2373743                            /home/watashi/gao/ghc/libraries/base/dist-install/build/HSbase-4.12.0.0.p_o
40d70000-40d74000 rwxp 00019000 00:29 585468                             /tmp/xxx/base64-bytestring-1.0.0.1/.cabal-sandbox/lib/x86_64-linux-ghc-8.7.20180920/base64-bytestring-1.0.0.1-G3Br32Wzx6yIe8CvhfIHtS/HSbase64-bytestring-1.0.0.1-G3Br32Wzx6yIe8CvhfIHtS.p_o
40e9a000-40f93000 rwxp 0086f000 08:01 2373743                            /home/watashi/gao/ghc/libraries/base/dist-install/build/HSbase-4.12.0.0.p_o
40f93000-4109d000 rwxp 0097d000 08:01 2373743                            /home/watashi/gao/ghc/libraries/base/dist-install/build/HSbase-4.12.0.0.p_o
4109e000-4109f000 rwxp 00a86000 08:01 2373743                            /home/watashi/gao/ghc/libraries/base/dist-install/build/HSbase-4.12.0.0.p_o
41e12000-41e26000 rwxp 0096a000 08:01 2373743                            /home/watashi/gao/ghc/libraries/base/dist-install/build/HSbase-4.12.0.0.p_o
41f2c000-4279c000 rwxp 00000000 08:01 2373743                            /home/watashi/gao/ghc/libraries/base/dist-install/build/HSbase-4.12.0.0.p_o
7f76de823000-7f76e0000000 rwxp 00000000 08:01 2373743                    /home/watashi/gao/ghc/libraries/base/dist-install/build/HSbase-4.12.0.0.p_o
7f76ec597000-7f76ec5d7000 rwxp 00000000 00:29 585468                     /tmp/xxx/base64-bytestring-1.0.0.1/.cabal-sandbox/lib/x86_64-linux-ghc-8.7.20180920/base64-bytestring-1.0.0.1-G3Br32Wzx6yIe8CvhfIHtS/HSbase64-bytestring-1.0.0.1-G3Br32Wzx6yIe8CvhfIHtS.p_o
```



---
Please include the following checklist in your PR:

* [*] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [*] Any changes that could be relevant to users have been recorded in the changelog.
* [*] The documentation has been updated, if necessary.
* [*] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
