### PR TITLE
Add CI dogfood test; only Windows for this PR

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-haskell@v1.1.4
         with:
           ghc-version: '8.6.5'
-          cabal-version: '3.2.0.0'
+          cabal-version: '3.4.0.0'
       - name: Print versions
         run: |
           [Environment]::GetEnvironmentVariable("Path")
@@ -37,9 +37,12 @@ jobs:
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v2
-      # We cannot ask for all dependencies, but we can for Cabal.
-      - name: cabal v2-build Cabal --only-dependencies
-        run: cabal v2-build Cabal --only-dependencies
+      # all dependencies of Cabal already there (due to GHC depending on Cabal)
+      - name: cabal v2-build Cabal
+        run: cabal v2-build Cabal
+      # We cannot ask for all dependencies, but we can for cabal-install.
+      - name: cabal v2-build cabal-install --only-dependencies
+        run: cabal v2-build cabal-install --only-dependencies
       - name: cabal v2-build
         run: cabal v2-build all
       - name: Cabal unit-tests
@@ -64,14 +67,16 @@ jobs:
       - name: cabal-tests
         # Using only one job, -j1, to fail less.
         run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.6.5\cabal-install-3.7.0.0\x\cabal\build\cabal\cabal.exe
-  test-windows-8_10_4:
-    name: test ghc-8.10.4
+
+#TODO: store the exe from above as artifact and re-use it here instead of building anew
+  test-windows-8_6_5-dogfood:
+    name: test ghc-8.6.5 dogfood
     runs-on: windows-latest
     steps:
       - uses: actions/setup-haskell@v1.1.4
         with:
-          ghc-version: '8.10.4'
-          cabal-version: '3.2.0.0'
+          ghc-version: '8.6.5'
+          cabal-version: '3.4.0.0'
       - name: Print versions
         run: |
           [Environment]::GetEnvironmentVariable("Path")
@@ -85,9 +90,55 @@ jobs:
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v2
-      # We cannot ask for all dependencies, but we can for Cabal.
-      - name: cabal v2-build Cabal --only-dependencies
-        run: cabal v2-build Cabal --only-dependencies
+      # all dependencies of Cabal already there (due to GHC depending on Cabal)
+      - name: cabal v2-build Cabal
+        run: cabal v2-build Cabal
+      # We cannot ask for all dependencies, but we can for cabal-install.
+      - name: cabal v2-build cabal-install --only-dependencies
+        run: cabal v2-build cabal-install --only-dependencies
+      - name: cabal v2-build
+        run: cabal v2-build all
+      - name: wipe out cabal store
+        run: Remove-Item -Recurse -Force C:\SR
+      - name: eat its own dogfood by building own Cabal source with itself
+        run: |
+          cp $(cabal list-bin exe:cabal) ./cabal-exe-current
+          ./cabal-exe-current --version
+          ./cabal-exe-current v2-build Cabal
+        shell: bash
+      - name: eat its own dogfood by building all deps with itself
+        run: ./cabal-exe-current v2-build cabal-install --only-dependencies
+        shell: bash
+      - name: eat its own dogfood by building own source with itself
+        run: ./cabal-exe-current v2-build all
+        shell: bash
+  test-windows-8_10_4:
+    name: test ghc-8.10.4
+    runs-on: windows-latest
+    steps:
+      - uses: actions/setup-haskell@v1.1.4
+        with:
+          ghc-version: '8.10.4'
+          cabal-version: '3.4.0.0'
+      - name: Print versions
+        run: |
+          [Environment]::GetEnvironmentVariable("Path")
+          cabal --version
+          ghc --version
+          cabal user-config init -a "http-transport: plain-http" -a "store-dir: C:\SR" -f -v3
+      - uses: actions/cache@v1
+        with:
+          path: C:\SR
+          key: windows-store-meta
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v2
+      # all dependencies of Cabal already there (due to GHC depending on Cabal)
+      - name: cabal v2-build Cabal
+        run: cabal v2-build Cabal
+      # We cannot ask for all dependencies, but we can for cabal-install.
+      - name: cabal v2-build cabal-install --only-dependencies
+        run: cabal v2-build cabal-install --only-dependencies
       - name: cabal v2-build
         run: cabal v2-build all
       - name: Cabal unit-tests
@@ -112,3 +163,48 @@ jobs:
       - name: cabal-tests
         # Using only one job, -j1, to fail less.
         run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.10.4\cabal-install-3.7.0.0\x\cabal\build\cabal\cabal.exe
+
+#TODO: store the exe from above as artifact and re-use it here instead of building anew
+  test-windows-8_10_4-dogfood:
+    name: test ghc-8.10.4 dogfood
+    runs-on: windows-latest
+    steps:
+      - uses: actions/setup-haskell@v1.1.4
+        with:
+          ghc-version: '8.10.4'
+          cabal-version: '3.4.0.0'
+      - name: Print versions
+        run: |
+          [Environment]::GetEnvironmentVariable("Path")
+          cabal --version
+          ghc --version
+          cabal user-config init -a "http-transport: plain-http" -a "store-dir: C:\SR" -f -v3
+      - uses: actions/cache@v1
+        with:
+          path: C:\SR
+          key: windows-store-meta
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v2
+      # all dependencies of Cabal already there (due to GHC depending on Cabal)
+      - name: cabal v2-build Cabal
+        run: cabal v2-build Cabal
+      # We cannot ask for all dependencies, but we can for cabal-install.
+      - name: cabal v2-build cabal-install --only-dependencies
+        run: cabal v2-build cabal-install --only-dependencies
+      - name: cabal v2-build
+        run: cabal v2-build all
+      - name: wipe out cabal store
+        run: Remove-Item -Recurse -Force C:\SR
+      - name: eat its own dogfood by building own Cabal source with itself
+        run: |
+          cp $(cabal list-bin exe:cabal) ./cabal-exe-current
+          ./cabal-exe-current --version
+          ./cabal-exe-current v2-build Cabal
+        shell: bash
+      - name: eat its own dogfood by building all deps with itself
+        run: ./cabal-exe-current v2-build cabal-install --only-dependencies
+        shell: bash
+      - name: eat its own dogfood by building own source with itself
+        run: ./cabal-exe-current v2-build all
+        shell: bash

--- a/templates/ci-windows.template.yml
+++ b/templates/ci-windows.template.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-haskell@v1.1.4
         with:
           ghc-version: '{{ job.chocoVersion }}'
-          cabal-version: '3.2.0.0'
+          cabal-version: '3.4.0.0'
       - name: Print versions
         run: |
           [Environment]::GetEnvironmentVariable("Path")
@@ -44,9 +44,12 @@ jobs:
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v2
-      # We cannot ask for all dependencies, but we can for Cabal.
-      - name: cabal v2-build Cabal --only-dependencies
-        run: cabal v2-build Cabal --only-dependencies
+      # all dependencies of Cabal already there (due to GHC depending on Cabal)
+      - name: cabal v2-build Cabal
+        run: cabal v2-build Cabal
+      # We cannot ask for all dependencies, but we can for cabal-install.
+      - name: cabal v2-build cabal-install --only-dependencies
+        run: cabal v2-build cabal-install --only-dependencies
       - name: cabal v2-build
         run: cabal v2-build all
       - name: Cabal unit-tests
@@ -71,4 +74,52 @@ jobs:
       - name: cabal-tests
         # Using only one job, -j1, to fail less.
         run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-{{ job.version }}\cabal-install-3.7.0.0\x\cabal\build\cabal\cabal.exe
+
+#TODO: store the exe from above as artifact and re-use it here instead of building anew
+  test-windows-{{ mangleVersion job.version }}-dogfood:
+    name: test ghc-{{job.version}} dogfood
+    runs-on: windows-latest
+{% for needs in job.needs %}
+    needs: test-windows-{{ mangleVersion needs }}
+{% endfor %}
+    steps:
+      - uses: actions/setup-haskell@v1.1.4
+        with:
+          ghc-version: '{{ job.chocoVersion }}'
+          cabal-version: '3.4.0.0'
+      - name: Print versions
+        run: |
+          [Environment]::GetEnvironmentVariable("Path")
+          cabal --version
+          ghc --version
+          cabal user-config init -a "http-transport: plain-http" -a "store-dir: C:\SR" -f -v3
+      - uses: actions/cache@v1
+        with:
+          path: C:\SR
+          key: windows-store-meta
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v2
+      # all dependencies of Cabal already there (due to GHC depending on Cabal)
+      - name: cabal v2-build Cabal
+        run: cabal v2-build Cabal
+      # We cannot ask for all dependencies, but we can for cabal-install.
+      - name: cabal v2-build cabal-install --only-dependencies
+        run: cabal v2-build cabal-install --only-dependencies
+      - name: cabal v2-build
+        run: cabal v2-build all
+      - name: wipe out cabal store
+        run: Remove-Item -Recurse -Force C:\SR
+      - name: eat its own dogfood by building own Cabal source with itself
+        run: |
+          cp $(cabal list-bin exe:cabal) ./cabal-exe-current
+          ./cabal-exe-current --version
+          ./cabal-exe-current v2-build Cabal
+        shell: bash
+      - name: eat its own dogfood by building all deps with itself
+        run: ./cabal-exe-current v2-build cabal-install --only-dependencies
+        shell: bash
+      - name: eat its own dogfood by building own source with itself
+        run: ./cabal-exe-current v2-build all
+        shell: bash
 {% endfor %}


### PR DESCRIPTION
A part of the effort to prevent hiccups like #7649.

I've tested that it fails with 3.6, works after reverting the offending autoconf PR, once the new CI jobs are merged, I will test if the new autoconf fix passes with it.

I've also fixed some details in he previous CI jobs from the workflow and bumped cabal used for bootstrapping from 3.2 to 3.4 in order to make `list-bin` available, needed for the dogfooding jobs.

Citing IRC:

> I will build master, wipe out store, build master again using the exe just obtained
> this is an automatic replication of the test with which @jneira originally detected #7649
> let's see if that's longer than current CIs
> (that was Tamar's reservation about this idea, I think)

> our windows.yml CI workflow builds network as part of all cabal deps (and cabal source itself), but it uses cabal 3.2.0.0 to do so
> it takes 21m to do so (BTW, the script a bit broken, the --only-dependencies part is vacuus, strangelyl)
> while the whole workflow takes 50min or more
> so the dog-fooding workflow would be faster than some of our existing workflows
> so, if run concurrently (not always the case), it would not increase the waiting time
> (that's with GHC 8.10)

> doh, I've just looked at the corresponding linux and macos CI script templates and the validate.sh script they run instead of the simple Windows commands and I have no idea what's going on there
> in particular, I'm not going to amend them in this commit; on the bright side, perhaps they do test dogfooding, given how smart they look 
[edit: actually, they probably don't, but they have autoconf tests that seem to catch at least some of autoconf-related breakage that doesn't break Windows CI]

> strangely network seems to compile fine in CI with GHC 8.6.5
> I also learned what the famed zinza is for --- it's for generating CI scripts from template