### PR TITLE
allow building cabal-install-3.10 with ghc-9.6

### DIFF
--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -95,7 +95,7 @@ test-suite parser-tests
     , tasty-golden      >=2.3.1.1 && <2.4
     , tasty-hunit
     , tasty-quickcheck
-    , tree-diff         >=0.1     && <0.3
+    , tree-diff         >=0.1     && <0.4
 
   ghc-options:      -Wall
   default-language: Haskell2010
@@ -161,7 +161,7 @@ test-suite hackage-tests
     , optparse-applicative  >=0.13.2.0 && <0.17
     , stm                   >=2.4.5.0  && <2.6
     , tar                   >=0.5.0.3  && <0.6
-    , tree-diff             >=0.1      && <0.3
+    , tree-diff             >=0.1      && <0.4
 
   ghc-options:        -Wall -rtsopts -threaded
   default-extensions: CPP

--- a/Cabal-tree-diff/Cabal-tree-diff.cabal
+++ b/Cabal-tree-diff/Cabal-tree-diff.cabal
@@ -13,7 +13,7 @@ library
     , base
     , Cabal-syntax  ^>=3.10.0.0
     , Cabal         ^>=3.10.0.0
-    , tree-diff     ^>=0.1 || ^>=0.2
+    , tree-diff     ^>=0.1 || ^>=0.2 || ^>=0.3
 
   exposed-modules:  Data.TreeDiff.Instances.Cabal
   other-modules:

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -105,7 +105,7 @@ library
 
   build-depends:
     , array         >=0.4      && <0.6
-    , base          >=4.10     && <4.18
+    , base          >=4.10     && <4.19
     , bytestring    >=0.10.6.0 && <0.12
     , Cabal         ^>=3.10
     , Cabal-syntax  ^>=3.10
@@ -138,7 +138,7 @@ Test-Suite unit-tests
      UnitTests.Distribution.Solver.Modular.MessageUtils
 
    build-depends:
-     , base        >= 4.10  && <4.18
+     , base        >= 4.10  && <4.19
      , Cabal
      , Cabal-syntax
      , cabal-install-solver

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -46,7 +46,7 @@ common warnings
       ghc-options: -Wunused-packages
 
 common base-dep
-    build-depends: base >=4.10 && <4.18
+    build-depends: base >=4.10 && <4.19
 
 common cabal-dep
     build-depends: Cabal ^>=3.10

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -26,7 +26,7 @@ common shared
   default-language: Haskell2010
 
   build-depends:
-    , base >= 4.9 && <4.18
+    , base >= 4.9 && <4.19
     -- this needs to match the in-tree lib:Cabal version
     , Cabal ^>= 3.10.0.0
     , Cabal-syntax ^>= 3.10.0.0
@@ -80,7 +80,7 @@ library
 
   if !os(windows)
     build-depends:
-      , unix                ^>= 2.6.0.0 || ^>= 2.7.0.0
+      , unix                ^>= 2.6.0.0 || ^>= 2.7.0.0 || ^>= 2.8.0.0
   else
     build-depends:
       , Win32


### PR DESCRIPTION
bump a few bounds to allow building with ghc-9.6

Yes cabal-install-3.10 ought to be buildable with 9.6...