### PR TITLE
Suppress warnings in autogenerated signatures.

### DIFF
--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -688,6 +688,7 @@ writeAutogenFiles verbosity pkg lbi clbi = do
                       </> ModuleName.toFilePath mod_name <.> "hsig"
             createDirectoryIfMissingVerbose verbosity True (takeDirectory sigPath)
             rewriteFileEx verbosity sigPath $
+                "{-# OPTIONS_GHC -w #-}\n" ++
                 "{-# LANGUAGE NoImplicitPrelude #-}\n" ++
                 "signature " ++ prettyShow mod_name ++ " where"
     _ -> return ()

--- a/cabal-testsuite/PackageTests/Regression/T5677/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T5677/cabal.out
@@ -1,0 +1,29 @@
+# cabal new-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - impl-0 (lib) (first run)
+ - sig-0 (lib) (first run)
+ - prog-0 (lib) (first run)
+ - prog-0 (lib with Sig=impl-0-inplace:Sig) (first run)
+ - prog-0 (exe:prog) (first run)
+Configuring library for impl-0..
+Preprocessing library for impl-0..
+Building library for impl-0..
+Configuring library for sig-0..
+Preprocessing library for sig-0..
+Building library instantiated with Sig = <Sig>
+for sig-0..
+Configuring library for prog-0..
+Preprocessing library for prog-0..
+Building library instantiated with Sig = <Sig>
+for prog-0..
+Configuring library instantiated with Sig = impl-0-inplace:Sig
+for prog-0..
+Preprocessing library for prog-0..
+Building library instantiated with Sig = impl-0-inplace:Sig
+for prog-0..
+Configuring executable 'prog' for prog-0..
+Warning: The package has an extraneous version range for a dependency on an internal library: prog -any && ==0. This version range includes the current package but isn't needed as the current package's library will always be used.
+Preprocessing executable 'prog' for prog-0..
+Building executable 'prog' for prog-0..

--- a/cabal-testsuite/PackageTests/Regression/T5677/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T5677/cabal.project
@@ -1,0 +1,4 @@
+packages:
+  sig/
+  impl/
+  prog/

--- a/cabal-testsuite/PackageTests/Regression/T5677/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5677/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+main = cabalTest $ do
+  skipUnless =<< ghcVersionIs (>= mkVersion [8,1])
+  cabal "new-build" ["all"]
+

--- a/cabal-testsuite/PackageTests/Regression/T5677/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5677/cabal.test.hs
@@ -1,5 +1,6 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
-  skipUnless =<< ghcVersionIs (>= mkVersion [8,1])
+  -- -Wmissing-export-lists is new in 8.4.
+  skipUnless =<< ghcVersionIs (>= mkVersion [8,3])
   cabal "new-build" ["all"]
 

--- a/cabal-testsuite/PackageTests/Regression/T5677/impl/Sig.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5677/impl/Sig.hs
@@ -1,0 +1,3 @@
+module Sig where
+
+foo = True

--- a/cabal-testsuite/PackageTests/Regression/T5677/impl/impl.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T5677/impl/impl.cabal
@@ -1,0 +1,10 @@
+cabal-version: 2.2
+name: impl
+version: 0
+
+library
+  default-language: Haskell2010
+  build-depends:
+    base
+  exposed-modules:
+    Sig

--- a/cabal-testsuite/PackageTests/Regression/T5677/prog/prog.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T5677/prog/prog.cabal
@@ -1,0 +1,19 @@
+cabal-version: 2.2
+name: prog
+version: 0
+
+library
+  default-language: Haskell2010
+  hs-source-dirs: src/
+  exposed-modules:
+    Prog
+  ghc-options: -Wmissing-export-lists -Werror
+  build-depends:
+    base, sig
+
+executable prog
+  default-language: Haskell2010
+  main-is: prog.hs
+  ghc-options: -Wmissing-export-lists -Werror
+  build-depends:
+    base, impl, prog

--- a/cabal-testsuite/PackageTests/Regression/T5677/prog/prog.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5677/prog/prog.hs
@@ -1,0 +1,5 @@
+module Main (main) where
+
+import qualified Prog
+
+main = Prog.main

--- a/cabal-testsuite/PackageTests/Regression/T5677/prog/src/Prog.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5677/prog/src/Prog.hs
@@ -1,0 +1,5 @@
+module Prog (main) where
+
+import Sig
+
+main = print foo

--- a/cabal-testsuite/PackageTests/Regression/T5677/sig/Sig.hsig
+++ b/cabal-testsuite/PackageTests/Regression/T5677/sig/Sig.hsig
@@ -1,0 +1,3 @@
+signature Sig where
+
+foo :: Bool

--- a/cabal-testsuite/PackageTests/Regression/T5677/sig/sig.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T5677/sig/sig.cabal
@@ -1,0 +1,10 @@
+cabal-version: 2.2
+name: sig
+version: 0
+
+library
+  default-language: Haskell2010
+  build-depends:
+    base
+  signatures:
+    Sig


### PR DESCRIPTION
Issue #5677 demonstrates one way for warnings to be produced by dummy
signatures. Autogenerated code really ought to never be generating
warnings, under any sets of flags provided by the user; this patch
uses the big hammer of entirely disabling warnings for the generated
signatures.

Fixes #5677.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
