### PR TITLE
Add undocumented GHC extensions to KnownExtensions

### DIFF
--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -864,6 +864,15 @@ data KnownExtension =
   -- | Enable data types for which an unlifted or levity-polymorphic result kind is inferred.
   | UnliftedDatatypes
 
+  -- | Undocumented parsing-related extensions introduced in GHC 7.0.
+  | AlternativeLayoutRule
+
+  -- | Undocumented parsing-related extensions introduced in GHC 7.0.
+  | AlternativeLayoutRuleTransitional
+
+  -- | Undocumented parsing-related extensions introduced in GHC 7.2.
+  | RelaxedLayout
+
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable, Data)
 
 instance Binary KnownExtension


### PR DESCRIPTION
The extensions — all parsing-related — are undocumented and not used in
the wild, but not yet deprecated:
- AlternativeLayoutRule
- AlternativeLayoutRuleTransitional
- RelaxedLayout


---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
