### PR TITLE
Disable .ghc-environment file generation by default

### DIFF
--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -405,7 +405,7 @@ runProjectPostBuildPhase verbosity
           $ projectConfig
 
         shouldWriteGhcEnvironment =
-          case fromFlagOrDefault WriteGhcEnvironmentFilesOnlyForGhc844AndNewer
+          case fromFlagOrDefault NeverWriteGhcEnvironmentFiles
                writeGhcEnvFilesPolicy
           of
             AlwaysWriteGhcEnvironmentFiles                -> True

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -597,8 +597,8 @@ instance Monoid AllowOlder where
 -- ------------------------------------------------------------
 
 -- | Whether 'v2-build' should write a .ghc.environment file after
--- success. Possible values: 'always', 'never', 'ghc8.4.4+' (the
--- default; GHC 8.4.4 is the earliest version that supports
+-- success. Possible values: 'always', 'never' (the default), 'ghc8.4.4+'
+-- (8.4.4 is the earliest version that supports
 -- '-package-env -').
 data WriteGhcEnvironmentFilesPolicy
   = AlwaysWriteGhcEnvironmentFiles

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,7 @@
 -*-change-log-*-
 
 3.0.0.0 (current development version)
+	* '--write-ghc-environment-files' now defaults to 'never' (#4242)
 	* Fix `sdist`'s output when sent to stdout. (#5874)
 	* Allow a list of dependencies to be provided for `repl --build-depends`. (#5845)
 	* Legacy commands are now only accessible with the `v1-` prefixes, and the `v2-`


### PR DESCRIPTION
See https://mail.haskell.org/pipermail/ghc-devs/2019-March/017351.html for discussion about this default.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
