### PR TITLE
Enable -fwarn-incomplete-record-updates

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -58,7 +58,7 @@ library
   else
     build-depends: unix  >= 2.6.0.0 && < 2.8
 
-  ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns
+  ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances
 

--- a/cabal-install/cabal-install-solver/src/Distribution/Solver/Types/OptionalStanza.hs
+++ b/cabal-install/cabal-install-solver/src/Distribution/Solver/Types/OptionalStanza.hs
@@ -9,7 +9,7 @@ module Distribution.Solver.Types.OptionalStanza
 import Distribution.Solver.Compat.Prelude
 import Prelude ()
 import Distribution.Types.ComponentRequestedSpec
-            (ComponentRequestedSpec(..), defaultComponentRequestedSpec)
+            (ComponentRequestedSpec(..))
 
 data OptionalStanza
     = TestStanzas
@@ -23,11 +23,14 @@ showStanza BenchStanzas = "bench"
 
 -- | Convert a list of 'OptionalStanza' into the corresponding
 -- 'ComponentRequestedSpec' which records what components are enabled.
+
+-- Note: [OptionalStanza] could become PerOptionalStanza Bool.
+-- See https://github.com/haskell/cabal/issues/6918
 enableStanzas :: [OptionalStanza] -> ComponentRequestedSpec
-enableStanzas = foldl' addStanza defaultComponentRequestedSpec
-  where
-    addStanza enabled TestStanzas  = enabled { testsRequested = True }
-    addStanza enabled BenchStanzas = enabled { benchmarksRequested = True }
+enableStanzas optionalStanzas = ComponentRequestedSpec {
+    testsRequested      = any (== TestStanzas)  optionalStanzas
+  , benchmarksRequested = any (== BenchStanzas) optionalStanzas
+  }
 
 instance Binary OptionalStanza
 instance Structured OptionalStanza

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -56,7 +56,7 @@ executable cabal
     main-is:        Main.hs
     hs-source-dirs: main
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances

--- a/cabal-install/cabal-install.cabal.dev
+++ b/cabal-install/cabal-install.cabal.dev
@@ -54,7 +54,7 @@ Flag lukko
 
 library cabal-lib-client
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances
@@ -279,7 +279,7 @@ library cabal-lib-client
 
 library cabal-install-solver-dsl
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances
@@ -305,7 +305,7 @@ executable cabal
     main-is:        Main.hs
     hs-source-dirs: main
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances
@@ -335,7 +335,7 @@ executable cabal
 --
 Test-Suite unit-tests
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances
@@ -409,7 +409,7 @@ Test-Suite unit-tests
 --
 Test-Suite memory-usage-tests
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances
@@ -443,7 +443,7 @@ Test-Suite memory-usage-tests
 --
 Test-Suite solver-quickcheck
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances
@@ -482,7 +482,7 @@ Test-Suite solver-quickcheck
 -- but still build whole projects
 test-suite integration-tests2
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances

--- a/cabal-install/cabal-install.cabal.prod
+++ b/cabal-install/cabal-install.cabal.prod
@@ -56,7 +56,7 @@ executable cabal
     main-is:        Main.hs
     hs-source-dirs: main
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances

--- a/cabal-install/cabal-install.cabal.zinza
+++ b/cabal-install/cabal-install.cabal.zinza
@@ -68,7 +68,7 @@ Version:            3.5.0.0
 {% endblock %}
 {% defblock componentCommon %}
     default-language: Haskell2010
-    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
+    ghc-options:    -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
     if impl(ghc >= 8.0)
         ghc-options: -Wcompat
                      -Wnoncanonical-monad-instances


### PR DESCRIPTION
to prepare for the time when GHC enables this flag under `-Wall`.