### PR TITLE
Fix js-sources passing in exe builds

### DIFF
--- a/Cabal/Distribution/Simple/GHCJS.hs
+++ b/Cabal/Distribution/Simple/GHCJS.hs
@@ -950,6 +950,7 @@ decodeMainIsArg arg
 -- | A collection of:
 --    * C input files
 --    * C++ input files
+--    * JS input files
 --    * GHC input files
 --    * GHC input modules
 --
@@ -957,6 +958,7 @@ decodeMainIsArg arg
 data BuildSources = BuildSources {
         cSourcesFiles      :: [FilePath],
         cxxSourceFiles     :: [FilePath],
+        jsSourceFiles      :: [FilePath],
         inputSourceFiles   :: [FilePath],
         inputSourceModules :: [ModuleName]
     }
@@ -1002,6 +1004,7 @@ gbuildSources verbosity specVer tmpDir bm =
              return BuildSources {
                         cSourcesFiles      = cSources bnfo,
                         cxxSourceFiles     = cxxSources bnfo,
+                        jsSourceFiles      = jsSources bnfo,
                         inputSourceFiles   = [main],
                         inputSourceModules = filter (/= mainModName) $ exeModules exe
                     }
@@ -1009,6 +1012,7 @@ gbuildSources verbosity specVer tmpDir bm =
           else return BuildSources {
                           cSourcesFiles      = cSources bnfo,
                           cxxSourceFiles     = cxxSources bnfo,
+                          jsSourceFiles      = jsSources bnfo,
                           inputSourceFiles   = [main],
                           inputSourceModules = exeModules exe
                       }
@@ -1022,6 +1026,7 @@ gbuildSources verbosity specVer tmpDir bm =
              in  return BuildSources {
                             cSourcesFiles      = csf,
                             cxxSourceFiles     = cxxsf,
+                            jsSourceFiles      = [],
                             inputSourceFiles   = [],
                             inputSourceModules = exeModules exe
                         }
@@ -1031,6 +1036,7 @@ gbuildSources verbosity specVer tmpDir bm =
         BuildSources {
             cSourcesFiles      = cSources bnfo,
             cxxSourceFiles     = cxxSources bnfo,
+            jsSourceFiles      = [],
             inputSourceFiles   = [],
             inputSourceModules = foreignLibModules flib
         }
@@ -1085,6 +1091,7 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
 
   let cSrcs               = cSourcesFiles buildSources
       cxxSrcs             = cxxSourceFiles buildSources
+      jsSrcs              = jsSourceFiles buildSources
       inputFiles          = inputSourceFiles buildSources
       inputModules        = inputSourceModules buildSources
       isGhcDynamic        = isDynamic comp
@@ -1137,8 +1144,8 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
                                                 PD.frameworks bnfo,
                       ghcOptLinkFrameworkDirs = toNubListR $
                                                 PD.extraFrameworkDirs bnfo,
-                      ghcOptInputFiles     = toNubListR
-                                             [tmpDir </> x | x <- cObjs ++ cxxObjs]
+                      ghcOptInputFiles     = toNubListR $
+                                             [tmpDir </> x | x <- cObjs ++ cxxObjs] ++ jsSrcs
                     }
       dynLinkerOpts = mempty {
                       ghcOptRPaths         = rpaths


### PR DESCRIPTION
Commit c470154 (#6025) removed buildOrReplExe, but did not port the `js-sources` functionality to the new `gbuild` function. This means `js-sources` was only being passed to GHC on lib builds, but js files were not being linked in on exe builds.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

I tested building my ghcjs exe with or without this patch and confirmed that the js-bits are now being linked in.