### PR TITLE
Refactor shared TargetProblem data types into their own module.

### DIFF
--- a/cabal-install/Distribution/Client/CmdBench.hs
+++ b/cabal-install/Distribution/Client/CmdBench.hs
@@ -8,7 +8,9 @@ module Distribution.Client.CmdBench (
     benchAction,
 
     -- * Internals exposed for testing
-    TargetProblem(..),
+    componentNotBenchmarkProblem,
+    isSubComponentProblem,
+    noBenchmarksProblem,
     selectPackageTargets,
     selectComponentTarget
   ) where
@@ -18,7 +20,11 @@ import Prelude ()
 
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.CmdErrorMessages
-
+         ( renderTargetSelector, showTargetSelector, renderTargetProblem,
+           renderTargetProblemNoTargets, plural, targetSelectorPluralPkgs,
+           targetSelectorFilter )
+import Distribution.Client.TargetProblem
+         ( TargetProblem (..) )
 import Distribution.Client.NixStyleOptions
          ( NixStyleFlags (..), nixStyleOptions, defaultNixStyleFlags )
 import Distribution.Client.Setup
@@ -98,7 +104,6 @@ benchAction flags@NixStyleFlags {..} targetStrings globalFlags = do
                      $ resolveTargets
                          selectPackageTargets
                          selectComponentTarget
-                         TargetProblemCommon
                          elaboratedPlan
                          Nothing
                          targetSelectors
@@ -126,7 +131,7 @@ benchAction flags@NixStyleFlags {..} targetStrings globalFlags = do
 -- or fail if there are no benchmarks or no buildable benchmarks.
 --
 selectPackageTargets :: TargetSelector
-                     -> [AvailableTarget k] -> Either TargetProblem [k]
+                     -> [AvailableTarget k] -> Either BenchTargetProblem [k]
 selectPackageTargets targetSelector targets
 
     -- If there are any buildable benchmark targets then we select those
@@ -139,7 +144,7 @@ selectPackageTargets targetSelector targets
 
     -- If there are no benchmarks but some other targets then we report that
   | not (null targets)
-  = Left (TargetProblemNoBenchmarks targetSelector)
+  = Left (noBenchmarksProblem targetSelector)
 
     -- If there are no targets at all then we report that
   | otherwise
@@ -161,34 +166,27 @@ selectPackageTargets targetSelector targets
 -- to the basic checks on being buildable etc.
 --
 selectComponentTarget :: SubComponentTarget
-                      -> AvailableTarget k -> Either TargetProblem k
+                      -> AvailableTarget k -> Either BenchTargetProblem k
 selectComponentTarget subtarget@WholeComponent t
   | CBenchName _ <- availableTargetComponentName t
-  = either (Left . TargetProblemCommon) return $
-           selectComponentTargetBasic subtarget t
+  = selectComponentTargetBasic subtarget t
   | otherwise
-  = Left (TargetProblemComponentNotBenchmark (availableTargetPackageId t)
-                                             (availableTargetComponentName t))
+  = Left (componentNotBenchmarkProblem
+           (availableTargetPackageId t)
+           (availableTargetComponentName t))
 
 selectComponentTarget subtarget t
-  = Left (TargetProblemIsSubComponent (availableTargetPackageId t)
-                                      (availableTargetComponentName t)
-                                       subtarget)
+  = Left (isSubComponentProblem
+           (availableTargetPackageId t)
+           (availableTargetComponentName t)
+           subtarget)
 
 -- | The various error conditions that can occur when matching a
 -- 'TargetSelector' against 'AvailableTarget's for the @bench@ command.
 --
-data TargetProblem =
-     TargetProblemCommon        TargetProblemCommon
-
-     -- | The 'TargetSelector' matches benchmarks but none are buildable
-   | TargetProblemNoneEnabled  TargetSelector [AvailableTarget ()]
-
-     -- | There are no targets at all
-   | TargetProblemNoTargets    TargetSelector
-
+data BenchProblem =
      -- | The 'TargetSelector' matches targets but no benchmarks
-   | TargetProblemNoBenchmarks TargetSelector
+     TargetProblemNoBenchmarks TargetSelector
 
      -- | The 'TargetSelector' refers to a component that is not a benchmark
    | TargetProblemComponentNotBenchmark PackageId ComponentName
@@ -197,25 +195,30 @@ data TargetProblem =
    | TargetProblemIsSubComponent   PackageId ComponentName SubComponentTarget
   deriving (Eq, Show)
 
-reportTargetProblems :: Verbosity -> [TargetProblem] -> IO a
+
+type BenchTargetProblem = TargetProblem BenchProblem
+
+noBenchmarksProblem :: TargetSelector -> TargetProblem BenchProblem
+noBenchmarksProblem = CustomTargetProblem . TargetProblemNoBenchmarks
+
+componentNotBenchmarkProblem :: PackageId -> ComponentName -> TargetProblem BenchProblem
+componentNotBenchmarkProblem pkgid name = CustomTargetProblem $
+  TargetProblemComponentNotBenchmark pkgid name
+
+isSubComponentProblem
+  :: PackageId
+  -> ComponentName
+  -> SubComponentTarget
+  -> TargetProblem BenchProblem
+isSubComponentProblem pkgid name subcomponent = CustomTargetProblem $
+    TargetProblemIsSubComponent pkgid name subcomponent
+
+reportTargetProblems :: Verbosity -> [BenchTargetProblem] -> IO a
 reportTargetProblems verbosity =
-    die' verbosity . unlines . map renderTargetProblem
+    die' verbosity . unlines . map renderBenchTargetProblem
 
-renderTargetProblem :: TargetProblem -> String
-renderTargetProblem (TargetProblemCommon problem) =
-    renderTargetProblemCommon "run" problem
-
-renderTargetProblem (TargetProblemNoneEnabled targetSelector targets) =
-    renderTargetProblemNoneEnabled "benchmark" targetSelector targets
-
-renderTargetProblem (TargetProblemNoBenchmarks targetSelector) =
-    "Cannot run benchmarks for the target '" ++ showTargetSelector targetSelector
- ++ "' which refers to " ++ renderTargetSelector targetSelector
- ++ " because "
- ++ plural (targetSelectorPluralPkgs targetSelector) "it does" "they do"
- ++ " not contain any benchmarks."
-
-renderTargetProblem (TargetProblemNoTargets targetSelector) =
+renderBenchTargetProblem :: BenchTargetProblem -> String
+renderBenchTargetProblem (TargetProblemNoTargets targetSelector) =
     case targetSelectorFilter targetSelector of
       Just kind | kind /= BenchKind
         -> "The bench command is for running benchmarks, but the target '"
@@ -223,8 +226,18 @@ renderTargetProblem (TargetProblemNoTargets targetSelector) =
            ++ renderTargetSelector targetSelector ++ "."
 
       _ -> renderTargetProblemNoTargets "benchmark" targetSelector
+renderBenchTargetProblem problem =
+    renderTargetProblem "benchmark" renderBenchProblem problem
 
-renderTargetProblem (TargetProblemComponentNotBenchmark pkgid cname) =
+renderBenchProblem :: BenchProblem -> String
+renderBenchProblem (TargetProblemNoBenchmarks targetSelector) =
+    "Cannot run benchmarks for the target '" ++ showTargetSelector targetSelector
+ ++ "' which refers to " ++ renderTargetSelector targetSelector
+ ++ " because "
+ ++ plural (targetSelectorPluralPkgs targetSelector) "it does" "they do"
+ ++ " not contain any benchmarks."
+
+renderBenchProblem (TargetProblemComponentNotBenchmark pkgid cname) =
     "The bench command is for running benchmarks, but the target '"
  ++ showTargetSelector targetSelector ++ "' refers to "
  ++ renderTargetSelector targetSelector ++ " from the package "
@@ -232,7 +245,7 @@ renderTargetProblem (TargetProblemComponentNotBenchmark pkgid cname) =
   where
     targetSelector = TargetComponent pkgid cname WholeComponent
 
-renderTargetProblem (TargetProblemIsSubComponent pkgid cname subtarget) =
+renderBenchProblem (TargetProblemIsSubComponent pkgid cname subtarget) =
     "The bench command can only run benchmarks as a whole, "
  ++ "not files or modules within them, but the target '"
  ++ showTargetSelector targetSelector ++ "' refers to "

--- a/cabal-install/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/Distribution/Client/CmdBuild.hs
@@ -7,7 +7,6 @@ module Distribution.Client.CmdBuild (
     buildAction,
 
     -- * Internals exposed for testing
-    TargetProblem(..),
     selectPackageTargets,
     selectComponentTarget
   ) where
@@ -16,6 +15,8 @@ import Prelude ()
 import Distribution.Client.Compat.Prelude
 
 import Distribution.Client.ProjectOrchestration
+import Distribution.Client.TargetProblem
+         ( TargetProblem (..), TargetProblem' )
 import Distribution.Client.CmdErrorMessages
 
 import Distribution.Client.NixStyleOptions
@@ -112,11 +113,10 @@ buildAction flags@NixStyleFlags { extraFlags = buildFlags, ..} targetStrings glo
 
             -- Interpret the targets on the command line as build targets
             -- (as opposed to say repl or haddock targets).
-            targets <- either (reportTargetProblems verbosity) return
+            targets <- either (reportBuildTargetProblems verbosity) return
                      $ resolveTargets
                          selectPackageTargets
                          selectComponentTarget
-                         TargetProblemCommon
                          elaboratedPlan
                          Nothing
                          targetSelectors
@@ -152,7 +152,7 @@ buildAction flags@NixStyleFlags { extraFlags = buildFlags, ..} targetStrings glo
 -- components
 --
 selectPackageTargets :: TargetSelector
-                     -> [AvailableTarget k] -> Either TargetProblem [k]
+                     -> [AvailableTarget k] -> Either TargetProblem' [k]
 selectPackageTargets targetSelector targets
 
     -- If there are any buildable targets then we select those
@@ -185,36 +185,12 @@ selectPackageTargets targetSelector targets
 -- For the @build@ command we just need the basic checks on being buildable etc.
 --
 selectComponentTarget :: SubComponentTarget
-                      -> AvailableTarget k -> Either TargetProblem k
-selectComponentTarget subtarget =
-    either (Left . TargetProblemCommon) Right
-  . selectComponentTargetBasic subtarget
+                      -> AvailableTarget k -> Either TargetProblem' k
+selectComponentTarget = selectComponentTargetBasic
 
-
--- | The various error conditions that can occur when matching a
--- 'TargetSelector' against 'AvailableTarget's for the @build@ command.
---
-data TargetProblem =
-     TargetProblemCommon       TargetProblemCommon
-
-     -- | The 'TargetSelector' matches targets but none are buildable
-   | TargetProblemNoneEnabled TargetSelector [AvailableTarget ()]
-
-     -- | There are no targets at all
-   | TargetProblemNoTargets   TargetSelector
-  deriving (Eq, Show)
-
-reportTargetProblems :: Verbosity -> [TargetProblem] -> IO a
-reportTargetProblems verbosity =
-    die' verbosity . unlines . map renderTargetProblem
-
-renderTargetProblem :: TargetProblem -> String
-renderTargetProblem (TargetProblemCommon problem) =
-    renderTargetProblemCommon "build" problem
-renderTargetProblem (TargetProblemNoneEnabled targetSelector targets) =
-    renderTargetProblemNoneEnabled "build" targetSelector targets
-renderTargetProblem(TargetProblemNoTargets targetSelector) =
-    renderTargetProblemNoTargets "build" targetSelector
+reportBuildTargetProblems :: Verbosity -> [TargetProblem'] -> IO a
+reportBuildTargetProblems verbosity problems =
+  reportTargetProblems verbosity "build" problems
 
 reportCannotPruneDependencies :: Verbosity -> CannotPruneDependencies -> IO a
 reportCannotPruneDependencies verbosity =

--- a/cabal-install/Distribution/Client/CmdTest.hs
+++ b/cabal-install/Distribution/Client/CmdTest.hs
@@ -8,7 +8,9 @@ module Distribution.Client.CmdTest (
     testAction,
 
     -- * Internals exposed for testing
-    TargetProblem(..),
+    isSubComponentProblem,
+    notTestProblem,
+    noTestsProblem,
     selectPackageTargets,
     selectComponentTarget
   ) where
@@ -18,7 +20,11 @@ import Prelude ()
 
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.CmdErrorMessages
-
+         ( renderTargetSelector, showTargetSelector, targetSelectorFilter, plural,
+           renderTargetProblem,
+           renderTargetProblemNoTargets, targetSelectorPluralPkgs )
+import Distribution.Client.TargetProblem
+         ( TargetProblem (..) )
 import Distribution.Client.NixStyleOptions
          ( NixStyleFlags (..), nixStyleOptions, defaultNixStyleFlags )
 import Distribution.Client.Setup
@@ -110,7 +116,6 @@ testAction flags@NixStyleFlags {..} targetStrings globalFlags = do
                      $ resolveTargets
                          selectPackageTargets
                          selectComponentTarget
-                         TargetProblemCommon
                          elaboratedPlan
                          Nothing
                          targetSelectors
@@ -138,7 +143,7 @@ testAction flags@NixStyleFlags {..} targetStrings globalFlags = do
 -- or fail if there are no test-suites or no buildable test-suites.
 --
 selectPackageTargets  :: TargetSelector
-                      -> [AvailableTarget k] -> Either TargetProblem [k]
+                      -> [AvailableTarget k] -> Either TestTargetProblem [k]
 selectPackageTargets targetSelector targets
 
     -- If there are any buildable test-suite targets then we select those
@@ -151,7 +156,7 @@ selectPackageTargets targetSelector targets
 
     -- If there are no test-suite but some other targets then we report that
   | not (null targets)
-  = Left (TargetProblemNoTests targetSelector)
+  = Left (noTestsProblem targetSelector)
 
     -- If there are no targets at all then we report that
   | otherwise
@@ -173,34 +178,28 @@ selectPackageTargets targetSelector targets
 -- to the basic checks on being buildable etc.
 --
 selectComponentTarget :: SubComponentTarget
-                      -> AvailableTarget k -> Either TargetProblem k
+                      -> AvailableTarget k -> Either TestTargetProblem k
 selectComponentTarget subtarget@WholeComponent t
   | CTestName _ <- availableTargetComponentName t
-  = either (Left . TargetProblemCommon) return $
+  = either Left return $
            selectComponentTargetBasic subtarget t
   | otherwise
-  = Left (TargetProblemComponentNotTest (availableTargetPackageId t)
-                                        (availableTargetComponentName t))
+  = Left (notTestProblem
+           (availableTargetPackageId t)
+           (availableTargetComponentName t))
 
 selectComponentTarget subtarget t
-  = Left (TargetProblemIsSubComponent (availableTargetPackageId t)
-                                      (availableTargetComponentName t)
-                                       subtarget)
+  = Left (isSubComponentProblem
+           (availableTargetPackageId t)
+           (availableTargetComponentName t)
+           subtarget)
 
 -- | The various error conditions that can occur when matching a
 -- 'TargetSelector' against 'AvailableTarget's for the @test@ command.
 --
-data TargetProblem =
-     TargetProblemCommon       TargetProblemCommon
-
-     -- | The 'TargetSelector' matches targets but none are buildable
-   | TargetProblemNoneEnabled TargetSelector [AvailableTarget ()]
-
-     -- | There are no targets at all
-   | TargetProblemNoTargets   TargetSelector
-
+data TestProblem =
      -- | The 'TargetSelector' matches targets but no test-suites
-   | TargetProblemNoTests     TargetSelector
+     TargetProblemNoTests     TargetSelector
 
      -- | The 'TargetSelector' refers to a component that is not a test-suite
    | TargetProblemComponentNotTest PackageId ComponentName
@@ -209,17 +208,35 @@ data TargetProblem =
    | TargetProblemIsSubComponent   PackageId ComponentName SubComponentTarget
   deriving (Eq, Show)
 
-reportTargetProblems :: Verbosity -> Flag Bool -> [TargetProblem] -> IO a
+
+type TestTargetProblem = TargetProblem TestProblem
+
+
+noTestsProblem :: TargetSelector -> TargetProblem TestProblem
+noTestsProblem = CustomTargetProblem . TargetProblemNoTests
+
+notTestProblem :: PackageId -> ComponentName -> TargetProblem TestProblem
+notTestProblem pkgid name = CustomTargetProblem $ TargetProblemComponentNotTest pkgid name
+
+isSubComponentProblem
+  :: PackageId
+  -> ComponentName
+  -> SubComponentTarget
+  -> TargetProblem TestProblem
+isSubComponentProblem pkgid name subcomponent = CustomTargetProblem $
+  TargetProblemIsSubComponent pkgid name subcomponent
+
+reportTargetProblems :: Verbosity -> Flag Bool -> [TestTargetProblem] -> IO a
 reportTargetProblems verbosity failWhenNoTestSuites problems =
   case (failWhenNoTestSuites, problems) of
-    (Flag True, [TargetProblemNoTests _]) ->
+    (Flag True, [CustomTargetProblem (TargetProblemNoTests _)]) ->
       die' verbosity problemsMessage
-    (_, [TargetProblemNoTests selector]) -> do
+    (_, [CustomTargetProblem (TargetProblemNoTests selector)]) -> do
       notice verbosity (renderAllowedNoTestsProblem selector)
       System.Exit.exitSuccess
     (_, _) -> die' verbosity problemsMessage
     where
-      problemsMessage = unlines . map renderTargetProblem $ problems
+      problemsMessage = unlines . map renderTestTargetProblem $ problems
 
 -- | Unless @--test-fail-when-no-test-suites@ flag is passed, we don't
 --   @die@ when the target problem is 'TargetProblemNoTests'.
@@ -229,21 +246,8 @@ renderAllowedNoTestsProblem :: TargetSelector -> String
 renderAllowedNoTestsProblem selector =
     "No tests to run for " ++ renderTargetSelector selector
 
-renderTargetProblem :: TargetProblem -> String
-renderTargetProblem (TargetProblemCommon problem) =
-    renderTargetProblemCommon "run" problem
-
-renderTargetProblem (TargetProblemNoneEnabled targetSelector targets) =
-    renderTargetProblemNoneEnabled "test" targetSelector targets
-
-renderTargetProblem (TargetProblemNoTests targetSelector) =
-    "Cannot run tests for the target '" ++ showTargetSelector targetSelector
- ++ "' which refers to " ++ renderTargetSelector targetSelector
- ++ " because "
- ++ plural (targetSelectorPluralPkgs targetSelector) "it does" "they do"
- ++ " not contain any test suites."
-
-renderTargetProblem (TargetProblemNoTargets targetSelector) =
+renderTestTargetProblem :: TestTargetProblem -> String
+renderTestTargetProblem (TargetProblemNoTargets targetSelector) =
     case targetSelectorFilter targetSelector of
       Just kind | kind /= TestKind
         -> "The test command is for running test suites, but the target '"
@@ -252,8 +256,19 @@ renderTargetProblem (TargetProblemNoTargets targetSelector) =
            ++ "\n" ++ show targetSelector
 
       _ -> renderTargetProblemNoTargets "test" targetSelector
+renderTestTargetProblem problem =
+    renderTargetProblem "test" renderTestProblem problem
 
-renderTargetProblem (TargetProblemComponentNotTest pkgid cname) =
+
+renderTestProblem :: TestProblem -> String
+renderTestProblem (TargetProblemNoTests targetSelector) =
+    "Cannot run tests for the target '" ++ showTargetSelector targetSelector
+ ++ "' which refers to " ++ renderTargetSelector targetSelector
+ ++ " because "
+ ++ plural (targetSelectorPluralPkgs targetSelector) "it does" "they do"
+ ++ " not contain any test suites."
+
+renderTestProblem (TargetProblemComponentNotTest pkgid cname) =
     "The test command is for running test suites, but the target '"
  ++ showTargetSelector targetSelector ++ "' refers to "
  ++ renderTargetSelector targetSelector ++ " from the package "
@@ -261,7 +276,7 @@ renderTargetProblem (TargetProblemComponentNotTest pkgid cname) =
   where
     targetSelector = TargetComponent pkgid cname WholeComponent
 
-renderTargetProblem (TargetProblemIsSubComponent pkgid cname subtarget) =
+renderTestProblem (TargetProblemIsSubComponent pkgid cname subtarget) =
     "The test command can only run test suites as a whole, "
  ++ "not files or modules within them, but the target '"
  ++ showTargetSelector targetSelector ++ "' refers to "

--- a/cabal-install/Distribution/Client/TargetProblem.hs
+++ b/cabal-install/Distribution/Client/TargetProblem.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DeriveFunctor #-}
+module Distribution.Client.TargetProblem (
+    TargetProblem(..),
+    TargetProblem',
+) where
+
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
+import Distribution.Client.ProjectPlanning    (AvailableTarget)
+import Distribution.Client.TargetSelector     (SubComponentTarget, TargetSelector)
+import Distribution.Package                   (PackageId, PackageName)
+import Distribution.Simple.LocalBuildInfo     (ComponentName (..))
+import Distribution.Types.UnqualComponentName (UnqualComponentName)
+
+-- | Target problems that occur during project orchestration.
+data TargetProblem a
+    = TargetNotInProject                   PackageName
+    | TargetAvailableInIndex               PackageName
+
+    | TargetComponentNotProjectLocal
+      PackageId ComponentName SubComponentTarget
+
+    | TargetComponentNotBuildable
+      PackageId ComponentName SubComponentTarget
+
+    | TargetOptionalStanzaDisabledByUser
+      PackageId ComponentName SubComponentTarget
+
+    | TargetOptionalStanzaDisabledBySolver
+      PackageId ComponentName SubComponentTarget
+
+    | TargetProblemUnknownComponent
+      PackageName (Either UnqualComponentName ComponentName)
+
+    | TargetProblemNoneEnabled TargetSelector [AvailableTarget ()]
+      -- ^ The 'TargetSelector' matches component (test/benchmark/...) but none are buildable
+
+    | TargetProblemNoTargets TargetSelector
+      -- ^ There are no targets at all
+
+    -- The target matching stuff only returns packages local to the project,
+    -- so these lookups should never fail, but if 'resolveTargets' is called
+    -- directly then of course it can.
+    | TargetProblemNoSuchPackage           PackageId
+    | TargetProblemNoSuchComponent         PackageId ComponentName
+
+    | CustomTargetProblem a
+      -- | A custom target problem
+  deriving (Eq, Show, Functor)
+
+-- | Type alias for a 'TargetProblem' with no user-defined problems/errors.
+--
+-- Can use the utilities below for reporting/rendering problems.
+type TargetProblem' = TargetProblem Void

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -251,6 +251,7 @@ executable cabal
         Distribution.Client.SrcDist
         Distribution.Client.Store
         Distribution.Client.Tar
+        Distribution.Client.TargetProblem
         Distribution.Client.TargetSelector
         Distribution.Client.Targets
         Distribution.Client.Types

--- a/cabal-install/cabal-install.cabal.pp
+++ b/cabal-install/cabal-install.cabal.pp
@@ -192,6 +192,7 @@ Version:            3.3.0.0
         Distribution.Client.SrcDist
         Distribution.Client.Store
         Distribution.Client.Tar
+        Distribution.Client.TargetProblem
         Distribution.Client.TargetSelector
         Distribution.Client.Targets
         Distribution.Client.Types


### PR DESCRIPTION
Moved "problem rendering" to CmdErrorMessages module

Additions by Oleg Grenrus:

- There were CommonTargetProblem, but now
  TargetProblem has an extension point so we can have just one type.
  A lot of code is simplified as we don't need to pass in injection
  from CommonTargetProblem to the resulting `err` type.

--

An extension of #6774. cc @m-renaud 