### PR TITLE
Try building with GHC 9.4 / HEAD in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        ghc: ["9.2.1", "9.0.2", "8.10.7", "8.8.4", "8.6.5", "8.4.4", "8.0.2"]
+        ghc: ["9.2.3", "9.0.2", "8.10.7", "8.8.4", "8.6.5", "8.4.4", "8.0.2"]
         exclude:
           # lot of segfaults caused by ghc bugs
           - os: "windows-latest"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,8 +59,9 @@ jobs:
           - os: "windows-latest"
             ghc: "8.0.2"
             cli: "false"
-          - os: "ubuntu-latest"
-            ghc: "head"
+          # haskell/actions/setup fails: https://github.com/haskell/actions/issues/93
+          #- os: "ubuntu-latest"
+          #  ghc: "head"
           - os: "ubuntu-latest"
             ghc: "9.4.0-alpha2"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,6 +59,10 @@ jobs:
           - os: "windows-latest"
             ghc: "8.0.2"
             cli: "false"
+          - os: "ubuntu-latest"
+            ghc: "head"
+          - os: "ubuntu-latest"
+            ghc: "9.4.0-alpha2"
 
     steps:
 


### PR DESCRIPTION
Bit unclear to me what `haskell/actions/setup` supports precisely, so let's just try it.

(I *think* it has special support for `HEAD`, and would use `ghcup` else which should fail for `9.4.1-alpha2`...)

Compare #8230.