### PR TITLE
Add .readthedocs.yml config file and pin to Python v2.7.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,7 @@
+version: 2
+
+sphinx:
+  configuration: Cabal/doc/conf.py
+
+python:
+  version: 2.7


### PR DESCRIPTION
At some point ReadTheDocs switched the default Python version from 2.7 to 3.7 causing all Cabal user guide docs to no longer build. The error surfaces as:

```
  File "/home/docs/checkouts/readthedocs.org/user_builds/m-renaud-haskell-cabal/checkouts/mrenaud-docs-getting-started/Cabal/doc/cabaldomain.py", line 153
    sig = re.sub(ur'<([-a-zA-Z ]+)>', ur'⟨\1⟩', sig)
```

This PR adds a config file which pins to python 2.7, we really should just update cabaldomain.py to be compatible with Python 3.7, but that's for another day.

Verified this branch builds at: https://readthedocs.org/projects/m-renaud-haskell-cabal/builds/10780554/ (not sure if this is publicly visible or not).

Edit: after looking at https://readthedocs.org/projects/cabal/builds/, it appears the docs have built successfully, maybe there's some config in the admin panel :/ In any case, this is the more programmatic way to pin the version.

