### PR TITLE
Sort the unit order for --enable-multi-repl

### DIFF
--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledClosure/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledClosure/cabal.test.hs
@@ -5,13 +5,7 @@ main = do
     skipUnlessGhcVersion ">= 9.4"
     -- Note: only the last package is interactive.
     -- this test should load pkg-b too.
-    res <- cabalWithStdin "v2-repl" ["--enable-multi-repl","pkg-a", "pkg-c"] ""
-
-    -- we should check that pkg-c is indeed loaded,
-    -- but currently the unit order is non-deterministic
-    -- Fix this when GHC has a way to change active unit.
-    -- TODO: ask for pkg-c unit, print Quu.quu
+    res <- cabalWithStdin "v2-repl" ["--enable-multi-repl","pkg-c", "pkg-a"] "Quu.quu"
 
     assertOutputContains "- pkg-b-0 (interactive)" res
-    -- assertOutputContains "168" res
-    return ()
+    assertOutputContains "168" res

--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledSucc/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledSucc/cabal.test.hs
@@ -4,9 +4,5 @@ main = do
   cabalTest $ do
     skipUnlessGhcVersion ">= 9.4"
     skipIfWindows -- heisenbug, see #9103
-    -- the package order is non-deterministic.
-    -- add Bar.Bar input to test that packages are trully loaded
-    -- when GHC gets support for switching active units
-    res <- cabalWithStdin "v2-repl" ["--enable-multi-repl","pkg-a", "pkg-b"] ""
-    -- assertOutputContains "3735929054" res
-    return ()
+    res <- cabalWithStdin "v2-repl" ["--enable-multi-repl","pkg-b", "pkg-a"] "Bar.bar"
+    assertOutputContains "3735929054" res

--- a/doc/internal/multi-repl.md
+++ b/doc/internal/multi-repl.md
@@ -33,11 +33,12 @@ Here are some common targets which you can specify when using `cabal`.
 
 * `all`: Build all the locally defined components.
 * `exe:haskell-language-server`: Build the executable called `haskell-language-server`
-* `lib:pkg-a lib:pkg-b`: Build the local libraries pkg-a and pkg-b.
+* `lib:pkg-a lib:pkg-b`: Build the local libraries pkg-a and pkg-b. pkg-a will be the active unit.
 * `src/Main.hs`: Build the unit which `src/Main.hs` belongs to.
 
 After enabling multi-repl, passing a target specification to `cabal repl` which
 resolves to multiple units will load all those units into a single repl session.
+The first "target" will be the active unit.
 For example:
 
 ```
@@ -202,6 +203,14 @@ to modify the GHCi interface in order to work nicely with multiple components in
 At this time, the multi-repl is best used for interactive development situations where
 you want to use the repl to obtain fast-feedback about your project.
 We have made sure that the multi-repl works with `ghcid` for example.
+
+When evaluating code, make sure that the code is in the scope of the active unit,
+which is the first target given on the command line. For example, to run the test suite
+entrypoint, use:
+
+```
+ghcid --command "cabal repl --enable-multi-repl test:suite lib:pkg" --test Main.main
+```
 
 # Conclusion
 


### PR DESCRIPTION
When using the multi components repl, the last unit given to ghc
is the active unit. This change uses the cabal repl argument
order instead of relying on the 'listDirectory' ordering.

Fixes #9195 

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

