### PR TITLE
Permit pre-releases in gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,8 @@ build-aarch64-linux-deb10:
     TARBALL_ARCHIVE_SUFFIX: aarch64-linux-deb10
     TARBALL_EXT: tar.xz
     ADD_CABAL_ARGS: ""
+    # this permits building pre-releases that are not on Hackage
+    CABAL_INSTALL_VERSION: 3.4.0.0
 
 build-armv7-linux-deb10:
   extends: .build
@@ -47,7 +49,7 @@ build-armv7-linux-deb10:
     TARBALL_ARCHIVE_SUFFIX: armv7-linux-deb1
     TARBALL_EXT: tar.xz
     ADD_CABAL_ARGS: ""
-    # temp, because 3.6.2.0 is broken
+    # this permits building pre-releases that are not on Hackage
     CABAL_INSTALL_VERSION: 3.4.0.0
   retry: 2
 
@@ -60,6 +62,8 @@ build-x86_64-linux:
     TARBALL_ARCHIVE_SUFFIX: x86_64-linux-deb10
     TARBALL_EXT: tar.xz
     ADD_CABAL_ARGS: "--enable-split-sections"
+    # this permits building pre-releases that are not on Hackage
+    CABAL_INSTALL_VERSION: 3.4.0.0
 
 build-x86_64-linux-alpine:
   extends: .build
@@ -73,6 +77,8 @@ build-x86_64-linux-alpine:
     TARBALL_ARCHIVE_SUFFIX: x86_64-linux-alpine
     TARBALL_EXT: tar.xz
     ADD_CABAL_ARGS: "--enable-split-sections --enable-executable-static"
+    # this permits building pre-releases that are not on Hackage
+    CABAL_INSTALL_VERSION: 3.4.0.0
 
 build-i386-linux-alpine:
   extends: .build
@@ -88,7 +94,7 @@ build-i386-linux-alpine:
     TARBALL_ARCHIVE_SUFFIX: i386-linux-alpine
     TARBALL_EXT: tar.xz
     ADD_CABAL_ARGS: "--enable-split-sections --enable-executable-static"
-    # temp, because 3.6.2.0 is broken
+    # this permits building pre-releases that are not on Hackage
     CABAL_INSTALL_VERSION: 3.4.0.0
 
 build-x86_64-freebsd12:
@@ -99,6 +105,8 @@ build-x86_64-freebsd12:
     TARBALL_ARCHIVE_SUFFIX: x86_64-freebsd12
     TARBALL_EXT: tar.xz
     ADD_CABAL_ARGS: "--enable-split-sections"
+    # this permits building pre-releases that are not on Hackage
+    CABAL_INSTALL_VERSION: 3.4.0.0
 
 build-x86_64-darwin:
   extends: .build
@@ -108,6 +116,8 @@ build-x86_64-darwin:
     TARBALL_ARCHIVE_SUFFIX: x86_64-darwin
     TARBALL_EXT: tar.xz
     ADD_CABAL_ARGS: ""
+    # this permits building pre-releases that are not on Hackage
+    CABAL_INSTALL_VERSION: 3.4.0.0
 
 build-aarch64-darwin:
   stage: build
@@ -133,6 +143,8 @@ build-aarch64-darwin:
     TARBALL_ARCHIVE_SUFFIX: aarch64-darwin
     TARBALL_EXT: tar.xz
     ADD_CABAL_ARGS: ""
+    # this permits building pre-releases that are not on Hackage
+    CABAL_INSTALL_VERSION: 3.4.0.0
   artifacts:
     expire_in: 2 week
     paths:
@@ -149,4 +161,6 @@ build-x86_64-windows:
     TARBALL_ARCHIVE_SUFFIX: x86_64-windows
     TARBALL_EXT: zip
     ADD_CABAL_ARGS: ""
+    # this permits building pre-releases that are not on Hackage
+    CABAL_INSTALL_VERSION: 3.4.0.0
   retry: 2


### PR DESCRIPTION
This is a blind attempt to fix gitlab failures at https://gitlab.haskell.org/haskell/cabal/-/pipelines/52777 probably caused by using a version of cabal that is not on Hackage (and not otherwise known to ghcup), because that version is a pre-release.

TODO in next PRs: I could add this line to .build, but perhaps one of the cases is going to need a special version of cabal in the future and I don't know if overwriting default variables works.

Edit: I've tagged this commit with gitlab-ci-try1-3.8.0.20220526, but gitlab doesn't seem to bite. Either there is a lag or it's manually started or only the main branches are permitted, I don't know.

Edit2: it worked now, @hasufell says it's an automatic mirror with pull frequency perhaps 30min. All passed, except FreeBSD that failed with `mkdir: /var/lib: Permission denied` and that @hasufell  says is busted: https://gitlab.haskell.org/haskell/cabal/-/pipelines/52803

Edit3: what we are now missing for a successfully pre-release release is a way to copy file into the 
 https://downloads.haskell.org/~cabal/ directory. This is not documented in the new docs at https://github.com/haskell/cabal/wiki/Making-a-release and the old ones don't work any more.

Edit4: learned and documented now.