### PR TITLE
ghcup supports Windows

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -5,9 +5,7 @@ Installing the Haskell toolchain
 --------------------------------
 
 To install the Haskell toolchain follow the `ghcup instructions
-<https://www.haskell.org/ghcup/>`__ if you're using Linux or Mac, or follow
-`this guide <https://hub.zhox.com/posts/introducing-haskell-dev/>`__ if you're
-using Windows.
+<https://www.haskell.org/ghcup/>`__.
 
 
 Creating a new application


### PR DESCRIPTION
Removes the special case for installing the Haskell toolchain on Windows, because ghcup now also supports Windows.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
