### PR TITLE
unbreak cabal haddock --disable-documentation

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddock.hs
@@ -143,7 +143,8 @@ haddockAction flags@NixStyleFlags {..} targetStrings globalFlags = do
     runProjectPostBuildPhase verbosity baseCtx buildCtx' buildOutcomes
   where
     verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
-    flags' = flags { installFlags = installFlags { installDocumentation = Flag True } }
+    installDoc = fromFlagOrDefault True (installDocumentation installFlags)
+    flags' = flags { installFlags = installFlags { installDocumentation = Flag installDoc } }
     cliConfig = commandLineFlagsToProjectConfig globalFlags flags' mempty -- ClientInstallFlags, not needed here
 
 -- | This defines what a 'TargetSelector' means for the @haddock@ command.

--- a/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/B/B.cabal
+++ b/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/B/B.cabal
@@ -1,0 +1,12 @@
+cabal-version:      2.4
+name:               B
+version:            0.1.0.0
+author:             Artem Pelenitsyn
+maintainer:         a.pelenitsyn@gmail.com
+
+library
+    exposed-modules:  B
+    build-depends:    base
+                    , A
+    hs-source-dirs:   .
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/B/B.hs
+++ b/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/B/B.hs
@@ -1,0 +1,8 @@
+-- | Module using external dependency and mentioning it in haddocks
+module B (b) where
+
+import A
+
+-- | Use 'a'
+b :: Int
+b = a

--- a/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/cabal.out
+++ b/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/cabal.out
@@ -1,0 +1,16 @@
+# cabal v2-update
+Downloading the latest package list from test-local-repo
+# cabal haddock
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - A-0.1.0.0 (lib) (requires build)
+ - B-0.1.0.0 (lib) (first run)
+Configuring library for A-0.1.0.0..
+Preprocessing library for A-0.1.0.0..
+Building library for A-0.1.0.0..
+Installing library in <PATH>
+Configuring library for B-0.1.0.0..
+Preprocessing library for B-0.1.0.0..
+Running Haddock on library for B-0.1.0.0..
+Documentation created: <ROOT>/cabal.dist/work/dist/build/<ARCH>/ghc-<GHCVER>/B-0.1.0.0/doc/html/B/index.html

--- a/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/cabal.project
+++ b/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/cabal.project
@@ -1,0 +1,1 @@
+packages: B

--- a/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/cabal.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+-- Test that `cabal haddock --disable-documention` works as expected and leads
+-- to a warning if a local package makes an outer reference.
+main = cabalTest . withRepo "repo" $ do
+    r <- cabal' "haddock" ["--disable-documentation", "B"]
+    assertOutputContains "Warning: B: could not find link destinations for" r

--- a/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/repo/A-0.1.0.0/A.cabal
+++ b/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/repo/A-0.1.0.0/A.cabal
@@ -1,0 +1,11 @@
+cabal-version:      2.4
+name:               A
+version:            0.1.0.0
+author:             Artem Pelenitsyn
+maintainer:         a.pelenitsyn@gmail.com
+
+library
+    exposed-modules:  A
+    build-depends:    base
+    hs-source-dirs:   .
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/repo/A-0.1.0.0/A.hs
+++ b/cabal-testsuite/PackageTests/NewHaddock/DisableDoc/repo/A-0.1.0.0/A.hs
@@ -1,0 +1,4 @@
+module A (a) where
+
+a :: Int
+a = 42


### PR DESCRIPTION
Trying to fix my fault from #8259 (thanks @andreasabel for noticing):  `cabal haddock --disable-documentation` seems to work as expected with this patch. 

Below is a description of a problem I initially had but no more. Preserved for historical interest.

---
But the testsuite is not cooperating. I see two options: you, guys, help me or allow me to ditch the test.

Here's the deal with the test:

```haskell
main = cabalTest . withRepo "repo" . fails $
    cabal "haddock" ["--disable-documentation", "B"]
```

should work, but it fails even when

```shell
❯ cabal run cabal-tests -- --with-cabal=(cabal list-bin cabal) cabal-testsuite/PackageTests/NewHaddock/DisableDoc/cabal.test.hs --accept
```

I see the output I'm expecting to see, in particular:

```shell
 100% (  2 /  2) in 'B'
Warning: B: could not find link destinations for:

        - A.a
```

but  the output ends with

```
cabal-tests: callProcess: /nix/store/glag1h91br1sqk489rzzp6mvmxf0pmiy-ghc-9.0.2/bin/runghc-9.0.2 "--" "--ghc-arg=-i" "--ghc-arg=-no-user-package-db" "--ghc-arg=-package-db" "--ghc-arg=/home/artem/.cabal/store/ghc-9.0.2/package.db" "--ghc-arg=-package-db" "--ghc-arg=/home/artem/tmp/cabal/enable-doc-regress/cabal/dist-newstyle/packagedb/ghc-9.0.2" "--ghc-arg=-package-id" "--ghc-arg=Cabal-3.9.0.0-inplace" "--ghc-arg=-package-id" "--ghc-arg=Cabal-syntax-3.9.0.0-inplace" "--ghc-arg=-package-id" "--ghc-arg=async-2.2.4-2b04cd6dcc0fc474e0072aec3462b9c67410113d7befe87d8f668b6a29dfe996" "--ghc-arg=-package-id" "--ghc-arg=base-4.15.1.0" "--ghc-arg=-package-id" "--ghc-arg=cabal-testsuite-3-inplace" "--ghc-arg=-package-id" "--ghc-arg=clock-0.8.3-12cb68ccaf6e6206378be8082c1ee7435ae9bbce4022f1012bd6cd3e5c8fc2aa" "--ghc-arg=-package-id" "--ghc-arg=exceptions-0.10.4" "--ghc-arg=-package-id" "--ghc-arg=filepath-1.4.2.1" "--ghc-arg=-package-id" "--ghc-arg=optparse-applicative-0.16.1.0-72520bdb9dc24ef310719d7357cf6ce0dac24c8b958b2d2663b3d141a87f2fd6" "--ghc-arg=-package-id" "--ghc-arg=process-1.6.14.0-42e0058a6e7535eea211d226cecb5365b21bf90abcca43d0f0527ff0319ccdca" "--ghc-arg=-package-id" "--ghc-arg=transformers-0.5.6.2" "cabal-testsuite/PackageTests/NewHaddock/DisableDoc/cabal.test.hs" "--builddir" "/home/artem/tmp/cabal/enable-doc-regress/cabal/dist-newstyle/build/x86_64-linux/ghc-9.0.2/cabal-testsuite-3" "cabal-testsuite/PackageTests/NewHaddock/DisableDoc/cabal.test.hs" "--with-cabal" "/home/artem/tmp/cabal/enable-doc-regress/cabal/dist-newstyle/build/x86_64-linux/ghc-9.0.2/cabal-install-3.9.0.0/x/cabal/build/cabal/cabal" "--accept" (exit 1): failed

```

Which is no good, as far as I understand. If I remove `fails` in the `.hs` file, the failure in the end seems to be the same. So, I'm probably using `fails` wrong?..

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
