### PR TITLE
[cabal-7825] Implement external command system

### DIFF
--- a/Cabal/src/Distribution/Make.hs
+++ b/Cabal/src/Distribution/Make.hs
@@ -88,8 +88,10 @@ defaultMainArgs :: [String] -> IO ()
 defaultMainArgs = defaultMainHelper
 
 defaultMainHelper :: [String] -> IO ()
-defaultMainHelper args =
-  case commandsRun (globalCommand commands) commands args of
+defaultMainHelper args = do
+  command <- commandsRun (globalCommand commands) commands args
+  case command of
+    CommandDelegate -> pure ()
     CommandHelp help -> printHelp help
     CommandList opts -> printOptionsList opts
     CommandErrors errs -> printErrors errs
@@ -98,6 +100,7 @@ defaultMainHelper args =
         _
           | fromFlag (globalVersion flags) -> printVersion
           | fromFlag (globalNumericVersion flags) -> printNumericVersion
+        CommandDelegate -> pure ()
         CommandHelp help -> printHelp help
         CommandList opts -> printOptionsList opts
         CommandErrors errs -> printErrors errs

--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -168,7 +168,9 @@ defaultMainWithHooksNoReadArgs hooks pkg_descr =
 defaultMainHelper :: UserHooks -> Args -> IO ()
 defaultMainHelper hooks args = topHandler $ do
   args' <- expandResponse args
-  case commandsRun (globalCommand commands) commands args' of
+  command <- commandsRun (globalCommand commands) commands args'
+  case command of
+    CommandDelegate -> pure ()
     CommandHelp help -> printHelp help
     CommandList opts -> printOptionsList opts
     CommandErrors errs -> printErrors errs
@@ -177,6 +179,7 @@ defaultMainHelper hooks args = topHandler $ do
         _
           | fromFlag (globalVersion flags) -> printVersion
           | fromFlag (globalNumericVersion flags) -> printNumericVersion
+        CommandDelegate -> pure ()
         CommandHelp help -> printHelp help
         CommandList opts -> printOptionsList opts
         CommandErrors errs -> printErrors errs

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -322,8 +322,10 @@ warnIfAssertionsAreEnabled =
 -- into IO actions for execution.
 mainWorker :: [String] -> IO ()
 mainWorker args = do
-  topHandler $
-    case commandsRun (globalCommand commands) commands args of
+  topHandler $ do
+    command <- commandsRun (globalCommand commands) commands args
+    case command of
+      CommandDelegate -> pure ()
       CommandHelp help -> printGlobalHelp help
       CommandList opts -> printOptionsList opts
       CommandErrors errs -> printErrors errs
@@ -334,6 +336,7 @@ mainWorker args = do
                 printVersion
             | fromFlagOrDefault False (globalNumericVersion globalFlags) ->
                 printNumericVersion
+          CommandDelegate -> pure ()
           CommandHelp help -> printCommandHelp help
           CommandList opts -> printOptionsList opts
           CommandErrors errs -> do

--- a/cabal-install/src/Distribution/Client/SavedFlags.hs
+++ b/cabal-install/src/Distribution/Client/SavedFlags.hs
@@ -51,6 +51,7 @@ readCommandFlags :: FilePath -> CommandUI flags -> IO flags
 readCommandFlags path command = do
   savedArgs <- fmap (fromMaybe []) (readSavedArgs path)
   case (commandParseArgs command True savedArgs) of
+    CommandDelegate -> error "CommandDelegate Flags evaluated, this should never occur"
     CommandHelp _ -> throwIO (SavedArgsErrorHelp savedArgs)
     CommandList _ -> throwIO (SavedArgsErrorList savedArgs)
     CommandErrors errs -> throwIO (SavedArgsErrorOther savedArgs errs)

--- a/doc/external-commands.rst
+++ b/doc/external-commands.rst
@@ -1,0 +1,8 @@
+External Commands
+=================
+
+Cabal provides a system for external commands, akin to the ones used by tools like ``git`` or ``cargo``.
+
+If you execute ``cabal my-custom-command``, Cabal will search the path for an executable named ``cabal-my-custom-command`` and execute it, passing any remaining arguments to this external command. An error will be thrown in case the custom command is not found.
+
+For ideas or existing external commands, visit `this Discourse thread <https://discourse.haskell.org/t/an-external-command-system-for-cabal-what-would-you-do-with-it/7114>`_.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,3 +18,4 @@ Welcome to the Cabal User Guide
    buildinfo-fields-reference
    bugs-and-stability
    nix-integration
+   external-commands


### PR DESCRIPTION
Fixes: #2349 and #7825 

This PR introduces a simple, extensible, and functional plugin system for `cabal-install`, as suggested in this [comment](https://github.com/haskell/cabal/issues/7825#issuecomment-1586166220): Plugins are standalone executables named `cabal-$COMMAND` that are available in the `PATH`. They can be invoked with `cabal $COMMAND`, and any extra command arguments are directly passed to these executables as CLI arguments. To showcase its potential, I created an example plugin, [`cabal-explain`](https://github.com/yvan-sraka/cabal-explain), which displays Haskell error codes in the terminal.

Although this approach doesn't offer additional functionality over directly calling `cabal-X` at the moment, it does lay the groundwork for a more versatile and useful plugin system. A subsequent PR could incorporate a `CABAL` environment variable that points to the `cabal-install` executable running the command, mirroring what [`cargo`](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-3rd-party-subcommands) does. I welcome your feedback on these changes and would appreciate insights into any `ENV` variable that `cabal-install` should set. However, IMHO, it's best to start with a minimalistic approach and avoid over-anticipating users' needs. 

Thank you for considering this PR. I appreciate your suggestions and comments. Special thanks to @Kleidukos, who assisted me in pair-programming this PR following a discussion in the GHC devroom at ZuriHac 2023 :)

**Checklist:**

- [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
- [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
- [x] The documentation has been updated, if necessary.
- [x] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!

**QA notes:**

Lastly, I require your advice on which sections of the manual would be best to update to effectively document this feature. While developing it, I used a simple end-to-end test to validate the functionality:
```bash
echo 'echo "Hello, $1!"' > cabal-greetings
chmod +x cabal-greetings
test "$(cabal greetings World)" = "Hello, World!"
```
Would this make a good and sufficient test to add to the `cabal-install` test suite?