### PR TITLE
Add GHC-8.8 flags to normaliseGhcFlags (with test)

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -594,9 +594,10 @@ test-suite unit-tests
     Test.Laws
     Test.QuickCheck.Utils
     UnitTests.Distribution.Compat.CreatePipe
-    UnitTests.Distribution.Compat.Time
     UnitTests.Distribution.Compat.Graph
+    UnitTests.Distribution.Compat.Time
     UnitTests.Distribution.Simple.Glob
+    UnitTests.Distribution.Simple.Program.GHC
     UnitTests.Distribution.Simple.Program.Internal
     UnitTests.Distribution.Simple.Utils
     UnitTests.Distribution.SPDX
@@ -624,6 +625,7 @@ test-suite unit-tests
     temporary,
     text,
     pretty,
+    Diff >=0.4 && <0.5,
     QuickCheck >= 2.13.2 && < 2.14,
     Cabal
   ghc-options: -Wall

--- a/Cabal/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/Distribution/Simple/Program/GHC.hs
@@ -55,7 +55,7 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
     supportedGHCVersions :: VersionRange
     supportedGHCVersions = intersectVersionRanges
         (orLaterVersion (mkVersion [8,0]))
-        (earlierVersion (mkVersion [8,7]))
+        (earlierVersion (mkVersion [8,9]))
 
     from :: Monoid m => [Int] -> m -> m
     from version flags
@@ -218,6 +218,7 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
       , from [8,4] [ "-ddebug-output" ]
       , from [8,4] $ to [8,6] [ "-fno-max-valid-substitutions" ]
       , from [8,6] [ "-dhex-word-literals" ]
+      , from [8,8] [ "-fshow-docs-of-hole-fits", "-fno-show-docs-of-hole-fits" ]
       ]
 
     isOptIntFlag :: String -> Any

--- a/Cabal/tests/UnitTests.hs
+++ b/Cabal/tests/UnitTests.hs
@@ -17,6 +17,7 @@ import qualified UnitTests.Distribution.Compat.CreatePipe
 import qualified UnitTests.Distribution.Compat.Time
 import qualified UnitTests.Distribution.Compat.Graph
 import qualified UnitTests.Distribution.Simple.Glob
+import qualified UnitTests.Distribution.Simple.Program.GHC
 import qualified UnitTests.Distribution.Simple.Program.Internal
 import qualified UnitTests.Distribution.Simple.Utils
 import qualified UnitTests.Distribution.System
@@ -45,6 +46,7 @@ tests mtimeChangeCalibrated =
         UnitTests.Distribution.Compat.Graph.tests
     , testGroup "Distribution.Simple.Glob"
         UnitTests.Distribution.Simple.Glob.tests
+    , UnitTests.Distribution.Simple.Program.GHC.tests
     , testGroup "Distribution.Simple.Program.Internal"
         UnitTests.Distribution.Simple.Program.Internal.tests
     , testGroup "Distribution.Simple.Utils" $

--- a/Cabal/tests/UnitTests/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/tests/UnitTests/Distribution/Simple/Program/GHC.hs
@@ -1,0 +1,93 @@
+module UnitTests.Distribution.Simple.Program.GHC (tests) where
+
+import Test.Tasty       (TestTree, testGroup)
+import Test.Tasty.HUnit
+import Data.Algorithm.Diff (PolyDiff (..), getDiff)
+
+import Distribution.Simple.Program.GHC (normaliseGhcArgs)
+import Distribution.PackageDescription (emptyPackageDescription)
+import Distribution.Version (mkVersion)
+
+tests :: TestTree
+tests = testGroup "Distribution.Simple.Program.GHC"
+    [ testGroup "normaliseGhcArgs"
+        [ testCase "options added in GHC-8.8" $ do
+            let flags :: [String]
+                flags = normaliseGhcArgs
+                    (Just $ mkVersion [8,8,1])
+                    emptyPackageDescription
+                    options_8_8_all
+
+            assertListEquals flags options_8_8_affects
+        ]
+    ]
+
+assertListEquals :: (Eq a, Show a) => [a] -> [a] -> Assertion
+assertListEquals xs ys
+    | xs == ys = return ()
+    | otherwise = assertFailure $ unlines $
+        "Lists are not equal" :
+        [ case d of
+            First x  -> "- " ++ show x
+            Second y -> "+ " ++ show y
+            Both x _ -> "  " ++ show x
+        | d <- getDiff xs ys
+        ]
+
+-------------------------------------------------------------------------------
+-- Options
+-------------------------------------------------------------------------------
+
+-- | Options added in GHC-8.8, to generate:
+--
+-- @
+-- ghc-8.6.5 --show-options | sort > 8.6.5.txt
+-- ghc-8.8.1 --show-options | sort > 8.8.1.txt
+-- diff -u 8.6.5 8.8.1
+-- @
+--
+-- - remove -W(no-)error=, -W(no-)warn flags.
+-- - split into all and flags which may affect artifacts
+options_8_8_all :: [String]
+options_8_8_all =
+    [ "-ddump-cfg-weights"
+    , "-dno-suppress-stg-exts"
+    , "-dsuppress-stg-exts"
+    , "-Wmissed-extra-shared-lib"
+    , "-Wmissing-deriving-strategies"
+    , "-Wmissing-space-after-bang"
+    , "-Wno-missed-extra-shared-lib"
+    , "-Wno-missing-deriving-strategies"
+    , "-Wno-missing-space-after-bang"
+    , "-fno-show-docs-of-hole-fits"
+    , "-fshow-docs-of-hole-fits"
+    ] ++ options_8_8_affects
+
+options_8_8_affects :: [String]
+options_8_8_affects =
+    [ "-fblock-layout-cfg"
+    , "-fblock-layout-weightless"
+    , "-fblock-layout-weights"
+    , "-fclear-plugins"
+    , "-fkeep-cafs"
+    , "-fno-block-layout-cfg"
+    , "-fno-block-layout-weightless"
+    , "-fno-keep-cafs"
+    , "-fno-safe-haskell"
+    , "-fno-stg-lift-lams"
+    , "-fno-stg-lift-lams-known"
+    , "-fno-validate-ide-info"
+    , "-fno-write-ide-info"
+    , "-fstg-lift-lams"
+    , "-fstg-lift-lams-known"
+    , "-fstg-lift-lams-non-rec-args"
+    , "-fstg-lift-lams-non-rec-args-any"
+    , "-fstg-lift-lams-rec-args"
+    , "-fstg-lift-lams-rec-args-any"
+    , "-fvalidate-ide-info"
+    , "-fwrite-ide-info"
+    , "-hiedir"
+    , "-hiesuf"
+    , "-keep-hscpp-file"
+    , "-keep-hscpp-files"
+    ]


### PR DESCRIPTION
cc @merijn

I don't think `-fshow-docs-of-hole-fits` is the only non-trivial safe-to-omit flag. I'm not stressing about this too much, as situation may be improved.