### PR TITLE
Propagate provenance when parsing ProjectConfig

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -572,7 +572,7 @@ readProjectFile verbosity DistDirLayout{distProjectFile}
 
     readExtensionFile =
           reportParseResult verbosity extensionDescription extensionFile
-        . parseProjectConfig
+        . (parseProjectConfig extensionFile)
       =<< BS.readFile extensionFile
 
     addProjectFileProvenance config =
@@ -587,10 +587,10 @@ readProjectFile verbosity DistDirLayout{distProjectFile}
 -- For the moment this is implemented in terms of parsers for legacy
 -- configuration types, plus a conversion.
 --
-parseProjectConfig :: BS.ByteString -> OldParser.ParseResult ProjectConfig
-parseProjectConfig content =
+parseProjectConfig :: FilePath -> BS.ByteString -> OldParser.ParseResult ProjectConfig
+parseProjectConfig source content =
     convertLegacyProjectConfig <$>
-      parseLegacyProjectConfig content
+      (parseLegacyProjectConfig source content)
 
 
 -- | Render the 'ProjectConfig' format.

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -158,7 +158,7 @@ prop_roundtrip_legacytypes_specific config =
 
 roundtrip_printparse :: ProjectConfig -> Property
 roundtrip_printparse config =
-    case fmap convertLegacyProjectConfig (parseLegacyProjectConfig (toUTF8BS str)) of
+    case fmap convertLegacyProjectConfig (parseLegacyProjectConfig "unused" (toUTF8BS str)) of
       ParseOk _ x     -> counterexample ("shown:\n" ++ str) $
           x `ediffEq` config { projectConfigProvenance = mempty }
       ParseFailed err -> counterexample ("shown:\n" ++ str ++ "\nERROR: " ++ show err) False
@@ -275,7 +275,7 @@ prop_roundtrip_printparse_RelaxDeps rdep =
 prop_roundtrip_printparse_RelaxDeps' :: RelaxDeps -> Property
 prop_roundtrip_printparse_RelaxDeps' rdep =
     counterexample rdep' $
-    Right rdep `ediffEq` eitherParsec rdep' 
+    Right rdep `ediffEq` eitherParsec rdep'
   where
     rdep' = go (prettyShow rdep)
 
@@ -522,7 +522,7 @@ instance Arbitrary ProjectConfigShared where
 
 projectConfigConstraintSource :: ConstraintSource
 projectConfigConstraintSource =
-    ConstraintSourceProjectConfig "TODO"
+    ConstraintSourceProjectConfig "unused"
 
 instance Arbitrary ProjectConfigProvenance where
     arbitrary = elements [Implicit, Explicit "cabal.project"]


### PR DESCRIPTION
In a project with lots of constraints it's not always obvious from which file a constraint is coming from. Also we are currently showing a big `TODO` message in place of the file name which is not nice.

It's not super great that we pass a dummy ConstraintSource to showProjectConfig but I would say it's not worse than before. 

Prior to this patch

```
$ cabal build all
Resolving dependencies...
cabal: Could not resolve dependencies:
[__0] trying: some-package-0.24.1.2 (user goal)
[__1] trying: foldl-1.4.8 (dependency of some-package)
[__2] next goal: mwc-random (dependency of foldl)
[__2] rejecting: mwc-random-0.15.0.0 (constraint from project config TODO
requires ==0.14.0.0)
[__2] trying: mwc-random-0.14.0.0
[__3] next goal: math-functions (dependency of mwc-random)
[__3] rejecting: math-functions-0.3.4.0, math-functions-0.3.3.0,
math-functions-0.3.2.1, math-functions-0.3.2.0, math-functions-0.3.1.0,
math-functions-0.3.0.2, math-functions-0.3.0.1, math-functions-0.3.0.0,
math-functions-0.2.1.0, math-functions-0.2.0.2, math-functions-0.2.0.1,
math-functions-0.2.0.0, math-functions-0.1.7.0, math-functions-0.1.6.0,
math-functions-0.1.5.2, math-functions-0.1.5.1, math-functions-0.1.4.0,
math-functions-0.1.3.0, math-functions-0.1.1.2, math-functions-0.1.1.1,
math-functions-0.1.1.0, math-functions-0.1.0.0 (constraint from project config
TODO requires ==0.3.4.1)
[__3] fail (backjumping, conflict set: math-functions, mwc-random)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: mwc-random, math-functions, foldl,
some-package
Try running with --minimize-conflict-set to improve the error message.
```

Note the TODO. No idea where th constraint is coming from :(

With this patch applied:

```
Resolving dependencies...
cabal: Could not resolve dependencies:
[__0] trying: some-package-0.24.1.2 (user goal)
[__1] trying: foldl-1.4.8 (dependency of some-packagge)
[__2] next goal: mwc-random (dependency of foldl)
[__2] rejecting: mwc-random-0.15.0.0 (constraint from project config
/Users/a602232/git/haskell-libs/cabal.project.freeze requires ==0.14.0.0)
[__2] trying: mwc-random-0.14.0.0
[__3] next goal: math-functions (dependency of mwc-random)
[__3] rejecting: math-functions-0.3.4.0, math-functions-0.3.3.0,
math-functions-0.3.2.1, math-functions-0.3.2.0, math-functions-0.3.1.0,
math-functions-0.3.0.2, math-functions-0.3.0.1, math-functions-0.3.0.0,
math-functions-0.2.1.0, math-functions-0.2.0.2, math-functions-0.2.0.1,
math-functions-0.2.0.0, math-functions-0.1.7.0, math-functions-0.1.6.0,
math-functions-0.1.5.2, math-functions-0.1.5.1, math-functions-0.1.4.0,
math-functions-0.1.3.0, math-functions-0.1.1.2, math-functions-0.1.1.1,
math-functions-0.1.1.0, math-functions-0.1.0.0 (constraint from project config
/Users/a602232/git/haskell-libs/cabal.project.freeze requires ==0.3.4.1)
[__3] fail (backjumping, conflict set: math-functions, mwc-random)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: mwc-random, math-functions, foldl,
some-package
Try running with --minimize-conflict-set to improve the error message.
```

Note that we now explicitly say where the constraint is coming from!


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
