### PR TITLE
Fix broken links in documentation

### DIFF
--- a/Cabal/doc/cabal-package.rst
+++ b/Cabal/doc/cabal-package.rst
@@ -2123,7 +2123,7 @@ system-dependent values for these fields.
     developer documentation for more details on frameworks. This entry
     is ignored on all other platforms.
 
-.. pkg-field:: extra-frameworks-dirs: directory list
+.. pkg-field:: extra-framework-dirs: directory list
     :since: 1.24
 
     On Darwin/MacOS X, a list of directories to search for frameworks.
@@ -2570,6 +2570,8 @@ a conditional and outside then they are combined using the following rules.
          Main-is: OtherMain.hs
        else
          Main-is: Main.hs
+
+.. _common-stanzas:
 
 Common stanzas
 ^^^^^^^^^^^^^^

--- a/Cabal/doc/cabal-project.rst
+++ b/Cabal/doc/cabal-project.rst
@@ -119,7 +119,7 @@ format:
    ``{vendor,pkgs}/*.cabal`` matches all Cabal files in the ``vendor``
    and ``pkgs`` subdirectories.
 
-Formally, the format described by the following BNF:
+Formally, the format is described by the following BNF:
 
 .. todo::
     convert globbing grammar to proper ABNF_ syntax

--- a/Cabal/doc/developing-packages.rst
+++ b/Cabal/doc/developing-packages.rst
@@ -209,7 +209,7 @@ your libraries and executable sections. For example:
         Proglet
 
 Note that the ``import`` **must** be the first thing in the stanza. For more
-information see the `Common stanzas`_ section.
+information see the :ref:`common-stanzas` section.
 
 Building the package
 --------------------
@@ -300,7 +300,7 @@ of digits such as "1.0.1" or "2.0". There are a range of common
 conventions for "versioning" packages, that is giving some meaning to
 the version number in terms of changes in the package, such as
 e.g. `SemVer <http://semver.org>`__; however, for packages intended to be
-distributed via Hackage Haskell's `Package Versioning Policy`_ applies
+distributed via Hackage Haskell's `Package Versioning Policy <https://pvp.haskell.org/>`_ applies
 (see also the `PVP/SemVer FAQ section <https://pvp.haskell.org/faq/#semver>`__).
 
 The combination of package name and version is called the *package ID*

--- a/Cabal/doc/file-format-changelog.rst
+++ b/Cabal/doc/file-format-changelog.rst
@@ -67,7 +67,7 @@ relative to the respective preceding *published* version.
                 import foo-deps
 
 * Allow redundant leading or trailing commas in package fields with
-  optional commas, such as :pkg-field:`exposed-modules`
+  optional commas, such as :pkg-field:`library:exposed-modules`
 
 * Require fields with optional commas to consistently omit or place
   commas between elements.

--- a/Cabal/doc/installing-packages.rst
+++ b/Cabal/doc/installing-packages.rst
@@ -235,12 +235,13 @@ Installing packages from Hackage
 --------------------------------
 
 The ``cabal`` tool also can download, configure, build and install a
-Hackage_ package and all of its
+`Hackage`_ package and all of its
 dependencies in a single step. To do this, run:
 
 ::
 
    $ cabal install [PACKAGE...]
 
-To browse the list of available packages, visit the
-Hackage_ web site.
+To browse the list of available packages, visit the `Hackage`_ web site.
+
+.. _Hackage: https://hackage.haskell.org/

--- a/Cabal/doc/nix-local-build-overview.rst
+++ b/Cabal/doc/nix-local-build-overview.rst
@@ -1,7 +1,7 @@
 Nix-style Local Builds
 ======================
 
-.. _nix-style-builds
+.. _nix-style-builds:
 
 Nix-style local builds are a new build system implementation inspired by Nix.
 The Nix-style local build system is commonly called "v2-build" for short

--- a/Cabal/doc/setup-commands.rst
+++ b/Cabal/doc/setup-commands.rst
@@ -34,7 +34,7 @@ results to some permanent place and registers the package with GHC.
 .. note ::
     
     Global installing of packages is not recommended.
-    The :ref:`_nix-style-builds` is the preferred of building and installing
+    The :ref:`Nix-style builds<nix-style-builds>` is the preferred way of building and installing
     packages.
 
 Creating a binary package
@@ -1002,7 +1002,7 @@ Miscellaneous options
     (:pkg-field:`build-depends`), build dependencies of build
     dependencies, and so on. Constraints normally do not apply to
     dependencies of the ``Setup.hs`` script of any package
-    (:pkg-field:`setup-depends`) nor do they apply to build tools
+    (:pkg-field:`custom-setup:setup-depends`) nor do they apply to build tools
     (:pkg-field:`build-tool-depends`) or the dependencies of build
     tools. To explicitly apply a constraint to a setup or build
     tool dependency, you can add a qualifier to the constraint as


### PR DESCRIPTION
This fixes about half of the "broken link" warnings displayed by sphinx.

<details>
  <summary>sphinx warnings before this PR</summary>
  <pre>
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/developing-packages.rst:211: WARNING: Unknown target name: "common stanzas".
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/developing-packages.rst:295: WARNING: Unknown target name: "package versioning policy".
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/installing-packages.rst:237: WARNING: Unknown target name: "hackage".
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/installing-packages.rst:245: WARNING: Unknown target name: "hackage".
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/nix-local-build-overview.rst:4: WARNING: malformed hyperlink target.
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:183: WARNING: cabal:pkg-field reference target not found: autogen-includes
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:191: WARNING: cabal:pkg-field reference target not found: autogen-modules
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:290: WARNING: cabal:pkg-field reference target not found: default-language
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:313: WARNING: cabal:pkg-field reference target not found: extra-dynamic-library-flavours
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:320: WARNING: cabal:pkg-field reference target not found: extra-framework-dirs
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:348: WARNING: cabal:pkg-field reference target not found: extra-library-flavours
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:383: WARNING: cabal:pkg-field reference target not found: ghcjs-options
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:390: WARNING: cabal:pkg-field reference target not found: ghcjs-prof-options
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:397: WARNING: cabal:pkg-field reference target not found: ghcjs-shared-options
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:471: WARNING: cabal:pkg-field reference target not found: other-languages
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:493: WARNING: cabal:pkg-field reference target not found: virtual-modules
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:635: WARNING: cabal:pkg-field reference target not found: main-is
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:642: WARNING: cabal:pkg-field reference target not found: test-module
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:649: WARNING: cabal:pkg-field reference target not found: type
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/cabal-package.rst:1623: WARNING: unknown option: --allow-newer
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/file-format-changelog.rst:37: WARNING: cabal:pkg-field reference target not found: default-language
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/file-format-changelog.rst:45: WARNING: cabal:pkg-field reference target not found: extra-dynamic-library-flavours
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/file-format-changelog.rst:45: WARNING: cabal:pkg-field reference target not found: extra-library-flavours
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/file-format-changelog.rst:69: WARNING: cabal:pkg-field reference target not found: exposed-modules
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/file-format-changelog.rst:89: WARNING: cabal:pkg-field reference target not found: autogen-includes
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/file-format-changelog.rst:127: WARNING: cabal:pkg-field reference target not found: import
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/file-format-changelog.rst:183: WARNING: cabal:pkg-field reference target not found: extra-framework-dirs
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/setup-commands.rst:36: WARNING: undefined label: _nix-style-builds (if the link has no caption the label must precede a section header)
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/setup-commands.rst:1001: WARNING: cabal:pkg-field reference target not found: setup-depends  </pre>
</details>

Checked locally that the links work.

For the other half there is no content to link to, so I left those unfixed:

<details>
  <summary>sphinx warnings after this PR</summary>
  <pre>
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:290: WARNING: cabal:pkg-field reference target not found: default-language
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:313: WARNING: cabal:pkg-field reference target not found: extra-dynamic-library-flavours
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:348: WARNING: cabal:pkg-field reference target not found: extra-library-flavours
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:383: WARNING: cabal:pkg-field reference target not found: ghcjs-options
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:390: WARNING: cabal:pkg-field reference target not found: ghcjs-prof-options
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:397: WARNING: cabal:pkg-field reference target not found: ghcjs-shared-options
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/buildinfo-fields-reference.rst:471: WARNING: cabal:pkg-field reference target not found: other-languages
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/cabal-package.rst:1623: WARNING: unknown option: --allow-newer
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/file-format-changelog.rst:37: WARNING: cabal:pkg-field reference target not found: default-language
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/file-format-changelog.rst:45: WARNING: cabal:pkg-field reference target not found: extra-dynamic-library-flavours
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/file-format-changelog.rst:45: WARNING: cabal:pkg-field reference target not found: extra-library-flavours
/home/jhrcek/Devel/github.com/haskell/cabal/Cabal/doc/file-format-changelog.rst:127: WARNING: cabal:pkg-field reference target not found: import
  </pre>
</details>
