### PR TITLE
CI: Add travis_retry when uploading binaries to S3

### DIFF
--- a/travis/upload.sh
+++ b/travis/upload.sh
@@ -86,7 +86,7 @@ rm $BINARIES # Don't check me in!
 
 # Upload to S3
 S3_URL=$(curl -X POST "https://s3-bouncer.herokuapp.com/put")
-curl "$S3_URL" --upload-file binaries.tgz
+travis_retry curl "$S3_URL" --upload-file binaries.tgz
 rm binaries.tgz # Don't check me in!
 echo "$S3_URL" | xargs basename | cut -d '?' -f 1 > s3-object.txt
 


### PR DESCRIPTION
Fixes #6324

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] ~Any changes that could be relevant to users have been recorded in the changelog.~
* [x] ~The documentation has been updated, if necessary.~
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Tested in my fork.