### PR TITLE
Add message to alert user to potential package casing errors.

### DIFF
--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,7 @@
 -*-change-log-*-
 
 2.6.0.0 (current development version)
+	* Add message to alert user to potential package casing errors. (#5635)
 	* New solver flag: '--reject-unconstrained-dependencies'. (#2568)
 	* "cabal new-repl" now works for indefinite (in the Backpack sense) components.
 


### PR DESCRIPTION
As pointed out to me by @hvr, this bit of helpful error reporting was not present in new-install.

Fixes #5601.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.