### PR TITLE
Document hs-source-dirs

### DIFF
--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2184,14 +2184,20 @@ system-dependent values for these fields.
        :pkg-field:`other-modules`, :pkg-field:`library:exposed-modules` or
        :pkg-field:`executable:main-is` fields.
 
+.. pkg-field:: hs-source-dir: directory list
+    :deprecated: 2.0
+    :removed: 3.0
+    :default: ``.``
+
+    Root directories for the module hierarchy.
+
+    Deprecated in favor of :pkg-field:`hs-source-dirs`.
+
 .. pkg-field:: hs-source-dirs: directory list
 
     :default: ``.``
 
     Root directories for the module hierarchy.
-
-    For backwards compatibility, the old variant ``hs-source-dir`` is
-    also recognized.
 
 .. pkg-field:: default-extensions: identifier list
 

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2199,6 +2199,13 @@ system-dependent values for these fields.
 
     Root directories for the module hierarchy.
 
+    .. note::
+
+      Components can share source directories but modules will be compiled if
+      they can be found there, i.e., if a library and an executable share a
+      source directory and the executable depends on the library's ``Foo``
+      module it will be recompiled even if the library has already been built.
+
 .. pkg-field:: default-extensions: identifier list
 
     A list of Haskell extensions used by every module. These determine

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2201,10 +2201,11 @@ system-dependent values for these fields.
 
     .. note::
 
-      Components can share source directories but modules will be compiled if
-      they can be found there, i.e., if a library and an executable share a
-      source directory and the executable depends on the library's ``Foo``
-      module it will be recompiled even if the library has already been built.
+      Components can share source directories but modules found there will be
+      recompiled even if other components already built them, i.e., if a
+      library and an executable share a source directory and the executable
+      depends on the library and imports its ``Foo`` module, ``Foo`` will be
+      compiled twice, once as part of the library and again for the executable.
 
 .. pkg-field:: default-extensions: identifier list
 


### PR DESCRIPTION
I replaced the note about `hs-source-dir` being deprecated in the
description of `hs-source-dirs` by a field of its own to include the
`deprecated` and `removed` fields because it's no longer in 3.0.

Source directories can be shared among components but there's a
non-obvious caveat which I've tried to clarify with a note for `hs-source-dirs`.
This definitely needs review because I'm not sure I understood it and whether I'm getting the point across.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!