### PR TITLE
Avoid using to-be-deprecated Data.List.NonEmpty.unzip

### DIFF
--- a/Cabal/src/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/src/Distribution/Simple/BuildTarget.hs
@@ -57,6 +57,7 @@ import Distribution.Utils.Path
 
 import qualified Distribution.Compat.CharParsing as P
 
+import Control.Arrow ( (&&&) )
 import Control.Monad ( msum )
 import Data.List ( stripPrefix, groupBy )
 import qualified Data.List.NonEmpty as NE
@@ -320,7 +321,8 @@ resolveBuildTarget pkg userTarget fexists =
   where
     classifyMatchErrors errs
       | Just expected' <- NE.nonEmpty expected
-                            = let (things, got:|_) = NE.unzip expected' in
+                            = let unzip' = fmap fst &&& fmap snd
+                                  (things, got:|_) = unzip' expected' in
                               BuildTargetExpected userTarget (NE.toList things) got
       | not (null nosuch)   = BuildTargetNoSuch   userTarget nosuch
       | otherwise = error $ "resolveBuildTarget: internal error in matching"


### PR DESCRIPTION
For CLC ticket [\#86](https://github.com/haskell/core-libraries-committee/issues/86)

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
[N/A] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
[N/A] The documentation has been updated, if necessary.
[N/A] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!
