### PR TITLE
bump base bounds

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -300,7 +300,7 @@ executable cabal
     build-depends:
         async      >= 2.0      && < 3,
         array      >= 0.4      && < 0.6,
-        base       >= 4.6      && < 5,
+        base       >= 4.8      && < 5,
         base16-bytestring >= 0.1.1 && < 0.2,
         binary     >= 0.7      && < 0.9,
         bytestring >= 0.10.2   && < 1,


### PR DESCRIPTION
Currently, building `cabal-install` with GHC 7.8.4 will fail. This updates the `.cabal` file to reflect that fact. 

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.
