### PR TITLE
Change exitcode-stdio-1.0 description to match current status quo

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/BenchmarkInterface.hs
+++ b/Cabal-syntax/src/Distribution/Types/BenchmarkInterface.hs
@@ -21,8 +21,8 @@ data BenchmarkInterface =
      -- | Benchmark interface \"exitcode-stdio-1.0\". The benchmark
      -- takes the form of an executable. It returns a zero exit code
      -- for success, non-zero for failure. The stdout and stderr
-     -- channels may be logged. It takes no command line parameters
-     -- and nothing on stdin.
+     -- channels may be logged. Test tooling may pass command line
+     -- arguments and/or connect the stdin channel to the test.
      --
      BenchmarkExeV10 Version FilePath
 

--- a/Cabal-syntax/src/Distribution/Types/TestSuiteInterface.hs
+++ b/Cabal-syntax/src/Distribution/Types/TestSuiteInterface.hs
@@ -21,8 +21,8 @@ data TestSuiteInterface =
 
      -- | Test interface \"exitcode-stdio-1.0\". The test-suite takes the form
      -- of an executable. It returns a zero exit code for success, non-zero for
-     -- failure. The stdout and stderr channels may be logged. It takes no
-     -- command line parameters and nothing on stdin.
+     -- failure. The stdout and stderr channels may be logged. Test tooling may
+     -- pass command line arguments and/or connect the stdin channel to the test.
      --
      TestSuiteExeV10 Version FilePath
 


### PR DESCRIPTION
Hi, I'm hoping to solicit comments/design discussion on an idea to add a new test suite interface. 

I'm the author of the [Sandwich](https://codedownio.github.io/sandwich/) test framework, which provides a way of running and visualizing tests in a terminal UI interface. It would be nice to add first-class support for this way of working to tooling like Cabal, so you could type `cabal test` from your terminal and get dropped into the interface.

This is currently not possible because Cabal's existing test suite types don't allow the tests to use `stdin`; see the [exitcode-stdio-1.0](https://hackage.haskell.org/package/Cabal-syntax-3.8.1.0/docs/Distribution-Types-TestSuiteInterface.html#v:TestSuiteExeV10) documentation.

This PR proposes to add a new `TestSuiteInterface` constructor called `TestSuiteInteractiveV10`, which behaves just like `TestSuiteExeV10` except for the restriction on `stdin`. I haven't filled in any other code and I'm not sure how hard the rest of the implementation would be.

Possible alternative: simply change the semantics of `exitcode-stdio-1.0` to allow `stdin` when used in interactive settings. It might be painful to add a new test suite type, because most tests in the wild assume `exitcode-stdio-1.0` (and some tools like `hpack` currently bake it in by default).

This PR was emboldened by @Mikolaj 's email to Haskell-Cafe :)


---
Please include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

