### PR TITLE
*.project.* files use program-options to specify -fno-ignore-asserts

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -25,32 +25,5 @@ constraints: these -assoc
 constraints: text >= 2.0
 constraints: time >= 1.12
 
--- So us hackers get all the assertion failures early:
---
--- NOTE: currently commented out, see
--- https://github.com/haskell/cabal/issues/3911
--- as a workaround we specify it for each package individually:
---
--- program-options
---   ghc-options: -fno-ignore-asserts
---
-package Cabal
-  ghc-options: -fno-ignore-asserts
-
-package cabal-testsuite
-  ghc-options: -fno-ignore-asserts
-
-package Cabal-QuickCheck
-  ghc-options: -fno-ignore-asserts
-
-package Cabal-tree-diff
-  ghc-options: -fno-ignore-asserts
-
-package Cabal-described
-  ghc-options: -fno-ignore-asserts
-
-package cabal-install-solver
-  ghc-options: -fno-ignore-asserts
-
-package cabal-install
+program-options
   ghc-options: -fno-ignore-asserts

--- a/cabal.project.coverage
+++ b/cabal.project.coverage
@@ -28,6 +28,9 @@ allow-newer: windns-0.1.0.1:base
 constraints: rere -rere-cfg
 constraints: these
 
+program-options
+  ghc-options: -fno-ignore-asserts
+
 -- NOTE: for library coverage in multi-project builds,
 -- see:
 --
@@ -39,41 +42,33 @@ constraints: these
 -- the `cabal-install` library
 --
 package Cabal-syntax
-  ghc-options: -fno-ignore-asserts
   coverage: False
   library-coverage: False
 
 package Cabal
-  ghc-options: -fno-ignore-asserts
   coverage: False
   library-coverage: False
 
 package cabal-testsuite
-  ghc-options: -fno-ignore-asserts
   coverage: False
   library-coverage: False
 
 package Cabal-QuickCheck
-  ghc-options: -fno-ignore-asserts
   coverage: False
   library-coverage: False
 
 package Cabal-tree-diff
-  ghc-options: -fno-ignore-asserts
   coverage: False
   library-coverage: False
 
 package Cabal-described
-  ghc-options: -fno-ignore-asserts
   coverage: False
   library-coverage: False
 
 package cabal-install-solver
-  ghc-options: -fno-ignore-asserts
   coverage: False
   library-coverage: False
 
 package cabal-install
-  ghc-options: -fno-ignore-asserts
   coverage: True
   library-coverage: True

--- a/cabal.project.libonly
+++ b/cabal.project.libonly
@@ -11,17 +11,4 @@ tests: True
 --optional-packages: */
 
 program-options
-  -- So us hackers get all the assertion failures early:
-  --
-  -- NOTE: currently commented out, see
-  -- https://github.com/haskell/cabal/issues/3911
-  --
-  -- ghc-options: -fno-ignore-asserts
-  --
-  -- as a workaround we specify it for each package individually:
-package Cabal-syntax
-  ghc-options: -fno-ignore-asserts
-package Cabal
-  ghc-options: -fno-ignore-asserts
-package cabal-testsuite
   ghc-options: -fno-ignore-asserts

--- a/cabal.project.validate
+++ b/cabal.project.validate
@@ -19,11 +19,14 @@ constraints: these -assoc
 
 write-ghc-environment-files: never
 
+program-options
+  ghc-options: -fno-ignore-asserts
+
 package Cabal-syntax
-  ghc-options: -Werror -fno-ignore-asserts
+  ghc-options: -Werror
 package Cabal
-  ghc-options: -Werror -fno-ignore-asserts
+  ghc-options: -Werror
 package cabal-testsuite
-  ghc-options: -Werror -fno-ignore-asserts
+  ghc-options: -Werror
 package cabal-install
-  ghc-options: -Werror -fno-ignore-asserts
+  ghc-options: -Werror

--- a/cabal.project.validate.libonly
+++ b/cabal.project.validate.libonly
@@ -14,12 +14,15 @@ write-ghc-environment-files: never
 constraints: rere -rere-cfg
 constraints: these -assoc
 
+program-options
+  ghc-options: -fno-ignore-asserts
+
 package Cabal-syntax
-  ghc-options: -Werror -fno-ignore-asserts
+  ghc-options: -Werror
 package Cabal
-  ghc-options: -Werror -fno-ignore-asserts
+  ghc-options: -Werror
 package cabal-testsuite
-  ghc-options: -Werror -fno-ignore-asserts
+  ghc-options: -Werror
 
 -- https://github.com/haskell-hvr/cryptohash-sha256/issues/12
 allow-newer: cryptohash-sha256:base


### PR DESCRIPTION
Simplifies `*.project.*` files a bit. It wasn't feasible before #7973, as `program-options` were applied to dependencies as well, which is undesirable.

This is undoing 0c99981, which was a stop-gap against #3911. #7973 should cover #3911 these days.

**TODO**:

- [x] as mentioned in https://github.com/haskell/cabal/pull/8350#issuecomment-1214174819, it requires CI to bump its `cabal` to 3.8

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
