### PR TITLE
Cabal-install GHC master compat

### DIFF
--- a/cabal-install/Distribution/Client/Dependency.hs
+++ b/cabal-install/Distribution/Client/Dependency.hs
@@ -721,7 +721,7 @@ resolveDependencies platform comp pkgConfigDB solver params =
                      pkgConfigDB preferences constraints targets
   where
 
-    finalparams @ (DepResolverParams
+    finalparams@(DepResolverParams
       targets constraints
       prefs defpref
       installedPkgIndex

--- a/cabal-install/Distribution/Client/Sandbox.hs
+++ b/cabal-install/Distribution/Client/Sandbox.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Sandbox


### PR DESCRIPTION
Bootstrapping cabal-install with ghc-master fails without these minor patches.
(Some of the package versions in bootstrap.sh also need updates, separate PR later).