### PR TITLE
Turn off T3827 for Linux and OSX due to heisenbugs not caused by cabal

### DIFF
--- a/cabal-testsuite/PackageTests/NewBuild/T3827/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T3827/cabal.test.hs
@@ -1,8 +1,11 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
+  heisenProfiling <- isGhcVersion ">= 9.2.0"
   linux <- isLinux
   missesProfilingLinux <- isGhcVersion ">= 9.0.2"
   osx <- isOSX
   missesProfilingOsx <- isGhcVersion ">= 8.10.7"
-  expectBrokenIf (linux && missesProfilingLinux || osx && missesProfilingOsx) 8032 $
+  skipIf "8032 heisenbug profiling" ((linux || osx) && heisenProfiling))
+  expectBrokenIf (linux && missesProfilingLinux
+                  || osx && missesProfilingOsx) 8032 $
     cabal "v2-build" ["exe:q"]

--- a/cabal-testsuite/PackageTests/NewBuild/T3827/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T3827/cabal.test.hs
@@ -1,11 +1,10 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
-  heisenProfiling <- isGhcVersion ">= 9.2.0"
   linux <- isLinux
   missesProfilingLinux <- isGhcVersion ">= 9.0.2"
   osx <- isOSX
   missesProfilingOsx <- isGhcVersion ">= 8.10.7"
-  skipIf "8032 heisenbug profiling" ((linux || osx) && heisenProfiling))
+  skipIf "8032 heisenbug profiling" linux
   expectBrokenIf (linux && missesProfilingLinux
                   || osx && missesProfilingOsx) 8032 $
     cabal "v2-build" ["exe:q"]

--- a/cabal-testsuite/PackageTests/NewBuild/T3827/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T3827/cabal.test.hs
@@ -1,10 +1,6 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
   linux <- isLinux
-  missesProfilingLinux <- isGhcVersion ">= 9.0.2"
   osx <- isOSX
-  missesProfilingOsx <- isGhcVersion ">= 8.10.7"
-  skipIf "8032 heisenbug profiling" linux
-  expectBrokenIf (linux && missesProfilingLinux
-                  || osx && missesProfilingOsx) 8032 $
-    cabal "v2-build" ["exe:q"]
+  skipIf "8032 heisenbug profiling" (linux || osx)
+  cabal "v2-build" ["exe:q"]


### PR DESCRIPTION
An emergency CI fix to unblock CI passing for https://github.com/haskell/cabal/pull/8336 and probably others. See https://github.com/haskell/cabal/issues/8032#issuecomment-1204057038 for more info.