### PR TITLE
Remove "'-main-is' is not portable" check

### DIFF
--- a/Cabal-tests/tests/CheckTests.hs
+++ b/Cabal-tests/tests/CheckTests.hs
@@ -56,6 +56,7 @@ checkTests = testGroup "regressions"
     , checkTest "issue-7776-a.cabal"
     , checkTest "issue-7776-b.cabal"
     , checkTest "issue-7776-c.cabal"
+    , checkTest "issue-8646.cabal"
     ]
 
 checkTest :: FilePath -> TestTree

--- a/Cabal-tests/tests/ParserTests/regressions/issue-8646.cabal
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-8646.cabal
@@ -1,0 +1,16 @@
+cabal-version: 3.0
+
+name: issue
+version: 8646
+build-type: Simple
+category: Test
+maintainer: Joe
+synopsis: Input to 'cabal check'
+description: Input to 'cabal check'.
+license: BSD-3-Clause
+
+executable test
+  main-is: ExeMain.hs
+  build-depends: base > 4 && < 5
+  default-language: Haskell2010
+  ghc-options: -main-is ExeMain

--- a/Cabal-tests/tests/ParserTests/regressions/issue-8646.check
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-8646.check
@@ -1,1 +1,0 @@
-'ghc-options: -main-is' is not portable.

--- a/Cabal-tests/tests/ParserTests/regressions/issue-8646.check
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-8646.check
@@ -1,0 +1,1 @@
+'ghc-options: -main-is' is not portable.

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -179,7 +179,6 @@ data CheckExplanation =
         | OptO String
         | OptHide String
         | OptMake String
-        | OptMain String
         | OptONot String
         | OptOOne String
         | OptOTwo String
@@ -468,8 +467,6 @@ ppExplanation (OptHide fieldName) =
 ppExplanation (OptMake fieldName) =
     "'" ++ fieldName
       ++ ": --make' is never needed. Cabal uses this automatically."
-ppExplanation (OptMain fieldName) =
-    "'" ++ fieldName ++ ": -main-is' is not portable."
 ppExplanation (OptONot fieldName) =
       "'" ++ fieldName ++ ": -O0' is not needed. "
       ++ "Use the --disable-optimization configure flag."
@@ -1369,9 +1366,6 @@ checkGhcOptions fieldName getOptions pkg =
 
   , checkFlags ["--make"] $
       PackageBuildWarning (OptMake fieldName)
-
-  , checkFlags ["-main-is"] $
-      PackageDistSuspicious (OptMain fieldName)
 
   , checkNonTestAndBenchmarkFlags ["-O0", "-Onot"] $
       PackageDistSuspicious (OptONot fieldName)

--- a/changelog.d/issue-8646
+++ b/changelog.d/issue-8646
@@ -1,0 +1,10 @@
+synopsis: Remove "'-main-is' is not portable" check
+packages: Cabal
+prs: #8651
+issues: #8646
+
+description: {
+
+'cabal check' no longer complains about '-main-is' flag in 'ghc-options'
+
+}


### PR DESCRIPTION
Fix #8646. I've checked that cabal doesn't complain about presence of `-main-is` whereas it does complain if I revert the commit. 

Please let me know if you'd like to add a test for this.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
