### PR TITLE
Add PackageCheck pretty print

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -27,6 +27,7 @@ module Distribution.PackageDescription.Check (
         checkPackage,
         checkConfiguredPackage,
         wrapParseWarning,
+        ppPackageCheck,
 
         -- ** Checking package contents
         checkPackageFiles,
@@ -801,8 +802,13 @@ data PackageCheck =
      | PackageDistInexcusable { explanation :: CheckExplanation }
   deriving (Eq, Ord)
 
+-- | Pretty printing 'PackageCheck'.
+--
+ppPackageCheck :: PackageCheck -> String
+ppPackageCheck e = ppExplanation (explanation e)
+
 instance Show PackageCheck where
-    show notice = ppExplanation (explanation notice)
+    show notice = ppPackageCheck notice
 
 check :: Bool -> PackageCheck -> Maybe PackageCheck
 check False _  = Nothing

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -1965,8 +1965,8 @@ checkPackageProblems verbosity dir gpkg pkg = do
       (errors, warnings) =
         partitionEithers (M.mapMaybe classEW $ pureChecks ++ ioChecks)
   if null errors
-    then traverse_ (warn verbosity) (map show warnings)
-    else die' verbosity (intercalate "\n\n" $ map show errors)
+    then traverse_ (warn verbosity) (map ppPackageCheck warnings)
+    else die' verbosity (intercalate "\n\n" $ map ppPackageCheck errors)
   where
     -- Classify error/warnings. Left: error, Right: warning.
     classEW :: PackageCheck -> Maybe (Either PackageCheck PackageCheck)

--- a/Cabal/src/Distribution/Simple/SrcDist.hs
+++ b/Cabal/src/Distribution/Simple/SrcDist.hs
@@ -504,10 +504,10 @@ printPackageProblems verbosity pkg_descr = do
       (errors, warnings) = partition isDistError (pureChecks ++ ioChecks)
   unless (null errors) $
       notice verbosity $ "Distribution quality errors:\n"
-                      ++ unlines (map show errors)
+                      ++ unlines (map ppPackageCheck errors)
   unless (null warnings) $
       notice verbosity $ "Distribution quality warnings:\n"
-                      ++ unlines (map show warnings)
+                      ++ unlines (map ppPackageCheck warnings)
   unless (null errors) $
       notice verbosity
         "Note: the public hackage server would reject this package."

--- a/changelog.d/pr-8311
+++ b/changelog.d/pr-8311
@@ -1,0 +1,4 @@
+synopsis: Export pretty printer `ppPackageCheck` from
+Distribution.PackageDescription.Check
+packages: Cabal
+prs: #8311


### PR DESCRIPTION
Both principled (we export, use a pretty printer) and pragmatic (we don't surprise programs depending on `Cabal` by modifying `Show` behaviour (yet)) stance.

---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.

Testsuite runs fine.