### PR TITLE
Mark "install --lib" as provisional

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -156,7 +156,8 @@ installCommand = CommandUI
     ++ "If you want the installed executables to be available globally, "
     ++ "make sure that the PATH environment variable contains that directory. "
     ++ "\n\n"
-    ++ "If TARGET is a library, it will be added to the global environment. "
+    ++ "If TARGET is a library and --lib (provisional) is used, "
+    ++ "it will be added to the global environment. "
     ++ "When doing this, cabal will try to build a plan that includes all "
     ++ "the previously installed libraries. This is currently not implemented."
   , commandNotes        = Just $ \pname ->
@@ -681,10 +682,16 @@ warnIfNoExes verbosity buildCtx =
     "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n" <>
     "@ WARNING: Installation might not be completed as desired! @\n" <>
     "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n" <>
-    "Without flags, the command \"cabal install\" doesn't expose" <>
-    " libraries in a usable manner.  You might have wanted to run" <>
-    " \"cabal install --lib " <>
-    unwords (showTargetSelector <$> selectors) <> "\". "
+    "The command \"cabal install [TARGETS]\" doesn't expose libraries.\n" <>
+    "* You might have wanted to add them as dependencies to your package." <>
+    " In this case add \"" <>
+    intercalate ", " (showTargetSelector <$> selectors) <>
+    "\" to the build-depends field(s) of your package's .cabal file.\n" <>
+    "* You might have wanted to add them to a GHC environment. In this case" <>
+    " use \"cabal install --lib " <>
+    unwords (showTargetSelector <$> selectors) <> "\". " <>
+    " The \"--lib\" flag is provisional: see" <>
+    " https://github.com/haskell/cabal/issues/6481 for more information."
   where
     targets    = concat $ Map.elems $ targetsMap buildCtx
     components = fst <$> targets

--- a/cabal-install/src/Distribution/Client/CmdInstall/ClientInstallFlags.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall/ClientInstallFlags.hs
@@ -54,7 +54,8 @@ defaultClientInstallFlags = ClientInstallFlags
 clientInstallOptions :: ShowOrParseArgs -> [OptionField ClientInstallFlags]
 clientInstallOptions _ =
   [ option [] ["lib"]
-    "Install libraries rather than executables from the target package."
+    ( "Install libraries rather than executables from the target package " <>
+      "(provisional, see https://github.com/haskell/cabal/issues/6481 for more information)." )
     cinstInstallLibs (\v flags -> flags { cinstInstallLibs = v })
     trueArg
   , option [] ["package-env", "env"]


### PR DESCRIPTION
Context: for the nth time, that confusing message pointed an user to `--lib` when it should have pointed them to `build-depends` instead  https://old.reddit.com/r/haskell/comments/mj7kv5/monthly_hask_anything_april_2021/gtwlp46/

I rewrote the message so that it suggests `build-depends` first, and requires (or at least encourages) people to know what ghc environments are before using `--lib`.

I also marked `--lib` as provisional, because that's what it is

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
