### PR TITLE
Bump known ghc versions in cabal library to < 9.8

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -140,12 +140,12 @@ configure verbosity hcPath hcPkgPath conf0 = do
       (userMaybeSpecifyPath "ghc" hcPath conf0)
   let implInfo = ghcVersionImplInfo ghcVersion
 
-  -- Cabal currently supports ghc >= 7.0.1 && < 9.6
+  -- Cabal currently supports ghc >= 7.0.1 && < 9.8
   -- ... and the following odd development version
-  unless (ghcVersion < mkVersion [9,6]) $
+  unless (ghcVersion < mkVersion [9,8]) $
     warn verbosity $
          "Unknown/unsupported 'ghc' version detected "
-      ++ "(Cabal " ++ prettyShow cabalVersion ++ " supports 'ghc' version < 9.6): "
+      ++ "(Cabal " ++ prettyShow cabalVersion ++ " supports 'ghc' version < 9.8): "
       ++ programPath ghcProg ++ " is version " ++ prettyShow ghcVersion
 
   -- This is slightly tricky, we have to configure ghc first, then we use the


### PR DESCRIPTION
If somebody would like to address https://github.com/haskell/cabal/pull/8260#discussion_r911641340 and factor out the thrice used GHC version number constant, pretty please do, before this PR gets merged. Otherwise, let's kick the can once again.
