### PR TITLE
cabal-install-solver: fix pkgconf 1.9 --modversion regression

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
@@ -67,11 +67,12 @@ readPkgConfigDb verbosity progdb = handle ioErrorHandler $ do
         -- The output of @pkg-config --list-all@ also includes a description
         -- for each package, which we do not need.
         let pkgNames = map (takeWhile (not . isSpace)) pkgList
-        (pkgVersions, _errs, exitCode) <-
+        (outs, _errs, exitCode) <-
                      getProgramInvocationOutputAndErrors verbosity
                        (programInvocation pkgConfig ("--modversion" : pkgNames))
-        if exitCode == ExitSuccess && length pkgNames == length pkgList
-          then (return . pkgConfigDbFromList . zip pkgNames) (lines pkgVersions)
+        let pkgVersions = lines outs
+        if exitCode == ExitSuccess && length pkgVersions == length pkgNames
+          then (return . pkgConfigDbFromList . zip pkgNames) pkgVersions
           else
           -- if there's a single broken pc file the above fails, so we fall back
           -- into calling it individually

--- a/changelog.d/pr-9391
+++ b/changelog.d/pr-9391
@@ -1,0 +1,4 @@
+synopsis: fix pkgconfig-depends for pkgconf-1.9
+packages: cabal-install-solver
+prs: #9391
+issues: #8923


### PR DESCRIPTION
Check that the numbers of *versions* output is equal to the number of pkgconf's

fixes #8923

Noting that the pkgconf behavior was since reverted upstream in 2.0.

(checking that equal pkgnames are output also doesn't hurt per se, but that should be trivially true and this should cover that case too anyway)

---

**This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

---

## QA Notes

A simple testcase is building [libarchive](https://hackage.haskell.org/package/libarchive) with `cabal build -f system-libarchive` and pkgconf-1.9 on Linux (eg with Fedora Linux 39)* -  though *any* package using `pkgconfig-depends` will do.

See also the original issue for more details.

(* which is how I ran into this again while trying to update ghcup version from source)