### PR TITLE
Let CI jobs run on all PRs, not just those rooted off master.

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created

--- a/templates/ci-artifacts.template.yml
+++ b/templates/ci-artifacts.template.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created

--- a/templates/ci-bootstrap.template.yml
+++ b/templates/ci-bootstrap.template.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created

--- a/templates/ci-linux.template.yml
+++ b/templates/ci-linux.template.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created

--- a/templates/ci-macos.template.yml
+++ b/templates/ci-macos.template.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created

--- a/templates/ci-quick-jobs.template.yml
+++ b/templates/ci-quick-jobs.template.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created

--- a/templates/ci-windows.template.yml
+++ b/templates/ci-windows.template.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
     types:
       - created


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#7308 Let CI jobs run on all PRs, not just those rooted off master.**

I want to use stack diffs (https://github.com/ezyang/ghstack/) to
submit PRs to Cabal.  Stack diffs, simply by virtue of what they
are, are PRs that are targeted to branches that are not master (they
target an appropriate base that lets GitHub render only the change
in question, even if there are other changes below it.)  However,
I don't get CI jobs on those stack diffs because the current
pull_request branch selector is too restrictive.  This PR makes
it less restrictive.

This PR is submitted using ghstack to validate that this indeed
works.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>