### PR TITLE
Actually propagate base16-bytestring 1.0 to all cabal files

### DIFF
--- a/cabal-install/cabal-install.cabal.dev
+++ b/cabal-install/cabal-install.cabal.dev
@@ -212,7 +212,7 @@ library cabal-lib-client
         async      >= 2.0      && < 2.3,
         array      >= 0.4      && < 0.6,
         base       >= 4.8      && < 4.15,
-        base16-bytestring >= 0.1.1 && < 0.2,
+        base16-bytestring >= 0.1.1 && < 1.1.0.0,
         binary     >= 0.7.3    && < 0.9,
         bytestring >= 0.10.6.0 && < 0.11,
         Cabal      == 3.5.*,

--- a/cabal-install/cabal-install.cabal.prod
+++ b/cabal-install/cabal-install.cabal.prod
@@ -267,7 +267,7 @@ executable cabal
         async      >= 2.0      && < 2.3,
         array      >= 0.4      && < 0.6,
         base       >= 4.8      && < 4.15,
-        base16-bytestring >= 0.1.1 && < 0.2,
+        base16-bytestring >= 0.1.1 && < 1.1.0.0,
         binary     >= 0.7.3    && < 0.9,
         bytestring >= 0.10.6.0 && < 0.11,
         Cabal      == 3.5.*,

--- a/cabal-install/cabal-install.cabal.zinza
+++ b/cabal-install/cabal-install.cabal.zinza
@@ -16,7 +16,7 @@ Version:            3.5.0.0
         async      >= 2.0      && < 2.3,
         array      >= 0.4      && < 0.6,
         base       >= 4.8      && < 4.15,
-        base16-bytestring >= 0.1.1 && < 0.2,
+        base16-bytestring >= 0.1.1 && < 1.1.0.0,
         binary     >= 0.7.3    && < 0.9,
         bytestring >= 0.10.6.0 && < 0.11,
         Cabal      == 3.5.*,


### PR DESCRIPTION
#7195 just modified the .cabal file. CI should have caught that but it didn't, I have no idea why. It only caught it later in a backport: https://github.com/haskell/cabal/runs/2149553218

Closes #7077 for real this time