### PR TITLE
Clarify assertionsEnabledMsg

### DIFF
--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -195,7 +195,7 @@ warnIfAssertionsAreEnabled =
   (\(_e :: AssertionFailed) -> putStrLn assertionsEnabledMsg)
   where
     assertionsEnabledMsg =
-      "Warning: this is a debug build with assertions enabled."
+      "Warning: this is a debug build of cabal-install with assertions enabled."
 
 mainWorker :: [String] -> IO ()
 mainWorker args = do


### PR DESCRIPTION
Clarify `assertionsEnabledMsg`

The original message confused me.
It should be clear from the message text whether it is a debug build of cabal-install itself or of the package that cabal-install is handling.

