### PR TITLE
Unmark foreign lib test as broken for win and ghc >= 9.0

### DIFF
--- a/cabal-testsuite/PackageTests/ForeignLibs/setup.test.hs
+++ b/cabal-testsuite/PackageTests/ForeignLibs/setup.test.hs
@@ -28,9 +28,7 @@ main = setupAndCabalTest . recordMode DoNotRecord $ do
   skipUnlessGhcVersion ">= 7.8"
   osx <- isOSX
   ghc80 <- isGhcVersion "== 8.0.2"
-  win <- isWindows
-  ghcGreaterThan90 <- isGhcVersion ">= 9.0"
-  expectBrokenIf ((osx && ghc80) || (win && ghcGreaterThan90)) 7989 $
+  expectBrokenIf (osx && ghc80) 7989 $
     withPackageDb $ do
         setup_install []
         setup "copy" [] -- regression test #4156

--- a/changelog.d/pr-7764
+++ b/changelog.d/pr-7764
@@ -1,0 +1,17 @@
+synopsis: Use ghc -flink-rts option when available
+packages: Cabal
+prs: #7764 #8111
+issues: #7763
+significance: significant
+
+description: {
+
+Previously Cabal did quite some headstands to link against libHSrts.
+Note only this is complex but it couples very tightly to GHC's implementation.
+Thankfully, as of GHC 9.0 GHC provides a -flink-rts flag for precisely this purpose.
+Use it when available.
+
+It fixed a bug which make Cabal unusable to build foreign libraries for windows and ghc 9.0 or 9.2.
+See <https://gitlab.haskell.org/ghc/ghc/-/issues/20520>
+
+}


### PR DESCRIPTION
* It seems #7764 fixed the test, but the pr was merged without having the ci green
* Since that, the validate workflow is failing 

---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.

