### PR TITLE
Setup: Don't skip repl for indefinite components

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -655,7 +655,7 @@ buildOrReplLib mReplFlags verbosity numJobs pkg_descr lbi lib clbi = do
            unless forRepl $ whenProfLib   (runGhcProgIfNeeded   profCxxOpts)
       | filename <- cxxSources libBi]
 
-  when has_code . ifReplLib $ do
+  ifReplLib $ do
     when (null (allLibModules lib clbi)) $ warn verbosity "No exposed modules"
     ifReplLib (runGhcProg replOpts)
 

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -2,6 +2,7 @@
 
 2.6.0.0 (current development version)
 	* New solver flag: '--reject-unconstrained-dependencies'. (#2568)
+	* "cabal new-repl" now works for indefinite (in the Backpack sense) components.
 
 2.4.0.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> September 2018
         * Bugfix: "cabal new-build --ghc-option '--bogus' --ghc-option '-O1'"


### PR DESCRIPTION
For some reason repl invocation was skipped for indefinite components.
However, GHCi seems to handle them just fine.

Fixes #5619.

How I tested this change: Using the test case from issue #5619. Ran `cabal new-repl` and verified that it does indeed launch GHCi.
I couldn't figure out how to add this as an automated test to the suite, as it required somehow killing GHCi to avoid hanging indefinitely. The simplest options I could think of is passing `:quit` as input, but I couldn't find facilities for passing stdin in the test machinery.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
