### PR TITLE
  Increase urllib.request.urlopen timeout in bootstrap.py to fix CI

### DIFF
--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -331,7 +331,7 @@ def fetch_from_plan(plan : FetchPlan, output_dir : Path):
     sha = plan[path].sha256
     if not output_path.exists():
       print(f'Fetching {url}...')
-      with urllib.request.urlopen(url, timeout = 10) as resp:
+      with urllib.request.urlopen(url, timeout=600) as resp:
         shutil.copyfileobj(resp, output_path.open('wb'))
     verify_sha256(sha, output_path)
 


### PR DESCRIPTION
Again trying to fix bootstrap job currently broken on CI via explicitly setting a timeout. I think the past attempts https://github.com/haskell/cabal/pull/8576 and #8593 helped, but the lag has grown since. But I may be wrong.

Also, I'm trying to make the Python library retry the requests (though I don't even know if they perhaps already retry).

Edit: nope, I gave up:  there are 3 versions of the urllib, randomly renamed, incompatible; I don't even know which version our scripts uses. I was guessing it's version 2, but a copy-pasted hack doesn't work, so probably not.