### PR TITLE
Update #7874: Add test, fix changelog

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -215,8 +215,6 @@
     ([#5431](https://github.com/haskell/cabal/pull/5431)).
   * Pass command line arguments to `hsc2hs` using response files when possible
     ([#3122](https://github.com/haskell/cabal/issues/3122)).
-  * `ghc-options` and `--with-gcc` are now passed to GHC when compiling
-    C and C++ sources ([#4439](https://github.com/haskell/cabal/issues/4439)).
 
 ----
 

--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -215,6 +215,8 @@
     ([#5431](https://github.com/haskell/cabal/pull/5431)).
   * Pass command line arguments to `hsc2hs` using response files when possible
     ([#3122](https://github.com/haskell/cabal/issues/3122)).
+  * `ghc-options` and `--with-gcc` are now passed to GHC when compiling
+    C and C++ sources ([#4439](https://github.com/haskell/cabal/issues/4439)).
 
 ----
 

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -301,7 +301,10 @@ componentCcGhcOptions verbosity _implInfo lbi bi clbi odir filename =
                                   NormalDebugInfo  -> ["-g"]
                                   MaximalDebugInfo -> ["-g3"]) ++
                                   ccOptions bi,
-      ghcOptObjDir         = toFlag odir
+      ghcOptCcProgram      = maybeToFlag $ programPath <$>
+                                 lookupProgram gccProgram (withPrograms lbi),
+      ghcOptObjDir         = toFlag odir,
+      ghcOptExtra          = hcOptions GHC bi
     }
 
 
@@ -337,7 +340,10 @@ componentCxxGhcOptions verbosity _implInfo lbi bi clbi odir filename =
                                   NormalDebugInfo  -> ["-g"]
                                   MaximalDebugInfo -> ["-g3"]) ++
                                   cxxOptions bi,
-      ghcOptObjDir         = toFlag odir
+      ghcOptCcProgram      = maybeToFlag $ programPath <$>
+                                 lookupProgram gccProgram (withPrograms lbi),
+      ghcOptObjDir         = toFlag odir,
+      ghcOptExtra          = hcOptions GHC bi
     }
 
 

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -446,6 +446,9 @@ data GhcOptions = GhcOptions {
   -- | Extra header files to include for old-style FFI; the @ghc -#include@ flag.
   ghcOptFfiIncludes    :: NubListR FilePath,
 
+  -- | Program to use for the C and C++ compiler; the @ghc -pgmc@ flag.
+  ghcOptCcProgram      :: Flag FilePath,
+
   ----------------------------
   -- Language and extensions
 
@@ -691,6 +694,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
                 _ -> "-optc"
     in [ cxxflag ++ opt | opt <- ghcOptCxxOptions opts]
   , [ "-opta" ++ opt | opt <- ghcOptAsmOptions opts]
+  , concat [ ["-pgmc", cc] | cc <- flag ghcOptCcProgram ]
 
   -----------------
   -- Linker stuff

--- a/cabal-testsuite/PackageTests/CCompilerOverride/Main.hs
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/Main.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Main (main) where
+
+foreign import ccall "foo" foo :: Int -> Int
+
+main :: IO ()
+main = do
+  let x = foo 0
+      y = x
+  let x = y
+  print x
+  pure ()

--- a/cabal-testsuite/PackageTests/CCompilerOverride/custom-cc
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/custom-cc
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if which cc >/dev/null 2>&1; then
+    cc -DNOERROR6 "${@}"
+elif which gcc >/dev/null 2>&1; then
+    gcc -DNOERROR6 "${@}"
+elif which clang >/dev/null 2>&1; then
+    clang -DNOERROR6 "${@}"
+else
+    echo "Cannot find C compiler" >&2
+    exit 1
+fi
+

--- a/cabal-testsuite/PackageTests/CCompilerOverride/custom-cc.bat
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/custom-cc.bat
@@ -1,0 +1,11 @@
+@echo OFF
+
+where /q gcc.exe
+
+IF %ERRORLEVEL% EQU 0 (
+   call gcc.exe -DNOERROR6 %*
+   EXIT /B %ERRORLEVEL%
+)
+
+ECHO "Cannot find C compiler"
+EXIT /B 1

--- a/cabal-testsuite/PackageTests/CCompilerOverride/foo.c
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/foo.c
@@ -1,0 +1,28 @@
+
+#ifndef NOERROR1
+#error "NOERROR1 was not passed"
+#endif
+
+#ifndef NOERROR2
+#error "NOERROR2 was not passed"
+#endif
+
+#ifndef NOERROR3
+#error "NOERROR3 was not passed"
+#endif
+
+#ifndef NOERROR4
+#error "NOERROR4 was not passed"
+#endif
+
+#ifndef NOERROR5
+#error "NOERROR5 was not passed"
+#endif
+
+#ifndef NOERROR6
+#error "NOERROR6 was not passed"
+#endif
+
+int foo(int x) {
+    return x + 42;
+}

--- a/cabal-testsuite/PackageTests/CCompilerOverride/my.cabal
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/my.cabal
@@ -1,0 +1,13 @@
+name:           my
+version:        0.1
+license:        BSD3
+cabal-version:  >= 1.10
+build-type:     Simple
+
+executable foo
+    default-language: Haskell2010
+    main-is:          Main.hs
+    c-sources:        foo.c
+    build-depends:    base
+    ghc-options:      -DNOERROR4
+    cc-options:       -DNOERROR5 -march=native

--- a/cabal-testsuite/PackageTests/CCompilerOverride/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/setup.cabal.out
@@ -1,0 +1,4 @@
+# Setup configure
+Configuring my-0.1...
+Warning: Instead of 'ghc-options: -DNOERROR4' use 'cpp-options: -DNOERROR4'
+# Setup build

--- a/cabal-testsuite/PackageTests/CCompilerOverride/setup.out
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/setup.out
@@ -1,0 +1,4 @@
+# Setup configure
+Configuring my-0.1...
+Warning: Instead of 'ghc-options: -DNOERROR4' use 'cpp-options: -DNOERROR4'
+# Setup build

--- a/cabal-testsuite/PackageTests/CCompilerOverride/setup.test.hs
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/setup.test.hs
@@ -4,6 +4,7 @@ import Test.Cabal.Prelude
 -- all end up routed to the C compiler. Otherwise the C file we depend on will
 -- not compile.
 main = setupAndCabalTest $ do
+  skipUnlessGhcVersion ">= 8.8"
   isWin <- isWindows
   env   <- getTestEnv
   let pwd      = testCurrentDir env

--- a/cabal-testsuite/PackageTests/CCompilerOverride/setup.test.hs
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/setup.test.hs
@@ -1,0 +1,18 @@
+import Test.Cabal.Prelude
+
+-- Test that all the respective defines -DNOERROR... specified in variosu ways
+-- all end up routed to the C compiler. Otherwise the C file we depend on will
+-- not compile.
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  env   <- getTestEnv
+  let pwd      = testCurrentDir env
+      customCC = pwd ++ "/custom-cc" ++ if isWin then ".bat" else ""
+
+  setup "configure"
+    [ "--ghc-option=-DNOERROR1"
+    , "--ghc-option=-optc=-DNOERROR2"
+    , "--ghc-option=-optP=-DNOERROR3"
+    , "--with-gcc=" ++ customCC
+    ]
+  setup "build" ["-v2"]

--- a/changelog.d/issue-4439
+++ b/changelog.d/issue-4439
@@ -1,0 +1,4 @@
+synopsis: `ghc-options` and `--with-gcc` are now passed to GHC when compiling C and C++ sources
+packages: Cabal
+issues: #4439
+prs: #5440 #7874


### PR DESCRIPTION
I have added test for #7874. It works by cabal package having a c file which will only compile if all the necessary defines are defined. I'm passing defines via various ways, including `cabal configure`, fields of cabal file and test that `gcc` is overridden by passing a custom script which defines final macro without which the c file will not compile.

The original patch seems to be working fine as without it the test doesn't pass. However, I noticed that the original patch only results in `cabal` passing `-pgmc` flag to `ghc`, thus overriding the C compiler. However original issue #4439 also mentioned the intention to override linker, which should have resulted in `-pgml` being passed to the `ghc`, but this doesn't happen in the original patch.