### PR TITLE
Consistent resolution of project root w.r.t --project-file path

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdClean.hs
+++ b/cabal-install/src/Distribution/Client/CmdClean.hs
@@ -95,7 +95,7 @@ cleanAction CleanFlags{..} extraArgs _ = do
         die' verbosity $ "'clean' extra arguments should be script files: "
                          ++ unwords notScripts
 
-    projectRoot <- either throwIO return =<< findProjectRoot Nothing mprojectFile
+    projectRoot <- either throwIO return =<< findProjectRoot mprojectFile
 
     let distLayout = defaultDistDirLayout projectRoot mdistDirectory
 

--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -301,7 +301,7 @@ depsFromFreezeFile verbosity = do
 depsFromNewFreezeFile :: Verbosity -> HttpTransport -> Compiler -> Platform -> Maybe FilePath -> IO [PackageVersionConstraint]
 depsFromNewFreezeFile verbosity httpTransport compiler (Platform arch os) mprojectFile = do
   projectRoot <- either throwIO return =<<
-                 findProjectRoot Nothing mprojectFile
+                 findProjectRoot mprojectFile
   let distDirLayout = defaultDistDirLayout projectRoot
                       {- TODO: Support dist dir override -} Nothing
   projectConfig <- runRebuild (distProjectRootDirectory distDirLayout) $ do

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -402,10 +402,9 @@ resolveBuildTimeSettings verbosity
 -- parent directories. If no project file is found then the current dir is the
 -- project root (and the project will use an implicit config).
 --
-findProjectRoot :: Maybe FilePath -- ^ starting directory, or current directory
-                -> Maybe FilePath -- ^ @cabal.project@ file name override
+findProjectRoot :: Maybe FilePath -- ^ @cabal.project@ file name override
                 -> IO (Either BadProjectRoot ProjectRoot)
-findProjectRoot _ (Just projectFile) = do
+findProjectRoot (Just projectFile) = do
     exists <- doesFileExist projectFile
     if exists
       then do projectFile' <- canonicalizePath projectFile
@@ -414,8 +413,8 @@ findProjectRoot _ (Just projectFile) = do
               return (Right projectRoot)
       else return (Left (BadProjectRootExplicitFile projectFile))
 
-findProjectRoot mstartdir Nothing = do
-    startdir <- maybe getCurrentDirectory canonicalizePath mstartdir
+findProjectRoot Nothing = do
+    startdir <- getCurrentDirectory
     homedir  <- getHomeDirectory
     probe startdir homedir
   where

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -405,8 +405,7 @@ resolveBuildTimeSettings verbosity
 findProjectRoot :: Maybe FilePath -- ^ starting directory, or current directory
                 -> Maybe FilePath -- ^ @cabal.project@ file name override
                 -> IO (Either BadProjectRoot ProjectRoot)
-findProjectRoot _ (Just projectFile)
-  | isAbsolute projectFile = do
+findProjectRoot _ (Just projectFile) = do
     exists <- doesFileExist projectFile
     if exists
       then do projectFile' <- canonicalizePath projectFile
@@ -415,13 +414,13 @@ findProjectRoot _ (Just projectFile)
               return (Right projectRoot)
       else return (Left (BadProjectRootExplicitFile projectFile))
 
-findProjectRoot mstartdir mprojectFile = do
+findProjectRoot mstartdir Nothing = do
     startdir <- maybe getCurrentDirectory canonicalizePath mstartdir
     homedir  <- getHomeDirectory
     probe startdir homedir
   where
     projectFileName :: String
-    projectFileName = fromMaybe "cabal.project" mprojectFile
+    projectFileName = "cabal.project"
 
     -- Search upwards. If we get to the users home dir or the filesystem root,
     -- then use the current dir
@@ -430,9 +429,7 @@ findProjectRoot mstartdir mprojectFile = do
       where
         go :: FilePath -> IO (Either BadProjectRoot ProjectRoot)
         go dir | isDrive dir || dir == homedir =
-          case mprojectFile of
-            Nothing   -> return (Right (ProjectRootImplicit startdir))
-            Just file -> return (Left (BadProjectRootExplicitFile file))
+          return (Right (ProjectRootImplicit startdir))
         go dir = do
           exists <- doesFileExist (dir </> projectFileName)
           if exists

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -208,7 +208,7 @@ establishProjectBaseContext
     -> CurrentCommand
     -> IO ProjectBaseContext
 establishProjectBaseContext verbosity cliConfig currentCommand = do
-    projectRoot <- either throwIO return =<< findProjectRoot Nothing mprojectFile
+    projectRoot <- either throwIO return =<< findProjectRoot mprojectFile
     establishProjectBaseContextWithRoot verbosity cliConfig projectRoot currentCommand
   where
     mprojectFile   = Setup.flagToMaybe projectConfigProjectFile

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -99,6 +99,8 @@ tests config =
     -- * dry-run tests with changes
   [ testGroup "Discovery and planning" $
     [ testCase "find root"      testFindProjectRoot
+    , testCase "find root for relative project explicit file" testExplicitRelativeFindProjectRoot
+    , testCase "find root for project file not in current dir." testResolveFindProjectRoot
     , testCase "find root fail" testExceptionFindProjectRoot
     , testCase "no package"    (testExceptionInFindingPackage config)
     , testCase "no package2"   (testExceptionInFindingPackage2 config)
@@ -162,6 +164,29 @@ testFindProjectRoot = do
     testdir  = basedir </> "exception" </> "no-pkg2"
     testfile = "bklNI8O1OpOUuDu3F4Ij4nv3oAqN"
 
+testExplicitRelativeFindProjectRoot :: Assertion
+testExplicitRelativeFindProjectRoot = do
+    cwd <- getCurrentDirectory
+    setCurrentDirectory testdir
+    Left (BadProjectRootExplicitFile file) <- findProjectRoot (Just testfile)
+    setCurrentDirectory cwd
+    file @?= testfile
+  where
+    testdir  = basedir </> "regression" </> "7695" </> "foo" </> "bar"
+    testfile = "../cabal.project"
+
+testResolveFindProjectRoot :: Assertion
+testResolveFindProjectRoot = do
+    cwd <- getCurrentDirectory
+    setCurrentDirectory testdir
+    Right (ProjectRootExplicit dir file) <- findProjectRoot Nothing
+    setCurrentDirectory cwd
+    dir @?= cwd </> rootdir
+    file @?= testfile
+  where
+    testdir  = basedir </> "regression" </> "7695" </> "foo" </> "bar"
+    rootdir  = basedir </> "regression" </> "7695"
+    testfile = "cabal.project"
 
 testExceptionFindProjectRoot :: Assertion
 testExceptionFindProjectRoot = do

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -153,8 +153,10 @@ tests config =
 
 testFindProjectRoot :: Assertion
 testFindProjectRoot = do
-    Left (BadProjectRootExplicitFile file) <- findProjectRoot (Just testdir)
-                                                              (Just testfile)
+    cwd <- getCurrentDirectory
+    setCurrentDirectory testdir
+    Left (BadProjectRootExplicitFile file) <- findProjectRoot (Just testfile)
+    setCurrentDirectory cwd
     file @?= testfile
   where
     testdir  = basedir </> "exception" </> "no-pkg2"
@@ -163,8 +165,10 @@ testFindProjectRoot = do
 
 testExceptionFindProjectRoot :: Assertion
 testExceptionFindProjectRoot = do
-    Right (ProjectRootExplicit dir _) <- findProjectRoot (Just testdir) Nothing
     cwd <- getCurrentDirectory
+    setCurrentDirectory testdir
+    Right (ProjectRootExplicit dir _) <- findProjectRoot Nothing
+    setCurrentDirectory cwd
     dir @?= cwd </> testdir
   where
     testdir = basedir </> "exception" </> "no-pkg2"

--- a/cabal-install/tests/IntegrationTests2/regression/7695/cabal.project
+++ b/cabal-install/tests/IntegrationTests2/regression/7695/cabal.project
@@ -1,0 +1,1 @@
+packages: bar

--- a/cabal-install/tests/IntegrationTests2/regression/7695/foo/bar/Bar.hs
+++ b/cabal-install/tests/IntegrationTests2/regression/7695/foo/bar/Bar.hs
@@ -1,0 +1,4 @@
+module Bar where
+
+bar :: Int
+bar = 42

--- a/cabal-install/tests/IntegrationTests2/regression/7695/foo/bar/bar.cabal
+++ b/cabal-install/tests/IntegrationTests2/regression/7695/foo/bar/bar.cabal
@@ -1,0 +1,8 @@
+name: bar
+version: 0.1
+build-type: Simple
+cabal-version: >= 1.2
+
+library
+  exposed-modules: Bar
+  build-depends: base

--- a/changelog.d/pr-7749
+++ b/changelog.d/pr-7749
@@ -1,0 +1,11 @@
+synopsis: Set project root as the directory where project file is located.
+packages: cabal-install
+prs: #7749
+issues: #7695
+
+descriptions: {
+
+Fixes a bug where project root is not resolved to the directory where cabal.project
+files are present when a relative file location is passed to --project-file.
+
+}

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -288,10 +288,14 @@ package, and thus apply globally:
     ``--project-file=my.project``, then the other files that will
     be probed are ``my.project.freeze`` and ``my.project.local``.
 
-    If the specified project file is a relative path, we will
-    look for the file relative to the current working directory,
-    and then for the parent directory, until the project file is
-    found or we have hit the top of the user's home directory.
+    The location of the ``--project-file`` also dictates the project
+    root with respect to which all other locations, like packages, are
+    resolved.
+
+    If a project file is not specified, we will look for the file relative
+    to the current working directory, and then for the parent directory,
+    until the project file is found or we have hit the top of the user's
+    home directory.
 
     This option cannot be specified via a ``cabal.project`` file.
 


### PR DESCRIPTION
- This commit sets the ProjectRoot consistently for both absolute
  and relative `--project-file` paths. The ProjectRoot is set as the
  directory where the `--project-file` is located.
- Before this change relative project files are rooted to where the
  project file is resolved, when recursively searching upward from
  the current directory, and not where it is located.

  Previous behaviour is as follows. With the following directory layout:
```
  gitpod ~/0/1/2/foo $ tree ~/0
  /home/gitpod/0
  └── 1
      ├── 2
      │   └── foo
      │       ├── app
      │       │   └── Main.hs
      │       ├── CHANGELOG.md
      │       └── foo.cabal
      └── cabal.project
```
  and inside foo let's run

```
  $ pwd
  /home/gitpod/0/1/2/foo
  $ cabal build all --project-file ../cabal.project
```
  which builds the project setting the project root at `2` using
  the project file at `1`

```
  $ ls ~/0/1 ~/0/1/2
  /home/gitpod/0/1:
  2  cabal.project

  /home/gitpod/0/1/2:
  dist-newstyle foo
```

  However, if the cabal.project file was instead in `0` directory,
  cabal would fail to build since the resolved project root is at
  `1` and cabal fails to find a package at `1/foo`

```
  gitpod ~/0/1/2/foo $ mv ~/0/1/cabal.project ~/0/
  gitpod ~/0/1/2/foo $ cabal build all --project-file ../cabal.project
  When using configuration(s) from /home/gitpod/0/1/../cabal.project, the following errors occurred:
  The package location 'foo' does not exist.

```
  This behaviour is almost never what we want.

See #7695 
---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
