### PR TITLE
Fix run command environment

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdExec.hs
+++ b/cabal-install/src/Distribution/Client/CmdExec.hs
@@ -263,6 +263,7 @@ withTempEnvFile verbosity baseCtx buildCtx buildStatus action = do
         action envOverrides
     )
 
+-- | Get paths to all dependency executables to be included in PATH and log them.
 pathAdditions :: Verbosity -> ProjectBaseContext -> ProjectBuildContext -> IO [FilePath]
 pathAdditions verbosity ProjectBaseContext{..} ProjectBuildContext{..} = do
   info verbosity . unlines $
@@ -274,6 +275,7 @@ pathAdditions verbosity ProjectBaseContext{..} ProjectBuildContext{..} = do
       S.toList $
         binDirectories distDirLayout elaboratedShared elaboratedPlanToExecute
 
+-- | Get paths to all dependency executables to be included in PATH.
 binDirectories
   :: DistDirLayout
   -> ElaboratedSharedConfig

--- a/changelog.d/pr-9341
+++ b/changelog.d/pr-9341
@@ -1,0 +1,11 @@
+synopsis: Fix run command environment
+packages: cabal-install
+prs: #9341
+issues: #8391
+
+description: {
+
+- The Run command will now add binary paths of dependencies
+  (build-tool-depends) to PATH, just like Exec and Test commands.
+
+}


### PR DESCRIPTION
* use `elabExeDependencyPaths` to get run test dependencies
* closes #8391

## QA Notes

Calling `cabal run` should run the executable with dependencies on PATH.

Run a test that uses the built executable (e.g. fourmolu or HLS) that it depends on via `build-tool-depends`.
For example in the case of `func-test` in HLS, the following invocations should now all pass:
```shell
cabal run func-test -- -p indefinite
cabal test func-test --test-options="-p indefinite"
cabal exec $(cabal list-bin func-test) -- -p indefinite
```

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.


