### PR TITLE
Add compilerLocation to Compiler datatype

### DIFF
--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -80,6 +80,7 @@ import Distribution.Compiler
 import Distribution.Version
 import Language.Haskell.Extension
 import Distribution.Simple.Utils
+import Distribution.Simple.Program.Types (ProgramLocation)
 
 import qualified Data.Map as Map (lookup)
 import System.Directory (canonicalizePath)
@@ -97,8 +98,10 @@ data Compiler = Compiler {
         -- ^ Supported language standards.
         compilerExtensions      :: [(Extension, Maybe CompilerFlag)],
         -- ^ Supported extensions.
-        compilerProperties      :: Map String String
+        compilerProperties      :: Map String String,
         -- ^ A key-value map for properties not covered by the above fields.
+        compilerLocation        :: ProgramLocation
+        -- ^ Compiler location
     }
     deriving (Eq, Generic, Typeable, Show, Read)
 

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -204,7 +204,8 @@ configure verbosity hcPath hcPkgPath conf0 = do
         compilerCompat     = [],
         compilerLanguages  = languages,
         compilerExtensions = extensions,
-        compilerProperties = ghcInfoMap
+        compilerProperties = ghcInfoMap,
+        compilerLocation   = programLocation ghcProg
       }
       compPlatform = Internal.targetPlatform ghcInfo
       -- configure gcc and ld

--- a/Cabal/src/Distribution/Simple/GHCJS.hs
+++ b/Cabal/src/Distribution/Simple/GHCJS.hs
@@ -165,7 +165,8 @@ configure verbosity hcPath hcPkgPath conf0 = do
         compilerCompat     = [CompilerId GHC ghcjsGhcVersion],
         compilerLanguages  = languages,
         compilerExtensions = extensions,
-        compilerProperties = ghcInfoMap
+        compilerProperties = ghcInfoMap,
+        compilerLocation   = programLocation ghcjsProg
       }
       compPlatform = Internal.targetPlatform ghcjsInfo
   return (comp, compPlatform, progdb3)

--- a/Cabal/src/Distribution/Simple/HaskellSuite.hs
+++ b/Cabal/src/Distribution/Simple/HaskellSuite.hs
@@ -80,7 +80,8 @@ configure verbosity mbHcPath hcPkgPath progdb0 = do
           compilerCompat         = [],
           compilerLanguages      = languages,
           compilerExtensions     = extensions,
-          compilerProperties     = mempty
+          compilerProperties     = mempty,
+          compilerLocation       = programLocation confdCompiler
         }
 
       return (comp, confdCompiler, progdb2)

--- a/Cabal/src/Distribution/Simple/ShowBuildInfo.hs
+++ b/Cabal/src/Distribution/Simple/ShowBuildInfo.hs
@@ -101,19 +101,8 @@ mkBuildInfo pkg_descr lbi _flags targetsToBuild = info
     mkCompilerInfo = JsonObject
       [ "flavour"     .= JsonString (prettyShow $ compilerFlavor $ compiler lbi)
       , "compiler-id" .= JsonString (showCompilerId $ compiler lbi)
-      , "path"        .= path
+      , "path"        .= JsonString (locationPath $ compilerLocation $ compiler lbi)
       ]
-      where
-        path = maybe JsonNull (JsonString . programPath)
-               $ (flavorToProgram . compilerFlavor $ compiler lbi)
-               >>= flip lookupProgram (withPrograms lbi)
-
-        flavorToProgram :: CompilerFlavor -> Maybe Program
-        flavorToProgram GHC   = Just ghcProgram
-        flavorToProgram GHCJS = Just ghcjsProgram
-        flavorToProgram UHC   = Just uhcProgram
-        flavorToProgram JHC   = Just jhcProgram
-        flavorToProgram _     = Nothing
 
     mkComponentInfo (name, clbi) = JsonObject
       [ "type"          .= JsonString compType

--- a/Cabal/src/Distribution/Simple/UHC.hs
+++ b/Cabal/src/Distribution/Simple/UHC.hs
@@ -54,7 +54,7 @@ configure :: Verbosity -> Maybe FilePath -> Maybe FilePath
           -> ProgramDb -> IO (Compiler, Maybe Platform, ProgramDb)
 configure verbosity hcPath _hcPkgPath progdb = do
 
-  (_uhcProg, uhcVersion, progdb') <-
+  (uhcProg, uhcVersion, progdb') <-
     requireProgramVersion verbosity uhcProgram
     (orLaterVersion (mkVersion [1,0,2]))
     (userMaybeSpecifyPath "uhc" hcPath progdb)
@@ -65,7 +65,8 @@ configure verbosity hcPath _hcPkgPath progdb = do
                compilerCompat     =  [],
                compilerLanguages  =  uhcLanguages,
                compilerExtensions =  uhcLanguageExtensions,
-               compilerProperties =  Map.empty
+               compilerProperties =  Map.empty,
+               compilerLocation   =  programLocation uhcProg
              }
       compPlatform = Nothing
   return (comp, compPlatform, progdb')


### PR DESCRIPTION
Avoids compiler program lookup logic code in `ShowBuildInfo`.

Split off from #7498 based on the comment https://github.com/haskell/cabal/pull/7498#discussion_r682513126