### PR TITLE
cabal haddock imply enable-documentation

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddock.hs
@@ -24,7 +24,7 @@ import Distribution.Client.TargetProblem
 import Distribution.Client.NixStyleOptions
          ( NixStyleFlags (..), nixStyleOptions, defaultNixStyleFlags )
 import Distribution.Client.Setup
-         ( GlobalFlags, ConfigFlags(..) )
+         ( GlobalFlags, ConfigFlags(..), InstallFlags (..))
 import Distribution.Simple.Setup
          ( HaddockFlags(..), fromFlagOrDefault, trueArg )
 import Distribution.Simple.Command
@@ -141,7 +141,8 @@ haddockAction flags@NixStyleFlags {..} targetStrings globalFlags = do
     runProjectPostBuildPhase verbosity baseCtx buildCtx' buildOutcomes
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
-    cliConfig = commandLineFlagsToProjectConfig globalFlags flags mempty -- ClientInstallFlags, not needed here
+    flags' = flags { installFlags = installFlags { installDocumentation = Flag True } }
+    cliConfig = commandLineFlagsToProjectConfig globalFlags flags' mempty -- ClientInstallFlags, not needed here
 
 -- | This defines what a 'TargetSelector' means for the @haddock@ command.
 -- It selects the 'AvailableTarget's that the 'TargetSelector' refers to,

--- a/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/B/B.cabal
+++ b/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/B/B.cabal
@@ -1,0 +1,12 @@
+cabal-version:      2.4
+name:               B
+version:            0.1.0.0
+author:             Artem Pelenitsyn
+maintainer:         a.pelenitsyn@gmail.com
+
+library
+    exposed-modules:  B
+    build-depends:    base
+                    , A
+    hs-source-dirs:   .
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/B/B.hs
+++ b/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/B/B.hs
@@ -1,0 +1,8 @@
+-- | Module using external dependency and mentioning it in haddocks
+module B (b) where
+
+import A
+
+-- | Use 'a'
+b :: Int
+b = a

--- a/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/cabal.out
+++ b/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/cabal.out
@@ -1,0 +1,19 @@
+# cabal v2-update
+Downloading the latest package list from test-local-repo
+# cabal haddock
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - A-0.1.0.0 (lib) (requires build)
+ - B-0.1.0.0 (lib) (first run)
+Configuring library for A-0.1.0.0..
+Preprocessing library for A-0.1.0.0..
+Building library for A-0.1.0.0..
+Preprocessing library for A-0.1.0.0..
+Running Haddock on library for A-0.1.0.0..
+Documentation created: dist/doc/html/A/index.html
+Installing library in <PATH>
+Configuring library for B-0.1.0.0..
+Preprocessing library for B-0.1.0.0..
+Running Haddock on library for B-0.1.0.0..
+Documentation created: <ROOT>/cabal.dist/work/dist/build/<ARCH>/ghc-<GHCVER>/B-0.1.0.0/doc/html/B/index.html

--- a/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/cabal.project
+++ b/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/cabal.project
@@ -1,0 +1,1 @@
+packages: B

--- a/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/cabal.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+-- Test that `cabal haddock` doesn't require explicit
+-- `--enable-dependencies` to happily process links to external packages.
+-- In this example package B depends on an external package A.
+main = cabalTest . withRepo "repo" $
+    cabal "haddock" ["B"]

--- a/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/repo/A-0.1.0.0/A.cabal
+++ b/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/repo/A-0.1.0.0/A.cabal
@@ -1,0 +1,11 @@
+cabal-version:      2.4
+name:               A
+version:            0.1.0.0
+author:             Artem Pelenitsyn
+maintainer:         a.pelenitsyn@gmail.com
+
+library
+    exposed-modules:  A
+    build-depends:    base
+    hs-source-dirs:   .
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/repo/A-0.1.0.0/A.hs
+++ b/cabal-testsuite/PackageTests/NewHaddock/ImplyDependencies/repo/A-0.1.0.0/A.hs
@@ -1,0 +1,4 @@
+module A (a) where
+
+a :: Int
+a = 42

--- a/changelog.d/issue-7462
+++ b/changelog.d/issue-7462
@@ -1,0 +1,4 @@
+synopsis: `cabal haddock` now implies `--enable-documentation`
+packages: cabal-install
+issues: #7462
+prs: #8259

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -1324,11 +1324,12 @@ Haddock options
     :default: False
 
     Enables building of Haddock documentation.
+    Implied when calling ``cabal haddock``.
 
     The command line variant of this flag is ``--enable-documentation``
     and ``--disable-documentation``.
 
-    `documentation: true` does not imply
+    ``documentation: true`` does not imply
     :cfg-field:`haddock-all`,
     :cfg-field:`haddock-benchmarks`,
     :cfg-field:`haddock-executables`,


### PR DESCRIPTION
The problem described  below was solved by nuking the store. All good now. Fixing #7462.

---

I hoped that implementing #7462 should be a breath. Alas, an obvious fix turns into a disfunctional `cabal haddock`: it keeps failing with

```
  67% (  2 /  3) in 'MyLib'
  Missing documentation for:
    Module header
haddock: internal error: /home/artem/.cabal/store/ghc-9.0.2/acme-cadre-0.1-084e219a2f22159b817e45921b58427b54e7a20f5f1736c7acdba987d88cc4e2/share/doc/html/doc-index.json: openBinaryFile: does not exist (No such file or directory)
```

For a simple project like this:

```
❯ cat t7462.cabal
cabal-version:      2.4
name:               t7462
version:            0.1.0.0
author:             Artem Pelenitsyn
maintainer:         a.pelenitsyn@gmail.com
extra-source-files: CHANGELOG.md

library
    exposed-modules:  MyLib
    build-depends:    base ^>=4.15.1.0
                    , acme-cadre
    hs-source-dirs:   src
    default-language: Haskell2010

❯ cat src/MyLib.hs 
module MyLib  where
import Acme.Cadre

-- | Some 'car' magic
someFunc :: IO ()
someFunc = putStrLn $ "someFunc" ++ (show $ car (1,2))

-- | Not very different from 'someFunc'
otherFunc :: IO ()
otherFunc = putStrLn "otherFunc"
```

Putting up this draft in case someone can spot the problem...

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] A test added.

Please also shortly describe how you tested your change. Bonus points for added tests!
