### PR TITLE
Making the user aware of an unchanged .cabal file in cabal init

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/src/Distribution/Client/Init/FileCreators.hs
@@ -267,8 +267,9 @@ writeFileSafe opts fileName content = do
           , newName
           ]
 
-        copyFile fileName newName
-        removeExistingFile fileName
+        copyFile fileName newName   -- backups the old file
+        removeExistingFile fileName -- removes the original old file
+        writeFile fileName content  -- writes the new file
       | otherwise = return ()
 
 writeDirectoriesSafe :: Interactive m => WriteOpts -> [String] -> m Bool
@@ -298,7 +299,8 @@ writeDirectoriesSafe opts dirs = fmap or $ for dirs $ \dir -> do
           , newDir
           ]
 
-        renameDirectory dir newDir
+        renameDirectory dir newDir -- backups the old directory
+        createDirectory dir        -- creates the new directory
       | otherwise = return ()
 
 findNewPath :: Interactive m => FilePath -> m FilePath

--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -94,7 +94,7 @@ createProject v pkgIx srcDb initFlags = do
 
   pkgType <- packageTypePrompt initFlags
   isMinimal <- getMinimal initFlags
-  doOverwrite <- getOverwrite initFlags
+  doOverwrite <- overwritePrompt initFlags
   pkgDir <- getPackageDir initFlags
   pkgDesc <- fixupDocFiles v =<< genPkgDescription initFlags srcDb
 
@@ -250,6 +250,13 @@ genTestTarget flags pkgs = initializeTestSuitePrompt flags >>= go
 
 -- -------------------------------------------------------------------- --
 -- Prompts
+
+overwritePrompt :: Interactive m => InitFlags -> m Bool
+overwritePrompt flags = do
+  isOverwrite <- getOverwrite flags
+  promptYesNo
+    "Do you wish to overwrite existing files (backups will be created) (y/n)"
+    (DefaultPrompt isOverwrite)
 
 cabalVersionPrompt :: Interactive m => InitFlags -> m CabalSpecVersion
 cabalVersionPrompt flags = getCabalVersion flags $ do

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Golden.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Golden.hs
@@ -348,20 +348,20 @@ pkgArgs = fromList
     ]
 
 testProjArgs :: String -> NonEmpty String
-testProjArgs comments = fromList ["4", "foo-package"]
+testProjArgs comments = fromList ["4", "n", "foo-package"]
   <> pkgArgs
   <> fromList (NEL.drop 1 testArgs)
   <> fromList [comments]
 
 libProjArgs :: String -> NonEmpty String
-libProjArgs comments = fromList ["1", "foo-package"]
+libProjArgs comments = fromList ["1", "n", "foo-package"]
   <> pkgArgs
   <> libArgs
   <> testArgs
   <> fromList [comments]
 
 fullProjArgs :: String -> NonEmpty String
-fullProjArgs comments = fromList ["3", "foo-package"]
+fullProjArgs comments = fromList ["3", "n", "foo-package"]
   <> pkgArgs
   <> libArgs
   <> exeArgs

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
@@ -72,7 +72,7 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
               , dependencies = Flag []
               }
 
-        case (_runPrompt $ createProject silent pkgIx srcDb dummyFlags') (fromList ["3", "quxTest/Main.hs"]) of
+        case (_runPrompt $ createProject silent pkgIx srcDb dummyFlags') (fromList ["n", "3", "quxTest/Main.hs"]) of
           Right (ProjectSettings opts desc (Just lib) (Just exe) (Just test), _) -> do
             _optOverwrite  opts @?= False
             _optMinimal    opts @?= False
@@ -130,6 +130,8 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
         let inputs = fromList
               -- package type
               [ "3"
+              -- overwrite
+              , "n"
               -- package dir
               , "test-package"
               -- package description
@@ -232,6 +234,8 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
         let inputs = fromList
               -- package type
               [  "1"
+              -- overwrite
+              , "n"
               -- package dir
               , "test-package"
               -- package description
@@ -319,6 +323,8 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
         let inputs = fromList
               -- package type
               [  "4"
+              -- overwrite
+              , "n"
               -- package dir
               , "test-package"
               -- package description
@@ -393,6 +399,8 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
         let inputs = fromList
               -- package type
               [ "3"
+              -- overwrite
+              , "n"
               -- package dir
               , "test-package"
               -- package description
@@ -481,6 +489,8 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
         let inputs = fromList
               -- package type
               [ "1"
+              -- overwrite
+              , "n"
               -- package dir
               , "test-package"
               -- package description
@@ -554,6 +564,8 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
         let inputs = fromList
               -- package type
               [ "1"
+              -- overwrite
+              , "n"
               -- package dir
               , "test-package"
               -- package description
@@ -633,6 +645,8 @@ createProjectTest pkgIx srcDb = testGroup "createProject tests"
         let inputs = fromList
               -- package type
               [ "2"
+              -- overwrite
+              , "n"
               -- package dir
               , "test-package"
               -- package description

--- a/cabal-testsuite/PackageTests/Init/init-backup.out
+++ b/cabal-testsuite/PackageTests/Init/init-backup.out
@@ -1,0 +1,6 @@
+# cabal init
+# Setup configure
+Configuring app-0.1.0.0...
+# Setup build
+Preprocessing executable 'app' for app-0.1.0.0..
+Building executable 'app' for app-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Init/init-backup.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-backup.test.hs
@@ -1,0 +1,20 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $
+  withSourceCopyDir "app" $ do
+    cwd <- fmap testSourceCopyDir getTestEnv
+
+    (initOut, buildOut) <- withDirectory cwd $ do
+      initOut <- cabalWithStdin "init" ["-i"]
+        "2\ny\n5\n\n\n2\n\n\n\n\n\n\n\n\n\n"
+      setup "configure" []
+      buildOut <- setup' "build" ["app"]
+      return (initOut, buildOut)
+
+    assertFileDoesContain (cwd </> "app.cabal")   "3.0"
+    assertFileDoesContain (cwd </> "app.cabal")   "BSD-3-Clause"
+    assertFileDoesContain (cwd </> "app.cabal")   "Simple"
+    shouldDirectoryExist (cwd </> "app.save0")
+    assertOutputContains "Backing up old version in app.save0" initOut
+    assertOutputContains "Overwriting directory ./app" initOut
+    assertOutputContains "Linking" buildOut

--- a/cabal-testsuite/PackageTests/Init/init-interactive-legacy.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-interactive-legacy.test.hs
@@ -6,7 +6,7 @@ main = cabalTest $
 
     buildOut <- withDirectory cwd $ do
       cabalWithStdin "init" ["-i"]
-        "2\n1\n\n\n10\n\n\n\n\n\n\n\n\n\n"
+        "2\n\n1\n\n\n10\n\n\n\n\n\n\n\n\n\n"
       setup "configure" []
       setup' "build" ["app"]
 

--- a/cabal-testsuite/PackageTests/Init/init-interactive.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-interactive.test.hs
@@ -6,7 +6,7 @@ main = cabalTest $
 
     buildOut <- withDirectory cwd $ do
       cabalWithStdin "init" ["-i"]
-        "2\n5\n\n\n2\n\n\n\n\n\n\n\n\n\n"
+        "2\n\n5\n\n\n2\n\n\n\n\n\n\n\n\n\n"
       setup "configure" []
       setup' "build" ["app"]
 


### PR DESCRIPTION
Closes #7957. This PR will:

* Prompts the user if overwriting files is desired for the interactive workflow;
* Warns the user if the .cabal file remains untouched after `cabal init` is finished;
* Unit tests adjustments for the new prompt;
* A new test in cabal-testsuite;
* Fixes a bug in the overwrite workflow.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
