### PR TITLE
Run always validate post-job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -276,6 +276,7 @@ jobs:
   # This way we can use it exclusively in branch protection rules
   # and abstract away the concrete jobs of the workflow, including their names
   validate-post-job:
+    if: always()
     name: Validate post job
     runs-on: ubuntu-18.04
     # IMPORTANT! Any job added to the workflow should be added here too


### PR DESCRIPTION
To make mergify not merge prs with failing validate jobs
If a main validate job fails github marks as skipped the rest of workflow jobs.
Otoh mergify considers prs with skipped required jobs as mergeable 😮 🤦 

This pr forces the run of the post job, which will fail if any of the previous jobs has failed or skipped

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
