### PR TITLE
Use ghc --merge-objs when available to join object files

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -934,15 +934,13 @@ buildOrReplLib mReplFlags verbosity numJobs pkg_descr lbi lib clbi = do
       whenVanillaLib False $ do
         Ar.createArLibArchive verbosity lbi vanillaLibFilePath staticObjectFiles
         whenGHCiLib $ do
-          (ldProg, _) <- requireProgram verbosity ldProgram (withPrograms lbi)
-          Ld.combineObjectFiles verbosity lbi ldProg
+          combineObjectFiles verbosity lbi ghcProg
             ghciLibFilePath staticObjectFiles
 
       whenProfLib $ do
         Ar.createArLibArchive verbosity lbi profileLibFilePath profObjectFiles
         whenGHCiLib $ do
-          (ldProg, _) <- requireProgram verbosity ldProgram (withPrograms lbi)
-          Ld.combineObjectFiles verbosity lbi ldProg
+          combineObjectFiles verbosity lbi ghcProg
             ghciProfLibFilePath profObjectFiles
 
       whenSharedLib False $
@@ -950,6 +948,35 @@ buildOrReplLib mReplFlags verbosity numJobs pkg_descr lbi lib clbi = do
 
       whenStaticLib False $
         runGhcProg ghcStaticLinkArgs
+
+-- | Join a set of object files together using, if possible, GHC's
+-- @--merge-objs@ mode or otherwise @ld@.
+--
+combineObjectFiles
+    :: Verbosity -> LocalBuildInfo
+    -> ConfiguredProgram  -- ^ GHC
+    -> FilePath -> [FilePath] -> IO ()
+combineObjectFiles verbosity lbi ghcProg target files
+  | compilerSupportsMergeObjs
+  = runGHC verbosity ghcProg (compiler lbi) (hostPlatform lbi) opts
+  where
+    -- GHC>=9.4 supports the -merge-objs mode which handles the
+    -- object merging for us.
+    compilerSupportsMergeObjs
+      | Just ghc_ver <- compilerCompatVersion GHC (compiler lbi)
+      = ghc_ver >= mkVersion [9,3]
+      | otherwise
+      = False
+
+    opts = mempty
+      { ghcOptMode = toFlag GhcModeMergeObjs
+      , ghcOptInputFiles = toNubListR files
+      , ghcOptOutputFile = toFlag target
+      }
+combineObjectFiles verbosity lbi _ target files
+  = do (ldProg, _) <- requireProgram verbosity ldProgram (withPrograms lbi)
+       Ld.combineObjectFiles verbosity lbi ldProg target files
+
 
 -- | Start a REPL without loading any source files.
 startInterpreter :: Verbosity -> ProgramDb -> Compiler -> Platform

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -542,6 +542,7 @@ data GhcMode = GhcModeCompile     -- ^ @ghc -c@
              | GhcModeMake        -- ^ @ghc --make@
              | GhcModeInteractive -- ^ @ghci@ \/ @ghc --interactive@
              | GhcModeAbiHash     -- ^ @ghc --abi-hash@
+             | GhcModeMergeObjs   -- ^ @ghc --merge-objs@
 --             | GhcModeDepAnalysis -- ^ @ghc -M@
 --             | GhcModeEvaluate    -- ^ @ghc -e@
  deriving (Show, Eq)
@@ -589,6 +590,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
        Just GhcModeMake        -> ["--make"]
        Just GhcModeInteractive -> ["--interactive"]
        Just GhcModeAbiHash     -> ["--abi-hash"]
+       Just GhcModeMergeObjs   -> ["--merge-objs"]
 --     Just GhcModeDepAnalysis -> ["-M"]
 --     Just GhcModeEvaluate    -> ["-e", expr]
 

--- a/changelog.d/pr-7960
+++ b/changelog.d/pr-7960
@@ -1,0 +1,4 @@
+synopsis: Use 'ghc --merge-objs' whenever available, instead of internal cabal hacks, to join object files
+packages: Cabal
+issues: #7828
+prs: #7960


### PR DESCRIPTION
Previously Cabal would rely on its own object-merge logic to produce
GHCi libraries. This was not ideal as it meant that this logic was
replicated in both GHC and Cabal. Moreover, Cabal's implementation
historically hasn't handled the more subtle aspects of interacting with
the linker, resulting in issues like #7828.

In GHC 9.4 we have introduced a new compiler mode, `--merge-objs`, which
exposes GHC's object merging mechanism. Here we teach Cabal to take
advantage of this mechanism when it is available.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
