### PR TITLE
Add traceM and traceShowM

### DIFF
--- a/Cabal-syntax/src/Distribution/Compat/Prelude.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Prelude.hs
@@ -125,7 +125,7 @@ module Distribution.Compat.Prelude (
     readMaybe,
 
     -- * Debug.Trace (as deprecated functions)
-    trace, traceShow, traceShowId,
+    trace, traceShow, traceShowId, traceM, traceShowM
     ) where
 
 -- We also could hide few partial function
@@ -286,3 +286,11 @@ traceShowId x = Debug.Trace.traceShow x x
 traceShow :: Show a => a -> b -> b
 traceShow = Debug.Trace.traceShow
 {-# DEPRECATED traceShow "Don't leave me in the code" #-}
+
+traceM :: Applicative f => String -> f ()
+traceM = Debug.Trace.traceM
+{-# DEPRECATED traceM "Don't leave me in the code" #-}
+
+traceShowM :: (Show a, Applicative f) => a -> f ()
+traceShowM = Debug.Trace.traceShowM
+{-# DEPRECATED traceShowM "Don't leave me in the code" #-}


### PR DESCRIPTION
Cabal codebase has its fair share of Applicatives/Monads. Adding traceM and traceShowM to the Compat.Prelude is quite convenient for testing purposes.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
