### PR TITLE
Fix 7835 for 3.6

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -270,7 +270,7 @@ executable cabal
         base16-bytestring >= 0.1.1 && < 1.1.0.0,
         binary     >= 0.7.3    && < 0.9,
         bytestring >= 0.10.6.0 && < 0.12,
-        Cabal      >= 3.6.1.0  && < 3.7
+        Cabal      >= 3.6.1.0  && < 3.7,
         containers >= 0.5.6.2  && < 0.7,
         cryptohash-sha256 >= 0.11 && < 0.12,
         deepseq    >= 1.4.1.1  && < 1.5,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -270,7 +270,7 @@ executable cabal
         base16-bytestring >= 0.1.1 && < 1.1.0.0,
         binary     >= 0.7.3    && < 0.9,
         bytestring >= 0.10.6.0 && < 0.12,
-        Cabal      == 3.6.*,
+        Cabal      >= 3.6.1.0  && < 3.7
         containers >= 0.5.6.2  && < 0.7,
         cryptohash-sha256 >= 0.11 && < 0.12,
         deepseq    >= 1.4.1.1  && < 1.5,
@@ -308,7 +308,7 @@ executable cabal
 
     if os(windows)
       -- newer directory for symlinks
-      build-depends: Win32 >= 2 && < 3, directory >=1.3.1.0
+      build-depends: Win32 >= 2 && < 2.8, directory >=1.3.1.0
     else
       build-depends: unix >= 2.5 && < 2.9
 

--- a/release-notes/Cabal-3.6.1.0.md
+++ b/release-notes/Cabal-3.6.1.0.md
@@ -52,6 +52,7 @@ Cabal 3.6.1.0 Changelog
 
 - lazily decode cache files for checking invalidation [#7516](https://github.com/haskell/cabal/pull/7516) [#7466](https://github.com/haskell/cabal/issues/7466)
   - This yields a significant 15% speedup on rebuilding build plans for projects with lots of individual cabal packages.
+  - It exports the [Tag data type](https://github.com/haskell/cabal/blob/899dd34bc48bbaa43da9a4b2fc354c24fd814d05/Cabal/src/Distribution/Utils/Structured.hs#L67), needed by cabal-install >= 3.6.0.0
 
 - defer build-tools-depends choices as well as setup choices [#7561](https://github.com/haskell/cabal/pull/7561) [#7472](https://github.com/haskell/cabal/issues/7472)
   - extends the existing solver pass that defers solving setup depends until top-level goals are solved to also defer build-tool-depends goals until top level goals are solved.

--- a/release-notes/Cabal-3.6.1.0.md
+++ b/release-notes/Cabal-3.6.1.0.md
@@ -52,7 +52,7 @@ Cabal 3.6.1.0 Changelog
 
 - lazily decode cache files for checking invalidation [#7516](https://github.com/haskell/cabal/pull/7516) [#7466](https://github.com/haskell/cabal/issues/7466)
   - This yields a significant 15% speedup on rebuilding build plans for projects with lots of individual cabal packages.
-  - It exports the [Tag data type](https://github.com/haskell/cabal/blob/899dd34bc48bbaa43da9a4b2fc354c24fd814d05/Cabal/src/Distribution/Utils/Structured.hs#L67), needed by cabal-install >= 3.6.0.0
+  - It exports the [Tag data type](https://github.com/haskell/cabal/blob/899dd34bc48bbaa43da9a4b2fc354c24fd814d05/Cabal/src/Distribution/Utils/Structured.hs#L67), needed by `cabal-install >= 3.6.0.0`.
 
 - defer build-tools-depends choices as well as setup choices [#7561](https://github.com/haskell/cabal/pull/7561) [#7472](https://github.com/haskell/cabal/issues/7472)
   - extends the existing solver pass that defers solving setup depends until top-level goals are solved to also defer build-tool-depends goals until top level goals are solved.


### PR DESCRIPTION
Fixes #7835 for the 3.6. branch

- [X] add Tag note to Cabal-3.6.1.0 release notes/changelog
- [X] add bounds to cabal-install that exclude Cabal-3.6.0.0
- [X] Plus please revise earlier releases of cabal-install, they have lax bounds Win32 < 3 as well.

---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.
