### PR TITLE
Consistent starting capital letter, ending period in help text.

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdBench.hs
+++ b/cabal-install/src/Distribution/Client/CmdBench.hs
@@ -41,7 +41,7 @@ import Distribution.Simple.Utils
 benchCommand :: CommandUI (NixStyleFlags ())
 benchCommand = CommandUI {
   commandName         = "v2-bench",
-  commandSynopsis     = "Run benchmarks",
+  commandSynopsis     = "Run benchmarks.",
   commandUsage        = usageAlternatives "v2-bench" [ "[TARGETS] [FLAGS]" ],
   commandDescription  = Just $ \_ -> wrapText $
         "Runs the specified benchmarks, first ensuring they are up to "

--- a/cabal-install/src/Distribution/Client/CmdConfigure.hs
+++ b/cabal-install/src/Distribution/Client/CmdConfigure.hs
@@ -40,7 +40,7 @@ import Distribution.Client.ProjectConfig.Types
 configureCommand :: CommandUI (NixStyleFlags ())
 configureCommand = CommandUI {
   commandName         = "v2-configure",
-  commandSynopsis     = "Add extra project configuration",
+  commandSynopsis     = "Add extra project configuration.",
   commandUsage        = usageAlternatives "v2-configure" [ "[FLAGS]" ],
   commandDescription  = Just $ \_ -> wrapText $
         "Adjust how the project is built by setting additional package flags "

--- a/cabal-install/src/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddock.hs
@@ -40,7 +40,7 @@ newtype ClientHaddockFlags = ClientHaddockFlags { openInBrowser :: Flag Bool }
 haddockCommand :: CommandUI (NixStyleFlags ClientHaddockFlags)
 haddockCommand = CommandUI {
   commandName         = "v2-haddock",
-  commandSynopsis     = "Build Haddock documentation",
+  commandSynopsis     = "Build Haddock documentation.",
   commandUsage        = usageAlternatives "v2-haddock" [ "[FLAGS] TARGET" ],
   commandDescription  = Just $ \_ -> wrapText $
         "Build Haddock documentation for the specified packages within the "

--- a/cabal-install/src/Distribution/Client/CmdListBin.hs
+++ b/cabal-install/src/Distribution/Client/CmdListBin.hs
@@ -55,11 +55,11 @@ import qualified Distribution.Solver.Types.ComponentDeps as CD
 listbinCommand :: CommandUI (NixStyleFlags ())
 listbinCommand = CommandUI
     { commandName = "list-bin"
-    , commandSynopsis = "list path to a single executable."
+    , commandSynopsis = "List the path to a single executable."
     , commandUsage = \pname ->
         "Usage: " ++ pname ++ " list-bin [FLAGS] TARGET\n"
     , commandDescription  = Just $ \_ -> wrapText
-        "List path to a build product."
+        "List the path to a build product."
     , commandNotes = Nothing
     , commandDefaultFlags = defaultNixStyleFlags ()
     , commandOptions      = nixStyleOptions (const [])

--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -98,7 +98,7 @@ import System.Directory
 outdatedCommand :: CommandUI (ProjectFlags, OutdatedFlags)
 outdatedCommand = CommandUI
   { commandName = "outdated"
-  , commandSynopsis = "Check for outdated dependencies"
+  , commandSynopsis = "Check for outdated dependencies."
   , commandDescription  = Just $ \_ -> wrapText $
       "Checks for outdated dependencies in the package description file "
       ++ "or freeze file"

--- a/cabal-install/src/Distribution/Client/CmdTest.hs
+++ b/cabal-install/src/Distribution/Client/CmdTest.hs
@@ -46,7 +46,7 @@ import qualified System.Exit (exitSuccess)
 testCommand :: CommandUI (NixStyleFlags ())
 testCommand = CommandUI
   { commandName         = "v2-test"
-  , commandSynopsis     = "Run test-suites"
+  , commandSynopsis     = "Run test-suites."
   , commandUsage        = usageAlternatives "v2-test" [ "[TARGETS] [FLAGS]" ]
   , commandDescription  = Just $ \_ -> wrapText $
         "Runs the specified test-suites, first ensuring they are up to "


### PR DESCRIPTION
Very minor change for consistency. After the fix:

```
> cabal help
Command line interface to the Haskell Cabal infrastructure.

See http://www.haskell.org/cabal/ for more information.

Usage: <interactive> [GLOBAL FLAGS] [COMMAND [FLAGS]]

Commands:
 [global]
  update            Updates list of known packages.
  install           Install packages.

  help              Help about commands.
  info              Display detailed information about a particular package.
  list              List packages matching a search string.
  fetch             Downloads packages for later installation.
  user-config       Display and update the user's global cabal configuration.

 [package]
  get               Download/Extract a package's source code (repository).
  unpack            Deprecated alias for 'get'.
  init              Create a new cabal package.

  configure         Add extra project configuration.
  build             Compile targets within the project.
  clean             Clean the package store and remove temporary files.

  run               Run an executable.
  repl              Open an interactive session for the given component.
  test              Run test-suites.
  bench             Run benchmarks.

  check             Check the package for common mistakes.
  sdist             Generate a source distribution file (.tar.gz).
  upload            Uploads source packages or documentation to Hackage.
  report            Upload build reports to a remote server.

  freeze            Freeze dependencies.
  gen-bounds        Generate dependency bounds.
  outdated          Check for outdated dependencies.
  haddock           Build Haddock documentation.
  hscolour          Generate HsColour colourised code, in HTML format.
  exec              Give a command access to the store.
  list-bin          List the path to a single executable.

 [new-style projects (forwards-compatible aliases)]
  v2-build          Compile targets within the project.
  v2-configure      Add extra project configuration.
  v2-repl           Open an interactive session for the given component.
  v2-run            Run an executable.
  v2-test           Run test-suites.
  v2-bench          Run benchmarks.
  v2-freeze         Freeze dependencies.
  v2-haddock        Build Haddock documentation.
  v2-exec           Give a command access to the store.
  v2-update         Updates list of known packages.
  v2-install        Install packages.
  v2-clean          Clean the package store and remove temporary files.
  v2-sdist          Generate a source distribution file (.tar.gz).

 [legacy command aliases]
  v1-build          Compile all/specific components.
  v1-configure      Prepare to build the package.
  v1-repl           Open an interpreter session for the given component.
  v1-run            Builds and runs an executable.
  v1-test           Run all/specific tests in the test suite.
  v1-bench          Run all/specific benchmarks.
  v1-freeze         Freeze dependencies.
  v1-haddock        Generate Haddock HTML documentation.


  v1-install        Install packages.
  v1-clean          Clean up after a build.


  v1-copy           Copy the files of all/specific components to install locations.
  v1-register       Register this package with the compiler.
  v1-reconfigure    Reconfigure the package if necessary.

For more information about a command use:
   <interactive> COMMAND --help
or <interactive> help COMMAND

To install Cabal packages from hackage use:
  <interactive> install foo [--dry-run]

Occasionally you need to update the list of available packages:
  <interactive> update

Global flags:
 -h, --help                     Show this help text
 -V, --version                  Print version information
 --numeric-version              Print just the version number
 --config-file=FILE             Set an alternate location for the config file
 --ignore-expiry                Ignore expiry dates on signed metadata (use
                                only in exceptional circumstances)
 --http-transport=HttpTransport
                                Set a transport for http(s) requests. Accepts
                                'curl', 'wget', 'powershell', and
                                'plain-http'. (default: 'curl')
 --enable-nix                   Enable Nix integration: run commands through
                                nix-shell if a 'shell.nix' file exists
 --disable-nix                  Disable Nix integration: run commands through
                                nix-shell if a 'shell.nix' file exists
 --store-dir=DIR                The location of the build store
 --active-repositories=REPOS    The active package repositories (set to
                                ':none' to disable all repositories)

You can edit the cabal configuration file to set defaults:
  /Users/.../.cabal/config
```
