### PR TITLE
doc: common stanzas: import must be the first field

### DIFF
--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2987,6 +2987,8 @@ Starting with Cabal-2.2 it's possible to use common build info stanzas.
 
 -  You can import multiple stanzas at once. Stanza names must be separated by commas.
 
+-  ``import`` must be the first field in a section.
+
 .. Note::
 
     The name `import` was chosen, because there is ``includes`` field.


### PR DESCRIPTION
Document https://github.com/haskell/cabal/pull/4751#issuecomment-418269774

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
