### PR TITLE
Fix #7641 : Fix `post-checkout-command` bug

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -1192,7 +1192,7 @@ syncAndReadSourcePackagesRemoteRepos verbosity
         for_ repoGroupWithPaths $ \(repo, _, repoPath) ->
             for_ (nonEmpty (srpCommand repo)) $ \(cmd :| args) -> liftIO $ do
                 exitCode <- rawSystemIOWithEnv verbosity cmd args (Just repoPath) Nothing Nothing Nothing Nothing
-                unless (exitCode /= ExitSuccess) $ exitWith exitCode
+                unless (exitCode == ExitSuccess) $ exitWith exitCode
 
         -- But for reading we go through each 'SourceRepo' including its subdir
         -- value and have to know which path each one ended up in.

--- a/cabal-testsuite/PackageTests/postCheckoutCommand/cabal.negative.project
+++ b/cabal-testsuite/PackageTests/postCheckoutCommand/cabal.negative.project
@@ -1,0 +1,8 @@
+packages: .
+
+source-repository-package
+    type: git
+-- A Sample repo to test post-checkout-command
+    location: https://github.com/haskell/bytestring 
+    post-checkout-command: false
+-- https://en.wikipedia.org/wiki/True_and_false_(commands)

--- a/cabal-testsuite/PackageTests/postCheckoutCommand/cabal.out
+++ b/cabal-testsuite/PackageTests/postCheckoutCommand/cabal.out
@@ -1,0 +1,2 @@
+# cabal v2-build
+# cabal v2-build

--- a/cabal-testsuite/PackageTests/postCheckoutCommand/cabal.positive.project
+++ b/cabal-testsuite/PackageTests/postCheckoutCommand/cabal.positive.project
@@ -1,0 +1,8 @@
+packages: .
+
+source-repository-package
+    type: git
+-- A Sample repo to test post-checkout-command
+    location: https://github.com/haskell/bytestring
+    post-checkout-command: true
+-- https://en.wikipedia.org/wiki/True_and_false_(commands)

--- a/cabal-testsuite/PackageTests/postCheckoutCommand/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/postCheckoutCommand/cabal.test.hs
@@ -1,0 +1,8 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    skipIfWindows 
+    withProjectFile "cabal.positive.project" $ do
+        cabal "v2-build" ["-v0"]
+    withProjectFile "cabal.negative.project" $ do
+        fails $ cabal "v2-build" ["-v0"]

--- a/cabal-testsuite/PackageTests/postCheckoutCommand/example.cabal
+++ b/cabal-testsuite/PackageTests/postCheckoutCommand/example.cabal
@@ -1,0 +1,9 @@
+cabal-version:      2.4
+name:               example
+version:            1.0
+
+library
+    exposed-modules:  Example
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/postCheckoutCommand/src/Example.hs
+++ b/cabal-testsuite/PackageTests/postCheckoutCommand/src/Example.hs
@@ -1,0 +1,4 @@
+module Example (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "Example"

--- a/changelog.d/issue-7641
+++ b/changelog.d/issue-7641
@@ -1,0 +1,4 @@
+synopsis: Fix post-checkout-command crash when 0 exit status bug
+issues: #7641
+packages: cabal-install
+prs: #7847


### PR DESCRIPTION
Attempt to fix #7641 

This fixes the crash when `post-checkout-command` option for
`source-repository-package` returns an exit status 0.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
