### PR TITLE
Don't write Setup.hs file during cabal init.

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -130,7 +130,6 @@ initCabal verbosity packageDBs repoCtxt comp progdb initFlags = do
   case license initFlags' of
     Flag PublicDomain -> return ()
     _                 -> writeLicense initFlags'
-  writeSetupFile initFlags'
   writeChangeLog initFlags'
   createDirectories (sourceDirs initFlags')
   createLibHs initFlags'
@@ -860,16 +859,6 @@ getYear = do
   let l = utcToLocalTime z u
       (y, _, _) = toGregorian $ localDay l
   return y
-
-writeSetupFile :: InitFlags -> IO ()
-writeSetupFile flags = do
-  message flags "Generating Setup.hs..."
-  writeFileSafe flags "Setup.hs" setupFile
- where
-  setupFile = unlines
-    [ "import Distribution.Simple"
-    , "main = defaultMain"
-    ]
 
 writeChangeLog :: InitFlags -> IO ()
 writeChangeLog flags = when ((defaultChangeLog `elem`) $ fromMaybe [] (extraSrc flags)) $ do


### PR DESCRIPTION
When `build-type: Simple` the contents of Setup.hs MUST BE standard. It is only
in advanced cases where a custom setup file is needed.

This also has the positive consequence of simplifying the directory contents created during package initialization.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
