### PR TITLE
Removed obsolete warning about mixins in the doc

### DIFF
--- a/doc/cabal-package.rst
+++ b/doc/cabal-package.rst
@@ -2297,10 +2297,10 @@ system-dependent values for these fields.
 
     .. Note::
 
-       The current version of Cabal suffers from an infelicity in how the
-       entries of :pkg-field:`mixins` are parsed: an entry will fail to parse
-       if the provided renaming clause has whitespace after the opening
-       parenthesis. This will be fixed in future versions of Cabal.
+       Cabal files with :pkg-field:`cabal-version` < 3.0 suffer from an
+       infelicity in how the entries of :pkg-field:`mixins` are parsed: an
+       entry will fail to parse if the provided renaming clause has whitespace
+       after the opening parenthesis. 
 
        See issues :issue:`5150`, :issue:`4864`, and :issue:`5293`.
 


### PR DESCRIPTION
The documentation for the "mixins:" field still featured an obsolete warning about a parsing bug which was solved in #5293 and #5292.

I have verified that it indeed works now.

Open issues about seemingly the same bug: #5150, #4864.