### PR TITLE
[backport/3.4] Allow Win32-2.9.0.0

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -328,7 +328,7 @@ library
     build-depends: binary >= 0.7 && < 0.9
 
   if os(windows)
-    build-depends: Win32 >= 2.3.0.0 && < 2.9
+    build-depends: Win32 >= 2.3.0.0 && < 2.10
   else
     build-depends: unix  >= 2.6.0.0 && < 2.8
 


### PR DESCRIPTION
This will be necessary for GHC 9.0 to accommodate WinIO.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
