### PR TITLE
Accept "linux-androideabi" as an alias for Android

### DIFF
--- a/Cabal/Distribution/System.hs
+++ b/Cabal/Distribution/System.hs
@@ -122,7 +122,8 @@ osAliases Permissive FreeBSD = ["kfreebsdgnu"]
 osAliases Compat     FreeBSD = ["kfreebsdgnu"]
 osAliases Permissive Solaris = ["solaris2"]
 osAliases Compat     Solaris = ["solaris2"]
-osAliases _          Android = ["linux-android"]
+osAliases Permissive Android = ["linux-android", "linux-androideabi", "linux-androideabihf"]
+osAliases Compat     Android = ["linux-android"]
 osAliases _          _       = []
 
 instance Pretty OS where


### PR DESCRIPTION
Google uses `armv7-none-linux-androideabi`, analogous to
`armv7-unknown-linux-gnueabi` for e.g. a 32-bit regular linux.

The existing alias it not a mistake, it is the right one for 64 bit.
Google for that use `aarch64-linux-android`, analogous to
`aarch64-unknown-linux-android` for a 64-bi regular linux.

See https://developer.android.com/ndk/guides/standalone_toolchain for
evidence/details.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
