### PR TITLE
Cabal init fileformat tests

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -284,6 +284,7 @@ Test-Suite unit-tests
       UnitTests.Distribution.Client.Init.NonInteractive
       UnitTests.Distribution.Client.Init.Simple
       UnitTests.Distribution.Client.Init.Utils
+      UnitTests.Distribution.Client.Init.FileCreators
       UnitTests.Distribution.Client.Store
       UnitTests.Distribution.Client.Tar
       UnitTests.Distribution.Client.TreeDiffInstances
@@ -320,6 +321,7 @@ Test-Suite unit-tests
           time,
           zlib,
           tasty >= 1.2.3 && <1.5,
+          tasty-expected-failure,
           tasty-golden >=2.3.1.1 && <2.4,
           tasty-quickcheck,
           tasty-hunit >= 0.10,

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -386,12 +386,12 @@ instance Interactive PurePrompt where
 
     putStr !_ = return ()
     putStrLn !_ = return ()
-    createDirectory !_ = return ()
-    removeDirectory !_ = return ()
-    writeFile !_ !_ = return ()
-    removeExistingFile !_ = return ()
-    copyFile !_ !_ = return ()
-    renameDirectory !_ !_ = return ()
+    createDirectory !d = checkInvalidPath d ()
+    removeDirectory !d = checkInvalidPath d ()
+    writeFile !f !_ = checkInvalidPath f ()
+    removeExistingFile !f = checkInvalidPath f ()
+    copyFile !f !_ = checkInvalidPath f ()
+    renameDirectory !d !_ = checkInvalidPath d ()
     hFlush _ = return ()
     message !_ !severity !msg = case severity of
       Error -> PurePrompt $ \_ -> Left $ BreakException
@@ -421,6 +421,14 @@ popList = pop >>= \a -> case P.safeRead a of
     Nothing -> throwPrompt $ BreakException ("popList: " ++ show a)
     Just as -> return as
 
+checkInvalidPath :: String -> a -> PurePrompt a
+checkInvalidPath path act = 
+    -- The check below is done this way so it's easier to append
+    -- more invalid paths in the future, if necessary
+    if path `elem` ["."] then
+      throwPrompt $ BreakException $ "Invalid path: " ++ path
+    else
+      return act
 
 -- | A pure exception thrown exclusively by the pure prompter
 -- to cancel infinite loops in the prompting process.

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -311,6 +311,7 @@ class Monad m => Interactive m where
     canonicalizePathNoThrow :: FilePath -> m FilePath
     readProcessWithExitCode :: FilePath -> [String] -> String -> m (ExitCode, String, String)
     getEnvironment :: m [(String, String)]
+    getCurrentYear :: m Integer
     listFilesInside :: (FilePath -> m Bool) -> FilePath -> m [FilePath]
     listFilesRecursive :: FilePath -> m [FilePath]
 
@@ -320,6 +321,7 @@ class Monad m => Interactive m where
     createDirectory :: FilePath -> m ()
     removeDirectory :: FilePath -> m ()
     writeFile :: FilePath -> String -> m ()
+    removeExistingFile :: FilePath -> m ()
     copyFile :: FilePath -> FilePath -> m ()
     renameDirectory :: FilePath -> FilePath -> m ()
     message :: Verbosity -> String -> m ()
@@ -341,6 +343,7 @@ instance Interactive IO where
     canonicalizePathNoThrow = P.canonicalizePathNoThrow
     readProcessWithExitCode = P.readProcessWithExitCode
     getEnvironment = P.getEnvironment
+    getCurrentYear = P.getCurrentYear
     listFilesInside = P.listFilesInside
     listFilesRecursive = P.listFilesRecursive
 
@@ -349,6 +352,7 @@ instance Interactive IO where
     createDirectory = P.createDirectory
     removeDirectory = P.removeDirectoryRecursive
     writeFile = P.writeFile
+    removeExistingFile = P.removeExistingFile
     copyFile = P.copyFile
     renameDirectory = P.renameDirectory
     message q = unless (q == silent) . putStrLn
@@ -372,6 +376,7 @@ instance Interactive PurePrompt where
       input <- pop
       return (ExitSuccess, input, "")
     getEnvironment = fmap (map read) popList
+    getCurrentYear = fmap read pop
     listFilesInside pred' !_ = do
       input <- map splitDirectories <$> popList
       map joinPath <$> filterM (fmap and . traverse pred') input
@@ -382,6 +387,7 @@ instance Interactive PurePrompt where
     createDirectory !_ = return ()
     removeDirectory !_ = return ()
     writeFile !_ !_ = return ()
+    removeExistingFile !_ = return ()
     copyFile !_ !_ = return ()
     renameDirectory !_ !_ = return ()
     message !_ !_ = return ()

--- a/cabal-install/src/Distribution/Client/Init/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Init/Utils.hs
@@ -223,7 +223,7 @@ retrieveDependencies v flags mods' pkgIx = do
       modDeps = map (\(mn, ds) -> (mn, ds, M.lookup ds modMap)) mods
       -- modDeps = map (id &&& flip M.lookup modMap) mods
 
-  message v "\nGuessing dependencies..."
+  message v Log "Guessing dependencies..."
   nub . catMaybes <$> traverse (chooseDep v flags) modDeps
 
 -- Given a module and a list of installed packages providing it,
@@ -254,7 +254,7 @@ chooseDep v flags (importer, m, mipi) = case mipi of
 
         -- Otherwise, choose the latest version and issue a warning.
         pids -> do
-          message v ("\nWarning: multiple versions of " ++ prettyShow (P.pkgName . NE.head $ pids) ++ " provide " ++ prettyShow m ++ ", choosing the latest.")
+          message v Warning ("multiple versions of " ++ prettyShow (P.pkgName . NE.head $ pids) ++ " provide " ++ prettyShow m ++ ", choosing the latest.")
           return $ P.Dependency
               (P.pkgName . NE.head $ pids)
               (pvpize desugar . maximum . fmap P.pkgVersion $ pids)
@@ -263,12 +263,12 @@ chooseDep v flags (importer, m, mipi) = case mipi of
       -- if multiple packages are found, we refuse to choose between
       -- different packages and make the user do it
       grps     -> do
-        message v ("\nWarning: multiple packages found providing " ++ prettyShow m ++ ": " ++ intercalate ", " (fmap (prettyShow . P.pkgName . NE.head) grps))
-        message v "You will need to pick one and manually add it to the build-depends field."
+        message v Warning ("multiple packages found providing " ++ prettyShow m ++ ": " ++ intercalate ", " (fmap (prettyShow . P.pkgName . NE.head) grps))
+        message v Warning "You will need to pick one and manually add it to the build-depends field."
         return Nothing
 
   _ -> do
-    message v ("\nWarning: no package found providing " ++ prettyShow m ++ " in " ++ prettyShow importer ++ ".")
+    message v Warning ("no package found providing " ++ prettyShow m ++ " in " ++ prettyShow importer ++ ".")
     return Nothing
 
   where
@@ -293,7 +293,7 @@ mkPackageNameDep pkg = mkDependency pkg anyVersion (NES.singleton LMainLibName)
 fixupDocFiles :: Interactive m => Verbosity -> PkgDescription -> m PkgDescription
 fixupDocFiles v pkgDesc
   | _pkgCabalVersion pkgDesc < CabalSpecV1_18 = do
-    message v $ concat
+    message v Warning $ concat
       [ "Cabal spec versions < 1.18 do not support extra-doc-files. "
       , "Doc files will be treated as extra-src-files."
       ]

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init.hs
@@ -8,6 +8,7 @@ import qualified UnitTests.Distribution.Client.Init.Interactive    as Interactiv
 import qualified UnitTests.Distribution.Client.Init.NonInteractive as NonInteractive
 import qualified UnitTests.Distribution.Client.Init.Golden         as Golden
 import qualified UnitTests.Distribution.Client.Init.Simple         as Simple
+import qualified UnitTests.Distribution.Client.Init.FileCreators   as FileCreators
 
 import UnitTests.Distribution.Client.Init.Utils
 
@@ -40,6 +41,7 @@ tests = do
          , NonInteractive.tests v initFlags' comp pkgIx srcDb
          , Golden.tests v initFlags' pkgIx srcDb
          , Simple.tests v initFlags' pkgIx srcDb
+         , FileCreators.tests v initFlags' comp pkgIx srcDb
          ]
   where
     v :: Verbosity

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
+module UnitTests.Distribution.Client.Init.FileCreators
+  ( tests
+  ) where
+
+import Test.Tasty
+import Test.Tasty.ExpectedFailure
+import Test.Tasty.HUnit
+
+import UnitTests.Distribution.Client.Init.Utils
+
+import Distribution.Client.Init.FileCreators
+import Distribution.Client.Init.NonInteractive.Command
+import Distribution.Client.Init.Types
+import Distribution.Client.Types
+import Distribution.Simple
+import Distribution.Simple.Flag
+import Distribution.Simple.PackageIndex
+import Distribution.Verbosity
+
+tests 
+    :: Verbosity
+    -> InitFlags
+    -> Compiler
+    -> InstalledPackageIndex
+    -> SourcePackageDb
+    -> TestTree
+tests _v _initFlags comp pkgIx srcDb =
+  testGroup "Distribution.Client.Init.FileCreators"
+    [ expectFail $ testCase "Check . as source directory" $ do
+        let dummyFlags' = dummyFlags
+              { packageType = Flag LibraryAndExecutable
+              , minimal = Flag False
+              , overwrite = Flag False
+              , packageDir = Flag "/home/test/test-package"
+              , extraDoc = Flag ["CHANGELOG.md"]
+              , exposedModules = Flag []
+              , otherModules = Flag []
+              , otherExts = Flag []
+              , buildTools = Flag []
+              , mainIs = Flag "quxApp/Main.hs"
+              , dependencies = Flag []
+              --, sourceDirs = Flag ["."]
+              }
+            inputs =
+              [ "True"
+              , "[\"quxTest/Main.hs\"]"
+              , "2021"
+              , "True"
+              , "True"
+              ]
+
+        case flip _runPrompt inputs $ do
+            projSettings <- createProject comp silent pkgIx srcDb dummyFlags'
+            writeProject projSettings of
+
+          Left (BreakException ex) -> assertFailure $ show ex
+          Right _ -> return ()
+        
+
+    ]


### PR DESCRIPTION
This PR adapts `cabal init`'s `FileCreators` module, so it has the capability to be tested through the testing machinery proper. It is also a compromise for the stalemate in #7807, as it will be unblocked.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
