### PR TITLE
testsuite README

### DIFF
--- a/Cabal-tests/tests/CheckTests.hs
+++ b/Cabal-tests/tests/CheckTests.hs
@@ -3,7 +3,6 @@ module Main
     ) where
 
 import Test.Tasty
-import Test.Tasty.ExpectedFailure
 import Test.Tasty.Golden.Advanced (goldenTest)
 
 import Data.Algorithm.Diff                    (PolyDiff (..), getGroupedDiff)

--- a/Cabal/src/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/src/Distribution/Simple/BuildPaths.hs
@@ -20,6 +20,7 @@ module Distribution.Simple.BuildPaths
   , haddockDirName
   , hscolourPref
   , haddockPref
+  , licenseFilePref
   , autogenPackageModulesDir
   , autogenComponentModulesDir
   , autogenPathsModuleName
@@ -89,6 +90,9 @@ haddockDirName ForHackage = (++ "-docs") . prettyShow . packageId
 haddockPref :: HaddockTarget -> FilePath -> PackageDescription -> FilePath
 haddockPref haddockTarget distPref pkg_descr =
   distPref </> "doc" </> "html" </> haddockDirName haddockTarget pkg_descr
+
+licenseFilePref :: FilePath -> FilePath -> FilePath
+licenseFilePref docPref = (docPref </>)
 
 -- | The directory in which we put auto-generated modules for EVERY
 -- component in the package.

--- a/Cabal/src/Distribution/Simple/Install.hs
+++ b/Cabal/src/Distribution/Simple/Install.hs
@@ -31,7 +31,11 @@ import Distribution.Types.UnqualComponentName
 
 import Distribution.Package
 import Distribution.PackageDescription
-import Distribution.Simple.BuildPaths (haddockName, haddockPref)
+import Distribution.Simple.BuildPaths
+  ( haddockName
+  , haddockPref
+  , licenseFilePref
+  )
 import Distribution.Simple.BuildTarget
 import Distribution.Simple.Compiler
   ( CompilerFlavor (..)
@@ -74,7 +78,6 @@ import System.Directory
 import System.FilePath
   ( isRelative
   , takeDirectory
-  , takeFileName
   , (</>)
   )
 
@@ -182,7 +185,7 @@ copyPackage verbosity pkg_descr lbi distPref copydest = do
     for_ lfiles $ \lfile' -> do
       let lfile :: FilePath
           lfile = getSymbolicPath lfile'
-      installOrdinaryFile verbosity lfile (docPref </> takeFileName lfile)
+      installOrdinaryFile verbosity lfile (licenseFilePref docPref lfile)
 
 -- | Copy files associated with a component.
 copyComponent

--- a/cabal-testsuite/README.md
+++ b/cabal-testsuite/README.md
@@ -25,10 +25,9 @@ There are a few useful flags:
   the autodetection doesn't work correctly (which may be the
   case for old versions of GHC.)
 
-doctests
-========
+### How to run the doctests
 
-You need to install the doctest tool. Make sure it's compiled with your current
+You need to install the `doctest` tool. Make sure it's compiled with your current
 GHC, and don't forget to reinstall it every time you switch GHC version:
 
 ``` shellsession
@@ -45,7 +44,7 @@ In this example we have run doctests in `Cabal-syntax`. Notice, that some
 components have broken doctests
 ([#8734](https://github.com/haskell/cabal/issues/8734));
 our CI currently checks that `Cabal-syntax` and `Cabal` doctests pass via
-`make doctest-install && make doctest` (you can use this make-based workflow too).
+`make doctest-install && make doctest` (you can use this `make`-based workflow too).
 
 How to write
 ------------

--- a/changelog.d/issue-9184
+++ b/changelog.d/issue-9184
@@ -1,0 +1,3 @@
+synopsis: Preserve the relative paths of license files
+packages: Cabal
+issues: #9184


### PR DESCRIPTION
- Define the path of license files
- Remove a reduent import (?)
- README of testsuite: fix formatting in `doctest` section
