### PR TITLE
Start GHCi with the main module in scope

### DIFF
--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -745,8 +745,10 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
   ---------------
   -- Inputs
 
-  , [ prettyShow modu | modu <- flags ghcOptInputModules ]
+  -- Specify the input file(s) first, so that in ghci the `main-is` module is
+  -- in scope instead of the first module defined in `other-modules`.
   , flags ghcOptInputFiles
+  , [ prettyShow modu | modu <- flags ghcOptInputModules ]
 
   , concat [ [ "-o",    out] | out <- flag ghcOptOutputFile ]
   , concat [ [ "-dyno", out] | out <- flag ghcOptOutputDynFile ]


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Fixes #5103.

I tested this change by locally building cabal-install, running it in a project whose `test-suite` has `other-modules` and asserting that the main module was in scope in the REPL.  I would love to make that a test, but I would need a little guidance (and/or prior art).

I'm also not sure if this is changelog worthy and/or if there is documentation to change or add to.  Please advise as I'd be happy to add these.

More generally, this is my first cabal PR (edit: nvm, second, after #5943 🙂) and I'm still ramping up in Haskell, so any feedback is welcome.