### PR TITLE
Add command line options tests for 9.2

### DIFF
--- a/Cabal-tests/tests/UnitTests/Distribution/Simple/Program/GHC.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Simple/Program/GHC.hs
@@ -170,3 +170,34 @@ options_9_0_affects :: [String]
 options_9_0_affects =
     [ "-fcmm-static-pred"
     ]
+
+-------------------------------------------------------------------------------
+-- GHC-9.2
+-------------------------------------------------------------------------------
+
+options_9_2_all :: [String]
+options_9_2_all =
+    [ "-dynohi"
+    , "-ddump-c-backend"
+    , "-ddump-stg-from-core"
+    , "-ddump-stg"
+    , "-ddump-faststrings"
+    , "--run"
+    , "-ffamily-application-cache"
+    , "-fno-family-application-cache"
+    ] ++ options_9_2_affects
+
+options_9_2_affects :: [String]
+options_9_2_affects =
+    [ "-fprof-callers"
+    , "-funfolding-case-threshold"
+    , "-funfolding-case-scaling"
+    , "-fdistinct-constructor-tables"
+    , "-finfo-table-map"
+    , "-fexpose-internal-symbols"
+    , "-finline-generics"
+    , "-finline-generics-aggressively"
+    , "-fno-expose-internal-symbols"
+    , "-fno-inline-generics"
+    , "-fno-inline-generics-aggressively"
+    ]


### PR DESCRIPTION
Update command line tests for 9.2. Let's wait for CI first, but is there a way to know which `flags which may affect artifacts`?

---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
