### PR TITLE
Add deprecation warnings to Nix integration

### DIFF
--- a/cabal-install/src/Distribution/Client/Nix.hs
+++ b/cabal-install/src/Distribution/Client/Nix.hs
@@ -47,7 +47,7 @@ import Distribution.Simple.Program
   , simpleProgram
   )
 import Distribution.Simple.Setup (fromFlagOrDefault)
-import Distribution.Simple.Utils (debug, existsAndIsMoreRecentThan)
+import Distribution.Simple.Utils (debug, existsAndIsMoreRecentThan, warn)
 
 import Distribution.Client.Config (SavedConfig (..))
 import Distribution.Client.GlobalFlags (GlobalFlags (..))
@@ -144,6 +144,9 @@ nixShell verb dist globalFlags config go = do
       findNixExpr globalFlags config >>= \case
         Nothing -> go
         Just shellNix -> do
+          -- Nix integration never worked with cabal-install v2 commands ...
+          warn verb "Nix integration has been deprecated and will be removed in a future release. You can learn more about it here: https://cabal.readthedocs.io/en/latest/nix-integration.html"
+
           let prog = simpleProgram "nix-shell"
           progdb <- configureOneProgram verb prog
 

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -502,17 +502,17 @@ globalCommand commands =
               )
               ""
               ["nix"] -- Must be empty because we need to return PP.empty from viewAsFieldDescr
-              "Nix integration: run commands through nix-shell if a 'shell.nix' file exists (default is False)"
+              "[DEPRECATED] Nix integration: run commands through nix-shell if a 'shell.nix' file exists (default is False)"
           , noArg
               (Flag True)
               []
               ["enable-nix"]
-              "Enable Nix integration: run commands through nix-shell if a 'shell.nix' file exists"
+              "[DEPRECATED] Enable Nix integration: run commands through nix-shell if a 'shell.nix' file exists"
           , noArg
               (Flag False)
               []
               ["disable-nix"]
-              "Disable Nix integration"
+              "[DEPRECATED] Disable Nix integration"
           ]
       , option
           []

--- a/doc/nix-integration.rst
+++ b/doc/nix-integration.rst
@@ -1,6 +1,15 @@
 Nix Integration
 ===============
 
+.. warning::
+
+    Nix integration has been deprecated and will be removed in a future release.
+
+    The original mechanism can still be easily replicated with the following commands:
+
+    - for a ``shell.nix``: ``nix-shell --run "cabal ..."``
+    - for a ``flake.nix``: ``nix develop -c cabal ...``
+
 .. note::
 
     This functionality doesn't work with nix-style builds.


### PR DESCRIPTION
 This PR modifies `cabal` behavior by adding deprecation warnings to [Nix integration](https://cabal.readthedocs.io/en/latest/nix-integration.html).

This has been discussed [on the discourse](https://discourse.haskell.org/t/community-survey-removing-cabals-nix-integration/). 

**Checklist:**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

Bonus points for added automated tests!

**QA Notes:**

- Calling `cabal --help` should display the `[DEPRECATED]` label next to each Nix integration-related flag in the list ;
- Using `cabal some-v1-command` with the `--enable-nix` or `--nix=True` flag should display a warning about the deprecation of the feature and provide a link to the online documentation for further information.