### PR TITLE
Remove outdated `install` method

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -87,15 +87,6 @@ with any other suitable archive.
 
 This will install the ``xmonad`` package plus all of its dependencies.
 
-In addition to packages that have been published in an archive,
-developers can install packages from local or remote tarball files, for
-example
-
-::
-
-    $ cabal install foo-1.0.tar.gz
-    $ cabal install http://example.com/foo-1.0.tar.gz
-
 Cabal provides a number of ways for a user to customise how and where a
 package is installed. They can decide where a package will be installed,
 which Haskell implementation to use and whether to build optimised code


### PR DESCRIPTION
You cannot install packages with `cabal install lentil-1.5.5.4.tar.gz` anymore.

The question is: should we fix the docs or `cabal`? I picked the former, since I haven’t witnessed installing with `cabal install foo.tar.gz` in the wild. If someone used this or knows someone else who used this, please add your comment.

Closes #9261.

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

