### PR TITLE
Inidication that a field is optional for cabal init prompts

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/FlagExtractors.hs
+++ b/cabal-install/src/Distribution/Client/Init/FlagExtractors.hs
@@ -220,19 +220,19 @@ simpleProjectPrompt :: Interactive m => InitFlags -> m Bool
 simpleProjectPrompt flags = getSimpleProject flags $
     promptYesNo
       "Should I generate a simple project with sensible defaults"
-      (Just True)
+      (DefaultPrompt True)
 
 initializeTestSuitePrompt :: Interactive m => InitFlags -> m Bool
 initializeTestSuitePrompt flags = getInitializeTestSuite flags $
     promptYesNo
       "Should I generate a test suite for the library"
-      (Just True)
+      (DefaultPrompt True)
 
 packageTypePrompt :: Interactive m => InitFlags -> m PackageType
 packageTypePrompt flags = getPackageType flags $ do
     pt <- promptList "What does the package build"
       packageTypes
-      (Just "Executable")
+      (DefaultPrompt "Executable")
       Nothing
       False
 
@@ -256,7 +256,7 @@ testMainPrompt :: Interactive m => m HsFilePath
 testMainPrompt = do
     fp <- promptList "What is the main module of the test suite?"
       [defaultMainIs', "Main.lhs"]
-      (Just defaultMainIs')
+      (DefaultPrompt defaultMainIs')
       Nothing
       True
 

--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -264,7 +264,7 @@ cabalVersionPrompt :: Interactive m => InitFlags -> m CabalSpecVersion
 cabalVersionPrompt flags = getCabalVersion flags $ do
     v <- promptList "Please choose version of the Cabal specification to use"
       ppVersions
-      (Just ppDefault)
+      (DefaultPrompt ppDefault)
       (Just takeVersion)
       False
     -- take just the version numbers for convenience
@@ -301,12 +301,12 @@ packageNamePrompt srcDb flags = getPackageName flags $ do
         Flag b -> return $ filePathToPkgName b
         NoFlag -> currentDirPkgName
 
-    go $ Just defName
+    go $ DefaultPrompt defName
   where
     go defName = prompt "Package name" defName >>= \n ->
       if isPkgRegistered n
       then do
-        don'tUseName <- promptYesNo (promptOtherNameMsg n) (Just True)
+        don'tUseName <- promptYesNo (promptOtherNameMsg n) (DefaultPrompt True)
         if don'tUseName
         then do
           putStrLn (inUseMsg n)
@@ -326,7 +326,7 @@ versionPrompt :: Interactive m => InitFlags -> m Version
 versionPrompt flags = getVersion flags go
   where
     go = do
-      vv <- promptStr "Package version" (Just $ prettyShow defaultVersion)
+      vv <- promptStr "Package version" (DefaultPrompt $ prettyShow defaultVersion)
       case simpleParsec vv of
         Nothing -> do
           putStrLn
@@ -339,7 +339,7 @@ licensePrompt :: Interactive m => InitFlags -> m SPDX.License
 licensePrompt flags = getLicense flags $ do
     l <- promptList "Please choose a license"
       licenses
-      Nothing
+      MandatoryPrompt
       Nothing
       True
 
@@ -353,24 +353,24 @@ licensePrompt flags = getLicense flags $ do
 
 authorPrompt :: Interactive m => InitFlags -> m String
 authorPrompt flags = getAuthor flags $
-    promptStr "Author name" Nothing
+    promptStr "Author name" OptionalPrompt
 
 emailPrompt :: Interactive m => InitFlags -> m String
 emailPrompt flags = getEmail flags $
-    promptStr "Maintainer email" Nothing
+    promptStr "Maintainer email" OptionalPrompt
 
 homepagePrompt :: Interactive m => InitFlags -> m String
 homepagePrompt flags = getHomepage flags $
-    promptStr "Project homepage URL" Nothing
+    promptStr "Project homepage URL" OptionalPrompt
 
 synopsisPrompt :: Interactive m => InitFlags -> m String
 synopsisPrompt flags = getSynopsis flags $
-    promptStr "Project synopsis" Nothing
+    promptStr "Project synopsis" OptionalPrompt
 
 categoryPrompt :: Interactive m => InitFlags -> m String
 categoryPrompt flags = getCategory flags $ promptList
       "Project category" defaultCategories
-      (Just "") (Just matchNone) True
+      (DefaultPrompt "") (Just matchNone) True
   where
     matchNone s
       | null s = "(none)"
@@ -383,7 +383,7 @@ mainFilePrompt flags = getMainFile flags go
     go = do
       fp <- promptList "What is the main module of the executable"
         [defaultMainIs', "Main.lhs"]
-        (Just defaultMainIs')
+        (DefaultPrompt defaultMainIs')
         Nothing
         True
 
@@ -402,14 +402,14 @@ mainFilePrompt flags = getMainFile flags go
 
 testDirsPrompt :: Interactive m => InitFlags -> m [String]
 testDirsPrompt flags = getTestDirs flags $ do
-    dir <- promptStr "Test directory" (Just defaultTestDir)
+    dir <- promptStr "Test directory" (DefaultPrompt defaultTestDir)
     return [dir]
 
 languagePrompt :: Interactive m => InitFlags -> String -> m Language
 languagePrompt flags pkgType = getLanguage flags $ do
     lang <- promptList ("Choose a language for your " ++ pkgType)
       ["Haskell2010", "Haskell98"]
-      (Just "Haskell2010")
+      (DefaultPrompt "Haskell2010")
       Nothing
       True
 
@@ -428,7 +428,7 @@ noCommentsPrompt :: Interactive m => InitFlags -> m Bool
 noCommentsPrompt flags = getNoComments flags $ do
     doComments <- promptYesNo
       "Add informative comments to each field in the cabal file. (y/n)"
-      (Just True)
+      (DefaultPrompt True)
 
     --
     -- if --no-comments is flagged, then we choose not to generate comments
@@ -443,7 +443,7 @@ appDirsPrompt :: Interactive m => InitFlags -> m [String]
 appDirsPrompt flags = getAppDirs flags $ do
     dir <- promptList promptMsg
       [defaultApplicationDir, "exe", "src-exe"]
-      (Just defaultApplicationDir)
+      (DefaultPrompt defaultApplicationDir)
       Nothing
       True
 
@@ -458,7 +458,7 @@ srcDirsPrompt :: Interactive m => InitFlags -> m [String]
 srcDirsPrompt flags = getSrcDirs flags $ do
     dir <- promptList "Library source directory"
       [defaultSourceDir, "lib", "src-lib"]
-      (Just defaultSourceDir)
+      (DefaultPrompt defaultSourceDir)
       Nothing
       True
 

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -45,6 +45,8 @@ module Distribution.Client.Init.Types
 , ProjectSettings(..)
   -- * Formatters
 , FieldAnnotation(..)
+  -- * Other conveniences
+, DefaultPrompt(..)
 ) where
 
 
@@ -421,6 +423,14 @@ type IsLiterate = Bool
 -- | Convenience alias for generating simple projects
 --
 type IsSimple = Bool
+
+-- | Defines whether or not a prompt will have a default value,
+--   is optional, or is mandatory.
+data DefaultPrompt t
+  = DefaultPrompt t
+  | OptionalPrompt
+  | MandatoryPrompt
+  deriving (Eq, Functor)
 
 -- -------------------------------------------------------------------- --
 -- Field annotation for pretty formatters


### PR DESCRIPTION
This PR aims to fix #7464. For any field that is both optional and don't have a default value, an `"[optional]"` "tag" will be appended next to the input location.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
