### PR TITLE
ensure range headers are only sent when from < to

### DIFF
--- a/cabal-install/src/Distribution/Client/Security/HTTP.hs
+++ b/cabal-install/src/Distribution/Client/Security/HTTP.hs
@@ -119,11 +119,16 @@ mkRangeHeader from to = HTTP.Header HTTP.HdrRange rangeHeader
     rangeHeader = "bytes=" ++ show from ++ "-" ++ show (to - 1)
 
 mkReqHeaders :: [HC.HttpRequestHeader] -> Maybe (Int, Int) -> [HTTP.Header]
-mkReqHeaders reqHeaders mRange = concat [
+mkReqHeaders reqHeaders mRange' = concat [
       tr [] reqHeaders
     , [mkRangeHeader fr to | Just (fr, to) <- [mRange]]
     ]
   where
+    -- guard against malformed range headers.
+    mRange = case mRange' of
+        Just (fr, to) | fr >= to -> Nothing
+        _ -> mRange'
+
     tr :: [(HTTP.HeaderName, [String])] -> [HC.HttpRequestHeader] -> [HTTP.Header]
     tr acc [] =
       concatMap finalize acc

--- a/changelog.d/pr-7970
+++ b/changelog.d/pr-7970
@@ -1,0 +1,9 @@
+synopsis: Avoid malformed range requests
+packages: cabal-install
+prs: #7970
+issues: #5952
+description: {
+
+- Don't send malformed range requests. Should make fetching from head.hackage and other "unstable" overlays more reliable.
+
+}


### PR DESCRIPTION
Speculative fix for https://github.com/haskell/cabal/issues/5952

Should be a strict improvement even if it doesn't resolve that ticket, as it just puts in place a sanity check to ensure range requests are not malformed.