### PR TITLE
Document readFields

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,7 @@ Code Style
 
 We use automated formatting with Fourmolu to enforce a unified style across the code bases. It is checked in the CI process.
 You can automatically format the code bases with `make style` at the top level of the project.
+You can also use `make style-modified` to only format modified files.
 
 Other Conventions
 -----------------

--- a/Cabal-syntax/src/Distribution/Fields/Parser.hs
+++ b/Cabal-syntax/src/Distribution/Fields/Parser.hs
@@ -57,6 +57,10 @@ import qualified Data.Text.Encoding       as T
 import qualified Data.Text.Encoding.Error as T
 #endif
 
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import Data.Either (isLeft)
+
 -- | The 'LexState'' (with a prime) is an instance of parsec's 'Stream'
 -- wrapped around lexer's 'LexState' (without a prime)
 data LexState' = LexState' !LexState (LToken, LexState')
@@ -330,10 +334,35 @@ fieldInlineOrBraces name =
         )
 
 -- | Parse cabal style 'B8.ByteString' into list of 'Field's, i.e. the cabal AST.
+--
+-- 'readFields' assumes that input 'B8.ByteString' is valid UTF8, specifically it doesn't validate that file is valid UTF8.
+-- Therefore bytestrings inside returned 'Field' will be invalid as UTF8 if the input were.
+--
+-- >>> readFields "foo: \223"
+-- Right [Field (Name (Position 1 1) "foo") [FieldLine (Position 1 6) "\223"]]
+--
+-- 'readFields' won't (necessarily) fail on invalid UTF8 data, but the reported positions may be off.
+--
+-- __You may get weird errors on non-UTF8 input__, for example 'readFields' will fail on latin1 encoded non-breaking space:
+--
+-- >>> isLeft (readFields "\xa0 foo: bar")
+-- True
+--
+-- That is rejected because parser thinks @\\xa0@ is a section name,
+-- and section arguments may not contain colon.
+-- If there are just latin1 non-breaking spaces, they become part of the name:
+--
+-- >>> readFields "\xa0\&foo: bar"
+-- Right [Field (Name (Position 1 1) "\160foo") [FieldLine (Position 1 7) "bar"]]
+--
+-- The UTF8 non-breaking space is accepted as an indentation character (but warned about by 'readFields'').
+--
+-- >>> readFields' "\xc2\xa0 foo: bar"
+-- Right ([Field (Name (Position 1 3) "foo") [FieldLine (Position 1 8) "bar"]],[LexWarning LexWarningNBSP (Position 1 1)])
 readFields :: B8.ByteString -> Either ParseError [Field Position]
 readFields s = fmap fst (readFields' s)
 
--- | Like 'readFields' but also return lexer warnings
+-- | Like 'readFields' but also return lexer warnings.
 readFields' :: B8.ByteString -> Either ParseError ([Field Position], [LexWarning])
 readFields' s = do
   parse parser "the input" lexSt

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,15 @@ style: ## Run the code styler
 		! -path Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs \
 		| xargs -P $(PROCS) -I {} fourmolu -q -i {}
 
+style-modified: ## Run the code styler on modified files
+	@git ls-files --modified Cabal Cabal-syntax cabal-install \
+		-X Cabal-syntax/src/Distribution/Fields/Lexer.hs \
+		-X Cabal-syntax/src/Distribution/SPDX/LicenseExceptionId.hs \
+		-X Cabal-syntax/src/Distribution/SPDX/LicenseId.hs \
+		-X Cabal/src/Distribution/Simple/Build/Macros/Z.hs \
+		-X Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs \
+		| grep '.hs$$' | xargs -P $(PROCS) -I {} fourmolu -q -i {}
+
 # source generation: Lexer
 
 LEXER_HS:=Cabal-syntax/src/Distribution/Fields/Lexer.hs


### PR DESCRIPTION
This PR cherry-picks a lexer BOM/NBSP commit from #8975.

The last commit documents `readFields`:

Document that readFields expects input to be UTF8
    
For example `parseGenericPackageDescription` validates input it passes to `readFields'`.
    
That is desirable: we want try to parse non-UTF8 inputs, and report as a warning if they are not UTF8. (There are non-UTF8 .cabal files on Hackage, e.g. with German names).

In some other world lexer could repair invalid UTF8 on the fly, but OTOH it's quite simple to just do a prepass, as lexer makes (most of its) decisions on ASCII characters, and can treat text parts as opaque bytes.

*This last commit doesn't change anything, it simply documents the current state of the codebase*.