### PR TITLE
Fix dropExeExtension on Windows

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -313,6 +313,7 @@ library
     Distribution.Compat.Directory
     Distribution.Compat.Environment
     Distribution.Compat.Exception
+    Distribution.Compat.FilePath
     Distribution.Compat.Graph
     Distribution.Compat.Internal.TempFile
     Distribution.Compat.Newtype

--- a/Cabal/Distribution/Compat/FilePath.hs
+++ b/Cabal/Distribution/Compat/FilePath.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE CPP #-}
+
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+
+module Distribution.Compat.FilePath
+( isExtensionOf
+, stripExtension
+) where
+
+import Data.List ( isSuffixOf, stripPrefix )
+import System.FilePath
+
+#if !MIN_VERSION_filepath(1,4,2)
+isExtensionOf :: String -> FilePath -> Bool
+isExtensionOf ext@('.':_) = isSuffixOf ext . takeExtensions
+isExtensionOf ext         = isSuffixOf ('.':ext) . takeExtensions
+#endif
+
+#if !MIN_VERSION_filepath(1,4,1)
+stripExtension :: String -> FilePath -> Maybe FilePath
+stripExtension []        path = Just path
+stripExtension ext@(x:_) path = stripSuffix dotExt path
+ where
+  dotExt = if isExtSeparator x then ext else '.':ext
+  stripSuffix :: Eq a => [a] -> [a] -> Maybe [a]
+  stripSuffix xs ys = fmap reverse $ stripPrefix (reverse xs) (reverse ys)
+#endif

--- a/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
+++ b/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
@@ -2,13 +2,16 @@ module UnitTests.Distribution.Simple.Utils
     ( tests
     ) where
 
+import Distribution.Simple.BuildPaths ( exeExtension )
 import Distribution.Simple.Utils
+import Distribution.System ( buildPlatform )
 import Distribution.Verbosity
 
 import Data.IORef
 import System.Directory ( doesDirectoryExist, doesFileExist
                         , getTemporaryDirectory
                         , removeDirectoryRecursive, removeFile )
+import System.FilePath ( (<.>) )
 import System.IO (hClose, localeEncoding, hPutStrLn)
 import System.IO.Error
 import qualified Control.Exception as Exception
@@ -84,6 +87,10 @@ rawSystemStdInOutTextDecodingTest ghcPath
     Left err | isDoesNotExistError err -> Exception.throwIO err -- no ghc!
              | otherwise               -> return ()
 
+dropExeExtensionTest :: Assertion
+dropExeExtensionTest =
+  assertBool "dropExeExtension didn't drop exeExtension!" $
+    dropExeExtension ("foo" <.> exeExtension buildPlatform) == "foo"
 
 
 tests :: FilePath -> [TestTree]
@@ -98,4 +105,6 @@ tests ghcPath =
       withTempDirRemovedTest
     , testCase "rawSystemStdInOut reports text decoding errors" $
       rawSystemStdInOutTextDecodingTest ghcPath
+    , testCase "dropExeExtension drops exe extension" $
+      dropExeExtensionTest
     ]


### PR DESCRIPTION
On Windows dropExeExtension doesn't actually drop the exe extension.

We have

    splitExtension "foo.exe" == ("foo", ".exe")

but the code is expecting just `"exe"` for the extension field.

Among other things this makes `guessToolFromGhcPath` behave
unexpectedly. Since `takeVersionSuffix` can't see past the extension the
`null suf` case in `mkGuesses` will trigger which causes the versioned
program path candidates to not be looked for.

---
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
