### PR TITLE
Reduce VCS QuickCheck count to 10 (from 100)

### DIFF
--- a/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
@@ -47,7 +47,7 @@ import UnitTests.TempTestDir (withTestDir, removeDirectoryRecursiveHack)
 -- checks that the working state is as expected (given the pure representation).
 --
 tests :: MTimeChange -> [TestTree]
-tests mtimeChange =
+tests mtimeChange = map (localOption $ QuickCheckTests 10)
   [ testGroup "git"
     [ testProperty "check VCS test framework"    prop_framework_git
     , testProperty "cloneSourceRepo"             prop_cloneRepo_git


### PR DESCRIPTION
CI times appear to be dominated by the VCS tests, which seems
excessive.

A typical Linux validate.sh job takes ~45 minutes, of which
15 are spent in the VCS tests. MacOS is even worse, with the
VCS tests taking >1h out of a total time of >2h.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
