### PR TITLE
Enable hackage tests for windows

### DIFF
--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -155,8 +155,6 @@ test-suite hackage-tests
   type:               exitcode-stdio-1.0
   main-is:            HackageTests.hs
 
-  if os(windows)
-    buildable: False
 
   hs-source-dirs:     tests
   build-depends:

--- a/Cabal-tests/tests/HackageTests.hs
+++ b/Cabal-tests/tests/HackageTests.hs
@@ -63,7 +63,7 @@ import Data.TreeDiff.Pretty          (ansiWlEditExprCompact)
 parseIndex :: (Monoid a, NFData a) => (FilePath -> Bool)
            -> (FilePath -> B.ByteString -> IO a) -> IO a
 parseIndex predicate action = do
-    cabalDir   <- getAppUserDataDirectory "cabal"
+    cabalDir   <- getCabalDir
     configPath <- getCabalConfigPath cabalDir
     cfg        <- B.readFile configPath
     cfgFields  <- either (fail . show) pure $ Parsec.readFields cfg
@@ -74,6 +74,11 @@ parseIndex predicate action = do
         tarName repo = repoCache </> repo </> "01-index.tar"
     mconcat <$> traverse (parseIndex' predicate action . tarName) repos
   where
+    getCabalDir = do
+        mx <- lookupEnv "CABAL_DIR"
+        case mx of
+            Just x  -> return x
+            Nothing -> getAppUserDataDirectory "cabal"
     getCabalConfigPath cabalDir = do
         mx <- lookupEnv "CABAL_CONFIG"
         case mx of

--- a/validate.sh
+++ b/validate.sh
@@ -401,18 +401,14 @@ CMD="$($CABALPLANLISTBIN Cabal-tests:test:no-thunks-test) $TESTSUITEJOBS --hide-
 (cd Cabal-tests && timed $CMD) || exit 1
 
 CMD=$($CABALPLANLISTBIN Cabal-tests:test:hackage-tests)
-# hackage-tests is not buildable in windows so $CMD will be empty here
-if [ "$OSTYPE" != "msys" ]; then
-    (cd Cabal-tests && timed $CMD read-fields) || exit 1
-    if $HACKAGETESTSALL; then
-        (cd Cabal-tests && timed $CMD parsec)    || exit 1
-        (cd Cabal-tests && timed $CMD roundtrip) || exit 1
-    else
-        (cd Cabal-tests && timed $CMD parsec d)    || exit 1
-        (cd Cabal-tests && timed $CMD roundtrip k) || exit 1
-    fi
+(cd Cabal-tests && timed $CMD read-fields) || exit 1
+if $HACKAGETESTSALL; then
+    (cd Cabal-tests && timed $CMD parsec)    || exit 1
+    (cd Cabal-tests && timed $CMD roundtrip) || exit 1
+else
+    (cd Cabal-tests && timed $CMD parsec d)    || exit 1
+    (cd Cabal-tests && timed $CMD roundtrip k) || exit 1
 fi
-
 }
 
 # Cabal cabal-testsuite


### PR DESCRIPTION
* Investigating on how to add tests for #7966 i tried to enable hackage tests for windows, expecting they will not be even buildable
* Surprisingly they were buildable and even passed in my local win env
* The ghcup installation in windows uses CABAL_DIR so i had to make tests honour the env var to make it read my hackage config
* Let's see how is the thing going in ci
