### PR TITLE
Temporarily expose some functionality for a hack in Hadrian

### DIFF
--- a/changelog.d/pr-8649
+++ b/changelog.d/pr-8649
@@ -1,0 +1,10 @@
+synopsis: Expose some functionality temporary for hack to build GHC
+prs: #8649
+
+description: {
+
+`runConfigureScriptAndReadAndValidateBuildInfo` should not be used for any
+other purpose as it has no stability guarantee and is marked deprecated to
+indicate this and ward of accidental usage.
+
+}


### PR DESCRIPTION
The hack is to skip the `postConf` hook for the RTS, because the detection of foreign libraries wasn't working.

The problem is that we are making the RTS use a configure script we can no longer skip *all* of `postConf` because then we will not run the configure script!

I am not sure what is the *right* thing to expose for this, so I am just making a perma-unstable stop-gap, by. deprecating it proactively. The RTS should not need this hack (indeed, only the Darwin jobs fail without it), and so I hope the longer-term solution is just to rid of it, obviating any need for Cabal changes.

Needed for https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6822

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
