### PR TITLE
Reduce cabal init field offset formatting by one space.

### DIFF
--- a/cabal-install/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/Distribution/Client/Init/FileCreators.hs
@@ -496,7 +496,7 @@ generateCabalFile fileName c = trimTrailingWS $
                         (False, _, _)     -> ($$ text "")
                       $
                       comment f <<>> text s <<>> colon
-                                <<>> text (replicate (20 - length s) ' ')
+                                <<>> text (replicate (19 - length s) ' ')
                                 <<>> text (fromMaybe "" . flagToMaybe $ f)
    comment NoFlag    = text "-- "
    comment (Flag "") = text "-- "

--- a/tests/fixtures/init/exe-only-golden.cabal
+++ b/tests/fixtures/init/exe-only-golden.cabal
@@ -1,16 +1,16 @@
-cabal-version:       2.4
-name:                foo
-version:             3.2.1
-synopsis:            The foo package
-homepage:            https://github.com/foo/foo
-license:             NONE
-author:              me
-maintainer:          me@me.me
-category:            SomeCat
-extra-source-files:  CHANGELOG.md
+cabal-version:      2.4
+name:               foo
+version:            3.2.1
+synopsis:           The foo package
+homepage:           https://github.com/foo/foo
+license:            NONE
+author:             me
+maintainer:         me@me.me
+category:           SomeCat
+extra-source-files: CHANGELOG.md
 
 executable foo
-  main-is:             Main.hs
-  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
-  hs-source-dirs:      app
-  default-language:    Haskell2010
+  main-is:            Main.hs
+  build-depends:      base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
+  hs-source-dirs:     app
+  default-language:   Haskell2010

--- a/tests/fixtures/init/lib-exe-and-test-golden.cabal
+++ b/tests/fixtures/init/lib-exe-and-test-golden.cabal
@@ -1,29 +1,29 @@
-cabal-version:       2.4
-name:                foo
-version:             3.2.1
-synopsis:            The foo package
-homepage:            https://github.com/foo/foo
-license:             NONE
-author:              me
-maintainer:          me@me.me
-category:            SomeCat
-extra-source-files:  CHANGELOG.md
+cabal-version:      2.4
+name:               foo
+version:            3.2.1
+synopsis:           The foo package
+homepage:           https://github.com/foo/foo
+license:            NONE
+author:             me
+maintainer:         me@me.me
+category:           SomeCat
+extra-source-files: CHANGELOG.md
 
 library
-  exposed-modules:     A, B
-  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
-  hs-source-dirs:      src
-  default-language:    Haskell2010
+  exposed-modules:    A, B
+  build-depends:      base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
+  hs-source-dirs:     src
+  default-language:   Haskell2010
 
 executable foo
-  main-is:             Main.hs
-  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
-  hs-source-dirs:      app
-  default-language:    Haskell2010
+  main-is:            Main.hs
+  build-depends:      base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
+  hs-source-dirs:     app
+  default-language:   Haskell2010
 
 test-suite foo-test
-  default-language:    Haskell2010
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      tests
-  main-is:             MyLibTest.hs
-  build-depends:       base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
+  default-language:   Haskell2010
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     tests
+  main-is:            MyLibTest.hs
+  build-depends:      base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0


### PR DESCRIPTION
This matches what is produced by PrettyField, so that when we switch over the
cabal file generation from manual formatting to PrettyField formatting we see
the true diffs and less field indent line noise.
