### PR TITLE
Doc: v2-building every package requires "all" [ci skip]

### DIFF
--- a/Cabal/doc/nix-local-build.rst
+++ b/Cabal/doc/nix-local-build.rst
@@ -51,7 +51,7 @@ directory, run the command: (using cabal-install-2.0 or greater.)
 
 ::
 
-    $ cabal v2-build
+    $ cabal v2-build all
 
 To build a specific package, you can either run ``v2-build`` from the
 directory of the package in question:


### PR DESCRIPTION
Calling `v2-build` by itself doesn't work.  Need `all`.