### PR TITLE
new-install: error on existing symlink, overwrite option

### DIFF
--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -632,7 +632,7 @@ symlinkBuiltExe :: Verbosity -> OverwritePolicy
                 -> UnqualComponentName
                 -> IO Bool
 symlinkBuiltExe verbosity overwritePolicy sourceDir destDir exe = do
-  notice verbosity $ "Symlinking " ++ prettyShow exe
+  notice verbosity $ "Symlinking '" <> prettyShow exe <> "'"
   symlinkBinary
     overwritePolicy
     destDir

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -625,7 +625,7 @@ symlinkBuiltPackage verbosity overwritePolicy
                    (mkSourceBinDir pkg) destDir exe
       let errorMessage = case overwritePolicy of
                   NeverOverwrite ->
-                    "Symlink for '" <> prettyShow exe <> "' already exists. "
+                    "Path '" <> (destDir </> prettyShow exe) <> "' already exists. "
                     <> "Use --overwrite-policy=always to overwrite."
                   -- This shouldn't even be possible, but we keep it in case
                   -- symlinking logic changes

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -96,7 +96,7 @@ import qualified Distribution.Client.BuildReports.Anonymous as BuildReports
 import qualified Distribution.Client.BuildReports.Storage as BuildReports
          ( storeAnonymous, storeLocal, fromInstallPlan, fromPlanningFailure )
 import qualified Distribution.Client.InstallSymlink as InstallSymlink
-         ( symlinkBinaries )
+         ( OverwritePolicy(..), symlinkBinaries )
 import qualified Distribution.Client.Win32SelfUpgrade as Win32SelfUpgrade
 import qualified Distribution.Client.World as World
 import qualified Distribution.InstalledPackageInfo as Installed
@@ -965,6 +965,7 @@ symlinkBinaries :: Verbosity
 symlinkBinaries verbosity platform comp configFlags installFlags
                 plan buildOutcomes = do
   failed <- InstallSymlink.symlinkBinaries platform comp
+                                           InstallSymlink.DontOverwrite
                                            configFlags installFlags
                                            plan buildOutcomes
   case failed of

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -965,7 +965,7 @@ symlinkBinaries :: Verbosity
 symlinkBinaries verbosity platform comp configFlags installFlags
                 plan buildOutcomes = do
   failed <- InstallSymlink.symlinkBinaries platform comp
-                                           InstallSymlink.DontOverwrite
+                                           InstallSymlink.NeverOverwrite
                                            configFlags installFlags
                                            plan buildOutcomes
   case failed of

--- a/cabal-install/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/Distribution/Client/InstallSymlink.hs
@@ -28,7 +28,7 @@ import Distribution.Simple.Setup (ConfigFlags)
 import Distribution.Simple.Compiler
 import Distribution.System
 
-data OverwritePolicy = DontOverwrite | DoOverwrite
+data OverwritePolicy = NeverOverwrite | AlwaysOverwrite
   deriving (Show, Eq)
 
 symlinkBinaries :: Platform -> Compiler
@@ -94,7 +94,7 @@ import Control.Exception
 import Data.Maybe
          ( catMaybes )
 
-data OverwritePolicy = DontOverwrite | DoOverwrite
+data OverwritePolicy = NeverOverwrite | AlwaysOverwrite
   deriving (Show, Eq)
 
 -- | We would like by default to install binaries into some location that is on
@@ -222,8 +222,8 @@ symlinkBinary overwritePolicy publicBindir privateBindir publicName privateName 
     OkToOverwrite     -> rmLink >> mkLink >> return True
     NotOurFile ->
       case overwritePolicy of
-        DontOverwrite ->                     return False
-        DoOverwrite   -> rmLink >> mkLink >> return True
+        NeverOverwrite  ->                     return False
+        AlwaysOverwrite -> rmLink >> mkLink >> return True
   where
     publicName' = display publicName
     relativeBindir = makeRelative publicBindir privateBindir


### PR DESCRIPTION
Phase 2 of the fix for #5491. Followup to #5602.

Erroring out is safer and more explicit.

Next, we'll have to check for error/no-op as early as possible (currently we build everything first).

/cc @hvr