### PR TITLE
Show resulting executable path when running 'cabal install'

### DIFF
--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -835,7 +835,7 @@ installBuiltExe
 installBuiltExe verbosity overwritePolicy
                 sourceDir exeName finalExeName
                 installdir InstallMethodSymlink = do
-  notice verbosity $ "Symlinking '" <> exeName <> "'"
+  notice verbosity $ "Symlinking '" <> exeName <> "' to '" <> installdir <> "'"
   symlinkBinary
     overwritePolicy
     installdir

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -845,7 +845,7 @@ installBuiltExe verbosity overwritePolicy
 installBuiltExe verbosity overwritePolicy
                 sourceDir exeName finalExeName
                 installdir InstallMethodCopy = do
-  notice verbosity $ "Copying '" <> exeName <> "'"
+  notice verbosity $ "Copying '" <> exeName <> "' to '" <> installdir <> "'"
   exists <- doesPathExist destination
   case (exists, overwritePolicy) of
     (True , NeverOverwrite ) -> pure False

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -835,7 +835,7 @@ installBuiltExe
 installBuiltExe verbosity overwritePolicy
                 sourceDir exeName finalExeName
                 installdir InstallMethodSymlink = do
-  notice verbosity $ "Symlinking '" <> exeName <> "' to '" <> installdir <> "'"
+  notice verbosity $ "Symlinking '" <> exeName <> "' to '" <> installdir </> finalExeName <> "'"
   symlinkBinary
     overwritePolicy
     installdir
@@ -845,7 +845,7 @@ installBuiltExe verbosity overwritePolicy
 installBuiltExe verbosity overwritePolicy
                 sourceDir exeName finalExeName
                 installdir InstallMethodCopy = do
-  notice verbosity $ "Copying '" <> exeName <> "' to '" <> installdir <> "'"
+  notice verbosity $ "Copying '" <> exeName <> "' to '" <> installdir </> finalExeName <> "'"
   exists <- doesPathExist destination
   case (exists, overwritePolicy) of
     (True , NeverOverwrite ) -> pure False

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -16,6 +16,7 @@
 	  --package-env` (#6298)
 	* `cabal v2-run` works with `.lhs` files (#6134)
 	* `subdir` in source-repository-package accepts multiple entries (#5472)
+	* 'cabal install' shows the resulting executable full path (symlinking and copying) (#6575)
 
 3.0.1.0 TBW December 2019
 	* Create store incoming directory

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -16,7 +16,6 @@
 	  --package-env` (#6298)
 	* `cabal v2-run` works with `.lhs` files (#6134)
 	* `subdir` in source-repository-package accepts multiple entries (#5472)
-	* 'cabal install' shows the resulting executable full path (symlinking and copying) (#6575)
 
 3.0.1.0 TBW December 2019
 	* Create store incoming directory


### PR DESCRIPTION
Tested the changes by installing and symlinking some programs. The output looks like the discussed in #6575 

Don't know where should I add the `ci skip` to avoid triggering a rebuild, so a maintainer should probably take a look into that

---
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.