### PR TITLE
Add Described to IndexState (incl. tests).

### DIFF
--- a/Cabal/Distribution/Types/PackageName.hs
+++ b/Cabal/Distribution/Types/PackageName.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 module Distribution.Types.PackageName
-  ( PackageName, unPackageName, mkPackageName
+  ( PackageName
+  , unPackageName, mkPackageName
+  , unPackageNameST, mkPackageNameST
   ) where
 
 import Prelude ()
@@ -29,6 +31,10 @@ newtype PackageName = PackageName ShortText
 unPackageName :: PackageName -> String
 unPackageName (PackageName s) = fromShortText s
 
+-- | @since 3.4.0.0
+unPackageNameST :: PackageName -> ShortText
+unPackageNameST (PackageName s) = s
+
 -- | Construct a 'PackageName' from a 'String'
 --
 -- 'mkPackageName' is the inverse to 'unPackageName'
@@ -39,6 +45,15 @@ unPackageName (PackageName s) = fromShortText s
 -- @since 2.0.0.2
 mkPackageName :: String -> PackageName
 mkPackageName = PackageName . toShortText
+
+-- | Construct a 'PackageName' from a 'ShortText'
+--
+-- Note: No validations are performed to ensure that the resulting
+-- 'PackageName' is valid
+--
+-- @since 3.4.0.0
+mkPackageNameST :: ShortText -> PackageName
+mkPackageNameST = PackageName
 
 -- | 'mkPackageName'
 --

--- a/Cabal/Distribution/Types/UnqualComponentName.hs
+++ b/Cabal/Distribution/Types/UnqualComponentName.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Distribution.Types.UnqualComponentName
-  ( UnqualComponentName, unUnqualComponentName, mkUnqualComponentName
+  ( UnqualComponentName, unUnqualComponentName, unUnqualComponentNameST, mkUnqualComponentName
   , packageNameToUnqualComponentName, unqualComponentNameToPackageName
   ) where
 
@@ -31,6 +31,10 @@ newtype UnqualComponentName = UnqualComponentName ShortText
 -- @since 2.0.0.2
 unUnqualComponentName :: UnqualComponentName -> String
 unUnqualComponentName (UnqualComponentName s) = fromShortText s
+
+-- | @since 3.4.0.0
+unUnqualComponentNameST :: UnqualComponentName -> ShortText
+unUnqualComponentNameST (UnqualComponentName s) = s
 
 -- | Construct a 'UnqualComponentName' from a 'String'
 --
@@ -78,7 +82,7 @@ instance NFData UnqualComponentName where
 --
 -- @since 2.0.0.2
 packageNameToUnqualComponentName :: PackageName -> UnqualComponentName
-packageNameToUnqualComponentName = mkUnqualComponentName . unPackageName
+packageNameToUnqualComponentName = UnqualComponentName . unPackageNameST
 
 -- | Converts an unqualified component name to a package name
 --
@@ -90,4 +94,4 @@ packageNameToUnqualComponentName = mkUnqualComponentName . unPackageName
 --
 -- @since 2.0.0.2
 unqualComponentNameToPackageName :: UnqualComponentName -> PackageName
-unqualComponentNameToPackageName = mkPackageName . unUnqualComponentName
+unqualComponentNameToPackageName = mkPackageNameST . unUnqualComponentNameST

--- a/Cabal/Distribution/Types/VersionRange.hs
+++ b/Cabal/Distribution/Types/VersionRange.hs
@@ -71,7 +71,6 @@ foldVersionRange anyv this later earlier union intersect = fold
     alg (MajorBoundVersionF v)          = fold (majorBound v)
     alg (UnionVersionRangesF v1 v2)     = union v1 v2
     alg (IntersectVersionRangesF v1 v2) = intersect v1 v2
-    alg (VersionRangeParensF v)         = v
 
     wildcard v = intersectVersionRanges
                    (orLaterVersion v)
@@ -104,12 +103,11 @@ normaliseVersionRange = hyloVersionRange embed projectVersionRange
 
 -- |  Remove 'VersionRangeParens' constructors.
 --
+-- Since version 3.4 this function is 'id', there aren't 'VersionRangeParens' constructor in 'VersionRange' anymore.
+--
 -- @since 2.2
 stripParensVersionRange :: VersionRange -> VersionRange
-stripParensVersionRange = hyloVersionRange embed projectVersionRange
-  where
-    embed (VersionRangeParensF vr) = vr
-    embed vr = embedVersionRange vr
+stripParensVersionRange = id
 
 -- | Does this version fall within the given range?
 --

--- a/Cabal/tests/ParserTests/regressions/encoding-0.8.expr
+++ b/Cabal/tests/ParserTests/regressions/encoding-0.8.expr
@@ -7,10 +7,9 @@ GenericPackageDescription
                      {condTreeComponents = [],
                       condTreeConstraints = [Dependency
                                                `PackageName "base"`
-                                               (VersionRangeParens
-                                                  (UnionVersionRanges
-                                                     (LaterVersion `mkVersion [4,4]`)
-                                                     (ThisVersion `mkVersion [4,4]`)))
+                                               (UnionVersionRanges
+                                                  (LaterVersion `mkVersion [4,4]`)
+                                                  (ThisVersion `mkVersion [4,4]`))
                                                (Set.fromList [LMainLibName])],
                       condTreeData = Library
                                        {exposedModules = [`ModuleName ["Data","Encoding"]`],
@@ -64,12 +63,11 @@ GenericPackageDescription
                                                           staticOptions = PerCompilerFlavor [] [],
                                                           targetBuildDepends = [Dependency
                                                                                   `PackageName "base"`
-                                                                                  (VersionRangeParens
-                                                                                     (UnionVersionRanges
-                                                                                        (LaterVersion
-                                                                                           `mkVersion [4,4]`)
-                                                                                        (ThisVersion
-                                                                                           `mkVersion [4,4]`)))
+                                                                                  (UnionVersionRanges
+                                                                                     (LaterVersion
+                                                                                        `mkVersion [4,4]`)
+                                                                                     (ThisVersion
+                                                                                        `mkVersion [4,4]`))
                                                                                   (Set.fromList
                                                                                      [LMainLibName])],
                                                           virtualModules = []},

--- a/Cabal/tests/ParserTests/regressions/encoding-0.8.format
+++ b/Cabal/tests/ParserTests/regressions/encoding-0.8.format
@@ -15,4 +15,4 @@ custom-setup
 library
     exposed-modules: Data.Encoding
     ghc-options:     -Wall -O2 -threaded -rtsopts "-with-rtsopts=-N1 -A64m"
-    build-depends:   base (>4.4 || ==4.4)
+    build-depends:   base >4.4 || ==4.4

--- a/Cabal/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -19,10 +19,10 @@ import UnitTests.Orphans ()
 tests :: TestTree
 tests = testGroup "Distribution.Utils.Structured"
     -- This test also verifies that structureHash doesn't loop.
-    [ testCase "VersionRange"   $ structureHash (Proxy :: Proxy VersionRange)   @?= Fingerprint 0x3827faffd22242bf 0xfd0c337e60fc808b
+    [ testCase "VersionRange"   $ structureHash (Proxy :: Proxy VersionRange)   @?= Fingerprint 0x6a33c568c9307696 0xe383268b2389a958
     , testCase "SPDX.License"   $ structureHash (Proxy :: Proxy License)        @?= Fingerprint 0xd3d4a09f517f9f75 0xbc3d16370d5a853a
     -- The difference is in encoding of newtypes
 #if MIN_VERSION_base(4,7,0)
-    , testCase "LocalBuildInfo" $ structureHash (Proxy :: Proxy LocalBuildInfo) @?= Fingerprint 0xb48ff44b0e5d96ff 0xfc099544337e90ab
+    , testCase "LocalBuildInfo" $ structureHash (Proxy :: Proxy LocalBuildInfo) @?= Fingerprint 0x57e3e6dcec2cf371 0x00ef351fd0f41443
 #endif
     ]

--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -15,7 +15,7 @@ import Distribution.Utils.Generic
 
 import Data.Typeable (typeOf)
 import Math.NumberTheory.Logarithms (intLog2)
-import Text.PrettyPrint as Disp (text, render, parens, hcat
+import Text.PrettyPrint as Disp (text, render, hcat
                                 ,punctuate, int, char, (<+>))
 import Test.Tasty
 import Test.Tasty.QuickCheck
@@ -284,7 +284,6 @@ prop_foldVersionRange range =
       UnionVersionRanges (expandVR v1) (expandVR v2)
     expandVR (IntersectVersionRanges v1 v2) =
       IntersectVersionRanges (expandVR v1) (expandVR v2)
-    expandVR (VersionRangeParens v) = expandVR v
     expandVR v = v
 
     upper = alterVersion $ \numbers -> case unsnoc numbers of
@@ -598,15 +597,7 @@ prop_parse_disp vr = counterexample (show (prettyShow vr')) $
 
 prop_parse_disp1 :: VersionRange -> Bool
 prop_parse_disp1 vr =
-    fmap stripParens (simpleParsec (prettyShow vr)) == Just (normaliseVersionRange vr)
-  where
-    stripParens :: VersionRange -> VersionRange
-    stripParens (VersionRangeParens v) = stripParens v
-    stripParens (UnionVersionRanges v1 v2) =
-      UnionVersionRanges (stripParens v1) (stripParens v2)
-    stripParens (IntersectVersionRanges v1 v2) =
-      IntersectVersionRanges (stripParens v1) (stripParens v2)
-    stripParens v = v
+    simpleParsec (prettyShow vr) == Just (normaliseVersionRange vr)
 
 prop_parse_disp2 :: VersionRange -> Property
 prop_parse_disp2 vr =
@@ -662,8 +653,6 @@ displayRaw =
     alg (MajorBoundVersionF v)          = Disp.text "^>=" <<>> pretty v
     alg (UnionVersionRangesF r1 r2)     = r1 <+> Disp.text "||" <+> r2
     alg (IntersectVersionRangesF r1 r2) = r1 <+> Disp.text "&&" <+> r2
-    alg (VersionRangeParensF r)         = Disp.parens r -- parens
-
 
     dispWild v =
            Disp.hcat (Disp.punctuate (Disp.char '.')

--- a/cabal-install/Distribution/Deprecated/Text.hs
+++ b/cabal-install/Distribution/Deprecated/Text.hs
@@ -47,7 +47,6 @@ import qualified Distribution.Types.PackageVersionConstraint as D
 import qualified Distribution.Types.SourceRepo               as D
 import qualified Distribution.Types.UnqualComponentName      as D
 import qualified Distribution.Version                        as D
-import qualified Distribution.Types.VersionRange.Internal    as D
 import qualified Language.Haskell.Extension                  as E
 
 -- | /Note:/ this class will soon be deprecated.
@@ -340,7 +339,7 @@ instance Text D.VersionRange where
                                  (Parse.char ')' >> Parse.skipSpaces)
                                  (do a <- p
                                      Parse.skipSpaces
-                                     return (D.VersionRangeParens a))
+                                     return a)
         digits = do
           firstDigit <- Parse.satisfy isDigit
           if firstDigit == '0'

--- a/cabal-install/cabal-install.cabal.pp
+++ b/cabal-install/cabal-install.cabal.pp
@@ -450,6 +450,7 @@ Test-Suite unit-tests
   ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -main-is UnitTests
   other-modules:
     UnitTests.Distribution.Client.ArbitraryInstances
+    UnitTests.Distribution.Client.Described
     UnitTests.Distribution.Client.Targets
     UnitTests.Distribution.Client.FileMonitor
     UnitTests.Distribution.Client.Get
@@ -482,6 +483,7 @@ Test-Suite unit-tests
         cabal-lib-client,
         cabal-install-solver-dsl,
         Cabal,
+        Cabal-quickcheck,
         containers,
         deepseq,
         mtl,
@@ -491,6 +493,7 @@ Test-Suite unit-tests
         tar,
         time,
         zlib,
+        rere >=0.1 && <0.2,
         network-uri < 2.6.2.0,
         network,
         tasty >= 1.2.3 && <1.3,

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -13,6 +13,7 @@ import qualified UnitTests.Distribution.Solver.Modular.Builder
 import qualified UnitTests.Distribution.Solver.Modular.WeightedPSQ
 import qualified UnitTests.Distribution.Solver.Modular.Solver
 import qualified UnitTests.Distribution.Solver.Modular.RetryLog
+import qualified UnitTests.Distribution.Client.Described
 import qualified UnitTests.Distribution.Client.FileMonitor
 import qualified UnitTests.Distribution.Client.Glob
 import qualified UnitTests.Distribution.Client.GZipUtils
@@ -78,6 +79,7 @@ tests mtimeChangeCalibrated =
        UnitTests.Distribution.Client.VCS.tests mtimeChange
   , testGroup "UnitTests.Distribution.Client.Get"
        UnitTests.Distribution.Client.Get.tests
+  , UnitTests.Distribution.Client.Described.tests
   ]
 
 main :: IO ()

--- a/cabal-install/tests/UnitTests/Distribution/Client/Described.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Described.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
-module UnitTests.Distribution.Described where
+module UnitTests.Distribution.Client.Described where
 
-import Distribution.Compat.Prelude.Internal
+import Distribution.Client.Compat.Prelude
 import Prelude ()
+import UnitTests.Distribution.Client.ArbitraryInstances ()
 
 import Data.Typeable         (typeOf)
 import Test.QuickCheck       (Arbitrary (..), Gen, Property, choose, counterexample)
@@ -17,10 +18,7 @@ import Distribution.Pretty                 (prettyShow)
 
 import qualified Distribution.Utils.CharSet as CS
 
-import Distribution.Types.Dependency   (Dependency)
-import Distribution.Types.PackageName  (PackageName)
-import Distribution.Types.Version      (Version)
-import Distribution.Types.VersionRange (VersionRange)
+import Distribution.Client.IndexUtils.Timestamp (IndexState, Timestamp)
 
 import qualified RERE         as RE
 import qualified RERE.CharSet as RE
@@ -30,10 +28,8 @@ import Test.QuickCheck.Instances.Cabal ()
 
 tests :: TestTree
 tests = testGroup "Described"
-    [ testDescribed (Proxy :: Proxy Dependency)
-    , testDescribed (Proxy :: Proxy PackageName)
-    , testDescribed (Proxy :: Proxy Version)
-    , testDescribed (Proxy :: Proxy VersionRange)
+    [ testDescribed (Proxy :: Proxy Timestamp)
+    , testDescribed (Proxy :: Proxy IndexState)
     ]
 
 -------------------------------------------------------------------------------
@@ -70,6 +66,7 @@ testDescribed _ = testGroup name
 
     propRoundtrip :: a -> Property
     propRoundtrip x = counterexample (show (res, str)) $ case res of
+
         Right y -> x == y
         Left _  -> False
       where

--- a/cabal.project.validate
+++ b/cabal.project.validate
@@ -1,6 +1,8 @@
 packages: Cabal/ cabal-testsuite/ cabal-install/ solver-benchmarks/
 tests: True
 
+packages: Cabal/Cabal-quickcheck/
+
 write-ghc-environment-files: never
 
 package Cabal


### PR DESCRIPTION
- Writing a regex to parse dates is awful.
- Add ShortText conversions to PackageName and UnqualComponentName
- Add mkDependency, which maintains the invariant
- Remove VersionRangeParens - it's not preserved by `parsec . pretty` roundtrip
- Move moree instances into Cabal-quickcheck,use the package in cabal-install tests
