### PR TITLE
Do not check PVP on internal targets (backport of #9004 to 3.10)

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -70,7 +70,7 @@ import System.FilePath
 
 import qualified Data.ByteString.Lazy      as BS
 import qualified Data.Map                  as Map
-import qualified Control.Monad as CM
+import qualified Control.Monad             as CM
 import qualified Distribution.Compat.DList as DList
 import qualified Distribution.SPDX         as SPDX
 import qualified System.Directory          as System

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -70,6 +70,7 @@ import System.FilePath
 
 import qualified Data.ByteString.Lazy      as BS
 import qualified Data.Map                  as Map
+import qualified Control.Monad as CM
 import qualified Distribution.Compat.DList as DList
 import qualified Distribution.SPDX         as SPDX
 import qualified System.Directory          as System
@@ -1899,13 +1900,23 @@ checkPackageVersions pkg =
     baseErrors
   where
     baseErrors = PackageDistInexcusable BaseNoUpperBounds <$ bases
-    deps = toDependencyVersionsMap allBuildDepends pkg
+    deps = toDependencyVersionsMap allNonInternalBuildDepends pkg
     -- base gets special treatment (it's more critical)
     (bases, others) = partition (("base" ==) . unPackageName) $
       [ name
       | (name, vr) <- Map.toList deps
       , not (hasUpperBound vr)
       ]
+
+    -- Get the combined build-depends entries of all components.
+    allNonInternalBuildDepends :: PackageDescription -> [Dependency]
+    allNonInternalBuildDepends = targetBuildDepends CM.<=< allNonInternalBuildInfo
+
+    allNonInternalBuildInfo :: PackageDescription -> [BuildInfo]
+    allNonInternalBuildInfo pkg_descr =
+      [bi | lib <- allLibraries pkg_descr, let bi = libBuildInfo lib]
+        ++ [bi | flib <- foreignLibs pkg_descr, let bi = foreignLibBuildInfo flib]
+        ++ [bi | exe <- executables pkg_descr, let bi = buildInfo exe]
 
 checkConditionals :: GenericPackageDescription -> [PackageCheck]
 checkConditionals pkg =

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -336,7 +336,7 @@ test-suite unit-tests
           tasty-quickcheck,
           tasty-hunit >= 0.10,
           tree-diff,
-          QuickCheck >= 2.14 && <2.15
+          QuickCheck >= 2.14.3 && <2.15
 
 
 -- Tests to run with a limited stack and heap size

--- a/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ArbitraryInstances.hs
@@ -44,7 +44,7 @@ import Distribution.Solver.Types.PackageConstraint       (PackageProperty (..))
 import Data.Coerce                      (Coercible, coerce)
 import Network.URI                      (URI (..), URIAuth (..), isUnreserved)
 import Test.QuickCheck
-import Test.QuickCheck.GenericArbitrary
+import Test.QuickCheck.GenericArbitrary (genericArbitrary)
 import Test.QuickCheck.Instances.Cabal ()
 
 -- note: there are plenty of instances defined in ProjectConfig test file.
@@ -106,11 +106,6 @@ arbitraryURIPort =
 -------------------------------------------------------------------------------
 -- cabal-install (and Cabal) types
 -------------------------------------------------------------------------------
-
-shrinkBoundedEnum :: (Eq a, Enum a, Bounded a) => a -> [a]
-shrinkBoundedEnum x
-    | x == minBound = []
-    | otherwise     = [pred x]
 
 adjustSize :: (Int -> Int) -> Gen a -> Gen a
 adjustSize adjust gen = sized (\n -> resize (adjust n) gen)

--- a/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/cabal.out
@@ -1,0 +1,2 @@
+# cabal check
+No errors or warnings could be found in the package.

--- a/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+
+-- Internal targets (tests, benchmarks) should not be checked.
+main = cabalTest $
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Check/NonConfCheck/PackageVersionsNoCheck/pkg.cabal
@@ -1,0 +1,20 @@
+cabal-version: 3.0
+name: pkg
+synopsis: synopsis
+description: description
+version: 0
+category: example
+maintainer: none@example.com
+license: GPL-3.0-or-later
+
+library
+  exposed-modules: Foo
+  default-language: Haskell2010
+  build-depends: base == 2.2.*
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: Test.hs
+  default-language: Haskell2010
+  build-depends: base == 2.2.*,
+                 criterion

--- a/changelog.d/pr-9004
+++ b/changelog.d/pr-9004
@@ -1,0 +1,11 @@
+synopsis: Do not check PVP on internal targets
+packages: cabal-install
+prs: #9004
+issues: #8361
+
+description: {
+
+- `cabal check` will not check for dependencies upper bounds in internal
+  targets (i.e. test-suites and benchmarks)
+
+}


### PR DESCRIPTION
backport

Internal targets: test-suites or benchmarks.
See #8361 for rationale.

Note that this patch is quite ugly (duplicating allBuildInfo, using list comprehensions, etc.) but we don’t care as everything will be overwritten by a much more sensible reimplementation in #8427.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!
