### PR TITLE
Have hlint ignore CmmSourcesExe Demo

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -94,9 +94,10 @@
 - ignore: {name: "Use when"} # 1 hint
 
 - arguments:
+    - --ignore-glob=Cabal-syntax/src/Distribution/Fields/Lexer.hs
     - --ignore-glob=cabal-testsuite/PackageTests/CmmSources/src/Demo.hs
     - --ignore-glob=cabal-testsuite/PackageTests/CmmSourcesDyn/src/Demo.hs
-    - --ignore-glob=Cabal-syntax/src/Distribution/Fields/Lexer.hs
+    - --ignore-glob=cabal-testsuite/PackageTests/CmmSourcesExe/src/Demo.hs
     - --ignore-glob=templates/Paths_pkg.template.hs
     - --ignore-glob=templates/SPDX.LicenseExceptionId.template.hs
     - --ignore-glob=templates/SPDX.LicenseId.template.hs


### PR DESCRIPTION
Ignore because it warns about missing MachDeps.h added in #9061.

```
$ hlint -j .
Warning: Can't find file "MachDeps.h" in directories
	./cabal-testsuite/PackageTests/CmmSourcesExe/src
	.
  Asked for by: ./cabal-testsuite/PackageTests/CmmSourcesExe/src/Demo.hs  at line 8 col 1
No hints
```

I also sorted the `--ignore-glob` list.