### PR TITLE
Stop using Data.Monoid.{First,Last}

### DIFF
--- a/Cabal/Distribution/Compat/Semigroup.hs
+++ b/Cabal/Distribution/Compat/Semigroup.hs
@@ -11,7 +11,10 @@ module Distribution.Compat.Semigroup
     , All(..)
     , Any(..)
 
+    , First'(..)
     , Last'(..)
+
+    , Option'(..)
 
     , gmappend
     , gmempty
@@ -19,7 +22,6 @@ module Distribution.Compat.Semigroup
 
 import Distribution.Compat.Binary (Binary)
 
-import Control.Applicative as App
 import GHC.Generics
 #if __GLASGOW_HASKELL__ >= 711
 -- Data.Semigroup is available since GHC 8.0/base-4.9
@@ -100,24 +102,36 @@ instance Ord k => Semigroup (Map k v) where
   (<>) = mappend
 #endif
 
--- | Cabal's own 'Data.Monoid.Last' copy to avoid requiring an orphan
--- 'Binary' instance.
---
--- Once the oldest `binary` version we support provides a 'Binary'
--- instance for 'Data.Monoid.Last' we can remove this one here.
---
--- NB: 'Data.Semigroup.Last' is defined differently and not a 'Monoid'
-newtype Last' a = Last' { getLast' :: Maybe a }
-                deriving (Eq, Ord, Read, Show, Binary,
-                          Functor, App.Applicative, Generic)
+-- | A copy of 'Data.Semigroup.First'.
+newtype First' a = First' { getFirst' :: a }
+  deriving (Eq, Ord, Show)
+
+instance Semigroup (First' a) where
+  a <> _ = a
+
+-- | A copy of 'Data.Semigroup.Last'.
+newtype Last' a = Last' { getLast' :: a }
+  deriving (Eq, Ord, Read, Show, Binary)
 
 instance Semigroup (Last' a) where
-    x <> Last' Nothing = x
-    _ <> x             = x
+  _ <> b = b
 
-instance Monoid (Last' a) where
-    mempty = Last' Nothing
-    mappend = (<>)
+instance Functor Last' where
+  fmap f (Last' x) = Last' (f x)
+
+-- | A wrapper around 'Maybe', providing the 'Semigroup' and 'Monoid' instances
+-- implemented for 'Maybe' since @base-4.11@.
+newtype Option' a = Option' { getOption' :: Maybe a }
+  deriving (Eq, Ord, Read, Show, Binary, Functor)
+
+instance Semigroup a => Semigroup (Option' a) where
+  Option' (Just a) <> Option' (Just b) = Option' (Just (a <> b))
+  Option' Nothing  <> b                = b
+  a                <> Option' Nothing  = a
+
+instance Semigroup a => Monoid (Option' a) where
+  mempty = Option' Nothing
+  mappend = (<>)
 
 -------------------------------------------------------------------------------
 -------------------------------------------------------------------------------

--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -543,8 +543,8 @@ getBuildConfig hooks verbosity distPref = do
             -- Since the list of unconfigured programs is not serialized,
             -- restore it to the same value as normally used at the beginning
             -- of a configure run:
-            configPrograms_ = restoreProgramDb
-                               (builtinPrograms ++ hookedPrograms hooks)
+            configPrograms_ = fmap (restoreProgramDb
+                                      (builtinPrograms ++ hookedPrograms hooks))
                                `fmap` configPrograms_ cFlags,
 
             -- Use the current, not saved verbosity level:

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -25,7 +25,7 @@ import Prelude ()
 import Distribution.Compat.Prelude
 
 import Distribution.Backpack
-import Distribution.Compat.Semigroup (Last'(..))
+import Distribution.Compat.Semigroup (First'(..), Last'(..), Option'(..))
 import Distribution.Simple.GHC.ImplInfo
 import Distribution.PackageDescription hiding (Flag)
 import Distribution.ModuleName
@@ -44,7 +44,7 @@ import Language.Haskell.Extension
 
 import Data.List (stripPrefix)
 import qualified Data.Map as Map
-import Data.Monoid (All(..), Alt(..), Any(..), Endo(..))
+import Data.Monoid (All(..), Any(..), Endo(..))
 import Data.Set (Set)
 import qualified Data.Set as Set
 
@@ -128,15 +128,15 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
     flagArgumentFilter :: [String] -> [String] -> [String]
     flagArgumentFilter flags = go
       where
-        makeFilter :: String -> String -> Alt Maybe ([String] -> [String])
-        makeFilter flag arg = Alt $ filterRest <$> stripPrefix flag arg
+        makeFilter :: String -> String -> Option' (First' ([String] -> [String]))
+        makeFilter flag arg = Option' $ First' . filterRest <$> stripPrefix flag arg
           where
             filterRest leftOver = case dropEq leftOver of
                 [] -> drop 1
                 _ -> id
 
         checkFilter :: String -> Maybe ([String] -> [String])
-        checkFilter = getAlt . foldMap makeFilter flags
+        checkFilter = fmap getFirst' . getOption' . foldMap makeFilter flags
 
         go :: [String] -> [String]
         go [] = []
@@ -264,15 +264,13 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
         ]
 
     safeToFilterHoles :: Bool
-    safeToFilterHoles = getAll . checkGhcFlags $ fromLast' . foldMap notDeferred
+    safeToFilterHoles = getAll . checkGhcFlags $
+        All . fromMaybe True . fmap getLast' . getOption' . foldMap notDeferred
       where
-        fromLast' :: Last' All -> All
-        fromLast' = fromMaybe (All True) . getLast'
-
-        notDeferred :: String -> Last' All
-        notDeferred "-fdefer-typed-holes" = Last' . Just . All $ False
-        notDeferred "-fno-defer-typed-holes" = Last' . Just . All $ True
-        notDeferred _ = Last' Nothing
+        notDeferred :: String -> Option' (Last' Bool)
+        notDeferred "-fdefer-typed-holes" = Option' . Just . Last' $ False
+        notDeferred "-fno-defer-typed-holes" = Option' . Just . Last' $ True
+        notDeferred _ = Option' Nothing
 
     isTypedHoleFlag :: String -> Any
     isTypedHoleFlag = mconcat

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -268,7 +268,7 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
       where
         fromLast' :: Last' All -> All
         fromLast' = fromMaybe (All True) . getLast'
- 
+
         notDeferred :: String -> Last' All
         notDeferred "-fdefer-typed-holes" = Last' . Just . All $ False
         notDeferred "-fno-defer-typed-holes" = Last' . Just . All $ True

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -105,7 +105,7 @@ import Distribution.Types.PackageName
 import Distribution.Types.UnqualComponentName (unUnqualComponentName)
 
 import Distribution.Compat.Stack
-import Distribution.Compat.Semigroup (Last' (..))
+import Distribution.Compat.Semigroup (Last' (..), Option' (..))
 
 import Data.Function (on)
 
@@ -202,8 +202,8 @@ data ConfigFlags = ConfigFlags {
     -- because the type of configure is constrained by the UserHooks.
     -- when we change UserHooks next we should pass the initial
     -- ProgramDb directly and not via ConfigFlags
-    configPrograms_     :: Last' ProgramDb, -- ^All programs that
-                                            -- @cabal@ may run
+    configPrograms_     :: Option' (Last' ProgramDb), -- ^All programs that
+                                                      -- @cabal@ may run
 
     configProgramPaths  :: [(String, FilePath)], -- ^user specified programs paths
     configProgramArgs   :: [(String, [String])], -- ^user specified programs args
@@ -286,7 +286,8 @@ instance Binary ConfigFlags
 -- | More convenient version of 'configPrograms'. Results in an
 -- 'error' if internal invariant is violated.
 configPrograms :: WithCallStack (ConfigFlags -> ProgramDb)
-configPrograms = maybe (error "FIXME: remove configPrograms") id . getLast' . configPrograms_
+configPrograms = fromMaybe (error "FIXME: remove configPrograms") . fmap getLast'
+               . getOption' . configPrograms_
 
 instance Eq ConfigFlags where
   (==) a b =
@@ -350,7 +351,7 @@ configAbsolutePaths f =
 defaultConfigFlags :: ProgramDb -> ConfigFlags
 defaultConfigFlags progDb = emptyConfigFlags {
     configArgs         = [],
-    configPrograms_    = pure progDb,
+    configPrograms_    = Option' (Just (Last' progDb)),
     configHcFlavor     = maybe NoFlag Flag defaultCompilerFlavor,
     configVanillaLib   = Flag True,
     configProfLib      = NoFlag,


### PR DESCRIPTION
Both will be deprecated in GHC 8.8.

This is part of https://gitlab.haskell.org/ghc/ghc/merge_requests/842.

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [X] Any changes that could be relevant to users have been recorded in the changelog.
* [X] The documentation has been updated, if necessary.
* [X] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.