### PR TITLE
Fix a TODO.

### DIFF
--- a/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
@@ -119,9 +119,9 @@ insert comp a = ComponentDeps . Map.alter aux comp . unComponentDeps
 
 -- | Zip two 'ComponentDeps' together by 'Component', using 'mempty'
 -- as the neutral element when a 'Component' is present only in one.
-zip :: (Monoid a, Monoid b) => ComponentDeps a -> ComponentDeps b -> ComponentDeps (a, b)
-{- TODO/FIXME: Once we can expect containers>=0.5, switch to the more efficient version below:
-
+zip
+  :: (Monoid a, Monoid b)
+  => ComponentDeps a -> ComponentDeps b -> ComponentDeps (a, b)
 zip (ComponentDeps d1) (ComponentDeps d2) =
     ComponentDeps $
       Map.mergeWithKey
@@ -129,15 +129,6 @@ zip (ComponentDeps d1) (ComponentDeps d2) =
         (fmap (\a -> (a, mempty)))
         (fmap (\b -> (mempty, b)))
         d1 d2
-
--}
-zip (ComponentDeps d1) (ComponentDeps d2) =
-    ComponentDeps $
-      Map.unionWith
-        mappend
-        (Map.map (\a -> (a, mempty)) d1)
-        (Map.map (\b -> (mempty, b)) d2)
-
 
 -- | Keep only selected components (and their associated deps info).
 filterDeps :: (Component -> a -> Bool) -> ComponentDeps a -> ComponentDeps a


### PR DESCRIPTION
We require `containers > 0.5.6.2` now.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
