### PR TITLE
Fix inconsistent indentation

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -250,9 +250,9 @@ library
     if flag(lukko)
       build-depends: lukko >= 0.1 && <0.2
 
-   -- pull in process version with fixed waitForProcess error
-   if impl(ghc >=8.2)
-     build-depends: process >= 1.6.15.0
+    -- pull in process version with fixed waitForProcess error
+    if impl(ghc >=8.2)
+      build-depends: process >= 1.6.15.0
 
 
 executable cabal


### PR DESCRIPTION
`cabal check` was complaining:

```sh
$ cabal check
These warnings will likely cause trouble when distributing the package:
Warning: cabal-install.cabal:254:4: Inconsistent indentation. Indentation
jumps at lines 254
These warnings may cause trouble when distributing the package:
Warning: Please consider moving the file 'changelog' from the
'extra-source-files' section of the .cabal file to the section
'extra-doc-files'.
```
---

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

