### PR TITLE
Require `type` field when spec < 3.8 (#8115)

### DIFF
--- a/Cabal-tests/tests/ParserTests/errors/issue-5055-2.errors
+++ b/Cabal-tests/tests/ParserTests/errors/issue-5055-2.errors
@@ -1,2 +1,2 @@
 VERSION: Just (mkVersion [2,0])
-issue-5055-2.cabal:15:1: Test suite "flag-cabal-test" is missing required field "main-is" or the field is not present in all conditional branches.
+issue-5055-2.cabal:15:1: Test suite "flag-cabal-test" is missing required field "type" or the field is not present in all conditional branches. The available test types are: exitcode-stdio-1.0, detailed-0.9

--- a/Cabal-tests/tests/ParserTests/errors/issue-5055.errors
+++ b/Cabal-tests/tests/ParserTests/errors/issue-5055.errors
@@ -1,2 +1,2 @@
 VERSION: Just (mkVersion [2,0])
-issue-5055.cabal:15:1: Test suite "flag-cabal-test" is missing required field "main-is" or the field is not present in all conditional branches.
+issue-5055.cabal:15:1: Test suite "flag-cabal-test" is missing required field "type" or the field is not present in all conditional branches. The available test types are: exitcode-stdio-1.0, detailed-0.9

--- a/Cabal-tests/tests/ParserTests/regressions/issue-5055.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-5055.expr
@@ -213,9 +213,11 @@ GenericPackageDescription {
               condTreeData = TestSuite {
                 testName = UnqualComponentName
                   "",
-                testInterface = TestSuiteExeV10
-                  (mkVersion [1, 0])
-                  "FirstMain.hs",
+                testInterface =
+                TestSuiteUnsupported
+                  (TestTypeUnknown
+                    ""
+                    (mkVersion [])),
                 testBuildInfo = BuildInfo {
                   buildable = True,
                   buildTools = [],

--- a/Cabal-tests/tests/ParserTests/regressions/issue-5055.format
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-5055.format
@@ -19,5 +19,3 @@ test-suite flag-cabal-test
     build-depends:    base >=4.8 && <5
 
     if os(windows)
-        type:    exitcode-stdio-1.0
-        main-is: FirstMain.hs

--- a/cabal-install/tests/IntegrationTests2/targets/benchmarks-disabled/p.cabal
+++ b/cabal-install/tests/IntegrationTests2/targets/benchmarks-disabled/p.cabal
@@ -1,7 +1,7 @@
+cabal-version: 3.8
 name: p
 version: 0.1
 build-type: Simple
-cabal-version: >= 1.10
 
 benchmark solver-disabled
   type: exitcode-stdio-1.0

--- a/cabal-install/tests/IntegrationTests2/targets/multiple-tests/p.cabal
+++ b/cabal-install/tests/IntegrationTests2/targets/multiple-tests/p.cabal
@@ -1,7 +1,7 @@
+cabal-version: 3.8
 name: p
 version: 0.1
 build-type: Simple
-cabal-version: >= 1.10
 
 test-suite p1
   main-is:  P1.hs

--- a/cabal-install/tests/IntegrationTests2/targets/variety/p.cabal
+++ b/cabal-install/tests/IntegrationTests2/targets/variety/p.cabal
@@ -1,7 +1,7 @@
+cabal-version: 3.8
 name: p
 version: 0.1
 build-type: Simple
-cabal-version: >= 1.10
 
 library
   exposed-modules: P

--- a/cabal-testsuite/PackageTests/DuplicateModuleName/DuplicateModuleName.cabal
+++ b/cabal-testsuite/PackageTests/DuplicateModuleName/DuplicateModuleName.cabal
@@ -1,10 +1,10 @@
+cabal-version:       3.8
 name:                DuplicateModuleName
 version:             0.1.0.0
-license:             BSD3
+license:             BSD-3-Clause
 author:              Edward Z. Yang
 maintainer:          ezyang@cs.stanford.edu
 build-type:          Simple
-cabal-version:       >=1.10
 
 library
   exposed-modules:     Foo

--- a/cabal-testsuite/PackageTests/NewBuild/CmdBench/MultipleBenchmarks/MultipleBenchmarks.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdBench/MultipleBenchmarks/MultipleBenchmarks.cabal
@@ -1,7 +1,7 @@
+cabal-version: 3.8
 name: MultipleBenchmarks
 version: 1.0
 build-type: Simple
-cabal-version: >= 1.10
 
 benchmark foo
     main-is: Foo.hs

--- a/changelog.d/pr-8115
+++ b/changelog.d/pr-8115
@@ -4,7 +4,7 @@ prs: #8115
 issues: #7459
 description: {
 
-Allow the ommission of the `type` field in `test-suite` and `benchmark` stanzas
+Allow the omission of the `type` field in `test-suite` and `benchmark` stanzas
 when the type can be inferred by the presence of `main-is` or `test-module`.
 
 }

--- a/doc/file-format-changelog.rst
+++ b/doc/file-format-changelog.rst
@@ -49,6 +49,8 @@ relative to the respective preceding *published* version.
   allowed of the form ``foo/**/literalFile``. Prior, double-star
   wildcards required the trailing filename itself be a wildcard.
 
+* Allow the omission of the `type` field in `test-suite` and `benchmark` stanzas
+  when the type can be inferred by the presence of `main-is` or `test-module`.
 
 ``cabal-version: 3.6``
 ----------------------


### PR DESCRIPTION
Addresses changes requested in https://github.com/haskell/cabal/pull/8115#issuecomment-1122494025

---

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.
