### PR TITLE
cabal init -i: add the GHC2021 language option

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase, MultiWayIf #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.Client.Init.Command
@@ -413,17 +413,22 @@ testDirsPrompt flags = getTestDirs flags $ do
 
 languagePrompt :: Interactive m => InitFlags -> String -> m Language
 languagePrompt flags pkgType = getLanguage flags $ do
-    lang <- promptList ("Choose a language for your " ++ pkgType)
-      ["Haskell2010", "Haskell98"]
-      (DefaultPrompt "Haskell2010")
+    let h2010   = "Haskell2010"
+        h98     = "Haskell98"
+        ghc2021 = "GHC2021 (requires at least GHC 9.2)"
+          
+    l <- promptList ("Choose a language for your " ++ pkgType)
+      [h2010, h98, ghc2021]
+      (DefaultPrompt h2010)
       Nothing
       True
 
-    case lang of
-      "Haskell2010" -> return Haskell2010
-      "Haskell98" -> return Haskell98
-      l | all isAlphaNum l -> return $ UnknownLanguage l
-      _ -> do
+    if
+      | l == h2010       -> return Haskell2010
+      | l == h98         -> return Haskell98
+      | l == ghc2021     -> return GHC2021
+      | all isAlphaNum l -> return $ UnknownLanguage l
+      | otherwise        -> do
         putStrLn
           $ "\nThe language must be alphanumeric. "
           ++ "Please enter a different language."

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
@@ -912,15 +912,15 @@ interactiveTests srcDb = testGroup "Check top level getter functions"
         ]
     , testGroup "Check languagePrompt output"
         [ testNumberedPrompt "Language indices" (`languagePrompt` "test")
-            [Haskell2010, Haskell98]
+            [Haskell2010, Haskell98, GHC2021]
         , testSimplePrompt "Other language"
             (`languagePrompt` "test") (UnknownLanguage "Haskell2022")
-            [ "3"
+            [ "4"
             , "Haskell2022"
             ]
         , testSimplePrompt "Invalid language"
             (`languagePrompt` "test") Haskell2010
-            [ "3"
+            [ "4"
             , "Lang_TS!"
             , "1"
             ]

--- a/cabal-testsuite/PackageTests/Init/init-interactive-ghc2021.out
+++ b/cabal-testsuite/PackageTests/Init/init-interactive-ghc2021.out
@@ -1,0 +1,1 @@
+# cabal init

--- a/cabal-testsuite/PackageTests/Init/init-interactive-ghc2021.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-interactive-ghc2021.test.hs
@@ -1,0 +1,11 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $
+  withSourceCopyDir "app" $ do
+    cwd <- fmap testSourceCopyDir getTestEnv
+
+    buildOut <- withDirectory cwd $ do
+      cabalWithStdin "init" ["-i"]
+        "2\n\n5\n\n\n2\n\n\n\n\n\n\n\n3\n\n"
+
+    assertFileDoesContain (cwd </> "app.cabal") "GHC2021"

--- a/changelog.d/issue-8265
+++ b/changelog.d/issue-8265
@@ -1,0 +1,4 @@
+synopsis: cabal init -i: add the GHC2021 language option
+packages: cabal-install
+prs: #8277
+issues: #8265


### PR DESCRIPTION
fix  #8265
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
