### PR TITLE
directory: ensure xdg compliance

### DIFF
--- a/Cabal-tests/tests/HackageTests.hs
+++ b/Cabal-tests/tests/HackageTests.hs
@@ -25,7 +25,7 @@ import Distribution.PackageDescription.PrettyPrint (showGenericPackageDescriptio
 import Distribution.PackageDescription.Quirks      (patchQuirks)
 import Distribution.Simple.Utils                   (fromUTF8BS, toUTF8BS)
 import Numeric                                     (showFFloat)
-import System.Directory                            (getAppUserDataDirectory)
+import System.Directory                            (getXdgDirectory, XdgDirectory(XdgData))
 import System.Environment                          (lookupEnv)
 import System.Exit                                 (exitFailure)
 import System.FilePath                             ((</>))
@@ -63,7 +63,7 @@ import Data.TreeDiff.Pretty          (ansiWlEditExprCompact)
 parseIndex :: (Monoid a, NFData a) => (FilePath -> Bool)
            -> (FilePath -> B.ByteString -> IO a) -> IO a
 parseIndex predicate action = do
-    cabalDir   <- getAppUserDataDirectory "cabal"
+    cabalDir   <- getXdgDirectory XdgData "cabal"
     configPath <- getCabalConfigPath cabalDir
     cfg        <- B.readFile configPath
     cfgFields  <- either (fail . show) pure $ Parsec.readFields cfg

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -113,7 +113,7 @@ import Control.Monad (msum, forM_)
 import Data.Char (isLower)
 import qualified Data.Map as Map
 import System.Directory
-         ( doesFileExist, getAppUserDataDirectory, createDirectoryIfMissing
+         ( doesFileExist, getXdgDirectory, XdgDirectory(XdgData), createDirectoryIfMissing
          , canonicalizePath, removeFile, renameFile, getDirectoryContents )
 import System.FilePath          ( (</>), (<.>), takeExtension
                                 , takeDirectory, replaceExtension
@@ -369,7 +369,7 @@ toPackageIndex verbosity pkgss progdb = do
 --
 -- @since 3.4.0.0
 getGhcAppDir :: IO FilePath
-getGhcAppDir = getAppUserDataDirectory "ghc"
+getGhcAppDir = getXdgDirectory XdgData "ghc"
 
 getLibDir :: Verbosity -> LocalBuildInfo -> IO FilePath
 getLibDir verbosity lbi =

--- a/Cabal/src/Distribution/Simple/GHCJS.hs
+++ b/Cabal/src/Distribution/Simple/GHCJS.hs
@@ -76,7 +76,7 @@ import Control.Monad (msum)
 import Data.Char (isLower)
 import qualified Data.Map as Map
 import System.Directory
-         ( doesFileExist, getAppUserDataDirectory, createDirectoryIfMissing
+         ( doesFileExist, getXdgDirectory, XdgDirectory(XdgData), createDirectoryIfMissing
          , canonicalizePath, removeFile, renameFile )
 import System.FilePath          ( (</>), (<.>), takeExtension
                                 , takeDirectory, replaceExtension
@@ -299,7 +299,7 @@ getUserPackageDB _verbosity ghcjsProg platform = do
     -- It's rather annoying that we have to reconstruct this, because ghc
     -- hides this information from us otherwise. But for certain use cases
     -- like change monitoring it really can't remain hidden.
-    appdir <- getAppUserDataDirectory "ghcjs"
+    appdir <- getXdgDirectory XdgData "ghcjs"
     return (appdir </> platformAndVersion </> packageConfFileName)
   where
     platformAndVersion = Internal.ghcPlatformAndVersionString
@@ -1801,7 +1801,7 @@ pkgRoot verbosity lbi = pkgRoot'
       let ghcjsProg = fromMaybe (error "GHCJS.pkgRoot: no ghcjs program") $ lookupProgram ghcjsProgram (withPrograms lbi)
       in  fmap takeDirectory (getGlobalPackageDB verbosity ghcjsProg)
     pkgRoot' UserPackageDB = do
-      appDir <- getAppUserDataDirectory "ghcjs"
+      appDir <- getXdgDirectory XdgData "ghcjs"
       -- fixme correct this version
       let ver      = compilerVersion (compiler lbi)
           subdir   = System.Info.arch ++ '-':System.Info.os

--- a/Cabal/src/Distribution/Simple/InstallDirs.hs
+++ b/Cabal/src/Distribution/Simple/InstallDirs.hs
@@ -59,7 +59,7 @@ import Distribution.System
 import Distribution.Compiler
 import Distribution.Simple.InstallDirs.Internal
 
-import System.Directory (getAppUserDataDirectory)
+import System.Directory (getXdgDirectory, XdgDirectory(XdgData))
 import System.FilePath
   ( (</>), isPathSeparator
   , pathSeparator, dropDrive
@@ -188,7 +188,7 @@ defaultInstallDirs' False comp userInstall _hasLibs = do
       then do
         mDir <- lookupEnv "CABAL_DIR"
         case mDir of
-          Nothing -> getAppUserDataDirectory "cabal"
+          Nothing -> getXdgDirectory XdgData "cabal"
           Just dir -> return dir
       else case buildOS of
            Windows -> do windowsProgramFilesDir <- getWindowsProgramFilesDir

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -130,7 +130,7 @@ import Text.PrettyPrint
 import Text.PrettyPrint.HughesPJ
          ( text, Doc )
 import System.Directory
-         ( createDirectoryIfMissing, getAppUserDataDirectory, renameFile )
+         ( createDirectoryIfMissing, getXdgDirectory, XdgDirectory(XdgData), renameFile )
 import Network.URI
          ( URI(..), URIAuth(..), parseURI )
 import System.FilePath
@@ -584,7 +584,7 @@ initialSavedConfig = do
   }
 
 defaultCabalDir :: IO FilePath
-defaultCabalDir = getAppUserDataDirectory "cabal"
+defaultCabalDir = getXdgDirectory XdgData "cabal"
 
 getCabalDir :: IO FilePath
 getCabalDir = do

--- a/doc/installing-packages.rst
+++ b/doc/installing-packages.rst
@@ -51,8 +51,8 @@ Various environment variables affect ``cabal-install``.
 
 ``CABAL_DIR``
    Default content directory for ``cabal-install`` files.
-   Default value is ``getAppUserDataDirectory "cabal"``, which is
-   ``$HOME/.cabal`` on unix systems and ``%APPDATA%\cabal`` in Windows.
+   Default value is ``getXdgDirectory XdgData "cabal"``, which is
+   ``$XDG_DATA_HOME/cabal`` on unix systems and ``%APPDATA%\cabal`` in Windows.
 
    .. note::
 


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
^ Not sure how I should add that to the changelog, any input appreciated! 
* [X] The documentation has been updated, if necessary.

This ensures compliance with the [XDG base specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
This will need to be merged alongside the upstream ghc PR https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4567 to avoid any unintended breakage. 
This fixes the upstream bug https://gitlab.haskell.org/ghc/ghc/-/issues/6077
