### PR TITLE
Add test for #6853

### DIFF
--- a/cabal-testsuite/PackageTests/Regression/T6853/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T6853/cabal.out
@@ -1,0 +1,8 @@
+# cabal v2-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - pkg-foo-0 (lib) (first run)
+Configuring library for pkg-foo-0..
+Preprocessing library for pkg-foo-0..
+Building library for pkg-foo-0..

--- a/cabal-testsuite/PackageTests/Regression/T6853/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T6853/cabal.project
@@ -1,0 +1,1 @@
+packages: pkg-foo/

--- a/cabal-testsuite/PackageTests/Regression/T6853/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T6853/cabal.test.hs
@@ -1,0 +1,3 @@
+import Test.Cabal.Prelude
+main = cabalTest $
+  cabal "v2-build" ["all"]

--- a/cabal-testsuite/PackageTests/Regression/T6853/pkg-foo/Foo.hs
+++ b/cabal-testsuite/PackageTests/Regression/T6853/pkg-foo/Foo.hs
@@ -1,0 +1,1 @@
+module Foo where

--- a/cabal-testsuite/PackageTests/Regression/T6853/pkg-foo/pkg-foo.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T6853/pkg-foo/pkg-foo.cabal
@@ -1,0 +1,17 @@
+cabal-version: 2.2
+name:          pkg-foo
+version:       0
+
+flag foo-bar
+  description: Should be toggled
+  manual:      False
+  default:     False
+
+library
+  default-language: Haskell2010
+  build-depends:    base
+  exposed-modules:  Foo
+
+  -- this says "toggle me"
+  if !flag(foo-bar)
+    build-depends: base <0


### PR DESCRIPTION
It's import that flag is *True*, so it's passed without prefix-sign.

This is test case forgotten in #6854