### PR TITLE
Prohibit empty file paths.

### DIFF
--- a/Cabal/src/Distribution/FieldGrammar/Newtypes.hs
+++ b/Cabal/src/Distribution/FieldGrammar/Newtypes.hs
@@ -250,7 +250,11 @@ newtype FilePathNT = FilePathNT { getFilePathNT :: String }
 instance Newtype String FilePathNT
 
 instance Parsec FilePathNT where
-    parsec = pack <$> parsecToken
+    parsec = do
+        token <- parsecToken
+        if null token
+        then P.unexpected "empty FilePath"
+        else return (FilePathNT token)
 
 instance Pretty FilePathNT where
     pretty = showFilePath . unpack

--- a/Cabal/src/Distribution/PackageDescription/Quirks.hs
+++ b/Cabal/src/Distribution/PackageDescription/Quirks.hs
@@ -268,6 +268,17 @@ patches = Map.fromList
          (Fingerprint 17812331267506881875 3005293725141563863)
          (Fingerprint 3445957263137759540 12472369104312474458)
          (bsReplace "cabal-version:  2" "cabal-version: 2.0")
+
+    -- Empty filepath in not license-file or data-dir
+    -- These have hs-source-dirs: ""
+    , mk "\nname:                wai-middleware-hmac-client\nversion:             0.1.0.1\nlicense:             BSD3\nlicense-file:        LICENSE\nauthor:              Christopher Reichert\nmaintainer:          creichert07@gmail.com\ncopyright:           (c) 2015, Christo"
+         (Fingerprint 3112606538775065787 11984607507024462091)
+         (Fingerprint 6916432989977230500 6621389616675138128)
+         (bsReplace "\"\"" ".")
+    , mk "\nname:                wai-middleware-hmac-client\nversion:             0.1.0.2\nlicense:             BSD3\nlicense-file:        LICENSE\nauthor:              Christopher Reichert\nmaintainer:          creichert07@gmail.com\ncopyright:           (c) 2015, Christo"
+         (Fingerprint 12566783342663020458 17562089389615949789)
+         (Fingerprint 15745683452603944938 10556498036622072844)
+         (bsReplace "\"\"" ".")
     ]
   where
     mk a b c d = ((a, b), (c, d))

--- a/Cabal/src/Distribution/Parsec/Warning.hs
+++ b/Cabal/src/Distribution/Parsec/Warning.hs
@@ -41,6 +41,8 @@ data PWarnType
 
     | PWTSpecVersion           -- ^ Warnings about cabal-version format.
 
+    | PWTEmptyFilePath         -- ^ Empty filepath, i.e. literally ""
+
     | PWTExperimental          -- ^ Experimental feature
     deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 

--- a/Cabal/src/Distribution/Types/PackageDescription.hs
+++ b/Cabal/src/Distribution/Types/PackageDescription.hs
@@ -222,7 +222,7 @@ emptyPackageDescription
                       testSuites   = [],
                       benchmarks   = [],
                       dataFiles    = [],
-                      dataDir      = "",
+                      dataDir      = ".",
                       extraSrcFiles = [],
                       extraTmpFiles = [],
                       extraDocFiles = []

--- a/Cabal/tests/ParserTests/regressions/Octree-0.5.expr
+++ b/Cabal/tests/ParserTests/regressions/Octree-0.5.expr
@@ -323,7 +323,7 @@ GenericPackageDescription
                            category = "Data",
                            copyright = "Copyright by Michal J. Gajda '2012",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "Octree data structure is relatively shallow data structure for space partitioning.",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/anynone.expr
+++ b/Cabal/tests/ParserTests/regressions/anynone.expr
@@ -79,7 +79,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/big-version.expr
+++ b/Cabal/tests/ParserTests/regressions/big-version.expr
@@ -70,7 +70,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/common-conditional.expr
+++ b/Cabal/tests/ParserTests/regressions/common-conditional.expr
@@ -656,7 +656,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/common.expr
+++ b/Cabal/tests/ParserTests/regressions/common.expr
@@ -145,7 +145,7 @@ GenericPackageDescription
                            copyright = "",
                            customFieldsPD = [_×_ "x-revision" "1",
                                              _×_ "x-follows-version-policy" ""],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/common2.expr
+++ b/Cabal/tests/ParserTests/regressions/common2.expr
@@ -682,7 +682,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/common3.expr
+++ b/Cabal/tests/ParserTests/regressions/common3.expr
@@ -175,7 +175,7 @@ GenericPackageDescription
                            copyright = "",
                            customFieldsPD = [_×_ "x-revision" "1",
                                              _×_ "x-follows-version-policy" ""],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/elif.expr
+++ b/Cabal/tests/ParserTests/regressions/elif.expr
@@ -147,7 +147,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/elif2.expr
+++ b/Cabal/tests/ParserTests/regressions/elif2.expr
@@ -350,7 +350,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/encoding-0.8.expr
+++ b/Cabal/tests/ParserTests/regressions/encoding-0.8.expr
@@ -91,7 +91,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/generics-sop.expr
+++ b/Cabal/tests/ParserTests/regressions/generics-sop.expr
@@ -708,7 +708,7 @@ GenericPackageDescription
                            category = "Generics",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = concat
                                            ["A library to support the definition of generic functions.\n",

--- a/Cabal/tests/ParserTests/regressions/hasktorch.expr
+++ b/Cabal/tests/ParserTests/regressions/hasktorch.expr
@@ -9799,7 +9799,7 @@ GenericPackageDescription
                            category = "Tensors, Machine Learning, AI",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "Hasktorch is a library for tensors and neural networks in Haskell. It is an independent open source community project which leverages the core C libraries shared by Torch and PyTorch. This library leverages @cabal v2-build@ and @backpack@. *Note that this project is in early development and should only be used by contributing developers. Expect substantial changes to the library API as it evolves. Contributions and PRs are welcome (see details on github).*",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/hidden-main-lib.expr
+++ b/Cabal/tests/ParserTests/regressions/hidden-main-lib.expr
@@ -79,7 +79,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/indentation.expr
+++ b/Cabal/tests/ParserTests/regressions/indentation.expr
@@ -70,7 +70,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = concat
                                            ["* foo\n",

--- a/Cabal/tests/ParserTests/regressions/indentation2.expr
+++ b/Cabal/tests/ParserTests/regressions/indentation2.expr
@@ -70,7 +70,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = concat ["foo\n", "  indent2\n", "    indent4"],
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/indentation3.expr
+++ b/Cabal/tests/ParserTests/regressions/indentation3.expr
@@ -70,7 +70,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = concat
                                            ["indent0\n",

--- a/Cabal/tests/ParserTests/regressions/issue-5055.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-5055.expr
@@ -222,7 +222,7 @@ GenericPackageDescription
                            category = "Test",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "no type in all branches.",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/issue-5846.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-5846.expr
@@ -144,7 +144,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/issue-6083-a.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-6083-a.expr
@@ -310,7 +310,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/issue-6083-b.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-6083-b.expr
@@ -317,7 +317,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/issue-6083-c.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-6083-c.expr
@@ -156,7 +156,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/issue-6083-pkg-pkg.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-6083-pkg-pkg.expr
@@ -90,7 +90,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/issue-774.expr
+++ b/Cabal/tests/ParserTests/regressions/issue-774.expr
@@ -75,7 +75,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = concat
                                            ["Here is some C code:\n",

--- a/Cabal/tests/ParserTests/regressions/jaeger-flamegraph.expr
+++ b/Cabal/tests/ParserTests/regressions/jaeger-flamegraph.expr
@@ -422,7 +422,7 @@ GenericPackageDescription
                            category = "Testing",
                            copyright = "(c) 2018 Symbiont.io",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = concat
                                            ["This is a small tool to convert JSON dumps obtained from a Jaeger\n",

--- a/Cabal/tests/ParserTests/regressions/leading-comma-2.expr
+++ b/Cabal/tests/ParserTests/regressions/leading-comma-2.expr
@@ -141,7 +141,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/leading-comma.expr
+++ b/Cabal/tests/ParserTests/regressions/leading-comma.expr
@@ -134,7 +134,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/libpq1.expr
+++ b/Cabal/tests/ParserTests/regressions/libpq1.expr
@@ -636,7 +636,7 @@ GenericPackageDescription
                            copyright = concat
                                          ["(c) 2010 Grant Monroe\n", "(c) 2011 Leon P Smith"],
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = concat
                                            ["This is a binding to libpq: the C application\n",

--- a/Cabal/tests/ParserTests/regressions/libpq2.expr
+++ b/Cabal/tests/ParserTests/regressions/libpq2.expr
@@ -636,7 +636,7 @@ GenericPackageDescription
                            copyright = concat
                                          ["(c) 2010 Grant Monroe\n", "(c) 2011 Leon P Smith"],
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = concat
                                            ["This is a binding to libpq: the C application\n",

--- a/Cabal/tests/ParserTests/regressions/mixin-1.expr
+++ b/Cabal/tests/ParserTests/regressions/mixin-1.expr
@@ -122,7 +122,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/mixin-2.expr
+++ b/Cabal/tests/ParserTests/regressions/mixin-2.expr
@@ -122,7 +122,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/mixin-3.expr
+++ b/Cabal/tests/ParserTests/regressions/mixin-3.expr
@@ -107,7 +107,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/monad-param.expr
+++ b/Cabal/tests/ParserTests/regressions/monad-param.expr
@@ -116,7 +116,7 @@ GenericPackageDescription
                            category = "Control",
                            copyright = "Copyright (C) 2006-2007, Edward Kmett",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "Implements parameterized monads by overloading the monad sugar with more liberal types.",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/multiple-libs-2.expr
+++ b/Cabal/tests/ParserTests/regressions/multiple-libs-2.expr
@@ -147,7 +147,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/noVersion.expr
+++ b/Cabal/tests/ParserTests/regressions/noVersion.expr
@@ -79,7 +79,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/nothing-unicode.expr
+++ b/Cabal/tests/ParserTests/regressions/nothing-unicode.expr
@@ -139,7 +139,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [_×_ "x-\28961" "\28961"],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/shake.expr
+++ b/Cabal/tests/ParserTests/regressions/shake.expr
@@ -2441,7 +2441,7 @@ GenericPackageDescription
                            category = "Development, Shake",
                            copyright = "Neil Mitchell 2011-2017",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = ["html/viz.js",
                                         "html/profile.html",
                                         "html/progress.html",

--- a/Cabal/tests/ParserTests/regressions/spdx-1.expr
+++ b/Cabal/tests/ParserTests/regressions/spdx-1.expr
@@ -70,7 +70,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/spdx-2.expr
+++ b/Cabal/tests/ParserTests/regressions/spdx-2.expr
@@ -70,7 +70,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/spdx-3.expr
+++ b/Cabal/tests/ParserTests/regressions/spdx-3.expr
@@ -70,7 +70,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/th-lift-instances.expr
+++ b/Cabal/tests/ParserTests/regressions/th-lift-instances.expr
@@ -533,7 +533,7 @@ GenericPackageDescription
                            category = "Template Haskell",
                            copyright = "Copyright (C) 2013-2014 Benno F\252nfst\252ck",
                            customFieldsPD = [_×_ "x-revision" "1"],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = concat
                                            ["Most data types in haskell platform do not have Lift instances. This package provides orphan instances\n",

--- a/Cabal/tests/ParserTests/regressions/version-sets.expr
+++ b/Cabal/tests/ParserTests/regressions/version-sets.expr
@@ -240,7 +240,7 @@ GenericPackageDescription
                            category = "",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = "",
                            executables = [],

--- a/Cabal/tests/ParserTests/regressions/wl-pprint-indef.expr
+++ b/Cabal/tests/ParserTests/regressions/wl-pprint-indef.expr
@@ -182,7 +182,7 @@ GenericPackageDescription
                            category = "Text",
                            copyright = "",
                            customFieldsPD = [],
-                           dataDir = "",
+                           dataDir = ".",
                            dataFiles = [],
                            description = concat
                                            ["This is a pretty printing library based on Wadler's paper \"A Prettier\n",


### PR DESCRIPTION
Because there are plenty of `license-file: ""` and `data-dir: ""`,
out there, parser accepts and
filters out or transforms to "." respectively.

There are just two files which have non-empty filepath somewhere
else, namely in `hs-source-dirs:`. These are handler by `Quirks`.

Warning increase:

```diff
-40411 files contained warnings
+41163 files contained warnings
```
