### PR TITLE
Backport filter --allow-depending-on-private-libs

### DIFF
--- a/cabal-install/Distribution/Client/Setup.hs
+++ b/cabal-install/Distribution/Client/Setup.hs
@@ -540,6 +540,8 @@ filterConfigureFlags flags cabalLibVersion
               convertToLegacyInternalDep (GivenComponent pn LMainLibName cid) =
                 Just $ GivenComponent pn LMainLibName cid
           in catMaybes $ convertToLegacyInternalDep <$> configDependencies flags
+        -- Cabal < 2.5 doesn't know about '--allow-depending-on-private-libs'.
+      , configAllowDependingOnPrivateLibs = NoFlag
         -- Cabal < 2.5 doesn't know about '--enable/disable-executable-static'.
       , configFullyStaticExe = NoFlag
       }


### PR DESCRIPTION
In #6836 I noticed that I forgot to filter out the --allow-depending-on-private-libs flag for old Cabals. With that patch it becomes necessary to have the filtering, but I guess having it in 3.2 would be good too?