### PR TITLE
Issue #6772 library creates exe

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Command.hs
@@ -468,20 +468,16 @@ getGenComments flags = do
 getAppDir :: InitFlags -> IO InitFlags
 getAppDir flags = do
   appDirs <-
-    return (applicationDirs flags)
-    ?>> noAppDirIfLibraryOnly
-    ?>> guessAppDir flags
-    ?>> promptUserForApplicationDir
-    ?>> setDefault
+    if (packageType flags) == Flag Library
+    then return (Just [])
+    else return (applicationDirs flags)
+      ?>> guessAppDir flags
+      ?>> promptUserForApplicationDir
+      ?>> setDefault
+
   return $ flags { applicationDirs = appDirs }
 
   where
-    -- If the packageType==Library, then there is no application dir.
-    noAppDirIfLibraryOnly :: IO (Maybe [String])
-    noAppDirIfLibraryOnly =
-      if (packageType flags) == Flag Library
-      then return (Just [])
-      else return Nothing
 
     -- Set the default application directory.
     setDefault :: IO (Maybe [String])

--- a/cabal-install/src/Distribution/Client/Init/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Command.hs
@@ -469,11 +469,11 @@ getAppDir :: InitFlags -> IO InitFlags
 getAppDir flags = do
   appDirs <-
     if (packageType flags) == Flag Library
-    then return (Just [])
-    else return (applicationDirs flags)
-      ?>> guessAppDir flags
-      ?>> promptUserForApplicationDir
-      ?>> setDefault
+        then return (Just [])
+        else return (applicationDirs flags)
+          ?>> guessAppDir flags
+          ?>> promptUserForApplicationDir
+          ?>> setDefault
 
   return $ flags { applicationDirs = appDirs }
 


### PR DESCRIPTION
This fixes init adding an exe folder if the package type is Library. This is for issue #6772 .

I added an if statement for checking if the PackageType is Library. We can just return Just [] to appDir, and skip other evaluation. I also removed noAppDirIfLibrary as its functionality is now covered by the new if statement.

It's also possible to create a lib directory when source-dir specified after selecting exe package type.

`$ mkdir foo`
`$ cd foo`
`$ cabal init --non-interactive --exe --source-dir=lib`
`$ ls`
`CHANGELOG.md  Main.hs   Setup.hs  lib  test.cabal`

Should I work on that or raise a seperate issue?

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.


Let me know what you think!

