### PR TITLE
Avoid `Data.List.{head,tail}`

### DIFF
--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -25,7 +25,6 @@ module Language.Haskell.Extension (
         knownExtensions
   ) where
 
-import qualified Prelude (head)
 import Distribution.Compat.Prelude
 
 import Data.Array (Array, accumArray, bounds, Ix(inRange), (!))
@@ -752,9 +751,9 @@ classifyKnownExtension string@(c : _)
 knownExtensionTable :: Array Char [(String, KnownExtension)]
 knownExtensionTable =
   accumArray (flip (:)) [] ('A', 'Z')
-    [ (Prelude.head str, (str, extension)) -- assume KnownExtension's Show returns a non-empty string
-    | extension <- [toEnum 0 ..]
-    , let str = show extension ]
+    [ (hd, (str, extension)) -- assume KnownExtension's Show returns a non-empty string
+    | (extension, str@(hd : _)) <- map (\e -> (e, show e)) [toEnum 0 ..]
+    ]
 
 knownExtensions :: [KnownExtension]
 knownExtensions = [minBound .. maxBound]

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -54,7 +54,7 @@ module Distribution.Simple.Configure
   , platformDefines,
   ) where
 
-import qualified Prelude as Unsafe (tail)
+import Prelude ()
 import Distribution.Compat.Prelude
 
 import Distribution.Compiler
@@ -106,7 +106,8 @@ import Data.ByteString.Lazy          ( ByteString )
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy.Char8 as BLC8
 import Data.List
-    ( (\\), inits, stripPrefix, intersect)
+    ( (\\), stripPrefix, intersect)
+import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as Map
 import System.Directory
     ( canonicalizePath, createDirectoryIfMissing, doesFileExist
@@ -1784,7 +1785,7 @@ checkForeignDeps pkg lbi verbosity =
         findOffendingHdr =
             ifBuildsWith allHeaders ccArgs
                          (return Nothing)
-                         (go . Unsafe.tail . inits $ allHeaders) -- inits always contains at least []
+                         (go . tail . NEL.inits $ allHeaders)
             where
               go [] = return Nothing       -- cannot happen
               go (hdrs:hdrsInits) =


### PR DESCRIPTION
CLC has approved the proposal to add `{-# WARNING #-}` to `Data.List.{head,tail}` (https://github.com/haskell/core-libraries-committee/issues/87). It means that usage of `head` and `tail` will emit compile-time warnings.

This patch eliminates `head` and `tail` in `Cabal-syntax` and `Cabal` packages. These are boot packages, so it's important for GHC HEAD to compile them without any warnings.