### PR TITLE
Slightly more information on multiple package error

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -551,8 +551,9 @@ resolveTargets selectPackageTargets selectComponentTarget
       | otherwise
       = Left (TargetProblemNoSuchPackage pkgid)
 
-    checkTarget (TargetPackage _ _ _)
-      = error "TODO: add support for multiple packages in a directory"
+    checkTarget (TargetPackage _ pkgids _)
+      = error ("TODO: add support for multiple packages in a directory.  Got\n"
+              ++ unlines (map prettyShow pkgids))
       -- For the moment this error cannot happen here, because it gets
       -- detected when the package config is being constructed. This case
       -- will need handling properly when we do add support.


### PR DESCRIPTION
This PR provides slightly more information when a [project contains duplicates in 'packages' declaration](https://github.com/haskell/cabal/issues/6197). Hopefully this is a useful stopgap before a better way of presenting the error message is found.

Before:

```
$ cabal v2-build
Resolving dependencies...
TODO: add support for multiple packages in a directory
CallStack (from HasCallStack):
  error, called at ./Distribution/Client/ProjectOrchestration.hs:548:9 in main:Distribution.Client.ProjectOrchestration
```

After:

```
$ cabal v2-build
Warning: Parsing the index cache failed (Data.Binary.Get.runGet at position
16: Non-matching structured hashes: a257ca064dfb5e0cb74f74e64a975b9e;
expected: f46da61e7afa58a5e8fd1d2b6fb79899). Trying to regenerate the index
cache...
Resolving dependencies...
TODO: add support for multiple packages in a directory.  Got
PackageIdentifier {pkgName = PackageName "opaleye", pkgVersion = mkVersion [0,7,1,0]}
PackageIdentifier {pkgName = PackageName "opaleye", pkgVersion = mkVersion [0,7,1,0]}

CallStack (from HasCallStack):
  error, called at src/Distribution/Client/ProjectOrchestration.hs:555:9 in main:Distribution.Client.ProjectOrchestration
```