### PR TITLE
[cabal-7825] Add `$CABAL` env variable for external commands

### DIFF
--- a/Cabal/src/Distribution/Simple/Command.hs
+++ b/Cabal/src/Distribution/Simple/Command.hs
@@ -93,7 +93,8 @@ import qualified Distribution.GetOpt as GetOpt
 import Distribution.ReadE
 import Distribution.Simple.Utils
 import System.Directory (findExecutable)
-import System.Process (callProcess)
+import System.Environment (getExecutablePath)
+import System.Process (CreateProcess (env), createProcess, proc)
 
 data CommandUI flags = CommandUI
   { commandName :: String
@@ -663,7 +664,8 @@ commandsRun globalCommand commands args =
 
     callExternal :: a -> String -> [String] -> IO (CommandParse (a, CommandParse action))
     callExternal flags exec cmdArgs = do
-      result <- try $ callProcess exec cmdArgs
+      execPath <- getExecutablePath
+      result <- try $ createProcess (proc exec cmdArgs){env = Just [("CABAL", execPath)]}
       case result of
         Left ex -> pure $ CommandErrors ["Error executing external command: " ++ show (ex :: SomeException)]
         Right _ -> pure $ CommandReadyToGo (flags, CommandDelegate)


### PR DESCRIPTION
This is a follow-up of #9063

**Checklist:**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

**QA notes:**

I tested it as followed, on my machine I have 2 scripts:
- `cabal-foobar`:
  
    ```bash
    #! /usr/bin/env bash
    env | grep CABAL
    ```
- `test-ext-cmd.sh`
  
    ```bash
    #! /usr/bin/env bash
    PATH="$PATH:." cabal run cabal-install foobar
    ```
Then, e.g., as expected:
```
% ./test-ext-cmd.sh
CABAL=/Users/yvan/IOHK/cabal/dist-newstyle/build/aarch64-osx/ghc-9.2.8/cabal-install-3.11.0.0/x/cabal/build/cabal/cabal
```