### PR TITLE
[ mergify ] allow 1 approver for backports

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,6 +9,7 @@ pull_request_rules:
         update_method: rebase
     name: Put pull requests in the rebase+merge queue
     conditions:
+      - base=main
       - label=merge me
       - '#approved-reviews-by>=2'
   # merge+squash strategy
@@ -21,8 +22,24 @@ pull_request_rules:
         update_method: merge
     name: Put pull requests in the squash+merge queue
     conditions:
+      - base=main
       - label=squash+merge me
       - '#approved-reviews-by>=2'
+  # rebase+merge strategy for backports: require 1 approver instead of 2
+  - actions:
+      queue:
+        name: default
+        # Merge with a merge commit
+        method: merge
+        # Update the pr branch with rebase, so the history is clean
+        update_method: rebase
+    name: Put backports in the rebase+merge queue
+    conditions:
+      - label=merge me
+      - author=mergify
+      - base!=master
+      - body~=backport
+      - '#approved-reviews-by>=1'
 
 queue_rules:
   - name: default

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -35,7 +35,7 @@ pull_request_rules:
         update_method: rebase
     name: Put backports in the rebase+merge queue
     conditions:
-      - label=merge backport
+      - label=merge me
       - base!=master
       - body~=backport
       - '#approved-reviews-by>=1'

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,7 +9,7 @@ pull_request_rules:
         update_method: rebase
     name: Put pull requests in the rebase+merge queue
     conditions:
-      - base=main
+      - base=master
       - label=merge me
       - '#approved-reviews-by>=2'
   # merge+squash strategy
@@ -22,7 +22,7 @@ pull_request_rules:
         update_method: merge
     name: Put pull requests in the squash+merge queue
     conditions:
-      - base=main
+      - base=master
       - label=squash+merge me
       - '#approved-reviews-by>=2'
   # rebase+merge strategy for backports: require 1 approver instead of 2

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -35,8 +35,7 @@ pull_request_rules:
         update_method: rebase
     name: Put backports in the rebase+merge queue
     conditions:
-      - label=merge me
-      - author=mergify
+      - label=merge backport
       - base!=master
       - body~=backport
       - '#approved-reviews-by>=1'


### PR DESCRIPTION
Trying to be more lenient to backport PRs...

I also took liberty to restrict normal mergify merges to `master`. If you think it's not ok, let me know and I'll revert.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
