### PR TITLE
Make GHC targetDir commands relative to current directory

### DIFF
--- a/changelog.d/pr-7581
+++ b/changelog.d/pr-7581
@@ -1,0 +1,2 @@
+synopsis: Paths passed to GHC are now relative to the current working directory
+packages: Cabal


### PR DESCRIPTION
GHC does not support response files (@file), so we are constrained in
how many characters we can pass to ghc invocations. On macOS <11 this
is 262144 (getconf ARG_MAX), but this also includes the environment
which can be very big. On Windows, ARG_MAX is probably even
less (32K?).

In projects with a lot of modules being linked (1000+), it’s very easy
to hit this limit because of the long length of cabal v2- build
prefixes. For example:
/Users/matthewbauer/my-haskell-project/dist-newstyle/build/x86_64-osx/ghc-8.10.3/mwb-0/noopt/build/Some/Generic/ModulePrefix/MyModule.dyn_o
is 139 chars and 139 * 1200 = 166800. This leads to errors like:

> ghc: createProcess: runInteractiveProcess: exec: resource exhausted (Argument list too long)

To minimize this likelihood, we should limit the path prefixes to what
is necessary. This can be done by converting our absolute build
directory to a relative build directory with
makeRelativeToCurrentDirectory.

Note this only really effects v2- cabal since v1- cabal utilizes ghc
--make resulting in much less args in general (and ghc doesn’t have to
call itself).


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
