### PR TITLE
Improve docs for html-location

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -1829,6 +1829,7 @@ running ``setup haddock``. (TODO: Where does the documentation get put.)
     ``haddock`` command).
 
 .. cfg-field:: haddock-html-location: templated path
+               --html-location=TEMPLATE
     :synopsis: Haddock HTML templates location.
 
     Specify a template for the location of HTML documentation for
@@ -1839,14 +1840,18 @@ running ``setup haddock``. (TODO: Where does the documentation get put.)
 
     ::
 
-        html-location: 'http://hackage.haskell.org/packages/archive/$pkg/latest/doc/html'
+        html-location: http://hackage.haskell.org/packages/archive/$pkg/latest/doc/html
+
+    The command line variant of this flag is ``--html-location`` (for
+    the ``haddock`` subcommand).
+
+    ::
+
+        --html-location='http://hackage.haskell.org/packages/archive/$pkg/latest/doc/html'
 
     Here the argument is quoted to prevent substitution by the shell. If
     this option is omitted, the location for each package is obtained
     using the package tool (e.g. ``ghc-pkg``).
-
-    The command line variant of this flag is ``--html-location`` (for
-    the ``haddock`` subcommand).
 
 .. cfg-field:: haddock-executables: boolean
     :synopsis: Generate documentation for executables.


### PR DESCRIPTION
Someone mentioned this section was confusing in #haskell. I added an
example of command line usage so there is no confusion.

[ci skip]

P.s.: I expected `templated path` to be a link to a section explaining how these templates work and what templating variables are available. Should I open up an issue on this?
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
