### PR TITLE
Bump package process dependency version to 1.6.15.0 and move from Cabal to cabal-install

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -46,10 +46,6 @@ library
     process    >= 1.2.1.0  && < 1.7,
     time       >= 1.4.0.1  && < 1.13
 
-  -- pull in process version with fixed waitForProcess error
-  if impl(ghc >=8.2)
-    build-depends: process >= 1.6.15.0
-
   if os(windows)
     build-depends: Win32 >= 2.3.0.0 && < 2.14
   else

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -48,7 +48,7 @@ library
 
   -- pull in process version with fixed waitForProcess error
   if impl(ghc >=8.2)
-    build-depends: process >= 1.6.14.0
+    build-depends: process >= 1.6.15.0
 
   if os(windows)
     build-depends: Win32 >= 2.3.0.0 && < 2.14

--- a/bootstrap/linux-8.10.7.json
+++ b/bootstrap/linux-8.10.7.json
@@ -10,13 +10,13 @@
             "version": "3.9.0.0"
         },
         {
-            "cabal_sha256": "b6ad76fd3f4bf133cdc2dc9176e23447f2a0a8e9316047d53154cd11f871446d",
+            "cabal_sha256": "04df32d9497add5f0b90a27a3eceffa4bad5c2f41d038bd12ed6efc454db3faf",
             "revision": 0,
-            "src_sha256": "89d3e89c1367f9046edad58b0a434b6758c76f1b8c62c7c56536e5d1ee9f4a3d",
+            "src_sha256": "44b31b6cd3129893ac1a007573dedb69dde667fa06ee108526d58f08b1a1f7ab",
             "flags": [],
             "package": "process",
             "source": "hackage",
-            "version": "1.6.14.0"
+            "version": "1.6.15.0"
         },
         {
             "cabal_sha256": null,

--- a/bootstrap/linux-8.6.5.json
+++ b/bootstrap/linux-8.6.5.json
@@ -10,13 +10,13 @@
             "version": "3.9.0.0"
         },
         {
-            "cabal_sha256": "b6ad76fd3f4bf133cdc2dc9176e23447f2a0a8e9316047d53154cd11f871446d",
+            "cabal_sha256": "04df32d9497add5f0b90a27a3eceffa4bad5c2f41d038bd12ed6efc454db3faf",
             "revision": 0,
-            "src_sha256": "89d3e89c1367f9046edad58b0a434b6758c76f1b8c62c7c56536e5d1ee9f4a3d",
+            "src_sha256": "44b31b6cd3129893ac1a007573dedb69dde667fa06ee108526d58f08b1a1f7ab",
             "flags": [],
             "package": "process",
             "source": "hackage",
-            "version": "1.6.14.0"
+            "version": "1.6.15.0"
         },
         {
             "cabal_sha256": null,

--- a/bootstrap/linux-8.8.4.json
+++ b/bootstrap/linux-8.8.4.json
@@ -10,13 +10,13 @@
             "version": "3.9.0.0"
         },
         {
-            "cabal_sha256": "b6ad76fd3f4bf133cdc2dc9176e23447f2a0a8e9316047d53154cd11f871446d",
+            "cabal_sha256": "04df32d9497add5f0b90a27a3eceffa4bad5c2f41d038bd12ed6efc454db3faf",
             "revision": 0,
-            "src_sha256": "89d3e89c1367f9046edad58b0a434b6758c76f1b8c62c7c56536e5d1ee9f4a3d",
+            "src_sha256": "44b31b6cd3129893ac1a007573dedb69dde667fa06ee108526d58f08b1a1f7ab",
             "flags": [],
             "package": "process",
             "source": "hackage",
-            "version": "1.6.14.0"
+            "version": "1.6.15.0"
         },
         {
             "cabal_sha256": null,

--- a/bootstrap/linux-9.0.2.json
+++ b/bootstrap/linux-9.0.2.json
@@ -10,13 +10,13 @@
             "version": "3.9.0.0"
         },
         {
-            "cabal_sha256": "b6ad76fd3f4bf133cdc2dc9176e23447f2a0a8e9316047d53154cd11f871446d",
+            "cabal_sha256": "04df32d9497add5f0b90a27a3eceffa4bad5c2f41d038bd12ed6efc454db3faf",
             "revision": 0,
-            "src_sha256": "89d3e89c1367f9046edad58b0a434b6758c76f1b8c62c7c56536e5d1ee9f4a3d",
+            "src_sha256": "44b31b6cd3129893ac1a007573dedb69dde667fa06ee108526d58f08b1a1f7ab",
             "flags": [],
             "package": "process",
             "source": "hackage",
-            "version": "1.6.14.0"
+            "version": "1.6.15.0"
         },
         {
             "cabal_sha256": null,

--- a/bootstrap/linux-9.2.3.json
+++ b/bootstrap/linux-9.2.3.json
@@ -10,13 +10,13 @@
             "version": "3.9.0.0"
         },
         {
-            "cabal_sha256": "b6ad76fd3f4bf133cdc2dc9176e23447f2a0a8e9316047d53154cd11f871446d",
+            "cabal_sha256": "04df32d9497add5f0b90a27a3eceffa4bad5c2f41d038bd12ed6efc454db3faf",
             "revision": 0,
-            "src_sha256": "89d3e89c1367f9046edad58b0a434b6758c76f1b8c62c7c56536e5d1ee9f4a3d",
+            "src_sha256": "44b31b6cd3129893ac1a007573dedb69dde667fa06ee108526d58f08b1a1f7ab",
             "flags": [],
             "package": "process",
             "source": "hackage",
-            "version": "1.6.14.0"
+            "version": "1.6.15.0"
         },
         {
             "cabal_sha256": null,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -245,6 +245,10 @@ library
     if flag(lukko)
       build-depends: lukko >= 0.1 && <0.2
 
+   -- pull in process version with fixed waitForProcess error
+   if impl(ghc >=8.2)
+     build-depends: process >= 1.6.15.0
+
 
 executable cabal
     import: warnings, base-dep, cabal-dep, cabal-syntax-dep


### PR DESCRIPTION
This mimics #8279 and is needed due to https://github.com/haskell/cabal/pull/8279#issuecomment-1204599705