### PR TITLE
Re #7916: haddockumentation of Distribution.Types.VersionInterval.Legacy

### DIFF
--- a/Cabal/src/Distribution/Types/VersionRange/Internal.hs
+++ b/Cabal/src/Distribution/Types/VersionRange/Internal.hs
@@ -168,14 +168,14 @@ majorBoundVersion = MajorBoundVersion
 --
 -- @since 2.2
 data VersionRangeF a
-  = ThisVersionF            Version -- = version
-  | LaterVersionF           Version -- > version  (NB. not >=)
-  | OrLaterVersionF         Version -- >= version
-  | EarlierVersionF         Version -- < version
-  | OrEarlierVersionF       Version -- <= version
-  | MajorBoundVersionF      Version -- @^>= ver@ (same as >= ver && < MAJ(ver)+1)
-  | UnionVersionRangesF     a a
-  | IntersectVersionRangesF a a
+  = ThisVersionF            Version -- ^ @== version@.
+  | LaterVersionF           Version -- ^ @>  version@.   NB: not @>=@
+  | OrLaterVersionF         Version -- ^ @>= version@.
+  | EarlierVersionF         Version -- ^ @<  version@.
+  | OrEarlierVersionF       Version -- ^ @<= version@.
+  | MajorBoundVersionF      Version -- ^ @^>= version@, same as @>= version && < MAJ(version)+1@.
+  | UnionVersionRangesF     a a     -- ^ @||@.
+  | IntersectVersionRangesF a a     -- ^ @&&@.
   deriving ( Data, Eq, Generic, Read, Show, Typeable
            , Functor, Foldable, Traversable )
 


### PR DESCRIPTION
Re #7916: `haddockumentation of Distribution.Types.VersionInterval.Legacy`

This commit affects only comments and documentation comments.

- clarifies existing haddock for `Distribution.Types.VersionInterval.Legacy`
- emphasizes the mathematical structure: canonical Boolean algebra
- adds docs when they were missing
- add some asymptotic complexity estimates
- add comments in the code that explain its function

Note: this module is declared "legacy", but the documentation effort
here can be salvaged to non-legacy code once #7916 is resolved.

