### PR TITLE
Add global configuration option for non-interactive cabal init.

### DIFF
--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -1141,6 +1141,7 @@ initAction initFlags extraArgs globalFlags = do
   let configFlags  = savedConfigureFlags config `mappend`
                      -- override with `--with-compiler` from CLI if available
                      mempty { configHcPath = initHcPath initFlags }
+  let initFlags'   = savedInitFlags      config `mappend` initFlags
   let globalFlags' = savedGlobalFlags    config `mappend` globalFlags
   (comp, _, progdb) <- configCompilerAux' configFlags
   withRepoContext verbosity globalFlags' $ \repoContext ->
@@ -1149,7 +1150,7 @@ initAction initFlags extraArgs globalFlags = do
             repoContext
             comp
             progdb
-            initFlags
+            initFlags'
 
 sandboxAction :: SandboxFlags -> [String] -> Action
 sandboxAction sandboxFlags extraArgs globalFlags = do


### PR DESCRIPTION
## Overview

This PR adds support for specifying the `non-interactive` option for `cabal init` in `~/.cabal/config` with the default value being `False`. This does not change any default behaviour.

When the configuration file is generated (when it does not exist), it will contain the following line:

```
-- non-interactive: False
```

This partially addresses #5696.

## Testing

Manually tested. Added `non-interactive: False` to `~/.cabal/config` and ran `cabal init`:

```
$ cabal init

Guessing dependencies...

Generating LICENSE...
Warning: unknown license type, you must put a copy in LICENSE yourself.
Generating Setup.hs...
Generating CHANGELOG.md...
Generating myapp.cabal...

Warning: no synopsis given. You should edit the .cabal file and add one.
You may want to edit the .cabal file and add a Description field.
```

Note that no `.hs` files (other than Setup) are generated because the default is `Library` which currently doesn't generate any Haskell files for (at least until #5740 is merged). Also, I'd like to change this to generate an executable by default (see follow-ups section below).

## Possible follow-ups (RFC)

- Change the flag from a negative (`non-interactive: False`) to a positive (`interactive-init: True`)
- Change `cabal init` to by default generate an `Executable` or `LibAndExe` (the more common case, see the "Default to executable" section of #5696 for rationale).
- Change the default to be non-interactive (`cabal init` requires no args and generates an executable)

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
