### PR TITLE
Remove redundant call to 'ifReplLib'

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -674,7 +674,7 @@ buildOrReplLib mReplFlags verbosity numJobs pkg_descr lbi lib clbi = do
 
   ifReplLib $ do
     when (null (allLibModules lib clbi)) $ warn verbosity "No exposed modules"
-    ifReplLib (runGhcProg replOpts)
+    runGhcProg replOpts
 
   -- build any C sources
   unless (not has_code || null (cSources libBi)) $ do


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!



I did not test it, but since the function definition for `ifReplLib` is as follows 
```haskell
      forRepl = maybe False (const True) mReplFlags
      ifReplLib = when forRepl
```
I argue that it is safe due to referential transparency and idempotency of the `when b` function.