### PR TITLE
Make enable/disable nix flag easier to read

### DIFF
--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -357,10 +357,14 @@ globalCommand commands = CommandUI {
          globalHttpTransport (\v flags -> flags { globalHttpTransport = v })
          (reqArgFlag "HttpTransport")
 
-      ,option [] ["nix"]
-         "Nix integration: run commands through nix-shell if a 'shell.nix' file exists"
-         globalNix (\v flags -> flags { globalNix = v })
-         (boolOpt [] [])
+      ,multiOption "nix"
+        globalNix (\v flags -> flags { globalNix = v })
+        [
+          noArg (Flag True) [] ["enable-nix"] 
+          "Enable Nix integration: run commands through nix-shell if a 'shell.nix' file exists",
+          noArg (Flag False) [] ["disable-nix"] 
+          "Disable Nix integration"
+        ]
 
       ,option [] ["store-dir", "storedir"]
          "The location of the build store"

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -150,8 +150,9 @@ tests config =
 testNixFlags :: Assertion
 testNixFlags = do
   let argsFn = commandOptions . globalCommand $ []
-  let defaultFlags = commandDefaultFlags . globalCommand $ []
   let args = argsFn ShowArgs
+
+  let defaultFlags = commandDefaultFlags . globalCommand $ []
   let mNixFlag = find (\(OptionField name _) -> name == "nix") args
   True @=? isJust mNixFlag -- Found the nix flag (--enable-nix, --disable-nix)
   let nixFlags = optionDescr . fromJust $ mNixFlag
@@ -165,6 +166,9 @@ testNixFlags = do
     findNixFlags _ _ [] = Nothing
     findNixFlags gf b [opt@(BoolOpt _ _ _ _ fn)]
       | fn gf == Just b = Just opt
+      | otherwise = Nothing
+    findNixFlags gf b [opt@(ChoiceOpt [(_, _, _, fn)])]
+      | fn gf == b = Just opt
       | otherwise = Nothing
     findNixFlags gf b (opt@(BoolOpt _ _ _ _ fn):xs)
       | fn gf == Just b = Just opt

--- a/changelog.d/issue-8036
+++ b/changelog.d/issue-8036
@@ -1,0 +1,4 @@
+synopsis: Make enable/disable nix flags easier to read
+packages: cabal-install
+issues: #8036
+prs: #8054


### PR DESCRIPTION
This PR is attempting to close #8036 

The `boolOpt` function will not allow for more than one description so I changed the option type from `option` to `multiOption` so that the "nix" (`--enable-nix` and `--disable-nix`) flags would still be grouped together and allow separate descriptions for disabled and enabled.

As far as the language goes I felt like if the description of "Nix integration" for the `--disable-nix` was taken out it would make it more clear. It is defined in `--enable-nix` and `--disable-nix` is right under it.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
