### PR TITLE
Default to initializing executable when not specified to `cabal init`

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -380,11 +380,11 @@ guessExtraSourceFiles flags = do
 getLibOrExec :: InitFlags -> IO InitFlags
 getLibOrExec flags = do
   pkgType <-     return (flagToMaybe $ packageType flags)
-           ?>> maybePrompt flags (either (const Library) id `fmap`
+           ?>> maybePrompt flags (either (const Executable) id `fmap`
                                    promptList "What does the package build"
-                                   [Library, Executable, LibraryAndExecutable]
+                                   [Executable, Library, LibraryAndExecutable]
                                    Nothing displayPackageType False)
-           ?>> return (Just Library)
+           ?>> return (Just Executable)
 
   -- If this package contains an executable, get the main file name.
   mainFile <- if pkgType == Just Library then return Nothing else


### PR DESCRIPTION
# Overview

Default to initializing an executable when running `cabal init` non-interactively. This is inline with the other Haskell project initialization tools, as well as tools in other languages (such as Rust's Cargo).

This partially addresses #5696.

# Rationale

It is more common to want a binary than a library because often one wants to simply play around with an idea then to develop a full fledged library to publish on Hackage. Additionally, the binary case is always more common than the library case because each library is depended upon by _1 or more_ executables.

# Behaviour Change

**Before:**

`cabal init --non-interactive` produces a library.

The `Library` option is choice 1 in the interactive prompt list.

**After:**

`cabal init --non-interactive` produces a binary.

The `Executable` option is choice 1 in the interactive prompt list.

 

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
