### PR TITLE
Fix typo in "Unexpected response" message

### DIFF
--- a/cabal-install/Distribution/Client/Security/HTTP.hs
+++ b/cabal-install/Distribution/Client/Security/HTTP.hs
@@ -153,7 +153,7 @@ data UnexpectedResponse = UnexpectedResponse URI Int
 
 instance Pretty UnexpectedResponse where
   pretty (UnexpectedResponse uri code) = "Unexpected response " ++ show code
-                                      ++ "for " ++ show uri
+                                      ++ " for " ++ show uri
 
 #if MIN_VERSION_base(4,8,0)
 deriving instance Show UnexpectedResponse


### PR DESCRIPTION
I added `[ci skip]` to the commit message because I only added a single space to a string. I didn't do any further testing either. Feel free to point out any steps I need to take since this *is* a user-facing message.

---
Please include the following checklist in your PR:

* [x ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x ] Any changes that could be relevant to users have been recorded in the changelog.
* [x ] The documentation has been updated, if necessary.
* [x ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
