### PR TITLE
Mark public libs as an experimental feature

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -215,6 +215,10 @@ extra-source-files:
   tests/ParserTests/regressions/pre-1.6-glob.check
   tests/ParserTests/regressions/pre-2.4-globstar.cabal
   tests/ParserTests/regressions/pre-2.4-globstar.check
+  tests/ParserTests/regressions/public-multilib-1.cabal
+  tests/ParserTests/regressions/public-multilib-1.check
+  tests/ParserTests/regressions/public-multilib-2.cabal
+  tests/ParserTests/regressions/public-multilib-2.check
   tests/ParserTests/regressions/shake.cabal
   tests/ParserTests/regressions/shake.expr
   tests/ParserTests/regressions/shake.format

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -103,7 +103,11 @@ parseInstalledPackageInfo s = case P.readFields s of
     Right fs -> case partitionFields fs of
         (fs', _) -> case P.runParseResult $ parseFieldGrammar cabalSpecLatest fs' ipiFieldGrammar of
             (ws, Right x) -> x `deepseq` Right (ws', x) where
-                ws' = map (P.showPWarning "") ws
+                ws' = [ P.showPWarning "" w
+                      | w@(P.PWarning wt _ _) <- ws
+                      -- filter out warnings about experimental features
+                      , wt /= P.PWTExperimental
+                      ]
             (_,  Left (_, errs)) -> Left errs' where
                 errs' = fmap (P.showPError "") errs
 

--- a/Cabal/Distribution/Parsec/Warning.hs
+++ b/Cabal/Distribution/Parsec/Warning.hs
@@ -38,6 +38,8 @@ data PWarnType
 
     | PWTVersionOperator       -- ^ Version operators used (without cabal-version: 1.8)
     | PWTVersionWildcard       -- ^ Version wildcard used (without cabal-version: 1.6)
+
+    | PWTExperimental          -- ^ Experimental feature
     deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 instance Binary PWarnType

--- a/Cabal/Distribution/Types/Dependency.hs
+++ b/Cabal/Distribution/Types/Dependency.hs
@@ -126,6 +126,7 @@ instance Parsec Dependency where
         libs <- option mainLib $ do
           _ <- char ':'
           versionGuardMultilibs
+          parsecWarning PWTExperimental "colon specifier is experimental feature (issue #5660)"
           Set.singleton <$> parseLib <|> parseMultipleLibs
 
         spaces -- https://github.com/haskell/cabal/issues/5846

--- a/Cabal/Distribution/Types/LibraryVisibility.hs
+++ b/Cabal/Distribution/Types/LibraryVisibility.hs
@@ -34,6 +34,7 @@ instance Pretty LibraryVisibility where
 instance Parsec LibraryVisibility where
   parsec = do
     name <- P.munch1 isAlpha
+    parsecWarning PWTExperimental "visibility is experimental feature (issue #5660)"
     case name of
       "public"  -> return LibraryVisibilityPublic
       "private" -> return LibraryVisibilityPrivate

--- a/Cabal/tests/CheckTests.hs
+++ b/Cabal/tests/CheckTests.hs
@@ -40,6 +40,8 @@ checkTests = testGroup "regressions"
     , checkTest "ghc-option-j.cabal"
     , checkTest "multiple-libs-2.cabal"
     , checkTest "assoc-cpp-options.cabal"
+    , checkTest "public-multilib-1.cabal"
+    , checkTest "public-multilib-2.cabal"
     ]
 
 checkTest :: FilePath -> TestTree

--- a/Cabal/tests/ParserTests/regressions/issue-5846.format
+++ b/Cabal/tests/ParserTests/regressions/issue-5846.format
@@ -1,3 +1,7 @@
+issue-5846.cabal:11:23: colon specifier is experimental feature (issue #5660)
+issue-5846.cabal:10:23: colon specifier is experimental feature (issue #5660)
+issue-5846.cabal:7:23: colon specifier is experimental feature (issue #5660)
+issue-5846.cabal:8:23: colon specifier is experimental feature (issue #5660)
 cabal-version: 3.0
 name:          issue
 version:       5846

--- a/Cabal/tests/ParserTests/regressions/issue-6083-pkg-pkg.format
+++ b/Cabal/tests/ParserTests/regressions/issue-6083-pkg-pkg.format
@@ -1,3 +1,4 @@
+issue-6083-pkg-pkg.cabal:9:27: colon specifier is experimental feature (issue #5660)
 cabal-version: 3.0
 name:          issue
 version:       6083

--- a/Cabal/tests/ParserTests/regressions/public-multilib-1.cabal
+++ b/Cabal/tests/ParserTests/regressions/public-multilib-1.cabal
@@ -1,0 +1,17 @@
+cabal-version: 3.0
+name:          public-multilib1
+version:       0
+synopsis:      public-multilibs are not polished enough for Hackage
+category:      Tests
+license:       MIT
+
+library
+  default-language: Haskell2010
+  build-depends:    base ^>=4.14, internal
+  exposed-modules:  Foo
+
+library internal
+  default-language: Haskell2010
+  build-depends:    base ^>=4.14
+  visibility:       public
+  exposed-modules:  Bar

--- a/Cabal/tests/ParserTests/regressions/public-multilib-1.check
+++ b/Cabal/tests/ParserTests/regressions/public-multilib-1.check
@@ -1,0 +1,3 @@
+public-multilib-1.cabal:16:27: visibility is experimental feature (issue #5660)
+No 'maintainer' field.
+No 'description' field.

--- a/Cabal/tests/ParserTests/regressions/public-multilib-2.cabal
+++ b/Cabal/tests/ParserTests/regressions/public-multilib-2.cabal
@@ -1,0 +1,14 @@
+cabal-version: 3.0
+name:          public-multilib1
+version:       0
+synopsis:      public-multilibs are not polished enough for Hackage
+category:      Tests
+license:       MIT
+
+library
+  default-language: Haskell2010
+  build-depends:
+    , base     ^>=4.14
+    , somelib:internal
+
+  exposed-modules:  Foo

--- a/Cabal/tests/ParserTests/regressions/public-multilib-2.check
+++ b/Cabal/tests/ParserTests/regressions/public-multilib-2.check
@@ -1,0 +1,3 @@
+public-multilib-2.cabal:12:15: colon specifier is experimental feature (issue #5660)
+No 'maintainer' field.
+No 'description' field.

--- a/cabal-install/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning.hs
@@ -3129,14 +3129,18 @@ legacyCustomSetupPkgs :: Compiler -> Platform -> [PackageName]
 legacyCustomSetupPkgs compiler (Platform _ os) =
     map mkPackageName $
         [ "array", "base", "binary", "bytestring", "containers"
-        , "deepseq", "directory", "filepath", "old-time", "pretty"
+        , "deepseq", "directory", "filepath", "pretty"
         , "process", "time", "transformers" ]
      ++ [ "Win32" | os == Windows ]
      ++ [ "unix"  | os /= Windows ]
      ++ [ "ghc-prim"         | isGHC ]
      ++ [ "template-haskell" | isGHC ]
+     ++ [ "old-time" | notGHC710 ]
   where
     isGHC = compilerCompatFlavor GHC compiler
+    notGHC710 = case compilerCompatVersion GHC compiler of
+        Nothing -> False
+        Just v  -> v <= mkVersion [7,9]
 
 -- The other aspects of our Setup.hs policy lives here where we decide on
 -- the 'SetupScriptOptions'.

--- a/cabal-testsuite/PackageTests/MultipleLibraries/cabal.out
+++ b/cabal-testsuite/PackageTests/MultipleLibraries/cabal.out
@@ -4,9 +4,11 @@ Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - d-0.1.0.0 (lib:privatelib) (first run)
  - p-0.1.0.0 (lib) (first run)
+Warning: d.cabal:10:22: visibility is experimental feature (issue #5660)
 Configuring library 'privatelib' for d-0.1.0.0..
 Preprocessing library 'privatelib' for d-0.1.0.0..
 Building library 'privatelib' for d-0.1.0.0..
+Warning: p.cabal:6:20: colon specifier is experimental feature (issue #5660)
 Configuring library for p-0.1.0.0..
 cabal: Encountered missing or private dependencies:
     d:{privatelib} ==0.1.0.0

--- a/cabal-testsuite/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/Test/Cabal/Monad.hs
@@ -325,7 +325,9 @@ runTestM mode m = withSystemTempDirectory "cabal-testsuite" $ \tmp_dir -> do
                         , ("HOME", Just (testHomeDir env))
                         -- Set CABAL_DIR in addition to HOME, since HOME has no
                         -- effect on Windows.
-                        , ("CABAL_DIR", Just (testCabalDir env))],
+                        , ("CABAL_DIR", Just (testCabalDir env))
+                        , ("CABAL_CONFIG", Just $ testCabalDir env </> "config")
+                        ],
                     testShouldFail = False,
                     testRelativeCurrentDir = ".",
                     testHavePackageDb = False,


### PR DESCRIPTION
Needs backport to whatever branch `hackage-server` would pick up.