### PR TITLE
Bump process version required for job support to 1.6.9

### DIFF
--- a/Cabal/src/Distribution/Compat/Process.hs
+++ b/Cabal/src/Distribution/Compat/Process.hs
@@ -26,11 +26,11 @@ import           System.Process (waitForProcess)
 -- in the presence of @exec(3)@ on Windows.
 --
 -- Unfortunately the process job support is badly broken in @process@ releases
--- prior to 1.6.8, so we disable it in these versions, despite the fact that
+-- prior to 1.6.9, so we disable it in these versions, despite the fact that
 -- this means we may see sporatic build failures without jobs.
 enableProcessJobs :: CreateProcess -> CreateProcess
 #ifdef MIN_VERSION_process
-#if MIN_VERSION_process(1,6,8)
+#if MIN_VERSION_process(1,6,9)
 enableProcessJobs cp = cp {Process.use_process_jobs = True}
 #else
 enableProcessJobs cp = cp


### PR DESCRIPTION
The CPP used to enable it even for version 1.6.8 which
turned out to still be buggy which causes segfaults when
building Cabal with ghc-8.10. See #6986.

This does not fully fix the issue as without job support
build failures can still sporadically occur.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [x] The documentation has been updated, if necessary.

Haven't tested it locally yet but will do so.
