### PR TITLE
Update stack.yaml resolver and fix cabal-testsuite stack build

### DIFF
--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -113,4 +113,5 @@ executable setup
 custom-setup
   -- we only depend on even stable releases of lib:Cabal
   setup-depends: Cabal == 2.2.* || == 2.4.* || == 3.0.* || ==3.2.* || ==3.4.* || ==3.6.*,
+                 Cabal-syntax == 3.6.*,
                  base, filepath, directory

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.17
+resolver: lts-18.28 # ghc-8.10.7
 
 packages:
 - Cabal-syntax/
@@ -14,7 +14,7 @@ packages:
 - solver-benchmarks/
 
 extra-deps:
-- rere-0.2@sha256:ec1d87554c03755d89f3401c5e5c27827e61dde835c54cbdaf509136ce8f6f2b,4079
+- rere-0.2@rev:1
 
 allow-newer: true
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,8 +14,12 @@ packages:
 - solver-benchmarks/
 
 extra-deps:
+# Not included in stackage
 - rere-0.2@rev:1
 
+# We require the released version of Cabal and Cabal-syntax for cabal-testsuite
+# but ususally we have a development, newer version set in the local package
+# Also needed for hackage-security and Win32
 allow-newer: true
 
 nix:


### PR DESCRIPTION
* No ci job is checking this but i tested it locally in debian 10
* I had to add `Cabal-syntax` to `setup-depends`in the cabal-testsuite or the build throwed the error:

```
cabal-testsuite> /home/debian/cabal/cabal-testsuite/Setup.hs:4:1: error:
cabal-testsuite>     Could not load module `Distribution.Backpack'
cabal-testsuite>     It is a member of the hidden package `Cabal-syntax-3.7.0.0'.
cabal-testsuite>     You can run `:set -package Cabal-syntax' to expose it.
cabal-testsuite>     (Note: this unloads all the modules in the current scope.)
cabal-testsuite>     It is a member of the hidden package `Cabal-3.2.1.0'.
cabal-testsuite>     You can run `:set -package Cabal' to expose it.
cabal-testsuite>     (Note: this unloads all the modules in the current scope.)
cabal-testsuite>     Use -v (or `:set -v` in ghci) to see a list of the files searched for.
cabal-testsuite>   |
cabal-testsuite> 4 | import Distribution.Backpack
cabal-testsuite>   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

* related with https://github.com/haskell/cabal/issues/7974