### PR TITLE
Add `-w`/`--with-compiler` flag to `cabal init`

### DIFF
--- a/cabal-install/Distribution/Client/Init/Types.hs
+++ b/cabal-install/Distribution/Client/Init/Types.hs
@@ -69,6 +69,8 @@ data InitFlags =
               , sourceDirs   :: Maybe [String]
               , buildTools   :: Maybe [String]
 
+              , initHcPath    :: Flag FilePath
+
               , initVerbosity :: Flag Verbosity
               , overwrite     :: Flag Bool
               }

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2295,6 +2295,14 @@ initCommand = CommandUI {
         (reqArg' "TOOL" (Just . (:[]))
                         (fromMaybe []))
 
+        -- NB: this is a bit of a transitional hack and will likely be
+        -- removed again if `cabal init` is migrated to the v2-* command
+        -- framework
+      , option "w" ["with-compiler"]
+        "give the path to a particular compiler"
+        IT.initHcPath (\v flags -> flags { IT.initHcPath = v })
+        (reqArgFlag "PATH")
+
       , optionVerbosity IT.initVerbosity (\v flags -> flags { IT.initVerbosity = v })
       ]
   }

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -38,7 +38,7 @@ import Distribution.Client.Setup
          , UploadFlags(..), uploadCommand
          , ReportFlags(..), reportCommand
          , runCommand
-         , InitFlags(initVerbosity), initCommand
+         , InitFlags(initVerbosity, initHcPath), initCommand
          , SDistFlags(..), SDistExFlags(..), sdistCommand
          , Win32SelfUpgradeFlags(..), win32SelfUpgradeCommand
          , ActAsSetupFlags(..), actAsSetupCommand
@@ -1143,7 +1143,9 @@ initAction initFlags extraArgs globalFlags = do
     die' verbosity $ "'init' doesn't take any extra arguments: " ++ unwords extraArgs
   (_useSandbox, config) <- loadConfigOrSandboxConfig verbosity
                            (globalFlags { globalRequireSandbox = Flag False })
-  let configFlags  = savedConfigureFlags config
+  let configFlags  = savedConfigureFlags config `mappend`
+                     -- override with `--with-compiler` from CLI if available
+                     mempty { configHcPath = initHcPath initFlags }
   let globalFlags' = savedGlobalFlags    config `mappend` globalFlags
   (comp, _, progdb) <- configCompilerAux' configFlags
   withRepoContext verbosity globalFlags' $ \repoContext ->


### PR DESCRIPTION
Fixes #5654 
Fixes #4936


----

Besides giving you the ability to conveniently pick a different `ghc` which you could workaround by e.g.

```
PATH=/opt/ghc/8.6.2/bin:$PATH cabal init
```

via a simpler, more explicit (because it doesn't rely on the indirection via $PATH to pick the right exe), and more idiomatic

```
cabal init -w ghc-8.6.2
```

if you have a setup where all `ghc` versions are symlinked version-suffixed in your $PATH already.

However, there's also the case where you don't have *any* `ghc` in your PATH, but *only* `ghc-<version>` symlinks; this is e.g. the default setup scheme promoted by `ghcup` and for this case, there's not necessarily any workaround (other than creating a `cabal.config` file or modifying your global cabal config). Or an even more pathological case is

```
cabal init -w /work/ghc/inplace/bin/ghc-stage2
```

---

TODO:

* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

