### PR TITLE
Don't output haddock stdout if verbosity is silent

### DIFF
--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -559,7 +559,9 @@ runHaddock verbosity tmpFileOpts comp platform haddockProg args
     renderArgs verbosity tmpFileOpts haddockVersion comp platform args $
       \(flags,result)-> do
 
-        runProgram verbosity haddockProg flags
+        haddockOut <- getProgramOutput verbosity haddockProg flags
+        unless (verbosity <= silent) $
+          putStr haddockOut
 
         notice verbosity $ "Documentation created: " ++ result
 

--- a/cabal-testsuite/PackageTests/NewHaddock/Fails/cabal.out
+++ b/cabal-testsuite/PackageTests/NewHaddock/Fails/cabal.out
@@ -12,4 +12,5 @@ In order, the following will be built:
  - example-1.0 (lib) (first run)
 Preprocessing library for example-1.0..
 Running Haddock on library for example-1.0..
+cabal: '<HADDOCK>' exited with an error:
 cabal: Failed to build documentation for example-1.0-inplace.

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -398,6 +398,9 @@ mkNormalizerEnv = do
     list_out <- liftIO $ readProcess (programPath ghc_pkg_program)
                       ["list", "--global", "--simple-output"] ""
     tmpDir <- liftIO $ getTemporaryDirectory
+    haddock_program <- requireProgramM haddockProgram
+    canonicalHaddockPath <- liftIO $ canonicalizePath $ programPath haddock_program
+    
     return NormalizerEnv {
         normalizerRoot
             = addTrailingPathSeparator (testSourceDir env),
@@ -410,8 +413,12 @@ mkNormalizerEnv = do
         normalizerKnownPackages
             = mapMaybe simpleParse (words list_out),
         normalizerPlatform
-            = testPlatform env
+            = testPlatform env,
+        normalizerHaddock
+            = canonicalHaddockPath
     }
+    where
+
 
 requireProgramM :: Program -> TestM ConfiguredProgram
 requireProgramM program = do

--- a/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
+++ b/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
@@ -14,6 +14,7 @@ import Distribution.System
 import Text.Regex.Base
 import Text.Regex.TDFA
 import Data.Array ((!))
+import Data.List (isPrefixOf, isInfixOf)
 
 import qualified Data.Foldable as F
 
@@ -62,10 +63,40 @@ normalizeOutput nenv =
         else id)
   -- hackage-security locks occur non-deterministically
   . resub "(Released|Acquired|Waiting) .*hackage-security-lock\n" ""
+  -- Substitute the haddock binary with <HADDOCK>
+  -- Do this before the <GHCVER> substitution
+  . resub (posixRegexEscape (normalizerHaddock nenv)) "<HADDOCK>"
+  . removeErrors
   where
     packageIdRegex pid =
         resub (posixRegexEscape (display pid) ++ "(-[A-Za-z0-9.-]+)?")
               (prettyShow (packageName pid) ++ "-<VERSION>")
+
+{- Given
+cabal: blah exited with an error:
+Example.hs:6:11: error:
+    * Couldn't match expected type `Int' with actual type `Bool'
+    * In the expression: False
+      In an equation for `example': example = False
+|
+6 | example = False
+| ^^^^^
+cabal: Failed to build documentation for example-1.0-inplace.
+
+this will remove the error in between the first line with "exited with an error"
+and the closing "cabal:". Pretty nasty, but its needed to ignore errors from
+external programs whose output might change.
+-}
+removeErrors :: String -> String
+removeErrors s = unlines (go (lines s) False)
+  where
+    go [] _ = []
+    go (x:xs) True
+      | "cabal:" `isPrefixOf` x = x:(go xs False)
+      | otherwise               = go xs True
+    go (x:xs) False
+      | "exited with an error" `isInfixOf` x = x:(go xs True)
+      | otherwise                            = x:(go xs False)
 
 data NormalizerEnv = NormalizerEnv
     { normalizerRoot          :: FilePath
@@ -74,6 +105,7 @@ data NormalizerEnv = NormalizerEnv
     , normalizerGhcVersion    :: Version
     , normalizerKnownPackages :: [PackageId]
     , normalizerPlatform      :: Platform
+    , normalizerHaddock       :: FilePath
     }
 
 posixSpecialChars :: [Char]

--- a/changelog.d/pr-7483
+++ b/changelog.d/pr-7483
@@ -1,0 +1,9 @@
+synopsis: Don't output haddock stdout if verbosity is silent
+packages: Cabal
+prs: #7483
+
+description: {
+
+- Silence the output of the Haddock executable if verbosity 'silent' is set.
+- Hide output of 'stderr' if Haddock succeeded.
+}


### PR DESCRIPTION
Extracted from #7478 

Basically, if verbosity is `silent`, don't output haddock to `stdout`.

As a non-ideal sideeffect, stderr output is swallowed if `haddock` has a zero-exit code.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
