### PR TITLE
Clarify `runhaskell` in Cabal's guide

### DIFF
--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -3,15 +3,17 @@ Setup.hs Commands
 
 .. highlight:: console
 
-The low-level Cabal interface is implemented using ``Setup.hs`` scripts.
-You should prefer using higher level interface provided by
-nix-style builds.
+GHC provides the commands ``runhaskell`` and ``runghc`` (they are equivalent)
+to allow you to run Haskell programs without first having to compile them
+(scripts). The low-level Cabal interface is implemented using ``Setup.hs``
+scripts. You should prefer using higher level interface provided by nix-style
+builds.
 
 ::
 
     $ runhaskell Setup.hs [command] [option...]
 
-For the summary of the command syntax, run:
+For the summary of the ``Setup.hs`` script's command syntax, run:
 
 ::
 


### PR DESCRIPTION
The original Cabal proposal https://www.haskell.org/cabal/proposal/ explained that `runhaskell`, in the proposal, was to refer to a symlink to `runhugs`, `runghc`, or `runnhc`. That explanation has been lost from the Cabal guide. Since the date of the original proposal, HUGS and NHC have fallen by the wayside. This pull request proposes two minor additions to restore the explanation:

1. A sentence "The command `runhaskell` (or its GHC equivalent, `runghc`) allows you to run Haskell programs without first having to compile them." This wording is lifted from the GHC user guide for `runghc`.

2. A clarification that `--help` provides information about the `Setup.hs` script (not the `runhaskell` command).


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
