### PR TITLE
Stop if cannot attain requested index-state, #8076.

### DIFF
--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -276,11 +276,11 @@ getSourcePackagesAtIndexState verbosity repoCtxt mb_idxState mb_activeRepos = do
         IndexStateTime ts0 -> do
             when (isiMaxTime isi /= ts0) $
                 if ts0 > isiMaxTime isi
-                    then warn verbosity $
-                                   "Requested index-state " ++ prettyShow ts0
-                                ++ " is newer than '" ++ unRepoName rname ++ "'!"
-                                ++ " Falling back to older state ("
-                                ++ prettyShow (isiMaxTime isi) ++ ")."
+                    then die' verbosity $
+                                   "Stopping this command as the requested index-state=" ++ prettyShow ts0
+                                ++ " is newer than (" ++ prettyShow (isiMaxTime isi)
+                                ++ "), the most recent state of '" ++ unRepoName rname
+                                ++ "'. You could try 'cabal update' to bring down a later state or request an earlier timestamp for index-state."
                     else info verbosity $
                                    "Requested index-state " ++ prettyShow ts0
                                 ++ " does not exist in '"++ unRepoName rname ++"'!"


### PR DESCRIPTION
As this is a change of behaviour, we will need a changelog entry won't we?

I intend to supplement this by changing "this command" with the actual command name.

The rendered output:

```
> cabal build --enable-tests
Error: cabal: Stopping this command as the requested
index-state=3022-03-22T14:16:26Z is newer than (2022-03-31T17:42:23Z), the
most recent state of 'hackage.haskell.org'. You could try 'cabal update' to
bring down a later state or request an earlier timestamp for index-state.
```
