### PR TITLE
Deduplicate config file path calculation in test.

### DIFF
--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -160,6 +160,7 @@ test-suite hackage-tests
     , bytestring
     , Cabal
     , Cabal-tree-diff
+    , cabal-install
     , containers
     , deepseq
     , directory


### PR DESCRIPTION
Tested with `cabal test Cabal-tests:hackage-tests` (*man* does Cabal have many test suites).

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
