### PR TITLE
Drop obsolete Backpack warning from Chapter 6. (See: #6005)

### DIFF
--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -404,11 +404,3 @@ not due to implementation but due to fundamental core invariants
 that must be satisfied for it to function correctly in the larger v2-build ecosystem.
 ``autogen-modules`` is able to replace uses of the hooks to add generated modules, along with
 the custom publishing of Haddock documentation to Hackage.
-
-.. warning::
-
-  Packages that use Backpack will stop working if uploaded to
-  Hackage, due to `issue #6005 <https://github.com/haskell/cabal/issues/6005>`_.
-  While this is happening, we recommend not uploading these packages
-  to Hackage (and instead referencing the package directly
-  as a ``source-repository-package``).


### PR DESCRIPTION
With Backpack interoperability problems now resolved, the related warnings in
the documentation can probably be removed. [1]

Drops the sole warning located by a text search for "6005".

[1] https://github.com/haskell/cabal/issues/6005#issuecomment-850468676


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
