### PR TITLE
Add documentation on --config-file and CABAL_CONFIG env variable.

### DIFF
--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -15,6 +15,10 @@ explicitly ask ``cabal`` to create it for you using
 
     $ cabal user-config update
 
+You can change the location of the global configuration file by specifying
+either ``--config-file=FILE`` on the command line or by setting the
+``CABAL_CONFIG`` environment variable.
+
 Most of the options in this configuration file are also available as
 command line arguments, and the corresponding documentation can be used
 to lookup their meaning. The created configuration file only specifies


### PR DESCRIPTION
Add information about the `--config-file` command line flag and the `CABAL_CONFIG` environment variable for specifying the cabal config file to section 2.1 ([Configuration](https://www.haskell.org/cabal/users-guide/installing-packages.html)) of the Cabal User Guide.

Fixes #5322.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
