### PR TITLE
Revert style2str change in b547ead58bf09bb838c13f02afb2f1042ad1bc7c

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanOutput.hs
@@ -272,9 +272,9 @@ encodePlanAsJson distDirLayout elaboratedInstallPlan elaboratedSharedConfig =
     comp2str = prettyShow
 
     style2str :: Bool -> BuildStyle -> String
-    style2str _     BuildAndInstall  = "global"
     style2str True  _                = "local"
     style2str False BuildInplaceOnly = "inplace"
+    style2str False BuildAndInstall  = "global"
 
     jdisplay :: Pretty a => a -> J.Value
     jdisplay = J.String . prettyShow


### PR DESCRIPTION
if elabLocalToProject says package is local, than it is. `inplace` packages are things which depend on local packages, but don't have local sources. (e.g. hackage-security in Cabal project). And global packages are the ones which can go to the store.

The original change didn't include changelog for this part of the change nor tests, so it's an easy revert.