### PR TITLE
Bump cabal-bootstrap-gen to GHC 9.2.4 ecosystem.

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -5,29 +5,29 @@ on a new platform. If you already have a functional (if dated) cabal-install
 please rather run `cabal v2-install`.
 
 The typical usage is porting to a new linux architecture,
-then the `linux-ghcvec.json` file is available in `bootstrap/` folder:
+then the `linux-$GHCVER.json` file is available in `bootstrap/` folder:
 
 On a (linux) system you are bootstrapping, run
 
-    ./bootstrap/bootstrap.py -d ./bootstrap/linux-ghcver.json -w /path/to-ghc
+    ./bootstrap/bootstrap.py -d ./bootstrap/linux-$GHCVER.json -w /path/to-ghc
 
 from the top directory of the source checkout.
 
-To generate the `platform-ghcver` files for other platforms, do:
+To generate the `$PLATFORM-$GHCVER` files for other platforms, do:
 
   1. On a system with functional cabal-install, install the same GHC version
      as you will use to bootstrap on the host system.
 
-  2. Build a dependency description file (`platform-ghcver.json`, e.g. `linux-8.8.3.json`) by running:
+  2. Build a dependency description file (`$PLATFORM-$GHCVER.json`, e.g. `linux-8.8.4.json`) by running:
 
        ```sh
        cabal v2-build --with-compiler=/path/to/ghc --dry-run cabal-install:exe:cabal
-       cp dist-newstyle/cache/plan.json bootstrap/platform-ghcver.plan.json
+       cp dist-newstyle/cache/plan.json bootstrap/$PLATFORM-$GHCVER.plan.json
        cd bootstrap
-       cabal v2-run -v0 cabal-bootstrap-gen -- platform-ghcver.plan.json | tee platform-ghcver.json
+       cabal v2-run -v0 cabal-bootstrap-gen -- $PLATFORM-$GHCVER.plan.json | tee $PLATFORM-$GHCVER.json
        ```
 
-  3. You may need to tweak `bootstrap/platform-ghcver.json` file manually,
+  3. You may need to tweak `bootstrap/$PLATFORM-$GHCVER.json` file manually,
      for example toggle flags.
 
-There are rules in top-level `Makefile` for generation of these files.
+There are rules in the top-level `Makefile` for generation of these files.

--- a/bootstrap/cabal-bootstrap-gen.cabal
+++ b/bootstrap/cabal-bootstrap-gen.cabal
@@ -8,13 +8,18 @@ executable cabal-bootstrap-gen
   ghc-options:      -Wall
   main-is:          Main.hs
   build-depends:
-    , aeson                  ^>=1.5.2.0
-    , base                   ^>=4.12.0.0 || ^>=4.13.0.0 || ^>=4.14.0.0
-    , bytestring             ^>=0.10.8.2 || ^>= 0.11.0.0
-    , Cabal                  ^>=3.2.0.0
-    , cabal-install-parsers  ^>=0.3.0.1
+    , aeson                  ^>=1.5.2.0  || ^>=2.0.3.0
+        -- Not yet picked up: (*)        || ^>=2.1.0.0
+    , base                   ^>=4.12.0.0 || ^>=4.13.0.0 || ^>=4.14.0.0 || ^>=4.15.0.0 || ^>=4.16.0.0
+    , bytestring             ^>=0.10.8.2 || ^>=0.11.0.0
+    , Cabal                  ^>=3.2.0.0  || ^>=3.4.1.0  || ^>=3.6.3.0
+        -- Not yet picked up: (*)        || ^>=3.8.1.0
+    , cabal-install-parsers  ^>=0.3.0.1  || ^>=0.4.5
     , cabal-plan             ^>=0.7.0.0
     , containers             ^>=0.6.0.1
     , text                   ^>=1.2.3.0
+        -- Not yet picked up: (*)        || ^>=2.0.1
     , topograph              ^>=1.0.0.1
     , transformers           ^>=0.5.6.2
+        -- Not yet picked up: (*)        || ^>=0.6.0.4
+        -- (*) as of 2022-08-19

--- a/bootstrap/src/Main.hs
+++ b/bootstrap/src/Main.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Main (main) where
 
 import Control.Monad      (when)
@@ -34,9 +36,15 @@ main = do
 
 main1 :: FilePath -> IO ()
 main1 planPath = do
-    meta <- I.cachedHackageMetadata
+    meta <- getMap <$> I.cachedHackageMetadata
     plan <- P.decodePlanJson planPath
     main2 meta plan
+  where
+#if MIN_VERSION_cabal_install_parsers(0,4,0)
+    getMap = snd
+#else
+    getMap = id
+#endif
 
 main2 :: Map.Map C.PackageName I.PackageInfo -> P.PlanJson -> IO ()
 main2 meta plan = do


### PR DESCRIPTION
Bump `cabal-bootstrap-gen` to GHC 9.2.4 ecosystem.

I ran `cabal outdated`, relaxed upper bounds, and then took away these highest versions which were not picked up by `cabal build -w ghc-9.2.4` (according to `cabal-plan`).

Also polished README a bit.

