### PR TITLE
Print a warning when assertions are enabled

### DIFF
--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -166,8 +166,7 @@ import System.IO                ( BufferMode(LineBuffering), hSetBuffering
 import System.Directory         ( doesFileExist, getCurrentDirectory
                                 , withCurrentDirectory)
 import Data.Monoid              (Any(..))
-import Control.Exception        (AssertionFailed, assert, catch, try)
-import Control.Monad            (mapM_)
+import Control.Exception        (AssertionFailed, assert, try)
 
 
 -- | Entry point

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP, ScopedTypeVariables #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -166,7 +166,8 @@ import System.IO                ( BufferMode(LineBuffering), hSetBuffering
 import System.Directory         ( doesFileExist, getCurrentDirectory
                                 , withCurrentDirectory)
 import Data.Monoid              (Any(..))
-import Control.Exception        (try)
+import Control.Exception        (AssertionFailed, assert, catch, try)
+import Control.Monad            (mapM_)
 
 
 -- | Entry point
@@ -177,6 +178,10 @@ main = do
   -- Enable line buffering so that we can get fast feedback even when piped.
   -- This is especially important for CI and build systems.
   hSetBuffering stdout LineBuffering
+
+  -- Check whether assertions are enabled and print a warning in that case.
+  warnIfAssertionsAreEnabled
+
   -- If the locale encoding for CLI doesn't support all Unicode characters,
   -- printing to it may fail unless we relax the handling of encoding errors
   -- when writing to stderr and stdout.
@@ -184,6 +189,14 @@ main = do
   relaxEncodingErrors stderr
   (args0, args1) <- break (== "--") <$> getArgs
   mainWorker =<< (++ args1) <$> expandResponse args0
+
+warnIfAssertionsAreEnabled :: IO ()
+warnIfAssertionsAreEnabled =
+  assert False (return ()) `catch`
+  (\(_e :: AssertionFailed) -> putStrLn assertionsEnabledMsg)
+  where
+    assertionsEnabledMsg =
+      "Warning: this is a debug build with assertions enabled."
 
 mainWorker :: [String] -> IO ()
 mainWorker args = do

--- a/changelog.d/pr-8240
+++ b/changelog.d/pr-8240
@@ -1,0 +1,10 @@
+synopsis: Print a warning when assertions are enabled
+packages: cabal-install
+prs: #8240
+issues: #4377
+
+description: {
+
+- Now cabal-install executable will print a warning if assertions are enabled
+
+}


### PR DESCRIPTION
* Fixes #4377.
* Superseeds #4552

I want to remember sometimes cabal builds with assetions enabled were leaked to final users.
Anyways i think warn about it would be useful for the reasons noted in #4377

Not sure how could this be tested without build a cabal version with assertions enabled and not sure it it worths it

---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).

Please also shortly describe how you tested your change. Bonus points for added tests!
