### PR TITLE
mergify: two-day delay should account for the squash label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,7 +9,9 @@ pull_request_rules:
     name: Wait for 2 days before validating merge
     conditions:
       - updated-at<2 days ago
-      - label=merge me
+      - or
+        - label=merge me
+        - label=squash+merge me
       - '#approved-reviews-by>=2'
 
   # rebase+merge strategy

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,7 +9,7 @@ pull_request_rules:
     name: Wait for 2 days before validating merge
     conditions:
       - updated-at<2 days ago
-      - or
+      - or:
         - label=merge me
         - label=squash+merge me
       - '#approved-reviews-by>=2'


### PR DESCRIPTION
That was an oversight on my part when I did it initially: the squash label was overseen.