### PR TITLE
Explain why an older cabal-version is used

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -35,6 +35,12 @@ Once you have an empty directory we can initialize our package:
 
     $ cabal init --cabal-version=2.4 --license=NONE -p myfirstapp
 
+.. note:: ``cabal-version`` refers to the
+          `version of the .cabal file format specification <file-format-changelog.html>`__,
+          that can be different from the versions of the cabal library and tool
+          in use. It is common to use a slightly older cabal-version, to strike
+          a compromise between feature availability and backward compatibility.
+
 This will generate the following files:
 
 .. code-block:: console


### PR DESCRIPTION
@Mergifyio backport 3.6

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
