### PR TITLE
Fix cabal init should not suggest Cabal < 2.0

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -286,7 +286,7 @@ cabalVersionPrompt flags = getCabalVersion flags $ do
 
     displayCabalVersion :: CabalSpecVersion -> String
     displayCabalVersion v = case v of
-      CabalSpecV2_0  -> "2.0   (+ support for Backpack, internal sub-libs, '^>=' operator)"
+      CabalSpecV2_0  -> "2.0   (support for Backpack, internal sub-libs, '^>=' operator)"
       CabalSpecV2_2  -> "2.2   (+ support for 'common', 'elif', redundant commas, SPDX)"
       CabalSpecV2_4  -> "2.4   (+ support for '**' globbing)"
       CabalSpecV3_0  -> "3.0   (+ set notation for ==, common stanzas in ifs, more redundant commas, better pkgconfig-depends)"

--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -286,7 +286,6 @@ cabalVersionPrompt flags = getCabalVersion flags $ do
 
     displayCabalVersion :: CabalSpecVersion -> String
     displayCabalVersion v = case v of
-      CabalSpecV1_24 -> "1.24  (legacy)"
       CabalSpecV2_0  -> "2.0   (+ support for Backpack, internal sub-libs, '^>=' operator)"
       CabalSpecV2_2  -> "2.2   (+ support for 'common', 'elif', redundant commas, SPDX)"
       CabalSpecV2_4  -> "2.4   (+ support for '**' globbing)"

--- a/changelog.d/issue-8680
+++ b/changelog.d/issue-8680
@@ -1,0 +1,9 @@
+synopsis: cabal init should not suggest Cabal < 2.0
+packages: Cabal
+issues: #8680
+
+description: {
+
+'cabal init' no longer suggests users to set cabal-version to less than 2.0
+
+}


### PR DESCRIPTION
Any Cabal release prior to 2.0 is no longer working, so cabal should not suggest users to set the `cabal-version` on packages to less than 2.0 as mentioned in #8680. 

With this, the least choice offered to users is 2.0.