### PR TITLE
More information in the generated modules `Paths_<pkgname>` and `PackageInfo_<pkgname>`

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -98,5 +98,6 @@
     - --ignore-glob=cabal-testsuite/PackageTests/CmmSourcesDyn/src/Demo.hs
     - --ignore-glob=Cabal-syntax/src/Distribution/Fields/Lexer.hs
     - --ignore-glob=templates/Paths_pkg.template.hs
+    - --ignore-glob=templates/PackageInfo_pkg.template.hs
     - --ignore-glob=templates/SPDX.LicenseExceptionId.template.hs
     - --ignore-glob=templates/SPDX.LicenseId.template.hs

--- a/Cabal/src/Distribution/Simple/Build/PackageInfoModule.hs
+++ b/Cabal/src/Distribution/Simple/Build/PackageInfoModule.hs
@@ -38,13 +38,15 @@ generatePackageInfoModule :: PackageDescription -> LocalBuildInfo -> String
 generatePackageInfoModule pkg_descr lbi =
   Z.render
     Z.Z
-      { Z.zPackageName = showPkgName $ packageName pkg_descr
+      { Z.zPackageName = packageName pkg_descr
       , Z.zVersionDigits = show $ versionNumbers $ packageVersion pkg_descr
-      , Z.zSynopsis = fromShortText $ synopsis pkg_descr
-      , Z.zCopyright = fromShortText $ copyright pkg_descr
-      , Z.zLicense = prettyShow $ license pkg_descr
-      , Z.zHomepage = fromShortText $ homepage pkg_descr
+      , Z.zSynopsis = show $ fromShortText $ synopsis pkg_descr
+      , Z.zCopyright = show $ fromShortText $ copyright pkg_descr
+      , Z.zLicense = show $ prettyShow $ license pkg_descr
+      , Z.zHomepage = show $ fromShortText $ homepage pkg_descr
       , Z.zSupportsNoRebindableSyntax = supports_rebindable_syntax
+      , Z.zManglePkgName = showPkgName
+      , Z.zShow = show
       }
   where
     supports_rebindable_syntax = ghc_newer_than (mkVersion [7, 0, 1])

--- a/Cabal/src/Distribution/Simple/Build/PackageInfoModule.hs
+++ b/Cabal/src/Distribution/Simple/Build/PackageInfoModule.hs
@@ -20,9 +20,9 @@ import Prelude ()
 
 import Distribution.Package
 import Distribution.PackageDescription
+import Distribution.Pretty (prettyShow)
 import Distribution.Simple.Compiler
 import Distribution.Simple.LocalBuildInfo
-import Distribution.Pretty ( prettyShow )
 import Distribution.Utils.ShortText
 import Distribution.Version
 
@@ -40,10 +40,17 @@ generatePackageInfoModule pkg_descr lbi =
     Z.Z
       { Z.zPackageName = packageName pkg_descr
       , Z.zVersionDigits = show $ versionNumbers $ packageVersion pkg_descr
-      , Z.zSynopsis = show $ fromShortText $ synopsis pkg_descr
-      , Z.zCopyright = show $ fromShortText $ copyright pkg_descr
       , Z.zLicense = show $ prettyShow $ license pkg_descr
+      , Z.zCopyright = show $ fromShortText $ copyright pkg_descr
+      , Z.zMaintainer = show $ fromShortText $ maintainer pkg_descr
+      , Z.zAuthor = show $ fromShortText $ author pkg_descr
+      , Z.zStability = show $ fromShortText $ stability pkg_descr
       , Z.zHomepage = show $ fromShortText $ homepage pkg_descr
+      , Z.zPkgUrl = show $ fromShortText $ pkgUrl pkg_descr
+      , Z.zBugReports = show $ fromShortText $ bugReports pkg_descr
+      , Z.zSynopsis = show $ fromShortText $ synopsis pkg_descr
+      , Z.zDescription = show $ fromShortText $ description pkg_descr
+      , Z.zCategory = show $ fromShortText $ category pkg_descr
       , Z.zSupportsNoRebindableSyntax = supports_rebindable_syntax
       , Z.zManglePkgName = showPkgName
       , Z.zShow = show

--- a/Cabal/src/Distribution/Simple/Build/PackageInfoModule.hs
+++ b/Cabal/src/Distribution/Simple/Build/PackageInfoModule.hs
@@ -22,6 +22,7 @@ import Distribution.Package
 import Distribution.PackageDescription
 import Distribution.Simple.Compiler
 import Distribution.Simple.LocalBuildInfo
+import Distribution.Pretty ( prettyShow )
 import Distribution.Utils.ShortText
 import Distribution.Version
 
@@ -41,6 +42,7 @@ generatePackageInfoModule pkg_descr lbi =
       , Z.zVersionDigits = show $ versionNumbers $ packageVersion pkg_descr
       , Z.zSynopsis = fromShortText $ synopsis pkg_descr
       , Z.zCopyright = fromShortText $ copyright pkg_descr
+      , Z.zLicense = prettyShow $ license pkg_descr
       , Z.zHomepage = fromShortText $ homepage pkg_descr
       , Z.zSupportsNoRebindableSyntax = supports_rebindable_syntax
       }

--- a/Cabal/src/Distribution/Simple/Build/PackageInfoModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PackageInfoModule/Z.hs
@@ -1,39 +1,37 @@
+{- FOURMOLU_DISABLE -}
 {-# LANGUAGE DeriveGeneric #-}
-
-module Distribution.Simple.Build.PackageInfoModule.Z (render, Z (..)) where
-
+module Distribution.Simple.Build.PackageInfoModule.Z (render, Z(..)) where
 import Distribution.ZinzaPrelude
-
-data Z = Z
-  { zPackageName :: String
-  , zVersionDigits :: String
-  , zSynopsis :: String
-  , zCopyright :: String
-  , zLicense :: String
-  , zHomepage :: String
-  , zSupportsNoRebindableSyntax :: Bool
-  }
-  deriving (Generic)
-
+data Z
+    = Z {zPackageName :: PackageName,
+         zVersionDigits :: String,
+         zSynopsis :: String,
+         zCopyright :: String,
+         zLicense :: String,
+         zHomepage :: String,
+         zSupportsNoRebindableSyntax :: Bool,
+         zManglePkgName :: (PackageName -> String),
+         zShow :: (String -> String)}
+    deriving Generic
 render :: Z -> String
 render z_root = execWriter $ do
   if (zSupportsNoRebindableSyntax z_root)
-    then do
-      tell "{-# LANGUAGE NoRebindableSyntax #-}\n"
-      return ()
-    else do
-      return ()
+  then do
+    tell "{-# LANGUAGE NoRebindableSyntax #-}\n"
+    return ()
+  else do
+    return ()
   tell "{-# OPTIONS_GHC -fno-warn-missing-import-lists #-}\n"
   tell "{-# OPTIONS_GHC -w #-}\n"
   tell "module PackageInfo_"
-  tell (zPackageName z_root)
-  tell " (\n"
-  tell "    name,\n"
-  tell "    version,\n"
-  tell "    synopsis,\n"
-  tell "    copyright,\n"
-  tell "    license, \n"
-  tell "    homepage,\n"
+  tell (zManglePkgName z_root (zPackageName z_root))
+  tell "\n"
+  tell "  ( name\n"
+  tell "  , version\n"
+  tell "  , synopsis\n"
+  tell "  , copyright\n"
+  tell "  , license\n"
+  tell "  , homepage\n"
   tell "  ) where\n"
   tell "\n"
   tell "import Data.Version (Version(..))\n"
@@ -41,7 +39,8 @@ render z_root = execWriter $ do
   tell "\n"
   tell "name :: String\n"
   tell "name = "
-  tell (show $ zPackageName z_root)
+  tell (zShow z_root (zManglePkgName z_root (zPackageName z_root)))
+  tell "\n"
   tell "\n"
   tell "version :: Version\n"
   tell "version = Version "
@@ -50,17 +49,21 @@ render z_root = execWriter $ do
   tell "\n"
   tell "synopsis :: String\n"
   tell "synopsis = "
-  tell (show $ zSynopsis z_root)
+  tell (zSynopsis z_root)
+  tell "\n"
   tell "\n"
   tell "copyright :: String\n"
   tell "copyright = "
-  tell (show $ zCopyright z_root)
+  tell (zCopyright z_root)
+  tell "\n"
   tell "\n"
   tell "license :: String\n"
   tell "license = "
-  tell (show $ zLicense z_root)
+  tell (zLicense z_root)
+  tell "\n"
   tell "\n"
   tell "homepage :: String\n"
   tell "homepage = "
-  tell (show $ zHomepage z_root)
+  tell (zHomepage z_root)
+  tell "\n"
   tell "\n"

--- a/Cabal/src/Distribution/Simple/Build/PackageInfoModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PackageInfoModule/Z.hs
@@ -9,6 +9,7 @@ data Z = Z
   , zVersionDigits :: String
   , zSynopsis :: String
   , zCopyright :: String
+  , zLicense :: String
   , zHomepage :: String
   , zSupportsNoRebindableSyntax :: Bool
   }
@@ -31,6 +32,7 @@ render z_root = execWriter $ do
   tell "    version,\n"
   tell "    synopsis,\n"
   tell "    copyright,\n"
+  tell "    license, \n"
   tell "    homepage,\n"
   tell "  ) where\n"
   tell "\n"
@@ -53,6 +55,10 @@ render z_root = execWriter $ do
   tell "copyright :: String\n"
   tell "copyright = "
   tell (show $ zCopyright z_root)
+  tell "\n"
+  tell "license :: String\n"
+  tell "license = "
+  tell (show $ zLicense z_root)
   tell "\n"
   tell "homepage :: String\n"
   tell "homepage = "

--- a/Cabal/src/Distribution/Simple/Build/PackageInfoModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PackageInfoModule/Z.hs
@@ -5,10 +5,17 @@ import Distribution.ZinzaPrelude
 data Z
     = Z {zPackageName :: PackageName,
          zVersionDigits :: String,
-         zSynopsis :: String,
-         zCopyright :: String,
          zLicense :: String,
+         zCopyright :: String,
+         zMaintainer :: String,
+         zAuthor :: String,
+         zStability :: String,
          zHomepage :: String,
+         zPkgUrl :: String,
+         zBugReports :: String,
+         zSynopsis :: String,
+         zDescription :: String,
+         zCategory :: String,
          zSupportsNoRebindableSyntax :: Bool,
          zManglePkgName :: (PackageName -> String),
          zShow :: (String -> String)}
@@ -28,10 +35,17 @@ render z_root = execWriter $ do
   tell "\n"
   tell "  ( name\n"
   tell "  , version\n"
-  tell "  , synopsis\n"
-  tell "  , copyright\n"
   tell "  , license\n"
+  tell "  , copyright\n"
+  tell "  , maintainer\n"
+  tell "  , author\n"
+  tell "  , stability\n"
   tell "  , homepage\n"
+  tell "  , pkgUrl\n"
+  tell "  , bugReports\n"
+  tell "  , synopsis\n"
+  tell "  , description\n"
+  tell "  , category\n"
   tell "  ) where\n"
   tell "\n"
   tell "import Data.Version (Version(..))\n"
@@ -47,9 +61,9 @@ render z_root = execWriter $ do
   tell (zVersionDigits z_root)
   tell " []\n"
   tell "\n"
-  tell "synopsis :: String\n"
-  tell "synopsis = "
-  tell (zSynopsis z_root)
+  tell "license :: String\n"
+  tell "license = "
+  tell (zLicense z_root)
   tell "\n"
   tell "\n"
   tell "copyright :: String\n"
@@ -57,13 +71,47 @@ render z_root = execWriter $ do
   tell (zCopyright z_root)
   tell "\n"
   tell "\n"
-  tell "license :: String\n"
-  tell "license = "
-  tell (zLicense z_root)
+  tell "maintainer :: String\n"
+  tell "maintainer = "
+  tell (zMaintainer z_root)
+  tell "\n"
+  tell "\n"
+  tell "author :: String\n"
+  tell "author = "
+  tell (zAuthor z_root)
+  tell "\n"
+  tell "\n"
+  tell "stability :: String\n"
+  tell "stability = "
+  tell (zStability z_root)
   tell "\n"
   tell "\n"
   tell "homepage :: String\n"
   tell "homepage = "
   tell (zHomepage z_root)
   tell "\n"
+  tell "\n"
+  tell "pkgUrl :: String\n"
+  tell "pkgUrl = "
+  tell (zPkgUrl z_root)
+  tell "\n"
+  tell "\n"
+  tell "bugReports :: String\n"
+  tell "bugReports = "
+  tell (zBugReports z_root)
+  tell "\n"
+  tell "\n"
+  tell "synopsis :: String\n"
+  tell "synopsis = "
+  tell (zSynopsis z_root)
+  tell "\n"
+  tell "\n"
+  tell "description :: String\n"
+  tell "description = "
+  tell (zDescription z_root)
+  tell "\n"
+  tell "\n"
+  tell "category :: String\n"
+  tell "category = "
+  tell (zCategory z_root)
   tell "\n"

--- a/Cabal/src/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule.hs
@@ -24,12 +24,16 @@ import Prelude ()
 
 import Distribution.Package
 import Distribution.PackageDescription
+import Distribution.Pretty ()
 import Distribution.Simple.Compiler
+import Distribution.Simple.PackageIndex ( allPackages )
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Utils (shortRelativePath)
 import Distribution.System
+import Distribution.Utils.Path ( getSymbolicPath )
 import Distribution.Version
 
+import System.FilePath
 import qualified Distribution.Simple.Build.PathsModule.Z as Z
 
 -- ------------------------------------------------------------
@@ -44,6 +48,7 @@ generatePathsModule pkg_descr lbi clbi =
     Z.Z
       { Z.zPackageName = packageName pkg_descr
       , Z.zVersionDigits = show $ versionNumbers $ packageVersion pkg_descr
+      , Z.zLicenseFiles = show $ getSymbolicPath <$> licenseFiles pkg_descr
       , Z.zSupportsCpp = supports_cpp
       , Z.zSupportsNoRebindableSyntax = supports_rebindable_syntax
       , Z.zAbsolute = absolute
@@ -58,6 +63,7 @@ generatePathsModule pkg_descr lbi clbi =
       , Z.zLibdir = zLibdir
       , Z.zDynlibdir = zDynlibdir
       , Z.zDatadir = zDatadir
+      , Z.zDocdir = zDocdir
       , Z.zLibexecdir = zLibexecdir
       , Z.zSysconfdir = zSysconfdir
       }
@@ -93,6 +99,7 @@ generatePathsModule pkg_descr lbi clbi =
       , libdir = flat_libdir
       , dynlibdir = flat_dynlibdir
       , datadir = flat_datadir
+      , docdir = flat_docdir
       , libexecdir = flat_libexecdir
       , sysconfdir = flat_sysconfdir
       , prefix = flat_prefix
@@ -103,17 +110,19 @@ generatePathsModule pkg_descr lbi clbi =
       , libdir = flat_libdirrel
       , dynlibdir = flat_dynlibdirrel
       , datadir = flat_datadirrel
+      , docdir = flat_docdirrel
       , libexecdir = flat_libexecdirrel
       , sysconfdir = flat_sysconfdirrel
       } = prefixRelativeComponentInstallDirs (packageId pkg_descr) lbi cid
 
-    zBindir, zLibdir, zDynlibdir, zDatadir, zLibexecdir, zSysconfdir :: String
-    (zBindir, zLibdir, zDynlibdir, zDatadir, zLibexecdir, zSysconfdir)
+    zBindir, zLibdir, zDynlibdir, zDatadir, zDocdir, zLibexecdir, zSysconfdir :: String
+    (zBindir, zLibdir, zDynlibdir, zDatadir, zDocdir, zLibexecdir, zSysconfdir)
       | relocatable lbi =
           ( show flat_bindir_reloc
           , show flat_libdir_reloc
           , show flat_dynlibdir_reloc
           , show flat_datadir_reloc
+          , show flat_docdir_reloc
           , show flat_libexecdir_reloc
           , show flat_sysconfdir_reloc
           )
@@ -122,6 +131,7 @@ generatePathsModule pkg_descr lbi clbi =
           , show flat_libdir
           , show flat_dynlibdir
           , show flat_datadir
+          , show flat_docdir
           , show flat_libexecdir
           , show flat_sysconfdir
           )
@@ -130,6 +140,7 @@ generatePathsModule pkg_descr lbi clbi =
           , mkGetDir flat_libdir flat_libdirrel
           , mkGetDir flat_dynlibdir flat_dynlibdirrel
           , mkGetDir flat_datadir flat_datadirrel
+          , mkGetDir flat_docdir flat_docdirrel
           , mkGetDir flat_libexecdir flat_libexecdirrel
           , mkGetDir flat_sysconfdir flat_sysconfdirrel
           )
@@ -144,6 +155,7 @@ generatePathsModule pkg_descr lbi clbi =
     flat_libdir_reloc = shortRelativePath flat_prefix flat_libdir
     flat_dynlibdir_reloc = shortRelativePath flat_prefix flat_dynlibdir
     flat_datadir_reloc = shortRelativePath flat_prefix flat_datadir
+    flat_docdir_reloc = shortRelativePath flat_prefix flat_docdir
     flat_libexecdir_reloc = shortRelativePath flat_prefix flat_libexecdir
     flat_sysconfdir_reloc = shortRelativePath flat_prefix flat_sysconfdir
 

--- a/Cabal/src/Distribution/Simple/Build/PathsModule.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule.hs
@@ -26,14 +26,12 @@ import Distribution.Package
 import Distribution.PackageDescription
 import Distribution.Pretty ()
 import Distribution.Simple.Compiler
-import Distribution.Simple.PackageIndex ( allPackages )
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Utils (shortRelativePath)
 import Distribution.System
-import Distribution.Utils.Path ( getSymbolicPath )
+import Distribution.Utils.Path (getSymbolicPath)
 import Distribution.Version
 
-import System.FilePath
 import qualified Distribution.Simple.Build.PathsModule.Z as Z
 
 -- ------------------------------------------------------------

--- a/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
@@ -5,6 +5,7 @@ import Distribution.ZinzaPrelude
 data Z
     = Z {zPackageName :: PackageName,
          zVersionDigits :: String,
+         zLicenseFiles :: String,
          zSupportsCpp :: Bool,
          zSupportsNoRebindableSyntax :: Bool,
          zAbsolute :: Bool,
@@ -17,6 +18,7 @@ data Z
          zLibdir :: FilePath,
          zDynlibdir :: FilePath,
          zDatadir :: FilePath,
+         zDocdir :: FilePath,
          zLibexecdir :: FilePath,
          zSysconfdir :: FilePath,
          zNot :: (Bool -> Bool),
@@ -55,9 +57,9 @@ render z_root = execWriter $ do
   tell "module Paths_"
   tell (zManglePkgName z_root (zPackageName z_root))
   tell " (\n"
-  tell "    version,\n"
-  tell "    getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,\n"
-  tell "    getDataFileName, getSysconfDir\n"
+  tell "    version, licenseFiles,\n"
+  tell "    getBinDir, getLibDir, getDynLibDir, getDataDir, getDocDir, getLibexecDir,\n"
+  tell "    getDataFileName, getDocFileName, getSysconfDir\n"
   tell "  ) where\n"
   tell "\n"
   if (zNot z_root (zAbsolute z_root))
@@ -106,12 +108,22 @@ render z_root = execWriter $ do
   tell (zVersionDigits z_root)
   tell " []\n"
   tell "\n"
+  tell "licenseFiles :: [FilePath]\n"
+  tell "licenseFiles = "
+  tell (zLicenseFiles z_root)
+  tell "\n"
+  tell "\n"
   tell "getDataFileName :: FilePath -> IO FilePath\n"
   tell "getDataFileName name = do\n"
   tell "  dir <- getDataDir\n"
   tell "  return (dir `joinFileName` name)\n"
   tell "\n"
-  tell "getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath\n"
+  tell "getDocFileName :: FilePath -> IO FilePath\n"
+  tell "getDocFileName name = do\n"
+  tell "  dir <- getDocDir\n"
+  tell "  return (dir `joinFileName` name)\n"
+  tell "\n"
+  tell "getBinDir, getLibDir, getDynLibDir, getDataDir, getDocDir, getLibexecDir, getSysconfDir :: IO FilePath\n"
   tell "\n"
   let
     z_var0_function_defs = do
@@ -168,6 +180,11 @@ render z_root = execWriter $ do
     tell "_datadir\")    (\\_ -> getPrefixDirReloc $ "
     tell (zDatadir z_root)
     tell ")\n"
+    tell "getDocDir     = catchIO (getEnv \""
+    tell (zManglePkgName z_root (zPackageName z_root))
+    tell "_docdir\")     (\\_ -> getPrefixDirReloc $ "
+    tell (zDocdir z_root)
+    tell ")\n"
     tell "getLibexecDir = catchIO (getEnv \""
     tell (zManglePkgName z_root (zPackageName z_root))
     tell "_libexecdir\") (\\_ -> getPrefixDirReloc $ "
@@ -199,6 +216,9 @@ render z_root = execWriter $ do
       tell "datadir    = "
       tell (zDatadir z_root)
       tell "\n"
+      tell "docdir     = "
+      tell (zDocdir z_root)
+      tell "\n"
       tell "libexecdir = "
       tell (zLibexecdir z_root)
       tell "\n"
@@ -218,6 +238,9 @@ render z_root = execWriter $ do
       tell "getDataDir    = catchIO (getEnv \""
       tell (zManglePkgName z_root (zPackageName z_root))
       tell "_datadir\")    (\\_ -> return datadir)\n"
+      tell "getDocDir     = catchIO (getEnv \""
+      tell (zManglePkgName z_root (zPackageName z_root))
+      tell "_docdir\")     (\\_ -> return docdir)\n"
       tell "getLibexecDir = catchIO (getEnv \""
       tell (zManglePkgName z_root (zPackageName z_root))
       tell "_libexecdir\") (\\_ -> return libexecdir)\n"
@@ -249,6 +272,9 @@ render z_root = execWriter $ do
         tell "_datadir\")    (\\_ -> "
         tell (zDatadir z_root)
         tell ")\n"
+        tell "getDocDir     = "
+        tell (zDocdir z_root)
+        tell "\n"
         tell "getLibexecDir = "
         tell (zLibexecdir z_root)
         tell "\n"

--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,18 @@ $(SPDX_EXCEPTION_HS) : templates/SPDX.LicenseExceptionId.template.hs cabal-dev-s
 
 TEMPLATE_MACROS:=Cabal/src/Distribution/Simple/Build/Macros/Z.hs
 TEMPLATE_PATHS:=Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
+TEMPLATE_PKGINFO:=Cabal/src/Distribution/Simple/Build/PackageInfoModule/Z.hs
 
-templates : phony $(TEMPLATE_MACROS) $(TEMPLATE_PATHS)
+templates : phony $(TEMPLATE_MACROS) $(TEMPLATE_PATHS) $(TEMPLATE_PKGINFO)
 
 $(TEMPLATE_MACROS) : templates/cabal_macros.template.h cabal-dev-scripts/src/GenCabalMacros.hs
 	cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-cabal-macros -- $< $@
 
 $(TEMPLATE_PATHS) : templates/Paths_pkg.template.hs cabal-dev-scripts/src/GenPathsModule.hs
 	cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-paths-module -- $< $@
+
+$(TEMPLATE_PKGINFO) : templates/PackageInfo_pkg.template.hs cabal-dev-scripts/src/GenPackageInfoModule.hs
+	cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-pkg-info-module -- $< $@
 
 # generated docs
 

--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -18,7 +18,7 @@ executable gen-spdx
   ghc-options:      -Wall
   build-depends:
     , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.1.1.0
-    , base                  >=4.10     && <4.17
+    , base                  >=4.10
     , bytestring
     , containers
     , Diff                  ^>=0.4
@@ -35,7 +35,7 @@ executable gen-spdx-exc
   ghc-options:      -Wall
   build-depends:
     , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.1.1.0
-    , base                  >=4.10     && <4.17
+    , base                  >=4.10
     , bytestring
     , containers
     , Diff                  ^>=0.4
@@ -73,6 +73,20 @@ executable gen-cabal-macros
 executable gen-paths-module
   default-language: Haskell2010
   main-is:          GenPathsModule.hs
+  other-modules:    Capture
+  hs-source-dirs:   src
+  ghc-options:      -Wall
+  build-depends:
+    , base
+    , bytestring
+    , Cabal
+    , syb               ^>=0.7.1
+    , template-haskell
+    , zinza             ^>=0.2
+
+executable gen-pkg-info-module
+  default-language: Haskell2010
+  main-is:          GenPackageInfoModule.hs
   other-modules:    Capture
   hs-source-dirs:   src
   ghc-options:      -Wall

--- a/cabal-dev-scripts/src/GenPackageInfoModule.hs
+++ b/cabal-dev-scripts/src/GenPackageInfoModule.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Main (main) where
+
+import Control.Exception              (SomeException (..), catch, displayException)
+import Distribution.Types.PackageName (PackageName)
+import GHC.Generics                   (Generic)
+import System.Environment             (getArgs)
+import System.Exit                    (exitFailure)
+import Zinza
+       (ModuleConfig (..), Ty (..), Zinza (..), genericFromValueSFP, genericToTypeSFP,
+       genericToValueSFP, parseAndCompileModuleIO)
+
+import Capture
+
+-------------------------------------------------------------------------------
+-- Inputs
+-------------------------------------------------------------------------------
+
+$(capture "decls" [d|
+    data Z = Z
+        { zPackageName                :: PackageName
+        , zVersionDigits              :: String
+        , zSynopsis                   :: String
+        , zCopyright                  :: String
+        , zLicense                    :: String
+        , zHomepage                   :: String
+
+        , zSupportsNoRebindableSyntax :: Bool
+
+        , zManglePkgName              :: PackageName -> String
+        , zShow                       :: String -> String
+        }
+      deriving (Generic)
+    |])
+
+-------------------------------------------------------------------------------
+-- Main
+-------------------------------------------------------------------------------
+
+withIO :: (FilePath -> FilePath -> IO a) -> IO a
+withIO k = do
+    args <- getArgs
+    case args of
+        [src,tgt] -> k src tgt `catch` \(SomeException e) -> do
+            putStrLn $ "Exception: " ++ displayException e
+            exitFailure
+        _         -> do
+            putStrLn "Usage cabal run ... source.temeplate.ext target.ext"
+            exitFailure
+
+main :: IO ()
+main = withIO $ \src tgt -> do
+    mdl <- parseAndCompileModuleIO config src
+    writeFile tgt mdl
+
+config :: ModuleConfig Z
+config = ModuleConfig
+    { mcRender = "render"
+    , mcHeader =
+        [ "{- FOURMOLU_DISABLE -}"
+        , "{-# LANGUAGE DeriveGeneric #-}"
+        , "module Distribution.Simple.Build.PackageInfoModule.Z (render, Z(..)) where"
+        , "import Distribution.ZinzaPrelude"
+        , decls
+        , "render :: Z -> String"
+        ]
+    }
+
+-------------------------------------------------------------------------------
+-- Zinza instances
+-------------------------------------------------------------------------------
+
+instance Zinza Z where
+    toType    = genericToTypeSFP
+    toValue   = genericToValueSFP
+    fromValue = genericFromValueSFP
+
+-------------------------------------------------------------------------------
+-- Orphans
+-------------------------------------------------------------------------------
+
+instance Zinza PackageName where
+    toType _    = TyString (Just "prettyShow")
+    toValue _   = error "not needed"
+    fromValue _ = error "not needed"

--- a/cabal-dev-scripts/src/GenPackageInfoModule.hs
+++ b/cabal-dev-scripts/src/GenPackageInfoModule.hs
@@ -24,10 +24,17 @@ $(capture "decls" [d|
     data Z = Z
         { zPackageName                :: PackageName
         , zVersionDigits              :: String
-        , zSynopsis                   :: String
-        , zCopyright                  :: String
         , zLicense                    :: String
+        , zCopyright                  :: String
+        , zMaintainer                 :: String
+        , zAuthor                     :: String
+        , zStability                  :: String
         , zHomepage                   :: String
+        , zPkgUrl                     :: String
+        , zBugReports                 :: String
+        , zSynopsis                   :: String
+        , zDescription                :: String
+        , zCategory                   :: String
 
         , zSupportsNoRebindableSyntax :: Bool
 

--- a/cabal-dev-scripts/src/GenPathsModule.hs
+++ b/cabal-dev-scripts/src/GenPathsModule.hs
@@ -25,6 +25,7 @@ $(capture "decls" [d|
     data Z = Z
         { zPackageName                :: PackageName
         , zVersionDigits              :: String
+        , zLicenseFiles               :: String
         , zSupportsCpp                :: Bool
         , zSupportsNoRebindableSyntax :: Bool
         , zAbsolute                   :: Bool
@@ -38,6 +39,7 @@ $(capture "decls" [d|
         , zLibdir     :: FilePath
         , zDynlibdir  :: FilePath
         , zDatadir    :: FilePath
+        , zDocdir     :: FilePath
         , zLibexecdir :: FilePath
         , zSysconfdir :: FilePath
 

--- a/templates/PackageInfo_pkg.template.hs
+++ b/templates/PackageInfo_pkg.template.hs
@@ -6,10 +6,17 @@
 module PackageInfo_{{ manglePkgName packageName }}
   ( name
   , version
-  , synopsis
-  , copyright
   , license
+  , copyright
+  , maintainer
+  , author
+  , stability
   , homepage
+  , pkgUrl
+  , bugReports
+  , synopsis
+  , description
+  , category
   ) where
 
 import Data.Version (Version(..))
@@ -21,15 +28,35 @@ name = {{ show (manglePkgName packageName) }}
 version :: Version
 version = Version {{ versionDigits }} []
 
-synopsis :: String
-synopsis = {{ synopsis }}
+license :: String
+license = {{ license }}
 
 copyright :: String
 copyright = {{ copyright }}
 
-license :: String
-license = {{ license }}
+maintainer :: String
+maintainer = {{ maintainer }}
+
+author :: String
+author = {{ author }}
+
+stability :: String
+stability = {{ stability }}
 
 homepage :: String
 homepage = {{ homepage }}
 
+pkgUrl :: String
+pkgUrl = {{ pkgUrl }}
+
+bugReports :: String
+bugReports = {{ bugReports }}
+
+synopsis :: String
+synopsis = {{ synopsis }}
+
+description :: String
+description = {{ description }}
+
+category :: String
+category = {{ category }}

--- a/templates/PackageInfo_pkg.template.hs
+++ b/templates/PackageInfo_pkg.template.hs
@@ -1,0 +1,35 @@
+{% if supportsNoRebindableSyntax %}
+{-# LANGUAGE NoRebindableSyntax #-}
+{% endif %}
+{-# OPTIONS_GHC -fno-warn-missing-import-lists #-}
+{-# OPTIONS_GHC -w #-}
+module PackageInfo_{{ manglePkgName packageName }}
+  ( name
+  , version
+  , synopsis
+  , copyright
+  , license
+  , homepage
+  ) where
+
+import Data.Version (Version(..))
+import Prelude
+
+name :: String
+name = {{ show (manglePkgName packageName) }}
+
+version :: Version
+version = Version {{ versionDigits }} []
+
+synopsis :: String
+synopsis = {{ synopsis }}
+
+copyright :: String
+copyright = {{ copyright }}
+
+license :: String
+license = {{ license }}
+
+homepage :: String
+homepage = {{ homepage }}
+

--- a/templates/Paths_pkg.template.hs
+++ b/templates/Paths_pkg.template.hs
@@ -15,9 +15,9 @@
 {-# OPTIONS_GHC -fno-warn-missing-import-lists #-}
 {-# OPTIONS_GHC -w #-}
 module Paths_{{ manglePkgName packageName }} (
-    version,
-    getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir,
-    getDataFileName, getSysconfDir
+    version, licenseFiles,
+    getBinDir, getLibDir, getDynLibDir, getDataDir, getDocDir, getLibexecDir,
+    getDataFileName, getDocFileName, getSysconfDir
   ) where
 
 {% if not absolute %}
@@ -56,12 +56,20 @@ catchIO = Exception.catch
 version :: Version
 version = Version {{ versionDigits }} []
 
+licenseFiles :: [FilePath]
+licenseFiles = {{ licenseFiles }}
+
 getDataFileName :: FilePath -> IO FilePath
 getDataFileName name = do
   dir <- getDataDir
   return (dir `joinFileName` name)
 
-getBinDir, getLibDir, getDynLibDir, getDataDir, getLibexecDir, getSysconfDir :: IO FilePath
+getDocFileName :: FilePath -> IO FilePath
+getDocFileName name = do
+  dir <- getDocDir
+  return (dir `joinFileName` name)
+
+getBinDir, getLibDir, getDynLibDir, getDataDir, getDocDir, getLibexecDir, getSysconfDir :: IO FilePath
 
 {% defblock function_defs %}
 minusFileName :: FilePath -> String -> FilePath
@@ -100,6 +108,7 @@ getBinDir     = catchIO (getEnv "{{ manglePkgName packageName }}_bindir")     (\
 getLibDir     = catchIO (getEnv "{{ manglePkgName packageName }}_libdir")     (\_ -> getPrefixDirReloc $ {{ libdir }})
 getDynLibDir  = catchIO (getEnv "{{ manglePkgName packageName }}_dynlibdir")  (\_ -> getPrefixDirReloc $ {{ dynlibdir }})
 getDataDir    = catchIO (getEnv "{{ manglePkgName packageName }}_datadir")    (\_ -> getPrefixDirReloc $ {{ datadir }})
+getDocDir     = catchIO (getEnv "{{ manglePkgName packageName }}_docdir")     (\_ -> getPrefixDirReloc $ {{ docdir }})
 getLibexecDir = catchIO (getEnv "{{ manglePkgName packageName }}_libexecdir") (\_ -> getPrefixDirReloc $ {{ libexecdir }})
 getSysconfDir = catchIO (getEnv "{{ manglePkgName packageName }}_sysconfdir") (\_ -> getPrefixDirReloc $ {{ sysconfdir }})
 
@@ -112,6 +121,7 @@ bindir     = {{ bindir }}
 libdir     = {{ libdir }}
 dynlibdir  = {{ dynlibdir }}
 datadir    = {{ datadir }}
+docdir     = {{ docdir }}
 libexecdir = {{ libexecdir }}
 sysconfdir = {{ sysconfdir }}
 
@@ -119,6 +129,7 @@ getBinDir     = catchIO (getEnv "{{ manglePkgName packageName }}_bindir")     (\
 getLibDir     = catchIO (getEnv "{{ manglePkgName packageName }}_libdir")     (\_ -> return libdir)
 getDynLibDir  = catchIO (getEnv "{{ manglePkgName packageName }}_dynlibdir")  (\_ -> return dynlibdir)
 getDataDir    = catchIO (getEnv "{{ manglePkgName packageName }}_datadir")    (\_ -> return datadir)
+getDocDir     = catchIO (getEnv "{{ manglePkgName packageName }}_docdir")     (\_ -> return docdir)
 getLibexecDir = catchIO (getEnv "{{ manglePkgName packageName }}_libexecdir") (\_ -> return libexecdir)
 getSysconfDir = catchIO (getEnv "{{ manglePkgName packageName }}_sysconfdir") (\_ -> return sysconfdir)
 
@@ -131,6 +142,7 @@ getBinDir     = getPrefixDirRel $ {{ bindir }}
 getLibDir     = {{ libdir }}
 getDynLibDir  = {{ dynlibdir }}
 getDataDir    = catchIO (getEnv "{{ manglePkgName packageName }}_datadir")    (\_ -> {{ datadir }})
+getDocDir     = {{ docdir }}
 getLibexecDir = {{ libexecdir }}
 getSysconfDir = {{ sysconfdir }}
 


### PR DESCRIPTION
This PR put more definitions in the automatically generated modules, i.e.

* `Paths_<pkgname>` includes additionally the path to doc and file names of license files
* `PackageInfo_<pkgname>` includes many more fields of a package description including `bug-reports`.
* `PackageInfo_<pkgname>` is now generated by `Zinza`.

---

**Template Α: This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

Bonus points for added automated tests!


