### PR TITLE
Remove >= from Cabal cabal-version

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,4 +1,4 @@
-cabal-version: >=1.22
+cabal-version: 1.22
 name:          Cabal
 version:       3.7.0.0
 copyright:     2003-2021, Cabal Development Team (see AUTHORS file)


### PR DESCRIPTION
>= shouldn't be used for cabal-version 1.12 and later, and
9e353b067e7045689003a3c662343dfd8dfd1fd1 changed it to 1.22

We should run `cabal check` in CI to catch errors like this one in the future

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
