### PR TITLE
add DeepSubsumption and TypeData language extensions (ghc proposals 511 & 106)

### DIFF
--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -583,6 +583,9 @@ data KnownExtension =
   -- | Enable explicit type applications with the syntax @id \@Int@.
   | TypeApplications
 
+  -- | Enable @type data@ declarations, defining constructors at the type level.
+  | TypeData
+
   -- | Dissolve the distinction between types and kinds, allowing the compiler
   -- to reason about kind equality and therefore enabling GADTs to be promoted
   -- to the type-level.

--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -165,6 +165,11 @@ data KnownExtension =
   -- | Enable the dreaded monomorphism restriction.
   | MonomorphismRestriction
 
+  -- | Enable deep subsumption, relaxing the simple subsumption rules,
+  -- implicitly inserting eta-expansions when matching up function types
+  -- with different quantification structures.
+  | DeepSubsumption
+
   -- | Allow a specification attached to a multi-parameter type class
   -- which indicates that some parameters are entirely determined by
   -- others. The implementation will check that this property holds
@@ -499,6 +504,9 @@ data KnownExtension =
   -- | Enable datatype promotion.
   | DataKinds
 
+  -- | Enable @type data@ declarations, defining constructors at the type level.
+  | TypeData
+
   -- | Enable parallel arrays syntax (@[:@, @:]@) for /Data Parallel Haskell/.
   | ParallelArrays
 
@@ -582,9 +590,6 @@ data KnownExtension =
 
   -- | Enable explicit type applications with the syntax @id \@Int@.
   | TypeApplications
-
-  -- | Enable @type data@ declarations, defining constructors at the type level.
-  | TypeData
 
   -- | Dissolve the distinction between types and kinds, allowing the compiler
   -- to reason about kind equality and therefore enabling GADTs to be promoted

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -27,9 +27,9 @@ tests = testGroup "Distribution.Utils.Structured"
     -- The difference is in encoding of newtypes
 #if MIN_VERSION_base(4,7,0)
     , testCase "GenericPackageDescription" $
-      md5Check (Proxy :: Proxy GenericPackageDescription) 0xb4f9bf3ec021f6bf9cdc19265d8a8d77
+      md5Check (Proxy :: Proxy GenericPackageDescription) 0x227c04c63afe656449d6feb7220e5194
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0x2589e2dc74afe5adf2a49383fd847d23
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0x4ec3f95ae75fea8422b1c5e15724f1a4
 #endif
     ]
 

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -27,9 +27,9 @@ tests = testGroup "Distribution.Utils.Structured"
     -- The difference is in encoding of newtypes
 #if MIN_VERSION_base(4,7,0)
     , testCase "GenericPackageDescription" $
-      md5Check (Proxy :: Proxy GenericPackageDescription) 0xaf3d4c667a8f019c98a45451419ad71c
+      md5Check (Proxy :: Proxy GenericPackageDescription) 0xb4f9bf3ec021f6bf9cdc19265d8a8d77
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0x8ef5a39cb640e4340cf5c43a8300ff94
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0x2589e2dc74afe5adf2a49383fd847d23
 #endif
     ]
 

--- a/changelog.d/pr-8493
+++ b/changelog.d/pr-8493
@@ -1,10 +1,11 @@
-synopsis: Add language extension TypeData
+synopsis: Add language extensions DeepSubsumption and TypeData
 packages: Cabal-syntax
 prs: #8493
 significance: significant
 
 description: {
 
+- adds support for the DeepSubsumption language extension (GHC proposal #511)
 - adds support for the TypeData language extension (GHC proposal #106)
 
 }

--- a/changelog.d/pr-8493
+++ b/changelog.d/pr-8493
@@ -5,6 +5,6 @@ significance: significant
 
 description: {
 
-- adds the TypeData language extension (ghc extension 106)
+- adds support for the TypeData language extension (GHC proposal #106)
 
 }

--- a/changelog.d/pr-8493
+++ b/changelog.d/pr-8493
@@ -1,0 +1,10 @@
+synopsis: Add language extension TypeData
+packages: Cabal-syntax
+prs: #8493
+significance: significant
+
+description: {
+
+- adds the TypeData language extension (ghc extension 106)
+
+}

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -160,6 +160,7 @@ syn keyword cabalExtension contained
   \ DataKinds
   \ DatatypeContexts
   \ DefaultSignatures
+  \ DeepSubsumption
   \ DeriveAnyClass
   \ DeriveDataTypeable
   \ DeriveFoldable

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -266,6 +266,7 @@ syn keyword cabalExtension contained
   \ TransformListComp
   \ TupleSections
   \ TypeApplications
+  \ TypeData
   \ TypeFamilies
   \ TypeFamilyDependencies
   \ TypeInType


### PR DESCRIPTION
This change adds the `TypeData` language extension (ghc extension [106](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0106-type-data.rst). GHC merge request [!8962](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8962) has been approved.