### PR TITLE
Add support for `v2-install`-ing foreign libraries.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -338,11 +338,14 @@ instance Semigroup SavedConfig where
           lastNonEmptyNL = lastNonEmptyNL' savedInstallFlags
 
       combinedSavedClientInstallFlags = ClientInstallFlags {
+        cinstInstallExes = combine cinstInstallExes,
         cinstInstallLibs = combine cinstInstallLibs,
+        cinstInstallFLibs = combine cinstInstallFLibs,
         cinstEnvironmentPath = combine cinstEnvironmentPath,
         cinstOverwritePolicy = combine cinstOverwritePolicy,
         cinstInstallMethod = combine cinstInstallMethod,
-        cinstInstalldir = combine cinstInstalldir
+        cinstInstallDir = combine cinstInstallDir,
+        cinstFLibInstallDir = combine cinstFLibInstallDir
         }
         where
           combine        = combine'        savedClientInstallFlags
@@ -549,11 +552,12 @@ baseSavedConfig = do
 --
 initialSavedConfig :: IO SavedConfig
 initialSavedConfig = do
-  cacheDir    <- defaultCacheDir
-  logsDir     <- defaultLogsDir
-  worldFile   <- defaultWorldFile
-  extraPath   <- defaultExtraPath
-  installPath <- defaultInstallPath
+  cacheDir        <- defaultCacheDir
+  logsDir         <- defaultLogsDir
+  worldFile       <- defaultWorldFile
+  extraPath       <- defaultExtraPath
+  installPath     <- defaultInstallPath
+  flibInstallPath <- defaultFLibInstallPath
   return mempty {
     savedGlobalFlags     = mempty {
       globalCacheDir     = toFlag cacheDir,
@@ -569,7 +573,8 @@ initialSavedConfig = do
       installNumJobs     = toFlag Nothing
     },
     savedClientInstallFlags = mempty {
-      cinstInstalldir = toFlag installPath
+      cinstInstallDir     = toFlag installPath,
+      cinstFLibInstallDir = toFlag flibInstallPath 
     }
   }
 
@@ -613,6 +618,11 @@ defaultInstallPath :: IO FilePath
 defaultInstallPath = do
   dir <- getCabalDir
   return (dir </> "bin")
+
+defaultFLibInstallPath :: IO FilePath
+defaultFLibInstallPath = do
+  dir <- getCabalDir
+  return (dir </> "lib")
 
 defaultCompiler :: CompilerFlavor
 defaultCompiler = fromMaybe GHC defaultCompilerFlavor

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,7 @@
 -*-change-log-*-
 
 3.0.0.0 (current development version)
+	* `v2-install` will now install foreign libraries. (#6046)
 	* `install-method` and `overwrite-policy` in `.cabal/config` now actually work. (#5942)
 	* `v2-install` now reports the error when a package fails to build. (#5641)
 	* `v2-install` now has a default when called in a project (#5978, #6014, #6092)

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -364,9 +364,12 @@ instance Arbitrary ClientInstallFlags where
     arbitrary =
       ClientInstallFlags
         <$> arbitrary
+        <*> arbitrary
+        <*> arbitrary
         <*> arbitraryFlag arbitraryShortToken
         <*> arbitrary
         <*> arbitrary
+        <*> arbitraryFlag arbitraryShortToken
         <*> arbitraryFlag arbitraryShortToken
 
 instance Arbitrary ProjectConfigBuildOnly where


### PR DESCRIPTION
Closes #6046.

Still needs documentation updates, plus shakedown testing from anyone who isn't me.

With more than two options of "thing that can be installed", existing interface doesn't make sense. Instead of exclusive modes, we now have a flag for each kind of thing that can be installed, allowing the user to select what they want explicitly.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
