### PR TITLE
Append newline to the end of sdist help message

### DIFF
--- a/cabal-install/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/Distribution/Client/CmdSdist.hs
@@ -51,7 +51,7 @@ import Distribution.Simple.Setup
 import Distribution.Simple.SrcDist
     ( listPackageSources )
 import Distribution.Simple.Utils
-    ( die', notice, withOutputMarker )
+    ( die', notice, withOutputMarker, wrapText )
 import Distribution.Types.ComponentName
     ( ComponentName, showComponentName )
 import Distribution.Types.PackageName
@@ -91,7 +91,7 @@ sdistCommand = CommandUI
     , commandSynopsis = "Generate a source distribution file (.tar.gz)."
     , commandUsage = \pname ->
         "Usage: " ++ pname ++ " v2-sdist [FLAGS] [PACKAGES]\n"
-    , commandDescription  = Just $ \_ ->
+    , commandDescription  = Just $ \_ -> wrapText
         "Generates tarballs of project packages suitable for upload to Hackage."
     , commandNotes = Nothing
     , commandDefaultFlags = defaultSdistFlags


### PR DESCRIPTION
The help message did not end with newline before and looked weird as it
can concatenate with next shell prompt.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
