### PR TITLE
Add the "macos" alias for the OSX constructor of the OS datatype

### DIFF
--- a/Cabal-syntax/src/Distribution/System.hs
+++ b/Cabal-syntax/src/Distribution/System.hs
@@ -86,7 +86,7 @@ data ClassificationStrictness = Permissive | Compat | Strict
 --   NetBSD, DragonFly, Solaris, AIX, HPUX, IRIX, HaLVM, Hurd, IOS, Android,
 --   Ghcjs, Wasi
 --
--- The following aliases can also be used:,
+-- The following aliases can also be used:
 --
 --    * Windows aliases: mingw32, win32, cygwin32
 --    * OSX alias: darwin, macos

--- a/Cabal-syntax/src/Distribution/System.hs
+++ b/Cabal-syntax/src/Distribution/System.hs
@@ -88,8 +88,9 @@ data ClassificationStrictness = Permissive | Compat | Strict
 --  ,HaLVM ,Hurd ,IOS, Android, Ghcjs, Wasi
 --
 -- The following aliases can also be used:,
+--
 --    * Windows aliases: mingw32, win32, cygwin32
---    * OSX alias: darwin
+--    * OSX alias: darwin, macos
 --    * Hurd alias: gnu
 --    * FreeBSD alias: kfreebsdgnu
 --    * Solaris alias: solaris2
@@ -123,7 +124,7 @@ knownOSs = [Linux, Windows, OSX
 osAliases :: ClassificationStrictness -> OS -> [String]
 osAliases Permissive Windows = ["mingw32", "win32", "cygwin32"]
 osAliases Compat     Windows = ["mingw32", "win32"]
-osAliases _          OSX     = ["darwin"]
+osAliases _          OSX     = ["darwin", "macos"]
 osAliases _          Hurd    = ["gnu"]
 osAliases Permissive FreeBSD = ["kfreebsdgnu"]
 osAliases Compat     FreeBSD = ["kfreebsdgnu"]
@@ -139,8 +140,6 @@ instance Pretty OS where
 
 instance Parsec OS where
   parsec = classifyOS Compat <$> parsecIdent
-
-
 
 classifyOS :: ClassificationStrictness -> String -> OS
 classifyOS strictness s =

--- a/Cabal-syntax/src/Distribution/System.hs
+++ b/Cabal-syntax/src/Distribution/System.hs
@@ -82,10 +82,9 @@ data ClassificationStrictness = Permissive | Compat | Strict
 -- * Operating System
 -- ------------------------------------------------------------
 
--- | These are the known OS names: Linux, Windows, OSX
---  ,FreeBSD, OpenBSD, NetBSD, DragonFly
---  ,Solaris, AIX, HPUX, IRIX
---  ,HaLVM ,Hurd ,IOS, Android, Ghcjs, Wasi
+-- | These are the known OS names: Linux, Windows, OSX, FreeBSD, OpenBSD,
+--   NetBSD, DragonFly, Solaris, AIX, HPUX, IRIX, HaLVM, Hurd, IOS, Android,
+--   Ghcjs, Wasi
 --
 -- The following aliases can also be used:,
 --

--- a/changelog.d/pr-8792
+++ b/changelog.d/pr-8792
@@ -1,0 +1,10 @@
+synopsis: Add the "macos" alias for the OSX constructor of the OS datatype
+prs: #8792
+packages: Cabal-syntax
+
+description: {
+
+Add the "macos" alias for the OSX constructor of the OS datatype.
+Haddock syntax is also fixed to render properly.
+
+}


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

## Before
![Screenshot 2023-02-21 at 10-32-56 Distribution System](https://user-images.githubusercontent.com/29253044/220305845-b153e57a-4933-42a8-9397-8ff9bac21631.png)

## After
![Screenshot 2023-02-21 at 10-33-06 Distribution System](https://user-images.githubusercontent.com/29253044/220305904-8817f05e-e655-4e09-a1e0-51b70fb08549.png)
