### PR TITLE
Do not ask overwrite questions for empty dirs

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -276,10 +276,16 @@ genTestTarget flags pkgs = initializeTestSuitePrompt flags >>= go
 
 overwritePrompt :: Interactive m => InitFlags -> m Bool
 overwritePrompt flags = do
-  isOverwrite <- getOverwrite flags
-  promptYesNo
-    "Do you wish to overwrite existing files (backups will be created) (y/n)"
-    (DefaultPrompt isOverwrite)
+  con <- getPackageDir flags >>= listDirectory
+
+  -- Do not ask useless overwrite question if directory is empty.
+  if null con
+    then return False
+    else do
+      isOverwrite <- getOverwrite flags
+      promptYesNo
+        "Do you wish to overwrite existing files (backups will be created) (y/n)"
+        (DefaultPrompt isOverwrite)
 
 cabalVersionPrompt :: Interactive m => InitFlags -> m CabalSpecVersion
 cabalVersionPrompt flags = getCabalVersion flags $ do

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Golden.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Golden.hs
@@ -372,14 +372,14 @@ pkgArgs =
 
 testProjArgs :: String -> NonEmpty String
 testProjArgs comments =
-  fromList ["4", "n", "foo-package"]
+  fromList ["4", "test-dir", "[]", "foo-package"]
     <> pkgArgs
     <> fromList (NEL.drop 1 testArgs)
     <> fromList [comments]
 
 libProjArgs :: String -> NonEmpty String
 libProjArgs comments =
-  fromList ["1", "n", "foo-package"]
+  fromList ["1", "test-dir", "[]", "foo-package"]
     <> pkgArgs
     <> libArgs
     <> testArgs
@@ -387,7 +387,7 @@ libProjArgs comments =
 
 fullProjArgs :: String -> NonEmpty String
 fullProjArgs comments =
-  fromList ["3", "n", "foo-package"]
+  fromList ["3", "test-dir", "[]", "foo-package"]
     <> pkgArgs
     <> libArgs
     <> exeArgs

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
@@ -76,7 +76,7 @@ createProjectTest pkgIx srcDb =
                     , dependencies = Flag []
                     }
 
-            case (_runPrompt $ createProject silent pkgIx srcDb dummyFlags') (fromList ["n", "3", "quxTest/Main.hs"]) of
+            case (_runPrompt $ createProject silent pkgIx srcDb dummyFlags') (fromList ["[]", "3", "quxTest/Main.hs"]) of
               Right (ProjectSettings opts desc (Just lib) (Just exe) (Just test), _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -134,8 +134,9 @@ createProjectTest pkgIx srcDb =
                   fromList
                     -- package type
                     [ "3"
-                    , -- overwrite
-                      "n"
+                    , -- overwrite (not asked, pristine folder)
+                      "test-package-dir"
+                    , "[]"
                     , -- package dir
                       "test-package"
                     , -- package description
@@ -240,8 +241,9 @@ createProjectTest pkgIx srcDb =
                   fromList
                     -- package type
                     [ "1"
-                    , -- overwrite
-                      "n"
+                    , -- overwrite (not asked, pristine folder)
+                      "test-package-dir"
+                    , "[]"
                     , -- package dir
                       "test-package"
                     , -- package description
@@ -331,8 +333,9 @@ createProjectTest pkgIx srcDb =
                   fromList
                     -- package type
                     [ "4"
-                    , -- overwrite
-                      "n"
+                    , -- overwrite (not asked, pristine folder)
+                      "test-package-dir"
+                    , "[]"
                     , -- package dir
                       "test-package"
                     , -- package description
@@ -411,8 +414,9 @@ createProjectTest pkgIx srcDb =
                   fromList
                     -- package type
                     [ "3"
-                    , -- overwrite
-                      "n"
+                    , -- overwrite (not asked, pristine folder)
+                      "test-package-dir"
+                    , "[]"
                     , -- package dir
                       "test-package"
                     , -- package description
@@ -503,8 +507,9 @@ createProjectTest pkgIx srcDb =
                   fromList
                     -- package type
                     [ "1"
-                    , -- overwrite
-                      "n"
+                    , -- overwrite (not asked, pristine folder)
+                      "test-package-dir"
+                    , "[]"
                     , -- package dir
                       "test-package"
                     , -- package description
@@ -580,8 +585,9 @@ createProjectTest pkgIx srcDb =
                   fromList
                     -- package type
                     [ "1"
-                    , -- overwrite
-                      "n"
+                    , -- overwrite (not asked, pristine folder)
+                      "test-package-dir"
+                    , "[]"
                     , -- package dir
                       "test-package"
                     , -- package description
@@ -664,8 +670,9 @@ createProjectTest pkgIx srcDb =
                   fromList
                     -- package type
                     [ "2"
-                    , -- overwrite
-                      "n"
+                    , -- overwrite (not asked, pristine folder)
+                      "test-package-dir"
+                    , "[]"
                     , -- package dir
                       "test-package"
                     , -- package description

--- a/cabal-testsuite/PackageTests/Init/init-interactive-empty-folder.out
+++ b/cabal-testsuite/PackageTests/Init/init-interactive-empty-folder.out
@@ -1,0 +1,1 @@
+# cabal init

--- a/cabal-testsuite/PackageTests/Init/init-interactive-empty-folder.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-interactive-empty-folder.test.hs
@@ -1,0 +1,10 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+  tmpDir <- testTmpDir <$> getTestEnv
+  withDirectory tmpDir $ do
+    res <- cabalWithStdin "init"
+                          ["-i"]
+                          (replicate 20 '\n') -- Default all the way down.
+    assertOutputDoesNotContain "backups will be created" res
+

--- a/changelog.d/pr-9155
+++ b/changelog.d/pr-9155
@@ -1,0 +1,4 @@
+synopsis: Do not ask overwrite permissions on blank project
+packages: cabal-install
+prs: #9155
+issues: #9150


### PR DESCRIPTION
Closes #9150, blank projects need not to ask permission to overwrite files.

---

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

Bonus points for added automated tests!

---

**Q&A instructions**

1. create an empty folder, `cd` into it
2. run `cabal init -i`,
3. with old cabal, you will see this string as second question `Do you wish to overwrite existing files (backups will be created) (y/n)? [default: n]`.
4. with new cabal, you will not see the question (since it is useless, as we are in an empty folder).

