### PR TITLE
Preserve the relative paths of license files

### DIFF
--- a/Cabal-tests/tests/CheckTests.hs
+++ b/Cabal-tests/tests/CheckTests.hs
@@ -3,7 +3,6 @@ module Main
     ) where
 
 import Test.Tasty
-import Test.Tasty.ExpectedFailure
 import Test.Tasty.Golden.Advanced (goldenTest)
 
 import Data.Algorithm.Diff                    (PolyDiff (..), getGroupedDiff)

--- a/Cabal/src/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/src/Distribution/Simple/BuildPaths.hs
@@ -20,6 +20,7 @@ module Distribution.Simple.BuildPaths
   , haddockDirName
   , hscolourPref
   , haddockPref
+  , licenseFilePref
   , autogenPackageModulesDir
   , autogenComponentModulesDir
   , autogenPathsModuleName
@@ -89,6 +90,9 @@ haddockDirName ForHackage = (++ "-docs") . prettyShow . packageId
 haddockPref :: HaddockTarget -> FilePath -> PackageDescription -> FilePath
 haddockPref haddockTarget distPref pkg_descr =
   distPref </> "doc" </> "html" </> haddockDirName haddockTarget pkg_descr
+
+licenseFilePref :: FilePath -> FilePath -> FilePath
+licenseFilePref docPref = (docPref </>)
 
 -- | The directory in which we put auto-generated modules for EVERY
 -- component in the package.

--- a/Cabal/src/Distribution/Simple/Install.hs
+++ b/Cabal/src/Distribution/Simple/Install.hs
@@ -31,7 +31,11 @@ import Distribution.Types.UnqualComponentName
 
 import Distribution.Package
 import Distribution.PackageDescription
-import Distribution.Simple.BuildPaths (haddockName, haddockPref)
+import Distribution.Simple.BuildPaths
+  ( haddockName
+  , haddockPref
+  , licenseFilePref
+  )
 import Distribution.Simple.BuildTarget
 import Distribution.Simple.Compiler
   ( CompilerFlavor (..)
@@ -74,7 +78,6 @@ import System.Directory
 import System.FilePath
   ( isRelative
   , takeDirectory
-  , takeFileName
   , (</>)
   )
 
@@ -182,7 +185,7 @@ copyPackage verbosity pkg_descr lbi distPref copydest = do
     for_ lfiles $ \lfile' -> do
       let lfile :: FilePath
           lfile = getSymbolicPath lfile'
-      installOrdinaryFile verbosity lfile (docPref </> takeFileName lfile)
+      installOrdinaryFile verbosity lfile (licenseFilePref docPref lfile)
 
 -- | Copy files associated with a component.
 copyComponent

--- a/changelog.d/issue-9184
+++ b/changelog.d/issue-9184
@@ -1,0 +1,3 @@
+synopsis: Preserve the relative paths of license files
+packages: Cabal
+issues: #9184


### PR DESCRIPTION
As suggested in #9172, I propose an independent PR to resolve #9184, which removes the use of `takeFileName` while copying license files.

It also moves the definition of paths of copied license files to the module `Distribution.Simple.BuildPaths`, as other packages might use this definition to determine the location of license files.

---

**Template Α: This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

Bonus points for added automated tests!

