### PR TITLE
Add reinstall test to LinkerOptions/NonignoredConfigs

### DIFF
--- a/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.out
+++ b/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.out
@@ -10,6 +10,13 @@ Building library for basic-0.1...
 Installing library in <PATH>
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
+Error: [Cabal-7145]
+Packages requested to install already exist in environment file at <ROOT>/cabal.dist/basic0.env. Overwriting them may break other packages. Use --force-reinstalls to proceed anyway. Packages: basic
+# cabal v2-install
+Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
+Resolving dependencies...
+# cabal v2-install
+Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
 In order, the following will be built:
@@ -20,7 +27,28 @@ Building library for basic-0.1...
 Installing library in <PATH>
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
+Error: [Cabal-7145]
+Packages requested to install already exist in environment file at <ROOT>/cabal.dist/basic1.env. Overwriting them may break other packages. Use --force-reinstalls to proceed anyway. Packages: basic
+# cabal v2-install
+Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Resolving dependencies...
+# cabal v2-install
+Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
+Resolving dependencies...
+# cabal v2-install
+Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
+Error: [Cabal-7145]
+Packages requested to install already exist in environment file at <ROOT>/cabal.dist/basic2.env. Overwriting them may break other packages. Use --force-reinstalls to proceed anyway. Packages: basic
+# cabal v2-install
+Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
+Resolving dependencies...
+# cabal v2-install
+Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
+Resolving dependencies...
+# cabal v2-install
+Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
+Error: [Cabal-7145]
+Packages requested to install already exist in environment file at <ROOT>/cabal.dist/basic3.env. Overwriting them may break other packages. Use --force-reinstalls to proceed anyway. Packages: basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.out
+++ b/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.out
@@ -1,3 +1,4 @@
+# install options: --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic0.env basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Resolving dependencies...
@@ -8,13 +9,16 @@ Configuring library for basic-0.1...
 Preprocessing library for basic-0.1...
 Building library for basic-0.1...
 Installing library in <PATH>
+# install options: --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic0.env basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Error: [Cabal-7145]
 Packages requested to install already exist in environment file at <ROOT>/cabal.dist/basic0.env. Overwriting them may break other packages. Use --force-reinstalls to proceed anyway. Packages: basic
+# install options: --force-reinstalls --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic0.env basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Resolving dependencies...
+# install options: --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic1.env --enable-shared --enable-executable-dynamic --disable-library-vanilla basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Resolving dependencies...
@@ -25,30 +29,38 @@ Configuring library for basic-0.1...
 Preprocessing library for basic-0.1...
 Building library for basic-0.1...
 Installing library in <PATH>
+# install options: --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic1.env --enable-shared --enable-executable-dynamic --disable-library-vanilla basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Error: [Cabal-7145]
 Packages requested to install already exist in environment file at <ROOT>/cabal.dist/basic1.env. Overwriting them may break other packages. Use --force-reinstalls to proceed anyway. Packages: basic
+# install options: --force-reinstalls --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic1.env --enable-shared --enable-executable-dynamic --disable-library-vanilla basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Resolving dependencies...
+# install options: --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic2.env basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Resolving dependencies...
+# install options: --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic2.env basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Error: [Cabal-7145]
 Packages requested to install already exist in environment file at <ROOT>/cabal.dist/basic2.env. Overwriting them may break other packages. Use --force-reinstalls to proceed anyway. Packages: basic
+# install options: --force-reinstalls --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic2.env basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Resolving dependencies...
+# install options: --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic3.env --enable-shared --enable-executable-dynamic --disable-library-vanilla basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Resolving dependencies...
+# install options: --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic3.env --enable-shared --enable-executable-dynamic --disable-library-vanilla basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Error: [Cabal-7145]
 Packages requested to install already exist in environment file at <ROOT>/cabal.dist/basic3.env. Overwriting them may break other packages. Use --force-reinstalls to proceed anyway. Packages: basic
+# install options: --force-reinstalls --disable-deterministic --lib --package-env=<ROOT>/cabal.dist/basic3.env --enable-shared --enable-executable-dynamic --disable-library-vanilla basic
 # cabal v2-install
 Wrote tarball sdist to <ROOT>/cabal.dist/work/./basic/../dist/sdist/basic-0.1.tar.gz
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.test.hs
@@ -70,7 +70,10 @@ main = cabalTest $ do
                     -- (see 'testCurrentDir').)
                     withDirectory ".." $ do
                         packageEnv <- (</> ("basic" ++ show idx ++ ".env")) . testWorkDir <$> getTestEnv
-                        cabal "v2-install" $ ["--disable-deterministic", "--lib", "--package-env=" ++ packageEnv] ++ linkConfigFlags linking ++ ["basic"]
+                        let installOptions = ["--disable-deterministic", "--lib", "--package-env=" ++ packageEnv] ++ linkConfigFlags linking ++ ["basic"]
+                        cabal "v2-install" installOptions
+                        fails $ cabal "v2-install" installOptions
+                        cabal "v2-install" $ "--force-reinstalls" : installOptions
                         let exIPID s = takeWhile (/= '\n') . head . filter (\t -> any (`isPrefixOf` t) ["basic-0.1-", "bsc-0.1-"]) $ tails s
                         hashedIpid <- exIPID <$> liftIO (readFile packageEnv)
                         return $ ((idx, linking), hashedIpid)

--- a/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/LinkerOptions/NonignoredConfigs/cabal.test.hs
@@ -71,9 +71,13 @@ main = cabalTest $ do
                     withDirectory ".." $ do
                         packageEnv <- (</> ("basic" ++ show idx ++ ".env")) . testWorkDir <$> getTestEnv
                         let installOptions = ["--disable-deterministic", "--lib", "--package-env=" ++ packageEnv] ++ linkConfigFlags linking ++ ["basic"]
-                        cabal "v2-install" installOptions
-                        fails $ cabal "v2-install" installOptions
-                        cabal "v2-install" $ "--force-reinstalls" : installOptions
+                        recordMode RecordMarked $ do
+                            recordHeader $ "install options:" : installOptions
+                            cabal "v2-install" installOptions
+                            recordHeader $ "install options:" : installOptions
+                            fails $ cabal "v2-install" installOptions
+                            recordHeader $ "install options:" : "--force-reinstalls" : installOptions
+                            cabal "v2-install" $ "--force-reinstalls" : installOptions
                         let exIPID s = takeWhile (/= '\n') . head . filter (\t -> any (`isPrefixOf` t) ["basic-0.1-", "bsc-0.1-"]) $ tails s
                         hashedIpid <- exIPID <$> liftIO (readFile packageEnv)
                         return $ ((idx, linking), hashedIpid)


### PR DESCRIPTION
Adds a test of `--force-reinstalls`.

I found no reinstall tests for #9268 but I did find a `LinkerOptions/NonignoredConfigs` test where I could add a reinstall test. Unfortunately this doesn't touch the code path of #9268 with its `Use --overwrite-policy=always to overwrite` message. The message is instead:

> Packages requested to install already exist in environment file at ... Overwriting them may break other packages. Use --force-reinstalls to proceed anyway.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

