### PR TITLE
Update RTD config for build.os config change

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.8"
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,6 +3,11 @@ version: 2
 sphinx:
   configuration: doc/conf.py
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 python:
   version: 3.8
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,5 @@ build:
     python: "3.11"
 
 python:
-  version: 3.8
   install:
     - requirements: doc/requirements.txt


### PR DESCRIPTION
See https://blog.readthedocs.com/use-build-os-config/ for details.

We are in a temporary brownout with the old config key disabled, so RTD builds will be failing for the next few hours; but the change will become permanent next month.

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

