### PR TITLE
Added or expanded 5 comments, documenting lightly defaultMainHelper i…

### DIFF
--- a/Cabal/src/Distribution/Compat/ResponseFile.hs
+++ b/Cabal/src/Distribution/Compat/ResponseFile.hs
@@ -65,6 +65,15 @@ escape cs c
 
 #endif
 
+-- | The arg file / response file parser.
+--
+-- This is not a well-documented capability,
+-- and is a bit eccentric (try cabal @foo @foo
+-- to see what it does), but is crucial
+-- for allowing complex arguments to cabal
+-- and cabal-install when working on command lines
+-- with input length limitations.
+
 expandResponse :: [String] -> IO [String]
 expandResponse = go recursionLimit "."
   where

--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -155,6 +155,12 @@ defaultMainWithHooksNoReadArgs :: UserHooks -> GenericPackageDescription -> [Str
 defaultMainWithHooksNoReadArgs hooks pkg_descr =
   defaultMainHelper hooks{readDesc = return (Just pkg_descr)}
 
+-- | Less the helper, and more the core splitter of
+-- the Simple build system.
+--
+-- Given hooks and args, this runs commandsRun
+-- onto the args, getting packed data back,
+-- which is then converted to IO actions.
 defaultMainHelper :: UserHooks -> Args -> IO ()
 defaultMainHelper hooks args = topHandler $ do
   args' <- expandResponse args

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -267,6 +267,17 @@ import System.IO
   )
 
 -- | Entry point
+--
+-- This does three things.
+-- One, it initializes the program, providing
+-- support for termination signals, preparing
+-- console linebuffering, and relaxing encoding errors.
+--
+-- Two, it processes (via an IO action) response
+-- files, calling expandResponse in Cabal/Distribution.Compat.ResponseFile
+--
+-- Three, it calls the mainWorker, which calls the
+-- actual parser, then converts the results to IO actions.
 main :: [String] -> IO ()
 main args = do
   installTerminationHandler
@@ -279,6 +290,11 @@ main args = do
   -- when writing to stderr and stdout.
   relaxEncodingErrors stdout
   relaxEncodingErrors stderr
+
+  -- Response files support.
+  -- See expandResponse documentation in
+  -- Cabal/Distribution.Compat.ResponseFile
+  -- for more information.
   let (args0, args1) = break (== "--") args
 
   mainWorker =<< (++ args1) <$> expandResponse args0
@@ -296,6 +312,13 @@ warnIfAssertionsAreEnabled =
     assertionsEnabledMsg =
       "Warning: this is a debug build of cabal-install with assertions enabled."
 
+
+-- | Core worker, similar to simpleMainHelper in
+-- Cabal/Distribution.Simple
+--
+-- With an exception-handler (topHandler),
+-- mainWorker calls commandsRun to parse arguments,
+-- returning IO values for execution.
 mainWorker :: [String] -> IO ()
 mainWorker args = do
   topHandler $


### PR DESCRIPTION
…n Cabal/Distribution.Simple, expandResponse in Cabal/Distribution.Compat.ResponseFile, expanding the main comment in cabal-install/Distribution.Client.Main, adding segmentation commenting marking responseFiles handling in cabal-install/Distribution.Client.Main (main), added haddock documentation to mainWorker in cabal-install/Distribution.Client.Main .

Just added some comments.
---
**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

