### PR TITLE
Add analytics to user guide.

### DIFF
--- a/Cabal/doc/_templates/layout.html
+++ b/Cabal/doc/_templates/layout.html
@@ -1,5 +1,18 @@
 {% extends "!layout.html" %}
 
+{%- block extrahead %}
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-42745779-5"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-42745779-5');
+  </script>
+{% endblock %}
+
+
 {% block menu %}
   {{ super() }}
   <a href="cabal-projectindex.html">Reference</a>


### PR DESCRIPTION
This uses Google Analytics to track site views and interactions.

## Benefits

- Determining which locales access the docs the most often
  - Benefit: Informs us if it would be useful to invest in an i18n version of the docs, and if so which languages
- Detecting dead links and duplicate pages, info missing from sitemap, etc.
  - Benefit: Improves SEO, letting users find what they're looking for more easily
- Bounce rate on individual pages to give insight into when users aren't finding what they're looking for on a page
  - Benefit: Informs us where attention should be focused in the existing docs
- Referrer
  - Benefits: Lets us determine if there's other locations that we want links to the docs to be visible, but is being missed (ex. we expect users to get to the user guide from https://www.haskell.org/cabal/, but we don't know if users are actually finding it on the page, so we could try out different placements and formats)