### PR TITLE
Print debug warning on stderr, not stdout.

### DIFF
--- a/cabal-install/main/Main.hs
+++ b/cabal-install/main/Main.hs
@@ -162,7 +162,7 @@ import System.Environment       (getArgs, getProgName)
 import System.FilePath          ( dropExtension, splitExtension
                                 , takeExtension, (</>), (<.>) )
 import System.IO                ( BufferMode(LineBuffering), hSetBuffering
-                                , stderr, stdout )
+                                , stderr, stdout, hPutStrLn )
 import System.Directory         ( doesFileExist, getCurrentDirectory
                                 , withCurrentDirectory)
 import Data.Monoid              (Any(..))
@@ -192,7 +192,7 @@ main = do
 warnIfAssertionsAreEnabled :: IO ()
 warnIfAssertionsAreEnabled =
   assert False (return ()) `catch`
-  (\(_e :: AssertionFailed) -> putStrLn assertionsEnabledMsg)
+  (\(_e :: AssertionFailed) -> hPutStrLn stderr assertionsEnabledMsg)
   where
     assertionsEnabledMsg =
       "Warning: this is a debug build of cabal-install with assertions enabled."


### PR DESCRIPTION
This prevents things like list-bin from being broken.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
