### PR TITLE
Rebuild on changes in all extra-source-files

### DIFF
--- a/cabal-install/Distribution/Client/SourceFiles.hs
+++ b/cabal-install/Distribution/Client/SourceFiles.hs
@@ -150,14 +150,8 @@ needBuildInfo pkg_descr bi modules = do
         , jsSources bi
         , cmmSources bi
         , asmSources bi
+        , extraSrcFiles pkg_descr
         ]
-    -- A MASSIVE HACK to (1) make sure we rebuild when header
-    -- files change, but (2) not have to rebuild when anything
-    -- in extra-src-files changes (most of these won't affect
-    -- compilation).  It would be even better if we knew on a
-    -- per-component basis which headers would be used but that
-    -- seems to be too difficult.
-    traverse_ needIfExists (filter ((==".h").takeExtension) (extraSrcFiles pkg_descr))
     for_ (installIncludes bi) $ \f ->
         findFileMonitored ("." : includeDirs bi) f
             >>= maybe (return ()) need

--- a/changelog.d/issue-4746
+++ b/changelog.d/issue-4746
@@ -1,0 +1,3 @@
+synopsis: all extra-source-files are change-tracked
+packages: cabal-install
+issues: #4746


### PR DESCRIPTION
This should alleviate #4746 for most use cases, if the dependent files
are declared in `extra-source-files`. The downside is that `cabal`
will not be able to avoid invoking GHC in as many cases, but GHC's
`--make` should be smart enough to avoid any "actual" rebuilding that
isn't necessary.

----

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!