### PR TITLE
Make v2-test succeed when no test suites found

### DIFF
--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -1855,6 +1855,7 @@ data TestFlags = TestFlags {
     testMachineLog  :: Flag PathTemplate,
     testShowDetails :: Flag TestShowDetails,
     testKeepTix     :: Flag Bool,
+    testAllowNoTestSuites :: Flag Bool,
     -- TODO: think about if/how options are passed to test exes
     testOptions     :: [PathTemplate]
   } deriving (Generic)
@@ -1867,6 +1868,7 @@ defaultTestFlags  = TestFlags {
     testMachineLog  = toFlag $ toPathTemplate $ "$pkgid.log",
     testShowDetails = toFlag Failures,
     testKeepTix     = toFlag False,
+    testAllowNoTestSuites = toFlag False,
     testOptions     = []
   }
 
@@ -1930,6 +1932,11 @@ testOptions' showOrParseArgs =
   , option [] ["keep-tix-files"]
         "keep .tix files for HPC between test runs"
         testKeepTix (\v flags -> flags { testKeepTix = v})
+        trueArg
+  , option [] ["allow-no-test-suites"]
+        ("Do not exit the test command with a failure when no test suites "
+         ++ "are found.")
+        testAllowNoTestSuites (\v flags -> flags { testAllowNoTestSuites = v})
         trueArg
   , option [] ["test-options"]
         ("give extra options to test executables "

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -1855,7 +1855,7 @@ data TestFlags = TestFlags {
     testMachineLog  :: Flag PathTemplate,
     testShowDetails :: Flag TestShowDetails,
     testKeepTix     :: Flag Bool,
-    testAllowNoTestSuites :: Flag Bool,
+    testFailWhenNoTestSuites :: Flag Bool,
     -- TODO: think about if/how options are passed to test exes
     testOptions     :: [PathTemplate]
   } deriving (Generic)
@@ -1868,7 +1868,7 @@ defaultTestFlags  = TestFlags {
     testMachineLog  = toFlag $ toPathTemplate $ "$pkgid.log",
     testShowDetails = toFlag Failures,
     testKeepTix     = toFlag False,
-    testAllowNoTestSuites = toFlag False,
+    testFailWhenNoTestSuites = toFlag False,
     testOptions     = []
   }
 
@@ -1933,10 +1933,9 @@ testOptions' showOrParseArgs =
         "keep .tix files for HPC between test runs"
         testKeepTix (\v flags -> flags { testKeepTix = v})
         trueArg
-  , option [] ["allow-no-test-suites"]
-        ("Do not exit the test command with a failure when no test suites "
-         ++ "are found.")
-        testAllowNoTestSuites (\v flags -> flags { testAllowNoTestSuites = v})
+  , option [] ["fail-when-no-test-suites"]
+        ("Exit with failure when no test suites are found.")
+        testFailWhenNoTestSuites (\v flags -> flags { testFailWhenNoTestSuites = v})
         trueArg
   , option [] ["test-options"]
         ("give extra options to test executables "

--- a/cabal-install/Distribution/Client/CmdTest.hs
+++ b/cabal-install/Distribution/Client/CmdTest.hs
@@ -23,14 +23,17 @@ import Distribution.Simple.Setup
          ( HaddockFlags, TestFlags(..), fromFlagOrDefault )
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
+import Distribution.Simple.Flag
+         ( Flag(..) )
 import Distribution.Deprecated.Text
          ( display )
 import Distribution.Verbosity
          ( Verbosity, normal )
 import Distribution.Simple.Utils
-         ( wrapText, die' )
+         ( notice, wrapText, die' )
 
 import Control.Monad (when)
+import qualified System.Exit (exitSuccess)
 
 
 testCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
@@ -102,7 +105,7 @@ testAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
 
             -- Interpret the targets on the command line as test targets
             -- (as opposed to say build or haddock targets).
-            targets <- either (reportTargetProblems verbosity) return
+            targets <- either (reportTargetProblems allowNoTestSuites verbosity) return
                      $ resolveTargets
                          selectPackageTargets
                          selectComponentTarget
@@ -122,6 +125,7 @@ testAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
     buildOutcomes <- runProjectBuildPhase verbosity baseCtx buildCtx
     runProjectPostBuildPhase verbosity baseCtx buildCtx buildOutcomes
   where
+    allowNoTestSuites = testAllowNoTestSuites testFlags
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
     cliConfig = commandLineFlagsToProjectConfig
                   globalFlags configFlags configExFlags
@@ -206,9 +210,24 @@ data TargetProblem =
    | TargetProblemIsSubComponent   PackageId ComponentName SubComponentTarget
   deriving (Eq, Show)
 
-reportTargetProblems :: Verbosity -> [TargetProblem] -> IO a
-reportTargetProblems verbosity =
-    die' verbosity . unlines . map renderTargetProblem
+reportTargetProblems :: Flag Bool -> Verbosity -> [TargetProblem] -> IO a
+reportTargetProblems allowNoTestSuites verbosity problems =
+  case (allowNoTestSuites, problems) of
+    (Flag True, [TargetProblemNoTests selector]) -> do
+      notice verbosity (renderAllowedNoTestsProblem selector)
+      System.Exit.exitSuccess
+    (_, _) -> die' verbosity problemsMessage
+    where
+      problemsMessage = unlines . map renderTargetProblem $ problems
+
+-- | When the @--test-allow-no-test-suites@ flag is passed we don't
+--   @die@ when the target problem is 'TargetProblemNoTests'.
+--   Instead, we display a notice saying that no tests have run and
+--   indicate how this behaviour was enabled.
+renderAllowedNoTestsProblem :: TargetSelector -> String
+renderAllowedNoTestsProblem selector =
+    "No tests to run for " ++ renderTargetSelector selector ++ ".\n"
+ ++ "This has been permitted by the '--allow-no-test-suites' flag."
 
 renderTargetProblem :: TargetProblem -> String
 renderTargetProblem (TargetProblemCommon problem) =
@@ -230,6 +249,7 @@ renderTargetProblem (TargetProblemNoTargets targetSelector) =
         -> "The test command is for running test suites, but the target '"
            ++ showTargetSelector targetSelector ++ "' refers to "
            ++ renderTargetSelector targetSelector ++ "."
+           ++ "\n" ++ show targetSelector
 
       _ -> renderTargetProblemNoTargets "test" targetSelector
 

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -436,7 +436,7 @@ instance Semigroup SavedConfig where
         testMachineLog  = combine testMachineLog,
         testShowDetails = combine testShowDetails,
         testKeepTix     = combine testKeepTix,
-        testAllowNoTestSuites = combine testAllowNoTestSuites,
+        testFailWhenNoTestSuites = combine testFailWhenNoTestSuites,
         testOptions     = lastNonEmpty testOptions
         }
         where

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -436,6 +436,7 @@ instance Semigroup SavedConfig where
         testMachineLog  = combine testMachineLog,
         testShowDetails = combine testShowDetails,
         testKeepTix     = combine testKeepTix,
+        testAllowNoTestSuites = combine testAllowNoTestSuites,
         testOptions     = lastNonEmpty testOptions
         }
         where

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -436,7 +436,7 @@ convertLegacyPerPackageFlags configFlags installFlags haddockFlags testFlags =
       testMachineLog            = packageConfigTestMachineLog,
       testShowDetails           = packageConfigTestShowDetails,
       testKeepTix               = packageConfigTestKeepTix,
-      testAllowNoTestSuites     = packageConfigTestAllowNoTestSuites,
+      testFailWhenNoTestSuites  = packageConfigTestFailWhenNoTestSuites,
       testOptions               = packageConfigTestTestOptions
     } = testFlags
 
@@ -775,7 +775,7 @@ convertToLegacyPerPackageConfig PackageConfig {..} =
       testMachineLog  = packageConfigTestMachineLog,
       testShowDetails = packageConfigTestShowDetails,
       testKeepTix     = packageConfigTestKeepTix,
-      testAllowNoTestSuites = packageConfigTestAllowNoTestSuites,
+      testFailWhenNoTestSuites = packageConfigTestFailWhenNoTestSuites,
       testOptions     = packageConfigTestTestOptions
     }
 
@@ -1063,7 +1063,7 @@ legacyPackageConfigFieldDescrs =
           (\v conf -> conf { testOptions = v })
       ]
   . filterFields
-      [ "log", "machine-log", "show-details", "keep-tix-files", "allow-no-test-suites" ]
+      [ "log", "machine-log", "show-details", "keep-tix-files", "fail-when-no-test-suites" ]
   . commandOptionsToFields
   ) (testOptions' ParseArgs)
 

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -436,6 +436,7 @@ convertLegacyPerPackageFlags configFlags installFlags haddockFlags testFlags =
       testMachineLog            = packageConfigTestMachineLog,
       testShowDetails           = packageConfigTestShowDetails,
       testKeepTix               = packageConfigTestKeepTix,
+      testAllowNoTestSuites     = packageConfigTestAllowNoTestSuites,
       testOptions               = packageConfigTestTestOptions
     } = testFlags
 
@@ -774,6 +775,7 @@ convertToLegacyPerPackageConfig PackageConfig {..} =
       testMachineLog  = packageConfigTestMachineLog,
       testShowDetails = packageConfigTestShowDetails,
       testKeepTix     = packageConfigTestKeepTix,
+      testAllowNoTestSuites = packageConfigTestAllowNoTestSuites,
       testOptions     = packageConfigTestTestOptions
     }
 
@@ -1061,7 +1063,7 @@ legacyPackageConfigFieldDescrs =
           (\v conf -> conf { testOptions = v })
       ]
   . filterFields
-      [ "log", "machine-log", "show-details", "keep-tix-files" ]
+      [ "log", "machine-log", "show-details", "keep-tix-files", "allow-no-test-suites" ]
   . commandOptionsToFields
   ) (testOptions' ParseArgs)
 

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -285,6 +285,7 @@ data PackageConfig
        packageConfigTestMachineLog      :: Flag PathTemplate,
        packageConfigTestShowDetails     :: Flag TestShowDetails,
        packageConfigTestKeepTix         :: Flag Bool,
+       packageConfigTestAllowNoTestSuites :: Flag Bool,
        packageConfigTestTestOptions     :: [PathTemplate]
      }
   deriving (Eq, Show, Generic)

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -285,7 +285,7 @@ data PackageConfig
        packageConfigTestMachineLog      :: Flag PathTemplate,
        packageConfigTestShowDetails     :: Flag TestShowDetails,
        packageConfigTestKeepTix         :: Flag Bool,
-       packageConfigTestAllowNoTestSuites :: Flag Bool,
+       packageConfigTestFailWhenNoTestSuites :: Flag Bool,
        packageConfigTestTestOptions     :: [PathTemplate]
      }
   deriving (Eq, Show, Generic)

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1879,7 +1879,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
         elabTestHumanLog        = perPkgOptionMaybe pkgid packageConfigTestHumanLog
         elabTestShowDetails     = perPkgOptionMaybe pkgid packageConfigTestShowDetails
         elabTestKeepTix         = perPkgOptionFlag pkgid False packageConfigTestKeepTix
-        elabTestAllowNoTestSuites = perPkgOptionFlag pkgid False packageConfigTestAllowNoTestSuites
+        elabTestFailWhenNoTestSuites = perPkgOptionFlag pkgid False packageConfigTestFailWhenNoTestSuites
         elabTestTestOptions     = perPkgOptionList pkgid packageConfigTestTestOptions
 
     perPkgOptionFlag  :: PackageId -> a ->  (PackageConfig -> Flag a) -> a
@@ -3395,7 +3395,7 @@ setupHsTestFlags (ElaboratedConfiguredPackage{..}) _ verbosity builddir = Cabal.
     , testHumanLog    = maybe mempty toFlag elabTestHumanLog
     , testShowDetails = maybe (Flag Cabal.Always) toFlag elabTestShowDetails
     , testKeepTix     = toFlag elabTestKeepTix
-    , testAllowNoTestSuites = toFlag elabTestAllowNoTestSuites
+    , testFailWhenNoTestSuites = toFlag elabTestFailWhenNoTestSuites
     , testOptions     = elabTestTestOptions
     }
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1879,6 +1879,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
         elabTestHumanLog        = perPkgOptionMaybe pkgid packageConfigTestHumanLog
         elabTestShowDetails     = perPkgOptionMaybe pkgid packageConfigTestShowDetails
         elabTestKeepTix         = perPkgOptionFlag pkgid False packageConfigTestKeepTix
+        elabTestAllowNoTestSuites = perPkgOptionFlag pkgid False packageConfigTestAllowNoTestSuites
         elabTestTestOptions     = perPkgOptionList pkgid packageConfigTestTestOptions
 
     perPkgOptionFlag  :: PackageId -> a ->  (PackageConfig -> Flag a) -> a
@@ -3394,6 +3395,7 @@ setupHsTestFlags (ElaboratedConfiguredPackage{..}) _ verbosity builddir = Cabal.
     , testHumanLog    = maybe mempty toFlag elabTestHumanLog
     , testShowDetails = maybe (Flag Cabal.Always) toFlag elabTestShowDetails
     , testKeepTix     = toFlag elabTestKeepTix
+    , testAllowNoTestSuites = toFlag elabTestAllowNoTestSuites
     , testOptions     = elabTestTestOptions
     }
 

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -292,6 +292,7 @@ data ElaboratedConfiguredPackage
        elabTestHumanLog          :: Maybe PathTemplate,
        elabTestShowDetails       :: Maybe TestShowDetails,
        elabTestKeepTix           :: Bool,
+       elabTestAllowNoTestSuites :: Bool,
        elabTestTestOptions       :: [PathTemplate],
 
        -- Setup.hs related things:

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -292,7 +292,7 @@ data ElaboratedConfiguredPackage
        elabTestHumanLog          :: Maybe PathTemplate,
        elabTestShowDetails       :: Maybe TestShowDetails,
        elabTestKeepTix           :: Bool,
-       elabTestAllowNoTestSuites :: Bool,
+       elabTestFailWhenNoTestSuites :: Bool,
        elabTestTestOptions       :: [PathTemplate],
 
        -- Setup.hs related things:

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1927,7 +1927,7 @@ testOptions showOrParseArgs
     | opt <- commandOptions Cabal.testCommand showOrParseArgs
     , let name = optionName opt
     , name `elem` ["log", "machine-log", "show-details", "keep-tix-files"
-                  ,"test-options", "test-option"]
+                  ,"allow-no-test-suites", "test-options", "test-option"]
     ]
   where
     prefixTest name | "test-" `isPrefixOf` name = name

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1927,7 +1927,7 @@ testOptions showOrParseArgs
     | opt <- commandOptions Cabal.testCommand showOrParseArgs
     , let name = optionName opt
     , name `elem` ["log", "machine-log", "show-details", "keep-tix-files"
-                  ,"allow-no-test-suites", "test-options", "test-option"]
+                  ,"fail-when-no-test-suites", "test-options", "test-option"]
     ]
   where
     prefixTest name | "test-" `isPrefixOf` name = name

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -6,6 +6,7 @@
 	* Improved error messages for cabal file parse errors. (#5710)
 	* Removed support for `.zip` format source distributions (#5755)
 	* Add "simple project" initialization option. (#5707)
+	* v2-test now succeeds when there are no test suites. (#5435)
 
 2.4.1.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> November 2018
 	* Add message to alert user to potential package casing errors. (#5635)

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -629,7 +629,7 @@ instance Arbitrary PackageConfig where
                          , packageConfigTestMachineLog = x45
                          , packageConfigTestShowDetails = x46
                          , packageConfigTestKeepTix = x47
-                         , packageConfigTestAllowNoTestSuites = x48
+                         , packageConfigTestFailWhenNoTestSuites = x48
                          , packageConfigTestTestOptions = x49 } =
       [ PackageConfig { packageConfigProgramPaths = postShrink_Paths x00'
                       , packageConfigProgramArgs = postShrink_Args x01'
@@ -681,7 +681,7 @@ instance Arbitrary PackageConfig where
                       , packageConfigTestMachineLog = x45'
                       , packageConfigTestShowDetails = x46'
                       , packageConfigTestKeepTix = x47'
-                      , packageConfigTestAllowNoTestSuites = x48'
+                      , packageConfigTestFailWhenNoTestSuites = x48'
                       , packageConfigTestTestOptions = x49' }
       |  (((x00', x01', x02', x03', x04'),
           (x05', x42', x06', x07', x08', x09'),

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -257,12 +257,12 @@ prop_roundtrip_printparse_RelaxedDep rdep =
 
 prop_roundtrip_printparse_RelaxDeps :: RelaxDeps -> Property
 prop_roundtrip_printparse_RelaxDeps rdep =
-    counterexample (Text.display rdep) $ 
+    counterexample (Text.display rdep) $
     runReadP Text.parse (Text.display rdep) === Just rdep
 
 prop_roundtrip_printparse_RelaxDeps' :: RelaxDeps -> Property
 prop_roundtrip_printparse_RelaxDeps' rdep =
-    counterexample rdep' $ 
+    counterexample rdep' $
     runReadP Text.parse rdep' === Just rdep
   where
     rdep' = go (Text.display rdep)
@@ -629,7 +629,8 @@ instance Arbitrary PackageConfig where
                          , packageConfigTestMachineLog = x45
                          , packageConfigTestShowDetails = x46
                          , packageConfigTestKeepTix = x47
-                         , packageConfigTestTestOptions = x48 } =
+                         , packageConfigTestAllowNoTestSuites = x48
+                         , packageConfigTestTestOptions = x49 } =
       [ PackageConfig { packageConfigProgramPaths = postShrink_Paths x00'
                       , packageConfigProgramArgs = postShrink_Args x01'
                       , packageConfigProgramPathExtra = x02'
@@ -680,7 +681,8 @@ instance Arbitrary PackageConfig where
                       , packageConfigTestMachineLog = x45'
                       , packageConfigTestShowDetails = x46'
                       , packageConfigTestKeepTix = x47'
-                      , packageConfigTestTestOptions = x48' }
+                      , packageConfigTestAllowNoTestSuites = x48'
+                      , packageConfigTestTestOptions = x49' }
       |  (((x00', x01', x02', x03', x04'),
           (x05', x42', x06', x07', x08', x09'),
           (x10', x11', x12', x13', x14'),
@@ -690,7 +692,7 @@ instance Arbitrary PackageConfig where
           (x30', x31', x32', (x33', x33_1'), x34'),
           (x35', x36', x37', x38', x43', x39'),
           (x40', x41'),
-          (x44', x45', x46', x47', x48')))
+          (x44', x45', x46', x47', x48', x49')))
           <- shrink
              (((preShrink_Paths x00, preShrink_Args x01, x02, x03, x04),
                 (x05, x42, x06, x07, x08, x09),
@@ -704,7 +706,7 @@ instance Arbitrary PackageConfig where
                  (x30, x31, x32, (x33, x33_1), x34),
                  (x35, x36, fmap NonEmpty x37, x38, x43, fmap NonEmpty x39),
                  (x40, x41),
-                 (x44, x45, x46, x47, x48)))
+                 (x44, x45, x46, x47, x48, x49)))
       ]
       where
         preShrink_Paths  = Map.map NonEmpty

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -572,6 +572,7 @@ instance Arbitrary PackageConfig where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
+        <*> arbitrary
         <*> shortListOf 5 arbitrary
       where
         arbitraryProgramName :: Gen String


### PR DESCRIPTION
# Overview 

Change the default behaviour of `v2-test` so that it succeeds when no test suites are found.

This changes the exit code behaviour of the `v2-test` command when the "problem" is that no tests were found. Previously, when no tests were found `cabal v2-test` exit with status `1`, now prints a it friendlier message and exits with status `0`. The old behaviour can be achieved by passing `--test-fail-when-no-test-suites` to `cabal v2-test`.

This addresses #5435.

## Example Usage

**--help output**
```
$ cabal v2-test help
<snip>
    --test-fail-when-no-test-suites                      Exit with failure when no
                                                         test suites are found.
<snip>
```

**Before**
```
$ cabal v2-test
Resolving dependencies...
cabal: Cannot run tests for the target '' which refers to the package
initsample-0.1.0.0 because it does not contain any test suites.

$ echo $?
1
```

**After**
```
$ cabal-dev v2-test
No tests to run for the package initsample-0.1.0.0.

$ echo $?
0
```

```
$ cabal v2-test --test-fail-when-no-test-suites
Resolving dependencies...
cabal: Cannot run tests for the target '' which refers to the package
initsample-0.1.0.0 because it does not contain any test suites.

$ echo $?
1
```

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

/cc @vrom911 @hvr 