### PR TITLE
Fix #8400 by marking output of `cabal list-bin`

### DIFF
--- a/cabal-testsuite/PackageTests/ListBin/Script/cabal.out
+++ b/cabal-testsuite/PackageTests/ListBin/Script/cabal.out
@@ -3,3 +3,4 @@ Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - fake-package-0 (exe:cabal-script-script.hs) (first run)
+<ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/fake-package-0/x/cabal-script-script.hs/build/cabal-script-script.hs/cabal-script-script.hs

--- a/cabal-testsuite/PackageTests/ListBin/SelectedComponent/cabal.out
+++ b/cabal-testsuite/PackageTests/ListBin/SelectedComponent/cabal.out
@@ -3,3 +3,4 @@ Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
  - SelectedComponent-1.0.0 (exe:testexe) (first run)
+<ROOT>/cabal.dist/work/./dist/build/<ARCH>/ghc-<GHCVER>/SelectedComponent-1.0.0/build/testexe/testexe

--- a/cabal-testsuite/PackageTests/ListBin/SelectedComponent/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ListBin/SelectedComponent/cabal.test.hs
@@ -4,5 +4,4 @@ import Test.Cabal.Prelude
 main = cabalTest . void $ do
     res <- cabal' "list-bin" ["exe:testexe"]
 
-    assertOutputContains "SelectedComponent-1.0.0" res
-    assertOutputContains "testexe" res
+    assertOutputContains "SelectedComponent-1.0.0/build/testexe/testexe" res

--- a/cabal-testsuite/PackageTests/ListBin/SelectedComponent/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ListBin/SelectedComponent/cabal.test.hs
@@ -1,7 +1,12 @@
+import System.FilePath ( joinPath )
+
 import Test.Cabal.Prelude
 
 -- https://github.com/haskell/cabal/issues/7679
+-- https://github.com/haskell/cabal/issues/8400
+
 main = cabalTest . void $ do
     res <- cabal' "list-bin" ["exe:testexe"]
 
-    assertOutputContains "SelectedComponent-1.0.0/build/testexe/testexe" res
+    let path = joinPath ["SelectedComponent-1.0.0", "build", "testexe", "testexe"]
+    assertOutputContains path res


### PR DESCRIPTION
Fix #8400 by marking output of `cabal list-bin`

The regular output of `cabal list-bin` should go to stdout always, but be marked for the sake of the testsuite.

- fixes #8400 
- fixes #8664 

If this PR is merged quickly, we do not need:
- #8668

Replaces:
- #8622