### PR TITLE
Add FileCreators.generateCabalFile unit tests.

### DIFF
--- a/cabal-install/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/Distribution/Client/Init/FileCreators.hs
@@ -22,6 +22,9 @@ module Distribution.Client.Init.FileCreators (
   , createMainHs
   , createTestSuiteIfEligible
   , writeCabalFile
+
+  -- * For testing
+  , generateCabalFile
   ) where
 
 import Prelude ()

--- a/cabal-install/cabal-install.cabal.pp
+++ b/cabal-install/cabal-install.cabal.pp
@@ -475,6 +475,7 @@ Test-Suite unit-tests
     UnitTests.Distribution.Client.GenericInstances
     UnitTests.Distribution.Client.Glob
     UnitTests.Distribution.Client.GZipUtils
+    UnitTests.Distribution.Client.Init.FileCreators
     UnitTests.Distribution.Client.Sandbox
     UnitTests.Distribution.Client.Sandbox.Timestamp
     UnitTests.Distribution.Client.Store
@@ -515,6 +516,7 @@ Test-Suite unit-tests
         network-uri < 2.6.2.0,
         network,
         tasty >= 1.2.3 && <1.3,
+        tasty-golden >=2.3.1.1 && <2.4,
         tasty-hunit >= 0.10,
         tasty-quickcheck,
         tagged,

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -17,6 +17,7 @@ import qualified UnitTests.Distribution.Client.Described
 import qualified UnitTests.Distribution.Client.FileMonitor
 import qualified UnitTests.Distribution.Client.Glob
 import qualified UnitTests.Distribution.Client.GZipUtils
+import qualified UnitTests.Distribution.Client.Init.FileCreators
 import qualified UnitTests.Distribution.Client.Sandbox
 import qualified UnitTests.Distribution.Client.Sandbox.Timestamp
 import qualified UnitTests.Distribution.Client.Store
@@ -55,6 +56,8 @@ tests mtimeChangeCalibrated =
         UnitTests.Distribution.Client.Glob.tests
   , testGroup "Distribution.Client.GZipUtils"
        UnitTests.Distribution.Client.GZipUtils.tests
+  , testGroup "Distribution.Client.Init.FileCreators"
+       UnitTests.Distribution.Client.Init.FileCreators.tests
   , testGroup "Distribution.Client.Sandbox"
        UnitTests.Distribution.Client.Sandbox.tests
   , testGroup "Distribution.Client.Sandbox.Timestamp"
@@ -95,4 +98,3 @@ main = do
   defaultMainWithIngredients
          (includingOptions extraOptions : defaultIngredients)
          (tests mtimeChange')
-

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
@@ -1,0 +1,151 @@
+module UnitTests.Distribution.Client.Init.FileCreators (
+  tests
+  ) where
+
+import Distribution.Client.Init.FileCreators
+  ( generateCabalFile )
+
+import Test.Tasty
+import Test.Tasty.Golden (goldenVsString)
+
+import System.FilePath
+  ( (</>) )
+import qualified Data.ByteString.Lazy as BS
+import qualified Data.ByteString.Lazy.Char8 as BS8
+import qualified Data.Set as Set
+
+import Distribution.Client.Init.Types
+  ( InitFlags(..), PackageType(..), defaultInitFlags )
+import Distribution.Simple.Setup
+  ( Flag(..) )
+
+import Distribution.CabalSpecVersion
+  ( CabalSpecVersion(CabalSpecV2_4) )
+import Distribution.Types.Dependency
+  ( Dependency, mkDependency )
+import Distribution.Types.LibraryName
+  ( LibraryName(LMainLibName) )
+import Distribution.Types.PackageName
+  ( mkPackageName )
+import Distribution.Types.VersionRange
+  ( majorBoundVersion )
+import Distribution.Types.Version
+  ( mkVersion )
+import qualified Distribution.ModuleName as ModuleName
+  ( fromString )
+import qualified Distribution.SPDX as SPDX
+import Language.Haskell.Extension ( Language(..) )
+
+tests :: [TestTree]
+tests = [ testGroup "cabal init goldens"
+          [ checkCabalFileGolden exeFlags "exe-only-golden.cabal"
+          , checkCabalFileGolden libExeAndTestFlags "lib-exe-and-test-golden.cabal"
+          ]
+        ]
+
+checkCabalFileGolden :: InitFlags -> FilePath -> TestTree
+checkCabalFileGolden flags goldenFileName =
+  goldenVsString goldenFileName goldenFilePath generatedCabalFile
+  where
+    goldenFilePath :: FilePath
+    goldenFilePath = "tests" </> "fixtures" </> "init" </> goldenFileName
+
+    generatedCabalFile :: IO BS.ByteString
+    generatedCabalFile = pure . BS8.pack $ generateCabalFile goldenFileName flags
+
+-- ==================================================
+-- Base flags to set common InitFlags values.
+
+baseFlags :: InitFlags
+baseFlags = defaultInitFlags {
+  -- Values common to all (or most) test flags.
+    packageName = Flag (mkPackageName "foo")
+  , noComments = Flag False
+  , minimal = Flag True
+  , version = Flag (mkVersion [3,2,1])
+  , synopsis = Flag "The foo package"
+  , homepage = Flag "https://github.com/foo/foo"
+  , license = Flag SPDX.NONE
+  , author = Flag "me"
+  , email = Flag "me@me.me"
+  , category = Flag (Left "SomeCat")
+  , cabalVersion = Flag CabalSpecV2_4
+  , extraSrc = Just ["CHANGELOG.md"]
+  , interactive = Flag False
+  , otherModules = Nothing
+  , otherExts = Nothing
+  , language = Flag Haskell2010
+  , buildTools = Nothing
+  , dependencies = Just testDependencies
+  , quiet = Flag True
+  , packageDir = NoFlag
+  , simpleProject = Flag False
+  , initHcPath = NoFlag
+  , overwrite = NoFlag
+
+  -- Commonly overridden values in test InitFlags.
+  -- It is fine to provide the same value in an overridden InitFlags
+  -- to make it clear what that particular test case is differentiating
+  -- from others.
+  , packageType = Flag Executable
+  , mainIs = Flag "Main.hs"
+  , applicationDirs = Just ["app"]
+  , sourceDirs = Nothing
+  , exposedModules = Nothing
+  , initializeTestSuite = Flag False
+  , testDirs = Nothing
+  }
+
+
+-- ==================================================
+-- Simple exe.
+
+exeFlags :: InitFlags
+exeFlags = baseFlags {
+  -- Create an executable only, with main living in app/Main.hs.
+    packageType = Flag Executable
+  , mainIs = Flag "Main.hs"
+  , applicationDirs = Just ["app"]
+  }
+
+
+-- ==================================================
+-- Lib, exe, and test suite
+
+libExeAndTestFlags :: InitFlags
+libExeAndTestFlags = baseFlags {
+  -- Create a library and executable
+    packageType = Flag LibraryAndExecutable
+
+  -- Main living in app/Main.hs.
+  , mainIs = Flag "Main.hs"
+  , applicationDirs = Just ["app"]
+
+  -- Library sources live in src/ and expose the modules A and B.
+  , sourceDirs = Just ["src"]
+  , exposedModules = Just (map ModuleName.fromString ["A", "B"])
+
+  -- Create a test suite living in tests/
+  , initializeTestSuite = Flag True
+  , testDirs = Just ["tests"]
+  }
+
+
+-- ==================================================
+-- Test dependency.
+
+testDependencies :: [Dependency]
+testDependencies =
+  [ mkDependency
+      (mkPackageName "base")
+      (majorBoundVersion (mkVersion [4,13,0,0]))
+      (Set.singleton LMainLibName)
+  , mkDependency
+      (mkPackageName "containers")
+      (majorBoundVersion (mkVersion [5,7,0,0]))
+      (Set.singleton LMainLibName)
+  , mkDependency
+      (mkPackageName "unordered-containers")
+      (majorBoundVersion (mkVersion [2,7,0,0]))
+      (Set.singleton LMainLibName)
+  ]

--- a/tests/UnitTests/Distribution/Client/Init/goldens/generateCabalFile/exe-only.cabal
+++ b/tests/UnitTests/Distribution/Client/Init/goldens/generateCabalFile/exe-only.cabal
@@ -1,0 +1,16 @@
+cabal-version:       2.4
+name:                foo
+version:             3.2.1
+synopsis:            The foo package
+homepage:            https://github.com/foo/foo
+license:             NONE
+author:              me
+maintainer:          me@me.me
+category:            SomeCat
+extra-source-files:  CHANGELOG.md
+
+executable foo
+  main-is:             Main.hs
+  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
+  hs-source-dirs:      app
+  default-language:    Haskell2010

--- a/tests/UnitTests/Distribution/Client/Init/goldens/generateCabalFile/lib-exe-and-test.cabal
+++ b/tests/UnitTests/Distribution/Client/Init/goldens/generateCabalFile/lib-exe-and-test.cabal
@@ -1,0 +1,29 @@
+cabal-version:       2.4
+name:                foo
+version:             3.2.1
+synopsis:            The foo package
+homepage:            https://github.com/foo/foo
+license:             NONE
+author:              me
+maintainer:          me@me.me
+category:            SomeCat
+extra-source-files:  CHANGELOG.md
+
+library
+  exposed-modules:     A, B
+  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+
+executable foo
+  main-is:             Main.hs
+  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
+  hs-source-dirs:      app
+  default-language:    Haskell2010
+
+test-suite foo-test
+  default-language:    Haskell2010
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      tests
+  main-is:             MyLibTest.hs
+  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0

--- a/tests/fixtures/init/exe-only-golden.cabal
+++ b/tests/fixtures/init/exe-only-golden.cabal
@@ -1,0 +1,16 @@
+cabal-version:       2.4
+name:                foo
+version:             3.2.1
+synopsis:            The foo package
+homepage:            https://github.com/foo/foo
+license:             NONE
+author:              me
+maintainer:          me@me.me
+category:            SomeCat
+extra-source-files:  CHANGELOG.md
+
+executable foo
+  main-is:             Main.hs
+  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
+  hs-source-dirs:      app
+  default-language:    Haskell2010

--- a/tests/fixtures/init/lib-exe-and-test-golden.cabal
+++ b/tests/fixtures/init/lib-exe-and-test-golden.cabal
@@ -1,0 +1,29 @@
+cabal-version:       2.4
+name:                foo
+version:             3.2.1
+synopsis:            The foo package
+homepage:            https://github.com/foo/foo
+license:             NONE
+author:              me
+maintainer:          me@me.me
+category:            SomeCat
+extra-source-files:  CHANGELOG.md
+
+library
+  exposed-modules:     A, B
+  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+
+executable foo
+  main-is:             Main.hs
+  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
+  hs-source-dirs:      app
+  default-language:    Haskell2010
+
+test-suite foo-test
+  default-language:    Haskell2010
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      tests
+  main-is:             MyLibTest.hs
+  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0


### PR DESCRIPTION
I'll be switching `cabal init` to use `PrettyField` in an upcoming PR, this will make it easier to verify that the output remains approximately the same (modulo better formatting).
