### PR TITLE
Work around CI problem from ghcup switch to GHC 9.2

### DIFF
--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -69,8 +69,8 @@ jobs:
       - name: ghcup
         run: |
           ghcup config set cache true
-          ghcup install ghc recommended
-          ghcup set ghc recommended
+          ghcup install ghc 8.10.7
+          ghcup set ghc 8.10.7
       - name: Update Hackage index
         run: cabal v2-update
       - name: Install doctest

--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -22,7 +22,7 @@ executable gen-spdx
     , bytestring
     , containers
     , Diff                  ^>=0.4
-    , lens                  ^>=4.18.1 || ^>=4.19.1 || ^>=5.0.1
+    , lens                  ^>=4.18.1 || ^>=4.19.1 || ^>=5.0.1 || ^>=5.2
     , optparse-applicative  ^>=0.15.1.0 || ^>=0.16.0.0
     , text
     , zinza                 ^>=0.2
@@ -39,7 +39,7 @@ executable gen-spdx-exc
     , bytestring
     , containers
     , Diff                  ^>=0.4
-    , lens                  ^>=4.18.1 || ^>=4.19.1 || ^>=5.0.1
+    , lens                  ^>=4.18.1 || ^>=4.19.1 || ^>=5.0.1 || ^>=5.2
     , optparse-applicative  ^>=0.15.1.0 || ^>=0.16.0.0
     , text
     , zinza                 ^>=0.2

--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -17,7 +17,7 @@ executable gen-spdx
   hs-source-dirs:   src
   ghc-options:      -Wall
   build-depends:
-    , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0
+    , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.1.1.0
     , base                  >=4.10     && <4.17
     , bytestring
     , containers
@@ -34,7 +34,7 @@ executable gen-spdx-exc
   hs-source-dirs:   src
   ghc-options:      -Wall
   build-depends:
-    , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0
+    , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.1.1.0
     , base                  >=4.10     && <4.17
     , bytestring
     , containers

--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -18,7 +18,7 @@ executable gen-spdx
   ghc-options:      -Wall
   build-depends:
     , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0
-    , base                  >=4.10     && <4.16
+    , base                  >=4.10     && <4.17
     , bytestring
     , containers
     , Diff                  ^>=0.4
@@ -35,7 +35,7 @@ executable gen-spdx-exc
   ghc-options:      -Wall
   build-depends:
     , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0
-    , base                  >=4.10     && <4.16
+    , base                  >=4.10     && <4.17
     , bytestring
     , containers
     , Diff                  ^>=0.4


### PR DESCRIPTION
This is a workaround for #7798 based on the theory that the recent CI breakage is caused by GHA bumping GHC to 9.4 (I'm quite surprised, but OTOH 9.4 is a good release and IIRC an LTS release).

Edit: a correction: it seems to be GHC 9.2. Much less surprising.

Edit2: actually, it seems this was not GHA upgrading GHC, but ghcup changing the "recommended" version and our scripts install that version