### PR TITLE
Add support for the 64-bit S390X architecture

### DIFF
--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -27,9 +27,9 @@ tests = testGroup "Distribution.Utils.Structured"
     -- The difference is in encoding of newtypes
 #if MIN_VERSION_base(4,7,0)
     , testCase "GenericPackageDescription" $
-      md5Check (Proxy :: Proxy GenericPackageDescription) 0x9b7d0415b1d2522d72ac9e9739c97574
+      md5Check (Proxy :: Proxy GenericPackageDescription) 0xb9c91a5756e2bcc84e38751911633b08
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0x0ca1dc5da4c4695a9da40e080bf4f536
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0x42521f320ab79665f48d13c61226cbaf
 #endif
     ]
 

--- a/Cabal/src/Distribution/Simple/PreProcess.hs
+++ b/Cabal/src/Distribution/Simple/PreProcess.hs
@@ -670,6 +670,7 @@ platformDefines lbi =
       SH          -> []
       IA64        -> ["ia64"]
       S390        -> ["s390"]
+      S390X       -> ["s390x"]
       Alpha       -> ["alpha"]
       Hppa        -> ["hppa"]
       Rs6000      -> ["rs6000"]

--- a/Cabal/src/Distribution/System.hs
+++ b/Cabal/src/Distribution/System.hs
@@ -151,8 +151,8 @@ buildOS = classifyOS Permissive System.Info.os
 -- ------------------------------------------------------------
 
 -- | These are the known Arches: I386, X86_64, PPC, PPC64, Sparc,
--- Arm, AArch64, Mips, SH, IA64, S39, Alpha, Hppa, Rs6000, M68k,
--- Vax, and JavaScript.
+-- Arm, AArch64, Mips, SH, IA64, S390, S390X, Alpha, Hppa, Rs6000,
+-- M68k, Vax, and JavaScript.
 --
 -- The following aliases can also be used:
 --    * PPC alias: powerpc
@@ -164,7 +164,7 @@ buildOS = classifyOS Permissive System.Info.os
 --
 data Arch = I386  | X86_64  | PPC  | PPC64 | Sparc
           | Arm   | AArch64 | Mips | SH
-          | IA64  | S390
+          | IA64  | S390    | S390X
           | Alpha | Hppa    | Rs6000
           | M68k  | Vax
           | JavaScript
@@ -178,7 +178,7 @@ instance NFData Arch where rnf = genericRnf
 knownArches :: [Arch]
 knownArches = [I386, X86_64, PPC, PPC64, Sparc
               ,Arm, AArch64, Mips, SH
-              ,IA64, S390
+              ,IA64, S390, S390X
               ,Alpha, Hppa, Rs6000
               ,M68k, Vax
               ,JavaScript]

--- a/changelog.d/pr-8072
+++ b/changelog.d/pr-8072
@@ -1,0 +1,3 @@
+synopsis: Add support for the 64-bit S390X architecture
+prs: #8072
+packages: Cabal


### PR DESCRIPTION
This is a backport of 1b7faea9d478ec76bf6a9b082f4af9f55c802378