### PR TITLE
Add support for the 64-bit S390X architecture

### DIFF
--- a/Cabal-syntax/src/Distribution/System.hs
+++ b/Cabal-syntax/src/Distribution/System.hs
@@ -151,8 +151,8 @@ buildOS = classifyOS Permissive System.Info.os
 -- ------------------------------------------------------------
 
 -- | These are the known Arches: I386, X86_64, PPC, PPC64, Sparc,
--- Arm, AArch64, Mips, SH, IA64, S39, Alpha, Hppa, Rs6000, M68k,
--- Vax, and JavaScript.
+-- Arm, AArch64, Mips, SH, IA64, S390, S390X, Alpha, Hppa, Rs6000,
+-- M68k, Vax, and JavaScript.
 --
 -- The following aliases can also be used:
 --    * PPC alias: powerpc
@@ -164,7 +164,7 @@ buildOS = classifyOS Permissive System.Info.os
 --
 data Arch = I386  | X86_64  | PPC  | PPC64 | Sparc
           | Arm   | AArch64 | Mips | SH
-          | IA64  | S390
+          | IA64  | S390    | S390X
           | Alpha | Hppa    | Rs6000
           | M68k  | Vax
           | JavaScript
@@ -178,7 +178,7 @@ instance NFData Arch where rnf = genericRnf
 knownArches :: [Arch]
 knownArches = [I386, X86_64, PPC, PPC64, Sparc
               ,Arm, AArch64, Mips, SH
-              ,IA64, S390
+              ,IA64, S390, S390X
               ,Alpha, Hppa, Rs6000
               ,M68k, Vax
               ,JavaScript]

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -27,9 +27,9 @@ tests = testGroup "Distribution.Utils.Structured"
     -- The difference is in encoding of newtypes
 #if MIN_VERSION_base(4,7,0)
     , testCase "GenericPackageDescription" $
-      md5Check (Proxy :: Proxy GenericPackageDescription) 0xafbf1cfb39ece402a2008d07f5e5ffd8
+      md5Check (Proxy :: Proxy GenericPackageDescription) 0x3713da01e295903b046123a7cba0fb14
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0xd8b4c7f04e75345f0303fe2c3093bc29
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0xd4d0449f6db57c79b68b6e412b5f4f55
 #endif
     ]
 

--- a/Cabal/src/Distribution/Simple/PreProcess.hs
+++ b/Cabal/src/Distribution/Simple/PreProcess.hs
@@ -722,6 +722,7 @@ platformDefines lbi =
       SH          -> []
       IA64        -> ["ia64"]
       S390        -> ["s390"]
+      S390X       -> ["s390x"]
       Alpha       -> ["alpha"]
       Hppa        -> ["hppa"]
       Rs6000      -> ["rs6000"]

--- a/changelog.d/pr-8065
+++ b/changelog.d/pr-8065
@@ -1,0 +1,3 @@
+synopsis: Add support for the 64-bit S390X architecture
+prs: #8065
+packages: Cabal, Cabal-syntax


### PR DESCRIPTION
So far only the 32-bit S390 architecture is supported. This patch also adds the 64-bit S390X architecture.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
