### PR TITLE
handle build reports in v2-build

### DIFF
--- a/cabal-install/src/Distribution/Client/BuildReports/Anonymous.hs
+++ b/cabal-install/src/Distribution/Client/BuildReports/Anonymous.hs
@@ -25,6 +25,7 @@ module Distribution.Client.BuildReports.Anonymous (
     parseBuildReport,
     parseBuildReportList,
     showBuildReport,
+    cabalInstallID
 --    showList,
   ) where
 


### PR DESCRIPTION
Resolves #6851 -- or rather resolves it enough for the purposes of hackage builder, which is likely the only thing that ever cared about these flags.

In particular makes the `--report-planning-failure` and `--build-summary` flags do anything at all. Note that this preserves the v1 behavior that by default, build-summary information for all builds gets written to ~/.cabal/logs/build.log (which had been lost with v2-build before). The former flag writes build-summary info even if the solver fails (otherwise such info is written only if a build occurs). The latter controls where to write summary info to.

Some notes on what this doesn't do:

This does _not_ provide the still missing "remote build reports" (enabled by `--remote-build-reporting`) since hackage builder doesn't use them, and nobody else seems to use or miss them either. At this point I think we should probably remove the flag from v2 and just strip the functionality entirely (saving code) when v1 is removed (if not sooner). For background context, the idea of anonymous/remote build reports was that instead of a central docbuilder, cabals could be taught to tarball up all the information from their builds so they could automatically upload it and "report to a central server" any successes or failures, optionally with logs, etc. It was an interesting idea, but never fully implemented. The existing machinery is not very fleshed out on the tricky bits (i.e. actually uploading the reports, controlling policy well, etc.) and there was never a clear policy worked out nor any upstream support. As such, I think we can strip out the code for this from the codebase and if we embark on this in the future, start fresh with a clear architecture and design first, and then write new code to suit that.

Further, this does _not_ write detailed logs for `--report-planning-failure` but rather just the summary log. It seemed an extra bit of unnecessary functionality, given that hackage builder doesn't use these logs, and as far as I can tell nobody else did, who might miss them. This means that as far as I can see, the `--build-log` argument to v2-build never gets used (though I may be mistaken here). It would be future work to confirm these flags are unused at the moment, and potentially to clean them up. Certainly something is still writing logs to `~/.cabal/logs/ghc-x.x.x/pkg-name-hash.log` but I'm not sure of that codepath.