### PR TITLE
Remove Text from D.PackageDescription

### DIFF
--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -51,7 +51,7 @@ import Distribution.PackageDescription
 import Distribution.Parsec.Common
 import Distribution.Parsec.Newtypes
 import Distribution.Parsec.ParseResult
-import Distribution.Text                      (display)
+import Distribution.Pretty                    (prettyShow)
 import Distribution.Types.ExecutableScope
 import Distribution.Types.ForeignLib
 import Distribution.Types.ForeignLibType
@@ -249,10 +249,10 @@ validateTestSuite pos stanza = case _testStanzaTestType stanza of
 
   where
     missingField name tt = "The '" ++ name ++ "' field is required for the "
-                        ++ display tt ++ " test suite type."
+                        ++ prettyShow tt ++ " test suite type."
 
     extraField   name tt = "The '" ++ name ++ "' field is not used for the '"
-                        ++ display tt ++ "' test suite type."
+                        ++ prettyShow tt ++ "' test suite type."
 
 unvalidateTestSuite :: TestSuite -> TestSuiteStanza
 unvalidateTestSuite t = TestSuiteStanza
@@ -337,10 +337,10 @@ validateBenchmark pos stanza = case _benchmarkStanzaBenchmarkType stanza of
 
   where
     missingField name tt = "The '" ++ name ++ "' field is required for the "
-                        ++ display tt ++ " benchmark type."
+                        ++ prettyShow tt ++ " benchmark type."
 
     extraField   name tt = "The '" ++ name ++ "' field is not used for the '"
-                        ++ display tt ++ "' benchmark type."
+                        ++ prettyShow tt ++ "' benchmark type."
 
 unvalidateBenchmark :: Benchmark -> BenchmarkStanza
 unvalidateBenchmark b = BenchmarkStanza

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -57,7 +57,6 @@ import Distribution.Parsec.Parser
 import Distribution.Parsec.ParseResult
 import Distribution.Pretty                          (prettyShow)
 import Distribution.Simple.Utils                    (fromUTF8BS)
-import Distribution.Text                            (display)
 import Distribution.Types.CondTree
 import Distribution.Types.Dependency                (Dependency)
 import Distribution.Types.ForeignLib
@@ -221,11 +220,11 @@ parseGenericPackageDescription' cabalVerM lexWarnings utf8WarnPos fs = do
           ++ displaySpecVersion (specVersionRaw pkg)
           ++ "' must use section syntax. See the Cabal user guide for details."
       where
-        displaySpecVersion (Left version)       = display version
+        displaySpecVersion (Left version)       = prettyShow version
         displaySpecVersion (Right versionRange) =
           case asVersionIntervals versionRange of
-            [] {- impossible -}           -> display versionRange
-            ((LowerBound version _, _):_) -> display (orLaterVersion version)
+            [] {- impossible -}           -> prettyShow versionRange
+            ((LowerBound version _, _):_) -> prettyShow (orLaterVersion version)
 
     maybeWarnCabalVersion _ _ = return ()
 
@@ -289,11 +288,11 @@ goSections specVer = traverse_ process
 
             let hasType ts = foreignLibType ts /= foreignLibType mempty
             unless (onAllBranches hasType flib) $ lift $ parseFailure pos $ concat
-                [ "Foreign library " ++ show (display name')
+                [ "Foreign library " ++ show (prettyShow name')
                 , " is missing required field \"type\" or the field "
                 , "is not present in all conditional branches. The "
                 , "available test types are: "
-                , intercalate ", " (map display knownForeignLibTypes)
+                , intercalate ", " (map prettyShow knownForeignLibTypes)
                 ]
 
             -- TODO check duplicate name here?
@@ -314,11 +313,11 @@ goSections specVer = traverse_ process
 
             let hasType ts = testInterface ts /= testInterface mempty
             unless (onAllBranches hasType testSuite) $ lift $ parseFailure pos $ concat
-                [ "Test suite " ++ show (display name')
+                [ "Test suite " ++ show (prettyShow name')
                 , " is missing required field \"type\" or the field "
                 , "is not present in all conditional branches. The "
                 , "available test types are: "
-                , intercalate ", " (map display knownTestTypes)
+                , intercalate ", " (map prettyShow knownTestTypes)
                 ]
 
             -- TODO check duplicate name here?
@@ -332,11 +331,11 @@ goSections specVer = traverse_ process
 
             let hasType ts = benchmarkInterface ts /= benchmarkInterface mempty
             unless (onAllBranches hasType bench) $ lift $ parseFailure pos $ concat
-                [ "Benchmark " ++ show (display name')
+                [ "Benchmark " ++ show (prettyShow name')
                 , " is missing required field \"type\" or the field "
                 , "is not present in all conditional branches. The "
                 , "available benchmark types are: "
-                , intercalate ", " (map display knownBenchmarkTypes)
+                , intercalate ", " (map prettyShow knownBenchmarkTypes)
                 ]
 
             -- TODO check duplicate name here?

--- a/Cabal/Distribution/PackageDescription/PrettyPrint.hs
+++ b/Cabal/Distribution/PackageDescription/PrettyPrint.hs
@@ -37,7 +37,7 @@ import Distribution.Types.CondTree
 import Distribution.PackageDescription
 import Distribution.Simple.Utils
 import Distribution.ParseUtils
-import Distribution.Text
+import Distribution.Pretty
 
 import Distribution.FieldGrammar (PrettyFieldGrammar', prettyFieldGrammar)
 import Distribution.PackageDescription.FieldGrammar
@@ -85,7 +85,7 @@ ppSourceRepos (hd:tl)                    = ppSourceRepo hd $+$ ppSourceRepos tl
 
 ppSourceRepo :: SourceRepo -> Doc
 ppSourceRepo repo =
-    emptyLine $ text "source-repository" <+> disp kind $+$
+    emptyLine $ text "source-repository" <+> pretty kind $+$
     nest indentWith (prettyFieldGrammar (sourceRepoFieldGrammar kind) repo)
   where
     kind = repoKind repo
@@ -140,35 +140,35 @@ ppCondLibrary (Just condTree) =
 
 ppCondSubLibraries :: [(UnqualComponentName, CondTree ConfVar [Dependency] Library)] -> Doc
 ppCondSubLibraries libs = vcat
-    [ emptyLine $ (text "library" <+> disp n) $+$
+    [ emptyLine $ (text "library" <+> pretty n) $+$
       nest indentWith (ppCondTree2 (libraryFieldGrammar $ Just n) condTree)
     | (n, condTree) <- libs
     ]
 
 ppCondForeignLibs :: [(UnqualComponentName, CondTree ConfVar [Dependency] ForeignLib)] -> Doc
 ppCondForeignLibs flibs = vcat
-    [ emptyLine $ (text "foreign-library" <+> disp n) $+$
+    [ emptyLine $ (text "foreign-library" <+> pretty n) $+$
       nest indentWith (ppCondTree2 (foreignLibFieldGrammar n) condTree)
     | (n, condTree) <- flibs
     ]
 
 ppCondExecutables :: [(UnqualComponentName, CondTree ConfVar [Dependency] Executable)] -> Doc
 ppCondExecutables exes = vcat
-    [ emptyLine $ (text "executable" <+> disp n) $+$
+    [ emptyLine $ (text "executable" <+> pretty n) $+$
       nest indentWith (ppCondTree2 (executableFieldGrammar n) condTree)
     | (n, condTree) <- exes
     ]
 
 ppCondTestSuites :: [(UnqualComponentName, CondTree ConfVar [Dependency] TestSuite)] -> Doc
 ppCondTestSuites suites = vcat
-    [ emptyLine $ (text "test-suite" <+> disp n) $+$
+    [ emptyLine $ (text "test-suite" <+> pretty n) $+$
       nest indentWith (ppCondTree2 testSuiteFieldGrammar (fmap FG.unvalidateTestSuite condTree))
     | (n, condTree) <- suites
     ]
 
 ppCondBenchmarks :: [(UnqualComponentName, CondTree ConfVar [Dependency] Benchmark)] -> Doc
 ppCondBenchmarks suites = vcat
-    [ emptyLine $ (text "benchmark" <+> disp n) $+$
+    [ emptyLine $ (text "benchmark" <+> pretty n) $+$
       nest indentWith (ppCondTree2 benchmarkFieldGrammar (fmap FG.unvalidateBenchmark condTree))
     | (n, condTree) <- suites
     ]
@@ -182,10 +182,10 @@ ppCondition (COr c1 c2)                  = parens (hsep [ppCondition c1, text "|
 ppCondition (CAnd c1 c2)                 = parens (hsep [ppCondition c1, text "&&"
                                                          <+> ppCondition c2])
 ppConfVar :: ConfVar -> Doc
-ppConfVar (OS os)                        = text "os"   <<>> parens (disp os)
-ppConfVar (Arch arch)                    = text "arch" <<>> parens (disp arch)
+ppConfVar (OS os)                        = text "os"   <<>> parens (pretty os)
+ppConfVar (Arch arch)                    = text "arch" <<>> parens (pretty arch)
 ppConfVar (Flag name)                    = text "flag" <<>> parens (ppFlagName name)
-ppConfVar (Impl c v)                     = text "impl" <<>> parens (disp c <+> disp v)
+ppConfVar (Impl c v)                     = text "impl" <<>> parens (pretty c <+> pretty v)
 
 ppFlagName :: FlagName -> Doc
 ppFlagName                               = text . unFlagName
@@ -240,7 +240,7 @@ showHookedBuildInfo (mb_lib_bi, ex_bis) = render $
     maybe mempty (prettyFieldGrammar buildInfoFieldGrammar) mb_lib_bi
     $$ vcat
         [ space
-        $$ (text "executable:" <+> disp name)
+        $$ (text "executable:" <+> pretty name)
         $$  prettyFieldGrammar buildInfoFieldGrammar bi
         | (name, bi) <- ex_bis
         ]


### PR DESCRIPTION
Next in series to get rid of ReadP

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
