### PR TITLE
update --build-depends help string

### DIFF
--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -125,9 +125,9 @@ defaultEnvFlags = EnvFlags
 envOptions :: ShowOrParseArgs -> [OptionField EnvFlags]
 envOptions _ =
   [ option ['b'] ["build-depends"]
-    "Include an additional package in the environment presented to GHCi."
+    "Include additional packages in the environment presented to GHCi."
     envPackages (\p flags -> flags { envPackages = p ++ envPackages flags })
-    (reqArg "DEPENDENCY" dependencyReadE (fmap prettyShow :: [Dependency] -> [String]))
+    (reqArg "DEPENDENCIES" dependenciesReadE (fmap prettyShow :: [Dependency] -> [String]))
   , option [] ["no-transitive-deps"]
     "Don't automatically include transitive dependencies of requested packages."
     envIncludeTransitive (\p flags -> flags { envIncludeTransitive = p })
@@ -138,10 +138,10 @@ envOptions _ =
     trueArg
   ]
   where
-    dependencyReadE :: ReadE [Dependency]
-    dependencyReadE =
+    dependenciesReadE :: ReadE [Dependency]
+    dependenciesReadE =
       parsecToReadE
-        ("couldn't parse dependency: " ++)
+        ("couldn't parse dependencies: " ++)
         (parsecCommaList parsec)
 
 replCommand :: CommandUI ( ConfigFlags, ConfigExFlags, InstallFlags
@@ -621,4 +621,3 @@ explanationSingleComponentLimitation =
     "The reason for this limitation is that current versions of ghci do not "
  ++ "support loading multiple components as source. Load just one component "
  ++ "and when you make changes to a dependent component then quit and reload."
-


### PR DESCRIPTION
This PR updates the `--build-depends` help string in repl. Additionally, it looks like my extr-whitespace-stripping macro caught some extraneous whitespace in the file. If you want me to revert, just say so

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
