### PR TITLE
Add --open flag to `cabal haddock`

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -324,6 +324,7 @@ resolveBuildTimeSettings verbosity
     buildSettingReportPlanningFailure
                               = fromFlag projectConfigReportPlanningFailure
     buildSettingProgPathExtra = fromNubList projectConfigProgPathExtra
+    buildSettingHaddockOpen   = False
 
     ProjectConfigBuildOnly{..} = defaults
                               <> projectConfigBuildOnly

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -457,5 +457,6 @@ data BuildTimeSettings
        buildSettingCacheDir              :: FilePath,
        buildSettingHttpTransport         :: Maybe String,
        buildSettingIgnoreExpiry          :: Bool,
-       buildSettingProgPathExtra         :: [FilePath]
+       buildSettingProgPathExtra         :: [FilePath],
+       buildSettingHaddockOpen           :: Bool
      }

--- a/changelog.d/pr-7550
+++ b/changelog.d/pr-7550
@@ -1,0 +1,4 @@
+synopsis: Add --open flag to `cabal haddock`
+packages: cabal-install
+prs: #7550
+issues: #7366

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -497,7 +497,7 @@ The following settings control the behavior of the dependency solver:
     active repositories are merged.
 
     When searching for a certain version of a certain package name, the list of
-    active repositories is searched last-to-first. 
+    active repositories is searched last-to-first.
 
     For example, suppose hackage.haskell.org has versions 1.0 and 2.0 of
     package X, and my-repository has version 2.0 of a similarly named package.
@@ -1405,6 +1405,13 @@ running ``setup haddock``. (TODO: Where does the documentation get put.)
 
     The command line variant of this flag is ``--keep-temp-files`` (for
     the ``haddock`` subcommand).
+
+.. cfg-field:: open: boolean
+    :synopsis: Open generated documentation in-browser.
+
+    When generating HTML documentation, attempt to open it in a browser
+    when complete. This will use ``xdg-open`` on Linux and BSD systems,
+    ``open`` on macOS, and ``start`` on Windows.
 
 Advanced global configuration options
 -------------------------------------


### PR DESCRIPTION
Both `stack` and other package managers like `cargo` have an `--open`
flag for the common case of opening documentation locally for
inspection or reference. This patch adds a `--open` flag, which when set
tries to open the HTML file associated with the generated
documentation, either through `xdg-open` (Linux) or `open` (macOS).

This is my first patch to `cabal`, so please inform me if I’ve made some obvious error apparent to someone with more experience in this codebase. I haven’t yet ported this functionality to `haddock` itself, but I can should that be necessary.

I tested this by, in the `cabal` project, invoking `cabal run cabal-install:exe:cabal -- haddock Cabal --open`.

Fixes #7366.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.