### PR TITLE
docs: cabal.project in parent directories

### DIFF
--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -32,7 +32,7 @@ options):
 
 4. ``cabal.project.local`` (the output of ``cabal v2-configure``)
 
-A call to ``cabal build`` will consider ``cabal.project*`` from parent 
+Any call to ``cabal build`` will consider ``cabal.project*`` files from parent 
 directories when there is none in the current directory.
 
 Specifying the local packages

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -32,6 +32,8 @@ options):
 
 4. ``cabal.project.local`` (the output of ``cabal v2-configure``)
 
+A call to ``cabal build`` will consider ``cabal.project*`` from parent 
+directories when there is none in the current directory.
 
 Specifying the local packages
 -----------------------------


### PR DESCRIPTION
This is a stop-gap measure against #7930. It's probably not ideal so I'm fine with just waiting for a better feature, if you think it's the right way forward. 