### PR TITLE
solver: swap catas with recursion, fuse travs

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Linking.hs
@@ -78,21 +78,21 @@ type Validate = Reader ValidateState
 -- * Equal flag assignments
 -- * Equal stanza assignments
 validateLinking :: Index -> Tree d c -> Tree d c
-validateLinking index = (`runReader` initVS) . cata go
+validateLinking index = (`runReader` initVS) . go
   where
-    go :: TreeF d c (Validate (Tree d c)) -> Validate (Tree d c)
+    go :: Tree d c -> Validate (Tree d c)
 
-    go (PChoiceF qpn rdm gr       cs) =
-      PChoice qpn rdm gr       <$> T.sequence (W.mapWithKey (goP qpn) cs)
-    go (FChoiceF qfn rdm gr t m d cs) =
-      FChoice qfn rdm gr t m d <$> T.sequence (W.mapWithKey (goF qfn) cs)
-    go (SChoiceF qsn rdm gr t     cs) =
-      SChoice qsn rdm gr t     <$> T.sequence (W.mapWithKey (goS qsn) cs)
+    go (PChoice qpn rdm gr       cs) =
+      PChoice qpn rdm gr       <$> (T.sequence . W.mapWithKey (goP qpn) $ fmap go cs)
+    go (FChoice qfn rdm gr t m d cs) =
+      FChoice qfn rdm gr t m d <$> (T.sequence . W.mapWithKey (goF qfn) $ fmap go cs)
+    go (SChoice qsn rdm gr t     cs) =
+      SChoice qsn rdm gr t     <$> (T.sequence . W.mapWithKey (goS qsn) $ fmap go cs)
 
     -- For the other nodes we just recurse
-    go (GoalChoiceF rdm           cs) = GoalChoice rdm <$> T.sequence cs
-    go (DoneF revDepMap s)            = return $ Done revDepMap s
-    go (FailF conflictSet failReason) = return $ Fail conflictSet failReason
+    go (GoalChoice rdm           cs) = GoalChoice rdm <$> T.traverse go cs
+    go (Done revDepMap s)            = return $ Done revDepMap s
+    go (Fail conflictSet failReason) = return $ Fail conflictSet failReason
 
     -- Package choices
     goP :: QPN -> POption -> Validate (Tree d c) -> Validate (Tree d c)

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Linking.hs
@@ -83,11 +83,11 @@ validateLinking index = (`runReader` initVS) . go
     go :: Tree d c -> Validate (Tree d c)
 
     go (PChoice qpn rdm gr       cs) =
-      PChoice qpn rdm gr       <$> (T.sequence . W.mapWithKey (goP qpn) $ fmap go cs)
+      PChoice qpn rdm gr       <$> (W.traverseWithKey (goP qpn) $ fmap go cs)
     go (FChoice qfn rdm gr t m d cs) =
-      FChoice qfn rdm gr t m d <$> (T.sequence . W.mapWithKey (goF qfn) $ fmap go cs)
+      FChoice qfn rdm gr t m d <$> (W.traverseWithKey (goF qfn) $ fmap go cs)
     go (SChoice qsn rdm gr t     cs) =
-      SChoice qsn rdm gr t     <$> (T.sequence . W.mapWithKey (goS qsn) $ fmap go cs)
+      SChoice qsn rdm gr t     <$> (W.traverseWithKey (goS qsn) $ fmap go cs)
 
     -- For the other nodes we just recurse
     go (GoalChoice rdm           cs) = GoalChoice rdm <$> T.traverse go cs

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
@@ -408,8 +408,8 @@ preferBaseGoalChoice = go
 
 -- | Deal with setup and build-tool-depends dependencies after regular dependencies,
 -- so we will link setup/exe dependencies against package dependencies when possible
-deferSetupChoices :: EndoTreeTrav d c
-deferSetupChoices = go
+deferSetupExeChoices :: EndoTreeTrav d c
+deferSetupExeChoices = go
   where
     go (GoalChoiceF rdm xs) = GoalChoiceF rdm (P.preferByKeys noSetupOrExe xs)
     go x                    = x

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
@@ -51,8 +51,8 @@ import qualified Distribution.Solver.Modular.WeightedPSQ as W
 -- children's versions, and package option. 'addWeights' prepends the new
 -- weights to the existing weights, which gives precedence to preferences that
 -- are applied later.
-addWeights :: [PN -> [Ver] -> POption -> Weight] -> Tree d c -> Tree d c
-addWeights fs = trav go
+addWeights :: [PN -> [Ver] -> POption -> Weight] -> EndoTreeTrav d c
+addWeights fs = go
   where
     go :: TreeF d c (Tree d c) -> TreeF d c (Tree d c)
     go (PChoiceF qpn@(Q _ pn) rdm x cs) =
@@ -69,21 +69,21 @@ addWeights fs = trav go
              W.mapWeightsWithKey (\k w -> weights k ++ w) cs)
     go x                            = x
 
-addWeight :: (PN -> [Ver] -> POption -> Weight) -> Tree d c -> Tree d c
+addWeight :: (PN -> [Ver] -> POption -> Weight) -> EndoTreeTrav d c
 addWeight f = addWeights [f]
 
 version :: POption -> Ver
 version (POption (I v _) _) = v
 
 -- | Prefer to link packages whenever possible.
-preferLinked :: Tree d c -> Tree d c
+preferLinked :: EndoTreeTrav d c
 preferLinked = addWeight (const (const linked))
   where
     linked (POption _ Nothing)  = 1
     linked (POption _ (Just _)) = 0
 
 -- Works by setting weights on choice nodes. Also applies stanza preferences.
-preferPackagePreferences :: (PN -> PackagePreferences) -> Tree d c -> Tree d c
+preferPackagePreferences :: (PN -> PackagePreferences) -> EndoTreeTrav d c
 preferPackagePreferences pcs =
     preferPackageStanzaPreferences pcs .
     addWeights [
@@ -127,8 +127,8 @@ preferPackagePreferences pcs =
 
 -- | Traversal that tries to establish package stanza enable\/disable
 -- preferences. Works by reordering the branches of stanza choices.
-preferPackageStanzaPreferences :: (PN -> PackagePreferences) -> Tree d c -> Tree d c
-preferPackageStanzaPreferences pcs = trav go
+preferPackageStanzaPreferences :: (PN -> PackagePreferences) -> EndoTreeTrav d c
+preferPackageStanzaPreferences pcs = go
   where
     go (SChoiceF qsn@(SN (Q pp pn) s) rdm gr _tr ts)
       | primaryPP pp && enableStanzaPref pn s =
@@ -221,9 +221,8 @@ processPackageConstraintS qpn s c b' (LabeledPackageConstraint (PackageConstrain
 -- by selectively disabling choices that have been ruled out by global user
 -- constraints.
 enforcePackageConstraints :: M.Map PN [LabeledPackageConstraint]
-                          -> Tree d c
-                          -> Tree d c
-enforcePackageConstraints pcs = trav go
+                          -> EndoTreeTrav d c
+enforcePackageConstraints pcs = go
   where
     go (PChoiceF qpn@(Q _ pn) rdm gr                    ts) =
       let c = varToConflictSet (P qpn)
@@ -268,8 +267,8 @@ enforcePackageConstraints pcs = trav go
 --
 -- This function does not enforce any of the constraints, since that is done by
 -- 'enforcePackageConstraints'.
-enforceManualFlags :: M.Map PN [LabeledPackageConstraint] -> Tree d c -> Tree d c
-enforceManualFlags pcs = trav go
+enforceManualFlags :: M.Map PN [LabeledPackageConstraint] -> EndoTreeTrav d c
+enforceManualFlags pcs = go
   where
     go (FChoiceF qfn@(FN (Q _ pn) fn) rdm gr tr Manual d ts) =
         FChoiceF qfn rdm gr tr Manual d $
@@ -295,8 +294,8 @@ enforceManualFlags pcs = trav go
     go x                                                            = x
 
 -- | Require installed packages.
-requireInstalled :: (PN -> Bool) -> Tree d c -> Tree d c
-requireInstalled p = trav go
+requireInstalled :: (PN -> Bool) -> EndoTreeTrav d c
+requireInstalled p = go
   where
     go (PChoiceF v@(Q _ pn) rdm gr cs)
       | p pn      = PChoiceF v rdm gr (W.mapWithKey installed cs)
@@ -319,8 +318,8 @@ requireInstalled p = trav go
 -- they are, perhaps this should just result in trying to reinstall those other
 -- packages as well. However, doing this all neatly in one pass would require to
 -- change the builder, or at least to change the goal set after building.
-avoidReinstalls :: (PN -> Bool) -> Tree d c -> Tree d c
-avoidReinstalls p = trav go
+avoidReinstalls :: (PN -> Bool) -> EndoTreeTrav d c
+avoidReinstalls p = go
   where
     go (PChoiceF qpn@(Q _ pn) rdm gr cs)
       | p pn      = PChoiceF qpn rdm gr disableReinstalls
@@ -337,8 +336,8 @@ avoidReinstalls p = trav go
     go x          = x
 
 -- | Require all packages to be mentioned in a constraint or as a goal.
-onlyConstrained :: (PN -> Bool) -> Tree d QGoalReason -> Tree d QGoalReason
-onlyConstrained p = trav go
+onlyConstrained :: (PN -> Bool) -> EndoTreeTrav d QGoalReason
+onlyConstrained p = go
   where
     go (PChoiceF v@(Q _ pn) _ gr _) | not (p pn)
       = FailF
@@ -348,8 +347,8 @@ onlyConstrained p = trav go
       = x
 
 -- | Sort all goals using the provided function.
-sortGoals :: (Variable QPN -> Variable QPN -> Ordering) -> Tree d c -> Tree d c
-sortGoals variableOrder = trav go
+sortGoals :: (Variable QPN -> Variable QPN -> Ordering) -> EndoTreeTrav d c
+sortGoals variableOrder = go
   where
     go (GoalChoiceF rdm xs) = GoalChoiceF rdm (P.sortByKeys goalOrder xs)
     go x                    = x
@@ -365,8 +364,8 @@ sortGoals variableOrder = trav go
 -- | Reduce the branching degree of the search tree by removing all choices
 -- after the first successful choice at each level. The returned tree is the
 -- minimal subtree containing the path to the first backjump.
-pruneAfterFirstSuccess :: Tree d c -> Tree d c
-pruneAfterFirstSuccess = trav go
+pruneAfterFirstSuccess :: EndoTreeTrav d c
+pruneAfterFirstSuccess = go
   where
     go (PChoiceF qpn rdm gr       ts) = PChoiceF qpn rdm gr       (W.takeUntil active ts)
     go (FChoiceF qfn rdm gr w m d ts) = FChoiceF qfn rdm gr w m d (W.takeUntil active ts)
@@ -379,8 +378,8 @@ pruneAfterFirstSuccess = trav go
 -- This is unnecessary for the default search strategy, because
 -- it descends only into the first goal choice anyway,
 -- but may still make sense to just reduce the tree size a bit.
-firstGoal :: Tree d c -> Tree d c
-firstGoal = trav go
+firstGoal :: EndoTreeTrav d c
+firstGoal = go
   where
     go (GoalChoiceF rdm xs) = GoalChoiceF rdm (P.firstOnly xs)
     go x                    = x
@@ -390,8 +389,8 @@ firstGoal = trav go
 -- possible by pruning all other goals when base is available. In nearly
 -- all cases, there's a single choice for the base package. Also, fixing
 -- base early should lead to better error messages.
-preferBaseGoalChoice :: Tree d c -> Tree d c
-preferBaseGoalChoice = trav go
+preferBaseGoalChoice :: EndoTreeTrav d c
+preferBaseGoalChoice = go
   where
     go (GoalChoiceF rdm xs) = GoalChoiceF rdm (P.filterIfAnyByKeys isBase xs)
     go x                    = x
@@ -402,8 +401,8 @@ preferBaseGoalChoice = trav go
 
 -- | Deal with setup dependencies after regular dependencies, so that we can
 -- will link setup dependencies against package dependencies when possible
-deferSetupChoices :: Tree d c -> Tree d c
-deferSetupChoices = trav go
+deferSetupChoices :: EndoTreeTrav d c
+deferSetupChoices = go
   where
     go (GoalChoiceF rdm xs) = GoalChoiceF rdm (P.preferByKeys noSetup xs)
     go x                    = x
@@ -415,8 +414,8 @@ deferSetupChoices = trav go
 -- | Transformation that tries to avoid making weak flag choices early.
 -- Weak flags are trivial flags (not influencing dependencies) or such
 -- flags that are explicitly declared to be weak in the index.
-deferWeakFlagChoices :: Tree d c -> Tree d c
-deferWeakFlagChoices = trav go
+deferWeakFlagChoices :: EndoTreeTrav d c
+deferWeakFlagChoices = go
   where
     go (GoalChoiceF rdm xs) = GoalChoiceF rdm (P.prefer noWeakFlag (P.prefer noWeakStanza xs))
     go x                    = x
@@ -435,8 +434,8 @@ deferWeakFlagChoices = trav go
 -- function prunes all other goals. This transformation can help the solver find
 -- a solution in fewer steps by allowing it to backtrack sooner when it is
 -- exploring a subtree with no solutions. However, each step is more expensive.
-preferReallyEasyGoalChoices :: Tree d c -> Tree d c
-preferReallyEasyGoalChoices = trav go
+preferReallyEasyGoalChoices :: EndoTreeTrav d c
+preferReallyEasyGoalChoices = go
   where
     go (GoalChoiceF rdm xs) = GoalChoiceF rdm (P.filterIfAny zeroOrOneChoices xs)
     go x                    = x
@@ -454,15 +453,21 @@ type EnforceSIR = Reader (Map (PI PN) QPN)
 -- goal resolving to that instance (there may be other goals _linking_ to that
 -- instance however).
 enforceSingleInstanceRestriction :: Tree d c -> Tree d c
-enforceSingleInstanceRestriction = (`runReader` M.empty) . cata go
+enforceSingleInstanceRestriction = (`runReader` M.empty) . go
   where
-    go :: TreeF d c (EnforceSIR (Tree d c)) -> EnforceSIR (Tree d c)
+    go :: Tree d c -> EnforceSIR (Tree d c)
 
     -- We just verify package choices.
-    go (PChoiceF qpn rdm gr cs) =
-      PChoice qpn rdm gr <$> sequenceA (W.mapWithKey (goP qpn) cs)
-    go _otherwise =
-      innM _otherwise
+    go (PChoice qpn rdm gr cs) =
+      PChoice qpn rdm gr <$> sequenceA (W.mapWithKey (goP qpn) (fmap go cs))
+    go (FChoice qfn rdm y t m d ts) =
+      FChoice qfn rdm y t m d <$> traverse go ts
+    go (SChoice qsn rdm y t ts) =
+      SChoice qsn rdm y t <$> traverse go ts
+    go (GoalChoice rdm ts) =
+      GoalChoice rdm <$> traverse go ts
+    go x@(Fail _ _) = return x
+    go x@(Done _ _) = return x
 
     -- The check proper
     goP :: QPN -> POption -> EnforceSIR (Tree d c) -> EnforceSIR (Tree d c)

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
@@ -124,7 +124,6 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
       let
           sortGoals = case goalOrder sc of
                         Nothing -> goalChoiceHeuristics .
-                                   heuristicsTree .
                                    P.deferSetupExeChoices .
                                    P.deferWeakFlagChoices .
                                    P.preferBaseGoalChoice

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
@@ -110,8 +110,8 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
   traceTree "semivalidated.json" id .
   validationCata    .
   traceTree "pruned.json" id .
-  trav prunePhase   $
-  traceTree "build.json" id .
+  trav prunePhase   .
+  traceTree "build.json" id $
   buildPhase
   where
     explorePhase     = backjumpAndExplore (maxBackjumps sc)

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Solver.hs
@@ -98,12 +98,20 @@ solve :: SolverConfig                         -- ^ solver parameters
       -> S.Set PN                             -- ^ global goals
       -> RetryLog Message SolverFailure (Assignment, RevDepMap)
 solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
-  explorePhase     $
-  detectCycles     $
-  heuristicsPhase  $
-  preferencesPhase $
-  validationPhase  $
-  prunePhase       $
+  explorePhase      .
+  traceTree "cycles.json" id .
+  detectCycles      .
+  traceTree "heuristics.json" id .
+  trav (
+   heuristicsPhase  .
+   preferencesPhase .
+   validationPhase
+  ) .
+  traceTree "semivalidated.json" id .
+  validationCata    .
+  traceTree "pruned.json" id .
+  trav prunePhase   $
+  traceTree "build.json" id .
   buildPhase
   where
     explorePhase     = backjumpAndExplore (maxBackjumps sc)
@@ -111,27 +119,24 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
                                           (fineGrainedConflicts sc)
                                           (countConflicts sc)
                                           idx
-    detectCycles     = traceTree "cycles.json" id . detectCyclesPhase
+    detectCycles     = detectCyclesPhase
     heuristicsPhase  =
-      let heuristicsTree = traceTree "heuristics.json" id
+      let
           sortGoals = case goalOrder sc of
                         Nothing -> goalChoiceHeuristics .
-                                   heuristicsTree .
                                    P.deferSetupChoices .
                                    P.deferWeakFlagChoices .
                                    P.preferBaseGoalChoice
                         Just order -> P.firstGoal .
-                                   heuristicsTree .
-                                   P.sortGoals order
+                                      P.sortGoals order
           PruneAfterFirstSuccess prune = pruneAfterFirstSuccess sc
       in sortGoals .
          (if prune then P.pruneAfterFirstSuccess else id)
     preferencesPhase = P.preferLinked .
                        P.preferPackagePreferences userPrefs
-    validationPhase  = traceTree "validated.json" id .
-                       P.enforcePackageConstraints userConstraints .
-                       P.enforceManualFlags userConstraints .
-                       P.enforceSingleInstanceRestriction .
+    validationPhase  = P.enforcePackageConstraints userConstraints .
+                       P.enforceManualFlags userConstraints
+    validationCata   = P.enforceSingleInstanceRestriction .
                        validateLinking idx .
                        validateTree cinfo idx pkgConfigDB
     prunePhase       = (if asBool (avoidReinstalls sc) then P.avoidReinstalls (const True) else id) .
@@ -143,8 +148,7 @@ solve sc cinfo idx pkgConfigDB userPrefs userConstraints userGoals =
                             P.onlyConstrained pkgIsExplicit
                           OnlyConstrainedNone ->
                             id)
-    buildPhase       = traceTree "build.json" id
-                     $ buildTree idx (independentGoals sc) (S.toList userGoals)
+    buildPhase       = buildTree idx (independentGoals sc) (S.toList userGoals)
 
     allExplicit = M.keysSet userConstraints `S.union` userGoals
 

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
@@ -14,6 +14,8 @@ module Distribution.Solver.Modular.Tree
     , trav
     , zeroOrOneChoices
     , active
+    , TreeTrav
+    , EndoTreeTrav
     ) where
 
 import Control.Monad hiding (mapM, sequence)
@@ -187,7 +189,10 @@ zeroOrOneChoices (Fail       _ _           ) = True
 cata :: (TreeF d c a -> a) -> Tree d c -> a
 cata phi x = (phi . fmap (cata phi) . out) x
 
-trav :: (TreeF d c (Tree d a) -> TreeF d a (Tree d a)) -> Tree d c -> Tree d a
+type TreeTrav d c a = TreeF d c (Tree d a) -> TreeF d a (Tree d a)
+type EndoTreeTrav d c = TreeTrav d c c
+
+trav :: TreeTrav d c a -> Tree d c -> Tree d a
 trav psi x = cata (inn . psi) x
 
 -- | Paramorphism on trees.

--- a/cabal-install-solver/src/Distribution/Solver/Modular/WeightedPSQ.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/WeightedPSQ.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 module Distribution.Solver.Modular.WeightedPSQ (
     WeightedPSQ
   , fromList
@@ -11,6 +12,7 @@ module Distribution.Solver.Modular.WeightedPSQ (
   , lookup
   , mapWithKey
   , mapWeightsWithKey
+  , traverseWithKey
   , union
   , takeUntil
   ) where
@@ -71,6 +73,15 @@ mapWeightsWithKey f (WeightedPSQ xs) = fromList $
 mapWithKey :: (k -> v1 -> v2) -> WeightedPSQ w k v1 -> WeightedPSQ w k v2
 mapWithKey f (WeightedPSQ xs) = WeightedPSQ $
                                 L.map (\ (w, k, v) -> (w, k, f k v)) xs
+
+-- | /O(N)/. Traverse and update values in some applicative functor.
+traverseWithKey
+  :: Applicative f
+  => (k -> v -> f v')
+  -> WeightedPSQ w k v
+  -> f (WeightedPSQ w k v')
+traverseWithKey f (WeightedPSQ q) = WeightedPSQ <$>
+  traverse (\(w,k,v) -> (w,k,) <$> f k v) q
 
 -- | /O((N + M) log (N + M))/. Combine two @WeightedPSQ@s, preserving all
 -- elements. Elements from the first @WeightedPSQ@ come before elements in the


### PR DESCRIPTION
This is the last refactor I had in mind to address the general performance issues discussed in https://github.com/haskell/cabal/issues/7466

It attains some modest but real improvement (mainly in allocations) from eliminating the intermediate `cata` calls in favor of explicit recursion in the solver tree.

For `trav` calls, rather than eliminate them entirely, it lifts out their intermediate functions to the top level and explicitly fuses them in the solver pipeline, which yields somewhat more significant improvements.

Overall not the huge win I hoped, but nonetheless given the straightforward nature of the changes to the code, still worth it I think.