### PR TITLE
Replace cabal project parsing with Parsec

### DIFF
--- a/Cabal/src/Distribution/Simple/PackageDescription.hs
+++ b/Cabal/src/Distribution/Simple/PackageDescription.hs
@@ -16,6 +16,7 @@ module Distribution.Simple.PackageDescription (
 
     -- * Utility Parsing function
     parseString,
+    readAndParseFile
     ) where
 
 import Prelude ()

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -151,6 +151,7 @@ library
         Distribution.Client.ProjectBuilding.Types
         Distribution.Client.ProjectConfig
         Distribution.Client.ProjectConfig.Legacy
+        Distribution.Client.ProjectConfig.Parsec
         Distribution.Client.ProjectConfig.Types
         Distribution.Client.ProjectFlags
         Distribution.Client.ProjectOrchestration

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -374,6 +374,9 @@ test-suite integration-tests2
   hs-source-dirs: tests
   default-language: Haskell2010
 
+  other-modules:
+    IntegrationTests2.ProjectConfig.ParsecTests
+
   build-depends:
         bytestring,
         cabal-install,

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -150,6 +150,7 @@ library
         Distribution.Client.ProjectBuilding
         Distribution.Client.ProjectBuilding.Types
         Distribution.Client.ProjectConfig
+        Distribution.Client.ProjectConfig.FieldGrammar
         Distribution.Client.ProjectConfig.Legacy
         Distribution.Client.ProjectConfig.Parsec
         Distribution.Client.ProjectConfig.Types

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -152,6 +152,7 @@ library
         Distribution.Client.ProjectConfig
         Distribution.Client.ProjectConfig.FieldGrammar
         Distribution.Client.ProjectConfig.Legacy
+        Distribution.Client.ProjectConfig.Lens
         Distribution.Client.ProjectConfig.Parsec
         Distribution.Client.ProjectConfig.Types
         Distribution.Client.ProjectFlags

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -10,6 +10,9 @@
 --
 module Distribution.Client.ProjectConfig (
 
+    readProjectFileSkeleton,
+    readProjectFileSkeletonLegacy,
+
     -- * Types for project config
     ProjectConfig(..),
     ProjectConfigBuildOnly(..),
@@ -590,6 +593,27 @@ readProjectFileSkeleton verbosity httpTransport DistDirLayout{distProjectFile, d
     extensionFile = distProjectFile extensionName
     readExtensionFile' = readAndParseFile Parsec.parseProjectSkeleton
     -- TODO #6101 only keep this for documentation purposes for now
+    readExtensionFile =
+          reportParseResult verbosity extensionDescription extensionFile
+      =<< parseProjectSkeleton distDownloadSrcDirectory httpTransport verbosity [] extensionFile
+      =<< BS.readFile extensionFile
+
+-- | Reads a named extended (with imports and conditionals) config file in the given project root dir, or returns empty.
+--
+readProjectFileSkeletonLegacy :: Verbosity -> HttpTransport -> DistDirLayout -> String -> String -> Rebuild ProjectConfigSkeleton
+readProjectFileSkeletonLegacy verbosity httpTransport DistDirLayout{distProjectFile, distDownloadSrcDirectory}
+                         extensionName extensionDescription = do
+    exists <- liftIO $ doesFileExist extensionFile
+    if exists
+      then do monitorFiles [monitorFileHashed extensionFile]
+              pcs <- liftIO readExtensionFile
+              monitorFiles $ map monitorFileHashed (projectSkeletonImports pcs)
+              pure pcs
+      else do monitorFiles [monitorNonExistentFile extensionFile]
+              return mempty
+  where
+    extensionFile = distProjectFile extensionName
+
     readExtensionFile =
           reportParseResult verbosity extensionDescription extensionFile
       =<< parseProjectSkeleton distDownloadSrcDirectory httpTransport verbosity [] extensionFile

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -584,19 +584,14 @@ readProjectFileSkeleton verbosity httpTransport DistDirLayout{distProjectFile, d
     exists <- liftIO $ doesFileExist extensionFile
     if exists
       then do monitorFiles [monitorFileHashed extensionFile]
-              pcs <- liftIO $ readExtensionFile' verbosity extensionFile
+              pcs <- liftIO $ readExtensionFile verbosity extensionFile
               monitorFiles $ map monitorFileHashed (projectSkeletonImports pcs)
               pure pcs
       else do monitorFiles [monitorNonExistentFile extensionFile]
               return mempty
   where
     extensionFile = distProjectFile extensionName
-    readExtensionFile' = readAndParseFile Parsec.parseProjectSkeleton
-    -- TODO #6101 only keep this for documentation purposes for now
-    readExtensionFile =
-          reportParseResult verbosity extensionDescription extensionFile
-      =<< parseProjectSkeleton distDownloadSrcDirectory httpTransport verbosity [] extensionFile
-      =<< BS.readFile extensionFile
+    readExtensionFile = readAndParseFile Parsec.parseProjectSkeleton
 
 -- | Reads a named extended (with imports and conditionals) config file in the given project root dir, or returns empty.
 --

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -1,11 +1,11 @@
 -- | 'ProjectConfig' Field descriptions
-module Distribution.Client.ProjectConfig.FieldGrammar (projectConfigSkeletonFieldGrammar) where
+module Distribution.Client.ProjectConfig.FieldGrammar (
+  projectConfigFieldGrammar
+  ) where
 
 import Distribution.Client.ProjectConfig.Legacy (ProjectConfigSkeleton)
+import Distribution.Client.ProjectConfig.Types (ProjectConfig)
 import Distribution.FieldGrammar
 
-projectConfigSkeletonFieldGrammar
-    :: ( FieldGrammar c g, Applicative (g ProjectConfigSkeleton)
-       )
-    => g ProjectConfigSkeleton ProjectConfigSkeleton
-projectConfigSkeletonFieldGrammar = undefined
+projectConfigFieldGrammar :: ParsecFieldGrammar' ProjectConfig
+projectConfigFieldGrammar = undefined

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -1,0 +1,11 @@
+-- | 'ProjectConfig' Field descriptions
+module Distribution.Client.ProjectConfig.FieldGrammar (projectConfigSkeletonFieldGrammar) where
+
+import Distribution.Client.ProjectConfig.Legacy (ProjectConfigSkeleton)
+import Distribution.FieldGrammar
+
+projectConfigSkeletonFieldGrammar
+    :: ( FieldGrammar c g, Applicative (g ProjectConfigSkeleton)
+       )
+    => g ProjectConfigSkeleton ProjectConfigSkeleton
+projectConfigSkeletonFieldGrammar = undefined

--- a/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/FieldGrammar.hs
@@ -1,11 +1,24 @@
+{-# LANGUAGE OverloadedStrings     #-}
 -- | 'ProjectConfig' Field descriptions
 module Distribution.Client.ProjectConfig.FieldGrammar (
   projectConfigFieldGrammar
   ) where
 
 import Distribution.Client.ProjectConfig.Legacy (ProjectConfigSkeleton)
-import Distribution.Client.ProjectConfig.Types (ProjectConfig)
+import qualified Distribution.Client.ProjectConfig.Lens as L
+import Distribution.Client.ProjectConfig.Types (ProjectConfig (..))
 import Distribution.FieldGrammar
+import Distribution.Parsec
 
 projectConfigFieldGrammar :: ParsecFieldGrammar' ProjectConfig
-projectConfigFieldGrammar = undefined
+projectConfigFieldGrammar = ProjectConfig
+  <$> monoidalFieldAla    "packages"   (alaList' FSep Token')      L.projectPackages
+  <*> undefined
+  <*> undefined
+  <*> undefined
+  <*> undefined
+  <*> undefined
+  <*> undefined
+  <*> undefined
+  <*> undefined
+  <*> undefined

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Lens.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Lens.hs
@@ -1,0 +1,9 @@
+module Distribution.Client.ProjectConfig.Lens where
+
+import Distribution.Client.ProjectConfig.Types (ProjectConfig (..))
+import Distribution.Compat.Lens
+import qualified Distribution.Client.ProjectConfig.Types as T
+
+projectPackages :: Lens' ProjectConfig [String]
+projectPackages f s = fmap (\x -> s { T.projectPackages = x }) (f (T.projectPackages s))
+{-# INLINE projectPackages #-}

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
@@ -1,0 +1,19 @@
+-- | Parsing project configuration.
+
+module Distribution.Client.ProjectConfig.Parsec (
+  -- * Package configuration
+  parseProjectSkeleton,
+
+  -- ** Parsing
+  ParseResult,
+  runParseResult
+  ) where
+
+-- TODO #6101 .Legacy -> ProjectConfigSkeleton should probably be moved here
+import Distribution.Client.ProjectConfig.Legacy (ProjectConfigSkeleton)
+import Distribution.Fields.ParseResult
+
+import qualified Data.ByteString                                   as BS
+
+parseProjectSkeleton :: BS.ByteString -> ParseResult ProjectConfigSkeleton
+parseProjectSkeleton = undefined

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Parsec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings   #-}
+
 -- | Parsing project configuration.
 
 module Distribution.Client.ProjectConfig.Parsec (
@@ -9,11 +11,126 @@ module Distribution.Client.ProjectConfig.Parsec (
   runParseResult
   ) where
 
+import Distribution.CabalSpecVersion
+import Distribution.Compat.Prelude
+import Distribution.FieldGrammar
 -- TODO #6101 .Legacy -> ProjectConfigSkeleton should probably be moved here
-import Distribution.Client.ProjectConfig.Legacy (ProjectConfigSkeleton)
+import Distribution.Client.ProjectConfig.FieldGrammar (projectConfigFieldGrammar)
+import Distribution.Client.ProjectConfig.Legacy (ProjectConfigSkeleton, ProjectConfigImport)
+import Distribution.Client.ProjectConfig.Types (ProjectConfig)
+import Distribution.Fields.ConfVar                   (parseConditionConfVar)
 import Distribution.Fields.ParseResult
+-- AST type
+import Distribution.Fields (Field, readFields', Name (..))
+import Distribution.Fields.LexerMonad                (LexWarning, toPWarnings)
+import Distribution.PackageDescription.Quirks        (patchQuirks)
+import Distribution.Parsec                           (parsec, simpleParsecBS)
+import Distribution.Parsec.Position                  (Position (..), zeroPos)
+import Distribution.Parsec.Warning                   (PWarnType (..))
+import Distribution.Types.CondTree                   (CondTree (..), CondBranch (..))
+import Distribution.Types.ConfVar                    (ConfVar (..))
+import Distribution.Utils.Generic                    (breakMaybe, fromUTF8BS, toUTF8BS, unfoldrM, validateUTF8)
 
 import qualified Data.ByteString                                   as BS
+import qualified Text.Parsec                                       as P
 
+-- TODO 6101 the following is copied from Distribution.PackageDescription.Parsec.parseGenericPackageDescription
+-- - do we need to use patchQuirks also for cabal.project files? if we do, we can extract a
+-- common preprocessing function (patchQuirks, valid UTF8, ) to avoid code duplication
+-- | Preprocess file and start parsing
 parseProjectSkeleton :: BS.ByteString -> ParseResult ProjectConfigSkeleton
-parseProjectSkeleton = undefined
+parseProjectSkeleton bs = do
+    case readFields' bs'' of
+        Right (fs, lexWarnings) -> do
+            when patched $
+                parseWarning zeroPos PWTQuirkyCabalFile "Legacy cabal file"
+            parseProjectSkeleton' lexWarnings invalidUtf8 fs
+        Left perr -> parseFatalFailure pos (show perr) where
+            ppos = P.errorPos perr
+            pos  = Position (P.sourceLine ppos) (P.sourceColumn ppos)
+  where
+    (patched, bs') = patchQuirks bs
+    invalidUtf8 = validateUTF8 bs'
+    bs'' = case invalidUtf8 of
+        Nothing -> bs'
+        Just _  -> toUTF8BS (fromUTF8BS bs')
+
+parseProjectSkeleton'
+    :: [LexWarning]
+    -> Maybe Int
+    -> [Field Position]
+    -> ParseResult ProjectConfigSkeleton
+parseProjectSkeleton' lexWarnings utf8WarnPos fs = do
+    parseWarnings (toPWarnings lexWarnings)
+    for_ utf8WarnPos $ \pos ->
+        parseWarning zeroPos PWTUTF $ "UTF8 encoding problem at byte offset " ++ show pos
+
+    -- TODO I am not sure whether we need sectionizeFields for cabal.project parsing
+    -- it is declared in Distribution.PackageDescription.Parsec.sectionizeFields
+    -- and used to convert old-style Cabal files, does this also apply to cabal.project files?
+    -- let (syntax, fs') = sectionizeFields fs
+    -- maybe we can also just use partitionFields
+
+    -- let (fields, sectionFields) = takeFields fs
+    parseCondTree specVer hasElif projectConfigFieldGrammar fs
+    where
+      -- TODO where do we get specVer?
+      specVer :: CabalSpecVersion
+      specVer = CabalSpecV3_8
+      hasElif = specHasElif specVer
+
+-- migrated from Distribution.PackageDescription.Parsec
+parseCondTree
+    :: CabalSpecVersion
+    -> HasElif                                    -- ^ accept @elif@
+    -> ParsecFieldGrammar' ProjectConfig          -- ^ grammar
+    -> [Field Position]
+    -> ParseResult ProjectConfigSkeleton
+parseCondTree v hasElif grammar = go
+  where
+    go fields0 = do
+        let (fs, ss) = partitionFields fields0
+        imports <- parseImports fs
+        x <- parseFieldGrammar v fs grammar
+        branches <- concat <$> traverse parseIfs ss
+        return $ CondNode x imports branches
+
+    parseIfs :: [Section Position] -> ParseResult [CondBranch ConfVar [ProjectConfigImport] ProjectConfig]
+    parseIfs [] = return []
+    parseIfs (MkSection (Name _ name) test fields : sections) | name == "if" = do
+        test' <- parseConditionConfVar test
+        fields' <- go fields
+        (elseFields, sections') <- parseElseIfs sections
+        return (CondBranch test' fields' elseFields : sections')
+    parseIfs (MkSection (Name pos name) _ _ : sections) = do
+        parseWarning pos PWTInvalidSubsection $ "invalid subsection " ++ show name
+        parseIfs sections
+
+    parseElseIfs
+        :: [Section Position]
+        -> ParseResult (Maybe (CondTree ConfVar [ProjectConfigImport] ProjectConfig), [CondBranch ConfVar [ProjectConfigImport] ProjectConfig])
+    parseElseIfs [] = return (Nothing, [])
+    parseElseIfs (MkSection (Name pos name) args fields : sections) | name == "else" = do
+        unless (null args) $
+            parseFailure pos $ "`else` section has section arguments " ++ show args
+        elseFields <- go fields
+        sections' <- parseIfs sections
+        return (Just elseFields, sections')
+
+    parseElseIfs (MkSection (Name _ name) test fields : sections) | hasElif == HasElif, name == "elif" = do
+        test' <- parseConditionConfVar test
+        fields' <- go fields
+        (elseFields, sections') <- parseElseIfs sections
+        -- we parse an empty 'Fields', to get empty value for a node
+        a <- parseFieldGrammar v mempty grammar
+        return (Just $ CondNode a mempty [CondBranch test' fields' elseFields], sections')
+
+    parseElseIfs (MkSection (Name pos name) _ _ : sections) | name == "elif" = do
+        parseWarning pos PWTInvalidSubsection $ "invalid subsection \"elif\". You should set cabal-version: 2.2 or larger to use elif-conditionals."
+        (,) Nothing <$> parseIfs sections
+
+    parseElseIfs sections = (,) Nothing <$> parseIfs sections
+
+-- TODO implement, caution: check for cyclical imports
+parseImports :: Fields Position -> ParseResult [ProjectConfigImport]
+parseImports fs = return mempty

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -79,6 +79,8 @@ import Distribution.Client.GlobalFlags (GlobalFlags, globalNix)
 import Distribution.Simple.Flag (Flag (Flag, NoFlag))
 import Data.Maybe (fromJust)
 
+import IntegrationTests2.ProjectConfig.ParsecTests
+
 #if !MIN_VERSION_directory(1,2,7)
 removePathForcibly :: FilePath -> IO ()
 removePathForcibly = removeDirectoryRecursive
@@ -89,9 +91,11 @@ main =
   defaultMainWithIngredients
     (defaultIngredients ++ [includingOptions projectConfigOptionDescriptions])
     (withProjectConfig $ \config ->
-      testGroup "Integration tests (internal)"
-                (tests config))
-
+      testGroup "Integration tests"
+        [
+         testGroup "ProjectConfig Parsec Tests" parserTests
+         , testGroup "Integration tests (internal)" (tests config)
+        ])
 
 tests :: ProjectConfig -> [TestTree]
 tests config =

--- a/cabal-install/tests/IntegrationTests2/ProjectConfig/ParsecTests.hs
+++ b/cabal-install/tests/IntegrationTests2/ProjectConfig/ParsecTests.hs
@@ -1,0 +1,58 @@
+-- | Integration Tests related to parsing of ProjectConfigs
+
+module IntegrationTests2.ProjectConfig.ParsecTests (parserTests) where
+
+import qualified Data.ByteString       as BS
+import System.Directory
+import System.FilePath
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.Options
+
+import Distribution.Client.HttpUtils
+import Distribution.Client.DistDirLayout
+import Distribution.Client.ProjectConfig
+import Distribution.Client.RebuildMonad (runRebuild)
+import Distribution.Verbosity
+
+-- TODO create tests:
+-- - parser tests to read and compare to expected values
+-- - golden tests for warnings and errors
+parserTests :: [TestTree]
+parserTests = [
+  testCase "read with legacy parser" testLegacyRead
+  ]
+
+-- Currently I compare the results of legacy parser with the new parser
+-- When the parser is implemented I will migrate it to compare to actual values
+testLegacyRead :: Assertion
+testLegacyRead = do
+  httpTransport <- configureTransport verbosity [] Nothing
+  let testdir = "ProjectConfig/files/"
+  projectRootDir <- canonicalizePath (basedir </> testdir)
+
+  -- let projectRoot = ProjectRootImplicit projectRootDir
+  let projectFileName = "cabal-minimal.project"
+      projectRoot = ProjectRootExplicit projectRootDir projectFileName
+      extensionName = ""
+      distDirLayout = defaultDistDirLayout projectRoot Nothing
+      extensionDescription = "description"
+      distProjectConfigFp = distProjectFile distDirLayout extensionName
+  print distProjectConfigFp
+  exists <- doesFileExist distProjectConfigFp
+  print $ exists
+  projectConfigSkeletonLegacy <- runRebuild projectRootDir $
+    readProjectFileSkeletonLegacy verbosity httpTransport distDirLayout extensionName extensionDescription
+  projectConfigSkeleton <- runRebuild projectRootDir $
+    readProjectFileSkeleton verbosity httpTransport distDirLayout extensionName extensionDescription
+  projectConfigSkeleton @?= projectConfigSkeletonLegacy
+
+-- | Test Utilities
+emptyProjectConfig :: ProjectConfig
+emptyProjectConfig = mempty
+
+verbosity :: Verbosity
+verbosity = minBound --normal --verbose --maxBound --minBound
+
+basedir :: FilePath
+basedir = "tests" </> "IntegrationTests2"

--- a/cabal-install/tests/IntegrationTests2/ProjectConfig/files/cabal-minimal.project
+++ b/cabal-install/tests/IntegrationTests2/ProjectConfig/files/cabal-minimal.project
@@ -1,0 +1,1 @@
+packages: .


### PR DESCRIPTION
Implements #6101 

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!

This is a really early version to gather some feedback and to check whether I am on the right track.
I created the rough module structure and a draft of the parser with still lots of holes. 
My next steps will be the definition of the FieldGrammar and Lens for ProjectConfigs, afterwards I want to add lots of tests for it.
There are some open questions in the source code that I am really unsure of, I will create some comments after I have created the PR.

