### PR TITLE
cabal check: cpp-options allows only -D and -U options

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -108,6 +108,8 @@ extra-source-files:
   tests/ParserTests/regressions/Octree-0.5.cabal
   tests/ParserTests/regressions/Octree-0.5.expr
   tests/ParserTests/regressions/Octree-0.5.format
+  tests/ParserTests/regressions/assoc-cpp-options.cabal
+  tests/ParserTests/regressions/assoc-cpp-options.check
   tests/ParserTests/regressions/bad-glob-syntax.cabal
   tests/ParserTests/regressions/bad-glob-syntax.check
   tests/ParserTests/regressions/cc-options-with-optimization.cabal

--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,4 +1,6 @@
 # 3.1.0.0 (current development version)
+  * `cabal check` verifies `cpp-options` more pedantically, allowing only
+    options starting with `-D` and `-U`.
   * TODO
 
  ----

--- a/Cabal/tests/CheckTests.hs
+++ b/Cabal/tests/CheckTests.hs
@@ -39,6 +39,7 @@ checkTests = testGroup "regressions"
     , checkTest "cxx-options-with-optimization.cabal"
     , checkTest "ghc-option-j.cabal"
     , checkTest "multiple-libs-2.cabal"
+    , checkTest "assoc-cpp-options.cabal"
     ]
 
 checkTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests/regressions/assoc-cpp-options.cabal
+++ b/Cabal/tests/ParserTests/regressions/assoc-cpp-options.cabal
@@ -1,0 +1,48 @@
+cabal-version: 1.12
+name:          assoc
+version:       1.1
+license:       BSD3
+license-file:  LICENSE
+synopsis:      swap and assoc: Symmetric and Semigroupy Bifunctors
+category:      Data
+description:
+  Provides generalisations of
+  @swap :: (a,b) -> (b,a)@ and
+  @assoc :: ((a,b),c) -> (a,(b,c))@
+  to
+  @Bifunctor@s supporting similar operations (e.g. @Either@, @These@).
+
+author:        Oleg Grenrus <oleg.grenrus@iki.fi>
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+build-type:    Simple
+tested-with:
+  GHC ==7.0.4
+   || ==7.2.2
+   || ==7.4.2
+   || ==7.6.3
+   || ==7.8.4
+   || ==7.10.3
+   || ==8.0.2
+   || ==8.2.2
+   || ==8.4.4
+   || ==8.6.5
+   || ==8.8.1
+
+source-repository head
+  type:     git
+  location: https://github.com/phadej/assoc.git
+
+library
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  build-depends:
+      base        >=4.3   && <4.13
+    , bifunctors  >=5.5.4 && <5.6
+
+  cpp-options: -traditional
+
+  exposed-modules:
+    Data.Bifunctor.Assoc
+    Data.Bifunctor.Swap
+
+  other-extensions: TypeFamilies

--- a/Cabal/tests/ParserTests/regressions/assoc-cpp-options.check
+++ b/Cabal/tests/ParserTests/regressions/assoc-cpp-options.check
@@ -1,0 +1,1 @@
+'cpp-options': -traditional is not portable C-preprocessor flag


### PR DESCRIPTION
Before:

130113 files processed
7304 have lexer/parser warnings
332 build impossible
9742 build warning
49779 build dist suspicious
38666 build dist suspicious warning
11834 build dist inexcusable

After:

130113 files processed
7304 have lexer/parser warnings
332 build impossible
10063 build warning
49779 build dist suspicious
38666 build dist suspicious warning
11834 build dist inexcusable

i.e. 321 build warnings on all Hackage

Examples:

NO_DEBUG_MODE                       -- forgotten -D?
-traditional                        -- doesn't work, nor needed
-fallow-undecidable-instances       -- wrong -options?
-fno-exceptions
-Wall
-Werror
--include=include/config.h          -- doesn't work
-maes                               -- cpp is not C++ ?
-mpclmul
-mssse3


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
