### PR TITLE
Add links to irc/matrix chat to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Stackage version](https://www.stackage.org/package/Cabal/badge/lts?label=Stackage)](https://www.stackage.org/package/Cabal)
 [![Artifacts](https://github.com/haskell/cabal/actions/workflows/artifacts.yml/badge.svg?branch=master)](https://github.com/haskell/cabal/actions/workflows/artifacts.yml?query=branch%3Amaster)
 [![Documentation Status](http://readthedocs.org/projects/cabal/badge/?version=latest)](http://cabal.readthedocs.io/en/latest/?badge=latest)
+**[IRC](https://web.libera.chat/#hackage)**
+**[Matrix](https://matrix.to/#/#hackage:libera.chat)**
 
 <img src="https://www.haskell.org/cabal/images/Cabal-light.png" align="right">
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Cabal [![Hackage version](https://img.shields.io/hackage/v/Cabal.svg?label=Hackage)](https://hackage.haskell.org/package/Cabal) [![Stackage version](https://www.stackage.org/package/Cabal/badge/lts?label=Stackage)](https://www.stackage.org/package/Cabal) [![Artifacts](https://github.com/haskell/cabal/actions/workflows/artifacts.yml/badge.svg?branch=master)](https://github.com/haskell/cabal/actions/workflows/artifacts.yml?query=branch%3Amaster) [![Documentation Status](http://readthedocs.org/projects/cabal/badge/?version=latest)](http://cabal.readthedocs.io/en/latest/?badge=latest)
+# Cabal
+
+[![Hackage version](https://img.shields.io/hackage/v/Cabal.svg?label=Hackage)](https://hackage.haskell.org/package/Cabal)
+[![Stackage version](https://www.stackage.org/package/Cabal/badge/lts?label=Stackage)](https://www.stackage.org/package/Cabal)
+[![Artifacts](https://github.com/haskell/cabal/actions/workflows/artifacts.yml/badge.svg?branch=master)](https://github.com/haskell/cabal/actions/workflows/artifacts.yml?query=branch%3Amaster)
+[![Documentation Status](http://readthedocs.org/projects/cabal/badge/?version=latest)](http://cabal.readthedocs.io/en/latest/?badge=latest)
 
 <img src="https://www.haskell.org/cabal/images/Cabal-light.png" align="right">
 


### PR DESCRIPTION
The irc channel is not very discoverable so let's fix that!

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

https://github.com/fgaz/cabal/tree/readme-chat-links#readme