### PR TITLE
Fix ambiguous file target selectors causing an internal error

### DIFF
--- a/Cabal/Distribution/Compat/Prelude.hs
+++ b/Cabal/Distribution/Compat/Prelude.hs
@@ -137,7 +137,7 @@ module Distribution.Compat.Prelude (
     readMaybe,
 
     -- * Debug.Trace (as deprecated functions)
-    traceShow, traceShowId,
+    trace, traceShow, traceShowId,
     ) where
 
 -- We also could hide few partial function
@@ -302,6 +302,10 @@ foldl1 = Data.Foldable.foldl1
 
 -- Functions from Debug.Trace
 -- but with DEPRECATED pragma, so -Werror will scream on them.
+
+trace :: String -> a -> a
+trace = Debug.Trace.trace
+{-# DEPRECATED trace "Don't leave me in the code" #-}
 
 traceShowId :: Show a => a -> a
 traceShowId x = Debug.Trace.traceShow x x

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -371,6 +371,14 @@ testTargetSelectorAmbiguous reportSubCase = do
       [ mkpkg "foo" [ mkexe "bar"  `withModules` ["Bar"]
                     , mkexe "bar2" `withModules` ["Bar"] ]
       ]
+    reportSubCase "ambiguous: file in multiple comps with path"
+    assertAmbiguous ("src" </> "Bar.hs")
+      [ mkTargetFile "foo" (CExeName "bar")  ("src" </> "Bar")
+      , mkTargetFile "foo" (CExeName "bar2") ("src" </> "Bar")
+      ]
+      [ mkpkg "foo" [ mkexe "bar"  `withModules` ["Bar"] `withHsSrcDirs` ["src"]
+                    , mkexe "bar2" `withModules` ["Bar"] `withHsSrcDirs` ["src"] ]
+      ]
 
     -- non-exact case packages and components are ambiguous
     reportSubCase "ambiguous: non-exact-case pkg names"
@@ -471,6 +479,10 @@ testTargetSelectorAmbiguous reportSubCase = do
     withCFiles :: Executable -> [FilePath] -> Executable
     withCFiles exe files =
       exe { buildInfo = (buildInfo exe) { cSources = files } }
+
+    withHsSrcDirs :: Executable -> [FilePath] -> Executable
+    withHsSrcDirs exe srcDirs =
+      exe { buildInfo = (buildInfo exe) { hsSourceDirs = srcDirs }}
 
 
 mkTargetPackage :: PackageId -> TargetSelector


### PR DESCRIPTION
These should have been returning an error message but instead were
causing an internal error because disambiguateTargetSelectors was
rendering syntax and rematching on it, which isn't equivalent. Due to
the way syntaxForm1File renders, it does not add a FileStatus to its
TargetStringFileStatus and so cannot be matched upon again.
The fix is to just copy over the FileStatus from the match input.
This fixes #6874