### PR TITLE
Add init section to global cabal config.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -802,7 +802,8 @@ commentSavedConfig = do
             IT.nonInteractive  = toFlag False,
             IT.cabalVersion    = toFlag (mkVersion [1,10]),
             IT.language        = toFlag Haskell2010,
-            IT.license         = toFlag BSD3
+            IT.license         = toFlag BSD3,
+            IT.sourceDirs      = Nothing
             },
         savedInstallFlags      = defaultInstallFlags,
         savedConfigureExFlags  = defaultConfigExFlags {
@@ -1260,7 +1261,7 @@ initFlagsFields = [ field
        "package-dir", "packagedir", "package-name", "version", "homepage",
         "synopsis", "category", "extra-source-file", "lib", "exe", "libandexe",
         "simple", "main-is", "expose-module", "exposed-modules", "extension",
-        "dependency", "source-dir", "build-tool", "with-compiler",
+        "dependency", "build-tool", "with-compiler",
         "verbose"]
 
 -- | Fields for the 'program-locations' section.


### PR DESCRIPTION
# Summary

Add a new `init` section to the global cabal config file for `cabal init`. The following fields can be currently be configured in this section: `non-interactive`, `cabal-version`, `license`, `language`, `source-dir`.

Partially addresses #5696.

# Testing

Re-generating ~/.cabal/config results in a section containing the current default values for `cabal init`:

```
init
  -- non-interactive: False
  -- cabal-version: 1.10
  -- license: BSD3
  -- language: Haskell2010
  -- source-dir:
```

Changing the values to:

```
init
  non-interactive: True
  cabal-version: 2.5
  -- license: BSD3
  -- language: Haskell2010
  -- source-dir:
```

And running `cabal init --exe` does not enter the interactive prompt and produces a cabal file with `cabal-version: 2.5`.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

/cc @23Skidoo @hvr 