### PR TITLE
Error correction on getting-started.rst page.

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -109,7 +109,7 @@ the ``executable myfirstapp`` section to include ``haskell-say``:
 .. code-block:: cabal
 
    executable myfirstapp
-       import: warnings
+--       import: warnings
        main-is: Main.hs
        build-depends:
            base ^>=4.14.3.0,


### PR DESCRIPTION
I commented "import: warnings" on line 112. That line throws an error on my fresh install, as follows:

% cabal build myfirstapp
Errors encountered when parsing cabal file ./myfirstapp.cabal:

myfirstapp.cabal:29:3: error:
Undefined common stanza imported: warnings

   28 | executable myfirstapp 
   29 |   import: warnings
      |   ^

% 

That line is not present in the docs for 3.6. I'll leave it for someone to suss out how it got added. It should probably be removed.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
I'm new, so I don't actually know for a fact that this change conforms to the above. It's a pretty simple errata which is likely terribly confusing to newbies.

Please also shortly describe how you tested your change. Bonus points for added tests!
I removed the problematic line from my own code and the myfirstapp project was successfully built when it was removed.