### PR TITLE
Do not throw away debug information in Distribution.Simple.Utils.findProgramVersion

### DIFF
--- a/cabal-testsuite/PackageTests/ExtraProgPath/setup.out
+++ b/cabal-testsuite/PackageTests/ExtraProgPath/setup.out
@@ -1,8 +1,8 @@
 # cabal v2-build
 Warning: cannot determine version of <ROOT>/./pkg-config :
-""
+<ROOT>/./pkg-config: createProcess: posix_spawnp: does not exist (No such file or directory)
 Warning: cannot determine version of <ROOT>/./pkg-config :
-""
+<ROOT>/./pkg-config: createProcess: posix_spawnp: does not exist (No such file or directory)
 Resolving dependencies...
 Error: cabal: Could not resolve dependencies:
 [__0] next goal: CheckExtraProgPath (user goal)


### PR DESCRIPTION
Currently if `catchIO` or `catchExit` has been triggered, the output is utterly unhelpful: e. g.,

```
Warning: cannot determine version of /usr/local/bin/ghc-9.2.2 :
""
cabal: The program 'ghc' version >=7.0.1 is required but the version of
/usr/local/bin/ghc-9.2.2 could not be determined.
```
(This is from https://github.com/haskell/filepath/actions/runs/4211364732/jobs/7309866698#step:7:12)

At the very least we should print the contents of errors caught, not throw away them immediately.