### PR TITLE
Annotationless exact-printer

### DIFF
--- a/Cabal-layout/Cabal-layout.cabal
+++ b/Cabal-layout/Cabal-layout.cabal
@@ -1,0 +1,111 @@
+cabal-version: 2.2
+name:          Cabal-layout
+version:       3.11.0.0
+copyright:     2003-2023, Cabal Development Team (see AUTHORS file)
+license:       BSD-3-Clause
+license-file:  LICENSE
+author:        Cabal Development Team <cabal-devel@haskell.org>
+maintainer:    cabal-devel@haskell.org
+homepage:      http://www.haskell.org/cabal/
+bug-reports:   https://github.com/haskell/cabal/issues
+synopsis:      Cabal format manipulation
+description:
+  Cabal format manipulation.
+
+category:       Distribution
+build-type:     Simple
+
+extra-source-files:
+  README.md ChangeLog.md
+
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell/cabal/
+  subdir:   Cabal-layout
+
+
+library
+  default-language: Haskell2010
+
+  hs-source-dirs: src
+
+  build-depends:
+      base       >= 4.9      && < 5
+    , bytestring
+    , parsec
+    , text
+
+  ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+
+  if impl(ghc >= 8.0)
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances
+
+  if impl(ghc >= 8.0) && impl(ghc < 8.8)
+    ghc-options: -Wnoncanonical-monadfail-instances
+
+  exposed-modules:
+    Codec.Manifest.Cabal.Layout
+
+  exposed-modules:
+    Codec.Manifest.Cabal.Internal.Layout
+    Codec.Manifest.Cabal.Internal.Parse
+    Codec.Manifest.Cabal.Internal.Render
+
+
+
+test-suite sanity
+  type: exitcode-stdio-1.0
+
+  main-is: Main.hs
+
+  default-language: Haskell2010
+
+  hs-source-dirs: src
+                , test/sanity
+
+  build-depends:
+      base       >= 4.9      && < 5
+    , bytestring
+    , parsec
+    , tasty
+    , tasty-hunit
+    , text
+
+  ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+
+  if impl(ghc >= 8.0)
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances
+
+  if impl(ghc >= 8.0) && impl(ghc < 8.8)
+    ghc-options: -Wnoncanonical-monadfail-instances
+
+
+
+test-suite hackage
+  type: exitcode-stdio-1.0
+
+  main-is: Main.hs
+
+  default-language: Haskell2010
+
+  hs-source-dirs: src
+                , test/hackage
+                , test/strictness
+
+  build-depends:
+      base       >= 4.9      && < 5
+    , bytestring
+    , directory
+    , filepath
+    , nothunks
+    , parsec
+    , text
+
+  ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+
+  if impl(ghc >= 8.0)
+    ghc-options: -Wcompat -Wnoncanonical-monad-instances
+
+  if impl(ghc >= 8.0) && impl(ghc < 8.8)
+    ghc-options: -Wnoncanonical-monadfail-instances

--- a/Cabal-layout/src/Codec/Manifest/Cabal/Internal/Layout.hs
+++ b/Cabal-layout/src/Codec/Manifest/Cabal/Internal/Layout.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE DerivingStrategies
+           , GeneralizedNewtypeDeriving
+           , QuantifiedConstraints
+           , StandaloneDeriving
+           , UndecidableInstances #-}
+
+module Codec.Manifest.Cabal.Internal.Layout where
+
+import           Data.Text (Text)
+
+
+
+-- | Context-dependent whitespace.
+newtype Offset = Offset Int
+                 deriving newtype Show
+
+-- | Context-independent whitespace.
+newtype Whitespace = Whitespace Int
+                     deriving newtype Show
+
+-- | Anything that follows two consecutive hyphens. Lasts until the end of the line.
+data Comment = Comment
+                 Whitespace -- ^ Before double hyphens
+                 Whitespace -- ^ Between double hyphens and text
+                 Text
+               deriving Show
+
+
+
+-- | Any Unicode characters, excluding '\x00'..'\x1F', '\DEL', '{', '}', ':'.
+newtype Heading = Heading Text
+                  deriving newtype Show
+
+
+
+-- | Field contents at the declaration line.
+data Inline = Inline
+                Whitespace -- ^ Between colon and start of text
+                Text
+
+            | EmptyI Whitespace
+
+              deriving Show
+
+-- | Field contents at the lines following the declaration.
+data Line = Line
+              Offset
+              Text
+
+          | CommentL Comment
+
+          | EmptyL Whitespace
+
+            deriving Show
+
+
+
+-- | Non-meaningful information.
+data Filler = CommentF Comment
+            | EmptyF Whitespace
+              deriving Show
+
+
+
+-- | Section contents with the curly bracket alternative.
+data Section = CurlS
+                 [Filler] -- ^ Between heading and left curly
+                 [Node]
+
+             | NormalS
+                 Filler   -- ^ Inline comment
+                 [Node]
+               deriving Show
+
+
+
+-- | Field contents.
+data Contents = Contents Inline [Line]
+                deriving Show
+
+-- | Field contents with the curly bracket alternative.
+data Field = CurlF
+               [Filler] -- ^ Between colon and left curly
+               Contents
+
+           | NormalF Contents
+             deriving Show
+
+
+
+data Node = Section
+              Offset
+              Heading
+              Section
+
+          | Field
+              Offset
+              Heading
+              Whitespace -- ^ Between field name and colon
+              Field
+
+          | CommentN Comment
+
+          | EmptyN Whitespace
+
+            deriving Show
+
+
+
+newtype Layout = Layout [Node]
+                 deriving newtype Show

--- a/Cabal-layout/src/Codec/Manifest/Cabal/Internal/Parse.hs
+++ b/Cabal-layout/src/Codec/Manifest/Cabal/Internal/Parse.hs
@@ -1,0 +1,752 @@
+{-# LANGUAGE BangPatterns
+           , OverloadedStrings
+           , RankNTypes #-}
+
+module Codec.Manifest.Cabal.Internal.Parse
+  ( layoutP
+  ) where
+
+import           Codec.Manifest.Cabal.Internal.Layout
+
+import           Control.Monad
+import qualified Data.ByteString.Lazy as BSL
+import           Data.ByteString.Builder
+import           Data.Char (isSpace)
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Data.Text.Encoding
+import qualified Data.Text.Internal.StrictBuilder as StrictBuilder
+import           Text.Parsec hiding (Line)
+import           Text.Parsec.Text.Lazy
+
+
+
+isControlC0 :: Char -> Bool
+isControlC0 c = (c <= '\x1F' && c /= '\t' && c /= '\r') || c == '\DEL'
+
+
+
+data Curliness = Normal | Curled
+
+commentP :: Parser (Whitespace -> Comment)
+commentP = do
+  space1_ <- many $ satisfy (\c -> c /= '\n' && isSpace c)
+  let !space1 = length space1_
+
+      sift = do
+        c <- anyChar
+        if isControlC0 c
+          then fail "C0 control codes and '\\DEL' are not allowed"
+          else pure c
+
+  txt_ <- manyTill sift $ eof <|> lookAhead (() <$ satisfy (== '\n'))
+  let !txt = Text.pack txt_
+
+  pure $ \space0 -> Comment space0 (Whitespace space1) txt
+
+uncomment :: Filler -> Inline
+uncomment filler =
+  case filler of
+    CommentF (Comment space0 (Whitespace space1) comment) ->
+      let !txt = StrictBuilder.toText . StrictBuilder.unsafeFromByteString
+                   . BSL.toStrict . toLazyByteString
+                       $ string8 "--"
+                      <> foldMap id (replicate space1 $ char8 ' ')
+                      <> byteString (encodeUtf8 comment)
+
+      in Inline space0 txt
+
+    EmptyF space_ -> EmptyI space_
+
+
+
+rightCurlyP :: SourcePos -> Parser ()
+rightCurlyP curlyPos = do
+  let sourcePosS pos = showString "line " . shows (sourceLine pos)
+                     . showString ", column " . shows (sourceColumn pos)
+
+  mayc <- optionMaybe $ lookAhead anyChar
+  case mayc of
+    Just c
+      | c == '}'  -> void anyChar
+
+      | otherwise ->
+          fail $
+            showString "Curly section started on " . sourcePosS curlyPos
+              $ showString
+                  " was not consumed correctly. This is not supposed to\
+                  \ happen, please report it as a Cabal bug." []
+
+    Nothing  ->
+      fail $
+        showString "Reached end of file without finding a closing bracket\
+                  \ for curly section started on " $ sourcePosS curlyPos []
+
+
+
+data Lined = Newline
+           | Trailing
+             deriving Show
+
+data Stop = LineEnd Lined
+          | MidLine Whitespace
+            deriving Show
+
+data Next = NextLine Whitespace
+          | NextComment Comment Lined
+          | NextEmpty Whitespace Lined
+          | NextFin
+            deriving Show
+
+nextP :: Curliness -> (Next -> Parser a) -> Parser a
+nextP curliness f = go 0
+  where
+    go !n = do
+      mayc <- optionMaybe $ lookAhead anyChar
+      case mayc of
+        Just c
+          | c == '\n' -> do
+              _ <- anyChar
+              f $ NextEmpty (Whitespace n) Newline
+
+          | isSpace c     -> do
+              _ <- anyChar
+              go (n + 1)
+
+          | c == '-'      -> do
+              mayd <- lookAhead $ do
+                        _ <- anyChar
+                        optionMaybe anyChar
+
+              case mayd of
+                Just '-' -> do
+                  _ <- anyChar
+                  _ <- anyChar
+                  comment_ <- commentP
+                  let !comment = comment_ (Whitespace n)
+
+                  maye <- optionMaybe $ lookAhead anyChar
+                  lined <- case maye of
+                             Just '\n' -> do _ <- anyChar
+                                             pure Newline
+
+                             _         -> pure Trailing
+
+                  f $ NextComment comment lined
+
+                _        -> f $ NextLine (Whitespace n)
+
+          | c == '}' ->
+              f $ case curliness of
+                    Curled
+                      | n <= 0    -> NextFin
+                      | otherwise -> NextEmpty (Whitespace n) Trailing
+
+                    _      -> NextLine (Whitespace n)
+
+          | otherwise -> f $ NextLine (Whitespace n)
+
+        Nothing ->
+          f $ if n > 0
+                then NextEmpty (Whitespace n) Trailing
+                else NextFin
+
+
+
+data Anchor = Bottom
+            | Anchor Int
+
+data Belonging = Belongs Offset
+               | Above
+
+relative :: Anchor -> Whitespace -> Belonging
+relative anchor (Whitespace space_) =
+  case anchor of
+    Bottom       -> Belongs (Offset space_)
+    Anchor pivot -> let off = space_ - pivot
+                    in if off > 0
+                         then Belongs (Offset off)
+                         else Above
+
+
+
+-- | Comments and newlines whose position within the layout has not yet been figured out.
+data Overflow = NoOverflow
+              | Overflow
+                  (forall a. (Whitespace -> a) -> (Comment -> a) -> [a] -> [a])
+
+instance Show Overflow where
+  showsPrec d flow =
+    case flow of
+      NoOverflow -> showString "NoOverflow"
+      Overflow _ -> showParen (d > 10) $ showString "Overflow _"
+
+flowComment :: Comment -> Overflow -> Overflow
+flowComment comment flow =
+  case flow of
+    NoOverflow -> Overflow $ \_   comm -> (:) (comm comment)
+    Overflow f -> Overflow $ \new comm -> f new comm . (:) (comm comment)
+
+flowEmpty :: Whitespace -> Overflow -> Overflow
+flowEmpty space_ flow =
+  case flow of
+    NoOverflow -> Overflow $ \new _    -> (:) (new space_)
+    Overflow f -> Overflow $ \new comm -> f new comm . (:) (new space_)
+
+runOverflow :: (Whitespace -> a) -> (Comment -> a) -> Overflow -> [a] -> [a]
+runOverflow new comm flow =
+  case flow of
+    NoOverflow -> id
+    Overflow f -> f new comm
+
+nodeOverflow :: Overflow -> [Node] -> [Node]
+nodeOverflow = runOverflow EmptyN CommentN
+
+lineOverflow :: Overflow -> [Line] -> [Line]
+lineOverflow = runOverflow EmptyL CommentL
+
+fillerOverflow :: Overflow -> [Filler] -> [Filler]
+fillerOverflow = runOverflow EmptyF CommentF
+
+
+
+data Result = Proper Node Overflow Stop
+            | Fin (Maybe Whitespace)
+              deriving Show
+
+data NodeLine = JustSection
+                  Int -- ^ Length of the section name
+                  Int -- ^ Whitespace between the name and line end
+
+              | CurlySection
+                  Int -- ^ Length of the section name
+                  Int -- ^ Whitespace between the name and left curly brace
+
+              | CommentSection
+                  Int -- ^ Length of the section name
+                  Int -- ^ Whitespace between the name and the comment start
+
+              | JustField
+                  Int -- ^ Length of the field name
+                  Int -- ^ Whitespace between the name and the colon
+
+                deriving Show
+
+layoutP :: Parser Layout
+layoutP = do
+  (acc, flow, stop) <- nodesP Normal Bottom (LineEnd Trailing)
+
+  atEnd <- option False $ True <$ eof
+  unless atEnd $
+    fail "Input was not consumed in its entirety. This is not supposed to\
+         \ happen, please report it as a Cabal bug."
+
+  let base = case stop of
+               LineEnd Newline  -> [EmptyN (Whitespace 0)]
+               LineEnd Trailing -> []
+               MidLine _        -> []
+
+  pure . Layout . acc $ nodeOverflow flow base
+
+
+nodesP :: Curliness -> Anchor -> Stop -> Parser ([Node] -> [Node], Overflow, Stop)
+nodesP curliness anchor = go id NoOverflow
+  where
+    go acc flow stop = do
+      result <- case stop of
+                  LineEnd _      -> nodeP curliness anchor
+                  MidLine lines_ -> spaceNodeP curliness anchor lines_
+
+      case result of
+        Proper node flow' stop' ->
+          let acc' xs = acc $ nodeOverflow flow (node : xs)
+          in case node of
+               Section _ _ _    -> go acc' flow' stop'
+               Field _ _ _ _    -> go acc' flow' stop'
+
+               CommentN comment -> go acc (flowComment comment flow) stop'
+               EmptyN space_    -> go acc (flowEmpty space_ flow) stop'
+
+        Fin mayOff ->
+          pure
+            ( acc
+            , flow
+            , case mayOff of
+                Just space' -> MidLine space'
+                Nothing     -> stop
+            )
+
+
+
+nodeP :: Curliness -> Anchor -> Parser Result
+nodeP curliness anchor =
+  nextP curliness $ \next -> do
+    case next of
+      NextLine space_            ->
+        spaceNodeP curliness anchor space_
+
+      NextComment comment lines_ ->
+        pure $ Proper (CommentN comment) NoOverflow (LineEnd lines_)
+
+      NextEmpty space_ lines_    ->
+        pure $ Proper (EmptyN space_) NoOverflow (LineEnd lines_)
+
+      NextFin                    -> pure $ Fin Nothing
+
+
+
+spaceNodeP :: Curliness -> Anchor -> Whitespace -> Parser Result
+spaceNodeP curliness anchor (Whitespace space_) = do
+  case relative anchor (Whitespace space_) of
+    Above       -> pure $ Fin (Just (Whitespace space_))
+    Belongs off -> do
+      mayc <- optionMaybe $ lookAhead anyChar
+      case mayc of
+        Just ':' -> fail "Colon"
+        Just '{' -> fail "Curly bracket"
+        _        -> pure ()
+
+      future <- lookAhead $ firstWordP 0
+      case future of
+        JustSection len space' -> do
+          heading_ <- count len anyChar
+          let !heading = Text.pack heading_
+
+          _ <- count space' anyChar
+          mc <- optionMaybe $ lookAhead anyChar
+          lined <- case mc of
+                     Just '\n' -> do void anyChar
+                                     pure Newline
+                     _         -> pure Trailing
+
+          (section, flow', stop) <-
+            ambiguousSectionP curliness (Anchor space_) (EmptyF (Whitespace space')) lined
+
+          pure $
+            Proper
+              (Section off (Heading heading) section)
+              flow'
+              stop
+
+        CurlySection len space' -> do
+          heading_ <- count len anyChar
+          let !heading = Text.pack heading_
+
+          _ <- count space' anyChar
+
+          curlyPos <- getPosition
+          _ <- anyChar -- '{'
+
+          (acc, flow', stop) <- nodesP Curled Bottom (LineEnd Trailing)
+
+          rightCurlyP curlyPos
+
+          let base = case stop of
+                       LineEnd Newline  -> [EmptyN (Whitespace 0)]
+                       LineEnd Trailing -> []
+                       MidLine _        -> []
+
+          pure $
+            Proper
+              (Section off (Heading heading) $ CurlS [EmptyF (Whitespace space')] (acc $ nodeOverflow flow' base))
+              NoOverflow
+              (LineEnd Trailing)
+
+        CommentSection len space' -> do
+          heading_ <- count len anyChar
+          let !heading = Text.pack heading_
+
+          _ <- count space' anyChar
+          _ <- anyChar -- '-'
+          _ <- anyChar -- '-'
+          comment <- commentP
+
+          mc <- optionMaybe $ lookAhead anyChar
+          lined <- case mc of
+                     Just '\n' -> do void anyChar
+                                     pure Newline
+                     _         -> pure Trailing
+
+          (section, flow', stop) <-
+            ambiguousSectionP curliness (Anchor space_) (CommentF $ comment (Whitespace space')) lined
+
+          pure $
+            Proper
+              (Section off (Heading heading) section)
+              flow'
+              stop
+
+        JustField len space' -> do
+          let !_ = off
+
+          heading_ <- count len anyChar
+          let !heading = Text.pack heading_
+
+          _ <- count space' anyChar
+          _ <- anyChar -- ':'
+
+          (field, flow', stop) <- fieldP curliness (Anchor space_)
+
+          pure $
+            Proper
+              (Field off (Heading heading) (Whitespace space') field)
+              flow'
+              stop
+
+  where
+    firstWordP :: Int -> Parser NodeLine
+    firstWordP !n = do
+      mayc <- optionMaybe $ lookAhead anyChar
+      case mayc of
+        Just c
+          | c == '\n'     -> pure $ JustSection n 0
+
+          | isSpace c     -> do
+              _ <- anyChar
+              firstSpaceP n 1
+
+          | c == '-'      -> do
+              mayd <- lookAhead $ do
+                        _ <- anyChar
+                        optionMaybe anyChar
+
+              case mayd of
+                Just '-' -> pure $ CommentSection n 0
+                Just _   -> do
+                  _ <- anyChar
+                  firstWordP (n + 1)
+
+                Nothing  -> pure $ JustSection n 0
+
+          | c == ':'      -> pure $ JustField n 0
+          | c == '{'      -> pure $ CurlySection n 0
+          | c == '}'      ->
+              case curliness of
+                Curled -> pure $ JustSection n 0
+                Normal -> fail "Closing curly bracket found, but no opening one"
+
+          | isControlC0 c ->
+              fail "C0 control codes and '\\DEL' are not allowed"
+
+          | otherwise     -> do
+              _ <- anyChar
+              firstWordP (n + 1)
+
+        Nothing -> pure $ JustSection n 0
+
+    firstSpaceP :: Int -> Int -> Parser NodeLine
+    firstSpaceP n !m = do
+      mayc <- optionMaybe $ lookAhead anyChar
+      case mayc of
+        Just c
+          | c == '\n'     -> pure $ JustSection n m
+
+          | isSpace c     -> do
+              _ <- anyChar
+              firstSpaceP n (m + 1)
+
+          | c == '-'      -> do
+              mayd <- lookAhead $ do
+                        _ <- anyChar
+                        optionMaybe anyChar
+
+              case mayd of
+                Just '-' -> pure $ CommentSection n m
+                Just _   -> do
+                  _ <- anyChar
+                  moreWordsP (n + m + 1) 0
+
+                Nothing  -> pure $ JustSection n m
+
+          | c == ':'      -> pure $ JustField n m
+          | c == '{'      -> pure $ CurlySection n m
+          | c == '}'      ->
+              case curliness of
+                Curled -> pure $ JustSection n m
+                Normal -> fail "Closing curly bracket found, but no opening one"
+
+          | isControlC0 c ->
+              fail "C0 control codes and '\\DEL' are not allowed"
+
+          | otherwise     -> do
+              _ <- anyChar
+              moreWordsP (n + m + 1) 0
+
+        Nothing -> pure $ JustSection n m
+
+    moreWordsP :: Int -> Int -> Parser NodeLine
+    moreWordsP !n !m = do
+      mayc <- optionMaybe $ lookAhead anyChar
+      case mayc of
+        Just c
+          | c == '\n'     -> pure $ JustSection n m
+
+          | isSpace c     -> do
+              _ <- anyChar
+              moreWordsP n (m + 1)
+
+          | c == '-'      -> do
+              mayd <- lookAhead $ do
+                        _ <- anyChar
+                        optionMaybe anyChar
+
+              case mayd of
+                Just '-' -> pure $ CommentSection n m
+                Just _   -> do
+                  _ <- anyChar
+                  moreWordsP (n + m + 1) 0
+
+                Nothing  -> pure $ JustSection n m
+
+          | c == '{'      -> pure $ CurlySection n m
+          | c == '}'      ->
+              case curliness of
+                Curled -> pure $ JustSection n m
+                Normal -> fail "Closing curly bracket found, but no opening one"
+
+          | c == ':'      -> pure $ JustField n m
+
+          | isControlC0 c ->
+              fail "C0 control codes and '\\DEL' are not allowed"
+
+          | otherwise     -> do
+              _ <- anyChar
+              moreWordsP (n + m + 1) 0
+
+        Nothing -> pure $ JustSection n 0
+
+
+
+ambiguousSectionP
+  :: Curliness
+  -> Anchor
+  -> Filler
+  -> Lined
+  -> Parser (Section, Overflow, Stop)
+ambiguousSectionP curliness anchor inline = go NoOverflow
+  where
+    go flow lined =
+      nextP curliness $ \next ->
+        case next of
+          NextLine space_ -> do
+            c <- lookAhead anyChar
+            case c of
+              '{' -> do
+                curlyPos <- getPosition
+                _ <- anyChar
+
+                (acc, flow', stop) <- nodesP Curled Bottom (LineEnd Trailing)
+                rightCurlyP curlyPos
+
+                let lines_ = inline : fillerOverflow flow [EmptyF space_]
+
+                    base = case stop of
+                             LineEnd Newline  -> [EmptyN (Whitespace 0)]
+                             LineEnd Trailing -> []
+                             MidLine _        -> []
+
+                pure
+                  ( CurlS lines_ (acc $ nodeOverflow flow' base)
+                  , NoOverflow
+                  , LineEnd Trailing
+                  )
+
+              _   ->
+                case relative anchor space_ of
+                  Belongs _ -> do
+                    (acc, flow', stop) <- nodesP curliness anchor (MidLine space_)
+
+                    let nodes = nodeOverflow flow $ acc []
+
+                    pure (NormalS inline nodes, flow', stop)
+
+                  Above -> pure (NormalS inline [], flow, MidLine space_)
+
+          NextComment comment lined' -> go (flowComment comment flow) lined'
+
+          NextEmpty space1 lined'    -> go (flowEmpty space1 flow) lined'
+
+          NextFin               ->
+            pure
+              ( NormalS inline []
+              , flow
+              , LineEnd lined
+              )
+
+
+
+lineP :: Curliness -> Parser (Text, Lined)
+lineP curliness = do
+  let predicate = case curliness of
+                    Normal -> (== '\n')
+                    Curled -> \c -> c == '\n' || c == '}'
+
+  txt_ <- manyTill anyChar $ eof <|> lookAhead (() <$ satisfy predicate)
+  let !txt = Text.pack txt_
+
+  maye <- optionMaybe $ lookAhead anyChar
+  lined <- case maye of
+             Just '\n' -> do void anyChar
+                             pure Newline
+
+             _         -> pure Trailing
+
+  pure (txt, lined)
+
+
+
+fieldP :: Curliness -> Anchor -> Parser (Field, Overflow, Stop)
+fieldP curliness0 anchor0 =
+  nextP curliness0 $ \next ->
+    case next of
+      NextLine space_           -> do
+        c <- lookAhead anyChar
+        case c of
+          '{' -> do
+            curlyPos <- getPosition
+            _ <- anyChar
+            contents <- curledInlineP
+            rightCurlyP curlyPos
+            pure
+              ( CurlF [EmptyF space_] contents
+              , NoOverflow
+              , LineEnd Trailing
+              )
+
+          _   -> do
+            (txt, lined) <- lineP curliness0
+            normalP curliness0 anchor0 (Inline space_ txt) id NoOverflow lined
+
+      NextComment comment lined ->
+        ambiguousP curliness0 anchor0 (CommentF comment) NoOverflow lined
+
+      NextEmpty space1 lined  ->
+        ambiguousP curliness0 anchor0 (EmptyF space1) NoOverflow lined
+
+      NextFin                   ->
+        pure
+          ( NormalF (Contents (EmptyI (Whitespace 0)) [])
+          , NoOverflow
+          , LineEnd Trailing
+          )
+
+  where
+    ambiguousP curliness anchor inline flow lined0 =
+      nextP curliness $ \next ->
+        case next of
+          NextLine space_ -> do
+            c <- lookAhead anyChar
+            case c of
+              '{' -> do
+                curlyPos <- getPosition
+                _ <- anyChar
+                contents <- curledInlineP
+                let lines_ = inline : fillerOverflow flow [EmptyF space_]
+
+                rightCurlyP curlyPos
+                pure
+                  ( CurlF lines_ contents
+                  , NoOverflow
+                  , LineEnd Trailing
+                  )
+
+              _   ->
+                let !inline' = uncomment inline
+                in case relative anchor space_ of
+                     Belongs off -> do
+                       (txt, lined1) <- lineP curliness
+
+                       normalP curliness anchor inline'
+                               (lineOverflow flow . (:) (Line off txt))
+                               NoOverflow
+                               lined1
+
+                     Above ->
+                       pure
+                         ( NormalF (Contents inline' [])
+                         , flow
+                         , MidLine space_
+                         )
+
+          NextComment comment lined1 ->
+            ambiguousP curliness anchor inline (flowComment comment flow) lined1
+
+          NextEmpty space1 lined1  ->
+            ambiguousP curliness anchor inline (flowEmpty space1 flow) lined1
+
+          NextFin               ->
+            let !inline' = uncomment inline
+            in pure
+                 ( NormalF (Contents inline' [])
+                 , flow
+                 , LineEnd lined0
+                 )
+
+
+    curledInlineP =
+      nextP Curled $ \next ->
+        case next of
+          NextLine (Whitespace space_) -> do
+            (txt, lined) <- lineP Curled
+            let !inline = Inline (Whitespace space_) txt
+            curledP inline id lined
+
+          NextComment comment lined ->
+            let !inline = uncomment (CommentF comment)
+            in curledP inline id lined
+
+          NextEmpty space_ lined ->
+            curledP (EmptyI space_) id lined
+
+          NextFin -> pure $ Contents (EmptyI (Whitespace 0)) []
+
+    curledP inline acc lined =
+      nextP Curled $ \next ->
+        case next of
+          NextLine (Whitespace space_) -> do
+            (txt, lined') <- lineP Curled
+            curledP inline (acc . (:) (Line (Offset space_) txt)) lined'
+
+          NextComment comment lined'   ->
+            curledP inline (acc . (:) (CommentL comment)) lined'
+
+          NextEmpty space_ lined'      ->
+            curledP inline (acc . (:) (EmptyL space_)) lined'
+
+          NextFin                      ->
+            let base = case lined of
+                         Newline  -> [EmptyL (Whitespace 0)]
+                         Trailing -> []
+
+            in pure $ Contents inline (acc base)
+
+
+    normalP curliness anchor inline acc flow lined =
+      nextP curliness $ \next ->
+        case next of
+          NextLine space_            ->
+            case relative anchor space_ of
+              Belongs off -> do
+                (txt, lined') <- lineP curliness
+
+                normalP curliness anchor inline
+                        (acc . lineOverflow flow . (:) (Line off txt))
+                        NoOverflow
+                        lined'
+
+              Above -> do
+                let !nodes = acc []
+                pure
+                  ( NormalF (Contents inline nodes)
+                  , flow
+                  , MidLine space_
+                  )
+
+          NextComment comment lined' ->
+            normalP curliness anchor inline acc (flowComment comment flow) lined'
+
+          NextEmpty space_ lined'    ->
+            normalP curliness anchor inline acc (flowEmpty space_ flow) lined'
+
+          NextFin                    ->
+            pure (NormalF (Contents inline (acc [])), flow, LineEnd lined)

--- a/Cabal-layout/src/Codec/Manifest/Cabal/Internal/Render.hs
+++ b/Cabal-layout/src/Codec/Manifest/Cabal/Internal/Render.hs
@@ -1,0 +1,175 @@
+module Codec.Manifest.Cabal.Internal.Render
+  ( layoutB
+  ) where
+
+import           Codec.Manifest.Cabal.Internal.Layout
+
+import           Data.ByteString.Builder
+import qualified Data.ByteString.Builder.Prim as Prim
+import           Data.Text.Encoding
+
+
+
+data Anchor = Bottom
+            | Anchor Int
+              deriving Show
+
+mintercalate :: Monoid m => m -> [m] -> m
+mintercalate x ys =
+  let go a bs =
+        case bs of
+          b:cs -> a <> x <> go b cs
+          []   -> a
+
+  in case ys of
+       a:bs   -> go a bs
+       []     -> mempty
+
+
+
+offset :: Offset -> Anchor -> Anchor
+offset (Offset n) anchor =
+  case anchor of
+    Bottom   | n > 0     -> Anchor n
+             | otherwise -> Bottom
+    Anchor m -> Anchor (m + n)
+
+anchorB :: Anchor -> Builder
+anchorB anchor =
+  case anchor of
+    Bottom   -> mempty
+    Anchor n -> spaceB (Whitespace $ max n 1)
+
+
+
+spaceB :: Whitespace -> Builder
+spaceB (Whitespace n) =
+  Prim.primMapListBounded (Prim.liftFixedToBounded Prim.char8) (replicate n ' ')
+
+commentB :: Comment -> Builder
+commentB (Comment space0 space1 comment) =
+  spaceB space0 <> string8 "--" <> spaceB space1 <> byteString (encodeUtf8 comment)
+
+
+
+
+fillerB :: Filler -> Builder
+fillerB filler =
+  case filler of
+    CommentF comment -> commentB comment
+    EmptyF space     -> spaceB space
+
+lineB :: Anchor -> Line -> Builder
+lineB anchor l =
+  case l of
+    Line off txt     -> anchorB (offset off anchor) <> byteString (encodeUtf8 txt)
+    CommentL comment -> commentB comment
+    EmptyL space     -> spaceB space
+
+
+
+contentsB :: Anchor -> Contents -> Builder
+contentsB anchor (Contents inline lines_) =
+  let fit inl =
+        case inl of
+          Inline (Whitespace space) txt -> Line (Offset space) txt
+          EmptyI space                  -> EmptyL space
+
+  in mintercalate (char8 '\n') $
+       lineB Bottom (fit inline) : (fmap (lineB anchor) lines_)
+
+
+
+data Trail = Contextual
+           | Trailing
+
+sectionB :: Anchor -> Trail -> Section -> (Builder, Trail)
+sectionB anchor trail section =
+  case section of
+    CurlS fillers nodes ->
+      (    mintercalate (char8 '\n') (fmap fillerB fillers)
+        <> char8 '{'
+        <> fst (nodesB Bottom Contextual nodes)
+        <> char8 '}'
+      , Trailing
+      )
+
+    NormalS filler nodes ->
+      case nodes of
+        [] -> (fillerB filler, trail)
+        _  -> let ~(rendered, trail') = nodesB anchor trail nodes
+              in (    fillerB filler
+                   <> char8 '\n'
+                   <> rendered
+                 , trail'
+                 )
+
+
+
+fieldB :: Anchor -> Field -> (Builder, Trail)
+fieldB anchor field =
+  case field of
+    CurlF fillers contents ->
+      (    mintercalate (char8 '\n') (fmap fillerB fillers)
+        <> char8 '{'
+        <> contentsB Bottom contents
+        <> char8 '}'
+      , Trailing
+      )
+
+    NormalF contents ->
+      (contentsB anchor contents, Contextual)
+
+
+
+layoutB :: Layout -> Builder
+layoutB (Layout nodes) = fst $ nodesB Bottom Contextual nodes
+
+nodesB :: Anchor -> Trail -> [Node] -> (Builder, Trail)
+nodesB anchor trail xs =
+  case xs of
+    y:zs -> go y zs
+    []   -> (mempty, Contextual)
+  where
+    go a bs =
+      let ~(rendered, trail') = nodeB anchor trail a
+      in case bs of
+           b:cs -> let (more, trail'') = go b cs
+                   in ( rendered <> case trail' of
+                                      Contextual -> char8 '\n' <> more
+                                      Trailing   -> more
+                      , trail''
+                      )
+
+           []   -> (rendered, trail')
+
+nodeB :: Anchor -> Trail -> Node -> (Builder, Trail)
+nodeB anchor trail node =
+  case node of
+    Section off (Heading heading) section ->
+      let anchor' = offset off anchor
+
+          ~(rendered, trail') = sectionB anchor' trail section
+
+      in (    anchorB anchor'
+           <> byteString (encodeUtf8 heading)
+           <> rendered
+         , trail'
+         )
+
+    Field off (Heading heading) space field ->
+      let anchor' = offset off anchor
+
+          ~(rendered, trail') = fieldB anchor' field
+
+      in (    anchorB anchor'
+           <> byteString (encodeUtf8 heading)
+           <> spaceB space
+           <> char8 ':'
+           <> rendered
+         , trail'
+         )
+
+    CommentN comment -> (commentB comment, Contextual)
+
+    EmptyN space     -> (spaceB space, Contextual)

--- a/Cabal-layout/src/Codec/Manifest/Cabal/Layout.hs
+++ b/Cabal-layout/src/Codec/Manifest/Cabal/Layout.hs
@@ -1,0 +1,38 @@
+module Codec.Manifest.Cabal.Layout
+  ( Codec.Manifest.Cabal.Layout.parse
+
+  , render
+
+  , -- * Types
+    Offset (..)
+  , Whitespace (..)
+  , Comment (..)
+  , Heading (..)
+  , Inline (..)
+  , Line (..)
+  , Filler (..)
+  , Section (..)
+  , Contents (..)
+  , Field (..)
+  , Node (..)
+  , Layout (..)
+  ) where
+
+import           Codec.Manifest.Cabal.Internal.Layout
+import           Codec.Manifest.Cabal.Internal.Parse
+import           Codec.Manifest.Cabal.Internal.Render
+
+import qualified Data.ByteString.Lazy.Char8 as BSLC
+import           Data.ByteString.Builder
+import qualified Data.Text.Lazy as Lazy (Text)
+import           Text.Parsec hiding (Line)
+
+
+
+parse :: Lazy.Text -> Either ParseError Layout
+parse = Text.Parsec.parse layoutP ""
+
+
+
+render :: Layout -> BSLC.ByteString
+render = toLazyByteString . layoutB

--- a/Cabal-layout/test/hackage/Main.hs
+++ b/Cabal-layout/test/hackage/Main.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main where
+
+import           Codec.Manifest.Cabal.Internal.Parse
+import           Codec.Manifest.Cabal.Internal.Render
+
+import           Test.Strictness.Layout ()
+
+import           Data.ByteString.Builder
+import           Data.Foldable
+import qualified Data.Text.Lazy as Lazy
+import           Data.Text.Lazy.Encoding
+import qualified Data.Text.Lazy.IO as Lazy
+import           System.Directory
+import           System.Environment
+import           System.FilePath
+import           System.IO
+import           Text.Parsec
+import           NoThunks.Class
+
+
+
+main :: IO ()
+main = do
+  as <- getArgs
+  case as of
+    []     -> fail "Expecting path to the Hackage index as an argument"
+    [path] -> hackage path
+    _:_:_  -> fail "Too many arguments provided"
+
+
+
+withCabalFile :: FilePath -> (Lazy.Text -> IO a) -> IO a
+withCabalFile path f =
+  withFile path ReadMode $ \h -> do
+    hSetEncoding h utf8
+    hSetNewlineMode h universalNewlineMode
+    file <- Lazy.hGetContents h
+
+    let detab c = case c of
+                    '\t'   -> ' '
+                    '\160' -> ' ' -- non-breaking space
+                    _      -> c
+
+    f $ Lazy.map detab file
+
+
+
+hackage :: FilePath -> IO ()
+hackage path = do
+  manifests <- listDirectory path
+  for_ manifests $ \manifest -> do
+    versions <- listDirectory $ path </> manifest
+    for_ versions $ \version ->
+      if version == "preferred-versions"
+        then pure ()
+        else do
+          let filepath = (path </> manifest) </> version </> manifest <.> "cabal"
+
+          putStr filepath
+          hFlush stdout
+
+          withCabalFile filepath $ \file -> do
+            case parse layoutP "" file of
+              Left err -> do
+                putStrLn " ✗"
+                fail $ show err
+
+              Right layout -> do
+                mayThunks <- wNoThunks [] layout
+                case mayThunks of
+                  Just (ThunkInfo ctx) -> do
+                    putStrLn " ✗"
+                    fail $ "Not fully evaluated: " <> show (reverse ctx)
+
+                  Nothing  ->
+                    if file == decodeUtf8 (toLazyByteString $ layoutB layout)
+                      then putStrLn " ✓"
+                      else do
+                        putStrLn " ✗"
+                        fail "Layout mismatch"

--- a/Cabal-layout/test/sanity/Main.hs
+++ b/Cabal-layout/test/sanity/Main.hs
@@ -1,0 +1,14 @@
+module Main where
+
+import           Test.Sanity.Layout.Parse
+
+import           Test.Tasty
+
+
+
+main :: IO ()
+main =
+  defaultMain $
+    testGroup "Tests"
+      [ parseT
+      ]

--- a/Cabal-layout/test/sanity/Test/Sanity/Layout/Parse.hs
+++ b/Cabal-layout/test/sanity/Test/Sanity/Layout/Parse.hs
@@ -1,0 +1,364 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving
+           , OverloadedStrings
+           , StandaloneDeriving #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Sanity.Layout.Parse
+  ( parseT
+  ) where
+
+import           Codec.Manifest.Cabal.Internal.Layout
+import           Codec.Manifest.Cabal.Internal.Parse
+
+import           Data.String
+import qualified Data.Text.Lazy as Lazy (Text)
+import           Text.Parsec hiding (Line)
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+
+
+deriving instance Eq Offset
+deriving instance Eq Whitespace
+deriving instance Eq Comment
+deriving instance Eq Heading
+deriving instance Eq Inline
+deriving instance Eq Line
+deriving instance Eq Filler
+deriving instance Eq Section
+deriving instance Eq Contents
+deriving instance Eq Field
+deriving instance Eq Node
+deriving instance Eq Layout
+
+deriving instance Num Offset
+deriving instance Num Whitespace
+
+deriving instance IsString Heading
+
+
+
+(==>) :: Lazy.Text -> [Node] -> Assertion
+input ==> output = parse layoutP "" input @?= Right (Layout output)
+
+fails :: Lazy.Text -> Assertion
+fails input =
+  case parse layoutP "" input of
+    Left _    -> pure ()
+    Right res -> assertFailure . showString "Succeeded: " $ show res
+
+parseT :: TestTree
+parseT = do
+  testGroup "Parse"
+    [ testCase "Empty" $
+        "" ==> []
+
+    , testCase "Lone C0" $
+        fails "\0"
+
+    , testCase "Lone colon" $
+        fails ":"
+
+    , testCase "Lone left curly" $
+        fails "{"
+
+    , testCase "Lone right curly" $
+        fails "{"
+
+    , testCase "Lone bracket section" $
+        fails "{}"
+
+    , testGroup "Newlines"
+        [ testCase "n"
+            newline1
+
+        , testCase "1n2"
+            newline2
+
+        , testCase "4n2n3n1n"
+            newline3
+        ]
+
+    , testGroup "Comments"
+        [ testCase "C0" $
+            fails "--c\0mment"
+
+        , testCase "Curlies and colons"
+            comment1
+
+        , testCase "c"
+            comment2
+
+        , testCase "c1+2"
+            comment3
+
+        , testCase "c4+2 c3+1 n"
+            comment4
+        ]
+
+    , testGroup "Fields"
+        [ testGroup "Normal"
+            [ testCase "f"
+                fieldN1
+
+            , testCase "f1+2 n"
+                fieldN2
+
+            , testCase "f c1+2"
+                fieldN3
+
+            , testCase "f c4+3 n c2+1 n"
+                fieldN4
+
+            , testCase "f c n n l"
+                fieldN5
+
+            , testCase "f n n c n f"
+                fieldN6
+            ]
+
+        , testGroup "Curled"
+            [ testCase "f"
+                fieldC1
+
+            , testCase "f1+2+3{4}"
+                fieldC2
+
+            , testCase "f c n { l n c }"
+                fieldC3
+            ]
+        ]
+
+    , testGroup "Section"
+        [ testGroup "Normal"
+            [ testCase "s"
+                sectionN1
+
+            , testCase "s1+2 n"
+                sectionN2
+
+            , testCase "s c1+2"
+                sectionN3
+
+            , testCase "s c4+3 n c2+1 n"
+                sectionN4
+
+            , testCase "s c n n s'"
+                sectionN5
+
+            , testCase "s n n c n s"
+                sectionN6
+            ]
+
+        , testGroup "Curled"
+            [ testCase "f"
+                sectionC1
+
+            , testCase "f1+2+3{4}"
+                sectionC2
+
+            , testCase "f c n { l n c }"
+                sectionC3
+            ]
+
+        ]
+    ]
+
+
+
+newline1 :: Assertion
+newline1 = "\n" ==> [EmptyN 0, EmptyN 0]
+
+newline2 :: Assertion
+newline2 = " \n  " ==> [EmptyN 1, EmptyN 2]
+
+newline3 :: Assertion
+newline3 = "    \n  \n   \n \n" ==> [EmptyN 4, EmptyN 2, EmptyN 3, EmptyN 1, EmptyN 0]
+
+
+
+comment1 :: Assertion
+comment1 = "--c{m:e}t" ==> [CommentN $ Comment 0 0 "c{m:e}t"]
+
+comment2 :: Assertion
+comment2 = "--comment" ==> [CommentN $ Comment 0 0 "comment"]
+
+comment3 :: Assertion
+comment3 = " --  com   ment" ==> [CommentN $ Comment 1 2 "com   ment"]
+
+comment4 :: Assertion
+comment4 =
+  "    --  this   \n   -- that\n"
+    ==> [ CommentN (Comment 4 2 "this   ")
+        , CommentN (Comment 3 1 "that")
+        , EmptyN 0
+        ]
+
+
+
+fieldN1 :: Assertion
+fieldN1 =
+  "field:" ==> [ Field 0 "field" 0 $
+                   NormalF (Contents (EmptyI 0) [])
+               ]
+
+fieldN2 :: Assertion
+fieldN2 =
+  " field  :\n"
+    ==> [ Field 1 "field" 2 $
+            NormalF (Contents (EmptyI 0) [])
+        , EmptyN 0
+        ]
+
+fieldN3 :: Assertion
+fieldN3 =
+  "field: --  comment\n"
+    ==> [ Field 0 "field" 0 $
+            NormalF (Contents (Inline 1 "--  comment") [])
+        , EmptyN 0
+        ]
+
+fieldN4 :: Assertion
+fieldN4 =
+  "field:    --   comment\n  -- comment \n"
+    ==> [ Field 0 "field" 0 $
+            NormalF (Contents (Inline 4 "--   comment") [])
+        , CommentN $ Comment 2 1 "comment "
+        , EmptyN 0
+        ]
+
+fieldN5 :: Assertion
+fieldN5 =
+  "field:    --   comment\n  \n \n foo"
+    ==> [ Field 0 "field" 0 $
+            NormalF $ Contents (Inline 4 "--   comment")
+                        [ EmptyL 2
+                        , EmptyL 1
+                        , Line 1 "foo"
+                        ]
+        ]
+
+fieldN6 :: Assertion
+fieldN6 =
+  "field:  \n   \n  -- comment \nfoo:"
+    ==> [ Field 0 "field" 0 $
+            NormalF (Contents (EmptyI 2) [])
+        , EmptyN 3
+        , CommentN $ Comment 2 1 "comment "
+        , Field 0 "foo" 0 $
+            NormalF (Contents (EmptyI 0) [])
+        ]
+
+
+fieldC1 :: Assertion
+fieldC1 =
+  "field:{}"
+    ==> [ Field 0 "field" 0 $
+            CurlF [EmptyF 0] (Contents (EmptyI 0) [])
+        ]
+
+fieldC2 :: Assertion
+fieldC2 =
+  " field  :   {    }"
+    ==> [ Field 1 "field" 2 $
+            CurlF [EmptyF 3] (Contents (EmptyI 4) [])
+        ]
+
+fieldC3 :: Assertion
+fieldC3 =
+  "foo: --  bar   \n {  ba{z: \n  --   th    is \n}"
+     ==> [ Field 0 "foo" 0 $
+             CurlF
+               [ CommentF (Comment 1 2 "bar   ")
+               , EmptyF 1
+               ]
+               $ Contents (Inline 2 "ba{z: ")
+                   [ CommentL (Comment 2 3 "th    is ")
+                   , EmptyL 0
+                   ]
+         ]
+
+
+
+sectionN1 :: Assertion
+sectionN1 =
+  "section" ==> [ Section 0 "section" $
+                    NormalS (EmptyF 0) []
+                ]
+
+sectionN2 :: Assertion
+sectionN2 =
+  " section  \n"
+    ==> [ Section 1 "section" $
+            NormalS (EmptyF 2) []
+        , EmptyN 0
+        ]
+
+sectionN3 :: Assertion
+sectionN3 =
+  "section --  comment\n"
+    ==> [ Section 0 "section" $
+            NormalS (CommentF $ Comment 1 2 "comment") []
+        , EmptyN 0
+        ]
+
+sectionN4 :: Assertion
+sectionN4 =
+  "section    --   comment\n  -- comment \n"
+    ==> [ Section 0 "section" $
+            NormalS (CommentF $ Comment 4 3 "comment") []
+        , CommentN $ Comment 2 1 "comment "
+        , EmptyN 0
+        ]
+
+sectionN5 :: Assertion
+sectionN5 =
+  "section    --   comment\n  \n \n foo"
+    ==> [ Section 0 "section" $
+            NormalS (CommentF $ Comment 4 3 "comment")
+              [ EmptyN 2
+              , EmptyN 1
+              , Section 1 "foo" $
+                  NormalS (EmptyF 0) []
+              ]
+        ]
+
+sectionN6 :: Assertion
+sectionN6 =
+  "section  \n   \n  -- comment \nfoo:"
+    ==> [ Section 0 "section" $
+            NormalS (EmptyF 2) []
+        , EmptyN 3
+        , CommentN $ Comment 2 1 "comment "
+        , Field 0 "foo" 0 $
+            NormalF (Contents (EmptyI 0) [])
+        ]
+
+
+sectionC1 :: Assertion
+sectionC1 =
+  "field:{}" ==> [ Field 0 "field" 0 $
+                     CurlF [EmptyF 0] (Contents (EmptyI 0) [])
+                 ]
+
+sectionC2 :: Assertion
+sectionC2 =
+  " field  :   {    }"
+    ==> [ Field 1 "field" 2 $
+            CurlF [EmptyF 3] (Contents (EmptyI 4) [])
+        ]
+
+sectionC3 :: Assertion
+sectionC3 =
+  "foo: --  bar   \n {  ba{z: \n  --   th    is \n}"
+    ==> [ Field 0 "foo" 0 $
+            CurlF
+              [ CommentF (Comment 1 2 "bar   ")
+              , EmptyF 1
+              ]
+              $ Contents (Inline 2 "ba{z: ")
+                  [ CommentL (Comment 2 3 "th    is ")
+                  , EmptyL 0
+                  ]
+        ]

--- a/Cabal-layout/test/strictness/Test/Strictness/Layout.hs
+++ b/Cabal-layout/test/strictness/Test/Strictness/Layout.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE DerivingStrategies
+           , GeneralizedNewtypeDeriving
+           , StandaloneDeriving #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Strictness.Layout () where
+
+import           Codec.Manifest.Cabal.Internal.Layout
+
+import           NoThunks.Class
+
+
+
+instance NoThunks Offset where
+  wNoThunks ctx (Offset off) = wNoThunks ctx off
+  showTypeOf _ = "Offset"
+
+instance NoThunks Whitespace where
+  wNoThunks ctx (Whitespace space) = wNoThunks ctx space
+  showTypeOf _ = "Whitespace"
+
+
+instance NoThunks Comment where
+  wNoThunks ctx (Comment space0 space1 comment) =
+    allNoThunks
+      [ noThunks ("(0)":ctx) space0
+      , noThunks ("(1)":ctx) space1
+      , noThunks ctx comment
+      ]
+
+  showTypeOf _ = "Comment"
+
+
+instance NoThunks Heading where
+  wNoThunks ctx (Heading heading) = wNoThunks ctx heading
+  showTypeOf _ = "Heading"
+
+
+instance NoThunks Inline where
+  wNoThunks ctx inline =
+    case inline of
+      Inline space text ->
+        allNoThunks
+          [ noThunks ("{I}":ctx) space
+          , noThunks ("{I}":ctx) text
+          ]
+
+      EmptyI space      -> noThunks ("{E}":ctx) space
+
+  showTypeOf _ = "Inline"
+
+
+instance NoThunks Line where
+  wNoThunks ctx line =
+    case line of
+      Line off text    ->
+        allNoThunks
+          [ noThunks ("{L}":ctx) off
+          , noThunks ("{L}":ctx) text
+          ]
+
+      CommentL comment -> wNoThunks ("{C}":ctx) comment
+
+      EmptyL space     -> noThunks ("{E}":ctx) space
+
+  showTypeOf _ = "Line"
+
+
+instance NoThunks Filler where
+  wNoThunks ctx filler =
+    case filler of
+      CommentF comment -> wNoThunks ("{C}":ctx) comment
+
+      EmptyF space     -> noThunks ("{E}":ctx) space
+
+  showTypeOf _ = "Filler"
+
+
+newtype List a = List [a]
+
+instance NoThunks a => NoThunks (List a) where
+  wNoThunks ctx (List xs) =
+    let brackets :: Int -> String
+        brackets n = showChar '[' . shows n $ showChar ']' []
+
+    in allNoThunks . fmap (\(n, x) -> wNoThunks (brackets n : ctx) x) $ zip [0 :: Int ..] xs
+
+  showTypeOf _ = "List"
+
+
+instance NoThunks Section where
+  wNoThunks ctx section =
+    case section of
+      CurlS fillers nodes  ->
+        allNoThunks
+          [ wNoThunks ("{C}":ctx) (List fillers)
+          , wNoThunks ("{C}":ctx) (List nodes)
+          ]
+
+      NormalS inline nodes ->
+        allNoThunks
+          [ wNoThunks ("{N}":ctx) inline
+          , wNoThunks ("{N}":ctx) (List nodes)
+          ]
+
+  showTypeOf _ = "Section"
+
+
+instance NoThunks Contents where
+  wNoThunks ctx (Contents inline lines_) =
+    allNoThunks
+     [ wNoThunks ("<0>":ctx) inline
+     , wNoThunks ("<1>":ctx) (List lines_)
+     ]
+
+  showTypeOf _ = "Contents"
+
+instance NoThunks Field where
+  wNoThunks ctx field =
+    case field of
+      CurlF fillers contents ->
+        allNoThunks
+          [ wNoThunks ("{C}":ctx) (List fillers)
+          , wNoThunks ("{C}":ctx) contents
+          ]
+
+      NormalF contents       -> wNoThunks ("{N}":ctx) contents
+
+  showTypeOf _ = "Field"
+
+
+instance NoThunks Node where
+  wNoThunks ctx node =
+    case node of
+      Section off heading section   ->
+        allNoThunks
+          [ noThunks ("{S}":ctx) off
+          , noThunks ("{S}":ctx) heading
+          , wNoThunks ("{S}":ctx) section
+          ]
+
+      Field off heading space field ->
+        allNoThunks
+          [ noThunks ("{F}":ctx) off
+          , noThunks ("{F}":ctx) heading
+          , noThunks ("{F}":ctx) space
+          , wNoThunks ("{F}":ctx) field
+          ]
+
+      CommentN comment              -> wNoThunks ("{C}":ctx) comment
+      EmptyN space                  -> noThunks ("{E}":ctx) space
+
+  showTypeOf _ = "Node"
+
+
+instance NoThunks Layout where
+  wNoThunks ctx (Layout nodes) = wNoThunks ctx (List nodes)
+  showTypeOf _ = "Layout"

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,7 @@
 packages: Cabal/
 packages: cabal-testsuite/
 packages: Cabal-syntax/
+packages: Cabal-layout/
 packages: cabal-install/
 packages: cabal-install-solver/
 packages: solver-benchmarks/


### PR DESCRIPTION
Potentially closes #7544.

### Skeleton parser

Currently able to parse every single manifest stored on Hackage and to render it back into the exact same representation.

Implementation choices:
- All whitespace is treated as spaces;

- Data representation cannot be delayed in either dimension:
  - Not depthwise due to curly bracket syntax;
  - Not breadthwise due to `parsec` not supporting returning the remainder of the input (`parsec` is the only available parser, per https://github.com/haskell/cabal/issues/7544#issuecomment-1778569911).

- Curly bracket syntax is treated more leniently than in the lexer (see https://github.com/haskell/cabal/issues/7544#issuecomment-1721351054 for examples, all of these are accepted here);

- Trailing whitespace and newlines are preserved everywhere in the format due to curly bracket positions depending on them.

- Fields are allowed to have names with spaces in them, due to the fact that certain extremely old packages allowed that (see e.g. `build depends` at the very end of [smartworld-0.0.0.5](https://hackage.haskell.org/package/smartword-0.0.0.5/smartword.cabal)).

### Further extensions

* [ ] Every single currently used field format
* [ ] Simple `Layout` encoding with automatic consistent offset increments
* [ ] Streamlined `Layout` manipulation (e.g. https://github.com/haskell/cabal/issues/7544#issuecomment-1719013941)
* [ ] \(?) Lexer compatibility: `Layout -> [Field Position]`

---

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.