### PR TITLE
Fix #7714: use `nroff -man | less` as backend for `cabal man`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -79,6 +79,10 @@ jobs:
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: apt-get update
+        run: apt-get update
+      - name: Install `nroff` for `cabal man`
+        run: apt-get install -y groff-base
       - name: Update Hackage index
         run: cabal v2-update
       # https://github.com/actions/checkout/issues/170
@@ -124,6 +128,10 @@ jobs:
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: apt-get update
+        run: apt-get update
+      - name: Install `nroff` for `cabal man`
+        run: apt-get install -y groff-base
       - name: Update Hackage index
         run: cabal v2-update
       # https://github.com/actions/checkout/issues/170
@@ -170,6 +178,10 @@ jobs:
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: apt-get update
+        run: apt-get update
+      - name: Install `nroff` for `cabal man`
+        run: apt-get install -y groff-base
       - name: Update Hackage index
         run: cabal v2-update
       # https://github.com/actions/checkout/issues/170
@@ -216,6 +228,10 @@ jobs:
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: apt-get update
+        run: apt-get update
+      - name: Install `nroff` for `cabal man`
+        run: apt-get install -y groff-base
       - name: Update Hackage index
         run: cabal v2-update
       # https://github.com/actions/checkout/issues/170
@@ -262,6 +278,10 @@ jobs:
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
+      - name: apt-get update
+        run: apt-get update
+      - name: Install `nroff` for `cabal man`
+        run: apt-get install -y groff-base
       - name: Update Hackage index
         run: cabal v2-update
       # https://github.com/actions/checkout/issues/170

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -362,6 +362,7 @@ library
     GeneralizedNewtypeDeriving
     ImplicitParams
     KindSignatures
+    LambdaCase
     NondecreasingIndentation
     OverloadedStrings
     RankNTypes

--- a/cabal-dev-scripts/src/GenValidate.hs
+++ b/cabal-dev-scripts/src/GenValidate.hs
@@ -21,7 +21,8 @@ main = do
             run <- parseAndCompileTemplateIO src
             -- this shouldn't fail (run-time errors are due bugs in zinza)
             w <- run Z
-                { zJobs =
+                { zJobs = -- version xenial flags                       old   needs     steps
+                          -------------------------------------------------------------------
                     [ GhcJob "9.0.1"  False "--lib-only"                False ["8.8.4"] libSteps
                     , GhcJob "8.10.4" False ""                          False ["8.8.4"] defSteps
                     , GhcJob "8.8.4"  False "--solver-benchmarks"       False []        defSteps
@@ -49,8 +50,8 @@ main = do
                     ]
                 , zMangleVersion = map mangleChar
                 , zOr            = (||)
-                , zNotNull       = not . null
-                , zFalse         = False
+                , zNot           = not
+                , zLibOnly       = (== "--lib-only")
                 }
 
             -- check that YAML is syntactically valid
@@ -94,8 +95,8 @@ data Z = Z
     , zWinJobs       :: [WinGhcJob]
     , zMangleVersion :: String -> String
     , zOr            :: Bool -> Bool -> Bool
-    , zNotNull       :: [String] -> Bool
-    , zFalse         :: Bool
+    , zNot           :: Bool -> Bool
+    , zLibOnly       :: String -> Bool
     }
   deriving (Generic)
 

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -972,7 +972,7 @@ manpageAction :: [CommandSpec action] -> ManpageFlags -> [String] -> Action
 manpageAction commands flags extraArgs _ = do
   let verbosity = fromFlag (manpageVerbosity flags)
   unless (null extraArgs) $
-    die' verbosity $ "'manpage' doesn't take any extra arguments: " ++ unwords extraArgs
+    die' verbosity $ "'man' doesn't take any extra arguments: " ++ unwords extraArgs
   pname <- getProgName
   let cabalCmd = if takeExtension pname == ".exe"
                  then dropExtension pname

--- a/cabal-install/src/Distribution/Client/Manpage.hs
+++ b/cabal-install/src/Distribution/Client/Manpage.hs
@@ -25,7 +25,6 @@ import Prelude ()
 import qualified Data.List.NonEmpty as List1
 
 import Distribution.Client.Init.Utils   (trim)
-  -- TODO #7744: move 'trim' to a more canonical place
 import Distribution.Client.ManpageFlags
 import Distribution.Client.Setup        (globalCommand)
 import Distribution.Simple.Command

--- a/cabal-install/src/Distribution/Client/Manpage.hs
+++ b/cabal-install/src/Distribution/Client/Manpage.hs
@@ -34,6 +34,8 @@ import Distribution.Simple.Utils
   ( IOData(..), IODataMode(..), createProcessWithEnv, ignoreSigPipe, rawSystemStdInOut )
 import qualified Distribution.Verbosity as Verbosity
 import System.IO                        (hClose, hPutStr)
+import System.Environment               (lookupEnv)
+import System.FilePath                  (takeFileName)
 
 import qualified System.Process as Process
 
@@ -78,11 +80,14 @@ manpageCmd pname commands flags
 
         unless (ec1 == ExitSuccess) $ exitWith ec1
 
+        pager <- fromMaybe "less" <$> lookupEnv "PAGER"
+        -- 'less' is borked with color sequences otherwise
+        let pagerArgs = if takeFileName pager == "less" then ["-R"] else []
         -- Pipe output of @nroff@ into @less@
         (Just inLess, _, _, procLess) <- createProcessWithEnv
           Verbosity.normal
-          "less"
-          []
+          pager
+          pagerArgs
           Nothing  -- Inherit working directory
           Nothing  -- Inherit environment
           Process.CreatePipe  -- in

--- a/cabal-install/src/Distribution/Client/Manpage.hs
+++ b/cabal-install/src/Distribution/Client/Manpage.hs
@@ -22,12 +22,17 @@ module Distribution.Client.Manpage
 
 import Distribution.Client.Compat.Prelude
 import Prelude ()
+import qualified Data.List.NonEmpty as List1
 
+import Distribution.Client.Init.Utils   (trim)
+  -- TODO #7744: move 'trim' to a more canonical place
 import Distribution.Client.ManpageFlags
 import Distribution.Client.Setup        (globalCommand)
-import Distribution.Compat.Process      (createProcess)
 import Distribution.Simple.Command
 import Distribution.Simple.Flag         (fromFlagOrDefault)
+import Distribution.Simple.Utils
+  ( IOData(..), IODataMode(..), createProcessWithEnv, rawSystemStdInOut )
+import qualified Distribution.Verbosity as Verbosity
 import System.IO                        (hClose, hPutStr)
 
 import qualified System.Process as Process
@@ -50,23 +55,43 @@ manpageCmd pname commands flags
     = putStrLn contents
     | otherwise
     = do
-        let cmd  = "man"
-            args = ["-l", "-"]
+        -- 2021-10-08, issue #7714
+        -- @cabal man --raw | man -l -@ does not work on macOS/BSD,
+        -- because BSD-man does not support option @-l@, rather would
+        -- accept directly a file argument, e.g. @man /dev/stdin@.
+        -- The following works both on macOS and Linux
+        -- (but not on Windows out-of-the-box):
+        --
+        --   cabal man --raw | nroff -man /dev/stdin | less
+        --
+        -- So let us simulate this!
 
-        (mb_in, _, _, ph) <- createProcess (Process.proc cmd args)
-            { Process.std_in  = Process.CreatePipe
-            , Process.std_out = Process.Inherit
-            , Process.std_err = Process.Inherit
-            }
+        -- Feed contents into @nroff -man /dev/stdin@
+        (formatted, _errors, ec1) <- rawSystemStdInOut
+          Verbosity.normal
+          "nroff"
+          [ "-man", "/dev/stdin" ]
+          Nothing  -- Inherit working directory
+          Nothing  -- Inherit environment
+          (Just $ IODataText contents)
+          IODataModeText
 
-        -- put contents
-        for_ mb_in $ \hin -> do
-            hPutStr hin contents
-            hClose hin
+        unless (ec1 == ExitSuccess) $ exitWith ec1
 
-        -- wait for process to exit, propagate exit code
-        ec <- Process.waitForProcess ph
-        exitWith ec
+        -- Pipe output of @nroff@ into @less@
+        (Just inLess, _, _, procLess) <- createProcessWithEnv
+          Verbosity.normal
+          "less"
+          []
+          Nothing  -- Inherit working directory
+          Nothing  -- Inherit environment
+          Process.CreatePipe  -- in
+          Process.Inherit     -- out
+          Process.Inherit     -- err
+
+        hPutStr inLess formatted
+        hClose  inLess
+        exitWith =<< Process.waitForProcess procLess
   where
     contents :: String
     contents = manpage pname commands
@@ -117,7 +142,7 @@ manpage pname commands = unlines $
 commandSynopsisLines :: String -> CommandSpec action -> [String]
 commandSynopsisLines pname (CommandSpec ui _ NormalCommand) =
   [ ".B " ++ pname ++ " " ++ (commandName ui)
-  , ".R - " ++ commandSynopsis ui
+  , "- " ++ commandSynopsis ui
   , ".br"
   ]
 commandSynopsisLines _ (CommandSpec _ _ HiddenCommand) = []
@@ -129,8 +154,8 @@ commandDetailsLines pname (CommandSpec ui _ NormalCommand) =
   , commandUsage ui pname
   , ""
   ] ++
-  optional commandDescription ++
-  optional commandNotes ++
+  optional removeLineBreaks commandDescription ++
+  optional id commandNotes ++
   [ "Flags:"
   , ".RS"
   ] ++
@@ -139,10 +164,26 @@ commandDetailsLines pname (CommandSpec ui _ NormalCommand) =
   , ""
   ]
   where
-    optional field =
+    optional f field =
       case field ui of
-        Just text -> [text pname, ""]
+        Just text -> [ f $ text pname, "" ]
         Nothing   -> []
+    -- 2021-10-12, https://github.com/haskell/cabal/issues/7714#issuecomment-940842905
+    -- Line breaks just before e.g. 'new-build' cause weird @nroff@ warnings.
+    -- Thus:
+    -- Remove line breaks but preserve paragraph breaks.
+    -- We group lines by empty/non-empty and then 'unwords'
+    -- blocks consisting of non-empty lines.
+    removeLineBreaks
+      = unlines
+      . concatMap unwordsNonEmpty
+      . List1.groupWith null
+      . map trim
+      . lines
+    unwordsNonEmpty :: List1.NonEmpty String -> [String]
+    unwordsNonEmpty ls1 = if null (List1.head ls1) then ls else [unwords ls]
+      where ls = List1.toList ls1
+
 commandDetailsLines _ (CommandSpec _ _ HiddenCommand) = []
 
 optionsLines :: CommandUI flags -> [String]

--- a/cabal-install/src/Distribution/Client/Manpage.hs
+++ b/cabal-install/src/Distribution/Client/Manpage.hs
@@ -31,7 +31,7 @@ import Distribution.Client.Setup        (globalCommand)
 import Distribution.Simple.Command
 import Distribution.Simple.Flag         (fromFlagOrDefault)
 import Distribution.Simple.Utils
-  ( IOData(..), IODataMode(..), createProcessWithEnv, rawSystemStdInOut )
+  ( IOData(..), IODataMode(..), createProcessWithEnv, ignoreSigPipe, rawSystemStdInOut )
 import qualified Distribution.Verbosity as Verbosity
 import System.IO                        (hClose, hPutStr)
 
@@ -54,7 +54,7 @@ manpageCmd pname commands flags
     | fromFlagOrDefault False (manpageRaw flags)
     = putStrLn contents
     | otherwise
-    = do
+    = ignoreSigPipe $ do
         -- 2021-10-08, issue #7714
         -- @cabal man --raw | man -l -@ does not work on macOS/BSD,
         -- because BSD-man does not support option @-l@, rather would

--- a/cabal-testsuite/PackageTests/Manpage/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Manpage/cabal.test.hs
@@ -1,21 +1,24 @@
 import System.Process
+import Distribution.System (OS(Windows,Linux,OSX), buildOS)
 import Test.Cabal.Prelude
-
 
 main = cabalTest $ do
     r <- cabal' "man" ["--raw"]
     assertOutputContains ".B cabal install" r
     assertOutputDoesNotContain ".B cabal manpage" r
 
-    -- Check that output of `cabal man --raw` can be passed through `nroff -man`
-    -- without producing any warnings (which are printed to stderr).
-    --
-    -- NB: runM is not suitable as it mixes stdout and stderr
-    -- r2 <- runM "nroff" ["-man", "/dev/stdin"] $ Just $ resultOutput r
-    (ec, _output, errors) <- liftIO $
-      readProcessWithExitCode "nroff" ["-man", "/dev/stdin"] $ resultOutput r
-    unless (null errors) $
-      assertFailure $ unlines
-        [ "Error: unexpected warnings produced by `nroff -man`:"
-        , errors
-        ]
+    -- The following test of `cabal man` needs `nroff` which is not available under Windows.
+    unless (buildOS == Windows) $ do
+
+      -- Check that output of `cabal man --raw` can be passed through `nroff -man`
+      -- without producing any warnings (which are printed to stderr).
+      --
+      -- NB: runM is not suitable as it mixes stdout and stderr
+      -- r2 <- runM "nroff" ["-man", "/dev/stdin"] $ Just $ resultOutput r
+      (ec, _output, errors) <- liftIO $
+        readProcessWithExitCode "nroff" ["-man", "/dev/stdin"] $ resultOutput r
+      unless (null errors) $
+        assertFailure $ unlines
+          [ "Error: unexpected warnings produced by `nroff -man`:"
+          , errors
+          ]

--- a/templates/ci-linux.template.yml
+++ b/templates/ci-linux.template.yml
@@ -40,7 +40,7 @@ jobs:
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
-{% if or job.xenial job.old %}
+{% if or job.xenial (or job.old (not (libOnly job.flags))) %}
       - name: apt-get update
         run: apt-get update
 {% endif %}
@@ -51,6 +51,10 @@ jobs:
 {% if job.old %}
       - name: Install extra compilers
         run: apt-get install -y ghc-7.0.4-dyn ghc-7.2.2-dyn ghc-7.4.2-dyn
+{% endif %}
+{% if not (libOnly job.flags) %}
+      - name: Install `nroff` for `cabal man`
+        run: apt-get install -y groff-base
 {% endif %}
       - name: Update Hackage index
         run: cabal v2-update


### PR DESCRIPTION
Fix #7714: use `nroff -man /dev/stdin | less` as backend for `cabal man`

WIP: This does not work yet, I need some help with constructing the pipe correctly in Haskell.

I seem to follow the example at
https://stackoverflow.com/questions/41030168/haskell-using-the-handle-created-from-createprocess-and-createpipe-to-pipe-int
which works for me, but my patch does not seem to invoke `less` correctly.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
