### PR TITLE
[ mergify ] fix condition of 'merge delay passed' label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
 
   # implementing PR delay logic: apply a label after 2 days of inactivity
-  # the label will allow Mergify to merge (see #8442, #8446)
+  # the label will allow Mergify to merge (see #8442, #8448)
   - actions:
       label:
         add:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
 
   # implementing PR delay logic: apply a label after 2 days of inactivity
-  # the label will allow Mergify to merge (see #8442)
+  # the label will allow Mergify to merge (see #8442, #8446)
   - actions:
       label:
         add:
@@ -9,6 +9,8 @@ pull_request_rules:
     name: Wait for 2 days before validating merge
     conditions:
       - updated-at<2 days ago
+      - label=merge me
+      - '#approved-reviews-by>=2'
 
   # rebase+merge strategy
   - actions:


### PR DESCRIPTION
Add the same conditions that we apply for the last stage of PR: 2 approvers and merge-me label. Otherwise, we get a lot of old PRs as well as some current ones getting the label prematurely.

As discussed here: https://github.com/haskell/cabal/pull/7386#issuecomment-1235254158

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
