### PR TITLE
Assume list-bin target selectors are for executables

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdListBin.hs
+++ b/cabal-install/src/Distribution/Client/CmdListBin.hs
@@ -77,7 +77,7 @@ listbinAction flags@NixStyleFlags{..} args globalFlags = do
 
     -- elaborate target selectors
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-        =<< readTargetSelectors localPkgs Nothing [target]
+        =<< readTargetSelectors localPkgs (Just ExeKind) [target]
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do

--- a/changelog.d/issue-7326
+++ b/changelog.d/issue-7326
@@ -1,3 +1,4 @@
 synopsis: Assume list-bin target selectors are for executables
 packages: cabal-install
 issues: #7326
+prs: #7335

--- a/changelog.d/issue-7326
+++ b/changelog.d/issue-7326
@@ -1,0 +1,3 @@
+synopsis: Assume list-bin target selectors are for executables
+packages: cabal-install
+issues: #7326


### PR DESCRIPTION
Fixes #7326.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I made a cabal project with an executable same name as the package. list-bin complained of ambiguity. Compiled and ran this version successfully.