### PR TITLE
Make Cabal tests environment configurable

### DIFF
--- a/Cabal/tests/UnitTests.hs
+++ b/Cabal/tests/UnitTests.hs
@@ -30,6 +30,7 @@ import qualified UnitTests.Distribution.Types.GenericPackageDescription
 tests :: Int -> TestTree
 tests mtimeChangeCalibrated =
   askOption $ \(OptionMtimeChangeDelay mtimeChangeProvided) ->
+  askOption $ \(GhcPath ghcPath) ->
   let mtimeChange = if mtimeChangeProvided /= 0
                     then mtimeChangeProvided
                     else mtimeChangeCalibrated
@@ -45,8 +46,8 @@ tests mtimeChangeCalibrated =
         UnitTests.Distribution.Simple.Glob.tests
     , testGroup "Distribution.Simple.Program.Internal"
         UnitTests.Distribution.Simple.Program.Internal.tests
-    , testGroup "Distribution.Simple.Utils"
-        UnitTests.Distribution.Simple.Utils.tests
+    , testGroup "Distribution.Simple.Utils" $
+        UnitTests.Distribution.Simple.Utils.tests ghcPath
     , testGroup "Distribution.Utils.Generic"
         UnitTests.Distribution.Utils.Generic.tests
     , testGroup "Distribution.Utils.NubList"
@@ -66,6 +67,7 @@ tests mtimeChangeCalibrated =
 extraOptions :: [OptionDescription]
 extraOptions =
   [ Option (Proxy :: Proxy OptionMtimeChangeDelay)
+  , Option (Proxy :: Proxy GhcPath)
   ]
 
 newtype OptionMtimeChangeDelay = OptionMtimeChangeDelay Int
@@ -77,6 +79,15 @@ instance IsOption OptionMtimeChangeDelay where
   optionName     = return "mtime-change-delay"
   optionHelp     = return $ "How long to wait before attempting to detect"
                    ++ "file modification, in microseconds"
+
+newtype GhcPath = GhcPath FilePath
+  deriving Typeable
+
+instance IsOption GhcPath where
+  defaultValue = GhcPath "ghc"
+  optionName   = return "with-ghc"
+  optionHelp   = return "The ghc compiler to use"
+  parseValue   = Just . GhcPath
 
 main :: IO ()
 main = do

--- a/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
+++ b/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
@@ -48,8 +48,8 @@ withTempDirRemovedTest = do
   withTempDirectory normal tempDir "foo" $ \dirPath -> do
     removeDirectoryRecursive dirPath
 
-rawSystemStdInOutTextDecodingTest :: Assertion
-rawSystemStdInOutTextDecodingTest
+rawSystemStdInOutTextDecodingTest :: FilePath -> Assertion
+rawSystemStdInOutTextDecodingTest ghcPath
     -- We can only get this exception when the locale encoding is UTF-8
     -- so skip the test if it's not.
     | show localeEncoding /= "UTF-8" = return ()
@@ -67,7 +67,7 @@ rawSystemStdInOutTextDecodingTest
 
       -- Compile
       (IODataText resOutput, resErrors, resExitCode) <- rawSystemStdInOut normal
-         "ghc" ["-o", filenameExe, filenameHs]
+         ghcPath ["-o", filenameExe, filenameHs]
          Nothing Nothing Nothing
          IODataModeText
       print (resOutput, resErrors, resExitCode)
@@ -86,8 +86,8 @@ rawSystemStdInOutTextDecodingTest
 
 
 
-tests :: [TestTree]
-tests =
+tests :: FilePath -> [TestTree]
+tests ghcPath =
     [ testCase "withTempFile works as expected" $
       withTempFileTest
     , testCase "withTempFile can handle removed files" $
@@ -97,5 +97,5 @@ tests =
     , testCase "withTempDirectory can handle removed directories" $
       withTempDirRemovedTest
     , testCase "rawSystemStdInOut reports text decoding errors" $
-      rawSystemStdInOutTextDecodingTest
+      rawSystemStdInOutTextDecodingTest ghcPath
     ]

--- a/validate.sh
+++ b/validate.sh
@@ -247,7 +247,7 @@ timed $CABALNEWBUILD Cabal:tests --enable-tests --disable-benchmarks --dry-run |
 timed $CABALNEWBUILD Cabal:tests --enable-tests --disable-benchmarks --dep || exit 1
 timed $CABALNEWBUILD Cabal:tests --enable-tests --disable-benchmarks || exit 1
 
-CMD="$($CABALPLAN list-bin Cabal:test:unit-tests) $TESTSUITEJOBS --hide-successes"
+CMD="$($CABALPLAN list-bin Cabal:test:unit-tests) $TESTSUITEJOBS --hide-successes --with-ghc=$HC"
 (cd Cabal && timed $CMD) || exit 1
 
 CMD="$($CABALPLAN list-bin Cabal:test:check-tests) $TESTSUITEJOBS --hide-successes"


### PR DESCRIPTION
- `unit-tests` take optional `--with-ghc` for a single test
- `hackage-tests` respect `CABAL_CONFIG`