### PR TITLE
Update format.yml

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,8 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: haskell-actions/run-fourmolu@v8
+    - uses: haskell-actions/run-fourmolu@v9
       with:
+        version: "0.12.0.0"
         pattern: |
           Cabal/**/*.hs
           Cabal-syntax/**/*.hs


### PR DESCRIPTION
Bump haskell-actions/run-fourmolu to v9 and fix fourmolu version to 0.12.0.0. This makes explicit which version is used and avoids unexpected changes later on.

The current version v8 of run-fourmolu uses fourmolu-0.12.0.0 so this should not produce any change in formatting now.