### PR TITLE
pipe auth into curl

### DIFF
--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -339,8 +339,9 @@ curlTransport prog =
                    [ ["--header", show name ++ ": " ++ value]
                    | Header name value <- reqHeaders ]
 
-          resp <- getProgramInvocationOutput verbosity
+          resp <- getProgramInvocationOutput verbosity $ addAuthConfig Nothing uri
                     (programInvocation prog args)
+
           withFile tmpFile ReadMode $ \hnd -> do
             headers <- hGetContents hnd
             (code, _err, etag') <- parseResponse verbosity uri resp headers
@@ -348,15 +349,25 @@ curlTransport prog =
 
     posthttp = noPostYet
 
-    addAuthConfig auth progInvocation = progInvocation
-      { progInvokeInput = do
-          (uname, passwd) <- auth
-          return $ IODataText $ unlines
-            [ "--digest"
-            , "--user " ++ uname ++ ":" ++ passwd
-            ]
-      , progInvokeArgs = ["--config", "-"] ++ progInvokeArgs progInvocation
-      }
+    addAuthConfig auth uri progInvocation = do
+      case uriAuthority uri of
+        Just (URIAuth u _ _) -> progInvocation
+          -- all `uriUserInfo` values have '@' as a suffix. drop it.
+          { progInvokeInput = Just $ IODataText $ unlines $
+              [ "--digest"
+              , "--user " ++ filter (/= '@') u
+              ]
+          , progInvokeArgs = ["--config", "-"] ++ progInvokeArgs progInvocation
+          }
+        Nothing -> progInvocation
+          { progInvokeInput = do
+              (uname, passwd) <- auth
+              return $ IODataText $ unlines
+                [ "--digest"
+                , "--user " ++ uname ++ ":" ++ passwd
+                ]
+          , progInvokeArgs = ["--config", "-"] ++ progInvokeArgs progInvocation
+          }
 
     posthttpfile verbosity uri path auth = do
         let args = [ show uri
@@ -367,7 +378,7 @@ curlTransport prog =
                    , "--header", "Accept: text/plain"
                    , "--location"
                    ]
-        resp <- getProgramInvocationOutput verbosity $ addAuthConfig auth
+        resp <- getProgramInvocationOutput verbosity $ addAuthConfig auth uri
                   (programInvocation prog args)
         (code, err, _etag) <- parseResponse verbosity uri resp ""
         return (code, err)
@@ -384,7 +395,7 @@ curlTransport prog =
                 ++ concat
                    [ ["--header", show name ++ ": " ++ value]
                    | Header name value <- headers ]
-        resp <- getProgramInvocationOutput verbosity $ addAuthConfig auth
+        resp <- getProgramInvocationOutput verbosity $ addAuthConfig auth uri
                   (programInvocation prog args)
         (code, err, _etag) <- parseResponse verbosity uri resp ""
         return (code, err)


### PR DESCRIPTION
Addresses #4743

Same pattern as in the wget transport: pipe auth config into the curl process if auth info is found in the repo URI.

Added embedded auth in the repo uri, chose the `curl` transport and ran `v2-update`:

```
Downloading the latest package list from private
To revert to previous state run:
    cabal v2-update 'private,2019-08-07T00:56:21Z'
```

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.
