### PR TITLE
Warn that dependencies using backpack are broken when installed from hackage

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -656,7 +656,7 @@ the custom publishing of Haddock documentation to Hackage.
 .. warning::
 
   Packages that use Backpack will stop working if uploaded to
-  Hackage, due to https://github.com/haskell/cabal/issues/6005
+  Hackage, due to `issue #6005 <https://github.com/haskell/cabal/issues/6005>`_.
   While this is happening, we recommend not uploading these packages
   to Hackage (and instead referencing the package directly
   as a ``source-repository-package``).

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -653,6 +653,13 @@ byte) that must be satisfied for it to function correctly in the larger v2-build
 ``autogen-modules`` is able to replace uses of the hooks to add generated modules, along with
 the custom publishing of Haddock documentation to Hackage.
 
+.. warning::
+
+  If a package uses backpack in any capacity, do not upload it to
+  hackage. The package will not be built correctly when Cabal
+  attempts to install it as a dependency. This may be fixed in
+  a future release.
+
 Configuring builds with cabal.project
 =====================================
 

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -655,10 +655,11 @@ the custom publishing of Haddock documentation to Hackage.
 
 .. warning::
 
-  If a package uses backpack in any capacity, do not upload it to
-  hackage. The package will not be built correctly when Cabal
-  attempts to install it as a dependency. This may be fixed in
-  a future release.
+  Packages that use Backpack will stop working if uploaded to
+  Hackage, due to https://github.com/haskell/cabal/issues/6005
+  While this is happening, we recommend not uploading these packages
+  to Hackage (and instead referencing the package directly
+  as a ``source-repository-package``).
 
 Configuring builds with cabal.project
 =====================================


### PR DESCRIPTION
Documents the deficiency from https://github.com/haskell/cabal/issues/6005 in the user manual. In the event that the issue does not get fixed for some time, documenting this should help prevent people from wasting space on hackage by uploading packages that no build tool can currently build.