### PR TITLE
Remove labels from template PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,3 @@
----
-labels: ["attention: needs-review"]
-
----
-
 Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.
 
 ---


### PR DESCRIPTION
Labels are not supported in PR templates, see
https://github.com/orgs/community/discussions/12815

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

