### PR TITLE
Address old comment in check code

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -24,7 +24,6 @@ module Distribution.PackageDescription.Check (
         -- * Package Checking
         PackageCheck(..),
         checkPackage,
-        checkConfiguredPackage,
 
         -- ** Checking package contents
         checkPackageFiles,
@@ -146,7 +145,7 @@ checkPackage :: GenericPackageDescription
              -> Maybe PackageDescription
              -> [PackageCheck]
 checkPackage gpkg mpkg =
-     checkConfiguredPackage pkg
+     checkConfiguredPackage
   ++ checkConditionals gpkg
   ++ checkPackageVersions gpkg
   ++ checkDevelopmentOnlyFlags gpkg
@@ -159,20 +158,18 @@ checkPackage gpkg mpkg =
   where
     pkg = fromMaybe (flattenPackageDescription gpkg) mpkg
 
---TODO: make this variant go away
---      we should always know the GenericPackageDescription
-checkConfiguredPackage :: PackageDescription -> [PackageCheck]
-checkConfiguredPackage pkg =
-    checkSanity pkg
- ++ checkFields pkg
- ++ checkLicense pkg
- ++ checkSourceRepos pkg
- ++ checkAllGhcOptions pkg
- ++ checkCCOptions pkg
- ++ checkCxxOptions pkg
- ++ checkCPPOptions pkg
- ++ checkPaths pkg
- ++ checkCabalVersion pkg
+    checkConfiguredPackage :: [PackageCheck]
+    checkConfiguredPackage =
+         checkSanity pkg
+      ++ checkFields pkg
+      ++ checkLicense pkg
+      ++ checkSourceRepos pkg
+      ++ checkAllGhcOptions pkg
+      ++ checkCCOptions pkg
+      ++ checkCxxOptions pkg
+      ++ checkCPPOptions pkg
+      ++ checkPaths pkg
+      ++ checkCabalVersion pkg
 
 
 -- ------------------------------------------------------------

--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -376,7 +376,7 @@ sdistAction :: UserHooks -> SDistFlags -> Args -> IO ()
 sdistAction _hooks flags _args = do
     (_, ppd) <- confPkgDescr emptyUserHooks verbosity Nothing
     let pkg_descr = flattenPackageDescription ppd
-    sdist pkg_descr flags srcPref knownSuffixHandlers
+    sdist ppd pkg_descr flags srcPref knownSuffixHandlers
   where
     verbosity = fromFlag (sDistVerbosity flags)
 


### PR DESCRIPTION
According to the comment in 'checkConfiguredPackage', the
'GenericPackageDescription' should always be available and the function
'checkConfiguredPackage' should be removed. That's how we did it and the
only consumer of that function has 'GenericPackageDescription'
available.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I did not test it at all, since it is only parameter re-order.

Unfortunately, I can't tell if this requires additional documentation for the user, etc...