### PR TITLE
Add support for LoongArch 64-bit architecture

### DIFF
--- a/Cabal-syntax/src/Distribution/System.hs
+++ b/Cabal-syntax/src/Distribution/System.hs
@@ -183,7 +183,7 @@ buildOS = classifyOS Permissive System.Info.os
 
 -- | These are the known Arches: I386, X86_64, PPC, PPC64, Sparc,
 -- Arm, AArch64, Mips, SH, IA64, S390, S390X, Alpha, Hppa, Rs6000,
--- M68k, Vax, RISCV64, JavaScript and Wasm32.
+-- M68k, Vax, RISCV64, LoongArch64, JavaScript and Wasm32.
 --
 -- The following aliases can also be used:
 --    * PPC alias: powerpc
@@ -211,6 +211,7 @@ data Arch
   | M68k
   | Vax
   | RISCV64
+  | LoongArch64
   | JavaScript
   | Wasm32
   | OtherArch String
@@ -240,6 +241,7 @@ knownArches =
   , M68k
   , Vax
   , RISCV64
+  , LoongArch64
   , JavaScript
   , Wasm32
   ]

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -27,9 +27,9 @@ tests = testGroup "Distribution.Utils.Structured"
     -- The difference is in encoding of newtypes
 #if MIN_VERSION_base(4,7,0)
     , testCase "GenericPackageDescription" $
-      md5Check (Proxy :: Proxy GenericPackageDescription) 0xedd391339de1201511636bbb563fa5db
+      md5Check (Proxy :: Proxy GenericPackageDescription) 0x6ad1e12c6f88291e9b8c131d239eda70
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0x40253e3699453643336bdc7911717af0
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0xbc7ac84a9bc43345c812af222c3e5ba0
 #endif
     ]
 

--- a/Cabal/src/Distribution/Simple/PreProcess.hs
+++ b/Cabal/src/Distribution/Simple/PreProcess.hs
@@ -863,6 +863,7 @@ platformDefines lbi =
       M68k -> ["m68k"]
       Vax -> ["vax"]
       RISCV64 -> ["riscv64"]
+      LoongArch64 -> ["loongarch64"]
       JavaScript -> ["javascript"]
       Wasm32 -> ["wasm32"]
       OtherArch _ -> []

--- a/changelog.d/pr-9215
+++ b/changelog.d/pr-9215
@@ -1,0 +1,3 @@
+synopsis: Add support for 64-bit LoongArch architecture
+prs: #9215
+packages: Cabal Cabal-syntax


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

Bonus points for added automated tests!

LoongArch 64-bit LLVM backend support has merged into GHC since `9.6.2` by this MR: [Implement LoongArch64 LLVM backend support](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9292)
