### PR TITLE
Add RequiredTypeArguments to known extensions

### DIFF
--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -663,6 +663,9 @@ data KnownExtension =
   -- | Enable linear types.
   | LinearTypes
 
+  -- | Allow the use of visible forall in types of terms.
+  | RequiredTypeArguments
+
   -- | Enable the generation of selector functions corresponding to record fields.
   | FieldSelectors
 

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -27,9 +27,9 @@ tests = testGroup "Distribution.Utils.Structured"
     -- The difference is in encoding of newtypes
 #if MIN_VERSION_base(4,7,0)
     , testCase "GenericPackageDescription" $
-      md5Check (Proxy :: Proxy GenericPackageDescription) 0x227c04c63afe656449d6feb7220e5194
+      md5Check (Proxy :: Proxy GenericPackageDescription) 0xa3e9433662ecf0c7a3c26f6d75a53ba1
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0x4ec3f95ae75fea8422b1c5e15724f1a4
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0x05ef40b1f97c55be526f63ea4cdacae1
 #endif
     ]
 

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -208,6 +208,7 @@ syn keyword cabalExtension contained
   \ LexicalNegation
   \ LiberalTypeSynonyms
   \ LinearTypes
+  \ RequiredTypeArguments
   \ MagicHash
   \ MonadComprehensions
   \ MonadFailDesugaring
@@ -345,6 +346,7 @@ syn keyword cabalExtension contained
   \ NoLexicalNegation
   \ NoLiberalTypeSynonyms
   \ NoLinearTypes
+  \ NoRequiredTypeArguments
   \ NoMagicHash
   \ NoMonadComprehensions
   \ NoMonadFailDesugaring


### PR DESCRIPTION
The extension is introduced in the accepted [GHC Proposal #281](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0281-visible-forall.rst). It hasn't been implemented in GHC yet, but I think it's fine if Cabal knows about it ahead of time.