### PR TITLE
Include the compiler ABI tag in nix-style package hashes

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
 
@@ -83,6 +84,7 @@ import Prelude ()
 
 import Control.Monad (forM_, msum)
 import Data.Char (isLower)
+import Data.List (stripPrefix)
 import qualified Data.Map as Map
 import Distribution.CabalSpecVersion
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
@@ -246,10 +248,16 @@ configure verbosity hcPath hcPkgPath conf0 = do
 
       filterExt ext = filter ((/= EnableExtension ext) . fst)
 
+      compilerId :: CompilerId
+      compilerId = CompilerId GHC ghcVersion
+
+      compilerAbiTag :: AbiTag
+      compilerAbiTag = maybe NoAbiTag AbiTag (Map.lookup "Project Unit Id" ghcInfoMap >>= stripPrefix (prettyShow compilerId <> "-"))
+
   let comp =
         Compiler
-          { compilerId = CompilerId GHC ghcVersion
-          , compilerAbiTag = NoAbiTag
+          { compilerId
+          , compilerAbiTag
           , compilerCompat = []
           , compilerLanguages = languages
           , compilerExtensions = extensions

--- a/cabal-install/src/Distribution/Client/PackageHash.hs
+++ b/cabal-install/src/Distribution/Client/PackageHash.hs
@@ -38,7 +38,8 @@ import Distribution.Package
   , mkComponentId
   )
 import Distribution.Simple.Compiler
-  ( CompilerId
+  ( AbiTag (..)
+  , CompilerId
   , DebugInfoLevel (..)
   , OptimisationLevel (..)
   , PackageDB
@@ -191,6 +192,7 @@ type PackageSourceHash = HashValue
 -- package hash.
 data PackageHashConfigInputs = PackageHashConfigInputs
   { pkgHashCompilerId :: CompilerId
+  , pkgHashCompilerAbiTag :: AbiTag
   , pkgHashPlatform :: Platform
   , pkgHashFlagAssignment :: FlagAssignment -- complete not partial
   , pkgHashConfigureScriptArgs :: [String] -- just ./configure for build-type Configure
@@ -301,6 +303,7 @@ renderPackageHashInputs
               pkgHashDirectDeps
           , -- and then all the config
             entry "compilerid" prettyShow pkgHashCompilerId
+          , entry "compiler-abi-tag" renderAbiTag pkgHashCompilerAbiTag
           , entry "platform" prettyShow pkgHashPlatform
           , opt "flags" mempty showFlagAssignment pkgHashFlagAssignment
           , opt "configure-script" [] unwords pkgHashConfigureScriptArgs
@@ -352,3 +355,8 @@ renderPackageHashInputs
       opt key def format value
         | value == def = Nothing
         | otherwise = entry key format value
+
+renderAbiTag :: AbiTag -> String
+renderAbiTag abiTag = case abiTag of
+  NoAbiTag -> "unknown"
+  AbiTag tag -> tag

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -4569,6 +4569,7 @@ packageHashConfigInputs
 packageHashConfigInputs shared@ElaboratedSharedConfig{..} pkg =
   PackageHashConfigInputs
     { pkgHashCompilerId = compilerId pkgConfigCompiler
+    , pkgHashCompilerAbiTag = compilerAbiTag pkgConfigCompiler
     , pkgHashPlatform = pkgConfigPlatform
     , pkgHashFlagAssignment = elabFlagAssignment
     , pkgHashConfigureScriptArgs = elabConfigureScriptArgs

--- a/changelog.d/pr-9325
+++ b/changelog.d/pr-9325
@@ -1,0 +1,3 @@
+synopsis: Include the compiler ABI tag in nix-style package hashes
+packages: Cabal cabal-install
+prs: #9325


### PR DESCRIPTION
- This allows you to use several **API incompatible builds of the same version of GHC** without corrupting the cabal store
- This relies on `"Project Unit Id"` which is available since GHC 9.8.1, older versions  of GHC will not benefit from this change
- I set `compiler-abi-tag` to `unknown` for pre-9.8.1 GHSs.  This invalidates store entries that have been populated by previous versions of `cabal`. Another option would be to leave out `compiler-abi-tag` for pre-9.8.1 GHSs.