### PR TITLE
Rebase #5440: Respect ghc-options and with-gcc when compiling C sources

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -215,6 +215,8 @@
     ([#5431](https://github.com/haskell/cabal/pull/5431)).
   * Pass command line arguments to `hsc2hs` using response files when possible
     ([#3122](https://github.com/haskell/cabal/issues/3122)).
+  * `ghc-options` and `--with-gcc` are now passed to GHC when compiling
+    C and C++ sources ([#4439](https://github.com/haskell/cabal/issues/4439)).
 
 ----
 

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -301,7 +301,10 @@ componentCcGhcOptions verbosity _implInfo lbi bi clbi odir filename =
                                   NormalDebugInfo  -> ["-g"]
                                   MaximalDebugInfo -> ["-g3"]) ++
                                   ccOptions bi,
-      ghcOptObjDir         = toFlag odir
+      ghcOptCcProgram      = maybeToFlag $ programPath <$>
+                                 lookupProgram gccProgram (withPrograms lbi),
+      ghcOptObjDir         = toFlag odir,
+      ghcOptExtra          = hcOptions GHC bi
     }
 
 
@@ -337,7 +340,10 @@ componentCxxGhcOptions verbosity _implInfo lbi bi clbi odir filename =
                                   NormalDebugInfo  -> ["-g"]
                                   MaximalDebugInfo -> ["-g3"]) ++
                                   cxxOptions bi,
-      ghcOptObjDir         = toFlag odir
+      ghcOptCcProgram      = maybeToFlag $ programPath <$>
+                                 lookupProgram gccProgram (withPrograms lbi),
+      ghcOptObjDir         = toFlag odir,
+      ghcOptExtra          = hcOptions GHC bi
     }
 
 

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -446,6 +446,9 @@ data GhcOptions = GhcOptions {
   -- | Extra header files to include for old-style FFI; the @ghc -#include@ flag.
   ghcOptFfiIncludes    :: NubListR FilePath,
 
+  -- | Program to use for the C and C++ compiler; the @ghc -pgmc@ flag.
+  ghcOptCcProgram      :: Flag FilePath,
+
   ----------------------------
   -- Language and extensions
 
@@ -691,6 +694,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
                 _ -> "-optc"
     in [ cxxflag ++ opt | opt <- ghcOptCxxOptions opts]
   , [ "-opta" ++ opt | opt <- ghcOptAsmOptions opts]
+  , concat [ ["-pgmc", cc] | cc <- flag ghcOptCcProgram ]
 
   -----------------
   -- Linker stuff


### PR DESCRIPTION
This is https://github.com/haskell/cabal/pull/5440 rebased on master

I don't understand the patch well enough to really help further right now. Please close if this isn't mergeable.