### PR TITLE
Haddock: Don't pass --quickjump uncoditionally

### DIFF
--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -867,7 +867,7 @@ renderPureArgs version comp platform args =
             $ args
         else []
     , ["--since-qual=external" | isVersion 2 20]
-    , [ "--quickjump" | isVersion 2 19, _ <- flagToList . argQuickJump $ args
+    , [ "--quickjump" | isVersion 2 19, True <- flagToList . argQuickJump $ args
       ]
     , [ "--hyperlinked-source" | isVersion 2 17, True <- flagToList . argLinkedSource $ args
       ]


### PR DESCRIPTION
Fix #9060 and improve #8326, i.e. with GHC < 9.4 `cabal haddock --enable-doc` works in more situations. #8326 is not fixed because `cabal haddock --enable-doc --haddock-for-hackage` still fails and doesn't seem to be fixable without upgrading to a newer GHC (9.4+) and Haddock.

---
Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!
