### PR TITLE
Default to cabal version 2.4 when running cabal init.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -850,7 +850,7 @@ commentSavedConfig = do
             },
         savedInitFlags       = mempty {
             IT.interactive     = toFlag False,
-            IT.cabalVersion    = toFlag (mkVersion [1,10]),
+            IT.cabalVersion    = toFlag (mkVersion [2,4]),
             IT.language        = toFlag Haskell2010,
             IT.license         = toFlag BSD3,
             IT.sourceDirs      = Nothing,


### PR DESCRIPTION
Cabal version 2.4 is over 2 years old at this point and has numerous additions
compared to the current default 1.10.

There are numerous references to the `^>=` operator throughout the docs (nix-local-build.rst and developing-packages.rst) but this does not work in version 1.10. This results in unnecessary confusion for users which then must manually edit the cabal file to change the version. To add to the confusion, the format written to the cabal file (`cabal-version: >=1.10`) only works for this version, to use a newer version you need to remove the `>=` which is undocumented and confusing.

Lets just default to a more recent version. 


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
