### PR TITLE
write multiline fields as multiline fields in config

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -890,10 +890,10 @@ configFieldDescriptions src =
         let name = "optimization" in
         FieldDescr name
           (\f -> case f of
-                   Flag NoOptimisation      -> Disp.text "False"
-                   Flag NormalOptimisation  -> Disp.text "True"
-                   Flag MaximumOptimisation -> Disp.text "2"
-                   _                        -> Disp.empty)
+                   Flag NoOptimisation      -> [Disp.text "False"]
+                   Flag NormalOptimisation  -> [Disp.text "True"]
+                   Flag MaximumOptimisation -> [Disp.text "2"]
+                   _                        -> [Disp.empty])
           (\line str _ -> case () of
            _ |  str == "False" -> ParseOk [] (Flag NoOptimisation)
              |  str == "True"  -> ParseOk [] (Flag NormalOptimisation)
@@ -912,11 +912,11 @@ configFieldDescriptions src =
         let name = "debug-info" in
         FieldDescr name
           (\f -> case f of
-                   Flag NoDebugInfo      -> Disp.text "False"
-                   Flag MinimalDebugInfo -> Disp.text "1"
-                   Flag NormalDebugInfo  -> Disp.text "True"
-                   Flag MaximalDebugInfo -> Disp.text "3"
-                   _                     -> Disp.empty)
+                   Flag NoDebugInfo      -> [Disp.text "False"]
+                   Flag MinimalDebugInfo -> [Disp.text "1"]
+                   Flag NormalDebugInfo  -> [Disp.text "True"]
+                   Flag MaximalDebugInfo -> [Disp.text "3"]
+                   _                     -> [Disp.empty])
           (\line str _ -> case () of
            _ |  str == "False" -> ParseOk [] (Flag NoDebugInfo)
              |  str == "True"  -> ParseOk [] (Flag NormalDebugInfo)

--- a/cabal-install/Distribution/Client/ParseUtils.hs
+++ b/cabal-install/Distribution/Client/ParseUtils.hs
@@ -50,6 +50,7 @@ import Distribution.Simple.Command
 
 import Control.Monad    ( foldM )
 import Text.PrettyPrint ( (<+>), ($+$) )
+import Data.Maybe       ( listToMaybe )
 import qualified Data.Map as Map
 import qualified Text.PrettyPrint as Disp
          ( (<>), Doc, text, colon, vcat, empty, isEmpty, nest )
@@ -157,9 +158,8 @@ parseFields fieldDescrs =
 -- that also optionally print default values for empty fields as comments.
 --
 ppFields :: [FieldDescr a] -> (Maybe a) -> a -> Disp.Doc
-ppFields fields def cur =
-    Disp.vcat [ ppField name (fmap getter def) (getter cur)
-              | FieldDescr name getter _ <- fields]
+ppFields fields def cur = Disp.vcat $
+   concatMap (\(FieldDescr name getter _) -> map (ppField name (listToMaybe . getter =<< def)) (getter cur)) fields
 
 ppField :: String -> (Maybe Disp.Doc) -> Disp.Doc -> Disp.Doc
 ppField name mdef cur
@@ -279,4 +279,3 @@ parseConfig fieldDescrs sectionDescrs empty str =
 --
 showConfig :: [FieldDescr a] -> [SectionDescr a] -> a -> Disp.Doc
 showConfig = ppFieldsAndSections
-

--- a/cabal-install/Distribution/Client/SourceRepoParse.hs
+++ b/cabal-install/Distribution/Client/SourceRepoParse.hs
@@ -16,7 +16,7 @@ sourceRepoFieldDescrs =
   where
     toDescr (name, pretty, parse) = FieldDescr
         { fieldName = fromUTF8BS name
-        , fieldGet  = pretty
+        , fieldGet  = (:[]) . pretty
         , fieldSet  = \lineNo str x ->
               either (syntaxError lineNo) return
               $ explicitEitherParsec (parse x) str

--- a/cabal-install/Distribution/Deprecated/ParseUtils.hs
+++ b/cabal-install/Distribution/Deprecated/ParseUtils.hs
@@ -61,8 +61,8 @@ import Distribution.PackageDescription (FlagAssignment, mkFlagAssignment)
 import Data.Tree        as Tree (Tree (..), flatten)
 import System.FilePath  (normalise)
 import Text.PrettyPrint
-       (Doc, Mode (..), colon, comma, fsep, hsep, isEmpty, mode, nest, punctuate, render,
-       renderStyle, sep, style, text, vcat, ($+$), (<+>))
+       (Doc, colon, comma, fsep, hsep, isEmpty, nest, punctuate, render,
+       sep, text, vcat, ($+$), (<+>))
 
 import qualified Data.Map                      as Map
 

--- a/cabal-install/Distribution/Deprecated/ViewAsFieldDescr.hs
+++ b/cabal-install/Distribution/Deprecated/ViewAsFieldDescr.hs
@@ -19,7 +19,7 @@ import Distribution.Deprecated.ParseUtils (FieldDescr (..), runE, syntaxError)
 viewAsFieldDescr :: OptionField a -> FieldDescr a
 viewAsFieldDescr (OptionField _n []) =
   error "Distribution.command.viewAsFieldDescr: unexpected"
-viewAsFieldDescr (OptionField n dd) = FieldDescr n get set
+viewAsFieldDescr (OptionField n dd) = FieldDescr n ((:[]) . get) set
 
     where
       optDescr = head $ sortBy cmp dd
@@ -81,5 +81,3 @@ getChoiceByLongFlag (ChoiceOpt alts) val = listToMaybe
 
 getChoiceByLongFlag _ _ =
   error "Distribution.command.getChoiceByLongFlag: expected a choice option"
-
-


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

This changes `fieldGet` of `FieldDescr` to have `a -> [Doc]` and almost everything to not care about the extra list functionality. The one exception is fields that are instantiated with `multiListField`, a new drop-in replacement for `newLineListField`. These fields are able to be monoidally combined regardless afaik. However, by being broken out across multiple entries, now we don't have to worry about different path conventions (a la #5420) for different systems.

Everything still passes the test suite.