### PR TITLE
Document internal library syntax changes

### DIFF
--- a/doc/cabal-package.rst
+++ b/doc/cabal-package.rst
@@ -999,6 +999,11 @@ a real-world use case:
 
       default-language: Haskell2010
 
+.. note::
+    For packages using ``cabal-version: 3.4`` or higher, the syntax to
+    specify an internal library in a ``build-depends:`` section is
+    ``package-name:internal-library-name``.
+
 **Multiple public libraries**
 
 Cabal 3.0 and later support exposing multiple libraries from a single package


### PR DESCRIPTION
As of cabal-version: 3.4 and higher, it's necessary to use a different syntax to depend on internal libraries than previous versions. Document this change in a note block in the Internal Libraries section.

See: #7565


---
Please include the following checklist in your PR:

* [X ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [X ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ X] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
