### PR TITLE
Re #6125: document that glob dirs are buggy in Cabal 2.4

### DIFF
--- a/doc/cabal-package.rst
+++ b/doc/cabal-package.rst
@@ -763,7 +763,8 @@ describe the package as a whole:
     behaviour, put the files that wildcards will match against in
     their own folder.
 
-    ``**`` wildcards are available starting in Cabal 2.4.
+    ``**`` wildcards are available starting in Cabal 2.4
+    and `bug-free since Cabal 3.0 <https://github.com/haskell/cabal/issues/6125#issuecomment-1379878419>`_.
 
 .. pkg-field:: data-dir: directory
 

--- a/doc/file-format-changelog.rst
+++ b/doc/file-format-changelog.rst
@@ -161,6 +161,10 @@ relative to the respective preceding *published* version.
     ``foo/**/bar.html`` are all invalid). As ``**`` was an error in
     globs before, this does not affect any existing ``.cabal`` files
     that previously worked.
+    (Caveat: Double-star wildcards in :pkg-field:`data-files` directories,
+    e.g. ``data-files: data/**/*.csv``,
+    `are only supported correctly from Cabal 3.0 <https://github.com/haskell/cabal/issues/6125#issuecomment-1379878419>`_.)
+
 
   * Wildcards now match when the pattern's extensions form a suffix of
     the candidate file's extension, rather than requiring strict


### PR DESCRIPTION
Re #6125: document that glob dirs are buggy in Cabal 2.4.

`cabal-version: 2.4` allows e.g. `data-files: foo/**/*.txt` but `**` directories are only handled correctly since Cabal 3.0 (issue #6125). This information should be part of the cabal file format history documentation.

Rendering here:
- End of this section: https://cabal--8665.org.readthedocs.build/en/8665/cabal-package.html#pkg-field-data-files
- "Caveat" here: https://cabal--8665.org.readthedocs.build/en/8665/file-format-changelog.html#cabal-version-2-4

Relevant CI succeeds.