### PR TITLE
Correct url to package properties

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -498,9 +498,8 @@ checkFields pkg =
         ++ "The 'description' field content is typically shown by tooling "
         ++ "(e.g. 'cabal info', Haddock, Hackage) below the 'synopsis' which "
         ++ "serves as a headline. "
-        ++ "Please refer to <https://www.haskell.org/"
-        ++ "cabal/users-guide/developing-packages.html#package-properties>"
-        ++ " for more details."
+        ++ "Please refer to <https://cabal.readthedocs.io/en/stable/"
+        ++ "cabal-package.html#package-properties> for more details."
 
     -- check use of impossible constraints "tested-with: GHC== 6.10 && ==6.12"
   , check (not (null testedWithImpossibleRanges)) $


### PR DESCRIPTION
Closes #7461

There is a [precedent](https://github.com/haskell/cabal/blob/709799a3dcafe03723de19946e78a36179a8f07c/cabal-install/src/Distribution/Client/CmdLegacy.hs#L105) using readthedocs so i suppose it is fine

does it need a changelog?

---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions)

