### PR TITLE
add documentation for single-file Haskell scripts

### DIFF
--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -845,6 +845,8 @@ The configuration information for the script is cached under the cabal directory
 and can be pre-built with ``cabal build path/to/script``.
 See ``cabal run`` for more information on scripts.
 
+.. _cabal run:
+
 cabal run
 ^^^^^^^^^
 

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -179,9 +179,9 @@ The cabal directives are placed in the file within a comment.
     {- cabal:
     build-depends: base, split
     -}
-    
+
     import Data.List.Split (chunksOf)
-    
+
     main :: IO ()
     main = getLine >>= print . chunksOf 3
 
@@ -190,9 +190,19 @@ This can be run using ``cabal run myscript`` or directly, with execute permissio
 .. code-block:: console
 
     $ cabal run myscript
-    
+
     $ chmod +x myscript
     $ ./myscript
+
+Project metadata can also be included:
+
+.. code-block:: haskell
+
+    {- project:
+    with-compiler: ghc-8.10.7
+    -}
+
+See more in the :doc:`cabal run <cabal-commands#cabal-run>` documentation.
 
 What Next?
 ----------

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -202,7 +202,7 @@ Project metadata can also be included:
     with-compiler: ghc-8.10.7
     -}
 
-See more in the :doc:`cabal run <cabal-commands#cabal-run>` documentation.
+See more in the documentation for :ref:`cabal run`.
 
 What Next?
 ----------

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -166,6 +166,33 @@ Now you can build and re-run your code to see the new output:
         /    /  /    /   \    \
        /____/  /____/     \____\
 
+Run a single-file Haskell script
+--------------------------------
+
+Cabal also enables us to run single-file Haskell scripts
+without creating a project directory or ``.cabal`` file.
+The cabal directives are placed in the file within a comment.
+
+.. code-block:: haskell
+
+    #!/usr/bin/env cabal
+    {- cabal:
+    build-depends: base, split
+    -}
+    
+    import Data.List.Split (chunksOf)
+    
+    main :: IO ()
+    main = getLine >>= print . chunksOf 3
+
+This can be run using ``cabal run myscript`` or directly, with execute permission.
+
+.. code-block:: console
+
+    $ cabal run myscript
+    
+    $ chmod +x myscript
+    $ ./myscript
 
 What Next?
 ----------

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -185,7 +185,8 @@ The cabal directives are placed in the file within a comment.
     main :: IO ()
     main = getLine >>= print . chunksOf 3
 
-This can be run using ``cabal run myscript`` or directly, with execute permission.
+This can be run using ``cabal run myscript``.
+On Unix-like systems this can be run directly with execute permission.
 
 .. code-block:: console
 


### PR DESCRIPTION
This is a useful feature which I think would benefit newcomers by being a top-level, early entry in the docs. See: https://stackoverflow.com/a/65541020

* [*] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [*] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [*] The documentation has been updated, if necessary.

No code changes. Documentation only.
