### PR TITLE
CI: disable prerelease validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -194,6 +194,9 @@ jobs:
   # - (sometimes) disabling some parts on Windows because it's hard to figure
   #   out why they fail
   validate-prerelease:
+    # TODO: reenable when the next GHC prerelease appears
+    if: false
+
     name: Validate ${{ matrix.os }} ghc-prerelease
     runs-on: ${{ matrix.os }}
     outputs:


### PR DESCRIPTION
We have a transient failure there due to bumping our package version numbers (https://github.com/haskell/cabal/pull/8844): the cabal testsuite can't be configured (https://github.com/haskell/cabal/issues/8133 strikes again). So, let's disable it, get CI green and wait until version numbers are settled with the addition of the proper 9.6 release (#8840).

The job could be reenabled later in the future when a new GHC prerelease appears (9.8 family).