### PR TITLE
Remove code duplication and unify definition of 'trim' function.

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -94,6 +94,7 @@ library
     Distribution.Utils.LogProgress
     Distribution.Utils.MapAccum
     Distribution.Utils.MD5
+    Distribution.Utils.String
     Distribution.Utils.Structured
     Distribution.Compat.CreatePipe
     Distribution.Compat.Directory
@@ -333,7 +334,6 @@ library
     Distribution.Compat.SnocList
     Distribution.GetOpt
     Distribution.Lex
-    Distribution.Utils.String
     Distribution.Simple.Build.Macros.Z
     Distribution.Simple.Build.PathsModule.Z
     Distribution.Simple.GHC.EnvironmentParser

--- a/Cabal/src/Distribution/Compat/Prelude.hs
+++ b/Cabal/src/Distribution/Compat/Prelude.hs
@@ -69,6 +69,7 @@ module Distribution.Compat.Prelude (
     sort, sortBy,
     nub, nubBy,
     partition,
+    dropWhileEnd,
 
     -- * Data.List.NonEmpty
     NonEmpty((:|)), nonEmpty, foldl1, foldr1,
@@ -186,7 +187,7 @@ import Data.Either                   (partitionEithers)
 import Data.Function                 (on)
 import Data.Functor.Identity         (Identity (..))
 import Data.Int                      (Int16, Int32, Int64, Int8)
-import Data.List                     (intercalate, intersperse, isPrefixOf, isSuffixOf, nub, nubBy, partition, sort, sortBy, unfoldr)
+import Data.List                     (dropWhileEnd, intercalate, intersperse, isPrefixOf, isSuffixOf, nub, nubBy, partition, sort, sortBy, unfoldr)
 import Data.List.NonEmpty            (NonEmpty ((:|)), nonEmpty, head, init, last, tail)
 import Data.Map                      (Map)
 import Data.Maybe                    (catMaybes, fromMaybe, isJust, isNothing, listToMaybe, mapMaybe, maybeToList)

--- a/Cabal/src/Distribution/FieldGrammar/FieldDescrs.hs
+++ b/Cabal/src/Distribution/FieldGrammar/FieldDescrs.hs
@@ -13,7 +13,6 @@ module Distribution.FieldGrammar.FieldDescrs (
 import Distribution.Compat.Prelude
 import Prelude ()
 
-import Data.List                   (dropWhileEnd)
 import Distribution.Compat.Lens    (aview, cloneLens)
 import Distribution.Utils.String (trim)
 import Distribution.Compat.Newtype

--- a/Cabal/src/Distribution/FieldGrammar/FieldDescrs.hs
+++ b/Cabal/src/Distribution/FieldGrammar/FieldDescrs.hs
@@ -15,6 +15,7 @@ import Prelude ()
 
 import Data.List                   (dropWhileEnd)
 import Distribution.Compat.Lens    (aview, cloneLens)
+import Distribution.Utils.String (trim)
 import Distribution.Compat.Newtype
 import Distribution.FieldGrammar
 import Distribution.Pretty         (Pretty (..), showFreeText)
@@ -114,8 +115,6 @@ parsecFreeText = dropDotLines <$ C.spaces <*> many C.anyChar
     trim' :: String -> String
     trim' = dropWhileEnd (`elem` (" \t" :: String))
 
-    trim :: String -> String
-    trim = dropWhile isSpace . dropWhileEnd isSpace
 
 class    (P.Parsec a, Pretty a) => ParsecPretty a
 instance (P.Parsec a, Pretty a) => ParsecPretty a

--- a/Cabal/src/Distribution/FieldGrammar/Parsec.hs
+++ b/Cabal/src/Distribution/FieldGrammar/Parsec.hs
@@ -65,7 +65,6 @@ module Distribution.FieldGrammar.Parsec (
     fieldLinesToStream,
     )  where
 
-import Data.List                   (dropWhileEnd)
 import Distribution.Compat.Newtype
 import Distribution.Compat.Prelude
 import Distribution.Simple.Utils   (fromUTF8BS)

--- a/Cabal/src/Distribution/FieldGrammar/Parsec.hs
+++ b/Cabal/src/Distribution/FieldGrammar/Parsec.hs
@@ -69,6 +69,7 @@ import Data.List                   (dropWhileEnd)
 import Distribution.Compat.Newtype
 import Distribution.Compat.Prelude
 import Distribution.Simple.Utils   (fromUTF8BS)
+import Distribution.Utils.String (trim)
 import Prelude ()
 
 import qualified Data.ByteString              as BS
@@ -271,8 +272,6 @@ instance FieldGrammar Parsec ParsecFieldGrammar where
             ]
         -- hack: recover the order of prefixed fields
         reorder = map snd . sortBy (comparing fst)
-        trim :: String -> String
-        trim = dropWhile isSpace . dropWhileEnd isSpace
 
     availableSince vs def (ParsecFG names prefixes parser) = ParsecFG names prefixes parser'
       where
@@ -390,9 +389,6 @@ fieldlinesToFreeText fls               = intercalate "\n" (map go fls)
         | otherwise = s
       where
         s = trim (fromUTF8BS bs)
-
-        trim :: String -> String
-        trim = dropWhile isSpace . dropWhileEnd isSpace
 
 fieldlinesToFreeText3 :: Position -> [FieldLine Position] -> String
 fieldlinesToFreeText3 _   []               = ""

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -106,7 +106,7 @@ import Data.ByteString.Lazy          ( ByteString )
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy.Char8 as BLC8
 import Data.List
-    ( (\\), inits, stripPrefix, intersect, dropWhileEnd )
+    ( (\\), inits, stripPrefix, intersect)
 import qualified Data.Map as Map
 import System.Directory
     ( canonicalizePath, createDirectoryIfMissing, doesFileExist

--- a/Cabal/src/Distribution/Simple/UHC.hs
+++ b/Cabal/src/Distribution/Simple/UHC.hs
@@ -121,7 +121,7 @@ getGlobalPackageDir verbosity progdb = do
     let pkgdir = trimEnd output
     return pkgdir
   where
-    trimEnd = reverse . dropWhile isSpace . reverse
+    trimEnd = dropWhileEnd isSpace
 
 getUserPackageDir :: IO FilePath
 getUserPackageDir = do

--- a/Cabal/src/Distribution/Utils/String.hs
+++ b/Cabal/src/Distribution/Utils/String.hs
@@ -95,5 +95,6 @@ encodeStringUtf8 (c:cs)
     w8ShiftR :: Int -> Word8
     w8ShiftR = fromIntegral . shiftR (ord c)
 
+-- @since 3.8.0.0
 trim :: String -> String
 trim = dropWhile isSpace . dropWhileEnd isSpace

--- a/Cabal/src/Distribution/Utils/String.hs
+++ b/Cabal/src/Distribution/Utils/String.hs
@@ -2,11 +2,14 @@ module Distribution.Utils.String
     ( -- * Encode to/from UTF8
       decodeStringUtf8
     , encodeStringUtf8
+    , trim
     ) where
 
 import Data.Word
 import Data.Bits
 import Data.Char (chr,ord)
+import Data.List (dropWhileEnd)
+import GHC.Unicode (isSpace)
 
 -- | Decode 'String' from UTF8-encoded octets.
 --
@@ -91,3 +94,6 @@ encodeStringUtf8 (c:cs)
     w8 = fromIntegral (ord c) :: Word8
     w8ShiftR :: Int -> Word8
     w8ShiftR = fromIntegral . shiftR (ord c)
+
+trim :: String -> String
+trim = dropWhile isSpace . dropWhileEnd isSpace

--- a/cabal-install/src/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/src/Distribution/Client/HttpUtils.hs
@@ -32,6 +32,7 @@ import qualified Control.Exception as Exception
 import Distribution.Simple.Utils
          ( die', info, warn, debug, notice
          , copyFileVerbose,  withTempFile, IOData (..) )
+import Distribution.Utils.String (trim)
 import Distribution.Client.Utils
          ( withTempFileName )
 import Distribution.Client.Version
@@ -889,12 +890,6 @@ statusParseFail :: Verbosity -> URI -> String -> IO a
 statusParseFail verbosity uri r =
     die' verbosity $ "Failed to download " ++ show uri ++ " : "
        ++ "No Status Code could be parsed from response: " ++ r
-
--- Trim
-trim :: String -> String
-trim = f . f
-      where f = reverse . dropWhile isSpace
-
 
 ------------------------------------------------------------------------------
 -- Multipart stuff partially taken from cgi package.

--- a/cabal-install/src/Distribution/Client/Init/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Init/Utils.hs
@@ -39,6 +39,7 @@ import qualified Distribution.Package as P
 import qualified Distribution.Types.PackageName as PN
 import Distribution.Simple.PackageIndex (InstalledPackageIndex, moduleNameIndex)
 import Distribution.Simple.Setup (Flag(..))
+import Distribution.Utils.String (trim)
 import Distribution.Version
 import Distribution.Client.Init.Defaults
 import Distribution.Client.Init.Types
@@ -202,11 +203,6 @@ takeWhile' p = takeWhile p . trim
 
 dropWhile' :: (Char -> Bool) -> String -> String
 dropWhile' p = dropWhile p . trim
-
-trim :: String -> String
-trim = removeLeadingSpace . reverse . removeLeadingSpace . reverse
-  where
-    removeLeadingSpace  = dropWhile isSpace
 
 -- | Check whether a potential source file is located in one of the
 --   source directories.

--- a/cabal-install/src/Distribution/Client/Upload.hs
+++ b/cabal-install/src/Distribution/Client/Upload.hs
@@ -12,6 +12,7 @@ import Distribution.Client.Setup
          ( IsCandidate(..), RepoContext(..) )
 
 import Distribution.Simple.Utils (notice, warn, info, die', toUTF8BS)
+import Distribution.Utils.String (trim)
 import Distribution.Client.Config
 
 import qualified Distribution.Client.BuildReports.Anonymous as BuildReport
@@ -228,7 +229,3 @@ handlePackage transport verbosity uri packageUri auth isCandidate path =
 formatWarnings :: String -> String
 formatWarnings x = "Warnings:\n" ++ (unlines . map ("- " ++) . lines) x
 
--- Trim
-trim :: String -> String
-trim = f . f
-      where f = reverse . dropWhile isSpace


### PR DESCRIPTION
Attempt to fix #7744 .

That's my first ever cabal PR so I somehow don't know what I'm doing. Just picked up first `good-first-issue` because I've found this https://twitter.com/bkmlep/status/1432474203245015040

`Distribution.Utils.String` sounds like a good place for `trim` but I had to expose this module unfortunately. 

This the situation after my change:
![image](https://user-images.githubusercontent.com/19495571/140286103-2e6f8566-896f-40c8-9417-07d1ff7d68a4.png)

Any advice or criticism fully welcomed!

Karol

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
