### PR TITLE
Freeze the versions of cabal-testsuite and solver-benchmarks

### DIFF
--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          cabal-testsuite
-version:       3.1.0.0
+version:       3
 copyright:     2003-2019, Cabal Development Team (see AUTHORS file)
 license:       BSD-3-Clause
 license-file:  LICENSE

--- a/solver-benchmarks/solver-benchmarks.cabal
+++ b/solver-benchmarks/solver-benchmarks.cabal
@@ -1,5 +1,5 @@
 name:          solver-benchmarks
-version:       3.1.0.0
+version:       3
 copyright:     2003-2017, Cabal Development Team (see AUTHORS file)
 license:       BSD3
 license-file:  LICENSE

--- a/travis-common.sh
+++ b/travis-common.sh
@@ -12,9 +12,9 @@ fi
 CABAL_STORE_DB="${HOME}/.cabal/store/ghc-${GHCVER}/package.db"
 CABAL_LOCAL_DB="${TRAVIS_BUILD_DIR}/dist-newstyle/packagedb/ghc-${GHCVER}"
 CABAL_BDIR="${TRAVIS_BUILD_DIR}/dist-newstyle/build/$ARCH/ghc-$GHCVER/Cabal-${CABAL_VERSION}"
-CABAL_TESTSUITE_BDIR="${TRAVIS_BUILD_DIR}/dist-newstyle/build/$ARCH/ghc-$GHCVER/cabal-testsuite-${CABAL_VERSION}"
+CABAL_TESTSUITE_BDIR="${TRAVIS_BUILD_DIR}/dist-newstyle/build/$ARCH/ghc-$GHCVER/cabal-testsuite-3"
 CABAL_INSTALL_BDIR="${TRAVIS_BUILD_DIR}/dist-newstyle/build/$ARCH/ghc-$GHCVER/cabal-install-${CABAL_INSTALL_VERSION}"
-SOLVER_BENCHMARKS_BDIR="${TRAVIS_BUILD_DIR}/dist-newstyle/build/$ARCH/ghc-$GHCVER/solver-benchmarks-${CABAL_VERSION}"
+SOLVER_BENCHMARKS_BDIR="${TRAVIS_BUILD_DIR}/dist-newstyle/build/$ARCH/ghc-$GHCVER/solver-benchmarks-3"
 CABAL_INSTALL_EXE=${CABAL_INSTALL_BDIR}/x/cabal/build/cabal/cabal
 
 # ---------------------------------------------------------------------

--- a/validate.sh
+++ b/validate.sh
@@ -176,9 +176,6 @@ timed $CABALPLAN --version
 # Basic setup
 #######################################################################
 
-# NOTE: This should match cabal-testsuite version
-CABAL_VERSION="3.1.0.0"
-
 if [ "$(uname)" = "Linux" ]; then
     ARCH="x86_64-linux"
 else
@@ -193,7 +190,7 @@ fi
 
 BASEHC=ghc-$($HC --numeric-version)
 BUILDDIR=dist-newstyle-validate-$BASEHC
-CABAL_TESTSUITE_BDIR="$(pwd)/$BUILDDIR/build/$ARCH/$BASEHC/cabal-testsuite-${CABAL_VERSION}"
+CABAL_TESTSUITE_BDIR="$(pwd)/$BUILDDIR/build/$ARCH/$BASEHC/cabal-testsuite-3"
 
 CABALNEWBUILD="${CABAL} v2-build $JOBS -w $HC --builddir=$BUILDDIR --project-file=$PROJECTFILE"
 CABALPLANLISTBIN="${CABALPLAN} list-bin --builddir=$BUILDDIR"


### PR DESCRIPTION
Similar change is done in 3.0 branch already.