### PR TITLE
Fix use of NumJobs

### DIFF
--- a/Cabal-tests/tests/UnitTests/Distribution/Simple/Program/GHC.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Simple/Program/GHC.hs
@@ -1,11 +1,16 @@
 module UnitTests.Distribution.Simple.Program.GHC (tests) where
 
+import qualified Data.Map as Map
 import Data.Algorithm.Diff (PolyDiff (..), getDiff)
 import Test.Tasty          (TestTree, testGroup)
 import Test.Tasty.HUnit
 
+import Distribution.System (Platform(..), Arch(X86_64), OS(Linux))
+import Distribution.Types.ParStrat
+import Distribution.Simple.Flag
+import Distribution.Simple.Compiler (Compiler(..), CompilerId(..), CompilerFlavor(..), AbiTag(NoAbiTag))
 import Distribution.PackageDescription (emptyPackageDescription)
-import Distribution.Simple.Program.GHC (normaliseGhcArgs)
+import Distribution.Simple.Program.GHC (normaliseGhcArgs, renderGhcOptions, ghcOptNumJobs)
 import Distribution.Version            (mkVersion)
 
 tests :: TestTree
@@ -38,6 +43,22 @@ tests = testGroup "Distribution.Simple.Program.GHC"
 
             assertListEquals flags options_9_0_affects
         ]
+    , testGroup "renderGhcOptions"
+      [ testCase "options" $ do
+            let flags :: [String]
+                flags = renderGhcOptions
+                  (Compiler
+                      { compilerId = CompilerId GHC (mkVersion [9,8,1])
+                      , compilerAbiTag = NoAbiTag
+                      , compilerCompat = []
+                      , compilerLanguages = []
+                      , compilerExtensions = []
+                      , compilerProperties = Map.singleton "Support parallel --make" "YES" 
+                      })
+                  (Platform X86_64 Linux)
+                  (mempty { ghcOptNumJobs = Flag (NumJobs (Just 4)) })
+            assertListEquals flags ["-j4", "-clear-package-db"]
+        ]        
     ]
 
 assertListEquals :: (Eq a, Show a) => [a] -> [a] -> Assertion

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -701,7 +701,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
                 if jsemSupported comp
                   then ["-jsem " ++ name]
                   else []
-              Flag (NumJobs n) -> ["-j" ++ show n]
+              Flag (NumJobs n) -> ["-j" ++ maybe "" show n]
             else []
         , --------------------
           -- Creating libraries


### PR DESCRIPTION
From `Cabal/src/Distribution/Types/ParStrat.hs`

```
data ParStratX sem
  = -- | Compile in parallel with the given number of jobs (`-jN` or `-j`).
    NumJobs (Maybe Int)
  ...
```

However in `Cabal/src/Distribution/Simple/Program/GHC.hs` `show` is applied to the `Maybe Int` and we get errors like:

```
ghc-9.9.20230901: on the commandline: malformed integer argument in -jJust 4
```

This change should correct the behavior in `Simple/Program/GHC.hs` to match the comment in `Types/ParStrat.hs`.