### PR TITLE
Reject index-states after last known index-state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ bench.html
 
 # Emacs
 .projectile
+
+# I'm unsure how to ignore these generated golden files
+cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.out

--- a/cabal-install/src/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/src/Distribution/Client/CmdUpdate.hs
@@ -258,7 +258,7 @@ updateRepo verbosity _updateFlags repoCtxt (repo, indexState) = do
     RepoSecure{} -> repoContextWithSecureRepo repoCtxt repo $ \repoSecure -> do
       let index = RepoIndex repoCtxt repo
       -- NB: This may be a NoTimestamp if we've never updated before
-      current_ts <- currentIndexTimestamp (lessVerbose verbosity) repoCtxt repo
+      current_ts <- currentIndexTimestamp (lessVerbose verbosity) index
       -- NB: always update the timestamp, even if we didn't actually
       -- download anything
       writeIndexTimestamp index indexState

--- a/cabal-install/src/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/src/Distribution/Client/CmdUpdate.hs
@@ -98,7 +98,7 @@ import Distribution.Simple.Command
 import System.FilePath (dropExtension, (<.>))
 
 import Distribution.Client.Errors
-import Distribution.Client.IndexUtils.Timestamp (nullTimestamp)
+import Distribution.Client.IndexUtils.Timestamp (Timestamp (NoTimestamp))
 import qualified Hackage.Security.Client as Sec
 
 updateCommand :: CommandUI (NixStyleFlags ())
@@ -257,7 +257,7 @@ updateRepo verbosity _updateFlags repoCtxt (repo, indexState) = do
           updateRepoIndexCache verbosity (RepoIndex repoCtxt repo)
     RepoSecure{} -> repoContextWithSecureRepo repoCtxt repo $ \repoSecure -> do
       let index = RepoIndex repoCtxt repo
-      -- NB: This may be a nullTimestamp if we've never updated before
+      -- NB: This may be a NoTimestamp if we've never updated before
       current_ts <- currentIndexTimestamp (lessVerbose verbosity) repoCtxt repo
       -- NB: always update the timestamp, even if we didn't actually
       -- download anything
@@ -294,7 +294,7 @@ updateRepo verbosity _updateFlags repoCtxt (repo, indexState) = do
 
       -- In case current_ts is a valid timestamp different from new_ts, let
       -- the user know how to go back to current_ts
-      when (current_ts /= nullTimestamp && new_ts /= current_ts) $
+      when (current_ts /= NoTimestamp && new_ts /= current_ts) $
         noticeNoWrap verbosity $
           "To revert to previous state run:\n"
             ++ "    cabal v2-update '"

--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -450,8 +450,8 @@ readRepoIndex verbosity repoCtxt repo idxState =
       if isDoesNotExistError e
         then do
           case repo of
-            RepoRemote{..} -> warn verbosity $ errMissingPackageList repoRemote
-            RepoSecure{..} -> warn verbosity $ errMissingPackageList repoRemote
+            RepoRemote{..} -> die' verbosity $ errMissingPackageList repoRemote
+            RepoSecure{..} -> die' verbosity $ errMissingPackageList repoRemote
             RepoLocalNoIndex local _ ->
               warn verbosity $
                 "Error during construction of local+noindex "

--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -951,7 +951,7 @@ withIndexEntries verbosity index callback _ = do
 -- | Read package data from a repository.
 -- Throws IOException if any arise while accessing the index
 -- (unless the repo is local+no-index) and dies if the cache
--- is corrupted and cannot be regereated correctly.
+-- is corrupted and cannot be regenerated correctly.
 readPackageIndexCacheFile
   :: Package pkg
   => Verbosity
@@ -1125,7 +1125,7 @@ readIndexCache verbosity index = do
 -- | Read a no-index repository cache from the filesystem
 --
 -- If a corrupted index cache is detected this function regenerates
--- the index cache and then reattempt to read the index once (and
+-- the index cache and then reattempts to read the index once (and
 -- 'die's if it fails again). Throws IOException if any arise.
 readNoIndexCache :: Verbosity -> Index -> IO NoIndexCache
 readNoIndexCache verbosity index = do
@@ -1180,7 +1180,7 @@ writeIndexTimestamp index st =
 -- timestamp you would use to revert to this version.
 --
 -- Note: this is not the same as 'readIndexTimestamp'!
--- This resolves HEAD to the the index isiHeadTime, i.e.
+-- This resolves HEAD to the index's 'isiHeadTime', i.e.
 -- the index latest known timestamp.
 --
 -- Return NoTimestamp if the index has never been updated.

--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -420,9 +420,6 @@ readRepoIndex
   -> IO (PackageIndex UnresolvedSourcePackage, [Dependency], IndexStateInfo)
 readRepoIndex verbosity repoCtxt repo idxState =
   handleNotFound $ do
-    -- note that if this step fails due to a bad repo cache, the the procedure can still succeed by reading from the existing cache, which is updated regardless.
-    updateRepoIndexCache verbosity (RepoIndex repoCtxt repo)
-      `catchIO` (\e -> warn verbosity $ "unable to update the repo index cache -- " ++ displayException e)
     ret@(_, _, isi) <-
       readPackageIndexCacheFile
         verbosity
@@ -430,8 +427,8 @@ readRepoIndex verbosity repoCtxt repo idxState =
         (RepoIndex repoCtxt repo)
         idxState
     when (isRepoRemote repo) $ do
-      dieIfRequestedIdxIsNewer isi
       warnIfIndexIsOld =<< getIndexFileAge repo
+      dieIfRequestedIdxIsNewer isi
     pure ret
   where
     mkAvailablePackage pkgEntry =

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -184,7 +184,7 @@ instance Arbitrary Timestamp where
   -- >>> utcTimeToPOSIXSeconds $ UTCTime (fromGregorian 100000 01 01) 0
   -- >>> 3093527980800s
   --
-  arbitrary = maybe (toEnum 0) id . epochTimeToTimestamp . (`mod` 3093527980800) . abs <$> arbitrary
+  arbitrary = epochTimeToTimestamp . (`mod` 3093527980800) . abs <$> arbitrary
 
 instance Arbitrary RepoIndexState where
   arbitrary =

--- a/cabal-install/tests/UnitTests/Distribution/Client/IndexUtils/Timestamp.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/IndexUtils/Timestamp.hs
@@ -23,23 +23,19 @@ tests =
 prop_timestamp1 :: NonNegative Int -> Bool
 prop_timestamp1 (NonNegative t0) = Just t == simpleParsec ('@' : show t0)
   where
-    t = toEnum t0 :: Timestamp
+    t = epochTimeToTimestamp $ toEnum t0 :: Timestamp
 
 -- test prettyShow/simpleParse roundtrip
 prop_timestamp2 :: Int -> Bool
-prop_timestamp2 t0
-  | t /= nullTimestamp = simpleParsec (prettyShow t) == Just t
-  | otherwise = prettyShow t == ""
+prop_timestamp2 t0 = simpleParsec (prettyShow t) == Just t
   where
-    t = toEnum t0 :: Timestamp
+    t = epochTimeToTimestamp $ toEnum t0 :: Timestamp
 
 -- test prettyShow against reference impl
 prop_timestamp3 :: Int -> Bool
-prop_timestamp3 t0
-  | t /= nullTimestamp = refDisp t == prettyShow t
-  | otherwise = prettyShow t == ""
+prop_timestamp3 t0 = refDisp t == prettyShow t
   where
-    t = toEnum t0 :: Timestamp
+    t = epochTimeToTimestamp $ toEnum t0 :: Timestamp
 
     refDisp =
       maybe undefined (formatTime undefined "%FT%TZ")
@@ -47,16 +43,13 @@ prop_timestamp3 t0
 
 -- test utcTimeToTimestamp/timestampToUTCTime roundtrip
 prop_timestamp4 :: Int -> Bool
-prop_timestamp4 t0
-  | t /= nullTimestamp = (utcTimeToTimestamp =<< timestampToUTCTime t) == Just t
-  | otherwise = timestampToUTCTime t == Nothing
+prop_timestamp4 t0 =
+  (utcTimeToTimestamp <$> timestampToUTCTime t) == Just t
   where
-    t = toEnum t0 :: Timestamp
+    t = epochTimeToTimestamp $ toEnum t0 :: Timestamp
 
 prop_timestamp5 :: Int -> Bool
-prop_timestamp5 t0
-  | t /= nullTimestamp = timestampToUTCTime t == Just ut
-  | otherwise = timestampToUTCTime t == Nothing
+prop_timestamp5 t0 = timestampToUTCTime t == Just ut
   where
-    t = toEnum t0 :: Timestamp
+    t = epochTimeToTimestamp $ toEnum t0 :: Timestamp
     ut = posixSecondsToUTCTime (fromIntegral t0)

--- a/cabal-testsuite/PackageTests/Get/OnlyDescription/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Get/OnlyDescription/cabal.test.hs
@@ -9,3 +9,4 @@ main = cabalTest $ withRepo "repo" $ do
   cabal
     "get"
     [ "criterion", "--only-package-description" ]
+  void (shell "rm" ["criterion-1.1.4.0.cabal"])

--- a/cabal-testsuite/PackageTests/Get/T7248/cabal.out
+++ b/cabal-testsuite/PackageTests/Get/T7248/cabal.out
@@ -1,6 +1,4 @@
 # cabal get
 Warning: <ROOT>/cabal.config: Unrecognized stanza on line 3
-Warning: The package list for 'repo.invalid' does not exist. Run 'cabal update' to download it.
-Error: [Cabal-7100]
-There is no package named 'a-b-s-e-n-t'. 
-You may need to run 'cabal update' to get the latest list of available packages.
+Error: [Cabal-7160]
+The package list for 'repo.invalid' does not exist. Run 'cabal update' to download it.

--- a/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.out.in
+++ b/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.out.in
@@ -1,0 +1,13 @@
+# cabal build
+Error: [Cabal-7159]
+Latest known index-state for 'repository.localhost' (REPLACEME) is older than the requested index-state (4000-01-01T00:00:00Z).
+Run 'cabal update' or set the index-state to a value at or before REPLACEME.
+# cabal build
+Warning: There is no index-state for 'repository.localhost' exactly at the requested timestamp (2023-01-01T00:00:00Z). Also, there are no index-states before the one requested, so the repository 'repository.localhost' will be empty.
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: fake-pkg-1.0 (user goal)
+[__1] unknown package: pkg (dependency of fake-pkg)
+[__1] fail (backjumping, conflict set: fake-pkg, pkg)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: fake-pkg (2), pkg (1)

--- a/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.project
+++ b/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.project
@@ -1,0 +1,1 @@
+packages: fake-pkg

--- a/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.test.hs
@@ -1,0 +1,19 @@
+import Test.Cabal.Prelude
+import Data.List (isPrefixOf)
+
+main = cabalTest $ withProjectFile "cabal.project" $ withRemoteRepo "repo" $ do
+  output <- last
+          . words
+          . head
+          . filter ("Index cache updated to index-state " `isPrefixOf`)
+          . lines
+          . resultOutput
+        <$> recordMode DoNotRecord (cabal' "update" [])
+  -- update golden output with actual timestamp
+  shell "cp" ["cabal.out.in", "cabal.out"]
+  shell "sed" ["-i''", "-e", "s/REPLACEME/" <> output <> "/g", "cabal.out"]
+  -- This shall fail with an error message as specified in `cabal.out`
+  fails $ cabal "build" ["--index-state=4000-01-01T00:00:00Z", "fake-pkg"]
+  -- This shall fail by not finding the package, what indicates that it
+  -- accepted an older index-state.
+  fails $ cabal "build" ["--index-state=2023-01-01T00:00:00Z", "fake-pkg"]

--- a/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/fake-pkg/Main.hs
+++ b/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/fake-pkg/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = print "hello"

--- a/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/fake-pkg/fake-pkg.cabal
+++ b/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/fake-pkg/fake-pkg.cabal
@@ -1,0 +1,8 @@
+version: 1.0
+name: fake-pkg
+build-type: Simple
+cabal-version: >= 1.2
+
+executable my-exe
+  main-is: Main.hs
+  build-depends: base, pkg

--- a/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/repo/pkg-1.0/Foo.hs
+++ b/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/repo/pkg-1.0/Foo.hs
@@ -1,0 +1,3 @@
+module Foo (someFunc) where
+
+someFunc = "hello"

--- a/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/repo/pkg-1.0/pkg.cabal
+++ b/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/repo/pkg-1.0/pkg.cabal
@@ -1,0 +1,8 @@
+name: pkg
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.2
+
+library
+  exposed-modules: Foo
+  build-depends: base

--- a/changelog.d/die-on-missing-pkg-list
+++ b/changelog.d/die-on-missing-pkg-list
@@ -1,0 +1,11 @@
+synopsis: Die if package list is missing
+packages: cabal-install
+prs: #8944
+
+description: {
+
+If a package list is missing, `cabal` will now die and suggest the user to run
+`cabal update` instead of continuing into not being able to find packages coming
+from the remote package server.
+
+}

--- a/changelog.d/index-state-cabal-update
+++ b/changelog.d/index-state-cabal-update
@@ -1,0 +1,14 @@
+synopsis: Reject index-state younger than cached index file
+packages: cabal-install
+prs: #8944
+
+description: {
+
+Requesting to use an index-state younger than the cached version will now fail,
+telling the user to use an index-state older or equal to the cached file, or to
+run `cabal update`.
+
+The warning for a non-existing index-state has been also demoted to appear only
+on verbose logging.
+
+}


### PR DESCRIPTION
The `index-state` warning expresses an internal mismatch in the existing index-states and the requested one, but this does not need an action from the user. On the other hand, requesting an index-state after the last known index means that the user should perform `cabal update`. This PR demotes the first one to verbose mode only and throws an error on the second one.

# QA notes

When building a project with a timestamp for which no index-state exists, cabal now warns the user and picks the previous index-state.

The index-state warning that said:

```
Warning: Requested index-state 2023-04-24T00:00:09Z is newer than
'hackage.haskell.org'! Falling back to older state (2023-04-23T19:32:13Z).
```

1. Setting the index-state in-between two existing index-states warns in verbose mode

```
❯ cabal build all -v
...
Reading available packages of hackage.haskell.org...
Using historical state as of 2023-05-09T13:27:17Z as explicitly requested (via
command line / project configuration)
There is no index-state for 'hackage.haskell.org' exactly at the requested
timestamp (2023-05-09T13:27:17Z). Falling back to the previous index-state
that exists: 2023-05-09T12:58:00Z
index-state(hackage.haskell.org) = 2023-05-09T12:58:00Z (HEAD =
2023-05-09T12:58:00Z)
```

2. Setting the index-state after the most-recent known index-state errors

```
❯ cabal build all
Error: cabal: Latest known index-state for 'hackage.haskell.org'
(2023-05-09T13:27:18Z) is older than the requested index-state
(2024-04-24T00:00:00Z). 
Run 'cabal update' or set the index-state to a value at or before
2023-05-09T13:27:18Z.
```

3. Setting the index-state before the oldest known index-state warns with normal verbosity

```
Warning: There is no index-state for 'hackage.haskell.org' exactly 
at the requested timestamp (1900-01-01T00:00:00Z). Also, there are 
no index-states before the one requested, so the repository 
'hackage.haskell.org' will be empty.
```

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!
