### PR TITLE
Remove warning on option -threaded when building libraries

### DIFF
--- a/Cabal-tests/tests/ParserTests/regressions/issue-774.check
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-774.check
@@ -2,6 +2,5 @@ issue-774.cabal:13:22: Packages with 'cabal-version: 1.12' or later should speci
 No 'category' field.
 No 'maintainer' field.
 The 'license' field is missing or is NONE.
-'ghc-options: -threaded' has no effect for libraries. It should only be used for executables.
 'ghc-options: -rtsopts' has no effect for libraries. It should only be used for executables.
 'ghc-options: -with-rtsopts' has no effect for libraries. It should only be used for executables.

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -187,7 +187,6 @@ data CheckExplanation =
         | OptSplitObjs String
         | OptWls String
         | OptExts String
-        | OptThreaded String
         | OptRts String
         | OptWithRts String
         | COptONumber String String
@@ -494,9 +493,6 @@ ppExplanation (OptWls fieldName) =
 ppExplanation (OptExts fieldName) =
     "Instead of '" ++ fieldName ++ ": -fglasgow-exts' it is preferable to use "
       ++ "the 'extensions' field."
-ppExplanation (OptThreaded fieldName) =
-    "'" ++ fieldName ++ ": -threaded' has no effect for libraries. It should "
-      ++ "only be used for executables."
 ppExplanation (OptRts fieldName) =
     "'" ++ fieldName ++ ": -rtsopts' has no effect for libraries. It should "
       ++ "only be used for executables."
@@ -1375,9 +1371,6 @@ checkGhcOptions fieldName getOptions pkg =
 
   , checkFlags ["-fglasgow-exts"] $
       PackageDistSuspicious (OptExts fieldName)
-
-  , check ("-threaded" `elem` lib_ghc_options) $
-      PackageBuildWarning (OptThreaded fieldName)
 
   , check ("-rtsopts" `elem` lib_ghc_options) $
       PackageBuildWarning (OptRts fieldName)

--- a/changelog.d/pr-8432
+++ b/changelog.d/pr-8432
@@ -1,0 +1,15 @@
+synopsis: Remove warning on option -threaded when building libraries
+packages: Cabal
+prs: #8432
+issues: #8431 #774
+
+description: {
+
+- Accompanied by option `-flink-rts`, option `-threaded` defines the flavour of
+  the ghc RTS library the built library will be linked against. Note that bare
+  ghc does not warn when option `-threaded` is used for building a library
+  either.
+- Note that the changes require modification of the regression check for issue
+  #774 which can be regarded as a proper test for this PR.
+
+}


### PR DESCRIPTION
Fixes #8431. Accompanied by option -flink-rts, option -threaded defines
the flavour of the ghc RTS library the built library will be linked
against. Note that bare ghc does not warn when option -threaded is used
for building a library either.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
