### PR TITLE
Use process createPipe

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -669,10 +669,12 @@ test-suite unit-tests
   main-is: UnitTests.hs
   build-depends:
     array,
+    async >= 2.2.2 && <2.3,
     base,
     binary,
     bytestring,
     containers,
+    deepseq,
     directory,
     filepath,
     integer-logarithms >= 1.0.2 && <1.1,

--- a/Cabal/Distribution/Compat/CreatePipe.hs
+++ b/Cabal/Distribution/Compat/CreatePipe.hs
@@ -4,7 +4,10 @@
 
 module Distribution.Compat.CreatePipe (createPipe) where
 
-import System.IO (Handle, hSetEncoding, localeEncoding)
+#if MIN_VERSION_process(1,2,1)
+import System.Process (createPipe)
+#else
+import System.IO (Handle, hSetBinaryMode)
 
 import Prelude ()
 import Distribution.Compat.Prelude
@@ -40,8 +43,8 @@ createPipe = do
         return (readfd, writefd)
     (do readh <- fdToHandle readfd ReadMode
         writeh <- fdToHandle writefd WriteMode
-        hSetEncoding readh localeEncoding
-        hSetEncoding writeh localeEncoding
+        hSetBinaryMode readh True
+        hSetBinaryMode writeh True
         return (readh, writeh)) `onException` (close readfd >> close writefd)
   where
     fdToHandle :: CInt -> IOMode -> IO Handle
@@ -69,9 +72,10 @@ createPipe = do
     (readfd, writefd) <- Posix.createPipe
     readh <- fdToHandle readfd
     writeh <- fdToHandle writefd
-    hSetEncoding readh localeEncoding
-    hSetEncoding writeh localeEncoding
+    hSetBinaryMode readh True
+    hSetBinaryMode writeh True
     return (readh, writeh)
   where
     _ = callStack
+#endif
 #endif

--- a/Cabal/tests/UnitTests/Distribution/Compat/CreatePipe.hs
+++ b/Cabal/tests/UnitTests/Distribution/Compat/CreatePipe.hs
@@ -1,19 +1,56 @@
 module UnitTests.Distribution.Compat.CreatePipe (tests) where
 
+import Control.Concurrent.Async (async, wait)
+import Control.DeepSeq          (force)
+import Control.Exception        (evaluate)
+import System.IO                (hClose, hGetContents, hPutStr, hSetEncoding, localeEncoding)
+import Test.Tasty               (TestTree)
+import Test.Tasty.HUnit         (Assertion, assertEqual, testCase)
+
+import qualified Data.ByteString as BS
+
 import Distribution.Compat.CreatePipe
-import System.IO (hClose, hGetContents, hPutStr, hSetEncoding, localeEncoding)
-import Test.Tasty
-import Test.Tasty.HUnit
 
 tests :: [TestTree]
-tests = [testCase "Locale Encoding" case_Locale_Encoding]
+tests =
+    [ testCase "Locale Encoding" case_Locale_Encoding
+    , testCase "Binary ByteStrings are not affected" case_ByteString
+    ]
 
 case_Locale_Encoding :: Assertion
 case_Locale_Encoding = do
-    let str = "\0252"
+    let str = "\0252foobar"
     (r, w) <- createPipe
     hSetEncoding w localeEncoding
-    out <- hGetContents r
-    hPutStr w str
-    hClose w
+    hSetEncoding r localeEncoding
+
+    ra <- async $ do
+        out <- hGetContents r
+        evaluate (force out)
+
+    wa <- async $ do
+        hPutStr w str
+        hClose w
+
+    out <- wait ra
+    wait wa
+
     assertEqual "createPipe should support Unicode roundtripping" str out
+
+case_ByteString :: Assertion
+case_ByteString = do
+    let bs = BS.pack[ 1..255]
+    (r, w) <- createPipe
+
+    ra <- async $ do
+        out <- BS.hGetContents r
+        evaluate (force out)
+
+    wa <- async $ do
+        BS.hPutStr w bs
+        hClose w
+
+    out <- wait ra
+    wait wa
+
+    assertEqual "createPipe should support Unicode roundtripping" bs out


### PR DESCRIPTION
cc @Mistuke 

This doesn't yet work due

```
Unit Tests
  Distribution.Compat.CreatePipe
    Locale Encoding:                                                                      FAIL
      tests/UnitTests/Distribution/Compat/CreatePipe.hs:19:
      createPipe should support Unicode roundtripping
      expected: "\252"
       but got: "\195\188"
```

Compare:

```haskell
createPipeInternal :: IO (Handle, Handle)
createPipeInternal = do
    (readfd, writefd) <- Posix.createPipe
    readh <- Posix.fdToHandle readfd
    writeh <- Posix.fdToHandle writefd
    return (readh, writeh)
```

and

```haskell
createPipe = do
    (readfd, writefd) <- Posix.createPipe
    readh <- fdToHandle readfd
    writeh <- fdToHandle writefd
    hSetEncoding readh localeEncoding
    hSetEncoding writeh localeEncoding
    return (readh, writeh)
  where
    _ = callStack
```

---

I will think how to rip this locale dependency off. As we use this to read stderr and stdout using single pipe, we really should just read `ByteString` and don't care of what kind of "crap" test suites give us, i.e. simply pass it through.