### PR TITLE
Revert PR #7510 (which was "Set PATH_SEPARATOR=; when calling ./configure")

### DIFF
--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE LambdaCase #-}
@@ -688,11 +687,7 @@ runConfigureScript verbosity backwardsCompatHack flags lbi = do
       pathEnv = maybe (intercalate spSep extraPath)
                 ((intercalate spSep extraPath ++ spSep)++) $ lookup "PATH" env
       overEnv = ("CFLAGS", Just cflagsEnv) :
--- TODO: Move to either Cabal/src/Distribution/Compat/Environment.hs
--- or Cabal/src/Distribution/Compat/FilePath.hs:
-#ifdef mingw32_HOST_OS
                 ("PATH_SEPARATOR", Just ";") :
-#endif
                 [("PATH", Just pathEnv) | not (null extraPath)]
       hp = hostPlatform lbi
       maybeHostFlag = if hp == buildPlatform then [] else ["--host=" ++ show (pretty hp)]

--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -687,7 +687,6 @@ runConfigureScript verbosity backwardsCompatHack flags lbi = do
       pathEnv = maybe (intercalate spSep extraPath)
                 ((intercalate spSep extraPath ++ spSep)++) $ lookup "PATH" env
       overEnv = ("CFLAGS", Just cflagsEnv) :
-                ("PATH_SEPARATOR", Just ";") :
                 [("PATH", Just pathEnv) | not (null extraPath)]
       hp = hostPlatform lbi
       maybeHostFlag = if hp == buildPlatform then [] else ["--host=" ++ show (pretty hp)]

--- a/changelog.d/pr-7510
+++ b/changelog.d/pr-7510
@@ -1,4 +1,0 @@
-synopsis: Set PATH_SEPARATOR=";" when calling ./configure on Windows; this fix is necessary for autoconf >= 2.70
-packages: Cabal
-prs: #7510
-issues: #7494


### PR DESCRIPTION
This reverts PR #7510 due to regression #7649. This revert reintroduces the problem from #7494, but it's going to be fixed differently (most probably) soon.