### PR TITLE
Document the `remote-repo-cache` option as is implemented (it is).

### DIFF
--- a/changelog.d/issue-8737
+++ b/changelog.d/issue-8737
@@ -1,0 +1,4 @@
+synopsis: Document `remote-repo-cache` as implemented.
+packages: Cabal
+issues: #8737
+prs: #8738

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -1583,8 +1583,8 @@ Advanced global configuration options
 
     :default: ``~/.cabal/packages``
 
-    :strike:`The location where packages downloaded from remote
-    repositories will be cached.` Not implemented yet.
+    The location where packages downloaded from remote repositories will be
+    cached.
 
     The command line variant of this flag is
     ``--remote-repo-cache=DIR``.


### PR DESCRIPTION
Fixes #8737 

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

I tested that the feature really is implemented and left a transcript on the issue.  I tested that the docs build and render using Python 3.8 on NixOS 22.11 in a virtualenv using the `requirements.txt` in the repo and visual inspection.
