### PR TITLE
Tidy up AppVeyor slightly

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - choco install -y ghc --version 8.0.2 --ignore-dependencies
   - choco install -y cabal-head -pre
   - refreshenv
-  - set
+  - set PATH
   - cabal --version
   - cabal %CABOPTS% update
   - cabal %CABOPTS% v1-install happy alex

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   - refreshenv
   # See http://help.appveyor.com/discussions/problems/6312-curl-command-not-found#comment_42195491
   # NB: Do this after refreshenv, otherwise it will be clobbered!
-  - set PATH=C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin;%PATH%
+  - set PATH=%PATH%;C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin
   - cabal --version
   - cabal %CABOPTS% update
   - cabal %CABOPTS% v1-install happy alex

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
   - choco install -y ghc --version 8.0.2 --ignore-dependencies
   - choco install -y cabal-head -pre
   - refreshenv
+  - set
   - cabal --version
   - cabal %CABOPTS% update
   - cabal %CABOPTS% v1-install happy alex

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,6 @@ install:
   - choco install -y ghc --version 8.0.2 --ignore-dependencies
   - choco install -y cabal-head -pre
   - refreshenv
-  - set PATH
   - cabal --version
   - cabal %CABOPTS% update
   - cabal %CABOPTS% v1-install happy alex

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,11 @@ branches:
     - "1.20"
     - "1.18"
 
+
+# Do not build feature branch with open Pull Requests
+# prevents PR double builds as branch
+skip_branch_with_pr: true
+
 install:
   # Using '-y' and 'refreshenv' as a workaround to:
   # https://github.com/haskell/cabal/issues/3687
@@ -20,7 +25,7 @@ install:
   - refreshenv
   # See http://help.appveyor.com/discussions/problems/6312-curl-command-not-found#comment_42195491
   # NB: Do this after refreshenv, otherwise it will be clobbered!
-  - set PATH=%APPDATA%\cabal\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin;C:\msys64\usr\bin;%PATH%
+  - set PATH=C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin;%PATH%
   - cabal --version
   - cabal %CABOPTS% update
   - cabal %CABOPTS% v1-install happy alex

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,6 @@ install:
   - choco install -y ghc --version 8.0.2 --ignore-dependencies
   - choco install -y cabal-head -pre
   - refreshenv
-  # See http://help.appveyor.com/discussions/problems/6312-curl-command-not-found#comment_42195491
-  # NB: Do this after refreshenv, otherwise it will be clobbered!
-  - set PATH=%PATH%;C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin
   - cabal --version
   - cabal %CABOPTS% update
   - cabal %CABOPTS% v1-install happy alex


### PR DESCRIPTION
The new `cabal-head` packages now automatically detect AppVeyor and set the required paths. (You can see this in the build log)
also use AppVeyor time better by not building branches to open PRs since the PR itself is also built.

I play to push this out to the stable branch with the next `cabal-install` release. 

