### PR TITLE
Data.ByteString.Lazy.Builder -> Data.ByteString.Builder

### DIFF
--- a/Cabal/src/Distribution/Utils/Structured.hs
+++ b/Cabal/src/Distribution/Utils/Structured.hs
@@ -87,7 +87,11 @@ import GHC.Generics
 
 import qualified Data.ByteString              as BS
 import qualified Data.ByteString.Lazy         as LBS
+#if MIN_VERSION_bytestring(0,10,4)
+import qualified Data.ByteString.Builder      as Builder
+#else
 import qualified Data.ByteString.Lazy.Builder as Builder
+#endif
 import qualified Data.IntMap                  as IM
 import qualified Data.IntSet                  as IS
 import qualified Data.Map                     as Map


### PR DESCRIPTION
Like #7015, but rebased and lowered the cut bound to `0.10.4` (which ships with GHC-7.8)