### PR TITLE
Changes to support new GHC 9.4's new Windows toolchain

### DIFF
--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -62,6 +62,7 @@ module Distribution.Simple.Compiler (
         profilingSupported,
         backpackSupported,
         arResponseFilesSupported,
+        arDashLSupported,
         libraryDynDirSupported,
         libraryVisibilitySupported,
 
@@ -364,6 +365,12 @@ libraryDynDirSupported comp = case compilerFlavor comp of
 -- arguments (i.e. @file-style arguments).
 arResponseFilesSupported :: Compiler -> Bool
 arResponseFilesSupported = ghcSupported "ar supports at file"
+
+-- | Does this compiler's "ar" command support llvm-ar's -L flag,
+-- which compels the archiver to add an input archive's members
+-- rather than adding the archive itself.
+arDashLSupported :: Compiler -> Bool
+arDashLSupported = ghcSupported "ar supports -L"
 
 -- | Does this compiler support Haskell program coverage?
 coverageSupported :: Compiler -> Bool

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -383,8 +383,8 @@ defaultConfigFlags progDb = emptyConfigFlags {
     configVerbosity    = Flag normal,
     configUserInstall  = Flag False,           --TODO: reverse this
 #if defined(mingw32_HOST_OS)
-    -- See #1589.
-    configGHCiLib      = Flag True,
+    -- See #8062 and GHC #21019.
+    configGHCiLib      = Flag False,
 #else
     configGHCiLib      = NoFlag,
 #endif

--- a/changelog.d/pr-8062
+++ b/changelog.d/pr-8062
@@ -1,0 +1,16 @@
+synopsis: Support GHC 9.4's `clang`-based Windows toolchain
+packages: Cabal
+prs: #8062
+
+description {
+
+- As the `lld` linker used by GHC 9.4 and later on Windows does not support
+  object merging, it is now an error to enable `--enable-library-for-ghci` on
+  Windows with such compilers. Note that this flag is merely enables an
+  optimisation and can safely be disabled if you encounter this error.
+
+- `Cabal` will now use `llvm-ar`'s `L` modifier if available when building
+  static archives. This enables static library merging which is the behavior
+  required by GHC 9.4 and later on Windows.
+
+}


### PR DESCRIPTION
As noted in [GHC #21068](https://gitlab.haskell.org/ghc/ghc/-/issues/21068), the lld linker used on Windows by GHC 9.4 and later does not support object merging. Consequently, `--enable-library-for-ghci` can no longer be supported on this platform. In this MR we:

 * turn `--enable-library-for-ghci` into an error on platforms where it is not supported.
 * teach `Cabal` to use `llvm-ar`'s `L` modifier when available, which is now necessary when building static archives on Windows (since the archive may contain other archives, as noted in [GHC #21068](https://gitlab.haskell.org/ghc/ghc/-/issues/21068))


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
