### PR TITLE
Passes cxx options with using -optcxx flag.

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,5 +1,6 @@
 # 3.1.0.0 (current development version)
   * TODO
+  * Passes cxx flags as -optscxx- for the GHC higher than 8.9 version.
 
  ----
 

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -664,7 +664,11 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
   , concat [ [ "-optP-include", "-optP" ++ inc]
            | inc <- flags ghcOptCppIncludes ]
   , [ "-optc" ++ opt | opt <- ghcOptCcOptions opts]
-  , [ "-optc" ++ opt | opt <- ghcOptCxxOptions opts]
+
+  , let prefix = if compilerVersion comp `withinRange` orLaterVersion (mkVersion [8,8])
+                 then "-optcxx"
+                 else "-optc"
+    in [ prefix ++ opt | opt <- ghcOptCxxOptions opts]
 
   -----------------
   -- Linker stuff


### PR DESCRIPTION
Recent GHC accepts CXX flags passed by optcxx, and this patch
makes use of that feature.



---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!