### PR TITLE
Parse program options for local packages

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -200,6 +200,7 @@ Maciej Bielecki          <maciej.bielecki@skubacz.pl>
 Maciek Makowski          <maciek.makowski@gmail.com>
 Magnus Jonsson           <magnus@smartelectronix.com>
 Malcolm Wallace          <Malcolm.Wallace@me.com>
+Marcin Szamotulski       <coot@coot.me>
 Mark Lentczner           <markl@glyphic.com>
 Mark Weber               <marco-oweber@gmx.de>
 Markus Pfeiffer          <markusp@mcs.st-andrews.ac.uk>

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1162,6 +1162,15 @@ legacyPackageConfigFieldDescrs =
       []
   . commandOptionsToFields
   ) (benchmarkOptions' ParseArgs)
+  ++
+    programOptionsFieldDescrs
+       (configProgramArgs . legacyConfigureFlags)
+       (\args pkgconf -> pkgconf {
+           legacyConfigureFlags = (legacyConfigureFlags pkgconf) {
+             configProgramArgs  = args
+           }
+         }
+       )
 
 
   where


### PR DESCRIPTION
This is a simple attempt to fix #3579

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
Documentation needs to be updated, but I'd like first see if this is an acceptable solution.

Please also shortly describe how you tested your change. Bonus points for added tests!
Manual testing by setting `ghc-options` in a `cabal.project.local` file.