### PR TITLE
Response-file related comments (did not touch Cabal Distribution.Simple)

### DIFF
--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -244,7 +244,7 @@ import Distribution.Version
 import Control.Exception (AssertionFailed, assert, try)
 import Data.Monoid (Any (..))
 import Distribution.Client.Errors
-import Distribution.Compat.ResponseFile
+import Distribution.Compat.ResponseFile (expandResponse)
 import System.Directory
   ( doesFileExist
   , getCurrentDirectory
@@ -266,7 +266,7 @@ import System.IO
   , stdout
   )
 
--- | Entry point
+-- | Entry point.
 main :: [String] -> IO ()
 main args = do
   installTerminationHandler
@@ -279,6 +279,9 @@ main args = do
   -- when writing to stderr and stdout.
   relaxEncodingErrors stdout
   relaxEncodingErrors stderr
+
+  -- Use expandResponse to add support for response files; see
+  -- Distribution.Compat.ResponseFile in the Cabal package.
   let (args0, args1) = break (== "--") args
 
   mainWorker =<< (++ args1) <$> expandResponse args0


### PR DESCRIPTION
Added commenting for exposed functions in the Distribution.Compat.ResponseFile module in Cabal. Hand-formatted code there to match the 80 column limit. Added an explanation for the response file code in Distribution.Client.Main in cabal-install.

Announcing one problem with this commit, however. I made explicit an import from Distribution.Compat.ResponseFile in Distribution.Client.Main, however. This is not covered by coding conventions, but there is only one other export available from Distribution.Compat.ResponseFile, and it's unused. Should this be reverted?

- [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

