### PR TITLE
allow trailing whitespace after flags

### DIFF
--- a/Cabal-syntax/src/Distribution/Compat/CharParsing.hs
+++ b/Cabal-syntax/src/Distribution/Compat/CharParsing.hs
@@ -41,7 +41,6 @@ module Distribution.Compat.CharParsing
   , signedIntegral
   , munch1
   , munch
-  , skipSpaces
   , skipSpaces1
   , module Distribution.Compat.Parsing
   ) where
@@ -356,7 +355,3 @@ munch = many . satisfy
 skipSpaces1 :: CharParsing m => m ()
 skipSpaces1 = skipSome space
 {-# INLINE skipSpaces1 #-}
-
-skipSpaces :: CharParsing m => m ()
-skipSpaces = skipMany space
-{-# INLINE skipSpaces #-}

--- a/Cabal-syntax/src/Distribution/Compat/CharParsing.hs
+++ b/Cabal-syntax/src/Distribution/Compat/CharParsing.hs
@@ -41,6 +41,7 @@ module Distribution.Compat.CharParsing
   , signedIntegral
   , munch1
   , munch
+  , skipSpaces
   , skipSpaces1
   , module Distribution.Compat.Parsing
   ) where
@@ -334,7 +335,7 @@ integral = toNumber <$> some d <?> "integral"
 
 -- | Accepts negative (starting with @-@) and positive (without sign) integral
 -- numbers.
--- 
+--
 -- @since 3.4.0.0
 signedIntegral :: (CharParsing m, Integral a) => m a
 signedIntegral = negate <$ char '-' <*> integral <|> integral
@@ -355,3 +356,7 @@ munch = many . satisfy
 skipSpaces1 :: CharParsing m => m ()
 skipSpaces1 = skipSome space
 {-# INLINE skipSpaces1 #-}
+
+skipSpaces :: CharParsing m => m ()
+skipSpaces = skipMany space
+{-# INLINE skipSpaces #-}

--- a/Cabal-syntax/src/Distribution/Types/Flag.hs
+++ b/Cabal-syntax/src/Distribution/Types/Flag.hs
@@ -111,7 +111,7 @@ instance Parsec FlagName where
     -- cabal check will do that.
     parsec = mkFlagName . lowercase <$> parsec'
       where
-        parsec' = (:) <$> lead <*> rest
+        parsec' = (<* P.skipSpaces) $ (:) <$> lead <*> rest
         lead = P.satisfy (\c ->  isAlphaNum c || c == '_')
         rest = P.munch (\c -> isAlphaNum c ||  c == '_' || c == '-')
 

--- a/Cabal-syntax/src/Distribution/Types/Flag.hs
+++ b/Cabal-syntax/src/Distribution/Types/Flag.hs
@@ -111,7 +111,7 @@ instance Parsec FlagName where
     -- cabal check will do that.
     parsec = mkFlagName . lowercase <$> parsec'
       where
-        parsec' = (<* P.skipSpaces) $ (:) <$> lead <*> rest
+        parsec' = (:) <$> lead <*> rest
         lead = P.satisfy (\c ->  isAlphaNum c || c == '_')
         rest = P.munch (\c -> isAlphaNum c ||  c == '_' || c == '-')
 
@@ -272,16 +272,17 @@ dispFlagAssignment = Disp.hsep . map (Disp.text . showFlagValue) . unFlagAssignm
 
 -- | Parses a flag assignment.
 parsecFlagAssignment :: CabalParsing m => m FlagAssignment
-parsecFlagAssignment = mkFlagAssignment <$>
-                       P.sepBy (onFlag <|> offFlag) P.skipSpaces1
+parsecFlagAssignment = mkFlagAssignment <$> many (onFlag <|> offFlag)
   where
     onFlag = do
         _ <- P.char '+'
         f <- parsec
+        _ <- P.skipSpaces
         return (f, True)
     offFlag = do
         _ <- P.char '-'
         f <- parsec
+        _ <- P.skipSpaces
         return (f, False)
 
 -- | Parse a non-empty flag assignment
@@ -290,16 +291,17 @@ parsecFlagAssignment = mkFlagAssignment <$>
 --
 -- @since 3.4.0.0
 parsecFlagAssignmentNonEmpty :: CabalParsing m => m FlagAssignment
-parsecFlagAssignmentNonEmpty = mkFlagAssignment . toList <$>
-    P.sepByNonEmpty (onFlag <|> offFlag) P.skipSpaces1
+parsecFlagAssignmentNonEmpty = mkFlagAssignment <$> some (onFlag <|> offFlag)
   where
     onFlag = do
         _ <- P.char '+'
         f <- parsec
+        _ <- P.skipSpaces
         return (f, True)
     offFlag = do
         _ <- P.char '-'
         f <- parsec
+        _ <- P.skipSpaces
         return (f, False)
 
 -- | Show flag assignment.


### PR DESCRIPTION
Resolves https://github.com/haskell/cabal/issues/7279

We just weren't lexing trailing whitespace in flag names. So a constraint like "pkg +flag , ..." would fail while "pkg +flag, ..." would succeed.

* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [x] Tests
