### PR TITLE
Fix sdist output when sent to stdout

### DIFF
--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,7 @@
 -*-change-log-*-
 
 3.0.0.0 (current development version)
+	* Fix `sdist`'s output when sent to stdout. (#5874)
 	* Allow a list of dependencies to be provided for `repl --build-depends`. (#5845)
 	* Legacy commands are now only accessible with the `v1-` prefixes, and the `v2-`
 	  commands are the new default. Accordingly, the next version of Cabal will be


### PR DESCRIPTION
This was broken by 7a029caa7026f9b6b585a68062a4175eadb6ca4f

We can not use `ByteString.pack` and then print it as `String`, which
will get encoded again based on the system setting, and very likely,
we get different things unless the encoding is something like ISO-8859-1, e.g.
in UTF-8 environment, the magic of gz "\x1f\x8b" will get encoded again
into "\x1f\xc2\x8b".

Before:

```
$ /cabal sdist --output-dir=- | tar -t -z -f -
tar: This does not look like a tar archive
```

And now:

```
$ cabal sdist --output-dir=- | tar -t -z -f -  | tail -n 1
cabal-install-2.5.0.0/tests/README.md
```


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
