### PR TITLE
tests: avoid blocking on git tagging

### DIFF
--- a/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
@@ -632,7 +632,7 @@ vcsTestDriverGit verbosity vcs repoRoot =
         return (Just commit')
 
     , vcsTagState = \_ tagname ->
-        git ["tag", "--force", tagname]
+        git ["tag", "--force", "--no-sign", tagname]
 
     , vcsSwitchBranch = \RepoState{allBranches} branchname -> do
         unless (branchname `Map.member` allBranches) $


### PR DESCRIPTION
I haven't understood 100%, but something about having the following in
my ~/.gitconfig:

    [tag]
      gpgsign = true
      forceSignAnnotated = true

means that creating these tags block on my editor exiting and providing
the annotated tag commit message.  I also didn't investigate all the
options, but I tested that this one fixes the issue for me.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] ~Any changes that could be relevant to users have been recorded in the changelog.~
* [x] ~The documentation has been updated, if necessary.~
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Tested by running `validate.sh`.