### PR TITLE
Bootstrapping fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,8 @@ tags :
 bootstrap-json-%: phony
 	cabal v2-build --project=cabal.project.release --with-compiler=ghc-$* --dry-run cabal-install:exe:cabal
 	cp dist-newstyle/cache/plan.json bootstrap/linux-$*.plan.json
-	cabal v2-run -vnormal+stderr --builddir=dist-newstyle-bootstrap --project=cabal.project.bootstrap cabal-bootstrap-gen -- bootstrap/linux-$*.plan.json  | python3 -m json.tool | tee bootstrap/linux-$*.json
+	@# -v0 to avoid build output on stdout
+	cabal v2-run -v0 --builddir=dist-newstyle-bootstrap --project=cabal.project.bootstrap cabal-bootstrap-gen -- bootstrap/linux-$*.plan.json  | python3 -m json.tool | tee bootstrap/linux-$*.json
 
 bootstrap-jsons: bootstrap-json-8.6.5 bootstrap-json-8.8.4 bootstrap-json-8.10.7
 

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,8 @@ bootstrap-json-%: phony
 	cabal v2-build --project=cabal.project.release --with-compiler=ghc-$* --dry-run cabal-install:exe:cabal
 	cp dist-newstyle/cache/plan.json bootstrap/linux-$*.plan.json
 	@# -v0 to avoid build output on stdout
-	cabal v2-run -v0 --builddir=dist-newstyle-bootstrap --project=cabal.project.bootstrap cabal-bootstrap-gen -- bootstrap/linux-$*.plan.json  | python3 -m json.tool | tee bootstrap/linux-$*.json
+	cd bootstrap && cabal v2-run -v0 cabal-bootstrap-gen -- linux-$*.plan.json \
+		| python3 -m json.tool | tee linux-$*.json
 
 bootstrap-jsons: bootstrap-json-8.6.5 bootstrap-json-8.8.4 bootstrap-json-8.10.7
 

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ bootstrap-json-%: phony
 	cp dist-newstyle/cache/plan.json bootstrap/linux-$*.plan.json
 	@# -v0 to avoid build output on stdout
 	cd bootstrap && cabal v2-run -v0 cabal-bootstrap-gen -- linux-$*.plan.json \
-		| python3 -m json.tool | tee linux-$*.json
+		| python3 -m json.tool > linux-$*.json
 
 bootstrap-jsons: bootstrap-json-8.6.5 bootstrap-json-8.8.4 bootstrap-json-8.10.7
 

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -23,8 +23,8 @@ To generate the `platform-ghcver` files for other platforms, do:
        ```sh
        cabal v2-build --with-compiler=/path/to/ghc --dry-run cabal-install:exe:cabal
        cp dist-newstyle/cache/plan.json bootstrap/platform-ghcver.plan.json
-       cabal v2-build               --builddir=dist-newstyle-bootstrap --project=cabal.project.bootstrap cabal-bootstrap-gen
-       cabal v2-run -vnormal+stderr --builddir=dist-newstyle-bootstrap --project=cabal.project.bootstrap cabal-bootstrap-gen -- bootstrap/platform-ghcver.plan.json | tee bootstrap/platform-ghcver.json
+       cd bootstrap
+       cabal v2-run -v0 cabal-bootstrap-gen -- platform-ghcver.plan.json | tee platform-ghcver.json
        ```
 
   3. You may need to tweak `bootstrap/platform-ghcver.json` file manually,

--- a/bootstrap/cabal.project
+++ b/bootstrap/cabal.project
@@ -1,5 +1,5 @@
 -- Separate project file to avoid conflicts,
 -- e.g. via the dependency on cabal-install-parsers
 
-packages: bootstrap/
+packages: .
 optimization: False

--- a/bootstrap/src/Main.hs
+++ b/bootstrap/src/Main.hs
@@ -214,8 +214,14 @@ instance A.ToJSON SrcType where
 -- Utilities
 -------------------------------------------------------------------------------
 
+-- | Log some debug information to stderr.
+--
+-- Disabled by default to keep the output tidy, replace by
+-- the version with 'hPutStrLn' when debugging.
+--
 info :: String -> IO ()
-info msg = hPutStrLn stderr $ "INFO: " ++ msg
+info _msg = return ()
+-- info msg = hPutStrLn stderr $ "INFO: " ++ msg
 
 die :: String -> IO a
 die msg = do


### PR DESCRIPTION
I found a bug in the bootstrap generation Makefile targets while checking them against #8079:

`cabal v2-run -vnormal+stderr` was (sometimes) writing GHC output to stdout, messing with
the boostrapping JSON. This fixes that, and makes things a tiny bit tidier.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
