### PR TITLE
Add support for cabal.project fields to scripts

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -29,6 +29,8 @@ module Distribution.Client.ProjectConfig (
     readGlobalConfig,
     readProjectLocalExtraConfig,
     readProjectLocalFreezeConfig,
+    parseProjectConfig,
+    reportParseResult,
     showProjectConfig,
     withProjectOrGlobalConfig,
     writeProjectLocalExtraConfig,

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptWithProjectBlock/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptWithProjectBlock/cabal.out
@@ -1,0 +1,7 @@
+# cabal v2-run
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O2
+In order, the following will be built:
+ - fake-package-0 (exe:cabal-script-s.hs) (first run)
+Configuring executable 'cabal-script-s.hs' for fake-package-0..
+Building executable 'cabal-script-s.hs' for fake-package-0..

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptWithProjectBlock/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptWithProjectBlock/cabal.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+    -- script is called "s.hs" to avoid Windows long path issue in CI
+    res <- cabal' "v2-run" ["s.hs"]
+    assertOutputContains "Hello World" res

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptWithProjectBlock/s.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/ScriptWithProjectBlock/s.hs
@@ -1,0 +1,10 @@
+#!/usr/bin/env cabal
+{- cabal:
+build-depends: base
+-}
+{- project:
+optimization: 2
+-}
+
+main :: IO ()
+main = putStrLn "Hello World"

--- a/changelog.d/pr-7851
+++ b/changelog.d/pr-7851
@@ -1,7 +1,7 @@
 synopsis:  Better support for scripts
 packages: cabal-install
-prs: #7851 #7925 #7938 #7990
-issues: #7842 #7073 #6354 #6149 #5508
+prs: #7851 #7925 #7938 #7990 #7997
+issues: #7842 #7073 #6354 #6149 #5508 #5698
 
 description: {
 
@@ -15,5 +15,7 @@ description: {
 - The name of the generated script executable has been changed from "script" to
   "cabal-script-<your-sanitized-script-name>" for easier process management.
 - Reduce the default verbosity of scripts, so that the build output doesn't interfere with the script output.
+- Scripts now support a project metadata block that allows them to use options
+  that would normally be set in a cabal.project file.
 
 }

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -480,6 +480,10 @@ Where there cabal metadata block is mandatory and contains fields from a
 package executable block, and the project metadata block is optional and
 contains fields that would be in the cabal.project file in a regular project.
 
+Only some fields are supported in the metadata blocks, and these fields are
+currently not validated. See
+`#8024 <https://github.com/haskell/cabal/issues/8024>`__ for details.
+
 It can either be executed like any other script, using ``cabal`` as an
 interpreter, or through this command:
 

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -465,13 +465,20 @@ a script that looks like:
 
     #!/usr/bin/env cabal
     {- cabal:
-    build-depends: base ^>= 4.11
-                , shelly ^>= 1.8.1
+    build-depends: base ^>= 4.14
+                , shelly ^>= 1.10
+    -}
+    {- project:
+    with-compiler: ghc-8.10.7
     -}
 
     main :: IO ()
     main = do
         ...
+
+Where there cabal metadata block is mandatory and contains fields from a
+package executable block, and the project metadata block is optional and
+contains fields that would be in the cabal.project file in a regular project.
 
 It can either be executed like any other script, using ``cabal`` as an
 interpreter, or through this command:

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -436,13 +436,15 @@ See `the v2-build section <#cabal-v2-build>`__ for the target syntax.
 
 When ``TARGET`` is one of the following:
 
-- A component target: execute the specified executable, benchmark or test suite
+- A component target: execute the specified executable, benchmark or test suite.
 
 - A package target:
    1. If the package has exactly one executable component, it will be selected.
    2. If the package has multiple executable components, an error is raised.
    3. If the package has exactly one test or benchmark component, it will be selected.
-   4. Otherwise an issue is raised
+   4. Otherwise an issue is raised.
+
+- The path to a script: execute the script at the path.
 
 - Empty target: Same as package target, implicitly using the package from the current
   working directory.
@@ -458,8 +460,8 @@ have to separate them with ``--``.
 
     $ cabal v2-run target -- -a -bcd --argument
 
-``v2-run`` also supports running script files that use a certain format. With
-a script that looks like:
+``v2-run`` supports running script files that use a certain format.
+Scripts look like:
 
 ::
 
@@ -484,13 +486,12 @@ Only some fields are supported in the metadata blocks, and these fields are
 currently not validated. See
 `#8024 <https://github.com/haskell/cabal/issues/8024>`__ for details.
 
-It can either be executed like any other script, using ``cabal`` as an
-interpreter, or through this command:
+A script can either be executed directly using `cabal` as an interpreter or
+with the command:
 
 ::
 
     $ cabal v2-run path/to/script
-    $ cabal v2-run path/to/script -- --arg1 # args are passed like this
 
 The executable is cached under the cabal directory, and can be pre-built with
 ``cabal v2-build path/to/script`` and the cache can be removed with


### PR DESCRIPTION
Closes #5698

Currently, as with the executable block, this just reads it and does not attempt to validate that the fields set are relevant to scripts. I think this is probably fine, but I'm open to discussing it.