### PR TITLE
ci(Mergify): use rebase+merge queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,9 +1,29 @@
 pull_request_rules:
+  # rebase+merge strategy
   - actions:
-      merge:
-        strict: smart+fasttrack
-        method: squash
-    name: Automatically merge pull requests
+      queue:
+        name: default
+        # Merge into master with a merge commit
+        method: merge
+        # Update the pr branch with rebase, so the history is clean
+        update_method: rebase
+    name: Put pull requests in the rebase+merge queue
     conditions:
       - label=merge me
       - '#approved-reviews-by>=2'
+  # merge+squash strategy
+  - actions:
+      queue:
+        name: default
+        method: squash
+        # both update methods get absorbed by the squash, so we use the most
+        # reliable
+        update_method: merge
+    name: Put pull requests in the squash+merge queue
+    conditions:
+      - label=squash+merge me
+      - '#approved-reviews-by>=2'
+
+queue_rules:
+  - name: default
+    conditions: []


### PR DESCRIPTION
This change has been made by @fgaz from https://mergify.io config editor.

---

actions/merge/strict is deprecated, so I switched it to merge queues.

I also changed the merge method from squash to rebase+merge, for a clean history (provided prs are clean too), which _I think_ was the original intent behind the introduction of this bot. Opinions? Maybe there should be both this and a "squash+merge me" label for squashable atomic prs so that we don't have to ask the author to do it when it's necessary?
edit: added the squash strategy too
