### PR TITLE
Cabal-syntax-3.8.1.0: allow mtl-2.3 and transformers-0.6

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -36,14 +36,14 @@ library
     deepseq    >= 1.3.0.1  && < 1.5,
     directory  >= 1.2      && < 1.4,
     filepath   >= 1.3.0.1  && < 1.5,
-    mtl        >= 2.1      && < 2.3,
+    mtl        >= 2.1      && < 2.4,
     parsec     >= 3.1.13.0 && < 3.2,
     pretty     >= 1.1.1    && < 1.2,
     text       (>= 1.2.3.0 && < 1.3) || (>= 2.0 && < 2.1),
     time       >= 1.4.0.1  && < 1.13,
     -- transformers-0.4.0.0 doesn't have record syntax e.g. for Identity
     -- See also https://github.com/ekmett/transformers-compat/issues/35
-    transformers (>= 0.3      && < 0.4) || (>=0.4.1.0 && <0.6)
+    transformers (>= 0.3      && < 0.4) || (>=0.4.1.0 && <0.7)
 
   if os(windows)
     build-depends: Win32 >= 2.3.0.0 && < 2.14

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -52,11 +52,9 @@ library
     build-depends: unix  >= 2.6.0.0 && < 2.8
 
   ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  ghc-options: -Wcompat -Wnoncanonical-monad-instances
 
-  if impl(ghc >= 8.0)
-    ghc-options: -Wcompat -Wnoncanonical-monad-instances
-
-  if impl(ghc >= 8.0) && impl(ghc < 8.8)
+  if impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
   exposed-modules:

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -1,6 +1,7 @@
 cabal-version: 1.22
 name:          Cabal-syntax
 version:       3.8.1.0
+x-revision:    2
 copyright:     2003-2022, Cabal Development Team (see AUTHORS file)
 license:       BSD3
 license-file:  LICENSE
@@ -29,7 +30,7 @@ library
 
   build-depends:
     array      >= 0.4.0.1  && < 0.6,
-    base       >= 4.6      && < 5,
+    base       >= 4.9      && < 5,
     binary     >= 0.7      && < 0.9,
     bytestring >= 0.10.0.0 && < 0.12,
     containers >= 0.5.0.0  && < 0.7,


### PR DESCRIPTION
The released Cabal-syntax 3.8.1.0 is already compatible with mtl-2.3.  I am intending to make the respective revision on Hackage (details see this PR).  This PR updates the 3.8 branch accordingly.

Lifted from: https://github.com/haskell/hackage-security/pull/289#issuecomment-1367200577

@Mikolaj wrote:
> if it's useful to anybody, I can revise even omitting the comment (but we should probably amend 3.8 branch, too, which has old bounds, so that somebody compiling from 3.8 branch source doesn't have worse bounds than from Hackage).

(I'd think the said comment can remain.)
