### PR TITLE
Hardwire a different CI cache path, to fix CI

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -30,7 +30,7 @@ jobs:
         name: Cache the downloads
         id: bootstrap-cache
         with:
-          path: "~/.cabal"
+          path: "/home/runner/work/cabal/cabal/_build"
           key: bootstrap-${{ runner.os }}-${{ matrix.ghc }}-20221115-${{ github.sha }}
           restore-keys: bootstrap-${{ runner.os }}-${{ matrix.ghc }}-20221115-
 


### PR DESCRIPTION
This is a fixup PR for #8595. Apparently, the `~./cabal` path from one of our other CI scripts is unused here, so caching was void, so I've hardwired `/home/runner/work/cabal/cabal/_build` instead.