### PR TITLE
Upgrade urllib3 due to CVE-2023-43804

### DIFF
--- a/doc/requirements.in
+++ b/doc/requirements.in
@@ -6,3 +6,5 @@ sphinxnotes-strike
 Pygments >= 2.7.4
 # CVE-2023-37920
 certifi >= 2023.07.22
+# CVE-2023-43804
+urllib3 >= 2.0.6

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -69,5 +69,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxnotes-strike==1.2
     # via -r requirements.in
-urllib3==2.0.2
-    # via requests
+urllib3==2.0.6
+    # via
+    #   -r requirements.in
+    #   requests


### PR DESCRIPTION
As reported by dependabot. Closes #9305.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

