### PR TITLE
TargetSelector: Include a hint in the error message for internal error

### DIFF
--- a/cabal-install/src/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/src/Distribution/Client/TargetSelector.hs
@@ -713,21 +713,26 @@ reportTargetSelectorProblems verbosity problems = do
     case [ (t, m, ms) | MatchingInternalError t m ms <- problems ] of
       [] -> return ()
       ((target, originalMatch, renderingsAndMatches):_) ->
-        die' verbosity $ "Internal error in target matching. It should always "
-           ++ "be possible to find a syntax that's sufficiently qualified to "
-           ++ "give an unambiguous match. However when matching '"
-           ++ showTargetString target ++ "'  we found "
-           ++ showTargetSelector originalMatch
-           ++ " (" ++ showTargetSelectorKind originalMatch ++ ") which does "
-           ++ "not have an unambiguous syntax. The possible syntax and the "
-           ++ "targets they match are as follows:\n"
+        die' verbosity $ "Internal error in target matching: could not make an "
+           ++ "unambiguous fully qualified target selector for '"
+           ++ showTargetString target ++ "'.\n"
+           ++ "We made the target '" ++ showTargetSelector originalMatch ++ "' ("
+           ++ showTargetSelectorKind originalMatch ++ ") that was expected to "
+           ++ "be unambiguous but matches the following targets:\n"
            ++ unlines
-                [ "'" ++ showTargetString rendering ++ "' which matches "
-                  ++ intercalate ", "
+                [ "'" ++ showTargetString rendering ++ "', matching:"
+                  ++ concatMap ("\n  - " ++)
                        [ showTargetSelector match ++
                          " (" ++ showTargetSelectorKind match ++ ")"
                        | match <- matches ]
                 | (rendering, matches) <- renderingsAndMatches ]
+           ++ "\nNote: Cabal expects to be able to make a single fully "
+           ++ "qualified name for a target or provide a more specific error. "
+           ++ "Our failure to do so is a bug in cabal. "
+           ++ "Tracking issue: https://github.com/haskell/cabal/issues/8684"
+           ++ "\n\nHint: this may be caused by trying to build a package that "
+           ++ "exists in the project directory but is missing from "
+           ++ "the 'packages' stanza in your cabal project file."
 
     case [ (t, e, g) | TargetSelectorExpected t e g <- problems ] of
       []      -> return ()


### PR DESCRIPTION
This is a mediocre solution, and really should generate a different error entirely at an earlier stage, but I'm not familiar enough with how to achieve that and I don't think I have time at the moment.

Fixes #8484.

```
[nix-shell:~/co/cabal/t8484]$ cabal build lib:generic-deriving
Error: cabal: Internal error in target matching. It should always be possible
to find a syntax that's sufficiently qualified to give an unambiguous match.
However when matching 'lib:generic-deriving' we found lib:generic-deriving
(unknown-component) which does not have an unambiguous syntax. The possible
syntax and the targets they match are as follows:
'lib:generic-deriving' which matches lib:generic-deriving (unknown-component),
:pkg:lib:lib:lib:file:generic-deriving (unknown-file)


[nix-shell:~/co/cabal/t8484]$ /Users/jade/co/cabal/dist-newstyle/build/aarch64-osx/ghc-9.2.4/cabal-install-3.9.0.0/x/cabal/build/cabal/cabal build lib:generic-deriving
Warning: this is a debug build of cabal-install with assertions enabled.
Error: cabal: Internal error in target matching. It should always be possible
to find a syntax that's sufficiently qualified to give an unambiguous match.
However when matching 'lib:generic-deriving' we found lib:generic-deriving
(unknown-component) which does not have an unambiguous syntax. The possible
syntax and the targets they match are as follows:
'lib:generic-deriving' which matches lib:generic-deriving (unknown-component),
:pkg:lib:lib:lib:file:generic-deriving (unknown-file)


Hint: this may be caused by trying to build a package that exists in the
project directory but is missing from cabal.project.
```
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [??] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
