### PR TITLE
Cabal: Improve cmdline help readability by breaking long lines

### DIFF
--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -20,6 +20,8 @@
 -- If you want to take on the challenge of merging this with the GetOpt
 -- from the base package then go for it!
 --
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE NamedFieldPuns #-}
 module Distribution.GetOpt (
    -- * GetOpt
    getOpt, getOpt',
@@ -44,32 +46,52 @@ data OptKind a                -- kind of cmd line arg (internal use only):
    | EndOfOpts                  --    end-of-options marker (i.e. "--")
    | OptErr    String           --    something went wrong...
 
+data OptHelp a = OptHelp {
+      optNames :: a,
+      optHelp :: String
+    }
+
 -- | Return a string describing the usage of a command, derived from
 -- the header (first argument) and the options described by the
 -- second argument.
 usageInfo :: String                    -- header
           -> [OptDescr a]              -- option descriptors
           -> String                    -- nicely formatted decription of options
-usageInfo header optDescr = unlines (header:table)
-   where (ss,ls,ds) = unzip3 [ (intercalate ", " (map (fmtShort ad) sos)
-                               ,concatMap (fmtLong  ad) (take 1 los)
-                               ,d)
-                             | Option sos los ad d <- optDescr ]
-         ssWidth    = (maximum . map length) ss
-         lsWidth    = (maximum . map length) ls
-         dsWidth    = 30 `max` (80 - (ssWidth + lsWidth + 3))
-         table      = [ " " ++ padTo ssWidth so' ++
-                        " " ++ padTo lsWidth lo' ++
-                        " " ++ d'
-                      | (so,lo,d) <- zip3 ss ls ds
-                      , (so',lo',d') <- fmtOpt dsWidth so lo d ]
-         padTo n x  = take n (x ++ repeat ' ')
+usageInfo header optDescr = unlines (header : table)
+  where
+    options = flip map optDescr $ \(Option sos los ad d) ->
+      OptHelp
+        { optNames =
+          intercalate ", " $
+            map (fmtShort ad) sos ++
+            map (fmtLong  ad) (take 1 los)
+        , optHelp = d
+        }
 
-fmtOpt :: Int -> String -> String -> String -> [(String, String, String)]
-fmtOpt descrWidth so lo descr =
-   case wrapText descrWidth descr of
-     []     -> [(so,lo,"")]
-     (d:ds) -> (so,lo,d) : [ ("","",d') | d' <- ds ]
+    maxOptNameWidth = 30
+    descolWidth = 80 - (maxOptNameWidth + 3)
+
+    table :: [String]
+    table = do
+      OptHelp{optNames, optHelp} <- options
+      let wrappedHelp = wrapText descolWidth optHelp
+      if length optNames >= maxOptNameWidth
+        then [" " ++ optNames] ++
+             renderColumns [] wrappedHelp
+        else renderColumns [optNames] wrappedHelp
+
+    renderColumns :: [String] -> [String] -> [String]
+    renderColumns xs ys = do
+      (x, y) <- zipDefault "" "" xs ys
+      return $ " " ++ padTo maxOptNameWidth x ++ " " ++ y
+
+    padTo n x  = take n (x ++ repeat ' ')
+
+zipDefault :: a -> b -> [a] -> [b] -> [(a,b)]
+zipDefault _  _  []     []     = []
+zipDefault _  bd (a:as) []     = (a,bd) : map (,bd) as
+zipDefault ad _  []     (b:bs) = (ad,b) : map (ad,) bs
+zipDefault ad bd (a:as) (b:bs) = (a,b)  : zipDefault ad bd as bs
 
 fmtShort :: ArgDescr a -> Char -> String
 fmtShort (NoArg  _   ) so = "-" ++ [so]


### PR DESCRIPTION
Currently usageInfo is very ridgid about wrapping the cmdline help
output. Only the help text itself is wrapped, the list of short and long
option names is kept on one line always.

This patch allows more wrapping to happen for very long long-option
names. For example cabal-install has the

    --write-ghc-environment-files=always|never|ghc8.4.4+

option which pushes the help text column over 80 cols for no good
reason. By simply wrapping the possible values after the "=" onto the next
line we can already return sanity to the output.

The patch also gets rid of the dedicated short options column. Previously
the long options column would be aligned to where the longest short option
ends, but since the vast majority of options are long options this seems
misguided. Now long and short options are simply smushed together into one
column.


---
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

--- 

Current `cabal build --help`, notice the crazy amount of dead space because `--write-ghc-environment-files` pushes everything to the right

```
    --write-ghc-environment-files=always|never|ghc8.4.4+ Whether to create a
                                                         .ghc.environment file after a
                                                         successful build (v2-build
                                                         only)
    --enable-documentation                               Enable building of
                                                         documentation
    --disable-documentation                              Disable building of
                                                         documentation
    --doc-index-file=TEMPLATE                            A central index of haddock
                                                         API documentation (template
                                                         cannot use $pkgid)
    --dry-run                                            Do not install anything, only
                                                         print what would be
                                                         installed.
```

<details>

```
 -h --help                                               Show this help text
 -v --verbose[=n]                                        Control verbosity (n is 0--3,
                                                         default verbosity level is 1)
    --builddir=DIR                                       The directory where Cabal
                                                         puts generated build files
                                                         (default dist)
 -g --ghc                                                compile with GHC
    --ghcjs                                              compile with GHCJS
    --uhc                                                compile with UHC
    --haskell-suite                                      compile with a haskell-suite
                                                         compiler
    --cabal-file=PATH                                    use this Cabal file
 -w --with-compiler=PATH                                 give the path to a particular
                                                         compiler
    --with-hc-pkg=PATH                                   give the path to the package
                                                         tool
    --prefix=DIR                                         bake this prefix in
                                                         preparation of installation
    --bindir=DIR                                         installation directory for
                                                         executables
    --libdir=DIR                                         installation directory for
                                                         libraries
    --libsubdir=DIR                                      subdirectory of libdir in
                                                         which libs are installed
    --dynlibdir=DIR                                      installation directory for
                                                         dynamic libraries
    --libexecdir=DIR                                     installation directory for
                                                         program executables
    --libexecsubdir=DIR                                  subdirectory of libexecdir in
                                                         which private executables are
                                                         installed
    --datadir=DIR                                        installation directory for
                                                         read-only data
    --datasubdir=DIR                                     subdirectory of datadir in
                                                         which data files are
                                                         installed
    --docdir=DIR                                         installation directory for
                                                         documentation
    --htmldir=DIR                                        installation directory for
                                                         HTML documentation
    --haddockdir=DIR                                     installation directory for
                                                         haddock interfaces
    --sysconfdir=DIR                                     installation directory for
                                                         configuration files
    --program-prefix=PREFIX                              prefix to be applied to
                                                         installed executables
    --program-suffix=SUFFIX                              suffix to be applied to
                                                         installed executables
    --enable-library-vanilla                             Enable Vanilla libraries
    --disable-library-vanilla                            Disable Vanilla libraries
 -p --enable-library-profiling                           Enable Library profiling
    --disable-library-profiling                          Disable Library profiling
    --enable-shared                                      Enable Shared library
    --disable-shared                                     Disable Shared library
    --enable-static                                      Enable Static library
    --disable-static                                     Disable Static library
    --enable-executable-dynamic                          Enable Executable dynamic
                                                         linking
    --disable-executable-dynamic                         Disable Executable dynamic
                                                         linking
    --enable-executable-static                           Enable Executable fully
                                                         static linking
    --disable-executable-static                          Disable Executable fully
                                                         static linking
    --enable-profiling                                   Enable Executable and library
                                                         profiling
    --disable-profiling                                  Disable Executable and
                                                         library profiling
    --enable-executable-profiling                        Enable Executable profiling
                                                         (DEPRECATED)
    --disable-executable-profiling                       Disable Executable profiling
                                                         (DEPRECATED)
    --profiling-detail=level                             Profiling detail level for
                                                         executable and library
                                                         (default, none,
                                                         exported-functions,
                                                         toplevel-functions,
                                                         all-functions).
    --library-profiling-detail=level                     Profiling detail level for
                                                         libraries only.
 -O --enable-optimization[=n]                            Build with optimization (n is
                                                         0--2, default is 1)
    --disable-optimization                               Build without optimization
    --enable-debug-info[=n]                              Emit debug info (n is 0--3,
                                                         default is 0)
    --disable-debug-info                                 Don't emit debug info
    --enable-library-for-ghci                            Enable compile library for
                                                         use with GHCi
    --disable-library-for-ghci                           Disable compile library for
                                                         use with GHCi
    --enable-split-sections                              Enable compile library code
                                                         such that unneeded
                                                         definitions can be dropped
                                                         from the final executable
                                                         (GHC 7.8+)
    --disable-split-sections                             Disable compile library code
                                                         such that unneeded
                                                         definitions can be dropped
                                                         from the final executable
                                                         (GHC 7.8+)
    --enable-split-objs                                  Enable split library into
                                                         smaller objects to reduce
                                                         binary sizes (GHC 6.6+)
    --disable-split-objs                                 Disable split library into
                                                         smaller objects to reduce
                                                         binary sizes (GHC 6.6+)
    --enable-executable-stripping                        Enable strip executables upon
                                                         installation to reduce binary
                                                         sizes
    --disable-executable-stripping                       Disable strip executables
                                                         upon installation to reduce
                                                         binary sizes
    --enable-library-stripping                           Enable strip libraries upon
                                                         installation to reduce binary
                                                         sizes
    --disable-library-stripping                          Disable strip libraries upon
                                                         installation to reduce binary
                                                         sizes
    --configure-option=OPT                               Extra option for configure
    --user                                               Enable doing a per-user
                                                         installation
    --global                                             Disable doing a per-user
                                                         installation
    --package-db=DB                                      Append the given package
                                                         database to the list of
                                                         package databases used (to
                                                         satisfy dependencies and
                                                         register into). May be a
                                                         specific file, 'global' or
                                                         'user'. The initial list is
                                                         ['global'], ['global',
                                                         'user'], or ['global',
                                                         $sandbox], depending on
                                                         context. Use 'clear' to reset
                                                         the list to empty. See the
                                                         user guide for details.
 -f --flags=FLAGS                                        Force values for the given
                                                         flags in Cabal conditionals
                                                         in the .cabal file. E.g.,
                                                         --flags="debug
                                                         -usebytestrings" forces the
                                                         flag "debug" to true and
                                                         "usebytestrings" to false.
    --extra-include-dirs=PATH                            A list of directories to
                                                         search for header files
    --enable-deterministic                               Enable Try to be as
                                                         deterministic as possible
                                                         (used by the test suite)
    --disable-deterministic                              Disable Try to be as
                                                         deterministic as possible
                                                         (used by the test suite)
    --ipid=IPID                                          Installed package ID to
                                                         compile this package as
    --cid=CID                                            Installed component ID to
                                                         compile this component as
    --extra-lib-dirs=PATH                                A list of directories to
                                                         search for external libraries
    --extra-framework-dirs=PATH                          A list of directories to
                                                         search for external
                                                         frameworks (OS X only)
    --extra-prog-path=PATH                               A list of directories to
                                                         search for required programs
                                                         (in addition to the normal
                                                         search locations)
    --instantiate-with=NAME=MOD                          A mapping of signature names
                                                         to concrete module
                                                         instantiations.
    --enable-tests                                       Enable dependency checking
                                                         and compilation for test
                                                         suites listed in the package
                                                         description file.
    --disable-tests                                      Disable dependency checking
                                                         and compilation for test
                                                         suites listed in the package
                                                         description file.
    --enable-coverage                                    Enable build package with
                                                         Haskell Program Coverage.
                                                         (GHC only)
    --disable-coverage                                   Disable build package with
                                                         Haskell Program Coverage.
                                                         (GHC only)
    --enable-library-coverage                            Enable build package with
                                                         Haskell Program Coverage.
                                                         (GHC only) (DEPRECATED)
    --disable-library-coverage                           Disable build package with
                                                         Haskell Program Coverage.
                                                         (GHC only) (DEPRECATED)
    --enable-benchmarks                                  Enable dependency checking
                                                         and compilation for
                                                         benchmarks listed in the
                                                         package description file.
    --disable-benchmarks                                 Disable dependency checking
                                                         and compilation for
                                                         benchmarks listed in the
                                                         package description file.
    --enable-relocatable                                 Enable building a package
                                                         that is relocatable. (GHC
                                                         only)
    --disable-relocatable                                Disable building a package
                                                         that is relocatable. (GHC
                                                         only)
    --disable-response-files                             enable workaround for old
                                                         versions of programs like
                                                         "ar" that do not support
                                                         @file arguments
    --allow-depending-on-private-libs                    Allow depending on private
                                                         libraries. If set, the
                                                         library visibility check MUST
                                                         be done externally.
    --with-PROG=PATH                                     give the path to PROG
    --PROG-option=OPT                                    give an extra option to PROG
                                                         (no need to quote options
                                                         containing spaces)
    --PROG-options=OPTS                                  give extra options to PROG
    --cabal-lib-version=VERSION                          Select which version of the
                                                         Cabal lib to use to build
                                                         packages (useful for
                                                         testing).
    --constraint=CONSTRAINT                              Specify constraints on a
                                                         package (version,
                                                         installed/source, flags)
    --preference=CONSTRAINT                              Specify preferences (soft
                                                         constraints) on the version
                                                         of a package
    --solver=SOLVER                                      Select dependency solver to
                                                         use (default: modular).
                                                         Choices: modular.
    --allow-older[=DEPS]                                 Ignore lower bounds in all
                                                         dependencies or DEPS
    --allow-newer[=DEPS]                                 Ignore upper bounds in all
                                                         dependencies or DEPS
[...]
    --max-backjumps=NUM                                  Maximum number of backjumps
                                                         allowed while solving
                                                         (default: 4000). Use a
                                                         negative number to enable
                                                         unlimited backtracking. Use 0
                                                         to disable backtracking
                                                         completely.
    --reorder-goals                                      Try to reorder goals
                                                         according to certain
                                                         heuristics. Slows things down
                                                         on average, but may make
                                                         backtracking faster for some
                                                         packages.
    --count-conflicts                                    Try to speed up solving by
                                                         preferring goals that are
                                                         involved in a lot of
                                                         conflicts (default).
    --fine-grained-conflicts                             Skip a version of a package
                                                         if it does not resolve the
                                                         conflicts encountered in the
                                                         last version, as a solver
                                                         optimization (default).
    --minimize-conflict-set                              When there is no solution,
                                                         try to improve the error
                                                         message by finding a minimal
                                                         conflict set (default:
                                                         false). May increase run time
                                                         significantly.
    --independent-goals                                  Treat several goals on the
                                                         command line as independent.
                                                         If several goals depend on
                                                         the same package, different
                                                         versions can be chosen.
    --shadow-installed-packages                          If multiple package instances
                                                         of the same version are
                                                         installed, treat all but one
                                                         as shadowed.
    --strong-flags                                       Do not defer flag choices
                                                         (this used to be the default
                                                         in cabal-install <= 1.20).
    --allow-boot-library-installs                        Allow cabal to install base,
                                                         ghc-prim, integer-simple,
                                                         integer-gmp, and
                                                         template-haskell.
    --reject-unconstrained-dependencies=none|all         Require these packages to
                                                         have constraints on them if
                                                         they are to be selected
                                                         (default: none).
    --reinstall                                          Install even if it means
                                                         installing the same version
                                                         again.
    --avoid-reinstalls                                   Do not select versions that
                                                         would destructively overwrite
                                                         installed packages.
    --force-reinstalls                                   Reinstall packages even if
                                                         they will most likely break
                                                         other installed packages.
    --upgrade-dependencies                               Pick the latest version for
                                                         all dependencies, rather than
                                                         trying to pick an installed
                                                         version.
    --only-dependencies                                  Install only the dependencies
                                                         necessary to build the given
                                                         packages
    --dependencies-only                                  A synonym for
                                                         --only-dependencies
    --index-state=STATE                                  Use source package index
                                                         state as it existed at a
                                                         previous time. Accepts
                                                         unix-timestamps (e.g.
                                                         '@1474732068'), ISO8601 UTC
                                                         timestamps (e.g.
                                                         '2016-09-24T17:47:48Z'), or
                                                         'HEAD' (default: 'HEAD').
    --root-cmd=COMMAND                                   (No longer supported, do not
                                                         use.)
    --symlink-bindir=DIR                                 Add symlinks to installed
                                                         executables into this
                                                         directory.
    --build-summary=TEMPLATE                             Save build summaries to file
                                                         (name template can use
                                                         $pkgid, $compiler, $os,
                                                         $arch)
    --build-log=TEMPLATE                                 Log all builds to file (name
                                                         template can use $pkgid,
                                                         $compiler, $os, $arch)
    --remote-build-reporting=LEVEL                       Generate build reports to
                                                         send to a remote server
                                                         (none, anonymous or
                                                         detailed).
    --report-planning-failure                            Generate build reports when
                                                         the dependency solver fails.
                                                         This is used by the Hackage
                                                         build bot.
    --enable-per-component                               Enable Per-component builds
                                                         when possible
    --disable-per-component                              Disable Per-component builds
                                                         when possible
    --one-shot                                           Do not record the packages in
                                                         the world file.
    --run-tests                                          Run package test suites
                                                         during installation.
 -j --jobs[=NUM]                                         Run NUM jobs simultaneously
                                                         (or '$ncpus' if no NUM is
                                                         given).
    --keep-going                                         After a build failure,
                                                         continue to build other
                                                         unaffected packages.
    --offline                                            Don't download packages from
                                                         the Internet.
    --project-file=FILE                                  Set the name of the
                                                         cabal.project file to search
                                                         for in parent directories
    --haddock-hoogle                                     Generate a hoogle database
    --haddock-html                                       Generate HTML documentation
                                                         (the default)
    --haddock-html-location=URL                          Location of HTML
                                                         documentation for
                                                         pre-requisite packages
    --haddock-for-hackage                                Collection of flags to
                                                         generate documentation
                                                         suitable for upload to
                                                         hackage
    --haddock-executables                                Run haddock for Executables
                                                         targets
    --haddock-tests                                      Run haddock for Test Suite
                                                         targets
    --haddock-benchmarks                                 Run haddock for Benchmark
                                                         targets
    --haddock-all                                        Run haddock for all targets
    --haddock-internal                                   Run haddock for internal
                                                         modules and include all
                                                         symbols
    --haddock-css=PATH                                   Use PATH as the haddock
                                                         stylesheet
    --haddock-hyperlink-source                           Hyperlink the documentation
                                                         to the source code
    --haddock-quickjump                                  Generate an index for
                                                         interactive documentation
                                                         navigation
    --haddock-hscolour-css=PATH                          Use PATH as the HsColour
                                                         stylesheet
    --haddock-contents-location=URL                      Bake URL in as the location
                                                         for the contents page
    --test-log=TEMPLATE                                  Log all test suite results to
                                                         file (name template can use
                                                         $pkgid, $compiler, $os,
                                                         $arch, $test-suite, $result)
    --test-machine-log=TEMPLATE                          Produce a machine-readable
                                                         log file (name template can
                                                         use $pkgid, $compiler, $os,
                                                         $arch, $result)
    --test-show-details=FILTER                           'always': always show results
                                                         of individual test cases.
                                                         'never': never show results
                                                         of individual test cases.
                                                         'failures': show results of
                                                         failing test cases.
                                                         'streaming': show results of
                                                         test cases in real
                                                         time.'direct': send results
                                                         of test cases in real time;
                                                         no log file.
    --test-keep-tix-files                                keep .tix files for HPC
                                                         between test runs
    --test-wrapper=FILE                                  Run test through a wrapper.
    --test-fail-when-no-test-suites                      Exit with failure when no
                                                         test suites are found.
    --test-options=TEMPLATES                             give extra options to test
                                                         executables (name templates
                                                         can use $pkgid, $compiler,
                                                         $os, $arch, $test-suite)
    --test-option=TEMPLATE                               give extra option to test
                                                         executables (no need to quote
                                                         options containing spaces,
                                                         name template can use $pkgid,
                                                         $compiler, $os, $arch,
                                                         $test-suite)
    --benchmark-options=TEMPLATES                        give extra options to
                                                         benchmark executables (name
                                                         templates can use $pkgid,
                                                         $compiler, $os, $arch,
                                                         $benchmark)
    --benchmark-option=TEMPLATE                          give extra option to
                                                         benchmark executables (no
                                                         need to quote options
                                                         containing spaces, name
                                                         template can use $pkgid,
                                                         $compiler, $os, $arch,
                                                         $benchmark)
    --only-configure                                     Instead of performing a full
                                                         build just run the configure
                                                         step
```
</details>

---

With this patch it fits nicely into 80 cols:


```
 --write-ghc-environment-files       Whether to create a .ghc.environment file
   =always|never|ghc8.4.4+           after a successful build (v2-build only)
 --enable-documentation              Enable building of documentation
 --disable-documentation             Disable building of documentation
 --doc-index-file=TEMPLATE           A central index of haddock API
                                     documentation (template cannot use
                                     $pkgid)
 --dry-run                           Do not install anything, only print what
                                     would be installed.
```

<details>

```
 -h, --help                          Show this help text
 -v, --verbose[=n]                   Control verbosity (n is 0--3, default
                                     verbosity level is 1)
 --builddir=DIR                      The directory where Cabal puts generated
                                     build files (default dist)
 -g, --ghc                           compile with GHC
 --ghcjs                             compile with GHCJS
 --uhc                               compile with UHC
 --haskell-suite                     compile with a haskell-suite compiler
 --cabal-file=PATH                   use this Cabal file
 -w, --with-compiler=PATH            give the path to a particular compiler
 --with-hc-pkg=PATH                  give the path to the package tool
 --prefix=DIR                        bake this prefix in preparation of
                                     installation
 --bindir=DIR                        installation directory for executables
 --libdir=DIR                        installation directory for libraries
 --libsubdir=DIR                     subdirectory of libdir in which libs are
                                     installed
 --dynlibdir=DIR                     installation directory for dynamic
                                     libraries
 --libexecdir=DIR                    installation directory for program
                                     executables
 --libexecsubdir=DIR                 subdirectory of libexecdir in which
                                     private executables are installed
 --datadir=DIR                       installation directory for read-only data
 --datasubdir=DIR                    subdirectory of datadir in which data
                                     files are installed
 --docdir=DIR                        installation directory for documentation
 --htmldir=DIR                       installation directory for HTML
                                     documentation
 --haddockdir=DIR                    installation directory for haddock
                                     interfaces
 --sysconfdir=DIR                    installation directory for configuration
                                     files
 --program-prefix=PREFIX             prefix to be applied to installed
                                     executables
 --program-suffix=SUFFIX             suffix to be applied to installed
                                     executables
 --enable-library-vanilla            Enable Vanilla libraries
 --disable-library-vanilla           Disable Vanilla libraries
 -p, --enable-library-profiling      Enable Library profiling
 --disable-library-profiling         Disable Library profiling
 --enable-shared                     Enable Shared library
 --disable-shared                    Disable Shared library
 --enable-static                     Enable Static library
 --disable-static                    Disable Static library
 --enable-executable-dynamic         Enable Executable dynamic linking
 --disable-executable-dynamic        Disable Executable dynamic linking
 --enable-executable-static          Enable Executable fully static linking
 --disable-executable-static         Disable Executable fully static linking
 --enable-profiling                  Enable Executable and library profiling
 --disable-profiling                 Disable Executable and library profiling
 --enable-executable-profiling       Enable Executable profiling (DEPRECATED)
 --disable-executable-profiling      Disable Executable profiling (DEPRECATED)
 --profiling-detail=level            Profiling detail level for executable and
                                     library (default, none,
                                     exported-functions, toplevel-functions,
                                     all-functions).
 --library-profiling-detail=level    Profiling detail level for libraries
                                     only.
 -O, --enable-optimization[=n]       Build with optimization (n is 0--2,
                                     default is 1)
 --disable-optimization              Build without optimization
 --enable-debug-info[=n]             Emit debug info (n is 0--3, default is 0)
 --disable-debug-info                Don't emit debug info
 --enable-library-for-ghci           Enable compile library for use with GHCi
 --disable-library-for-ghci          Disable compile library for use with GHCi
 --enable-split-sections             Enable compile library code such that
                                     unneeded definitions can be dropped from
                                     the final executable (GHC 7.8+)
 --disable-split-sections            Disable compile library code such that
                                     unneeded definitions can be dropped from
                                     the final executable (GHC 7.8+)
 --enable-split-objs                 Enable split library into smaller objects
                                     to reduce binary sizes (GHC 6.6+)
 --disable-split-objs                Disable split library into smaller
                                     objects to reduce binary sizes (GHC 6.6+)
 --enable-executable-stripping       Enable strip executables upon
                                     installation to reduce binary sizes
 --disable-executable-stripping      Disable strip executables upon
                                     installation to reduce binary sizes
 --enable-library-stripping          Enable strip libraries upon installation
                                     to reduce binary sizes
 --disable-library-stripping         Disable strip libraries upon installation
                                     to reduce binary sizes
 --configure-option=OPT              Extra option for configure
 --user                              Enable doing a per-user installation
 --global                            Disable doing a per-user installation
 --package-db=DB                     Append the given package database to the
                                     list of package databases used (to
                                     satisfy dependencies and register into).
                                     May be a specific file, 'global' or
                                     'user'. The initial list is ['global'],
                                     ['global', 'user'], or ['global',
                                     $sandbox], depending on context. Use
                                     'clear' to reset the list to empty. See
                                     the user guide for details.
 -f, --flags=FLAGS                   Force values for the given flags in Cabal
                                     conditionals in the .cabal file. E.g.,
                                     --flags="debug -usebytestrings" forces
                                     the flag "debug" to true and
                                     "usebytestrings" to false.
 --extra-include-dirs=PATH           A list of directories to search for
                                     header files
 --enable-deterministic              Enable Try to be as deterministic as
                                     possible (used by the test suite)
 --disable-deterministic             Disable Try to be as deterministic as
                                     possible (used by the test suite)
 --ipid=IPID                         Installed package ID to compile this
                                     package as
 --cid=CID                           Installed component ID to compile this
                                     component as
 --extra-lib-dirs=PATH               A list of directories to search for
                                     external libraries
 --extra-framework-dirs=PATH         A list of directories to search for
                                     external frameworks (OS X only)
 --extra-prog-path=PATH              A list of directories to search for
                                     required programs (in addition to the
                                     normal search locations)
 --instantiate-with=NAME=MOD         A mapping of signature names to concrete
                                     module instantiations.
 --enable-tests                      Enable dependency checking and
                                     compilation for test suites listed in the
                                     package description file.
 --disable-tests                     Disable dependency checking and
                                     compilation for test suites listed in the
                                     package description file.
 --enable-coverage                   Enable build package with Haskell Program
                                     Coverage. (GHC only)
 --disable-coverage                  Disable build package with Haskell
                                     Program Coverage. (GHC only)
 --enable-library-coverage           Enable build package with Haskell Program
                                     Coverage. (GHC only) (DEPRECATED)
 --disable-library-coverage          Disable build package with Haskell
                                     Program Coverage. (GHC only) (DEPRECATED)
 --enable-benchmarks                 Enable dependency checking and
                                     compilation for benchmarks listed in the
                                     package description file.
 --disable-benchmarks                Disable dependency checking and
                                     compilation for benchmarks listed in the
                                     package description file.
 --enable-relocatable                Enable building a package that is
                                     relocatable. (GHC only)
 --disable-relocatable               Disable building a package that is
                                     relocatable. (GHC only)
 --disable-response-files            enable workaround for old versions of
                                     programs like "ar" that do not support
                                     @file arguments
 --allow-depending-on-private-libs   Allow depending on private libraries. If
                                     set, the library visibility check MUST be
                                     done externally.
 --with-PROG=PATH                    give the path to PROG
 --PROG-option=OPT                   give an extra option to PROG (no need to
                                     quote options containing spaces)
 --PROG-options=OPTS                 give extra options to PROG
 --cabal-lib-version=VERSION         Select which version of the Cabal lib to
                                     use to build packages (useful for
                                     testing).
 --constraint=CONSTRAINT             Specify constraints on a package
                                     (version, installed/source, flags)
 --preference=CONSTRAINT             Specify preferences (soft constraints) on
                                     the version of a package
 --solver=SOLVER                     Select dependency solver to use (default:
                                     modular). Choices: modular.
 --allow-older[=DEPS]                Ignore lower bounds in all dependencies
                                     or DEPS
 --allow-newer[=DEPS]                Ignore upper bounds in all dependencies
                                     or DEPS
[...]
 --max-backjumps=NUM                 Maximum number of backjumps allowed while
                                     solving (default: 4000). Use a negative
                                     number to enable unlimited backtracking.
                                     Use 0 to disable backtracking completely.
 --reorder-goals                     Try to reorder goals according to certain
                                     heuristics. Slows things down on average,
                                     but may make backtracking faster for some
                                     packages.
 --count-conflicts                   Try to speed up solving by preferring
                                     goals that are involved in a lot of
                                     conflicts (default).
 --fine-grained-conflicts            Skip a version of a package if it does
                                     not resolve the conflicts encountered in
                                     the last version, as a solver
                                     optimization (default).
 --minimize-conflict-set             When there is no solution, try to improve
                                     the error message by finding a minimal
                                     conflict set (default: false). May
                                     increase run time significantly.
 --independent-goals                 Treat several goals on the command line
                                     as independent. If several goals depend
                                     on the same package, different versions
                                     can be chosen.
 --shadow-installed-packages         If multiple package instances of the same
                                     version are installed, treat all but one
                                     as shadowed.
 --strong-flags                      Do not defer flag choices (this used to
                                     be the default in cabal-install <= 1.20).
 --allow-boot-library-installs       Allow cabal to install base, ghc-prim,
                                     integer-simple, integer-gmp, and
                                     template-haskell.
 --reject-unconstrained-dependencies Require these packages to have
   =none|all                         constraints on them if they are to be
                                     selected (default: none).
 --reinstall                         Install even if it means installing the
                                     same version again.
 --avoid-reinstalls                  Do not select versions that would
                                     destructively overwrite installed
                                     packages.
 --force-reinstalls                  Reinstall packages even if they will most
                                     likely break other installed packages.
 --upgrade-dependencies              Pick the latest version for all
                                     dependencies, rather than trying to pick
                                     an installed version.
 --only-dependencies                 Install only the dependencies necessary
                                     to build the given packages
 --dependencies-only                 A synonym for --only-dependencies
 --index-state=STATE                 Use source package index state as it
                                     existed at a previous time. Accepts
                                     unix-timestamps (e.g. '@1474732068'),
                                     ISO8601 UTC timestamps (e.g.
                                     '2016-09-24T17:47:48Z'), or 'HEAD'
                                     (default: 'HEAD').
 --root-cmd=COMMAND                  (No longer supported, do not use.)
 --build-summary=TEMPLATE            Save build summaries to file (name
                                     template can use $pkgid, $compiler, $os,
                                     $arch)
 --build-log=TEMPLATE                Log all builds to file (name template can
                                     use $pkgid, $compiler, $os, $arch)
 --remote-build-reporting=LEVEL      Generate build reports to send to a
                                     remote server (none, anonymous or
                                     detailed).
 --report-planning-failure           Generate build reports when the
                                     dependency solver fails. This is used by
                                     the Hackage build bot.
 --enable-per-component              Enable Per-component builds when possible
 --disable-per-component             Disable Per-component builds when
                                     possible
 --one-shot                          Do not record the packages in the world
                                     file.
 --run-tests                         Run package test suites during
                                     installation.
 -j, --jobs[=NUM]                    Run NUM jobs simultaneously (or '$ncpus'
                                     if no NUM is given).
 --keep-going                        After a build failure, continue to build
                                     other unaffected packages.
 --offline                           Don't download packages from the
                                     Internet.
 --haddock-hoogle                    Generate a hoogle database
 --haddock-html                      Generate HTML documentation (the default)
 --haddock-html-location=URL         Location of HTML documentation for
                                     pre-requisite packages
 --haddock-for-hackage               Collection of flags to generate
                                     documentation suitable for upload to
                                     hackage
 --haddock-executables               Run haddock for Executables targets
 --haddock-tests                     Run haddock for Test Suite targets
 --haddock-benchmarks                Run haddock for Benchmark targets
 --haddock-all                       Run haddock for all targets
 --haddock-internal                  Run haddock for internal modules and
                                     include all symbols
 --haddock-css=PATH                  Use PATH as the haddock stylesheet
 --haddock-hyperlink-source          Hyperlink the documentation to the source
                                     code
 --haddock-quickjump                 Generate an index for interactive
                                     documentation navigation
 --haddock-hscolour-css=PATH         Use PATH as the HsColour stylesheet
 --haddock-contents-location=URL     Bake URL in as the location for the
                                     contents page
 --test-log=TEMPLATE                 Log all test suite results to file (name
                                     template can use $pkgid, $compiler, $os,
                                     $arch, $test-suite, $result)
 --test-machine-log=TEMPLATE         Produce a machine-readable log file (name
                                     template can use $pkgid, $compiler, $os,
                                     $arch, $result)
 --test-show-details=FILTER          'always': always show results of
                                     individual test cases. 'never': never
                                     show results of individual test cases.
                                     'failures': show results of failing test
                                     cases. 'streaming': show results of test
                                     cases in real time.'direct': send results
                                     of test cases in real time; no log file.
 --test-keep-tix-files               keep .tix files for HPC between test runs
 --test-wrapper=FILE                 Run test through a wrapper.
 --test-fail-when-no-test-suites     Exit with failure when no test suites are
                                     found.
 --test-options=TEMPLATES            give extra options to test executables
                                     (name templates can use $pkgid,
                                     $compiler, $os, $arch, $test-suite)
 --test-option=TEMPLATE              give extra option to test executables (no
                                     need to quote options containing spaces,
                                     name template can use $pkgid, $compiler,
                                     $os, $arch, $test-suite)
 --benchmark-options=TEMPLATES       give extra options to benchmark
                                     executables (name templates can use
                                     $pkgid, $compiler, $os, $arch,
                                     $benchmark)
 --benchmark-option=TEMPLATE         give extra option to benchmark
                                     executables (no need to quote options
                                     containing spaces, name template can use
                                     $pkgid, $compiler, $os, $arch,
                                     $benchmark)
 --project-file=FILE                 Set the name of the cabal.project file to
                                     search for in parent directories
 --only-configure                    Instead of performing a full build just
                                     run the configure step
```
</details>