### PR TITLE
Don't export 'read': panic explicitly

### DIFF
--- a/Cabal/Distribution/Compat/Prelude.hs
+++ b/Cabal/Distribution/Compat/Prelude.hs
@@ -91,10 +91,15 @@ module Distribution.Compat.Prelude (
 
     -- * Text.PrettyPrint
     (<<>>),
+
+    -- * Text.Read
+    readMaybe,
     ) where
 -- We also could hide few partial function
 import Prelude                       as BasePrelude hiding
   ( IO, mapM, mapM_, sequence, null, length, foldr, any, all
+  -- partial functions
+  , read
 #if MINVER_base_411
   -- As of base 4.11.0.0 Prelude exports part of Semigroup(..).
   -- Hide this so we instead rely on Distribution.Compat.Semigroup.
@@ -140,6 +145,7 @@ import Data.Maybe
 import Data.String                   (IsString (..))
 import Data.Int
 import Data.Word
+import Text.Read                     (readMaybe)
 
 import qualified Text.PrettyPrint as Disp
 

--- a/Cabal/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/Distribution/Simple/InstallDirs.hs
@@ -395,7 +395,10 @@ type PathTemplateEnv = [(PathTemplateVariable, PathTemplate)]
 -- | Convert a 'FilePath' to a 'PathTemplate' including any template vars.
 --
 toPathTemplate :: FilePath -> PathTemplate
-toPathTemplate = PathTemplate . read -- TODO: eradicateNoParse
+toPathTemplate fp = PathTemplate
+    . fromMaybe (error $ "panic! toPathTemplate " ++ show fp)
+    . readMaybe -- TODO: eradicateNoParse
+    $ fp
 
 -- | Convert back to a path, any remaining vars are included
 --

--- a/Cabal/Distribution/Simple/PreProcess/Unlit.hs
+++ b/Cabal/Distribution/Simple/PreProcess/Unlit.hs
@@ -37,7 +37,8 @@ classify ('#':s) = case tokens s of
                                   && length file >= 2
                                   && head file == '"'
                                   && last file == '"'
-                                -> Line (read line) (tail (init file)) -- TODO:eradicateNoParse
+                                -- this shouldn't fail as we tested for 'all isDigit'
+                                -> Line (fromMaybe (error $ "panic! read @Int " ++ show line) $ readMaybe line) (tail (init file)) -- TODO:eradicateNoParse
                      _          -> CPP s
   where tokens = unfoldr $ \str -> case lex str of
                                    (t@(_:_), str'):_ -> Just (t, str')

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -242,11 +242,6 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
         parseInt :: String -> Maybe Int
         parseInt = readMaybe . dropEq
 
-        readMaybe :: Read a => String -> Maybe a
-        readMaybe s = case reads s of
-            [(x, "")] -> Just x
-            _ -> Nothing
-
     dropEq :: String -> String
     dropEq ('=':s) = s
     dropEq s = s

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -123,7 +123,8 @@ runTest pkg_descr lbi clbi flags suite = do
                                  (unUnqualComponentName $ testSuiteName l) (testLogs l)
         -- Generate TestSuiteLog from executable exit code and a machine-
         -- readable test log
-        suiteLog <- fmap ((\l -> l { logFile = finalLogName l }) . read) -- TODO: eradicateNoParse
+        suiteLog <- fmap (\s -> (\l -> l { logFile = finalLogName l })
+                    . fromMaybe (error $ "panic! read @TestSuiteLog " ++ show s) $ readMaybe s) -- TODO: eradicateNoParse
                     $ readFile tempLog
 
         -- Write summary notice to log file indicating start of test suite
@@ -219,7 +220,7 @@ simpleTestStub m = unlines
 -- of detectable errors when Cabal is compiled.
 stubMain :: IO [Test] -> IO ()
 stubMain tests = do
-    (f, n) <- fmap read getContents -- TODO: eradicateNoParse
+    (f, n) <- fmap (\s -> fromMaybe (error $ "panic! read " ++ show s) $ readMaybe s) getContents -- TODO: eradicateNoParse
     dir <- getCurrentDirectory
     results <- (tests >>= stubRunTests) `CE.catch` errHandler
     setCurrentDirectory dir

--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -24,7 +24,6 @@ import Test.QuickCheck.Utils
 
 import Data.Maybe (fromJust)
 import Data.Function (on)
-import Text.Read (readMaybe)
 
 versionTests :: [TestTree]
 versionTests =

--- a/cabal-install/Distribution/Client/Compat/Prelude.hs
+++ b/cabal-install/Distribution/Client/Compat/Prelude.hs
@@ -13,10 +13,7 @@
 module Distribution.Client.Compat.Prelude
   ( module Distribution.Compat.Prelude.Internal
   , Prelude.IO
-  , readMaybe
   ) where
 
 import Prelude (IO)
 import Distribution.Compat.Prelude.Internal hiding (IO)
-import Text.Read
-         ( readMaybe )

--- a/cabal-install/Distribution/Deprecated/Text.hs
+++ b/cabal-install/Distribution/Deprecated/Text.hs
@@ -23,7 +23,7 @@ module Distribution.Deprecated.Text (
   ) where
 
 import Distribution.Client.Compat.Prelude
-import Prelude ()
+import Prelude (read)
 
 import           Distribution.Deprecated.ReadP ((<++))
 import qualified Distribution.Deprecated.ReadP as Parse

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -1220,7 +1220,7 @@ userConfigAction ucflags extraArgs globalFlags = do
 win32SelfUpgradeAction :: Win32SelfUpgradeFlags -> [String] -> Action
 win32SelfUpgradeAction selfUpgradeFlags (pid:path:_extraArgs) _globalFlags = do
   let verbosity = fromFlag (win32SelfUpgradeVerbosity selfUpgradeFlags)
-  Win32SelfUpgrade.deleteOldExeFile verbosity (read pid) path -- TODO: eradicateNoParse
+  Win32SelfUpgrade.deleteOldExeFile verbosity (fromMaybe (error $ "panic! read pid=" ++ show pid) $ readMaybe pid) path -- TODO: eradicateNoParse
 win32SelfUpgradeAction _ _ _ = return ()
 
 -- | Used as an entry point when cabal-install needs to invoke itself


### PR DESCRIPTION
Motivated by failing test, which now gives more hints why it failed:

```
panic! read @TestSuiteLog ""
CallStack (from HasCallStack):
  error, called at ./Distribution/Simple/Test/LibV09.hs:127:34 in Cabal-3.0.0.0-inplace:Distribution.Simple.Test.LibV09
  runTest, called at ./Distribution/Simple/Test.hs:69:19 in Cabal-3.0.0.0-inplace:Distribution.Simple.Test
  doTest, called at ./Distribution/Simple/Test.hs:115:24 in Cabal-3.0.0.0-inplace:Distribution.Simple.Test
```