### PR TITLE
Remove overlapping patterns

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1734,10 +1734,6 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
                 elaboratedSharedConfig
                 elab)  -- recursive use of elab
 
-          | otherwise
-          = error $ "elaborateInstallPlan: non-inplace package "
-                 ++ " is missing a source hash: " ++ prettyShow pkgid
-
         -- Need to filter out internal dependencies, because they don't
         -- correspond to anything real anymore.
         isExt confid = confSrcId confid /= pkgid
@@ -3495,7 +3491,6 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
                               = Map.toList $
                                 Map.insertWith (++) "ghc" ["-hide-all-packages"]
                                                elabProgramArgs
-        | otherwise           = Map.toList elabProgramArgs
     configProgramPathExtra    = toNubList elabProgramPathExtra
     configHcFlavor            = toFlag (compilerFlavor pkgConfigCompiler)
     configHcPath              = mempty -- we use configProgramPaths instead


### PR DESCRIPTION
These two `otherwise`s have been dead code since about 2016 but GHC has
started warning about them only since 9.2.

I have checked that in these cases GHC has always been picking the first matching pattern.