### PR TITLE
Docs: change sample "cabal init" to use version 3.4

### DIFF
--- a/Cabal/doc/getting-started.rst
+++ b/Cabal/doc/getting-started.rst
@@ -33,7 +33,7 @@ Once you have an empty directory we can initialize our package:
 
 .. code-block:: console
 
-    $ cabal init --cabal-version=2.4 --license=NONE -p myfirstapp
+    $ cabal init --cabal-version=3.4 --license=NONE -p myfirstapp
 
 This will generate the following files:
 


### PR DESCRIPTION
I'm assuming the docs for Cabal 3.4 should not use --cabal-version=2.4 in examples. I'm a Cabal beginner, though. If this isn't really a problem, then I'm sorry for the noise.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
