### PR TITLE
Work around ghcup cache woes also in our dogfooding CI scripts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -274,6 +274,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # See https://github.com/haskell/cabal/pull/8739
+      - name: Sudo chmod to permit ghcup to update its cache
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            sudo ls -lah /usr/local/.ghcup/cache
+            sudo mkdir -p /usr/local/.ghcup/cache
+            sudo ls -lah /usr/local/.ghcup/cache
+            sudo chown -R $USER /usr/local/.ghcup
+            sudo chmod -R 777 /usr/local/.ghcup
+          fi
       - uses: haskell/actions/setup@v2
         id: setup-haskell
         with:


### PR DESCRIPTION
This is part 3 of CI script hacks to work around GHA file permission woes. See https://github.com/haskell/cabal/pull/8739 and https://github.com/haskell/cabal/pull/8743