### PR TITLE
Backing up only when overwritting to allow cabalisation

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/src/Distribution/Client/Init/FileCreators.hs
@@ -231,21 +231,20 @@ writeFileSafe opts fileName content = do
     exists <- doesFileExist fileName
 
     let action
-          | doOverwrite = "Overwriting"
-          | exists = "Creating fresh"
-          | otherwise = "Creating"
+          | exists && doOverwrite = "Overwriting"
+          | not exists = "Creating fresh"
+          | otherwise = "Using existing"
 
     go exists
 
     message opts T.Log $ action ++ " file " ++ fileName ++ "..."
-    writeFile fileName content
   where
     doOverwrite = _optOverwrite opts
 
     go exists
-      | exists, doOverwrite = do
-        removeExistingFile fileName
-      | exists, not doOverwrite = do
+      | not exists = do
+        writeFile fileName content
+      | exists && doOverwrite = do
         newName <- findNewPath fileName
         message opts T.Log $ concat
           [ fileName
@@ -262,21 +261,20 @@ writeDirectoriesSafe opts dirs = for_ dirs $ \dir -> do
     exists <- doesDirectoryExist dir
 
     let action
-          | doOverwrite = "Overwriting"
-          | exists = "Creating fresh"
-          | otherwise = "Creating"
+          | exists && doOverwrite = "Overwriting"
+          | not exists = "Creating fresh"
+          | otherwise = "Using existing"
 
     go dir exists
 
     message opts T.Log $ action ++ " directory ./" ++ dir ++ "..."
-    createDirectory dir
   where
     doOverwrite = _optOverwrite opts
 
     go dir exists
-      | exists, doOverwrite = do
-        removeDirectory dir
-      | exists, not doOverwrite = do
+      | not exists = do
+        createDirectory dir
+      | exists && doOverwrite = do
         newDir <- findNewPath dir
         message opts T.Log $ concat
           [ dir

--- a/cabal-testsuite/PackageTests/Init/app/Main.hs
+++ b/cabal-testsuite/PackageTests/Init/app/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "This should remain as is!"

--- a/cabal-testsuite/PackageTests/Init/init.out
+++ b/cabal-testsuite/PackageTests/Init/init.out
@@ -1,0 +1,1 @@
+# cabal init

--- a/cabal-testsuite/PackageTests/Init/init.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init.test.hs
@@ -1,0 +1,8 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $
+  withSourceCopyDir "app" $ do
+    cwd <- fmap testSourceCopyDir getTestEnv
+    cabal "init" ["-n", "--exe", "--application-dir=app", "--main-is=Main.hs", "--", cwd]
+
+    assertFileDoesContain (cwd </> "app/Main.hs") "This should remain as is!"

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -287,6 +287,7 @@ cabalGArgs global_args cmd args input = do
               , "check"
               , "get", "unpack"
               , "info"
+              , "init"
               ]
           = [ ]
 


### PR DESCRIPTION
Fixes #7810.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.