### PR TITLE
Do not always pass `--quickjump` to haddock

### DIFF
--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -867,7 +867,7 @@ renderPureArgs version comp platform args =
             $ args
         else []
     , ["--since-qual=external" | isVersion 2 20]
-    , [ "--quickjump" | isVersion 2 19, _ <- flagToList . argQuickJump $ args
+    , [ "--quickjump" | isVersion 2 19, True <- flagToList . argQuickJump $ args
       ]
     , [ "--hyperlinked-source" | isVersion 2 17, True <- flagToList . argLinkedSource $ args
       ]

--- a/changelog.d/pr-9049
+++ b/changelog.d/pr-9049
@@ -1,0 +1,13 @@
+synopsis: Do not always pass --quickjump to haddock #9049
+packages: Cabal
+prs: #9049
+issues: #9060
+description: {
+
+6d8adf13101 caused `cabal` to always pass the `--quickjump` flag to Haddock.
+Not only does this waste memory for a service that user hasn't asked for,
+but also leads to a failure with Haddocks shipped with GHC 9.0 and 9.2,
+which had a separate bug (fixed in later versions but not backported) when
+Haddock does not pass `--quickjump` recursively to the package dependencies.
+
+}


### PR DESCRIPTION
6d8adf13101c4d28fef14bdec55d485feec356fd caused cabal to always pass the `--quickjump` flag to haddock. This commit fixes it by requiring that the result of `flagToList` on `argQuickJump` is `True`, instead of anything.