### PR TITLE
Extensible Interface Directories 

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -2000,7 +2000,7 @@ installLib verbosity lbi targetDir dynlibTargetDir _builtDir pkg lib clbi = do
 
     copyModuleFiles ext =
       findModuleFilesEx verbosity [builtDir] [ext] (allLibModules lib clbi)
-      >>= installOrdinaryFiles verbosity targetDir
+      >>= installDirectoriesContents verbosity targetDir
 
     compiler_id = compilerId (compiler lbi)
     platform = hostPlatform lbi


### PR DESCRIPTION
This patch aims to support future work on GHC with the intent of `.hi` interface files instead being directories (https://gitlab.haskell.org/ghc/ghc/-/issues/18954). This feature requires small breaking changes in Cabal, so the goal of this is to get ahead of the release cycle.

Currently, GHC supports extensibility features in standard `.hi` interfaces files by way of a custom format (https://gitlab.haskell.org/ghc/ghc/-/wikis/Extensible-Interface-Files). However, there are a number of advantages to doing away with a custom format and instead relying on the filesystem for this. In particular, by supporting `.hi` directories instead of having an extra custom directory for extensibility, we only need to support this feature once within Cabal for the `install` command - whereas an additional directory would require all tools to have knowledge of it.