### PR TITLE
Implement --benchmark-options for v2-bench

### DIFF
--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -57,7 +57,8 @@ module Distribution.Simple.Setup (
   defaultBenchmarkFlags, benchmarkCommand,
   CopyDest(..),
   configureArgs, configureOptions, configureCCompiler, configureLinker,
-  buildOptions, haddockOptions, installDirsOptions, testOptions',
+  buildOptions, haddockOptions, installDirsOptions,
+  testOptions', benchmarkOptions',
   programDbOptions, programDbPaths',
   programFlagsDescription,
   replOptions,
@@ -2026,29 +2027,32 @@ benchmarkCommand = CommandUI
       , "BENCHCOMPONENTS [FLAGS]"
       ]
   , commandDefaultFlags = defaultBenchmarkFlags
-  , commandOptions = \showOrParseArgs ->
-      [ optionVerbosity benchmarkVerbosity
-        (\v flags -> flags { benchmarkVerbosity = v })
-      , optionDistPref
-            benchmarkDistPref (\d flags -> flags { benchmarkDistPref = d })
-            showOrParseArgs
-      , option [] ["benchmark-options"]
-            ("give extra options to benchmark executables "
-             ++ "(name templates can use $pkgid, $compiler, "
-             ++ "$os, $arch, $benchmark)")
-            benchmarkOptions (\v flags -> flags { benchmarkOptions = v })
-            (reqArg' "TEMPLATES" (map toPathTemplate . splitArgs)
-                (const []))
-      , option [] ["benchmark-option"]
-            ("give extra option to benchmark executables "
-             ++ "(no need to quote options containing spaces, "
-             ++ "name template can use $pkgid, $compiler, "
-             ++ "$os, $arch, $benchmark)")
-            benchmarkOptions (\v flags -> flags { benchmarkOptions = v })
-            (reqArg' "TEMPLATE" (\x -> [toPathTemplate x])
-                (map fromPathTemplate))
-      ]
+  , commandOptions = benchmarkOptions'
   }
+
+benchmarkOptions' :: ShowOrParseArgs -> [OptionField BenchmarkFlags]
+benchmarkOptions' showOrParseArgs =
+  [ optionVerbosity benchmarkVerbosity
+    (\v flags -> flags { benchmarkVerbosity = v })
+  , optionDistPref
+        benchmarkDistPref (\d flags -> flags { benchmarkDistPref = d })
+        showOrParseArgs
+  , option [] ["benchmark-options"]
+        ("give extra options to benchmark executables "
+         ++ "(name templates can use $pkgid, $compiler, "
+         ++ "$os, $arch, $benchmark)")
+        benchmarkOptions (\v flags -> flags { benchmarkOptions = v })
+        (reqArg' "TEMPLATES" (map toPathTemplate . splitArgs)
+            (const []))
+  , option [] ["benchmark-option"]
+        ("give extra option to benchmark executables "
+         ++ "(no need to quote options containing spaces, "
+         ++ "name template can use $pkgid, $compiler, "
+         ++ "$os, $arch, $benchmark)")
+        benchmarkOptions (\v flags -> flags { benchmarkOptions = v })
+        (reqArg' "TEMPLATE" (\x -> [toPathTemplate x])
+            (map fromPathTemplate))
+  ]
 
 emptyBenchmarkFlags :: BenchmarkFlags
 emptyBenchmarkFlags = mempty

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -1672,6 +1672,8 @@ This command takes the following options:
     Keeps the configuration information so it is not necessary to run
     the configure step again before building.
 
+.. _setup-test:
+
 setup test
 ----------
 
@@ -1716,7 +1718,7 @@ the package.
 
 .. option:: --test-option=option
 
-    give an extra option to the test executables. There is no need to
+    Give an extra option to the test executables. There is no need to
     quote options containing spaces because a single option is assumed,
     so options will not be split on spaces.
 
@@ -1726,6 +1728,26 @@ the package.
    execution context. The text executable path and test arguments are
    passed as arguments to the wrapper and it is expected that the wrapper
    will return the test's return code, as well as a copy of stdout/stderr.
+
+.. _setup-bench:
+
+setup bench
+-----------
+
+Run the benchmarks specified in the package description file. Aside
+from the following flags, Cabal accepts the name of one or more benchmarks
+on the command line after ``bench``. When supplied, Cabal will run
+only the named benchmarks, otherwise, Cabal will run all benchmarks in
+the package.
+
+.. option:: --benchmark-options=options
+    Give extra options to the benchmark executables.
+
+.. option:: --benchmark-option=option
+
+    Give an extra option to the benchmark executables. There is no need to
+    quote options containing spaces because a single option is assumed,
+    so options will not be split on spaces.
 
 .. _setup-sdist:
 

--- a/cabal-install/Distribution/Client/CmdBench.hs
+++ b/cabal-install/Distribution/Client/CmdBench.hs
@@ -20,7 +20,7 @@ import Distribution.Client.Setup
          ( GlobalFlags, ConfigFlags(..), ConfigExFlags, InstallFlags )
 import qualified Distribution.Client.Setup as Client
 import Distribution.Simple.Setup
-         ( HaddockFlags, TestFlags, fromFlagOrDefault )
+         ( HaddockFlags, TestFlags, BenchmarkFlags, fromFlagOrDefault )
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
 import Distribution.Deprecated.Text
@@ -33,7 +33,9 @@ import Distribution.Simple.Utils
 import Control.Monad (when)
 
 
-benchCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+benchCommand :: CommandUI ( ConfigFlags, ConfigExFlags, InstallFlags
+                          , HaddockFlags, TestFlags, BenchmarkFlags
+                          )
 benchCommand = Client.installCommand {
   commandName         = "v2-bench",
   commandSynopsis     = "Run benchmarks",
@@ -73,9 +75,11 @@ benchCommand = Client.installCommand {
 -- For more details on how this works, see the module
 -- "Distribution.Client.ProjectOrchestration"
 --
-benchAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+benchAction :: ( ConfigFlags, ConfigExFlags, InstallFlags
+               , HaddockFlags, TestFlags, BenchmarkFlags )
             -> [String] -> GlobalFlags -> IO ()
-benchAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
+benchAction ( configFlags, configExFlags, installFlags
+            , haddockFlags, testFlags, benchmarkFlags )
             targetStrings globalFlags = do
 
     baseCtx <- establishProjectBaseContext verbosity cliConfig OtherCommand
@@ -119,7 +123,7 @@ benchAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
                   globalFlags configFlags configExFlags
                   installFlags
                   mempty -- ClientInstallFlags, not needed here
-                  haddockFlags testFlags
+                  haddockFlags testFlags benchmarkFlags
 
 -- | This defines what a 'TargetSelector' means for the @bench@ command.
 -- It selects the 'AvailableTarget's that the 'TargetSelector' refers to,

--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -20,7 +20,7 @@ import Distribution.Client.Setup
          , liftOptions, yesNoOpt )
 import qualified Distribution.Client.Setup as Client
 import Distribution.Simple.Setup
-         ( HaddockFlags, TestFlags
+         ( HaddockFlags, TestFlags, BenchmarkFlags
          , Flag(..), toFlag, fromFlag, fromFlagOrDefault )
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives, option )
@@ -35,7 +35,8 @@ import qualified Data.Map as Map
 buildCommand ::
   CommandUI
   (BuildFlags, ( ConfigFlags, ConfigExFlags
-               , InstallFlags, HaddockFlags, TestFlags))
+               , InstallFlags, HaddockFlags
+               , TestFlags, BenchmarkFlags ))
 buildCommand = CommandUI {
   commandName         = "v2-build",
   commandSynopsis     = "Compile targets within the project.",
@@ -103,11 +104,13 @@ defaultBuildFlags = BuildFlags
 --
 buildAction ::
   ( BuildFlags
-  , (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags))
+  , ( ConfigFlags, ConfigExFlags, InstallFlags
+    , HaddockFlags, TestFlags, BenchmarkFlags ))
   -> [String] -> GlobalFlags -> IO ()
 buildAction
   ( buildFlags
-  , (configFlags, configExFlags, installFlags, haddockFlags, testFlags))
+  , ( configFlags, configExFlags, installFlags
+    , haddockFlags, testFlags, benchmarkFlags ))
             targetStrings globalFlags = do
     -- TODO: This flags defaults business is ugly
     let onlyConfigure = fromFlag (buildOnlyConfigure defaultBuildFlags
@@ -159,7 +162,7 @@ buildAction
                   globalFlags configFlags configExFlags
                   installFlags
                   mempty -- ClientInstallFlags, not needed here
-                  haddockFlags testFlags
+                  haddockFlags testFlags benchmarkFlags
 
 -- | This defines what a 'TargetSelector' means for the @bench@ command.
 -- It selects the 'AvailableTarget's that the 'TargetSelector' refers to,

--- a/cabal-install/Distribution/Client/CmdConfigure.hs
+++ b/cabal-install/Distribution/Client/CmdConfigure.hs
@@ -16,7 +16,7 @@ import Distribution.Client.ProjectConfig
 import Distribution.Client.Setup
          ( GlobalFlags, ConfigFlags(..), ConfigExFlags, InstallFlags )
 import Distribution.Simple.Setup
-         ( HaddockFlags, TestFlags, fromFlagOrDefault )
+         ( HaddockFlags, TestFlags, BenchmarkFlags, fromFlagOrDefault )
 import Distribution.Verbosity
          ( normal )
 
@@ -26,8 +26,9 @@ import Distribution.Simple.Utils
          ( wrapText, notice )
 import qualified Distribution.Client.Setup as Client
 
-configureCommand :: CommandUI (ConfigFlags, ConfigExFlags
-                              ,InstallFlags, HaddockFlags, TestFlags)
+configureCommand :: CommandUI ( ConfigFlags, ConfigExFlags, InstallFlags
+                              , HaddockFlags, TestFlags, BenchmarkFlags
+                              )
 configureCommand = Client.installCommand {
   commandName         = "v2-configure",
   commandSynopsis     = "Add extra project configuration",
@@ -78,9 +79,11 @@ configureCommand = Client.installCommand {
 -- For more details on how this works, see the module
 -- "Distribution.Client.ProjectOrchestration"
 --
-configureAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+configureAction :: ( ConfigFlags, ConfigExFlags, InstallFlags
+                   , HaddockFlags, TestFlags, BenchmarkFlags )
                 -> [String] -> GlobalFlags -> IO ()
-configureAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
+configureAction ( configFlags, configExFlags, installFlags
+                , haddockFlags, testFlags, benchmarkFlags )
                 _extraArgs globalFlags = do
     --TODO: deal with _extraArgs, since flags with wrong syntax end up there
 
@@ -123,5 +126,5 @@ configureAction (configFlags, configExFlags, installFlags, haddockFlags, testFla
                   globalFlags configFlags configExFlags
                   installFlags
                   mempty -- ClientInstallFlags, not needed here
-                  haddockFlags testFlags
+                  haddockFlags testFlags benchmarkFlags
 

--- a/cabal-install/Distribution/Client/CmdExec.hs
+++ b/cabal-install/Distribution/Client/CmdExec.hs
@@ -76,6 +76,7 @@ import Distribution.Simple.GHC
 import Distribution.Simple.Setup
   ( HaddockFlags
   , TestFlags
+  , BenchmarkFlags
   , fromFlagOrDefault
   )
 import Distribution.Simple.Utils
@@ -95,7 +96,9 @@ import Distribution.Client.Compat.Prelude
 import qualified Data.Set as S
 import qualified Data.Map as M
 
-execCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+execCommand :: CommandUI ( ConfigFlags, ConfigExFlags, InstallFlags
+                         , HaddockFlags, TestFlags, BenchmarkFlags
+                         )
 execCommand = CommandUI
   { commandName = "v2-exec"
   , commandSynopsis = "Give a command access to the store."
@@ -120,9 +123,11 @@ execCommand = CommandUI
   , commandDefaultFlags = commandDefaultFlags Client.installCommand
   }
 
-execAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+execAction :: ( ConfigFlags, ConfigExFlags, InstallFlags
+              , HaddockFlags, TestFlags, BenchmarkFlags )
            -> [String] -> GlobalFlags -> IO ()
-execAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
+execAction ( configFlags, configExFlags, installFlags
+           , haddockFlags, testFlags, benchmarkFlags )
            extraArgs globalFlags = do
 
   baseCtx <- establishProjectBaseContext verbosity cliConfig OtherCommand
@@ -196,7 +201,7 @@ execAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
                   globalFlags configFlags configExFlags
                   installFlags
                   mempty -- ClientInstallFlags, not needed here
-                  haddockFlags testFlags
+                  haddockFlags testFlags benchmarkFlags
     withOverrides env args program = program
       { programOverrideEnv = programOverrideEnv program ++ env
       , programDefaultArgs = programDefaultArgs program ++ args}

--- a/cabal-install/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/Distribution/Client/CmdFreeze.hs
@@ -33,7 +33,7 @@ import Distribution.PackageDescription
 import Distribution.Client.Setup
          ( GlobalFlags, ConfigFlags(..), ConfigExFlags, InstallFlags )
 import Distribution.Simple.Setup
-         ( HaddockFlags, TestFlags, fromFlagOrDefault )
+         ( HaddockFlags, TestFlags, BenchmarkFlags, fromFlagOrDefault )
 import Distribution.Simple.Utils
          ( die', notice, wrapText )
 import Distribution.Verbosity
@@ -49,7 +49,9 @@ import Distribution.Simple.Command
 import qualified Distribution.Client.Setup as Client
 
 
-freezeCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+freezeCommand :: CommandUI ( ConfigFlags, ConfigExFlags, InstallFlags
+                           , HaddockFlags, TestFlags, BenchmarkFlags
+                           )
 freezeCommand = Client.installCommand {
   commandName         = "v2-freeze",
   commandSynopsis     = "Freeze dependencies.",
@@ -99,9 +101,11 @@ freezeCommand = Client.installCommand {
 -- For more details on how this works, see the module
 -- "Distribution.Client.ProjectOrchestration"
 --
-freezeAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+freezeAction :: ( ConfigFlags, ConfigExFlags, InstallFlags
+                , HaddockFlags, TestFlags, BenchmarkFlags )
              -> [String] -> GlobalFlags -> IO ()
-freezeAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
+freezeAction ( configFlags, configExFlags, installFlags
+             , haddockFlags, testFlags, benchmarkFlags )
              extraArgs globalFlags = do
 
     unless (null extraArgs) $
@@ -132,7 +136,7 @@ freezeAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
                   globalFlags configFlags configExFlags
                   installFlags
                   mempty -- ClientInstallFlags, not needed here
-                  haddockFlags testFlags
+                  haddockFlags testFlags benchmarkFlags
 
 
 

--- a/cabal-install/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/Distribution/Client/CmdHaddock.hs
@@ -20,7 +20,7 @@ import Distribution.Client.Setup
          ( GlobalFlags, ConfigFlags(..), ConfigExFlags, InstallFlags )
 import qualified Distribution.Client.Setup as Client
 import Distribution.Simple.Setup
-         ( HaddockFlags(..), TestFlags, fromFlagOrDefault )
+         ( HaddockFlags(..), TestFlags, BenchmarkFlags(..), fromFlagOrDefault )
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
 import Distribution.Verbosity
@@ -31,8 +31,9 @@ import Distribution.Simple.Utils
 import Control.Monad (when)
 
 
-haddockCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags
-                            ,HaddockFlags, TestFlags)
+haddockCommand :: CommandUI ( ConfigFlags, ConfigExFlags, InstallFlags
+                            , HaddockFlags, TestFlags, BenchmarkFlags
+                            )
 haddockCommand = Client.installCommand {
   commandName         = "v2-haddock",
   commandSynopsis     = "Build Haddock documentation",
@@ -69,9 +70,11 @@ haddockCommand = Client.installCommand {
 -- For more details on how this works, see the module
 -- "Distribution.Client.ProjectOrchestration"
 --
-haddockAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+haddockAction :: ( ConfigFlags, ConfigExFlags, InstallFlags
+                 , HaddockFlags, TestFlags, BenchmarkFlags )
                  -> [String] -> GlobalFlags -> IO ()
-haddockAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
+haddockAction ( configFlags, configExFlags, installFlags
+              , haddockFlags, testFlags, benchmarkFlags )
                 targetStrings globalFlags = do
 
     baseCtx <- establishProjectBaseContext verbosity cliConfig HaddockCommand
@@ -113,7 +116,7 @@ haddockAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
                   globalFlags configFlags configExFlags
                   installFlags
                   mempty -- ClientInstallFlags, not needed here
-                  haddockFlags testFlags
+                  haddockFlags testFlags benchmarkFlags
 
 -- | This defines what a 'TargetSelector' means for the @haddock@ command.
 -- It selects the 'AvailableTarget's that the 'TargetSelector' refers to,

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -32,7 +32,7 @@ import Distribution.Client.CmdInstall.ClientInstallFlags
 import Distribution.Client.Setup
          ( GlobalFlags(..), ConfigFlags(..), ConfigExFlags, InstallFlags(..)
          , configureExOptions, haddockOptions, installOptions, testOptions
-         , configureOptions, liftOptions )
+         , benchmarkOptions, configureOptions, liftOptions )
 import Distribution.Solver.Types.ConstraintSource
          ( ConstraintSource(..) )
 import Distribution.Client.Types
@@ -87,7 +87,8 @@ import Distribution.Client.RebuildMonad
 import Distribution.Client.InstallSymlink
          ( OverwritePolicy(..), symlinkBinary )
 import Distribution.Simple.Setup
-         ( Flag(..), HaddockFlags, TestFlags, fromFlagOrDefault, flagToMaybe )
+         ( Flag(..), HaddockFlags, TestFlags, BenchmarkFlags
+         , fromFlagOrDefault, flagToMaybe )
 import Distribution.Solver.Types.SourcePackage
          ( SourcePackage(..) )
 import Distribution.Simple.Command
@@ -142,7 +143,8 @@ import System.FilePath
 
 
 installCommand :: CommandUI ( ConfigFlags, ConfigExFlags, InstallFlags
-                            , HaddockFlags, TestFlags, ClientInstallFlags
+                            , HaddockFlags, TestFlags, BenchmarkFlags
+                            , ClientInstallFlags
                             )
 installCommand = CommandUI
   { commandName         = "v2-install"
@@ -194,17 +196,19 @@ installCommand = CommandUI
                   . optionName) $
                                 haddockOptions showOrParseArgs)
      ++ liftOptions get5 set5 (testOptions showOrParseArgs)
-     ++ liftOptions get6 set6 (clientInstallOptions showOrParseArgs)
-  , commandDefaultFlags = ( mempty, mempty, mempty, mempty, mempty
+     ++ liftOptions get6 set6 (benchmarkOptions showOrParseArgs)
+     ++ liftOptions get7 set7 (clientInstallOptions showOrParseArgs)
+  , commandDefaultFlags = ( mempty, mempty, mempty, mempty, mempty, mempty
                           , defaultClientInstallFlags )
   }
   where
-    get1 (a,_,_,_,_,_) = a; set1 a (_,b,c,d,e,f) = (a,b,c,d,e,f)
-    get2 (_,b,_,_,_,_) = b; set2 b (a,_,c,d,e,f) = (a,b,c,d,e,f)
-    get3 (_,_,c,_,_,_) = c; set3 c (a,b,_,d,e,f) = (a,b,c,d,e,f)
-    get4 (_,_,_,d,_,_) = d; set4 d (a,b,c,_,e,f) = (a,b,c,d,e,f)
-    get5 (_,_,_,_,e,_) = e; set5 e (a,b,c,d,_,f) = (a,b,c,d,e,f)
-    get6 (_,_,_,_,_,f) = f; set6 f (a,b,c,d,e,_) = (a,b,c,d,e,f)
+    get1 (a,_,_,_,_,_,_) = a; set1 a (_,b,c,d,e,f,g) = (a,b,c,d,e,f,g)
+    get2 (_,b,_,_,_,_,_) = b; set2 b (a,_,c,d,e,f,g) = (a,b,c,d,e,f,g)
+    get3 (_,_,c,_,_,_,_) = c; set3 c (a,b,_,d,e,f,g) = (a,b,c,d,e,f,g)
+    get4 (_,_,_,d,_,_,_) = d; set4 d (a,b,c,_,e,f,g) = (a,b,c,d,e,f,g)
+    get5 (_,_,_,_,e,_,_) = e; set5 e (a,b,c,d,_,f,g) = (a,b,c,d,e,f,g)
+    get6 (_,_,_,_,_,f,_) = f; set6 f (a,b,c,d,e,_,g) = (a,b,c,d,e,f,g)
+    get7 (_,_,_,_,_,_,g) = g; set7 g (a,b,c,d,e,f,_) = (a,b,c,d,e,f,g)
 
 
 -- | The @install@ command actually serves four different needs. It installs:
@@ -225,11 +229,13 @@ installCommand = CommandUI
 -- "Distribution.Client.ProjectOrchestration"
 --
 installAction
-  :: ( ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags
+  :: ( ConfigFlags, ConfigExFlags, InstallFlags
+     , HaddockFlags, TestFlags, BenchmarkFlags
      , ClientInstallFlags)
   -> [String] -> GlobalFlags
   -> IO ()
-installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
+installAction ( configFlags, configExFlags, installFlags
+              , haddockFlags, testFlags, benchmarkFlags
               , clientInstallFlags' )
               targetStrings globalFlags = do
   -- We never try to build tests/benchmarks for remote packages.
@@ -599,7 +605,7 @@ installAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags
     cliConfig = commandLineFlagsToProjectConfig
                   globalFlags configFlags' configExFlags
                   installFlags clientInstallFlags'
-                  haddockFlags testFlags
+                  haddockFlags testFlags benchmarkFlags
     globalConfigFlag = projectConfigConfigFile (projectConfigShared cliConfig)
 
 -- | Install any built exe by symlinking/copying it

--- a/cabal-install/Distribution/Client/CmdLegacy.hs
+++ b/cabal-install/Distribution/Client/CmdLegacy.hs
@@ -68,6 +68,9 @@ instance (HasVerbosity a) => HasVerbosity (a, b, c, d) where
 instance (HasVerbosity a) => HasVerbosity (a, b, c, d, e) where
     verbosity (a, _, _, _, _) = verbosity a
 
+instance (HasVerbosity a) => HasVerbosity (a, b, c, d, e, f) where
+    verbosity (a, _, _, _, _, _) = verbosity a
+
 instance HasVerbosity Setup.BuildFlags where
     verbosity = verbosity . Setup.buildVerbosity
 

--- a/cabal-install/Distribution/Client/CmdRun.hs
+++ b/cabal-install/Distribution/Client/CmdRun.hs
@@ -29,7 +29,7 @@ import Distribution.Client.GlobalFlags
          ( defaultGlobalFlags )
 import qualified Distribution.Client.Setup as Client
 import Distribution.Simple.Setup
-         ( HaddockFlags, TestFlags, fromFlagOrDefault )
+         ( HaddockFlags, TestFlags, BenchmarkFlags, fromFlagOrDefault )
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
 import Distribution.Types.ComponentName
@@ -107,7 +107,9 @@ import System.FilePath
          ( (</>), isValid, isPathSeparator, takeExtension )
 
 
-runCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+runCommand :: CommandUI ( ConfigFlags, ConfigExFlags, InstallFlags
+                        , HaddockFlags, TestFlags, BenchmarkFlags
+                        )
 runCommand = Client.installCommand {
   commandName         = "v2-run",
   commandSynopsis     = "Run an executable.",
@@ -153,9 +155,11 @@ runCommand = Client.installCommand {
 -- For more details on how this works, see the module
 -- "Distribution.Client.ProjectOrchestration"
 --
-runAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+runAction :: ( ConfigFlags, ConfigExFlags, InstallFlags
+             , HaddockFlags, TestFlags, BenchmarkFlags )
           -> [String] -> GlobalFlags -> IO ()
-runAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
+runAction ( configFlags, configExFlags, installFlags
+          , haddockFlags, testFlags, benchmarkFlags )
             targetStrings globalFlags = do
     globalTmp <- getTemporaryDirectory
     tempDir <- createTempDirectory globalTmp "cabal-repl."
@@ -299,7 +303,7 @@ runAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
                   globalFlags configFlags configExFlags
                   installFlags
                   mempty -- ClientInstallFlags, not needed here
-                  haddockFlags testFlags
+                  haddockFlags testFlags benchmarkFlags
     globalConfigFlag = projectConfigConfigFile (projectConfigShared cliConfig)
 
 -- | Used by the main CLI parser as heuristic to decide whether @cabal@ was

--- a/cabal-install/Distribution/Client/CmdTest.hs
+++ b/cabal-install/Distribution/Client/CmdTest.hs
@@ -20,7 +20,7 @@ import Distribution.Client.Setup
          ( GlobalFlags(..), ConfigFlags(..), ConfigExFlags, InstallFlags )
 import qualified Distribution.Client.Setup as Client
 import Distribution.Simple.Setup
-         ( HaddockFlags, TestFlags(..), fromFlagOrDefault )
+         ( HaddockFlags, TestFlags(..), BenchmarkFlags(..), fromFlagOrDefault )
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
 import Distribution.Simple.Flag
@@ -36,7 +36,9 @@ import Control.Monad (when)
 import qualified System.Exit (exitSuccess)
 
 
-testCommand :: CommandUI (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+testCommand :: CommandUI ( ConfigFlags, ConfigExFlags, InstallFlags
+                         , HaddockFlags, TestFlags, BenchmarkFlags
+                         )
 testCommand = Client.installCommand
   { commandName         = "v2-test"
   , commandSynopsis     = "Run test-suites"
@@ -84,9 +86,11 @@ testCommand = Client.installCommand
 -- For more details on how this works, see the module
 -- "Distribution.Client.ProjectOrchestration"
 --
-testAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+testAction :: ( ConfigFlags, ConfigExFlags, InstallFlags
+              , HaddockFlags, TestFlags, BenchmarkFlags )
            -> [String] -> GlobalFlags -> IO ()
-testAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
+testAction ( configFlags, configExFlags, installFlags
+           , haddockFlags, testFlags, benchmarkFlags )
            targetStrings globalFlags = do
 
     baseCtx <- establishProjectBaseContext verbosity cliConfig OtherCommand
@@ -131,7 +135,7 @@ testAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
                   globalFlags configFlags configExFlags
                   installFlags
                   mempty -- ClientInstallFlags, not needed here
-                  haddockFlags testFlags
+                  haddockFlags testFlags benchmarkFlags
 
 -- | This defines what a 'TargetSelector' means for the @test@ command.
 -- It selects the 'AvailableTarget's that the 'TargetSelector' refers to,

--- a/cabal-install/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/Distribution/Client/CmdUpdate.hs
@@ -36,7 +36,7 @@ import Distribution.Client.Setup
          , UpdateFlags, defaultUpdateFlags
          , RepoContext(..) )
 import Distribution.Simple.Setup
-         ( HaddockFlags, TestFlags, fromFlagOrDefault )
+         ( HaddockFlags, TestFlags, BenchmarkFlags, fromFlagOrDefault )
 import Distribution.Simple.Utils
          ( die', notice, wrapText, writeFileAtomic, noticeNoWrap )
 import Distribution.Verbosity
@@ -64,7 +64,9 @@ import qualified Distribution.Client.Setup as Client
 import qualified Hackage.Security.Client as Sec
 
 updateCommand :: CommandUI ( ConfigFlags, ConfigExFlags
-                           , InstallFlags, HaddockFlags, TestFlags )
+                           , InstallFlags, HaddockFlags
+                           , TestFlags, BenchmarkFlags
+                           )
 updateCommand = Client.installCommand {
   commandName         = "v2-update",
   commandSynopsis     = "Updates list of known packages.",
@@ -114,9 +116,11 @@ instance Text UpdateRequest where
             name <- ReadP.manyTill (ReadP.satisfy (\c -> c /= ',')) ReadP.eof
             return (UpdateRequest name IndexStateHead)
 
-updateAction :: (ConfigFlags, ConfigExFlags, InstallFlags, HaddockFlags, TestFlags)
+updateAction :: ( ConfigFlags, ConfigExFlags, InstallFlags
+                , HaddockFlags, TestFlags, BenchmarkFlags )
              -> [String] -> GlobalFlags -> IO ()
-updateAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
+updateAction ( configFlags, configExFlags, installFlags
+             , haddockFlags, testFlags, benchmarkFlags )
              extraArgs globalFlags = do
   projectConfig <- withProjectOrGlobalConfig verbosity globalConfigFlag
     (projectConfig <$> establishProjectBaseContext verbosity cliConfig OtherCommand)
@@ -174,7 +178,7 @@ updateAction (configFlags, configExFlags, installFlags, haddockFlags, testFlags)
                   globalFlags configFlags configExFlags
                   installFlags
                   mempty -- ClientInstallFlags, not needed here
-                  haddockFlags testFlags
+                  haddockFlags testFlags benchmarkFlags
     globalConfigFlag = projectConfigConfigFile (projectConfigShared cliConfig)
 
 updateRepo :: Verbosity -> UpdateFlags -> RepoContext -> (Repo, IndexState)

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -79,6 +79,7 @@ import Distribution.Simple.Setup
          ( ConfigFlags(..), configureOptions, defaultConfigFlags
          , HaddockFlags(..), haddockOptions, defaultHaddockFlags
          , TestFlags(..), defaultTestFlags
+         , BenchmarkFlags(..), defaultBenchmarkFlags
          , installDirsOptions, optionDistPref
          , programDbPaths', programDbOptions
          , Flag(..), toFlag, flagToMaybe, fromFlagOrDefault )
@@ -169,7 +170,8 @@ data SavedConfig = SavedConfig {
     savedUploadFlags       :: UploadFlags,
     savedReportFlags       :: ReportFlags,
     savedHaddockFlags      :: HaddockFlags,
-    savedTestFlags         :: TestFlags
+    savedTestFlags         :: TestFlags,
+    savedBenchmarkFlags    :: BenchmarkFlags
   } deriving Generic
 
 instance Monoid SavedConfig where
@@ -189,7 +191,8 @@ instance Semigroup SavedConfig where
     savedUploadFlags       = combinedSavedUploadFlags,
     savedReportFlags       = combinedSavedReportFlags,
     savedHaddockFlags      = combinedSavedHaddockFlags,
-    savedTestFlags         = combinedSavedTestFlags
+    savedTestFlags         = combinedSavedTestFlags,
+    savedBenchmarkFlags    = combinedSavedBenchmarkFlags
   }
     where
       -- This is ugly, but necessary. If we're mappending two config files, we
@@ -512,6 +515,15 @@ instance Semigroup SavedConfig where
         where
           combine      = combine'        savedTestFlags
           lastNonEmpty = lastNonEmpty'   savedTestFlags
+
+      combinedSavedBenchmarkFlags = BenchmarkFlags {
+        benchmarkDistPref  = combine benchmarkDistPref,
+        benchmarkVerbosity = combine benchmarkVerbosity,
+        benchmarkOptions   = lastNonEmpty benchmarkOptions
+        }
+        where
+          combine      = combine'        savedBenchmarkFlags
+          lastNonEmpty = lastNonEmpty'   savedBenchmarkFlags
 
 
 --
@@ -850,7 +862,8 @@ commentSavedConfig = do
         savedUploadFlags       = commandDefaultFlags uploadCommand,
         savedReportFlags       = commandDefaultFlags reportCommand,
         savedHaddockFlags      = defaultHaddockFlags,
-        savedTestFlags         = defaultTestFlags
+        savedTestFlags         = defaultTestFlags,
+        savedBenchmarkFlags    = defaultBenchmarkFlags
         }
   conf1 <- extendToEffectiveConfig conf0
   let globalFlagsConf1 = savedGlobalFlags conf1

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -294,7 +294,9 @@ data PackageConfig
        packageConfigTestKeepTix         :: Flag Bool,
        packageConfigTestWrapper         :: Flag FilePath,
        packageConfigTestFailWhenNoTestSuites :: Flag Bool,
-       packageConfigTestTestOptions     :: [PathTemplate]
+       packageConfigTestTestOptions     :: [PathTemplate],
+       -- Benchmark options
+       packageConfigBenchmarkOptions    :: [PathTemplate]
      }
   deriving (Eq, Show, Generic)
 

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -1884,6 +1884,8 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
         elabTestFailWhenNoTestSuites = perPkgOptionFlag pkgid False packageConfigTestFailWhenNoTestSuites
         elabTestTestOptions     = perPkgOptionList pkgid packageConfigTestTestOptions
 
+        elabBenchmarkOptions    = perPkgOptionList pkgid packageConfigBenchmarkOptions
+
     perPkgOptionFlag  :: PackageId -> a ->  (PackageConfig -> Flag a) -> a
     perPkgOptionMaybe :: PackageId ->       (PackageConfig -> Flag a) -> Maybe a
     perPkgOptionList  :: PackageId ->       (PackageConfig -> [a])    -> [a]
@@ -3456,10 +3458,10 @@ setupHsBenchFlags :: ElaboratedConfiguredPackage
                   -> Verbosity
                   -> FilePath
                   -> Cabal.BenchmarkFlags
-setupHsBenchFlags _ _ verbosity builddir = Cabal.BenchmarkFlags
+setupHsBenchFlags (ElaboratedConfiguredPackage{..}) _ verbosity builddir = Cabal.BenchmarkFlags
     { benchmarkDistPref  = toFlag builddir
     , benchmarkVerbosity = toFlag verbosity
-    , benchmarkOptions   = mempty
+    , benchmarkOptions   = elabBenchmarkOptions
     }
 
 setupHsBenchArgs :: ElaboratedConfiguredPackage -> [String]

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -297,6 +297,8 @@ data ElaboratedConfiguredPackage
        elabTestFailWhenNoTestSuites :: Bool,
        elabTestTestOptions       :: [PathTemplate],
 
+       elabBenchmarkOptions      :: [PathTemplate],
+
        -- Setup.hs related things:
 
        -- | One of four modes for how we build and interact with the Setup.hs

--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -91,7 +91,7 @@ import qualified Distribution.Simple.LocalBuildInfo as LocalBuildInfo
 import Distribution.Simple.PreProcess         ( knownSuffixHandlers )
 import Distribution.Simple.Program            ( ProgramDb )
 import Distribution.Simple.Setup              ( Flag(..), HaddockFlags(..)
-                                              , emptyTestFlags
+                                              , emptyTestFlags, emptyBenchmarkFlags
                                               , fromFlagOrDefault, flagToMaybe )
 import Distribution.Simple.SrcDist            ( prepareTree )
 import Distribution.Simple.Utils              ( die', debug, notice, info, warn
@@ -685,7 +685,7 @@ reinstallAddSourceDeps verbosity configFlags' configExFlags
                   ,comp, platform, progdb
                   ,UseSandbox sandboxDir, Just sandboxPkgInfo
                   ,globalFlags, configFlags, configExFlags, installFlags
-                  ,haddockFlags, emptyTestFlags)
+                  ,haddockFlags, emptyTestFlags, emptyBenchmarkFlags)
 
         -- This can actually be replaced by a call to 'install', but we use a
         -- lower-level API because of layer separation reasons. Additionally, we

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,7 +1,9 @@
 -*-change-log-*-
 
 3.1.0.0 (current development version)
-	* TODO
+	* `v2-build` (and other `v2-`prefixed commands) now accept the
+	  `--benchmark-option(s)` flags, which pass options to benchmark executables
+	  (analogous to how `--test-option(s)` works). (#6209)
 
 3.0.0.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> August 2019
 	* Parse comma-separated lists for extra-prog-path, extra-lib-dirs, extra-framework-dirs,

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -605,6 +605,7 @@ instance Arbitrary PackageConfig where
         <*> arbitraryFlag arbitraryShortToken
         <*> arbitrary
         <*> shortListOf 5 arbitrary
+        <*> shortListOf 5 arbitrary
       where
         arbitraryProgramName :: Gen String
         arbitraryProgramName =
@@ -664,7 +665,8 @@ instance Arbitrary PackageConfig where
                          , packageConfigTestKeepTix = x47
                          , packageConfigTestWrapper = x48
                          , packageConfigTestFailWhenNoTestSuites = x49
-                         , packageConfigTestTestOptions = x51 } =
+                         , packageConfigTestTestOptions = x51
+                         , packageConfigBenchmarkOptions = x52 } =
       [ PackageConfig { packageConfigProgramPaths = postShrink_Paths x00'
                       , packageConfigProgramArgs = postShrink_Args x01'
                       , packageConfigProgramPathExtra = x02'
@@ -718,7 +720,8 @@ instance Arbitrary PackageConfig where
                       , packageConfigTestKeepTix = x47'
                       , packageConfigTestWrapper = x48'
                       , packageConfigTestFailWhenNoTestSuites = x49'
-                      , packageConfigTestTestOptions = x51' }
+                      , packageConfigTestTestOptions = x51'
+                      , packageConfigBenchmarkOptions = x52' }
       |  (((x00', x01', x02', x03', x04'),
           (x05', x42', x06', x50', x07', x08', x09'),
           (x10', x11', x12', x13', x14'),
@@ -728,7 +731,7 @@ instance Arbitrary PackageConfig where
           (x30', x31', x32', (x33', x33_1'), x34'),
           (x35', x36', x37', x38', x43', x39'),
           (x40', x41'),
-          (x44', x45', x46', x47', x48', x49', x51')))
+          (x44', x45', x46', x47', x48', x49', x51', x52')))
           <- shrink
              (((preShrink_Paths x00, preShrink_Args x01, x02, x03, x04),
                 (x05, x42, x06, x50, x07, x08, x09),
@@ -742,7 +745,7 @@ instance Arbitrary PackageConfig where
                  (x30, x31, x32, (x33, x33_1), x34),
                  (x35, x36, fmap NonEmpty x37, x38, x43, fmap NonEmpty x39),
                  (x40, x41),
-                 (x44, x45, x46, x47, x48, x49, x51)))
+                 (x44, x45, x46, x47, x48, x49, x51, x52)))
       ]
       where
         preShrink_Paths  = Map.map NonEmpty

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBench/OptionsFlag/OptionsFlag.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBench/OptionsFlag/OptionsFlag.cabal
@@ -1,0 +1,10 @@
+name: OptionsFlag
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+benchmark optionsflag
+    type: exitcode-stdio-1.0
+    main-is: OptionsFlag.hs
+    build-depends: base
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBench/OptionsFlag/OptionsFlag.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBench/OptionsFlag/OptionsFlag.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import System.Environment (getArgs)
+import System.Exit (exitFailure, exitSuccess)
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let allArgs = unwords args
+  if allArgs == "1 2 3 4 5 6"
+     then exitSuccess
+     else putStrLn ("Got: " ++ allArgs) >> exitFailure

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBench/OptionsFlag/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBench/OptionsFlag/cabal.out
@@ -1,0 +1,11 @@
+# cabal v2-bench
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - OptionsFlag-1.0 (bench:optionsflag) (first run)
+Configuring benchmark 'optionsflag' for OptionsFlag-1.0..
+Preprocessing benchmark 'optionsflag' for OptionsFlag-1.0..
+Building benchmark 'optionsflag' for OptionsFlag-1.0..
+Running 1 benchmarks...
+Benchmark optionsflag: RUNNING...
+Benchmark optionsflag: FINISH

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBench/OptionsFlag/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBench/OptionsFlag/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBench/OptionsFlag/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBench/OptionsFlag/cabal.test.hs
@@ -1,0 +1,9 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    cabal "v2-bench"
+      [ "--benchmark-option=1"
+      , "--benchmark-options=\"2 3\""
+      , "--benchmark-option=4"
+      , "--benchmark-options=\"5 6\""
+      ]

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OptionsFlag/OptionsFlag.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OptionsFlag/OptionsFlag.cabal
@@ -1,0 +1,10 @@
+name: OptionsFlag
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+test-suite optionsflag
+    type: exitcode-stdio-1.0
+    main-is: OptionsFlag.hs
+    build-depends: base
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OptionsFlag/OptionsFlag.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OptionsFlag/OptionsFlag.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import System.Environment (getArgs)
+import System.Exit (exitFailure, exitSuccess)
+
+main :: IO ()
+main = do
+  args <- getArgs
+  let allArgs = unwords args
+  if allArgs == "1 2 3 4 5 6"
+     then exitSuccess
+     else putStrLn ("Got: " ++ allArgs) >> exitFailure

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OptionsFlag/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OptionsFlag/cabal.out
@@ -1,0 +1,13 @@
+# cabal v2-test
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - OptionsFlag-1.0 (test:optionsflag) (first run)
+Configuring test suite 'optionsflag' for OptionsFlag-1.0..
+Preprocessing test suite 'optionsflag' for OptionsFlag-1.0..
+Building test suite 'optionsflag' for OptionsFlag-1.0..
+Running 1 test suites...
+Test suite optionsflag: RUNNING...
+Test suite optionsflag: PASS
+Test suite logged to: <ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/OptionsFlag-1.0/t/optionsflag/test/OptionsFlag-1.0-optionsflag.log
+1 of 1 test suites (1 of 1 test cases) passed.

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OptionsFlag/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OptionsFlag/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OptionsFlag/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OptionsFlag/cabal.test.hs
@@ -1,0 +1,9 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    cabal "v2-test"
+      [ "--test-option=1"
+      , "--test-options=\"2 3\""
+      , "--test-option=4"
+      , "--test-options=\"5 6\""
+      ]


### PR DESCRIPTION
This implements lots of plumbing to allow the `--benchmark-option(s)` flags to be used with `v2-bench`, analgous to `v2-test`'s `--test-option(s)` flag.

Fixes #6209.
---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X] Any changes that could be relevant to users have been recorded in the changelog.
* [X] The documentation has been updated, if necessary.
* [X] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
