### PR TITLE
Re #7916: undeprecate Distribution.Types.VersionInterval.Legacy

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/VersionInterval.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionInterval.hs
@@ -1,7 +1,13 @@
 {-# LANGUAGE BangPatterns       #-}
 {-# LANGUAGE DeriveDataTypeable #-}
--- | In @Cabal-3.6@ this module have been rewritten.
+
+-- | This module implements a view of a 'VersionRange' as a finite
+-- list of separated version intervals.
 --
+-- In conversion from and to 'VersionRange' it makes some effort to
+-- preserve the caret operator @^>=x.y@.  This constraint a priori
+-- specifies the same interval as @==x.y.*@, but indicates that newer
+-- versions could be acceptable (@allow-newer: ^@).
 --
 module Distribution.Types.VersionInterval (
     -- * Version intervals

--- a/Cabal-syntax/src/Distribution/Types/VersionInterval/Legacy.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionInterval/Legacy.hs
@@ -1,9 +1,16 @@
 {-# LANGUAGE DeriveDataTypeable #-}
--- | This is old version of "Distribution.Types.VersionInterval" module.
+
+-- | This module implements a view of a 'VersionRange' as a finite
+-- list of separated version intervals and provides the Boolean
+-- algebra operations union, intersection, and complement.
 --
--- It will be removed in @Cabal-3.8@.
+-- It interprets the caret operator @^>=x.y@ as simply @==x.y.*@.
+-- Until @Cabal < 3.6@, this module was called "Distribution.Types.VersionInterval".
+-- The current module "Distribution.Types.VersionInterval" (refurbished since
+-- @Cabal >= 3.6@) makes some effort to preserve the caret operator,
+-- but so far does not expose the Boolean algebra structure.
 --
-module Distribution.Types.VersionInterval.Legacy {-# DEPRECATED "Use Distribution.Types.VersionInterval instead" #-} (
+module Distribution.Types.VersionInterval.Legacy (
     -- * Version intervals
     VersionIntervals,
     toVersionIntervals,


### PR DESCRIPTION
Undeprecate `Distribution.Types.VersionInterval.Legacy`, see
- #7916

While `Distribution.Types.VersionInterval` does not export the Boolean algebra operations union, intersection and complement on `VersionIntervals`, the Legacy variant is still needed. Third party tools like `hackage-cli` rely on this API.

This patch only removes a DEPRECATED pragma and fixes the haddocs.  (No functionality changes.)

This needs to go into the 3.8 release.