### PR TITLE
Improve printing of errors of parsing .cabal files even further

### DIFF
--- a/cabal-install/Distribution/Client/Check.hs
+++ b/cabal-install/Distribution/Client/Check.hs
@@ -16,9 +16,11 @@ module Distribution.Client.Check (
     check
   ) where
 
+
 import Distribution.Client.Compat.Prelude
 import Prelude ()
 
+import Distribution.Client.Utils.Parsec              (renderParseError)
 import Distribution.PackageDescription               (GenericPackageDescription)
 import Distribution.PackageDescription.Check
 import Distribution.PackageDescription.Configuration (flattenPackageDescription)
@@ -42,7 +44,7 @@ readGenericPackageDescriptionCheck verbosity fpath = do
     case result of
         Left (_, errors) -> do
             traverse_ (warn verbosity . showPError fpath) errors
-            die' verbosity $ "Failed parsing \"" ++ fpath ++ "\"."
+            die' verbosity $ renderParseError fpath bs errors warnings
         Right x  -> return (warnings, x)
 
 -- | Note: must be called with the CWD set to the directory containing

--- a/cabal-install/Distribution/Client/Utils/Parsec.hs
+++ b/cabal-install/Distribution/Client/Utils/Parsec.hs
@@ -1,0 +1,65 @@
+module Distribution.Client.Utils.Parsec (
+    renderParseError,
+    ) where
+
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
+import qualified Data.ByteString       as BS
+import qualified Data.ByteString.Char8 as BS8
+
+import Distribution.Parsec.Common
+       (PError (..), PWarning (..), Position (..), showPError, showPWarning, zeroPos)
+import Distribution.Simple.Utils  (fromUTF8BS)
+
+-- | Render parse error highlighting the part of the input file.
+renderParseError
+    :: FilePath
+    -> BS.ByteString
+    -> [PError]
+    -> [PWarning]
+    -> String
+renderParseError filepath contents errors warnings = unlines $
+    [ "Errors encountered when parsing cabal file " <> filepath <> ":"
+    ]
+    ++ renderedErrors
+    ++ renderedWarnings
+  where
+    -- lines of the input file.
+    ls = BS8.lines contents
+
+    nths :: Int -> [a] -> [a]
+    nths n | n <= 0 = take 2
+    nths n = take 3 . drop (n - 1)
+
+    -- empty line before each error and warning
+    renderedErrors   = concatMap (prepend . renderError) errors
+    renderedWarnings = concatMap (prepend . renderWarning) warnings
+
+    prepend = ("" :)
+
+    renderError :: PError -> [String]
+    renderError e@(PError pos@(Position row _col) _)
+        -- if position is 0:0, then it doesn't make sense to show input
+        -- looks like, Parsec errors have line-feed in them
+        | pos == zeroPos = [trim $ showPError filepath e]
+        | otherwise      = [trim $ showPError filepath e, ""] ++
+            zipWith formatInputLine (nths (row - 1) ls) [row - 1 ..]
+
+    -- sometimes there are (especially trailing) newlines.
+    trim = dropWhile (== '\n') . reverse . dropWhile (== '\n') . reverse
+
+    renderWarning :: PWarning -> [String]
+    renderWarning w@(PWarning _ pos@(Position row _col) _)
+        | pos == zeroPos = [showPWarning filepath w]
+        | otherwise      = [showPWarning filepath w, ""] ++
+            zipWith formatInputLine (nths (row - 1) ls) [row - 1 ..]
+
+    -- format line: prepend the given line number
+    formatInputLine :: BS.ByteString -> Int -> String
+    formatInputLine bs l =
+        showN l ++ " | " ++ fromUTF8BS bs
+
+    -- hopefully we don't need to work with over 99999 lines .cabal files
+    -- at that point small glitches in error messages are hopefully fine.
+    showN n = let s = show n in replicate (5 - length s) ' ' ++ s

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -243,6 +243,7 @@ executable cabal
         Distribution.Client.Utils
         Distribution.Client.Utils.Assertion
         Distribution.Client.Utils.Json
+        Distribution.Client.Utils.Parsec
         Distribution.Client.VCS
         Distribution.Client.Win32SelfUpgrade
         Distribution.Client.World

--- a/cabal-install/cabal-install.cabal.pp
+++ b/cabal-install/cabal-install.cabal.pp
@@ -169,6 +169,7 @@ Version:            2.5.0.0
         Distribution.Client.Utils
         Distribution.Client.Utils.Assertion
         Distribution.Client.Utils.Json
+        Distribution.Client.Utils.Parsec
         Distribution.Client.VCS
         Distribution.Client.Win32SelfUpgrade
         Distribution.Client.World


### PR DESCRIPTION
- Separate the logic into own module
- Use same function in `cabal check` codepath
- Tweak the output a little more

```
% cabal check
Warning: tree-diff.cabal:88:5:
unexpected 't'
expecting space, "&&", white space, "||", comma or end of input
cabal: Errors encountered when parsing cabal file ./tree-diff.cabal:

tree-diff.cabal:88:5:
unexpected 't'
expecting space, "&&", white space, "||", comma or end of input

87 | tagged >=0.8.5 && <0.9
88 | text >=1.2.2.2 && <1.3,
89 | time >=1.4.2 && <1.9,

tree-diff.cabal:70:3: Unknown field: "build-depend"

69 | Data.TreeDiff.QuickCheck
70 | build-depend: base
71 | build-depends:

tree-diff.cabal:59:3: Unknown field: "build-depend"

58 | library
59 | build-depend: base
60 | exposed-modules:

```

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
