### PR TITLE
Make .python-sphinx-virtualenv target in Makefile more precise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,12 +210,12 @@ SPHINX_HTML_OUTDIR:=dist-newstyle/doc/users-guide
 USERGUIDE_STAMP:=$(SPHINX_HTML_OUTDIR)/index.html
 
 # do pip install every time so we have up to date requirements when we build
-users-guide: .python-sphinx-virtualenv $(USERGUIDE_STAMP)
+users-guide: .python-sphinx-virtualenv/bin/activate $(USERGUIDE_STAMP)
 $(USERGUIDE_STAMP) : doc/*.rst
 	mkdir -p $(SPHINX_HTML_OUTDIR)
 	(. ./.python-sphinx-virtualenv/bin/activate && pip install -r doc/requirements.txt && $(SPHINXCMD) $(SPHINX_FLAGS) doc $(SPHINX_HTML_OUTDIR))
 
-.python-sphinx-virtualenv:
+.python-sphinx-virtualenv/bin/activate:
 	python3 -m venv .python-sphinx-virtualenv
 	(. ./.python-sphinx-virtualenv/bin/activate)
 
@@ -224,7 +224,7 @@ $(USERGUIDE_STAMP) : doc/*.rst
 users-guide-requirements: doc/requirements.txt
 
 .PHONY: doc/requirements.txt
-doc/requirements.txt: .python-sphinx-virtualenv
+doc/requirements.txt: .python-sphinx-virtualenv/bin/activate
 	. .python-sphinx-virtualenv/bin/activate \
 	  && make -C doc build-and-check-requirements
 


### PR DESCRIPTION
This fixes a problem I had when I tried to build the user-guide:

On first invocation of `make users-guide` the `.python-sphinx-virtualenv` directory was successfully created, but due to some missing dependency that I had to install via `apt` the file `.python-sphinx-virtualenv/bin/activate` was not created. Running `make users-guide` in this state fails with the following error:

```console
david@anaxes ~/GitRepos/cabal (master)$ make users-guide
mkdir -p dist-newstyle/doc/users-guide
(. ./.python-sphinx-virtualenv/bin/activate && pip install -r doc/requirements.txt && sphinx-build -n -W --keep-going -E doc dist-newstyle/doc/users-guide)
/bin/sh: 1: .: cannot open ./.python-sphinx-virtualenv/bin/activate: No such file
make: *** [Makefile:216: dist-newstyle/doc/users-guide/index.html] Error 2
```

I fixed this problem by making the target more precise: We require the file `bin/activate` to be present, and not just the directory.
