### PR TITLE
When generating `Paths` modules, define functions when used

### DIFF
--- a/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
@@ -104,6 +104,29 @@ render z_root = execWriter $ do
   tell "\n"
   tell "getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"
   tell "\n"
+  let
+    z_var0_function_defs = do
+      tell "minusFileName :: FilePath -> String -> FilePath\n"
+      tell "minusFileName dir \"\"     = dir\n"
+      tell "minusFileName dir \".\"    = dir\n"
+      tell "minusFileName dir suffix =\n"
+      tell "  minusFileName (fst (splitFileName dir)) (fst (splitFileName suffix))\n"
+      tell "\n"
+      tell "splitFileName :: FilePath -> (String, String)\n"
+      tell "splitFileName p = (reverse (path2++drive), reverse fname)\n"
+      tell "  where\n"
+      tell "    (path,drive) = case p of\n"
+      tell "      (c:':':p') -> (reverse p',[':',c])\n"
+      tell "      _          -> (reverse p ,\"\")\n"
+      tell "    (fname,path1) = break isPathSeparator path\n"
+      tell "    path2 = case path1 of\n"
+      tell "      []                           -> \".\"\n"
+      tell "      [_]                          -> path1   -- don't remove the trailing slash if\n"
+      tell "                                              -- there is only one character\n"
+      tell "      (c:path') | isPathSeparator c -> path'\n"
+      tell "      _                             -> path1\n"
+      return ()
+  tell "\n"
   tell "\n"
   if (zRelocatable z_root)
   then do
@@ -146,6 +169,8 @@ render z_root = execWriter $ do
     tell "_sysconfdir\") (\\_ -> getPrefixDirReloc $ "
     tell (zSysconfdir z_root)
     tell ")\n"
+    tell "\n"
+    z_var0_function_defs
     tell "\n"
     return ()
   else do
@@ -237,6 +262,8 @@ render z_root = execWriter $ do
         tell ") `joinFileName` dirRel)\n"
         tell "            | otherwise  -> try_size (size * 2)\n"
         tell "\n"
+        z_var0_function_defs
+        tell "\n"
         if (zIsI386 z_root)
         then do
           tell "foreign import stdcall unsafe \"windows.h GetModuleFileNameW\"\n"
@@ -265,31 +292,6 @@ render z_root = execWriter $ do
       return ()
     return ()
   tell "\n"
-  tell "\n"
-  if (zNot z_root (zAbsolute z_root))
-  then do
-    tell "minusFileName :: FilePath -> String -> FilePath\n"
-    tell "minusFileName dir \"\"     = dir\n"
-    tell "minusFileName dir \".\"    = dir\n"
-    tell "minusFileName dir suffix =\n"
-    tell "  minusFileName (fst (splitFileName dir)) (fst (splitFileName suffix))\n"
-    tell "\n"
-    tell "splitFileName :: FilePath -> (String, String)\n"
-    tell "splitFileName p = (reverse (path2++drive), reverse fname)\n"
-    tell "  where\n"
-    tell "    (path,drive) = case p of\n"
-    tell "       (c:':':p') -> (reverse p',[':',c])\n"
-    tell "       _          -> (reverse p ,\"\")\n"
-    tell "    (fname,path1) = break isPathSeparator path\n"
-    tell "    path2 = case path1 of\n"
-    tell "      []                           -> \".\"\n"
-    tell "      [_]                          -> path1   -- don't remove the trailing slash if\n"
-    tell "                                              -- there is only one character\n"
-    tell "      (c:path') | isPathSeparator c -> path'\n"
-    tell "      _                             -> path1\n"
-    return ()
-  else do
-    return ()
   tell "\n"
   tell "joinFileName :: String -> String -> FilePath\n"
   tell "joinFileName \"\"  fname = fname\n"

--- a/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/Main.hs
+++ b/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/Main.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import Paths_PathsModule (getBinDir)
+
+main :: IO ()
+main = do
+    _ <- getBinDir
+    return ()

--- a/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/my.cabal
+++ b/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/my.cabal
@@ -1,0 +1,16 @@
+name: PathsModule
+version: 0.1
+license: BSD3
+author: Johan Tibell
+stability: stable
+category: PackageTests
+build-type: Simple
+Cabal-version: >= 1.2
+
+description:
+    Check that the generated paths module compiles.
+
+Executable TestPathsModule
+    main-is: Main.hs
+    other-modules: Paths_PathsModule
+    build-depends: base

--- a/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/setup.cabal.out
@@ -1,0 +1,5 @@
+# Setup configure
+Configuring PathsModule-0.1...
+# Setup build
+Preprocessing executable 'TestPathsModule' for PathsModule-0.1..
+Building executable 'TestPathsModule' for PathsModule-0.1..

--- a/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/setup.out
+++ b/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/setup.out
@@ -1,0 +1,5 @@
+# Setup configure
+Configuring PathsModule-0.1...
+# Setup build
+Preprocessing executable 'TestPathsModule' for PathsModule-0.1..
+Building executable 'TestPathsModule' for PathsModule-0.1..

--- a/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/setup.test.hs
+++ b/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/setup.test.hs
@@ -1,0 +1,7 @@
+import Test.Cabal.Prelude
+-- Test that Paths module is generated and usable when relocatable is turned on.
+
+main = setupAndCabalTest $ do
+  skipIfWindows
+  skipUnlessGhcVersion ">= 8.0"
+  setup_build ["--enable-relocatable"]

--- a/changelog.d/pr-8220
+++ b/changelog.d/pr-8220
@@ -1,0 +1,12 @@
+synopsis: Fix generation of Path_ modules with relocatable
+packages: Cabal
+prs: #8220
+issues: #8219
+description: {
+
+The generation of the functions `minusFileName` and `splitFileName`
+are now in the same conditional block as their call,
+preventing generation of inconsistent Paths_ files
+where those functions are used but not defined.
+
+}


### PR DESCRIPTION
This addresses #8219 

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!