### PR TITLE
Add the ExtendedLiterals extension

### DIFF
--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -93,7 +93,7 @@ classifyLanguage = \str -> case lookup str langTable of
 -- Note: if you add a new 'KnownExtension':
 --
 
--- * also add it to the Distribution.Simple.X.languageExtensions lists
+-- * also add it to the Distribution.Simple.X.compilerExtensions lists
 
 --   (where X is each compiler: GHC, UHC, HaskellSuite)
 --
@@ -532,6 +532,8 @@ data KnownExtension
     OverloadedRecordUpdate
   | -- | Enable data types for which an unlifted or levity-polymorphic result kind is inferred.
     UnliftedDatatypes
+  | -- | Enable syntax for primitive numeric literals, e.g. @3#Int8@
+    ExtendedLiterals
   | -- | Undocumented parsing-related extensions introduced in GHC 7.0.
     AlternativeLayoutRule
   | -- | Undocumented parsing-related extensions introduced in GHC 7.0.

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -27,9 +27,9 @@ tests = testGroup "Distribution.Utils.Structured"
     -- The difference is in encoding of newtypes
 #if MIN_VERSION_base(4,7,0)
     , testCase "GenericPackageDescription" $
-      md5Check (Proxy :: Proxy GenericPackageDescription) 0xa3e9433662ecf0c7a3c26f6d75a53ba1
+      md5Check (Proxy :: Proxy GenericPackageDescription) 0x8d8f340f10a58b8d8a87bf42213dac89
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0x30ebb8fffa1af2aefa9432ff4028eef8
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0xbb22c3258d3092f31e992bc093d09170
 #endif
     ]
 

--- a/changelog.d/pr-8992
+++ b/changelog.d/pr-8992
@@ -1,0 +1,10 @@
+synopsis: Add language extension ExtendedLiterals
+packages: Cabal-syntax
+prs: #8992
+significance: significant
+
+description: {
+
+- adds support for the ExtendedLiterals language extension (GHC proposal #451)
+
+}

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -181,6 +181,7 @@ syn keyword cabalExtension contained
   \ ExplicitForAll
   \ ExplicitNamespaces
   \ ExtendedDefaultRules
+  \ ExtendedLiterals
   \ ExtensibleRecords
   \ FieldSelectors
   \ FlexibleContexts
@@ -299,6 +300,7 @@ syn keyword cabalExtension contained
   \ NoDataKinds
   \ NoDatatypeContexts
   \ NoDefaultSignatures
+  \ NoDeepSubsumption
   \ NoDeriveAnyClass
   \ NoDeriveDataTypeable
   \ NoDeriveFoldable
@@ -319,6 +321,7 @@ syn keyword cabalExtension contained
   \ NoExplicitForAll
   \ NoExplicitNamespaces
   \ NoExtendedDefaultRules
+  \ NoExtendedLiterals
   \ NoExtensibleRecords
   \ NoFieldSelectors
   \ NoFlexibleContexts
@@ -406,6 +409,7 @@ syn keyword cabalExtension contained
   \ NoTransformListComp
   \ NoTupleSections
   \ NoTypeApplications
+  \ NoTypeData
   \ NoTypeFamilies
   \ NoTypeFamilyDependencies
   \ NoTypeInType


### PR DESCRIPTION
GHC 9.8 will feature a new extension, `ExtendedLiterals`: https://github.com/ghc/ghc/commit/931c8d82f28fb98a7e0ad0a837eff05c08021cbe.

I am adding it to Cabal following [Note [Adding a language extension]](https://github.com/ghc/ghc/blob/00a1e50b65354f65f508408d171ec1af4045dd95/compiler/GHC/Driver/Session.hs#L345) in GHC.

A comment says that I should update `languageExtensions` which I believe is now `compilerExtensions`. As far as I can tell there's nothing to change, since supported GHC flags are fetched rather than hardcoded.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!
