### PR TITLE
Documented limitation with compiler field in project files 

### DIFF
--- a/changelog.d/issue-7370
+++ b/changelog.d/issue-7370
@@ -1,0 +1,3 @@
+synopsis: Documented limitation to compiler section of cabal project files
+issues:
+  #7370

--- a/changelog.d/issue-7370
+++ b/changelog.d/issue-7370
@@ -1,3 +1,0 @@
-synopsis: Documented limitation to compiler section of cabal project files
-issues:
-  #7370

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -703,9 +703,8 @@ feature was added.
 
     The command line variant of this flag is ``--compiler=ghc``.
 
-    At the moment, it's not possible to set :cfg-field:`compiler` on a
-    per-package basis, but eventually we plan on relaxing this
-    restriction. If this is something you need, give us a shout.
+    It's not possible to set :cfg-field:`compiler` on a
+    per-package basis. 
 
 .. cfg-field:: tests: boolean
                --enable-tests

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -624,9 +624,8 @@ feature was added.
     build trees for different versions of GHC without clobbering each
     other.
 
-    At the moment, it's not possible to set :cfg-field:`with-compiler` on a
-    per-package basis, but eventually we plan on relaxing this
-    restriction. If this is something you need, give us a shout.
+    It's not possible to set :cfg-field:`with-compiler` on a
+    per-package basis. 
 
     The command line variant of this flag is
     ``--with-compiler=ghc-7.8``; there is also a short version

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -703,6 +703,10 @@ feature was added.
 
     The command line variant of this flag is ``--compiler=ghc``.
 
+    At the moment, it's not possible to set :cfg-field:`compiler` on a
+    per-package basis, but eventually we plan on relaxing this
+    restriction. If this is something you need, give us a shout.
+
 .. cfg-field:: tests: boolean
                --enable-tests
                --disable-tests


### PR DESCRIPTION
Added a declaimer (copied and changed) from the `with-compiler` section to the `compiler` section of the cabal project description part of the docs to assist with #7370 


* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
