### PR TITLE
Default to cabal version 2.4 when running `cabal init --simple`.

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -197,6 +197,7 @@ getSimpleProject flags = do
       flags { nonInteractive = Flag True
             , simpleProject = Flag True
             , packageType = Flag LibraryAndExecutable
+            , cabalVersion = Flag (mkVersion [2,4])
             }
     simpleProjFlag@_ ->
       flags { simpleProject = simpleProjFlag }


### PR DESCRIPTION
## Overview

`cabal init --simple` provides a way of initializing a cabal package with sensible defaults instead of requiring one to go through the entire interactive prompt. Its goal is to generate a modern directory structure (src/MyLib.hs, app/Main.hs, tests/MyLibTests.hs, etc.) and showcase new cabal features (^>=, recent cabal spec version, common stanzas, etc).

This change defaults to using a more recent cabal spec version instead of the current default of version 1.12.

This partially addresses #5696 and #5705.

## Testing

Manually tested. After running `cabal init --simple` the `.cabal` file contains `cabal-version: 2.4` as the first line of the file.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
