### PR TITLE
bootstrap: generate missing Setup.hs in dependencies

### DIFF
--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -184,6 +184,12 @@ def install_dep(dep: BootstrapDep, ghc: Compiler) -> None:
         if dep.revision is not None:
             shutil.copyfile(cabal_file, sdist_dir / f'{dep.package}.cabal')
 
+        # We rely on the presence of Setup.hs
+        if len(list(sdist_dir.glob('Setup.*hs'))) == 0:
+            with open(sdist_dir / 'Setup.hs', 'w') as f:
+                f.write('import Distribution.Simple\n')
+                f.write('main = defaultMain\n')
+
     elif dep.source == PackageSource.LOCAL:
         if dep.package == 'Cabal':
             sdist_dir = Path('Cabal').resolve()


### PR DESCRIPTION
This allows bootstrapping against zlib 0.6.3.0, which ships
without Setup.hs.

I hope this should generally be a more robust approach than
asking maintainers of dependencies to keep Setup.hs.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Testing: I ran the bootstrap successfully locally, with the zlib version updated to 0.6.3.0.