### PR TITLE
docs: Reference default-extensions from ghc-options

### DIFF
--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -2388,7 +2388,7 @@ system-dependent values for these fields.
 .. pkg-field:: ghc-options: token list
 
     Additional options for GHC. You can often achieve the same effect
-    using the :pkg-field:`extensions` field, which is preferred.
+    using the :pkg-field:`default-extensions` field, which is preferred.
 
     Options required only by one module may be specified by placing an
     ``OPTIONS_GHC`` pragma in the source file affected.


### PR DESCRIPTION
Previously the user's guide stated that the `extensions` field was
preferred over `ghc-options` even though `extensions` are deprecated
in favour for `default-extensions`.

[ci skip]
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
