### PR TITLE
Add test summary

### DIFF
--- a/cabal-testsuite/main/cabal-tests.hs
+++ b/cabal-testsuite/main/cabal-tests.hs
@@ -214,8 +214,13 @@ main = do
             unexpected_passes <- takeMVar unexpected_passes_var
             skipped           <- takeMVar skipped_var
 
-            -- print skipped
-            logAll $ "SKIPPED " ++ show (length skipped) ++ " tests"
+            -- print summary
+            let sl = show . length
+                testSummary =
+                  sl all_tests ++ " tests, " ++ sl skipped ++ " skipped, "
+                    ++ sl unexpected_passes ++ " unexpected passes, "
+                    ++ sl unexpected_fails ++ " unexpected fails."
+            logAll testSummary
 
             -- print failed or unexpected ok
             if null (unexpected_fails ++ unexpected_passes)

--- a/cabal-testsuite/main/cabal-tests.hs
+++ b/cabal-testsuite/main/cabal-tests.hs
@@ -217,7 +217,7 @@ main = do
             -- print skipped
             logAll $ "SKIPPED " ++ show (length skipped) ++ " tests"
 
-            -- print failed or ook
+            -- print failed or unexpected ok
             if null (unexpected_fails ++ unexpected_passes)
             then logAll "OK"
             else do


### PR DESCRIPTION
Make `cabal-test` tests will end with a useful summary:

```
⁝
ConfiguredPackage/License/UnknownLicence/cabal.test.hs                      OK (0.13s)
ConfiguredPackage/License/NoFileSpecified/cabal.test.hs                     OK (0.14s)
ConfiguredPackage/License/NoLicense/cabal.test.hs                           OK (0.13s)
OK
112 tests, 0 skipped, 0 unexpected passes, 0 unexpected fails.
```

This is useful when you are dealing with a lot of failures (e.g. refactoring) and an integer is more useful than a long list of test names.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Not a user change, nothing to write in a changeloc.
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
