### PR TITLE
Upload to specific repo

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -452,7 +452,8 @@ instance Semigroup SavedConfig where
         uploadUsername    = combine uploadUsername,
         uploadPassword    = combine uploadPassword,
         uploadPasswordCmd = combine uploadPasswordCmd,
-        uploadVerbosity   = combine uploadVerbosity
+        uploadVerbosity   = combine uploadVerbosity,
+        uploadRepoName    = combine uploadRepoName
         }
         where
           combine = combine' savedUploadFlags
@@ -460,7 +461,8 @@ instance Semigroup SavedConfig where
       combinedSavedReportFlags = ReportFlags {
         reportUsername  = combine reportUsername,
         reportPassword  = combine reportPassword,
-        reportVerbosity = combine reportVerbosity
+        reportVerbosity = combine reportVerbosity,
+        reportRepoName  = combine reportRepoName
         }
         where
           combine = combine' savedReportFlags

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -74,7 +74,7 @@ import Distribution.Deprecated.ReadP (readP_to_E)
 import Distribution.Client.Types
          ( Username(..), Password(..), RemoteRepo(..)
          , AllowNewer(..), AllowOlder(..), RelaxDeps(..)
-         , WriteGhcEnvironmentFilesPolicy(..)
+         , WriteGhcEnvironmentFilesPolicy(..), RemoteRepoName (..)
          )
 import Distribution.Client.BuildReports.Types
          ( ReportLevel(..) )
@@ -1473,14 +1473,16 @@ runCommand = CommandUI {
 data ReportFlags = ReportFlags {
     reportUsername  :: Flag Username,
     reportPassword  :: Flag Password,
-    reportVerbosity :: Flag Verbosity
+    reportVerbosity :: Flag Verbosity,
+    reportRepoName  :: Flag RemoteRepoName
   } deriving Generic
 
 defaultReportFlags :: ReportFlags
 defaultReportFlags = ReportFlags {
     reportUsername  = mempty,
     reportPassword  = mempty,
-    reportVerbosity = toFlag normal
+    reportVerbosity = toFlag normal,
+    reportRepoName  = mempty
   }
 
 reportCommand :: CommandUI ReportFlags
@@ -1506,6 +1508,11 @@ reportCommand = CommandUI {
         reportPassword (\v flags -> flags { reportPassword = v })
         (reqArg' "PASSWORD" (toFlag . Password)
                             (flagToList . fmap unPassword))
+
+      ,option ['R'] ["repository-name"]
+        "Hackage repository to upload to."
+        reportRepoName (\v flags -> flags { reportRepoName = v })
+        (reqArg' "REPO" (toFlag . RemoteRepoName) (flagToList . fmap unRemoteRepoName))
       ]
   }
 
@@ -2150,7 +2157,8 @@ data UploadFlags = UploadFlags {
     uploadUsername    :: Flag Username,
     uploadPassword    :: Flag Password,
     uploadPasswordCmd :: Flag [String],
-    uploadVerbosity   :: Flag Verbosity
+    uploadVerbosity   :: Flag Verbosity,
+    uploadRepoName    :: Flag RemoteRepoName
   } deriving Generic
 
 defaultUploadFlags :: UploadFlags
@@ -2160,7 +2168,8 @@ defaultUploadFlags = UploadFlags {
     uploadUsername    = mempty,
     uploadPassword    = mempty,
     uploadPasswordCmd = mempty,
-    uploadVerbosity   = toFlag normal
+    uploadVerbosity   = toFlag normal,
+    uploadRepoName    = mempty
   }
 
 uploadCommand :: CommandUI UploadFlags
@@ -2207,6 +2216,11 @@ uploadCommand = CommandUI {
         "Command to get Hackage password."
         uploadPasswordCmd (\v flags -> flags { uploadPasswordCmd = v })
         (reqArg' "PASSWORD" (Flag . words) (fromMaybe [] . flagToMaybe))
+
+      ,option ['R'] ["repository-name"]
+        "Hackage repository to upload to."
+        uploadRepoName (\v flags -> flags { uploadRepoName = v })
+        (reqArg' "REPO" (toFlag . RemoteRepoName) (flagToList . fmap unRemoteRepoName))
       ]
   }
 

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -74,8 +74,9 @@ import Control.Exception
 import qualified Text.PrettyPrint as Disp
 
 
-newtype Username = Username { unUsername :: String }
-newtype Password = Password { unPassword :: String }
+newtype Username       = Username { unUsername :: String }
+newtype Password       = Password { unPassword :: String }
+newtype RemoteRepoName = RemoteRepoName { unRemoteRepoName :: String }
 
 -- | This is the information we get from a @00-index.tar.gz@ hackage index.
 --

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,9 +1,10 @@
 -*-change-log-*-
 
 3.1.0.0 (current development version)
+	* Cabal upload allows specifying which repo to upload to with '--repository-name'
 
 3.0.0.0 TBD
-        * Parses comma-seperated lists for extra-prog-path, extra-lib-dirs, extra-framework-dirs, 
+	* Parses comma-seperated lists for extra-prog-path, extra-lib-dirs, extra-framework-dirs,
 	  and extra-include-dirs as actual lists. (#5420)
 	* `v2-repl` no longer changes directory to a randomized temporary folder
 	  when used outside of a project. (#5544)


### PR DESCRIPTION
Closes https://github.com/haskell/cabal/issues/4402

You can now specify `cabal upload --repository-name [repo name]` to tell cabal to upload to a specific hackage repo.

```
cabal upload dist-newstyle/sdist/dummy-lib-0.2.0.0.tar.gz --repository-name private
Uploading dist-newstyle/sdist/dummy-lib-0.2.0.0.tar.gz...
Package successfully uploaded as candidate. You can now preview the result at
'https://private/package/dummy-lib-0.2.0.0/candidate'. To
publish the candidate, use 'cabal upload --publish'.
```

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.