### PR TITLE
Allow curl to use .netrc

### DIFF
--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -59,6 +59,7 @@ import System.IO.Error
 import Distribution.Simple.Program
          ( Program, simpleProgram, ConfiguredProgram, programPath
          , ProgramInvocation(..), programInvocation
+         , programOverrideArgs, programPostConf
          , ProgramSearchPathEntry(..)
          , getProgramInvocationOutput )
 import Distribution.Simple.Program.Db
@@ -252,6 +253,12 @@ supportedTransports :: [(String, Maybe Program, Bool,
 supportedTransports =
     [ let prog = simpleProgram "curl" in
       ( "curl", Just prog, True
+      , \db -> curlTransport <$> lookupProgram prog db )
+
+    , let prog = (simpleProgram "curl") { programPostConf = post }
+          args = ["-n"]
+          post = \_ p -> return p { programOverrideArgs = args } in
+      ( "curlnetrc", Just prog, True
       , \db -> curlTransport <$> lookupProgram prog db )
 
     , let prog = simpleProgram "wget" in

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -405,7 +405,7 @@ globalCommand commands = CommandUI {
          trueArg
 
       ,option [] ["http-transport"]
-         "Set a transport for http(s) requests. Accepts 'curl', 'wget', 'powershell', and 'plain-http'. (default: 'curl')"
+         "Set a transport for http(s) requests. Accepts 'curl', 'curlnetrc', 'wget', 'powershell', and 'plain-http'. (default: 'curl')"
          globalHttpTransport (\v flags -> flags { globalHttpTransport = v })
          (reqArgFlag "HttpTransport")
       ,option [] ["nix"]

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -39,6 +39,7 @@
 	* Add --test-wrapper that allows a prebuild script to set the test environment.
 	* Add filterTestFlags: filter test-wrapper for Cabal < 3.0.0.
 	* Cabal now only builds the minimum of a package for `v2-install` (#5754, #6091)
+	* Cabal uses `~/.netrc` when using the curlnetrc transport method.
 
 2.4.1.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> November 2018
 	* Add message to alert user to potential package casing errors. (#5635)


### PR DESCRIPTION
If using a private hackage repo in conjunction with the main one, and the private one requires HTTP Basic Auth, then you are forced to use the wget transport. The curl transport doesn't understand http auth credentials embedded within the repo uri.

e.g.
```
repository private
  url: https://user:pass@hackage.private.net/
```

`curlTransport` doesn't understand this, but `wgetTransport` does.

Unfortunately, `wgetTransport` doesn't do range requests so updating from hackage is really slow.

This PR simply adds a `curlnetrc` transport which runs `curl -n` instead of just `curl`. If a user has a private repo configured, and if it requires auth, and if they have provided credentials in `~/.netrc`, then this will allow using the curl transport to grab updates.

If the user doesn't have a `~/.netrc`, then behaviour is unchanged.

== Testing

Added a private repository entry in `~/.cabal/config` without embedded credentials:

```
repository private
  url: https://hackage.private.net/

http-transport: curlnetrc
```

And specified the credentials in `~/.netrc` instead:
```
machine hackage.private.net
login uuu
password xxx
```

```
$ dist-newstyle/build/x86_64-osx/ghc-8.6.5/cabal-install-3.0.0.0/build/cabal/cabal v2-update
Resolving dependencies...
Up to date
Downloading the latest package lists from:
- hackage.haskell.org
- private
To revert to previous state run:
    cabal v2-update 'private,2019-07-04T05:42:06Z'
To revert to previous state run:
    cabal v2-update 'hackage.haskell.org,2019-07-04T23:22:51Z'
```

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.
