### PR TITLE
Future-proof against potential Prelude.foldl'

### DIFF
--- a/Cabal-syntax/src/Distribution/Compat/Prelude.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Prelude.hs
@@ -130,10 +130,9 @@ module Distribution.Compat.Prelude (
 
 -- We also could hide few partial function
 import Prelude                       as BasePrelude hiding
-    ( mapM, mapM_, sequence, null, length, foldr, any, all, head, tail, last, init
+    ( mapM, mapM_, sequence, any, all, head, tail, last, init
     -- partial functions
     , read
-    , foldr1, foldl1
 #if MINVER_base_411
     -- As of base 4.11.0.0 Prelude exports part of Semigroup(..).
     -- Hide this so we instead rely on Distribution.Compat.Semigroup.
@@ -142,8 +141,9 @@ import Prelude                       as BasePrelude hiding
     , Word
     -- We hide them, as we import only some members
     , Traversable, traverse, sequenceA
-    , Foldable, foldMap
+    , Foldable(..)
     )
+import Data.Foldable as BasePrelude (foldl, elem, sum, product, maximum, minimum)
 
 -- AMP
 import Data.Foldable

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/CharSet.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/CharSet.hs
@@ -5,8 +5,9 @@
 #endif
 module UnitTests.Distribution.Utils.CharSet where
 
+import Prelude hiding (Foldable(..))
 import Data.Char        (isAlpha, isAlphaNum)
-import Data.List        (foldl')
+import Data.Foldable    (foldl')
 import Test.Tasty       (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 


### PR DESCRIPTION
See https://github.com/haskell/core-libraries-committee/issues/167

This is, of course, a bit speculative at the moment, but given that the change does not involve CPP, it should not hurt to merge it early to simplify further impact assessment.