### PR TITLE
Grayjay update solver benchmarks

### DIFF
--- a/.docker/validate-8.8.1.dockerfile
+++ b/.docker/validate-8.8.1.dockerfile
@@ -49,4 +49,4 @@ RUN     cabal v2-install -w ghc-8.8.1 --lib \
 # Validate
 WORKDIR /build
 COPY    . /build
-RUN     sh ./validate.sh -w ghc-8.8.1 -v -D
+RUN     sh ./validate.sh -w ghc-8.8.1 -v -D -b

--- a/cabal.project.validate
+++ b/cabal.project.validate
@@ -1,4 +1,4 @@
-packages: Cabal/ cabal-testsuite/ cabal-install/
+packages: Cabal/ cabal-testsuite/ cabal-install/ solver-benchmarks/
 
 write-ghc-environment-files: never
 

--- a/solver-benchmarks/HackageBenchmark.hs
+++ b/solver-benchmarks/HackageBenchmark.hs
@@ -27,7 +27,9 @@ import Statistics.Test.MannWhitneyU ( PositionTest(..), TestResult(..)
                                     , mannWhitneyUCriticalValue
                                     , mannWhitneyUtest)
 import Statistics.Types (PValue, mkPValue)
+import System.Directory (getTemporaryDirectory)
 import System.Exit (ExitCode(..), exitFailure)
+import System.FilePath ((</>))
 import System.IO ( BufferMode(LineBuffering), hPutStrLn, hSetBuffering, stderr
                  , stdout)
 import System.Process ( StdStream(CreatePipe), CreateProcess(..), callProcess
@@ -173,6 +175,8 @@ hackageBenchmarkMain = do
 runCabal :: Int -> FilePath -> [String] -> PackageName -> IO CabalTrial
 runCabal timeoutSeconds cabal flags pkg = do
   ((exitCode, err), time) <- timeEvent $ do
+    tmpDir <- getTemporaryDirectory
+
     let timeout = "timeout --foreground -sINT " ++ show timeoutSeconds
         cabalCmd = unwords $
             [ cabal
@@ -180,7 +184,7 @@ runCabal timeoutSeconds cabal flags pkg = do
               -- A non-existent store directory prevents cabal from reading the
               -- store, which would cause the size of the store to affect run
               -- time.
-            , "--store-dir=non-existent-store-dir"
+            , "--store-dir=" ++ (tmpDir </> "non-existent-store-dir")
 
             , "v2-install"
 

--- a/solver-benchmarks/solver-benchmarks.cabal
+++ b/solver-benchmarks/solver-benchmarks.cabal
@@ -30,6 +30,8 @@ library
     base,
     bytestring,
     Cabal >= 2.3,
+    directory,
+    filepath,
     optparse-applicative,
     process,
     time,


### PR DESCRIPTION
One commit on top of #6434 which allows to run benchmarks as part of `validate.sh` (to see that they work).

Probably because of asserts in development version, `cabal-install-3.0.1.0` seems to be slightly faster, on my machine :)

cc @grayjay, I'll merge this when travis turns green.