### PR TITLE
Implement v2-outdated command

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -169,6 +169,7 @@ library
         Distribution.Client.ManpageFlags
         Distribution.Client.Nix
         Distribution.Client.NixStyleOptions
+        Distribution.Client.Outdated
         Distribution.Client.PackageHash
         Distribution.Client.ParseUtils
         Distribution.Client.ProjectBuilding

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -133,6 +133,7 @@ import qualified Distribution.Client.CmdSdist as CmdSdist
 import qualified Distribution.Client.CmdTarget as CmdTarget
 import qualified Distribution.Client.CmdTest as CmdTest
 import qualified Distribution.Client.CmdUpdate as CmdUpdate
+import qualified Distribution.Client.Outdated as Outdated
 
 import Distribution.Client.Check as Check (check)
 import Distribution.Client.Configure (configure, writeConfigFlags)

--- a/cabal-install/src/Distribution/Client/Outdated.hs
+++ b/cabal-install/src/Distribution/Client/Outdated.hs
@@ -8,7 +8,7 @@
 --
 -- Implementation of the 'outdated' command. Checks for outdated
 -- dependencies in the package description file or freeze file.
-module Distribution.Client.CmdOutdated
+module Distribution.Client.Outdated
   ( outdatedCommand
   , outdatedAction
   , ListOutdatedSettings (..)


### PR DESCRIPTION
Implement a `v2-outdated` command which is simply the `v2` version of the `outdated` command.

It does all the `v2` style setup in order to extract a `PackageVersionConstraint` list and then calls into the v1 version of the command for the logic and IO for the results.

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

Bonus points for added automated tests!

**Note:** The diff on the file `CmdOutput.hs` is rather weird because this PR renames `CmsOutdated.hs` to `Outdated.hs` and then creates a new file  `CmdOutput.hs`.

## QA Notes

* The `v2-outdated` command should work in an old project directory layout (a single top level `<package>.cabal` file) and a new project directory with just a `cabal.project` file.