### PR TITLE
Updated getting-started guide to reflect how cabal currently works.

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -44,13 +44,12 @@ This will generate the following files:
 .. code-block:: console
 
     $ ls
+    app/Main.hs
     CHANGELOG.md
-    Main.hs
     myfirstapp.cabal
-    Setup.hs
 
 
-``Main.hs`` is where your package's code lives. By default ``cabal init``
+``app/Main.hs`` is where your package's code lives. By default ``cabal init``
 creates an executable with the same name as the package ``myfirstapp`` in this
 case, you can instruct ``cabal init`` to generate just a library (with
 ``--lib``) or both a library and executable with (``--libandexe``); for the full
@@ -110,14 +109,17 @@ the ``executable myfirstapp`` section to include ``haskell-say``:
    executable myfirstapp
        main-is: Main.hs
        build-depends:
-           base >=4.11 && <4.12,
+           base ^>=4.14.3.0,
            haskell-say ^>=1.0.0.0
+       hs-source-dirs:   app
+       default-language: Haskell2010
+
 
 .. NOTE::
    ``^>=1.0.0.0`` means use version 1.0.0.0 of the library or any more recent
    minor release with the same major version.
 
-Next we'll update ``Main.hs`` to use the ``HaskellSay`` library:
+Next we'll update ``app/Main.hs`` to use the ``HaskellSay`` library:
 
 .. code-block:: haskell
 


### PR DESCRIPTION
Partially fixes https://github.com/haskell/cabal/issues/7750 .

Current getting-started guide seems to be a bit stale compared to the current state of the things.

I used cabal 3.6.2.0 and updated the docs based on it.

NOTE: It would be important to consider applying this same change to the `latest` branch? Not sure what is the workflow there.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

This is just an addition to the docs so no tests!
