### PR TITLE
Use default install directory if not specified.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -26,6 +26,7 @@ module Distribution.Client.Config (
     defaultConfigFile,
     defaultCacheDir,
     defaultCompiler,
+    defaultInstallPath,
     defaultLogsDir,
     defaultUserInstall,
 


### PR DESCRIPTION
Cabal 3.0.0.0 added the `--installdir` option to specify the location that binaries should be installed in. Running a `cabal user-config update` would populate the config file with the default value, but the `cabal install` program would error if it wasn't set. This change uses the default value that would be written to the config if its unset, and outputs a warning.

Previous error:
```
cabal: installdir is not defined. Set it in your cabal config file or use
--installdir=<path>
```

New warning (install succeds):
```
Warning: installdir is not defined. Set it in your cabal config file or use
--installdir=<path>. Using default installdir: "/path/to/the/default/installdir/bin"

```

This resolves #5973  

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!

/cc @phadej @fgaz 