### PR TITLE
Use absolute builddir path for building non-inplace packages

### DIFF
--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -720,13 +720,9 @@ rebuildTarget verbosity
           buildSettings registerLock cacheLock
           sharedPackageConfig
           plan rpkg
-          srcdir builddir'
-      where
-        builddir' = makeRelative srcdir builddir
-        --TODO: [nice to have] ^^ do this relative stuff better
+          srcdir builddir
 
     buildInplace buildStatus srcdir builddir =
-        --TODO: [nice to have] use a relative build dir rather than absolute
         buildInplaceUnpackedPackage
           verbosity distDirLayout
           buildSettings registerLock cacheLock


### PR DESCRIPTION
This fixes #3699 by not trying to make the builddir relative in `rebuildTarget`. 

@dcoutts Since you wrote this code, is there any good reason for makeing the builddir relative so srcdir here?

We could also just prepend the srcdir to the builddir in `buildAndInstallUnpackedPackage` when calling `createDirectoryIfMissingVerbose` instead if there is a good reason to keep the bulddir absolute, see [fix-3699-minimal](https://github.com/haskell/cabal/compare/master...DanielG:fix-3699-minimal)

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.
