### PR TITLE
cabal init -n: avoid extra blank lines

### DIFF
--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-no-comments.golden
@@ -49,4 +49,3 @@ test-suite y-test
     build-depends:
         base,
         y
-

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-and-exe-with-comments.golden
@@ -129,4 +129,3 @@ test-suite y-test
     build-depends:
         base,
         y
-

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-no-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-no-comments.golden
@@ -37,4 +37,3 @@ test-suite y-test
     build-depends:
         base,
         y
-

--- a/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-with-comments.golden
+++ b/cabal-install/tests/fixtures/init/golden/cabal/cabal-lib-with-comments.golden
@@ -105,4 +105,3 @@ test-suite y-test
     build-depends:
         base,
         y
-

--- a/changelog.d/issue-8236
+++ b/changelog.d/issue-8236
@@ -1,0 +1,4 @@
+synopsis: cabal init -n: avoid extra blank lines
+packages: cabal-init Cabal-syntax
+issues: #8236
+prs: #8292


### PR DESCRIPTION
fix #8236

`cabal init -n`'s strategy is to create a list of field descriptions (the `PrettyField` type), which then gets transformed into a list of `Block`s, which, finally, goes into a list of strings and those strings go right into the generated `.cabal` file.

Some fields may be deemed unnecessary depending on the `init`'s flags (e.g. by default there's an `executable` field but no `library` field). Those fields are represented by the `PrettyEmpty` constructor of `PrettyField`. On the next stage, `PrettyEmpty` goes into a block with empty contents and no "margins" (cf. the `Margin` datatype). In theory, such empty blocks should turn into nothing in the output file. Unfortunately, the algorithm turning blocks into lines, `flattenBlocks`, is a bit tricky and does show sensitivity to empty blocks, producing spurious empty lines.

The simplest solution to this issue that I could think of is filtering out empty blocks before converting blocks to lines. This PR implements the idea.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
