### PR TITLE
Cabal: Use -flink-rts when available

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -415,6 +415,9 @@ data GhcOptions = GhcOptions {
   -- @ghc -framework-path@ flag.
   ghcOptLinkFrameworkDirs :: NubListR String,
 
+  -- | Instruct GHC to link against @libHSrts@ when producing a shared library.
+  ghcOptLinkRts :: Flag Bool,
+
   -- | Don't do the link step, useful in make mode; the @ghc -no-link@ flag.
   ghcOptNoLink :: Flag Bool,
 
@@ -595,6 +598,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
   , ghcOptExtraDefault opts
 
   , [ "-no-link" | flagBool ghcOptNoLink ]
+  , [ "-flink-rts" | flagBool ghcOptLinkRts ]
 
   ---------------
   -- Misc flags


### PR DESCRIPTION
Previously Cabal did quite some headstands to link against libHSrts.
Note only this is complex but it couples very tightly to GHC's
implementation. Thankfully, as of GHC 9.0 GHC provides a `-flink-rts`
flag for precisely this purpose. Use it when available.


Fixes #7763.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
