### PR TITLE
Cabal: Disable GHCi libraries on Windows with GHC >=9.4

### DIFF
--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -62,6 +62,7 @@ module Distribution.Simple.Compiler (
         profilingSupported,
         backpackSupported,
         arResponseFilesSupported,
+        arDashLSupported,
         libraryDynDirSupported,
         libraryVisibilitySupported,
 
@@ -364,6 +365,12 @@ libraryDynDirSupported comp = case compilerFlavor comp of
 -- arguments (i.e. @file-style arguments).
 arResponseFilesSupported :: Compiler -> Bool
 arResponseFilesSupported = ghcSupported "ar supports at file"
+
+-- | Does this compiler's "ar" command support llvm-ar's -L flag,
+-- which compels the archiver to add an input archive's members
+-- rather than adding the archive itself.
+arDashLSupported :: Compiler -> Bool
+arDashLSupported = ghcSupported "ar supports -L"
 
 -- | Does this compiler support Haskell program coverage?
 coverageSupported :: Compiler -> Bool

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -635,6 +635,22 @@ configure (pkg_descr0, pbi) cfg = do
                                       "--enable-split-objs; ignoring")
                                 return False
 
+    let compilerSupportsGhciLibs :: Bool
+        compilerSupportsGhciLibs =
+          case compilerId comp of
+            CompilerId GHC version
+              | version > mkVersion [9,3] && windows ->
+                False
+            CompilerId GHC _ ->
+                True
+            CompilerId GHCJS _ ->
+                True
+            _ -> False
+          where
+            windows = case compPlatform of
+              Platform _ Windows -> True
+              Platform _ _ -> False
+
     let ghciLibByDefault =
           case compilerId comp of
             CompilerId GHC _ ->
@@ -650,6 +666,15 @@ configure (pkg_descr0, pbi) cfg = do
             CompilerId GHCJS _ ->
               not (GHCJS.isDynamic comp)
             _ -> False
+
+    withGHCiLib_ <-
+      case fromFlagOrDefault ghciLibByDefault (configGHCiLib cfg) of
+        True | not compilerSupportsGhciLibs -> do
+          warn verbosity $
+                "--enable-library-for-ghci is no longer supported on Windows with"
+              ++ "GHC 9.4 and later; ignoring..."
+          return False
+        v -> return v
 
     let sharedLibsByDefault
           | fromFlag (configDynExe cfg) =
@@ -747,8 +772,7 @@ configure (pkg_descr0, pbi) cfg = do
                 withProfExeDetail   = ProfDetailNone,
                 withOptimization    = fromFlag $ configOptimization cfg,
                 withDebugInfo       = fromFlag $ configDebugInfo cfg,
-                withGHCiLib         = fromFlagOrDefault ghciLibByDefault $
-                                      configGHCiLib cfg,
+                withGHCiLib         = withGHCiLib_,
                 splitSections       = split_sections,
                 splitObjs           = split_objs,
                 stripExes           = strip_exe,

--- a/Cabal/src/Distribution/Simple/Program/Ar.hs
+++ b/Cabal/src/Distribution/Simple/Program/Ar.hs
@@ -24,7 +24,7 @@ import Distribution.Compat.Prelude
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import Distribution.Compat.CopyFile (filesEqual)
-import Distribution.Simple.Compiler (arResponseFilesSupported)
+import Distribution.Simple.Compiler (arResponseFilesSupported, arDashLSupported)
 import Distribution.Simple.LocalBuildInfo (LocalBuildInfo(..))
 import Distribution.Simple.Program
          ( ProgramInvocation, arProgram, requireProgram )
@@ -68,17 +68,25 @@ createArLibArchive verbosity lbi targetPath files = do
   --     do that. We have duplicates because of modules like "A.M" and "B.M"
   --     both make an object file "M.o" and ar does not consider the directory.
   --
+  --  -- llvm-ar, which GHC >=9.4 uses on Windows, supports a "L" modifier
+  --     which compels the archiver to add the members of an input archive to
+  --     the output, rather than the archive itself. This is necessary as GHC
+  --     may produce .o files that are actually archives. See
+  --     https://gitlab.haskell.org/ghc/ghc/-/issues/21068.
+  --
   -- Our solution is to use "ar r" in the simple case when one call is enough.
   -- When we need to call ar multiple times we use "ar q" and for the last
   -- call on OSX we use "ar qs" so that it'll make the index.
 
   let simpleArgs  = case hostOS of
              OSX -> ["-r", "-s"]
+             _ | dashLSupported -> ["-rL"]
              _   -> ["-r"]
 
       initialArgs = ["-q"]
       finalArgs   = case hostOS of
              OSX -> ["-q", "-s"]
+             _ | dashLSupported -> ["-qL"]
              _   -> ["-q"]
 
       extraArgs   = verbosityOpts verbosity ++ [tmpPath]
@@ -90,8 +98,10 @@ createArLibArchive verbosity lbi targetPath files = do
 
       oldVersionManualOverride =
         fromFlagOrDefault False $ configUseResponseFiles $ configFlags lbi
-      responseArgumentsNotSupported   =
+      responseArgumentsNotSupported =
         not (arResponseFilesSupported (compiler lbi))
+      dashLSupported =
+        arDashLSupported (compiler lbi)
 
       invokeWithResponesFile :: FilePath -> ProgramInvocation
       invokeWithResponesFile atFile =


### PR DESCRIPTION
As noted in [GHC #21068](https://gitlab.haskell.org/ghc/ghc/-/issues/21068), the lld linker used on Windows by GHC 9.4 and later does not support object merging. Consequently, `--enable-library-for-ghci` can no longer be supported on this platform.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
