### PR TITLE
Warn about inconsistent indentation

### DIFF
--- a/Cabal-syntax/src/Distribution/Parsec/Warning.hs
+++ b/Cabal-syntax/src/Distribution/Parsec/Warning.hs
@@ -57,6 +57,8 @@ data PWarnType
     PWTSpecVersion
   | -- | Empty filepath, i.e. literally ""
     PWTEmptyFilePath
+  | -- | sections contents (sections and fields) are indented inconsistently
+    PWTInconsistentIndentation
   | -- | Experimental feature
     PWTExperimental
   deriving (Eq, Ord, Show, Enum, Bounded, Generic)

--- a/Cabal-tests/tests/CheckTests.hs
+++ b/Cabal-tests/tests/CheckTests.hs
@@ -57,6 +57,7 @@ checkTests = testGroup "regressions"
     , checkTest "issue-7776-b.cabal"
     , checkTest "issue-7776-c.cabal"
     , checkTest "issue-8646.cabal"
+    , checkTest "decreasing-indentation.cabal"
     ]
 
 checkTest :: FilePath -> TestTree

--- a/Cabal-tests/tests/ParserTests/regressions/decreasing-indentation.cabal
+++ b/Cabal-tests/tests/ParserTests/regressions/decreasing-indentation.cabal
@@ -1,0 +1,72 @@
+name:       RSA
+category:   Cryptography, Codec
+version:    1.0.0
+license:    BSD3
+license-file: LICENSE
+author:     Adam Wick <awick@galois.com>
+maintainer: Adam Wick <awick@galois.com>
+stability:  stable
+build-type: Simple
+cabal-version: >= 1.2
+tested-with: GHC ==6.8.0
+synopsis: Implementation of RSA, using the padding schemes of PKCS#1 v2.1.
+description: This library implements the RSA encryption and signature
+             algorithms for arbitrarily-sized ByteStrings. While the
+             implementations work, they are not necessarily the fastest ones
+             on the planet. Particularly key generation. The algorithms
+             included are based of RFC 3447, or the Public-Key Cryptography
+             Standard for RSA, version 2.1 (a.k.a, PKCS#1 v2.1).
+
+Flag IncludeMD5
+  Description: Include support for using MD5 in the various crypto routines.
+
+Flag UseBinary
+  Description: Use the binary package for serializing keys.
+
+Library
+ build-depends: base >= 3
+ if flag(UseBinary)
+   build-depends: binary <10
+   CPP-Options: -DUSE_BINARY
+ if flag(IncludeMD5) && flag(UseBinary)
+   build-depends: pureMD5 <10
+   CPP-Options: -DINCLUDE_MD5
+ exposed-modules: Codec.Crypto.RSA
+
+Executable test_rsa
+    build-depends: base >= 3
+  CPP-Options: -DRSA_TEST
+  Main-Is: Test.hs
+  Other-Modules: Codec.Crypto.RSA
+
+-- The above is actual RSA-1.0.0 cabal file (slightly modified to produce less check warnings)
+
+-- The following sections is further inconsistent indentation examples.
+
+-- Note that here main-is is part of GHC-Options field. (and thus warned about as missing)
+Executable warnings
+    build-depends: base < 5
+  GHC-Options: -Wall
+    main-is: warnings.hs
+  Other-Modules: FooBar
+
+-- Increasing indentation is also possible if we use braces to delimit field contents.
+Executable warnings2
+  build-depends: { base <5 }
+    main-is: { warnings2.hs }
+      Other-Modules: FooBar
+
+-- another common mistake is something like below,
+-- where a sub-section is over-indented
+flag splitBase
+
+Executable warnings3
+    if flag(splitBase)
+        build-depends: base >= 3
+    else
+        build-depends: base <  3
+
+ Main-Is: warnings3.hs
+ Other-Modules:
+  Graphics.UI.WXCore
+  Graphics.UI.WXCore.Wx

--- a/Cabal-tests/tests/ParserTests/regressions/decreasing-indentation.check
+++ b/Cabal-tests/tests/ParserTests/regressions/decreasing-indentation.check
@@ -1,0 +1,2 @@
+decreasing-indentation.cabal:38:3: Inconsistent indentation. Indentation jumps at lines 38, 49, 56, 57, 69
+No 'main-is' field found for executable warnings

--- a/cabal-testsuite/PackageTests/Check/NonConfCheck/DuplicatedModules/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Check/NonConfCheck/DuplicatedModules/pkg.cabal
@@ -16,4 +16,4 @@ library
 --   if !os(linux)
 --     exposed-modules: Bar
 
-  default-language: Haskell2010
+    default-language: Haskell2010

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,6 @@
-packages: Cabal/ cabal-testsuite/ Cabal-syntax/
+packages: Cabal/
+packages: cabal-testsuite/
+packages: Cabal-syntax/
 packages: cabal-install/
 packages: cabal-install-solver/
 packages: solver-benchmarks/

--- a/changelog.d/inconsistent-indentation
+++ b/changelog.d/inconsistent-indentation
@@ -1,0 +1,23 @@
+synopsis: Warn about inconsistent indentation
+packages: Cabal-syntax
+prs: #8975
+
+description:
+    Make Cabal warn about inconsistent indentation in .cabal files.
+
+    For example warn about somewhat common decreasing indentation like in
+
+    ```cabal
+    library
+        default-language: Haskell2010
+      build-depends: base
+      ghc-options: -Wall
+    ```
+
+    The change is `readFields` function.
+
+    This is an effect of using `indentOfAtLeast` method/approach: any indentation greater than current offset is accepted.
+
+    That behavior is desirable to parsing multiline field contents, but it is a bit surprising for fields in sections, which we expect to be aligned.
+
+    Such insonsistency seems to be always a mistake, and it's easy to fix once a machine points it out.


### PR DESCRIPTION
This is an effect of using `indentOfAtLeast` method: any indentation greater than current offset is fine.

That behavior is desirable to parsing multiline field contents, but it is a bit surprising for fields in sections, which we expect to be aligned.

Such insonsistency seems to be always a mistake, and it's easy to fix once a machine points it out.