### PR TITLE
Change echo to printf

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/Script.hs
+++ b/Cabal/src/Distribution/Simple/Program/Script.hs
@@ -48,7 +48,7 @@ invocationAsShellScript
        ++ [ "cd " ++ quote cwd | cwd <- maybeToList mcwd ]
        ++ [ (case minput of
               Nothing     -> ""
-              Just input -> "echo " ++ quote (iodataToText input) ++ " | ")
+              Just input -> "printf '%s' " ++ quote (iodataToText input) ++ " | ")
          ++ unwords (map quote $ path : args) ++ " \"$@\""]
 
   where


### PR DESCRIPTION
The command echo behaves differently in different shells whereas printf is more portable. This means `runhaskell Setup register --gen-script` may generate a buggy script for some shells. if there are escape sequences in the package description.

Although all shells have echo the implementations is different. POSIX says: if the first argument is -n or any argument contains backslashes, then the behaviour is unspecified. The scripts currently produced are only guaranteed to work correctly in bash-like shells.

### Why is this a problem

Some packages such as [lens](https://github.com/ekmett/lens/blob/master/lens.cabal#L79) contain backslashes in their descriptions. In this case the 'register.sh' script produced by `runhaskell Setup register --gen-script` does not behave consistently for different shells. You can test this by setting your `/bin/sh` to dash or zsh and installing lens as a system package. It will fail to register.

### Solution

This could be solved by adding more rules to escape the backslashes but it is easier done if `echo` is replaced with `printf '%s'`. Printf is more portable because it behaves the same in all shells. This would not require any other changes as only single quotes need to be escaped in printf (like bash echo). In general printf is recommended over echo (see links below). 

### See Also

https://unix.stackexchange.com/questions/65803/why-is-printf-better-than-echo/65819#65819
https://www.in-ulm.de/~mascheck/various/echo+printf/

https://www.reddit.com/r/archlinux/comments/joj4rc/psa_haskelllens_package_broken_for_people_using/

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [x] The documentation has been updated, if necessary.

### Tests
I downloaded the ghc<sup>1</sup> source and modified it with my changes. I then rebuilt<sup>2</sup> it and installed it. To test it worked I rebuilt the lens<sup>3</sup> package.

I tested the old and new register.sh (minus the pipe and `export PATH`) produced by the lens package with a script `test.sh`<sup>4</sup> and the output was identical in all shells<sup>5</sup> tested.

<sup>1</sup> Version 8.10.2
<sup>2</sup> All done using [Arch Build System](https://wiki.archlinux.org/index.php/Arch_Build_System)
<sup>3</sup> This was the package which I had a problem with in the first place
<sup>4</sup> see https://gist.github.com/jaredforrest/38ae290913f5428070a650b09dd2fcd9
<sup>5</sup> tested bash dash zsh ksh and mksh
