### PR TITLE
caret operator accepts a set of versions

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -73,6 +73,14 @@ extra-source-files:
   tests/ParserTests/errors/spdx-2.errors
   tests/ParserTests/errors/spdx-3.cabal
   tests/ParserTests/errors/spdx-3.errors
+  tests/ParserTests/errors/version-sets-1.cabal
+  tests/ParserTests/errors/version-sets-1.errors
+  tests/ParserTests/errors/version-sets-2.cabal
+  tests/ParserTests/errors/version-sets-2.errors
+  tests/ParserTests/errors/version-sets-3.cabal
+  tests/ParserTests/errors/version-sets-3.errors
+  tests/ParserTests/errors/version-sets-4.cabal
+  tests/ParserTests/errors/version-sets-4.errors
   tests/ParserTests/ipi/Includes2.cabal
   tests/ParserTests/ipi/Includes2.expr
   tests/ParserTests/ipi/Includes2.format
@@ -172,6 +180,9 @@ extra-source-files:
   tests/ParserTests/regressions/th-lift-instances.cabal
   tests/ParserTests/regressions/th-lift-instances.expr
   tests/ParserTests/regressions/th-lift-instances.format
+  tests/ParserTests/regressions/version-sets.cabal
+  tests/ParserTests/regressions/version-sets.expr
+  tests/ParserTests/regressions/version-sets.format
   tests/ParserTests/regressions/wl-pprint-indef.cabal
   tests/ParserTests/regressions/wl-pprint-indef.expr
   tests/ParserTests/regressions/wl-pprint-indef.format

--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,6 +1,6 @@
 # 2.6.0.0 (current development version)
   * TODO
-  * `^>=` takes multiple parameters
+  * Introduce set notation for `^>=` and `==` operators.
   * 'check' reports warnings for various ghc-\*-options fields separately
     ([#5342](https://github.com/haskell/cabal/issues/5432)).
   * `KnownExtension`: added new extension `DerivingVia`.

--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,5 +1,6 @@
 # 2.6.0.0 (current development version)
   * TODO
+  * `^>=` takes multiple parameters
   * 'check' reports warnings for various ghc-\*-options fields separately
     ([#5342](https://github.com/haskell/cabal/issues/5432)).
   * `KnownExtension`: added new extension `DerivingVia`.

--- a/Cabal/Distribution/Types/VersionRange.hs
+++ b/Cabal/Distribution/Types/VersionRange.hs
@@ -495,12 +495,15 @@ instance Parsec VersionRange where
         verSet :: CabalParsing m => m [Version]
         verSet = do
             _ <- P.char '{'
-            vs <- P.sepBy1 (P.spaces *> verPlain) (P.try (P.spaces *> P.char ','))
             P.spaces
+            vs <- P.sepBy1 (verPlain <* P.spaces) (P.char ',' *> P.spaces)
             _ <- P.char '}'
             pure vs
 
-        -- plain version without tags or wildcards
+        -- a plain version without tags or wildcards
+        -- note: this uses P.integral which allows redundant zeros.
+        --   This is not a problem because 'verPlain' is only used by
+        --   'verSet' which requires cabal > 3
         verPlain :: CabalParsing m => m Version
         verPlain = mkVersion <$> P.sepBy1 P.integral (P.char '.')
 

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2134,6 +2134,25 @@ system-dependent values for these fields.
        renaming in ``build-depends``; however, this support has since been
        removed and should not be used.
 
+    Starting with Cabal 3.0, a set notation for the ``==`` and ``^>=`` operator
+    is available. For instance,
+
+    ::
+
+        tested-with: GHC == 8.6.3, GHC == 8.4.4, GHC == 8.2.2, GHC == 8.0.2,
+                     GHC == 7.10.3, GHC == 7.8.4, GHC == 7.6.3, GHC == 7.4.2
+
+        build-depends: network ^>= 2.6.3.6 || ^>= 2.7.0.2 || ^>= 2.8.0.0 || ^>= 3.0.1.0
+
+    can be then written in a more convenient and concise form
+
+    ::
+
+        tested-with: GHC == { 8.6.3, 8.4.4, 8.2.2, 8.0.2, 7.10.3, 7.8.4, 7.6.3, 7.4.2 }
+
+        build-depends: network ^>= { 2.6.3.6, 2.7.0.2, 2.8.0.0, 3.0.1.0 }
+
+
 .. pkg-field:: other-modules: identifier list
 
     A list of modules used by the component but not exposed to users.

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -112,6 +112,10 @@ errorTests = testGroup "errors"
     , errorTest "spdx-2.cabal"
     , errorTest "spdx-3.cabal"
     , errorTest "removed-fields.cabal"
+    , errorTest "version-sets-1.cabal"
+    , errorTest "version-sets-2.cabal"
+    , errorTest "version-sets-3.cabal"
+    , errorTest "version-sets-4.cabal"
     ]
 
 errorTest :: FilePath -> TestTree
@@ -159,6 +163,7 @@ regressionTests = testGroup "regressions"
     , regressionTest "spdx-3.cabal"
     , regressionTest "hidden-main-lib.cabal"
     , regressionTest "jaeger-flamegraph.cabal"
+    , regressionTest "version-sets.cabal"
     ]
 
 regressionTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests/errors/version-sets-1.cabal
+++ b/Cabal/tests/ParserTests/errors/version-sets-1.cabal
@@ -1,0 +1,8 @@
+cabal-version:       2.5
+name:                version-sets
+version:             0
+synopsis:            version set notation
+
+library
+  default-language: Haskell2010
+  build-depends: network == { }

--- a/Cabal/tests/ParserTests/errors/version-sets-1.errors
+++ b/Cabal/tests/ParserTests/errors/version-sets-1.errors
@@ -1,0 +1,5 @@
+VERSION: Just (mkVersion [2,5])
+version-sets-1.cabal:8:31: 
+unexpected "}"
+expecting space or integral
+

--- a/Cabal/tests/ParserTests/errors/version-sets-2.cabal
+++ b/Cabal/tests/ParserTests/errors/version-sets-2.cabal
@@ -1,0 +1,8 @@
+cabal-version:       2.5
+name:                version-sets
+version:             0
+synopsis:            version set notation
+
+library
+  default-language: Haskell2010
+  build-depends: network >= { 2.8.0.0 }

--- a/Cabal/tests/ParserTests/errors/version-sets-2.errors
+++ b/Cabal/tests/ParserTests/errors/version-sets-2.errors
@@ -1,0 +1,5 @@
+VERSION: Just (mkVersion [2,5])
+version-sets-2.cabal:8:29: 
+unexpected "{"
+expecting space or integral
+

--- a/Cabal/tests/ParserTests/errors/version-sets-3.cabal
+++ b/Cabal/tests/ParserTests/errors/version-sets-3.cabal
@@ -1,0 +1,8 @@
+cabal-version:       2.5
+name:                version-sets
+version:             0
+synopsis:            version set notation
+
+library
+  default-language: Haskell2010
+  build-depends: network == { 2.8.0.0, }

--- a/Cabal/tests/ParserTests/errors/version-sets-3.errors
+++ b/Cabal/tests/ParserTests/errors/version-sets-3.errors
@@ -1,0 +1,5 @@
+VERSION: Just (mkVersion [2,5])
+version-sets-3.cabal:8:40: 
+unexpected "}"
+expecting space or integral
+

--- a/Cabal/tests/ParserTests/errors/version-sets-4.cabal
+++ b/Cabal/tests/ParserTests/errors/version-sets-4.cabal
@@ -1,0 +1,8 @@
+cabal-version:       2.5
+name:                version-sets
+version:             0
+synopsis:            version set notation
+
+library
+  default-language: Haskell2010
+  build-depends: network == { 2.8.* }

--- a/Cabal/tests/ParserTests/errors/version-sets-4.errors
+++ b/Cabal/tests/ParserTests/errors/version-sets-4.errors
@@ -1,0 +1,5 @@
+VERSION: Just (mkVersion [2,5])
+version-sets-4.cabal:8:35: 
+unexpected "*"
+expecting integral
+

--- a/Cabal/tests/ParserTests/regressions/version-sets.cabal
+++ b/Cabal/tests/ParserTests/regressions/version-sets.cabal
@@ -1,0 +1,18 @@
+cabal-version:       2.5
+name:                version-sets
+version:             0
+synopsis:            version set notation
+tested-with: GHC == { 8.6.3, 8.4.4, 8.2.2, 8.0.2, 7.10.3, 7.8.4, 7.6.3, 7.4.2 }
+
+library
+  default-language: Haskell2010
+  build-depends: network ^>= {0}
+  build-depends: base == {1}, base == { 1 }, base == {1,2}, base == {1.2}, base == {1.2,3.4}
+  build-depends: ghc == {
+    8.6.3
+    ,
+    8.4.4    ,8.2.2     ,
+    8.0.2,7.10.3
+    , 7.8.4, 7.6.3, 7.4.2
+    }
+  build-depends: Cabal ^>= { 2.4.1.1, 2.2.0.0 }

--- a/Cabal/tests/ParserTests/regressions/version-sets.expr
+++ b/Cabal/tests/ParserTests/regressions/version-sets.expr
@@ -1,0 +1,241 @@
+GenericPackageDescription
+  {condBenchmarks = [],
+   condExecutables = [],
+   condForeignLibs = [],
+   condLibrary = Just
+                   CondNode
+                     {condTreeComponents = [],
+                      condTreeConstraints = [Dependency
+                                               `PackageName "network"`
+                                               (MajorBoundVersion `mkVersion [0]`)
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "base"`
+                                               (ThisVersion `mkVersion [1]`)
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "base"`
+                                               (ThisVersion `mkVersion [1]`)
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "base"`
+                                               (UnionVersionRanges
+                                                  (ThisVersion `mkVersion [1]`)
+                                                  (ThisVersion `mkVersion [2]`))
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "base"`
+                                               (ThisVersion `mkVersion [1,2]`)
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "base"`
+                                               (UnionVersionRanges
+                                                  (ThisVersion `mkVersion [1,2]`)
+                                                  (ThisVersion `mkVersion [3,4]`))
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "ghc"`
+                                               (UnionVersionRanges
+                                                  (ThisVersion `mkVersion [8,6,3]`)
+                                                  (UnionVersionRanges
+                                                     (ThisVersion `mkVersion [8,4,4]`)
+                                                     (UnionVersionRanges
+                                                        (ThisVersion `mkVersion [8,2,2]`)
+                                                        (UnionVersionRanges
+                                                           (ThisVersion `mkVersion [8,0,2]`)
+                                                           (UnionVersionRanges
+                                                              (ThisVersion `mkVersion [7,10,3]`)
+                                                              (UnionVersionRanges
+                                                                 (ThisVersion `mkVersion [7,8,4]`)
+                                                                 (UnionVersionRanges
+                                                                    (ThisVersion
+                                                                       `mkVersion [7,6,3]`)
+                                                                    (ThisVersion
+                                                                       `mkVersion [7,4,2]`))))))))
+                                               (Set.fromList [LMainLibName]),
+                                             Dependency
+                                               `PackageName "Cabal"`
+                                               (UnionVersionRanges
+                                                  (MajorBoundVersion `mkVersion [2,4,1,1]`)
+                                                  (MajorBoundVersion `mkVersion [2,2,0,0]`))
+                                               (Set.fromList [LMainLibName])],
+                      condTreeData = Library
+                                       {exposedModules = [],
+                                        libBuildInfo = BuildInfo
+                                                         {asmOptions = [],
+                                                          asmSources = [],
+                                                          autogenModules = [],
+                                                          buildToolDepends = [],
+                                                          buildTools = [],
+                                                          buildable = True,
+                                                          cSources = [],
+                                                          ccOptions = [],
+                                                          cmmOptions = [],
+                                                          cmmSources = [],
+                                                          cppOptions = [],
+                                                          customFieldsBI = [],
+                                                          cxxOptions = [],
+                                                          cxxSources = [],
+                                                          defaultExtensions = [],
+                                                          defaultLanguage = Just Haskell2010,
+                                                          extraBundledLibs = [],
+                                                          extraDynLibFlavours = [],
+                                                          extraFrameworkDirs = [],
+                                                          extraGHCiLibs = [],
+                                                          extraLibDirs = [],
+                                                          extraLibFlavours = [],
+                                                          extraLibs = [],
+                                                          frameworks = [],
+                                                          hsSourceDirs = [],
+                                                          includeDirs = [],
+                                                          includes = [],
+                                                          installIncludes = [],
+                                                          jsSources = [],
+                                                          ldOptions = [],
+                                                          mixins = [],
+                                                          oldExtensions = [],
+                                                          options = PerCompilerFlavor [] [],
+                                                          otherExtensions = [],
+                                                          otherLanguages = [],
+                                                          otherModules = [],
+                                                          pkgconfigDepends = [],
+                                                          profOptions = PerCompilerFlavor [] [],
+                                                          sharedOptions = PerCompilerFlavor [] [],
+                                                          staticOptions = PerCompilerFlavor [] [],
+                                                          targetBuildDepends = [Dependency
+                                                                                  `PackageName "network"`
+                                                                                  (MajorBoundVersion
+                                                                                     `mkVersion [0]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
+                                                                                Dependency
+                                                                                  `PackageName "base"`
+                                                                                  (ThisVersion
+                                                                                     `mkVersion [1]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
+                                                                                Dependency
+                                                                                  `PackageName "base"`
+                                                                                  (ThisVersion
+                                                                                     `mkVersion [1]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
+                                                                                Dependency
+                                                                                  `PackageName "base"`
+                                                                                  (UnionVersionRanges
+                                                                                     (ThisVersion
+                                                                                        `mkVersion [1]`)
+                                                                                     (ThisVersion
+                                                                                        `mkVersion [2]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
+                                                                                Dependency
+                                                                                  `PackageName "base"`
+                                                                                  (ThisVersion
+                                                                                     `mkVersion [1,2]`)
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
+                                                                                Dependency
+                                                                                  `PackageName "base"`
+                                                                                  (UnionVersionRanges
+                                                                                     (ThisVersion
+                                                                                        `mkVersion [1,2]`)
+                                                                                     (ThisVersion
+                                                                                        `mkVersion [3,4]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
+                                                                                Dependency
+                                                                                  `PackageName "ghc"`
+                                                                                  (UnionVersionRanges
+                                                                                     (ThisVersion
+                                                                                        `mkVersion [8,6,3]`)
+                                                                                     (UnionVersionRanges
+                                                                                        (ThisVersion
+                                                                                           `mkVersion [8,4,4]`)
+                                                                                        (UnionVersionRanges
+                                                                                           (ThisVersion
+                                                                                              `mkVersion [8,2,2]`)
+                                                                                           (UnionVersionRanges
+                                                                                              (ThisVersion
+                                                                                                 `mkVersion [8,0,2]`)
+                                                                                              (UnionVersionRanges
+                                                                                                 (ThisVersion
+                                                                                                    `mkVersion [7,10,3]`)
+                                                                                                 (UnionVersionRanges
+                                                                                                    (ThisVersion
+                                                                                                       `mkVersion [7,8,4]`)
+                                                                                                    (UnionVersionRanges
+                                                                                                       (ThisVersion
+                                                                                                          `mkVersion [7,6,3]`)
+                                                                                                       (ThisVersion
+                                                                                                          `mkVersion [7,4,2]`))))))))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName]),
+                                                                                Dependency
+                                                                                  `PackageName "Cabal"`
+                                                                                  (UnionVersionRanges
+                                                                                     (MajorBoundVersion
+                                                                                        `mkVersion [2,4,1,1]`)
+                                                                                     (MajorBoundVersion
+                                                                                        `mkVersion [2,2,0,0]`))
+                                                                                  (Set.fromList
+                                                                                     [LMainLibName])],
+                                                          virtualModules = []},
+                                        libExposed = True,
+                                        libName = LMainLibName,
+                                        libVisibility = LibraryVisibilityPublic,
+                                        reexportedModules = [],
+                                        signatures = []}},
+   condSubLibraries = [],
+   condTestSuites = [],
+   genPackageFlags = [],
+   packageDescription = PackageDescription
+                          {author = "",
+                           benchmarks = [],
+                           bugReports = "",
+                           buildTypeRaw = Nothing,
+                           category = "",
+                           copyright = "",
+                           customFieldsPD = [],
+                           dataDir = "",
+                           dataFiles = [],
+                           description = "",
+                           executables = [],
+                           extraDocFiles = [],
+                           extraSrcFiles = [],
+                           extraTmpFiles = [],
+                           foreignLibs = [],
+                           homepage = "",
+                           library = Nothing,
+                           licenseFiles = [],
+                           licenseRaw = Left NONE,
+                           maintainer = "",
+                           package = PackageIdentifier
+                                       {pkgName = `PackageName "version-sets"`,
+                                        pkgVersion = `mkVersion [0]`},
+                           pkgUrl = "",
+                           setupBuildInfo = Nothing,
+                           sourceRepos = [],
+                           specVersionRaw = Left `mkVersion [2,5]`,
+                           stability = "",
+                           subLibraries = [],
+                           synopsis = "version set notation",
+                           testSuites = [],
+                           testedWith = [_×_
+                                           GHC
+                                           (UnionVersionRanges
+                                              (ThisVersion `mkVersion [8,6,3]`)
+                                              (UnionVersionRanges
+                                                 (ThisVersion `mkVersion [8,4,4]`)
+                                                 (UnionVersionRanges
+                                                    (ThisVersion `mkVersion [8,2,2]`)
+                                                    (UnionVersionRanges
+                                                       (ThisVersion `mkVersion [8,0,2]`)
+                                                       (UnionVersionRanges
+                                                          (ThisVersion `mkVersion [7,10,3]`)
+                                                          (UnionVersionRanges
+                                                             (ThisVersion `mkVersion [7,8,4]`)
+                                                             (UnionVersionRanges
+                                                                (ThisVersion `mkVersion [7,6,3]`)
+                                                                (ThisVersion
+                                                                   `mkVersion [7,4,2]`))))))))]}}

--- a/Cabal/tests/ParserTests/regressions/version-sets.format
+++ b/Cabal/tests/ParserTests/regressions/version-sets.format
@@ -1,0 +1,18 @@
+cabal-version: 2.5
+name:          version-sets
+version:       0
+tested-with:
+    ghc ==8.6.3 || ==8.4.4 || ==8.2.2 || ==8.0.2 || ==7.10.3 || ==7.8.4 || ==7.6.3 || ==7.4.2
+synopsis:      version set notation
+
+library
+    default-language: Haskell2010
+    build-depends:
+        network ^>=0,
+        base ==1,
+        base ==1,
+        base ==1 || ==2,
+        base ==1.2,
+        base ==1.2 || ==3.4,
+        ghc ==8.6.3 || ==8.4.4 || ==8.2.2 || ==8.0.2 || ==7.10.3 || ==7.8.4 || ==7.6.3 || ==7.4.2,
+        Cabal ^>=2.4.1.1 || ^>=2.2.0.0


### PR DESCRIPTION
I've found the `^>=` operator to be quite verbose to use when I am supporting multiple ghcs (or stackage snapshots). I found this cool post from ages ago https://www.reddit.com/r/haskell/comments/7tykqi/should_stackage_ignore_version_bounds/dtgp0v0 which looked good. e.g.

```
  build-depends: network ^>= { 2.6.3.6, 2.7.0.2, 2.8.0.0, 3.0.1.0 }
```

I don't know how to write a test. Somebody please help?

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
