### PR TITLE
Adjusting cabal check warning for long synopses

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -482,7 +482,7 @@ checkFields pkg =
     --TODO: recommend not using the stability field
     --TODO: recommend specifying a source repo
 
-  , check (ShortText.length (synopsis pkg) >= 80) $
+  , check (ShortText.length (synopsis pkg) > 80) $
       PackageDistSuspicious
         "The 'synopsis' field is rather long (max 80 chars is recommended)."
 

--- a/cabal-testsuite/PackageTests/Check/SynopsisLength/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/SynopsisLength/cabal.out
@@ -1,0 +1,2 @@
+# cabal check
+No errors or warnings could be found in the package.

--- a/cabal-testsuite/PackageTests/Check/SynopsisLength/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/SynopsisLength/cabal.test.hs
@@ -1,0 +1,3 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/SynopsisLength/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Check/SynopsisLength/pkg.cabal
@@ -1,0 +1,12 @@
+cabal-version: 2.2
+name: pkg
+version: 0
+category: example
+maintainer: none@example.com
+synopsis: this is a preposterously big synopsis but don't worry because it is this big on 
+description: this is a preposterously filler description so warnings are not triggered but don
+license: BSD-3-Clause
+
+library
+  exposed-modules: Foo
+  default-language: Haskell2010

--- a/changelog.d/pr-7933
+++ b/changelog.d/pr-7933
@@ -1,0 +1,4 @@
+synopsis: changes the cabal check warning about long synopsis, so it warns only synopsis bigger than the set size
+packages: Cabal
+prs: #7933
+issues: #7932


### PR DESCRIPTION
Fixes #7932.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.