### PR TITLE
Add 'optional-target' field to plan.json

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -157,7 +157,7 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
                     [ "depends"     J..= map (jdisplay . confInstId) ldeps
                     , "exe-depends" J..= map (jdisplay . confInstId) edeps
                     ] ++
-                    requestedByDefaultJ c ++
+                    optionalTargetJ c ++
                     bin_file c)
                   | (c,(ldeps,edeps))
                       <- ComponentDeps.toList $
@@ -169,10 +169,10 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
             ,"exe-depends" J..= map jdisplay (elabExeDependencies elab)
             ,"component-name" J..= J.String (comp2str (compSolverName comp))
             ] ++
-            requestedByDefaultJ (compSolverName comp) ++
+            optionalTargetJ (compSolverName comp) ++
             bin_file (compSolverName comp)
      where
-      requestedByDefaultJ comp =
+      optionalTargetJ comp =
           case componentOptionalStanza comp of
             Nothing -> []
             Just _  -> [ "optional-target" J..= J.Bool True ]

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -175,7 +175,7 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
       requestedByDefaultJ comp =
           case componentOptionalStanza comp of
             Nothing -> []
-            Just _  -> [ "requested-by-default" J..= J.Bool False ]
+            Just _  -> [ "optional-target" J..= J.Bool True ]
 
       packageLocationToJ :: PackageLocation (Maybe FilePath) -> J.Value
       packageLocationToJ pkgloc =

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -155,7 +155,9 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
             let components = J.object $
                   [ comp2str c J..= (J.object $
                     [ "depends"     J..= map (jdisplay . confInstId) ldeps
-                    , "exe-depends" J..= map (jdisplay . confInstId) edeps ] ++
+                    , "exe-depends" J..= map (jdisplay . confInstId) edeps
+                    ] ++
+                    requestedByDefaultJ c ++
                     bin_file c)
                   | (c,(ldeps,edeps))
                       <- ComponentDeps.toList $
@@ -167,8 +169,14 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
             ,"exe-depends" J..= map jdisplay (elabExeDependencies elab)
             ,"component-name" J..= J.String (comp2str (compSolverName comp))
             ] ++
+            requestedByDefaultJ (compSolverName comp) ++
             bin_file (compSolverName comp)
      where
+      requestedByDefaultJ comp =
+          case componentOptionalStanza comp of
+            Nothing -> []
+            Just _  -> [ "requested-by-default" J..= J.Bool False ]
+
       packageLocationToJ :: PackageLocation (Maybe FilePath) -> J.Value
       packageLocationToJ pkgloc =
         case pkgloc of

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -2424,7 +2424,7 @@ availableSourceTargets elab =
     componentAvailableTargetStatus
       :: Component -> AvailableTargetStatus (UnitId, ComponentName)
     componentAvailableTargetStatus component =
-        case componentOptionalStanza (componentName component) of
+        case componentOptionalStanza $ CD.componentNameToComponent cname of
           -- it is not an optional stanza, so a library, exe or foreign lib
           Nothing
             | not buildable  -> TargetNotBuildable
@@ -2744,7 +2744,9 @@ pruneInstallPlanPass1 pkgs =
                                   ++ elabBenchTargets pkg
                                   ++ maybeToList (elabReplTarget pkg)
                                   ++ elabHaddockTargets pkg
-        , stanza <- maybeToList (componentOptionalStanza cname)
+        , stanza <- maybeToList $
+                    componentOptionalStanza $
+                    CD.componentNameToComponent cname
         ]
 
     availablePkgs =
@@ -2873,11 +2875,6 @@ mapConfiguredPackage f (InstallPlan.Installed pkg) =
   InstallPlan.Installed (f pkg)
 mapConfiguredPackage _ (InstallPlan.PreExisting pkg) =
   InstallPlan.PreExisting pkg
-
-componentOptionalStanza :: Cabal.ComponentName -> Maybe OptionalStanza
-componentOptionalStanza (Cabal.CTestName  _) = Just TestStanzas
-componentOptionalStanza (Cabal.CBenchName _) = Just BenchStanzas
-componentOptionalStanza _                    = Nothing
 
 ------------------------------------
 -- Support for --only-dependencies

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -54,6 +54,8 @@ module Distribution.Client.ProjectPlanning.Types (
     isTestComponentTarget,
     isBenchComponentTarget,
 
+    componentOptionalStanza,
+
     -- * Setup script
     SetupScriptStyle(..),
   ) where
@@ -779,6 +781,11 @@ isExeComponentTarget _                                 = False
 isSubLibComponentTarget :: ComponentTarget -> Bool
 isSubLibComponentTarget (ComponentTarget (CLibName (LSubLibName _)) _) = True
 isSubLibComponentTarget _                                              = False
+
+componentOptionalStanza :: CD.Component -> Maybe OptionalStanza
+componentOptionalStanza (CD.ComponentTest _)  = Just TestStanzas
+componentOptionalStanza (CD.ComponentBench _) = Just BenchStanzas
+componentOptionalStanza _                     = Nothing
 
 ---------------------------
 -- Setup.hs script policy

--- a/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
@@ -91,12 +91,12 @@ instance Traversable ComponentDeps where
 instance Binary a => Binary (ComponentDeps a)
 
 componentNameToComponent :: CN.ComponentName -> Component
-componentNameToComponent (CN.CLibName LN.LMainLibName   ) = ComponentLib
+componentNameToComponent (CN.CLibName  LN.LMainLibName)   = ComponentLib
 componentNameToComponent (CN.CLibName (LN.LSubLibName s)) = ComponentSubLib s
-componentNameToComponent (CN.CFLibName s)   = ComponentFLib s
-componentNameToComponent (CN.CExeName s)    = ComponentExe s
-componentNameToComponent (CN.CTestName s)   = ComponentTest s
-componentNameToComponent (CN.CBenchName s)  = ComponentBench s
+componentNameToComponent (CN.CFLibName                s)  = ComponentFLib   s
+componentNameToComponent (CN.CExeName                 s)  = ComponentExe    s
+componentNameToComponent (CN.CTestName                s)  = ComponentTest   s
+componentNameToComponent (CN.CBenchName               s)  = ComponentBench  s
 
 {-------------------------------------------------------------------------------
   Construction


### PR DESCRIPTION
Having this enables tooling to give better error messages when build output is
missing. cabal-install can choose to include optional components in the build
plan even though they weren't requested explicitly by the user. Currently
tooling would have to assume missing build output after a `v2-build all` call
means the component is currently disabled, which is just not very clean.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.