### PR TITLE
 Fix --only-download making install fail

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns        #-}
 
 -- | cabal-install CLI command: build
 --
@@ -46,7 +45,8 @@ import Distribution.Types.PackageId
 import Distribution.Client.ProjectConfig
          ( ProjectPackageLocation(..)
          , fetchAndReadSourcePackages
-         )
+         , projectConfigWithBuilderRepoContext
+         , resolveBuildTimeSettings, withProjectOrGlobalConfig )
 import Distribution.Client.NixStyleOptions
          ( NixStyleFlags (..), nixStyleOptions, defaultNixStyleFlags )
 import Distribution.Client.ProjectFlags (ProjectFlags (..))
@@ -78,9 +78,6 @@ import Distribution.Solver.Types.PackageConstraint
          ( PackageProperty(..) )
 import Distribution.Client.IndexUtils
          ( getSourcePackages, getInstalledPackages )
-import Distribution.Client.ProjectConfig
-         ( projectConfigWithBuilderRepoContext
-         , resolveBuildTimeSettings, withProjectOrGlobalConfig )
 import Distribution.Client.ProjectPlanning
          ( storePackageInstallDirs' )
 import Distribution.Client.ProjectPlanning.Types

--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -382,10 +382,11 @@ installAction flags@NixStyleFlags { extraFlags = clientInstallFlags', .. } targe
     -- Now that we built everything we can do the installation part.
     -- First, figure out if / what parts we want to install:
     let
-      dryRun = buildSettingDryRun $ buildSettings baseCtx
+      dryRun = buildSettingDryRun (buildSettings baseCtx)
+            || buildSettingOnlyDownload (buildSettings baseCtx)
 
     -- Then, install!
-    when (not dryRun) $
+    unless dryRun $
       if installLibs
       then installLibraries verbosity
            buildCtx compiler packageDbs progDb envFile nonGlobalEnvEntries

--- a/cabal-install/src/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding.hs
@@ -653,6 +653,14 @@ rebuildTarget verbosity
               sharedPackageConfig
               plan rpkg@(ReadyPackage pkg)
               pkgBuildStatus
+    -- Technically, doing the --only-download filtering only in this function is
+    -- not perfect. We could also prune the plan at an earlier stage, like it's
+    -- done with --only-dependencies. But...
+    --   * the benefit would be minimal (practically just avoiding to print the
+    --     "requires build" parts of the plan)
+    --   * we currently don't have easy access to the BuildStatus of packages
+    --     in the pruning phase
+    --   * we still have to check it here to avoid performing successive phases
     | buildSettingOnlyDownload buildSettings = do
         case pkgBuildStatus of
           BuildStatusDownload ->


### PR DESCRIPTION
Plus a comment and some clean-up

Fixes #7351

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog). (fixes a not-yet-released feature)
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I ran `cabal install --only-download`. No test though