### PR TITLE
Fix non-interactive flag name.

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2211,7 +2211,7 @@ initOptions _ =
   [ option ['i'] ["interactive"]
     "interactive mode."
     IT.interactive (\v flags -> flags { IT.interactive = v })
-    (boolOpt' (['i'], ["interactive"]) (['n'], ["nonInteractive"]))
+    (boolOpt' (['i'], ["interactive"]) (['n'], ["non-interactive"]))
 
   , option ['q'] ["quiet"]
     "Do not generate log messages to stdout."


### PR DESCRIPTION
When introducing the --interactive flag in #5864 I accidentally changed the flag
name from --non-interactive to --nonInteractive. This reverts that change.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
