### PR TITLE
Support for -this-package-key deprecation

### DIFF
--- a/Cabal/Distribution/Backpack/Id.hs
+++ b/Cabal/Distribution/Backpack/Id.hs
@@ -125,8 +125,8 @@ computeCompatPackageKey
     -> UnitId
     -> String
 computeCompatPackageKey comp pkg_name pkg_version uid
-    | not (packageKeySupported comp) =
-        prettyShow pkg_name ++ "-" ++ prettyShow pkg_version
+    | not (packageKeySupported comp || unitIdSupported comp)
+    = prettyShow pkg_name ++ "-" ++ prettyShow pkg_version
     | not (unifiedIPIDRequired comp) =
         let str = unUnitId uid -- assume no Backpack support
             mb_verbatim_key


### PR DESCRIPTION
-this-package-key command-line flag has been deprecated in GHC a long
time ago (superseded by -this-unit-id). Cabal should support newer GHC
releases without it.

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
