### PR TITLE
Remove support for `.zip` format source distributions

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -5,7 +5,7 @@ Quickstart
 
 Suppose that you are in a directory containing a single Cabal package
 which you wish to build (if you haven't set up a package yet check
-out `developing packages <developing-packages.html>`__ for 
+out `developing packages <developing-packages.html>`__ for
 instructions). You can configure and build it using Nix-style
 local builds with this command (configuring is not necessary):
 
@@ -141,8 +141,8 @@ identify the result of a build; if we compute this identifier and we
 find that we already have this ID built, we can just use the already
 built version.
 
-The global package store is ``~/.cabal/store`` (configurable via 
-global `store-dir` option); if you need to clear your store for 
+The global package store is ``~/.cabal/store`` (configurable via
+global `store-dir` option); if you need to clear your store for
 whatever reason (e.g., to reclaim disk space or because the global
 store is corrupted), deleting this directory is safe (``new-build``
 will just rebuild everything it needs on its next invocation).
@@ -411,7 +411,7 @@ them manually or to install them globally.
 This command opens a REPL with the current default target loaded, and a version
 of the ``vector`` package matching that specification exposed.
 
-:: 
+::
 
     $ cabal new-repl --build-depends "vector >= 0.12 && < 0.13"
 
@@ -540,7 +540,7 @@ invocations and bringing the project's executables into scope.
 cabal new-install
 -----------------
 
-``cabal new-install [FLAGS] PACKAGES`` builds the specified packages and 
+``cabal new-install [FLAGS] PACKAGES`` builds the specified packages and
 symlinks their executables in ``symlink-bindir`` (usually ``~/.cabal/bin``).
 
 For example this command will build the latest ``cabal-install`` and symlink
@@ -559,7 +559,7 @@ repository, this command will build cabal-install HEAD and symlink the
 
     $ cabal new-install exe:cabal
 
-It is also possible to "install" libraries using the ``--lib`` flag. For 
+It is also possible to "install" libraries using the ``--lib`` flag. For
 example, this command will build the latest Cabal library and install it:
 
 ::
@@ -629,10 +629,6 @@ and two archives of the same format built from the same source will hash to the 
 - ``-l``, ``--list-only``: Rather than creating an archive, lists files that would be included.
   Output is to ``stdout`` by default. The file paths are relative to the project's root
   directory.
-
-- ``--targz``: Output an archive in ``.tar.gz`` format.
-
-- ``--zip``: Output an archive in ``.zip`` format.
 
 - ``-o``, ``--output-dir``: Sets the output dir, if a non-default one is desired. The default is
   ``dist-newstyle/sdist/``. ``--output-dir -`` will send output to ``stdout``
@@ -895,7 +891,7 @@ package, and thus apply globally:
 .. option:: --store-dir=DIR
 
     Specifies the name of the directory of the global package store.
-    
+
 Solver configuration options
 ----------------------------
 
@@ -908,7 +904,7 @@ The following settings control the behavior of the dependency solver:
     Add extra constraints to the version bounds, flag settings,
     and other properties a solver can pick for a
     package. For example:
-               
+
     ::
 
         constraints: bar == 2.1

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -375,7 +375,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
             unless (Map.null targets) $
               mapM_
                 (\(SpecificSourcePackage pkg) -> packageToSdist verbosity
-                  (distProjectRootDirectory localDistDirLayout) TargzFormat
+                  (distProjectRootDirectory localDistDirLayout) TarGzArchive
                   (distSdistFile localDistDirLayout (packageId pkg)) pkg
                 ) (localPackages localBaseCtx)
 

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -375,7 +375,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
             unless (Map.null targets) $
               mapM_
                 (\(SpecificSourcePackage pkg) -> packageToSdist verbosity
-                  (distProjectRootDirectory localDistDirLayout) Tarball
+                  (distProjectRootDirectory localDistDirLayout) TargzFormat
                   (distSdistFile localDistDirLayout (packageId pkg)) pkg
                 ) (localPackages localBaseCtx)
 

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -323,7 +323,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
                         , unlines (("- " ++) . unPackageName . fst <$> xs)
                         ]
                   _ -> return ()
-    
+
                 when (not . null $ errs') $ reportTargetProblems verbosity errs'
 
                 let
@@ -351,7 +351,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
 
               sdistize (SpecificSourcePackage spkg@SourcePackage{..}) = SpecificSourcePackage spkg'
                 where
-                  sdistPath = distSdistFile localDistDirLayout packageInfoId TargzFormat
+                  sdistPath = distSdistFile localDistDirLayout packageInfoId
                   spkg' = spkg { packageSource = LocalTarballPackage sdistPath }
               sdistize named = named
 
@@ -375,8 +375,8 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
             unless (Map.null targets) $
               mapM_
                 (\(SpecificSourcePackage pkg) -> packageToSdist verbosity
-                  (distProjectRootDirectory localDistDirLayout) (Archive TargzFormat)
-                  (distSdistFile localDistDirLayout (packageId pkg) TargzFormat) pkg
+                  (distProjectRootDirectory localDistDirLayout) Tarball
+                  (distSdistFile localDistDirLayout (packageId pkg)) pkg
                 ) (localPackages localBaseCtx)
 
             if null targets
@@ -391,9 +391,9 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
           | Just (pkg :: PackageId) <- simpleParse pkgName = return pkg
           | otherwise = die' verbosity ("Invalid package ID: " ++ pkgName)
       packageIds <- mapM parsePkg targetStrings
-      
+
       cabalDir <- getCabalDir
-      let 
+      let
         projectConfig = globalConfig <> cliConfig
 
         ProjectConfigBuildOnly {
@@ -413,7 +413,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
                           projectConfig
 
       SourcePackageDb { packageIndex } <- projectConfigWithBuilderRepoContext
-                                            verbosity buildSettings 
+                                            verbosity buildSettings
                                             (getSourcePackages verbosity)
 
       for_ targetStrings $ \case
@@ -724,7 +724,7 @@ entriesForLibraryComponents = Map.foldrWithKey' (\k v -> mappend (go k v)) []
     hasLib :: (ComponentTarget, [TargetSelector]) -> Bool
     hasLib (ComponentTarget (CLibName _) _, _) = True
     hasLib _                                   = False
-    
+
     go :: UnitId -> [(ComponentTarget, [TargetSelector])] -> [GhcEnvironmentFileEntry]
     go unitId targets
       | any hasLib targets = [GhcEnvFilePackageId unitId]

--- a/cabal-install/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/Distribution/Client/CmdSdist.hs
@@ -170,7 +170,7 @@ sdistAction SdistFlags{..} targetStrings globalFlags = do
         format =
             if | listSources, nulSeparated -> SourceList '\0'
                | listSources               -> SourceList '\n'
-               | otherwise                 -> TargzFormat
+               | otherwise                 -> TarGzArchive
 
         outputPath pkg = case mOutputPath' of
             Just path
@@ -194,7 +194,7 @@ data IsExec = Exec | NoExec
             deriving (Show, Eq)
 
 data OutputFormat = SourceList Char
-                  | TargzFormat
+                  | TarGzArchive
                   deriving (Show, Eq)
 
 packageToSdist :: Verbosity -> FilePath -> OutputFormat -> FilePath -> UnresolvedSourcePackage -> IO ()
@@ -216,7 +216,7 @@ packageToSdist verbosity projectRootDir format outputFile pkg = do
     case dir0 of
       Left tgz -> do
         case format of
-          TargzFormat -> do
+          TarGzArchive -> do
             write =<< BSL.readFile tgz
             when (outputFile /= "-") $
               notice verbosity $ "Wrote tarball sdist to " ++ outputFile ++ "\n"
@@ -238,7 +238,7 @@ packageToSdist verbosity projectRootDir format outputFile pkg = do
                 write (BSL.pack . (++ [nulSep]) . intercalate [nulSep] . fmap ((prefix </>) . snd) $ files)
                 when (outputFile /= "-") $
                     notice verbosity $ "Wrote source list to " ++ outputFile ++ "\n"
-            TargzFormat -> do
+            TarGzArchive -> do
                 let entriesM :: StateT (Set.Set FilePath) (WriterT [Tar.Entry] IO) ()
                     entriesM = do
                         let prefix = prettyShow (packageId pkg)

--- a/cabal-install/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/Distribution/Client/CmdSdist.hs
@@ -170,7 +170,7 @@ sdistAction SdistFlags{..} targetStrings globalFlags = do
         format =
             if | listSources, nulSeparated -> SourceList '\0'
                | listSources               -> SourceList '\n'
-               | otherwise                 -> Tarball
+               | otherwise                 -> TargzFormat
 
         outputPath pkg = case mOutputPath' of
             Just path
@@ -194,7 +194,7 @@ data IsExec = Exec | NoExec
             deriving (Show, Eq)
 
 data OutputFormat = SourceList Char
-                  | Tarball
+                  | TargzFormat
                   deriving (Show, Eq)
 
 packageToSdist :: Verbosity -> FilePath -> OutputFormat -> FilePath -> UnresolvedSourcePackage -> IO ()
@@ -216,7 +216,7 @@ packageToSdist verbosity projectRootDir format outputFile pkg = do
     case dir0 of
       Left tgz -> do
         case format of
-          Tarball -> do
+          TargzFormat -> do
             write =<< BSL.readFile tgz
             when (outputFile /= "-") $
               notice verbosity $ "Wrote tarball sdist to " ++ outputFile ++ "\n"
@@ -238,7 +238,7 @@ packageToSdist verbosity projectRootDir format outputFile pkg = do
                 write (BSL.pack . (++ [nulSep]) . intercalate [nulSep] . fmap ((prefix </>) . snd) $ files)
                 when (outputFile /= "-") $
                     notice verbosity $ "Wrote source list to " ++ outputFile ++ "\n"
-            Tarball -> do
+            TargzFormat -> do
                 let entriesM :: StateT (Set.Set FilePath) (WriterT [Tar.Entry] IO) ()
                     entriesM = do
                         let prefix = prettyShow (packageId pkg)

--- a/cabal-install/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/Distribution/Client/CmdSdist.hs
@@ -119,7 +119,6 @@ sdistCommand = CommandUI
             (choiceOpt
                 [ (Flag TargzFormat, ([], ["targz"]),
                         "Produce a '.tar.gz' format archive (default and required for uploading to hackage)")
-                  -- ...
                 ]
             )
         , option ['o'] ["output-dir", "outputdir"]

--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -231,8 +231,7 @@ defaultDistDirLayout projectRoot mdistDirectory =
         where
           ext = case format of
             TargzFormat -> "tar.gz"
-            ZipFormat -> "zip"
-    
+
     distSdistDirectory = distDirectory </> "sdist"
 
     distTempDirectory = distDirectory </> "tmp"

--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -27,8 +27,6 @@ import System.FilePath
 
 import Distribution.Package
          ( PackageId, ComponentId, UnitId )
-import Distribution.Client.Setup
-         ( ArchiveFormat(..) )
 import Distribution.Compiler
 import Distribution.Simple.Compiler
          ( PackageDB(..), PackageDBStack, OptimisationLevel(..) )
@@ -115,7 +113,7 @@ data DistDirLayout = DistDirLayout {
        distPackageCacheDirectory    :: DistDirParams -> FilePath,
 
        -- | The location that sdists are placed by default.
-       distSdistFile                :: PackageId -> ArchiveFormat -> FilePath,
+       distSdistFile                :: PackageId -> FilePath,
        distSdistDirectory           :: FilePath,
 
        distTempDirectory            :: FilePath,
@@ -227,10 +225,7 @@ defaultDistDirLayout projectRoot mdistDirectory =
     distPackageCacheDirectory params = distBuildDirectory params </> "cache"
     distPackageCacheFile params name = distPackageCacheDirectory params </> name
 
-    distSdistFile pid format = distSdistDirectory </> prettyShow pid <.> ext
-        where
-          ext = case format of
-            TargzFormat -> "tar.gz"
+    distSdistFile pid = distSdistDirectory </> prettyShow pid <.> "tar.gz"
 
     distSdistDirectory = distDirectory </> "sdist"
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2389,7 +2389,7 @@ data SDistExFlags = SDistExFlags {
   }
   deriving (Show, Generic)
 
-data ArchiveFormat = TargzFormat | ZipFormat -- ...
+data ArchiveFormat = TargzFormat -- ...
   deriving (Show, Eq)
 
 defaultSDistExFlags :: SDistExFlags
@@ -2416,8 +2416,7 @@ sdistCommand = Cabal.sdistCommand {
          (choiceOpt
             [ (Flag TargzFormat, ([], ["targz"]),
                  "Produce a '.tar.gz' format archive (default and required for uploading to hackage)")
-            , (Flag ZipFormat,   ([], ["zip"]),
-                 "Produce a '.zip' format archive")
+              -- ...
             ])
       ]
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -43,7 +43,7 @@ module Distribution.Client.Setup
     , reportCommand, ReportFlags(..)
     , runCommand
     , initCommand, IT.InitFlags(..)
-    , sdistCommand, SDistFlags(..), SDistExFlags(..), ArchiveFormat(..)
+    , sdistCommand, SDistFlags(..)
     , win32SelfUpgradeCommand, Win32SelfUpgradeFlags(..)
     , actAsSetupCommand, ActAsSetupFlags(..)
     , sandboxCommand, defaultSandboxLocation, SandboxFlags(..)
@@ -2384,47 +2384,13 @@ initCommand = CommandUI {
 
 -- | Extra flags to @sdist@ beyond runghc Setup sdist
 --
-data SDistExFlags = SDistExFlags {
-    sDistFormat    :: Flag ArchiveFormat
-  }
-  deriving (Show, Generic)
-
-data ArchiveFormat = TargzFormat -- ...
-  deriving (Show, Eq)
-
-defaultSDistExFlags :: SDistExFlags
-defaultSDistExFlags = SDistExFlags {
-    sDistFormat  = Flag TargzFormat
-  }
-
-sdistCommand :: CommandUI (SDistFlags, SDistExFlags)
+sdistCommand :: CommandUI SDistFlags
 sdistCommand = Cabal.sdistCommand {
     commandUsage        = \pname ->
         "Usage: " ++ pname ++ " v1-sdist [FLAGS]\n",
-    commandDefaultFlags = (commandDefaultFlags Cabal.sdistCommand, defaultSDistExFlags),
-    commandOptions      = \showOrParseArgs ->
-         liftOptions fst setFst (commandOptions Cabal.sdistCommand showOrParseArgs)
-      ++ liftOptions snd setSnd sdistExOptions
+    commandDefaultFlags = (commandDefaultFlags Cabal.sdistCommand)
   }
-  where
-    setFst a (_,b) = (a,b)
-    setSnd b (a,_) = (a,b)
 
-    sdistExOptions =
-      [option [] ["archive-format"] "archive-format"
-         sDistFormat (\v flags -> flags { sDistFormat = v })
-         (choiceOpt
-            [ (Flag TargzFormat, ([], ["targz"]),
-                 "Produce a '.tar.gz' format archive (default and required for uploading to hackage)")
-            ])
-      ]
-
-instance Monoid SDistExFlags where
-  mempty = gmempty
-  mappend = (<>)
-
-instance Semigroup SDistExFlags where
-  (<>) = gmappend
 
 --
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2416,7 +2416,6 @@ sdistCommand = Cabal.sdistCommand {
          (choiceOpt
             [ (Flag TargzFormat, ([], ["targz"]),
                  "Produce a '.tar.gz' format archive (default and required for uploading to hackage)")
-              -- ...
             ])
       ]
 

--- a/cabal-install/Distribution/Client/SrcDist.hs
+++ b/cabal-install/Distribution/Client/SrcDist.hs
@@ -26,7 +26,7 @@ import Distribution.Simple.Utils
          ( createDirectoryIfMissingVerbose, defaultPackageDesc
          , warn, notice, withTempDirectory )
 import Distribution.Client.Setup
-         ( SDistFlags(..), SDistExFlags(..), ArchiveFormat(..) )
+         ( SDistFlags(..) )
 import Distribution.Simple.Setup
          ( Flag(..), sdistCommand, flagToList, fromFlag, fromFlagOrDefault
          , defaultSDistFlags )
@@ -45,8 +45,8 @@ import System.Directory (getTemporaryDirectory)
 import Control.Exception                             (IOException, evaluate)
 
 -- |Create a source distribution.
-sdist :: SDistFlags -> SDistExFlags -> IO ()
-sdist flags exflags = do
+sdist :: SDistFlags -> IO ()
+sdist flags = do
   pkg <- liftM flattenPackageDescription
     (readGenericPackageDescription verbosity =<< defaultPackageDesc verbosity)
   let withDir :: (FilePath -> IO a) -> IO a
@@ -70,7 +70,7 @@ sdist flags exflags = do
     -- Unless we were given --list-sources or --output-directory ourselves,
     -- create an archive.
     when needMakeArchive $
-      createArchive verbosity pkg tmpDir distPref
+      createTarGzArchive verbosity pkg tmpDir distPref
 
     when isOutDirectory $
       notice verbosity $ "Source directory created: " ++ tmpTargetDir
@@ -96,9 +96,6 @@ sdist flags exflags = do
                         then orLaterVersion $ mkVersion [1,17,0]
                         else orLaterVersion $ mkVersion [1,12,0]
       }
-    format        = fromFlag (sDistFormat exflags)
-    createArchive = case format of
-      TargzFormat -> createTarGzArchive
 
 tarBallName :: PackageDescription -> String
 tarBallName = display . packageId

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -333,7 +333,6 @@ executable cabal
         zlib       >= 0.5.3    && < 0.7,
         hackage-security >= 0.5.2.2 && < 0.6,
         text       >= 1.2.3    && < 1.3,
-        zip-archive >= 0.3.2.5 && < 0.4,
         parsec     >= 3.1.13.0 && < 3.2
 
     if flag(native-dns)

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -333,6 +333,7 @@ executable cabal
         zlib       >= 0.5.3    && < 0.7,
         hackage-security >= 0.5.2.2 && < 0.6,
         text       >= 1.2.3    && < 1.3,
+        zip-archive >= 0.3.2.5 && < 0.4,
         parsec     >= 3.1.13.0 && < 3.2
 
     if flag(native-dns)

--- a/cabal-install/cabal-install.cabal.pp
+++ b/cabal-install/cabal-install.cabal.pp
@@ -44,7 +44,6 @@ Version:            2.5.0.0
         zlib       >= 0.5.3    && < 0.7,
         hackage-security >= 0.5.2.2 && < 0.6,
         text       >= 1.2.3    && < 1.3,
-        zip-archive >= 0.3.2.5 && < 0.4,
         parsec     >= 3.1.13.0 && < 3.2
 
     if flag(native-dns)

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -4,6 +4,7 @@
 	* New solver flag: '--reject-unconstrained-dependencies'. (#2568)
 	* Ported old-style test options to the new-style commands (#5455).
 	* Improved error messages for cabal file parse errors. (#5710)
+	* Removed support for `.zip` format source distributions (#5755)
 
 2.4.1.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> November 2018
 	* Add message to alert user to potential package casing errors. (#5635)

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -1074,7 +1074,7 @@ sdistAction sdistFlags extraArgs globalFlags = do
   load <- try (loadConfigOrSandboxConfig verbosity globalFlags)
   let config = either (\(SomeException _) -> mempty) snd load
   distPref <- findSavedDistPref config (sDistDistPref sdistFlags)
-  sdist $ sdistFlags { sDistDistPref = toFlag distPref }
+  sdist sdistFlags { sDistDistPref = toFlag distPref }
 
 reportAction :: ReportFlags -> [String] -> Action
 reportAction reportFlags extraArgs globalFlags = do

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -39,7 +39,7 @@ import Distribution.Client.Setup
          , ReportFlags(..), reportCommand
          , runCommand
          , InitFlags(initVerbosity, initHcPath), initCommand
-         , SDistFlags(..), SDistExFlags(..), sdistCommand
+         , SDistFlags(..), sdistCommand
          , Win32SelfUpgradeFlags(..), win32SelfUpgradeCommand
          , ActAsSetupFlags(..), actAsSetupCommand
          , SandboxFlags(..), sandboxCommand
@@ -1066,16 +1066,15 @@ uninstallAction verbosityFlag extraArgs _globalFlags = do
     ++ package ++ "' or 'cabal sandbox hc-pkg -- unregister " ++ package ++ "'."
 
 
-sdistAction :: (SDistFlags, SDistExFlags) -> [String] -> Action
-sdistAction (sdistFlags, sdistExFlags) extraArgs globalFlags = do
+sdistAction :: SDistFlags -> [String] -> Action
+sdistAction sdistFlags extraArgs globalFlags = do
   let verbosity = fromFlag (sDistVerbosity sdistFlags)
   unless (null extraArgs) $
     die' verbosity $ "'sdist' doesn't take any extra arguments: " ++ unwords extraArgs
   load <- try (loadConfigOrSandboxConfig verbosity globalFlags)
   let config = either (\(SomeException _) -> mempty) snd load
   distPref <- findSavedDistPref config (sDistDistPref sdistFlags)
-  let sdistFlags' = sdistFlags { sDistDistPref = toFlag distPref }
-  sdist sdistFlags' sdistExFlags
+  sdist $ sdistFlags { sDistDistPref = toFlag distPref }
 
 reportAction :: ReportFlags -> [String] -> Action
 reportAction reportFlags extraArgs globalFlags = do


### PR DESCRIPTION
This PR addresses #5735, including the removal of the `zip-archive` dependency per the comments

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Extra:

* [x] Remove archive format + related code (per the comments)


