### PR TITLE
Remove "-any" from AnyVersion pretty-print output.

### DIFF
--- a/Cabal/Cabal-quickcheck/src/Test/QuickCheck/Instances/Cabal.hs
+++ b/Cabal/Cabal-quickcheck/src/Test/QuickCheck/Instances/Cabal.hs
@@ -73,11 +73,11 @@ instance Arbitrary Version where
                               , not (null ns) ]
 
 instance Arbitrary VersionRange where
-  arbitrary = sized verRangeExp
+  arbitrary = oneof [sized verRangeExp, return anyVersion]
     where
+      verRangeExp :: Int -> Gen VersionRange
       verRangeExp n = frequency $
-        [ (2, return anyVersion)
-        , (1, fmap thisVersion arbitrary)
+        [ (1, fmap thisVersion arbitrary)
         , (1, fmap laterVersion arbitrary)
         , (1, fmap orLaterVersion arbitrary)
         , (1, fmap orLaterVersion' arbitrary)

--- a/Cabal/Distribution/Types/VersionRange.hs
+++ b/Cabal/Distribution/Types/VersionRange.hs
@@ -50,7 +50,7 @@ import Prelude ()
 --
 -- For a semantic view use 'asVersionIntervals'.
 --
-foldVersionRange :: a                         -- ^ @\"-any\"@ version
+foldVersionRange :: a                         -- ^ "any" version
                  -> (Version -> a)            -- ^ @\"== v\"@
                  -> (Version -> a)            -- ^ @\"> v\"@
                  -> (Version -> a)            -- ^ @\"< v\"@

--- a/Cabal/Distribution/Types/VersionRange/Internal.hs
+++ b/Cabal/Distribution/Types/VersionRange/Internal.hs
@@ -235,7 +235,7 @@ hyloVersionRange f g = h where h = f . fmap h . g
 instance Pretty VersionRange where
     pretty = fst . cataVersionRange alg
       where
-        alg AnyVersionF                     = (Disp.text "-any", 0 :: Int)
+        alg AnyVersionF                     = (Disp.empty, 0 :: Int)
         alg (ThisVersionF v)                = (Disp.text "==" <<>> pretty v, 0)
         alg (LaterVersionF v)               = (Disp.char '>'  <<>> pretty v, 0)
         alg (OrLaterVersionF v)             = (Disp.text ">=" <<>> pretty v, 0)

--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -15,7 +15,7 @@ import Distribution.Utils.Generic
 
 import Data.Typeable (typeOf)
 import Math.NumberTheory.Logarithms (intLog2)
-import Text.PrettyPrint as Disp (text, render, hcat
+import Text.PrettyPrint as Disp (empty, text, render, hcat
                                 ,punctuate, int, char, (<+>))
 import Test.Tasty
 import Test.Tasty.QuickCheck
@@ -643,7 +643,7 @@ displayRaw =
 
     -- precedence:
     -- All the same as the usual pretty printer, except for the parens
-    alg AnyVersionF                     = Disp.text "-any"
+    alg AnyVersionF                     = Disp.empty
     alg (ThisVersionF v)                = Disp.text "==" <<>> pretty v
     alg (LaterVersionF v)               = Disp.char '>'  <<>> pretty v
     alg (EarlierVersionF v)             = Disp.char '<'  <<>> pretty v


### PR DESCRIPTION
## Behaviour Change

**Old behaviour:**

```
λ> pretty AnyVersion
-any
```

**New behaviour:**

```
λ> pretty AnyVersion

```

## Testing

```
cabal run hackage-tests roundtrip
```

There is one failure in the `Workflow` package version 0.7.0.0 which uses the `-any` syntax (see [Workflow.cabal](https://hackage.haskell.org/package/Workflow-0.7.0.0/src/Workflow.cabal)) in addition to a version bound check: `TCache -any && <1.0`. Is this even valid? It would be equivalent to `TCache <1.0`.

```
TCache -any && <1.0
```

```
TCache && <1.0
       ^ Parse error
```

How would we go about fixing this @phadej ?

Also, let me know if there's other places you'd like to see updated, I just updates the `pretty` function as suggested in the other PR.

### TODO

- Fix lib-tests
- Update changelog
- Update docs

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
