### PR TITLE
Only use relocatable linker flag if linker supports it

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/src/Distribution/Simple/Program/Builtin.hs
@@ -362,7 +362,8 @@ ldProgram =
         -- choice for windows linking does not support this feature. However
         -- if using binutils ld or another linker that supports --relocatable,
         -- we should still be good to generate pre-linked objects.
-        ldHelpOutput <-
+        ldHelpOutput <- do
+          _ <- error "Distribution.Simple.Program.Builtin.ldProgram"
           getProgramInvocationOutput
             verbosity
             (programInvocation ldProg ["--help"])

--- a/Cabal/src/Distribution/Simple/Setup/Common.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Common.hs
@@ -327,7 +327,9 @@ configureCCompiler
 configureCCompiler verbosity progdb = configureProg verbosity progdb gccProgram
 
 configureLinker :: Verbosity -> ProgramDb -> IO (FilePath, [String])
-configureLinker verbosity progdb = configureProg verbosity progdb ldProgram
+configureLinker verbosity progdb = do
+  _ <- error $ show ldProgram
+  configureProg verbosity progdb ldProgram
 
 configureProg
   :: Verbosity

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -322,12 +322,7 @@ defaultConfigFlags progDb =
     , configCabalFilePath = NoFlag
     , configVerbosity = Flag normal
     , configUserInstall = Flag False -- TODO: reverse this
-#if defined(mingw32_HOST_OS)
-        -- See #8062 and GHC #21019.
-    , configGHCiLib = Flag False
-#else
-    , configGHCiLib = NoFlag
-#endif
+    , configGHCiLib = Flag True
     , configSplitSections = Flag False
     , configSplitObjs = Flag False -- takes longer, so turn off by default
     , configStripExes = NoFlag


### PR DESCRIPTION
**Template Α: This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

Bonus points for added automated tests!
