### PR TITLE
Resolve #6288

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -1151,10 +1151,10 @@ checkCabalVersion pkg =
            "To use the 'default-language' field the package needs to specify "
         ++ "at least 'cabal-version: >= 1.10'."
 
-  , check (specVersion pkg >= CabalSpecV1_10
+  , check (specVersion pkg >= CabalSpecV1_10 && specVersion pkg < CabalSpecV3_4
            && (any isNothing (buildInfoField defaultLanguage))) $
       PackageBuildWarning $
-           "Packages using 'cabal-version: >= 1.10' must specify the "
+           "Packages using 'cabal-version: >= 1.10' and before 'cabal-version: 3.4' must specify the "
         ++ "'default-language' field for each component (e.g. Haskell98 or "
         ++ "Haskell2010). If a component uses different languages in "
         ++ "different modules then list the other ones in the "

--- a/Cabal/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal/Distribution/PackageDescription/FieldGrammar.hs
@@ -530,10 +530,15 @@ buildInfoFieldGrammar = BuildInfo
     <*> monoidalFieldAla "virtual-modules"      (alaList' VCat MQuoted)       L.virtualModules
         ^^^ availableSince CabalSpecV2_2 []
     <*> monoidalFieldAla "autogen-modules"      (alaList' VCat MQuoted)       L.autogenModules
+        ^^^ availableSince CabalSpecV2_0 []
     <*> optionalFieldAla "default-language"     MQuoted                       L.defaultLanguage
+        ^^^ availableSince CabalSpecV1_10 Nothing
     <*> monoidalFieldAla "other-languages"      (alaList' FSep MQuoted)       L.otherLanguages
+        ^^^ availableSince CabalSpecV1_10 []
     <*> monoidalFieldAla "default-extensions"   (alaList' FSep MQuoted)       L.defaultExtensions
+        ^^^ availableSince CabalSpecV1_10 []
     <*> monoidalFieldAla "other-extensions"     formatOtherExtensions         L.otherExtensions
+        ^^^ availableSince CabalSpecV1_10 []
     <*> monoidalFieldAla "extensions"           (alaList' FSep MQuoted)       L.oldExtensions
         ^^^ deprecatedSince CabalSpecV1_12
             "Please use 'default-extensions' or 'other-extensions' fields."

--- a/Cabal/doc/file-format-changelog.rst
+++ b/Cabal/doc/file-format-changelog.rst
@@ -34,6 +34,9 @@ relative to the respective preceding *published* version.
 * Remove ``-any`` and ``-none`` syntax for version ranges
   Use ``>=0`` and ``<0`` respectively.
 
+* :pkg-field:`default-language` is optional.
+  The Default value is to use the compiler's default language.
+
 * :pkg-field:`mixins` field allow specifying a sublibrary.
 
 ``cabal-version: 3.0``

--- a/Cabal/tests/ParserTests/regressions/issue-6288-a.check
+++ b/Cabal/tests/ParserTests/regressions/issue-6288-a.check
@@ -1,1 +1,1 @@
-To use the 'default-language' field the package needs to specify at least 'cabal-version: >= 1.10'.
+issue-6288-a.cabal:13:3: The field "default-language" is available only since the Cabal specification version 1.10. This field will be ignored.

--- a/Cabal/tests/ParserTests/regressions/issue-6288-d.check
+++ b/Cabal/tests/ParserTests/regressions/issue-6288-d.check
@@ -1,1 +1,1 @@
-Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.
+Packages using 'cabal-version: >= 1.10' and before 'cabal-version: 3.4' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.

--- a/Cabal/tests/ParserTests/regressions/issue-6288-f.check
+++ b/Cabal/tests/ParserTests/regressions/issue-6288-f.check
@@ -1,1 +1,0 @@
-Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.

--- a/cabal-testsuite/PackageTests/AutogenModules/SrcDist/AutogenModules.cabal
+++ b/cabal-testsuite/PackageTests/AutogenModules/SrcDist/AutogenModules.cabal
@@ -7,7 +7,7 @@ maintainer: Federico Mastellone
 synopsis: AutogenModules
 category: PackageTests
 build-type: Simple
-cabal-version: 1.24
+cabal-version: 2.0
 
 description:
     Check that Cabal recognizes the autogen-modules fields below.
@@ -22,6 +22,7 @@ Library
     other-modules:
         MyLibModule
     autogen-modules:
+        Paths_AutogenModules
         MyLibHelperModule
 
 Executable Exe
@@ -33,6 +34,7 @@ Executable Exe
         Paths_AutogenModules
         MyExeHelperModule
     autogen-modules:
+        Paths_AutogenModules
         MyExeHelperModule
 
 Test-Suite Test
@@ -45,6 +47,7 @@ Test-Suite Test
         Paths_AutogenModules
         MyTestHelperModule
     autogen-modules:
+        Paths_AutogenModules
         MyTestHelperModule
 
 Benchmark Bench
@@ -57,4 +60,5 @@ Benchmark Bench
         Paths_AutogenModules
         MyBenchHelperModule
     autogen-modules:
+        Paths_AutogenModules
         MyBenchHelperModule

--- a/cabal-testsuite/PackageTests/AutogenModules/SrcDist/setup.test.hs
+++ b/cabal-testsuite/PackageTests/AutogenModules/SrcDist/setup.test.hs
@@ -25,16 +25,16 @@ main = setupAndCabalTest $ do
         let gotTestSuite  = head $ testSuites  (localPkgDescr lbi)
         let gotBenchmark  = head $ benchmarks  (localPkgDescr lbi)
         assertEqual "library 'autogen-modules' field does not match expected"
-                [fromString "MyLibHelperModule"]
+                [fromString "Paths_AutogenModules", fromString "MyLibHelperModule"]
                 (libModulesAutogen gotLibrary)
         assertEqual "executable 'autogen-modules' field does not match expected"
-                [fromString "MyExeHelperModule"]
+                [fromString "Paths_AutogenModules", fromString "MyExeHelperModule"]
                 (exeModulesAutogen gotExecutable)
         assertEqual "test-suite 'autogen-modules' field does not match expected"
-                [fromString "MyTestHelperModule"]
+                [fromString "Paths_AutogenModules", fromString "MyTestHelperModule"]
                 (testModulesAutogen gotTestSuite)
         assertEqual "benchmark 'autogen-modules' field does not match expected"
-                [fromString "MyBenchHelperModule"]
+                [fromString "Paths_AutogenModules", fromString "MyBenchHelperModule"]
                 (benchmarkModulesAutogen gotBenchmark)
 
         -- Package check messages.

--- a/cabal-testsuite/PackageTests/Backpack/T5634/T5634.cabal
+++ b/cabal-testsuite/PackageTests/Backpack/T5634/T5634.cabal
@@ -4,6 +4,7 @@ build-type: Simple
 cabal-version: 2.0
 
 library
+    default-language: Haskell2010
     build-depends: base, impl, sig-with-th
     hs-source-dirs: .
     mixins: sig-with-th requires (Sig as Impl)
@@ -11,12 +12,14 @@ library
     exposed-modules: Go
 
 library sig-with-th
+    default-language: Haskell2010
     build-depends: base
     hs-source-dirs: sig-with-th
     signatures: Sig
     exposed-modules: THFuns
 
 library impl
+    default-language: Haskell2010
     build-depends: base
     hs-source-dirs: impl
     exposed-modules: Impl

--- a/cabal-testsuite/PackageTests/Backpack/T5634/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/T5634/setup.cabal.out
@@ -1,6 +1,5 @@
 # Setup configure
 Configuring th-backpack-failure-1.0...
-Warning: Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.
 # Setup build
 Preprocessing library 'sig-with-th' for th-backpack-failure-1.0..
 Building library 'sig-with-th' instantiated with Sig = <Sig>

--- a/cabal-testsuite/PackageTests/Backpack/T5634/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/T5634/setup.out
@@ -1,6 +1,5 @@
 # Setup configure
 Configuring th-backpack-failure-1.0...
-Warning: Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.
 # Setup build
 Preprocessing library 'sig-with-th' for th-backpack-failure-1.0..
 Building library 'sig-with-th' instantiated with Sig = <Sig>

--- a/cabal-testsuite/PackageTests/BenchmarkStanza/my.cabal
+++ b/cabal-testsuite/PackageTests/BenchmarkStanza/my.cabal
@@ -11,10 +11,12 @@ description:
     Check that Cabal recognizes the benchmark stanza defined below.
 
 Library
+    default-language: Haskell2010
     exposed-modules: MyLibrary
     build-depends: base
 
 benchmark dummy
+    default-language: Haskell2010
     main-is: dummy.hs
     type: exitcode-stdio-1.0
     build-depends: base

--- a/cabal-testsuite/PackageTests/BenchmarkStanza/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/BenchmarkStanza/setup.cabal.out
@@ -1,3 +1,2 @@
 # Setup configure
 Configuring BenchmarkStanza-0.1...
-Warning: Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.

--- a/cabal-testsuite/PackageTests/BenchmarkStanza/setup.out
+++ b/cabal-testsuite/PackageTests/BenchmarkStanza/setup.out
@@ -1,3 +1,2 @@
 # Setup configure
 Configuring BenchmarkStanza-0.1...
-Warning: Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.

--- a/cabal-testsuite/PackageTests/Haddock/my.cabal
+++ b/cabal-testsuite/PackageTests/Haddock/my.cabal
@@ -5,12 +5,13 @@ author: Iain Nicol
 stability: stable
 category: PackageTests
 build-type: Simple
-Cabal-version: >= 1.2
+Cabal-version: >= 1.10
 
 description:
     Check that Cabal successfully invokes Haddock.
 
 Library
+    default-language: Haskell2010
     exposed-modules: CPP, Literate, NoCPP, Simple
     other-extensions: CPP
     build-depends: base

--- a/cabal-testsuite/PackageTests/Regression/T3847/T3847.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T3847/T3847.cabal
@@ -1,11 +1,13 @@
 name: T3847
 version: 1.0
 build-type: Simple
-cabal-version: >= 1.8
+cabal-version: >= 1.10
 
 library
+  default-language: Haskell2010
 
 test-suite tests
+  default-language: Haskell2010
   other-extensions: ThisDoesNotExist
   type: exitcode-stdio-1.0
   main-is: Main.hs

--- a/cabal-testsuite/PackageTests/Regression/T4025/T4025.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T4025/T4025.cabal
@@ -4,10 +4,12 @@ build-type: Simple
 cabal-version: >= 1.10
 
 library
+  default-language: Haskell2010
   build-depends: base
   exposed-modules: A
 
 executable exe
+  default-language: Haskell2010
   build-depends: T4025, base
   hs-source-dirs: exe
   main-is: Main.hs

--- a/cabal-testsuite/PackageTests/Regression/T4025/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T4025/setup.cabal.out
@@ -1,6 +1,5 @@
 # Setup configure
 Configuring T4025-1.0...
-Warning: Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.
 # Setup build
 Preprocessing library for T4025-1.0..
 Building library for T4025-1.0..

--- a/cabal-testsuite/PackageTests/Regression/T4025/setup.out
+++ b/cabal-testsuite/PackageTests/Regression/T4025/setup.out
@@ -1,6 +1,5 @@
 # Setup configure
 Configuring T4025-1.0...
-Warning: Packages using 'cabal-version: >= 1.10' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.
 # Setup build
 Preprocessing library for T4025-1.0..
 Building library for T4025-1.0..


### PR DESCRIPTION
- Add availableSince to language/extension fields
   - Also autogen-modules once we are on that.
- Remove default-language check for cabal-version: 3.4

We cannot make the field `uniqueFieldAlaDef`, as that would require
specifying `default-language` in each subconditional.
I leave it for https://github.com/haskell/cabal/issues/6925

Note: the default language is whatever is the compiler's default.
The GHC-8.10 default is its variant of Haskell2010
with NondecreasingIndentation and without DatatypeContexts


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
