### PR TITLE
Fix #5410: include `unpack` in help text as deprecated alias for `get`

### DIFF
--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -232,7 +232,7 @@ mainWorker args = do
       , regularCmd infoCommand infoAction
       , regularCmd fetchCommand fetchAction
       , regularCmd getCommand getAction
-      , hiddenCmd  unpackCommand unpackAction
+      , regularCmd unpackCommand unpackAction
       , regularCmd checkCommand checkAction
       , regularCmd uploadCommand uploadAction
       , regularCmd reportCommand reportAction

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -161,6 +161,7 @@ globalCommand commands = CommandUI {
           , "info"
           , "user-config"
           , "get"
+          , "unpack"
           , "init"
           , "configure"
           , "build"
@@ -248,6 +249,7 @@ globalCommand commands = CommandUI {
         , par
         , startGroup "package"
         , addCmd "get"
+        , addCmd "unpack"
         , addCmd "init"
         , par
         , addCmd "configure"
@@ -1313,17 +1315,8 @@ getCommand :: CommandUI GetFlags
 getCommand = CommandUI {
     commandName         = "get",
     commandSynopsis     = "Download/Extract a package's source code (repository).",
-    commandDescription  = Just $ \_ -> wrapText $
-          "Creates a local copy of a package's source code. By default it gets "
-       ++ "the source\ntarball and unpacks it in a local subdirectory. "
-       ++ "Alternatively, with -s it will\nget the code from the source "
-       ++ "repository specified by the package.\n",
-    commandNotes        = Just $ \pname ->
-          "Examples:\n"
-       ++ "  " ++ pname ++ " get hlint\n"
-       ++ "    Download the latest stable version of hlint;\n"
-       ++ "  " ++ pname ++ " get lens --source-repository=head\n"
-       ++ "    Download the source repository (i.e. git clone from github).\n",
+    commandDescription  = Just $ \_ -> wrapText $ unlines descriptionOfGetCommand,
+    commandNotes        = Just $ \pname -> unlines $ notesOfGetCommand "get" pname,
     commandUsage        = usagePackages "get",
     commandDefaultFlags = defaultGetFlags,
     commandOptions      = \_ -> [
@@ -1364,12 +1357,38 @@ getCommand = CommandUI {
        ]
   }
 
+-- | List of lines describing command @get@.
+descriptionOfGetCommand :: [String]
+descriptionOfGetCommand =
+  [ "Creates a local copy of a package's source code. By default it gets the source"
+  , "tarball and unpacks it in a local subdirectory. Alternatively, with -s it will"
+  , "get the code from the source repository specified by the package."
+  ]
+
+-- | Notes for the command @get@.
+notesOfGetCommand
+  :: String    -- ^ Either @"get"@ or @"unpack"@.
+  -> String    -- ^ E.g. @"cabal"@.
+  -> [String]  -- ^ List of lines.
+notesOfGetCommand cmd pname =
+  [ "Examples:"
+  , "  " ++ unwords [ pname, cmd, "hlint" ]
+  , "    Download the latest stable version of hlint;"
+  , "  " ++ unwords [ pname, cmd, "lens --source-repository=head" ]
+  , "    Download the source repository of lens (i.e. git clone from github)."
+  ]
+
 -- 'cabal unpack' is a deprecated alias for 'cabal get'.
 unpackCommand :: CommandUI GetFlags
-unpackCommand = getCommand {
-  commandName  = "unpack",
-  commandUsage = usagePackages "unpack"
+unpackCommand = getCommand
+  { commandName        = "unpack"
+  , commandSynopsis    = synopsis
+  , commandNotes       = Just $ \ pname -> unlines $
+      notesOfGetCommand "unpack" pname
+  , commandUsage       = usagePackages "unpack"
   }
+  where
+  synopsis = "Deprecated alias for 'get'."
 
 instance Monoid GetFlags where
   mempty = gmempty


### PR DESCRIPTION
Fix #5410: include `unpack` in help text as deprecated alias for `get`

New output:
```
$ cabal --help
...
 [package]
  get               Download/Extract a package's source code (repository).
  unpack            Deprecated alias for 'get'.
...

$ cabal unpack --help
Deprecated alias for 'get'.

Usage: cabal unpack [PACKAGES]

Creates a local copy of a package's source code. By default it gets the source
tarball and unpacks it in a local subdirectory. Alternatively, with -s it will
get the code from the source repository specified by the package.

Flags for unpack:
 -h, --help                     Show this help text
 -v, --verbose[=n]              Control verbosity (n is 0--3, default
                                verbosity level is 1)
 -d, --destdir=PATH             Where to place the package source, defaults to
                                the current directory.
 -s, --source-repository[=[head|this|...]]
                                Copy the package's source repository (ie git
                                clone, darcs get, etc as appropriate).
 --index-state=STATE            Use source package index state as it existed
                                at a previous time. Accepts unix-timestamps
                                (e.g. '@1474732068'), ISO8601 UTC timestamps
                                (e.g. '2016-09-24T17:47:48Z'), or 'HEAD'
                                (default: 'HEAD'). This determines which
                                package versions are available as well as
                                .cabal file revision is selected (unless
                                --pristine is used).
 --pristine                     Unpack the original pristine tarball, rather
                                than updating the .cabal file with the latest
                                revision from the package archive.

Examples:
  cabal unpack hlint
    Download the latest stable version of hlint;
  cabal unpack lens --source-repository=head
    Download the source repository of lens (i.e. git clone from github).
```


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
