### PR TITLE
Update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+```
+$ cabal v2-build ...
+```
+
+```
+```
+
+Please use versions prefixed commands to avoid ambiguity.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**System informataion**
+ - Operating system
+ - `cabal`, `ghc` versions
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ Steps to reproduce the behavior:
 $ cabal v2-build ...
 ```
 
-Please use versions prefixed commands (e.g. `v2-build` or `v1-build`) to avoid ambiguity.
+Please use version-prefixed commands (e.g. `v2-build` or `v1-build`) to avoid ambiguity.
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,10 +17,7 @@ Steps to reproduce the behavior:
 $ cabal v2-build ...
 ```
 
-```
-```
-
-Please use versions prefixed commands to avoid ambiguity.
+Please use versions prefixed commands (e.g. `v2-build` or `v1-build`) to avoid ambiguity.
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.


### PR DESCRIPTION
Make a new bug report template.

I noticed that we need to ask whether it's `v1-` or `v2-` build. Maybe a template will help remove single roundtrip.