### PR TITLE
Bump deepseq bounds to allow 1.5

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -33,7 +33,7 @@ library
     binary     >= 0.7      && < 0.9,
     bytestring >= 0.10.0.0 && < 0.12,
     containers >= 0.5.0.0  && < 0.7,
-    deepseq    >= 1.3.0.1  && < 1.5,
+    deepseq    >= 1.3.0.1  && < 1.6,
     directory  >= 1.2      && < 1.4,
     filepath   >= 1.3.0.1  && < 1.5,
     mtl        >= 2.1      && < 2.4,

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -39,7 +39,7 @@ library
     base       >= 4.9      && < 5,
     bytestring >= 0.10.0.0 && < 0.12,
     containers >= 0.5.0.0  && < 0.7,
-    deepseq    >= 1.3.0.1  && < 1.5,
+    deepseq    >= 1.3.0.1  && < 1.6,
     directory  >= 1.2      && < 1.4,
     filepath   >= 1.3.0.1  && < 1.5,
     pretty     >= 1.1.1    && < 1.2,


### PR DESCRIPTION
Bumps bounds of `Cabal` and `Cabal-syntax` for  GHC 9.8.