### PR TITLE
Add --ignore-project flag to v2-run

### DIFF
--- a/cabal-dev-scripts/src/Preprocessor.hs
+++ b/cabal-dev-scripts/src/Preprocessor.hs
@@ -1,3 +1,6 @@
+{- cabal:
+build-depends: base, containers
+-}
 {-# LANGUAGE DeriveFunctor #-}
 module Main (main) where
 

--- a/cabal-install/Distribution/Client/CmdRun/ClientRunFlags.hs
+++ b/cabal-install/Distribution/Client/CmdRun/ClientRunFlags.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase    #-}
+module Distribution.Client.CmdRun.ClientRunFlags
+( ClientRunFlags(..)
+, defaultClientRunFlags
+, clientRunOptions
+) where
+
+import Distribution.Client.Compat.Prelude
+
+import Distribution.Simple.Command (OptionField (..), ShowOrParseArgs (..), option)
+import Distribution.Simple.Setup   (Flag (..), toFlag, trueArg)
+
+data ClientRunFlags = ClientRunFlags
+  { crunIgnoreProject   :: Flag Bool
+  } deriving (Eq, Show, Generic)
+
+instance Monoid ClientRunFlags where
+  mempty = gmempty
+  mappend = (<>)
+
+instance Semigroup ClientRunFlags where
+  (<>) = gmappend
+
+instance Binary ClientRunFlags
+instance Structured ClientRunFlags
+
+defaultClientRunFlags :: ClientRunFlags
+defaultClientRunFlags = ClientRunFlags
+  { crunIgnoreProject   = toFlag False
+  }
+
+clientRunOptions :: ShowOrParseArgs -> [OptionField ClientRunFlags]
+clientRunOptions _ =
+  [ option "z" ["ignore-project"]
+    "Ignore local project configuration"
+    crunIgnoreProject (\v flags -> flags { crunIgnoreProject = v })
+    trueArg
+  ]

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -177,6 +177,7 @@ executable cabal
         Distribution.Client.CmdInstall.ClientInstallFlags
         Distribution.Client.CmdRepl
         Distribution.Client.CmdRun
+        Distribution.Client.CmdRun.ClientRunFlags
         Distribution.Client.CmdTest
         Distribution.Client.CmdLegacy
         Distribution.Client.CmdSdist

--- a/cabal-install/cabal-install.cabal.pp
+++ b/cabal-install/cabal-install.cabal.pp
@@ -108,6 +108,7 @@ Version:            3.3.0.0
         Distribution.Client.CmdInstall.ClientInstallFlags
         Distribution.Client.CmdRepl
         Distribution.Client.CmdRun
+        Distribution.Client.CmdRun.ClientRunFlags
         Distribution.Client.CmdTest
         Distribution.Client.CmdLegacy
         Distribution.Client.CmdSdist


### PR DESCRIPTION
I tested with meta-command:

```
% cabal run -- cabal run --ignore-project cabal-dev-scripts/src/Preprocessor.hs -- --help
```