### PR TITLE
Improve error message for empty --allow-newer= (fix #7740)

### DIFF
--- a/Cabal/src/Distribution/ReadE.hs
+++ b/Cabal/src/Distribution/ReadE.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.ReadE
@@ -13,13 +14,17 @@ module Distribution.ReadE (
    -- * ReadE
    ReadE(..), succeedReadE, failReadE,
    -- * Projections
-   parsecToReadE,
+   parsecToReadE, parsecToReadEErr,
+   -- * Parse Errors
+   unexpectMsgString,
   ) where
 
 import Distribution.Compat.Prelude
 import Prelude ()
+import qualified Data.Bifunctor as Bi (first)
 
 import Distribution.Parsec
+import qualified Text.Parsec.Error as Parsec
 import Distribution.Parsec.FieldLineStream
 
 -- | Parser with simple error reporting
@@ -37,9 +42,22 @@ succeedReadE f = ReadE (Right . f)
 failReadE :: ErrorMsg -> ReadE a
 failReadE = ReadE . const . Left
 
+runParsecFromString :: ParsecParser a -> String -> Either Parsec.ParseError a
+runParsecFromString p txt = 
+    runParsecParser p "<parsecToReadE>" (fieldLineStreamFromString txt)
+
 parsecToReadE :: (String -> ErrorMsg) -> ParsecParser a -> ReadE a
 parsecToReadE err p = ReadE $ \txt ->
-    case runParsecParser p "<parsecToReadE>" (fieldLineStreamFromString txt) of
-        Right x -> Right x
-        Left _e -> Left (err txt)
--- TODO: use parsec error to make 'ErrorMsg'.
+    (const $ err txt) `Bi.first` runParsecFromString p txt
+
+parsecToReadEErr :: (Parsec.ParseError -> ErrorMsg) -> ParsecParser a -> ReadE a
+parsecToReadEErr err p = ReadE $ 
+    Bi.first err . runParsecFromString p
+
+-- Show only unexpected error messages
+unexpectMsgString :: Parsec.ParseError -> String 
+unexpectMsgString = unlines
+   . map Parsec.messageString
+   . filter (\case { Parsec.UnExpect _ -> True; _ -> False })
+   . Parsec.errorMessages
+

--- a/changelog.d/pr-8140
+++ b/changelog.d/pr-8140
@@ -1,0 +1,11 @@
+synopsis: Improve error message for empty --allow-newer= 
+packages: Cabal, cabal-install
+prs: #8140
+issues: #7740
+description: {
+
+Instead of internal error, the message now explains that empty argument for
+--allow-newer= is not allowed and reminds what --allow-newer (with the empty
+argument) means.
+
+}


### PR DESCRIPTION
~~This is a WIP, it's not beautiful:~~ (see the first comment below)

```
❯ $CABAL build --allow-newer=                                                                                              1 (0.018s) < 04:31:50
Error: cabal: invalid argument to option `--allow-newer': "<parsecToReadE>"
(line 1, column 1):
unexpected empty argument list for --allow-newer=. Use --allow-newer without
the equals sign to permit all packages to use newer versions.
expecting "*"
```

Should `"parsecToReadE"` be removed? It can be but this may make it harder to debug anything that goes via `parsecToReadE`. 

`expecting "*"` is annoying but I'm not sure how to remove it either.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
