### PR TITLE
Fix #9151 (cabal init logs at loglevel "Log")

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/src/Distribution/Client/Init/FileCreators.hs
@@ -65,7 +65,7 @@ writeProject (ProjectSettings opts pkgDesc libTarget exeTarget testTarget)
       message opts T.Error "no package name given, so no .cabal file can be generated\n"
   | otherwise = do
       -- clear prompt history a bit"
-      message opts T.Log $
+      message opts T.Info $
         "Using cabal specification: "
           ++ showCabalSpecVersion (_optCabalSpec opts)
 
@@ -269,7 +269,7 @@ writeFileSafe opts fileName content = do
 
   go exists
 
-  message opts T.Log $ show action ++ " file " ++ fileName ++ "..."
+  message opts T.Info $ show action ++ " file " ++ fileName ++ "..."
   return $ action == Existing
   where
     doOverwrite = _optOverwrite opts
@@ -279,7 +279,7 @@ writeFileSafe opts fileName content = do
           writeFile fileName content
       | exists && doOverwrite = do
           newName <- findNewPath fileName
-          message opts T.Log $
+          message opts T.Info $
             concat
               [ fileName
               , " already exists. Backing up old version in "
@@ -302,7 +302,7 @@ writeDirectoriesSafe opts dirs = fmap or $ for dirs $ \dir -> do
 
   go dir exists
 
-  message opts T.Log $ show action ++ " directory ./" ++ dir ++ "..."
+  message opts T.Info $ show action ++ " directory ./" ++ dir ++ "..."
   return $ action == Existing
   where
     doOverwrite = _optOverwrite opts
@@ -312,7 +312,7 @@ writeDirectoriesSafe opts dirs = fmap or $ for dirs $ \dir -> do
           createDirectory dir
       | exists && doOverwrite = do
           newDir <- findNewPath dir
-          message opts T.Log $
+          message opts T.Info $
             concat
               [ dir
               , " already exists. Backing up old version in "

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -455,7 +455,7 @@ newtype BreakException = BreakException String deriving (Eq, Show)
 instance Exception BreakException
 
 -- | Used to inform the intent of prompted messages.
-data Severity = Log | Info | Warning | Error deriving (Eq, Show)
+data Severity = Info | Warning | Error deriving (Eq, Show)
 
 -- | Convenience alias for the literate haskell flag
 type IsLiterate = Bool

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -458,10 +458,10 @@ instance Exception BreakException
 data Severity = Info | Warning | Error deriving (Eq)
 
 displaySeverity :: Severity -> String
-displaySeverity severity
-  | severity == Info = "Info"
-  | severity == Warning = "Warn"
-  | severity == Error = "Err"
+displaySeverity severity = case severity of
+  Info -> "Info"
+  Warning -> "Warn"
+  Error -> "Err"
 
 -- | Convenience alias for the literate haskell flag
 type IsLiterate = Bool

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -368,7 +368,7 @@ instance Interactive IO where
   hFlush = System.IO.hFlush
   message q severity msg
     | q == silent = pure ()
-    | otherwise = putStrLn $ "[" ++ show severity ++ "] " ++ msg
+    | otherwise = putStrLn $ "[" ++ displaySeverity severity ++ "] " ++ msg
   break = return False
   throwPrompt = throwM
 
@@ -407,7 +407,7 @@ instance Interactive PurePrompt where
     Error -> PurePrompt $ \_ ->
       Left $
         BreakException
-          (show severity ++ ": " ++ msg)
+          (displaySeverity severity ++ ": " ++ msg)
     _ -> return ()
 
   break = return True
@@ -455,7 +455,12 @@ newtype BreakException = BreakException String deriving (Eq, Show)
 instance Exception BreakException
 
 -- | Used to inform the intent of prompted messages.
-data Severity = Info | Warning | Error deriving (Eq, Show)
+data Severity = Info | Warning | Error deriving (Eq)
+
+displaySeverity :: Severity -> String
+displaySeverity severity | severity == Info = "Info"
+                         | severity == Warning = "Warn"
+                         | severity == Error = "Err"
 
 -- | Convenience alias for the literate haskell flag
 type IsLiterate = Bool

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -458,9 +458,10 @@ instance Exception BreakException
 data Severity = Info | Warning | Error deriving (Eq)
 
 displaySeverity :: Severity -> String
-displaySeverity severity | severity == Info = "Info"
-                         | severity == Warning = "Warn"
-                         | severity == Error = "Err"
+displaySeverity severity
+  | severity == Info = "Info"
+  | severity == Warning = "Warn"
+  | severity == Error = "Err"
 
 -- | Convenience alias for the literate haskell flag
 type IsLiterate = Bool

--- a/cabal-install/src/Distribution/Client/Init/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Init/Utils.hs
@@ -214,7 +214,7 @@ retrieveDependencies v flags mods' pkgIx = do
       modDeps = map (\(mn, ds) -> (mn, ds, M.lookup ds modMap)) mods
   -- modDeps = map (id &&& flip M.lookup modMap) mods
 
-  message v Log "Guessing dependencies..."
+  message v Info "Guessing dependencies..."
   nub . catMaybes <$> traverse (chooseDep v flags) modDeps
 
 -- Given a module and a list of installed packages providing it,

--- a/changelog.d/pr-9346
+++ b/changelog.d/pr-9346
@@ -7,7 +7,7 @@ significance: minor
 description: {
 
 - Log is used in cabal-install as a loglevel.
-- "Log" is not a (loglevel)[https://betterstack.com/community/guides/logging/log-levels-explained/].
+- "Log" is not a [loglevel](https://betterstack.com/community/guides/logging/log-levels-explained/).
 - replace Log with Info where it is used.
 
 }

--- a/changelog.d/pr-9346
+++ b/changelog.d/pr-9346
@@ -1,0 +1,13 @@
+synopsis: remove 
+packages: cabal-install
+prs: #9346
+issues: #9151
+significance: minor
+
+description: {
+
+- Log is used in cabal-install as a loglevel.
+- "Log" is not a (loglevel)[https://betterstack.com/community/guides/logging/log-levels-explained/].
+- replace Log with Info where it is used.
+
+}

--- a/changelog.d/pr-9346
+++ b/changelog.d/pr-9346
@@ -2,7 +2,7 @@ synopsis: remove
 packages: cabal-install
 prs: #9346
 issues: #9151
-significance: minor
+significance: significant
 
 description: {
 

--- a/changelog.d/pr-9346
+++ b/changelog.d/pr-9346
@@ -6,8 +6,7 @@ significance: significant
 
 description: {
 
-- Log is used in cabal-install as a loglevel.
-- "Log" is not a [loglevel](https://betterstack.com/community/guides/logging/log-levels-explained/).
-- replace Log with Info where it is used.
+- Remove "Log" as a log level in favour of "Info".
+- Remove "Show" in Severity and replace by "displaySeverity" function
 
 }


### PR DESCRIPTION
The actual ADT for severity should change because "Log" is useless as a datatype, arguably it shouldn't even be an entry in the ADT and the severity should be at `Info` for everything that's not a `Warn`.

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

## QA notes:

when calling `cabal init` the user sees log entries categorized as Info, while entries categorized as Log should not appear.