### PR TITLE
Resolve #6013: Warn if packages and optional-packages are both empty

### DIFF
--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -222,6 +222,10 @@ establishProjectBaseContext verbosity cliConfig currentCommand = do
                           verbosity cabalDirLayout
                           projectConfig
 
+    -- https://github.com/haskell/cabal/issues/6013
+    when (null (projectPackages projectConfig) && null (projectPackagesOptional projectConfig)) $
+        warn verbosity "There are no packages or optional-packages in the project"
+
     return ProjectBaseContext {
       distDirLayout,
       cabalDirLayout,


### PR DESCRIPTION
Now there's a warning

```
Warning: There are no packages or optional-packages in the project
cabal: There is no <pkgname>.cabal package file or cabal.project file. To
build packages locally you need at minimum a <pkgname>.cabal file. You can use
'cabal init' to create one.

For non-trivial projects you will also want a cabal.project file in the root
directory of your project. This file lists the packages in your project and
all other build configuration. See the Cabal user guide for full details.
```

It's subtle, but that's the issue with how we output warnings, not the warning itself.

I'm only making it a warning at this point, as I'm not 100% sure if that setup may still be useful for something. Playing safe for 3.2