### PR TITLE
CI: add automated GitHub prereleases

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -136,8 +136,9 @@ jobs:
              # see https://github.com/actions/virtual-environments/issues/2619#issuecomment-788397841
              sudo /usr/sbin/purge
           fi
-          tar -cvf cabal-head.tar -C $(dirname "$CABAL_EXEC") $(basename "$CABAL_EXEC")
-          echo "CABAL_EXEC_TAR=cabal-head.tar" >> $GITHUB_ENV
+          export CABAL_EXEC_TAR="cabal-head-${{ runner.os }}-x86_64.tar"
+          tar -cvf $CABAL_EXEC_TAR -C $(dirname "$CABAL_EXEC") $(basename "$CABAL_EXEC")
+          echo "CABAL_EXEC_TAR=$CABAL_EXEC_TAR" >> $GITHUB_ENV
 
       # We upload the cabal executable built with the ghc used in the release for:
       # - Reuse it in the dogfooding job (although we could use the cached build dir)
@@ -146,7 +147,7 @@ jobs:
         if: matrix.ghc == env.GHC_FOR_RELEASE
         uses: actions/upload-artifact@v3
         with:
-          name: cabal-${{ runner.os }}-${{ matrix.ghc }}
+          name: cabal-${{ runner.os }}-x86_64
           path: ${{ env.CABAL_EXEC_TAR }}
 
       - name: Validate lib-tests
@@ -271,11 +272,11 @@ jobs:
       - name: Download cabal executable from workflow artifacts
         uses: actions/download-artifact@v3
         with:
-          name: cabal-${{ runner.os }}-${{ matrix.ghc }}
+          name: cabal-${{ runner.os }}-x86_64
           path: cabal-head
 
       - name: Untar the cabal executable
-        run: tar -xf ./cabal-head/cabal-head.tar -C ./cabal-head
+        run: tar -xf ./cabal-head/cabal-head-${{ runner.os }}-x86_64.tar -C cabal-head
 
       - name: print-config using cabal HEAD
         run: sh validate.sh ${{ env.COMMON_FLAGS }} --with-cabal ./cabal-head/cabal -s print-config
@@ -284,6 +285,39 @@ jobs:
       # This way we check cabal can build all its dependencies
       - name: Build using cabal HEAD
         run: sh validate.sh ${{ env.COMMON_FLAGS }} --with-cabal ./cabal-head/cabal -s build
+
+  prerelease-head:
+    name: Create a GitHub prerelease with the binary artifacts
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+
+    # IMPORTANT! Any job added to the workflow should be added here too
+    needs: [validate, validate-old-ghcs, dogfooding]
+
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: cabal-Windows-x86_64
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: cabal-Linux-x86_64
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: cabal-macOS-x86_64
+
+    - name: Create GitHub prerelease
+      uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "cabal-head"
+        prerelease: true
+        title: "cabal-head"
+        files: |
+          cabal-head-Windows-x86_64.tar
+          cabal-head-Linux-x86_64.tar
+          cabal-head-macOS-x86_64.tar
 
   # We use this job as a summary of the workflow
   # It will fail if any of the previous jobs does it

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -136,8 +136,8 @@ jobs:
              # see https://github.com/actions/virtual-environments/issues/2619#issuecomment-788397841
              sudo /usr/sbin/purge
           fi
-          export CABAL_EXEC_TAR="cabal-head-${{ runner.os }}-x86_64.tar"
-          tar -cvf $CABAL_EXEC_TAR -C $(dirname "$CABAL_EXEC") $(basename "$CABAL_EXEC")
+          export CABAL_EXEC_TAR="cabal-head-${{ runner.os }}-x86_64.tar.gz"
+          tar -czvf $CABAL_EXEC_TAR -C $(dirname "$CABAL_EXEC") $(basename "$CABAL_EXEC")
           echo "CABAL_EXEC_TAR=$CABAL_EXEC_TAR" >> $GITHUB_ENV
 
       # We upload the cabal executable built with the ghc used in the release for:
@@ -276,7 +276,7 @@ jobs:
           path: cabal-head
 
       - name: Untar the cabal executable
-        run: tar -xf ./cabal-head/cabal-head-${{ runner.os }}-x86_64.tar -C cabal-head
+        run: tar -xzf ./cabal-head/cabal-head-${{ runner.os }}-x86_64.tar.gz -C cabal-head
 
       - name: print-config using cabal HEAD
         run: sh validate.sh ${{ env.COMMON_FLAGS }} --with-cabal ./cabal-head/cabal -s print-config
@@ -315,9 +315,9 @@ jobs:
         prerelease: true
         title: "cabal-head"
         files: |
-          cabal-head-Windows-x86_64.tar
-          cabal-head-Linux-x86_64.tar
-          cabal-head-macOS-x86_64.tar
+          cabal-head-Windows-x86_64.tar.gz
+          cabal-head-Linux-x86_64.tar.gz
+          cabal-head-macOS-x86_64.tar.gz
 
   # We use this job as a summary of the workflow
   # It will fail if any of the previous jobs does it

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Ways to get the `cabal-install` binary
 2. _[Download from official website](https://www.haskell.org/cabal/download.html)_:
     the `cabal-install` binary download for your platform should contain the `cabal` executable.
 
+_Getting unreleased versions of `cabal-install`_: gives you a chance to try out yet-unreleased features.
+Currently, we only provide binaries for `x86_64` platforms.
+
+1. _[GitHub preview release built from the tip of the `master branch](https://github.com/haskell/cabal/releases/tag/cabal-head)_:
+
+2. Even more cutting-edge binaries built from pull requests are always available
+   from the `Validate` worklow page on GitHub at the very bottom of the page.
+
 Ways to build `cabal-install` for everyday use
 --------------------------------------------
 


### PR DESCRIPTION
As announced on the meeting, this PR adds an automated GitHub prerelease holding the `cabal-install` binaries in this repository.  If you wanna taste what it looks like, you can head out to my fork: the [Releases](https://github.com/ulysses4ever/cabal/releases) tab has the [`cabal-head`](https://github.com/ulysses4ever/cabal/releases/tag/cabal-head) prerelease with three binaries for the three main OSes in the `Assets` section -- that's what you get with this PR.

I add a note about it in the README but perhaps some more advertisement could be done (not sure how). Prereleases appear only on the Releases tab in GitHub UI, while proper releases are also featured on the index page of the repo. So, it's not very visible...

I'm not sure if `ghcup` can be used to easily get these. Suggestions are welcome. I don't think `ghcup` can add much on top of a `wget` for the direct link (e.g. `wget https://github.com/ulysses4ever/cabal/releases/download/cabal-head/cabal-head-Linux-x86_64.tar`; well, you need to untar and put it in the right spot, I guess...). Again, if someone is willing to explore it, I can add instructions to the README.

The artifacts that I put in the prerelease are built in the CI as usual, so they're debug builds with assertions enabled. It'd be more work to have actual release-mode binaries, and I didn't feel like it's worth it. Hopefully, after #8821, it's not as hard to use debug binaries. But if we get too much complains about failing assertions, we can consider going the full-blown release mode instead of debug mode.

Should close #8541, I think.

---

Please include the following checklist in your PR:

* [x] N/A ~~Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).~~
* [x] N/A ~~Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).~~
* [x] The documentation has been updated, if necessary.
* [x] N/A ~~Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.~~
