### PR TITLE
Fix #9318 Avoid Haddock warning with `haddock --for-hackage`

### DIFF
--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -866,19 +866,18 @@ renderPureArgs version comp platform args =
     , ["--since-qual=external" | isVersion 2 20]
     , [ "--quickjump" | isVersion 2 19, True <- flagToList . argQuickJump $ args
       ]
-    , [ "--hyperlinked-source" | isHyperlinkedSource ]
+    , ["--hyperlinked-source" | isHyperlinkedSource]
     , (\(All b, xs) -> bool (map (("--hide=" ++) . prettyShow) xs) [] b)
         . argHideModules
         $ args
     , bool ["--ignore-all-exports"] [] . getAny . argIgnoreExports $ args
-      -- Haddock's --source-* options are ignored once --hyperlinked-source is
+    , -- Haddock's --source-* options are ignored once --hyperlinked-source is
       -- set.
       -- See https://haskell-haddock.readthedocs.io/en/latest/invoking.html#cmdoption-hyperlinked-source
       -- To avoid Haddock's warning, we only set --source-* options if
       -- --hyperlinked-source is not set.
-    , if isHyperlinkedSource
-        then
-          []
+      if isHyperlinkedSource
+        then []
         else
           maybe
             []
@@ -975,8 +974,8 @@ renderPureArgs version comp platform args =
     haddockSupportsPackageName = version > mkVersion [2, 16]
     haddockSupportsHyperlinkedSource = isVersion 2 17
     isHyperlinkedSource =
-         haddockSupportsHyperlinkedSource
-      && fromFlagOrDefault False (argLinkedSource args)
+      haddockSupportsHyperlinkedSource
+        && fromFlagOrDefault False (argLinkedSource args)
 
 ---------------------------------------------------------------------------------
 


### PR DESCRIPTION
The logic of this change is simple: if the existing condition for the use of Haddock's `--hyperlinked-source` flag is met, don't also include the existing logic for the use of Haddock's `--source-*` options.

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions). I have followed the style of the surrounding code.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog). I don't think this change is worthy of an entry in the Change Log.
* [x] The documentation has been updated, if necessary. The underlying feature is undocumented, so there is no documentation to update.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included. I've included code comments. I don't think QA notes are required.

Bonus points for added automated tests!