### PR TITLE
Add LinearTypes extension

### DIFF
--- a/Cabal/Language/Haskell/Extension.hs
+++ b/Cabal/Language/Haskell/Extension.hs
@@ -839,6 +839,9 @@ data KnownExtension =
 
   -- | Enable unlifted newtypes.
   | UnliftedNewtypes
+  
+  -- | Enable linear types.
+  | LinearTypes
 
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable, Data)
 


### PR DESCRIPTION
LinearTypes have been merged to GHC master (the version that will become 8.12).

This adds the extension to Cabal, as described in Note [Adding a language extension].
https://github.com/ghc/ghc/blob/96aa578/compiler/GHC/Driver/Session.hs#L339

No testing was done.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!