### PR TITLE
Reduce CI matrix for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,15 +69,19 @@ matrix:
    - env: GHCVER=8.4.4 SCRIPT=solver-debug-flags USE_GOLD=YES
      sudo: required
      os: linux
+     if: type != pull_request
    - env: GHCVER=8.4.4 SCRIPT=script DEBUG_EXPENSIVE_ASSERTIONS=YES TAGSUFFIX="-fdebug-expensive-assertions" USE_GOLD=YES
      os: linux
      sudo: required
+     if: type != pull_request
    - env: GHCVER=8.0.2 SCRIPT=bootstrap USE_GOLD=YES
      sudo: required
      os: linux
+     if: type != pull_request
    - env: GHCVER=8.4.4 SCRIPT=bootstrap USE_GOLD=YES
      sudo: required
      os: linux
+     if: type != pull_request
 
    # We axed GHC 7.6 and earlier because it's not worth the trouble to
    # make older GHC work with clang's cpp.  See
@@ -86,15 +90,18 @@ matrix:
      os: osx
      # Keep this synced with travis/upload.sh
      osx_image: xcode6.4 # We need 10.10
+     if: type != pull_request
 
    # TODO: We might want to specify OSX version
    # https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version
    - env: GHCVER=7.10.3 SCRIPT=script
      os: osx
+     if: type != pull_request
    - env: GHCVER=8.0.2 SCRIPT=script
      os: osx
    - env: GHCVER=8.0.2 SCRIPT=bootstrap
      os: osx
+     if: type != pull_request
 
   # It's been long known that CI with
   # Stack does not work so it's disabled until further notice


### PR DESCRIPTION
Fixes #4384

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] ~Any changes that could be relevant to users have been recorded in the changelog.~
* [x] ~The documentation has been updated, if necessary.~
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

The ticket (#4384) mentions:

> we should have some mechanism for triggering the extra tests in PR if a user wants them (e.g., a high risk commit.)

I'm thinking that for high risk commits perhaps calling the API to trigger an "api"-type build (as opposed to a "pull_request"-type build) would run the additional jobs.  WDYT?