### PR TITLE
Correct store-dir dir in ghc env files generated by `cabal install --lib --package-env`

### DIFF
--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -458,6 +458,9 @@ installAction ( configFlags, configExFlags, installFlags
   home <- getHomeDirectory
   let
     ProjectConfig {
+      projectConfigBuildOnly = ProjectConfigBuildOnly {
+        projectConfigLogsDir
+      },
       projectConfigShared = ProjectConfigShared {
         projectConfigHcFlavor,
         projectConfigHcPath,
@@ -532,7 +535,7 @@ installAction ( configFlags, configExFlags, installFlags
   mstoreDir <-
     sequenceA $ makeAbsolute <$> flagToMaybe projectConfigStoreDir
   let
-    mlogsDir    = flagToMaybe (globalLogsDir globalFlags)
+    mlogsDir    = flagToMaybe projectConfigLogsDir
     cabalLayout = mkCabalDirLayout cabalDir mstoreDir mlogsDir
     packageDbs  = storePackageDBStack (cabalStoreDirLayout cabalLayout) compilerId
 

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -461,7 +461,8 @@ installAction ( configFlags, configExFlags, installFlags
       projectConfigShared = ProjectConfigShared {
         projectConfigHcFlavor,
         projectConfigHcPath,
-        projectConfigHcPkg
+        projectConfigHcPkg,
+        projectConfigStoreDir
       },
       projectConfigLocalPackages = PackageConfig {
         packageConfigProgramPaths,
@@ -529,7 +530,7 @@ installAction ( configFlags, configExFlags, installFlags
 
   cabalDir  <- getCabalDir
   mstoreDir <-
-    sequenceA $ makeAbsolute <$> flagToMaybe (globalStoreDir globalFlags)
+    sequenceA $ makeAbsolute <$> flagToMaybe projectConfigStoreDir
   let
     mlogsDir    = flagToMaybe (globalLogsDir globalFlags)
     cabalLayout = mkCabalDirLayout cabalDir mstoreDir mlogsDir


### PR DESCRIPTION
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [X] The documentation has been updated, if necessary.

It should fix #5925 and help to fix https://github.com/DanielG/cabal-helper/issues/83

Tested manually running the command and check that the package env file contains the custom `store-dir`:

```shell
PS D:\dev\ws\haskell\cabal-test> cabal install --lib --package-env .
Wrote tarball sdist to
D:\dev\ws\haskell\cabal-test\dist-newstyle\sdist\cabal-test-0.1.0.0.tar.gz
Resolving dependencies...
Up to date
PS D:\dev\ws\haskell\cabal-test> type .\.ghc.environment.x86_64-mingw32-8.6.5
clear-package-db
global-package-db
package-db C:\Users\atrey\AppData\Roaming\cabal\store\ghc-8.6.5\package.db
package-id ghc-8.6.5
....
PS D:\dev\ws\haskell\cabal-test> D:\bin\cabals\3.1.0.0\cabal install --lib --package-env .
Wrote tarball sdist to
D:\dev\ws\haskell\cabal-test\dist-newstyle\sdist\cabal-test-0.1.0.0.tar.gz
Resolving dependencies...
Up to date
PS D:\dev\ws\haskell\cabal-test> type .\.ghc.environment.x86_64-mingw32-8.6.5
clear-package-db
global-package-db
package-db C:\sd\ghc-8.6.5\package.db
....
```

