### PR TITLE
Export CompatFilePath and CompatLicenseFile

### DIFF
--- a/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
@@ -6,6 +6,8 @@
 module Distribution.PackageDescription.FieldGrammar (
     -- * Package description
     packageDescriptionFieldGrammar,
+    CompatFilePath(..),
+    CompatLicenseFile(..),
     -- * Library
     libraryFieldGrammar,
     -- * Foreign library


### PR DESCRIPTION
These two types need to be exported for users to be able to define their own FieldGrammar.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
