### PR TITLE
Specify default exe extension on wasm32 to be .wasm

### DIFF
--- a/Cabal/src/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/src/Distribution/Simple/BuildPaths.hs
@@ -235,8 +235,9 @@ mkGenericSharedBundledLibName platform comp lib
 -- | Default extension for executable files on the current platform.
 -- (typically @\"\"@ on Unix and @\"exe\"@ on Windows or OS\/2)
 exeExtension :: Platform -> String
-exeExtension (Platform _arch os) = case os of
-                   Windows -> "exe"
+exeExtension platform = case platform of
+                   Platform _ Windows -> "exe"
+                   Platform Wasm32 _  -> "wasm"
                    _       -> ""
 
 -- | Extension for object files. For GHC the extension is @\"o\"@.

--- a/Cabal/src/Distribution/Simple/Utils.hs
+++ b/Cabal/src/Distribution/Simple/Utils.hs
@@ -1535,12 +1535,13 @@ dropExeExtension filepath =
 -- | List of possible executable file extensions on the current build
 -- platform.
 exeExtensions :: [String]
-exeExtensions = case buildOS of
+exeExtensions = case (buildArch, buildOS) of
   -- Possible improvement: on Windows, read the list of extensions from the
   -- PATHEXT environment variable. By default PATHEXT is ".com; .exe; .bat;
   -- .cmd".
-  Windows -> ["", "exe"]
-  Ghcjs   -> ["", "exe"]
+  (_, Windows) -> ["", "exe"]
+  (_, Ghcjs)   -> ["", "exe"]
+  (Wasm32, _)  -> ["", "wasm"]
   _       -> [""]
 
 -- ------------------------------------------------------------

--- a/changelog.d/pr-8633
+++ b/changelog.d/pr-8633
@@ -1,0 +1,7 @@
+synopsis: Specify default exe extension on wasm32 to be .wasm
+packages: Cabal
+prs: #8633
+issues:
+description: {
+  Specify default exe extension on wasm32 to be .wasm, following the convention in other WebAssembly toolchains.
+}


### PR DESCRIPTION
This PR changes default exe extension on wasm32 to be `.wasm`, following convention of other WebAssembly toolchains. This is a part of the effort tracked in https://gitlab.haskell.org/ghc/ghc/-/issues/22594.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.