### PR TITLE
[3.8] Revert "Implement --prefer-oldest (#8261)"

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Preference.hs
@@ -86,31 +86,18 @@ preferLinked = addWeight (const (const linked))
 preferPackagePreferences :: (PN -> PackagePreferences) -> EndoTreeTrav d c
 preferPackagePreferences pcs =
     preferPackageStanzaPreferences pcs .
-    -- Each package is assigned a list of weights (currently three of them),
-    -- and options are ordered by comparison of these lists.
-    --
-    -- The head of the list (and thus the top priority for ordering)
-    -- is whether the package version is "preferred"
-    -- (https://hackage.haskell.org/packages/preferred-versions).
-    --
-    -- The next two elements depend on 'PackagePreferences'.
-    -- For 'PreferInstalled' they are whether the version is installed (0 or 1)
-    -- and how close is the version to the latest one (between 0.0 and 1.0).
-    -- For 'PreferLatest' the weights are the same, but swapped, so that
-    -- ordering considers how new is the package first.
-    -- For 'PreferOldest' one weight measures how close is the version to the
-    -- the oldest one possible (between 0.0 and 1.0) and another checks whether
-    -- the version is installed (0 or 1).
     addWeights [
           \pn _  opt -> preferred pn opt
+
+        -- Note that we always rank installed before uninstalled, and later
+        -- versions before earlier, but we can change the priority of the
+        -- two orderings.
         , \pn vs opt -> case preference pn of
                           PreferInstalled -> installed opt
                           PreferLatest    -> latest vs opt
-                          PreferOldest    -> oldest vs opt
         , \pn vs opt -> case preference pn of
                           PreferInstalled -> latest vs opt
                           PreferLatest    -> installed opt
-                          PreferOldest    -> installed opt
         ]
   where
     -- Prefer packages with higher version numbers over packages with
@@ -120,11 +107,6 @@ preferPackagePreferences pcs =
       let l = length sortedVersions
           index = fromMaybe l $ L.findIndex (<= version opt) sortedVersions
       in  fromIntegral index / fromIntegral l
-
-    -- Prefer packages with lower version numbers over packages with
-    -- higher version numbers.
-    oldest :: [Ver] -> POption -> Weight
-    oldest sortedVersions opt = 1 - latest sortedVersions opt
 
     preference :: PN -> InstalledPreference
     preference pn =

--- a/cabal-install-solver/src/Distribution/Solver/Types/InstalledPreference.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/InstalledPreference.hs
@@ -7,5 +7,5 @@ import Prelude (Show)
 -- | Whether we prefer an installed version of a package or simply the latest
 -- version.
 --
-data InstalledPreference = PreferInstalled | PreferLatest | PreferOldest
+data InstalledPreference = PreferInstalled | PreferLatest
   deriving Show

--- a/cabal-install-solver/src/Distribution/Solver/Types/Settings.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/Settings.hs
@@ -3,7 +3,6 @@
 module Distribution.Solver.Types.Settings
     ( ReorderGoals(..)
     , IndependentGoals(..)
-    , PreferOldest(..)
     , MinimizeConflictSet(..)
     , AvoidReinstalls(..)
     , ShadowPkgs(..)
@@ -41,9 +40,6 @@ newtype MinimizeConflictSet = MinimizeConflictSet Bool
 newtype IndependentGoals = IndependentGoals Bool
   deriving (BooleanFlag, Eq, Generic, Show)
 
-newtype PreferOldest = PreferOldest Bool
-  deriving (BooleanFlag, Eq, Generic, Show)
-
 newtype AvoidReinstalls = AvoidReinstalls Bool
   deriving (BooleanFlag, Eq, Generic, Show)
 
@@ -73,7 +69,6 @@ instance Binary ReorderGoals
 instance Binary CountConflicts
 instance Binary FineGrainedConflicts
 instance Binary IndependentGoals
-instance Binary PreferOldest
 instance Binary MinimizeConflictSet
 instance Binary AvoidReinstalls
 instance Binary ShadowPkgs
@@ -86,7 +81,6 @@ instance Structured ReorderGoals
 instance Structured CountConflicts
 instance Structured FineGrainedConflicts
 instance Structured IndependentGoals
-instance Structured PreferOldest
 instance Structured MinimizeConflictSet
 instance Structured AvoidReinstalls
 instance Structured ShadowPkgs

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -302,7 +302,6 @@ instance Semigroup SavedConfig where
         installFineGrainedConflicts  = combine installFineGrainedConflicts,
         installMinimizeConflictSet   = combine installMinimizeConflictSet,
         installIndependentGoals      = combine installIndependentGoals,
-        installPreferOldest          = combine installPreferOldest,
         installShadowPkgs            = combine installShadowPkgs,
         installStrongFlags           = combine installStrongFlags,
         installAllowBootLibInstalls  = combine installAllowBootLibInstalls,

--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -109,7 +109,7 @@ import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ConstraintSource
 import           Distribution.Solver.Types.DependencyResolver
-import           Distribution.Solver.Types.InstalledPreference as Preference
+import           Distribution.Solver.Types.InstalledPreference
 import           Distribution.Solver.Types.LabeledPackageConstraint
 import           Distribution.Solver.Types.OptionalStanza
 import           Distribution.Solver.Types.PackageConstraint
@@ -767,14 +767,13 @@ interpretPackagesPreference selected defaultPref prefs =
       [ (pkgname, pref)
       | PackageInstalledPreference pkgname pref <- prefs ]
     installPrefDefault = case defaultPref of
-      PreferAllLatest         -> const Preference.PreferLatest
-      PreferAllOldest         -> const Preference.PreferOldest
-      PreferAllInstalled      -> const Preference.PreferInstalled
+      PreferAllLatest         -> const PreferLatest
+      PreferAllInstalled      -> const PreferInstalled
       PreferLatestForSelected -> \pkgname ->
         -- When you say cabal install foo, what you really mean is, prefer the
         -- latest version of foo, but the installed version of everything else
-        if pkgname `Set.member` selected then Preference.PreferLatest
-                                         else Preference.PreferInstalled
+        if pkgname `Set.member` selected then PreferLatest
+                                         else PreferInstalled
 
     stanzasPref :: PackageName -> [OptionalStanza]
     stanzasPref pkgname =
@@ -1020,9 +1019,8 @@ resolveWithoutDependencies (DepResolverParams targets constraints
                           (installPref pkg, versionPref pkg, packageVersion pkg)
         installPref   :: UnresolvedSourcePackage -> Bool
         installPref   = case preferInstalled of
-          Preference.PreferLatest    -> const False
-          Preference.PreferOldest    -> const False
-          Preference.PreferInstalled -> not . null
+          PreferLatest    -> const False
+          PreferInstalled -> not . null
                            . InstalledPackageIndex.lookupSourcePackageId
                                                      installedPkgIndex
                            . packageId

--- a/cabal-install/src/Distribution/Client/Dependency/Types.hs
+++ b/cabal-install/src/Distribution/Client/Dependency/Types.hs
@@ -49,13 +49,6 @@ data PackagesPreferenceDefault =
      --
      PreferAllLatest
 
-     -- | Always prefer the oldest version irrespective of any existing
-     -- installed version or packages explicitly requested.
-     --
-     -- * This is enabled by --prefer-oldest.
-     --
-   | PreferAllOldest
-
      -- | Always prefer the installed versions over ones that would need to be
      -- installed. Secondarily, prefer latest versions (eg the latest installed
      -- version or if there are none then the latest source version).

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -254,7 +254,6 @@ resolveSolverSettings ProjectConfig{
     solverSettingIndexState        = flagToMaybe projectConfigIndexState
     solverSettingActiveRepos       = flagToMaybe projectConfigActiveRepos
     solverSettingIndependentGoals  = fromFlag projectConfigIndependentGoals
-    solverSettingPreferOldest      = fromFlag projectConfigPreferOldest
   --solverSettingShadowPkgs        = fromFlag projectConfigShadowPkgs
   --solverSettingReinstall         = fromFlag projectConfigReinstall
   --solverSettingAvoidReinstalls   = fromFlag projectConfigAvoidReinstalls
@@ -275,8 +274,7 @@ resolveSolverSettings ProjectConfig{
        projectConfigStrongFlags       = Flag (StrongFlags False),
        projectConfigAllowBootLibInstalls = Flag (AllowBootLibInstalls False),
        projectConfigOnlyConstrained   = Flag OnlyConstrainedNone,
-       projectConfigIndependentGoals  = Flag (IndependentGoals False),
-       projectConfigPreferOldest      = Flag (PreferOldest False)
+       projectConfigIndependentGoals  = Flag (IndependentGoals False)
      --projectConfigShadowPkgs        = Flag False,
      --projectConfigReinstall         = Flag False,
      --projectConfigAvoidReinstalls   = Flag False,

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -514,7 +514,6 @@ convertLegacyAllPackageFlags globalFlags configFlags configExFlags installFlags 
       installMinimizeConflictSet = projectConfigMinimizeConflictSet,
       installPerComponent       = projectConfigPerComponent,
       installIndependentGoals   = projectConfigIndependentGoals,
-      installPreferOldest       = projectConfigPreferOldest,
     --installShadowPkgs         = projectConfigShadowPkgs,
       installStrongFlags        = projectConfigStrongFlags,
       installAllowBootLibInstalls = projectConfigAllowBootLibInstalls,
@@ -757,7 +756,6 @@ convertToLegacySharedConfig
       installFineGrainedConflicts = projectConfigFineGrainedConflicts,
       installMinimizeConflictSet = projectConfigMinimizeConflictSet,
       installIndependentGoals  = projectConfigIndependentGoals,
-      installPreferOldest      = projectConfigPreferOldest,
       installShadowPkgs        = mempty, --projectConfigShadowPkgs,
       installStrongFlags       = projectConfigStrongFlags,
       installAllowBootLibInstalls = projectConfigAllowBootLibInstalls,
@@ -1167,7 +1165,7 @@ legacySharedConfigFieldDescrs constraintSrc = concat
       , "jobs", "keep-going", "offline", "per-component"
         -- solver flags:
       , "max-backjumps", "reorder-goals", "count-conflicts"
-      , "fine-grained-conflicts" , "minimize-conflict-set", "independent-goals", "prefer-oldest"
+      , "fine-grained-conflicts" , "minimize-conflict-set", "independent-goals"
       , "strong-flags" , "allow-boot-library-installs"
       , "reject-unconstrained-dependencies", "index-state"
       ]

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -203,7 +203,6 @@ data ProjectConfigShared
        projectConfigOnlyConstrained   :: Flag OnlyConstrained,
        projectConfigPerComponent      :: Flag Bool,
        projectConfigIndependentGoals  :: Flag IndependentGoals,
-       projectConfigPreferOldest      :: Flag PreferOldest,
 
        projectConfigProgPathExtra     :: NubList FilePath
 
@@ -411,8 +410,7 @@ data SolverSettings
        solverSettingOnlyConstrained   :: OnlyConstrained,
        solverSettingIndexState        :: Maybe TotalIndexState,
        solverSettingActiveRepos       :: Maybe ActiveRepos,
-       solverSettingIndependentGoals  :: IndependentGoals,
-       solverSettingPreferOldest      :: PreferOldest
+       solverSettingIndependentGoals  :: IndependentGoals
        -- Things that only make sense for manual mode, not --local mode
        -- too much control!
      --solverSettingShadowPkgs        :: Bool,

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1076,10 +1076,7 @@ planPackages verbosity comp platform solver SolverSettings{..}
         -- installed for global packages, or prefer latest even for
         -- global packages. Perhaps should be configurable but with a
         -- different name than "upgrade-dependencies".
-      . setPreferenceDefault
-        (if Cabal.asBool solverSettingPreferOldest
-          then PreferAllOldest
-          else PreferLatestForSelected)
+      . setPreferenceDefault PreferLatestForSelected
                            {-(if solverSettingUpgradeDeps
                                 then PreferAllLatest
                                 else PreferLatestForSelected)-}

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -943,7 +943,6 @@ data FetchFlags = FetchFlags {
       fetchFineGrainedConflicts :: Flag FineGrainedConflicts,
       fetchMinimizeConflictSet :: Flag MinimizeConflictSet,
       fetchIndependentGoals :: Flag IndependentGoals,
-      fetchPreferOldest     :: Flag PreferOldest,
       fetchShadowPkgs       :: Flag ShadowPkgs,
       fetchStrongFlags      :: Flag StrongFlags,
       fetchAllowBootLibInstalls :: Flag AllowBootLibInstalls,
@@ -965,7 +964,6 @@ defaultFetchFlags = FetchFlags {
     fetchFineGrainedConflicts = Flag (FineGrainedConflicts True),
     fetchMinimizeConflictSet = Flag (MinimizeConflictSet False),
     fetchIndependentGoals = Flag (IndependentGoals False),
-    fetchPreferOldest     = Flag (PreferOldest False),
     fetchShadowPkgs       = Flag (ShadowPkgs False),
     fetchStrongFlags      = Flag (StrongFlags False),
     fetchAllowBootLibInstalls = Flag (AllowBootLibInstalls False),
@@ -1029,7 +1027,6 @@ fetchCommand = CommandUI {
                          fetchFineGrainedConflicts (\v flags -> flags { fetchFineGrainedConflicts = v })
                          fetchMinimizeConflictSet (\v flags -> flags { fetchMinimizeConflictSet = v })
                          fetchIndependentGoals (\v flags -> flags { fetchIndependentGoals = v })
-                         fetchPreferOldest     (\v flags -> flags { fetchPreferOldest = v })
                          fetchShadowPkgs       (\v flags -> flags { fetchShadowPkgs       = v })
                          fetchStrongFlags      (\v flags -> flags { fetchStrongFlags      = v })
                          fetchAllowBootLibInstalls (\v flags -> flags { fetchAllowBootLibInstalls = v })
@@ -1052,7 +1049,6 @@ data FreezeFlags = FreezeFlags {
       freezeFineGrainedConflicts :: Flag FineGrainedConflicts,
       freezeMinimizeConflictSet :: Flag MinimizeConflictSet,
       freezeIndependentGoals :: Flag IndependentGoals,
-      freezePreferOldest     :: Flag PreferOldest,
       freezeShadowPkgs       :: Flag ShadowPkgs,
       freezeStrongFlags      :: Flag StrongFlags,
       freezeAllowBootLibInstalls :: Flag AllowBootLibInstalls,
@@ -1072,7 +1068,6 @@ defaultFreezeFlags = FreezeFlags {
     freezeFineGrainedConflicts = Flag (FineGrainedConflicts True),
     freezeMinimizeConflictSet = Flag (MinimizeConflictSet False),
     freezeIndependentGoals = Flag (IndependentGoals False),
-    freezePreferOldest     = Flag (PreferOldest False),
     freezeShadowPkgs       = Flag (ShadowPkgs False),
     freezeStrongFlags      = Flag (StrongFlags False),
     freezeAllowBootLibInstalls = Flag (AllowBootLibInstalls False),
@@ -1127,7 +1122,6 @@ freezeCommand = CommandUI {
                          freezeFineGrainedConflicts (\v flags -> flags { freezeFineGrainedConflicts = v })
                          freezeMinimizeConflictSet (\v flags -> flags { freezeMinimizeConflictSet = v })
                          freezeIndependentGoals (\v flags -> flags { freezeIndependentGoals = v })
-                         freezePreferOldest     (\v flags -> flags { freezePreferOldest = v })
                          freezeShadowPkgs       (\v flags -> flags { freezeShadowPkgs       = v })
                          freezeStrongFlags      (\v flags -> flags { freezeStrongFlags      = v })
                          freezeAllowBootLibInstalls (\v flags -> flags { freezeAllowBootLibInstalls = v })
@@ -1562,7 +1556,6 @@ data InstallFlags = InstallFlags {
     installFineGrainedConflicts :: Flag FineGrainedConflicts,
     installMinimizeConflictSet :: Flag MinimizeConflictSet,
     installIndependentGoals :: Flag IndependentGoals,
-    installPreferOldest     :: Flag PreferOldest,
     installShadowPkgs       :: Flag ShadowPkgs,
     installStrongFlags      :: Flag StrongFlags,
     installAllowBootLibInstalls :: Flag AllowBootLibInstalls,
@@ -1605,7 +1598,6 @@ defaultInstallFlags = InstallFlags {
     installFineGrainedConflicts = Flag (FineGrainedConflicts True),
     installMinimizeConflictSet = Flag (MinimizeConflictSet False),
     installIndependentGoals= Flag (IndependentGoals False),
-    installPreferOldest    = Flag (PreferOldest False),
     installShadowPkgs      = Flag (ShadowPkgs False),
     installStrongFlags     = Flag (StrongFlags False),
     installAllowBootLibInstalls = Flag (AllowBootLibInstalls False),
@@ -1831,7 +1823,6 @@ installOptions showOrParseArgs =
                         installFineGrainedConflicts (\v flags -> flags { installFineGrainedConflicts = v })
                         installMinimizeConflictSet (\v flags -> flags { installMinimizeConflictSet = v })
                         installIndependentGoals (\v flags -> flags { installIndependentGoals = v })
-                        installPreferOldest     (\v flags -> flags { installPreferOldest = v })
                         installShadowPkgs       (\v flags -> flags { installShadowPkgs       = v })
                         installStrongFlags      (\v flags -> flags { installStrongFlags      = v })
                         installAllowBootLibInstalls (\v flags -> flags { installAllowBootLibInstalls = v })
@@ -2408,14 +2399,13 @@ optionSolverFlags :: ShowOrParseArgs
                   -> (flags -> Flag FineGrainedConflicts) -> (Flag FineGrainedConflicts -> flags -> flags)
                   -> (flags -> Flag MinimizeConflictSet) -> (Flag MinimizeConflictSet -> flags -> flags)
                   -> (flags -> Flag IndependentGoals) -> (Flag IndependentGoals -> flags -> flags)
-                  -> (flags -> Flag PreferOldest) -> (Flag PreferOldest -> flags -> flags)
                   -> (flags -> Flag ShadowPkgs)       -> (Flag ShadowPkgs       -> flags -> flags)
                   -> (flags -> Flag StrongFlags)      -> (Flag StrongFlags      -> flags -> flags)
                   -> (flags -> Flag AllowBootLibInstalls) -> (Flag AllowBootLibInstalls -> flags -> flags)
                   -> (flags -> Flag OnlyConstrained)  -> (Flag OnlyConstrained  -> flags -> flags)
                   -> [OptionField flags]
 optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg getcc setcc
-                  getfgc setfgc getmc setmc getig setig getpo setpo getsip setsip
+                  getfgc setfgc getmc setmc getig setig getsip setsip
                   getstrfl setstrfl getib setib getoc setoc =
   [ option [] ["max-backjumps"]
       ("Maximum number of backjumps allowed while solving (default: " ++ show defaultMaxBackjumps ++ "). Use a negative number to enable unlimited backtracking. Use 0 to disable backtracking completely.")
@@ -2448,11 +2438,6 @@ optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg getcc setcc
       "Treat several goals on the command line as independent. If several goals depend on the same package, different versions can be chosen."
       (fmap asBool . getig)
       (setig . fmap IndependentGoals)
-      (yesNoOpt showOrParseArgs)
-  , option [] ["prefer-oldest"]
-      "Prefer the oldest (instead of the latest) versions of packages available. Useful to determine lower bounds in the build-depends section."
-      (fmap asBool . getpo)
-      (setpo . fmap PreferOldest)
       (yesNoOpt showOrParseArgs)
   , option [] ["shadow-installed-packages"]
       "If multiple package instances of the same version are installed, treat all but one as shadowed."

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -479,7 +479,6 @@ instance Arbitrary ProjectConfigShared where
         projectConfigOnlyConstrained      <- arbitrary
         projectConfigPerComponent         <- arbitrary
         projectConfigIndependentGoals     <- arbitrary
-        projectConfigPreferOldest         <- arbitrary
         projectConfigProgPathExtra        <- toNubList <$> listOf arbitraryShortToken
         return ProjectConfigShared {..}
       where
@@ -519,7 +518,6 @@ instance Arbitrary ProjectConfigShared where
         <*> shrinker projectConfigOnlyConstrained
         <*> shrinker projectConfigPerComponent
         <*> shrinker projectConfigIndependentGoals
-        <*> shrinker projectConfigPreferOldest
         <*> shrinker projectConfigProgPathExtra
       where
         preShrink_Constraints  = map fst
@@ -796,9 +794,6 @@ instance Arbitrary MinimizeConflictSet where
 
 instance Arbitrary IndependentGoals where
     arbitrary = IndependentGoals <$> arbitrary
-
-instance Arbitrary PreferOldest where
-    arbitrary = PreferOldest <$> arbitrary
 
 instance Arbitrary StrongFlags where
     arbitrary = StrongFlags <$> arbitrary

--- a/cabal-install/tests/UnitTests/Distribution/Client/TreeDiffInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/TreeDiffInstances.hs
@@ -54,7 +54,6 @@ instance ToExpr OverwritePolicy
 instance ToExpr PackageConfig
 instance ToExpr PackageDB
 instance ToExpr PackageProperty
-instance ToExpr PreferOldest
 instance ToExpr PreSolver
 instance ToExpr ProjectConfig
 instance ToExpr ProjectConfigBuildOnly

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -733,7 +733,6 @@ exResolve :: ExampleDb
           -> FineGrainedConflicts
           -> MinimizeConflictSet
           -> IndependentGoals
-          -> PreferOldest
           -> ReorderGoals
           -> AllowBootLibInstalls
           -> OnlyConstrained
@@ -746,7 +745,7 @@ exResolve :: ExampleDb
           -> EnableAllTests
           -> Progress String String CI.SolverInstallPlan.SolverInstallPlan
 exResolve db exts langs pkgConfigDb targets mbj countConflicts
-          fineGrainedConflicts minimizeConflictSet indepGoals prefOldest reorder
+          fineGrainedConflicts minimizeConflictSet indepGoals reorder
           allowBootLibInstalls onlyConstrained enableBj solveExes goalOrder
           constraints prefs verbosity enableAllTests
     = resolveDependencies C.buildPlatform compiler pkgConfigDb Modular params
@@ -775,7 +774,6 @@ exResolve db exts langs pkgConfigDb targets mbj countConflicts
                    $ setFineGrainedConflicts fineGrainedConflicts
                    $ setMinimizeConflictSet minimizeConflictSet
                    $ setIndependentGoals indepGoals
-                   $ (if asBool prefOldest then setPreferenceDefault PreferAllOldest else id)
                    $ setReorderGoals reorder
                    $ setMaxBackjumps mbj
                    $ setAllowBootLibInstalls allowBootLibInstalls

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL/TestCaseUtils.hs
@@ -7,7 +7,6 @@ module UnitTests.Distribution.Solver.Modular.DSL.TestCaseUtils (
   , disableFineGrainedConflicts
   , minimizeConflictSet
   , independentGoals
-  , preferOldest
   , allowBootLibInstalls
   , onlyConstrained
   , disableBackjumping
@@ -67,10 +66,6 @@ minimizeConflictSet test =
 independentGoals :: SolverTest -> SolverTest
 independentGoals test = test { testIndepGoals = IndependentGoals True }
 
--- | Combinator to turn on --prefer-oldest
-preferOldest :: SolverTest -> SolverTest
-preferOldest test = test { testPreferOldest = PreferOldest True }
-
 allowBootLibInstalls :: SolverTest -> SolverTest
 allowBootLibInstalls test =
     test { testAllowBootLibInstalls = AllowBootLibInstalls True }
@@ -116,7 +111,6 @@ data SolverTest = SolverTest {
   , testFineGrainedConflicts :: FineGrainedConflicts
   , testMinimizeConflictSet  :: MinimizeConflictSet
   , testIndepGoals           :: IndependentGoals
-  , testPreferOldest         :: PreferOldest
   , testAllowBootLibInstalls :: AllowBootLibInstalls
   , testOnlyConstrained      :: OnlyConstrained
   , testEnableBackjumping    :: EnableBackjumping
@@ -214,7 +208,6 @@ mkTestExtLangPC exts langs mPkgConfigDb db label targets result = SolverTest {
   , testFineGrainedConflicts = FineGrainedConflicts True
   , testMinimizeConflictSet  = MinimizeConflictSet False
   , testIndepGoals           = IndependentGoals False
-  , testPreferOldest         = PreferOldest False
   , testAllowBootLibInstalls = AllowBootLibInstalls False
   , testOnlyConstrained      = OnlyConstrainedNone
   , testEnableBackjumping    = EnableBackjumping True
@@ -237,7 +230,7 @@ runTest SolverTest{..} = askOption $ \(OptionShowSolverLog showSolverLog) ->
                      testSupportedLangs testPkgConfigDb testTargets
                      testMaxBackjumps (CountConflicts True)
                      testFineGrainedConflicts testMinimizeConflictSet
-                     testIndepGoals testPreferOldest (ReorderGoals False) testAllowBootLibInstalls
+                     testIndepGoals (ReorderGoals False) testAllowBootLibInstalls
                      testOnlyConstrained testEnableBackjumping testSolveExecutables
                      (sortGoals <$> testGoalOrder) testConstraints
                      testSoftConstraints testVerbosity testEnableAllTests

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -57,7 +57,7 @@ tests = [
                 r2 = solve' mGoalOrder2 test { testTargets = targets2 }
                 solve' goalOrder =
                     solve (EnableBackjumping True) (FineGrainedConflicts True)
-                          (ReorderGoals False) (CountConflicts True) indepGoals (PreferOldest False)
+                          (ReorderGoals False) (CountConflicts True) indepGoals
                           (getBlind <$> goalOrder)
                 targets = testTargets test
                 targets2 = case targetOrder of
@@ -74,7 +74,7 @@ tests = [
                 r2 = solve' (IndependentGoals True)  test
                 solve' indep =
                     solve (EnableBackjumping True) (FineGrainedConflicts True)
-                          reorderGoals (CountConflicts True) indep (PreferOldest False)Nothing
+                          reorderGoals (CountConflicts True) indep Nothing
              in counterexample (showResults r1 r2) $
                 noneReachedBackjumpLimit [r1, r2] ==>
                 isRight (resultPlan r1) `implies` isRight (resultPlan r2)
@@ -85,7 +85,7 @@ tests = [
                 r2 = solve' (EnableBackjumping False) test
                 solve' enableBj =
                     solve enableBj (FineGrainedConflicts False) reorderGoals
-                          (CountConflicts True) indepGoals (PreferOldest False) Nothing
+                          (CountConflicts True) indepGoals Nothing
              in counterexample (showResults r1 r2) $
                 noneReachedBackjumpLimit [r1, r2] ==>
                 isRight (resultPlan r1) === isRight (resultPlan r2)
@@ -96,18 +96,7 @@ tests = [
                 r2 = solve' (FineGrainedConflicts False) test
                 solve' fineGrainedConflicts =
                     solve (EnableBackjumping True) fineGrainedConflicts
-                    reorderGoals (CountConflicts True) indepGoals (PreferOldest False) Nothing
-             in counterexample (showResults r1 r2) $
-                noneReachedBackjumpLimit [r1, r2] ==>
-                isRight (resultPlan r1) === isRight (resultPlan r2)
-
-    , testPropertyWithSeed "prefer oldest does not affect solvability" $
-          \test reorderGoals indepGoals ->
-            let r1 = solve' (PreferOldest True)  test
-                r2 = solve' (PreferOldest False) test
-                solve' prefOldest  =
-                    solve (EnableBackjumping True) (FineGrainedConflicts True)
-                    reorderGoals (CountConflicts True) indepGoals prefOldest Nothing
+                    reorderGoals (CountConflicts True) indepGoals Nothing
              in counterexample (showResults r1 r2) $
                 noneReachedBackjumpLimit [r1, r2] ==>
                 isRight (resultPlan r1) === isRight (resultPlan r2)
@@ -127,7 +116,7 @@ tests = [
                 r2 = solve' (EnableBackjumping False) test
                 solve' enableBj =
                     solve enableBj (FineGrainedConflicts False) reorderGoals
-                          (CountConflicts False) indepGoals (PreferOldest False) Nothing
+                          (CountConflicts False) indepGoals Nothing
              in counterexample (showResults r1 r2) $
                 noneReachedBackjumpLimit [r1, r2] ==>
                 resultPlan r1 === resultPlan r2
@@ -139,7 +128,7 @@ tests = [
                 r2 = solve' (FineGrainedConflicts False) test
                 solve' fineGrainedConflicts =
                     solve (EnableBackjumping True) fineGrainedConflicts
-                          reorderGoals (CountConflicts False) indepGoals (PreferOldest False) Nothing
+                          reorderGoals (CountConflicts False) indepGoals Nothing
              in counterexample (showResults r1 r2) $
                 noneReachedBackjumpLimit [r1, r2] ==>
                 resultPlan r1 === resultPlan r2
@@ -174,11 +163,10 @@ solve :: EnableBackjumping
       -> ReorderGoals
       -> CountConflicts
       -> IndependentGoals
-      -> PreferOldest
       -> Maybe VarOrdering
       -> SolverTest
       -> Result
-solve enableBj fineGrainedConflicts reorder countConflicts indep prefOldest goalOrder test =
+solve enableBj fineGrainedConflicts reorder countConflicts indep goalOrder test =
   let (lg, result) =
         runProgress $ exResolve (unTestDb (testDb test)) Nothing Nothing
                   (pkgConfigDbFromList [])
@@ -187,7 +175,7 @@ solve enableBj fineGrainedConflicts reorder countConflicts indep prefOldest goal
                   -- too much time and memory.
                   (Just defaultMaxBackjumps)
                   countConflicts fineGrainedConflicts
-                  (MinimizeConflictSet False) indep prefOldest reorder
+                  (MinimizeConflictSet False) indep reorder
                   (AllowBootLibInstalls False) OnlyConstrainedNone enableBj
                   (SolveExecutables True) (unVarOrdering <$> goalOrder)
                   (testConstraints test) (testPreferences test) normal

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -30,8 +30,6 @@ tests = [
       testGroup "Simple dependencies" [
           runTest $         mkTest db1 "alreadyInstalled"   ["A"]      (solverSuccess [])
         , runTest $         mkTest db1 "installLatest"      ["B"]      (solverSuccess [("B", 2)])
-        , runTest $ preferOldest
-                  $         mkTest db1 "installOldest"      ["B"]      (solverSuccess [("B", 1)])
         , runTest $         mkTest db1 "simpleDep1"         ["C"]      (solverSuccess [("B", 1), ("C", 1)])
         , runTest $         mkTest db1 "simpleDep2"         ["D"]      (solverSuccess [("B", 2), ("D", 1)])
         , runTest $         mkTest db1 "failTwoVersions"    ["C", "D"] anySolverFailure

--- a/changelog.d/pr-8261
+++ b/changelog.d/pr-8261
@@ -1,9 +1,0 @@
-synopsis: Implement --prefer-oldest
-packages: cabal-install
-prs: #8261
-
-description: {
-
-- Implement `--prefer-oldest` flag for Cabal solver, which tries to find a build plan with the oldest versions possible. This is useful to establish lower bounds.
-
-}

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -1726,22 +1726,4 @@ Most users generally won't need these.
     The command line variant of this field is
     ``--cabal-lib-version=1.24.0.1``.
 
-.. cfg-field:: prefer-oldest: boolean
-               --prefer-oldest
-               --no-prefer-oldest
-    :synopsis: Prefer the oldest versions of packages available.
-    :since:    3.8
-
-    :default:  False
-
-    By default, when solver has a choice of multiple versions of the same
-    package, it will first try to derive a build plan with the latest
-    version. This flag switches the behaviour, making the solver
-    to prefer the oldest packages available.
-
-    The primary use case is to help users in establishing lower bounds
-    of upstream dependencies.
-
-    The command line variant of this field is ``--(no-)prefer-oldest``.
-
 .. include:: references.inc


### PR DESCRIPTION
It's a (library) breaking change:
https://github.com/haskell/cabal/pull/8261#discussion_r945548996

This reverts commit d8ad036d6fae073bb1e039e1006397d6efdc3637.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
