### PR TITLE
Partially revert #8071

### DIFF
--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -322,12 +322,7 @@ defaultConfigFlags progDb =
     , configCabalFilePath = NoFlag
     , configVerbosity = Flag normal
     , configUserInstall = Flag False -- TODO: reverse this
-#if defined(mingw32_HOST_OS)
-        -- See #8062 and GHC #21019.
-    , configGHCiLib = Flag False
-#else
-    , configGHCiLib = NoFlag
-#endif
+    , configGHCiLib = Flag True
     , configSplitSections = Flag False
     , configSplitObjs = Flag False -- takes longer, so turn off by default
     , configStripExes = NoFlag


### PR DESCRIPTION
This whole PR #8071 is built on the premise that GHC is using `lld` as a linker. What if it doesn't? Why do we blanket deny the the generation of the merged object?
I know there are underlying issues with address randomisation, and the fact that `lld` can't produce the right merged objects, but if we don't use `lld` and don't care about address randomisation, why prohibit the creation of those?

A bit further why this is a problem:
When using ghci to load archives (because we don't have merged objects now anymore) this can easily blow up the linker. Thus the lack of merged object files (and technically dynamic way), means we rely on archives to load stuff into GHCi sessions. This then becomes impossible. However for those of us still using `bfd.ld` there is no good reason for being disallowed to use merged objects. `bfd.ld` _does_ support the merging of objects. Yes there are other issues specifically ASLR, but again if that is not an issue to us, cabal should _not_ prohibit us from creating merged objects. GHC is _not_ guaranteed to be linked against `lld`. Only in those cases do we know _today_ that we can't use merged objects.