### PR TITLE
Fix a typo in the split-objs/split-sections warning message

### DIFF
--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -626,7 +626,7 @@ configure (pkg_descr0, pbi) cfg = do
                         _ | split_sections
                           -> do warn verbosity
                                      ("--enable-split-sections and " ++
-                                      "--enable-split-objs are mutually" ++
+                                      "--enable-split-objs are mutually " ++
                                       "exclusive; ignoring the latter")
                                 return False
                         GHC


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
