### PR TITLE
Add rules to run tests via "make parser-tests" etc

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -558,6 +558,7 @@ test-suite parser-tests
     base,
     base-compat >=0.10.4 && <0.11,
     bytestring,
+    directory,
     filepath,
     tasty >= 1.1.0.3 && < 1.2,
     tasty-hunit,
@@ -584,6 +585,7 @@ test-suite check-tests
   build-depends:
     base,
     bytestring,
+    directory,
     filepath,
     tasty >= 1.1.0.3 && < 1.2,
     tasty-golden >=2.3.1.1 && <2.4,

--- a/Cabal/tests/CheckTests.hs
+++ b/Cabal/tests/CheckTests.hs
@@ -11,6 +11,8 @@ import Distribution.PackageDescription.Parsec (parseGenericPackageDescription)
 import Distribution.Parsec.Common             (showPError, showPWarning)
 import Distribution.Parsec.ParseResult        (runParseResult)
 import Distribution.Utils.Generic             (fromUTF8BS, toUTF8BS)
+import System.Directory                       (setCurrentDirectory)
+import System.Environment                     (getArgs, withArgs)
 import System.FilePath                        (replaceExtension, (</>))
 
 import qualified Data.ByteString       as BS
@@ -61,7 +63,13 @@ checkTest fp = cabalGoldenTest fp correct $ do
 -------------------------------------------------------------------------------
 
 main :: IO ()
-main = defaultMain tests
+main = do
+    args <- getArgs
+    case args of
+        ("--cwd" : cwd : args') -> do
+            setCurrentDirectory cwd
+            withArgs args' $ defaultMain tests
+        _ -> defaultMain tests
 
 cabalGoldenTest :: TestName -> FilePath -> IO BS.ByteString -> TestTree
 cabalGoldenTest name ref act = goldenTest name (BS.readFile ref) act cmp upd

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -20,6 +20,8 @@ import Distribution.Parsec.Common
        (PWarnType (..), PWarning (..), showPError, showPWarning)
 import Distribution.Parsec.ParseResult             (runParseResult)
 import Distribution.Utils.Generic                  (fromUTF8BS, toUTF8BS)
+import System.Directory                            (setCurrentDirectory)
+import System.Environment                          (getArgs, withArgs)
 import System.FilePath                             (replaceExtension, (</>))
 
 import qualified Data.ByteString       as BS
@@ -311,7 +313,13 @@ ipiFormatRoundTripTest fp = testCase "roundtrip" $ do
 -------------------------------------------------------------------------------
 
 main :: IO ()
-main = defaultMain tests
+main = do
+    args <- getArgs
+    case args of
+        ("--cwd" : cwd : args') -> do
+            setCurrentDirectory cwd
+            withArgs args' $ defaultMain tests
+        _ -> defaultMain tests
 
 cabalGoldenTest :: TestName -> FilePath -> IO BS.ByteString -> TestTree
 cabalGoldenTest name ref act = goldenTest name (BS.readFile ref) act cmp upd

--- a/Makefile
+++ b/Makefile
@@ -6,22 +6,39 @@ LEXER_HS:=Cabal/Distribution/Parsec/Lexer.hs
 SPDX_LICENSE_HS:=Cabal/Distribution/SPDX/LicenseId.hs
 SPDX_EXCEPTION_HS:=Cabal/Distribution/SPDX/LicenseExceptionId.hs
 
+CABALBUILD := cabal new-build --enable-tests
+CABALRUN   := cabal new-run --enable-tests
+
+# default rules
+
 all : exe lib
 
-lexer : $(LEXER_HS)
+lib : $(LEXER_HS)
+	$(CABALBUILD) Cabal:libs
 
-spdx : $(SPDX_LICENSE_HS) $(SPDX_EXCEPTION_HS)
+exe : $(LEXER_HS)
+	$(CABALBUILD) cabal-install:exes
+
+# source generation: Lexer
+
+lexer : $(LEXER_HS)
 
 $(LEXER_HS) : boot/Lexer.x
 	alex --latin1 --ghc -o $@ $^
 	cat -s $@ > Lexer.tmp
 	mv Lexer.tmp $@
 
+# source generation: SPDX
+
+spdx : $(SPDX_LICENSE_HS) $(SPDX_EXCEPTION_HS)
+
 $(SPDX_LICENSE_HS) : boot/SPDX.LicenseId.template.hs cabal-dev-scripts/src/GenUtils.hs cabal-dev-scripts/src/GenSPDX.hs license-list-data/licenses-3.0.json license-list-data/licenses-3.2.json
 	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-spdx -- boot/SPDX.LicenseId.template.hs license-list-data/licenses-3.0.json license-list-data/licenses-3.2.json license-list-data/licenses-3.3.json $(SPDX_LICENSE_HS)
 
 $(SPDX_EXCEPTION_HS) : boot/SPDX.LicenseExceptionId.template.hs cabal-dev-scripts/src/GenUtils.hs cabal-dev-scripts/src/GenSPDXExc.hs license-list-data/exceptions-3.0.json license-list-data/exceptions-3.2.json
 	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-spdx-exc -- boot/SPDX.LicenseExceptionId.template.hs license-list-data/exceptions-3.0.json license-list-data/exceptions-3.2.json license-list-data/exceptions-3.3.json $(SPDX_EXCEPTION_HS)
+
+# cabal-install.cabal file generation
 
 cabal-install-prod : cabal-install/cabal-install.cabal.pp
 	runghc cabal-dev-scripts/src/Preprocessor.hs -o cabal-install/cabal-install.cabal cabal-install/cabal-install.cabal.pp
@@ -37,14 +54,7 @@ cabal-install-monolithic : cabal-install/cabal-install.cabal.pp
 	@echo "tell git to ignore changes to cabal-install.cabal:"
 	@echo "git update-index --assume-unchanged cabal-install/cabal-install.cabal"
 
-lib : $(LEXER_HS)
-	cabal new-build --enable-tests Cabal
-
-exe : $(LEXER_HS)
-	cabal new-build --enable-tests cabal-install
-
-doctest :
-	doctest --fast Cabal/Distribution Cabal/Language
+# extra-source-files generation
 
 gen-extra-source-files : gen-extra-source-files-lib gen-extra-source-files-cli
 
@@ -57,7 +67,30 @@ gen-extra-source-files-cli :
 	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-extra-source-files -- $$(pwd)/cabal-install/cabal-install.cabal.pp $$(pwd)/cabal-install/cabal-install.cabal
 	$(MAKE) cabal-install-prod
 
+# doctests (relies on .ghc.environment files)
+
+doctest :
+	doctest --fast Cabal/Distribution Cabal/Language
+
+# tests
+
+check-tests :
+	$(CABALRUN) --enable-tests check-tests -- --cwd Cabal ${TEST}
+
+parser-tests :
+	$(CABALRUN) parser-tests -- --cwd Cabal ${TEST}
+
+custom-setup-tests :
+	$(CABALRUN) custom-setup-tests --
+
+hackage-parsec-tests :
+	$(CABALRUN) hackage-tests -- parsec +RTS -s -qg -I0 -A64M -N${THREADS} -RTS ${TEST}
+
+hackage-roundtrip-tests :
+	$(CABALRUN) hackage-tests -- roundtrip +RTS -s -qg -I0 -A64M -N${THREADS} -RTS ${TEST}
+
 cabal-install-test:
-	cabal new-build -j3 all --disable-tests --disable-benchmarks
+	@which cabal-plan
+	$(CABALBUILD) -j3 cabal-tests cabal
 	rm -rf .ghc.environment.*
 	cd cabal-testsuite && `cabal-plan list-bin cabal-tests` --with-cabal=`cabal-plan list-bin cabal` --hide-successes -j3 ${TEST}


### PR DESCRIPTION
Add hacked the --cwd argument parsing to
parser-tests and check-tests. It's a kludge
but it's good enough.
