### PR TITLE
Change 'optional-packages' default on missing cabal.project

### DIFF
--- a/Cabal/doc/cabal-project.rst
+++ b/Cabal/doc/cabal-project.rst
@@ -67,7 +67,7 @@ project are:
 .. cfg-field:: optional-packages: package location list (space or comma-separated)
     :synopsis: Optional project packages.
 
-    :default: ``./*/*.cabal``
+    :default: empty
 
     Like :cfg-field:`packages`, specifies a list of package locations
     containing local packages to be built. Unlike :cfg-field:`packages`,
@@ -90,13 +90,14 @@ project are:
 
 All local packages are *vendored*, in the sense that if other packages
 (including external ones from Hackage) depend on a package with the name
-of a local package, the local package is preferentially used.  This
-motivates the default settings::
+of a local package, the local package is preferentially used.
+For subdirectories to be considered local packages, the following setting
+can be used::
 
     packages: ./*.cabal
     optional-packages: ./*/*.cabal
 
-...any package can be vendored simply by making a checkout in the
+...then any package can be vendored simply by making a checkout in the
 top-level project directory, as might be seen in this hypothetical
 directory layout::
 

--- a/cabal-install/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig.hs
@@ -544,9 +544,6 @@ readProjectLocalConfigOrDefault verbosity distDirLayout = do
         -- We expect a package in the current directory.
         projectPackages         = [ "./*.cabal" ],
 
-        -- This is to automatically pick up deps that we unpack locally.
-        projectPackagesOptional = [ "./*/*.cabal" ],
-
         projectConfigProvenance = Set.singleton Implicit
       }
 

--- a/changelog.d/issue-6739
+++ b/changelog.d/issue-6739
@@ -1,0 +1,3 @@
+synopsis: Change 'optional-packages' default to empty, when cabal.project is mising.
+issues: #6739
+prs: #6740


### PR DESCRIPTION
Fixes #6739