### PR TITLE
cabal man handles $PAGER with more than one word now

### DIFF
--- a/changelog.d/issue-8405
+++ b/changelog.d/issue-8405
@@ -1,0 +1,14 @@
+synopsis: `cabal man` handles $PAGER containing arguments now
+packages: cabal-install
+prs: #8353
+issues: #8405
+
+description: {
+
+Things like `PAGER="less -FX" cabal man` work now.
+
+There's a slight change in the default behavior. We still use `less -R` as the default,
+but if the user passes `PAGER=less`, we won't add -R to that, unlike before. This is
+reasonable, as the user should be able to set the variable as they see fit.
+
+}


### PR DESCRIPTION
Fix #8405

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
