### PR TITLE
Backport 3.6: Force cabal to use a build plan where exe:cabal-plan is enabled

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install cabal-plan
         run: |
           cd $(mktemp -d)
-          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
+          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast' --constraint='cabal-plan +exe'
       - uses: actions/checkout@v2
       - name: Validate print-config
         run: sh validate.sh -j 2 -w ghc-8.8.3 -v  -s print-config
@@ -106,7 +106,7 @@ jobs:
       - name: Install cabal-plan
         run: |
           cd $(mktemp -d)
-          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
+          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast' --constraint='cabal-plan +exe'
       - uses: actions/checkout@v2
       - name: Validate print-config
         run: sh validate.sh -j 2 -w ghc-8.6.5 -v  -s print-config

--- a/templates/ci-macos.template.yml
+++ b/templates/ci-macos.template.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           cd $(mktemp -d)
 {# aeson +fast, so we don't wait for -O2 #}
-          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast'
+          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast' --constraint='cabal-plan +exe'
       - uses: actions/checkout@v2
 {% for step in job.steps %}
       - name: Validate {{step}}


### PR DESCRIPTION
Backport of #7497 