### PR TITLE
GHC 9.8 is not sufficient to run AutogenModulesToggling

### DIFF
--- a/cabal-testsuite/PackageTests/AutogenModulesToggling/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/AutogenModulesToggling/cabal.test.hs
@@ -2,6 +2,6 @@ import Test.Cabal.Prelude
 
 main :: IO ()
 main = cabalTest . recordMode RecordMarked $ do
-  skipUnlessGhcVersion ">= 9.7"
+  skipUnlessGhcVersion ">= 9.9"
   cabal "v2-run" ["-fgenerate", "autogen-toggle-test"]
   cabal "v2-run" ["-f-generate", "autogen-toggle-test"]


### PR DESCRIPTION
A followup to https://github.com/haskell/cabal/pull/9330.

The 9.8.1 comes with Cabal-3.10.2.0 which dosen’t have the fixes needed to make this test work. The test relies on Custom setup and thus depends on Cabal-the-library version.

**This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

