### PR TITLE
Check early for failures in new-install

### DIFF
--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -511,6 +511,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, newInstal
     printPlan verbosity baseCtx buildCtx
 
     buildOutcomes <- runProjectBuildPhase verbosity baseCtx buildCtx
+    runProjectPostBuildPhase verbosity baseCtx buildCtx buildOutcomes
 
     let
       mkPkgBinDir = (</> "bin") .
@@ -536,7 +537,6 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, newInstal
                       overwritePolicy
                       mkPkgBinDir symlinkBindir
         in traverse_ doSymlink $ Map.toList $ targetsMap buildCtx
-    runProjectPostBuildPhase verbosity baseCtx buildCtx buildOutcomes
 
     when installLibs $
       if supportsPkgEnvFiles


### PR DESCRIPTION
So we don't try to symlink failed packages

Fixes #5550 (the dead symlink part, not the error reporting (#5641))

Just running ci, should be safe to merge.

/cc @hvr