### PR TITLE
Remove 'do' in 'instance Text ModuleRenaming'

### DIFF
--- a/Cabal/Distribution/Types/ModuleRenaming.hs
+++ b/Cabal/Distribution/Types/ModuleRenaming.hs
@@ -112,7 +112,7 @@ instance Parsec ModuleRenaming where
 
 
 instance Text ModuleRenaming where
-  parse = do fmap ModuleRenaming parseRns
+  parse = fmap ModuleRenaming parseRns
              <++ parseHidingRenaming
              <++ return DefaultRenaming
     where parseRns = do


### PR DESCRIPTION
We have this code in `Cabal`, which I don't believe to be syntactically valid Haskell:

```
  do fmap ModuleRenaming parseRns
     <++ parseHidingRenaming
     <++ return DefaultRenaming
```

It works by a fluke. The GHC parser shifts and we parse it as

```
  do (fmap ModuleRenaming parseRns
     <++ parseHidingRenaming
     <++ return DefaultRenaming)
```

rather than

```
  do (fmap ModuleRenaming parseRns)
     (<++ parseHidingRenaming)
     (<++ return DefaultRenaming)
```

However, this behaviour is hard to support. I'm currently working on a set of changes to the parser that result in no shift in this case -- and then get the latter parse, which results in an error about no LHS for `<++`.

Furthermore, even in today's GHC such syntax is not fully supported (happens to work for the `<++` operator above, but not if the operator is `!`).

I'd appreciate if we could merge this to both `master` and the `2.4` branch. (`2.4` because that's what the GHC submodule tracks currently).

----
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

