### PR TITLE
Haddocks command

### DIFF
--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -699,7 +699,7 @@ renderPureArgs version comp platform args = concat
     [ map (\f -> "--dump-interface="++ unDir (argOutputDir args) </> f)
       . flagToList . argInterfaceFile $ args 
 
-    , if isVersion 2 16
+    , if haddockSupportsPackageName
         then maybe [] (\pkg -> [ "--package-name=" ++ prettyShow (pkgName pkg)
                                , "--package-version=" ++ prettyShow (pkgVersion pkg)
                                ])
@@ -803,6 +803,7 @@ renderPureArgs version comp platform args = concat
        | isVersion 2 5 = "--verbosity=1"
        | otherwise     = "--verbose"
       haddockSupportsVisibility = version >= mkVersion [2,26,1]
+      haddockSupportsPackageName = version > mkVersion [2,16]
 
 ---------------------------------------------------------------------------------
 

--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -105,6 +105,10 @@ data HaddockArgs = HaddockArgs {
  -- ^ Optional custom CSS file.
  argContents :: Flag String,
  -- ^ Optional URL to contents page.
+ argIndex :: Flag String,
+ -- ^ Optional URL to index page.
+ argBaseUrl :: Flag String,
+ -- ^ Optional base url from which static files will be loaded.
  argVerbose :: Any,
  argOutput :: Flag [Output],
  -- ^ HTML or Hoogle doc or both? Required.
@@ -352,6 +356,9 @@ fromFlags env flags =
       argCssFile = haddockCss flags,
       argContents = fmap (fromPathTemplate . substPathTemplate env)
                     (haddockContents flags),
+      argIndex = fmap (fromPathTemplate . substPathTemplate env)
+                    (haddockIndex flags),
+      argBaseUrl = haddockBaseUrl flags,
       argVerbose = maybe mempty (Any . (>= deafening))
                    . flagToMaybe $ haddockVerbosity flags,
       argOutput =
@@ -658,6 +665,10 @@ renderPureArgs version comp platform args = concat
     , maybe [] ((:[]) . ("--css="++)) . flagToMaybe . argCssFile $ args
 
     , maybe [] ((:[]) . ("--use-contents="++)) . flagToMaybe . argContents $ args
+
+    , maybe [] ((:[]) . ("--use-index="++)) . flagToMaybe . argIndex $ args
+
+    , maybe [] ((:[]) . ("--base-url="++)) . flagToMaybe . argBaseUrl $ args
 
     , bool [] [verbosityFlag] . getAny . argVerbose $ args
 

--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -132,8 +132,10 @@ data HaddockArgs = HaddockArgs {
  -- ^ To find the correct GHC, required.
  argReexports :: [OpenModule],
  -- ^ Re-exported modules
- argTargets :: [FilePath]
+ argTargets :: [FilePath],
  -- ^ Modules to process.
+ argLib :: Flag String
+ -- ^ haddock's static \/ auxiliary files.
 } deriving Generic
 
 -- | The FilePath of a directory, it's a monoid under '(</>)'.
@@ -383,6 +385,7 @@ fromFlags env flags =
                     (haddockIndex flags),
       argGenIndex = Flag False,
       argBaseUrl = haddockBaseUrl flags,
+      argLib = haddockLib flags,
       argVerbose = maybe mempty (Any . (>= deafening))
                    . flagToMaybe $ haddockVerbosity flags,
       argOutput =
@@ -407,6 +410,7 @@ fromHaddockProjectFlags flags =
       , argPrologueFile = haddockProjectPrologue flags
       , argInterfaces = fromFlagOrDefault [] (haddockProjectInterfaces flags)
       , argLinkedSource = haddockProjectLinkedSource flags
+      , argLib = haddockProjectLib flags
       }
 
 
@@ -763,6 +767,7 @@ renderPureArgs version comp platform args = concat
       ]
 
     , argTargets $ args
+    , maybe [] ((:[]) . ("--lib="++)) . flagToMaybe . argLib $ args
     ]
     where
       renderInterfaces = map renderInterface

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -1590,6 +1590,7 @@ data HaddockProjectFlags = HaddockProjectFlags {
 
     haddockProjectProgramPaths :: [(String, FilePath)],
     haddockProjectProgramArgs  :: [(String, [String])],
+    haddockProjectHoogle       :: Flag Bool,
     -- haddockHtml is not supported
     -- haddockForHackage is not supported
     haddockProjectExecutables  :: Flag Bool,
@@ -1620,6 +1621,7 @@ defaultHaddockProjectFlags = HaddockProjectFlags {
     haddockProjectTestSuites   = Flag False,
     haddockProjectProgramPaths = mempty,
     haddockProjectProgramArgs  = mempty,
+    haddockProjectHoogle       = Flag False,
     haddockProjectExecutables  = Flag False,
     haddockProjectBenchmarks   = Flag False,
     haddockProjectForeignLibs  = Flag False,
@@ -1680,6 +1682,11 @@ haddockProjectOptions _showOrParseArgs =
     ,option "" ["gen-contents"]
      "Generate contents"
      haddockProjectGenContents (\v flags -> flags { haddockProjectGenContents = v})
+     trueArg
+
+    ,option "" ["hoogle"]
+     "Generate a hoogle database"
+     haddockProjectHoogle (\v flags -> flags { haddockProjectHoogle = v })
      trueArg
 
     ,option "" ["executables"]

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -1376,10 +1376,12 @@ data HaddockFlags = HaddockFlags {
     haddockQuickJump    :: Flag Bool,
     haddockHscolourCss  :: Flag FilePath,
     haddockContents     :: Flag PathTemplate,
+    haddockIndex        :: Flag PathTemplate,
     haddockDistPref     :: Flag FilePath,
     haddockKeepTempFiles:: Flag Bool,
     haddockVerbosity    :: Flag Verbosity,
     haddockCabalFilePath :: Flag FilePath,
+    haddockBaseUrl      :: Flag String,
     haddockArgs         :: [String]
   }
   deriving (Show, Generic, Typeable)
@@ -1406,6 +1408,8 @@ defaultHaddockFlags  = HaddockFlags {
     haddockKeepTempFiles= Flag False,
     haddockVerbosity    = Flag normal,
     haddockCabalFilePath = mempty,
+    haddockIndex        = NoFlag,
+    haddockBaseUrl      = NoFlag,
     haddockArgs         = mempty
   }
 
@@ -1533,6 +1537,18 @@ haddockOptions showOrParseArgs =
    (reqArg' "URL"
     (toFlag . toPathTemplate)
     (flagToList . fmap fromPathTemplate))
+
+  ,option "" ["index-location"]
+   "Use a separately-generated HTML index"
+   haddockIndex (\v flags -> flags { haddockIndex = v})
+   (reqArg' "URL"
+    (toFlag . toPathTemplate)
+    (flagToList . fmap fromPathTemplate))
+
+  ,option "" ["base-url"]
+   "Base URL for static files."
+   haddockBaseUrl (\v flags -> flags { haddockBaseUrl = v})
+   (reqArgFlag "URL")
   ]
 
 emptyHaddockFlags :: HaddockFlags

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -43,8 +43,8 @@ module Distribution.Simple.Setup (
   InstallFlags(..),  emptyInstallFlags,  defaultInstallFlags,  installCommand,
   HaddockTarget(..),
   HaddockFlags(..),  emptyHaddockFlags,  defaultHaddockFlags,  haddockCommand,
-  HaddockProjectFlags(..), emptyHaddockProjectFlags,
-  defaultHaddockProjectFlags, haddockProjectCommand,
+  Visibility(..),
+  HaddockProjectFlags(..), emptyHaddockProjectFlags, defaultHaddockProjectFlags, haddockProjectCommand,
   HscolourFlags(..), emptyHscolourFlags, defaultHscolourFlags, hscolourCommand,
   BuildFlags(..),    emptyBuildFlags,    defaultBuildFlags,    buildCommand,
   DumpBuildInfo(..),
@@ -1574,15 +1574,23 @@ instance Semigroup HaddockFlags where
 -- * HaddocksFlags flags
 -- ------------------------------------------------------------
 
+-- | Governs whether modules from a given interface should be visible or
+-- hidden in the Haddock generated content page.  We don't expose this
+-- functionality to the user, but simply use 'Visible' for only local packages.
+-- Visibility of modules is available since @haddock-2.26.1@.
+--
+data Visibility = Visible | Hidden
+  deriving (Eq, Show)
+
 data HaddockProjectFlags = HaddockProjectFlags {
     -- options passed to @haddock@ via 'createHaddockIndex'
     haddockProjectDir          :: Flag String,
-    -- ^ output directory of combined haddockProject, the default is './haddocks'
+    -- ^ output directory of combined haddocks, the default is './haddocks'
     haddockProjectPrologue     :: Flag String,
     haddockProjectGenIndex     :: Flag Bool,
     haddockProjectGenContents  :: Flag Bool,
-    haddockProjectInterfaces   :: Flag [(FilePath, Maybe FilePath, Maybe FilePath)],
-    -- ^ 'haddockProjectInterfaces' is inferred by the 'haddocksAction'; currently not
+    haddockProjectInterfaces   :: Flag [(FilePath, Maybe FilePath, Maybe FilePath, Visibility)],
+    -- ^ 'haddocksInterfaces' is inferred by the 'haddocksAction'; currently not
     -- exposed to the user.
 
     -- options passed to @haddock@ via 'HaddockFlags' when building

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -1384,6 +1384,7 @@ data HaddockFlags = HaddockFlags {
     haddockVerbosity    :: Flag Verbosity,
     haddockCabalFilePath :: Flag FilePath,
     haddockBaseUrl      :: Flag String,
+    haddockLib          :: Flag String,
     haddockArgs         :: [String]
   }
   deriving (Show, Generic, Typeable)
@@ -1412,6 +1413,7 @@ defaultHaddockFlags  = HaddockFlags {
     haddockCabalFilePath = mempty,
     haddockIndex        = NoFlag,
     haddockBaseUrl      = NoFlag,
+    haddockLib          = NoFlag,
     haddockArgs         = mempty
   }
 
@@ -1551,6 +1553,11 @@ haddockOptions showOrParseArgs =
    "Base URL for static files."
    haddockBaseUrl (\v flags -> flags { haddockBaseUrl = v})
    (reqArgFlag "URL")
+
+  ,option "" ["lib"]
+   "location of Haddocks static / auxiliary files"
+   haddockLib (\v flags -> flags { haddockLib = v})
+   (reqArgFlag "DIR")
   ]
 
 emptyHaddockFlags :: HaddockFlags
@@ -1592,12 +1599,13 @@ data HaddockProjectFlags = HaddockProjectFlags {
     haddockProjectLinkedSource :: Flag Bool,
     haddockProjectQuickJump    :: Flag Bool,
     haddockProjectHscolourCss  :: Flag FilePath,
-    -- haddockProjectContent is not supported, a fixed value is provided
-    -- haddockProjectIndex is not supported, a fixed value is provided
-    -- haddockDistPerf is not supported, note: it changes location of the haddockProject
+    -- haddockContent is not supported, a fixed value is provided
+    -- haddockIndex is not supported, a fixed value is provided
+    -- haddockDistPerf is not supported, note: it changes location of the haddocks
     haddockProjectKeepTempFiles:: Flag Bool,
-    haddockProjectVerbosity    :: Flag Verbosity
+    haddockProjectVerbosity    :: Flag Verbosity,
     -- haddockBaseUrl is not supported, a fixed value is provided
+    haddockProjectLib          :: Flag String
   }
   deriving (Show, Generic, Typeable)
 
@@ -1618,6 +1626,7 @@ defaultHaddockProjectFlags = HaddockProjectFlags {
     haddockProjectHscolourCss  = NoFlag,
     haddockProjectKeepTempFiles= Flag False,
     haddockProjectVerbosity    = Flag normal,
+    haddockProjectLib          = NoFlag,
     haddockProjectInterfaces   = NoFlag
   }
 
@@ -1711,6 +1720,10 @@ haddockProjectOptions _showOrParseArgs =
     ,optionVerbosity haddockProjectVerbosity
      (\v flags -> flags { haddockProjectVerbosity = v })
 
+    ,option "" ["lib"]
+     "location of Haddocks static / auxiliary files"
+     haddockProjectLib (\v flags -> flags { haddockProjectLib = v})
+     (reqArgFlag "DIR")
     ]
 
 

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -1588,6 +1588,8 @@ data HaddockProjectFlags = HaddockProjectFlags {
     -- options passed to @haddock@ via 'HaddockFlags' when building
     -- documentation
 
+    haddockProjectProgramPaths :: [(String, FilePath)],
+    haddockProjectProgramArgs  :: [(String, [String])],
     -- haddockHtml is not supported
     -- haddockForHackage is not supported
     haddockProjectExecutables  :: Flag Bool,
@@ -1616,6 +1618,8 @@ defaultHaddockProjectFlags = HaddockProjectFlags {
     haddockProjectGenIndex     = Flag False,
     haddockProjectGenContents  = Flag False,
     haddockProjectTestSuites   = Flag False,
+    haddockProjectProgramPaths = mempty,
+    haddockProjectProgramArgs  = mempty,
     haddockProjectExecutables  = Flag False,
     haddockProjectBenchmarks   = Flag False,
     haddockProjectForeignLibs  = Flag False,
@@ -1642,8 +1646,19 @@ haddockProjectCommand = CommandUI
       , "COMPONENTS [FLAGS]"
       ]
   , commandDefaultFlags = defaultHaddockProjectFlags
-  , commandOptions      = haddockProjectOptions
+  , commandOptions      = \showOrParseArgs ->
+         haddockProjectOptions showOrParseArgs
+      ++ programDbPaths   progDb ParseArgs
+             haddockProjectProgramPaths (\v flags -> flags { haddockProjectProgramPaths = v})
+      ++ programDbOption  progDb showOrParseArgs
+             haddockProjectProgramArgs (\v fs -> fs { haddockProjectProgramArgs = v })
+      ++ programDbOptions progDb ParseArgs
+             haddockProjectProgramArgs  (\v flags -> flags { haddockProjectProgramArgs = v})
   }
+  where
+    progDb = addKnownProgram haddockProgram
+             $ addKnownProgram ghcProgram
+             $ emptyProgramDb
 
 haddockProjectOptions :: ShowOrParseArgs -> [OptionField HaddockProjectFlags]
 haddockProjectOptions _showOrParseArgs =

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -1600,6 +1600,7 @@ data HaddockProjectFlags = HaddockProjectFlags {
     haddockProjectProgramArgs  :: [(String, [String])],
     haddockProjectHoogle       :: Flag Bool,
     -- haddockHtml is not supported
+    haddockProjectHtmlLocation :: Flag String,
     -- haddockForHackage is not supported
     haddockProjectExecutables  :: Flag Bool,
     haddockProjectTestSuites   :: Flag Bool,
@@ -1630,6 +1631,7 @@ defaultHaddockProjectFlags = HaddockProjectFlags {
     haddockProjectProgramPaths = mempty,
     haddockProjectProgramArgs  = mempty,
     haddockProjectHoogle       = Flag False,
+    haddockProjectHtmlLocation = NoFlag,
     haddockProjectExecutables  = Flag False,
     haddockProjectBenchmarks   = Flag False,
     haddockProjectForeignLibs  = Flag False,
@@ -1696,6 +1698,11 @@ haddockProjectOptions _showOrParseArgs =
      "Generate a hoogle database"
      haddockProjectHoogle (\v flags -> flags { haddockProjectHoogle = v })
      trueArg
+
+    ,option "" ["html-location"]
+     "Location of HTML documentation for pre-requisite packages"
+     haddockProjectHtmlLocation (\v flags -> flags { haddockProjectHtmlLocation = v })
+     (reqArgFlag "URL")
 
     ,option "" ["executables"]
      "Run haddock for Executables targets"

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -1583,6 +1583,23 @@ data Visibility = Visible | Hidden
   deriving (Eq, Show)
 
 data HaddockProjectFlags = HaddockProjectFlags {
+    haddockProjectHackage      :: Flag Bool,
+    -- ^ a shortcut option which builds documentation linked to hackage.  It implies:
+    -- * `--html-location='https://hackage.haskell.org/package/$prg-$version/docs'
+    -- * `--quickjump`
+    -- * `--gen-index`
+    -- * `--gen-contents`
+    -- * `--hyperlinked-source`
+    haddockProjectLocal        :: Flag Bool,
+    -- ^ a shortcut option which builds self contained directory which contains
+    -- all the documentation, it implies:
+    -- * `--quickjump`
+    -- * `--gen-index`
+    -- * `--gen-contents`
+    -- * `--hyperlinked-source`
+    --
+    -- And it will also pass `--base-url` option to `haddock`.
+
     -- options passed to @haddock@ via 'createHaddockIndex'
     haddockProjectDir          :: Flag String,
     -- ^ output directory of combined haddocks, the default is './haddocks'
@@ -1623,6 +1640,8 @@ data HaddockProjectFlags = HaddockProjectFlags {
 
 defaultHaddockProjectFlags :: HaddockProjectFlags
 defaultHaddockProjectFlags = HaddockProjectFlags {
+    haddockProjectHackage      = Flag False,
+    haddockProjectLocal        = Flag False,
     haddockProjectDir          = Flag "./haddocks",
     haddockProjectPrologue     = NoFlag,
     haddockProjectGenIndex     = Flag False,
@@ -1674,7 +1693,23 @@ haddockProjectCommand = CommandUI
 
 haddockProjectOptions :: ShowOrParseArgs -> [OptionField HaddockProjectFlags]
 haddockProjectOptions _showOrParseArgs =
-    [option "" ["output"]
+    [option "" ["hackage"]
+     (concat ["A short-cut option to build documentation linked to hackage; "
+             ,"it implies --quickjump, --gen-index, --gen-contents, "
+             ,"--hyperlinked-source and --html-location"
+             ])
+     haddockProjectHackage (\v flags -> flags { haddockProjectHackage = v })
+     trueArg
+
+    ,option "" ["local"]
+     (concat ["A short-cut option to build self contained documentation; "
+             ,"it implies  --quickjump, --gen-index, --gen-contents "
+             ,"and --hyperlinked-source."
+             ])
+     haddockProjectLocal (\v flags -> flags { haddockProjectLocal = v })
+     trueArg
+
+    ,option "" ["output"]
       "Output directory"
       haddockProjectDir (\v flags -> flags { haddockProjectDir = v })
       (optArg' "DIRECTORY" maybeToFlag (fmap Just . flagToList))

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -83,6 +83,7 @@ library
         Distribution.Client.CmdExec
         Distribution.Client.CmdFreeze
         Distribution.Client.CmdHaddock
+        Distribution.Client.CmdHaddockProject
         Distribution.Client.CmdInstall
         Distribution.Client.CmdInstall.ClientInstallFlags
         Distribution.Client.CmdInstall.ClientInstallTargetSelector

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -78,6 +78,7 @@ import qualified Distribution.Client.CmdBuild     as CmdBuild
 import qualified Distribution.Client.CmdRepl      as CmdRepl
 import qualified Distribution.Client.CmdFreeze    as CmdFreeze
 import qualified Distribution.Client.CmdHaddock   as CmdHaddock
+import qualified Distribution.Client.CmdHaddockProject as CmdHaddockProject
 import qualified Distribution.Client.CmdInstall   as CmdInstall
 import qualified Distribution.Client.CmdRun       as CmdRun
 import qualified Distribution.Client.CmdTest      as CmdTest
@@ -257,6 +258,8 @@ mainWorker args = do
       , newCmd  CmdRepl.replCommand           CmdRepl.replAction
       , newCmd  CmdFreeze.freezeCommand       CmdFreeze.freezeAction
       , newCmd  CmdHaddock.haddockCommand     CmdHaddock.haddockAction
+      , newCmd  CmdHaddockProject.haddockProjectCommand
+                                              CmdHaddockProject.haddockProjectAction
       , newCmd  CmdInstall.installCommand     CmdInstall.installAction
       , newCmd  CmdRun.runCommand             CmdRun.runAction
       , newCmd  CmdTest.testCommand           CmdTest.testAction

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -60,7 +60,7 @@ import Distribution.Simple.InstallDirs
 import Distribution.Simple.Haddock (createHaddockIndex)
 import Distribution.Simple.Utils
          ( die', createDirectoryIfMissingVerbose
-         , copyDirectoryRecursive, )
+         , copyDirectoryRecursive, warn )
 import Distribution.Simple.Program.Builtin
          ( haddockProgram )
 import Distribution.Simple.Program.Db
@@ -89,6 +89,8 @@ haddockProjectAction flags _extraArgs globalFlags = do
             + flagElim 0 (const 1)  (haddockProjectHtmlLocation flags)
             )) $
       die' verbosity "Options `--local`, `--hackage` and `--html-location` are mutually exclusive`"
+
+    warn verbosity "haddock-project command is experimental, it might break in the future"
 
     -- build all packages with appropriate haddock flags
     let haddockFlags = defaultHaddockFlags

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -80,6 +80,7 @@ haddockProjectAction flags _extraArgs globalFlags = do
           , haddockBaseUrl      = Flag ".."
           , haddockProgramPaths = haddockProjectProgramPaths  flags
           , haddockProgramArgs  = haddockProjectProgramArgs   flags
+          , haddockHoogle       = haddockProjectHoogle        flags
           , haddockExecutables  = haddockProjectExecutables   flags
           , haddockTestSuites   = haddockProjectTestSuites    flags
           , haddockBenchmarks   = haddockProjectBenchmarks    flags

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -87,6 +87,7 @@ haddockProjectAction flags _extraArgs globalFlags = do
           , haddockIndex        = Flag (toPathTemplate "../doc-index.html")
           , haddockKeepTempFiles= haddockProjectKeepTempFiles flags
           , haddockVerbosity    = haddockProjectVerbosity     flags
+          , haddockLib          = haddockProjectLib           flags
           }
         nixFlags = (commandDefaultFlags CmdHaddock.haddockCommand)
                    { NixStyleOptions.haddockFlags = haddockFlags

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -1,0 +1,206 @@
+module Distribution.Client.CmdHaddockProject
+  ( haddockProjectCommand
+  , haddockProjectAction
+  ) where
+
+import Prelude ()
+import Distribution.Client.Compat.Prelude hiding (get)
+
+import qualified Distribution.Client.CmdBuild   as CmdBuild
+import qualified Distribution.Client.CmdHaddock as CmdHaddock
+
+import Distribution.Client.DistDirLayout      (DistDirLayout(..)
+                                              ,CabalDirLayout(..)
+                                              ,StoreDirLayout(..))
+import Distribution.Client.InstallPlan        (foldPlanPackage)
+import qualified Distribution.Client.InstallPlan as InstallPlan
+import qualified Distribution.Client.NixStyleOptions as NixStyleOptions
+import Distribution.Client.ProjectOrchestration
+                                              (AvailableTarget(..)
+                                              ,AvailableTargetStatus(..)
+                                              ,ProjectBaseContext(..)
+                                              ,ProjectBuildContext(..)
+                                              ,TargetSelector(..)
+                                              ,printPlan
+                                              ,pruneInstallPlanToTargets
+                                              ,resolveTargets
+                                              ,runProjectPreBuildPhase
+                                              ,selectComponentTargetBasic)
+import Distribution.Client.ProjectPlanning    (ElaboratedConfiguredPackage(..)
+                                              ,ElaboratedInstallPlan
+                                              ,ElaboratedSharedConfig(..)
+                                              ,TargetAction(..))
+import Distribution.Client.ProjectPlanning.Types
+                                              (elabDistDirParams)
+import Distribution.Client.Setup              (GlobalFlags(..)
+                                              ,ConfigFlags(..))
+import Distribution.Client.ScriptUtils        (AcceptNoTargets(..)
+                                              ,TargetContext(..)
+                                              ,updateContextAndWriteProjectFile
+                                              ,withContextAndSelectors)
+import Distribution.Client.TargetProblem      (TargetProblem(..))
+
+import Distribution.Types.PackageId (pkgName)
+import Distribution.Types.PackageName (unPackageName)
+import Distribution.Simple.Command
+         ( CommandUI(..) )
+import Distribution.Simple.Compiler
+         ( Compiler (..) )
+import Distribution.Simple.InstallDirs
+         ( toPathTemplate )
+import Distribution.Simple.Haddock (createHaddockIndex)
+import Distribution.Simple.Utils
+         ( die', createDirectoryIfMissingVerbose
+         , copyDirectoryRecursive, )
+import Distribution.Simple.Setup
+         ( HaddockFlags(..), defaultHaddockFlags
+         , HaddockProjectFlags(..)
+         , Flag(..), fromFlag, fromFlagOrDefault
+         , haddockProjectCommand
+         )
+import Distribution.Verbosity as Verbosity
+         ( normal )
+
+import System.FilePath          ( normalise, (</>), (<.>) )
+import System.Directory         ( doesDirectoryExist )
+
+haddockProjectAction :: HaddockProjectFlags -> [String] -> GlobalFlags -> IO ()
+haddockProjectAction flags _extraArgs globalFlags = do
+    -- create destination directory if it does not exist
+    let outputDir = normalise $ fromFlag (haddockProjectDir flags)
+    createDirectoryIfMissingVerbose verbosity True outputDir
+
+    -- build all packages with appropriate haddock flags
+    let haddockFlags = defaultHaddockFlags
+          { haddockHtml         = Flag True
+          , haddockBaseUrl      = Flag ".."
+          , haddockExecutables  = haddockProjectExecutables   flags
+          , haddockTestSuites   = haddockProjectTestSuites    flags
+          , haddockBenchmarks   = haddockProjectBenchmarks    flags
+          , haddockForeignLibs  = haddockProjectForeignLibs   flags
+          , haddockInternal     = haddockProjectInternal      flags
+          , haddockCss          = haddockProjectCss           flags
+          , haddockLinkedSource = haddockProjectLinkedSource  flags
+          , haddockQuickJump    = haddockProjectQuickJump     flags
+          , haddockHscolourCss  = haddockProjectHscolourCss   flags
+          , haddockContents     = Flag (toPathTemplate "../index.html")
+          , haddockIndex        = Flag (toPathTemplate "../doc-index.html")
+          , haddockKeepTempFiles= haddockProjectKeepTempFiles flags
+          , haddockVerbosity    = haddockProjectVerbosity     flags
+          }
+        nixFlags = (commandDefaultFlags CmdHaddock.haddockCommand)
+                   { NixStyleOptions.haddockFlags = haddockFlags
+                   , NixStyleOptions.configFlags  =
+                       (NixStyleOptions.configFlags (commandDefaultFlags CmdBuild.buildCommand))
+                       { configVerbosity = haddockProjectVerbosity flags }
+                   }
+    CmdHaddock.haddockAction
+      nixFlags
+      ["all"]
+      globalFlags
+
+    -- copy local packages to the destination directory
+    withContextAndSelectors RejectNoTargets Nothing nixFlags ["all"] globalFlags $ \targetCtx ctx targetSelectors -> do
+      baseCtx <- case targetCtx of
+        ProjectContext             -> return ctx
+        GlobalContext              -> return ctx
+        ScriptContext path exemeta -> updateContextAndWriteProjectFile ctx path exemeta
+      let distLayout  = distDirLayout baseCtx
+          cabalLayout = cabalDirLayout baseCtx
+      buildCtx <-
+        runProjectPreBuildPhase verbosity baseCtx $ \elaboratedPlan -> do
+              -- Interpret the targets on the command line as build targets
+              -- (as opposed to say repl or haddock targets).
+              targets <- either reportTargetProblems return
+                       $ resolveTargets
+                           selectPackageTargets
+                           selectComponentTargetBasic
+                           elaboratedPlan
+                           Nothing
+                           targetSelectors
+
+              let elaboratedPlan' = pruneInstallPlanToTargets
+                                      TargetActionBuild
+                                      targets
+                                      elaboratedPlan
+              return (elaboratedPlan', targets)
+
+      printPlan verbosity baseCtx buildCtx
+
+      let elaboratedPlan :: ElaboratedInstallPlan
+          elaboratedPlan = elaboratedPlanOriginal buildCtx
+
+          sharedConfig :: ElaboratedSharedConfig
+          sharedConfig = elaboratedShared buildCtx
+
+          pkgs :: [ElaboratedConfiguredPackage]
+          pkgs = matchingPackages elaboratedPlan
+      packageNames <- fmap (nub . catMaybes) $ for pkgs $ \package ->
+        if elabLocalToProject package
+        then do
+          let distDirParams = elabDistDirParams sharedConfig package
+              buildDir = distBuildDirectory distLayout distDirParams
+              packageName = unPackageName (pkgName $ elabPkgSourceId package)
+          let docDir = buildDir
+                   </> "doc" </> "html"
+                   </> packageName
+              destDir = outputDir </> packageName
+          a <- doesDirectoryExist docDir
+          case a of
+            True  -> copyDirectoryRecursive verbosity docDir destDir
+                  >> return (Just (packageName, destDir))
+            False -> return Nothing
+        else do
+          let packageName = unPackageName (pkgName $ elabPkgSourceId package)
+              packageDir = storePackageDirectory (cabalStoreDirLayout cabalLayout)
+                             (compilerId (pkgConfigCompiler sharedConfig))
+                             (elabUnitId package)
+              docDir = packageDir </> "share" </> "doc" </> "html"
+              destDir = outputDir </> packageName
+          a <- doesDirectoryExist docDir
+          case a of
+            True  -> copyDirectoryRecursive verbosity docDir destDir
+                  >> return (Just (packageName, destDir))
+            False -> return Nothing
+
+      -- run haddock to generate index, content, etc.
+      let flags' = flags
+            { haddockProjectDir        = Flag outputDir
+            , haddockProjectInterfaces = Flag
+                [ ( destDir </> packageName <.> "haddock"
+                  , Just packageName
+                  , Just packageName
+                  )
+                | (packageName, destDir) <- packageNames
+                ]
+            }
+      createHaddockIndex verbosity
+                         (pkgConfigCompilerProgs sharedConfig)
+                         (pkgConfigCompiler sharedConfig)
+                         (pkgConfigPlatform sharedConfig)
+                         flags'
+  where
+    verbosity = fromFlagOrDefault normal (haddockProjectVerbosity flags)
+
+    reportTargetProblems :: Show x => [x] -> IO a
+    reportTargetProblems =
+        die' verbosity . unlines . map show
+
+    -- TODO: this is just a sketch
+    selectPackageTargets :: TargetSelector
+                         -> [AvailableTarget k]
+                         -> Either (TargetProblem ()) [k]
+    selectPackageTargets _ ts = Right $
+      mapMaybe
+        (\t -> case availableTargetStatus t of
+            TargetBuildable k _ | availableTargetLocalToProject t
+                                -> Just k
+            _                   -> Nothing)
+        ts
+
+    matchingPackages :: ElaboratedInstallPlan
+                     -> [ElaboratedConfiguredPackage]
+    matchingPackages =
+        catMaybes
+      . fmap (foldPlanPackage (const Nothing) Just)
+      . InstallPlan.toList

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -487,6 +487,8 @@ instance Semigroup SavedConfig where
         haddockKeepTempFiles = combine haddockKeepTempFiles,
         haddockVerbosity     = combine haddockVerbosity,
         haddockCabalFilePath = combine haddockCabalFilePath,
+        haddockIndex         = combine haddockIndex,
+        haddockBaseUrl       = combine haddockBaseUrl,
         haddockArgs          = lastNonEmpty haddockArgs
         }
         where

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -489,6 +489,7 @@ instance Semigroup SavedConfig where
         haddockCabalFilePath = combine haddockCabalFilePath,
         haddockIndex         = combine haddockIndex,
         haddockBaseUrl       = combine haddockBaseUrl,
+        haddockLib           = combine haddockLib,
         haddockArgs          = lastNonEmpty haddockArgs
         }
         where

--- a/cabal-install/src/Distribution/Client/Haddock.hs
+++ b/cabal-install/src/Distribution/Client/Haddock.hs
@@ -41,7 +41,7 @@ regenerateHaddockIndex :: Verbosity
                        -> IO ()
 regenerateHaddockIndex verbosity pkgs progdb index = do
       (paths, warns) <- haddockPackagePaths pkgs' Nothing
-      let paths' = [ (interface, html) | (interface, Just html, _) <- paths]
+      let paths' = [ (interface, html) | (interface, Just html, _, _) <- paths]
       for_ warns (debug verbosity)
 
       (confHaddock, _, _) <-

--- a/cabal-install/src/Distribution/Client/PackageHash.hs
+++ b/cabal-install/src/Distribution/Client/PackageHash.hs
@@ -217,7 +217,8 @@ data PackageHashConfigInputs = PackageHashConfigInputs {
        pkgHashHaddockQuickJump    :: Bool,
        pkgHashHaddockContents     :: Maybe PathTemplate,
        pkgHashHaddockIndex        :: Maybe PathTemplate,
-       pkgHashHaddockBaseUrl      :: Maybe String
+       pkgHashHaddockBaseUrl      :: Maybe String,
+       pkgHashHaddockLib          :: Maybe String
 
 --     TODO: [required eventually] pkgHashToolsVersions     ?
 --     TODO: [required eventually] pkgHashToolsExtraOptions ?
@@ -313,6 +314,7 @@ renderPackageHashInputs PackageHashInputs{
       , opt   "haddock-contents-location" Nothing (maybe "" fromPathTemplate) pkgHashHaddockContents
       , opt   "haddock-index-location" Nothing (maybe "" fromPathTemplate) pkgHashHaddockIndex
       , opt   "haddock-base-url" Nothing (fromMaybe "") pkgHashHaddockBaseUrl
+      , opt   "haddock-lib" Nothing (fromMaybe "") pkgHashHaddockLib
 
       ] ++ Map.foldrWithKey (\prog args acc -> opt (prog ++ "-options") [] unwords args : acc) [] pkgHashProgramArgs
   where

--- a/cabal-install/src/Distribution/Client/PackageHash.hs
+++ b/cabal-install/src/Distribution/Client/PackageHash.hs
@@ -215,7 +215,9 @@ data PackageHashConfigInputs = PackageHashConfigInputs {
        pkgHashHaddockCss          :: Maybe FilePath,
        pkgHashHaddockLinkedSource :: Bool,
        pkgHashHaddockQuickJump    :: Bool,
-       pkgHashHaddockContents     :: Maybe PathTemplate
+       pkgHashHaddockContents     :: Maybe PathTemplate,
+       pkgHashHaddockIndex        :: Maybe PathTemplate,
+       pkgHashHaddockBaseUrl      :: Maybe String
 
 --     TODO: [required eventually] pkgHashToolsVersions     ?
 --     TODO: [required eventually] pkgHashToolsExtraOptions ?
@@ -309,6 +311,8 @@ renderPackageHashInputs PackageHashInputs{
       , opt   "haddock-hyperlink-source" False prettyShow pkgHashHaddockLinkedSource
       , opt   "haddock-quickjump" False prettyShow pkgHashHaddockQuickJump
       , opt   "haddock-contents-location" Nothing (maybe "" fromPathTemplate) pkgHashHaddockContents
+      , opt   "haddock-index-location" Nothing (maybe "" fromPathTemplate) pkgHashHaddockIndex
+      , opt   "haddock-base-url" Nothing (fromMaybe "") pkgHashHaddockBaseUrl
 
       ] ++ Map.foldrWithKey (\prog args acc -> opt (prog ++ "-options") [] unwords args : acc) [] pkgHashProgramArgs
   where

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -597,7 +597,8 @@ convertLegacyPerPackageFlags configFlags installFlags
       haddockHscolourCss        = packageConfigHaddockHscolourCss,
       haddockContents           = packageConfigHaddockContents,
       haddockIndex              = packageConfigHaddockIndex,
-      haddockBaseUrl            = packageConfigHaddockBaseUrl
+      haddockBaseUrl            = packageConfigHaddockBaseUrl,
+      haddockLib                = packageConfigHaddockLib
     } = haddockFlags
 
     TestFlags {
@@ -960,6 +961,7 @@ convertToLegacyPerPackageConfig PackageConfig {..} =
       haddockCabalFilePath = mempty,
       haddockIndex         = packageConfigHaddockIndex,
       haddockBaseUrl       = packageConfigHaddockBaseUrl,
+      haddockLib           = packageConfigHaddockLib,
       haddockArgs          = mempty
     }
 
@@ -1280,6 +1282,7 @@ legacyPackageConfigFieldDescrs =
       , "executables", "tests", "benchmarks", "all", "internal", "css"
       , "hyperlink-source", "quickjump", "hscolour-css"
       , "contents-location", "index-location", "keep-temp-files", "base-url"
+      , "lib"
       ]
   . commandOptionsToFields
   ) (haddockOptions ParseArgs)

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -595,7 +595,9 @@ convertLegacyPerPackageFlags configFlags installFlags
       haddockLinkedSource       = packageConfigHaddockLinkedSource,
       haddockQuickJump          = packageConfigHaddockQuickJump,
       haddockHscolourCss        = packageConfigHaddockHscolourCss,
-      haddockContents           = packageConfigHaddockContents
+      haddockContents           = packageConfigHaddockContents,
+      haddockIndex              = packageConfigHaddockIndex,
+      haddockBaseUrl            = packageConfigHaddockBaseUrl
     } = haddockFlags
 
     TestFlags {
@@ -956,6 +958,8 @@ convertToLegacyPerPackageConfig PackageConfig {..} =
       haddockKeepTempFiles = mempty,
       haddockVerbosity     = mempty,
       haddockCabalFilePath = mempty,
+      haddockIndex         = packageConfigHaddockIndex,
+      haddockBaseUrl       = packageConfigHaddockBaseUrl,
       haddockArgs          = mempty
     }
 
@@ -1275,7 +1279,7 @@ legacyPackageConfigFieldDescrs =
       , "foreign-libraries"
       , "executables", "tests", "benchmarks", "all", "internal", "css"
       , "hyperlink-source", "quickjump", "hscolour-css"
-      , "contents-location", "keep-temp-files"
+      , "contents-location", "index-location", "keep-temp-files", "base-url"
       ]
   . commandOptionsToFields
   ) (haddockOptions ParseArgs)

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -289,6 +289,7 @@ data PackageConfig
        packageConfigHaddockContents     :: Flag PathTemplate, --TODO: [required eventually] use this
        packageConfigHaddockIndex        :: Flag PathTemplate, --TODO: [required eventually] use this
        packageConfigHaddockBaseUrl      :: Flag String, --TODO: [required eventually] use this
+       packageConfigHaddockLib          :: Flag String, --TODO: [required eventually] use this
        packageConfigHaddockForHackage   :: Flag HaddockTarget,
        -- Test options
        packageConfigTestHumanLog        :: Flag PathTemplate,

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -287,6 +287,8 @@ data PackageConfig
        packageConfigHaddockQuickJump    :: Flag Bool, --TODO: [required eventually] use this
        packageConfigHaddockHscolourCss  :: Flag FilePath, --TODO: [required eventually] use this
        packageConfigHaddockContents     :: Flag PathTemplate, --TODO: [required eventually] use this
+       packageConfigHaddockIndex        :: Flag PathTemplate, --TODO: [required eventually] use this
+       packageConfigHaddockBaseUrl      :: Flag String, --TODO: [required eventually] use this
        packageConfigHaddockForHackage   :: Flag HaddockTarget,
        -- Test options
        packageConfigTestHumanLog        :: Flag PathTemplate,

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -3743,9 +3743,13 @@ setupHsHaddockFlags :: ElaboratedConfiguredPackage
                     -> Verbosity
                     -> FilePath
                     -> Cabal.HaddockFlags
-setupHsHaddockFlags (ElaboratedConfiguredPackage{..}) _ verbosity builddir =
+setupHsHaddockFlags (ElaboratedConfiguredPackage{..}) (ElaboratedSharedConfig{..}) verbosity builddir =
     Cabal.HaddockFlags {
-      haddockProgramPaths  = mempty, --unused, set at configure time
+      haddockProgramPaths  =
+        case lookupProgram haddockProgram pkgConfigCompilerProgs of
+          Nothing  -> mempty
+          Just prg -> [( programName haddockProgram
+                       , locationPath (programLocation prg) )],
       haddockProgramArgs   = mempty, --unused, set at configure time
       haddockHoogle        = toFlag elabHaddockHoogle,
       haddockHtml          = toFlag elabHaddockHtml,

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1956,6 +1956,7 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
         elabHaddockContents     = perPkgOptionMaybe pkgid packageConfigHaddockContents
         elabHaddockIndex        = perPkgOptionMaybe pkgid packageConfigHaddockIndex
         elabHaddockBaseUrl      = perPkgOptionMaybe pkgid packageConfigHaddockBaseUrl
+        elabHaddockLib          = perPkgOptionMaybe pkgid packageConfigHaddockLib
 
         elabTestMachineLog      = perPkgOptionMaybe pkgid packageConfigTestMachineLog
         elabTestHumanLog        = perPkgOptionMaybe pkgid packageConfigTestHumanLog
@@ -3766,6 +3767,7 @@ setupHsHaddockFlags (ElaboratedConfiguredPackage{..}) _ verbosity builddir =
       haddockCabalFilePath = mempty,
       haddockIndex         = maybe mempty toFlag elabHaddockIndex,
       haddockBaseUrl       = maybe mempty toFlag elabHaddockBaseUrl,
+      haddockLib           = maybe mempty toFlag elabHaddockLib,
       haddockArgs          = mempty
     }
 
@@ -3920,7 +3922,8 @@ packageHashConfigInputs shared@ElaboratedSharedConfig{..} pkg =
       pkgHashHaddockQuickJump    = elabHaddockQuickJump,
       pkgHashHaddockContents     = elabHaddockContents,
       pkgHashHaddockIndex        = elabHaddockIndex,
-      pkgHashHaddockBaseUrl      = elabHaddockBaseUrl
+      pkgHashHaddockBaseUrl      = elabHaddockBaseUrl,
+      pkgHashHaddockLib          = elabHaddockLib
     }
   where
     ElaboratedConfiguredPackage{..} = normaliseConfiguredPackage shared pkg

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1954,6 +1954,8 @@ elaborateInstallPlan verbosity platform compiler compilerprogdb pkgConfigDB
         elabHaddockQuickJump    = perPkgOptionFlag pkgid False packageConfigHaddockQuickJump
         elabHaddockHscolourCss  = perPkgOptionMaybe pkgid packageConfigHaddockHscolourCss
         elabHaddockContents     = perPkgOptionMaybe pkgid packageConfigHaddockContents
+        elabHaddockIndex        = perPkgOptionMaybe pkgid packageConfigHaddockIndex
+        elabHaddockBaseUrl      = perPkgOptionMaybe pkgid packageConfigHaddockBaseUrl
 
         elabTestMachineLog      = perPkgOptionMaybe pkgid packageConfigTestMachineLog
         elabTestHumanLog        = perPkgOptionMaybe pkgid packageConfigTestHumanLog
@@ -3762,6 +3764,8 @@ setupHsHaddockFlags (ElaboratedConfiguredPackage{..}) _ verbosity builddir =
       haddockKeepTempFiles = mempty, --TODO: from build settings
       haddockVerbosity     = toFlag verbosity,
       haddockCabalFilePath = mempty,
+      haddockIndex         = maybe mempty toFlag elabHaddockIndex,
+      haddockBaseUrl       = maybe mempty toFlag elabHaddockBaseUrl,
       haddockArgs          = mempty
     }
 
@@ -3914,7 +3918,9 @@ packageHashConfigInputs shared@ElaboratedSharedConfig{..} pkg =
       pkgHashHaddockCss          = elabHaddockCss,
       pkgHashHaddockLinkedSource = elabHaddockLinkedSource,
       pkgHashHaddockQuickJump    = elabHaddockQuickJump,
-      pkgHashHaddockContents     = elabHaddockContents
+      pkgHashHaddockContents     = elabHaddockContents,
+      pkgHashHaddockIndex        = elabHaddockIndex,
+      pkgHashHaddockBaseUrl      = elabHaddockBaseUrl
     }
   where
     ElaboratedConfiguredPackage{..} = normaliseConfiguredPackage shared pkg

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -292,6 +292,8 @@ data ElaboratedConfiguredPackage
        elabHaddockQuickJump      :: Bool,
        elabHaddockHscolourCss    :: Maybe FilePath,
        elabHaddockContents       :: Maybe PathTemplate,
+       elabHaddockIndex          :: Maybe PathTemplate,
+       elabHaddockBaseUrl        :: Maybe String,
 
        elabTestMachineLog        :: Maybe PathTemplate,
        elabTestHumanLog          :: Maybe PathTemplate,

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -294,6 +294,7 @@ data ElaboratedConfiguredPackage
        elabHaddockContents       :: Maybe PathTemplate,
        elabHaddockIndex          :: Maybe PathTemplate,
        elabHaddockBaseUrl        :: Maybe String,
+       elabHaddockLib            :: Maybe String,
 
        elabTestMachineLog        :: Maybe PathTemplate,
        elabTestHumanLog          :: Maybe PathTemplate,

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -1749,7 +1749,7 @@ haddockOptions showOrParseArgs
     , name `elem` ["hoogle", "html", "html-location"
                   ,"executables", "tests", "benchmarks", "all", "internal", "css"
                   ,"hyperlink-source", "quickjump", "hscolour-css"
-                  ,"contents-location", "for-hackage"]
+                  ,"contents-location", "use-index", "for-hackage", "base-url"]
     ]
 
 testOptions :: ShowOrParseArgs -> [OptionField TestFlags]

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -1749,7 +1749,7 @@ haddockOptions showOrParseArgs
     , name `elem` ["hoogle", "html", "html-location"
                   ,"executables", "tests", "benchmarks", "all", "internal", "css"
                   ,"hyperlink-source", "quickjump", "hscolour-css"
-                  ,"contents-location", "use-index", "for-hackage", "base-url"]
+                  ,"contents-location", "use-index", "for-hackage", "base-url", "lib"]
     ]
 
 testOptions :: ShowOrParseArgs -> [OptionField TestFlags]

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -571,6 +571,8 @@ instance Arbitrary PackageConfig where
         <*> arbitraryFlag arbitraryShortToken
         <*> arbitrary
         <*> arbitrary
+        <*> arbitraryFlag arbitraryShortToken
+        <*> arbitrary
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
@@ -634,6 +636,8 @@ instance Arbitrary PackageConfig where
                          , packageConfigHaddockHscolourCss = x39
                          , packageConfigHaddockContents = x40
                          , packageConfigHaddockForHackage = x41
+                         , packageConfigHaddockIndex = x54
+                         , packageConfigHaddockBaseUrl = x55
                          , packageConfigTestHumanLog = x44
                          , packageConfigTestMachineLog = x45
                          , packageConfigTestShowDetails = x46
@@ -691,6 +695,8 @@ instance Arbitrary PackageConfig where
                       , packageConfigHaddockHscolourCss = fmap getNonEmpty x39'
                       , packageConfigHaddockContents = x40'
                       , packageConfigHaddockForHackage = x41'
+                      , packageConfigHaddockIndex = x54'
+                      , packageConfigHaddockBaseUrl = x55'
                       , packageConfigTestHumanLog = x44'
                       , packageConfigTestMachineLog = x45'
                       , packageConfigTestShowDetails = x46'
@@ -708,7 +714,7 @@ instance Arbitrary PackageConfig where
           (x30', x31', x32', (x33', x33_1'), x34'),
           (x35', x36', x37', x38', x43', x39'),
           (x40', x41'),
-          (x44', x45', x46', x47', x48', x49', x51', x52')))
+          (x44', x45', x46', x47', x48', x49', x51', x52', x54', x55')))
           <- shrink
              (((preShrink_Paths x00, preShrink_Args x01, x02, x03, x04),
                 (x05, x42, x06, x50, x07, x08, x09),
@@ -722,7 +728,7 @@ instance Arbitrary PackageConfig where
                  (x30, x31, x32, (x33, x33_1), x34),
                  (x35, x36, fmap NonEmpty x37, x38, x43, fmap NonEmpty x39),
                  (x40, x41),
-                 (x44, x45, x46, x47, x48, x49, x51, x52)))
+                 (x44, x45, x46, x47, x48, x49, x51, x52, x54, x55)))
       ]
       where
         preShrink_Paths  = Map.map NonEmpty

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -572,6 +572,7 @@ instance Arbitrary PackageConfig where
         <*> arbitrary
         <*> arbitrary
         <*> arbitraryFlag arbitraryShortToken
+        <*> arbitraryFlag arbitraryShortToken
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
@@ -638,6 +639,7 @@ instance Arbitrary PackageConfig where
                          , packageConfigHaddockForHackage = x41
                          , packageConfigHaddockIndex = x54
                          , packageConfigHaddockBaseUrl = x55
+                         , packageConfigHaddockLib = x56
                          , packageConfigTestHumanLog = x44
                          , packageConfigTestMachineLog = x45
                          , packageConfigTestShowDetails = x46
@@ -697,6 +699,7 @@ instance Arbitrary PackageConfig where
                       , packageConfigHaddockForHackage = x41'
                       , packageConfigHaddockIndex = x54'
                       , packageConfigHaddockBaseUrl = x55'
+                      , packageConfigHaddockLib = x56'
                       , packageConfigTestHumanLog = x44'
                       , packageConfigTestMachineLog = x45'
                       , packageConfigTestShowDetails = x46'
@@ -714,7 +717,8 @@ instance Arbitrary PackageConfig where
           (x30', x31', x32', (x33', x33_1'), x34'),
           (x35', x36', x37', x38', x43', x39'),
           (x40', x41'),
-          (x44', x45', x46', x47', x48', x49', x51', x52', x54', x55')))
+          (x44', x45', x46', x47', x48', x49', x51', x52', x54', x55'),
+          x56'))
           <- shrink
              (((preShrink_Paths x00, preShrink_Args x01, x02, x03, x04),
                 (x05, x42, x06, x50, x07, x08, x09),
@@ -728,7 +732,7 @@ instance Arbitrary PackageConfig where
                  (x30, x31, x32, (x33, x33_1), x34),
                  (x35, x36, fmap NonEmpty x37, x38, x43, fmap NonEmpty x39),
                  (x40, x41),
-                 (x44, x45, x46, x47, x48, x49, x51, x52, x54, x55)))
+                 (x44, x45, x46, x47, x48, x49, x51, x52, x54, x55), x56))
       ]
       where
         preShrink_Paths  = Map.map NonEmpty

--- a/changelog.d/pr-8162
+++ b/changelog.d/pr-8162
@@ -1,0 +1,17 @@
+synopsis: Added haddocks command
+packages: cabal-install
+prs: #8162
+issues: #7669
+description: {
+
+The `haddock-package` command can be used to build documentation of multiple
+packages.  By passing `--local` option the directory will be self contained,
+by passing `--hackage` links to dependencies will link to `hackage`.  Both
+`--local` and `--hackage` options imply `--quickfix`, `--gen-index`,
+`--gen-contents`, and `--hyperlinked-source`.
+
+Building self contained directory is the default, unless `--hackage` or
+`--html-location`.
+
+The PR #8162 also fixes the `--with-haddock` option.
+}

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -33,6 +33,7 @@ legacy sections. We talk in detail about some global and package commands.
 
     freeze            Freeze dependencies.
     haddock           Build Haddock documentation.
+    haddock-project   Build Haddock documentation of local packages.
     exec              Give a command access to the store.
     list-bin          List path to a single executable.
 
@@ -580,6 +581,31 @@ the specified packages within the project.
 If a target is not a library :cfg-field:`haddock-benchmarks`,
 :cfg-field:`haddock-executables`, :cfg-field:`haddock-internal`,
 :cfg-field:`haddock-tests` will be implied as necessary.
+
+cabal haddock-project
+---------------------
+
+``cabal haddock-project [FLAGS]`` builds Haddock documentation for all local
+packages specified in the project.
+
+By default the documentation will be put in ``./haddocks`` folder, this can be
+modified with the ``--output`` flag.
+
+This command supports two primary modes: building a self contained directory
+(by specifying ``--local`` flag) or documentation that links to hackage (with
+``--hackage`` flag).  Both options imply: ``--quickjump``, ``--gen-index``,
+``--gen-contents`` and ``--hyperlinked-source``.
+
+If neither ``--local`` nor ``--hackage`` option is specified a self contained
+directory will only be build if ``--html-location`` is not specified.
+
+In both cases the html index as well as quickjump index will include all terms
+and types defined in any of the local packages, but not ones that are included
+in any of the dependencies.  But note that if you navigate to a dependency,
+you will have access to its quickjump index.
+
+The generated landing page will contain one tree of all modules per local
+package.
 
 cabal exec
 ----------


### PR DESCRIPTION
Fixes #7669, also fixes `--with-haddock` support which is useful when testing a newer version of `haddock` than the one distributed with `ghc`.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
