### PR TITLE
Workaround for failing test due to GHC #19397

### DIFF
--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/demo/Main.hs
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/demo/Main.hs
@@ -1,2 +1,9 @@
+{-# LANGUAGE CPP #-}
 module Main (main) where
-import Demo (main)
+
+-- Qualified due to https://gitlab.haskell.org/ghc/ghc/-/issues/19397
+--
+import qualified Demo (main)
+
+main :: IO ()
+main = Demo.main


### PR DESCRIPTION
Fixes a CI regression merged in #7252 due to https://gitlab.haskell.org/ghc/ghc/-/issues/19397. An issue has been raised to track the followup: https://github.com/haskell/cabal/issues/7363