### PR TITLE
Consider Installed packages when pruning the install plan

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2680,16 +2680,22 @@ pruneInstallPlanPass1 pkgs =
                 setDocumentation
               $ addOptionalStanzas elab
 
-    find_root (InstallPlan.Configured (PrunedPackage elab _)) =
-        if not $ and [ null (elabConfigureTargets elab)
-                     , null (elabBuildTargets elab)
-                     , null (elabTestTargets elab)
-                     , null (elabBenchTargets elab)
-                     , isNothing (elabReplTarget elab)
-                     , null (elabHaddockTargets elab)
-                     ]
-            then Just (installedUnitId elab)
-            else Nothing
+    is_root :: PrunedPackage -> Maybe UnitId
+    is_root (PrunedPackage elab _) =
+      if not $ and [ null (elabConfigureTargets elab)
+                   , null (elabBuildTargets elab)
+                   , null (elabTestTargets elab)
+                   , null (elabBenchTargets elab)
+                   , isNothing (elabReplTarget elab)
+                   , null (elabHaddockTargets elab)
+                   ]
+          then Just (installedUnitId elab)
+          else Nothing
+
+    find_root (InstallPlan.Configured pkg) = is_root pkg
+    -- When using the extra-packages stanza we need to
+    -- look at installed packages as well.
+    find_root (InstallPlan.Installed pkg)  = is_root pkg
     find_root _ = Nothing
 
     -- Note [Sticky enabled testsuites]

--- a/cabal-testsuite/PackageTests/ExtraPackages/Foo.hs
+++ b/cabal-testsuite/PackageTests/ExtraPackages/Foo.hs
@@ -1,0 +1,1 @@
+module Foo where

--- a/cabal-testsuite/PackageTests/ExtraPackages/cabal.out
+++ b/cabal-testsuite/PackageTests/ExtraPackages/cabal.out
@@ -1,0 +1,12 @@
+# cabal v2-update
+Downloading the latest package list from test-local-repo
+# cabal v2-run
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - some-exe-0.0.1.0 (exe:some-exe) (requires build)
+Configuring some-exe-0.0.1.0...
+Preprocessing executable 'some-exe' for some-exe-0.0.1.0..
+Building executable 'some-exe' for some-exe-0.0.1.0..
+Installing executable some-exe in <PATH>
+Warning: The directory <ROOT>/cabal.dist/home/.cabal/store/ghc-<GHCVER>/incoming/new-<HASH><ROOT>/cabal.dist/home/.cabal/store/ghc-<GHCVER>/sm-x-0.0.1.0-<HASH>/bin is not in the system search path.

--- a/cabal-testsuite/PackageTests/ExtraPackages/cabal.out
+++ b/cabal-testsuite/PackageTests/ExtraPackages/cabal.out
@@ -9,4 +9,4 @@ Configuring some-exe-0.0.1.0...
 Preprocessing executable 'some-exe' for some-exe-0.0.1.0..
 Building executable 'some-exe' for some-exe-0.0.1.0..
 Installing executable some-exe in <PATH>
-Warning: The directory <ROOT>/cabal.dist/home/.cabal/store/ghc-<GHCVER>/incoming/new-<HASH><ROOT>/cabal.dist/home/.cabal/store/ghc-<GHCVER>/sm-x-0.0.1.0-<HASH>/bin is not in the system search path.
+Warning: The directory <ROOT>/cabal.dist/home/.cabal/store/ghc-<GHCVER>/incoming/<PACKAGE>-<HASH><ROOT>/cabal.dist/home/.cabal/store/ghc-<GHCVER>/<PACKAGE>-<HASH>/bin is not in the system search path.

--- a/cabal-testsuite/PackageTests/ExtraPackages/cabal.project
+++ b/cabal-testsuite/PackageTests/ExtraPackages/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+extra-packages: some-exe

--- a/cabal-testsuite/PackageTests/ExtraPackages/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ExtraPackages/cabal.test.hs
@@ -1,0 +1,3 @@
+import Test.Cabal.Prelude
+main = cabalTest $ withRepo "repo" $ do
+  cabal "v2-run" [ "some-exe" ]

--- a/cabal-testsuite/PackageTests/ExtraPackages/my.cabal
+++ b/cabal-testsuite/PackageTests/ExtraPackages/my.cabal
@@ -1,0 +1,9 @@
+name:           my
+version:        0.1
+license:        BSD3
+cabal-version:  >= 1.2
+build-type:     Simple
+
+library
+    exposed-modules:    Foo
+    build-depends:      base

--- a/cabal-testsuite/PackageTests/ExtraPackages/repo/some-exe-0.0.1.0/Main.hs
+++ b/cabal-testsuite/PackageTests/ExtraPackages/repo/some-exe-0.0.1.0/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "hello world"

--- a/cabal-testsuite/PackageTests/ExtraPackages/repo/some-exe-0.0.1.0/some-exe.cabal
+++ b/cabal-testsuite/PackageTests/ExtraPackages/repo/some-exe-0.0.1.0/some-exe.cabal
@@ -1,0 +1,9 @@
+name:           some-exe
+version:        0.0.1.0
+license:        BSD3
+cabal-version:  >= 1.2
+build-type:     Simple
+
+Executable some-exe
+  main-is: Main.hs
+  build-depends: base

--- a/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
+++ b/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
@@ -43,8 +43,8 @@ normalizeOutput nenv =
   . resub "/incoming/new-[0-9]+"
           "/incoming/new-<RAND>"
     -- look for PackageHash directories
-  . resub "/(([A-Za-z0-9]+)(-[A-Za-z0-9\\.]+)*)-[0-9a-f]{4,64}/"
-          "/\\1-<HASH>/"
+  . resub "/(([A-Za-z0-9_]+)(-[A-Za-z0-9\\._]+)*)-[0-9a-f]{4,64}/"
+          "/<PACKAGE>-<HASH>/"
     -- Normalize architecture
   . resub (posixRegexEscape (display (normalizerPlatform nenv))) "<ARCH>"
     -- Some GHC versions are chattier than others

--- a/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
+++ b/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
@@ -30,7 +30,7 @@ normalizeOutput nenv =
     -- This is dumb but I don't feel like pulling in another dep for
     -- string search-replace.  Make sure we do this before backslash
     -- normalization!
-  . resub (posixRegexEscape (normalizerGblTmpDir nenv) ++ "[a-z0-9.-]+") "<GBLTMPDIR>" -- note, after TMPDIR
+  . resub (posixRegexEscape (normalizerGblTmpDir nenv) ++ "[a-z0-9\\.-]+") "<GBLTMPDIR>" -- note, after TMPDIR
   . resub (posixRegexEscape (normalizerRoot nenv)) "<ROOT>/"
   . resub (posixRegexEscape (normalizerTmpDir nenv)) "<TMPDIR>/"
   . appEndo (F.fold (map (Endo . packageIdRegex) (normalizerKnownPackages nenv)))
@@ -39,6 +39,12 @@ normalizeOutput nenv =
     -- Apply this before packageIdRegex, otherwise this regex doesn't match.
   . resub "[0-9]+(\\.[0-9]+)*/installed-[A-Za-z0-9.+]+"
           "<VERSION>/installed-<HASH>"
+    -- incoming directories in the store
+  . resub "/incoming/new-[0-9]+"
+          "/incoming/new-<RAND>"
+    -- look for PackageHash directories
+  . resub "/(([A-Za-z0-9]+)(-[A-Za-z0-9\\.]+)*)-[0-9a-f]{4,64}/"
+          "/\\1-<HASH>/"
     -- Normalize architecture
   . resub (posixRegexEscape (display (normalizerPlatform nenv))) "<ARCH>"
     -- Some GHC versions are chattier than others

--- a/changelog.d/pr-6972
+++ b/changelog.d/pr-6972
@@ -1,0 +1,3 @@
+synopsis: Make extra-packages work properly
+packages: cabal-install
+prs: #6972


### PR DESCRIPTION
The discussion in #6952 indicated that extra-packages stanzas wouldn't quite work yet. It turns out in order for cabal to find exes for already installed extra-packages we need to also consider `installed` packages when pruning the install plan.

Here is what you can do with it: 

```patch
diff --git a/cabal.project b/cabal.project
index af1d8a383..b1d724259 100644
--- a/cabal.project
+++ b/cabal.project
@@ -7,6 +7,8 @@ packages: Cabal/Cabal-tree-diff/
 packages: Cabal/Cabal-described
 packages: cabal-benchmarks/
 
+extra-packages: stylish-haskell
+
 -- Uncomment to allow picking up extra local unpacked deps:
 --optional-packages: */
```

Using HEAD

```
$ cabal run cabal-install -- run -- stylish-haskell --version
Up to date
cabal: Unknown executable stylish-haskell in package
stylsh-hskll-0.9.3.0-cdf9f8e3
```

With this patch applied

```
$ cabal run cabal-install -- run -- stylish-haskell --version
Up to date
stylish-haskell 0.9.3.0
```

* [ ] Come up with a test case that doesn't need to depend on an external package :S 

---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
