### PR TITLE
Parse list fields in cabal config file

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -1129,7 +1129,7 @@ parseConfig src initial = \str -> do
     splitMultiPath [s] = case runP 0 "" (parseOptCommaList parseTokenQ) s of
             ParseOk _ res -> res
             _ -> [s]
-    splitMultiPath xs = trace ( show xs) xs
+    splitMultiPath xs = xs
 
     -- This is a fixup, pending a full config parser rewrite, to ensure that
     -- config fields which can be comma seperated lists actually parse as comma seperated lists

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -3,6 +3,8 @@
 3.1.0.0 (current development version)
 
 3.0.0.0 TBD
+        * Parses comma-seperated lists for extra-prog-path, extra-lib-dirs, extra-framework-dirs, 
+	  and extra-include-dirs as actual lists. (#5420)
 	* `v2-repl` no longer changes directory to a randomized temporary folder
 	  when used outside of a project. (#5544)
 	* `install-method` and `overwrite-policy` in `.cabal/config` now actually work. (#5942)

--- a/cabal-testsuite/PackageTests/UserConfig/cabal.out
+++ b/cabal-testsuite/PackageTests/UserConfig/cabal.out
@@ -6,3 +6,9 @@ cabal: <ROOT>/cabal.dist/cabal-config already exists.
 Writing default configuration to <ROOT>/cabal.dist/cabal-config
 # cabal user-config
 Writing default configuration to <ROOT>/cabal.dist/cabal-config2
+# cabal user-config
+Renaming <ROOT>/cabal.dist/cabal-config to <ROOT>/cabal.dist/cabal-config.backup.
+Writing merged config to <ROOT>/cabal.dist/cabal-config.
+# cabal user-config
+Renaming <ROOT>/cabal.dist/cabal-config to <ROOT>/cabal.dist/cabal-config.backup.
+Writing merged config to <ROOT>/cabal.dist/cabal-config.

--- a/cabal-testsuite/PackageTests/UserConfig/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/UserConfig/cabal.test.hs
@@ -11,3 +11,7 @@ main = cabalTest $ do
     withEnv [("CABAL_CONFIG", Just conf2)] $ do
         cabal "user-config" ["init"]
         shouldExist conf2
+    cabalG ["--config-file", conf] "user-config" ["update", "-f", "-a", "extra-prog-path: foo", "-a", "extra-prog-path: bar"]
+    assertFileDoesContain conf "foo,bar"
+    cabalG ["--config-file", conf] "user-config" ["update", "-f", "-a", "extra-prog-path: foo, bar"]
+    assertFileDoesContain conf "foo,bar"


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

This changes parsing of cabal config files to be more uniform with parsing of cabal project files.

Specifically,  "extra-include-dirs", "extra-lib-dirs", "extra-framework-dirs", "extra-prog-path", and "configure-options" are now parsed as comma separated fields rather than single strings. This should resolve #5420 by making the syntax for this portable across systems. It is an alternative approach to #6155. Rather than writing multiple lines in config files, it brings the parsing and printing into accord by allowing parsing of comma separation (which the emitting already assumes is possible).

The entire config parser stuff is pretty antiquated and needs a full rewrite. In the meantime, this just "patches" the parsing after the fact. It makes use of the same parsers as for cabal project files, to not introduce yet another duplicate path. To do so we had to move certain "local" combinators from the cabal project file parser into their "proper" home (where the comments indicated they already should be moved as a further cleanup step). I audited the use cases for when they replace existing combinators there, and they're strictly more correct, so we should be fine.

Tested against the full suite and added a test specifically against this as well.