### PR TITLE
Add package revision and cabal file hash to plan.json

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -19,7 +19,7 @@ import           Distribution.Client.ProjectPlanning.Types
 import           Distribution.Client.ProjectBuilding.Types
 import           Distribution.Client.DistDirLayout
 import           Distribution.Client.Types (Repo(..), RemoteRepo(..), PackageLocation(..), confInstId)
-import           Distribution.Client.PackageHash (showHashValue)
+import           Distribution.Client.PackageHash (showHashValue, hashValue)
 
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import qualified Distribution.Client.Utils.Json as J
@@ -140,6 +140,12 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
                                      | (fn,v) <- PD.unFlagAssignment (elabFlagAssignment elab) ]
         , "style"      J..= J.String (style2str (elabLocalToProject elab) (elabBuildStyle elab))
         , "pkg-src"    J..= packageLocationToJ (elabPkgSourceLocation elab)
+        ] ++
+        [ "pkg-revision" J..=  J.String x
+        | Just x <- [lookup "x-revision" (PD.customFieldsPD (elabPkgDescription elab))]
+        ] ++
+        [ "pkg-revised-cabal-sha256" J..= J.String hash
+        | Just hash  <- [ fmap (showHashValue . hashValue) (elabPkgDescriptionOverride elab) ]
         ] ++
         [ "pkg-src-sha256" J..= J.String (showHashValue hash)
         | Just hash <- [elabPkgSourceHash elab] ] ++


### PR DESCRIPTION
This is useful for external tools like plan2nix [1] which
can then create their own build plan based on the cabal
solver output, even in the presence of revised cabal files.

[1] - https://github.com/angerman/nix-tools/tree/master/plan2nix

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

