### PR TITLE
Fix #7712 fix #7803: do not link to other .rst files by .html links

### DIFF
--- a/doc/cabal-package.rst
+++ b/doc/cabal-package.rst
@@ -780,7 +780,7 @@ describe the package as a whole:
     A list of additional files or directories to be removed by
     :ref:`setup-clean`. These  would typically be additional files created by
     additional hooks, such as the scheme described in the section on
-    `system-dependent parameters`_
+    `system-dependent parameters`_.
 
 Library
 ^^^^^^^
@@ -2507,8 +2507,8 @@ Configuration Flags
 
     .. note::
 
-      This value may be `overridden in several
-      ways <installing-packages.html#controlling-flag-assignments>`__. The
+      This value may be :ref:`overridden in several
+      ways <controlling flag assignments>`. The
       rationale for having flags default to True is that users usually
       want new features as soon as they are available. Flags representing
       features that are not (yet) recommended for most users (such as
@@ -2621,8 +2621,7 @@ Resolution of Conditions and Flags
 """"""""""""""""""""""""""""""""""
 
 If a package descriptions specifies configuration flags the package user
-can `control these in several
-ways <installing-packages.html#controlling-flag-assignments>`__. If the
+can :ref:`control these in several ways <controlling flag assignments>`. If the
 user does not fix the value of a flag, Cabal will try to find a flag
 assignment in the following way.
 
@@ -3087,8 +3086,8 @@ Accessing data files from package code
 
 The placement on the target system of files listed in
 the :pkg-field:`data-files` field varies between systems, and in some cases
-one can even move packages around after installation (see `prefix
-independence <setup-commands.html#prefix-independence>`__). To
+one can even move packages around after installation
+(see :ref:`prefix independence`). To
 enable packages to find these files in a portable way, Cabal generates a
 module called :file:`Paths_{pkgname}` (with any hyphens in *pkgname*
 replaced by underscores) during building, so that it may be imported by
@@ -3146,7 +3145,7 @@ exports the constant ``version ::``
 which is defined as the version of your package as specified in the
 ``version`` field.
 
-.. _system-dependent-parameters:
+.. _system-dependent parameters:
 
 System-dependent parameters
 ---------------------------
@@ -3417,8 +3416,8 @@ a few options:
 
 -  Finally, with the :pkg-field:`build-type` ``Custom``, you can also write your
    own setup script from scratch. It must conform to the interface
-   described in the section on `building and installing
-   packages <installing-packages.html>`__, and you may use the Cabal
+   described in the section on :doc:`building and installing
+   packages <installing-packages>`, and you may use the Cabal
    library for all or part of the work. One option is to copy the source
    of ``Distribution.Simple``, and alter it for your needs. Good luck.
 

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -322,9 +322,9 @@ The following settings control the behavior of the dependency solver:
         constraints: bar == 2.1,
                      bar +foo -baz
 
-    Valid constraints take the same form as for the `constraint
-    command line option
-    <installing-packages.html#cmdoption-setup-configure-constraint>`__.
+    Valid constraints take the same form as for the
+    :option:`runhaskell Setup.hs configure --constraint`
+    command line option.
 
 .. cfg-field:: preferences: preference (comma separated)
                --preference="pkg >= 2.0"
@@ -721,8 +721,7 @@ feature was added.
     A list of extra arguments to pass to the external ``./configure``
     script, if one is used. This is only useful for packages which have
     the ``Configure`` build type. See also the section on
-    `system-dependent
-    parameters <developing-packages.html#system-dependent-parameters>`__.
+    :ref:`system-dependent parameters`.
 
     The command line variant of this flag is ``--configure-option=arg``,
     which can be specified multiple times to pass multiple options.

--- a/doc/developing-packages.rst
+++ b/doc/developing-packages.rst
@@ -2,7 +2,7 @@ Quickstart
 ==========
 
 .. TIP::
-    If this is your first time using `cabal` you should check out the `Getting Started guide <getting-started.html>`__.
+    If this is your first time using `cabal` you should check out the :doc:`Getting Started guide <getting-started>`.
 
 Starting from scratch, we're going to walk you through creating a simple
 Haskell application.

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -61,7 +61,7 @@ little bit when we add an external dependency to our package.
 Running the application
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-When we ran ``cabal init myfirstapp -n`` above, it generated a package with a single 
+When we ran ``cabal init myfirstapp -n`` above, it generated a package with a single
 executable named same as the package (in this case ``myfirstapp``) that prints
 ``"Hello, Haskell!"`` to the terminal. To run the executable enter the project's
 directory and run it, by inputting the following commands:
@@ -116,7 +116,7 @@ the ``executable myfirstapp`` section to include ``haskell-say``:
            haskell-say ^>=1.0.0.0
        hs-source-dirs: app
        default-language: Haskell2010
-       
+
 
 .. NOTE::
    ``^>=1.0.0.0`` means use version 1.0.0.0 of the library or any more recent
@@ -173,4 +173,4 @@ What Next?
 Now that you know how to set up a simple Haskell package using Cabal, check out
 some of the resources on the Haskell website's `documentation page
 <https://www.haskell.org/documentation/>`__ or read more about packages and
-Cabal on the `introduction <intro.html>`__ page.
+Cabal on the :doc:`introduction <intro>` page.

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -102,8 +102,8 @@ which Haskell implementation to use and whether to build optimised code
 or build with the ability to profile code. It is not expected that users
 will have to modify any of the information in the ``.cabal`` file.
 
-For full details, see the section on `building and installing
-packages <installing-packages.html>`__.
+For full details, see the section on :doc:`building and installing
+packages <installing-packages>`.
 
 Note that ``cabal`` is not the only tool for working with Cabal
 packages. Due to the standardised format and a library for reading
@@ -125,7 +125,7 @@ the package depends on.
 
 For full details on what goes in the ``.cabal`` and ``Setup.hs`` files,
 and for all the other features provided by the build system, see the
-section on `developing packages <developing-packages.html>`__.
+section on :doc:`developing packages <developing-packages>`.
 
 Cabal featureset
 ----------------

--- a/doc/nix-local-build.rst
+++ b/doc/nix-local-build.rst
@@ -5,7 +5,7 @@ Quickstart
 
 Suppose that you are in a directory containing a single Cabal package
 which you wish to build (if you haven't set up a package yet check
-out `developing packages <developing-packages.html>`__ for
+out :doc:`developing packages <developing-packages>` for
 instructions). You can configure and build it using Nix-style
 local builds with this command (configuring is not necessary):
 

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -108,7 +108,7 @@ the values supplied via these options are recorded in a private file
 read by later stages.
 
 If a user-supplied ``configure`` script is run (see the section on
-:ref:`system-dependent-parameters` or
+:ref:`system-dependent parameters` or
 on :ref:`more-complex-packages`), it is
 passed the :option:`--with-hc-pkg`, :option:`--prefix`, :option:`--bindir`,
 :option:`--libdir`, :option:`--dynlibdir`, :option:`--datadir`, :option:`--libexecdir` and
@@ -376,8 +376,7 @@ used when specifying installation paths. The defaults are also specified
 in terms of these variables. A number of the variables are actually for
 other paths, like ``$prefix``. This allows paths to be specified
 relative to each other rather than as absolute paths, which is important
-for building relocatable packages (see `prefix
-independence <#prefix-independence>`__).
+for building relocatable packages (see :ref:`prefix independence`).
 
 $prefix
     The path variable that stands for the root of the installation. For
@@ -479,14 +478,16 @@ For the simple build system, the following defaults apply:
       - (empty)
       - (empty)
 
-Prefix-independence
+.. _prefix independence:
+
+Prefix independence
 """""""""""""""""""
 
 On Windows it is possible to obtain the pathname of the running program.
 This means that we can construct an installable executable package that
 is independent of its absolute install location. The executable can find
 its auxiliary files by finding its own path and knowing the location of
-the other files relative to ``$bindir``. Prefix-independence is
+the other files relative to ``$bindir``. Prefix independence is
 particularly useful: it means the user can choose the install location
 (i.e. the value of ``$prefix``) at install-time, rather than having to
 bake the path into the binary when it is built.
@@ -496,16 +497,17 @@ all of ``$bindir``, ``$libdir``, ``$dynlibdir``, ``$datadir`` and ``$libexecdir`
 with ``$prefix``. If this is not the case then the compiled executable
 will have baked-in all absolute paths.
 
-The application need do nothing special to achieve prefix-independence.
+The application need do nothing special to achieve prefix independence.
 If it finds any files using ``getDataFileName`` and the :ref:`other functions
-provided for the
-purpose <accessing-data-files>`,
+provided for the purpose <accessing-data-files>`,
 the files will be accessed relative to the location of the current
 executable.
 
-A library cannot (currently) be prefix-independent, because it will be
+A library cannot (currently) be prefix independent, because it will be
 linked into an executable whose file system location bears no relation
 to the library package.
+
+.. _controlling flag assignments:
 
 Controlling Flag Assignments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -817,7 +819,7 @@ Miscellaneous options
 .. option:: --configure-option=str
 
     An extra option to an external ``configure`` script, if one is used
-    (see the section on :ref:`system-dependent-parameters`).
+    (see the section on :ref:`system-dependent parameters`).
     There can be several of these options.
 
 .. option:: --extra-include-dirs[=dir]


### PR DESCRIPTION
Fix #7712 fix #7803: do not link to other `.rst` files by `.html` links.

Links to `.html` files are not checked by sphinx and thus bit-rot.
Rather, link by `:ref:`, `:doc:`, `:option:` etc.

This commit does not address the links of the form

    ../release/cabal-latest/doc/API/**.html

which I do not know how to handle.  These are all broken on `readthedocs.org` and I have no clue how these were supposed to work.

