### PR TITLE
Relax extension `.c` requirement for c-sources

### DIFF
--- a/cabal-testsuite/PackageTests/CSourcesSanitisation/build.out
+++ b/cabal-testsuite/PackageTests/CSourcesSanitisation/build.out
@@ -5,21 +5,38 @@ In order, the following will be built:
  - repro-0.1.0.0 (lib) (first run)
  - repro-0.1.0.0 (exe:exec1) (first run)
  - repro-0.1.0.0 (lib:lib2) (first run)
+ - repro-0.1.0.0 (lib:lib3) (first run)
+ - repro-0.1.0.0 (lib:lib4) (first run)
 Configuring library for repro-0.1.0.0..
 Preprocessing library for repro-0.1.0.0..
 Building library for repro-0.1.0.0..
-Warning: The following files listed in the main library's c-sources will not be used: cbits/gwinsz.h.
+Warning: The following header files listed in the main library's c-sources will not be used: cbits/gwinsz.h.
 Header files should be in the 'include' or 'install-include' stanza.
 See https://cabal.readthedocs.io/en/3.10/cabal-package.html#pkg-field-includes
 Configuring executable 'exec1' for repro-0.1.0.0..
 Preprocessing executable 'exec1' for repro-0.1.0.0..
 Building executable 'exec1' for repro-0.1.0.0..
-Warning: The following files listed in exec1's c-sources will not be used: cbits/gwinsz.h.
+Warning: The following header files listed in exec1's c-sources will not be used: cbits/gwinsz.h.
 Header files should be in the 'include' or 'install-include' stanza.
 See https://cabal.readthedocs.io/en/3.10/cabal-package.html#pkg-field-includes
 Configuring library 'lib2' for repro-0.1.0.0..
 Preprocessing library 'lib2' for repro-0.1.0.0..
 Building library 'lib2' for repro-0.1.0.0..
-Warning: The following files listed in library lib2's c-sources will not be used: cbits/gwinsz.h.
+Warning: The following header files listed in library lib2's c-sources will not be used: cbits/gwinsz.h.
 Header files should be in the 'include' or 'install-include' stanza.
 See https://cabal.readthedocs.io/en/3.10/cabal-package.html#pkg-field-includes
+Configuring library 'lib3' for repro-0.1.0.0..
+Preprocessing library 'lib3' for repro-0.1.0.0..
+Building library 'lib3' for repro-0.1.0.0..
+Warning: The following header files listed in library lib3's c-sources will not be used: cbits/gwinsz.h.
+Header files should be in the 'include' or 'install-include' stanza.
+See https://cabal.readthedocs.io/en/3.10/cabal-package.html#pkg-field-includes
+Warning: The following files listed in library lib3's c-sources do not have the expected '.c' extension cbits/gwinsz.cc.
+C++ files should be in the 'cxx-sources' stanza.
+See https://cabal.readthedocs.io/en/3.10/cabal-package.html#pkg-field-cxx-sources
+Configuring library 'lib4' for repro-0.1.0.0..
+Preprocessing library 'lib4' for repro-0.1.0.0..
+Building library 'lib4' for repro-0.1.0.0..
+Warning: The following files listed in library lib4's c-sources do not have the expected '.c' extension cbits/gwinsz.cc.
+C++ files should be in the 'cxx-sources' stanza.
+See https://cabal.readthedocs.io/en/3.10/cabal-package.html#pkg-field-cxx-sources

--- a/cabal-testsuite/PackageTests/CSourcesSanitisation/repro.cabal
+++ b/cabal-testsuite/PackageTests/CSourcesSanitisation/repro.cabal
@@ -15,6 +15,17 @@ library lib2
                       cbits/gwinsz.c
     build-depends:    base
 
+library lib3
+    default-language: Haskell2010
+    c-sources:        cbits/gwinsz.h
+                      cbits/gwinsz.cc
+    build-depends:    base
+
+library lib4
+    default-language: Haskell2010
+    c-sources:        cbits/gwinsz.cc
+    build-depends:    base
+
 executable exec1
     main-is: Main.hs
     default-language: Haskell2010


### PR DESCRIPTION
#9200 started filtering `.cc` files from `c-sources` and does not always issue a warning (there has to be at least one `.c` file present before it warns you it is ignoring the others).

Some packages in hackage (`double-conversion` for instance) rely on the ability to include `C++` source files in `c-sources`.  This is not ideal, but we should probably continue to support these packages.

This change will relax the filtering, so that only `.h` files are automatically excluded (with a warning).  It will also warn if other non `.c` files are present (suggesting the `cxx-sources` since C++ sources are the most likely to be used).

The bug that prevented warnings being displayed when no `.c` files were present is fixed.