### PR TITLE
Provide explanation for invalid license identifier

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -328,7 +328,11 @@ licensePrompt flags = getLicense flags $ do
 
     case simpleParsec l of
       Nothing -> do
-        putStrLn "The license must be a valid SPDX expression."
+        putStrLn ( "The license must be a valid SPDX expression:"
+                ++ "\n - On the SPDX License List: https://spdx.org/licenses/"
+                ++ "\n - NONE, if you do not want to grant any license"
+                ++ "\n - LicenseRef-( alphanumeric | - | . )+"
+                 )
         licensePrompt flags
       Just l' -> return l'
   where


### PR DESCRIPTION
After discussion in #hackage it seemed prudent to me to add some minimal
explanation of what a valid SPDX identifier might look like to the error
message.

I haven't tested the code and added `[ci skip]` because I'd like to invite comments about wording first.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
