### PR TITLE
Docs: properly escape character literals

### DIFF
--- a/Cabal/Distribution/Fields/Parser.hs
+++ b/Cabal/Distribution/Fields/Parser.hs
@@ -161,42 +161,42 @@ inLexerMode (LexerMode mode) p =
 -- @
 -- CabalStyleFile ::= SecElems
 --
--- SecElems       ::= SecElem* '\n'?
--- SecElem        ::= '\n' SecElemLayout | SecElemBraces
+-- SecElems       ::= SecElem* '\\n'?
+-- SecElem        ::= '\\n' SecElemLayout | SecElemBraces
 -- SecElemLayout  ::= FieldLayout | FieldBraces | SectionLayout | SectionBraces
 -- SecElemBraces  ::= FieldInline | FieldBraces |                 SectionBraces
--- FieldLayout    ::= name ':' line? ('\n' line)*
--- FieldBraces    ::= name ':' '\n'? '{' content '}'
+-- FieldLayout    ::= name ':' line? ('\\n' line)*
+-- FieldBraces    ::= name ':' '\\n'? '{' content '}'
 -- FieldInline    ::= name ':' content
 -- SectionLayout  ::= name arg* SecElems
--- SectionBraces  ::= name arg* '\n'? '{' SecElems '}'
+-- SectionBraces  ::= name arg* '\\n'? '{' SecElems '}'
 -- @
 --
 -- and the same thing but left factored...
 --
 -- @
 -- SecElems              ::= SecElem*
--- SecElem               ::= '\n' name SecElemLayout
+-- SecElem               ::= '\\n' name SecElemLayout
 --                         |      name SecElemBraces
 -- SecElemLayout         ::= ':'   FieldLayoutOrBraces
 --                         | arg*  SectionLayoutOrBraces
--- FieldLayoutOrBraces   ::= '\n'? '{' content '}'
---                         | line? ('\n' line)*
--- SectionLayoutOrBraces ::= '\n'? '{' SecElems '\n'? '}'
+-- FieldLayoutOrBraces   ::= '\\n'? '{' content '}'
+--                         | line? ('\\n' line)*
+-- SectionLayoutOrBraces ::= '\\n'? '{' SecElems '\\n'? '}'
 --                         | SecElems
 -- SecElemBraces         ::= ':' FieldInlineOrBraces
---                         | arg* '\n'? '{' SecElems '\n'? '}'
--- FieldInlineOrBraces   ::= '\n'? '{' content '}'
+--                         | arg* '\\n'? '{' SecElems '\\n'? '}'
+-- FieldInlineOrBraces   ::= '\\n'? '{' content '}'
 --                         | content
 -- @
 --
 -- Note how we have several productions with the sequence:
 --
--- > '\n'? '{'
+-- > '\\n'? '{'
 --
 -- That is, an optional newline (and indent) followed by a @{@ token.
 -- In the @SectionLayoutOrBraces@ case you can see that this makes it
--- not fully left factored (because @SecElems@ can start with a @\n@).
+-- not fully left factored (because @SecElems@ can start with a @\\n@).
 -- Fully left factoring here would be ugly, and though we could use a
 -- lookahead of two tokens to resolve the alternatives, we can't
 -- conveniently use Parsec's 'try' here to get a lookahead of only two.
@@ -223,7 +223,7 @@ elements ilevel = many (element ilevel)
 -- layout style or braces style. For layout style then it must start on
 -- a line on its own (so that we know its indentation level).
 --
--- element ::= '\n' name elementInLayoutContext
+-- element ::= '\\n' name elementInLayoutContext
 --           |      name elementInNonLayoutContext
 element :: IndentLevel -> Parser (Field Position)
 element ilevel =
@@ -251,7 +251,7 @@ elementInLayoutContext ilevel name =
 -- themselves use braces style, or inline style fields.
 --
 -- elementInNonLayoutContext ::= ':' FieldInlineOrBraces
---                             | arg* '\n'? '{' elements '\n'? '}'
+--                             | arg* '\\n'? '{' elements '\\n'? '}'
 elementInNonLayoutContext :: Name Position -> Parser (Field Position)
 elementInNonLayoutContext name =
       (do colon; fieldInlineOrBraces name)
@@ -264,8 +264,8 @@ elementInNonLayoutContext name =
 
 -- The body of a field, using either layout style or braces style.
 --
--- fieldLayoutOrBraces   ::= '\n'? '{' content '}'
---                         | line? ('\n' line)*
+-- fieldLayoutOrBraces   ::= '\\n'? '{' content '}'
+--                         | line? ('\\n' line)*
 fieldLayoutOrBraces :: IndentLevel -> Name Position -> Parser (Field Position)
 fieldLayoutOrBraces ilevel name = braces <|> fieldLayout
   where
@@ -283,7 +283,7 @@ fieldLayoutOrBraces ilevel name = braces <|> fieldLayout
 
 -- The body of a section, using either layout style or braces style.
 --
--- sectionLayoutOrBraces ::= '\n'? '{' elements \n? '}'
+-- sectionLayoutOrBraces ::= '\\n'? '{' elements \\n? '}'
 --                         | elements
 sectionLayoutOrBraces :: IndentLevel -> Parser [Field Position]
 sectionLayoutOrBraces ilevel =
@@ -296,7 +296,7 @@ sectionLayoutOrBraces ilevel =
 
 -- The body of a field, using either inline style or braces.
 --
--- fieldInlineOrBraces   ::= '\n'? '{' content '}'
+-- fieldInlineOrBraces   ::= '\\n'? '{' content '}'
 --                         | content
 fieldInlineOrBraces :: Name Position -> Parser (Field Position)
 fieldInlineOrBraces name =

--- a/Cabal/Distribution/Parsec/FieldLineStream.hs
+++ b/Cabal/Distribution/Parsec/FieldLineStream.hs
@@ -19,7 +19,7 @@ import Prelude ()
 import qualified Data.ByteString as BS
 import qualified Text.Parsec     as Parsec
 
--- | This is essentially a lazy bytestring, but chunks are glued with newline '\n'.
+-- | This is essentially a lazy bytestring, but chunks are glued with newline @\'\\n\'@.
 data FieldLineStream
     = FLSLast !ByteString
     | FLSCons {-# UNPACK #-} !ByteString FieldLineStream

--- a/Cabal/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/Distribution/Simple/BuildPaths.hs
@@ -188,7 +188,7 @@ flibBuildDir lbi flib = buildDir lbi </> nm </> nm ++ "-tmp"
 -- Library file names
 
 -- | Create a library name for a static library from a given name.
--- Prepends 'lib' and appends the static library extension ('.a').
+-- Prepends @lib@ and appends the static library extension (@.a@).
 mkGenericStaticLibName :: String -> String
 mkGenericStaticLibName lib = "lib" ++ lib <.> "a"
 
@@ -199,7 +199,7 @@ mkProfLibName :: UnitId -> String
 mkProfLibName lib =  mkGenericStaticLibName (getHSLibraryName lib ++ "_p")
 
 -- | Create a library name for a shared library from a given name.
--- Prepends 'lib' and appends the '-<compilerFlavour><compilerVersion>'
+-- Prepends @lib@ and appends the @-\<compilerFlavour\>\<compilerVersion\>@
 -- as well as the shared library extension.
 mkGenericSharedLibName :: Platform -> CompilerId -> String -> String
 mkGenericSharedLibName platform (CompilerId compilerFlavor compilerVersion) lib
@@ -207,8 +207,8 @@ mkGenericSharedLibName platform (CompilerId compilerFlavor compilerVersion) lib
   where comp = prettyShow compilerFlavor ++ prettyShow compilerVersion
 
 -- Implement proper name mangling for dynamical shared objects
--- libHS<packagename>-<compilerFlavour><compilerVersion>
--- e.g. libHSbase-2.1-ghc6.6.1.so
+-- @libHS\<packagename\>-\<compilerFlavour\>\<compilerVersion\>@
+-- e.g. @libHSbase-2.1-ghc6.6.1.so@
 mkSharedLibName :: Platform -> CompilerId -> UnitId -> String
 mkSharedLibName platform comp lib
   = mkGenericSharedLibName platform comp (getHSLibraryName lib)


### PR DESCRIPTION
Single quotes in Haddock are used for references to other identifiers.
Character literals should have both the single quote and possible backslash
escaped with extra backslashes.

[ci skip]

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
