### PR TITLE
Add wasm32-wasi to recognized arch/os

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,8 +72,8 @@ jobs:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-*
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          key: ${{ runner.os }}-${{ matrix.ghc }}-20220419-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-20220419-
 
       # The '+exe' constraint below is important, otherwise cabal-install
       # might decide to build the library but not the executable which is
@@ -211,8 +211,8 @@ jobs:
           path: |
             ${{ steps.setup-haskell.outputs.cabal-store }}
             dist-*
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          key: ${{ runner.os }}-${{ matrix.ghc }}-20220419-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-20220419-
 
       - name: Install cabal-plan
         run: |

--- a/Cabal-syntax/src/Distribution/System.hs
+++ b/Cabal-syntax/src/Distribution/System.hs
@@ -80,7 +80,7 @@ data ClassificationStrictness = Permissive | Compat | Strict
 -- | These are the known OS names: Linux, Windows, OSX
 --  ,FreeBSD, OpenBSD, NetBSD, DragonFly
 --  ,Solaris, AIX, HPUX, IRIX
---  ,HaLVM ,Hurd ,IOS, Android,Ghcjs
+--  ,HaLVM ,Hurd ,IOS, Android, Ghcjs, Wasi
 --
 -- The following aliases can also be used:,
 --    * Windows aliases: mingw32, win32, cygwin32
@@ -97,6 +97,7 @@ data OS = Linux | Windows | OSX        -- tier 1 desktop OSs
         | Hurd                         -- GNU's microkernel
         | IOS  | Android               -- mobile OSs
         | Ghcjs
+        | Wasi
         | OtherOS String
   deriving (Eq, Generic, Ord, Show, Read, Typeable, Data)
 
@@ -111,7 +112,8 @@ knownOSs = [Linux, Windows, OSX
            ,HaLVM
            ,Hurd
            ,IOS, Android
-           ,Ghcjs]
+           ,Ghcjs
+           ,Wasi]
 
 osAliases :: ClassificationStrictness -> OS -> [String]
 osAliases Permissive Windows = ["mingw32", "win32", "cygwin32"]
@@ -152,7 +154,7 @@ buildOS = classifyOS Permissive System.Info.os
 
 -- | These are the known Arches: I386, X86_64, PPC, PPC64, Sparc,
 -- Arm, AArch64, Mips, SH, IA64, S390, S390X, Alpha, Hppa, Rs6000,
--- M68k, Vax, and JavaScript.
+-- M68k, Vax, JavaScript and Wasm32.
 --
 -- The following aliases can also be used:
 --    * PPC alias: powerpc
@@ -168,6 +170,7 @@ data Arch = I386  | X86_64  | PPC  | PPC64 | Sparc
           | Alpha | Hppa    | Rs6000
           | M68k  | Vax
           | JavaScript
+          | Wasm32
           | OtherArch String
   deriving (Eq, Generic, Ord, Show, Read, Typeable, Data)
 
@@ -181,7 +184,8 @@ knownArches = [I386, X86_64, PPC, PPC64, Sparc
               ,IA64, S390, S390X
               ,Alpha, Hppa, Rs6000
               ,M68k, Vax
-              ,JavaScript]
+              ,JavaScript
+              ,Wasm32]
 
 archAliases :: ClassificationStrictness -> Arch -> [String]
 archAliases Strict _       = []

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -27,9 +27,9 @@ tests = testGroup "Distribution.Utils.Structured"
     -- The difference is in encoding of newtypes
 #if MIN_VERSION_base(4,7,0)
     , testCase "GenericPackageDescription" $
-      md5Check (Proxy :: Proxy GenericPackageDescription) 0x3713da01e295903b046123a7cba0fb14
+      md5Check (Proxy :: Proxy GenericPackageDescription) 0x344677c9c09bde1c0f8cf94dc2b45030
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0xd4d0449f6db57c79b68b6e412b5f4f55
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0x637b149bf956b706bfd3e4f99e66a910
 #endif
     ]
 

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -1776,6 +1776,7 @@ getRPaths lbi clbi | supportRPaths hostOS = do
     supportRPaths IOS         = False
     supportRPaths Android     = False
     supportRPaths Ghcjs       = False
+    supportRPaths Wasi        = False
     supportRPaths Hurd        = False
     supportRPaths (OtherOS _) = False
     -- Do _not_ add a default case so that we get a warning here when a new OS

--- a/Cabal/src/Distribution/Simple/GHCJS.hs
+++ b/Cabal/src/Distribution/Simple/GHCJS.hs
@@ -1536,6 +1536,7 @@ getRPaths lbi clbi | supportRPaths hostOS = do
     supportRPaths IOS         = False
     supportRPaths Android     = False
     supportRPaths Ghcjs       = False
+    supportRPaths Wasi        = False
     supportRPaths Hurd        = False
     supportRPaths (OtherOS _) = False
     -- Do _not_ add a default case so that we get a warning here when a new OS

--- a/Cabal/src/Distribution/Simple/PreProcess.hs
+++ b/Cabal/src/Distribution/Simple/PreProcess.hs
@@ -708,6 +708,7 @@ platformDefines lbi =
       IOS       -> ["ios"]
       Android   -> ["android"]
       Ghcjs     -> ["ghcjs"]
+      Wasi      -> ["wasi"]
       Hurd      -> ["hurd"]
       OtherOS _ -> []
     archStr = case hostArch of
@@ -729,6 +730,7 @@ platformDefines lbi =
       M68k        -> ["m68k"]
       Vax         -> ["vax"]
       JavaScript  -> ["javascript"]
+      Wasm32      -> ["wasm32"]
       OtherArch _ -> []
 
 ppHappy :: BuildInfo -> LocalBuildInfo -> ComponentLocalBuildInfo -> PreProcessor

--- a/changelog.d/pr-8096
+++ b/changelog.d/pr-8096
@@ -1,0 +1,3 @@
+synopsis: Add wasm32-wasi to recognized arch/os
+prs: #8096
+packages: Cabal, Cabal-syntax


### PR DESCRIPTION
This patch adds `wasm32` to known archs, and `wasi` to known oss. It's a part of the work of adding webassembly support to ghc at https://gitlab.haskell.org/ghc/ghc/-/merge_requests/7632.