### PR TITLE
Include `cmm-sources` when linking shared objects

### DIFF
--- a/Cabal/Distribution/Simple/GHC.hs
+++ b/Cabal/Distribution/Simple/GHC.hs
@@ -779,9 +779,9 @@ buildOrReplLib mReplFlags verbosity numJobs pkg_descr lbi lib clbi = do
   when has_code . unless forRepl $ do
     info verbosity "Linking..."
     let cProfObjs            = map (`replaceExtension` ("p_" ++ objExtension))
-                               (cSources libBi ++ cxxSources libBi)
+                               cLikeFiles
         cSharedObjs          = map (`replaceExtension` ("dyn_" ++ objExtension))
-                               (cSources libBi ++ cxxSources libBi)
+                               cLikeFiles
         compiler_id          = compilerId (compiler lbi)
         vanillaLibFilePath   = libTargetDir </> mkLibName uid
         profileLibFilePath   = libTargetDir </> mkProfLibName uid
@@ -1364,7 +1364,9 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
                                              [tmpDir </> x | x <- cObjs ++ cxxObjs]
                     }
       dynLinkerOpts = mempty {
-                      ghcOptRPaths         = rpaths
+                      ghcOptRPaths         = rpaths,
+                      ghcOptInputFiles     = toNubListR
+                                             [tmpDir </> x | x <- cObjs ++ cxxObjs]
                    }
       replOpts   = baseOpts {
                     ghcOptExtra            = Internal.filterGhciFlags

--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/cabal.out
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/cabal.out
@@ -1,0 +1,13 @@
+# cabal v2-run
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - cmmexperiment-0 (lib) (first run)
+ - cmmexperiment-0 (exe:demo) (first run)
+Configuring library for cmmexperiment-0..
+Preprocessing library for cmmexperiment-0..
+Building library for cmmexperiment-0..
+Configuring executable 'demo' for cmmexperiment-0..
+Warning: The package has an extraneous version range for a dependency on an internal library: cmmexperiment >=0 && ==0. This version range includes the current package but isn't needed as the current package's library will always be used.
+Preprocessing executable 'demo' for cmmexperiment-0..
+Building executable 'demo' for cmmexperiment-0..

--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/cabal.project
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+executable-dynamic: True

--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/cabal.test.hs
@@ -1,0 +1,7 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    skipIf =<< isWindows
+    res <- cabal' "v2-run" ["demo"]
+    assertOutputContains "= Post common block elimination =" res
+    assertOutputContains "In Box we have 0x" res

--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/cbits/HeapPrim.cmm
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/cbits/HeapPrim.cmm
@@ -1,0 +1,6 @@
+#include "Cmm.h"
+
+aToMyWordzh (P_ clos)
+{
+    return (clos);
+}

--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/cmmexperiment.cabal
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/cmmexperiment.cabal
@@ -1,0 +1,27 @@
+cabal-version: 3.0
+name: cmmexperiment
+version: 0
+build-type: Simple
+
+-- This code is extracted form ghc-heap
+-- Copyright (c) 2012-2013, Joachim Breitner
+-- (and probably -2020 GHC Team)
+-- Under BSD-3-Clause
+
+library 
+  default-language: Haskell2010
+  hs-source-dirs: src
+  build-depends: base
+  exposed-modules: Demo
+
+  cmm-sources: cbits/HeapPrim.cmm
+  if impl(ghc >=8.2)
+    cmm-options: -ddump-cmm-verbose
+  else
+    cmm-options: -ddump-cmm
+
+executable demo
+  default-language: Haskell2010
+  main-is: Main.hs
+  hs-source-dirs: demo
+  build-depends: base, cmmexperiment

--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/demo/Main.hs
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/demo/Main.hs
@@ -1,0 +1,2 @@
+module Main (main) where
+import Demo (main)

--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/setup.out
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/setup.out
@@ -1,0 +1,7 @@
+# Setup configure
+Configuring cmmexperiment-0...
+# Setup build
+Preprocessing library for cmmexperiment-0..
+Building library for cmmexperiment-0..
+Preprocessing executable 'demo' for cmmexperiment-0..
+Building executable 'demo' for cmmexperiment-0..

--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/setup.test.hs
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/setup.test.hs
@@ -1,0 +1,7 @@
+import Test.Cabal.Prelude
+
+main = setupTest $ do
+    skipIf =<< ghcVersionIs (< mkVersion [7,8])
+    setup "configure" []
+    res <- setup' "build" []
+    assertOutputContains "= Post common block elimination =" res

--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/src/Demo.hs
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/src/Demo.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE GHCForeignImportPrim #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnliftedFFITypes #-}
+module Demo (main) where
+
+#include "MachDeps.h"
+
+import Data.Bits
+import GHC.Exts
+import Numeric (showHex)
+
+foreign import prim "aToMyWordzh" aToWord# :: Any -> Word#
+
+tAG_MASK :: Int
+tAG_MASK = (1 `shift` TAG_BITS) - 1
+
+data Box = Box Any
+
+instance Show Box where
+   showsPrec _ (Box a) rs =
+    -- unsafePerformIO (print "↓" >> pClosure a) `seq`
+    pad_out (showHex addr "") ++ (if tag>0 then "/" ++ show tag else "") ++ rs
+     where
+       ptr  = W# (aToWord# a)
+       tag  = ptr .&. fromIntegral tAG_MASK -- ((1 `shiftL` TAG_BITS) -1)
+       addr = ptr - tag
+       pad_out ls = '0':'x':ls
+
+asBox :: a -> Box
+asBox x = Box (unsafeCoerce# x)
+
+main :: IO ()
+main = do
+    let box = asBox "foobar"
+    putStrLn $ "In Box we have " ++ show box


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [x] The documentation has been updated, if necessary.

FIxes #7182 by fixing inconsistent object sets used during linking of vanilla and shared object output.