### PR TITLE
Add with-compiler field for cabal scripts

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -443,6 +443,7 @@ library
     Distribution.Types.UnqualComponentName
     Distribution.Types.IncludeRenaming
     Distribution.Types.Mixin
+    Distribution.Types.Script
     Distribution.Types.SetupBuildInfo
     Distribution.Types.TestSuite
     Distribution.Types.TestSuiteInterface
@@ -521,6 +522,7 @@ library
     Distribution.Types.Library.Lens
     Distribution.Types.PackageDescription.Lens
     Distribution.Types.PackageId.Lens
+    Distribution.Types.Script.Lens
     Distribution.Types.SetupBuildInfo.Lens
     Distribution.Types.SourceRepo.Lens
     Distribution.Types.TestSuite.Lens

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -555,3 +555,4 @@ scriptFieldGrammar = Script
     <*> optionalFieldAla "with-compiler" FilePathNT L.hcPath
 {-# SPECIALIZE scriptFieldGrammar :: ParsecFieldGrammar' Script #-}
 {-# SPECIALIZE scriptFieldGrammar :: PrettyFieldGrammar' Script #-}
+

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -37,6 +37,8 @@ module Distribution.PackageDescription.FieldGrammar (
     setupBInfoFieldGrammar,
     -- * Component build info
     buildInfoFieldGrammar,
+    -- * Script
+    scriptFieldGrammar
     ) where
 
 import Distribution.Compat.Lens
@@ -57,6 +59,7 @@ import Distribution.Types.ExecutableScope
 import Distribution.Types.ForeignLib
 import Distribution.Types.ForeignLibType
 import Distribution.Types.LibraryVisibility
+import Distribution.Types.Script
 import Distribution.Types.UnqualComponentName
 import Distribution.Version                   (anyVersion)
 
@@ -539,3 +542,16 @@ setupBInfoFieldGrammar def = flip SetupBuildInfo def
     <$> monoidalFieldAla "setup-depends" (alaList CommaVCat) L.setupDepends
 {-# SPECIALIZE setupBInfoFieldGrammar :: Bool -> ParsecFieldGrammar' SetupBuildInfo #-}
 {-# SPECIALIZE setupBInfoFieldGrammar :: Bool ->PrettyFieldGrammar' SetupBuildInfo #-}
+
+-------------------------------------------------------------------------------
+-- Script
+-------------------------------------------------------------------------------
+
+scriptFieldGrammar
+    :: (FieldGrammar g, Applicative (g Script), Applicative (g Executable), Applicative (g BuildInfo))
+    => g Script Script
+scriptFieldGrammar = Script
+    <$> blurFieldGrammar L.executable (executableFieldGrammar "script")
+    <*> optionalFieldAla "with-compiler" FilePathNT L.hcPath
+{-# SPECIALIZE scriptFieldGrammar :: ParsecFieldGrammar' Script #-}
+{-# SPECIALIZE scriptFieldGrammar :: PrettyFieldGrammar' Script #-}

--- a/Cabal/Distribution/Types/Lens.hs
+++ b/Cabal/Distribution/Types/Lens.hs
@@ -7,6 +7,7 @@ module Distribution.Types.Lens (
     module Distribution.Types.Library.Lens,
     module Distribution.Types.PackageDescription.Lens,
     module Distribution.Types.PackageId.Lens,
+    module Distribution.Types.Script.Lens,
     module Distribution.Types.SetupBuildInfo.Lens,
     module Distribution.Types.SourceRepo.Lens,
     module Distribution.Types.TestSuite.Lens,
@@ -20,6 +21,7 @@ import Distribution.Types.GenericPackageDescription.Lens
 import Distribution.Types.Library.Lens
 import Distribution.Types.PackageDescription.Lens
 import Distribution.Types.PackageId.Lens
+import Distribution.Types.Script.Lens
 import Distribution.Types.SetupBuildInfo.Lens
 import Distribution.Types.SourceRepo.Lens
 import Distribution.Types.TestSuite.Lens

--- a/Cabal/Distribution/Types/Script.hs
+++ b/Cabal/Distribution/Types/Script.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+module Distribution.Types.Script (
+    Script(..)
+) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+import Distribution.Types.Executable
+
+data Script = Script {
+    executable :: Executable,
+    hcPath :: Maybe FilePath
+    }
+    deriving (Generic, Show, Read, Eq, Typeable)

--- a/Cabal/Distribution/Types/Script.hs
+++ b/Cabal/Distribution/Types/Script.hs
@@ -14,3 +14,4 @@ data Script = Script {
     hcPath :: Maybe FilePath
     }
     deriving (Generic, Show, Read, Eq, Typeable)
+

--- a/Cabal/Distribution/Types/Script/Lens.hs
+++ b/Cabal/Distribution/Types/Script/Lens.hs
@@ -1,0 +1,21 @@
+module Distribution.Types.Script.Lens (
+    Script,
+    module Distribution.Types.Script.Lens,
+    ) where
+
+import Distribution.Compat.Lens
+import Distribution.Compat.Prelude
+import Prelude ()
+
+import Distribution.Types.Executable          (Executable)
+import Distribution.Types.Script              (Script)
+
+import qualified Distribution.Types.Script as T
+
+executable :: Lens' Script Executable
+executable f s = fmap (\x -> s { T.executable = x }) (f (T.executable s))
+{-# INLINE executable #-}
+
+hcPath :: Lens' Script (Maybe FilePath)
+hcPath f s = fmap (\x -> s { T.hcPath = x }) (f (T.hcPath s))
+{-# INLINE hcPath #-}

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -462,7 +462,6 @@ a script that looks like:
     {- cabal:
     build-depends: base ^>= 4.11
                 , shelly ^>= 1.8.1
-    with-compiler: ghc-8.8.1
     -}
 
     main :: IO ()
@@ -476,6 +475,12 @@ interpreter, or through this command:
 
     $ cabal v2-run script.hs
     $ cabal v2-run script.hs -- --arg1 # args are passed like this
+
+Supported fields include:
+
+- ``build-depends``
+
+- ``with-compiler``
 
 cabal v2-freeze
 ----------------

--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -462,6 +462,7 @@ a script that looks like:
     {- cabal:
     build-depends: base ^>= 4.11
                 , shelly ^>= 1.8.1
+    with-compiler: ghc-8.8.1
     -}
 
     main :: IO ()

--- a/cabal-install/Distribution/Client/CmdRun.hs
+++ b/cabal-install/Distribution/Client/CmdRun.hs
@@ -70,7 +70,7 @@ import Distribution.Client.Types
 import Distribution.FieldGrammar
          ( takeFields, parseFieldGrammar )
 import Distribution.PackageDescription.FieldGrammar
-         ( executableFieldGrammar, scriptFieldGrammar )
+         ( scriptFieldGrammar )
 import Distribution.PackageDescription.PrettyPrint
          ( writeGenericPackageDescription )
 import Distribution.Parsec
@@ -445,7 +445,8 @@ handleScriptCase verbosity pol baseCtx tempDir scriptContents = do
   let
     projectConfigShared' :: ProjectConfigShared
     projectConfigShared' = (projectConfigShared (projectConfig baseCtx))
-      { projectConfigHcPath = maybeToFlag hcPath
+      { projectConfigHcPath = (maybeToFlag hcPath) <>
+                              projectConfigHcPath (projectConfigShared (projectConfig baseCtx))
       }
     baseCtx' = baseCtx
       { localPackages = localPackages baseCtx ++ [SpecificSourcePackage sourcePackage]

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -4,6 +4,7 @@
 	* `v2-build` (and other `v2-`prefixed commands) now accept the
 	  `--benchmark-option(s)` flags, which pass options to benchmark executables
 	  (analogous to how `--test-option(s)` works). (#6209)
+	* `v2-run` can now read a `with-compiler` flag in the metadata field
 
 3.0.0.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> August 2019
 	* Parse comma-separated lists for extra-prog-path, extra-lib-dirs, extra-framework-dirs,

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -4,7 +4,7 @@
 	* `v2-build` (and other `v2-`prefixed commands) now accept the
 	  `--benchmark-option(s)` flags, which pass options to benchmark executables
 	  (analogous to how `--test-option(s)` works). (#6209)
-	* `v2-run` can now read a `with-compiler` flag in the metadata field
+	* `v2-run` can now read a `with-compiler` flag in the script metadata field
 
 3.0.0.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> August 2019
 	* Parse comma-separated lists for extra-prog-path, extra-lib-dirs, extra-framework-dirs,


### PR DESCRIPTION
Adds a new data type and field grammar for parsing script metadata.
Now it is possible to have scripts like:

```haskell
#!/usr/bin/env cabal
{- cabal:
build-depends: base
with-compiler: ghc-8.6.5
-}
main = putStrLn "hey"
```

Progresses towards #5698

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!