### PR TITLE
Fix cabal-install fighting over index cache with old versions

### DIFF
--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -549,8 +549,8 @@ indexFile (RepoIndex _ctxt repo) = indexBaseName repo <.> "tar"
 indexFile (SandboxIndex index)   = index
 
 cacheFile :: Index -> FilePath
-cacheFile (RepoIndex _ctxt repo) = indexBaseName repo <.> "cache"
-cacheFile (SandboxIndex index)   = index `replaceExtension` "cache"
+cacheFile (RepoIndex _ctxt repo) = indexBaseName repo <.> "cache-v2"
+cacheFile (SandboxIndex index)   = index `replaceExtension` "cache-v2"
 
 timestampFile :: Index -> FilePath
 timestampFile (RepoIndex _ctxt repo) = indexBaseName repo <.> "timestamp"


### PR DESCRIPTION
Currently 2.4.1.0 and master/3.0 fight over the global index cache. Every time one switches between the versions you get:

```
Warning: Parsing the index cache failed (Unknown encoding for constructor).
Trying to regenerate the index cache...
[takes 30sec or so]
```

and it takes just long enough to be really annoying.

Here's my proposed solution: just rename the index cache file.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
