### PR TITLE
Bump cabal-version in the remaining .cabal files and update BSD3 name

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -1,8 +1,8 @@
-cabal-version: >=1.10
+cabal-version: 2.0
 name:          Cabal-syntax
 version:       3.7.0.0
 copyright:     2003-2021, Cabal Development Team (see AUTHORS file)
-license:       BSD3
+license:       BSD-3-Clause
 license-file:  LICENSE
 author:        Cabal Development Team <cabal-devel@haskell.org>
 maintainer:    cabal-devel@haskell.org

--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -1,8 +1,8 @@
-cabal-version: >=1.10
+cabal-version: 2.0
 name:          Cabal-tests
 version:       3
 copyright:     2003-2021, Cabal Development Team (see AUTHORS file)
-license:       BSD3
+license:       BSD-3-Clause
 license-file:  LICENSE
 author:        Cabal Development Team <cabal-devel@haskell.org>
 maintainer:    cabal-devel@haskell.org

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,8 +1,8 @@
-cabal-version: 1.22
+cabal-version: 2.0
 name:          Cabal
 version:       3.7.0.0
 copyright:     2003-2021, Cabal Development Team (see AUTHORS file)
-license:       BSD3
+license:       BSD-3-Clause
 license-file:  LICENSE
 author:        Cabal Development Team <cabal-devel@haskell.org>
 maintainer:    cabal-devel@haskell.org

--- a/cabal-benchmarks/cabal-benchmarks.cabal
+++ b/cabal-benchmarks/cabal-benchmarks.cabal
@@ -1,7 +1,7 @@
 name:               cabal-benchmarks
 version:            3
 copyright:          2003-2021, Cabal Development Team (see AUTHORS file)
-license:            BSD3
+license:            BSD-3-Clause
 license-file:       LICENSE
 author:             Cabal Development Team <cabal-devel@haskell.org>
 maintainer:         cabal-devel@haskell.org
@@ -12,7 +12,7 @@ description:
   This package contains benchmarks that test cabal's dependency solver by running the cabal executable.
 
 category:           Distribution
-cabal-version:      >=1.10
+cabal-version:      2.0
 build-type:         Simple
 extra-source-files: README.md
 

--- a/solver-benchmarks/solver-benchmarks.cabal
+++ b/solver-benchmarks/solver-benchmarks.cabal
@@ -1,7 +1,7 @@
 name:          solver-benchmarks
 version:       3
 copyright:     2003-2020, Cabal Development Team (see AUTHORS file)
-license:       BSD3
+license:       BSD-3-Clause
 license-file:  LICENSE
 author:        Cabal Development Team <cabal-devel@haskell.org>
 maintainer:    cabal-devel@haskell.org
@@ -11,7 +11,7 @@ synopsis:      Benchmarks for the cabal dependency solver
 description:
   This package contains benchmarks that test cabal's dependency solver by running the cabal executable.
 category:       Distribution
-cabal-version:  >=1.10
+cabal-version:  2.0
 build-type:     Simple
 
 extra-source-files:


### PR DESCRIPTION
This makes our packages more uniform and future-proofs their licence fields.