### PR TITLE
Use ref instead head_ref to cancelling jobs

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -2,7 +2,7 @@ name: Bootstrap
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,7 @@ name: Linux
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,7 +2,7 @@ name: MacOS
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -2,7 +2,7 @@ name: Quick jobs
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/users-guide.yml
+++ b/.github/workflows/users-guide.yml
@@ -4,7 +4,7 @@ name: Users guide
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,7 @@ name: Windows
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
+  group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
As per @fgaz question here: https://github.com/haskell/cabal/pull/8000#discussion_r813643975

Rationale

> Good point head_ref is only defined for pull requests and workflows are triggered for direct commits too.
The consequence is that, for consecutive direct and merge commits in master (and 3.6, 3.4 etc), they will be cancelled but the last one.
> So we will lose the status of those intermmediate commits.
> There is a small probability of a green pr breaking master cause we are not enforcing the pr is up to date with master before merging it. Also there is a even small probability of merge another pr just after the offending one and we will not know the real cause is the intemmediate and no the final one.

---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).


Please also shortly describe how you tested your change. Bonus points for added tests!
