### PR TITLE
Ignore ~/.cabal if $XDG_CONFIG_HOME/cabal/config exists.

### DIFF
--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -601,7 +601,7 @@ warnOnTwoConfigs verbosity = do
   xdgCfg <- getXdgDirectory XdgConfig ("cabal" </> "config")
   xdgCfgExists <- doesFileExist xdgCfg
   when (dotCabalExists && xdgCfgExists) $
-    warn normal $
+    warn verbosity $
     "Both " <> defaultDir <>
     " and " <> xdgCfg <>
     " exist - ignoring the former."

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -604,7 +604,7 @@ warnOnTwoConfigs verbosity = do
     warn verbosity $
     "Both " <> defaultDir <>
     " and " <> xdgCfg <>
-    " exist - ignoring the former.\n"
+    " exist - ignoring the former.\n" <>
     "It is advisable to remove one of them. In that case, we will use the remaining one by default (unless '$CABAL_DIR' is explicitly set)."
 
 -- | If @CABAL\_DIR@ is set, return @Just@ its value. Otherwise, if

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -604,15 +604,16 @@ warnOnTwoConfigs verbosity = do
     warn verbosity $
     "Both " <> defaultDir <>
     " and " <> xdgCfg <>
-    " exist - ignoring the former."
+    " exist - ignoring the former.\n"
+    "It is advisable to remove one of them. In that case, we will use the remaining one by default (unless '$CABAL_DIR' is explicitly set)."
 
--- | If @CABAL\_DIR@ is set or @~/.cabal@ exists (and
--- @$XDG_CONFIG_HOME/cabal/config@ does not exist), return that
--- directory.  Otherwise returns Nothing.  If this function returns
--- Nothing, then it implies that we are not using a single directory
--- for everything, but instead use XDG paths.  Fundamentally, this
--- function is used to implement transparent backwards compatibility
--- with pre-XDG versions of cabal-install.
+-- | If @CABAL\_DIR@ is set, return @Just@ its value. Otherwise, if
+-- @~/.cabal@ exists and @$XDG_CONFIG_HOME/cabal/config@ does not
+-- exist, return @Just "~/.cabal"@.  Otherwise, return @Nothing@.  If
+-- this function returns Nothing, then it implies that we are not
+-- using a single directory for everything, but instead use XDG paths.
+-- Fundamentally, this function is used to implement transparent
+-- backwards compatibility with pre-XDG versions of cabal-install.
 maybeGetCabalDir :: IO (Maybe FilePath)
 maybeGetCabalDir = do
   mDir <- lookupEnv "CABAL_DIR"

--- a/changelog.d/issue-8577
+++ b/changelog.d/issue-8577
@@ -1,0 +1,13 @@
+synopsis: Existence of $XDG_CONFIG_HOME/cabal/config now overrides existence of $HOME/.cabal
+packages: cabal-install
+issues: #8577
+
+description: {
+
+To avoid pre-XDG backwards compatibility from triggering due to other
+tools accidentally creating a $HOME/.cabal directory, the presence of
+$XDG_CONFIG_HOME/cabal/config now disables pre-XDG backwards
+compatibility.  Presumably $XDG_CONFIG_HOME/cabal/config will never be
+created by accident.
+
+}

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -61,9 +61,10 @@ Various environment variables affect ``cabal-install``.
    .. note::
 
        For backwards compatibility, if the directory ``~/.cabal`` on
-       Unix or ``%APPDATA%\cabal`` on Windows exist and ``CABAL_DIR``
-       is unset, ``cabal-install`` will behave as if ``CABAL_DIR`` was
-       set to point at this directory.
+       Unix or ``%APPDATA%\cabal`` on Windows exists, and
+       ``$XDG_CONFIG_HOME/cabal/config`` does not exist, and
+       ``CABAL_DIR`` is unset, ``cabal-install`` will behave as if
+       ``CABAL_DIR`` was set to point at this directory.
 
 ``CABAL_BUILDDIR``
 


### PR DESCRIPTION
This is a draft implementation of #8577.

There is one flaw in this implementation: the warning is printed many times, and with non-configurable verbosity.  Changing that would require one of:

1) Significant refactoring of how `getDefaultDir` is called, which has non-local implications.
2) Doing the warning somewhere else (e.g. in Main.hs).

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
