### PR TITLE
Work around git problem with file transport

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -74,6 +74,10 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ghc }}-20220419-${{ github.sha }}
           restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-20220419-
 
+      - name: Work around git problem https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586 (cabal PR #8546)
+        run: |
+          git config --global protocol.file.allow always
+
       # The '+exe' constraint below is important, otherwise cabal-install
       # might decide to build the library but not the executable which is
       # what we need.


### PR DESCRIPTION
We use the latest Ubuntu GHA container, which has some advantages, but gets us bitten by such bugs early and so we have to workaround ourselves.

