### PR TITLE
[ fix #7251 ] sort and nub module list inferred by cabal init --lib

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Command.hs
@@ -33,6 +33,8 @@ import System.FilePath
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
+import qualified Data.Set as Set
+
 import Control.Monad
   ( (>=>) )
 import Control.Arrow
@@ -595,7 +597,7 @@ getModulesBuildToolsAndDeps pkgIx flags = do
   let sourceFiles = filter (isSourceFile (sourceDirs flags)) sourceFiles0
 
   Just mods <-      return (exposedModules flags)
-           ?>> (return . Just . map moduleName $ sourceFiles)
+           ?>> (return . Just . sortNub . map moduleName $ sourceFiles)
 
   tools <-     return (buildTools flags)
            ?>> (return . Just . neededBuildPrograms $ sourceFiles)
@@ -644,6 +646,10 @@ getModulesBuildToolsAndDeps pkgIx flags = do
                  , dependencies   = deps
                  , otherExts      = exts
                  }
+
+  where
+  sortNub :: Ord a => [a] -> [a]
+  sortNub = Set.toList . Set.fromList
 
 -- | Given a list of imported modules, retrieve the list of dependencies that
 -- provide those modules.


### PR DESCRIPTION
[ fix #7251 ] sort and nub module list inferred by cabal init --lib

This should fix the problem that duplicate entries end up in exposed-modules, e.g. from `Foo.x` and `Foo.hs` (with `alex` as build-tool).

* [x] > Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] > Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
  This fixes a broken behavior, shouldn't need mentioning.
* [x] > The documentation has been updated, if necessary.
  Ditto

> Please also shortly describe how you tested your change. Bonus points for added tests!

Couldn't test yet because of https://github.com/haskell/cabal/issues/7251#issuecomment-763050836 :-(

TODO:
- [ ] test
- [ ] changelog
