### PR TITLE
Add 'preferred-versions' support for LocalIndexRepo 

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -279,6 +279,7 @@ Test-Suite unit-tests
       UnitTests.Distribution.Client.UserConfig
       UnitTests.Distribution.Client.ProjectConfig
       UnitTests.Distribution.Client.JobControl
+      UnitTests.Distribution.Client.IndexUtils
       UnitTests.Distribution.Client.IndexUtils.Timestamp
       UnitTests.Distribution.Client.InstallPlan
       UnitTests.Distribution.Solver.Modular.Builder

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -17,11 +17,11 @@ import qualified UnitTests.Distribution.Client.Targets
 import qualified UnitTests.Distribution.Client.UserConfig
 import qualified UnitTests.Distribution.Client.ProjectConfig
 import qualified UnitTests.Distribution.Client.JobControl
+import qualified UnitTests.Distribution.Client.IndexUtils
 import qualified UnitTests.Distribution.Client.IndexUtils.Timestamp
 import qualified UnitTests.Distribution.Client.Init
 import qualified UnitTests.Distribution.Client.InstallPlan
 import qualified UnitTests.Distribution.Client.Get
-
 
 main :: IO ()
 main =
@@ -53,6 +53,8 @@ main =
         UnitTests.Distribution.Client.ProjectConfig.tests
     , testGroup "UnitTests.Distribution.Client.JobControl"
         UnitTests.Distribution.Client.JobControl.tests
+    , testGroup "UnitTests.Distribution.Client.IndexUtils"
+        UnitTests.Distribution.Client.IndexUtils.tests
     , testGroup "UnitTests.Distribution.Client.IndexUtils.Timestamp"
         UnitTests.Distribution.Client.IndexUtils.Timestamp.tests
     , testGroup "UnitTests.Distribution.Client.InstallPlan"

--- a/cabal-install/tests/UnitTests/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/IndexUtils.hs
@@ -1,0 +1,79 @@
+module UnitTests.Distribution.Client.IndexUtils where
+
+import Distribution.Client.IndexUtils
+import qualified Distribution.Compat.NonEmptySet as NES
+import Distribution.Simple.Utils (toUTF8LBS)
+import Distribution.Version
+import Distribution.Types.Dependency
+import Distribution.Types.PackageName
+import Distribution.Types.LibraryName
+
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: [TestTree]
+tests =
+    [ simpleVersionsParserTests
+    ]
+
+simpleVersionsParserTests :: TestTree
+simpleVersionsParserTests = testGroup "Simple preferred-versions Parser Tests"
+    [ testCase "simple deprecation dependency" $ do
+        let prefs = parsePreferredVersionsWarnings (toUTF8LBS "binary < 0.9.0.0 || > 0.9.0.0")
+        prefs @?=
+            [ Right
+                (Dependency
+                    (mkPackageName "binary")
+                    (unionVersionRanges
+                        (earlierVersion $ mkVersion [0,9,0,0])
+                        (laterVersion $ mkVersion [0,9,0,0])
+                    )
+                    (NES.singleton LMainLibName)
+                )
+            ]
+    , testCase "multiple deprecation dependency" $ do
+        let prefs = parsePreferredVersionsWarnings (toUTF8LBS "binary < 0.9.0.0 || > 0.9.0.0\ncontainers == 0.6.4.1")
+        prefs @?=
+            [ Right
+                (Dependency
+                    (mkPackageName "binary")
+                    (unionVersionRanges
+                        (earlierVersion $ mkVersion [0,9,0,0])
+                        (laterVersion $ mkVersion [0,9,0,0])
+                    )
+                    (NES.singleton LMainLibName)
+                )
+            , Right
+                (Dependency
+                    (mkPackageName "containers")
+                    (thisVersion $ mkVersion [0,6,4,1])
+                    (NES.singleton LMainLibName)
+                )
+            ]
+    , testCase "unparsable dependency" $ do
+        let prefs = parsePreferredVersionsWarnings (toUTF8LBS "binary 0.9.0.0 || > 0.9.0.0")
+        prefs @?=
+            [ Left binaryDepParseError
+            ]
+    , testCase "partial parse" $ do
+        let prefs = parsePreferredVersionsWarnings (toUTF8LBS "binary 0.9.0.0 || > 0.9.0.0\ncontainers == 0.6.4.1")
+        prefs @?=
+            [ Left binaryDepParseError
+            , Right
+                (Dependency
+                    (mkPackageName "containers")
+                    (thisVersion $ mkVersion [0,6,4,1])
+                    (NES.singleton LMainLibName)
+                )
+            ]
+    ]
+    where
+        binaryDepParseError = PreferredVersionsParseError
+            { preferredVersionsParsecError = mconcat
+                [ "\"<eitherParsec>\" (line 1, column 8):\n"
+                , "unexpected '0'\n"
+                , "expecting space, white space, opening paren, operator or end of input"
+                ]
+            , preferredVersionsOriginalDependency = "binary 0.9.0.0 || > 0.9.0.0"
+            }

--- a/changelog.d/pr-7295
+++ b/changelog.d/pr-7295
@@ -1,0 +1,13 @@
+synopsis: Add 'preferred-versions' support for LocalIndexRepo
+packages: cabal-install
+prs: #7295
+issues: #7294
+
+description: {
+
+- Previously, the only repo-index-type that reads the preferred-versions file is `RepoRemote`.
+  `LocalIndexRepo` now also supports parsing `preferred-versions` file, main purpose is to write tests.
+  As a nice side-effect, users can provide their own overlay over package sets to restrict or prefer certain package versions.
+
+}
+

--- a/doc/installing-packages.rst
+++ b/doc/installing-packages.rst
@@ -185,6 +185,34 @@ The part of the path will be used to determine the cache key part.
     as described in the previous sections, thus requiring manual construction
     of ``01-index.tar`` file.
 
+It is possible to define ``preferred-versions``, containing additional version constraints
+for deprecating or preferring certain package versions, in the given directory.
+
+For example, if ``/absolute/path/to/directory`` looks like
+::
+
+    /absolute/path/to/directory/
+        foo-0.1.0.0.tar.gz
+        bar-0.2.0.0.tar.gz
+        preferred-versions
+
+then package deprecations and preferences will be taken into account by the solver.
+
+The contents of ``preferred-versions`` is a list of package version constraints, e.g.
+::
+
+    binary < 0.8.0.0 || > 0.8.0.0
+    text == 1.2.0.0
+
+thus, looks similar to a ``package-name.cabal``'s ``build-depends`` section.
+
+.. note::
+    The ``preferred-versions`` file can be used to restrict the package set from Hackage, by preferring
+    certain versions or marking a specific version as deprecated. To achieve this, add a
+    local no-index repository to your ``~/.cabal/config``, where the directory contains your custom
+    ``preferred-versions``. After running ``cabal update``, all ``cabal`` operations will honour the
+    configuration.
+
 Legacy repositories
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Closes #7294 

Generated index parses `preferred-versions` file contents.

The plan is to allow **one** preferred-versions file in the top-level of the LocalRepo location. 

Example:
```
index/
├── base-3.0.3.1.tar.gz
│   └── base.cabal
├── base-3.0.3.2.tar.gz
│   └── base.cabal
├── base-4.0.0.0.tar.gz
│   └── base.cabal
├── template-haskell-2.3.0.0.tar.gz
│   └── template-haskell.cabal
├── template-haskell-2.3.0.1.tar.gz
│   └── template-haskell.cabal
├── template-haskell-2.4.0.0.tar.gz
|   └── template-haskell.cabal
├── noindex.cache
└── preferred-versions
```

where `preferred-versions` contains the accumulated preferred versions, similar to how it looks in https://hackage.haskell.org/packages/preferred.

The `preferred-versions` are serialised into `noindex.cache` and can be read from the cache again.

Implementation: 
Afaict, this requires changing the `Binary` Instance of `NoIndexCacheEntry` and extending it with a field such as `NoIndexCachePreference`, more closely resembling the Constructors of `IndexCacheEntry`.


For the cabal test-suite, the idea is similar: allow **one** preferred-versions file that basically is copied into the right location. example structure:
```
repo/
├── base-3.0.3.1
│   └── base.cabal
├── base-3.0.3.2
│   └── base.cabal
├── base-4.0.0.0
│   └── base.cabal
├── template-haskell-2.3.0.0
│   └── template-haskell.cabal
├── template-haskell-2.3.0.1
│   └── template-haskell.cabal
├── template-haskell-2.4.0.0
|   └── template-haskell.cabal
└── preferred-versions
```

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
