### PR TITLE
Apple Silicon Foreign Library Support (#8227)

### DIFF
--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -2065,12 +2065,12 @@ checkForeignLibSupported comp platform flib = go (compilerFlavor comp)
       ]
 
     goGhcPlatform :: Platform -> Maybe String
-    goGhcPlatform (Platform X86_64 OSX    ) = goGhcOsx     (foreignLibType flib)
+    goGhcPlatform (Platform _      OSX    ) = goGhcOsx     (foreignLibType flib)
     goGhcPlatform (Platform _      Linux  ) = goGhcLinux   (foreignLibType flib)
     goGhcPlatform (Platform I386   Windows) = goGhcWindows (foreignLibType flib)
     goGhcPlatform (Platform X86_64 Windows) = goGhcWindows (foreignLibType flib)
     goGhcPlatform _ = unsupported [
-        "Building foreign libraries is currently only supported on OSX, "
+        "Building foreign libraries is currently only supported on Mac OS, "
       , "Linux and Windows"
       ]
 

--- a/changelog.d/issue-8227
+++ b/changelog.d/issue-8227
@@ -1,0 +1,11 @@
+synopsis: Enabled foreign library building on apple silicon
+packages: cabal-install
+issues: #8227, #7837
+significance: significant
+
+description: {
+
+- Enabled foreign library building on apple silicon
+- Updated error message for foreign library builds on unsupported platforms
+
+}


### PR DESCRIPTION
Fix for issue #8227
- Allowed building Foreign Libraries for all architecture on apple
  silicon
- Updated error message to name Mac OS instead of OSX as supported
  platform


---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.

I successfully compiled a dylib, although I confess that I have't tested said dylib.
