### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -14,6 +14,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   bootstrap:
     strategy:

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -19,6 +19,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -14,6 +14,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   meta:
     name: Meta checks

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,6 +29,9 @@ env:
   GHC_FOR_COMPLETE_HACKAGE_TESTS: '8.10.7'
   COMMON_FLAGS: '-j 2 -v'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate ${{ matrix.os }} ghc-${{ matrix.ghc }}
@@ -178,6 +181,8 @@ jobs:
         run: sh validate.sh $FLAGS -s cli-suite
 
   validate-old-ghcs:
+    permissions:
+      contents: none
     name: Validate old ghcs ${{ matrix.extra-ghc }}
     runs-on: ubuntu-18.04
     needs: validate
@@ -291,6 +296,8 @@ jobs:
   # This way we can use it exclusively in branch protection rules
   # and abstract away the concrete jobs of the workflow, including their names
   validate-post-job:
+    permissions:
+      contents: none
     if: always()
     name: Validate post job
     runs-on: ubuntu-18.04


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
