### PR TITLE
Enable TypeOperators to use (~)

### DIFF
--- a/Cabal/src/Distribution/Compat/Graph.hs
+++ b/Cabal/src/Distribution/Compat/Graph.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 -----------------------------------------------------------------------------
 -- |

--- a/Cabal/src/Distribution/Utils/IOData.hs
+++ b/Cabal/src/Distribution/Utils/IOData.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE RankNTypes #-}
 -- | @since 2.2.0
 module Distribution.Utils.IOData


### PR DESCRIPTION
[GHC Proposal #371](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0371-non-magical-eq.md) requires `TypeOperators` to use type equality `a~b`. The following lines are affected:

```
Cabal/src/Distribution/Compat/Graph.hs
181:instance (IsNode a, IsNode b, Key a ~ Key b) => IsNode (Either a b) where

Cabal/src/Distribution/Utils/IOData.hs
61:instance a ~ Char => KnownIODataMode [a] where
```

The fix is to simply enable the extension.
