### PR TITLE
Cabal: Bump time upper bound to allow 1.12

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -46,7 +46,7 @@ library
     filepath   >= 1.3.0.1  && < 1.5,
     pretty     >= 1.1.1    && < 1.2,
     process    >= 1.1.0.2  && < 1.7,
-    time       >= 1.4.0.1  && < 1.12
+    time       >= 1.4.0.1  && < 1.13
 
   if flag(bundled-binary-generic)
     build-depends: binary >= 0.5.1.1 && < 0.7


### PR DESCRIPTION
In service of [GHC #20547](https://gitlab.haskell.org/ghc/ghc/-/issues/20547).

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
