### PR TITLE
Bump upper bound on bytestring

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -310,7 +310,7 @@ library
   build-depends:
     array      >= 0.4.0.1  && < 0.6,
     base       >= 4.6      && < 5,
-    bytestring >= 0.10.0.0 && < 0.11,
+    bytestring >= 0.10.0.0 && < 0.12,
     containers >= 0.5.0.0  && < 0.7,
     deepseq    >= 1.3.0.1  && < 1.5,
     directory  >= 1.2      && < 1.4,


### PR DESCRIPTION
Admit bytestring-0.11


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
