### PR TITLE
Put back github actions cache restore

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,20 +57,6 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      #  See the following link for a breakdown of the following step
-      #  https://github.com/haskell/actions/issues/7#issuecomment-745697160
-      #
-      # See https://github.com/haskell/cabal/pull/8739 for why Windows is excluded
-      - if: ${{ runner.os != 'Windows' }}
-        uses: actions/cache@v3
-        with:
-          # validate.sh uses a special build dir
-          path: |
-            ${{ steps.setup-haskell.outputs.cabal-store }}
-            dist-*
-          key: ${{ runner.os }}-${{ matrix.ghc }}-20220419-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-20220419-
-
       # See https://github.com/haskell/cabal/pull/8739
       - name: Sudo chmod to permit ghcup to update its cache
         run: |
@@ -86,6 +72,21 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: '3.10.1.0'
+
+      #  actions/cache: see the following link for a breakdown of this step
+      #  https://github.com/haskell/actions/issues/7#issuecomment-745697160
+      #
+      # See https://github.com/haskell/cabal/pull/8739 for why Windows is excluded
+      #
+      - if: ${{ runner.os != 'Windows' }}
+        uses: actions/cache@v3
+        with:
+          # validate.sh uses a special build dir
+          path: |
+            ${{ steps.setup-haskell.outputs.cabal-store }}
+            dist-*
+          key: ${{ runner.os }}-${{ matrix.ghc }}-20220419-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-20220419-
 
       - name: Work around git problem https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586 (cabal PR #8546)
         run: |


### PR DESCRIPTION
The recent reordering was done in anger due to https://github.com/haskell/actions/issues/203 but it has been fixed upstream. The current state is not correct because we say we cache the cabal-store that doesn't exist yet (because of the said reordering).

Undo https://github.com/haskell/cabal/commit/6bd17fcf4cd0d5f9e906ad743bde7e8faabfb08b from https://github.com/haskell/cabal/pull/8844.