### PR TITLE
Fix dynamic deps 2 arts

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
@@ -92,7 +92,13 @@ data InstalledPackageInfo
         frameworks        :: [String],
         haddockInterfaces :: [FilePath],
         haddockHTMLs      :: [FilePath],
-        pkgRoot           :: Maybe FilePath
+        pkgRoot           :: Maybe FilePath,
+        -- Artifacts included in this package:
+        pkgVanillaLib     :: Bool,
+        pkgSharedLib      :: Bool,
+        pkgDynExe         :: Bool,
+        pkgProfLib        :: Bool,
+        pkgProfExe        :: Bool
     }
     deriving (Eq, Generic, Typeable, Read, Show)
 
@@ -173,5 +179,10 @@ emptyInstalledPackageInfo
         haddockInterfaces = [],
         haddockHTMLs      = [],
         pkgRoot           = Nothing,
-        libVisibility     = LibraryVisibilityPrivate
+        libVisibility     = LibraryVisibilityPrivate,
+        pkgVanillaLib     = True,
+        pkgSharedLib      = True,
+        pkgDynExe         = True,
+        pkgProfLib        = True,
+        pkgProfExe        = True
     }

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
@@ -121,6 +121,11 @@ ipiFieldGrammar = mkInstalledPackageInfo
     <@> monoidalFieldAla    "haddock-interfaces"   (alaList' FSep FilePathNT)    L.haddockInterfaces
     <@> monoidalFieldAla    "haddock-html"         (alaList' FSep FilePathNT)    L.haddockHTMLs
     <@> optionalFieldAla    "pkgroot"              FilePathNT                    L.pkgRoot
+    <@> booleanFieldDef     "pkg-vanilla-lib"                                    L.pkgVanillaLib True
+    <@> booleanFieldDef     "pkg-shared-lib"                                     L.pkgSharedLib True
+    <@> booleanFieldDef     "pkg-dyn-exe"                                        L.pkgDynExe True
+    <@> booleanFieldDef     "pkg-prof-lib"                                       L.pkgProfLib True
+    <@> booleanFieldDef     "pkg-prof-exe"                                       L.pkgProfExe True
   where
     mkInstalledPackageInfo _ Basic {..} = InstalledPackageInfo
         -- _basicPkgName is not used

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/Lens.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/Lens.hs
@@ -196,3 +196,23 @@ libVisibility :: Lens' InstalledPackageInfo LibraryVisibility
 libVisibility f s = fmap (\x -> s { T.libVisibility = x }) (f (T.libVisibility s))
 {-# INLINE libVisibility #-}
 
+pkgVanillaLib :: Lens' InstalledPackageInfo Bool
+pkgVanillaLib f s = fmap (\x -> s { T.pkgVanillaLib = x }) (f (T.pkgVanillaLib s))
+{-# INLINE pkgVanillaLib #-}
+
+pkgSharedLib :: Lens' InstalledPackageInfo Bool
+pkgSharedLib f s = fmap (\x -> s { T.pkgSharedLib = x }) (f (T.pkgSharedLib s))
+{-# INLINE pkgSharedLib #-}
+
+pkgDynExe :: Lens' InstalledPackageInfo Bool
+pkgDynExe f s = fmap (\x -> s { T.pkgDynExe = x }) (f (T.pkgDynExe s))
+{-# INLINE pkgDynExe #-}
+
+pkgProfLib :: Lens' InstalledPackageInfo Bool
+pkgProfLib f s = fmap (\x -> s { T.pkgProfLib = x }) (f (T.pkgProfLib s))
+{-# INLINE pkgProfLib #-}
+
+pkgProfExe :: Lens' InstalledPackageInfo Bool
+pkgProfExe f s = fmap (\x -> s { T.pkgProfExe = x }) (f (T.pkgProfExe s))
+{-# INLINE pkgProfExe #-}
+

--- a/Cabal/src/Distribution/Simple/Register.hs
+++ b/Cabal/src/Distribution/Simple/Register.hs
@@ -448,7 +448,12 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     IPI.haddockInterfaces  = [haddockdir installDirs </> haddockName pkg],
     IPI.haddockHTMLs       = [htmldir installDirs],
     IPI.pkgRoot            = Nothing,
-    IPI.libVisibility      = libVisibility lib
+    IPI.libVisibility      = libVisibility lib,
+    IPI.pkgVanillaLib      = withVanillaLib lbi,
+    IPI.pkgSharedLib       = withProfLib lbi,
+    IPI.pkgDynExe          = withSharedLib lbi,
+    IPI.pkgProfLib         = withStaticLib lbi,
+    IPI.pkgProfExe         = withDynExe lbi
   }
   where
     ghc84 = case compilerId $ compiler lbi of

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -81,6 +81,7 @@ library
     Distribution.Solver.Modular.Var
     Distribution.Solver.Modular.Version
     Distribution.Solver.Modular.WeightedPSQ
+    Distribution.Solver.Types.ArtifactSelection
     Distribution.Solver.Types.ComponentDeps
     Distribution.Solver.Types.ConstraintSource
     Distribution.Solver.Types.DependencyResolver

--- a/cabal-install-solver/src/Distribution/Solver/Modular.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular.hs
@@ -64,7 +64,7 @@ modularResolver sc (Platform arch os) cinfo iidx sidx pkgConfigDB pprefs pcs pns
   solve' sc cinfo idx pkgConfigDB pprefs gcs pns
     where
       -- Indices have to be converted into solver-specific uniform index.
-      idx    = convPIs os arch cinfo gcs (shadowPkgs sc) (strongFlags sc) (solveExecutables sc) iidx sidx
+      idx    = convPIs os arch cinfo gcs (shadowPkgs sc) (strongFlags sc) (solveExecutables sc) (sourceArtifacts sc) iidx sidx
       -- Constraints have to be converted into a finite map indexed by PN.
       gcs    = M.fromListWith (++) (map pair pcs)
         where

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Builder.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Builder.hs
@@ -179,7 +179,7 @@ addChildren bs@(BS { rdeps = rdm, next = OneGoal (StanzaGoal qsn@(SN qpn _) t gr
 -- and furthermore we update the set of goals.
 --
 -- TODO: We could inline this above.
-addChildren bs@(BS { next = Instance qpn (PInfo fdeps _ fdefs _) }) =
+addChildren bs@(BS { next = Instance qpn (PInfo fdeps _ fdefs _ _) }) =
   addChildren ((scopedExtendOpen qpn fdeps fdefs bs)
          { next = Goals })
 

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Explore.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Explore.hs
@@ -269,7 +269,7 @@ exploreLog mbj enableBj fineGrainedConflicts (CountConflicts countConflicts) idx
     -- to be merged with the previous one.
     couldResolveConflicts :: QPN -> POption -> S.Set CS.Conflict -> Maybe ConflictSet
     couldResolveConflicts currentQPN@(Q _ pn) (POption i@(I v _) _) conflicts =
-      let (PInfo deps _ _ _) = idx M.! pn M.! i
+      let (PInfo deps _ _ _ _) = idx M.! pn M.! i
           qdeps = qualifyDeps (defaultQualifyOptions idx) currentQPN deps
 
           couldBeResolved :: CS.Conflict -> Maybe ConflictSet

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Index.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Index.hs
@@ -18,6 +18,7 @@ import Distribution.Solver.Modular.Dependency
 import Distribution.Solver.Modular.Flag
 import Distribution.Solver.Modular.Package
 import Distribution.Solver.Modular.Tree
+import Distribution.Solver.Types.ArtifactSelection
 
 -- | An index contains information about package instances. This is a nested
 -- dictionary. Package names are mapped to instances, which in turn is mapped
@@ -32,10 +33,13 @@ type Index = Map PN (Map I PInfo)
 -- globally, for reasons external to the solver. We currently use this
 -- for shadowing which essentially is a GHC limitation, and for
 -- installed packages that are broken.
+--
+-- Additionally, track build artifacts provided and build artifacts required.
 data PInfo = PInfo (FlaggedDeps PN)
                    (Map ExposedComponent ComponentInfo)
                    FlagInfo
                    (Maybe FailReason)
+                   (ArtifactSelection, ArtifactSelection)
 
 -- | Info associated with each library and executable in a package instance.
 data ComponentInfo = ComponentInfo {
@@ -64,7 +68,7 @@ defaultQualifyOptions idx = QO {
                               | -- Find all versions of base ..
                                 Just is <- [M.lookup base idx]
                                 -- .. which are installed ..
-                              , (I _ver (Inst _), PInfo deps _comps _flagNfo _fr) <- M.toList is
+                              , (I _ver (Inst _), PInfo deps _comps _flagNfo _fr _arts) <- M.toList is
                                 -- .. and flatten all their dependencies ..
                               , (LDep _ (Dep (PkgComponent dep _) _ci), _comp) <- flattenFlaggedDeps deps
                               ]

--- a/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/IndexConversion.hs
@@ -25,6 +25,8 @@ import Distribution.PackageDescription.Configuration
 import qualified Distribution.Simple.PackageIndex as SI
 import Distribution.System
 
+import           Distribution.Solver.Types.ArtifactSelection
+                   ( ArtifactSelection(..), allArtifacts, staticOutsOnly, dynOutsOnly, noOuts )
 import           Distribution.Solver.Types.ComponentDeps
                    ( Component(..), componentNameToComponent )
 import           Distribution.Solver.Types.Flag
@@ -55,11 +57,12 @@ import Distribution.Solver.Modular.Version
 -- explicitly requested.
 convPIs :: OS -> Arch -> CompilerInfo -> Map PN [LabeledPackageConstraint]
         -> ShadowPkgs -> StrongFlags -> SolveExecutables
+        -> Maybe (ArtifactSelection, ArtifactSelection)
         -> SI.InstalledPackageIndex -> CI.PackageIndex (SourcePackage loc)
         -> Index
-convPIs os arch comp constraints sip strfl solveExes iidx sidx =
+convPIs os arch comp constraints sip strfl solveExes srcArts iidx sidx =
   mkIndex $
-  convIPI' sip iidx ++ convSPI' os arch comp constraints strfl solveExes sidx
+  convIPI' sip iidx ++ convSPI' os arch comp constraints strfl solveExes srcArts sidx
 
 -- | Convert a Cabal installed package index to the simpler,
 -- more uniform index format of the solver.
@@ -75,8 +78,8 @@ convIPI' (ShadowPkgs sip) idx =
   where
 
     -- shadowing is recorded in the package info
-    shadow (pn, i, PInfo fdeps comps fds _)
-      | sip = (pn, i, PInfo fdeps comps fds (Just Shadowed))
+    shadow (pn, i, PInfo fdeps comps fds _ arts)
+      | sip = (pn, i, PInfo fdeps comps fds (Just Shadowed) arts)
     shadow x                                     = x
 
 -- | Extract/recover the package ID from an installed package info, and convert it to a solver's I.
@@ -90,8 +93,8 @@ convId ipi = (pn, I ver $ Inst $ IPI.installedUnitId ipi)
 convIP :: SI.InstalledPackageIndex -> IPI.InstalledPackageInfo -> (PN, I, PInfo)
 convIP idx ipi =
   case traverse (convIPId (DependencyReason pn M.empty S.empty) comp idx) (IPI.depends ipi) of
-        Left u    -> (pn, i, PInfo [] M.empty M.empty (Just (Broken u)))
-        Right fds -> (pn, i, PInfo fds components M.empty Nothing)
+        Left u    -> (pn, i, PInfo [] M.empty M.empty (Just (Broken u)) mempty)
+        Right fds -> (pn, i, PInfo fds components M.empty Nothing (ipiToAS ipi))
  where
   -- TODO: Handle sub-libraries and visibility.
   components =
@@ -151,21 +154,34 @@ convIPId dr comp idx ipid =
                 -- NB: something we pick up from the
                 -- InstalledPackageIndex is NEVER an executable
 
+-- | Extract the 'ArtifactSelection's representing which artifacts are
+-- available in this installed package and which artifacts this installed
+-- package requires.  Assume both are the same.
+ipiToAS :: IPI.InstalledPackageInfo -> (ArtifactSelection, ArtifactSelection)
+ipiToAS ipi = (\x -> (x, x)) $ mconcat [statics, dynamics]
+  where
+    statics :: ArtifactSelection
+    statics = if any ($ ipi) [IPI.pkgVanillaLib] then staticOutsOnly else mempty
+    dynamics :: ArtifactSelection
+    dynamics = if any ($ ipi) [IPI.pkgSharedLib, IPI.pkgDynExe] then dynOutsOnly else mempty
+
 -- | Convert a cabal-install source package index to the simpler,
 -- more uniform index format of the solver.
 convSPI' :: OS -> Arch -> CompilerInfo -> Map PN [LabeledPackageConstraint]
-         -> StrongFlags -> SolveExecutables
+         -> StrongFlags -> SolveExecutables -> Maybe (ArtifactSelection, ArtifactSelection)
          -> CI.PackageIndex (SourcePackage loc) -> [(PN, I, PInfo)]
-convSPI' os arch cinfo constraints strfl solveExes =
-    L.map (convSP os arch cinfo constraints strfl solveExes) . CI.allPackages
+convSPI' os arch cinfo constraints strfl solveExes srcArts =
+    L.map (convSP os arch cinfo constraints strfl solveExes srcArts) . CI.allPackages
 
 -- | Convert a single source package into the solver-specific format.
 convSP :: OS -> Arch -> CompilerInfo -> Map PN [LabeledPackageConstraint]
-       -> StrongFlags -> SolveExecutables -> SourcePackage loc -> (PN, I, PInfo)
-convSP os arch cinfo constraints strfl solveExes (SourcePackage (PackageIdentifier pn pv) gpd _ _pl) =
+       -> StrongFlags -> SolveExecutables -> Maybe (ArtifactSelection, ArtifactSelection)
+       -> SourcePackage loc
+       -> (PN, I, PInfo)
+convSP os arch cinfo constraints strfl solveExes srcArts (SourcePackage (PackageIdentifier pn pv) gpd _ _pl) =
   let i = I pv InRepo
       pkgConstraints = fromMaybe [] $ M.lookup pn constraints
-  in  (pn, i, convGPD os arch cinfo pkgConstraints strfl solveExes pn gpd)
+  in  (pn, i, convGPD os arch cinfo pkgConstraints strfl solveExes srcArts pn gpd)
 
 -- We do not use 'flattenPackageDescription' or 'finalizePD'
 -- from 'Distribution.PackageDescription.Configuration' here, because we
@@ -173,9 +189,11 @@ convSP os arch cinfo constraints strfl solveExes (SourcePackage (PackageIdentifi
 
 -- | Convert a generic package description to a solver-specific 'PInfo'.
 convGPD :: OS -> Arch -> CompilerInfo -> [LabeledPackageConstraint]
-        -> StrongFlags -> SolveExecutables -> PN -> GenericPackageDescription
+        -> StrongFlags -> SolveExecutables
+        -> Maybe (ArtifactSelection, ArtifactSelection)
+        -> PN -> GenericPackageDescription
         -> PInfo
-convGPD os arch cinfo constraints strfl solveExes pn
+convGPD os arch cinfo constraints strfl solveExes srcArts pn
         (GenericPackageDescription pkg scannedVersion flags mlib sub_libs flibs exes tests benchs) =
   let
     fds  = flagInfo strfl flags
@@ -238,7 +256,7 @@ convGPD os arch cinfo constraints strfl solveExes pn
         isPrivate LibraryVisibilityPrivate = True
         isPrivate LibraryVisibilityPublic  = False
 
-  in PInfo flagged_deps components fds fr
+  in PInfo flagged_deps components fds fr (fromMaybe (allArtifacts, noOuts) srcArts)
 
 -- | Applies the given predicate (for example, testing buildability or
 -- visibility) to the given component and environment. Values are combined with

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Linking.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Linking.hs
@@ -100,9 +100,9 @@ validateLinking index = (`runReader` initVS) . go
     goP :: QPN -> POption -> Validate (Tree d c) -> Validate (Tree d c)
     goP qpn@(Q _pp pn) opt@(POption i _) r = do
       vs <- ask
-      let PInfo deps _ _ _ = vsIndex vs ! pn ! i
-          qdeps            = qualifyDeps (vsQualifyOptions vs) qpn deps
-          newSaved         = M.insert qpn qdeps (vsSaved vs)
+      let PInfo deps _ _ _ _ = vsIndex vs ! pn ! i
+          qdeps              = qualifyDeps (vsQualifyOptions vs) qpn deps
+          newSaved           = M.insert qpn qdeps (vsSaved vs)
       case execUpdateState (pickPOption qpn opt qdeps) vs of
         Left  (cs, err) -> return $ Fail cs (DependenciesNotLinked err)
         Right vs'       -> local (const vs' { vsSaved = newSaved }) r
@@ -349,7 +349,7 @@ verifyLinkGroup lg =
       -- if a constructor is added to the datatype we won't notice it here
       Just i -> do
         vs <- get
-        let PInfo _deps _exes finfo _ = vsIndex vs ! lgPackage lg ! i
+        let PInfo _deps _exes finfo _ _ = vsIndex vs ! lgPackage lg ! i
             flags   = M.keys finfo
             stanzas = [TestStanzas, BenchStanzas]
         forM_ flags $ \fn -> do

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Message.hs
@@ -244,6 +244,7 @@ showFR _ MultipleInstances                = " (multiple instances)"
 showFR c (DependenciesNotLinked msg)      = " (dependencies not linked: " ++ msg ++ "; conflict set: " ++ showConflictSet c ++ ")"
 showFR c CyclicDependencies               = " (cyclic dependencies; conflict set: " ++ showConflictSet c ++ ")"
 showFR _ (UnsupportedSpecVer ver)         = " (unsupported spec-version " ++ prettyShow ver ++ ")"
+showFR _ (MissingArtifacts arts)          = " (missing build artifacts: " ++ prettyShow arts ++ ")"
 -- The following are internal failures. They should not occur. In the
 -- interest of not crashing unnecessarily, we still just print an error
 -- message though.

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Tree.hs
@@ -30,6 +30,7 @@ import Distribution.Solver.Modular.PSQ (PSQ)
 import Distribution.Solver.Modular.Version
 import Distribution.Solver.Modular.WeightedPSQ (WeightedPSQ)
 import qualified Distribution.Solver.Modular.WeightedPSQ as W
+import Distribution.Solver.Types.ArtifactSelection
 import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.Flag
 import Distribution.Solver.Types.PackagePath
@@ -129,6 +130,7 @@ data FailReason = UnsupportedExtension Extension
                 | DependenciesNotLinked String
                 | CyclicDependencies
                 | UnsupportedSpecVer Ver
+                | MissingArtifacts ArtifactSelection
   deriving (Eq, Show)
 
 -- | Information about a dependency involved in a conflict, for error messages.

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Validate.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Validate.hs
@@ -210,7 +210,7 @@ validate = go
       rComps         <- asks requiredComponents
       qo             <- asks qualifyOptions
       -- obtain dependencies and index-dictated exclusions introduced by the choice
-      let (PInfo deps comps _ mfr) = idx ! pn ! i
+      let (PInfo deps comps _ mfr _) = idx ! pn ! i
       -- qualify the deps in the current scope
       let qdeps = qualifyDeps qo qpn deps
       -- the new active constraints are given by the instance we have chosen,

--- a/cabal-install-solver/src/Distribution/Solver/Types/ArtifactSelection.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ArtifactSelection.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | Provide a type for categorizing artifact requirements.
+module Distribution.Solver.Types.ArtifactSelection
+    ( ArtifactSelection(..)
+    , ArtifactKind(..)
+    , allArtifacts
+    , dynOutsOnly
+    , staticOutsOnly
+    , noOuts
+    , unArtifactSelection
+    , artsSubsetOf
+    , artsDifference
+    ) where
+
+import Distribution.Solver.Compat.Prelude
+import Prelude ()
+
+import qualified Data.Set as S
+
+import Distribution.Pretty ( Pretty(pretty) )
+import qualified Text.PrettyPrint as PP
+
+-- | A type for specifying which artifacts are available to be required.
+newtype ArtifactSelection = ArtifactSelection (S.Set ArtifactKind)
+  deriving (Eq, Show, Ord, Generic, Semigroup, Monoid)
+
+instance Pretty ArtifactSelection where
+  pretty arts
+    | arts == allArtifacts   = PP.text "all artifacts"
+    | arts == dynOutsOnly    = PP.text "dynamic artifacts"
+    | arts == staticOutsOnly = PP.text "static artifacts"
+    | arts == noOuts         = PP.text "no output artifacts"
+    | otherwise              = PP.text "unknown artifacts"
+
+instance Binary ArtifactSelection
+instance Structured ArtifactSelection
+
+-- | Specific kinds of artifacts.
+data ArtifactKind
+  = DynOuts     -- ^ Exclude static outputs.
+  | StaticOuts  -- ^ Exclude dynamic outputs.
+  deriving (Eq, Show, Generic, Ord)
+
+instance Binary ArtifactKind
+instance Structured ArtifactKind
+
+-- | ArtifactSelection alias: e.g. dynamic and static interface files.
+allArtifacts :: ArtifactSelection
+allArtifacts = ArtifactSelection $ S.fromList [DynOuts, StaticOuts]
+
+-- | ArtifactSelection alias: exclude static outputs.
+dynOutsOnly :: ArtifactSelection
+dynOutsOnly = ArtifactSelection $ S.fromList [DynOuts]
+
+-- | ArtifactSelection alias: exclude static outputs.
+staticOutsOnly :: ArtifactSelection
+staticOutsOnly = ArtifactSelection $ S.fromList [StaticOuts]
+
+-- | ArtifactSelection alias: exclude all artifacts.
+noOuts :: ArtifactSelection
+noOuts = ArtifactSelection $ S.fromList []
+
+-- | Obtain the set of artifact kinds included in this artifact selection.
+unArtifactSelection :: ArtifactSelection -> S.Set ArtifactKind
+unArtifactSelection (ArtifactSelection set) = set
+
+-- | Is a selection a subset of another?
+artsSubsetOf :: ArtifactSelection -> ArtifactSelection -> Bool
+artsSubsetOf = S.isSubsetOf `on` unArtifactSelection
+
+-- | Return artifacts in the first set not present in the second set.
+artsDifference :: ArtifactSelection -> ArtifactSelection -> ArtifactSelection
+artsDifference (ArtifactSelection a) (ArtifactSelection b) =
+  ArtifactSelection $ a `S.difference` b

--- a/cabal-install-solver/src/Distribution/Solver/Types/Settings.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/Settings.hs
@@ -14,6 +14,7 @@ module Distribution.Solver.Types.Settings
     , CountConflicts(..)
     , FineGrainedConflicts(..)
     , SolveExecutables(..)
+    , RequireArtifacts(..)
     ) where
 
 import Distribution.Solver.Compat.Prelude
@@ -69,6 +70,9 @@ newtype EnableBackjumping = EnableBackjumping Bool
 newtype SolveExecutables = SolveExecutables Bool
   deriving (BooleanFlag, Eq, Generic, Show)
 
+newtype RequireArtifacts = RequireArtifacts Bool
+  deriving (BooleanFlag, Eq, Generic, Show)
+
 instance Binary ReorderGoals
 instance Binary CountConflicts
 instance Binary FineGrainedConflicts
@@ -81,6 +85,7 @@ instance Binary StrongFlags
 instance Binary AllowBootLibInstalls
 instance Binary OnlyConstrained
 instance Binary SolveExecutables
+instance Binary RequireArtifacts
 
 instance Structured ReorderGoals
 instance Structured CountConflicts
@@ -94,6 +99,7 @@ instance Structured StrongFlags
 instance Structured AllowBootLibInstalls
 instance Structured OnlyConstrained
 instance Structured SolveExecutables
+instance Structured RequireArtifacts
 
 instance Pretty OnlyConstrained where
   pretty OnlyConstrainedAll  = PP.text "all"

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -310,6 +310,7 @@ instance Semigroup SavedConfig where
         installStrongFlags           = combine installStrongFlags,
         installAllowBootLibInstalls  = combine installAllowBootLibInstalls,
         installOnlyConstrained       = combine installOnlyConstrained,
+        installRequireArtifacts      = combine installRequireArtifacts,
         installReinstall             = combine installReinstall,
         installAvoidReinstalls       = combine installAvoidReinstalls,
         installOverrideReinstall     = combine installOverrideReinstall,

--- a/cabal-install/src/Distribution/Client/Configure.hs
+++ b/cabal-install/src/Distribution/Client/Configure.hs
@@ -41,6 +41,7 @@ import Distribution.Client.Targets
          ( userToPackageConstraint, userConstraintPackageName )
 import Distribution.Client.JobControl (Lock)
 
+import           Distribution.Solver.Types.ArtifactSelection
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.Settings
 import           Distribution.Solver.Types.ConstraintSource
@@ -308,6 +309,12 @@ planLocalPackage verbosity comp platform configFlags configExFlags
       benchmarksEnabled =
         fromFlagOrDefault False $ configBenchmarks configFlags
 
+      sourceArts = mconcat $
+        [ sourceArtsOf staticOutsOnly [(configVanillaLib, True)]
+        , sourceArtsOf dynOutsOnly    [(configSharedLib, False), (configDynExe, False)]
+        ]
+      sourceArtsOf arts fs = if any (\(fld, def) -> fromFlagOrDefault def . (fld $) $ configFlags) fs then arts else mempty
+
       resolverParams :: DepResolverParams
       resolverParams =
           removeLowerBounds
@@ -319,6 +326,8 @@ planLocalPackage verbosity comp platform configFlags configExFlags
             -- preferences from the config file or command line
             [ PackageVersionPreference name ver
             | PackageVersionConstraint name ver <- configPreferences configExFlags ]
+
+        . setSourceArtifacts (Just (sourceArts, sourceArts))
 
         . addConstraints
             -- version constraints from the config file or command line

--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -53,6 +53,8 @@ module Distribution.Client.Dependency (
     setStrongFlags,
     setAllowBootLibInstalls,
     setOnlyConstrained,
+    setRequireArtifacts,
+    setSourceArtifacts,
     setMaxBackjumps,
     setEnableBackjumping,
     setSolveExecutables,
@@ -105,6 +107,7 @@ import Distribution.Verbosity
 import Distribution.Version
 import qualified Distribution.Compat.Graph as Graph
 
+import           Distribution.Solver.Types.ArtifactSelection (ArtifactSelection)
 import           Distribution.Solver.Types.ComponentDeps (ComponentDeps)
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ConstraintSource
@@ -174,7 +177,9 @@ data DepResolverParams = DepResolverParams {
 
        -- | Function to override the solver's goal-ordering heuristics.
        depResolverGoalOrder         :: Maybe (Variable QPN -> Variable QPN -> Ordering),
-       depResolverVerbosity         :: Verbosity
+       depResolverVerbosity         :: Verbosity,
+       depResolverRequireArtifacts  :: RequireArtifacts,
+       depResolverSourceArtifacts   :: Maybe (ArtifactSelection, ArtifactSelection)
      }
 
 showDepResolverParams :: DepResolverParams -> String
@@ -199,6 +204,9 @@ showDepResolverParams p =
   ++ "\nonly constrained packages: " ++ show (depResolverOnlyConstrained p)
   ++ "\nmax backjumps: "     ++ maybe "infinite" show
                                      (depResolverMaxBackjumps             p)
+  ++ "\nrequire artifacts: " ++ show (asBool (depResolverRequireArtifacts p))
+  ++ "\nsource artifacts provided: " ++ fromMaybe "(default)" (prettyShow . fst <$> depResolverSourceArtifacts p)
+  ++ "\nsource artifacts required: " ++ fromMaybe "(default)" (prettyShow . snd <$> depResolverSourceArtifacts p)
   where
     showLabeledConstraint :: LabeledPackageConstraint -> String
     showLabeledConstraint (LabeledPackageConstraint pc src) =
@@ -259,7 +267,9 @@ basicDepResolverParams installedPkgIndex sourcePkgIndex =
        depResolverEnableBackjumping = EnableBackjumping True,
        depResolverSolveExecutables  = SolveExecutables True,
        depResolverGoalOrder         = Nothing,
-       depResolverVerbosity         = normal
+       depResolverVerbosity         = normal,
+       depResolverRequireArtifacts  = RequireArtifacts True,
+       depResolverSourceArtifacts   = Nothing
      }
 
 addTargets :: [PackageName]
@@ -350,6 +360,18 @@ setOnlyConstrained :: OnlyConstrained -> DepResolverParams -> DepResolverParams
 setOnlyConstrained i params =
   params {
     depResolverOnlyConstrained = i
+  }
+
+setRequireArtifacts :: RequireArtifacts -> DepResolverParams -> DepResolverParams
+setRequireArtifacts i params =
+  params {
+    depResolverRequireArtifacts = i
+  }
+
+setSourceArtifacts :: Maybe (ArtifactSelection, ArtifactSelection) -> DepResolverParams -> DepResolverParams
+setSourceArtifacts i params =
+  params {
+    depResolverSourceArtifacts = i
   }
 
 setMaxBackjumps :: Maybe Int -> DepResolverParams -> DepResolverParams
@@ -711,7 +733,8 @@ resolveDependencies platform comp pkgConfigDB solver params =
   $ runSolver solver (SolverConfig reordGoals cntConflicts fineGrained minimize
                       indGoals noReinstalls
                       shadowing strFlags allowBootLibs onlyConstrained_ maxBkjumps enableBj
-                      solveExes order verbosity (PruneAfterFirstSuccess False))
+                      solveExes order verbosity (PruneAfterFirstSuccess False)
+                      requireArts sourceArts)
                      platform comp installedPkgIndex sourcePkgIndex
                      pkgConfigDB preferences constraints targets
   where
@@ -735,7 +758,9 @@ resolveDependencies platform comp pkgConfigDB solver params =
       enableBj
       solveExes
       order
-      verbosity) =
+      verbosity
+      requireArts
+      sourceArts) =
         if asBool (depResolverAllowBootLibInstalls params)
         then params
         else dontUpgradeNonUpgradeablePackages params
@@ -997,7 +1022,8 @@ resolveWithoutDependencies (DepResolverParams targets constraints
                               _reorderGoals _countConflicts _fineGrained
                               _minimizeConflictSet _indGoals _avoidReinstalls
                               _shadowing _strFlags _maxBjumps _enableBj _solveExes
-                              _allowBootLibInstalls _onlyConstrained _order _verbosity) =
+                              _allowBootLibInstalls _onlyConstrained _order _verbosity
+                              _requireArtifacts _sourceArtifacts) =
     collectEithers $ map selectPackage (Set.toList targets)
   where
     selectPackage :: PackageName -> Either ResolveNoDepsError UnresolvedSourcePackage

--- a/cabal-install/src/Distribution/Client/Fetch.hs
+++ b/cabal-install/src/Distribution/Client/Fetch.hs
@@ -170,6 +170,8 @@ planPackages verbosity comp platform fetchFlags
 
       . setOnlyConstrained onlyConstrained
 
+      . setRequireArtifacts requireArtifacts
+
       . setSolverVerbosity verbosity
 
       . addConstraints
@@ -205,6 +207,7 @@ planPackages verbosity comp platform fetchFlags
     maxBackjumps     = fromFlag (fetchMaxBackjumps     fetchFlags)
     allowBootLibInstalls = fromFlag (fetchAllowBootLibInstalls fetchFlags)
     onlyConstrained  = fromFlag (fetchOnlyConstrained  fetchFlags)
+    requireArtifacts = fromFlag (fetchRequireArtifacts fetchFlags)
 
 
 checkTarget :: Verbosity -> UserTarget -> IO ()

--- a/cabal-install/src/Distribution/Client/Freeze.hs
+++ b/cabal-install/src/Distribution/Client/Freeze.hs
@@ -178,6 +178,8 @@ planPackages verbosity comp platform freezeFlags
 
       . setOnlyConstrained onlyConstrained
 
+      . setRequireArtifacts requireArtifacts
+
       . setSolverVerbosity verbosity
 
       . addConstraints
@@ -206,6 +208,7 @@ planPackages verbosity comp platform freezeFlags
     maxBackjumps     = fromFlag (freezeMaxBackjumps     freezeFlags)
     allowBootLibInstalls = fromFlag (freezeAllowBootLibInstalls freezeFlags)
     onlyConstrained  = fromFlag (freezeOnlyConstrained  freezeFlags)
+    requireArtifacts = fromFlag (freezeRequireArtifacts freezeFlags)
 
 
 -- | Remove all unneeded packages from an install plan.

--- a/cabal-install/src/Distribution/Client/Install.hs
+++ b/cabal-install/src/Distribution/Client/Install.hs
@@ -89,6 +89,7 @@ import qualified Distribution.Client.Win32SelfUpgrade as Win32SelfUpgrade
 import qualified Distribution.InstalledPackageInfo as Installed
 import Distribution.Client.JobControl
 
+import           Distribution.Solver.Types.ArtifactSelection
 import qualified Distribution.Solver.Types.ComponentDeps as CD
 import           Distribution.Solver.Types.ConstraintSource
 import           Distribution.Solver.Types.Settings
@@ -375,6 +376,10 @@ planPackages verbosity comp platform solver
 
       . setOnlyConstrained onlyConstrained
 
+      . setRequireArtifacts requireArtifacts
+
+      . setSourceArtifacts sourceArtifacts
+
       . setSolverVerbosity verbosity
 
       . setPreferenceDefault (if upgradeDeps then PreferAllLatest
@@ -438,6 +443,8 @@ planPackages verbosity comp platform solver
     maxBackjumps     = fromFlag (installMaxBackjumps      installFlags)
     allowBootLibInstalls = fromFlag (installAllowBootLibInstalls installFlags)
     onlyConstrained  = fromFlag (installOnlyConstrained   installFlags)
+    requireArtifacts = fromFlag (installRequireArtifacts  installFlags)
+    sourceArtifacts  = Just (sourceArts, sourceArts)
     upgradeDeps      = fromFlag (installUpgradeDeps       installFlags)
     onlyDeps         = fromFlag (installOnlyDeps          installFlags)
 
@@ -445,6 +452,12 @@ planPackages verbosity comp platform solver
                                  (configAllowOlder configExFlags)
     allowNewer       = fromMaybe (AllowNewer mempty)
                                  (configAllowNewer configExFlags)
+
+    sourceArts       = mconcat $
+      [ sourceArtsOf staticOutsOnly [(configVanillaLib, True)]
+      , sourceArtsOf dynOutsOnly    [(configSharedLib, False), (configDynExe, False)]
+      ]
+    sourceArtsOf arts fs = if any (\(fld, def) -> fromFlagOrDefault def . (fld $) $ configFlags) fs then arts else mempty
 
 -- | Remove the provided targets from the install plan.
 pruneInstallPlan :: Package targetpkg

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -535,7 +535,8 @@ convertLegacyAllPackageFlags globalFlags configFlags configExFlags installFlags 
     --installShadowPkgs         = projectConfigShadowPkgs,
       installStrongFlags        = projectConfigStrongFlags,
       installAllowBootLibInstalls = projectConfigAllowBootLibInstalls,
-      installOnlyConstrained    = projectConfigOnlyConstrained
+      installOnlyConstrained    = projectConfigOnlyConstrained,
+      installRequireArtifacts   = projectConfigRequireArtifacts
     } = installFlags
 
     ProjectFlags
@@ -782,6 +783,7 @@ convertToLegacySharedConfig
       installStrongFlags       = projectConfigStrongFlags,
       installAllowBootLibInstalls = projectConfigAllowBootLibInstalls,
       installOnlyConstrained   = projectConfigOnlyConstrained,
+      installRequireArtifacts  = projectConfigRequireArtifacts,
       installOnly              = mempty,
       installOnlyDeps          = projectConfigOnlyDeps,
       installIndexState        = projectConfigIndexState,
@@ -1192,7 +1194,7 @@ legacySharedConfigFieldDescrs constraintSrc = concat
       , "max-backjumps", "reorder-goals", "count-conflicts"
       , "fine-grained-conflicts" , "minimize-conflict-set", "independent-goals", "prefer-oldest"
       , "strong-flags" , "allow-boot-library-installs"
-      , "reject-unconstrained-dependencies", "index-state"
+      , "reject-unconstrained-dependencies", "require-artifacts", "index-state"
       ]
   . commandOptionsToFields
   $ installOptions ParseArgs

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -42,6 +42,7 @@ import Distribution.Client.IndexUtils.ActiveRepos
 import Distribution.Client.CmdInstall.ClientInstallFlags
          ( ClientInstallFlags(..) )
 
+import Distribution.Solver.Types.ArtifactSelection
 import Distribution.Solver.Types.Settings
 import Distribution.Solver.Types.ConstraintSource
 
@@ -201,6 +202,7 @@ data ProjectConfigShared
        projectConfigStrongFlags       :: Flag StrongFlags,
        projectConfigAllowBootLibInstalls :: Flag AllowBootLibInstalls,
        projectConfigOnlyConstrained   :: Flag OnlyConstrained,
+       projectConfigRequireArtifacts  :: Flag RequireArtifacts,
        projectConfigPerComponent      :: Flag Bool,
        projectConfigIndependentGoals  :: Flag IndependentGoals,
        projectConfigPreferOldest      :: Flag PreferOldest,
@@ -412,6 +414,8 @@ data SolverSettings
        solverSettingStrongFlags       :: StrongFlags,
        solverSettingAllowBootLibInstalls :: AllowBootLibInstalls,
        solverSettingOnlyConstrained   :: OnlyConstrained,
+       solverSettingRequireArtifacts  :: RequireArtifacts,
+       solverSettingSourceArtifacts   :: Maybe (ArtifactSelection, ArtifactSelection),
        solverSettingIndexState        :: Maybe TotalIndexState,
        solverSettingActiveRepos       :: Maybe ActiveRepos,
        solverSettingIndependentGoals  :: IndependentGoals,

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1075,6 +1075,10 @@ planPackages verbosity comp platform solver SolverSettings{..}
 
       . setOnlyConstrained solverSettingOnlyConstrained
 
+      . setRequireArtifacts solverSettingRequireArtifacts
+
+      . setSourceArtifacts solverSettingSourceArtifacts
+
       . setSolverVerbosity verbosity
 
         --TODO: [required eventually] decide if we need to prefer

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -956,6 +956,7 @@ data FetchFlags = FetchFlags {
       fetchStrongFlags      :: Flag StrongFlags,
       fetchAllowBootLibInstalls :: Flag AllowBootLibInstalls,
       fetchOnlyConstrained  :: Flag OnlyConstrained,
+      fetchRequireArtifacts :: Flag RequireArtifacts,
       fetchTests            :: Flag Bool,
       fetchBenchmarks       :: Flag Bool,
       fetchVerbosity :: Flag Verbosity
@@ -978,6 +979,7 @@ defaultFetchFlags = FetchFlags {
     fetchStrongFlags      = Flag (StrongFlags False),
     fetchAllowBootLibInstalls = Flag (AllowBootLibInstalls False),
     fetchOnlyConstrained  = Flag OnlyConstrainedNone,
+    fetchRequireArtifacts = Flag (RequireArtifacts True),
     fetchTests            = toFlag False,
     fetchBenchmarks       = toFlag False,
     fetchVerbosity = toFlag normal
@@ -1042,6 +1044,7 @@ fetchCommand = CommandUI {
                          fetchStrongFlags      (\v flags -> flags { fetchStrongFlags      = v })
                          fetchAllowBootLibInstalls (\v flags -> flags { fetchAllowBootLibInstalls = v })
                          fetchOnlyConstrained  (\v flags -> flags { fetchOnlyConstrained  = v })
+                         fetchRequireArtifacts (\v flags -> flags { fetchRequireArtifacts = v })
 
   }
 
@@ -1065,6 +1068,7 @@ data FreezeFlags = FreezeFlags {
       freezeStrongFlags      :: Flag StrongFlags,
       freezeAllowBootLibInstalls :: Flag AllowBootLibInstalls,
       freezeOnlyConstrained  :: Flag OnlyConstrained,
+      freezeRequireArtifacts :: Flag RequireArtifacts,
       freezeVerbosity        :: Flag Verbosity
     }
 
@@ -1085,6 +1089,7 @@ defaultFreezeFlags = FreezeFlags {
     freezeStrongFlags      = Flag (StrongFlags False),
     freezeAllowBootLibInstalls = Flag (AllowBootLibInstalls False),
     freezeOnlyConstrained  = Flag OnlyConstrainedNone,
+    freezeRequireArtifacts = Flag (RequireArtifacts True),
     freezeVerbosity        = toFlag normal
    }
 
@@ -1140,6 +1145,7 @@ freezeCommand = CommandUI {
                          freezeStrongFlags      (\v flags -> flags { freezeStrongFlags      = v })
                          freezeAllowBootLibInstalls (\v flags -> flags { freezeAllowBootLibInstalls = v })
                          freezeOnlyConstrained  (\v flags -> flags { freezeOnlyConstrained  = v })
+                         freezeRequireArtifacts (\v flags -> flags { freezeRequireArtifacts = v })
 
   }
 
@@ -1587,6 +1593,7 @@ data InstallFlags = InstallFlags {
     installStrongFlags      :: Flag StrongFlags,
     installAllowBootLibInstalls :: Flag AllowBootLibInstalls,
     installOnlyConstrained  :: Flag OnlyConstrained,
+    installRequireArtifacts :: Flag RequireArtifacts,
     installReinstall        :: Flag Bool,
     installAvoidReinstalls  :: Flag AvoidReinstalls,
     installOverrideReinstall :: Flag Bool,
@@ -1630,6 +1637,7 @@ defaultInstallFlags = InstallFlags {
     installStrongFlags     = Flag (StrongFlags False),
     installAllowBootLibInstalls = Flag (AllowBootLibInstalls False),
     installOnlyConstrained = Flag OnlyConstrainedNone,
+    installRequireArtifacts = Flag (RequireArtifacts True),
     installReinstall       = Flag False,
     installAvoidReinstalls = Flag (AvoidReinstalls False),
     installOverrideReinstall = Flag False,
@@ -1855,7 +1863,8 @@ installOptions showOrParseArgs =
                         installShadowPkgs       (\v flags -> flags { installShadowPkgs       = v })
                         installStrongFlags      (\v flags -> flags { installStrongFlags      = v })
                         installAllowBootLibInstalls (\v flags -> flags { installAllowBootLibInstalls = v })
-                        installOnlyConstrained  (\v flags -> flags { installOnlyConstrained  = v }) ++
+                        installOnlyConstrained  (\v flags -> flags { installOnlyConstrained  = v })
+                        installRequireArtifacts (\v flags -> flags { installRequireArtifacts = v }) ++
 
       [ option [] ["reinstall"]
           "Install even if it means installing the same version again."
@@ -2433,10 +2442,11 @@ optionSolverFlags :: ShowOrParseArgs
                   -> (flags -> Flag StrongFlags)      -> (Flag StrongFlags      -> flags -> flags)
                   -> (flags -> Flag AllowBootLibInstalls) -> (Flag AllowBootLibInstalls -> flags -> flags)
                   -> (flags -> Flag OnlyConstrained)  -> (Flag OnlyConstrained  -> flags -> flags)
+                  -> (flags -> Flag RequireArtifacts) -> (Flag RequireArtifacts -> flags -> flags)
                   -> [OptionField flags]
 optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg getcc setcc
                   getfgc setfgc getmc setmc getig setig getpo setpo getsip setsip
-                  getstrfl setstrfl getib setib getoc setoc =
+                  getstrfl setstrfl getib setib getoc setoc getra setra =
   [ option [] ["max-backjumps"]
       ("Maximum number of backjumps allowed while solving (default: " ++ show defaultMaxBackjumps ++ "). Use a negative number to enable unlimited backtracking. Use 0 to disable backtracking completely.")
       getmbj setmbj
@@ -2499,6 +2509,11 @@ optionSolverFlags showOrParseArgs getmbj setmbj getrg setrg getcc setcc
             (toFlag `fmap` parsec))
          (flagToList . fmap prettyShow))
 
+  , option [] ["require-artifacts"]
+      "Reject installed dependency package options that are missing required build artifacts (default)."
+      (fmap asBool . getra)
+      (setra . fmap RequireArtifacts)
+      (yesNoOpt showOrParseArgs)
   ]
 
 usagePackages :: String -> String -> String

--- a/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/cabal.out
+++ b/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/cabal.out
@@ -1,0 +1,14 @@
+# cabal v2-configure
+# cabal v2-build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - dynamic-1.0 (lib) (first run)
+Configuring library for dynamic-1.0..
+Preprocessing library for dynamic-1.0..
+Building library for dynamic-1.0..
+# cabal v2-sdist
+Wrote tarball sdist to <ROOT>/cabal.dist/dynamic-sdist-repo/dynamic-1.0.tar.gz
+# cabal v2-configure
+# depender depender
+Dynamic's number is 3.

--- a/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/cabal.test.hs
@@ -1,0 +1,227 @@
+import Test.Cabal.Prelude
+
+-- Build and install a package dynamically only, then build and install a
+-- package statically that depends on that dynamic package.  Old cabals are
+-- tempted to consider both the source package and the installed package
+-- (IPI) option with dynamic-only flags as valid, so they normally construct a
+-- build plan with this IPI option that results in a build error like the
+-- following:
+-- > [1 of 1] Compiling Main             ( Main.hs, ../setup.dist/work/depender/dist/build/depender/depender-tmp/Main.o )
+-- >
+-- > Main.hs:3:1: error:
+-- >     Could not find module `Dynamic'
+-- >     There are files missing in the `dynamic-1.0' package,
+-- >     try running 'ghc-pkg check'.
+-- >     Use -v (or `:set -v` in ghci) to see a list of the files searched for.
+-- >   |
+-- >   | import qualified Dynamic (number)
+-- >   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--
+-- However, with ‘--require-artifacts’ rather than ‘--no-require-artifacts’,
+-- cabal will detect this error in advance and reject this particular IPI,
+-- leaving only building the source package as the only valid package option
+-- (I) we can choose as an assignment for the QPN (and any other valid IPIs if
+-- there were multiple pre-installed packages to choose from, including those
+-- with configure flags that work for us).
+
+import Data.Maybe (fromMaybe)  -- for ghcPkg1'
+import Data.Version
+import System.Directory
+import System.FilePath
+
+main = do
+    cabalTest $ do
+        withPackageDb $ do
+            -- If ghc-pkg is too old, cabal-install still works but has the
+            -- same bug which we fixed, and our test would fail.  Skip.
+            skipIfOldGhcPkg
+
+            -- Build a package with only dynamic build artifacts.
+            sdistRepoDir <- (</> "dynamic-sdist-repo") . testWorkDir <$> getTestEnv
+            installDynamic sdistRepoDir
+
+            -- TODO: Before building a package that depends on this, just
+            -- double check that we actually have an IPI in the same packageDB
+            -- that will be used so that cabal-install will see it and be tempted.
+
+            -- Build a package that requires static build artifacts.  Old
+            -- cabal-installs don't bother to check static and dynamic
+            -- configuration, so it'll probably produce a build plan that'll
+            -- fail as we described above.  With the build artifact checker,
+            -- our pre-installed IPI option we made earlier is detected to not
+            -- be a valid option in advance, so rather than producing a build
+            -- plan we know will fail, instead reject this particular option,
+            -- so that the moduler resolver cabal-install uses only picks the
+            -- only valid option left, which is to build from source.  (For our
+            -- test to work, we need the depender build to be aware of both the
+            -- pre-installed option and also the source package so that it can
+            -- rebuild from source with the correct flags, so that the
+            -- bug/enhancement scenario can be reproduced.)
+            installDepender sdistRepoDir
+
+-- Run ‘ghc-pkg field base pkg-vanilla-lib’ to test whether the ghc-pkg
+-- we are using is new enough to support the 5 new IPI fields in the ‘.conf’
+-- files.  If ghc-pkg is too old, then its Cabal-syntax dependency
+-- (cabal-install also uses Cabal-syntax for the IPI fields) will emit an
+-- ‘Unknown field’ warning if cabal-install tries to update or register an IPI
+-- with new fields, but it should otherwise work besides having full
+-- functionality of the artifact checker.
+skipIfOldGhcPkg :: TestM ()
+skipIfOldGhcPkg = do
+    control <- resultExitCode <$> ghcPkg1' "field" ["*", "id"]
+    hasArts <- resultExitCode <$> ghcPkg1' "field" ["*", "pkg-vanilla-lib"]
+
+    -- cabal-install will still work without these 5 build artifact fields,
+    -- except the artifact checker wouldn't detect missing artifacts
+    -- without knowing what artifacts installed packages provide.
+    skipIf "ghc-pkg too old for 5 arts fields" $ hasArts /= control
+
+-- ghcPkg' that can return non-zero.
+--
+-- It's basically a copy except without ‘requireSuccess’.
+ghcPkg1' :: String -> [String] -> TestM Result
+ghcPkg1' cmd args = do
+    env <- getTestEnv
+    unless (testHavePackageDb env) $
+        error "Must initialize package database using withPackageDb"
+    -- NB: testDBStack already has the local database
+    ghcConfProg <- requireProgramM ghcProgram
+    let db_stack = testPackageDBStack env
+        extraArgs = ghcPkgPackageDBParams
+                        (fromMaybe
+                            (error "ghc-pkg: cannot detect version")
+                            (programVersion ghcConfProg))
+                        db_stack
+    recordHeader ["ghc-pkg", cmd]
+    runProgram1M ghcPkgProgram (cmd : extraArgs ++ args) Nothing
+    where
+        runProgram1M :: Program -> [String] -> Maybe String -> TestM Result
+        runProgram1M prog args input = do
+            configured_prog <- requireProgramM prog
+            -- TODO: Consider also using other information from
+            -- ConfiguredProgram, e.g., env and args
+            run1M (programPath configured_prog) args input
+
+        run1M :: FilePath -> [String] -> Maybe String -> TestM Result
+        run1M path args input = do
+            env <- getTestEnv
+            r <- liftIO $ run (testVerbosity env)
+                        (Just (testCurrentDir env))
+                        (testEnvironment env)
+                        path
+                        args
+                        input
+            recordLog r
+            return r
+
+-- Flags.
+-- (Swap the line comments to trigger the bug the artifect checker validation
+-- step fixes - the ‘missing files’ error.)
+--commonArgs = ["--disable-backup", "--no-require-artifacts"]
+commonArgs = ["--disable-backup"]
+dynamicArgs =
+    [
+        "--enable-shared",
+        "--enable-executable-dynamic",
+        "--disable-library-vanilla",
+        "--disable-static",
+        "--disable-executable-static"
+    ]
+staticArgs =
+    [
+        "--enable-static"
+    ]
+
+-- Build a package with only dynamic build artifacts.
+installDynamic :: FilePath -> TestM ()
+installDynamic sdistRepoDir = do
+    withDirectory "dynamic" $ do
+        withSourceCopyDir ("dyn") $ do
+            cwd <- fmap testSourceCopyDir getTestEnv
+            -- (Now do ‘cd ..’, since withSourceCopyDir made our previous
+            -- previous such withDirectories now accumulate to be
+            -- relative to cabal.dist/dyn, not testSourceDir
+            -- (see 'testCurrentDir').)
+            withDirectory ".." $ do
+                -- Our project still resides in ‘dynamic/’.
+                withDirectory "dynamic" $ do
+                    cabal "v2-configure" $ [] ++ commonArgs ++ dynamicArgs
+                    cabal "v2-build" $ []
+                    recordMode DoNotRecord $ do
+                        cabal "v2-install" $ ["--lib"] ++ commonArgs ++ dynamicArgs
+                    tmpBuildDir <- (</> "dynamic-sdist-build") . testWorkDir <$> getTestEnv
+                    cabal "v2-sdist" $ ["-o", sdistRepoDir, "--builddir", tmpBuildDir]
+
+-- Build a package that requires static build artifacts.  (The same packageDB
+-- is shared.)
+installDepender :: FilePath -> TestM ()
+installDepender sdistRepoDir = do
+    withDirectory "depender" $ do
+        withSourceCopyDir ("depr") $ do
+            cwd <- fmap testSourceCopyDir getTestEnv
+            -- (As before.)
+            withDirectory ".." $ do
+                withDirectory "depender" $ do
+                    -- depender knows of the source package and the installed package.
+                    -- The installed package should only have dynamic files (.dyn_hi,
+                    -- .so), but not any static files (.a, .hi).  New ghc-pkg IPI file
+                    -- fields track these, so with a new GHC, a new cabal-install
+                    -- should reject the installed package while building the tree
+                    -- (reason: missing build artifacts) and instead choose the sdist
+                    -- (source package) so that it can figure out its own configuration
+                    -- flags.
+                    --
+                    -- (For instance, if you comment out the sdist references so that we
+                    -- only see the installed package, you should see an error message
+                    -- like this (e.g. remove those two ‘-- ’ strings to write out only
+                    -- a ‘packages: ./../dep…’ line):)
+                    -- > Error: cabal: Could not resolve dependencies:
+                    -- > [__0] trying: depender-1.0 (user goal)
+                    -- > [__1] next goal: dynamic (dependency of depender)
+                    -- > [__1] rejecting: dynamic-1.0/installed-19c7c1e50b8f1e56115c4f668dfdadd7114fc2c7dad267c2df43028892cc0ff5 (missing build artifacts: static artifacts)
+                    -- > [__1] fail (backjumping, conflict set: depender, dynamic)
+                    -- > After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: depender (3), dynamic (2)
+
+                    -- Setup the project file.
+                    -- > sed -nEe 's/\{SDIST\}/…path…to…sdist…dir…/g; p' < cabal.project.in > cabal.project
+                    writeSourceFile "cabal.project" . unlines $
+                        [
+                            "packages: ./../depender/*.cabal",
+                            -- "" {-
+                            "",
+                            "repository my-local-repository",
+                            "    url: file+noindex://" ++ sdistRepoDir ++ "#shared-cache"
+                            --    -}
+                        ]
+
+                    -- Make sure our test scenario setup lets the depender see
+                    -- the pre-installed dynamic package IPI we built.
+                    guessedPackageDbPath <- do
+                        recordMode DoNotRecord $ do
+                            guessPackageDbPathDepender
+                    let sharedPackageDbFlags = ["--package-db=" ++ guessedPackageDbPath]
+
+                    -- Use 'staticArgs' here.
+                    cabal "v2-configure" $ [] ++ commonArgs ++ staticArgs ++ sharedPackageDbFlags
+                    recordMode DoNotRecord $ do
+                        cabal "v2-build" $ [] ++ sharedPackageDbFlags
+
+                    -- Optional: check the output.
+                    recordMode DoNotRecord $ do
+                        cabal "v2-install" $ [] ++ commonArgs ++ staticArgs
+                    withPlan $ do
+                        runPlanExe' "depender" "depender" []
+                            >>= assertOutputContains "Dynamic's number is 3."
+
+guessPackageDbPathDepender :: TestM FilePath
+guessPackageDbPathDepender = do
+    env <- getTestEnv
+    hasGhc <- isAvailableProgram ghcProgram
+    skipUnless "failed to guess package-db: couldn't find ghc" hasGhc
+    tryProgramVersion <- programVersion <$> requireProgramM ghcProgram
+    let convertVersion = makeVersion . versionNumbers
+    programVersion <- maybe (skip "failed to guess package-db: unknown ghc version" >> return "") return $ showVersion . convertVersion <$> tryProgramVersion
+    path <- liftIO . canonicalizePath $ testCabalDir env </> "store" </> "ghc-" ++ programVersion </> "package.db"
+    exists <- liftIO $ doesPathExist path
+    skipUnless ("failed to guess package-db: guessed dir path does not exist: " ++ path) exists
+    return path

--- a/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/depender/depender/.gitignore
+++ b/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/depender/depender/.gitignore
@@ -1,0 +1,1 @@
+/cabal.project

--- a/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/depender/depender/Main.hs
+++ b/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/depender/depender/Main.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import qualified Dynamic (number)
+
+main :: IO ()
+main = do
+    putStrLn $ "Dynamic's number is " ++ (show Dynamic.number) ++ "."

--- a/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/depender/depender/cabal.project.in
+++ b/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/depender/depender/cabal.project.in
@@ -1,0 +1,4 @@
+packages: ./*.cabal
+
+repository my-local-repository
+    url: file+noindex://{SDIST_PATH}#shared-cache

--- a/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/depender/depender/depender.cabal
+++ b/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/depender/depender/depender.cabal
@@ -1,0 +1,9 @@
+cabal-version: >= 1.10
+name: depender
+version: 1.0
+build-type: Simple
+
+executable depender
+  build-depends: dynamic, base
+  default-language: Haskell2010
+  main-is: Main.hs

--- a/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/dynamic/dynamic/Dynamic.hs
+++ b/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/dynamic/dynamic/Dynamic.hs
@@ -1,0 +1,10 @@
+module Dynamic where
+
+simple :: (a -> b -> c) -> b -> a -> c
+simple f = \a b -> f b a
+
+name :: String
+name = "Dynamic"
+
+number :: Integer
+number = 3

--- a/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/dynamic/dynamic/cabal.project
+++ b/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/dynamic/dynamic/cabal.project
@@ -1,0 +1,1 @@
+packages: ./*.cabal

--- a/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/dynamic/dynamic/dynamic.cabal
+++ b/cabal-testsuite/PackageTests/LinkerOptions/DynDeps/dynamic/dynamic/dynamic.cabal
@@ -1,0 +1,10 @@
+cabal-version: >= 1.10
+name: dynamic
+version: 1.0
+build-type: Simple
+
+library
+  default-language: Haskell2010
+  build-depends: base
+  exposed-modules:
+    Dynamic


### PR DESCRIPTION
This was originally the second of two parts to the ‘Track static vs. dynamic dependencies.’ pull request ([#8461](https://github.com/haskell/cabal/pull/8461)), which I've cleaned up and split into two separate PRs.

As in the commit message:
```
Track build artifacts in installed packages.

    1) Extend the InstalledPackageInfo record with 5 records involving
    configuration flags that affect which build artifacts (dynamic and static
    files) are provided.  (This record corresponds to the ‘.conf’ files in
    package-db directories, and Cabal-syntax provides an interface to this record.
    Cabal-syntax is used as a dependency by ‘ghc-pkg’ and ‘cabal-install’, and old
    Cabal-syntax implementations may produce an ‘Unknown field’ warning when used
    with new ‘.conf’ files.)
    2) Add a step to the validation phase of the modular resolver that also rules
    out pre-installed package options that would introduce a missing artifact
    condition, so that alternatives if available can be chosen instead, rather than
    producing assignments for a build plan that would fail with ‘files missing’
    (e.g. ‘….hi’ or ‘….dyn_hi’).
```

Additionally this adds a test that shows what this new step in the validation
phase of the modular resolver can check.

As written in the second commit message:
```
Add a PackageTest test for missing static files.

    The test builds and installs a package dynamically only, then builds and
    install a package statically that depends on that dynamic package.

    This demonstrates how cabal-install can fail when it ignores which build
    artifacts are provided by a package, e.g. static and/or dynamic files.  Recent
    changes add to the InstalledPackageInfo record so that installed packages are
    more explicit in what is available, so that cabal-install is better able to
    know when it should rebuild from source, when installed packages were not built
    from config flags to build the required artifacts.
```

(I ran the cabal-testsuite/PackageTests test suite and found ‘432 tests, 6 skipped, 0 unexpected passes, 0 unexpected fails’.)