### PR TITLE
Add a config path on Windows in a message

### DIFF
--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -1669,7 +1669,7 @@ reportCommand =
     , commandSynopsis = "Upload build reports to a remote server."
     , commandDescription = Nothing
     , commandNotes = Just $ \_ ->
-        "You can store your Hackage login in the ~/.config/cabal/config file\n"
+        "You can store your Hackage login in the ~/.config/cabal/config file (the %APPDATA%\\cabal\\config file on Windows)\n"
     , commandUsage = usageAlternatives "report" ["[FLAGS]"]
     , commandDefaultFlags = defaultReportFlags
     , commandOptions = \_ ->
@@ -2689,7 +2689,7 @@ uploadCommand =
     , commandSynopsis = "Uploads source packages or documentation to Hackage."
     , commandDescription = Nothing
     , commandNotes = Just $ \_ ->
-        "You can store your Hackage login in the ~/.config/cabal/config file\n"
+        "You can store your Hackage login in the ~/.config/cabal/config file (the %APPDATA%\\cabal\\config file on Windows)\n"
           ++ relevantConfigValuesText ["username", "password", "password-command"]
     , commandUsage = \pname ->
         "Usage: " ++ pname ++ " upload [FLAGS] TARFILES\n"

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -1669,7 +1669,8 @@ reportCommand =
     , commandSynopsis = "Upload build reports to a remote server."
     , commandDescription = Nothing
     , commandNotes = Just $ \_ ->
-        "You can store your Hackage login in the ~/.config/cabal/config file (the %APPDATA%\\cabal\\config file on Windows)\n"
+        "You can store your Hackage login in the ~/.config/cabal/config file\n"
+          ++ "(the %APPDATA%\\cabal\\config file on Windows)\n"
     , commandUsage = usageAlternatives "report" ["[FLAGS]"]
     , commandDefaultFlags = defaultReportFlags
     , commandOptions = \_ ->
@@ -2689,7 +2690,8 @@ uploadCommand =
     , commandSynopsis = "Uploads source packages or documentation to Hackage."
     , commandDescription = Nothing
     , commandNotes = Just $ \_ ->
-        "You can store your Hackage login in the ~/.config/cabal/config file (the %APPDATA%\\cabal\\config file on Windows)\n"
+        "You can store your Hackage login in the ~/.config/cabal/config file\n"
+          ++ "(the %APPDATA%\\cabal\\config file on Windows)\n"
           ++ relevantConfigValuesText ["username", "password", "password-command"]
     , commandUsage = \pname ->
         "Usage: " ++ pname ++ " upload [FLAGS] TARFILES\n"


### PR DESCRIPTION
A default config file on Windows is not at _~/.config/cabal/config_ but _%APPDATA%\cabal\config_.

This PR adds it to command line notes.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

