### PR TITLE
docs: allow TOC navigation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -57,9 +57,13 @@ exclude_patterns = ['.build', "*.gen.rst"]
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
+html_theme = 'sphinx_rtd_theme'
+# only import the theme if we're building docs locally
+if on_rtd:
+    html_style = None
+    using_rtd_theme = True
+else:
     import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
@@ -80,6 +84,9 @@ html_context = {
     "github_version": "master/",
     "conf_py_path": "doc/",
     "source_suffix": '.rst',
+}
+html_theme_options = {
+    'collapse_navigation': False,
 }
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,12 +28,12 @@ master_doc = 'index'
 
 # extlinks -- see http://www.sphinx-doc.org/en/stable/ext/extlinks.html
 extlinks = {
-    'issue': ('https://github.com/haskell/cabal/issues/%s', '#'),
+    'issue': ('https://github.com/haskell/cabal/issues/%s', 'issue #%s'),
 
-    'ghc-wiki': ('https://gitlab.haskell.org/ghc/ghc/-/wikis/%s', ''),
-    'ghc-ticket': ('https://gitlab.haskell.org/ghc/ghc/-/issues/%s', 'GHC #'),
+    'ghc-wiki': ('https://gitlab.haskell.org/ghc/ghc/-/wikis/%s', '%s'),
+    'ghc-ticket': ('https://gitlab.haskell.org/ghc/ghc/-/issues/%s', 'GHC issue #%s'),
 
-    'hackage-pkg': ('http://hackage.haskell.org/package/%s', ''),
+    'hackage-pkg': ('http://hackage.haskell.org/package/%s', '%s'),
 }
 
 # General information about the project.

--- a/doc/requirements.in
+++ b/doc/requirements.in
@@ -1,5 +1,5 @@
-sphinx >= 3.1
-sphinx_rtd_theme
+sphinx >= 5
+sphinx_rtd_theme >= 1
 sphinx-jsonschema
 # Pygments>=2.7.4 suggested by CVE-2021-20270 CVE-2021-27291
 Pygments >= 2.7.4

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -21,6 +21,8 @@ idna==2.10
     # via requests
 imagesize==1.2.0
     # via sphinx
+importlib-metadata==4.11.4
+    # via sphinx
 jinja2==2.11.3
     # via sphinx
 jsonpointer==2.1
@@ -45,7 +47,7 @@ requests==2.26.0
     #   sphinx-jsonschema
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==4.2.0
+sphinx==5.0.1
     # via
     #   -r requirements.in
     #   sphinx-rtd-theme
@@ -67,6 +69,5 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 urllib3==1.26.7
     # via requests
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+zipp==3.8.0
+    # via importlib-metadata


### PR DESCRIPTION
It annoys me beyond measure that I can't freely browse TOC (in the left sidebar) without jumping between pages. It turned out there's a little switch that allows you to (**almost**) freely unfold menu items, and I turn it on in this PR. 

Why "almost" is because it will still only show one section unfolded at a time. There's a long-standing PR to fix that: https://github.com/readthedocs/sphinx_rtd_theme/pull/692 I think that it's still way better than the current state.

Another related but different idea is to have the TOC fully unfolded always. I'm less sure that I'd want that (perhaps I'd), but `sphinx_rtd_theme` currently doesn't allow it out of the box: https://github.com/readthedocs/sphinx_rtd_theme/issues/455

Here's what TOC will look like, and you can unfold entries by clicking in [+] without leaving the current page
![2022-06-07_20-06-1654647339](https://user-images.githubusercontent.com/6832600/172505052-0430c71a-6ecf-4ad1-87c4-b8cea9914597.png)

