### PR TITLE
Add language extensions for ghc-8.10

### DIFF
--- a/Cabal/Language/Haskell/Extension.hs
+++ b/Cabal/Language/Haskell/Extension.hs
@@ -825,6 +825,18 @@ data KnownExtension =
   -- * <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#deriving-instances-for-empty-data-types>
   | EmptyDataDeriving
 
+  -- | Enable detection of complete user-supplied kind signatures.
+  | CUSKs
+
+  -- | Allows the syntax @import M qualified@.
+  | ImportQualifiedPost
+
+  -- | Allow the use of standalone kind signatures.
+  | StandaloneKindSignatures
+
+  -- | Enable unlifted newtypes.
+  | UnliftedNewtypes
+
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable, Data)
 
 instance Binary KnownExtension


### PR DESCRIPTION
I'd like you to review and merge this at the appropriate phase of the cabal project.

The ghc-8.10 will support these extensions.
These extensions already landed in master and ghc-8.10 branch:
  * CUSKs
  * ImportQualifiedPost
  * StandaloneKindSignatures
  * UnliftedNewtypes

Please see also:
  * https://gitlab.haskell.org/ghc/ghc/blob/master/docs/users_guide/8.10.1-notes.rst
  * https://gitlab.haskell.org/ghc/ghc/blob/master/testsuite/tests/driver/T4437.hs


---
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

No testing performed.

