### PR TITLE
use config (i.e. freeze) constraints also as solver version prefs

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -288,7 +288,7 @@ resolveSolverSettings ProjectConfig{
     -- for any constraints to a fixed package, just to "hint" the solver a little
     constraintToVersionPref :: Show a => (UserConstraint, a) -> Maybe PackageVersionConstraint
     constraintToVersionPref (UserConstraint (UserQualified UserQualToplevel pn) (PackagePropertyVersion vrange),_) = Just (PackageVersionConstraint pn vrange)
-    constraintToVersionPref x = Nothing -- trace ("nomatch constraint: " ++ show x) Nothing
+    constraintToVersionPref _ = Nothing 
 
 -- | Resolve the project configuration, with all its optional fields, into
 -- 'BuildTimeSettings' with no optional fields (by applying defaults).


### PR DESCRIPTION
This extends version prefs handed to the solver (to guide it) by any version constraints fixed directly in a project config (or freeze) file. It cuts down the number of local backjumps, because the prefs are applied before directly traversing the version tree. This was done to see if it could improve the situation in #7466 but my tests don't seem to show a significant speedup -- i.e. local backjumps appear cheap, similar to #7490 .

So I'm not sure if there's any significant benefit in ensuring preferences are applied before running the solver and just letting the constraint conflict machinery immediately apply the fixed version constraints from the freeze file. Again interested in feedback from the Usual solver experts (@dcoutts @grayjay @ezyang and anyone else I may not have thought of here).