### PR TITLE
code-generators now marked to 3.8 spec

### DIFF
--- a/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
@@ -322,7 +322,7 @@ testSuiteFieldGrammar = TestSuiteStanza
     <*> optionalField    "test-module"            testStanzaTestModule
     <*> blurFieldGrammar testStanzaBuildInfo buildInfoFieldGrammar
     <*> monoidalFieldAla "code-generators"        (alaList'  CommaFSep Token)     testStanzaCodeGenerators
-          ^^^ availableSince CabalSpecV3_6 [] -- TODO 3_8
+          ^^^ availableSince CabalSpecV3_8 []
 
 validateTestSuite :: Position -> TestSuiteStanza -> ParseResult TestSuite
 validateTestSuite pos stanza = case testSuiteType of

--- a/cabal-testsuite/PackageTests/TestCodeGenerator/my.cabal
+++ b/cabal-testsuite/PackageTests/TestCodeGenerator/my.cabal
@@ -1,4 +1,4 @@
-cabal-version:  3.6
+cabal-version:  3.8
 name:           my
 version:        0.1
 license:        BSD-3-Clause


### PR DESCRIPTION
followup from https://github.com/haskell/cabal/pull/7688