### PR TITLE
[3.4] cabal-install.cabal: allow base-4.15 (ghc-9.0)

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -336,7 +336,7 @@ executable cabal
     build-depends:
         async      >= 2.0      && < 2.3,
         array      >= 0.4      && < 0.6,
-        base       >= 4.8      && < 4.15,
+        base       >= 4.8      && < 4.16,
         base16-bytestring >= 0.1.1 && < 1.1.0.0,
         binary     >= 0.7.3    && < 0.9,
         bytestring >= 0.10.6.0 && < 0.11,


### PR DESCRIPTION
This allows building cabal-install-3.4 with ghc-9.0.

I have tested that cabal-install-3.4.1.0 can build with this in current Stackage Nightly (ghc-9.0.2)
