### PR TITLE
Modernise `outdated` command

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -140,7 +140,7 @@ library
         Distribution.Client.ManpageFlags
         Distribution.Client.Nix
         Distribution.Client.NixStyleOptions
-        Distribution.Client.Outdated
+        Distribution.Client.CmdOutdated
         Distribution.Client.PackageHash
         Distribution.Client.ParseUtils
         Distribution.Client.ProjectBuilding

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -85,6 +85,7 @@ library
         Distribution.Client.CmdInstall.ClientInstallTargetSelector
         Distribution.Client.CmdLegacy
         Distribution.Client.CmdListBin
+        Distribution.Client.CmdOutdated
         Distribution.Client.CmdRepl
         Distribution.Client.CmdRun
         Distribution.Client.CmdSdist
@@ -140,7 +141,6 @@ library
         Distribution.Client.ManpageFlags
         Distribution.Client.Nix
         Distribution.Client.NixStyleOptions
-        Distribution.Client.CmdOutdated
         Distribution.Client.PackageHash
         Distribution.Client.ParseUtils
         Distribution.Client.ProjectBuilding

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -28,7 +28,6 @@ import Distribution.Client.Setup
          , FetchFlags(..), fetchCommand
          , FreezeFlags(..), freezeCommand
          , genBoundsCommand
-         , OutdatedFlags(..), outdatedCommand
          , GetFlags(..), getCommand, unpackCommand
          , checkCommand
          , formatCommand
@@ -87,6 +86,7 @@ import qualified Distribution.Client.CmdExec      as CmdExec
 import qualified Distribution.Client.CmdClean     as CmdClean
 import qualified Distribution.Client.CmdSdist     as CmdSdist
 import qualified Distribution.Client.CmdListBin   as CmdListBin
+import qualified Distribution.Client.CmdOutdated  as CmdOutdated
 import           Distribution.Client.CmdLegacy
 
 import Distribution.Client.Install            (install)
@@ -94,7 +94,6 @@ import Distribution.Client.Configure          (configure, writeConfigFlags)
 import Distribution.Client.Fetch              (fetch)
 import Distribution.Client.Freeze             (freeze)
 import Distribution.Client.GenBounds          (genBounds)
-import Distribution.Client.CmdOutdated           (outdated)
 import Distribution.Client.Check as Check     (check)
 --import Distribution.Client.Clean            (clean)
 import qualified Distribution.Client.Upload as Upload
@@ -240,7 +239,7 @@ mainWorker args = do
       , regularCmd initCommand initAction
       , regularCmd userConfigCommand userConfigAction
       , regularCmd genBoundsCommand genBoundsAction
-      , regularCmd outdatedCommand outdatedAction
+      , regularCmd CmdOutdated.outdatedCommand CmdOutdated.outdatedAction
       , wrapperCmd hscolourCommand hscolourVerbosity hscolourDistPref
       , hiddenCmd  formatCommand formatAction
       , hiddenCmd  actAsSetupCommand actAsSetupAction
@@ -777,17 +776,6 @@ genBoundsAction freezeFlags _extraArgs globalFlags = do
                 repoContext
                 comp platform progdb
                 globalFlags' freezeFlags
-
-outdatedAction :: OutdatedFlags -> [String] -> GlobalFlags -> IO ()
-outdatedAction outdatedFlags _extraArgs globalFlags = do
-  let verbosity = fromFlag (outdatedVerbosity outdatedFlags)
-  config <- loadConfigOrSandboxConfig verbosity globalFlags
-  let configFlags  = savedConfigureFlags config
-      globalFlags' = savedGlobalFlags config `mappend` globalFlags
-  (comp, platform, _progdb) <- configCompilerAux' configFlags
-  withRepoContext verbosity globalFlags' $ \repoContext ->
-    outdated verbosity outdatedFlags repoContext
-             comp platform
 
 uploadAction :: UploadFlags -> [String] -> Action
 uploadAction uploadFlags extraArgs globalFlags = do

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -94,7 +94,7 @@ import Distribution.Client.Configure          (configure, writeConfigFlags)
 import Distribution.Client.Fetch              (fetch)
 import Distribution.Client.Freeze             (freeze)
 import Distribution.Client.GenBounds          (genBounds)
-import Distribution.Client.Outdated           (outdated)
+import Distribution.Client.CmdOutdated           (outdated)
 import Distribution.Client.Check as Check     (check)
 --import Distribution.Client.Clean            (clean)
 import qualified Distribution.Client.Upload as Upload

--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
--- Module      :  Distribution.Client.Outdated
+-- Module      :  Distribution.Client.CmdOutdated
 -- Maintainer  :  cabal-devel@haskell.org
 -- Portability :  portable
 --
@@ -9,7 +9,7 @@
 -- dependencies in the package description file or freeze file.
 -----------------------------------------------------------------------------
 
-module Distribution.Client.Outdated ( outdated
+module Distribution.Client.CmdOutdated ( outdated
                                     , ListOutdatedSettings(..), listOutdated )
 where
 

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -34,7 +34,6 @@ module Distribution.Client.Setup
     , fetchCommand, FetchFlags(..)
     , freezeCommand, FreezeFlags(..)
     , genBoundsCommand
-    , outdatedCommand, OutdatedFlags(..), IgnoreMajorVersionBumps(..)
     , getCommand, unpackCommand, GetFlags(..)
     , checkCommand
     , formatCommand
@@ -106,8 +105,6 @@ import Distribution.Simple.InstallDirs
          , toPathTemplate, fromPathTemplate, combinePathTemplate )
 import Distribution.Version
          ( Version, mkVersion )
-import Distribution.Package
-         ( PackageName )
 import Distribution.Types.GivenComponent
          ( GivenComponent(..) )
 import Distribution.Types.PackageVersionConstraint
@@ -600,7 +597,7 @@ configCompilerAux' configFlags =
 data ConfigExFlags = ConfigExFlags {
     configCabalVersion  :: Flag Version,
     configAppend        :: Flag Bool,
-    configBackup        :: Flag Bool, 
+    configBackup        :: Flag Bool,
     configExConstraints :: [(UserConstraint, ConstraintSource)],
     configPreferences   :: [PackageVersionConstraint],
     configSolver        :: Flag PreSolver,
@@ -1133,123 +1130,6 @@ genBoundsCommand = CommandUI {
      optionVerbosity freezeVerbosity (\v flags -> flags { freezeVerbosity = v })
      ]
   }
-
--- ------------------------------------------------------------
--- * 'outdated' command
--- ------------------------------------------------------------
-
-data IgnoreMajorVersionBumps = IgnoreMajorVersionBumpsNone
-                             | IgnoreMajorVersionBumpsAll
-                             | IgnoreMajorVersionBumpsSome [PackageName]
-
-instance Monoid IgnoreMajorVersionBumps where
-  mempty  = IgnoreMajorVersionBumpsNone
-  mappend = (<>)
-
-instance Semigroup IgnoreMajorVersionBumps where
-  IgnoreMajorVersionBumpsNone       <> r                               = r
-  l@IgnoreMajorVersionBumpsAll      <> _                               = l
-  l@(IgnoreMajorVersionBumpsSome _) <> IgnoreMajorVersionBumpsNone     = l
-  (IgnoreMajorVersionBumpsSome   _) <> r@IgnoreMajorVersionBumpsAll    = r
-  (IgnoreMajorVersionBumpsSome   a) <> (IgnoreMajorVersionBumpsSome b) =
-    IgnoreMajorVersionBumpsSome (a ++ b)
-
-data OutdatedFlags = OutdatedFlags {
-  outdatedVerbosity     :: Flag Verbosity,
-  outdatedFreezeFile    :: Flag Bool,
-  outdatedNewFreezeFile :: Flag Bool,
-  outdatedProjectFile   :: Flag FilePath,
-  outdatedSimpleOutput  :: Flag Bool,
-  outdatedExitCode      :: Flag Bool,
-  outdatedQuiet         :: Flag Bool,
-  outdatedIgnore        :: [PackageName],
-  outdatedMinor         :: Maybe IgnoreMajorVersionBumps
-  }
-
-defaultOutdatedFlags :: OutdatedFlags
-defaultOutdatedFlags = OutdatedFlags {
-  outdatedVerbosity     = toFlag normal,
-  outdatedFreezeFile    = mempty,
-  outdatedNewFreezeFile = mempty,
-  outdatedProjectFile   = mempty,
-  outdatedSimpleOutput  = mempty,
-  outdatedExitCode      = mempty,
-  outdatedQuiet         = mempty,
-  outdatedIgnore        = mempty,
-  outdatedMinor         = mempty
-  }
-
-outdatedCommand :: CommandUI OutdatedFlags
-outdatedCommand = CommandUI {
-  commandName = "outdated",
-  commandSynopsis = "Check for outdated dependencies",
-  commandDescription  = Just $ \_ -> wrapText $
-    "Checks for outdated dependencies in the package description file "
-    ++ "or freeze file",
-  commandNotes = Nothing,
-  commandUsage = usageFlags "outdated",
-  commandDefaultFlags = defaultOutdatedFlags,
-  commandOptions      = \ _ -> [
-    optionVerbosity outdatedVerbosity
-      (\v flags -> flags { outdatedVerbosity = v })
-
-    ,option [] ["freeze-file", "v1-freeze-file"]
-     "Act on the freeze file"
-     outdatedFreezeFile (\v flags -> flags { outdatedFreezeFile = v })
-     trueArg
-
-    ,option [] ["v2-freeze-file", "new-freeze-file"]
-     "Act on the new-style freeze file (default: cabal.project.freeze)"
-     outdatedNewFreezeFile (\v flags -> flags { outdatedNewFreezeFile = v })
-     trueArg
-
-    ,option [] ["project-file"]
-     "Act on the new-style freeze file named PROJECTFILE.freeze rather than the default cabal.project.freeze"
-     outdatedProjectFile (\v flags -> flags { outdatedProjectFile = v })
-     (reqArgFlag "PROJECTFILE")
-
-    ,option [] ["simple-output"]
-     "Only print names of outdated dependencies, one per line"
-     outdatedSimpleOutput (\v flags -> flags { outdatedSimpleOutput = v })
-     trueArg
-
-    ,option [] ["exit-code"]
-     "Exit with non-zero when there are outdated dependencies"
-     outdatedExitCode (\v flags -> flags { outdatedExitCode = v })
-     trueArg
-
-    ,option ['q'] ["quiet"]
-     "Don't print any output. Implies '--exit-code' and '-v0'"
-     outdatedQuiet (\v flags -> flags { outdatedQuiet = v })
-     trueArg
-
-   ,option [] ["ignore"]
-    "Packages to ignore"
-    outdatedIgnore (\v flags -> flags { outdatedIgnore = v })
-    (reqArg "PKGS" pkgNameListParser (map prettyShow))
-
-   ,option [] ["minor"]
-    "Ignore major version bumps for these packages"
-    outdatedMinor (\v flags -> flags { outdatedMinor = v })
-    (optArg "PKGS" ignoreMajorVersionBumpsParser
-      (Just IgnoreMajorVersionBumpsAll) ignoreMajorVersionBumpsPrinter)
-   ]
-  }
-  where
-    ignoreMajorVersionBumpsPrinter :: (Maybe IgnoreMajorVersionBumps)
-                                   -> [Maybe String]
-    ignoreMajorVersionBumpsPrinter Nothing = []
-    ignoreMajorVersionBumpsPrinter (Just IgnoreMajorVersionBumpsNone)= []
-    ignoreMajorVersionBumpsPrinter (Just IgnoreMajorVersionBumpsAll) = [Nothing]
-    ignoreMajorVersionBumpsPrinter (Just (IgnoreMajorVersionBumpsSome pkgs)) =
-      map (Just . prettyShow) $ pkgs
-
-    ignoreMajorVersionBumpsParser  =
-      (Just . IgnoreMajorVersionBumpsSome) `fmap` pkgNameListParser
-
-    pkgNameListParser = parsecToReadE
-      ("Couldn't parse the list of package names: " ++)
-      (fmap toList (P.sepByNonEmpty parsec (P.char ',')))
 
 -- ------------------------------------------------------------
 -- * Update command


### PR DESCRIPTION
Move `Outdated` to `CmdOutdated` module.

Modifications include:
* Explicit imports
* Removes redundant parenthesis
* Reformats the code-style to fit to other `Cmd*` modules
* Remove old code-paths from `cabal-install/src/Distribution/Client/Setup.hs`

Pre-step for #6815, performs no actual behaviour modification.

I started with this refactoring, noticing a bit too late that it is probably not completely necessary for #6815, but submitting it now anyway as I deem it helpful. Feel free to correct me, though!

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
