### PR TITLE
Extend the InstalledPackageInfo record with 2 fields for artifacts.

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
@@ -92,7 +92,10 @@ data InstalledPackageInfo
         frameworks        :: [String],
         haddockInterfaces :: [FilePath],
         haddockHTMLs      :: [FilePath],
-        pkgRoot           :: Maybe FilePath
+        pkgRoot           :: Maybe FilePath,
+        -- Artifacts included in this package:
+        providesStaticArtifacts  :: Bool,
+        providesDynamicArtifacts :: Bool
     }
     deriving (Eq, Generic, Typeable, Read, Show)
 
@@ -173,5 +176,7 @@ emptyInstalledPackageInfo
         haddockInterfaces = [],
         haddockHTMLs      = [],
         pkgRoot           = Nothing,
-        libVisibility     = LibraryVisibilityPrivate
+        libVisibility     = LibraryVisibilityPrivate,
+        providesStaticArtifacts  = True,
+        providesDynamicArtifacts = True
     }

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
@@ -121,6 +121,8 @@ ipiFieldGrammar = mkInstalledPackageInfo
     <@> monoidalFieldAla    "haddock-interfaces"   (alaList' FSep FilePathNT)    L.haddockInterfaces
     <@> monoidalFieldAla    "haddock-html"         (alaList' FSep FilePathNT)    L.haddockHTMLs
     <@> optionalFieldAla    "pkgroot"              FilePathNT                    L.pkgRoot
+    <@> booleanFieldDef     "provides-static-artifacts"                          L.providesStaticArtifacts True
+    <@> booleanFieldDef     "provides-dynamic-artifacts"                         L.providesDynamicArtifacts True
   where
     mkInstalledPackageInfo _ Basic {..} = InstalledPackageInfo
         -- _basicPkgName is not used

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/Lens.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/Lens.hs
@@ -196,3 +196,11 @@ libVisibility :: Lens' InstalledPackageInfo LibraryVisibility
 libVisibility f s = fmap (\x -> s { T.libVisibility = x }) (f (T.libVisibility s))
 {-# INLINE libVisibility #-}
 
+providesStaticArtifacts :: Lens' InstalledPackageInfo Bool
+providesStaticArtifacts f s = fmap (\x -> s { T.providesStaticArtifacts = x }) (f (T.providesStaticArtifacts s))
+{-# INLINE providesStaticArtifacts #-}
+
+providesDynamicArtifacts :: Lens' InstalledPackageInfo Bool
+providesDynamicArtifacts f s = fmap (\x -> s { T.providesDynamicArtifacts = x }) (f (T.providesDynamicArtifacts s))
+{-# INLINE providesDynamicArtifacts #-}
+

--- a/Cabal-tests/tests/ParserTests/ipi/Includes2.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/Includes2.expr
@@ -89,4 +89,6 @@ InstalledPackageInfo {
   haddockHTMLs =
   [
     "/home/travis/build/haskell/cabal/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.dist/work/./dist/build/x86_64-linux/ghc-8.2.2/Includes2-0.1.0.0/l/mylib/Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n/doc/html/Includes2"],
-  pkgRoot = Nothing}
+  pkgRoot = Nothing,
+  providesStaticArtifacts = True,
+  providesDynamicArtifacts = True}

--- a/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.expr
@@ -73,4 +73,6 @@ InstalledPackageInfo {
     "/home/ogre/Documents/other-haskell/cabal/cabal-testsuite/PackageTests/CustomPreProcess/setup.dist/work/dist/doc/html/internal-preprocessor-test"],
   pkgRoot =
   Just
-    "/home/ogre/Documents/other-haskell/cabal/cabal-testsuite/PackageTests/CustomPreProcess/setup.dist/work/dist"}
+    "/home/ogre/Documents/other-haskell/cabal/cabal-testsuite/PackageTests/CustomPreProcess/setup.dist/work/dist",
+  providesStaticArtifacts = True,
+  providesDynamicArtifacts = True}

--- a/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
@@ -2181,4 +2181,6 @@ InstalledPackageInfo {
     "/opt/ghc/8.2.2/share/doc/ghc-8.2.2/html/libraries/transformers-0.5.2.0/transformers.haddock"],
   haddockHTMLs = [
     "/opt/ghc/8.2.2/share/doc/ghc-8.2.2/html/libraries/transformers-0.5.2.0"],
-  pkgRoot = Nothing}
+  pkgRoot = Nothing,
+  providesStaticArtifacts = True,
+  providesDynamicArtifacts = True}

--- a/Cabal-tests/tests/ParserTests/ipi/transformers.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/transformers.expr
@@ -181,4 +181,6 @@ InstalledPackageInfo {
   haddockHTMLs = [
     "/opt/ghc/8.2.2/share/doc/ghc-8.2.2/html/libraries/transformers-0.5.2.0"],
   pkgRoot = Just
-    "/opt/ghc/8.2.2/lib/ghc-8.2.2"}
+    "/opt/ghc/8.2.2/lib/ghc-8.2.2",
+  providesStaticArtifacts = True,
+  providesDynamicArtifacts = True}

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -29,7 +29,7 @@ tests = testGroup "Distribution.Utils.Structured"
     , testCase "GenericPackageDescription" $
       md5Check (Proxy :: Proxy GenericPackageDescription) 0xa3e9433662ecf0c7a3c26f6d75a53ba1
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0x91ffcd61bbd83525e8edba877435a031
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0x89eabee921ae834a5222e4a10ce68439
 #endif
     ]
 

--- a/changelog.d/pr-8692
+++ b/changelog.d/pr-8692
@@ -1,0 +1,10 @@
+synopsis: Extend the InstalledPackageInfo record with fields for artifacts.
+packages: Cabal-syntax Cabal Cabal-tests
+prs: #8692
+description: {
+    Extend the InstalledPackageInfo record with new fields involving build
+    artifact configuration.  The moduler resolver could then (in a separate set
+    of changes) use these new fields to avoid selecting installed package
+    options missing required artifacts and producing build plans that would
+    fail, even if alternatives would succeed.
+}


### PR DESCRIPTION
(Split from [PR #8624](https://github.com/haskell/cabal/pulls/8624); there is more discussion there.)

This PR adds 2 new IPI fields that would allow the modular resolver to detect installed package options that would be missing required artifacts, to avoid build plans that would cause missing file errors.

This is the Cabal part of [PR #8624](https://github.com/haskell/cabal/pulls/8624) outside cabal-install, and it adds 2 new fields to the IPI, updating the syntax.