### PR TITLE
Rebased version of #6703: Remove v2- prefix from command, package, and project docs.

### DIFF
--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -37,7 +37,7 @@ legacy sections. We talk in detail about some global and package commands.
     list-bin          List path to a single executable.
 
     [new-style projects (forwards-compatible aliases)]
-    Since cabal-install-3.0.0.0 all v2 prefixed commands are alias for the default, unprefixed ones.
+    Since cabal-install-3.0.0.0, all 'v2-' prefixed names of commands are just aliases for the simple unprefixed names.
     So v2-build is an alias for build, v2-install for install and so on.
 
     [legacy command aliases]

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -2,8 +2,7 @@ cabal-install Commands
 ======================
 
 ``cabal help`` groups commands into global, package, new-style project and
-legacy sections. We talk in detail about some global and package commands,
-``help`` and ``list-bin`` but there are other commands.
+legacy sections. We talk in detail about some global and package commands.
 
 ::
 

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -230,7 +230,7 @@ We can also scope to test suite targets as they produce binaries.
     /.../dist-newstyle/.../unit-tests/unit-tests
 
 cabal configure
--------------------
+---------------
 
 ``cabal configure`` takes a set of arguments and writes a
 ``cabal.project.local`` file based on the flags passed to this command.
@@ -278,7 +278,7 @@ flag.
 
 
 cabal update
-----------------
+------------
 
 ``cabal update`` updates the state of the package index. If the
 project contains multiple remote package repositories it will update
@@ -328,7 +328,7 @@ A cabal command target can take any of the following forms:
    Script targets are not part of a package.
 
 cabal build
----------------
+-----------
 
 ``cabal build`` takes a set of targets and builds them. It
 automatically handles building and installing any dependencies of these
@@ -372,7 +372,7 @@ In addition ``cabal build`` accepts these flags:
 
 
 cabal repl
---------------
+----------
 
 ``cabal repl TARGET`` loads all of the modules of the target into
 GHCi as interpreted bytecode. In addition to ``cabal build``'s flags,
@@ -429,7 +429,7 @@ and can be pre-built with ``cabal build path/to/script``.
 See ``cabal run`` for more information on scripts.
 
 cabal run
--------------
+---------
 
 ``cabal run [TARGET [ARGS]]`` runs the executable specified by the
 target, which can be a component, a package or can be left blank, as
@@ -521,7 +521,7 @@ or the interpreter line
 For more information see :cfg-field:`verbose`
 
 cabal freeze
-----------------
+------------
 
 ``cabal freeze`` writes out a **freeze file** which records all of
 the versions and flags that are picked by the solver under the
@@ -551,21 +551,21 @@ recommended: users often need to build against different versions of
 libraries than what you developed against.
 
 cabal bench
----------------
+-----------
 
 ``cabal bench [TARGETS] [OPTIONS]`` runs the specified benchmarks
 (all the benchmarks in the current package by default), first ensuring
 they are up to date.
 
 cabal test
---------------
+----------
 
 ``cabal test [TARGETS] [OPTIONS]`` runs the specified test suites
 (all the test suites in the current package by default), first ensuring
 they are up to date.
 
 cabal haddock
------------------
+-------------
 
 ``cabal haddock [FLAGS] [TARGET]`` builds Haddock documentation for
 the specified packages within the project.
@@ -575,14 +575,14 @@ If a target is not a library :cfg-field:`haddock-benchmarks`,
 :cfg-field:`haddock-tests` will be implied as necessary.
 
 cabal exec
----------------
+----------
 
 ``cabal exec [FLAGS] [--] COMMAND [--] [ARGS]`` runs the specified command
 using the project's environment. That is, passing the right flags to compiler
 invocations and bringing the project's executables into scope.
 
 cabal install
------------------
+-------------
 
 ``cabal install [FLAGS] [TARGETS]`` builds the specified target packages and
 symlinks/copies their executables in ``installdir`` (usually ``~/.cabal/bin``).
@@ -673,7 +673,7 @@ You can learn more about how to use these environments in `this section of the
 GHC manual <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#package-environments>`_.
 
 cabal clean
----------------
+-----------
 
 ``cabal clean [FLAGS]`` cleans up the temporary files and build artifacts
 stored in the ``dist-newstyle`` folder.
@@ -690,7 +690,7 @@ In addition when clean is invoked it will remove all script build artifacts for
 which the corresponding script no longer exists.
 
 cabal sdist
----------------
+-----------
 
 ``cabal sdist [FLAGS] [TARGETS]`` takes the crucial files needed to build ``TARGETS``
 and puts them into an archive format ready for upload to Hackage. These archives are stable

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -2,7 +2,7 @@ cabal-install Commands
 ======================
 
 ``cabal help`` groups commands into global, package, new-style project and
-legacy sections. We talk in detail about some of the new-style project commands,
+legacy sections. We talk in detail about some global and package commands,
 ``help`` and ``list-bin`` but there are other commands.
 
 ::
@@ -16,25 +16,30 @@ legacy sections. We talk in detail about some of the new-style project commands,
 
     Commands:
     [global]
+    update            Updates list of known packages.
+    install           Install packages.
     help              Help about commands.
 
     [package]
-    list-bin          list path to a single executable.
+    configure         Add extra project configuration.
+    build             Compile targets within the project.
+    clean             Clean the package store and remove temporary files.
+
+    run               Run an executable.
+    repl              Open an interactive session for the given component.
+    test              Run test-suites.
+    bench             Run benchmarks.
+
+    sdist             Generate a source distribution file (.tar.gz).
+
+    freeze            Freeze dependencies.
+    haddock           Build Haddock documentation.
+    exec              Give a command access to the store.
+    list-bin          List path to a single executable.
 
     [new-style projects (forwards-compatible aliases)]
-    v2-build          Compile targets within the project.
-    v2-configure      Add extra project configuration
-    v2-repl           Open an interactive session for the given component.
-    v2-run            Run an executable.
-    v2-test           Run test-suites
-    v2-bench          Run benchmarks
-    v2-freeze         Freeze dependencies.
-    v2-haddock        Build Haddock documentation
-    v2-exec           Give a command access to the store.
-    v2-update         Updates list of known packages.
-    v2-install        Install packages.
-    v2-clean          Clean the package store and remove temporary files.
-    v2-sdist          Generate a source distribution file (.tar.gz).
+    Since cabal-install-3.0.0.0 all v2 prefixed commands are alias for the default, unprefixed ones.
+    So v2-build is an alias for build, v2-install for install and so on.
 
     [legacy command aliases]
     No legacy commands are described.
@@ -187,7 +192,7 @@ cabal list-bin
 
 ``cabal list-bin`` will either (a) display the path for a single executable or (b)
 complain that the target doesn't resolve to a single binary. In the latter case,
-it will name the binary products contained in the package. These products can 
+it will name the binary products contained in the package. These products can
 be used to narrow the search and get an actual path to a particular executable.
 
 Example showing a failure to resolve to a single executable.
@@ -225,24 +230,24 @@ We can also scope to test suite targets as they produce binaries.
     $ cabal list-bin cabal-install:unit-tests
     /.../dist-newstyle/.../unit-tests/unit-tests
 
-cabal v2-configure
+cabal configure
 -------------------
 
-``cabal v2-configure`` takes a set of arguments and writes a
+``cabal configure`` takes a set of arguments and writes a
 ``cabal.project.local`` file based on the flags passed to this command.
-``cabal v2-configure FLAGS; cabal v2-build`` is roughly equivalent to
-``cabal v2-build FLAGS``, except that with ``v2-configure`` the flags
-are persisted to all subsequent calls to ``v2-build``.
+``cabal configure FLAGS; cabal build`` is roughly equivalent to
+``cabal build FLAGS``, except that with ``configure`` the flags
+are persisted to all subsequent calls to ``build``.
 
-``cabal v2-configure`` is intended to be a convenient way to write out
+``cabal configure`` is intended to be a convenient way to write out
 a ``cabal.project.local`` for simple configurations; e.g.,
-``cabal v2-configure -w ghc-7.8`` would ensure that all subsequent
-builds with ``cabal v2-build`` are performed with the compiler
+``cabal configure -w ghc-7.8`` would ensure that all subsequent
+builds with ``cabal build`` are performed with the compiler
 ``ghc-7.8``. For more complex configuration, we recommend writing the
 ``cabal.project.local`` file directly (or placing it in
 ``cabal.project``!)
 
-``cabal v2-configure`` inherits options from ``Cabal``. semantics:
+``cabal configure`` inherits options from ``Cabal``. semantics:
 
 -  Any flag accepted by ``./Setup configure``.
 
@@ -264,7 +269,7 @@ apply options to an external package, use a ``package`` stanza in a
 ``cabal.project`` file.
 
 There are two ways of modifying the ``cabal.project.local`` file through
-``cabal v2-configure``, either by appending new configurations to it, or
+``cabal configure``, either by appending new configurations to it, or
 by simply overwriting it all. Overwriting is the default behaviour, as
 such, there's a flag ``--enable-append`` to append the new configurations
 instead. Since overwriting is rather destructive in nature, a backup system
@@ -273,10 +278,10 @@ file, this feature can also be disabled by using the ``--disable-backup``
 flag.
 
 
-cabal v2-update
+cabal update
 ----------------
 
-``cabal v2-update`` updates the state of the package index. If the
+``cabal update`` updates the state of the package index. If the
 project contains multiple remote package repositories it will update
 the index of all of them (e.g. when using overlays).
 
@@ -284,8 +289,8 @@ Some examples:
 
 ::
 
-    $ cabal v2-update                  # update all remote repos
-    $ cabal v2-update head.hackage     # update only head.hackage
+    $ cabal update                  # update all remote repos
+    $ cabal update head.hackage     # update only head.hackage
 
 Target Forms
 ------------
@@ -323,10 +328,10 @@ A cabal command target can take any of the following forms:
    file. This is supported by ``build``, ``repl``, ``run``, and ``clean``.
    Script targets are not part of a package.
 
-cabal v2-build
+cabal build
 ---------------
 
-``cabal v2-build`` takes a set of targets and builds them. It
+``cabal build`` takes a set of targets and builds them. It
 automatically handles building and installing any dependencies of these
 targets.
 
@@ -341,37 +346,37 @@ Some example targets:
 
 ::
 
-    $ cabal v2-build lib:foo-pkg       # build the library named foo-pkg
-    $ cabal v2-build foo-pkg:foo-tests # build foo-tests in foo-pkg
-    $ cabal v2-build src/Lib.s         # build the library component to
+    $ cabal build lib:foo-pkg       # build the library named foo-pkg
+    $ cabal build foo-pkg:foo-tests # build foo-tests in foo-pkg
+    $ cabal build src/Lib.s         # build the library component to
                                        # which "src/Lib.hs" belongs
-    $ cabal v2-build app/Main.hs       # build the executable component of
+    $ cabal build app/Main.hs       # build the executable component of
                                        # "app/Main.hs"
-    $ cabal v2-build Lib               # build the library component to
+    $ cabal build Lib               # build the library component to
                                        # which the module "Lib" belongs
-    $ cabal v2-build path/to/script    # build the script as an executable
+    $ cabal build path/to/script    # build the script as an executable
 
-Beyond a list of targets, ``cabal v2-build`` accepts all the flags that
-``cabal v2-configure`` takes. Most of these flags are only taken into
+Beyond a list of targets, ``cabal build`` accepts all the flags that
+``cabal configure`` takes. Most of these flags are only taken into
 consideration when building local packages; however, some flags may
 cause extra store packages to be built (for example,
 ``--enable-profiling`` will automatically make sure profiling libraries
 for all transitive dependencies are built and installed.)
 
 When building a script, the executable is cached under the cabal directory.
-See ``cabal v2-run`` for more information on scripts.
+See ``cabal run`` for more information on scripts.
 
-In addition ``cabal v2-build`` accepts these flags:
+In addition ``cabal build`` accepts these flags:
 
 - ``--only-configure``: When given we will forego performing a full build and
   abort after running the configure phase of each target package.
 
 
-cabal v2-repl
+cabal repl
 --------------
 
-``cabal v2-repl TARGET`` loads all of the modules of the target into
-GHCi as interpreted bytecode. In addition to ``cabal v2-build``'s flags,
+``cabal repl TARGET`` loads all of the modules of the target into
+GHCi as interpreted bytecode. In addition to ``cabal build``'s flags,
 it additionally takes the ``--repl-options`` and ``--repl-no-load`` flags.
 
 To avoid ``ghci`` specific flags from triggering unneeded global rebuilds these
@@ -383,8 +388,8 @@ repl`` and ``Setup repl`` on sufficiently new versions of Cabal.)
 
 The ``repl-no-load`` flag disables the loading of target modules at startup.
 
-Currently, it is not supported to pass multiple targets to ``v2-repl``
-(``v2-repl`` will just successively open a separate GHCi session for
+Currently, it is not supported to pass multiple targets to ``repl``
+(``repl`` will just successively open a separate GHCi session for
 each target.)
 
 It also provides a way to experiment with libraries without needing to download
@@ -395,7 +400,7 @@ of the ``vector`` package matching that specification exposed.
 
 ::
 
-    $ cabal v2-repl --build-depends "vector >= 0.12 && < 0.13"
+    $ cabal repl --build-depends "vector >= 0.12 && < 0.13"
 
 Both of these commands do the same thing as the above, but only exposes ``base``,
 ``vector``, and the ``vector`` package's transitive dependencies even if the user
@@ -403,8 +408,8 @@ is in a project context.
 
 ::
 
-    $ cabal v2-repl --ignore-project --build-depends "vector >= 0.12 && < 0.13"
-    $ cabal v2-repl --project='' --build-depends "vector >= 0.12 && < 0.13"
+    $ cabal repl --ignore-project --build-depends "vector >= 0.12 && < 0.13"
+    $ cabal repl --project='' --build-depends "vector >= 0.12 && < 0.13"
 
 This command would add ``vector``, but not (for example) ``primitive``, because
 it only includes the packages specified on the command line (and ``base``, which
@@ -412,27 +417,27 @@ cannot be excluded for technical reasons).
 
 ::
 
-    $ cabal v2-repl --build-depends vector --no-transitive-deps
+    $ cabal repl --build-depends vector --no-transitive-deps
 
-``v2-repl`` can open scripts by passing the path to the script as the target.
+``repl`` can open scripts by passing the path to the script as the target.
 
 ::
 
-    $ cabal v2-repl path/to/script
+    $ cabal repl path/to/script
 
 The configuration information for the script is cached under the cabal directory
-and can be pre-built with ``cabal v2-build path/to/script``.
-See ``cabal v2-run`` for more information on scripts.
+and can be pre-built with ``cabal build path/to/script``.
+See ``cabal run`` for more information on scripts.
 
-cabal v2-run
+cabal run
 -------------
 
-``cabal v2-run [TARGET [ARGS]]`` runs the executable specified by the
+``cabal run [TARGET [ARGS]]`` runs the executable specified by the
 target, which can be a component, a package or can be left blank, as
 long as it can uniquely identify an executable within the project.
 Tests and benchmarks are also treated as executables.
 
-See `the v2-build section <#cabal-v2-build>`__ for the target syntax.
+See `the build section <#cabal-build>`__ for the target syntax.
 
 When ``TARGET`` is one of the following:
 
@@ -456,9 +461,9 @@ have to separate them with ``--``.
 
 ::
 
-    $ cabal v2-run target -- -a -bcd --argument
+    $ cabal run target -- -a -bcd --argument
 
-``v2-run`` also supports running script files that use a certain format. With
+``run`` also supports running script files that use a certain format. With
 a script that looks like:
 
 ::
@@ -478,12 +483,12 @@ interpreter, or through this command:
 
 ::
 
-    $ cabal v2-run path/to/script
-    $ cabal v2-run path/to/script -- --arg1 # args are passed like this
+    $ cabal run path/to/script
+    $ cabal run path/to/script -- --arg1 # args are passed like this
 
 The executable is cached under the cabal directory, and can be pre-built with
-``cabal v2-build path/to/script`` and the cache can be removed with
-``cabal v2-clean path/to/script``.
+``cabal build path/to/script`` and the cache can be removed with
+``cabal clean path/to/script``.
 
 A note on targets: Whenever a command takes a script target and it matches the
 name of another target, the other target is preferred. To load the script
@@ -494,20 +499,20 @@ build output for a script either use the command
 
 ::
 
-    $ cabal v2-run --verbose=n path/to/script
+    $ cabal run --verbose=n path/to/script
 
 or the interpreter line
 
 ::
 
-    #!/usr/bin/env -S cabal v2-run --verbose=n
+    #!/usr/bin/env -S cabal run --verbose=n
 
 For more information see :cfg-field:`verbose`
 
-cabal v2-freeze
+cabal freeze
 ----------------
 
-``cabal v2-freeze`` writes out a **freeze file** which records all of
+``cabal freeze`` writes out a **freeze file** which records all of
 the versions and flags that are picked by the solver under the
 current index and flags.  Default name of this file is
 ``cabal.project.freeze`` but in combination with a
@@ -534,41 +539,41 @@ users see a consistent set of dependencies. For libraries, this is not
 recommended: users often need to build against different versions of
 libraries than what you developed against.
 
-cabal v2-bench
+cabal bench
 ---------------
 
-``cabal v2-bench [TARGETS] [OPTIONS]`` runs the specified benchmarks
+``cabal bench [TARGETS] [OPTIONS]`` runs the specified benchmarks
 (all the benchmarks in the current package by default), first ensuring
 they are up to date.
 
-cabal v2-test
+cabal test
 --------------
 
-``cabal v2-test [TARGETS] [OPTIONS]`` runs the specified test suites
+``cabal test [TARGETS] [OPTIONS]`` runs the specified test suites
 (all the test suites in the current package by default), first ensuring
 they are up to date.
 
-cabal v2-haddock
+cabal haddock
 -----------------
 
-``cabal v2-haddock [FLAGS] [TARGET]`` builds Haddock documentation for
+``cabal haddock [FLAGS] [TARGET]`` builds Haddock documentation for
 the specified packages within the project.
 
 If a target is not a library :cfg-field:`haddock-benchmarks`,
 :cfg-field:`haddock-executables`, :cfg-field:`haddock-internal`,
 :cfg-field:`haddock-tests` will be implied as necessary.
 
-cabal v2-exec
+cabal exec
 ---------------
 
-``cabal v2-exec [FLAGS] [--] COMMAND [--] [ARGS]`` runs the specified command
+``cabal exec [FLAGS] [--] COMMAND [--] [ARGS]`` runs the specified command
 using the project's environment. That is, passing the right flags to compiler
 invocations and bringing the project's executables into scope.
 
-cabal v2-install
+cabal install
 -----------------
 
-``cabal v2-install [FLAGS] [TARGETS]`` builds the specified target packages and
+``cabal install [FLAGS] [TARGETS]`` builds the specified target packages and
 symlinks/copies their executables in ``installdir`` (usually ``~/.cabal/bin``).
 
 .. warning::
@@ -582,16 +587,16 @@ its ``cabal`` executable:
 
 ::
 
-    $ cabal v2-install cabal-install
+    $ cabal install cabal-install
 
-In addition, it's possible to use ``cabal v2-install`` to install components
+In addition, it's possible to use ``cabal install`` to install components
 of a local project. For example, with an up-to-date Git clone of the Cabal
 repository, this command will build cabal-install HEAD and symlink the
 ``cabal`` executable:
 
 ::
 
-    $ cabal v2-install exe:cabal
+    $ cabal install exe:cabal
 
 Where symlinking is not possible (eg. on some Windows versions) the ``copy``
 method is used by default. You can specify the install method
@@ -599,7 +604,7 @@ by using ``--install-method`` flag:
 
 ::
 
-    $ cabal v2-install exe:cabal --install-method=copy --installdir=$HOME/bin
+    $ cabal install exe:cabal --install-method=copy --installdir=$HOME/bin
 
 Note that copied executables are not self-contained, since they might use
 data-files from the store.
@@ -614,27 +619,27 @@ example, this command will build the latest Cabal library and install it:
 
 ::
 
-    $ cabal v2-install --lib Cabal
+    $ cabal install --lib Cabal
 
 This works by managing GHC package environment files. By default, it is writing
 to the global environment in ``~/.ghc/$ARCH-$OS-$GHCVER/environments/default``.
-``v2-install`` provides the ``--package-env`` flag to control which of these
+``install`` provides the ``--package-env`` flag to control which of these
 environments is modified.
 
 This command will modify the environment file in the current directory:
 
 ::
 
-    $ cabal v2-install --lib Cabal --package-env .
+    $ cabal install --lib Cabal --package-env .
 
 This command will modify the environment file in the ``~/foo`` directory:
 
 ::
 
-    $ cabal v2-install --lib Cabal --package-env foo/
+    $ cabal install --lib Cabal --package-env foo/
 
 Do note that the results of the previous two commands will be overwritten by
-the use of other v2-style commands, so it is not recommended to use them inside
+the use of other style commands, so it is not recommended to use them inside
 a project directory.
 
 This command will modify the environment in the ``local.env`` file in the
@@ -642,13 +647,13 @@ current directory:
 
 ::
 
-    $ cabal v2-install --lib Cabal --package-env local.env
+    $ cabal install --lib Cabal --package-env local.env
 
 This command will modify the ``myenv`` named global environment:
 
 ::
 
-    $ cabal v2-install --lib Cabal --package-env myenv
+    $ cabal install --lib Cabal --package-env myenv
 
 If you wish to create a named environment file in the current directory where
 the name does not contain an extension, you must reference it as ``./myenv``.
@@ -656,10 +661,10 @@ the name does not contain an extension, you must reference it as ``./myenv``.
 You can learn more about how to use these environments in `this section of the
 GHC manual <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#package-environments>`_.
 
-cabal v2-clean
+cabal clean
 ---------------
 
-``cabal v2-clean [FLAGS]`` cleans up the temporary files and build artifacts
+``cabal clean [FLAGS]`` cleans up the temporary files and build artifacts
 stored in the ``dist-newstyle`` folder.
 
 By default, it removes the entire folder, but it can also spare the configuration
@@ -667,20 +672,20 @@ and caches if the ``--save-config`` option is given, in which case it only remov
 the build artefacts (``.hi``, ``.o`` along with any other temporary files generated
 by the compiler, along with the build output).
 
-``cabal v2-clean [FLAGS] path/to/script`` cleans up the temporary files and build
+``cabal clean [FLAGS] path/to/script`` cleans up the temporary files and build
 artifacts for the script, which are stored under the .cabal/script-builds directory.
 
 In addition when clean is invoked it will remove all script build artifacts for
 which the corresponding script no longer exists.
 
-cabal v2-sdist
+cabal sdist
 ---------------
 
-``cabal v2-sdist [FLAGS] [TARGETS]`` takes the crucial files needed to build ``TARGETS``
+``cabal sdist [FLAGS] [TARGETS]`` takes the crucial files needed to build ``TARGETS``
 and puts them into an archive format ready for upload to Hackage. These archives are stable
 and two archives of the same format built from the same source will hash to the same value.
 
-``cabal v2-sdist`` takes the following flags:
+``cabal sdist`` takes the following flags:
 
 - ``-l``, ``--list-only``: Rather than creating an archive, lists files that would be included.
   Output is to ``stdout`` by default. The file paths are relative to the project's root
@@ -693,9 +698,9 @@ and two archives of the same format built from the same source will hash to the 
 - ``--null-sep``: Only used with ``--list-only``. Separates filenames with a NUL
   byte instead of newlines.
 
-``v2-sdist`` is inherently incompatible with sdist hooks (which were removed in `Cabal-3.0`),
+``sdist`` is inherently incompatible with sdist hooks (which were removed in `Cabal-3.0`),
 not due to implementation but due to fundamental core invariants
 (same source code should result in the same tarball, byte for byte)
-that must be satisfied for it to function correctly in the larger v2-build ecosystem.
+that must be satisfied for it to function correctly in the larger build ecosystem.
 ``autogen-modules`` is able to replace uses of the hooks to add generated modules, along with
 the custom publishing of Haddock documentation to Hackage.

--- a/doc/cabal-package.rst
+++ b/doc/cabal-package.rst
@@ -2978,7 +2978,7 @@ The availability of the
 ``MIN_VERSION_package_(A,B,C)`` CPP macros
 inside ``Setup.hs`` scripts depends on the condition that either
 
-- a ``custom-setup`` section has been declared (or ``cabal v2-build`` is being
+- a ``custom-setup`` section has been declared (or ``cabal build`` is being
   used which injects an implicit hard-coded ``custom-setup`` stanza if it's missing), or
 - GHC 8.0 or later is used (which natively injects package version CPP macros)
 

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -17,7 +17,7 @@ project or can be referenced as a unit):
 
 In general, the accepted field names coincide with the accepted command
 line flags that ``cabal install`` and other commands take. For example,
-``cabal v2-configure --enable-profiling`` will write out a project
+``cabal configure --enable-profiling`` will write out a project
 file with ``profiling: True``.
 
 The full configuration of a project is determined by combining the
@@ -28,9 +28,9 @@ options):
 
 2. ``cabal.project`` (the project configuration)
 
-3. ``cabal.project.freeze`` (the output of ``cabal v2-freeze``)
+3. ``cabal.project.freeze`` (the output of ``cabal freeze``)
 
-4. ``cabal.project.local`` (the output of ``cabal v2-configure``)
+4. ``cabal.project.local`` (the output of ``cabal configure``)
 
 Any call to ``cabal build`` will consider ``cabal.project*`` files from parent 
 directories when there is none in the current directory.
@@ -112,7 +112,7 @@ directory layout::
     foo-helper/     # local package
     unix/           # vendored external package
 
-All of these options support globs. ``cabal v2-build`` has its own glob
+All of these options support globs. ``cabal build`` has its own glob
 format:
 
 -  Anywhere in a path, as many times as you like, you can specify an
@@ -393,7 +393,7 @@ The following settings control the behavior of the dependency solver:
     dependency solver runtime.
 
     One way to use :cfg-field:`preferences` is to take a known working set of
-    constraints (e.g., via ``cabal v2-freeze``) and record them as
+    constraints (e.g., via ``cabal freeze``) and record them as
     preferences. In this case, the solver will first attempt to use this
     configuration, and if this violates hard constraints, it will try to
     find the minimal number of upgrades to satisfy the hard constraints
@@ -527,7 +527,7 @@ The following settings control the behavior of the dependency solver:
       index-state: @1474739268
 
       -- ISO8601 UTC timestamp format example
-      -- This format is used by 'cabal v2-configure'
+      -- This format is used by 'cabal configure'
       -- for storing `--index-state` values.
       index-state: 2016-09-24T17:47:48Z
 
@@ -680,7 +680,7 @@ feature was added.
     The command line variant of this flag is ``--flags``. There is also
     a shortened form ``-ffoo -f-bar``.
 
-    A common mistake is to say ``cabal v2-build -fhans``, where
+    A common mistake is to say ``cabal build -fhans``, where
     ``hans`` is a flag for a transitive dependency that is not in the
     local package; in this case, the flag will be silently ignored. If
     ``haskell-tor`` is the package you want this flag to apply to, try
@@ -705,7 +705,7 @@ feature was added.
     ``ghc-pkg`` in the same directory as the ``ghc`` directory. If this
     heuristic does not work, set :cfg-field:`with-hc-pkg` explicitly.
 
-    For inplace packages, ``cabal v2-build`` maintains a separate build
+    For inplace packages, ``cabal build`` maintains a separate build
     directory for each version of GHC, so you can maintain multiple
     build trees for different versions of GHC without clobbering each
     other.
@@ -1142,7 +1142,7 @@ Profiling options
     Build libraries and executables with profiling enabled (for
     compilers that support profiling as a separate mode). It is only
     necessary to specify :cfg-field:`profiling` for the specific package you
-    want to profile; ``cabal v2-build`` will ensure that all of its
+    want to profile; ``cabal build`` will ensure that all of its
     transitive dependencies are built with profiling enabled.
 
     To enable profiling for only libraries or executables, see


### PR DESCRIPTION
* Rebasing master on #6703
* It removes the v2- prefix from https://github.com/haskell/cabal/blob/master/doc/cabal-commands.rst (the pr changed the version prior to moving the file in [Cabal/doc/cabal-commands.rst](https://github.com/haskell/cabal/pull/6703/files#diff-398cd72d68f75f49e9235320347ffba87abb3af68ea11aed159c630905d6f2d9))
  * git was not able to keep track of that file :shrug: 
* It changes the header of that file as it mentions default commands and no `new-style` ones

// @m-renaud feel free to use those changes to rebase yours, other alternative could be close #6703 and merge this  