### PR TITLE
Fix #7469: broken link to "prefix independence" in docs

### DIFF
--- a/doc/cabal-package.rst
+++ b/doc/cabal-package.rst
@@ -2150,7 +2150,7 @@ system-dependent values for these fields.
     setup described in the section on `system-dependent parameters`_.
 
 .. pkg-field:: hsc2hs-options: token list
-    :since 3.6
+    :since: 3.6
 
     Command-line arguments to be passed to ``hsc2hs``.
 
@@ -3029,7 +3029,7 @@ Accessing data files from package code
 The placement on the target system of files listed in
 the :pkg-field:`data-files` field varies between systems, and in some cases
 one can even move packages around after installation (see `prefix
-independence <installing-packages.html#prefix-independence>`__). To
+independence <setup-commands.html#prefix-independence>`__). To
 enable packages to find these files in a portable way, Cabal generates a
 module called :file:`Paths_{pkgname}` (with any hyphens in *pkgname*
 replaced by underscores) during building, so that it may be imported by


### PR DESCRIPTION
Fix #7469: broken link to "prefix independence" in docs.

I tested this by building the documentation with sphinx and checking that the link now works.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
