### PR TITLE
Haddock recompilation avoidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ bench.html
 # Emacs
 .projectile
 
+# direnv
+.envrc
+
 ## Release Scripts
 
 # ignore the downloaded binary files

--- a/Cabal/src/Distribution/Simple/Setup/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Haddock.hs
@@ -115,7 +115,6 @@ data HaddockFlags = HaddockFlags
   , haddockBaseUrl :: Flag String
   , haddockResourcesDir :: Flag String
   , haddockOutputDir :: Flag FilePath
-  , haddockVersionCPP :: Flag Bool
   }
   deriving (Show, Generic, Typeable)
 
@@ -171,7 +170,6 @@ defaultHaddockFlags =
     , haddockBaseUrl = NoFlag
     , haddockResourcesDir = NoFlag
     , haddockOutputDir = NoFlag
-    , haddockVersionCPP = Flag False
     }
 
 haddockCommand :: CommandUI HaddockFlags
@@ -380,13 +378,6 @@ haddockOptions showOrParseArgs =
         haddockOutputDir
         (\v flags -> flags{haddockOutputDir = v})
         (reqArgFlag "DIR")
-    , option
-        ""
-        ["version-cpp"]
-        "Define the __HADDOCK_VERSION__ macro when invoking GHC through Haddock. This will likely trigger recompilation during documentation generation."
-        haddockVersionCPP
-        (\v flags -> flags{haddockVersionCPP = v})
-        trueArg
     ]
 
 emptyHaddockFlags :: HaddockFlags
@@ -451,7 +442,6 @@ data HaddockProjectFlags = HaddockProjectFlags
   , -- haddockBaseUrl is not supported, a fixed value is provided
     haddockProjectResourcesDir :: Flag String
   , haddockProjectOutputDir :: Flag FilePath
-  , haddockProjectVersionCPP :: Flag Bool
   }
   deriving (Show, Generic, Typeable)
 
@@ -477,7 +467,6 @@ defaultHaddockProjectFlags =
     , haddockProjectResourcesDir = NoFlag
     , haddockProjectOutputDir = NoFlag
     , haddockProjectInterfaces = NoFlag
-    , haddockProjectVersionCPP = Flag False
     }
 
 haddockProjectCommand :: CommandUI HaddockProjectFlags
@@ -631,13 +620,6 @@ haddockProjectOptions _showOrParseArgs =
       haddockProjectOutputDir
       (\v flags -> flags{haddockProjectOutputDir = v})
       (reqArgFlag "DIR")
-  , option
-      ""
-      ["version-cpp"]
-      "Define the __HADDOCK_VERSION__ macro when invoking GHC through Haddock. This will likely trigger recompilation during documentation generation."
-      haddockProjectVersionCPP
-      (\v flags -> flags{haddockProjectVersionCPP = v})
-      trueArg
   ]
 
 emptyHaddockProjectFlags :: HaddockProjectFlags

--- a/Cabal/src/Distribution/Simple/Setup/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Haddock.hs
@@ -113,8 +113,9 @@ data HaddockFlags = HaddockFlags
   , haddockIndex :: Flag PathTemplate
   , haddockKeepTempFiles :: Flag Bool
   , haddockBaseUrl :: Flag String
-  , haddockLib :: Flag String
+  , haddockResourcesDir :: Flag String
   , haddockOutputDir :: Flag FilePath
+  , haddockVersionCPP :: Flag Bool
   }
   deriving (Show, Generic, Typeable)
 
@@ -168,8 +169,9 @@ defaultHaddockFlags =
     , haddockKeepTempFiles = Flag False
     , haddockIndex = NoFlag
     , haddockBaseUrl = NoFlag
-    , haddockLib = NoFlag
+    , haddockResourcesDir = NoFlag
     , haddockOutputDir = NoFlag
+    , haddockVersionCPP = Flag False
     }
 
 haddockCommand :: CommandUI HaddockFlags
@@ -366,10 +368,10 @@ haddockOptions showOrParseArgs =
         (reqArgFlag "URL")
     , option
         ""
-        ["lib"]
+        ["resources-dir"]
         "location of Haddocks static / auxiliary files"
-        haddockLib
-        (\v flags -> flags{haddockLib = v})
+        haddockResourcesDir
+        (\v flags -> flags{haddockResourcesDir = v})
         (reqArgFlag "DIR")
     , option
         ""
@@ -378,6 +380,13 @@ haddockOptions showOrParseArgs =
         haddockOutputDir
         (\v flags -> flags{haddockOutputDir = v})
         (reqArgFlag "DIR")
+    , option
+        ""
+        ["version-cpp"]
+        "Define the __HADDOCK_VERSION__ macro when invoking GHC through Haddock. This will likely trigger recompilation during documentation generation."
+        haddockVersionCPP
+        (\v flags -> flags{haddockVersionCPP = v})
+        trueArg
     ]
 
 emptyHaddockFlags :: HaddockFlags
@@ -440,8 +449,9 @@ data HaddockProjectFlags = HaddockProjectFlags
     haddockProjectKeepTempFiles :: Flag Bool
   , haddockProjectVerbosity :: Flag Verbosity
   , -- haddockBaseUrl is not supported, a fixed value is provided
-    haddockProjectLib :: Flag String
+    haddockProjectResourcesDir :: Flag String
   , haddockProjectOutputDir :: Flag FilePath
+  , haddockProjectVersionCPP :: Flag Bool
   }
   deriving (Show, Generic, Typeable)
 
@@ -464,9 +474,10 @@ defaultHaddockProjectFlags =
     , haddockProjectHscolourCss = NoFlag
     , haddockProjectKeepTempFiles = Flag False
     , haddockProjectVerbosity = Flag normal
-    , haddockProjectLib = NoFlag
+    , haddockProjectResourcesDir = NoFlag
     , haddockProjectOutputDir = NoFlag
     , haddockProjectInterfaces = NoFlag
+    , haddockProjectVersionCPP = Flag False
     }
 
 haddockProjectCommand :: CommandUI HaddockProjectFlags
@@ -608,10 +619,10 @@ haddockProjectOptions _showOrParseArgs =
       (\v flags -> flags{haddockProjectVerbosity = v})
   , option
       ""
-      ["lib"]
+      ["resources-dir"]
       "location of Haddocks static / auxiliary files"
-      haddockProjectLib
-      (\v flags -> flags{haddockProjectLib = v})
+      haddockProjectResourcesDir
+      (\v flags -> flags{haddockProjectResourcesDir = v})
       (reqArgFlag "DIR")
   , option
       ""
@@ -620,6 +631,13 @@ haddockProjectOptions _showOrParseArgs =
       haddockProjectOutputDir
       (\v flags -> flags{haddockProjectOutputDir = v})
       (reqArgFlag "DIR")
+  , option
+      ""
+      ["version-cpp"]
+      "Define the __HADDOCK_VERSION__ macro when invoking GHC through Haddock. This will likely trigger recompilation during documentation generation."
+      haddockProjectVersionCPP
+      (\v flags -> flags{haddockProjectVersionCPP = v})
+      trueArg
   ]
 
 emptyHaddockProjectFlags :: HaddockProjectFlags

--- a/Cabal/src/Distribution/Types/LocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/LocalBuildInfo.hs
@@ -57,6 +57,7 @@ module Distribution.Types.LocalBuildInfo
   , buildDir
   , buildDirPBD
   , setupFlagsBuildDir
+  , distPrefLBI
   , packageRoot
   , progPrefix
   , progSuffix
@@ -288,6 +289,9 @@ buildDirPBD (LBC.PackageBuildDescr{configFlags = cfg}) =
 
 setupFlagsBuildDir :: CommonSetupFlags -> SymbolicPath Pkg (Dir Build)
 setupFlagsBuildDir cfg = fromFlag (setupDistPref cfg) </> makeRelativePathEx "build"
+
+distPrefLBI :: LocalBuildInfo -> SymbolicPath Pkg (Dir Dist)
+distPrefLBI = fromFlag . setupDistPref . configCommonFlags . LBC.configFlags . LBC.packageBuildDescr . localBuildDescr
 
 -- | The (relative or absolute) path to the package root, based on
 --

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -148,8 +148,9 @@ haddockProjectAction flags _extraArgs globalFlags = do
                 then Flag (toPathTemplate "../doc-index.html")
                 else NoFlag
           , haddockKeepTempFiles = haddockProjectKeepTempFiles flags
-          , haddockLib = haddockProjectLib flags
+          , haddockResourcesDir = haddockProjectResourcesDir flags
           , haddockOutputDir = haddockProjectOutputDir flags
+          , haddockVersionCPP = haddockProjectVersionCPP flags
           }
       nixFlags =
         (commandDefaultFlags CmdHaddock.haddockCommand)

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -150,7 +150,6 @@ haddockProjectAction flags _extraArgs globalFlags = do
           , haddockKeepTempFiles = haddockProjectKeepTempFiles flags
           , haddockResourcesDir = haddockProjectResourcesDir flags
           , haddockOutputDir = haddockProjectOutputDir flags
-          , haddockVersionCPP = haddockProjectVersionCPP flags
           }
       nixFlags =
         (commandDefaultFlags CmdHaddock.haddockCommand)

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -632,7 +632,6 @@ instance Semigroup SavedConfig where
           , haddockBaseUrl = combine haddockBaseUrl
           , haddockResourcesDir = combine haddockResourcesDir
           , haddockOutputDir = combine haddockOutputDir
-          , haddockVersionCPP = combine haddockVersionCPP
           }
         where
           combine = combine' savedHaddockFlags

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -630,8 +630,9 @@ instance Semigroup SavedConfig where
           , haddockKeepTempFiles = combine haddockKeepTempFiles
           , haddockIndex = combine haddockIndex
           , haddockBaseUrl = combine haddockBaseUrl
-          , haddockLib = combine haddockLib
+          , haddockResourcesDir = combine haddockResourcesDir
           , haddockOutputDir = combine haddockOutputDir
+          , haddockVersionCPP = combine haddockVersionCPP
           }
         where
           combine = combine' savedHaddockFlags

--- a/cabal-install/src/Distribution/Client/PackageHash.hs
+++ b/cabal-install/src/Distribution/Client/PackageHash.hs
@@ -240,7 +240,6 @@ data PackageHashConfigInputs = PackageHashConfigInputs
   , pkgHashHaddockBaseUrl :: Maybe String
   , pkgHashHaddockResourcesDir :: Maybe String
   , pkgHashHaddockOutputDir :: Maybe FilePath
-  , pkgHashHaddockVersionCPP :: Bool
   --     TODO: [required eventually] pkgHashToolsVersions     ?
   --     TODO: [required eventually] pkgHashToolsExtraOptions ?
   }
@@ -350,7 +349,6 @@ renderPackageHashInputs
           , opt "haddock-base-url" Nothing (fromMaybe "") pkgHashHaddockBaseUrl
           , opt "haddock-resources-dir" Nothing (fromMaybe "") pkgHashHaddockResourcesDir
           , opt "haddock-output-dir" Nothing (fromMaybe "") pkgHashHaddockOutputDir
-          , opt "haddock-version-cpp" False prettyShow pkgHashHaddockVersionCPP
           ]
             ++ Map.foldrWithKey (\prog args acc -> opt (prog ++ "-options") [] unwords args : acc) [] pkgHashProgramArgs
     where

--- a/cabal-install/src/Distribution/Client/PackageHash.hs
+++ b/cabal-install/src/Distribution/Client/PackageHash.hs
@@ -238,8 +238,9 @@ data PackageHashConfigInputs = PackageHashConfigInputs
   , pkgHashHaddockContents :: Maybe PathTemplate
   , pkgHashHaddockIndex :: Maybe PathTemplate
   , pkgHashHaddockBaseUrl :: Maybe String
-  , pkgHashHaddockLib :: Maybe String
+  , pkgHashHaddockResourcesDir :: Maybe String
   , pkgHashHaddockOutputDir :: Maybe FilePath
+  , pkgHashHaddockVersionCPP :: Bool
   --     TODO: [required eventually] pkgHashToolsVersions     ?
   --     TODO: [required eventually] pkgHashToolsExtraOptions ?
   }
@@ -347,8 +348,9 @@ renderPackageHashInputs
           , opt "haddock-contents-location" Nothing (maybe "" fromPathTemplate) pkgHashHaddockContents
           , opt "haddock-index-location" Nothing (maybe "" fromPathTemplate) pkgHashHaddockIndex
           , opt "haddock-base-url" Nothing (fromMaybe "") pkgHashHaddockBaseUrl
-          , opt "haddock-lib" Nothing (fromMaybe "") pkgHashHaddockLib
+          , opt "haddock-resources-dir" Nothing (fromMaybe "") pkgHashHaddockResourcesDir
           , opt "haddock-output-dir" Nothing (fromMaybe "") pkgHashHaddockOutputDir
+          , opt "haddock-version-cpp" False prettyShow pkgHashHaddockVersionCPP
           ]
             ++ Map.foldrWithKey (\prog args acc -> opt (prog ++ "-options") [] unwords args : acc) [] pkgHashProgramArgs
     where

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -823,7 +823,6 @@ convertLegacyPerPackageFlags
         , haddockBaseUrl = packageConfigHaddockBaseUrl
         , haddockResourcesDir = packageConfigHaddockResourcesDir
         , haddockOutputDir = packageConfigHaddockOutputDir
-        , haddockVersionCPP = packageConfigHaddockVersionCPP
         } = haddockFlags
 
       TestFlags
@@ -1221,7 +1220,6 @@ convertToLegacyPerPackageConfig PackageConfig{..} =
         , haddockBaseUrl = packageConfigHaddockBaseUrl
         , haddockResourcesDir = packageConfigHaddockResourcesDir
         , haddockOutputDir = packageConfigHaddockOutputDir
-        , haddockVersionCPP = packageConfigHaddockVersionCPP
         }
 
     testFlags =
@@ -1623,7 +1621,6 @@ legacyPackageConfigFieldDescrs =
             , "base-url"
             , "resources-dir"
             , "output-dir"
-            , "version-cpp"
             ]
           . commandOptionsToFields
        )

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -821,8 +821,9 @@ convertLegacyPerPackageFlags
         , haddockContents = packageConfigHaddockContents
         , haddockIndex = packageConfigHaddockIndex
         , haddockBaseUrl = packageConfigHaddockBaseUrl
-        , haddockLib = packageConfigHaddockLib
+        , haddockResourcesDir = packageConfigHaddockResourcesDir
         , haddockOutputDir = packageConfigHaddockOutputDir
+        , haddockVersionCPP = packageConfigHaddockVersionCPP
         } = haddockFlags
 
       TestFlags
@@ -1218,8 +1219,9 @@ convertToLegacyPerPackageConfig PackageConfig{..} =
         , haddockKeepTempFiles = mempty
         , haddockIndex = packageConfigHaddockIndex
         , haddockBaseUrl = packageConfigHaddockBaseUrl
-        , haddockLib = packageConfigHaddockLib
+        , haddockResourcesDir = packageConfigHaddockResourcesDir
         , haddockOutputDir = packageConfigHaddockOutputDir
+        , haddockVersionCPP = packageConfigHaddockVersionCPP
         }
 
     testFlags =
@@ -1619,8 +1621,9 @@ legacyPackageConfigFieldDescrs =
             , "index-location"
             , "keep-temp-files"
             , "base-url"
-            , "lib"
+            , "resources-dir"
             , "output-dir"
+            , "version-cpp"
             ]
           . commandOptionsToFields
        )

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -305,8 +305,9 @@ data PackageConfig = PackageConfig
   , packageConfigHaddockContents :: Flag PathTemplate -- TODO: [required eventually] use this
   , packageConfigHaddockIndex :: Flag PathTemplate -- TODO: [required eventually] use this
   , packageConfigHaddockBaseUrl :: Flag String -- TODO: [required eventually] use this
-  , packageConfigHaddockLib :: Flag String -- TODO: [required eventually] use this
+  , packageConfigHaddockResourcesDir :: Flag String -- TODO: [required eventually] use this
   , packageConfigHaddockOutputDir :: Flag FilePath -- TODO: [required eventually] use this
+  , packageConfigHaddockVersionCPP :: Flag Bool -- TODO: [required eventually] use this
   , packageConfigHaddockForHackage :: Flag HaddockTarget
   , -- Test options
     packageConfigTestHumanLog :: Flag PathTemplate

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -307,7 +307,6 @@ data PackageConfig = PackageConfig
   , packageConfigHaddockBaseUrl :: Flag String -- TODO: [required eventually] use this
   , packageConfigHaddockResourcesDir :: Flag String -- TODO: [required eventually] use this
   , packageConfigHaddockOutputDir :: Flag FilePath -- TODO: [required eventually] use this
-  , packageConfigHaddockVersionCPP :: Flag Bool -- TODO: [required eventually] use this
   , packageConfigHaddockForHackage :: Flag HaddockTarget
   , -- Test options
     packageConfigTestHumanLog :: Flag PathTemplate

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -2280,7 +2280,6 @@ elaborateInstallPlan
             elabHaddockBaseUrl = perPkgOptionMaybe pkgid packageConfigHaddockBaseUrl
             elabHaddockResourcesDir = perPkgOptionMaybe pkgid packageConfigHaddockResourcesDir
             elabHaddockOutputDir = perPkgOptionMaybe pkgid packageConfigHaddockOutputDir
-            elabHaddockVersionCPP = perPkgOptionFlag pkgid False packageConfigHaddockVersionCPP
 
             elabTestMachineLog = perPkgOptionMaybe pkgid packageConfigTestMachineLog
             elabTestHumanLog = perPkgOptionMaybe pkgid packageConfigTestHumanLog
@@ -4148,7 +4147,6 @@ setupHsHaddockFlags
       , haddockBaseUrl = maybe mempty toFlag elabHaddockBaseUrl
       , haddockResourcesDir = maybe mempty toFlag elabHaddockResourcesDir
       , haddockOutputDir = maybe mempty toFlag elabHaddockOutputDir
-      , haddockVersionCPP = maybe mempty toFlag elabHaddockVersionCPP
       }
 
 setupHsHaddockArgs :: ElaboratedConfiguredPackage -> [String]
@@ -4307,7 +4305,6 @@ packageHashConfigInputs shared@ElaboratedSharedConfig{..} pkg =
     , pkgHashHaddockBaseUrl = elabHaddockBaseUrl
     , pkgHashHaddockResourcesDir = elabHaddockResourcesDir
     , pkgHashHaddockOutputDir = elabHaddockOutputDir
-    , pkgHashHaddockVersionCPP = elabHaddockVersionCPP
     }
   where
     ElaboratedConfiguredPackage{..} = normaliseConfiguredPackage shared pkg

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -300,8 +300,9 @@ data ElaboratedConfiguredPackage = ElaboratedConfiguredPackage
   , elabHaddockContents :: Maybe PathTemplate
   , elabHaddockIndex :: Maybe PathTemplate
   , elabHaddockBaseUrl :: Maybe String
-  , elabHaddockLib :: Maybe String
+  , elabHaddockResourcesDir :: Maybe String
   , elabHaddockOutputDir :: Maybe FilePath
+  , elabHaddockVersionCPP :: Bool
   , elabTestMachineLog :: Maybe PathTemplate
   , elabTestHumanLog :: Maybe PathTemplate
   , elabTestShowDetails :: Maybe TestShowDetails

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -302,7 +302,6 @@ data ElaboratedConfiguredPackage = ElaboratedConfiguredPackage
   , elabHaddockBaseUrl :: Maybe String
   , elabHaddockResourcesDir :: Maybe String
   , elabHaddockOutputDir :: Maybe FilePath
-  , elabHaddockVersionCPP :: Bool
   , elabTestMachineLog :: Maybe PathTemplate
   , elabTestHumanLog :: Maybe PathTemplate
   , elabTestShowDetails :: Maybe TestShowDetails

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -2435,8 +2435,9 @@ haddockOptions showOrParseArgs =
              , "use-index"
              , "for-hackage"
              , "base-url"
-             , "lib"
+             , "resources-dir"
              , "output-dir"
+             , "version-cpp"
              ]
   ]
 

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -2437,7 +2437,6 @@ haddockOptions showOrParseArgs =
              , "base-url"
              , "resources-dir"
              , "output-dir"
-             , "version-cpp"
              ]
   ]
 

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -2101,7 +2101,6 @@ testConfigOptionComments = do
   "  -- base-url" @=? findLineWith True "base-url" defaultConfigFile
   "  -- resources-dir" @=? findLineWith True "resources-dir" defaultConfigFile
   "  -- output-dir" @=? findLineWith True "output-dir" defaultConfigFile
-  "  -- version-cpp" @=? findLineWith True "version-cpp" defaultConfigFile
 
   "  -- interactive" @=? findLineWith True "interactive" defaultConfigFile
   "  -- quiet" @=? findLineWith True "quiet" defaultConfigFile

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -2099,7 +2099,9 @@ testConfigOptionComments = do
   "  -- contents-location" @=? findLineWith True "contents-location" defaultConfigFile
   "  -- index-location" @=? findLineWith True "index-location" defaultConfigFile
   "  -- base-url" @=? findLineWith True "base-url" defaultConfigFile
+  "  -- resources-dir" @=? findLineWith True "resources-dir" defaultConfigFile
   "  -- output-dir" @=? findLineWith True "output-dir" defaultConfigFile
+  "  -- version-cpp" @=? findLineWith True "version-cpp" defaultConfigFile
 
   "  -- interactive" @=? findLineWith True "interactive" defaultConfigFile
   "  -- quiet" @=? findLineWith True "quiet" defaultConfigFile

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -726,6 +726,7 @@ instance Arbitrary PackageConfig where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
       <*> arbitraryFlag arbitraryShortToken
       <*> arbitrary
       <*> shortListOf 5 arbitrary
@@ -791,8 +792,9 @@ instance Arbitrary PackageConfig where
       , packageConfigHaddockForHackage = x41
       , packageConfigHaddockIndex = x54
       , packageConfigHaddockBaseUrl = x55
-      , packageConfigHaddockLib = x56
+      , packageConfigHaddockResourcesDir = x56
       , packageConfigHaddockOutputDir = x57
+      , packageConfigHaddockVersionCPP = x58
       , packageConfigTestHumanLog = x44
       , packageConfigTestMachineLog = x45
       , packageConfigTestShowDetails = x46
@@ -854,8 +856,9 @@ instance Arbitrary PackageConfig where
         , packageConfigHaddockForHackage = x41'
         , packageConfigHaddockIndex = x54'
         , packageConfigHaddockBaseUrl = x55'
-        , packageConfigHaddockLib = x56'
+        , packageConfigHaddockResourcesDir = x56'
         , packageConfigHaddockOutputDir = x57'
+        , packageConfigHaddockVersionCPP = x58'
         , packageConfigTestHumanLog = x44'
         , packageConfigTestMachineLog = x45'
         , packageConfigTestShowDetails = x46'
@@ -878,6 +881,7 @@ instance Arbitrary PackageConfig where
               , (x44', x45', x46', x47', x48', x49', x51', x52', x54', x55')
               , x56'
               , x57'
+              , x58'
               )
           ) <-
           shrink
@@ -903,6 +907,7 @@ instance Arbitrary PackageConfig where
               , (x44, x45, x46, x47, x48, x49, x51, x52, x54, x55)
               , x56
               , x57
+              , x58
               )
             )
       ]

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -726,7 +726,6 @@ instance Arbitrary PackageConfig where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
       <*> arbitraryFlag arbitraryShortToken
       <*> arbitrary
       <*> shortListOf 5 arbitrary
@@ -794,7 +793,6 @@ instance Arbitrary PackageConfig where
       , packageConfigHaddockBaseUrl = x55
       , packageConfigHaddockResourcesDir = x56
       , packageConfigHaddockOutputDir = x57
-      , packageConfigHaddockVersionCPP = x58
       , packageConfigTestHumanLog = x44
       , packageConfigTestMachineLog = x45
       , packageConfigTestShowDetails = x46
@@ -858,7 +856,6 @@ instance Arbitrary PackageConfig where
         , packageConfigHaddockBaseUrl = x55'
         , packageConfigHaddockResourcesDir = x56'
         , packageConfigHaddockOutputDir = x57'
-        , packageConfigHaddockVersionCPP = x58'
         , packageConfigTestHumanLog = x44'
         , packageConfigTestMachineLog = x45'
         , packageConfigTestShowDetails = x46'
@@ -881,7 +878,6 @@ instance Arbitrary PackageConfig where
               , (x44', x45', x46', x47', x48', x49', x51', x52', x54', x55')
               , x56'
               , x57'
-              , x58'
               )
           ) <-
           shrink
@@ -907,7 +903,6 @@ instance Arbitrary PackageConfig where
               , (x44, x45, x46, x47, x48, x49, x51, x52, x54, x55)
               , x56
               , x57
-              , x58
               )
             )
       ]

--- a/cabal-testsuite/PackageTests/NewHaddock/Fails/cabal.out
+++ b/cabal-testsuite/PackageTests/NewHaddock/Fails/cabal.out
@@ -11,7 +11,8 @@ Failed to build example-1.0-inplace.
 # cabal v2-haddock
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
- - example-1.0 (lib) (first run)
+ - example-1.0 (lib) (configuration changed)
+Configuring library for example-1.0...
 Preprocessing library for example-1.0...
 Running Haddock on library for example-1.0...
 Error: [Cabal-7125]

--- a/changelog.d/pr-9177
+++ b/changelog.d/pr-9177
@@ -13,10 +13,13 @@ description: {
 
 * We no longer define the `__HADDOCK_VERSION__` macro when invoking GHC through
   Haddock, since doing so essentially guarantees recompilation during
-  documentation generation. Since a very limited set of users may still rely on
-  this flag, we introduce the `--haddock-version-cpp` flag and
-  `haddock-version-cpp:` cabal.project field, which enables the definition of
-  the `__HADDOCK_VERSION__` macro when invoking GHC through Haddock.
+  documentation generation. We audited all uses of `__HADDOCK_VERSION__` in
+  hackage, ensuring there was a reasonable path forward to migrate away from
+  using `__HADDOCK_VERSION__` for each, while generating the same documentation
+  as it did before.
+  If you are a user of `__HADDOCK_VERSION__`, please take a look at the
+  discussion in https://github.com/haskell/cabal/pull/9177 and reach out to us
+  if your use case is not covered.
 
 * Rename the `--haddock-lib` flag to `--haddock-resources-dir` (and
   `haddock-lib:` cabal.project field to `haddock-resources-dir:`), and add this

--- a/changelog.d/pr-9177
+++ b/changelog.d/pr-9177
@@ -1,0 +1,28 @@
+synopsis: Enable recompilation avoidance during Haddock generation
+packages: cabal-install
+prs: #9177
+issues: #9175
+
+description: {
+
+* Haddock no longer writes compilation files by default, so we do not need to
+  pass tmp dirs for `-hidir`, `-stubdir`, and `-odir` via `--optghc`. Indeed, we
+  do not *want* to do so, since it results in recompilation for every invocation
+  of Haddock via Cabal. We now stop this from happening for Haddock versions
+  2.28 and greater, since that is when Hi Haddock was introduced.
+
+* We no longer define the `__HADDOCK_VERSION__` macro when invoking GHC through
+  Haddock, since doing so essentially guarantees recompilation during
+  documentation generation. Since a very limited set of users may still rely on
+  this flag, we introduce the `--haddock-version-cpp` flag and
+  `haddock-version-cpp:` cabal.project field, which enables the definition of
+  the `__HADDOCK_VERSION__` macro when invoking GHC through Haddock.
+
+* Rename the `--haddock-lib` flag to `--haddock-resources-dir` (and
+  `haddock-lib:` cabal.project field to `haddock-resources-dir:`), and add this
+  flag to the users guide since it was missing an entry.
+
+* `documentation: true` or `--enable-documentation` now implies `-haddock` for
+  GHC.
+
+}

--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -1619,16 +1619,6 @@ running ``setup haddock``.
     be automatically inferred. For Haddock built from source, however, this path
     should likely be explicitly set for every Haddock invocation.
 
-.. cfg-field:: haddock-no-version-cpp: boolean
-               --haddock-no-version-cpp
-    :synopsis: Do not define the ``__HADDOCK_VERSION__`` macro when invoking GHC
-               through Haddock.
-
-    Do not define the ``__HADDOCK_VERSION__`` macro when invoking GHC through
-    Haddock. This is critical for avoiding recompilation during documentation
-    generation, since such a macro definition will trigger recompilation if the
-    interface files on disk were compiled without it, as they likely were.
-
 .. cfg-field:: open: boolean
                --open
     :synopsis: Open generated documentation in-browser.

--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -1610,6 +1610,25 @@ running ``setup haddock``.
     This flag is provided as a technology preview and is subject to change in the
     next releases.
 
+.. cfg-field:: haddock-resources-dir: DIR
+               --haddock-resources-dir=DIR
+    :synopsis: Location of Haddock's static/auxiliary files.
+
+    Location of Haddock's static/auxiliary files. For Haddock distributed with
+    GHC (or, more precisely, built within the GHC source tree), this path should
+    be automatically inferred. For Haddock built from source, however, this path
+    should likely be explicitly set for every Haddock invocation.
+
+.. cfg-field:: haddock-no-version-cpp: boolean
+               --haddock-no-version-cpp
+    :synopsis: Do not define the ``__HADDOCK_VERSION__`` macro when invoking GHC
+               through Haddock.
+
+    Do not define the ``__HADDOCK_VERSION__`` macro when invoking GHC through
+    Haddock. This is critical for avoiding recompilation during documentation
+    generation, since such a macro definition will trigger recompilation if the
+    interface files on disk were compiled without it, as they likely were.
+
 .. cfg-field:: open: boolean
                --open
     :synopsis: Open generated documentation in-browser.

--- a/release-notes/WIP-Cabal-3.12.x.0.md
+++ b/release-notes/WIP-Cabal-3.12.x.0.md
@@ -1,0 +1,19 @@
+Cabal 3.12.1.0 changelog and release notes.
+
+This file will be edited and the changes incorprated into the official
+3.12.1.0 Cabal and Cabal-syntax release notes.
+
+---
+
+### Significant changes
+
+- Deprecation of the `__HADDOCK_VERSION__` macro:
+    In the next major version of Cabal, we no longer define the
+    `__HADDOCK_VERSION__` macro when invoking GHC through Haddock, since doing
+    so essentially guarantees recompilation during documentation generation. We
+    audited all uses of `__HADDOCK_VERSION__` in hackage, ensuring there was a
+    reasonable path forward to migrate away from using `__HADDOCK_VERSION__` for
+    each, while generating the same documentation as it did before.  If you are
+    a user of `__HADDOCK_VERSION__`, please take a look at the discussion in
+    https://github.com/haskell/cabal/pull/9177 and reach out to us if your use
+    case is not covered.

--- a/test/IntegrationTests2/config/default-config
+++ b/test/IntegrationTests2/config/default-config
@@ -143,7 +143,6 @@ haddock
   -- base-url:
   -- resources-dir:
   -- output-dir:
-  -- version-cpp: False
 
 init
   -- interactive: False

--- a/test/IntegrationTests2/config/default-config
+++ b/test/IntegrationTests2/config/default-config
@@ -33,8 +33,8 @@ remote-repo-cache: /home/colton/.cabal/packages
 -- cabal-file:
 -- with-compiler:
 -- with-hc-pkg:
--- program-prefix: 
--- program-suffix: 
+-- program-prefix:
+-- program-suffix:
 -- library-vanilla: True
 -- library-profiling:
 -- shared:
@@ -141,8 +141,9 @@ haddock
   -- contents-location:
   -- index-location:
   -- base-url:
-  -- lib:
+  -- resources-dir:
   -- output-dir:
+  -- version-cpp: False
 
 init
   -- interactive: False

--- a/test/IntegrationTests2/nix-config/default-config
+++ b/test/IntegrationTests2/nix-config/default-config
@@ -143,7 +143,6 @@ haddock
   -- base-url:
   -- resources-dir:
   -- output-dir:
-  -- version-cpp: False
 
 init
   -- interactive: False

--- a/test/IntegrationTests2/nix-config/default-config
+++ b/test/IntegrationTests2/nix-config/default-config
@@ -33,8 +33,8 @@ remote-repo-cache: /home/colton/.cabal/packages
 -- cabal-file:
 -- with-compiler:
 -- with-hc-pkg:
--- program-prefix: 
--- program-suffix: 
+-- program-prefix:
+-- program-suffix:
 -- library-vanilla: True
 -- library-profiling:
 -- shared:
@@ -141,8 +141,9 @@ haddock
   -- contents-location:
   -- index-location:
   -- base-url:
-  -- lib:
+  -- resources-dir:
   -- output-dir:
+  -- version-cpp: False
 
 init
   -- interactive: False

--- a/tests/IntegrationTests2/config/default-config
+++ b/tests/IntegrationTests2/config/default-config
@@ -145,7 +145,6 @@ haddock
   -- base-url:
   -- resources-dir:
   -- output-dir:
-  -- version-cpp: False
 
 init
   -- interactive: False

--- a/tests/IntegrationTests2/config/default-config
+++ b/tests/IntegrationTests2/config/default-config
@@ -25,8 +25,8 @@ repository hackage.haskell.org
 -- store-dir:
 -- active-repositories:
 -- local-no-index-repo:
-remote-repo-cache: /home/colton/.cabal/packages
--- logs-dir: /home/colton/.cabal/logs
+remote-repo-cache: /Users/finley/.cabal/packages
+-- logs-dir: /Users/finley/.cabal/logs
 -- default-user-config:
 -- verbose: 1
 -- compiler: ghc
@@ -63,7 +63,7 @@ remote-repo-cache: /home/colton/.cabal/packages
 -- extra-lib-dirs:
 -- extra-lib-dirs-static:
 -- extra-framework-dirs:
-extra-prog-path: /home/colton/.cabal/bin
+-- extra-prog-path:
 -- instantiate-with:
 -- tests: False
 -- coverage: False
@@ -104,12 +104,13 @@ extra-prog-path: /home/colton/.cabal/bin
 -- index-state:
 -- root-cmd:
 -- symlink-bindir:
-build-summary: /home/colton/.cabal/logs/build.log
+build-summary: /Users/finley/.cabal/logs/build.log
 -- build-log:
 remote-build-reporting: none
 -- report-planning-failure: False
 -- per-component: True
 -- run-tests:
+-- semaphore: False
 jobs: $ncpus
 -- keep-going: False
 -- offline: False
@@ -117,10 +118,11 @@ jobs: $ncpus
 -- package-env:
 -- overwrite-policy:
 -- install-method:
-installdir: /home/colton/.cabal/bin
+installdir: /Users/finley/.cabal/bin
 -- username:
 -- password:
 -- password-command:
+-- multi-repl:
 -- builddir:
 
 haddock
@@ -141,8 +143,9 @@ haddock
   -- contents-location:
   -- index-location:
   -- base-url:
-  -- lib:
+  -- resources-dir:
   -- output-dir:
+  -- version-cpp: False
 
 init
   -- interactive: False
@@ -160,7 +163,7 @@ init
   -- source-dir: src
 
 install-dirs user
-  -- prefix: /home/colton/.cabal
+  -- prefix: /Users/finley/.cabal
   -- bindir: $prefix/bin
   -- libdir: $prefix/lib
   -- libsubdir: $abi/$libname

--- a/tests/IntegrationTests2/nix-config/default-config
+++ b/tests/IntegrationTests2/nix-config/default-config
@@ -143,7 +143,6 @@ haddock
   -- base-url:
   -- resources-dir:
   -- output-dir:
-  -- version-cpp: False
 
 init
   -- interactive: False

--- a/tests/IntegrationTests2/nix-config/default-config
+++ b/tests/IntegrationTests2/nix-config/default-config
@@ -33,8 +33,8 @@ remote-repo-cache: /home/colton/.cabal/packages
 -- cabal-file:
 -- with-compiler:
 -- with-hc-pkg:
--- program-prefix: 
--- program-suffix: 
+-- program-prefix:
+-- program-suffix:
 -- library-vanilla: True
 -- library-profiling:
 -- shared:
@@ -141,8 +141,9 @@ haddock
   -- contents-location:
   -- index-location:
   -- base-url:
-  -- lib:
+  -- resources-dir:
   -- output-dir:
+  -- version-cpp: False
 
 init
   -- interactive: False


### PR DESCRIPTION
Haddock no longer writes compilation files by default, so we do not need to pass tmp dirs for `-hidir`, `-stubdir`, and `-odir` via `--optghc`. Indeed, we do not *want* to do so, since it results in recompilation for every invocation of Haddock via Cabal. This commit stops this from happening for Haddock versions 2.28 or greater (when Hi Haddock was introduced).

This commit also prevents the definition of the `__HADDOCK_VERSION__` macro when invoking GHC through Haddock by default, which necessary to avoid recompilation during documentation generation, since the macro invalidates existing build results. Since a limited set of users may rely on this macro still, we introduce the `--haddock-version-cpp` flag and `haddock-version-cpp:` cabal.project field, which enable the definition of the `__HADDOCK_VERSION__` macro when invoking GHC through Haddock.

This commit also renames the `--haddock-lib` flag to `--haddock-resources-dir` (and `haddock-lib:` cabal.project field to `haddock-resources-dir:`), and adds this flag to the users guide since it was missing an entry. This also allows us to add this field to `cabal-install:test:integration-tests2`, since it is no longer ambiguous with the `--lib` flag.

This commit also causes `documentation: true` or `--enable-documentation` to imply `-haddock` for GHC.

Also, since Haddock >= 2.29 is renaming `--lib` to `--resources-dir`, this commit switches the flag provided to Haddock using a backwards compatible condition based on the Haddock version.

---
## QA Notes

Consider a Haskell package with dependencies. We should be able to simply configure the package so that doing `cabal build` followed by `cabal haddock` does not trigger a recompilation. Use the following `deps.cabal` file:
```cabal
cabal-version: 3.6
name: deps
version: 0.1.0

library
  build-depends:
      base
    , acme-missiles
  exposed-modules: Lib
```

The following `cabal.project` file:
```cabal
packages: .

package *
  documentation: True
  haddock-options: --optghc=-ddump-hi-diffs
```

And any `Lib.hs` will do:
```haskell
-- | Lib reexports 'launchMissiles'
module Lib (myMissiles, launchMissiles) where

import Acme.Missiles

-- | Another 'launchMissiles'
myMissiles :: IO ()
myMissiles = launchMissiles
```

This configuration should avoid recompilation during documentation generation. To verify this, with a package such as above, just run `cabal build`. Since documentation is enabled, the package will first build then generate Haddocks. Since Haddock is passing `-ddump-hi-diffs` to GHC, you should see output indicating that no recompilation checks have triggered during the Haddock phase:
```
Module flags unchanged
Optimisation flags changed; ignoring
HPC flags unchanged
signatures to merge in unchanged
[]
implementing module unchanged
Checking interface for module Prelude base
Module fingerprint unchanged
Checking interface for module Acme.Missiles cm-mssls-0.3-9160cec8
Module fingerprint unchanged
Checking interface for module GHC.Types ghc-prim
Module fingerprint unchanged
```

This means recompilation was successfully avoided.

**NOTE:** I am working on making `no-tmp-comp-dir` the default behavior for Haddock 2.29, but until then it is necessary to avoid recompilation.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

Fixes  #9175 