### PR TITLE
ci gitlab clear global index state

### DIFF
--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -27,6 +27,8 @@ export BOOTSTRAP_HASKELL_NONINTERACTIVE=1
 export BOOTSTRAP_HASKELL_GHC_VERSION=$GHC_VERSION
 export BOOTSTRAP_HASKELL_CABAL_VERSION=$CABAL_INSTALL_VERSION
 export BOOTSTRAP_HASKELL_ADJUST_CABAL_CONFIG=yes
+# We don't use stack, and it isn't available on i386-deb9
+export BOOTSTRAP_HASKELL_INSTALL_NO_STACK=yes
 
 # for some reason the subshell doesn't pick up the arm64 environment on darwin
 # and starts installing x86_64 GHC

--- a/.gitlab/ci.sh
+++ b/.gitlab/ci.sh
@@ -65,6 +65,13 @@ args=(
     ${ADD_CABAL_ARGS}
 )
 
+# Make sure we get rid of any global index-state
+run cabal update hackage.haskell.org,HEAD
+# cabal-install used to have a bug that caused reporting the wrong index-state, so we do it manually too
+
+info "This is the index-state as determined by $CABAL_DIR/packages/hackage.haskell.org/01-index.timestamp: $(cat $CABAL_DIR/packages/hackage.haskell.org/01-index.timestamp)"
+
+
 run cabal v2-build ${args[@]} cabal-install
 
 mkdir "$CI_PROJECT_DIR/out"


### PR DESCRIPTION
`cabal update` alone will update the tarball but preserve the global index state if one is set.

[![pipeline status](https://gitlab.haskell.org/haskell/cabal/badges/andrea/ci-gitlab-clear-global-index-state/pipeline.svg)](https://gitlab.haskell.org/haskell/cabal/-/commits/andrea/ci-gitlab-clear-global-index-state) 
