### PR TITLE
Extra argument for `cabal init` as starting dir

### DIFF
--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -2031,10 +2031,12 @@ initCommand = CommandUI {
       ++ "Calling init with no arguments runs interactive mode, "
       ++ "which will try to guess as much as possible and prompt you for the rest.\n"
       ++ "Non-interactive mode can be invoked by the -n/--non-interactive flag, "
-      ++ "which will let you specify the options via flags and will use the defaults for the rest.\n",
+      ++ "which will let you specify the options via flags and will use the defaults for the rest.\n"
+      ++ "It is also possible to call init with a single argument, which denotes the project's desired "
+      ++ "root directory.\n",
     commandNotes = Nothing,
     commandUsage = \pname ->
-         "Usage: " ++ pname ++ " init [FLAGS]\n",
+         "Usage: " ++ pname ++ " init [PROJECT ROOT] [FLAGS]\n",
     commandDefaultFlags = IT.defaultInitFlags,
     commandOptions = initOptions
   }

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -19,19 +19,16 @@ and how to add external dependencies.
 Initializing the application
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Start by creating a ``myfirstapp`` directory to hold the project files, these
-instructions work in unix shells and PowerShell (if you're on Windows).
+Start by initialising our ``myfirstapp`` project, these instructions work in
+unix shells and PowerShell (if you're on Windows).
 
 .. code-block:: console
 
-    $ mkdir myfirstapp
-    $ cd myfirstapp
+    $ cabal init myfirstapp -n
 
-Once you have an empty directory we can initialize our package:
-
-.. code-block:: console
-
-    $ cabal init -n
+.. note:: ``myfirstapp`` stands for the directory (or path) where the project
+          will reside in, if ommited, ``cabal init`` will do its proceedings
+          in the directory it's called in.
 
 .. note:: ``-n`` stands for ``--non-interactive``, which means that cabal will try to guess
           how to set up the project for you and use the default settings, which will serve us
@@ -48,10 +45,11 @@ This will generate the following files:
 
     $ tree
     .
-    ├── app
-    │   └── Main.hs
-    ├── CHANGELOG.md
-    └── myfirstapp.cabal
+    └── myfirstapp
+        ├── app
+        │   └── Main.hs
+        ├── CHANGELOG.md
+        └── myfirstapp.cabal
 
 ``app/Main.hs`` is where your package's code lives.
 
@@ -63,11 +61,15 @@ little bit when we add an external dependency to our package.
 Running the application
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-When we ran ``cabal init -n`` above, it generated a package with a single executable
-named same as the package (in this case ``myfirstapp``) that prints ``"Hello, Haskell!"``
-to the terminal. To run the executable enter the following command:
+When we ran ``cabal init myfirstapp -n`` above, it generated a package with a single 
+executable named same as the package (in this case ``myfirstapp``) that prints
+``"Hello, Haskell!"`` to the terminal. To run the executable enter the project's
+directory and run it, by inputting the following commands:
 
-``cabal run myfirstapp``
+.. code-block:: console
+
+    cd myfirstapp
+    cabal run myfirstapp
 
 You should see the following output in the terminal:
 


### PR DESCRIPTION
Closes #7871. `cabal init` will now take the first value in `extraArgs` and treat it as the root directory for the new project; i.e.:
```
cabal init -n -- my-project
```

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
