### PR TITLE
Fix the duplicate modules check

### DIFF
--- a/Cabal-tests/tests/CheckTests.hs
+++ b/Cabal-tests/tests/CheckTests.hs
@@ -50,11 +50,10 @@ checkTests = testGroup "regressions"
     , checkTest "issue-6288-e.cabal"
     , checkTest "issue-6288-f.cabal"
     , checkTest "denormalised-paths.cabal"
-    , regression7776 $ checkTest "issue-7776-a.cabal"
-    , regression7776 $ checkTest "issue-7776-b.cabal"
+    , checkTest "issue-7776-a.cabal"
+    , checkTest "issue-7776-b.cabal"
     , checkTest "issue-7776-c.cabal"
     ]
-    where regression7776 = expectFailBecause "Regression described in #7776, will be fixed by #7966"
 
 checkTest :: FilePath -> TestTree
 checkTest fp = cabalGoldenTest fp correct $ do


### PR DESCRIPTION
Resolves https://github.com/haskell/cabal/issues/7776

Now if a package _may_ have duplicate modules (subject to conditionals), cabal warns on this.

But if a package _necessarily_ has duplicate modules (because they are not guarded by conditionals), cabal will error.