### PR TITLE
Validate --store-dir arguments early

### DIFF
--- a/Cabal/src/Distribution/Simple/Flag.hs
+++ b/Cabal/src/Distribution/Simple/Flag.hs
@@ -62,6 +62,20 @@ instance Functor Flag where
   fmap f (Flag x) = Flag (f x)
   fmap _ NoFlag  = NoFlag
 
+instance Foldable Flag where
+    foldMap f (Flag x) = f x
+    foldMap _ NoFlag = mempty
+
+    foldr _ z NoFlag = z
+    foldr f z (Flag x) = f x z
+
+    foldl _ z NoFlag = z
+    foldl f z (Flag x) = f z x
+
+instance Traversable Flag where
+    traverse f (Flag x) = Flag <$> f x
+    traverse _ NoFlag = pure NoFlag
+
 instance Applicative Flag where
   (Flag x) <*> y = x <$> y
   NoFlag   <*> _ = NoFlag

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -53,7 +53,7 @@ module Distribution.Client.Setup
     , yesNoOpt
     ) where
 
-import Prelude ()
+import Prelude (sequence)
 import Distribution.Client.Compat.Prelude hiding (get)
 
 import Distribution.Client.Types.Credentials (Username (..), Password (..))
@@ -133,7 +133,13 @@ import Distribution.Parsec
 import Data.List
          ( deleteFirstsBy )
 import System.FilePath
-         ( (</>) )
+         ( (</>), isAbsolute )
+
+type AbsoluteFilePath = FilePath
+readAbsoluteFilePath :: FilePath -> Maybe AbsoluteFilePath
+readAbsoluteFilePath filePath
+    | isAbsolute filePath || "${pkgroot}" `isPrefixOf` filePath = Just filePath
+    | otherwise = Nothing
 
 globalCommand :: [Command action] -> CommandUI GlobalFlags
 globalCommand commands = CommandUI {
@@ -379,7 +385,11 @@ globalCommand commands = CommandUI {
 
       ,option [] ["store-dir", "storedir"]
          "The location of the build store"
-         globalStoreDir (\v flags -> flags { globalStoreDir = v })
+         globalStoreDir (\v flags ->
+            case sequence $ fmap readAbsoluteFilePath v of
+                Just flag -> flags { globalStoreDir = flag }
+                Nothing -> error "expected an absolute directory name for --store-dir"
+         )
          (reqArgFlag "DIR")
 
       , option [] ["active-repositories"]

--- a/cabal-testsuite/PackageTests/AutoconfBadPaths/configure
+++ b/cabal-testsuite/PackageTests/AutoconfBadPaths/configure
@@ -1069,7 +1069,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir runstatedir store-dir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.


### PR DESCRIPTION
I'm a new contributor to Cabal and a relatively new Haskell user so I'm open to all feedback.

Resolves #8791 

Check list
---
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

The test appears in https://github.com/haskell/cabal/commit/e5ae4cb0cd74229e79e575d5fd8cbb4f22a6159c

@andreasabel 