### PR TITLE
Try to fix CI/Meta-checks failure

### DIFF
--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -24,8 +24,6 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "/opt/cabal/3.2/bin" >> $GITHUB_PATH
-          echo "/opt/ghc/8.10.4/bin" >> $GITHUB_PATH
       - uses: actions/cache@v1
         with:
           path: ~/.cabal/store
@@ -52,8 +50,6 @@ jobs:
       - name: Set PATH
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "/opt/cabal/3.2/bin" >> $GITHUB_PATH
-          echo "/opt/ghc/8.10.4/bin" >> $GITHUB_PATH
       - name: Install cabal-env
         run: |
           mkdir -p $HOME/.cabal/bin

--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -22,7 +22,7 @@ executable gen-spdx
     , bytestring
     , containers
     , Diff                  ^>=0.4
-    , lens                  ^>=4.18.1 || ^>=4.19.1
+    , lens                  ^>=4.18.1 || ^>=4.19.1 || ^>=5.0.1
     , optparse-applicative  ^>=0.15.1.0 || ^>=0.16.0.0
     , text
     , zinza                 ^>=0.2
@@ -39,7 +39,7 @@ executable gen-spdx-exc
     , bytestring
     , containers
     , Diff                  ^>=0.4
-    , lens                  ^>=4.18.1 || ^>=4.19.1
+    , lens                  ^>=4.18.1 || ^>=4.19.1 || ^>=5.0.1
     , optparse-applicative  ^>=0.15.1.0 || ^>=0.16.0.0
     , text
     , zinza                 ^>=0.2

--- a/templates/ci-quick-jobs.template.yml
+++ b/templates/ci-quick-jobs.template.yml
@@ -24,8 +24,6 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "/opt/cabal/3.2/bin" >> $GITHUB_PATH
-          echo "/opt/ghc/8.10.4/bin" >> $GITHUB_PATH
       - uses: actions/cache@v1
         with:
           path: ~/.cabal/store
@@ -52,8 +50,6 @@ jobs:
       - name: Set PATH
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "/opt/cabal/3.2/bin" >> $GITHUB_PATH
-          echo "/opt/ghc/8.10.4/bin" >> $GITHUB_PATH
       - name: Install cabal-env
         run: |
           mkdir -p $HOME/.cabal/bin


### PR DESCRIPTION
This PR is the second aiming to eliminate the recent CI failures. This one seems to be caused by a bumped GHC version on GHA that also bump `TH` that forces `lens` bump that conflicts with bounds in cabal-dev-scripts.cabal.