### PR TITLE
Fix c2hs handling in Cabal

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -468,6 +468,10 @@ library
     Distribution.Version
     Language.Haskell.Extension
     Distribution.Compat.Binary
+  other-modules:
+    Distribution.C2Hs
+    Distribution.C2Hs.Lexer
+  build-tool-depends: alex:alex
 
   -- Parsec parser-related modules
   build-depends:

--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,5 +1,6 @@
 # 3.1.0.0 (current development version)
   * TODO
+  * Fix dependency resolution for preprocessing `chs` files.
 
  ----
 

--- a/Cabal/Distribution/C2Hs.hs
+++ b/Cabal/Distribution/C2Hs.hs
@@ -1,0 +1,74 @@
+module Distribution.C2Hs ( fixDeps ) where
+
+import qualified Data.Map                        as M
+import qualified Data.Set                        as S
+import           Distribution.C2Hs.Lexer
+import           Distribution.ModuleName         (ModuleName, components)
+import           Distribution.PackageDescription (PackageDescription)
+import qualified Distribution.PackageDescription as PD
+import           Distribution.Simple.Utils       (dieNoVerbosity,
+                                                  findFileWithExtension,
+                                                  withUTF8FileContents)
+import           Distribution.Text               (simpleParse)
+import           System.FilePath                 (joinPath)
+
+fixDeps :: PackageDescription -> IO PackageDescription
+fixDeps pd@PD.PackageDescription {
+          PD.library = Just lib@PD.Library {
+            PD.exposedModules = expMods,
+            PD.libBuildInfo = bi@PD.BuildInfo {
+              PD.hsSourceDirs = srcDirs,
+              PD.otherModules = othMods
+            }}} = do
+
+  let findModule = findFileWithExtension [".chs"] srcDirs . joinPath . components
+
+  mExpFiles <- traverse findModule expMods
+  mOthFiles <- traverse findModule othMods
+
+  let modDeps = zipWith (ModDep True []) expMods mExpFiles ++
+                zipWith (ModDep False []) othMods mOthFiles
+  modDeps <- traverse extractDeps modDeps
+  let (othMods, expMods) = span (not . mdExposed) $ sortTopological modDeps
+  return pd { PD.library = Just lib {
+    PD.exposedModules = map mdOriginal (reverse expMods),
+    PD.libBuildInfo = bi { PD.otherModules = map mdOriginal (reverse othMods) }
+  }}
+fixDeps pd = pure pd
+
+data ModDep = ModDep {
+  mdExposed  :: Bool,
+  mdRequires :: [ModuleName],
+  mdOriginal :: ModuleName,
+  mdLocation :: Maybe FilePath
+}
+
+instance Show ModDep where
+  show x = show (mdLocation x)
+
+instance Eq ModDep where
+  ModDep { mdOriginal = m1 } == ModDep { mdOriginal = m2 } = m1==m2
+instance Ord ModDep where
+  compare ModDep { mdOriginal = m1 } ModDep { mdOriginal = m2 } = compare m1 m2
+
+extractDeps :: ModDep -> IO ModDep
+extractDeps md@ModDep { mdLocation = Nothing } = return md
+extractDeps md@ModDep { mdLocation = Just f } = withUTF8FileContents f $ \con -> do
+  mods <- case getImports con of
+        Right ms -> case traverse simpleParse ms of
+            Just ms -> pure ms
+            Nothing -> dieNoVerbosity ("Cannot parse module name in c2hs file " ++ f)
+        Left err -> dieNoVerbosity ("Cannot parse c2hs import in " ++ f ++ ": " ++ err)
+  return md { mdRequires = mods }
+
+sortTopological :: [ModDep] -> [ModDep]
+sortTopological ms = fst $ foldl visit (([]), S.empty) (mdOriginal <$> ms)
+  where
+  set = M.fromList (map (\m -> (mdOriginal m, m)) ms)
+  visit (out,visited) m
+    | m `S.member` visited = (out,visited)
+    | otherwise = case m `M.lookup` set of
+        Nothing -> (out, m `S.insert` visited)
+        Just md -> (md:out', visited')
+          where
+            (out',visited') = foldl visit (out, m `S.insert` visited) (mdRequires md)

--- a/Cabal/Distribution/C2Hs.hs
+++ b/Cabal/Distribution/C2Hs.hs
@@ -1,74 +1,53 @@
-module Distribution.C2Hs ( fixDeps ) where
+-- Based on https://github.com/gtk2hs/gtk2hs/blob/master/tools/src/Gtk2HsSetup.hs#L414
+module Distribution.C2Hs ( reorderC2Hs ) where
 
-import qualified Data.Map                        as M
-import qualified Data.Set                        as S
-import           Distribution.C2Hs.Lexer
-import           Distribution.ModuleName         (ModuleName, components)
-import           Distribution.PackageDescription (PackageDescription)
-import qualified Distribution.PackageDescription as PD
-import           Distribution.Simple.Utils       (dieNoVerbosity,
-                                                  findFileWithExtension,
-                                                  withUTF8FileContents)
-import           Distribution.Text               (simpleParse)
-import           System.FilePath                 (joinPath)
+import Data.List (foldl')
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Distribution.C2Hs.Lexer
+import Distribution.ModuleName (ModuleName, components)
+import Distribution.Parsec (simpleParsec)
+import Distribution.Simple.Utils (dieNoVerbosity, findFileWithExtension, withUTF8FileContents)
+import System.FilePath (joinPath)
 
-fixDeps :: PackageDescription -> IO PackageDescription
-fixDeps pd@PD.PackageDescription {
-          PD.library = Just lib@PD.Library {
-            PD.exposedModules = expMods,
-            PD.libBuildInfo = bi@PD.BuildInfo {
-              PD.hsSourceDirs = srcDirs,
-              PD.otherModules = othMods
-            }}} = do
+reorderC2Hs :: [FilePath] -> [ModuleName] -> IO [ModuleName]
+reorderC2Hs dirs preMods = do
 
-  let findModule = findFileWithExtension [".chs"] srcDirs . joinPath . components
+  let findModule = findFileWithExtension [".chs"] dirs . joinPath . components
 
-  mExpFiles <- traverse findModule expMods
-  mOthFiles <- traverse findModule othMods
+  mFiles <- traverse findModule preMods
 
-  let modDeps = zipWith (ModDep True []) expMods mExpFiles ++
-                zipWith (ModDep False []) othMods mOthFiles
-  modDeps <- traverse extractDeps modDeps
-  let (othMods, expMods) = span (not . mdExposed) $ sortTopological modDeps
-  return pd { PD.library = Just lib {
-    PD.exposedModules = map mdOriginal (reverse expMods),
-    PD.libBuildInfo = bi { PD.otherModules = map mdOriginal (reverse othMods) }
-  }}
-fixDeps pd = pure pd
+  let preDeps = zipWith (ModDep []) preMods mFiles
 
-data ModDep = ModDep {
-  mdExposed  :: Bool,
-  mdRequires :: [ModuleName],
-  mdOriginal :: ModuleName,
-  mdLocation :: Maybe FilePath
-}
+  modDeps <- traverse extractDeps preDeps
 
-instance Show ModDep where
-  show x = show (mdLocation x)
+  let mods = reverse (sortTopological modDeps)
 
-instance Eq ModDep where
-  ModDep { mdOriginal = m1 } == ModDep { mdOriginal = m2 } = m1==m2
-instance Ord ModDep where
-  compare ModDep { mdOriginal = m1 } ModDep { mdOriginal = m2 } = compare m1 m2
+  pure (mdOriginal <$> mods)
+
+data ModDep = ModDep { mdRequires :: [ModuleName]
+                     , mdOriginal :: ModuleName
+                     , mdLocation :: Maybe FilePath
+                     }
 
 extractDeps :: ModDep -> IO ModDep
-extractDeps md@ModDep { mdLocation = Nothing } = return md
-extractDeps md@ModDep { mdLocation = Just f } = withUTF8FileContents f $ \con -> do
+extractDeps md@(ModDep _ _ Nothing) = pure md
+extractDeps md@(ModDep _ _ (Just f)) = withUTF8FileContents f $ \con -> do
   mods <- case getImports con of
-        Right ms -> case traverse simpleParse ms of
-            Just ms -> pure ms
+        Right ms -> case traverse simpleParsec ms of
+            Just ms' -> pure ms'
             Nothing -> dieNoVerbosity ("Cannot parse module name in c2hs file " ++ f)
         Left err -> dieNoVerbosity ("Cannot parse c2hs import in " ++ f ++ ": " ++ err)
-  return md { mdRequires = mods }
+  pure (md { mdRequires = mods })
 
 sortTopological :: [ModDep] -> [ModDep]
-sortTopological ms = fst $ foldl visit (([]), S.empty) (mdOriginal <$> ms)
+sortTopological ms = fst $ foldl' visit (([]), S.empty) (mdOriginal <$> ms)
   where
-  set = M.fromList (map (\m -> (mdOriginal m, m)) ms)
-  visit (out,visited) m
-    | m `S.member` visited = (out,visited)
-    | otherwise = case m `M.lookup` set of
-        Nothing -> (out, m `S.insert` visited)
-        Just md -> (md:out', visited')
-          where
-            (out',visited') = foldl visit (out, m `S.insert` visited) (mdRequires md)
+    set = M.fromList (fmap (\m -> (mdOriginal m, m)) ms)
+    visit (out,visited) m
+      | m `S.member` visited = (out,visited)
+      | otherwise = case m `M.lookup` set of
+          Nothing -> (out, m `S.insert` visited)
+          Just md -> (md:out', visited')
+            where
+              (out',visited') = foldl' visit (out, m `S.insert` visited) (mdRequires md)

--- a/Cabal/Distribution/C2Hs/Lexer.x
+++ b/Cabal/Distribution/C2Hs/Lexer.x
@@ -1,8 +1,5 @@
 {
 module Distribution.C2Hs.Lexer ( getImports ) where
-
-import Data.List (groupBy)
-
 }
 
 %wrapper "monad"
@@ -66,7 +63,7 @@ nested_comment = go 1 =<< alexGetInput
                                 Just (c',input_) -> go (addLevel c' $ n) input_
                         _ -> go n input'
 
-          addLevel c' = if c' == 123 then (+1) else id
+          addLevel c' = if c' == 45 then (+1) else id
 
           err (pos,_,_,_) =
             let (AlexPn _ line col) = pos in
@@ -86,11 +83,5 @@ loop = do
     case tok' of
         End -> pure []
         _ -> (tok' :) <$> loop
-
-split :: String -> [String]
-split = filter (/= ":") . groupBy g
-    where g ':' _ = False
-          g _ ':' = False
-          g _ _   = True
 
 }

--- a/Cabal/Distribution/C2Hs/Lexer.x
+++ b/Cabal/Distribution/C2Hs/Lexer.x
@@ -1,0 +1,96 @@
+{
+module Distribution.C2Hs.Lexer ( getImports ) where
+
+import Data.List (groupBy)
+
+}
+
+%wrapper "monad"
+
+$module = [A-Za-z\.]
+
+tokens :-
+
+    $white+                      ;
+    <0> "--".*                   ;
+
+    <0> "{-"                     { \_ _ -> nested_comment }
+
+    <chs> "import"               { \_ _ -> alex Import }
+    <chs> "qualified"            ;
+    <chs> "#}"                   { begin 0 }
+    <0> "{#"                     { begin chs }
+    <chs> $module+               { tok (\_ s -> alex (Module s)) }
+
+    <0> [^\{]+                   ;
+    <0> $printable               ;
+    <chs> [^\#$module]+          ;
+
+{
+
+data Token = Import
+           | Module String
+           | End
+
+tok f (p,_,_,s) len = f p (take len s)
+
+alex :: a -> Alex a
+alex = pure
+
+alexEOF :: Alex Token
+alexEOF = pure End
+
+-- | Given a 'String' containing C2Hs, return a list of modules it @{#import#}@s.
+getImports :: String -> Either String [FilePath]
+getImports = fmap extractDeps . lexC
+
+-- from: https://github.com/simonmar/alex/blob/master/examples/haskell.x#L128
+nested_comment :: Alex Token
+nested_comment = go 1 =<< alexGetInput
+
+    where go :: Int -> AlexInput -> Alex Token
+          go 0 input = alexSetInput input *> alexMonadScan
+          go n input =
+            case alexGetByte input of
+                Nothing -> err input
+                Just (c, input') ->
+                    case c of
+                        45 ->
+                            case alexGetByte input' of
+                                Nothing -> err input'
+                                Just (125,input_) -> go (n-1) input_
+                                Just (_,input_) -> go n input_
+                        125 ->
+                            case alexGetByte input' of
+                                Nothing -> err input'
+                                Just (c',input_) -> go (addLevel c' $ n) input_
+                        _ -> go n input'
+
+          addLevel c' = if c' == 123 then (+1) else id
+
+          err (pos,_,_,_) =
+            let (AlexPn _ line col) = pos in
+                alexError ("Error in nested comment at line " ++ show line ++ ", column " ++ show col)
+
+extractDeps :: [Token] -> [FilePath]
+extractDeps []                   = []
+extractDeps (Import:Module s:xs) = s : extractDeps xs
+extractDeps (_:xs)               = extractDeps xs
+
+lexC :: String -> Either String [Token]
+lexC = flip runAlex loop
+
+loop :: Alex [Token]
+loop = do
+    tok' <- alexMonadScan
+    case tok' of
+        End -> pure []
+        _ -> (tok' :) <$> loop
+
+split :: String -> [String]
+split = filter (/= ":") . groupBy g
+    where g ':' _ = False
+          g _ ':' = False
+          g _ _   = True
+
+}

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -33,6 +33,7 @@ import Prelude ()
 import Distribution.Compat.Prelude
 import Distribution.Compat.Stack
 
+import Distribution.C2Hs
 import Distribution.Simple.PreProcess.Unlit
 import Distribution.Backpack.DescribeUnitId
 import Distribution.Package
@@ -168,7 +169,8 @@ preprocessComponent pd comp lbi clbi isSrcDist verbosity handlers = do
   (CLib lib@Library{ libBuildInfo = bi }) -> do
     let dirs = hsSourceDirs bi ++ [autogenComponentModulesDir lbi clbi
                                   ,autogenPackageModulesDir lbi]
-    for_ (map ModuleName.toFilePath $ allLibModules lib clbi) $
+    mods <- reorderC2Hs dirs (allLibModules lib clbi)
+    for_ (map ModuleName.toFilePath mods) $
       pre dirs (componentBuildDir lbi clbi) (localHandlers bi)
   (CFLib flib@ForeignLib { foreignLibBuildInfo = bi, foreignLibName = nm }) -> do
     let nm' = unUnqualComponentName nm


### PR DESCRIPTION
This fixes a 13 year-old bug, viz. https://github.com/haskell/cabal/issues/55 aka https://github.com/haskell/cabal/issues/1906

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

I tested it by building my own [library](https://github.com/vmchale/libarchive).
