### PR TITLE
add dependabot: add Actions CI updates merge requests automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  # NOTE: Dependabot official configuration documentation:
+  # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem
+
+  # Maintain dependencies for internal GitHub Actions CI for pull requests
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot would weekly check updates for project's [.github/workflows/workflow.yml](https://github.com/haskell/actions/blob/main/.github/workflows/workflow.yml) & send information & patch updates ([like these](https://github.com/haskell-nix/hnix-store/pull/169)).

PR to CI configuration run CI with changes applied, which is a self-test.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.