### PR TITLE
(partially) fix issue #6888, source-repository-package branch failure 

### DIFF
--- a/cabal-install/src/Distribution/Client/VCS.hs
+++ b/cabal-install/src/Distribution/Client/VCS.hs
@@ -521,8 +521,12 @@ vcsGit =
               Nothing -> []
               Just peerLocalDir -> ["--reference", peerLocalDir]
             ++ verboseArg
+            ++ branchArg
           where
             loc = srpLocation
+            branchArg = case srpBranch of
+              Just b -> ["--branch", b]
+              Nothing -> []
         resetArgs = "reset" : verboseArg ++ ["--hard", resetTarget, "--"]
         resetTarget = fromMaybe "HEAD" (srpBranch `mplus` srpTag)
         verboseArg = ["--quiet" | verbosity < Verbosity.normal]


### PR DESCRIPTION
As the title of the issue states, this (partially) fixes issue #6888 ; i.e.  if a user specifies a git branch in the 'source-repository-package' stanza in cabal.project cabal actually properly checks out that branch. 

The core of the issue is that (1) the (existing) implementation always uses 'vcsSyncRepos' to check out a (git) repository rather than 'vcsCloneRepo', and (2) vcsSyncRepos did not specify the '--branch' field to clone. (Afterwards it also runs git reset --hard <name of the specified branch>', but that fails since it did not clone the right initial branch.

This PR provides a somewhat minimalistic approach to solving this issue: i.e. it now also provides the branch to clone in the implementation of vcsSyncRepos in vcsGit, which fixes the issue.

I do think this reveals some opportunity for more refactoring though. In particular it seems that 

-  vcsCloneRepo is not actually used anywhere in the project !? 
- I only added the --branch stuff to the implementation of vcsGit; I would think that the other vcs systems (hg, bazaar etc) probably also need some sort of --branch argument in order to work correctly. Just glancing at the code there I'm guessing that does not work either. 

Not entirely sure what to do about these two remaining parts. I can't easily figure out/test what the right --branch invocations would be for the other VCSes. If desired, ripping out vcsCloneRepo, is probably done best in a separate PR. I'm happy to hear input about this. (Afterwards I can write the changelog entry).


**
Include the following checklist in your PR:

* [X ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
