### PR TITLE
[Backpack]: improve the error message in case of a mutually recursive unit

### DIFF
--- a/Cabal/src/Distribution/Backpack/UnifyM.hs
+++ b/Cabal/src/Distribution/Backpack/UnifyM.hs
@@ -386,19 +386,19 @@ lookupMooEnv (m, i) k =
 
 -- The workhorse functions
 
-convertUnitIdU' :: MooEnv -> UnitIdU s -> UnifyM s OpenUnitId
+-- | Returns `OpenUnitId` if there is no a mutually recursive unit.
+-- | Otherwise returns a list of signatures instantiated by given `UnitIdU`.
+convertUnitIdU' :: MooEnv -> UnitIdU s -> UnifyM s (Either [ModuleName] OpenUnitId)
 convertUnitIdU' stk uid_u = do
     x <- liftST $ UnionFind.find uid_u
     case x of
-        UnitIdThunkU uid -> return (DefiniteUnitId uid)
+        UnitIdThunkU uid -> return $ Right (DefiniteUnitId uid)
         UnitIdU u cid insts_u ->
             case lookupMooEnv stk u of
-                Just _i ->
-                    failWith (text "Unsupported mutually recursive unit identifier")
-                    -- return (UnitIdVar i)
+                Just _i -> return $ Left $ Map.keys insts_u
                 Nothing -> do
                     insts <- for insts_u $ convertModuleU' (extendMooEnv stk u)
-                    return (IndefFullUnitId cid insts)
+                    return $ Right (IndefFullUnitId cid insts)
 
 convertModuleU' :: MooEnv -> ModuleU s -> UnifyM s OpenModule
 convertModuleU' stk mod_u = do
@@ -406,12 +406,19 @@ convertModuleU' stk mod_u = do
     case mod of
         ModuleVarU mod_name -> return (OpenModuleVar mod_name)
         ModuleU uid_u mod_name -> do
-            uid <- convertUnitIdU' stk uid_u
-            return (OpenModule uid mod_name)
+            x <- convertUnitIdU' stk uid_u
+            case x of
+                Right uid -> return (OpenModule uid mod_name)
+                Left mod_names ->
+                    let sigsList = hcat $ punctuate (text ", ") $ map (quotes . pretty) mod_names in
+                    failWith $
+                        text "Cannot instantiate requirement " <+> quotes (pretty mod_name) $$
+                        text "Check that \"build-depends:\" doesn't include library with signatures: " <+> sigsList $$
+                        text "as this creates a cyclic dependency, which GHC does not support."
 
 -- Helper functions
 
-convertUnitIdU :: UnitIdU s -> UnifyM s OpenUnitId
+convertUnitIdU :: UnitIdU s -> UnifyM s (Either [ModuleName] OpenUnitId)
 convertUnitIdU = convertUnitIdU' emptyMooEnv
 
 convertModuleU :: ModuleU s -> UnifyM s OpenModule


### PR DESCRIPTION
This PR improves the error message in case when the user adds a dependency with signature to the implementation:

```
library interface
  hs-source-dirs: interface
  signatures: A
  build-depends: base

library impl
  hs-source-dirs: impl
  exposed-modules: ImplA
  reexported-modules: ImplA as A
  build-depends: base, interface

executable exe
  main-is: Main.hs
  build-depends: base, impl, interface
```

The error message was:

```
Error:
    Unsupported mutually recursive unit identifier
    In the stanza 'executable exe'
    In the inplace package 'example-0.1.0.0'
```

The improved error message:

```
Error:
    Cannot instantiate requirement  'ImplA'
    Check that "build-depends:" doesn't include library with signatures:  'A'
    as this creates a cyclic dependency, which GHC does not support.
    In the stanza 'executable exe'
    In the inplace package 'example-0.1.0.0'
```

which is almost the same as in https://github.com/haskell/cabal/blob/master/Cabal/src/Distribution/Backpack/MixLink.hs#L70

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
