### PR TITLE
Render short option with arg.

### DIFF
--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -132,8 +132,8 @@ zipDefault ad bd (a : as) (b : bs) = (a, b) : zipDefault ad bd as bs
 
 fmtShort :: ArgDescr a -> Char -> String
 fmtShort (NoArg _) so = "-" ++ [so]
-fmtShort (ReqArg _ _) so = "-" ++ [so]
-fmtShort (OptArg _ _) so = "-" ++ [so]
+fmtShort (ReqArg _ ad) so = "-" ++ [so] ++ take 1 ad
+fmtShort (OptArg _ ad) so = "-" ++ [so] ++ take 1 ad
 
 -- unlike upstream GetOpt we omit the arg name for short options
 

--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -131,20 +131,44 @@ zipDefault _ bd (a : as) [] = (a, bd) : map (,bd) as
 zipDefault ad _ [] (b : bs) = (ad, b) : map (ad,) bs
 zipDefault ad bd (a : as) (b : bs) = (a, b) : zipDefault ad bd as bs
 
+-- | Pretty printing of short options.
+-- * With required arguments can be given as:
+--    @-w PATH or -wPATH (but not -w=PATH)@
+--   This is dislayed as:
+--    @-w PATH or -wPATH@
+-- * With optional but default arguments can be given as:
+--    @-j or -jNUM (but not -j=NUM or -j NUM)@
+--   This is dislayed as:
+--    @-j[NUM]@
 fmtShort :: ArgDescr a -> Char -> String
 fmtShort (NoArg _) so = "-" ++ [so]
-fmtShort (ReqArg _ ad) so = let opt = "-" ++ [so] in
-  opt ++ " " ++ ad ++ " or " ++ opt ++ ad ++ " (but not " ++ opt ++ "=" ++ ad ++ ")"
-fmtShort (OptArg Nothing _ ad) so = "-" ++ [so] ++ " " ++ ad
-fmtShort (OptArg Just{} _ ad) so = let opt = "-" ++ [so] in
-  opt ++ ad ++ " (but not " ++ opt ++ "=" ++ ad ++ ")"
+fmtShort (ReqArg _ ad) so =
+  let opt = "-" ++ [so]
+   in opt ++ " " ++ ad ++ " or " ++ opt ++ ad
+fmtShort (OptArg Nothing _ ad) so =
+  let opt = "-" ++ [so]
+   in opt ++ " " ++ ad
+fmtShort (OptArg Just{} _ ad) so =
+  let opt = "-" ++ [so]
+   in opt ++ "[" ++ ad ++ "]"
 
--- unlike upstream GetOpt we omit the arg name for short options
-
+-- | Pretty printing of long options.
+-- * With required arguments can be given as:
+--    @--with-compiler=PATH (but not --with-compiler PATH)@
+--   This is dislayed as:
+--    @--with-compiler=PATH@
+-- * With optional but default arguments can be given as:
+--    @--jobs or --jobs=NUM (but not --jobs NUM)@
+--   This is dislayed as:
+--    @--jobs[=NUM]@
 fmtLong :: ArgDescr a -> String -> String
 fmtLong (NoArg _) lo = "--" ++ lo
-fmtLong (ReqArg _ ad) lo = "--" ++ lo ++ "=" ++ ad
-fmtLong (OptArg _ _ ad) lo = "--" ++ lo ++ "[=" ++ ad ++ "]"
+fmtLong (ReqArg _ ad) lo =
+  let opt = "--" ++ lo
+   in opt ++ "=" ++ ad
+fmtLong (OptArg _ _ ad) lo =
+  let opt = "--" ++ lo
+   in opt ++ "[=" ++ ad ++ "]"
 
 wrapText :: Int -> String -> [String]
 wrapText width = map unwords . wrap 0 [] . words

--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -132,9 +132,15 @@ zipDefault _ bd (a : as) [] = (a, bd) : map (,bd) as
 zipDefault ad _ [] (b : bs) = (ad, b) : map (ad,) bs
 zipDefault ad bd (a : as) (b : bs) = (a, b) : zipDefault ad bd as bs
 
+-- | Don't abbreviate for required arguments, as it's confusing with no
+-- separator.  Go with option b.
+-- a) -wP, --with-compiler=PATH
+-- b) -wPATH, --with-compiler=PATH
+-- Abbreviate optional arguments, as it's clear with separators.
+-- -j[N], --jobs[=NUM]
 fmtShort :: ArgDescr a -> Char -> String
 fmtShort (NoArg _) so = "-" ++ [so]
-fmtShort (ReqArg _ ad) so = "-" ++ [so] ++ take 1 ad
+fmtShort (ReqArg _ ad) so = "-" ++ [so] ++ ad
 fmtShort (OptArg _ ad) so = "-" ++ [so] ++ (take 1 ad & \case
   "" -> ""
   abbreviation -> "[" ++ abbreviation ++ "]")

--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TupleSections #-}
+
 -----------------------------------------------------------------------------
 
 -- |
@@ -38,9 +39,9 @@ module Distribution.GetOpt
     -- | See "System.Console.GetOpt" for examples
   ) where
 
+import Data.Function ((&))
 import Distribution.Compat.Prelude
 import Prelude ()
-import Data.Function ((&))
 
 -- | What to do with options following non-options
 data ArgOrder a
@@ -141,9 +142,13 @@ zipDefault ad bd (a : as) (b : bs) = (a, b) : zipDefault ad bd as bs
 fmtShort :: ArgDescr a -> Char -> String
 fmtShort (NoArg _) so = "-" ++ [so]
 fmtShort (ReqArg _ ad) so = "-" ++ [so] ++ ad
-fmtShort (OptArg _ ad) so = "-" ++ [so] ++ (take 1 ad & \case
-  "" -> ""
-  abbreviation -> "[" ++ abbreviation ++ "]")
+fmtShort (OptArg _ ad) so =
+  "-"
+    ++ [so]
+    ++ ( take 1 ad & \case
+          "" -> ""
+          abbreviation -> "[" ++ abbreviation ++ "]"
+       )
 
 -- unlike upstream GetOpt we omit the arg name for short options
 

--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -1,6 +1,7 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
------------------------------------------------------------------------------
 {-# LANGUAGE TupleSections #-}
+-----------------------------------------------------------------------------
 
 -- |
 -- Module      :  Distribution.GetOpt
@@ -39,6 +40,7 @@ module Distribution.GetOpt
 
 import Distribution.Compat.Prelude
 import Prelude ()
+import Data.Function ((&))
 
 -- | What to do with options following non-options
 data ArgOrder a
@@ -133,7 +135,9 @@ zipDefault ad bd (a : as) (b : bs) = (a, b) : zipDefault ad bd as bs
 fmtShort :: ArgDescr a -> Char -> String
 fmtShort (NoArg _) so = "-" ++ [so]
 fmtShort (ReqArg _ ad) so = "-" ++ [so] ++ take 1 ad
-fmtShort (OptArg _ ad) so = "-" ++ [so] ++ take 1 ad
+fmtShort (OptArg _ ad) so = "-" ++ [so] ++ (take 1 ad & \case
+  "" -> ""
+  abbreviation -> "[" ++ abbreviation ++ "]")
 
 -- unlike upstream GetOpt we omit the arg name for short options
 

--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -68,7 +68,7 @@ data ArgDescr a
   | -- |   option requires argument
     ReqArg (String -> Either String a) String
   | -- |   optional argument
-    OptArg (Maybe String) (Maybe String -> Either String a) String
+    OptArg String (Maybe String -> Either String a) String
 
 instance Functor ArgDescr where
   fmap f (NoArg a) = NoArg (f a)
@@ -145,10 +145,7 @@ fmtShort (NoArg _) so = "-" ++ [so]
 fmtShort (ReqArg _ ad) so =
   let opt = "-" ++ [so]
    in opt ++ " " ++ ad ++ " or " ++ opt ++ ad
-fmtShort (OptArg Nothing _ ad) so =
-  let opt = "-" ++ [so]
-   in opt ++ " " ++ ad
-fmtShort (OptArg Just{} _ ad) so =
+fmtShort (OptArg _ _ ad) so =
   let opt = "-" ++ [so]
    in opt ++ "[" ++ ad ++ "]"
 

--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -68,12 +68,12 @@ data ArgDescr a
   | -- |   option requires argument
     ReqArg (String -> Either String a) String
   | -- |   optional argument
-    OptArg (Maybe String -> Either String a) String
+    OptArg (Maybe String) (Maybe String -> Either String a) String
 
 instance Functor ArgDescr where
   fmap f (NoArg a) = NoArg (f a)
   fmap f (ReqArg g s) = ReqArg (fmap f . g) s
-  fmap f (OptArg g s) = OptArg (fmap f . g) s
+  fmap f (OptArg dv g s) = OptArg dv (fmap f . g) s
 
 data OptKind a -- kind of cmd line arg (internal use only):
   = Opt a --    an option
@@ -131,23 +131,20 @@ zipDefault _ bd (a : as) [] = (a, bd) : map (,bd) as
 zipDefault ad _ [] (b : bs) = (ad, b) : map (ad,) bs
 zipDefault ad bd (a : as) (b : bs) = (a, b) : zipDefault ad bd as bs
 
--- | Don't abbreviate for required arguments, as it's confusing with no
--- separator.  Go with option b.
--- a) -wP, --with-compiler=PATH
--- b) -wPATH, --with-compiler=PATH
--- Abbreviate optional arguments, as it's clear with separators.
--- -j[N], --jobs[=NUM]
 fmtShort :: ArgDescr a -> Char -> String
 fmtShort (NoArg _) so = "-" ++ [so]
-fmtShort (ReqArg _ ad) so = "-" ++ [so] ++ ad
-fmtShort (OptArg _ ad) so = "-" ++ [so] ++ ad
+fmtShort (ReqArg _ ad) so = let opt = "-" ++ [so] in
+  opt ++ " " ++ ad ++ " or " ++ opt ++ ad ++ " (but not " ++ opt ++ "=" ++ ad ++ ")"
+fmtShort (OptArg Nothing _ ad) so = "-" ++ [so] ++ " " ++ ad
+fmtShort (OptArg Just{} _ ad) so = let opt = "-" ++ [so] in
+  opt ++ ad ++ " (but not " ++ opt ++ "=" ++ ad ++ ")"
 
 -- unlike upstream GetOpt we omit the arg name for short options
 
 fmtLong :: ArgDescr a -> String -> String
 fmtLong (NoArg _) lo = "--" ++ lo
 fmtLong (ReqArg _ ad) lo = "--" ++ lo ++ "=" ++ ad
-fmtLong (OptArg _ ad) lo = "--" ++ lo ++ "[=" ++ ad ++ "]"
+fmtLong (OptArg _ _ ad) lo = "--" ++ lo ++ "[=" ++ ad ++ "]"
 
 wrapText :: Int -> String -> [String]
 wrapText width = map unwords . wrap 0 [] . words
@@ -237,8 +234,8 @@ longOpt ls rs optDescr = long ads arg rs
     long [ReqArg _ d] [] [] = (errReq d optStr, [])
     long [ReqArg f _] [] (r : rest) = (fromRes (f r), rest)
     long [ReqArg f _] ('=' : xs) rest = (fromRes (f xs), rest)
-    long [OptArg f _] [] rest = (fromRes (f Nothing), rest)
-    long [OptArg f _] ('=' : xs) rest = (fromRes (f (Just xs)), rest)
+    long [OptArg _ f _] [] rest = (fromRes (f Nothing), rest)
+    long [OptArg _ f _] ('=' : xs) rest = (fromRes (f (Just xs)), rest)
     long _ _ rest = (UnreqOpt ("--" ++ ls), rest)
 
 -- handle short option
@@ -256,8 +253,8 @@ shortOpt y ys rs optDescr = short ads ys rs
     short (ReqArg _ d : _) [] [] = (errReq d optStr, [])
     short (ReqArg f _ : _) [] (r : rest) = (fromRes (f r), rest)
     short (ReqArg f _ : _) xs rest = (fromRes (f xs), rest)
-    short (OptArg f _ : _) [] rest = (fromRes (f Nothing), rest)
-    short (OptArg f _ : _) xs rest = (fromRes (f (Just xs)), rest)
+    short (OptArg _ f _ : _) [] rest = (fromRes (f Nothing), rest)
+    short (OptArg _ f _ : _) xs rest = (fromRes (f (Just xs)), rest)
     short [] [] rest = (UnreqOpt optStr, rest)
     short [] xs rest = (UnreqOpt (optStr ++ xs), rest)
 

--- a/Cabal/src/Distribution/GetOpt.hs
+++ b/Cabal/src/Distribution/GetOpt.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TupleSections #-}
 
@@ -39,7 +38,6 @@ module Distribution.GetOpt
     -- | See "System.Console.GetOpt" for examples
   ) where
 
-import Data.Function ((&))
 import Distribution.Compat.Prelude
 import Prelude ()
 
@@ -142,13 +140,7 @@ zipDefault ad bd (a : as) (b : bs) = (a, b) : zipDefault ad bd as bs
 fmtShort :: ArgDescr a -> Char -> String
 fmtShort (NoArg _) so = "-" ++ [so]
 fmtShort (ReqArg _ ad) so = "-" ++ [so] ++ ad
-fmtShort (OptArg _ ad) so =
-  "-"
-    ++ [so]
-    ++ ( take 1 ad & \case
-          "" -> ""
-          abbreviation -> "[" ++ abbreviation ++ "]"
-       )
+fmtShort (OptArg _ ad) so = "-" ++ [so] ++ ad
 
 -- unlike upstream GetOpt we omit the arg name for short options
 

--- a/Cabal/src/Distribution/Simple/Command.hs
+++ b/Cabal/src/Distribution/Simple/Command.hs
@@ -139,7 +139,7 @@ data OptDescr a
       OptFlags
       ArgPlaceHolder
       (ReadE (a -> a))
-      (Maybe String, a -> a)
+      (String, a -> a)
       (a -> [Maybe String])
   | ChoiceOpt [(Description, OptFlags, a -> a, a -> Bool)]
   | BoolOpt
@@ -232,7 +232,7 @@ optArg
   :: Monoid b
   => ArgPlaceHolder
   -> ReadE b
-  -> (Maybe String, b)
+  -> (String, b)
   -> (b -> [Maybe String])
   -> MkOptDescr (a -> b) (b -> a -> a) a
 optArg ad mkflag (dv, mkDef) showflag sf lf d get set =
@@ -262,12 +262,12 @@ optArg'
   -> (b -> [Maybe String])
   -> MkOptDescr (a -> b) (b -> a -> a) a
 optArg' ad mkflag showflag =
-  optArg ad (succeedReadE (mkflag . Just)) (Nothing, mkflag Nothing) showflag
+  optArg ad (succeedReadE (mkflag . Just)) ("", mkflag Nothing) showflag
 
 optArgDef'
   :: Monoid b
   => ArgPlaceHolder
-  -> (Maybe String, Maybe String -> b)
+  -> (String, Maybe String -> b)
   -> (b -> [Maybe String])
   -> MkOptDescr (a -> b) (b -> a -> a) a
 optArgDef' ad (dv, mkflag) showflag =

--- a/Cabal/src/Distribution/Simple/Command.hs
+++ b/Cabal/src/Distribution/Simple/Command.hs
@@ -74,6 +74,7 @@ module Distribution.Simple.Command
   , reqArg'
   , optArg
   , optArg'
+  , optArgDef'
   , noArg
   , boolOpt
   , boolOpt'
@@ -138,7 +139,7 @@ data OptDescr a
       OptFlags
       ArgPlaceHolder
       (ReadE (a -> a))
-      (a -> a)
+      (Maybe String, a -> a)
       (a -> [Maybe String])
   | ChoiceOpt [(Description, OptFlags, a -> a, a -> Bool)]
   | BoolOpt
@@ -231,16 +232,16 @@ optArg
   :: Monoid b
   => ArgPlaceHolder
   -> ReadE b
-  -> b
+  -> (Maybe String, b)
   -> (b -> [Maybe String])
   -> MkOptDescr (a -> b) (b -> a -> a) a
-optArg ad mkflag def showflag sf lf d get set =
+optArg ad mkflag (dv, mkDef) showflag sf lf d get set =
   OptArg
     d
     (sf, lf)
     ad
     (fmap (\a b -> set (get b `mappend` a) b) mkflag)
-    (\b -> set (get b `mappend` def) b)
+    (dv, \b -> set (get b `mappend` mkDef) b)
     (showflag . get)
 
 -- | (String -> a) variant of "reqArg"
@@ -261,9 +262,16 @@ optArg'
   -> (b -> [Maybe String])
   -> MkOptDescr (a -> b) (b -> a -> a) a
 optArg' ad mkflag showflag =
-  optArg ad (succeedReadE (mkflag . Just)) def showflag
-  where
-    def = mkflag Nothing
+  optArg ad (succeedReadE (mkflag . Just)) (Nothing, mkflag Nothing) showflag
+
+optArgDef'
+  :: Monoid b
+  => ArgPlaceHolder
+  -> (Maybe String, Maybe String -> b)
+  -> (b -> [Maybe String])
+  -> MkOptDescr (a -> b) (b -> a -> a) a
+optArgDef' ad (dv, mkflag) showflag =
+  optArg ad (succeedReadE (mkflag . Just)) (dv, mkflag Nothing) showflag
 
 noArg :: Eq b => b -> MkOptDescr (a -> b) (b -> a -> a) a
 noArg flag sf lf d = choiceOpt [(flag, (sf, lf), d)] sf lf d
@@ -339,8 +347,8 @@ viewAsGetOpt (OptionField _n aa) = concatMap optDescrToGetOpt aa
   where
     optDescrToGetOpt (ReqArg d (cs, ss) arg_desc set _) =
       [GetOpt.Option cs ss (GetOpt.ReqArg (runReadE set) arg_desc) d]
-    optDescrToGetOpt (OptArg d (cs, ss) arg_desc set def _) =
-      [GetOpt.Option cs ss (GetOpt.OptArg set' arg_desc) d]
+    optDescrToGetOpt (OptArg d (cs, ss) arg_desc set (dv, def) _) =
+      [GetOpt.Option cs ss (GetOpt.OptArg dv set' arg_desc) d]
       where
         set' Nothing = Right def
         set' (Just txt) = runReadE set txt
@@ -374,13 +382,13 @@ liftOptDescr get' set' (ChoiceOpt opts) =
     [ (d, ff, liftSet get' set' set, (get . get'))
     | (d, ff, set, get) <- opts
     ]
-liftOptDescr get' set' (OptArg d ff ad set def get) =
+liftOptDescr get' set' (OptArg d ff ad set (dv, mkDef) get) =
   OptArg
     d
     ff
     ad
     (liftSet get' set' `fmap` set)
-    (liftSet get' set' def)
+    (dv, liftSet get' set' mkDef)
     (get . get')
 liftOptDescr get' set' (ReqArg d ff ad set get) =
   ReqArg d ff ad (liftSet get' set' `fmap` set) (get . get')

--- a/Cabal/src/Distribution/Simple/Setup/Common.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Common.hs
@@ -282,7 +282,7 @@ optionVerbosity get set =
     ( optArg
         "n"
         (fmap Flag flagToVerbosity)
-        (Flag verbose) -- default Value if no n is given
+        (Just $ show verbose, Flag verbose) -- default Value if no n is given
         (fmap (Just . showForCabal) . flagToList)
     )
 
@@ -300,7 +300,7 @@ optionNumJobs get set =
     ( optArg
         "NUM"
         (fmap Flag numJobsParser)
-        (Flag Nothing)
+        (Just "$ncpus", Flag Nothing)
         (map (Just . maybe "$ncpus" show) . flagToList)
     )
   where

--- a/Cabal/src/Distribution/Simple/Setup/Common.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Common.hs
@@ -282,7 +282,7 @@ optionVerbosity get set =
     ( optArg
         "n"
         (fmap Flag flagToVerbosity)
-        (Just $ show verbose, Flag verbose) -- default Value if no n is given
+        (show verbose, Flag verbose) -- default Value if no n is given
         (fmap (Just . showForCabal) . flagToList)
     )
 
@@ -300,7 +300,7 @@ optionNumJobs get set =
     ( optArg
         "NUM"
         (fmap Flag numJobsParser)
-        (Just "$ncpus", Flag Nothing)
+        ("$ncpus", Flag Nothing)
         (map (Just . maybe "$ncpus" show) . flagToList)
     )
   where

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -543,7 +543,7 @@ configureOptions showOrParseArgs =
           (\v flags -> flags{configOptimization = v})
           [ optArgDef'
               "n"
-              (Just $ show NoOptimisation, Flag . flagToOptimisationLevel)
+              (show NoOptimisation, Flag . flagToOptimisationLevel)
               ( \f -> case f of
                   Flag NoOptimisation -> []
                   Flag NormalOptimisation -> [Nothing]

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -541,9 +541,9 @@ configureOptions showOrParseArgs =
           "optimization"
           configOptimization
           (\v flags -> flags{configOptimization = v})
-          [ optArg'
+          [ optArgDef'
               "n"
-              (Flag . flagToOptimisationLevel)
+              (Just $ show NoOptimisation, Flag . flagToOptimisationLevel)
               ( \f -> case f of
                   Flag NoOptimisation -> []
                   Flag NormalOptimisation -> [Nothing]

--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -281,7 +281,7 @@ outdatedOptions _showOrParseArgs =
       ( optArg
           "PKGS"
           ignoreMajorVersionBumpsParser
-          (Just "TODO", Just IgnoreMajorVersionBumpsAll)
+          ("", Just IgnoreMajorVersionBumpsAll)
           ignoreMajorVersionBumpsPrinter
       )
   ]

--- a/cabal-install/src/Distribution/Client/CmdOutdated.hs
+++ b/cabal-install/src/Distribution/Client/CmdOutdated.hs
@@ -281,7 +281,7 @@ outdatedOptions _showOrParseArgs =
       ( optArg
           "PKGS"
           ignoreMajorVersionBumpsParser
-          (Just IgnoreMajorVersionBumpsAll)
+          (Just "TODO", Just IgnoreMajorVersionBumpsAll)
           ignoreMajorVersionBumpsPrinter
       )
   ]

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -934,7 +934,7 @@ configureExOptions _showOrParseArgs src =
       ( optArg
           "DEPS"
           (parsecToReadEErr unexpectMsgString relaxDepsParser)
-          (Just $ show RelaxDepsAll, Just RelaxDepsAll)
+          (show RelaxDepsAll, Just RelaxDepsAll)
           relaxDepsPrinter
       )
   , option
@@ -946,7 +946,7 @@ configureExOptions _showOrParseArgs src =
       ( optArg
           "DEPS"
           (parsecToReadEErr unexpectMsgString relaxDepsParser)
-          (Just $ show RelaxDepsAll, Just RelaxDepsAll)
+          (show RelaxDepsAll, Just RelaxDepsAll)
           relaxDepsPrinter
       )
   , option
@@ -1766,7 +1766,7 @@ getCommand =
                     (const "invalid source-repository")
                     (fmap (toFlag . Just) parsec)
                 )
-                (Nothing, Flag Nothing)
+                ("", Flag Nothing)
                 (map (fmap show) . flagToList)
             )
         , option

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -934,7 +934,7 @@ configureExOptions _showOrParseArgs src =
       ( optArg
           "DEPS"
           (parsecToReadEErr unexpectMsgString relaxDepsParser)
-          (Just RelaxDepsAll)
+          (Just $ show RelaxDepsAll, Just RelaxDepsAll)
           relaxDepsPrinter
       )
   , option
@@ -946,7 +946,7 @@ configureExOptions _showOrParseArgs src =
       ( optArg
           "DEPS"
           (parsecToReadEErr unexpectMsgString relaxDepsParser)
-          (Just RelaxDepsAll)
+          (Just $ show RelaxDepsAll, Just RelaxDepsAll)
           relaxDepsPrinter
       )
   , option
@@ -1766,7 +1766,7 @@ getCommand =
                     (const "invalid source-repository")
                     (fmap (toFlag . Just) parsec)
                 )
-                (Flag Nothing)
+                (Nothing, Flag Nothing)
                 (map (fmap show) . flagToList)
             )
         , option

--- a/changelog.d/issue-8785
+++ b/changelog.d/issue-8785
@@ -1,0 +1,29 @@
+synopsis: Also render short options with arguments
+packages: cabal-install
+prs: #9043
+issues: #8785
+
+description: {
+
+Show how arguments are used with both short and long forms of options:
+
+```diff
+<  -v, --verbose[=n]              Control verbosity (n is 0--3, default
+>  -v[n], --verbose[=n]           Control verbosity (n is 0--3, default
+<  -w, --with-compiler=PATH       give the path to a particular compiler
+>  -w PATH or -wPATH, --with-compiler=PATH
+>                                 give the path to a particular compiler
+<  -O, --enable-optimization[=n]  Build with optimization (n is 0--2, default is
+>  -O[n], --enable-optimization[=n]
+>                                 Build with optimization (n is 0--2, default is
+<  -f, --flags=FLAGS              Force values for the given flags in Cabal
+>  -f FLAGS or -fFLAGS, --flags=FLAGS
+>                                 Force values for the given flags in Cabal
+<  -c, --constraint=CONSTRAINT    Specify constraints on a package (version,
+>  -c CONSTRAINT or -cCONSTRAINT, --constraint=CONSTRAINT
+>                                 Specify constraints on a package (version,
+<  -j, --jobs[=NUM]               Run NUM jobs simultaneously (or '$ncpus' if no
+>  -j[NUM], --jobs[=NUM]          Run NUM jobs simultaneously (or '$ncpus' if no
+```
+
+}

--- a/changelog.d/issue-8785
+++ b/changelog.d/issue-8785
@@ -12,18 +12,6 @@ Show how arguments are used with both short and long forms of options:
 >  -v[n], --verbose[=n]           Control verbosity (n is 0--3, default
 <  -w, --with-compiler=PATH       give the path to a particular compiler
 >  -w PATH or -wPATH, --with-compiler=PATH
->                                 give the path to a particular compiler
-<  -O, --enable-optimization[=n]  Build with optimization (n is 0--2, default is
->  -O[n], --enable-optimization[=n]
->                                 Build with optimization (n is 0--2, default is
-<  -f, --flags=FLAGS              Force values for the given flags in Cabal
->  -f FLAGS or -fFLAGS, --flags=FLAGS
->                                 Force values for the given flags in Cabal
-<  -c, --constraint=CONSTRAINT    Specify constraints on a package (version,
->  -c CONSTRAINT or -cCONSTRAINT, --constraint=CONSTRAINT
->                                 Specify constraints on a package (version,
-<  -j, --jobs[=NUM]               Run NUM jobs simultaneously (or '$ncpus' if no
->  -j[NUM], --jobs[=NUM]          Run NUM jobs simultaneously (or '$ncpus' if no
 ```
 
 }

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -60,7 +60,7 @@ Arguments and flags common to some or all commands are:
     users to peg themselves to stable package collections.
 
 
-.. option:: --allow-newer[=pkgs], --allow-older[=pkgs]
+.. option:: --allow-newer[=DEPS], --allow-older[=DEPS]
 
     Selectively relax upper or lower bounds in dependencies without
     editing the package description respectively.
@@ -125,7 +125,7 @@ Arguments and flags common to some or all commands are:
     'allow-newer' selectively is also supported in the config file
     (``allow-newer: foo, bar, baz:base``).
 
-.. option:: --preference=preference
+.. option:: --preference=CONSTRAINT
 
     Specify a soft constraint on versions of a package. The solver will
     attempt to satisfy these preferences on a "best-effort" basis.
@@ -248,11 +248,11 @@ cabal preferences. It is very useful when you are e.g. first configuring
 - ``cabal user-config update`` updates the user's config file with additional
   lines.
 
-  .. option:: -a, --augment=CONFIGLINE
+  .. option:: -a CONFIGLINE or -aCONFIGLINE, --augment=CONFIGLINE
 
       Pass additional configuration lines to be incorporated in the
       config file. e.g.
-      ``cabal user-config update --augment "offline: True"``.
+      ``cabal user-config update --augment="offline: True"``.
 
       Note how ``--augment`` syntax follows ``cabal user-config diff``
       output.
@@ -297,7 +297,7 @@ cabal list
     Append the given package database to the list of used package
     databases. See `cabal info`_ for a thorough explanation.
 
-.. option:: -w, --with-compiler=PATH
+.. option:: -w PATH or -wPATH, --with-compiler=PATH
 
     Path to specific compiler.
 
@@ -377,7 +377,7 @@ folder. By default the latest version of the package is downloaded, you can
 ask for a spefic one by adding version numbers
 (``cabal get random-1.0.0.1``).
 
-.. option:: -s, --source-repository[=head|this|...]]
+.. option:: -s[[head|this|...]], --source-repository[=[head|this|...]]
 
     Clone the package's source repository (Darcs, Git, etc.) instead
     of downloading the tarball. Only works if the package specifies
@@ -491,7 +491,7 @@ description file or freeze file.
 
 ``cabal outdated`` supports the following flags:
 
-.. option:: --v1-freeze-file
+.. option:: --freeze-file
 
     Read dependency version bounds from the freeze file.
 
@@ -507,7 +507,7 @@ description file or freeze file.
     description file. ``--new-freeze-file`` is an alias for this flag
     that can be used with pre-2.4 ``cabal``.
 
-.. option:: --project-file PROJECTFILE
+.. option:: --project-file=FILE
 
     :since: 2.4
 
@@ -529,11 +529,11 @@ description file or freeze file.
 
     Don't print any output. Implies ``-v0`` and ``--exit-code``.
 
-.. option:: --ignore PACKAGENAMES
+.. option:: --ignore=PKGS
 
     Don't warn about outdated dependency version bounds for the packages in this list.
 
-.. option:: --minor [PACKAGENAMES]
+.. option:: --minor[PKGS]
 
     Ignore major version bumps for these packages.
 
@@ -810,7 +810,7 @@ Examples:
 Configuration flags can be specified on the command line and these extend the project
 configuration from the 'cabal.project', 'cabal.project.local' and other files.
 
-.. option:: --repl-options
+.. option:: --repl-options=FLAG
 
     To avoid ``ghci``-specific flags from triggering unneeded global rebuilds, these
     flags are stripped from the internal configuration. As a result,
@@ -822,7 +822,7 @@ configuration from the 'cabal.project', 'cabal.project.local' and other files.
 
     Disables the loading of target modules at startup.
 
-.. option:: -b, --build-depends
+.. option:: -b DEPENDENCIES or -bDEPENDENCIES, --build-depends=DEPENDENCIES
 
     A way to experiment with libraries without needing to download
     them manually or to install them globally.
@@ -832,7 +832,7 @@ configuration from the 'cabal.project', 'cabal.project.local' and other files.
 
     ::
 
-        $ cabal repl --build-depends "vector >= 0.12 && < 0.13"
+        $ cabal repl --build-depends="vector >= 0.12 && < 0.13"
 
     Both of these commands do the same thing as the above, but only expose ``base``,
     ``vector``, and the ``vector`` package's transitive dependencies even if the user
@@ -840,8 +840,8 @@ configuration from the 'cabal.project', 'cabal.project.local' and other files.
 
     ::
 
-        $ cabal repl --ignore-project --build-depends "vector >= 0.12 && < 0.13"
-        $ cabal repl --project='' --build-depends "vector >= 0.12 && < 0.13"
+        $ cabal repl --ignore-project --build-depends="vector >= 0.12 && < 0.13"
+        $ cabal repl --project='' --build-depends="vector >= 0.12 && < 0.13"
 
     This command would add ``vector``, but not (for example) ``primitive``, because
     it only includes the packages specified on the command line (and ``base``, which
@@ -849,7 +849,7 @@ configuration from the 'cabal.project', 'cabal.project.local' and other files.
 
     ::
 
-        $ cabal repl --build-depends vector --no-transitive-deps
+        $ cabal repl --build-depends=vector --no-transitive-deps
 
 ``cabal repl`` can open scripts by passing the path to the script as the target.
 
@@ -879,9 +879,9 @@ See ``cabal run`` for more information on scripts.
 cabal run
 ^^^^^^^^^
 
-``cabal run [TARGET [ARGS]]`` runs the executable specified by the
-target, which can be a component, a package or can be left blank, as
-long as it can uniquely identify an executable within the project.
+``cabal run [TARGET] [FLAGS] [-- EXECUTABLE_FLAGS]`` runs the executable
+specified by the target, which can be a component, a package or can be left
+blank, as long as it can uniquely identify an executable within the project.
 Tests and benchmarks are also treated as executables.
 
 See `the build section <#cabal-build>`__ for the target syntax.
@@ -971,7 +971,7 @@ For more information see :cfg-field:`verbose`
 cabal bench
 ^^^^^^^^^^^
 
-``cabal bench [TARGETS] [OPTIONS]`` runs the specified benchmarks
+``cabal bench [TARGETS] [FLAGS]`` runs the specified benchmarks
 (all the benchmarks in the current package by default), first ensuring
 they are up to date.
 
@@ -981,7 +981,7 @@ they are up to date.
 cabal test
 ^^^^^^^^^^
 
-``cabal test [TARGETS] [OPTIONS]`` runs the specified test suites
+``cabal test [TARGETS] [FLAGS]`` runs the specified test suites
 (all the test suites in the current package by default), first ensuring
 they are up to date.
 
@@ -1010,9 +1010,9 @@ tricky GHC options, etc.).
 
 Run ``cabal check`` in the folder where your ``.cabal`` package file is.
 
-.. option:: -v, --verbose[=n]
+.. option:: -v[n], --verbose[=n]
 
-    Set verbosity level (0–3, default is 1).
+    Control verbosity (n is 0--3, default verbosity level is 1).
 
 Issues are classified as ``Warning``\s and ``Error``\s. The latter correspond
 to Hackage requirements for uploaded packages: if no error is reported,
@@ -1022,7 +1022,7 @@ exits with ``1`` and Hackage will refuse the package.
 cabal sdist
 ^^^^^^^^^^^
 
-``cabal sdist [FLAGS] [TARGETS]`` takes the crucial files needed to build ``TARGETS``
+``cabal sdist [FLAGS] [PACKAGES]`` takes the crucial files needed to build ``PACKAGES``
 and puts them into an archive format ready for upload to Hackage. These archives are stable
 and two archives of the same format built from the same source will hash to the same value.
 
@@ -1035,7 +1035,7 @@ and two archives of the same format built from the same source will hash to the 
     Output is to ``stdout`` by default. The file paths are relative to the project's root
     directory.
 
-.. option:: -o, --output-directory
+.. option:: -o PATH or -oPATH, --output-directory=PATH
 
     Sets the output dir, if a non-default one is desired. The default is
     ``dist-newstyle/sdist/``. ``--output-directory -`` will send output to ``stdout``
@@ -1072,22 +1072,22 @@ to Hackage.
     documentation for a published package (and not a candidate), add
     ``--publish``.
 
-.. option:: -u, --username
+.. option:: -u USERNAME or -uUSERNAME, --username=USERNAME
 
     Your Hackage username.
 
-.. option:: -p, --password
+.. option:: -p PASSWORD or -pPASSWORD, --password=PASSWORD
 
     Your Hackage password.
 
-.. option:: -P, --password-command
+.. option:: -P COMMAND or -PCOMMAND, --password-command=COMMAND
 
     Command to get your Hackage password.  Arguments with whitespace
     must be quoted (double-quotes only).  For example:
 
     ::
 
-        --password-command 'sh -c "grep hackage ~/secrets | cut -d : -f 2"'
+        --password-command='sh -c "grep hackage ~/secrets | cut -d : -f 2"'
 
     Or in the config file:
 
@@ -1101,10 +1101,10 @@ cabal report
 
 ``cabal report [FLAGS]`` uploads build reports to Hackage.
 
-.. option:: -u, --username
+.. option:: -u USERNAME or -uUSERNAME, --username=USERNAME
 
     Your Hackage username.
 
-.. option:: -p, --password
+.. option:: -p PASSWORD or -pPASSWORD, --password=PASSWORD
 
     Your Hackage password.

--- a/doc/cabal-project.rst
+++ b/doc/cabal-project.rst
@@ -243,7 +243,7 @@ package, and thus apply globally:
 
 
 .. cfg-field:: verbose: nat
-               --verbose=n, -vn
+               -v[n], --verbose[=n]
     :synopsis: Build verbosity level.
 
     :default: 1
@@ -255,7 +255,7 @@ package, and thus apply globally:
     form ``-v2`` is also supported.
 
 .. cfg-field:: jobs: nat or $ncpus
-               --jobs=n, -jn, --jobs=$ncpus
+               -j[NUM], --jobs[=NUM], --jobs=$ncpus
     :synopsis: Number of builds running in parallel.
 
     :default: 1
@@ -320,7 +320,7 @@ package, and thus apply globally:
 
     This option can only be specified from the command line.
 
-.. option:: --ignore-project
+.. option:: -z, --ignore-project
 
     Ignores the local ``cabal.project`` file and uses the default
     configuration with the local ``foo.cabal`` file. Note that
@@ -411,7 +411,8 @@ Solver configuration options
 
 The following settings control the behavior of the dependency solver:
 
-.. cfg-field:: constraints: constraints list (comma separated)
+.. cfg-field:: constraints: CONSTRAINT (comma separated list)
+               -c CONSTRAINT or -cCONSTRAINT, --constraint=CONSTRAINT
                --constraint="pkg >= 2.0", -c "pkg >= 2.0"
     :synopsis: Extra dependencies constraints.
 
@@ -438,7 +439,8 @@ The following settings control the behavior of the dependency solver:
     :option:`runhaskell Setup.hs configure --constraint`
     command line option.
 
-.. cfg-field:: preferences: preference (comma separated)
+.. cfg-field:: preferences: CONSTRAINT (comma separated list)
+               --preference=CONSTRAINT
                --preference="pkg >= 2.0"
     :synopsis: Preferred dependency versions.
 
@@ -717,6 +719,7 @@ scripts that require a version of the Cabal library older than when the
 feature was added.
 
 .. cfg-field:: flags: list of +flagname or -flagname (space separated)
+               -f FLAGS or -fFLAGS, --flags=FLAGS
                --flags="+foo -bar", -ffoo, -f-bar
     :synopsis: Enable or disable package flags.
 
@@ -746,8 +749,8 @@ feature was added.
     ``haskell-tor`` is the package you want this flag to apply to, try
     ``--constraint="haskell-tor +hans"`` instead.
 
-.. cfg-field:: with-compiler: executable
-               --with-compiler=executable
+.. cfg-field:: with-compiler: PATH
+               -w PATH or -wPATH, --with-compiler=PATH
     :synopsis: Path to compiler executable.
 
     Specify the path to a particular compiler to be used. If not an
@@ -777,9 +780,9 @@ feature was added.
     ``--with-compiler=ghc-7.8``; there is also a short version
     ``-w ghc-7.8``.
 
-.. cfg-field:: with-hc-pkg: executable
-               --with-hc-pkg=executable
-    :synopsis: Specifies package tool.
+.. cfg-field:: with-hc-pkg: PATH
+               --with-hc-pkg=PATH
+    :synopsis: Path to package tool.
 
     Specify the path to the package tool, e.g., ``ghc-pkg``. This
     package tool must be compatible with the compiler specified by
@@ -791,7 +794,7 @@ feature was added.
     ``--with-hc-pkg=ghc-pkg-7.8``.
 
 .. cfg-field:: optimization: nat
-               --enable-optimization
+               -O[n], --enable-optimization[=n]
                --disable-optimization
     :synopsis: Build with optimization.
 
@@ -823,8 +826,8 @@ feature was added.
     equivalent to ``-O``). There are also long-form variants
     ``--enable-optimization`` and ``--disable-optimization``.
 
-.. cfg-field:: configure-options: args (space separated)
-               --configure-option=arg
+.. cfg-field:: configure-options: OPT (space separated list)
+               --configure-option=OPT
     :synopsis: Options to pass to configure script.
 
     A list of extra arguments to pass to the external ``./configure``
@@ -881,7 +884,7 @@ feature was added.
     ``--disable-benchmarks``.
 
 .. _cmdoption-extra-prog-path:
-.. cfg-field:: extra-prog-path: paths (newline or comma separated)
+.. cfg-field:: extra-prog-path: PATH (newline or comma separated list)
                --extra-prog-path=PATH
     :synopsis: Add directories to program search path.
     :since: 1.18
@@ -901,11 +904,11 @@ feature was added.
 
 .. cfg-field:: run-tests: boolean
                --run-tests
-    :synopsis: Run package test suite upon installation.
+    :synopsis: Run package test suite during installation.
 
     :default: ``False``
 
-    Run the package test suite upon installation. This is useful for
+    Run the package test suite during installation. This is useful for
     saying "When this package is installed, check that the test suite
     passes, terminating the rest of the build if it is broken."
 
@@ -923,7 +926,7 @@ Object code options
 ^^^^^^^^^^^^^^^^^^^
 
 .. cfg-field:: debug-info: integer
-               --enable-debug-info=<n>
+               --enable-debug-info[=n]
                --disable-debug-info
     :synopsis: Build with debug info enabled.
     :since: 1.22
@@ -1020,8 +1023,8 @@ Object code options
 Executable options
 ^^^^^^^^^^^^^^^^^^
 
-.. cfg-field:: program-prefix: prefix
-               --program-prefix=prefix
+.. cfg-field:: program-prefix: PREFIX
+               --program-prefix=PREFIX
     :synopsis: Prepend prefix to program names.
 
     :strike:`Prepend *prefix* to installed program names.` (Currently
@@ -1034,8 +1037,8 @@ Executable options
 
     The command line variant of this flag is ``--program-prefix=foo-``.
 
-.. cfg-field:: program-suffix: suffix
-               --program-suffix=suffix
+.. cfg-field:: program-suffix: SUFFIX
+               --program-suffix=SUFFIX
     :synopsis: Append refix to program names.
 
     :strike:`Append *suffix* to installed program names.` (Currently
@@ -1412,9 +1415,9 @@ running ``setup haddock``.
     Generate an index for interactive documentation navigation.
     This is equivalent to running ``haddock`` with the ``--quickjump`` flag.
 
-.. cfg-field:: haddock-html-location: templated path
-               --haddock-html-location=TEMPLATE
-    :synopsis: Haddock HTML templates location.
+.. cfg-field:: haddock-html-location: URL (templated path)
+               --haddock-html-location=URL
+    :synopsis: Location of HTML documentation for prerequisite packages.
 
     Specify a template for the location of HTML documentation for
     prerequisite packages. The substitutions are applied to the template
@@ -1477,7 +1480,7 @@ running ``setup haddock``.
 
     Run haddock on all components.
 
-.. cfg-field:: haddock-css: path
+.. cfg-field:: haddock-css: PATH
                --haddock-css=PATH
     :synopsis: Location of Haddock CSS file.
 
@@ -1494,7 +1497,7 @@ running ``setup haddock``.
     Haddock documentation link to it.
     This is equivalent to running ``haddock`` with the ``--hyperlinked-source`` flag.
 
-.. cfg-field:: haddock-hscolour-css: path
+.. cfg-field:: haddock-hscolour-css: PATH
                --haddock-hscolour-css=PATH
     :synopsis: Location of CSS file for HsColour
 
@@ -1514,8 +1517,8 @@ running ``setup haddock``.
 
     There is no command line variant of this flag.
 
-.. cfg-field:: haddock-output-dir: path
-               --haddock-output-dir=PATH
+.. cfg-field:: haddock-output-dir: DIR
+               --haddock-output-dir=DIR
     :synopsis: Generate haddock documentation into this directory.
 
     Generate haddock documentation into this directory instead of the default
@@ -1536,7 +1539,7 @@ Advanced global configuration options
 -------------------------------------
 
 .. cfg-field:: write-ghc-environment-files: always, never, or ghc8.4.4+
-               --write-ghc-environment-files=policy
+               --write-ghc-environment-files=always\|never\|ghc8.4.4+
     :synopsis: Whether a ``.ghc.environment`` should be created after a successful build.
 
     :default: ``never``
@@ -1655,8 +1658,8 @@ Advanced solver options
 
 Most users generally won't need these.
 
-.. cfg-field:: solver: modular
-               --solver=modular
+.. cfg-field:: solver: SOLVER
+               --solver=SOLVER
     :synopsis: Which solver to use.
 
     This field is reserved to allow the specification of alternative
@@ -1763,8 +1766,8 @@ Most users generally won't need these.
     The command line variant of this field is
     ``--(no-)allow-boot-library-installs``.
 
-.. cfg-field:: cabal-lib-version: version
-               --cabal-lib-version=version
+.. cfg-field:: cabal-lib-version: VERSION
+               --cabal-lib-version=VERSION
     :synopsis: Version of Cabal library used to build package.
 
     This field selects the version of the Cabal library which should be

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -213,19 +213,19 @@ files of a package:
     embedded spaced need to be quoted, for example
     ``--foo-options='--bar="C:\Program File\Bar"'``. As an alternative
     that takes only one option at a time but avoids the need to quote,
-    use :option:`--prog-option` instead.
+    use :option:`--PROG-option` instead.
 
 .. option:: --PROG-option=OPT
 
     Specify a single additional option to the program *prog*. For
     passing an option that contains embedded spaces, such as a file name
-    with embedded spaces, using this rather than :option:`--prog-options`
+    with embedded spaces, using this rather than :option:`--PROG-options`
     means you do not need an additional level of quoting. Of course if you
     are using a command shell you may still need to quote, for example
     ``--foo-options="--bar=C:\Program File\Bar"``.
 
-All of the options passed with either :option:`--prog-options`
-or :option:`--prog-option` are passed in the order they were
+All of the options passed with either :option:`--PROG-options`
+or :option:`--PROG-option` are passed in the order they were
 specified on the configure command line.
 
 Installation paths

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -166,14 +166,17 @@ Programs used for building
 The following options govern the programs used to process the source
 files of a package:
 
-.. option:: --ghc or -g, --jhc, --lhc, --uhc
+.. option:: -g, --ghc
+            --ghcjs
+            --uhc
+            --haskell-suite
 
     Specify which Haskell implementation to use to build the package. At
     most one of these flags may be given. If none is given, the
     implementation under which the setup script was compiled or
     interpreted is used.
 
-.. option:: --with-compiler=path or -w *path*
+.. option:: -w PATH or -wPATH, --with-compiler=PATH
 
     Specify the path to a particular compiler. If given, this must match
     the implementation selected above. The default is to search for the
@@ -184,14 +187,14 @@ files of a package:
     ``runhaskell Setup.hs configure -v`` to ensure that it finds the right package
     tool (or use :option:`--with-hc-pkg` explicitly).
 
-.. option:: --with-hc-pkg=path
+.. option:: --with-hc-pkg=PATH
 
     Specify the path to the package tool, e.g. ``ghc-pkg``. The package
     tool must be compatible with the compiler specified by
     :option:`--with-compiler`. If this option is omitted, the default value is
     determined from the compiler selected.
 
-.. option:: --with-prog=path
+.. option:: --with-PROG=PATH
 
     Specify the path to the program *prog*. Any program known to Cabal
     can be used in place of *prog*. It can either be a fully path or the
@@ -201,7 +204,7 @@ files of a package:
     programs is not enumerated in this user guide. Rather, run
     ``cabal install --help`` to view the list.
 
-.. option:: --prog-options=options
+.. option:: --PROG-options=OPTS
 
     Specify additional options to the program *prog*. Any program known
     to Cabal can be used in place of *prog*. For example:
@@ -212,7 +215,7 @@ files of a package:
     that takes only one option at a time but avoids the need to quote,
     use :option:`--prog-option` instead.
 
-.. option:: --prog-option=option
+.. option:: --PROG-option=OPT
 
     Specify a single additional option to the program *prog*. For
     passing an option that contains embedded spaces, such as a file name
@@ -231,7 +234,7 @@ Installation paths
 The following options govern the location of installed files from a
 package:
 
-.. option:: --prefix=dir
+.. option:: --prefix=DIR
 
     The root of the installation. For example for a global install you
     might use ``/usr/local`` on a Unix system, or ``C:\Program Files``
@@ -242,7 +245,7 @@ package:
     variables: ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``,
     ``$os``, ``$arch``, ``$abi``, ``$abitag``
 
-.. option:: --bindir=dir
+.. option:: --bindir=DIR
 
     Executables that the user might invoke are installed here.
 
@@ -250,7 +253,7 @@ package:
     variables: ``$prefix``, ``$pkgid``, ``$pkg``, ``$version``,
     ``$compiler``, ``$os``, ``$arch``, ``$abi``, ``$abitag``
 
-.. option:: --libdir=dir
+.. option:: --libdir=DIR
 
     Object-code libraries are installed here.
 
@@ -259,7 +262,7 @@ package:
     ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
-.. option:: --dynlibdir=dir
+.. option:: --dynlibdir=DIR
 
     Dynamic libraries are installed here.
 
@@ -271,7 +274,7 @@ package:
     ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
-.. option:: --libexecdir=dir
+.. option:: --libexecdir=DIR
 
     Executables that are not expected to be invoked directly by the user
     are installed here.
@@ -281,7 +284,7 @@ package:
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``
 
-.. option:: --datadir=dir
+.. option:: --datadir=DIR
 
     Architecture-independent data files are installed here.
 
@@ -290,7 +293,7 @@ package:
     ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``
 
-.. option:: --sysconfdir=dir
+.. option:: --sysconfdir=DIR
 
     Installation directory for the configuration files.
 
@@ -302,7 +305,7 @@ package:
 In addition the simple build system supports the following installation
 path options:
 
-.. option:: --libsubdir=dir
+.. option:: --libsubdir=DIR
 
     A subdirectory of *libdir* in which libraries are actually installed. For
     example, in the simple build system on Unix, the default *libdir* is
@@ -316,7 +319,7 @@ path options:
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
-.. option:: --libexecsubdir=dir
+.. option:: --libexecsubdir=DIR
 
     A subdirectory of *libexecdir* in which private executables are
     installed. For example, in the simple build system on Unix, the default
@@ -328,7 +331,7 @@ path options:
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
-.. option:: --datasubdir=dir
+.. option:: --datasubdir=DIR
 
     A subdirectory of *datadir* in which data files are actually
     installed.
@@ -337,7 +340,7 @@ path options:
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
-.. option:: --docdir=dir
+.. option:: --docdir=DIR
 
     Documentation files are installed relative to this directory.
 
@@ -346,7 +349,7 @@ path options:
     ``$datasubdir``, ``$pkgid``, ``$pkg``, ``$version``, ``$compiler``,
     ``$os``, ``$arch``, ``$abi``, ``$abitag``
 
-.. option:: --htmldir=dir
+.. option:: --htmldir=DIR
 
     HTML documentation files are installed relative to this directory.
 
@@ -355,7 +358,7 @@ path options:
     ``$datasubdir``, ``$docdir``, ``$pkgid``, ``$pkg``, ``$version``,
     ``$compiler``, ``$os``, ``$arch``, ``$abi``, ``$abitag``
 
-.. option:: --program-prefix=prefix
+.. option:: --program-prefix=PREFIX
 
     Prepend *prefix* to installed program names.
 
@@ -363,7 +366,7 @@ path options:
     ``$pkg``, ``$version``, ``$compiler``, ``$os``, ``$arch``, ``$abi``,
     ``$abitag``
 
-.. option:: --program-suffix=suffix
+.. option:: --program-suffix=SUFFIX
 
     Append *suffix* to installed program names. The most obvious use for
     this is to append the program's version number to make it possible
@@ -585,7 +588,7 @@ Miscellaneous options
     packages in the user's package database will be ignored. Typically
     the final installation step will require administrative privileges.
 
-.. option:: --package-db=db
+.. option:: --package-db=DB
 
     Allows package dependencies to be satisfied from this additional
     package database *db* in addition to the global package database.
@@ -603,7 +606,7 @@ Miscellaneous options
 
     To reset the stack, use ``--package-db=clear``.
 
-.. option:: --ipid=ipid
+.. option:: --ipid=IPID
 
     Specifies the *installed package identifier* of the package to be
     built; this identifier is passed on to GHC and serves as the basis
@@ -613,12 +616,12 @@ Miscellaneous options
     internal library ``foo`` from package ``p-0.1-abcd`` will get the
     identifier ``p-0.1-abcd-foo``.
 
-.. option:: --cid=cid
+.. option:: --cid=CID
 
     Specifies the *component identifier* of the component being built;
     this is only valid if you are configuring a single component.
 
-.. option:: --enable-optimization[=n] or -O [n]
+.. option:: -O[n], --enable-optimization[=n]
 
     (default) Build with optimization flags (if available). This is
     appropriate for production use, taking more time to build faster
@@ -659,7 +662,7 @@ Miscellaneous options
     (default) Do not enable profiling in generated libraries and
     executables.
 
-.. option:: --enable-library-profiling or -p
+.. option:: -p, --enable-library-profiling
 
     As with :option:`--enable-profiling` above, but it applies only for
     libraries. So this generates an additional profiling instance of the
@@ -674,7 +677,7 @@ Miscellaneous options
 
     (default) Do not generate an additional profiling version of the library.
 
-.. option:: --profiling-detail[=level]
+.. option:: --profiling-detail=level
 
     Some compilers that support profiling, notably GHC, can allocate
     costs to different parts of the program and there are different
@@ -711,7 +714,7 @@ Miscellaneous options
     This flag is new in Cabal-1.24. Prior versions used the equivalent
     of ``none`` above.
 
-.. option:: --library-profiling-detail[=level]
+.. option:: --library-profiling-detail=level
 
     As with :option:`--profiling-detail` above, but it applies only for
     libraries.
@@ -828,7 +831,7 @@ Miscellaneous options
     (see the section on :ref:`system-dependent parameters`).
     There can be several of these options.
 
-.. option:: --extra-include-dirs[=dir]
+.. option:: --extra-include-dirs=PATH
 
     An extra directory to search for C header files. You can use this
     flag multiple times to get a list of directories.
@@ -843,12 +846,12 @@ Miscellaneous options
     and for libraries it is also saved in the package registration
     information and used when compiling modules that use the library.
 
-.. option:: --extra-lib-dirs[=dir]
+.. option:: --extra-lib-dirs=PATH
 
     An extra directory to search for system libraries files. You can use
     this flag multiple times to get a list of directories.
 
-.. option:: --extra-framework-dirs[=dir]
+.. option:: --extra-framework-dirs=PATH
 
     An extra directory to search for frameworks (OS X only). You can use
     this flag multiple times to get a list of directories.
@@ -863,14 +866,14 @@ Miscellaneous options
     and for libraries it is also saved in the package registration
     information and used when compiling modules that use the library.
 
-.. option:: --dependency[=pkgname=ipid]
+.. option:: --dependency[=pkgname=IPID]
 
     Specify that a particular dependency should used for a particular
     package name. In particular, it declares that any reference to
     *pkgname* in a :pkg-field:`build-depends` should be resolved to
     *ipid*.
 
-.. option:: --promised-dependency[=pkgname=ipid]
+.. option:: --promised-dependency[=pkgname=IPID]
 
     Very much like ``--dependency`` but the package doesn't need to already
     be installed. This is useful when attempting to start multiple component
@@ -889,7 +892,7 @@ Miscellaneous options
     :option:`--dependency` flags.
 
 
-.. option:: --constraint=constraint
+.. option:: -c CONSTRAINT or -cCONSTRAINT, --constraint=CONSTRAINT
 
     Restrict solutions involving a package to given version
     bounds, flag settings, and other properties.
@@ -999,7 +1002,7 @@ This command takes the following options:
 
 .. program:: runhaskell Setup.hs build
 
-.. option:: --prog-options=options, --prog-option=option
+.. option:: --PROG-options=OPTS, --PROG-option=OPT
 
     These are mostly the same as the `options configure
     step <#setup-configure>`__. Unlike the options specified at the
@@ -1277,12 +1280,12 @@ the package.
 
 .. program:: runhaskell Setup.hs test
 
-.. option:: --builddir=dir
+.. option:: --builddir=DIR
 
     The directory where Cabal puts generated build files (default:
     ``dist``). Test logs will be located in the ``test`` subdirectory.
 
-.. option:: --human-log=path
+.. option:: --test-log=TEMPLATE
 
     The template used to name human-readable test logs; the path is
     relative to ``dist/test``. By default, logs are named according to
@@ -1291,14 +1294,14 @@ the package.
     variables allowed are: ``$pkgid``, ``$compiler``, ``$os``,
     ``$arch``, ``$abi``, ``$abitag``, ``$test-suite``, and ``$result``.
 
-.. option:: --machine-log=path
+.. option:: --test-machine-log=TEMPLATE
 
     The path to the machine-readable log, relative to ``dist/test``. The
     default template is ``$pkgid.log``. Template variables allowed are:
     ``$pkgid``, ``$compiler``, ``$os``, ``$arch``, ``$abi``, ``$abitag``
     and ``$result``.
 
-.. option:: --show-details=filter
+.. option:: --test-show-details=FILTER
 
     Determines if the results of individual test cases are shown on the
     terminal. May be ``always`` (always show), ``never`` (never show),
@@ -1311,17 +1314,17 @@ the package.
     frameworks. (On the other hand, ``streaming`` creates a log but looses
     coloring.)
 
-.. option:: --test-options=options
+.. option:: --test-options=TEMPLATES
 
     Give extra options to the test executables.
 
-.. option:: --test-option=option
+.. option:: --test-option=TEMPLATE
 
     Give an extra option to the test executables. There is no need to
     quote options containing spaces because a single option is assumed,
     so options will not be split on spaces.
 
-.. option:: --test-wrapper=path
+.. option:: --test-wrapper=FILE
 
    The wrapper script/application used to setup and tear down the test
    execution context. The text executable path and test arguments are
@@ -1339,11 +1342,11 @@ on the command line after ``bench``. When supplied, Cabal will run
 only the named benchmarks, otherwise, Cabal will run all benchmarks in
 the package.
 
-.. option:: --benchmark-options=options
+.. option:: --benchmark-options=TEMPLATES
 
     Give extra options to the benchmark executables.
 
-.. option:: --benchmark-option=option
+.. option:: --benchmark-option=TEMPLATE
 
     Give an extra option to the benchmark executables. There is no need to
     quote options containing spaces because a single option is assumed,


### PR DESCRIPTION
See #8785.

* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary (but not set up commands - `runhaskell`).

I'm not sure a changelog entry is needed but code snippets of the command `--help` output may need to be updated in the docs.

```diff
<  -v, --verbose[=n]              Control verbosity (n is 0--3, default
>  -v[n], --verbose[=n]           Control verbosity (n is 0--3, default
<  -w, --with-compiler=PATH       give the path to a particular compiler
>  -wPATH, --with-compiler=PATH   give the path to a particular compiler
<  -O, --enable-optimization[=n]  Build with optimization (n is 0--2, default is
>  -O[n], --enable-optimization[=n]
>                                 Build with optimization (n is 0--2, default is
<  -f, --flags=FLAGS              Force values for the given flags in Cabal
>  -fFLAGS, --flags=FLAGS         Force values for the given flags in Cabal
<  -c, --constraint=CONSTRAINT    Specify constraints on a package (version,
>  -cCONSTRAINT, --constraint=CONSTRAINT
>                                 Specify constraints on a package (version,
<  -j, --jobs[=NUM]               Run NUM jobs simultaneously (or '$ncpus' if no
>  -j[N], --jobs[=NUM]            Run NUM jobs simultaneously (or '$ncpus' if no
```