### PR TITLE
Do not check PVP on internal targets

### DIFF
--- a/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/cabal.out
@@ -1,0 +1,2 @@
+# cabal check
+No errors or warnings could be found in the package.

--- a/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+
+-- Internal targets (tests, benchmarks) should not be checked.
+main = cabalTest $
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/pkg.cabal
@@ -1,0 +1,21 @@
+cabal-version: 3.0
+name: pkg
+synopsis: synopsis
+description: description
+version: 0
+category: example
+maintainer: none@example.com
+license: GPL-3.0-or-later
+
+library
+  exposed-modules: Foo
+  default-language: Haskell2010
+  build-depends: base == 2.2.*
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: Test.hs
+  default-language: Haskell2010
+  build-depends: base == 2.2.*,
+                 criterion
+

--- a/changelog.d/pr-9004
+++ b/changelog.d/pr-9004
@@ -1,0 +1,11 @@
+synopsis: Do not check PVP on internal targets
+packages: cabal-install
+prs: #9004
+issues: #8361
+
+description: {
+
+- `cabal check` will not check for dependencies upper bounds in internal
+  targets (i.e. test-suites and benchmarks)
+
+}


### PR DESCRIPTION
Internal targets: test-suites or benchmarks.
See #8361 for rationale.

Note that this patch is quite ugly (duplicating allBuildInfo, using list comprehensions, etc.) but we don’t care as everything will be overwritten by a much more sensible reimplementation in #8427.


---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] ~The documentation has been updated, if necessary.~ N/A, since no warning-specific docs in master, but they have been updated in #8427.
* [x] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

---

## QA Notes

1. fetch any cabal package with a test-suite, say `cabal get lentil`
2. `cd` into it
3. in the `build-depends` section of the `test-suite` stanza, add an unbounded dependency
4. run `cabal check`, it should *not* complain about missing upper bounds