### PR TITLE
Exe dependency less lexeme

### DIFF
--- a/Cabal/Distribution/Types/ExeDependency.hs
+++ b/Cabal/Distribution/Types/ExeDependency.hs
@@ -53,11 +53,11 @@ instance Pretty ExeDependency where
 -- Nothing
 --
 -- >>> simpleParsec "happy :happy >= 1.19.12" :: Maybe ExeDependency
--- Just (ExeDependency (PackageName "happy") (UnqualComponentName "happy") (OrLaterVersion (mkVersion [1,19,12])))
+-- Nothing
 --
 instance Parsec ExeDependency where
     parsec = do
-        name <- lexemeParsec
+        name <- parsec
         _    <- P.char ':'
         exe  <- lexemeParsec
         ver  <- parsec <|> pure anyVersion

--- a/Cabal/Distribution/Types/ExeDependency.hs
+++ b/Cabal/Distribution/Types/ExeDependency.hs
@@ -33,6 +33,28 @@ instance Pretty ExeDependency where
   pretty (ExeDependency name exe ver) =
     (pretty name <<>> text ":" <<>> pretty exe) <+> pretty ver
 
+-- | 
+--
+-- Examples
+--
+-- >>> simpleParsec "happy:happy" :: Maybe ExeDependency
+-- Just (ExeDependency (PackageName "happy") (UnqualComponentName "happy") AnyVersion)
+--
+-- >>> simpleParsec "happy:happy >= 1.19.12" :: Maybe ExeDependency
+-- Just (ExeDependency (PackageName "happy") (UnqualComponentName "happy") (OrLaterVersion (mkVersion [1,19,12])))
+--
+-- >>> simpleParsec "happy:happy>=1.19.12" :: Maybe ExeDependency
+-- Just (ExeDependency (PackageName "happy") (UnqualComponentName "happy") (OrLaterVersion (mkVersion [1,19,12])))
+--
+-- >>> simpleParsec "happy : happy >= 1.19.12" :: Maybe ExeDependency
+-- Nothing
+--
+-- >>> simpleParsec "happy: happy >= 1.19.12" :: Maybe ExeDependency
+-- Nothing
+--
+-- >>> simpleParsec "happy :happy >= 1.19.12" :: Maybe ExeDependency
+-- Just (ExeDependency (PackageName "happy") (UnqualComponentName "happy") (OrLaterVersion (mkVersion [1,19,12])))
+--
 instance Parsec ExeDependency where
     parsec = do
         name <- lexemeParsec


### PR DESCRIPTION
This is tricky: There are no `happy :happy` (note the space) uses of `build-tool-depends` on Hackage, so if we are quick to make Cabal-3.0.x.y with this patch and deploy `hackage-server` using it, it can be as simple as this.

Note: this is different than with spaces in `mixins` as here I'm *restricting* the grammar: existing `cabal-install` / tools using old `Cabal` will continue to work fine.

Edit: look at the `Make ExeDependency parser stricter` commit to see how the example output change.