### PR TITLE
Add sync support for hg

### DIFF
--- a/cabal-install/src/Distribution/Client/VCS.hs
+++ b/cabal-install/src/Distribution/Client/VCS.hs
@@ -445,7 +445,35 @@ vcsHg =
                  -> ConfiguredProgram
                  -> [(SourceRepositoryPackage f, FilePath)]
                  -> IO [MonitorFilePath]
-    vcsSyncRepos _v _p _rs = fail "sync repo not yet supported for hg"
+    vcsSyncRepos _ _ [] = return []
+    vcsSyncRepos verbosity hgProg
+                 ((primaryRepo, primaryLocalDir) : secondaryRepos) = do
+      vcsSyncRepo verbosity hgProg primaryRepo primaryLocalDir
+      sequence_
+        [ vcsSyncRepo verbosity hgProg repo localDir
+        | (repo, localDir) <- secondaryRepos ]
+      return [ monitorDirectoryExistence dir
+            | dir <- (primaryLocalDir : map snd secondaryRepos) ]
+    vcsSyncRepo verbosity hgProg repo localDir = do
+        exists <- doesDirectoryExist localDir
+        if exists
+          then hg localDir ["pull"]
+          else hg (takeDirectory localDir) cloneArgs
+        hg localDir checkoutArgs
+      where
+        hg :: FilePath -> [String] -> IO ()
+        hg cwd args = runProgramInvocation verbosity $
+                          (programInvocation hgProg args) {
+                            progInvokeCwd = Just cwd
+                          }
+        cloneArgs      = ["clone", "--noupdate", (srpLocation repo), localDir]
+                        ++ verboseArg
+        verboseArg = [ "--quiet" | verbosity < Verbosity.normal ]
+        checkoutArgs = [ "checkout", "--clean" ]
+                      ++ tagArgs
+        tagArgs = case srpTag repo of
+            Just t  -> ["--rev", t]
+            Nothing -> []
 
 hgProgram :: Program
 hgProgram = (simpleProgram "hg") {


### PR DESCRIPTION
* [Y ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ NA] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ NA] The documentation has been updated, if necessary.

Change was tested using a cabal.project.local with the following:

source-repository-package
   type: hg
   location: https://hg.sr.ht/~sumo/pairing-serialize
   tag: b8c5d29837eb

First checkout was verified with tag and without. On rebuild followup fetch + checkouts were verified against hg revs verified by using the hg id in the local checkout.

