### PR TITLE
[Rel-Eng]: Adds script to automatically generate GHCup metadata for Cabal releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,8 @@ bench.html
 
 # I'm unsure how to ignore these generated golden files
 cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.out
+
+## Release Scripts
+
+# ignore the downloaded binary files
+scripts/release/binary-downloads/

--- a/scripts/release/create-release-metadata-for-ghcup.sh
+++ b/scripts/release/create-release-metadata-for-ghcup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script, when passed the cabal release number as the first and only argument
 # generates the metadata in the correct format to be useable as is by GHCup

--- a/scripts/release/create-release-metadata-for-ghcup.sh
+++ b/scripts/release/create-release-metadata-for-ghcup.sh
@@ -5,12 +5,21 @@
 # for eg:-
 # $ create-release-metadata-for-ghcup.sh 3.10.2.0 or "3.10.2.0"
 
+# Note:- Please run ./download-cabal-install-release-binaries.sh before running this script.
 set -eu
 set -o pipefail
 
 RELEASE=$1
 ## FixMe:// What dir to use here?
-## cd "gh-release-artifacts/Cabal-${RELEASE}"
+
+if [ -d "binary-downloads/cabal-install-${RELEASE}-binaries" ]; then
+    echo "binary downloads folder for release ${RELEASE} found, starting generating GHCup metadata..."
+else
+    echo "The binary downloads for release ${RELEASE} not found."
+    echo "Please run the script to download them first."
+fi
+
+cd "binary-downloads/cabal-install-${RELEASE}-binaries"
 
 cat <<EOF > /dev/stdout
     $RELEASE:

--- a/scripts/release/create-release-metadata-for-ghcup.sh
+++ b/scripts/release/create-release-metadata-for-ghcup.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# This script, when passed the cabal release number as the first and only argument
+# generates the metadata in the correct format to be useable as is by GHCup
+# for eg:-
+# $ create-release-metadata-for-ghcup.sh 3.10.2.0 or "3.10.2.0"
+
+set -eu
+set -o pipefail
+
+RELEASE=$1
+## FixMe:// What dir to use here?
+## cd "gh-release-artifacts/Cabal-${RELEASE}"
+
+cat <<EOF > /dev/stdout
+    $RELEASE:
+      viTags:
+        - Latest
+      viChangeLog: https://github.com/haskell/cabal/blob/master/release-notes/cabal-install-$RELEASE.md
+      viPostInstall: *cabal-${RELEASE//./}-post-install
+      viArch:
+        A_64:
+          Linux_UnknownLinux:
+            unknown_versioning: &cabal-${RELEASE//./}-64
+            dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-linux-alpine3_12.tar.xz
+            dlSubdir: cabal-install-$RELEASE
+            dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-linux-alpine3_12.tar.xz" | awk '{ print $1 }')
+          Linux_Alpine:
+            unknown_versioning: &cabal-${RELEASE//./}-64
+          Linux_CentOS:
+            unknown_versioning: &cabal-${RELEASE//./}-64-centos7
+            dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-linux-centos7.tar.xz
+            dlSubdir: cabal-install-$RELEASE
+            dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-linux-centos7.tar.xz" | awk '{ print $1 }')
+          Linux_Debian:
+            ' ( >= 9 && < 10)': &cabal-${RELEASE//./}-64-debian
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-linux-deb9.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-linux-deb9.tar.xz" | awk '{ print $1 }')
+            ' ( == 10 && < 11)':
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-linux-deb10.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-linux-deb10.tar.xz" | awk '{ print $1 }')
+            ' ( >= 11)':
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-linux-deb11.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-linux-deb11.tar.xz" | awk '{ print $1 }')
+            unknown_versioning: &cabal-${RELEASE//./}-64-debian
+          Linux_Fedora:
+            '>= 33':
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-linux-fedora33.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-linux-fedora33.tar.xz" | awk '{ print $1 }')
+            unknown_versioning: &cabal-${RELEASE//./}-64-centos7
+          Linux_Ubuntu:
+            '< 20': &cabal-${RELEASE//./}-64-ubuntu18
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-linux-ubuntu18_04.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-linux-ubuntu18_04.tar.xz" | awk '{ print $1 }')
+            '>= 20': &cabal-${RELEASE//./}-64-ubuntu20
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-linux-ubuntu20_04.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-linux-ubuntu20_04.tar.xz" | awk '{ print $1 }')
+            unknown_versioning: *cabal-${RELEASE//./}-64-ubuntu18
+          Linux_Mint:
+            '< 20': *cabal-${RELEASE//./}-64-ubuntu18
+            '>= 20': *cabal-${RELEASE//./}-64-ubuntu20
+            unknown_versioning: *cabal-${RELEASE//./}-64-ubuntu18
+          Darwin:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-darwin.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-darwin.tar.xz" | awk '{ print $1 }')
+          Windows:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-windows.zip
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-windows.zip" | awk '{ print $1 }')
+          FreeBSD:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-x86_64-freebsd.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-x86_64-freebsd.tar.xz" | awk '{ print $1 }')
+        A_32:
+          Linux_UnknownLinux:
+            unknown_versioning: &cabal-${RELEASE//./}-32
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-i386-linux-alpine3_12.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-i386-linux-alpine3_12.tar.xz" | awk '{ print $1 }')
+          Linux_Alpine:
+            unknown_versioning: *cabal-${RELEASE//./}-32
+          Linux_Debian:
+            '( >= 9 )':
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-i386-linux-deb9.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-i386-linux-deb9.tar.xz" | awk '{ print $1 }')
+            unknown_versioning: *cabal-${RELEASE//./}-32
+        A_ARM64:
+          Darwin:
+            unknown_versioning:
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-aarch64-darwin.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-aarch64-darwin.tar.xz" | awk '{ print $1 }')
+          Linux_Debian:
+            '( >= 10 && < 11)': &cabal-31020-arm64
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-aarch64-linux-deb10.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-aarch64-linux-deb10.tar.xz" | awk '{ print $1 }')
+            '( >= 11)':
+              dlUri: https://downloads.haskell.org/~cabal/cabal-install-$RELEASE/cabal-install-$RELEASE-aarch64-linux-deb11.tar.xz
+              dlSubdir: cabal-install-$RELEASE
+              dlHash: $(sha256sum "cabal-install-$RELEASE-aarch64-linux-deb11.tar.xz" | awk '{ print $1 }')
+            unknown_versioning: *cabal-${RELEASE//./}-arm64
+          Linux_UnknownLinux:
+            unknown_versioning: *cabal-${RELEASE//./}-arm64
+EOF

--- a/scripts/release/download-cabal-install-release-binaries.sh
+++ b/scripts/release/download-cabal-install-release-binaries.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# A script to download the release binary files for a given cabal release
+# from upstream "downlods.haskell.org".
+# It accepts the first and only argument as the release number.
+#
+# useage:-
+#   $ download-cabal-install-release-binaries.sh "3.10.1.0"
+#
+# This was initally made to be used with ./create-release-metadata-for-ghcup.sh
+
+set -eu
+set -o pipefail
+
+RELEASE=$1
+
+echo "RELEASE: $RELEASE"
+
+for com in wget sha256sum ; do
+        command -V ${com} >/dev/null 2>&1
+done
+
+[ ! -d "binary-downloads/cabal-install-${RELEASE}-binaries" ]
+
+mkdir -p "binary-downloads/cabal-install-${RELEASE}-binaries"
+
+cd "binary-downloads/cabal-install-${RELEASE}-binaries"
+
+## Download release files
+echo "Downloading form: \"https://downloads.haskell.org/~cabal/cabal-install-${RELEASE}/\""
+wget --no-parent -r --reject "index.html*" --no-directories "https://downloads.haskell.org/~cabal/cabal-install-${RELEASE}/"
+
+## Verify that sha256 sums of downloaded files match the ones mentioned in the upstream SHA256SUMS file
+echo "verifying checksums for downloaded files..."
+
+if sha256sum --check ./SHA256SUMS; then
+    echo "All checksums match!"
+    echo "Successfully downloaded binaries for release: ${RELEASE}"
+else
+    echo "checksums of downloaded files do no match the ones listed in upstream SHA256SUMS file."
+    echo "please try deleting \"binary-downloads/cabal-install-${RELEASE}-binaries\" folder and downloading again."
+fi

--- a/scripts/release/download-cabal-install-release-binaries.sh
+++ b/scripts/release/download-cabal-install-release-binaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A script to download the release binary files for a given cabal release
 # from upstream "downlods.haskell.org".


### PR DESCRIPTION
Draft PR for feedback and suggestion for issue #9298 

### The problem
Currently, on a cabal release, for it to be released by GHCup, the metadata of the release required by GHCup is manually generated. The process seems quite arduous and is an overhead for a release manager.

### The solution
This PR intends to introduce a script that would help make cabal releases easier and more streamlined by automatically generating the required cabal release metadata in the correct format that is usable by GHCup as-is. It then essentially becomes a simpler affair for the release manager to introduce the new release in GHCup.

The [link](url) in the issue 9298 thread was used as a reference for this script.

### Current Progress
The basic core functionality of the script works, as in, if you give it a release number as it's first and only argument, it generates the metadata for that release which can be used drop-in by GHCup. An example of the output to follow in the first comment of the PR.

More sections and info TBD

### Todos
- [ ] figure out the correct directory to CD into for artifacts/downloads [(the line here)](https://github.com/arjunkathuria/cabal/blob/release-metadata-script/scripts/release/create-release-metadata-for-ghcup.sh#L13)
- [ ] verify which directory the script should reside in. It currently resides in the top level `scripts/release` directory.
- [ ] TBD based on reviews and feedbacks.