### PR TITLE
Prepends >= to cabal versions older than 1.12

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Format.hs
+++ b/cabal-install/src/Distribution/Client/Init/Format.hs
@@ -278,7 +278,7 @@ mkTestStanza opts (TestTarget testMain dirs lang otherMods exts deps tools) =
 
 mkPkgDescription :: WriteOpts -> PkgDescription -> [PrettyField FieldAnnotation]
 mkPkgDescription opts pkgDesc =
-    [ field "cabal-version" text (showCabalSpecVersion cabalSpec)
+    [ field "cabal-version" text ((if cabalSpec < CabalSpecV1_12 then ">=" else "") ++ showCabalSpecVersion cabalSpec)
       [ "The cabal-version field refers to the version of the .cabal specification,"
       , "and can be different from the cabal-install (the tool) version and the"
       , "Cabal (the library) version you are using. As such, the Cabal (the library)"

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Golden.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Golden.hs
@@ -87,10 +87,10 @@ goldenPkgDescTests v srcDb pkgDir pkgName = testGroup "package description golde
         let opts = WriteOpts False False False v pkgDir Library pkgName defaultCabalVersion
         in runPkgDesc opts emptyFlags pkgArgs
 
-    , goldenVsString "Dummy flags, with comments"
+    , goldenVsString "Dummy flags, >= cabal version syntax, with comments"
       (goldenPkgDesc "pkg-with-flags.golden") $
         let opts = WriteOpts False False False v pkgDir Library pkgName defaultCabalVersion
-        in runPkgDesc opts dummyFlags pkgArgs
+        in runPkgDesc opts (dummyFlags {cabalVersion = Flag CabalSpecV1_0}) pkgArgs
 
     , goldenVsString "Dummy flags, old cabal version, with comments"
       (goldenPkgDesc "pkg-old-cabal-with-flags.golden") $

--- a/cabal-install/tests/fixtures/init/golden/pkg-desc/pkg-with-flags.golden
+++ b/cabal-install/tests/fixtures/init/golden/pkg-desc/pkg-with-flags.golden
@@ -1,4 +1,4 @@
-cabal-version:      2.2
+cabal-version:      >=1.0
 -- The cabal-version field refers to the version of the .cabal specification,
 -- and can be different from the cabal-install (the tool) version and the
 -- Cabal (the library) version you are using. As such, the Cabal (the library)

--- a/changelog.d/issue-8206
+++ b/changelog.d/issue-8206
@@ -1,0 +1,4 @@
+synopsis: cabal init now generates cabal versions older than 1.12 with the correct >= syntax
+packages: cabal-install
+prs: #8860
+issues: #8206


### PR DESCRIPTION
Closes #8206. I updated one of the golden tests so it detects this stuff.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
