### PR TITLE
Chain configuration of ldProgram

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        ghc: ["9.6.3", "9.4.7", "9.2.8", "9.0.2", "8.10.7", "8.8.4", "8.6.5", "8.4.4"]
+        ghc: ["9.6.3", "9.4.7", "9.2.7", "9.0.2", "8.10.7", "8.8.4", "8.6.5", "8.4.4"]
         exclude:
           # corrupts GHA cache or the fabric of reality itself, see https://github.com/haskell/cabal/issues/8356
           - os: "windows-latest"
@@ -73,7 +73,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
 
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -215,7 +215,7 @@ jobs:
           apt-get update
           apt-get install -y ghc-${{ matrix.extra-ghc }}-dyn
 
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
@@ -268,7 +268,7 @@ jobs:
             sudo chown -R $USER /usr/local/.ghcup
             sudo chmod -R 777 /usr/local/.ghcup
           fi
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}

--- a/Cabal/src/Distribution/Simple/Errors.hs
+++ b/Cabal/src/Distribution/Simple/Errors.hs
@@ -170,6 +170,7 @@ data CabalException
   | NoProgramFound String VersionRange
   | BadVersionDb String Version VersionRange FilePath
   | UnknownVersionDb String VersionRange FilePath
+  | CombineObjectFilesRelocatableUnsupported
   deriving (Show, Typeable)
 
 exceptionCode :: CabalException -> Int
@@ -301,6 +302,7 @@ exceptionCode e = case e of
   NoProgramFound{} -> 7620
   BadVersionDb{} -> 8038
   UnknownVersionDb{} -> 1008
+  CombineObjectFilesRelocatableUnsupported -> 4346
 
 versionRequirement :: VersionRange -> String
 versionRequirement range
@@ -791,3 +793,6 @@ exceptionMessage e = case e of
       ++ " is required but the version of "
       ++ locationPath
       ++ " could not be determined."
+  CombineObjectFilesRelocatableUnsupported ->
+    "combineObjectFiles: Have been asked to combine object "
+      ++ "files but the configured linker does not support relocations."

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -114,7 +114,9 @@ configureToolchain _implInfo ghcProg ghcInfo =
     . addKnownProgram
       ldProgram
         { programFindLocation = findProg ldProgramName extraLdPath
-        , programPostConf = configureLd
+        , programPostConf = \v cp ->
+            -- Call any existing configuration first and then add any new configuration
+            configureLd v =<< programPostConf ldProgram v cp
         }
     . addKnownProgram
       arProgram

--- a/Cabal/src/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/src/Distribution/Simple/Program/Builtin.hs
@@ -370,7 +370,19 @@ ldProgram =
             -- `lld` only accepts `-help`.
             `catchIO` (\_ -> return "")
         let k = "Supports relocatable output"
-            v = if "--relocatable" `isInfixOf` ldHelpOutput then "YES" else "NO"
+            -- Standard GNU `ld` ues `--relocatable` while `ld.gold` uses
+            -- `-relocatable` (single `-`).
+            v
+              | "-relocatable" `isInfixOf` ldHelpOutput = "YES"
+              -- ld64 on macOS has this lovely response for "--help"
+              --
+              --   ld64: For information on command line options please use 'man ld'.
+              --
+              -- it does however support -r, if you read the manpage
+              -- (e.g. https://www.manpagez.com/man/1/ld64/)
+              | "ld64:" `isPrefixOf` ldHelpOutput = "YES"
+              | otherwise = "NO"
+
             m = Map.insert k v (programProperties ldProg)
         return $ ldProg{programProperties = m}
     }

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -322,12 +322,7 @@ defaultConfigFlags progDb =
     , configCabalFilePath = NoFlag
     , configVerbosity = Flag normal
     , configUserInstall = Flag False -- TODO: reverse this
-#if defined(mingw32_HOST_OS)
-        -- See #8062 and GHC #21019.
-    , configGHCiLib = Flag False
-#else
-    , configGHCiLib = NoFlag
-#endif
+    , configGHCiLib = Flag True
     , configSplitSections = Flag False
     , configSplitObjs = Flag False -- takes longer, so turn off by default
     , configStripExes = NoFlag

--- a/cabal-testsuite/PackageTests/Ambiguity/setup-package-import.test.hs
+++ b/cabal-testsuite/PackageTests/Ambiguity/setup-package-import.test.hs
@@ -3,6 +3,9 @@ import Test.Cabal.Prelude
 -- qualified imports.  (Paper Backpack doesn't natively support
 -- this but we must!)
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
         withDirectory "p" $ setup_install []
         withDirectory "q" $ setup_install []

--- a/cabal-testsuite/PackageTests/Ambiguity/setup-reexport.test.hs
+++ b/cabal-testsuite/PackageTests/Ambiguity/setup-reexport.test.hs
@@ -2,8 +2,11 @@ import Test.Cabal.Prelude
 -- Test that we can resolve a module name ambiguity when reexporting
 -- by explicitly specifying what package we want.
 main = setupAndCabalTest $ do
-    skipUnlessGhcVersion ">= 7.9"
-    withPackageDb $ do
+    isWin <- isWindows
+    ghc94 <- isGhcVersion "== 9.4.*"
+    expectBrokenIf (isWin && ghc94) 9414 $ do
+      skipUnlessGhcVersion ">= 7.9"
+      withPackageDb $ do
         withDirectory "p" $ setup_install []
         withDirectory "q" $ setup_install []
         withDirectory "reexport" $ setup_install []

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/setup-internal.test.hs
@@ -1,5 +1,8 @@
 import Test.Cabal.Prelude
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     skipUnlessGhcVersion ">= 8.1"
     withPackageDb $ do
         setup_install ["--cabal-file", "Includes2.cabal"]

--- a/cabal-testsuite/PackageTests/Backpack/Includes3/setup-internal.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes3/setup-internal.test.hs
@@ -1,5 +1,8 @@
 import Test.Cabal.Prelude
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     skipUnlessGhcVersion ">= 8.1"
     withPackageDb $ do
       setup_install []

--- a/cabal-testsuite/PackageTests/Backpack/Includes4/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes4/setup.test.hs
@@ -1,5 +1,8 @@
 import Test.Cabal.Prelude
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     skipUnlessGhcVersion ">= 8.1"
     withPackageDb $ do
       setup_install []

--- a/cabal-testsuite/PackageTests/Backpack/Includes5/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes5/setup.test.hs
@@ -1,5 +1,8 @@
 import Test.Cabal.Prelude
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     skipUnlessGhcVersion ">= 8.1"
     setup "configure" []
     r <- fails $ setup' "build" []

--- a/cabal-testsuite/PackageTests/Backpack/Reexport1/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Reexport1/setup.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 main = setupAndCabalTest $ do
-    skipUnlessGhcVersion ">= 8.1"
+  skipUnlessGhcVersion ">= 8.1"
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
       withDirectory "p" $ setup_install_with_docs []
       withDirectory "q" $ do

--- a/cabal-testsuite/PackageTests/Backpack/T4754/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T4754/setup.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 main = setupAndCabalTest $ do
-    skipUnlessGhcVersion ">= 8.1"
+  skipUnlessGhcVersion ">= 8.1"
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     skipUnless "no profiling libs" =<< hasProfiledLibraries
     setup "configure" ["--enable-profiling"]
     setup "build" []

--- a/cabal-testsuite/PackageTests/Backpack/T5634/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T5634/setup.test.hs
@@ -1,5 +1,8 @@
 import Test.Cabal.Prelude
 main = setupAndCabalTest $ do
-    skipUnlessGhcVersion ">= 8.1"
+  skipUnlessGhcVersion ">= 8.1"
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     setup "configure" []
     setup "build" []

--- a/cabal-testsuite/PackageTests/BenchmarkExeV10/setup.test.hs
+++ b/cabal-testsuite/PackageTests/BenchmarkExeV10/setup.test.hs
@@ -1,3 +1,7 @@
 import Test.Cabal.Prelude
 -- Test if exitcode-stdio-1.0 benchmark builds correctly
-main = setupAndCabalTest $ setup_build ["--enable-benchmarks"]
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    setup_build ["--enable-benchmarks"]

--- a/cabal-testsuite/PackageTests/BuildDeps/InternalLibrary1/setup.test.hs
+++ b/cabal-testsuite/PackageTests/BuildDeps/InternalLibrary1/setup.test.hs
@@ -1,4 +1,8 @@
 import Test.Cabal.Prelude
 -- Test executable depends on internal library.
-main = setupAndCabalTest $ setup_build []
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    setup_build []
 

--- a/cabal-testsuite/PackageTests/BuildDeps/InternalLibrary2/setup.test.hs
+++ b/cabal-testsuite/PackageTests/BuildDeps/InternalLibrary2/setup.test.hs
@@ -1,9 +1,13 @@
 import Test.Cabal.Prelude
-main = setupAndCabalTest . withPackageDb $ do
-    withDirectory "to-install" $ setup_install []
-    setup_build []
-    r <- runExe' "lemon" []
-    assertEqual
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    withPackageDb $ do
+      withDirectory "to-install" $ setup_install []
+      setup_build []
+      r <- runExe' "lemon" []
+      assertEqual
         ("executable should have linked with the internal library")
         ("foo foo myLibFunc internal")
         (concatOutput (resultOutput r))

--- a/cabal-testsuite/PackageTests/BuildDeps/InternalLibrary3/setup.test.hs
+++ b/cabal-testsuite/PackageTests/BuildDeps/InternalLibrary3/setup.test.hs
@@ -1,11 +1,15 @@
 import Test.Cabal.Prelude
 -- Test that internal library is preferred to an installed on
 -- with the same name and LATER version
-main = setupAndCabalTest . withPackageDb $ do
-    withDirectory "to-install" $ setup_install []
-    setup_build []
-    r <- runExe' "lemon" []
-    assertEqual
-        ("executable should have linked with the internal library")
-        ("foo foo myLibFunc internal")
-        (concatOutput (resultOutput r))
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    withPackageDb $ do
+      withDirectory "to-install" $ setup_install []
+      setup_build []
+      r <- runExe' "lemon" []
+      assertEqual
+          ("executable should have linked with the internal library")
+          ("foo foo myLibFunc internal")
+          (concatOutput (resultOutput r))

--- a/cabal-testsuite/PackageTests/BuildDeps/SameDepsAllRound/setup.test.hs
+++ b/cabal-testsuite/PackageTests/BuildDeps/SameDepsAllRound/setup.test.hs
@@ -2,5 +2,9 @@ import Test.Cabal.Prelude
 -- Test "old build-dep behavior", where we should get the
 -- same package dependencies on all targets if setup-version
 -- is sufficiently old.
-main = setupAndCabalTest $ setup_build []
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    setup_build []
 

--- a/cabal-testsuite/PackageTests/BuildDeps/TargetSpecificDeps2/setup.test.hs
+++ b/cabal-testsuite/PackageTests/BuildDeps/TargetSpecificDeps2/setup.test.hs
@@ -1,4 +1,8 @@
 import Test.Cabal.Prelude
 -- This is a control on ../TargetSpecificDeps1/setup.test.hs; it should
 -- succeed.
-main = setupAndCabalTest $ setup_build []
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    setup_build []

--- a/cabal-testsuite/PackageTests/BuildTools/Internal/setup.test.hs
+++ b/cabal-testsuite/PackageTests/BuildTools/Internal/setup.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 -- Test PATH-munging
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     setup_build []
     runExe' "hello-world" []
         >>= assertOutputContains "1111"

--- a/cabal-testsuite/PackageTests/CabalMacros/setup.test.hs
+++ b/cabal-testsuite/PackageTests/CabalMacros/setup.test.hs
@@ -2,6 +2,9 @@ import Test.Cabal.Prelude
 import qualified Data.ByteString.Char8 as BS8
 
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     env <- getTestEnv
     let mode = testRecordMode env
 

--- a/cabal-testsuite/PackageTests/CmmSources/setup.test.hs
+++ b/cabal-testsuite/PackageTests/CmmSources/setup.test.hs
@@ -1,7 +1,10 @@
 import Test.Cabal.Prelude
 
 main = setupTest $ do
-    skipUnlessGhcVersion ">= 7.8"
+  skipUnlessGhcVersion ">= 7.8"
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     setup "configure" []
     res <- setup' "build" []
     assertOutputContains "= Post common block elimination =" res

--- a/cabal-testsuite/PackageTests/CmmSourcesDyn/setup.test.hs
+++ b/cabal-testsuite/PackageTests/CmmSourcesDyn/setup.test.hs
@@ -1,7 +1,10 @@
 import Test.Cabal.Prelude
 
 main = setupTest $ do
-    skipIf "ghc < 7.8" =<< isGhcVersion "< 7.8"
+  skipIf "ghc < 7.8" =<< isGhcVersion "< 7.8"
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     setup "configure" []
     res <- setup' "build" []
     assertOutputContains "= Post common block elimination =" res

--- a/cabal-testsuite/PackageTests/ConfigureComponent/SubLib/setup-explicit-fail.test.hs
+++ b/cabal-testsuite/PackageTests/ConfigureComponent/SubLib/setup-explicit-fail.test.hs
@@ -2,6 +2,9 @@
 import Test.Cabal.Prelude
 -- NB: The --dependency flag is not supported by cabal-install
 main = setupTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     withPackageDb $ do
         base_id <- getIPID "base"
         setup_install ["sublib", "--cid", "sublib-0.1-abc"]

--- a/cabal-testsuite/PackageTests/ConfigureComponent/SubLib/setup-explicit.test.hs
+++ b/cabal-testsuite/PackageTests/ConfigureComponent/SubLib/setup-explicit.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 -- NB: The --dependency flag is not supported by cabal-install
 main = setupTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
         base_id <- getIPID "base"
         setup_install ["sublib", "--cid", "sublib-0.1-abc"]

--- a/cabal-testsuite/PackageTests/ConfigureComponent/SubLib/setup.test.hs
+++ b/cabal-testsuite/PackageTests/ConfigureComponent/SubLib/setup.test.hs
@@ -5,6 +5,9 @@ import Test.Cabal.Prelude
 -- a problem for you; the advised workaround is to use Setup directly
 -- if you need per-component builds.
 main = setupTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
         setup_install ["sublib"]
         setup_install ["exe"]

--- a/cabal-testsuite/PackageTests/ConfigureComponent/Test/setup.test.hs
+++ b/cabal-testsuite/PackageTests/ConfigureComponent/Test/setup.test.hs
@@ -3,6 +3,9 @@ import Test.Cabal.Prelude
 -- dependency solver doesn't know how to solve for only
 -- a single component of a package.
 main = setupTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
         setup_install ["test-for-cabal"]
         withDirectory "testlib" $ setup_install []

--- a/cabal-testsuite/PackageTests/CopyComponent/Lib/setup.test.hs
+++ b/cabal-testsuite/PackageTests/CopyComponent/Lib/setup.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 -- Test that per-component copy works, when only building library
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
         setup "configure" []
         setup "build" ["lib:p"]

--- a/cabal-testsuite/PackageTests/CopyHie/setup.test.hs
+++ b/cabal-testsuite/PackageTests/CopyHie/setup.test.hs
@@ -1,7 +1,11 @@
 import Test.Cabal.Prelude
 
-main = setupAndCabalTest $ withPackageDb $ do
-  skipUnlessGhcVersion ">= 8.8"
-  setup_install ["hie-local"]
-  env <- getTestEnv
-  shouldExist $ testLibInstallDir env </> "hie-local-0.1.0.0" </> "extra-compilation-artifacts" </> "hie" </> "HieLocal.hie"
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
+    withPackageDb $ do
+      skipUnlessGhcVersion ">= 8.8"
+      setup_install ["hie-local"]
+      env <- getTestEnv
+      shouldExist $ testLibInstallDir env </> "hie-local-0.1.0.0" </> "extra-compilation-artifacts" </> "hie" </> "HieLocal.hie"

--- a/cabal-testsuite/PackageTests/DeterministicAr/setup-default-ar.test.hs
+++ b/cabal-testsuite/PackageTests/DeterministicAr/setup-default-ar.test.hs
@@ -7,6 +7,9 @@ import Test.Cabal.CheckArMetadata
 
 -- Test that setup deterministically generates object archives
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     setup_build []
     dist_dir <- fmap testDistDir getTestEnv
     lbi <- getLocalBuildInfoM

--- a/cabal-testsuite/PackageTests/DeterministicAr/setup-old-ar-without-at-args.test.hs
+++ b/cabal-testsuite/PackageTests/DeterministicAr/setup-old-ar-without-at-args.test.hs
@@ -7,6 +7,9 @@ import Test.Cabal.CheckArMetadata
 
 -- Test that setup deterministically generates object archives
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     setup_build ["--disable-response-files"]
     dist_dir <- fmap testDistDir getTestEnv
     lbi <- getLocalBuildInfoM

--- a/cabal-testsuite/PackageTests/InternalLibraries/Haddock/haddock.test.hs
+++ b/cabal-testsuite/PackageTests/InternalLibraries/Haddock/haddock.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 -- https://github.com/haskell/cabal/issues/1919
-main = setupAndCabalTest $
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
         setup_install []
         setup "haddock" []

--- a/cabal-testsuite/PackageTests/InternalLibraries/Library/setup.test.hs
+++ b/cabal-testsuite/PackageTests/InternalLibraries/Library/setup.test.hs
@@ -1,7 +1,10 @@
 import Test.Cabal.Prelude
 -- Internal library used by public library; it must be installed and
 -- registered.
-main = setupAndCabalTest $
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
         withDirectory "foolib" $ setup_install []
         withDirectory "fooexe" $ do

--- a/cabal-testsuite/PackageTests/InternalLibraries/setup-gen-pkg-config.test.hs
+++ b/cabal-testsuite/PackageTests/InternalLibraries/setup-gen-pkg-config.test.hs
@@ -5,6 +5,9 @@ import System.Directory
 import Data.List
 -- Test to see if --gen-pkg-config works.
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     withPackageDb $ do
         withDirectory "p" $ do
             setup_build []

--- a/cabal-testsuite/PackageTests/InternalLibraries/setup-gen-script.test.hs
+++ b/cabal-testsuite/PackageTests/InternalLibraries/setup-gen-script.test.hs
@@ -1,13 +1,15 @@
 import Test.Cabal.Prelude
 -- Test to see if --gen-script
 main = setupAndCabalTest $ do
-    is_windows <- isWindows
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     withPackageDb $ do
         withDirectory "p" $ do
             setup_build []
             setup "copy" []
             setup "register" ["--gen-script"]
-            _ <- if is_windows
+            _ <- if isWin
                     then shell "cmd" ["/C", "register.bat"]
                     else shell "sh" ["register.sh"]
             return ()

--- a/cabal-testsuite/PackageTests/InternalLibraries/setup-per-component.test.hs
+++ b/cabal-testsuite/PackageTests/InternalLibraries/setup-per-component.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 -- No cabal test because per-component is broken for it
 main = setupTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
       withDirectory "p" $ do
         setup_install ["q"]

--- a/cabal-testsuite/PackageTests/InternalLibraries/setup.test.hs
+++ b/cabal-testsuite/PackageTests/InternalLibraries/setup.test.hs
@@ -3,6 +3,9 @@ import Test.Cabal.Prelude
 -- sure that the internal library correctly is used, not the
 -- external library.
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
         withDirectory "q" $ setup_install []
         withDirectory "p" $ do

--- a/cabal-testsuite/PackageTests/Macros/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Macros/setup.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 -- Test to ensure that setup_macros.h are computed per-component.
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     setup_build []
     runExe "macros-a" []
     runExe "macros-b" []

--- a/cabal-testsuite/PackageTests/MultipleLibraries/T6894/setup.test.hs
+++ b/cabal-testsuite/PackageTests/MultipleLibraries/T6894/setup.test.hs
@@ -1,3 +1,6 @@
 import Test.Cabal.Prelude
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     setup_build []

--- a/cabal-testsuite/PackageTests/MultipleLibraries/T7270/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/MultipleLibraries/T7270/cabal.test.hs
@@ -1,5 +1,8 @@
 import Test.Cabal.Prelude
-main = setupAndCabalTest $
-  withPackageDb $ do
-    withDirectory "dep" $ setup_install []
-    withDirectory "p" $ setup_build []
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    withPackageDb $ do
+      withDirectory "dep" $ setup_install []
+      withDirectory "p" $ setup_build []

--- a/cabal-testsuite/PackageTests/OrderFlags/setup.test.hs
+++ b/cabal-testsuite/PackageTests/OrderFlags/setup.test.hs
@@ -1,4 +1,8 @@
 import Test.Cabal.Prelude
 -- Test that setup properly orders GHC flags passed to GHC (when
 -- there are multiple ghc-options fields.)
-main = setupAndCabalTest $ setup_build []
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    setup_build []

--- a/cabal-testsuite/PackageTests/PackageDB/cabal-fail-no-base.test.hs
+++ b/cabal-testsuite/PackageTests/PackageDB/cabal-fail-no-base.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
-    withPackageDb $ do
+    isWin <- isWindows
+    ghc94 <- isGhcVersion "== 9.4.*"
+    expectBrokenIf (isWin && ghc94) 9414 $
+      withPackageDb $ do
         withDirectory "p" $
             setup_install []
 

--- a/cabal-testsuite/PackageTests/PackageDB/cabal-fail-no-p.test.hs
+++ b/cabal-testsuite/PackageTests/PackageDB/cabal-fail-no-p.test.hs
@@ -1,5 +1,8 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
         withDirectory "p" $
             setup_install []

--- a/cabal-testsuite/PackageTests/PackageDB/cabal-manual-packagedb.test.hs
+++ b/cabal-testsuite/PackageTests/PackageDB/cabal-manual-packagedb.test.hs
@@ -1,5 +1,8 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
         withDirectory "p" $
             setup_install []

--- a/cabal-testsuite/PackageTests/PackageDB/cabal-packagedb.test.hs
+++ b/cabal-testsuite/PackageTests/PackageDB/cabal-packagedb.test.hs
@@ -1,5 +1,8 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     withPackageDb $ do
         withDirectory "p" $
             setup_install []

--- a/cabal-testsuite/PackageTests/PackageInfoModule/Library/setup.test.hs
+++ b/cabal-testsuite/PackageTests/PackageInfoModule/Library/setup.test.hs
@@ -1,3 +1,7 @@
 import Test.Cabal.Prelude
 -- Test that Paths module is generated and available for libraries.
-main = setupAndCabalTest $ setup_build []
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    setup_build []

--- a/cabal-testsuite/PackageTests/PathsModule/Library/setup.test.hs
+++ b/cabal-testsuite/PackageTests/PathsModule/Library/setup.test.hs
@@ -1,3 +1,7 @@
 import Test.Cabal.Prelude
 -- Test that Paths module is generated and available for libraries.
-main = setupAndCabalTest $ setup_build []
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    setup_build []

--- a/cabal-testsuite/PackageTests/PathsModule/MissingSafeHaskellMode/setup.test.hs
+++ b/cabal-testsuite/PackageTests/PathsModule/MissingSafeHaskellMode/setup.test.hs
@@ -1,3 +1,7 @@
 import Test.Cabal.Prelude
 -- Test that Paths module is generated and available for libraries.
-main = setupAndCabalTest $ setup_build []
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    setup_build []

--- a/cabal-testsuite/PackageTests/PreProcess/Basic/setup.test.hs
+++ b/cabal-testsuite/PackageTests/PreProcess/Basic/setup.test.hs
@@ -1,3 +1,7 @@
 import Test.Cabal.Prelude
 -- Check that preprocessors (hsc2hs) are run
-main = setupAndCabalTest $ setup_build ["--enable-tests", "--enable-benchmarks"]
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    setup_build ["--enable-tests", "--enable-benchmarks"]

--- a/cabal-testsuite/PackageTests/PreProcessExtraSources/setup.test.hs
+++ b/cabal-testsuite/PackageTests/PreProcessExtraSources/setup.test.hs
@@ -1,3 +1,7 @@
 import Test.Cabal.Prelude
 -- Check that preprocessors that generate extra C sources are handled
-main = setupAndCabalTest $ setup_build ["--enable-tests", "--enable-benchmarks"]
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    setup_build ["--enable-tests", "--enable-benchmarks"]

--- a/cabal-testsuite/PackageTests/QuasiQuotes/profiling/setup.test.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/profiling/setup.test.hs
@@ -2,6 +2,9 @@ import Test.Cabal.Prelude
 -- Test building a profiled library/executable which uses QuasiQuotes
 -- (setup has to build the non-profiled version first)
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     skipUnless "no profiling libs" =<< hasProfiledLibraries
     setup_build ["--enable-library-profiling",
                  "--enable-profiling"]

--- a/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/setup.test.hs
+++ b/cabal-testsuite/PackageTests/QuasiQuotes/vanilla/setup.test.hs
@@ -1,3 +1,6 @@
 import Test.Cabal.Prelude
 -- Test building a vanilla library/executable which uses QuasiQuotes
-main = setupAndCabalTest $ setup_build []
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ setup_build []

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.test.hs
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup-fail-ambiguous.test.hs
@@ -1,5 +1,8 @@
 import Test.Cabal.Prelude
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     skipUnlessGhcVersion ">= 7.9"
     withPackageDb $ do
         withDirectory "containers-dupe" $

--- a/cabal-testsuite/PackageTests/ReexportedModules/setup.test.hs
+++ b/cabal-testsuite/PackageTests/ReexportedModules/setup.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 -- Test that reexported modules build correctly
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     skipUnlessGhcVersion ">= 7.9"
     withPackageDb $ do
         withDirectory "p" $ setup_install ["--cabal-file", "p.cabal"]

--- a/cabal-testsuite/PackageTests/Regression/T4449/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T4449/setup.test.hs
@@ -1,5 +1,8 @@
 import Test.Cabal.Prelude
 main = cabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     skipUnlessGhcVersion ">= 7.10"
     setup "configure" []
     setup "build" []

--- a/cabal-testsuite/PackageTests/SPDX/cabal-old-build.test.hs
+++ b/cabal-testsuite/PackageTests/SPDX/cabal-old-build.test.hs
@@ -1,7 +1,11 @@
 import Test.Cabal.Prelude
-main = setupAndCabalTest $ withPackageDb $ do
-    setup_install []
-    recordMode DoNotRecord $ do
-        ghc84 <- isGhcVersion ">= 8.4"
-        let lic = if ghc84 then "BSD-3-Clause" else "BSD3"
-        ghcPkg' "field" ["my", "license"] >>= assertOutputContains lic
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    withPackageDb $ do
+      setup_install []
+      recordMode DoNotRecord $ do
+          ghc84 <- isGhcVersion ">= 8.4"
+          let lic = if ghc84 then "BSD-3-Clause" else "BSD3"
+          ghcPkg' "field" ["my", "license"] >>= assertOutputContains lic

--- a/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/custom.test.hs
+++ b/cabal-testsuite/PackageTests/ShowBuildInfo/Custom/custom.test.hs
@@ -6,23 +6,25 @@ import           Control.Monad.Trans.Reader
 main = setupTest $ do
   -- No cabal test because per-component is broken with it
   skipUnlessGhcVersion ">= 8.1"
-  withPackageDb $ do
-    setup_build ["--enable-build-info"]
-    env <- ask
-    let buildInfoFp = testDistDir env </> "build-info.json"
-    buildInfo <- decodeBuildInfoFile buildInfoFp
-    assertCommonBuildInfo buildInfo
-    let [libBI, exeBI] = components buildInfo
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
+    withPackageDb $ do
+      setup_build ["--enable-build-info"]
+      env <- ask
+      let buildInfoFp = testDistDir env </> "build-info.json"
+      buildInfo <- decodeBuildInfoFile buildInfoFp
+      assertCommonBuildInfo buildInfo
+      let [libBI, exeBI] = components buildInfo
 
-    assertComponentPure libBI defCompAssertion
-      { modules = ["MyLib"]
-      , compType = "lib"
-      , sourceDirs = ["src"]
-      }
+      assertComponentPure libBI defCompAssertion
+        { modules = ["MyLib"]
+        , compType = "lib"
+        , sourceDirs = ["src"]
+        }
 
-    assertComponentPure exeBI defCompAssertion
-      { sourceFiles = ["Main.hs"]
-      , compType = "exe"
-      , sourceDirs = ["app"]
-      }
-
+      assertComponentPure exeBI defCompAssertion
+        { sourceFiles = ["Main.hs"]
+        , compType = "exe"
+        , sourceDirs = ["app"]
+        }

--- a/cabal-testsuite/PackageTests/TemplateHaskell/profiling/setup.test.hs
+++ b/cabal-testsuite/PackageTests/TemplateHaskell/profiling/setup.test.hs
@@ -2,6 +2,9 @@ import Test.Cabal.Prelude
 -- Test building a profiled library/executable which uses Template Haskell
 -- (setup has to build the non-profiled version first)
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     skipUnless "no profiling libs" =<< hasProfiledLibraries
     setup_build ["--enable-library-profiling",
                  "--enable-profiling"]

--- a/cabal-testsuite/PackageTests/TemplateHaskell/vanilla/setup.test.hs
+++ b/cabal-testsuite/PackageTests/TemplateHaskell/vanilla/setup.test.hs
@@ -1,3 +1,6 @@
 import Test.Cabal.Prelude
 -- Test building a vanilla library/executable which uses Template Haskell
-main = setupAndCabalTest $ setup_build []
+main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ setup_build []

--- a/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/setup-no-markup.test.hs
+++ b/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/setup-no-markup.test.hs
@@ -4,6 +4,9 @@ import Distribution.Simple.Hpc
 -- Ensures that even if a .tix file happens to be left around
 -- markup isn't generated.
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     dist_dir <- fmap testDistDir getTestEnv
     let tixFile = tixFilePath dist_dir Vanilla "test-Short"
     withEnv [("HPCTIXFILE", Just tixFile)] $ do

--- a/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/setup-no-tix.test.hs
+++ b/cabal-testsuite/PackageTests/TestSuiteTests/ExeV10/setup-no-tix.test.hs
@@ -12,6 +12,9 @@ import Distribution.Simple.Hpc
 -- at all.)
 --
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $
     -- Source copy is necessary as GHC defaults to dumping tix
     -- file in the CWD, and we do NOT clean it up after the fact.
     withSourceCopy $ do

--- a/cabal-testsuite/PackageTests/UniqueIPID/setup.test.hs
+++ b/cabal-testsuite/PackageTests/UniqueIPID/setup.test.hs
@@ -2,15 +2,18 @@ import Test.Cabal.Prelude
 import Data.List
 -- Test that setup computes different IPIDs when dependencies change
 main = setupAndCabalTest $ do
+  isWin <- isWindows
+  ghc94 <- isGhcVersion "== 9.4.*"
+  expectBrokenIf (isWin && ghc94) 9414 $ do
     withPackageDb $ do
         withDirectory "P1" $ setup "configure" ["--disable-deterministic"]
         withDirectory "P2" $ setup "configure" ["--disable-deterministic"]
         withDirectory "P1" $ setup "build" []
         withDirectory "P1" $ setup "build" [] -- rebuild should work
         recordMode DoNotRecord $ do
-            r1 <- withDirectory "P1" $ setup' "register" ["--print-ipid", "--inplace"]
-            withDirectory "P2" $ setup "build" []
-            r2 <- withDirectory "P2" $ setup' "register" ["--print-ipid", "--inplace"]
-            let exIPID s = takeWhile (/= '\n') $
-                     head . filter (isPrefixOf $ "UniqueIPID-0.1-") $ (tails s)
-            assertNotEqual "ipid match" (exIPID $ resultOutput r1) (exIPID $ resultOutput r2)
+          r1 <- withDirectory "P1" $ setup' "register" ["--print-ipid", "--inplace"]
+          withDirectory "P2" $ setup "build" []
+          r2 <- withDirectory "P2" $ setup' "register" ["--print-ipid", "--inplace"]
+          let exIPID s = takeWhile (/= '\n') $
+                   head . filter (isPrefixOf $ "UniqueIPID-0.1-") $ (tails s)
+          assertNotEqual "ipid match" (exIPID $ resultOutput r1) (exIPID $ resultOutput r2)


### PR DESCRIPTION
Cabal currently adds the `-r` (relocatable) flag to some invocations of `ldProgram`, but `lld` (commonly used on WIndows) does not understand the `-r` flag. This PR just detects if `ldProgram` accepts `-r` and conditionally adds it, only if it is supported.

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

Bonus points for added automated tests!
