### PR TITLE
GetOpt: Make OptHelp less polymorphic

### DIFF
--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -46,8 +46,8 @@ data OptKind a                -- kind of cmd line arg (internal use only):
    | EndOfOpts                  --    end-of-options marker (i.e. "--")
    | OptErr    String           --    something went wrong...
 
-data OptHelp a = OptHelp {
-      optNames :: a,
+data OptHelp = OptHelp {
+      optNames :: String,
       optHelp :: String
     }
 


### PR DESCRIPTION
This was a leftover from the first iteration in #7190 where we used to map over optNames, but it's not needed anymore.
