### PR TITLE
Fix Haddocks for `unAbiHash` and `mkAbiHash`

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/AbiHash.hs
+++ b/Cabal-syntax/src/Distribution/Types/AbiHash.hs
@@ -27,18 +27,18 @@ import Text.PrettyPrint (text)
 newtype AbiHash = AbiHash ShortText
     deriving (Eq, Show, Read, Generic, Typeable)
 
+-- | Convert 'AbiHash' to 'String'
+--
+-- @since 2.0.0.2
+unAbiHash :: AbiHash -> String
+unAbiHash (AbiHash h) = fromShortText h
+
 -- | Construct a 'AbiHash' from a 'String'
 --
 -- 'mkAbiHash' is the inverse to 'unAbiHash'
 --
 -- Note: No validations are performed to ensure that the resulting
 -- 'AbiHash' is valid
---
--- @since 2.0.0.2
-unAbiHash :: AbiHash -> String
-unAbiHash (AbiHash h) = fromShortText h
-
--- | Convert 'AbiHash' to 'String'
 --
 -- @since 2.0.0.2
 mkAbiHash :: String -> AbiHash


### PR DESCRIPTION
The existing Haddock documentation for `unAbiHash` and `mkAbiHash` appears to have been swapped, in error. This pull request swaps it back.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests! N/A - documentation only.
