### PR TITLE
Add RepoName newtype

### DIFF
--- a/cabal-install/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/Distribution/Client/GlobalFlags.hs
@@ -17,7 +17,7 @@ import Prelude ()
 import Distribution.Client.Compat.Prelude
 
 import Distribution.Client.Types
-         ( Repo(..), RemoteRepo(..), LocalRepo (..), localRepoCacheKey )
+         ( Repo(..), unRepoName, RemoteRepo(..), LocalRepo (..), localRepoCacheKey )
 import Distribution.Simple.Setup
          ( Flag(..), fromFlag, flagToMaybe )
 import Distribution.Utils.NubList
@@ -162,7 +162,7 @@ withRepoContext' verbosity remoteRepos localRepos localNoIndexRepos
                  sharedCacheDir httpTransport ignoreExpiry extraPaths = \callback -> do
     for_ localNoIndexRepos $ \local ->
         unless (FilePath.Posix.isAbsolute (localRepoPath local)) $
-            warn verbosity $ "file+noindex " ++ localRepoName local ++ " repository path is not absolute; this is fragile, and not recommended"
+            warn verbosity $ "file+noindex " ++ unRepoName (localRepoName local) ++ " repository path is not absolute; this is fragile, and not recommended"
 
     transportRef <- newMVar Nothing
     let httpLib = Sec.HTTP.transportAdapter
@@ -185,7 +185,7 @@ withRepoContext' verbosity remoteRepos localRepos localNoIndexRepos
     allRemoteRepos =
       [ (if isSecure then RepoSecure else RepoRemote) remote cacheDir
       | remote <- remoteRepos
-      , let cacheDir = sharedCacheDir </> remoteRepoName remote
+      , let cacheDir = sharedCacheDir </> unRepoName (remoteRepoName remote)
             isSecure = remoteRepoSecure remote == Just True
       ]
 

--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -43,7 +43,7 @@ import Distribution.Simple.Utils
 import Distribution.Client.Utils
          ( withTempFileName )
 import Distribution.Client.Types
-         ( RemoteRepo(..) )
+         ( unRepoName, RemoteRepo(..) )
 import Distribution.System
          ( buildOS, buildArch )
 import qualified System.FilePath.Posix as FilePath.Posix
@@ -204,8 +204,8 @@ remoteRepoCheckHttps :: Verbosity -> HttpTransport -> RemoteRepo -> IO ()
 remoteRepoCheckHttps verbosity transport repo
   | uriScheme (remoteRepoURI repo) == "https:"
   , not (transportSupportsHttps transport)
-              = die' verbosity $ "The remote repository '" ++ remoteRepoName repo
-                   ++ "' specifies a URL that " ++ requiresHttpsErrorMessage
+  = die' verbosity $ "The remote repository '" ++ unRepoName (remoteRepoName repo)
+    ++ "' specifies a URL that " ++ requiresHttpsErrorMessage
   | otherwise = return ()
 
 transportCheckHttps :: Verbosity -> HttpTransport -> URI -> IO ()

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -886,7 +886,7 @@ storeDetailedBuildReports verbosity logsDir reports = sequence_
   [ do dotCabal <- getCabalDir
        let logFileName = prettyShow (BuildReports.package report) <.> "log"
            logFile     = logsDir </> logFileName
-           reportsDir  = dotCabal </> "reports" </> remoteRepoName remoteRepo
+           reportsDir  = dotCabal </> "reports" </> unRepoName (remoteRepoName remoteRepo)
            reportFile  = reportsDir </> logFileName
 
        handleMissingLogFile $ do

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -27,8 +27,8 @@ import Distribution.Deprecated.ParseUtils (parseFlagAssignment)
 
 import Distribution.Client.ProjectConfig.Types
 import Distribution.Client.Types
-         ( RemoteRepo(..), LocalRepo (..), emptyRemoteRepo
-         , AllowNewer(..), AllowOlder(..) )
+         ( RepoName (..), RemoteRepo(..), LocalRepo (..), emptyRemoteRepo
+         , AllowNewer(..), AllowOlder(..), unRepoName )
 import Distribution.Client.SourceRepo (sourceRepositoryPackageGrammar, SourceRepoList)
 
 import Distribution.Client.Config
@@ -1397,7 +1397,7 @@ programDbOptions progDb showOrParseArgs get' set =
 remoteRepoSectionDescr :: SectionDescr GlobalFlags
 remoteRepoSectionDescr = SectionDescr
     { sectionName        = "repository"
-    , sectionEmpty       = emptyRemoteRepo ""
+    , sectionEmpty       = emptyRemoteRepo (RepoName "")
     , sectionFields      = remoteRepoFields
     , sectionSubsections = []
     , sectionGet         = getS
@@ -1406,9 +1406,9 @@ remoteRepoSectionDescr = SectionDescr
   where
     getS :: GlobalFlags -> [(String, RemoteRepo)]
     getS gf =
-        map (\x->(remoteRepoName x, x)) (fromNubList (globalRemoteRepos gf))
+        map (\x->(unRepoName $ remoteRepoName x, x)) (fromNubList (globalRemoteRepos gf))
         ++
-        map (\x->(localRepoName x, localToRemote x)) (fromNubList (globalLocalNoIndexRepos gf))
+        map (\x->(unRepoName $ localRepoName x, localToRemote x)) (fromNubList (globalLocalNoIndexRepos gf))
 
     setS :: Int -> String -> RemoteRepo -> GlobalFlags -> ParseResult GlobalFlags
     setS lineno reponame repo0 conf = do

--- a/cabal-install/Distribution/Client/Update.hs
+++ b/cabal-install/Distribution/Client/Update.hs
@@ -20,7 +20,7 @@ import Distribution.Simple.Setup
 import Distribution.Client.Compat.Directory
          ( setModificationTime )
 import Distribution.Client.Types
-         ( Repo(..), RemoteRepo(..), maybeRepoRemote )
+         ( Repo(..), RemoteRepo(..), maybeRepoRemote, unRepoName )
 import Distribution.Client.HttpUtils
          ( DownloadResult(..) )
 import Distribution.Client.FetchUtils
@@ -33,8 +33,8 @@ import Distribution.Client.JobControl
          ( newParallelJobControl, spawnJob, collectJob )
 import Distribution.Client.Setup
          ( RepoContext(..), UpdateFlags(..) )
-import Distribution.Deprecated.Text
-         ( display )
+import Distribution.Pretty
+         ( prettyShow )
 import Distribution.Verbosity
 
 import Distribution.Simple.Utils
@@ -61,10 +61,10 @@ update verbosity updateFlags repoCtxt = do
     [] -> return ()
     [remoteRepo] ->
         notice verbosity $ "Downloading the latest package list from "
-                        ++ remoteRepoName remoteRepo
+                        ++ unRepoName (remoteRepoName remoteRepo)
     _ -> notice verbosity . unlines
             $ "Downloading the latest package lists from: "
-            : map (("- " ++) . remoteRepoName) remoteRepos
+            : map (("- " ++) . unRepoName . remoteRepoName) remoteRepos
   jobCtrl <- newParallelJobControl (length repos)
   mapM_ (spawnJob jobCtrl . updateRepo verbosity updateFlags repoCtxt) repos
   mapM_ (\_ -> collectJob jobCtrl) repos
@@ -108,4 +108,4 @@ updateRepo verbosity updateFlags repoCtxt repo = do
       when (current_ts /= nullTimestamp) $
         noticeNoWrap verbosity $
           "To revert to previous state run:\n" ++
-          "    cabal update --index-state='" ++ display current_ts ++ "'\n"
+          "    cabal update --index-state='" ++ prettyShow current_ts ++ "'\n"

--- a/cabal-install/Distribution/Client/Upload.hs
+++ b/cabal-install/Distribution/Client/Upload.hs
@@ -1,7 +1,7 @@
 module Distribution.Client.Upload (upload, uploadDoc, report) where
 
 import Distribution.Client.Types ( Username(..), Password(..)
-                                 , RemoteRepo(..), maybeRepoRemote )
+                                 , RemoteRepo(..), maybeRepoRemote, unRepoName )
 import Distribution.Client.HttpUtils
          ( HttpTransport(..), remoteRepoTryUpgradeToHttps )
 import Distribution.Client.Setup
@@ -177,7 +177,7 @@ report verbosity repoCtxt mUsername mPassword = do
       let auth        = (username, password)
 
       dotCabal <- getCabalDir
-      let srcDir = dotCabal </> "reports" </> remoteRepoName remoteRepo
+      let srcDir = dotCabal </> "reports" </> unRepoName (remoteRepoName remoteRepo)
       -- We don't want to bomb out just because we haven't built any packages
       -- from this repo yet.
       srcExists <- doesDirectoryExist srcDir

--- a/cabal-install/tests/UnitTests/Distribution/Client/IndexUtils/Timestamp.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/IndexUtils/Timestamp.hs
@@ -1,6 +1,7 @@
 module UnitTests.Distribution.Client.IndexUtils.Timestamp (tests) where
 
-import Distribution.Deprecated.Text
+import Distribution.Parsec (simpleParsec)
+import Distribution.Pretty (prettyShow)
 import Data.Time
 import Data.Time.Clock.POSIX
 
@@ -19,24 +20,24 @@ tests =
     ]
 
 -- test unixtime format parsing
-prop_timestamp1 :: Int -> Bool
-prop_timestamp1 t0 = Just t == simpleParse ('@':show t0)
+prop_timestamp1 :: NonNegative Int -> Bool
+prop_timestamp1 (NonNegative t0) = Just t == simpleParsec ('@':show t0)
   where
     t = toEnum t0 :: Timestamp
 
--- test display/simpleParse roundtrip
+-- test prettyShow/simpleParse roundtrip
 prop_timestamp2 :: Int -> Bool
 prop_timestamp2 t0
-  | t /= nullTimestamp  = simpleParse (display t) == Just t
-  | otherwise           = display t == ""
+  | t /= nullTimestamp  = simpleParsec (prettyShow t) == Just t
+  | otherwise           = prettyShow t == ""
   where
     t = toEnum t0 :: Timestamp
 
--- test display against reference impl
+-- test prettyShow against reference impl
 prop_timestamp3 :: Int -> Bool
 prop_timestamp3 t0
-  | t /= nullTimestamp  = refDisp t == display t
-  | otherwise           = display t == ""
+  | t /= nullTimestamp  = refDisp t == prettyShow t
+  | otherwise           = prettyShow t == ""
   where
     t = toEnum t0 :: Timestamp
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -11,6 +11,7 @@ import Control.Applicative
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.List
+import Data.Char (isAlphaNum)
 
 import Distribution.Deprecated.ParseUtils
 import Distribution.Deprecated.Text as Text
@@ -819,11 +820,11 @@ instance Arbitrary PackageDB where
 instance Arbitrary RemoteRepo where
     arbitrary =
       RemoteRepo
-        <$> arbitraryShortToken `suchThat` (not . (":" `isPrefixOf`))
+        <$> arbitrary
         <*> arbitrary  -- URI
         <*> arbitrary
         <*> listOf arbitraryRootKey
-        <*> (fmap getNonNegative arbitrary)
+        <*> fmap getNonNegative arbitrary
         <*> pure False
       where
         arbitraryRootKey =
@@ -832,9 +833,13 @@ instance Arbitrary RemoteRepo where
 
 instance Arbitrary LocalRepo where
     arbitrary = LocalRepo
-        <$> arbitraryShortToken `suchThat` (not . (":" `isPrefixOf`))
+        <$> arbitrary
         <*> elements ["/tmp/foo", "/tmp/bar"] -- TODO: generate valid absolute paths
         <*> arbitrary
+
+instance Arbitrary RepoName where
+    arbitrary = RepoName <$> shortListOf1 10 (elements repochars) where
+        repochars = [ c | c <- [ '\NUL' .. '\255' ], isAlphaNum c || c `elem` ".-_" ]
 
 instance Arbitrary UserConstraintScope where
     arbitrary = oneof [ UserQualified <$> arbitrary <*> arbitrary

--- a/cabal-install/tests/UnitTests/Distribution/Client/TreeDiffInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/TreeDiffInstances.hs
@@ -90,6 +90,7 @@ instance ToExpr RelaxedDep
 instance ToExpr RemoteRepo
 instance ToExpr ReorderGoals
 instance ToExpr RepoKind
+instance ToExpr RepoName
 instance ToExpr RepoType
 instance ToExpr ReportLevel
 instance ToExpr ShortText


### PR DESCRIPTION
Make it, LocalRepo, RemoteRepo, IndexState and Timestamp use
Pretty/Parsec instead of Text

Mostly adding `unRepoName` to error printing statements
