### PR TITLE
Add static flag to cabal executable

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -102,6 +102,11 @@ source-repository head
   location: https://github.com/haskell/cabal/
   subdir:   cabal-install
 
+Flag static
+  description:  Build statically linked executable
+  default:      False
+  manual:       True
+
 Flag native-dns
   description:  Enable use of the [resolv](https://hackage.haskell.org/package/resolv) & [windns](https://hackage.haskell.org/package/windns) packages for performing DNS lookups
   default:      True
@@ -352,6 +357,9 @@ executable cabal
 
     if flag(debug-expensive-assertions)
       cpp-options: -DDEBUG_EXPENSIVE_ASSERTIONS
+
+    if flag(static)
+      ld-options: -static
 
     if flag(debug-conflict-sets)
       cpp-options: -DDEBUG_CONFLICT_SETS

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -27,6 +27,7 @@
 	  that make it possible to copy the executable instead of symlinking it
 	* --symlink-bindir no longer controls the symlinking directory of
 	  v2-install (installdir controls both symlinking and copying now)
+	* New cabal flag for cabal-install: static
 
 2.4.1.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> November 2018
 	* Add message to alert user to potential package casing errors. (#5635)


### PR DESCRIPTION
Adds a new flag to the .cabal file for cabal-install. This makes cross-compilation a little easier.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.
