### PR TITLE
Updated warning message to output on stderr

### DIFF
--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -149,7 +149,7 @@ import Distribution.Simple.Program.Db (reconfigurePrograms)
 import qualified Distribution.Simple.Setup as Cabal
 import Distribution.Simple.Utils
          ( cabalVersion, die', dieNoVerbosity, info, notice, topHandler
-         , findPackageDesc, tryFindPackageDesc, createDirectoryIfMissingVerbose )
+         , findPackageDesc, tryFindPackageDesc, createDirectoryIfMissingVerbose, warn )
 import Distribution.Text
          ( display )
 import Distribution.Verbosity as Verbosity
@@ -192,10 +192,10 @@ main = do
 warnIfAssertionsAreEnabled :: IO ()
 warnIfAssertionsAreEnabled =
   assert False (return ()) `catch`
-  (\(_e :: AssertionFailed) -> hPutStrLn stderr assertionsEnabledMsg)
+  (\(_e :: AssertionFailed) -> warn normal assertionsEnabledMsg)
   where
     assertionsEnabledMsg =
-      "Warning: this is a debug build of cabal-install with assertions enabled."
+      "this is a debug build of cabal-install with assertions enabled."
 
 mainWorker :: [String] -> IO ()
 mainWorker args = do

--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -192,7 +192,7 @@ main = do
 warnIfAssertionsAreEnabled :: IO ()
 warnIfAssertionsAreEnabled =
   assert False (return ()) `catch`
-  (\(_e :: AssertionFailed) -> putStrLn assertionsEnabledMsg)
+  (\(_e :: AssertionFailed) -> hPutStrLn stderr assertionsEnabledMsg)
   where
     assertionsEnabledMsg =
       "Warning: this is a debug build of cabal-install with assertions enabled."


### PR DESCRIPTION
This Fixes #8393
The message warning about assertions being enabled was previously being output to the stdout stream rather than stderr.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
