### PR TITLE
"Build profile" now reflects optimization level set in global config

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -859,8 +859,10 @@ printPlan verbosity
           ProjectBaseContext {
             buildSettings = BuildTimeSettings{buildSettingDryRun},
             projectConfig = ProjectConfig {
+              projectConfigAllPackages =
+                  PackageConfig {packageConfigOptimization = globalOptimization},
               projectConfigLocalPackages =
-                  PackageConfig {packageConfigOptimization}
+                  PackageConfig {packageConfigOptimization = localOptimization}
             }
           }
           ProjectBuildContext {
@@ -994,7 +996,7 @@ printPlan verbosity
     showBuildProfile :: String
     showBuildProfile = "Build profile: " ++ unwords [
       "-w " ++ (showCompilerId . pkgConfigCompiler) elaboratedShared,
-      "-O" ++  (case packageConfigOptimization of
+      "-O" ++  (case globalOptimization <> localOptimization of -- if local is not set, read global
                 Setup.Flag NoOptimisation      -> "0"
                 Setup.Flag NormalOptimisation  -> "1"
                 Setup.Flag MaximumOptimisation -> "2"

--- a/cabal-testsuite/PackageTests/ConfigFile/T8487/cabal.out
+++ b/cabal-testsuite/PackageTests/ConfigFile/T8487/cabal.out
@@ -1,0 +1,8 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O2
+In order, the following will be built:
+ - test-0.1.0.0 (lib) (first run)
+Configuring library for test-0.1.0.0..
+Preprocessing library for test-0.1.0.0..
+Building library for test-0.1.0.0..

--- a/cabal-testsuite/PackageTests/ConfigFile/T8487/cabal.project
+++ b/cabal-testsuite/PackageTests/ConfigFile/T8487/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/ConfigFile/T8487/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ConfigFile/T8487/cabal.test.hs
@@ -1,0 +1,7 @@
+-- 2022-09-20, issue #8487
+--
+
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+  cabalG [ "--config-file", "config.file" ] "build" [ "test" ]

--- a/cabal-testsuite/PackageTests/ConfigFile/T8487/config.file
+++ b/cabal-testsuite/PackageTests/ConfigFile/T8487/config.file
@@ -1,0 +1,1 @@
+optimization: 2

--- a/cabal-testsuite/PackageTests/ConfigFile/T8487/src/MyLib.hs
+++ b/cabal-testsuite/PackageTests/ConfigFile/T8487/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/cabal-testsuite/PackageTests/ConfigFile/T8487/test.cabal
+++ b/cabal-testsuite/PackageTests/ConfigFile/T8487/test.cabal
@@ -1,0 +1,13 @@
+cabal-version:   3.0
+name:            test
+version:         0.1.0.0
+license:         NONE
+author:          a.pelenitsyn@gmail.com
+maintainer:      Artem Pelenitsyn
+build-type:      Simple
+
+library
+    exposed-modules:  MyLib
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/changelog.d/issue-8487
+++ b/changelog.d/issue-8487
@@ -1,0 +1,12 @@
+synopsis: "Build profile" message now reflects optimization level set in global config
+packages: cabal-install
+prs: #8488
+issues: #8487
+
+description: {
+
+Imagine you have `optimization: 2` in your `~/.cabal/config`, and you call `cabal build`
+in a project that doesn't have optimization level explicitly set in its project file.
+You will still see 'Build profile: -w ghc-<VER> -O1'. This is incorrect and was fixed
+in this patch: now you'll see '-O2'.
+}


### PR DESCRIPTION
It still reports local config's optimization level if it was set.

Fix #8487.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
