### PR TITLE
Make cabal-install compilable with NoImplicitPrelude

### DIFF
--- a/Cabal/Distribution/Compat/CopyFile.hs
+++ b/Cabal/Distribution/Compat/CopyFile.hs
@@ -14,13 +14,11 @@ module Distribution.Compat.CopyFile (
 import Prelude ()
 import Distribution.Compat.Prelude
 
-import Distribution.Compat.Exception
-
 #ifndef mingw32_HOST_OS
 import Distribution.Compat.Internal.TempFile
 
 import Control.Exception
-         ( bracketOnError, throwIO )
+         ( bracketOnError )
 import qualified Data.ByteString.Lazy as BSL
 import System.IO.Error
          ( ioeSetLocation )
@@ -43,8 +41,6 @@ import Foreign.C
 
 #else /* else mingw32_HOST_OS */
 
-import Control.Exception
-  ( throwIO )
 import qualified Data.ByteString.Lazy as BSL
 import System.IO.Error
   ( ioeSetLocation )

--- a/Cabal/Distribution/Compat/Exception.hs
+++ b/Cabal/Distribution/Compat/Exception.hs
@@ -6,22 +6,32 @@ module Distribution.Compat.Exception (
   displayException,
   ) where
 
+#ifdef MIN_VERSION_base
+#define MINVER_base_48 MIN_VERSION_base(4,8,0)
+#else
+#define MINVER_base_48 (__GLASGOW_HASKELL__ >= 710)
+#endif
+
 import System.Exit
 import qualified Control.Exception as Exception
-#if __GLASGOW_HASKELL__ >= 710
+
+#if MINVER_base_48
 import Control.Exception (displayException)
 #endif
 
+-- | Try 'IOException'.
 tryIO :: IO a -> IO (Either Exception.IOException a)
 tryIO = Exception.try
 
+-- | Catch 'IOException'.
 catchIO :: IO a -> (Exception.IOException -> IO a) -> IO a
 catchIO = Exception.catch
 
+-- | Catch 'ExitCode'
 catchExit :: IO a -> (ExitCode -> IO a) -> IO a
 catchExit = Exception.catch
 
-#if __GLASGOW_HASKELL__ < 710
+#if !MINVER_base_48
 displayException :: Exception.Exception e => e -> String
 displayException = show
 #endif

--- a/Cabal/Distribution/Compat/Graph.hs
+++ b/Cabal/Distribution/Compat/Graph.hs
@@ -88,7 +88,6 @@ import Distribution.Compat.Prelude hiding (empty, lookup, null, toList)
 import Prelude ()
 
 import Data.Array                    ((!))
-import Data.Either                   (partitionEithers)
 import Data.Graph                    (SCC (..))
 import Distribution.Utils.Structured (Structure (..), Structured (..))
 

--- a/Cabal/Distribution/Compat/Lens.hs
+++ b/Cabal/Distribution/Compat/Lens.hs
@@ -50,7 +50,6 @@ module Distribution.Compat.Lens (
 import Prelude()
 import Distribution.Compat.Prelude
 
-import Control.Applicative (Const (..))
 import Control.Monad.State.Class (MonadState (..), gets, modify)
 
 import qualified Distribution.Compat.DList as DList

--- a/Cabal/Distribution/Compat/ResponseFile.hs
+++ b/Cabal/Distribution/Compat/ResponseFile.hs
@@ -5,10 +5,9 @@
 -- http://hackage.haskell.org/package/base-4.12.0.0/src/LICENSE
 module Distribution.Compat.ResponseFile (expandResponse) where
 
-import Prelude (mapM)
 import Distribution.Compat.Prelude
+import Prelude ()
 
-import System.Exit
 import System.FilePath
 import System.IO (hPutStrLn, stderr)
 import System.IO.Error
@@ -57,7 +56,7 @@ expandResponse = go recursionLimit "."
 
     go :: Int -> FilePath -> [String] -> IO [String]
     go n dir
-      | n >= 0    = fmap concat . mapM (expand n dir)
+      | n >= 0    = fmap concat . traverse (expand n dir)
       | otherwise = const $ hPutStrLn stderr "Error: response file recursion limit exceeded." >> exitFailure
 
     expand :: Int -> FilePath -> String -> IO [String]

--- a/Cabal/Distribution/FieldGrammar/Newtypes.hs
+++ b/Cabal/Distribution/FieldGrammar/Newtypes.hs
@@ -44,7 +44,7 @@ import Distribution.Parsec
 import Distribution.Pretty
 import Distribution.Version
        (LowerBound (..), Version, VersionRange, VersionRangeF (..), anyVersion, asVersionIntervals, cataVersionRange, mkVersion, version0, versionNumbers)
-import Text.PrettyPrint              (Doc, comma, fsep, punctuate, text, vcat, (<+>))
+import Text.PrettyPrint              (Doc, comma, fsep, punctuate, text, vcat)
 
 import qualified Data.Set                        as Set
 import qualified Distribution.Compat.CharParsing as P

--- a/Cabal/Distribution/FieldGrammar/Parsec.hs
+++ b/Cabal/Distribution/FieldGrammar/Parsec.hs
@@ -66,7 +66,6 @@ module Distribution.FieldGrammar.Parsec (
     )  where
 
 import Data.List                   (dropWhileEnd)
-import Data.Ord                    (comparing)
 import Distribution.Compat.Newtype
 import Distribution.Compat.Prelude
 import Distribution.Simple.Utils   (fromUTF8BS)

--- a/Cabal/Distribution/Fields/Parser.hs
+++ b/Cabal/Distribution/Fields/Parser.hs
@@ -27,7 +27,6 @@ module Distribution.Fields.Parser (
 #endif
     ) where
 
-import           Control.Monad                  (guard)
 import qualified Data.ByteString.Char8          as B8
 import           Data.Functor.Identity
 import           Distribution.Compat.Prelude

--- a/Cabal/Distribution/InstalledPackageInfo.hs
+++ b/Cabal/Distribution/InstalledPackageInfo.hs
@@ -52,7 +52,6 @@ import Distribution.Package                  hiding (installedUnitId)
 import Distribution.Types.ComponentName
 import Distribution.Utils.Generic            (toUTF8BS)
 
-import Control.DeepSeq (deepseq)
 import Data.ByteString (ByteString)
 
 import qualified Data.Map            as Map

--- a/Cabal/Distribution/Make.hs
+++ b/Cabal/Distribution/Make.hs
@@ -67,7 +67,6 @@ import Prelude ()
 import Distribution.Compat.Prelude
 
 -- local
-import Distribution.Compat.Exception
 import Distribution.Package
 import Distribution.Simple.Program
 import Distribution.Simple.Setup
@@ -80,7 +79,6 @@ import Distribution.Version
 import Distribution.Pretty
 
 import System.Environment (getArgs, getProgName)
-import System.Exit
 
 defaultMain :: IO ()
 defaultMain = getArgs >>= defaultMainArgs

--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -35,12 +35,8 @@ module Distribution.PackageDescription.Parsec (
 import Distribution.Compat.Prelude
 import Prelude ()
 
-import Control.Applicative                           (Const (..))
-import Control.DeepSeq                               (deepseq)
-import Control.Monad                                 (guard)
 import Control.Monad.State.Strict                    (StateT, execStateT)
 import Control.Monad.Trans.Class                     (lift)
-import Data.List                                     (partition)
 import Distribution.CabalSpecVersion
 import Distribution.Compat.Lens
 import Distribution.FieldGrammar

--- a/Cabal/Distribution/PackageDescription/PrettyPrint.hs
+++ b/Cabal/Distribution/PackageDescription/PrettyPrint.hs
@@ -51,7 +51,7 @@ import Distribution.PackageDescription.FieldGrammar
 
 import qualified Distribution.PackageDescription.FieldGrammar as FG
 
-import Text.PrettyPrint (Doc, char, hsep, parens, text, (<+>))
+import Text.PrettyPrint (Doc, char, hsep, parens, text)
 
 import qualified Data.ByteString.Lazy.Char8 as BS.Char8
 

--- a/Cabal/Distribution/SPDX/LicenseExpression.hs
+++ b/Cabal/Distribution/SPDX/LicenseExpression.hs
@@ -16,7 +16,6 @@ import Distribution.SPDX.LicenseId
 import Distribution.SPDX.LicenseListVersion
 import Distribution.SPDX.LicenseReference
 import Distribution.Utils.Generic           (isAsciiAlphaNum)
-import Text.PrettyPrint                     ((<+>))
 
 import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint                as Disp

--- a/Cabal/Distribution/Simple.hs
+++ b/Cabal/Distribution/Simple.hs
@@ -98,7 +98,6 @@ import Distribution.System (buildPlatform)
 import System.Environment (getArgs, getProgName)
 import System.Directory   (removeFile, doesFileExist
                           ,doesDirectoryExist, removeDirectoryRecursive)
-import System.Exit                          (exitWith,ExitCode(..))
 import System.FilePath                      (searchPathSeparator, takeDirectory, (</>), splitDirectories, dropDrive)
 import Distribution.Compat.ResponseFile (expandResponse)
 import Distribution.Compat.Directory        (makeAbsolute)

--- a/Cabal/Distribution/Simple/Bench.hs
+++ b/Cabal/Distribution/Simple/Bench.hs
@@ -32,7 +32,6 @@ import Distribution.Simple.UserHooks
 import Distribution.Simple.Utils
 import Distribution.Pretty
 
-import System.Exit ( ExitCode(..), exitFailure, exitSuccess )
 import System.Directory ( doesFileExist )
 import System.FilePath ( (</>), (<.>) )
 

--- a/Cabal/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/Distribution/Simple/BuildTarget.hs
@@ -57,9 +57,8 @@ import Distribution.Verbosity
 import qualified Distribution.Compat.CharParsing as P
 
 import Control.Monad ( msum )
-import Data.List ( stripPrefix, groupBy, partition )
+import Data.List ( stripPrefix, groupBy )
 import qualified Data.List.NonEmpty as NE
-import Data.Either ( partitionEithers )
 import System.FilePath as FilePath
          ( dropExtension, normalise, splitDirectories, joinPath, splitPath
          , hasTrailingPathSeparator )

--- a/Cabal/Distribution/Simple/Compiler.hs
+++ b/Cabal/Distribution/Simple/Compiler.hs
@@ -80,7 +80,6 @@ import Distribution.Version
 import Language.Haskell.Extension
 import Distribution.Simple.Utils
 
-import Control.Monad (join)
 import qualified Data.Map as Map (lookup)
 import System.Directory (canonicalizePath)
 

--- a/Cabal/Distribution/Simple/GHC/EnvironmentParser.hs
+++ b/Cabal/Distribution/Simple/GHC/EnvironmentParser.hs
@@ -17,8 +17,6 @@ import Distribution.Simple.GHC.Internal
 import Distribution.Types.UnitId
     ( mkUnitId )
 
-import Control.Exception
-    ( Exception, throwIO )
 import qualified Text.Parsec as P
 import Text.Parsec.String
     ( Parser, parseFromFile )

--- a/Cabal/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/Distribution/Simple/GHC/Internal.hs
@@ -53,7 +53,6 @@ import Distribution.Types.ComponentLocalBuildInfo
 import Distribution.Backpack
 import qualified Distribution.InstalledPackageInfo as IPI
 import Distribution.PackageDescription
-import Distribution.Compat.Exception
 import Distribution.Lex
 import Distribution.Simple.Compiler
 import Distribution.Simple.Program.GHC
@@ -669,9 +668,9 @@ renderGhcEnvironmentFile =
 renderGhcEnvironmentFileEntry :: GhcEnvironmentFileEntry -> String
 renderGhcEnvironmentFileEntry entry = case entry of
     GhcEnvFileComment   comment   -> format comment
-      where format = intercalate "\n" . map ("--" <+>) . lines
-            pref <+> ""  = pref
-            pref <+> str = pref ++ " " ++ str
+      where format = intercalate "\n" . map ("--" <++>) . lines
+            pref <++> ""  = pref
+            pref <++> str = pref ++ " " ++ str
     GhcEnvFilePackageId pkgid     -> "package-id " ++ prettyShow pkgid
     GhcEnvFilePackageDb pkgdb     ->
       case pkgdb of

--- a/Cabal/Distribution/Simple/Glob.hs
+++ b/Cabal/Distribution/Simple/Glob.hs
@@ -28,8 +28,6 @@ module Distribution.Simple.Glob (
 import Prelude ()
 import Distribution.Compat.Prelude
 
-import Control.Monad (guard)
-
 import Distribution.CabalSpecVersion
 import Distribution.Simple.Utils
 import Distribution.Verbosity

--- a/Cabal/Distribution/Simple/HaskellSuite.hs
+++ b/Cabal/Distribution/Simple/HaskellSuite.hs
@@ -6,9 +6,6 @@ module Distribution.Simple.HaskellSuite where
 import Prelude ()
 import Distribution.Compat.Prelude
 
-import Data.Either (partitionEithers)
-
-import qualified Data.Map as Map (empty)
 import qualified Data.List.NonEmpty as NE
 
 import Distribution.Simple.Program
@@ -25,7 +22,6 @@ import Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.PackageDescription
 import Distribution.Simple.LocalBuildInfo
 import Distribution.System (Platform)
-import Distribution.Compat.Exception
 import Language.Haskell.Extension
 import Distribution.Simple.Program.Builtin
 
@@ -83,7 +79,7 @@ configure verbosity mbHcPath hcPkgPath progdb0 = do
           compilerCompat         = [],
           compilerLanguages      = languages,
           compilerExtensions     = extensions,
-          compilerProperties     = Map.empty
+          compilerProperties     = mempty
         }
 
       return (comp, confdCompiler, progdb2)

--- a/Cabal/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/Distribution/Simple/Program/Builtin.hs
@@ -54,7 +54,6 @@ import Distribution.Simple.Program.Internal
 import Distribution.Simple.Program.Run
 import Distribution.Simple.Program.Types
 import Distribution.Simple.Utils
-import Distribution.Compat.Exception
 import Distribution.Verbosity
 import Distribution.Version
 

--- a/Cabal/Distribution/Simple/Program/Db.hs
+++ b/Cabal/Distribution/Simple/Program/Db.hs
@@ -73,8 +73,7 @@ import Distribution.Utils.Structured       (Structure (..), Structured (..))
 import Distribution.Verbosity
 import Distribution.Version
 
-import Control.Monad (join)
-import Data.Tuple    (swap)
+import Data.Tuple (swap)
 
 import qualified Data.Map as Map
 

--- a/Cabal/Distribution/Simple/Program/HcPkg.hs
+++ b/Cabal/Distribution/Simple/Program/HcPkg.hs
@@ -47,7 +47,6 @@ module Distribution.Simple.Program.HcPkg (
 import Distribution.Compat.Prelude hiding (init)
 import Prelude ()
 
-import Distribution.Compat.Exception
 import Distribution.InstalledPackageInfo
 import Distribution.Parsec
 import Distribution.Pretty

--- a/Cabal/Distribution/Simple/Program/Hpc.hs
+++ b/Cabal/Distribution/Simple/Program/Hpc.hs
@@ -19,7 +19,6 @@ module Distribution.Simple.Program.Hpc
 import Prelude ()
 import Distribution.Compat.Prelude
 
-import Control.Monad (mapM)
 import System.Directory (makeRelativeToCurrentDirectory)
 
 import Distribution.ModuleName
@@ -61,7 +60,7 @@ markup hpc hpcVer verbosity tixFile hpcDirs destDir excluded = do
             return passedDirs
 
     -- Prior to GHC 8.0, hpc assumes all .mix paths are relative.
-    hpcDirs'' <- mapM makeRelativeToCurrentDirectory hpcDirs'
+    hpcDirs'' <- traverse makeRelativeToCurrentDirectory hpcDirs'
 
     runProgramInvocation verbosity
       (markupInvocation hpc tixFile hpcDirs'' destDir excluded)

--- a/Cabal/Distribution/Simple/Program/Run.hs
+++ b/Cabal/Distribution/Simple/Program/Run.hs
@@ -38,8 +38,7 @@ import Distribution.Simple.Utils
 import Distribution.Utils.Generic
 import Distribution.Verbosity
 
-import System.Exit     (ExitCode (..), exitWith)
-import System.FilePath
+import System.FilePath (searchPathSeparator)
 
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map             as Map

--- a/Cabal/Distribution/Simple/Register.hs
+++ b/Cabal/Distribution/Simple/Register.hs
@@ -87,7 +87,6 @@ import Distribution.Compat.Graph (IsNode(nodeKey))
 import System.FilePath ((</>), (<.>), isAbsolute)
 import System.Directory
 
-import Data.List (partition)
 import qualified Data.ByteString.Lazy.Char8 as BS.Char8
 
 -- -----------------------------------------------------------------------------

--- a/Cabal/Distribution/Simple/Setup.hs
+++ b/Cabal/Distribution/Simple/Setup.hs
@@ -108,8 +108,6 @@ import Distribution.Types.UnqualComponentName (unUnqualComponentName)
 import Distribution.Compat.Stack
 import Distribution.Compat.Semigroup (Last' (..), Option' (..))
 
-import Data.Function (on)
-
 -- FIXME Not sure where this should live
 defaultDistPref :: FilePath
 defaultDistPref = "dist"

--- a/Cabal/Distribution/Simple/SrcDist.hs
+++ b/Cabal/Distribution/Simple/SrcDist.hs
@@ -64,13 +64,11 @@ import Distribution.Pretty
 import Distribution.Types.ForeignLib
 import Distribution.Verbosity
 
-import Data.List (partition)
 import qualified Data.Map as Map
 import Data.Time (UTCTime, getCurrentTime, toGregorian, utctDay)
 import System.Directory ( doesFileExist )
 import System.IO (IOMode(WriteMode), hPutStrLn, withFile)
 import System.FilePath ((</>), (<.>), dropExtension, isRelative)
-import Control.Monad
 
 -- |Create a source distribution.
 sdist :: PackageDescription     -- ^ information from the tarball
@@ -189,7 +187,7 @@ listPackageSources' verbosity rip cwd pkg_descr pps =
   , fmap concat
     . withAllFLib $ \flib@(ForeignLib { foreignLibBuildInfo = flibBi }) -> do
        biSrcs   <- allSourcesBuildInfo verbosity rip cwd flibBi pps []
-       defFiles <- mapM (findModDefFile verbosity cwd flibBi pps)
+       defFiles <- traverse (findModDefFile verbosity cwd flibBi pps)
          (foreignLibModDefFile flib)
        return (defFiles ++ biSrcs)
 

--- a/Cabal/Distribution/Simple/Test.hs
+++ b/Cabal/Distribution/Simple/Test.hs
@@ -40,7 +40,6 @@ import Distribution.Pretty
 import System.Directory
     ( createDirectoryIfMissing, doesFileExist, getDirectoryContents
     , removeFile )
-import System.Exit ( exitFailure, exitSuccess )
 import System.FilePath ( (</>) )
 
 -- |Perform the \"@.\/setup test@\" action.

--- a/Cabal/Distribution/Simple/Test/ExeV10.hs
+++ b/Cabal/Distribution/Simple/Test/ExeV10.hs
@@ -31,7 +31,6 @@ import Control.Concurrent (forkIO)
 import System.Directory
     ( createDirectoryIfMissing, doesDirectoryExist, doesFileExist
     , getCurrentDirectory, removeDirectoryRecursive )
-import System.Exit ( ExitCode(..) )
 import System.FilePath ( (</>), (<.>) )
 import System.IO ( hGetContents, stdout, stderr )
 

--- a/Cabal/Distribution/Simple/Test/LibV09.hs
+++ b/Cabal/Distribution/Simple/Test/LibV09.hs
@@ -39,7 +39,6 @@ import System.Directory
     , doesDirectoryExist, doesFileExist
     , getCurrentDirectory, removeDirectoryRecursive, removeFile
     , setCurrentDirectory )
-import System.Exit ( exitSuccess, exitWith, ExitCode(..) )
 import System.FilePath ( (</>), (<.>) )
 import System.IO ( hClose, hGetContents, hPutStr )
 import System.Process (StdStream(..), waitForProcess)

--- a/Cabal/Distribution/Simple/Utils.hs
+++ b/Cabal/Distribution/Simple/Utils.hs
@@ -188,7 +188,6 @@ import Distribution.Version
 import Distribution.Compat.Async
 import Distribution.Compat.CopyFile
 import Distribution.Compat.Internal.TempFile
-import Distribution.Compat.Exception
 import Distribution.Compat.FilePath as FilePath
 import Distribution.Compat.Stack
 import Distribution.Verbosity
@@ -221,8 +220,6 @@ import System.Directory
     , getModificationTime, createDirectory, removeDirectoryRecursive )
 import System.Environment
     ( getProgName )
-import System.Exit
-    ( exitWith, ExitCode(..) )
 import System.FilePath as FilePath
     ( normalise, (</>), (<.>)
     , getSearchPath, joinPath, takeDirectory, splitExtension
@@ -237,7 +234,6 @@ import qualified Control.Exception as Exception
 
 import Foreign.C.Error (Errno (..), ePIPE)
 import Data.Time.Clock.POSIX (getPOSIXTime, POSIXTime)
-import Control.Exception (IOException, evaluate, throwIO, fromException)
 import Numeric (showFFloat)
 import Distribution.Compat.Process  (createProcess, rawSystem, runInteractiveProcess)
 import System.Process

--- a/Cabal/Distribution/Types/Dependency.hs
+++ b/Cabal/Distribution/Types/Dependency.hs
@@ -24,7 +24,6 @@ import Distribution.Pretty
 import Distribution.Types.LibraryName
 import Distribution.Types.PackageName
 import Distribution.Types.UnqualComponentName
-import Text.PrettyPrint                       ((<+>))
 
 import qualified Distribution.Compat.NonEmptySet as NonEmptySet
 import qualified Text.PrettyPrint                as PP

--- a/Cabal/Distribution/Types/IncludeRenaming.hs
+++ b/Cabal/Distribution/Types/IncludeRenaming.hs
@@ -15,7 +15,7 @@ import Distribution.Types.ModuleRenaming
 import qualified Distribution.Compat.CharParsing as P
 import           Distribution.Parsec
 import           Distribution.Pretty
-import           Text.PrettyPrint           (text, (<+>))
+import           Text.PrettyPrint           (text)
 import qualified Text.PrettyPrint           as Disp
 
 -- ---------------------------------------------------------------------------

--- a/Cabal/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
+++ b/Cabal/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
@@ -47,10 +47,10 @@ import qualified Distribution.Types.PackageId.Lens            as L
 -- https://ghc.haskell.org/trac/ghc/ticket/13253 might be the cause.
 --
 -- The workaround is to prevent GHC optimising the code:
-infixl 4 <+>
-(<+>) :: Applicative f => f (a -> b) -> f a -> f b
-f <+> x = f <*> x
-{-# NOINLINE (<+>) #-}
+infixl 4 <@>
+(<@>) :: Applicative f => f (a -> b) -> f a -> f b
+f <@> x = f <*> x
+{-# NOINLINE (<@>) #-}
 
 ipiFieldGrammar
     :: ( FieldGrammar c g, Applicative (g InstalledPackageInfo), Applicative (g Basic)
@@ -78,47 +78,47 @@ ipiFieldGrammar = mkInstalledPackageInfo
         --- https://github.com/haskell/cabal/commit/40f3601e17024f07e0da8e64d3dd390177ce908b
         ^^^ deprecatedSince CabalSpecV1_22 "hugs isn't supported anymore"
     -- Very basic fields: name, version, package-name, lib-name and visibility
-    <+> blurFieldGrammar basic basicFieldGrammar
+    <@> blurFieldGrammar basic basicFieldGrammar
     -- Basic fields
-    <+> optionalFieldDef    "id"                                                 L.installedUnitId (mkUnitId "")
-    <+> optionalFieldDefAla "instantiated-with"    InstWith                      L.instantiatedWith []
-    <+> optionalFieldDefAla "key"                  CompatPackageKey              L.compatPackageKey ""
-    <+> optionalFieldDefAla "license"              SpecLicenseLenient            L.license (Left SPDX.NONE)
-    <+> freeTextFieldDefST  "copyright"                                          L.copyright
-    <+> freeTextFieldDefST  "maintainer"                                         L.maintainer
-    <+> freeTextFieldDefST  "author"                                             L.author
-    <+> freeTextFieldDefST  "stability"                                          L.stability
-    <+> freeTextFieldDefST  "homepage"                                           L.homepage
-    <+> freeTextFieldDefST  "package-url"                                        L.pkgUrl
-    <+> freeTextFieldDefST  "synopsis"                                           L.synopsis
-    <+> freeTextFieldDefST  "description"                                        L.description
-    <+> freeTextFieldDefST  "category"                                           L.category
+    <@> optionalFieldDef    "id"                                                 L.installedUnitId (mkUnitId "")
+    <@> optionalFieldDefAla "instantiated-with"    InstWith                      L.instantiatedWith []
+    <@> optionalFieldDefAla "key"                  CompatPackageKey              L.compatPackageKey ""
+    <@> optionalFieldDefAla "license"              SpecLicenseLenient            L.license (Left SPDX.NONE)
+    <@> freeTextFieldDefST  "copyright"                                          L.copyright
+    <@> freeTextFieldDefST  "maintainer"                                         L.maintainer
+    <@> freeTextFieldDefST  "author"                                             L.author
+    <@> freeTextFieldDefST  "stability"                                          L.stability
+    <@> freeTextFieldDefST  "homepage"                                           L.homepage
+    <@> freeTextFieldDefST  "package-url"                                        L.pkgUrl
+    <@> freeTextFieldDefST  "synopsis"                                           L.synopsis
+    <@> freeTextFieldDefST  "description"                                        L.description
+    <@> freeTextFieldDefST  "category"                                           L.category
     -- Installed fields
-    <+> optionalFieldDef    "abi"                                                L.abiHash (mkAbiHash "")
-    <+> booleanFieldDef     "indefinite"                                         L.indefinite False
-    <+> booleanFieldDef     "exposed"                                            L.exposed False
-    <+> monoidalFieldAla    "exposed-modules"      ExposedModules                L.exposedModules
-    <+> monoidalFieldAla    "hidden-modules"       (alaList' FSep MQuoted)       L.hiddenModules
-    <+> booleanFieldDef     "trusted"                                            L.trusted False
-    <+> monoidalFieldAla    "import-dirs"          (alaList' FSep FilePathNT)    L.importDirs
-    <+> monoidalFieldAla    "library-dirs"         (alaList' FSep FilePathNT)    L.libraryDirs
-    <+> monoidalFieldAla    "dynamic-library-dirs" (alaList' FSep FilePathNT)    L.libraryDynDirs
-    <+> optionalFieldDefAla "data-dir"             FilePathNT                    L.dataDir ""
-    <+> monoidalFieldAla    "hs-libraries"         (alaList' FSep Token)         L.hsLibraries
-    <+> monoidalFieldAla    "extra-libraries"      (alaList' FSep Token)         L.extraLibraries
-    <+> monoidalFieldAla    "extra-ghci-libraries" (alaList' FSep Token)         L.extraGHCiLibraries
-    <+> monoidalFieldAla    "include-dirs"         (alaList' FSep FilePathNT)    L.includeDirs
-    <+> monoidalFieldAla    "includes"             (alaList' FSep FilePathNT)    L.includes
-    <+> monoidalFieldAla    "depends"              (alaList FSep)                L.depends
-    <+> monoidalFieldAla    "abi-depends"          (alaList FSep)                L.abiDepends
-    <+> monoidalFieldAla    "cc-options"           (alaList' FSep Token)         L.ccOptions
-    <+> monoidalFieldAla    "cxx-options"          (alaList' FSep Token)         L.cxxOptions
-    <+> monoidalFieldAla    "ld-options"           (alaList' FSep Token)         L.ldOptions
-    <+> monoidalFieldAla    "framework-dirs"       (alaList' FSep FilePathNT)    L.frameworkDirs
-    <+> monoidalFieldAla    "frameworks"           (alaList' FSep Token)         L.frameworks
-    <+> monoidalFieldAla    "haddock-interfaces"   (alaList' FSep FilePathNT)    L.haddockInterfaces
-    <+> monoidalFieldAla    "haddock-html"         (alaList' FSep FilePathNT)    L.haddockHTMLs
-    <+> optionalFieldAla    "pkgroot"              FilePathNT                    L.pkgRoot
+    <@> optionalFieldDef    "abi"                                                L.abiHash (mkAbiHash "")
+    <@> booleanFieldDef     "indefinite"                                         L.indefinite False
+    <@> booleanFieldDef     "exposed"                                            L.exposed False
+    <@> monoidalFieldAla    "exposed-modules"      ExposedModules                L.exposedModules
+    <@> monoidalFieldAla    "hidden-modules"       (alaList' FSep MQuoted)       L.hiddenModules
+    <@> booleanFieldDef     "trusted"                                            L.trusted False
+    <@> monoidalFieldAla    "import-dirs"          (alaList' FSep FilePathNT)    L.importDirs
+    <@> monoidalFieldAla    "library-dirs"         (alaList' FSep FilePathNT)    L.libraryDirs
+    <@> monoidalFieldAla    "dynamic-library-dirs" (alaList' FSep FilePathNT)    L.libraryDynDirs
+    <@> optionalFieldDefAla "data-dir"             FilePathNT                    L.dataDir ""
+    <@> monoidalFieldAla    "hs-libraries"         (alaList' FSep Token)         L.hsLibraries
+    <@> monoidalFieldAla    "extra-libraries"      (alaList' FSep Token)         L.extraLibraries
+    <@> monoidalFieldAla    "extra-ghci-libraries" (alaList' FSep Token)         L.extraGHCiLibraries
+    <@> monoidalFieldAla    "include-dirs"         (alaList' FSep FilePathNT)    L.includeDirs
+    <@> monoidalFieldAla    "includes"             (alaList' FSep FilePathNT)    L.includes
+    <@> monoidalFieldAla    "depends"              (alaList FSep)                L.depends
+    <@> monoidalFieldAla    "abi-depends"          (alaList FSep)                L.abiDepends
+    <@> monoidalFieldAla    "cc-options"           (alaList' FSep Token)         L.ccOptions
+    <@> monoidalFieldAla    "cxx-options"          (alaList' FSep Token)         L.cxxOptions
+    <@> monoidalFieldAla    "ld-options"           (alaList' FSep Token)         L.ldOptions
+    <@> monoidalFieldAla    "framework-dirs"       (alaList' FSep FilePathNT)    L.frameworkDirs
+    <@> monoidalFieldAla    "frameworks"           (alaList' FSep Token)         L.frameworks
+    <@> monoidalFieldAla    "haddock-interfaces"   (alaList' FSep FilePathNT)    L.haddockInterfaces
+    <@> monoidalFieldAla    "haddock-html"         (alaList' FSep FilePathNT)    L.haddockHTMLs
+    <@> optionalFieldAla    "pkgroot"              FilePathNT                    L.pkgRoot
   where
     mkInstalledPackageInfo _ Basic {..} = InstalledPackageInfo
         -- _basicPkgName is not used
@@ -297,7 +297,7 @@ basicFieldGrammar = mkBasic
     <*> optionalFieldDefAla "version"       MQuoted  basicVersion nullVersion
     <*> optionalField       "package-name"           basicPkgName
     <*> optionalField       "lib-name"               basicLibName
-    <+> optionalFieldDef    "visibility"             basicLibVisibility LibraryVisibilityPrivate
+    <*> optionalFieldDef    "visibility"             basicLibVisibility LibraryVisibilityPrivate
   where
     mkBasic n v pn ln lv = Basic n v pn ln' lv'
       where

--- a/Cabal/Distribution/Types/LegacyExeDependency.hs
+++ b/Cabal/Distribution/Types/LegacyExeDependency.hs
@@ -12,7 +12,7 @@ import Distribution.Pretty
 import Distribution.Version (VersionRange, anyVersion)
 
 import qualified Distribution.Compat.CharParsing as P
-import           Text.PrettyPrint                (text, (<+>))
+import qualified Text.PrettyPrint                as Disp
 
 -- | Describes a legacy `build-tools`-style dependency on an executable
 --
@@ -31,8 +31,8 @@ instance Structured LegacyExeDependency
 instance NFData LegacyExeDependency where rnf = genericRnf
 
 instance Pretty LegacyExeDependency where
-  pretty (LegacyExeDependency name ver) =
-    text name <+> pretty ver
+    pretty (LegacyExeDependency name ver) =
+        Disp.text name <+> pretty ver
 
 instance Parsec LegacyExeDependency where
     parsec = do

--- a/Cabal/Distribution/Types/Mixin.hs
+++ b/Cabal/Distribution/Types/Mixin.hs
@@ -8,8 +8,6 @@ module Distribution.Types.Mixin (
 import Distribution.Compat.Prelude
 import Prelude ()
 
-import Text.PrettyPrint ((<+>))
-
 import Distribution.Parsec
 import Distribution.Pretty
 import Distribution.Types.IncludeRenaming

--- a/Cabal/Distribution/Types/ModuleReexport.hs
+++ b/Cabal/Distribution/Types/ModuleReexport.hs
@@ -14,8 +14,7 @@ import Distribution.Pretty
 import Distribution.Types.PackageName
 
 import qualified Distribution.Compat.CharParsing as P
-import           Text.PrettyPrint           ((<+>))
-import qualified Text.PrettyPrint           as Disp
+import qualified Text.PrettyPrint                as Disp
 
 -- -----------------------------------------------------------------------------
 -- Module re-exports

--- a/Cabal/Distribution/Types/ModuleRenaming.hs
+++ b/Cabal/Distribution/Types/ModuleRenaming.hs
@@ -20,7 +20,7 @@ import Distribution.Pretty
 import qualified Data.Map                   as Map
 import qualified Data.Set                   as Set
 import qualified Distribution.Compat.CharParsing as P
-import           Text.PrettyPrint           (hsep, parens, punctuate, text, (<+>), comma)
+import           Text.PrettyPrint           (hsep, parens, punctuate, text, comma)
 
 -- | Renaming applied to the modules provided by a package.
 -- The boolean indicates whether or not to also include all of the

--- a/Cabal/Distribution/Types/PackageVersionConstraint.hs
+++ b/Cabal/Distribution/Types/PackageVersionConstraint.hs
@@ -18,7 +18,6 @@ import Distribution.Types.VersionRange.Internal
 import Distribution.Version                     (simplifyVersionRange)
 
 import qualified Distribution.Compat.CharParsing as P
-import           Text.PrettyPrint                ((<+>))
 
 -- | A version constraint on a package. Different from 'ExeDependency' and
 -- 'Dependency' since it does not specify the need for a component, not even

--- a/Cabal/Distribution/Types/PkgconfigDependency.hs
+++ b/Cabal/Distribution/Types/PkgconfigDependency.hs
@@ -14,7 +14,6 @@ import Distribution.Parsec
 import Distribution.Pretty
 
 import qualified Distribution.Compat.CharParsing as P
-import           Text.PrettyPrint                ((<+>))
 
 -- | Describes a dependency on a pkg-config library
 --

--- a/Cabal/Distribution/Types/VersionRange/Internal.hs
+++ b/Cabal/Distribution/Types/VersionRange/Internal.hs
@@ -42,7 +42,6 @@ import Distribution.CabalSpecVersion
 import Distribution.Parsec
 import Distribution.Pretty
 import Distribution.Utils.Generic    (unsnoc)
-import Text.PrettyPrint              ((<+>))
 
 import qualified Distribution.Compat.CharParsing as P
 import qualified Distribution.Compat.DList       as DList

--- a/Cabal/Distribution/Utils/Generic.hs
+++ b/Cabal/Distribution/Utils/Generic.hs
@@ -90,8 +90,6 @@ import Distribution.Utils.String
 import Data.Bits ((.&.), (.|.), shiftL)
 import Data.List
     ( isInfixOf )
-import Data.Ord
-    ( comparing )
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.Set as Set
 

--- a/Cabal/tests/UnitTests/Distribution/Version.hs
+++ b/Cabal/tests/UnitTests/Distribution/Version.hs
@@ -16,7 +16,7 @@ import Distribution.Utils.Generic
 import Data.Typeable (typeOf)
 import Math.NumberTheory.Logarithms (intLog2)
 import Text.PrettyPrint as Disp (text, render, hcat
-                                ,punctuate, int, char, (<+>))
+                                ,punctuate, int, char)
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import qualified Test.Laws as Laws
@@ -24,7 +24,6 @@ import qualified Test.Laws as Laws
 import Test.QuickCheck.Instances.Cabal ()
 
 import Data.Maybe (fromJust)
-import Data.Function (on)
 
 versionTests :: [TestTree]
 versionTests =

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ gen-extra-source-files : gen-extra-source-files-lib gen-extra-source-files-cli
 gen-extra-source-files-lib :
 	cabal v2-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-extra-source-files -- $$(pwd)/Cabal/Cabal.cabal
 
+# analyse-imports
+analyse-imports : phony
+	find Cabal/Distribution cabal-install/Distribution -type f -name '*.hs' | xargs cabal v2-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta analyse-imports --
+
 # github actions
 github-actions : .github/workflows/artifacts.yml
 github-actions : .github/workflows/quick-jobs.yml

--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -80,3 +80,14 @@ executable gen-cabal-macros
     , syb               ^>=0.7.1
     , template-haskell
     , zinza             ^>=0.2
+
+executable analyse-imports
+  default-language: Haskell2010
+  main-is:          AnalyseImports.hs
+  hs-source-dirs:   src
+  ghc-options:      -Wall
+  build-depends:
+    , base
+    , containers
+    , regex-applicative
+    , haskell-lexer  ^>=1.1

--- a/cabal-dev-scripts/src/AnalyseImports.hs
+++ b/cabal-dev-scripts/src/AnalyseImports.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE LambdaCase #-}
+module Main (main) where
+
+import Control.Applicative    (liftA2, many, (<|>))
+import Control.Monad          (void)
+import Data.Foldable          (for_)
+import Data.List              (sortBy)
+import Data.Maybe             (fromMaybe)
+import Data.Ord               (comparing)
+import Language.Haskell.Lexer (PosToken, Token (..), lexerPass0)
+import System.Environment     (getArgs)
+import Text.Regex.Applicative (RE)
+
+import qualified Data.Map.Strict        as Map
+import qualified Text.Regex.Applicative as RE
+
+main :: IO ()
+main = do
+    args <- getArgs
+
+    data_ <- traverse processFile args
+
+    putStrLn "Modules"
+    let modules = sortBy (flip $ comparing snd) $ Map.toList $ Map.fromListWith (+)
+          [ (mn, 1 :: Int)
+          | xs <- data_
+          , (mn, _) <- xs
+          ]
+
+    for_ (take 30 modules) $ \(mn, n) ->
+        putStrLn $ mn ++ "  " ++ show n
+
+    putStrLn ""
+
+    putStrLn "Symbols"
+    let symbols = sortBy (flip $ comparing snd) $ Map.toList $ Map.fromListWith (+)
+          [ ((mn,sym), 1 :: Int)
+          | xs <- data_
+          , (mn, syms) <- xs
+          , sym <- syms
+          ]
+
+    for_ (take 50 symbols) $ \((mn,sym), n) ->
+        putStrLn $ mn ++ "." ++ sym ++ "  " ++ show n
+
+processFile :: FilePath -> IO [(String, [String])]
+processFile fp = do
+    contents <- readFile fp
+    let tokens = filter (\(t, _) -> t `notElem` [Whitespace, Comment, Commentstart, NestedComment])
+               $ lexerPass0 contents
+
+    return $ fromMaybe [] $ RE.match (somewhere imports) tokens
+
+imports :: RE PosToken (String, [String])
+imports = (,)
+    <$ reservedid "import" <*> (conid <|> qconid) <*> msymbols
+  where
+    msymbols :: RE PosToken [String]
+    msymbols =special "(" *> symbols <* special ")" <|> pure []
+
+    symbols :: RE PosToken [String]
+    symbols = liftA2 (:) symbol $ many (special "," *> symbol)
+
+    symbol :: RE PosToken String
+    symbol = varid <|> special "(" *> varsym <* special ")"
+
+
+-------------------------------------------------------------------------------
+-- regex-applicative + haskell-lexer
+-------------------------------------------------------------------------------
+
+anything :: RE s ()
+anything = void $ RE.few RE.anySym
+
+somewhere :: RE s a -> RE s [a]
+somewhere re = anything *> RE.few (re <* anything)
+
+reservedid :: String -> RE PosToken ()
+reservedid k = RE.msym $ \case
+    (Reservedid, (_, k')) | k == k' -> Just ()
+    _                               -> Nothing
+
+special :: String -> RE PosToken ()
+special k = RE.msym $ \case
+    (Special, (_, k')) | k == k' -> Just ()
+    _                            -> Nothing
+
+conid :: RE PosToken String
+conid = RE.msym $ \case
+    (Conid, (_, k)) -> Just k
+    _               -> Nothing
+
+qconid :: RE PosToken String
+qconid = RE.msym $ \case
+    (Qconid, (_, k)) -> Just k
+    _                -> Nothing
+
+varid :: RE PosToken String
+varid = RE.msym $ \case
+    (Varid, (_, k)) -> Just k
+    _               -> Nothing
+
+varsym :: RE PosToken String
+varsym = RE.msym $ \case
+    (Varsym, (_, k)) -> Just k
+    _                -> Nothing

--- a/cabal-install/Distribution/Client/BuildReports/Storage.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Storage.hs
@@ -24,6 +24,9 @@ module Distribution.Client.BuildReports.Storage (
     fromPlanningFailure,
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Client.BuildReports.Anonymous (BuildReport, showBuildReport, newBuildReport)
 import qualified Distribution.Client.BuildReports.Anonymous as BuildReport
 
@@ -47,12 +50,11 @@ import Distribution.System
 import Distribution.Compiler
          ( CompilerId(..), CompilerInfo(..)  )
 import Distribution.Simple.Utils
-         ( comparing, equating )
+         ( equating )
 
-import Data.List
-         ( groupBy, sortBy )
-import Data.Maybe
-         ( mapMaybe )
+import Data.List.NonEmpty
+         ( groupBy )
+import qualified Data.List as L
 import System.FilePath
          ( (</>), takeDirectory )
 import System.Directory
@@ -71,8 +73,8 @@ storeAnonymous reports = sequence_
     separate :: [(BuildReport, Maybe Repo)]
              -> [(Repo, [BuildReport])]
     separate = map (\rs@((_,repo,_):_) -> (repo, [ r | (r,_,_) <- rs ]))
-             . map concat
-             . groupBy (equating (repoName . head))
+             . map (concatMap toList)
+             . L.groupBy (equating (repoName . head))
              . sortBy (comparing (repoName . head))
              . groupBy (equating repoName)
              . onlyRemote
@@ -115,7 +117,7 @@ storeLocal cinfo templates reports platform = sequence_
                     platform
 
     groupByFileName = map (\grp@((filename,_):_) -> (filename, map snd grp))
-                    . groupBy (equating  fst)
+                    . L.groupBy (equating  fst)
                     . sortBy  (comparing fst)
 
 -- ------------------------------------------------------------

--- a/cabal-install/Distribution/Client/BuildReports/Types.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Types.hs
@@ -26,11 +26,8 @@ import qualified Text.PrettyPrint                as Disp
 
 import Distribution.Compiler           (CompilerId (..))
 import Distribution.PackageDescription (FlagAssignment)
-import Distribution.Parsec             (Parsec (..))
-import Distribution.Pretty             (Pretty (..))
 import Distribution.System             (Arch, OS)
 import Distribution.Types.PackageId    (PackageIdentifier)
-import Text.PrettyPrint                ((<+>))
 
 -------------------------------------------------------------------------------
 -- ReportLevel

--- a/cabal-install/Distribution/Client/BuildReports/Upload.hs
+++ b/cabal-install/Distribution/Client/BuildReports/Upload.hs
@@ -7,6 +7,9 @@ module Distribution.Client.BuildReports.Upload
     , uploadReports
     ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 {-
 import Network.Browser
          ( BrowserAction, request, setAllowRedirects )
@@ -17,14 +20,10 @@ import Network.TCP (HandleStream)
 -}
 import Network.URI (URI, uriPath) --parseRelativeReference, relativeTo)
 
-import Control.Monad
-         ( forM_ )
 import System.FilePath.Posix
          ( (</>) )
 import qualified Distribution.Client.BuildReports.Anonymous as BuildReport
 import Distribution.Client.BuildReports.Anonymous (BuildReport, showBuildReport)
-import Distribution.Pretty (prettyShow)
-import Distribution.Verbosity (Verbosity)
 import Distribution.Simple.Utils (die')
 import Distribution.Client.HttpUtils
 import Distribution.Client.Setup
@@ -35,7 +34,7 @@ type BuildLog = String
 
 uploadReports :: Verbosity -> RepoContext -> (String, String) -> URI -> [(BuildReport, Maybe BuildLog)] -> IO ()
 uploadReports verbosity repoCtxt auth uri reports = do
-  forM_ reports $ \(report, mbBuildLog) -> do
+  for_ reports $ \(report, mbBuildLog) -> do
      buildId <- postBuildReport verbosity repoCtxt auth uri report
      case mbBuildLog of
        Just buildLog -> putBuildLog verbosity repoCtxt auth buildId buildLog

--- a/cabal-install/Distribution/Client/Check.hs
+++ b/cabal-install/Distribution/Client/Check.hs
@@ -28,7 +28,6 @@ import Distribution.PackageDescription.Parsec
        (parseGenericPackageDescription, runParseResult)
 import Distribution.Parsec                           (PWarning (..), showPError, showPWarning)
 import Distribution.Simple.Utils                     (defaultPackageDesc, die', notice, warn)
-import Distribution.Verbosity                        (Verbosity)
 import System.IO                                     (hPutStr, stderr)
 
 import qualified Data.ByteString  as BS

--- a/cabal-install/Distribution/Client/CmdBench.hs
+++ b/cabal-install/Distribution/Client/CmdBench.hs
@@ -13,6 +13,9 @@ module Distribution.Client.CmdBench (
     selectComponentTarget
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.CmdErrorMessages
 
@@ -24,15 +27,10 @@ import Distribution.Simple.Flag
          ( fromFlagOrDefault )
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
-import Distribution.Pretty
-         ( prettyShow )
 import Distribution.Verbosity
-         ( Verbosity, normal )
+         ( normal )
 import Distribution.Simple.Utils
          ( wrapText, die' )
-
-import Control.Monad (when)
-
 
 benchCommand :: CommandUI (NixStyleFlags ())
 benchCommand = CommandUI {

--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -26,7 +26,7 @@ import Distribution.Simple.Flag ( Flag(..), toFlag, fromFlag, fromFlagOrDefault 
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives, option, optionName )
 import Distribution.Verbosity
-         ( Verbosity, normal )
+         ( normal )
 import Distribution.Simple.Utils
          ( wrapText, die' )
 

--- a/cabal-install/Distribution/Client/CmdClean.hs
+++ b/cabal-install/Distribution/Client/CmdClean.hs
@@ -20,12 +20,8 @@ import Distribution.Simple.Command
 import Distribution.Simple.Utils
     ( info, die', wrapText, handleDoesNotExist )
 import Distribution.Verbosity
-    ( Verbosity, normal )
+    ( normal )
 
-import Control.Monad
-    ( mapM_ )
-import Control.Exception
-    ( throwIO )
 import System.Directory
     ( removeDirectoryRecursive, removeFile
     , doesDirectoryExist, getDirectoryContents )
@@ -111,5 +107,5 @@ cleanAction CleanFlags{..} extraArgs _ = do
 
 removeEnvFiles :: FilePath -> IO ()
 removeEnvFiles dir =
-  (mapM_ (removeFile . (dir </>)) . filter ((".ghc.environment" ==) . take 16))
+  (traverse_ (removeFile . (dir </>)) . filter ((".ghc.environment" ==) . take 16))
   =<< getDirectoryContents dir

--- a/cabal-install/Distribution/Client/CmdConfigure.hs
+++ b/cabal-install/Distribution/Client/CmdConfigure.hs
@@ -6,8 +6,10 @@ module Distribution.Client.CmdConfigure (
     configureAction,
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import System.Directory
-import Control.Monad
 import qualified Data.Map as Map
 
 import Distribution.Client.ProjectOrchestration

--- a/cabal-install/Distribution/Client/CmdErrorMessages.hs
+++ b/cabal-install/Distribution/Client/CmdErrorMessages.hs
@@ -22,11 +22,8 @@ import Distribution.Types.LibraryName
          ( LibraryName(..) )
 import Distribution.Solver.Types.OptionalStanza
          ( OptionalStanza(..) )
-import Distribution.Pretty
-         ( prettyShow )
 
 import qualified Data.List.NonEmpty as NE
-import Data.Function (on)
 
 
 -----------------------

--- a/cabal-install/Distribution/Client/CmdExec.hs
+++ b/cabal-install/Distribution/Client/CmdExec.hs
@@ -83,8 +83,7 @@ import Distribution.Simple.Utils
   , wrapText
   )
 import Distribution.Verbosity
-  ( Verbosity
-  , normal
+  ( normal
   )
 
 import Prelude ()

--- a/cabal-install/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/Distribution/Client/CmdFreeze.hs
@@ -7,6 +7,9 @@ module Distribution.Client.CmdFreeze (
     freezeAction,
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Client.NixStyleOptions
          ( NixStyleFlags (..), nixStyleOptions, defaultNixStyleFlags )
 import Distribution.Client.ProjectOrchestration
@@ -44,8 +47,6 @@ import Distribution.Verbosity
          ( normal )
 
 import qualified Data.Map as Map
-import Data.Map (Map)
-import Control.Monad (unless)
 
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )

--- a/cabal-install/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/Distribution/Client/CmdHaddock.hs
@@ -13,6 +13,9 @@ module Distribution.Client.CmdHaddock (
     selectComponentTarget
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.CmdErrorMessages
 
@@ -25,12 +28,9 @@ import Distribution.Simple.Setup
 import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
 import Distribution.Verbosity
-         ( Verbosity, normal )
+         ( normal )
 import Distribution.Simple.Utils
          ( wrapText, die' )
-
-import Control.Monad (when)
-
 
 haddockCommand :: CommandUI (NixStyleFlags ())
 haddockCommand = CommandUI {

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -120,27 +120,17 @@ import Distribution.Types.UnitId
 import Distribution.Types.UnqualComponentName
          ( UnqualComponentName, unUnqualComponentName )
 import Distribution.Verbosity
-         ( Verbosity, normal, lessVerbose )
+         ( normal, lessVerbose )
 import Distribution.Simple.Utils
          ( wrapText, die', notice, warn
          , withTempDirectory, createDirectoryIfMissingVerbose
          , ordNub )
 import Distribution.Utils.Generic
          ( safeHead, writeFileAtomic )
-import Distribution.Parsec
-         ( simpleParsec )
-import Distribution.Pretty
-         ( prettyShow )
 
-import Control.Exception
-         ( catch )
-import Control.Monad
-         ( mapM, forM_ )
 import qualified Data.ByteString.Lazy.Char8 as BS
-import Data.Either
-         ( partitionEithers )
 import Data.Ord
-         ( comparing, Down(..) )
+         ( Down(..) )
 import qualified Data.Map as Map
 import Distribution.Utils.NubList
          ( fromNubList )
@@ -263,7 +253,7 @@ installAction flags@NixStyleFlags { extraFlags = clientInstallFlags', .. } targe
 
     withoutProject :: ProjectConfig -> IO ([PackageSpecifier pkg], [URI], [TargetSelector], ProjectConfig)
     withoutProject globalConfig = do
-      tss <- mapM (parseWithoutProjectTargetSelector verbosity) targetStrings'
+      tss <- traverse (parseWithoutProjectTargetSelector verbosity) targetStrings'
 
       cabalDir <- getCabalDir
       let
@@ -478,7 +468,7 @@ getSpecsAndTargetSelectors verbosity reducedVerbosity pkgDb targetSelectors loca
 
   createDirectoryIfMissing True (distSdistDirectory localDistDirLayout)
 
-  unless (Map.null targets) $ forM_ (localPackages localBaseCtx) $ \lpkg -> case lpkg of
+  unless (Map.null targets) $ for_ (localPackages localBaseCtx) $ \lpkg -> case lpkg of
       SpecificSourcePackage pkg -> packageToSdist verbosity
         (distProjectRootDirectory localDistDirLayout) TarGzArchive
         (distSdistFile localDistDirLayout (packageId pkg)) pkg

--- a/cabal-install/Distribution/Client/CmdInstall/ClientInstallFlags.hs
+++ b/cabal-install/Distribution/Client/CmdInstall/ClientInstallFlags.hs
@@ -16,8 +16,6 @@ import Distribution.Simple.Command
          ( ShowOrParseArgs(..), OptionField(..), option, reqArg )
 import Distribution.Simple.Setup
          ( Flag(..), trueArg, flagToList, toFlag )
-import Distribution.Parsec (Parsec (..), CabalParsing)
-import Distribution.Pretty (prettyShow)
 
 import Distribution.Client.Types.InstallMethod
          ( InstallMethod (..) )

--- a/cabal-install/Distribution/Client/CmdInstall/ClientInstallTargetSelector.hs
+++ b/cabal-install/Distribution/Client/CmdInstall/ClientInstallTargetSelector.hs
@@ -15,11 +15,9 @@ import Distribution.Client.TargetSelector
 import Distribution.Client.Types
 import Distribution.Compat.CharParsing             (char, optional)
 import Distribution.Package
-import Distribution.Parsec
 import Distribution.Simple.LocalBuildInfo          (ComponentName (CExeName))
 import Distribution.Simple.Utils                   (die')
 import Distribution.Solver.Types.PackageConstraint (PackageProperty (..))
-import Distribution.Verbosity                      (Verbosity)
 import Distribution.Version
 
 data WithoutProjectTargetSelector
@@ -36,7 +34,7 @@ parseWithoutProjectTargetSelector verbosity input =
             Just uri -> return (WoURI uri)
             Nothing  -> die' verbosity $ "Invalid package ID: " ++ input ++ "\n" ++ err
   where
-    parser :: ParsecParser WithoutProjectTargetSelector
+    parser :: CabalParsing m => m WithoutProjectTargetSelector
     parser = do
         pid <- parsec
         cn  <- optional (char ':' *> parsec)

--- a/cabal-install/Distribution/Client/CmdLegacy.hs
+++ b/cabal-install/Distribution/Client/CmdLegacy.hs
@@ -17,10 +17,10 @@ import Distribution.Simple.Command
 import Distribution.Simple.Utils
     ( wrapText )
 import Distribution.Verbosity
-    ( Verbosity, normal )
+    ( normal )
 
 import Control.Exception
-    ( SomeException(..), try )
+    ( try )
 import qualified Data.Text as T
 
 -- Tweaked versions of code from Main.

--- a/cabal-install/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/Distribution/Client/CmdRepl.hs
@@ -56,9 +56,7 @@ import Distribution.Package
          ( Package(..), packageName, UnitId, installedUnitId )
 import Distribution.PackageDescription.PrettyPrint
 import Distribution.Parsec
-         ( Parsec(..), parsecCommaList )
-import Distribution.Pretty
-         ( prettyShow )
+         ( parsecCommaList )
 import Distribution.ReadE
          ( ReadE, parsecToReadE )
 import qualified Distribution.SPDX.License as SPDX
@@ -87,7 +85,7 @@ import Distribution.Types.VersionRange
 import Distribution.Utils.Generic
          ( safeHead )
 import Distribution.Verbosity
-         ( Verbosity, normal, lessVerbose )
+         ( normal, lessVerbose )
 import Distribution.Simple.Utils
          ( wrapText, die', debugNoWrap, ordNub, createTempDirectory, handleDoesNotExist )
 import Language.Haskell.Extension

--- a/cabal-install/Distribution/Client/CmdRun.hs
+++ b/cabal-install/Distribution/Client/CmdRun.hs
@@ -37,11 +37,9 @@ import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
 import Distribution.Types.ComponentName
          ( showComponentName )
-import Distribution.Pretty
-         ( prettyShow )
 import Distribution.CabalSpecVersion (CabalSpecVersion (..), cabalSpecLatest)
 import Distribution.Verbosity
-         ( Verbosity, normal )
+         ( normal )
 import Distribution.Simple.Utils
          ( wrapText, warn, die', ordNub, info
          , createTempDirectory, handleDoesNotExist )

--- a/cabal-install/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/Distribution/Client/CmdSdist.hs
@@ -39,8 +39,6 @@ import Distribution.Package
     ( Package(packageId) )
 import Distribution.PackageDescription.Configuration
     ( flattenPackageDescription )
-import Distribution.Pretty
-    ( prettyShow )
 import Distribution.ReadE
     ( succeedReadE )
 import Distribution.Simple.Command
@@ -60,7 +58,7 @@ import Distribution.Types.ComponentName
 import Distribution.Types.PackageName
     ( PackageName, unPackageName )
 import Distribution.Verbosity
-    ( Verbosity, normal )
+    ( normal )
 
 import qualified Codec.Archive.Tar       as Tar
 import qualified Codec.Archive.Tar.Entry as Tar
@@ -73,8 +71,6 @@ import Control.Monad.Writer.Lazy
     ( WriterT, tell, execWriterT )
 import qualified Data.ByteString.Char8      as BS
 import qualified Data.ByteString.Lazy.Char8 as BSL
-import Data.Either
-    ( partitionEithers )
 import qualified Data.Set as Set
 import System.Directory
     ( getCurrentDirectory

--- a/cabal-install/Distribution/Client/CmdTest.hs
+++ b/cabal-install/Distribution/Client/CmdTest.hs
@@ -13,6 +13,9 @@ module Distribution.Client.CmdTest (
     selectComponentTarget
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.CmdErrorMessages
 
@@ -26,14 +29,11 @@ import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
 import Distribution.Simple.Flag
          ( Flag(..) )
-import Distribution.Pretty
-         ( prettyShow )
 import Distribution.Verbosity
-         ( Verbosity, normal )
+         ( normal )
 import Distribution.Simple.Utils
          ( notice, wrapText, die' )
 
-import Control.Monad (when)
 import qualified System.Exit (exitSuccess)
 
 

--- a/cabal-install/Distribution/Client/Compat/ExecutablePath.hs
+++ b/cabal-install/Distribution/Client/Compat/ExecutablePath.hs
@@ -7,6 +7,8 @@
 
 module Distribution.Client.Compat.ExecutablePath ( getExecutablePath ) where
 
+import Prelude
+
 -- The imports are purposely kept completely disjoint to prevent edits
 -- to one OS implementation from breaking another.
 

--- a/cabal-install/Distribution/Client/Compat/FilePerms.hs
+++ b/cabal-install/Distribution/Client/Compat/FilePerms.hs
@@ -6,6 +6,8 @@ module Distribution.Client.Compat.FilePerms (
   setFileHidden,
   ) where
 
+import Prelude (FilePath, IO, return, ($))
+
 #ifndef mingw32_HOST_OS
 import System.Posix.Types
          ( FileMode )

--- a/cabal-install/Distribution/Client/Compat/Orphans.hs
+++ b/cabal-install/Distribution/Client/Compat/Orphans.hs
@@ -7,6 +7,7 @@ import Distribution.Compat.Binary    (Binary (..))
 import Distribution.Compat.Typeable  (typeRep)
 import Distribution.Utils.Structured (Structure (Nominal), Structured (..))
 import Network.URI                   (URI (..), URIAuth (..))
+import Prelude                       (error, return)
 
 -------------------------------------------------------------------------------
 -- network-uri
@@ -34,7 +35,7 @@ instance Binary URIAuth where
 --Added in 46aa019ec85e313e257d122a3549cce01996c566
 instance Binary SomeException where
     put _ = return ()
-    get = fail "cannot serialise exceptions"
+    get = error "cannot serialise exceptions"
 
 instance Structured SomeException where
     structure p = Nominal (typeRep p) 0 "SomeException" []

--- a/cabal-install/Distribution/Client/Compat/Prelude.hs
+++ b/cabal-install/Distribution/Client/Compat/Prelude.hs
@@ -12,7 +12,13 @@
 --
 module Distribution.Client.Compat.Prelude
   ( module Distribution.Compat.Prelude.Internal
+  , module X
   ) where
 
-import Distribution.Compat.Prelude.Internal
 import Distribution.Client.Compat.Orphans ()
+import Distribution.Compat.Prelude.Internal
+import Prelude ()
+
+import Distribution.Parsec    as X (CabalParsing, Parsec (..), eitherParsec, explicitEitherParsec, simpleParsec)
+import Distribution.Pretty    as X (Pretty (..), prettyShow)
+import Distribution.Verbosity as X (Verbosity)

--- a/cabal-install/Distribution/Client/Compat/Process.hs
+++ b/cabal-install/Distribution/Client/Compat/Process.hs
@@ -16,6 +16,8 @@ module Distribution.Client.Compat.Process (
   readProcessWithExitCode
 ) where
 
+import Prelude (FilePath, IO, String, return, (||))
+
 import           Control.Exception (catch, throw)
 import           System.Exit       (ExitCode (ExitFailure))
 import           System.IO.Error   (isDoesNotExistError, isPermissionError)

--- a/cabal-install/Distribution/Client/Compat/Semaphore.hs
+++ b/cabal-install/Distribution/Client/Compat/Semaphore.hs
@@ -7,6 +7,8 @@ module Distribution.Client.Compat.Semaphore
     , signalQSem
     ) where
 
+import Prelude (IO, return, Eq (..), Int, Bool (..), ($), ($!), Num (..), flip)
+
 import Control.Concurrent.STM (TVar, atomically, newTVar, readTVar, retry,
                                writeTVar)
 import Control.Exception (mask_, onException)

--- a/cabal-install/Distribution/Client/Config.hs
+++ b/cabal-install/Distribution/Client/Config.hs
@@ -117,19 +117,16 @@ import Distribution.Client.Utils
 import Distribution.Compiler
          ( CompilerFlavor(..), defaultCompilerFlavor )
 import Distribution.Verbosity
-         ( Verbosity, normal )
+         ( normal )
 import qualified Distribution.Compat.CharParsing as P
 import Distribution.Client.ProjectFlags (ProjectFlags (..))
 import Distribution.Solver.Types.ConstraintSource
 
-import Data.List
-         ( partition )
 import qualified Distribution.Deprecated.ReadP as Parse
          ( (<++), option )
 import qualified Text.PrettyPrint as Disp
          ( render, text, empty )
-import Distribution.Parsec (parsec, simpleParsec, parsecOptCommaList)
-import Distribution.Pretty (pretty, prettyShow)
+import Distribution.Parsec (parsecOptCommaList)
 import Text.PrettyPrint
          ( ($+$) )
 import Text.PrettyPrint.HughesPJ
@@ -144,11 +141,7 @@ import System.IO.Error
          ( isDoesNotExistError )
 import Distribution.Compat.Environment
          ( getEnvironment, lookupEnv )
-import Distribution.Compat.Exception
-         ( catchIO )
 import qualified Data.Map as M
-import Data.Function
-         ( on )
 
 --
 -- * Configuration saved in the config file

--- a/cabal-install/Distribution/Client/Configure.hs
+++ b/cabal-install/Distribution/Client/Configure.hs
@@ -26,7 +26,6 @@ import Prelude ()
 import Distribution.Client.Compat.Prelude
 import Distribution.Utils.Generic (safeHead)
 
-import Distribution.Pretty (prettyShow)
 import Distribution.Client.Dependency
 import qualified Distribution.Client.InstallPlan as InstallPlan
 import Distribution.Client.SolverInstallPlan (SolverInstallPlan)
@@ -81,11 +80,7 @@ import Distribution.Simple.Utils as Utils
          , defaultPackageDesc )
 import Distribution.System
          ( Platform )
-import Distribution.Verbosity as Verbosity
-         ( Verbosity )
 
-import Data.Foldable
-         ( forM_ )
 import System.FilePath ( (</>) )
 
 -- | Choose the Cabal version such that the setup scripts compiled against this
@@ -273,10 +268,10 @@ checkConfigExFlags :: Package pkg
                    -> ConfigExFlags
                    -> IO ()
 checkConfigExFlags verbosity installedPkgIndex sourcePkgIndex flags = do
-  forM_ (safeHead unknownConstraints) $ \h ->
+  for_ (safeHead unknownConstraints) $ \h ->
     warn verbosity $ "Constraint refers to an unknown package: "
           ++ showConstraint h
-  forM_ (safeHead unknownPreferences) $ \h ->
+  for_ (safeHead unknownPreferences) $ \h ->
     warn verbosity $ "Preference refers to an unknown package: "
           ++ prettyShow h
   where

--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -64,6 +64,9 @@ module Distribution.Client.Dependency (
     addSetupCabalMaxVersionConstraint,
   ) where
 
+import Distribution.Client.Compat.Prelude
+import qualified Prelude as Unsafe (head)
+
 import Distribution.Solver.Modular
          ( modularResolver, SolverConfig(..), PruneAfterFirstSuccess(..) )
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
@@ -96,13 +99,10 @@ import Distribution.System
          ( Platform )
 import Distribution.Client.Utils
          ( duplicatesBy, mergeBy, MergeResult(..) )
-import Distribution.Simple.Utils
-         ( comparing )
 import Distribution.Simple.Setup
          ( asBool )
-import Distribution.Pretty (prettyShow)
 import Distribution.Verbosity
-         ( normal, Verbosity )
+         ( normal  )
 import Distribution.Version
 import qualified Distribution.Compat.Graph as Graph
 
@@ -127,12 +127,9 @@ import           Distribution.Solver.Types.SourcePackage
 import           Distribution.Solver.Types.Variable
 
 import Data.List
-         ( foldl', sort, sortBy, nubBy, maximumBy, intercalate, nub )
-import Data.Function (on)
-import Data.Maybe (fromMaybe, mapMaybe)
+         ( maximumBy )
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import Data.Set (Set)
 import Control.Exception
          ( assert )
 
@@ -847,7 +844,7 @@ planPackagesProblems platform cinfo pkgs =
      | Configured pkg <- pkgs
      , let packageProblems = configuredPackageProblems platform cinfo pkg
      , not (null packageProblems) ]
-  ++ [ DuplicatePackageSolverId (Graph.nodeKey (head dups)) dups
+  ++ [ DuplicatePackageSolverId (Graph.nodeKey (Unsafe.head dups)) dups
      | dups <- duplicatesBy (comparing Graph.nodeKey) pkgs ]
 
 data PackageProblem = DuplicateFlag PD.FlagName
@@ -1029,11 +1026,6 @@ collectEithers = collect . partitionEithers
   where
     collect ([], xs) = Right xs
     collect (errs,_) = Left errs
-    partitionEithers :: [Either a b] -> ([a],[b])
-    partitionEithers = foldr (either left right) ([],[])
-     where
-       left  a (l, r) = (a:l, r)
-       right a (l, r) = (l, a:r)
 
 -- | Errors for 'resolveWithoutDependencies'.
 --

--- a/cabal-install/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/Distribution/Client/Dependency/Types.hs
@@ -8,8 +8,6 @@ module Distribution.Client.Dependency.Types (
 import Distribution.Client.Compat.Prelude
 import Prelude ()
 
-import Distribution.Parsec (Parsec (..))
-import Distribution.Pretty (Pretty (..))
 import Text.PrettyPrint (text)
 
 import qualified Distribution.Compat.CharParsing as P

--- a/cabal-install/Distribution/Client/DistDirLayout.hs
+++ b/cabal-install/Distribution/Client/DistDirLayout.hs
@@ -22,7 +22,9 @@ module Distribution.Client.DistDirLayout (
     defaultCabalDirLayout
 ) where
 
-import Data.Maybe (fromMaybe)
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import System.FilePath
 
 import Distribution.Package
@@ -30,8 +32,6 @@ import Distribution.Package
 import Distribution.Compiler
 import Distribution.Simple.Compiler
          ( PackageDB(..), PackageDBStack, OptimisationLevel(..) )
-import Distribution.Pretty
-         ( prettyShow )
 import Distribution.Types.ComponentName
 import Distribution.Types.LibraryName
 import Distribution.System

--- a/cabal-install/Distribution/Client/Exec.hs
+++ b/cabal-install/Distribution/Client/Exec.hs
@@ -21,7 +21,6 @@ import Distribution.Simple.Program.Types ( simpleProgram, ConfiguredProgram(..) 
 import Distribution.Simple.Utils       (die')
 
 import Distribution.System    (Platform(..))
-import Distribution.Verbosity (Verbosity)
 
 -- | Execute the given command in the package's environment.
 --

--- a/cabal-install/Distribution/Client/Fetch.hs
+++ b/cabal-install/Distribution/Client/Fetch.hs
@@ -14,6 +14,9 @@ module Distribution.Client.Fetch (
     fetch,
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Client.Types
 import Distribution.Client.Targets
 import Distribution.Client.FetchUtils hiding (fetchPackage)
@@ -44,13 +47,6 @@ import Distribution.Simple.Utils
          ( die', notice, debug )
 import Distribution.System
          ( Platform )
-import Distribution.Pretty
-         ( prettyShow )
-import Distribution.Verbosity
-         ( Verbosity )
-
-import Control.Monad
-         ( filterM )
 
 -- ------------------------------------------------------------
 -- * The fetch command
@@ -84,7 +80,7 @@ fetch verbosity _ _ _ _ _ _ _ [] =
 fetch verbosity packageDBs repoCtxt comp platform progdb
       globalFlags fetchFlags userTargets = do
 
-    mapM_ (checkTarget verbosity) userTargets
+    traverse_ (checkTarget verbosity) userTargets
 
     installedPkgIndex <- getInstalledPackages verbosity comp packageDBs progdb
     sourcePkgDb       <- getSourcePackages    verbosity repoCtxt
@@ -112,7 +108,7 @@ fetch verbosity packageDBs repoCtxt comp platform progdb
                      "The following packages would be fetched:"
                    : map (prettyShow . packageId) pkgs'
 
-             else mapM_ (fetchPackage verbosity repoCtxt . packageSource) pkgs'
+             else traverse_ (fetchPackage verbosity repoCtxt . packageSource) pkgs'
 
   where
     dryRun = fromFlag (fetchDryRun fetchFlags)

--- a/cabal-install/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/Distribution/Client/FileMonitor.hs
@@ -652,7 +652,7 @@ probeMonitorStateGlobRel kindfile kinddir root dirName
                  . filter (matchGlob glob)
                =<< liftIO (getDirectoryContents (root </> dirName))
 
-        children' <- mapM probeMergeResult $
+        children' <- traverse probeMergeResult $
                           mergeBy (\(path1,_) path2 -> compare path1 path2)
                                   children
                                   (sort matches)
@@ -717,14 +717,14 @@ probeMonitorStateGlobRel _ _ root dirName
         matches <- return . filter (matchGlob glob)
                =<< liftIO (getDirectoryContents (root </> dirName))
 
-        mapM_ probeMergeResult $
+        traverse_ probeMergeResult $
               mergeBy (\(path1,_) path2 -> compare path1 path2)
                       children
                       (sort matches)
         return mtime'
 
     -- Check that none of the children have changed
-    forM_ children $ \(file, status) ->
+    for_ children $ \(file, status) ->
       probeMonitorStateFileStatus root (dirName </> file) status
 
 
@@ -928,7 +928,7 @@ buildMonitorStateGlobRel mstartTime hashcache kindfile kinddir root
         subdirs <- filterM (\subdir -> doesDirectoryExist (absdir </> subdir))
                  $ filter (matchGlob glob) dirEntries
         subdirStates <-
-          forM (sort subdirs) $ \subdir -> do
+          for (sort subdirs) $ \subdir -> do
             fstate <- buildMonitorStateGlobRel
                         mstartTime hashcache kindfile kinddir root
                         (dir </> subdir) globPath'
@@ -938,7 +938,7 @@ buildMonitorStateGlobRel mstartTime hashcache kindfile kinddir root
       GlobFile glob -> do
         let files = filter (matchGlob glob) dirEntries
         filesStates <-
-          forM (sort files) $ \file -> do
+          for (sort files) $ \file -> do
             fstate <- buildMonitorStateFile
                         mstartTime hashcache kindfile kinddir root
                         (dir </> file)

--- a/cabal-install/Distribution/Client/Freeze.hs
+++ b/cabal-install/Distribution/Client/Freeze.hs
@@ -53,10 +53,6 @@ import Distribution.Simple.Utils
          ( die', notice, debug, writeFileAtomic )
 import Distribution.System
          ( Platform )
-import Distribution.Pretty
-         ( prettyShow )
-import Distribution.Verbosity
-         ( Verbosity )
 
 import qualified Data.ByteString.Lazy.Char8 as BS.Char8
 import Distribution.Version

--- a/cabal-install/Distribution/Client/GenBounds.hs
+++ b/cabal-install/Distribution/Client/GenBounds.hs
@@ -44,10 +44,6 @@ import Distribution.Simple.Utils
          ( tryFindPackageDesc )
 import Distribution.System
          ( Platform )
-import Distribution.Pretty
-         ( prettyShow )
-import Distribution.Verbosity
-         ( Verbosity )
 import Distribution.Version
          ( Version, alterVersion
          , LowerBound(..), UpperBound(..), VersionRange, asVersionIntervals

--- a/cabal-install/Distribution/Client/Glob.hs
+++ b/cabal-install/Distribution/Client/Glob.hs
@@ -22,9 +22,6 @@ import Data.List        (stripPrefix)
 import System.Directory
 import System.FilePath
 
-import Distribution.Parsec (CabalParsing, Parsec (..))
-import Distribution.Pretty (Pretty (..))
-
 import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint                as Disp
 

--- a/cabal-install/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/Distribution/Client/GlobalFlags.hs
@@ -24,8 +24,6 @@ import Distribution.Utils.NubList
          ( NubList, fromNubList )
 import Distribution.Client.HttpUtils
          ( HttpTransport, configureTransport )
-import Distribution.Verbosity
-         ( Verbosity )
 import Distribution.Simple.Utils
          ( info, warn )
 
@@ -34,8 +32,6 @@ import Distribution.Client.IndexUtils.ActiveRepos
 
 import Control.Concurrent
          ( MVar, newMVar, modifyMVar )
-import Control.Exception
-         ( throwIO )
 import System.FilePath
          ( (</>) )
 import Network.URI

--- a/cabal-install/Distribution/Client/Haddock.hs
+++ b/cabal-install/Distribution/Client/Haddock.hs
@@ -16,8 +16,10 @@ module Distribution.Client.Haddock
     )
     where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Data.List (maximumBy)
-import Data.Foldable (forM_)
 import System.Directory (createDirectoryIfMissing, renameFile)
 import System.FilePath ((</>), splitFileName)
 import Distribution.Package
@@ -26,11 +28,10 @@ import Distribution.Simple.Haddock (haddockPackagePaths)
 import Distribution.Simple.Program (haddockProgram, ProgramDb
                                    , runProgram, requireProgramVersion)
 import Distribution.Version (mkVersion, orLaterVersion)
-import Distribution.Verbosity (Verbosity)
 import Distribution.Simple.PackageIndex
          ( InstalledPackageIndex, allPackagesByName )
 import Distribution.Simple.Utils
-         ( comparing, debug, installDirectoryContents, withTempDirectory )
+         ( debug, installDirectoryContents, withTempDirectory )
 import Distribution.InstalledPackageInfo as InstalledPackageInfo
          ( InstalledPackageInfo(exposed) )
 
@@ -41,7 +42,7 @@ regenerateHaddockIndex :: Verbosity
 regenerateHaddockIndex verbosity pkgs progdb index = do
       (paths, warns) <- haddockPackagePaths pkgs' Nothing
       let paths' = [ (interface, html) | (interface, Just html, _) <- paths]
-      forM_ warns (debug verbosity)
+      for_ warns (debug verbosity)
 
       (confHaddock, _, _) <-
           requireProgramVersion verbosity haddockProgram

--- a/cabal-install/Distribution/Client/HashValue.hs
+++ b/cabal-install/Distribution/Client/HashValue.hs
@@ -19,7 +19,6 @@ import qualified Data.ByteString.Base16     as Base16
 import qualified Data.ByteString.Char8      as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
-import Control.Exception (evaluate)
 import System.IO         (IOMode (..), withBinaryFile)
 
 -----------------------------------------------

--- a/cabal-install/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/Distribution/Client/HttpUtils.hs
@@ -28,14 +28,6 @@ import Network.Browser
          ( browse, setOutHandler, setErrHandler, setProxy
          , setAuthorityGen, request, setAllowBasicAuth, setUserAgent )
 import qualified Control.Exception as Exception
-import Control.Exception
-         ( evaluate )
-import Control.DeepSeq
-         ( force )
-import Control.Monad
-         ( guard )
-import Distribution.Verbosity (Verbosity)
-import Distribution.Pretty (prettyShow)
 import Distribution.Simple.Utils
          ( die', info, warn, debug, notice
          , copyFileVerbose,  withTempFile, IOData (..) )
@@ -55,7 +47,6 @@ import System.IO
          ( withFile, IOMode(ReadMode), hGetContents, hClose )
 import System.IO.Error
          ( isDoesNotExistError )
-import Distribution.Parsec (explicitEitherParsec)
 import Distribution.Simple.Program
          ( Program, simpleProgram, ConfiguredProgram, programPath
          , ProgramInvocation(..), programInvocation
@@ -70,7 +61,6 @@ import Distribution.Simple.Program.Run
          ( getProgramInvocationOutputAndErrors )
 import Numeric (showHex)
 import System.Random (randomRIO)
-import System.Exit (ExitCode(..))
 
 import qualified Crypto.Hash.SHA256         as SHA256
 import qualified Data.ByteString.Base16     as Base16

--- a/cabal-install/Distribution/Client/IndexUtils/ActiveRepos.hs
+++ b/cabal-install/Distribution/Client/IndexUtils/ActiveRepos.hs
@@ -13,8 +13,7 @@ import Distribution.Client.Compat.Prelude
 import Distribution.Client.Types.RepoName (RepoName (..))
 import Prelude ()
 
-import Distribution.Parsec (Parsec (..), parsecLeadingCommaNonEmpty)
-import Distribution.Pretty (Pretty (..), prettyShow)
+import Distribution.Parsec (parsecLeadingCommaNonEmpty)
 
 import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint                as Disp

--- a/cabal-install/Distribution/Client/IndexUtils/IndexState.hs
+++ b/cabal-install/Distribution/Client/IndexUtils/IndexState.hs
@@ -21,8 +21,7 @@ import Distribution.Client.Compat.Prelude
 import Distribution.Client.IndexUtils.Timestamp (Timestamp)
 import Distribution.Client.Types.RepoName       (RepoName (..))
 
-import Distribution.Parsec (Parsec (..), parsecLeadingCommaNonEmpty)
-import Distribution.Pretty (Pretty (..))
+import Distribution.Parsec (parsecLeadingCommaNonEmpty)
 
 import qualified Data.Map.Strict                 as Map
 import qualified Distribution.Compat.CharParsing as P

--- a/cabal-install/Distribution/Client/IndexUtils/Timestamp.hs
+++ b/cabal-install/Distribution/Client/IndexUtils/Timestamp.hs
@@ -27,8 +27,6 @@ import Prelude (read)
 
 import Data.Time             (UTCTime (..), fromGregorianValid, makeTimeOfDayValid, showGregorian, timeOfDayToTime, timeToTimeOfDay)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
-import Distribution.Parsec   (Parsec (..))
-import Distribution.Pretty   (Pretty (..))
 
 import qualified Codec.Archive.Tar.Entry         as Tar
 import qualified Distribution.Compat.CharParsing as P

--- a/cabal-install/Distribution/Client/Init/Command.hs
+++ b/cabal-install/Distribution/Client/Init/Command.hs
@@ -32,11 +32,9 @@ import System.FilePath
   ( (</>), takeBaseName, equalFilePath )
 
 import qualified Data.List.NonEmpty as NE
-import Data.Function
-  ( on )
 import qualified Data.Map as M
 import Control.Monad
-  ( (>=>), join, mapM )
+  ( (>=>) )
 import Control.Arrow
   ( (&&&), (***) )
 
@@ -45,8 +43,6 @@ import Distribution.CabalSpecVersion
 import Distribution.Version
   ( Version, mkVersion, alterVersion, majorBoundVersion
   , orLaterVersion, earlierVersion, intersectVersionRanges, VersionRange )
-import Distribution.Verbosity
-  ( Verbosity )
 import Distribution.ModuleName
   ( ModuleName )  -- And for the Text instance
 import Distribution.InstalledPackageInfo
@@ -85,10 +81,6 @@ import Distribution.Simple.Program
   ( ProgramDb )
 import Distribution.Simple.PackageIndex
   ( InstalledPackageIndex, moduleNameIndex )
-import Distribution.Pretty
-  ( prettyShow )
-import Distribution.Parsec
-  ( eitherParsec )
 
 import Distribution.Solver.Types.PackageIndex
   ( elemByPackageName )
@@ -657,7 +649,7 @@ importsToDeps flags mods pkgIx = do
       modDeps = map (id &&& flip M.lookup modMap) mods
 
   message flags "\nGuessing dependencies..."
-  nub . catMaybes <$> mapM (chooseDep flags) modDeps
+  nub . catMaybes <$> traverse (chooseDep flags) modDeps
 
 -- Given a module and a list of installed packages providing it,
 -- choose a dependency (i.e. package + version range) to use for that

--- a/cabal-install/Distribution/Client/Init/Defaults.hs
+++ b/cabal-install/Distribution/Client/Init/Defaults.hs
@@ -19,6 +19,8 @@ module Distribution.Client.Init.Defaults (
   , myLibModule
   ) where
 
+import Prelude (String)
+
 import Distribution.ModuleName
   ( ModuleName )  -- And for the Text instance
 import qualified Distribution.ModuleName as ModuleName

--- a/cabal-install/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/Distribution/Client/Init/FileCreators.hs
@@ -34,13 +34,9 @@ import Distribution.Client.Compat.Prelude hiding (empty)
 import System.FilePath
   ( (</>), (<.>), takeExtension )
 
-import Distribution.Pretty (Pretty, pretty, prettyShow)
 import Distribution.Types.Dependency
 import Distribution.Types.VersionRange
 
-
-import Control.Monad
-  ( forM_ )
 import Data.Time
   ( getCurrentTime, utcToLocalTime, toGregorian, localDay, getCurrentTimeZone )
 import System.Directory
@@ -184,7 +180,7 @@ writeFileSafe flags fileName content = do
 -- | Create directories, if they were given, and don't already exist.
 createDirectories :: Maybe [String] -> IO ()
 createDirectories mdirs = case mdirs of
-  Just dirs -> forM_ dirs (createDirectoryIfMissing True)
+  Just dirs -> for_ dirs (createDirectoryIfMissing True)
   Nothing   -> return ()
 
 -- | Create MyLib.hs file, if its the only module in the liste.

--- a/cabal-install/Distribution/Client/Init/Licenses.hs
+++ b/cabal-install/Distribution/Client/Init/Licenses.hs
@@ -23,6 +23,8 @@ module Distribution.Client.Init.Licenses
   , isc
   ) where
 
+import Prelude (String, unlines, (++))
+
 type License = String
 
 bsd2 :: String -> String -> License

--- a/cabal-install/Distribution/Client/Init/Prompt.hs
+++ b/cabal-install/Distribution/Client/Init/Prompt.hs
@@ -26,15 +26,8 @@ module Distribution.Client.Init.Prompt (
 import Prelude ()
 import Distribution.Client.Compat.Prelude hiding (empty)
 
-import Control.Monad
-  ( mapM_ )
-
 import Distribution.Client.Init.Types
   ( InitFlags(..) )
-import Distribution.Parsec
-  ( Parsec, simpleParsec )
-import Distribution.Pretty
-  ( Pretty, prettyShow )
 import Distribution.Simple.Setup
   ( Flag(..) )
 
@@ -76,15 +69,15 @@ promptDefault' :: (String -> Maybe t)       -- ^ parser
                -> String                    -- ^ prompt message
                -> Maybe t                   -- ^ optional default value
                -> IO t
-promptDefault' parser pretty pr def = do
-  putStr $ mkDefPrompt pr (pretty `fmap` def)
+promptDefault' parser ppr pr def = do
+  putStr $ mkDefPrompt pr (ppr `fmap` def)
   inp <- getLine
   case (inp, def) of
     ("", Just d)  -> return d
     _  -> case parser inp of
             Just t  -> return t
             Nothing -> do putStrLn $ "Couldn't parse " ++ inp ++ ", please try again!"
-                          promptDefault' parser pretty pr def
+                          promptDefault' parser ppr pr def
 
 -- | Create a prompt from a prompt string and a String representation
 --   of an optional default value.
@@ -126,7 +119,7 @@ promptList pr choices def displayItem other = do
   let options1 = map (\c -> (Just c == def, displayItem c)) choices
       options2 = zip ([1..]::[Int])
                      (options1 ++ [(False, "Other (specify)") | other])
-  mapM_ (putStrLn . \(n,(i,s)) -> showOption n i ++ s) options2
+  traverse_ (putStrLn . \(n,(i,s)) -> showOption n i ++ s) options2
   promptList' displayItem (length options2) choices def other
  where showOption n i | n < 10 = " " ++ star i ++ " " ++ rest
                       | otherwise = " " ++ star i ++ rest

--- a/cabal-install/Distribution/Client/Init/Types.hs
+++ b/cabal-install/Distribution/Client/Init/Types.hs
@@ -32,8 +32,6 @@ import Language.Haskell.Extension ( Language(..), Extension )
 import qualified Text.PrettyPrint as Disp
 import qualified Distribution.Compat.CharParsing as P
 import qualified Data.Map as Map
-import Distribution.Pretty (Pretty (..))
-import Distribution.Parsec (Parsec (..))
 
 -- | InitFlags is really just a simple type to represent certain
 --   portions of a .cabal file.  Rather than have a flag for EVERY

--- a/cabal-install/Distribution/Client/Init/Utils.hs
+++ b/cabal-install/Distribution/Client/Init/Utils.hs
@@ -17,6 +17,9 @@ module Distribution.Client.Init.Utils (
   , message
   ) where
 
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import Distribution.Simple.Setup
   ( Flag(..) )
 import Distribution.Client.Init.Types

--- a/cabal-install/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/Distribution/Client/InstallPlan.hs
@@ -83,7 +83,7 @@ import Distribution.Package
          , HasUnitId(..), UnitId )
 import Distribution.Solver.Types.SolverPackage
 import Distribution.Client.JobControl
-import Distribution.Pretty (Pretty (..), prettyShow, defaultStyle)
+import Distribution.Pretty (defaultStyle)
 import Text.PrettyPrint
 import qualified Distribution.Client.SolverInstallPlan as SolverInstallPlan
 import Distribution.Client.SolverInstallPlan (SolverInstallPlan)

--- a/cabal-install/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/Distribution/Client/InstallSymlink.hs
@@ -48,9 +48,7 @@ import Distribution.Simple.Compiler
          ( Compiler, compilerInfo, CompilerInfo(..) )
 import Distribution.System
          ( Platform )
-import Distribution.Verbosity  ( Verbosity )
 import Distribution.Simple.Utils ( info, withTempDirectory )
-import Distribution.Pretty (prettyShow)
 
 import System.Directory
          ( canonicalizePath, getTemporaryDirectory, removeFile )
@@ -59,7 +57,6 @@ import System.FilePath
 
 import System.IO.Error
          ( isDoesNotExistError, ioError )
-import Distribution.Compat.Exception ( catchIO )
 import Control.Exception
          ( assert )
 

--- a/cabal-install/Distribution/Client/JobControl.hs
+++ b/cabal-install/Distribution/Client/JobControl.hs
@@ -28,13 +28,16 @@ module Distribution.Client.JobControl (
     criticalSection
   ) where
 
-import Control.Monad
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
+import Control.Monad (forever, replicateM_)
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar
 import Control.Concurrent.STM (STM, atomically)
 import Control.Concurrent.STM.TVar
 import Control.Concurrent.STM.TChan
-import Control.Exception (SomeException, bracket_, throwIO, try)
+import Control.Exception (bracket_, try)
 import Distribution.Client.Compat.Semaphore
 
 

--- a/cabal-install/Distribution/Client/List.hs
+++ b/cabal-install/Distribution/Client/List.hs
@@ -30,20 +30,18 @@ import Distribution.PackageDescription
          ( PackageFlag(..), unFlagName )
 import Distribution.PackageDescription.Configuration
          ( flattenPackageDescription )
-import Distribution.Pretty (pretty, prettyShow)
 
 import Distribution.Simple.Compiler
         ( Compiler, PackageDBStack )
 import Distribution.Simple.Program (ProgramDb)
 import Distribution.Simple.Utils
-        ( equating, comparing, die', notice )
+        ( equating, die', notice )
 import Distribution.Simple.Setup (fromFlag, fromFlagOrDefault)
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import qualified Distribution.Simple.PackageIndex as InstalledPackageIndex
 import Distribution.Version
          ( Version, mkVersion, versionNumbers, VersionRange, withinRange, anyVersion
          , intersectVersionRanges, simplifyVersionRange )
-import Distribution.Verbosity (Verbosity)
 
 import qualified Distribution.SPDX as SPDX
 
@@ -67,21 +65,19 @@ import Distribution.Client.FetchUtils
 
 import Data.Bits ((.|.))
 import Data.List
-         ( maximumBy, partition )
+         ( maximumBy )
 import Data.List.NonEmpty (groupBy, nonEmpty)
 import qualified Data.List as L
 import Data.Maybe
          ( fromJust )
 import qualified Data.Map as Map
 import Data.Tree as Tree
-import Control.Monad
-         ( join )
 import Control.Exception
          ( assert )
 import qualified Text.PrettyPrint as Disp
 import Text.PrettyPrint
          ( lineLength, ribbonsPerLine, Doc, renderStyle, char
-         , (<+>), nest, ($+$), text, vcat, style, parens, fsep)
+         , nest, ($+$), text, vcat, style, parens, fsep)
 import System.Directory
          ( doesDirectoryExist )
 

--- a/cabal-install/Distribution/Client/Manpage.hs
+++ b/cabal-install/Distribution/Client/Manpage.hs
@@ -28,7 +28,6 @@ import Distribution.Client.Setup        (globalCommand)
 import Distribution.Compat.Process      (createProcess)
 import Distribution.Simple.Command
 import Distribution.Simple.Flag         (fromFlagOrDefault)
-import System.Exit                      (exitWith)
 import System.IO                        (hClose, hPutStr)
 
 import qualified System.Process as Process

--- a/cabal-install/Distribution/Client/ManpageFlags.hs
+++ b/cabal-install/Distribution/Client/ManpageFlags.hs
@@ -10,7 +10,7 @@ import Distribution.Client.Compat.Prelude
 
 import Distribution.Simple.Command (OptionField (..), ShowOrParseArgs (..), option)
 import Distribution.Simple.Setup   (Flag (..), toFlag, trueArg, optionVerbosity)
-import Distribution.Verbosity      (Verbosity, normal)
+import Distribution.Verbosity      (normal)
 
 data ManpageFlags = ManpageFlags
   { manpageVerbosity :: Flag Verbosity

--- a/cabal-install/Distribution/Client/Nix.hs
+++ b/cabal-install/Distribution/Client/Nix.hs
@@ -10,7 +10,7 @@ module Distribution.Client.Nix
 
 import Distribution.Client.Compat.Prelude
 
-import Control.Exception (bracket, catch)
+import Control.Exception (bracket)
 import System.Directory
        ( canonicalizePath, createDirectoryIfMissing, doesDirectoryExist
        , doesFileExist, removeDirectoryRecursive, removeFile )
@@ -23,8 +23,6 @@ import System.Process (showCommandForUser)
 
 import Distribution.Compat.Environment
        ( lookupEnv, setEnv, unsetEnv )
-
-import Distribution.Verbosity
 
 import Distribution.Simple.Program
        ( Program(..), ProgramDb
@@ -84,7 +82,7 @@ nixInstantiate
   -> GlobalFlags
   -> SavedConfig
   -> IO ()
-nixInstantiate verb dist force globalFlags config =
+nixInstantiate verb dist force' globalFlags config =
   findNixExpr globalFlags config >>= \case
     Nothing -> return ()
     Just shellNix -> do
@@ -96,7 +94,7 @@ nixInstantiate verb dist force globalFlags config =
       let timestamp = timestampPath dist shellNix
       upToDate <- existsAndIsMoreRecentThan timestamp shellNix
 
-      let ready = alreadyInShell || (instantiated && upToDate && not force)
+      let ready = alreadyInShell || (instantiated && upToDate && not force')
       unless ready $ do
 
         let prog = simpleProgram "nix-instantiate"

--- a/cabal-install/Distribution/Client/Outdated.hs
+++ b/cabal-install/Distribution/Client/Outdated.hs
@@ -31,7 +31,6 @@ import Distribution.Utils.Generic
 import Distribution.Package                          (PackageName, packageVersion)
 import Distribution.PackageDescription               (allBuildDepends)
 import Distribution.PackageDescription.Configuration (finalizePD)
-import Distribution.Pretty                           (prettyShow)
 import Distribution.Simple.Compiler                  (Compiler, compilerInfo)
 import Distribution.Simple.Setup
        (fromFlagOrDefault, flagToMaybe)
@@ -42,7 +41,7 @@ import Distribution.Types.ComponentRequestedSpec
        (ComponentRequestedSpec(..))
 import Distribution.Types.Dependency
        (Dependency(..))
-import Distribution.Verbosity                        (Verbosity, silent)
+import Distribution.Verbosity                        (silent)
 import Distribution.Version
        (Version, VersionRange, LowerBound(..), UpperBound(..)
        ,asVersionIntervals, majorBoundVersion)
@@ -53,8 +52,6 @@ import Distribution.Types.PackageVersionConstraint
 
 import qualified Data.Set as S
 import System.Directory                              (getCurrentDirectory)
-import System.Exit                                   (exitFailure)
-import Control.Exception                             (throwIO)
 
 -- | Entry point for the 'outdated' command.
 outdated :: Verbosity -> OutdatedFlags -> RepoContext

--- a/cabal-install/Distribution/Client/PackageHash.hs
+++ b/cabal-install/Distribution/Client/PackageHash.hs
@@ -37,7 +37,6 @@ import Distribution.Simple.Compiler
          , ProfDetailLevel(..), showProfDetailLevel )
 import Distribution.Simple.InstallDirs
          ( PathTemplate, fromPathTemplate )
-import Distribution.Pretty (prettyShow)
 import Distribution.Types.PkgconfigVersion (PkgconfigVersion)
 import Distribution.Client.HashValue
 import Distribution.Client.Types
@@ -47,8 +46,6 @@ import qualified Distribution.Solver.Types.ComponentDeps as CD
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-
-import Data.Function     (on)
 
 -------------------------------
 -- Calculating package hashes

--- a/cabal-install/Distribution/Client/PackageUtils.hs
+++ b/cabal-install/Distribution/Client/PackageUtils.hs
@@ -14,6 +14,9 @@ module Distribution.Client.PackageUtils (
     externalBuildDepends,
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Package                      (packageName, packageVersion)
 import Distribution.PackageDescription
        (PackageDescription (..), enabledBuildDepends, libName)

--- a/cabal-install/Distribution/Client/ParseUtils.hs
+++ b/cabal-install/Distribution/Client/ParseUtils.hs
@@ -54,7 +54,7 @@ import Distribution.Deprecated.ViewAsFieldDescr
 import Distribution.Simple.Command
          ( OptionField  )
 
-import Text.PrettyPrint ( (<+>), ($+$) )
+import Text.PrettyPrint ( ($+$) )
 import qualified Data.Map as Map
 import qualified Text.PrettyPrint as Disp
          ( (<>), Doc, text, colon, vcat, empty, isEmpty, nest )

--- a/cabal-install/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding.hs
@@ -90,8 +90,6 @@ import           Distribution.Simple.Compiler
 
 import           Distribution.Simple.Utils
 import           Distribution.Version
-import           Distribution.Verbosity
-import           Distribution.Pretty
 import           Distribution.Compat.Graph (IsNode(..))
 
 import qualified Data.List.NonEmpty as NE
@@ -100,8 +98,7 @@ import qualified Data.Set as Set
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 
-import Control.Exception (Exception (..), Handler (..), SomeAsyncException, SomeException, assert, catches, handle, throwIO)
-import Data.Function     (on)
+import Control.Exception (Handler (..), SomeAsyncException, assert, catches, handle)
 import System.Directory  (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, removeFile, renameDirectory)
 import System.FilePath   (dropDrive, makeRelative, normalise, takeDirectory, (<.>), (</>))
 import System.IO         (IOMode (AppendMode), withFile)

--- a/cabal-install/Distribution/Client/ProjectBuilding/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectBuilding/Types.hs
@@ -22,17 +22,15 @@ module Distribution.Client.ProjectBuilding.Types (
     BuildFailureReason(..),
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Client.Types          (DocsResult, TestsResult)
 import Distribution.Client.FileMonitor    (MonitorChangedReason(..))
 
 import Distribution.Package               (UnitId, PackageId)
 import Distribution.InstalledPackageInfo  (InstalledPackageInfo)
 import Distribution.Simple.LocalBuildInfo (ComponentName)
-
-import Data.Map          (Map)
-import Data.Set          (Set)
-import Data.Typeable     (Typeable)
-import Control.Exception (Exception, SomeException)
 
 
 ------------------------------------------------------------------------------

--- a/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Legacy.hs
@@ -41,8 +41,6 @@ import Distribution.Client.CmdInstall.ClientInstallFlags
 import Distribution.Solver.Types.ConstraintSource
 
 import Distribution.FieldGrammar
-import Distribution.Pretty (Pretty (..), prettyShow)
-import Distribution.Parsec (Parsec (..), simpleParsec)
 import Distribution.Package
 import Distribution.Types.SourceRepo (RepoType)
 import Distribution.PackageDescription

--- a/cabal-install/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectConfig/Types.hs
@@ -64,8 +64,6 @@ import Distribution.Simple.InstallDirs
          ( PathTemplate )
 import Distribution.Utils.NubList
          ( NubList )
-import Distribution.Verbosity
-         ( Verbosity )
 
 import qualified Data.Map as Map
 

--- a/cabal-install/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/Distribution/Client/ProjectOrchestration.hs
@@ -158,19 +158,14 @@ import           Distribution.Simple.Utils
 import           Distribution.Verbosity
 import           Distribution.Version
                    ( mkVersion )
-import           Distribution.Pretty
-                   ( prettyShow )
 import           Distribution.Simple.Compiler
                    ( compilerCompatVersion, showCompilerId
                    , OptimisationLevel(..))
 
-import qualified Data.Monoid as Mon
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as Set
 import qualified Data.Map as Map
-import           Data.Either
-import           Control.Exception (Exception(..), throwIO, assert)
-import           System.Exit (ExitCode(..), exitFailure)
+import           Control.Exception (assert)
 #ifdef MIN_VERSION_unix
 import           System.Posix.Signals (sigKILL, sigSEGV)
 #endif
@@ -949,7 +944,7 @@ printPlan verbosity
               computeEffectiveProfiling fullConfigureFlags
 
             partialConfigureFlags
-              = Mon.mempty {
+              = mempty {
                 configProf    =
                     nubFlag False (configProf fullConfigureFlags),
                 configProfExe =

--- a/cabal-install/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanOutput.hs
@@ -44,7 +44,6 @@ import           Distribution.Simple.GHC
                    ( getImplInfo, GhcImplInfo(supportsPkgEnvFiles)
                    , GhcEnvironmentFileEntry(..), simpleGhcEnvironmentFile
                    , writeGhcEnvironmentFile )
-import           Distribution.Pretty (Pretty, prettyShow)
 import qualified Distribution.Compat.Graph as Graph
 import           Distribution.Compat.Graph (Graph, Node)
 import qualified Distribution.Compat.Binary as Binary

--- a/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/Distribution/Client/ProjectPlanning/Types.hs
@@ -78,8 +78,7 @@ import           Distribution.Client.DistDirLayout
 import           Distribution.Backpack
 import           Distribution.Backpack.ModuleShape
 
-import           Distribution.Pretty
-import           Distribution.Verbosity
+import           Distribution.Verbosity (normal)
 import           Distribution.Types.ComponentRequestedSpec
 import           Distribution.Types.PkgconfigVersion
 import           Distribution.Types.PackageDescription (PackageDescription(..))
@@ -108,7 +107,6 @@ import           Distribution.Simple.Utils (ordNub)
 import qualified Data.Map as Map
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Monoid as Mon
-import           Control.Monad (guard)
 import           System.FilePath ((</>))
 
 

--- a/cabal-install/Distribution/Client/RebuildMonad.hs
+++ b/cabal-install/Distribution/Client/RebuildMonad.hs
@@ -63,7 +63,6 @@ import Distribution.Client.Glob hiding (matchFileGlob)
 import qualified Distribution.Client.Glob as Glob (matchFileGlob)
 
 import Distribution.Simple.Utils (debug)
-import Distribution.Verbosity    (Verbosity)
 
 import qualified Data.Map.Strict as Map
 import Control.Monad.State as State

--- a/cabal-install/Distribution/Client/Reconfigure.hs
+++ b/cabal-install/Distribution/Client/Reconfigure.hs
@@ -5,8 +5,6 @@ import Distribution.Client.Compat.Prelude
 import Data.Monoid ( Any(..) )
 import System.Directory ( doesFileExist )
 
-import Distribution.Verbosity
-
 import Distribution.Simple.Configure ( localBuildInfoFile )
 import Distribution.Simple.Setup ( Flag, flagToMaybe, toFlag )
 import Distribution.Simple.Utils
@@ -126,11 +124,11 @@ reconfigure
             <> checkDist
             <> checkOutdated
             <> check
-      (Any force, flags@(configFlags, _)) <- runCheck checks mempty savedFlags
+      (Any frc, flags@(configFlags, _)) <- runCheck checks mempty savedFlags
 
       let config' = updateInstallDirs (configUserInstall configFlags) config
 
-      when force $ configureAction flags extraArgs globalFlags
+      when frc $ configureAction flags extraArgs globalFlags
       return config'
 
   where

--- a/cabal-install/Distribution/Client/Run.hs
+++ b/cabal-install/Distribution/Client/Run.hs
@@ -34,8 +34,6 @@ import Distribution.Simple.Utils             (die', notice, warn,
                                               rawSystemExitWithEnv,
                                               addLibraryPath)
 import Distribution.System                   (Platform (..))
-import Distribution.Verbosity                (Verbosity)
-import Distribution.Pretty                   (prettyShow)
 
 import qualified Distribution.Simple.GHCJS as GHCJS
 

--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -42,7 +42,6 @@ import Distribution.Simple.Program            ( ProgramDb )
 import Distribution.Simple.Setup              ( Flag(..)
                                               , fromFlagOrDefault, flagToMaybe )
 import Distribution.System                    ( Platform )
-import Distribution.Verbosity                 ( Verbosity )
 
 import System.Directory                       ( getCurrentDirectory )
 

--- a/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
+++ b/cabal-install/Distribution/Client/Sandbox/PackageEnvironment.hs
@@ -22,6 +22,9 @@ module Distribution.Client.Sandbox.PackageEnvironment (
   , userPackageEnvironmentFile
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Client.Config      ( SavedConfig(..) 
                                        , configFieldDescriptions
                                        , haddockFlagsFields
@@ -44,23 +47,13 @@ import Distribution.Deprecated.ParseUtils         ( FieldDescr(..), ParseResult(
                                        , readFields
                                        , showPWarning 
                                        , syntaxError, warning )
-import Distribution.Verbosity          ( Verbosity )
-import Control.Monad                   ( foldM, unless )
-import Data.List                       ( partition, sortBy )
-import Data.Ord                        ( comparing )
-import Distribution.Compat.Exception   ( catchIO )
-import Distribution.Compat.Semigroup
 import System.Directory                ( doesFileExist )
 import System.FilePath                 ( (</>) )
 import System.IO.Error                 ( isDoesNotExistError )
 import Text.PrettyPrint                ( ($+$) )
-import Distribution.Parsec             (Parsec (..))
-import Distribution.Pretty             (Pretty (..))
 
 import qualified Text.PrettyPrint          as Disp
 import qualified Distribution.Deprecated.ParseUtils   as ParseUtils ( Field(..) )
-import GHC.Generics ( Generic )
-
 
 --
 -- * Configuration saved in the package environment file

--- a/cabal-install/Distribution/Client/SavedFlags.hs
+++ b/cabal-install/Distribution/Client/SavedFlags.hs
@@ -5,17 +5,15 @@ module Distribution.Client.SavedFlags
        , readSavedArgs, writeSavedArgs
        ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Simple.Command
 import Distribution.Simple.UserHooks ( Args )
 import Distribution.Simple.Utils
        ( createDirectoryIfMissingVerbose, unintersperse )
 import Distribution.Verbosity
 
-import Control.Exception ( Exception, throwIO )
-import Control.Monad ( liftM )
-import Data.List ( intercalate )
-import Data.Maybe ( fromMaybe )
-import Data.Typeable
 import System.Directory ( doesFileExist )
 import System.FilePath ( takeDirectory )
 
@@ -41,7 +39,7 @@ readSavedArgs :: FilePath -> IO (Maybe [String])
 readSavedArgs path = do
   exists <- doesFileExist path
   if exists
-     then liftM (Just . unintersperse '\0') (readFile path)
+     then fmap (Just . unintersperse '\0') (readFile path)
     else return Nothing
 
 
@@ -49,7 +47,7 @@ readSavedArgs path = do
 -- Returns the default flags if the file does not exist.
 readCommandFlags :: FilePath -> CommandUI flags -> IO flags
 readCommandFlags path command = do
-  savedArgs <- liftM (fromMaybe []) (readSavedArgs path)
+  savedArgs <- fmap (fromMaybe []) (readSavedArgs path)
   case (commandParseArgs command True savedArgs) of
     CommandHelp _ -> throwIO (SavedArgsErrorHelp savedArgs)
     CommandList _ -> throwIO (SavedArgsErrorList savedArgs)

--- a/cabal-install/Distribution/Client/Security/DNS.hs
+++ b/cabal-install/Distribution/Client/Security/DNS.hs
@@ -7,12 +7,8 @@ module Distribution.Client.Security.DNS
 import Prelude ()
 import Distribution.Client.Compat.Prelude
 import Network.URI (URI(..), URIAuth(..), parseURI)
-import Distribution.Verbosity
-import Control.Monad
-import Control.DeepSeq (force)
-import Control.Exception (SomeException, evaluate, try)
+import Control.Exception (try)
 import Distribution.Simple.Utils
-import Distribution.Compat.Exception (displayException)
 
 #if defined(MIN_VERSION_resolv) || defined(MIN_VERSION_windns)
 import Network.DNS (queryTXT, Name(..), CharStr(..))
@@ -70,7 +66,7 @@ queryBootstrapMirrors verbosity repoUri
          then warn verbosity ("No mirrors found for " ++ show repoUri)
          else do info verbosity ("located " ++ show (length mirrors) ++
                                  " mirrors for " ++ show repoUri ++ " :")
-                 forM_ mirrors $ \url -> info verbosity ("- " ++ show url)
+                 for_ mirrors $ \url -> info verbosity ("- " ++ show url)
 
          return mirrors
 
@@ -117,7 +113,7 @@ queryBootstrapMirrors verbosity repoUri
               then warn verbosity ("No mirrors found for " ++ show repoUri)
               else do info verbosity ("located " ++ show (length mirrors) ++
                                       " mirrors for " ++ show repoUri ++ " :")
-                      forM_ mirrors $ \url -> info verbosity ("- " ++ show url)
+                      for_ mirrors $ \url -> info verbosity ("- " ++ show url)
 
               return mirrors
 

--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -79,8 +79,6 @@ import Distribution.Client.Targets
          ( UserConstraint, readUserConstraint )
 import Distribution.Utils.NubList
          ( NubList, toNubList, fromNubList)
-import Distribution.Parsec (CabalParsing, simpleParsec, parsec, eitherParsec)
-import Distribution.Pretty (prettyShow)
 
 import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.Settings
@@ -126,7 +124,7 @@ import Distribution.ReadE
          ( ReadE(..), succeedReadE, parsecToReadE )
 import qualified Distribution.Compat.CharParsing as P
 import Distribution.Verbosity
-         ( Verbosity, lessVerbose, normal, verboseNoFlags, verboseNoTimestamp )
+         ( lessVerbose, normal, verboseNoFlags, verboseNoTimestamp )
 import Distribution.Simple.Utils
          ( wrapText )
 import Distribution.Client.GlobalFlags

--- a/cabal-install/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/Distribution/Client/SetupWrapper.hs
@@ -87,7 +87,7 @@ import Distribution.Utils.Generic
          ( safeHead )
 import Distribution.Simple.Utils
          ( die', debug, info, infoNoWrap
-         , cabalVersion, tryFindPackageDesc, comparing
+         , cabalVersion, tryFindPackageDesc
          , createDirectoryIfMissingVerbose, installExecutableFile
          , copyFileVerbose, rewriteFileEx, rewriteFileLBS )
 import Distribution.Client.Utils
@@ -100,18 +100,14 @@ import Distribution.Client.Utils
 
 import Distribution.ReadE
 import Distribution.System ( Platform(..), buildPlatform )
-import Distribution.Pretty (prettyShow)
 import Distribution.Utils.NubList
          ( toNubListR )
 import Distribution.Verbosity
-import Distribution.Compat.Exception
-         ( catchIO )
 import Distribution.Compat.Stack
 
 import System.Directory    ( doesFileExist )
 import System.FilePath     ( (</>), (<.>) )
 import System.IO           ( Handle, hPutStr )
-import System.Exit         ( ExitCode(..), exitWith )
 import Distribution.Compat.Process (createProcess)
 import System.Process      ( StdStream(..), proc, waitForProcess
                            , ProcessHandle )

--- a/cabal-install/Distribution/Client/SolverInstallPlan.hs
+++ b/cabal-install/Distribution/Client/SolverInstallPlan.hs
@@ -58,8 +58,6 @@ import Distribution.Package
          ( PackageIdentifier(..), Package(..), PackageName
          , HasUnitId(..), PackageId, packageVersion, packageName )
 import qualified Distribution.Solver.Types.ComponentDeps as CD
-import Distribution.Pretty
-         ( prettyShow )
 
 import Distribution.Client.Types
          ( UnresolvedPkgLoc )

--- a/cabal-install/Distribution/Client/SrcDist.hs
+++ b/cabal-install/Distribution/Client/SrcDist.hs
@@ -3,6 +3,9 @@ module Distribution.Client.SrcDist (
     allPackageSourceFiles,
 )  where
 
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import Distribution.PackageDescription.Configuration (flattenPackageDescription)
 import Distribution.PackageDescription.Parsec        (readGenericPackageDescription)
 import Distribution.Simple.PreProcess                (knownSuffixHandlers)

--- a/cabal-install/Distribution/Client/Store.hs
+++ b/cabal-install/Distribution/Client/Store.hs
@@ -33,11 +33,10 @@ import           Distribution.Compiler (CompilerId)
 import           Distribution.Simple.Utils
                    ( withTempDirectory, debug, info )
 import           Distribution.Verbosity
-import           Distribution.Pretty (prettyShow)
+                   ( silent )
 
 import qualified Data.Set as Set
 import           Control.Exception
-import           Control.Monad (forM_)
 import           System.FilePath
 import           System.Directory
 
@@ -214,7 +213,7 @@ newStoreEntry verbosity storeDirLayout@StoreDirLayout{..}
 
             -- Atomically rename the temp dir to the final store entry location.
             renameDirectory incomingEntryDir finalEntryDir
-            forM_ otherFiles $ \file -> do
+            for_ otherFiles $ \file -> do
               let finalStoreFile = storeDirectory compid </> makeRelative (incomingTmpDir </> (dropDrive (storeDirectory compid))) file
               createDirectoryIfMissing True (takeDirectory finalStoreFile)
               renameFile file finalStoreFile

--- a/cabal-install/Distribution/Client/Tar.hs
+++ b/cabal-install/Distribution/Client/Tar.hs
@@ -28,6 +28,9 @@ module Distribution.Client.Tar (
   entriesToList,
   ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import qualified Data.ByteString.Lazy    as BS
 import qualified Codec.Archive.Tar       as Tar
 import qualified Codec.Archive.Tar.Entry as Tar
@@ -35,7 +38,8 @@ import qualified Codec.Archive.Tar.Check as Tar
 import qualified Codec.Compression.GZip  as GZip
 import qualified Distribution.Client.GZipUtils as GZipUtils
 
-import Control.Exception (Exception(..), throw)
+-- for foldEntries...
+import Control.Exception (throw)
 
 --
 -- * High level operations

--- a/cabal-install/Distribution/Client/Types/AllowNewer.hs
+++ b/cabal-install/Distribution/Client/Types/AllowNewer.hs
@@ -14,8 +14,7 @@ module Distribution.Client.Types.AllowNewer (
 import Distribution.Client.Compat.Prelude
 import Prelude ()
 
-import Distribution.Parsec            (CabalParsing, Parsec (..), parsecLeadingCommaNonEmpty)
-import Distribution.Pretty            (Pretty (..))
+import Distribution.Parsec            (parsecLeadingCommaNonEmpty)
 import Distribution.Types.PackageId   (PackageId, PackageIdentifier (..))
 import Distribution.Types.PackageName (PackageName, mkPackageName)
 import Distribution.Types.Version     (nullVersion)

--- a/cabal-install/Distribution/Client/Types/BuildResults.hs
+++ b/cabal-install/Distribution/Client/Types/BuildResults.hs
@@ -11,8 +11,6 @@ module Distribution.Client.Types.BuildResults (
 import Distribution.Client.Compat.Prelude
 import Prelude ()
 
-import Control.Exception (Exception, SomeException)
-
 import Distribution.Types.InstalledPackageInfo (InstalledPackageInfo)
 import Distribution.Types.PackageId            (PackageId)
 import Distribution.Types.UnitId               (UnitId)

--- a/cabal-install/Distribution/Client/Types/Credentials.hs
+++ b/cabal-install/Distribution/Client/Types/Credentials.hs
@@ -3,5 +3,7 @@ module Distribution.Client.Types.Credentials (
     Password (..),
 ) where
 
+import Prelude (String)
+
 newtype Username = Username { unUsername :: String }
 newtype Password = Password { unPassword :: String }

--- a/cabal-install/Distribution/Client/Types/InstallMethod.hs
+++ b/cabal-install/Distribution/Client/Types/InstallMethod.hs
@@ -4,9 +4,6 @@ module Distribution.Client.Types.InstallMethod where
 import Distribution.Client.Compat.Prelude
 import Prelude ()
 
-import Distribution.Parsec (Parsec (..))
-import Distribution.Pretty (Pretty (..))
-
 import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint                as PP
 

--- a/cabal-install/Distribution/Client/Types/OverwritePolicy.hs
+++ b/cabal-install/Distribution/Client/Types/OverwritePolicy.hs
@@ -4,9 +4,6 @@ module Distribution.Client.Types.OverwritePolicy where
 import Distribution.Client.Compat.Prelude
 import Prelude ()
 
-import Distribution.Parsec (Parsec (..))
-import Distribution.Pretty (Pretty (..))
-
 import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint                as PP
 

--- a/cabal-install/Distribution/Client/Types/Repo.hs
+++ b/cabal-install/Distribution/Client/Types/Repo.hs
@@ -18,8 +18,6 @@ import Prelude ()
 
 import Network.URI (URI (..), nullURI, parseAbsoluteURI, uriToString)
 
-import Distribution.Parsec       (Parsec (..))
-import Distribution.Pretty       (Pretty (..))
 import Distribution.Simple.Utils (toUTF8BS)
 
 import Distribution.Client.HashValue (hashValue, showHashValue, truncateHash)

--- a/cabal-install/Distribution/Client/Types/RepoName.hs
+++ b/cabal-install/Distribution/Client/Types/RepoName.hs
@@ -7,9 +7,6 @@ module Distribution.Client.Types.RepoName (
 import Distribution.Client.Compat.Prelude
 import Prelude ()
 
-import Distribution.Parsec (Parsec (..))
-import Distribution.Pretty (Pretty (..))
-
 import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint                as Disp
 

--- a/cabal-install/Distribution/Client/Update.hs
+++ b/cabal-install/Distribution/Client/Update.hs
@@ -15,6 +15,9 @@ module Distribution.Client.Update
     ( update
     ) where
 
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
 import Distribution.Simple.Setup
          ( fromFlag )
 import Distribution.Client.Compat.Directory
@@ -34,9 +37,7 @@ import Distribution.Client.JobControl
          ( newParallelJobControl, spawnJob, collectJob )
 import Distribution.Client.Setup
          ( RepoContext(..), UpdateFlags(..) )
-import Distribution.Pretty
-         ( prettyShow )
-import Distribution.Verbosity
+import Distribution.Verbosity (lessVerbose)
 
 import Distribution.Simple.Utils
          ( writeFileAtomic, warn, notice, noticeNoWrap )
@@ -44,9 +45,7 @@ import Distribution.Simple.Utils
 import qualified Data.ByteString.Lazy       as BS
 import Distribution.Client.GZipUtils (maybeDecompress)
 import System.FilePath ((<.>), dropExtension)
-import Data.Maybe (mapMaybe)
 import Data.Time (getCurrentTime)
-import Control.Monad
 
 import qualified Hackage.Security.Client as Sec
 
@@ -67,8 +66,8 @@ update verbosity updateFlags repoCtxt = do
             $ "Downloading the latest package lists from: "
             : map (("- " ++) . unRepoName . remoteRepoName) remoteRepos
   jobCtrl <- newParallelJobControl (length repos)
-  mapM_ (spawnJob jobCtrl . updateRepo verbosity updateFlags repoCtxt) repos
-  mapM_ (\_ -> collectJob jobCtrl) repos
+  traverse_ (spawnJob jobCtrl . updateRepo verbosity updateFlags repoCtxt) repos
+  traverse_ (\_ -> collectJob jobCtrl) repos
 
 updateRepo :: Verbosity -> UpdateFlags -> RepoContext -> Repo -> IO ()
 updateRepo verbosity updateFlags repoCtxt repo = do

--- a/cabal-install/Distribution/Client/Utils.hs
+++ b/cabal-install/Distribution/Client/Utils.hs
@@ -27,18 +27,16 @@ import Prelude ()
 import Distribution.Client.Compat.Prelude
 
 import Distribution.Compat.Environment
-import Distribution.Compat.Exception   ( catchIO )
-import Distribution.Compat.Time ( getModTime )
+import Distribution.Compat.Time        ( getModTime )
 import Distribution.Simple.Setup       ( Flag(..) )
 import Distribution.Version
-import Distribution.Verbosity
 import Distribution.Simple.Utils       ( die', findPackageDesc, noticeNoWrap )
 import qualified Data.ByteString.Lazy as BS
 import Data.Bits
          ( (.|.), shiftL, shiftR )
 import System.FilePath
 import Control.Monad
-         ( mapM, mapM_, zipWithM_ )
+         ( zipWithM_ )
 import Data.List
          ( groupBy )
 import Foreign.C.Types ( CInt(..) )
@@ -149,8 +147,8 @@ withEnv k v m = do
 -- environment is a process-global concept.
 withEnvOverrides :: [(String, Maybe FilePath)] -> IO a -> IO a
 withEnvOverrides overrides m = do
-  mb_olds <- mapM lookupEnv envVars
-  mapM_ (uncurry update) overrides
+  mb_olds <- traverse lookupEnv envVars
+  traverse_ (uncurry update) overrides
   m `Exception.finally` zipWithM_ update envVars mb_olds
    where
     envVars :: [String]

--- a/cabal-install/Distribution/Client/Utils/Assertion.hs
+++ b/cabal-install/Distribution/Client/Utils/Assertion.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE CPP #-}
 module Distribution.Client.Utils.Assertion (expensiveAssert) where
 
+
 #ifdef DEBUG_EXPENSIVE_ASSERTIONS
+import Prelude (Bool)
 import Control.Exception (assert)
 import Distribution.Compat.Stack
+#else
+import Prelude (Bool, id)
 #endif
 
 -- | Like 'assert', but only enabled with -fdebug-expensive-assertions. This

--- a/cabal-install/Distribution/Client/VCS.hs
+++ b/cabal-install/Distribution/Client/VCS.hs
@@ -40,7 +40,7 @@ import Distribution.Client.Types.SourceRepo (SourceRepoMaybe, SourceRepositoryPa
 import Distribution.Client.RebuildMonad
          ( Rebuild, monitorFiles, MonitorFilePath, monitorDirectoryExistence )
 import Distribution.Verbosity as Verbosity
-         ( Verbosity, normal )
+         ( normal )
 import Distribution.Simple.Program
          ( Program(programFindVersion)
          , ConfiguredProgram(programVersion)
@@ -51,14 +51,10 @@ import Distribution.Version
          ( mkVersion )
 import qualified Distribution.PackageDescription as PD
 
-import Control.Monad
-         ( mapM_ )
 import Control.Monad.Trans
          ( liftIO )
 import qualified Data.Char as Char
 import qualified Data.Map  as Map
-import Data.Either
-         ( partitionEithers )
 import System.FilePath
          ( takeDirectory )
 import System.Directory
@@ -187,7 +183,7 @@ cloneSourceRepo
     -> IO ()
 cloneSourceRepo verbosity vcs
                 repo@SourceRepositoryPackage{ srpLocation = srcuri } destdir =
-    mapM_ (runProgramInvocation verbosity) invocations
+    traverse_ (runProgramInvocation verbosity) invocations
   where
     invocations = vcsCloneRepo vcs verbosity
                                (vcsProgram vcs) repo

--- a/cabal-install/Distribution/Client/Win32SelfUpgrade.hs
+++ b/cabal-install/Distribution/Client/Win32SelfUpgrade.hs
@@ -42,6 +42,9 @@ module Distribution.Client.Win32SelfUpgrade (
     deleteOldExeFile,
   ) where
 
+import Distribution.Client.Compat.Prelude hiding (log)
+import Prelude ()
+
 #ifdef mingw32_HOST_OS
 
 import qualified System.Win32 as Win32
@@ -51,10 +54,9 @@ import System.Process (runProcess)
 import System.Directory (canonicalizePath)
 import System.FilePath (takeBaseName, replaceBaseName, equalFilePath)
 
-import Distribution.Verbosity as Verbosity (Verbosity, showForCabal)
+import Distribution.Verbosity as Verbosity (showForCabal)
 import Distribution.Simple.Utils (debug, info)
 
-import Prelude hiding (log)
 
 -- | If one of the given files is our own exe file then we arrange things such
 -- that the nested action can replace our own exe file.
@@ -68,7 +70,7 @@ possibleSelfUpgrade :: Verbosity
 possibleSelfUpgrade verbosity newPaths action = do
   dstPath <- canonicalizePath =<< Win32.getModuleFileName Win32.nullHANDLE
 
-  newPaths' <- mapM canonicalizePath newPaths
+  newPaths' <- traverse canonicalizePath newPaths
   let doingSelfUpgrade = any (equalFilePath dstPath) newPaths'
 
   if not doingSelfUpgrade
@@ -211,7 +213,6 @@ setEvent handle =
 
 #else
 
-import Distribution.Verbosity (Verbosity)
 import Distribution.Simple.Utils (die')
 
 possibleSelfUpgrade :: Verbosity

--- a/cabal-install/Distribution/Client/World.hs
+++ b/cabal-install/Distribution/Client/World.hs
@@ -37,14 +37,9 @@ import Distribution.Types.Dependency
 import Distribution.Types.Flag
          ( FlagAssignment, unFlagAssignment
          , unFlagName, parsecFlagAssignmentNonEmpty )
-import Distribution.Verbosity
-         ( Verbosity )
 import Distribution.Simple.Utils
          ( die', info, chattyTry, writeFileAtomic )
-import Distribution.Parsec (Parsec (..), CabalParsing, simpleParsec)
-import Distribution.Pretty (Pretty (..), prettyShow)
 import qualified Distribution.Compat.CharParsing as P
-import Distribution.Compat.Exception ( catchIO )
 import qualified Text.PrettyPrint as Disp
 
 import Data.List

--- a/cabal-install/Distribution/Deprecated/ParseUtils.hs
+++ b/cabal-install/Distribution/Deprecated/ParseUtils.hs
@@ -57,7 +57,7 @@ import Text.PrettyPrint (Doc, punctuate, comma, fsep, sep)
 import qualified Text.Read as Read
 
 import qualified Control.Monad.Fail as Fail
-import Distribution.Parsec (ParsecParser, explicitEitherParsec, parsecLeadingCommaList, parsecLeadingOptCommaList)
+import Distribution.Parsec (ParsecParser, parsecLeadingCommaList, parsecLeadingOptCommaList)
 
 -- -----------------------------------------------------------------------------
 

--- a/cabal-install/Distribution/Deprecated/ViewAsFieldDescr.hs
+++ b/cabal-install/Distribution/Deprecated/ViewAsFieldDescr.hs
@@ -6,8 +6,6 @@ import Distribution.Client.Compat.Prelude hiding (get)
 import Prelude ()
 
 import qualified Data.List.NonEmpty as NE
-import Distribution.Parsec   (parsec)
-import Distribution.Pretty
 import Distribution.ReadE          (parsecToReadE)
 import Distribution.Simple.Command
 import Text.PrettyPrint            (cat, comma, punctuate, text)

--- a/cabal-install/Distribution/Solver/Modular.hs
+++ b/cabal-install/Distribution/Solver/Modular.hs
@@ -17,7 +17,6 @@ import Distribution.Solver.Compat.Prelude
 
 import qualified Data.Map as M
 import Data.Set (isSubsetOf)
-import Data.Ord
 import Distribution.Compat.Graph
          ( IsNode(..) )
 import Distribution.Compiler

--- a/cabal-install/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install/Distribution/Solver/Modular/Explore.hs
@@ -3,13 +3,14 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Distribution.Solver.Modular.Explore (backjumpAndExplore) where
 
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import qualified Distribution.Solver.Types.Progress as P
 
-import Data.Foldable as F
-import Data.List as L (foldl')
-import Data.Maybe (fromMaybe)
-import Data.Map.Strict as M
-import Data.Set as S
+import qualified Data.List as L (foldl')
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
 
 import Distribution.Simple.Setup (asBool)
 
@@ -81,7 +82,7 @@ backjump :: forall w k a . Maybe Int
          -> ExploreState -> ConflictSetLog a
 backjump mbj enableBj fineGrainedConflicts couldResolveConflicts
          logSkippedChoice var lastCS xs =
-    F.foldr combine avoidGoal [(k, v) | (_, k, v) <- W.toList xs] CS.empty Nothing
+    foldr combine avoidGoal [(k, v) | (_, k, v) <- W.toList xs] CS.empty Nothing
   where
     combine :: (k, ExploreState -> ConflictSetLog a)
             -> (ConflictSet -> Maybe ConflictSet -> ExploreState -> ConflictSetLog a)
@@ -269,7 +270,7 @@ exploreLog mbj enableBj fineGrainedConflicts (CountConflicts countConflicts) idx
     -- to be merged with the previous one.
     couldResolveConflicts :: QPN -> POption -> S.Set CS.Conflict -> Maybe ConflictSet
     couldResolveConflicts currentQPN@(Q _ pn) (POption i@(I v _) _) conflicts =
-      let (PInfo deps _ _ _) = idx ! pn ! i
+      let (PInfo deps _ _ _) = idx M.! pn M.! i
           qdeps = qualifyDeps (defaultQualifyOptions idx) currentQPN deps
 
           couldBeResolved :: CS.Conflict -> Maybe ConflictSet
@@ -277,7 +278,7 @@ exploreLog mbj enableBj fineGrainedConflicts (CountConflicts countConflicts) idx
           couldBeResolved (CS.GoalConflict conflictingDep) =
               -- Check whether this package instance also has 'conflictingDep'
               -- as a dependency (ignoring flag and stanza choices).
-              if F.null [() | Simple (LDep _ (Dep (PkgComponent qpn _) _)) _ <- qdeps, qpn == conflictingDep]
+              if null [() | Simple (LDep _ (Dep (PkgComponent qpn _) _)) _ <- qdeps, qpn == conflictingDep]
               then Nothing
               else Just CS.empty
           couldBeResolved (CS.VersionConstraintConflict dep excludedVersion) =

--- a/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install/Distribution/Solver/Modular/IndexConversion.hs
@@ -2,11 +2,11 @@ module Distribution.Solver.Modular.IndexConversion
     ( convPIs
     ) where
 
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import qualified Data.List as L
-import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
-import Data.Maybe (mapMaybe, fromMaybe, maybeToList)
-import Data.Monoid as Mon
 import qualified Data.Set as S
 
 import qualified Distribution.InstalledPackageInfo as IPI
@@ -90,7 +90,7 @@ convId ipi = (pn, I ver $ Inst $ IPI.installedUnitId ipi)
 -- | Convert a single installed package into the solver-specific format.
 convIP :: SI.InstalledPackageIndex -> IPI.InstalledPackageInfo -> (PN, I, PInfo)
 convIP idx ipi =
-  case mapM (convIPId (DependencyReason pn M.empty S.empty) comp idx) (IPI.depends ipi) of
+  case traverse (convIPId (DependencyReason pn M.empty S.empty) comp idx) (IPI.depends ipi) of
         Nothing  -> (pn, i, PInfo [] M.empty M.empty (Just Broken))
         Just fds -> ( pn
                     , i
@@ -182,7 +182,7 @@ convGPD os arch cinfo constraints strfl solveExes pn
     ipns = S.fromList $ [ unqualComponentNameToPackageName nm
                         | (nm, _) <- sub_libs ]
 
-    conv :: Mon.Monoid a => Component -> (a -> BuildInfo) -> DependencyReason PN ->
+    conv :: Monoid a => Component -> (a -> BuildInfo) -> DependencyReason PN ->
             CondTree ConfVar [Dependency] a -> FlaggedDeps PN
     conv comp getInfo dr =
         convCondTree M.empty dr pkg os arch cinfo pn fds comp getInfo ipns solveExes .

--- a/cabal-install/Distribution/Solver/Modular/LabeledGraph.hs
+++ b/cabal-install/Distribution/Solver/Modular/LabeledGraph.hs
@@ -17,10 +17,11 @@ module Distribution.Solver.Modular.LabeledGraph (
   , topSort
   ) where
 
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import Data.Array
 import Data.Graph (Vertex, Bounds)
-import Data.List (sortBy)
-import Data.Maybe (mapMaybe)
 import qualified Data.Graph as G
 
 {-------------------------------------------------------------------------------

--- a/cabal-install/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install/Distribution/Solver/Modular/Linking.hs
@@ -13,7 +13,6 @@ import Distribution.Solver.Compat.Prelude hiding (get,put)
 import Control.Exception (assert)
 import Control.Monad.Reader
 import Control.Monad.State
-import Data.Function (on)
 import Data.Map ((!))
 import qualified Data.Map         as M
 import qualified Data.Set         as S

--- a/cabal-install/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install/Distribution/Solver/Modular/Preference.hs
@@ -21,11 +21,9 @@ module Distribution.Solver.Modular.Preference
 import Prelude ()
 import Distribution.Solver.Compat.Prelude
 
-import Data.Function (on)
 import qualified Data.List as L
 import qualified Data.Map as M
-import Control.Monad.Reader hiding (sequence)
-import Data.Traversable (sequence)
+import Control.Monad.Trans.Reader (Reader, runReader, ask, local)
 
 import Distribution.PackageDescription (lookupFlagAssignment, unFlagAssignment) -- from Cabal
 
@@ -462,7 +460,7 @@ enforceSingleInstanceRestriction = (`runReader` M.empty) . cata go
 
     -- We just verify package choices.
     go (PChoiceF qpn rdm gr cs) =
-      PChoice qpn rdm gr <$> sequence (W.mapWithKey (goP qpn) cs)
+      PChoice qpn rdm gr <$> sequenceA (W.mapWithKey (goP qpn) cs)
     go _otherwise =
       innM _otherwise
 

--- a/cabal-install/Distribution/Solver/Modular/RetryLog.hs
+++ b/cabal-install/Distribution/Solver/Modular/RetryLog.hs
@@ -11,6 +11,9 @@ module Distribution.Solver.Modular.RetryLog
     , tryWith
     ) where
 
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import Distribution.Solver.Modular.Message
 import Distribution.Solver.Types.Progress
 

--- a/cabal-install/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/Distribution/Solver/Modular/Solver.hs
@@ -9,6 +9,9 @@ module Distribution.Solver.Modular.Solver
     , PruneAfterFirstSuccess(..)
     ) where
 
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import qualified Data.Map as M
 import qualified Data.List as L
 import qualified Data.Set as S

--- a/cabal-install/Distribution/Solver/Modular/Version.hs
+++ b/cabal-install/Distribution/Solver/Modular/Version.hs
@@ -11,6 +11,9 @@ module Distribution.Solver.Modular.Version
     , (.||.)
     ) where
 
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import qualified Distribution.Version as CV -- from Cabal
 import Distribution.Pretty (prettyShow)
 

--- a/cabal-install/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install/Distribution/Solver/Types/ConstraintSource.hs
@@ -4,9 +4,8 @@ module Distribution.Solver.Types.ConstraintSource
     , showConstraintSource
     ) where
 
-import GHC.Generics (Generic)
-import Distribution.Compat.Binary (Binary)
-import Distribution.Utils.Structured (Structured)
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
 
 -- | Source of a 'PackageConstraint'.
 data ConstraintSource =

--- a/cabal-install/Distribution/Solver/Types/DependencyResolver.hs
+++ b/cabal-install/Distribution/Solver/Types/DependencyResolver.hs
@@ -2,7 +2,8 @@ module Distribution.Solver.Types.DependencyResolver
     ( DependencyResolver
     ) where
 
-import Data.Set (Set)
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
 
 import Distribution.Solver.Types.LabeledPackageConstraint
 import Distribution.Solver.Types.PkgConfigDb ( PkgConfigDb )

--- a/cabal-install/Distribution/Solver/Types/Flag.hs
+++ b/cabal-install/Distribution/Solver/Types/Flag.hs
@@ -2,5 +2,7 @@ module Distribution.Solver.Types.Flag
     ( FlagType(..)
     ) where
 
+import Prelude (Eq, Show)
+
 data FlagType = Manual | Automatic
   deriving (Eq, Show)

--- a/cabal-install/Distribution/Solver/Types/InstSolverPackage.hs
+++ b/cabal-install/Distribution/Solver/Types/InstSolverPackage.hs
@@ -3,8 +3,9 @@ module Distribution.Solver.Types.InstSolverPackage
     ( InstSolverPackage(..)
     ) where
 
-import Distribution.Compat.Binary (Binary(..))
-import Distribution.Utils.Structured (Structured)
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import Distribution.Package ( Package(..), HasMungedPackageId(..), HasUnitId(..) )
 import Distribution.Solver.Types.ComponentDeps ( ComponentDeps )
 import Distribution.Solver.Types.SolverId
@@ -12,7 +13,6 @@ import Distribution.Types.MungedPackageId
 import Distribution.Types.PackageId
 import Distribution.Types.MungedPackageName
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
-import GHC.Generics (Generic)
 
 -- | An 'InstSolverPackage' is a pre-existing installed package
 -- specified by the dependency solver.

--- a/cabal-install/Distribution/Solver/Types/InstalledPreference.hs
+++ b/cabal-install/Distribution/Solver/Types/InstalledPreference.hs
@@ -2,6 +2,8 @@ module Distribution.Solver.Types.InstalledPreference
     ( InstalledPreference(..),
     ) where
 
+import Prelude (Show)
+
 -- | Whether we prefer an installed version of a package or simply the latest
 -- version.
 --

--- a/cabal-install/Distribution/Solver/Types/OptionalStanza.hs
+++ b/cabal-install/Distribution/Solver/Types/OptionalStanza.hs
@@ -6,13 +6,10 @@ module Distribution.Solver.Types.OptionalStanza
     , enableStanzas
     ) where
 
-import GHC.Generics (Generic)
-import Data.Typeable
-import Distribution.Compat.Binary (Binary)
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
 import Distribution.Types.ComponentRequestedSpec
             (ComponentRequestedSpec(..), defaultComponentRequestedSpec)
-import Data.List (foldl')
-import Distribution.Utils.Structured (Structured)
 
 data OptionalStanza
     = TestStanzas

--- a/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageConstraint.hs
@@ -18,20 +18,18 @@ module Distribution.Solver.Types.PackageConstraint (
     packageConstraintToDependency
   ) where
 
-import Distribution.Compat.Binary                  (Binary)
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import Distribution.Package                        (PackageName)
 import Distribution.PackageDescription             (FlagAssignment, dispFlagAssignment)
 import Distribution.Pretty                         (flatStyle, pretty)
 import Distribution.Types.PackageVersionConstraint (PackageVersionConstraint (..))
-import Distribution.Utils.Structured               (Structured)
 import Distribution.Version                        (VersionRange, simplifyVersionRange)
 
-import Distribution.Solver.Compat.Prelude       ((<<>>))
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.PackagePath
 
-import           GHC.Generics     (Generic)
-import           Text.PrettyPrint ((<+>))
 import qualified Text.PrettyPrint as Disp
 
 

--- a/cabal-install/Distribution/Solver/Types/PackageIndex.hs
+++ b/cabal-install/Distribution/Solver/Types/PackageIndex.hs
@@ -61,7 +61,7 @@ import Distribution.Package
 import Distribution.Version
          ( VersionRange, withinRange )
 import Distribution.Simple.Utils
-         ( lowercase, comparing )
+         ( lowercase )
 
 import qualified Prelude (foldr1)
 

--- a/cabal-install/Distribution/Solver/Types/PackagePath.hs
+++ b/cabal-install/Distribution/Solver/Types/PackagePath.hs
@@ -9,10 +9,11 @@ module Distribution.Solver.Types.PackagePath
     , showQPN
     ) where
 
-import Distribution.Package
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+import Distribution.Package (PackageName)
 import Distribution.Pretty (pretty, flatStyle)
 import qualified Text.PrettyPrint as Disp
-import Distribution.Solver.Compat.Prelude ((<<>>))
 
 -- | A package path consists of a namespace and a package path inside that
 -- namespace.

--- a/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install/Distribution/Solver/Types/PkgConfigDb.hs
@@ -23,7 +23,7 @@ module Distribution.Solver.Types.PkgConfigDb
 import Distribution.Solver.Compat.Prelude
 import Prelude ()
 
-import           Control.Exception (IOException, handle)
+import           Control.Exception (handle)
 import qualified Data.Map          as M
 import           System.FilePath   (splitSearchPath)
 

--- a/cabal-install/Distribution/Solver/Types/ResolverPackage.hs
+++ b/cabal-install/Distribution/Solver/Types/ResolverPackage.hs
@@ -6,17 +6,17 @@ module Distribution.Solver.Types.ResolverPackage
     , resolverPackageExeDeps
     ) where
 
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import Distribution.Solver.Types.InstSolverPackage
 import Distribution.Solver.Types.SolverId
 import Distribution.Solver.Types.SolverPackage
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 
-import Distribution.Compat.Binary (Binary)
-import Distribution.Utils.Structured (Structured)
 import Distribution.Compat.Graph (IsNode(..))
 import Distribution.Package (Package(..), HasUnitId(..))
 import Distribution.Simple.Utils (ordNub)
-import GHC.Generics (Generic)
 
 -- | The dependency resolver picks either pre-existing installed packages
 -- or it picks source packages along with package configuration.

--- a/cabal-install/Distribution/Solver/Types/Settings.hs
+++ b/cabal-install/Distribution/Solver/Types/Settings.hs
@@ -15,12 +15,12 @@ module Distribution.Solver.Types.Settings
     , SolveExecutables(..)
     ) where
 
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import Distribution.Simple.Setup ( BooleanFlag(..) )
-import Distribution.Compat.Binary (Binary)
-import Distribution.Utils.Structured (Structured)
 import Distribution.Pretty ( Pretty(pretty) )
 import Distribution.Parsec ( Parsec(parsec) )
-import GHC.Generics (Generic)
 
 import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint as PP

--- a/cabal-install/Distribution/Solver/Types/SolverId.hs
+++ b/cabal-install/Distribution/Solver/Types/SolverId.hs
@@ -5,10 +5,10 @@ module Distribution.Solver.Types.SolverId
 
 where
 
-import Distribution.Compat.Binary (Binary)
-import Distribution.Utils.Structured (Structured)
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import Distribution.Package (PackageId, Package(..), UnitId)
-import GHC.Generics (Generic)
 
 -- | The solver can produce references to existing packages or
 -- packages we plan to install.  Unlike 'ConfiguredId' we don't

--- a/cabal-install/Distribution/Solver/Types/SolverPackage.hs
+++ b/cabal-install/Distribution/Solver/Types/SolverPackage.hs
@@ -3,15 +3,15 @@ module Distribution.Solver.Types.SolverPackage
     ( SolverPackage(..)
     ) where
 
-import Distribution.Compat.Binary (Binary)
-import Distribution.Utils.Structured (Structured)
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import Distribution.Package ( Package(..) )
 import Distribution.PackageDescription ( FlagAssignment )
 import Distribution.Solver.Types.ComponentDeps ( ComponentDeps )
 import Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Types.SolverId
 import Distribution.Solver.Types.SourcePackage
-import GHC.Generics (Generic)
 
 -- | A 'SolverPackage' is a package specified by the dependency solver.
 -- It will get elaborated into a 'ConfiguredPackage' or even an

--- a/cabal-install/Distribution/Solver/Types/SourcePackage.hs
+++ b/cabal-install/Distribution/Solver/Types/SourcePackage.hs
@@ -5,16 +5,15 @@ module Distribution.Solver.Types.SourcePackage
     , SourcePackage(..)
     ) where
 
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
 import Distribution.Package
          ( PackageId, Package(..) )
 import Distribution.PackageDescription
          ( GenericPackageDescription(..) )
 
 import Data.ByteString.Lazy (ByteString)
-import GHC.Generics (Generic)
-import Distribution.Compat.Binary (Binary)
-import Data.Typeable
-import Distribution.Utils.Structured (Structured)
 
 -- | A package description along with the location of the package sources.
 --

--- a/cabal-install/Distribution/Solver/Types/Variable.hs
+++ b/cabal-install/Distribution/Solver/Types/Variable.hs
@@ -1,5 +1,7 @@
 module Distribution.Solver.Types.Variable where
 
+import Prelude (Eq, Show)
+
 import Distribution.Solver.Types.OptionalStanza
 
 import Distribution.PackageDescription (FlagName)

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -163,15 +163,13 @@ import qualified Paths_cabal_install (version)
 
 import Distribution.Compat.ResponseFile
 import System.Environment       (getArgs, getProgName)
-import System.Exit              (exitFailure, exitSuccess)
 import System.FilePath          ( dropExtension, splitExtension
                                 , takeExtension, (</>), (<.>) )
 import System.IO                ( BufferMode(LineBuffering), hSetBuffering
                                 , stderr, stdout )
 import System.Directory         (doesFileExist, getCurrentDirectory)
 import Data.Monoid              (Any(..))
-import Control.Exception        (SomeException(..), try)
-import Control.Monad            (mapM_)
+import Control.Exception        (try)
 import Data.Version             (showVersion)
 
 -- | Entry point
@@ -978,16 +976,16 @@ execAction execFlags extraArgs globalFlags = do
 userConfigAction :: UserConfigFlags -> [String] -> Action
 userConfigAction ucflags extraArgs globalFlags = do
   let verbosity  = fromFlag (userConfigVerbosity ucflags)
-      force      = fromFlag (userConfigForce ucflags)
+      frc        = fromFlag (userConfigForce ucflags)
       extraLines = fromFlag (userConfigAppendLines ucflags)
   case extraArgs of
     ("init":_) -> do
       path       <- configFile
       fileExists <- doesFileExist path
-      if (not fileExists || (fileExists && force))
+      if (not fileExists || (fileExists && frc))
       then void $ createDefaultConfigFile verbosity extraLines path
       else die' verbosity $ path ++ " already exists."
-    ("diff":_) -> mapM_ putStrLn =<< userConfigDiff verbosity globalFlags extraLines
+    ("diff":_) -> traverse_ putStrLn =<< userConfigDiff verbosity globalFlags extraLines
     ("update":_) -> userConfigUpdate verbosity globalFlags extraLines
     -- Error handling.
     [] -> die' verbosity $ "Please specify a subcommand (see 'help user-config')"

--- a/cabal-install/solver-dsl/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/solver-dsl/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -44,7 +44,6 @@ import Distribution.Utils.Generic
 
 -- base
 import Control.Arrow (second)
-import Data.Either (partitionEithers)
 import qualified Data.Map as Map
 
 -- Cabal

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -51,7 +51,6 @@ import Distribution.Simple.Compiler
 import Distribution.System
 import Distribution.Version
 import Distribution.ModuleName (ModuleName)
-import Distribution.Verbosity
 import Distribution.Text
 
 import qualified Data.Map as Map

--- a/cabal-install/tests/UnitTests/Distribution/Client/DescribedInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/DescribedInstances.hs
@@ -5,7 +5,6 @@ module UnitTests.Distribution.Client.DescribedInstances where
 import Distribution.Client.Compat.Prelude
 
 import Distribution.Described
-import Distribution.Pretty    (prettyShow)
 import Data.List ((\\))
 
 import Distribution.Types.Dependency   (Dependency)

--- a/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/GZipUtils.hs
@@ -7,8 +7,7 @@ import Distribution.Client.Compat.Prelude
 
 import Codec.Compression.GZip          as GZip
 import Codec.Compression.Zlib          as Zlib
-import Control.Exception.Base                  (evaluate)
-import Control.Exception                       (try, SomeException)
+import Control.Exception                       (try)
 import Data.ByteString                as BS    (null)
 import Data.ByteString.Lazy           as BSL   (pack, toChunks)
 import Data.ByteString.Lazy.Char8     as BSLL  (pack, init, length)

--- a/cabal-install/tests/UnitTests/Distribution/Client/Glob.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Glob.hs
@@ -6,9 +6,6 @@ module UnitTests.Distribution.Client.Glob (tests) where
 import Distribution.Client.Compat.Prelude hiding (last)
 import Prelude ()
 
-import Distribution.Pretty (prettyShow)
-import Distribution.Parsec (eitherParsec)
-
 import Distribution.Client.Glob
 import Distribution.Utils.Structured (structureHash)
 import UnitTests.Distribution.Client.ArbitraryInstances ()
@@ -16,7 +13,6 @@ import UnitTests.Distribution.Client.ArbitraryInstances ()
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import Test.Tasty.HUnit
-import Control.Exception
 import GHC.Fingerprint (Fingerprint (..))
 
 tests :: [TestTree]

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
@@ -31,7 +31,6 @@ import Prelude ()
 import Distribution.Solver.Compat.Prelude
 
 import Data.List (elemIndex)
-import Data.Ord (comparing)
 
 -- test-framework
 import Test.Tasty as TF

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -9,12 +9,9 @@ import Prelude ()
 import Distribution.Client.Compat.Prelude
 
 import Control.Arrow ((&&&))
-import Control.DeepSeq (force)
 import Data.Either (lefts)
-import Data.Function (on)
 import Data.Hashable (Hashable(..))
 import Data.List (groupBy, isInfixOf)
-import Data.Ord (comparing)
 
 import Text.Show.Pretty (parseValue, valToStr)
 


### PR DESCRIPTION
I.e. find out where we don't yet
used `Distribution.Client.Compat.Prelude`.

- If the module is small I added direct `Prelude` imports.
- Add Exception, deepseq stuff to Cabal Prelude
- Add Parsec, Pretty and Verbosity to Client Prelude
- use for, for_, traverse and traverse_ (removes need for Control.Monad)