### PR TITLE
Accept "linux-androideabi" as an alias for Android

### DIFF
--- a/Cabal/Distribution/System.hs
+++ b/Cabal/Distribution/System.hs
@@ -122,7 +122,8 @@ osAliases Permissive FreeBSD = ["kfreebsdgnu"]
 osAliases Compat     FreeBSD = ["kfreebsdgnu"]
 osAliases Permissive Solaris = ["solaris2"]
 osAliases Compat     Solaris = ["solaris2"]
-osAliases _          Android = ["linux-android"]
+osAliases Permissive Android = ["linux-android", "linux-androideabi", "linux-androideabihf"]
+osAliases Compat     Android = ["linux-android"]
 osAliases _          _       = []
 
 instance Pretty OS where

--- a/changelog.d/pr-6301
+++ b/changelog.d/pr-6301
@@ -1,0 +1,2 @@
+synopsis: Accept "linux-androideabi" for determining buildOS
+prs: #6301


### PR DESCRIPTION
rebased #6301 (added a changelog entry).