### PR TITLE
Revamp issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: ["type: bug", "needs triage"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,16 @@
+---
+name: Documentation
+about: Report missing, stale, or inaccurate documentation
+title: ''
+labels: ["documentation"]
+assignees: ''
+
+---
+
+**What is wrong with the docs?**
+Describe what you were searching. Was documentation not there? Was it
+outdated? Was it not clear?
+
+**Additional context**
+Add any other relevant context here.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest a new feature
+title: ''
+labels: ["type: enhancement"]
+assignees: ''
+
+---
+
+**Describe the feature request**
+A simple description of what you would like to be added to Cabal.
+
+
+**Additional context**
+What made you ask for this functionality? How would the feature benefit you
+and other users? Add any other relevant context about the request here.

--- a/.github/ISSUE_TEMPLATE/user_question.md
+++ b/.github/ISSUE_TEMPLATE/user_question.md
@@ -1,0 +1,28 @@
+---
+name: Question
+about: Ask a question to the developers
+title: ''
+labels: ["type: user-question"]
+assignees: ''
+
+---
+
+Two great places to ask questions are
+[Haskell Matrix](https://matrix.to/#/#haskell:matrix.org) (online chat)
+and [Haskell Discourse](https://discourse.haskell.org). There are many
+experienced programmers there who can quickly help you with using
+Cabal and `cabal-install`.
+
+If you did not find an answer to your question, fill in this template.
+
+**What is your question?**
+State your question in simple terms. What were you attempting to do?
+What have you have tried?
+
+**System information**
+ - Operating system
+ - `cabal`, `ghc` versions
+
+**Additional context**
+Add any other relevant context here.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,8 @@
+---
+labels: ["attention: needs-review"]
 
 ---
+
 Please include the following checklist in your PR:
 
 * [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

--- a/.github/PULL_REQUEST_TEMPLATE/full_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/full_pr.md
@@ -4,7 +4,8 @@ labels: ["attention: needs-review"]
 
 ---
 
-Please include the following checklist in your PR:
+Read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions)
+and please include the following checklist in your PR:
 
 * [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
 * [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).

--- a/.github/PULL_REQUEST_TEMPLATE/full_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/full_pr.md
@@ -1,4 +1,5 @@
 ---
+about: This PR modifies `cabal` behaviour
 labels: ["attention: needs-review"]
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/simple_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/simple_pr.md
@@ -1,0 +1,9 @@
+---
+about: This PR does not modify `cabal` behaviour (docs, tests, refactor, etc.)
+labels: ["attention: needs-review"]
+
+---
+
+Please include the following checklist in your PR:
+
+* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

--- a/.github/PULL_REQUEST_TEMPLATE/simple_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/simple_pr.md
@@ -4,6 +4,7 @@ labels: ["attention: needs-review"]
 
 ---
 
-Please include the following checklist in your PR:
+Read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions)
+and please include the following checklist in your PR:
 
 * [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).


### PR DESCRIPTION
Closes #8511.

Adds “Feature Request”, “Documentation” and “Question” issue templates.
Splits PR template in two (simple and full one), adding PR Convetion link to both.

---
Please include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] ~~Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).~~ N/A
* [x] The documentation has been updated, if necessary.
* [x] ~~Include [manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) if your PR relates to cabal-install.~~ N/A

~~Bonus points for added automated tests!~~ N/A
