### PR TITLE
Build release archives (and validate) with GHC 9.2.3

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,7 +22,7 @@ jobs:
         ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.3"]
         include:
           - os: macos-latest
-            ghc: "8.10.7"
+            ghc: "9.2.3"
     name: Bootstrap ${{ matrix.os }} ghc-${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,10 +23,10 @@ on:
 env:
   # We choose a stable ghc version across all os's
   # which will be used to do the next release
-  GHC_FOR_RELEASE: '8.10.7'
+  GHC_FOR_RELEASE: '9.2.3'
   # Ideally we should use the version about to be released for hackage tests and benchmarks
-  GHC_FOR_SOLVER_BENCHMARKS: '8.10.7'
-  GHC_FOR_COMPLETE_HACKAGE_TESTS: '8.10.7'
+  GHC_FOR_SOLVER_BENCHMARKS: '9.2.3'
+  GHC_FOR_COMPLETE_HACKAGE_TESTS: '9.2.3'
   COMMON_FLAGS: '-j 2 -v'
 
 jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ variables:
   DOCKER_REV: "4ed1a4f27828ba96a34662dc954335e29b470cd2"
 
   GHC_VERSION: 9.2.3
-  CABAL_INSTALL_VERSION: 3.9.0.0
+  CABAL_INSTALL_VERSION: 3.6.2.0
 
 workflow:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
   # Commit of ghc/ci-images repository from which to pull Docker images
   DOCKER_REV: "4ed1a4f27828ba96a34662dc954335e29b470cd2"
 
-  GHC_VERSION: 8.10.7
+  GHC_VERSION: 9.2.3
   CABAL_INSTALL_VERSION: 3.9.0.0
 
 workflow:

--- a/changelog.d/pr-8272
+++ b/changelog.d/pr-8272
@@ -1,0 +1,10 @@
+synopsis: Build release archives (and validate) with GHC 9.2.3
+packages: cabal-install
+prs: #8272
+issues: #8271
+
+description: {
+
+- The release binaries are now built with GHC 9.2.3, which fixes some minor snags
+
+}


### PR DESCRIPTION
Fixes #8271.

Do we need this in a changelog? I guess not, just as we don't file CI changes? Though this one is user-visible, namely for the users of our binary archives.
