### PR TITLE
addFileMode: Replace use of Posix.Internals module with public API

### DIFF
--- a/cabal-install/src/Distribution/Client/Compat/FilePerms.hs
+++ b/cabal-install/src/Distribution/Client/Compat/FilePerms.hs
@@ -7,10 +7,10 @@ module Distribution.Client.Compat.FilePerms (
   ) where
 
 import Prelude (FilePath, IO, return)
-import Data.Bits ((.|.))
 
 #ifndef mingw32_HOST_OS
 import Prelude ((<$>))
+import Data.Bits ((.|.))
 import System.Posix.Types
          ( FileMode )
 import System.Posix.Files


### PR DESCRIPTION
Another follow-up to #7572 

Turns out there's a less gnarly API for file modes than the .Internals stuff we were already using.

---
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] 