### PR TITLE
Try to make test for 3324 more robust

### DIFF
--- a/cabal-install/cabal-install.cabal.pp
+++ b/cabal-install/cabal-install.cabal.pp
@@ -657,6 +657,7 @@ test-suite integration-tests2
   other-modules:
   build-depends:
         base,
+        bytestring,
         Cabal,
         cabal-lib-client,
         containers,


### PR DESCRIPTION
On Windows moving files fails often enough,
let's try another tactic for recovering modified file.