### PR TITLE
Add regression test, and resolve #6334

### DIFF
--- a/cabal-install/Distribution/Client/SourceFiles.hs
+++ b/cabal-install/Distribution/Client/SourceFiles.hs
@@ -17,7 +17,6 @@ import Distribution.Client.RebuildMonad
 
 import Distribution.Solver.Types.OptionalStanza
 
-import Distribution.Simple.Glob
 import Distribution.Simple.PreProcess
 
 import Distribution.Types.PackageDescription
@@ -34,14 +33,11 @@ import Distribution.Types.ForeignLib
 
 import Distribution.ModuleName
 
-import Distribution.Verbosity (silent)
-
 import Prelude ()
 import Distribution.Client.Compat.Prelude
 
 import System.FilePath
 import Control.Monad
-import Control.Monad.IO.Class
 import qualified Data.Set as Set
 
 needElaboratedConfiguredPackage :: ElaboratedConfiguredPackage -> Rebuild ()
@@ -156,9 +152,7 @@ needBuildInfo pkg_descr bi modules = do
     -- compilation).  It would be even better if we knew on a
     -- per-component basis which headers would be used but that
     -- seems to be too difficult.
-    forM_ (extraSrcFiles pkg_descr) $ \ glob -> do
-      files <- liftIO $ matchDirFileGlob silent (specVersion pkg_descr) "." glob
-      mapM_ needIfExists (filter ((==".h").takeExtension) files)
+    mapM_ needIfExists (filter ((==".h").takeExtension) (extraSrcFiles pkg_descr))
     forM_ (installIncludes bi) $ \f ->
         findFileMonitored ("." : includeDirs bi) f
             >>= maybe (return ()) need

--- a/cabal-testsuite/PackageTests/Regression/T6334/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T6334/cabal.out
@@ -1,0 +1,8 @@
+# cabal v2-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - foo-0 (lib) (first run)
+Configuring library for foo-0..
+Preprocessing library for foo-0..
+Building library for foo-0..

--- a/cabal-testsuite/PackageTests/Regression/T6334/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T6334/cabal.project
@@ -1,0 +1,1 @@
+packages: foo

--- a/cabal-testsuite/PackageTests/Regression/T6334/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T6334/cabal.test.hs
@@ -1,0 +1,3 @@
+import Test.Cabal.Prelude
+main = cabalTest $
+  cabal "v2-build" ["all"]

--- a/cabal-testsuite/PackageTests/Regression/T6334/foo/README.md
+++ b/cabal-testsuite/PackageTests/Regression/T6334/foo/README.md
@@ -1,0 +1,1 @@
+Some file

--- a/cabal-testsuite/PackageTests/Regression/T6334/foo/foo.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T6334/foo/foo.cabal
@@ -1,0 +1,13 @@
+cabal-version: 2.2
+name: foo
+version: 0
+description:
+  https://github.com/haskell/cabal/issues/6334
+extra-source-files:
+  README.md
+
+library
+  default-language: Haskell2010
+  hs-source-dirs: src
+  exposed-modules: Foo
+  build-depends: base <5

--- a/cabal-testsuite/PackageTests/Regression/T6334/foo/src/Foo.hs
+++ b/cabal-testsuite/PackageTests/Regression/T6334/foo/src/Foo.hs
@@ -1,0 +1,1 @@
+module Foo () where


### PR DESCRIPTION
Revert "Properly expand globs when looking for headers in extra-src-files."

This reverts commit 3b54835cc6ac756c09e3809254c3213e09947180.

cc @quasicomputational 