### PR TITLE
Allow offline bootstrapping of cabal-install

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -32,8 +32,12 @@ jobs:
           GHC_VERSION=${{ matrix.ghc }}
           ghcup config set cache true
           ghcup install ghc $GHC_VERSION
-          # We use linux dependencies also on macos
-          python3 bootstrap/bootstrap.py -w $(ghcup whereis ghc $GHC_VERSION) -d bootstrap/linux-$GHC_VERSION.json
+
+          # Fetch the bootstrap sources (we use linux dependencies also on macos)
+          python3 bootstrap/bootstrap.py -w $(ghcup whereis ghc $GHC_VERSION) -d bootstrap/linux-$GHC_VERSION.json fetch
+
+          # Bootstrap using the bootstrap sources
+          python3 bootstrap/bootstrap.py -w $(ghcup whereis ghc $GHC_VERSION) --bootstrap-sources bootstrap-sources.tar.gz
 
       - name: Smoke test
         run: |

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -5,15 +5,24 @@ on a new platform. If you already have a functional (if dated) cabal-install
 please rather run `cabal v2-install`.
 
 The typical usage is porting to a new linux architecture,
-then the `linux-$GHCVER.json` file is available in `bootstrap/` folder:
+then the `linux-{ghc-ver}.json` file is available in the `bootstrap/` folder:
 
 On a (linux) system you are bootstrapping, run
 
-    ./bootstrap/bootstrap.py -d ./bootstrap/linux-$GHCVER.json -w /path/to-ghc
+   ./bootstrap/bootstrap.py -d ./bootstrap/linux-ghcver.json -w /path/to-ghc
 
 from the top directory of the source checkout.
 
-To generate the `$PLATFORM-$GHCVER` files for other platforms, do:
+For offline builds, you can first run
+
+   ./bootstrap/bootstrap.py -d ./bootstrap/linux-ghcver.json -w /path/to-ghc fetch
+
+to fetch tarballs for all the dependencies. These can then be used by a further
+bootstrap command by way of the `--bootstrap-sources` argument:
+
+   ./bootstrap/bootstrap.py -w /path/to-ghc --bootstrap-sources bootstrap-sources.tar.gz
+
+To generate the `platform-{ghc-ver}` files for other platforms, do:
 
   1. On a system with functional cabal-install, install the same GHC version
      as you will use to bootstrap on the host system.

--- a/changelog.d/pr-8368
+++ b/changelog.d/pr-8368
@@ -1,0 +1,10 @@
+synopsis: Allow offline bootstrapping of cabal-install
+prs: #8368
+packages: cabal-install
+
+description: {
+
+- The bootstrap script for cabal-install now supports fetching the sources of the dependencies in a separate step.
+  One can then copy over the resulting archive and perform offline bootstrapping of cabal-install.
+
+}


### PR DESCRIPTION
This ports to cabal-install the offline bootstrapping logic which was
introduced for Hadrian in GHC MR !6315.

This adds a "fetch" command to the bootstrap script, which fetches
all the dependency tarballs from Hackage, to be used in an offline
build. See bootstrap/README.md for further information.

I tested this locally but would appreciate further testing, perhaps changing the bootstrap CI scripts to separately fetch the archive and then build with the archives.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

