### PR TITLE
Remove v2-prefix from other documentation where appropriate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,10 +14,8 @@ A clear and concise description of what the bug is.
 Steps to reproduce the behavior:
 
 ```
-$ cabal v2-build ...
+$ cabal build ...
 ```
-
-Please use version-prefixed commands (e.g. `v2-build` or `v1-build`) to avoid ambiguity.
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,18 +3,16 @@
 Building Cabal for hacking
 --------------------------
 
-The current recommended way of developing Cabal is to use the
-`v2-build` feature which [shipped in cabal-install-1.24](http://blog.ezyang.com/2016/05/announcing-cabal-new-build-nix-style-local-builds/).
 If you use the latest version of cabal published on Hackage, it is sufficient to run:
 
 ```
-cabal v2-build cabal
+cabal build cabal
 ```
 
 If not, you aren't able to build the testsuite, so you need to disable the default `cabal.project` that implies configuring the testsuite, e.g., with:
 
 ```
-cabal v2-build --project-file=cabal.project.release cabal
+cabal build --project-file=cabal.project.release cabal
 ```
 
 The location of your build products will vary depending on which version of
@@ -25,9 +23,9 @@ to find the binary (or just run `find -type f -executable -name cabal`).
 Here are some other useful variations on the commands:
 
 ```
-cabal v2-build Cabal # build library only
-cabal v2-build Cabal-tests:unit-tests # build Cabal's unit test suite
-cabal v2-build cabal-tests # etc...
+cabal build Cabal # build library only
+cabal build Cabal-tests:unit-tests # build Cabal's unit test suite
+cabal build cabal-tests # etc...
 ```
 
 Running tests
@@ -80,7 +78,7 @@ If none of these let you reproduce, there might be some race condition
 or continuous integration breakage; please file a bug.
 
 **Running tests locally.**
-To run tests locally with `v2-build`, you will need to know the
+To run tests locally with `cabal`, you will need to know the
 name of the test suite you want.  Cabal and cabal-install have
 several.  Also, you'll want to read [Where are my build products?](http://cabal.readthedocs.io/en/latest/nix-local-build.html#where-are-my-build-products)
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY : all lexer sdpx lib exe doctest
 .PHONY : phony
 
-CABALBUILD := cabal v2-build
-CABALRUN   := cabal v2-run
+CABALBUILD := cabal build
+CABALRUN   := cabal run
 
 # default rules
 
@@ -57,10 +57,10 @@ spdx : $(SPDX_LICENSE_HS) $(SPDX_EXCEPTION_HS)
 SPDX_LICENSE_VERSIONS:=3.0 3.2 3.6 3.9 3.10 3.16
 
 $(SPDX_LICENSE_HS) : templates/SPDX.LicenseId.template.hs cabal-dev-scripts/src/GenUtils.hs cabal-dev-scripts/src/GenSPDX.hs license-list-data/licenses-3.0.json license-list-data/licenses-3.2.json
-	cabal v2-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-spdx -- templates/SPDX.LicenseId.template.hs $(SPDX_LICENSE_VERSIONS:%=license-list-data/licenses-%.json) $(SPDX_LICENSE_HS)
+	cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-spdx -- templates/SPDX.LicenseId.template.hs $(SPDX_LICENSE_VERSIONS:%=license-list-data/licenses-%.json) $(SPDX_LICENSE_HS)
 
 $(SPDX_EXCEPTION_HS) : templates/SPDX.LicenseExceptionId.template.hs cabal-dev-scripts/src/GenUtils.hs cabal-dev-scripts/src/GenSPDXExc.hs license-list-data/exceptions-3.0.json license-list-data/exceptions-3.2.json
-	cabal v2-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-spdx-exc -- templates/SPDX.LicenseExceptionId.template.hs $(SPDX_LICENSE_VERSIONS:%=license-list-data/exceptions-%.json) $(SPDX_EXCEPTION_HS)
+	cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-spdx-exc -- templates/SPDX.LicenseExceptionId.template.hs $(SPDX_LICENSE_VERSIONS:%=license-list-data/exceptions-%.json) $(SPDX_EXCEPTION_HS)
 
 # source generation: templates
 
@@ -70,10 +70,10 @@ TEMPLATE_PATHS:=Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
 templates : phony $(TEMPLATE_MACROS) $(TEMPLATE_PATHS)
 
 $(TEMPLATE_MACROS) : templates/cabal_macros.template.h cabal-dev-scripts/src/GenCabalMacros.hs
-	cabal v2-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-cabal-macros -- $< $@
+	cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-cabal-macros -- $< $@
 
 $(TEMPLATE_PATHS) : templates/Paths_pkg.template.hs cabal-dev-scripts/src/GenPathsModule.hs
-	cabal v2-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-paths-module -- $< $@
+	cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-paths-module -- $< $@
 
 # generated docs
 
@@ -83,15 +83,15 @@ buildinfo-fields-reference : phony
 
 # analyse-imports
 analyse-imports : phony
-	find Cabal-syntax/src Cabal/src cabal-install/src -type f -name '*.hs' | xargs cabal v2-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta analyse-imports --
+	find Cabal-syntax/src Cabal/src cabal-install/src -type f -name '*.hs' | xargs cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta analyse-imports --
 
 # ghcid
 
 ghcid-lib :
-	ghcid -c 'cabal v2-repl Cabal'
+	ghcid -c 'cabal repl Cabal'
 
 ghcid-cli :
-	ghcid -c 'cabal v2-repl cabal-install'
+	ghcid -c 'cabal repl cabal-install'
 
 # Artem, 2023-02-03, https://github.com/haskell/cabal/issues/8504
 # The new and prefered way to call the doctest tool (as of now) is based on cabal repl --with-ghc=doctest.
@@ -171,7 +171,7 @@ validate-dockerfiles : .docker/validate-8.4.4.dockerfile
 validate-dockerfiles : .docker/validate-8.2.2.dockerfile
 
 .docker/validate-%.dockerfile : .docker/validate.dockerfile.zinza cabal-dev-scripts/src/GenValidateDockerfile.hs
-	cabal v2-run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-validate-dockerfile -- $* $< $@
+	cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-validate-dockerfile -- $* $< $@
 
 # This is good idea anyway
 # and we have a test relying on this limit being sufficiently small
@@ -209,10 +209,10 @@ tags :
 ##############################################################################
 
 bootstrap-json-%: phony
-	cabal v2-build --project=cabal.project.release --with-compiler=ghc-$* --dry-run cabal-install:exe:cabal
+	cabal build --project=cabal.project.release --with-compiler=ghc-$* --dry-run cabal-install:exe:cabal
 	cp dist-newstyle/cache/plan.json bootstrap/linux-$*.plan.json
 	@# -v0 to avoid build output on stdout
-	cd bootstrap && cabal v2-run -v0 cabal-bootstrap-gen -- linux-$*.plan.json \
+	cd bootstrap && cabal run -v0 cabal-bootstrap-gen -- linux-$*.plan.json \
 		| python3 -m json.tool > linux-$*.json
 
 BOOTSTRAP_GHC_VERSIONS := 8.10.7 9.0.2 9.2.7 9.4.4

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -10,7 +10,7 @@ See bootstrap/README.md for usage instructions.
 USAGE = """
 This utility is only intended for use in building cabal-install
 on a new platform. If you already have a functional (if dated) cabal-install
-please rather run `cabal v2-install .`.
+please rather run `cabal install .`.
 """
 
 import argparse
@@ -458,7 +458,7 @@ def main() -> None:
 
         print(dedent(f'''
             You now should use this to build a full cabal-install distribution
-            using v2-build.
+            using 'cabal build'.
             '''))
 
 def subprocess_run(args, **kwargs):

--- a/cabal-dev-scripts/src/GenCabalInstallCabal.hs
+++ b/cabal-dev-scripts/src/GenCabalInstallCabal.hs
@@ -19,7 +19,7 @@ withIO k = do
                 putStrLn $ "Exception: " ++ displayException e
                 exitFailure
         _         -> do
-            putStrLn "Usage cabal v2-run ... source.temeplate.ext target.ext"
+            putStrLn "Usage cabal run ... source.temeplate.ext target.ext"
             exitFailure
   where
     parseBool "True"  = Just True

--- a/cabal-dev-scripts/src/GenCabalMacros.hs
+++ b/cabal-dev-scripts/src/GenCabalMacros.hs
@@ -65,7 +65,7 @@ withIO k = do
             putStrLn $ "Exception: " ++ displayException e
             exitFailure
         _         -> do
-            putStrLn "Usage cabal v2-run ... source.temeplate.ext target.ext"
+            putStrLn "Usage cabal run ... source.temeplate.ext target.ext"
             exitFailure
 
 main :: IO ()

--- a/cabal-dev-scripts/src/GenPathsModule.hs
+++ b/cabal-dev-scripts/src/GenPathsModule.hs
@@ -59,7 +59,7 @@ withIO k = do
             putStrLn $ "Exception: " ++ displayException e
             exitFailure
         _         -> do
-            putStrLn "Usage cabal v2-run ... source.temeplate.ext target.ext"
+            putStrLn "Usage cabal run ... source.temeplate.ext target.ext"
             exitFailure
 
 main :: IO ()

--- a/cabal-dev-scripts/src/GenValidateDockerfile.hs
+++ b/cabal-dev-scripts/src/GenValidateDockerfile.hs
@@ -19,7 +19,7 @@ withIO k = do
                 putStrLn $ "Exception: " ++ displayException e
                 exitFailure
         _         -> do
-            putStrLn "Usage cabal v2-run ... version"
+            putStrLn "Usage cabal run ... version"
             exitFailure
 
 main :: IO ()

--- a/solver-benchmarks/HackageBenchmark.hs
+++ b/solver-benchmarks/HackageBenchmark.hs
@@ -240,7 +240,7 @@ runCabal timeoutSeconds cabalUnderTest cabal flags = do
           cabalCmd = unwords $
               [ cabal
 
-              , "v2-install"
+              , "install"
 
                 -- These flags prevent a Cabal project or package environment from
                 -- affecting the install plan.

--- a/validate.sh
+++ b/validate.sh
@@ -40,7 +40,7 @@ Usage: ./validate.sh [options]
   A script which runs all the tests.
 
 Available options:
-  -j, --jobs JOBS                   cabal v2-build -j argument (default:  $JOBS)
+  -j, --jobs JOBS                   cabal build -j argument (default:  $JOBS)
       --libonly                     Test only Cabal-the-library
       --cli                         Test both Cabal-the-library and cabal-install
       --(no-)run-lib-tests          Run library tests
@@ -307,7 +307,7 @@ BASEHC=ghc-$($HC --numeric-version)
 BUILDDIR=dist-newstyle-validate-$BASEHC
 CABAL_TESTSUITE_BDIR="$(pwd)/$BUILDDIR/build/$ARCH/$BASEHC/cabal-testsuite-3"
 
-CABALNEWBUILD="${CABAL} v2-build $JOBS -w $HC --builddir=$BUILDDIR --project-file=$PROJECTFILE"
+CABALNEWBUILD="${CABAL} build $JOBS -w $HC --builddir=$BUILDDIR --project-file=$PROJECTFILE"
 CABALLISTBIN="${CABAL} list-bin --builddir=$BUILDDIR --project-file=$PROJECTFILE"
 
 # header


### PR DESCRIPTION
Note: I'm aware of @tomjaguarpaw 's PR [here](https://github.com/haskell/cabal/pull/9087) and intend to rebase once that lands as not to duplicate their efforts. 

The general approach I took here was to search for any file that mentioned "v2-" that wasn't a test file and remove the prefix if:
- it appeared to be a recommendation for what command to run
- didn't appear to be commenting on the aliased commands

Happy to consider any cases that I've missed or revert anything that does what we don't want. My goal at the end of this is to not have cabal mention `v2` _anywhere_ it's not appropriate, whether that's in command line output, documentation, or otherwise. I'm happy to update tests if that's what's required. 

I intend to complete this work (and thus properly fill out the checkbox below) over this weekend (July 7 - July 9, 2023).

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.

Bonus points for added automated tests!

## QA Notes
This PR isn't intended to change any functional behavior. Visually, I would expect the following:
* [ ]  the commands echoed by make targets *should not* display any `v2-` commands
* [ ] none of the cabal dev scripts should print usage information that suggests `v2-` commands
* [ ] benchmarks should not use `v2-` commands

