### PR TITLE
Default to SPDX.NONE license in cabal init interactive mode.

### DIFF
--- a/cabal-install/Distribution/Client/Init/Command.hs
+++ b/cabal-install/Distribution/Client/Init/Command.hs
@@ -268,7 +268,7 @@ getVersion flags = do
 getLicense :: InitFlags -> IO InitFlags
 getLicense flags = do
   elic <- return (fmap Right $ flagToMaybe $ license flags)
-      ?>> maybePrompt flags (promptList "Please choose a license" listedLicenses Nothing prettyShow True)
+      ?>> maybePrompt flags (promptList "Please choose a license" listedLicenses (Just SPDX.NONE) prettyShow True)
 
   case elic of
       Nothing          -> return flags { license = NoFlag }


### PR DESCRIPTION
This resolves #6675.