### PR TITLE
Prompt overwrite policy

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -90,7 +90,7 @@ import Distribution.Client.DistDirLayout
 import Distribution.Client.RebuildMonad
          ( runRebuild )
 import Distribution.Client.InstallSymlink
-         ( symlinkBinary, trySymlink )
+         ( symlinkBinary, trySymlink, promptRun )
 import Distribution.Client.Types.OverwritePolicy
          ( OverwritePolicy (..) )
 import Distribution.Simple.Flag
@@ -140,8 +140,6 @@ import System.Directory
          , removeFile, removeDirectory, copyFile )
 import System.FilePath
          ( (</>), (<.>), takeDirectory, takeBaseName )
-import Distribution.Client.Init.Types (DefaultPrompt(MandatoryPrompt))
-import Distribution.Client.Init.Prompt (promptYesNo)
 
 installCommand :: CommandUI (NixStyleFlags ClientInstallFlags)
 installCommand = CommandUI
@@ -833,11 +831,10 @@ installBuiltExe verbosity overwritePolicy
     overwrite :: IO Bool
     overwrite = remove >> copy
     maybeOverwrite :: IO Bool
-    maybeOverwrite = do
-      a <- promptYesNo
-        "Existing file found while installing executable. Do you want to unlink that file? (y/n)"
-        MandatoryPrompt
-      if a then overwrite else pure a
+    maybeOverwrite
+      = promptRun
+        "Existing file found while installing executable. Do you want to overwrite that file? (y/n)"
+        overwrite
 
 -- | Create 'GhcEnvironmentFileEntry's for packages with exposed libraries.
 entriesForLibraryComponents :: TargetsMap -> [GhcEnvironmentFileEntry]

--- a/cabal-install/src/Distribution/Client/CmdInstall/ClientInstallFlags.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall/ClientInstallFlags.hs
@@ -65,7 +65,7 @@ clientInstallOptions _ =
   , option [] ["overwrite-policy"]
     "How to handle already existing symlinks."
     cinstOverwritePolicy (\v flags -> flags { cinstOverwritePolicy = v })
-    $ reqArg "always|never"
+    $ reqArg "always|never|prompt"
         (parsecToReadE (\err -> "Error parsing overwrite-policy: " ++ err) (toFlag `fmap` parsec)) 
         (map prettyShow . flagToList)
   , option [] ["install-method"]

--- a/cabal-install/src/Distribution/Client/Init/Prompt.hs
+++ b/cabal-install/src/Distribution/Client/Init/Prompt.hs
@@ -25,6 +25,7 @@ import Prelude hiding (break, putStrLn, getLine, putStr)
 
 import Distribution.Client.Compat.Prelude hiding (break, empty, getLine, putStr, putStrLn)
 import Distribution.Client.Init.Types
+import qualified System.IO
 
 
 -- | Create a prompt with optional default value that returns a
@@ -149,6 +150,7 @@ promptDefault
     -> m t
 promptDefault parse pprint msg def = do
   putStr $ mkDefPrompt msg (pprint <$> def)
+  hFlush System.IO.stdout
   input <- getLine
   case def of
     DefaultPrompt d | null input  -> return d

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -69,6 +69,7 @@ import Distribution.CabalSpecVersion
 import Distribution.Client.Utils as P
 import Distribution.Fields.Pretty
 import Language.Haskell.Extension ( Language(..), Extension )
+import qualified System.IO
 
 import qualified System.Directory as P
 import qualified System.Process as P
@@ -322,6 +323,7 @@ class Monad m => Interactive m where
     copyFile :: FilePath -> FilePath -> m ()
     renameDirectory :: FilePath -> FilePath -> m ()
     message :: Verbosity -> String -> m ()
+    hFlush :: System.IO.Handle -> m ()
 
     -- misc functions
     break :: m Bool
@@ -350,6 +352,7 @@ instance Interactive IO where
     copyFile = P.copyFile
     renameDirectory = P.renameDirectory
     message q = unless (q == silent) . putStrLn
+    hFlush = System.IO.hFlush
 
     break = return False
     throwPrompt = throwM
@@ -382,6 +385,7 @@ instance Interactive PurePrompt where
     copyFile !_ !_ = return ()
     renameDirectory !_ !_ = return ()
     message !_ !_ = return ()
+    hFlush _ = return ()
 
     break = return True
     throwPrompt (BreakException e) = PurePrompt $ \s -> Left $ BreakException

--- a/cabal-install/src/Distribution/Client/Types/OverwritePolicy.hs
+++ b/cabal-install/src/Distribution/Client/Types/OverwritePolicy.hs
@@ -10,6 +10,7 @@ import qualified Text.PrettyPrint                as PP
 data OverwritePolicy
     = NeverOverwrite
     | AlwaysOverwrite
+    | PromptOverwrite
   deriving (Show, Eq, Generic, Bounded, Enum)
 
 instance Binary OverwritePolicy
@@ -21,8 +22,10 @@ instance Parsec OverwritePolicy where
         case name of
             "always" -> pure AlwaysOverwrite
             "never"  -> pure NeverOverwrite
+            "prompt" -> pure PromptOverwrite
             _        -> P.unexpected $ "OverwritePolicy: " ++ name
 
 instance Pretty OverwritePolicy where
     pretty NeverOverwrite  = PP.text "never"
     pretty AlwaysOverwrite = PP.text "always"
+    pretty PromptOverwrite = PP.text "prompt"

--- a/changelog.d/pr-5672
+++ b/changelog.d/pr-5672
@@ -1,0 +1,2 @@
+synopsis: Add "prompt" strategy when symlinking binaries.
+prs: #5672


### PR DESCRIPTION
When linking binaries into a globally accessible location on the machine `--overwrite-policy=always` is needed if an existing file sits where we are trying to create a link. This allows for a prompt-the-user strategy.

---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [X] Any changes that could be relevant to users have been recorded in the changelog.
* [X] The documentation has been updated, if necessary.
  NA: Couldn't find any existing documentation about `overwrite-policy`.
* [X] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

How I tested the change:

I simply ran `cabal new-install` on `cabal-install` (after having installed `cabal-install` with my feature.

## WIP
* [ ] Testing on Windows. Help wanted
* [x] A way to globally configure `--overwrite-policy=prompt` as the default. This was my idea with the patch. I need a bit of help on how to achieve this though as I'm not familiar with the code-base.