### PR TITLE
Remove fields in cabal spec 3.0

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -59,6 +59,8 @@ extra-source-files:
   tests/ParserTests/errors/noVersion2.errors
   tests/ParserTests/errors/range-ge-wild.cabal
   tests/ParserTests/errors/range-ge-wild.errors
+  tests/ParserTests/errors/removed-fields.cabal
+  tests/ParserTests/errors/removed-fields.errors
   tests/ParserTests/errors/spdx-1.cabal
   tests/ParserTests/errors/spdx-1.errors
   tests/ParserTests/errors/spdx-2.cabal

--- a/Cabal/Distribution/FieldGrammar/Class.hs
+++ b/Cabal/Distribution/FieldGrammar/Class.hs
@@ -95,6 +95,13 @@ class FieldGrammar g where
         -> g s a
         -> g s a
 
+    -- | Removed in. If we occur removed field, parsing fails.
+    removedIn
+        :: CabalSpecVersion   -- ^ version
+        -> String             -- ^ removal message
+        -> g s a
+        -> g s a
+
     -- | Annotate field with since spec-version.
     availableSince
         :: CabalSpecVersion  -- ^ spec version

--- a/Cabal/Distribution/FieldGrammar/FieldDescrs.hs
+++ b/Cabal/Distribution/FieldGrammar/FieldDescrs.hs
@@ -82,5 +82,6 @@ instance FieldGrammar FieldDescrs where
     prefixedFields _fnPfx _l = F mempty
     knownField _           = pure ()
     deprecatedSince _  _ x = x
+    removedIn _ _ x        = x
     availableSince _ _     = id
     hiddenField _          = F mempty

--- a/Cabal/Distribution/FieldGrammar/Pretty.hs
+++ b/Cabal/Distribution/FieldGrammar/Pretty.hs
@@ -75,7 +75,11 @@ instance FieldGrammar PrettyFieldGrammar where
             ]
 
     knownField _           = pure ()
-    deprecatedSince _  _ x = x
+    deprecatedSince _ _ x  = x
+    -- TODO: as PrettyFieldGrammar isn't aware of cabal-version: we output the field
+    -- this doesn't affect roundtrip as `removedIn` fields cannot be parsed
+    -- so invalid documents can be only manually constructed.
+    removedIn _ _ x        = x
     availableSince _ _     = id
     hiddenField _          = PrettyFG (\_ -> mempty)
 

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -380,6 +380,8 @@ buildInfoFieldGrammar = BuildInfo
     <*> monoidalFieldAla "build-tools"          (alaList  CommaFSep)          L.buildTools
         ^^^ deprecatedSince CabalSpecV2_0
             "Please use 'build-tool-depends' field"
+        ^^^ removedIn CabalSpecV3_0
+            "Please use 'build-tool-depends' field."
     <*> monoidalFieldAla "build-tool-depends"   (alaList  CommaFSep)          L.buildToolDepends
         -- {- ^^^ availableSince [2,0] [] -}
         -- here, we explicitly want to recognise build-tool-depends for all Cabal files
@@ -414,6 +416,8 @@ buildInfoFieldGrammar = BuildInfo
     <*> monoidalFieldAla "extensions"           (alaList' FSep MQuoted)       L.oldExtensions
         ^^^ deprecatedSince CabalSpecV1_12
             "Please use 'default-extensions' or 'other-extensions' fields."
+        ^^^ removedIn CabalSpecV3_0
+            "Please use 'default-extensions' or 'other-extensions' fields."
     <*> monoidalFieldAla "extra-libraries"      (alaList' VCat Token)         L.extraLibs
     <*> monoidalFieldAla "extra-ghci-libraries" (alaList' VCat Token)         L.extraGHCiLibs
     <*> monoidalFieldAla "extra-bundled-libraries" (alaList' VCat Token)      L.extraBundledLibs
@@ -443,6 +447,7 @@ hsSourceDirsGrammar = (++)
     <*> monoidalFieldAla "hs-source-dir"  (alaList' FSep FilePathNT) wrongLens
         --- https://github.com/haskell/cabal/commit/49e3cdae3bdf21b017ccd42e66670ca402e22b44
         ^^^ deprecatedSince CabalSpecV1_2 "Please use 'hs-source-dirs'"
+        ^^^ removedIn CabalSpecV3_0 "Please use 'hs-source-dirs' field."
   where
     -- TODO: make pretty printer aware of CabalSpecVersion
     wrongLens :: Functor f => LensLike' f BuildInfo [FilePath]

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2173,7 +2173,8 @@ system-dependent values for these fields.
     :pkg-field:`other-extensions` declarations.
 
 .. pkg-field:: extensions: identifier list
-   :deprecated:
+   :deprecated: 1.12
+   :removed: 3.0
 
    Deprecated in favor of :pkg-field:`default-extensions`.
 
@@ -2230,7 +2231,8 @@ system-dependent values for these fields.
       compatibility.
 
 .. pkg-field:: build-tools: program list
-    :deprecated:
+    :deprecated: 2.0
+    :removed: 3.0
 
     Deprecated in favor of :pkg-field:`build-tool-depends`, but :ref:`see below for backwards compatibility information <buildtoolsbc>`.
 

--- a/Cabal/doc/file-format-changelog.rst
+++ b/Cabal/doc/file-format-changelog.rst
@@ -22,12 +22,15 @@ relative to the respective preceding *published* version.
 ``cabal-version: 3.0``
 ----------------------
 
-* Added the `extra-dynamic-library-flavours` field to specify non-trivial
-  variants of dynamic flavours. It is `extra-library-flavours` but for
+* Added the :pkg-field:`extra-dynamic-library-flavours` field to specify non-trivial
+  variants of dynamic flavours. It is :pkg-field:`extra-library-flavours` but for
   shared libraries. Mainly useful for GHC's RTS library.
 
 * License fields use identifiers from SPDX License List version
   ``3.3 2018-10-24``
+
+* Remove deprecated ``hs-source-dir``, :pkg-field:`extensions` and
+  :pkg-field:`build-tools` fields.
 
 ``cabal-version: 2.4``
 ----------------------

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -106,6 +106,7 @@ errorTests = testGroup "errors"
     , errorTest "spdx-1.cabal"
     , errorTest "spdx-2.cabal"
     , errorTest "spdx-3.cabal"
+    , errorTest "removed-fields.cabal"
     ]
 
 errorTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests/errors/removed-fields.cabal
+++ b/Cabal/tests/ParserTests/errors/removed-fields.cabal
@@ -1,0 +1,14 @@
+cabal-version:       2.5
+name:                removed-fields
+version:             0
+synopsis:            some fields are removed
+build-type:          Simple
+
+library
+  default-language: Haskell2010
+  exposed-modules:  RemovedFields
+
+  build-depends: base, containers
+
+  extensions: CPP
+  extensions: DeriveFunctor

--- a/Cabal/tests/ParserTests/errors/removed-fields.errors
+++ b/Cabal/tests/ParserTests/errors/removed-fields.errors
@@ -1,0 +1,3 @@
+VERSION: Just (mkVersion [2,5])
+removed-fields.cabal:13:3: The field "extensions" is removed in the Cabal specification version 3.0. Please use 'default-extensions' or 'other-extensions' fields.
+removed-fields.cabal:14:3: The field "extensions" is removed in the Cabal specification version 3.0. Please use 'default-extensions' or 'other-extensions' fields.


### PR DESCRIPTION
- extensions
- (singular) hs-source-dir
- build-tools

Example, with `cabal-version: 2.5`

```
[laptop] tree-diff % cabal new-build --dry
Errors encountered when parsing cabal file ./tree-diff.cabal:

tree-diff.cabal:59:3: error:
The field "extensions" is removed in the Cabal specification version 2.5. Please use 'default-extensions' or 'other-extensions' fields.

   58 | library
   59 |   extensions: CPP
      |   ^

tree-diff.cabal:60:3: error:
The field "extensions" is removed in the Cabal specification version 2.5. Please use 'default-extensions' or 'other-extensions' fields.

   59 |   extensions: CPP
   60 |   extensions: DeriveGeneric
      |   ^
```

Resolves https://github.com/haskell/cabal/issues/5726

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
