### PR TITLE
WIP/RFC: Parse .cabal files to a source code representation

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -447,6 +447,7 @@ library
     Distribution.Types.MungedPackageId
     Distribution.Types.PackageId
     Distribution.Types.UnitId
+    Distribution.Types.CommonStanza
     Distribution.Types.Executable
     Distribution.Types.ExecutableScope
     Distribution.Types.Library
@@ -474,6 +475,7 @@ library
     Distribution.Types.TestSuiteInterface
     Distribution.Types.TestType
     Distribution.Types.GenericPackageDescription
+    Distribution.Types.PackageSourceDescription
     Distribution.Types.Condition
     Distribution.Types.CondTree
     Distribution.Types.HookedBuildInfo
@@ -543,9 +545,11 @@ library
     Distribution.Types.Lens
     Distribution.Types.Benchmark.Lens
     Distribution.Types.BuildInfo.Lens
+    Distribution.Types.CommonStanza.Lens
     Distribution.Types.Executable.Lens
     Distribution.Types.ForeignLib.Lens
     Distribution.Types.GenericPackageDescription.Lens
+    Distribution.Types.PackageSourceDescription.Lens
     Distribution.Types.InstalledPackageInfo.Lens
     Distribution.Types.Library.Lens
     Distribution.Types.PackageDescription.Lens

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -448,6 +448,7 @@ library
     Distribution.Types.PackageId
     Distribution.Types.UnitId
     Distribution.Types.CommonStanza
+    Distribution.Types.CommonStanzaImports
     Distribution.Types.Executable
     Distribution.Types.ExecutableScope
     Distribution.Types.Library
@@ -522,6 +523,8 @@ library
     Distribution.FieldGrammar.Parsec
     Distribution.FieldGrammar.Pretty
     Distribution.PackageDescription.FieldGrammar
+    Distribution.PackageDescription.PackageSourceDescriptionParser
+    Distribution.PackageDescription.PackageSourceDescriptionPrettyPrint
     Distribution.PackageDescription.Parsec
     Distribution.PackageDescription.Quirks
     Distribution.Parsec
@@ -546,6 +549,7 @@ library
     Distribution.Types.Benchmark.Lens
     Distribution.Types.BuildInfo.Lens
     Distribution.Types.CommonStanza.Lens
+    Distribution.Types.CommonStanzaImports.Lens
     Distribution.Types.Executable.Lens
     Distribution.Types.ForeignLib.Lens
     Distribution.Types.GenericPackageDescription.Lens

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -129,7 +129,8 @@ commonStanzaFieldGrammar
     :: (FieldGrammar g, Applicative (g CommonStanza), Applicative (g BuildInfo))
     => UnqualComponentName -> g CommonStanza CommonStanza
 commonStanzaFieldGrammar n = CommonStanza n
-    <$> blurFieldGrammar L.buildInfo buildInfoFieldGrammar
+    <$> optionalFieldDef  "import"  L.commonStanzaRecursiveImports emptyCommonStanzaImports
+    <*> blurFieldGrammar L.buildInfo buildInfoFieldGrammar
 {-# SPECIALIZE commonStanzaFieldGrammar :: UnqualComponentName -> ParsecFieldGrammar' CommonStanza #-}
 {-# SPECIALIZE commonStanzaFieldGrammar :: UnqualComponentName -> PrettyFieldGrammar' CommonStanza #-}
 

--- a/Cabal/Distribution/PackageDescription/PackageSourceDescriptionParser.hs
+++ b/Cabal/Distribution/PackageDescription/PackageSourceDescriptionParser.hs
@@ -541,7 +541,7 @@ checkCommonStanzaImports v commonStanzas fs@(Field (Name pos name) fls : fields)
 
         -- If the Cabal spec version declared in the file does not support
         -- common stanzas than emit a warning.
-        when (hasCommonStanzas == NoCommonStanzas) $
+        when ((specHasCommonStanzas v) == NoCommonStanzas) $
           parseWarning pos PWTUnknownField "Unknown field: import. You should set cabal-version: 2.2 or larger to use common stanzas"
 
         -- Verify that all imported common pragmas have been defined in the file.
@@ -563,13 +563,10 @@ checkCommonStanzaImports v commonStanzas fs@(Field (Name pos name) fls : fields)
         pure fs
 
   where
-    hasCommonStanzas = specHasCommonStanzas v
-
     getList' :: List CommaFSep Token String -> [String]
     getList' = Newtype.unpack
 
 checkCommonStanzaImports _ _ fs = pure fs
-
 
 
 -- | Warn on "import" fields, also map to Maybe, so errorneous fields can be filtered

--- a/Cabal/Distribution/PackageDescription/PackageSourceDescriptionPrettyPrint.hs
+++ b/Cabal/Distribution/PackageDescription/PackageSourceDescriptionPrettyPrint.hs
@@ -1,0 +1,219 @@
+{-# LANGUAGE OverloadedStrings #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Distribution.PackageDescription.PackageSourceDescriptionPrettyPrint
+-- License     :  BSD3
+--
+-- Maintainer  : cabal-devel@haskell.org
+-- Stability   : provisional
+-- Portability : portable
+--
+-- Pretty printing for cabal files
+--
+-----------------------------------------------------------------------------
+
+module Distribution.PackageDescription.PackageSourceDescriptionPrettyPrint (
+    -- * Generic package descriptions
+    writePackageSourceDescription,
+    showPackageSourceDescription,
+    ppPackageSourceDescription,
+
+     -- ** Supplementary build information
+     writeHookedBuildInfo,
+     showHookedBuildInfo,
+) where
+
+import Distribution.Compat.Prelude
+import Prelude ()
+
+import Distribution.Types.CondTree
+import Distribution.Types.Dependency
+import Distribution.Types.ForeignLib          (ForeignLib (foreignLibName))
+import Distribution.Types.LibraryName
+import Distribution.Types.UnqualComponentName
+
+import Distribution.CabalSpecVersion
+import Distribution.Fields.Pretty
+import Distribution.PackageDescription
+       (PackageDescription, SourceRepo, SetupBuildInfo, Flag(..), FlagName, ConfVar(..),
+        Library, Executable, TestSuite, Benchmark, Condition(..), HookedBuildInfo,
+        specVersion, setupBuildInfo, sourceRepos, repoKind, defaultSetupDepends, unFlagName)
+import Distribution.Pretty
+import Distribution.Simple.Utils
+import Distribution.Types.PackageSourceDescription
+       (PackageSourceDescription, packageDescription, genPackageFlags, condCommonStanzas,
+        condLibrary, condSubLibraries, condForeignLibs, condExecutables, condTestSuites,
+        condBenchmarks)
+import Distribution.Types.CommonStanza (CommonStanza)
+import Distribution.Types.Version (versionNumbers)
+
+import Distribution.FieldGrammar
+       (PrettyFieldGrammar', prettyFieldGrammar)
+import Distribution.PackageDescription.FieldGrammar
+       (benchmarkFieldGrammar, buildInfoFieldGrammar, commonStanzaFieldGrammar, executableFieldGrammar, flagFieldGrammar,
+       foreignLibFieldGrammar, libraryFieldGrammar, packageDescriptionFieldGrammar,
+       setupBInfoFieldGrammar, sourceRepoFieldGrammar, testSuiteFieldGrammar)
+
+import qualified Distribution.PackageDescription.FieldGrammar as FG
+
+import Text.PrettyPrint (Doc, char, hsep, parens, text, (<+>))
+
+import qualified Data.ByteString.Lazy.Char8 as BS.Char8
+
+-- | Writes a .cabal file from a generic package description
+writePackageSourceDescription :: FilePath -> PackageSourceDescription -> IO ()
+writePackageSourceDescription fpath pkg = writeUTF8File fpath (showPackageSourceDescription pkg)
+
+-- | Writes a generic package description to a string
+showPackageSourceDescription :: PackageSourceDescription -> String
+showPackageSourceDescription gpd = showFields (const []) $ ppPackageSourceDescription v gpd
+  where
+    v = cabalSpecFromVersionDigits
+      $ versionNumbers
+      $ specVersion
+      $ packageDescription gpd
+
+-- | Convert a generic package description to 'PrettyField's.
+ppPackageSourceDescription :: CabalSpecVersion -> PackageSourceDescription -> [PrettyField ()]
+ppPackageSourceDescription v gpd = concat
+    [ ppPackageDescription v (packageDescription gpd)
+    , ppSetupBInfo v (setupBuildInfo (packageDescription gpd))
+    , ppGenPackageFlags v (genPackageFlags gpd)
+    , ppCommonStanzas v (condCommonStanzas gpd)
+    , ppCondLibrary v (condLibrary gpd)
+    , ppCondSubLibraries v (condSubLibraries gpd)
+    , ppCondForeignLibs v (condForeignLibs gpd)
+    , ppCondExecutables v (condExecutables gpd)
+    , ppCondTestSuites v (condTestSuites gpd)
+    , ppCondBenchmarks v (condBenchmarks gpd)
+    ]
+
+ppPackageDescription :: CabalSpecVersion -> PackageDescription -> [PrettyField ()]
+ppPackageDescription v pd =
+    prettyFieldGrammar v packageDescriptionFieldGrammar pd
+    ++ ppSourceRepos v (sourceRepos pd)
+
+ppSourceRepos :: CabalSpecVersion -> [SourceRepo] -> [PrettyField ()]
+ppSourceRepos = map . ppSourceRepo
+
+ppSourceRepo :: CabalSpecVersion -> SourceRepo -> PrettyField ()
+ppSourceRepo v repo = PrettySection () "source-repository" [pretty kind] $
+    prettyFieldGrammar v (sourceRepoFieldGrammar kind) repo
+  where
+    kind = repoKind repo
+
+ppSetupBInfo :: CabalSpecVersion -> Maybe SetupBuildInfo -> [PrettyField ()]
+ppSetupBInfo _ Nothing = mempty
+ppSetupBInfo v (Just sbi)
+    | defaultSetupDepends sbi = mempty
+    | otherwise = pure $ PrettySection () "custom-setup" [] $
+        prettyFieldGrammar v (setupBInfoFieldGrammar False) sbi
+
+ppGenPackageFlags :: CabalSpecVersion -> [Flag] -> [PrettyField ()]
+ppGenPackageFlags = map . ppFlag
+
+ppFlag :: CabalSpecVersion -> Flag -> PrettyField ()
+ppFlag v flag@(MkFlag name _ _ _)  = PrettySection () "flag" [ppFlagName name] $
+    prettyFieldGrammar v (flagFieldGrammar name) flag
+
+ppCondTree2 :: CabalSpecVersion -> PrettyFieldGrammar' s -> CondTree ConfVar [Dependency] s -> [PrettyField ()]
+ppCondTree2 v grammar = go
+  where
+    -- TODO: recognise elif opportunities
+    go (CondNode it _ ifs) =
+        prettyFieldGrammar v grammar it ++
+        concatMap ppIf ifs
+
+    ppIf (CondBranch c thenTree Nothing)
+--        | isEmpty thenDoc = mempty
+        | otherwise       = [ppIfCondition c thenDoc]
+      where
+        thenDoc = go thenTree
+
+    ppIf (CondBranch c thenTree (Just elseTree)) =
+      -- See #6193
+      [ ppIfCondition c (go thenTree)
+      , PrettySection () "else" [] (go elseTree)
+      ]
+
+ppCommonStanzas :: CabalSpecVersion -> [(UnqualComponentName, CondTree ConfVar [Dependency] CommonStanza)] -> [PrettyField ()]
+ppCommonStanzas v commonStanzas =
+    [ PrettySection () "common" [pretty n]
+    $ ppCondTree2 v (commonStanzaFieldGrammar n) condTree
+    | (n, condTree) <- commonStanzas
+    ]
+
+ppCondLibrary :: CabalSpecVersion -> Maybe (CondTree ConfVar [Dependency] Library) -> [PrettyField ()]
+ppCondLibrary _ Nothing = mempty
+ppCondLibrary v (Just condTree) = pure $ PrettySection () "library" [] $
+    ppCondTree2 v (libraryFieldGrammar LMainLibName) condTree
+
+ppCondSubLibraries :: CabalSpecVersion -> [(UnqualComponentName, CondTree ConfVar [Dependency] Library)] -> [PrettyField ()]
+ppCondSubLibraries v libs =
+    [ PrettySection () "library" [pretty n]
+    $ ppCondTree2 v (libraryFieldGrammar $ LSubLibName n) condTree
+    | (n, condTree) <- libs
+    ]
+
+ppCondForeignLibs :: CabalSpecVersion -> [(UnqualComponentName, CondTree ConfVar [Dependency] ForeignLib)] -> [PrettyField ()]
+ppCondForeignLibs v flibs =
+    [ PrettySection () "foreign-library" [pretty n]
+    $ ppCondTree2 v (foreignLibFieldGrammar n) condTree
+    | (n, condTree) <- flibs
+    ]
+
+ppCondExecutables :: CabalSpecVersion -> [(UnqualComponentName, CondTree ConfVar [Dependency] Executable)] -> [PrettyField ()]
+ppCondExecutables v exes =
+    [ PrettySection () "executable" [pretty n]
+    $ ppCondTree2 v (executableFieldGrammar n) condTree
+    | (n, condTree) <- exes
+    ]
+
+ppCondTestSuites :: CabalSpecVersion -> [(UnqualComponentName, CondTree ConfVar [Dependency] TestSuite)] -> [PrettyField ()]
+ppCondTestSuites v suites =
+    [ PrettySection () "test-suite" [pretty n]
+    $ ppCondTree2 v testSuiteFieldGrammar (fmap FG.unvalidateTestSuite condTree)
+    | (n, condTree) <- suites
+    ]
+
+ppCondBenchmarks :: CabalSpecVersion -> [(UnqualComponentName, CondTree ConfVar [Dependency] Benchmark)] -> [PrettyField ()]
+ppCondBenchmarks v suites =
+    [ PrettySection () "benchmark" [pretty n]
+    $ ppCondTree2 v benchmarkFieldGrammar (fmap FG.unvalidateBenchmark condTree)
+    | (n, condTree) <- suites
+    ]
+
+ppCondition :: Condition ConfVar -> Doc
+ppCondition (Var x)                      = ppConfVar x
+ppCondition (Lit b)                      = text (show b)
+ppCondition (CNot c)                     = char '!' <<>> (ppCondition c)
+ppCondition (COr c1 c2)                  = parens (hsep [ppCondition c1, text "||"
+                                                         <+> ppCondition c2])
+ppCondition (CAnd c1 c2)                 = parens (hsep [ppCondition c1, text "&&"
+                                                         <+> ppCondition c2])
+ppConfVar :: ConfVar -> Doc
+ppConfVar (OS os)                        = text "os"   <<>> parens (pretty os)
+ppConfVar (Arch arch)                    = text "arch" <<>> parens (pretty arch)
+ppConfVar (Flag name)                    = text "flag" <<>> parens (ppFlagName name)
+ppConfVar (Impl c v)                     = text "impl" <<>> parens (pretty c <+> pretty v)
+
+ppFlagName :: FlagName -> Doc
+ppFlagName                               = text . unFlagName
+
+ppIfCondition :: Condition ConfVar -> [PrettyField ()] -> PrettyField ()
+ppIfCondition c = PrettySection () "if" [ppCondition c]
+
+
+-- | @since 2.0.0.2
+writeHookedBuildInfo :: FilePath -> HookedBuildInfo -> IO ()
+writeHookedBuildInfo fpath = writeFileAtomic fpath . BS.Char8.pack
+                             . showHookedBuildInfo
+
+-- | @since 2.0.0.2
+showHookedBuildInfo :: HookedBuildInfo -> String
+showHookedBuildInfo (mb_lib_bi, ex_bis) = showFields (const []) $
+    maybe mempty (prettyFieldGrammar cabalSpecLatest buildInfoFieldGrammar) mb_lib_bi ++
+    [ PrettySection () "executable:" [pretty name]
+    $ prettyFieldGrammar cabalSpecLatest buildInfoFieldGrammar bi
+    | (name, bi) <- ex_bis
+    ]

--- a/Cabal/Distribution/PackageDescription/PackageSourceDescriptionPrettyPrint.hs
+++ b/Cabal/Distribution/PackageDescription/PackageSourceDescriptionPrettyPrint.hs
@@ -28,7 +28,7 @@ import Prelude ()
 
 import Distribution.Types.CondTree
 import Distribution.Types.Dependency
-import Distribution.Types.ForeignLib          (ForeignLib (foreignLibName))
+import Distribution.Types.ForeignLib          (ForeignLib)
 import Distribution.Types.LibraryName
 import Distribution.Types.UnqualComponentName
 

--- a/Cabal/Distribution/Simple/Build.hs
+++ b/Cabal/Distribution/Simple/Build.hs
@@ -470,6 +470,7 @@ testSuiteExeV10AsExe :: TestSuite -> Executable
 testSuiteExeV10AsExe test@TestSuite { testInterface = TestSuiteExeV10 _ mainFile } =
     Executable {
       exeName    = testName test,
+      exeImports = mempty,
       modulePath = mainFile,
       exeScope   = ExecutablePublic,
       buildInfo  = testBuildInfo test
@@ -481,6 +482,7 @@ benchmarkExeV10asExe :: Benchmark -> Executable
 benchmarkExeV10asExe bm@Benchmark { benchmarkInterface = BenchmarkExeV10 _ mainFile } =
     Executable {
       exeName    = benchmarkName bm,
+      exeImports = mempty,
       modulePath = mainFile,
       exeScope   = ExecutablePublic,
       buildInfo  = benchmarkBuildInfo bm
@@ -507,6 +509,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
     bi  = testBuildInfo test
     lib = Library {
             libName = LMainLibName,
+            libImports = mempty,
             exposedModules = [ m ],
             reexportedModules = [],
             signatures = [],
@@ -547,6 +550,7 @@ testSuiteLibV09AsLibAndExe pkg_descr
     testLibDep = thisPackageVersion $ package pkg
     exe = Executable {
             exeName    = mkUnqualComponentName $ stubName test,
+            exeImports = mempty,
             modulePath = stubFilePath test,
             exeScope   = ExecutablePublic,
             buildInfo  = (testBuildInfo test) {

--- a/Cabal/Distribution/Simple/Haddock.hs
+++ b/Cabal/Distribution/Simple/Haddock.hs
@@ -480,6 +480,7 @@ compToExe comp =
     CTest test@TestSuite { testInterface = TestSuiteExeV10 _ f } ->
       Just Executable {
         exeName    = testName test,
+        exeImports = mempty,
         modulePath = f,
         exeScope   = ExecutablePublic,
         buildInfo  = testBuildInfo test
@@ -487,6 +488,7 @@ compToExe comp =
     CBench bench@Benchmark { benchmarkInterface = BenchmarkExeV10 _ f } ->
       Just Executable {
         exeName    = benchmarkName bench,
+        exeImports = mempty,
         modulePath = f,
         exeScope   = ExecutablePublic,
         buildInfo  = benchmarkBuildInfo bench

--- a/Cabal/Distribution/Types/Benchmark.hs
+++ b/Cabal/Distribution/Types/Benchmark.hs
@@ -13,6 +13,7 @@ import Prelude ()
 import Distribution.Compat.Prelude
 
 import Distribution.Types.BuildInfo
+import Distribution.Types.CommonStanzaImports
 import Distribution.Types.BenchmarkType
 import Distribution.Types.BenchmarkInterface
 import Distribution.Types.UnqualComponentName
@@ -20,11 +21,13 @@ import Distribution.Types.UnqualComponentName
 import Distribution.ModuleName
 
 import qualified Distribution.Types.BuildInfo.Lens as L
+import qualified Distribution.Types.CommonStanzaImports.Lens as L
 
 -- | A \"benchmark\" stanza in a cabal file.
 --
 data Benchmark = Benchmark {
         benchmarkName      :: UnqualComponentName,
+        benchmarkImports   :: CommonStanzaImports,
         benchmarkInterface :: BenchmarkInterface,
         benchmarkBuildInfo :: BuildInfo
     }
@@ -34,12 +37,16 @@ instance Binary Benchmark
 instance Structured Benchmark
 instance NFData Benchmark where rnf = genericRnf
 
+instance L.HasCommonStanzaImports Benchmark where
+    commonStanzaImports f (Benchmark x1 x2 x3 x4) = fmap (\i1 -> Benchmark x1 i1 x3 x4) (f x2)
+
 instance L.HasBuildInfo Benchmark where
-    buildInfo f (Benchmark x1 x2 x3) = fmap (\y1 -> Benchmark x1 x2 y1) (f x3)
+    buildInfo f (Benchmark x1 x2 x3 x4) = fmap (\y1 -> Benchmark x1 x2 x3 y1) (f x4)
 
 instance Monoid Benchmark where
     mempty = Benchmark {
         benchmarkName      = mempty,
+        benchmarkImports   = mempty,
         benchmarkInterface = mempty,
         benchmarkBuildInfo = mempty
     }
@@ -48,6 +55,7 @@ instance Monoid Benchmark where
 instance Semigroup Benchmark where
     a <> b = Benchmark {
         benchmarkName      = combine' benchmarkName,
+        benchmarkImports   = combine  benchmarkImports,
         benchmarkInterface = combine  benchmarkInterface,
         benchmarkBuildInfo = combine  benchmarkBuildInfo
     }

--- a/Cabal/Distribution/Types/Benchmark/Lens.hs
+++ b/Cabal/Distribution/Types/Benchmark/Lens.hs
@@ -10,6 +10,7 @@ import Prelude ()
 import Distribution.Types.Benchmark           (Benchmark)
 import Distribution.Types.BenchmarkInterface  (BenchmarkInterface)
 import Distribution.Types.BuildInfo           (BuildInfo)
+import Distribution.Types.CommonStanzaImports (CommonStanzaImports)
 import Distribution.Types.UnqualComponentName (UnqualComponentName)
 
 import qualified Distribution.Types.Benchmark as T
@@ -17,6 +18,10 @@ import qualified Distribution.Types.Benchmark as T
 benchmarkName :: Lens' Benchmark UnqualComponentName
 benchmarkName f s = fmap (\x -> s { T.benchmarkName = x }) (f (T.benchmarkName s))
 {-# INLINE benchmarkName #-}
+
+benchmarkImports :: Lens' Benchmark CommonStanzaImports
+benchmarkImports f s = fmap (\x -> s { T.benchmarkImports = x }) (f (T.benchmarkImports s))
+{-# INLINE benchmarkImports #-}
 
 benchmarkInterface :: Lens' Benchmark BenchmarkInterface
 benchmarkInterface f s = fmap (\x -> s { T.benchmarkInterface = x }) (f (T.benchmarkInterface s))

--- a/Cabal/Distribution/Types/CommonStanza.hs
+++ b/Cabal/Distribution/Types/CommonStanza.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
+
+module Distribution.Types.CommonStanza (
+    CommonStanza(..),
+) where
+
+import Distribution.Compat.Prelude
+import Prelude ()
+
+import Distribution.Types.BuildInfo
+import Distribution.Types.UnqualComponentName
+
+import qualified Distribution.Types.BuildInfo.Lens as L
+
+data CommonStanza = CommonStanza
+    { commonStanzaName      :: UnqualComponentName
+    , commonStanzaBuildInfo :: BuildInfo
+    }
+    deriving (Generic, Show, Eq, Read, Typeable, Data)
+
+instance L.HasBuildInfo CommonStanza where
+    buildInfo f l = (\x -> l { commonStanzaBuildInfo = x }) <$> f (commonStanzaBuildInfo l)
+
+instance Binary CommonStanza
+instance Structured CommonStanza
+instance NFData CommonStanza where rnf = genericRnf

--- a/Cabal/Distribution/Types/CommonStanza.hs
+++ b/Cabal/Distribution/Types/CommonStanza.hs
@@ -10,15 +10,21 @@ import Distribution.Compat.Prelude
 import Prelude ()
 
 import Distribution.Types.BuildInfo
+import Distribution.Types.CommonStanzaImports
 import Distribution.Types.UnqualComponentName
 
 import qualified Distribution.Types.BuildInfo.Lens as L
+import qualified Distribution.Types.CommonStanzaImports.Lens as L
 
 data CommonStanza = CommonStanza
     { commonStanzaName      :: UnqualComponentName
+    , commonStanzaRecursiveImports:: CommonStanzaImports
     , commonStanzaBuildInfo :: BuildInfo
     }
     deriving (Generic, Show, Eq, Read, Typeable, Data)
+
+instance L.HasCommonStanzaImports CommonStanza where
+    commonStanzaImports f l = (\x -> l { commonStanzaRecursiveImports = x }) <$> f (commonStanzaRecursiveImports l)
 
 instance L.HasBuildInfo CommonStanza where
     buildInfo f l = (\x -> l { commonStanzaBuildInfo = x }) <$> f (commonStanzaBuildInfo l)
@@ -34,6 +40,7 @@ instance Monoid CommonStanza where
 instance Semigroup CommonStanza where
   a <> b = CommonStanza{
     commonStanzaName = combine' commonStanzaName,
+    commonStanzaRecursiveImports = combine commonStanzaRecursiveImports,
     commonStanzaBuildInfo = combine commonStanzaBuildInfo
   }
     where combine field = field a `mappend` field b

--- a/Cabal/Distribution/Types/CommonStanza.hs
+++ b/Cabal/Distribution/Types/CommonStanza.hs
@@ -3,6 +3,7 @@
 
 module Distribution.Types.CommonStanza (
     CommonStanza(..),
+    emptyCommonStanza,
 ) where
 
 import Distribution.Compat.Prelude
@@ -25,3 +26,23 @@ instance L.HasBuildInfo CommonStanza where
 instance Binary CommonStanza
 instance Structured CommonStanza
 instance NFData CommonStanza where rnf = genericRnf
+
+instance Monoid CommonStanza where
+  mempty = gmempty
+  mappend = (<>)
+
+instance Semigroup CommonStanza where
+  a <> b = CommonStanza{
+    commonStanzaName = combine' commonStanzaName,
+    commonStanzaBuildInfo = combine commonStanzaBuildInfo
+  }
+    where combine field = field a `mappend` field b
+          combine' field = case ( unUnqualComponentName $ field a
+                                , unUnqualComponentName $ field b) of
+                      ("", _) -> field b
+                      (_, "") -> field a
+                      (x, y) -> error $ "Ambiguous values for executable field: '"
+                                  ++ x ++ "' and '" ++ y ++ "'"
+
+emptyCommonStanza :: CommonStanza
+emptyCommonStanza = mempty

--- a/Cabal/Distribution/Types/CommonStanza/Lens.hs
+++ b/Cabal/Distribution/Types/CommonStanza/Lens.hs
@@ -1,0 +1,22 @@
+module Distribution.Types.CommonStanza.Lens (
+    CommonStanza,
+    module Distribution.Types.CommonStanza.Lens,
+    ) where
+
+import Distribution.Compat.Lens
+import Distribution.Compat.Prelude
+import Prelude ()
+
+import Distribution.Types.BuildInfo           (BuildInfo)
+import Distribution.Types.CommonStanza        (CommonStanza)
+import Distribution.Types.UnqualComponentName (UnqualComponentName)
+
+import qualified Distribution.Types.CommonStanza as T
+
+commonStanzaName :: Lens' CommonStanza UnqualComponentName
+commonStanzaName f s = fmap (\x -> s { T.commonStanzaName = x }) (f (T.commonStanzaName s))
+{-# INLINE commonStanzaName #-}
+
+commonStanzaBuildInfo :: Lens' CommonStanza BuildInfo
+commonStanzaBuildInfo f s = fmap (\x -> s { T.commonStanzaBuildInfo = x }) (f (T.commonStanzaBuildInfo s))
+{-# INLINE commonStanzaBuildInfo #-}

--- a/Cabal/Distribution/Types/CommonStanza/Lens.hs
+++ b/Cabal/Distribution/Types/CommonStanza/Lens.hs
@@ -9,6 +9,7 @@ import Prelude ()
 
 import Distribution.Types.BuildInfo           (BuildInfo)
 import Distribution.Types.CommonStanza        (CommonStanza)
+import Distribution.Types.CommonStanzaImports (CommonStanzaImports)
 import Distribution.Types.UnqualComponentName (UnqualComponentName)
 
 import qualified Distribution.Types.CommonStanza as T
@@ -16,6 +17,11 @@ import qualified Distribution.Types.CommonStanza as T
 commonStanzaName :: Lens' CommonStanza UnqualComponentName
 commonStanzaName f s = fmap (\x -> s { T.commonStanzaName = x }) (f (T.commonStanzaName s))
 {-# INLINE commonStanzaName #-}
+
+commonStanzaRecursiveImports :: Lens' CommonStanza CommonStanzaImports
+commonStanzaRecursiveImports f s = fmap (\x -> s { T.commonStanzaRecursiveImports = x }) (f (T.commonStanzaRecursiveImports s))
+{-# INLINE commonStanzaRecursiveImports #-}
+
 
 commonStanzaBuildInfo :: Lens' CommonStanza BuildInfo
 commonStanzaBuildInfo f s = fmap (\x -> s { T.commonStanzaBuildInfo = x }) (f (T.commonStanzaBuildInfo s))

--- a/Cabal/Distribution/Types/CommonStanzaImports.hs
+++ b/Cabal/Distribution/Types/CommonStanzaImports.hs
@@ -50,7 +50,7 @@ instance Pretty CommonStanzaImports where
     Disp.fsep (Disp.punctuate Disp.comma (map pretty imports))
 
 instance Parsec CommonStanzaImports where
-  parsec = CommonStanzaImports <$> parsecCommaList parsec
+  parsec = CommonStanzaImports <$> parsecLeadingCommaList parsec
 
 instance Described CommonStanzaImports where
   describe _ = RETodo

--- a/Cabal/Distribution/Types/CommonStanzaImports.hs
+++ b/Cabal/Distribution/Types/CommonStanzaImports.hs
@@ -22,7 +22,7 @@ import Distribution.FieldGrammar.Described
 --   of sections in a cabal file.
 data CommonStanzaImports = CommonStanzaImports {
   -- | The names of common stanzas to be imported.
-  commonStanzaImports :: [UnqualComponentName]
+  getCommonStanzaImports :: [UnqualComponentName]
   }
   deriving (Generic, Show, Read, Eq, Typeable, Data)
 
@@ -32,13 +32,13 @@ instance NFData CommonStanzaImports where rnf = genericRnf
 
 instance Monoid CommonStanzaImports where
   mempty = CommonStanzaImports {
-    commonStanzaImports = []
+    getCommonStanzaImports = []
     }
   mappend = (<>)
 
 instance Semigroup CommonStanzaImports where
   a <> b = CommonStanzaImports {
-    commonStanzaImports = commonStanzaImports a <> commonStanzaImports b
+    getCommonStanzaImports = getCommonStanzaImports a <> getCommonStanzaImports b
     }
 
 emptyCommonStanzaImports :: CommonStanzaImports

--- a/Cabal/Distribution/Types/CommonStanzaImports.hs
+++ b/Cabal/Distribution/Types/CommonStanzaImports.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Distribution.Types.CommonStanzaImports (
+  CommonStanzaImports(..),
+
+  emptyCommonStanzaImports,
+) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+
+import Distribution.Parsec
+import Distribution.Pretty
+import Distribution.Types.UnqualComponentName (UnqualComponentName, mkUnqualComponentName)
+import qualified Text.PrettyPrint                as Disp
+import Distribution.FieldGrammar.Described
+
+
+-- | Represents the list of common stanzas specified in the `import` directive
+--   of sections in a cabal file.
+data CommonStanzaImports = CommonStanzaImports {
+  -- | The names of common stanzas to be imported.
+  commonStanzaImports :: [UnqualComponentName]
+  }
+  deriving (Generic, Show, Read, Eq, Typeable, Data)
+
+instance Binary CommonStanzaImports
+instance Structured CommonStanzaImports
+instance NFData CommonStanzaImports where rnf = genericRnf
+
+instance Monoid CommonStanzaImports where
+  mempty = CommonStanzaImports {
+    commonStanzaImports = []
+    }
+  mappend = (<>)
+
+instance Semigroup CommonStanzaImports where
+  a <> b = CommonStanzaImports {
+    commonStanzaImports = commonStanzaImports a <> commonStanzaImports b
+    }
+
+emptyCommonStanzaImports :: CommonStanzaImports
+emptyCommonStanzaImports = mempty
+
+instance Pretty CommonStanzaImports where
+  pretty (CommonStanzaImports []) = Disp.empty
+  pretty (CommonStanzaImports imports) =
+    Disp.fsep (Disp.punctuate Disp.comma (map pretty imports))
+
+instance Parsec CommonStanzaImports where
+  parsec = CommonStanzaImports <$> parsecCommaList parsec
+
+instance Described CommonStanzaImports where
+  describe _ = RETodo

--- a/Cabal/Distribution/Types/CommonStanzaImports/Lens.hs
+++ b/Cabal/Distribution/Types/CommonStanzaImports/Lens.hs
@@ -1,0 +1,18 @@
+module Distribution.Types.CommonStanzaImports.Lens (
+    CommonStanzaImports,
+    HasCommonStanzaImports (..),
+    ) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+import Distribution.Compat.Lens
+
+import Distribution.Types.CommonStanzaImports (CommonStanzaImports)
+
+-- | Class lenses for 'CommonStanzaImports'.
+class HasCommonStanzaImports a where
+    commonStanzaImports :: Lens' a CommonStanzaImports
+
+instance HasCommonStanzaImports CommonStanzaImports where
+    commonStanzaImports = id
+    {-# INLINE commonStanzaImports #-}

--- a/Cabal/Distribution/Types/Executable.hs
+++ b/Cabal/Distribution/Types/Executable.hs
@@ -12,19 +12,25 @@ import Prelude ()
 import Distribution.Compat.Prelude
 
 import Distribution.Types.BuildInfo
+import Distribution.Types.CommonStanzaImports
 import Distribution.Types.UnqualComponentName
 import Distribution.Types.ExecutableScope
 import Distribution.ModuleName
 
 import qualified Distribution.Types.BuildInfo.Lens as L
+import qualified Distribution.Types.CommonStanzaImports.Lens as L
 
 data Executable = Executable {
         exeName    :: UnqualComponentName,
+        exeImports :: CommonStanzaImports,
         modulePath :: FilePath,
         exeScope   :: ExecutableScope,
         buildInfo  :: BuildInfo
     }
     deriving (Generic, Show, Read, Eq, Typeable, Data)
+
+instance L.HasCommonStanzaImports Executable where
+    commonStanzaImports f l = (\x -> l { exeImports = x }) <$> f (exeImports l)
 
 instance L.HasBuildInfo Executable where
     buildInfo f l = (\x -> l { buildInfo = x }) <$> f (buildInfo l)
@@ -40,6 +46,7 @@ instance Monoid Executable where
 instance Semigroup Executable where
   a <> b = Executable{
     exeName    = combine' exeName,
+    exeImports = combine exeImports,
     modulePath = combine modulePath,
     exeScope   = combine exeScope,
     buildInfo  = combine buildInfo

--- a/Cabal/Distribution/Types/Executable/Lens.hs
+++ b/Cabal/Distribution/Types/Executable/Lens.hs
@@ -8,6 +8,7 @@ import Distribution.Compat.Prelude
 import Prelude ()
 
 import Distribution.Types.BuildInfo           (BuildInfo)
+import Distribution.Types.CommonStanzaImports (CommonStanzaImports)
 import Distribution.Types.Executable          (Executable)
 import Distribution.Types.ExecutableScope     (ExecutableScope)
 import Distribution.Types.UnqualComponentName (UnqualComponentName)
@@ -17,6 +18,9 @@ import qualified Distribution.Types.Executable as T
 exeName :: Lens' Executable UnqualComponentName
 exeName f s = fmap (\x -> s { T.exeName = x }) (f (T.exeName s))
 {-# INLINE exeName #-}
+
+exeImports :: Lens' Executable CommonStanzaImports
+exeImports f s = fmap (\x -> s { T.exeImports = x }) (f (T.exeImports s))
 
 modulePath :: Lens' Executable String
 modulePath f s = fmap (\x -> s { T.modulePath = x }) (f (T.modulePath s))

--- a/Cabal/Distribution/Types/ForeignLib.hs
+++ b/Cabal/Distribution/Types/ForeignLib.hs
@@ -25,6 +25,7 @@ import Distribution.Parsec
 import Distribution.Pretty
 import Distribution.System
 import Distribution.Types.BuildInfo
+import Distribution.Types.CommonStanzaImports
 import Distribution.Types.ForeignLibOption
 import Distribution.Types.ForeignLibType
 import Distribution.Types.UnqualComponentName
@@ -35,12 +36,15 @@ import qualified Text.PrettyPrint                as Disp
 import qualified Text.Read                       as Read
 
 import qualified Distribution.Types.BuildInfo.Lens as L
+import qualified Distribution.Types.CommonStanzaImports.Lens as L
 
 -- | A foreign library stanza is like a library stanza, except that
 -- the built code is intended for consumption by a non-Haskell client.
 data ForeignLib = ForeignLib {
       -- | Name of the foreign library
       foreignLibName       :: UnqualComponentName
+      -- | Common stanza imports
+    , foreignLibImports    :: CommonStanzaImports
       -- | What kind of foreign library is this (static or dynamic).
     , foreignLibType       :: ForeignLibType
       -- | What options apply to this foreign library (e.g., are we
@@ -136,6 +140,9 @@ libVersionNumberShow v =
 libVersionMajor :: LibVersionInfo -> Int
 libVersionMajor (LibVersionInfo c _ a) = c-a
 
+instance L.HasCommonStanzaImports ForeignLib where
+    commonStanzaImports f l = (\x -> l { foreignLibImports = x }) <$> f (foreignLibImports l)
+
 instance L.HasBuildInfo ForeignLib where
     buildInfo f l = (\x -> l { foreignLibBuildInfo = x }) <$> f (foreignLibBuildInfo l)
 
@@ -146,6 +153,7 @@ instance NFData ForeignLib where rnf = genericRnf
 instance Semigroup ForeignLib where
   a <> b = ForeignLib {
       foreignLibName         = combine'  foreignLibName
+    , foreignLibImports      = combine   foreignLibImports
     , foreignLibType         = combine   foreignLibType
     , foreignLibOptions      = combine   foreignLibOptions
     , foreignLibBuildInfo    = combine   foreignLibBuildInfo
@@ -165,6 +173,7 @@ instance Semigroup ForeignLib where
 instance Monoid ForeignLib where
   mempty = ForeignLib {
       foreignLibName         = mempty
+    , foreignLibImports      = mempty
     , foreignLibType         = ForeignLibTypeUnknown
     , foreignLibOptions      = []
     , foreignLibBuildInfo    = mempty

--- a/Cabal/Distribution/Types/ForeignLib/Lens.hs
+++ b/Cabal/Distribution/Types/ForeignLib/Lens.hs
@@ -8,6 +8,7 @@ import Distribution.Compat.Prelude
 import Prelude ()
 
 import Distribution.Types.BuildInfo           (BuildInfo)
+import Distribution.Types.CommonStanzaImports (CommonStanzaImports)
 import Distribution.Types.ForeignLib          (ForeignLib, LibVersionInfo)
 import Distribution.Types.ForeignLibOption    (ForeignLibOption)
 import Distribution.Types.ForeignLibType      (ForeignLibType)
@@ -19,6 +20,10 @@ import qualified Distribution.Types.ForeignLib as T
 foreignLibName :: Lens' ForeignLib UnqualComponentName
 foreignLibName f s = fmap (\x -> s { T.foreignLibName = x }) (f (T.foreignLibName s))
 {-# INLINE foreignLibName #-}
+
+foreignLibImports :: Lens' ForeignLib CommonStanzaImports
+foreignLibImports f s = fmap (\x -> s { T.foreignLibImports = x }) (f (T.foreignLibImports s))
+{-# INLINE foreignLibImports #-}
 
 foreignLibType :: Lens' ForeignLib ForeignLibType
 foreignLibType f s = fmap (\x -> s { T.foreignLibType = x }) (f (T.foreignLibType s))

--- a/Cabal/Distribution/Types/Import.hs
+++ b/Cabal/Distribution/Types/Import.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Distribution.Types.CommonStanzaImports (
+  CommonStanzaImports(..),
+
+  emptyCommonStanzaImports,
+) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+-- | Represents the list of common stanzas specified in the `import` directive
+--   of sections in a cabal file.
+data CommonStanzaImports = CommonStanzaImports {
+  -- | The names of common stanzas to be imported.
+  commonStanzaImports :: [String]
+  }
+  deriving (Generic, Show, Read, Eq, Typeable, Data)
+
+instance Binary BuildInfo
+instance Structured BuildInfo
+instance NFData BuildInfo where rnf = genericRnf
+
+instance Monoid BuildInfo where
+  mempty = BuildInfo {
+    commonStanzaImports = [],
+    }
+  mappend = (<>)
+
+instance Semigroup CommonStanzaImports where
+  a <> b = CommonStanzaImports {
+    commonStanzaImports = commonStanzaImports a <> commonStanzaImports b
+    }

--- a/Cabal/Distribution/Types/Lens.hs
+++ b/Cabal/Distribution/Types/Lens.hs
@@ -1,6 +1,8 @@
 module Distribution.Types.Lens (
     module Distribution.Types.Benchmark.Lens,
     module Distribution.Types.BuildInfo.Lens,
+    module Distribution.Types.CommonStanza.Lens,
+    module Distribution.Types.CommonStanzaImports.Lens,
     module Distribution.Types.Executable.Lens,
     module Distribution.Types.ForeignLib.Lens,
     module Distribution.Types.GenericPackageDescription.Lens,
@@ -14,6 +16,8 @@ module Distribution.Types.Lens (
 
 import Distribution.Types.Benchmark.Lens
 import Distribution.Types.BuildInfo.Lens
+import Distribution.Types.CommonStanza.Lens
+import Distribution.Types.CommonStanzaImports.Lens
 import Distribution.Types.Executable.Lens
 import Distribution.Types.ForeignLib.Lens
 import Distribution.Types.GenericPackageDescription.Lens

--- a/Cabal/Distribution/Types/Library.hs
+++ b/Cabal/Distribution/Types/Library.hs
@@ -13,14 +13,17 @@ import Prelude ()
 
 import Distribution.ModuleName
 import Distribution.Types.BuildInfo
+import Distribution.Types.CommonStanzaImports
 import Distribution.Types.LibraryVisibility
 import Distribution.Types.ModuleReexport
 import Distribution.Types.LibraryName
 
 import qualified Distribution.Types.BuildInfo.Lens as L
+import qualified Distribution.Types.CommonStanzaImports.Lens as L
 
 data Library = Library
     { libName           :: LibraryName
+    , libImports        :: CommonStanzaImports
     , exposedModules    :: [ModuleName]
     , reexportedModules :: [ModuleReexport]
     , signatures        :: [ModuleName]       -- ^ What sigs need implementations?
@@ -29,6 +32,9 @@ data Library = Library
     , libBuildInfo      :: BuildInfo
     }
     deriving (Generic, Show, Eq, Read, Typeable, Data)
+
+instance L.HasCommonStanzaImports Library where
+    commonStanzaImports f l = (\x -> l { libImports = x }) <$> f (libImports l)
 
 instance L.HasBuildInfo Library where
     buildInfo f l = (\x -> l { libBuildInfo = x }) <$> f (libBuildInfo l)
@@ -40,6 +46,7 @@ instance NFData Library where rnf = genericRnf
 emptyLibrary :: Library
 emptyLibrary = Library
     { libName           = LMainLibName
+    , libImports        = mempty
     , exposedModules    = mempty
     , reexportedModules = mempty
     , signatures        = mempty
@@ -63,6 +70,7 @@ instance Monoid Library where
 instance Semigroup Library where
   a <> b = Library
     { libName           = combineLibraryName (libName a) (libName b)
+    , libImports        = combine libImports
     , exposedModules    = combine exposedModules
     , reexportedModules = combine reexportedModules
     , signatures        = combine signatures

--- a/Cabal/Distribution/Types/Library/Lens.hs
+++ b/Cabal/Distribution/Types/Library/Lens.hs
@@ -9,6 +9,7 @@ import Prelude ()
 
 import Distribution.ModuleName              (ModuleName)
 import Distribution.Types.BuildInfo         (BuildInfo)
+import Distribution.Types.CommonStanzaImports (CommonStanzaImports)
 import Distribution.Types.Library           (Library)
 import Distribution.Types.LibraryName       (LibraryName)
 import Distribution.Types.LibraryVisibility (LibraryVisibility)
@@ -19,6 +20,10 @@ import qualified Distribution.Types.Library as T
 libName :: Lens' Library LibraryName
 libName f s = fmap (\x -> s { T.libName = x }) (f (T.libName s))
 {-# INLINE libName #-}
+
+libImports :: Lens' Library CommonStanzaImports
+libImports f s = fmap (\x -> s { T.libImports = x }) (f (T.libImports s))
+{-# INLINE libImports #-}
 
 exposedModules :: Lens' Library [ModuleName]
 exposedModules f s = fmap (\x -> s { T.exposedModules = x }) (f (T.exposedModules s))

--- a/Cabal/Distribution/Types/PackageSourceDescription.hs
+++ b/Cabal/Distribution/Types/PackageSourceDescription.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Distribution.Types.PackageSourceDescription (
+    PackageSourceDescription(..),
+    emptyPackageSourceDescription,
+) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+-- lens
+import Distribution.Compat.Lens                     as L
+import qualified Distribution.Types.BuildInfo.Lens  as L
+
+import Distribution.Types.PackageDescription
+
+import Distribution.Types.Benchmark
+import Distribution.Types.CommonStanza
+import Distribution.Types.CondTree
+import Distribution.Types.ConfVar
+import Distribution.Types.Dependency
+import Distribution.Types.Executable
+import Distribution.Types.Flag
+import Distribution.Types.ForeignLib
+import Distribution.Types.Library
+import Distribution.Types.TestSuite
+import Distribution.Types.UnqualComponentName
+import Distribution.Package
+
+-- ---------------------------------------------------------------------------
+-- The 'PackageSourceDescription' type which represents the parsed package
+-- source code before simplifications have been applied. This means that this
+-- representation still contains comments and common stanzas.
+
+data PackageSourceDescription =
+  PackageSourceDescription
+  { packageDescription :: PackageDescription
+  , genPackageFlags    :: [Flag]
+  , condCommonStanzas  :: [( UnqualComponentName
+                           , CondTree ConfVar [Dependency] CommonStanza )]
+  , condLibrary        :: Maybe (CondTree ConfVar [Dependency] Library)
+  , condSubLibraries   :: [( UnqualComponentName
+                           , CondTree ConfVar [Dependency] Library )]
+  , condForeignLibs    :: [( UnqualComponentName
+                           , CondTree ConfVar [Dependency] ForeignLib )]
+  , condExecutables    :: [( UnqualComponentName
+                           , CondTree ConfVar [Dependency] Executable )]
+  , condTestSuites     :: [( UnqualComponentName
+                           , CondTree ConfVar [Dependency] TestSuite )]
+  , condBenchmarks     :: [( UnqualComponentName
+                           , CondTree ConfVar [Dependency] Benchmark )]
+  }
+    deriving (Show, Eq, Typeable, Data, Generic)
+
+instance Package PackageSourceDescription where
+  packageId = packageId . packageDescription
+
+instance Binary PackageSourceDescription
+instance Structured PackageSourceDescription
+instance NFData PackageSourceDescription where rnf = genericRnf
+
+emptyPackageSourceDescription :: PackageSourceDescription
+emptyPackageSourceDescription = PackageSourceDescription emptyPackageDescription [] [] Nothing [] [] [] [] []
+
+-- -----------------------------------------------------------------------------
+-- Traversal Instances
+
+instance L.HasBuildInfos PackageSourceDescription where
+  traverseBuildInfos f (PackageSourceDescription p a1 x1 x2 x3 x4 x5 x6 x7) =
+    PackageSourceDescription
+        <$> L.traverseBuildInfos f p
+        <*> pure a1
+        <*> (traverse . L._2 . traverse . L.buildInfo) f x1
+        <*> (traverse . traverse . L.buildInfo) f x2
+        <*> (traverse . L._2 . traverse . L.buildInfo) f x3
+        <*> (traverse . L._2 . traverse . L.buildInfo) f x4
+        <*> (traverse . L._2 . traverse . L.buildInfo) f x5
+        <*> (traverse . L._2 . traverse . L.buildInfo) f x6
+        <*> (traverse . L._2 . traverse . L.buildInfo) f x7

--- a/Cabal/Distribution/Types/PackageSourceDescription/Lens.hs
+++ b/Cabal/Distribution/Types/PackageSourceDescription/Lens.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE Rank2Types #-}
+module Distribution.Types.PackageSourceDescription.Lens (
+    PackageSourceDescription,
+    Flag,
+    FlagName,
+    ConfVar (..),
+    module Distribution.Types.PackageSourceDescription.Lens,
+    ) where
+
+import Prelude()
+import Distribution.Compat.Prelude
+import Distribution.Compat.Lens
+
+import qualified Distribution.Types.PackageSourceDescription as T
+
+-- We import types from their packages, so we can remove unused imports
+-- and have wider inter-module dependency graph
+import Distribution.Types.CondTree (CondTree)
+import Distribution.Types.CommonStanza (CommonStanza)
+import Distribution.Types.Dependency (Dependency)
+import Distribution.Types.Executable (Executable)
+import Distribution.Types.PackageDescription (PackageDescription)
+import Distribution.Types.Benchmark (Benchmark)
+import Distribution.Types.ForeignLib (ForeignLib)
+import Distribution.Types.PackageSourceDescription (PackageSourceDescription(PackageSourceDescription) )
+import Distribution.Types.Flag (Flag(MkFlag), FlagName)
+import Distribution.Types.ConfVar (ConfVar (..))
+import Distribution.Types.Library (Library)
+import Distribution.Types.TestSuite (TestSuite)
+import Distribution.Types.UnqualComponentName (UnqualComponentName)
+import Distribution.System (Arch, OS)
+import Distribution.Compiler (CompilerFlavor)
+import Distribution.Version (VersionRange)
+
+-------------------------------------------------------------------------------
+-- PackageSourceDescription
+-------------------------------------------------------------------------------
+
+packageDescription :: Lens' PackageSourceDescription PackageDescription
+packageDescription f s = fmap (\x -> s { T.packageDescription = x }) (f (T.packageDescription s))
+{-# INLINE packageDescription #-}
+
+condCommonStanzas :: Lens' PackageSourceDescription [(UnqualComponentName,(CondTree ConfVar [Dependency] CommonStanza))]
+condCommonStanzas f s = fmap (\x -> s { T.condCommonStanzas = x }) (f (T.condCommonStanzas s))
+{-# INLINE condCommonStanzas #-}
+
+genPackageFlags :: Lens' PackageSourceDescription [Flag]
+genPackageFlags f s = fmap (\x -> s { T.genPackageFlags = x }) (f (T.genPackageFlags s))
+{-# INLINE genPackageFlags #-}
+
+condLibrary :: Lens' PackageSourceDescription (Maybe (CondTree ConfVar [Dependency] Library))
+condLibrary f s = fmap (\x -> s { T.condLibrary = x }) (f (T.condLibrary s))
+{-# INLINE condLibrary #-}
+
+condSubLibraries :: Lens' PackageSourceDescription [(UnqualComponentName,(CondTree ConfVar [Dependency] Library))]
+condSubLibraries f s = fmap (\x -> s { T.condSubLibraries = x }) (f (T.condSubLibraries s))
+{-# INLINE condSubLibraries #-}
+
+condForeignLibs :: Lens' PackageSourceDescription [(UnqualComponentName,(CondTree ConfVar [Dependency] ForeignLib))]
+condForeignLibs f s = fmap (\x -> s { T.condForeignLibs = x }) (f (T.condForeignLibs s))
+{-# INLINE condForeignLibs #-}
+
+condExecutables :: Lens' PackageSourceDescription [(UnqualComponentName,(CondTree ConfVar [Dependency] Executable))]
+condExecutables f s = fmap (\x -> s { T.condExecutables = x }) (f (T.condExecutables s))
+{-# INLINE condExecutables #-}
+
+condTestSuites :: Lens' PackageSourceDescription [(UnqualComponentName,(CondTree ConfVar [Dependency] TestSuite))]
+condTestSuites f s = fmap (\x -> s { T.condTestSuites = x }) (f (T.condTestSuites s))
+{-# INLINE condTestSuites #-}
+
+condBenchmarks :: Lens' PackageSourceDescription [(UnqualComponentName,(CondTree ConfVar [Dependency] Benchmark))]
+condBenchmarks f s = fmap (\x -> s { T.condBenchmarks = x }) (f (T.condBenchmarks s))
+{-# INLINE condBenchmarks #-}
+
+allCondTrees
+  :: Applicative f
+  => (forall a. CondTree ConfVar [Dependency] a
+          -> f (CondTree ConfVar [Dependency] a))
+  -> PackageSourceDescription
+  -> f PackageSourceDescription
+allCondTrees f (PackageSourceDescription p a1 x1 x2 x3 x4 x5 x6 x7) =
+    PackageSourceDescription
+        <$> pure p
+        <*> pure a1
+        <*> (traverse . _2) f x1
+        <*> traverse f x2
+        <*> (traverse . _2) f x3
+        <*> (traverse . _2) f x4
+        <*> (traverse . _2) f x5
+        <*> (traverse . _2) f x6
+        <*> (traverse . _2) f x7
+
+
+-------------------------------------------------------------------------------
+-- Flag
+-------------------------------------------------------------------------------
+
+flagName :: Lens' Flag FlagName
+flagName f (MkFlag x1 x2 x3 x4) = fmap (\y1 -> MkFlag y1 x2 x3 x4) (f x1)
+{-# INLINE flagName #-}
+
+flagDescription :: Lens' Flag String
+flagDescription f (MkFlag x1 x2 x3 x4) = fmap (\y1 -> MkFlag x1 y1 x3 x4) (f x2)
+{-# INLINE flagDescription #-}
+
+flagDefault :: Lens' Flag Bool
+flagDefault f (MkFlag x1 x2 x3 x4) = fmap (\y1 -> MkFlag x1 x2 y1 x4) (f x3)
+{-# INLINE flagDefault #-}
+
+flagManual :: Lens' Flag Bool
+flagManual f (MkFlag x1 x2 x3 x4) = fmap (\y1 -> MkFlag x1 x2 x3 y1) (f x4)
+{-# INLINE flagManual #-}
+
+-------------------------------------------------------------------------------
+-- ConfVar
+-------------------------------------------------------------------------------
+
+_OS :: Traversal' ConfVar OS
+_OS f (OS os) = OS <$> f os
+_OS _ x       = pure x
+
+_Arch :: Traversal' ConfVar Arch
+_Arch f (Arch arch) = Arch <$> f arch
+_Arch _ x           = pure x
+
+_Flag :: Traversal' ConfVar FlagName
+_Flag f (Flag flag) = Flag <$> f flag
+_Flag _ x           = pure x
+
+_Impl :: Traversal' ConfVar (CompilerFlavor, VersionRange)
+_Impl f (Impl cf vr) = uncurry Impl <$> f (cf, vr)
+_Impl _ x            = pure x

--- a/Cabal/Distribution/Types/TestSuite.hs
+++ b/Cabal/Distribution/Types/TestSuite.hs
@@ -13,6 +13,7 @@ import Prelude ()
 import Distribution.Compat.Prelude
 
 import Distribution.Types.BuildInfo
+import Distribution.Types.CommonStanzaImports
 import Distribution.Types.TestType
 import Distribution.Types.TestSuiteInterface
 import Distribution.Types.UnqualComponentName
@@ -20,15 +21,20 @@ import Distribution.Types.UnqualComponentName
 import Distribution.ModuleName
 
 import qualified Distribution.Types.BuildInfo.Lens as L
+import qualified Distribution.Types.CommonStanzaImports.Lens as L
 
 -- | A \"test-suite\" stanza in a cabal file.
 --
 data TestSuite = TestSuite {
         testName      :: UnqualComponentName,
+        testImports   :: CommonStanzaImports,
         testInterface :: TestSuiteInterface,
         testBuildInfo :: BuildInfo
     }
     deriving (Generic, Show, Read, Eq, Typeable, Data)
+
+instance L.HasCommonStanzaImports TestSuite where
+    commonStanzaImports f l = (\x -> l { testImports = x }) <$> f (testImports l)
 
 instance L.HasBuildInfo TestSuite where
     buildInfo f l = (\x -> l { testBuildInfo = x }) <$> f (testBuildInfo l)
@@ -41,6 +47,7 @@ instance NFData TestSuite where rnf = genericRnf
 instance Monoid TestSuite where
     mempty = TestSuite {
         testName      = mempty,
+        testImports   = mempty,
         testInterface = mempty,
         testBuildInfo = mempty
     }
@@ -49,6 +56,7 @@ instance Monoid TestSuite where
 instance Semigroup TestSuite where
     a <> b = TestSuite {
         testName      = combine' testName,
+        testImports   = combine  testImports,
         testInterface = combine  testInterface,
         testBuildInfo = combine  testBuildInfo
     }

--- a/Cabal/Distribution/Types/TestSuite/Lens.hs
+++ b/Cabal/Distribution/Types/TestSuite/Lens.hs
@@ -8,6 +8,7 @@ import Distribution.Compat.Prelude
 import Prelude ()
 
 import Distribution.Types.BuildInfo           (BuildInfo)
+import Distribution.Types.CommonStanzaImports (CommonStanzaImports)
 import Distribution.Types.TestSuite           (TestSuite)
 import Distribution.Types.TestSuiteInterface  (TestSuiteInterface)
 import Distribution.Types.UnqualComponentName (UnqualComponentName)
@@ -17,6 +18,10 @@ import qualified Distribution.Types.TestSuite as T
 testName :: Lens' TestSuite UnqualComponentName
 testName f s = fmap (\x -> s { T.testName = x }) (f (T.testName s))
 {-# INLINE testName #-}
+
+testImports :: Lens' TestSuite CommonStanzaImports
+testImports f s = fmap (\x -> s { T.testImports = x }) (f (T.testImports s))
+{-# INLINE testImports #-}
 
 testInterface :: Lens' TestSuite TestSuiteInterface
 testInterface f s = fmap (\x -> s { T.testInterface = x }) (f (T.testInterface s))

--- a/Cabal/tests/Instances/TreeDiff.hs
+++ b/Cabal/tests/Instances/TreeDiff.hs
@@ -22,6 +22,8 @@ import Distribution.ModuleName                (ModuleName)
 import Distribution.Package                   (Dependency, PackageIdentifier, PackageName)
 import Distribution.PackageDescription
 import Distribution.Types.AbiHash             (AbiHash)
+import Distribution.Types.CommonStanza
+import Distribution.Types.CommonStanzaImports
 import Distribution.Types.ComponentId         (ComponentId)
 import Distribution.Types.CondTree
 import Distribution.Types.ExecutableScope
@@ -55,6 +57,8 @@ instance ToExpr BenchmarkInterface
 instance ToExpr BenchmarkType
 instance ToExpr BuildInfo
 instance ToExpr BuildType
+instance ToExpr CommonStanza
+instance ToExpr CommonStanzaImports
 instance ToExpr CompilerFlavor
 instance ToExpr ComponentId where toExpr = defaultExprViaShow
 instance ToExpr DefUnitId

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -150,6 +150,10 @@ import Distribution.PackageDescription
          ( BuildType(..), Executable(..), buildable )
 import Distribution.PackageDescription.Parsec ( readGenericPackageDescription )
 
+import Distribution.PackageDescription.PackageSourceDescriptionParser
+         ( readPackageSourceDescription)
+import Distribution.PackageDescription.PackageSourceDescriptionPrettyPrint
+         ( writePackageSourceDescription)
 import Distribution.PackageDescription.PrettyPrint
          ( writeGenericPackageDescription )
 import qualified Distribution.Simple as Simple
@@ -1034,9 +1038,9 @@ formatAction verbosityFlag extraArgs _globalFlags = do
     [] -> do cwd <- getCurrentDirectory
              tryFindPackageDesc verbosity cwd
     (p:_) -> return p
-  pkgDesc <- readGenericPackageDescription verbosity path
+  pkgDesc <- readPackageSourceDescription verbosity path
   -- Uses 'writeFileAtomic' under the hood.
-  writeGenericPackageDescription path pkgDesc
+  writePackageSourceDescription path pkgDesc
 
 uninstallAction :: Flag Verbosity -> [String] -> Action
 uninstallAction verbosityFlag extraArgs _globalFlags = do


### PR DESCRIPTION
> **NOTE:** This is a work in progress, looking for input on direction/structuring (see Open Questions below).

**TL;DR;** Don't perform all simplification steps _during_ parsing, do them as a follow-up transformation.



## Why

- Allows `cabal format` to maintain key pieces of source code (common stanzas for example #5734)

- Separation of concerns; simplifies parser logic (no longer need to strange `FromBuildInfo` typeclass while parsing)

## How

- Create a source representation in the AST (`PackageSourceDescription`) for common stanza sections (`CommonStanza`) and for `import` directives within sections (`CommonStanzaImports`).

- Don't perform inlining of sections during parsing, leave that to another step. The transformation from `PackageSourceDescription` is not yet implemented, but should be pretty trivial.

Another alternative is to update `GenericPackageDescription` in place, but I thought it may be useful (if not more code) to have a separate representation. May be too complicated but we could look at the "trees that grow" approach that is used in GHC as well.


> **NOTE:** For simplicity I forked the code from GenericPackageDescription instead of modifying in place to keep things separate, so there's a lot of duplication right now. We'll likely want to refactor several modules as pre-steps to this. 

> **NOTE:** Ignore the `HasCommonStanzaImports` typeclass, that's an artifact from another approach I took and isn't used currently.

## Testing

I've updated the `cabal format` command to round trip thorough `PackageSourceDescription` instead of `GenericPackageDescription` and it appears to work for all the common cases I've tested (including `common` stanzas that `import` other common stanzas).

## Open Questions

1) What's up with `PackageDescription` and `GenericPackageDescription`? Why do they both exist? Historical reasons or separate concerns?

2) Currently I've added a `CommonStanzaImports` field to each of the section types that can have a common stanza, this results in having to insert `mempty`s in places where these sections are created manually (and thus will never have `import`s). A more principled way would be to create separate types for `ExecutableSource`, `LibrarySource` etc. which has the `CommonStanzaImports` fields, and leave the existing section types used in GenericPackageDescription unchanged.

3) As a first step should we keep this separate from the `GenericPackageDescription` parser and just use it for `cabal format`?

4) Is there good test coverage for parsing to `GenericPackageDescription`? In other words, if I replace the `String -> GenericPackageDescription` parser with a `String -> PackageSourceDescription` parser and then a separate `PackageSourceDescription -> GenericPackageDescription` transform, how confident can I be that it works?

/cc @phadej @gbaz 

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
