### PR TITLE
GHC-8.10 support for 3.2

### DIFF
--- a/.docker/validate-8.10.1.dockerfile
+++ b/.docker/validate-8.10.1.dockerfile
@@ -1,0 +1,60 @@
+FROM    phadej/ghc:8.10.1-bionic
+
+# Install cabal-plan
+RUN     mkdir -p /root/.cabal/bin && \
+        curl -L https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz && \
+        echo "de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz" | sha256sum -c - && \
+        xz -d < cabal-plan.xz > /root/.cabal/bin/cabal-plan && \
+        rm -f cabal-plan.xz && \
+        chmod a+x /root/.cabal/bin/cabal-plan
+
+# Update index
+RUN     cabal v2-update
+
+# We install happy, so it's in the store; we (hopefully) don't use it directly.
+RUN     cabal v2-install happy --constraint 'happy ^>=1.19.12'
+
+# Install some other dependencies
+# Remove $HOME/.ghc so there aren't any environments
+RUN     cabal v2-install -w ghc-8.10.1 --lib \
+          aeson \
+          async \
+          base-compat \
+          base16-bytestring \
+          base64-bytestring \
+          cryptohash-sha256 \
+          Diff \
+          echo \
+          ed25519 \
+          edit-distance \
+          haskell-lexer \
+          HTTP \
+          network \
+          optparse-applicative \
+          pretty-show \
+          regex-compat-tdfa \
+          regex-tdfa \
+          statistics \
+          tar \
+          tasty \
+          tasty-golden \
+          tasty-hunit \
+          tasty-quickcheck \
+          tree-diff \
+          zlib \
+      --constraint="bytestring installed" \
+      --constraint="binary     installed" \
+      --constraint="containers installed" \
+      --constraint="deepseq    installed" \
+      --constraint="directory  installed" \
+      --constraint="filepath   installed" \
+      --constraint="pretty     installed" \
+      --constraint="process    installed" \
+      --constraint="time       installed" \
+      --constraint="unix       installed" \
+        && rm -rf $HOME/.ghc
+
+# Validate
+WORKDIR /build
+COPY    . /build
+RUN     sh ./validate.sh -w ghc-8.10.1 -v

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -25,7 +25,7 @@ jobs:
           echo "::add-path::$HOME/.cabal/bin"
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Release project
         run: |
           cp cabal.project.release cabal.project
@@ -71,7 +71,7 @@ jobs:
           echo "::add-path::$HOME/.cabal/bin"
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Release project
         run: |
           cp cabal.project.release cabal.project
@@ -115,7 +115,7 @@ jobs:
           cabal user-config init -a "http-transport: plain-http" -a "store-dir: C:\SR" -f -v3
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Release project
         shell: bash
         run: |

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set PATH
         run: |
           echo "::add-path::/opt/ghc/8.6.5/bin"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: bootstrap.sh
         env:
           EXTRA_CONFIGURE_OPTS: ""
@@ -53,7 +53,7 @@ jobs:
         run: |
           echo "::add-path::/opt/ghc/8.6.5/bin"
           echo "::add-path::$HOME/.cabal/bin"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: bootstrap.sh
         env:
           EXTRA_CONFIGURE_OPTS: ""

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,11 +19,12 @@ on:
       - created
 
 jobs:
-  validate-8_8_2:
-    name: validate.sh ghc-8.8.2
+  validate-8_10_1:
+    name: validate.sh ghc-8.10.1
     runs-on: ubuntu-18.04
+    needs: validate-8_8_3
     container:
-      image: phadej/ghc:8.8.2-bionic
+      image: phadej/ghc:8.10.1-bionic
     steps:
       # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
       - name: Set PATH
@@ -39,28 +40,34 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
       - name: Validate print-config
-        run: sh validate.sh -j 2 -w ghc-8.8.2 -v --solver-benchmarks -s print-config
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v  -s print-config
       - name: Validate print-tool-versions
-        run: sh validate.sh -j 2 -w ghc-8.8.2 -v --solver-benchmarks -s print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v  -s print-tool-versions
       - name: Validate make-cabal-install-dev
-        run: sh validate.sh -j 2 -w ghc-8.8.2 -v --solver-benchmarks -s make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v  -s make-cabal-install-dev
       - name: Validate build
-        run: sh validate.sh -j 2 -w ghc-8.8.2 -v --solver-benchmarks -s build
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v  -s build
       - name: Validate lib-tests
-        run: sh validate.sh -j 2 -w ghc-8.8.2 -v --solver-benchmarks -s lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v  -s lib-tests
       - name: Validate lib-suite
-        run: sh validate.sh -j 2 -w ghc-8.8.2 -v --solver-benchmarks -s lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v  -s lib-suite
       - name: Validate cli-tests
-        run: sh validate.sh -j 2 -w ghc-8.8.2 -v --solver-benchmarks -s cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v  -s cli-tests
       - name: Validate cli-suite
-        run: sh validate.sh -j 2 -w ghc-8.8.2 -v --solver-benchmarks -s cli-suite
-  validate-8_8_1:
-    name: validate.sh ghc-8.8.1
+        run: sh validate.sh -j 2 -w ghc-8.10.1 -v  -s cli-suite
+  validate-8_8_3:
+    name: validate.sh ghc-8.8.3
     runs-on: ubuntu-18.04
     container:
-      image: phadej/ghc:8.8.1-bionic
+      image: phadej/ghc:8.8.3-bionic
     steps:
       # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
       - name: Set PATH
@@ -76,27 +83,33 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
       - name: Validate print-config
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s print-config
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --solver-benchmarks -s print-config
       - name: Validate print-tool-versions
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --solver-benchmarks -s print-tool-versions
       - name: Validate make-cabal-install-dev
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --solver-benchmarks -s make-cabal-install-dev
       - name: Validate build
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s build
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --solver-benchmarks -s build
       - name: Validate lib-tests
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --solver-benchmarks -s lib-tests
       - name: Validate lib-suite
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --solver-benchmarks -s lib-suite
       - name: Validate cli-tests
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --solver-benchmarks -s cli-tests
       - name: Validate cli-suite
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --solver-benchmarks -s cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --solver-benchmarks -s cli-suite
   validate-8_6_5:
     name: validate.sh ghc-8.6.5
     runs-on: ubuntu-18.04
-    needs: validate-8_8_1
+    needs: validate-8_8_3
     container:
       image: phadej/ghc:8.6.5-bionic
     steps:
@@ -114,27 +127,33 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
       - name: Validate print-config
-        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s print-config
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v --complete-hackage-tests -s print-config
       - name: Validate print-tool-versions
-        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v --complete-hackage-tests -s print-tool-versions
       - name: Validate make-cabal-install-dev
-        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v --complete-hackage-tests -s make-cabal-install-dev
       - name: Validate build
-        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s build
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v --complete-hackage-tests -s build
       - name: Validate lib-tests
-        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v --complete-hackage-tests -s lib-tests
       - name: Validate lib-suite
-        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v --complete-hackage-tests -s lib-suite
       - name: Validate cli-tests
-        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v --complete-hackage-tests -s cli-tests
       - name: Validate cli-suite
-        run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.6.5 -v --complete-hackage-tests -s cli-suite
   validate-8_4_4:
     name: validate.sh ghc-8.4.4
     runs-on: ubuntu-18.04
-    needs: validate-8_8_1
+    needs: validate-8_8_3
     container:
       image: phadej/ghc:8.4.4-bionic
     steps:
@@ -152,7 +171,13 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
       - name: Validate print-config
         run: sh validate.sh -j 2 -w ghc-8.4.4 -v  -s print-config
       - name: Validate print-tool-versions
@@ -172,7 +197,7 @@ jobs:
   validate-8_2_2:
     name: validate.sh ghc-8.2.2
     runs-on: ubuntu-18.04
-    needs: validate-8_8_1
+    needs: validate-8_8_3
     container:
       image: phadej/ghc:8.2.2-bionic
     steps:
@@ -190,7 +215,13 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
       - name: Validate print-config
         run: sh validate.sh -j 2 -w ghc-8.2.2 -v  -s print-config
       - name: Validate print-tool-versions
@@ -210,7 +241,7 @@ jobs:
   validate-8_0_2:
     name: validate.sh ghc-8.0.2
     runs-on: ubuntu-18.04
-    needs: validate-8_8_1
+    needs: validate-8_8_3
     container:
       image: phadej/ghc:8.0.2-bionic
     steps:
@@ -228,7 +259,13 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
       - name: Validate print-config
         run: sh validate.sh -j 2 -w ghc-8.0.2 -v  -s print-config
       - name: Validate print-tool-versions
@@ -248,7 +285,7 @@ jobs:
   validate-7_10_3:
     name: validate.sh ghc-7.10.3
     runs-on: ubuntu-18.04
-    needs: validate-8_8_1
+    needs: validate-8_8_3
     container:
       image: phadej/ghc:7.10.3-bionic
     steps:
@@ -266,7 +303,13 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
       - name: Validate print-config
         run: sh validate.sh -j 2 -w ghc-7.10.3 -v  -s print-config
       - name: Validate print-tool-versions
@@ -286,7 +329,7 @@ jobs:
   validate-7_8_4:
     name: validate.sh ghc-7.8.4
     runs-on: ubuntu-18.04
-    needs: validate-8_8_1
+    needs: validate-8_8_3
     container:
       image: phadej/ghc:7.8.4-bionic
     steps:
@@ -304,7 +347,13 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
       - name: Validate print-config
         run: sh validate.sh -j 2 -w ghc-7.8.4 -v --lib-only -s print-config
       - name: Validate print-tool-versions
@@ -318,7 +367,7 @@ jobs:
   validate-7_6_3:
     name: validate.sh ghc-7.6.3
     runs-on: ubuntu-18.04
-    needs: validate-8_8_1
+    needs: validate-8_8_3
     container:
       image: phadej/ghc:7.6.3-xenial
     steps:
@@ -340,7 +389,13 @@ jobs:
         run: apt-get install -y ghc-7.6.3-dyn
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
       - name: Validate print-config
         run: sh validate.sh -j 2 -w ghc-7.6.3 -v --lib-only -s print-config
       - name: Validate print-tool-versions
@@ -351,12 +406,12 @@ jobs:
         run: sh validate.sh -j 2 -w ghc-7.6.3 -v --lib-only -s lib-tests
       - name: Validate lib-suite
         run: sh validate.sh -j 2 -w ghc-7.6.3 -v --lib-only -s lib-suite
-  validate-8_8_1-old:
+  validate-8_8_3-old:
     name: validate.sh old GHCs
     runs-on: ubuntu-18.04
-    needs: validate-8_8_1
+    needs: validate-8_8_3
     container:
-      image: phadej/ghc:8.8.1-xenial
+      image: phadej/ghc:8.8.3-xenial
     steps:
       # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#add-a-system-path-add-path
       - name: Set PATH
@@ -373,25 +428,31 @@ jobs:
       - name: apt-get update
         run: apt-get update
       - name: Install dynamic libraries
-        run: apt-get install -y ghc-8.8.1-dyn
+        run: apt-get install -y ghc-8.8.3-dyn
       - name: Install extra compilers
         run: apt-get install -y ghc-7.0.4-dyn ghc-7.2.2-dyn ghc-7.4.2-dyn
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
       - name: Validate print-config
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s print-config
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --lib-only -s print-config
       - name: Validate print-tool-versions
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --lib-only -s print-tool-versions
       - name: Validate build
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s build
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --lib-only -s build
       - name: Validate lib-tests
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --lib-only -s lib-tests
       - name: Validate lib-suite
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --lib-only -s lib-suite
       - name: Validate lib-suite-extras --extra-hc /opt/ghc/7.0.4/bin/ghc-7.0.4
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s lib-suite-extras --extra-hc /opt/ghc/7.0.4/bin/ghc-7.0.4
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --lib-only -s lib-suite-extras --extra-hc /opt/ghc/7.0.4/bin/ghc-7.0.4
       - name: Validate lib-suite-extras --extra-hc /opt/ghc/7.2.2/bin/ghc-7.2.2
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s lib-suite-extras --extra-hc /opt/ghc/7.2.2/bin/ghc-7.2.2
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --lib-only -s lib-suite-extras --extra-hc /opt/ghc/7.2.2/bin/ghc-7.2.2
       - name: Validate lib-suite-extras --extra-hc /opt/ghc/7.4.2/bin/ghc-7.4.2
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v --lib-only -s lib-suite-extras --extra-hc /opt/ghc/7.4.2/bin/ghc-7.4.2
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v --lib-only -s lib-suite-extras --extra-hc /opt/ghc/7.4.2/bin/ghc-7.4.2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,17 +19,20 @@ on:
       - created
 
 jobs:
-  validate-macos-8_8_1:
-    name: validate.sh ghc-8.8.1
+  validate-macos-8_8_3:
+    name: validate.sh macos ghc-8.8.3
     runs-on: macos-latest
     steps:
+      - name: Install Autotools
+        run: |
+          brew install automake
       - name: Install GHC
         run: |
           cd $(mktemp -d)
-          curl -sLO https://downloads.haskell.org/~ghc/8.8.1/ghc-8.8.1-x86_64-apple-darwin.tar.xz
+          curl -sLO https://downloads.haskell.org/~ghc/8.8.3/ghc-8.8.3-x86_64-apple-darwin.tar.xz
           tar -xJf ghc-*.tar.xz
           cd ghc-*
-          ./configure --prefix=/opt/ghc/8.8.1
+          ./configure --prefix=/opt/ghc/8.8.3
           sudo make install
       - name: Install Cabal
         run: |
@@ -41,7 +44,7 @@ jobs:
           sudo chmod 755 /opt/cabal/3.0/bin/cabal
       - name: Set PATH
         run: |
-          echo "::add-path::/opt/ghc/8.8.1/bin"
+          echo "::add-path::/opt/ghc/8.8.3/bin"
           echo "::add-path::/opt/cabal/3.0/bin"
           echo "::add-path::$HOME/.cabal/bin"
       - name: Update Hackage index
@@ -50,28 +53,31 @@ jobs:
         run: |
           cd $(mktemp -d)
           cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Validate print-config
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s print-config
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v  -s print-config
       - name: Validate print-tool-versions
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v  -s print-tool-versions
       - name: Validate make-cabal-install-dev
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s make-cabal-install-dev
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v  -s make-cabal-install-dev
       - name: Validate build
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s build
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v  -s build
       - name: Validate lib-tests
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v  -s lib-tests
       - name: Validate lib-suite
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v  -s lib-suite
       - name: Validate cli-tests
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v  -s cli-tests
       - name: Validate cli-suite
-        run: sh validate.sh -j 2 -w ghc-8.8.1 -v  -s cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.8.3 -v  -s cli-suite
   validate-macos-8_6_5:
-    name: validate.sh ghc-8.6.5
+    name: validate.sh macos ghc-8.6.5
     runs-on: macos-latest
-    needs: validate-macos-8_8_1
+    needs: validate-macos-8_8_3
     steps:
+      - name: Install Autotools
+        run: |
+          brew install automake
       - name: Install GHC
         run: |
           cd $(mktemp -d)
@@ -99,7 +105,7 @@ jobs:
         run: |
           cd $(mktemp -d)
           cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Validate print-config
         run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s print-config
       - name: Validate print-tool-versions

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -37,7 +37,7 @@ jobs:
         run: cabal v2-update
       - name: Install alex
         run: cabal v2-install alex
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Regenerate files
         run: |
           make lexer
@@ -78,6 +78,6 @@ jobs:
           cabal-env --transitive QuickCheck
           cabal-env array bytestring containers deepseq directory filepath pretty process time binary unix text parsec mtl
           cat $HOME/.ghc/*/environments/default
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Doctest
         run: make doctest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,13 +29,13 @@ jobs:
       - name: Install msys2
         run: choco install -y msys2
       - name: Install Cabal
-        run: choco install -y cabal --version 3.0.0.0
+        run: choco install -y cabal --version 3.2.0.0
       - name: Install GHC
         run: choco install -y ghc --version 8.6.5
       - name: Set PATH
         run: |
           [Environment]::GetEnvironmentVariable("Path")
-          Write-Host "::add-path::C:\ProgramData\chocolatey\lib\cabal\tools\cabal-3.0.0.0"
+          Write-Host "::add-path::C:\ProgramData\chocolatey\lib\cabal\tools\cabal-3.2.0.0"
           Write-Host "::add-path::C:\ProgramData\chocolatey\lib\ghc\tools\ghc-8.6.5\bin"
       - name: Print versions
         run: |
@@ -48,7 +48,7 @@ jobs:
           key: linux-store-meta
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: make cabal-install-dev
         run: runghc cabal-dev-scripts/src/Preprocessor.hs -o cabal-install/cabal-install.cabal -f CABAL_FLAG_LIB cabal-install/cabal-install.cabal.pp
       # We cannot ask for all dependencies, but we can for Cabal.
@@ -75,3 +75,114 @@ jobs:
       - name: cabal-tests
         # Using only one job, -j1, to fail less.
         run: cabal v2-run cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.6.5\cabal-install-3.2.0.0\x\cabal\build\cabal\cabal.exe
+  test-windows-8_8_3:
+    name: test ghc-8.8.3
+    runs-on: windows-latest
+    steps:
+      - name: Configure Chocolatey
+        run: choco source add -n mistuke -s https://www.myget.org/F/mistuke/api/v2
+      - name: Install msys2
+        run: choco install -y msys2
+      - name: Install Cabal
+        run: choco install -y cabal --version 3.2.0.0
+      - name: Install GHC
+        run: choco install -y ghc --version 8.8.3
+      - name: Set PATH
+        run: |
+          [Environment]::GetEnvironmentVariable("Path")
+          Write-Host "::add-path::C:\ProgramData\chocolatey\lib\cabal\tools\cabal-3.2.0.0"
+          Write-Host "::add-path::C:\ProgramData\chocolatey\lib\ghc\tools\ghc-8.8.3\bin"
+      - name: Print versions
+        run: |
+          ghc --version
+          cabal --version
+          cabal user-config init -a "http-transport: plain-http" -a "store-dir: C:\SR" -f -v3
+      - uses: actions/cache@v1
+        with:
+          path: C:\SR
+          key: linux-store-meta
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v2
+      - name: make cabal-install-dev
+        run: runghc cabal-dev-scripts/src/Preprocessor.hs -o cabal-install/cabal-install.cabal -f CABAL_FLAG_LIB cabal-install/cabal-install.cabal.pp
+      # We cannot ask for all dependencies, but we can for Cabal.
+      - name: cabal v2-build Cabal --only-dependencies
+        run: cabal v2-build Cabal --only-dependencies
+      - name: cabal v2-build
+        run: cabal v2-build all
+      - name: cabal-install memory-usage-tests
+        run: |
+          cd cabal-install
+          cabal v2-run cabal-install:memory-usage-tests
+      - name: cabal-install solver-quickcheck
+        run: |
+          cd cabal-install
+          cabal v2-run cabal-install:solver-quickcheck
+      - name: cabal-install integration-tests2
+        run: |
+          cd cabal-install
+          cabal v2-run cabal-install:integration-tests2
+      - name: cabal-install unit-tests
+        run: |
+          cd cabal-install
+          cabal v2-run cabal-install:unit-tests -- --pattern "! (/FileMonitor/ || /VCS/ || /Get/)"
+      - name: cabal-tests
+        # Using only one job, -j1, to fail less.
+        run: cabal v2-run cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.8.3\cabal-install-3.2.0.0\x\cabal\build\cabal\cabal.exe
+  test-windows-8_10_1:
+    name: test ghc-8.10.1
+    runs-on: windows-latest
+    needs: test-windows-8_8_3
+    steps:
+      - name: Configure Chocolatey
+        run: choco source add -n mistuke -s https://www.myget.org/F/mistuke/api/v2
+      - name: Install msys2
+        run: choco install -y msys2
+      - name: Install Cabal
+        run: choco install -y cabal --version 3.2.0.0
+      - name: Install GHC
+        run: choco install -y ghc --version 8.10.1
+      - name: Set PATH
+        run: |
+          [Environment]::GetEnvironmentVariable("Path")
+          Write-Host "::add-path::C:\ProgramData\chocolatey\lib\cabal\tools\cabal-3.2.0.0"
+          Write-Host "::add-path::C:\ProgramData\chocolatey\lib\ghc\tools\ghc-8.10.1\bin"
+      - name: Print versions
+        run: |
+          ghc --version
+          cabal --version
+          cabal user-config init -a "http-transport: plain-http" -a "store-dir: C:\SR" -f -v3
+      - uses: actions/cache@v1
+        with:
+          path: C:\SR
+          key: linux-store-meta
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v2
+      - name: make cabal-install-dev
+        run: runghc cabal-dev-scripts/src/Preprocessor.hs -o cabal-install/cabal-install.cabal -f CABAL_FLAG_LIB cabal-install/cabal-install.cabal.pp
+      # We cannot ask for all dependencies, but we can for Cabal.
+      - name: cabal v2-build Cabal --only-dependencies
+        run: cabal v2-build Cabal --only-dependencies
+      - name: cabal v2-build
+        run: cabal v2-build all
+      - name: cabal-install memory-usage-tests
+        run: |
+          cd cabal-install
+          cabal v2-run cabal-install:memory-usage-tests
+      - name: cabal-install solver-quickcheck
+        run: |
+          cd cabal-install
+          cabal v2-run cabal-install:solver-quickcheck
+      - name: cabal-install integration-tests2
+        run: |
+          cd cabal-install
+          cabal v2-run cabal-install:integration-tests2
+      - name: cabal-install unit-tests
+        run: |
+          cd cabal-install
+          cabal v2-run cabal-install:unit-tests -- --pattern "! (/FileMonitor/ || /VCS/ || /Get/)"
+      - name: cabal-tests
+        # Using only one job, -j1, to fail less.
+        run: cabal v2-run cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.10.1\cabal-install-3.2.0.0\x\cabal\build\cabal\cabal.exe

--- a/Cabal/Distribution/PackageDescription/Quirks.hs
+++ b/Cabal/Distribution/PackageDescription/Quirks.hs
@@ -250,7 +250,24 @@ patches = Map.fromList
          (Fingerprint 12475837388692175691 18053834261188158945)
          (Fingerprint 16279938253437334942 15753349540193002309)
          (bsReplace "9223372036854775807" "999")
-
+    -- Not UTF8
+    , mk "Name:                     nat\nVersion:                  0.1\nDescription:            Implementation of natural numbers and integers by a binary\n                                representation. The implementation is supposed to be lazy and\n                   "
+         (Fingerprint 9222512268705577108 13085311382746579495)
+         (Fingerprint 17468921266614378430 13221316288008291892)
+         (bsReplace "\xf6" "\xc3\xb6")
+    -- cabal-version: 2
+    , mk "name:                streaming-bracketed\nversion:             0.1.0.0\nsynopsis:            A resource management decorator for \"streaming\".        \ndescription:         This package provides a decorator for the Stream type from\n                     the \"st"
+         (Fingerprint 14670044663153191927 1427497586294143829)
+         (Fingerprint 9233007756654759985 6571998449003682006)
+         (bsReplace "cabal-version:       2" "cabal-version: 2.0")
+    , mk "name:                streaming-bracketed\nversion:             0.1.0.1\nsynopsis:            A resource management decorator for \"streaming\".        \ndescription:         This package provides a decorator for the Stream type from\n                     \"stream"
+         (Fingerprint 7298738862909203815 10141693276062967842)
+         (Fingerprint 1349949738792220441 3593683359695349293)
+         (bsReplace "cabal-version:       2" "cabal-version: 2.0")
+    , mk "name:           zsyntax\nversion:        0.2.0.0\ndescription:    An automated theorem prover for Zsyntax, a\n                logical calculus for molecular biology inspired by linear logic,\n                that can be used to automatically verify biological\n"
+         (Fingerprint 17812331267506881875 3005293725141563863)
+         (Fingerprint 3445957263137759540 12472369104312474458)
+         (bsReplace "cabal-version:  2" "cabal-version: 2.0")
     ]
   where
     mk a b c d = ((a, b), (c, d))

--- a/Makefile
+++ b/Makefile
@@ -160,5 +160,9 @@ validate-via-docker-8.6.5:
 validate-via-docker-8.8.1:
 	docker build -t cabal-validate -f .docker/validate-8.8.1.dockerfile .
 
+# Only library ATM
+validate-via-docker-8.10.1:
+	docker build -t cabal-validate -f .docker/validate-8.10.1.dockerfile .
+
 validate-via-docker-old:
 	docker build -t cabal-validate -f .docker/validate-old.dockerfile .

--- a/boot/ci-artifacts.template.yml
+++ b/boot/ci-artifacts.template.yml
@@ -25,7 +25,7 @@ jobs:
           echo "::add-path::$HOME/.cabal/bin"
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Release project
         run: |
           cp cabal.project.release cabal.project
@@ -71,7 +71,7 @@ jobs:
           echo "::add-path::$HOME/.cabal/bin"
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Release project
         run: |
           cp cabal.project.release cabal.project
@@ -115,7 +115,7 @@ jobs:
           cabal user-config init -a "http-transport: plain-http" -a "store-dir: C:\SR" -f -v3
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Release project
         shell: bash
         run: |

--- a/boot/ci-bootstrap.template.yml
+++ b/boot/ci-bootstrap.template.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set PATH
         run: |
           echo "::add-path::/opt/ghc/8.6.5/bin"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: bootstrap.sh
         env:
           EXTRA_CONFIGURE_OPTS: ""
@@ -53,7 +53,7 @@ jobs:
         run: |
           echo "::add-path::/opt/ghc/8.6.5/bin"
           echo "::add-path::$HOME/.cabal/bin"
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: bootstrap.sh
         env:
           EXTRA_CONFIGURE_OPTS: ""

--- a/boot/ci-linux.template.yml
+++ b/boot/ci-linux.template.yml
@@ -55,7 +55,13 @@ jobs:
 {% endif %}
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      # https://github.com/actions/checkout/issues/170
+      # - uses: actions/checkout@v2
+      - name: Checkout
+        run: |
+          git clone --depth 1 https://github.com/$GITHUB_REPOSITORY.git .
+          git fetch origin $GITHUB_REF:temporary-ci-branch
+          git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
 {% for step in job.steps %}
       - name: Validate {{step}}
         run: sh validate.sh -j 2 -w ghc-{{job.version}} -v {{job.flags}} -s {{step}}

--- a/boot/ci-macos.template.yml
+++ b/boot/ci-macos.template.yml
@@ -21,12 +21,15 @@ on:
 jobs:
 {% for job in macosJobs %}
   validate-macos-{{ mangleVersion job.version }}:
-    name: validate.sh ghc-{{job.version}}
+    name: validate.sh macos ghc-{{job.version}}
     runs-on: macos-latest
 {% for needs in job.needs %}
     needs: validate-macos-{{ mangleVersion needs }}
 {% endfor %}
     steps:
+      - name: Install Autotools
+        run: |
+          brew install automake
       - name: Install GHC
         run: |
           cd $(mktemp -d)
@@ -55,7 +58,7 @@ jobs:
           cd $(mktemp -d)
 {# aeson +fast, so we don't wait for -O2 #}
           cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 {% for step in job.steps %}
       - name: Validate {{step}}
         run: sh validate.sh -j 2 -w ghc-{{job.version}} -v {{job.flags}} -s {{step}}

--- a/boot/ci-quick-jobs.template.yml
+++ b/boot/ci-quick-jobs.template.yml
@@ -37,7 +37,7 @@ jobs:
         run: cabal v2-update
       - name: Install alex
         run: cabal v2-install alex
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Regenerate files
         run: |
           make lexer
@@ -78,6 +78,6 @@ jobs:
           cabal-env --transitive QuickCheck
           cabal-env array bytestring containers deepseq directory filepath pretty process time binary unix text parsec mtl
           cat $HOME/.ghc/*/environments/default
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Doctest
         run: make doctest

--- a/boot/ci-windows.template.yml
+++ b/boot/ci-windows.template.yml
@@ -36,13 +36,13 @@ jobs:
       - name: Install msys2
         run: choco install -y msys2
       - name: Install Cabal
-        run: choco install -y cabal --version 3.0.0.0
+        run: choco install -y cabal --version 3.2.0.0
       - name: Install GHC
-        run: choco install -y ghc --version 8.6.5
+        run: choco install -y ghc --version {{ job.version }}
       - name: Set PATH
         run: |
           [Environment]::GetEnvironmentVariable("Path")
-          Write-Host "::add-path::C:\ProgramData\chocolatey\lib\cabal\tools\cabal-3.0.0.0"
+          Write-Host "::add-path::C:\ProgramData\chocolatey\lib\cabal\tools\cabal-3.2.0.0"
           Write-Host "::add-path::C:\ProgramData\chocolatey\lib\ghc\tools\ghc-{{ job.version }}\bin"
       - name: Print versions
         run: |
@@ -55,7 +55,7 @@ jobs:
           key: linux-store-meta
       - name: Update Hackage index
         run: cabal v2-update
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: make cabal-install-dev
         run: runghc cabal-dev-scripts/src/Preprocessor.hs -o cabal-install/cabal-install.cabal -f CABAL_FLAG_LIB cabal-install/cabal-install.cabal.pp
       # We cannot ask for all dependencies, but we can for Cabal.

--- a/cabal-dev-scripts/src/GenValidate.hs
+++ b/cabal-dev-scripts/src/GenValidate.hs
@@ -3,15 +3,14 @@
 -- runghc -package-env=default Validate.hs validate.yml.zinza .github/workflows/validate.yml
 module Main (main) where
 
+import Data.List          (isPrefixOf)
 import GHC.Generics       (Generic)
 import System.Environment (getArgs)
 import System.Exit        (exitFailure)
-import Zinza
-       (Zinza (..), genericFromValueSFP, genericToTypeSFP, genericToValueSFP,
-       parseAndCompileTemplateIO)
+import Zinza              (Zinza (..), genericFromValueSFP, genericToTypeSFP, genericToValueSFP, parseAndCompileTemplateIO)
 
 import qualified Data.ByteString.Lazy.Char8 as LBS8
-import qualified Data.YAML             as YAML
+import qualified Data.YAML                  as YAML
 
 main :: IO ()
 main = do
@@ -22,16 +21,16 @@ main = do
             -- this shouldn't fail (run-time errors are due bugs in zinza)
             w <- run Z
                 { zJobs =
-                    [ GhcJob "8.8.2"  False "--solver-benchmarks" False [] defSteps
-                    , GhcJob "8.8.1"  False "--solver-benchmarks" False [] defSteps -- to be removed
-                    , GhcJob "8.6.5"  False ""                    False ["8.8.1"] defSteps
-                    , GhcJob "8.4.4"  False ""                    False ["8.8.1"] defSteps
-                    , GhcJob "8.2.2"  False ""                    False ["8.8.1"] defSteps
-                    , GhcJob "8.0.2"  False ""                    False ["8.8.1"] defSteps
-                    , GhcJob "7.10.3" False ""                    False ["8.8.1"] defSteps
-                    , GhcJob "7.8.4"  False "--lib-only"          False ["8.8.1"] libSteps
-                    , GhcJob "7.6.3"  True  "--lib-only"          False ["8.8.1"] libSteps
-                    , GhcJob "8.8.1"  True  "--lib-only"          True  ["8.8.1"] $
+                    [ GhcJob "8.10.1" False ""                          False ["8.8.3"] defSteps
+                    , GhcJob "8.8.3"  False "--solver-benchmarks"       False []        defSteps
+                    , GhcJob "8.6.5"  False "--complete-hackage-tests"  False ["8.8.3"] defSteps
+                    , GhcJob "8.4.4"  False ""                          False ["8.8.3"] defSteps
+                    , GhcJob "8.2.2"  False ""                          False ["8.8.3"] defSteps
+                    , GhcJob "8.0.2"  False ""                          False ["8.8.3"] defSteps
+                    , GhcJob "7.10.3" False ""                          False ["8.8.3"] defSteps
+                    , GhcJob "7.8.4"  False "--lib-only"                False ["8.8.3"] libSteps
+                    , GhcJob "7.6.3"  True  "--lib-only"                False ["8.8.3"] libSteps
+                    , GhcJob "8.8.3"  True  "--lib-only"                True  ["8.8.3"] $
                         libSteps ++
                         [ "lib-suite-extras --extra-hc /opt/ghc/7.0.4/bin/ghc-7.0.4"
                         , "lib-suite-extras --extra-hc /opt/ghc/7.2.2/bin/ghc-7.2.2"
@@ -39,7 +38,7 @@ main = do
                         ]
                     ]
                 , zMacosJobs =
-                    [ mkMacGhcJob "8.8.1" "https://downloads.haskell.org/~ghc/8.8.1/ghc-8.8.1-x86_64-apple-darwin.tar.xz"
+                    [ mkMacGhcJob "8.8.3" "https://downloads.haskell.org/~ghc/8.8.3/ghc-8.8.3-x86_64-apple-darwin.tar.xz"
                     , mkMacGhcJob "8.6.5" "https://downloads.haskell.org/~ghc/8.6.5/ghc-8.6.5-x86_64-apple-darwin.tar.xz"
                     ]
                 , zWinJobs =
@@ -49,6 +48,8 @@ main = do
                     -- cabal-tests: fd:10: hClose: resource vanished (Broken pipe)
                     -- [ WinGhcJob "8.8.1" ["8.6.5"]
                     [ WinGhcJob "8.6.5" []
+                    , WinGhcJob "8.8.3"  []
+                    , WinGhcJob "8.10.1" ["8.8.3"]
                     ]
                 , zMangleVersion = map mangleChar
                 , zOr            = (||)
@@ -133,7 +134,7 @@ mkMacGhcJob v u = MacGhcJob
     { mgjVersion = v
     , mgjGhcUrl  = u
     , mgjFlags   = ""
-    , mgjNeeds   = ["8.8.1" | v /= "8.8.1"]
+    , mgjNeeds   = ["8.8.3" | not $ "8.8" `isPrefixOf` v ]
     , mgjSteps   = defSteps
     }
 

--- a/cabal-install/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/Distribution/Client/CmdSdist.hs
@@ -237,7 +237,10 @@ packageToSdist verbosity projectRootDir format outputFile pkg = do
         (norm NoExec -> nonexec, norm Exec -> exec) <-
            listPackageSources verbosity (flattenPackageDescription $ packageDescription pkg) knownSuffixHandlers
 
+        print $ map snd exec
+        print $ map snd nonexec
         let files =  nub . sortOn snd $ nonexec ++ exec
+        print files
 
         case format of
             SourceList nulSep -> do

--- a/cabal-install/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/Distribution/Client/FetchUtils.hs
@@ -176,8 +176,8 @@ fetchRepoTarball verbosity' repoCtxt repo pkgid = do
     verbosity = verboseUnmarkOutput verbosity'
 
     downloadRepoPackage = case repo of
-      RepoLocal{..} -> return (packageFile repo pkgid)
-      RepoLocalNoIndex{..} -> return (packageFile repo pkgid)
+      RepoLocal{} -> return (packageFile repo pkgid)
+      RepoLocalNoIndex{} -> return (packageFile repo pkgid)
 
       RepoRemote{..} -> do
         transport <- repoContextGetTransport repoCtxt

--- a/cabal-install/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/Distribution/Client/IndexUtils.hs
@@ -634,7 +634,7 @@ withIndexEntries
     -> ([IndexCacheEntry] -> IO a)
     -> ([NoIndexCacheEntry] -> IO a)
     -> IO a
-withIndexEntries _ (RepoIndex repoCtxt repo@RepoSecure{..}) callback _ =
+withIndexEntries _ (RepoIndex repoCtxt repo@RepoSecure{}) callback _ =
     repoContextWithSecureRepo repoCtxt repo $ \repoSecure ->
       Sec.withIndex repoSecure $ \Sec.IndexCallbacks{..} -> do
         -- Incrementally (lazily) read all the entries in the tar file in order,

--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -666,7 +666,7 @@ reinstallAddSourceDeps :: Verbosity
                           -> FilePath
                           -> IO WereDepsReinstalled
 reinstallAddSourceDeps verbosity configFlags' configExFlags
-                       installFlags globalFlags sandboxDir = topHandler' $ do
+                       installFlags globalFlags sandboxDir = topHandlerWith errorMsg $ do
   let sandboxDistPref     = sandboxBuildDir sandboxDir
       configFlags         = configFlags'
                             { configDistPref  = Flag sandboxDistPref }
@@ -710,7 +710,8 @@ reinstallAddSourceDeps verbosity configFlags' configExFlags
         ++ "offending packages or recreating the sandbox."
       logMsg message rest = debugNoWrap verbosity message >> rest
 
-      topHandler' = topHandlerWith $ \_ -> do
+      errorMsg :: a -> IO WereDepsReinstalled
+      errorMsg _ = do
         warn verbosity "Couldn't reinstall some add-source dependencies."
         -- Here we can't know whether any deps have been reinstalled, so we have
         -- to be conservative.

--- a/cabal-install/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/Distribution/Client/TargetSelector.hs
@@ -222,7 +222,7 @@ readTargetSelectorsWith :: (Applicative m, Monad m) => DirActions m
                         -> Maybe ComponentKindFilter
                         -> [String]
                         -> m (Either [TargetSelectorProblem] [TargetSelector])
-readTargetSelectorsWith dirActions@DirActions{..} pkgs mfilter targetStrs =
+readTargetSelectorsWith dirActions@DirActions{} pkgs mfilter targetStrs =
     case parseTargetStrings targetStrs of
       ([], usertargets) -> do
         usertargets' <- mapM (getTargetStringFileStatus dirActions) usertargets

--- a/cabal-install/Distribution/Client/Update.hs
+++ b/cabal-install/Distribution/Client/Update.hs
@@ -73,8 +73,8 @@ updateRepo :: Verbosity -> UpdateFlags -> RepoContext -> Repo -> IO ()
 updateRepo verbosity updateFlags repoCtxt repo = do
   transport <- repoContextGetTransport repoCtxt
   case repo of
-    RepoLocal{..} -> return ()
-    RepoLocalNoIndex{..} -> return ()
+    RepoLocal{} -> return ()
+    RepoLocalNoIndex{} -> return ()
     RepoRemote{..} -> do
       downloadResult <- downloadIndex transport verbosity repoRemote repoLocalDir
       case downloadResult of

--- a/cabal-install/Distribution/Client/Utils/Json.hs
+++ b/cabal-install/Distribution/Client/Utils/Json.hs
@@ -15,12 +15,9 @@ module Distribution.Client.Utils.Json
     )
     where
 
-import Data.Char
-import Data.Int
-import Data.String
-import Data.Word
-import Data.List
-import Data.Monoid
+import Distribution.Client.Compat.Prelude
+
+import Data.Char (intToDigit)
 
 import Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as BB
@@ -135,13 +132,13 @@ encodeArrayBB :: [Value] -> Builder
 encodeArrayBB [] = "[]"
 encodeArrayBB jvs = BB.char8 '[' <> go jvs <> BB.char8 ']'
   where
-    go = Data.Monoid.mconcat . intersperse (BB.char8 ',') . map encodeValueBB
+    go = mconcat . intersperse (BB.char8 ',') . map encodeValueBB
 
 encodeObjectBB :: Object -> Builder
 encodeObjectBB [] = "{}"
 encodeObjectBB jvs = BB.char8 '{' <> go jvs <> BB.char8 '}'
   where
-    go = Data.Monoid.mconcat . intersperse (BB.char8 ',') . map encPair
+    go = mconcat . intersperse (BB.char8 ',') . map encPair
     encPair (l,x) = encodeStringBB l <> BB.char8 ':' <> encodeValueBB x
 
 encodeStringBB :: String -> Builder

--- a/cabal-install/Distribution/Solver/Modular/Assignment.hs
+++ b/cabal-install/Distribution/Solver/Modular/Assignment.hs
@@ -9,10 +9,11 @@ module Distribution.Solver.Modular.Assignment
 import Prelude ()
 import Distribution.Solver.Compat.Prelude hiding (pi)
 
-import Data.Array as A
-import Data.List as L
-import Data.Map as M
-import Data.Maybe
+import qualified Data.Array as A
+import qualified Data.List as L
+import qualified Data.Map as M
+
+import Data.Maybe (fromJust)
 
 import Distribution.PackageDescription (FlagAssignment, mkFlagAssignment) -- from Cabal
 
@@ -79,7 +80,7 @@ toCPs (A pa fa sa) rdm =
     -- Dependencies per package.
     depp :: QPN -> [(Component, PI QPN)]
     depp qpn = let v :: Vertex
-                   v   = fromJust (cvm qpn)
+                   v   = fromJust (cvm qpn) -- TODO: why this is safe?
                    dvs :: [(Component, Vertex)]
                    dvs = tg A.! v
                in L.map (\ (comp, dv) -> case vm dv of (_, x, _) -> (comp, PI x (pa M.! x))) dvs

--- a/cabal-install/Distribution/Solver/Modular/Builder.hs
+++ b/cabal-install/Distribution/Solver/Modular/Builder.hs
@@ -19,10 +19,10 @@ module Distribution.Solver.Modular.Builder (
 -- flag-guarded dependencies, we cannot introduce them immediately. Instead, we
 -- store the entire dependency.
 
-import Data.List as L
-import Data.Map as M
-import Data.Set as S
-import Prelude hiding (sequence, mapM)
+import qualified Data.List as L
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Prelude
 
 import qualified Distribution.Solver.Modular.ConflictSet as CS
 import Distribution.Solver.Modular.Dependency
@@ -55,7 +55,7 @@ data BuildState = BS {
 }
 
 -- | Map of available linking targets.
-type LinkingState = Map (PN, I) [PackagePath]
+type LinkingState = M.Map (PN, I) [PackagePath]
 
 -- | Extend the set of open goals with the new goals listed.
 --

--- a/cabal-install/Distribution/Solver/Modular/Index.hs
+++ b/cabal-install/Distribution/Solver/Modular/Index.hs
@@ -6,9 +6,11 @@ module Distribution.Solver.Modular.Index
     , mkIndex
     ) where
 
-import Data.List as L
-import Data.Map as M
 import Prelude hiding (pi)
+
+import Data.Map (Map)
+import qualified Data.List as L
+import qualified Data.Map as M
 
 import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Flag

--- a/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
@@ -2,12 +2,12 @@ module Distribution.Solver.Modular.IndexConversion
     ( convPIs
     ) where
 
-import Data.List as L
+import qualified Data.List as L
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
-import Data.Maybe
+import Data.Maybe (mapMaybe, fromMaybe, maybeToList)
 import Data.Monoid as Mon
-import Data.Set as S
+import qualified Data.Set as S
 
 import Distribution.Compiler
 import Distribution.InstalledPackageInfo as IPI
@@ -330,7 +330,7 @@ flagInfo (StrongFlags strfl) =
 
 -- | Internal package names, which should not be interpreted as true
 -- dependencies.
-type IPNs = Set PN
+type IPNs = S.Set PN
 
 -- | Convenience function to delete a 'Dependency' if it's
 -- for a 'PN' that isn't actually real.

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -9,9 +9,9 @@ module Distribution.Solver.Modular.Solver
     , PruneAfterFirstSuccess(..)
     ) where
 
-import Data.Map as M
-import Data.List as L
-import Data.Set as S
+import qualified Data.Map as M
+import qualified Data.List as L
+import qualified Data.Set as S
 import Distribution.Verbosity
 
 import Distribution.Compiler (CompilerInfo)
@@ -91,8 +91,8 @@ solve :: SolverConfig                         -- ^ solver parameters
       -> Index                                -- ^ all available packages as an index
       -> PkgConfigDb                          -- ^ available pkg-config pkgs
       -> (PN -> PackagePreferences)           -- ^ preferences
-      -> Map PN [LabeledPackageConstraint]    -- ^ global constraints
-      -> Set PN                               -- ^ global goals
+      -> M.Map PN [LabeledPackageConstraint]  -- ^ global constraints
+      -> S.Set PN                             -- ^ global goals
       -> RetryLog Message SolverFailure (Assignment, RevDepMap)
 solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
   explorePhase     $
@@ -232,7 +232,7 @@ instance GSimpleTree (Tree d c) where
 
       -- Show conflict set
       goCS :: ConflictSet -> String
-      goCS cs = "{" ++ (intercalate "," . L.map showVar . CS.toList $ cs) ++ "}"
+      goCS cs = "{" ++ (L.intercalate "," . L.map showVar . CS.toList $ cs) ++ "}"
 #endif
 
 -- | Replace all goal reasons with a dummy goal reason in the tree

--- a/cabal-install/Distribution/Solver/Modular/Validate.hs
+++ b/cabal-install/Distribution/Solver/Modular/Validate.hs
@@ -15,10 +15,11 @@ module Distribution.Solver.Modular.Validate (validateTree) where
 import Control.Applicative
 import Control.Monad.Reader hiding (sequence)
 import Data.Function (on)
-import Data.List as L
-import Data.Set as S
 import Data.Traversable
 import Prelude hiding (sequence)
+
+import qualified Data.List as L
+import qualified Data.Set as S
 
 import Language.Haskell.Extension (Extension, Language)
 

--- a/cabal-install/bootstrap.sh
+++ b/cabal-install/bootstrap.sh
@@ -260,9 +260,9 @@ EDIT_DISTANCE_VER="0.2.2.1"; EDIT_DISTANCE_VER_REGEXP="0\.2\.2\.?"
                        # 0.2.2.*
 ED25519_VER="0.0.5.0"; ED25519_VER_REGEXP="0\.0\.?"
                        # 0.0.*
-HACKAGE_SECURITY_VER="0.6.0.0"; HACKAGE_SECURITY_VER_REGEXP="0\.6\."
-                       # >= 0.7.0.0 && < 0.7
-TAR_VER="0.5.1.0";     TAR_VER_REGEXP="0\.5\.([1-9]|1[0-9]|0\.[3-9]|0\.1[0-9])\.?"
+HACKAGE_SECURITY_VER="0.6.0.1"; HACKAGE_SECURITY_VER_REGEXP="0\.6\."
+                       # >= 0.6.0.0 && < 0.7
+TAR_VER="0.5.1.1";     TAR_VER_REGEXP="0\.5\.([1-9]|1[0-9]|0\.[3-9]|0\.1[0-9])\.?"
                        # >= 0.5.0.3  && < 0.6
 DIGEST_VER="0.0.1.2"; DIGEST_REGEXP="0\.0\.(1\.[2-9]|[2-9]\.?)"
                        # >= 0.0.1.2 && < 0.1

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -316,7 +316,7 @@ executable cabal
     build-depends:
         async      >= 2.0      && < 2.3,
         array      >= 0.4      && < 0.6,
-        base       >= 4.8      && < 4.14,
+        base       >= 4.8      && < 4.15,
         base16-bytestring >= 0.1.1 && < 0.2,
         binary     >= 0.7.3    && < 0.9,
         bytestring >= 0.10.6.0 && < 0.11,
@@ -341,7 +341,7 @@ executable cabal
         time       >= 1.5.0.1  && < 1.10,
         transformers >= 0.4.2.0 && < 0.6,
         zlib       >= 0.5.3    && < 0.7,
-        hackage-security >= 0.6.0.0 && < 0.7,
+        hackage-security >= 0.6.0.1 && < 0.7,
         text       >= 1.2.3    && < 1.3,
         parsec     >= 3.1.13.0 && < 3.2
 

--- a/cabal-install/cabal-install.cabal.pp
+++ b/cabal-install/cabal-install.cabal.pp
@@ -18,7 +18,7 @@ Version:            3.2.0.0
     build-depends:
         async      >= 2.0      && < 2.3,
         array      >= 0.4      && < 0.6,
-        base       >= 4.8      && < 4.14,
+        base       >= 4.8      && < 4.15,
         base16-bytestring >= 0.1.1 && < 0.2,
         binary     >= 0.7.3    && < 0.9,
         bytestring >= 0.10.6.0 && < 0.11,
@@ -43,7 +43,7 @@ Version:            3.2.0.0
         time       >= 1.5.0.1  && < 1.10,
         transformers >= 0.4.2.0 && < 0.6,
         zlib       >= 0.5.3    && < 0.7,
-        hackage-security >= 0.6.0.0 && < 0.7,
+        hackage-security >= 0.6.0.1 && < 0.7,
         text       >= 1.2.3    && < 1.3,
         parsec     >= 3.1.13.0 && < 3.2
 

--- a/cabal-install/tests/IntegrationTests2/targets/complex/q/q.cabal
+++ b/cabal-install/tests/IntegrationTests2/targets/complex/q/q.cabal
@@ -5,7 +5,8 @@ cabal-version: >= 1.2
 
 library
   exposed-modules: Q
-  build-depends: base, filepath
+  -- we rely that filepath has filepath-tests component
+  build-depends: base, filepath >=1.4.0.0
 
 executable buildable-false
   main-is: Main.hs

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -26,7 +26,7 @@ common shared
   default-language: Haskell2010
 
   build-depends:
-    , base >= 4.6 && <4.14
+    , base >= 4.6 && <4.15
     -- this needs to match the in-tree lib:Cabal version
     , Cabal == 3.2.0.0
 
@@ -107,5 +107,5 @@ executable setup
 
 custom-setup
   -- we only depend on even stable releases of lib:Cabal
-  setup-depends: Cabal == 2.2.* || == 2.4.* || == 3.0.*,
+  setup-depends: Cabal == 2.2.* || == 2.4.* || == 3.0.* || ==3.2.*,
                  base, filepath, directory

--- a/validate.sh
+++ b/validate.sh
@@ -16,6 +16,7 @@ DEPSONLY=false
 DOCTEST=false
 BENCHMARKS=false
 VERBOSE=false
+HACKAGETESTSALL=false
 
 TARGETS=""
 STEPS=""
@@ -47,6 +48,8 @@ Available options:
       --extra-hc HC                 Extra compiler to run test-suite with
       --(no-)doctest                Run doctest on library
       --(no-)solver-benchmarks      Build and trial run solver-benchmarks
+      --complete-hackage-tests      Run hackage-tests on complete Hackage data
+      --partial-hackage-tests       Run hackage-tests on parts of Hackage data
   -v, --verbose                     Verbose output
   -q, --quiet                       Less output
   -s, --step STEP                   Run only specific step (can be specified mutliple times)
@@ -211,6 +214,14 @@ while [ $# -gt 0 ]; do
             ;;
         --no-solver-benchmarks)
             BENCHMARKS=false
+            shift
+            ;;
+        --complete-hackage-tests)
+            HACKAGETESTSALL=true
+            shift
+            ;;
+        --partial-hackage-tests)
+            HACKAGETESTSALL=false
             shift
             ;;
         -v|--verbose)
@@ -383,8 +394,14 @@ CMD="$($CABALPLANLISTBIN Cabal:test:parser-tests) $TESTSUITEJOBS --hide-successe
 
 CMD=$($CABALPLANLISTBIN Cabal:test:hackage-tests)
 (cd Cabal && timed $CMD read-fields) || exit 1
-(cd Cabal && timed $CMD parsec d)    || exit 1
-(cd Cabal && timed $CMD roundtrip k) || exit 1
+
+if $HACKAGETESTSALL; then
+  (cd Cabal && timed $CMD parsec)    || exit 1
+  (cd Cabal && timed $CMD roundtrip) || exit 1
+else
+  (cd Cabal && timed $CMD parsec d)    || exit 1
+  (cd Cabal && timed $CMD roundtrip k) || exit 1
+fi
 }
 
 # Cabal cabal-testsuite


### PR DESCRIPTION
Includes cherry-picked commits:

- Test cabal-install with GHC-8.10 #6709
- Add GHC-8.10.1 job. Only tests Cabal-the-lib part atm. #6617

Also add topHandler' signature.