### PR TITLE
Fix typos

### DIFF
--- a/Cabal/Distribution/Fields/Field.hs
+++ b/Cabal/Distribution/Fields/Field.hs
@@ -73,7 +73,7 @@ fieldLineBS (FieldLine _ bs) = bs
 -- | Section arguments, e.g. name of the library
 data SectionArg ann
     = SecArgName  !ann !ByteString
-      -- ^ identifier, or omething which loos like number. Also many dot numbers, i.e. "7.6.3"
+      -- ^ identifier, or something which looks like number. Also many dot numbers, i.e. "7.6.3"
     | SecArgStr   !ann !ByteString
       -- ^ quoted string
     | SecArgOther !ann !ByteString

--- a/Cabal/Distribution/Simple/Configure.hs
+++ b/Cabal/Distribution/Simple/Configure.hs
@@ -972,7 +972,7 @@ dependencySatisfiable
            -- Reinterpret the "package name" as an unqualified component
            -- name
            = LSubLibName $ packageNameToUnqualComponentName depName
-    -- Check whether a libray exists and is visible.
+    -- Check whether a library exists and is visible.
     -- We don't disambiguate between dependency on non-existent or private
     -- library yet, so we just return a bool and later report a generic error.
     visible lib = maybe

--- a/Cabal/Distribution/Simple/Test/Log.hs
+++ b/Cabal/Distribution/Simple/Test/Log.hs
@@ -143,7 +143,7 @@ summarizePackage verbosity packageLog = do
   where
     addTriple (p1, f1, e1) (p2, f2, e2) = (p1 + p2, f1 + f2, e1 + e2)
 
--- | Print a summary of a single test case's result to the console, supressing
+-- | Print a summary of a single test case's result to the console, suppressing
 -- output for certain verbosity or test filter levels.
 summarizeTest :: Verbosity -> TestShowDetails -> TestLogs -> IO ()
 summarizeTest _ _ (GroupLogs {}) = return ()

--- a/Cabal/Distribution/Types/BuildInfo.hs
+++ b/Cabal/Distribution/Types/BuildInfo.hs
@@ -82,7 +82,7 @@ data BuildInfo = BuildInfo {
                                        --   Example 2: a library that is being built by a foreing tool (e.g. rust)
                                        --              and copied and registered together with this library.  The
                                        --              logic on how this library is built will have to be encoded in a
-                                       --              custom Setup for now.  Oherwise cabal would need to lear how to
+                                       --              custom Setup for now.  Otherwise cabal would need to lear how to
                                        --              call arbitrary library builders.
         extraLibFlavours  :: [String], -- ^ Hidden Flag.  This set of strings, will be appended to all libraries when
                                        --   copying. E.g. [libHS<name>_<flavour> | flavour <- extraLibFlavours]. This

--- a/Cabal/Distribution/Types/PackageDescription.hs
+++ b/Cabal/Distribution/Types/PackageDescription.hs
@@ -475,6 +475,6 @@ instance L.HasBuildInfos PackageDescription where
         <*> (traverse . L.buildInfo) f x6 -- benchmarks
         <*> pure a20                      -- data files
         <*> pure a21                      -- data dir
-        <*> pure a22                      -- exta src files
+        <*> pure a22                      -- extra src files
         <*> pure a23                      -- extra temp files
         <*> pure a24                      -- extra doc files

--- a/Cabal/Distribution/Utils/IOData.hs
+++ b/Cabal/Distribution/Utils/IOData.hs
@@ -78,7 +78,7 @@ instance KnownIODataMode LBS.ByteString where
 -- This is the dual operation ot 'hGetIODataContents',
 -- and consequently the handle is closed with `hClose`.
 --
--- /Note:/ this performes lazy-IO.
+-- /Note:/ this performs lazy-IO.
 --
 -- @since 2.2
 hPutContents :: System.IO.Handle -> IOData -> Prelude.IO ()

--- a/Cabal/Distribution/Utils/Structured.hs
+++ b/Cabal/Distribution/Utils/Structured.hs
@@ -178,7 +178,7 @@ typeName f (Structure t v n s) = fmap (\n' -> Structure t v n' s) (f n)
 -- | Flatten 'Structure' into something we can calculate hash of.
 --
 -- As 'Structure' can be potentially infinite. For mutually recursive types,
--- we keep track of 'TypeRep's, and put just 'TypeRep' name when it's occured
+-- we keep track of 'TypeRep's, and put just 'TypeRep' name when it's occurred
 -- another time.
 structureBuilder :: Structure -> Builder.Builder
 structureBuilder s0 = State.evalState (go s0) Map.empty where

--- a/Cabal/doc/hcar/Cabal-201604.tex
+++ b/Cabal/doc/hcar/Cabal-201604.tex
@@ -94,7 +94,7 @@ features that are currently targeted at 1.26 are:
 \item Further work on nix-style local builds, perhaps making that code path the
   default.
 \item Enabling Hackage Security by default.
-\item Native suport for
+\item Native support for
   \href{https://github.com/haskell/cabal/pull/2540}{``foreign libraries''}:
   Haskell libraries that are intended to be used by non-Haskell code.
 \item New Parsec-based parser for \texttt{.cabal} files.

--- a/Cabal/tests/ParserTests/errors/big-version.cabal
+++ b/Cabal/tests/ParserTests/errors/big-version.cabal
@@ -1,5 +1,5 @@
 cabal-version:       3.0
-name:                big-vesion
+name:                big-version
 -- 10 digits
 version:             1234567890
 

--- a/Cabal/tests/ParserTests/regressions/big-version.cabal
+++ b/Cabal/tests/ParserTests/regressions/big-version.cabal
@@ -1,5 +1,5 @@
 cabal-version:       3.0
-name:                big-vesion
+name:                big-version
 -- 9 digits
 version:             123456789
 

--- a/Cabal/tests/ParserTests/regressions/big-version.expr
+++ b/Cabal/tests/ParserTests/regressions/big-version.expr
@@ -82,7 +82,7 @@ GenericPackageDescription
                            licenseRaw = Left NONE,
                            maintainer = "",
                            package = PackageIdentifier
-                                       {pkgName = `PackageName "big-vesion"`,
+                                       {pkgName = `PackageName "big-version"`,
                                         pkgVersion = `mkVersion [123456789]`},
                            pkgUrl = "",
                            setupBuildInfo = Nothing,

--- a/Cabal/tests/ParserTests/regressions/big-version.format
+++ b/Cabal/tests/ParserTests/regressions/big-version.format
@@ -1,5 +1,5 @@
 cabal-version: 3.0
-name:          big-vesion
+name:          big-version
 version:       123456789
 
 library

--- a/Cabal/tests/Test/Laws.hs
+++ b/Cabal/tests/Test/Laws.hs
@@ -53,7 +53,7 @@ monoid_2 :: (Eq a, Data.Monoid.Monoid a) => a -> a -> a -> Bool
 monoid_2 x y z = (x `mappend`  y) `mappend` z
               ==  x `mappend` (y  `mappend` z)
 
--- | The 'mconcat' definition. It can be overidden for the sake of effeciency
+-- | The 'mconcat' definition. It can be overidden for the sake of efficiency
 -- but it must still satisfy the property given by the default definition:
 --
 -- > mconcat = foldr mappend mempty

--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -155,11 +155,11 @@ data CabalDirLayout = CabalDirLayout {
 
 -- | Information about the root directory of the project.
 --
--- It can either be an implict project root in the current dir if no
+-- It can either be an implicit project root in the current dir if no
 -- @cabal.project@ file is found, or an explicit root if the file is found.
 --
 data ProjectRoot =
-       -- | -- ^ An implict project root. It contains the absolute project
+       -- | -- ^ An implicit project root. It contains the absolute project
        -- root dir.
        ProjectRootImplicit FilePath
 

--- a/cabal-install/Distribution/Client/Security/HTTP.hs
+++ b/cabal-install/Distribution/Client/Security/HTTP.hs
@@ -143,7 +143,7 @@ mkReqHeaders reqHeaders mRange = concat [
     insert :: Eq a => a -> [b] -> [(a, [b])] -> [(a, [b])]
     insert x y = modifyAssocList x (++ y)
 
-    -- modify the first maching element
+    -- modify the first matching element
     modifyAssocList :: Eq a => a -> (b -> b) -> [(a, b)] -> [(a, b)]
     modifyAssocList a f = go where
         go []                         = []

--- a/cabal-install/Distribution/Solver/Types/InstSolverPackage.hs
+++ b/cabal-install/Distribution/Solver/Types/InstSolverPackage.hs
@@ -14,7 +14,7 @@ import Distribution.Types.MungedPackageName
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
 import GHC.Generics (Generic)
 
--- | An 'InstSolverPackage' is a pre-existing installed pacakge
+-- | An 'InstSolverPackage' is a pre-existing installed package
 -- specified by the dependency solver.
 data InstSolverPackage = InstSolverPackage {
       instSolverPkgIPI :: InstalledPackageInfo,

--- a/cabal-testsuite/PackageTests/Regression/T5309/memoized-tcm/costMatrix.h
+++ b/cabal-testsuite/PackageTests/Regression/T5309/memoized-tcm/costMatrix.h
@@ -139,7 +139,7 @@ class CostMatrix
          *  the median for the two. Puts the median and alphabet size into retMedian,
          *  which must therefore by necessity be allocated elsewhere.
          *
-         *  This functin allocates _if necessary_. So freeing inputs after a call will not
+         *  This function allocates _if necessary_. So freeing inputs after a call will not
          *  cause invalid reads from the cost matrix.
          */
         int getSetCostMedian(dcElement_t* left, dcElement_t* right, dcElement_t* retMedian);

--- a/generics-sop-lens.hs
+++ b/generics-sop-lens.hs
@@ -38,7 +38,7 @@ genericLenses
 genericLenses p = case gdatatypeInfo p of
     Newtype _ _ _                   -> "-- newtype deriving not implemented"
     ADT _ _  (Constructor _ :* Nil) -> "-- fieldnameless deriving not implemented"
-    ADT _ _  (Infix _ _ _ :* Nil)   -> "-- infix consturctor deriving not implemented"
+    ADT _ _  (Infix _ _ _ :* Nil)   -> "-- infix constructor deriving not implemented"
     ADT _ dn (Record _ fis :* Nil) ->
         unlines $ concatMap replaceTypes $ hcollapse $ hcmap (Proxy :: Proxy Typeable) derive fis
       where
@@ -57,7 +57,7 @@ genericClassyLenses
 genericClassyLenses p = case gdatatypeInfo p of
     Newtype _ _ _                   -> "-- newtype deriving not implemented"
     ADT _ _  (Constructor _ :* Nil) -> "-- fieldnameless deriving not implemented"
-    ADT _ _  (Infix _ _ _ :* Nil)   -> "-- infix consturctor deriving not implemented"
+    ADT _ _  (Infix _ _ _ :* Nil)   -> "-- infix constructor deriving not implemented"
     ADT _ dn (Record _ fis :* Nil) ->
         unlines $ concatMap replaceTypes $
             [[ "class Has" ++ dn ++ " a where"


### PR DESCRIPTION
Should be non-semantic. I would particularly appreciate it if the "version" changes are verified, as they may have been intentional.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.