### PR TITLE
Minor clean up after PR #7934

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/src/Distribution/Client/CmdUpdate.hs
@@ -64,6 +64,7 @@ import Distribution.Simple.Command
          ( CommandUI(..), usageAlternatives )
 
 import qualified Hackage.Security.Client as Sec
+import Distribution.Client.IndexUtils.Timestamp (nullTimestamp)
 
 updateCommand :: CommandUI (NixStyleFlags ())
 updateCommand = CommandUI
@@ -227,7 +228,10 @@ updateRepo verbosity _updateFlags repoCtxt (repo, indexState) = do
       -- TODO: This will print multiple times if there are multiple
       -- repositories: main problem is we don't have a way of updating
       -- a specific repo.  Once we implement that, update this.
-      when (new_ts /= current_ts) $
+
+      -- In case current_ts is a valid timestamp different from new_ts, let
+      -- the user know how to go back to current_ts
+      when (current_ts /= nullTimestamp && new_ts /= current_ts) $
         noticeNoWrap verbosity $
           "To revert to previous state run:\n" ++
           "    cabal v2-update '" ++ prettyShow (UpdateRequest rname (IndexStateTime current_ts)) ++ "'\n"

--- a/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.out
+++ b/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.out
@@ -4,8 +4,6 @@ Warning: No mirrors found for http://localhost:8000/
 Downloading the latest package list from repository.localhost
 Package list of repository.localhost has been updated.
 The index-state is set to 2022-01-28T02:36:41Z.
-To revert to previous state run:
-    cabal v2-update 'repository.localhost,'
 # cabal update
 Downloading the latest package list from repository.localhost
 Package list of repository.localhost is up to date.


### PR DESCRIPTION
I noticed I had left out a small detail in the previous PR. `current_ts` can be an invalid timestamp (of value `nullTimestamp`) if, e.g., the repository is missing. In this case we shouldn't tell the user how to go back to `current_ts` because it does not make any sense. Test case explains this better than my words :)

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
