### PR TITLE
testuite: doctest: move to ghcup-recommended ghc

### DIFF
--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -69,8 +69,8 @@ jobs:
       - name: ghcup
         run: |
           ghcup config set cache true
-          ghcup install ghc 8.10.7
-          ghcup set ghc 8.10.7
+          ghcup install ghc recommended
+          ghcup set ghc recommended
       - name: Update Hackage index
         run: cabal v2-update
       - name: Install doctest

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ ghcid-cli :
 # doctests (relies on .ghc.environment files)
 
 doctest :
-	doctest --fast Cabal-syntax/src Cabal/src
+	doctest --fast -XHaskell2010 Cabal-syntax/src Cabal/src
 
 # This is not run as part of validate.sh (we need hackage-security, which is tricky to get).
 doctest-cli :


### PR DESCRIPTION
Another stub at #8504: choosing to upgrade existing doctest rather than anything else mentioned in the ticket. It looks like, our issue with upgrading GHC 8.10 -> 9.2 was due to the default `-XGHC2021` adopted in 9.2, and nomeata suggested an easy fix (thanks!) to explicitly request `-XHaskell2010`.

I'm sad to declare defeat at trying to switch to the recommended way of using `doctest` these days (namely, via `cabal repl`) due to a failure described in https://github.com/haskell/cabal/issues/8504#issuecomment-1302498805 It's not only sad because we're using a not (officially) supported way of communication with `doctest`, but also because we have to employ `cabal-env`, which has an unclear maintenance status.

I also took a liberty to use `ghcup set ghc recommended` (which is currently 9.2.5) instead of a specific version or version matrix for a couple of reasons:

- the other "quick job" "Meta checks" have been using it since 475222dd
- it makes sense for explicitly secondary job (referring to the name "Quick jobs") to use just one GHC instead of e.g. the whole support window; 
- trying single GHC saves time on CI;
- using `recommended` instead of a specific version will make sure that we're moving forward even if slowly instead of being stuck on one version until someone remembers to upgrade.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
