### PR TITLE
Fix concurrency/exception bugs in asyncFetchPackages

### DIFF
--- a/bootstrap/linux-8.10.7.json
+++ b/bootstrap/linux-8.10.7.json
@@ -255,6 +255,15 @@
             "version": "0.1.2.0"
         },
         {
+            "cabal_sha256": "8bc9cd9991863a238b3531dfc663f262016adbbd814f30b1c63a6ce914ff7906",
+            "revision": 0,
+            "src_sha256": "69637f794146a8e7bfbc2db2bd0501c274ec99504b597728e203187790064895",
+            "flags": [],
+            "package": "safe-exceptions",
+            "source": "hackage",
+            "version": "0.1.7.2"
+        },
+        {
             "cabal_sha256": "b83dec34a53520de84c6dd3dc7aae45d22409b46eb471c478b98108215a370f0",
             "revision": 1,
             "src_sha256": "484df85be0e76c4fed9376451e48e1d0c6e97952ce79735b72d54297e7e0a725",

--- a/bootstrap/linux-8.6.5.json
+++ b/bootstrap/linux-8.6.5.json
@@ -255,17 +255,6 @@
             "version": "0.1.2.0"
         },
         {
-            "cabal_sha256": "b83dec34a53520de84c6dd3dc7aae45d22409b46eb471c478b98108215a370f0",
-            "revision": 1,
-            "src_sha256": "484df85be0e76c4fed9376451e48e1d0c6e97952ce79735b72d54297e7e0a725",
-            "flags": [
-                "-bench"
-            ],
-            "package": "async",
-            "source": "hackage",
-            "version": "2.2.4"
-        },
-        {
             "cabal_sha256": "7ed09aed03683d5b4337088061106c2389d274b3472031a330ff1b220bad2b2d",
             "revision": 3,
             "src_sha256": "4d0bfb4355cffcd67d300811df9d5fe44ea3594ed63750795bfc1f797abd84cf",
@@ -275,6 +264,26 @@
             "package": "exceptions",
             "source": "hackage",
             "version": "0.10.4"
+        },
+        {
+            "cabal_sha256": "8bc9cd9991863a238b3531dfc663f262016adbbd814f30b1c63a6ce914ff7906",
+            "revision": 0,
+            "src_sha256": "69637f794146a8e7bfbc2db2bd0501c274ec99504b597728e203187790064895",
+            "flags": [],
+            "package": "safe-exceptions",
+            "source": "hackage",
+            "version": "0.1.7.2"
+        },
+        {
+            "cabal_sha256": "b83dec34a53520de84c6dd3dc7aae45d22409b46eb471c478b98108215a370f0",
+            "revision": 1,
+            "src_sha256": "484df85be0e76c4fed9376451e48e1d0c6e97952ce79735b72d54297e7e0a725",
+            "flags": [
+                "-bench"
+            ],
+            "package": "async",
+            "source": "hackage",
+            "version": "2.2.4"
         },
         {
             "cabal_sha256": null,

--- a/bootstrap/linux-8.8.4.json
+++ b/bootstrap/linux-8.8.4.json
@@ -255,17 +255,6 @@
             "version": "0.1.2.0"
         },
         {
-            "cabal_sha256": "b83dec34a53520de84c6dd3dc7aae45d22409b46eb471c478b98108215a370f0",
-            "revision": 1,
-            "src_sha256": "484df85be0e76c4fed9376451e48e1d0c6e97952ce79735b72d54297e7e0a725",
-            "flags": [
-                "-bench"
-            ],
-            "package": "async",
-            "source": "hackage",
-            "version": "2.2.4"
-        },
-        {
             "cabal_sha256": "7ed09aed03683d5b4337088061106c2389d274b3472031a330ff1b220bad2b2d",
             "revision": 3,
             "src_sha256": "4d0bfb4355cffcd67d300811df9d5fe44ea3594ed63750795bfc1f797abd84cf",
@@ -275,6 +264,26 @@
             "package": "exceptions",
             "source": "hackage",
             "version": "0.10.4"
+        },
+        {
+            "cabal_sha256": "8bc9cd9991863a238b3531dfc663f262016adbbd814f30b1c63a6ce914ff7906",
+            "revision": 0,
+            "src_sha256": "69637f794146a8e7bfbc2db2bd0501c274ec99504b597728e203187790064895",
+            "flags": [],
+            "package": "safe-exceptions",
+            "source": "hackage",
+            "version": "0.1.7.2"
+        },
+        {
+            "cabal_sha256": "b83dec34a53520de84c6dd3dc7aae45d22409b46eb471c478b98108215a370f0",
+            "revision": 1,
+            "src_sha256": "484df85be0e76c4fed9376451e48e1d0c6e97952ce79735b72d54297e7e0a725",
+            "flags": [
+                "-bench"
+            ],
+            "package": "async",
+            "source": "hackage",
+            "version": "2.2.4"
         },
         {
             "cabal_sha256": null,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -226,7 +226,8 @@ library
         text       >= 1.2.3    && < 1.3,
         parsec     >= 3.1.13.0 && < 3.2,
         regex-base  >= 0.94.0.0 && <0.95,
-        regex-posix >= 0.96.0.0 && <0.97
+        regex-posix >= 0.96.0.0 && <0.97,
+        safe-exceptions >= 0.1.7.0 && < 0.2
 
     if flag(native-dns)
       if os(windows)

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -209,7 +209,7 @@ library
         directory  >= 1.2.2.0  && < 1.4,
         echo       >= 0.1.3    && < 0.2,
         edit-distance >= 0.2.2 && < 0.3,
-        exceptions,
+        exceptions >= 0.10.4   && < 0.11,
         filepath   >= 1.4.0.0  && < 1.5,
         hashable   >= 1.0      && < 1.4,
         HTTP       >= 4000.1.5 && < 4000.4,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -275,10 +275,11 @@ Test-Suite unit-tests
       UnitTests.Distribution.Client.ArbitraryInstances
       UnitTests.Distribution.Client.BuildReport
       UnitTests.Distribution.Client.Configure
-      UnitTests.Distribution.Client.Targets
       UnitTests.Distribution.Client.Get
       UnitTests.Distribution.Client.Glob
       UnitTests.Distribution.Client.GZipUtils
+      UnitTests.Distribution.Client.IndexUtils
+      UnitTests.Distribution.Client.IndexUtils.Timestamp
       UnitTests.Distribution.Client.Init
       UnitTests.Distribution.Client.Init.Golden
       UnitTests.Distribution.Client.Init.Interactive
@@ -286,16 +287,15 @@ Test-Suite unit-tests
       UnitTests.Distribution.Client.Init.Simple
       UnitTests.Distribution.Client.Init.Utils
       UnitTests.Distribution.Client.Init.FileCreators
-      UnitTests.Distribution.Client.Store
-      UnitTests.Distribution.Client.Tar
-      UnitTests.Distribution.Client.TreeDiffInstances
-      UnitTests.Distribution.Client.UserConfig
+      UnitTests.Distribution.Client.InstallPlan
+      UnitTests.Distribution.Client.JobControl
       UnitTests.Distribution.Client.ProjectConfig
       UnitTests.Distribution.Client.ProjectPlanning
-      UnitTests.Distribution.Client.JobControl
-      UnitTests.Distribution.Client.IndexUtils
-      UnitTests.Distribution.Client.IndexUtils.Timestamp
-      UnitTests.Distribution.Client.InstallPlan
+      UnitTests.Distribution.Client.Store
+      UnitTests.Distribution.Client.Tar
+      UnitTests.Distribution.Client.Targets
+      UnitTests.Distribution.Client.TreeDiffInstances
+      UnitTests.Distribution.Client.UserConfig
       UnitTests.Distribution.Solver.Modular.Builder
       UnitTests.Distribution.Solver.Modular.RetryLog
       UnitTests.Distribution.Solver.Modular.Solver

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -275,6 +275,7 @@ Test-Suite unit-tests
       UnitTests.Distribution.Client.ArbitraryInstances
       UnitTests.Distribution.Client.BuildReport
       UnitTests.Distribution.Client.Configure
+      UnitTests.Distribution.Client.FetchUtils
       UnitTests.Distribution.Client.Get
       UnitTests.Distribution.Client.Glob
       UnitTests.Distribution.Client.GZipUtils

--- a/cabal-install/src/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/src/Distribution/Client/FetchUtils.hs
@@ -227,7 +227,10 @@ type AsyncFetchMap = Map UnresolvedPkgLoc
 --
 -- The body action is passed a map from those packages (identified by their
 -- location) to a completion var for that package. So the body action should
--- lookup the location and use 'asyncFetchPackage' to get the result.
+-- lookup the location and use 'waitAsyncFetchPackage' to get the result.
+--
+-- Synchronous exceptions raised by the download actions are delivered
+-- via 'waitAsyncFetchPackage'.
 --
 asyncFetchPackages :: Verbosity
                    -> RepoContext

--- a/cabal-install/src/Distribution/Client/Types/RepoName.hs
+++ b/cabal-install/src/Distribution/Client/Types/RepoName.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Distribution.Client.Types.RepoName (
     RepoName (..),
-    unRepoName,
 ) where
 
 import Distribution.Client.Compat.Prelude
@@ -17,11 +16,8 @@ import qualified Text.PrettyPrint                as Disp
 --
 -- May be used as path segment.
 --
-newtype RepoName = RepoName String
+newtype RepoName = RepoName { unRepoName :: String }
   deriving (Show, Eq, Ord, Generic)
-
-unRepoName :: RepoName -> String
-unRepoName (RepoName n) = n
 
 instance Binary RepoName
 instance Structured RepoName

--- a/cabal-install/src/Distribution/Client/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Utils.hs
@@ -49,7 +49,9 @@ import Data.List
          ( groupBy )
 import Foreign.C.Types ( CInt(..) )
 import qualified Control.Exception as Exception
-         ( finally, bracket )
+         ( finally )
+import qualified Control.Exception.Safe as Safe
+         ( bracket )
 import System.Directory
          ( canonicalizePath, doesFileExist, findExecutable, getCurrentDirectory
          , removeFile, setCurrentDirectory, getDirectoryContents, doesDirectoryExist )
@@ -118,7 +120,7 @@ withTempFileName :: FilePath
                  -> String
                  -> (FilePath -> IO a) -> IO a
 withTempFileName tmpDir template action =
-  Exception.bracket
+  Safe.bracket
     (openTempFile tmpDir template)
     (\(name, _) -> removeExistingFile name)
     (\(name, h) -> hClose h >> action name)

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 
 import qualified UnitTests.Distribution.Client.BuildReport
 import qualified UnitTests.Distribution.Client.Configure
+import qualified UnitTests.Distribution.Client.FetchUtils
 import qualified UnitTests.Distribution.Client.Get
 import qualified UnitTests.Distribution.Client.Glob
 import qualified UnitTests.Distribution.Client.GZipUtils
@@ -33,6 +34,8 @@ main = do
         UnitTests.Distribution.Client.BuildReport.tests
     , testGroup "UnitTests.Distribution.Client.Configure"
         UnitTests.Distribution.Client.Configure.tests
+    , testGroup "UnitTests.Distribution.Client.FetchUtils"
+        UnitTests.Distribution.Client.FetchUtils.tests
     , testGroup "UnitTests.Distribution.Client.Get"
         UnitTests.Distribution.Client.Get.tests
     , testGroup "UnitTests.Distribution.Client.Glob"

--- a/cabal-install/tests/UnitTests.hs
+++ b/cabal-install/tests/UnitTests.hs
@@ -3,49 +3,56 @@ module Main (main) where
 
 import Test.Tasty
 
-import qualified UnitTests.Distribution.Solver.Modular.Builder
-import qualified UnitTests.Distribution.Solver.Modular.WeightedPSQ
-import qualified UnitTests.Distribution.Solver.Modular.Solver
-import qualified UnitTests.Distribution.Solver.Modular.RetryLog
-import qualified UnitTests.Distribution.Solver.Types.OptionalStanza
 import qualified UnitTests.Distribution.Client.BuildReport
 import qualified UnitTests.Distribution.Client.Configure
+import qualified UnitTests.Distribution.Client.Get
 import qualified UnitTests.Distribution.Client.Glob
 import qualified UnitTests.Distribution.Client.GZipUtils
-import qualified UnitTests.Distribution.Client.Store
-import qualified UnitTests.Distribution.Client.Tar
-import qualified UnitTests.Distribution.Client.Targets
-import qualified UnitTests.Distribution.Client.UserConfig
-import qualified UnitTests.Distribution.Client.ProjectConfig
-import qualified UnitTests.Distribution.Client.ProjectPlanning
-import qualified UnitTests.Distribution.Client.JobControl
 import qualified UnitTests.Distribution.Client.IndexUtils
 import qualified UnitTests.Distribution.Client.IndexUtils.Timestamp
 import qualified UnitTests.Distribution.Client.Init
 import qualified UnitTests.Distribution.Client.InstallPlan
-import qualified UnitTests.Distribution.Client.Get
+import qualified UnitTests.Distribution.Client.JobControl
+import qualified UnitTests.Distribution.Client.ProjectConfig
+import qualified UnitTests.Distribution.Client.ProjectPlanning
+import qualified UnitTests.Distribution.Client.Store
+import qualified UnitTests.Distribution.Client.Tar
+import qualified UnitTests.Distribution.Client.Targets
+import qualified UnitTests.Distribution.Client.UserConfig
+import qualified UnitTests.Distribution.Solver.Modular.Builder
+import qualified UnitTests.Distribution.Solver.Modular.RetryLog
+import qualified UnitTests.Distribution.Solver.Modular.Solver
+import qualified UnitTests.Distribution.Solver.Modular.WeightedPSQ
+import qualified UnitTests.Distribution.Solver.Types.OptionalStanza
 
 main :: IO ()
 main = do
   initTests <- UnitTests.Distribution.Client.Init.tests
   defaultMain $ testGroup "Unit Tests"
-    [ testGroup "UnitTests.Distribution.Solver.Modular.Builder"
-          UnitTests.Distribution.Solver.Modular.Builder.tests
-    , testGroup "UnitTests.Distribution.Solver.Modular.WeightedPSQ"
-          UnitTests.Distribution.Solver.Modular.WeightedPSQ.tests
-    , testGroup "UnitTests.Distribution.Solver.Modular.Solver"
-          UnitTests.Distribution.Solver.Modular.Solver.tests
-    , testGroup "UnitTests.Distribution.Solver.Modular.RetryLog"
-          UnitTests.Distribution.Solver.Modular.RetryLog.tests
-    , UnitTests.Distribution.Solver.Types.OptionalStanza.tests
-    , testGroup "UnitTests.Distribution.Client.Glob"
-          UnitTests.Distribution.Client.Glob.tests
+    [ testGroup "UnitTests.Distribution.Client.BuildReport"
+        UnitTests.Distribution.Client.BuildReport.tests
     , testGroup "UnitTests.Distribution.Client.Configure"
         UnitTests.Distribution.Client.Configure.tests
+    , testGroup "UnitTests.Distribution.Client.Get"
+        UnitTests.Distribution.Client.Get.tests
+    , testGroup "UnitTests.Distribution.Client.Glob"
+        UnitTests.Distribution.Client.Glob.tests
     , testGroup "Distribution.Client.GZipUtils"
         UnitTests.Distribution.Client.GZipUtils.tests
+    , testGroup "UnitTests.Distribution.Client.IndexUtils"
+        UnitTests.Distribution.Client.IndexUtils.tests
+    , testGroup "UnitTests.Distribution.Client.IndexUtils.Timestamp"
+        UnitTests.Distribution.Client.IndexUtils.Timestamp.tests
     , testGroup "Distribution.Client.Init"
         initTests
+    , testGroup "UnitTests.Distribution.Client.InstallPlan"
+        UnitTests.Distribution.Client.InstallPlan.tests
+    , testGroup "UnitTests.Distribution.Client.JobControl"
+        UnitTests.Distribution.Client.JobControl.tests
+    , testGroup "UnitTests.Distribution.Client.ProjectConfig"
+        UnitTests.Distribution.Client.ProjectConfig.tests
+    , testGroup "UnitTests.Distribution.Client.ProjectPlanning"
+        UnitTests.Distribution.Client.ProjectPlanning.tests
     , testGroup "Distribution.Client.Store"
         UnitTests.Distribution.Client.Store.tests
     , testGroup "Distribution.Client.Tar"
@@ -54,20 +61,14 @@ main = do
         UnitTests.Distribution.Client.Targets.tests
     , testGroup "UnitTests.Distribution.Client.UserConfig"
         UnitTests.Distribution.Client.UserConfig.tests
-    , testGroup "UnitTests.Distribution.Client.ProjectConfig"
-        UnitTests.Distribution.Client.ProjectConfig.tests
-    , testGroup "UnitTests.Distribution.Client.ProjectPlanning"
-        UnitTests.Distribution.Client.ProjectPlanning.tests
-    , testGroup "UnitTests.Distribution.Client.JobControl"
-        UnitTests.Distribution.Client.JobControl.tests
-    , testGroup "UnitTests.Distribution.Client.IndexUtils"
-        UnitTests.Distribution.Client.IndexUtils.tests
-    , testGroup "UnitTests.Distribution.Client.IndexUtils.Timestamp"
-        UnitTests.Distribution.Client.IndexUtils.Timestamp.tests
-    , testGroup "UnitTests.Distribution.Client.InstallPlan"
-        UnitTests.Distribution.Client.InstallPlan.tests
-    , testGroup "UnitTests.Distribution.Client.Get"
-        UnitTests.Distribution.Client.Get.tests
-    , UnitTests.Distribution.Client.BuildReport.tests
-
+    , testGroup "UnitTests.Distribution.Solver.Modular.Builder"
+        UnitTests.Distribution.Solver.Modular.Builder.tests
+    , testGroup "UnitTests.Distribution.Solver.Modular.RetryLog"
+        UnitTests.Distribution.Solver.Modular.RetryLog.tests
+    , testGroup "UnitTests.Distribution.Solver.Modular.Solver"
+        UnitTests.Distribution.Solver.Modular.Solver.tests
+    , testGroup "UnitTests.Distribution.Solver.Modular.WeightedPSQ"
+        UnitTests.Distribution.Solver.Modular.WeightedPSQ.tests
+    , testGroup "UnitTests.Distribution.Solver.Types.OptionalStanza"
+        UnitTests.Distribution.Solver.Types.OptionalStanza.tests
     ]

--- a/cabal-install/tests/UnitTests/Distribution/Client/BuildReport.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/BuildReport.hs
@@ -9,7 +9,7 @@ import UnitTests.Distribution.Client.TreeDiffInstances ()
 
 import Data.TreeDiff.QuickCheck (ediffEq)
 import Test.QuickCheck          (Property, counterexample)
-import Test.Tasty               (TestTree, testGroup)
+import Test.Tasty               (TestTree)
 import Test.Tasty.QuickCheck    (testProperty)
 
 import Distribution.Client.BuildReports.Anonymous (BuildReport, parseBuildReport, showBuildReport)
@@ -18,8 +18,8 @@ import Distribution.Simple.Utils                  (toUTF8BS)
 -- instances
 import Test.QuickCheck.Instances.Cabal ()
 
-tests :: TestTree
-tests = testGroup "BuildReport"
+tests :: [TestTree]
+tests =
     [ testProperty "test" roundtrip
     ]
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/FetchUtils.hs
@@ -1,0 +1,209 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module UnitTests.Distribution.Client.FetchUtils
+  ( tests,
+  )
+where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception
+import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
+import Distribution.Client.FetchUtils
+import Distribution.Client.GlobalFlags (RepoContext (..))
+import Distribution.Client.HttpUtils (HttpCode, HttpTransport (..))
+import Distribution.Client.Types.PackageLocation (PackageLocation (..), ResolvedPkgLoc)
+import Distribution.Client.Types.Repo (Repo (..), emptyRemoteRepo)
+import Distribution.Client.Types.RepoName (RepoName (..))
+import Distribution.Types.PackageId (PackageIdentifier (..))
+import Distribution.Types.PackageName (mkPackageName)
+import qualified Distribution.Verbosity as Verbosity
+import Distribution.Version (mkVersion)
+import Network.URI (URI, uriPath)
+import Test.Tasty
+import Test.Tasty.HUnit
+import UnitTests.TempTestDir (withTestDir)
+
+tests :: [TestTree]
+tests =
+  [ testGroup
+      "asyncFetchPackages"
+      [ testCase "handles an empty package list" testEmpty,
+        testCase "passes an unpacked local package through" testPassLocalPackage,
+        testCase "handles http" testHttp,
+        testCase "aborts on interrupt in GET" $ testGetInterrupt,
+        testCase "aborts on other exception in GET" $ testGetException,
+        testCase "aborts on interrupt in GET (uncollected download)" $ testUncollectedInterrupt,
+        testCase "continues on other exception in GET (uncollected download)" $ testUncollectedException
+      ]
+  ]
+
+verbosity :: Verbosity.Verbosity
+verbosity = Verbosity.silent
+
+-- | An interval that we use to assert that something happens "immediately".
+-- Must be shorter than 'longSleep' to ensure those are interrupted.
+-- 1s would be a reasonable value, but failed tempfile cleanup on Windows CI
+-- takes ~1s.
+shortDelta :: NominalDiffTime
+shortDelta = 5 -- 5s
+
+longSleep :: IO ()
+longSleep = threadDelay 10000000 -- 10s
+
+testEmpty :: Assertion
+testEmpty = do
+  let repoCtxt = undefined
+      pkgLocs = []
+  res <- asyncFetchPackages verbosity repoCtxt pkgLocs $ \_ ->
+    return ()
+  res @?= ()
+
+testPassLocalPackage :: Assertion
+testPassLocalPackage = do
+  let repoCtxt = error "repoCtxt undefined"
+      loc = LocalUnpackedPackage "a"
+  res <- asyncFetchPackages verbosity repoCtxt [loc] $ \downloadMap ->
+    waitAsyncFetchPackage verbosity downloadMap loc
+  res @?= LocalUnpackedPackage "a"
+
+testHttp :: Assertion
+testHttp = withFakeRepoCtxt get200 $ \repoCtxt repo -> do
+  let pkgId = mkPkgId "foo"
+      loc = RepoTarballPackage repo pkgId Nothing
+  res <- asyncFetchPackages verbosity repoCtxt [loc] $ \downloadMap ->
+    waitAsyncFetchPackage verbosity downloadMap loc
+  case res of
+    RepoTarballPackage repo' pkgId' _ -> do
+      repo' @?= repo
+      pkgId' @?= pkgId
+    _ -> assertFailure $ "expected RepoTarballPackage, got " ++ show res
+  where
+    get200 = \_uri -> return 200
+
+testGetInterrupt :: Assertion
+testGetInterrupt = testGetAny UserInterrupt
+
+testGetException :: Assertion
+testGetException = testGetAny $ userError "some error"
+
+-- | Test that if a GET request fails with the given exception,
+-- we exit promptly. We queue two slow downloads after the failing
+-- download to cover a buggy scenario where
+-- 1. first download throws
+-- 2. second download is cancelled, but swallows AsyncCancelled
+-- 3. third download keeps running
+testGetAny :: Exception e => e -> Assertion
+testGetAny exc = withFakeRepoCtxt get $ \repoCtxt repo -> do
+  let loc pkgId = RepoTarballPackage repo pkgId Nothing
+      pkgLocs = [loc throws, loc slowA, loc slowB]
+
+  start <- getCurrentTime
+  res :: Either SomeException ResolvedPkgLoc <-
+    try $
+      asyncFetchPackages verbosity repoCtxt pkgLocs $ \downloadMap -> do
+        waitAsyncFetchPackage verbosity downloadMap (loc throws)
+  assertFaster start shortDelta
+  case res of
+    Left _ -> pure ()
+    Right _ -> assertFailure $ "expected an exception, got " ++ show res
+  where
+    throws = mkPkgId "throws"
+    slowA = mkPkgId "slowA"
+    slowB = mkPkgId "slowB"
+    get uri = case uriPath uri of
+      "package/throws-1.0.tar.gz" -> throwIO exc
+      "package/slowA-1.0.tar.gz" -> longSleep >> return 200
+      "package/slowB-1.0.tar.gz" -> longSleep >> return 200
+      _ -> assertFailure $ "unexpected URI: " ++ show uri
+
+-- | Test that when an undemanded download is interrupted (Ctrl-C),
+-- we still abort directly.
+testUncollectedInterrupt :: Assertion
+testUncollectedInterrupt = withFakeRepoCtxt get $ \repoCtxt repo -> do
+  let loc pkgId = RepoTarballPackage repo pkgId Nothing
+      pkgLocs = [loc throws, loc slowA, loc slowB]
+
+  start <- getCurrentTime
+  res :: Either SomeException ResolvedPkgLoc <-
+    try $
+      asyncFetchPackages verbosity repoCtxt pkgLocs $ \downloadMap -> do
+        waitAsyncFetchPackage verbosity downloadMap (loc slowA)
+  assertFaster start shortDelta
+  case res of
+    Left _ -> pure ()
+    Right _ -> assertFailure $ "expected an exception, got " ++ show res
+  where
+    throws = mkPkgId "throws"
+    slowA = mkPkgId "slowA"
+    slowB = mkPkgId "slowB"
+    get uri = case uriPath uri of
+      "package/throws-1.0.tar.gz" -> throwIO UserInterrupt
+      "package/slowA-1.0.tar.gz" -> longSleep >> return 200
+      "package/slowB-1.0.tar.gz" -> longSleep >> return 200
+      _ -> assertFailure $ "unexpected URI: " ++ show uri
+
+-- | Test that a download failure doesn't automatically abort things,
+-- e.g. if we don't collect the download. (In practice, we might collect
+-- the download and handle its exception.)
+testUncollectedException :: Assertion
+testUncollectedException = withFakeRepoCtxt get $ \repoCtxt repo -> do
+  let loc pkgId = RepoTarballPackage repo pkgId Nothing
+      pkgLocs = [loc throws, loc foo]
+
+  start <- getCurrentTime
+  res <- asyncFetchPackages verbosity repoCtxt pkgLocs $ \downloadMap -> do
+    waitAsyncFetchPackage verbosity downloadMap (loc foo)
+  assertFaster start shortDelta
+  case res of
+    RepoTarballPackage repo' pkgId' _ -> do
+      repo' @?= repo
+      pkgId' @?= foo
+    _ -> assertFailure $ "expected RepoTarballPackage, got " ++ show res
+  where
+    throws = mkPkgId "throws"
+    foo = mkPkgId "foo"
+    get uri = case uriPath uri of
+      "package/throws-1.0.tar.gz" -> throwIO $ userError "failed download"
+      "package/foo-1.0.tar.gz" -> return 200
+      _ -> assertFailure $ "unexpected URI: " ++ show uri
+
+assertFaster :: UTCTime -> NominalDiffTime -> Assertion
+assertFaster start delta = do
+  t <- getCurrentTime
+  assertBool ("took longer than " ++ show delta) (diffUTCTime t start < delta)
+
+mkPkgId :: String -> PackageIdentifier
+mkPkgId name = PackageIdentifier (mkPackageName name) (mkVersion [1, 0])
+
+-- | Provide a repo and a repo context with the given GET handler.
+withFakeRepoCtxt ::
+  (URI -> IO HttpCode) ->
+  (RepoContext -> Repo -> IO a) ->
+  IO a
+withFakeRepoCtxt handleGet action =
+  withTestDir verbosity "fake repo" $ \tmpDir ->
+    let repo =
+          RepoRemote
+            { repoRemote = emptyRemoteRepo $ RepoName "fake",
+              repoLocalDir = tmpDir
+            }
+        repoCtxt =
+          RepoContext
+            { repoContextRepos = [repo],
+              repoContextGetTransport = return httpTransport,
+              repoContextWithSecureRepo = \_ _ ->
+                error "fake repo ctxt: repoContextWithSecureRepo not implemented",
+              repoContextIgnoreExpiry = error "fake repo ctxt: repoContextIgnoreExpiry not implemented"
+            }
+     in action repoCtxt repo
+  where
+    httpTransport =
+      HttpTransport
+        { getHttp = \_verbosity uri _etag _filepath _headers -> do
+            code <- handleGet uri
+            return (code, Nothing),
+          postHttp = error "fake transport: postHttp not implemented",
+          postHttpFile = error "fake transport: postHttpFile not implemented",
+          putHttpFile = error "fake transport: putHttp not implemented",
+          transportSupportsHttps = error "fake transport: transportSupportsHttps not implemented",
+          transportManuallySelected = True
+        }

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Types/OptionalStanza.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Types/OptionalStanza.hs
@@ -13,8 +13,8 @@ import Test.Tasty.QuickCheck
 import Data.Monoid
 #endif
 
-tests :: TestTree
-tests = testGroup "Distribution.Solver.Types.OptionalStanza"
+tests :: [TestTree]
+tests =
     [ testProperty "fromList . toList = id" $ \xs ->
         optStanzaSetFromList (optStanzaSetToList xs) === xs
     , testProperty "member x (insert x xs) = True" $ \x xs ->

--- a/changelog.d/pr-7929
+++ b/changelog.d/pr-7929
@@ -1,0 +1,4 @@
+synopsis: fix Ctrl-C handling during package download
+packages: cabal-install
+prs: #7929
+issues: #6322


### PR DESCRIPTION
This fixes Ctrl-C not interrupting cabal properly while it is downloading. I believe
that might be #6322, although it would be good to verify that.

There are ~~two~~ three concrete bugs:
- `try` catches asynchronous exceptions, preventing `withAsync` from interrupting it when its `body` action finishes prematurely.
- the use of `withAsync` is not safe since we don't wait for the async and hence lose exceptions it might throw
- the use of regular `bracket` in `withTempFileName` can "convert" `AsyncCancelled` into a regular IO exception

The first bug manifests during `cabal build` when hitting Ctrl-C during
download, e.g.:

1. Ctrl-C interrupts a curl process
2. This interrupt is converted into a UserInterrupt exception
   via the process package's delegate_ctlc functionality.
3. UserInterrupt bubbles up through `fetchPackage`, is caught by
   the `try` (fine) and writen to the result mvar.
   Meanwhile, `fetchPackage` continues its loop, starting to
   fetch the next package.
4. Some `rebuildTarget` is waiting for the interrupted download;
  `waitAsyncFetchPackage` rethrows UserInterrupt in that thread.
5. UserInterrupt bubbles up through `collectJob`, `execute`, the
   `body` action.
6. `withAsync`'s finalizer cancels the `fetchPackages` async.
7. The `fetchPackages` async receives the AsyncCancelled exception
   while fetching the next package (see 3. above). This interrupts
   the download action (it shouldn't matter whether we happen to
   be running curl again or not), and AsyncCancelled bubbles up
   through `fetchPackage`, is caught by the `try` (not fine!) and
   written to the mvar. But no-one is reading that mvar anymore
   because the build job already aborted (step 5), and that
   AsyncCancelled exception is lost.
8. `fetchPackages` keeps doing its thing, exiting eventually.

To fix this, use `try` from safe-exceptions, which doesn't catch
asynchronous exceptions. Note that this change affects both
instances of `try` in this story: `UserInterrupt` is also an asynchronous
exception, so after the change the `UserInterrupt` takes a different path
from step 3.

This relates to the second bug, uncovered during testing of the fix for
the first bug: `UserInterrupt` can now cause the async part of
`withAsync` to crash. That one is fixed by using `concurrently` instead
of withAsync.

Finally, the third bug showed on Windows CI during testing, where temporary
file cleanup trigged by async cancellation fails with an IO exception, which is
then treated as a regular download failure, while the attempt to cancel the
async is ignored.

- To verify manually, call `cabal build` for a package with several undownloaded
  dependencies, and hit Ctrl-C when it gets started. Prior to these changes, `cabal`
  doesn't exit until it's done downloading, afterwards it does. I've checked this
  on macOS.
- The PR includes unit tests for `asyncFetchPackages` with a faked HTTP transport,
  simulating several failure scenarios where the `asyncFetchPackages` might not exit
  promptly or even deadlock. Some of these fail before the change, and now pass.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
