### PR TITLE
Removing `chooseSolver` and inline `Modular` solver as default choice

### DIFF
--- a/cabal-install/src/Distribution/Client/Configure.hs
+++ b/cabal-install/src/Distribution/Client/Configure.hs
@@ -101,7 +101,6 @@ import Distribution.Simple.Program (ProgramDb)
 import Distribution.Simple.Setup
   ( ConfigFlags (..)
   , flagToMaybe
-  , fromFlag
   , fromFlagOrDefault
   , toFlag
   )
@@ -405,11 +404,6 @@ planLocalPackage
         =<< case flagToMaybe (configCabalFilePath configFlags) of
           Nothing -> defaultPackageDesc verbosity
           Just fp -> return fp
-    solver <-
-      chooseSolver
-        verbosity
-        (fromFlag $ configSolver configExFlags)
-        (compilerInfo comp)
 
     let
       -- We create a local package and ask to resolve a dependency on it
@@ -476,7 +470,7 @@ planLocalPackage
             (SourcePackageDb mempty packagePrefs)
             [SpecificSourcePackage localPkg]
 
-    return (resolveDependencies platform (compilerInfo comp) pkgConfigDb solver resolverParams)
+    return (resolveDependencies platform (compilerInfo comp) pkgConfigDb resolverParams)
 
 -- | Call an installer for an 'SourcePackage' but override the configure
 -- flags with the ones given by the 'ReadyPackage'. In particular the

--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -17,7 +17,6 @@
 module Distribution.Client.Dependency
   ( -- * The main package dependency resolver
     DepResolverParams
-  , chooseSolver
   , resolveDependencies
   , Progress (..)
   , foldProgress
@@ -72,8 +71,6 @@ import qualified Prelude as Unsafe (head)
 
 import Distribution.Client.Dependency.Types
   ( PackagesPreferenceDefault (..)
-  , PreSolver (..)
-  , Solver (..)
   )
 import Distribution.Client.SolverInstallPlan (SolverInstallPlan)
 import qualified Distribution.Client.SolverInstallPlan as SolverInstallPlan
@@ -756,14 +753,8 @@ standardInstallPolicy installedPkgIndex sourcePkgDb pkgSpecifiers =
 
 -- ------------------------------------------------------------
 
-chooseSolver :: Verbosity -> PreSolver -> CompilerInfo -> IO Solver
-chooseSolver _verbosity preSolver _cinfo =
-  case preSolver of
-    AlwaysModular -> do
-      return Modular
-
-runSolver :: Solver -> SolverConfig -> DependencyResolver UnresolvedPkgLoc
-runSolver Modular = modularResolver
+runSolver :: SolverConfig -> DependencyResolver UnresolvedPkgLoc
+runSolver = modularResolver
 
 -- | Run the dependency solver.
 --
@@ -774,14 +765,12 @@ resolveDependencies
   :: Platform
   -> CompilerInfo
   -> PkgConfigDb
-  -> Solver
   -> DepResolverParams
   -> Progress String String SolverInstallPlan
-resolveDependencies platform comp pkgConfigDB solver params =
+resolveDependencies platform comp pkgConfigDB params =
   Step (showDepResolverParams finalparams) $
     fmap (validateSolverResult platform comp indGoals) $
       runSolver
-        solver
         ( SolverConfig
             reordGoals
             cntConflicts

--- a/cabal-install/src/Distribution/Client/Fetch.hs
+++ b/cabal-install/src/Distribution/Client/Fetch.hs
@@ -173,11 +173,6 @@ planPackages
   pkgConfigDb
   pkgSpecifiers
     | includeDependencies = do
-        solver <-
-          chooseSolver
-            verbosity
-            (fromFlag (fetchSolver fetchFlags))
-            (compilerInfo comp)
         notice verbosity "Resolving dependencies..."
         installPlan <-
           foldProgress logMsg (die' verbosity) return $
@@ -185,7 +180,6 @@ planPackages
               platform
               (compilerInfo comp)
               pkgConfigDb
-              solver
               resolverParams
 
         -- The packages we want to fetch are those packages the 'InstallPlan'

--- a/cabal-install/src/Distribution/Client/Freeze.hs
+++ b/cabal-install/src/Distribution/Client/Freeze.hs
@@ -212,11 +212,6 @@ planPackages
   sourcePkgDb
   pkgConfigDb
   pkgSpecifiers = do
-    solver <-
-      chooseSolver
-        verbosity
-        (fromFlag (freezeSolver freezeFlags))
-        (compilerInfo comp)
     notice verbosity "Resolving dependencies..."
 
     installPlan <-
@@ -225,7 +220,6 @@ planPackages
           platform
           (compilerInfo comp)
           pkgConfigDb
-          solver
           resolverParams
 
     return $ pruneInstallPlan installPlan pkgSpecifiers

--- a/cabal-install/src/Distribution/Client/Install.hs
+++ b/cabal-install/src/Distribution/Client/Install.hs
@@ -89,9 +89,6 @@ import Distribution.Client.Configure
   , configureSetupScript
   )
 import Distribution.Client.Dependency
-import Distribution.Client.Dependency.Types
-  ( Solver (..)
-  )
 import Distribution.Client.FetchUtils
 import qualified Distribution.Client.Haddock as Haddock (regenerateHaddockIndex)
 import Distribution.Client.HttpUtils
@@ -493,18 +490,12 @@ makeInstallPlan
     , pkgSpecifiers
     , _
     ) = do
-    solver <-
-      chooseSolver
-        verbosity
-        (fromFlag (configSolver configExFlags))
-        (compilerInfo comp)
     notice verbosity "Resolving dependencies..."
     return $
       planPackages
         verbosity
         comp
         platform
-        solver
         configFlags
         configExFlags
         installFlags
@@ -562,7 +553,6 @@ planPackages
   :: Verbosity
   -> Compiler
   -> Platform
-  -> Solver
   -> ConfigFlags
   -> ConfigExFlags
   -> InstallFlags
@@ -575,7 +565,6 @@ planPackages
   verbosity
   comp
   platform
-  solver
   configFlags
   configExFlags
   installFlags
@@ -587,7 +576,6 @@ planPackages
       platform
       (compilerInfo comp)
       pkgConfigDb
-      solver
       resolverParams
       >>= if onlyDeps then pruneInstallPlan pkgSpecifiers else return
     where

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -84,7 +84,6 @@ import Distribution.Client.Store
 
 import Distribution.Client.Config
 import Distribution.Client.Dependency
-import Distribution.Client.Dependency.Types
 import Distribution.Client.DistDirLayout
 import Distribution.Client.FetchUtils
 import qualified Distribution.Client.IndexUtils as IndexUtils
@@ -733,12 +732,6 @@ rebuildInstallPlan
               -- ones relevant for the compiler.
 
               liftIO $ do
-                solver <-
-                  chooseSolver
-                    verbosity
-                    (solverSettingSolver solverSettings)
-                    (compilerInfo compiler)
-
                 notice verbosity "Resolving dependencies..."
                 planOrError <-
                   foldProgress logMsg (pure . Left) (pure . Right) $
@@ -746,7 +739,6 @@ rebuildInstallPlan
                       verbosity
                       compiler
                       platform
-                      solver
                       solverSettings
                       (installedPackages <> installedPkgIndex)
                       sourcePkgDb
@@ -1243,7 +1235,6 @@ planPackages
   :: Verbosity
   -> Compiler
   -> Platform
-  -> Solver
   -> SolverSettings
   -> InstalledPackageIndex
   -> SourcePackageDb
@@ -1255,7 +1246,6 @@ planPackages
   verbosity
   comp
   platform
-  solver
   SolverSettings{..}
   installedPkgIndex
   sourcePkgDb
@@ -1266,7 +1256,6 @@ planPackages
       platform
       (compilerInfo comp)
       pkgConfigDB
-      solver
       resolverParams
     where
       -- TODO: [nice to have] disable multiple instances restriction in

--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/DSL.hs
@@ -79,7 +79,6 @@ import Language.Haskell.Extension (Extension (..), Language (..))
 
 -- cabal-install
 import Distribution.Client.Dependency
-import Distribution.Client.Dependency.Types
 import qualified Distribution.Client.SolverInstallPlan as CI.SolverInstallPlan
 import Distribution.Client.Types
 
@@ -821,7 +820,7 @@ exResolve
   prefs
   verbosity
   enableAllTests =
-    resolveDependencies C.buildPlatform compiler pkgConfigDb Modular params
+    resolveDependencies C.buildPlatform compiler pkgConfigDb params
     where
       defaultCompiler = C.unknownCompilerInfo C.buildCompilerId C.NoAbiTag
       compiler =


### PR DESCRIPTION
This PR does not modify `cabal` behaviour (refactoring). Its purpose is too split https://github.com/haskell/cabal/pull/9206 into two!

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

