### PR TITLE
[3.6] fixup sYNCHRONIZE for Win32-2.8+

### DIFF
--- a/cabal-install/src/Distribution/Client/Win32SelfUpgrade.hs
+++ b/cabal-install/src/Distribution/Client/Win32SelfUpgrade.hs
@@ -140,7 +140,7 @@ deleteOldExeFile verbosity oldPID tmpPath = do
      ++ show oldPID ++ " at path " ++ tmpPath
 
   log $ "getting handle of parent process " ++ show oldPID
-  oldPHANDLE <- Win32.openProcess Win32.sYNCHORNIZE False (fromIntegral oldPID)
+  oldPHANDLE <- Win32.openProcess Win32.sYNCHRONIZE False (fromIntegral oldPID)
 
   log $ "synchronising with parent"
   event <- openEvent syncEventName


### PR DESCRIPTION
This completes the backport of the fix for #7835 for 3.6 (done in #7983) 
which was missing this change included in 3.8 (#7982).

(see for example commercialhaskell/stackage#6778)