### PR TITLE
Mention password-command option in upload --help

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -2201,7 +2201,7 @@ uploadCommand = CommandUI {
     commandDescription  = Nothing,
     commandNotes        = Just $ \_ ->
          "You can store your Hackage login in the ~/.cabal/config file\n"
-      ++ relevantConfigValuesText ["username", "password"],
+      ++ relevantConfigValuesText ["username", "password", "password-command"],
     commandUsage        = \pname ->
          "Usage: " ++ pname ++ " upload [FLAGS] TARFILES\n",
     commandDefaultFlags = defaultUploadFlags,

--- a/changelog.d/issue-5224
+++ b/changelog.d/issue-5224
@@ -1,0 +1,3 @@
+synopsis: `upload --help` now includes `password-command` as a config file option (#5224)
+issues: #5224
+prs: #6609 #6313 #6680


### PR DESCRIPTION
Fixes #5224, supersedes #6609 and #6313