### PR TITLE
 Use ghc --merge-objs when available to join object files

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -572,9 +572,11 @@ data GhcMode
   | -- | @ghci@ \/ @ghc --interactive@
     GhcModeInteractive
   | -- | @ghc --abi-hash@
-    --             | GhcModeDepAnalysis -- ^ @ghc -M@
-    --             | GhcModeEvaluate    -- ^ @ghc -e@
     GhcModeAbiHash
+  | -- | @ghc --merge-objs@
+    GhcModeMergeObjs
+  --             | GhcModeDepAnalysis -- ^ @ghc -M@
+  --             | GhcModeEvaluate    -- ^ @ghc -e@
   deriving (Show, Eq)
 
 data GhcOptimisation
@@ -644,6 +646,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
             Just GhcModeMake -> ["--make"]
             Just GhcModeInteractive -> ["--interactive"]
             Just GhcModeAbiHash -> ["--abi-hash"]
+            Just GhcModeMergeObjs -> ["--merge-objs"]
         , --     Just GhcModeDepAnalysis -> ["-M"]
           --     Just GhcModeEvaluate    -> ["-e", expr]
 

--- a/changelog.d/pr-9226
+++ b/changelog.d/pr-9226
@@ -1,0 +1,18 @@
+synopsis: Use `ghc --merge-objs` when available to join object files
+packages: Cabal
+prs: #9226
+
+description: {
+
+Previously Cabal would rely on its own object-merge logic to produce
+GHCi libraries. This was not ideal as it meant that this logic was
+replicated in both GHC and Cabal. Moreover, Cabal's implementation
+historically hasn't handled the more subtle aspects of interacting with
+the linker, resulting in issues like #7828.
+
+In GHC 9.4 a new compiler mode was introduced, `--merge-objs`, which
+exposes GHC's object merging mechanism. Here we teach `Cabal` to take
+advantage of this mechanism when it is available, ensuring that object
+merging behavior is consistent between GHC and Cabal.
+
+}


### PR DESCRIPTION
Previously Cabal would rely on its own object-merge logic to produce
GHCi libraries. This was not ideal as it meant that this logic was
replicated in both GHC and Cabal. Moreover, Cabal's implementation
historically hasn't handled the more subtle aspects of interacting with
the linker, resulting in issues like https://github.com/haskell/cabal/issues/7828.

In GHC 9.4 we have introduced a new compiler mode, `--merge-objs`, which
exposes GHC's object merging mechanism. Here we teach Cabal to take
advantage of this mechanism when it is available. This ensures that the
platform-dependent process of object merging remains squarely in GHC's 
court, preventing issues like #7828.

This is a rebase of #7960, which we previously decided not to merge as GHC
was able to find another way around the proximate problem. However, in light
of recent issues turned up by GHC's `ghc-toolchain` [work](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/11135), I think we should again
consider merging this for GHC 9.10.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
