### PR TITLE
Fix race condition in PackageTests/NewBuild/CmdRun/Terminate

### DIFF
--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Terminate/Main.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Terminate/Main.hs
@@ -4,13 +4,11 @@ import qualified System.Posix.Signals as Signal
 import System.Exit (exitFailure)
 
 main = do
-  writeFile "exe.run" "up and running"
   mainThreadId <- myThreadId
   Signal.installHandler Signal.sigTERM (Signal.Catch $ killThread mainThreadId) Nothing
-  sleep
-    `finally` putStrLn "exiting"
-  where
-    sleep = do
-      putStrLn "about to sleep"
-      threadDelay 10000000 -- 10s
-      putStrLn "done sleeping"
+  do
+    putStrLn "about to sleep"
+    writeFile "exe.run" "up and running"
+    threadDelay 10000000 -- 10s
+    putStrLn "done sleeping"
+  `finally` putStrLn "exiting"


### PR DESCRIPTION
The "up and running" file was written before the signal handler
was installed, so it was possible for the test to kill the
subprocess before, leading to a missed "exiting" line in the
output.

I hope this fixes the sporadic failures we're seeing (#8080).

(I'm sure it's a good change, just not 100% on whether this
is the problem we saw in CI.)

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
