### PR TITLE
Fix command notes being replaced by descriptions

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdLegacy.hs
+++ b/cabal-install/src/Distribution/Client/CmdLegacy.hs
@@ -138,7 +138,7 @@ newCmd origUi@CommandUI{..} action = [cmd defaultUi, cmd newUi, cmd origUi]
             { commandName = newMsg commandName
             , commandUsage = newMsg . commandUsage
             , commandDescription = (newMsg .) <$> commandDescription
-            , commandNotes = (newMsg .) <$> commandDescription
+            , commandNotes = (newMsg .) <$> commandNotes
             }
 
         defaultMsg = T.unpack . T.replace "v2-" "" . T.pack
@@ -146,5 +146,5 @@ newCmd origUi@CommandUI{..} action = [cmd defaultUi, cmd newUi, cmd origUi]
             { commandName = defaultMsg commandName
             , commandUsage = defaultMsg . commandUsage
             , commandDescription = (defaultMsg .) <$> commandDescription
-            , commandNotes = (defaultMsg .) <$> commandDescription
+            , commandNotes = (defaultMsg .) <$> commandNotes
             }


### PR DESCRIPTION
This was causing the description of "new" prefixed and unprefixed
commands to be printed at both the top and bottom of their help text.
