### PR TITLE
Stick to GHC 8.10.7 in CI until changelog-d is updated and update CI job names to permit making them mandatory in Settings

### DIFF
--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -1,4 +1,4 @@
-name: Changelogs
+name: Assorted
 
 on:
   push:
@@ -21,6 +21,7 @@ defaults:
 
 jobs:
   build:
+    name: Changelogs
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -35,8 +35,9 @@ jobs:
       - name: ghcup
         run: |
           ghcup config set cache true
-          ghcup install ghc recommended
-          ghcup set ghc recommended
+          ghcup install ghc 8.10.7
+          ghcup set ghc 8.10.7
+      # GHC 8.10.7 needed due to https://github.com/phadej/changelog-d/pull/2
       - name: Update Hackage index
         run: cabal v2-update
       # Cannot install it from tarball due to

--- a/.github/workflows/users-guide.yml
+++ b/.github/workflows/users-guide.yml
@@ -1,6 +1,6 @@
 # Adapted from agda/agda/.github/workflows/user-manual.yml by Andreas, 2021-09-11
 
-name: Users guide
+name: Assorted
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:
@@ -42,6 +42,7 @@ defaults:
 
 jobs:
   build:
+    name: Users guide
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -1,4 +1,4 @@
-name: Whitespace
+name: Assorted
 
 on:
   push:
@@ -10,6 +10,7 @@ on:
       - created
 jobs:
   check:
+    name: Whitespace
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
This is a continuation of #8503. It turns out https://github.com/phadej/changelog-d/pull/2 requires a fixed GHC in CI, as well, but it must have been cached, so I CI passed fine in the workaround PR, but failed in #7386.