### PR TITLE
fix spelling errors

### DIFF
--- a/Cabal/src/Distribution/Backpack/Id.hs
+++ b/Cabal/src/Distribution/Backpack/Id.hs
@@ -41,7 +41,7 @@ computeComponentId
 computeComponentId deterministic mb_ipid mb_cid pid cname mb_details =
     -- show is found to be faster than intercalate and then replacement of
     -- special character used in intercalating. We cannot simply hash by
-    -- doubly concating list, as it just flatten out the nested list, so
+    -- doubly concatenating list, as it just flatten out the nested list, so
     -- different sources can produce same hash
     let hash_suffix
             | Just (dep_ipids, flags) <- mb_details

--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -83,7 +83,7 @@ data OptHelp = OptHelp {
 -- second argument.
 usageInfo :: String                    -- header
           -> [OptDescr a]              -- option descriptors
-          -> String                    -- nicely formatted decription of options
+          -> String                    -- nicely formatted description of options
 usageInfo header optDescr = unlines (header : table)
   where
     options = flip map optDescr $ \(Option sos los ad d) ->

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Dependency.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Dependency.hs
@@ -212,7 +212,7 @@ qualifyDeps QO{..} (Q pp@(PackagePath ns q) pn) = go
     -- dependency on R. We do not do this for the base qualifier however.
     --
     -- The inherited qualifier is only used for regular dependencies; for setup
-    -- and base deppendencies we override the existing qualifier. See #3160 for
+    -- and base dependencies we override the existing qualifier. See #3160 for
     -- a detailed discussion.
     inheritedQ :: Qualifier
     inheritedQ = case q of

--- a/cabal-install/src/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/src/Distribution/Client/FileMonitor.hs
@@ -453,7 +453,7 @@ checkFileMonitorChanged
       where
         -- In fileMonitorCheckIfOnlyValueChanged mode we want to guarantee that
         -- if we return MonitoredValueChanged that only the value changed.
-        -- We do that by checkin for file changes first. Otherwise it makes
+        -- We do that by checking for file changes first. Otherwise it makes
         -- more sense to do the cheaper test first.
         checkForChanges :: IO (Maybe (MonitorChangedReason a))
         checkForChanges
@@ -768,7 +768,7 @@ probeMonitorStateGlobRel _ _ root dirName
 
 
     return (MonitorStateGlobFiles glob mtime' children)
-    -- Again, we don't force a cache rewite with 'cacheChanged', but we do use
+    -- Again, we don't force a cache rewrite with 'cacheChanged', but we do use
     -- the new mtime' if any.
   where
     probeMergeResult :: MergeResult (FilePath, MonitorStateFileStatus) FilePath

--- a/cabal-install/src/Distribution/Client/GlobalFlags.hs
+++ b/cabal-install/src/Distribution/Client/GlobalFlags.hs
@@ -112,7 +112,7 @@ data RepoContext = RepoContext {
     --
     -- NOTE: It is important that we don't eagerly initialize the transport.
     -- Initializing the transport is not free, and especially in contexts where
-    -- we don't know a-priori whether or not we need the transport (for instance
+    -- we don't know a priori whether or not we need the transport (for instance
     -- when using cabal in "nix mode") incurring the overhead of transport
     -- initialization on _every_ invocation (eg @cabal build@) is undesirable.
   , repoContextGetTransport :: IO HttpTransport

--- a/cabal-install/src/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/src/Distribution/Client/HttpUtils.hs
@@ -495,7 +495,7 @@ wgetTransport prog =
 
         -- wget doesn't support range requests.
         -- so, we not only ignore range request headers,
-        -- but we also dispay a warning message when we see them.
+        -- but we also display a warning message when we see them.
         let hasRangeHeader =  any isRangeHeader reqHeaders
             warningMsg     =  "the 'wget' transport currently doesn't support"
                            ++ " range requests, which wastes network bandwidth."

--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -365,7 +365,7 @@ readRepoIndex :: Verbosity -> RepoContext -> Repo -> RepoIndexState
 readRepoIndex verbosity repoCtxt repo idxState =
   handleNotFound $ do
     when (isRepoRemote repo) $ warnIfIndexIsOld =<< getIndexFileAge repo
-    -- note that if this step fails due to a bad repocache, the the procedure can still succeed by reading from the existing cache, which is updated regardless.
+    -- note that if this step fails due to a bad repo cache, the the procedure can still succeed by reading from the existing cache, which is updated regardless.
     updateRepoIndexCache verbosity (RepoIndex repoCtxt repo) `catchIO`
        (\e -> warn verbosity $ "unable to update the repo index cache -- " ++ displayException e)
     readPackageIndexCacheFile verbosity mkAvailablePackage

--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -1086,7 +1086,7 @@ hashConsCache cache0
     -- If/when we redo the binary serialisation via e.g. CBOR and we
     -- are able to use incremental decoding, we may want to move the
     -- hash-consing into the incremental deserialisation, or
-    -- alterantively even do something like
+    -- alternatively even do something like
     -- http://cbor.schmorp.de/value-sharing
     --
     go _ _ [] = []

--- a/cabal-install/src/Distribution/Client/InstallPlan.hs
+++ b/cabal-install/src/Distribution/Client/InstallPlan.hs
@@ -708,7 +708,7 @@ processingInvariant plan (Processing processingSet completedSet failedSet) =
     -- The failed set is upwards closed, i.e. equal to its own rev dep closure
     assert (failedSet == reverseClosure failedSet) $
 
-    -- All immediate reverse deps of packges that are currently processing
+    -- All immediate reverse deps of packages that are currently processing
     -- are not currently being processed (ie not in the processing set).
     assert (and [ rdeppkgid `Set.notMember` processingSet
                 | pkgid     <- Set.toList processingSet

--- a/cabal-install/src/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding.hs
@@ -599,7 +599,7 @@ rebuildTargets verbosity
     createDirectoryIfMissingVerbose verbosity True distTempDirectory
     traverse_ (createPackageDBIfMissing verbosity compiler progdb) packageDBsToUse
 
-    -- Before traversing the install plan, pre-emptively find all packages that
+    -- Before traversing the install plan, preemptively find all packages that
     -- will need to be downloaded and start downloading them.
     asyncDownloadPackages verbosity withRepoCtx
                           installPlan pkgsBuildStatus $ \downloadMap ->

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1405,7 +1405,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
             -- invocation of the same `./configure` script.
             -- See https://github.com/haskell/cabal/issues/4548
             --
-            -- Moreoever, at this point in time, only non-Custom setup scripts
+            -- Moreover, at this point in time, only non-Custom setup scripts
             -- are supported.  Implementing per-component builds with
             -- Custom would require us to create a new 'ElabSetup'
             -- type, and teach all of the code paths how to handle it.
@@ -3483,7 +3483,7 @@ setupHsConfigureFlags (ReadyPackage elab@ElaboratedConfiguredPackage{..})
           -- So for now, let's pass the rather harmless and idempotent
           -- `-hide-all-packages` flag to all invocations (which has
           -- the benefit that every GHC invocation starts with a
-          -- conistently well-defined clean slate) until we find a
+          -- consistently well-defined clean slate) until we find a
           -- better way.
                               = Map.toList $
                                 Map.insertWith (++) "ghc" ["-hide-all-packages"]

--- a/changelog.d/pr-7349
+++ b/changelog.d/pr-7349
@@ -1,4 +1,4 @@
 synopsis: Add language extensions for GHC 9.2
 pr: #7349
 issues: #7312
-decription: { Add support for new language extensions added in 9.2 }
+description: { Add support for new language extensions added in 9.2 }

--- a/changelog.d/pr-7407
+++ b/changelog.d/pr-7407
@@ -1,4 +1,4 @@
 synopsis: --dry-run and --only-download effect v2-configure, v2-freeze, v2-run, and v2-exec
 pr: #7407
 issues: #7379
-decription: { v2-configure, v2-freeze, v2-run, and v2-exec now behave expectedly under the --dry-run and --only-download flags }
+description: { v2-configure, v2-freeze, v2-run, and v2-exec now behave expectedly under the --dry-run and --only-download flags }


### PR DESCRIPTION
Cabal/src/Distribution/GetOpt.hs
cabal-install-solver/src/Distribution/Solver/Modular/Dependency.hs
cabal-install/src/Distribution/Client/FileMonitor.hs
cabal-install/src/Distribution/Client/GlobalFlags.hs
cabal-install/src/Distribution/Client/HttpUtils.hs
cabal-install/src/Distribution/Client/IndexUtils.hs
cabal-install/src/Distribution/Client/InstallPlan.hs
cabal-install/src/Distribution/Client/ProjectBuilding.hs
cabal-install/src/Distribution/Client/ProjectPlanning.hs
changelog.d/pr-7349
changelog.d/pr-7407

@Mikolaj missed these in `#8046`

<hr>

typo `concating` unattended to

cabal/Cabal/src/Distribution/Backpack/Id.hs

```
    -- show is found to be faster than intercalate and then replacement of
    -- special character used in intercalating. We cannot simply hash by
    -- doubly concating list, as it just flatten out the nested list, so
    -- different sources can produce same hash
```

typo `repocache` unattended to

cabal-install/src/Distribution/Client/IndexUtils.hs

```
    -- note that if this step fails due to a bad repocache, the the procedure can still succeed by reading from the existing cache, which is updated regardless.
```