### PR TITLE
`cabal init` common stanzas and default flags

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/src/Distribution/Client/Init/FileCreators.hs
@@ -61,12 +61,13 @@ writeProject (ProjectSettings opts pkgDesc libTarget exeTarget testTarget)
       writeChangeLog opts pkgDesc
 
       let pkgFields = mkPkgDescription opts pkgDesc
+          commonStanza = mkCommonStanza opts
 
       libStanza <- prepareLibTarget opts libTarget
       exeStanza <- prepareExeTarget opts exeTarget
       testStanza <- prepareTestTarget opts testTarget
 
-      writeCabalFile opts $ pkgFields ++ [libStanza, exeStanza, testStanza]
+      writeCabalFile opts $ pkgFields ++ [commonStanza, libStanza, exeStanza, testStanza]
 
       when (null $ _pkgSynopsis pkgDesc) $
         message opts "\nWarning: no synopsis given. You should edit the .cabal file and add one."

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Golden.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Golden.hs
@@ -271,24 +271,27 @@ goldenCabalTests v pkgIx srcDb = testGroup ".cabal file golden tests"
 
         (Right (ProjectSettings opts pkgDesc (Just libTarget) (Just exeTarget) (Just testTarget), _)) -> do
           let pkgFields = mkPkgDescription opts pkgDesc
+              commonStanza = mkCommonStanza opts
               libStanza  = mkLibStanza  opts $ libTarget {_libDependencies  = mangleBaseDep libTarget  _libDependencies}
               exeStanza  = mkExeStanza  opts $ exeTarget {_exeDependencies  = mangleBaseDep exeTarget  _exeDependencies}
               testStanza = mkTestStanza opts $ testTarget {_testDependencies = mangleBaseDep testTarget _testDependencies}
 
-          mkStanza $ pkgFields ++ [libStanza, exeStanza, testStanza]
+          mkStanza $ pkgFields ++ [commonStanza, libStanza, exeStanza, testStanza]
 
         (Right (ProjectSettings opts pkgDesc (Just libTarget) Nothing (Just testTarget), _)) -> do
           let pkgFields = mkPkgDescription opts pkgDesc
+              commonStanza = mkCommonStanza opts
               libStanza  = mkLibStanza  opts $ libTarget  {_libDependencies  = mangleBaseDep libTarget  _libDependencies}
               testStanza = mkTestStanza opts $ testTarget {_testDependencies = mangleBaseDep testTarget _testDependencies}
 
-          mkStanza $ pkgFields ++ [libStanza, testStanza]
+          mkStanza $ pkgFields ++ [commonStanza, libStanza, testStanza]
         
         (Right (ProjectSettings opts pkgDesc Nothing Nothing (Just testTarget), _)) -> do
           let pkgFields = mkPkgDescription opts pkgDesc
+              commonStanza = mkCommonStanza opts
               testStanza = mkTestStanza opts $ testTarget {_testDependencies = mangleBaseDep testTarget _testDependencies}
           
-          mkStanza $ pkgFields ++ [testStanza]
+          mkStanza $ pkgFields ++ [commonStanza, testStanza]
 
         (Right (ProjectSettings _ _ l e t, _)) -> assertFailure $
           show l ++ "\n" ++ show e ++ "\n" ++ show t

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-no-comments.golden
@@ -20,7 +20,11 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
+common warnings
+    ghc-options: -Wall
+
 library
+    import:           warnings
     exposed-modules:  MyLib
 
     -- Modules included in this library but not exported.
@@ -33,6 +37,7 @@ library
     default-language: Haskell98
 
 executable y
+    import:           warnings
     main-is:          Main.hs
 
     -- Modules included in this executable, other than Main.
@@ -48,6 +53,7 @@ executable y
     default-language: Haskell2010
 
 test-suite y-test
+    import:           warnings
     default-language: Haskell2010
 
     -- Modules included in this executable, other than Main.

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-with-comments.golden
@@ -52,7 +52,13 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
+common warnings
+    ghc-options: -Wall
+
 library
+    -- Import common warning flags.
+    import:           warnings
+
     -- Modules exported by the library.
     exposed-modules:  MyLib
 
@@ -72,6 +78,9 @@ library
     default-language: Haskell98
 
 executable y
+    -- Import common warning flags.
+    import:           warnings
+
     -- .hs or .lhs file containing the Main module.
     main-is:          Main.hs
 
@@ -93,6 +102,9 @@ executable y
     default-language: Haskell2010
 
 test-suite y-test
+    -- Import common warning flags.
+    import:           warnings
+
     -- Base language which the package is written in.
     default-language: Haskell2010
 

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-no-comments.golden
@@ -20,7 +20,11 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
+common warnings
+    ghc-options: -Wall
+
 library
+    import:           warnings
     exposed-modules:  MyLib
 
     -- Modules included in this library but not exported.
@@ -33,6 +37,7 @@ library
     default-language: Haskell98
 
 test-suite y-test
+    import:           warnings
     default-language: Haskell2010
 
     -- Modules included in this executable, other than Main.

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-with-comments.golden
@@ -52,7 +52,13 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
+common warnings
+    ghc-options: -Wall
+
 library
+    -- Import common warning flags.
+    import:           warnings
+
     -- Modules exported by the library.
     exposed-modules:  MyLib
 
@@ -72,6 +78,9 @@ library
     default-language: Haskell98
 
 test-suite y-test
+    -- Import common warning flags.
+    import:           warnings
+
     -- Base language which the package is written in.
     default-language: Haskell2010
 

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-test-suite-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-test-suite-no-comments.golden
@@ -20,7 +20,11 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
+common warnings
+    ghc-options: -Wall
+
 test-suite y-test
+    import:           warnings
     default-language: Haskell2010
 
     -- Modules included in this executable, other than Main.

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-test-suite-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-test-suite-with-comments.golden
@@ -52,7 +52,13 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
+common warnings
+    ghc-options: -Wall
+
 test-suite y-test
+    -- Import common warning flags.
+    import:           warnings
+
     -- Base language which the package is written in.
     default-language: Haskell2010
 

--- a/cabal-install/tests/fixtures/init/golden/exe/exe-build-tools-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/exe/exe-build-tools-with-comments.golden
@@ -1,4 +1,7 @@
 executable y
+    -- Import common warning flags.
+    import:             warnings
+
     -- .hs or .lhs file containing the Main module.
     main-is:            Main.hs
 

--- a/cabal-install/tests/fixtures/init/golden/exe/exe-minimal-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/exe/exe-minimal-no-comments.golden
@@ -1,4 +1,5 @@
 executable y
+    import:           warnings
     main-is:          Main.hs
     build-depends:    base
     hs-source-dirs:   exe

--- a/cabal-install/tests/fixtures/init/golden/exe/exe-simple-minimal-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/exe/exe-simple-minimal-with-comments.golden
@@ -1,4 +1,5 @@
 executable y
+    import:           warnings
     main-is:          Main.hs
     build-depends:    base
     hs-source-dirs:   exe

--- a/cabal-install/tests/fixtures/init/golden/exe/exe-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/exe/exe-with-comments.golden
@@ -1,4 +1,7 @@
 executable y
+    -- Import common warning flags.
+    import:           warnings
+
     -- .hs or .lhs file containing the Main module.
     main-is:          Main.hs
 

--- a/cabal-install/tests/fixtures/init/golden/exe/exe.golden
+++ b/cabal-install/tests/fixtures/init/golden/exe/exe.golden
@@ -1,4 +1,5 @@
 executable y
+    import:           warnings
     main-is:          Main.hs
 
     -- Modules included in this executable, other than Main.

--- a/cabal-install/tests/fixtures/init/golden/lib/lib-build-tools-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/lib/lib-build-tools-with-comments.golden
@@ -1,4 +1,7 @@
 library
+    -- Import common warning flags.
+    import:             warnings
+
     -- Modules exported by the library.
     exposed-modules:    MyLib
 

--- a/cabal-install/tests/fixtures/init/golden/lib/lib-minimal-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/lib/lib-minimal-no-comments.golden
@@ -1,4 +1,5 @@
 library
+    import:           warnings
     exposed-modules:  MyLib
     build-depends:    base
     hs-source-dirs:   src

--- a/cabal-install/tests/fixtures/init/golden/lib/lib-simple-minimal-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/lib/lib-simple-minimal-with-comments.golden
@@ -1,4 +1,5 @@
 library
+    import:           warnings
     exposed-modules:  MyLib
     build-depends:    base
     hs-source-dirs:   src

--- a/cabal-install/tests/fixtures/init/golden/lib/lib-simple.golden
+++ b/cabal-install/tests/fixtures/init/golden/lib/lib-simple.golden
@@ -1,4 +1,5 @@
 library
+    import:           warnings
     exposed-modules:  MyLib
 
     -- Modules included in this library but not exported.

--- a/cabal-install/tests/fixtures/init/golden/lib/lib-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/lib/lib-with-comments.golden
@@ -1,4 +1,7 @@
 library
+    -- Import common warning flags.
+    import:           warnings
+
     -- Modules exported by the library.
     exposed-modules:  MyLib
 

--- a/cabal-install/tests/fixtures/init/golden/lib/lib.golden
+++ b/cabal-install/tests/fixtures/init/golden/lib/lib.golden
@@ -1,4 +1,5 @@
 library
+    import:           warnings
     exposed-modules:  MyLib
 
     -- Modules included in this library but not exported.

--- a/cabal-install/tests/fixtures/init/golden/test/standalone-test-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/standalone-test-with-comments.golden
@@ -1,4 +1,7 @@
 test-suite y-test
+    -- Import common warning flags.
+    import:           warnings
+
     -- Base language which the package is written in.
     default-language: Haskell2010
 

--- a/cabal-install/tests/fixtures/init/golden/test/standalone-test.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/standalone-test.golden
@@ -1,4 +1,5 @@
 test-suite y-test
+    import:           warnings
     default-language: Haskell2010
 
     -- Modules included in this executable, other than Main.

--- a/cabal-install/tests/fixtures/init/golden/test/test-build-tools-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/test-build-tools-with-comments.golden
@@ -1,4 +1,7 @@
 test-suite y-test
+    -- Import common warning flags.
+    import:             warnings
+
     -- Base language which the package is written in.
     default-language:   Haskell2010
 

--- a/cabal-install/tests/fixtures/init/golden/test/test-minimal-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/test-minimal-no-comments.golden
@@ -1,4 +1,5 @@
 test-suite y-test
+    import:           warnings
     default-language: Haskell2010
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test

--- a/cabal-install/tests/fixtures/init/golden/test/test-simple-minimal-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/test-simple-minimal-with-comments.golden
@@ -1,4 +1,5 @@
 test-suite y-test
+    import:           warnings
     default-language: Haskell2010
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test

--- a/cabal-install/tests/fixtures/init/golden/test/test-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/test-with-comments.golden
@@ -1,4 +1,7 @@
 test-suite y-test
+    -- Import common warning flags.
+    import:           warnings
+
     -- Base language which the package is written in.
     default-language: Haskell2010
 

--- a/cabal-install/tests/fixtures/init/golden/test/test.golden
+++ b/cabal-install/tests/fixtures/init/golden/test/test.golden
@@ -1,4 +1,5 @@
 test-suite y-test
+    import:           warnings
     default-language: Haskell2010
 
     -- Modules included in this executable, other than Main.


### PR DESCRIPTION
This PR aims to add common stanzas to the `cabal init` command and possible default flags that could go with it. This PR will close #7465.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.