### PR TITLE
Clearly state that invalid fields are ignored

### DIFF
--- a/Cabal/Distribution/FieldGrammar/Parsec.hs
+++ b/Cabal/Distribution/FieldGrammar/Parsec.hs
@@ -266,7 +266,7 @@ instance FieldGrammar ParsecFieldGrammar where
                 for_ (Map.toList unknownFields) $ \(name, fields) ->
                     for_ fields $ \(MkNamelessField pos _) ->
                         parseWarning pos PWTUnknownField $
-                            "The field " <> show name <> " is available only since the Cabal specification version " ++ showCabalSpecVersion vs ++ "."
+                            "The field " <> show name <> " is available only since the Cabal specification version " ++ showCabalSpecVersion vs ++ ". This field will be ignored."
 
                 pure def
 


### PR DESCRIPTION
Previously we would issue a warning of the following form when
we encountered a field that isn't supported by the cabal-version
declared in the cabal file:

    Warning: ghc-heap.cabal:30:3: The field "cmm-sources" is available
    only since the Cabal specification version 3.0.

The message, however, doesn't tell the user the consequence of this
warning. Consequently a user could easily be confused when the build
subsequently fail.

Avoid this possibility by clearly stating that the field value will be
ignored.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
