### PR TITLE
Derive Eq on DependencyMap

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/Dependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/Dependency.hs
@@ -33,6 +33,10 @@ import qualified Text.PrettyPrint                as PP
 -- /Invariant:/ package name does not appear as 'LSubLibName' in
 -- set of library names.
 --
+-- /Note:/ 'Dependency' is not an instance of 'Ord', and so it cannot be used
+-- in 'Set' or as the key to a 'Map'.  For these and similar use cases see
+-- 'DependencyMap'.
+--
 data Dependency = Dependency
                     PackageName
                     VersionRange

--- a/Cabal-syntax/src/Distribution/Types/DependencyMap.hs
+++ b/Cabal-syntax/src/Distribution/Types/DependencyMap.hs
@@ -19,7 +19,7 @@ import qualified Data.Map.Lazy as Map
 -- | A map of dependencies.  Newtyped since the default monoid instance is not
 --   appropriate.  The monoid instance uses 'intersectVersionRanges'.
 newtype DependencyMap = DependencyMap { unDependencyMap :: Map PackageName (VersionRange, NonEmptySet LibraryName) }
-  deriving (Show, Read)
+  deriving (Show, Read, Eq)
 
 instance Monoid DependencyMap where
     mempty = DependencyMap Map.empty

--- a/changelog.d/pr-8061
+++ b/changelog.d/pr-8061
@@ -1,0 +1,4 @@
+synopsis: Derive Eq for DependencyMap
+packages: Cabal-syntax
+prs: #8061
+issues: #7849


### PR DESCRIPTION
This change derives the `Eq` type class on `DependencyMap` in the
`Distribution.Types` module.

Closes #7849 