### PR TITLE
Add 'mkVersionIntervals' for creating a VersionIntervals from a list

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/VersionInterval.hs
+++ b/Cabal-syntax/src/Distribution/Types/VersionInterval.hs
@@ -12,6 +12,7 @@ module Distribution.Types.VersionInterval
   ( -- * Version intervals
     VersionIntervals
   , unVersionIntervals
+  , mkVersionIntervals
 
     -- * Conversions
   , toVersionIntervals
@@ -69,6 +70,12 @@ newtype VersionIntervals = VersionIntervals [VersionInterval]
 -- | Inspect the list of version intervals.
 unVersionIntervals :: VersionIntervals -> [VersionInterval]
 unVersionIntervals (VersionIntervals is) = is
+
+-- | Directly construct a 'VersionIntervals' from a list of intervals.
+mkVersionIntervals :: [VersionInterval] -> Maybe VersionIntervals
+mkVersionIntervals intervals
+  | invariantVersionIntervals (VersionIntervals intervals) = Just . VersionIntervals $ intervals
+  | otherwise = Nothing
 
 data VersionInterval = VersionInterval !LowerBound !UpperBound deriving (Eq, Show)
 data LowerBound = LowerBound !Version !Bound deriving (Eq, Show)

--- a/changelog.d/pr-9034
+++ b/changelog.d/pr-9034
@@ -1,11 +1,11 @@
-synopsis: Add 'mkVersionIntervals' for creating a VersionIntervals from a list
-packages: Cabal
+synopsis: Add `mkVersionIntervals` for creating a `VersionIntervals` from a list
+packages: Cabal-syntax
 prs: #9034
 
 description: {
 
-If external tools want to change the version intervals of dependencies they
+If external tools want to change the version intervals of dependencies, they
 need to be able to create a `VersionRange` from a `[VersionInterval]` list. Adding
-the function 'mkVersionIntervals' makes this possible again.
+the function `mkVersionIntervals` makes this possible again.
 
 }

--- a/changelog.d/pr-9034
+++ b/changelog.d/pr-9034
@@ -5,7 +5,7 @@ prs: #9034
 description: {
 
 If external tools want to change the version intervals of dependencies they
-need to be able to create a VersionRange from a [VersionInterval] list. Adding
+need to be able to create a `VersionRange` from a `[VersionInterval]` list. Adding
 the function 'mkVersionIntervals' makes this possible again.
 
 }

--- a/changelog.d/pr-9034
+++ b/changelog.d/pr-9034
@@ -1,0 +1,11 @@
+synopsis: Add 'mkVersionIntervals' for creating a VersionIntervals from a list
+packages: Cabal
+prs: #9034
+
+description: {
+
+If external tools want to change the version intervals of dependencies they
+need to be able to create a VersionRange from a [VersionInterval] list. Adding
+the function 'mkVersionIntervals' makes this possible again.
+
+}


### PR DESCRIPTION
I tried updating my program cabal-bounds[1] to the newest cabal version, but wasn't able anymore to create a 'VersionIntervals' from a '[VersionInterval]'.

This patch adds back the 'mkVersionIntervals' function.

[1] https://github.com/dan-t/cabal-bounds

---
* [ X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
