### PR TITLE
cabal-install.cabal: use -fhide-source-paths for ghc-8.2+

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -40,6 +40,8 @@ Flag lukko
 
 common warnings
     ghc-options: -Wall -Wcompat -Wnoncanonical-monad-instances -Wincomplete-uni-patterns -Wincomplete-record-updates
+    if impl(ghc >= 8.2)
+      ghc-options: -fhide-source-paths
     if impl(ghc < 8.8)
       ghc-options: -Wnoncanonical-monadfail-instances
     if impl(ghc >=8.10)


### PR DESCRIPTION
This should only affect builds of cabal-install