### PR TITLE
Update GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,19 +36,6 @@ build-aarch64-linux-deb10:
     TARBALL_EXT: tar.xz
     ADD_CABAL_ARGS: ""
 
-build-armv7-linux-deb10:
-  extends: .build
-  tags:
-    - armv7-linux
-  image: "registry.gitlab.haskell.org/ghc/ci-images/armv7-linux-deb10:$DOCKER_REV"
-  variables:
-    TARBALL_ARCHIVE_SUFFIX: armv7-linux-deb1
-    TARBALL_EXT: tar.xz
-    ADD_CABAL_ARGS: ""
-    # temp, because 3.6.2.0 is broken
-    CABAL_INSTALL_VERSION: 3.4.0.0
-  retry: 2
-
 build-x86_64-linux:
   extends: .build
   parallel:
@@ -83,32 +70,6 @@ build-x86_64-linux-alpine:
     TARBALL_ARCHIVE_SUFFIX: x86_64-linux-alpine
     TARBALL_EXT: tar.xz
     ADD_CABAL_ARGS: "--enable-split-sections --enable-executable-static"
-
-build-i386-linux-alpine:
-  extends: .build
-  tags:
-    - x86_64-linux
-  image: "i386/alpine:3.12"
-  before_script:
-    # for GHC
-    - apk add --no-cache bash curl gcc g++ binutils binutils-gold bsd-compat-headers gmp-dev ncurses-dev libffi-dev make xz tar perl
-    # for cabal build
-    - apk add --no-cache zlib zlib-dev zlib-static
-  variables:
-    TARBALL_ARCHIVE_SUFFIX: i386-linux-alpine
-    TARBALL_EXT: tar.xz
-    ADD_CABAL_ARGS: "--enable-split-sections --enable-executable-static"
-    # temp, because 3.6.2.0 is broken
-    CABAL_INSTALL_VERSION: 3.4.0.0
-
-build-x86_64-freebsd12:
-  extends: .build
-  tags:
-    - x86_64-freebsd12
-  variables:
-    TARBALL_ARCHIVE_SUFFIX: x86_64-freebsd12
-    TARBALL_EXT: tar.xz
-    ADD_CABAL_ARGS: "--enable-split-sections"
 
 build-x86_64-darwin:
   extends: .build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,9 @@
 stages:
   - build
 
-# Used for ci setup in the gitlab mirror of the project:
-# https://gitlab.haskell.org/haskell/haskell-language-server/-/pipelines
 variables:
   # Commit of ghc/ci-images repository from which to pull Docker images
-  DOCKER_REV: "9e4c540d9e4972a36291dfdf81f079f37d748890"
+  DOCKER_REV: "572353e0644044fe3a5465bba4342a9a0b0eb60e"
 
   GHC_VERSION: 9.2.3
   CABAL_INSTALL_VERSION: 3.6.2.0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,21 +51,16 @@ build-armv7-linux-deb10:
 
 build-x86_64-linux:
   extends: .build
+  parallel:
+    matrix:
+      - PLATFORM:
+        - x86_64-linux-deb10
+        - x86_64-linux-deb11
   tags:
     - x86_64-linux
-  image: "registry.gitlab.haskell.org/ghc/ci-images/x86_64-linux-deb10:$DOCKER_REV"
+  image: "registry.gitlab.haskell.org/ghc/ci-images/$PLATFORM:$DOCKER_REV"
   variables:
-    TARBALL_ARCHIVE_SUFFIX: x86_64-linux-deb10
-    TARBALL_EXT: tar.xz
-    ADD_CABAL_ARGS: "--enable-split-sections"
-
-build-x86_64-linux-deb11:
-  extends: .build
-  tags:
-    - x86_64-linux
-  image: "registry.gitlab.haskell.org/ghc/ci-images/x86_64-linux-deb11:$DOCKER_REV"
-  variables:
-    TARBALL_ARCHIVE_SUFFIX: x86_64-linux-deb11
+    TARBALL_ARCHIVE_SUFFIX: $PLATFORM
     TARBALL_EXT: tar.xz
     ADD_CABAL_ARGS: "--enable-split-sections"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,16 +26,6 @@ workflow:
     paths:
       - out/*
 
-build-aarch64-linux-deb10:
-  extends: .build
-  tags:
-    - aarch64-linux
-  image: "registry.gitlab.haskell.org/ghc/ci-images/aarch64-linux-deb10:$DOCKER_REV"
-  variables:
-    TARBALL_ARCHIVE_SUFFIX: aarch64-linux-deb10
-    TARBALL_EXT: tar.xz
-    ADD_CABAL_ARGS: ""
-
 build-x86_64-linux:
   extends: .build
   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,12 @@ build-x86_64-linux:
   parallel:
     matrix:
       - PLATFORM:
+        - i386-linux-deb9
+        - x86_64-linux-deb9
+        - x86_64-linux-fedora33
+        - x86_64-linux-rocky8
+        - x86_64-linux-ubuntu18_04
+        - x86_64-linux-ubuntu20_04
         - x86_64-linux-deb10
         - x86_64-linux-deb11
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,7 @@ build-x86_64-linux:
     matrix:
       - PLATFORM:
         - i386-linux-deb9
+        - x86_64-linux-centos7
         - x86_64-linux-deb9
         - x86_64-linux-fedora33
         - x86_64-linux-rocky8

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -Eeuxo pipefail
+set -Eeuo pipefail
 
 source "$CI_PROJECT_DIR/.gitlab/common.sh"
 
@@ -26,7 +26,6 @@ export PATH="$GHCUP_BINDIR:$PATH"
 export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
 export BOOTSTRAP_HASKELL_GHC_VERSION=$GHC_VERSION
 export BOOTSTRAP_HASKELL_CABAL_VERSION=$CABAL_INSTALL_VERSION
-export BOOTSTRAP_HASKELL_VERBOSE=1
 export BOOTSTRAP_HASKELL_ADJUST_CABAL_CONFIG=yes
 
 # for some reason the subshell doesn't pick up the arm64 environment on darwin

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -48,7 +48,11 @@ case "$(uname -s)" in
 esac
 
 # https://github.com/haskell/cabal/issues/7313#issuecomment-811851884
-if [ "$(getconf LONG_BIT)" == "32" ] ; then
+# and
+# https://github.com/haskellari/lukko/issues/17
+#
+# $PLATFORM comes from CI.
+if [ "$(getconf LONG_BIT)" = "32" -o "${PLATFORM:=xxx}" = "x86_64-linux-centos7" ] ; then
     echo 'constraints: lukko -ofd-locking' >> cabal.project.release.local
 fi
 


### PR DESCRIPTION
## Background

* Cabal's GitLab CI has 12 jobs, of which 5 are broken.
* Cabal 3.8.1 was released for 6 platforms.
* Cabal maintainers want to use GitLab CI for 3.10 release (#8674)

## Goal

1. Get GitLab CI green
2. Support the Cabal 3.8.1 platforms
3. Support the GHC 9.6.1 platforms---a superset of Cabal 3.8.1 platforms

## Status

1. :heavy_check_mark:  CI is green: https://gitlab.haskell.org/haskell/cabal/-/pipelines/63801
2. :x: aarch64-linux-deb10 was removed because GHCUp has a glibc incompatibility https://gitlab.haskell.org/haskell/cabal/-/jobs/1388613
3. :heavy_check_mark: besides aarch64-linux-deb10, all other platforms supported by GHC 9.6.1 are included in the pipeline, bringing the total to 13.