### PR TITLE
Improve GHCJS support

### DIFF
--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -306,15 +306,15 @@ buildComponent verbosity _ _ _ _
 
 buildComponent verbosity numJobs pkg_descr lbi suffixes
                comp@(CBench bm@Benchmark { benchmarkInterface = BenchmarkExeV10 {} })
-               clbi _ = do
-    let (exe, exeClbi) = benchmarkExeV10asExe bm clbi
+               clbi _distPref = do
+    let exe = benchmarkExeV10asExe bm
     preprocessComponent pkg_descr comp lbi clbi False verbosity suffixes
     extras <- preprocessExtras verbosity comp lbi
     setupMessage' verbosity "Building" (packageId pkg_descr)
       (componentLocalName clbi) (maybeComponentInstantiatedWith clbi)
     let ebi = buildInfo exe
         exe' = exe { buildInfo = addExtraCSources ebi extras }
-    buildExe verbosity numJobs pkg_descr lbi exe' exeClbi
+    buildExe verbosity numJobs pkg_descr lbi exe' clbi
     return Nothing
 
 
@@ -406,13 +406,13 @@ replComponent _ verbosity _ _ _
 
 replComponent replFlags verbosity pkg_descr lbi suffixes
                comp@(CBench bm@Benchmark { benchmarkInterface = BenchmarkExeV10 {} })
-               clbi _ = do
-    let (exe, exeClbi) = benchmarkExeV10asExe bm clbi
+               clbi _distPref = do
+    let exe = benchmarkExeV10asExe bm
     preprocessComponent pkg_descr comp lbi clbi False verbosity suffixes
     extras <- preprocessExtras verbosity comp lbi
     let ebi = buildInfo exe
         exe' = exe { buildInfo = ebi { cSources = cSources ebi ++ extras } }
-    replExe replFlags verbosity pkg_descr lbi exe' exeClbi
+    replExe replFlags verbosity pkg_descr lbi exe' clbi
 
 
 replComponent _ verbosity _ _ _
@@ -434,6 +434,17 @@ testSuiteExeV10AsExe test@TestSuite { testInterface = TestSuiteExeV10 _ mainFile
       buildInfo  = testBuildInfo test
     }
 testSuiteExeV10AsExe TestSuite{} = error "testSuiteExeV10AsExe: wrong kind"
+
+-- | Translate a exe-style 'Benchmark' component into an exe for building
+benchmarkExeV10asExe :: Benchmark -> Executable
+benchmarkExeV10asExe bm@Benchmark { benchmarkInterface = BenchmarkExeV10 _ mainFile } =
+    Executable {
+      exeName    = benchmarkName bm,
+      modulePath = mainFile,
+      exeScope   = ExecutablePublic,
+      buildInfo  = benchmarkBuildInfo bm
+    }
+benchmarkExeV10asExe Benchmark{} = error "benchmarkExeV10asExe: wrong kind"
 
 -- | Translate a lib-style 'TestSuite' component into a lib + exe for building
 testSuiteLibV09AsLibAndExe :: PackageDescription
@@ -526,30 +537,6 @@ testSuiteLibV09AsLibAndExe pkg_descr
               }
 testSuiteLibV09AsLibAndExe _ TestSuite{} _ _ _ _ = error "testSuiteLibV09AsLibAndExe: wrong kind"
 
-
--- | Translate a exe-style 'Benchmark' component into an exe for building
-benchmarkExeV10asExe :: Benchmark -> ComponentLocalBuildInfo
-                     -> (Executable, ComponentLocalBuildInfo)
-benchmarkExeV10asExe bm@Benchmark { benchmarkInterface = BenchmarkExeV10 _ f }
-                     clbi =
-    (exe, exeClbi)
-  where
-    exe = Executable {
-            exeName    = benchmarkName bm,
-            modulePath = f,
-            exeScope   = ExecutablePublic,
-            buildInfo  = benchmarkBuildInfo bm
-          }
-    exeClbi = ExeComponentLocalBuildInfo {
-                componentUnitId = componentUnitId clbi,
-                componentComponentId = componentComponentId clbi,
-                componentLocalName = CExeName (benchmarkName bm),
-                componentInternalDeps = componentInternalDeps clbi,
-                componentExeDeps = componentExeDeps clbi,
-                componentPackageDeps = componentPackageDeps clbi,
-                componentIncludes = componentIncludes clbi
-              }
-benchmarkExeV10asExe Benchmark{} _ = error "benchmarkExeV10asExe: wrong kind"
 
 -- | Initialize a new package db file for libraries defined
 -- internally to the package.

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -563,8 +563,11 @@ buildOrReplExe mReplFlags verbosity numJobs _pkg_descr lbi
   let isGhcjsDynamic      = isDynamic comp
       dynamicTooSupported = supportsDynamicToo comp
       buildRunner = case clbi of
-                       ExeComponentLocalBuildInfo {} -> False
-                       _                             -> True
+                      LibComponentLocalBuildInfo   {} -> False
+                      FLibComponentLocalBuildInfo  {} -> False
+                      ExeComponentLocalBuildInfo   {} -> True
+                      TestComponentLocalBuildInfo  {} -> True
+                      BenchComponentLocalBuildInfo {} -> True
       isHaskellMain = elem (takeExtension srcMainFile) [".hs", ".lhs"]
       jsSrcs        = jsSources exeBi
       cSrcs         = cSources exeBi ++ [srcMainFile | not isHaskellMain]

--- a/Cabal/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/Distribution/Simple/LocalBuildInfo.hs
@@ -161,7 +161,7 @@ withExeLBI pkg lbi f =
 withBenchLBI :: PackageDescription -> LocalBuildInfo
             -> (Benchmark -> ComponentLocalBuildInfo -> IO ()) -> IO ()
 withBenchLBI pkg lbi f =
-    sequence_ [ f test clbi | (test, clbi) <- enabledBenchLBIs pkg lbi ]
+    sequence_ [ f bench clbi | (bench, clbi) <- enabledBenchLBIs pkg lbi ]
 
 withTestLBI :: PackageDescription -> LocalBuildInfo
             -> (TestSuite -> ComponentLocalBuildInfo -> IO ()) -> IO ()


### PR DESCRIPTION
This PR contains two commits:

----

### Align `benchmarkExeV10asExe` with `testSuiteExeV10AsExe`'s type-sig 

For some reason, the two operations

    testSuiteExeV10AsExe :: TestSuite -> Executable

    benchmarkExeV10asExe :: Benchmark -> ComponentLocalBuildInfo -> (Executable, ComponentLocalBuildInfo)

were different even though benchmarks and test-suite should be handled
mostly the same.

This divergence was exposed by #5831.

----

### Enable `ghcjs`' `-build-runner` explicitly for exe/test/benches

This way, we automatically gain *some* level of support for
`build-tools-depends` as well as for `v2-install` for applications
which are executed via nodejs

For instance, the following now works:

    $ cabal v2-install -w /opt/ghcjs/8.4/bin/ghcjs --ghcjs alex --symlink-bindir=/tmp/bin
    Resolving dependencies...
    Build profile: -w ghcjs-8.4.0.1 -O1
    In order, the following will be built (use -v for more details):
     - alex-3.2.4 (exe:alex) (requires build)
    Starting     alex-3.2.4 (exe:alex)
    Building     alex-3.2.4 (exe:alex)
    Installing   alex-3.2.4 (exe:alex)
    Completed    alex-3.2.4 (exe:alex)
    Symlinking 'alex'

    $ file - < /tmp/bin/alex
    /dev/stdin: a /usr/bin/nodejs script, UTF-8 Unicode text executable

    $ /tmp/bin/alex  --version
    Alex version 3.2.4, (c) 2003 Chris Dornan and Simon Marlow

This is the best we can without teaching cabal about cross-compilation
and distinguishing local native executables (build by a native-targetting
haskell compiler) for build-tools/custom-setup vs
the main compilation goals for the target platform (which is build with
a haskell cross-compiler).