### PR TITLE
Allow text-2.0 in Cabal.cabal only

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -271,7 +271,7 @@ library
     -- See also https://github.com/ekmett/transformers-compat/issues/35
     transformers (>= 0.3      && < 0.4) || (>=0.4.1.0 && <0.6),
     mtl           >= 2.1      && < 2.3,
-    text          >= 1.2.3.0  && < 1.3,
+    text         (>= 1.2.3.0  && < 1.3) || (>= 2.0 && < 2.1),
     parsec        >= 3.1.13.0 && < 3.2
   exposed-modules:
     Distribution.Compat.Parsing


### PR DESCRIPTION
`text-2.0` is not yet released, but I would like to update `Cabal` (not `cabal-install`) HEAD so that we can bump `text` submodule in GHC source tree and start patching of `head.hackage` to iron out potential migration issues before a final release. Cf. https://github.com/haskell/parsec/pull/135

`Cabal` package does not really delve into `text` deep enough to be affected by `text-2.0` changes, and I checked all usages manually. 

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

