### PR TITLE
root relative glob expansion of extra source files

### DIFF
--- a/cabal-install/src/Distribution/Client/SourceFiles.hs
+++ b/cabal-install/src/Distribution/Client/SourceFiles.hs
@@ -39,7 +39,7 @@ import Distribution.ModuleName
 
 import Prelude ()
 import Distribution.Client.Compat.Prelude
-import Distribution.Verbosity (silent)
+import Distribution.Verbosity (normal)
 
 import System.FilePath
 
@@ -150,7 +150,8 @@ needBuildInfo pkg_descr bi modules = do
     -- A.hs-boot; need to track both.
     findNeededModules ["hs", "lhs", "hsig", "lhsig"]
     findNeededModules ["hs-boot", "lhs-boot"]
-    expandedExtraSrcFiles <- liftIO $ fmap concat . for (extraSrcFiles pkg_descr) $ \fpath -> matchDirFileGlobWithDie silent (\ _ _ -> return []) (specVersion pkg_descr) "." fpath
+    root <- askRoot
+    expandedExtraSrcFiles <- liftIO $ fmap concat . for (extraSrcFiles pkg_descr) $ \fpath -> matchDirFileGlobWithDie normal (\ _ _ -> return []) (specVersion pkg_descr) root fpath
     traverse_ needIfExists $ concat
         [ cSources bi
         , cxxSources bi

--- a/changelog.d/pr-8640
+++ b/changelog.d/pr-8640
@@ -1,0 +1,10 @@
+synopsis: Fix extra-source-file rebuild tracking when run in a multi-package project
+packages: cabal-install
+issues: #8632 #8634
+prs: #8640
+
+description: {
+
+- Fixes an issue where glob expansion of extra-source-files for rebuild tracking purposes was not occuring correctly when run in a multi-package setting (i.e. when the globs needed to be expanded relative to something other than ".").
+
+}


### PR DESCRIPTION
Resolves https://github.com/haskell/cabal/issues/8632 
Resolves https://github.com/haskell/cabal/issues/8634

This was indeed a bug in https://github.com/haskell/cabal/pull/7608

The confusion is that the cabal in the 3.6 series tested against did not contain a backport of that patch.

The issue is that extra-source-file glob expansion was written to expand relative to "." rather than the relative root of the package in question. So this worked in single-package setups, but not when in the base directory of a project with multiple packages.

Along the way, this bumps the verbosity of glob expansion.