### PR TITLE
Updated getting-started.rst to correctly reflect how cabal 3.6.2.0 works

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -45,10 +45,13 @@ This will generate the following files:
 
 .. code-block:: console
 
-    $ ls
-    app/Main.hs
-    CHANGELOG.md
-    myfirstapp.cabal
+    $ tree
+    .
+    ├── app
+    │   └── Main.hs
+    ├── CHANGELOG.md
+    └── myfirstapp.cabal
+
 
 
 ``app/Main.hs`` is where your package's code lives. By default ``cabal init``


### PR DESCRIPTION
Fixes #7750 .

getting-started guide for version 3.6 (the latest one) seems to be a bit stale compared to the current state of the things.

I used cabal 3.6.2.0 and updated the docs based on it.

NOTE: It would be important to consider applying this same change to the latest branch? Not sure what is the workflow there, I guess you would take this into account?

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

Nothing to test here!
