### PR TITLE
Add a regression test for #4291

### DIFF
--- a/cabal-testsuite/PackageTests/Regression/T4291/dependee/Dependee.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4291/dependee/Dependee.hs
@@ -1,0 +1,1 @@
+module Dependee where

--- a/cabal-testsuite/PackageTests/Regression/T4291/dependee/dependee.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T4291/dependee/dependee.cabal
@@ -1,0 +1,11 @@
+name:                 dependee
+version:              0.1.0.0
+author:               Zejun Wu
+maintainer:           watashi@watashi.ws
+build-type:           Simple
+cabal-version:        >=2.0
+
+library
+  build-depends:      base
+  default-language:   Haskell2010
+  exposed-modules:    Dependee

--- a/cabal-testsuite/PackageTests/Regression/T4291/depender/depender.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T4291/depender/depender.cabal
@@ -1,0 +1,10 @@
+name:                 depender
+version:              0.1.0.0
+author:               Zejun Wu
+maintainer:           watashi@watashi.ws
+build-type:           Simple
+cabal-version:        >=2.0
+
+library
+  build-depends:      base, dependee
+  default-language:   Haskell2010

--- a/cabal-testsuite/PackageTests/Regression/T4291/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T4291/setup.cabal.out
@@ -1,0 +1,20 @@
+# Setup configure
+Resolving dependencies...
+Configuring dependee-0.1.0.0...
+# Setup build
+Preprocessing library for dependee-0.1.0.0..
+Building library for dependee-0.1.0.0..
+# Setup copy
+Installing library in <PATH>
+# Setup register
+Registering library for dependee-0.1.0.0..
+# Setup configure
+Resolving dependencies...
+Configuring depender-0.1.0.0...
+# Setup build
+Preprocessing library for depender-0.1.0.0..
+Building library for depender-0.1.0.0..
+# Setup copy
+Installing library in <PATH>
+# Setup register
+Registering library for depender-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Regression/T4291/setup.out
+++ b/cabal-testsuite/PackageTests/Regression/T4291/setup.out
@@ -1,0 +1,18 @@
+# Setup configure
+Configuring dependee-0.1.0.0...
+# Setup build
+Preprocessing library for dependee-0.1.0.0..
+Building library for dependee-0.1.0.0..
+# Setup copy
+Installing library in <PATH>
+# Setup register
+Registering library for dependee-0.1.0.0..
+# Setup configure
+Configuring depender-0.1.0.0...
+# Setup build
+Preprocessing library for depender-0.1.0.0..
+Building library for depender-0.1.0.0..
+# Setup copy
+Installing library in <PATH>
+# Setup register
+Registering library for depender-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Regression/T4291/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4291/setup.test.hs
@@ -1,0 +1,17 @@
+import Data.List (isPrefixOf)
+import Test.Cabal.Prelude
+
+-- Test that checkRelocate doesn't fail when library directory of dependee
+-- contains '..'
+main = setupAndCabalTest $ withPackageDb $ do
+  skipIf =<< isWindows
+  skipUnless =<< ghcVersionIs (>= mkVersion [7,6])
+  env <- getTestEnv
+  let pkgroot = takeDirectory $ testPackageDbDir env
+      prefix = testTmpDir env </> "prefix"
+  assertBool "we need a prefix that is not under pkgroot for this test" $
+    not $ pkgroot `isPrefixOf` prefix
+  withDirectory "dependee" $
+    setup_install ["--enable-relocatable", "--prefix", prefix]
+  withDirectory "depender" $
+    setup_install ["--enable-relocatable", "--prefix", prefix]


### PR DESCRIPTION
Add a regression test for #4291: relocatable is broken because some double dots in a path are not interpreted

This test used to fail with error message like:

```
setup: Library directory of a dependency: "/home/watashi/gao/hackage-github/cabal.fork/cabal-testsuite/PackageTests/Regression/T4291/setup.dist/../../../../../../../../../../tmp/cabal-testsuite-b71ce456fcbd95fa/prefix/lib/x86_64-linux-ghc-8.6.2/dependee-0.1.0.0"
is not relative to the installation prefix:
"/tmp/cabal-testsuite-b71ce456fcbd95fa/prefix"
```

and now passes with #5767: Fix checkRelocatable for deps when prefix is not subdir of pkgroot

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
