### PR TITLE
Move `process >= 1.16.4` constraint from `Cabal-3.8.1.0` to `cabal-install-3.8.1.0`

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -1,6 +1,7 @@
 cabal-version: 1.22
 name:          Cabal-syntax
 version:       3.8.1.0
+x-revision: 3
 copyright:     2003-2022, Cabal Development Team (see AUTHORS file)
 license:       BSD3
 license-file:  LICENSE
@@ -29,31 +30,31 @@ library
 
   build-depends:
     array      >= 0.4.0.1  && < 0.6,
-    base       >= 4.6      && < 5,
+    base       >= 4.9      && < 5,
     binary     >= 0.7      && < 0.9,
     bytestring >= 0.10.0.0 && < 0.12,
     containers >= 0.5.0.0  && < 0.7,
     deepseq    >= 1.3.0.1  && < 1.5,
     directory  >= 1.2      && < 1.4,
     filepath   >= 1.3.0.1  && < 1.5,
-    mtl        >= 2.1      && < 2.3,
+    mtl        >= 2.1      && < 2.4,
     parsec     >= 3.1.13.0 && < 3.2,
     pretty     >= 1.1.1    && < 1.2,
     text       (>= 1.2.3.0 && < 1.3) || (>= 2.0 && < 2.1),
     time       >= 1.4.0.1  && < 1.13,
     -- transformers-0.4.0.0 doesn't have record syntax e.g. for Identity
     -- See also https://github.com/ekmett/transformers-compat/issues/35
-    transformers (>= 0.3      && < 0.4) || (>=0.4.1.0 && <0.6)
+    transformers (>= 0.3      && < 0.4) || (>=0.4.1.0 && <0.7)
 
   if os(windows)
     build-depends: Win32 >= 2.3.0.0 && < 2.14
   else
-    build-depends: unix  >= 2.6.0.0 && < 2.8
+    build-depends: unix  >= 2.6.0.0 && < 2.9
 
   ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   ghc-options: -Wcompat -Wnoncanonical-monad-instances
 
-  if impl(ghc <8.8)
+  if impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
   exposed-modules:

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,6 +1,7 @@
 cabal-version: 1.22
 name:          Cabal
 version:       3.8.1.0
+x-revision:    2
 copyright:     2003-2022, Cabal Development Team (see AUTHORS file)
 license:       BSD3
 license-file:  LICENSE
@@ -48,7 +49,7 @@ library
 
   -- pull in process version with fixed waitForProcess error
   if impl(ghc >=8.2)
-    build-depends: process >= 1.6.14.0
+    build-depends: process >= 1.2.1.0
 
   if os(windows)
     build-depends: Win32 >= 2.3.0.0 && < 2.14

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -301,8 +301,8 @@ library
   build-depends:
     -- transformers-0.4.0.0 doesn't have record syntax e.g. for Identity
     -- See also https://github.com/ekmett/transformers-compat/issues/35
-    transformers (>= 0.3      && < 0.4) || (>=0.4.1.0 && <0.6),
-    mtl           >= 2.1      && < 2.3,
+    transformers (>= 0.3      && < 0.4) || (>=0.4.1.0 && < 0.7),
+    mtl           >= 2.1      && < 2.4,
     text         (>= 1.2.3.0  && < 1.3) || (>= 2.0 && < 2.1),
     parsec        >= 3.1.13.0 && < 3.2
 

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -53,7 +53,7 @@ library
   if os(windows)
     build-depends: Win32 >= 2.3.0.0 && < 2.14
   else
-    build-depends: unix  >= 2.6.0.0 && < 2.8
+    build-depends: unix  >= 2.6.0.0 && < 2.9
 
   ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   ghc-options: -Wcompat -Wnoncanonical-monad-instances

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -1,6 +1,7 @@
 cabal-version: 2.2
 name:          cabal-install-solver
 version:       3.8.1.0
+x-revision: 1
 synopsis:      The command-line interface for Cabal and Hackage.
 description:
   The solver component used in cabal-install command-line program
@@ -105,7 +106,7 @@ library
 
   build-depends:
     , array         >=0.4      && <0.6
-    , base          >=4.10     && <4.17
+    , base          >=4.10     && <4.18
     , bytestring    >=0.10.6.0 && <0.12
     , Cabal         ^>=3.8
     , Cabal-syntax  ^>=3.8
@@ -138,7 +139,7 @@ Test-Suite unit-tests
      UnitTests.Distribution.Solver.Modular.MessageUtils
 
    build-depends:
-     , base        >= 4.10  && <4.17
+     , base        >= 4.10  && <4.18
      , Cabal
      , Cabal-syntax
      , cabal-install-solver

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -2,6 +2,7 @@ Cabal-Version:      2.2
 
 Name:               cabal-install
 Version:            3.8.1.0
+x-revision:         3
 Synopsis:           The command-line interface for Cabal and Hackage.
 Description:
     The \'cabal\' command-line program simplifies the process of managing
@@ -216,7 +217,8 @@ library
         mtl        >= 2.0      && < 2.3,
         network-uri >= 2.6.0.2 && < 2.7,
         pretty     >= 1.1      && < 1.2,
-        process    >= 1.2.3.0  && < 1.7,
+        -- process lower bound moved from Cabal-3.8.1.0 to here:
+        process    >= 1.6.14.0 && < 1.7,
         random     >= 1.2      && < 1.3,
         stm        >= 2.0      && < 2.6,
         tar        >= 0.5.0.3  && < 0.6,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -46,7 +46,7 @@ common warnings
       ghc-options: -Wunused-packages
 
 common base-dep
-    build-depends: base >=4.10 && <4.17
+    build-depends: base >=4.10 && <4.18
 
 common cabal-dep
     build-depends: Cabal ^>=3.8
@@ -220,10 +220,10 @@ library
         random     >= 1.2      && < 1.3,
         stm        >= 2.0      && < 2.6,
         tar        >= 0.5.0.3  && < 0.6,
-        time       >= 1.5.0.1  && < 1.12,
+        time       >= 1.5.0.1  && < 1.13,
         zlib       >= 0.5.3    && < 0.7,
         hackage-security >= 0.6.2.0 && < 0.7,
-        text       >= 1.2.3    && < 1.3,
+        text       >= 1.2.3    && < 1.3 || >=2.0 && <2.1,
         parsec     >= 3.1.13.0 && < 3.2,
         regex-base  >= 0.94.0.0 && <0.95,
         regex-posix >= 0.96.0.0 && <0.97,

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -26,10 +26,10 @@ common shared
   default-language: Haskell2010
 
   build-depends:
-    , base >= 4.6 && <4.17
+    , base >= 4.6 && <4.18
     -- this needs to match the in-tree lib:Cabal version
-    , Cabal ^>=3.8.0.0
-    , Cabal-syntax ^>=3.8.0.0
+    , Cabal ^>=3.8.1.0
+    , Cabal-syntax ^>=3.8.1.0
 
   ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
 
@@ -57,7 +57,7 @@ library
     Test.Cabal.ScriptEnv0
 
   build-depends:
-    , aeson                 ^>= 1.4.2.0 || ^>=1.5.0.0 || ^>= 2.0.0.0
+    , aeson                 ^>= 1.4.2.0 || ^>=1.5.0.0 || ^>= 2.0.0.0 || ^>= 2.1.0.0
     , async                 ^>= 2.2.1
     , attoparsec            ^>= 0.13.2.2 || ^>=0.14.1
     , base16-bytestring     ^>= 0.1.1.6 || ^>= 1.0.0.0
@@ -67,8 +67,8 @@ library
     , directory             ^>= 1.2.0.1 || ^>= 1.3.0.0
     , exceptions            ^>= 0.10.0
     , filepath              ^>= 1.3.0.1 || ^>= 1.4.0.0
-    , network-wait          ^>= 0.1.2.0
-    , optparse-applicative  ^>= 0.14.3.0 || ^>=0.15.1.0 || ^>=0.16.0.0
+    , network-wait           >= 0.1.2.0  && < 0.3
+    , optparse-applicative  ^>= 0.14.3.0 || ^>=0.15.1.0 || ^>=0.16.0.0 || ^>=0.17.0.0
     , process               ^>= 1.2.1.0 || ^>= 1.4.2.0 || ^>= 1.6.1.0
     , regex-base            ^>= 0.94.0.1
     , regex-tdfa            ^>= 1.2.3.1 || ^>=1.3.1.0
@@ -80,7 +80,7 @@ library
 
   if !os(windows)
     build-depends:
-      , unix                ^>= 2.6.0.0 || ^>= 2.7.0.0
+      , unix                ^>= 2.6.0.0 || ^>= 2.7.0.0 || ^>= 2.8.0.0
   else
     build-depends:
       , Win32
@@ -113,6 +113,6 @@ custom-setup
   -- we only depend on even stable releases of lib:Cabal
   -- and due to Custom complexity and ConstraintSetupCabalMaxVersion
   -- it can't be the current version
-  setup-depends: Cabal == 3.6.*,
-                 Cabal-syntax == 3.6.*,
+  setup-depends: Cabal == 3.8.*,
+                 Cabal-syntax == 3.8.*,
                  base, filepath, directory

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,10 @@ packages: cabal-benchmarks/
 
 optional-packages: ./vendored/*/*.cabal
 
-allow-newer:
-  hackage-security:Cabal
+allow-newer: hackage-security:Cabal
+
+allow-newer: *:text
+allow-newer: *:unix
 
 -- avoiding extra dependencies
 constraints: rere -rere-cfg


### PR DESCRIPTION
Resolves #8554.

This PR is **not to be merged**, just for testing and discussion, as agreed in the Cabal developers meeting of 2023-02-23.
  
The plan is to revise `Cabal-3.8.1.0` and `cabal-install-3.8.1.0` according to this PR, namely the last 2 commits:
- 2beee0b7512d2873e0303f750f8782d6523877ae
- aa60929e3ac2154fc6b28b052c1e33f009b0de0b

The first commit just capture revisions already present on hackage.  The second commit makes changes so that this PR builds.

I checked builds locally:
- `Cabal` with `mtl-2.3.1` (for 2beee0b7512d2873e0303f750f8782d6523877ae)
- `cabal-install` with `unix-2.8.0.0` (for aa60929e3ac2154fc6b28b052c1e33f009b0de0b)