### PR TITLE
Apply command line flags to install packages (#8637)

### DIFF
--- a/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.test.hs
@@ -50,7 +50,7 @@ linkConfigFlags Dynamic =
 lrun :: [Linking]
 lrun = [Static, Dynamic, Static, Dynamic]
 
-main = cabalTest . expectBroken 8744 $ do
+main = cabalTest $ do
     -- Skip if on Windows, since my default Chocolatey Windows setup (and the CI
     -- server setup at the time, presumably) lacks support for dynamic builds
     -- since the base package appears to be static only, lacking e.g. ‘.dyn_o’

--- a/changelog.d/issue-8637
+++ b/changelog.d/issue-8637
@@ -1,0 +1,13 @@
+synopsis: Apply command line flags to install packages
+packages: cabal-install
+prs: #8779
+issues: #8637
+
+description: {
+
+- Command line flags usually only apply to "local" packages (packages specified
+  in the cabal.project). This change causes the v2-install command to ignore
+  that distinction to better match the expected behavior for packages specified
+  directly in the command.
+
+}


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

---

This PR reverses the effects of https://github.com/haskell/cabal/pull/7973 specifically for targets of the "install" command to more closely match expected behavior.

Before this change:
```
cabal v2-install --ghc-option=-foo hello
```
would not apply "-foo" to "hello" because "hello" is not a local package. After this change, -foo is applied to "hello" because it is a direct target of the install command, so gets the local package configs added to it.

To test, I ran:
```
cabal install --ghc-option=-foo alex --verbose
```
which resulted in:
```
# Installation of "directory" dependency, no "-foo" flag present
/home/patrick/projects/haskell/cabal/dist-newstyle/build/x86_64-linux/ghc-9.2.3/cabal-install-3.9.0.0/x/cabal/build/cabal/cabal
act-as-setup --build-type=Configure -- configure --verbose=2 --builddir=dist
--ghc
--prefix=/home/patrick/.cabal/store/ghc-9.2.3/directory-1.3.8.0-
<snip>
--ghc-option=-hide-all-packages

# Installation of "alex" package, "-foo" flag present
/home/patrick/projects/haskell/cabal/dist-newstyle/build/x86_64-linux/ghc-9.2.3/cabal-install-3.9.0.0/x/cabal/build/cabal/cabal
act-as-setup --build-type=Simple -- configure --verbose=2 --builddir=dist
--ghc
--prefix=/home/patrick/.cabal/store/ghc-9.2.3/alex...
<snip>
--ghc-option=-hide-all-packages --ghc-option=-foo exe:alex
```