### PR TITLE
README of testsuite: fix formatting in `doctest` section

### DIFF
--- a/cabal-testsuite/README.md
+++ b/cabal-testsuite/README.md
@@ -25,10 +25,9 @@ There are a few useful flags:
   the autodetection doesn't work correctly (which may be the
   case for old versions of GHC.)
 
-doctests
-========
+### How to run the doctests
 
-You need to install the doctest tool. Make sure it's compiled with your current
+You need to install the `doctest` tool. Make sure it's compiled with your current
 GHC, and don't forget to reinstall it every time you switch GHC version:
 
 ``` shellsession
@@ -45,7 +44,7 @@ In this example we have run doctests in `Cabal-syntax`. Notice, that some
 components have broken doctests
 ([#8734](https://github.com/haskell/cabal/issues/8734));
 our CI currently checks that `Cabal-syntax` and `Cabal` doctests pass via
-`make doctest-install && make doctest` (you can use this make-based workflow too).
+`make doctest-install && make doctest` (you can use this `make`-based workflow too).
 
 How to write
 ------------


### PR DESCRIPTION
Cosmetic changes in developer docs:
- caption "doctests" was too large
- use tt font for commands