### PR TITLE
Fix #6679 : Warn about `v2-haddock` failure

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddock.hs
@@ -30,8 +30,10 @@ import Distribution.Simple.Command
 import Distribution.Verbosity
          ( normal )
 import Distribution.Simple.Utils
-         ( wrapText, die' )
+         ( wrapText, die', notice )
 import Distribution.Simple.Flag (Flag(..))
+
+import qualified System.Exit (exitSuccess)
 
 newtype ClientHaddockFlags = ClientHaddockFlags { openInBrowser :: Flag Bool }
 
@@ -185,5 +187,12 @@ selectComponentTarget :: SubComponentTarget
 selectComponentTarget = selectComponentTargetBasic
 
 reportBuildDocumentationTargetProblems :: Verbosity -> [TargetProblem'] -> IO a
-reportBuildDocumentationTargetProblems verbosity problems =
-  reportTargetProblems verbosity "build documentation for" problems
+reportBuildDocumentationTargetProblems verbosity problems = 
+  case problems of
+    [TargetProblemNoneEnabled _ _] -> do
+      notice verbosity $
+          "No documentation was generated as this package does not contain a library. "
+       ++ "Perhaps you want to use the --haddock-executables, --haddock-tests, --haddock-benchmarks or "
+       ++ "--haddock-internal flags."
+      System.Exit.exitSuccess
+    _ -> reportTargetProblems verbosity "build documentation for" problems

--- a/cabal-testsuite/PackageTests/HaddockWarn/Main.hs
+++ b/cabal-testsuite/PackageTests/HaddockWarn/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/cabal-testsuite/PackageTests/HaddockWarn/cabal.out
+++ b/cabal-testsuite/PackageTests/HaddockWarn/cabal.out
@@ -1,0 +1,3 @@
+# cabal v2-haddock
+Resolving dependencies...
+No documentation was generated as this package does not contain a library. Perhaps you want to use the --haddock-executables, --haddock-tests, --haddock-benchmarks or --haddock-internal flags.

--- a/cabal-testsuite/PackageTests/HaddockWarn/cabal.project
+++ b/cabal-testsuite/PackageTests/HaddockWarn/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/HaddockWarn/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockWarn/cabal.test.hs
@@ -1,0 +1,4 @@
+import Test.Cabal.Prelude
+import System.Exit (ExitCode (..))
+
+main = cabalTest $ cabal "v2-haddock" []

--- a/cabal-testsuite/PackageTests/HaddockWarn/example.cabal
+++ b/cabal-testsuite/PackageTests/HaddockWarn/example.cabal
@@ -1,0 +1,11 @@
+name:               example
+version:            1.0
+build-type:         Simple
+cabal-version:      >= 1.10
+
+
+executable example
+    main-is:          Main.hs
+    build-depends:    base
+    default-language: Haskell2010
+

--- a/changelog.d/issue-6679
+++ b/changelog.d/issue-6679
@@ -1,0 +1,4 @@
+synopsis: Fix v2-haddock results in "unexpected status"
+packages: cabal-install
+prs: #7843
+issues: #6679


### PR DESCRIPTION
Attempt to fix #6679


Handle the `v2-haddock` error when it's ran on an invalid target
without any flags.
Now exits gracefully with helpful warning message taken from
`v1-haddock` with updated flags.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
