### PR TITLE
PR template: Fix link to coding conventions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 ---
 Please include the following checklist in your PR:
 
-* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
+* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
 * [ ] Any changes that could be relevant to users have been recorded in the changelog.
 * [ ] The documentation has been updated, if necessary.
 * [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.


### PR DESCRIPTION
[ci skip]

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [X] Any changes that could be relevant to users have been recorded in the changelog.
* [X] The documentation has been updated, if necessary.
* [X] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.