### PR TITLE
Add autogen include directories for inplace packages

### DIFF
--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -500,7 +500,10 @@ inplaceInstalledPackageInfo inplaceDir distPref pkg abi_hash lib lbi clbi =
     generalInstalledPackageInfo adjustRelativeIncludeDirs
                                 pkg abi_hash lib lbi clbi installDirs
   where
-    adjustRelativeIncludeDirs = map (inplaceDir </>)
+    adjustRelativeIncludeDirs = concatMap $ \d ->
+      [ inplaceDir </> d                    -- local include-dir
+      , inplaceDir </> libTargetDir </> d   -- autogen include-dir
+      ]
     libTargetDir = componentBuildDir lbi clbi
     installDirs =
       (absoluteComponentInstallDirs pkg lbi (componentUnitId clbi) NoCopyDest) {


### PR DESCRIPTION
Local packages may have include heades in
- `inplaceDir </> d` (bundled, in source tree)
- `inplaceDir </> libTargetDir </> d` (autogenerated, somewhere in
  builddir)

We need both, for dependant packages to work.

The simple reproduce case is to have `unix` and `process`
locally in the project and try to build `process` (which depends on `unix` and its `HsUnixConfig.h`)

--- 

This addresses 
- https://github.com/haskell/cabal/issues/5223#issuecomment-381571846
- https://github.com/haskell/cabal/issues/5223#issuecomment-490229741