### PR TITLE
Add test for build tool depends with per-component builds disabled

### DIFF
--- a/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/cabal.project
+++ b/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/cabal.project
@@ -1,0 +1,2 @@
+packages: client
+optional-packages: pre-proc

--- a/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/client/Hello.hs
+++ b/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/client/Hello.hs
@@ -1,0 +1,8 @@
+{-# OPTIONS_GHC -F -pgmF zero-to-one #-}
+module Main where
+
+a :: String
+a = "0000"
+
+main :: IO ()
+main = putStrLn a

--- a/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/client/client.cabal
+++ b/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/client/client.cabal
@@ -1,0 +1,13 @@
+name:                client
+version:             0.1.0.0
+synopsis:            Checks build-tool-depends are put in PATH
+license:             BSD3
+category:            Testing
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable             hello-world
+  main-is:             Hello.hs
+  build-depends:       base
+  build-tool-depends:  pre-proc:zero-to-one
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/pre-proc/MyCustomPreprocessor.hs
+++ b/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/pre-proc/MyCustomPreprocessor.hs
@@ -1,0 +1,11 @@
+module Main where
+
+import System.Environment
+import System.IO
+
+main :: IO ()
+main = do
+  (_:source:target:_) <- getArgs
+  let f '0' = '1'
+      f c = c
+  writeFile target . map f  =<< readFile source

--- a/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/pre-proc/pre-proc.cabal
+++ b/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/pre-proc/pre-proc.cabal
@@ -1,0 +1,17 @@
+name:                pre-proc
+version:             999.999.999
+synopsis:            Checks build-tool-depends are put in PATH
+license:             BSD3
+category:            Testing
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable             zero-to-one
+  main-is:             MyCustomPreprocessor.hs
+  build-depends:       base, directory
+  default-language:    Haskell2010
+
+executable             bad-do-not-build-me
+  main-is:             MyMissingPreprocessor.hs
+  build-depends:       base, directory
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/setup.out
+++ b/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/setup.out
@@ -1,0 +1,12 @@
+# cabal v2-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - pre-proc-999.999.999 (exe:zero-to-one) (first run)
+ - client-0.1.0.0 (exe:hello-world) (first run)
+Configuring executable 'zero-to-one' for pre-proc-999.999.999..
+Preprocessing executable 'zero-to-one' for pre-proc-999.999.999..
+Building executable 'zero-to-one' for pre-proc-999.999.999..
+Configuring executable 'hello-world' for client-0.1.0.0..
+Preprocessing executable 'hello-world' for client-0.1.0.0..
+Building executable 'hello-world' for client-0.1.0.0..

--- a/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/setup.test.hs
+++ b/cabal-testsuite/PackageTests/BuildToolDependsNonComponent/setup.test.hs
@@ -1,0 +1,4 @@
+import Test.Cabal.Prelude
+-- Test build-tool-depends between two packages
+main = cabalTest $ do
+    cabal "v2-build" ["client", "--disable-per-component"]


### PR DESCRIPTION
This seems to be the underlying issue in #6011

I'm not sure how to fix it (yet), but I'm hoping to solicit suggestions. My best guess is that the bug is in `Distribution.Client.ProjectPlanning`.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
