### PR TITLE
Split --repl-options on whitespace

### DIFF
--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -1819,7 +1819,7 @@ replOptions _ =
   , option [] ["repl-options"]
     "use this option for the repl"
     replOptionsFlags (\p flags -> flags { replOptionsFlags = p })
-    (reqArg "FLAG" (succeedReadE (:[])) id)
+    (reqArg "FLAG" (succeedReadE words) id)
   ]
 
 -- ------------------------------------------------------------

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -1817,7 +1817,7 @@ replOptions _ =
     replOptionsNoLoad (\p flags -> flags { replOptionsNoLoad = p })
     trueArg
   , option [] ["repl-options"]
-    "use this option for the repl"
+    "Use the option(s) for the repl"
     replOptionsFlags (\p flags -> flags { replOptionsFlags = p })
     (reqArg "FLAG" (succeedReadE words) id)
   ]

--- a/cabal-testsuite/PackageTests/ReplOptions/ModuleA.hs
+++ b/cabal-testsuite/PackageTests/ReplOptions/ModuleA.hs
@@ -1,0 +1,4 @@
+module ModuleA where
+
+a :: Int
+a = 42

--- a/cabal-testsuite/PackageTests/ReplOptions/ModuleC.hs
+++ b/cabal-testsuite/PackageTests/ReplOptions/ModuleC.hs
@@ -1,0 +1,4 @@
+module ModuleC where
+
+c :: Int
+c = 42

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal-repl-options.cabal
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal-repl-options.cabal
@@ -1,0 +1,10 @@
+name: cabal-repl-options
+version: 0.1
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+  exposed-modules: ModuleA, ModuleC
+  build-depends: base
+  default-language: Haskell2010
+

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.multiple-repl-options-multiple-flags.out
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.multiple-repl-options-multiple-flags.out
@@ -1,0 +1,9 @@
+# cabal clean
+# cabal v2-repl
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - cabal-repl-options-0.1 (lib) (first run)
+Configuring library for cabal-repl-options-0.1..
+Preprocessing library for cabal-repl-options-0.1..
+

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.multiple-repl-options.out
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.multiple-repl-options.out
@@ -1,0 +1,9 @@
+# cabal clean
+# cabal v2-repl
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - cabal-repl-options-0.1 (lib) (first run)
+Configuring library for cabal-repl-options-0.1..
+Preprocessing library for cabal-repl-options-0.1..
+

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.project
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.single-repl-options-multiple-flags-negative.out
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.single-repl-options-multiple-flags-negative.out
@@ -1,0 +1,10 @@
+# cabal clean
+# cabal v2-repl
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - cabal-repl-options-0.1 (lib) (first run)
+Configuring library for cabal-repl-options-0.1..
+Preprocessing library for cabal-repl-options-0.1..
+Error: cabal: repl failed for cabal-repl-options-0.1-inplace.
+

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.single-repl-options-multiple-flags.out
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.single-repl-options-multiple-flags.out
@@ -1,0 +1,9 @@
+# cabal clean
+# cabal v2-repl
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - cabal-repl-options-0.1 (lib) (first run)
+Configuring library for cabal-repl-options-0.1..
+Preprocessing library for cabal-repl-options-0.1..
+

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.single-repl-options.out
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.single-repl-options.out
@@ -1,0 +1,9 @@
+# cabal clean
+# cabal v2-repl
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - cabal-repl-options-0.1 (lib) (first run)
+Configuring library for cabal-repl-options-0.1..
+Preprocessing library for cabal-repl-options-0.1..
+

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
@@ -6,35 +6,35 @@ main = do
     cabal' "clean" []
     res <- cabalWithStdin "v2-repl" ["--repl-options=-fwrite-interface"] ":set"
     assertOutputContains "Ok, two modules loaded." res
-    assertOutputContains "-fwrite-interface" res
+    assertOutputContains "  -fwrite-interface" res
   cabalTest' "multiple-repl-options" $ do
     cabal' "clean" []
-    res <- cabalWithStdin "v2-repl" ["--repl-options=-fwrite-interface", "--repl-options=-fdiagnostics-show-caret"] ":set"
+    res <- cabalWithStdin "v2-repl" ["--repl-options=-fwrite-interface", "--repl-options=-fdefer-typed-holes"] ":set"
     assertOutputContains "Ok, two modules loaded." res
-    assertOutputContains "-fwrite-interface" res
-    assertOutputContains "-fdiagnostics-show-caret" res
+    assertOutputContains "  -fwrite-interface" res
+    assertOutputContains "  -fdefer-typed-holes" res
   cabalTest' "single-repl-options-multiple-flags" $ do
     cabal' "clean" []
-    res <- cabalWithStdin "v2-repl" ["--repl-options=-fdiagnostics-show-caret -fwrite-interface"] ":set"
+    res <- cabalWithStdin "v2-repl" ["--repl-options=-fdefer-typed-holes -fwrite-interface"] ":set"
     assertOutputContains "Ok, two modules loaded." res
-    assertOutputContains "-fwrite-interface" res
-    assertOutputContains "-fdiagnostics-show-caret" res
+    assertOutputContains "  -fwrite-interface" res
+    assertOutputContains "  -fdefer-typed-holes" res
   cabalTest' "single-repl-options-multiple-flags-negative" $ do
     cabal' "clean" []
-    res <- local setTestAsNegative $ cabalWithStdin "v2-repl" ["--repl-options=-fdiagnostics-show-baret -fwrite-interface"] ":set"
+    res <- local setTestAsNegative $ cabalWithStdin "v2-repl" ["--repl-options=-fwrite-interface -fdiagnostics-show-baret"] ":set"
     assertOutputDoesNotContain "Ok, two modules loaded." res
-    assertOutputContains "-fwrite-interface" res
-    assertOutputContains "-fdiagnostics-show-baret" res
     assertOutputContains "ghc: unrecognised flag: -fdiagnostics-show-baret" res
     assertOutputContains "did you mean one of:" res
   cabalTest' "multiple-repl-options-multiple-flags" $ do
     cabal' "clean" []
     res <- cabalWithStdin "v2-repl" [
-      "--repl-options=-fdiagnostics-show-caret -fwrite-interface",
+      "--repl-options=-fenable-th-splice-warnings -fwrite-interface",
         "--repl-options=-fdefer-type-errors -fdefer-typed-holes"
       ] ":set"
     assertOutputContains "Ok, two modules loaded." res
-    assertOutputContains "-fwrite-interface" res
-    assertOutputContains "-fdiagnostics-show-caret" res
+    assertOutputContains "  -fwrite-interface" res
+    assertOutputContains "  -fenable-th-splice-warnings" res
+    assertOutputContains "  -fdefer-typed-holes" res
+    assertOutputContains "  -fdefer-type-errors" res
       where
         setTestAsNegative env = env { testShouldFail = True }

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
@@ -23,7 +23,7 @@ main = do
     cabal' "clean" []
     res <- local negativeTest $ cabalWithStdin "v2-repl" ["--repl-options=-fwrite-interface -fdiagnostics-show-baret"] ":set"
     assertOutputDoesNotContain "Ok, two modules loaded." res
-    assertOutputContains "ghc: unrecognised flag: -fdiagnostics-show-baret" res
+    assertOutputContains "unrecognised flag: -fdiagnostics-show-baret" res
     assertOutputContains "did you mean one of:" res
   cabalTest' "multiple-repl-options-multiple-flags" $ do
     cabal' "clean" []

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
@@ -21,20 +21,20 @@ main = do
     assertOutputContains "  -fdefer-typed-holes" res
   cabalTest' "single-repl-options-multiple-flags-negative" $ do
     cabal' "clean" []
-    res <- local setTestAsNegative $ cabalWithStdin "v2-repl" ["--repl-options=-fwrite-interface -fdiagnostics-show-baret"] ":set"
+    res <- local negativeTest $ cabalWithStdin "v2-repl" ["--repl-options=-fwrite-interface -fdiagnostics-show-baret"] ":set"
     assertOutputDoesNotContain "Ok, two modules loaded." res
     assertOutputContains "ghc: unrecognised flag: -fdiagnostics-show-baret" res
     assertOutputContains "did you mean one of:" res
   cabalTest' "multiple-repl-options-multiple-flags" $ do
     cabal' "clean" []
     res <- cabalWithStdin "v2-repl" [
-      "--repl-options=-fenable-th-splice-warnings -fwrite-interface",
+      "--repl-options=-fignore-optim-changes -fwrite-interface",
         "--repl-options=-fdefer-type-errors -fdefer-typed-holes"
       ] ":set"
     assertOutputContains "Ok, two modules loaded." res
     assertOutputContains "  -fwrite-interface" res
-    assertOutputContains "  -fenable-th-splice-warnings" res
+    assertOutputContains "  -fignore-optim-changes" res
     assertOutputContains "  -fdefer-typed-holes" res
     assertOutputContains "  -fdefer-type-errors" res
       where
-        setTestAsNegative env = env { testShouldFail = True }
+        negativeTest env = env { testShouldFail = True }

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
@@ -1,0 +1,40 @@
+import Test.Cabal.Prelude
+import Control.Monad.Reader (local)
+
+main = do
+  cabalTest' "single-repl-options" $ do
+    cabal' "clean" []
+    res <- cabalWithStdin "v2-repl" ["--repl-options=-fwrite-interface"] ":set"
+    assertOutputContains "Ok, two modules loaded." res
+    assertOutputContains "-fwrite-interface" res
+  cabalTest' "multiple-repl-options" $ do
+    cabal' "clean" []
+    res <- cabalWithStdin "v2-repl" ["--repl-options=-fwrite-interface", "--repl-options=-fdiagnostics-show-caret"] ":set"
+    assertOutputContains "Ok, two modules loaded." res
+    assertOutputContains "-fwrite-interface" res
+    assertOutputContains "-fdiagnostics-show-caret" res
+  cabalTest' "single-repl-options-multiple-flags" $ do
+    cabal' "clean" []
+    res <- cabalWithStdin "v2-repl" ["--repl-options=-fdiagnostics-show-caret -fwrite-interface"] ":set"
+    assertOutputContains "Ok, two modules loaded." res
+    assertOutputContains "-fwrite-interface" res
+    assertOutputContains "-fdiagnostics-show-caret" res
+  cabalTest' "single-repl-options-multiple-flags-negative" $ do
+    cabal' "clean" []
+    res <- local setTestAsNegative $ cabalWithStdin "v2-repl" ["--repl-options=-fdiagnostics-show-baret -fwrite-interface"] ":set"
+    assertOutputDoesNotContain "Ok, two modules loaded." res
+    assertOutputContains "-fwrite-interface" res
+    assertOutputContains "-fdiagnostics-show-baret" res
+    assertOutputContains "ghc: unrecognised flag: -fdiagnostics-show-baret" res
+    assertOutputContains "did you mean one of:" res
+  cabalTest' "multiple-repl-options-multiple-flags" $ do
+    cabal' "clean" []
+    res <- cabalWithStdin "v2-repl" [
+      "--repl-options=-fdiagnostics-show-caret -fwrite-interface",
+        "--repl-options=-fdefer-type-errors -fdefer-typed-holes"
+      ] ":set"
+    assertOutputContains "Ok, two modules loaded." res
+    assertOutputContains "-fwrite-interface" res
+    assertOutputContains "-fdiagnostics-show-caret" res
+      where
+        setTestAsNegative env = env { testShouldFail = True }

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
@@ -28,12 +28,12 @@ main = do
   cabalTest' "multiple-repl-options-multiple-flags" $ do
     cabal' "clean" []
     res <- cabalWithStdin "v2-repl" [
-      "--repl-options=-fignore-optim-changes -fwrite-interface",
+      "--repl-options=-fforce-recomp -fwrite-interface",
         "--repl-options=-fdefer-type-errors -fdefer-typed-holes"
       ] ":set"
     assertOutputContains "Ok, two modules loaded." res
     assertOutputContains "  -fwrite-interface" res
-    assertOutputContains "  -fignore-optim-changes" res
+    assertOutputContains "  -fforce-recomp" res
     assertOutputContains "  -fdefer-typed-holes" res
     assertOutputContains "  -fdefer-type-errors" res
       where

--- a/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ReplOptions/cabal.test.hs
@@ -1,5 +1,4 @@
 import Test.Cabal.Prelude
-import Control.Monad.Reader (local)
 
 main = do
   cabalTest' "single-repl-options" $ do
@@ -21,7 +20,7 @@ main = do
     assertOutputContains "  -fdefer-typed-holes" res
   cabalTest' "single-repl-options-multiple-flags-negative" $ do
     cabal' "clean" []
-    res <- local negativeTest $ cabalWithStdin "v2-repl" ["--repl-options=-fwrite-interface -fdiagnostics-show-baret"] ":set"
+    res <- fails $ cabalWithStdin "v2-repl" ["--repl-options=-fwrite-interface -fdiagnostics-show-baret"] ":set"
     assertOutputDoesNotContain "Ok, two modules loaded." res
     assertOutputContains "unrecognised flag: -fdiagnostics-show-baret" res
     assertOutputContains "did you mean one of:" res
@@ -36,5 +35,4 @@ main = do
     assertOutputContains "  -fforce-recomp" res
     assertOutputContains "  -fdefer-typed-holes" res
     assertOutputContains "  -fdefer-type-errors" res
-      where
-        negativeTest env = env { testShouldFail = True }
+

--- a/changelog.d/issue-6190
+++ b/changelog.d/issue-6190
@@ -1,0 +1,4 @@
+synopsis: --repl-options doesn’t split on whitespace
+packages: Cabal
+issues: #6190
+prs: #7799


### PR DESCRIPTION
Attempt to fix #6190

Function `words` used instead of cons operator which was just adding
full string value to an empty array.

I'm newbie here but is there any place with kind of CLI tests where I could capture this behavior?

For now I tested it manually and I think it works:
1. ~Negative scenario:
```bash
$ cabal-new v2-repl --repl-options="-fwrite-interface -fbyte-codeaa"
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - programming-in-haskell-0.1.0.0 (lib:chapters) (first run)
Preprocessing library 'chapters' for programming-in-haskell-0.1.0.0..
GHCi, version 8.10.7: https://www.haskell.org/ghc/  :? for help
ghc: unrecognised flag: -fbyte-codeaa
did you mean one of:
  -fbyte-code

Usage: For basic information, try the `--help' option.
Error: cabal: repl failed for lib:chapters from
programming-in-haskell-0.1.0.0.
```

2. Positive scenario:
```bash
$ cabal-new v2-repl --repl-options="-fwrite-interface -fbyte-code"
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - programming-in-haskell-0.1.0.0 (lib:chapters) (first run)
Preprocessing library 'chapters' for programming-in-haskell-0.1.0.0..
GHCi, version 8.10.7: https://www.haskell.org/ghc/  :? for help
Ok, 8 modules loaded.
Prelude Excs1>
```

Best regards,
Karol

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
