### PR TITLE
Clarify `check` documentation

### DIFF
--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -1200,8 +1200,8 @@ checkCommand = CommandUI {
     commandDescription  = Just $ \_ -> wrapText $
          "Expects a .cabal package file in the current directory.\n"
       ++ "\n"
-      ++ "The checks correspond to the requirements to packages on Hackage. "
-      ++ "If no errors and warnings are reported, Hackage should accept the "
+      ++ "Some checks correspond to the requirements to packages on Hackage. "
+      ++ "If no `Error` is reported, Hackage should accept the "
       ++ "package. If errors are present, `check` exits with 1 and Hackage "
       ++ "will refuse the package.\n",
     commandNotes        = Nothing,

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -1009,9 +1009,10 @@ Run ``cabal check`` in the folder where your ``.cabal`` package file is.
 
     Set verbosity level (0–3, default is 1).
 
-``cabal check`` mimics Hackage's requirements: if no error or warning
-is reported, Hackage should accept your package. If errors are present
-``cabal check`` exits with ``1`` and Hackage will refuse the package.
+Issues are classified as ``Warning``\s and ``Error``\s. The latter correspond
+to Hackage requirements for uploaded packages: if no error is reported,
+Hackage should accept your package. If errors are present ``cabal check``
+exits with ``1`` and Hackage will refuse the package.
 
 cabal sdist
 ^^^^^^^^^^^


### PR DESCRIPTION
Highlight which issues are critical for uploading to Hackage and which are not, as suggested on `#cabal`. Rendered:

![check](https://github.com/haskell/cabal/assets/87714215/35c5083f-5145-4007-8914-e3731f6c2fd4)

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#conventions).
* [x]  ~~Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).~~ no need
* [x] ~~The documentation has been updated, if necessary.~~
* [x] ~~Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.~~ no need

~~Bonus points for added automated tests!~~ no need
