### PR TITLE
Bump Win32 upper bound

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -54,7 +54,7 @@ library
     build-depends: binary >= 0.7 && < 0.9
 
   if os(windows)
-    build-depends: Win32 >= 2.3.0.0 && < 2.11
+    build-depends: Win32 >= 2.3.0.0 && < 2.13
   else
     build-depends: unix  >= 2.6.0.0 && < 2.8
 


### PR DESCRIPTION
Declare compatibility with Win32-2.12.0.0. No functional changes necessary; just a bounds bump.