### PR TITLE
Bump base in cabal-dev-scripts.cabal

### DIFF
--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -18,7 +18,7 @@ executable gen-spdx
   ghc-options:      -Wall
   build-depends:
     , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.1.1.0
-    , base                  >=4.10     && <4.17
+    , base                  >=4.10     && <4.19
     , bytestring
     , containers
     , Diff                  ^>=0.4
@@ -35,7 +35,7 @@ executable gen-spdx-exc
   ghc-options:      -Wall
   build-depends:
     , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.1.1.0
-    , base                  >=4.10     && <4.17
+    , base                  >=4.10     && <4.19
     , bytestring
     , containers
     , Diff                  ^>=0.4


### PR DESCRIPTION
Bump base in cabal-dev-scripts.cabal. We are now using GHC 9.4.7 in CI, which ships with base 4.17.2.0. I am bumping all the way to <4.19 after testing everything compiles with GHC 9.6.3 (base-4.18.1.0).

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

