### PR TITLE
Use the cli flags in fetching packages in building a project config 

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -326,7 +326,7 @@ rebuildProjectConfig verbosity
       $ do
           liftIO $ info verbosity "Project settings changed, reconfiguring..."
           projectConfig <- phaseReadProjectConfig
-          localPackages <- phaseReadLocalPackages projectConfig
+          localPackages <- phaseReadLocalPackages (projectConfig <> cliConfig)
           return (projectConfig, localPackages)
 
     info verbosity


### PR DESCRIPTION
fixes a logic bug.

resolves https://github.com/haskell/cabal/issues/7775