### PR TITLE
Use GHC.Conc.Sync.getNumProcessors instead of C

### DIFF
--- a/cabal-install/src/Distribution/Client/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Utils.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ForeignFunctionInterface, ScopedTypeVariables, CPP #-}
+{-# LANGUAGE ScopedTypeVariables, CPP #-}
 
 module Distribution.Client.Utils
   ( MergeResult(..)
@@ -48,7 +48,6 @@ import Control.Monad
          ( zipWithM_ )
 import Data.List
          ( groupBy )
-import Foreign.C.Types ( CInt(..) )
 import qualified Control.Exception as Exception
          ( finally )
 import qualified Control.Exception.Safe as Safe
@@ -62,6 +61,7 @@ import System.IO
          )
 import System.IO.Unsafe ( unsafePerformIO )
 
+import GHC.Conc.Sync ( getNumProcessors )
 import GHC.IO.Encoding
          ( recover, TextEncoding(TextEncoding) )
 import GHC.IO.Encoding.Failure
@@ -196,12 +196,10 @@ logDirChange l (Just d) m = do
   m `Exception.finally`
     (l $ "cabal: Leaving directory '" ++ d ++ "'\n")
 
-foreign import ccall "getNumberOfProcessors" c_getNumberOfProcessors :: IO CInt
-
 -- The number of processors is not going to change during the duration of the
 -- program, so unsafePerformIO is safe here.
 numberOfProcessors :: Int
-numberOfProcessors = fromEnum $ unsafePerformIO c_getNumberOfProcessors
+numberOfProcessors = unsafePerformIO getNumProcessors
 
 -- | Determine the number of jobs to use given the value of the '-j' flag.
 determineNumJobs :: Flag (Maybe Int) -> Int


### PR DESCRIPTION
The C call is almost exactly the same as GHC.Conc.Sync.getNumProcessors, and we used the C function from GHC, so there should be no actual difference.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
