### PR TITLE
Remove unix constraint from cabal.project (forward port)

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -168,7 +168,6 @@ timed $CABALNEWBUILD cabal-testsuite --enable-tests --disable-benchmarks --dry-r
 timed $CABALNEWBUILD cabal-testsuite --enable-tests --disable-benchmarks --dep || exit 1
 timed $CABALNEWBUILD cabal-testsuite --enable-tests --disable-benchmarks || exit 1
 
-
 if $CABALSUITETESTS; then
 echo "$CYAN=== cabal-testsuite: Cabal test ======================== $(date +%T) === $RESET"
 


### PR DESCRIPTION
- Add bunch of installed constraints to cabal.project.local.travis
- Fix compat in D.Compat.Directory
- Compat (process-1.1/ghc-7.6) in cabal-testsuite
- validate.sh improvements
- Warningless cabal-testsuite build

Forward port of #5730 

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
