### PR TITLE
Bring back cabal-install-dev call removed by backport of #7653

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v2
+      - name: make cabal-install-dev
+        run: cp cabal-install/cabal-install.cabal.dev cabal-install/cabal-install.cabal
       # all dependencies of Cabal already there (due to GHC depending on Cabal)
       - name: cabal v2-build Cabal
         run: cabal v2-build Cabal
@@ -132,6 +134,8 @@ jobs:
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v2
+      - name: make cabal-install-dev
+        run: cp cabal-install/cabal-install.cabal.dev cabal-install/cabal-install.cabal
       # all dependencies of Cabal already there (due to GHC depending on Cabal)
       - name: cabal v2-build Cabal
         run: cabal v2-build Cabal

--- a/templates/ci-windows.template.yml
+++ b/templates/ci-windows.template.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v2
+      - name: make cabal-install-dev
+        run: cp cabal-install/cabal-install.cabal.dev cabal-install/cabal-install.cabal
       # all dependencies of Cabal already there (due to GHC depending on Cabal)
       - name: cabal v2-build Cabal
         run: cabal v2-build Cabal


### PR DESCRIPTION
I guess I mistakenly removed it when resolving a conflict in backport
of #7653 in c3354c96cbfdad3fac8afcce9c5806f77187bcee,
because on master these omitted lines are absent.
BTW, this backport was not reviewed, by my mistake.
A good example why careful reviews are essential.
Sadly, this PR will get in without reviews, too, because we are 
greatly lagging behind with reviews this week.