### PR TITLE
Fix typo in Pretty.hs

### DIFF
--- a/Cabal-syntax/src/Distribution/Fields/Pretty.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Pretty.hs
@@ -59,7 +59,7 @@ showFields rann = showFields' rann (const id) 4
 -- | 'showFields' with user specified indentation.
 showFields'
   :: (ann -> CommentPosition)
-     -- ^ Convert an annotation to lined to preceed the field or section.
+     -- ^ Convert an annotation to lined to precede the field or section.
   -> (ann -> [String] -> [String])
      -- ^ Post-process non-annotation produced lines.
   -> Int


### PR DESCRIPTION
preceed -> precede


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
