### PR TITLE
validate.sh: Allow using short-version ghc binaries, like ghc-8.6

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -191,7 +191,7 @@ else
     PROJECTFILE=cabal.project.validate
 fi
 
-BASEHC=$(basename $HC)
+BASEHC=ghc-$($HC --numeric-version)
 BUILDDIR=dist-newstyle-validate-$BASEHC
 CABAL_TESTSUITE_BDIR="$(pwd)/$BUILDDIR/build/$ARCH/$BASEHC/cabal-testsuite-${CABAL_VERSION}"
 


### PR DESCRIPTION
Previously this would work until CABAL_TESTSUITE_BDIR was needed, at
which point it would fail because it looked for things under
.../ghc-8.6/... while cabal v2-build actually put them in
.../ghc-8.6.5/...

Hard-coding "ghc" is unfortunate, but I didn't know if there was an easy
way to avoid it.  I also didn't want to over-complicate it, until it was
necessary.

validate.sh isn't tested in CI so...
[ci skip]

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] ~Any changes that could be relevant to users have been recorded in the changelog.~
* [x] ~The documentation has been updated, if necessary.~
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Tested by running `validate.sh`.