### PR TITLE
Set PATH_SEPARATOR=; when calling ./configure; fix #7494

### DIFF
--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE LambdaCase #-}
@@ -715,7 +716,11 @@ runConfigureScript verbosity backwardsCompatHack flags lbi = do
       pathEnv = maybe (intercalate spSep extraPath)
                 ((intercalate spSep extraPath ++ spSep)++) $ lookup "PATH" env
       overEnv = ("CFLAGS", Just cflagsEnv) :
+-- TODO: Move to either Cabal/src/Distribution/Compat/Environment.hs
+-- or Cabal/src/Distribution/Compat/FilePath.hs:
+#ifdef mingw32_HOST_OS
                 ("PATH_SEPARATOR", Just ";") :
+#endif
                 [("PATH", Just pathEnv) | not (null extraPath)]
       hp = hostPlatform lbi
       maybeHostFlag = if hp == buildPlatform then [] else ["--host=" ++ show (pretty hp)]

--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -715,6 +715,7 @@ runConfigureScript verbosity backwardsCompatHack flags lbi = do
       pathEnv = maybe (intercalate spSep extraPath)
                 ((intercalate spSep extraPath ++ spSep)++) $ lookup "PATH" env
       overEnv = ("CFLAGS", Just cflagsEnv) :
+                ("PATH_SEPARATOR", Just ";") :
                 [("PATH", Just pathEnv) | not (null extraPath)]
       hp = hostPlatform lbi
       maybeHostFlag = if hp == buildPlatform then [] else ["--host=" ++ show (pretty hp)]

--- a/changelog.d/pr-7510
+++ b/changelog.d/pr-7510
@@ -1,0 +1,4 @@
+synopsis: Set PATH_SEPARATOR=";" when calling ./configure on Windows; this fix is necessary for autoconf >= 2.70
+packages: Cabal
+prs: #7510
+issues: #7494


### PR DESCRIPTION
No tests, because they depend on a particular version of autoconf and I think the current tests of autoconf would already fail with the new autoconf version on Windows CI (but either they are not run on Windows or autoconf on CI is old; they are run on Linux, because setting PATH_SEPARATOR breaks these tests and @jneira kindly reproduced the fail on Windows locally).

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
