### PR TITLE
Disallow GHC <8.0 for Cabal{,-syntax} & cabal-install-solver

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -29,7 +29,7 @@ library
 
   build-depends:
     array      >= 0.4.0.1  && < 0.6,
-    base       >= 4.6      && < 5,
+    base       >= 4.9      && < 5,
     binary     >= 0.7      && < 0.9,
     bytestring >= 0.10.0.0 && < 0.12,
     containers >= 0.5.0.0  && < 0.7,

--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -51,7 +51,7 @@ test-suite unit-tests
   build-depends:
       array
     , async               >=2.2.2 && <2.3
-    , base                >=0     && <5
+    , base                >=4.9     && <5
     , binary
     , bytestring
     , Cabal

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -36,7 +36,7 @@ library
   build-depends:
     Cabal-syntax ^>= 3.9,
     array      >= 0.4.0.1  && < 0.6,
-    base       >= 4.6      && < 5,
+    base       >= 4.9      && < 5,
     bytestring >= 0.10.0.0 && < 0.12,
     containers >= 0.5.0.0  && < 0.7,
     deepseq    >= 1.3.0.1  && < 1.5,

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -121,7 +121,7 @@ library
 
   if flag(debug-conflict-sets)
     cpp-options:   -DDEBUG_CONFLICT_SETS
-    build-depends: base >=4.8
+    build-depends: base >=4.9
 
   if flag(debug-tracetree)
     cpp-options:   -DDEBUG_TRACETREE

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -26,7 +26,7 @@ common shared
   default-language: Haskell2010
 
   build-depends:
-    , base >= 4.6 && <4.18
+    , base >= 4.9 && <4.18
     -- this needs to match the in-tree lib:Cabal version
     , Cabal ^>= 3.9.0.0
     , Cabal-syntax ^>= 3.9.0.0

--- a/changelog.d/pr-8794
+++ b/changelog.d/pr-8794
@@ -1,0 +1,10 @@
+synopsis: Disallow GHC <8.0 for 
+packages: Cabal Cabal-syntax cabal-install-solver
+prs: #8794
+issues: #8715 #7531
+
+description: {
+
+Disallow GHC <8.0 by restricting the version of base that can be used to at least 4.9
+
+}


### PR DESCRIPTION
(hopefully) closes #8715


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
