### PR TITLE
Suppress warnings for verbosity

### DIFF
--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -29,7 +29,7 @@ tests = testGroup "Distribution.Utils.Structured"
     , testCase "GenericPackageDescription" $
       md5Check (Proxy :: Proxy GenericPackageDescription) 0x9b7d0415b1d2522d72ac9e9739c97574
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0x0ca1dc5da4c4695a9da40e080bf4f536
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0x9da2b93b62f2108858322770734daf31
 #endif
     ]
 

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -539,13 +539,15 @@ checkFields pkg =
         ++ "for example 'tested-with: GHC==6.10.4, GHC==6.12.3' and not "
         ++ "'tested-with: GHC==6.10.4 && ==6.12.3'."
 
-  , check (not (null depInternalLibraryWithExtraVersion)) $
-      PackageBuildWarning $
-           "The package has an extraneous version range for a dependency on an "
-        ++ "internal library: "
-        ++ commaSep (map prettyShow depInternalLibraryWithExtraVersion)
-        ++ ". This version range includes the current package but isn't needed "
-        ++ "as the current package's library will always be used."
+  -- for more details on why the following was commented out,
+  -- check https://github.com/haskell/cabal/pull/7470#issuecomment-875878507
+  -- , check (not (null depInternalLibraryWithExtraVersion)) $
+  --     PackageBuildWarning $
+  --          "The package has an extraneous version range for a dependency on an "
+  --       ++ "internal library: "
+  --       ++ commaSep (map prettyShow depInternalLibraryWithExtraVersion)
+  --       ++ ". This version range includes the current package but isn't needed "
+  --       ++ "as the current package's library will always be used."
 
   , check (not (null depInternalLibraryWithImpossibleVersion)) $
       PackageBuildImpossible $
@@ -555,13 +557,13 @@ checkFields pkg =
         ++ ". This version range does not include the current package, and must "
         ++ "be removed as the current package's library will always be used."
 
-  , check (not (null depInternalExecutableWithExtraVersion)) $
-      PackageBuildWarning $
-           "The package has an extraneous version range for a dependency on an "
-        ++ "internal executable: "
-        ++ commaSep (map prettyShow depInternalExecutableWithExtraVersion)
-        ++ ". This version range includes the current package but isn't needed "
-        ++ "as the current package's executable will always be used."
+  -- , check (not (null depInternalExecutableWithExtraVersion)) $
+  --     PackageBuildWarning $
+  --          "The package has an extraneous version range for a dependency on an "
+  --       ++ "internal executable: "
+  --       ++ commaSep (map prettyShow depInternalExecutableWithExtraVersion)
+  --       ++ ". This version range includes the current package but isn't needed "
+  --       ++ "as the current package's executable will always be used."
 
   , check (not (null depInternalExecutableWithImpossibleVersion)) $
       PackageBuildImpossible $
@@ -617,12 +619,12 @@ checkFields pkg =
       , isInternal pkg dep
       ]
 
-    depInternalLibraryWithExtraVersion =
-      [ dep
-      | dep@(Dependency _ versionRange _) <- internalLibDeps
-      , not $ isAnyVersion versionRange
-      , packageVersion pkg `withinRange` versionRange
-      ]
+    -- depInternalLibraryWithExtraVersion =
+    --   [ dep
+    --   | dep@(Dependency _ versionRange _) <- internalLibDeps
+    --   , not $ isAnyVersion versionRange
+    --   , packageVersion pkg `withinRange` versionRange
+    --   ]
 
     depInternalLibraryWithImpossibleVersion =
       [ dep
@@ -630,12 +632,12 @@ checkFields pkg =
       , not $ packageVersion pkg `withinRange` versionRange
       ]
 
-    depInternalExecutableWithExtraVersion =
-      [ dep
-      | dep@(ExeDependency _ _ versionRange) <- internalExeDeps
-      , not $ isAnyVersion versionRange
-      , packageVersion pkg `withinRange` versionRange
-      ]
+    -- depInternalExecutableWithExtraVersion =
+    --   [ dep
+    --   | dep@(ExeDependency _ _ versionRange) <- internalExeDeps
+    --   , not $ isAnyVersion versionRange
+    --   , packageVersion pkg `withinRange` versionRange
+    --   ]
 
     depInternalExecutableWithImpossibleVersion =
       [ dep

--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -442,7 +442,7 @@ verbosityHandle verbosity
 --
 warn :: Verbosity -> String -> IO ()
 warn verbosity msg = withFrozenCallStack $ do
-  when (verbosity >= normal) $ do
+  when ((verbosity >= normal) && not (isVerboseNoWarn verbosity)) $ do
     ts <- getPOSIXTime
     hFlush stdout
     hPutStr stderr . withMetadata ts NormalMark FlagTrace verbosity

--- a/Cabal/src/Distribution/Verbosity.hs
+++ b/Cabal/src/Distribution/Verbosity.hs
@@ -52,6 +52,9 @@ module Distribution.Verbosity (
   -- * Stderr
   verboseStderr, isVerboseStderr,
   verboseNoStderr,
+
+  -- * No warnings
+  verboseNoWarn, isVerboseNoWarn
   ) where
 
 import Prelude ()
@@ -213,6 +216,7 @@ parsecVerbosity = parseIntVerbosity <|> parseStringVerbosity
             "timestamp"  -> return verboseTimestamp
             "stderr"     -> return verboseStderr
             "stdout"     -> return verboseNoStderr
+            "nowarn"     -> return verboseNoWarn
             _            -> P.unexpected $ "Bad verbosity flag: " ++ token
 
 flagToVerbosity :: ReadE Verbosity
@@ -239,6 +243,7 @@ showForCabal v
     showFlag VMarkOutput = ["+markoutput"]
     showFlag VTimestamp  = ["+timestamp"]
     showFlag VStderr     = ["+stderr"]
+    showFlag VNoWarn     = ["+nowarn"]
 
 showForGHC :: Verbosity -> String
 showForGHC   v = maybe (error "unknown verbosity") show $
@@ -290,6 +295,10 @@ verboseStderr = verboseFlag VStderr
 verboseNoStderr :: Verbosity -> Verbosity
 verboseNoStderr = verboseNoFlag VStderr
 
+-- | Turn off warnings for log messages
+verboseNoWarn :: Verbosity -> Verbosity
+verboseNoWarn = verboseFlag VNoWarn
+
 -- | Helper function for flag enabling functions
 verboseFlag :: VerbosityFlag -> (Verbosity -> Verbosity)
 verboseFlag flag v = v { vFlags = Set.insert flag (vFlags v) }
@@ -334,6 +343,10 @@ isVerboseTimestamp = isVerboseFlag VTimestamp
 -- @since 3.4.0.0
 isVerboseStderr :: Verbosity -> Bool
 isVerboseStderr = isVerboseFlag VStderr
+
+-- | Test if we should output warnings when we log.
+isVerboseNoWarn :: Verbosity -> Bool
+isVerboseNoWarn = isVerboseFlag VNoWarn
 
 -- | Helper function for flag testing functions.
 isVerboseFlag :: VerbosityFlag -> Verbosity -> Bool

--- a/Cabal/src/Distribution/Verbosity/Internal.hs
+++ b/Cabal/src/Distribution/Verbosity/Internal.hs
@@ -21,6 +21,7 @@ data VerbosityFlag
     | VMarkOutput
     | VTimestamp
     | VStderr -- ^ @since 3.4.0.0
+    | VNoWarn
     deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable)
 
 instance Binary VerbosityFlag

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.out
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.out
@@ -34,11 +34,9 @@ Building library 'mylib' instantiated with
   Database = Includes2-0.1.0.0-inplace-postgresql:Database.PostgreSQL
 for Includes2-0.1.0.0..
 Configuring library for Includes2-0.1.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: Includes2:{mylib, mysql, postgresql} (((>=0 && >=0 && >=0) && ==0.1.0.0) && ==0.1.0.0) && ==0.1.0.0, Includes2 ((>=0 && ==0.1.0.0) && ==0.1.0.0) && ==0.1.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing library for Includes2-0.1.0.0..
 Building library for Includes2-0.1.0.0..
 Configuring executable 'exe' for Includes2-0.1.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: Includes2:{mylib, mysql, postgresql} (>=0 && >=0 && >=0) && ==0.1.0.0, Includes2 >=0 && ==0.1.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'exe' for Includes2-0.1.0.0..
 Building executable 'exe' for Includes2-0.1.0.0..
 # Includes2 exe

--- a/cabal-testsuite/PackageTests/BuildDeps/InternalLibrary1/cabal.out
+++ b/cabal-testsuite/PackageTests/BuildDeps/InternalLibrary1/cabal.out
@@ -8,6 +8,5 @@ Configuring library for InternalLibrary1-0.1..
 Preprocessing library for InternalLibrary1-0.1..
 Building library for InternalLibrary1-0.1..
 Configuring executable 'lemon' for InternalLibrary1-0.1..
-Warning: The package has an extraneous version range for a dependency on an internal library: InternalLibrary1 >=0 && ==0.1. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'lemon' for InternalLibrary1-0.1..
 Building executable 'lemon' for InternalLibrary1-0.1..

--- a/cabal-testsuite/PackageTests/BuildTools/Internal/cabal.out
+++ b/cabal-testsuite/PackageTests/BuildTools/Internal/cabal.out
@@ -12,6 +12,5 @@ Configuring library for foo-0.1.0.0..
 Preprocessing library for foo-0.1.0.0..
 Building library for foo-0.1.0.0..
 Configuring executable 'hello-world' for foo-0.1.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: foo >=0 && ==0.1.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'hello-world' for foo-0.1.0.0..
 Building executable 'hello-world' for foo-0.1.0.0..

--- a/cabal-testsuite/PackageTests/CmmSources/cabal.out
+++ b/cabal-testsuite/PackageTests/CmmSources/cabal.out
@@ -8,6 +8,5 @@ Configuring library for cmmexperiment-0..
 Preprocessing library for cmmexperiment-0..
 Building library for cmmexperiment-0..
 Configuring executable 'demo' for cmmexperiment-0..
-Warning: The package has an extraneous version range for a dependency on an internal library: cmmexperiment >=0 && ==0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'demo' for cmmexperiment-0..
 Building executable 'demo' for cmmexperiment-0..

--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/cabal.out
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/cabal.out
@@ -8,6 +8,5 @@ Configuring library for cmmexperiment-0..
 Preprocessing library for cmmexperiment-0..
 Building library for cmmexperiment-0..
 Configuring executable 'demo' for cmmexperiment-0..
-Warning: The package has an extraneous version range for a dependency on an internal library: cmmexperiment >=0 && ==0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'demo' for cmmexperiment-0..
 Building executable 'demo' for cmmexperiment-0..

--- a/cabal-testsuite/PackageTests/InternalLibraries/cabal.out
+++ b/cabal-testsuite/PackageTests/InternalLibraries/cabal.out
@@ -9,10 +9,8 @@ Configuring library 'q' for p-0.1.0.0..
 Preprocessing library 'q' for p-0.1.0.0..
 Building library 'q' for p-0.1.0.0..
 Configuring executable 'foo' for p-0.1.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: p:q >=0 && ==0.1.0.0, p:q >=0 && ==0.1.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'foo' for p-0.1.0.0..
 Building executable 'foo' for p-0.1.0.0..
 Configuring library for p-0.1.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: p:q >=0 && ==0.1.0.0, p:q >=0 && ==0.1.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing library for p-0.1.0.0..
 Building library for p-0.1.0.0..

--- a/cabal-testsuite/PackageTests/InternalVersions/BuildDependsExtra/setup.test.hs
+++ b/cabal-testsuite/PackageTests/InternalVersions/BuildDependsExtra/setup.test.hs
@@ -1,6 +1,6 @@
 import Test.Cabal.Prelude
 -- Test unneed version bound on internal build-tools deps
-main = setupAndCabalTest $ do
+main = setupAndCabalTest . expectBroken 7470 $ do
     setup' "configure" []
     assertOutputContains "extraneous version range"
         =<< setup' "sdist" []

--- a/cabal-testsuite/PackageTests/InternalVersions/BuildToolDependsExtra/setup.test.hs
+++ b/cabal-testsuite/PackageTests/InternalVersions/BuildToolDependsExtra/setup.test.hs
@@ -1,6 +1,6 @@
 import Test.Cabal.Prelude
 -- Test unneed version bound on internal build-tools deps
-main = setupAndCabalTest $ do
+main = setupAndCabalTest . expectBroken 7470 $ do
     setup' "configure" []
     assertOutputContains "extraneous version range"
         =<< setup' "sdist" []

--- a/cabal-testsuite/PackageTests/InternalVersions/BuildToolsExtra/setup.test.hs
+++ b/cabal-testsuite/PackageTests/InternalVersions/BuildToolsExtra/setup.test.hs
@@ -1,6 +1,6 @@
 import Test.Cabal.Prelude
 -- Test unneed version bound on internal build-tools deps
-main = setupAndCabalTest $ do
+main = setupAndCabalTest . expectBroken 7470 $ do
     setup' "configure" []
     assertOutputContains "extraneous version range"
         =<< setup' "sdist" []

--- a/cabal-testsuite/PackageTests/MultipleLibraries/T6083Post/cabal.out
+++ b/cabal-testsuite/PackageTests/MultipleLibraries/T6083Post/cabal.out
@@ -10,6 +10,5 @@ Preprocessing library for pkg-def-0.1.0.0..
 Building library for pkg-def-0.1.0.0..
 Warning: pkg-abc.cabal:19:15: colon specifier is experimental feature (issue #5660)
 Configuring executable 'program' for pkg-abc-0.1.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: pkg-def >=0 && ==0.1.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'program' for pkg-abc-0.1.0.0..
 Building executable 'program' for pkg-abc-0.1.0.0..

--- a/cabal-testsuite/PackageTests/MultipleLibraries/T6083PostMixin/cabal.out
+++ b/cabal-testsuite/PackageTests/MultipleLibraries/T6083PostMixin/cabal.out
@@ -11,6 +11,5 @@ Building library for pkg-def-0.1.0.0..
 Warning: pkg-abc.cabal:15:29: colon specifier is experimental feature (issue #5660)
 Warning: pkg-abc.cabal:20:15: colon specifier is experimental feature (issue #5660)
 Configuring executable 'program' for pkg-abc-0.1.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: pkg-def >=0 && ==0.1.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'program' for pkg-abc-0.1.0.0..
 Building executable 'program' for pkg-abc-0.1.0.0..

--- a/cabal-testsuite/PackageTests/MultipleLibraries/T6894/cabal.out
+++ b/cabal-testsuite/PackageTests/MultipleLibraries/T6894/cabal.out
@@ -10,6 +10,5 @@ Preprocessing library 'sublib' for issue-6894..
 Building library 'sublib' for issue-6894..
 Warning: issue.cabal:7:30: colon specifier is experimental feature (issue #5660)
 Configuring library for issue-6894..
-Warning: The package has an extraneous version range for a dependency on an internal library: issue:sublib >=0 && ==6894. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing library for issue-6894..
 Building library for issue-6894..

--- a/cabal-testsuite/PackageTests/Regression/T5213/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T5213/cabal.out
@@ -8,7 +8,6 @@ Configuring library for cabal-gh5213-0.1..
 Preprocessing library for cabal-gh5213-0.1..
 Building library for cabal-gh5213-0.1..
 Configuring test suite 'tests' for cabal-gh5213-0.1..
-Warning: The package has an extraneous version range for a dependency on an internal library: cabal-gh5213 >=0 && ==0.1. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing test suite 'tests' for cabal-gh5213-0.1..
 Building test suite 'tests' for cabal-gh5213-0.1..
 Running 1 test suites...

--- a/cabal-testsuite/PackageTests/Regression/T5213ExeCoverage/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T5213ExeCoverage/cabal.out
@@ -8,7 +8,6 @@ Configuring library for cabal-gh5213-0.1..
 Preprocessing library for cabal-gh5213-0.1..
 Building library for cabal-gh5213-0.1..
 Configuring test suite 'tests' for cabal-gh5213-0.1..
-Warning: The package has an extraneous version range for a dependency on an internal library: cabal-gh5213 >=0 && ==0.1. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing test suite 'tests' for cabal-gh5213-0.1..
 Building test suite 'tests' for cabal-gh5213-0.1..
 Running 1 test suites...

--- a/cabal-testsuite/PackageTests/Regression/T5309/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T5309/cabal.out
@@ -12,7 +12,6 @@ Configuring executable 'exe-no-lib' for T5309-1.0.0.0..
 Preprocessing executable 'exe-no-lib' for T5309-1.0.0.0..
 Building executable 'exe-no-lib' for T5309-1.0.0.0..
 Configuring executable 'exe-with-lib' for T5309-1.0.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: T5309 >=0 && ==1.0.0.0, T5309 >=0 && ==1.0.0.0, T5309 >=0 && ==1.0.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'exe-with-lib' for T5309-1.0.0.0..
 Building executable 'exe-with-lib' for T5309-1.0.0.0..
 # cabal v2-test
@@ -29,7 +28,6 @@ Test suite test-no-lib: PASS
 Test suite logged to: <ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/T5309-1.0.0.0/t/test-no-lib/test/T5309-1.0.0.0-test-no-lib.log
 1 of 1 test suites (1 of 1 test cases) passed.
 Configuring test suite 'test-with-lib' for T5309-1.0.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: T5309 >=0 && ==1.0.0.0, T5309 >=0 && ==1.0.0.0, T5309 >=0 && ==1.0.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing test suite 'test-with-lib' for T5309-1.0.0.0..
 Building test suite 'test-with-lib' for T5309-1.0.0.0..
 Running 1 test suites...
@@ -49,7 +47,6 @@ Running 1 benchmarks...
 Benchmark bench-no-lib: RUNNING...
 Benchmark bench-no-lib: FINISH
 Configuring benchmark 'bench-with-lib' for T5309-1.0.0.0..
-Warning: The package has an extraneous version range for a dependency on an internal library: T5309 >=0 && ==1.0.0.0, T5309 >=0 && ==1.0.0.0, T5309 >=0 && ==1.0.0.0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing benchmark 'bench-with-lib' for T5309-1.0.0.0..
 Building benchmark 'bench-with-lib' for T5309-1.0.0.0..
 Running 1 benchmarks...

--- a/cabal-testsuite/PackageTests/Regression/T5677/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T5677/cabal.out
@@ -24,6 +24,5 @@ Preprocessing library for prog-0..
 Building library instantiated with Sig = impl-0-inplace:Sig
 for prog-0..
 Configuring executable 'prog' for prog-0..
-Warning: The package has an extraneous version range for a dependency on an internal library: prog >=0 && ==0. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing executable 'prog' for prog-0..
 Building executable 'prog' for prog-0..

--- a/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/cabal.out
+++ b/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/cabal.out
@@ -9,7 +9,6 @@ Configuring library for my-0.1..
 Preprocessing library for my-0.1..
 Building library for my-0.1..
 Configuring test suite 'test-Short' for my-0.1..
-Warning: The package has an extraneous version range for a dependency on an internal library: my >=0 && ==0.1, my >=0 && ==0.1. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing test suite 'test-Short' for my-0.1..
 Building test suite 'test-Short' for my-0.1..
 Running 1 test suites...
@@ -18,7 +17,6 @@ Test suite test-Short: PASS
 Test suite logged to: <ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/my-0.1/t/test-Short/test/my-0.1-test-Short.log
 1 of 1 test suites (1 of 1 test cases) passed.
 Configuring test suite 'test-Foo' for my-0.1..
-Warning: The package has an extraneous version range for a dependency on an internal library: my >=0 && ==0.1, my >=0 && ==0.1. This version range includes the current package but isn't needed as the current package's library will always be used.
 Preprocessing test suite 'test-Foo' for my-0.1..
 Building test suite 'test-Foo' for my-0.1..
 Running 1 test suites...

--- a/changelog.d/pr-7470
+++ b/changelog.d/pr-7470
@@ -1,0 +1,4 @@
+synopsis: adds a verbosity flag "+nowarn", to suppress all warnings
+packages: cabal-install
+prs: #7470
+issues: #7286

--- a/changelog.d/pr-7470-backport
+++ b/changelog.d/pr-7470-backport
@@ -1,0 +1,4 @@
+synopsis: removes the warnings for extraneous versions
+packages: cabal-install
+prs: #7470
+issues: #7286


### PR DESCRIPTION
This PR will add the ability to suppress all warnings within a given command. For example, to suppress all warnings in `cabal build`, while keeping the output verbose: `cabal build --verbose="verbose+nowarn"`.

This PR serves as a palliative measure for #7286, while also doubling up on adding a new feature.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary