### PR TITLE
Don't use `--detach` when cloning, fixes #6888

### DIFF
--- a/cabal-install/src/Distribution/Client/VCS.hs
+++ b/cabal-install/src/Distribution/Client/VCS.hs
@@ -384,7 +384,7 @@ vcsGit =
                            Just peerLocalDir -> ["--reference", peerLocalDir]
                       ++ verboseArg
                          where loc = srpLocation
-        checkoutArgs   = "checkout" : verboseArg ++ ["--detach", "--force"
+        checkoutArgs   = "checkout" : verboseArg ++ ["--force"
                          , checkoutTarget, "--" ]
         checkoutTarget = fromMaybe "HEAD" (srpBranch `mplus` srpTag)
         verboseArg     = [ "--quiet" | verbosity < Verbosity.normal ]


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
  - **Help needed:** Should add a changelog file for this fix?
* [x] The documentation has been updated, if necessary.
  - I have not made any documentation updates. This PR does not change intended behaviour - it merely fixes a bug in an existing implementation.

Please also shortly describe how you tested your change. Bonus points for added tests!

---

I think this fixes #6888 but I'm not sure how to write an automated test for this.

#6888 happens because we use `--detach` even when we are checking out branch names. This causes `git` to fail with the error message `fatal: '--detach' cannot be used with '-b/-B/--orphan'`. To the best of my knowledge, there's no reason to ever prefer `--detached` over regular tag names, so I've removed that flag.

I tested this fix by using the binary built from this commit to successfully build and run my project that depends on a non-`master` branch of a Git repository for an external package. [Here](https://github.com/liftM/hipsterfy/tree/02751f04848d26d4d4ab5615d67b495e36dc2252) is the exact commit that does not compile on with cabal-install 3.2.0.0, but does compile with this patch.