### PR TITLE
Revert "add marked output to `cabal list-bin`"

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdListBin.hs
+++ b/cabal-install/src/Distribution/Client/CmdListBin.hs
@@ -34,12 +34,12 @@ import Distribution.Client.TargetProblem         (TargetProblem (..))
 import Distribution.Simple.BuildPaths            (dllExtension, exeExtension)
 import Distribution.Simple.Command               (CommandUI (..))
 import Distribution.Simple.Setup                 (configVerbosity, fromFlagOrDefault)
-import Distribution.Simple.Utils                 (die', info, wrapText)
+import Distribution.Simple.Utils                 (die', wrapText)
 import Distribution.System                       (Platform)
 import Distribution.Types.ComponentName          (showComponentName)
 import Distribution.Types.UnitId                 (UnitId)
 import Distribution.Types.UnqualComponentName    (UnqualComponentName)
-import Distribution.Verbosity                    (normal, silent, verboseStderr)
+import Distribution.Verbosity                    (silent, verboseStderr)
 import System.FilePath                           ((<.>), (</>))
 
 import qualified Data.Map                                as Map
@@ -133,7 +133,7 @@ listbinAction flags@NixStyleFlags{..} args globalFlags = do
 
     case binfiles of
         []     -> die' verbosity "No target found"
-        [exe] -> info normal exe
+        [exe] -> putStrLn exe
         _ -> die' verbosity "Multiple targets found"
   where
     defaultVerbosity = verboseStderr silent


### PR DESCRIPTION
Reverts 
- #8622

Said PR didn't solve #8400 properly and introduced regression #8664.  As 3.10 cut is imminent, I propose a swift action here, giving us peace to solve #8400 without time pressure.

Fixes #8664.

Update: I have prepared another PR, #8670, that fixes #8400.  If we manage to merge that one quickly, we do not need the present PR.
- #8670