### PR TITLE
Fix index-state falling back warning

### DIFF
--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -275,7 +275,7 @@ getSourcePackagesAtIndexState verbosity repoCtxt mb_idxState mb_activeRepos = do
             return ()
         IndexStateTime ts0 -> do
             when (isiMaxTime isi /= ts0) $
-                if ts0 > isiMaxTime isi
+                if ts0 > isiHeadTime isi
                     then warn verbosity $
                                    "Requested index-state " ++ prettyShow ts0
                                 ++ " is newer than '" ++ unRepoName rname ++ "'!"


### PR DESCRIPTION
I think it should only be a warning here if `ts0 > isiHeadTime isi`.

My understanding is that `isiMaxTime isi <= isiHeadTime isi` (is that correct?) and that since `isiMaxTime isi` is calculated on the filtered index `isiMaxTime isi <= ts0`.