### PR TITLE
Fix some markdown in the local builds docs

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -416,7 +416,7 @@ of the ``vector`` package matching that specification exposed.
     $ cabal new-repl --build-depends "vector >= 0.12 && < 0.13"
 
 Both of these commands do the same thing as the above, but only exposes ``base``,
-``vector``, and the``vector`` package's transitive dependencies even if the user
+``vector``, and the ``vector`` package's transitive dependencies even if the user
 is in a project context.
 
 ::


### PR DESCRIPTION
[ci skip]

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.