### PR TITLE
Skip less: docker ulimit and local+noindex to run withRepo tests. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,36 +184,39 @@ validate-dockerfiles : .docker/validate-7.6.3.dockerfile
 .docker/validate-%.dockerfile : .docker/validate.dockerfile.zinza cabal-dev-scripts/src/GenValidateDockerfile.hs
 	cabal v2-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-validate-dockerfile -- $* $< $@
 
+# This is good idea anyway
+# and we have a test relying on this limit being sufficiently small
+DOCKERARGS:=--ulimit nofile=1024:1024
+
 validate-via-docker-7.6.3:
-	docker build -t cabal-validate -f .docker/validate-7.6.3.dockerfile .
+	docker build $(DOCKERARGS) -t cabal-validate:7.6.3 -f .docker/validate-7.6.3.dockerfile .
 
 validate-via-docker-7.8.4:
-	docker build -t cabal-validate -f .docker/validate-7.8.4.dockerfile .
+	docker build $(DOCKERARGS) -t cabal-validate:7.8.4 -f .docker/validate-7.8.4.dockerfile .
 
 validate-via-docker-7.10.3:
-	docker build -t cabal-validate -f .docker/validate-7.10.3.dockerfile .
+	docker build $(DOCKERARGS) -t cabal-validate:7.10.3 -f .docker/validate-7.10.3.dockerfile .
 
 validate-via-docker-8.0.2:
-	docker build -t cabal-validate -f .docker/validate-8.0.2.dockerfile .
+	docker build $(DOCKERARGS) -t cabal-validate:8.0.2 -f .docker/validate-8.0.2.dockerfile .
 
 validate-via-docker-8.2.2:
-	docker build -t cabal-validate -f .docker/validate-8.2.2.dockerfile .
+	docker build $(DOCKERARGS) -t cabal-validate:8.2.2 -f .docker/validate-8.2.2.dockerfile .
 
 validate-via-docker-8.4.4:
-	docker build -t cabal-validate -f .docker/validate-8.4.4.dockerfile .
+	docker build $(DOCKERARGS) -t cabal-validate:8.4.4 -f .docker/validate-8.4.4.dockerfile .
 
 validate-via-docker-8.6.5:
-	docker build -t cabal-validate -f .docker/validate-8.6.5.dockerfile .
+	docker build $(DOCKERARGS) -t cabal-validate:8.6.5 -f .docker/validate-8.6.5.dockerfile .
 
 validate-via-docker-8.8.3:
-	docker build -t cabal-validate -f .docker/validate-8.8.3.dockerfile .
+	docker build $(DOCKERARGS) -t cabal-validate:8.8.3 -f .docker/validate-8.8.3.dockerfile .
 
-# Only library ATM
 validate-via-docker-8.10.1:
-	docker build -t cabal-validate -f .docker/validate-8.10.1.dockerfile .
+	docker build $(DOCKERARGS) -t cabal-validate:8.10.1 -f .docker/validate-8.10.1.dockerfile .
 
 validate-via-docker-old:
-	docker build -t cabal-validate -f .docker/validate-old.dockerfile .
+	docker build $(DOCKERARGS) -t cabal-validate:older -f .docker/validate-old.dockerfile .
 
 # Weeder
 weeder :

--- a/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-repo.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-repo.out
@@ -1,12 +1,12 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v2-build
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
- - sigs-0.1.0.0 (lib) (requires download & build)
- - indef-0.1.0.0 (lib) (requires download & build)
- - indef-0.1.0.0 (lib with Data.Map=containers-<VERSION>:Data.Map) (requires download & build)
+ - sigs-0.1.0.0 (lib) (requires build)
+ - indef-0.1.0.0 (lib) (requires build)
+ - indef-0.1.0.0 (lib with Data.Map=containers-<VERSION>:Data.Map) (requires build)
  - exe-0.1.0.0 (exe:exe) (first run)
 Configuring library for sigs-0.1.0.0..
 Preprocessing library for sigs-0.1.0.0..

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/use-local-version-of-package.out
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackage/use-local-version-of-package.out
@@ -1,4 +1,4 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v2-build
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.out
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.out
@@ -1,11 +1,11 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v2-build
 Resolving dependencies...
 cabal: Could not resolve dependencies:
 [__0] trying: pkg-1.0 (user goal)
 [__1] next goal: setup-dep (user goal)
-[__1] rejecting: setup-dep-2.0 (conflict: pkg => setup-dep==1.*)
+[__1] rejecting: setup-dep-2.0 (conflict: pkg => setup-dep>=1 && <2)
 [__1] rejecting: setup-dep-1.0 (constraint from user target requires ==2.0)
 [__1] fail (backjumping, conflict set: pkg, setup-dep)
 After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: setup-dep (3), pkg (2)

--- a/cabal-testsuite/PackageTests/Freeze/disable-benchmarks.out
+++ b/cabal-testsuite/PackageTests/Freeze/disable-benchmarks.out
@@ -1,4 +1,4 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v1-freeze
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/Freeze/disable-tests.out
+++ b/cabal-testsuite/PackageTests/Freeze/disable-tests.out
@@ -1,4 +1,4 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v1-freeze
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/Freeze/dry-run.out
+++ b/cabal-testsuite/PackageTests/Freeze/dry-run.out
@@ -1,2 +1,2 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo

--- a/cabal-testsuite/PackageTests/Freeze/enable-benchmarks.out
+++ b/cabal-testsuite/PackageTests/Freeze/enable-benchmarks.out
@@ -1,4 +1,4 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v1-freeze
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/Freeze/enable-tests.out
+++ b/cabal-testsuite/PackageTests/Freeze/enable-tests.out
@@ -1,4 +1,4 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v1-freeze
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/Freeze/freeze.out
+++ b/cabal-testsuite/PackageTests/Freeze/freeze.out
@@ -1,4 +1,4 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v1-freeze
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/build-local-package-with-custom-setup.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/build-local-package-with-custom-setup.out
@@ -1,2 +1,2 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/build-package-from-repo-with-custom-setup.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/build-package-from-repo-with-custom-setup.out
@@ -1,4 +1,4 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # pkg my-exe
 pkg Main.hs: remote-pkg-2.0

--- a/cabal-testsuite/PackageTests/NewBuild/T4375/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/T4375/cabal.out
@@ -1,17 +1,7 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v2-build
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
- - old-locale-1.0.0.7 (lib) (requires download & build)
- - old-time-1.1.0.3 (lib) (requires download & build)
  - a-0.1 (lib:a) (first run)
-Configuring library for old-locale-1.0.0.7..
-Preprocessing library for old-locale-1.0.0.7..
-Building library for old-locale-1.0.0.7..
-Installing library in <PATH>
-Configuring library for old-time-1.1.0.3..
-Preprocessing library for old-time-1.1.0.3..
-Building library for old-time-1.1.0.3..
-Installing library in <PATH>

--- a/cabal-testsuite/PackageTests/NewFreeze/BuildTools/new_freeze.out
+++ b/cabal-testsuite/PackageTests/NewFreeze/BuildTools/new_freeze.out
@@ -1,12 +1,12 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v2-build
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following would be built:
- - my-build-tool-dep-1.0 (exe:my-build-tool) (requires download & build)
- - my-build-tool-dep-3.0 (exe:my-build-tool) (requires download & build)
- - my-library-dep-1.0 (lib) (requires download & build)
+ - my-build-tool-dep-1.0 (exe:my-build-tool) (requires build)
+ - my-build-tool-dep-3.0 (exe:my-build-tool) (requires build)
+ - my-library-dep-1.0 (lib) (requires build)
  - my-local-package-1.0 (lib) (first run)
 # cabal v2-freeze
 Resolving dependencies...
@@ -15,7 +15,7 @@ Wrote freeze file: <ROOT>/new_freeze.dist/source/cabal.project.freeze
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following would be built:
- - my-build-tool-dep-1.0 (exe:my-build-tool) (requires download & build)
- - my-build-tool-dep-2.0 (exe:my-build-tool) (requires download & build)
- - my-library-dep-1.0 (lib) (requires download & build)
+ - my-build-tool-dep-1.0 (exe:my-build-tool) (requires build)
+ - my-build-tool-dep-2.0 (exe:my-build-tool) (requires build)
+ - my-library-dep-1.0 (lib) (requires build)
  - my-local-package-1.0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/NewFreeze/Flags/new_freeze.out
+++ b/cabal-testsuite/PackageTests/NewFreeze/Flags/new_freeze.out
@@ -1,11 +1,11 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v2-build
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following would be built:
- - true-dep-1.0 (lib) (requires download & build)
- - my-library-dep-1.0 (lib) (requires download & build)
+ - true-dep-1.0 (lib) (requires build)
+ - my-library-dep-1.0 (lib) (requires build)
  - my-local-package-1.0 (lib) (first run)
 # cabal v2-freeze
 Resolving dependencies...
@@ -14,6 +14,6 @@ Wrote freeze file: <ROOT>/new_freeze.dist/source/cabal.project.freeze
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following would be built:
- - false-dep-1.0 (lib) (requires download & build)
- - my-library-dep-1.0 (lib) (requires download & build)
+ - false-dep-1.0 (lib) (requires build)
+ - my-library-dep-1.0 (lib) (requires build)
  - my-local-package-1.0 (lib) (first run)

--- a/cabal-testsuite/PackageTests/NewFreeze/FreezeFile/new_freeze.out
+++ b/cabal-testsuite/PackageTests/NewFreeze/FreezeFile/new_freeze.out
@@ -1,10 +1,10 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal v2-build
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following would be built:
- - my-library-dep-2.0 (lib) (requires download & build)
+ - my-library-dep-2.0 (lib) (requires build)
  - my-local-package-1.0 (exe:my-exe) (first run)
 # cabal v2-freeze
 Resolving dependencies...
@@ -13,7 +13,7 @@ Wrote freeze file: <ROOT>/new_freeze.dist/source/cabal.project.freeze
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
- - my-library-dep-1.0 (lib) (requires download & build)
+ - my-library-dep-1.0 (lib) (requires build)
  - my-local-package-1.0 (exe:my-exe) (first run)
 Configuring library for my-library-dep-1.0..
 Preprocessing library for my-library-dep-1.0..
@@ -28,7 +28,7 @@ Wrote freeze file: <ROOT>/new_freeze.dist/source/cabal.project.freeze
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following would be built:
- - my-library-dep-2.0 (lib) (requires download & build)
+ - my-library-dep-2.0 (lib) (requires build)
  - my-local-package-1.0 (exe:my-exe) (configuration changed)
 # cabal v2-freeze
 Wrote freeze file: <ROOT>/new_freeze.dist/source/cabal.project.freeze

--- a/cabal-testsuite/PackageTests/Outdated/outdated-project-file.out
+++ b/cabal-testsuite/PackageTests/Outdated/outdated-project-file.out
@@ -1,4 +1,4 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal outdated
 Outdated dependencies:

--- a/cabal-testsuite/PackageTests/Outdated/outdated.out
+++ b/cabal-testsuite/PackageTests/Outdated/outdated.out
@@ -1,8 +1,8 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal outdated
 Outdated dependencies:
-base ==3.* (latest: 4.0.0.0)
+base >=3 && <4 (latest: 4.0.0.0)
 template-haskell >=2.3.0.0 && <2.4 (latest: 2.4.0.0)
 # cabal outdated
 Outdated dependencies:

--- a/cabal-testsuite/PackageTests/Outdated/outdated_freeze.out
+++ b/cabal-testsuite/PackageTests/Outdated/outdated_freeze.out
@@ -1,4 +1,4 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # cabal outdated
 Outdated dependencies:

--- a/cabal-testsuite/PackageTests/Regression/T3932/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T3932/cabal.out
@@ -1,2 +1,2 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo

--- a/cabal-testsuite/PackageTests/Regression/T5409/use-different-versions-of-dependency-for-library-and-build-tool.out
+++ b/cabal-testsuite/PackageTests/Regression/T5409/use-different-versions-of-dependency-for-library-and-build-tool.out
@@ -1,4 +1,4 @@
-# cabal v1-update
+# cabal v2-update
 Downloading the latest package list from test-local-repo
 # pkg my-exe
 build-tool library version: 1,

--- a/cabal-testsuite/PackageTests/Regression/T5409/use-different-versions-of-dependency-for-library-and-build-tool.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5409/use-different-versions-of-dependency-for-library-and-build-tool.test.hs
@@ -16,11 +16,15 @@ main = withShorterPathForNewBuildStore $ \storeDir ->
     withRepo "repo" $ do
       r1 <- recordMode DoNotRecord $
             cabalG' ["--store-dir=" ++ storeDir] "v2-build" ["pkg:my-exe"]
-      let msg = "In order, the following will be built:"
-             ++ "  - build-tool-pkg-1 (lib) (requires download & build)"
-             ++ "  - build-tool-pkg-2 (lib) (requires download & build)"  -- dependency of build-tool-exe
-             ++ "  - build-tool-pkg-2 (exe:build-tool-exe) (requires download & build)"
-             ++ "  - pkg-1.0 (exe:my-exe) (first run)"
+
+      let msg = concat
+              [ "In order, the following will be built:"
+              , "  - build-tool-pkg-1 (lib) (requires build)"
+              , "  - build-tool-pkg-2 (lib) (requires build)"
+              , "  - build-tool-pkg-2 (exe:build-tool-exe) (requires build)"
+              , "  - pkg-1.0 (exe:my-exe) (first run)"
+              ]
+
       assertOutputContains msg r1
       withPlan $ do
         r2 <- runPlanExe' "pkg" "my-exe" []

--- a/cabal-testsuite/main/cabal-tests.hs
+++ b/cabal-testsuite/main/cabal-tests.hs
@@ -251,8 +251,6 @@ main = do
 
             -- print skipped
             logAll $ "SKIPPED " ++ show (length skipped) ++ " tests"
-            unless (null skipped) $ logAll $
-                "SKIPPED: " ++ intercalate " " skipped
 
             -- print failed or ook
             if null (unexpected_fails ++ unexpected_passes)

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -778,7 +778,7 @@ skipIfWindows = skipIf "Windows" =<< isWindows
 skipUnlessGhcVersion :: String -> TestM ()
 skipUnlessGhcVersion str =
     case eitherParsec str of
-        Right vr -> skipUnless ("ghc" ++ prettyShow vr) =<< ghcVersionIs (`withinRange` vr)
+        Right vr -> skipUnless ("needs ghc" ++ prettyShow vr) =<< ghcVersionIs (`withinRange` vr)
         Left err -> fail err
 
 getOpenFilesLimit :: TestM (Maybe Integer)

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -494,59 +494,44 @@ infixr 4 `archiveTo`
 -- external repository corresponding to all of these packages
 withRepo :: FilePath -> TestM a -> TestM a
 withRepo repo_dir m = do
+    -- https://github.com/haskell/cabal/issues/7065
+    -- you don't simply put a windows path into URL...
+    skipIfWindows
+
     env <- getTestEnv
 
-    -- Check if hackage-repo-tool is available, and skip if not
-    skipUnless "no hackage-repo-tool program" =<< isAvailableProgram hackageRepoToolProgram
-
-    -- 1. Generate keys
-    hackageRepoTool "create-keys" ["--keys", testKeysDir env]
-    -- 2. Initialize repo directory
-    let package_dir = testRepoDir env </> "package"
-    liftIO $ createDirectoryIfMissing True (testRepoDir env </> "index")
+    -- 1. Initialize repo directory
+    let package_dir = testRepoDir env
     liftIO $ createDirectoryIfMissing True package_dir
-    -- 3. Create tarballs
+
+    -- 2. Create tarballs
     pkgs <- liftIO $ getDirectoryContents (testCurrentDir env </> repo_dir)
     forM_ pkgs $ \pkg -> do
         case pkg of
             '.':_ -> return ()
-            _     -> testCurrentDir env </> repo_dir </> pkg
-                        `archiveTo`
-                            package_dir </> pkg <.> "tar.gz"
-    -- 4. Initialize repository
-    hackageRepoTool "bootstrap" ["--keys", testKeysDir env, "--repo", testRepoDir env]
-    -- 5. Wire it up in .cabal/config
+            _     -> archiveTo
+                (testCurrentDir env </> repo_dir </> pkg)
+                (package_dir </> pkg <.> "tar.gz")
+
+    -- 3. Wire it up in .cabal/config
     -- TODO: libify this
     let package_cache = testCabalDir env </> "packages"
     liftIO $ appendFile (testUserCabalConfigFile env)
            $ unlines [ "repository test-local-repo"
                      , "  url: " ++ repoUri env
-                     , "  secure: True"
-                     -- TODO: Hypothetically, we could stick in the
-                     -- correct key here
-                     , "  root-keys: "
-                     , "  key-threshold: 0"
                      , "remote-repo-cache: " ++ package_cache ]
-    -- 6. Create local directories (TODO: this is a bug #4136, once you
-    -- fix that this can be removed)
-    liftIO $ createDirectoryIfMissing True (package_cache </> "test-local-repo")
-    -- 7. Update our local index
-    cabal "v1-update" []
-    -- 8. Profit
+    liftIO $ print $ testUserCabalConfigFile env
+    liftIO $ print =<< readFile (testUserCabalConfigFile env)
+
+    -- 4. Update our local index
+    -- Note: this doesn't do anything for file+noindex repositories.
+    cabal "v2-update" ["-z"]
+
+    -- 5. Profit
     withReaderT (\env' -> env' { testHaveRepo = True }) m
     -- TODO: Arguably should undo everything when we're done...
   where
-    -- Work around issue #5218 (incorrect conversions between Windows paths and
-    -- file URIs) by using a relative path on Windows.
-    repoUri env =
-      if buildOS == Windows
-      then let relPath = definitelyMakeRelative (testCurrentDir env)
-                                                (testRepoDir env)
-               convertSeparators = intercalate "/"
-                                 . map dropTrailingPathSeparator
-                                 . splitPath
-           in "file:" ++ convertSeparators relPath
-      else "file:" ++ testRepoDir env
+    repoUri env ="file+noindex://" ++ testRepoDir env
 
 ------------------------------------------------------------------------
 -- * Subprocess run results


### PR DESCRIPTION
only 3 skipped on recent GHCs with `make validate-via-docker-8.6.5`