### PR TITLE
Prefer canonicalized path when guessing tools from GHC path

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -240,7 +240,7 @@ guessToolFromGhcPath tool ghcProg verbosity searchpath
                              | otherwise = [guessGhcVersioned dir suf,
                                             guessVersioned dir suf,
                                             guessNormal dir]
-           -- oder matters here, see https://github.com/haskell/cabal/issues/7390
+           -- order matters here, see https://github.com/haskell/cabal/issues/7390
            guesses = (if real_path == given_path
                         then []
                         else mkGuesses real_dir real_suf)

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -240,10 +240,11 @@ guessToolFromGhcPath tool ghcProg verbosity searchpath
                              | otherwise = [guessGhcVersioned dir suf,
                                             guessVersioned dir suf,
                                             guessNormal dir]
-           guesses = mkGuesses given_dir given_suf ++
-                            if real_path == given_path
-                                then []
-                                else mkGuesses real_dir real_suf
+           -- oder matters here, see https://github.com/haskell/cabal/issues/7390
+           guesses = (if real_path == given_path
+                        then []
+                        else mkGuesses real_dir real_suf)
+                     ++ mkGuesses given_dir given_suf
        info verbosity $ "looking for tool " ++ toolname
          ++ " near compiler in " ++ given_dir
        debug verbosity $ "candidate locations: " ++ show guesses

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectory/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectory/setup.cabal.out
@@ -1,3 +1,3 @@
 # Setup configure
 Configuring SameDirectory-0.1.0.0...
-cabal: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc is version <GHCVER> <ROOT>/./ghc-pkg is version 9999999
+cabal: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc is version <GHCVER> <ROOT>/ghc-pkg is version 9999999

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectory/setup.out
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectory/setup.out
@@ -1,3 +1,3 @@
 # Setup configure
 Configuring SameDirectory-0.1.0.0...
-setup: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc is version <GHCVER> <ROOT>/./ghc-pkg is version 9999999
+setup: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc is version <GHCVER> <ROOT>/ghc-pkg is version 9999999

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryGhcVersion/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryGhcVersion/setup.cabal.out
@@ -1,3 +1,3 @@
 # Setup configure
 Configuring SameDirectory-0.1.0.0...
-cabal: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc-7.10 is version <GHCVER> <ROOT>/./ghc-pkg-ghc-7.10 is version 9999999
+cabal: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc-7.10 is version <GHCVER> <ROOT>/ghc-pkg-ghc-7.10 is version 9999999

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryGhcVersion/setup.out
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryGhcVersion/setup.out
@@ -1,3 +1,3 @@
 # Setup configure
 Configuring SameDirectory-0.1.0.0...
-setup: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc-7.10 is version <GHCVER> <ROOT>/./ghc-pkg-ghc-7.10 is version 9999999
+setup: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc-7.10 is version <GHCVER> <ROOT>/ghc-pkg-ghc-7.10 is version 9999999

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryVersion/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryVersion/setup.cabal.out
@@ -1,3 +1,3 @@
 # Setup configure
 Configuring SameDirectory-0.1.0.0...
-cabal: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc-7.10 is version <GHCVER> <ROOT>/./ghc-pkg-7.10 is version 9999999
+cabal: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc-7.10 is version <GHCVER> <ROOT>/ghc-pkg-7.10 is version 9999999

--- a/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryVersion/setup.out
+++ b/cabal-testsuite/PackageTests/GhcPkgGuess/SameDirectoryVersion/setup.out
@@ -1,3 +1,3 @@
 # Setup configure
 Configuring SameDirectory-0.1.0.0...
-setup: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc-7.10 is version <GHCVER> <ROOT>/./ghc-pkg-7.10 is version 9999999
+setup: Version mismatch between ghc and ghc-pkg: <ROOT>/./ghc-7.10 is version <GHCVER> <ROOT>/ghc-pkg-7.10 is version 9999999

--- a/changelog.d/pr-7392
+++ b/changelog.d/pr-7392
@@ -1,0 +1,44 @@
+synopsis: Prefer canonicalized path when guessing tools from GHC path
+packages: Cabal
+prs: #7392
+issues: #7390
+
+description: {
+
+Motivation
+----------
+Often times, the user facing `ghc` binary is
+symlinked by other forces, such as the package manager,
+tooling like ghcup etc. As such, the naming convention
+(version suffix in particular) may not align with the
+assumptions made in Cabal and it may find an incorrect ghc-pkg.
+
+See:
+  - https://github.com/haskell/cabal/issues/7390
+  - https://gitlab.haskell.org/ghc/ghc/-/issues/18807
+  - https://gitlab.haskell.org/haskell/ghcup-hs/-/issues/73
+
+Solution
+--------
+Guessing the ghc-pkg path is already a hack and will be solved
+more appropriately in the future, see
+  - https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4214
+  - https://gitlab.haskell.org/ghc/ghc/-/snippets/2710
+These patches will solve the issue for future GHC versions.
+
+As such, this patch provides a workaround for
+older, already existing GHC versions by first always
+following the symbolic link of the ghc binary (if it is one)
+and prefering its target directory as the guess lookup
+location.
+
+Rationale
+---------
+The canonicalized path of the ghc binary usually points to the
+bin/ directory unpacked from a bindist, which is less likely to be
+tampered with by distributions and tools. As such, prefering the
+canoncialized path should get us more robust results.
+
+}
+
+


### PR DESCRIPTION
Motivation
----------
Often times, the user facing `ghc` binary is
symlinked by other forces, such as the package manager,
tooling like ghcup etc. As such, the naming convention
(version suffix in particular) may not align with the
assumptions made in Cabal and it may find an incorrect ghc-pkg.

See:
  - https://github.com/haskell/cabal/issues/7390
  - https://gitlab.haskell.org/ghc/ghc/-/issues/18807
  - https://gitlab.haskell.org/haskell/ghcup-hs/-/issues/73

Solution
--------
Guessing the ghc-pkg path is already a hack and will be solved
more appropriately in the future, see
  - https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4214
  - https://gitlab.haskell.org/ghc/ghc/-/snippets/2710
These patches will solve the issue for future GHC versions.

As such, this patch provides a workaround for
older, already existing GHC versions by first always
following the symbolic link of the ghc binary (if it is one)
and prefering its target directory as the guess lookup
location.

Rationale
---------
The canonicalized path of the ghc binary usually points to the
bin/ directory unpacked from a bindist, which is less likely to be
tampered with by distributions and tools. As such, prefering the
canoncialized path should get us more robust results.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
