### PR TITLE
Include the GHC "Project Unit Id" in the cabal store path

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
 
@@ -83,6 +84,7 @@ import Prelude ()
 
 import Control.Monad (forM_, msum)
 import Data.Char (isLower)
+import Data.List (stripPrefix)
 import qualified Data.Map as Map
 import Distribution.CabalSpecVersion
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
@@ -246,10 +248,16 @@ configure verbosity hcPath hcPkgPath conf0 = do
 
       filterExt ext = filter ((/= EnableExtension ext) . fst)
 
+      compilerId :: CompilerId
+      compilerId = CompilerId GHC ghcVersion
+
+      compilerAbiTag :: AbiTag
+      compilerAbiTag = maybe NoAbiTag AbiTag (Map.lookup "Project Unit Id" ghcInfoMap >>= stripPrefix (prettyShow compilerId <> "-"))
+
   let comp =
         Compiler
-          { compilerId = CompilerId GHC ghcVersion
-          , compilerAbiTag = NoAbiTag
+          { compilerId
+          , compilerAbiTag
           , compilerCompat = []
           , compilerLanguages = languages
           , compilerExtensions = extensions

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -54,9 +54,6 @@ import Distribution.Client.TargetProblem (TargetProblem (..))
 import Distribution.Simple.Command
   ( CommandUI (..)
   )
-import Distribution.Simple.Compiler
-  ( Compiler (..)
-  )
 import Distribution.Simple.Flag
   ( Flag (..)
   , fromFlag
@@ -319,7 +316,7 @@ haddockProjectAction flags _extraArgs globalFlags = do
                     packageDir =
                       storePackageDirectory
                         (cabalStoreDirLayout cabalLayout)
-                        (compilerId (pkgConfigCompiler sharedConfig'))
+                        (pkgConfigCompiler sharedConfig')
                         (elabUnitId package)
                     docDir = packageDir </> "share" </> "doc" </> "html"
                     destDir = outputDir </> packageName

--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -481,8 +481,7 @@ installAction flags@NixStyleFlags{extraFlags = clientInstallFlags', ..} targetSt
 
   -- progDb is a program database with compiler tools configured properly
   ( compiler@Compiler
-      { compilerId =
-        compilerId@(CompilerId compilerFlavor compilerVersion)
+      { compilerId = CompilerId compilerFlavor compilerVersion
       }
     , platform
     , progDb
@@ -495,7 +494,7 @@ installAction flags@NixStyleFlags{extraFlags = clientInstallFlags', ..} targetSt
   envFile <- getEnvFile clientInstallFlags platform compilerVersion
   existingEnvEntries <-
     getExistingEnvEntries verbosity compilerFlavor supportsPkgEnvFiles envFile
-  packageDbs <- getPackageDbStack compilerId projectConfigStoreDir projectConfigLogsDir
+  packageDbs <- getPackageDbStack compiler projectConfigStoreDir projectConfigLogsDir
   installedIndex <- getInstalledPackages verbosity compiler packageDbs progDb
 
   let
@@ -811,7 +810,7 @@ installExes
         mkUnitBinDir :: UnitId -> FilePath
         mkUnitBinDir =
           InstallDirs.bindir
-            . storePackageInstallDirs' storeDirLayout (compilerId compiler)
+            . storePackageInstallDirs' storeDirLayout compiler
 
         mkExeName :: UnqualComponentName -> FilePath
         mkExeName exe = unUnqualComponentName exe <.> exeExtension platform
@@ -1191,16 +1190,16 @@ getLocalEnv dir platform compilerVersion =
     <> ghcPlatformAndVersionString platform compilerVersion
 
 getPackageDbStack
-  :: CompilerId
+  :: Compiler
   -> Flag FilePath
   -> Flag FilePath
   -> IO PackageDBStack
-getPackageDbStack compilerId storeDirFlag logsDirFlag = do
+getPackageDbStack compiler storeDirFlag logsDirFlag = do
   mstoreDir <- traverse makeAbsolute $ flagToMaybe storeDirFlag
   let
     mlogsDir = flagToMaybe logsDirFlag
   cabalLayout <- mkCabalDirLayout mstoreDir mlogsDir
-  pure $ storePackageDBStack (cabalStoreDirLayout cabalLayout) compilerId
+  pure $ storePackageDBStack (cabalStoreDirLayout cabalLayout) compiler
 
 -- | This defines what a 'TargetSelector' means for the @bench@ command.
 -- It selects the 'AvailableTarget's that the 'TargetSelector' refers to,

--- a/cabal-install/src/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding.hs
@@ -98,7 +98,6 @@ import Distribution.Simple.Command (CommandUI)
 import Distribution.Simple.Compiler
   ( Compiler
   , PackageDB (..)
-  , compilerId
   , jsemSupported
   )
 import qualified Distribution.Simple.InstallDirs as InstallDirs
@@ -1280,7 +1279,7 @@ buildAndInstallUnpackedPackage
                 let ipkg = ipkg0{Installed.installedUnitId = uid}
                 assert
                   ( elabRegisterPackageDBStack pkg
-                      == storePackageDBStack compid
+                      == storePackageDBStack compiler
                   )
                   (return ())
                 criticalSection registerLock $
@@ -1288,7 +1287,7 @@ buildAndInstallUnpackedPackage
                     verbosity
                     compiler
                     progdb
-                    (storePackageDBStack compid)
+                    (storePackageDBStack compiler)
                     ipkg
                     Cabal.defaultRegisterOptions
                       { Cabal.registerMultiInstance = True
@@ -1300,7 +1299,7 @@ buildAndInstallUnpackedPackage
         newStoreEntry
           verbosity
           storeDirLayout
-          compid
+          compiler
           uid
           copyPkgFiles
           registerPkg
@@ -1330,7 +1329,6 @@ buildAndInstallUnpackedPackage
     where
       pkgid = packageId rpkg
       uid = installedUnitId rpkg
-      compid = compilerId compiler
 
       dispname :: String
       dispname = case elabPkgOrComp pkg of

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -898,7 +898,7 @@ rebuildInstallPlan
         -> Rebuild ElaboratedInstallPlan
       phaseImprovePlan elaboratedPlan elaboratedShared = do
         liftIO $ debug verbosity "Improving the install plan..."
-        storePkgIdSet <- getStoreEntries cabalStoreDirLayout compid
+        storePkgIdSet <- getStoreEntries cabalStoreDirLayout compiler
         let improvedPlan =
               improveInstallPlanWithInstalledPackages
                 storePkgIdSet
@@ -910,7 +910,7 @@ rebuildInstallPlan
         -- matches up as expected, e.g. no dangling deps, files deleted.
         return improvedPlan
         where
-          compid = compilerId (pkgConfigCompiler elaboratedShared)
+          compiler = pkgConfigCompiler elaboratedShared
 
 -- | If a 'PackageSpecifier' refers to a single package, return Just that
 -- package.
@@ -2350,7 +2350,7 @@ elaborateInstallPlan
 
       corePackageDbs =
         applyPackageDbFlags
-          (storePackageDBStack (compilerId compiler))
+          (storePackageDBStack compiler)
           (projectConfigPackageDBs sharedPackageConfig)
 
       -- For this local build policy, every package that lives in a local source
@@ -4027,15 +4027,15 @@ userInstallDirTemplates compiler = do
 
 storePackageInstallDirs
   :: StoreDirLayout
-  -> CompilerId
+  -> Compiler
   -> InstalledPackageId
   -> InstallDirs.InstallDirs FilePath
-storePackageInstallDirs storeDirLayout compid ipkgid =
-  storePackageInstallDirs' storeDirLayout compid $ newSimpleUnitId ipkgid
+storePackageInstallDirs storeDirLayout compiler ipkgid =
+  storePackageInstallDirs' storeDirLayout compiler $ newSimpleUnitId ipkgid
 
 storePackageInstallDirs'
   :: StoreDirLayout
-  -> CompilerId
+  -> Compiler
   -> UnitId
   -> InstallDirs.InstallDirs FilePath
 storePackageInstallDirs'
@@ -4043,12 +4043,12 @@ storePackageInstallDirs'
     { storePackageDirectory
     , storeDirectory
     }
-  compid
+  compiler
   unitid =
     InstallDirs.InstallDirs{..}
     where
-      store = storeDirectory compid
-      prefix = storePackageDirectory compid unitid
+      store = storeDirectory compiler
+      prefix = storePackageDirectory compiler unitid
       bindir = prefix </> "bin"
       libdir = prefix </> "lib"
       libsubdir = ""
@@ -4098,7 +4098,7 @@ computeInstallDirs storeDirLayout defaultInstallDirs elaboratedShared elab
       -- use special simplified install dirs
       storePackageInstallDirs'
         storeDirLayout
-        (compilerId (pkgConfigCompiler elaboratedShared))
+        (pkgConfigCompiler elaboratedShared)
         (elabUnitId elab)
 
 -- TODO: [code cleanup] perhaps reorder this code

--- a/changelog.d/pr-9326
+++ b/changelog.d/pr-9326
@@ -1,0 +1,10 @@
+synopsis: Include the GHC "Project Unit Id" in the cabal store path
+packages: Cabal cabal-install
+prs: #9326
+issues: #8114
+description: {
+- This allows the use of several **API incompatible builds of the same version
+  of GHC** without corrupting the cabal store.
+- This relies on the "Project Unit Id" which is available since GHC 9.8.1,
+  older versions of GHC do not benefit from this change.
+}


### PR DESCRIPTION
- This allows the use of several **API incompatible builds of the same version of GHC** without corrupting the cabal store.
- This relies on the "Project Unit Id" which is available since GHC 9.8.1, older versions of GHC do not benefit from this change.


This PR is an alternative to https://github.com/haskell/cabal/pull/9325.  It changes the store path from e.g. `[...]store/ghc-9.8.1` to `[..]store/ghc-9.8.1-f7d8`.

[fixes #8114]