### PR TITLE
Data.ByteString.Lazy.Builder -> Data.ByteString.Builder

### DIFF
--- a/Cabal/src/Distribution/Utils/Structured.hs
+++ b/Cabal/src/Distribution/Utils/Structured.hs
@@ -87,7 +87,11 @@ import GHC.Generics
 
 import qualified Data.ByteString              as BS
 import qualified Data.ByteString.Lazy         as LBS
+#if MIN_VERSION_bytestring(0,10,6)
+import qualified Data.ByteString.Builder      as Builder
+#else
 import qualified Data.ByteString.Lazy.Builder as Builder
+#endif
 import qualified Data.IntMap                  as IM
 import qualified Data.IntSet                  as IS
 import qualified Data.Map                     as Map


### PR DESCRIPTION
The former was deprecated in 0.10.10.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
