### PR TITLE
Recognise flags that change error message format as simple

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,5 +1,6 @@
 # 3.1.0.0 (current development version)
-  * TODO
+  * Don’t rebuild world when new ghc flags that affect how error
+    messages are presented is specified.
 
  ----
 

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -211,7 +211,7 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
 
     simpleFlags :: Set String
     simpleFlags = Set.fromList . mconcat $
-      [ [ "-n", "-#include", "-Rghc-timing", "-dsuppress-all", "-dstg-stats"
+      [ [ "-n", "-#include", "-Rghc-timing", "-dstg-stats"
         , "-dth-dec-file", "-dsource-stats", "-dverbose-core2core"
         , "-dverbose-stg2stg", "-dcore-lint", "-dstg-lint", "-dcmm-lint"
         , "-dasm-lint", "-dannot-lint", "-dshow-passes", "-dfaststring-stats"

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -172,6 +172,15 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
               , "break-on-exception", "print-bind-result"
               , "print-bind-contents", "print-evld-with-show"
               , "implicit-import-qualified", "error-spans"
+              , "print-explicit-foralls"
+              , "print-explicit-kinds"
+              , "print-explicit-coercions"
+              , "print-explicit-runtime-reps"
+              , "print-equality-relations"
+              , "print-unicode-syntax"
+              , "print-expanded-synonyms"
+              , "print-potential-instances"
+              , "print-typechecker-elaboration"
               ]
             , from [8,2]
                 [ "diagnostics-show-caret", "local-ghci-history"


### PR DESCRIPTION
I.e. don’t rebuild everything when a ghc flag that affects how error messages are presented is added.

Tested with `cabal test` and by hand on a project where adding `-fprint-potential-instances` to `cabal.project` caused all dependencies to be rebuilt.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
