### PR TITLE
Pass -optcxx for GHC >= 8.10

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -686,7 +686,11 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
   , concat [ [ "-optP-include", "-optP" ++ inc]
            | inc <- flags ghcOptCppIncludes ]
   , [ "-optc" ++ opt | opt <- ghcOptCcOptions opts]
-  , [ "-optc" ++ opt | opt <- ghcOptCxxOptions opts]
+  , -- C++ compiler options: GHC >= 8.10 requires -optcxx, older requires -optc
+    let cxxflag = case compilerCompatVersion GHC comp of
+                Just v | v >= mkVersion [8, 10] -> "-optcxx"
+                _ -> "-optc"
+    in [ cxxflag ++ opt | opt <- ghcOptCxxOptions opts]
   , [ "-opta" ++ opt | opt <- ghcOptAsmOptions opts]
 
   -----------------

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsC/Main.hs
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsC/Main.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Main where
+
+import Foreign.C (CInt (..))
+
+foreign import ccall "clib.h meaning_of_life_c"
+  meaning_of_life_c :: IO CInt
+
+main :: IO ()
+main = do
+    secret <- meaning_of_life_c
+    -- The value 11 comes from __TESTOPT_C__ - see the cabal file.
+    if (secret == 11)
+        then putStrLn ("The secret is " ++ show secret)
+        else error ("Expected value 11, got " ++ show secret)

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsC/README.md
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsC/README.md
@@ -1,0 +1,5 @@
+# ForeignOptsC
+
+This test case asserts that cabal passes `cc-options` to the C compiler (and NOT `cxx-options`).
+
+See the additional case `ForeignOptsCxx`.

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsC/cabal.out
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsC/cabal.out
@@ -1,0 +1,10 @@
+# cabal v2-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - foreign-opts-c-0.1 (exe:foreign-opts-c-exe) (first run)
+Configuring executable 'foreign-opts-c-exe' for foreign-opts-c-0.1..
+Preprocessing executable 'foreign-opts-c-exe' for foreign-opts-c-0.1..
+Building executable 'foreign-opts-c-exe' for foreign-opts-c-0.1..
+# foreign-opts-c foreign-opts-c-exe
+The secret is 11

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsC/cabal.project
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsC/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsC/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsC/cabal.test.hs
@@ -1,0 +1,4 @@
+import Test.Cabal.Prelude
+main = cabalTest $ do
+    cabal "v2-build" ["foreign-opts-c-exe"]
+    withPlan $ runPlanExe "foreign-opts-c" "foreign-opts-c-exe" []

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsC/cbits/clib.c
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsC/cbits/clib.c
@@ -1,0 +1,13 @@
+#include "clib.h"
+
+#ifndef __TESTOPT_C__
+#error "Did not get required __TESTOPT_C__ from cc-options"
+#endif
+
+#ifdef __TESTOPT_CXX__
+#error "Got unexpected __TESTOPT_CXX__ from cxx-options"
+#endif
+
+int meaning_of_life_c() {
+    return __TESTOPT_C__;
+}

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsC/cbits/clib.h
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsC/cbits/clib.h
@@ -1,0 +1,6 @@
+#ifndef CLIB_H
+#define CLIB_H
+
+int meaning_of_life_c();
+
+#endif

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsC/foreign-opts-c.cabal
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsC/foreign-opts-c.cabal
@@ -1,0 +1,14 @@
+cabal-version:       2.2
+name:                foreign-opts-c
+version:             0.1
+build-type:          Simple
+
+executable foreign-opts-c-exe
+  main-is:             Main.hs
+  build-depends:       base
+  default-language:    Haskell2010
+  include-dirs:        cbits
+  c-sources:           cbits/clib.c
+  -- The following options are shared in all ForeignOpts cases:
+  cc-options:          -D__TESTOPT_C__=11
+  cxx-options:         -D__TESTOPT_CXX__=22

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/Main.hs
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/Main.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Main where
+
+import Foreign.C (CInt (..))
+
+foreign import ccall "cxxlib.h meaning_of_life_cxx"
+  meaning_of_life_cxx :: IO CInt
+
+main :: IO ()
+main = do
+    secret <- meaning_of_life_cxx
+    -- The value 22 comes from __TESTOPT_CXX__ - see the cabal file.
+    if (secret == 22)
+        then putStrLn ("The secret is " ++ show secret)
+        else error ("Expected value 22, got " ++ show secret)

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/README.md
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/README.md
@@ -1,0 +1,7 @@
+# ForeignOptsCxx
+
+This asserts that cabal passes `cxx-options` to the C++ compiler (and NOT `cc-options`).
+
+Since GHC 8.10, they are passed through GHC with `-optcxx`. Before that, they were passed with `-optc`.
+
+See the additional case `ForeignOptsC`.

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/cabal.out
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/cabal.out
@@ -1,0 +1,10 @@
+# cabal v2-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - foreign-opts-cxx-0.1 (exe:foreign-opts-cxx-exe) (first run)
+Configuring executable 'foreign-opts-cxx-exe' for foreign-opts-cxx-0.1..
+Preprocessing executable 'foreign-opts-cxx-exe' for foreign-opts-cxx-0.1..
+Building executable 'foreign-opts-cxx-exe' for foreign-opts-cxx-0.1..
+# foreign-opts-cxx foreign-opts-cxx-exe
+The secret is 22

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/cabal.project
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/cabal.test.hs
@@ -1,0 +1,4 @@
+import Test.Cabal.Prelude
+main = cabalTest $ do
+    cabal "v2-build" ["foreign-opts-cxx-exe"]
+    withPlan $ runPlanExe "foreign-opts-cxx" "foreign-opts-cxx-exe" []

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/cxxbits/cxxlib.cpp
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/cxxbits/cxxlib.cpp
@@ -1,0 +1,13 @@
+#include "cxxlib.h"
+
+#ifdef __TESTOPT_C__
+#error "Got unexpected __TESTOPT_C__ from cc-options"
+#endif
+
+#ifndef __TESTOPT_CXX__
+#error "Did not get required __TESTOPT_CXX__ from cxx-options"
+#endif
+
+int meaning_of_life_cxx() {
+    return __TESTOPT_CXX__;
+}

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/cxxbits/cxxlib.h
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/cxxbits/cxxlib.h
@@ -1,0 +1,12 @@
+#ifndef CXXLIB_H
+#define CXXLIB_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int meaning_of_life_cxx();
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/foreign-opts-cxx.cabal
+++ b/cabal-testsuite/PackageTests/FFI/ForeignOptsCxx/foreign-opts-cxx.cabal
@@ -1,0 +1,15 @@
+cabal-version:       2.2
+name:                foreign-opts-cxx
+version:             0.1
+build-type:          Simple
+
+executable foreign-opts-cxx-exe
+  main-is:             Main.hs
+  build-depends:       base
+  default-language:    Haskell2010
+  include-dirs:        cxxbits
+  extra-libraries:     stdc++
+  cxx-sources:         cxxbits/cxxlib.cpp
+  -- The following options are shared in all ForeignOpts cases:
+  cc-options:          -D__TESTOPT_C__=11
+  cxx-options:         -D__TESTOPT_CXX__=22


### PR DESCRIPTION
Intends to resolve [this issue](https://github.com/haskell/cabal/issues/6421). To summarize, cabal passes all C and C++ flags through GHC to the underlying C or C++ compiler using `-optc`. This works for GHC < 8.10, but now GHC expects C++ flags to come through `-optcxx`. This means that anything through `-optc` is ignored, so we cannot pass any flags to the C++ compiler. This change simply detects the GHC version and uses the correct arguments.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

This PR has been tested manually on this [repro](https://github.com/ejconlon/ffi-repro) and two `PackageTests` have been added to `cabal-testsuite`. They pass under GHC 8.8.4 and GHC 8.10.2.