### PR TITLE
Work around ghcup cache woes also in our tiny CI scripts

### DIFF
--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           path: ~/.cabal/store
           key: linux-store-changelogs
+      # See https://github.com/haskell/cabal/pull/8739
+      - name: Sudo chmod to permit ghcup to update its cache
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            sudo mkdir -p /usr/local/.ghcup/cache
+            sudo chown -R $USER /usr/local/.ghcup
+            sudo chmod -R 777 /usr/local/.ghcup
+          fi
       - name: ghcup
         run: |
           ghcup config set cache true

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -31,6 +31,15 @@ jobs:
         path: "~/.local/bin"
         key: fix-whitespace-${{ env.fix-whitespace-ver }}
 
+    # See https://github.com/haskell/cabal/pull/8739
+    - name: Sudo chmod to permit ghcup to update its cache
+      run: |
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          sudo mkdir -p /usr/local/.ghcup/cache
+          sudo chown -R $USER /usr/local/.ghcup
+          sudo chmod -R 777 /usr/local/.ghcup
+        fi
+
     - uses: haskell/actions/setup@v2
       if: ${{ !steps.cache.outputs.cache-hit }}
       with:


### PR DESCRIPTION
This is a continuation of #8739, which fixed a CI problem that now shows up also in these scripts. I hope there is no more affected code.