### PR TITLE
[WIP] Only buildable tests

### DIFF
--- a/Cabal-QuickCheck/src/Test/QuickCheck/Instances/Cabal.hs
+++ b/Cabal-QuickCheck/src/Test/QuickCheck/Instances/Cabal.hs
@@ -29,6 +29,7 @@ import Distribution.Simple.Setup                   (HaddockTarget (..), TestShow
 import Distribution.SPDX
 import Distribution.System
 import Distribution.Types.Dependency
+import Distribution.Types.EnableComponentType
 import Distribution.Types.Flag                     (FlagAssignment, FlagName, mkFlagAssignment, mkFlagName, unFlagAssignment)
 import Distribution.Types.IncludeRenaming
 import Distribution.Types.LibraryName
@@ -491,6 +492,13 @@ instance Arbitrary PackageDB where
 -------------------------------------------------------------------------------
 
 instance Arbitrary DumpBuildInfo where
+    arbitrary = arbitraryBoundedEnum
+
+-------------------------------------------------------------------------------
+-- EnableComponentType
+-------------------------------------------------------------------------------
+
+instance Arbitrary EnableComponentType where
     arbitrary = arbitraryBoundedEnum
 
 -------------------------------------------------------------------------------

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -255,6 +255,7 @@ library
     Distribution.Types.VersionInterval.Legacy
     Distribution.Types.GivenComponent
     Distribution.Types.PackageVersionConstraint
+    Distribution.Types.EnableComponentType
     Distribution.Utils.Generic
     Distribution.Utils.Json
     Distribution.Utils.NubList

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -80,6 +80,7 @@ import Distribution.Types.PackageVersionConstraint
 import Distribution.Types.LocalBuildInfo
 import Distribution.Types.ComponentRequestedSpec
 import Distribution.Types.GivenComponent
+import Distribution.Types.EnableComponentType
 import Distribution.Simple.Utils
 import Distribution.System
 import Distribution.Version
@@ -401,12 +402,15 @@ configure (pkg_descr0, pbi) cfg = do
                                 -- nomenclature; it's just a request; a
                                 -- @buildable: False@ might make it
                                 -- not possible to enable.
-                                { testsRequested = fromFlag (configTests cfg)
+                                { testsRequested =
+                                  fromFlag (configTests cfg) == EnableAll
                                 , benchmarksRequested =
-                                  fromFlag (configBenchmarks cfg) }
+                                  fromFlag (configBenchmarks cfg) == EnableAll
+                                }
     -- Some sanity checks related to enabling components.
     when (isJust mb_cname
-          && (fromFlag (configTests cfg) || fromFlag (configBenchmarks cfg))) $
+          && ( fromFlag (configTests cfg) == EnableAll
+            || fromFlag (configBenchmarks cfg) == EnableAll)) $
         die' verbosity $
               "--enable-tests/--enable-benchmarks are incompatible with" ++
               " explicitly specifying a component to configure."

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -701,10 +701,10 @@ configureOptions showOrParseArgs =
       ,multiOption "tests"
          configTests (\v flags -> flags { configTests = v })
          [noArg (Flag True) []
-                ["enable-test","enable-tests"]
+                ["enable-tests", "enable-test"]
                 "Build all the test suites listed in the package description file."
          ,noArg (Flag False) []
-                ["disable-test","disable-tests"]
+                ["disable-tests", "disable-test"]
                 "Do not build any test suites."
          ]
 
@@ -727,10 +727,10 @@ configureOptions showOrParseArgs =
       ,multiOption "benchmarks"
          configBenchmarks (\v flags -> flags { configBenchmarks = v })
          [noArg (Flag True) []
-                ["enable-benchmark","enable-benchmarks"]
+                ["enable-benchmarks", "enable-benchmark"]
                 "Build all the benchmarks listed in the package description file."
          ,noArg (Flag False) []
-                ["disable-benchmark","disable-benchmarks"]
+                ["disable-benchmarks", "disable-benchmark"]
                 "Do not build any benchmarks."
          ]
 

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -701,7 +701,7 @@ configureOptions showOrParseArgs =
       ,multiOption "tests"
          configTests (\v flags -> flags { configTests = v })
          [noArg NoFlag []
-                ["only-buildable-tests", "only-buildable-test"]
+                ["enable-tests-when-possible", "enable-test-if-possible"]
                 "Build the tests if a build plan can be found, don't build them otherwise. The decision is made independently for each package, not for each test suite."
          ,noArg (Flag True) []
                 ["enable-tests", "enable-test"]
@@ -730,7 +730,7 @@ configureOptions showOrParseArgs =
       ,multiOption "benchmarks"
          configBenchmarks (\v flags -> flags { configBenchmarks = v })
          [noArg NoFlag []
-                ["only-buildable-benchmarks", "only-buildable-benchmark"]
+                ["enable-benchmarks-when-possible", "enable-benchmark-if-possible"]
                 "Build the benchmarks if a build plan can be found, don't build them otherwise. The decision is made independently for each package, not for each benchmark."
          ,noArg (Flag True) []
                 ["enable-benchmarks", "enable-benchmark"]

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -698,10 +698,15 @@ configureOptions showOrParseArgs =
             (parsecToReadE ("Cannot parse module substitution: " ++) (fmap (:[]) parsecModSubstEntry))
             (map (Disp.renderStyle defaultStyle . dispModSubstEntry)))
 
-      ,option "" ["tests"]
-         "dependency checking and compilation for test suites listed in the package description file."
+      ,multiOption "tests"
          configTests (\v flags -> flags { configTests = v })
-         (boolOpt [] [])
+         [noArg (Flag True) []
+                ["enable-test","enable-tests"]
+                "Build all the test suites listed in the package description file."
+         ,noArg (Flag False) []
+                ["disable-test","disable-tests"]
+                "Do not build any test suites."
+         ]
 
       ,option "" ["coverage"]
          "build package with Haskell Program Coverage. (GHC only)"
@@ -719,10 +724,15 @@ configureOptions showOrParseArgs =
          (\v flags -> flags { configExactConfiguration = v })
          trueArg
 
-      ,option "" ["benchmarks"]
-         "dependency checking and compilation for benchmarks listed in the package description file."
+      ,multiOption "benchmarks"
          configBenchmarks (\v flags -> flags { configBenchmarks = v })
-         (boolOpt [] [])
+         [noArg (Flag True) []
+                ["enable-benchmark","enable-benchmarks"]
+                "Build all the benchmarks listed in the package description file."
+         ,noArg (Flag False) []
+                ["disable-benchmark","disable-benchmarks"]
+                "Do not build any benchmarks."
+         ]
 
       ,option "" ["relocatable"]
          "building a package that is relocatable. (GHC only)"

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -100,6 +100,7 @@ import Distribution.Verbosity
 import Distribution.Utils.NubList
 import Distribution.Types.ComponentId
 import Distribution.Types.DumpBuildInfo
+import Distribution.Types.EnableComponentType
 import Distribution.Types.GivenComponent
 import Distribution.Types.Module
 import Distribution.Types.PackageVersionConstraint
@@ -264,8 +265,8 @@ data ConfigFlags = ConfigFlags {
       -- package does not use Backpack, or we just want to typecheck
       -- the indefinite package.
     configConfigurationsFlags :: FlagAssignment,
-    configTests               :: Flag Bool, -- ^Enable test suite compilation
-    configBenchmarks          :: Flag Bool, -- ^Enable benchmark compilation
+    configTests               :: Flag EnableComponentType, -- ^Enable test suite compilation
+    configBenchmarks          :: Flag EnableComponentType, -- ^Enable benchmark compilation
     configCoverage :: Flag Bool, -- ^Enable program coverage
     configLibCoverage :: Flag Bool, -- ^Enable program coverage (deprecated)
     configExactConfiguration  :: Flag Bool,
@@ -392,8 +393,8 @@ defaultConfigFlags progDb = emptyConfigFlags {
     configSplitObjs    = Flag False, -- takes longer, so turn off by default
     configStripExes    = NoFlag,
     configStripLibs    = NoFlag,
-    configTests        = Flag False,
-    configBenchmarks   = Flag False,
+    configTests        = Flag EnableWhenPossible,
+    configBenchmarks   = Flag EnableWhenPossible,
     configCoverage     = Flag False,
     configLibCoverage  = NoFlag,
     configExactConfiguration = Flag False,
@@ -700,13 +701,13 @@ configureOptions showOrParseArgs =
 
       ,multiOption "tests"
          configTests (\v flags -> flags { configTests = v })
-         [noArg NoFlag []
+         [noArg (Flag EnableWhenPossible) []
                 ["enable-tests-when-possible", "enable-test-if-possible"]
                 "Build the tests if a build plan can be found, don't build them otherwise. The decision is made independently for each package, not for each test suite."
-         ,noArg (Flag True) []
+         ,noArg (Flag EnableAll) []
                 ["enable-tests", "enable-test"]
                 "Build all the test suites listed in the package description file."
-         ,noArg (Flag False) []
+         ,noArg (Flag DisableAll) []
                 ["disable-tests", "disable-test"]
                 "Do not build any test suites."
          ]
@@ -729,13 +730,13 @@ configureOptions showOrParseArgs =
 
       ,multiOption "benchmarks"
          configBenchmarks (\v flags -> flags { configBenchmarks = v })
-         [noArg NoFlag []
+         [noArg (Flag EnableWhenPossible) []
                 ["enable-benchmarks-when-possible", "enable-benchmark-if-possible"]
                 "Build the benchmarks if a build plan can be found, don't build them otherwise. The decision is made independently for each package, not for each benchmark."
-         ,noArg (Flag True) []
+         ,noArg (Flag EnableAll) []
                 ["enable-benchmarks", "enable-benchmark"]
                 "Build all the benchmarks listed in the package description file."
-         ,noArg (Flag False) []
+         ,noArg (Flag DisableAll) []
                 ["disable-benchmarks", "disable-benchmark"]
                 "Do not build any benchmarks."
          ]

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -700,7 +700,10 @@ configureOptions showOrParseArgs =
 
       ,multiOption "tests"
          configTests (\v flags -> flags { configTests = v })
-         [noArg (Flag True) []
+         [noArg NoFlag []
+                ["only-buildable-tests", "only-buildable-test"]
+                "Build the tests if a build plan can be found, don't build them otherwise. The decision is made independently for each package, not for each test suite."
+         ,noArg (Flag True) []
                 ["enable-tests", "enable-test"]
                 "Build all the test suites listed in the package description file."
          ,noArg (Flag False) []
@@ -726,7 +729,10 @@ configureOptions showOrParseArgs =
 
       ,multiOption "benchmarks"
          configBenchmarks (\v flags -> flags { configBenchmarks = v })
-         [noArg (Flag True) []
+         [noArg NoFlag []
+                ["only-buildable-benchmarks", "only-buildable-benchmark"]
+                "Build the benchmarks if a build plan can be found, don't build them otherwise. The decision is made independently for each package, not for each benchmark."
+         ,noArg (Flag True) []
                 ["enable-benchmarks", "enable-benchmark"]
                 "Build all the benchmarks listed in the package description file."
          ,noArg (Flag False) []

--- a/Cabal/src/Distribution/Types/EnableComponentType.hs
+++ b/Cabal/src/Distribution/Types/EnableComponentType.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+module Distribution.Types.EnableComponentType (
+    EnableComponentType(..),
+
+    defaultEnableComponentType,
+) where
+
+import Prelude ()
+import Distribution.Compat.Prelude
+
+-- | Which subset of a given component type to enable. Specified by option
+-- triples like @--enable-tests@, @--disable-tests@, and
+-- @--enable-tests-when-possible@.
+--
+-- @since 3.7.0.0
+data EnableComponentType
+    = EnableAll
+    | DisableAll
+    | EnableWhenPossible
+  deriving (Generic, Read, Show, Eq, Typeable, Bounded, Enum)
+
+instance Binary EnableComponentType
+instance Structured EnableComponentType
+
+-- | 'EnableComponentType' is only used for tests and benchmarks, for which the
+-- default behaviour of @cabal configure@ is to try to include them in the
+-- build plan if possible, and to silently drop them otherwise.
+--
+-- It's not a big deal to drop them because the default behaviour of @cabal
+-- build@ is to build the libraries and executables, but not the tests nor the
+-- benchmarks. But it's better to include them in the build plan if we can, so
+-- that running @cabal test@ after @cabal build@ doesn't unnecessarily rebuild
+-- because of a changed build plan.
+--
+-- @since 3.7.0.0
+defaultEnableComponentType :: EnableComponentType
+defaultEnableComponentType = EnableWhenPossible

--- a/Cabal/src/Distribution/Types/EnableComponentType.hs
+++ b/Cabal/src/Distribution/Types/EnableComponentType.hs
@@ -4,6 +4,7 @@ module Distribution.Types.EnableComponentType (
     EnableComponentType(..),
 
     defaultEnableComponentType,
+    enableComponentTypeToRequest,
 ) where
 
 import Prelude ()
@@ -36,3 +37,14 @@ instance Structured EnableComponentType
 -- @since 3.7.0.0
 defaultEnableComponentType :: EnableComponentType
 defaultEnableComponentType = EnableWhenPossible
+
+-- | With the 'EnableAll' and 'DisableAll' settings, the user makes an explicit
+-- request, either to definitely enable or to definitely disable a certain type
+-- of component. However, with 'EnableWhenPossible', the user is not making any
+-- request.
+--
+-- @since 3.7.0.0
+enableComponentTypeToRequest :: EnableComponentType -> Maybe Bool
+enableComponentTypeToRequest EnableAll = Just True
+enableComponentTypeToRequest DisableAll = Just False
+enableComponentTypeToRequest EnableWhenPossible = Nothing

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -149,6 +149,8 @@ import Distribution.Simple.Utils
          , findPackageDesc, tryFindPackageDesc )
 import Distribution.Text
          ( display )
+import Distribution.Types.EnableComponentType
+         ( EnableComponentType(..) )
 import Distribution.Verbosity as Verbosity
          ( normal )
 import Distribution.Version
@@ -526,7 +528,7 @@ installAction
         -- '--run-tests' implies '--enable-tests'.
         maybeForceTests installFlags' configFlags' =
           if fromFlagOrDefault False (installRunTests installFlags')
-          then configFlags' { configTests = toFlag True }
+          then configFlags' { configTests = toFlag EnableAll }
           else configFlags'
 
 testAction :: (BuildFlags, TestFlags) -> [String] -> GlobalFlags
@@ -538,11 +540,12 @@ testAction (buildFlags, testFlags) extraArgs globalFlags = do
   let buildFlags'    = buildFlags
                       { buildVerbosity = testVerbosity testFlags }
       checkFlags = Check $ \_ flags@(configFlags, configExFlags) ->
-        if fromFlagOrDefault False (configTests configFlags)
+        if fromFlagOrDefault EnableWhenPossible (configTests configFlags)
+             == EnableAll
           then pure (mempty, flags)
           else do
             info verbosity "reconfiguring to enable tests"
-            let flags' = ( configFlags { configTests = toFlag True }
+            let flags' = ( configFlags { configTests = toFlag EnableAll }
                         , configExFlags
                         )
             pure (Any True, flags')
@@ -612,11 +615,12 @@ benchmarkAction
                       { buildVerbosity = benchmarkVerbosity benchmarkFlags }
 
   let checkFlags = Check $ \_ flags@(configFlags, configExFlags) ->
-        if fromFlagOrDefault False (configBenchmarks configFlags)
+        if fromFlagOrDefault EnableWhenPossible (configBenchmarks configFlags)
+             == EnableAll
           then pure (mempty, flags)
           else do
             info verbosity "reconfiguring to enable benchmarks"
-            let flags' = ( configFlags { configBenchmarks = toFlag True }
+            let flags' = ( configFlags { configBenchmarks = toFlag EnableAll }
                         , configExFlags
                         )
             pure (Any True, flags')

--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -113,6 +113,8 @@ import Distribution.Simple.GHC
          , renderGhcEnvironmentFile, readGhcEnvironmentFile, ParseErrorExc )
 import Distribution.System
          ( Platform , buildOS, OS (Windows) )
+import Distribution.Types.EnableComponentType
+         ( EnableComponentType(..) )
 import Distribution.Types.UnitId
          ( UnitId )
 import Distribution.Types.UnqualComponentName
@@ -408,10 +410,10 @@ verifyPreconditionsOrDie verbosity configFlags = do
   -- We never try to build tests/benchmarks for remote packages.
   -- So we set them as disabled by default and error if they are explicitly
   -- enabled.
-  when (configTests configFlags == Flag True) $
+  when (configTests configFlags == Flag EnableAll) $
     die' verbosity $ "--enable-tests was specified, but tests can't "
                   ++ "be enabled in a remote package"
-  when (configBenchmarks configFlags == Flag True) $
+  when (configBenchmarks configFlags == Flag EnableAll) $
     die' verbosity $ "--enable-benchmarks was specified, but benchmarks can't "
                   ++ "be enabled in a remote package"
 
@@ -741,8 +743,8 @@ environmentFileToSpecifiers ipi = foldMap $ \case
 -- | Disables tests and benchmarks if they weren't explicitly enabled.
 disableTestsBenchsByDefault :: ConfigFlags -> ConfigFlags
 disableTestsBenchsByDefault configFlags =
-  configFlags { configTests = Flag False <> configTests configFlags
-              , configBenchmarks = Flag False <> configBenchmarks configFlags }
+  configFlags { configTests = Flag DisableAll <> configTests configFlags
+              , configBenchmarks = Flag DisableAll <> configBenchmarks configFlags }
 
 -- | Symlink/copy every exe from a package from the store to a given location
 installUnitExes

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -883,8 +883,14 @@ commentSavedConfig = do
       removeRootKeys :: RemoteRepo -> RemoteRepo
       removeRootKeys r = r { remoteRepoRootKeys = [] }
 
--- | All config file fields.
+-- | The parser and pretty-printer for the 'SavedConfig' fields are mostly
+-- derived from the command-line options for the various commands (@cabal
+-- configure@, @cabal install@, etc.). When the format in the configuration
+-- file differs from the format in the command-line option, we define a
+-- separate 'FieldDescr' here.
 --
+-- Fields which are valid in both a 'ProjectConfig' and a 'SavedConfig' also
+-- need a separate 'FieldDescr' in 'legacyProjectConfigFieldDescrs'.
 configFieldDescriptions :: ConstraintSource -> [FieldDescr SavedConfig]
 configFieldDescriptions src =
 

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -965,17 +965,10 @@ configFieldDescriptions src =
                  ++ "' field is case sensitive, use 'True' or 'False'.")
        ,liftField configTests (\v flags -> flags { configTests = v }) $
         let name = "tests" in
-        FieldDescr name
-          (\f -> case f of
-                   Flag False -> Disp.text "DisableAll"
-                   Flag True  -> Disp.text "EnableAll"
-                   _          -> Disp.empty)
-          (\line str _ -> case () of
-           _ |  str == "DisableAll" -> ParseOk [] (Flag False)
-             |  str == "False"      -> ParseOk [] (Flag False)
-             |  str == "EnableAll"  -> ParseOk [] (Flag True)
-             |  str == "True"       -> ParseOk [] (Flag True)
-             | otherwise       -> ParseFailed (NoParse name line))
+        FieldDescr name prettyPrintEnableStanza (parseEnableStanza name)
+       ,liftField configBenchmarks (\v flags -> flags { configBenchmarks = v }) $
+        let name = "benchmarks" in
+        FieldDescr name prettyPrintEnableStanza (parseEnableStanza name)
        ]
 
   ++ toSavedConfig liftConfigExFlag
@@ -1046,6 +1039,17 @@ configFieldDescriptions src =
 
     toRelaxDeps True  = RelaxDepsAll
     toRelaxDeps False = mempty
+
+    prettyPrintEnableStanza NoFlag       = Disp.empty
+    prettyPrintEnableStanza (Flag False) = Disp.text "DisableAll"
+    prettyPrintEnableStanza (Flag True)  = Disp.text "EnableAll"
+
+    parseEnableStanza name line str _ = case () of
+      _ |  str == "DisableAll" -> ParseOk [] (Flag False)
+        |  str == "False"      -> ParseOk [] (Flag False)
+        |  str == "EnableAll"  -> ParseOk [] (Flag True)
+        |  str == "True"       -> ParseOk [] (Flag True)
+        | otherwise            -> ParseFailed (NoParse name line)
 
 
 -- TODO: next step, make the deprecated fields elicit a warning.

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -963,6 +963,19 @@ configFieldDescriptions src =
                caseWarning = PWarning $
                  "The '" ++ name
                  ++ "' field is case sensitive, use 'True' or 'False'.")
+       ,liftField configTests (\v flags -> flags { configTests = v }) $
+        let name = "tests" in
+        FieldDescr name
+          (\f -> case f of
+                   Flag False -> Disp.text "DisableAll"
+                   Flag True  -> Disp.text "EnableAll"
+                   _          -> Disp.empty)
+          (\line str _ -> case () of
+           _ |  str == "DisableAll" -> ParseOk [] (Flag False)
+             |  str == "False"      -> ParseOk [] (Flag False)
+             |  str == "EnableAll"  -> ParseOk [] (Flag True)
+             |  str == "True"       -> ParseOk [] (Flag True)
+             | otherwise       -> ParseFailed (NoParse name line))
        ]
 
   ++ toSavedConfig liftConfigExFlag

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -121,6 +121,7 @@ import Distribution.Verbosity
 import qualified Distribution.Compat.CharParsing as P
 import Distribution.Client.ProjectFlags (ProjectFlags (..))
 import Distribution.Solver.Types.ConstraintSource
+import Distribution.Types.EnableComponentType
 
 import qualified Text.PrettyPrint as Disp
          ( render, text, empty )
@@ -1040,16 +1041,17 @@ configFieldDescriptions src =
     toRelaxDeps True  = RelaxDepsAll
     toRelaxDeps False = mempty
 
-    prettyPrintEnableStanza NoFlag       = Disp.text "EnableWhenPossible"
-    prettyPrintEnableStanza (Flag False) = Disp.text "DisableAll"
-    prettyPrintEnableStanza (Flag True)  = Disp.text "EnableAll"
+    prettyPrintEnableStanza NoFlag                    = Disp.text "EnableWhenPossible"
+    prettyPrintEnableStanza (Flag EnableWhenPossible) = Disp.text "EnableWhenPossible"
+    prettyPrintEnableStanza (Flag DisableAll)         = Disp.text "DisableAll"
+    prettyPrintEnableStanza (Flag EnableAll)          = Disp.text "EnableAll"
 
     parseEnableStanza name line str _ = case () of
-      _ |  str == "EnableWhenPossible" -> ParseOk [] NoFlag
-        |  str == "DisableAll"         -> ParseOk [] (Flag False)
-        |  str == "False"              -> ParseOk [] (Flag False)
-        |  str == "EnableAll"          -> ParseOk [] (Flag True)
-        |  str == "True"               -> ParseOk [] (Flag True)
+      _ |  str == "EnableWhenPossible" -> ParseOk [] (Flag EnableWhenPossible)
+        |  str == "DisableAll"         -> ParseOk [] (Flag DisableAll)
+        |  str == "False"              -> ParseOk [] (Flag DisableAll)
+        |  str == "EnableAll"          -> ParseOk [] (Flag EnableAll)
+        |  str == "True"               -> ParseOk [] (Flag EnableAll)
         | otherwise                    -> ParseFailed (NoParse name line)
 
 

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -1040,16 +1040,17 @@ configFieldDescriptions src =
     toRelaxDeps True  = RelaxDepsAll
     toRelaxDeps False = mempty
 
-    prettyPrintEnableStanza NoFlag       = Disp.empty
+    prettyPrintEnableStanza NoFlag       = Disp.text "OnlyBuildable"
     prettyPrintEnableStanza (Flag False) = Disp.text "DisableAll"
     prettyPrintEnableStanza (Flag True)  = Disp.text "EnableAll"
 
     parseEnableStanza name line str _ = case () of
-      _ |  str == "DisableAll" -> ParseOk [] (Flag False)
-        |  str == "False"      -> ParseOk [] (Flag False)
-        |  str == "EnableAll"  -> ParseOk [] (Flag True)
-        |  str == "True"       -> ParseOk [] (Flag True)
-        | otherwise            -> ParseFailed (NoParse name line)
+      _ |  str == "OnlyBuildable" -> ParseOk [] NoFlag
+        |  str == "DisableAll"    -> ParseOk [] (Flag False)
+        |  str == "False"         -> ParseOk [] (Flag False)
+        |  str == "EnableAll"     -> ParseOk [] (Flag True)
+        |  str == "True"          -> ParseOk [] (Flag True)
+        | otherwise               -> ParseFailed (NoParse name line)
 
 
 -- TODO: next step, make the deprecated fields elicit a warning.

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -1040,17 +1040,17 @@ configFieldDescriptions src =
     toRelaxDeps True  = RelaxDepsAll
     toRelaxDeps False = mempty
 
-    prettyPrintEnableStanza NoFlag       = Disp.text "OnlyBuildable"
+    prettyPrintEnableStanza NoFlag       = Disp.text "EnableWhenPossible"
     prettyPrintEnableStanza (Flag False) = Disp.text "DisableAll"
     prettyPrintEnableStanza (Flag True)  = Disp.text "EnableAll"
 
     parseEnableStanza name line str _ = case () of
-      _ |  str == "OnlyBuildable" -> ParseOk [] NoFlag
-        |  str == "DisableAll"    -> ParseOk [] (Flag False)
-        |  str == "False"         -> ParseOk [] (Flag False)
-        |  str == "EnableAll"     -> ParseOk [] (Flag True)
-        |  str == "True"          -> ParseOk [] (Flag True)
-        | otherwise               -> ParseFailed (NoParse name line)
+      _ |  str == "EnableWhenPossible" -> ParseOk [] NoFlag
+        |  str == "DisableAll"         -> ParseOk [] (Flag False)
+        |  str == "False"              -> ParseOk [] (Flag False)
+        |  str == "EnableAll"          -> ParseOk [] (Flag True)
+        |  str == "True"               -> ParseOk [] (Flag True)
+        | otherwise                    -> ParseFailed (NoParse name line)
 
 
 -- TODO: next step, make the deprecated fields elicit a warning.

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -143,7 +143,7 @@ import qualified Data.Map as M
 import qualified Data.ByteString as BS
 
 --
--- * Configuration saved in the config file
+-- * Configuration saved in the @~/.cabal/config@ file
 --
 
 data SavedConfig = SavedConfig

--- a/cabal-install/src/Distribution/Client/Configure.hs
+++ b/cabal-install/src/Distribution/Client/Configure.hs
@@ -63,6 +63,7 @@ import Distribution.Simple.PackageIndex as PackageIndex
          ( InstalledPackageIndex, lookupPackageName )
 import Distribution.Package
          ( Package(..), packageName, PackageId )
+import Distribution.Types.EnableComponentType
 import Distribution.Types.GivenComponent
          ( GivenComponent(..) )
 import Distribution.Types.PackageVersionConstraint
@@ -312,10 +313,13 @@ planLocalPackage verbosity comp platform configFlags configExFlags
       }
 
       testsEnabled :: Bool
-      testsEnabled = fromFlagOrDefault False $ configTests configFlags
+      testsEnabled = fromFlagOrDefault EnableWhenPossible
+                                       (configTests configFlags)
+                  == EnableAll
       benchmarksEnabled :: Bool
-      benchmarksEnabled =
-        fromFlagOrDefault False $ configBenchmarks configFlags
+      benchmarksEnabled = fromFlagOrDefault EnableWhenPossible
+                                            (configBenchmarks configFlags)
+                       == EnableAll
 
       resolverParams :: DepResolverParams
       resolverParams =
@@ -419,9 +423,11 @@ configurePackage verbosity platform comp scriptOptions configFlags
       -- NB: if the user explicitly specified
       -- --enable-tests/--enable-benchmarks, always respect it.
       -- (But if they didn't, let solver decide.)
-      configBenchmarks         = toFlag (BenchStanzas `optStanzaSetMember` stanzas)
+      configBenchmarks         = toFlag (if BenchStanzas `optStanzaSetMember` stanzas
+                                         then EnableAll else DisableAll)
                                     `mappend` configBenchmarks configFlags,
-      configTests              = toFlag (TestStanzas `optStanzaSetMember` stanzas)
+      configTests              = toFlag (if TestStanzas `optStanzaSetMember` stanzas
+                                         then EnableAll else DisableAll)
                                     `mappend` configTests configFlags
     }
 

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1263,13 +1263,14 @@ legacyPackageConfigFieldDescrs =
                     | otherwise = "test-" ++ name
 
     prettyPrintEnableStanza v = case v of
-      NoFlag     -> mempty
+      NoFlag     -> Disp.text "OnlyBuildable"
       Flag True  -> Disp.text "EnableAll"
       Flag False -> Disp.text "DisableAll"
 
     parseEnableStanza
-        = (Flag True  <$ (Parse.string "EnableAll"  <|> Parse.string "True"))
-      <|> (Flag False <$ (Parse.string "DisableAll" <|> Parse.string "False"))
+        = (NoFlag     <$ Parse.string "OnlyBuildable")
+      <|> (Flag True  <$ (Parse.string "EnableAll"     <|> Parse.string "True"))
+      <|> (Flag False <$ (Parse.string "DisableAll"    <|> Parse.string "False"))
 
 
 legacyPackageConfigFGSectionDescrs

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -92,6 +92,7 @@ import Distribution.Simple.Command
          , OptionField, option, reqArg' )
 import Distribution.Types.PackageVersionConstraint
          ( PackageVersionConstraint )
+import Distribution.Types.EnableComponentType
 import Distribution.Parsec (ParsecParser)
 
 import qualified Data.Map as Map
@@ -1263,14 +1264,15 @@ legacyPackageConfigFieldDescrs =
                     | otherwise = "test-" ++ name
 
     prettyPrintEnableStanza v = case v of
-      NoFlag     -> Disp.text "EnableWhenPossible"
-      Flag True  -> Disp.text "EnableAll"
-      Flag False -> Disp.text "DisableAll"
+      NoFlag                   -> Disp.text "EnableWhenPossible"
+      Flag EnableWhenPossible  -> Disp.text "EnableWhenPossible"
+      Flag EnableAll           -> Disp.text "EnableAll"
+      Flag DisableAll          -> Disp.text "DisableAll"
 
     parseEnableStanza
-        = (NoFlag     <$ Parse.string "EnableWhenPossible")
-      <|> (Flag True  <$ (Parse.string "EnableAll"  <|> Parse.string "True"))
-      <|> (Flag False <$ (Parse.string "DisableAll" <|> Parse.string "False"))
+        = (Flag EnableWhenPossible <$ Parse.string "EnableWhenPossible")
+      <|> (Flag EnableAll  <$ (Parse.string "EnableAll"  <|> Parse.string "True"))
+      <|> (Flag DisableAll <$ (Parse.string "DisableAll" <|> Parse.string "False"))
 
 
 legacyPackageConfigFGSectionDescrs

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1263,14 +1263,14 @@ legacyPackageConfigFieldDescrs =
                     | otherwise = "test-" ++ name
 
     prettyPrintEnableStanza v = case v of
-      NoFlag     -> Disp.text "OnlyBuildable"
+      NoFlag     -> Disp.text "EnableWhenPossible"
       Flag True  -> Disp.text "EnableAll"
       Flag False -> Disp.text "DisableAll"
 
     parseEnableStanza
-        = (NoFlag     <$ Parse.string "OnlyBuildable")
-      <|> (Flag True  <$ (Parse.string "EnableAll"     <|> Parse.string "True"))
-      <|> (Flag False <$ (Parse.string "DisableAll"    <|> Parse.string "False"))
+        = (NoFlag     <$ Parse.string "EnableWhenPossible")
+      <|> (Flag True  <$ (Parse.string "EnableAll"  <|> Parse.string "True"))
+      <|> (Flag False <$ (Parse.string "DisableAll" <|> Parse.string "False"))
 
 
 legacyPackageConfigFGSectionDescrs

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -49,7 +49,7 @@ import Distribution.Simple.Compiler
          ( OptimisationLevel(..), DebugInfoLevel(..) )
 import Distribution.Simple.InstallDirs ( CopyDest (NoCopyDest) )
 import Distribution.Simple.Setup
-         ( Flag(Flag), toFlag, fromFlagOrDefault
+         ( Flag(NoFlag, Flag), toFlag, fromFlagOrDefault
          , ConfigFlags(..), configureOptions
          , HaddockFlags(..), haddockOptions, defaultHaddockFlags
          , TestFlags(..), testOptions', defaultTestFlags
@@ -84,7 +84,7 @@ import Distribution.Deprecated.ParseUtils
          ( ParseResult(..), PError(..), syntaxError, PWarning(..)
          , commaNewLineListFieldParsec, newLineListField, parseTokenQ
          , parseHaskellString, showToken
-         , simpleFieldParsec
+         , simpleField, simpleFieldParsec
          )
 import Distribution.Client.ParseUtils
 import Distribution.Simple.Command
@@ -1078,6 +1078,14 @@ legacyPackageConfigFieldDescrs =
           showTokenQ parseTokenQ
           configConfigureArgs
           (\v conf -> conf { configConfigureArgs = v })
+      , simpleField "tests"
+          prettyPrintEnableStanza parseEnableStanza
+          configTests
+          (\v conf -> conf { configTests = v })
+      , simpleField "benchmarks"
+          prettyPrintEnableStanza parseEnableStanza
+          configBenchmarks
+          (\v conf -> conf { configBenchmarks = v })
       , simpleFieldParsec "flags"
           dispFlagAssignment parsecFlagAssignment
           configConfigurationsFlags
@@ -1093,7 +1101,6 @@ legacyPackageConfigFieldDescrs =
       , "profiling-detail", "library-profiling-detail"
       , "library-for-ghci", "split-objs", "split-sections"
       , "executable-stripping", "library-stripping"
-      , "tests", "benchmarks"
       , "coverage", "library-coverage"
       , "relocatable"
         -- not "extra-include-dirs", "extra-lib-dirs", "extra-framework-dirs"
@@ -1253,6 +1260,15 @@ legacyPackageConfigFieldDescrs =
 
     prefixTest name | "test-" `isPrefixOf` name = name
                     | otherwise = "test-" ++ name
+
+    prettyPrintEnableStanza v = case v of
+      NoFlag     -> mempty
+      Flag True  -> Disp.text "EnableAll"
+      Flag False -> Disp.text "DisableAll"
+
+    parseEnableStanza
+        = (Flag True  <$ (Parse.string "EnableAll"  <|> Parse.string "True"))
+      <|> (Flag False <$ (Parse.string "DisableAll" <|> Parse.string "False"))
 
 
 legacyPackageConfigFGSectionDescrs

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -103,14 +103,8 @@ import Network.URI (URI (..))
 -- Representing the project config file in terms of legacy types
 --
 
--- | We already have parsers\/pretty-printers for almost all the fields in the
--- project config file, but they're in terms of the types used for the command
--- line flags for Setup.hs or cabal commands. We don't want to redefine them
--- all, at least not yet so for the moment we use the parsers at the old types
--- and use conversion functions.
---
--- Ultimately if\/when this project-based approach becomes the default then we
--- can redefine the parsers directly for the new types.
+-- | Used when parsing and pretty-printing 'ProjectConfig', as it was easier to
+-- write two way conversions than to implement a new parser and pretty-printer.
 --
 data LegacyProjectConfig = LegacyProjectConfig {
        legacyPackages          :: [String],
@@ -171,8 +165,8 @@ instance Semigroup LegacySharedConfig where
 -- line into a 'ProjectConfig' value that can combined with configuration from
 -- other sources.
 --
--- At the moment this uses the legacy command line flag types. See
--- 'LegacyProjectConfig' for an explanation.
+-- TODO: why is this in the Legacy module? There's nothing "legacy" about these
+-- "convertLegacy*" functions as far as I can tell.
 --
 commandLineFlagsToProjectConfig :: GlobalFlags
                                 -> NixStyleFlags a
@@ -272,8 +266,7 @@ convertLegacyGlobalConfig
 
 
 -- | Convert the project config from the legacy types to the 'ProjectConfig'
--- and associated types. See 'LegacyProjectConfig' for an explanation of the
--- approach.
+-- and associated types.
 --
 convertLegacyProjectConfig :: LegacyProjectConfig -> ProjectConfig
 convertLegacyProjectConfig
@@ -875,6 +868,14 @@ showLegacyProjectConfig config =
     constraintSrc = ConstraintSourceProjectConfig "unused"
 
 
+-- | The parser and pretty-printer for the 'LegacyProjectConfig' (and thus
+-- 'ProjectConfig') fields are mostly derived from the command-line options for
+-- the various commands (@cabal configure@, @cabal install@, etc.). When the
+-- format in the configuration file differs from the format in the command-line
+-- option, we define a separate 'FieldDescr' here.
+--
+-- Fields which are valid in both a 'ProjectConfig' and a 'SavedConfig' also
+-- need a separate 'FieldDescr' in 'configFieldDescriptions'.
 legacyProjectConfigFieldDescrs :: ConstraintSource -> [FieldDescr LegacyProjectConfig]
 legacyProjectConfigFieldDescrs constraintSrc =
 

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -47,6 +47,8 @@ import Distribution.Solver.Types.ConstraintSource
 
 import Distribution.Package
          ( PackageName, PackageId, UnitId )
+import Distribution.Types.EnableComponentType
+         ( EnableComponentType(..) )
 import Distribution.Types.PackageVersionConstraint
          ( PackageVersionConstraint )
 import Distribution.Version
@@ -265,8 +267,8 @@ data PackageConfig
        packageConfigSplitObjs           :: Flag Bool,
        packageConfigStripExes           :: Flag Bool,
        packageConfigStripLibs           :: Flag Bool,
-       packageConfigTests               :: Flag Bool,
-       packageConfigBenchmarks          :: Flag Bool,
+       packageConfigTests               :: Flag EnableComponentType,
+       packageConfigBenchmarks          :: Flag EnableComponentType,
        packageConfigCoverage            :: Flag Bool,
        packageConfigRelocatable         :: Flag Bool,
        packageConfigDebugInfo           :: Flag DebugInfoLevel,

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1819,8 +1819,8 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
             BenchStanzas -> listToMaybe [ v | v <- maybeToList benchmarks, _ <- PD.benchmarks elabPkgDescription ]
           where
             tests, benchmarks :: Maybe Bool
-            tests      = fmap (== EnableAll) $ perPkgOptionMaybe pkgid packageConfigTests
-            benchmarks = fmap (== EnableAll) $ perPkgOptionMaybe pkgid packageConfigBenchmarks
+            tests      = enableComponentTypeToRequest $ perPkgOptionFlag pkgid EnableWhenPossible packageConfigTests
+            benchmarks = enableComponentTypeToRequest $ perPkgOptionFlag pkgid EnableWhenPossible packageConfigBenchmarks
 
         -- This is a placeholder which will get updated by 'pruneInstallPlanPass1'
         -- and 'pruneInstallPlanPass2'.  We can't populate it here

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2600,7 +2600,7 @@ availableSourceTargets elab =
             | otherwise      -> TargetBuildable (elabUnitId elab, cname)
                                                 TargetRequestedByDefault
 
-          -- it is not an optional stanza, so a testsuite or benchmark
+          -- it is an optional stanza, so a testsuite or benchmark
           Just stanza ->
             case (optStanzaLookup stanza (elabStanzasRequested elab), -- TODO
                   optStanzaSetMember stanza (elabStanzasAvailable elab)) of

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2600,9 +2600,13 @@ availableSourceTargets elab =
             | otherwise      -> TargetBuildable (elabUnitId elab, cname)
                                                 TargetRequestedByDefault
 
-          -- it is an optional stanza, so a testsuite or benchmark
+          -- it is an optional stanza, so a testsuite or benchmark.
+          --
+          -- TODO: once 'elabStanzasRequested' has been upgraded to an
+          -- ADT with three cases (see TODO note for 'elabStanzasRequested'),
+          -- use those to pick a better failure cause here.
           Just stanza ->
-            case (optStanzaLookup stanza (elabStanzasRequested elab), -- TODO
+            case (optStanzaLookup stanza (elabStanzasRequested elab),
                   optStanzaSetMember stanza (elabStanzasAvailable elab)) of
               _ | not withinPlan -> TargetNotLocal
               (Just False,   _)  -> TargetDisabledByUser

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -36,6 +36,8 @@ import Distribution.Solver.Types.ConstraintSource
          ( ConstraintSource(ConstraintSourceUnknown) )
 import Distribution.Solver.Types.PackageConstraint
          ( PackageProperty(PackagePropertySource) )
+import Distribution.Types.EnableComponentType
+         ( EnableComponentType(..) )
 
 import qualified Distribution.Client.CmdBuild   as CmdBuild
 import qualified Distribution.Client.CmdRepl    as CmdRepl
@@ -638,7 +640,7 @@ testTargetProblemsCommon config0 = do
     testdir = "targets/complex"
     config  = config0 {
       projectConfigLocalPackages = (projectConfigLocalPackages config0) {
-        packageConfigBenchmarks = toFlag False
+        packageConfigBenchmarks = toFlag DisableAll
       }
     , projectConfigShared = (projectConfigShared config0) {
         projectConfigConstraints =
@@ -664,7 +666,7 @@ testTargetProblemsBuild config reportSubCase = do
       "targets/all-disabled"
       config {
         projectConfigLocalPackages = (projectConfigLocalPackages config) {
-          packageConfigBenchmarks = toFlag False
+          packageConfigBenchmarks = toFlag DisableAll
         }
       }
       CmdBuild.selectPackageTargets
@@ -687,8 +689,8 @@ testTargetProblemsBuild config reportSubCase = do
     -- whole package selects those component kinds too
     do (_,elaboratedPlan,_) <- planProject "targets/variety" config {
            projectConfigLocalPackages = (projectConfigLocalPackages config) {
-             packageConfigTests      = toFlag True,
-             packageConfigBenchmarks = toFlag True
+             packageConfigTests      = toFlag EnableAll,
+             packageConfigBenchmarks = toFlag EnableAll
            }
          }
        assertProjectDistinctTargets
@@ -708,8 +710,8 @@ testTargetProblemsBuild config reportSubCase = do
     -- whole package only selects the library, foreign lib and exes
     do (_,elaboratedPlan,_) <- planProject "targets/variety" config {
            projectConfigLocalPackages = (projectConfigLocalPackages config) {
-             packageConfigTests      = toFlag False,
-             packageConfigBenchmarks = toFlag False
+             packageConfigTests      = toFlag DisableAll,
+             packageConfigBenchmarks = toFlag DisableAll
            }
          }
        assertProjectDistinctTargets
@@ -928,7 +930,7 @@ testTargetProblemsTest config reportSubCase = do
       "targets/tests-disabled"
       config {
         projectConfigLocalPackages = (projectConfigLocalPackages config) {
-          packageConfigTests = toFlag False
+          packageConfigTests = toFlag DisableAll
         }
       }
       CmdTest.selectPackageTargets
@@ -1030,7 +1032,7 @@ testTargetProblemsBench config reportSubCase = do
       "targets/benchmarks-disabled"
       config {
         projectConfigLocalPackages = (projectConfigLocalPackages config) {
-          packageConfigBenchmarks = toFlag False
+          packageConfigBenchmarks = toFlag DisableAll
         }
       }
       CmdBench.selectPackageTargets

--- a/cabal-install/tests/UnitTests/Distribution/Client/TreeDiffInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/TreeDiffInstances.hs
@@ -20,6 +20,8 @@ import Distribution.Client.Types
 import Distribution.Client.Types.OverwritePolicy         (OverwritePolicy)
 import Distribution.Client.Types.SourceRepo              (SourceRepositoryPackage)
 
+import Distribution.Types.EnableComponentType
+
 import Data.TreeDiff.Class
 import Data.TreeDiff.Instances.Cabal ()
 import Network.URI
@@ -39,6 +41,7 @@ instance ToExpr ClientInstallFlags
 instance ToExpr CombineStrategy
 instance ToExpr ConstraintSource
 instance ToExpr CountConflicts
+instance ToExpr EnableComponentType
 instance ToExpr FineGrainedConflicts
 instance ToExpr IndependentGoals
 instance ToExpr InstallMethod

--- a/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/UserConfig.hs
@@ -22,6 +22,7 @@ import Distribution.Client.Setup (GlobalFlags (..), InstallFlags (..))
 import Distribution.Client.Utils (removeExistingFile)
 import Distribution.Simple.Setup (Flag (..), ConfigFlags (..), fromFlag)
 import Distribution.Simple.Utils (withTempDirectory)
+import Distribution.Types.EnableComponentType (EnableComponentType(..))
 import Distribution.Verbosity (silent)
 
 tests :: [TestTree]
@@ -59,7 +60,7 @@ canUpdateConfig = bracketTest $ \configFile -> do
     userConfigUpdate silent (globalFlags configFile) []
     -- Load it again.
     updated <- loadConfig silent (Flag configFile)
-    assertBool ("Field 'tests' should be True") $
+    assertEqual ("Field 'tests' should be EnableAll") EnableAll $
         fromFlag (configTests $ savedConfigureFlags updated)
 
 

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/cabal.out
@@ -1,0 +1,25 @@
+# cabal v2-test
+Resolving dependencies...
+Error: cabal: Could not resolve dependencies:
+[__0] trying: package-with-unbuildable-test-1.0 (user goal)
+[__1] trying: package-with-unbuildable-test:*test
+[__2] next goal: base (dependency of package-with-unbuildable-test *test)
+[__2] rejecting: base-<VERSION>/installed-<HASH> (conflict: package-with-unbuildable-test *test => base<1 && >1)
+[__2] fail (backjumping, conflict set: base, package-with-unbuildable-test, package-with-unbuildable-test:test)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: package-with-unbuildable-test (4), package-with-unbuildable-test:test (4), base (2)
+# cabal v2-test
+Resolving dependencies...
+Error: cabal: Cannot test all the packages in the project because none of the components are available to build: the test suite 'buildable-test' and the test suite 'unbuildable-test' are  not available because building test suites has been disabled in the configuration
+# cabal v2-test
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - package-with-buildable-test-1.0 (test:buildable-test) (first run)
+Configuring test suite 'buildable-test' for package-with-buildable-test-1.0..
+Preprocessing test suite 'buildable-test' for package-with-buildable-test-1.0..
+Building test suite 'buildable-test' for package-with-buildable-test-1.0..
+Running 1 test suites...
+Test suite buildable-test: RUNNING...
+Test suite buildable-test: PASS
+Test suite logged to: <ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/package-with-buildable-test-1.0/t/buildable-test/test/package-with-buildable-test-1.0-buildable-test.log
+1 of 1 test suites (1 of 1 test cases) passed.

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/cabal.project
@@ -1,0 +1,1 @@
+packages: package-with-buildable-test package-with-unbuildable-test

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/cabal.test.hs
@@ -5,9 +5,9 @@ main = cabalTest $ do
     -- possibilities, they are only the two extremes: build _all_ the tests,
     -- and build _none_ of the tests.
     --
-    -- The default, which does not currently correspond to a named option, is
-    -- to only build the tests for which a build plan can be found, and to
-    -- silently ignore the tests for which a build plan cannot be found.
+    -- The default, "--only-buildable-tests", is to only build the tests for
+    -- which a build plan can be found, and to silently ignore the tests for
+    -- which a build plan cannot be found.
     
     -- This project has two package; one with a buildable test, and one with an
     -- unbuildable test. If we request both tests to be built and run, then
@@ -20,4 +20,4 @@ main = cabalTest $ do
 
     -- If we request the buildable tests to be built and run, then "cabal test"
     -- should successfully build one test.
-    cabal "v2-test" ["all"]
+    cabal "v2-test" ["--only-buildable-tests", "all"]

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/cabal.test.hs
@@ -1,0 +1,23 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    -- "--enable-tests" and "--disable-tests" are not the only two
+    -- possibilities, they are only the two extremes: build _all_ the tests,
+    -- and build _none_ of the tests.
+    --
+    -- The default, which does not currently correspond to a named option, is
+    -- to only build the tests for which a build plan can be found, and to
+    -- silently ignore the tests for which a build plan cannot be found.
+    
+    -- This project has two package; one with a buildable test, and one with an
+    -- unbuildable test. If we request both tests to be built and run, then
+    -- "cabal test" command should fail because of the unbuildable test.
+    fails $ cabal "v2-test" ["--enable-tests", "all"]
+    
+    -- If we request zero tests to be built, then "cabal test" should fail
+    -- because there are no tests to run.
+    fails $ cabal "v2-test" ["--disable-tests", "all"]
+
+    -- If we request the buildable tests to be built and run, then "cabal test"
+    -- should successfully build one test.
+    cabal "v2-test" ["all"]

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/cabal.test.hs
@@ -5,9 +5,9 @@ main = cabalTest $ do
     -- possibilities, they are only the two extremes: build _all_ the tests,
     -- and build _none_ of the tests.
     --
-    -- The default, "--only-buildable-tests", is to only build the tests for
-    -- which a build plan can be found, and to silently ignore the tests for
-    -- which a build plan cannot be found.
+    -- The default, "--enable-tests-when-possible", is to only build the tests
+    -- for which a build plan can be found, and to silently ignore the tests
+    -- for which a build plan cannot be found.
     
     -- This project has two package; one with a buildable test, and one with an
     -- unbuildable test. If we request both tests to be built and run, then
@@ -20,4 +20,4 @@ main = cabalTest $ do
 
     -- If we request the buildable tests to be built and run, then "cabal test"
     -- should successfully build one test.
-    cabal "v2-test" ["--only-buildable-tests", "all"]
+    cabal "v2-test" ["--enable-tests-when-possible", "all"]

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/package-with-buildable-test/BuildableTest.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/package-with-buildable-test/BuildableTest.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = pure ()

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/package-with-buildable-test/package-with-buildable-test.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/package-with-buildable-test/package-with-buildable-test.cabal
@@ -1,0 +1,10 @@
+name: package-with-buildable-test
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+test-suite buildable-test
+    type: exitcode-stdio-1.0
+    main-is: BuildableTest.hs
+    build-depends: base
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/package-with-unbuildable-test/UnbuildableTest.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/package-with-unbuildable-test/UnbuildableTest.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = pure ()

--- a/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/package-with-unbuildable-test/package-with-unbuildable-test.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdTest/OnlyBuildableTests/package-with-unbuildable-test/package-with-unbuildable-test.cabal
@@ -1,0 +1,10 @@
+name: package-with-unbuildable-test
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.10
+
+test-suite unbuildable-test
+    type: exitcode-stdio-1.0
+    main-is: UnbuildableTest.hs
+    build-depends: base < 1 && > 1
+    default-language: Haskell2010


### PR DESCRIPTION
[As requested](https://github.com/haskell/cabal/issues/5079#issuecomment-974270197), I am trying to implement an `--only-buildable-tests` flag whose behaviour matches the default behaviour when neither `--enable-tests` nor `--disable-tests` is specified.

This PR is a WIP, as I am still at the beginning of my investigation. So far, I have only added a test which exercises the current behaviour, and I have slightly tweaked how `--enable-tests` and `--disable-tests` are parsed (which slightly affects the `--help` output). Still, my impression is that cabal is a complex and fragile beast, so I would like to make sure that this small change hasn't already broken something. I am thus following [the recommendation](https://github.com/haskell/cabal/blob/cff9b1a7c6188796873ffcb7ba9332dca718548f/CONTRIBUTING.md#running-tests) and opening a WIP PR to get the tests to run.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
