### PR TITLE
Use GitHub Actions

### DIFF
--- a/.docker/validate-7.6.3.dockerfile
+++ b/.docker/validate-7.6.3.dockerfile
@@ -63,4 +63,4 @@ RUN     cabal v2-install -w ghc-7.6.3 --lib \
 # Validate
 WORKDIR /build
 COPY    . /build
-RUN     sh ./validate.sh -l -w ghc-7.6.3 -v
+RUN     sh ./validate.sh --lib-only -w ghc-7.6.3 -v

--- a/.docker/validate-8.8.1.dockerfile
+++ b/.docker/validate-8.8.1.dockerfile
@@ -8,6 +8,13 @@ RUN     mkdir -p /root/.cabal/bin && \
         rm -f cabal-plan.xz && \
         chmod a+x /root/.cabal/bin/cabal-plan
 
+# install cabal-env
+RUN     curl -sL https://github.com/phadej/cabal-extras/releases/download/preview-20191225/cabal-env-snapshot-20191225-x86_64-linux.xz > cabal-env.xz && \
+        echo "1b567d529c5f627fd8c956e57ae8f0d9f11ee66d6db34b7fb0cb1c370b4edf01  cabal-env.xz" | sha256sum -c - && \
+        xz -d < cabal-env.xz > $HOME/.cabal/bin/cabal-env && \
+        rm -f cabal-env.xz && \
+        chmod a+x $HOME/.cabal/bin/cabal-env
+
 # Update index
 RUN     cabal v2-update
 
@@ -49,4 +56,4 @@ RUN     cabal v2-install -w ghc-8.8.1 --lib \
 # Validate
 WORKDIR /build
 COPY    . /build
-RUN     sh ./validate.sh -w ghc-8.8.1 -v -D -b
+RUN     sh ./validate.sh -w ghc-8.8.1 -v --doctest --solver-benchmarks

--- a/.docker/validate-old.dockerfile
+++ b/.docker/validate-old.dockerfile
@@ -1,6 +1,4 @@
-# TODO: change to bionic
-# https://github.com/haskell-CI/haskell-ci/issues/342
-FROM    phadej/ghc:7.8.4-xenial
+FROM    phadej/ghc:8.8.1-xenial
 
 # Install cabal-plan
 RUN     mkdir -p /root/.cabal/bin && \
@@ -10,9 +8,9 @@ RUN     mkdir -p /root/.cabal/bin && \
         rm -f cabal-plan.xz && \
         chmod a+x /root/.cabal/bin/cabal-plan
 
-# We need newer compiler, to install cabal-plan
+# Install older compilers
 RUN     apt-get update
-RUN     apt-get install -y ghc-7.8.4-dyn
+RUN     apt-get install -y ghc-7.0.4 ghc-7.0.4-dyn ghc-7.2.2 ghc-7.2.2-dyn ghc-7.4.2 ghc-7.4.2-dyn
 
 # Update index
 RUN     cabal v2-update
@@ -22,7 +20,7 @@ RUN     cabal v2-install happy --constraint 'happy ^>=1.19.12'
 
 # Install some other dependencies
 # Remove $HOME/.ghc so there aren't any environments
-RUN     cabal v2-install -w ghc-7.8.4 --lib \
+RUN     cabal v2-install -w ghc-8.8.1 --lib \
           aeson \
           async \
           base-compat \
@@ -40,6 +38,7 @@ RUN     cabal v2-install -w ghc-7.8.4 --lib \
           pretty-show \
           regex-compat-tdfa \
           regex-tdfa \
+          resolv \
           statistics \
           tar \
           tasty \
@@ -48,19 +47,9 @@ RUN     cabal v2-install -w ghc-7.8.4 --lib \
           tasty-quickcheck \
           tree-diff \
           zlib \
-      --constraint="bytestring installed" \
-      --constraint="binary     installed" \
-      --constraint="containers installed" \
-      --constraint="deepseq    installed" \
-      --constraint="directory  installed" \
-      --constraint="filepath   installed" \
-      --constraint="pretty     installed" \
-      --constraint="process    installed" \
-      --constraint="time       installed" \
-      --constraint="unix       installed" \
         && rm -rf $HOME/.ghc
 
 # Validate
 WORKDIR /build
 COPY    . /build
-RUN     sh ./validate.sh --lib-only -w ghc-7.8.4 -v
+RUN     sh ./validate.sh -w ghc-8.8.1 -v --lib-only --extra-hc /opt/ghc/7.0.4/bin/ghc-7.0.4 --extra-hc /opt/ghc/7.2.2/bin/ghc-7.2.2 --extra-hc /opt/ghc/7.4.2/bin/ghc-7.4.2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,579 @@
+# This file is auto-generated
+#
+# To regenerate it run
+#
+#     make github-actions
+#
+name: Validation
+on:
+  push:
+    branches:
+      - master
+      - "3.2"
+  pull_request:
+    branches:
+      - master
+  release:
+    types:
+      - created
+
+jobs:
+  meta:
+    name: Meta checks
+    runs-on: ubuntu-18.04
+    # This job is not run in a container, any recent GHC should be fine
+    steps:
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+          echo "::add-path::/opt/cabal/3.0/bin"
+          echo "::add-path::/opt/ghc/8.6.5/bin"
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cabal/store
+          key: linux-store-meta
+      - name: Update Hackage index
+        run: cabal v2-update
+      - name: Install alex
+        run: cabal v2-install alex
+      - uses: actions/checkout@v1
+      - name: Regenerate files
+        run: |
+          make lexer
+          make gen-extra-source-files
+          make spdx
+          make github-actions
+      - name: Check that diff is clean
+        run: |
+          git status > /dev/null
+          git diff-files -p --exit-code
+  doctest:
+    name: Doctest Cabal
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+          echo "::add-path::/opt/cabal/3.0/bin"
+          echo "::add-path::/opt/ghc/8.6.5/bin"
+      - name: Install cabal-env
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/preview-20191225/cabal-env-snapshot-20191225-x86_64-linux.xz > cabal-env.xz
+          echo "1b567d529c5f627fd8c956e57ae8f0d9f11ee66d6db34b7fb0cb1c370b4edf01  cabal-env.xz" | sha256sum -c -
+          xz -d < cabal-env.xz > $HOME/.cabal/bin/cabal-env
+          rm -f cabal-env.xz
+          chmod a+x $HOME/.cabal/bin/cabal-env
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cabal/store
+          key: linux-store-doctest
+      - name: Update Hackage index
+        run: cabal v2-update
+      - name: Install doctest
+        run: cabal v2-install doctest
+      - name: Install libraries
+        run: |
+          cabal-env --transitive QuickCheck
+          cabal-env array bytestring containers deepseq directory filepath pretty process time binary unix text parsec mtl
+          cat $HOME/.ghc/*/environments/default
+      - uses: actions/checkout@v1
+      - name: Doctest
+        run: make doctest
+
+  boostrap-linux:
+    name: Bootstrap on Linux
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Set PATH
+        run: |
+          echo "::add-path::/opt/ghc/8.6.5/bin"
+      - uses: actions/checkout@v1
+      - name: bootstrap.sh
+        env:
+          EXTRA_CONFIGURE_OPTS: ""
+        run: |
+          cd cabal-install
+          sh ./bootstrap.sh --no-doc
+      - name: Smoke test
+        run: |
+          $HOME/.cabal/bin/cabal --version
+
+      - name: Prepare for upload
+        run: xz -c < $HOME/.cabal/bin/cabal > cabal-artifact.xz
+      - uses: actions/upload-artifact@v1
+        with:
+          name: cabal-linux-x86_64.xz
+          path: cabal-artifact.xz
+
+  boostrap-macos:
+    name: Bootstrap on macOS
+    runs-on: macos-latest
+    steps:
+      - name: Install GHC
+        run: |
+          cd $(mktemp -d)
+          curl -sLO "https://downloads.haskell.org/~ghc/8.6.5/ghc-8.6.5-x86_64-apple-darwin.tar.xz"
+          tar -xJf ghc-*.tar.xz
+          cd ghc-*
+          ./configure --prefix=/opt/ghc/8.6.5
+          sudo make install
+      - name: Set PATH
+        run: |
+          echo "::add-path::/opt/ghc/8.6.5/bin"
+          echo "::add-path::$HOME/.cabal/bin"
+      - uses: actions/checkout@v1
+      - name: bootstrap.sh
+        env:
+          EXTRA_CONFIGURE_OPTS: ""
+        run: |
+          cd cabal-install
+          sh ./bootstrap.sh --no-doc
+      - name: Smoke test
+        run: |
+          $HOME/.cabal/bin/cabal --version
+
+      - name: Prepare for upload
+        run: xz -c < $HOME/.cabal/bin/cabal > cabal-artifact.xz
+      - uses: actions/upload-artifact@v1
+        with:
+          name: cabal-macos-x86_64.xz
+          path: cabal-artifact.xz
+
+  validate-8_8_1:
+    name: validate.sh ghc-8.8.1
+    runs-on: ubuntu-18.04
+    container:
+      image: phadej/ghc:8.8.1-bionic
+    steps:
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
+          echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v1
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s print-tool-versions
+      - name: Validate make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s make-cabal-install-dev
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s lib-suite
+      - name: Validate cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s cli-tests
+      - name: Validate cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s cli-suite
+  validate-8_6_5:
+    name: validate.sh ghc-8.6.5
+    runs-on: ubuntu-18.04
+    needs: validate-8_8_1
+    container:
+      image: phadej/ghc:8.6.5-bionic
+    steps:
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
+          echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v1
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s print-tool-versions
+      - name: Validate make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s make-cabal-install-dev
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s lib-suite
+      - name: Validate cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s cli-tests
+      - name: Validate cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s cli-suite
+  validate-8_4_4:
+    name: validate.sh ghc-8.4.4
+    runs-on: ubuntu-18.04
+    needs: validate-8_8_1
+    container:
+      image: phadej/ghc:8.4.4-bionic
+    steps:
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
+          echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v1
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-8.4.4 -v  -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.4.4 -v  -s print-tool-versions
+      - name: Validate make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-8.4.4 -v  -s make-cabal-install-dev
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-8.4.4 -v  -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.4.4 -v  -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.4.4 -v  -s lib-suite
+      - name: Validate cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.4.4 -v  -s cli-tests
+      - name: Validate cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.4.4 -v  -s cli-suite
+  validate-8_2_2:
+    name: validate.sh ghc-8.2.2
+    runs-on: ubuntu-18.04
+    needs: validate-8_8_1
+    container:
+      image: phadej/ghc:8.2.2-bionic
+    steps:
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
+          echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v1
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-8.2.2 -v  -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.2.2 -v  -s print-tool-versions
+      - name: Validate make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-8.2.2 -v  -s make-cabal-install-dev
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-8.2.2 -v  -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.2.2 -v  -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.2.2 -v  -s lib-suite
+      - name: Validate cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.2.2 -v  -s cli-tests
+      - name: Validate cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.2.2 -v  -s cli-suite
+  validate-8_0_2:
+    name: validate.sh ghc-8.0.2
+    runs-on: ubuntu-18.04
+    needs: validate-8_8_1
+    container:
+      image: phadej/ghc:8.0.2-bionic
+    steps:
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
+          echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v1
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-8.0.2 -v  -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.0.2 -v  -s print-tool-versions
+      - name: Validate make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-8.0.2 -v  -s make-cabal-install-dev
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-8.0.2 -v  -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.0.2 -v  -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.0.2 -v  -s lib-suite
+      - name: Validate cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.0.2 -v  -s cli-tests
+      - name: Validate cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.0.2 -v  -s cli-suite
+  validate-7_10_3:
+    name: validate.sh ghc-7.10.3
+    runs-on: ubuntu-18.04
+    needs: validate-8_8_1
+    container:
+      image: phadej/ghc:7.10.3-bionic
+    steps:
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
+          echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v1
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-7.10.3 -v  -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-7.10.3 -v  -s print-tool-versions
+      - name: Validate make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-7.10.3 -v  -s make-cabal-install-dev
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-7.10.3 -v  -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-7.10.3 -v  -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-7.10.3 -v  -s lib-suite
+      - name: Validate cli-tests
+        run: sh validate.sh -j 2 -w ghc-7.10.3 -v  -s cli-tests
+      - name: Validate cli-suite
+        run: sh validate.sh -j 2 -w ghc-7.10.3 -v  -s cli-suite
+  validate-7_8_4:
+    name: validate.sh ghc-7.8.4
+    runs-on: ubuntu-18.04
+    needs: validate-8_8_1
+    container:
+      image: phadej/ghc:7.8.4-bionic
+    steps:
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
+          echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v1
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-7.8.4 -v --lib-only -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-7.8.4 -v --lib-only -s print-tool-versions
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-7.8.4 -v --lib-only -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-7.8.4 -v --lib-only -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-7.8.4 -v --lib-only -s lib-suite
+  validate-7_6_3:
+    name: validate.sh ghc-7.6.3
+    runs-on: ubuntu-18.04
+    needs: validate-8_8_1
+    container:
+      image: phadej/ghc:7.6.3-xenial
+    steps:
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
+          echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: apt-get update
+        run: apt-get update
+      - name: Install dynamic libraries
+        run: apt-get install -y ghc-7.6.3-dyn
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v1
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-7.6.3 -v --lib-only -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-7.6.3 -v --lib-only -s print-tool-versions
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-7.6.3 -v --lib-only -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-7.6.3 -v --lib-only -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-7.6.3 -v --lib-only -s lib-suite
+  validate-8_8_1-old:
+    name: validate.sh old GHCs
+    runs-on: ubuntu-18.04
+    needs: validate-8_8_1
+    container:
+      image: phadej/ghc:8.8.1-xenial
+    steps:
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
+          echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: apt-get update
+        run: apt-get update
+      - name: Install dynamic libraries
+        run: apt-get install -y ghc-8.8.1-dyn
+      - name: Install extra compilers
+        run: apt-get install -y ghc-7.0.4-dyn ghc-7.2.2-dyn ghc-7.4.2-dyn
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v1
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s print-tool-versions
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s lib-suite
+      - name: Validate lib-suite-extras --extra-hc /opt/ghc/7.0.4/bin/ghc-7.0.4
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s lib-suite-extras --extra-hc /opt/ghc/7.0.4/bin/ghc-7.0.4
+      - name: Validate lib-suite-extras --extra-hc /opt/ghc/7.2.2/bin/ghc-7.2.2
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s lib-suite-extras --extra-hc /opt/ghc/7.2.2/bin/ghc-7.2.2
+      - name: Validate lib-suite-extras --extra-hc /opt/ghc/7.4.2/bin/ghc-7.4.2
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s lib-suite-extras --extra-hc /opt/ghc/7.4.2/bin/ghc-7.4.2
+
+  validate-macos-8_8_1:
+    name: validate.sh macOS ghc-8.8.1
+    runs-on: macos-latest
+    steps:
+      - name: Install GHC
+        run: |
+          cd $(mktemp -d)
+          curl -sLO https://downloads.haskell.org/~ghc/8.8.1/ghc-8.8.1-x86_64-apple-darwin.tar.xz
+          tar -xJf ghc-*.tar.xz
+          cd ghc-*
+          ./configure --prefix=/opt/ghc/8.8.1
+          sudo make install
+      - name: Install Cabal
+        run: |
+          cd $(mktemp -d)
+          curl -sLO https://downloads.haskell.org/~cabal/cabal-install-3.0.0.0/cabal-install-3.0.0.0-x86_64-apple-darwin17.7.0.tar.xz
+          tar -xJf cabal-install-*.tar.xz
+          sudo mkdir -p /opt/cabal/3.0/bin
+          sudo cp cabal /opt/cabal/3.0/bin/cabal
+          sudo chmod 755 /opt/cabal/3.0/bin/cabal
+      - name: Set PATH
+        run: |
+          echo "::add-path::/opt/ghc/8.8.1/bin"
+          echo "::add-path::/opt/cabal/3.0/bin"
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Update Hackage index
+        run: cabal v2-update
+      - name: Install cabal-plan
+        run: |
+          cd $(mktemp -d)
+          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
+      - uses: actions/checkout@v1
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s print-tool-versions
+      - name: Validate make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s make-cabal-install-dev
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s lib-suite
+      - name: Validate cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s cli-tests
+      - name: Validate cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s cli-suite
+  validate-macos-8_6_5:
+    name: validate.sh macOS ghc-8.6.5
+    runs-on: macos-latest
+    needs: validate-macos-8_8_1
+    steps:
+      - name: Install GHC
+        run: |
+          cd $(mktemp -d)
+          curl -sLO https://downloads.haskell.org/~ghc/8.6.5/ghc-8.6.5-x86_64-apple-darwin.tar.xz
+          tar -xJf ghc-*.tar.xz
+          cd ghc-*
+          ./configure --prefix=/opt/ghc/8.6.5
+          sudo make install
+      - name: Install Cabal
+        run: |
+          cd $(mktemp -d)
+          curl -sLO https://downloads.haskell.org/~cabal/cabal-install-3.0.0.0/cabal-install-3.0.0.0-x86_64-apple-darwin17.7.0.tar.xz
+          tar -xJf cabal-install-*.tar.xz
+          sudo mkdir -p /opt/cabal/3.0/bin
+          sudo cp cabal /opt/cabal/3.0/bin/cabal
+          sudo chmod 755 /opt/cabal/3.0/bin/cabal
+      - name: Set PATH
+        run: |
+          echo "::add-path::/opt/ghc/8.6.5/bin"
+          echo "::add-path::/opt/cabal/3.0/bin"
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Update Hackage index
+        run: cabal v2-update
+      - name: Install cabal-plan
+        run: |
+          cd $(mktemp -d)
+          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
+      - uses: actions/checkout@v1
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s print-tool-versions
+      - name: Validate make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s make-cabal-install-dev
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s lib-suite
+      - name: Validate cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s cli-tests
+      - name: Validate cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s cli-suite

--- a/Makefile
+++ b/Makefile
@@ -148,3 +148,6 @@ validate-via-docker-8.6.5:
 
 validate-via-docker-8.8.1:
 	docker build -t cabal-validate -f .docker/validate-8.8.1.dockerfile .
+
+validate-via-docker-old:
+	docker build -t cabal-validate -f .docker/validate-old.dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,12 @@ gen-extra-source-files : gen-extra-source-files-lib gen-extra-source-files-cli
 gen-extra-source-files-lib :
 	cabal v2-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-extra-source-files -- $$(pwd)/Cabal/Cabal.cabal
 
+# github actions
+github-actions : .github/workflows/validate.yml
+
+.github/workflows/validate.yml : boot/validate.template.yml cabal-dev-scripts/src/GenValidate.hs
+	cabal v2-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-validate -- $< $@
+
 # We need to generate cabal-install-dev so the test modules are in .cabal file!
 gen-extra-source-files-cli :
 	$(MAKE) cabal-install-dev

--- a/boot/validate.template.yml
+++ b/boot/validate.template.yml
@@ -1,0 +1,239 @@
+# This file is auto-generated
+#
+# To regenerate it run
+#
+#     make github-actions
+#
+name: Validation
+on:
+  push:
+    branches:
+      - master
+      - "3.2"
+  pull_request:
+    branches:
+      - master
+  release:
+    types:
+      - created
+
+jobs:
+{############################################################################}
+{# Misc jobs                                                                #}
+{############################################################################}
+  meta:
+    name: Meta checks
+    runs-on: ubuntu-18.04
+    # This job is not run in a container, any recent GHC should be fine
+    steps:
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+          echo "::add-path::/opt/cabal/3.0/bin"
+          echo "::add-path::/opt/ghc/8.6.5/bin"
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cabal/store
+          key: linux-store-meta
+      - name: Update Hackage index
+        run: cabal v2-update
+      - name: Install alex
+        run: cabal v2-install alex
+      - uses: actions/checkout@v1
+      - name: Regenerate files
+        run: |
+          make lexer
+          make gen-extra-source-files
+          make spdx
+          make github-actions
+      - name: Check that diff is clean
+        run: |
+          git status > /dev/null
+          git diff-files -p --exit-code
+  doctest:
+    name: Doctest Cabal
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+          echo "::add-path::/opt/cabal/3.0/bin"
+          echo "::add-path::/opt/ghc/8.6.5/bin"
+      - name: Install cabal-env
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/preview-20191225/cabal-env-snapshot-20191225-x86_64-linux.xz > cabal-env.xz
+          echo "1b567d529c5f627fd8c956e57ae8f0d9f11ee66d6db34b7fb0cb1c370b4edf01  cabal-env.xz" | sha256sum -c -
+          xz -d < cabal-env.xz > $HOME/.cabal/bin/cabal-env
+          rm -f cabal-env.xz
+          chmod a+x $HOME/.cabal/bin/cabal-env
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cabal/store
+          key: linux-store-doctest
+      - name: Update Hackage index
+        run: cabal v2-update
+      - name: Install doctest
+        run: cabal v2-install doctest
+      - name: Install libraries
+        run: |
+          cabal-env --transitive QuickCheck
+          cabal-env array bytestring containers deepseq directory filepath pretty process time binary unix text parsec mtl
+          cat $HOME/.ghc/*/environments/default
+      - uses: actions/checkout@v1
+      - name: Doctest
+        run: make doctest
+
+{############################################################################}
+{# Bootstrap jobs                                                           #}
+{############################################################################}
+  boostrap-linux:
+    name: Bootstrap on Linux
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Set PATH
+        run: |
+          echo "::add-path::/opt/ghc/8.6.5/bin"
+      - uses: actions/checkout@v1
+      - name: bootstrap.sh
+        env:
+          EXTRA_CONFIGURE_OPTS: ""
+        run: |
+          cd cabal-install
+          sh ./bootstrap.sh --no-doc
+      - name: Smoke test
+        run: |
+          $HOME/.cabal/bin/cabal --version
+
+      - name: Prepare for upload
+        run: xz -c < $HOME/.cabal/bin/cabal > cabal-artifact.xz
+      - uses: actions/upload-artifact@v1
+        with:
+          name: cabal-linux-x86_64.xz
+          path: cabal-artifact.xz
+
+  boostrap-macos:
+    name: Bootstrap on macOS
+    runs-on: macos-latest
+    steps:
+      - name: Install GHC
+        run: |
+          cd $(mktemp -d)
+          curl -sLO "https://downloads.haskell.org/~ghc/8.6.5/ghc-8.6.5-x86_64-apple-darwin.tar.xz"
+          tar -xJf ghc-*.tar.xz
+          cd ghc-*
+          ./configure --prefix=/opt/ghc/8.6.5
+          sudo make install
+      - name: Set PATH
+        run: |
+          echo "::add-path::/opt/ghc/8.6.5/bin"
+          echo "::add-path::$HOME/.cabal/bin"
+      - uses: actions/checkout@v1
+      - name: bootstrap.sh
+        env:
+          EXTRA_CONFIGURE_OPTS: ""
+        run: |
+          cd cabal-install
+          sh ./bootstrap.sh --no-doc
+      - name: Smoke test
+        run: |
+          $HOME/.cabal/bin/cabal --version
+
+      - name: Prepare for upload
+        run: xz -c < $HOME/.cabal/bin/cabal > cabal-artifact.xz
+      - uses: actions/upload-artifact@v1
+        with:
+          name: cabal-macos-x86_64.xz
+          path: cabal-artifact.xz
+
+{############################################################################}
+{# Linux jobs                                                               #}
+{############################################################################}
+{% for job in jobs %}
+  validate-{{ mangleVersion job.version }}{% if job.old %}-old{% endif %}:
+    name: validate.sh {%if job.old %}old GHCs{% else %}ghc-{{job.version}}{% endif %}
+    runs-on: ubuntu-18.04
+{% for needs in job.needs %}
+    needs: validate-{{ mangleVersion needs }}
+{% endfor %}
+    container:
+      image: phadej/ghc:{{job.version}}-{% if job.xenial %}xenial{% else %}bionic{% endif %}
+    steps:
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
+          echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+{% if or job.xenial job.old %}
+      - name: apt-get update
+        run: apt-get update
+{% endif %}
+{% if job.xenial %}
+      - name: Install dynamic libraries
+        run: apt-get install -y ghc-{{job.version}}-dyn
+{% endif %}
+{% if job.old %}
+      - name: Install extra compilers
+        run: apt-get install -y ghc-7.0.4-dyn ghc-7.2.2-dyn ghc-7.4.2-dyn
+{% endif %}
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v1
+{% for step in job.steps %}
+      - name: Validate {{step}}
+        run: sh validate.sh -j 2 -w ghc-{{job.version}} -v {{job.flags}} -s {{step}}
+{% endfor %}
+{% endfor %}
+
+{############################################################################}
+{# MacOS jobs                                                               #}
+{############################################################################}
+{% for job in macosJobs %}
+  validate-macos-{{ mangleVersion job.version }}:
+    name: validate.sh macOS ghc-{{job.version}}
+    runs-on: macos-latest
+{% for needs in job.needs %}
+    needs: validate-macos-{{ mangleVersion needs }}
+{% endfor %}
+    steps:
+      - name: Install GHC
+        run: |
+          cd $(mktemp -d)
+          curl -sLO {{job.ghcUrl}}
+          tar -xJf ghc-*.tar.xz
+          cd ghc-*
+          ./configure --prefix=/opt/ghc/{{job.version}}
+          sudo make install
+      - name: Install Cabal
+        run: |
+          cd $(mktemp -d)
+          curl -sLO https://downloads.haskell.org/~cabal/cabal-install-3.0.0.0/cabal-install-3.0.0.0-x86_64-apple-darwin17.7.0.tar.xz
+          tar -xJf cabal-install-*.tar.xz
+          sudo mkdir -p /opt/cabal/3.0/bin
+          sudo cp cabal /opt/cabal/3.0/bin/cabal
+          sudo chmod 755 /opt/cabal/3.0/bin/cabal
+      - name: Set PATH
+        run: |
+          echo "::add-path::/opt/ghc/{{job.version}}/bin"
+          echo "::add-path::/opt/cabal/3.0/bin"
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Update Hackage index
+        run: cabal v2-update
+      - name: Install cabal-plan
+        run: |
+          cd $(mktemp -d)
+{# aeson +fast, so we don't wait for -O2 #}
+          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
+      - uses: actions/checkout@v1
+{% for step in job.steps %}
+      - name: Validate {{step}}
+        run: sh validate.sh -j 2 -w ghc-{{job.version}} -v {{job.flags}} -s {{step}}
+{% endfor %}
+{% endfor %}

--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -55,3 +55,14 @@ executable gen-spdx-exc
     , optparse-applicative  ^>=0.15.1.0
     , text
     , zinza                 ^>=0.2
+
+executable gen-validate
+  default-language: Haskell2010
+  main-is:          GenValidate.hs
+  hs-source-dirs:   src
+  ghc-options:      -Wall
+  build-depends:
+    , base
+    , bytestring
+    , HsYAML      ^>=0.2.1.0
+    , zinza       ^>=0.2

--- a/cabal-dev-scripts/src/GenValidate.hs
+++ b/cabal-dev-scripts/src/GenValidate.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- runghc -package-env=default Validate.hs validate.yml.zinza .github/workflows/validate.yml
+module Main (main) where
+
+import GHC.Generics       (Generic)
+import System.Environment (getArgs)
+import System.Exit        (exitFailure)
+import Zinza
+       (Zinza (..), genericFromValueSFP, genericToTypeSFP, genericToValueSFP,
+       parseAndCompileTemplateIO)
+
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+import qualified Data.YAML             as YAML
+
+main :: IO ()
+main = do
+    args <- getArgs
+    case args of
+        [src,tgt] -> do
+            run <- parseAndCompileTemplateIO src
+            -- this shouldn't fail (run-time errors are due bugs in zinza)
+            w <- run Z
+                { zJobs =
+                    [ GhcJob "8.8.1"  False "--solver-benchmarks" False [] defSteps
+                    , GhcJob "8.6.5"  False ""                    False ["8.8.1"] defSteps
+                    , GhcJob "8.4.4"  False ""                    False ["8.8.1"] defSteps
+                    , GhcJob "8.2.2"  False ""                    False ["8.8.1"] defSteps
+                    , GhcJob "8.0.2"  False ""                    False ["8.8.1"] defSteps
+                    , GhcJob "7.10.3" False ""                    False ["8.8.1"] defSteps
+                    , GhcJob "7.8.4"  False "--lib-only"          False ["8.8.1"] libSteps
+                    , GhcJob "7.6.3"  True  "--lib-only"          False ["8.8.1"] libSteps
+                    , GhcJob "8.8.1"  True  "--lib-only"          True  ["8.8.1"] $
+                        libSteps ++
+                        [ "lib-suite-extras --extra-hc /opt/ghc/7.0.4/bin/ghc-7.0.4"
+                        , "lib-suite-extras --extra-hc /opt/ghc/7.2.2/bin/ghc-7.2.2"
+                        , "lib-suite-extras --extra-hc /opt/ghc/7.4.2/bin/ghc-7.4.2"
+                        ]
+                    ]
+                , zMacosJobs =
+                    [ mkMacGhcJob "8.8.1" "https://downloads.haskell.org/~ghc/8.8.1/ghc-8.8.1-x86_64-apple-darwin.tar.xz"
+                    , mkMacGhcJob "8.6.5" "https://downloads.haskell.org/~ghc/8.6.5/ghc-8.6.5-x86_64-apple-darwin.tar.xz"
+                    ]
+                , zMangleVersion = map mangleChar
+                , zOr            = (||)
+                , zNotNull       = not . null
+                , zFalse         = False
+                }
+
+            -- check that YAML is syntactically valid
+            let bs = LBS8.pack w
+            case YAML.decode1 bs of
+                Right (_ :: YAML.Node YAML.Pos) -> return ()
+                Left (pos, err)                 -> do
+                    putStrLn $ "ERROR:" ++ YAML.prettyPosWithSource pos bs err
+                    exitFailure
+
+            writeFile tgt w
+        _ -> putStrLn "Usage source.yml.zinza target.yml"
+
+mangleChar :: Char -> Char
+mangleChar '.' = '_'
+mangleChar c   = c
+
+defSteps :: [String]
+defSteps =
+    [ "print-config"
+    , "print-tool-versions"
+    , "make-cabal-install-dev"
+    , "build"
+    , "lib-tests"
+    , "lib-suite"
+    , "cli-tests"
+    , "cli-suite"
+    ]
+
+libSteps :: [String]
+libSteps =
+    [ "print-config"
+    , "print-tool-versions"
+    , "build"
+    , "lib-tests"
+    , "lib-suite"
+    ]
+
+data Z = Z
+    { zJobs          :: [GhcJob]
+    , zMacosJobs     :: [MacGhcJob]
+    , zMangleVersion :: String -> String
+    , zOr            :: Bool -> Bool -> Bool
+    , zNotNull       :: [String] -> Bool
+    , zFalse         :: Bool
+    }
+  deriving (Generic)
+
+data GhcJob = GhcJob
+    { gjVersion :: String
+    , gjXenial  :: Bool
+    , gjFlags   :: String
+    , gjOld     :: Bool
+    , gjNeeds   :: [String]
+    , gjSteps   :: [String]
+    }
+  deriving (Generic)
+
+data MacGhcJob = MacGhcJob
+    { mgjVersion :: String
+    , mgjGhcUrl  :: String
+    , mgjFlags   :: String
+    , mgjNeeds   :: [String]
+    , mgjSteps   :: [String]
+    }
+  deriving (Generic)
+
+mkMacGhcJob :: String -> String -> MacGhcJob
+mkMacGhcJob v u = MacGhcJob
+    { mgjVersion = v
+    , mgjGhcUrl  = u
+    , mgjFlags   = ""
+    , mgjNeeds   = ["8.8.1" | v /= "8.8.1"]
+    , mgjSteps   = defSteps
+    }
+
+instance Zinza Z where
+    toType    = genericToTypeSFP
+    toValue   = genericToValueSFP
+    fromValue = genericFromValueSFP
+
+instance Zinza GhcJob where
+    toType    = genericToTypeSFP
+    toValue   = genericToValueSFP
+    fromValue = genericFromValueSFP
+
+instance Zinza MacGhcJob where
+    toType    = genericToTypeSFP
+    toValue   = genericToValueSFP
+    fromValue = genericFromValueSFP

--- a/cabal.project.validate
+++ b/cabal.project.validate
@@ -1,4 +1,5 @@
 packages: Cabal/ cabal-testsuite/ cabal-install/ solver-benchmarks/
+tests: True
 
 write-ghc-environment-files: never
 

--- a/cabal.project.validate.libonly
+++ b/cabal.project.validate.libonly
@@ -1,4 +1,5 @@
 packages: Cabal/ cabal-testsuite/
+tests: True
 
 write-ghc-environment-files: never
 

--- a/validate.sh
+++ b/validate.sh
@@ -442,7 +442,7 @@ CMD="$($CABALPLANLISTBIN cabal-testsuite:exe:cabal-tests) --builddir=$CABAL_TEST
 # solver-benchmarks
 #######################################################################
 
-step_solver_benchmarks_test() {
+step_solver_benchmarks_tests() {
 print_header "solver-benchmarks: test"
 
 CMD="$($CABALPLANLISTBIN solver-benchmarks:test:unit-tests)"

--- a/validate.sh
+++ b/validate.sh
@@ -8,14 +8,20 @@ HC=ghc-8.2.2
 CABAL=cabal
 CABALPLAN=cabal-plan
 JOBS=4
-CABALTESTS=true
-CABALINSTALLTESTS=true
+LIBTESTS=true
+CLITESTS=true
 CABALSUITETESTS=true
-CABALONLY=false
+LIBONLY=false
 DEPSONLY=false
 DOCTEST=false
 BENCHMARKS=false
 VERBOSE=false
+
+TARGETS=""
+STEPS=""
+EXTRAHCS=""
+
+LISTSTEPS=false
 
 # Help
 #######################################################################
@@ -24,24 +30,29 @@ show_usage() {
 cat <<EOF
 ./validate.sh - build & test
 
-Usage: ./validate.sh [ -j JOBS | -l | -C | -c | -s | -w HC | -x CABAL | -y CABALPLAN | -d | -D | -b | -v ]
+Usage: ./validate.sh [options]
   A script which runs all the tests.
 
 Available options:
-  -j JOBS        cabal v2-build -j argument (default: $JOBS)
-  -l             Test Cabal-the-library only (default: $CABALONLY)
-  -C             Don't run Cabal tests (default: $CABALTESTS)
-  -c             Don't run cabal-install tests (default: $CABALINSTALLTESTS)
-  -s             Don't run cabal-testsuite tests (default: $CABALSUITETESTS)
-  -w HC          With compiler
-  -x CABAL       With cabal-install
-  -y CABALPLAN   With cabal-plan
-  -d             Build dependencies only
-  -D             Run doctest
-  -b             Run benchmarks (quick run, verify they work)
-  -v             Verbose
+  -j, --jobs JOBS                   cabal v2-build -j argument (default:  $JOBS)
+      --libonly                     Test onlt Cabal-the-library
+      --cli                         Test both Cabal-the-library and cabal-install
+      --(no-)run-lib-tests          Run library tests
+      --(no-)run-cli-tests          Run client tests
+      --(no-)run-lib-suite          Run cabal-testsuite with library
+      --(no-)run-cli-suite          Run cabal-testsuite with client
+  -w, --with-compiler HC            With compiler
+      --with-cabal CABAL            With cabal-install
+      --with-cabal-plan CABALPLAN   With cabal-plan
+      --extra-hc HC                 Extra compiler to run test-suite with
+      --(no-)doctest                Run doctest on library
+      --(no-)solver-benchmarks      Build and trial run solver-benchmarks
+  -v, --verbose                     Verbose output
+  -q, --quiet                       Less output
+  -s, --step STEP                   Run only specific step (can be specified mutliple times)
+      --list-steps                  List steps and build-targets and exit
+      --help                        Print this message and exit
 EOF
-exit 0
 }
 
 # "library"
@@ -103,56 +114,165 @@ timed() {
     fi
 }
 
-footer() {
-    JOB_END_TIME=$(date +%s)
-    tduration=$((JOB_END_TIME - JOB_START_TIME))
+print_header() {
+    TITLE=$1
+    TITLEPAT="$(echo "$TITLE"|sed 's:.:=:g')"
+    echo "$CYAN===X============================================================ $(date +%T) ===$RESET" \
+      | sed "s#X$TITLEPAT=# $TITLE #"
 
-    echo "$CYAN=== END ============================================ $(date +%T) === $RESET"
-    echo "$CYAN!!! Validation took $tduration seconds. $RESET"
 }
 
 # getopt
 #######################################################################
 
-while getopts 'j:lCcsw:x:y:dDbv' flag; do
-    case $flag in
-        j) JOBS="$OPTARG"
+while [ $# -gt 0 ]; do
+    arg=$1
+    case $arg in
+        --help)
+            show_usage
+            exit
             ;;
-        l) CABALONLY=true
+        -j|--jobs)
+            JOBS="$2"
+            shift
+            shift
             ;;
-        C) CABALTESTS=false
+        --lib-only)
+            LIBONLY=true
+            shift
             ;;
-        c) CABALINSTALLTESTS=false
+        --cli)
+            LIBONLY=false
+            shift
             ;;
-        s) CABALSUITETESTS=false
+        --run-lib-tests)
+            LIBTESTS=true
+            shift
             ;;
-        w) HC="$OPTARG"
+        --no-run-lib-tests)
+            LIBTESTS=false
+            shift
             ;;
-        x) CABAL="$OPTARG"
+        --run-cli-tests)
+            CLITESTS=true
+            shift
             ;;
-        y) CABALPLAN="$OPTARG"
+        --no-run-cli-tests)
+            CLITESTS=false
+            shift
             ;;
-        d) DEPSONLY=true
+        --run-lib-suite)
+            LIBSUITE=true
+            shift
             ;;
-        D) DOCTEST=true
+        --no-run-lib-suite)
+            LIBSUITE=false
+            shift
             ;;
-        b) BENCHMARKS=true
+        --run-cli-suite)
+            CLISUITE=true
+            shift
             ;;
-        v) VERBOSE=true
+        --no-run-cli-suite)
+            CLISUITE=false
+            shift
             ;;
-        ?) show_usage
+        -w|--with-compiler)
+            HC=$2
+            shift
+            shift
             ;;
+        --with-cabal)
+            CABAL=$2
+            shift
+            shift
+            ;;
+        --with-cabal-plan)
+            CABALPLAN=$2
+            shift
+            shift
+            ;;
+        --extra-hc)
+            EXTRAHCS="$EXTRAHCS $2"
+            shift
+            shift
+            ;;
+        --doctest)
+            DOCTEST=true
+            shift
+            ;;
+        --no-doctest)
+            DOCTEST=false
+            shift
+            ;;
+        --solver-benchmarks)
+            BENCHMARKS=true
+            shift
+            ;;
+        --no-solver-benchmarks)
+            BENCHMARKS=false
+            shift
+            ;;
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -q|--quiet)
+            VERBOSE=false
+            shift
+            ;;
+        -s|--step)
+            STEPS="$STEPS $2"
+            shift
+            shift
+            ;;
+        --list-steps)
+            LISTSTEPS=true
+            shift
+            ;;
+        *)
+            echo "Unknown option $arg"
+            exit 1
     esac
 done
 
-shift $((OPTIND - 1))
-
-# header
+# calculate steps and build targets
 #######################################################################
 
-if [ "xhelp" = "x$1" ]; then
-    show_usage;
+# If there are no explicit steps given calculate them
+if $LIBONLY; then
+    CLITESTS=false
+    CLISUITE=false
+    BENCHMARKS=false
 fi
+
+if [ -z "$STEPS" ]; then
+    STEPS="print-config print-tool-versions"
+    if ! $LIBONLY;  then STEPS="$STEPS make-cabal-install-dev"; fi
+    STEPS="$STEPS build"
+    if $DOCTEST;    then STEPS="$STEPS doctest";   fi
+    if $LIBTESTS;   then STEPS="$STEPS lib-tests"; fi
+    if $LIBSUITE;   then STEPS="$STEPS lib-suite"; fi
+    if $LIBSUITE && [ -n "$EXTRAHCS" ];
+                    then STEPS="$STEPS lib-suite-extras"; fi
+    if $CLITESTS;   then STEPS="$STEPS cli-tests"; fi
+    if $CLISUITE;   then STEPS="$STEPS cli-suite"; fi
+    if $BENCHMARKS; then STEPS="$STEPS solver-benchmarks-tests solver-benchmarks-run"; fi
+    STEPS="$STEPS time-summary"
+fi
+
+TARGETS="Cabal cabal-testsuite"
+if ! $LIBONLY;  then TARGETS="$TARGETS cabal-install"; fi
+if $BENCHMARKS; then TARGETS="$TARGETS solver-benchmarks"; fi
+
+if $LISTSTEPS; then
+  echo "Targets: $TARGETS"
+  echo "Steps:   $STEPS"
+  exit
+fi
+
+# Adjust runtime configuration
+#######################################################################
 
 TESTSUITEJOBS="-j$JOBS"
 JOBS="-j$JOBS"
@@ -160,39 +280,13 @@ JOBS="-j$JOBS"
 # assume compiler is GHC
 RUNHASKELL=$(echo $HC | sed -E 's/ghc(-[0-9.]*)$/runghc\1/')
 
-echo "$CYAN=== validate.sh ======================================== $(date +%T) === $RESET"
-
-cat <<EOF
-compiler:            $HC
-runhaskell           $RUNHASKELL
-cabal-install:       $CABAL
-cabal-plan:          $CABALPLAN
-jobs:                $JOBS
-Cabal tests:         $CABALTESTS
-cabal-install tests: $CABALINSTALLTESTS
-cabal-testsuite:     $CABALSUITETESTS
-library only:        $CABALONLY
-dependencies only:   $DEPSONLY
-doctest:             $DOCTEST
-benchmarks:          $BENCHMARKS
-verbose:             $VERBOSE
-
-EOF
-
-timed $HC --version
-timed $CABAL --version
-timed $CABALPLAN --version
-
-# Basic setup
-#######################################################################
-
 if [ "$(uname)" = "Linux" ]; then
     ARCH="x86_64-linux"
 else
     ARCH="x86_64-osx"
 fi
 
-if $CABALONLY; then
+if $LIBONLY; then
     PROJECTFILE=cabal.project.validate.libonly
 else
     PROJECTFILE=cabal.project.validate
@@ -205,69 +299,78 @@ CABAL_TESTSUITE_BDIR="$(pwd)/$BUILDDIR/build/$ARCH/$BASEHC/cabal-testsuite-3"
 CABALNEWBUILD="${CABAL} v2-build $JOBS -w $HC --builddir=$BUILDDIR --project-file=$PROJECTFILE"
 CABALPLANLISTBIN="${CABALPLAN} list-bin --builddir=$BUILDDIR"
 
-# SCRIPT
+# header
 #######################################################################
 
-if ! $CABALONLY; then
+step_print_config() {
+print_header print-config
 
-echo "$CYAN=== make cabal-install-dev ============================= $(date +%T) === $RESET"
+cat <<EOF
+compiler:            $HC
+runhaskell           $RUNHASKELL
+cabal-install:       $CABAL
+cabal-plan:          $CABALPLAN
+jobs:                $JOBS
+Cabal tests:         $LIBTESTS
+cabal-install tests: $CLITESTS
+cabal-testsuite:     $CABALSUITETESTS
+library only:        $LIBONLY
+dependencies only:   $DEPSONLY
+doctest:             $DOCTEST
+benchmarks:          $BENCHMARKS
+verbose:             $VERBOSE
+extra complers:      $EXTRAHCS
 
-# make cabal-install-dev
+EOF
+}
+
+step_print_tool_versions() {
+print_header print-tool-versions
+
+timed $HC --version
+timed $CABAL --version
+timed $CABALPLAN --version
+
+for EXTRAHC in $EXTRAHCS; do
+    timed $EXTRAHC --version
+done
+}
+
+step_time_summary() {
+    print_header END
+
+    JOB_END_TIME=$(date +%s)
+    tduration=$((JOB_END_TIME - JOB_START_TIME))
+
+    echo "$CYAN!!! Validation took $tduration seconds. $RESET"
+}
+
+# build
+#######################################################################
+
+step_make_cabal_install_dev() {
+print_header "make cabal-install-dev"
 timed ${RUNHASKELL} cabal-dev-scripts/src/Preprocessor.hs -o cabal-install/cabal-install.cabal -f CABAL_FLAG_LIB cabal-install/cabal-install.cabal.pp
+}
 
-fi # CABALONLY
-
-# Dependencies
-
-if $DEPSONLY; then
-
-echo "$CYAN=== dependencies  ====================================== $(date +%T) === $RESET"
-
-timed $CABALNEWBUILD Cabal:lib:Cabal --enable-tests --disable-benchmarks --dep --dry-run || exit 1
-timed $CABALNEWBUILD Cabal:lib:Cabal --enable-tests --disable-benchmarks --dep || exit 1
-if $CABALTESTS; then
-    timed $CABALNEWBUILD Cabal --enable-tests --disable-benchmarks --dep --dry-run || exit 1
-    timed $CABALNEWBUILD Cabal --enable-tests --disable-benchmarks --dep || exit 1
-fi
-
-# Unfortunately we can not install cabal-install or cabal-testsuite dependencies:
-# that would build Cabal-lib!
-
-footer
-exit
-
-fi # DEPSONLY
+step_build() {
+print_header "build"
+timed $CABALNEWBUILD $TARGETS --dry-run || exit 1
+timed $CABALNEWBUILD $TARGETS || exit 1
+}
 
 # Cabal lib
 #######################################################################
 
-echo "$CYAN=== Cabal: build ======================================= $(date +%T) === $RESET"
+step_doctest() {
+print_header "Cabal: doctest"
+cabal-env --name doctest-Cabal --transitive QuickCheck
+cabal-env --name doctest-Cabal array bytestring containers deepseq directory filepath pretty process time binary unix text parsec mtl
+timed doctest -package-env=doctest-Cabal --fast Cabal/Distribution Cabal/Language
+}
 
-timed $CABALNEWBUILD Cabal:lib:Cabal --enable-tests --disable-benchmarks --dry-run || exit 1
-timed $CABALNEWBUILD Cabal:lib:Cabal --enable-tests --disable-benchmarks --dep || exit 1
-timed $CABALNEWBUILD Cabal:lib:Cabal --enable-tests --disable-benchmarks || exit 1
-
-if $DOCTEST; then
-if command -v doctest >/dev/null; then
-echo "$CYAN=== Cabal: doctest ===================================== $(date +%T) === $RESET"
-
-timed $CABALNEWBUILD Cabal:lib:Cabal --enable-tests --disable-benchmarks --write-ghc-environment-files=always || exit 1
-timed doctest --fast Cabal/Distribution Cabal/Language
-timed rm -f .ghc.environment.*
-
-else
-
-echo "No doctest command found"
-
-fi # command -v doctest
-fi # DOCTEST
-
-if $CABALTESTS; then
-echo "$CYAN=== Cabal: test ======================================== $(date +%T) === $RESET"
-
-timed $CABALNEWBUILD Cabal:tests --enable-tests --disable-benchmarks --dry-run || exit 1
-timed $CABALNEWBUILD Cabal:tests --enable-tests --disable-benchmarks --dep || exit 1
-timed $CABALNEWBUILD Cabal:tests --enable-tests --disable-benchmarks || exit 1
+step_lib_tests() {
+print_header "Cabal: tests"
 
 CMD="$($CABALPLANLISTBIN Cabal:test:unit-tests) $TESTSUITEJOBS --hide-successes --with-ghc=$HC"
 (cd Cabal && timed $CMD) || exit 1
@@ -282,44 +385,32 @@ CMD=$($CABALPLANLISTBIN Cabal:test:hackage-tests)
 (cd Cabal && timed $CMD read-fields) || exit 1
 (cd Cabal && timed $CMD parsec d)    || exit 1
 (cd Cabal && timed $CMD roundtrip k) || exit 1
+}
 
-fi # $CABALTESTS
+# Cabal cabal-testsuite
+#######################################################################
 
-if $CABALSUITETESTS; then
-
-echo "$CYAN=== cabal-testsuite: build ============================= $(date +%T) === $RESET"
-
-timed $CABALNEWBUILD cabal-testsuite --enable-tests --disable-benchmarks --dry-run || exit 1
-timed $CABALNEWBUILD cabal-testsuite --enable-tests --disable-benchmarks --dep || exit 1
-timed $CABALNEWBUILD cabal-testsuite --enable-tests --disable-benchmarks || exit 1
-
-echo "$CYAN=== cabal-testsuite: Cabal test ======================== $(date +%T) === $RESET"
+step_lib_suite() {
+print_header "Cabal: cabal-testsuite"
 
 CMD="$($CABALPLANLISTBIN cabal-testsuite:exe:cabal-tests) --builddir=$CABAL_TESTSUITE_BDIR $TESTSUITEJOBS --with-ghc=$HC --hide-successes"
 (cd cabal-testsuite && timed $CMD) || exit 1
+}
 
-fi # CABALSUITETESTS (Cabal)
+step_lib_suite_extras() {
+for EXTRAHC in $EXTRAHCS; do
 
-# If testing only library, stop here
-if $CABALONLY; then
-    footer
-    exit
-fi
+CMD="$($CABALPLANLISTBIN cabal-testsuite:exe:cabal-tests) --builddir=$CABAL_TESTSUITE_BDIR $TESTSUITEJOBS --with-ghc=$EXTRAHC --hide-successes"
+(cd cabal-testsuite && timed $CMD) || exit 1
+
+done
+}
 
 # cabal-install
 #######################################################################
 
-echo "$CYAN=== cabal-install: build =============================== $(date +%T) === $RESET"
-
-timed $CABALNEWBUILD cabal-install --enable-tests --disable-benchmarks --dry-run || exit 1
-
-# For some reason this sometimes fails. So we try twice.
-CMD="$CABALNEWBUILD cabal-install --enable-tests --disable-benchmarks"
-(timed $CMD) || (timed $CMD) || exit 1
-
-
-if $CABALINSTALLTESTS; then
-echo "$CYAN=== cabal-install: test ================================ $(date +%T) === $RESET"
+step_cli_tests() {
+print_header "cabal-install: tests"
 
 # this are sorted in asc time used, quicker tests first.
 CMD="$($CABALPLANLISTBIN cabal-install:test:solver-quickcheck) $TESTSUITEJOBS --hide-successes"
@@ -336,42 +427,59 @@ CMD="$($CABALPLANLISTBIN cabal-install:test:memory-usage-tests) -j1 --hide-succe
 # This test-suite doesn't like concurrency
 CMD="$($CABALPLANLISTBIN cabal-install:test:integration-tests2) -j1 --hide-successes --with-ghc=$HC"
 (cd cabal-install && timed $CMD) || exit 1
+}
 
-fi # CABALINSTALLTESTS
+# cabal-install cabal-testsuite
+#######################################################################
 
-
-if $CABALSUITETESTS; then
-echo "$CYAN=== cabal-testsuite: cabal-install test ================ $(date +%T) === $RESET"
+step_cli_suite() {
+print_header "cabal-install: cabal-testsuite"
 
 CMD="$($CABALPLANLISTBIN cabal-testsuite:exe:cabal-tests) --builddir=$CABAL_TESTSUITE_BDIR --with-cabal=$($CABALPLANLISTBIN cabal-install:exe:cabal) $TESTSUITEJOBS --hide-successes"
 (cd cabal-testsuite && timed $CMD) || exit 1
-
-fi # CABALSUITETESTS
+}
 
 # solver-benchmarks
 #######################################################################
 
-if $BENCHMARKS; then
-echo "$CYAN=== solver-benchmarks: build =========================== $(date +%T) === $RESET"
-
-timed $CABALNEWBUILD solver-benchmarks:hackage-benchmark solver-benchmarks:unit-tests --enable-tests
-
-echo "$CYAN=== solver-benchmarks: test ============================ $(date +%T) === $RESET"
+step_solver_benchmarks_test() {
+print_header "solver-benchmarks: test"
 
 CMD="$($CABALPLANLISTBIN solver-benchmarks:test:unit-tests)"
 (cd Cabal && timed $CMD) || exit 1
+}
 
-echo "$CYAN=== solver-benchmarks: run ============================= $(date +%T) === $RESET"
+step_solver_benchmarks_run() {
+print_header "solver-benchmarks: run"
 
 SOLVEPKG=Chart-diagrams
 CMD="$($CABALPLANLISTBIN solver-benchmarks:exe:hackage-benchmark) --cabal1=$CABAL --cabal2=$($CABALPLANLISTBIN cabal-install:exe:cabal) --trials=5 --packages=$SOLVEPKG --print-trials"
 (cd Cabal && timed $CMD) || exit 1
+}
 
-fi
-
-# END
+# Steps dispatcher
 #######################################################################
 
-footer
+for step in $STEPS; do
+    case $step in
+        print-config)             step_print_config            ;;
+        print-tool-versions)      step_print_tool_versions     ;;
+        make-cabal-install-dev)   step_make_cabal_install_dev  ;;
+        build)                    step_build                   ;;
+        doctest)                  step_doctest                 ;;
+        lib-tests)                step_lib_tests               ;;
+        cli-tests)                step_cli_tests               ;;
+        lib-suite)                step_lib_suite               ;;
+        lib-suite-extras)         step_lib_suite_extras        ;;
+        cli-suite)                step_cli_suite               ;;
+        solver-benchmarks-tests)  step_solver_benchmarks_tests ;;
+        solver-benchmarks-run)    step_solver_benchmarks_run   ;;
+        time-summary)             step_time_summary            ;;
+        *) 
+            echo "Invalid step $step"
+            exit 1
+            ;;
+    esac
+done
 
 #######################################################################


### PR DESCRIPTION
I'm not removing `.travis.yml` just yet. Let's have it on until 3.2 is done.

I'll cleanup the generation (there's todo about documenting it), will do that early 2020 and then merge. Please comment before that. The setup is simpler, but I'm not 100% if it has same the coverage as current travis setup

- *pro* simpler
- *pro* uses `validate.sh`, so you have better chance to reproduce on own machine
- *con* even closer integration with GitHub
    - yet, the new setup is less GitHub specific than the current setup is Travis specific, so I guess it's not that bad 