### PR TITLE
Use Data.List.NonEmpty and avoid some partial functions

### DIFF
--- a/Cabal/Distribution/Backpack/ComponentsGraph.hs
+++ b/Cabal/Distribution/Backpack/ComponentsGraph.hs
@@ -8,7 +8,7 @@ module Distribution.Backpack.ComponentsGraph (
     componentCycleMsg
 ) where
 
-import Prelude ()
+import Prelude (head)
 import Distribution.Compat.Prelude
 
 import Distribution.Package

--- a/Cabal/Distribution/Compat/DList.hs
+++ b/Cabal/Distribution/Compat/DList.hs
@@ -19,7 +19,7 @@ module Distribution.Compat.DList (
 ) where
 
 import Prelude ()
-import Distribution.Compat.Prelude
+import Distribution.Compat.Prelude hiding (toList)
 
 -- | Difference list.
 newtype DList a = DList ([a] -> [a])

--- a/Cabal/Distribution/Compat/Graph.hs
+++ b/Cabal/Distribution/Compat/Graph.hs
@@ -85,7 +85,7 @@ module Distribution.Compat.Graph (
 
 import Prelude ()
 import qualified Distribution.Compat.Prelude as Prelude
-import Distribution.Compat.Prelude hiding (lookup, null, empty)
+import Distribution.Compat.Prelude hiding (lookup, null, empty, toList)
 
 import Data.Graph (SCC(..))
 import qualified Data.Graph as G

--- a/Cabal/Distribution/Compat/Parsing.hs
+++ b/Cabal/Distribution/Compat/Parsing.hs
@@ -25,12 +25,9 @@ module Distribution.Compat.Parsing
   , some     -- from Control.Applicative, parsec many1
   , many     -- from Control.Applicative
   , sepBy
-  , sepBy1
   , sepByNonEmpty
-  , sepEndBy1
   , sepEndByNonEmpty
   , sepEndBy
-  , endBy1
   , endByNonEmpty
   , endBy
   , count
@@ -97,26 +94,14 @@ between bra ket p = bra *> p <* ket
 --
 -- >  commaSep p  = p `sepBy` (symbol ",")
 sepBy :: Alternative m => m a -> m sep -> m [a]
-sepBy p sep = sepBy1 p sep <|> pure []
+sepBy p sep = toList <$> sepByNonEmpty p sep <|> pure []
 {-# INLINE sepBy #-}
-
--- | @sepBy1 p sep@ parses /one/ or more occurrences of @p@, separated
--- by @sep@. Returns a list of values returned by @p@.
-sepBy1 :: Alternative m => m a -> m sep -> m [a]
-sepBy1 p sep = toList <$> sepByNonEmpty p sep
-{-# INLINE sepBy1 #-}
 
 -- | @sepByNonEmpty p sep@ parses /one/ or more occurrences of @p@, separated
 -- by @sep@. Returns a non-empty list of values returned by @p@.
 sepByNonEmpty :: Alternative m => m a -> m sep -> m (NonEmpty a)
 sepByNonEmpty p sep = (:|) <$> p <*> many (sep *> p)
 {-# INLINE sepByNonEmpty #-}
-
--- | @sepEndBy1 p sep@ parses /one/ or more occurrences of @p@,
--- separated and optionally ended by @sep@. Returns a list of values
--- returned by @p@.
-sepEndBy1 :: Alternative m => m a -> m sep -> m [a]
-sepEndBy1 p sep = toList <$> sepEndByNonEmpty p sep
 
 -- | @sepEndByNonEmpty p sep@ parses /one/ or more occurrences of @p@,
 -- separated and optionally ended by @sep@. Returns a non-empty list of values
@@ -130,14 +115,8 @@ sepEndByNonEmpty p sep = (:|) <$> p <*> ((sep *> sepEndBy p sep) <|> pure [])
 --
 -- >  haskellStatements  = haskellStatement `sepEndBy` semi
 sepEndBy :: Alternative m => m a -> m sep -> m [a]
-sepEndBy p sep = sepEndBy1 p sep <|> pure []
+sepEndBy p sep = toList <$> sepEndByNonEmpty p sep <|> pure []
 {-# INLINE sepEndBy #-}
-
--- | @endBy1 p sep@ parses /one/ or more occurrences of @p@, separated
--- and ended by @sep@. Returns a list of values returned by @p@.
-endBy1 :: Alternative m => m a -> m sep -> m [a]
-endBy1 p sep = some (p <* sep)
-{-# INLINE endBy1 #-}
 
 -- | @endByNonEmpty p sep@ parses /one/ or more occurrences of @p@, separated
 -- and ended by @sep@. Returns a non-empty list of values returned by @p@.

--- a/Cabal/Distribution/Compat/Parsing.hs
+++ b/Cabal/Distribution/Compat/Parsing.hs
@@ -28,10 +28,10 @@ module Distribution.Compat.Parsing
   , sepBy1
   , sepByNonEmpty
   , sepEndBy1
-  -- , sepEndByNonEmpty
+  , sepEndByNonEmpty
   , sepEndBy
   , endBy1
-  -- , endByNonEmpty
+  , endByNonEmpty
   , endBy
   , count
   , chainl
@@ -58,6 +58,7 @@ import Control.Monad.Trans.Reader (ReaderT (..))
 import Control.Monad.Trans.Identity (IdentityT (..))
 import Data.Foldable (asum)
 
+import qualified Data.List.NonEmpty as NE
 import qualified Text.Parsec as Parsec
 
 -- | @choice ps@ tries to apply the parsers in the list @ps@ in order,
@@ -102,8 +103,7 @@ sepBy p sep = sepBy1 p sep <|> pure []
 -- | @sepBy1 p sep@ parses /one/ or more occurrences of @p@, separated
 -- by @sep@. Returns a list of values returned by @p@.
 sepBy1 :: Alternative m => m a -> m sep -> m [a]
-sepBy1 p sep = (:) <$> p <*> many (sep *> p)
--- toList <$> sepByNonEmpty p sep
+sepBy1 p sep = toList <$> sepByNonEmpty p sep
 {-# INLINE sepBy1 #-}
 
 -- | @sepByNonEmpty p sep@ parses /one/ or more occurrences of @p@, separated
@@ -116,16 +116,13 @@ sepByNonEmpty p sep = (:|) <$> p <*> many (sep *> p)
 -- separated and optionally ended by @sep@. Returns a list of values
 -- returned by @p@.
 sepEndBy1 :: Alternative m => m a -> m sep -> m [a]
-sepEndBy1 p sep = (:) <$> p <*> ((sep *> sepEndBy p sep) <|> pure [])
--- toList <$> sepEndByNonEmpty p sep
+sepEndBy1 p sep = toList <$> sepEndByNonEmpty p sep
 
-{-
 -- | @sepEndByNonEmpty p sep@ parses /one/ or more occurrences of @p@,
 -- separated and optionally ended by @sep@. Returns a non-empty list of values
 -- returned by @p@.
 sepEndByNonEmpty :: Alternative m => m a -> m sep -> m (NonEmpty a)
 sepEndByNonEmpty p sep = (:|) <$> p <*> ((sep *> sepEndBy p sep) <|> pure [])
--}
 
 -- | @sepEndBy p sep@ parses /zero/ or more occurrences of @p@,
 -- separated and optionally ended by @sep@, ie. haskell style
@@ -142,13 +139,11 @@ endBy1 :: Alternative m => m a -> m sep -> m [a]
 endBy1 p sep = some (p <* sep)
 {-# INLINE endBy1 #-}
 
-{-
 -- | @endByNonEmpty p sep@ parses /one/ or more occurrences of @p@, separated
 -- and ended by @sep@. Returns a non-empty list of values returned by @p@.
 endByNonEmpty :: Alternative m => m a -> m sep -> m (NonEmpty a)
-endByNonEmpty p sep = some1 (p <* sep)
+endByNonEmpty p sep = NE.some1 (p <* sep)
 {-# INLINE endByNonEmpty #-}
--}
 
 -- | @endBy p sep@ parses /zero/ or more occurrences of @p@, separated
 -- and ended by @sep@. Returns a list of values returned by @p@.

--- a/Cabal/Distribution/Compat/Prelude.hs
+++ b/Cabal/Distribution/Compat/Prelude.hs
@@ -71,6 +71,7 @@ module Distribution.Compat.Prelude (
     find, foldl',
     traverse_, for_,
     any, all,
+    toList,
 
     -- * Data.Traversable
     Traversable, traverse, sequenceA,
@@ -103,7 +104,7 @@ module Distribution.Compat.Prelude (
     ) where
 -- We also could hide few partial function
 import Prelude                       as BasePrelude hiding
-  ( IO, mapM, mapM_, sequence, null, length, foldr, any, all
+  ( IO, mapM, mapM_, sequence, null, length, foldr, any, all, head, tail, last, init
   -- partial functions
   , read
   , foldr1, foldl1
@@ -123,8 +124,9 @@ import Prelude                       as BasePrelude hiding
 #if !MINVER_base_48
 import Control.Applicative           (Applicative (..), (<$), (<$>))
 import Distribution.Compat.Semigroup (Monoid (..))
+import Data.Foldable                 (toList)
 #else
-import Data.Foldable                 (length, null)
+import Data.Foldable                 (length, null, Foldable(toList))
 #endif
 
 import Data.Foldable                 (Foldable (foldMap, foldr), find, foldl', for_, traverse_, any, all)

--- a/Cabal/Distribution/ModuleName.hs
+++ b/Cabal/Distribution/ModuleName.hs
@@ -50,7 +50,7 @@ instance Pretty ModuleName where
     Disp.hcat (intersperse (Disp.char '.') (map Disp.text $ stlToStrings ms))
 
 instance Parsec ModuleName where
-    parsec = fromComponents <$> P.sepBy1 component (P.char '.')
+    parsec = fromComponents <$> toList <$> P.sepByNonEmpty component (P.char '.')
       where
         component = do
             c  <- P.satisfy isUpper

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -34,7 +34,7 @@ module Distribution.PackageDescription.Check (
   ) where
 
 import Distribution.Compat.Prelude
-import Prelude ()
+import Prelude (last, init)
 
 import Control.Monad                                 (mapM)
 import Data.List                                     (group)

--- a/Cabal/Distribution/Parsec.hs
+++ b/Cabal/Distribution/Parsec.hs
@@ -259,8 +259,8 @@ parsecLeadingCommaList :: CabalParsing m => m a -> m [a]
 parsecLeadingCommaList p = do
     c <- P.optional comma
     case c of
-        Nothing -> P.sepEndBy1 lp comma <|> pure []
-        Just _  -> P.sepBy1 lp comma
+        Nothing -> toList <$> P.sepEndByNonEmpty lp comma <|> pure []
+        Just _  -> toList <$> P.sepByNonEmpty lp comma
   where
     lp = p <* P.spaces
     comma = P.char ',' *> P.spaces P.<?> "comma"
@@ -289,7 +289,7 @@ parsecLeadingOptCommaList p = do
     c <- P.optional comma
     case c of
         Nothing -> sepEndBy1Start <|> pure []
-        Just _  -> P.sepBy1 lp comma
+        Just _  -> toList <$> P.sepByNonEmpty lp comma
   where
     lp = p <* P.spaces
     comma = P.char ',' *> P.spaces P.<?> "comma"
@@ -310,7 +310,7 @@ parsecMaybeQuoted :: CabalParsing m => m a -> m a
 parsecMaybeQuoted p = parsecQuoted p <|> p
 
 parsecUnqualComponentName :: CabalParsing m => m String
-parsecUnqualComponentName = intercalate "-" <$> P.sepBy1 component (P.char '-')
+parsecUnqualComponentName = intercalate "-" <$> toList <$> P.sepByNonEmpty component (P.char '-')
   where
     component :: CabalParsing m => m String
     component = do

--- a/Cabal/Distribution/Parsec.hs
+++ b/Cabal/Distribution/Parsec.hs
@@ -268,7 +268,7 @@ parsecLeadingCommaList p = do
 parsecOptCommaList :: CabalParsing m => m a -> m [a]
 parsecOptCommaList p = P.sepBy (p <* P.spaces) (P.optional comma)
   where
-    comma = P.char ',' *>  P.spaces
+    comma = P.char ',' *> P.spaces
 
 -- | Like 'parsecOptCommaList' but
 --

--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -57,7 +57,7 @@ module Distribution.Simple (
 
 import Control.Exception (try)
 
-import Prelude ()
+import Prelude (head)
 import Distribution.Compat.Prelude
 
 -- local

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -28,7 +28,7 @@ module Distribution.Simple.Build (
     writeAutogenFiles,
   ) where
 
-import Prelude ()
+import Prelude (head, init)
 import Distribution.Compat.Prelude
 
 import Distribution.Types.ComponentLocalBuildInfo

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -73,6 +73,7 @@ module Distribution.Simple.Compiler (
 
 import Prelude ()
 import Distribution.Compat.Prelude
+import Distribution.Utils.Generic(safeLast)
 import Distribution.Pretty
 
 import Distribution.Compiler
@@ -197,8 +198,9 @@ type PackageDBStack = [PackageDB]
 -- the top of the stack.
 --
 registrationPackageDB :: PackageDBStack -> PackageDB
-registrationPackageDB []  = error "internal error: empty package db set"
-registrationPackageDB dbs = last dbs
+registrationPackageDB dbs  = case safeLast dbs of
+  Nothing -> error "internal error: empty package db set"
+  Just p  -> p
 
 -- | Make package paths absolute
 

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -54,7 +54,7 @@ module Distribution.Simple.Configure
   , platformDefines,
   ) where
 
-import Prelude ()
+import Prelude (head, tail, last)
 import Distribution.Compat.Prelude
 
 import Distribution.Compiler

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -69,7 +69,7 @@ module Distribution.Simple.GHC (
         GhcImplInfo(..)
  ) where
 
-import Prelude ()
+import Prelude (head, tail)
 import Distribution.Compat.Prelude
 
 import qualified Distribution.Simple.GHC.Internal as Internal

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -37,7 +37,7 @@ module Distribution.Simple.GHCJS (
         GhcImplInfo(..)
  ) where
 
-import Prelude ()
+import Prelude (head)
 import Distribution.Compat.Prelude
 
 import qualified Distribution.Simple.GHC.Internal as Internal
@@ -939,7 +939,7 @@ decodeMainIsArg arg
     splitLongestPrefix :: String -> (Char -> Bool) -> (String,String)
     splitLongestPrefix str pred'
       | null r_pre = (str,           [])
-      | otherwise  = (reverse (tail r_pre), reverse r_suf)
+      | otherwise  = (reverse (safeTail r_pre), reverse r_suf)
                            -- 'tail' drops the char satisfying 'pred'
       where (r_suf, r_pre) = break pred' (reverse str)
 

--- a/Cabal/Distribution/Simple/Glob.hs
+++ b/Cabal/Distribution/Simple/Glob.hs
@@ -37,6 +37,8 @@ import Distribution.Version
 import System.Directory (getDirectoryContents, doesDirectoryExist, doesFileExist)
 import System.FilePath (joinPath, splitExtensions, splitDirectories, takeFileName, (</>), (<.>))
 
+import qualified Data.List.NonEmpty as NE
+
 -- Note throughout that we use splitDirectories, not splitPath. On
 -- Posix, this makes no difference, but, because Windows accepts both
 -- slash and backslash as its path separators, if we left in the
@@ -151,7 +153,7 @@ fileGlobMatchesSegments pat (seg : segs) = case pat of
     fileGlobMatchesSegments pat' segs
   GlobFinal final -> case final of
     FinalMatch Recursive multidot ext -> do
-      let (candidateBase, candidateExts) = splitExtensions (last $ seg:segs)
+      let (candidateBase, candidateExts) = splitExtensions (NE.last $ seg:|segs)
       guard (not (null candidateBase))
       checkExt multidot ext candidateExts
     FinalMatch NonRecursive multidot ext -> do

--- a/Cabal/Distribution/Simple/HaskellSuite.hs
+++ b/Cabal/Distribution/Simple/HaskellSuite.hs
@@ -3,7 +3,7 @@
 
 module Distribution.Simple.HaskellSuite where
 
-import Prelude ()
+import Prelude (last, init)
 import Distribution.Compat.Prelude
 
 import Data.Either (partitionEithers)

--- a/Cabal/Distribution/Simple/PackageIndex.hs
+++ b/Cabal/Distribution/Simple/PackageIndex.hs
@@ -112,6 +112,7 @@ import Data.Array ((!))
 import qualified Data.Array as Array
 import qualified Data.Graph as Graph
 import Data.List as List ( groupBy,  deleteBy, deleteFirstsBy )
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Tree  as Tree
 import Control.Monad
 import Distribution.Compat.Stack
@@ -210,20 +211,20 @@ mkPackageIndex pids pnames = assert (invariant index) index
 -- ones.
 --
 fromList :: [IPI.InstalledPackageInfo] -> InstalledPackageIndex
-fromList pkgs = mkPackageIndex pids pnames
+fromList pkgs = mkPackageIndex pids ((fmap . fmap) toList pnames)
   where
     pids      = Map.fromList [ (installedUnitId pkg, pkg) | pkg <- pkgs ]
     pnames    =
       Map.fromList
-        [ (liftM2 (,) packageName IPI.sourceLibName (head pkgsN), pvers)
-        | pkgsN <- groupBy (equating  (liftM2 (,) packageName IPI.sourceLibName))
+        [ (liftM2 (,) packageName IPI.sourceLibName (NE.head pkgsN), pvers)
+        | pkgsN <- NE.groupBy (equating  (liftM2 (,) packageName IPI.sourceLibName))
                  . sortBy  (comparing (liftM3 (,,) packageName IPI.sourceLibName packageVersion))
                  $ pkgs
         , let pvers =
                 Map.fromList
-                [ (packageVersion (head pkgsNV),
-                   nubBy (equating installedUnitId) (reverse pkgsNV))
-                | pkgsNV <- groupBy (equating packageVersion) pkgsN
+                [ (packageVersion (NE.head pkgsNV),
+                   NE.nubBy (equating installedUnitId) (NE.reverse pkgsNV))
+                | pkgsNV <- NE.groupBy (equating packageVersion) pkgsN
                 ]
         ]
 

--- a/Cabal/Distribution/Simple/PreProcess.hs
+++ b/Cabal/Distribution/Simple/PreProcess.hs
@@ -269,7 +269,7 @@ preprocessFile searchLoc buildLoc forSDist baseFile verbosity builtinSuffixes ha
             let (srcStem, ext) = splitExtension psrcRelFile
                 psrcFile = psrcLoc </> psrcRelFile
                 pp = fromMaybe (error "Distribution.Simple.PreProcess: Just expected")
-                               (lookup (tailNotNull ext) handlers)
+                               (lookup (safeTail ext) handlers)
             -- Preprocessing files for 'sdist' is different from preprocessing
             -- for 'build'.  When preprocessing for sdist we preprocess to
             -- avoid that the user has to have the preprocessors available.
@@ -296,8 +296,6 @@ preprocessFile searchLoc buildLoc forSDist baseFile verbosity builtinSuffixes ha
 
   where
     dirName = takeDirectory
-    tailNotNull [] = []
-    tailNotNull x  = tail x
 
     -- FIXME: This is a somewhat nasty hack. GHC requires that hs-boot files
     -- be in the same place as the hs files, so if we put the hs file in dist/

--- a/Cabal/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/Distribution/Simple/Program/HcPkg.hs
@@ -42,8 +42,8 @@ module Distribution.Simple.Program.HcPkg (
     listInvocation,
   ) where
 
-import Prelude ()
-import Distribution.Compat.Prelude hiding (init)
+import Prelude (last)
+import Distribution.Compat.Prelude
 
 import Data.Either (partitionEithers)
 import qualified Data.List.NonEmpty as NE

--- a/Cabal/Distribution/Simple/Program/Internal.hs
+++ b/Cabal/Distribution/Simple/Program/Internal.hs
@@ -13,6 +13,7 @@ module Distribution.Simple.Program.Internal (
 
 import Prelude ()
 import Distribution.Compat.Prelude
+import Distribution.Utils.Generic(safeTail)
 
 -- | Extract the version number from the output of 'strip --version'.
 --
@@ -29,7 +30,7 @@ stripExtractVersion str =
       filterPar' :: Int -> [String] -> [String]
       filterPar' _ []                   = []
       filterPar' n (x:xs)
-        | n >= 0 && "(" `isPrefixOf` x = filterPar' (n+1) ((tail x):xs)
+        | n >= 0 && "(" `isPrefixOf` x = filterPar' (n+1) ((safeTail x):xs)
         | n >  0 && ")" `isSuffixOf` x = filterPar' (n-1) xs
         | n >  0                       = filterPar' n xs
         | otherwise                    = x:filterPar' n xs

--- a/Cabal/Distribution/Simple/Program/Run.hs
+++ b/Cabal/Distribution/Simple/Program/Run.hs
@@ -27,7 +27,7 @@ module Distribution.Simple.Program.Run (
     getEffectiveEnvironment,
   ) where
 
-import Prelude ()
+import Prelude (last, init)
 import Distribution.Compat.Prelude
 
 import Distribution.Simple.Program.Types

--- a/Cabal/Distribution/Simple/UHC.hs
+++ b/Cabal/Distribution/Simple/UHC.hs
@@ -22,9 +22,8 @@ module Distribution.Simple.UHC (
     buildLib, buildExe, installLib, registerPackage, inplacePackageDbPath
   ) where
 
-import Prelude ()
+import Prelude (last)
 import Distribution.Compat.Prelude
-import Data.Foldable (toList)
 
 import Distribution.InstalledPackageInfo
 import Distribution.Package hiding (installedUnitId)

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -150,6 +150,7 @@ module Distribution.Simple.Utils (
         ordNub,
         ordNubBy,
         ordNubRight,
+        safeHead,
         safeTail,
         unintersperse,
         wrapText,

--- a/Cabal/Distribution/Types/LegacyExeDependency.hs
+++ b/Cabal/Distribution/Types/LegacyExeDependency.hs
@@ -40,7 +40,7 @@ instance Parsec LegacyExeDependency where
         verRange <- parsecMaybeQuoted parsec <|> pure anyVersion
         pure $ LegacyExeDependency name verRange
       where
-        nameP = intercalate "-" <$> P.sepBy1 component (P.char '-')
+        nameP = intercalate "-" <$> toList <$> P.sepByNonEmpty component (P.char '-')
         component = do
             cs <- P.munch1 (\c -> isAlphaNum c || c == '+' || c == '_')
             if all isDigit cs then fail "invalid component" else return cs

--- a/Cabal/Distribution/Types/MungedPackageName.hs
+++ b/Cabal/Distribution/Types/MungedPackageName.hs
@@ -137,7 +137,7 @@ zdashcode s = go s (Nothing :: Maybe Int) []
 
 parseZDashCode :: CabalParsing m => m [String]
 parseZDashCode = do
-    ns <- P.sepBy1 (some (P.satisfy (/= '-'))) (P.char '-')
+    ns <- toList <$> P.sepByNonEmpty (some (P.satisfy (/= '-'))) (P.char '-')
     return (go ns)
   where
     go ns = case break (=="z") ns of

--- a/Cabal/Distribution/Types/MungedPackageName.hs
+++ b/Cabal/Distribution/Types/MungedPackageName.hs
@@ -68,7 +68,7 @@ instance NFData MungedPackageName where rnf = genericRnf
 -- >>> prettyShow $ MungedPackageName "servant" LMainLibName
 -- "servant"
 --
--- >>> prettyShow $ MungedPackageName "servant" (LSubLibName "lackey") 
+-- >>> prettyShow $ MungedPackageName "servant" (LSubLibName "lackey")
 -- "z-servant-z-lackey"
 --
 instance Pretty MungedPackageName where
@@ -77,7 +77,7 @@ instance Pretty MungedPackageName where
     -- indefinite package for us.
     pretty = Disp.text . encodeCompatPackageName'
 
--- | 
+-- |
 --
 -- >>> simpleParsec "servant" :: Maybe MungedPackageName
 -- Just (MungedPackageName (PackageName "servant") LMainLibName)

--- a/Cabal/Distribution/Types/PackageId.hs
+++ b/Cabal/Distribution/Types/PackageId.hs
@@ -13,6 +13,7 @@ import Distribution.Pretty
 import Distribution.Types.PackageName
 import Distribution.Version           (Version, nullVersion)
 
+import qualified Data.List.NonEmpty              as NE
 import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint                as Disp
 
@@ -58,10 +59,10 @@ instance Pretty PackageIdentifier where
 --
 instance Parsec PackageIdentifier where
   parsec = do
-      xs' <- P.sepBy1 component (P.char '-')
-      (v, xs) <- case simpleParsec (last xs') of
-          Nothing -> return (nullVersion, xs') -- all components are version
-          Just v  -> return (v, init xs')
+      xs' <- P.sepByNonEmpty component (P.char '-')
+      (v, xs) <- case simpleParsec (NE.last xs') of
+          Nothing -> return (nullVersion, toList xs') -- all components are version
+          Just v  -> return (v, NE.init xs')
       if not (null xs) && all (\c ->  all (/= '.') c && not (all isDigit c)) xs
       then return $ PackageIdentifier (mkPackageName (intercalate  "-" xs)) v
       else fail "all digits or a dot in a portion of package name"

--- a/Cabal/Distribution/Types/Version.hs
+++ b/Cabal/Distribution/Types/Version.hs
@@ -92,7 +92,7 @@ instance Pretty Version where
                                 (map Disp.int $ versionNumbers ver))
 
 instance Parsec Version where
-    parsec = mkVersion <$> P.sepBy1 versionDigitParser (P.char '.') <* tags
+    parsec = mkVersion <$> toList <$> P.sepByNonEmpty versionDigitParser (P.char '.') <* tags
       where
         tags = do
             ts <- many $ P.char '-' *> some (P.satisfy isAlphaNum)

--- a/Cabal/Distribution/Types/VersionInterval.hs
+++ b/Cabal/Distribution/Types/VersionInterval.hs
@@ -21,7 +21,7 @@ module Distribution.Types.VersionInterval (
     Bound(..),
     ) where
 
-import Prelude ()
+import Prelude (tail)
 import Distribution.Compat.Prelude
 import Control.Exception (assert)
 

--- a/Cabal/Distribution/Types/VersionRange.hs
+++ b/Cabal/Distribution/Types/VersionRange.hs
@@ -39,7 +39,7 @@ module Distribution.Types.VersionRange (
 import Distribution.Compat.Prelude
 import Distribution.Types.Version
 import Distribution.Types.VersionRange.Internal
-import Prelude ()
+import Prelude (last, init)
 
 -- | Fold over the basic syntactic structure of a 'VersionRange'.
 --

--- a/Cabal/Distribution/Types/VersionRange/Internal.hs
+++ b/Cabal/Distribution/Types/VersionRange/Internal.hs
@@ -381,7 +381,7 @@ versionRangeParser digitParser = expr
 
         -- a plain version without tags or wildcards
         verPlain :: CabalParsing m => m Version
-        verPlain = mkVersion <$> P.sepBy1 digitParser (P.char '.')
+        verPlain = mkVersion <$> toList <$> P.sepByNonEmpty digitParser (P.char '.')
 
         -- either wildcard or normal version
         verOrWild :: CabalParsing m => m (Bool, Version)

--- a/Cabal/Distribution/Utils/Generic.hs
+++ b/Cabal/Distribution/Utils/Generic.hs
@@ -64,7 +64,10 @@ module Distribution.Utils.Generic (
         ordNub,
         ordNubBy,
         ordNubRight,
+        safeHead,
         safeTail,
+        safeLast,
+        safeInit,
         unintersperse,
         wrapText,
         wrapLine,
@@ -77,7 +80,7 @@ module Distribution.Utils.Generic (
         isRelativeOnAnyPlatform,
   ) where
 
-import Prelude ()
+import Prelude (head, tail, last, init)
 import Distribution.Compat.Prelude
 
 import Distribution.Utils.String
@@ -363,10 +366,25 @@ listUnionRight a b = ordNubRight (filter (`Set.notMember` bSet) a) ++ b
   where
     bSet = Set.fromList b
 
+-- | A total variant of 'head'.
+safeHead :: [a] -> Maybe a
+safeHead [] = Nothing
+safeHead xs = Just (head xs)
+
 -- | A total variant of 'tail'.
 safeTail :: [a] -> [a]
-safeTail []     = []
-safeTail (_:xs) = xs
+safeTail [] = []
+safeTail xs = tail xs
+
+-- | A total variant of 'last'.
+safeLast :: [a] -> Maybe a
+safeLast [] = Nothing
+safeLast xs = Just (last xs)
+
+-- | A total variant of 'init'.
+safeInit :: [a] -> [a]
+safeInit [] = []
+safeInit xs = init xs
 
 equating :: Eq a => (b -> a) -> b -> b -> Bool
 equating p x y = p x == p y

--- a/Cabal/Distribution/Utils/NubList.hs
+++ b/Cabal/Distribution/Utils/NubList.hs
@@ -66,7 +66,7 @@ instance (Ord a, Read a) => Read (NubList a) where
 
 -- | Helper used by NubList/NubListR's Read instances.
 readNubList :: (Read a) => ([a] -> l a) -> R.ReadPrec (l a)
-readNubList toList = R.parens . R.prec 10 $ fmap toList R.readPrec
+readNubList listToL = R.parens . R.prec 10 $ fmap listToL R.readPrec
 
 -- | Binary instance for 'NubList a' is the same as for '[a]'. For 'put', we
 -- just pull off constructor and put the list. For 'get', we get the list and

--- a/Cabal/Language/Haskell/Extension.hs
+++ b/Cabal/Language/Haskell/Extension.hs
@@ -23,7 +23,7 @@ module Language.Haskell.Extension (
         classifyExtension,
   ) where
 
-import Prelude ()
+import Prelude (head)
 import Distribution.Compat.Prelude
 
 import Data.Array (Array, accumArray, bounds, Ix(inRange), (!))

--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -6,7 +6,7 @@
 module UnitTests.Distribution.Version (versionTests) where
 
 import Distribution.Compat.Prelude.Internal
-import Prelude ()
+import Prelude (tail, last, init)
 
 import Distribution.Version
 import Distribution.Types.VersionRange.Internal

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -18,7 +18,7 @@ module Distribution.Client.CmdInstall (
     establishDummyProjectBaseContext
   ) where
 
-import Prelude ()
+import Prelude (head)
 import Distribution.Client.Compat.Prelude
 import Distribution.Compat.Directory
          ( doesPathExist )

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -17,7 +17,7 @@ module Distribution.Client.CmdRepl (
     selectComponentTarget
   ) where
 
-import Prelude ()
+import Prelude (head)
 import Distribution.Client.Compat.Prelude
 
 import Distribution.Compat.Lens

--- a/cabal-install/Distribution/Client/CmdRun.hs
+++ b/cabal-install/Distribution/Client/CmdRun.hs
@@ -18,7 +18,7 @@ module Distribution.Client.CmdRun (
   ) where
 
 import Prelude ()
-import Distribution.Client.Compat.Prelude
+import Distribution.Client.Compat.Prelude hiding (toList)
 
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.CmdErrorMessages

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -24,6 +24,7 @@ module Distribution.Client.Configure (
 
 import Prelude ()
 import Distribution.Client.Compat.Prelude
+import Distribution.Utils.Generic (safeHead)
 
 import Distribution.Client.Dependency
 import qualified Distribution.Client.InstallPlan as InstallPlan
@@ -85,6 +86,8 @@ import Distribution.Deprecated.Text ( display )
 import Distribution.Verbosity as Verbosity
          ( Verbosity )
 
+import Data.Foldable
+         ( forM_ )
 import System.FilePath ( (</>) )
 
 -- | Choose the Cabal version such that the setup scripts compiled against this
@@ -272,12 +275,12 @@ checkConfigExFlags :: Package pkg
                    -> ConfigExFlags
                    -> IO ()
 checkConfigExFlags verbosity installedPkgIndex sourcePkgIndex flags = do
-  unless (null unknownConstraints) $ warn verbosity $
-             "Constraint refers to an unknown package: "
-          ++ showConstraint (head unknownConstraints)
-  unless (null unknownPreferences) $ warn verbosity $
-             "Preference refers to an unknown package: "
-          ++ display (head unknownPreferences)
+  forM_ (safeHead unknownConstraints) $ \h ->
+    warn verbosity $ "Constraint refers to an unknown package: "
+          ++ showConstraint h
+  forM_ (safeHead unknownPreferences) $ \h ->
+    warn verbosity $ "Preference refers to an unknown package: "
+          ++ display h
   where
     unknownConstraints = filter (unknown . userConstraintPackageName . fst) $
                          configExConstraints flags

--- a/cabal-install/Distribution/Client/GenBounds.hs
+++ b/cabal-install/Distribution/Client/GenBounds.hs
@@ -17,6 +17,7 @@ module Distribution.Client.GenBounds (
 
 import Prelude ()
 import Distribution.Client.Compat.Prelude
+import Distribution.Utils.Generic (safeLast)
 
 import Distribution.Client.Init
          ( incVersion )
@@ -59,9 +60,9 @@ import System.Directory
 -- | Does this version range have an upper bound?
 hasUpperBound :: VersionRange -> Bool
 hasUpperBound vr =
-    case asVersionIntervals vr of
-      [] -> False
-      is -> if snd (last is) == NoUpperBound then False else True
+    case safeLast (asVersionIntervals vr) of
+      Nothing -> False
+      Just l  -> if snd l == NoUpperBound then False else True
 
 -- | Given a version, return an API-compatible (according to PVP) version range.
 --

--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -14,7 +14,7 @@ module Distribution.Client.HttpUtils (
     isOldHackageURI
   ) where
 
-import Prelude ()
+import Prelude (head)
 import Distribution.Client.Compat.Prelude hiding (Proxy (..))
 
 import Network.HTTP

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -31,6 +31,7 @@ module Distribution.Client.Install (
 
 import Prelude ()
 import Distribution.Client.Compat.Prelude
+import Distribution.Utils.Generic(safeLast)
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
@@ -701,11 +702,11 @@ printPlan dryRun verbosity plan sourcePkgDb = case plan of
         Nothing -> ""
       where
         mLatestVersion :: Maybe Version
-        mLatestVersion = case SourcePackageIndex.lookupPackageName
-                                (packageIndex sourcePkgDb)
-                                (packageName pkg) of
-            [] -> Nothing
-            x -> Just $ packageVersion $ last x
+        mLatestVersion = fmap packageVersion $
+                         safeLast $
+                         SourcePackageIndex.lookupPackageName
+                           (packageIndex sourcePkgDb)
+                           (packageName pkg)
 
     toFlagAssignment :: [Flag] -> FlagAssignment
     toFlagAssignment =  mkFlagAssignment . map (\ f -> (flagName f, flagDefault f))

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -96,7 +96,7 @@ import           Distribution.Utils.LogProgress
 
 import Data.List
          ( foldl', intercalate )
-import qualified Data.Foldable as Foldable (all)
+import qualified Data.Foldable as Foldable (all, toList)
 import Data.Maybe
          ( fromMaybe, mapMaybe )
 import qualified Distribution.Compat.Graph as Graph
@@ -278,7 +278,7 @@ showPlanGraph :: (Package ipkg, Package srcpkg,
                   IsUnit ipkg, IsUnit srcpkg)
               => Graph (GenericPlanPackage ipkg srcpkg) -> String
 showPlanGraph graph = renderStyle defaultStyle $
-    vcat (map dispPlanPackage (Graph.toList graph))
+    vcat (map dispPlanPackage (Foldable.toList graph))
   where dispPlanPackage p =
             hang (hsep [ text (showPlanPackageTag p)
                        , disp (packageId p)
@@ -309,7 +309,7 @@ toGraph = planGraph
 
 toList :: GenericInstallPlan ipkg srcpkg
        -> [GenericPlanPackage ipkg srcpkg]
-toList = Graph.toList . planGraph
+toList = Foldable.toList . planGraph
 
 toMap :: GenericInstallPlan ipkg srcpkg
       -> Map UnitId (GenericPlanPackage ipkg srcpkg)
@@ -929,7 +929,7 @@ problems graph =
      --TODO: consider re-enabling this one, see SolverInstallPlan
 -}
   ++ [ PackageStateInvalid pkg pkg'
-     | pkg <- Graph.toList graph
+     | pkg <- Foldable.toList graph
      , Just pkg' <- map (flip Graph.lookup graph)
                     (nodeNeighbors pkg)
      , not (stateDependencyRelation pkg pkg') ]

--- a/cabal-install/Distribution/Client/Outdated.hs
+++ b/cabal-install/Distribution/Client/Outdated.hs
@@ -13,7 +13,7 @@ module Distribution.Client.Outdated ( outdated
                                     , ListOutdatedSettings(..), listOutdated )
 where
 
-import Prelude ()
+import Prelude (last)
 import Distribution.Client.Config
 import Distribution.Client.IndexUtils as IndexUtils
 import Distribution.Client.Compat.Prelude

--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -44,6 +44,7 @@ module Distribution.Client.Sandbox (
 
 import Prelude ()
 import Distribution.Client.Compat.Prelude
+import Distribution.Utils.Generic(safeLast)
 
 import Distribution.Client.Setup
   ( SandboxFlags(..), ConfigFlags(..), ConfigExFlags(..), InstallFlags(..)
@@ -216,10 +217,10 @@ tryGetIndexFilePath verbosity config = tryGetIndexFilePath' verbosity (savedGlob
 tryGetIndexFilePath' :: Verbosity -> GlobalFlags -> IO FilePath
 tryGetIndexFilePath' verbosity globalFlags = do
   let paths = fromNubList $ globalLocalRepos globalFlags
-  case paths of
-    []  -> die' verbosity $ "Distribution.Client.Sandbox.tryGetIndexFilePath: " ++
+  case safeLast paths of
+    Nothing   -> die' verbosity $ "Distribution.Client.Sandbox.tryGetIndexFilePath: " ++
            "no local repos found. " ++ checkConfiguration
-    _   -> return $ (last paths) </> Index.defaultIndexFileName
+    Just lp   -> return $ lp </> Index.defaultIndexFileName
   where
     checkConfiguration = "Please check your configuration ('"
                          ++ userPackageEnvironmentFile ++ "')."

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -22,7 +22,7 @@ module Distribution.Client.SetupWrapper (
     defaultSetupScriptOptions,
   ) where
 
-import Prelude ()
+import Prelude (head)
 import Distribution.Client.Compat.Prelude
 
 import qualified Distribution.Make as Make

--- a/cabal-install/Distribution/Client/SolverInstallPlan.hs
+++ b/cabal-install/Distribution/Client/SolverInstallPlan.hs
@@ -73,6 +73,7 @@ import Data.Maybe
          ( fromMaybe, mapMaybe )
 import Distribution.Compat.Binary (Binary(..))
 import Distribution.Compat.Graph (Graph, IsNode(..))
+import qualified Data.Foldable as Foldable
 import qualified Data.Graph as OldGraph
 import qualified Distribution.Compat.Graph as Graph
 import qualified Data.Map as Map
@@ -144,7 +145,7 @@ new indepGoals index =
     probs -> Left probs
 
 toList :: SolverInstallPlan -> [SolverPlanPackage]
-toList = Graph.toList . planIndex
+toList = Foldable.toList . planIndex
 
 toMap :: SolverInstallPlan -> Map SolverId SolverPlanPackage
 toMap = Graph.toMap . planIndex
@@ -239,7 +240,7 @@ problems indepGoals index =
        dependencyInconsistencies indepGoals index ]
 
   ++ [ PackageStateInvalid pkg pkg'
-     | pkg <- Graph.toList index
+     | pkg <- Foldable.toList index
      , Just pkg' <- map (flip Graph.lookup index)
                     (nodeNeighbors pkg)
      , not (stateDependencyRelation pkg pkg') ]
@@ -316,7 +317,7 @@ libraryRoots index =
 setupRoots :: SolverPlanIndex -> [[SolverId]]
 setupRoots = filter (not . null)
            . map (CD.setupDeps . resolverPackageLibDeps)
-           . Graph.toList
+           . Foldable.toList
 
 -- | Given a package index where we assume we want to use all the packages
 -- (use 'dependencyClosure' if you need to get such a index subset) find out
@@ -345,7 +346,7 @@ dependencyInconsistencies' index =
     inverseIndex = Map.fromListWith (Map.unionWith (\(a,b) (_,b') -> (a,b++b')))
       [ (packageName dep, Map.fromList [(sid,(dep,[packageId pkg]))])
       | -- For each package @pkg@
-        pkg <- Graph.toList index
+        pkg <- Foldable.toList index
         -- Find out which @sid@ @pkg@ depends on
       , sid <- CD.nonSetupDeps (resolverPackageLibDeps pkg)
         -- And look up those @sid@ (i.e., @sid@ is the ID of @dep@)

--- a/cabal-install/Distribution/Deprecated/ViewAsFieldDescr.hs
+++ b/cabal-install/Distribution/Deprecated/ViewAsFieldDescr.hs
@@ -3,7 +3,7 @@ module Distribution.Deprecated.ViewAsFieldDescr (
     ) where
 
 import Distribution.Client.Compat.Prelude hiding (get)
-import Prelude ()
+import Prelude (head)
 
 import Distribution.Parsec   (parsec)
 import Distribution.Pretty

--- a/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
+++ b/cabal-install/Distribution/Solver/Types/ComponentDeps.hs
@@ -38,7 +38,7 @@ module Distribution.Solver.Types.ComponentDeps (
 
 import Prelude ()
 import Distribution.Types.UnqualComponentName
-import Distribution.Solver.Compat.Prelude hiding (empty,zip)
+import Distribution.Solver.Compat.Prelude hiding (empty,toList,zip)
 
 import qualified Data.Map as Map
 import Data.Foldable (fold)

--- a/cabal-install/Distribution/Solver/Types/PackageIndex.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageIndex.hs
@@ -50,7 +50,8 @@ import Distribution.Solver.Compat.Prelude hiding (lookup)
 
 import Control.Exception (assert)
 import qualified Data.Map as Map
-import Data.List (groupBy, isInfixOf)
+import Data.List (isInfixOf)
+import qualified Data.List.NonEmpty as NE
 
 import Distribution.Package
          ( PackageName, unPackageName, PackageIdentifier(..)
@@ -136,9 +137,9 @@ fromList pkgs = mkPackageIndex
   where
     fixBucket = -- out of groups of duplicates, later ones mask earlier ones
                 -- but Map.fromListWith (++) constructs groups in reverse order
-                map head
+                map NE.head
                 -- Eq instance for PackageIdentifier is wrong, so use Ord:
-              . groupBy (\a b -> EQ == comparing packageId a b)
+              . NE.groupBy (\a b -> EQ == comparing packageId a b)
                 -- relies on sortBy being a stable sort so we
                 -- can pick consistently among duplicates
               . sortBy (comparing packageId)

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -67,7 +67,7 @@ import Distribution.Simple.Setup
          , configAbsolutePaths
          )
 
-import Prelude ()
+import Prelude (head, tail)
 import Distribution.Solver.Compat.Prelude hiding (get)
 
 import Distribution.Client.SetupWrapper

--- a/cabal-install/solver-dsl/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/solver-dsl/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -37,7 +37,7 @@ module UnitTests.Distribution.Solver.Modular.DSL (
   , mkVersionRange
   ) where
 
-import Prelude ()
+import Prelude (head)
 import Distribution.Solver.Compat.Prelude
 
 -- base


### PR DESCRIPTION
(Rebased & fixed resubmission of #6142.)

Add safe alternatives to some partial functions in Distribution.Utils.Generic, and removes the originals from Distribution.Compat.Prelude. See #6107.

Uncomment versions of functions in Distribution.Compat.Parsing that return non-empty lists.

There are still many partial functions in use like `maximum` after this PR, and there are a few uses of `head`, `last`, `tail` and `init` that still remain because I didn't find any easy way to remove them.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Tested by running `cabal new-run cabal-tests`, `cabal new-test Cabal:unit-tests`, etc.
(Also tested by running the PR validation in a fork.)