### PR TITLE
Allow preprocessor-specific reorderings

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,6 +1,7 @@
 # 3.1.0.0 (current development version)
   * `cabal check` verifies `cpp-options` more pedantically, allowing only
     options starting with `-D` and `-U`.
+  * A `PreProcessor` can define a function to sort modules
   * TODO
 
  ----

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -118,7 +118,7 @@ data PreProcessor = PreProcessor {
                   -> Verbosity -- verbosity
                   -> IO (),    -- Should exit if the preprocessor fails
 
-  reorderPreProcessorDeps :: [FilePath] -- ^ Source directories
+  reorderPreProcessorDeps :: [FilePath] -- Source directories
                           -> Verbosity
                           -> [ModuleName]
                           -> IO [ModuleName] -- Should fail with a warning if dependency resolution fails

--- a/cabal-testsuite/PackageTests/CustomPreProcess/Setup.hs
+++ b/cabal-testsuite/PackageTests/CustomPreProcess/Setup.hs
@@ -19,7 +19,8 @@ main = defaultMainWithHooks
         platformIndependent = True,
         runPreProcessor = mkSimplePreProcessor $ \inFile outFile verbosity ->
           do info verbosity ("Preprocessing " ++ inFile ++ " to " ++ outFile)
-             callProcess progPath [inFile, outFile]
+             callProcess progPath [inFile, outFile],
+        reorderPreProcessDeps = unorderedPreProcessor
         }
       where
         builddir = buildDir lbi

--- a/cabal-testsuite/PackageTests/CustomPreProcess/Setup.hs
+++ b/cabal-testsuite/PackageTests/CustomPreProcess/Setup.hs
@@ -20,7 +20,7 @@ main = defaultMainWithHooks
         runPreProcessor = mkSimplePreProcessor $ \inFile outFile verbosity ->
           do info verbosity ("Preprocessing " ++ inFile ++ " to " ++ outFile)
              callProcess progPath [inFile, outFile],
-        reorderPreProcessDeps = unorderedPreProcessor
+        reorderPreProcessorDeps = unorderedPreProcessor
         }
       where
         builddir = buildDir lbi


### PR DESCRIPTION
This is a slimmed-down version of https://github.com/haskell/cabal/pull/6233 that allows users to define a reordering function when they define a pre-processor, based on @DanielG's suggestion. 

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

This was not tested; I do know it "intervenes" in the right place by the past pull request. It is one step towards handling `c2hs` correctly. 
