### PR TITLE
remove coverage from main cabal.project, add to dedicated file

### DIFF
--- a/cabal.project.coverage
+++ b/cabal.project.coverage
@@ -28,34 +28,49 @@ allow-newer: windns-0.1.0.1:base
 
 -- avoiding extra dependencies
 constraints: rere -rere-cfg
-constraints: these -assoc
+constraints: these
 
--- So us hackers get all the assertion failures early:
+-- NOTE: for library coverage in multi-project builds,
+-- see:
 --
--- NOTE: currently commented out, see
--- https://github.com/haskell/cabal/issues/3911
--- as a workaround we specify it for each package individually:
+-- * https://github.com/haskell/cabal/issues/6440
+-- * https://github.com/haskell/cabal/issues/5213#issuecomment-586517129
 --
--- program-options
---   ghc-options: -fno-ignore-asserts
+-- We must mask coverage for dependencies of `cabal-install` in
+-- multiproject settings in order to generate coverage for
+-- the `cabal-install` library
 --
 package Cabal
   ghc-options: -fno-ignore-asserts
+  coverage: False
+  library-coverage: False
 
 package cabal-testsuite
   ghc-options: -fno-ignore-asserts
+  coverage: False
+  library-coverage: False
 
 package Cabal-QuickCheck
   ghc-options: -fno-ignore-asserts
+  coverage: False
+  library-coverage: False
 
 package Cabal-tree-diff
   ghc-options: -fno-ignore-asserts
+  coverage: False
+  library-coverage: False
 
 package Cabal-described
   ghc-options: -fno-ignore-asserts
+  coverage: False
+  library-coverage: False
 
 package cabal-install-solver
   ghc-options: -fno-ignore-asserts
+  coverage: False
+  library-coverage: False
 
 package cabal-install
   ghc-options: -fno-ignore-asserts
+  coverage: True
+  library-coverage: True


### PR DESCRIPTION
This PR addresses #7384 by deliberately keeping the project coverage details encapsulated in a dedicated `.project` file so the main build will not result in .tix file litter. 