### PR TITLE
immediately fail for non-existent active-repositories

### DIFF
--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -302,7 +302,7 @@ getSourcePackagesAtIndexState verbosity repoCtxt mb_idxState mb_activeRepos = do
 
   pkgss' <- case organizeByRepos activeRepos rdRepoName pkgss of
     Right x  -> return x
-    Left err -> warn verbosity err >> return (map (\x -> (x, CombineStrategyMerge)) pkgss)
+    Left err -> die' verbosity err
 
   let activeRepos' :: ActiveRepos
       activeRepos' = ActiveRepos

--- a/cabal-install/src/Distribution/Client/IndexUtils/ActiveRepos.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils/ActiveRepos.hs
@@ -178,7 +178,7 @@ organizeByRepos (ActiveRepos xs0) sel ys0 =
 
     extract :: RepoName -> [a] -> Either String (a, [a])
     extract r = loop id where
-        loop _acc []     = Left $ "no repository provided " ++ prettyShow r
+        loop _acc []     = Left $ "unknown repository: " ++ prettyShow r
         loop  acc (x:xs)
             | sel x == r = Right (x, acc xs)
             | otherwise  = loop (acc . (x :)) xs


### PR DESCRIPTION
Previously this produced just a warning and Cabal ignored the
active-repositories in this case.

fixes #8213


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  **TODO**
* [x] The documentation has been updated, if necessary.
  I think a documentation update is not necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

Tested by creating a `cabal.project.local` file containing `active-repositories: nonexistentRepo` and checking if `cabal v2-build` immediately fails.