### PR TITLE
Fix project relative imports

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -117,7 +117,7 @@ import Network.URI (URI (..), parseURI)
 import Distribution.Fields.ConfVar (parseConditionConfVarFromClause)
 
 import Distribution.Client.HttpUtils
-import System.FilePath ((</>), isPathSeparator, makeValid)
+import System.FilePath ((</>), isPathSeparator, makeValid, isAbsolute, takeDirectory)
 import System.Directory (createDirectoryIfMissing)
 
 
@@ -224,7 +224,8 @@ parseProjectSkeleton cacheDir httpTransport verbosity seenImports source bs = (s
             createDirectoryIfMissing True cacheDir
             _ <- downloadURI httpTransport verbosity uri fp
             BS.readFile fp
-         Nothing -> BS.readFile pci
+         Nothing -> BS.readFile $
+           if isAbsolute pci then pci else takeDirectory source </> pci
 
     modifiesCompiler :: ProjectConfig -> Bool
     modifiesCompiler pc = isSet projectConfigHcFlavor || isSet projectConfigHcPath || isSet projectConfigHcPkg

--- a/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.test.hs
@@ -64,7 +64,6 @@ main = cabalTest $ do
         results <- forM (zip [0..] lrun) $ \(idx, linking) -> do
             withDirectory "basic" $ do
                 withSourceCopyDir ("basic" ++ show idx) $ do
-                    cwd <- fmap testSourceCopyDir getTestEnv
                     -- (Now do ‘cd ..’, since withSourceCopyDir made our previous
                     -- previous such withDirectories now accumulate to be
                     -- relative to setup.dist/basic0, not testSourceDir

--- a/cabal-testsuite/PackageTests/RelativePathProjectImports/Lib.hs
+++ b/cabal-testsuite/PackageTests/RelativePathProjectImports/Lib.hs
@@ -1,0 +1,7 @@
+module Lib (foo) where
+
+import Dep (bar)
+import Dep2 (baz)
+
+foo :: Int
+foo = bar + baz

--- a/cabal-testsuite/PackageTests/RelativePathProjectImports/cabal.out
+++ b/cabal-testsuite/PackageTests/RelativePathProjectImports/cabal.out
@@ -1,0 +1,24 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - dep-0.1 (lib) (first run)
+ - dep2-0.1 (lib) (first run)
+ - main-0.1 (lib) (first run)
+Configuring library for dep-0.1..
+Preprocessing library for dep-0.1..
+Building library for dep-0.1..
+Configuring library for dep2-0.1..
+Preprocessing library for dep2-0.1..
+Building library for dep2-0.1..
+Configuring library for main-0.1..
+Preprocessing library for main-0.1..
+Building library for main-0.1..
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - dep2-0.1 (lib) (first run)
+Configuring library for dep2-0.1..
+Preprocessing library for dep2-0.1..
+Building library for dep2-0.1..

--- a/cabal-testsuite/PackageTests/RelativePathProjectImports/cabal.project
+++ b/cabal-testsuite/PackageTests/RelativePathProjectImports/cabal.project
@@ -1,0 +1,6 @@
+import: ./dep/cabal.project
+
+packages:
+  main.cabal
+  dep/dep.cabal
+  dep2/dep2.cabal

--- a/cabal-testsuite/PackageTests/RelativePathProjectImports/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/RelativePathProjectImports/cabal.test.hs
@@ -1,0 +1,8 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+  -- Build from toplevel.
+  cabal "build" []
+  withDirectory "dep2" $ do
+    -- Build from one of the subdirectories that uses toplevel cabal.project.
+    cabal "build" []

--- a/cabal-testsuite/PackageTests/RelativePathProjectImports/dep/Dep.hs
+++ b/cabal-testsuite/PackageTests/RelativePathProjectImports/dep/Dep.hs
@@ -1,0 +1,4 @@
+module Dep (bar) where
+
+bar :: Int
+bar = 1

--- a/cabal-testsuite/PackageTests/RelativePathProjectImports/dep/cabal.project
+++ b/cabal-testsuite/PackageTests/RelativePathProjectImports/dep/cabal.project
@@ -1,0 +1,2 @@
+package dep
+  ghc-options: -O2

--- a/cabal-testsuite/PackageTests/RelativePathProjectImports/dep/dep.cabal
+++ b/cabal-testsuite/PackageTests/RelativePathProjectImports/dep/dep.cabal
@@ -1,0 +1,15 @@
+cabal-version: 3.0
+
+name: dep
+version: 0.1
+build-type: Simple
+category: Test
+maintainer: Joe
+synopsis: Test input
+description: Test input
+license: BSD-3-Clause
+
+library
+  exposed-modules: Dep
+  build-depends: base > 4
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/RelativePathProjectImports/dep2/Dep2.hs
+++ b/cabal-testsuite/PackageTests/RelativePathProjectImports/dep2/Dep2.hs
@@ -1,0 +1,4 @@
+module Dep2 (baz) where
+
+baz :: Int
+baz = 2

--- a/cabal-testsuite/PackageTests/RelativePathProjectImports/dep2/dep2.cabal
+++ b/cabal-testsuite/PackageTests/RelativePathProjectImports/dep2/dep2.cabal
@@ -1,0 +1,15 @@
+cabal-version: 3.0
+
+name: dep2
+version: 0.1
+build-type: Simple
+category: Test
+maintainer: Joe
+synopsis: Test input
+description: Test input
+license: BSD-3-Clause
+
+library
+  exposed-modules: Dep2
+  build-depends: base > 4
+  default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/RelativePathProjectImports/main.cabal
+++ b/cabal-testsuite/PackageTests/RelativePathProjectImports/main.cabal
@@ -1,0 +1,15 @@
+cabal-version: 3.0
+
+name: main
+version: 0.1
+build-type: Simple
+category: Test
+maintainer: Joe
+synopsis: Test input
+description: Test input
+license: BSD-3-Clause
+
+library
+  exposed-modules: Lib
+  build-depends: base > 4, dep >= 0.1, dep2
+  default-language: Haskell2010

--- a/cabal-testsuite/src/Test/Cabal/CheckArMetadata.hs
+++ b/cabal-testsuite/src/Test/Cabal/CheckArMetadata.hs
@@ -20,10 +20,8 @@ import qualified Data.ByteString.Char8 as BS8
 import Data.Char (isSpace)
 import System.IO
 
-import Distribution.Compiler              (CompilerFlavor(..), CompilerId(..))
 import Distribution.Package               (getHSLibraryName)
-import Distribution.Simple.Compiler       (compilerId)
-import Distribution.Simple.LocalBuildInfo (LocalBuildInfo, compiler, localUnitId)
+import Distribution.Simple.LocalBuildInfo (LocalBuildInfo, localUnitId)
 
 -- Almost a copypasta of Distribution.Simple.Program.Ar.wipeMetadata
 checkMetadata :: LocalBuildInfo -> FilePath -> IO ()

--- a/cabal-testsuite/src/Test/Cabal/CheckArMetadata.hs
+++ b/cabal-testsuite/src/Test/Cabal/CheckArMetadata.hs
@@ -32,10 +32,6 @@ checkMetadata lbi dir = withBinaryFile path ReadMode $ \ h ->
   where
     path = dir </> "lib" ++ getHSLibraryName (localUnitId lbi) ++ ".a"
 
-    _ghc_7_10 = case compilerId (compiler lbi) of
-      CompilerId GHC version | version >= mkVersion [7, 10]  -> True
-      _                                                      -> False
-
     checkError msg = assertFailure (
         "PackageTests.DeterministicAr.checkMetadata: " ++ msg ++
         " in " ++ path) >> undefined

--- a/changelog.d/pr-8686
+++ b/changelog.d/pr-8686
@@ -1,0 +1,11 @@
+synopsis: Fix resolution of imports by relative paths in cabal.project
+packages: cabal-install
+prs: #8686
+
+description: {
+
+Fix bug where cabal tries to resolve imports by relative paths against
+the directory cabal executable was invoked in rather than directory of
+cabal.project file that does the import.
+
+}


### PR DESCRIPTION
Fix bug where cabal tries to resolve imports by relative paths against the directory cabal executable was invoked in rather than directory of cabal.project file that does the import.

The problem occurs if `<toplevel>/cabal.project` does something like `import: dep/cabal.project` and then `cabal build` is invoked from some subridectory e.g. `<toplevel>/dep2`. Cabal tries to resolve `dep/cabal.project` against `<toplevel>/dep2` but it probably should do the resolution against the `<toplevel>` directory that contains `cabal.project` that does the import.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
