### PR TITLE
cabal-testsuite #8401: communicate better the need for `--with-cabal`

### DIFF
--- a/cabal-testsuite/README.md
+++ b/cabal-testsuite/README.md
@@ -7,8 +7,8 @@ How to run
 1. Build `cabal-testsuite` (`cabal build cabal-testsuite:cabal-tests`)
 2. Run the `cabal-tests` executable. It will scan for all tests
    in your current directory and subdirectories and run them.
-   To run a specific set of tests, use `cabal-tests PATH ...`.
-   (e.g. `cabal run cabal-testsuite:cabal-tests -- cabal-testsuite/PackageTests/TestOptions/setup.test.hs`)
+   To run a specific set of tests, use `cabal-tests --with-cabal=CABALBIN PATH ...`.
+   (e.g. `cabal run cabal-testsuite:cabal-tests -- --with-cabal=cabal cabal-testsuite/PackageTests/TestOptions/setup.test.hs`)
    You can control parallelism using the `-j` flag.
 
 There are a few useful flags:

--- a/cabal-testsuite/main/cabal-tests.hs
+++ b/cabal-testsuite/main/cabal-tests.hs
@@ -82,8 +82,8 @@ main = do
     -- https://github.com/appveyor/ci/issues/1364
     hSetBuffering stderr LineBuffering
 
-    -- Parse arguments
-    args <- execParser (info mainArgParser mempty)
+    -- Parse arguments.  N.B. 'helper' adds the option `--help`.
+    args <- execParser $ info (mainArgParser <**> helper) mempty
     let verbosity = if mainArgVerbose args then verbose else normal
 
     -- To run our test scripts, we need to be able to run Haskell code

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -104,7 +104,7 @@ data CommonArgs = CommonArgs {
 commonArgParser :: Parser CommonArgs
 commonArgParser = CommonArgs
     <$> optional (option str
-        ( help "Path to cabal-install executable to test"
+        ( help "Path to cabal-install executable to test. If omitted, tests involving cabal-install are skipped!"
        <> long "with-cabal"
        <> metavar "PATH"
         ))

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | The test monad
@@ -72,7 +73,10 @@ import Distribution.Text
 import Distribution.Verbosity
 import Distribution.Version
 
-import Data.Monoid ((<>), mempty)
+#if !MIN_VERSION_base(4,11,0)
+import Data.Monoid ((<>))
+#endif
+import Data.Monoid (mempty)
 import qualified Control.Exception as E
 import Control.Monad
 import Control.Monad.Trans.Reader
@@ -101,7 +105,7 @@ commonArgParser :: Parser CommonArgs
 commonArgParser = CommonArgs
     <$> optional (option str
         ( help "Path to cabal-install executable to test"
-       Data.Monoid.<> long "with-cabal"
+       <> long "with-cabal"
        <> metavar "PATH"
         ))
     <*> optional (option str


### PR DESCRIPTION
cabal-testsuite #8401: communicate better the need for `--with-cabal`
- include option `--help` in `cabal-testsuite` (separate commit)
- include warning in help text for option `--with-cabal`
- include `--with-cabal` in README examples
- passer-by: remove a CPP-avoidance hack (separate commit)

N.B. Separate commits, no squashing please!