### PR TITLE
Support qualified module renamings

### DIFF
--- a/Cabal/src/Distribution/ModuleName.hs
+++ b/Cabal/src/Distribution/ModuleName.hs
@@ -18,6 +18,7 @@ module Distribution.ModuleName (
         fromString,
         fromComponents,
         components,
+        joinModuleName,
         toFilePath,
         main,
         -- * Internal
@@ -43,6 +44,12 @@ newtype ModuleName = ModuleName ShortText
 
 unModuleName :: ModuleName -> String
 unModuleName (ModuleName s) = fromShortText s
+
+-- Guaranteed to be valid by invariants on the initial module
+-- names (in particular, empty module name is not valid)
+joinModuleName :: ModuleName -> ModuleName -> ModuleName
+joinModuleName a b =
+  ModuleName (toShortText (unModuleName a ++ "." ++ unModuleName b))
 
 instance Binary ModuleName
 instance Structured ModuleName

--- a/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/A.hs
+++ b/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/A.hs
@@ -1,0 +1,2 @@
+module A where
+import Prefix.Quxbaz

--- a/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/QualifiedIncludes.cabal
+++ b/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/QualifiedIncludes.cabal
@@ -1,0 +1,19 @@
+name:                QualifiedIncludes
+version:             0.1.0.0
+license:             BSD3
+author:              Edward Z. Yang
+maintainer:          ezyang@cs.stanford.edu
+build-type:          Simple
+cabal-version:       2.0
+
+library impl
+  build-depends: base
+  exposed-modules: Foobar, Quxbaz
+  hs-source-dirs: impl
+  default-language:    Haskell2010
+
+library good
+  build-depends: base, impl
+  mixins: impl qualified Prefix
+  exposed-modules: A
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/impl/Foobar.hs
+++ b/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/impl/Foobar.hs
@@ -1,0 +1,1 @@
+module Foobar where

--- a/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/impl/Quxbaz.hs
+++ b/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/impl/Quxbaz.hs
@@ -1,0 +1,1 @@
+module Quxbaz where

--- a/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/setup.cabal.out
@@ -1,0 +1,9 @@
+# Setup configure
+Configuring Includes5-0.1.0.0...
+# Setup build
+Preprocessing library 'impl' for Includes5-0.1.0.0..
+Building library 'impl' for Includes5-0.1.0.0..
+Preprocessing library 'good' for Includes5-0.1.0.0..
+Building library 'good' for Includes5-0.1.0.0..
+Preprocessing library 'bad' for Includes5-0.1.0.0..
+Building library 'bad' for Includes5-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/setup.out
+++ b/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/setup.out
@@ -1,0 +1,7 @@
+# Setup configure
+Configuring QualifiedIncludes-0.1.0.0...
+# Setup build
+Preprocessing library 'impl' for QualifiedIncludes-0.1.0.0..
+Building library 'impl' for QualifiedIncludes-0.1.0.0..
+Preprocessing library 'good' for QualifiedIncludes-0.1.0.0..
+Building library 'good' for QualifiedIncludes-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/QualifiedIncludes/setup.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+main = setupAndCabalTest $ do
+    skipUnlessGhcVersion ">= 8.1"
+    setup "configure" []
+    setup "build" []
+    return ()


### PR DESCRIPTION
Qualified module renamings let you bring all modules from a library
into scope, but qualified under some module prefix.  If you write
'pkg qualified Prefix', then if pkg exposes A and B, you will be
able to access them as Prefix.A and Prefix.B.  This functionality
doesn't require any GHC changes; Cabal takes care of desugaring
the qualified syntax into an explicit list of renamings.

Partially address #7290

Signed-off-by: Edward Z. Yang <ezyang@fb.com>


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
