### PR TITLE
gitlab-ci/brew.sh/curl: fail with more noise

### DIFF
--- a/.gitlab/brew.sh
+++ b/.gitlab/brew.sh
@@ -9,7 +9,7 @@ brew_dir="${CI_PROJECT_DIR}/.brew"
 
 if [ ! -e "${brew_dir}" ]; then
     mkdir -p "${brew_dir}"
-    curl -L "https://github.com/Homebrew/brew/archive/refs/tags/${BREW_VERSION}.tar.gz" | tar xz --strip 1 -C "${brew_dir}"
+    curl --fail-with-body -L "https://github.com/Homebrew/brew/archive/refs/tags/${BREW_VERSION}.tar.gz" | tar xz --strip 1 -C "${brew_dir}"
 fi
 
 export PATH="${brew_dir}/bin:${brew_dir}/sbin:$PATH"


### PR DESCRIPTION
When the GitLab pipeline failed because of a GitHub outage (https://gitlab.haskell.org/haskell/cabal/-/pipelines/83703/failures), one job in particular (https://gitlab.haskell.org/haskell/cabal/-/jobs/1655828) threw a useless error message. This change might help that.