### PR TITLE
Fix `config` format docs.

### DIFF
--- a/doc/nix-local-build.rst
+++ b/doc/nix-local-build.rst
@@ -268,7 +268,7 @@ this folder (the most important two are first):
     ``cabal sdist --list-only``. Thus if you do not list all your
     source files in a Cabal file, Cabal may fail to recompile when you
     edit them.
-``config`` (same format as ``cabal.project``)
+``config`` (binary)
     The full project configuration, merged from ``cabal.project`` (and
     friends) as well as the command line arguments.
 ``compiler`` (binary)


### PR DESCRIPTION
Documentation says “config (same format as cabal.project)”, but it is an internal binary format.

Close #8782


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
