### PR TITLE
Fix cabal on Windows 7

### DIFF
--- a/Cabal/src/Distribution/Compat/Process.hs
+++ b/Cabal/src/Distribution/Compat/Process.hs
@@ -27,7 +27,7 @@ import           System.Process (waitForProcess)
 --
 -- Unfortunately the process job support is badly broken in @process@ releases
 -- prior to 1.6.9, so we disable it in these versions, despite the fact that
--- this means we may see sporatic build failures without jobs.
+-- this means we may see sporadic build failures without jobs.
 enableProcessJobs :: CreateProcess -> CreateProcess
 #ifdef MIN_VERSION_process
 #if MIN_VERSION_process(1,6,9)

--- a/Cabal/src/Distribution/Compat/Process.hs
+++ b/Cabal/src/Distribution/Compat/Process.hs
@@ -28,6 +28,9 @@ import           System.Win32.Info.Version (dwMajorVersion, dwMinorVersion, getV
 -------------------------------------------------------------------------------
 
 #if defined(mingw32_HOST_OS) && MIN_VERSION_process(1,6,9)
+-- This exception, needed to support Windows 7, could be removed when
+-- the lowest GHC version cabal supports is a GHC that doesn’t support
+-- Windows 7 any more.
 {-# NOINLINE isWindows8OrLater #-}
 isWindows8OrLater :: Bool
 isWindows8OrLater = unsafePerformIO $ do

--- a/Cabal/src/Distribution/Compat/Process.hs
+++ b/Cabal/src/Distribution/Compat/Process.hs
@@ -18,9 +18,22 @@ import qualified System.Process as Process
 import           System.Process (waitForProcess)
 #endif
 
+#if defined(mingw32_HOST_OS) && MIN_VERSION_process(1,6,9)
+import           System.IO.Unsafe (unsafePerformIO)
+import           System.Win32.Info.Version (dwMajorVersion, dwMinorVersion, getVersionEx)
+#endif
+
 -------------------------------------------------------------------------------
 -- enableProcessJobs
 -------------------------------------------------------------------------------
+
+#if defined(mingw32_HOST_OS) && MIN_VERSION_process(1,6,9)
+{-# NOINLINE isWindows8OrLater #-}
+isWindows8OrLater :: Bool
+isWindows8OrLater = unsafePerformIO $ do
+  v <- getVersionEx
+  pure $ (dwMajorVersion v, dwMinorVersion v) >= (6, 2)
+#endif
 
 -- | Enable process jobs to ensure accurate determination of process completion
 -- in the presence of @exec(3)@ on Windows.
@@ -28,13 +41,18 @@ import           System.Process (waitForProcess)
 -- Unfortunately the process job support is badly broken in @process@ releases
 -- prior to 1.6.9, so we disable it in these versions, despite the fact that
 -- this means we may see sporadic build failures without jobs.
+--
+-- On Windows 7 or before the jobs are disabled due to the fact that
+-- processes on these systems can only have one job. This prevents
+-- spawned process from assigning jobs to its own children. Suppose
+-- processs A spawns process B. The B process has a job assigned (call
+-- it J1) and when it tries to spawn a new process C the C
+-- automatically inherits the job. But at it also tries to assign a
+-- new job J2 to C since it doesn’t have access J1. This fails on
+-- Windows 7 or before.
 enableProcessJobs :: CreateProcess -> CreateProcess
-#ifdef MIN_VERSION_process
-#if MIN_VERSION_process(1,6,9)
-enableProcessJobs cp = cp {Process.use_process_jobs = True}
-#else
-enableProcessJobs cp = cp
-#endif
+#if defined(mingw32_HOST_OS) && MIN_VERSION_process(1,6,9)
+enableProcessJobs cp = cp {Process.use_process_jobs = isWindows8OrLater}
 #else
 enableProcessJobs cp = cp
 #endif

--- a/changelog.d/pr-7844
+++ b/changelog.d/pr-7844
@@ -1,0 +1,8 @@
+synopsis: Disable job management on Windows 7
+packages: Cabal
+prs: #7844
+significance: significant
+
+description: {
+- cabal now works on Windows 7
+}


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

---

I have encountered severe issue on Windows 7. `cabal` executable built with `process` 1.6.9 or later is unable to build any packages. The issue manifests itself as cabal being unable to determine version of the ghc but the actual issue is that it's process spawning mechanic is faulty.

The investigation revealed following: starting with `process` 1.6.9 the `Cabal` library enables so-called jobs for newly created processes. This is done to better detect when a spawned process terminates. Simplistically, a job is a set of processes tracked by the OS. When a relevant relevant is supplied, the processes spawned by the `process` package are assigned a fresh job and any children they spawn will inherit that job. Later on the job can be checked for whether all the processes in it terminated.

The issue on Windows 7 (and earlier versions as well, but that's less relevant) is that a process can have at most one job assigned to it[^1] which breaks when a job is inherited automatically. I.e. spawned processes are unable to use job management for their own children.

Specifically, I invoke `cabal build` which spawns `cabal act-as-setup` process and assigns a job to it. The `cabal act-as-setup` tries to spawn more processes, like `ghc --numeric-version` but cannot assign fresh jobs to them since they already inherit one. The process cannot be started and build does not proceed.

Thus the proposed fix is to disable job management on Windows 7 or earlier. On later Windows versions it's fine since it allows processes to have multiple jobs provided they're included into one another.

[^1]:
    Relevant exceprt from https://docs.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-assignprocesstojobobject:
    
    > Windows 7, Windows Server 2008 R2, Windows XP with SP3, Windows Server 2008, Windows Vista and Windows Server 2003:  The process must not already be assigned to a job; if it is, the function fails with ERROR_ACCESS_DENIED. This behavior changed starting in Windows 8 and Windows Server 2012.