### PR TITLE
Fix v2-install ProgramDb confusion

### DIFF
--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -468,7 +468,8 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
     hcPath   = flagToMaybe projectConfigHcPath
     hcPkg    = flagToMaybe projectConfigHcPkg
 
-    progDb =
+    -- ProgramDb with directly user specified paths
+    preProgDb =
         userSpecifyPaths (Map.toList (getMapLast packageConfigProgramPaths))
       . userSpecifyArgss (Map.toList (getMapMappend packageConfigProgramArgs))
       . modifyProgramSearchPath
@@ -476,9 +477,10 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
               | dir <- fromNubList packageConfigProgramPathExtra ])
       $ defaultProgramDb
 
+  -- progDb is a program database with compiler tools configured properly
   (compiler@Compiler { compilerId =
-    compilerId@(CompilerId compilerFlavor compilerVersion) }, platform, progDb') <-
-      configCompilerEx hcFlavor hcPath hcPkg progDb verbosity
+    compilerId@(CompilerId compilerFlavor compilerVersion) }, platform, progDb) <-
+      configCompilerEx hcFlavor hcPath hcPkg preProgDb verbosity
 
   let
     globalEnv name =
@@ -527,7 +529,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
     cabalLayout = mkCabalDirLayout cabalDir mstoreDir mlogsDir
     packageDbs  = storePackageDBStack (cabalStoreDirLayout cabalLayout) compilerId
 
-  installedIndex <- getInstalledPackages verbosity compiler packageDbs progDb'
+  installedIndex <- getInstalledPackages verbosity compiler packageDbs progDb
 
   let (envSpecs, envEntries') =
         environmentFileToSpecifiers installedIndex envEntries


### PR DESCRIPTION
Commit 273dacf ("Extract installLibraries and InstallExes from
installAction") makes 'getInstalledPackages' get passed the
pre-`configCompilerEx` ProgramDb which will cause pattern match failures when
the code tries to lookup ghc-pkg in the progdb.

As far as I can tell on master currently any `v2-install` invocation would fail with 

```
Distribution/Simple/GHC.hs:1967:5-56: Irrefutable pattern failed for pattern Just ghcPkgProg
```

but I only tested with `cabal v2-install --lib Cabal-3.0.0.0`.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.