### PR TITLE
Fix #4130: Create incoming directory

### DIFF
--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -984,6 +984,12 @@ buildAndInstallUnpackedPackage verbosity
             let prefix   = normalise $
                            dropDrive (InstallDirs.prefix (elabInstallDirs pkg))
                 entryDir = tmpDirNormalised </> prefix
+
+            -- if there weren't anything to build, it might be that directory is not created
+            -- the @setup Cabal.copyCommand@ above might do nothing.
+            -- https://github.com/haskell/cabal/issues/4130
+            createDirectoryIfMissingVerbose verbosity True entryDir
+
             LBS.writeFile
               (entryDir </> "cabal-hash.txt")
               (renderPackageHashInputs (packageHashInputs pkgshared pkg))


### PR DESCRIPTION
It's probably silent assumption that `setup Cabal.copyCommand`
would create directory structure. Who said it would do that.
For empty packages, sometimes it doesn't.

It's easier to be defensive here

---

I didn't write any test, I'll take a blame for that, I did test locally though.

---

```
% ghc-pkg --package-db=/cabal/store/ghc-8.6.5/package.db describe snap-app-0.7.0
name: snap-app
version: 0.7.0
id: snap-app-0.7.0-69381acbcfc33e2f42e1fee72b15c9d7d1d268b1e258f52f29e71a36232fc0bb
key: snap-app-0.7.0-69381acbcfc33e2f42e1fee72b15c9d7d1d268b1e258f52f29e71a36232fc0bb
license: BSD-3-Clause
author: None
synopsis: None
description:
    None
abi: daffb3201b734bc0c941cb76f1ff3f3e
exposed: True
data-dir: /cabal/store/ghc-8.6.5/snap-app-0.7.0-69381acbcfc33e2f42e1fee72b15c9d7d1d268b1e258f52f29e71a36232fc0bb/share
haddock-interfaces: /cabal/store/ghc-8.6.5/snap-app-0.7.0-69381acbcfc33e2f42e1fee72b15c9d7d1d268b1e258f52f29e71a36232fc0bb/share/doc/html/snap-app.haddock
haddock-html: /cabal/store/ghc-8.6.5/snap-app-0.7.0-69381acbcfc33e2f42e1fee72b15c9d7d1d268b1e258f52f29e71a36232fc0bb/share/doc/html
pkgroot: "/cabal/store/ghc-8.6.5"
```

```
% ls /cabal/store/ghc-8.6.5/snap-app-0.7.0-69381acbcfc33e2f42e1fee72b15c9d7d1d268b1e258f52f29e71a36232fc0bb
cabal-hash.txt
```

Compare to

```
% ghc-pkg --package-db=/cabal/store/ghc-8.6.5/package.db describe nats-1.1.1                               
name: nats
version: 1.1.1
id: nats-1.1.1-278430eda67bdb99a922d6693a9178db384b3273326705931c1a44b44c9d3e49
key: nats-1.1.1-278430eda67bdb99a922d6693a9178db384b3273326705931c1a44b44c9d3e49
license: BSD-3-Clause
copyright: Copyright (C) 2011-2014 Edward A. Kmett
maintainer: Edward A. Kmett <ekmett@gmail.com>
author: Edward A. Kmett
stability: provisional
homepage: http://github.com/ekmett/nats/
synopsis: Natural numbers
description:
    Natural numbers
category: Numeric, Algebra
abi: daffb3201b734bc0c941cb76f1ff3f3e
exposed: True
data-dir: /cabal/store/ghc-8.6.5/nats-1.1.1-278430eda67bdb99a922d6693a9178db384b3273326705931c1a44b44c9d3e49/share
haddock-interfaces: /cabal/store/ghc-8.6.5/nats-1.1.1-278430eda67bdb99a922d6693a9178db384b3273326705931c1a44b44c9d3e49/share/doc/html/nats.haddock
haddock-html: /cabal/store/ghc-8.6.5/nats-1.1.1-278430eda67bdb99a922d6693a9178db384b3273326705931c1a44b44c9d3e49/share/doc/html
pkgroot: "/cabal/store/ghc-8.6.5"
```

```
% find /cabal/store/ghc-8.6.5/nats-1.1.1-278430eda67bdb99a922d6693a9178db384b3273326705931c1a44b44c9d3e49
/cabal/store/ghc-8.6.5/nats-1.1.1-278430eda67bdb99a922d6693a9178db384b3273326705931c1a44b44c9d3e49
/cabal/store/ghc-8.6.5/nats-1.1.1-278430eda67bdb99a922d6693a9178db384b3273326705931c1a44b44c9d3e49/cabal-hash.txt
/cabal/store/ghc-8.6.5/nats-1.1.1-278430eda67bdb99a922d6693a9178db384b3273326705931c1a44b44c9d3e49/share
/cabal/store/ghc-8.6.5/nats-1.1.1-278430eda67bdb99a922d6693a9178db384b3273326705931c1a44b44c9d3e49/share/doc
/cabal/store/ghc-8.6.5/nats-1.1.1-278430eda67bdb99a922d6693a9178db384b3273326705931c1a44b44c9d3e49/share/doc/LICENSE
```

So the non-legacy builds worked because most packages have `license-file`, `snap-app-0.7.0` doesn't.