### PR TITLE
Remove show-build-info command and generate build-info as a side-effect of 'build'

### DIFF
--- a/Cabal-QuickCheck/src/Test/QuickCheck/Instances/Cabal.hs
+++ b/Cabal-QuickCheck/src/Test/QuickCheck/Instances/Cabal.hs
@@ -25,7 +25,7 @@ import Distribution.ModuleName
 import Distribution.Simple.Compiler                (DebugInfoLevel (..), OptimisationLevel (..), PackageDB (..), ProfDetailLevel (..), knownProfDetailLevels)
 import Distribution.Simple.Flag                    (Flag (..))
 import Distribution.Simple.InstallDirs
-import Distribution.Simple.Setup                   (HaddockTarget (..), TestShowDetails (..))
+import Distribution.Simple.Setup                   (HaddockTarget (..), TestShowDetails (..), DumpBuildInfo)
 import Distribution.SPDX
 import Distribution.System
 import Distribution.Types.Dependency
@@ -486,6 +486,12 @@ instance Arbitrary PackageDB where
                       , SpecificPackageDB <$> arbitraryShortToken
                       ]
 
+-------------------------------------------------------------------------------
+-- DumpBuildInfo
+-------------------------------------------------------------------------------
+
+instance Arbitrary DumpBuildInfo where
+    arbitrary = arbitraryBoundedEnum
 
 -------------------------------------------------------------------------------
 -- Helpers

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -29,7 +29,7 @@ tests = testGroup "Distribution.Utils.Structured"
     , testCase "GenericPackageDescription" $
       md5Check (Proxy :: Proxy GenericPackageDescription) 0xa164cbe5092a1cd31da1f15358d1537a
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0xac70971ea59d30aab7e4b6dafc9113d4
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0x9ce83e4aec3b2fa6d7f999dbc32c2a33
 #endif
     ]
 

--- a/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
+++ b/Cabal-tree-diff/src/Data/TreeDiff/Instances/Cabal.hs
@@ -29,6 +29,7 @@ import Distribution.Simple.Setup                   (HaddockTarget, TestShowDetai
 import Distribution.System
 import Distribution.Types.AbiHash                  (AbiHash)
 import Distribution.Types.ComponentId              (ComponentId)
+import Distribution.Types.DumpBuildInfo            (DumpBuildInfo)
 import Distribution.Types.PackageVersionConstraint
 import Distribution.Types.UnitId                   (DefUnitId, UnitId)
 import Distribution.Utils.NubList                  (NubList)
@@ -74,6 +75,7 @@ instance ToExpr CompilerId
 instance ToExpr ComponentId
 instance ToExpr DebugInfoLevel
 instance ToExpr DefUnitId
+instance ToExpr DumpBuildInfo
 instance ToExpr ExeDependency
 instance ToExpr Executable
 instance ToExpr ExecutableScope

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -201,6 +201,7 @@ library
     Distribution.Types.ComponentInclude
     Distribution.Types.ConfVar
     Distribution.Types.Dependency
+    Distribution.Types.DumpBuildInfo
     Distribution.Types.ExeDependency
     Distribution.Types.LegacyExeDependency
     Distribution.Types.PkgconfigDependency

--- a/Cabal/src/Distribution/Simple/Build.hs
+++ b/Cabal/src/Distribution/Simple/Build.hs
@@ -141,8 +141,9 @@ showBuildInfo :: PackageDescription  -- ^ Mostly information from the .cabal fil
 showBuildInfo pkg_descr lbi flags = do
   let verbosity = fromFlag (buildVerbosity flags)
   targets <- readTargetInfos verbosity pkg_descr lbi (buildArgs flags)
+  pwd <- getCurrentDirectory
   let targetsToBuild = neededTargetsInBuildOrder' pkg_descr lbi (map nodeKey targets)
-      doc = mkBuildInfo pkg_descr lbi flags targetsToBuild
+      doc = mkBuildInfo pwd pkg_descr lbi flags targetsToBuild
   return $ renderJson doc
 
 

--- a/Cabal/src/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/src/Distribution/Simple/BuildPaths.hs
@@ -15,7 +15,7 @@
 
 module Distribution.Simple.BuildPaths (
     defaultDistPref, srcPref,
-    haddockDirName, hscolourPref, haddockPref,
+    buildInfoPref, haddockDirName, hscolourPref, haddockPref,
     autogenPackageModulesDir,
     autogenComponentModulesDir,
 
@@ -66,6 +66,10 @@ srcPref distPref = distPref </> "src"
 
 hscolourPref :: HaddockTarget -> FilePath -> PackageDescription -> FilePath
 hscolourPref = haddockPref
+
+-- | Build info json file, generated in every build
+buildInfoPref :: FilePath -> FilePath
+buildInfoPref distPref = distPref </> "build-info.json"
 
 -- | This is the name of the directory in which the generated haddocks
 -- should be stored. It does not include the @<dist>/doc/html@ prefix.

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -2189,15 +2189,18 @@ optionNumJobs get set =
 -- ------------------------------------------------------------
 
 data ShowBuildInfoFlags = ShowBuildInfoFlags
-  { buildInfoBuildFlags :: BuildFlags
-  , buildInfoOutputFile :: Maybe FilePath
+  { buildInfoBuildFlags     :: BuildFlags
+  , buildInfoOutputFile     :: Maybe FilePath
+  , buildInfoComponentsOnly :: Flag Bool
+  -- ^ If 'True' then only print components, each separated by a newline
   } deriving (Show, Typeable)
 
 defaultShowBuildFlags  :: ShowBuildInfoFlags
 defaultShowBuildFlags =
     ShowBuildInfoFlags
-      { buildInfoBuildFlags = defaultBuildFlags
-      , buildInfoOutputFile = Nothing
+      { buildInfoBuildFlags     = defaultBuildFlags
+      , buildInfoOutputFile     = Nothing
+      , buildInfoComponentsOnly = Flag False
       }
 
 showBuildInfoCommand :: ProgramDb -> CommandUI ShowBuildInfoFlags
@@ -2234,8 +2237,12 @@ showBuildInfoCommand progDb = CommandUI
       ++
       [ option [] ["buildinfo-json-output"]
                 "Write the result to the given file instead of stdout"
-                buildInfoOutputFile (\pf flags -> flags { buildInfoOutputFile = pf })
+                buildInfoOutputFile (\v flags -> flags { buildInfoOutputFile = v })
                 (reqArg' "FILE" Just (maybe [] pure))
+      , option [] ["buildinfo-components-only"]
+                  "Print out only the component info, each separated by a newline"
+                  buildInfoComponentsOnly (\v flags -> flags { buildInfoComponentsOnly = v})
+                  trueArg
       ]
 
   }

--- a/Cabal/src/Distribution/Simple/ShowBuildInfo.hs
+++ b/Cabal/src/Distribution/Simple/ShowBuildInfo.hs
@@ -104,6 +104,10 @@ mkBuildInfo wdir pkg_descr lbi _flags targetsToBuild = (warnings, JsonObject bui
 
 -- | A variant of 'mkBuildInfo' if you need to call 'mkCompilerInfo' and
 -- 'mkComponentInfo' yourself.
+--
+-- If you change the format or any name in the output json, don't forget to update
+-- the schema at @\/doc\/json-schemas\/build-info.schema.json@ and the docs of
+-- @--enable-build-info@\/@--disable-build-info@.
 mkBuildInfo'
   :: Json   -- ^ The 'Json' from 'mkCompilerInfo'
   -> [Json] -- ^ The 'Json' from 'mkComponentInfo'

--- a/Cabal/src/Distribution/Types/DumpBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/DumpBuildInfo.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+module Distribution.Types.DumpBuildInfo
+    ( DumpBuildInfo(..)
+    ) where
+
+import Distribution.Compat.Prelude
+
+data DumpBuildInfo
+  = NoDumpBuildInfo
+  | DumpBuildInfo
+  deriving (Read, Show, Eq, Ord, Enum, Bounded, Generic, Typeable)
+
+instance Binary DumpBuildInfo
+instance Structured DumpBuildInfo

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -409,6 +409,7 @@ instance Semigroup SavedConfig where
         configFlagError           = combine configFlagError,
         configRelocatable         = combine configRelocatable,
         configUseResponseFiles    = combine configUseResponseFiles,
+        configDumpBuildInfo       = combine configDumpBuildInfo,
         configAllowDependingOnPrivateLibs =
             combine configAllowDependingOnPrivateLibs
         }

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -59,7 +59,7 @@ import Distribution.Simple.Compiler
          ( Compiler, CompilerFlavor
          , OptimisationLevel(..), ProfDetailLevel, DebugInfoLevel(..) )
 import Distribution.Simple.Setup
-         ( Flag, HaddockTarget(..), TestShowDetails(..) )
+         ( Flag, HaddockTarget(..), TestShowDetails(..), DumpBuildInfo (..) )
 import Distribution.Simple.InstallDirs
          ( PathTemplate )
 import Distribution.Utils.NubList
@@ -271,6 +271,7 @@ data PackageConfig
        packageConfigCoverage            :: Flag Bool,
        packageConfigRelocatable         :: Flag Bool,
        packageConfigDebugInfo           :: Flag DebugInfoLevel,
+       packageConfigDumpBuildInfo       :: Flag DumpBuildInfo,
        packageConfigRunTests            :: Flag Bool, --TODO: [required eventually] use this
        packageConfigDocumentation       :: Flag Bool, --TODO: [required eventually] use this
        -- Haddock options

--- a/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
@@ -179,17 +179,17 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
      where
       -- | Only add build-info file location if the Setup.hs CLI
       -- is recent enough to be able to generate build info files.
-      -- Otherwise, do not add the expected file location.
+      -- Otherwise, write 'null'.
       --
-      -- Consumers of `plan.json` can use the absence of this file location
+      -- Consumers of `plan.json` can use the nullability of this file location
       -- to indicate that the given component uses `build-type: Custom`
       -- with an old lib:Cabal version.
       buildInfoFileLocation :: J.Pair
       buildInfoFileLocation
         | elabSetupScriptCliVersion elab < mkVersion [3, 7, 0, 0]
-        = ("build-info" J..= J.Null)
+        = "build-info" J..= J.Null
         | otherwise
-        = ("build-info" J..= J.String (buildInfoPref dist_dir))
+        = "build-info" J..= J.String (buildInfoPref dist_dir)
 
       packageLocationToJ :: PackageLocation (Maybe FilePath) -> J.Value
       packageLocationToJ pkgloc =

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -115,6 +115,8 @@ import           Distribution.ModuleName
 import           Distribution.Package
 import           Distribution.Types.AnnotatedId
 import           Distribution.Types.ComponentName
+import           Distribution.Types.DumpBuildInfo
+                   ( DumpBuildInfo (..) )
 import           Distribution.Types.LibraryName
 import           Distribution.Types.GivenComponent
   (GivenComponent(..))
@@ -1838,6 +1840,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
         elabStripLibs     = perPkgOptionFlag pkgid False packageConfigStripLibs
         elabStripExes     = perPkgOptionFlag pkgid False packageConfigStripExes
         elabDebugInfo     = perPkgOptionFlag pkgid NoDebugInfo packageConfigDebugInfo
+        elabDumpBuildInfo = perPkgOptionFlag pkgid NoDumpBuildInfo packageConfigDumpBuildInfo
 
         -- Combine the configured compiler prog settings with the user-supplied
         -- config. For the compiler progs any user-supplied config was taken
@@ -3468,6 +3471,7 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
     configStripExes           = toFlag elabStripExes
     configStripLibs           = toFlag elabStripLibs
     configDebugInfo           = toFlag elabDebugInfo
+    configDumpBuildInfo       = toFlag elabDumpBuildInfo
 
     configConfigurationsFlags = elabFlagAssignment
     configConfigureArgs       = elabConfigureScriptArgs

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -95,7 +95,8 @@ import           Distribution.Simple.LocalBuildInfo
                    ( ComponentName(..), LibraryName(..) )
 import qualified Distribution.Simple.InstallDirs as InstallDirs
 import           Distribution.Simple.InstallDirs (PathTemplate)
-import           Distribution.Simple.Setup (HaddockTarget, TestShowDetails, ReplOptions)
+import           Distribution.Simple.Setup
+                   ( HaddockTarget, TestShowDetails, DumpBuildInfo (..), ReplOptions )
 import           Distribution.Version
 
 import qualified Distribution.Solver.Types.ComponentDeps as CD
@@ -261,6 +262,7 @@ data ElaboratedConfiguredPackage
        elabStripLibs            :: Bool,
        elabStripExes            :: Bool,
        elabDebugInfo            :: DebugInfoLevel,
+       elabDumpBuildInfo        :: DumpBuildInfo,
 
        elabProgramPaths          :: Map String FilePath,
        elabProgramArgs           :: Map String [String],

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -450,7 +450,7 @@ filterConfigureFlags :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags flags cabalLibVersion
   -- NB: we expect the latest version to be the most common case,
   -- so test it first.
-  | cabalLibVersion >= mkVersion [2,5,0]  = flags_latest
+  | cabalLibVersion >= mkVersion [3,7,0]  = flags_latest
   -- The naming convention is that flags_version gives flags with
   -- all flags *introduced* in version eliminated.
   -- It is NOT the latest version of Cabal library that
@@ -483,7 +483,10 @@ filterConfigureFlags flags cabalLibVersion
 
     flags_3_7_0 = flags_latest {
         -- Cabal < 3.7 does not know about --extra-lib-dirs-static
-        configExtraLibDirsStatic = []
+        configExtraLibDirsStatic = [],
+
+        -- Cabal < 3.7 does not understand '--enable-build-info' or '--disable-build-info'
+        configDumpBuildInfo = NoFlag
       }
 
     flags_2_5_0 = flags_3_7_0 {

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -559,7 +559,7 @@ instance Arbitrary PackageConfig where
         <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary
-        <*> arbitrary <*> arbitrary
+        <*> arbitrary <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary
         <*> arbitraryFlag arbitraryShortToken
         <*> arbitrary
@@ -618,6 +618,7 @@ instance Arbitrary PackageConfig where
                          , packageConfigCoverage = x25
                          , packageConfigRelocatable = x26
                          , packageConfigDebugInfo = x27
+                         , packageConfigDumpBuildInfo = x27_1
                          , packageConfigRunTests = x28
                          , packageConfigDocumentation = x29
                          , packageConfigHaddockHoogle = x30
@@ -674,6 +675,7 @@ instance Arbitrary PackageConfig where
                       , packageConfigCoverage = x25'
                       , packageConfigRelocatable = x26'
                       , packageConfigDebugInfo = x27'
+                      , packageConfigDumpBuildInfo = x27_1'
                       , packageConfigRunTests = x28'
                       , packageConfigDocumentation = x29'
                       , packageConfigHaddockHoogle = x30'
@@ -703,7 +705,7 @@ instance Arbitrary PackageConfig where
           (x10', x11', x12', x13', x14'),
           (x15', x16', x53', x17', x18', x19')),
          ((x20', x20_1', x21', x22', x23', x24'),
-          (x25', x26', x27', x28', x29'),
+          (x25', x26', x27', x27_1', x28', x29'),
           (x30', x31', x32', (x33', x33_1'), x34'),
           (x35', x36', x37', x38', x43', x39'),
           (x40', x41'),
@@ -717,7 +719,7 @@ instance Arbitrary PackageConfig where
                   map NonEmpty x18,
                   x19)),
                ((x20, x20_1, x21, x22, x23, x24),
-                 (x25, x26, x27, x28, x29),
+                 (x25, x26, x27, x27_1, x28, x29),
                  (x30, x31, x32, (x33, x33_1), x34),
                  (x35, x36, fmap NonEmpty x37, x38, x43, fmap NonEmpty x39),
                  (x40, x41),

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/A.cabal
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/A.cabal
@@ -1,0 +1,23 @@
+cabal-version:       2.4
+name:                A
+version:             0.1.0.0
+license:             BSD-3-Clause
+
+library
+  exposed-modules:     A
+  build-depends:       base >=4
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+
+executable A
+  main-is:             Main.hs
+  build-depends:       base >=4
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+
+test-suite A-tests
+  type:                exitcode-stdio-1.0
+  main-is:             Test.hs
+  build-depends:       base >=4, A
+  hs-source-dirs:      src
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/B/B.cabal
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/B/B.cabal
@@ -1,0 +1,10 @@
+cabal-version:       2.4
+name:                B
+version:             0.1.0.0
+license:             BSD-3-Clause
+
+library
+  exposed-modules:     B
+  build-depends:       base >=4.0.0.0, A
+  hs-source-dirs:      lib
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/B/lib/B.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/B/lib/B.hs
@@ -1,0 +1,4 @@
+module B where
+
+foo :: Int -> Int
+foo = id

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/build-info-all.out
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/build-info-all.out
@@ -1,0 +1,20 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - A-0.1.0.0 (lib) (first run)
+ - A-0.1.0.0 (exe:A) (first run)
+ - B-0.1.0.0 (lib) (first run)
+ - A-0.1.0.0 (test:A-tests) (first run)
+Configuring library for A-0.1.0.0..
+Preprocessing library for A-0.1.0.0..
+Building library for A-0.1.0.0..
+Configuring executable 'A' for A-0.1.0.0..
+Preprocessing executable 'A' for A-0.1.0.0..
+Building executable 'A' for A-0.1.0.0..
+Configuring library for B-0.1.0.0..
+Preprocessing library for B-0.1.0.0..
+Building library for B-0.1.0.0..
+Configuring test suite 'A-tests' for A-0.1.0.0..
+Preprocessing test suite 'A-tests' for A-0.1.0.0..
+Building test suite 'A-tests' for A-0.1.0.0..

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/build-info-all.test.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/build-info-all.test.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+import           Test.Cabal.Prelude
+import           Test.Cabal.DecodeShowBuildInfo
+
+main = cabalTest $ do
+  runShowBuildInfo ["all", "--enable-tests"]
+  withPlan $ do
+    assertComponent "A" (exe "A")
+      defCompAssertion
+        { sourceFiles = ["Main.hs"]
+        , sourceDirs = ["src"]
+        }
+    assertComponent "A" mainLib
+      defCompAssertion
+        { modules = ["A"]
+        , sourceDirs = ["src"]
+        }
+
+    assertComponent "B" mainLib
+      defCompAssertion
+        { modules = ["B"]
+        , sourceDirs = ["lib"]
+        }
+    assertComponent "A" (test "A-tests")
+      defCompAssertion
+        { sourceFiles = ["Test.hs"]
+        , sourceDirs = ["src"]
+        }

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/build-info-exe.out
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/build-info-exe.out
@@ -1,0 +1,8 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - A-0.1.0.0 (exe:A) (first run)
+Configuring executable 'A' for A-0.1.0.0..
+Preprocessing executable 'A' for A-0.1.0.0..
+Building executable 'A' for A-0.1.0.0..

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/build-info-exe.test.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/build-info-exe.test.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+import           Test.Cabal.Prelude
+import           Test.Cabal.DecodeShowBuildInfo
+
+main = cabalTest $ do
+  runShowBuildInfo ["exe:A"]
+  withPlan $ do
+    assertComponent "A" (exe "A")
+      defCompAssertion
+          { sourceFiles = ["Main.hs"]
+          , sourceDirs = ["src"]
+          -- does not list lib as a target
+          , compilerArgsPred = all (/= "A-0.1.0.0-inplace")
+          }

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/cabal.project
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/cabal.project
@@ -1,0 +1,1 @@
+packages: . ./B/

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/remove-outdated.out
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/remove-outdated.out
@@ -1,0 +1,15 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - A-0.1.0.0 (exe:A) (first run)
+Configuring executable 'A' for A-0.1.0.0..
+Preprocessing executable 'A' for A-0.1.0.0..
+Building executable 'A' for A-0.1.0.0..
+# cabal v2-build
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - A-0.1.0.0 (exe:A) (configuration changed)
+Configuring executable 'A' for A-0.1.0.0..
+Preprocessing executable 'A' for A-0.1.0.0..
+Building executable 'A' for A-0.1.0.0..

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/remove-outdated.test.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/remove-outdated.test.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+import           Test.Cabal.Prelude
+import           Test.Cabal.DecodeShowBuildInfo
+import           Test.Cabal.Plan
+import           Control.Monad.Trans.Reader
+import           System.Directory
+
+main = cabalTest $ do
+  runShowBuildInfo ["exe:A"]
+  withPlan $ do
+    assertComponent "A" (exe "A")
+      defCompAssertion
+          { sourceFiles = ["Main.hs"]
+          , sourceDirs = ["src"]
+          -- does not list lib as a target
+          , compilerArgsPred = all (/= "A-0.1.0.0-inplace")
+          }
+
+  cabal' "v2-build" ["exe:A", "--disable-build-info"]
+  withPlan $ do
+    Just plan <- fmap testPlan ask
+    let fp = buildInfoFile plan "A" (exe "A")
+    shouldNotExist fp

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/remove-outdated.test.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/remove-outdated.test.hs
@@ -3,7 +3,6 @@ import           Test.Cabal.Prelude
 import           Test.Cabal.DecodeShowBuildInfo
 import           Test.Cabal.Plan
 import           Control.Monad.Trans.Reader
-import           System.Directory
 
 main = cabalTest $ do
   runShowBuildInfo ["exe:A"]

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/src/A.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/src/A.hs
@@ -1,0 +1,3 @@
+module A where
+
+foo = 2

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/src/Main.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/src/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = return ()

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/A/src/Test.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/A/src/Test.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = return ()

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/CompileFail.cabal
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/CompileFail.cabal
@@ -1,0 +1,29 @@
+cabal-version:      3.0
+name:               CompileFail
+version:            0.1.0.0
+build-type:         Simple
+
+library
+    exposed-modules:  MyLib
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+library failing
+    exposed-modules:  MyLib2
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite CompileFail-test
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Main.hs
+    build-depends:    base, CompileFail
+
+executable CompileFail-exe
+    default-language: Haskell2010
+    hs-source-dirs:   app
+    main-is:          Main.hs
+    build-depends:    base, failing

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/app/Main.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/app/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import MyLib2 (someFunc2)
+
+main :: IO ()
+main = someFunc2

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/cabal.project
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/cabal.project
@@ -1,0 +1,1 @@
+packages: ./

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/compile-fail.out
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/compile-fail.out
@@ -1,0 +1,22 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - CompileFail-0.1.0.0 (lib) (first run)
+ - CompileFail-0.1.0.0 (test:CompileFail-test) (first run)
+Configuring library for CompileFail-0.1.0.0..
+Preprocessing library for CompileFail-0.1.0.0..
+Building library for CompileFail-0.1.0.0..
+Configuring test suite 'CompileFail-test' for CompileFail-0.1.0.0..
+Preprocessing test suite 'CompileFail-test' for CompileFail-0.1.0.0..
+Building test suite 'CompileFail-test' for CompileFail-0.1.0.0..
+# cabal build
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - CompileFail-0.1.0.0 (lib:failing) (first run)
+ - CompileFail-0.1.0.0 (exe:CompileFail-exe) (first run)
+Configuring library 'failing' for CompileFail-0.1.0.0..
+Preprocessing library 'failing' for CompileFail-0.1.0.0..
+Building library 'failing' for CompileFail-0.1.0.0..
+cabal: Failed to build CompileFail-0.1.0.0 because it depends on CompileFail-0.1.0.0 which itself failed to build.
+Failed to build CompileFail-0.1.0.0-inplace-failing.

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/compile-fail.test.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/compile-fail.test.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+import           Test.Cabal.Prelude
+import           Test.Cabal.DecodeShowBuildInfo
+import           Test.Cabal.Plan
+import           Control.Monad.Trans.Reader
+
+main = cabalTest $ do
+  -- Leaf component fails to compile, should still dump
+  -- build info for both components.
+  fails $ runShowBuildInfo ["test:CompileFail-test"]
+  withPlan $ do
+    -- Lib has to be built, thus info is dumped
+    assertComponent "CompileFail" mainLib
+      defCompAssertion
+        { modules = ["MyLib"]
+        , sourceDirs = ["src"]
+        }
+
+    -- Build Info is still dumped, although compilation failed
+    assertComponent "CompileFail" (test "CompileFail-test")
+      defCompAssertion
+        { sourceFiles = ["Main.hs"]
+        , sourceDirs = ["test"]
+        }
+
+  fails $ runShowBuildInfo ["exe:CompileFail-exe"]
+  withPlan $ do
+    -- Internal Lib has to be built, thus info is dumped
+    assertComponent "CompileFail" (lib "failing")
+      defCompAssertion
+        { modules = ["MyLib2"]
+        , sourceDirs = ["src"]
+        }
+    -- However, since the internal lib failed to compile
+    -- we can not have executable build information.
+    Just plan <- fmap testPlan ask
+    let fp = buildInfoFile plan "CompileFail" (exe "CompileFail-exe")
+    shouldNotExist fp

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/src/MyLib.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/src/MyLib2.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/src/MyLib2.hs
@@ -1,0 +1,6 @@
+module MyLib2 (someFunc2) where
+
+someFunc2 :: IO ()
+-- Intentional typo, should fail to compile
+someFunc2 = putStrn "someFunc"
+--          ^^------- missing 'L'

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/test/Main.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/CompileFail/test/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+main :: IO ()
+-- Intentional typo, should fail to compile
+main = putStrn "Test suite not yet implemented."
+--          ^^------- missing 'L'

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/Complex.cabal
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/Complex.cabal
@@ -1,0 +1,72 @@
+cabal-version: 2.4
+name:          Complex
+version:       0.1.0.0
+license:       MIT
+
+library
+  build-depends:    base
+  hs-source-dirs:   src doesnt-exist
+  default-language: Haskell2010
+  exposed-modules:
+    A
+    B
+
+  autogen-modules:  Paths_Complex
+  other-modules:
+    C
+    D
+    Paths_Complex
+
+  ghc-options:      -Wall
+
+executable Complex
+  main-is:          Main.lhs
+  build-depends:
+    , base
+    , Complex
+
+  hs-source-dirs:   app
+  autogen-modules:  Paths_Complex
+  other-modules:
+    Other
+    Paths_Complex
+
+  ghc-options:
+    -threaded -rtsopts "-with-rtsopts=-N -T" -Wredundant-constraints
+
+  default-language: Haskell2010
+
+test-suite unit-test
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  build-depends:
+    , another-framework
+    , base
+
+  main-is:          UnitMain.hs
+  default-language: Haskell2010
+
+test-suite func-test
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  build-depends:
+    , base
+    , Complex
+    , test-framework
+
+  main-is:          FuncMain.hs
+  default-language: Haskell2010
+
+benchmark complex-benchmarks
+  type:             exitcode-stdio-1.0
+  main-is:          Main.hs
+  other-modules:    Paths_Complex
+  autogen-modules:  Paths_Complex
+  hs-source-dirs:   benchmark
+  ghc-options:      -Wall -rtsopts -threaded -with-rtsopts=-N
+  build-depends:
+    , base
+    , Complex
+    , criterion  ^>=1.1.4
+
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/app/Main.lhs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/app/Main.lhs
@@ -1,0 +1,8 @@
+> module Main where
+>
+> import A
+> import Other
+>
+> main = do
+>     print foo
+>     print bar

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/app/Other.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/app/Other.hs
@@ -1,0 +1,3 @@
+module Other where
+
+bar = ()

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/benchmark/Main.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/benchmark/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = pure ()

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/cabal.project
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/cabal.project
@@ -1,0 +1,4 @@
+packages: .
+
+tests: True
+benchmarks: True

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/repo/another-framework-0.8.1.1/another-framework.cabal
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/repo/another-framework-0.8.1.1/another-framework.cabal
@@ -1,0 +1,8 @@
+name: another-framework
+version: 0.8.1.1
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    build-depends: base
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/repo/criterion-1.1.4.0/criterion.cabal
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/repo/criterion-1.1.4.0/criterion.cabal
@@ -1,0 +1,8 @@
+name: criterion
+version: 1.1.4.0
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    build-depends: base, ghc-prim
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/repo/test-framework-0.8.1.1/test-framework.cabal
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/repo/test-framework-0.8.1.1/test-framework.cabal
@@ -1,0 +1,8 @@
+name: test-framework
+version: 0.8.1.1
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+    build-depends: base
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/single.out
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/single.out
@@ -1,0 +1,67 @@
+# cabal v2-update
+Downloading the latest package list from test-local-repo
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - Complex-0.1.0.0 (lib) (first run)
+ - Complex-0.1.0.0 (exe:Complex) (first run)
+Configuring library for Complex-0.1.0.0..
+Warning: 'hs-source-dirs: doesnt-exist' specifies a directory which does not exist.
+Preprocessing library for Complex-0.1.0.0..
+Building library for Complex-0.1.0.0..
+Configuring executable 'Complex' for Complex-0.1.0.0..
+Warning: 'hs-source-dirs: doesnt-exist' specifies a directory which does not exist.
+Preprocessing executable 'Complex' for Complex-0.1.0.0..
+Building executable 'Complex' for Complex-0.1.0.0..
+# show-build-info Complex exe:Complex
+{"cabal-lib-version":"3.7.0.0","compiler":{"flavour":"ghc","compiler-id":"ghc-<GHCVER>","path":"<GHCPATH>"},"components":[{"type":"exe","name":"exe:Complex","unit-id":"Complex-0.1.0.0-inplace-Complex","compiler-args":["-fbuilding-cabal-package","-O","-outputdir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/x/Complex/build","-odir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/x/Complex/build","-hidir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/x/Complex/build","-stubdir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/x/Complex/build","-i","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/x/Complex/build","-iapp","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/x/Complex/build/Complex/autogen","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/x/Complex/build/global-autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/x/Complex/build/Complex/autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/x/Complex/build/global-autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/x/Complex/build","-optP-include","-optP<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/x/Complex/build/Complex/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","<ROOT>/single.dist/home/.cabal/store/ghc-<GHCVER>/package.db","-package-db","<ROOT>/single.dist/work/./dist/packagedb/ghc-<GHCVER>","-package-id","<PACKAGEDEP>","-package-id","<PACKAGEDEP>","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N -T","-Wredundant-constraints"],"modules":["Other","Paths_Complex"],"src-files":["Main.lhs"],"hs-src-dirs":["app"],"src-dir":"<ROOT>/","cabal-file":"./Complex.cabal"}]}
+# cabal build
+Up to date
+# show-build-info Complex lib
+{"cabal-lib-version":"3.7.0.0","compiler":{"flavour":"ghc","compiler-id":"ghc-<GHCVER>","path":"<GHCPATH>"},"components":[{"type":"lib","name":"lib","unit-id":"Complex-0.1.0.0-inplace","compiler-args":["-fbuilding-cabal-package","-O","-outputdir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/build","-odir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/build","-hidir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/build","-stubdir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/build","-i","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/build","-isrc","-idoesnt-exist","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/build/autogen","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/build/global-autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/build/autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/build/global-autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/build","-optP-include","-optP<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/build/autogen/cabal_macros.h","-this-unit-id","Complex-0.1.0.0-inplace","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","<ROOT>/single.dist/home/.cabal/store/ghc-<GHCVER>/package.db","-package-db","<ROOT>/single.dist/work/./dist/packagedb/ghc-<GHCVER>","-package-id","<PACKAGEDEP>","-XHaskell2010","-Wall"],"modules":["A","B","C","D","Paths_Complex"],"src-files":[],"hs-src-dirs":["src","doesnt-exist"],"src-dir":"<ROOT>/","cabal-file":"./Complex.cabal"}]}
+# cabal build
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - criterion-1.1.4.0 (lib) (requires build)
+ - Complex-0.1.0.0 (bench:complex-benchmarks) (first run)
+Configuring library for criterion-1.1.4.0..
+Preprocessing library for criterion-1.1.4.0..
+Building library for criterion-1.1.4.0..
+Installing library in <PATH>
+Configuring benchmark 'complex-benchmarks' for Complex-0.1.0.0..
+Warning: 'hs-source-dirs: doesnt-exist' specifies a directory which does not exist.
+Preprocessing benchmark 'complex-benchmarks' for Complex-0.1.0.0..
+Building benchmark 'complex-benchmarks' for Complex-0.1.0.0..
+# show-build-info Complex bench:complex-benchmarks
+{"cabal-lib-version":"3.7.0.0","compiler":{"flavour":"ghc","compiler-id":"ghc-<GHCVER>","path":"<GHCPATH>"},"components":[{"type":"bench","name":"bench:complex-benchmarks","unit-id":"Complex-0.1.0.0-inplace-complex-benchmarks","compiler-args":["-fbuilding-cabal-package","-O","-outputdir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/b/complex-benchmarks/build","-odir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/b/complex-benchmarks/build","-hidir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/b/complex-benchmarks/build","-stubdir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/b/complex-benchmarks/build","-i","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/b/complex-benchmarks/build","-ibenchmark","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/b/complex-benchmarks/build/complex-benchmarks/autogen","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/b/complex-benchmarks/build/global-autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/b/complex-benchmarks/build/complex-benchmarks/autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/b/complex-benchmarks/build/global-autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/b/complex-benchmarks/build","-optP-include","-optP<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/b/complex-benchmarks/build/complex-benchmarks/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","<ROOT>/single.dist/home/.cabal/store/ghc-<GHCVER>/package.db","-package-db","<ROOT>/single.dist/work/./dist/packagedb/ghc-<GHCVER>","-package-id","<PACKAGEDEP>","-package-id","<PACKAGEDEP>","-package-id","<PACKAGEDEP>","-XHaskell2010","-Wall","-rtsopts","-threaded","-with-rtsopts=-N"],"modules":["Paths_Complex"],"src-files":["Main.hs"],"hs-src-dirs":["benchmark"],"src-dir":"<ROOT>/","cabal-file":"./Complex.cabal"}]}
+# cabal build
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - test-framework-0.8.1.1 (lib) (requires build)
+ - Complex-0.1.0.0 (test:func-test) (first run)
+Configuring library for test-framework-0.8.1.1..
+Preprocessing library for test-framework-0.8.1.1..
+Building library for test-framework-0.8.1.1..
+Installing library in <PATH>
+Configuring test suite 'func-test' for Complex-0.1.0.0..
+Warning: 'hs-source-dirs: doesnt-exist' specifies a directory which does not exist.
+Preprocessing test suite 'func-test' for Complex-0.1.0.0..
+Building test suite 'func-test' for Complex-0.1.0.0..
+# show-build-info Complex test:func-test
+{"cabal-lib-version":"3.7.0.0","compiler":{"flavour":"ghc","compiler-id":"ghc-<GHCVER>","path":"<GHCPATH>"},"components":[{"type":"test","name":"test:func-test","unit-id":"Complex-0.1.0.0-inplace-func-test","compiler-args":["-fbuilding-cabal-package","-O","-outputdir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/func-test/build","-odir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/func-test/build","-hidir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/func-test/build","-stubdir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/func-test/build","-i","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/func-test/build","-itest","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/func-test/build/func-test/autogen","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/func-test/build/global-autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/func-test/build/func-test/autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/func-test/build/global-autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/func-test/build","-optP-include","-optP<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/func-test/build/func-test/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","<ROOT>/single.dist/home/.cabal/store/ghc-<GHCVER>/package.db","-package-db","<ROOT>/single.dist/work/./dist/packagedb/ghc-<GHCVER>","-package-id","<PACKAGEDEP>","-package-id","<PACKAGEDEP>","-package-id","<PACKAGEDEP>","-XHaskell2010"],"modules":[],"src-files":["FuncMain.hs"],"hs-src-dirs":["test"],"src-dir":"<ROOT>/","cabal-file":"./Complex.cabal"}]}
+# cabal build
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - another-framework-0.8.1.1 (lib) (requires build)
+ - Complex-0.1.0.0 (test:unit-test) (first run)
+Configuring library for another-framework-0.8.1.1..
+Preprocessing library for another-framework-0.8.1.1..
+Building library for another-framework-0.8.1.1..
+Installing library in <PATH>
+Configuring test suite 'unit-test' for Complex-0.1.0.0..
+Warning: 'hs-source-dirs: doesnt-exist' specifies a directory which does not exist.
+Preprocessing test suite 'unit-test' for Complex-0.1.0.0..
+Building test suite 'unit-test' for Complex-0.1.0.0..
+# show-build-info Complex test:unit-test
+{"cabal-lib-version":"3.7.0.0","compiler":{"flavour":"ghc","compiler-id":"ghc-<GHCVER>","path":"<GHCPATH>"},"components":[{"type":"test","name":"test:unit-test","unit-id":"Complex-0.1.0.0-inplace-unit-test","compiler-args":["-fbuilding-cabal-package","-O","-outputdir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/unit-test/build","-odir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/unit-test/build","-hidir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/unit-test/build","-stubdir","<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/unit-test/build","-i","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/unit-test/build","-itest","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/unit-test/build/unit-test/autogen","-i<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/unit-test/build/global-autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/unit-test/build/unit-test/autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/unit-test/build/global-autogen","-I<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/unit-test/build","-optP-include","-optP<ROOT>/single.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/Complex-0.1.0.0/t/unit-test/build/unit-test/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","<ROOT>/single.dist/home/.cabal/store/ghc-<GHCVER>/package.db","-package-db","<ROOT>/single.dist/work/./dist/packagedb/ghc-<GHCVER>","-package-id","<PACKAGEDEP>","-package-id","<PACKAGEDEP>","-XHaskell2010"],"modules":[],"src-files":["UnitMain.hs"],"hs-src-dirs":["test"],"src-dir":"<ROOT>/","cabal-file":"./Complex.cabal"}]}

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/single.test.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/single.test.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE OverloadedStrings #-}
+import           Test.Cabal.Prelude
+import           Test.Cabal.DecodeShowBuildInfo
+
+main = cabalTest $ withRepo "repo" $ do
+  runShowBuildInfo ["exe:Complex"] >> withPlan (do
+    recordBuildInfo "Complex" (exe "Complex")
+    assertComponent "Complex" (exe "Complex") defCompAssertion
+      { modules = ["Other", "Paths_Complex"]
+      , sourceFiles = ["Main.lhs"]
+      , sourceDirs = ["app"]
+      })
+
+  runShowBuildInfo ["lib:Complex"] >> withPlan (do
+    recordBuildInfo "Complex" mainLib
+    assertComponent "Complex" mainLib defCompAssertion
+      { modules = ["A", "B", "C", "D", "Paths_Complex"]
+      , sourceDirs = ["src", "doesnt-exist"]
+      })
+
+  runShowBuildInfo ["benchmark:complex-benchmarks"] >> withPlan (do
+    recordBuildInfo "Complex" (bench "complex-benchmarks")
+    assertComponent "Complex" (bench "complex-benchmarks") defCompAssertion
+      { modules = ["Paths_Complex"]
+      , sourceFiles = ["Main.hs"]
+      , sourceDirs = ["benchmark"]
+      })
+
+  runShowBuildInfo ["test:func-test"] >> withPlan (do
+    recordBuildInfo "Complex" (test "func-test")
+    assertComponent "Complex" (test "func-test") defCompAssertion
+      { sourceFiles = ["FuncMain.hs"]
+      , sourceDirs = ["test"]
+      })
+
+  runShowBuildInfo ["test:unit-test"] >> withPlan (do
+    recordBuildInfo "Complex" (test "unit-test")
+    assertComponent "Complex" (test "unit-test") defCompAssertion
+      { sourceFiles = ["UnitMain.hs"]
+      , sourceDirs = ["test"]
+      })

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/src/A.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/src/A.hs
@@ -1,0 +1,5 @@
+module A where
+
+import D
+
+foo = d

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/src/B.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/src/B.hs
@@ -1,0 +1,3 @@
+module B where
+
+b = 1

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/src/C.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/src/C.hs
@@ -1,0 +1,5 @@
+module C where
+
+import B
+
+c = b

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/src/D.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/src/D.hs
@@ -1,0 +1,5 @@
+module D where
+
+import C
+
+d = c

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/test/FuncMain.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/test/FuncMain.hs
@@ -1,0 +1,1 @@
+main = return ()

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/test/UnitMain.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Complex/test/UnitMain.hs
@@ -1,0 +1,1 @@
+main = return ()

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/Custom.cabal
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/Custom.cabal
@@ -1,0 +1,21 @@
+cabal-version:      3.0
+name:               Custom
+version:            0.1.0.0
+
+build-type:         Custom
+
+custom-setup
+  setup-depends: Cabal >= 3.7, base
+
+library
+    exposed-modules:  MyLib
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+executable great-exe
+    main-is:          Main.hs
+    build-depends:    base, Custom
+    hs-source-dirs:   app
+    default-language: Haskell2010
+

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/Setup.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/Setup.hs
@@ -1,0 +1,12 @@
+-- Setup.hs taken from 'cabal-testsuite/Setup.hs'
+{-# LANGUAGE Haskell2010 #-}
+module Main (main) where
+
+import Distribution.Simple
+
+main :: IO ()
+main = defaultMainWithHooks simpleUserHooks
+    { buildHook = \pkg lbi hooks flags -> do
+        putStrLn "Custom Setup.hs has been invoked!"
+        buildHook simpleUserHooks pkg lbi hooks flags
+    }

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/app/Main.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/app/Main.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import MyLib
+
+main = pure ()

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/cabal.project
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/cabal.project
@@ -1,0 +1,2 @@
+packages:
+    .

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/custom.out
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/custom.out
@@ -1,0 +1,7 @@
+# Setup configure
+Configuring Custom-0.1.0.0...
+# Setup build
+Preprocessing library for Custom-0.1.0.0..
+Building library for Custom-0.1.0.0..
+Preprocessing executable 'great-exe' for Custom-0.1.0.0..
+Building executable 'great-exe' for Custom-0.1.0.0..

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/custom.test.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/custom.test.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE OverloadedStrings #-}
+import           Test.Cabal.Prelude
+import           Test.Cabal.DecodeShowBuildInfo
+import           Control.Monad.Trans.Reader
+
+main = setupTest $ do
+  -- No cabal test because per-component is broken with it
+  skipUnlessGhcVersion ">= 8.1"
+  withPackageDb $ do
+    setup_build ["--enable-build-info"]
+    env <- ask
+    let buildInfoFp = testDistDir env </> "build-info.json"
+    buildInfo <- decodeBuildInfoFile buildInfoFp
+    assertCommonBuildInfo buildInfo
+    let [libBI, exeBI] = components buildInfo
+    
+    assertComponentPure libBI defCompAssertion
+      { modules = ["MyLib"]
+      , compType = "lib"
+      , sourceDirs = ["src"]
+      }
+
+    assertComponentPure exeBI defCompAssertion
+      { sourceFiles = ["Main.hs"]
+      , compType = "exe"
+      , sourceDirs = ["app"]
+      }
+

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/src/MyLib.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -39,6 +39,7 @@ library
   hs-source-dirs: src
   exposed-modules:
     Test.Cabal.CheckArMetadata
+    Test.Cabal.DecodeShowBuildInfo
     Test.Cabal.Monad
     Test.Cabal.OutputNormalizer
     Test.Cabal.Plan

--- a/cabal-testsuite/src/Test/Cabal/DecodeShowBuildInfo.hs
+++ b/cabal-testsuite/src/Test/Cabal/DecodeShowBuildInfo.hs
@@ -111,7 +111,7 @@ defCompAssertion = ComponentAssertion
   , modules = []
   , sourceFiles = []
   , sourceDirs = []
-  , compType = mempty
+  , compType = ""
   }
 
 -- | Assert common build information, such as compiler location, compiler version

--- a/cabal-testsuite/src/Test/Cabal/DecodeShowBuildInfo.hs
+++ b/cabal-testsuite/src/Test/Cabal/DecodeShowBuildInfo.hs
@@ -1,0 +1,188 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts #-}
+module Test.Cabal.DecodeShowBuildInfo where
+
+import           Test.Cabal.Prelude
+import           Test.Cabal.Plan
+import           Distribution.Compat.Stack
+import           Distribution.Text (display)
+import           Distribution.Types.ComponentName
+import           Distribution.Types.LibraryName
+import           Distribution.Types.UnqualComponentName
+import           Distribution.Package
+import           Distribution.Pretty (prettyShow)
+import           Control.Monad.Trans.Reader
+import           Data.Aeson
+import           GHC.Generics
+import           System.Exit
+
+-- | Execute 'cabal build --enable-build-info'.
+--
+-- Results can be read via 'withPlan', 'buildInfoFile' and 'decodeBuildInfoFile'.
+runShowBuildInfo :: [String] -> TestM ()
+runShowBuildInfo args = cabal "build" ("--enable-build-info":args)
+
+-- | Read 'build-info.json' for a given package and component
+-- from disk and record the content. Helpful for defining test-cases
+-- where the build info matters.
+recordBuildInfo :: PackageName -> ComponentName -> TestM ()
+recordBuildInfo pkgName cname = do
+  Just plan <- fmap testPlan ask
+  let fp = buildInfoFile plan pkgName cname
+  recordMode RecordAll $ do
+    recordHeader ["show-build-info", prettyShow pkgName, prettyShow cname]
+    buildInfo <- liftIO $ readFile fp
+    recordLog $ Result ExitSuccess "build --enable-build-info" buildInfo
+
+-- | Decode the given filepath into a 'BuildInfo'.
+--
+-- If the filepath doesn't exist or its contents are not a valid 'BuildInfo'
+-- json file, then an error is raised.
+decodeBuildInfoFile :: FilePath -> TestM BuildInfo
+decodeBuildInfoFile fp = do
+  shouldExist fp
+  res <- liftIO $ eitherDecodeFileStrict fp
+  case res of
+    Left err -> fail $ "Could not parse show-build-info file: " ++ err
+    Right buildInfos -> return buildInfos
+
+data BuildInfo = BuildInfo
+  { cabalLibVersion :: String
+  , compiler :: CompilerInfo
+  , components :: [ComponentInfo]
+  } deriving (Generic, Show)
+
+data CompilerInfo = CompilerInfo
+  { flavour :: String
+  , compilerId :: String
+  , path :: String
+  } deriving (Generic, Show)
+
+data ComponentInfo = ComponentInfo
+  { componentType :: String
+  , componentName :: String
+  , componentUnitId :: String
+  , componentCompilerArgs :: [String]
+  , componentModules :: [String]
+  , componentSrcFiles :: [FilePath]
+  , componentHsSrcDirs :: [FilePath]
+  , componentSrcDir :: FilePath
+  } deriving (Generic, Show)
+
+instance ToJSON BuildInfo where
+  toEncoding = genericToEncoding defaultOptions
+instance FromJSON BuildInfo where
+  parseJSON = genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '-' }
+
+instance ToJSON CompilerInfo where
+  toEncoding = genericToEncoding defaultOptions
+instance FromJSON CompilerInfo where
+  parseJSON = genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '-' }
+
+instance ToJSON ComponentInfo where
+  toEncoding = genericToEncoding defaultOptions
+instance FromJSON ComponentInfo where
+  parseJSON = genericParseJSON defaultOptions { fieldLabelModifier = drop 10 . camelTo2 '-' }
+
+-- -----------------------------------------------------------
+-- Assertion Helpers to define succinct test cases
+-- -----------------------------------------------------------
+
+data ComponentAssertion = ComponentAssertion
+  { unitIdPred :: (String -> Bool)
+  -- ^ Predicate to apply to a component's unit id.
+  , compilerArgsPred :: ([String] -> Bool)
+  -- ^ Predicate the compilation arguments must satisfy.
+  , modules :: [String]
+  -- ^ Which modules should a component contain.
+  , sourceFiles :: [FilePath]
+  -- ^ Which source files are part of a component.
+  , sourceDirs :: [FilePath]
+  -- ^ Expected source directories for a component.
+  , compType :: String
+  -- ^ Type of the component, usually one of 'bench', 'exe', 'test', 'lib', 'flib'
+  }
+
+defCompAssertion :: ComponentAssertion
+defCompAssertion = ComponentAssertion
+  { unitIdPred = not . null
+  , compilerArgsPred = not . null
+  , modules = []
+  , sourceFiles = []
+  , sourceDirs = []
+  , compType = mempty
+  }
+
+-- | Assert common build information, such as compiler location, compiler version
+-- and cabal library version.
+assertCommonBuildInfo :: WithCallStack (BuildInfo -> TestM ())
+assertCommonBuildInfo buildInfo = do
+  assertEqual "Cabal Version" (display cabalVersionLibrary) (cabalLibVersion buildInfo)
+  assertEqual "Compiler flavour" "ghc" (flavour $ compiler buildInfo)
+  assertBool "Compiler id" (and $ zipWith (==) "ghc" (compilerId $ compiler buildInfo))
+  assertBool "Compiler path non-empty" (not . null . path $ compiler buildInfo)
+
+-- | Pure assertion helper. Check whether the given 'ComponentInfo' satisfy
+-- the 'ComponentAssertion'.
+assertComponentPure :: WithCallStack (ComponentInfo -> ComponentAssertion -> TestM ())
+assertComponentPure component ComponentAssertion{..} = do
+  assertEqual "Component type" compType (componentType component)
+  assertBool  "Component Unit Id" (unitIdPred $ componentUnitId component)
+  assertBool  "Component compiler args" (compilerArgsPred  $ componentCompilerArgs component)
+  assertEqual "Component modules" modules (componentModules component)
+  assertEqual "Component source files" sourceFiles (componentSrcFiles component)
+  assertEqual "Component source directories" sourceDirs (componentHsSrcDirs component)
+
+-- | @'assertComponent' pkgName cname assertion@
+--
+-- Assert that a component identified by 'pkgName' and 'cname', generated
+-- a 'build-info.json' and its contents satisfy the assertions specified in 'assertion'.
+--
+-- This assertion must be wrapped in 'withPlan'.
+assertComponent :: WithCallStack (PackageName -> ComponentName -> ComponentAssertion -> TestM ())
+assertComponent pkgName cname assert = do
+  Just plan <- fmap testPlan ask
+  let fp = buildInfoFile plan pkgName cname
+  buildInfo <- decodeBuildInfoFile fp
+  assertCommonBuildInfo buildInfo
+
+  let component = findComponentInfo buildInfo
+  let assertWithCompType = assert { compType = compTypeStr cname }
+  assertComponentPure component assertWithCompType
+  where
+    compTypeStr :: ComponentName -> String
+    compTypeStr (CLibName _)    = "lib"
+    compTypeStr (CFLibName _) = "flib"
+    compTypeStr (CExeName _) = "exe"
+    compTypeStr (CTestName _) = "test"
+    compTypeStr (CBenchName _) = "bench"
+
+    findComponentInfo :: BuildInfo -> ComponentInfo
+    findComponentInfo buildInfo =
+      case filter (\c -> prettyShow cname == componentName c) (components buildInfo) of
+        [x] -> x
+        [] ->  error $ "findComponentInfo: component " ++ prettyShow cname ++ " does not"
+                    ++ " exist in build info-file"
+        _   -> error $ "findComponentInfo: found multiple copies of component " ++ prettyShow cname
+                    ++ " in build info plan"
+
+-- | Helper function to create an executable component name.
+exe :: String -> ComponentName
+exe = CExeName . mkUnqualComponentName
+
+-- | Helper function to create a named sub-library component name.
+lib :: String -> ComponentName
+lib = CLibName . LSubLibName . mkUnqualComponentName
+
+-- | Helper function to create an test component name.
+test :: String -> ComponentName
+test = CTestName . mkUnqualComponentName
+
+-- | Helper function to create an benchmark component name.
+bench :: String -> ComponentName
+bench = CBenchName . mkUnqualComponentName
+
+-- | Helper function to create a main library component name.
+mainLib :: ComponentName
+mainLib = CLibName LMainLibName

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -48,6 +48,8 @@ module Test.Cabal.Monad (
     CommonArgs(..),
     renderCommonArgs,
     commonArgParser,
+    -- * Version Constants
+    cabalVersionLibrary,
 ) where
 
 import Test.Cabal.Script
@@ -63,9 +65,11 @@ import Distribution.Simple.Program.Db
 import Distribution.Simple.Program
 import Distribution.Simple.Configure
     ( configCompilerEx )
+import qualified Distribution.Simple.Utils as U (cabalVersion)
 import Distribution.Text
 
 import Distribution.Verbosity
+import Distribution.Version
 
 import Data.Monoid ((<>), mempty)
 import qualified Control.Exception as E
@@ -399,6 +403,7 @@ mkNormalizerEnv = do
     list_out <- liftIO $ readProcess (programPath ghc_pkg_program)
                       ["list", "--global", "--simple-output"] ""
     tmpDir <- liftIO $ getTemporaryDirectory
+
     return NormalizerEnv {
         normalizerRoot
             = addTrailingPathSeparator (testSourceDir env),
@@ -411,8 +416,14 @@ mkNormalizerEnv = do
         normalizerKnownPackages
             = mapMaybe simpleParse (words list_out),
         normalizerPlatform
-            = testPlatform env
+            = testPlatform env,
+        normalizerCabalVersion
+            = cabalVersionLibrary
     }
+    where
+
+cabalVersionLibrary :: Version
+cabalVersionLibrary = U.cabalVersion
 
 requireProgramM :: Program -> TestM ConfiguredProgram
 requireProgramM program = do

--- a/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
+++ b/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
@@ -49,6 +49,7 @@ normalizeOutput nenv =
           "/incoming/new-<RAND>"
     -- Normalize architecture
   . resub (posixRegexEscape (display (normalizerPlatform nenv))) "<ARCH>"
+  . normalizeBuildInfoJson
     -- Some GHC versions are chattier than others
   . resub "^ignoring \\(possibly broken\\) abi-depends field for packages" ""
     -- Normalize the current GHC version.  Apply this BEFORE packageIdRegex,
@@ -67,6 +68,30 @@ normalizeOutput nenv =
         resub (posixRegexEscape (display pid) ++ "(-[A-Za-z0-9.-]+)?")
               (prettyShow (packageName pid) ++ "-<VERSION>")
 
+    -- 'build-info.json' contains a plethora of host system specific information.
+    --
+    -- This must happen before the root-dir normalisation.
+    normalizeBuildInfoJson =
+        -- Remove ghc path from show-build-info output
+        resub ("\"path\":\"[^\"]*\"}")
+          "\"path\":\"<GHCPATH>\"}"
+        -- Remove cabal version output from show-build-info output
+      . resub ("{\"cabal-version\":\"" ++ posixRegexEscape (display (normalizerCabalVersion nenv)) ++ "\"")
+              "{\"cabal-version\":\"<CABALVER>\""
+        -- Remove the package id for stuff such as:
+        -- > "-package-id","base-4.14.0.0-<some-hash>"
+        -- and replace it with:
+        -- > "-package-id","<PACKAGEDEP>"
+        --
+        -- Otherwise, output can not be properly normalized as on MacOs we remove
+        -- vowels from packages to make the names shorter.
+        -- E.g. "another-framework-0.8.1.1" -> "nthr-frmwrk-0.8.1.1"
+        --
+        -- This makes it impossible to have a stable package id, thus remove it completely.
+        -- Check manually in your test-cases if the package-id needs to be verified.
+      . resub ("\"-package-id\",\"([^\"]*)\"")
+              "\"-package-id\",\"<PACKAGEDEP>\""
+
 data NormalizerEnv = NormalizerEnv
     { normalizerRoot          :: FilePath
     , normalizerTmpDir        :: FilePath
@@ -74,6 +99,7 @@ data NormalizerEnv = NormalizerEnv
     , normalizerGhcVersion    :: Version
     , normalizerKnownPackages :: [PackageId]
     , normalizerPlatform      :: Platform
+    , normalizerCabalVersion  :: Version
     }
 
 posixSpecialChars :: [Char]

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -1432,6 +1432,32 @@ Advanced global configuration options
     the ``-package-env -`` option that allows ignoring the package
     environment files).
 
+.. cfg-field:: build-info: True, False
+               --enable-build-info
+               --disable-build-info
+    :synopsis: Whether build information for each individual component should be
+               written in a machine readable format.
+
+    :default: ``False``
+
+    Enable generation of build information for Cabal components. Contains very
+    detailed information on how to build an individual component, such as
+    compiler version, modules of a component and how to compile the component.
+
+    The output format is in json, and the exact location can be discovered from
+    ``plan.json``, where it is identified by ``build-info`` within the items in
+    the ``install-plan``.
+    Note, that this field in ``plan.json`` can be ``null``, if and only if
+    ``build-type: Custom`` is set, and the ``Cabal`` version is too
+    old (i.e. ``< 3.7``).
+    If the field is missing entirely, the component is not a local one, thus,
+    no ``build-info`` exists for that particular component within the
+    ``install-plan``.
+
+    .. note::
+        The format and fields of the generated build information is currently experimental,
+        in the future we might add or remove fields, depending on the needs of other tooling.
+
 
 .. cfg-field:: http-transport: curl, wget, powershell, or plain-http
                --http-transport=transport

--- a/doc/json-schemas/build-info.schema.json
+++ b/doc/json-schemas/build-info.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$comment": "When you change this, make sure to update the code in 'ShowBuildInfo.hs'",
+  "type": "object",
+  "properties": {
+    "cabal-lib-version": {
+      "type": "string"
+    },
+    "compiler": {
+      "type": "object",
+      "properties": {
+        "flavour": {
+          "type": "string"
+        },
+        "compiler-id": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": ["flavour", "compiler-id", "path"]
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "unit-id": {
+            "type": "string"
+          },
+          "compiler-args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "modules": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "src-files": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "hs-src-dirs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "src-dir": {
+            "type": "string"
+          },
+          "cabal-file": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name",
+          "unit-id",
+          "compiler-args",
+          "modules",
+          "src-files",
+          "hs-src-dirs",
+          "src-dir",
+          "cabal-file"
+        ]
+      }
+    }
+  },
+  "required": ["cabal-lib-version", "compiler", "components"]
+}

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 sphinx == 3.1.*
 sphinx_rtd_theme
+sphinx-jsonschema == 1.16.*

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -32,7 +32,7 @@ performs the actual building, while the last both copies the build
 results to some permanent place and registers the package with GHC.
 
 .. note ::
-    
+
     Global installing of packages is not recommended.
     The :ref:`nix-style-builds` is the preferred way of building and installing
     packages.
@@ -1034,6 +1034,61 @@ Miscellaneous options
     Specify a soft constraint on versions of a package. The solver will
     attempt to satisfy these preferences on a "best-effort" basis.
 
+.. option:: --enable-build-info
+
+    Generate accurate build information for build components.
+
+    Information contains meta information, such as component type, compiler type, and
+    Cabal library version used during the build, but also fine grained information,
+    such as dependencies, what modules are part of the component, etc...
+
+    On build, a file ``build-info.json`` (in the ``json`` format) will be written to
+    the root of the build directory.
+
+    .. note::
+        The format and fields of the generated build information is currently
+        experimental. In the future we might add or remove fields, depending
+        on the needs of other tooling.
+
+    :: example
+        {
+            "cabal-lib-version": "<cabal lib version>",
+            "compiler": {
+                "flavour": "<compiler name>",
+                "compiler-id": "<compiler id>",
+                "path": "<absolute path of the compiler>"
+            },
+            "components": [
+                {
+                "type": "<component type, e.g. lib | bench | exe | flib | test>",
+                "name": "<component name>",
+                "unit-id": "<unitid>",
+                "compiler-args": [
+                    "<compiler args necessary for compilation>"
+                ],
+                "modules": [
+                    "<modules in this component>"
+                ],
+                "src-files": [
+                    "<source files relative to hs-src-dirs>"
+                ],
+                "hs-src-dirs": [
+                    "<source directories of this component>"
+                ],
+                "src-dir": "<root directory of this component>",
+                "cabal-file": "<cabal file location>"
+                }
+            ]
+        }
+
+    .. jsonschema:: ./json-schemas/build-info.schema.json
+
+.. option:: --disable-build-info
+
+    (default) Do not generate detailed build information for built components.
+
+    Already generated `build-info.json` files will be removed since they would be stale otherwise.
+
 .. option:: --disable-response-files
 
     Enable workaround for older versions of programs such as ``ar`` or
@@ -1132,7 +1187,7 @@ This command takes the following options:
 .. option:: --hscolour-css=path
 
     The argument *path* denotes a CSS file, which is passed to HsColour_ as in
-    
+
     ::
 
         $ runhaskell Setup.hs hscolour --css=*path*
@@ -1358,7 +1413,7 @@ the package.
     results in real time).
 
 .. option:: --test-options=options
-    
+
     Give extra options to the test executables.
 
 .. option:: --test-option=option


### PR DESCRIPTION
This is the first step for implementing Approach 3 of #7489.
Mainly extracted from #7478 

In particular, add a flag `--enable-build-info` to configure of `Setup.hs` and generate build-info.json right next to `setup-config`.

Readable by tooling.

* [x] Cabal Tests using `build-type: Simple`
* [x] Cabal Tests using `build-type: Custom`
* [x] Optional: Add `cabal configure --enable-dump-buildinfo` (e.g. enable/disable the generation)
* [x] Add `buildInfoJson` to `plan.json` output
* [x] Guard against older Cabal versions