### PR TITLE
Add LibraryVisibility to InstalledPackageInfo

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -7,6 +7,7 @@
   * Add `extra-dynamic-library-flavours`, to specify extra dynamic library
     flavours to build and install from a .cabal file.
   * `autoconfUserHooks` now passes `--host=$HOST` when cross-compiling
+  * Add a `LibraryVisibility` field to `InstalledPackageInfo`
 
 ----
 

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -447,7 +447,8 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     IPI.frameworkDirs      = extraFrameworkDirs bi,
     IPI.haddockInterfaces  = [haddockdir installDirs </> haddockName pkg],
     IPI.haddockHTMLs       = [htmldir installDirs],
-    IPI.pkgRoot            = Nothing
+    IPI.pkgRoot            = Nothing,
+    IPI.libVisibility      = libVisibility lib
   }
   where
     ghc84 = case compilerId $ compiler lbi of

--- a/Cabal/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/Types/InstalledPackageInfo.hs
@@ -20,6 +20,7 @@ import Distribution.ModuleName
 import Distribution.Package                   hiding (installedUnitId)
 import Distribution.Types.AbiDependency
 import Distribution.Types.ExposedModule
+import Distribution.Types.LibraryVisibility
 import Distribution.Types.MungedPackageId
 import Distribution.Types.MungedPackageName
 import Distribution.Types.UnqualComponentName
@@ -86,7 +87,8 @@ data InstalledPackageInfo
         frameworks        :: [String],
         haddockInterfaces :: [FilePath],
         haddockHTMLs      :: [FilePath],
-        pkgRoot           :: Maybe FilePath
+        pkgRoot           :: Maybe FilePath,
+        libVisibility     :: LibraryVisibility
     }
     deriving (Eq, Generic, Typeable, Read, Show)
 
@@ -166,5 +168,6 @@ emptyInstalledPackageInfo
         frameworks        = [],
         haddockInterfaces = [],
         haddockHTMLs      = [],
-        pkgRoot           = Nothing
+        pkgRoot           = Nothing,
+        libVisibility     = LibraryVisibilityPrivate
     }

--- a/Cabal/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
+++ b/Cabal/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
@@ -21,6 +21,7 @@ import Distribution.Package
 import Distribution.Parsec
 import Distribution.Parsec.Newtypes
 import Distribution.Pretty
+import Distribution.Types.LibraryVisibility
 import Distribution.Types.MungedPackageName
 import Distribution.Types.UnqualComponentName
 import Distribution.Version
@@ -100,6 +101,7 @@ ipiFieldGrammar = mkInstalledPackageInfo
     <+> monoidalFieldAla    "haddock-interfaces"   (alaList' FSep FilePathNT)    L.haddockInterfaces
     <+> monoidalFieldAla    "haddock-html"         (alaList' FSep FilePathNT)    L.haddockHTMLs
     <+> optionalFieldAla    "pkgroot"              FilePathNT                    L.pkgRoot
+    <+> optionalFieldDef    "visibility"                                         L.libVisibility LibraryVisibilityPrivate
   where
     mkInstalledPackageInfo _ Basic {..} = InstalledPackageInfo
         -- _basicPkgName is not used

--- a/Cabal/Distribution/Types/InstalledPackageInfo/Lens.hs
+++ b/Cabal/Distribution/Types/InstalledPackageInfo/Lens.hs
@@ -12,6 +12,7 @@ import Distribution.License                    (License)
 import Distribution.ModuleName                 (ModuleName)
 import Distribution.Package                    (AbiHash, ComponentId, PackageIdentifier, UnitId)
 import Distribution.Types.InstalledPackageInfo (AbiDependency, ExposedModule, InstalledPackageInfo)
+import Distribution.Types.LibraryVisibility    (LibraryVisibility)
 import Distribution.Types.UnqualComponentName  (UnqualComponentName)
 
 import qualified Distribution.SPDX                       as SPDX
@@ -180,4 +181,8 @@ haddockHTMLs f s = fmap (\x -> s { T.haddockHTMLs = x }) (f (T.haddockHTMLs s))
 pkgRoot :: Lens' InstalledPackageInfo (Maybe FilePath)
 pkgRoot f s = fmap (\x -> s { T.pkgRoot = x }) (f (T.pkgRoot s))
 {-# INLINE pkgRoot #-}
+
+libVisibility :: Lens' InstalledPackageInfo LibraryVisibility
+libVisibility f s = fmap (\x -> s { T.libVisibility = x }) (f (T.libVisibility s))
+{-# INLINE libVisibility #-}
 

--- a/Cabal/tests/ParserTests/ipi/Includes2.expr
+++ b/Cabal/tests/ParserTests/ipi/Includes2.expr
@@ -36,6 +36,7 @@ InstalledPackageInfo
                                (DefUnitId `UnitId "Includes2-0.1.0.0-inplace-mysql"`))
                             `ModuleName ["Database","MySQL"]`)],
    ldOptions = [],
+   libVisibility = LibraryVisibilityPrivate,
    libraryDirs = ["/home/travis/build/haskell/cabal/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.dist/work/./dist/build/x86_64-linux/ghc-8.2.2/Includes2-0.1.0.0/l/mylib/Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n/build/Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n"],
    libraryDynDirs = ["/home/travis/build/haskell/cabal/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.dist/work/./dist/build/x86_64-linux/ghc-8.2.2/Includes2-0.1.0.0/l/mylib/Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n/build/Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n"],
    license = Right BSD3,

--- a/Cabal/tests/ParserTests/ipi/internal-preprocessor-test.expr
+++ b/Cabal/tests/ParserTests/ipi/internal-preprocessor-test.expr
@@ -29,6 +29,7 @@ InstalledPackageInfo
    installedUnitId = `UnitId "internal-preprocessor-test-0.1.0.0"`,
    instantiatedWith = [],
    ldOptions = [],
+   libVisibility = LibraryVisibilityPrivate,
    libraryDirs = ["/home/ogre/Documents/other-haskell/cabal/cabal-testsuite/PackageTests/CustomPreProcess/setup.dist/work/dist/build",
                   "/home/ogre/Documents/other-haskell/cabal/cabal-testsuite/PackageTests/CustomPreProcess/setup.dist/work/dist/build"],
    libraryDynDirs = [],

--- a/Cabal/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
+++ b/Cabal/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
@@ -2071,6 +2071,7 @@ InstalledPackageInfo
                 "-lm",
                 "-lm",
                 "-lm"],
+   libVisibility = LibraryVisibilityPrivate,
    libraryDirs = ["/opt/ghc/8.2.2/lib/ghc-8.2.2/transformers-0.5.2.0"],
    libraryDynDirs = ["/opt/ghc/8.2.2/lib/ghc-8.2.2/transformers-0.5.2.0"],
    license = Right BSD3,

--- a/Cabal/tests/ParserTests/ipi/transformers.expr
+++ b/Cabal/tests/ParserTests/ipi/transformers.expr
@@ -4,9 +4,9 @@ InstalledPackageInfo
    author = "Andy Gill, Ross Paterson",
    category = "Control",
    ccOptions = [],
-   cxxOptions = [],
    compatPackageKey = "transformers-0.5.2.0",
    copyright = "",
+   cxxOptions = [],
    dataDir = "/opt/ghc/8.2.2/share/x86_64-linux-ghc-8.2.2/transformers-0.5.2.0",
    depends = [`UnitId "base-4.10.1.0"`],
    description = concat
@@ -71,6 +71,7 @@ InstalledPackageInfo
    installedUnitId = `UnitId "transformers-0.5.2.0"`,
    instantiatedWith = [],
    ldOptions = [],
+   libVisibility = LibraryVisibilityPrivate,
    libraryDirs = ["/opt/ghc/8.2.2/lib/ghc-8.2.2/transformers-0.5.2.0"],
    libraryDynDirs = ["/opt/ghc/8.2.2/lib/ghc-8.2.2/transformers-0.5.2.0"],
    license = Right BSD3,


### PR DESCRIPTION
This pr only modifies the datatype. The field is not filled with the correct visibility info yet. We'll need a ghc-pkg compiled with this patch to actually record this information and properly test the visibility checks.

/cc @phadej @ezyang @23Skidoo

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
