### PR TITLE
A makefile to run doctests in Cabal-syntax

### DIFF
--- a/Cabal-syntax/Makefile
+++ b/Cabal-syntax/Makefile
@@ -1,0 +1,26 @@
+# Andreas, 2023-01-26: Makefile for running the doctests.
+
+# Needs `ghc` and `ghc-pkg` in PATH.
+# Not clear how to make this multi-GHC ready: https://github.com/sol/doctest/issues/396
+
+# doctest is GHC-specific, so we query the version.
+GHC_VERSION = $(shell ghc --numeric-version)
+
+.PHONY: doctest
+doctest: install-doctest run-doctest
+
+.PHONY: install-doctest
+# doctest only works with the GHC it got installed with.
+# So on ghc 9.4.4 we install doctest as doctest-9.4.4.
+# `doctest --numeric-version` gives the ghc version it got installed with.
+install-doctest:
+	[[ "$$(doctest-$(GHC_VERSION) --numeric-version)" == "$(GHC_VERSION)" ]] \
+	  || cabal install --ignore-project --overwrite-policy=always --program-suffix=-$(GHC_VERSION) doctest \
+	     && [[ "$$(doctest-$(GHC_VERSION) --numeric-version)" == "$(GHC_VERSION)" ]]
+                # Paranoia: test whether we really got the right version
+
+.PHONY: run-doctest
+run-doctest:
+	cabal repl -w doctest-$(GHC_VERSION) --repl-options=-w
+
+# EOF

--- a/Cabal-syntax/src/Distribution/Backpack.hs
+++ b/Cabal-syntax/src/Distribution/Backpack.hs
@@ -114,7 +114,7 @@ instance Pretty OpenUnitId where
 -- |
 --
 -- >>> eitherParsec "foobar" :: Either String OpenUnitId
---Right (DefiniteUnitId (DefUnitId {unDefUnitId = UnitId "foobar"}))
+-- Right (DefiniteUnitId (DefUnitId {unDefUnitId = UnitId "foobar"}))
 --
 -- >>> eitherParsec "foo[Str=text-1.2.3:Data.Text.Text]" :: Either String OpenUnitId
 -- Right (IndefFullUnitId (ComponentId "foo") (fromList [(ModuleName "Str",OpenModule (DefiniteUnitId (DefUnitId {unDefUnitId = UnitId "text-1.2.3"})) (ModuleName "Data.Text.Text"))]))

--- a/Cabal-syntax/src/Distribution/InstalledPackageInfo.hs
+++ b/Cabal-syntax/src/Distribution/InstalledPackageInfo.hs
@@ -63,7 +63,7 @@ import Distribution.Types.InstalledPackageInfo
 import Distribution.Types.InstalledPackageInfo.FieldGrammar
 
 -- $setup
--- >>> :set -XOverloadedStrings
+-- >>> :seti -XOverloadedStrings
 
 installedComponentId :: InstalledPackageInfo -> ComponentId
 installedComponentId ipi =


### PR DESCRIPTION
`make` in `Cabal-syntax` will run the doctests there.

Couldn't get this to work in `Cabal`, ran into the same problems with `QuickCheck` as @ulysses4ever in https://github.com/haskell/cabal/issues/8504#issuecomment-1303791788.


See:
- #8504 
- #8147