### PR TITLE
Get clones the source repository.

### DIFF
--- a/doc/cabal-package.rst
+++ b/doc/cabal-package.rst
@@ -2908,7 +2908,7 @@ The ``get`` command supports the following options:
     Where to place the package source, defaults to (a subdirectory of)
     the current directory.
 ``-s --source-repository`` *[head\|this\|...]*
-    Fork the package's source repository using the appropriate version
+    Clone the package's source repository using the appropriate version
     control system. The optional argument allows to choose a specific
     repository kind.
 ``--index-state`` *[HEAD\|@<unix-timestamp>\|<iso8601-utc-timestamp>]*


### PR DESCRIPTION
Minor doc change.

```
> cabal get siggy-chardust --source-repository
Cloning into 'siggy-chardust'...
```
