### PR TITLE
Increase `max-backjumps` default from 2000 to 4000

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -2050,13 +2050,13 @@ Most users generally won't need these.
                --max-backjumps=N
     :synopsis: Maximum number of solver backjumps.
 
-    :default: 2000
+    :default: 4000
 
     Maximum number of backjumps (backtracking multiple steps) allowed
     while solving. Set -1 to allow unlimited backtracking, and 0 to
     disable backtracking completely.
 
-    The command line variant of this field is ``--max-backjumps=2000``.
+    The command line variant of this field is ``--max-backjumps=4000``.
 
 .. cfg-field:: reorder-goals: boolean
                --reorder-goals

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -1781,7 +1781,7 @@ defaultInstallFlags = InstallFlags {
                                    </> "$arch-$os-$compiler" </> "index.html")
 
 defaultMaxBackjumps :: Int
-defaultMaxBackjumps = 2000
+defaultMaxBackjumps = 4000
 
 defaultSolver :: PreSolver
 defaultSolver = AlwaysModular

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -19,6 +19,7 @@
 	* Init improvements: add flag '--application-dir', and when creating
 	  a library also create a MyLib.hs module. (#5740)
 	* Add support for generating test-suite via cabal init. (#5761)
+	* Increase `max-backjumps` default from 2000 to 4000.
 
 2.4.1.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> November 2018
 	* Add message to alert user to potential package casing errors. (#5635)


### PR DESCRIPTION
The last time the max-backjumps was increased was back in 2014
(see 0229cd5252d44ca65cf33fe350852b46b1a70b20) as suggested
per #1780, and while `--reorder-goals` might often help as well,
it also often comes at a bigger runtime penalty on average than
doubling the max-backjumps.

This should also address issues such as #5882


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
