### PR TITLE
Bump Cabal to 3.6.3.0 and add changelog

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,6 +1,6 @@
 cabal-version: >=1.10
 name:          Cabal
-version:       3.6.2.0
+version:       3.6.3.0
 copyright:     2003-2021, Cabal Development Team (see AUTHORS file)
 license:       BSD3
 license-file:  LICENSE

--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,3 +1,6 @@
+# 3.6.3.0 March 2022
+  * See https://github.com/haskell/cabal/blob/master/release-notes/Cabal-3.6.3.0.md
+
 # 3.6.2.0 [Emily Pillmore](mailgo:emilypi@cohomolo.gy) October 2021
   * See https://github.com/haskell/cabal/blob/master/release-notes/Cabal-3.6.2.0.md
 

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -28,7 +28,7 @@ common shared
   build-depends:
     , base >= 4.6 && <4.17
     -- this needs to match the in-tree lib:Cabal version
-    , Cabal == 3.6.2.0
+    , Cabal == 3.6.3.0
 
   ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
 

--- a/release-notes/Cabal-3.6.3.0.md
+++ b/release-notes/Cabal-3.6.3.0.md
@@ -1,0 +1,8 @@
+Cabal 3.6.3.0 Changelog
+---
+
+### Significant changes
+
+- Disable job management on Windows 7
+
+  - Cabal now works on Windows 7.


### PR DESCRIPTION
As discussed, we need to bump Cabal version in order for GHC to pick it up. I took a liberty to add a changelog as well, so this should be ready for Hackage release as well.