### PR TITLE
Add new root keys

### DIFF
--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -899,6 +899,10 @@ defaultHackageRemoteRepoKeys =
     "0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d"
   , -- Norman Ramsey (ZI8di3a9Un0s2RBrt5GwVRvfOXVuywADfXGPZfkiDb0=)
     "51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921"
+  , -- Mathieu Boespflug (ydN1nGGQ79K1Q0nN+ul+Ln8MxikTB95w0YdGd3v3kmg=)
+    "be75553f3c7ba1dbe298da81f1d1b05c9d39dd8ed2616c9bddf1525ca8c03e48"
+  , -- Joachim Breitner (5iUgwqZCWrCJktqMx0bBMIuoIyT4A1RYGozzchRN9rA=)
+    "d26e46f3b631aae1433b89379a6c68bd417eb5d1c408f0643dcc07757fece522"
   ]
 
 -- | The required threshold of root key signatures for hackage.haskell.org

--- a/changelog.d/pr-9068
+++ b/changelog.d/pr-9068
@@ -1,0 +1,12 @@
+synopsis: Add new Hackage root keys to bootstrap set
+packages: cabal-install
+prs: #9068
+
+description: {
+
+The two new [Hackage root keyholders](https://github.com/haskell-infra/hackage-root-keys/tree/master/root-keys) were added to the bootstrap set.
+
+- Added Hackage root key for Joachim Breitner
+- Added Hackage root key for Mathieu Boespflug
+
+}


### PR DESCRIPTION
Hackage Security has gotten two new root keyholders. This PR adds them to the bootstrap set. They're not in the currently-deployed root.json, but I'm in the process of getting that file ready to go (this is part of that process).

The correctness of this PR can be checked against https://github.com/haskell-infra/hackage-root-keys/tree/master/root-keys.

See #8669 for a prior MR in this series. The final comment in that thread mentions getting new root keyholders - this is the realization of that.

---

Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!
