### PR TITLE
Pull revision onto 3.8 branch: Cabal: allow mtl-2.3 and transformers-0.6

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -299,8 +299,8 @@ library
   build-depends:
     -- transformers-0.4.0.0 doesn't have record syntax e.g. for Identity
     -- See also https://github.com/ekmett/transformers-compat/issues/35
-    transformers (>= 0.3      && < 0.4) || (>=0.4.1.0 && <0.6),
-    mtl           >= 2.1      && < 2.3,
+    transformers (>= 0.3      && < 0.4) || (>= 0.4.1.0 && < 0.7),
+    mtl           >= 2.1      && < 2.4,
     text         (>= 1.2.3.0  && < 1.3) || (>= 2.0 && < 2.1),
     parsec        >= 3.1.13.0 && < 3.2
 


### PR DESCRIPTION
This revision of `Cabal-3.8.1.0` is already on Hackage: allow `mtl-2.3` and `transformers-0.6`.
Syncing to 3.8 branch.