### PR TITLE
IOData improvements and faster ghc-pkg dump parsing

### DIFF
--- a/Cabal/Distribution/Simple/HaskellSuite.hs
+++ b/Cabal/Distribution/Simple/HaskellSuite.hs
@@ -139,7 +139,7 @@ getInstalledPackages verbosity packagedbs progdb =
 
   where
     parsePackages str =
-        case partitionEithers $ map parseInstalledPackageInfo (splitPkgs str) of
+        case partitionEithers $ map (parseInstalledPackageInfo . toUTF8BS) (splitPkgs str) of
             ([], ok)   -> Right [ pkg | (_, pkg) <- ok ]
             (msgss, _) -> Left (foldMap NE.toList msgss)
 
@@ -219,7 +219,7 @@ registerPackage verbosity progdb packageDbs installedPkgInfo = do
   runProgramInvocation verbosity $
     (programInvocation hspkg
       ["update", packageDbOpt $ registrationPackageDB packageDbs])
-      { progInvokeInput = Just $ showInstalledPackageInfo installedPkgInfo }
+      { progInvokeInput = Just $ IODataText $ showInstalledPackageInfo installedPkgInfo }
 
 initPackageDB :: Verbosity -> ProgramDb -> FilePath -> IO ()
 initPackageDB verbosity progdb dbPath =

--- a/Cabal/Distribution/Simple/Program.hs
+++ b/Cabal/Distribution/Simple/Program.hs
@@ -61,6 +61,7 @@ module Distribution.Simple.Program (
     , programInvocation
     , runProgramInvocation
     , getProgramInvocationOutput
+    , getProgramInvocationLBS
 
     -- * The collection of unconfigured and configured programs
     , builtinPrograms

--- a/Cabal/Distribution/Utils/IOData.hs
+++ b/Cabal/Distribution/Utils/IOData.hs
@@ -1,14 +1,17 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
 -- | @since 2.2.0
 module Distribution.Utils.IOData
     ( -- * 'IOData' & 'IODataMode' type
-      IOData(..)
-    , IODataMode(..)
+      IOData (..)
+    , IODataMode (..)
+    , KnownIODataMode (..)
+    , withIOData
     , null
-    , hGetContents
     , hPutContents
     ) where
 
-import qualified Data.ByteString.Lazy as BS
+import qualified Data.ByteString.Lazy as LBS
 import           Distribution.Compat.Prelude hiding (null)
 import qualified Prelude
 import qualified System.IO
@@ -16,46 +19,68 @@ import qualified System.IO
 -- | Represents either textual or binary data passed via I/O functions
 -- which support binary/text mode
 --
--- @since 2.2.0
-data IOData = IODataText    String
-              -- ^ How Text gets encoded is usually locale-dependent.
-            | IODataBinary  BS.ByteString
-              -- ^ Raw binary which gets read/written in binary mode.
+-- @since 2.2
+data IOData
+    = IODataText String
+    -- ^ How Text gets encoded is usually locale-dependent.
+    | IODataBinary LBS.ByteString
+    -- ^ Raw binary which gets read/written in binary mode.
+
+withIOData :: IOData -> (forall mode. IODataMode mode -> mode -> r) -> r
+withIOData (IODataText str) k   = k IODataModeText str
+withIOData (IODataBinary lbs) k = k IODataModeBinary lbs
 
 -- | Test whether 'IOData' is empty
---
--- @since 2.2.0
 null :: IOData -> Bool
-null (IODataText s) = Prelude.null s
-null (IODataBinary b) = BS.null b
+null (IODataText s)   = Prelude.null s
+null (IODataBinary b) = LBS.null b
 
 instance NFData IOData where
-    rnf (IODataText s) = rnf s
-    rnf (IODataBinary bs) = rnf bs
+    rnf (IODataText s)     = rnf s
+    rnf (IODataBinary lbs) = rnf lbs
 
-data IODataMode = IODataModeText | IODataModeBinary
+-- | @since 2.2
+class NFData mode => KnownIODataMode mode where
+    -- | 'IOData' Wrapper for 'System.IO.hGetContents'
+    --
+    -- __Note__: This operation uses lazy I/O. Use 'NFData' to force all
+    -- data to be read and consequently the internal file handle to be
+    -- closed.
+    --
+    hGetIODataContents :: System.IO.Handle -> Prelude.IO mode
 
--- | 'IOData' Wrapper for 'System.IO.hGetContents'
---
--- __Note__: This operation uses lazy I/O. Use 'NFData' to force all
--- data to be read and consequently the internal file handle to be
--- closed.
---
--- @since 2.2.0
-hGetContents :: System.IO.Handle -> IODataMode -> Prelude.IO IOData
-hGetContents h IODataModeText = do
-    System.IO.hSetBinaryMode h False
-    IODataText <$> System.IO.hGetContents h
-hGetContents h IODataModeBinary = do
-    System.IO.hSetBinaryMode h True
-    IODataBinary <$> BS.hGetContents h
+    toIOData   :: mode -> IOData
+    iodataMode :: IODataMode mode
+
+-- | @since 3.2
+data IODataMode mode where
+    IODataModeText   :: IODataMode String
+    IODataModeBinary :: IODataMode LBS.ByteString
+
+instance a ~ Char => KnownIODataMode [a] where
+    hGetIODataContents h = do
+        System.IO.hSetBinaryMode h False
+        System.IO.hGetContents h
+
+    toIOData = IODataText
+    iodataMode = IODataModeText
+
+instance KnownIODataMode LBS.ByteString where
+    hGetIODataContents h = do
+        System.IO.hSetBinaryMode h True
+        LBS.hGetContents h
+
+    toIOData = IODataBinary
+    iodataMode = IODataModeBinary
 
 -- | 'IOData' Wrapper for 'System.IO.hPutStr' and 'System.IO.hClose'
 --
--- This is the dual operation ot 'ioDataHGetContents',
+-- This is the dual operation ot 'hGetIODataContents',
 -- and consequently the handle is closed with `hClose`.
 --
--- @since 2.2.0
+-- /Note:/ this performes lazy-IO.
+--
+-- @since 2.2
 hPutContents :: System.IO.Handle -> IOData -> Prelude.IO ()
 hPutContents h (IODataText c) = do
     System.IO.hSetBinaryMode h False
@@ -63,5 +88,5 @@ hPutContents h (IODataText c) = do
     System.IO.hClose h
 hPutContents h (IODataBinary c) = do
     System.IO.hSetBinaryMode h True
-    BS.hPutStr h c
+    LBS.hPutStr h c
     System.IO.hClose h

--- a/Cabal/tests/ParserTests.hs
+++ b/Cabal/tests/ParserTests.hs
@@ -283,7 +283,7 @@ ipiTest fp = testGroup fp $
 
 ipiFormatGoldenTest :: FilePath -> TestTree
 ipiFormatGoldenTest fp = cabalGoldenTest "format" correct $ do
-    contents <- readFile input
+    contents <- BS.readFile input
     let res = IPI.parseInstalledPackageInfo contents
     return $ toUTF8BS $ case res of
         Left err -> "ERROR " ++ show err
@@ -296,7 +296,7 @@ ipiFormatGoldenTest fp = cabalGoldenTest "format" correct $ do
 #ifdef MIN_VERSION_tree_diff
 ipiTreeDiffGoldenTest :: FilePath -> TestTree
 ipiTreeDiffGoldenTest fp = ediffGolden goldenTest "expr" exprFile $ do
-    contents <- readFile input
+    contents <- BS.readFile input
     let res = IPI.parseInstalledPackageInfo contents
     case res of
         Left err -> fail $ "ERROR " ++ show err
@@ -308,10 +308,10 @@ ipiTreeDiffGoldenTest fp = ediffGolden goldenTest "expr" exprFile $ do
 
 ipiFormatRoundTripTest :: FilePath -> TestTree
 ipiFormatRoundTripTest fp = testCase "roundtrip" $ do
-    contents <- readFile input
+    contents <- BS.readFile input
     x <- parse contents
     let contents' = IPI.showInstalledPackageInfo x
-    y <- parse contents'
+    y <- parse (toUTF8BS contents')
 
     -- ghc-pkg prints pkgroot itself, based on cli arguments!
     let x' = x { IPI.pkgRoot = Nothing }
@@ -321,11 +321,11 @@ ipiFormatRoundTripTest fp = testCase "roundtrip" $ do
 
     -- Complete round-trip
     let contents2 = IPI.showFullInstalledPackageInfo x
-    z <- parse contents2
+    z <- parse (toUTF8BS contents2)
     assertEqual "re-parsed doesn't match" x z
 
   where
-    parse :: String -> IO IPI.InstalledPackageInfo
+    parse :: BS.ByteString -> IO IPI.InstalledPackageInfo
     parse c = do
         case IPI.parseInstalledPackageInfo c of
             Right (_, ipi) -> return ipi

--- a/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
+++ b/Cabal/tests/UnitTests/Distribution/Simple/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 module UnitTests.Distribution.Simple.Utils
     ( tests
     ) where
@@ -69,7 +70,7 @@ rawSystemStdInOutTextDecodingTest ghcPath
       hClose handleExe
 
       -- Compile
-      (IODataText resOutput, resErrors, resExitCode) <- rawSystemStdInOut normal
+      (resOutput, resErrors, resExitCode) <- rawSystemStdInOut normal
          ghcPath ["-o", filenameExe, filenameHs]
          Nothing Nothing Nothing
          IODataModeText
@@ -82,8 +83,7 @@ rawSystemStdInOutTextDecodingTest ghcPath
            Nothing Nothing Nothing
            IODataModeText -- not binary mode output, ie utf8 text mode so try to decode
   case res of
-    Right (IODataText x1, x2, x3) -> assertFailure $ "expected IO decoding exception: " ++ show (x1,x2,x3)
-    Right (IODataBinary _, _, _)  -> assertFailure "internal error"
+    Right (x1, x2, x3) -> assertFailure $ "expected IO decoding exception: " ++ show (x1,x2,x3)
     Left err | isDoesNotExistError err -> Exception.throwIO err -- no ghc!
              | otherwise               -> return ()
 

--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -40,7 +40,7 @@ import Distribution.Verbosity (Verbosity)
 import Distribution.Pretty (prettyShow)
 import Distribution.Simple.Utils
          ( die', info, warn, debug, notice
-         , copyFileVerbose,  withTempFile )
+         , copyFileVerbose,  withTempFile, IOData (..) )
 import Distribution.Client.Utils
          ( withTempFileName )
 import Distribution.Client.Types
@@ -351,7 +351,7 @@ curlTransport prog =
     addAuthConfig auth progInvocation = progInvocation
       { progInvokeInput = do
           (uname, passwd) <- auth
-          return $ unlines
+          return $ IODataText $ unlines
             [ "--digest"
             , "--user " ++ uname ++ ":" ++ passwd
             ]
@@ -508,7 +508,7 @@ wgetTransport prog =
         -- and sensitive data should not be passed via command line arguments.
         let
           invocation = (programInvocation prog ("--input-file=-" : args))
-            { progInvokeInput = Just (uriToString id uri "")
+            { progInvokeInput = Just $ IODataText $ uriToString id uri ""
             }
 
         -- wget returns its output on stderr rather than stdout
@@ -619,7 +619,7 @@ powershellTransport prog =
             ]
       debug verbosity script
       getProgramInvocationOutput verbosity (programInvocation prog args)
-        { progInvokeInput = Just (script ++ "\nExit(0);")
+        { progInvokeInput = Just $ IODataText $ script ++ "\nExit(0);"
         }
 
     escape = show


### PR DESCRIPTION
Based on #6364 

Parsing the `ghc-dump` is now two times faster and uses less memory.
For big cabal nix-stores this speedup is noticeable:

```haskell
{- ghc-pkg --simple-output

%  time ghc-pkg-8.6.5 --package-db=/cabal/store/ghc-8.6.5/package.db list --simple-output | wc 
      1    4473   82025
ghc-pkg-8.6.5 --package-db=/cabal/store/ghc-8.6.5/package.db list --simple-output  2,40s user 0,06s system 99% cpu 2,457 total
wc  0,00s user 0,00s system 0% cpu 2,457 total

-}
{- This script BEFORE THE CHANGE

% time runghc GhcPkgScript.hs ghc-pkg-8.6.5 /cabal/store/ghc-8.6.5/package.db | wc
Loaded package environment from /home/phadej/.ghc/x86_64-linux-8.6.5/environments/default
   4473    4473  372073
runghc GhcPkgScript.hs ghc-pkg-8.6.5 /cabal/store/ghc-8.6.5/package.db  13,34s user 1,22s system 100% cpu 14,481 total
wc  0,05s user 0,38s system 2% cpu 14,480 total

-}
{- AFTER THE CHANGE

% time runghc ./GhcPkgScript.hs ghc-pkg /cabal/store/ghc-8.6.5/package.db | wc 
Loaded package environment from /code/shared-haskell/cabal/.ghc.environment.x86_64-linux-8.6.5
   4477    4477  372405
runghc ./GhcPkgScript.hs ghc-pkg /cabal/store/ghc-8.6.5/package.db  7,48s user 0,94s system 100% cpu 8,369 total
wc  0,05s user 0,38s system 5% cpu 8,369 total

-}
module Main (main) where

import Distribution.InstalledPackageInfo (InstalledPackageInfo (..))
import Distribution.Pretty (prettyShow)
import Distribution.Simple.Compiler (PackageDB (..))
import Distribution.Simple.Program.HcPkg (dump, HcPkgInfo (..))
import Distribution.Simple.Program.Types (ConfiguredProgram, simpleConfiguredProgram, ProgramLocation (..))
import Distribution.Verbosity (silent)
import System.Environment (getArgs)

main :: IO ()
main = do
    (ghcpkg : arg : _) <- getArgs

    let cp :: ConfiguredProgram
        cp = simpleConfiguredProgram "ghc-pkg" (FoundOnSystem ghcpkg)

    let hcPkgInfo = HcPkgInfo cp
           -- this boolean flags are irrelevant for dump
           False False False False False False False False
                       -- ^ -- package-conf toggler for very old GHCs
    ipis <- dump hcPkgInfo silent (SpecificPackageDB arg)
    mapM_ (putStrLn . prettyShow . installedUnitId) ipis
```