### PR TITLE
Update `CONTRIBUTING.md` with Nix developer shell instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,13 @@ If not, you aren't able to build the testsuite, so you need to disable the defau
 cabal build --project-file=cabal.project.release cabal
 ```
 
+> **Note**
+> If you're using Nix, you might find it convenient to work within a shell that has all the `Cabal` development dependencies:
+> ```
+> $ nix-shell -p cabal-install ghc ghcid haskellPackages.fourmolu_0_12_0_0 pkgconfig zlib.dev
+> ```
+> A Nix flake developer shell with these dependencies is also available, supported solely by the community, through the command `nix develop github:yvan-sraka/cabal.nix`.
+
 The location of your build products will vary depending on which version of
 cabal-install you use to build; see the documentation section
 [Where are my build products?](http://cabal.readthedocs.io/en/latest/nix-local-build.html#where-are-my-build-products)


### PR DESCRIPTION
This PR does not modify the `cabal` behavior.  It only updates the `CONTRIBUTING.md` documentation with instructions on setting up a Nix developer shell. I believe this could help some newcomers get started more easily to contribute to the project.

[Rendered](https://github.com/yvan-sraka/cabal/blob/nix-devshell/CONTRIBUTING.md)

**Checklist:**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).