### PR TITLE
Fix #701: Add `licenseFiles` to `InstalledPackageInfo` 

### DIFF
--- a/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
@@ -154,12 +154,11 @@ packageDescriptionFieldGrammar =
 
     licenseFilesGrammar =
       (++)
-        -- TODO: neither field is deprecated
-        -- should we pretty print license-file if there's single license file
-        -- and license-files when more
-        <$> monoidalFieldAla "license-file" CompatLicenseFile L.licenseFiles
+        -- Always pretty print license-files
+        <$> ( monoidalFieldAla "license-file" CompatLicenseFile L.licenseFiles
+                ^^^ hiddenField
+            )
         <*> monoidalFieldAla "license-files" (alaList FSep) L.licenseFiles
-          ^^^ hiddenField
 
 -------------------------------------------------------------------------------
 -- Library

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
@@ -52,6 +52,7 @@ data InstalledPackageInfo = InstalledPackageInfo
     instantiatedWith :: [(ModuleName, OpenModule)]
   , compatPackageKey :: String
   , license :: Either SPDX.License License
+  , licenseFiles :: [FilePath]
   , copyright :: !ShortText
   , maintainer :: !ShortText
   , author :: !ShortText
@@ -138,6 +139,7 @@ emptyInstalledPackageInfo =
     , instantiatedWith = []
     , compatPackageKey = ""
     , license = Left SPDX.NONE
+    , licenseFiles = []
     , copyright = ""
     , maintainer = ""
     , author = ""

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
@@ -88,6 +88,7 @@ ipiFieldGrammar =
     <@> optionalFieldDefAla "instantiated-with" InstWith L.instantiatedWith []
     <@> optionalFieldDefAla "key" CompatPackageKey L.compatPackageKey ""
     <@> optionalFieldDefAla "license" SpecLicenseLenient L.license (Left SPDX.NONE)
+    <@> monoidalFieldAla "license-files" (alaList' FSep FilePathNT) L.licenseFiles
     <@> freeTextFieldDefST "copyright" L.copyright
     <@> freeTextFieldDefST "maintainer" L.maintainer
     <@> freeTextFieldDefST "author" L.author

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/Lens.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/Lens.hs
@@ -47,6 +47,10 @@ license :: Lens' InstalledPackageInfo (Either SPDX.License License)
 license f s = fmap (\x -> s{T.license = x}) (f (T.license s))
 {-# INLINE license #-}
 
+licenseFiles :: Lens' InstalledPackageInfo [FilePath]
+licenseFiles f s = fmap (\x -> s{T.licenseFiles = x}) (f (T.licenseFiles s))
+{-# INLINE licenseFiles #-}
+
 copyright :: Lens' InstalledPackageInfo ShortText
 copyright f s = fmap (\x -> s{T.copyright = x}) (f (T.copyright s))
 {-# INLINE copyright #-}

--- a/Cabal-tests/tests/ParserTests/ipi/Includes2.cabal
+++ b/Cabal-tests/tests/ParserTests/ipi/Includes2.cabal
@@ -6,6 +6,7 @@ package-name: Includes2
 lib-name: mylib
 key: Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n
 license: BSD3
+license-files: LICENSE
 maintainer: ezyang@cs.stanford.edu
 author: Edward Z. Yang
 exposed: False

--- a/Cabal-tests/tests/ParserTests/ipi/Includes2.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/Includes2.expr
@@ -25,6 +25,7 @@ InstalledPackageInfo {
   compatPackageKey =
   "Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n",
   license = Right BSD3,
+  licenseFiles = ["LICENSE"],
   copyright = "",
   maintainer =
   "ezyang@cs.stanford.edu",

--- a/Cabal-tests/tests/ParserTests/ipi/Includes2.format
+++ b/Cabal-tests/tests/ParserTests/ipi/Includes2.format
@@ -6,6 +6,7 @@ id:                   Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n
 instantiated-with:    Database=Includes2-0.1.0.0-inplace-mysql:Database.MySQL
 key:                  Includes2-0.1.0.0-inplace-mylib+3gY9SyjX86dBypHcOaev1n
 license:              BSD3
+license-files:        LICENSE
 maintainer:           ezyang@cs.stanford.edu
 author:               Edward Z. Yang
 abi:                  inplace

--- a/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.cabal
+++ b/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.cabal
@@ -3,6 +3,7 @@ version: 0.1.0.0
 id: internal-preprocessor-test-0.1.0.0
 key: internal-preprocessor-test-0.1.0.0
 license: GPL-3
+license-files: LICENSE
 maintainer: mikhail.glushenkov@gmail.com
 synopsis: Internal custom preprocessor example.
 description:

--- a/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.expr
@@ -17,6 +17,7 @@ InstalledPackageInfo {
   "internal-preprocessor-test-0.1.0.0",
   license = Right
     (GPL (Just (mkVersion [3]))),
+  licenseFiles = ["LICENSE"],
   copyright = "",
   maintainer =
   "mikhail.glushenkov@gmail.com",

--- a/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.format
+++ b/Cabal-tests/tests/ParserTests/ipi/internal-preprocessor-test.format
@@ -4,6 +4,7 @@ visibility:         public
 id:                 internal-preprocessor-test-0.1.0.0
 key:                internal-preprocessor-test-0.1.0.0
 license:            GPL-3
+license-files:      LICENSE
 maintainer:         mikhail.glushenkov@gmail.com
 author:             Mikhail Glushenkov
 synopsis:           Internal custom preprocessor example.

--- a/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.cabal
+++ b/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.cabal
@@ -3,6 +3,7 @@ version: 0.5.2.0
 id: transformers-0.5.2.0
 key: transformers-0.5.2.0
 license: BSD3
+license-files: LICENSE
 maintainer: Ross Paterson <R.Paterson@city.ac.uk>
 synopsis: Concrete functor and monad transformers
 description:

--- a/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.expr
@@ -16,6 +16,7 @@ InstalledPackageInfo {
   compatPackageKey =
   "transformers-0.5.2.0",
   license = Right BSD3,
+  licenseFiles = ["LICENSE"],
   copyright = "",
   maintainer =
   "Ross Paterson <R.Paterson@city.ac.uk>",

--- a/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.format
+++ b/Cabal-tests/tests/ParserTests/ipi/issue-2276-ghc-9885.format
@@ -4,6 +4,7 @@ visibility:           public
 id:                   transformers-0.5.2.0
 key:                  transformers-0.5.2.0
 license:              BSD3
+license-files:        LICENSE
 maintainer:           Ross Paterson <R.Paterson@city.ac.uk>
 author:               Andy Gill, Ross Paterson
 synopsis:             Concrete functor and monad transformers

--- a/Cabal-tests/tests/ParserTests/ipi/transformers.cabal
+++ b/Cabal-tests/tests/ParserTests/ipi/transformers.cabal
@@ -3,6 +3,7 @@ version: 0.5.2.0
 id: transformers-0.5.2.0
 key: transformers-0.5.2.0
 license: BSD3
+license-files: LICENSE
 maintainer: Ross Paterson <R.Paterson@city.ac.uk>
 synopsis: Concrete functor and monad transformers
 description:

--- a/Cabal-tests/tests/ParserTests/ipi/transformers.expr
+++ b/Cabal-tests/tests/ParserTests/ipi/transformers.expr
@@ -16,6 +16,7 @@ InstalledPackageInfo {
   compatPackageKey =
   "transformers-0.5.2.0",
   license = Right BSD3,
+  licenseFiles = ["LICENSE"],
   copyright = "",
   maintainer =
   "Ross Paterson <R.Paterson@city.ac.uk>",

--- a/Cabal-tests/tests/ParserTests/ipi/transformers.format
+++ b/Cabal-tests/tests/ParserTests/ipi/transformers.format
@@ -4,6 +4,7 @@ visibility:           public
 id:                   transformers-0.5.2.0
 key:                  transformers-0.5.2.0
 license:              BSD3
+license-files:        LICENSE
 maintainer:           Ross Paterson <R.Paterson@city.ac.uk>
 author:               Andy Gill, Ross Paterson
 synopsis:             Concrete functor and monad transformers

--- a/Cabal-tests/tests/ParserTests/regressions/Octree-0.5.format
+++ b/Cabal-tests/tests/ParserTests/regressions/Octree-0.5.format
@@ -3,7 +3,7 @@ cabal-version: >=1.8
 name:          Octree
 version:       0.5
 license:       BSD3
-license-file:  LICENSE
+license-files: LICENSE
 copyright:     Copyright by Michal J. Gajda '2012
 maintainer:    mjgajda@googlemail.com
 author:        Michal J. Gajda

--- a/Cabal-tests/tests/ParserTests/regressions/generics-sop.format
+++ b/Cabal-tests/tests/ParserTests/regressions/generics-sop.format
@@ -2,7 +2,7 @@ cabal-version:      >=1.10
 name:               generics-sop
 version:            0.3.1.0
 license:            BSD3
-license-file:       LICENSE
+license-files:      LICENSE
 maintainer:         andres@well-typed.com
 author:
     Edsko de Vries <edsko@well-typed.com>, Andres Löh <andres@well-typed.com>

--- a/Cabal-tests/tests/ParserTests/regressions/jaeger-flamegraph.format
+++ b/Cabal-tests/tests/ParserTests/regressions/jaeger-flamegraph.format
@@ -2,7 +2,7 @@ cabal-version: 2.2
 name:          jaeger-flamegraph
 version:       1.0.0
 license:       BSD-3-Clause
-license-file:  LICENSE
+license-files: LICENSE
 copyright:     (c) 2018 Symbiont.io
 maintainer:    Sam Halliday
 author:        Sam Halliday

--- a/Cabal-tests/tests/ParserTests/regressions/libpq1.format
+++ b/Cabal-tests/tests/ParserTests/regressions/libpq1.format
@@ -2,7 +2,7 @@ cabal-version:      >=1.8
 name:               postgresql-libpq
 version:            0.9.4.2
 license:            BSD3
-license-file:       LICENSE
+license-files:      LICENSE
 copyright:
     (c) 2010 Grant Monroe
     (c) 2011 Leon P Smith

--- a/Cabal-tests/tests/ParserTests/regressions/libpq2.format
+++ b/Cabal-tests/tests/ParserTests/regressions/libpq2.format
@@ -2,7 +2,7 @@ cabal-version:      3.0
 name:               postgresql-libpq
 version:            0.9.4.2
 license:            BSD-3-Clause
-license-file:       LICENSE
+license-files:      LICENSE
 copyright:
     (c) 2010 Grant Monroe
     (c) 2011 Leon P Smith

--- a/Cabal-tests/tests/ParserTests/regressions/monad-param.format
+++ b/Cabal-tests/tests/ParserTests/regressions/monad-param.format
@@ -1,21 +1,21 @@
 monad-param.cabal:19:1: Tabs used as indentation at 19:1, 20:1
-name:         monad-param
-version:      0.0.1
-license:      BSD3
-license-file: LICENSE
-copyright:    Copyright (C) 2006-2007, Edward Kmett
-maintainer:   Edward Kmett <ekmett@gmail.com>
-author:       Edward Kmett <ekmett@gmail.com>
-stability:    alpha
+name:          monad-param
+version:       0.0.1
+license:       BSD3
+license-files: LICENSE
+copyright:     Copyright (C) 2006-2007, Edward Kmett
+maintainer:    Edward Kmett <ekmett@gmail.com>
+author:        Edward Kmett <ekmett@gmail.com>
+stability:     alpha
 homepage:
     http://comonad.com/haskell/monad-param/dist/doc/html/Control-Monad-Parameterized.html
 
-package-url:  http://comonad.com/haskell/monad-param
-synopsis:     Parameterized monads
+package-url:   http://comonad.com/haskell/monad-param
+synopsis:      Parameterized monads
 description:
     Implements parameterized monads by overloading the monad sugar with more liberal types.
 
-category:     Control
+category:      Control
 
 library
     exposed-modules: Control.Monad.Parameterized

--- a/Cabal-tests/tests/ParserTests/regressions/shake.format
+++ b/Cabal-tests/tests/ParserTests/regressions/shake.format
@@ -2,7 +2,7 @@ cabal-version:      1.18
 name:               shake
 version:            0.15.11
 license:            BSD3
-license-file:       LICENSE
+license-files:      LICENSE
 copyright:          Neil Mitchell 2011-2017
 maintainer:         Neil Mitchell <ndmitchell@gmail.com>
 author:             Neil Mitchell <ndmitchell@gmail.com>

--- a/Cabal-tests/tests/ParserTests/regressions/th-lift-instances.format
+++ b/Cabal-tests/tests/ParserTests/regressions/th-lift-instances.format
@@ -3,7 +3,7 @@ cabal-version:      >=1.10
 name:               th-lift-instances
 version:            0.1.4
 license:            BSD3
-license-file:       LICENSE
+license-files:      LICENSE
 copyright:          Copyright (C) 2013-2014 Benno Fünfstück
 maintainer:         Benno Fünfstück <benno.fuenfstueck@gmail.com>
 author:             Benno Fünfstück

--- a/Cabal-tests/tests/ParserTests/regressions/wl-pprint-indef.format
+++ b/Cabal-tests/tests/ParserTests/regressions/wl-pprint-indef.format
@@ -5,7 +5,7 @@ cabal-version: >=1.6
 name:          wl-pprint-indef
 version:       1.2
 license:       BSD3
-license-file:  LICENSE
+license-files: LICENSE
 maintainer:    Noam Lewis <jones.noamle@gmail.com>
 author:        Daan Leijen
 synopsis:      The Wadler/Leijen Pretty Printer

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -29,7 +29,7 @@ tests = testGroup "Distribution.Utils.Structured"
     , testCase "GenericPackageDescription" $
       md5Check (Proxy :: Proxy GenericPackageDescription) 0xedd391339de1201511636bbb563fa5db
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0x40253e3699453643336bdc7911717af0
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0x70da7ec48f751a73d4958e5fc0bbd25e
 #endif
     ]
 

--- a/Cabal/src/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/src/Distribution/Simple/BuildPaths.hs
@@ -20,6 +20,7 @@ module Distribution.Simple.BuildPaths
   , haddockDirName
   , hscolourPref
   , haddockPref
+  , licenseFilePref
   , autogenPackageModulesDir
   , autogenComponentModulesDir
   , autogenPathsModuleName
@@ -89,6 +90,9 @@ haddockDirName ForHackage = (++ "-docs") . prettyShow . packageId
 haddockPref :: HaddockTarget -> FilePath -> PackageDescription -> FilePath
 haddockPref haddockTarget distPref pkg_descr =
   distPref </> "doc" </> "html" </> haddockDirName haddockTarget pkg_descr
+
+licenseFilePref :: FilePath -> FilePath -> FilePath
+licenseFilePref docPref = (docPref </>)
 
 -- | The directory in which we put auto-generated modules for EVERY
 -- component in the package.

--- a/Cabal/src/Distribution/Simple/Install.hs
+++ b/Cabal/src/Distribution/Simple/Install.hs
@@ -31,7 +31,11 @@ import Distribution.Types.UnqualComponentName
 
 import Distribution.Package
 import Distribution.PackageDescription
-import Distribution.Simple.BuildPaths (haddockName, haddockPref)
+import Distribution.Simple.BuildPaths
+  ( haddockName
+  , haddockPref
+  , licenseFilePref
+  )
 import Distribution.Simple.BuildTarget
 import Distribution.Simple.Compiler
   ( CompilerFlavor (..)
@@ -74,7 +78,6 @@ import System.Directory
 import System.FilePath
   ( isRelative
   , takeDirectory
-  , takeFileName
   , (</>)
   )
 
@@ -182,7 +185,7 @@ copyPackage verbosity pkg_descr lbi distPref copydest = do
     for_ lfiles $ \lfile' -> do
       let lfile :: FilePath
           lfile = getSymbolicPath lfile'
-      installOrdinaryFile verbosity lfile (docPref </> takeFileName lfile)
+      installOrdinaryFile verbosity lfile (licenseFilePref docPref lfile)
 
 -- | Copy files associated with a component.
 copyComponent

--- a/Cabal/src/Distribution/Simple/Register.hs
+++ b/Cabal/src/Distribution/Simple/Register.hs
@@ -79,6 +79,7 @@ import Distribution.Simple.Setup.Register
 import Distribution.Simple.Utils
 import Distribution.System
 import Distribution.Utils.MapAccum
+import Distribution.Utils.Path
 import Distribution.Verbosity as Verbosity
 import Distribution.Version
 
@@ -511,6 +512,9 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
         if ghc84
           then Left $ either id licenseToSPDX $ licenseRaw pkg
           else Right $ either licenseFromSPDX id $ licenseRaw pkg
+    , IPI.licenseFiles =
+        let doc = docdir installDirs
+         in map ((doc </>) . getSymbolicPath) $ licenseFiles pkg
     , IPI.copyright = copyright pkg
     , IPI.maintainer = maintainer pkg
     , IPI.author = author pkg

--- a/Cabal/src/Distribution/Simple/Register.hs
+++ b/Cabal/src/Distribution/Simple/Register.hs
@@ -512,9 +512,7 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
         if ghc84
           then Left $ either id licenseToSPDX $ licenseRaw pkg
           else Right $ either licenseFromSPDX id $ licenseRaw pkg
-    , IPI.licenseFiles =
-        let doc = docdir installDirs
-         in map ((doc </>) . getSymbolicPath) $ licenseFiles pkg
+    , IPI.licenseFiles = licenseFilePref (docdir installDirs) . getSymbolicPath <$> licenseFiles pkg
     , IPI.copyright = copyright pkg
     , IPI.maintainer = maintainer pkg
     , IPI.author = author pkg

--- a/changelog.d/pr-9172
+++ b/changelog.d/pr-9172
@@ -1,0 +1,11 @@
+synopsis: Add `licenseFiles` to `InstalledPackageInfo`
+packages: Cabal-syntax Cabal
+prs: #9172
+issues: #701 #9184
+
+description: {
+
+- A new field `licenseFiles` is added to `InstalledPackageInfo` to track their locations.
+- The field `licenseFiles` is pretty printed as `license-files` canonically.
+
+}


### PR DESCRIPTION
This PR address the issue #701 and #9184. A field `licenseFile` (singular) should have been there in `InstalledPackageInfo`, `IPI` for short) as described in [Section 5.9.9](https://downloads.haskell.org/ghc/latest/docs/users_guide/packages.html#installedpackageinfo-a-package-specification) the GHC documentation, but it is not. 

Thus, this PR adds a field `license-files` for multiple license files and changes the pretty printer of `PackageDescription` to print the field `license-files` which was previously hidden. 

Rationale:
`cabal` has supported the field `licenseFiles` for multiple license files and some [packages](https://hackage.haskell.org/package/resolv) have adopted this form, so it makes sense to support `licenseFiles` in `IPI` as well. Considering that `IPI` has not yet supported the singular form of `licenseFiles` (i.e. no backward compatibility is needed), I suggest only the field name `license-files` should be used to simplify pretty printer and parsing.
 
---

**Template Α: This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

Bonus points for added automated tests!
