### PR TITLE
Do not print "up to date" unless running build

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -863,24 +863,22 @@ printPlan verbosity
                   PackageConfig {packageConfigOptimization = globalOptimization},
               projectConfigLocalPackages =
                   PackageConfig {packageConfigOptimization = localOptimization}
-            }
+            },
+            currentCommand
           }
           ProjectBuildContext {
             elaboratedPlanToExecute = elaboratedPlan,
             elaboratedShared,
             pkgsBuildStatus
           }
-
-  | null pkgs
-  = notice verbosity "Up to date"
-
-  | otherwise
-  = noticeNoWrap verbosity $ unlines $
+  | null pkgs && currentCommand == BuildCommand
+    = notice verbosity "Up to date"
+  | not (null pkgs) = noticeNoWrap verbosity $ unlines $
       (showBuildProfile ++ "In order, the following "
        ++ wouldWill ++ " be built"
        ++ ifNormal " (use -v for more details)" ++ ":")
     : map showPkgAndReason pkgs
-
+  | otherwise = return ()
   where
     pkgs = InstallPlan.executionOrder elaboratedPlan
 


### PR DESCRIPTION
closes #4994 

"Up to date" will not print unless the `build` command is run.

I expect this to break tests that use the `build` and `run` commands so I'll update them based on the CI results. This should in effect test the PR itself to keep it from regressing.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
