### PR TITLE
add entry for 3.0 to init script

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -194,6 +194,7 @@ displayCabalVersion v = case versionNumbers v of
   [2,0]  -> "2.0    (+ support for Backpack, internal sub-libs, '^>=' operator)"
   [2,2]  -> "2.2    (+ support for 'common', 'elif', redundant commas, SPDX)"
   [2,4]  -> "2.4    (+ support for '**' globbing)"
+  [3,0]  -> "3.0    (+ support for v2-* options as default, other bikesheddable content here)"
   _      -> display v
 
 -- | Ask if a simple project with sensible defaults should be created.
@@ -221,12 +222,20 @@ getCabalVersion flags = do
   cabVer <-     return (flagToMaybe $ cabalVersion flags)
             ?>> maybePrompt flags (either (const defaultCabalVersion) id `fmap`
                                   promptList "Please choose version of the Cabal specification to use"
-                                  [mkVersion [1,10], mkVersion [2,0], mkVersion [2,2], mkVersion [2,4]]
+                                  vlist
                                   (Just defaultCabalVersion) displayCabalVersion False)
             ?>> return (Just defaultCabalVersion)
 
   return $  flags { cabalVersion = maybeToFlag cabVer }
 
+  where
+    vlist =
+      [ mkVersion [1,10]
+      , mkVersion [2,0]
+      , mkVersion [2,2]
+      , mkVersion [2,4]
+      , mkVersion [3,0]
+      ]
 
 -- | Get the package name: use the package directory (supplied, or the current
 --   directory by default) as a guess. It looks at the SourcePackageDb to avoid

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -194,7 +194,7 @@ displayCabalVersion v = case versionNumbers v of
   [2,0]  -> "2.0    (+ support for Backpack, internal sub-libs, '^>=' operator)"
   [2,2]  -> "2.2    (+ support for 'common', 'elif', redundant commas, SPDX)"
   [2,4]  -> "2.4    (+ support for '**' globbing)"
-  [3,0]  -> "3.0    (+ support for v2-* options as default, other bikesheddable content here)"
+  [3,0]  -> "3.0    (+ support for set-notation syntax for '==' and '^>=')"
   _      -> display v
 
 -- | Ask if a simple project with sensible defaults should be created.
@@ -222,19 +222,19 @@ getCabalVersion flags = do
   cabVer <-     return (flagToMaybe $ cabalVersion flags)
             ?>> maybePrompt flags (either (const defaultCabalVersion) id `fmap`
                                   promptList "Please choose version of the Cabal specification to use"
-                                  vlist
+                                  versionList
                                   (Just defaultCabalVersion) displayCabalVersion False)
             ?>> return (Just defaultCabalVersion)
 
   return $  flags { cabalVersion = maybeToFlag cabVer }
 
   where
-    vlist =
-      [ mkVersion [1,10]
-      , mkVersion [2,0]
-      , mkVersion [2,2]
-      , mkVersion [2,4]
-      , mkVersion [3,0]
+    versionList = fmap mkVersion
+      [ [1,10]
+      , [2,0]
+      , [2,2]
+      , [2,4]
+      , [3,0]
       ]
 
 -- | Get the package name: use the package directory (supplied, or the current

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,7 +1,7 @@
 -*-change-log-*-
 
 3.1.0.0 (current development version)
-	* TODO
+	* Add entry for cabal version 3.0 to cabal initialization script
 
 3.0.0.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> August 2019
 	* Parse comma-separated lists for extra-prog-path, extra-lib-dirs, extra-framework-dirs,

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,7 +1,7 @@
 -*-change-log-*-
 
 3.1.0.0 (current development version)
-	* Add entry for cabal version 3.0 to cabal initialization script
+	* Add entry for cabal version 3.0 to `cabal init`
 
 3.0.0.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> August 2019
 	* Parse comma-separated lists for extra-prog-path, extra-lib-dirs, extra-framework-dirs,


### PR DESCRIPTION

The prompt for 3.0 requires some feedback. Otherwise, this addresses #6239 


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
