### PR TITLE
Generate cabal-testsuite modules at configure time

### DIFF
--- a/changelog.d/pr-9007
+++ b/changelog.d/pr-9007
@@ -1,0 +1,11 @@
+synopsis: Generate cabal-testsuite modules at configure time
+packages: cabal-testsuite
+prs: #9007
+
+description: {
+
+Generate modules required by cabal-testsuite at configure time rather than build time.
+This allows to run `cabal repl cabal-testsuite` out of the box.
+In addition, enables HLS support for `cabal-testsuite`.
+
+}


### PR DESCRIPTION
Allows to run `cabal repl cabal-testsuite` out of the box. Enables HLS support for `cabal-testsuite`.

Fixes https://github.com/haskell/hie-bios/issues/404

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!

