### PR TITLE
Fix datadir path in generated `Paths_` file

### DIFF
--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -192,10 +192,18 @@ generate pkg_descr lbi clbi =
           bindir     = flat_bindir,
           libdir     = flat_libdir,
           dynlibdir  = flat_dynlibdir,
-          datadir    = flat_datadir,
           libexecdir = flat_libexecdir,
           sysconfdir = flat_sysconfdir
         } = absoluteComponentInstallDirs pkg_descr lbi cid NoCopyDest
+
+        -- The install command uses the non-component variant of the paths
+        -- as the datadir path in `Distribution.Simple.Install.copyPackage`,
+        -- so maintaining consistency here prevents problems with configuring
+        -- and building component.
+        InstallDirs {
+          datadir    = flat_datadir
+        } = absoluteInstallDirs pkg_descr lbi NoCopyDest
+
         InstallDirs {
           bindir     = flat_bindirrel,
           libdir     = flat_libdirrel,

--- a/Cabal/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/Distribution/Simple/Build/PathsModule.hs
@@ -192,17 +192,10 @@ generate pkg_descr lbi clbi =
           bindir     = flat_bindir,
           libdir     = flat_libdir,
           dynlibdir  = flat_dynlibdir,
+          datadir    = flat_datadir,
           libexecdir = flat_libexecdir,
           sysconfdir = flat_sysconfdir
-        } = absoluteComponentInstallDirs pkg_descr lbi cid NoCopyDest
-
-        -- The install command uses the non-component variant of the paths
-        -- as the datadir path in `Distribution.Simple.Install.copyPackage`,
-        -- so maintaining consistency here prevents problems with configuring
-        -- and building component.
-        InstallDirs {
-          datadir    = flat_datadir
-        } = absoluteInstallDirs pkg_descr lbi NoCopyDest
+        } = absoluteInstallCommandDirs pkg_descr lbi cid NoCopyDest
 
         InstallDirs {
           bindir     = flat_bindirrel,

--- a/Cabal/Distribution/Simple/Install.hs
+++ b/Cabal/Distribution/Simple/Install.hs
@@ -97,21 +97,10 @@ copyPackage verbosity pkg_descr lbi distPref copydest = do
       -- per-component (data files and Haddock files.)
       InstallDirs {
          datadir    = dataPref,
-         -- NB: The situation with Haddock is a bit delicate.  On the
-         -- one hand, the easiest to understand Haddock documentation
-         -- path is pkgname-0.1, which means it's per-package (not
-         -- per-component).  But this means that it's impossible to
-         -- install Haddock documentation for internal libraries.  We'll
-         -- keep this constraint for now; this means you can't use
-         -- Cabal to Haddock internal libraries.  This does not seem
-         -- like a big problem.
          docdir     = docPref,
          htmldir    = htmlPref,
-         haddockdir = interfacePref}
-             -- Notice use of 'absoluteInstallDirs' (not the
-             -- per-component variant).  This means for non-library
-             -- packages we'll just pick a nondescriptive foo-0.1
-             = absoluteInstallDirs pkg_descr lbi copydest
+         haddockdir = interfacePref
+      } = absoluteInstallCommandDirs pkg_descr lbi (localUnitId lbi) copydest
 
   -- Install (package-global) data files
   installDataFiles verbosity pkg_descr dataPref
@@ -161,7 +150,7 @@ copyComponent verbosity pkg_descr lbi (CLib lib) clbi copydest = do
             libdir = libPref,
             dynlibdir = dynlibPref,
             includedir = incPref
-            } = absoluteComponentInstallDirs pkg_descr lbi (componentUnitId clbi) copydest
+            } = absoluteInstallCommandDirs pkg_descr lbi (componentUnitId clbi) copydest
         buildPref = componentBuildDir lbi clbi
 
     case libName lib of


### PR DESCRIPTION
The generated datadir path can be incorrect if a project is configured for a single component as per https://github.com/haskell/cabal/issues/5862

Since the install command uses the non-component variant of the paths for the datadir, https://github.com/haskell/cabal/blob/27ef964abfa78e9b2013e51bd197f6c2321a36d0/Cabal/Distribution/Simple/Install.hs#L98-L114 this patch changes the generated path to use the same function.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
