### PR TITLE
.travis.yml: Add fast_finish to get build status faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,10 @@ matrix:
  # It seems pointless to run head if we're going to ignore the results.
  #- GHCVER=head
 
+  # Marks the build result as soon as all the non-"allow_failures" jobs finish, based on their results
+  # while the remaining `allow_failures` jobs continue to run.
+  fast_finish: true
+
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:
  - export PATH=/opt/ghc/$GHCVER/bin:$PATH


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.