### PR TITLE
Fix erroneous "no exes" warning on lib+exe packages

### DIFF
--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -534,6 +534,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
                     $ projectConfigBuildOnly
                     $ projectConfig $ baseCtx
       createDirectoryIfMissingVerbose verbosity False symlinkBindir
+      warnIfNoExes verbosity buildCtx
       let
         doSymlink = symlinkBuiltPackage
                       verbosity
@@ -577,6 +578,23 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
     overwritePolicy = fromFlagOrDefault NeverOverwrite
                         $ ninstOverwritePolicy newInstallFlags
 
+warnIfNoExes :: Verbosity -> ProjectBuildContext -> IO ()
+warnIfNoExes verbosity buildCtx =
+  when noExes $
+    warn verbosity $ "You asked to install executables, "
+                  <> "but there are no executables in "
+                  <> plural (listPlural selectors) "target" "targets" <> ": "
+                  <> intercalate ", " (showTargetSelector <$> selectors) <> ". "
+                  <> "Perhaps you want to use --lib "
+                  <> "to install libraries instead."
+  where
+    targets = concat $ Map.elems $ targetsMap buildCtx
+    components = fst <$> targets
+    selectors = concatMap snd targets
+    noExes = null $ catMaybes $ exeMaybe <$> components
+    exeMaybe (ComponentTarget (CExeName exe) _) = Just exe
+    exeMaybe _ = Nothing
+
 globalPackages :: [PackageName]
 globalPackages = mkPackageName <$>
   [ "ghc", "hoopl", "bytestring", "unix", "base", "time", "hpc", "filepath"
@@ -617,16 +635,8 @@ symlinkBuiltPackage :: Verbosity
 symlinkBuiltPackage verbosity overwritePolicy
                     mkSourceBinDir destDir
                     (pkg, components) =
-  if null exes
-    then warn verbosity $ "You asked to install executables, "
-                       <> "but there are no executables in "
-                       <> plural (listPlural targets) "target" "targets" <> ": "
-                       <> intercalate ", " (showTargetSelector <$> targets) <> ". "
-                       <> "Perhaps you want to use --lib "
-                       <> "to install libraries instead."
-    else traverse_ symlinkAndWarn exes
+  traverse_ symlinkAndWarn exes
   where
-    targets = concat $ snd <$> components
     exes = catMaybes $ (exeMaybe . fst) <$> components
     exeMaybe (ComponentTarget (CExeName exe) _) = Just exe
     exeMaybe _ = Nothing


### PR DESCRIPTION
f6aaeeeae3daca0240a6192024934f4b2143412e acted on units, but an exe+lib
package generates two units (when per-component building is enabled) and
it produced a warning for the lib one.

Now the check is done on all units together.

/cc @hvr