### PR TITLE
Literate run

### DIFF
--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Script/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Script/cabal.test.hs
@@ -1,5 +1,5 @@
 import Test.Cabal.Prelude
 
 main = cabalTest $ do
-    expectBroken 5775 $ cabal' "v2-run" ["script.hs"]
-    return ()
+    res <- cabal' "v2-run" ["script.hs"]
+    assertOutputContains "Hello World" res

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Script/script.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Script/script.hs
@@ -1,6 +1,6 @@
 #! /usr/bin/env cabal
 {- cabal:
-build-depends: base ^>= 4.0
+build-depends: base >= 4.3 && <5
 -}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -8,4 +8,4 @@ build-depends: base ^>= 4.0
 import Prelude
 
 main :: IO ()
-main = return ()
+main = putStrLn "Hello World"

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptLiterate/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptLiterate/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptLiterate/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptLiterate/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    res <- cabal' "v2-run" ["script.lhs"]
+    assertOutputContains "Hello World" res

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptLiterate/script.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptLiterate/script.cabal
@@ -1,0 +1,4 @@
+name: script
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptLiterate/script.lhs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptLiterate/script.lhs
@@ -1,0 +1,10 @@
+%cabal:
+%build-depends: base >= 4.3 && <5
+%endcabal
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+import Prelude
+
+main :: IO ()
+main = putStrLn "Hello World"


### PR DESCRIPTION
An example file 

```latex
%cabal:
%build-depends: base, lens
%endcabal
\documentclass{article}
%include polycode.fmt
\begin{document}

This is an example document

\begin{code}
import Control.Lens

main :: IO ()
main = putStrLn $ toListOf traverse "hello world"
\end{code}

\end{document}
```

Comments on "syntax" are welcome. Having distinct start and end markers helps parsing. `%endcabal` is distinctive enough end marker, but should start marker be `%cabal:` or `%cabal` (without colon), or some completely different markers?

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
