### PR TITLE
Fix #6128 on 7.10.

### DIFF
--- a/cabal-install/Distribution/Client/SourceFiles.hs
+++ b/cabal-install/Distribution/Client/SourceFiles.hs
@@ -41,7 +41,7 @@ import Distribution.Client.Compat.Prelude
 
 import System.FilePath
 import Control.Monad
-import Control.Monad.IO.Class
+import Control.Monad.Trans (liftIO)
 import qualified Data.Set as Set
 
 needElaboratedConfiguredPackage :: ElaboratedConfiguredPackage -> Rebuild ()


### PR DESCRIPTION
Every version *except* the famously fussy 7.10 was happy with
importing liftIO from Control.Monad.IO.Class.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
