### PR TITLE
guide the user towards solving test-plan issues

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdErrorMessages.hs
+++ b/cabal-install/src/Distribution/Client/CmdErrorMessages.hs
@@ -330,10 +330,13 @@ renderTargetProblemNoneEnabled verb targetSelector targets =
               [ "the " ++ showComponentName availableTargetComponentName
               | AvailableTarget {availableTargetComponentName} <- targets' ]
          ++ plural (listPlural targets') " is " " are "
-         ++ "not available because the solver did not find a plan that "
-         ++ "included the " ++ renderOptionalStanza Plural stanza
-         ++ ". Force the solver to enable this for all packages by adding the "
-         ++ "line 'tests: True' to the 'cabal.project.local' file."
+         ++ "not available because the solver picked a plan that does not "
+         ++ "include the " ++ renderOptionalStanza Plural stanza
+         ++ ", perhaps because no such plan exists. To see the error message "
+         ++ "explaining the problems with such plans, force the solver to "
+         ++ "include the " ++ renderOptionalStanza Plural stanza ++ " for all "
+         ++ "packages, by adding the line 'tests: True' to the "
+         ++ "'cabal.project.local' file."
         (TargetNotBuildable, _) ->
             renderListCommaAnd
               [ "the " ++ showComponentName availableTargetComponentName


### PR DESCRIPTION
This simpler change (tweaking an error message) came up [while discussing a larger PR](https://github.com/haskell/cabal/pull/7829#issuecomment-976468255). Let's make this smaller change first!

---

When `cabal test` and the error message recommends setting `tests: True`, the next `cabal test` run is likely to fail with a solver error. The user might incorrectly conclude that setting `tests: True` made the problem worse, because the failure now occurs earlier (at solving time rather than at testing time).

By including the fact that a plan failure is expected in the error message, hopefully users will be more confident that setting `tests: True` was the right move, so they will be able to focus on the true cause of the problem: the fact that no plan including the tests exist.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
