### PR TITLE
Better recovery from a few index/tar errors

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/src/Distribution/Client/CmdUpdate.hs
@@ -13,6 +13,7 @@ module Distribution.Client.CmdUpdate (
   ) where
 
 import Prelude ()
+import Control.Exception
 import Distribution.Client.Compat.Prelude
 
 import Distribution.Client.NixStyleOptions
@@ -209,7 +210,7 @@ updateRepo verbosity _updateFlags repoCtxt (repo, indexState) = do
       case updated of
         Sec.NoUpdates  -> do
           now <- getCurrentTime
-          setModificationTime (indexBaseName repo <.> "tar") now
+          _ <- try $ setModificationTime (indexBaseName repo <.> "tar") now :: IO (Either SomeException ())
           noticeNoWrap verbosity $
             "Package list of " ++ prettyShow rname ++
             " is up to date at index-state " ++ prettyShow (IndexStateTime current_ts)

--- a/cabal-install/src/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/src/Distribution/Client/CmdUpdate.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE NamedFieldPuns  #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections   #-}
 {-# LANGUAGE ViewPatterns    #-}
 
@@ -43,7 +44,7 @@ import Distribution.Client.Setup
 import Distribution.Simple.Flag
          ( fromFlagOrDefault )
 import Distribution.Simple.Utils
-         ( die', notice, wrapText, writeFileAtomic, noticeNoWrap )
+         ( die', notice, wrapText, writeFileAtomic, noticeNoWrap, warn )
 import Distribution.Verbosity
          ( normal, lessVerbose )
 import Distribution.Client.IndexUtils.Timestamp
@@ -210,7 +211,7 @@ updateRepo verbosity _updateFlags repoCtxt (repo, indexState) = do
       case updated of
         Sec.NoUpdates  -> do
           now <- getCurrentTime
-          _ <- try $ setModificationTime (indexBaseName repo <.> "tar") now :: IO (Either SomeException ())
+          setModificationTime (indexBaseName repo <.> "tar") now `catch` (\(e :: SomeException) -> warn verbosity $ "Could not set modification time of index tarball -- " ++ show e)
           noticeNoWrap verbosity $
             "Package list of " ++ prettyShow rname ++
             " is up to date at index-state " ++ prettyShow (IndexStateTime current_ts)

--- a/cabal-install/src/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/src/Distribution/Client/CmdUpdate.hs
@@ -211,7 +211,8 @@ updateRepo verbosity _updateFlags repoCtxt (repo, indexState) = do
       case updated of
         Sec.NoUpdates  -> do
           now <- getCurrentTime
-          setModificationTime (indexBaseName repo <.> "tar") now `catch` (\(e :: SomeException) -> warn verbosity $ "Could not set modification time of index tarball -- " ++ show e)
+          setModificationTime (indexBaseName repo <.> "tar") now `catchIO`
+             (\e -> warn verbosity $ "Could not set modification time of index tarball -- " ++ displayException e)
           noticeNoWrap verbosity $
             "Package list of " ++ prettyShow rname ++
             " is up to date at index-state " ++ prettyShow (IndexStateTime current_ts)

--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -366,7 +366,7 @@ readRepoIndex verbosity repoCtxt repo idxState =
   handleNotFound $ do
     when (isRepoRemote repo) $ warnIfIndexIsOld =<< getIndexFileAge repo
     -- note that if this step fails due to a bad repocache, the the procedure can still succeed by reading from the existing cache, which is updated regardless.
-    _ <- try $ updateRepoIndexCache verbosity (RepoIndex repoCtxt repo) :: IO (Either SomeException ())
+    updateRepoIndexCache verbosity (RepoIndex repoCtxt repo) `catch` (\(e :: SomeException) -> warn verbosity $ "unable to update the repo index cache -- " ++ displayException e)
     readPackageIndexCacheFile verbosity mkAvailablePackage
                               (RepoIndex repoCtxt repo)
                               idxState

--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -247,7 +247,7 @@ getSourcePackagesAtIndexState verbosity repoCtxt mb_idxState mb_activeRepos = do
             " as explicitly requested (via command line / project configuration)"
           return idxState
         Nothing -> do
-          mb_idxState' <- readIndexTimestamp (RepoIndex repoCtxt r)
+          mb_idxState' <- readIndexTimestamp verbosity (RepoIndex repoCtxt r)
           case mb_idxState' of
             Nothing -> do
               info verbosity "Using most recent state (could not read timestamp file)"
@@ -366,7 +366,8 @@ readRepoIndex verbosity repoCtxt repo idxState =
   handleNotFound $ do
     when (isRepoRemote repo) $ warnIfIndexIsOld =<< getIndexFileAge repo
     -- note that if this step fails due to a bad repocache, the the procedure can still succeed by reading from the existing cache, which is updated regardless.
-    updateRepoIndexCache verbosity (RepoIndex repoCtxt repo) `catch` (\(e :: SomeException) -> warn verbosity $ "unable to update the repo index cache -- " ++ displayException e)
+    updateRepoIndexCache verbosity (RepoIndex repoCtxt repo) `catchIO`
+       (\e -> warn verbosity $ "unable to update the repo index cache -- " ++ displayException e)
     readPackageIndexCacheFile verbosity mkAvailablePackage
                               (RepoIndex repoCtxt repo)
                               idxState
@@ -1055,7 +1056,7 @@ writeIndexTimestamp index st
 -- timestamp you would use to revert to this version
 currentIndexTimestamp :: Verbosity -> RepoContext -> Repo -> IO Timestamp
 currentIndexTimestamp verbosity repoCtxt r = do
-    mb_is <- readIndexTimestamp (RepoIndex repoCtxt r)
+    mb_is <- readIndexTimestamp verbosity (RepoIndex repoCtxt r)
     case mb_is of
       Just (IndexStateTime ts) -> return ts
       _ -> do
@@ -1063,14 +1064,14 @@ currentIndexTimestamp verbosity repoCtxt r = do
         return (isiHeadTime isi)
 
 -- | Read the 'IndexState' from the filesystem
-readIndexTimestamp :: Index -> IO (Maybe RepoIndexState)
-readIndexTimestamp index
+readIndexTimestamp :: Verbosity -> Index -> IO (Maybe RepoIndexState)
+readIndexTimestamp verbosity index
   = fmap simpleParsec (readFile (timestampFile index))
         `catchIO` \e ->
             if isDoesNotExistError e
                 then return Nothing
                 else do
-                   putStrLn $ "Warning: could not read current index timestamp: " ++ show e
+                   warn verbosity $ "Warning: could not read current index timestamp: " ++ displayException e
                    return Nothing
 
 -- | Optimise sharing of equal values inside 'Cache'


### PR DESCRIPTION
Resolves https://github.com/haskell/cabal/issues/5518 and https://github.com/haskell/cabal/issues/4987

Both these errors are in theory non-fatal, but simply gave uncaught exceptions. Cabal now warns on the exceptions and continues. This improves the resilience of cabal to bad cached index state from remote repositories, but does not solve the general problem completely. The most general path is to implement https://github.com/haskell/hackage-security/issues/199