### PR TITLE
Add release notes for 3.6.3 and move release checklist to the wiki and update some

### DIFF
--- a/Cabal/ChangeLog.md
+++ b/Cabal/ChangeLog.md
@@ -1,3 +1,6 @@
+# 3.6.3.0 March 2022
+  * See https://github.com/haskell/cabal/blob/master/release-notes/Cabal-3.6.3.0.md
+
 # 3.6.2.0 [Emily Pillmore](mailgo:emilypi@cohomolo.gy) October 2021
   * See https://github.com/haskell/cabal/blob/master/release-notes/Cabal-3.6.2.0.md
 

--- a/release-checklist.md
+++ b/release-checklist.md
@@ -1,11 +1,1 @@
-# For major release
-
-- Add new SPDX License list data
-
-# For release for new GHC version:
-
-- Update GHC flags in `normaliseGhcArgs`, and add the GHC version to
-  `supportedGHCVersions` (`Distribution.Simple.Program.GHC`)
-- Update `Language.Haskell.Extension` list, if there are new GHC extensions
-- Update `setupMinCabalVersionConstraint` (in `Distribution.Client.ProjectPlanning`)
-- Update `Cabal.Distribution.Simple.GHC` to include new GHC version
+the new release checklist is at https://github.com/haskell/cabal/wiki/Making-a-release (easier to edit)

--- a/release-notes/Cabal-3.6.3.0.md
+++ b/release-notes/Cabal-3.6.3.0.md
@@ -1,0 +1,8 @@
+Cabal 3.6.3.0 Changelog
+---
+
+### Significant changes
+
+- Disable job management on Windows 7
+
+  - Cabal now works on Windows 7.


### PR DESCRIPTION
Also, a PR for any fallout of the Cabal 3.6.3 release that ought to be fixed on master branch, not only 3.6 branch.