### PR TITLE
PackageOutput: Dump path to local dir for source-repository-package

### DIFF
--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -193,10 +193,13 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
             J.object [ "type" J..= J.String "repo-tar"
                      , "repo" J..= repoToJ repo
                      ]
-          RemoteSourceRepoPackage srcRepo _ ->
-            J.object [ "type" J..= J.String "source-repo"
-                     , "source-repo" J..= sourceRepoToJ srcRepo
-                     ]
+          RemoteSourceRepoPackage srcRepo local ->
+            J.object $
+              [ "type" J..= J.String "source-repo"
+              , "source-repo" J..= sourceRepoToJ srcRepo
+              ] ++
+              [ "path" J..= J.String path | path <- maybeToList local ]
+
 
       repoToJ :: Repo -> J.Value
       repoToJ repo =


### PR DESCRIPTION
This allows external tools to find the directory the source repository got
cloned into.

Needed to fix DanielG/cabal-helper#99

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.
