### PR TITLE
Describe a gitpod workflow for docs.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -16,6 +16,21 @@ Building the documentation requires Python 3 be installed
 * Python on Mac OS X dislikes `LC_CTYPE=UTF-8`, unset the env var in
 terminal preferences and instead set `LC_ALL=en_US.UTF-8` or something
 
+### Gitpod workflow
+
+From a fork of cabal, these docs can be edited online with
+[gitpod](https://www.gitpod.io/):
+
+* Open in gitpod https://gitpod.io/#https://github.com/username/cabal
+* Install the virtual environment prerequisite.
+  `> sudo apt install python3.8-venv`
+* Build the user guide `> make users-guide`.
+* Open the guide in a local browser.
+  `> python -m http.server 8000 --directory=dist-newstyle/doc/users-guide`
+
+Make your edits, rebuild the guide and refresh the browser to preview the
+changes. When happy, commit your changes with git in the included terminal.
+
 ### Caveats, for newcomers to RST from MD
 RST does not allow you to skip section levels when nesting, like MD
 does.


### PR DESCRIPTION
I tried doing a comprehensive pre-canned set up for gitpod with a `.gitpod.yml` and `.gitpod.Dockerfile` but couldn't quite get that to work so settled on something manual. This is a quick way of contributing to the docs without having to have a local python and sphinx setup for building and previewing changes as a fix for #7975.
