### PR TITLE
Always transliterate coding failures for stdout and stderr

### DIFF
--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -142,9 +142,7 @@ import Distribution.Client.Init               (initCabal)
 import Distribution.Client.Manpage            (manpage)
 import qualified Distribution.Client.Win32SelfUpgrade as Win32SelfUpgrade
 import Distribution.Client.Utils              (determineNumJobs
-#if defined(mingw32_HOST_OS)
                                               ,relaxEncodingErrors
-#endif
                                               )
 
 import Distribution.Package (packageId)
@@ -191,10 +189,7 @@ import System.Exit              (exitFailure, exitSuccess)
 import System.FilePath          ( dropExtension, splitExtension
                                 , takeExtension, (</>), (<.>))
 import System.IO                ( BufferMode(LineBuffering), hSetBuffering
-#ifdef mingw32_HOST_OS
-                                , stderr
-#endif
-                                , stdout )
+                                , stderr, stdout )
 import System.Directory         (doesFileExist, getCurrentDirectory)
 import Data.Monoid              (Any(..))
 import Control.Exception        (SomeException(..), try)
@@ -230,13 +225,11 @@ main' = do
   -- Enable line buffering so that we can get fast feedback even when piped.
   -- This is especially important for CI and build systems.
   hSetBuffering stdout LineBuffering
-  -- The default locale encoding for Windows CLI is not UTF-8 and printing
-  -- Unicode characters to it will fail unless we relax the handling of encoding
-  -- errors when writing to stderr and stdout.
-#ifdef mingw32_HOST_OS
+  -- If the locale encoding for CLI doesn't support all Unicode characters,
+  -- printing to it may fail unless we relax the handling of encoding errors
+  -- when writing to stderr and stdout.
   relaxEncodingErrors stdout
   relaxEncodingErrors stderr
-#endif
   getArgs >>= mainWorker
 
 mainWorker :: [String] -> IO ()


### PR DESCRIPTION
We used to only transliterate coding failures on Windows, but this can
fail on other platforms as well, e.g. when `LANG=C` is set on Linux.
We have done this in ghc for all platforms:
https://phabricator.haskell.org/D4642

Before, following commands will fail

```
$ LANG=C cabal install base-compat --verbose=3
Finalized package description:
...
(c) 2014-2018 Jo<stdout>: commitBuffer: invalid argument (invalid character)
```

and now finishes without problem, and print

```
(c) 2014-2018 Jo?o Crist?v?o,
```

instead.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
