### PR TITLE
Use the newer haskell-actions organisation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: haskell/actions/hlint-setup@v2
+    - uses: haskell-actions/hlint-setup@v2
       with:
         version: "3.5"
-    - uses: haskell/actions/hlint-run@v2
+    - uses: haskell-actions/hlint-run@v2
       with:
         path: "."
         fail-on: suggestion


### PR DESCRIPTION
Only changes the lint github workflow, picking up each action from the newer organisation for these actions.

