### PR TITLE
No crash on bad package file.

### DIFF
--- a/changelog.d/no-index-no-crash
+++ b/changelog.d/no-index-no-crash
@@ -1,0 +1,2 @@
+synopsis: No crash on bad package file (local repo with no index).
+prs: #7254


### PR DESCRIPTION
If we can't decompress a package file and read the cabal file in it, warn the user rather than crash.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog (add file to `changelog.d` directory).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested locally with a local repo sans index containing a few empty ".tar.gz" files.
