### PR TITLE
Add more descriptive error message 

### DIFF
--- a/Cabal/Distribution/PackageDescription/Parsec.hs
+++ b/Cabal/Distribution/PackageDescription/Parsec.hs
@@ -182,7 +182,9 @@ parseGenericPackageDescription' scannedVer lexWarnings utf8WarnPos fs = do
                 -- if it were at the beginning, scanner would found it
                 when (v >= CabalSpecV2_2) $ parseFailure pos $
                     "cabal-version should be at the beginning of the file starting with spec version 2.2. " ++
-                    "See https://github.com/haskell/cabal/issues/4899"
+                    "See https://github.com/haskell/cabal/issues/4899" ++ 
+                    "\nYou may also need to check version number format, as described at " ++
+                    "https://cabal.readthedocs.io/en/latest/file-format-changelog.html"
 
                 return v
 


### PR DESCRIPTION
The addition documents a case of supplying a wrong cabal version (eg `3` or `3.2.0.0`) if encountered in .cabal file. Addresses #6862.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
