### PR TITLE
Fix #7582: add Ord to the derived instances of SymbolicPath

### DIFF
--- a/Cabal/src/Distribution/Utils/Path.hs
+++ b/Cabal/src/Distribution/Utils/Path.hs
@@ -35,7 +35,7 @@ import qualified Distribution.Compat.CharParsing as P
 -- until we interpret them.
 --
 newtype SymbolicPath from to = SymbolicPath FilePath
-  deriving (Generic, Show, Read, Eq, Typeable, Data)
+  deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
 
 instance Binary (SymbolicPath from to)
 instance (Typeable from, Typeable to) => Structured (SymbolicPath from to)


### PR DESCRIPTION
Fix #7582: add `Ord` to the derived instances of `SymbolicPath`.

- Tested by checking compilation.
- Given the granularity of the changelog, this change is below the threshold.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
