### PR TITLE
Add some debugging to CmdRun/Terminate test

### DIFF
--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Terminate/Main.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Terminate/Main.hs
@@ -6,9 +6,9 @@ import System.Exit (exitFailure)
 main = do
   mainThreadId <- myThreadId
   Signal.installHandler Signal.sigTERM (Signal.Catch $ killThread mainThreadId) Nothing
-  do
+  (do
     putStrLn "about to sleep"
     writeFile "exe.run" "up and running"
     threadDelay 10000000 -- 10s
-    putStrLn "done sleeping"
-  `finally` putStrLn "exiting"
+    putStrLn "done sleeping")
+    `finally` putStrLn "exiting"

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Terminate/Main.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Terminate/Main.hs
@@ -2,13 +2,21 @@ import Control.Concurrent (killThread, threadDelay, myThreadId)
 import Control.Exception (finally)
 import qualified System.Posix.Signals as Signal
 import System.Exit (exitFailure)
+import qualified Data.Time.Clock as Time
+import qualified Data.Time.Format as Time
 
 main = do
+  -- timestamped logging to aid with #8416
+  let log msg = do
+        ts <- Time.getCurrentTime
+        let tsfmt = Time.formatTime Time.defaultTimeLocale "%H:%M:%S.%q" ts
+        putStrLn $ tsfmt <> " [exe       ] " <> msg
   mainThreadId <- myThreadId
   Signal.installHandler Signal.sigTERM (Signal.Catch $ killThread mainThreadId) Nothing
   (do
-    putStrLn "about to sleep"
+    log "about to write file"
     writeFile "exe.run" "up and running"
+    log "about to sleep"
     threadDelay 10000000 -- 10s
-    putStrLn "done sleeping")
-    `finally` putStrLn "exiting"
+    log "done sleeping")
+    `finally` log "exiting"

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRun/Terminate/RunKill.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRun/Terminate/RunKill.cabal
@@ -5,5 +5,5 @@ cabal-version: >= 1.10
 
 executable exe
   default-language: Haskell2010
-  build-depends: base, process, unix
+  build-depends: base, process, time, unix
   main-is: Main.hs


### PR DESCRIPTION
Compare #8416. This adds timestamped debug output, so that next time it fails we can tell a bit better what went wrong.