### PR TITLE
testsuite: use removeDirectoryRecursiveHack to cleanup

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -151,6 +151,7 @@ library
     Distribution.Utils.Json
     Distribution.Utils.NubList
     Distribution.Utils.Progress
+    Distribution.Utils.TempTestDir
     Distribution.Verbosity
     Distribution.Verbosity.Internal
 

--- a/Cabal/src/Distribution/Utils/TempTestDir.hs
+++ b/Cabal/src/Distribution/Utils/TempTestDir.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 
-module UnitTests.TempTestDir
+module Distribution.Utils.TempTestDir
   ( withTestDir
   , removeDirectoryRecursiveHack
   ) where

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -314,7 +314,6 @@ test-suite unit-tests
       UnitTests.Distribution.Solver.Modular.WeightedPSQ
       UnitTests.Distribution.Solver.Types.OptionalStanza
       UnitTests.Options
-      UnitTests.TempTestDir
 
     build-depends:
           array,
@@ -403,7 +402,6 @@ test-suite long-tests
     UnitTests.Distribution.Solver.Modular.QuickCheck
     UnitTests.Distribution.Solver.Modular.QuickCheck.Utils
     UnitTests.Options
-    UnitTests.TempTestDir
 
   build-depends:
         Cabal-QuickCheck,

--- a/cabal-install/tests/UnitTests/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/FetchUtils.hs
@@ -21,7 +21,7 @@ import Distribution.Version (mkVersion)
 import Network.URI (URI, uriPath)
 import Test.Tasty
 import Test.Tasty.HUnit
-import UnitTests.TempTestDir (withTestDir)
+import Distribution.Utils.TempTestDir (withTestDir)
 
 tests :: [TestTree]
 tests =

--- a/cabal-install/tests/UnitTests/Distribution/Client/Get.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Get.hs
@@ -23,7 +23,7 @@ import System.IO.Error
 import Test.Tasty
 import Test.Tasty.HUnit
 import UnitTests.Options (RunNetworkTests (..))
-import UnitTests.TempTestDir (withTestDir)
+import Distribution.Utils.TempTestDir (withTestDir)
 
 tests :: [TestTree]
 tests =

--- a/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
@@ -16,6 +16,7 @@ import Distribution.Client.Types.SourceRepo (SourceRepoProxy, SourceRepositoryPa
 import Distribution.Client.VCS
 import Distribution.Simple.Program
 import Distribution.System (OS (Windows), buildOS)
+import Distribution.Utils.TempTestDir (removeDirectoryRecursiveHack, withTestDir)
 import Distribution.Verbosity as Verbosity
 
 import Data.List (mapAccumL)
@@ -37,7 +38,6 @@ import Test.Tasty
 import Test.Tasty.ExpectedFailure
 import Test.Tasty.QuickCheck
 import UnitTests.Distribution.Client.ArbitraryInstances
-import UnitTests.TempTestDir (removeDirectoryRecursiveHack, withTestDir)
 
 -- | These tests take the following approach: we generate a pure representation
 -- of a repository plus a corresponding real repository, and then run various

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -70,6 +70,7 @@ import Distribution.Simple.Configure
 import qualified Distribution.Simple.Utils as U (cabalVersion)
 import Distribution.Text
 
+import Distribution.Utils.TempTestDir (removeDirectoryRecursiveHack)
 import Distribution.Verbosity
 import Distribution.Version
 
@@ -232,7 +233,6 @@ runTestM mode m = withSystemTempDirectory "cabal-testsuite" $ \tmp_dir -> do
         script_base = dropExtensions script_filename
     -- Canonicalize this so that it is stable across working directory changes
     script_dir <- canonicalizePath script_dir0
-    let verbosity = normal -- TODO: configurable
     senv <- mkScriptEnv verbosity
     -- Add test suite specific programs
     let program_db0 =
@@ -344,9 +344,11 @@ runTestM mode m = withSystemTempDirectory "cabal-testsuite" $ \tmp_dir -> do
                 return r
     runReaderT go env
   where
+    verbosity = normal -- TODO: configurable
+
     cleanup = do
         env <- getTestEnv
-        onlyIfExists . removeDirectoryRecursive $ testWorkDir env
+        onlyIfExists . removeDirectoryRecursiveHack verbosity $ testWorkDir env
         -- NB: it's important to initialize this ourselves, as
         -- the default configuration hardcodes Hackage, which we do
         -- NOT want to assume for these tests (no test should

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -30,7 +30,7 @@ import Distribution.Simple.Program.Db
 import Distribution.Simple.Program
 import Distribution.System (OS(Windows,Linux,OSX), Arch(JavaScript), buildOS, buildArch)
 import Distribution.Simple.Utils
-    ( withFileContents, withTempDirectory, tryFindPackageDesc )
+    ( withFileContents, tryFindPackageDesc )
 import Distribution.Simple.Configure
     ( getPersistBuildConfig )
 import Distribution.Version
@@ -39,6 +39,7 @@ import Distribution.Parsec (eitherParsec)
 import Distribution.Types.UnqualComponentName
 import Distribution.Types.LocalBuildInfo
 import Distribution.PackageDescription
+import Distribution.Utils.TempTestDir (withTestDir)
 import Distribution.Verbosity (normal)
 
 import Distribution.Compat.Stack
@@ -62,7 +63,7 @@ import System.Exit (ExitCode (..))
 import System.FilePath ((</>), takeExtensions, takeDrive, takeDirectory, normalise, splitPath, joinPath, splitFileName, (<.>), dropTrailingPathSeparator)
 import Control.Concurrent (threadDelay)
 import qualified Data.Char as Char
-import System.Directory (getTemporaryDirectory, getCurrentDirectory, canonicalizePath, copyFile, copyFile, doesDirectoryExist, doesFileExist, createDirectoryIfMissing, getDirectoryContents, listDirectory)
+import System.Directory (canonicalizePath, copyFile, copyFile, doesDirectoryExist, doesFileExist, createDirectoryIfMissing, getDirectoryContents, listDirectory)
 import Control.Retry (exponentialBackoff, limitRetriesByCumulativeDelay)
 import Network.Wait (waitTcpVerbose)
 
@@ -1136,11 +1137,8 @@ isTestFile f =
 -- function creates a directory immediately under the current drive on Windows.
 -- The directory must be passed to new- commands with --store-dir.
 withShorterPathForNewBuildStore :: (FilePath -> IO a) -> IO a
-withShorterPathForNewBuildStore test = do
-  tempDir <- if buildOS == Windows
-             then takeDrive `fmap` getCurrentDirectory
-             else getTemporaryDirectory
-  withTempDirectory normal tempDir "cabal-test-store" test
+withShorterPathForNewBuildStore test =
+  withTestDir normal "cabal-test-store" test
 
 -- | Find where a package locates in the store dir. This works only if there is exactly one 1 ghc version
 -- and exactly 1 directory for the given package in the store dir.


### PR DESCRIPTION
This is supposedly more robust on Windows than removeDirectoryRecursive.


---
Please include the following checklist in your PR:

* [NA] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [NA] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [NA] The documentation has been updated, if necessary.
* [NA] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!
