### PR TITLE
Add info on common stanzas to Quickstart module import section

### DIFF
--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -185,6 +185,27 @@ The last is just shorthand, for example ``base == 4.*`` means exactly
 the same thing as ``base >= 4 && < 5``. Please refer to the documentation
 on the :pkg-field:`build-depends` field for more information.
 
+Also, you can factor out shared ``build-depends`` (and other fields such
+as ``ghc-options``) into a ``common`` stanza which you can ``import`` in
+your libraries and executable sections. For example:
+
+::
+
+    common shared-properties
+      default-language: Haskell2010
+      build-depends:
+        base == 4.*
+      ghc-options:
+        -Wall
+
+    library
+      import: shared-properties
+      exposed-modules:
+        Proglet
+
+Note that the ``import`` **must** be the first thing in the stanza. For more
+information see the `Common stanzas`_ section.
+
 Building the package
 --------------------
 


### PR DESCRIPTION
Add a paragraph about common stanzas to the "Modules imported from other packages" section in Quickstart. This improves discoverability of this cabal feature which is currently somewhat difficult to find.

Fixes #5860.

Rendered docs: https://i.imgur.com/OcOgFhy.png

/cc @david-christiansen

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.


