### PR TITLE
Add GHC-8.10.1 job. Only tests Cabal-the-lib part atm.

### DIFF
--- a/.docker/validate-8.10.1.dockerfile
+++ b/.docker/validate-8.10.1.dockerfile
@@ -1,0 +1,60 @@
+FROM    phadej/ghc:8.10.1-bionic
+
+# Install cabal-plan
+RUN     mkdir -p /root/.cabal/bin && \
+        curl -L https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz && \
+        echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c - && \
+        xz -d < cabal-plan.xz > /root/.cabal/bin/cabal-plan && \
+        rm -f cabal-plan.xz && \
+        chmod a+x /root/.cabal/bin/cabal-plan
+
+# Update index
+RUN     cabal v2-update
+
+# We install happy, so it's in the store; we (hopefully) don't use it directly.
+RUN     cabal v2-install happy --constraint 'happy ^>=1.19.12'
+
+# Install some other dependencies
+# Remove $HOME/.ghc so there aren't any environments
+RUN     cabal v2-install -w ghc-8.10.1 --lib \
+          aeson \
+          async \
+          base-compat \
+          base16-bytestring \
+          base64-bytestring \
+          cryptohash-sha256 \
+          Diff \
+          echo \
+          ed25519 \
+          edit-distance \
+          haskell-lexer \
+          HTTP \
+          network \
+          optparse-applicative \
+          pretty-show \
+          regex-compat-tdfa \
+          regex-tdfa \
+          statistics \
+          tar \
+          tasty \
+          tasty-golden \
+          tasty-hunit \
+          tasty-quickcheck \
+          tree-diff \
+          zlib \
+      --constraint="bytestring installed" \
+      --constraint="binary     installed" \
+      --constraint="containers installed" \
+      --constraint="deepseq    installed" \
+      --constraint="directory  installed" \
+      --constraint="filepath   installed" \
+      --constraint="pretty     installed" \
+      --constraint="process    installed" \
+      --constraint="time       installed" \
+      --constraint="unix       installed" \
+        && rm -rf $HOME/.ghc
+
+# Validate
+WORKDIR /build
+COPY    . /build
+RUN     sh ./validate.sh --lib-only -w ghc-8.10.1 -v

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,6 +18,44 @@ on:
       - created
 
 jobs:
+  validate-8_10_1:
+    name: validate.sh ghc-8.10.1
+    runs-on: ubuntu-18.04
+    needs: validate-8_8_3
+    container:
+      image: phadej/ghc:8.10.1-bionic
+    steps:
+      # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
+      - name: Set PATH
+        run: |
+          echo "::add-path::$HOME/.cabal/bin"
+      - name: Install cabal-plan
+        run: |
+          mkdir -p $HOME/.cabal/bin
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
+          echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c -
+          xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
+          rm -f cabal-plan.xz
+          chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: Update Hackage index
+        run: cabal v2-update
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v --lib-only -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v --lib-only -s print-tool-versions
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v --lib-only -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v --lib-only -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v --lib-only -s lib-suite
   validate-8_8_3:
     name: validate.sh ghc-8.8.3
     runs-on: ubuntu-18.04

--- a/Makefile
+++ b/Makefile
@@ -172,5 +172,9 @@ validate-via-docker-8.6.5:
 validate-via-docker-8.8.1:
 	docker build -t cabal-validate -f .docker/validate-8.8.1.dockerfile .
 
+# Only library ATM
+validate-via-docker-8.10.1:
+	docker build -t cabal-validate -f .docker/validate-8.10.1.dockerfile .
+
 validate-via-docker-old:
 	docker build -t cabal-validate -f .docker/validate-old.dockerfile .

--- a/cabal-dev-scripts/src/GenValidate.hs
+++ b/cabal-dev-scripts/src/GenValidate.hs
@@ -21,7 +21,8 @@ main = do
             -- this shouldn't fail (run-time errors are due bugs in zinza)
             w <- run Z
                 { zJobs =
-                    [ GhcJob "8.8.3"  False "--solver-benchmarks" False [] defSteps
+                    [ GhcJob "8.10.1" False "--lib-only"          False ["8.8.3"] libSteps -- Note: only library atm.
+                    , GhcJob "8.8.3"  False "--solver-benchmarks" False [] defSteps
                     , GhcJob "8.6.5"  False ""                    False ["8.8.3"] defSteps
                     , GhcJob "8.4.4"  False ""                    False ["8.8.3"] defSteps
                     , GhcJob "8.2.2"  False ""                    False ["8.8.3"] defSteps

--- a/cabal-install/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/Distribution/Client/CmdSdist.hs
@@ -237,7 +237,10 @@ packageToSdist verbosity projectRootDir format outputFile pkg = do
         (norm NoExec -> nonexec, norm Exec -> exec) <-
            listPackageSources verbosity (flattenPackageDescription $ packageDescription pkg) knownSuffixHandlers
 
+        print $ map snd exec
+        print $ map snd nonexec
         let files =  nub . sortOn snd $ nonexec ++ exec
+        print files
 
         case format of
             SourceList nulSep -> do

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -26,7 +26,7 @@ common shared
   default-language: Haskell2010
 
   build-depends:
-    , base >= 4.6 && <4.14
+    , base >= 4.6 && <4.15
     -- this needs to match the in-tree lib:Cabal version
     , Cabal == 3.3.0.0
 
@@ -107,5 +107,5 @@ executable setup
 
 custom-setup
   -- we only depend on even stable releases of lib:Cabal
-  setup-depends: Cabal == 2.2.* || == 2.4.* || == 3.0.*,
+  setup-depends: Cabal == 2.2.* || == 2.4.* || == 3.0.* || ==3.2.*,
                  base, filepath, directory


### PR DESCRIPTION
Also add validate-8.10.1 make rule

This needs backporting. I'll do that when `cabal-install` dependencies are updated as well.