### PR TITLE
check: allow "haiku" as a valid OS string.

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -1932,7 +1932,7 @@ checkConditionals pkg =
       PackageDistInexcusable (UnknownCompiler unknownImpls)
   ]
   where
-    unknownOSs    = [ os   | OS   (OtherOS os)           <- conditions ]
+    unknownOSs    = [ os   | OS   (OtherOS os)           <- conditions, os /= "haiku" ]
     unknownArches = [ arch | Arch (OtherArch arch)       <- conditions ]
     unknownImpls  = [ impl | Impl (OtherCompiler impl) _ <- conditions ]
     conditions = concatMap fvs (maybeToList (condLibrary pkg))


### PR DESCRIPTION
The `OSHaiku` identifier has been merged in #9006, for a future 3.12 release. However, tools that rely on earlier versions of cabal -- such as hackage -- don't recognise "haiku" as a valid OS identifier.

This allows packages with `os(haiku)` present to pass CI and be uploaded to hackage until hackage can eventually be upgraded to use cabal 3.12.


---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!
