### PR TITLE
Follow hlint suggestion: redundant list comprehension

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -22,7 +22,6 @@
 - ignore: {name: "Redundant guard"} # 2 hints
 - ignore: {name: "Redundant if"} # 1 hint
 - ignore: {name: "Redundant lambda"} # 22 hints
-- ignore: {name: "Redundant list comprehension"} # 3 hints
 - ignore: {name: "Redundant map"} # 1 hint
 - ignore: {name: "Redundant multi-way if"} # 1 hint
 - ignore: {name: "Redundant return"} # 4 hints

--- a/Cabal/src/Distribution/Simple/PreProcess.hs
+++ b/Cabal/src/Distribution/Simple/PreProcess.hs
@@ -648,7 +648,7 @@ ppHsc2hs bi lbi clbi =
            | pkg <- pkgs
            , opt <-
               ["-I" ++ opt | opt <- Installed.includeDirs pkg]
-                ++ [opt | opt <- Installed.ccOptions pkg]
+                ++ Installed.ccOptions pkg
            ]
         ++ [ "--lflag=" ++ opt
            | pkg <- pkgs
@@ -662,7 +662,7 @@ ppHsc2hs bi lbi clbi =
                         then Installed.extraLibrariesStatic pkg
                         else Installed.extraLibraries pkg
                    ]
-                ++ [opt | opt <- Installed.ldOptions pkg]
+                ++ Installed.ldOptions pkg
            ]
         ++ preccldFlags
         ++ hsc2hsOptions bi

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -769,7 +769,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
             [ ["-optl-Wl,-rpath," ++ dir]
             | dir <- flags ghcOptRPaths
             ]
-        , [modDefFile | modDefFile <- flags ghcOptLinkModDefFiles]
+        , flags ghcOptLinkModDefFiles
         , -------------
           -- Packages
 


### PR DESCRIPTION
See #9110. We do nothing with these bindings in list comprehensions. I'd say we're not giving up documentation value by losing these bindings:

```
opt <- ccOptions pkg
opt <- ldOptions pkg
modDefFile <- flags ghcOptLinkModDefFiles
```
