### PR TITLE
Add CI job testing only Cabal with the latest GHC

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -46,6 +46,18 @@ jobs:
           - os: "windows-latest"
             ghc: "8.4.4"
         include:
+          # this is to build Cabal with boot packages form the lastest GHC
+          # (cabal-install will include other dependencies which will likely exclude package versions release with newer GHCs)
+          - os: "ubuntu-latest"
+            ghc: "9.2.1"
+            cli: "false"
+          - os: "macos-latest"
+            ghc: "9.2.1"
+            cli: "false"
+          - os: "windows-latest"
+            ghc: "9.2.1"
+            cli: "false"
+          #
           - os: "ubuntu-latest"
             ghc: "8.0.2"
             cli: "false"


### PR DESCRIPTION
This is to build Cabal with boot packages form the latest GHC.

(cabal-install will include other dependencies which will likely exclude package versions release with newer GHCs).

Ping @Mikolaj @jneira @phadej 

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
