### PR TITLE
Backport: Add ghcup install call to boostrap script to be future safe

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: bootstrap.py
         run: |
+          ghcup config set cache true
           ghcup install ghc 8.10.7
           python3 bootstrap/bootstrap.py -w $(ghcup whereis ghc 8.10.7) -d bootstrap/linux-8.10.7.json
 
@@ -51,6 +52,7 @@ jobs:
       # We use linux dependencies
       - name: bootstrap.py
         run: |
+          ghcup config set cache true
           ghcup install ghc 8.10.7
           python3 bootstrap/bootstrap.py -w $(ghcup whereis ghc 8.10.7) -d bootstrap/linux-8.10.7.json
 

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: bootstrap.py
         run: |
+          ghcup install ghc 8.10.7
           python3 bootstrap/bootstrap.py -w $(ghcup whereis ghc 8.10.7) -d bootstrap/linux-8.10.7.json
 
       - name: Smoke test
@@ -50,7 +51,8 @@ jobs:
       # We use linux dependencies
       - name: bootstrap.py
         run: |
-          python3 bootstrap/bootstrap.py -w /opt/ghc/8.10.7/bin/ghc -d bootstrap/linux-8.10.7.json
+          ghcup install ghc 8.10.7
+          python3 bootstrap/bootstrap.py -w $(ghcup whereis ghc 8.10.7) -d bootstrap/linux-8.10.7.json
 
       - name: Smoke test
         run: |

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           path: ~/.cabal/store
           key: linux-store-meta
+      - name: ghcup
+        run: |
+          ghcup config set cache true
+          ghcup install ghc recommended
+          ghcup set ghc recommended
       - name: Update Hackage index
         run: cabal v2-update
       - name: Install alex
@@ -63,6 +68,11 @@ jobs:
         with:
           path: ~/.cabal/store
           key: linux-store-doctest
+      - name: ghcup
+        run: |
+          ghcup config set cache true
+          ghcup install ghc recommended
+          ghcup set ghc recommended
       - name: Update Hackage index
         run: cabal v2-update
       - name: Install doctest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,7 +68,7 @@ jobs:
           cabal v2-run cabal-install:unit-tests -- --pattern "! (/FileMonitor/ || /VCS/ || /Get/)"
       - name: cabal-tests
         # Using only one job, -j1, to fail less.
-        run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.6.5\cabal-install-3.6.0.0\x\cabal\build\cabal\cabal.exe
+        run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.6.5\cabal-install-3.6.2.0\x\cabal\build\cabal\cabal.exe
 
   test-windows-8_6_5-dogfood:
     name: test ghc-8.6.5 dogfood
@@ -165,7 +165,7 @@ jobs:
           cabal v2-run cabal-install:unit-tests -- --pattern "! (/FileMonitor/ || /VCS/ || /Get/)"
       - name: cabal-tests
         # Using only one job, -j1, to fail less.
-        run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.10.4\cabal-install-3.6.0.0\x\cabal\build\cabal\cabal.exe
+        run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-8.10.4\cabal-install-3.6.2.0\x\cabal\build\cabal\cabal.exe
 
   test-windows-8_10_4-dogfood:
     name: test ghc-8.10.4 dogfood

--- a/templates/ci-bootstrap.template.yml
+++ b/templates/ci-bootstrap.template.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: bootstrap.py
         run: |
+          ghcup config set cache true
           ghcup install ghc 8.10.7
           python3 bootstrap/bootstrap.py -w $(ghcup whereis ghc 8.10.7) -d bootstrap/linux-8.10.7.json
 
@@ -51,6 +52,7 @@ jobs:
       # We use linux dependencies
       - name: bootstrap.py
         run: |
+          ghcup config set cache true
           ghcup install ghc 8.10.7
           python3 bootstrap/bootstrap.py -w $(ghcup whereis ghc 8.10.7) -d bootstrap/linux-8.10.7.json
 

--- a/templates/ci-bootstrap.template.yml
+++ b/templates/ci-bootstrap.template.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: bootstrap.py
         run: |
+          ghcup install ghc 8.10.7
           python3 bootstrap/bootstrap.py -w $(ghcup whereis ghc 8.10.7) -d bootstrap/linux-8.10.7.json
 
       - name: Smoke test
@@ -50,7 +51,8 @@ jobs:
       # We use linux dependencies
       - name: bootstrap.py
         run: |
-          python3 bootstrap/bootstrap.py -w /opt/ghc/8.10.7/bin/ghc -d bootstrap/linux-8.10.7.json
+          ghcup install ghc 8.10.7
+          python3 bootstrap/bootstrap.py -w $(ghcup whereis ghc 8.10.7) -d bootstrap/linux-8.10.7.json
 
       - name: Smoke test
         run: |

--- a/templates/ci-quick-jobs.template.yml
+++ b/templates/ci-quick-jobs.template.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           path: ~/.cabal/store
           key: linux-store-meta
+      - name: ghcup
+        run: |
+          ghcup config set cache true
+          ghcup install ghc recommended
+          ghcup set ghc recommended
       - name: Update Hackage index
         run: cabal v2-update
       - name: Install alex
@@ -63,6 +68,11 @@ jobs:
         with:
           path: ~/.cabal/store
           key: linux-store-doctest
+      - name: ghcup
+        run: |
+          ghcup config set cache true
+          ghcup install ghc recommended
+          ghcup set ghc recommended
       - name: Update Hackage index
         run: cabal v2-update
       - name: Install doctest

--- a/templates/ci-windows.template.yml
+++ b/templates/ci-windows.template.yml
@@ -75,7 +75,7 @@ jobs:
           cabal v2-run cabal-install:unit-tests -- --pattern "! (/FileMonitor/ || /VCS/ || /Get/)"
       - name: cabal-tests
         # Using only one job, -j1, to fail less.
-        run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-{{ job.version }}\cabal-install-3.6.0.0\x\cabal\build\cabal\cabal.exe
+        run: cabal v2-run cabal-testsuite:cabal-tests -- -j1 --with-cabal=dist-newstyle\build\x86_64-windows\ghc-{{ job.version }}\cabal-install-3.6.2.0\x\cabal\build\cabal\cabal.exe
 
   test-windows-{{ mangleVersion job.version }}-dogfood:
     name: test ghc-{{job.version}} dogfood


### PR DESCRIPTION
A backport of d83c38b575571750d842d3fac23ec4371769d8fb and 475222dde71b4258abce8133d7005c39be4f3a14 to fix CI on 3.6.

Committed to master in #7658 and #7796.