### PR TITLE
Create zinza and use it for SPDX module generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,17 @@ $(LEXER_HS) : boot/Lexer.x
 
 spdx : $(SPDX_LICENSE_HS) $(SPDX_EXCEPTION_HS)
 
-$(SPDX_LICENSE_HS) : boot/SPDX.LicenseId.template.hs cabal-dev-scripts/src/GenUtils.hs cabal-dev-scripts/src/GenSPDX.hs license-list-data/licenses-3.0.json license-list-data/licenses-3.2.json
-	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-spdx -- boot/SPDX.LicenseId.template.hs license-list-data/licenses-3.0.json license-list-data/licenses-3.2.json license-list-data/licenses-3.5.json $(SPDX_LICENSE_HS)
+cabal-dev-scripts/src/Template/LicenseId.hs : boot/SPDX.LicenseId.template.hs
+	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta zinza -- $^ $@ --module-name Template.LicenseId
 
-$(SPDX_EXCEPTION_HS) : boot/SPDX.LicenseExceptionId.template.hs cabal-dev-scripts/src/GenUtils.hs cabal-dev-scripts/src/GenSPDXExc.hs license-list-data/exceptions-3.0.json license-list-data/exceptions-3.2.json
-	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-spdx-exc -- boot/SPDX.LicenseExceptionId.template.hs license-list-data/exceptions-3.0.json license-list-data/exceptions-3.2.json license-list-data/exceptions-3.5.json $(SPDX_EXCEPTION_HS)
+cabal-dev-scripts/src/Template/LicenseExceptionId.hs : boot/SPDX.LicenseExceptionId.template.hs
+	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta zinza -- $^ $@ --module-name Template.LicenseExceptionId
+
+$(SPDX_LICENSE_HS) : cabal-dev-scripts/src/Template/LicenseId.hs  cabal-dev-scripts/src/GenUtils.hs cabal-dev-scripts/src/GenSPDX.hs license-list-data/licenses-3.0.json license-list-data/licenses-3.2.json
+	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-spdx -- license-list-data/licenses-3.0.json license-list-data/licenses-3.2.json license-list-data/licenses-3.5.json $(SPDX_LICENSE_HS)
+
+$(SPDX_EXCEPTION_HS) : cabal-dev-scripts/src/Template/LicenseExceptionId.hs cabal-dev-scripts/src/GenUtils.hs cabal-dev-scripts/src/GenSPDXExc.hs license-list-data/exceptions-3.0.json license-list-data/exceptions-3.2.json
+	cabal new-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-spdx-exc -- license-list-data/exceptions-3.0.json license-list-data/exceptions-3.2.json license-list-data/exceptions-3.5.json $(SPDX_EXCEPTION_HS)
 
 # cabal-install.cabal file generation
 

--- a/boot/SPDX.LicenseExceptionId.template.hs
+++ b/boot/SPDX.LicenseExceptionId.template.hs
@@ -28,7 +28,7 @@ import qualified Text.PrettyPrint as Disp
 
 -- | SPDX License identifier
 data LicenseExceptionId
-{{{ licenseIds }}}
+{{ licenseIds }}
   deriving (Eq, Ord, Enum, Bounded, Show, Read, Typeable, Data, Generic)
 
 instance Binary LicenseExceptionId where
@@ -58,15 +58,15 @@ instance NFData LicenseExceptionId where
 
 -- | License SPDX identifier, e.g. @"BSD-3-Clause"@.
 licenseExceptionId :: LicenseExceptionId -> String
-{{#licenses}}
-licenseExceptionId {{licenseCon}} = {{{licenseId}}}
-{{/licenses}}
+{% for l in licenses %}
+licenseExceptionId {{l.con}} = {{l.id}}
+{% endfor %}
 
 -- | License name, e.g. @"GNU General Public License v2.0 only"@
 licenseExceptionName :: LicenseExceptionId -> String
-{{#licenses}}
-licenseExceptionName {{licenseCon}} = {{{licenseName}}}
-{{/licenses}}
+{% for l in licenses %}
+licenseExceptionName {{l.con}} = {{l.name}}
+{% endfor %}
 
 -------------------------------------------------------------------------------
 -- Creation
@@ -74,13 +74,13 @@ licenseExceptionName {{licenseCon}} = {{{licenseName}}}
 
 licenseExceptionIdList :: LicenseListVersion -> [LicenseExceptionId]
 licenseExceptionIdList LicenseListVersion_3_0 =
-{{{licenseList_3_0}}}
+{{licenseList_3_0}}
     ++ bulkOfLicenses
 licenseExceptionIdList LicenseListVersion_3_2 =
-{{{licenseList_3_2}}}
+{{licenseList_3_2}}
     ++ bulkOfLicenses
 licenseExceptionIdList LicenseListVersion_3_5 =
-{{{licenseList_3_5}}}
+{{licenseList_3_5}}
     ++ bulkOfLicenses
 
 -- | Create a 'LicenseExceptionId' from a 'String'.
@@ -104,4 +104,4 @@ stringLookup_3_5 = Map.fromList $ map (\i -> (licenseExceptionId i, i)) $
 --  | License exceptions in all SPDX License lists
 bulkOfLicenses :: [LicenseExceptionId]
 bulkOfLicenses =
-{{{licenseList_all}}}
+{{licenseList_all}}

--- a/boot/SPDX.LicenseId.template.hs
+++ b/boot/SPDX.LicenseId.template.hs
@@ -31,7 +31,7 @@ import qualified Text.PrettyPrint as Disp
 
 -- | SPDX License identifier
 data LicenseId
-{{{ licenseIds }}}
+{{ licenseIds }}
   deriving (Eq, Ord, Enum, Bounded, Show, Read, Typeable, Data, Generic)
 
 instance Binary LicenseId where
@@ -110,23 +110,23 @@ licenseIdMigrationMessage = go where
 
 -- | License SPDX identifier, e.g. @"BSD-3-Clause"@.
 licenseId :: LicenseId -> String
-{{#licenses}}
-licenseId {{licenseCon}} = {{{licenseId}}}
-{{/licenses}}
+{% for license in licenses %}
+licenseId {{license.con}} = {{license.id}}
+{% endfor %}
 
 -- | License name, e.g. @"GNU General Public License v2.0 only"@
 licenseName :: LicenseId -> String
-{{#licenses}}
-licenseName {{licenseCon}} = {{{licenseName}}}
-{{/licenses}}
+{% for license in licenses %}
+licenseName {{license.con}} = {{license.name}}
+{% endfor %}
 
 -- | Whether the license is approved by Open Source Initiative (OSI).
 --
 -- See <https://opensource.org/licenses/alphabetical>.
 licenseIsOsiApproved :: LicenseId -> Bool
-{{#licenses}}
-licenseIsOsiApproved {{licenseCon}} = {{#isOsiApproved}}True{{/isOsiApproved}}{{^isOsiApproved}}False{{/isOsiApproved}}
-{{/licenses}}
+{% for license in licenses %}
+licenseIsOsiApproved {{license.con}} = {% if license.isOsiApproved %}True{% endif %}{% if !license.isOsiApproved %}False{% endif %}
+{% endfor %}
 
 -------------------------------------------------------------------------------
 -- Creation
@@ -134,13 +134,13 @@ licenseIsOsiApproved {{licenseCon}} = {{#isOsiApproved}}True{{/isOsiApproved}}{{
 
 licenseIdList :: LicenseListVersion -> [LicenseId]
 licenseIdList LicenseListVersion_3_0 =
-{{{licenseList_3_0}}}
+{{licenseList_3_0}}
     ++ bulkOfLicenses
 licenseIdList LicenseListVersion_3_2 =
-{{{licenseList_3_2}}}
+{{licenseList_3_2}}
     ++ bulkOfLicenses
 licenseIdList LicenseListVersion_3_5 =
-{{{licenseList_3_5}}}
+{{licenseList_3_5}}
     ++ bulkOfLicenses
 
 -- | Create a 'LicenseId' from a 'String'.
@@ -164,4 +164,4 @@ stringLookup_3_5 = Map.fromList $ map (\i -> (licenseId i, i)) $
 --  | Licenses in all SPDX License lists
 bulkOfLicenses :: [LicenseId]
 bulkOfLicenses =
-{{{licenseList_all}}}
+{{licenseList_all}}

--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -1,58 +1,76 @@
-name:                cabal-dev-scripts
-version:             0
-synopsis:            Dev scripts for cabal development
-description:
-  This package provides a tools for Cabal development
-homepage:            http://www.haskell.org/cabal/
-license:             BSD3
-license-file:        LICENSE
-author:              Cabal Development Team <cabal-devel@haskell.org>
-category:            Distribution
-build-type:          Simple
-cabal-version:       >=2.0
+cabal-version: 2.2
+name:          cabal-dev-scripts
+version:       0
+synopsis:      Dev scripts for cabal development
+description:   This package provides a tools for Cabal development
+homepage:      http://www.haskell.org/cabal/
+license:       BSD-3-Clause
+license-file:  LICENSE
+author:        Cabal Development Team <cabal-devel@haskell.org>
+category:      Distribution
+build-type:    Simple
 
 executable gen-extra-source-files
-  default-language:    Haskell2010
-  main-is:             GenExtraSourceFiles.hs
-  hs-source-dirs:      src
+  default-language: Haskell2010
+  main-is:          GenExtraSourceFiles.hs
+  hs-source-dirs:   src
   build-depends:
-    base                 >=4.10    && <4.13,
-    Cabal                >=2.2     && <2.6,
-    bytestring,
-    directory,
-    filepath,
-    process
+    , base        >=4.10 && <4.13
+    , bytestring
+    , Cabal       >=2.2  && <2.6
+    , directory
+    , filepath
+    , process
+
+executable zinza
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  ghc-options:      -Wall
+  main-is:          Zinza.hs
+  build-depends:
+    , base                  >=4.10     && <4.13
+    , containers
+    , optparse-applicative  >=0.13     && <0.15
+    , parsec                ^>=3.1.3.0
+    , semialign             ^>=1
+    , these                 ^>=1
+    , transformers
+    , unification-fd        ^>=0.10.0.1
 
 executable gen-spdx
-  default-language:    Haskell2010
-  main-is:             GenSPDX.hs
-  other-modules:       GenUtils
-  hs-source-dirs:      src
-  ghc-options:         -Wall
+  default-language: Haskell2010
+  main-is:          GenSPDX.hs
+  other-modules:
+    GenUtils
+    Template.LicenseId
+
+  autogen-modules:  Template.LicenseId
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-    base                 >=4.10    && <4.13,
-    aeson                >=1.4.0.0 && <1.5,
-    bytestring,
-    containers,
-    Diff                 >=0.3.4   && <0.4,
-    lens                 >=4.17    && <4.18,
-    microstache          >=1.0.1.1 && <1.1,
-    optparse-applicative >=0.13    && <0.15,
-    text
+    , aeson                 ^>=1.4.0.0
+    , base                  >=4.10    && <4.13
+    , bytestring
+    , containers
+    , Diff                  ^>=0.3.4
+    , optparse-applicative  >=0.13    && <0.15
+    , text
 
 executable gen-spdx-exc
-  default-language:    Haskell2010
-  main-is:             GenSPDXExc.hs
-  other-modules:       GenUtils
-  hs-source-dirs:      src
-  ghc-options:         -Wall
+  default-language: Haskell2010
+  main-is:          GenSPDXExc.hs
+  other-modules:
+    GenUtils
+    Template.LicenseExceptionId
+
+  autogen-modules:  Template.LicenseExceptionId
+  hs-source-dirs:   src
+  ghc-options:      -Wall
   build-depends:
-    base                 >=4.10    && <4.13,
-    aeson                >=1.4.0.0 && <1.5,
-    bytestring,
-    containers,
-    Diff                 >=0.3.4   && <0.4,
-    lens                 >=4.17    && <4.18,
-    microstache          >=1.0.1.1 && <1.1,
-    optparse-applicative >=0.13    && <0.15,
-    text
+    , aeson                 ^>=1.4.0.0
+    , base                  >=4.10    && <4.13
+    , bytestring
+    , containers
+    , Diff                  ^>=0.3.4
+    , optparse-applicative  >=0.13    && <0.15
+    , text

--- a/cabal-dev-scripts/src/GenSPDX.hs
+++ b/cabal-dev-scripts/src/GenSPDX.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
-import Control.Lens     hiding ((.=))
-import Data.Aeson       (FromJSON (..), Value, eitherDecode, object, withObject, (.:), (.=))
-import Data.Foldable    (for_)
+import Data.Aeson       (FromJSON (..), eitherDecode, withObject, (.:))
 import Data.List        (sortOn)
 import Data.Semigroup   ((<>))
 import Data.Text        (Text)
@@ -13,13 +11,14 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Set             as Set
 import qualified Data.Text            as T
 import qualified Data.Text.Lazy       as TL
-import qualified Data.Text.Lazy.IO    as TL
 import qualified Options.Applicative  as O
-import qualified Text.Microstache     as M
+
+import qualified Template.LicenseId as Z
 
 import GenUtils
 
-data Opts = Opts FilePath (PerV FilePath) FilePath
+data Opts = Opts (PerV FilePath) FilePath
+  deriving (Show)
 
 main :: IO ()
 main = generate =<< O.execParser opts where
@@ -29,17 +28,12 @@ main = generate =<< O.execParser opts where
         ]
 
     parser :: O.Parser Opts
-    parser = Opts <$> template <*> licensesAll <*> output
+    parser = Opts <$> licensesAll <*> output
 
     licensesAll = PerV
         <$> licenses "3.0"
         <*> licenses "3.2"
         <*> licenses "3.5"
-
-    template = O.strArgument $ mconcat
-        [ O.metavar "SPDX.LicenseId.template.hs"
-        , O.help    "Module template file"
-        ]
 
     licenses ver = O.strArgument $ mconcat
         [ O.metavar $ "licenses-" ++ ver ++ ".json"
@@ -52,29 +46,26 @@ main = generate =<< O.execParser opts where
         ]
 
 generate :: Opts -> IO ()
-generate (Opts tmplFile fns out) = do
+generate (Opts fns out) = do
     lss <- for fns $ \fn -> either fail pure . eitherDecode =<< LBS.readFile fn
-    template <- M.compileMustacheFile tmplFile
-    let (ws, rendered) = generate' lss template
-    for_ ws $ putStrLn . M.displayMustacheWarning
-    TL.writeFile out (header <> "\n" <> rendered)
+    let rendered = Z.instantiate $ config lss
+    writeFile out (TL.unpack header ++ "\n" ++ rendered)
     putStrLn $ "Generated file " ++ out
 
-generate'
+config
     :: PerV LicenseList
-    -> M.Template
-    -> ([M.MustacheWarning], TL.Text)
-generate' lss template = M.renderMustacheW template $ object
-    [ "licenseIds" .= licenseIds
-    , "licenses"   .= licenseValues
-    , "licenseList_all" .= mkLicenseList (== allVers)
-    , "licenseList_3_0" .= mkLicenseList
+    -> Z.Cfg
+config lss = Z.Cfg
+    { Z.cfgLicenseIds      = T.unpack licenseIds
+    , Z.cfgLicenses        = licenseValues
+    , Z.cfgLicenseList_all = T.unpack $ mkLicenseList (== allVers)
+    , Z.cfgLicenseList_3_0 = T.unpack $ mkLicenseList
         (\vers -> vers /= allVers && Set.member SPDXLicenseListVersion_3_0 vers)
-    , "licenseList_3_2" .= mkLicenseList
+    , Z.cfgLicenseList_3_2 = T.unpack $ mkLicenseList
         (\vers -> vers /= allVers && Set.member SPDXLicenseListVersion_3_2 vers)
-    , "licenseList_3_5" .= mkLicenseList
+    , Z.cfgLicenseList_3_5 = T.unpack $ mkLicenseList
         (\vers -> vers /= allVers && Set.member SPDXLicenseListVersion_3_5 vers)
-    ]
+    }
   where
     PerV (LL ls_3_0) (LL ls_3_2) (LL ls_3_5) = lss
 
@@ -88,13 +79,13 @@ generate' lss template = M.renderMustacheW template $ object
 
     filterDeprecated = filter (not . licenseDeprecated)
 
-    licenseValues :: [Value]
-    licenseValues = flip map constructorNames $ \(c, l, _) -> object
-        [ "licenseCon"      .= c
-        , "licenseId"       .= textShow (licenseId l)
-        , "licenseName"     .= textShow (licenseName l)
-        , "isOsiApproved"   .= licenseOsiApproved l
-        ]
+    licenseValues :: [Z.CfgLicenses]
+    licenseValues = flip map constructorNames $ \(c, l, _) -> Z.CfgLicenses
+        { Z.cfgLicensesCon           = T.unpack c
+        , Z.cfgLicensesId            = show (licenseId l)
+        , Z.cfgLicensesName          = show (licenseName l)
+        , Z.cfgLicensesIsOsiApproved = licenseOsiApproved l
+        }
 
     licenseIds :: Text
     licenseIds = T.intercalate "\n" $ flip imap constructorNames $ \i (c, l, vers) ->

--- a/cabal-dev-scripts/src/Template/LicenseExceptionId.hs
+++ b/cabal-dev-scripts/src/Template/LicenseExceptionId.hs
@@ -1,0 +1,153 @@
+module Template.LicenseExceptionId (instantiate, Cfg(..), CfgLicenses(..)) where
+
+-- data types
+
+data Cfg = Cfg
+  { cfgLicenseIds :: !String
+  , cfgLicenseList_3_0 :: !String
+  , cfgLicenseList_3_2 :: !String
+  , cfgLicenseList_3_5 :: !String
+  , cfgLicenseList_all :: !String
+  , cfgLicenses :: ![CfgLicenses]
+  } deriving (Show)
+
+data CfgLicenses = CfgLicenses
+  { cfgLicensesCon :: !String
+  , cfgLicensesId :: !String
+  , cfgLicensesName :: !String
+  } deriving (Show)
+
+-- template instantiation
+
+instantiate :: Cfg -> String
+instantiate cfg = ($ []) $ id
+  . showString "{-# LANGUAGE DeriveDataTypeable #-}\n"
+  . showString "{-# LANGUAGE DeriveGeneric      #-}\n"
+  . showString "module Distribution.SPDX.LicenseExceptionId (\n"
+  . showString "    LicenseExceptionId (..),\n"
+  . showString "    licenseExceptionId,\n"
+  . showString "    licenseExceptionName,\n"
+  . showString "    mkLicenseExceptionId,\n"
+  . showString "    licenseExceptionIdList,\n"
+  . showString "    ) where\n"
+  . showString "\n"
+  . showString "import Distribution.Compat.Prelude\n"
+  . showString "import Prelude ()\n"
+  . showString "\n"
+  . showString "import Distribution.Pretty\n"
+  . showString "import Distribution.Parsec\n"
+  . showString "import Distribution.Utils.Generic (isAsciiAlphaNum)\n"
+  . showString "import Distribution.SPDX.LicenseListVersion\n"
+  . showString "\n"
+  . showString "import qualified Data.Binary.Get as Binary\n"
+  . showString "import qualified Data.Binary.Put as Binary\n"
+  . showString "import qualified Data.Map.Strict as Map\n"
+  . showString "import qualified Distribution.Compat.CharParsing as P\n"
+  . showString "import qualified Text.PrettyPrint as Disp\n"
+  . showString "\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "-- LicenseExceptionId\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "\n"
+  . showString "-- | SPDX License identifier\n"
+  . showString "data LicenseExceptionId\n"
+  . showString (cfgLicenseIds $ cfg)
+  . showString "\n"
+  . showString "  deriving (Eq, Ord, Enum, Bounded, Show, Read, Typeable, Data, Generic)\n"
+  . showString "\n"
+  . showString "instance Binary LicenseExceptionId where\n"
+  . showString "    put = Binary.putWord8 . fromIntegral . fromEnum\n"
+  . showString "    get = do\n"
+  . showString "        i <- Binary.getWord8\n"
+  . showString "        if i > fromIntegral (fromEnum (maxBound :: LicenseExceptionId))\n"
+  . showString "        then fail \"Too large LicenseExceptionId tag\"\n"
+  . showString "        else return (toEnum (fromIntegral i))\n"
+  . showString "\n"
+  . showString "instance Pretty LicenseExceptionId where\n"
+  . showString "    pretty = Disp.text . licenseExceptionId\n"
+  . showString "\n"
+  . showString "instance Parsec LicenseExceptionId where\n"
+  . showString "    parsec = do\n"
+  . showString "        n <- some $ P.satisfy $ \\c -> isAsciiAlphaNum c || c == '-' || c == '.'\n"
+  . showString "        v <- askCabalSpecVersion\n"
+  . showString "        maybe (fail $ \"Unknown SPDX license exception identifier: \" ++ n) return $\n"
+  . showString "            mkLicenseExceptionId (cabalSpecVersionToSPDXListVersion v) n\n"
+  . showString "\n"
+  . showString "instance NFData LicenseExceptionId where\n"
+  . showString "    rnf l = l `seq` ()\n"
+  . showString "\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "-- License Data\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "\n"
+  . showString "-- | License SPDX identifier, e.g. @\"BSD-3-Clause\"@.\n"
+  . showString "licenseExceptionId :: LicenseExceptionId -> String\n"
+  . _forImpl (cfgLicenses $ cfg) (\l -> id
+    . showString "licenseExceptionId "
+    . showString (cfgLicensesCon $ l)
+    . showString " = "
+    . showString (cfgLicensesId $ l)
+    . showString "\n"
+    )
+  . showString "\n"
+  . showString "-- | License name, e.g. @\"GNU General Public License v2.0 only\"@\n"
+  . showString "licenseExceptionName :: LicenseExceptionId -> String\n"
+  . _forImpl (cfgLicenses $ cfg) (\l -> id
+    . showString "licenseExceptionName "
+    . showString (cfgLicensesCon $ l)
+    . showString " = "
+    . showString (cfgLicensesName $ l)
+    . showString "\n"
+    )
+  . showString "\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "-- Creation\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "\n"
+  . showString "licenseExceptionIdList :: LicenseListVersion -> [LicenseExceptionId]\n"
+  . showString "licenseExceptionIdList LicenseListVersion_3_0 =\n"
+  . showString (cfgLicenseList_3_0 $ cfg)
+  . showString "\n"
+  . showString "    ++ bulkOfLicenses\n"
+  . showString "licenseExceptionIdList LicenseListVersion_3_2 =\n"
+  . showString (cfgLicenseList_3_2 $ cfg)
+  . showString "\n"
+  . showString "    ++ bulkOfLicenses\n"
+  . showString "licenseExceptionIdList LicenseListVersion_3_5 =\n"
+  . showString (cfgLicenseList_3_5 $ cfg)
+  . showString "\n"
+  . showString "    ++ bulkOfLicenses\n"
+  . showString "\n"
+  . showString "-- | Create a 'LicenseExceptionId' from a 'String'.\n"
+  . showString "mkLicenseExceptionId :: LicenseListVersion -> String -> Maybe LicenseExceptionId\n"
+  . showString "mkLicenseExceptionId LicenseListVersion_3_0 s = Map.lookup s stringLookup_3_0\n"
+  . showString "mkLicenseExceptionId LicenseListVersion_3_2 s = Map.lookup s stringLookup_3_2\n"
+  . showString "mkLicenseExceptionId LicenseListVersion_3_5 s = Map.lookup s stringLookup_3_5\n"
+  . showString "\n"
+  . showString "stringLookup_3_0 :: Map String LicenseExceptionId\n"
+  . showString "stringLookup_3_0 = Map.fromList $ map (\\i -> (licenseExceptionId i, i)) $\n"
+  . showString "    licenseExceptionIdList LicenseListVersion_3_0\n"
+  . showString "\n"
+  . showString "stringLookup_3_2 :: Map String LicenseExceptionId\n"
+  . showString "stringLookup_3_2 = Map.fromList $ map (\\i -> (licenseExceptionId i, i)) $\n"
+  . showString "    licenseExceptionIdList LicenseListVersion_3_2\n"
+  . showString "\n"
+  . showString "stringLookup_3_5 :: Map String LicenseExceptionId\n"
+  . showString "stringLookup_3_5 = Map.fromList $ map (\\i -> (licenseExceptionId i, i)) $\n"
+  . showString "    licenseExceptionIdList LicenseListVersion_3_5\n"
+  . showString "\n"
+  . showString "--  | License exceptions in all SPDX License lists\n"
+  . showString "bulkOfLicenses :: [LicenseExceptionId]\n"
+  . showString "bulkOfLicenses =\n"
+  . showString (cfgLicenseList_all $ cfg)
+  . showString "\n"
+
+-- 'prelude'
+
+_ifImpl :: Bool -> ShowS -> ShowS
+_ifImpl True  s = s
+_ifImpl False _ = id
+
+_forImpl :: [a] -> (a -> ShowS) -> ShowS
+_forImpl xs f = foldr (\x s -> f x . s) id xs
+

--- a/cabal-dev-scripts/src/Template/LicenseId.hs
+++ b/cabal-dev-scripts/src/Template/LicenseId.hs
@@ -1,0 +1,223 @@
+module Template.LicenseId (instantiate, Cfg(..), CfgLicenses(..)) where
+
+-- data types
+
+data Cfg = Cfg
+  { cfgLicenseIds :: !String
+  , cfgLicenseList_3_0 :: !String
+  , cfgLicenseList_3_2 :: !String
+  , cfgLicenseList_3_5 :: !String
+  , cfgLicenseList_all :: !String
+  , cfgLicenses :: ![CfgLicenses]
+  } deriving (Show)
+
+data CfgLicenses = CfgLicenses
+  { cfgLicensesCon :: !String
+  , cfgLicensesId :: !String
+  , cfgLicensesIsOsiApproved :: !Bool
+  , cfgLicensesName :: !String
+  } deriving (Show)
+
+-- template instantiation
+
+instantiate :: Cfg -> String
+instantiate cfg = ($ []) $ id
+  . showString "{-# LANGUAGE DeriveDataTypeable #-}\n"
+  . showString "{-# LANGUAGE DeriveGeneric      #-}\n"
+  . showString "module Distribution.SPDX.LicenseId (\n"
+  . showString "    LicenseId (..),\n"
+  . showString "    licenseId,\n"
+  . showString "    licenseName,\n"
+  . showString "    licenseIsOsiApproved,\n"
+  . showString "    mkLicenseId,\n"
+  . showString "    licenseIdList,\n"
+  . showString "    -- * Helpers\n"
+  . showString "    licenseIdMigrationMessage,\n"
+  . showString "    ) where\n"
+  . showString "\n"
+  . showString "import Distribution.Compat.Prelude\n"
+  . showString "import Prelude ()\n"
+  . showString "\n"
+  . showString "import Distribution.Pretty\n"
+  . showString "import Distribution.Parsec\n"
+  . showString "import Distribution.Utils.Generic (isAsciiAlphaNum)\n"
+  . showString "import Distribution.SPDX.LicenseListVersion\n"
+  . showString "\n"
+  . showString "import qualified Data.Binary.Get as Binary\n"
+  . showString "import qualified Data.Binary.Put as Binary\n"
+  . showString "import qualified Data.Map.Strict as Map\n"
+  . showString "import qualified Distribution.Compat.CharParsing as P\n"
+  . showString "import qualified Text.PrettyPrint as Disp\n"
+  . showString "\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "-- LicenseId\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "\n"
+  . showString "-- | SPDX License identifier\n"
+  . showString "data LicenseId\n"
+  . showString (cfgLicenseIds $ cfg)
+  . showString "\n"
+  . showString "  deriving (Eq, Ord, Enum, Bounded, Show, Read, Typeable, Data, Generic)\n"
+  . showString "\n"
+  . showString "instance Binary LicenseId where\n"
+  . showString "    -- Word16 is encoded in big endianess\n"
+  . showString "    -- https://github.com/kolmodin/binary/blob/master/src/Data/Binary/Class.hs#L220-LL227\n"
+  . showString "    put = Binary.putWord16be . fromIntegral . fromEnum\n"
+  . showString "    get = do\n"
+  . showString "        i <- Binary.getWord16be\n"
+  . showString "        if i > fromIntegral (fromEnum (maxBound :: LicenseId))\n"
+  . showString "        then fail \"Too large LicenseId tag\"\n"
+  . showString "        else return (toEnum (fromIntegral i))\n"
+  . showString "\n"
+  . showString "instance Pretty LicenseId where\n"
+  . showString "    pretty = Disp.text . licenseId\n"
+  . showString "\n"
+  . showString "-- |\n"
+  . showString "-- >>> eitherParsec \"BSD-3-Clause\" :: Either String LicenseId\n"
+  . showString "-- Right BSD_3_Clause\n"
+  . showString "--\n"
+  . showString "-- >>> eitherParsec \"BSD3\" :: Either String LicenseId\n"
+  . showString "-- Left \"...Unknown SPDX license identifier: 'BSD3' Do you mean BSD-3-Clause?\"\n"
+  . showString "--\n"
+  . showString "instance Parsec LicenseId where\n"
+  . showString "    parsec = do\n"
+  . showString "        n <- some $ P.satisfy $ \\c -> isAsciiAlphaNum c || c == '-' || c == '.'\n"
+  . showString "        v <- askCabalSpecVersion\n"
+  . showString "        maybe (fail $ \"Unknown SPDX license identifier: '\" ++  n ++ \"' \" ++ licenseIdMigrationMessage n) return $\n"
+  . showString "            mkLicenseId (cabalSpecVersionToSPDXListVersion v) n\n"
+  . showString "\n"
+  . showString "instance NFData LicenseId where\n"
+  . showString "    rnf l = l `seq` ()\n"
+  . showString "\n"
+  . showString "-- | Help message for migrating from non-SPDX license identifiers.\n"
+  . showString "--\n"
+  . showString "-- Old 'License' is almost SPDX, except for 'BSD2', 'BSD3'. This function\n"
+  . showString "-- suggests SPDX variant:\n"
+  . showString "--\n"
+  . showString "-- >>> licenseIdMigrationMessage \"BSD3\"\n"
+  . showString "-- \"Do you mean BSD-3-Clause?\"\n"
+  . showString "--\n"
+  . showString "-- Also 'OtherLicense', 'AllRightsReserved', and 'PublicDomain' aren't\n"
+  . showString "-- valid SPDX identifiers\n"
+  . showString "--\n"
+  . showString "-- >>> traverse_ (print . licenseIdMigrationMessage) [ \"OtherLicense\", \"AllRightsReserved\", \"PublicDomain\" ]\n"
+  . showString "-- \"SPDX license list contains plenty of licenses. See https://spdx.org/licenses/. Also they can be combined into complex expressions with AND and OR.\"\n"
+  . showString "-- \"You can use NONE as a value of license field.\"\n"
+  . showString "-- \"Public Domain is a complex matter. See https://wiki.spdx.org/view/Legal_Team/Decisions/Dealing_with_Public_Domain_within_SPDX_Files. Consider using a proper license.\"\n"
+  . showString "--\n"
+  . showString "-- SPDX License list version 3.0 introduced \"-only\" and \"-or-later\" variants for GNU family of licenses.\n"
+  . showString "-- See <https://spdx.org/news/news/2018/01/license-list-30-released>\n"
+  . showString "-- >>> licenseIdMigrationMessage \"GPL-2.0\"\n"
+  . showString "-- \"SPDX license list 3.0 deprecated suffixless variants of GNU family of licenses. Use GPL-2.0-only or GPL-2.0-or-later.\"\n"
+  . showString "--\n"
+  . showString "-- For other common licenses their old license format coincides with the SPDX identifiers:\n"
+  . showString "--\n"
+  . showString "-- >>> traverse eitherParsec [\"GPL-2.0-only\", \"GPL-3.0-only\", \"LGPL-2.1-only\", \"MIT\", \"ISC\", \"MPL-2.0\", \"Apache-2.0\"] :: Either String [LicenseId]\n"
+  . showString "-- Right [GPL_2_0_only,GPL_3_0_only,LGPL_2_1_only,MIT,ISC,MPL_2_0,Apache_2_0]\n"
+  . showString "--\n"
+  . showString "licenseIdMigrationMessage :: String -> String\n"
+  . showString "licenseIdMigrationMessage = go where\n"
+  . showString "    go l | gnuVariant l    = \"SPDX license list 3.0 deprecated suffixless variants of GNU family of licenses. Use \" ++ l ++ \"-only or \" ++ l ++ \"-or-later.\"\n"
+  . showString "    go \"BSD3\"              = \"Do you mean BSD-3-Clause?\"\n"
+  . showString "    go \"BSD2\"              = \"Do you mean BSD-2-Clause?\"\n"
+  . showString "    go \"AllRightsReserved\" = \"You can use NONE as a value of license field.\"\n"
+  . showString "    go \"OtherLicense\"      = \"SPDX license list contains plenty of licenses. See https://spdx.org/licenses/. Also they can be combined into complex expressions with AND and OR.\"\n"
+  . showString "    go \"PublicDomain\"      = \"Public Domain is a complex matter. See https://wiki.spdx.org/view/Legal_Team/Decisions/Dealing_with_Public_Domain_within_SPDX_Files. Consider using a proper license.\"\n"
+  . showString "\n"
+  . showString "    -- otherwise, we don't know\n"
+  . showString "    go _ = \"\"\n"
+  . showString "\n"
+  . showString "    gnuVariant = flip elem [\"GPL-2.0\", \"GPL-3.0\", \"LGPL-2.1\", \"LGPL-3.0\", \"AGPL-3.0\" ]\n"
+  . showString "\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "-- License Data\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "\n"
+  . showString "-- | License SPDX identifier, e.g. @\"BSD-3-Clause\"@.\n"
+  . showString "licenseId :: LicenseId -> String\n"
+  . _forImpl (cfgLicenses $ cfg) (\license -> id
+    . showString "licenseId "
+    . showString (cfgLicensesCon $ license)
+    . showString " = "
+    . showString (cfgLicensesId $ license)
+    . showString "\n"
+    )
+  . showString "\n"
+  . showString "-- | License name, e.g. @\"GNU General Public License v2.0 only\"@\n"
+  . showString "licenseName :: LicenseId -> String\n"
+  . _forImpl (cfgLicenses $ cfg) (\license -> id
+    . showString "licenseName "
+    . showString (cfgLicensesCon $ license)
+    . showString " = "
+    . showString (cfgLicensesName $ license)
+    . showString "\n"
+    )
+  . showString "\n"
+  . showString "-- | Whether the license is approved by Open Source Initiative (OSI).\n"
+  . showString "--\n"
+  . showString "-- See <https://opensource.org/licenses/alphabetical>.\n"
+  . showString "licenseIsOsiApproved :: LicenseId -> Bool\n"
+  . _forImpl (cfgLicenses $ cfg) (\license -> id
+    . showString "licenseIsOsiApproved "
+    . showString (cfgLicensesCon $ license)
+    . showString " = "
+    . ( _ifImpl (cfgLicensesIsOsiApproved $ license) $ id
+      . showString "True"
+      )
+    . ( _ifImpl (not $ cfgLicensesIsOsiApproved $ license) $ id
+      . showString "False"
+      )
+    . showString "\n"
+    )
+  . showString "\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "-- Creation\n"
+  . showString "-------------------------------------------------------------------------------\n"
+  . showString "\n"
+  . showString "licenseIdList :: LicenseListVersion -> [LicenseId]\n"
+  . showString "licenseIdList LicenseListVersion_3_0 =\n"
+  . showString (cfgLicenseList_3_0 $ cfg)
+  . showString "\n"
+  . showString "    ++ bulkOfLicenses\n"
+  . showString "licenseIdList LicenseListVersion_3_2 =\n"
+  . showString (cfgLicenseList_3_2 $ cfg)
+  . showString "\n"
+  . showString "    ++ bulkOfLicenses\n"
+  . showString "licenseIdList LicenseListVersion_3_5 =\n"
+  . showString (cfgLicenseList_3_5 $ cfg)
+  . showString "\n"
+  . showString "    ++ bulkOfLicenses\n"
+  . showString "\n"
+  . showString "-- | Create a 'LicenseId' from a 'String'.\n"
+  . showString "mkLicenseId :: LicenseListVersion -> String -> Maybe LicenseId\n"
+  . showString "mkLicenseId LicenseListVersion_3_0 s = Map.lookup s stringLookup_3_0\n"
+  . showString "mkLicenseId LicenseListVersion_3_2 s = Map.lookup s stringLookup_3_2\n"
+  . showString "mkLicenseId LicenseListVersion_3_5 s = Map.lookup s stringLookup_3_5\n"
+  . showString "\n"
+  . showString "stringLookup_3_0 :: Map String LicenseId\n"
+  . showString "stringLookup_3_0 = Map.fromList $ map (\\i -> (licenseId i, i)) $\n"
+  . showString "    licenseIdList LicenseListVersion_3_0\n"
+  . showString "\n"
+  . showString "stringLookup_3_2 :: Map String LicenseId\n"
+  . showString "stringLookup_3_2 = Map.fromList $ map (\\i -> (licenseId i, i)) $\n"
+  . showString "    licenseIdList LicenseListVersion_3_2\n"
+  . showString "\n"
+  . showString "stringLookup_3_5 :: Map String LicenseId\n"
+  . showString "stringLookup_3_5 = Map.fromList $ map (\\i -> (licenseId i, i)) $\n"
+  . showString "    licenseIdList LicenseListVersion_3_5\n"
+  . showString "\n"
+  . showString "--  | Licenses in all SPDX License lists\n"
+  . showString "bulkOfLicenses :: [LicenseId]\n"
+  . showString "bulkOfLicenses =\n"
+  . showString (cfgLicenseList_all $ cfg)
+  . showString "\n"
+
+-- 'prelude'
+
+_ifImpl :: Bool -> ShowS -> ShowS
+_ifImpl True  s = s
+_ifImpl False _ = id
+
+_forImpl :: [a] -> (a -> ShowS) -> ShowS
+_forImpl xs f = foldr (\x s -> f x . s) id xs
+

--- a/cabal-dev-scripts/src/Zinza.hs
+++ b/cabal-dev-scripts/src/Zinza.hs
@@ -1,0 +1,592 @@
+-- |
+-- SPDX-Identifier-Id: GPL-2.0-or-later AND BSD-3-Clause
+--
+-- Zinza - a small jinja-syntax-inspired template compiler.
+--
+-- Zinza compiles a template into as Haskell module. The template arguments are
+-- ordinary Haskell records. Type-safe (text) templates without Template
+-- Haskell, but using a preprocessor.
+--
+-- Zinza is very minimalistic. Features are added when needed.
+--
+-- == Examples
+--
+-- For an example see SPDX LicenseId module generation.
+--
+-- == Executable usage
+--
+-- @
+-- ./zinza INPUT.tmpl OUTPUT.hs [--module-name=Template]
+-- @
+--
+-- == Syntax
+--
+-- === Expressions
+--
+-- @
+-- {{ expression }}
+-- @
+--
+-- Expression syntax has two structures
+--
+-- * negated: @!foo@
+--
+-- * field access @foo.bar@
+--
+-- === Control structures
+--
+-- The __for__ and __if__ statements are supported:
+--
+-- @
+-- {% for value in values %}
+-- ...
+-- {% endfor %}
+-- @
+--
+-- @
+-- {% if boolExpression %}
+-- ...
+-- {% endif %}
+-- @
+--
+-- If a control structure tag starts at the first column, the possible
+-- trailing new line feed is stripped. This way full-line control tags
+-- don't introduce new lines in the output.
+--
+-- == Miscellanea
+--
+-- A plan is to iterate @zinza@ for some time in @Cabal@ code-base
+-- and later release as a separate package.
+--
+-- Zinza could produce invalid Haskell code.
+-- In some cases it could be smarter, or you can edit your template.
+--
+-- The license is @GPL-2.0-or-later@ with an exception
+-- that the code embedded into a generate template is free of it.
+-- I use @Bison-exception-2.2@ to indicate that.
+--
+{-# LANGUAGE DeriveFoldable       #-}
+{-# LANGUAGE DeriveFunctor        #-}
+{-# LANGUAGE DeriveTraversable    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Main (main) where
+
+import Control.Applicative              (many, optional, some, (<|>))
+import Control.Monad                    (ap, void, when)
+import Control.Monad.Trans.Class        (lift)
+import Control.Monad.Trans.State.Strict (State, get, modify', put, runState)
+import Data.Char                        (isAlphaNum, isLower, toLower, toUpper)
+import Data.Functor.Identity            (Identity (..))
+import Data.Maybe                       (fromMaybe, isJust)
+import Data.Semialign                   (alignWith)
+import Data.These                       (these)
+import Data.Void                        (Void, absurd)
+import Text.Parsec
+       (eof, getPosition, lookAhead, notFollowedBy, parse, satisfy, sourceColumn, try)
+import Text.Parsec.Char                 (char, space, spaces, string)
+import Text.Parsec.String               (Parser)
+
+import qualified Control.Monad.EitherK      as U
+import qualified Control.Unification        as U
+import qualified Control.Unification.IntVar as U
+import qualified Control.Unification.Types  as U
+
+import qualified Data.Map            as M
+import qualified Options.Applicative as O
+
+main :: IO ()
+main = do
+    Opts input output mn <- O.execParser $ O.info (O.helper <*> optsP) $ mconcat
+        [ O.fullDesc
+        , O.progDesc "Generate template module"
+        ]
+
+    contents <- readFile input
+    nodes <- either (fail . show) return $
+        parse (nodesP <* eof) input contents
+
+    (nodes', rootTy) <- either (fail . show) return $ inference nodes
+
+    let (strTypes, types) = generateTypes rootTy
+    let types' = concatMap (\t -> ", " ++ t ++ "(..)") $ reverse types
+
+    let contentsO :: String
+        contentsO = unlines
+            [ "module " ++ mn ++ " (instantiate" ++ types' ++ ") where"
+            , ""
+            , strTypes
+            , generateTemplate nodes'
+            , prelude
+            ]
+
+    if output == "-"
+    then putStrLn contentsO
+    else writeFile output contentsO
+
+-------------------------------------------------------------------------------
+-- Opts
+-------------------------------------------------------------------------------
+
+data Opts = Opts FilePath FilePath String
+
+optsP :: O.Parser Opts
+optsP = Opts
+    <$> strArgument
+        [ O.metavar "TEMPLATE"
+        , O.help    "Template input"
+        ]
+    <*> strArgument
+        [ O.metavar "OUTPUT"
+        , O.help    "Haskell module output"
+        ]
+    <*> strOption
+        [ O.long    "module-name"
+        , O.metavar "MODULE"
+        , O.help    "Module name"
+        , O.value   "Main"
+        , O.showDefault
+        ]
+  where
+    strArgument = O.strArgument . mconcat
+    strOption   = O.strOption   . mconcat
+
+-------------------------------------------------------------------------------
+-- Node syntax
+-------------------------------------------------------------------------------
+
+type Var = String
+
+type Nodes a = [Node a]
+
+-- | Template parts.
+--
+-- We use polymorphic recursion for de Bruijn indices.
+-- See materials on @bound@ library.
+data Node a
+    = NRaw  String                          -- ^ raw text block
+    | NExpr (Expr a)                        -- ^ expression @expr : String@
+    | NIf   (Expr a) (Nodes a)              -- ^ conditional block, @expr : Bool@
+    | NFor  Var (Expr a) (Nodes (Maybe a))  -- ^ for loop, @expr : List a@
+  deriving (Eq, Show, Functor, Foldable, Traversable)
+
+-- | Expressions
+data Expr a
+    = EVar a               -- ^ variable
+    | ERoot                -- ^ root variable
+    | EField (Expr a) Var  -- ^ field accessor
+    | ENot (Expr a)        -- ^ negation
+  deriving (Eq, Show, Functor, Foldable, Traversable)
+
+-- | 'Monad' instances give substitution.
+instance Monad Expr where
+    return = EVar
+
+    EVar x          >>= k = k x
+    ERoot           >>= _ = ERoot
+    EField expr var >>= k = EField (expr >>= k) var
+    ENot expr       >>= k = ENot (expr >>= k)
+
+instance Applicative Expr where
+    pure = return
+    (<*>) = ap
+
+-- | Substitution.
+(>>==) :: Node a -> (a -> Expr b) -> Node b
+NRaw s           >>== _ = NRaw s
+NExpr expr       >>== k = NExpr (expr >>= k)
+NIf expr ns      >>== k = NIf (expr >>= k) (map (>>== k) ns)
+NFor var expr ns >>== k = NFor var (expr >>= k) (map (>>== traverse k) ns)
+
+-------------------------------------------------------------------------------
+-- "bound"
+-------------------------------------------------------------------------------
+
+-- | Abstraction.
+abstract1 :: (Functor f, Eq a) => a -> f a -> f (Maybe a)
+abstract1 x = fmap $ \y ->
+    if x == y
+    then Nothing
+    else Just y
+
+-- | Instantiate with a variable type
+instantiate1ret :: Functor f => a -> f (Maybe a) -> f a
+instantiate1ret = fmap . fromMaybe
+
+-------------------------------------------------------------------------------
+-- Parser
+-------------------------------------------------------------------------------
+
+varP :: Parser Var
+varP = (:) <$> satisfy isLower <*> many (satisfy isVarChar)
+
+isVarChar :: Char -> Bool
+isVarChar c = isAlphaNum c || c == '_'
+
+nodeP :: Parser (Node Var)
+nodeP = directiveP <|> exprNodeP <|> newlineN <|> rawP
+
+nodesP :: Parser (Nodes Var)
+nodesP = many nodeP
+
+newlineN :: Parser (Node Var)
+newlineN = NRaw . pure <$> char '\n'
+
+rawP :: Parser (Node Var)
+rawP = mk <$> some rawCharP <*> optional (char '\n') where
+    rawCharP   = notBrace <|> try (char '{' <* lookAhead notSpecial)
+    notBrace   = satisfy $ \c -> c /= '{' && c /= '\n'
+    notSpecial = satisfy $ \c -> c /= '{' && c /= '\n' && c /= '%'
+
+    mk s Nothing  = NRaw s
+    mk s (Just c) = NRaw (s ++ [c])
+
+exprNodeP :: Parser (Node Var)
+exprNodeP = do
+    _ <- try (string "{{")
+    spaces
+    expr <- exprP
+    spaces
+    _ <- string "}}"
+    return (NExpr expr)
+
+exprP :: Parser (Expr Var)
+exprP =  do
+    b <- optional (char '!')
+    v <- varP
+    vs <- many (char '.' *> varP)
+    let expr = foldl EField (EVar v) vs
+    return $
+        if isJust b
+        then ENot expr
+        else expr
+
+directiveP :: Parser (Node Var)
+directiveP = forP <|> ifP
+
+spaces1 :: Parser ()
+spaces1 = space *> spaces
+
+open :: String -> Parser Bool
+open n = do
+    pos <- getPosition
+    _ <- try $ string "{%" *> spaces *> string n *> spaces
+    return $ sourceColumn pos == 1  -- parsec counts pos from 1, not zero.
+
+close :: String -> Parser ()
+close n = do
+    on0 <- open ("end" ++ n)
+    close' on0
+
+close' :: Bool -> Parser ()
+close' on0 = do
+    _ <- string "%}"
+    when on0 $ void $ optional (char '\n')
+
+forP :: Parser (Node Var)
+forP = do
+    on0 <- open "for"
+    var <- varP
+    spaces1
+    _ <- string "in"
+    notFollowedBy $ satisfy isAlphaNum
+    spaces1
+    expr <- exprP
+    spaces1
+    close' on0
+    ns <- nodesP
+    close "for"
+    return $ NFor var expr (abstract1 var <$> ns)
+
+ifP :: Parser (Node Var)
+ifP = do
+    on0 <- open "if"
+    expr <- exprP
+    spaces
+    close' on0
+    ns <- nodesP
+    close "if"
+    return $ NIf expr ns
+
+-------------------------------------------------------------------------------
+-- Types
+-------------------------------------------------------------------------------
+
+data Ty
+    = TyUnit
+    | TyBool
+    | TyString
+    | TyList Ty
+    | TyRecord (M.Map Var Ty)
+  deriving (Eq, Ord, Show)
+
+data TyF a
+    = TyVarF a
+    | TyUnitF
+    | TyBoolF
+    | TyStringF
+    | TyListF a
+    | TyRecordF (M.Map Var a)
+  deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
+
+instance U.Unifiable TyF where
+    zipMatch (TyVarF a)    (TyVarF b)    = Just (TyVarF (Right (a, b)))
+    zipMatch TyUnitF       TyUnitF       = Just TyUnitF
+    zipMatch TyBoolF       TyBoolF       = Just TyBoolF
+    zipMatch TyStringF     TyStringF     = Just TyStringF
+    zipMatch (TyListF a)   (TyListF b)   = Just (TyListF (Right (a, b)))
+    zipMatch (TyRecordF a) (TyRecordF b) = Just $ TyRecordF $
+        alignWith (these Left Left (curry Right)) a b
+
+    zipMatch _ _ = Nothing
+
+type UTy = U.UTerm TyF U.IntVar
+
+-- | Convert type used in unification into normal type.
+-- If a type contains free unification variables, we default them to 'TyUnit'.
+--
+-- /Note:/ use 'freeze' only after 'U.applyBindings'.
+freeze :: UTy -> Ty
+freeze (U.UVar _)              = TyUnit
+freeze (U.UTerm (TyVarF x))    = freeze x
+freeze (U.UTerm TyUnitF)       = TyUnit
+freeze (U.UTerm TyBoolF)       = TyBool
+freeze (U.UTerm TyStringF)     = TyString
+freeze (U.UTerm (TyListF a))   = TyList (freeze a)
+freeze (U.UTerm (TyRecordF m)) = TyRecord (fmap freeze m)
+
+-------------------------------------------------------------------------------
+-- Type inference.
+-------------------------------------------------------------------------------
+
+type Error = U.UFailure TyF U.IntVar
+type Unify = U.EitherKT Error (U.IntBindingT TyF Identity)
+
+-- | Type-inference for used variables.
+inference
+    :: [Node Var]                      -- ^ input nodes
+    -> Either Error ([Node Void], Ty)  -- ^ elaborated nodes and type of the root record.
+inference ns0 =
+    fmap (fmap freeze) $ runIdentity $ U.evalIntBindingT $ U.runEitherKT $ do
+        -- all non binded variables are considered to be fields of "root".
+        rootTy <- newVar
+        let ns1 :: [Node (Void, UTy)]  -- Void, i.e. no free variables.
+                                       -- each variable knows own type
+                                       -- (if there were any variables :)
+            ns1 = fmap (>>== rootField) ns0
+
+        -- traverse the nodes, inferring the type of root.
+        ns3 <- inferenceM rootTy ns1
+
+        -- finalise the unifications
+        rootTy' <- U.applyBindings rootTy
+
+        -- done.
+        return (ns3, rootTy')
+  where
+    rootField :: Var -> Expr (Void, UTy)
+    rootField = EField ERoot
+
+newVar :: Unify UTy
+newVar = lift $ U.UVar <$> U.freeVar
+
+inferenceM
+    :: UTy               -- ^ root type
+    -> [Node (a, UTy)]
+    -> Unify [Node a]
+inferenceM rootTy = goMany where
+    goMany :: [Node (a, UTy)] -> Unify [Node a]
+    goMany = traverse go
+
+    go :: Node (a, UTy) -> Unify (Node a)
+
+    go (NRaw t)  = return $ NRaw t
+
+    go (NExpr expr) = do
+        (expr', _) <- checkExpr rootTy expr (U.UTerm TyStringF)
+        return $ NExpr expr'
+
+    go (NFor var expr ns) = do
+        elTy <- newVar
+        (expr', _) <- checkExpr rootTy expr (U.UTerm (TyListF elTy))
+        let fwd :: Maybe (a, UTy) -> (Maybe a, UTy)
+            fwd Nothing        = (Nothing, elTy)
+            fwd (Just (x, ty)) = (Just x, ty)
+
+        let nsB = fmap2 fwd ns
+        nsB' <- goMany nsB
+
+        return $ NFor var expr' nsB'
+
+    go (NIf expr ns) = do
+        (expr', _) <- checkExpr rootTy expr (U.UTerm TyBoolF)
+        ns' <- goMany ns
+
+        return $ NIf expr' ns'
+
+-- | Expressions are checked, as statements require specific types.
+checkExpr
+    :: UTy                  -- ^ type of root expression
+    -> Expr (a, UTy)        -- ^ expression
+    -> UTy                  -- ^ expected type.
+    -> Unify (Expr a, UTy)  -- ^ elaborated expression and its type
+checkExpr rootTy ERoot         ty' = do
+    rootTy' <- U.unify rootTy ty'
+    return (ERoot, rootTy')
+checkExpr _     (EVar (v, ty)) ty' = do
+    ty'' <- U.unify ty ty'
+    return (EVar v, ty'')
+checkExpr rootTy (EField expr field) ty' = do
+    (expr', exprTy) <- checkExpr rootTy expr $ U.UTerm $ TyRecordF $ M.singleton field ty'
+    return (EField expr' field, exprTy)
+checkExpr rootTy (ENot expr) ty = do
+    let boolTy = U.UTerm TyBoolF
+    _ <- U.unify ty boolTy
+    (expr', _exprTy) <- checkExpr rootTy expr boolTy
+    return (ENot expr', boolTy)
+
+-------------------------------------------------------------------------------
+-- Generate types
+-------------------------------------------------------------------------------
+
+generateTypes :: Ty -> (String, [TyName])
+generateTypes ty0 =
+    ( unlines $ "-- data types" : ls
+    , types
+    )
+  where
+    ls :: [String]
+    types :: [TyName]
+    (ls, (_, types)) = runState loop ([("Cfg", ty0)], [])
+
+    loop :: State ([(String, Ty)], [TyName]) [String]
+    loop = do
+        x <- get
+        case x of
+            ([], _) -> return []
+            ((name, ty):tys, tys') -> do
+                put (tys, tys')
+                (++) <$> single name ty <*> loop
+
+    single name (TyRecord m) = do
+        modify' $ \(x, y) ->
+            ( [ (typeNameRec k, ty) | (k, ty) <- M.toList m ]  ++ x
+            , name : y
+            )
+        return $
+            [ ""
+            , "data " ++ name ++ " = " ++ name
+            ] ++ mapHeadTail ("  { " ++) ("  , " ++)
+            [ fieldName name k ++ " :: !" ++ typeName k ty
+            | (k, ty) <- M.toList m
+            ] ++
+            [ "  } deriving (Show)"
+            ]
+    single name (TyList ty) = single name ty
+    single _ _ = return []
+
+fieldName :: TyName -> String -> String
+fieldName tyName field = mapFirst toLower tyName ++ mapFirst toUpper field
+
+typeName :: String -> Ty -> TyName
+typeName name (TyRecord _) = typeNameRec name
+typeName _    TyUnit       = "()"
+typeName _    TyBool       = "Bool"
+typeName _    TyString     = "String"
+typeName name (TyList el)  = "[" ++ typeName name el ++ "]"
+
+typeNameRec :: String -> String
+typeNameRec = ("Cfg" ++) . mapFirst toUpper
+
+mapHeadTail :: (a -> a) -> (a -> a) -> [a] -> [a]
+mapHeadTail _ _ []     = []
+mapHeadTail f g (x:xs) = f x : map g xs
+
+mapFirst f = mapHeadTail f id
+mapFirst :: (a -> a) -> [a] -> [a]
+
+-------------------------------------------------------------------------------
+-- Generate template
+-------------------------------------------------------------------------------
+
+type TyName = String
+
+generateTemplate :: [Node Void] -> String
+generateTemplate ns0 = unlines $
+    "-- template instantiation" :
+    "" :
+    "instantiate :: Cfg -> String" :
+    "instantiate cfg = ($ []) $ id" :
+    strs
+  where
+    ns1 :: [Node (Var, TyName)]
+    ns1 = fmap2 absurd ns0
+
+    strs = goMany "  " ns1
+
+    goMany :: String -> [Node (Var, TyName)] -> [String]
+    goMany pfx = concatMap (go pfx)
+
+    go :: String -> Node (Var, TyName) -> [String]
+    go pfx (NRaw  s)          = [pfx ++ ". showString " ++ show s]
+    go pfx (NExpr e)          = [pfx ++ ". showString (" ++ fst (showExpr e) ++ ")"]
+    go pfx (NIf expr ns)    =
+        [ pfx ++ ". ( _ifImpl (" ++ varCode ++ ") $ id"
+        ] ++
+        goMany ("  " ++ pfx) ns ++
+        [ pfx ++ "  )"
+        ]
+      where
+        (varCode, _) = showExpr expr
+    go pfx (NFor var expr ns) =
+        [ pfx ++ ". _forImpl (" ++ varCode ++ ") (\\" ++ var ++ " -> id"
+        ] ++
+        goMany ("  " ++ pfx) (map (instantiate1ret (var, varTyName)) ns) ++
+        [ pfx ++ "  )"
+        ]
+      where
+        (varCode, varTyName) = showExpr expr
+
+showExpr :: Expr (Var, TyName) -> (String, TyName)
+showExpr ERoot               = ("cfg", "Cfg")
+showExpr (EVar varTy)        = varTy
+showExpr (EField expr field) =
+    (fieldName exprTyName field ++ " $ " ++ exprCode, typeNameRec field)
+  where
+    (exprCode, exprTyName) = showExpr expr
+showExpr (ENot expr)         =
+    ("not $ " ++ fst (showExpr expr), "Bool")
+
+-------------------------------------------------------------------------------
+-- Utils
+-------------------------------------------------------------------------------
+
+fmap2 :: (Functor f, Functor g) => (a -> b) -> f (g a) -> f (g b)
+fmap2 = fmap . fmap
+
+-------------------------------------------------------------------------------
+-- Prelude
+-------------------------------------------------------------------------------
+
+-- | Functions used by generate template module.
+--
+-- Their names begin with underscores for two reasons:
+--
+-- * If they are not used, there are no warnings
+--
+-- * Less likely to clash with some identifier.
+--
+-- The included code, i.e. @_ifImpl@ and @_forImpl@ 
+-- are licensed under the @BSD-3-Clause@ license.
+--
+prelude :: String
+prelude = unlines
+    [ "-- 'prelude'"
+    , ""
+    , "_ifImpl :: Bool -> ShowS -> ShowS"
+    , "_ifImpl True  s = s"
+    , "_ifImpl False _ = id"
+    , ""
+    , "_forImpl :: [a] -> (a -> ShowS) -> ShowS"
+    , "_forImpl xs f = foldr (\\x s -> f x . s) id xs"
+    ]


### PR DESCRIPTION
Zinza is a small templating engine,
which compiles template to a Haskell code
of that template.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
