### PR TITLE
Backport batch 1 for 3.2

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -291,7 +291,7 @@ library
   else
     build-depends: unix  >= 2.6.0.0 && < 2.8
 
-  ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs
+  ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances
 

--- a/Cabal/Distribution/Backpack/Configure.hs
+++ b/Cabal/Distribution/Backpack/Configure.hs
@@ -162,7 +162,8 @@ toComponentLocalBuildInfos
                        . map Right
                        $ graph
         combined_graph = Graph.unionRight external_graph internal_graph
-        Just local_graph = Graph.closure combined_graph (map nodeKey graph)
+        local_graph = fromMaybe (error "toComponentLocalBuildInfos: closure returned Nothing")
+                    $ Graph.closure combined_graph (map nodeKey graph)
         -- The database of transitively reachable installed packages that the
         -- external components the package (as a whole) depends on.  This will be
         -- used in several ways:

--- a/Cabal/Distribution/Parsec.hs
+++ b/Cabal/Distribution/Parsec.hs
@@ -379,7 +379,9 @@ escapeCode = (charEsc <|> charNum <|> charAscii <|> charControl) P.<?> "escape c
                                      nomore :: m ()
                                      nomore = P.notFollowedBy anyd <|> toomuch
 
-                                     (low, ex : high) = splitAt bd dps
+                                     (low, ex, high) = case splitAt bd dps of
+                                        (low', ex' : high') -> (low', ex', high')
+                                        (_, _)              -> error "escapeCode: Logic error"
                                   in ((:) <$> P.choice low <*> atMost (length bds) anyd) <* nomore
                                      <|> ((:) <$> ex <*> ([] <$ nomore <|> bounded'' dps bds))
                                      <|> if not (null bds)

--- a/Cabal/Distribution/Simple/Build/Macros.hs
+++ b/Cabal/Distribution/Simple/Build/Macros.hs
@@ -109,9 +109,9 @@ generateToolVersionMacros progs = concat
   ++ generateMacros "TOOL_" progname version
   | prog <- progs
   , isJust . programVersion $ prog
-  , let progid       = programId prog ++ "-" ++ prettyShow version
-        progname     = map fixchar (programId prog)
-        Just version = programVersion prog
+  , let progid   = programId prog ++ "-" ++ prettyShow version
+        progname = map fixchar (programId prog)
+        version  = fromMaybe version0 (programVersion prog)
   ]
 
 -- | Common implementation of 'generatePackageVersionMacros' and
@@ -131,7 +131,11 @@ generateMacros macro_prefix name version =
     ]
   ,"\n"]
   where
-    (major1:major2:minor:_) = map show (versionNumbers version ++ repeat 0)
+    (major1,major2,minor) = case map show (versionNumbers version) of
+        []        -> ("0", "0", "0")
+        [x]       -> (x,   "0", "0")
+        [x,y]     -> (x,   y,   "0")
+        (x:y:z:_) -> (x,   y,   z)
 
 -- | Generate the @CURRENT_COMPONENT_ID@ definition for the component ID
 --   of the current package.

--- a/Cabal/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/Distribution/Simple/BuildTarget.hs
@@ -58,6 +58,7 @@ import qualified Distribution.Compat.CharParsing as P
 
 import Control.Monad ( msum )
 import Data.List ( stripPrefix, groupBy, partition )
+import qualified Data.List.NonEmpty as NE
 import Data.Either ( partitionEithers )
 import System.FilePath as FilePath
          ( dropExtension, normalise, splitDirectories, joinPath, splitPath
@@ -318,8 +319,9 @@ resolveBuildTarget pkg userTarget fexists =
 
   where
     classifyMatchErrors errs
-      | not (null expected) = let (things, got:_) = unzip expected in
-                              BuildTargetExpected userTarget things got
+      | Just expected' <- NE.nonEmpty expected
+                            = let (things, got:|_) = NE.unzip expected' in
+                              BuildTargetExpected userTarget (NE.toList things) got
       | not (null nosuch)   = BuildTargetNoSuch   userTarget nosuch
       | otherwise = error $ "resolveBuildTarget: internal error in matching"
       where

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -317,7 +317,7 @@ guessRunghcFromGhcPath = guessToolFromGhcPath runghcProgram
 getGhcInfo :: Verbosity -> ConfiguredProgram -> IO [(String, String)]
 getGhcInfo verbosity ghcProg = Internal.getGhcInfo verbosity implInfo ghcProg
   where
-    Just version = programVersion ghcProg
+    version = fromMaybe (error "GHC.getGhcInfo: no ghc version") $ programVersion ghcProg
     implInfo = ghcVersionImplInfo version
 
 -- | Given a single package DB, return all installed packages.
@@ -363,7 +363,7 @@ toPackageIndex verbosity pkgss progdb = do
   return $! mconcat indices
 
   where
-    Just ghcProg = lookupProgram ghcProgram progdb
+    ghcProg = fromMaybe (error "GHC.toPackageIndex: no ghc program") $ lookupProgram ghcProgram progdb
 
 getLibDir :: Verbosity -> LocalBuildInfo -> IO FilePath
 getLibDir verbosity lbi =
@@ -396,7 +396,7 @@ getUserPackageDB _verbosity ghcProg platform = do
     platformAndVersion = Internal.ghcPlatformAndVersionString
                            platform ghcVersion
     packageConfFileName = "package.conf.d"
-    Just ghcVersion = programVersion ghcProg
+    ghcVersion = fromMaybe (error "GHC.getUserPackageDB: no ghc version") $ programVersion ghcProg
 
 checkPackageDbEnvVar :: Verbosity -> IO ()
 checkPackageDbEnvVar verbosity =
@@ -475,7 +475,7 @@ getInstalledPackagesMonitorFiles verbosity platform progdb =
       if isFileStyle then return path
                      else return (path </> "package.cache")
 
-    Just ghcProg = lookupProgram ghcProgram progdb
+    ghcProg = fromMaybe (error "GHC.toPackageIndex: no ghc program") $ lookupProgram ghcProgram progdb
 
 
 -- -----------------------------------------------------------------------------
@@ -2032,9 +2032,9 @@ hcPkgInfo progdb = HcPkg.HcPkgInfo
   , HcPkg.suppressFilesCheck   = v >= [6,6]
   }
   where
-    v               = versionNumbers ver
-    Just ghcPkgProg = lookupProgram ghcPkgProgram progdb
-    Just ver        = programVersion ghcPkgProg
+    v          = versionNumbers ver
+    ghcPkgProg = fromMaybe (error "GHC.hcPkgInfo: no ghc program") $ lookupProgram ghcPkgProgram progdb
+    ver        = fromMaybe (error "GHC.hcPkgInfo: no ghc version") $ programVersion ghcPkgProg
 
 registerPackage
   :: Verbosity
@@ -2051,7 +2051,7 @@ pkgRoot :: Verbosity -> LocalBuildInfo -> PackageDB -> IO FilePath
 pkgRoot verbosity lbi = pkgRoot'
    where
     pkgRoot' GlobalPackageDB =
-      let Just ghcProg = lookupProgram ghcProgram (withPrograms lbi)
+      let ghcProg = fromMaybe (error "GHC.pkgRoot: no ghc program") $ lookupProgram ghcProgram (withPrograms lbi)
       in  fmap takeDirectory (getGlobalPackageDB verbosity ghcProg)
     pkgRoot' UserPackageDB = do
       appDir <- getAppUserDataDirectory "ghc"

--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -241,7 +241,7 @@ guessToolFromGhcjsPath tool ghcjsProg verbosity searchpath
 getGhcInfo :: Verbosity -> ConfiguredProgram -> IO [(String, String)]
 getGhcInfo verbosity ghcjsProg = Internal.getGhcInfo verbosity implInfo ghcjsProg
   where
-    Just version = programVersion ghcjsProg
+    version = fromMaybe (error "GHCJS.getGhcInfo: no version") $ programVersion ghcjsProg
     implInfo = ghcVersionImplInfo version
 
 -- | Given a single package DB, return all installed packages.
@@ -275,7 +275,7 @@ toPackageIndex verbosity pkgss progdb = do
   return $! (mconcat indices)
 
   where
-    Just ghcjsProg = lookupProgram ghcjsProgram progdb
+    ghcjsProg = fromMaybe (error "GHCJS.toPackageIndex no ghcjs program") $ lookupProgram ghcjsProgram progdb
 
 getLibDir :: Verbosity -> LocalBuildInfo -> IO FilePath
 getLibDir verbosity lbi =
@@ -307,7 +307,7 @@ getUserPackageDB _verbosity ghcjsProg platform = do
     platformAndVersion = Internal.ghcPlatformAndVersionString
                            platform ghcjsVersion
     packageConfFileName = "package.conf.d"
-    Just ghcjsVersion = programVersion ghcjsProg
+    ghcjsVersion = fromMaybe (error "GHCJS.getUserPackageDB: no version") $ programVersion ghcjsProg
 
 checkPackageDbEnvVar :: Verbosity -> IO ()
 checkPackageDbEnvVar verbosity =
@@ -360,7 +360,7 @@ getInstalledPackagesMonitorFiles verbosity platform progdb =
       if isFileStyle then return path
                      else return (path </> "package.cache")
 
-    Just ghcjsProg = lookupProgram ghcjsProgram progdb
+    ghcjsProg = fromMaybe (error "GHCJS.toPackageIndex no ghcjs program") $ lookupProgram ghcjsProgram progdb
 
 
 toJSLibName :: String -> String
@@ -1782,8 +1782,8 @@ hcPkgInfo progdb = HcPkg.HcPkgInfo { HcPkg.hcPkgProgram    = ghcjsPkgProg
                                    }
   where
     v7_10 = mkVersion [7,10]
-    Just ghcjsPkgProg = lookupProgram ghcjsPkgProgram progdb
-    Just ver          = programVersion ghcjsPkgProg
+    ghcjsPkgProg = fromMaybe (error "GHCJS.hcPkgInfo no ghcjs program") $ lookupProgram ghcjsPkgProgram progdb
+    ver          = fromMaybe (error "GHCJS.hcPkgInfo no ghcjs version") $ programVersion ghcjsPkgProg
 
 registerPackage
   :: Verbosity
@@ -1800,7 +1800,7 @@ pkgRoot :: Verbosity -> LocalBuildInfo -> PackageDB -> IO FilePath
 pkgRoot verbosity lbi = pkgRoot'
    where
     pkgRoot' GlobalPackageDB =
-      let Just ghcjsProg = lookupProgram ghcjsProgram (withPrograms lbi)
+      let ghcjsProg = fromMaybe (error "GHCJS.pkgRoot: no ghcjs program") $ lookupProgram ghcjsProgram (withPrograms lbi)
       in  fmap takeDirectory (getGlobalPackageDB verbosity ghcjsProg)
     pkgRoot' UserPackageDB = do
       appDir <- getAppUserDataDirectory "ghcjs"
@@ -1830,4 +1830,4 @@ runCmd progdb exe =
   )
   where
     script = exe <.> "jsexe" </> "all" <.> "js"
-    Just ghcjsProg = lookupProgram ghcjsProgram progdb
+    ghcjsProg = fromMaybe (error "GHCJS.runCmd: no ghcjs program") $ lookupProgram ghcjsProgram progdb

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -525,7 +525,11 @@ getGhcCppOpts haddockVersion bi =
     haddockVersionMacro  = "-D__HADDOCK_VERSION__="
                            ++ show (v1 * 1000 + v2 * 10 + v3)
       where
-        [v1, v2, v3] = take 3 $ versionNumbers haddockVersion ++ [0,0]
+        (v1, v2, v3) = case versionNumbers haddockVersion of
+            []        -> (0,0,0)
+            [x]       -> (x,0,0)
+            [x,y]     -> (x,y,0)
+            (x:y:z:_) -> (x,y,z)
 
 getGhcLibDir :: Verbosity -> LocalBuildInfo
              -> IO HaddockArgs

--- a/Cabal/Distribution/Simple/ShowBuildInfo.hs
+++ b/Cabal/Distribution/Simple/ShowBuildInfo.hs
@@ -56,6 +56,9 @@
 
 module Distribution.Simple.ShowBuildInfo (mkBuildInfo) where
 
+import Distribution.Compat.Prelude
+import Prelude ()
+
 import qualified Distribution.Simple.GHC   as GHC
 import qualified Distribution.Simple.Program.GHC as GHC
 
@@ -122,7 +125,7 @@ mkBuildInfo pkg_descr lbi _flags targetsToBuild = info
       ]
       where
         bi = componentBuildInfo comp
-        Just comp = lookupComponent pkg_descr name
+        comp = fromMaybe (error $ "mkBuildInfo: no component " ++ prettyShow name) $ lookupComponent pkg_descr name
         compType = case comp of
           CLib _   -> "lib"
           CExe _   -> "exe"

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -207,7 +207,9 @@ writeSimpleTestStub :: PD.TestSuite -- ^ library 'TestSuite' for which a stub
 writeSimpleTestStub t dir = do
     createDirectoryIfMissing True dir
     let filename = dir </> stubFilePath t
-        PD.TestSuiteLibV09 _ m = PD.testInterface t
+        m = case PD.testInterface t of
+            PD.TestSuiteLibV09 _  m' -> m'
+            _                        -> error "writeSimpleTestStub: invalid TestSuite passed"
     writeFile filename $ simpleTestStub m
 
 -- | Source code for library test suite stub executable

--- a/Cabal/Distribution/Simple/UHC.hs
+++ b/Cabal/Distribution/Simple/UHC.hs
@@ -116,9 +116,11 @@ getGlobalPackageDir :: Verbosity -> ProgramDb -> IO FilePath
 getGlobalPackageDir verbosity progdb = do
     output <- getDbProgramOutput verbosity
                 uhcProgram progdb ["--meta-pkgdir-system"]
-    -- call to "lines" necessary, because pkgdir contains an extra newline at the end
-    let [pkgdir] = lines output
+    -- we need to trim because pkgdir contains an extra newline at the end
+    let pkgdir = trimEnd output
     return pkgdir
+  where
+    trimEnd = reverse . dropWhile isSpace . reverse
 
 getUserPackageDir :: NoCallStackIO FilePath
 getUserPackageDir = do

--- a/cabal-install/Distribution/Client/BuildReports/Storage.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Storage.hs
@@ -1,3 +1,5 @@
+-- TODO
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Reporting

--- a/cabal-install/Distribution/Client/CmdErrorMessages.hs
+++ b/cabal-install/Distribution/Client/CmdErrorMessages.hs
@@ -7,6 +7,9 @@ module Distribution.Client.CmdErrorMessages (
     module Distribution.Client.TargetSelector,
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.TargetSelector
          ( ComponentKindFilter, componentKind, showTargetSelector )
@@ -22,8 +25,7 @@ import Distribution.Solver.Types.OptionalStanza
 import Distribution.Deprecated.Text
          ( display )
 
-import Data.Maybe (isNothing)
-import Data.List (sortBy, groupBy, nub)
+import qualified Data.List.NonEmpty as NE
 import Data.Function (on)
 
 
@@ -77,8 +79,8 @@ renderListSemiAnd (x:xs) = x ++ "; " ++ renderListSemiAnd xs
 -- >   | (pkgname, components) <- sortGroupOn packageName allcomponents ]
 --
 sortGroupOn :: Ord b => (a -> b) -> [a] -> [(b, [a])]
-sortGroupOn key = map (\xs@(x:_) -> (key x, xs))
-                . groupBy ((==) `on` key)
+sortGroupOn key = map (\(x:|xs) -> (key x, x:xs))
+                . NE.groupBy ((==) `on` key)
                 . sortBy  (compare `on` key)
 
 

--- a/cabal-install/Distribution/Client/CmdInstall/ClientInstallFlags.hs
+++ b/cabal-install/Distribution/Client/CmdInstall/ClientInstallFlags.hs
@@ -29,6 +29,7 @@ instance Structured InstallMethod
 
 data ClientInstallFlags = ClientInstallFlags
   { cinstInstallLibs     :: Flag Bool
+  , cinstIgnoreProject   :: Flag Bool
   , cinstEnvironmentPath :: Flag FilePath
   , cinstOverwritePolicy :: Flag OverwritePolicy
   , cinstInstallMethod   :: Flag InstallMethod
@@ -48,6 +49,7 @@ instance Structured ClientInstallFlags
 defaultClientInstallFlags :: ClientInstallFlags
 defaultClientInstallFlags = ClientInstallFlags
   { cinstInstallLibs     = toFlag False
+  , cinstIgnoreProject   = toFlag False
   , cinstEnvironmentPath = mempty
   , cinstOverwritePolicy = mempty
   , cinstInstallMethod   = mempty
@@ -59,6 +61,10 @@ clientInstallOptions _ =
   [ option [] ["lib"]
     "Install libraries rather than executables from the target package."
     cinstInstallLibs (\v flags -> flags { cinstInstallLibs = v })
+    trueArg
+  , option "z" ["ignore-project"]
+    "Ignore local project configuration"
+    cinstIgnoreProject (\v flags -> flags { cinstIgnoreProject = v })
     trueArg
   , option [] ["package-env", "env"]
     "Set the environment file that may be modified."

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -250,13 +250,14 @@ replAction ( configFlags, configExFlags, installFlags
         -- help us resolve the targets, but that isn't ideal for performance,
         -- especially in the no-project case.
         withInstallPlan (lessVerbose verbosity) baseCtx $ \elaboratedPlan _ -> do
+          -- targets should be non-empty map, but there's no NonEmptyMap yet.
           targets <- validatedTargets elaboratedPlan targetSelectors
           
           let
-            Just (unitId, _) = safeHead $ Map.toList targets
+            (unitId, _) = fromMaybe (error "panic: targets should be non-empty") $ safeHead $ Map.toList targets
             originalDeps = installedUnitId <$> InstallPlan.directDeps elaboratedPlan unitId
             oci = OriginalComponentInfo unitId originalDeps
-            Just pkgId = packageId <$> InstallPlan.lookup elaboratedPlan unitId 
+            pkgId = fromMaybe (error $ "cannot find " ++ prettyShow unitId) $ packageId <$> InstallPlan.lookup elaboratedPlan unitId 
             baseCtx' = addDepsToProjectTarget (envPackages envFlags) pkgId baseCtx
 
           return (Just oci, baseCtx')

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -30,15 +30,13 @@ import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.ProjectBuilding
          ( rebuildTargetsDryRun, improveInstallPlanWithUpToDatePackages )
 import Distribution.Client.ProjectConfig
-         ( ProjectConfig(..), withProjectOrGlobalConfig
-         , projectConfigConfigFile, readGlobalConfig )
+         ( ProjectConfig(..), withProjectOrGlobalConfigIgn
+         , projectConfigConfigFile )
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.ProjectPlanning 
        ( ElaboratedSharedConfig(..), ElaboratedInstallPlan )
 import Distribution.Client.ProjectPlanning.Types
        ( elabOrderExeDependencies )
-import Distribution.Client.RebuildMonad
-         ( runRebuild )
 import Distribution.Client.Setup
          ( GlobalFlags, ConfigFlags(..), ConfigExFlags, InstallFlags )
 import qualified Distribution.Client.Setup as Client
@@ -237,11 +235,8 @@ replAction ( configFlags, configExFlags, installFlags
       with           = withProject    cliConfig             verbosity targetStrings
       without config = withoutProject (config <> cliConfig) verbosity targetStrings
     
-    (baseCtx, targetSelectors, finalizer, replType) <- if ignoreProject
-      then do
-        globalConfig <- runRebuild "" $ readGlobalConfig verbosity globalConfigFlag
-        without globalConfig
-      else withProjectOrGlobalConfig verbosity globalConfigFlag with without
+    (baseCtx, targetSelectors, finalizer, replType) <-
+      withProjectOrGlobalConfigIgn ignoreProject verbosity globalConfigFlag with without
 
     when (buildSettingOnlyDeps (buildSettings baseCtx)) $
       die' verbosity $ "The repl command does not support '--only-dependencies'. "

--- a/cabal-install/Distribution/Client/Compat/Semaphore.hs
+++ b/cabal-install/Distribution/Client/Compat/Semaphore.hs
@@ -12,6 +12,8 @@ import Control.Concurrent.STM (TVar, atomically, newTVar, readTVar, retry,
 import Control.Exception (mask_, onException)
 import Control.Monad (join, unless)
 import Data.Typeable (Typeable)
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
 
 -- | 'QSem' is a quantity semaphore in which the resource is aqcuired
 -- and released in units of one. It provides guaranteed FIFO ordering
@@ -97,8 +99,8 @@ signalQSem s@(QSem q b1 b2) =
     checkwake2 [] = do
       writeTVar q 1
       return (return ())
-    checkwake2 ys = do
-      let (z:zs) = reverse ys
+    checkwake2 (y:ys) = do
+      let (z:|zs) = NE.reverse (y:|ys)
       writeTVar b1 zs
       writeTVar b2 []
       return (wake s z)

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -341,12 +341,13 @@ instance Semigroup SavedConfig where
           combine        = combine'        savedInstallFlags
           lastNonEmptyNL = lastNonEmptyNL' savedInstallFlags
 
-      combinedSavedClientInstallFlags = ClientInstallFlags {
-        cinstInstallLibs = combine cinstInstallLibs,
-        cinstEnvironmentPath = combine cinstEnvironmentPath,
-        cinstOverwritePolicy = combine cinstOverwritePolicy,
-        cinstInstallMethod = combine cinstInstallMethod,
-        cinstInstalldir = combine cinstInstalldir
+      combinedSavedClientInstallFlags = ClientInstallFlags
+        { cinstInstallLibs     = combine cinstInstallLibs
+        , cinstIgnoreProject   = combine cinstIgnoreProject
+        , cinstEnvironmentPath = combine cinstEnvironmentPath
+        , cinstOverwritePolicy = combine cinstOverwritePolicy
+        , cinstInstallMethod   = combine cinstInstallMethod
+        , cinstInstalldir      = combine cinstInstalldir
         }
         where
           combine        = combine'        savedClientInstallFlags

--- a/cabal-install/Distribution/Client/Exec.hs
+++ b/cabal-install/Distribution/Client/Exec.hs
@@ -89,7 +89,7 @@ sandboxEnvironment verbosity sandboxDir comp platform programDb iEnv =
                Windows -> "PATH"
                _       -> "LD_LIBRARY_PATH"
     env getGlobalPackageDB hcProgram packagePathEnvVar = do
-        let Just program = lookupProgram hcProgram programDb
+        let program = fromMaybe (error "failed to find hcProgram") $ lookupProgram hcProgram programDb
         gDb <- getGlobalPackageDB verbosity program
         sandboxConfigFilePath <- getSandboxConfigFilePath mempty
         let sandboxPackagePath   = sandboxPackageDBPath sandboxDir comp platform

--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric, DeriveFunctor, GeneralizedNewtypeDeriving,
              NamedFieldPuns, BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -1097,11 +1098,16 @@ checkDirectoryModificationTime dir mtime =
       then return Nothing
       else return (Just mtime')
 
--- | Run an IO computation, returning @e@ if there is an 'error'
+-- | Run an IO computation, returning the first argument @e@ if there is an 'error'
 -- call. ('ErrorCall')
 handleErrorCall :: a -> IO a -> IO a
-handleErrorCall e =
-    handle (\(ErrorCall _) -> return e)
+handleErrorCall e = handle handler where
+#if MIN_VERSION_base(4,9,0)
+    handler (ErrorCallWithLocation _ _) = return e
+#else
+    handler (ErrorCall _) = return e
+#endif
+
 
 -- | Run an IO computation, returning @e@ if there is any 'IOException'.
 --

--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -35,6 +35,7 @@ import Distribution.Simple.Utils
          ( notice, die', info, writeFileAtomic )
 import Distribution.Verbosity
          ( Verbosity )
+import Distribution.Pretty (prettyShow)
 import Distribution.Deprecated.Text (display)
 import qualified Distribution.PackageDescription as PD
 import Distribution.Simple.Program
@@ -273,7 +274,7 @@ clonePackagesFromSourceRepo verbosity destDirPrefix
            throwIO (ClonePackageFailedWithExitCode
                       pkgid (srpToProxy repo) (programName (vcsProgram vcs)) exitcode)
       | (pkgid, repo, vcs, destDir) <- pkgrepos'
-      , let Just vcs' = Map.lookup (vcsRepoType vcs) vcss
+      , let vcs' = Map.findWithDefault (error $ "Cannot configure " ++ prettyShow (vcsRepoType vcs)) (vcsRepoType vcs) vcss
       ]
 
   where

--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -951,7 +951,9 @@ createMainHs flags =
       _ -> writeMainHs flags mainFile
   else return ()
   where
-    Flag mainFile = mainIs flags
+    mainFile = case mainIs flags of
+      Flag x -> x
+      NoFlag -> error "createMainHs: no mainIs"
 
 --- | Write a main file if it doesn't already exist.
 writeMainHs :: InitFlags -> FilePath -> IO ()

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -69,6 +69,7 @@ module Distribution.Client.InstallPlan (
 
 import Distribution.Client.Compat.Prelude hiding (toList, lookup, tail)
 import Prelude (tail)
+import Distribution.Compat.Stack (WithCallStack)
 
 import Distribution.Client.Types hiding (BuildOutcomes)
 import qualified Distribution.PackageDescription as PD
@@ -83,6 +84,7 @@ import Distribution.Package
 import Distribution.Solver.Types.SolverPackage
 import Distribution.Client.JobControl
 import Distribution.Deprecated.Text
+import Distribution.Pretty (prettyShow)
 import Text.PrettyPrint
 import qualified Distribution.Client.SolverInstallPlan as SolverInstallPlan
 import Distribution.Client.SolverInstallPlan (SolverInstallPlan)
@@ -164,6 +166,11 @@ data GenericPlanPackage ipkg srcpkg
    | Configured  srcpkg
    | Installed   srcpkg
   deriving (Eq, Show, Generic)
+
+displayGenericPlanPackage :: (IsUnit ipkg, IsUnit srcpkg) => GenericPlanPackage ipkg srcpkg -> String
+displayGenericPlanPackage (PreExisting pkg) = "PreExisting " ++ prettyShow (nodeKey pkg)
+displayGenericPlanPackage (Configured pkg)  = "Configured " ++ prettyShow (nodeKey pkg)
+displayGenericPlanPackage (Installed pkg)   = "Installed " ++ prettyShow (nodeKey pkg)
 
 -- | Convenience combinator for destructing 'GenericPlanPackage'.
 -- This is handy because if you case manually, you have to handle
@@ -249,7 +256,7 @@ mkInstallPlan loc graph indepGoals =
       planIndepGoals = indepGoals
     }
 
-internalError :: String -> String -> a
+internalError :: WithCallStack (String -> String -> a)
 internalError loc msg = error $ "internal error in InstallPlan." ++ loc
                              ++ if null msg then "" else ": " ++ msg
 
@@ -619,7 +626,7 @@ isInstalled _                = False
 -- and return any packages that are newly in the processing state (ie ready to
 -- process), along with the updated 'Processing' state.
 --
-completed :: (IsUnit ipkg, IsUnit srcpkg)
+completed :: forall ipkg srcpkg. (IsUnit ipkg, IsUnit srcpkg)
           => GenericInstallPlan ipkg srcpkg
           -> Processing -> UnitId
           -> ([GenericReadyPackage srcpkg], Processing)
@@ -644,8 +651,9 @@ completed plan (Processing processingSet completedSet failedSet) pkgid =
                             (map nodeKey newlyReady)
     processing'    = Processing processingSet' completedSet' failedSet
 
-    asReadyPackage (Configured pkg) = ReadyPackage pkg
-    asReadyPackage _ = internalError "completed" ""
+    asReadyPackage :: GenericPlanPackage ipkg srcpkg -> GenericReadyPackage srcpkg
+    asReadyPackage (Configured pkg)  = ReadyPackage pkg
+    asReadyPackage pkg = internalError "completed" $ "not in configured state: " ++ displayGenericPlanPackage pkg
 
 failed :: (IsUnit ipkg, IsUnit srcpkg)
        => GenericInstallPlan ipkg srcpkg
@@ -671,7 +679,7 @@ failed plan (Processing processingSet completedSet failedSet) pkgid =
     processing'    = Processing processingSet' completedSet failedSet'
 
     asConfiguredPackage (Configured pkg) = pkg
-    asConfiguredPackage _ = internalError "failed" "not in configured state"
+    asConfiguredPackage pkg = internalError "failed" $ "not in configured state: " ++ displayGenericPlanPackage pkg
 
 processingInvariant :: (IsUnit ipkg, IsUnit srcpkg)
                     => GenericInstallPlan ipkg srcpkg

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -286,7 +286,7 @@ foldMInstallPlanDepOrder visit =
       -- we go in the right order so the results map has entries for all deps
       let depresults :: [b]
           depresults =
-            map (\ipkgid -> let Just result = Map.lookup ipkgid results
+            map (\ipkgid -> let result = Map.findWithDefault (error "foldMInstallPlanDepOrder") ipkgid results
                               in result)
                 (InstallPlan.depends pkg)
       result <- visit pkg depresults
@@ -596,7 +596,7 @@ rebuildTargets verbosity
         handle (\(e :: BuildFailure) -> return (Left e)) $ fmap Right $
 
         let uid = installedUnitId pkg
-            Just pkgBuildStatus = Map.lookup uid pkgsBuildStatus in
+            pkgBuildStatus = Map.findWithDefault (error "rebuildTargets") uid pkgsBuildStatus in
 
         rebuildTarget
           verbosity
@@ -756,7 +756,7 @@ asyncDownloadPackages verbosity withRepoCtx installPlan pkgsBuildStatus body
       | InstallPlan.Configured elab
          <- InstallPlan.reverseTopologicalOrder installPlan
       , let uid = installedUnitId elab
-            Just pkgBuildStatus = Map.lookup uid pkgsBuildStatus
+            pkgBuildStatus = Map.findWithDefault (error "asyncDownloadPackages") uid pkgsBuildStatus
       , BuildStatusDownload <- [pkgBuildStatus]
       ]
 

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -29,6 +29,7 @@ module Distribution.Client.ProjectConfig (
     readGlobalConfig,
     readProjectLocalFreezeConfig,
     withProjectOrGlobalConfig,
+    withProjectOrGlobalConfigIgn,
     writeProjectLocalExtraConfig,
     writeProjectLocalFreezeConfig,
     writeProjectConfigFile,
@@ -453,6 +454,24 @@ instance Exception BadProjectRoot where
 renderBadProjectRoot :: BadProjectRoot -> String
 renderBadProjectRoot (BadProjectRootExplicitFile projectFile) =
     "The given project file '" ++ projectFile ++ "' does not exist."
+
+-- | Like 'withProjectOrGlobalConfig', with an additional boolean
+-- which tells to ignore local project.
+--
+-- Used to implement -z / --ignore-project behaviour
+--
+withProjectOrGlobalConfigIgn
+    :: Bool -- ^ whether to ignore local project
+    -> Verbosity
+    -> Flag FilePath
+    -> IO a
+    -> (ProjectConfig -> IO a)
+    -> IO a
+withProjectOrGlobalConfigIgn True  verbosity gcf _with without = do
+    globalConfig <- runRebuild "" $ readGlobalConfig verbosity gcf
+    without globalConfig
+withProjectOrGlobalConfigIgn False verbosity gcf with without =
+    withProjectOrGlobalConfig verbosity gcf with without
 
 withProjectOrGlobalConfig :: Verbosity
                           -> Flag FilePath

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -100,7 +100,7 @@ import Distribution.PackageDescription.Parsec
          ( parseGenericPackageDescription )
 import Distribution.Fields
          ( runParseResult, PError, PWarning, showPWarning)
-import Distribution.Pretty ()
+import Distribution.Pretty (prettyShow)
 import Distribution.Types.SourceRepo
          ( RepoType(..) )
 import Distribution.Client.SourceRepo
@@ -1152,7 +1152,7 @@ syncAndReadSourcePackagesRemoteRepos verbosity
     --TODO: pass progPathExtra on to 'configureVCS'
     let _progPathExtra = fromNubList projectConfigProgPathExtra
     getConfiguredVCS <- delayInitSharedResources $ \repoType ->
-                          let Just vcs = Map.lookup repoType knownVCSs in
+                          let vcs = Map.findWithDefault (error $ "Unknown VCS: " ++ prettyShow repoType) repoType knownVCSs in
                           configureVCS verbosity {-progPathExtra-} vcs
 
     concat <$> sequence

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -222,6 +222,10 @@ establishProjectBaseContext verbosity cliConfig currentCommand = do
                           verbosity cabalDirLayout
                           projectConfig
 
+    -- https://github.com/haskell/cabal/issues/6013
+    when (null (projectPackages projectConfig) && null (projectPackagesOptional projectConfig)) $
+        warn verbosity "There are no packages or optional-packages in the project"
+
     return ProjectBaseContext {
       distDirLayout,
       cabalDirLayout,

--- a/cabal-install/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/Distribution/Client/TargetSelector.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP, DeriveGeneric, DeriveFunctor,
              RecordWildCards, NamedFieldPuns #-}
+-- TODO
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.TargetSelector
@@ -78,6 +80,7 @@ import Data.Function
          ( on )
 import Data.List
          ( stripPrefix, partition, groupBy )
+import qualified Data.List.NonEmpty as NE
 import Data.Ord
          ( comparing )
 import qualified Data.Map.Lazy   as Map.Lazy
@@ -503,9 +506,9 @@ resolveTargetSelector knowntargets@KnownTargets{..} mfilter targetStrStatus =
     projectIsEmpty = null knownPackagesAll
 
     classifyMatchErrors errs
-      | not (null expected)
-      = let (things, got:_) = unzip expected in
-        TargetSelectorExpected targetStr things got
+      | Just expectedNE <- NE.nonEmpty expected
+      = let (things, got:|_) = NE.unzip expectedNE in
+        TargetSelectorExpected targetStr (NE.toList things) got
 
       | not (null nosuch)
       = TargetSelectorNoSuch targetStr nosuch

--- a/cabal-install/Distribution/Solver/Modular/ConfiguredConversion.hs
+++ b/cabal-install/Distribution/Solver/Modular/ConfiguredConversion.hs
@@ -45,7 +45,7 @@ convCP iidx sidx (CP qpi fa es ds) =
                       solverPkgExeDeps = fmap snd ds'
                     }
       where
-        Just srcpkg = CI.lookupPackageId sidx pi
+        srcpkg = fromMaybe (error "convCP: lookupPackageId failed") $ CI.lookupPackageId sidx pi
   where
     ds' :: ComponentDeps ([SolverId] {- lib -}, [SolverId] {- exe -})
     ds' = fmap (partitionEithers . map convConfId) ds

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+
+-- TODO: remove this
+{-# OPTIONS -fno-warn-incomplete-uni-patterns #-}
 module Distribution.Solver.Modular.Linking (
     validateLinking
   ) where

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -137,7 +137,7 @@ executable cabal
     main-is:        Main.hs
     hs-source-dirs: main
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances

--- a/cabal-install/cabal-install.cabal.pp
+++ b/cabal-install/cabal-install.cabal.pp
@@ -69,7 +69,7 @@ Version:            3.2.0.0
 %enddef
 %def CABAL_COMPONENTCOMMON
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances
@@ -527,7 +527,7 @@ Test-Suite unit-tests
   type: exitcode-stdio-1.0
   main-is: UnitTests.hs
   hs-source-dirs: tests
-  ghc-options: -Wall -fwarn-tabs -main-is UnitTests
+  ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -main-is UnitTests
   other-modules:
     UnitTests.Distribution.Client.ArbitraryInstances
     UnitTests.Distribution.Client.Targets
@@ -591,7 +591,7 @@ Test-Suite memory-usage-tests
   type: exitcode-stdio-1.0
   main-is: MemoryUsageTests.hs
   hs-source-dirs: tests
-  ghc-options: -Wall -fwarn-tabs "-with-rtsopts=-M4M -K1K" -main-is MemoryUsageTests
+  ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns "-with-rtsopts=-M4M -K1K" -main-is MemoryUsageTests
   other-modules:
     UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils
     UnitTests.Distribution.Solver.Modular.MemoryUsage
@@ -619,7 +619,7 @@ Test-Suite solver-quickcheck
   type: exitcode-stdio-1.0
   main-is: SolverQuickCheck.hs
   hs-source-dirs: tests
-  ghc-options: -Wall -fwarn-tabs -main-is SolverQuickCheck
+  ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -main-is SolverQuickCheck
   other-modules:
     UnitTests.Distribution.Solver.Modular.QuickCheck
     UnitTests.Distribution.Solver.Modular.QuickCheck.Utils
@@ -651,7 +651,7 @@ test-suite integration-tests2
   type: exitcode-stdio-1.0
   main-is: IntegrationTests2.hs
   hs-source-dirs: tests
-  ghc-options: -Wall -fwarn-tabs -main-is IntegrationTests2
+  ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -main-is IntegrationTests2
   other-modules:
   build-depends:
         base,

--- a/cabal-install/solver-dsl/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/solver-dsl/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -587,7 +587,9 @@ exAvSrcPkg ex =
     -- custom-setup only supports simple dependencies
     mkSetupDeps :: [ExampleDependency] -> [C.Dependency]
     mkSetupDeps deps =
-      let (directDeps, []) = splitDeps deps in map mkDirect directDeps
+      case splitDeps deps of
+        (directDeps, []) -> map mkDirect directDeps
+        _                -> error "mkSetupDeps: custom setup has non-simple deps"
 
 mkSimpleVersion :: ExamplePkgVersion -> C.Version
 mkSimpleVersion n = C.mkVersion [n, 0, 0]

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -8,6 +8,9 @@
 
 module IntegrationTests2 where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Client.DistDirLayout
 import Distribution.Client.ProjectConfig
 import Distribution.Client.Config (getCabalDir)
@@ -49,11 +52,6 @@ import Distribution.ModuleName (ModuleName)
 import Distribution.Verbosity
 import Distribution.Text
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (mempty, mappend)
-#endif
-import Data.List (sort)
-import Data.String (IsString(..))
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Control.Monad
@@ -65,8 +63,6 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.Options
 import Data.Tagged (Tagged(..))
-import Data.Proxy  (Proxy(..))
-import Data.Typeable (Typeable)
 
 #if !MIN_VERSION_directory(1,2,7)
 removePathForcibly :: FilePath -> IO ()
@@ -439,7 +435,7 @@ testTargetSelectorAmbiguous reportSubCase = do
         }
       }
       where
-        Just pkgid = simpleParse pkgidstr
+        pkgid = fromMaybe (error $ "failed to parse " ++ pkgidstr) $ simpleParse pkgidstr
 
     mkexe :: String -> Executable
     mkexe name = mempty { exeName = fromString name }
@@ -474,7 +470,7 @@ mkTargetAllPackages = TargetAllPackages Nothing
 
 instance IsString PackageIdentifier where
     fromString pkgidstr = pkgid
-      where Just pkgid = simpleParse pkgidstr
+      where pkgid = fromMaybe (error $"fromString @PackageIdentifier " ++ show pkgidstr) $ simpleParse pkgidstr
 
 
 testTargetSelectorNoCurrentPackage :: Assertion
@@ -492,7 +488,7 @@ testTargetSelectorNoCurrentPackage = do
     zipWithM_ (@?=) errs
       [ TargetSelectorNoCurrentPackage ts
       | target <- targets
-      , let Just ts = parseTargetString target
+      , let ts = fromMaybe (error $ "failed to parse target string " ++ target) $ parseTargetString target
       ]
     cleanProject testdir
   where

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -366,6 +366,7 @@ instance Arbitrary ClientInstallFlags where
     arbitrary =
       ClientInstallFlags
         <$> arbitrary
+        <*> arbitrary
         <*> arbitraryFlag arbitraryShortToken
         <*> arbitrary
         <*> arbitrary

--- a/cabal-install/tests/UnitTests/Distribution/Client/Tar.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Tar.hs
@@ -30,8 +30,9 @@ filterTest :: Assertion
 filterTest = do
   let e1 = getFileEntry "file1" "x"
       e2 = getFileEntry "file2" "y"
-      p = (\e -> let (NormalFile dta _) = entryContent e
-                     str = BS.Char8.unpack dta
+      p = (\e -> let str = BS.Char8.unpack $ case entryContent e of
+                       NormalFile dta _ -> dta
+                       _                -> error "Invalid entryContent"
                  in str /= "y")
   assertEqual "Unexpected result for filter" "xz" $
     entriesToString $ filterEntries p $ Next e1 $ Next e2 Done
@@ -44,8 +45,9 @@ filterMTest :: Assertion
 filterMTest = do
   let e1 = getFileEntry "file1" "x"
       e2 = getFileEntry "file2" "y"
-      p = (\e -> let (NormalFile dta _) = entryContent e
-                     str = BS.Char8.unpack dta
+      p = (\e -> let str = BS.Char8.unpack $ case entryContent e of
+                       NormalFile dta _ -> dta
+                       _                -> error "Invalid entryContent"
                  in tell "t" >> return (str /= "y"))
 
   (r, w) <- runWriterT $ filterEntriesM p $ Next e1 $ Next e2 Done
@@ -70,6 +72,7 @@ getFileEntry pth dta =
 
 entriesToString :: Entries String -> String
 entriesToString =
-  foldEntries (\e acc -> let (NormalFile dta _) = entryContent e
-                             str = BS.Char8.unpack dta
+  foldEntries (\e acc -> let str = BS.Char8.unpack $ case entryContent e of
+                               NormalFile dta _ -> dta
+                               _                -> error "Invalid entryContent"
                           in str ++ acc) "z" id

--- a/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Targets.hs
@@ -88,8 +88,8 @@ readUserConstraintTest :: String -> UserConstraint -> Assertion
 readUserConstraintTest str uc =
   assertEqual ("Couldn't read constraint: '" ++ str ++ "'") expected actual
   where
-    expected = uc
-    actual   = let Right r = readUserConstraint str in r
+    expected = Right uc
+    actual   = readUserConstraint str
 
 parseUserConstraintTest :: String -> UserConstraint -> Assertion
 parseUserConstraintTest str uc =

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -30,7 +30,8 @@ common shared
     -- this needs to match the in-tree lib:Cabal version
     , Cabal == 3.2.0.0
 
-  ghc-options: -Wall -fwarn-tabs
+  ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+
 
 library
   import: shared
@@ -69,6 +70,9 @@ library
     , temporary             ^>= 1.3
     , text                  ^>= 1.2.3.1
     , transformers          ^>= 0.3.0.0 || ^>= 0.4.2.0 || ^>= 0.5.2.0
+
+  if !impl(ghc >= 8.0)
+    build-depends:  semigroups
 
   if !os(windows)
     build-depends:


### PR DESCRIPTION
Resolve #5919
Resolve #6410

Add `withProjectOrGlobalConfigIgn` to unify the behaviour with `-z` in `cabal
repl`
