### PR TITLE
Fix `v2-sdist` permissions

### DIFF
--- a/cabal-install/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/Distribution/Client/CmdSdist.hs
@@ -79,7 +79,8 @@ import Data.List
 import qualified Data.Set as Set
 import System.Directory
     ( getCurrentDirectory, setCurrentDirectory
-    , createDirectoryIfMissing, makeAbsolute )
+    , createDirectoryIfMissing, makeAbsolute
+    , getPermissions, executable )
 import System.FilePath
     ( (</>), (<.>), makeRelative, normalise, takeDirectory )
 
@@ -255,10 +256,11 @@ packageToSdist verbosity projectRootDir format outputFile pkg = do
                             Right path -> tell [Tar.directoryEntry path]
 
                         for_ files $ \(perm, file) -> do
+                            realPerm <- getPermissions file
                             let fileDir = takeDirectory (prefix </> file)
                                 perm' = case perm of
-                                    Exec -> Tar.executableFilePermissions
-                                    NoExec -> Tar.ordinaryFilePermissions
+                                    Exec | executable realPerm -> Tar.executableFilePermissions
+                                    _                          -> Tar.ordinaryFilePermissions
                             needsEntry <- gets (Set.notMember fileDir)
 
                             when needsEntry $ do

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,8 @@
 -*-change-log-*-
 
 3.1.0.0 (current development version)
+	* `v2-sdist` no longer gives files that are not already executable extra permissions
+	  when generating a tarball. (#5813, #6454)
 	* `v2-build` (and other `v2-`prefixed commands) now accept the
 	  `--benchmark-option(s)` flags, which pass options to benchmark executables
 	  (analogous to how `--test-option(s)` works). (#6209)


### PR DESCRIPTION
Fixes #5813.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
