### PR TITLE
Fix compilation on old GHCs (fixes #8371)

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -51,9 +51,11 @@ library
     build-depends: unix  >= 2.6.0.0 && < 2.8
 
   ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
-  ghc-options: -Wcompat -Wnoncanonical-monad-instances
 
-  if impl(ghc <8.8)
+  if impl(ghc >= 8.2)
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances
+
+  if impl(ghc >= 8.2) && impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
   exposed-modules:

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -52,10 +52,10 @@ library
 
   ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
 
-  if impl(ghc >= 8.2)
+  if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances
 
-  if impl(ghc >= 8.2) && impl(ghc < 8.8)
+  if impl(ghc >= 8.0) && impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
   exposed-modules:

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -57,10 +57,10 @@ library
 
   ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
 
-  if impl(ghc >= 8.2)
+  if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances
 
-  if impl(ghc >= 8.2) && impl(ghc < 8.8)
+  if impl(ghc >= 8.0) && impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
   exposed-modules:

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -56,9 +56,11 @@ library
     build-depends: unix  >= 2.6.0.0 && < 2.8
 
   ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
-  ghc-options: -Wcompat -Wnoncanonical-monad-instances
 
-  if impl(ghc <8.8)
+  if impl(ghc >= 8.2)
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances
+
+  if impl(ghc >= 8.2) && impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
   exposed-modules:


### PR DESCRIPTION
Would simplify https://github.com/haskell/hackage-security/pull/281 and fix similar errors for others. More delicate than bumping lower bounds on base.

Fixes https://github.com/haskell/cabal/issues/8371