### PR TITLE
Cabal init prints error message forever when using invalid license

### DIFF
--- a/cabal-install/Distribution/Client/Init.hs
+++ b/cabal-install/Distribution/Client/Init.hs
@@ -278,9 +278,8 @@ getLicense flags = do
                   (maybePrompt flags
                     (promptList "Please choose a license" listedLicenses
                      (Just BSD3) displayLicense True))
-
   case checkLicenseInvalid lic of
-    Just msg -> putStrLn msg >> getLicense flags
+    Just msg -> putStrLn msg >> return (flags { license = maybeToFlag lic })
     Nothing  -> return $ flags { license = maybeToFlag lic }
 
   where


### PR DESCRIPTION
fixes #6227 
When choosing non adequate license error message is printed in a loop.
I fixed that behavior and now we get something like this:
```
The license must be alphanumeric. If your license name has many words, the convention is to use camel case (e.g. PublicDomain). Please choose a different license.

Guessing dependencies...

Generating LICENSE...
Warning: unknown license type, you must put a copy in LICENSE yourself.
Generating Setup.hs...

```
The issue where the user sees the exception on failed parsing is still there:
```
Cannot parse license: a-a-1
CallStack (from HasCallStack):
  error, called at ./Distribution/ReadE.hs:42:24 in Cabal-3.0.0.0-fb617b94c4973e1d5149e5c5439c47b4e57443a0819f354a288475aa6cef5eae:Distribution.ReadE
```
I don't know if we want to prevent this from happening. 
In my mind users should't see these kinds of exceptions but maybe it should be a separate issue.
