### PR TITLE
v2-sdist now respects --ignore-project

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/src/Distribution/Client/CmdSdist.hs
@@ -27,9 +27,9 @@ import Distribution.Solver.Types.SourcePackage
 import Distribution.Client.Types
     ( PackageSpecifier(..), PackageLocation(..), UnresolvedSourcePackage )
 import Distribution.Client.DistDirLayout
-    ( DistDirLayout(..), ProjectRoot (..) )
+    ( DistDirLayout(..), ProjectRoot (..), CabalDirLayout (cabalLogsDirectory) )
 import Distribution.Client.ProjectConfig
-    ( ProjectConfig, withProjectOrGlobalConfig, commandLineFlagsToProjectConfig, projectConfigConfigFile, projectConfigShared )
+    ( ProjectConfig (projectPackagesOptional, projectConfigAllPackages), withProjectOrGlobalConfig, commandLineFlagsToProjectConfig, projectConfigConfigFile, projectConfigShared, PackageConfig (packageConfigTests), projectPackages )
 import Distribution.Client.ProjectFlags
      ( ProjectFlags (..), defaultProjectFlags, projectFlagsOptions )
 
@@ -174,7 +174,6 @@ sdistAction (ProjectFlags{..}, SdistFlags{..}) targetStrings globalFlags = do
                 | listSources -> "-"
                 | otherwise   -> distSdistFile distDirLayout (packageId pkg)
 
-
     case reifyTargetSelectors localPkgs targetSelectors of
         Left errs -> die' verbosity . unlines . fmap renderTargetProblem $ errs
         Right pkgs
@@ -210,7 +209,7 @@ sdistAction (ProjectFlags{..}, SdistFlags{..}) targetStrings globalFlags = do
     withoutProject :: ProjectConfig -> IO (ProjectBaseContext, DistDirLayout)
     withoutProject config = do
         cwd <- getCurrentDirectory
-        baseCtx <- establishProjectBaseContextWithRoot verbosity (config <> prjConfig) (ProjectRootImplicit cwd) OtherCommand
+        baseCtx <- establishProjectBaseContextWithRoot verbosity (config <> prjConfig) True (ProjectRootImplicit cwd) OtherCommand
         return (baseCtx, distDirLayout baseCtx)
 
 data OutputFormat = SourceList Char

--- a/cabal-install/src/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/src/Distribution/Client/CmdSdist.hs
@@ -138,7 +138,7 @@ sdistOptions showOrParseArgs =
 
 sdistAction :: (ProjectFlags, SdistFlags) -> [String] -> GlobalFlags -> IO ()
 sdistAction (ProjectFlags{..}, SdistFlags{..}) targetStrings globalFlags = do
-    (baseCtx, distDirLayout) <- withProjectOrGlobalConfig verbosity ignoreProject globalConfigFlag withProject withoutProject
+    (baseCtx, distDirLayout) <- withProjectOrGlobalConfig verbosity flagIgnoreProject globalConfigFlag withProject withoutProject
 
     let localPkgs = localPackages baseCtx
 
@@ -187,7 +187,6 @@ sdistAction (ProjectFlags{..}, SdistFlags{..}) targetStrings globalFlags = do
     listSources    = fromFlagOrDefault False sdistListSources
     nulSeparated   = fromFlagOrDefault False sdistNulSeparated
     mOutputPath    = flagToMaybe sdistOutputPath
-    ignoreProject  = flagIgnoreProject
 
     prjConfig :: ProjectConfig
     prjConfig = commandLineFlagsToProjectConfig
@@ -210,7 +209,7 @@ sdistAction (ProjectFlags{..}, SdistFlags{..}) targetStrings globalFlags = do
     withoutProject :: ProjectConfig -> IO (ProjectBaseContext, DistDirLayout)
     withoutProject config = do
         cwd <- getCurrentDirectory
-        baseCtx <- establishProjectBaseContextWithRoot verbosity (config <> prjConfig) True (ProjectRootImplicit cwd) OtherCommand
+        baseCtx <- establishProjectBaseContextWithRoot verbosity (config <> prjConfig) flagIgnoreProject (ProjectRootImplicit cwd) OtherCommand
         return (baseCtx, distDirLayout baseCtx)
 
 data OutputFormat = SourceList Char

--- a/cabal-install/src/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/src/Distribution/Client/CmdSdist.hs
@@ -209,7 +209,7 @@ sdistAction (ProjectFlags{..}, SdistFlags{..}) targetStrings globalFlags = do
     withoutProject :: ProjectConfig -> IO (ProjectBaseContext, DistDirLayout)
     withoutProject config = do
         cwd <- getCurrentDirectory
-        baseCtx <- establishProjectBaseContextWithRoot verbosity (config <> prjConfig) flagIgnoreProject (ProjectRootImplicit cwd) OtherCommand
+        baseCtx <- establishProjectBaseContextWithRoot verbosity (config <> prjConfig) (ProjectRootImplicit cwd) OtherCommand
         return (baseCtx, distDirLayout baseCtx)
 
 data OutputFormat = SourceList Char

--- a/cabal-install/src/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/src/Distribution/Client/CmdSdist.hs
@@ -27,9 +27,9 @@ import Distribution.Solver.Types.SourcePackage
 import Distribution.Client.Types
     ( PackageSpecifier(..), PackageLocation(..), UnresolvedSourcePackage )
 import Distribution.Client.DistDirLayout
-    ( DistDirLayout(..), ProjectRoot (..), CabalDirLayout (cabalLogsDirectory) )
+    ( DistDirLayout(..), ProjectRoot (..) )
 import Distribution.Client.ProjectConfig
-    ( ProjectConfig (projectPackagesOptional, projectConfigAllPackages), withProjectOrGlobalConfig, commandLineFlagsToProjectConfig, projectConfigConfigFile, projectConfigShared, PackageConfig (packageConfigTests), projectPackages )
+    ( ProjectConfig, withProjectOrGlobalConfig, commandLineFlagsToProjectConfig, projectConfigConfigFile, projectConfigShared )
 import Distribution.Client.ProjectFlags
      ( ProjectFlags (..), defaultProjectFlags, projectFlagsOptions )
 

--- a/cabal-install/src/Distribution/Client/CmdSdist.hs
+++ b/cabal-install/src/Distribution/Client/CmdSdist.hs
@@ -174,6 +174,7 @@ sdistAction (ProjectFlags{..}, SdistFlags{..}) targetStrings globalFlags = do
                 | listSources -> "-"
                 | otherwise   -> distSdistFile distDirLayout (packageId pkg)
 
+
     case reifyTargetSelectors localPkgs targetSelectors of
         Left errs -> die' verbosity . unlines . fmap renderTargetProblem $ errs
         Right pkgs

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -462,7 +462,7 @@ renderBadProjectRoot (BadProjectRootExplicitFile projectFile) =
 
 withProjectOrGlobalConfig
     :: Verbosity                  -- ^ verbosity
-    -> Flag Bool                  -- ^ whether to ignore local project
+    -> Flag Bool                  -- ^ whether to ignore local project (--ignore-project flag)
     -> Flag FilePath              -- ^ @--cabal-config@
     -> IO a                       -- ^ with project
     -> (ProjectConfig -> IO a)    -- ^ without projet
@@ -504,7 +504,7 @@ withProjectOrGlobalConfig' verbosity globalConfigFlag with without = do
 --
 readProjectConfig :: Verbosity
                   -> HttpTransport
-                  -> Bool
+                  -> Flag Bool
                   -> Flag FilePath
                   -> DistDirLayout
                   -> Rebuild ProjectConfigSkeleton
@@ -513,7 +513,7 @@ readProjectConfig verbosity httpTransport ignoreProjectFlag configFileFlag distD
     local  <- readProjectLocalConfigOrDefault verbosity httpTransport distDirLayout
     freeze <- readProjectLocalFreezeConfig    verbosity httpTransport distDirLayout
     extra  <- readProjectLocalExtraConfig     verbosity httpTransport distDirLayout
-    if ignoreProjectFlag then return (global <> (singletonProjectConfigSkeleton defaultProject))
+    if ignoreProjectFlag == Flag True then return (global <> (singletonProjectConfigSkeleton defaultProject))
     else return (global <> local <> freeze <> extra)
     where
       defaultProject :: ProjectConfig

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -513,7 +513,7 @@ readProjectConfig verbosity httpTransport ignoreProjectFlag configFileFlag distD
     local  <- readProjectLocalConfigOrDefault verbosity httpTransport distDirLayout
     freeze <- readProjectLocalFreezeConfig    verbosity httpTransport distDirLayout
     extra  <- readProjectLocalExtraConfig     verbosity httpTransport distDirLayout
-    if ignoreProjectFlag then return global
+    if ignoreProjectFlag then return (global <> (singletonProjectConfigSkeleton defaultImplicitProjectConfig))
     else return (global <> local <> freeze <> extra)
 
 
@@ -537,14 +537,13 @@ readProjectLocalConfigOrDefault verbosity httpTransport distDirLayout = do
     projectFile :: FilePath
     projectFile = distProjectFile distDirLayout ""
 
-    defaultImplicitProjectConfig :: ProjectConfig
-    defaultImplicitProjectConfig =
-      mempty {
-        -- We expect a package in the current directory.
-        projectPackages         = [ "./*.cabal" ],
+defaultImplicitProjectConfig :: ProjectConfig
+defaultImplicitProjectConfig = mempty {
+  -- We expect a package in the current directory.
+  projectPackages         = [ "./*.cabal" ],
 
-        projectConfigProvenance = Set.singleton Implicit
-      }
+  projectConfigProvenance = Set.singleton Implicit
+}
 
 -- | Reads a @cabal.project.local@ file in the given project root dir,
 -- or returns empty. This file gets written by @cabal configure@, or in

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -795,6 +795,7 @@ findProjectPackages DistDirLayout{distProjectRootDirectory}
     optionalPkgs <- findPackageLocations False   projectPackagesOptional
     let repoPkgs  = map ProjectPackageRemoteRepo projectPackagesRepo
         namedPkgs = map ProjectPackageNamed      projectPackagesNamed
+
     return (concat [requiredPkgs, optionalPkgs, repoPkgs, namedPkgs])
   where
     findPackageLocations :: Bool -> [String] -> Rebuild [ProjectPackageLocation]

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -513,9 +513,13 @@ readProjectConfig verbosity httpTransport ignoreProjectFlag configFileFlag distD
     local  <- readProjectLocalConfigOrDefault verbosity httpTransport distDirLayout
     freeze <- readProjectLocalFreezeConfig    verbosity httpTransport distDirLayout
     extra  <- readProjectLocalExtraConfig     verbosity httpTransport distDirLayout
-    if ignoreProjectFlag then return (global <> (singletonProjectConfigSkeleton defaultImplicitProjectConfig))
+    if ignoreProjectFlag then return (global <> (singletonProjectConfigSkeleton defaultProject))
     else return (global <> local <> freeze <> extra)
-
+    where
+      defaultProject :: ProjectConfig
+      defaultProject = mempty {
+        projectPackages = ["./"]
+      }
 
 -- | Reads an explicit @cabal.project@ file in the given project root dir,
 -- or returns the default project config for an implicitly defined project.
@@ -536,14 +540,13 @@ readProjectLocalConfigOrDefault verbosity httpTransport distDirLayout = do
   where
     projectFile :: FilePath
     projectFile = distProjectFile distDirLayout ""
+    defaultImplicitProjectConfig :: ProjectConfig
+    defaultImplicitProjectConfig = mempty {
+      -- We expect a package in the current directory.
+      projectPackages         = [ "./*.cabal" ],
 
-defaultImplicitProjectConfig :: ProjectConfig
-defaultImplicitProjectConfig = mempty {
-  -- We expect a package in the current directory.
-  projectPackages         = [ "./*.cabal" ],
-
-  projectConfigProvenance = Set.singleton Implicit
-}
+      projectConfigProvenance = Set.singleton Implicit
+    }
 
 -- | Reads a @cabal.project.local@ file in the given project root dir,
 -- or returns empty. This file gets written by @cabal configure@, or in

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -504,7 +504,7 @@ withProjectOrGlobalConfig' verbosity globalConfigFlag with without = do
 --
 readProjectConfig :: Verbosity
                   -> HttpTransport
-                  -> Flag Bool
+                  -> Flag Bool -- ^ @--ignore-project@
                   -> Flag FilePath
                   -> DistDirLayout
                   -> Rebuild ProjectConfigSkeleton

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -504,15 +504,17 @@ withProjectOrGlobalConfig' verbosity globalConfigFlag with without = do
 --
 readProjectConfig :: Verbosity
                   -> HttpTransport
+                  -> Bool
                   -> Flag FilePath
                   -> DistDirLayout
                   -> Rebuild ProjectConfigSkeleton
-readProjectConfig verbosity httpTransport configFileFlag distDirLayout = do
+readProjectConfig verbosity httpTransport ignoreProjectFlag configFileFlag distDirLayout = do
     global <- singletonProjectConfigSkeleton <$> readGlobalConfig verbosity configFileFlag
     local  <- readProjectLocalConfigOrDefault verbosity httpTransport distDirLayout
     freeze <- readProjectLocalFreezeConfig    verbosity httpTransport distDirLayout
     extra  <- readProjectLocalExtraConfig     verbosity httpTransport distDirLayout
-    return (global <> local <> freeze <> extra)
+    if ignoreProjectFlag then return global
+    else return (global <> local <> freeze <> extra)
 
 
 -- | Reads an explicit @cabal.project@ file in the given project root dir,
@@ -793,7 +795,6 @@ findProjectPackages DistDirLayout{distProjectRootDirectory}
     optionalPkgs <- findPackageLocations False   projectPackagesOptional
     let repoPkgs  = map ProjectPackageRemoteRepo projectPackagesRepo
         namedPkgs = map ProjectPackageNamed      projectPackagesNamed
-
     return (concat [requiredPkgs, optionalPkgs, repoPkgs, namedPkgs])
   where
     findPackageLocations :: Bool -> [String] -> Rebuild [ProjectPackageLocation]

--- a/cabal-install/src/Distribution/Client/ProjectFlags.hs
+++ b/cabal-install/src/Distribution/Client/ProjectFlags.hs
@@ -14,7 +14,7 @@ import Distribution.ReadE          (succeedReadE)
 import Distribution.Simple.Command
     ( MkOptDescr, OptionField(optionName), ShowOrParseArgs (..), boolOpt', option
     , reqArg )
-import Distribution.Simple.Setup   (Flag (..), flagToList, flagToMaybe, toFlag, trueArg)
+import Distribution.Simple.Setup   (Flag (..), flagToList, flagToMaybe, toFlag, trueArg, fromFlagOrDefault)
 
 data ProjectFlags = ProjectFlags
     { flagProjectFileName :: Flag FilePath
@@ -47,7 +47,8 @@ projectFlagsOptions showOrParseArgs =
         (reqArg "FILE" (succeedReadE Flag) flagToList)
     , option ['z'] ["ignore-project"]
         "Ignore local project configuration"
-        flagIgnoreProject (\v flags -> flags { flagIgnoreProject = v })
+        -- If the "--project-file" flag is set, then this will always be false
+        flagIgnoreProject (\v flags -> flags { flagIgnoreProject = toFlag (not ((not (fromFlagOrDefault False v)) || (NoFlag /= (flagProjectFileName flags))))  })
         (yesNoOpt showOrParseArgs)
     ]
 

--- a/cabal-install/src/Distribution/Client/ProjectFlags.hs
+++ b/cabal-install/src/Distribution/Client/ProjectFlags.hs
@@ -14,7 +14,7 @@ import Distribution.ReadE          (succeedReadE)
 import Distribution.Simple.Command
     ( MkOptDescr, OptionField(optionName), ShowOrParseArgs (..), boolOpt', option
     , reqArg )
-import Distribution.Simple.Setup   (Flag (..), flagToList, flagToMaybe, toFlag, trueArg, fromFlagOrDefault)
+import Distribution.Simple.Setup   (Flag (..), flagToList, flagToMaybe, toFlag, trueArg)
 
 data ProjectFlags = ProjectFlags
     { flagProjectFileName :: Flag FilePath
@@ -47,8 +47,10 @@ projectFlagsOptions showOrParseArgs =
         (reqArg "FILE" (succeedReadE Flag) flagToList)
     , option ['z'] ["ignore-project"]
         "Ignore local project configuration"
-        -- If the "--project-file" flag is set, then this will always be false
-        flagIgnoreProject (\v flags -> flags { flagIgnoreProject = toFlag (not ((not (fromFlagOrDefault False v)) || (NoFlag /= (flagProjectFileName flags))))  })
+        -- Flag True: --ignore-project is given and --project-file is not given
+        -- Flag False: --ignore-project and --project-file is given
+        -- NoFlag: neither --ignore-project or --project-file is given
+        flagIgnoreProject (\v flags -> flags { flagIgnoreProject = if v == NoFlag then NoFlag else toFlag ((flagProjectFileName flags) == NoFlag && v == Flag True) })
         (yesNoOpt showOrParseArgs)
     ]
 

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -209,7 +209,7 @@ establishProjectBaseContext
     -> IO ProjectBaseContext
 establishProjectBaseContext verbosity cliConfig currentCommand = do
     projectRoot <- either throwIO return =<< findProjectRoot Nothing mprojectFile
-    establishProjectBaseContextWithRoot verbosity cliConfig projectRoot currentCommand
+    establishProjectBaseContextWithRoot verbosity cliConfig False projectRoot currentCommand
   where
     mprojectFile   = Setup.flagToMaybe projectConfigProjectFile
     ProjectConfigShared { projectConfigProjectFile} = projectConfigShared cliConfig
@@ -218,10 +218,11 @@ establishProjectBaseContext verbosity cliConfig currentCommand = do
 establishProjectBaseContextWithRoot
     :: Verbosity
     -> ProjectConfig
+    -> Bool
     -> ProjectRoot
     -> CurrentCommand
     -> IO ProjectBaseContext
-establishProjectBaseContextWithRoot verbosity cliConfig projectRoot currentCommand = do
+establishProjectBaseContextWithRoot verbosity cliConfig ignoreLocalProjectFile projectRoot currentCommand = do
     cabalDir <- getCabalDir
 
     let distDirLayout  = defaultDistDirLayout projectRoot mdistDirectory
@@ -233,6 +234,7 @@ establishProjectBaseContextWithRoot verbosity cliConfig projectRoot currentComma
     (projectConfig, localPackages) <-
       rebuildProjectConfig verbosity
                            httpTransport
+                           ignoreLocalProjectFile
                            distDirLayout
                            cliConfig
 

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -209,7 +209,7 @@ establishProjectBaseContext
     -> IO ProjectBaseContext
 establishProjectBaseContext verbosity cliConfig currentCommand = do
     projectRoot <- either throwIO return =<< findProjectRoot Nothing mprojectFile
-    establishProjectBaseContextWithRoot verbosity cliConfig False projectRoot currentCommand
+    establishProjectBaseContextWithRoot verbosity cliConfig Setup.NoFlag projectRoot currentCommand
   where
     mprojectFile   = Setup.flagToMaybe projectConfigProjectFile
     ProjectConfigShared { projectConfigProjectFile} = projectConfigShared cliConfig
@@ -218,11 +218,11 @@ establishProjectBaseContext verbosity cliConfig currentCommand = do
 establishProjectBaseContextWithRoot
     :: Verbosity
     -> ProjectConfig
-    -> Bool
+    -> Setup.Flag Bool -- ^ @--ignore-project@
     -> ProjectRoot
     -> CurrentCommand
     -> IO ProjectBaseContext
-establishProjectBaseContextWithRoot verbosity cliConfig ignoreLocalProjectFile projectRoot currentCommand = do
+establishProjectBaseContextWithRoot verbosity cliConfig ignoreProjectFlag projectRoot currentCommand = do
     cabalDir <- getCabalDir
 
     let distDirLayout  = defaultDistDirLayout projectRoot mdistDirectory
@@ -234,7 +234,7 @@ establishProjectBaseContextWithRoot verbosity cliConfig ignoreLocalProjectFile p
     (projectConfig, localPackages) <-
       rebuildProjectConfig verbosity
                            httpTransport
-                           ignoreLocalProjectFile
+                           ignoreProjectFlag
                            distDirLayout
                            cliConfig
 

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -209,7 +209,7 @@ establishProjectBaseContext
     -> IO ProjectBaseContext
 establishProjectBaseContext verbosity cliConfig currentCommand = do
     projectRoot <- either throwIO return =<< findProjectRoot Nothing mprojectFile
-    establishProjectBaseContextWithRoot verbosity cliConfig Setup.NoFlag projectRoot currentCommand
+    establishProjectBaseContextWithRoot verbosity cliConfig projectRoot currentCommand
   where
     mprojectFile   = Setup.flagToMaybe projectConfigProjectFile
     ProjectConfigShared { projectConfigProjectFile} = projectConfigShared cliConfig
@@ -218,11 +218,10 @@ establishProjectBaseContext verbosity cliConfig currentCommand = do
 establishProjectBaseContextWithRoot
     :: Verbosity
     -> ProjectConfig
-    -> Setup.Flag Bool -- ^ @--ignore-project@
     -> ProjectRoot
     -> CurrentCommand
     -> IO ProjectBaseContext
-establishProjectBaseContextWithRoot verbosity cliConfig ignoreProjectFlag projectRoot currentCommand = do
+establishProjectBaseContextWithRoot verbosity cliConfig projectRoot currentCommand = do
     cabalDir <- getCabalDir
 
     let distDirLayout  = defaultDistDirLayout projectRoot mdistDirectory
@@ -234,7 +233,6 @@ establishProjectBaseContextWithRoot verbosity cliConfig ignoreProjectFlag projec
     (projectConfig, localPackages) <-
       rebuildProjectConfig verbosity
                            httpTransport
-                           ignoreProjectFlag
                            distDirLayout
                            cliConfig
 

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -304,12 +304,14 @@ sanityCheckElaboratedPackage ElaboratedConfiguredPackage{..}
 --
 rebuildProjectConfig :: Verbosity
                      -> HttpTransport
+                     -> Bool
                      -> DistDirLayout
                      -> ProjectConfig
                      -> IO ( ProjectConfig
                            , [PackageSpecifier UnresolvedSourcePackage] )
 rebuildProjectConfig verbosity
                      httpTransport
+                     ignoreLocalProjectFile
                      distDirLayout@DistDirLayout {
                        distProjectRootDirectory,
                        distDirectory,
@@ -318,7 +320,7 @@ rebuildProjectConfig verbosity
                        distProjectFile
                      }
                      cliConfig = do
-
+           
     fileMonitorProjectConfigKey <- do
       configPath <- getConfigFilePath projectConfigConfigFile
       return (configPath, distProjectFile "")
@@ -364,7 +366,7 @@ rebuildProjectConfig verbosity
     --
     phaseReadProjectConfig :: Rebuild ProjectConfigSkeleton
     phaseReadProjectConfig = do
-      readProjectConfig verbosity httpTransport projectConfigConfigFile distDirLayout
+      readProjectConfig verbosity httpTransport ignoreLocalProjectFile projectConfigConfigFile distDirLayout
 
     -- Look for all the cabal packages in the project
     -- some of which may be local src dirs, tarballs etc
@@ -376,7 +378,6 @@ rebuildProjectConfig verbosity
                                projectConfigBuildOnly
                              } = do
       pkgLocations <- findProjectPackages distDirLayout projectConfig
-
       -- Create folder only if findProjectPackages did not throw a
       -- BadPackageLocations exception.
       liftIO $ do

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -304,14 +304,12 @@ sanityCheckElaboratedPackage ElaboratedConfiguredPackage{..}
 --
 rebuildProjectConfig :: Verbosity
                      -> HttpTransport
-                     -> Flag Bool
                      -> DistDirLayout
                      -> ProjectConfig
                      -> IO ( ProjectConfig
                            , [PackageSpecifier UnresolvedSourcePackage] )
 rebuildProjectConfig verbosity
                      httpTransport
-                     ignoreProjectFlag -- ^ @--ignore-project@
                      distDirLayout@DistDirLayout {
                        distProjectRootDirectory,
                        distDirectory,
@@ -354,6 +352,9 @@ rebuildProjectConfig verbosity
     ProjectConfigShared { projectConfigConfigFile } =
       projectConfigShared cliConfig
 
+    ProjectConfigShared { projectConfigIgnoreProject } =
+      projectConfigShared cliConfig
+
     fileMonitorProjectConfig ::
       FileMonitor
         (FilePath, FilePath)
@@ -366,7 +367,7 @@ rebuildProjectConfig verbosity
     --
     phaseReadProjectConfig :: Rebuild ProjectConfigSkeleton
     phaseReadProjectConfig = do
-      readProjectConfig verbosity httpTransport ignoreProjectFlag projectConfigConfigFile distDirLayout
+      readProjectConfig verbosity httpTransport projectConfigIgnoreProject projectConfigConfigFile distDirLayout
 
     -- Look for all the cabal packages in the project
     -- some of which may be local src dirs, tarballs etc

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -320,7 +320,7 @@ rebuildProjectConfig verbosity
                        distProjectFile
                      }
                      cliConfig = do
-           
+
     fileMonitorProjectConfigKey <- do
       configPath <- getConfigFilePath projectConfigConfigFile
       return (configPath, distProjectFile "")
@@ -377,6 +377,7 @@ rebuildProjectConfig verbosity
                                projectConfigShared,
                                projectConfigBuildOnly
                              } = do
+
       pkgLocations <- findProjectPackages distDirLayout projectConfig
       -- Create folder only if findProjectPackages did not throw a
       -- BadPackageLocations exception.

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -304,14 +304,14 @@ sanityCheckElaboratedPackage ElaboratedConfiguredPackage{..}
 --
 rebuildProjectConfig :: Verbosity
                      -> HttpTransport
-                     -> Bool
+                     -> Flag Bool
                      -> DistDirLayout
                      -> ProjectConfig
                      -> IO ( ProjectConfig
                            , [PackageSpecifier UnresolvedSourcePackage] )
 rebuildProjectConfig verbosity
                      httpTransport
-                     ignoreLocalProjectFile
+                     ignoreProjectFlag -- ^ @--ignore-project@
                      distDirLayout@DistDirLayout {
                        distProjectRootDirectory,
                        distDirectory,
@@ -366,7 +366,7 @@ rebuildProjectConfig verbosity
     --
     phaseReadProjectConfig :: Rebuild ProjectConfigSkeleton
     phaseReadProjectConfig = do
-      readProjectConfig verbosity httpTransport ignoreLocalProjectFile projectConfigConfigFile distDirLayout
+      readProjectConfig verbosity httpTransport ignoreProjectFlag projectConfigConfigFile distDirLayout
 
     -- Look for all the cabal packages in the project
     -- some of which may be local src dirs, tarballs etc

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -53,7 +53,7 @@ import Distribution.Simple.Setup (toFlag, HaddockFlags(..), defaultHaddockFlags)
 import Distribution.Client.Setup (globalCommand)
 import Distribution.Simple.Compiler
 import Distribution.Simple.Command
-import qualified Distribution.Simple.Flag as Flg
+import qualified Distribution.Simple.Flag as Flag
 import Distribution.System
 import Distribution.Version
 import Distribution.ModuleName (ModuleName)
@@ -1969,11 +1969,11 @@ testIgnoreProjectFlag = do
   -- Coverage flag should be false globally by default (~/.cabal folder)
   (_, _, prjConfigGlobal, _, _) <- configureProject testdir ignoreSetConfig
   let globalCoverageFlag = packageConfigCoverage . projectConfigLocalPackages $ prjConfigGlobal
-  False @=? Flg.fromFlagOrDefault False globalCoverageFlag
+  False @=? Flag.fromFlagOrDefault False globalCoverageFlag
   -- It is set to true in the cabal.project file
   (_, _, prjConfigLocal, _, _) <- configureProject testdir emptyConfig
   let localCoverageFlag = packageConfigCoverage . projectConfigLocalPackages $ prjConfigLocal
-  True @=? Flg.fromFlagOrDefault False localCoverageFlag
+  True @=? Flag.fromFlagOrDefault False localCoverageFlag
   where
     testdir = "build/ignore-project"
     emptyConfig = mempty

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -174,7 +174,7 @@ testExceptionFindProjectRoot = do
 
 testTargetSelectors :: (String -> IO ()) -> Assertion
 testTargetSelectors reportSubCase = do
-    (_, _, _, localPackages, _) <- configureProject False testdir config
+    (_, _, _, localPackages, _) <- configureProject NoFlag testdir config
     let readTargetSelectors' = readTargetSelectorsWith (dirActions testdir)
                                                        localPackages
                                                        Nothing
@@ -286,7 +286,7 @@ testTargetSelectors reportSubCase = do
 
 testTargetSelectorBadSyntax :: Assertion
 testTargetSelectorBadSyntax = do
-    (_, _, _, localPackages, _) <- configureProject False testdir config
+    (_, _, _, localPackages, _) <- configureProject NoFlag testdir config
     let targets = [ "foo bar",  " foo"
                   , "foo:", "foo::bar"
                   , "foo: ", "foo: :bar"
@@ -528,7 +528,7 @@ instance IsString PackageIdentifier where
 
 testTargetSelectorNoCurrentPackage :: Assertion
 testTargetSelectorNoCurrentPackage = do
-    (_, _, _, localPackages, _) <- configureProject False testdir config
+    (_, _, _, localPackages, _) <- configureProject NoFlag testdir config
     let readTargetSelectors' = readTargetSelectorsWith (dirActions testdir)
                                                        localPackages
                                                        Nothing
@@ -551,7 +551,7 @@ testTargetSelectorNoCurrentPackage = do
 
 testTargetSelectorNoTargets :: Assertion
 testTargetSelectorNoTargets = do
-    (_, _, _, localPackages, _) <- configureProject False testdir config
+    (_, _, _, localPackages, _) <- configureProject NoFlag testdir config
     Left errs <- readTargetSelectors localPackages Nothing []
     errs @?= [TargetSelectorNoTargetsInCwd True]
     cleanProject testdir
@@ -562,7 +562,7 @@ testTargetSelectorNoTargets = do
 
 testTargetSelectorProjectEmpty :: Assertion
 testTargetSelectorProjectEmpty = do
-    (_, _, _, localPackages, _) <- configureProject False testdir config
+    (_, _, _, localPackages, _) <- configureProject NoFlag testdir config
     Left errs <- readTargetSelectors localPackages Nothing []
     errs @?= [TargetSelectorNoTargetsInProject]
     cleanProject testdir
@@ -576,7 +576,7 @@ testTargetSelectorProjectEmpty = do
 -- drive capitalisation mismatch when no targets are given
 testTargetSelectorCanonicalizedPath :: Assertion
 testTargetSelectorCanonicalizedPath = do
-  (_, _, _, localPackages, _) <- configureProject False testdir config
+  (_, _, _, localPackages, _) <- configureProject NoFlag testdir config
   cwd <- getCurrentDirectory
   let virtcwd = cwd </> basedir </> symlink
   -- Check that the symlink is there before running test as on Windows
@@ -1676,8 +1676,8 @@ type ProjDetails = (DistDirLayout,
                     [PackageSpecifier UnresolvedSourcePackage],
                     BuildTimeSettings)
 
-configureProject :: Bool -> FilePath -> ProjectConfig -> IO ProjDetails
-configureProject ignoreLocalProject testdir cliConfig = do
+configureProject :: Flag Bool -> FilePath -> ProjectConfig -> IO ProjDetails
+configureProject ignoreProjectFlag testdir cliConfig = do
     cabalDir <- getCabalDir
     let cabalDirLayout = defaultCabalDirLayout cabalDir
 
@@ -1698,7 +1698,7 @@ configureProject ignoreLocalProject testdir cliConfig = do
     (projectConfig, localPackages) <-
       rebuildProjectConfig verbosity
                            httpTransport
-                           ignoreLocalProject
+                           ignoreProjectFlag
                            distDirLayout
                            cliConfig
 
@@ -1724,7 +1724,7 @@ planProject testdir cliConfig = do
        cabalDirLayout,
        projectConfig,
        localPackages,
-       _buildSettings) <- configureProject False testdir cliConfig
+       _buildSettings) <- configureProject NoFlag testdir cliConfig
 
     (elaboratedPlan, _, elaboratedShared, _, _) <-
       rebuildInstallPlan verbosity
@@ -1968,11 +1968,11 @@ testNixFlags = do
 testIgnoreProjectFlag :: Assertion
 testIgnoreProjectFlag = do
   -- Coverage flag should be false globally by default (~/.cabal folder)
-  (_, _, prjConfigGlobal, _, _) <- configureProject True testdir emptyConfig
+  (_, _, prjConfigGlobal, _, _) <- configureProject (Flag True) testdir emptyConfig
   let globalCoverageFlag = packageConfigCoverage . projectConfigLocalPackages $ prjConfigGlobal
   False @=? Flg.fromFlagOrDefault False globalCoverageFlag
   -- It is set to true in the cabal.project file
-  (_, _, prjConfigLocal, _, _) <- configureProject False testdir emptyConfig
+  (_, _, prjConfigLocal, _, _) <- configureProject NoFlag testdir emptyConfig
   let localCoverageFlag = packageConfigCoverage . projectConfigLocalPackages $ prjConfigLocal
   True @=? Flg.fromFlagOrDefault False localCoverageFlag
   where

--- a/cabal-install/tests/IntegrationTests2/build/ignore-project/A.hs
+++ b/cabal-install/tests/IntegrationTests2/build/ignore-project/A.hs
@@ -1,0 +1,4 @@
+module A where
+
+a :: Int
+a = 42

--- a/cabal-install/tests/IntegrationTests2/build/ignore-project/Setup.hs
+++ b/cabal-install/tests/IntegrationTests2/build/ignore-project/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/cabal-install/tests/IntegrationTests2/build/ignore-project/a.cabal
+++ b/cabal-install/tests/IntegrationTests2/build/ignore-project/a.cabal
@@ -1,0 +1,10 @@
+name: a
+version: 0.1
+build-type: Simple
+cabal-version: >= 1.10
+
+library
+  exposed-modules: A
+  build-depends: base
+  default-language: Haskell2010
+  profiling: true

--- a/cabal-install/tests/IntegrationTests2/build/ignore-project/cabal.project
+++ b/cabal-install/tests/IntegrationTests2/build/ignore-project/cabal.project
@@ -1,0 +1,3 @@
+packages: .
+
+coverage: true

--- a/cabal-testsuite/PackageTests/Regression/T5318/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T5318/cabal.project
@@ -1,0 +1,1 @@
+packages: ./

--- a/cabal-testsuite/PackageTests/Regression/T5318/sdist-list-sources.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5318/sdist-list-sources.test.hs
@@ -2,6 +2,6 @@ import Test.Cabal.Prelude
 main = cabalTest $ do
   tmpdir <- fmap testTmpDir getTestEnv
   let fn = tmpdir </> "empty-data-dir-0.list"
-  cabal "v2-sdist" ["--ignore-project", "--list-only", "--output-directory", tmpdir]
+  cabal "v2-sdist" ["--list-only", "--output-directory", tmpdir]
   -- --list-sources outputs with slashes on posix and backslashes on Windows. 'normalise' converts our needle to the necessary format.
   assertFileDoesContain fn $ normalise "foo.dat"

--- a/cabal-testsuite/PackageTests/SDist/T5195/cabal.project
+++ b/cabal-testsuite/PackageTests/SDist/T5195/cabal.project
@@ -1,0 +1,1 @@
+packages: ./

--- a/cabal-testsuite/PackageTests/SDist/T5195/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/SDist/T5195/cabal.test.hs
@@ -1,5 +1,5 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
   tmpdir <- fmap testTmpDir getTestEnv
-  res <- fails $ cabal' "v2-sdist" ["--ignore-project", "--list-only", "--output-directory", tmpdir]
+  res <- fails $ cabal' "v2-sdist" ["--list-only", "--output-directory", tmpdir]
   assertOutputContains "filepath wildcard './actually-a-directory' does not match any files" res

--- a/cabal-testsuite/PackageTests/SDist/T7028/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/SDist/T7028/cabal.test.hs
@@ -1,4 +1,4 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
   tmpdir <- fmap testTmpDir getTestEnv
-  cabal "v2-sdist" ["--ignore-project", "--list-only", "--output-directory", tmpdir, "t7028"]
+  cabal "v2-sdist" ["--list-only", "--output-directory", tmpdir, "t7028"]

--- a/cabal-testsuite/PackageTests/SDist/T7124/cabal-list.test.hs
+++ b/cabal-testsuite/PackageTests/SDist/T7124/cabal-list.test.hs
@@ -6,4 +6,4 @@ import Test.Cabal.Prelude
 main :: IO ()
 main = cabalTest $ do
   tmpdir <- fmap testTmpDir getTestEnv
-  fails $ cabal "v2-sdist" ["--ignore-project", "--list-only", "--output-directory", tmpdir, "all"]
+  fails $ cabal "v2-sdist" ["--list-only", "--output-directory", tmpdir, "all"]

--- a/cabal-testsuite/PackageTests/SDist/T7124/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/SDist/T7124/cabal.test.hs
@@ -6,4 +6,4 @@ import Test.Cabal.Prelude
 main :: IO ()
 main = cabalTest $ do
   tmpdir <- fmap testTmpDir getTestEnv
-  fails $ cabal "v2-sdist" ["--ignore-project", "--output-directory", tmpdir, "all"]
+  fails $ cabal "v2-sdist" ["--output-directory", tmpdir, "all"]

--- a/cabal-testsuite/PackageTests/SDist/T7698/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/SDist/T7698/cabal.test.hs
@@ -1,4 +1,4 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
   tmpdir <- fmap testTmpDir getTestEnv
-  cabal "v2-sdist" ["--ignore-project", "--list-only", "--output-directory", tmpdir, "all"]
+  cabal "v2-sdist" ["--list-only", "--output-directory", tmpdir, "all"]

--- a/changelog.d/issue-7965
+++ b/changelog.d/issue-7965
@@ -1,0 +1,4 @@
+synopsis: Ensure that v2-sdist command respects the --ignore-project flag
+packages: cabal-install
+issues: #7965
+prs: #8109

--- a/changelog.d/issue-7965
+++ b/changelog.d/issue-7965
@@ -1,4 +1,5 @@
 synopsis: Ensure that v2-sdist command respects the --ignore-project flag
+-- If the "--project-file" flag is set, then this [--ignore-project] will always be false
 packages: cabal-install
 issues: #7965
 prs: #8109

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -295,6 +295,13 @@ package, and thus apply globally:
 
     This option cannot be specified via a ``cabal.project`` file.
 
+-- option:: --ignore-project
+    
+    Ignores the local ``cabal.project`` file and uses the default
+    configuration with the local ``foo.cabal`` file. Note that
+    if this flag is set while the ``--project-file`` flag is also
+    set then this flag will be ignored.
+
 .. option:: --store-dir=DIR
 
     Specifies the name of the directory of the global package store.


### PR DESCRIPTION
It seems that many commands did not respect the `--ignore-project` flag at all and always built from the `cabal.project` file that the program can find either in it's current directory or the parent directories. This PR changes the `readProjectConfig` function of the `Distribution.Client.ProjectConfig` to accept a boolean that will determine if the function will return the only the global project config or the settings found in the local `cabal.project` file. Whatever is returned gets merged with the local `foo.cabal` file and the package config is returned. This should make it so that if the `--ignore-project` flag is set then the local `cabal.project` file will be ignored and the global config and the `foo.cabal` file are merged together and the `sdist` command is run with that configuration.

There was some [discussion](https://github.com/haskell/cabal/issues/7965#issuecomment-1035625022) about the other commands that may or may not work with this flag. It was unclear to me whether or not they should be fixed and to what extent. This pr is just to have a proof of concept for the other commands so that I know that this flag is now doing what it is supposed to do and more work can be done later to the other commands making it behave the same way.

I wrote a test for this that tests the `readProjectConfig` with the flag set to true (all other tests that use this command were set to false for consistency). I'm not sure how to abstract this test any farther up the chain but that may not be needed since the `readProjectConfig` function is the only one with any significant change. 

Below is some output with the new changes showing that the `--ignore-project` flag ignores the `cabal.project` file for the "cabal" project when in the "cabal-install" folder.
![image](https://user-images.githubusercontent.com/5422113/164947102-996c1ebc-7685-44d7-842e-a7fe1647b77d.png)

---
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.