### PR TITLE
.travis.yml: Allow forks to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,9 @@ dist: trusty
 sudo: true
 
 # We whitelist branches, as we don't really need to build dev-branches.
+# Except if those branches are in a fork.
 # Remember to add release branches, both here and to appveyor.yml.
-branches:
-  only:
-    - master
-    - "3.0"
-    - "2.4"
-    - "2.2"
-    - "2.0"
-    - "1.24"
-    - "1.22"
-    - "1.20"
-    - "1.18"
+if: branch IN (master, 3.0, 2.4, 2.2, 2.0, 1.24, 1.22, 1.20, 1.18) OR repo != haskell/cabal
 
 # The following enables several GHC versions to be tested; often it's enough to
 # test only against the last release in a major GHC version. Feel free to omit
@@ -177,6 +168,9 @@ after_success:
 
 notifications:
   irc:
+    if: repo = haskell/cabal
     channels:
       - "chat.freenode.net##haskell-cabal"
-  slack: haskell-cabal:sCq6GLfy9N8MJrInosg871n4
+  slack:
+    if: repo = haskell/cabal
+    rooms: haskell-cabal:sCq6GLfy9N8MJrInosg871n4


### PR DESCRIPTION
But then exclude builds in forks from the notifications.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] ~Any changes that could be relevant to users have been recorded in the changelog.~
* [x] ~The documentation has been updated, if necessary.~
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

In terms of testing, the `if` condition I'm fairly confident about, as it's a simpler version of a version I use at work.  Also it triggered https://travis-ci.com/dwijnand/cabal/builds/133725400 to build.

Regarding the notification changes, I believe them to be correct, using https://docs.travis-ci.com/user/notifications#conditional-notifications as reference.  However, using https://config.travis-ci.com/explore it complains that:

    [alert] on notifications.slack.rooms: expected an encrypted string

So perhaps someone should double-check that builds are still notified if this PR lands.

(Btw, I'm getting a "Failed! token_revoked" error message when trying to use https://haskell-cabal.herokuapp.com/.  May I join the Slack team some other way?)