### PR TITLE
Avoid double space in "Executing install plan ..."

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding.hs
@@ -672,9 +672,9 @@ rebuildTargets
         info verbosity $
           "Executing install plan "
             ++ case buildSettingNumJobs of
-              NumJobs n -> " in parallel using " ++ show n ++ " threads."
-              UseSem n -> " in parallel using a semaphore with " ++ show n ++ " slots."
-              Serial -> " serially."
+              NumJobs n -> "in parallel using " ++ show n ++ " threads."
+              UseSem n -> "in parallel using a semaphore with " ++ show n ++ " slots."
+              Serial -> "serially."
 
         createDirectoryIfMissingVerbose verbosity True distBuildRootDirectory
         createDirectoryIfMissingVerbose verbosity True distTempDirectory

--- a/changelog.d/pr-9376
+++ b/changelog.d/pr-9376
@@ -1,0 +1,6 @@
+synopsis: Avoid a double space in "Executing install plan ..."
+description:
+  The "Executing·install·plan··serially" and other similar "Executing install
+  plan··..." outputs no longer contain double spaces.
+packages: cabal-install
+prs: #9376


### PR DESCRIPTION
**This PR does not modify `cabal` behaviour**[^1]

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

[^1]: A double space in a message is reduced to a single space:

```diff
$ cabal run cabal-testsuite:cabal-tests -- \
   --with-cabal=./dist-newstyle/build/x86_64-linux/ghc-9.2.7/cabal-install-3.11.0.0/x/cabal/build/cabal/cabal cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.test.hs
...
  -----BEGIN CABAL OUTPUT-----
  Build profile: -w ghc-9.2.7 -O1
  In order, the following will be built:
   - basic-0.1 (lib) (requires build)
  -----END CABAL OUTPUT-----
-  Executing install plan  serially.
+  Executing install plan serially.
```

Scratch that. This PR modifies `cabal` behaviour.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary (not necessary).
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included (shown inline here).

Bonus points for added automated tests!