### PR TITLE
Link to 'developing packages' from new-build docs.

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -4,7 +4,9 @@ Quickstart
 ==========
 
 Suppose that you are in a directory containing a single Cabal package
-which you wish to build. You can configure and build it using Nix-style
+which you wish to build (if you haven't set up a package yet check
+out `developing packages <developing-packages.html>`__ for 
+instructions). You can configure and build it using Nix-style
 local builds with this command (configuring is not necessary):
 
 ::


### PR DESCRIPTION
This page is often surfaces above the "Developing Packages Quickstart" section in search results (for queries including "cabal new project") but a beginner ending up here may not know how to set up their package before using the commands here. This adds a link to the relevant section in the docs that walks through how to set up a package so they don't need to go looking for it themselves.

This is a docs-only change.

[ci skip]

