### PR TITLE
Force cabal to use a build plan where exe:cabal-plan is enabled

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install cabal-plan
         run: |
           cd $(mktemp -d)
-          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
+          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast' --constraint='cabal-plan +exe'
       - uses: actions/checkout@v2
       - name: Validate print-config
         run: sh validate.sh -j 2 -w ghc-8.8.3 -v  -s print-config
@@ -104,7 +104,7 @@ jobs:
       - name: Install cabal-plan
         run: |
           cd $(mktemp -d)
-          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
+          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast' --constraint='cabal-plan +exe'
       - uses: actions/checkout@v2
       - name: Validate print-config
         run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s print-config

--- a/templates/ci-macos.template.yml
+++ b/templates/ci-macos.template.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           cd $(mktemp -d)
 {# aeson +fast, so we don't wait for -O2 #}
-          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
+          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast' --constraint='cabal-plan +exe'
       - uses: actions/checkout@v2
 {% for step in job.steps %}
       - name: Validate {{step}}


### PR DESCRIPTION
For some reason, `cabal v2-install cabal-plan` installs the library on macos instead of the executable, causing CI failures such as: https://github.com/haskell/cabal/pull/7477/checks?check_run_id=3170346447

Logs from CI:
``` 
  cd $(mktemp -d)
  cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
  shell: /bin/bash -e {0}
Resolving dependencies...
Build profile: -w ghc-8.8.3 -O1
In order, the following will be built (use -v for more details):
 - base-compat-0.11.2 (lib) (requires download & build)
 - base-orphans-0.8.4 (lib) (requires download & build)
 - base16-bytestring-0.1.1.7 (lib) (requires download & build)
 - dlist-1.0 (lib) (requires download & build)
 - hashable-1.3.2.0 (lib) (requires download & build)
 - indexed-traversable-0.1.1 (lib) (requires download & build)
 - integer-logarithms-1.0.3.1 (lib) (requires download & build)
 - primitive-0.7.1.0 (lib) (requires download & build)
 - splitmix-0.1.0.3 (lib) (requires download & build)
 - tagged-0.8.6.1 (lib) (requires download & build)
 - th-abstraction-0.4.2.0 (lib) (requires download & build)
 - transformers-compat-0.7 (lib) (requires download & build)
 - base-compat-batteries-0.11.2 (lib) (requires download & build)
 - time-compat-1.9.6 (lib) (requires download & build)
 - unordered-containers-0.2.14.0 (lib) (requires download & build)
 - data-fix-0.3.1 (lib) (requires download & build)
 - vector-0.12.3.0 (lib) (requires download & build)
 - scientific-0.3.7.0 (lib) (requires download & build)
 - random-1.2.0 (lib) (requires download & build)
 - distributive-0.6.2.1 (lib) (requires download & build)
 - attoparsec-0.14.1 (lib) (requires download & build)
 - uuid-types-1.0.5 (lib) (requires download & build)
 - comonad-5.0.8 (lib) (requires download & build)
 - bifunctors-5.5.11 (lib) (requires download & build)
 - assoc-1.0.2 (lib) (requires download & build)
 - these-1.1.1.1 (lib) (requires download & build)
 - strict-0.4.0.1 (lib) (requires download & build)
 - aeson-1.5.6.0 (lib) (requires download & build)
 - cabal-plan-0.6.2.0 (lib) (requires download & build)
Downloading  base-orphans-0.8.4
``` 

See the missing goal 
```
 - cabal-plan-0.6.2.0 (exe:cabal-plan) (requires download & build)
 ```
 
 And the logs also report:
```
...
 Completed    cabal-plan-0.6.2.0 (lib)
Warning:
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@ WARNING: Installation might not be completed as desired! @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Without flags, the command "cabal install" doesn't expose libraries in a
usable manner. You might have wanted to run "cabal install --lib cabal-plan". 
```

This is a work-around to force `cabal` to always build the exe (At least I hope that is what it does.)