### PR TITLE
Use Haskell2010 and BSD3 for simple project initialization.

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -195,9 +195,11 @@ getSimpleProject flags = do
   return $ case maybeToFlag simpleProj of
     Flag True ->
       flags { nonInteractive = Flag True
-            , simpleProject = Flag True
-            , packageType = Flag LibraryAndExecutable
-            , cabalVersion = Flag (mkVersion [2,4])
+            , simpleProject  = Flag True
+            , packageType    = Flag LibraryAndExecutable
+            , cabalVersion   = Flag (mkVersion [2,4])
+            , language       = Flag Haskell2010
+            , license        = Flag BSD3
             }
     simpleProjFlag@_ ->
       flags { simpleProject = simpleProjFlag }


### PR DESCRIPTION
# Overview

cabal init --simple provides a way of initializing a cabal package with sensible defaults instead of requiring one to go through the entire interactive prompt. Its goal is to generate a modern directory structure (src/MyLib.hs, app/Main.hs, tests/MyLibTests.hs, etc.) and showcase new cabal features (^>=, recent cabal spec version, common stanzas, etc).

This change explicitly specifies Haskell2010 and BSD3 for the license.

This partially addresses #5696.

Testing
Manually tested. After running `cabal init --simple` the `.cabal` file contains `license: BSD-3-Clause` .

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
