### PR TITLE
Fix #6856 Make `--lib` warning louder and clearer

### DIFF
--- a/cabal-install/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/Distribution/Client/CmdInstall.hs
@@ -678,10 +678,14 @@ warnIfNoExes :: Verbosity -> ProjectBuildContext -> IO ()
 warnIfNoExes verbosity buildCtx =
   when noExes $
     warn verbosity $
-    "You asked to install executables, but there are no executables in "
-    <> plural (listPlural selectors) "target" "targets" <> ": "
-    <> intercalate ", " (showTargetSelector <$> selectors) <> ". "
-    <> "Perhaps you want to use --lib to install libraries instead."
+    "\n" <>
+    "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n" <>
+    "@ WARNING: Installation might not be completed as desired! @\n" <>
+    "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n" <>
+    "Without flags, the command \"cabal install\" doesn't expose" <>
+    " libraries in a usable manner.  You might have wanted to run" <>
+    " \"cabal install --lib " <>
+    unwords (showTargetSelector <$> selectors) <> "\". "
   where
     targets    = concat $ Map.elems $ targetsMap buildCtx
     components = fst <$> targets

--- a/changelog.d/issue-6856
+++ b/changelog.d/issue-6856
@@ -1,0 +1,4 @@
+synopsis: Adjust message indicating `--lib` is likely desired
+packages: cabal-install
+issues: #6856
+prs: #6857


### PR DESCRIPTION
* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).

In so far as I didn't even add a newline, just some output characters.

* [X] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).

* [X] The documentation has been updated, if necessary.

I tested it by running the binary and observing the warning is now red on my screen.  I googled and found claims the color works on windows terminals as well.