### PR TITLE
Bump Win32 bound to <2.11

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -325,7 +325,7 @@ library
     build-depends: binary >= 0.7 && < 0.9
 
   if os(windows)
-    build-depends: Win32 >= 2.3.0.0 && < 2.10
+    build-depends: Win32 >= 2.3.0.0 && < 2.11
   else
     build-depends: unix  >= 2.6.0.0 && < 2.8
 


### PR DESCRIPTION
Cabal is unaffected by the renamings done in 2.10.0.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
