### PR TITLE
Revert "Change cabal-plan list-bin to cabal list-bin in Makefile"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ $(TEMPLATE_PATHS) : templates/Paths_pkg.template.hs cabal-dev-scripts/src/GenPat
 
 buildinfo-fields-reference : phony
 	cabal build --builddir=dist-newstyle-bi --project-file=cabal.project.buildinfo buildinfo-reference-generator
-	$$(cabal list-bin --builddir=dist-newstyle-bi buildinfo-reference-generator) buildinfo-reference-generator/template.zinza | tee $@
+	$$(cabal-plan list-bin --builddir=dist-newstyle-bi buildinfo-reference-generator) buildinfo-reference-generator/template.zinza | tee $@
 
 # analyse-imports
 analyse-imports : phony
@@ -119,22 +119,24 @@ hackage-roundtrip-tests :
 	$(CABALRUN) hackage-tests -- roundtrip +RTS -s -qg -I0 -A64M -N${THREADS} -RTS ${TEST}
 
 cabal-install-test:
+	@which cabal-plan
 	$(CABALBUILD) -j3 cabal-tests cabal
 	rm -rf .ghc.environment.*
-	cd cabal-testsuite && `cabal list-bin cabal-tests` --with-cabal=`cabal list-bin cabal` --hide-successes -j3 ${TEST}
+	cd cabal-testsuite && `cabal-plan list-bin cabal-tests` --with-cabal=`cabal-plan list-bin cabal` --hide-successes -j3 ${TEST}
 
 # hackage-benchmarks (solver)
 
 hackage-benchmarks-run:
 	$(CABALBUILD) -j3 hackage-benchmark cabal
 	rm -rf .ghc.environment.*
-	$$(cabal list-bin hackage-benchmark) --cabal1=cabal --cabal2=$$(cabal list-bin cabal) --packages="hakyll servant-auth-server" --print-trials --concurrently
+	$$(cabal-plan list-bin hackage-benchmark) --cabal1=cabal --cabal2=$$(cabal-plan list-bin cabal) --packages="hakyll servant-auth-server" --print-trials --concurrently
 
 
 # This doesn't run build, as you first need to test with cabal-install-test :)
 cabal-install-test-accept:
+	@which cabal-plan
 	rm -rf .ghc.environment.*
-	cd cabal-testsuite && `cabal list-bin cabal-tests` --with-cabal=`cabal list-bin cabal` --hide-successes -j3 --accept ${TEST}
+	cd cabal-testsuite && `cabal-plan list-bin cabal-tests` --with-cabal=`cabal-plan list-bin cabal` --hide-successes -j3 --accept ${TEST}
 
 # Docker validation
 


### PR DESCRIPTION
Reverts haskell/cabal#7648

The replacement of `cabal-plan list-bin` by `cabal list-bin` did not work for macOS.
Details see https://github.com/haskell/cabal/pull/7648#issuecomment-924111500.