### PR TITLE
Add missing spaces between words in output

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdErrorMessages.hs
+++ b/cabal-install/src/Distribution/Client/CmdErrorMessages.hs
@@ -136,9 +136,9 @@ renderTargetSelector (TargetComponentUnknown pkgname (Right cname) subtarget) =
 renderSubComponentTarget :: SubComponentTarget -> String
 renderSubComponentTarget WholeComponent         = ""
 renderSubComponentTarget (FileTarget filename)  =
-  "the file " ++ filename ++ "in "
+  "the file " ++ filename ++ " in "
 renderSubComponentTarget (ModuleTarget modname) =
-  "the module" ++ prettyShow modname ++ "in "
+  "the module " ++ prettyShow modname ++ " in "
 
 
 renderOptionalStanza :: Plural -> OptionalStanza -> String


### PR DESCRIPTION
Fixes error messages like this one (note the missing space in `Build.hsin`):
```
cabal: The run command can only run an executable as a whole, not files or
modules within them, but the target 'Build.hs' refers to the file Build.hsin
the executable shake
```