### PR TITLE
Update GHC environment location (fixes #6565)

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -2060,7 +2060,7 @@ pkgRoot verbosity lbi = pkgRoot'
       let ghcProg = fromMaybe (error "GHC.pkgRoot: no ghc program") $ lookupProgram ghcProgram (withPrograms lbi)
       in  fmap takeDirectory (getGlobalPackageDB verbosity ghcProg)
     pkgRoot' UserPackageDB = do
-      appDir <- getAppUserDataDirectory "ghc"
+      appDir <- getGhcAppDir
       let ver      = compilerVersion (compiler lbi)
           subdir   = System.Info.arch ++ '-':System.Info.os
                      ++ '-':prettyShow ver

--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -51,6 +51,7 @@ module Distribution.Simple.GHC (
         registerPackage,
         componentGhcOptions,
         componentCcGhcOptions,
+        getGhcAppDir,
         getLibDir,
         isDynamic,
         getGlobalPackageDB,
@@ -366,6 +367,10 @@ toPackageIndex verbosity pkgss progdb = do
   where
     ghcProg = fromMaybe (error "GHC.toPackageIndex: no ghc program") $ lookupProgram ghcProgram progdb
 
+-- | Return the 'FilePath' to the GHC application data directory.
+getGhcAppDir :: IO FilePath
+getGhcAppDir = getAppUserDataDirectory "ghc"
+
 getLibDir :: Verbosity -> LocalBuildInfo -> IO FilePath
 getLibDir verbosity lbi =
     dropWhileEndLE isSpace `fmap`
@@ -391,7 +396,7 @@ getUserPackageDB _verbosity ghcProg platform = do
     -- It's rather annoying that we have to reconstruct this, because ghc
     -- hides this information from us otherwise. But for certain use cases
     -- like change monitoring it really can't remain hidden.
-    appdir <- getAppUserDataDirectory "ghc"
+    appdir <- getGhcAppDir
     return (appdir </> platformAndVersion </> packageConfFileName)
   where
     platformAndVersion = Internal.ghcPlatformAndVersionString

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -850,13 +850,13 @@ entriesForLibraryComponents = Map.foldrWithKey' (\k v -> mappend (go k v)) []
 -- | Gets the file file path to the request environment file.
 getEnvFile :: ClientInstallFlags -> Platform -> Version -> IO FilePath
 getEnvFile clientInstallFlags platform compilerVersion = do
-  appData <- getGhcAppDir
+  appDir <- getGhcAppDir
   case flagToMaybe (cinstEnvironmentPath clientInstallFlags) of
     Just spec
       -- Is spec a bare word without any "pathy" content, then it refers to
       -- a named global environment.
       | takeBaseName spec == spec ->
-          return (getGlobalEnv appData platform compilerVersion spec)
+          return (getGlobalEnv appDir platform compilerVersion spec)
       | otherwise                 -> do
         spec' <- makeAbsolute spec
         isDir <- doesDirectoryExist spec'
@@ -867,7 +867,7 @@ getEnvFile clientInstallFlags platform compilerVersion = do
           -- Otherwise, treat it like a literal file path.
           else return spec'
     Nothing                       ->
-      return (getGlobalEnv appData platform compilerVersion "default")
+      return (getGlobalEnv appDir platform compilerVersion "default")
 
 -- | Returns the list of @GhcEnvFilePackageIj@ values already existing in the
 --   environment being operated on.
@@ -891,8 +891,8 @@ getExistingEnvEntries verbosity compilerFlavor supportsPkgEnvFiles envFile = do
 --
 -- TODO(m-renaud): Create PkgEnvName newtype wrapper.
 getGlobalEnv :: FilePath -> Platform -> Version -> String -> FilePath
-getGlobalEnv appData platform compilerVersion name =
-  appData </> ghcPlatformAndVersionString platform compilerVersion
+getGlobalEnv appDir platform compilerVersion name =
+  appDir </> ghcPlatformAndVersionString platform compilerVersion
   </> "environments" </> name
 
 -- | Constructs the path to a local GHC environment file.

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -109,7 +109,7 @@ import Distribution.Simple.Compiler
          ( Compiler(..), CompilerId(..), CompilerFlavor(..)
          , PackageDBStack )
 import Distribution.Simple.GHC
-         ( ghcPlatformAndVersionString
+         ( ghcPlatformAndVersionString, getGhcAppDir
          , GhcImplInfo(..), getImplInfo
          , GhcEnvironmentFileEntry(..)
          , renderGhcEnvironmentFile, readGhcEnvironmentFile, ParseErrorExc )
@@ -146,7 +146,7 @@ import Distribution.Utils.NubList
          ( fromNubList )
 import Network.URI (URI)
 import System.Directory
-         ( getAppUserDataDirectory, doesFileExist, createDirectoryIfMissing
+         ( doesFileExist, createDirectoryIfMissing
          , getTemporaryDirectory, makeAbsolute, doesDirectoryExist
          , removeFile, removeDirectory, copyFile )
 import System.FilePath
@@ -850,7 +850,7 @@ entriesForLibraryComponents = Map.foldrWithKey' (\k v -> mappend (go k v)) []
 -- | Gets the file file path to the request environment file.
 getEnvFile :: ClientInstallFlags -> Platform -> Version -> IO FilePath
 getEnvFile clientInstallFlags platform compilerVersion = do
-  appData <- getAppUserDataDirectory "ghc"
+  appData <- getGhcAppDir
   case flagToMaybe (cinstEnvironmentPath clientInstallFlags) of
     Just spec
       -- Is spec a bare word without any "pathy" content, then it refers to

--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -146,7 +146,7 @@ import Distribution.Utils.NubList
          ( fromNubList )
 import Network.URI (URI)
 import System.Directory
-         ( getHomeDirectory, doesFileExist, createDirectoryIfMissing
+         ( getAppUserDataDirectory, doesFileExist, createDirectoryIfMissing
          , getTemporaryDirectory, makeAbsolute, doesDirectoryExist
          , removeFile, removeDirectory, copyFile )
 import System.FilePath
@@ -850,13 +850,13 @@ entriesForLibraryComponents = Map.foldrWithKey' (\k v -> mappend (go k v)) []
 -- | Gets the file file path to the request environment file.
 getEnvFile :: ClientInstallFlags -> Platform -> Version -> IO FilePath
 getEnvFile clientInstallFlags platform compilerVersion = do
-  home <- getHomeDirectory
+  appData <- getAppUserDataDirectory "ghc"
   case flagToMaybe (cinstEnvironmentPath clientInstallFlags) of
     Just spec
       -- Is spec a bare word without any "pathy" content, then it refers to
       -- a named global environment.
       | takeBaseName spec == spec ->
-          return (getGlobalEnv home platform compilerVersion spec)
+          return (getGlobalEnv appData platform compilerVersion spec)
       | otherwise                 -> do
         spec' <- makeAbsolute spec
         isDir <- doesDirectoryExist spec'
@@ -867,7 +867,7 @@ getEnvFile clientInstallFlags platform compilerVersion = do
           -- Otherwise, treat it like a literal file path.
           else return spec'
     Nothing                       ->
-      return (getGlobalEnv home platform compilerVersion "default")
+      return (getGlobalEnv appData platform compilerVersion "default")
 
 -- | Returns the list of @GhcEnvFilePackageIj@ values already existing in the
 --   environment being operated on.
@@ -891,8 +891,8 @@ getExistingEnvEntries verbosity compilerFlavor supportsPkgEnvFiles envFile = do
 --
 -- TODO(m-renaud): Create PkgEnvName newtype wrapper.
 getGlobalEnv :: FilePath -> Platform -> Version -> String -> FilePath
-getGlobalEnv home platform compilerVersion name =
-  home </> ".ghc" </> ghcPlatformAndVersionString platform compilerVersion
+getGlobalEnv appData platform compilerVersion name =
+  appData </> ghcPlatformAndVersionString platform compilerVersion
   </> "environments" </> name
 
 -- | Constructs the path to a local GHC environment file.


### PR DESCRIPTION
cabal-install currently assumes that the GHC environment files are always located in `$HOME/.ghc/`. However, GHC itself doesn't query the home directory directly. Instead, it uses `getAppUserDataDirectory "ghc"` ([GHC code](https://gitlab.haskell.org/ghc/ghc/-/blob/4898df1cc25132dc9e2599d4fa4e1bbc9423cda5/compiler/main/DynFlags.hs#L1514), [getAppUserDataDirectory](https://hackage.haskell.org/package/directory-1.3.6.1/docs/System-Directory.html#v:getAppUserDataDirectory)) which happens to coincide with `$HOME/.ghc/` on UNIX systems. On Windows, however, GHC ends up looking in `%APPDATA%/ghc/`.

As a result, `cabal install --lib` doesn't change the correct environment files on Windows.

This PR changes the environment file locations to match GHC. On UNIX, there is no change since `getAppUserDataDirectory "ghc"` is defined as `(</> ".ghc") <$> getHomeDirectory`. On windows, I have confirmed that cabal-install changes the correct GHC environment file with this PR.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [x] The documentation has been updated, if necessary.
