### PR TITLE
Set exe as default component for `cabal run` and `cabal list-bin`

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdListBin.hs
+++ b/cabal-install/src/Distribution/Client/CmdListBin.hs
@@ -6,6 +6,14 @@
 module Distribution.Client.CmdListBin (
     listbinCommand,
     listbinAction,
+
+    -- * Internals exposed for testing
+    selectPackageTargets,
+    selectComponentTarget,
+    noComponentsProblem,
+    matchesMultipleProblem,
+    multipleTargetsProblem,
+    componentNotRightKindProblem
 ) where
 
 import Distribution.Client.Compat.Prelude

--- a/cabal-install/src/Distribution/Client/CmdListBin.hs
+++ b/cabal-install/src/Distribution/Client/CmdListBin.hs
@@ -210,17 +210,21 @@ selectPackageTargets :: TargetSelector
                      -> [AvailableTarget k] -> Either ListBinTargetProblem [k]
 selectPackageTargets targetSelector targets
 
-    -- If there is exactly one buildable executable then we select that
+  -- If there is a single executable component, select that. See #7403
   | [target] <- targetsExesBuildable
   = Right [target]
 
+  -- Otherwise, if there is a single executable-like component left, select that.
+  | [target] <- targetsExeLikesBuildable
+  = Right [target]
+
     -- but fail if there are multiple buildable executables.
-  | not (null targetsExesBuildable)
-  = Left (matchesMultipleProblem targetSelector targetsExesBuildable')
+  | not (null targetsExeLikesBuildable)
+  = Left (matchesMultipleProblem targetSelector targetsExeLikesBuildable')
 
     -- If there are executables but none are buildable then we report those
-  | not (null targetsExes)
-  = Left (TargetProblemNoneEnabled targetSelector targetsExes)
+  | not (null targetsExeLikes')
+  = Left (TargetProblemNoneEnabled targetSelector targetsExeLikes')
 
     -- If there are no executables but some other targets then we report that
   | not (null targets)
@@ -230,14 +234,19 @@ selectPackageTargets targetSelector targets
   | otherwise
   = Left (TargetProblemNoTargets targetSelector)
   where
-    -- Targets that can be executed
-    targetsExecutableLike =
-      concatMap (\kind -> filterTargetsKind kind targets)
-                [ExeKind, TestKind, BenchKind]
-    (targetsExesBuildable,
-     targetsExesBuildable') = selectBuildableTargets' targetsExecutableLike
+    -- Targets that are precisely executables
+    targetsExes = filterTargetsKind ExeKind targets
+    targetsExesBuildable = selectBuildableTargets targetsExes
 
-    targetsExes             = forgetTargetsDetail targetsExecutableLike
+    -- Any target that could be executed
+    targetsExeLikes = targetsExes
+                   ++ filterTargetsKind TestKind targets
+                   ++ filterTargetsKind BenchKind targets
+
+    (targetsExeLikesBuildable,
+     targetsExeLikesBuildable') = selectBuildableTargets' targetsExeLikes
+
+    targetsExeLikes'             = forgetTargetsDetail targetsExeLikes
 
 
 -- | For a 'TargetComponent' 'TargetSelector', check if the component can be

--- a/cabal-install/src/Distribution/Client/CmdRun.hs
+++ b/cabal-install/src/Distribution/Client/CmdRun.hs
@@ -480,17 +480,21 @@ selectPackageTargets :: TargetSelector
                      -> [AvailableTarget k] -> Either RunTargetProblem [k]
 selectPackageTargets targetSelector targets
 
-    -- If there is exactly one buildable executable then we select that
+  -- If there is a single executable component, select that. See #7403
   | [target] <- targetsExesBuildable
   = Right [target]
 
-    -- but fail if there are multiple buildable executables.
-  | not (null targetsExesBuildable)
-  = Left (matchesMultipleProblem targetSelector targetsExesBuildable')
+  -- Otherwise, if there is a single executable-like component left, select that.
+  | [target] <- targetsExeLikesBuildable
+  = Right [target]
+
+  -- but fail if there are multiple buildable executables.
+  | not (null targetsExeLikesBuildable)
+  = Left (matchesMultipleProblem targetSelector targetsExeLikesBuildable')
 
     -- If there are executables but none are buildable then we report those
-  | not (null targetsExes)
-  = Left (TargetProblemNoneEnabled targetSelector targetsExes)
+  | not (null targetsExeLikes')
+  = Left (TargetProblemNoneEnabled targetSelector targetsExeLikes')
 
     -- If there are no executables but some other targets then we report that
   | not (null targets)
@@ -500,14 +504,19 @@ selectPackageTargets targetSelector targets
   | otherwise
   = Left (TargetProblemNoTargets targetSelector)
   where
-    -- Targets that can be executed
-    targetsExecutableLike =
-      concatMap (\kind -> filterTargetsKind kind targets)
-                [ExeKind, TestKind, BenchKind]
-    (targetsExesBuildable,
-     targetsExesBuildable') = selectBuildableTargets' targetsExecutableLike
+    -- Targets that are precisely executables
+    targetsExes = filterTargetsKind ExeKind targets
+    targetsExesBuildable = selectBuildableTargets targetsExes
 
-    targetsExes             = forgetTargetsDetail targetsExecutableLike
+    -- Any target that could be executed
+    targetsExeLikes = targetsExes
+                   ++ filterTargetsKind TestKind targets
+                   ++ filterTargetsKind BenchKind targets
+
+    (targetsExeLikesBuildable,
+     targetsExeLikesBuildable') = selectBuildableTargets' targetsExeLikes
+
+    targetsExeLikes'             = forgetTargetsDetail targetsExeLikes
 
 
 -- | For a 'TargetComponent' 'TargetSelector', check if the component can be

--- a/cabal-install/src/Distribution/Client/CmdRun.hs
+++ b/cabal-install/src/Distribution/Client/CmdRun.hs
@@ -121,8 +121,9 @@ runCommand = CommandUI
 
       ++ "Any executable-like component in any package in the project can be "
       ++ "specified. A package can be specified if contains just one "
-      ++ "executable-like. The default is to use the package in the current "
-      ++ "directory if it contains just one executable-like.\n\n"
+      ++ "executable-like, preferring a single executable. The default is to "
+      ++ "use the package in the current directory if it contains just one "
+      ++ "executable-like.\n\n"
 
       ++ "Extra arguments can be passed to the program, but use '--' to "
       ++ "separate arguments for the program from arguments for " ++ pname

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -865,6 +865,17 @@ testTargetProblemsRepl config reportSubCase = do
 testTargetProblemsRun :: ProjectConfig -> (String -> IO ()) -> Assertion
 testTargetProblemsRun config reportSubCase = do
 
+    reportSubCase "one-of-each"
+    do (_,elaboratedPlan,_) <- planProject "targets/one-of-each" config
+       assertProjectDistinctTargets
+         elaboratedPlan
+         CmdRun.selectPackageTargets
+         CmdRun.selectComponentTarget
+         [ TargetPackage TargetExplicitNamed ["p-0.1"] Nothing
+         ]
+         [ ("p-0.1-inplace-p1",      CExeName   "p1")
+         ]
+
     reportSubCase "multiple-exes"
     assertProjectTargetProblems
       "targets/multiple-exes" config

--- a/cabal-install/tests/IntegrationTests2/targets/one-of-each/cabal.project
+++ b/cabal-install/tests/IntegrationTests2/targets/one-of-each/cabal.project
@@ -1,0 +1,1 @@
+packages: ./

--- a/cabal-install/tests/IntegrationTests2/targets/one-of-each/p.cabal
+++ b/cabal-install/tests/IntegrationTests2/targets/one-of-each/p.cabal
@@ -1,0 +1,26 @@
+name: p
+version: 0.1
+build-type: Simple
+cabal-version: >= 1.10
+
+executable p1
+  main-is:  P1.hs
+  build-depends: base
+
+benchmark p2
+  type: exitcode-stdio-1.0
+  main-is:  P2.hs
+  build-depends: base
+
+test-suite p3
+  type: exitcode-stdio-1.0
+  main-is:  P3.hs
+  build-depends: base
+
+library p4
+  exposed-modules: P4
+  build-depends: base
+
+foreign-library libp
+  type: native-shared
+  other-modules: FLib

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -194,6 +194,19 @@ Tests and benchmarks are also treated as executables.
 
 See `the v2-build section <#cabal-v2-build>`__ for the target syntax.
 
+When ``TARGET`` is one of the following:
+
+- A component target: execute the specified executable, benchmark or test suite
+
+- A package target:
+   1. If the package has exactly one executable component, it will be selected.
+   2. If the package has multiple executable components, an error is raised.
+   3. If the package has exactly one test or benchmark component, it will be selected.
+   4. Otherwise an issue is raised
+
+- Empty target: Same as package target, implicitly using the package from the current
+  working directory.
+
 Except in the case of the empty target, the strings after it will be
 passed to the executable as arguments.
 


### PR DESCRIPTION
Resolves #7403

The modification was tested against https://github.com/dminuoso/cabal-repro and the added integration test.

Documentation will be updated tomorrow.

---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
