### PR TITLE
Terminate child processes on sigINT/sigTERM

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -46,7 +46,8 @@ library
     filepath   >= 1.3.0.1  && < 1.5,
     pretty     >= 1.1.1    && < 1.2,
     process    >= 1.1.0.2  && < 1.7,
-    time       >= 1.4.0.1  && < 1.12
+    time       >= 1.4.0.1  && < 1.12,
+    signal
 
   if flag(bundled-binary-generic)
     build-depends: binary >= 0.5.1.1 && < 0.7


### PR DESCRIPTION
For more information, check out https://github.com/ndmitchell/shake/issues/169

Questions that may need to be discussed:

1. Is the additional dependency allowed? It's a small single-module package that could be incorporated. It seems to work even on windows, utilizing some [foreign calls](https://hackage.haskell.org/package/signal-0.1.0.4/docs/src/System-Signal.html#installHandler) (also see [MS documentation](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/signal?view=msvc-160)), maybe @Mistuke can comment
2. I don't see an obvious way to clean up the handlers themselves cross-platform. Will consecutive calls to running external binaries cause problems here?
3. How safe is this in general?
4. Another approach is to use [`exec`](https://hackage.haskell.org/package/rio-0.1.21.0/docs/RIO-Process.html#v:exec) (at least for `cabal run/exec`), but that doesn't seem to be available on windows.