### PR TITLE
Clarify cabal.project documentation

### DIFF
--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -21,7 +21,8 @@ line flags that ``cabal install`` and other commands take. For example,
 file with ``profiling: True``.
 
 The full configuration of a project is determined by combining the
-following sources (later entries override earlier ones):
+following sources (later entries override earlier ones, except for appendable
+options):
 
 1. ``~/.cabal/config`` (the user-wide global configuration)
 
@@ -64,6 +65,9 @@ project are:
        and built.
 
     There is no command line variant of this field; see :issue:`3585`.
+    Note that the default value is only included if there is no
+    ``cabal.project`` file. The field is appendable which means there would be
+    no way to drop the default value if it was included.
 
 .. cfg-field:: optional-packages: package location list (space or comma-separated)
     :synopsis: Optional project packages.

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -49,7 +49,7 @@ project are:
     1. They can specify a Cabal file, or a directory containing a Cabal
        file, e.g., ``packages: Cabal cabal-install/cabal-install.cabal``.
 
-    2. They can specify a glob-style wildcards, which must match one or
+    2. They can specify glob-style wildcards, which must match one or
        more (a) directories containing a (single) Cabal file, (b) Cabal
        files (extension ``.cabal``), or (c) tarballs which contain Cabal
        packages (extension ``.tar.gz``).

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -4,7 +4,8 @@ cabal.project Reference
 ``cabal.project`` files support a variety of options which configure the
 details of your build. The general syntax of a ``cabal.project`` file is
 similar to that of a Cabal file: there are a number of fields, some of
-which live inside stanzas:
+which live inside stanzas (groups of fields that apply to only part of a
+project or can be referenced as a unit):
 
 ::
 


### PR DESCRIPTION
I was confused about the resolution of settings in the presence of a `cabal.project` so I added some minimal documentation that would've helped me.

I was confused because in a project with both a `<pkgname>.cabal` and a `cabal.project`, v2-build complained about neither of them existing:
```
cabal: There is no <pkgname>.cabal package file or cabal.project file. To
build packages locally you need at minimum a <pkgname>.cabal file. You can use
'cabal init' to create one.

For non-trivial projects you will also want a cabal.project file in the root
directory of your project. This file lists the packages in your project and
all other build configuration. See the Cabal user guide for full details.
```

The problem turned out to be not setting `packages:` in the `cabal.project`, I'd only set `index-state:` which erases the default value.

I'd like to refine that error message to be more helpful in case a `cabal.project` file is present, explaining `packages:` should probably be set, rather than denying the files exist : )

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
