### PR TITLE
Exclude broken 'Validate windows-latest ghc-8.4.4' job that cancels CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,6 +43,8 @@ jobs:
           # lot of segfaults caused by ghc bugs
           - os: "windows-latest"
             ghc: "8.8.4"
+          - os: "windows-latest"
+            ghc: "8.4.4"
         include:
           - os: "ubuntu-latest"
             ghc: "8.0.2"


### PR DESCRIPTION
See https://github.com/haskell/cabal/pull/8115#issuecomment-1113136131 and later comments.