### PR TITLE
[RFC] Support for entering/leaving annotations and concurrent log linearization

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -159,6 +159,7 @@ executable cabal
         Distribution.Client.ProjectConfig.Legacy
         Distribution.Client.ProjectConfig.Types
         Distribution.Client.ProjectFlags
+        Distribution.Client.ProjectLogging
         Distribution.Client.ProjectOrchestration
         Distribution.Client.ProjectPlanOutput
         Distribution.Client.ProjectPlanning

--- a/cabal-install/cabal-install.cabal.dev
+++ b/cabal-install/cabal-install.cabal.dev
@@ -151,6 +151,7 @@ library cabal-lib-client
         Distribution.Client.ProjectConfig.Legacy
         Distribution.Client.ProjectConfig.Types
         Distribution.Client.ProjectFlags
+        Distribution.Client.ProjectLogging
         Distribution.Client.ProjectOrchestration
         Distribution.Client.ProjectPlanOutput
         Distribution.Client.ProjectPlanning

--- a/cabal-install/cabal-install.cabal.prod
+++ b/cabal-install/cabal-install.cabal.prod
@@ -159,6 +159,7 @@ executable cabal
         Distribution.Client.ProjectConfig.Legacy
         Distribution.Client.ProjectConfig.Types
         Distribution.Client.ProjectFlags
+        Distribution.Client.ProjectLogging
         Distribution.Client.ProjectOrchestration
         Distribution.Client.ProjectPlanOutput
         Distribution.Client.ProjectPlanning

--- a/cabal-install/cabal-install.cabal.zinza
+++ b/cabal-install/cabal-install.cabal.zinza
@@ -170,6 +170,7 @@ Version:            3.5.0.0
         Distribution.Client.ProjectConfig.Legacy
         Distribution.Client.ProjectConfig.Types
         Distribution.Client.ProjectFlags
+        Distribution.Client.ProjectLogging
         Distribution.Client.ProjectOrchestration
         Distribution.Client.ProjectPlanOutput
         Distribution.Client.ProjectPlanning

--- a/cabal-install/src/Distribution/Client/Configure.hs
+++ b/cabal-install/src/Distribution/Client/Configure.hs
@@ -218,6 +218,8 @@ configureSetupScript packageDBs
     , useDependenciesExclusive = not defaultSetupDeps && isJust explicitSetupDeps
     , useVersionMacros         = not defaultSetupDeps && isJust explicitSetupDeps
     , isInteractive            = False
+    , processCloseHandle       = True
+    , processCloseFds          = False
     }
   where
     -- When we are compiling a legacy setup script without an explicit

--- a/cabal-install/src/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding.hs
@@ -106,7 +106,7 @@ import Control.Exception (Handler (..), SomeAsyncException, assert, catches, han
 -- import Data.Function     (on)
 import System.Directory  (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, removeFile, renameDirectory)
 import System.FilePath   (dropDrive, makeRelative, normalise, takeDirectory, (<.>), (</>))
-import System.IO         (stdout)
+import System.IO         (hPutStrLn, stdout)
 
 import Distribution.Compat.Directory (listDirectory)
 
@@ -944,6 +944,16 @@ buildAndInstallUnpackedPackage verbosity
 
     bracket_ initLogFile closeLogFile $ do
 
+    let
+        entering = withLogging $ \mLogFileHandle -> do
+          let hdl = fromMaybe stdout mLogFileHandle
+          hPutStrLn hdl $ "Entering directory '" ++ srcdir ++ "'"
+        leaving  = withLogging $ \mLogFileHandle -> do
+          let hdl = fromMaybe stdout mLogFileHandle
+          hPutStrLn hdl $ "Leaving directory '" ++ srcdir ++ "'"
+
+    bracket_ entering leaving $ do
+
     --TODO: [code cleanup] deal consistently with talking to older
     --      Setup.hs versions, much like we do for ghc, with a proper
     --      options type and rendering step which will also let us
@@ -1228,6 +1238,16 @@ buildInplaceUnpackedPackage verbosity
           (distPackageCacheDirectory dparams)
 
         bracket_ initLogFile closeLogFile $ do
+
+        let
+            entering = withLogging $ \mLogFileHandle -> do
+              let hdl = fromMaybe stdout mLogFileHandle
+              hPutStrLn hdl $ "Entering directory '" ++ srcdir ++ "'"
+            leaving  = withLogging $ \mLogFileHandle -> do
+              let hdl = fromMaybe stdout mLogFileHandle
+              hPutStrLn hdl $ "Leaving directory '" ++ srcdir ++ "'"
+
+        bracket_ entering leaving $ do
 
         -- Configure phase
         --

--- a/cabal-install/src/Distribution/Client/ProjectLogging.hs
+++ b/cabal-install/src/Distribution/Client/ProjectLogging.hs
@@ -1,0 +1,197 @@
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE NondecreasingIndentation #-}
+
+-- | Support for linearized logging
+--
+module Distribution.Client.ProjectLogging
+    ( LogHandle -- abstract
+    , newLogHandleMap
+    , openLogHandle
+    , withLogHandle
+    , getLogHandle
+    , closeLogHandle
+    ) where
+
+import           Distribution.Client.ProjectPlanning
+import           Distribution.Client.ProjectBuilding.Types
+import qualified Distribution.Client.InstallPlan as InstallPlan
+import           Distribution.Client.Types (GenericReadyPackage(..))
+import           Distribution.Package
+import           Distribution.Utils.Generic (ordNub)
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Control.Monad
+import           Control.Exception (try, throwIO, assert)
+import           Control.Concurrent
+import           Control.Concurrent.Async
+import           System.IO
+import           System.IO.Error
+import           System.Posix.IO hiding (createPipe)
+import           System.Posix.Terminal
+import           GHC.IO.Exception
+
+data LogHandleState
+    = Buffering
+    | Forwarding
+    | Closed
+      deriving (Eq, Ord, Read, Show)
+
+data LogHandleVar = LogHandleVar
+    { lhState  :: LogHandleState
+    , lhTTY    :: Handle
+    , lhFile   :: Handle
+    , lhMaster :: Handle
+    , lhSlave  :: Handle
+    , lhFilePath :: FilePath
+    , lhAsync :: Async ()
+    } deriving (Eq)
+
+data LogHandle = LogHandle
+    { _lhUnitId :: UnitId
+    , lhNext   :: Maybe LogHandle
+    , lhFirst  :: Bool
+    , lhVar    :: MVar LogHandleVar
+    } deriving (Eq)
+
+type LogHandleMap = Map UnitId LogHandle
+newLogHandleMap :: BuildStatusMap -> ElaboratedInstallPlan -> IO LogHandleMap
+newLogHandleMap pkgsBuildStatus installPlan = fmap Map.fromList $ do
+    foldM newLogHandle [] (reverse (uids `zip` (True : repeat False)))
+  where
+    newLogHandle lhds (uid, first) = do
+      mv <- newEmptyMVar
+      return $ (uid, LogHandle uid (snd <$> headMay lhds) first mv) : lhds
+
+    headMay [] = Nothing
+    headMay (x:_) = Just x
+
+    -- All the units that need building. If we get this wrong we'll hang
+    -- forever in passForwarding as the next LogHandle will never be opened
+    -- so watch out.
+    uids = assert (ordNub uids' == uids') uids'
+    uids' =
+      [ uid
+      | ReadyPackage elab
+         <- InstallPlan.executionOrder installPlan
+      , let uid = installedUnitId elab
+            pkgBuildStatus = Map.findWithDefault (error "newLogHandleMap uid not found") uid pkgsBuildStatus
+      , buildStatusRequiresBuild pkgBuildStatus
+      ]
+
+openLogHandle :: LogHandle -> FilePath -> Handle -> IO ()
+openLogHandle lh@LogHandle{lhVar=mv, lhFirst} logFile ttyhdl = do
+    mlhv <- tryTakeMVar mv
+    putMVar mv =<< case fmap lhState mlhv of
+      Nothing -> do
+        filehdl <- openFile logFile ReadWriteMode
+        (amux, master, slave) <- newLogMuxThread lh
+        return $ LogHandleVar
+          { lhState = if lhFirst then Forwarding else Buffering
+          , lhTTY  = ttyhdl
+          , lhFile = filehdl
+          , lhMaster = master
+          , lhSlave = slave
+          , lhFilePath = logFile
+          , lhAsync = amux
+          }
+      Just Buffering -> do
+        error "openLogFile: already buffering!"
+      Just Forwarding ->
+        error "openLogFile: already forwarding!"
+      Just Closed ->
+        error "openLogFile: already closed!"
+
+withLogHandle :: LogHandle -> (Handle -> IO a) -> IO a
+withLogHandle lh action = action =<< getLogHandle lh
+
+getLogHandle :: LogHandle -> IO Handle
+getLogHandle LogHandle{lhVar=mv} = do
+    lhv <- readMVar mv
+    when (lhState lhv == Closed) $
+      error "withLogHandle: already closed!"
+    return (lhSlave lhv)
+
+closeLogHandle :: LogHandle -> IO ()
+closeLogHandle lh@LogHandle{lhVar=mv} = do
+    amux <- withMVar mv $ \lhv -> do
+       when (lhState lhv == Closed) $
+         error "closeLogHandle: already closed!"
+       hClose $ lhSlave lhv -- signal mux thread to exit
+       return $ lhAsync lhv
+    wait amux
+
+    -- now we can close the rest without breaking the mux thread
+    modifyMVar_ mv $ \lhv -> do
+      hClose $ lhFile lhv
+      when (lhState lhv == Forwarding) $
+        void $ forkIO $ passForwarding lh
+      return lhv { lhState = Closed }
+
+  where
+    drain whdl rhdl = do
+      ebuf <- BS.hGetSome rhdl 4096
+      case ebuf of
+        buf | BS.null buf -> return ()
+        buf -> do
+          BS.hPut whdl buf
+          drain whdl rhdl
+
+    passForwarding LogHandle{lhNext=Nothing} =
+      return ()
+    passForwarding LogHandle{lhNext=Just nlh} = do
+      let nmv = lhVar nlh
+      modifyMVar_ nmv $ \nlhv -> do -- waits until openend
+        case lhState nlhv of
+          Forwarding ->
+            error $ "passForwarding: next handle already forwarding!?"
+          Closed -> do
+            LBS.hPut (lhTTY nlhv) =<< LBS.readFile (lhFilePath nlhv)
+            passForwarding nlh
+            return nlhv
+          Buffering -> do
+            hSeek (lhFile nlhv) AbsoluteSeek 0
+            drain (lhTTY nlhv) (lhFile nlhv)
+            hSeek (lhFile nlhv) SeekFromEnd 0
+            return $ nlhv { lhState = Forwarding }
+
+newLogMuxThread :: LogHandle -> IO (Async (), Handle, Handle)
+newLogMuxThread LogHandle{lhVar=mv} = do
+--    (rhdl, whdl) <- createPipe -- pipes are nice and portable but buffer
+--    the output like crazy. There really is no way around ptys for smooth
+--    output -- at least that I can find.
+    (master, slave) <- openPseudoTerminal
+    rhdl <- fdToHandle master
+    whdl <- fdToHandle slave
+    amux <- async $ loop rhdl
+    return (amux, rhdl, whdl)
+  where
+    loop rhdl = do
+      ebuf <- try $ BS.hGetSome rhdl 512
+      case ebuf of
+        -- pty master will throw EIO on slave close (at least on linux)
+        Left err | ioeGetErrorType err == HardwareFault -> do
+          hClose rhdl
+
+        -- BS.hGetSome will usually signal EOF of a pipe via zero buffer
+        -- size. For pty masters this doesn't happen, see below. "Some
+        -- platforms" might still do it this way (ugh).
+        Right buf | BS.null buf -> do
+          hClose rhdl
+
+        Left err -> throwIO err
+        Right buf -> do
+          LogHandleVar{lhState, lhTTY, lhFile} <- readMVar mv
+          case lhState of
+            Forwarding -> do
+              BS.hPut lhTTY buf
+              BS.hPut lhFile buf
+            Buffering  ->
+              BS.hPut lhFile buf
+            Closed ->
+              error "newLogMuxThread.loop: handle closed prematurely"
+          loop rhdl

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -3209,7 +3209,9 @@ setupHsScriptOptions (ReadyPackage elab@ElaboratedConfiguredPackage{..})
       useWin32CleanHack        = False,   --TODO: [required eventually]
       forceExternalSetupMethod = isParallelBuild,
       setupCacheLock           = Just cacheLock,
-      isInteractive            = False
+      isInteractive            = False,
+      processCloseHandle       = True,
+      processCloseFds          = False
     }
 
 


### PR DESCRIPTION
Commit messages:

```
Add entering/leaving directory messages to build output

Ok, so here's the deal: with v2-build we can have multiple different
package directories in one build. At the moment we always start GHC in the
package directory with the paths to the sources being relative to
that. GHC's error messages are going to copy those paths verbatim.

Now when we have multiple packages in seperate directories, say:

    proj/
      pkg-a/A.hs
      pkg-b/B.hs

then error messages are juts going to mention "A.hs" or "B.hs" without the
pkg-* prefix.

So while this is kinda confusing for users that's not really the main
problem. Editors (Emacs in my case) usually have a mode that parses
compiler output to provide jump-to-error functionality. This usually relies
on the paths in error messages being relative to the current directory of
the editor or some such but we break this assumption with v2-build.

It turns out we're not the first build-tool to have this problem, recursive
make pretty much has the same problem and the "solution" there is to just
print messages before and after starting a recursive instance of the build
system in another directory. Editors already have support to parse these
annotations so I'm just adding support to do that to cabal.

Cabal's equivalent of the recursive make instance is Setup.hs/SetupWrapper
which for v2 is always invoked through either 'buildInplaceUnpackedPackage'
or 'buildAndInstallUnpackedPackage' so we add code there to print these
messages.

Together with the preceeding commit adding log linearizaton we can actually
guarantee that the output will make sense to editors trying to parse it
since it's as if we'd run with -j1, unlike the mess 'make' makes of things
when concurrent builds are active!
```

```
cabal-install: Add log linearization support

This adds support for simultaniously buffering log output in log files and
"tail -f"ing the the first package in build order which is still in the
process of being built.

This results in build output wich is strictly ordered and exactly the same
as what -j1 would produce but the actual build is run concurrently and
build output shows up on the user's console live, but with only one unit's
output being live at any time. That's the tradeoff. You get live output
with reproducible order but it doesn't feel qute as "fast" because we're
not inteleaving the build output.

Initial idea from https://apenwarr.ca/log/20181106.
```

```
SetupWrapper: Allow controlling FDs leaks in child procsesses

The way we currently call createProcess makes all open file descriptors
leak into child processes. This is not only a cosmetic problem but also
lead to really nasty concurrency bugs.

This doesn't seem to really be a problem currently but I'm about to commit
some code that breaks with leaking handles.

Unfortunately we cannot simply use 'close_fds' always as, according to the
docs, it doesn't work on windows when the std streams are not inherited
from the parent process.

I also introduce a separate field which allows making the handles we pass
to the child process "leak" in the parent. By default 'createProcess'
closes handles passed to the child process but in my case the handles are a
pipe/pty-slave that I cannot easily re-open.
```

---
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.

TODO:
* [ ] Add runtime flags controlling log-lineraization and entering-leaving messages
* [ ] Either find a way to make it work on windows (help needed) or ifdef it away there. 
* [ ] Figure out how linearization should interact with `--build-log`

---

I've been using this patch set for the past couple of weeks, hence all the bug reports against 3.0/master recently and it's working really well, just the interaction with build logging on the cabal-install side needs to be figured out. I've just ignored it for now since I don't use it. Also please ignore the leading fix commits I'll submit thse for master seperately. They're just there for testing convinience of this branch. 

So what do you guys think of these features?