### PR TITLE
Fix cabal init name deduction

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Command.hs
@@ -81,6 +81,8 @@ import Distribution.Simple.Program
   ( ProgramDb )
 import Distribution.Simple.PackageIndex
   ( InstalledPackageIndex, moduleNameIndex )
+import Distribution.Simple.Utils
+  ( die' )
 
 import Distribution.Solver.Types.PackageIndex
   ( elemByPackageName )
@@ -106,7 +108,7 @@ initCabal verbosity packageDBs repoCtxt comp progdb initFlags = do
 
   hSetBuffering stdout NoBuffering
 
-  initFlags' <- extendFlags installedPkgIndex sourcePkgDb initFlags
+  initFlags' <- extendFlags verbosity installedPkgIndex sourcePkgDb initFlags
 
   case license initFlags' of
     Flag SPDX.NONE -> return ()
@@ -127,12 +129,12 @@ initCabal verbosity packageDBs repoCtxt comp progdb initFlags = do
 
 -- | Fill in more details in InitFlags by guessing, discovering, or prompting
 -- the user.
-extendFlags :: InstalledPackageIndex -> SourcePackageDb -> InitFlags -> IO InitFlags
-extendFlags pkgIx sourcePkgDb =
+extendFlags :: Verbosity -> InstalledPackageIndex -> SourcePackageDb -> InitFlags -> IO InitFlags
+extendFlags verbosity pkgIx sourcePkgDb =
       getSimpleProject
   >=> getLibOrExec
   >=> getCabalVersion
-  >=> getPackageName sourcePkgDb
+  >=> getPackageName verbosity sourcePkgDb
   >=> getVersion
   >=> getLicense
   >=> getAuthorInfo
@@ -208,29 +210,33 @@ getCabalVersion flags = do
 -- | Get the package name: use the package directory (supplied, or the current
 --   directory by default) as a guess. It looks at the SourcePackageDb to avoid
 --   using an existing package name.
-getPackageName :: SourcePackageDb -> InitFlags -> IO InitFlags
-getPackageName sourcePkgDb flags = do
-  guess    <-     traverse guessPackageName (flagToMaybe $ packageDir flags)
-              ?>> Just `fmap` (getCurrentDirectory >>= guessPackageName)
+getPackageName :: Verbosity -> SourcePackageDb -> InitFlags -> IO InitFlags
+getPackageName verbosity sourcePkgDb flags = do
+  guess <- maybe (getCurrentDirectory >>= guessPackageName) pure =<< traverse guessPackageName (flagToMaybe $ packageDir flags)
 
-  let guess' | isPkgRegistered guess = Nothing
-             | otherwise = guess
+  pkgName' <- case flagToMaybe $ packageName flags of
+    Just pkgName -> return $ Just $ pkgName
+    _ -> maybePrompt flags (prompt "Package name" (Just guess))
+  let pkgName = fromMaybe guess pkgName'
 
-  pkgName' <-     return (flagToMaybe $ packageName flags)
-              ?>> maybePrompt flags (prompt "Package name" guess')
-              ?>> return guess'
-
-  chooseAgain <- if isPkgRegistered pkgName'
-                    then promptYesNo promptOtherNameMsg (Just True)
-                    else return False
+  chooseAgain <- if isPkgRegistered pkgName
+                   then do
+                     answer' <- maybePrompt flags (promptYesNo promptOtherNameMsg (Just True))
+                     case answer' of
+                       Just answer -> return answer
+                       _ -> die' verbosity $ deathNameMsg pkgName
+                 else
+                   return False
 
   if chooseAgain
-    then getPackageName sourcePkgDb flags
-    else return $ flags { packageName = maybeToFlag pkgName' }
+    then getPackageName verbosity sourcePkgDb flags
+    else return $ flags { packageName = Flag pkgName }
 
   where
-    isPkgRegistered (Just pkg) = elemByPackageName (packageIndex sourcePkgDb) pkg
-    isPkgRegistered Nothing    = False
+    isPkgRegistered pkg = elemByPackageName (packageIndex sourcePkgDb) pkg
+
+    deathNameMsg pkgName = "The name " ++ (P.unPackageName pkgName) ++
+                        " is already used by another package on Hackage."
 
     promptOtherNameMsg = "This package name is already used by another " ++
                          "package on hackage. Do you want to choose a " ++

--- a/cabal-install/src/Distribution/Client/Init/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Command.hs
@@ -222,10 +222,10 @@ getPackageName verbosity sourcePkgDb flags = do
 
   chooseAgain <- if isPkgRegistered pkgName
                    then do
-                     answer' <- maybePrompt flags (promptYesNo promptOtherNameMsg (Just True))
+                     answer' <- maybePrompt flags (promptYesNo (promptOtherNameMsg pkgName) (Just True))
                      case answer' of
                        Just answer -> return answer
-                       _ -> die' verbosity $ deathNameMsg pkgName
+                       _ -> die' verbosity $ inUseMsg pkgName
                  else
                    return False
 
@@ -236,12 +236,11 @@ getPackageName verbosity sourcePkgDb flags = do
   where
     isPkgRegistered pkg = elemByPackageName (packageIndex sourcePkgDb) pkg
 
-    deathNameMsg pkgName = "The name " ++ (P.unPackageName pkgName) ++
-                           " is already used by another package on Hackage."
+    inUseMsg pkgName = "The name " ++ (P.unPackageName pkgName) ++
+                       " is already in use by another package on Hackage."
 
-    promptOtherNameMsg = "This package name is already used by another " ++
-                         "package on hackage. Do you want to choose a " ++
-                         "different name"
+    promptOtherNameMsg pkgName = (inUseMsg pkgName) ++
+                                 " Do you want to choose a different name"
 
 -- | Package version: use 0.1.0.0 as a last resort, but try prompting the user
 --  if possible.

--- a/cabal-install/src/Distribution/Client/Init/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Command.hs
@@ -212,7 +212,8 @@ getCabalVersion flags = do
 --   using an existing package name.
 getPackageName :: Verbosity -> SourcePackageDb -> InitFlags -> IO InitFlags
 getPackageName verbosity sourcePkgDb flags = do
-  guess <- maybe (getCurrentDirectory >>= guessPackageName) pure =<< traverse guessPackageName (flagToMaybe $ packageDir flags)
+  guess <- maybe (getCurrentDirectory >>= guessPackageName) pure
+             =<< traverse guessPackageName (flagToMaybe $ packageDir flags)
 
   pkgName' <- case flagToMaybe $ packageName flags of
     Just pkgName -> return $ Just $ pkgName
@@ -236,7 +237,7 @@ getPackageName verbosity sourcePkgDb flags = do
     isPkgRegistered pkg = elemByPackageName (packageIndex sourcePkgDb) pkg
 
     deathNameMsg pkgName = "The name " ++ (P.unPackageName pkgName) ++
-                        " is already used by another package on Hackage."
+                           " is already used by another package on Hackage."
 
     promptOtherNameMsg = "This package name is already used by another " ++
                          "package on hackage. Do you want to choose a " ++


### PR DESCRIPTION
Fixes #6861, #6236

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [X] The documentation has been updated, if necessary.

Regarding item number 2 on the checklist, I do not think this bugfix is significant enough to warrant a changelog entry.

### Non-interactive use
```
auri@aoi lens $ cabal init --non-interactive
cabal: The name lens is already in use by another package on Hackage.

auri@aoi lens $ cabal init --non-interactive --package-name=microlens
cabal: The name microlens is already in use by another package on Hackage.

```

### Interactive use
```
auri@aoi lens $ cabal init --interactive --package-name=microlens
Should I generate a simple project with sensible defaults? [default: y] y
cabal: The name microlens is already in use by another package on Hackage.

auri@aoi lens $ cabal init --interactive --package-name=microlens
Should I generate a simple project with sensible defaults? [default: y] n
[snip]
The name microlens is already in use by another package on Hackage. Do you want to choose a different name? [default: y] y
Package name? [default: lens] lens
The name lens is already in use by another package on Hackage. Do you want to choose a different name? [default: y] n
[snip]
Guessing dependencies...
Generating CHANGELOG.md...
Generating src/MyLib.hs...
Generating test/MyLibTest.hs...
Generating lens.cabal...

Warning: no synopsis given. You should edit the .cabal file and add one.
You may want to edit the .cabal file and add a Description field.

```

These are all the changes. Otherwise, `init` behaves the same as before.