### PR TITLE
Disable RPath usage on macOS

### DIFF
--- a/changelog.d/no-pass-rpath-on-macos
+++ b/changelog.d/no-pass-rpath-on-macos
@@ -1,0 +1,3 @@
+synopsis: Do not pass -rpath to GHC, but let GHC figure it out on its own.
+prs: 7076
+description: To reduce Load Command Sizes for dynamic libraries/executables together with https://gitlab.haskell.org/ghc/ghc/-/commit/4ff93292243888545da452ea4d4c1987f2343591


### PR DESCRIPTION
This interferes with dead_strip_dylib, and pollutes the load commands,
which have a size limit in recent macOS versions.  We now rely on GHC
to construct the correct -rpath entries *after* the linking phase by
inspecting the produced dynamic product and adding -rpaths for all
non-dead-stripped referenced libraries.

See https://gitlab.haskell.org/ghc/ghc/-/commit/4ff93292243888545da452ea4d4c1987f2343591
or  ghc/ghc@4ff9329

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
