### PR TITLE
pass --host=$HOST to configure when cross-compiling

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -6,6 +6,7 @@
   * `KnownExtension`: added new extension `DerivingVia`
   * Add `extra-dynamic-library-flavours`, to specify extra dynamic library
     flavours to build and install from a .cabal file.
+  * `autoconfUserHooks` now passes `--host=$HOST` when cross-compiling
 
 ----
 

--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -93,6 +93,7 @@ import Language.Haskell.Extension
 import Distribution.Version
 import Distribution.License
 import Distribution.Pretty
+import Distribution.System (buildPlatform)
 
 -- Base
 import System.Environment (getArgs, getProgName)
@@ -755,7 +756,9 @@ runConfigureScript verbosity backwardsCompatHack flags lbi = do
                 ((intercalate spSep extraPath ++ spSep)++) $ lookup "PATH" env
       overEnv = ("CFLAGS", Just cflagsEnv) :
                 [("PATH", Just pathEnv) | not (null extraPath)]
-      args' = configureFile':args ++ ["CC=" ++ ccProgShort]
+      hp = hostPlatform lbi
+      maybeHostFlag = if hp == buildPlatform then [] else ["--host=" ++ show (pretty hp)]
+      args' = configureFile':args ++ ["CC=" ++ ccProgShort] ++ maybeHostFlag
       shProg = simpleProgram "sh"
       progDb = modifyProgramSearchPath
                (\p -> map ProgramSearchPathDir extraPath ++ p) emptyProgramDb


### PR DESCRIPTION
This fixes https://github.com/haskell/cabal/issues/5765

This has the minor downside of possibly breaking past behavior, since a `configure` script could feasibly error when passed an unknown flag. However, this would only occur when cross-compiling, and any `configure` script that doesn't accept a `--host` flag is unlikely to cross-compile anyways. 

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

I tested this by cross-compiling `network` (which uses `build-type: Configure`) locally. 