### PR TITLE
Fix incorrect conditional block documentation

### DIFF
--- a/doc/cabal-package.rst
+++ b/doc/cabal-package.rst
@@ -2568,7 +2568,7 @@ Configuration Flags
 Conditional Blocks
 ^^^^^^^^^^^^^^^^^^
 
-Conditional blocks may appear anywhere inside a library or executable
+Conditional blocks may appear anywhere inside a component or common
 section. They have to follow rather strict formatting rules. Conditional
 blocks must always be of the shape
 


### PR DESCRIPTION
**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

