### PR TITLE
Bump dependencies for GHC 9.8

### DIFF
--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -60,7 +60,7 @@ test-suite unit-tests
     , Cabal-QuickCheck
     , containers
     , deepseq
-    , Diff                >=0.4   && <0.5
+    , Diff                >=0.4   && <0.6
     , directory
     , filepath
     , integer-logarithms  >=1.0.2 && <1.1
@@ -68,7 +68,7 @@ test-suite unit-tests
     , QuickCheck          >=2.14  && <2.15
     , rere                >=0.1   && <0.3
     , tagged
-    , tasty               >=1.2.3 && <1.5
+    , tasty               >=1.2.3 && <1.6
     , tasty-hunit
     , tasty-quickcheck
     , temporary
@@ -84,14 +84,14 @@ test-suite parser-tests
   main-is:          ParserTests.hs
   build-depends:
       base
-    , base-compat       >=0.11.0  && <0.13
+    , base-compat       >=0.11.0  && <0.14
     , bytestring
     , Cabal-syntax
     , Cabal-tree-diff
-    , Diff              >=0.4     && <0.5
+    , Diff              >=0.4     && <0.6
     , directory
     , filepath
-    , tasty             >=1.2.3   && <1.5
+    , tasty             >=1.2.3   && <1.6
     , tasty-golden      >=2.3.1.1 && <2.4
     , tasty-hunit
     , tasty-quickcheck
@@ -109,10 +109,10 @@ test-suite check-tests
     , bytestring
     , Cabal
     , Cabal-syntax
-    , Diff          >=0.4     && <0.5
+    , Diff          >=0.4     && <0.6
     , directory
     , filepath
-    , tasty         >=1.2.3   && <1.5
+    , tasty         >=1.2.3   && <1.6
     , tasty-expected-failure
     , tasty-golden  >=2.3.1.1 && <2.4
 
@@ -155,10 +155,10 @@ test-suite hackage-tests
     , filepath
 
   build-depends:
-      base-compat           >=0.11.0   && <0.13
-    , base-orphans          >=0.6      && <0.9
+      base-compat           >=0.11.0   && <0.14
+    , base-orphans          >=0.6      && <0.10
     , clock                 >=0.8      && <0.9
-    , optparse-applicative  >=0.13.2.0 && <0.17
+    , optparse-applicative  >=0.13.2.0 && <0.19
     , stm                   >=2.4.5.0  && <2.6
     , tar                   >=0.5.0.3  && <0.6
     , tree-diff             >=0.1      && <0.4
@@ -178,7 +178,7 @@ test-suite rpmvercmp
 
   build-depends:
       QuickCheck
-    , tasty             >=1.2.3 && <1.5
+    , tasty             >=1.2.3 && <1.6
     , tasty-hunit
     , tasty-quickcheck
 
@@ -197,7 +197,7 @@ test-suite no-thunks-test
       base
     , bytestring
     , Cabal-syntax
-    , tasty        >=1.2.3 && <1.5
+    , tasty        >=1.2.3 && <1.6
     , tasty-hunit
 
   -- this is test is buildable on old GHCs

--- a/cabal-benchmarks/cabal-benchmarks.cabal
+++ b/cabal-benchmarks/cabal-benchmarks.cabal
@@ -31,4 +31,4 @@ test-suite cabal-benchmarks
       base
     , bytestring
     , Cabal-syntax
-    , criterion   >=1.5.6.2 && <1.6
+    , criterion   >=1.5.6.2 && <1.7

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -105,7 +105,7 @@ library
 
   build-depends:
     , array         >=0.4      && <0.6
-    , base          >=4.10     && <4.19
+    , base          >=4.10     && <4.20
     , bytestring    >=0.10.6.0 && <0.13
     , Cabal         ^>=3.11
     , Cabal-syntax  ^>=3.11
@@ -138,10 +138,10 @@ Test-Suite unit-tests
      UnitTests.Distribution.Solver.Modular.MessageUtils
 
    build-depends:
-     , base        >= 4.10  && <4.19
+     , base        >= 4.10  && <4.20
      , Cabal
      , Cabal-syntax
      , cabal-install-solver
-     , tasty       >= 1.2.3 && <1.5
+     , tasty       >= 1.2.3 && <1.6
      , tasty-quickcheck
      , tasty-hunit >= 0.10

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -46,7 +46,7 @@ common warnings
       ghc-options: -Wunused-packages
 
 common base-dep
-    build-depends: base >=4.10 && <4.19
+    build-depends: base >=4.10 && <4.20
 
 common cabal-dep
     build-depends: Cabal ^>=3.11
@@ -229,7 +229,7 @@ library
         time       >= 1.5.0.1  && < 1.13,
         zlib       >= 0.5.3    && < 0.7,
         hackage-security >= 0.6.2.0 && < 0.7,
-        text       >= 1.2.3    && < 1.3 || >= 2.0 && < 2.1,
+        text       >= 1.2.3    && < 1.3 || >= 2.0 && < 2.2,
         parsec     >= 3.1.13.0 && < 3.2,
         regex-base  >= 0.94.0.0 && <0.95,
         regex-posix >= 0.96.0.0 && <0.97,
@@ -332,7 +332,7 @@ test-suite unit-tests
           tar,
           time,
           zlib,
-          tasty >= 1.2.3 && <1.5,
+          tasty >= 1.2.3 && <1.6,
           tasty-golden >=2.3.1.1 && <2.4,
           tasty-quickcheck,
           tasty-hunit >= 0.10,

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -26,7 +26,7 @@ common shared
   default-language: Haskell2010
 
   build-depends:
-    , base >= 4.9 && <4.19
+    , base >= 4.9 && <4.20
     -- this needs to match the in-tree lib:Cabal version
     , Cabal ^>= 3.11.0.0
     , Cabal-syntax ^>= 3.11.0.0
@@ -57,7 +57,7 @@ library
     Test.Cabal.ScriptEnv0
 
   build-depends:
-    , aeson                 ^>= 1.4.2.0 || ^>=1.5.0.0 || ^>= 2.0.0.0 || ^>= 2.1.0.0
+    , aeson                 ^>= 1.4.2.0 || ^>=1.5.0.0 || ^>= 2.0.0.0 || ^>= 2.1.0.0 || ^>= 2.2.1.0
     , async                 ^>= 2.2.1
     , attoparsec            ^>= 0.13.2.2 || ^>=0.14.1
     , base64-bytestring     ^>= 1.0.0.0 || ^>= 1.1.0.0 || ^>= 1.2.0.0
@@ -68,14 +68,14 @@ library
     , exceptions            ^>= 0.10.0
     , filepath              ^>= 1.3.0.1 || ^>= 1.4.0.0
     , network-wait          ^>= 0.1.2.0 || ^>= 0.2.0.0
-    , optparse-applicative  ^>= 0.14.3.0 || ^>=0.15.1.0 || ^>=0.16.0.0 || ^>= 0.17.0.0
+    , optparse-applicative  ^>= 0.14.3.0 || ^>=0.15.1.0 || ^>=0.16.0.0 || ^>= 0.17.0.0 || ^>= 0.18.1.0
     , process               ^>= 1.2.1.0 || ^>= 1.4.2.0 || ^>= 1.6.1.0
     , regex-base            ^>= 0.94.0.1
     , regex-tdfa            ^>= 1.2.3.1 || ^>=1.3.1.0
     , retry                 ^>= 0.9.1.0
     , array                 ^>= 0.4.0.1 || ^>= 0.5.0.0
     , temporary             ^>= 1.3
-    , text                  ^>= 1.2.3.1 || ^>= 2.0.1
+    , text                  ^>= 1.2.3.1 || ^>= 2.0.1   || ^>= 2.1
     , transformers          ^>= 0.3.0.0 || ^>= 0.4.2.0 || ^>= 0.5.2.0 || ^>= 0.6.0.2
 
   if !os(windows)

--- a/cabal.project
+++ b/cabal.project
@@ -15,17 +15,9 @@ packages: cabal-benchmarks/
 
 optional-packages: ./vendored/*/*.cabal
 
-allow-newer:
-  hackage-security:Cabal
-
 -- avoiding extra dependencies
 constraints: rere -rere-cfg
 constraints: these -assoc
-
--- Andreas, 2022-08-19, https://github.com/haskell/cabal/issues/8377
--- Force latest dependencies in the development version:
-constraints: text >= 2.0
-constraints: time >= 1.12
 
 program-options
   ghc-options: -fno-ignore-asserts


### PR DESCRIPTION
Bump to latest dependencies for GHC 9.8.1, closes #9368.

Update: I added a `allow-newer` for `rere` into `cabal.project` now.
~~TODO:~~
- [x] ~~Temporarily added `cabal.project.local` for outdated deps, needs to be removed once deps have caught up to GHC 9.8.~~

Upstream issues:
- [x] https://github.com/phadej/rere/issues/23 (https://github.com/phadej/rere/pull/24)
- [x] https://github.com/input-output-hk/nothunks/issues/35
