### PR TITLE
Fix QuickCheck instance of PackageName to not produce 'all' (fix #8986)

### DIFF
--- a/Cabal-QuickCheck/src/Test/QuickCheck/Instances/Cabal.hs
+++ b/Cabal-QuickCheck/src/Test/QuickCheck/Instances/Cabal.hs
@@ -74,7 +74,7 @@ instance Arbitrary PackageName where
     arbitrary = mkPackageName . intercalate "-" <$> shortListOf1 2 nameComponent
       where
         nameComponent = shortListOf1 5 (elements packageChars)
-                        `suchThat` (not . all isDigit)
+                        `suchThat` (liftA2 (&&) (not . all isDigit) (/= "all"))
         packageChars  = filter isAlphaNum ['\0'..'\127']
 
 instance Arbitrary PackageIdentifier where


### PR DESCRIPTION
## QA Notes

As described in #8986, you can run

```
❯ cabal run cabal-install:unit-tests -- -j1 -p '/individual parser tests/' --quickcheck-replay=122872
```

before and after this patch: you should see failure and no failure.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [N/A] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [N/A] The documentation has been updated, if necessary.
* [x] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.
