### PR TITLE
Fix `prefer-oldest` documentation

### DIFF
--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -1769,7 +1769,7 @@ Most users generally won't need these.
                --prefer-oldest
                --no-prefer-oldest
     :synopsis: Prefer the oldest versions of packages available.
-    :since:    3.8
+    :since:    3.10
 
     :default:  False
 


### PR DESCRIPTION
Available since 3.10, not 3.8.
Closes #8656

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] (not relevant) Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] (not relevant) Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!
