### PR TITLE
ci: try validate job with plain ghcup

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -159,9 +159,8 @@ jobs:
           path: ${{ env.CABAL_EXEC_TAR }}
 
       - name: Validate lib-tests
-        env:
-          # `rawSystemStdInOut reports text decoding errors`
-          # test does not find ghc without the full path in windows
+        # `rawSystemStdInOut reports text decoding errors`
+        # test does not find ghc without the full path in windows
         run: |
           export GHCPATH=$(ghcup whereis ghc)
           sh validate.sh $FLAGS -s lib-tests

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           ghcup install ghc ${{ matrix.ghc }}
           ghcup set ghc ${{ matrix.ghc }}
+          cabal update
 
       #  See the following link for a breakdown of the following step
       #  https://github.com/haskell/actions/issues/7#issuecomment-745697160

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -64,11 +64,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: haskell/actions/setup@v1
-        id: setup-haskell
-        with:
-          ghc-version: ${{ matrix.ghc }}
-          cabal-version: latest # default, keeping for visibility
+      - name: ghcup
+        run: |
+          ghcup install ghc ${{ matrix.ghc }}
+          ghcup set ghc ${{ matrix.ghc }}
 
       #  See the following link for a breakdown of the following step
       #  https://github.com/haskell/actions/issues/7#issuecomment-745697160
@@ -76,7 +75,7 @@ jobs:
         with:
           # validate.sh uses a special build dir
           path: |
-            ${{ steps.setup-haskell.outputs.cabal-store }}
+            ~/.cabal/store
             dist-*
           key: ${{ runner.os }}-${{ matrix.ghc }}-20220419-${{ github.sha }}
           restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-20220419-
@@ -163,8 +162,9 @@ jobs:
         env:
           # `rawSystemStdInOut reports text decoding errors`
           # test does not find ghc without the full path in windows
-          GHCPATH: ${{ steps.setup-haskell.outputs.ghc-exe }}
-        run: sh validate.sh $FLAGS -s lib-tests
+        run: |
+          export GHCPATH=$(ghcup whereis ghc)
+          sh validate.sh $FLAGS -s lib-tests
 
       - name: Validate lib-suite
         run: sh validate.sh $FLAGS -s lib-suite


### PR DESCRIPTION
the haskell setup action is a bit limited and doesn't do much for us, let's see if we can use ghcup directly

main doubt is the cabal caching directory, where haskell/setup does some smart things