### PR TITLE
Remove the deprecated extension MonadFailDesugaring

### DIFF
--- a/Cabal/src/Language/Haskell/Extension.hs
+++ b/Cabal/src/Language/Haskell/Extension.hs
@@ -783,10 +783,6 @@ data KnownExtension =
   -- | Allow recursive (and therefore undecidable) super-class relationships.
   | UndecidableSuperClasses
 
-  -- | A temporary extension to help library authors check if their
-  -- code will compile with the new planned desugaring of fail.
-  | MonadFailDesugaring
-
   -- | A subset of @TemplateHaskell@ including only quoting.
   | TemplateHaskellQuotes
 

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -207,7 +207,6 @@ syn keyword cabalExtension contained
   \ LinearTypes
   \ MagicHash
   \ MonadComprehensions
-  \ MonadFailDesugaring
   \ MonoLocalBinds
   \ MonoPatBinds
   \ MonomorphismRestriction


### PR DESCRIPTION
This PR is the sibling of https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4767 that removes the deprecated extension MonadFailDesugaring. 

cc @phadej 
