### PR TITLE
Make `check` comply with Hackage requirements

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -28,6 +28,7 @@ module Distribution.PackageDescription.Check (
         checkConfiguredPackage,
         wrapParseWarning,
         ppPackageCheck,
+        isHackageDistError,
 
         -- ** Checking package contents
         checkPackageFiles,
@@ -845,6 +846,12 @@ data PackageCheck =
        -- problems.
      | PackageDistInexcusable { explanation :: CheckExplanation }
   deriving (Eq, Ord)
+
+-- | Would Hackage refuse a package because of this error?
+isHackageDistError :: PackageCheck -> Bool
+isHackageDistError (PackageDistSuspicious {}) = False
+isHackageDistError (PackageDistSuspiciousWarn {}) = False
+isHackageDistError _ = True
 
 -- | Pretty printing 'PackageCheck'.
 --

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -849,9 +849,11 @@ data PackageCheck =
 
 -- | Would Hackage refuse a package because of this error?
 isHackageDistError :: PackageCheck -> Bool
+isHackageDistError (PackageBuildImpossible {}) = True
+isHackageDistError (PackageBuildWarning {}) = True
+isHackageDistError (PackageDistInexcusable {}) = True
 isHackageDistError (PackageDistSuspicious {}) = False
 isHackageDistError (PackageDistSuspiciousWarn {}) = False
-isHackageDistError _ = True
 
 -- | Pretty printing 'PackageCheck'.
 --

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Distribution.PackageDescription.Check
@@ -849,11 +851,12 @@ data PackageCheck =
 
 -- | Would Hackage refuse a package because of this error?
 isHackageDistError :: PackageCheck -> Bool
-isHackageDistError (PackageBuildImpossible {}) = True
-isHackageDistError (PackageBuildWarning {}) = True
-isHackageDistError (PackageDistInexcusable {}) = True
-isHackageDistError (PackageDistSuspicious {}) = False
-isHackageDistError (PackageDistSuspiciousWarn {}) = False
+isHackageDistError = \case
+    (PackageBuildImpossible {}) -> True
+    (PackageBuildWarning {}) -> True
+    (PackageDistInexcusable {}) -> True
+    (PackageDistSuspicious {}) -> False
+    (PackageDistSuspiciousWarn {}) -> False
 
 -- | Pretty printing 'PackageCheck'.
 --

--- a/Cabal/src/Distribution/Simple/SrcDist.hs
+++ b/Cabal/src/Distribution/Simple/SrcDist.hs
@@ -501,10 +501,7 @@ printPackageProblems :: Verbosity -> PackageDescription -> IO ()
 printPackageProblems verbosity pkg_descr = do
   ioChecks      <- checkPackageFiles verbosity pkg_descr "."
   let pureChecks = checkConfiguredPackage pkg_descr
-      isDistError (PackageDistSuspicious     _) = False
-      isDistError (PackageDistSuspiciousWarn _) = False
-      isDistError _                             = True
-      (errors, warnings) = partition isDistError (pureChecks ++ ioChecks)
+      (errors, warnings) = partition isHackageDistError (pureChecks ++ ioChecks)
   unless (null errors) $
       notice verbosity $ "Distribution quality errors:\n"
                       ++ unlines (map ppPackageCheck errors)

--- a/cabal-install/src/Distribution/Client/Check.hs
+++ b/cabal-install/src/Distribution/Client/Check.hs
@@ -48,7 +48,9 @@ readGenericPackageDescriptionCheck verbosity fpath = do
             die' verbosity "parse error"
         Right x  -> return (warnings, x)
 
--- | Note: must be called with the CWD set to the directory containing
+-- | Checks a packge for common errors. Returns @True@ if the package
+-- is fit to upload to Hackage, @False@ otherwise.
+-- Note: must be called with the CWD set to the directory containing
 -- the '.cabal' file.
 check :: Verbosity -> IO Bool
 check verbosity = do
@@ -94,9 +96,7 @@ check verbosity = do
         warn verbosity "The following errors will cause portability problems on other environments:"
         printCheckMessages distInexusable
 
-    let isCheckError (PackageDistSuspiciousWarn {}) = False
-        isCheckError _                              = True
-        errors = filter isHackageDistError packageChecks
+    let errors = filter isHackageDistError packageChecks
 
     unless (null errors) $
         warn verbosity "Hackage would reject this package."
@@ -104,7 +104,7 @@ check verbosity = do
     when (null packageChecks) $
         notice verbosity "No errors or warnings could be found in the package."
 
-    return (not . any isCheckError $ packageChecks)
+    return (null errors)
 
   where
     printCheckMessages :: [PackageCheck] -> IO ()

--- a/cabal-install/src/Distribution/Client/Check.hs
+++ b/cabal-install/src/Distribution/Client/Check.hs
@@ -94,12 +94,9 @@ check verbosity = do
         warn verbosity "The following errors will cause portability problems on other environments:"
         printCheckMessages distInexusable
 
-    let isDistError (PackageDistSuspicious     {}) = False
-        isDistError (PackageDistSuspiciousWarn {}) = False
-        isDistError _                              = True
-        isCheckError (PackageDistSuspiciousWarn {}) = False
+    let isCheckError (PackageDistSuspiciousWarn {}) = False
         isCheckError _                              = True
-        errors = filter isDistError packageChecks
+        errors = filter isHackageDistError packageChecks
 
     unless (null errors) $
         warn verbosity "Hackage would reject this package."

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -1202,7 +1202,8 @@ checkCommand = CommandUI {
       ++ "\n"
       ++ "The checks correspond to the requirements to packages on Hackage. "
       ++ "If no errors and warnings are reported, Hackage should accept the "
-      ++ "package. If 1 is returned, Hackage will refuse it.\n",
+      ++ "package. If errors are present, `check` exits with 1 and Hackage "
+      ++ "will refuse the package.\n",
     commandNotes        = Nothing,
     commandUsage        = usageFlags "check",
     commandDefaultFlags = toFlag normal,

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -1201,8 +1201,8 @@ checkCommand = CommandUI {
          "Expects a .cabal package file in the current directory.\n"
       ++ "\n"
       ++ "The checks correspond to the requirements to packages on Hackage. "
-      ++ "If no errors and warnings are reported, Hackage will accept this "
-      ++ "package.\n",
+      ++ "If no errors and warnings are reported, Hackage should accept the "
+      ++ "package. If 1 is returned, Hackage will refuse it.\n",
     commandNotes        = Nothing,
     commandUsage        = usageFlags "check",
     commandDefaultFlags = toFlag normal,

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/COptions/CxxOs/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/COptions/CxxOs/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- `cxx-options`, do not use `-O1`.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/DefaultExtension/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/DefaultExtension/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- `default-extensions` need ≥1.10.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/DefaultLanguage/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/DefaultLanguage/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- `default-language` need ≥1.10.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/ExtraDynamicLibraryFlavour/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/ExtraDynamicLibraryFlavour/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- `extra-dynamic-library-flavour` need ≥3.0.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/Mixins/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/Mixins/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- `mixins` need ≥2.0.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/Sources/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/Sources/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- `cmm-sources` and friends need ≥3.0.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/VirtualModules/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/VirtualModules/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- `virtual-modules` need ≥2.2.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/DeprecatedExtension/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/DeprecatedExtension/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- Deprecated extension.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/NoCategory/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/NoCategory/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- No category.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/NoDescription/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/NoDescription/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- No description.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/NoMaintainer/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/NoMaintainer/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- No maintainer.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/NoSynopsis/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/NoSynopsis/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- No synopsis.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/ShortDescription/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/ShortDescription/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- Description should be longer than synopsis.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/GHCOptions/GHCSharedOptions/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/GHCOptions/GHCSharedOptions/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- Tricky option in `ghc-shared-options`.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/License/NoFileSpecified/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/License/NoFileSpecified/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- `licence-file` missing.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/License/SuspiciousLicense/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/License/SuspiciousLicense/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- Suspicious license BSD4.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/License/SuspiciousVersion/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/License/SuspiciousVersion/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- Suspicious license version.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/License/WarnAllRightsReserved/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/License/WarnAllRightsReserved/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- Dubious AllRightsReserved.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Sanity/VersionSignatures/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Sanity/VersionSignatures/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- `signatures` field used with cabal-version < 2.0
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/NonConfCheck/DevOnlyFlags/Profiling/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/NonConfCheck/DevOnlyFlags/Profiling/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- Profiling flags unsuited for distribution.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/NonConfCheck/UnusedFlags/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/NonConfCheck/UnusedFlags/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- Unused flag.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/PackageFiles/VCSInfo/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/PackageFiles/VCSInfo/cabal.test.hs
@@ -2,4 +2,4 @@ import Test.Cabal.Prelude
 
 -- Missing VCS info.
 main = cabalTest $
-  fails $ cabal "check" []
+  cabal "check" []

--- a/changelog.d/pr-8897
+++ b/changelog.d/pr-8897
@@ -1,0 +1,14 @@
+synopsis: Make check comply with Hackage requirements
+packages: Cabal cabal-install
+prs: #8897
+
+description: {
+
+- `cabal check` will only return exitcode 1 when the package is not fit
+  for Hackage. E.g. it will not error anymore when your `synopsis:` is
+  larger than `description:`, just emit a warning.
+- Cabal: Distribution.Client.Check now exports `isHackageDistError`, for
+  third-party tools to know if a specific error will preclude a package
+  from being uploaded to Hacakge.
+
+}

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -978,7 +978,7 @@ Run ``cabal check`` in the folder where your ``.cabal`` package file is.
 
 ``cabal check`` mimics Hackage's requirements: if no error or warning
 is reported, Hackage should accept your package. If errors are present
-``cabal check`` exits with ``1`` and Hackage will will refuse the package.
+``cabal check`` exits with ``1`` and Hackage will refuse the package.
 
 cabal sdist
 ^^^^^^^^^^^

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -977,7 +977,8 @@ Run ``cabal check`` in the folder where your ``.cabal`` package file is.
     Set verbosity level (0–3, default is 1).
 
 ``cabal check`` mimics Hackage's requirements: if no error or warning
-is reported, Hackage should accept your package.
+is reported, Hackage should accept your package. If ``cabal check`` exits
+with ``1``, Hackage will refuse it.
 
 cabal sdist
 ^^^^^^^^^^^

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -977,8 +977,8 @@ Run ``cabal check`` in the folder where your ``.cabal`` package file is.
     Set verbosity level (0–3, default is 1).
 
 ``cabal check`` mimics Hackage's requirements: if no error or warning
-is reported, Hackage should accept your package. If ``cabal check`` exits
-with ``1``, Hackage will refuse it.
+is reported, Hackage should accept your package. If errors are present
+``cabal check`` exits with ``1`` and Hackage will will refuse the package.
 
 cabal sdist
 ^^^^^^^^^^^


### PR DESCRIPTION
tl;dr: `cabal check` will exit with `1` if and only if `Hackage would reject the package`.

As today, `cabal check` handles reports a “failure” in two distinct ways:
- first one: with an informative `Hackage would reject this package.` string
- second one: with exitcode `1`. This one is *not* the same as `Hackage would reject this package.` It is a bit more strict: you could end up with `exitcode 1` but no `Hackage would reject this package.` string.

What this patch does: make the two “failures” bijective. You will get `exitcode 1` iif `Hackage would reject this package.`

Examples of checks which will *not* exit with `1` anymore:
- `description` longer than `synopsis`;
- `-O1` usage;
- missing `maintainer`.

Check last commit for all of them. If someone has a good reason for them to return `1`, let me know (would CI get more annoying to set up? Third-party tools? Maybe it is better to return multiple failure exitcodes?).  

Towards: #8880
Reviewers: review by commit to skip testsuite changes. 
Related from an UX point of view: #8587  

---

QA notes:
- run `cabal check` in any project of yours
- take note if you see `Hackage would reject this package` in the output.
- take note of the exit code (`printf '%d\n' $?`).
- exit code should be `1` if and only if you see the message `Hackage would reject this package.`

(a quick way to get `Hackage would refuse this package` string is to remove `default-language:   Haskell2010` from your `.cabal`)

Specific to this patch:
- modify your package `synopsis` to be longer than your `description`
- exit code should be `0` and you should not see any `Hackage would reject this package.` message
 
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.

Tests: I have adjusted the testsuite appropriately.