### PR TITLE
Use ghc as the linker with hsc2hs

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,6 +1,7 @@
 # 3.1.0.0 (current development version)
   * `cabal check` verifies `cpp-options` more pedantically, allowing only
     options starting with `-D` and `-U`.
+  * Added `hsc2hs-options`, for specifying additional options to pass to `hsc2hs`
   * TODO
 
  ----

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -395,6 +395,7 @@ buildInfoFieldGrammar = BuildInfo
     <*> monoidalFieldAla "cxx-options"          (alaList' NoCommaFSep Token') L.cxxOptions
         ^^^ availableSince CabalSpecV2_2 []
     <*> monoidalFieldAla "ld-options"           (alaList' NoCommaFSep Token') L.ldOptions
+    <*> monoidalFieldAla "hsc2hs-options"       (alaList' NoCommaFSep Token') L.hsc2hsOptions
     <*> monoidalFieldAla "pkgconfig-depends"    (alaList  CommaFSep)          L.pkgconfigDepends
     <*> monoidalFieldAla "frameworks"           (alaList' FSep Token)         L.frameworks
     <*> monoidalFieldAla "extra-framework-dirs" (alaList' FSep FilePathNT)    L.extraFrameworkDirs

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -424,11 +424,8 @@ ppHsc2hs bi lbi clbi =
     -- directly, or via a response file.
     genPureArgs :: ConfiguredProgram -> String -> String -> [String]
     genPureArgs gccProg inFile outFile =
-          [ "--cc=" ++ programPath gccProg
-          , "--ld=" ++ programPath gccProg ]
-
           -- Additional gcc options
-       ++ [ "--cflag=" ++ opt | opt <- programDefaultArgs  gccProg
+          [ "--cflag=" ++ opt | opt <- programDefaultArgs  gccProg
                                     ++ programOverrideArgs gccProg ]
        ++ [ "--lflag=" ++ opt | opt <- programDefaultArgs  gccProg
                                     ++ programOverrideArgs gccProg ]
@@ -486,6 +483,14 @@ ppHsc2hs bi lbi clbi =
                                  , opt <- Installed.libraryDirs    pkg ]
                 ++ [ "-l" ++ opt | opt <- Installed.extraLibraries pkg ]
                 ++ [         opt | opt <- Installed.ldOptions      pkg ] ]
+       ++ hsc2hsOptions bi
+
+          -- hsc2hs flag parsing is wrong (see
+          -- https://github.com/haskell/hsc2hs/issues/35) so we need to put
+          -- --cc/--ld *after* hsc2hsOptions so that they can be overridden.
+       ++ [ "--cc=" ++ programPath gccProg
+          , "--ld=" ++ programPath gccProg ]
+
        ++ ["-o", outFile, inFile]
 
     hacked_index = packageHacks (installedPkgs lbi)

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -16,6 +16,7 @@ module Distribution.Simple.Program.GHC (
 
     runGHC,
 
+    packageDbArgs,
     packageDbArgsDb,
     normaliseGhcArgs
 

--- a/Cabal/Distribution/Types/BuildInfo.hs
+++ b/Cabal/Distribution/Types/BuildInfo.hs
@@ -56,6 +56,7 @@ data BuildInfo = BuildInfo {
         ccOptions         :: [String],  -- ^ options for C compiler
         cxxOptions        :: [String],  -- ^ options for C++ compiler
         ldOptions         :: [String],  -- ^ options for linker
+        hsc2hsOptions     :: [String],  -- ^ options for hsc2hs
         pkgconfigDepends  :: [PkgconfigDependency], -- ^ pkg-config packages that are used
         frameworks        :: [String], -- ^support frameworks for Mac OS X
         extraFrameworkDirs:: [String], -- ^ extra locations to find frameworks.
@@ -123,6 +124,7 @@ instance Monoid BuildInfo where
     ccOptions           = [],
     cxxOptions          = [],
     ldOptions           = [],
+    hsc2hsOptions       = [],
     pkgconfigDepends    = [],
     frameworks          = [],
     extraFrameworkDirs  = [],
@@ -171,6 +173,7 @@ instance Semigroup BuildInfo where
     ccOptions           = combine    ccOptions,
     cxxOptions          = combine    cxxOptions,
     ldOptions           = combine    ldOptions,
+    hsc2hsOptions       = combine    hsc2hsOptions,
     pkgconfigDepends    = combine    pkgconfigDepends,
     frameworks          = combineNub frameworks,
     extraFrameworkDirs  = combineNub extraFrameworkDirs,

--- a/Cabal/Distribution/Types/BuildInfo/Lens.hs
+++ b/Cabal/Distribution/Types/BuildInfo/Lens.hs
@@ -60,6 +60,10 @@ class HasBuildInfo a where
    ldOptions = buildInfo . ldOptions
    {-# INLINE ldOptions #-}
 
+   hsc2hsOptions :: Lens' a [String]
+   hsc2hsOptions = buildInfo . hsc2hsOptions
+   {-# INLINE hsc2hsOptions #-}
+
    pkgconfigDepends :: Lens' a [PkgconfigDependency]
    pkgconfigDepends = buildInfo . pkgconfigDepends
    {-# INLINE pkgconfigDepends #-}
@@ -227,6 +231,9 @@ instance HasBuildInfo BuildInfo where
 
     ldOptions f s = fmap (\x -> s { T.ldOptions = x }) (f (T.ldOptions s))
     {-# INLINE ldOptions #-}
+
+    hsc2hsOptions f s = fmap (\x -> s { T.hsc2hsOptions = x }) (f (T.hsc2hsOptions s))
+    {-# INLINE hsc2hsOptions #-}
 
     pkgconfigDepends f s = fmap (\x -> s { T.pkgconfigDepends = x }) (f (T.pkgconfigDepends s))
     {-# INLINE pkgconfigDepends #-}

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2576,6 +2576,11 @@ system-dependent values for these fields.
     arguments are compiler-dependent, this field is more useful with the
     setup described in the section on `system-dependent parameters`_.
 
+.. pkg-field:: hsc2hs-options: token list
+    :since 3.1
+
+    Command-line arguments to be passed to hsc2hs.
+
 .. pkg-field:: pkgconfig-depends: package list
 
     A list of


### PR DESCRIPTION
(Note that this depends on https://github.com/haskell/cabal/pull/6295 and includes that commit)

This enables hsc2hs to depend on Haskell code via foreign export. I have
an upcoming use case that requires this.

Should we make this optional? I'm hoping we can get away without adding
an option, because it shouldn't break any existing uses: using GHC as
the linker only provides access to more symbols, which shouldn't break
anything provided the libraries that GHC adds don't shadow anything,
which should be the case.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
