### PR TITLE
Use ShortText in IPI

### DIFF
--- a/Cabal/Distribution/FieldGrammar.hs
+++ b/Cabal/Distribution/FieldGrammar.hs
@@ -25,6 +25,7 @@ module Distribution.FieldGrammar  (
     takeFields,
     runFieldParser,
     runFieldParser',
+    defaultFreeTextFieldDefST,
     )  where
 
 import Distribution.Compat.Prelude

--- a/Cabal/Distribution/FieldGrammar/Class.hs
+++ b/Cabal/Distribution/FieldGrammar/Class.hs
@@ -4,6 +4,7 @@ module Distribution.FieldGrammar.Class (
     optionalField,
     optionalFieldDef,
     monoidalField,
+    defaultFreeTextFieldDefST,
     ) where
 
 import Distribution.Compat.Lens
@@ -15,6 +16,7 @@ import Distribution.Compat.Newtype   (Newtype)
 import Distribution.Fields.Field
 import Distribution.Parsec           (Parsec)
 import Distribution.Pretty           (Pretty)
+import Distribution.Utils.ShortText
 
 -- | 'FieldGrammar' is parametrised by
 --
@@ -78,6 +80,12 @@ class FieldGrammar g where
         :: FieldName
         -> ALens' s String -- ^ lens into the field
         -> g s String
+
+    -- | @since 3.2.0.0
+    freeTextFieldDefST
+        :: FieldName
+        -> ALens' s ShortText -- ^ lens into the field
+        -> g s ShortText
 
     -- | Monoidal field.
     --
@@ -157,3 +165,15 @@ monoidalField
     -> ALens' s a  -- ^ lens into the field
     -> g s a
 monoidalField fn = monoidalFieldAla fn Identity
+
+-- | Default implementation for 'freeTextFieldDefST'.
+defaultFreeTextFieldDefST
+    :: (Functor (g s), FieldGrammar g)
+    => FieldName
+    -> ALens' s ShortText -- ^ lens into the field
+    -> g s ShortText
+defaultFreeTextFieldDefST fn l =
+    toShortText <$> freeTextFieldDef fn (cloneLens l . st)
+  where
+    st :: Lens' ShortText String
+    st f s = toShortText <$> f (fromShortText s)

--- a/Cabal/Distribution/FieldGrammar/FieldDescrs.hs
+++ b/Cabal/Distribution/FieldGrammar/FieldDescrs.hs
@@ -84,6 +84,8 @@ instance FieldGrammar FieldDescrs where
         f s = showFreeText (aview l s)
         g s = cloneLens l (const parsecFreeText) s
 
+    freeTextFieldDefST = defaultFreeTextFieldDefST
+
     monoidalFieldAla fn _pack l = singletonF fn f g where
         f s = pretty (pack' _pack (aview l s))
         g s = cloneLens l (\x -> mappend x . unpack' _pack <$> P.parsec) s

--- a/Cabal/Distribution/FieldGrammar/Pretty.hs
+++ b/Cabal/Distribution/FieldGrammar/Pretty.hs
@@ -72,6 +72,8 @@ instance FieldGrammar PrettyFieldGrammar where
             showFT | v >= CabalSpecV3_0 = showFreeTextV3
                    | otherwise          = showFreeText
 
+    freeTextFieldDefST = defaultFreeTextFieldDefST
+
     monoidalFieldAla fn _pack l = PrettyFG pp
       where
         pp v s = ppField fn (prettyVersioned v (pack' _pack (aview l s)))

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -101,7 +101,7 @@ parseInstalledPackageInfo s = case P.readFields s of
     Left err -> Left (show err :| [])
     Right fs -> case partitionFields fs of
         (fs', _) -> case P.runParseResult $ parseFieldGrammar cabalSpecLatest fs' ipiFieldGrammar of
-            (ws, Right x) -> ws' `deepseq` x `deepseq` Right (ws', x) where
+            (ws, Right x) -> x `deepseq` Right (ws', x) where
                 ws' = map (P.showPWarning "") ws
             (_,  Left (_, errs)) -> Left errs' where
                 errs' = fmap (P.showPError "") errs

--- a/Cabal/Distribution/ModuleName.hs
+++ b/Cabal/Distribution/ModuleName.hs
@@ -28,8 +28,8 @@ import Prelude ()
 
 import Distribution.Parsec
 import Distribution.Pretty
-import Distribution.Utils.ShortText
-import System.FilePath               (pathSeparator)
+import Distribution.Utils.ShortText (ShortText, fromShortText, toShortText)
+import System.FilePath              (pathSeparator)
 
 import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint                as Disp

--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -73,6 +73,7 @@ import qualified System.Directory        (getDirectoryContents)
 import qualified System.FilePath.Windows as FilePath.Windows (isValid)
 
 import qualified Data.Set as Set
+import qualified Distribution.Utils.ShortText as ShortText
 
 import qualified Distribution.Types.BuildInfo.Lens                 as L
 import qualified Distribution.Types.GenericPackageDescription.Lens as L
@@ -497,32 +498,32 @@ checkFields pkg =
             ++ "' use '" ++ prettyShow replacement ++ "'."
              | (ext, Just replacement) <- ourDeprecatedExtensions ]
 
-  , check (null (category pkg)) $
+  , check (ShortText.null (category pkg)) $
       PackageDistSuspicious "No 'category' field."
 
-  , check (null (maintainer pkg)) $
+  , check (ShortText.null (maintainer pkg)) $
       PackageDistSuspicious "No 'maintainer' field."
 
-  , check (null (synopsis pkg) && null (description pkg)) $
+  , check (ShortText.null (synopsis pkg) && ShortText.null (description pkg)) $
       PackageDistInexcusable "No 'synopsis' or 'description' field."
 
-  , check (null (description pkg) && not (null (synopsis pkg))) $
+  , check (ShortText.null (description pkg) && not (ShortText.null (synopsis pkg))) $
       PackageDistSuspicious "No 'description' field."
 
-  , check (null (synopsis pkg) && not (null (description pkg))) $
+  , check (ShortText.null (synopsis pkg) && not (ShortText.null (description pkg))) $
       PackageDistSuspicious "No 'synopsis' field."
 
     --TODO: recommend the bug reports URL, author and homepage fields
     --TODO: recommend not using the stability field
     --TODO: recommend specifying a source repo
 
-  , check (length (synopsis pkg) >= 80) $
+  , check (ShortText.length (synopsis pkg) >= 80) $
       PackageDistSuspicious
         "The 'synopsis' field is rather long (max 80 chars is recommended)."
 
     -- See also https://github.com/haskell/cabal/pull/3479
-  , check (not (null (description pkg))
-           && length (description pkg) <= length (synopsis pkg)) $
+  , check (not (ShortText.null (description pkg))
+           && ShortText.length (description pkg) <= ShortText.length (synopsis pkg)) $
       PackageDistSuspicious $
            "The 'description' field should be longer than the 'synopsis' "
         ++ "field. "

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -76,18 +76,18 @@ packageDescriptionFieldGrammar = PackageDescription
     <*> blurFieldGrammar L.package packageIdentifierGrammar
     <*> optionalFieldDefAla "license"       SpecLicense                L.licenseRaw (Left SPDX.NONE)
     <*> licenseFilesGrammar
-    <*> freeTextFieldDef    "copyright"                                L.copyright
-    <*> freeTextFieldDef    "maintainer"                               L.maintainer
-    <*> freeTextFieldDef    "author"                                   L.author
-    <*> freeTextFieldDef    "stability"                                L.stability
+    <*> freeTextFieldDefST  "copyright"                                L.copyright
+    <*> freeTextFieldDefST  "maintainer"                               L.maintainer
+    <*> freeTextFieldDefST  "author"                                   L.author
+    <*> freeTextFieldDefST  "stability"                                L.stability
     <*> monoidalFieldAla    "tested-with"   (alaList' FSep TestedWith) L.testedWith
-    <*> freeTextFieldDef    "homepage"                                 L.homepage
-    <*> freeTextFieldDef    "package-url"                              L.pkgUrl
-    <*> freeTextFieldDef    "bug-reports"                              L.bugReports
+    <*> freeTextFieldDefST  "homepage"                                 L.homepage
+    <*> freeTextFieldDefST  "package-url"                              L.pkgUrl
+    <*> freeTextFieldDefST   "bug-reports"                              L.bugReports
     <*> pure [] -- source-repos are stanza
-    <*> freeTextFieldDef    "synopsis"                                 L.synopsis
-    <*> freeTextFieldDef    "description"                              L.description
-    <*> freeTextFieldDef    "category"                                 L.category
+    <*> freeTextFieldDefST  "synopsis"                                 L.synopsis
+    <*> freeTextFieldDefST  "description"                              L.description
+    <*> freeTextFieldDefST  "category"                                 L.category
     <*> prefixedFields      "x-"                                       L.customFieldsPD
     <*> optionalField       "build-type"                               L.buildTypeRaw
     <*> pure Nothing -- custom-setup

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -36,6 +36,7 @@ import Distribution.Compat.Prelude
 import Prelude ()
 
 import Control.Applicative                           (Const (..))
+import Control.DeepSeq                               (deepseq)
 import Control.Monad                                 (guard)
 import Control.Monad.State.Strict                    (StateT, execStateT)
 import Control.Monad.Trans.Class                     (lift)
@@ -70,9 +71,7 @@ import Distribution.Types.PackageDescription         (specVersion')
 import Distribution.Types.UnqualComponentName        (UnqualComponentName, mkUnqualComponentName)
 import Distribution.Utils.Generic                    (breakMaybe, unfoldrM, validateUTF8)
 import Distribution.Verbosity                        (Verbosity)
-import Distribution.Version
-       (LowerBound (..), Version, asVersionIntervals, mkVersion, orLaterVersion, version0,
-       versionNumbers)
+import Distribution.Version                          (LowerBound (..), Version, asVersionIntervals, mkVersion, orLaterVersion, version0, versionNumbers)
 
 import qualified Data.ByteString                                   as BS
 import qualified Data.ByteString.Char8                             as BS8
@@ -200,7 +199,7 @@ parseGenericPackageDescription' cabalVerM lexWarnings utf8WarnPos fs = do
     gpd1 <- view stateGpd <$> execStateT (goSections specVer sectionFields) (SectionS gpd Map.empty)
 
     checkForUndefinedFlags gpd1
-    return gpd1
+    gpd1 `deepseq` return gpd1
   where
     safeLast :: [a] -> Maybe a
     safeLast = listToMaybe . reverse

--- a/Cabal/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/Types/InstalledPackageInfo.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE OverloadedStrings  #-}
 module Distribution.Types.InstalledPackageInfo (
     InstalledPackageInfo (..),
     emptyInstalledPackageInfo,
@@ -25,6 +26,7 @@ import Distribution.Types.LibraryVisibility
 import Distribution.Types.MungedPackageId
 import Distribution.Types.MungedPackageName
 import Distribution.Version                 (nullVersion)
+import Distribution.Utils.ShortText         (ShortText)
 
 import qualified Distribution.Package as Package
 import qualified Distribution.SPDX    as SPDX
@@ -50,15 +52,15 @@ data InstalledPackageInfo
         instantiatedWith  :: [(ModuleName, OpenModule)],
         compatPackageKey  :: String,
         license           :: Either SPDX.License License,
-        copyright         :: String,
-        maintainer        :: String,
-        author            :: String,
-        stability         :: String,
-        homepage          :: String,
-        pkgUrl            :: String,
-        synopsis          :: String,
-        description       :: String,
-        category          :: String,
+        copyright         :: !ShortText,
+        maintainer        :: !ShortText,
+        author            :: !ShortText,
+        stability         :: !ShortText,
+        homepage          :: !ShortText,
+        pkgUrl            :: !ShortText,
+        synopsis          :: !ShortText,
+        description       :: !ShortText,
+        category          :: !ShortText,
         -- these parts are required by an installed package only:
         abiHash           :: AbiHash,
         indefinite        :: Bool,

--- a/Cabal/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
+++ b/Cabal/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
@@ -67,15 +67,15 @@ ipiFieldGrammar = mkInstalledPackageInfo
     <+> optionalFieldDefAla "instantiated-with"    InstWith                      L.instantiatedWith []
     <+> optionalFieldDefAla "key"                  CompatPackageKey              L.compatPackageKey ""
     <+> optionalFieldDefAla "license"              SpecLicenseLenient            L.license (Left SPDX.NONE)
-    <+> freeTextFieldDef    "copyright"                                          L.copyright
-    <+> freeTextFieldDef    "maintainer"                                         L.maintainer
-    <+> freeTextFieldDef    "author"                                             L.author
-    <+> freeTextFieldDef    "stability"                                          L.stability
-    <+> freeTextFieldDef    "homepage"                                           L.homepage
-    <+> freeTextFieldDef    "package-url"                                        L.pkgUrl
-    <+> freeTextFieldDef    "synopsis"                                           L.synopsis
-    <+> freeTextFieldDef    "description"                                        L.description
-    <+> freeTextFieldDef    "category"                                           L.category
+    <+> freeTextFieldDefST    "copyright"                                          L.copyright
+    <+> freeTextFieldDefST    "maintainer"                                         L.maintainer
+    <+> freeTextFieldDefST    "author"                                             L.author
+    <+> freeTextFieldDefST    "stability"                                          L.stability
+    <+> freeTextFieldDefST    "homepage"                                           L.homepage
+    <+> freeTextFieldDefST    "package-url"                                        L.pkgUrl
+    <+> freeTextFieldDefST    "synopsis"                                           L.synopsis
+    <+> freeTextFieldDefST    "description"                                        L.description
+    <+> freeTextFieldDefST    "category"                                           L.category
     -- Installed fields
     <+> optionalFieldDef    "abi"                                                L.abiHash (mkAbiHash "")
     <+> booleanFieldDef     "indefinite"                                         L.indefinite False

--- a/Cabal/Distribution/Types/InstalledPackageInfo/Lens.hs
+++ b/Cabal/Distribution/Types/InstalledPackageInfo/Lens.hs
@@ -14,6 +14,8 @@ import Distribution.Package                    (AbiHash, ComponentId, PackageIde
 import Distribution.Types.InstalledPackageInfo (AbiDependency, ExposedModule, InstalledPackageInfo)
 import Distribution.Types.LibraryName          (LibraryName)
 import Distribution.Types.LibraryVisibility    (LibraryVisibility)
+import Distribution.Utils.ShortText            (ShortText)
+
 
 import qualified Distribution.SPDX                       as SPDX
 import qualified Distribution.Types.InstalledPackageInfo as T
@@ -46,39 +48,39 @@ license :: Lens' InstalledPackageInfo (Either SPDX.License License)
 license f s = fmap (\x -> s { T.license = x }) (f (T.license s))
 {-# INLINE license #-}
 
-copyright :: Lens' InstalledPackageInfo String
+copyright :: Lens' InstalledPackageInfo ShortText
 copyright f s = fmap (\x -> s { T.copyright = x }) (f (T.copyright s))
 {-# INLINE copyright #-}
 
-maintainer :: Lens' InstalledPackageInfo String
+maintainer :: Lens' InstalledPackageInfo ShortText
 maintainer f s = fmap (\x -> s { T.maintainer = x }) (f (T.maintainer s))
 {-# INLINE maintainer #-}
 
-author :: Lens' InstalledPackageInfo String
+author :: Lens' InstalledPackageInfo ShortText
 author f s = fmap (\x -> s { T.author = x }) (f (T.author s))
 {-# INLINE author #-}
 
-stability :: Lens' InstalledPackageInfo String
+stability :: Lens' InstalledPackageInfo ShortText
 stability f s = fmap (\x -> s { T.stability = x }) (f (T.stability s))
 {-# INLINE stability #-}
 
-homepage :: Lens' InstalledPackageInfo String
+homepage :: Lens' InstalledPackageInfo ShortText
 homepage f s = fmap (\x -> s { T.homepage = x }) (f (T.homepage s))
 {-# INLINE homepage #-}
 
-pkgUrl :: Lens' InstalledPackageInfo String
+pkgUrl :: Lens' InstalledPackageInfo ShortText
 pkgUrl f s = fmap (\x -> s { T.pkgUrl = x }) (f (T.pkgUrl s))
 {-# INLINE pkgUrl #-}
 
-synopsis :: Lens' InstalledPackageInfo String
+synopsis :: Lens' InstalledPackageInfo ShortText
 synopsis f s = fmap (\x -> s { T.synopsis = x }) (f (T.synopsis s))
 {-# INLINE synopsis #-}
 
-description :: Lens' InstalledPackageInfo String
+description :: Lens' InstalledPackageInfo ShortText
 description f s = fmap (\x -> s { T.description = x }) (f (T.description s))
 {-# INLINE description #-}
 
-category :: Lens' InstalledPackageInfo String
+category :: Lens' InstalledPackageInfo ShortText
 category f s = fmap (\x -> s { T.category = x }) (f (T.category s))
 {-# INLINE category #-}
 

--- a/Cabal/Distribution/Types/PackageDescription.hs
+++ b/Cabal/Distribution/Types/PackageDescription.hs
@@ -88,6 +88,7 @@ import Distribution.Compiler
 import Distribution.License
 import Distribution.Package
 import Distribution.Version
+import Distribution.Utils.ShortText
 
 import qualified Distribution.SPDX as SPDX
 
@@ -113,18 +114,18 @@ data PackageDescription
         package        :: PackageIdentifier,
         licenseRaw     :: Either SPDX.License License,
         licenseFiles   :: [FilePath],
-        copyright      :: String,
-        maintainer     :: String,
-        author         :: String,
-        stability      :: String,
+        copyright      :: !ShortText,
+        maintainer     :: !ShortText,
+        author         :: !ShortText,
+        stability      :: !ShortText,
         testedWith     :: [(CompilerFlavor,VersionRange)],
-        homepage       :: String,
-        pkgUrl         :: String,
-        bugReports     :: String,
+        homepage       :: !ShortText,
+        pkgUrl         :: !ShortText,
+        bugReports     :: !ShortText,
         sourceRepos    :: [SourceRepo],
-        synopsis       :: String, -- ^A one-line summary of this package
-        description    :: String, -- ^A more verbose description of this package
-        category       :: String,
+        synopsis       :: !ShortText, -- ^A one-line summary of this package
+        description    :: !ShortText, -- ^A more verbose description of this package
+        category       :: !ShortText,
         customFieldsPD :: [(String,String)], -- ^Custom fields starting
                                              -- with x-, stored in a
                                              -- simple assoc-list.
@@ -224,18 +225,18 @@ emptyPackageDescription
                       licenseFiles = [],
                       specVersionRaw = Right anyVersion,
                       buildTypeRaw = Nothing,
-                      copyright    = "",
-                      maintainer   = "",
-                      author       = "",
-                      stability    = "",
+                      copyright    = mempty,
+                      maintainer   = mempty,
+                      author       = mempty,
+                      stability    = mempty,
                       testedWith   = [],
-                      homepage     = "",
-                      pkgUrl       = "",
-                      bugReports   = "",
+                      homepage     = mempty,
+                      pkgUrl       = mempty,
+                      bugReports   = mempty,
                       sourceRepos  = [],
-                      synopsis     = "",
-                      description  = "",
-                      category     = "",
+                      synopsis     = mempty,
+                      description  = mempty,
+                      category     = mempty,
                       customFieldsPD = [],
                       setupBuildInfo = Nothing,
                       library      = Nothing,

--- a/Cabal/Distribution/Types/PackageDescription/Lens.hs
+++ b/Cabal/Distribution/Types/PackageDescription/Lens.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RankNTypes        #-}
 module Distribution.Types.PackageDescription.Lens (
     PackageDescription,
     module Distribution.Types.PackageDescription.Lens,
@@ -9,27 +9,28 @@ import Distribution.Compat.Lens
 import Distribution.Compat.Prelude
 import Prelude ()
 
-import Distribution.Compiler                  (CompilerFlavor)
-import Distribution.License                   (License)
-import Distribution.ModuleName                (ModuleName)
-import Distribution.Types.Benchmark           (Benchmark, benchmarkModules)
-import Distribution.Types.Benchmark.Lens      (benchmarkName, benchmarkBuildInfo)
-import Distribution.Types.BuildInfo           (BuildInfo)
-import Distribution.Types.BuildType           (BuildType)
-import Distribution.Types.ComponentName       (ComponentName(..))
-import Distribution.Types.Executable          (Executable, exeModules)
-import Distribution.Types.Executable.Lens     (exeName, exeBuildInfo)
-import Distribution.Types.ForeignLib          (ForeignLib, foreignLibModules)
-import Distribution.Types.ForeignLib.Lens     (foreignLibName, foreignLibBuildInfo)
-import Distribution.Types.Library             (Library, explicitLibModules)
-import Distribution.Types.Library.Lens        (libName, libBuildInfo)
-import Distribution.Types.PackageDescription  (PackageDescription)
-import Distribution.Types.PackageId           (PackageIdentifier)
-import Distribution.Types.SetupBuildInfo      (SetupBuildInfo)
-import Distribution.Types.SourceRepo          (SourceRepo)
-import Distribution.Types.TestSuite           (TestSuite, testModules)
-import Distribution.Types.TestSuite.Lens      (testName, testBuildInfo)
-import Distribution.Version                   (Version, VersionRange)
+import Distribution.Compiler                 (CompilerFlavor)
+import Distribution.License                  (License)
+import Distribution.ModuleName               (ModuleName)
+import Distribution.Types.Benchmark          (Benchmark, benchmarkModules)
+import Distribution.Types.Benchmark.Lens     (benchmarkBuildInfo, benchmarkName)
+import Distribution.Types.BuildInfo          (BuildInfo)
+import Distribution.Types.BuildType          (BuildType)
+import Distribution.Types.ComponentName      (ComponentName (..))
+import Distribution.Types.Executable         (Executable, exeModules)
+import Distribution.Types.Executable.Lens    (exeBuildInfo, exeName)
+import Distribution.Types.ForeignLib         (ForeignLib, foreignLibModules)
+import Distribution.Types.ForeignLib.Lens    (foreignLibBuildInfo, foreignLibName)
+import Distribution.Types.Library            (Library, explicitLibModules)
+import Distribution.Types.Library.Lens       (libBuildInfo, libName)
+import Distribution.Types.PackageDescription (PackageDescription)
+import Distribution.Types.PackageId          (PackageIdentifier)
+import Distribution.Types.SetupBuildInfo     (SetupBuildInfo)
+import Distribution.Types.SourceRepo         (SourceRepo)
+import Distribution.Types.TestSuite          (TestSuite, testModules)
+import Distribution.Types.TestSuite.Lens     (testBuildInfo, testName)
+import Distribution.Utils.ShortText          (ShortText)
+import Distribution.Version                  (Version, VersionRange)
 
 import qualified Distribution.SPDX                     as SPDX
 import qualified Distribution.Types.PackageDescription as T
@@ -42,23 +43,23 @@ licenseRaw :: Lens' PackageDescription (Either SPDX.License License)
 licenseRaw f s = fmap (\x -> s { T.licenseRaw = x }) (f (T.licenseRaw s))
 {-# INLINE licenseRaw #-}
 
-licenseFiles :: Lens' PackageDescription [String]
+licenseFiles :: Lens' PackageDescription [FilePath]
 licenseFiles f s = fmap (\x -> s { T.licenseFiles = x }) (f (T.licenseFiles s))
 {-# INLINE licenseFiles #-}
 
-copyright :: Lens' PackageDescription String
+copyright :: Lens' PackageDescription ShortText
 copyright f s = fmap (\x -> s { T.copyright = x }) (f (T.copyright s))
 {-# INLINE copyright #-}
 
-maintainer :: Lens' PackageDescription String
+maintainer :: Lens' PackageDescription ShortText
 maintainer f s = fmap (\x -> s { T.maintainer = x }) (f (T.maintainer s))
 {-# INLINE maintainer #-}
 
-author :: Lens' PackageDescription String
+author :: Lens' PackageDescription ShortText
 author f s = fmap (\x -> s { T.author = x }) (f (T.author s))
 {-# INLINE author #-}
 
-stability :: Lens' PackageDescription String
+stability :: Lens' PackageDescription ShortText
 stability f s = fmap (\x -> s { T.stability = x }) (f (T.stability s))
 {-# INLINE stability #-}
 
@@ -66,15 +67,15 @@ testedWith :: Lens' PackageDescription [(CompilerFlavor,VersionRange)]
 testedWith f s = fmap (\x -> s { T.testedWith = x }) (f (T.testedWith s))
 {-# INLINE testedWith #-}
 
-homepage :: Lens' PackageDescription String
+homepage :: Lens' PackageDescription ShortText
 homepage f s = fmap (\x -> s { T.homepage = x }) (f (T.homepage s))
 {-# INLINE homepage #-}
 
-pkgUrl :: Lens' PackageDescription String
+pkgUrl :: Lens' PackageDescription ShortText
 pkgUrl f s = fmap (\x -> s { T.pkgUrl = x }) (f (T.pkgUrl s))
 {-# INLINE pkgUrl #-}
 
-bugReports :: Lens' PackageDescription String
+bugReports :: Lens' PackageDescription ShortText
 bugReports f s = fmap (\x -> s { T.bugReports = x }) (f (T.bugReports s))
 {-# INLINE bugReports #-}
 
@@ -82,15 +83,15 @@ sourceRepos :: Lens' PackageDescription [SourceRepo]
 sourceRepos f s = fmap (\x -> s { T.sourceRepos = x }) (f (T.sourceRepos s))
 {-# INLINE sourceRepos #-}
 
-synopsis :: Lens' PackageDescription String
+synopsis :: Lens' PackageDescription ShortText
 synopsis f s = fmap (\x -> s { T.synopsis = x }) (f (T.synopsis s))
 {-# INLINE synopsis #-}
 
-description :: Lens' PackageDescription String
+description :: Lens' PackageDescription ShortText
 description f s = fmap (\x -> s { T.description = x }) (f (T.description s))
 {-# INLINE description #-}
 
-category :: Lens' PackageDescription String
+category :: Lens' PackageDescription ShortText
 category f s = fmap (\x -> s { T.category = x }) (f (T.category s))
 {-# INLINE category #-}
 
@@ -165,18 +166,18 @@ componentModules :: Monoid r => ComponentName -> Getting r PackageDescription [M
 componentModules cname = case cname of
     CLibName    name ->
       componentModules' name allLibraries             libName            explicitLibModules
-    CFLibName   name -> 
+    CFLibName   name ->
       componentModules' name (foreignLibs . traverse) foreignLibName     foreignLibModules
-    CExeName    name -> 
+    CExeName    name ->
       componentModules' name (executables . traverse) exeName            exeModules
-    CTestName   name -> 
+    CTestName   name ->
       componentModules' name (testSuites  . traverse) testName           testModules
     CBenchName  name ->
       componentModules' name (benchmarks  . traverse) benchmarkName      benchmarkModules
   where
     componentModules'
         :: (Eq name, Monoid r)
-        => name 
+        => name
         -> Traversal' PackageDescription a
         -> Lens' a name
         -> (a -> [ModuleName])
@@ -192,21 +193,21 @@ componentModules cname = case cname of
 -- | @since 2.4
 componentBuildInfo :: ComponentName -> Traversal' PackageDescription BuildInfo
 componentBuildInfo cname = case cname of
-    CLibName    name -> 
+    CLibName    name ->
       componentBuildInfo' name allLibraries             libName            libBuildInfo
-    CFLibName   name -> 
+    CFLibName   name ->
       componentBuildInfo' name (foreignLibs . traverse) foreignLibName     foreignLibBuildInfo
-    CExeName    name -> 
+    CExeName    name ->
       componentBuildInfo' name (executables . traverse) exeName            exeBuildInfo
-    CTestName   name -> 
+    CTestName   name ->
       componentBuildInfo' name (testSuites  . traverse) testName           testBuildInfo
     CBenchName  name ->
       componentBuildInfo' name (benchmarks  . traverse) benchmarkName      benchmarkBuildInfo
   where
     componentBuildInfo' :: Eq name
-                        => name 
+                        => name
                         -> Traversal' PackageDescription a
-                        -> Lens' a name 
+                        -> Lens' a name
                         -> Traversal' a BuildInfo
                         -> Traversal' PackageDescription BuildInfo
     componentBuildInfo' name pdL nameL biL =

--- a/Cabal/tests/HackageTests.hs
+++ b/Cabal/tests/HackageTests.hs
@@ -231,8 +231,8 @@ roundtripTest testFieldsTransform fpath bs = do
     let x1 = x0 & L.packageDescription . L.licenseFiles %~ stripEmpty
     let y2 = y1 & L.packageDescription . L.licenseFiles %~ stripEmpty
 
-    let y = y2 & L.packageDescription . L.description .~ ""
-    let x = x1 & L.packageDescription . L.description .~ ""
+    let y = y2 & L.packageDescription . L.description .~ mempty
+    let x = x1 & L.packageDescription . L.description .~ mempty
 
     assertEqual' bs' x y
 

--- a/Cabal/tests/Instances/TreeDiff.hs
+++ b/Cabal/tests/Instances/TreeDiff.hs
@@ -36,6 +36,7 @@ import Distribution.Types.Mixin
 import Distribution.Types.PkgconfigDependency
 import Distribution.Types.UnitId              (DefUnitId, UnitId)
 import Distribution.Types.UnqualComponentName
+import Distribution.Utils.ShortText           (ShortText, fromShortText)
 
 -------------------------------------------------------------------------------
 -- instances
@@ -94,3 +95,5 @@ instance ToExpr TestSuiteInterface
 instance ToExpr TestType
 instance ToExpr UnitId where toExpr = defaultExprViaShow
 instance ToExpr UnqualComponentName where toExpr = defaultExprViaShow
+
+instance ToExpr ShortText where toExpr = toExpr . fromShortText

--- a/Cabal/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -23,6 +23,6 @@ tests = testGroup "Distribution.Utils.Structured"
     , testCase "SPDX.License"   $ structureHash (Proxy :: Proxy License)        @?= Fingerprint 0xd3d4a09f517f9f75 0xbc3d16370d5a853a
     -- The difference is in encoding of newtypes
 #if MIN_VERSION_base(4,7,0)
-    , testCase "LocalBuildInfo" $ structureHash (Proxy :: Proxy LocalBuildInfo) @?= Fingerprint 0x968aca759a33b9f8 0x19323edc38fbcbcb
+    , testCase "LocalBuildInfo" $ structureHash (Proxy :: Proxy LocalBuildInfo) @?= Fingerprint 0xb48ff44b0e5d96ff 0xfc099544337e90ab
 #endif
     ]

--- a/Makefile
+++ b/Makefile
@@ -112,26 +112,18 @@ cabal-install-test:
 
 # Docker validation
 
-validate-via-docker-all :
-	@echo "This takes a lot of time"
-	@echo 5
-	@sleep 1
-	@echo 4
-	@sleep 1
-	@echo 3
-	@sleep 1
-	@echo 2
-	@sleep 1
-	@echo 1
-	@sleep 1
-	$(MAKE) validate-via-docker-7.6.3
-	$(MAKE) validate-via-docker-7.8.4
-	$(MAKE) validate-via-docker-7.10.3
-	$(MAKE) validate-via-docker-8.0.2
-	$(MAKE) validate-via-docker-8.2.2
-	$(MAKE) validate-via-docker-8.4.4
-	$(MAKE) validate-via-docker-8.6.5
-	$(MAKE) validate-via-docker-8.8.1
+# Use this carefully, on big machine you can say
+#
+#   make validate-via-docker-all -j4 -O
+#
+validate-via-docker-all : validate-via-docker-7.6.3
+validate-via-docker-all : validate-via-docker-7.8.4
+validate-via-docker-all : validate-via-docker-7.10.3
+validate-via-docker-all : validate-via-docker-8.0.2
+validate-via-docker-all : validate-via-docker-8.2.2
+validate-via-docker-all : validate-via-docker-8.4.4
+validate-via-docker-all : validate-via-docker-8.6.5
+validate-via-docker-all : validate-via-docker-8.8.1
 
 validate-via-docker-7.6.3:
 	docker build -t cabal-validate -f .docker/validate-7.6.3.dockerfile .

--- a/cabal-install/Distribution/Client/Init/Heuristics.hs
+++ b/cabal-install/Distribution/Client/Init/Heuristics.hs
@@ -57,6 +57,8 @@ import Distribution.Client.Init.Types     ( InitFlags(..) )
 import Distribution.Client.Compat.Process ( readProcessWithExitCode )
 import System.Exit ( ExitCode(..) )
 
+import qualified Distribution.Utils.ShortText as ShortText
+
 -- | Return a list of candidate main files for this executable: top-level
 -- modules including the word 'Main' in the file name. The list is sorted in
 -- order of preference, shorter file names are preferred. 'Right's are existing
@@ -348,7 +350,7 @@ knownCategories :: SourcePackageDb -> [String]
 knownCategories (SourcePackageDb sourcePkgIndex _) = nubSet
     [ cat | pkg <- maybeToList . safeHead =<< (allPackagesByName sourcePkgIndex)
           , let catList = (PD.category . PD.packageDescription . packageDescription) pkg
-          , cat <- splitString ',' catList
+          , cat <- splitString ',' $ ShortText.fromShortText catList
     ]
 
 -- Parse name and email, from darcs pref files or environment variable

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -77,6 +77,9 @@ import Text.PrettyPrint as Disp
 import System.Directory
          ( doesDirectoryExist )
 
+import Distribution.Utils.ShortText (ShortText)
+import qualified Distribution.Utils.ShortText as ShortText
+
 
 -- | Return a list of packages matching given search strings.
 getPkgList :: Verbosity
@@ -277,15 +280,15 @@ data PackageDisplayInfo = PackageDisplayInfo {
     installedVersions :: [Version],
     sourceVersions    :: [Version],
     preferredVersions :: VersionRange,
-    homepage          :: String,
-    bugReports        :: String,
-    sourceRepo        :: String,
-    synopsis          :: String,
-    description       :: String,
-    category          :: String,
+    homepage          :: ShortText,
+    bugReports        :: ShortText,
+    sourceRepo        :: String, -- TODO
+    synopsis          :: ShortText,
+    description       :: ShortText,
+    category          :: ShortText,
     license           :: Either SPDX.License License,
-    author            :: String,
-    maintainer        :: String,
+    author            :: ShortText,
+    maintainer        :: ShortText,
     dependencies      :: [ExtDependency],
     flags             :: [Flag],
     hasLib            :: Bool,
@@ -307,7 +310,7 @@ showPackageSummaryInfo pkginfo =
      char '*' <+> disp (pkgName pkginfo)
      $+$
      (nest 4 $ vcat [
-       maybeShow (synopsis pkginfo) "Synopsis:" reflowParagraphs
+       maybeShowST (synopsis pkginfo) "Synopsis:" reflowParagraphs
      , text "Default available version:" <+>
        case selectedSourcePkg pkginfo of
          Nothing  -> text "[ Not available from any configured repository ]"
@@ -318,13 +321,14 @@ showPackageSummaryInfo pkginfo =
              | otherwise      -> text "[ Unknown ]"
          versions             -> dispTopVersions 4
                                    (preferredVersions pkginfo) versions
-     , maybeShow (homepage pkginfo) "Homepage:" text
+     , maybeShowST (homepage pkginfo) "Homepage:" text
      , text "License: " <+> either pretty pretty (license pkginfo)
      ])
      $+$ text ""
   where
-    maybeShow [] _ _ = empty
-    maybeShow l  s f = text s <+> (f l)
+    maybeShowST l s f
+        | ShortText.null l = empty
+        | otherwise        = text s <+> f (ShortText.fromShortText l)
 
 showPackageDetailedInfo :: PackageDisplayInfo -> String
 showPackageDetailedInfo pkginfo =
@@ -335,7 +339,7 @@ showPackageDetailedInfo pkginfo =
             Disp.<> parens pkgkind
    $+$
    (nest 4 $ vcat [
-     entry "Synopsis"      synopsis     hideIfNull     reflowParagraphs
+     entryST "Synopsis"      synopsis     hideIfNull  reflowParagraphs
    , entry "Versions available" sourceVersions
            (altText null "[ Not available from server ]")
            (dispTopVersions 9 (preferredVersions pkginfo))
@@ -343,13 +347,13 @@ showPackageDetailedInfo pkginfo =
            (altText null (if hasLib pkginfo then "[ Not installed ]"
                                             else "[ Unknown ]"))
            (dispTopVersions 4 (preferredVersions pkginfo))
-   , entry "Homepage"      homepage     orNotSpecified text
-   , entry "Bug reports"   bugReports   orNotSpecified text
-   , entry "Description"   description  hideIfNull     reflowParagraphs
-   , entry "Category"      category     hideIfNull     text
+   , entryST "Homepage"      homepage     orNotSpecified text
+   , entryST "Bug reports"   bugReports   orNotSpecified text
+   , entryST "Description"   description  hideIfNull     reflowParagraphs
+   , entryST "Category"      category     hideIfNull     text
    , entry "License"       license      alwaysShow     (either pretty pretty)
-   , entry "Author"        author       hideIfNull     reflowLines
-   , entry "Maintainer"    maintainer   hideIfNull     reflowLines
+   , entryST "Author"        author       hideIfNull     reflowLines
+   , entryST "Maintainer"    maintainer   hideIfNull     reflowLines
    , entry "Source repo"   sourceRepo   orNotSpecified text
    , entry "Executables"   executables  hideIfNull     (commaSep disp)
    , entry "Flags"         flags        hideIfNull     (commaSep dispFlag)
@@ -368,6 +372,8 @@ showPackageDetailedInfo pkginfo =
       where
         label   = text fname Disp.<> char ':' Disp.<> padding
         padding = text (replicate (13 - length fname ) ' ')
+
+    entryST fname field = entry fname (ShortText.fromShortText . field)
 
     normal      = Nothing
     hide        = Just Nothing
@@ -446,14 +452,14 @@ mergePackageInfo versionPref installedPkgs sourcePkgs selectedPkg showVer =
                            Installed.author     installed,
     homepage     = combine Source.homepage      source
                            Installed.homepage   installed,
-    bugReports   = maybe "" Source.bugReports source,
-    sourceRepo   = fromMaybe "" . join
+    bugReports   = maybe mempty Source.bugReports source,
+    sourceRepo   = fromMaybe mempty . join
                  . fmap (uncons Nothing Source.repoLocation
                        . sortBy (comparing Source.repoKind)
                        . Source.sourceRepos)
                  $ source,
                     --TODO: installed package info is missing synopsis
-    synopsis     = maybe "" Source.synopsis      source,
+    synopsis     = maybe mempty Source.synopsis      source,
     description  = combine Source.description    source
                            Installed.description installed,
     category     = combine Source.category       source

--- a/cabal-install/solver-dsl/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/solver-dsl/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
 -- | DSL for testing the modular solver
 module UnitTests.Distribution.Solver.Modular.DSL (
     ExampleDependency(..)


### PR DESCRIPTION
Based on #6366 

For benchmarks see https://oleg.fi/shorttext-benchmarks.html

- synthetic `hackage-tests`: no difference
- `Distribution.Simple.Program.HcPkg.dump`: faster and less memory usage
    - there's still plenty of `(:)` due `FilePath`s (my hypothesis)
- `cabal build --dry all` in large-ish project: same time, but less residency
