### PR TITLE
spelling correction

### DIFF
--- a/release-notes/Cabal-3.4.0.0.md
+++ b/release-notes/Cabal-3.4.0.0.md
@@ -120,7 +120,7 @@
   This changes makes `Version` type less "syntactic",
   i.e. contains less constructors for semantically same version ranges.
   
-- Cabal-QuickCheck package with `Arbirary` instances [#6882](https://github.com/haskell/cabal/issues/6882) [!6557](https://github.com/haskell/cabal/pull/6557) [!6891](https://github.com/haskell/cabal/pull/6891)
+- Cabal-QuickCheck package with `Arbitrary` instances [#6882](https://github.com/haskell/cabal/issues/6882) [!6557](https://github.com/haskell/cabal/pull/6557) [!6891](https://github.com/haskell/cabal/pull/6891)
 - Create Cabal-tree-diff package with `ToExpr` instances [!6789](https://github.com/haskell/cabal/pull/6789)
 - `Cabal.Distribution.Compiler`: add `Traversable` instance for `PerCompilerFlavor` [!6763](https://github.com/haskell/cabal/pull/6763)
 - Improvements to cabal-testsuite framework [!6643](https://github.com/haskell/cabal/pull/6643)


### PR DESCRIPTION
https://github.com/haskell/cabal/commit/8e2ac1a5cc0c7d6d8c26fb0c9fd045620674a75b overlooked this

release-notes/Cabal-3.4.0.0.md