### PR TITLE
Try each pkg-config query separatedly

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/src/Distribution/Simple/Program/Builtin.hs
@@ -400,4 +400,11 @@ pkgConfigProgram :: Program
 pkgConfigProgram =
   (simpleProgram "pkg-config")
     { programFindVersion = findProgramVersion "--version" id
+    , programPostConf = \_ pkgConfProg ->
+        let programOverrideEnv' =
+              programOverrideEnv pkgConfProg
+                ++ [ ("PKG_CONFIG_ALLOW_SYSTEM_CFLAGS", Just "1")
+                   , ("PKG_CONFIG_ALLOW_SYSTEM_LIBS", Just "1")
+                   ]
+         in pure $ pkgConfProg{programOverrideEnv = programOverrideEnv'}
     }

--- a/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
@@ -70,12 +70,18 @@ readPkgConfigDb verbosity progdb = handle ioErrorHandler $ do
         (pkgVersions, _errs, exitCode) <-
                      getProgramInvocationOutputAndErrors verbosity
                        (programInvocation pkgConfig ("--modversion" : pkgNames))
-        case exitCode of
-          ExitSuccess -> (return . pkgConfigDbFromList . zip pkgNames) (lines pkgVersions)
-          -- if there's a single broken pc file the above fails, so we fall back into calling it individually
-          _ -> do
-             info verbosity ("call to pkg-config --modversion on all packages failed. Falling back to querying pkg-config individually on each package")
-             pkgConfigDbFromList . catMaybes <$> mapM (getIndividualVersion pkgConfig) pkgNames
+        if exitCode == ExitSuccess && length pkgNames == length pkgList
+          then (return . pkgConfigDbFromList . zip pkgNames) (lines pkgVersions)
+          else
+          -- if there's a single broken pc file the above fails, so we fall back
+          -- into calling it individually
+          --
+          -- Also some implementations of @pkg-config@ do not provide more than
+          -- one package version, so if the returned list is shorter than the
+          -- requested one, we fall back to querying one by one.
+          do
+            info verbosity ("call to pkg-config --modversion on all packages failed. Falling back to querying pkg-config individually on each package")
+            pkgConfigDbFromList . catMaybes <$> mapM (getIndividualVersion pkgConfig) pkgNames
   where
     -- For when pkg-config invocation fails (possibly because of a
     -- too long command line).
@@ -92,7 +98,7 @@ readPkgConfigDb verbosity progdb = handle ioErrorHandler $ do
     getIndividualVersion pkgConfig pkg = do
        (pkgVersion, _errs, exitCode) <-
                getProgramInvocationOutputAndErrors verbosity
-                 (programInvocation pkgConfig ["--modversion",pkg])
+                 (programInvocation pkgConfig ["--modversion", pkg])
        return $ case exitCode of
          ExitSuccess -> Just (pkg, pkgVersion)
          _ -> Nothing

--- a/changelog.d/pkgconfig-envvars
+++ b/changelog.d/pkgconfig-envvars
@@ -1,0 +1,8 @@
+synopsis: PkgConfig environment variables
+prs: #9134
+
+description: {
+
+- `cabal` invokes `pkg-config` with `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS` and `PKG_CONFIG_ALLOW_SYSTEM_LIBS` set
+
+}

--- a/changelog.d/pkgconfig-once
+++ b/changelog.d/pkgconfig-once
@@ -1,0 +1,8 @@
+synopsis: PkgConfig individual calls
+prs: #9134
+
+description: {
+
+- `cabal` invokes `pkg-config` individually for each lib if querying for all doesn't return the expected result
+
+}


### PR DESCRIPTION
MinGW's pkg-config returns only one version even if queried for multiple libraries. This PR makes it so that cabal will invoke pkg-config once for each requested library if the result is not of the expected length, therefore supporting these pkg-config implementations, in particular `mingw-w64-x86_64-pkgconf` (which is also installed by GHCup when bootstrapping MSYS2).

```
Javier@DESKTOP-JDT20GG MINGW64 ~
$ pkg-config --modversion libcrypto libffi
3.1.1
```

In the same spirit as https://github.com/rust-lang/pkg-config-rs/issues/92, as we also are not GCC, we also set `PKG_CONFIG_ALLOW_SYSTEM_(CFLAGS|LIBS)` when calling `pkg-config`

## QA Notes

Building a package that depends on more than one library provided by `pkg-config` on MinGW should now be able to find the required library.


* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
