### PR TITLE
Flatten duplicate warnings about experimental features

### DIFF
--- a/Cabal/src/Distribution/Simple/PackageDescription.hs
+++ b/Cabal/src/Distribution/Simple/PackageDescription.hs
@@ -24,12 +24,16 @@ import Distribution.Compat.Prelude
 import Distribution.Fields.ParseResult
 import Distribution.PackageDescription
 import Distribution.PackageDescription.Parsec
-import Distribution.Parsec.Error    (showPError)
-import Distribution.Parsec.Warning  (showPWarning)
-import Distribution.Simple.Utils
-import Distribution.Verbosity
+    ( parseGenericPackageDescription, parseHookedBuildInfo )
+import Distribution.Parsec.Error ( showPError )
+import Distribution.Parsec.Warning
+    ( PWarning(..), PWarnType(PWTExperimental), showPWarning )
+import Distribution.Simple.Utils ( equating, die', warn )
+import Distribution.Verbosity ( normal, Verbosity )
 
-import qualified Data.ByteString    as BS
+import Data.List ( groupBy )
+import Text.Printf ( printf )
+import qualified Data.ByteString as BS
 import System.Directory (doesFileExist)
 
 readGenericPackageDescription :: Verbosity -> FilePath -> IO GenericPackageDescription
@@ -65,10 +69,35 @@ parseString
     -> IO a
 parseString parser verbosity name bs = do
     let (warnings, result) = runParseResult (parser bs)
-    traverse_ (warn verbosity . showPWarning name) warnings
+    traverse_ (warn verbosity . showPWarning name) (flattenDups verbosity warnings)
     case result of
         Right x -> return x
         Left (_, errors) -> do
             traverse_ (warn verbosity . showPError name) errors
             die' verbosity $ "Failed parsing \"" ++ name ++ "\"."
 
+-- Collapse duplicate experimental feature warnings into single warning, with
+-- a count of further sites
+flattenDups :: Verbosity -> [PWarning] -> [PWarning]
+flattenDups verbosity ws
+    | verbosity <= normal = rest ++ experimentals
+    | otherwise = ws -- show all instances
+    where
+        (exps, rest) = partition (\(PWarning w _ _) -> w == PWTExperimental) ws
+        experimentals =
+             concatMap flatCount
+           . groupBy (equating warningStr)
+           . sortBy (comparing warningStr)
+           $ exps
+
+        warningStr (PWarning _ _ w) = w
+
+        -- flatten if we have 3 or more examples
+        flatCount :: [PWarning] -> [PWarning]
+        flatCount w@[] = w
+        flatCount w@[_] = w
+        flatCount w@[_,_] = w
+        flatCount (PWarning t pos w:xs) =
+            [PWarning t pos
+                (w <> printf " (and %d more occurrences)" (length xs))
+            ]

--- a/Cabal/src/Distribution/Simple/PackageDescription.hs
+++ b/Cabal/src/Distribution/Simple/PackageDescription.hs
@@ -76,7 +76,7 @@ parseString parser verbosity name bs = do
             traverse_ (warn verbosity . showPError name) errors
             die' verbosity $ "Failed parsing \"" ++ name ++ "\"."
 
--- Collapse duplicate experimental feature warnings into single warning, with
+-- | Collapse duplicate experimental feature warnings into single warning, with
 -- a count of further sites
 flattenDups :: Verbosity -> [PWarning] -> [PWarning]
 flattenDups verbosity ws

--- a/cabal-testsuite/PackageTests/DuplicateExperimental/Four.hs
+++ b/cabal-testsuite/PackageTests/DuplicateExperimental/Four.hs
@@ -1,0 +1,1 @@
+module Four where

--- a/cabal-testsuite/PackageTests/DuplicateExperimental/Main.hs
+++ b/cabal-testsuite/PackageTests/DuplicateExperimental/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import One
+import Two
+import Three
+import Four

--- a/cabal-testsuite/PackageTests/DuplicateExperimental/One.hs
+++ b/cabal-testsuite/PackageTests/DuplicateExperimental/One.hs
@@ -1,0 +1,1 @@
+module One where

--- a/cabal-testsuite/PackageTests/DuplicateExperimental/Three.hs
+++ b/cabal-testsuite/PackageTests/DuplicateExperimental/Three.hs
@@ -1,0 +1,1 @@
+module Three where

--- a/cabal-testsuite/PackageTests/DuplicateExperimental/Two.hs
+++ b/cabal-testsuite/PackageTests/DuplicateExperimental/Two.hs
@@ -1,0 +1,1 @@
+module Two where

--- a/cabal-testsuite/PackageTests/DuplicateExperimental/cabal.project
+++ b/cabal-testsuite/PackageTests/DuplicateExperimental/cabal.project
@@ -1,0 +1,2 @@
+packages:
+  ./

--- a/cabal-testsuite/PackageTests/DuplicateExperimental/duplicate.cabal
+++ b/cabal-testsuite/PackageTests/DuplicateExperimental/duplicate.cabal
@@ -1,0 +1,35 @@
+cabal-version: 3.0
+name:          duplicate
+version:       0
+synopsis:      Test of de-duping multiple warnings for experimental features
+category:      Tests
+license:       MIT
+
+library
+  build-depends:    base, one, two, three, four
+  exposed-modules:  Main
+  default-language:    Haskell2010
+
+library one
+  visibility:       public
+  exposed-modules:  One
+  build-depends: base
+  default-language:    Haskell2010
+
+library two
+  visibility:       public
+  exposed-modules:  Two
+  build-depends: base
+  default-language:    Haskell2010
+
+library three
+  visibility:       public
+  exposed-modules:  Three
+  build-depends: base
+  default-language:    Haskell2010
+
+library four
+  visibility:       public
+  exposed-modules:  Four
+  build-depends: base
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/DuplicateExperimental/setup.out
+++ b/cabal-testsuite/PackageTests/DuplicateExperimental/setup.out
@@ -1,0 +1,2 @@
+# cabal build
+# cabal build

--- a/cabal-testsuite/PackageTests/DuplicateExperimental/setup.test.hs
+++ b/cabal-testsuite/PackageTests/DuplicateExperimental/setup.test.hs
@@ -1,0 +1,9 @@
+import Test.Cabal.Prelude
+main = cabalTest $ do
+    -- check output is summarized in -v1 (-v normal)
+    res <- cabal' "build" ["--only-configure","duplicate","-vnormal"]
+    assertOutputContains "(and 3 more occurrences)" res
+
+    -- check output is _not_ summarized in -v2 (verbose)
+    res <- cabal' "build" ["--only-configure","duplicate","-vverbose"]
+    assertOutputDoesNotContain "(and 3 more occurrences)" res

--- a/changelog.d/pr-8023
+++ b/changelog.d/pr-8023
@@ -1,0 +1,11 @@
+synopsis: Flatten duplicate warnings about experimental features
+packages: Cabal
+prs: #8023
+issues:
+description: {
+
+- Make builds that use experimental Cabal language features less noisy. At -v1
+  (normal) we show just first instance of use of experimental cabal language
+features, along with count of further occurences in the same file.
+
+}


### PR DESCRIPTION
For some projects (e.g. glean) that make wide use of colon specifiers or
visibility, we get hundreds (thousands) of duplicating warnings about
these language features, spamming our builds.

Flatten this warning into a single instance per parse, and a count of
others.

Example:
```
Warning: glean.cabal:1674:15: colon specifier is experimental feature (issue
Warning: glean.cabal:1625:24: visibility is experimental feature (issue #5660)
(and 32 more occurrences)
```

Test plan:
- try on glean.cabal from https://github.com/facebookincubator/Glean and
  see it working as above
- cabal test all


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
