### PR TITLE
Show full config file contents when option test fails

### DIFF
--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -2173,7 +2173,7 @@ testConfigOptionComments = do
     findLineWith :: Bool -> String -> String -> String
     findLineWith isComment target text
       | not . null $ findLinesWith isComment target text = removeCommentValue . L.head $ findLinesWith isComment target text
-      | otherwise  = ""
+      | otherwise  = text
     findLinesWith :: Bool -> String -> String -> [String]
     findLinesWith isComment target
       | isComment = filter (isInfixOf (" " ++ target ++ ":")) . lines


### PR DESCRIPTION
---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!

To fix a problem with [this pr](https://github.com/haskell/cabal/pull/8955) I sent the whole file contents of the default config (whatever that is based on the current build) to the error output so that I could see what needed to be fixed. This will probably be useful whenever the test breaks again, so I'm making a PR for it from @Mikolaj 's comment.
