### PR TITLE
[ci skip] Enable opensearch in Cabal documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -94,7 +94,7 @@ html_theme_options = {
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+html_use_opensearch = 'https://cabal.readthedocs.io/en/stable'
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 #html_file_suffix = None


### PR DESCRIPTION
---
Please include the following checklist in your PR:

This PR fixed #6537.

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
