### PR TITLE
Return empty default when git fails

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -355,14 +355,10 @@ licensePrompt flags = getLicense flags $ do
       else fmap prettyShow knownLicenses
 
 authorPrompt :: Interactive m => InitFlags -> m String
-authorPrompt flags = getAuthor flags $ do
-    name <- guessAuthorName
-    promptStr "Author name" (DefaultPrompt name)
+authorPrompt flags = getAuthor flags $ guessAuthorName >>= promptOrDefault "Author name"
 
 emailPrompt :: Interactive m => InitFlags -> m String
-emailPrompt flags = getEmail flags $ do
-    email' <- guessAuthorEmail
-    promptStr "Maintainer email" (DefaultPrompt email')
+emailPrompt flags = getEmail flags $ guessAuthorEmail >>= promptOrDefault "Maintainer email"
 
 homepagePrompt :: Interactive m => InitFlags -> m String
 homepagePrompt flags = getHomepage flags $
@@ -467,3 +463,6 @@ srcDirsPrompt flags = getSrcDirs flags $ do
       True
 
     return [dir]
+
+promptOrDefault :: Interactive m => String -> Maybe String -> m String
+promptOrDefault s = maybe (promptStr s MandatoryPrompt)  (promptStr s . DefaultPrompt)

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
@@ -276,14 +276,14 @@ licenseHeuristics flags = getLicense flags $ guessLicense flags
 -- | The author's name. Prompt, or try to guess from an existing
 --   git repo.
 authorHeuristics :: Interactive m => InitFlags -> m String
-authorHeuristics flags = guessAuthorEmail >>=
-  maybe (getAuthor flags $ return "") (getAuthor flags . return)
+authorHeuristics flags = guessAuthorName >>=
+  maybe (getAuthor flags $ return "Unknown") (getAuthor flags . return)
 
 -- | The author's email. Prompt, or try to guess from an existing
 --   git repo.
 emailHeuristics :: Interactive m => InitFlags -> m String
-emailHeuristics flags = guessAuthorName >>=
-  maybe (getEmail flags $ return "") (getEmail flags . return)
+emailHeuristics flags = guessAuthorEmail >>=
+  maybe (getEmail flags $ return "Unknown") (getEmail flags . return)
 
 -- | Prompt for a homepage URL for the package.
 homepageHeuristics :: Interactive m => InitFlags -> m String

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Command.hs
@@ -274,14 +274,16 @@ licenseHeuristics :: Interactive m => InitFlags -> m SpecLicense
 licenseHeuristics flags = getLicense flags $ guessLicense flags
 
 -- | The author's name. Prompt, or try to guess from an existing
---   darcs repo.
+--   git repo.
 authorHeuristics :: Interactive m => InitFlags -> m String
-authorHeuristics flags = getAuthor flags guessAuthorEmail
+authorHeuristics flags = guessAuthorEmail >>=
+  maybe (getAuthor flags $ return "") (getAuthor flags . return)
 
 -- | The author's email. Prompt, or try to guess from an existing
---   darcs repo.
+--   git repo.
 emailHeuristics :: Interactive m => InitFlags -> m String
-emailHeuristics flags = getEmail flags guessAuthorName
+emailHeuristics flags = guessAuthorName >>=
+  maybe (getEmail flags $ return "") (getEmail flags . return)
 
 -- | Prompt for a homepage URL for the package.
 homepageHeuristics :: Interactive m => InitFlags -> m String

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
@@ -44,7 +44,9 @@ tests _v _initFlags comp pkgIx srcDb =
               }
             inputs =
               -- createProject stuff
-              [ "True"
+              [ "Foobar"
+              , "foobar@qux.com"
+              , "True"
               , "[\"quxTest/Main.hs\"]"
               -- writeProject stuff
               -- writeLicense

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
@@ -73,7 +73,9 @@ driverFunctionTest pkgIx srcDb comp = testGroup "createProject"
               , dependencies = Flag []
               }
             inputs = NEL.fromList
-              [ "True"
+              ["Foobar"
+              , "foobar@qux.com"
+              , "True"
               , "[\"quxTest/Main.hs\"]"
               ]
 
@@ -149,8 +151,11 @@ driverFunctionTest pkgIx srcDb comp = testGroup "createProject"
               , dependencies = Flag []
               }
             inputs = NEL.fromList
+
+              [ "Foobar"
+              , "foobar@qux.com"
               -- extra sources
-              [ "[\"CHANGELOG.md\"]"
+              , "[\"CHANGELOG.md\"]"
               -- lib other modules
               , "False"
               -- exe other modules


### PR DESCRIPTION
As mentioned in #8478, cabal init throws an error when git is not installed as it fails to guess a default name and email for the user. Instead, it should give an empty default (or no default perhaps?) and perhaps a note.