### PR TITLE
Default cabal init application-dir to app, and source-dir to src.

### DIFF
--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -851,8 +851,8 @@ commentSavedConfig = do
             IT.cabalVersion    = toFlag IT.defaultCabalVersion,
             IT.language        = toFlag Haskell2010,
             IT.license         = NoFlag,
-            IT.sourceDirs      = Nothing,
-            IT.applicationDirs = Nothing
+            IT.sourceDirs      = Just [IT.defaultSourceDir],
+            IT.applicationDirs = Just [IT.defaultApplicationDir]
             },
         savedInstallFlags      = defaultInstallFlags,
         savedClientInstallFlags= defaultClientInstallFlags,

--- a/cabal-install/Distribution/Client/Init/Defaults.hs
+++ b/cabal-install/Distribution/Client/Init/Defaults.hs
@@ -13,7 +13,9 @@
 -----------------------------------------------------------------------------
 
 module Distribution.Client.Init.Defaults (
-    defaultCabalVersion
+    defaultApplicationDir
+  , defaultSourceDir
+  , defaultCabalVersion
   , myLibModule
   ) where
 
@@ -23,6 +25,12 @@ import qualified Distribution.ModuleName as ModuleName
   ( fromString )
 import Distribution.CabalSpecVersion
   ( CabalSpecVersion (..))
+
+defaultApplicationDir :: String
+defaultApplicationDir = "app"
+
+defaultSourceDir :: String
+defaultSourceDir = "src"
 
 defaultCabalVersion :: CabalSpecVersion
 defaultCabalVersion = CabalSpecV2_4

--- a/cabal-install/Distribution/Client/Init/Prompt.hs
+++ b/cabal-install/Distribution/Client/Init/Prompt.hs
@@ -20,7 +20,6 @@ module Distribution.Client.Init.Prompt (
   , promptStr
   , promptList
   , promptListOptional
-  , promptListOptional'
   , maybePrompt
   ) where
 

--- a/changelog.d/cabal-init
+++ b/changelog.d/cabal-init
@@ -8,6 +8,7 @@ description: {
 - Licenses are always asked using SPDX expression
 - Fix an infinite loop when invalid license was passed on command line
 - `Setup.hs` is not written anymore
+- Default to --source-dir=src and --application-dir=app
 
 TODO: complete the description
 }


### PR DESCRIPTION
This sets the default directory for the main module as `app/` (`--application-dir=app`) and library source files as `src/` (`--source-dir=src`).

This avoids the problem described in #6150 of having a library and executable share the same `hs-source-dirs`. Even for just the executable case its best to have a separate directory because its likely that eventually code will be moved into internal libraries for testing (which should also have a separate `hs-source-dirs`).

Tested manually, both interactively and non-interactively.

This resolves #6150. 

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog.
* [x] The documentation has been updated, if necessary.
* [x] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
