### PR TITLE
Improve error message for empty config file

### DIFF
--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -964,7 +964,9 @@ loadRawConfig verbosity configFileFlag = do
         CommandlineOption -> failNoConfigFile
         EnvironmentVariable -> failNoConfigFile
       where
-        msgNotFound = unwords ["Config file not found:", configFile]
+        msgNotFound
+          | null configFile = "Config file name is empty"
+          | otherwise = unwords ["Config file not found:", configFile]
         failNoConfigFile =
           die' verbosity $
             unlines


### PR DESCRIPTION
Otherwise

```
$ CONFIG_FILE= cabal build
Error: cabal-3.10.1.0: Config file not found:
```

looks abrupt and confusing. Now it says

```
Error: cabal: Config file name is empty
```