### PR TITLE
Add cabal init golden test exercising --libandexe behaviour.

### DIFF
--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
@@ -39,6 +39,7 @@ import Language.Haskell.Extension ( Language(..) )
 tests :: [TestTree]
 tests = [ testGroup "cabal init goldens"
           [ checkCabalFileGolden exeFlags "exe-only-golden.cabal"
+          , checkCabalFileGolden libAndExeFlags "lib-and-exe-golden.cabal"
           , checkCabalFileGolden libExeAndTestFlags "lib-exe-and-test-golden.cabal"
           ]
         ]
@@ -106,6 +107,29 @@ exeFlags = baseFlags {
     packageType = Flag Executable
   , mainIs = Flag "Main.hs"
   , applicationDirs = Just ["app"]
+  }
+
+
+-- ==================================================
+-- Simple lib and exe (as created by `cabal init --libandexe`).
+--
+-- Specifically, having 'exposedModules = Just ["MyLib"]' is a special
+-- case which results in the executable depending on the library from
+-- the same package, i.e. 'build-depends = foo' with no version
+-- constraints.
+
+libAndExeFlags :: InitFlags
+libAndExeFlags = baseFlags {
+  -- Create a library and executable
+    packageType = Flag LibraryAndExecutable
+
+  -- Main living in app/Main.hs.
+  , mainIs = Flag "Main.hs"
+  , applicationDirs = Just ["app"]
+
+  -- Library sources live in src/ and expose the module MyLib.
+  , sourceDirs = Just ["src"]
+  , exposedModules = Just (map ModuleName.fromString ["MyLib"])
   }
 
 

--- a/tests/fixtures/init/lib-and-exe-golden.cabal
+++ b/tests/fixtures/init/lib-and-exe-golden.cabal
@@ -1,0 +1,22 @@
+cabal-version:      2.4
+name:               foo
+version:            3.2.1
+synopsis:           The foo package
+homepage:           https://github.com/foo/foo
+license:            NONE
+author:             me
+maintainer:         me@me.me
+category:           SomeCat
+extra-source-files: CHANGELOG.md
+
+library
+  exposed-modules:    MyLib
+  build-depends:      base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0
+  hs-source-dirs:     src
+  default-language:   Haskell2010
+
+executable foo
+  main-is:            Main.hs
+  build-depends:      base ^>=4.13.0.0, containers ^>=5.7.0.0, unordered-containers ^>=2.7.0.0, foo
+  hs-source-dirs:     app
+  default-language:   Haskell2010


### PR DESCRIPTION
The key item captured in this test is that when `cabal init --libandexe` is run in an empty directory it will result in a dependency on the library from the executable in the form of `build-depends = <package-name>` but with no version constraints since they are implied by the version of the current package.
