### PR TITLE
Select buildable targets on 3.6

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -724,20 +724,22 @@ filterTargetsKindWith p ts =
 selectBuildableTargets :: [AvailableTarget k] -> [k]
 selectBuildableTargets = selectBuildableTargetsWith (const True)
 
+zipBuildableTargetsWith :: (TargetRequested -> Bool)
+                        -> [AvailableTarget k] -> [(k, AvailableTarget k)]
+zipBuildableTargetsWith p ts =
+    [ (k, t) | t@(AvailableTarget _ _ (TargetBuildable k req) _) <- ts, p req ]
+
 selectBuildableTargetsWith :: (TargetRequested -> Bool)
                           -> [AvailableTarget k] -> [k]
-selectBuildableTargetsWith p ts =
-    [ k | AvailableTarget _ _ (TargetBuildable k req) _ <- ts, p req ]
+selectBuildableTargetsWith p = map fst . zipBuildableTargetsWith p
 
 selectBuildableTargets' :: [AvailableTarget k] -> ([k], [AvailableTarget ()])
 selectBuildableTargets' = selectBuildableTargetsWith' (const True)
 
 selectBuildableTargetsWith' :: (TargetRequested -> Bool)
                            -> [AvailableTarget k] -> ([k], [AvailableTarget ()])
-selectBuildableTargetsWith' p ts =
-    (,) [ k | AvailableTarget _ _ (TargetBuildable k req) _ <- ts, p req ]
-        [ forgetTargetDetail t
-        | t@(AvailableTarget _ _ (TargetBuildable _ req) _) <- ts, p req ]
+selectBuildableTargetsWith' p =
+  (fmap . map) forgetTargetDetail . unzip . zipBuildableTargetsWith p
 
 
 forgetTargetDetail :: AvailableTarget k -> AvailableTarget ()


### PR DESCRIPTION
I found the `selectBuildableTargets...` functions a little bit harder to read than I think they should have been. The comprehensions they contain are all basically the same, so I factored out the commonality.  I think it is a modest readability improvement. Small quality of life improvements really make it much easier for new developers to start contributing.

What do you think?

----

Alternative to https://github.com/haskell/cabal/pull/7080 because I'm not sure which branch PR's should be based on. If PRs should be based on master please close this one.