### PR TITLE
Fixes for GHC 9.2

### DIFF
--- a/Cabal/src/Language/Haskell/Extension.hs
+++ b/Cabal/src/Language/Haskell/Extension.hs
@@ -849,6 +849,18 @@ data KnownExtension =
   -- | Enable linear types.
   | LinearTypes
 
+  -- | Disable the generation of selector functions corresponding to record fields.
+  | NoFieldSelectors
+
+  -- | Enable the use of record dot-accessor and updater syntax
+  | RecordDotSyntax
+
+  -- | Enable the use of the GHC2021 collection of language extensions.
+  | GHC2021
+
+  -- | Enable data types for which an unlifted or levity-polymorphic result kind is inferred.
+  | UnliftedDatatypes
+
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable, Data)
 
 instance Binary KnownExtension

--- a/Cabal/src/Language/Haskell/Extension.hs
+++ b/Cabal/src/Language/Haskell/Extension.hs
@@ -853,11 +853,11 @@ data KnownExtension =
   -- | Enable linear types.
   | LinearTypes
 
-  -- | Disable the generation of selector functions corresponding to record fields.
-  | NoFieldSelectors
+  -- | Enable the generation of selector functions corresponding to record fields.
+  | FieldSelectors
 
   -- | Enable the use of record dot-accessor and updater syntax
-  | RecordDotSyntax
+  | OverloadedRecordDot
 
   -- | Enable data types for which an unlifted or levity-polymorphic result kind is inferred.
   | UnliftedDatatypes

--- a/Cabal/src/Language/Haskell/Extension.hs
+++ b/Cabal/src/Language/Haskell/Extension.hs
@@ -54,6 +54,10 @@ data Language =
   -- <http://www.haskell.org/onlinereport/haskell2010>
   | Haskell2010
 
+  -- | The GHC2021 language as defined by GHC Proposal #380
+  -- <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0380-ghc2021.rst>.
+  | GHC2021
+
   -- | An unknown language, identified by its name.
   | UnknownLanguage String
   deriving (Generic, Show, Read, Eq, Typeable, Data)
@@ -64,7 +68,7 @@ instance Structured Language
 instance NFData Language where rnf = genericRnf
 
 knownLanguages :: [Language]
-knownLanguages = [Haskell98, Haskell2010]
+knownLanguages = [Haskell98, Haskell2010, GHC2021]
 
 instance Pretty Language where
   pretty (UnknownLanguage other) = Disp.text other
@@ -854,9 +858,6 @@ data KnownExtension =
 
   -- | Enable the use of record dot-accessor and updater syntax
   | RecordDotSyntax
-
-  -- | Enable the use of the GHC2021 collection of language extensions.
-  | GHC2021
 
   -- | Enable data types for which an unlifted or levity-polymorphic result kind is inferred.
   | UnliftedDatatypes

--- a/changelog.d/pr-7349
+++ b/changelog.d/pr-7349
@@ -1,0 +1,4 @@
+synopsis: Add language extensions for GHC 9.2
+pr: #7349
+issues: #7312
+decription: { Add support for new language extensions added in 9.2 }

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -186,6 +186,7 @@ syn keyword cabalExtension contained
   \ FunctionalDependencies
   \ GADTSyntax
   \ GADTs
+  \ GHC2021
   \ GHCForeignImportPrim
   \ GeneralisedNewtypeDeriving
   \ GeneralizedNewtypeDeriving
@@ -242,6 +243,7 @@ syn keyword cabalExtension contained
   \ Rank2Types
   \ RankNTypes
   \ RebindableSyntax
+  \ RecordDotSyntax
   \ RecordPuns
   \ RecordWildCards
   \ RecursiveDo
@@ -273,6 +275,7 @@ syn keyword cabalExtension contained
   \ UndecidableInstances
   \ UndecidableSuperClasses
   \ UnicodeSyntax
+  \ UnliftedDatatypes
   \ UnliftedFFITypes
   \ UnliftedNewtypes
   \ ViewPatterns
@@ -313,6 +316,7 @@ syn keyword cabalExtension contained
   \ NoExplicitNamespaces
   \ NoExtendedDefaultRules
   \ NoExtensibleRecords
+  \ NoFieldSelectors
   \ NoFlexibleContexts
   \ NoFlexibleInstances
   \ NoForeignFunctionInterface


### PR DESCRIPTION
 * Treat `GHC2021` as a language rather than a language extension
 * Fix the spellings of the `FieldSelectors` and `OverloadedRecordDot` extensions

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
