### PR TITLE
Allow building cabal-3.6 with GHC 9.2

### DIFF
--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -88,7 +88,7 @@ test-suite parser-tests
   main-is:          ParserTests.hs
   build-depends:
       base
-    , base-compat       >=0.11.0  && <0.12
+    , base-compat       >=0.11.0  && <0.13
     , bytestring
     , Cabal
     , Cabal-tree-diff
@@ -166,7 +166,7 @@ test-suite hackage-tests
     , filepath
 
   build-depends:
-      base-compat           >=0.11.0   && <0.12
+      base-compat           >=0.11.0   && <0.13
     , base-orphans          >=0.6      && <0.9
     , clock                 >=0.8      && <0.9
     , optparse-applicative  >=0.13.2.0 && <0.17

--- a/cabal-install/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install/cabal-install-solver/cabal-install-solver.cabal
@@ -103,7 +103,7 @@ library
   other-modules:    Distribution.Client.Utils.Assertion
   build-depends:
     , array         >=0.4      && <0.6
-    , base          >=4.8      && <4.15
+    , base          >=4.8      && <4.17
     , binary        >=0.7.3    && <0.9
     , bytestring    >=0.10.6.0 && <0.12
     , Cabal         ^>=3.6

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -266,7 +266,7 @@ executable cabal
     build-depends:
         async      >= 2.0      && < 2.3,
         array      >= 0.4      && < 0.6,
-        base       >= 4.8      && < 4.15,
+        base       >= 4.8      && < 4.17,
         base16-bytestring >= 0.1.1 && < 1.1.0.0,
         binary     >= 0.7.3    && < 0.9,
         bytestring >= 0.10.6.0 && < 0.12,

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -26,7 +26,7 @@ common shared
   default-language: Haskell2010
 
   build-depends:
-    , base >= 4.6 && <4.16
+    , base >= 4.6 && <4.17
     -- this needs to match the in-tree lib:Cabal version
     , Cabal == 3.6.2.0
 
@@ -55,9 +55,9 @@ library
     Test.Cabal.ScriptEnv0
 
   build-depends:
-    , aeson                 ^>= 1.4.2.0 || ^>=1.5.0.0
+    , aeson                 ^>= 1.4.2.0 || ^>= 1.5.0.0 || ^>= 2.0.0.0
     , async                 ^>= 2.2.1
-    , attoparsec            ^>= 0.13.2.2
+    , attoparsec            ^>= 0.13.2.2 || ^>= 0.14.0.0
     , base16-bytestring     ^>= 0.1.1.6 || ^>= 1.0.0.0
     , bytestring            ^>= 0.10.0.2 || ^>= 0.11.0.0
     , containers            ^>= 0.5.0.0 || ^>= 0.6.0.1
@@ -110,5 +110,5 @@ executable setup
 
 custom-setup
   -- we only depend on even stable releases of lib:Cabal
-  setup-depends: Cabal == 2.2.* || == 2.4.* || == 3.0.* || ==3.2.* || ==3.4.*,
+  setup-depends: Cabal == 2.2.* || == 2.4.* || == 3.0.* || ==3.2.* || ==3.4.* || ==3.6.*,
                  base, filepath, directory

--- a/cabal.project
+++ b/cabal.project
@@ -14,16 +14,6 @@ packages: vendor/cabal-doctest-1.0.8
 
 optional-packages: ./vendored/*/*.cabal
 
--- Remove after hackage-repo-tool release
-allow-newer:
-  hackage-repo-tool:optparse-applicative
-
-allow-newer:
-  hackage-security:Cabal
-
--- https://github.com/haskell-hvr/windns/pull/2
-allow-newer: windns-0.1.0.1:base
-
 -- avoiding extra dependencies
 constraints: rere -rere-cfg
 constraints: these -assoc

--- a/cabal.project.validate.libonly
+++ b/cabal.project.validate.libonly
@@ -19,6 +19,3 @@ package Cabal
   ghc-options: -Werror -fno-ignore-asserts
 package cabal-testsuite
   ghc-options: -Werror -fno-ignore-asserts
-
--- https://github.com/haskell-hvr/cryptohash-sha256/issues/12
-allow-newer: cryptohash-sha256:base

--- a/vendor/cabal-doctest-1.0.8/cabal-doctest.cabal
+++ b/vendor/cabal-doctest-1.0.8/cabal-doctest.cabal
@@ -33,7 +33,7 @@ library
   other-modules:
   other-extensions:
   build-depends:
-      base       >=4.3  && <4.16
+      base       >=4.3  && <4.17
     , Cabal      >=1.10 && <3.8
     , directory
     , filepath


### PR DESCRIPTION
Otherwise GHC 9.2.2 cannot be bootstrapped by GHC 9.2.1. 

@Mikolaj could we please have it merged and released soon as Cabal-3.6.3.0? Just a revision would not be enough, because GHC source tree refers to Cabal repo, not to Cabal package on Hackage. 