### PR TITLE
Use renderListPretty for list-bin problems

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdListBin.hs
+++ b/cabal-install/src/Distribution/Client/CmdListBin.hs
@@ -20,7 +20,7 @@ import Distribution.Client.Compat.Prelude
 import Prelude ()
 
 import Distribution.Client.CmdErrorMessages
-       (plural, renderListCommaAnd, renderTargetProblem, renderTargetProblemNoTargets,
+       (plural, renderListPretty, renderTargetProblem, renderTargetProblemNoTargets,
        renderTargetSelector, showTargetSelector, targetSelectorFilter, targetSelectorPluralPkgs)
 import Distribution.Client.DistDirLayout         (DistDirLayout (..))
 import Distribution.Client.NixStyleOptions
@@ -347,7 +347,7 @@ renderListBinProblem (TargetProblemMatchesMultiple targetSelector targets) =
     "The list-bin command is for finding a single binary at once. The target '"
  ++ showTargetSelector targetSelector ++ "' refers to "
  ++ renderTargetSelector targetSelector ++ " which includes "
- ++ renderListCommaAnd ( ("the "++) <$>
+ ++ renderListPretty ( ("the "++) <$>
                          showComponentName <$>
                          availableTargetComponentName <$>
                          foldMap
@@ -357,8 +357,8 @@ renderListBinProblem (TargetProblemMatchesMultiple targetSelector targets) =
 
 renderListBinProblem (TargetProblemMultipleTargets selectorMap) =
     "The list-bin command is for finding a single binary at once. The targets "
- ++ renderListCommaAnd [ "'" ++ showTargetSelector ts ++ "'"
-                       | ts <- uniqueTargetSelectors selectorMap ]
+ ++ renderListPretty [ "'" ++ showTargetSelector ts ++ "'"
+                     | ts <- uniqueTargetSelectors selectorMap ]
  ++ " refer to different executables."
 
 renderListBinProblem (TargetProblemComponentNotRightKind pkgid cname) =

--- a/cabal-install/src/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/src/Distribution/Client/CmdRepl.hs
@@ -31,7 +31,7 @@ import Distribution.Client.CmdErrorMessages
          ( renderTargetSelector, showTargetSelector,
            renderTargetProblem,
            targetSelectorRefersToPkgs,
-           renderComponentKind, renderListCommaAnd, renderListSemiAnd,
+           renderComponentKind, renderListPretty, renderListSemiAnd, 
            componentKind, sortGroupOn, Plural(..) )
 import Distribution.Client.TargetProblem
          ( TargetProblem(..) )
@@ -509,7 +509,7 @@ renderReplProblem (TargetProblemMatchesMultiple targetSelector targets) =
  ++ (if targetSelectorRefersToPkgs targetSelector then "includes " else "are ")
  ++ renderListSemiAnd
       [ "the " ++ renderComponentKind Plural ckind ++ " " ++
-        renderListCommaAnd
+        renderListPretty
           [ maybe (prettyShow pkgname) prettyShow (componentNameString cname)
           | t <- ts
           , let cname   = availableTargetComponentName t
@@ -524,7 +524,7 @@ renderReplProblem (TargetProblemMatchesMultiple targetSelector targets) =
 
 renderReplProblem (TargetProblemMultipleTargets selectorMap) =
     "Cannot open a repl for multiple components at once. The targets "
- ++ renderListCommaAnd
+ ++ renderListPretty
       [ "'" ++ showTargetSelector ts ++ "'"
       | ts <- uniqueTargetSelectors selectorMap ]
  ++ " refer to different components."

--- a/cabal-install/src/Distribution/Client/CmdRun.hs
+++ b/cabal-install/src/Distribution/Client/CmdRun.hs
@@ -446,8 +446,8 @@ renderRunProblem (TargetProblemMatchesMultiple targetSelector targets) =
 
 renderRunProblem (TargetProblemMultipleTargets selectorMap) =
     "The run command is for running a single executable at once. The targets "
- ++ renderListCommaAnd [ "'" ++ showTargetSelector ts ++ "'"
-                       | ts <- uniqueTargetSelectors selectorMap ]
+ ++ renderListPretty [ "'" ++ showTargetSelector ts ++ "'"
+                     | ts <- uniqueTargetSelectors selectorMap ]
  ++ " refer to different executables."
 
 renderRunProblem (TargetProblemComponentNotExe pkgid cname) =


### PR DESCRIPTION
Extends #8234 to fix #8189 for list-bin: see https://github.com/haskell/cabal/issues/8189#issuecomment-1550140401

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] ~~The documentation has been updated, if necessary.~~ (N/A)
* [x] ~~Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.~~ (N/A)
