### PR TITLE
Update semigroups dep and bump time and text deps on Hackage

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -68,7 +68,7 @@ library
   if !impl(ghc >= 8.0)
     -- at least one of lib:Cabal's dependency (i.e. `parsec`)
     -- already depends on `fail` and `semigroups` transitively
-    build-depends: fail == 4.9.*, semigroups >= 0.18.3 && < 0.20
+    build-depends: fail == 4.9.*, semigroups >= 0.18.3 && < 0.21
 
   if !impl(ghc >= 7.10)
     build-depends: void >= 0.7.3 && < 0.8


### PR DESCRIPTION
On request of devs using Cabal sources, I'm updating semigroups dep and I will bump semigroups, time and text deps on Hackage, as a revision (and backport, as needed, to 3.6; `time` bump is already in 3.6).