### PR TITLE
Update bootstrap root keys

### DIFF
--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -737,10 +737,23 @@ addInfoForKnownRepos other = other
 --
 defaultHackageRemoteRepoKeys :: [String]
 defaultHackageRemoteRepoKeys =
-    [ "fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0",
+    -- Key owners and public keys are provided as a convenience to readers.
+    -- The canonical source for this mapping data is the hackage-root-keys
+    -- repository and Hackage's root.json file.
+    --
+    -- Links:
+    --  * https://github.com/haskell-infra/hackage-root-keys
+    --  * https://hackage.haskell.org/root.json
+    -- Please consult root.json on Hackage to map key IDs to public keys,
+    -- and the hackage-root-keys repository to map public keys to their
+    -- owners.
+    [ -- Adam Gundry (uRPdSiL3/MNsk50z6NB55ABo0OrrNDXigtCul4vtzmw=)
+      "fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0",
+      -- Gershom Bazerman (bYoUXXQ9TtX10UriaMiQtTccuXPGnmldP68djzZ7cLo=)
       "1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42",
-      "2c6c3627bd6c982990239487f1abd02e08a02e6cf16edb105a8012d444d870c3",
+      -- John Wiegley (zazm5w480r+zPO6Z0+8fjGuxZtb9pAuoVmQ+VkuCvgU=)
       "0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d",
+      -- Norman Ramsey (ZI8di3a9Un0s2RBrt5GwVRvfOXVuywADfXGPZfkiDb0=)
       "51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921"
     ]
 


### PR DESCRIPTION
Johan Tibell is not part of the signing process anymore, so his key is removed.

I've also annotated the keys with their owners and public keys, because every time we consult this, I end up spending a bunch of time in a scratch buffer correlating key IDs, public key values, and ownership attestations. Might as well save the work for next time, with appropriate disclaimers added.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

I was unable to test the changes, as I can't build the contents of the repo right now:
```
$ cabal update
Downloading the latest package list from hackage.haskell.org
Updated package list of hackage.haskell.org to the index-state 2023-01-13T05:15:22Z
To revert to previous state run:
    cabal v2-update 'hackage.haskell.org,2022-11-14T10:09:26Z'
$ cabal v2-build Cabal
Resolving dependencies...
cabal: Could not resolve dependencies:
[__0] trying: cabal-testsuite-3 (user goal)
[__1] next goal: cabal-testsuite:setup.Cabal (dependency of cabal-testsuite)
[__1] rejecting: cabal-testsuite:setup.Cabal-3.9.0.0,
cabal-testsuite:setup.Cabal-3.8.1.0 (constraint from maximum version of Cabal
used by Setup.hs requires <3.8)
[__1] rejecting: cabal-testsuite:setup.Cabal-3.6.3.0/installed-3.6.3.0
(conflict: cabal-testsuite => cabal-testsuite:setup.Cabal>=3.8 && <3.9)
[__1] skipping: cabal-testsuite:setup.Cabal-3.6.3.0,
cabal-testsuite:setup.Cabal-3.6.2.0, cabal-testsuite:setup.Cabal-3.6.1.0,
cabal-testsuite:setup.Cabal-3.6.0.0, cabal-testsuite:setup.Cabal-3.4.1.0,
cabal-testsuite:setup.Cabal-3.4.0.0, cabal-testsuite:setup.Cabal-3.2.1.0,
cabal-testsuite:setup.Cabal-3.2.0.0, cabal-testsuite:setup.Cabal-3.0.2.0,
cabal-testsuite:setup.Cabal-3.0.1.0, cabal-testsuite:setup.Cabal-3.0.0.0,
cabal-testsuite:setup.Cabal-2.4.1.0, cabal-testsuite:setup.Cabal-2.4.0.1,
cabal-testsuite:setup.Cabal-2.4.0.0, cabal-testsuite:setup.Cabal-2.2.0.1,
cabal-testsuite:setup.Cabal-2.2.0.0, cabal-testsuite:setup.Cabal-2.0.1.1,
cabal-testsuite:setup.Cabal-2.0.1.0, cabal-testsuite:setup.Cabal-2.0.0.2,
cabal-testsuite:setup.Cabal-1.24.2.0, cabal-testsuite:setup.Cabal-1.24.0.0,
cabal-testsuite:setup.Cabal-1.22.8.0, cabal-testsuite:setup.Cabal-1.22.7.0,
cabal-testsuite:setup.Cabal-1.22.6.0, cabal-testsuite:setup.Cabal-1.22.5.0,
cabal-testsuite:setup.Cabal-1.22.4.0, cabal-testsuite:setup.Cabal-1.22.3.0,
cabal-testsuite:setup.Cabal-1.22.2.0, cabal-testsuite:setup.Cabal-1.22.1.1,
cabal-testsuite:setup.Cabal-1.22.1.0, cabal-testsuite:setup.Cabal-1.22.0.0,
cabal-testsuite:setup.Cabal-1.20.0.4, cabal-testsuite:setup.Cabal-1.20.0.3,
cabal-testsuite:setup.Cabal-1.20.0.2, cabal-testsuite:setup.Cabal-1.20.0.1,
cabal-testsuite:setup.Cabal-1.20.0.0, cabal-testsuite:setup.Cabal-1.18.1.7,
cabal-testsuite:setup.Cabal-1.18.1.6, cabal-testsuite:setup.Cabal-1.18.1.5,
cabal-testsuite:setup.Cabal-1.18.1.4, cabal-testsuite:setup.Cabal-1.18.1.3,
cabal-testsuite:setup.Cabal-1.18.1.2, cabal-testsuite:setup.Cabal-1.18.1.1,
cabal-testsuite:setup.Cabal-1.18.1, cabal-testsuite:setup.Cabal-1.18.0,
cabal-testsuite:setup.Cabal-1.16.0.3, cabal-testsuite:setup.Cabal-1.16.0.2,
cabal-testsuite:setup.Cabal-1.16.0.1, cabal-testsuite:setup.Cabal-1.16.0,
cabal-testsuite:setup.Cabal-1.14.0, cabal-testsuite:setup.Cabal-1.12.0,
cabal-testsuite:setup.Cabal-1.10.2.0, cabal-testsuite:setup.Cabal-1.10.1.0,
cabal-testsuite:setup.Cabal-1.10.0.0, cabal-testsuite:setup.Cabal-1.8.0.6,
cabal-testsuite:setup.Cabal-1.8.0.4, cabal-testsuite:setup.Cabal-1.8.0.2,
cabal-testsuite:setup.Cabal-1.6.0.3, cabal-testsuite:setup.Cabal-1.6.0.2,
cabal-testsuite:setup.Cabal-1.6.0.1, cabal-testsuite:setup.Cabal-1.4.0.2,
cabal-testsuite:setup.Cabal-1.4.0.1, cabal-testsuite:setup.Cabal-1.4.0.0,
cabal-testsuite:setup.Cabal-1.2.4.0, cabal-testsuite:setup.Cabal-1.2.3.0,
cabal-testsuite:setup.Cabal-1.2.2.0, cabal-testsuite:setup.Cabal-1.2.1,
cabal-testsuite:setup.Cabal-1.1.6, cabal-testsuite:setup.Cabal-1.24.1.0 (has
the same characteristics that caused the previous version to fail: excluded by
constraint '>=3.8 && <3.9' from 'cabal-testsuite')
[__1] fail (backjumping, conflict set: cabal-testsuite,
cabal-testsuite:setup.Cabal)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: cabal-testsuite,
cabal-testsuite:setup.Cabal

$ cabal --version
cabal-install version 3.6.2.0
compiled using version 3.6.2.0 of the Cabal library 
```

So I'll rely on CI.