### PR TITLE
Add AmbiguityResolver to decide how to resolve ambiguity

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdBench.hs
+++ b/cabal-install/src/Distribution/Client/CmdBench.hs
@@ -85,7 +85,8 @@ benchAction flags@NixStyleFlags {..} targetStrings globalFlags = do
     baseCtx <- establishProjectBaseContext verbosity cliConfig OtherCommand
 
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-                   =<< readTargetSelectors (localPackages baseCtx) (Just BenchKind) targetStrings
+                   =<< readTargetSelectors (localPackages baseCtx)
+                        (Just BenchKind) flags targetStrings
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do
@@ -118,7 +119,7 @@ benchAction flags@NixStyleFlags {..} targetStrings globalFlags = do
     runProjectPostBuildPhase verbosity baseCtx buildCtx buildOutcomes
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
-    cliConfig = commandLineFlagsToProjectConfig globalFlags flags 
+    cliConfig = commandLineFlagsToProjectConfig globalFlags flags
                   mempty -- ClientInstallFlags, not needed here
 
 -- | This defines what a 'TargetSelector' means for the @bench@ command.

--- a/cabal-install/src/Distribution/Client/CmdBuild.hs
+++ b/cabal-install/src/Distribution/Client/CmdBuild.hs
@@ -107,7 +107,8 @@ buildAction flags@NixStyleFlags { extraFlags = buildFlags, ..} targetStrings glo
 
     targetSelectors <-
       either (reportTargetSelectorProblems verbosity) return
-      =<< readTargetSelectors (localPackages baseCtx) Nothing targetStrings
+      =<< readTargetSelectors (localPackages baseCtx)
+            Nothing flags targetStrings
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do

--- a/cabal-install/src/Distribution/Client/CmdErrorMessages.hs
+++ b/cabal-install/src/Distribution/Client/CmdErrorMessages.hs
@@ -21,7 +21,7 @@ import Distribution.Client.TargetSelector
 import Distribution.Client.TargetProblem
          ( TargetProblem(..), TargetProblem' )
 import Distribution.Client.TargetSelector
-         ( ComponentKind(..), ComponentKindFilter, TargetSelector(..),
+         ( ComponentKind(..), TargetSelector(..),
            componentKind, showTargetSelector )
 
 import Distribution.Package
@@ -170,7 +170,7 @@ targetSelectorRefersToPkgs (TargetPackageNamed _ mkfilter) = isNothing mkfilter
 targetSelectorRefersToPkgs  TargetComponent{}              = False
 targetSelectorRefersToPkgs  TargetComponentUnknown{}       = False
 
-targetSelectorFilter :: TargetSelector -> Maybe ComponentKindFilter
+targetSelectorFilter :: TargetSelector -> Maybe ComponentKind
 targetSelectorFilter (TargetPackage    _ _ mkfilter) = mkfilter
 targetSelectorFilter (TargetPackageNamed _ mkfilter) = mkfilter
 targetSelectorFilter (TargetAllPackages    mkfilter) = mkfilter

--- a/cabal-install/src/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddock.hs
@@ -74,7 +74,8 @@ haddockAction flags@NixStyleFlags {..} targetStrings globalFlags = do
     baseCtx <- establishProjectBaseContext verbosity cliConfig HaddockCommand
 
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-                   =<< readTargetSelectors (localPackages baseCtx) Nothing targetStrings
+                   =<< readTargetSelectors (localPackages baseCtx) Nothing flags
+                         targetStrings
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do

--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -238,8 +238,8 @@ installAction flags@NixStyleFlags { extraFlags = clientInstallFlags', .. } targe
         else do
           targetSelectors <-
             either (reportTargetSelectorProblems verbosity) return
-            =<< readTargetSelectors (localPackages localBaseCtx)
-                                    Nothing targetStrings''
+            =<< readTargetSelectors (localPackages localBaseCtx) Nothing flags
+                 targetStrings''
 
           (specs, selectors) <-
             getSpecsAndTargetSelectors
@@ -429,7 +429,7 @@ getSpecsAndTargetSelectors
   -> [TargetSelector]
   -> DistDirLayout
   -> ProjectBaseContext
-  -> Maybe ComponentKindFilter
+  -> Maybe ComponentKind
   -> IO ([PackageSpecifier UnresolvedSourcePackage], [TargetSelector])
 getSpecsAndTargetSelectors verbosity reducedVerbosity pkgDb targetSelectors localDistDirLayout localBaseCtx targetFilter =
   withInstallPlan reducedVerbosity localBaseCtx $ \elaboratedPlan _ -> do

--- a/cabal-install/src/Distribution/Client/CmdListBin.hs
+++ b/cabal-install/src/Distribution/Client/CmdListBin.hs
@@ -77,7 +77,7 @@ listbinAction flags@NixStyleFlags{..} args globalFlags = do
 
     -- elaborate target selectors
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-        =<< readTargetSelectors localPkgs (Just ExeKind) [target]
+        =<< readTargetSelectors localPkgs (Just ExeKind) flags [target]
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do

--- a/cabal-install/src/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/src/Distribution/Client/CmdRepl.hs
@@ -199,7 +199,7 @@ replCommand = Client.installCommand {
 replAction :: NixStyleFlags (ReplFlags, EnvFlags) -> [String] -> GlobalFlags -> IO ()
 replAction flags@NixStyleFlags { extraFlags = (replFlags, envFlags), ..} targetStrings globalFlags = do
     let
-      with           = withProject    cliConfig             verbosity targetStrings
+      with           = withProject flags cliConfig          verbosity targetStrings
       without config = withoutProject (config <> cliConfig) verbosity targetStrings
 
     (baseCtx, targetSelectors, finalizer, replType) <-
@@ -333,13 +333,14 @@ data ReplType = ProjectRepl
                                     --   7.6, though. 🙁
               deriving (Show, Eq)
 
-withProject :: ProjectConfig -> Verbosity -> [String]
+withProject :: NixStyleFlags a -> ProjectConfig -> Verbosity -> [String]
             -> IO (ProjectBaseContext, [TargetSelector], IO (), ReplType)
-withProject cliConfig verbosity targetStrings = do
+withProject flags cliConfig verbosity targetStrings = do
   baseCtx <- establishProjectBaseContext verbosity cliConfig OtherCommand
 
   targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-                 =<< readTargetSelectors (localPackages baseCtx) (Just LibKind) targetStrings
+                 =<< readTargetSelectors (localPackages baseCtx) (Just LibKind)
+                      flags targetStrings
 
   return (baseCtx, targetSelectors, return (), ProjectRepl)
 

--- a/cabal-install/src/Distribution/Client/CmdRun.hs
+++ b/cabal-install/src/Distribution/Client/CmdRun.hs
@@ -180,7 +180,7 @@ runAction flags@NixStyleFlags {..} targetStrings globalFlags = do
           else reportTargetSelectorProblems verbosity err
 
     (baseCtx', targetSelectors) <-
-      readTargetSelectors (localPackages baseCtx) (Just ExeKind) (take 1 targetStrings)
+      readTargetSelectors (localPackages baseCtx) (Just ExeKind) flags (take 1 targetStrings)
         >>= \case
           Left err@(TargetSelectorNoTargetsInProject:_)
             | (script:_) <- targetStrings -> scriptOrError script err

--- a/cabal-install/src/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/src/Distribution/Client/CmdSdist.hs
@@ -19,7 +19,7 @@ import Distribution.Client.NixStyleOptions
          ( NixStyleFlags (..), defaultNixStyleFlags )
 import Distribution.Client.TargetSelector
     ( TargetSelector(..), ComponentKind
-    , readTargetSelectors, reportTargetSelectorProblems )
+    , readTargetSelectors', reportTargetSelectorProblems )
 import Distribution.Client.Setup
     ( GlobalFlags(..) )
 import Distribution.Solver.Types.SourcePackage
@@ -143,7 +143,7 @@ sdistAction (ProjectFlags{..}, SdistFlags{..}) targetStrings globalFlags = do
     let localPkgs = localPackages baseCtx
 
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-        =<< readTargetSelectors localPkgs Nothing targetStrings
+        =<< readTargetSelectors' localPkgs Nothing targetStrings
 
     -- elaborate path, create target directory
     mOutputPath' <- case mOutputPath of

--- a/cabal-install/src/Distribution/Client/CmdTest.hs
+++ b/cabal-install/src/Distribution/Client/CmdTest.hs
@@ -97,7 +97,8 @@ testAction flags@NixStyleFlags {..} targetStrings globalFlags = do
     baseCtx <- establishProjectBaseContext verbosity cliConfig OtherCommand
 
     targetSelectors <- either (reportTargetSelectorProblems verbosity) return
-                   =<< readTargetSelectors (localPackages baseCtx) (Just TestKind) targetStrings
+                  =<< readTargetSelectors (localPackages baseCtx)
+                        (Just TestKind) flags targetStrings
 
     buildCtx <-
       runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -431,7 +431,9 @@ instance Semigroup SavedConfig where
         configAllowOlder    =
             combineMonoid savedConfigureExFlags configAllowOlder,
         configWriteGhcEnvironmentFilesPolicy
-                            = combine configWriteGhcEnvironmentFilesPolicy
+                            = combine configWriteGhcEnvironmentFilesPolicy,
+        configPickFirstTarget
+                            = combine configPickFirstTarget
         }
         where
           combine      = combine' savedConfigureExFlags

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -607,7 +607,9 @@ convertToLegacySharedConfig
       configAllowOlder    = projectConfigAllowOlder,
       configAllowNewer    = projectConfigAllowNewer,
       configWriteGhcEnvironmentFilesPolicy
-                          = projectConfigWriteGhcEnvironmentFilesPolicy
+                          = projectConfigWriteGhcEnvironmentFilesPolicy,
+      configPickFirstTarget
+                          = mempty
     }
 
     installFlags = InstallFlags {

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -604,12 +604,15 @@ data ConfigExFlags = ConfigExFlags {
     configAllowNewer    :: Maybe AllowNewer,
     configAllowOlder    :: Maybe AllowOlder,
     configWriteGhcEnvironmentFilesPolicy
-      :: Flag WriteGhcEnvironmentFilesPolicy
+      :: Flag WriteGhcEnvironmentFilesPolicy,
+    configPickFirstTarget
+      :: Flag Bool
   }
   deriving (Eq, Show, Generic)
 
 defaultConfigExFlags :: ConfigExFlags
-defaultConfigExFlags = mempty { configSolver     = Flag defaultSolver }
+defaultConfigExFlags = mempty { configSolver          = Flag defaultSolver
+                              , configPickFirstTarget = Flag False }
 
 configureExCommand :: CommandUI (ConfigFlags, ConfigExFlags)
 configureExCommand = configureCommand {
@@ -685,6 +688,13 @@ configureExOptions _showOrParseArgs src =
     (reqArg "always|never|ghc8.4.4+"
      writeGhcEnvironmentFilesPolicyParser
      writeGhcEnvironmentFilesPolicyPrinter)
+
+  , option [] ["pick-first-target"]
+    ("If there's an amibguity in the target selector, then resolve it by"
+      ++ " choosing the first")
+    configPickFirstTarget
+    (\v flags -> flags { configPickFirstTarget = v})
+    trueArg
   ]
 
 

--- a/cabal-install/src/Distribution/Client/TargetProblem.hs
+++ b/cabal-install/src/Distribution/Client/TargetProblem.hs
@@ -45,8 +45,8 @@ data TargetProblem a
     | TargetProblemNoSuchPackage           PackageId
     | TargetProblemNoSuchComponent         PackageId ComponentName
 
-      -- | A custom target problem
     | CustomTargetProblem a
+      -- ^ A custom target problem
   deriving (Eq, Show, Functor)
 
 -- | Type alias for a 'TargetProblem' with no user-defined problems/errors.


### PR DESCRIPTION
Add --pick-first-target flag

Every other command defaults to what they used to do.

Extracted from #7478 

Not entirely sure about the purpose, extracted relevant changes and leaving this here so if somebody cares about it, they can pick it up from here.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
