### PR TITLE
Changelog.d

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,43 +1,41 @@
-# 3.2.0.0 [Someone](mailto:somewhere@example.com) February 2020
-  * `cabal check` verifies `cpp-options` more pedantically, allowing only
-    options starting with `-D` and `-U`.
-  * Don’t rebuild world when new ghc flags that affect how error
-    messages are presented is specified.
-  * Fix multilib build-depends parsing (#5846)
+# 3.2.0.0 [Herbert Valerio Riedel](mailto:hvr@gnu.org) April 2020
   * Change free text `String` fields to use `ShortText` in package description
     and installed packge info.
   * Split `Distribution.Types.Flag` and `Distribution.Types.ConfVar`
-    `Distribution.Types.GenericPackageDescription`
+    `Distribution.Types.GenericPackageDescription`.
   * Add GHC-8.10 support, including new extensions to
-    `Language.Haskell.Extension`
-  * Use more `NonEmpty` instead of ordinary lists
-  * Add `Distribution.Utils.Structured` for fingeprinting `Binary` blobs
-  * Add `null`, `length` and `unsafeFromUTF8BS` to `Distribution.Utils.ShortText`
-  * Refactor `Distribution.Utils.IOData` module
-  * Rename `Distribution.Compat.MD5` to `Distribution.Utils.MD5`
-  * Add `safeHead`, `safeTail`, `safeLast` to `Distribution.Utils.Generic`
-  * Add `unsnoc` and `unsnocNE` to `Distribution.Utils.Generic`
-  * Add `Set'` modifier to `Distribution.Parsec.Newtypes`
-  * Add `Distribution.Compat.Async`
-  * Add `Distribution.Compat.Process` with `enableProcessJobs`
-  * Disallow spaces around colon `:` in Dependency (`build-depends` syntax
-  * Make `configure` accept any `pkg-config --modversion` output
+    `Language.Haskell.Extension`.
+  * Use more `NonEmpty` instead of ordinary lists.
+  * Add `Distribution.Utils.Structured` for fingeprinting `Binary` blobs.
+  * Add `null`, `length` and `unsafeFromUTF8BS` to `Distribution.Utils.ShortText`.
+  * Refactor `Distribution.Utils.IOData` module.
+  * Rename `Distribution.Compat.MD5` to `Distribution.Utils.MD5`.
+  * Add `safeHead`, `safeTail`, `safeLast` to `Distribution.Utils.Generic`.
+  * Add `unsnoc` and `unsnocNE` to `Distribution.Utils.Generic`.
+  * Add `Set'` modifier to `Distribution.Parsec.Newtypes`.
+  * Add `Distribution.Compat.Async`.
 
-# 3.0.1.0 TBW
-  * Add GHC-8.8 flags to normaliseGhcFlags
-    ([#6379](https://github.com/haskell/cabal/pull/6379))
+# 3.0.2.0 [Herbert Valerio Riedel](mailto:hvr@gnu.org) April 2020
+  * Disallow spaces around colon `:` in Dependency `build-depends` syntax
+    ([#6538](https://github.com/haskell/cabal/pull/6538)).
+  * Make `configure` accept any `pkg-config --modversion` output
+    ([#6541](https://github.com/haskell/cabal/pull/6541)).
+
+# 3.0.1.0 [Herbert Valerio Riedel](mailto:hvr@gnu.org) April 2020
+  * Add GHC-8.8 flags to `normaliseGhcFlags`
+    ([#6379](https://github.com/haskell/cabal/pull/6379)).
   * Typo fixes
-    ([#6372](https://github.com/haskell/cabal/pull/6372))
+    ([#6372](https://github.com/haskell/cabal/pull/6372)).
   * Limit version number parts to contain at most 9 digits
-    ([#6386](https://github.com/haskell/cabal/pull/6386)
+    ([#6386](https://github.com/haskell/cabal/pull/6386)).
   * Fix boundless sublibrary depedency parse failure
-    ([#5846](https://github.com/haskell/cabal/issues/5846))
+    ([#5846](https://github.com/haskell/cabal/issues/5846)).
   * `cabal check` verifies `cpp-options` more pedantically, allowing only
     options starting with `-D` and `-U`.
   * Don’t rebuild world when new ghc flags that affect how error
     messages are presented is specified.
   * Fix dropExeExtension behaviour on Windows
-    ([#6287](https://github.com/haskell/cabal/pull/6287)
+    ([#6287](https://github.com/haskell/cabal/pull/6287)).
 
 # 3.0.0.0 [Mikhail Glushenkov](mailto:mikhail.glushenkov@gmail.com) August 2019
   * The 3.0 migration guide gives advice on adapting Custom setup

--- a/cabal-install/changelog
+++ b/cabal-install/changelog
@@ -1,6 +1,6 @@
 -*-change-log-*-
 
-3.2.0.0 Someone <mailto:somewhere@example.com> February 2020
+3.2.0.0 Herbert Valerio Riedel <hvr@gnu.org> April 2020
 	* `v2-build` (and other `v2-`prefixed commands) now accept the
 	  `--benchmark-option(s)` flags, which pass options to benchmark executables
 	  (analogous to how `--test-option(s)` works). (#6209)
@@ -17,7 +17,7 @@
 	* `cabal v2-run` works with `.lhs` files (#6134)
 	* `subdir` in source-repository-package accepts multiple entries (#5472)
 
-3.0.1.0 TBW December 2019
+3.0.1.0 Herbert Valerio Riedel <hvr@gnu.org> April 2020
 	* Create store incoming directory
 	  ([#4130](https://github.com/haskell/cabal/issues/4130))
 	* `fetchRepoTarball` output is not marked
@@ -34,7 +34,6 @@
 	* Use `hackage-security-0.6`
 	  ([#6388](https://github.com/haskell/cabal/pull/6388))
 	* Other dependency upgrades
-	* On windows use copy as the default install method for executables
 
 3.0.0.0 Mikhail Glushenkov <mikhail.glushenkov@gmail.com> August 2019
 	* `v2-haddock` fails on `haddock` failures (#5977)

--- a/changelog.d/cabal-init
+++ b/changelog.d/cabal-init
@@ -1,0 +1,2 @@
+synopsis: `cabal init` defaults to `cabal-version: 2.4`
+prs: #6607

--- a/changelog.d/config
+++ b/changelog.d/config
@@ -1,0 +1,2 @@
+organization: haskell
+repository:   cabal

--- a/changelog.d/documentation
+++ b/changelog.d/documentation
@@ -1,0 +1,2 @@
+synopsis: Documentation updates
+prs: #6613

--- a/changelog.d/index-state
+++ b/changelog.d/index-state
@@ -1,0 +1,3 @@
+synopsis: More rich `index-state` syntax. `v2-freeze` saves `index-state`.
+packages: cabal-install
+prs: #6596 #6581 #6597

--- a/changelog.d/install-sha256
+++ b/changelog.d/install-sha256
@@ -1,0 +1,3 @@
+synopsis: Check sha256 if `#sha256=...` fragments are given to URIs
+packages: cabal-install
+prs: #6576

--- a/changelog.d/issue-6210
+++ b/changelog.d/issue-6210
@@ -1,0 +1,3 @@
+synopsis: Default to 'NoReports' for remote build reporting
+issues: #6210
+prs: #6625

--- a/changelog.d/issue-6369
+++ b/changelog.d/issue-6369
@@ -1,0 +1,4 @@
+synopsis: Allow cabal v2-install pkgname:exename
+packages: cabal-install
+prs: #6576
+issues: #6369

--- a/changelog.d/issue-6393
+++ b/changelog.d/issue-6393
@@ -1,0 +1,4 @@
+synopsis: Allow cabal v2-install http://
+packages: cabal-install
+prs: #6576
+issues: #6393

--- a/changelog.d/issue-6432
+++ b/changelog.d/issue-6432
@@ -1,0 +1,4 @@
+synopsis: Split `KnownRepoType` out of `RepoType`
+packages: Cabal
+issues: #6432
+prs: #6612

--- a/changelog.d/issue-6575
+++ b/changelog.d/issue-6575
@@ -1,0 +1,4 @@
+synopsis: cabal v2-install prints copy/symlink destination
+packages: cabal-install
+prs: #6582 #6890
+issues: #6575

--- a/changelog.d/others
+++ b/changelog.d/others
@@ -1,0 +1,1 @@
+synopsis: other changes

--- a/changelog.d/public-libs
+++ b/changelog.d/public-libs
@@ -1,0 +1,2 @@
+synopsis: Mark public-libs as experimental feature
+prs: #6605

--- a/changelog.d/utf8
+++ b/changelog.d/utf8
@@ -1,0 +1,3 @@
+synopsis: Better UTF8 handling, parsed ShortText should be valid now
+packages: Cabal
+prs: #6588


### PR DESCRIPTION
Since 3.2 we have done at least:

- `cabal init` defaults to `cabal-version: 2.4` [#6607](https://github.com/haskell/cabal/pull/6607)
- Documentation updates [#6613](https://github.com/haskell/cabal/pull/6613)
- *cabal-install* More rich `index-state` syntax. `v2-freeze` saves `index-state`. [#6581](https://github.com/haskell/cabal/pull/6581) [#6596](https://github.com/haskell/cabal/pull/6596) [#6597](https://github.com/haskell/cabal/pull/6597)
- *cabal-install* Check sha256 if `#sha256=...` fragments are given to URIs [#6576](https://github.com/haskell/cabal/pull/6576)
- Default to 'NoReports' for remote build reporting [#6210](https://github.com/haskell/cabal/issues/6210) [#6625](https://github.com/haskell/cabal/pull/6625)
- *cabal-install* Allow cabal v2-install pkgname:exename [#6369](https://github.com/haskell/cabal/issues/6369) [#6576](https://github.com/haskell/cabal/pull/6576)
- *cabal-install* Allow cabal v2-install http:// [#6393](https://github.com/haskell/cabal/issues/6393) [#6576](https://github.com/haskell/cabal/pull/6576)
- *Cabal* Split `KnownRepoType` out of `RepoType` [#6432](https://github.com/haskell/cabal/issues/6432) [#6612](https://github.com/haskell/cabal/pull/6612)
- *cabal-install* cabal v2-install prints copy/symlink destination [#6575](https://github.com/haskell/cabal/issues/6575) [#6582](https://github.com/haskell/cabal/pull/6582) [#6890](https://github.com/haskell/cabal/pull/6890)
- other changes
- Mark public-libs as experimental feature [#6605](https://github.com/haskell/cabal/pull/6605)
- *Cabal* Better UTF8 handling, parsed ShortText should be valid now [#6588](https://github.com/haskell/cabal/pull/6588)
