### PR TITLE
Don't warn about 'prepositive-qualified-module' in Paths_pkgs

### DIFF
--- a/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
@@ -41,6 +41,14 @@ render z_root = execWriter $ do
     return ()
   else do
     return ()
+  if (zSupportsCpp z_root)
+  then do
+    tell "#if __GLASGOW_HASKELL__ >= 810\n"
+    tell "{-# OPTIONS_GHC -Wno-prepositive-qualified-module #-}\n"
+    tell "#endif\n"
+    return ()
+  else do
+    return ()
   tell "{-# OPTIONS_GHC -fno-warn-missing-import-lists #-}\n"
   tell "{-# OPTIONS_GHC -w #-}\n"
   tell "module Paths_"

--- a/cabal-testsuite/PackageTests/PathsModule/ImportQualifiedPost/Main.hs
+++ b/cabal-testsuite/PackageTests/PathsModule/ImportQualifiedPost/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = return ()

--- a/cabal-testsuite/PackageTests/PathsModule/ImportQualifiedPost/my.cabal
+++ b/cabal-testsuite/PackageTests/PathsModule/ImportQualifiedPost/my.cabal
@@ -1,0 +1,17 @@
+name: PathsModule
+version: 0.1
+license: BSD3
+author: Martijn Bastiaan
+category: PackageTests
+build-type: Simple
+Cabal-version: >= 1.2
+
+description:
+    Check that the generated paths module compiles.
+
+Executable TestPathsModule
+    main-is: Main.hs
+    if impl(ghc >= 8.10.0)
+        ghc-options: -Werror -fwarn-prepositive-qualified-module
+    other-modules: Paths_PathsModule
+    build-depends: base

--- a/cabal-testsuite/PackageTests/PathsModule/ImportQualifiedPost/setup.cabal.out
+++ b/cabal-testsuite/PackageTests/PathsModule/ImportQualifiedPost/setup.cabal.out
@@ -1,0 +1,5 @@
+# Setup configure
+Configuring PathsModule-0.1...
+# Setup build
+Preprocessing executable 'TestPathsModule' for PathsModule-0.1..
+Building executable 'TestPathsModule' for PathsModule-0.1..

--- a/cabal-testsuite/PackageTests/PathsModule/ImportQualifiedPost/setup.out
+++ b/cabal-testsuite/PackageTests/PathsModule/ImportQualifiedPost/setup.out
@@ -1,0 +1,5 @@
+# Setup configure
+Configuring PathsModule-0.1...
+# Setup build
+Preprocessing executable 'TestPathsModule' for PathsModule-0.1..
+Building executable 'TestPathsModule' for PathsModule-0.1..

--- a/cabal-testsuite/PackageTests/PathsModule/ImportQualifiedPost/setup.test.hs
+++ b/cabal-testsuite/PackageTests/PathsModule/ImportQualifiedPost/setup.test.hs
@@ -1,0 +1,4 @@
+import Test.Cabal.Prelude
+-- Test that Paths module is generated and available for executables.
+main = setupAndCabalTest $ setup_build []
+

--- a/templates/Paths_pkg.template.hs
+++ b/templates/Paths_pkg.template.hs
@@ -7,6 +7,11 @@
 {% if not absolute %}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {% endif %}
+{% if supportsCpp %}
+#if __GLASGOW_HASKELL__ >= 810
+{-# OPTIONS_GHC -Wno-prepositive-qualified-module #-}
+#endif
+{% endif %}
 {-# OPTIONS_GHC -fno-warn-missing-import-lists #-}
 {-# OPTIONS_GHC -w #-}
 module Paths_{{ manglePkgName packageName }} (


### PR DESCRIPTION
Enabling '-Wprepositive-qualified-module' in a project leads to warnings
when used in combination with Cabal's Paths_* feature. Given that this
is code outside of a user's control, this warning should be disabled
locally.


---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
