### PR TITLE
[WIP] use GHC 8.10.7 in GitHub Actions

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: bootstrap.py
         run: |
-          python3 bootstrap/bootstrap.py -w /opt/ghc/8.10.4/bin/ghc -d bootstrap/linux-8.10.4.json
+          python3 bootstrap/bootstrap.py -w /opt/ghc/8.10.7/bin/ghc -d bootstrap/linux-8.10.7.json
 
       - name: Smoke test
         run: |
@@ -40,17 +40,17 @@ jobs:
       - name: Install GHC
         run: |
           cd $(mktemp -d)
-          curl -sLO "https://downloads.haskell.org/~ghc/8.10.4/ghc-8.10.4-x86_64-apple-darwin.tar.xz"
+          curl -sLO "https://downloads.haskell.org/~ghc/8.10.7/ghc-8.10.7-x86_64-apple-darwin.tar.xz"
           tar -xJf ghc-*.tar.xz
           cd ghc-*
-          ./configure --prefix=/opt/ghc/8.10.4
+          ./configure --prefix=/opt/ghc/8.10.7
           sudo make install
       - uses: actions/checkout@v2
 
       # We use linux dependencies
       - name: bootstrap.py
         run: |
-          python3 bootstrap/bootstrap.py -w /opt/ghc/8.10.4/bin/ghc -d bootstrap/linux-8.10.4.json
+          python3 bootstrap/bootstrap.py -w /opt/ghc/8.10.7/bin/ghc -d bootstrap/linux-8.10.7.json
 
       - name: Smoke test
         run: |

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: bootstrap.py
         run: |
-          python3 bootstrap/bootstrap.py -w /opt/ghc/8.10.7/bin/ghc -d bootstrap/linux-8.10.7.json
+          python3 bootstrap/bootstrap.py -w /opt/ghc/8.10.4/bin/ghc -d bootstrap/linux-8.10.4.json
 
       - name: Smoke test
         run: |
@@ -40,17 +40,17 @@ jobs:
       - name: Install GHC
         run: |
           cd $(mktemp -d)
-          curl -sLO "https://downloads.haskell.org/~ghc/8.10.7/ghc-8.10.7-x86_64-apple-darwin.tar.xz"
+          curl -sLO "https://downloads.haskell.org/~ghc/8.10.4/ghc-8.10.4-x86_64-apple-darwin.tar.xz"
           tar -xJf ghc-*.tar.xz
           cd ghc-*
-          ./configure --prefix=/opt/ghc/8.10.7
+          ./configure --prefix=/opt/ghc/8.10.4
           sudo make install
       - uses: actions/checkout@v2
 
       # We use linux dependencies
       - name: bootstrap.py
         run: |
-          python3 bootstrap/bootstrap.py -w /opt/ghc/8.10.7/bin/ghc -d bootstrap/linux-8.10.7.json
+          python3 bootstrap/bootstrap.py -w /opt/ghc/8.10.4/bin/ghc -d bootstrap/linux-8.10.4.json
 
       - name: Smoke test
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,12 +57,12 @@ jobs:
         run: sh validate.sh -j 2 -w ghc-9.0.1 -v --lib-only -s lib-tests
       - name: Validate lib-suite
         run: sh validate.sh -j 2 -w ghc-9.0.1 -v --lib-only -s lib-suite
-  validate-8_10_4:
-    name: validate.sh ghc-8.10.4
+  validate-8_10_7:
+    name: validate.sh ghc-8.10.7
     runs-on: ubuntu-18.04
     needs: validate-8_8_4
     container:
-      image: phadej/ghc:8.10.4-bionic
+      image: phadej/ghc:8.10.7-bionic
     steps:
       - name: System info
         run: |
@@ -90,19 +90,19 @@ jobs:
           git fetch origin $GITHUB_SHA:temporary-ci-branch
           git checkout $GITHUB_SHA || (git fetch && git checkout $GITHUB_SHA)
       - name: Validate print-config
-        run: sh validate.sh -j 2 -w ghc-8.10.4 -v  -s print-config
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s print-config
       - name: Validate print-tool-versions
-        run: sh validate.sh -j 2 -w ghc-8.10.4 -v  -s print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s print-tool-versions
       - name: Validate build
-        run: sh validate.sh -j 2 -w ghc-8.10.4 -v  -s build
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s build
       - name: Validate lib-tests
-        run: sh validate.sh -j 2 -w ghc-8.10.4 -v  -s lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s lib-tests
       - name: Validate lib-suite
-        run: sh validate.sh -j 2 -w ghc-8.10.4 -v  -s lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s lib-suite
       - name: Validate cli-tests
-        run: sh validate.sh -j 2 -w ghc-8.10.4 -v  -s cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s cli-tests
       - name: Validate cli-suite
-        run: sh validate.sh -j 2 -w ghc-8.10.4 -v  -s cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s cli-suite
   validate-8_8_4:
     name: validate.sh ghc-8.8.4
     runs-on: ubuntu-18.04

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,6 +15,58 @@ on:
       - created
 
 jobs:
+  validate-macos-8_10_7:
+    name: validate.sh macos ghc-8.10.7
+    runs-on: macos-latest
+    steps:
+      - name: System info
+        run: |
+          uname -a
+      - name: Install Autotools
+        run: |
+          brew install automake
+      - name: Install GHC
+        run: |
+          cd $(mktemp -d)
+          curl -sLO https://downloads.haskell.org/~ghc/8.10.7/ghc-8.10.7-x86_64-apple-darwin.tar.xz
+          tar -xJf ghc-*.tar.xz
+          cd ghc-*
+          ./configure --prefix=/opt/ghc/8.10.7
+          sudo make install
+      - name: Install Cabal
+        run: |
+          cd $(mktemp -d)
+          curl -sLO http://oleg.fi/cabal-install-3.4.0.0-rc1/cabal-install-3.4.0.0-x86_64-darwin-sierra.tar.xz
+          tar -xJf cabal-install-*.tar.xz
+          sudo mkdir -p /opt/cabal/3.4/bin
+          sudo cp cabal /opt/cabal/3.4/bin/cabal
+          sudo chmod 755 /opt/cabal/3.4/bin/cabal
+      - name: Set PATH
+        run: |
+          echo "/opt/ghc/8.10.7/bin" >> $GITHUB_PATH
+          echo "/opt/cabal/3.4/bin" >> $GITHUB_PATH
+          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+      - name: Update Hackage index
+        run: cabal v2-update
+      - name: Install cabal-plan
+        run: |
+          cd $(mktemp -d)
+          cabal v2-install cabal-plan --constraint='cabal-plan ^>=0.6.2.0' --constraint='aeson +fast' --constraint='cabal-plan +exe'
+      - uses: actions/checkout@v2
+      - name: Validate print-config
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s print-config
+      - name: Validate print-tool-versions
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s print-tool-versions
+      - name: Validate build
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s build
+      - name: Validate lib-tests
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s lib-tests
+      - name: Validate lib-suite
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s lib-suite
+      - name: Validate cli-tests
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s cli-tests
+      - name: Validate cli-suite
+        run: sh validate.sh -j 2 -w ghc-8.10.7 -v  -s cli-suite
   validate-macos-8_8_4:
     name: validate.sh macos ghc-8.8.4
     runs-on: macos-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,6 +18,7 @@ jobs:
   validate-macos-8_10_7:
     name: validate.sh macos ghc-8.10.7
     runs-on: macos-latest
+    needs: validate-macos-8_8_4
     steps:
       - name: System info
         run: |

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -24,7 +24,7 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "/opt/cabal/3.2/bin" >> $GITHUB_PATH
+          echo "/opt/cabal/3.4/bin" >> $GITHUB_PATH
           echo "/opt/ghc/8.10.7/bin" >> $GITHUB_PATH
       - uses: actions/cache@v1
         with:
@@ -53,7 +53,7 @@ jobs:
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
           echo "/opt/cabal/3.2/bin" >> $GITHUB_PATH
-          echo "/opt/ghc/8.10.7/bin" >> $GITHUB_PATH
+          echo "/opt/ghc/8.10.4/bin" >> $GITHUB_PATH
       - name: Install cabal-env
         run: |
           mkdir -p $HOME/.cabal/bin

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
           echo "/opt/cabal/3.2/bin" >> $GITHUB_PATH
-          echo "/opt/ghc/8.10.4/bin" >> $GITHUB_PATH
+          echo "/opt/ghc/8.10.7/bin" >> $GITHUB_PATH
       - uses: actions/cache@v1
         with:
           path: ~/.cabal/store
@@ -53,7 +53,7 @@ jobs:
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
           echo "/opt/cabal/3.2/bin" >> $GITHUB_PATH
-          echo "/opt/ghc/8.10.4/bin" >> $GITHUB_PATH
+          echo "/opt/ghc/8.10.7/bin" >> $GITHUB_PATH
       - name: Install cabal-env
         run: |
           mkdir -p $HOME/.cabal/bin

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -64,13 +64,13 @@ jobs:
       - name: cabal-tests
         # Using only one job, -j1, to fail less.
         run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.6.5\cabal-install-3.7.0.0\x\cabal\build\cabal\cabal.exe
-  test-windows-8_10_4:
-    name: test ghc-8.10.4
+  test-windows-8_10_7:
+    name: test ghc-8.10.7
     runs-on: windows-latest
     steps:
       - uses: actions/setup-haskell@v1.1.4
         with:
-          ghc-version: '8.10.4'
+          ghc-version: '8.10.7'
           cabal-version: '3.2.0.0'
       - name: Print versions
         run: |
@@ -111,4 +111,4 @@ jobs:
           cabal v2-run cabal-install:unit-tests -- --pattern "! (/FileMonitor/ || /VCS/ || /Get/)"
       - name: cabal-tests
         # Using only one job, -j1, to fail less.
-        run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.10.4\cabal-install-3.7.0.0\x\cabal\build\cabal\cabal.exe
+        run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.10.7\cabal-install-3.7.0.0\x\cabal\build\cabal\cabal.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-haskell@v1.1.4
         with:
           ghc-version: '8.6.5'
-          cabal-version: '3.2.0.0'
+          cabal-version: '3.4.0.0'
       - name: Print versions
         run: |
           [Environment]::GetEnvironmentVariable("Path")

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/setup-haskell@v1.1.4
         with:
           ghc-version: '8.10.7'
-          cabal-version: '3.2.0.0'
+          cabal-version: '3.4.0.0'
       - name: Print versions
         run: |
           [Environment]::GetEnvironmentVariable("Path")

--- a/cabal-dev-scripts/src/GenValidate.hs
+++ b/cabal-dev-scripts/src/GenValidate.hs
@@ -23,7 +23,7 @@ main = do
             w <- run Z
                 { zJobs =
                     [ GhcJob "9.0.1"  False "--lib-only"                False ["8.8.4"] libSteps
-                    , GhcJob "8.10.4" False ""                          False ["8.8.4"] defSteps
+                    , GhcJob "8.10.7" False ""                          False ["8.8.4"] defSteps
                     , GhcJob "8.8.4"  False "--solver-benchmarks"       False []        defSteps
                     , GhcJob "8.6.5"  False "--complete-hackage-tests"  False ["8.8.4"] defSteps
                     , GhcJob "8.4.4"  False ""                          False ["8.8.4"] defSteps
@@ -40,12 +40,13 @@ main = do
                         ]
                     ]
                 , zMacosJobs =
-                    [ mkMacGhcJob "8.8.4" "https://downloads.haskell.org/~ghc/8.8.4/ghc-8.8.4-x86_64-apple-darwin.tar.xz"
+                    [ mkMacGhcJob "8.10.7" "https://downloads.haskell.org/~ghc/8.10.7/ghc-8.10.7-x86_64-apple-darwin.tar.xz"
+                    , mkMacGhcJob "8.8.4" "https://downloads.haskell.org/~ghc/8.8.4/ghc-8.8.4-x86_64-apple-darwin.tar.xz"
                     , mkMacGhcJob "8.6.5" "https://downloads.haskell.org/~ghc/8.6.5/ghc-8.6.5-x86_64-apple-darwin.tar.xz"
                     ]
                 , zWinJobs =
                     [ mkWinGhcJob "8.6.5"  Nothing           []
-                    , mkWinGhcJob "8.10.4" (Just "8.10.4")   []
+                    , mkWinGhcJob "8.10.7" (Just "8.10.7")   []
                     ]
                 , zMangleVersion = map mangleChar
                 , zOr            = (||)

--- a/cabal-dev-scripts/src/GenValidateDockerfile.hs
+++ b/cabal-dev-scripts/src/GenValidateDockerfile.hs
@@ -40,7 +40,7 @@ main = withIO $ \version src tgt -> do
 
 params :: Map.Map String Z
 params = Map.fromList
-    [ pair "8.10.4" $ Z "ghc-8.10.4" "8.10.4-bionic" False True  False True  ""
+    [ pair "8.10.7" $ Z "ghc-8.10.7" "8.10.7-bionic" False True  False True  ""
     , pair "8.8.4"  $ Z "ghc-8.8.4"  "8.8.4-bionic"  False True  False True  "--doctest --solver-benchmarks --complete-hackage"
     , pair "8.6.5"  $ Z "ghc-8.6.5"  "8.6.5-bionic"  False True  False True  ""
     , pair "8.4.4"  $ Z "ghc-8.4.4"  "8.4.4-bionic"  False True  False True  ""

--- a/templates/ci-quick-jobs.template.yml
+++ b/templates/ci-quick-jobs.template.yml
@@ -24,8 +24,8 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "/opt/cabal/3.2/bin" >> $GITHUB_PATH
-          echo "/opt/ghc/8.10.4/bin" >> $GITHUB_PATH
+          echo "/opt/cabal/3.4/bin" >> $GITHUB_PATH
+          echo "/opt/ghc/8.10.7/bin" >> $GITHUB_PATH
       - uses: actions/cache@v1
         with:
           path: ~/.cabal/store

--- a/templates/ci-windows.template.yml
+++ b/templates/ci-windows.template.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-haskell@v1.1.4
         with:
           ghc-version: '{{ job.chocoVersion }}'
-          cabal-version: '3.2.0.0'
+          cabal-version: '3.4.0.0'
       - name: Print versions
         run: |
           [Environment]::GetEnvironmentVariable("Path")


### PR DESCRIPTION
- updates CI from GHC 8.10.4 to 8.10.7
- Adds CI coverage for Mac using GHC 8.10.7. Previously there was no Mac coverage for GHC 8.10.
- updates CI from Cabal 3.2 to 3.4

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
