### PR TITLE
Added or expanded 5 comments, fourmolu-formatted affected files.

### DIFF
--- a/Cabal/src/Distribution/Compat/ResponseFile.hs
+++ b/Cabal/src/Distribution/Compat/ResponseFile.hs
@@ -73,7 +73,6 @@ escape cs c
 -- for allowing complex arguments to cabal
 -- and cabal-install when working on command lines
 -- with input length limitations.
-
 expandResponse :: [String] -> IO [String]
 expandResponse = go recursionLimit "."
   where

--- a/Cabal/src/Distribution/Compat/ResponseFile.hs
+++ b/Cabal/src/Distribution/Compat/ResponseFile.hs
@@ -65,6 +65,15 @@ escape cs c
 
 #endif
 
+-- | The arg file / response file parser.
+--
+-- This is not a well-documented capability,
+-- and is a bit eccentric (try cabal @foo @foo
+-- to see what it does), but is crucial
+-- for allowing complex arguments to cabal
+-- and cabal-install when working on command lines
+-- with input length limitations.
+
 expandResponse :: [String] -> IO [String]
 expandResponse = go recursionLimit "."
   where

--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -185,9 +185,9 @@ defaultMainHelper hooks args = topHandler $ do
       exitWith (ExitFailure 1)
     printNumericVersion = putStrLn $ prettyShow cabalVersion
     printVersion =
-      putStrLn $
-        "Cabal library version "
-          ++ prettyShow cabalVersion
+      putStrLn
+        $ "Cabal library version "
+        ++ prettyShow cabalVersion
 
     progs = addKnownPrograms (hookedPrograms hooks) defaultProgramDb
     commands =
@@ -649,11 +649,11 @@ getBuildConfig hooks verbosity distPref = do
   where
     reconfigure :: FilePath -> LocalBuildInfo -> IO LocalBuildInfo
     reconfigure pkg_descr_file lbi = do
-      notice verbosity $
-        pkg_descr_file
-          ++ " has been changed. "
-          ++ "Re-configuring with most recently used options. "
-          ++ "If this fails, please run configure manually.\n"
+      notice verbosity
+        $ pkg_descr_file
+        ++ " has been changed. "
+        ++ "Re-configuring with most recently used options. "
+        ++ "If this fails, please run configure manually.\n"
       let cFlags = configFlags lbi
       let cFlags' =
             cFlags

--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -155,6 +155,12 @@ defaultMainWithHooksNoReadArgs :: UserHooks -> GenericPackageDescription -> [Str
 defaultMainWithHooksNoReadArgs hooks pkg_descr =
   defaultMainHelper hooks{readDesc = return (Just pkg_descr)}
 
+-- | Less the helper, and more the core splitter of
+-- the Simple build system.
+--
+-- Given hooks and args, this runs commandsRun
+-- onto the args, getting packed data back,
+-- which is then converted to IO actions.
 defaultMainHelper :: UserHooks -> Args -> IO ()
 defaultMainHelper hooks args = topHandler $ do
   args' <- expandResponse args

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -320,8 +320,8 @@ warnIfAssertionsAreEnabled =
 -- returning IO values for execution.
 mainWorker :: [String] -> IO ()
 mainWorker args = do
-  topHandler $
-    case commandsRun (globalCommand commands) commands args of
+  topHandler
+    $ case commandsRun (globalCommand commands) commands args of
       CommandHelp help -> printGlobalHelp help
       CommandList opts -> printOptionsList opts
       CommandErrors errs -> printErrors errs
@@ -357,26 +357,26 @@ mainWorker args = do
       pname <- getProgName
       configFile <- defaultConfigFile
       putStr (help pname)
-      putStr $
-        "\nYou can edit the cabal configuration file to set defaults:\n"
-          ++ "  "
-          ++ configFile
-          ++ "\n"
+      putStr
+        $ "\nYou can edit the cabal configuration file to set defaults:\n"
+        ++ "  "
+        ++ configFile
+        ++ "\n"
       exists <- doesFileExist configFile
-      unless exists $
-        putStrLn $
-          "This file will be generated with sensible "
-            ++ "defaults if you run 'cabal update'."
+      unless exists
+        $ putStrLn
+        $ "This file will be generated with sensible "
+        ++ "defaults if you run 'cabal update'."
     printOptionsList = putStr . unlines
     printErrors errs = dieNoVerbosity $ intercalate "\n" errs
     printNumericVersion = putStrLn $ display cabalInstallVersion
     printVersion =
-      putStrLn $
-        "cabal-install version "
-          ++ display cabalInstallVersion
-          ++ "\ncompiled using version "
-          ++ display cabalVersion
-          ++ " of the Cabal library "
+      putStrLn
+        $ "cabal-install version "
+        ++ display cabalInstallVersion
+        ++ "\ncompiled using version "
+        ++ display cabalVersion
+        ++ " of the Cabal library "
 
     commands = map commandFromSpec commandSpecs
     commandSpecs =
@@ -616,8 +616,10 @@ filterBuildFlags version config buildFlags
       buildFlags
         { -- Take the 'jobs' setting config file into account.
           buildNumJobs =
-            Flag . Just . determineNumJobs $
-              (numJobsConfigFlag `mappend` numJobsCmdLineFlag)
+            Flag
+              . Just
+              . determineNumJobs
+              $ (numJobsConfigFlag `mappend` numJobsCmdLineFlag)
         }
     numJobsConfigFlag = installNumJobs . savedInstallFlags $ config
     numJobsCmdLineFlag = buildNumJobs buildFlags
@@ -657,8 +659,8 @@ replAction replFlags extraArgs globalFlags = do
               , replDistPref = toFlag distPref
               }
 
-      nixShell verbosity distPref globalFlags config $
-        setupWrapper verbosity setupOptions Nothing (Cabal.replCommand progDb) (const replFlags') (const extraArgs)
+      nixShell verbosity distPref globalFlags config
+        $ setupWrapper verbosity setupOptions Nothing (Cabal.replCommand progDb) (const replFlags') (const extraArgs)
 
     -- No .cabal file in the current directory: just start the REPL (possibly
     -- using the sandbox package DB).
@@ -725,9 +727,9 @@ installAction
       targets <- readUserTargets verb extraArgs
 
       let configFlags' =
-            maybeForceTests installFlags' $
-              savedConfigureFlags config
-                `mappend` configFlags{configDistPref = toFlag dist}
+            maybeForceTests installFlags'
+              $ savedConfigureFlags config
+              `mappend` configFlags{configDistPref = toFlag dist}
           configExFlags' =
             defaultConfigExFlags
               `mappend` savedConfigureExFlags config
@@ -866,10 +868,10 @@ componentNamesFromLBI verbosity distPref targetsDescr compPred = do
               $ LBI.pkgComponents pkgDescr
       if null names
         then do
-          notice verbosity $
-            "Package has no buildable "
-              ++ targetsDescr
-              ++ "."
+          notice verbosity
+            $ "Package has no buildable "
+            ++ targetsDescr
+            ++ "."
           exitSuccess -- See #3215.
         else return $! (ComponentNames names)
 
@@ -1119,13 +1121,14 @@ uploadAction uploadFlags extraArgs globalFlags = do
   let uploadFlags' = savedUploadFlags config `mappend` uploadFlags
       globalFlags' = savedGlobalFlags config `mappend` globalFlags
       tarfiles = extraArgs
-  when (null tarfiles && not (fromFlag (uploadDoc uploadFlags'))) $
-    dieWithException verbosity UploadAction
+  when (null tarfiles && not (fromFlag (uploadDoc uploadFlags')))
+    $ dieWithException verbosity UploadAction
   checkTarFiles extraArgs
   maybe_password <-
     case uploadPasswordCmd uploadFlags' of
       Flag (xs : xss) ->
-        Just . Password
+        Just
+          . Password
           <$> getProgramInvocationOutput
             verbosity
             (simpleProgramInvocation xs xss)
@@ -1133,8 +1136,8 @@ uploadAction uploadFlags extraArgs globalFlags = do
   withRepoContext verbosity globalFlags' $ \repoContext -> do
     if fromFlag (uploadDoc uploadFlags')
       then do
-        when (length tarfiles > 1) $
-          dieWithException verbosity UploadActionDocumentation
+        when (length tarfiles > 1)
+          $ dieWithException verbosity UploadActionDocumentation
         tarfile <- maybe (generateDocTarball config) return $ listToMaybe tarfiles
         Upload.uploadDoc
           verbosity
@@ -1171,12 +1174,12 @@ uploadAction uploadFlags extraArgs globalFlags = do
           (file', ".gz") -> takeExtension file' == ".tar"
           _ -> False
     generateDocTarball config = do
-      notice verbosity $
-        "No documentation tarball specified. "
-          ++ "Building a documentation tarball with default settings...\n"
-          ++ "If you need to customise Haddock options, "
-          ++ "run 'haddock --for-hackage' first "
-          ++ "to generate a documentation tarball."
+      notice verbosity
+        $ "No documentation tarball specified. "
+        ++ "Building a documentation tarball with default settings...\n"
+        ++ "If you need to customise Haddock options, "
+        ++ "run 'haddock --for-hackage' first "
+        ++ "to generate a documentation tarball."
       haddockAction
         (defaultHaddockFlags{haddockForHackage = Flag ForHackage})
         []
@@ -1188,9 +1191,9 @@ uploadAction uploadFlags extraArgs globalFlags = do
 checkAction :: Flag Verbosity -> [String] -> Action
 checkAction verbosityFlag extraArgs _globalFlags = do
   let verbosity = fromFlag verbosityFlag
-  unless (null extraArgs) $
-    dieWithException verbosity $
-      CheckAction extraArgs
+  unless (null extraArgs)
+    $ dieWithException verbosity
+    $ CheckAction extraArgs
   allOk <- Check.check (fromFlag verbosityFlag)
   unless allOk exitFailure
 
@@ -1209,9 +1212,9 @@ formatAction verbosityFlag extraArgs _globalFlags = do
 reportAction :: ReportFlags -> [String] -> Action
 reportAction reportFlags extraArgs globalFlags = do
   let verbosity = fromFlag (reportVerbosity reportFlags)
-  unless (null extraArgs) $
-    dieWithException verbosity $
-      ReportAction extraArgs
+  unless (null extraArgs)
+    $ dieWithException verbosity
+    $ ReportAction extraArgs
   config <- loadConfig verbosity (globalConfigFile globalFlags)
   let globalFlags' = savedGlobalFlags config `mappend` globalFlags
       reportFlags' = savedReportFlags config `mappend` reportFlags
@@ -1333,9 +1336,9 @@ actAsSetupAction actAsSetupFlags args _globalFlags =
 manpageAction :: [CommandSpec action] -> ManpageFlags -> [String] -> Action
 manpageAction commands flags extraArgs _ = do
   let verbosity = fromFlag (manpageVerbosity flags)
-  unless (null extraArgs) $
-    dieWithException verbosity $
-      ManpageAction extraArgs
+  unless (null extraArgs)
+    $ dieWithException verbosity
+    $ ManpageAction extraArgs
   pname <- getProgName
   let cabalCmd =
         if takeExtension pname == ".exe"

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -312,7 +312,6 @@ warnIfAssertionsAreEnabled =
     assertionsEnabledMsg =
       "Warning: this is a debug build of cabal-install with assertions enabled."
 
-
 -- | Core worker, similar to simpleMainHelper in
 -- Cabal/Distribution.Simple
 --
@@ -321,8 +320,8 @@ warnIfAssertionsAreEnabled =
 -- returning IO values for execution.
 mainWorker :: [String] -> IO ()
 mainWorker args = do
-  topHandler $
-    case commandsRun (globalCommand commands) commands args of
+  topHandler
+    $ case commandsRun (globalCommand commands) commands args of
       CommandHelp help -> printGlobalHelp help
       CommandList opts -> printOptionsList opts
       CommandErrors errs -> printErrors errs
@@ -358,26 +357,26 @@ mainWorker args = do
       pname <- getProgName
       configFile <- defaultConfigFile
       putStr (help pname)
-      putStr $
-        "\nYou can edit the cabal configuration file to set defaults:\n"
-          ++ "  "
-          ++ configFile
-          ++ "\n"
+      putStr
+        $ "\nYou can edit the cabal configuration file to set defaults:\n"
+        ++ "  "
+        ++ configFile
+        ++ "\n"
       exists <- doesFileExist configFile
-      unless exists $
-        putStrLn $
-          "This file will be generated with sensible "
-            ++ "defaults if you run 'cabal update'."
+      unless exists
+        $ putStrLn
+        $ "This file will be generated with sensible "
+        ++ "defaults if you run 'cabal update'."
     printOptionsList = putStr . unlines
     printErrors errs = dieNoVerbosity $ intercalate "\n" errs
     printNumericVersion = putStrLn $ display cabalInstallVersion
     printVersion =
-      putStrLn $
-        "cabal-install version "
-          ++ display cabalInstallVersion
-          ++ "\ncompiled using version "
-          ++ display cabalVersion
-          ++ " of the Cabal library "
+      putStrLn
+        $ "cabal-install version "
+        ++ display cabalInstallVersion
+        ++ "\ncompiled using version "
+        ++ display cabalVersion
+        ++ " of the Cabal library "
 
     commands = map commandFromSpec commandSpecs
     commandSpecs =
@@ -617,8 +616,10 @@ filterBuildFlags version config buildFlags
       buildFlags
         { -- Take the 'jobs' setting config file into account.
           buildNumJobs =
-            Flag . Just . determineNumJobs $
-              (numJobsConfigFlag `mappend` numJobsCmdLineFlag)
+            Flag
+              . Just
+              . determineNumJobs
+              $ (numJobsConfigFlag `mappend` numJobsCmdLineFlag)
         }
     numJobsConfigFlag = installNumJobs . savedInstallFlags $ config
     numJobsCmdLineFlag = buildNumJobs buildFlags
@@ -658,8 +659,8 @@ replAction replFlags extraArgs globalFlags = do
               , replDistPref = toFlag distPref
               }
 
-      nixShell verbosity distPref globalFlags config $
-        setupWrapper verbosity setupOptions Nothing (Cabal.replCommand progDb) (const replFlags') (const extraArgs)
+      nixShell verbosity distPref globalFlags config
+        $ setupWrapper verbosity setupOptions Nothing (Cabal.replCommand progDb) (const replFlags') (const extraArgs)
 
     -- No .cabal file in the current directory: just start the REPL (possibly
     -- using the sandbox package DB).
@@ -726,9 +727,9 @@ installAction
       targets <- readUserTargets verb extraArgs
 
       let configFlags' =
-            maybeForceTests installFlags' $
-              savedConfigureFlags config
-                `mappend` configFlags{configDistPref = toFlag dist}
+            maybeForceTests installFlags'
+              $ savedConfigureFlags config
+              `mappend` configFlags{configDistPref = toFlag dist}
           configExFlags' =
             defaultConfigExFlags
               `mappend` savedConfigureExFlags config
@@ -867,10 +868,10 @@ componentNamesFromLBI verbosity distPref targetsDescr compPred = do
               $ LBI.pkgComponents pkgDescr
       if null names
         then do
-          notice verbosity $
-            "Package has no buildable "
-              ++ targetsDescr
-              ++ "."
+          notice verbosity
+            $ "Package has no buildable "
+            ++ targetsDescr
+            ++ "."
           exitSuccess -- See #3215.
         else return $! (ComponentNames names)
 
@@ -1120,13 +1121,14 @@ uploadAction uploadFlags extraArgs globalFlags = do
   let uploadFlags' = savedUploadFlags config `mappend` uploadFlags
       globalFlags' = savedGlobalFlags config `mappend` globalFlags
       tarfiles = extraArgs
-  when (null tarfiles && not (fromFlag (uploadDoc uploadFlags'))) $
-    dieWithException verbosity UploadAction
+  when (null tarfiles && not (fromFlag (uploadDoc uploadFlags')))
+    $ dieWithException verbosity UploadAction
   checkTarFiles extraArgs
   maybe_password <-
     case uploadPasswordCmd uploadFlags' of
       Flag (xs : xss) ->
-        Just . Password
+        Just
+          . Password
           <$> getProgramInvocationOutput
             verbosity
             (simpleProgramInvocation xs xss)
@@ -1134,8 +1136,8 @@ uploadAction uploadFlags extraArgs globalFlags = do
   withRepoContext verbosity globalFlags' $ \repoContext -> do
     if fromFlag (uploadDoc uploadFlags')
       then do
-        when (length tarfiles > 1) $
-          dieWithException verbosity UploadActionDocumentation
+        when (length tarfiles > 1)
+          $ dieWithException verbosity UploadActionDocumentation
         tarfile <- maybe (generateDocTarball config) return $ listToMaybe tarfiles
         Upload.uploadDoc
           verbosity
@@ -1172,12 +1174,12 @@ uploadAction uploadFlags extraArgs globalFlags = do
           (file', ".gz") -> takeExtension file' == ".tar"
           _ -> False
     generateDocTarball config = do
-      notice verbosity $
-        "No documentation tarball specified. "
-          ++ "Building a documentation tarball with default settings...\n"
-          ++ "If you need to customise Haddock options, "
-          ++ "run 'haddock --for-hackage' first "
-          ++ "to generate a documentation tarball."
+      notice verbosity
+        $ "No documentation tarball specified. "
+        ++ "Building a documentation tarball with default settings...\n"
+        ++ "If you need to customise Haddock options, "
+        ++ "run 'haddock --for-hackage' first "
+        ++ "to generate a documentation tarball."
       haddockAction
         (defaultHaddockFlags{haddockForHackage = Flag ForHackage})
         []
@@ -1189,9 +1191,9 @@ uploadAction uploadFlags extraArgs globalFlags = do
 checkAction :: Flag Verbosity -> [String] -> Action
 checkAction verbosityFlag extraArgs _globalFlags = do
   let verbosity = fromFlag verbosityFlag
-  unless (null extraArgs) $
-    dieWithException verbosity $
-      CheckAction extraArgs
+  unless (null extraArgs)
+    $ dieWithException verbosity
+    $ CheckAction extraArgs
   allOk <- Check.check (fromFlag verbosityFlag)
   unless allOk exitFailure
 
@@ -1210,9 +1212,9 @@ formatAction verbosityFlag extraArgs _globalFlags = do
 reportAction :: ReportFlags -> [String] -> Action
 reportAction reportFlags extraArgs globalFlags = do
   let verbosity = fromFlag (reportVerbosity reportFlags)
-  unless (null extraArgs) $
-    dieWithException verbosity $
-      ReportAction extraArgs
+  unless (null extraArgs)
+    $ dieWithException verbosity
+    $ ReportAction extraArgs
   config <- loadConfig verbosity (globalConfigFile globalFlags)
   let globalFlags' = savedGlobalFlags config `mappend` globalFlags
       reportFlags' = savedReportFlags config `mappend` reportFlags
@@ -1334,9 +1336,9 @@ actAsSetupAction actAsSetupFlags args _globalFlags =
 manpageAction :: [CommandSpec action] -> ManpageFlags -> [String] -> Action
 manpageAction commands flags extraArgs _ = do
   let verbosity = fromFlag (manpageVerbosity flags)
-  unless (null extraArgs) $
-    dieWithException verbosity $
-      ManpageAction extraArgs
+  unless (null extraArgs)
+    $ dieWithException verbosity
+    $ ManpageAction extraArgs
   pname <- getProgName
   let cabalCmd =
         if takeExtension pname == ".exe"

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -267,6 +267,17 @@ import System.IO
   )
 
 -- | Entry point
+--
+-- This does three things.
+-- One, it initializes the program, providing
+-- support for termination signals, preparing
+-- console linebuffering, and relaxing encoding errors.
+--
+-- Two, it processes (via an IO action) response
+-- files, calling expandResponse in Cabal/Distribution.Compat.ResponseFile
+--
+-- Three, it calls the mainWorker, which calls the
+-- actual parser, then converts the results to IO actions.
 main :: [String] -> IO ()
 main args = do
   installTerminationHandler
@@ -279,6 +290,11 @@ main args = do
   -- when writing to stderr and stdout.
   relaxEncodingErrors stdout
   relaxEncodingErrors stderr
+
+  -- Response files support.
+  -- See expandResponse documentation in
+  -- Cabal/Distribution.Compat.ResponseFile
+  -- for more information.
   let (args0, args1) = break (== "--") args
 
   mainWorker =<< (++ args1) <$> expandResponse args0
@@ -296,6 +312,13 @@ warnIfAssertionsAreEnabled =
     assertionsEnabledMsg =
       "Warning: this is a debug build of cabal-install with assertions enabled."
 
+
+-- | Core worker, similar to simpleMainHelper in
+-- Cabal/Distribution.Simple
+--
+-- With an exception-handler (topHandler),
+-- mainWorker calls commandsRun to parse arguments,
+-- returning IO values for execution.
 mainWorker :: [String] -> IO ()
 mainWorker args = do
   topHandler $

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -320,8 +320,8 @@ warnIfAssertionsAreEnabled =
 -- returning IO values for execution.
 mainWorker :: [String] -> IO ()
 mainWorker args = do
-  topHandler
-    $ case commandsRun (globalCommand commands) commands args of
+  topHandler $
+    case commandsRun (globalCommand commands) commands args of
       CommandHelp help -> printGlobalHelp help
       CommandList opts -> printOptionsList opts
       CommandErrors errs -> printErrors errs
@@ -357,26 +357,26 @@ mainWorker args = do
       pname <- getProgName
       configFile <- defaultConfigFile
       putStr (help pname)
-      putStr
-        $ "\nYou can edit the cabal configuration file to set defaults:\n"
-        ++ "  "
-        ++ configFile
-        ++ "\n"
+      putStr $
+        "\nYou can edit the cabal configuration file to set defaults:\n"
+          ++ "  "
+          ++ configFile
+          ++ "\n"
       exists <- doesFileExist configFile
-      unless exists
-        $ putStrLn
-        $ "This file will be generated with sensible "
-        ++ "defaults if you run 'cabal update'."
+      unless exists $
+        putStrLn $
+          "This file will be generated with sensible "
+            ++ "defaults if you run 'cabal update'."
     printOptionsList = putStr . unlines
     printErrors errs = dieNoVerbosity $ intercalate "\n" errs
     printNumericVersion = putStrLn $ display cabalInstallVersion
     printVersion =
-      putStrLn
-        $ "cabal-install version "
-        ++ display cabalInstallVersion
-        ++ "\ncompiled using version "
-        ++ display cabalVersion
-        ++ " of the Cabal library "
+      putStrLn $
+        "cabal-install version "
+          ++ display cabalInstallVersion
+          ++ "\ncompiled using version "
+          ++ display cabalVersion
+          ++ " of the Cabal library "
 
     commands = map commandFromSpec commandSpecs
     commandSpecs =
@@ -616,10 +616,8 @@ filterBuildFlags version config buildFlags
       buildFlags
         { -- Take the 'jobs' setting config file into account.
           buildNumJobs =
-            Flag
-              . Just
-              . determineNumJobs
-              $ (numJobsConfigFlag `mappend` numJobsCmdLineFlag)
+            Flag . Just . determineNumJobs $
+              (numJobsConfigFlag `mappend` numJobsCmdLineFlag)
         }
     numJobsConfigFlag = installNumJobs . savedInstallFlags $ config
     numJobsCmdLineFlag = buildNumJobs buildFlags
@@ -659,8 +657,8 @@ replAction replFlags extraArgs globalFlags = do
               , replDistPref = toFlag distPref
               }
 
-      nixShell verbosity distPref globalFlags config
-        $ setupWrapper verbosity setupOptions Nothing (Cabal.replCommand progDb) (const replFlags') (const extraArgs)
+      nixShell verbosity distPref globalFlags config $
+        setupWrapper verbosity setupOptions Nothing (Cabal.replCommand progDb) (const replFlags') (const extraArgs)
 
     -- No .cabal file in the current directory: just start the REPL (possibly
     -- using the sandbox package DB).
@@ -727,9 +725,9 @@ installAction
       targets <- readUserTargets verb extraArgs
 
       let configFlags' =
-            maybeForceTests installFlags'
-              $ savedConfigureFlags config
-              `mappend` configFlags{configDistPref = toFlag dist}
+            maybeForceTests installFlags' $
+              savedConfigureFlags config
+                `mappend` configFlags{configDistPref = toFlag dist}
           configExFlags' =
             defaultConfigExFlags
               `mappend` savedConfigureExFlags config
@@ -868,10 +866,10 @@ componentNamesFromLBI verbosity distPref targetsDescr compPred = do
               $ LBI.pkgComponents pkgDescr
       if null names
         then do
-          notice verbosity
-            $ "Package has no buildable "
-            ++ targetsDescr
-            ++ "."
+          notice verbosity $
+            "Package has no buildable "
+              ++ targetsDescr
+              ++ "."
           exitSuccess -- See #3215.
         else return $! (ComponentNames names)
 
@@ -1121,14 +1119,13 @@ uploadAction uploadFlags extraArgs globalFlags = do
   let uploadFlags' = savedUploadFlags config `mappend` uploadFlags
       globalFlags' = savedGlobalFlags config `mappend` globalFlags
       tarfiles = extraArgs
-  when (null tarfiles && not (fromFlag (uploadDoc uploadFlags')))
-    $ dieWithException verbosity UploadAction
+  when (null tarfiles && not (fromFlag (uploadDoc uploadFlags'))) $
+    dieWithException verbosity UploadAction
   checkTarFiles extraArgs
   maybe_password <-
     case uploadPasswordCmd uploadFlags' of
       Flag (xs : xss) ->
-        Just
-          . Password
+        Just . Password
           <$> getProgramInvocationOutput
             verbosity
             (simpleProgramInvocation xs xss)
@@ -1136,8 +1133,8 @@ uploadAction uploadFlags extraArgs globalFlags = do
   withRepoContext verbosity globalFlags' $ \repoContext -> do
     if fromFlag (uploadDoc uploadFlags')
       then do
-        when (length tarfiles > 1)
-          $ dieWithException verbosity UploadActionDocumentation
+        when (length tarfiles > 1) $
+          dieWithException verbosity UploadActionDocumentation
         tarfile <- maybe (generateDocTarball config) return $ listToMaybe tarfiles
         Upload.uploadDoc
           verbosity
@@ -1174,12 +1171,12 @@ uploadAction uploadFlags extraArgs globalFlags = do
           (file', ".gz") -> takeExtension file' == ".tar"
           _ -> False
     generateDocTarball config = do
-      notice verbosity
-        $ "No documentation tarball specified. "
-        ++ "Building a documentation tarball with default settings...\n"
-        ++ "If you need to customise Haddock options, "
-        ++ "run 'haddock --for-hackage' first "
-        ++ "to generate a documentation tarball."
+      notice verbosity $
+        "No documentation tarball specified. "
+          ++ "Building a documentation tarball with default settings...\n"
+          ++ "If you need to customise Haddock options, "
+          ++ "run 'haddock --for-hackage' first "
+          ++ "to generate a documentation tarball."
       haddockAction
         (defaultHaddockFlags{haddockForHackage = Flag ForHackage})
         []
@@ -1191,9 +1188,9 @@ uploadAction uploadFlags extraArgs globalFlags = do
 checkAction :: Flag Verbosity -> [String] -> Action
 checkAction verbosityFlag extraArgs _globalFlags = do
   let verbosity = fromFlag verbosityFlag
-  unless (null extraArgs)
-    $ dieWithException verbosity
-    $ CheckAction extraArgs
+  unless (null extraArgs) $
+    dieWithException verbosity $
+      CheckAction extraArgs
   allOk <- Check.check (fromFlag verbosityFlag)
   unless allOk exitFailure
 
@@ -1212,9 +1209,9 @@ formatAction verbosityFlag extraArgs _globalFlags = do
 reportAction :: ReportFlags -> [String] -> Action
 reportAction reportFlags extraArgs globalFlags = do
   let verbosity = fromFlag (reportVerbosity reportFlags)
-  unless (null extraArgs)
-    $ dieWithException verbosity
-    $ ReportAction extraArgs
+  unless (null extraArgs) $
+    dieWithException verbosity $
+      ReportAction extraArgs
   config <- loadConfig verbosity (globalConfigFile globalFlags)
   let globalFlags' = savedGlobalFlags config `mappend` globalFlags
       reportFlags' = savedReportFlags config `mappend` reportFlags
@@ -1336,9 +1333,9 @@ actAsSetupAction actAsSetupFlags args _globalFlags =
 manpageAction :: [CommandSpec action] -> ManpageFlags -> [String] -> Action
 manpageAction commands flags extraArgs _ = do
   let verbosity = fromFlag (manpageVerbosity flags)
-  unless (null extraArgs)
-    $ dieWithException verbosity
-    $ ManpageAction extraArgs
+  unless (null extraArgs) $
+    dieWithException verbosity $
+      ManpageAction extraArgs
   pname <- getProgName
   let cabalCmd =
         if takeExtension pname == ".exe"


### PR DESCRIPTION
Commit message:

Added or expanded 5 comments, and fourmolu-formatted affected files. I documented lightly defaultMainHelper in Cabal/Distribution.Simple, expandResponse in Cabal/Distribution.Compat.ResponseFile, expanding the main comment in cabal-install/Distribution.Client.Main, adding segmentation commenting marking responseFiles handling in cabal-install/Distribution.Client.Main (main), added haddock documentation to mainWorker in cabal-install/Distribution.Client.Main .

* [ x ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

If this doesn't work, I think the fourmolu CI is processing intermediate commits, and this might have to be discussed.