### PR TITLE
Fixing `cabal init` file output for `cabal-version < 2.2`

### DIFF
--- a/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
+++ b/Cabal-syntax/src/Distribution/FieldGrammar/Newtypes.hs
@@ -356,6 +356,7 @@ instance Pretty SpecVersion where
 
 -- | SPDX License expression or legacy license
 newtype SpecLicense = SpecLicense { getSpecLicense :: Either SPDX.License License }
+    deriving (Show, Eq)
 
 instance Newtype (Either SPDX.License License) SpecLicense
 

--- a/cabal-install/src/Distribution/Client/Init/Defaults.hs
+++ b/cabal-install/src/Distribution/Client/Init/Defaults.hs
@@ -48,7 +48,8 @@ import qualified Distribution.SPDX.LicenseId as SPDX
 import Distribution.Simple.Flag (toFlag)
 import Distribution.Verbosity (normal)
 import Distribution.Types.Version
-import Distribution.Simple
+import Distribution.FieldGrammar.Newtypes
+import Distribution.Simple (Language(..), License(..))
 
 
 -- -------------------------------------------------------------------- --
@@ -75,8 +76,10 @@ defaultPackageType = Executable
 defaultChangelog :: FilePath
 defaultChangelog = "CHANGELOG.md"
 
-defaultLicense :: SPDX.License
-defaultLicense = SPDX.NONE
+defaultLicense :: CabalSpecVersion -> SpecLicense
+defaultLicense csv
+  | csv < CabalSpecV2_2 = SpecLicense $ Right AllRightsReserved
+  | otherwise           = SpecLicense $ Left  SPDX.NONE
 
 defaultMainIs :: HsFilePath
 defaultMainIs = toHsFilePath "Main.hs"

--- a/cabal-install/src/Distribution/Client/Init/FlagExtractors.hs
+++ b/cabal-install/src/Distribution/Client/Init/FlagExtractors.hs
@@ -5,6 +5,7 @@ module Distribution.Client.Init.FlagExtractors
 , getSimpleProject
 , getMinimal
 , getCabalVersion
+, getCabalVersionNoPrompt
 , getPackageName
 , getVersion
 , getLicense
@@ -48,8 +49,8 @@ import Distribution.Version (Version)
 import Distribution.ModuleName (ModuleName)
 import Distribution.Types.Dependency (Dependency(..))
 import Distribution.Types.PackageName (PackageName)
-import qualified Distribution.SPDX as SPDX
 import Distribution.Client.Init.Defaults
+import Distribution.FieldGrammar.Newtypes (SpecLicense)
 import Distribution.Client.Init.Types
 import Distribution.Simple.Setup (Flag(..), fromFlagOrDefault, flagToMaybe)
 import Distribution.Simple.Flag (flagElim)
@@ -84,6 +85,9 @@ getMinimal = return . fromFlagOrDefault False . minimal
 getCabalVersion :: Interactive m => InitFlags -> m CabalSpecVersion -> m CabalSpecVersion
 getCabalVersion flags = fromFlagOrPrompt (cabalVersion flags)
 
+getCabalVersionNoPrompt :: InitFlags -> CabalSpecVersion
+getCabalVersionNoPrompt = fromFlagOrDefault defaultCabalVersion . cabalVersion
+
 -- | Get the package name: use the package directory (supplied, or the current
 --   directory by default) as a guess. It looks at the SourcePackageDb to avoid
 --   using an existing package name.
@@ -98,7 +102,7 @@ getVersion flags = fromFlagOrPrompt (version flags)
 -- | Choose a license for the package.
 -- The license can come from Initflags (license field), if it is not present
 -- then prompt the user from a predefined list of licenses.
-getLicense :: Interactive m => InitFlags -> m SPDX.License -> m SPDX.License
+getLicense :: Interactive m => InitFlags -> m SpecLicense -> m SpecLicense
 getLicense flags = fromFlagOrPrompt (license flags)
 
 -- | The author's name. Prompt, or try to guess from an existing

--- a/cabal-install/src/Distribution/Client/Init/Format.hs
+++ b/cabal-install/src/Distribution/Client/Init/Format.hs
@@ -31,10 +31,11 @@ module Distribution.Client.Init.Format
 import Distribution.Pretty
 import Distribution.Fields
 import Distribution.Client.Init.Types
+import Distribution.License
 import Text.PrettyPrint
 import Distribution.Solver.Compat.Prelude hiding (empty)
 import Distribution.PackageDescription.FieldGrammar
-import Distribution.Simple.Utils
+import Distribution.Simple.Utils hiding (cabalVersion)
 import Distribution.Utils.Path
 import Distribution.Package (unPackageName)
 import qualified Distribution.SPDX.License as SPDX
@@ -328,7 +329,9 @@ mkPkgDescription opts pkgDesc =
       False
       opts
 
-    , field  "license" pretty (_pkgLicense pkgDesc)
+    , (if _pkgCabalVersion pkgDesc < CabalSpecV2_2
+        then field "license" pretty (licenseFromSPDX $ _pkgLicense pkgDesc)
+        else field "license" pretty (_pkgLicense pkgDesc))
       ["The license under which the package is released."]
       True
       opts

--- a/cabal-install/src/Distribution/Client/Init/Format.hs
+++ b/cabal-install/src/Distribution/Client/Init/Format.hs
@@ -40,6 +40,7 @@ import Distribution.Utils.Path
 import Distribution.Package (unPackageName)
 import qualified Distribution.SPDX.License as SPDX
 import Distribution.CabalSpecVersion
+import Distribution.FieldGrammar.Newtypes (SpecLicense(SpecLicense))
 
 
 -- | Construct a 'PrettyField' from a field that can be automatically
@@ -329,15 +330,15 @@ mkPkgDescription opts pkgDesc =
       False
       opts
 
-    , (if _pkgCabalVersion pkgDesc < CabalSpecV2_2
-        then field "license" pretty (licenseFromSPDX $ _pkgLicense pkgDesc)
-        else field "license" pretty (_pkgLicense pkgDesc))
+    , field "license" pretty (_pkgLicense pkgDesc)
       ["The license under which the package is released."]
       True
       opts
 
     , case _pkgLicense pkgDesc of
-        SPDX.NONE -> PrettyEmpty
+        SpecLicense (Left  SPDX.NONE)          -> PrettyEmpty
+        SpecLicense (Right AllRightsReserved)  -> PrettyEmpty
+        SpecLicense (Right UnspecifiedLicense) -> PrettyEmpty
         _ -> field "license-file" text "LICENSE"
              ["The file containing the license text."]
              False

--- a/cabal-install/src/Distribution/Client/Init/Format.hs
+++ b/cabal-install/src/Distribution/Client/Init/Format.hs
@@ -359,12 +359,10 @@ mkPkgDescription opts pkgDesc =
       []
       False
       opts
-    , if cabalSpec < CabalSpecV2_2
-      then PrettyEmpty
-      else field "build-type" text "Simple"
-           []
-           False
-           opts
+    , field "build-type" text "Simple"
+      []
+      False
+      opts
     , case _pkgExtraDocFiles pkgDesc of
         Nothing -> PrettyEmpty
         Just fs ->

--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -164,9 +164,11 @@ genPkgDescription
     => InitFlags
     -> SourcePackageDb
     -> m PkgDescription
-genPkgDescription flags srcDb = PkgDescription
-    <$> cabalVersionPrompt flags
-    <*> packageNamePrompt srcDb flags
+genPkgDescription flags' srcDb = do
+  csv <- cabalVersionPrompt flags'
+  let flags = flags' { cabalVersion = Flag csv }
+  PkgDescription csv
+    <$> packageNamePrompt srcDb flags
     <*> versionPrompt flags
     <*> licensePrompt flags
     <*> authorPrompt flags

--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -100,37 +100,38 @@ createProject v pkgIx srcDb initFlags = do
       mkOpts cs = WriteOpts
         doOverwrite isMinimal cs
         v pkgDir pkgType pkgName
+      initFlags' = initFlags { cabalVersion = Flag cabalSpec }
 
   case pkgType of
     Library -> do
-      libTarget <- genLibTarget initFlags pkgIx
+      libTarget <- genLibTarget initFlags' pkgIx
       testTarget <- addLibDepToTest pkgName <$>
-        genTestTarget initFlags pkgIx
+        genTestTarget initFlags' pkgIx
 
-      comments <- noCommentsPrompt initFlags
+      comments <- noCommentsPrompt initFlags'
 
       return $ ProjectSettings
         (mkOpts comments cabalSpec) pkgDesc
         (Just libTarget) Nothing testTarget
 
     Executable -> do
-      exeTarget <- genExeTarget initFlags pkgIx
-      comments <- noCommentsPrompt initFlags
+      exeTarget <- genExeTarget initFlags' pkgIx
+      comments <- noCommentsPrompt initFlags'
 
       return $ ProjectSettings
         (mkOpts comments cabalSpec) pkgDesc Nothing
         (Just exeTarget) Nothing
 
     LibraryAndExecutable -> do
-      libTarget <- genLibTarget initFlags pkgIx
+      libTarget <- genLibTarget initFlags' pkgIx
 
       exeTarget <- addLibDepToExe pkgName <$>
-        genExeTarget initFlags pkgIx
+        genExeTarget initFlags' pkgIx
 
       testTarget <- addLibDepToTest pkgName <$>
-        genTestTarget initFlags pkgIx
+        genTestTarget initFlags' pkgIx
 
-      comments <- noCommentsPrompt initFlags
+      comments <- noCommentsPrompt initFlags'
 
       return $ ProjectSettings
         (mkOpts comments cabalSpec) pkgDesc (Just libTarget)
@@ -141,10 +142,10 @@ createProject v pkgIx srcDb initFlags = do
       -- are *not* passed, the user will be prompted for a package type (which
       -- includes TestSuite in the list). It prevents that the user end up with a
       -- TestSuite target with initializeTestSuite set to NoFlag, thus avoiding the prompt.
-      let initFlags' = initFlags { initializeTestSuite = Flag True }
-      testTarget <- genTestTarget initFlags' pkgIx
+      let initFlags'' = initFlags' { initializeTestSuite = Flag True }
+      testTarget <- genTestTarget initFlags'' pkgIx
 
-      comments <- noCommentsPrompt initFlags'
+      comments <- noCommentsPrompt initFlags''
 
       return $ ProjectSettings
         (mkOpts comments cabalSpec) pkgDesc

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
@@ -46,7 +46,6 @@ import Distribution.Version (Version)
 import Distribution.ModuleName (ModuleName, components)
 import Distribution.Types.Dependency (Dependency(..))
 import Distribution.Types.PackageName (PackageName, unPackageName)
-import qualified Distribution.SPDX as SPDX
 import Distribution.Client.Init.Defaults
 import Distribution.Client.Init.NonInteractive.Heuristics
 import Distribution.Client.Init.Utils
@@ -63,6 +62,7 @@ import Language.Haskell.Extension (Language(..), Extension(..))
 import System.FilePath (splitDirectories, (</>))
 import Distribution.Simple.Compiler
 import qualified Data.Set as Set
+import Distribution.FieldGrammar.Newtypes
 
 
 -- | Main driver for interactive prompt code.
@@ -270,7 +270,7 @@ versionHeuristics flags = getVersion flags $ return defaultVersion
 -- | Choose a license for the package.
 -- The license can come from Initflags (license field), if it is not present
 -- then prompt the user from a predefined list of licenses.
-licenseHeuristics :: Interactive m => InitFlags -> m SPDX.License
+licenseHeuristics :: Interactive m => InitFlags -> m SpecLicense
 licenseHeuristics flags = getLicense flags $ guessLicense flags
 
 -- | The author's name. Prompt, or try to guess from an existing

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
@@ -33,9 +33,9 @@ import Distribution.Simple.Setup (fromFlagOrDefault)
 
 import qualified Data.List as L
 import Distribution.Client.Init.Defaults
+import Distribution.Client.Init.FlagExtractors (getCabalVersionNoPrompt)
 import Distribution.Client.Init.Types
 import Distribution.Client.Init.Utils
-import qualified Distribution.SPDX as SPDX
 import System.FilePath
 import Distribution.CabalSpecVersion
 import Language.Haskell.Extension
@@ -43,6 +43,7 @@ import Distribution.Version
 import Distribution.Types.PackageName (PackageName, mkPackageName)
 import Distribution.Simple.Compiler
 import qualified Data.Set as Set
+import Distribution.FieldGrammar.Newtypes
 
 
 
@@ -103,8 +104,8 @@ guessPackageName = fmap (mkPackageName . repair . fromMaybe "" . safeLast . spli
 -- | Try to guess the license from an already existing @LICENSE@ file in
 --   the package directory, comparing the file contents with the ones
 --   listed in @Licenses.hs@, for now it only returns a default value.
-guessLicense :: Interactive m => InitFlags -> m SPDX.License
-guessLicense _ = return SPDX.NONE
+guessLicense :: Interactive m => InitFlags -> m SpecLicense
+guessLicense flags = return . defaultLicense $ getCabalVersionNoPrompt flags
 
 guessExtraDocFiles :: Interactive m => InitFlags -> m (Maybe (Set FilePath))
 guessExtraDocFiles flags = do

--- a/cabal-install/src/Distribution/Client/Init/Simple.hs
+++ b/cabal-install/src/Distribution/Client/Init/Simple.hs
@@ -98,7 +98,7 @@ genSimplePkgDesc flags = mkPkgDesc <$> currentDirPkgName
       (fromFlagOrDefault defaultCabalVersion (cabalVersion flags))
       pkgName
       (fromFlagOrDefault defaultVersion (version flags))
-      (fromFlagOrDefault defaultLicense (license flags))
+      (fromFlagOrDefault (defaultLicense $ getCabalVersionNoPrompt flags) (license flags))
       (fromFlagOrDefault "" (author flags))
       (fromFlagOrDefault "" (email flags))
       (fromFlagOrDefault "" (homepage flags))

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -64,7 +64,6 @@ import Distribution.Types.Dependency as P
 import Distribution.Verbosity (silent)
 import Distribution.Version
 import qualified Distribution.Package as P
-import Distribution.SPDX.License (License)
 import Distribution.ModuleName
 import Distribution.CabalSpecVersion
 import Distribution.Client.Utils as P
@@ -76,6 +75,7 @@ import qualified System.Directory as P
 import qualified System.Process as Process
 import qualified Distribution.Compat.Environment as P
 import System.FilePath
+import Distribution.FieldGrammar.Newtypes (SpecLicense)
 
 
 -- -------------------------------------------------------------------- --
@@ -96,7 +96,7 @@ data InitFlags =
     , packageName :: Flag P.PackageName
     , version :: Flag Version
     , cabalVersion :: Flag CabalSpecVersion
-    , license :: Flag License
+    , license :: Flag SpecLicense
     , author :: Flag String
     , email :: Flag String
     , homepage :: Flag String
@@ -139,7 +139,7 @@ data PkgDescription = PkgDescription
     { _pkgCabalVersion :: CabalSpecVersion
     , _pkgName :: P.PackageName
     , _pkgVersion :: Version
-    , _pkgLicense :: License
+    , _pkgLicense :: SpecLicense
     , _pkgAuthor :: String
     , _pkgEmail :: String
     , _pkgHomePage :: String

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
@@ -27,6 +27,7 @@ import Distribution.Client.Init.FlagExtractors
 import Distribution.Simple.Setup
 import Distribution.CabalSpecVersion
 import qualified Data.Set as Set
+import Distribution.FieldGrammar.Newtypes
 
 
 -- -------------------------------------------------------------------- --
@@ -84,7 +85,7 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
             _pkgCabalVersion  desc @?= CabalSpecV2_2
             _pkgName          desc @?= mkPackageName "QuxPackage"
             _pkgVersion       desc @?= mkVersion [4,2,6]
-            _pkgLicense       desc @?! SPDX.NONE
+            _pkgLicense       desc @?! (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= "qux.com"
@@ -188,7 +189,7 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
             _pkgCabalVersion  desc @?= CabalSpecV2_4
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [3,1,2,3]
-            _pkgLicense       desc @?! SPDX.NONE
+            _pkgLicense       desc @?! (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= "qux.com"
@@ -283,7 +284,7 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
             _pkgCabalVersion  desc @?= CabalSpecV2_4
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [3,1,2,3]
-            _pkgLicense       desc @?! SPDX.NONE
+            _pkgLicense       desc @?! (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= "qux.com"
@@ -364,7 +365,7 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
             _pkgCabalVersion  desc @?= CabalSpecV2_4
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [3,1,2,3]
-            _pkgLicense       desc @?! SPDX.NONE
+            _pkgLicense       desc @?! (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= "qux.com"
@@ -445,7 +446,7 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
             _pkgCabalVersion  desc @?= CabalSpecV2_4
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [3,1,2,3]
-            _pkgLicense       desc @?! SPDX.NONE
+            _pkgLicense       desc @?! (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= "qux.com"
@@ -526,7 +527,7 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
             _pkgCabalVersion  desc @?= CabalSpecV2_4
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [3,1,2,3]
-            _pkgLicense       desc @?! SPDX.NONE
+            _pkgLicense       desc @?! (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= "qux.com"
@@ -605,7 +606,7 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
             _pkgCabalVersion  desc @?= CabalSpecV1_10
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [3,1,2,3]
-            _pkgLicense       desc @?! SPDX.NONE
+            _pkgLicense       desc @?! (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= "qux.com"
@@ -678,7 +679,7 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
             _pkgCabalVersion  desc @?= CabalSpecV2_4
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [3,1,2,3]
-            _pkgLicense       desc @?! SPDX.NONE
+            _pkgLicense       desc @?! (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= "qux.com"
@@ -847,24 +848,24 @@ interactiveTests srcDb = testGroup "Check top level getter functions"
       ]
     , testGroup "Check licensePrompt output" $ let other = show (1 + P.length defaultLicenseIds) in
         [ testNumberedPrompt "License indices" licensePrompt $
-            fmap (\l -> SPDX.License $ SPDX.ELicense (SPDX.ELicenseId l) Nothing) defaultLicenseIds
+            fmap (\l -> SpecLicense . Left . SPDX.License $ SPDX.ELicense (SPDX.ELicenseId l) Nothing) defaultLicenseIds
         , testSimplePrompt "Other license 1"
-            licensePrompt (mkLicense SPDX.CC_BY_NC_ND_4_0)
+            licensePrompt (SpecLicense . Left $ mkLicense SPDX.CC_BY_NC_ND_4_0)
             [ other
             , "CC-BY-NC-ND-4.0"
             ]
         , testSimplePrompt "Other license 2"
-            licensePrompt (mkLicense SPDX.D_FSL_1_0)
+            licensePrompt (SpecLicense . Left $ mkLicense SPDX.D_FSL_1_0)
             [ other
             , "D-FSL-1.0"
             ]
         , testSimplePrompt "Other license 3"
-            licensePrompt (mkLicense SPDX.NPOSL_3_0)
+            licensePrompt (SpecLicense . Left $ mkLicense SPDX.NPOSL_3_0)
             [ other
             , "NPOSL-3.0"
             ]
         , testSimplePrompt "Invalid license"
-            licensePrompt SPDX.NONE
+            licensePrompt (SpecLicense $ Left SPDX.NONE)
             [ other
             , "yay"
             , other

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
@@ -23,6 +23,7 @@ import Distribution.Simple.Flag
 import Data.List (foldl')
 import qualified Data.Set as Set
 import Distribution.Client.Init.Utils (mkPackageNameDep, mkStringyDep)
+import Distribution.FieldGrammar.Newtypes
 
 tests
     :: Verbosity
@@ -83,7 +84,7 @@ driverFunctionTest pkgIx srcDb comp = testGroup "createProject"
             _pkgCabalVersion  desc @?= CabalSpecV2_2
             _pkgName          desc @?= mkPackageName "QuxPackage"
             _pkgVersion       desc @?= mkVersion [4,2,6]
-            _pkgLicense       desc @?! SPDX.NONE
+            _pkgLicense       desc @?! (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= "qux.com"
@@ -168,7 +169,7 @@ driverFunctionTest pkgIx srcDb comp = testGroup "createProject"
             _pkgCabalVersion  desc @?= CabalSpecV2_2
             _pkgName          desc @?= mkPackageName "QuxPackage"
             _pkgVersion       desc @?= mkVersion [4,2,6]
-            _pkgLicense       desc @?! SPDX.NONE
+            _pkgLicense       desc @?! (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= "qux.com"
@@ -346,7 +347,7 @@ driverFunctionTest pkgIx srcDb comp = testGroup "createProject"
             _pkgCabalVersion  desc @?= CabalSpecV3_4
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [0,1,0,0]
-            _pkgLicense       desc @?= SPDX.NONE
+            _pkgLicense       desc @?= (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= ""
@@ -490,7 +491,7 @@ driverFunctionTest pkgIx srcDb comp = testGroup "createProject"
             _pkgCabalVersion  desc @?= CabalSpecV3_4
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [0,1,0,0]
-            _pkgLicense       desc @?= SPDX.NONE
+            _pkgLicense       desc @?= (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= ""
@@ -633,7 +634,7 @@ driverFunctionTest pkgIx srcDb comp = testGroup "createProject"
             _pkgCabalVersion  desc @?= CabalSpecV3_4
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [0,1,0,0]
-            _pkgLicense       desc @?= SPDX.NONE
+            _pkgLicense       desc @?= (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= ""
@@ -744,7 +745,7 @@ driverFunctionTest pkgIx srcDb comp = testGroup "createProject"
             _pkgCabalVersion  desc @?= CabalSpecV3_4
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [0,1,0,0]
-            _pkgLicense       desc @?= SPDX.NONE
+            _pkgLicense       desc @?= (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= ""
@@ -836,7 +837,7 @@ driverFunctionTest pkgIx srcDb comp = testGroup "createProject"
             _pkgCabalVersion  desc @?= CabalSpecV3_4
             _pkgName          desc @?= mkPackageName "test-package"
             _pkgVersion       desc @?= mkVersion [0,1,0,0]
-            _pkgLicense       desc @?= SPDX.NONE
+            _pkgLicense       desc @?= (SpecLicense . Left $ SPDX.NONE)
             _pkgAuthor        desc @?= "Foobar"
             _pkgEmail         desc @?= "foobar@qux.com"
             _pkgHomePage      desc @?= ""
@@ -1224,7 +1225,7 @@ nonInteractiveTests pkgIx srcDb comp = testGroup "Check top level getter functio
       , testSimple "Check minimalHeuristics output" minimalHeuristics False [""]
       , testSimple "Check overwriteHeuristics output" overwriteHeuristics False [""]
       , testSimple "Check initializeTestSuiteHeuristics output" initializeTestSuiteHeuristics False [""]
-      , testSimple "Check licenseHeuristics output" licenseHeuristics SPDX.NONE [""]
+      , testSimple "Check licenseHeuristics output" licenseHeuristics (SpecLicense $ Left SPDX.NONE) [""]
       ]
     , testGroup "Bool heuristics tests"
       [ testBool "Check noCommentsHeuristics output" noCommentsHeuristics False ""

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Simple.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Simple.hs
@@ -25,6 +25,7 @@ import qualified Data.List.NonEmpty as NEL
 import Distribution.Types.Dependency
 import Distribution.Client.Init.Utils (mkPackageNameDep, getBaseDep)
 import qualified Data.Set as Set
+import Distribution.Client.Init.FlagExtractors (getCabalVersionNoPrompt)
 
 tests
     :: Verbosity
@@ -140,7 +141,7 @@ simplePkgDesc pkgName = PkgDescription
     defaultCabalVersion
     pkgName
     defaultVersion
-    defaultLicense
+    (defaultLicense $ getCabalVersionNoPrompt dummyFlags)
     "" "" "" "" ""
     mempty
     (Just $ Set.singleton defaultChangelog)

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Utils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Utils.hs
@@ -23,6 +23,7 @@ import Distribution.Types.Dependency
 import Distribution.Types.VersionRange
 import Distribution.Simple.Compiler
 import Distribution.Pretty
+import Distribution.FieldGrammar.Newtypes
 
 
 -- -------------------------------------------------------------------- --
@@ -34,7 +35,7 @@ dummyFlags = emptyFlags
   , packageName         = Flag (mkPackageName "QuxPackage")
   , version             = Flag (mkVersion [4,2,6])
   , cabalVersion        = Flag CabalSpecV2_2
-  , license             = Flag $ SPDX.License $ SPDX.ELicense (SPDX.ELicenseId SPDX.MIT) Nothing
+  , license             = Flag $ SpecLicense $ Left $ SPDX.License $ SPDX.ELicense (SPDX.ELicenseId SPDX.MIT) Nothing
   , author              = Flag "Foobar"
   , email               = Flag "foobar@qux.com"
   , homepage            = Flag "qux.com"

--- a/cabal-install/tests/fixtures/init/golden/pkg-desc/pkg-old-cabal-with-flags.golden
+++ b/cabal-install/tests/fixtures/init/golden/pkg-desc/pkg-old-cabal-with-flags.golden
@@ -46,6 +46,7 @@ maintainer:         foobar@qux.com
 -- A copyright notice.
 -- copyright:
 category:           Control
+build-type:         Simple
 
 -- Extra doc files to be distributed with the package, such as a CHANGELOG or a README.
 extra-doc-files:    CHANGELOG.md

--- a/cabal-testsuite/PackageTests/Init/init-interactive-legacy.out
+++ b/cabal-testsuite/PackageTests/Init/init-interactive-legacy.out
@@ -1,0 +1,6 @@
+# cabal init
+# Setup configure
+Configuring app-0.1.0.0...
+# Setup build
+Preprocessing executable 'app' for app-0.1.0.0..
+Building executable 'app' for app-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Init/init-interactive-legacy.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-interactive-legacy.test.hs
@@ -6,7 +6,7 @@ main = cabalTest $
 
     buildOut <- withDirectory cwd $ do
       cabalWithStdin "init" ["-i"]
-        "2\n1\n\n\n2\n\n\n\n\n\n\n\n\n\n"
+        "2\n1\n\n\n10\n\n\n\n\n\n\n\n\n\n"
       setup "configure" []
       setup' "build" ["app"]
 

--- a/cabal-testsuite/PackageTests/Init/init-interactive-legacy.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-interactive-legacy.test.hs
@@ -1,0 +1,18 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $
+  withSourceCopyDir "app" $ do
+    cwd <- fmap testSourceCopyDir getTestEnv
+
+    buildOut <- withDirectory cwd $ do
+      cabalWithStdin "init" ["-i"]
+        "2\n1\n\n\n2\n\n\n\n\n\n\n\n\n\n"
+      setup "configure" []
+      setup' "build" ["app"]
+
+    assertFileDoesContain    (cwd </> "app.cabal")   "1.24"
+    assertFileDoesContain    (cwd </> "app.cabal")   "BSD3"
+    assertFileDoesContain    (cwd </> "app.cabal")   "Simple"
+    assertFileDoesNotContain (cwd </> "app.cabal")   "^>="
+    assertFileDoesContain    (cwd </> "app/Main.hs") "This should remain as is!"
+    assertOutputContains "Linking" buildOut

--- a/cabal-testsuite/PackageTests/Init/init-interactive.out
+++ b/cabal-testsuite/PackageTests/Init/init-interactive.out
@@ -1,0 +1,6 @@
+# cabal init
+# Setup configure
+Configuring app-0.1.0.0...
+# Setup build
+Preprocessing executable 'app' for app-0.1.0.0..
+Building executable 'app' for app-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Init/init-interactive.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-interactive.test.hs
@@ -5,11 +5,13 @@ main = cabalTest $
     cwd <- fmap testSourceCopyDir getTestEnv
 
     buildOut <- withDirectory cwd $ do
-      cabal "init" ["-n", "--exe", "--application-dir=app", "--main-is=Main.hs"]
+      cabalWithStdin "init" ["-i"]
+        "2\n5\n\n\n2\n\n\n\n\n\n\n\n\n\n"
       setup "configure" []
       setup' "build" ["app"]
 
+    assertFileDoesContain (cwd </> "app.cabal")   "3.0"
+    assertFileDoesContain (cwd </> "app.cabal")   "BSD-3-Clause"
     assertFileDoesContain (cwd </> "app.cabal")   "Simple"
-    assertFileDoesContain (cwd </> "app.cabal")   "base ^>="
     assertFileDoesContain (cwd </> "app/Main.hs") "This should remain as is!"
     assertOutputContains "Linking" buildOut

--- a/cabal-testsuite/PackageTests/Init/init-legacy.out
+++ b/cabal-testsuite/PackageTests/Init/init-legacy.out
@@ -1,0 +1,6 @@
+# cabal init
+# Setup configure
+Configuring app-0.1.0.0...
+# Setup build
+Preprocessing executable 'app' for app-0.1.0.0..
+Building executable 'app' for app-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Init/init-legacy.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-legacy.test.hs
@@ -1,0 +1,16 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $
+  withSourceCopyDir "app" $ do
+    cwd <- fmap testSourceCopyDir getTestEnv
+
+    buildOut <- withDirectory cwd $ do
+      cabal "init" ["-n", "--exe", "--application-dir=app", "--main-is=Main.hs", "--cabal-version=1.24"]
+      setup "configure" []
+      setup' "build" ["app"]
+
+    assertFileDoesContain    (cwd </> "app.cabal")   "1.24"
+    assertFileDoesContain    (cwd </> "app.cabal")   "Simple"
+    assertFileDoesNotContain (cwd </> "app.cabal")   "^>="
+    assertFileDoesContain    (cwd </> "app/Main.hs") "This should remain as is!"
+    assertOutputContains "Linking" buildOut


### PR DESCRIPTION
This PR aims to fix three buggy behaviours within the `cabal init` file output:
* the versions in the `build-depends` field should not use the caret style constraint for major bound versions if `cabal-version < 2.0`
* the license prompt, for the `License` field, should present legacy or SPDX license options depending on the cabal version picked previously
* for `cabal-version < 2.2`, the field `build-type` must be set

Fixes #7946 and fixes #7947.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
