### PR TITLE
Add instructions to the PR template for manual QA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,6 @@ Please include the following checklist in your PR:
 * [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
 * [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
 * [ ] The documentation has been updated, if necessary.
-* [ ] Include manual QA notes if your PR relates to cabal-install.
+* [ ] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.
 
 Please also shortly describe how you tested your change. Bonus points for added tests!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@ Please include the following checklist in your PR:
 * [ ] The documentation has been updated, if necessary.
 * [ ] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.
 
-Please also shortly describe how you tested your change. Bonus points for added tests!
+Bonus points for added automated tests!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,6 @@ Please include the following checklist in your PR:
 * [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
 * [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
 * [ ] The documentation has been updated, if necessary.
+* [ ] Include manual QA notes if your PR relates to cabal-install.
 
 Please also shortly describe how you tested your change. Bonus points for added tests!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,22 @@ For these test executables, `-p` which applies a regex filter to the test
 names. When running `cabal-install` test suites, one need only use `cabal test` or
 `cabal run <test-target>` in order to test locally.
 
+QA Notes
+--------
+
+Manual Quality Assurance (QA) is done manually to ensure that the changes impacting the command-line interface, wether it is adding or modifying a behaviour,
+are tested before being released. This allows us to catch UX regressions and put a human perspective into testing.
+
+Contributions that touch `cabal-install` are expected to include notes for the QA team. They are a description of an expected result upon calling `cabal-install` with
+certain parameters. For instance:
+
+> ## QA Notes
+> Calling `cabal haddock-project` should produce documentation for the whole cabal project with the following defaults enabled:
+> * Documentation lives in ./haddocks
+> * The file `./haddocks/index.html` should exist
+
+Manual QA is not expected to find every possible bug, but to really challenge the assumptions of the contributor, and to verify that their own testing
+of their patch is not influenced by their setup or implicit knowledge of the system.
 
 Whitespace Conventions
 ----------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,8 @@ Building Cabal for hacking
 --------------------------
 
 The current recommended way of developing Cabal is to use the
-`v2-build` feature which [shipped in cabal-install-1.24](http://blog.ezyang.com/2016/05/announcing-cabal-new-build-nix-style-local-builds/).  If you use the latest version of cabal published on Hackage, it is sufficient to run:
+`v2-build` feature which [shipped in cabal-install-1.24](http://blog.ezyang.com/2016/05/announcing-cabal-new-build-nix-style-local-builds/).
+If you use the latest version of cabal published on Hackage, it is sufficient to run:
 
 ```
 cabal v2-build cabal
@@ -118,11 +119,15 @@ names. When running `cabal-install` test suites, one need only use `cabal test` 
 QA Notes
 --------
 
-Manual Quality Assurance (QA) is performed to ensure that the changes impacting the command-line interface, whether adding or modifying a behaviour,
-are tested before being released. This allows us to catch UX regressions and put a human perspective into testing.
+Manual Quality Assurance (QA) is performed to ensure that the changes impacting
+the command-line interface, whether adding or modifying a behaviour,
+are tested before being released. This allows us to catch UX regressions and put
+a human perspective into testing.
 
-Contributions that touch `cabal-install` are expected to include notes for the QA team. They are a description of an expected result upon calling `cabal-install` with
-certain parameters. For instance:
+Contributions that touch `cabal-install` are expected to include notes for the QA team.
+They are a description of an expected result upon calling `cabal-install` with certain parameters.
+
+For instance:
 
 > ## QA Notes
 > Calling `cabal haddock-project` should produce documentation for the whole cabal project with the following defaults enabled:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ names. When running `cabal-install` test suites, one need only use `cabal test` 
 QA Notes
 --------
 
-Manual Quality Assurance (QA) is done manually to ensure that the changes impacting the command-line interface, wether it is adding or modifying a behaviour,
+Manual Quality Assurance (QA) is performed to ensure that the changes impacting the command-line interface, whether adding or modifying a behaviour,
 are tested before being released. This allows us to catch UX regressions and put a human perspective into testing.
 
 Contributions that touch `cabal-install` are expected to include notes for the QA team. They are a description of an expected result upon calling `cabal-install` with


### PR DESCRIPTION
This PR adds instructions for adding manual QA instructions to new PRs that relate to cabal-install when a behaviour is introduced or modified.

Relates to #8865