### PR TITLE
ci: use ubuntu-latest instead of ubuntu-18.04

### DIFF
--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   meta:
     name: Meta checks
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     # This job is not run in a container, any recent GHC should be fine
     steps:
       - name: Set PATH
@@ -49,7 +49,7 @@ jobs:
           git diff-files -p --exit-code
   doctest:
     name: Doctest Cabal
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set PATH
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -172,7 +172,7 @@ jobs:
 
   validate-old-ghcs:
     name: Validate old ghcs ${{ matrix.extra-ghc }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: validate
     # This job needs an older ubuntu (16.04) cause
     # the required old ghcs using the `-dyn` flavour
@@ -286,7 +286,7 @@ jobs:
   validate-post-job:
     if: always()
     name: Validate post job
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     # IMPORTANT! Any job added to the workflow should be added here too
     needs: [validate, validate-old-ghcs, dogfooding]
 


### PR DESCRIPTION
Builds with ubuntu-18.04 are failing with

    This is a scheduled Ubuntu-18.04 brownout.

due to deprecation of the action runner:

    https://github.com/actions/runner-images/issues/6002


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
