### PR TITLE
Update pretty printing to use 2 space indent.

### DIFF
--- a/Cabal/Distribution/Pretty.hs
+++ b/Cabal/Distribution/Pretty.hs
@@ -92,4 +92,4 @@ lines_ s  =
 
 -- | the indentation used for pretty printing
 indentWith :: Int
-indentWith = 4
+indentWith = 2


### PR DESCRIPTION
This is inline with all the documentation and examples I've seen throughout the cabal docs, as well as all cabal file templates I've seen in the wild and those constructed with stack and summoner (the two other leading ways to initialize a project). It appears that `cabal format` hasn't been released yet so this is unlikely to cause a large number of diffs.

/cc @phadej who made the original change.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
