### PR TITLE
Replace fake `Semigroup`/`NonEmpty` with proper ones from `semigroups`

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -283,9 +283,9 @@ library
     ghc-options: -Wcompat -Wnoncanonical-monad-instances
                  -Wnoncanonical-monadfail-instances
   else
-    -- at least one of lib:Cabal's dependency (`parsec`)
-    -- already depends on `fail` transitively
-    build-depends: fail == 4.9.*
+    -- at least one of lib:Cabal's dependency (i.e. `parsec`)
+    -- already depends on `fail` and `semigroups` transitively
+    build-depends: fail == 4.9.*, semigroups >= 0.18.3 && < 0.20
 
   exposed-modules:
     Distribution.Backpack

--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -25,6 +25,7 @@
   * Change the arguments of `Newtype` class to better suit @DeriveAnyClass@ usage,
     add default implementation in terms of `coerce` / `unsafeCoerce`.
   * Implement support for response file arguments to defaultMain* and cabal-install.
+  * Uniformly provide 'Semigroup' instances for `base < 4.9` via `semigroups` package
 
 ----
 

--- a/Cabal/Distribution/Compat/Parsing.hs
+++ b/Cabal/Distribution/Compat/Parsing.hs
@@ -108,8 +108,8 @@ sepBy1 p sep = (:) <$> p <*> many (sep *> p)
 
 -- | @sepByNonEmpty p sep@ parses /one/ or more occurrences of @p@, separated
 -- by @sep@. Returns a non-empty list of values returned by @p@.
-sepByNonEmpty :: Alternative m => m a -> m sep -> m (a,[a])
-sepByNonEmpty p sep = (,) <$> p <*> many (sep *> p)
+sepByNonEmpty :: Alternative m => m a -> m sep -> m (NonEmpty a)
+sepByNonEmpty p sep = (:|) <$> p <*> many (sep *> p)
 {-# INLINE sepByNonEmpty #-}
 
 -- | @sepEndBy1 p sep@ parses /one/ or more occurrences of @p@,

--- a/Cabal/Distribution/Compat/Prelude.hs
+++ b/Cabal/Distribution/Compat/Prelude.hs
@@ -59,6 +59,9 @@ module Distribution.Compat.Prelude (
     sort, sortBy,
     nub, nubBy,
 
+    -- * Data.List.NonEmpty
+    NonEmpty((:|)), foldl1, foldr1,
+
     -- * Data.Foldable
     Foldable, foldMap, foldr,
     null, length,
@@ -123,6 +126,7 @@ import Data.Foldable                 (length, null)
 
 import Data.Foldable                 (Foldable (foldMap, foldr), find, foldl', for_, traverse_, any, all)
 import Data.Traversable              (Traversable (traverse, sequenceA), for)
+import qualified Data.Foldable
 
 import Control.Applicative           (Alternative (..))
 import Control.DeepSeq               (NFData (..))
@@ -142,6 +146,7 @@ import Data.Char
 import Data.List                     (intercalate, intersperse, isPrefixOf,
                                       isSuffixOf, nub, nubBy, sort, sortBy,
                                       unfoldr)
+import Data.List.NonEmpty            (NonEmpty((:|)))
 import Data.Maybe
 import Data.String                   (IsString (..))
 import Data.Int
@@ -215,3 +220,28 @@ instance (GNFData a, GNFData b) => GNFData (a :+: b) where
   grnf (L1 x) = grnf x
   grnf (R1 x) = grnf x
   {-# INLINEABLE grnf #-}
+
+
+-- TODO: if we want foldr1/foldl1 to work on more than NonEmpty, we
+-- can define a local typeclass 'Foldable1', e.g.
+--
+-- @
+-- class Foldable f => Foldable1 f
+--
+-- instance Foldable1 NonEmpty
+--
+-- foldr1 :: Foldable1 t => (a -> a -> a) -> t a -> a
+-- foldr1 = Data.Foldable.foldr1
+--
+-- foldl1 :: Foldable1 t => (a -> a -> a) -> t a -> a
+-- foldl1 = Data.Foldable.foldl1
+-- @
+--
+
+{-# INLINE foldr1 #-}
+foldr1 :: (a -> a -> a) -> NonEmpty a -> a
+foldr1 = Data.Foldable.foldr1
+
+{-# INLINE foldl1 #-}
+foldl1 :: (a -> a -> a) -> NonEmpty a -> a
+foldl1 = Data.Foldable.foldl1

--- a/Cabal/Distribution/Compat/Semigroup.hs
+++ b/Cabal/Distribution/Compat/Semigroup.hs
@@ -23,84 +23,11 @@ module Distribution.Compat.Semigroup
 import Distribution.Compat.Binary (Binary)
 
 import GHC.Generics
-#if __GLASGOW_HASKELL__ >= 711
--- Data.Semigroup is available since GHC 8.0/base-4.9
+-- Data.Semigroup is available since GHC 8.0/base-4.9 in `base`
+-- for older GHC/base, it's provided by `semigroups`
 import Data.Semigroup
 import qualified Data.Monoid as Mon
-#else
--- provide internal simplified non-exposed class for older GHCs
-import Data.Monoid as Mon (Monoid(..), All(..), Any(..), Dual(..))
--- containers
-import Data.Set (Set)
-import Data.IntSet (IntSet)
-import Data.Map (Map)
-import Data.IntMap (IntMap)
 
-
-class Semigroup a where
-    (<>) :: a -> a -> a
-
--- several primitive instances
-instance Semigroup () where
-    _ <> _ = ()
-
-instance Semigroup [a] where
-    (<>) = (++)
-
-instance Semigroup a => Semigroup (Dual a) where
-    Dual a <> Dual b = Dual (b <> a)
-
-instance Semigroup a => Semigroup (Maybe a) where
-    Nothing <> b       = b
-    a       <> Nothing = a
-    Just a  <> Just b  = Just (a <> b)
-
-instance Semigroup (Either a b) where
-    Left _ <> b = b
-    a      <> _ = a
-
-instance Semigroup Ordering where
-    LT <> _ = LT
-    EQ <> y = y
-    GT <> _ = GT
-
-instance Semigroup b => Semigroup (a -> b) where
-    f <> g = \a -> f a <> g a
-
-instance Semigroup All where
-    All a <> All b = All (a && b)
-
-instance Semigroup Any where
-    Any a <> Any b = Any (a || b)
-
-instance (Semigroup a, Semigroup b) => Semigroup (a, b) where
-    (a,b) <> (a',b') = (a<>a',b<>b')
-
-instance (Semigroup a, Semigroup b, Semigroup c)
-         => Semigroup (a, b, c) where
-    (a,b,c) <> (a',b',c') = (a<>a',b<>b',c<>c')
-
-instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d)
-         => Semigroup (a, b, c, d) where
-    (a,b,c,d) <> (a',b',c',d') = (a<>a',b<>b',c<>c',d<>d')
-
-instance (Semigroup a, Semigroup b, Semigroup c, Semigroup d, Semigroup e)
-         => Semigroup (a, b, c, d, e) where
-    (a,b,c,d,e) <> (a',b',c',d',e') = (a<>a',b<>b',c<>c',d<>d',e<>e')
-
--- containers instances
-instance Semigroup IntSet where
-  (<>) = mappend
-
-instance Ord a => Semigroup (Set a) where
-  (<>) = mappend
-
-instance Semigroup (IntMap v) where
-  (<>) = mappend
-
-instance Ord k => Semigroup (Map k v) where
-  (<>) = mappend
-#endif
 
 -- | A copy of 'Data.Semigroup.First'.
 newtype First' a = First' { getFirst' :: a }

--- a/Cabal/Distribution/Fields/ConfVar.hs
+++ b/Cabal/Distribution/Fields/ConfVar.hs
@@ -38,7 +38,7 @@ parseConditionConfVar args =
 type Parser = P.Parsec [SectionArg Position] ()
 
 sepByNonEmpty :: Parser a -> Parser sep -> Parser (NonEmpty a)
-sepByNonEmpty p sep = (,) <$> p <*> many (sep *> p)
+sepByNonEmpty p sep = (:|) <$> p <*> many (sep *> p)
 
 parser :: Parser (Condition ConfVar)
 parser = condOr
@@ -124,12 +124,3 @@ parser = condOr
         bs <- identBS
         let fls = fieldLineStreamFromBS bs
         either (fail . show) pure (runParsecParser p "<fromParsec'>" fls)
-
--------------------------------------------------------------------------------
--- NonEmpty
--------------------------------------------------------------------------------
-
-type NonEmpty a = (a, [a])
-
-foldl1 :: (a -> a -> a) -> NonEmpty a -> a
-foldl1 f ~(x, xs) = foldl f x xs

--- a/Cabal/Distribution/PackageDescription/Configuration.hs
+++ b/Cabal/Distribution/PackageDescription/Configuration.hs
@@ -596,12 +596,3 @@ transformAllBuildDepends f =
   . over (L.packageDescription . L.setupBuildInfo . traverse . L.setupDepends . traverse) f
   -- cannot be point-free as normal because of higher rank
   . over (\f' -> L.allCondTrees $ traverseCondTreeC f') (map f)
-
--------------------------------------------------------------------------------
--- NonEmpty
--------------------------------------------------------------------------------
-
-type NonEmpty a = (a, [a])
-
-foldl1 :: (a -> a -> a) -> NonEmpty a -> a
-foldl1 f ~(x, xs) = foldl f x xs

--- a/Cabal/Distribution/Types/PkgconfigVersionRange.hs
+++ b/Cabal/Distribution/Types/PkgconfigVersionRange.hs
@@ -24,9 +24,6 @@ import qualified Data.ByteString.Char8           as BS8
 import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint                as PP
 
--- NonEmpty
-import qualified Prelude (foldr1)
-
 -- | @since 3.0
 data PkgconfigVersionRange
   = PcAnyVersion
@@ -143,12 +140,3 @@ versionRangeToPkgconfigVersionRange = foldVersionRange
     (PcEarlierVersion . versionToPkgconfigVersion)
     PcUnionVersionRanges
     PcIntersectVersionRanges
-
--------------------------------------------------------------------------------
--- NonEmpty
--------------------------------------------------------------------------------
-
-type NonEmpty a = (a, [a])
-
-foldr1 :: (a -> a -> a) -> NonEmpty a -> a
-foldr1 f ~(x, xs) = Prelude.foldr1 f (x : xs)


### PR DESCRIPTION
This is a proof of concept for depending on `semigroups` instead of defining a fake local `class Semigroup` as suggested in https://github.com/haskell/cabal/issues/6082#issuecomment-502598220



/cc @phadej

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
