### PR TITLE
Exclude CI job 8.10.7 on Windows that corrupts all CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,6 +40,9 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         ghc: ["9.2.3", "9.0.2", "8.10.7", "8.8.4", "8.6.5", "8.4.4"]
         exclude:
+          # corrupts GHA cache or the fabric of reality itself, see https://github.com/haskell/cabal/issues/8356
+          - os: "windows-latest"
+            ghc: "8.10.7"
           # lot of segfaults caused by ghc bugs
           - os: "windows-latest"
             ghc: "8.8.4"

--- a/cabal-testsuite/PackageTests/NewSdist/DeterministicTrivial/deterministic.test.hs
+++ b/cabal-testsuite/PackageTests/NewSdist/DeterministicTrivial/deterministic.test.hs
@@ -1,12 +1,9 @@
 import Test.Cabal.Prelude
 import qualified Data.ByteString as BS
--- import qualified Data.ByteString.Base16 as BS16
--- import qualified Crypto.Hash.SHA256 as SHA256
+import qualified Data.ByteString.Base16 as BS16
+import qualified Crypto.Hash.SHA256 as SHA256
 import System.FilePath
     ( (</>) )
-
-    -- Note: we cannot simply use `expectBroken` or `skip` or similar
-    -- becuase this test fails on imports (see #8357).
 
 main = cabalTest $ do
     cabal "v2-sdist" ["deterministic"]
@@ -24,6 +21,4 @@ main = cabalTest $ do
     known <- liftIO (BS.readFile knownSdist)
     unknown <- liftIO (BS.readFile mySdist)
 
-    skipIf "#8356" True -- bogus, just to indicate that the test is skipped
-    assertEqual "hashes didn't match for sdist" True True
-    -- assertEqual "hashes didn't match for sdist" (BS16.encode $ SHA256.hash known) (BS16.encode $ SHA256.hash unknown)
+    assertEqual "hashes didn't match for sdist" (BS16.encode $ SHA256.hash known) (BS16.encode $ SHA256.hash unknown)


### PR DESCRIPTION
See https://github.com/haskell/cabal/issues/8356 and https://github.com/haskell/cabal/pull/8385.