### PR TITLE
Accept unknown future GHCs in the argument filtering code

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -52,9 +52,9 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
    = argumentFilters . filter simpleFilters . filterRtsOpts $ ghcArgs
   where
     supportedGHCVersions :: VersionRange
-    supportedGHCVersions = intersectVersionRanges
-        (orLaterVersion (mkVersion [8,0]))
-        (earlierVersion (mkVersion [9,3]))
+    supportedGHCVersions = orLaterVersion (mkVersion [8,0])
+      -- we (weakly) support unknown future GHC versions for the purpose
+      -- of filtering GHC arguments
 
     from :: Monoid m => [Int] -> m -> m
     from version flags

--- a/changelog.d/pr-8310
+++ b/changelog.d/pr-8310
@@ -1,0 +1,7 @@
+synopsis: Remove the GHC version upper bound when deciding whether to filter GHC arguments
+pr: #8310 #8260
+description: {
+
+- Previously, for unknown new versions of GHC, it was not filtering GHC arguments at all, while now it filters them in the same way as for the last known GHC version. This seems a better default and it's one less place to update at release time. Perhaps erroring out or emitting a warning would be safer, but we already emit a general warning elsewhere.
+
+}


### PR DESCRIPTION
A followup to https://github.com/haskell/cabal/pull/8260#issuecomment-1190098926

Not tested. Theoretically one could test locally by using GHC 9.4 and verifying in the cabal -v3 log that arguments are filtered in the same way as for GHC 9.2. One would need to find a cabal invocation in which the filtering is not vacuus. The test would fail without this change, but pass with this change.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).

Please also shortly describe how you tested your change. Bonus points for added tests!
