### PR TITLE
Improve the handling of .ghc.environment files

### DIFF
--- a/Cabal/Distribution/Simple/GHC/EnvironmentParser.hs
+++ b/Cabal/Distribution/Simple/GHC/EnvironmentParser.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
-module Distribution.Simple.GHC.EnvironmentParser 
+module Distribution.Simple.GHC.EnvironmentParser
     ( parseGhcEnvironmentFile, readGhcEnvironmentFile, ParseErrorExc(..) ) where
 
 import Prelude ()
@@ -20,7 +20,7 @@ import Distribution.Types.UnitId
 import Control.Exception
     ( Exception, throwIO )
 import qualified Text.Parsec as P
-import Text.Parsec.String 
+import Text.Parsec.String
     ( Parser, parseFromFile )
 
 parseEnvironmentFileLine :: Parser GhcEnvironmentFileEntry
@@ -30,7 +30,7 @@ parseEnvironmentFileLine =      GhcEnvFileComment             <$> comment
                        <|> pure GhcEnvFileClearPackageDbStack <*  clearDb
     where
         comment = P.string "--" *> P.many (P.noneOf "\r\n")
-        unitId = P.try $ P.string "package-id" *> P.spaces *> 
+        unitId = P.try $ P.string "package-id" *> P.spaces *>
             (mkUnitId <$> P.many1 (P.satisfy $ \c -> isAlphaNum c || c `elem` "-_.+"))
         packageDb = (P.string "global-package-db"      *> pure GlobalPackageDB)
                 <|> (P.string "user-package-db"        *> pure UserPackageDB)

--- a/cabal-install/Distribution/Client/CmdClean.hs
+++ b/cabal-install/Distribution/Client/CmdClean.hs
@@ -61,7 +61,8 @@ cleanCommand = CommandUI
             cleanDistDir (\dd flags -> flags { cleanDistDir = dd })
             showOrParseArgs
         , option [] ["project-file"]
-            "Set the name of the cabal.project file to search for in parent directories"
+            ("Set the name of the cabal.project file"
+             ++ " to search for in parent directories")
             cleanProjectFile (\pf flags -> flags {cleanProjectFile = pf})
             (reqArg "FILE" (succeedReadE Flag) flagToList)
         , option ['s'] ["save-config"]
@@ -79,7 +80,8 @@ cleanAction CleanFlags{..} extraArgs _ = do
         mprojectFile = flagToMaybe cleanProjectFile
 
     unless (null extraArgs) $
-        die' verbosity $ "'clean' doesn't take any extra arguments: " ++ unwords extraArgs
+        die' verbosity $ "'clean' doesn't take any extra arguments: "
+                         ++ unwords extraArgs
 
     projectRoot <- either throwIO return =<< findProjectRoot Nothing mprojectFile
 

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -363,7 +363,9 @@ instance Semigroup SavedConfig where
         configPreferences   = lastNonEmpty configPreferences,
         configSolver        = combine configSolver,
         configAllowNewer    = combineMonoid savedConfigureExFlags configAllowNewer,
-        configAllowOlder    = combineMonoid savedConfigureExFlags configAllowOlder
+        configAllowOlder    = combineMonoid savedConfigureExFlags configAllowOlder,
+        configWriteGhcEnvironmentFilesPolicy
+                            = combine configWriteGhcEnvironmentFilesPolicy
         }
         where
           combine      = combine' savedConfigureExFlags

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -334,7 +334,9 @@ convertLegacyAllPackageFlags globalFlags configFlags
       configPreferences         = projectConfigPreferences,
       configSolver              = projectConfigSolver,
       configAllowOlder          = projectConfigAllowOlder,
-      configAllowNewer          = projectConfigAllowNewer
+      configAllowNewer          = projectConfigAllowNewer,
+      configWriteGhcEnvironmentFilesPolicy
+                                = projectConfigWriteGhcEnvironmentFilesPolicy
     } = configExFlags
 
     InstallFlags {
@@ -555,8 +557,9 @@ convertToLegacySharedConfig
       configPreferences   = projectConfigPreferences,
       configSolver        = projectConfigSolver,
       configAllowOlder    = projectConfigAllowOlder,
-      configAllowNewer    = projectConfigAllowNewer
-
+      configAllowNewer    = projectConfigAllowNewer,
+      configWriteGhcEnvironmentFilesPolicy
+                          = projectConfigWriteGhcEnvironmentFilesPolicy
     }
 
     installFlags = InstallFlags {
@@ -925,7 +928,7 @@ legacySharedConfigFieldDescrs =
         (\v conf -> conf { configAllowNewer = fmap AllowNewer v })
       ]
   . filterFields
-      [ "cabal-lib-version", "solver"
+      [ "cabal-lib-version", "solver", "write-ghc-environment-files"
         -- not "constraint" or "preference", we use our own plural ones above
       ]
   . commandOptionsToFields

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -21,7 +21,8 @@ module Distribution.Client.ProjectConfig.Types (
   ) where
 
 import Distribution.Client.Types
-         ( RemoteRepo, AllowNewer(..), AllowOlder(..) )
+         ( RemoteRepo, AllowNewer(..), AllowOlder(..)
+         , WriteGhcEnvironmentFilesPolicy )
 import Distribution.Client.Dependency.Types
          ( PreSolver )
 import Distribution.Client.Targets
@@ -187,6 +188,8 @@ data ProjectConfigShared
        projectConfigSolver            :: Flag PreSolver,
        projectConfigAllowOlder        :: Maybe AllowOlder,
        projectConfigAllowNewer        :: Maybe AllowNewer,
+       projectConfigWriteGhcEnvironmentFilesPolicy
+                                      :: Flag WriteGhcEnvironmentFilesPolicy,
        projectConfigMaxBackjumps      :: Flag Int,
        projectConfigReorderGoals      :: Flag ReorderGoals,
        projectConfigCountConflicts    :: Flag CountConflicts,

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -821,4 +821,3 @@ data SetupScriptStyle = SetupCustomExplicitDeps
   deriving (Eq, Show, Generic, Typeable)
 
 instance Binary SetupScriptStyle
-

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE LambdaCase          #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Setup
@@ -70,6 +71,7 @@ import Distribution.Client.Compat.Prelude hiding (get)
 import Distribution.Client.Types
          ( Username(..), Password(..), RemoteRepo(..)
          , AllowNewer(..), AllowOlder(..), RelaxDeps(..)
+         , WriteGhcEnvironmentFilesPolicy(..)
          )
 import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
@@ -637,12 +639,14 @@ configCompilerAux' configFlags =
 -- | cabal configure takes some extra flags beyond runghc Setup configure
 --
 data ConfigExFlags = ConfigExFlags {
-    configCabalVersion :: Flag Version,
-    configExConstraints:: [(UserConstraint, ConstraintSource)],
-    configPreferences  :: [PackageVersionConstraint],
-    configSolver       :: Flag PreSolver,
-    configAllowNewer   :: Maybe AllowNewer,
-    configAllowOlder   :: Maybe AllowOlder
+    configCabalVersion  :: Flag Version,
+    configExConstraints :: [(UserConstraint, ConstraintSource)],
+    configPreferences   :: [PackageVersionConstraint],
+    configSolver        :: Flag PreSolver,
+    configAllowNewer    :: Maybe AllowNewer,
+    configAllowOlder    :: Maybe AllowOlder,
+    configWriteGhcEnvironmentFilesPolicy
+      :: Flag WriteGhcEnvironmentFilesPolicy
   }
   deriving (Eq, Generic)
 
@@ -707,7 +711,32 @@ configureExOptions _showOrParseArgs src =
      (readP_to_E ("Cannot parse the list of packages: " ++) relaxDepsParser)
      (Just RelaxDepsAll) relaxDepsPrinter)
 
+  , option [] ["write-ghc-environment-files"]
+    ("Whether to create a .ghc.environment file after a successful build"
+      ++ " (v2-build only)")
+    configWriteGhcEnvironmentFilesPolicy
+    (\v flags -> flags { configWriteGhcEnvironmentFilesPolicy = v})
+    (reqArg "always|never|ghc8.4.4+"
+     writeGhcEnvironmentFilesPolicyParser
+     writeGhcEnvironmentFilesPolicyPrinter)
   ]
+
+
+writeGhcEnvironmentFilesPolicyParser :: ReadE (Flag WriteGhcEnvironmentFilesPolicy)
+writeGhcEnvironmentFilesPolicyParser = ReadE $ \case
+  "always"    -> Right $ Flag AlwaysWriteGhcEnvironmentFiles
+  "never"     -> Right $ Flag NeverWriteGhcEnvironmentFiles
+  "ghc8.4.4+" -> Right $ Flag WriteGhcEnvironmentFilesOnlyForGhc844AndNewer
+  policy      -> Left  $ "Cannot parse the GHC environment file write policy '"
+                 <> policy <> "'"
+
+writeGhcEnvironmentFilesPolicyPrinter
+  :: Flag WriteGhcEnvironmentFilesPolicy -> [String]
+writeGhcEnvironmentFilesPolicyPrinter = \case
+  (Flag AlwaysWriteGhcEnvironmentFiles)                -> ["always"]
+  (Flag NeverWriteGhcEnvironmentFiles)                 -> ["never"]
+  (Flag WriteGhcEnvironmentFilesOnlyForGhc844AndNewer) -> ["ghc8.4.4+"]
+  NoFlag                                               -> []
 
 
 relaxDepsParser :: Parse.ReadP r (Maybe RelaxDeps)

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -591,3 +591,19 @@ instance Monoid AllowNewer where
 instance Monoid AllowOlder where
   mempty  = AllowOlder mempty
   mappend = (<>)
+
+-- ------------------------------------------------------------
+-- * --write-ghc-environment-file
+-- ------------------------------------------------------------
+
+-- | Whether 'v2-build' should write a .ghc.environment file after
+-- success. Possible values: 'always', 'never', 'ghc8.4.4+' (the
+-- default; GHC 8.4.4 is the earliest version that supports
+-- '-pkg-env -').
+data WriteGhcEnvironmentFilesPolicy
+  = AlwaysWriteGhcEnvironmentFiles
+  | NeverWriteGhcEnvironmentFiles
+  | WriteGhcEnvironmentFilesOnlyForGhc844AndNewer
+  deriving (Eq, Generic, Show)
+
+instance Binary WriteGhcEnvironmentFilesPolicy

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -604,6 +604,6 @@ data WriteGhcEnvironmentFilesPolicy
   = AlwaysWriteGhcEnvironmentFiles
   | NeverWriteGhcEnvironmentFiles
   | WriteGhcEnvironmentFilesOnlyForGhc844AndNewer
-  deriving (Eq, Generic, Show)
+  deriving (Eq, Enum, Bounded, Generic, Show)
 
 instance Binary WriteGhcEnvironmentFilesPolicy

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -34,6 +34,7 @@ import Distribution.Simple.InstallDirs
 
 import Distribution.Utils.NubList
 
+import Distribution.Client.Types
 import Distribution.Client.IndexUtils.Timestamp
 
 import Test.QuickCheck
@@ -191,3 +192,6 @@ instance Arbitrary IndexState where
     arbitrary = frequency [ (1, pure IndexStateHead)
                           , (50, IndexStateTime <$> arbitrary)
                           ]
+
+instance Arbitrary WriteGhcEnvironmentFilesPolicy where
+    arbitrary = arbitraryBoundedEnum

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -436,6 +436,7 @@ instance Arbitrary ProjectConfigShared where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
+        <*> arbitrary
         <*> (toNubList <$> listOf arbitraryShortToken)
       where
         arbitraryConstraints :: Gen [(UserConstraint, ConstraintSource)]
@@ -457,17 +458,18 @@ instance Arbitrary ProjectConfigShared where
                                , projectConfigSolver = x12
                                , projectConfigAllowOlder = x13
                                , projectConfigAllowNewer = x14
-                               , projectConfigMaxBackjumps = x15
-                               , projectConfigReorderGoals = x16
-                               , projectConfigCountConflicts = x17
-                               , projectConfigStrongFlags = x18
-                               , projectConfigAllowBootLibInstalls = x19
-                               , projectConfigOnlyConstrained = x20
-                               , projectConfigPerComponent = x21
-                               , projectConfigIndependentGoals = x22
-                               , projectConfigConfigFile = x23
-                               , projectConfigProgPathExtra = x24
-                               , projectConfigStoreDir = x25 } =
+                               , projectConfigWriteGhcEnvironmentFilesPolicy = x15
+                               , projectConfigMaxBackjumps = x16
+                               , projectConfigReorderGoals = x17
+                               , projectConfigCountConflicts = x18
+                               , projectConfigStrongFlags = x19
+                               , projectConfigAllowBootLibInstalls = x20
+                               , projectConfigOnlyConstrained = x21
+                               , projectConfigPerComponent = x22
+                               , projectConfigIndependentGoals = x23
+                               , projectConfigConfigFile = x24
+                               , projectConfigProgPathExtra = x25
+                               , projectConfigStoreDir = x26 } =
       [ ProjectConfigShared { projectConfigDistDir = x00'
                             , projectConfigProjectFile = x01'
                             , projectConfigHcFlavor = x02'
@@ -483,28 +485,29 @@ instance Arbitrary ProjectConfigShared where
                             , projectConfigSolver = x12'
                             , projectConfigAllowOlder = x13'
                             , projectConfigAllowNewer = x14'
-                            , projectConfigMaxBackjumps = x15'
-                            , projectConfigReorderGoals = x16'
-                            , projectConfigCountConflicts = x17'
-                            , projectConfigStrongFlags = x18'
-                            , projectConfigAllowBootLibInstalls = x19'
-                            , projectConfigOnlyConstrained = x20'
-                            , projectConfigPerComponent = x21'
-                            , projectConfigIndependentGoals = x22'
-                            , projectConfigConfigFile = x23'
-                            , projectConfigProgPathExtra = x24'
-                            , projectConfigStoreDir = x25' }
+                            , projectConfigWriteGhcEnvironmentFilesPolicy = x15'
+                            , projectConfigMaxBackjumps = x16'
+                            , projectConfigReorderGoals = x17'
+                            , projectConfigCountConflicts = x18'
+                            , projectConfigStrongFlags = x19'
+                            , projectConfigAllowBootLibInstalls = x20'
+                            , projectConfigOnlyConstrained = x21'
+                            , projectConfigPerComponent = x22'
+                            , projectConfigIndependentGoals = x23'
+                            , projectConfigConfigFile = x24'
+                            , projectConfigProgPathExtra = x25'
+                            , projectConfigStoreDir = x26' }
       | ((x00', x01', x02', x03', x04'),
          (x05', x06', x07', x08', x09'),
-         (x10', x11', x12', x13', x14'),
-         (x15', x16', x17', x18', x19'),
-          x20', x21', x22', x23', x24', x25')
+         (x10', x11', x12', x13', x14', x15'),
+         (x16', x17', x18', x19', x20'),
+          x21', x22', x23', x24', x25', x26')
           <- shrink
                ((x00, x01, x02, fmap NonEmpty x03, fmap NonEmpty x04),
                 (x05, x06, x07, x08, preShrink_Constraints x09),
-                (x10, x11, x12, x13, x14),
-                (x15, x16, x17, x18, x19),
-                 x20, x21, x22, x23, x24, x25)
+                (x10, x11, x12, x13, x14, x15),
+                (x16, x17, x18, x19, x20),
+                 x21, x22, x23, x24, x25, x26)
       ]
       where
         preShrink_Constraints  = map fst

--- a/cabal-testsuite/PackageTests/NewBuild/CmdExec/GhcInvocation/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdExec/GhcInvocation/cabal.test.hs
@@ -10,9 +10,8 @@ main = cabalTest $ do
     cabal "new-exec" ["ghc", "--", "Main.hs", "-o", dest]
     -- TODO external (store) deps, once new-install is working
 
+-- copy-pasted from D.C.CmdClean.
 removeEnvFiles :: FilePath -> IO ()
-removeEnvFiles dir = (mapM_ (removeFile . (dir </>))
-                   . filter
-                       ((".ghc.environment" ==)
-                       . take 16))
-                   =<< getDirectoryContents dir
+removeEnvFiles dir =
+  (mapM_ (removeFile . (dir </>)) . filter ((".ghc.environment" ==) . take 16))
+  =<< getDirectoryContents dir

--- a/cabal-testsuite/PackageTests/NewBuild/CmdExec/GhcInvocation/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdExec/GhcInvocation/cabal.test.hs
@@ -16,4 +16,3 @@ removeEnvFiles dir = (mapM_ (removeFile . (dir </>))
                        ((".ghc.environment" ==)
                        . take 16))
                    =<< getDirectoryContents dir
-


### PR DESCRIPTION
* Add a config flag to control generation of `.ghc.environment` files. Fixes #4542.
* Change `new-clean` to also remove `.ghc.environment` files. Fixes #5587.

This is the final blocker before the 2.4.1.0 release.

I haven't updated the docs yet, will do tomorrow.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
