### PR TITLE
Follow hlint suggestion: redundant where (dead code)

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -26,7 +26,6 @@
 - ignore: {name: "Redundant map"} # 1 hint
 - ignore: {name: "Redundant multi-way if"} # 1 hint
 - ignore: {name: "Redundant return"} # 4 hints
-- ignore: {name: "Redundant where"} # 3 hints
 - ignore: {name: "Replace case with fromMaybe"} # 5 hints
 - ignore: {name: "Replace case with maybe"} # 10 hints
 - ignore: {name: "Unused LANGUAGE pragma"} # 121 hints

--- a/Cabal-syntax/src/Distribution/Fields/ParseResult.hs
+++ b/Cabal-syntax/src/Distribution/Fields/ParseResult.hs
@@ -67,7 +67,8 @@ runParseResult :: ParseResult a -> ([PWarning], Either (Maybe Version, NonEmpty 
 runParseResult pr = unPR pr emptyPRState failure success
   where
     failure (PRState warns [] v) = (warns, Left (v, PError zeroPos "panic" :| []))
-    failure (PRState warns (err : errs) v) = (warns, Left (v, err :| errs)) where
+    failure (PRState warns (err : errs) v) = (warns, Left (v, err :| errs))
+
     success (PRState warns [] _) x = (warns, Right x)
     -- If there are any errors, don't return the result
     success (PRState warns (err : errs) v) _ = (warns, Left (v, err :| errs))

--- a/Cabal-syntax/src/Distribution/Types/Mixin.hs
+++ b/Cabal-syntax/src/Distribution/Types/Mixin.hs
@@ -67,7 +67,6 @@ instance Parsec Mixin where
     P.spaces
     incl <- parsec
     return (mkMixin pn ln incl)
-    where
 
 versionGuardMultilibs :: CabalParsing m => m ()
 versionGuardMultilibs = do

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -431,7 +431,6 @@ mkNormalizerEnv = do
         normalizerCabalVersion
             = cabalVersionLibrary
     }
-    where
 
 cabalVersionLibrary :: Version
 cabalVersionLibrary = U.cabalVersion


### PR DESCRIPTION
See #9110, remove dead code detected by hlint.

