### PR TITLE
Remove redundant init message for hackage dir name

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -137,7 +137,7 @@ createProject v pkgIx srcDb initFlags = do
       return $ ProjectSettings
         (mkOpts comments cabalSpec) pkgDesc (Just libTarget)
         (Just exeTarget) testTarget
-    
+
     TestSuite -> do
       -- the line below is necessary because if both package type and test flags
       -- are *not* passed, the user will be prompted for a package type (which
@@ -145,7 +145,7 @@ createProject v pkgIx srcDb initFlags = do
       -- TestSuite target with initializeTestSuite set to NoFlag, thus avoiding the prompt.
       let initFlags' = initFlags { initializeTestSuite = Flag True }
       testTarget <- genTestTarget initFlags' pkgIx
-      
+
       comments <- noCommentsPrompt initFlags'
 
       return $ ProjectSettings
@@ -308,9 +308,7 @@ packageNamePrompt srcDb flags = getPackageName flags $ do
       then do
         don'tUseName <- promptYesNo (promptOtherNameMsg n) (DefaultPrompt True)
         if don'tUseName
-        then do
-          putStrLn (inUseMsg n)
-          go defName
+        then go defName
         else return n
       else return n
 


### PR DESCRIPTION
This PR removes an unnecessary print statement during the init process when the package dir matches a hackage package name. 

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
