### PR TITLE
Allow specify index-state per repository

### DIFF
--- a/cabal-install/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/Distribution/Client/CmdUpdate.hs
@@ -102,7 +102,7 @@ updateCommand = Client.installCommand {
 
 data UpdateRequest = UpdateRequest
   { _updateRequestRepoName  :: RepoName
-  , _updateRequestRepoState :: IndexState
+  , _updateRequestRepoState :: RepoIndexState
   } deriving (Show)
 
 instance Pretty UpdateRequest where
@@ -146,7 +146,7 @@ updateAction ( configFlags, configExFlags, installFlags
                          ++ "\" can not be found in known remote repo(s): "
                          ++ intercalate ", " (map unRepoName remoteRepoNames)
 
-    let reposToUpdate :: [(Repo, IndexState)]
+    let reposToUpdate :: [(Repo, RepoIndexState)]
         reposToUpdate = case updateRepoRequests of
           -- If we are not given any specific repository, update all
           -- repositories to HEAD.
@@ -179,7 +179,7 @@ updateAction ( configFlags, configExFlags, installFlags
                   haddockFlags testFlags benchmarkFlags
     globalConfigFlag = projectConfigConfigFile (projectConfigShared cliConfig)
 
-updateRepo :: Verbosity -> UpdateFlags -> RepoContext -> (Repo, IndexState)
+updateRepo :: Verbosity -> UpdateFlags -> RepoContext -> (Repo, RepoIndexState)
            -> IO ()
 updateRepo verbosity _updateFlags repoCtxt (repo, indexState) = do
   transport <- repoContextGetTransport repoCtxt

--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -52,7 +52,7 @@ import Distribution.Client.VCS
 import Distribution.Client.FetchUtils
 import qualified Distribution.Client.Tar as Tar (extractTarGzFile)
 import Distribution.Client.IndexUtils as IndexUtils
-        ( getSourcePackagesAtIndexState )
+        ( getSourcePackagesAtIndexState, TotalIndexState )
 import Distribution.Solver.Types.SourcePackage
 
 import Control.Exception
@@ -86,7 +86,8 @@ get verbosity repoCtxt globalFlags getFlags userTargets = do
   unless useSourceRepo $
     mapM_ (checkTarget verbosity) userTargets
 
-  let idxState = flagToMaybe $ getIndexState getFlags
+  let idxState :: Maybe TotalIndexState
+      idxState = flagToMaybe $ getIndexState getFlags
 
   sourcePkgDb <- getSourcePackagesAtIndexState verbosity repoCtxt idxState
 

--- a/cabal-install/Distribution/Client/Get.hs
+++ b/cabal-install/Distribution/Client/Get.hs
@@ -89,7 +89,7 @@ get verbosity repoCtxt globalFlags getFlags userTargets = do
   let idxState :: Maybe TotalIndexState
       idxState = flagToMaybe $ getIndexState getFlags
 
-  sourcePkgDb <- getSourcePackagesAtIndexState verbosity repoCtxt idxState
+  (sourcePkgDb, _) <- getSourcePackagesAtIndexState verbosity repoCtxt idxState
 
   pkgSpecifiers <- resolveUserTargets verbosity repoCtxt
                    (fromFlag $ globalWorldFile globalFlags)

--- a/cabal-install/Distribution/Client/IndexUtils/IndexState.hs
+++ b/cabal-install/Distribution/Client/IndexUtils/IndexState.hs
@@ -14,6 +14,7 @@ module Distribution.Client.IndexUtils.IndexState (
     headTotalIndexState,
     makeTotalIndexState,
     lookupIndexState,
+    insertIndexState,
 ) where
 
 import Distribution.Client.Compat.Prelude
@@ -105,6 +106,12 @@ makeTotalIndexState def m = normalise (TIS def m)
 -- | Lookup a 'RepoIndexState' for an individual repository from 'TotalIndexState'.
 lookupIndexState :: RepoName -> TotalIndexState -> RepoIndexState
 lookupIndexState rn (TIS def m) = Map.findWithDefault def rn m
+
+-- | Insert a 'RepoIndexState' to 'TotalIndexState'.
+insertIndexState :: RepoName -> RepoIndexState -> TotalIndexState -> TotalIndexState
+insertIndexState rn idx (TIS def m)
+    | idx == def = TIS def (Map.delete rn m)
+    | otherwise  = TIS def (Map.insert rn idx m)
 
 -------------------------------------------------------------------------------
 -- Repository index state

--- a/cabal-install/Distribution/Client/IndexUtils/IndexState.hs
+++ b/cabal-install/Distribution/Client/IndexUtils/IndexState.hs
@@ -6,41 +6,130 @@
 -- Copyright   :  (c) 2016 Herbert Valerio Riedel
 -- License     :  BSD3
 --
--- Timestamp type used in package indexes
+-- Package repositories index state.
+--
 module Distribution.Client.IndexUtils.IndexState (
-    IndexState(..),
+    RepoIndexState(..),
+    TotalIndexState,
+    headTotalIndexState,
+    makeTotalIndexState,
+    lookupIndexState,
 ) where
 
 import Distribution.Client.Compat.Prelude
 import Distribution.Client.IndexUtils.Timestamp (Timestamp)
+import Distribution.Client.Types                (RepoName (..))
 
 import Distribution.FieldGrammar.Described
 import Distribution.Parsec                 (Parsec (..))
 import Distribution.Pretty                 (Pretty (..))
 
 import qualified Distribution.Compat.CharParsing as P
+import qualified Data.Map.Strict as Map
 import qualified Text.PrettyPrint                as Disp
 
+-------------------------------------------------------------------------------
+-- Total index state
+-------------------------------------------------------------------------------
+
+-- | Index state of multiple repositories
+data TotalIndexState = TIS RepoIndexState (Map RepoName RepoIndexState)
+  deriving (Eq, Show, Generic)
+
+instance Binary TotalIndexState
+instance Structured TotalIndexState
+instance NFData TotalIndexState
+
+instance Pretty TotalIndexState where
+    pretty (TIS IndexStateHead m)
+        | not (Map.null m)
+        = Disp.hsep
+            [ pretty rn <<>> Disp.colon <<>> pretty idx
+            | (rn, idx) <- Map.toList m
+            ]
+    pretty (TIS def m) = foldl' go (pretty def) (Map.toList m) where
+        go doc (rn, idx) = doc Disp.<+> pretty rn <<>> Disp.colon <<>> pretty idx
+
+instance Parsec TotalIndexState where
+    parsec = normalise . foldl' add headTotalIndexState <$> some (single0 <* P.spaces) where
+        -- hard to do without try
+        -- 2020-03-21T11:22:33Z looks like it begins with
+        -- repository name 2020-03-21T11
+        --
+        -- To make this easy, we could forbid repository names starting with digit
+        --
+        single0 = P.try single1 <|> TokTimestamp <$> parsec
+        single1 = do
+            token <- P.munch1 (\c -> isAlphaNum c || c == '_' || c == '-' || c == '.')
+            single2 token <|> single3 token
+
+        single2 token = do
+            _   <- P.char ':'
+            idx <- parsec
+            return (TokRepo (RepoName token) idx)
+
+        single3 "HEAD" = return TokHead
+        single3 token  = P.unexpected ("Repository " ++ token ++ " without index state (after comma)")
+
+        add :: TotalIndexState -> Tok -> TotalIndexState
+        add _           TokHead           = headTotalIndexState
+        add _           (TokTimestamp ts) = TIS (IndexStateTime ts) Map.empty
+        add (TIS def m) (TokRepo rn idx)  = TIS def (Map.insert rn idx m)
+
+instance Described TotalIndexState where
+    describe _ = REMunch1 RESpaces1 $ REUnion
+        [ describe (Proxy :: Proxy RepoName) <> reChar ':' <> ris
+        , ris
+        ]
+      where
+        ris = describe (Proxy :: Proxy RepoIndexState)
+
+-- used in Parsec TotalIndexState implementation
+data Tok
+    = TokRepo RepoName RepoIndexState
+    | TokTimestamp Timestamp
+    | TokHead
+
+-- | Remove non-default values from 'TotalIndexState'.
+normalise :: TotalIndexState -> TotalIndexState
+normalise (TIS def m) = TIS def (Map.filter (/= def) m)
+
+-- | 'TotalIndexState' where all repositories are at @HEAD@ index state.
+headTotalIndexState :: TotalIndexState
+headTotalIndexState = TIS IndexStateHead Map.empty
+
+-- | Create 'TotalIndexState'.
+makeTotalIndexState :: RepoIndexState -> Map RepoName RepoIndexState -> TotalIndexState
+makeTotalIndexState def m = normalise (TIS def m)
+
+-- | Lookup a 'RepoIndexState' for an individual repository from 'TotalIndexState'.
+lookupIndexState :: RepoName -> TotalIndexState -> RepoIndexState
+lookupIndexState rn (TIS def m) = Map.findWithDefault def rn m
+
+-------------------------------------------------------------------------------
+-- Repository index state
+-------------------------------------------------------------------------------
+
 -- | Specification of the state of a specific repo package index
-data IndexState = IndexStateHead -- ^ Use all available entries
-                | IndexStateTime !Timestamp -- ^ Use all entries that existed at
-                                            -- the specified time
-                deriving (Eq,Generic,Show)
+data RepoIndexState
+    = IndexStateHead -- ^ Use all available entries
+    | IndexStateTime !Timestamp -- ^ Use all entries that existed at the specified time
+    deriving (Eq,Generic,Show)
 
-instance Binary IndexState
-instance Structured IndexState
-instance NFData IndexState
+instance Binary RepoIndexState
+instance Structured RepoIndexState
+instance NFData RepoIndexState
 
-instance Pretty IndexState where
+instance Pretty RepoIndexState where
     pretty IndexStateHead = Disp.text "HEAD"
     pretty (IndexStateTime ts) = pretty ts
 
-instance Parsec IndexState where
+instance Parsec RepoIndexState where
     parsec = parseHead <|> parseTime where
         parseHead = IndexStateHead <$ P.string "HEAD"
         parseTime = IndexStateTime <$> parsec
 
-instance Described IndexState where
+instance Described RepoIndexState where
     describe _ = REUnion
         [ "HEAD"
         , RENamed "timestamp" (describe (Proxy :: Proxy Timestamp))

--- a/cabal-install/Distribution/Client/Install.hs
+++ b/cabal-install/Distribution/Client/Install.hs
@@ -289,7 +289,7 @@ makeInstallContext verbosity
     let idxState = flagToMaybe (installIndexState installFlags)
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs progdb
-    sourcePkgDb       <- getSourcePackagesAtIndexState verbosity repoCtxt idxState
+    (sourcePkgDb, _)  <- getSourcePackagesAtIndexState verbosity repoCtxt idxState
     pkgConfigDb       <- readPkgConfigDb      verbosity progdb
 
     checkConfigExFlags verbosity installedPkgIndex

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -35,7 +35,7 @@ import Distribution.Client.BuildReports.Types
 import Distribution.Client.SourceRepo (SourceRepoList)
 
 import Distribution.Client.IndexUtils.IndexState
-         ( IndexState )
+         ( TotalIndexState )
 
 import Distribution.Client.CmdInstall.ClientInstallFlags
          ( ClientInstallFlags(..) )
@@ -180,7 +180,7 @@ data ProjectConfigShared
        projectConfigRemoteRepos       :: NubList RemoteRepo,     -- ^ Available Hackage servers.
        projectConfigLocalRepos        :: NubList FilePath,
        projectConfigLocalNoIndexRepos :: NubList LocalRepo,
-       projectConfigIndexState        :: Flag IndexState,
+       projectConfigIndexState        :: Flag TotalIndexState,
        projectConfigStoreDir          :: Flag FilePath,
 
        -- solver configuration
@@ -406,7 +406,7 @@ data SolverSettings
        solverSettingStrongFlags       :: StrongFlags,
        solverSettingAllowBootLibInstalls :: AllowBootLibInstalls,
        solverSettingOnlyConstrained   :: OnlyConstrained,
-       solverSettingIndexState        :: Maybe IndexState,
+       solverSettingIndexState        :: Maybe TotalIndexState,
        solverSettingIndependentGoals  :: IndependentGoals
        -- Things that only make sense for manual mode, not --local mode
        -- too much control!

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -292,7 +292,7 @@ withInstallPlan
     -- everything in the project. This is independent of any specific targets
     -- the user has asked for.
     --
-    (elaboratedPlan, _, elaboratedShared) <-
+    (elaboratedPlan, _, elaboratedShared, _) <-
       rebuildInstallPlan verbosity
                          distDirLayout cabalDirLayout
                          projectConfig
@@ -317,7 +317,7 @@ runProjectPreBuildPhase
     -- everything in the project. This is independent of any specific targets
     -- the user has asked for.
     --
-    (elaboratedPlan, _, elaboratedShared) <-
+    (elaboratedPlan, _, elaboratedShared, _) <-
       rebuildInstallPlan verbosity
                          distDirLayout cabalDirLayout
                          projectConfig

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -758,7 +758,7 @@ getPackageDBContents verbosity compiler progdb platform packagedb = do
 -}
 
 getSourcePackages :: Verbosity -> (forall a. (RepoContext -> IO a) -> IO a)
-                  -> Maybe IndexUtils.IndexState -> Rebuild SourcePackageDb
+                  -> Maybe IndexUtils.TotalIndexState -> Rebuild SourcePackageDb
 getSourcePackages verbosity withRepoCtx idxState = do
     (sourcePkgDb, repos) <-
       liftIO $

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -78,7 +78,7 @@ import Distribution.Client.BuildReports.Types
 import Distribution.Client.Dependency.Types
          ( PreSolver(..) )
 import Distribution.Client.IndexUtils.IndexState
-         ( IndexState(..) )
+         ( TotalIndexState, headTotalIndexState )
 import qualified Distribution.Client.Init.Types as IT
          ( InitFlags(..), PackageType(..) )
 import Distribution.Client.Targets
@@ -1334,14 +1334,14 @@ outdatedCommand = CommandUI {
 data UpdateFlags
     = UpdateFlags {
         updateVerbosity  :: Flag Verbosity,
-        updateIndexState :: Flag IndexState
+        updateIndexState :: Flag TotalIndexState
     } deriving Generic
 
 defaultUpdateFlags :: UpdateFlags
 defaultUpdateFlags
     = UpdateFlags {
         updateVerbosity  = toFlag normal,
-        updateIndexState = toFlag IndexStateHead
+        updateIndexState = toFlag headTotalIndexState
     }
 
 updateCommand  :: CommandUI UpdateFlags
@@ -1534,7 +1534,7 @@ instance Semigroup ReportFlags where
 data GetFlags = GetFlags {
     getDestDir          :: Flag FilePath,
     getPristine         :: Flag Bool,
-    getIndexState       :: Flag IndexState,
+    getIndexState       :: Flag TotalIndexState,
     getSourceRepository :: Flag (Maybe RepoKind),
     getVerbosity        :: Flag Verbosity
   } deriving Generic
@@ -1765,7 +1765,7 @@ data InstallFlags = InstallFlags {
     installUpgradeDeps      :: Flag Bool,
     installOnly             :: Flag Bool,
     installOnlyDeps         :: Flag Bool,
-    installIndexState       :: Flag IndexState,
+    installIndexState       :: Flag TotalIndexState,
     installRootCmd          :: Flag String,
     installSummaryFile      :: NubList PathTemplate,
     installLogFile          :: Flag PathTemplate,

--- a/cabal-install/Distribution/Client/Types.hs
+++ b/cabal-install/Distribution/Client/Types.hs
@@ -285,6 +285,7 @@ unRepoName (RepoName n) = n
 
 instance Binary RepoName
 instance Structured RepoName
+instance NFData RepoName
 
 instance Pretty RepoName where
     pretty = Disp.text . unRepoName

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -1541,7 +1541,7 @@ planProject testdir cliConfig = do
        localPackages,
        _buildSettings) <- configureProject testdir cliConfig
 
-    (elaboratedPlan, _, elaboratedShared) <-
+    (elaboratedPlan, _, elaboratedShared, _) <-
       rebuildInstallPlan verbosity
                          distDirLayout cabalDirLayout
                          projectConfig

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -23,7 +23,7 @@ import Distribution.Utils.NubList
 
 import Distribution.Client.BuildReports.Types            (ReportLevel (..))
 import Distribution.Client.CmdInstall.ClientInstallFlags (InstallMethod)
-import Distribution.Client.IndexUtils.IndexState         (IndexState (..))
+import Distribution.Client.IndexUtils.IndexState         (RepoIndexState (..), TotalIndexState, makeTotalIndexState)
 import Distribution.Client.IndexUtils.Timestamp          (Timestamp, epochTimeToTimestamp)
 import Distribution.Client.InstallSymlink                (OverwritePolicy)
 import Distribution.Client.Types                         (RepoName (..), WriteGhcEnvironmentFilesPolicy)
@@ -137,10 +137,13 @@ instance Arbitrary Timestamp where
     --
     arbitrary = maybe (toEnum 0) id . epochTimeToTimestamp . (`mod` 3093527980800) . abs <$> arbitrary
 
-instance Arbitrary IndexState where
+instance Arbitrary RepoIndexState where
     arbitrary = frequency [ (1, pure IndexStateHead)
                           , (50, IndexStateTime <$> arbitrary)
                           ]
+
+instance Arbitrary TotalIndexState where
+    arbitrary = makeTotalIndexState <$> arbitrary <*> arbitrary
 
 instance Arbitrary WriteGhcEnvironmentFilesPolicy where
     arbitrary = arbitraryBoundedEnum

--- a/cabal-install/tests/UnitTests/Distribution/Client/Described.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Described.hs
@@ -17,7 +17,7 @@ import Distribution.Pretty                 (prettyShow)
 
 import qualified Distribution.Utils.CharSet as CS
 
-import Distribution.Client.IndexUtils.IndexState (IndexState)
+import Distribution.Client.IndexUtils.IndexState (RepoIndexState, TotalIndexState)
 import Distribution.Client.IndexUtils.Timestamp  (Timestamp)
 import Distribution.Client.Types                 (RepoName)
 
@@ -30,7 +30,8 @@ import Test.QuickCheck.Instances.Cabal ()
 tests :: TestTree
 tests = testGroup "Described"
     [ testDescribed (Proxy :: Proxy Timestamp)
-    , testDescribed (Proxy :: Proxy IndexState)
+    , testDescribed (Proxy :: Proxy RepoIndexState)
+    , testDescribed (Proxy :: Proxy TotalIndexState)
     , testDescribed (Proxy :: Proxy RepoName)
     ]
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/TreeDiffInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/TreeDiffInstances.hs
@@ -48,6 +48,8 @@ instance (ToExpr k, ToExpr v) => ToExpr (MapLast k v)
 instance (ToExpr a) => ToExpr (NubList a)
 instance (ToExpr a) => ToExpr (Flag a)
 
+instance ToExpr (f FilePath) => ToExpr (SourceRepositoryPackage f)
+
 instance ToExpr AllowBootLibInstalls
 instance ToExpr AllowNewer
 instance ToExpr AllowOlder
@@ -61,7 +63,6 @@ instance ToExpr FlagAssignment
 instance ToExpr FlagName where toExpr = defaultExprViaShow
 instance ToExpr HaddockTarget
 instance ToExpr IndependentGoals
-instance ToExpr IndexState
 instance ToExpr InstallMethod
 instance ToExpr LocalRepo
 instance ToExpr MinimizeConflictSet
@@ -84,22 +85,23 @@ instance ToExpr ProjectConfigBuildOnly
 instance ToExpr ProjectConfigProvenance
 instance ToExpr ProjectConfigShared
 instance ToExpr RelaxDepMod
+instance ToExpr RelaxDeps
 instance ToExpr RelaxDepScope
 instance ToExpr RelaxDepSubject
-instance ToExpr RelaxDeps
 instance ToExpr RelaxedDep
 instance ToExpr RemoteRepo
 instance ToExpr ReorderGoals
+instance ToExpr RepoIndexState
 instance ToExpr RepoKind
 instance ToExpr RepoName
-instance ToExpr RepoType
 instance ToExpr ReportLevel
+instance ToExpr RepoType
 instance ToExpr ShortText
 instance ToExpr SourceRepo
-instance ToExpr (f FilePath) => ToExpr (SourceRepositoryPackage f)
 instance ToExpr StrongFlags
 instance ToExpr TestShowDetails
 instance ToExpr Timestamp
+instance ToExpr TotalIndexState
 instance ToExpr URI
 instance ToExpr URIAuth
 instance ToExpr UserConstraint


### PR DESCRIPTION
One concern I have is the syntax.

`v2-update` uses comma :

```
hackage.haskell.org,HEAD
hackage.haskell.org,2020-03-16T01:24:50Z
hackage.haskell.org,@123123123
```

Yet, I don't want comma in configuration files to mean anything else then list separator,
therefore I took colon, which we use e.g. in `allow-newer` and other "namespace" cases:

```
hackage.haskell.org:HEAD
hackage.haskell.org:2020-03-16T01:24:50Z
hackage.haskell.org:@123123123
```

This is a bit unfortunate, as timestamp has colons in it.

Another alternative would be to use `@`, note double `@` when using posix-timestamp.

```
hackage.haskell.org@HEAD
hackage.haskell.org@2020-03-16T01:24:50Z
hackage.haskell.org@@123123123
```

---

I'll merge the colon version; this can be changed before `3.4` is released.
Perfectly, `v2-update` would use (or at least accept) the colons too.
