### PR TITLE
Add separate cache for getPkgConfigDb

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/PkgConfigDb.hs
@@ -51,7 +51,7 @@ import Distribution.Verbosity                   (Verbosity)
 -- but we don't know the exact version (because parsing of the version number
 -- failed).
 newtype PkgConfigDb = PkgConfigDb (M.Map PkgconfigName (Maybe PkgconfigVersion))
-     deriving (Show, Generic)
+     deriving (Eq, Show, Generic)
 
 instance Binary PkgConfigDb
 instance Structured PkgConfigDb

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -67,6 +67,7 @@ module Distribution.Client.ProjectConfig
   , BuildTimeSettings (..)
   , resolveBuildTimeSettings
   , resolveNumJobsSetting
+  , resolveProgramDb
 
     -- * Checking configuration
   , checkBadPerPackageCompilerPaths
@@ -186,6 +187,12 @@ import Distribution.Simple.InstallDirs
 import Distribution.Simple.Program
   ( ConfiguredProgram (..)
   )
+import Distribution.Simple.Program.Db
+  ( ProgramDb
+  , defaultProgramDb
+  , prependProgramSearchPath
+  , userSpecifyPaths
+  )
 import Distribution.Simple.Setup
   ( Flag
   , flagToList
@@ -212,7 +219,8 @@ import Distribution.Utils.Generic
   , toUTF8LBS
   )
 import Distribution.Utils.NubList
-  ( fromNubList
+  ( NubList
+  , fromNubList
   )
 import Distribution.Verbosity
   ( makeVerbose
@@ -565,6 +573,17 @@ resolveNumJobsSetting projectConfigUseSemaphore projectConfigNumJobs =
     else case (determineNumJobs projectConfigNumJobs) of
       1 -> Serial
       n -> NumJobs (Just n)
+
+-- | ProgramDb with user specified paths from both global and local config.
+-- Mirrors the path-resolution order used by 'configureCompiler'.
+resolveProgramDb :: Verbosity -> NubList FilePath -> PackageConfig -> IO ProgramDb
+resolveProgramDb verbosity globalExtraPath packageConfig = do
+  let localExtraPath = fromNubList (packageConfigProgramPathExtra packageConfig)
+  programDb <-
+    prependProgramSearchPath verbosity (fromNubList globalExtraPath) [] defaultProgramDb
+      >>= prependProgramSearchPath verbosity localExtraPath []
+  let paths = Map.toList $ getMapLast (packageConfigProgramPaths packageConfig)
+  return $ userSpecifyPaths paths programDb
 
 ---------------------------------------------
 -- Reading and writing project config files

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -678,6 +678,19 @@ rebuildInstallPlan
       progsearchpath <- liftIO getSystemSearchPath
       let projectConfigMonitored = projectConfig{projectConfigBuildOnly = mempty}
 
+      progdb <-
+        liftIO $
+          resolveProgramDb
+            verbosity
+            (projectConfigProgPathExtra (projectConfigShared projectConfig))
+            (projectConfigAllPackages projectConfig)
+
+      -- Query the pkg-config DB before the plan caches so that it always runs
+      -- and reports when it re-queries. The inner fileMonitorPkgConfigDb handles
+      -- caching; its body also monitors the pkg-config binary so that binary
+      -- changes invalidate the cache.
+      pkgConfigDB <- getPkgConfigDb verbosity distDirLayout progdb
+
       -- The overall improved plan is cached
       rerunIfChanged
         verbosity
@@ -698,15 +711,15 @@ rebuildInstallPlan
               $ do
                 compilerEtc <- phaseConfigureCompiler projectConfig
                 _ <- phaseConfigurePrograms projectConfig compilerEtc
-                (solverPlan, pkgConfigDB, totalIndexState, activeRepos) <-
+                (solverPlan, totalIndexState, activeRepos) <-
                   phaseRunSolver
                     projectConfig
                     compilerEtc
+                    pkgConfigDB
                     localPackages
                     (fromMaybe mempty mbInstalledPackages)
-                ( elaboratedPlan
-                  , elaboratedShared
-                  ) <-
+
+                (elaboratedPlan, elaboratedShared) <-
                   phaseElaboratePlan
                     projectConfig
                     compilerEtc
@@ -740,7 +753,8 @@ rebuildInstallPlan
       phaseConfigureCompiler
         :: ProjectConfig
         -> Rebuild (Compiler, Platform, ProgramDb)
-      phaseConfigureCompiler = configureCompiler verbosity distDirLayout
+      phaseConfigureCompiler projectConfig =
+        configureCompiler verbosity distDirLayout projectConfig
 
       -- Configuring other programs.
       --
@@ -780,15 +794,17 @@ rebuildInstallPlan
       phaseRunSolver
         :: ProjectConfig
         -> (Compiler, Platform, ProgramDb)
+        -> Maybe PkgConfigDb
         -> [PackageSpecifier UnresolvedSourcePackage]
         -> InstalledPackageIndex
-        -> Rebuild (SolverInstallPlan, Maybe PkgConfigDb, IndexUtils.TotalIndexState, IndexUtils.ActiveRepos)
+        -> Rebuild (SolverInstallPlan, IndexUtils.TotalIndexState, IndexUtils.ActiveRepos)
       phaseRunSolver
         projectConfig@ProjectConfig
           { projectConfigShared
           , projectConfigBuildOnly
           }
         (compiler, platform, progdb)
+        pkgConfigDB
         localPackages
         installedPackages =
           rerunIfChanged
@@ -800,6 +816,7 @@ rebuildInstallPlan
             , compiler
             , platform
             , programDbSignature progdb
+            , pkgConfigDB
             )
             $ do
               installedPkgIndex <-
@@ -815,7 +832,6 @@ rebuildInstallPlan
                   withRepoCtx
                   (solverSettingIndexState solverSettings)
                   (solverSettingActiveRepos solverSettings)
-              pkgConfigDB <- getPkgConfigDb verbosity progdb
 
               -- TODO: [code cleanup] it'd be better if the Compiler contained the
               -- ConfiguredPrograms that it needs, rather than relying on the progdb
@@ -840,7 +856,7 @@ rebuildInstallPlan
                   Left msg -> do
                     reportPlanningFailure projectConfig compiler platform localPackages
                     dieWithException verbosity $ PhaseRunSolverErr msg
-                  Right plan -> return (plan, pkgConfigDB, tis, ar)
+                  Right plan -> return (plan, tis, ar)
           where
             corePackageDbs :: PackageDBStackCWD
             corePackageDbs =
@@ -1128,13 +1144,25 @@ getSourcePackages verbosity withRepoCtx idxState activeRepos = do
     $ repos
   return sourcePkgDbWithTIS
 
-getPkgConfigDb :: Verbosity -> ProgramDb -> Rebuild (Maybe PkgConfigDb)
-getPkgConfigDb verbosity progdb = do
-  dirs <- liftIO $ getPkgConfigDbDirs verbosity progdb
-  -- Just monitor the dirs so we'll notice new .pc files.
-  -- Alternatively we could monitor all the .pc files too.
-  traverse_ monitorDirectoryStatus dirs
-  liftIO $ readPkgConfigDb verbosity progdb
+getPkgConfigDb :: Verbosity -> DistDirLayout -> ProgramDb -> Rebuild (Maybe PkgConfigDb)
+getPkgConfigDb verbosity distDirLayout progdb = do
+  mpkgConfig <- liftIO $ needProgram verbosity pkgConfigProgram progdb
+  case mpkgConfig of
+    Nothing -> do
+      liftIO $ info verbosity "Cannot find pkg-config program. Cabal will continue without solving for pkg-config constraints."
+      return Nothing
+    Just (pkgConfig, progdb') -> do
+      dirs <- liftIO $ getPkgConfigDbDirs verbosity progdb'
+      rerunIfChanged verbosity fileMonitorPkgConfigDb (pkgConfig, dirs) $ do
+        -- Monitor the pkg-config executable so binary changes invalidate the cache.
+        monitorFiles (programsMonitorFiles progdb)
+        -- By monitoring the dirs, we'll notice new .pc files. We do not monitor changes in the .pc files themselves.
+        traverse_ monitorDirectoryStatus dirs
+        liftIO $ do
+          info verbosity "Querying pkg-config database..."
+          readPkgConfigDb verbosity progdb'
+  where
+    fileMonitorPkgConfigDb = newFileMonitor $ distProjectCacheFile distDirLayout "pkg-config-db"
 
 -- | Select the config values to monitor for changes package source hashes.
 packageLocationsSignature

--- a/cabal-testsuite/PackageTests/ExtraProgPath/setup.out
+++ b/cabal-testsuite/PackageTests/ExtraProgPath/setup.out
@@ -1,8 +1,6 @@
 # cabal v2-build
 Warning: cannot determine version of <ROOT>/pkg-config :
 ""
-Warning: cannot determine version of <ROOT>/pkg-config :
-""
 Resolving dependencies...
 Error: [Cabal-7107]
 Could not resolve dependencies:

--- a/cabal-testsuite/PackageTests/ExtraProgPathGlobal/setup.out
+++ b/cabal-testsuite/PackageTests/ExtraProgPathGlobal/setup.out
@@ -1,8 +1,6 @@
 # cabal v2-build
 Warning: cannot determine version of <ROOT>/scripts/pkg-config :
 ""
-Warning: cannot determine version of <ROOT>/scripts/pkg-config :
-""
 Resolving dependencies...
 Error: [Cabal-7107]
 Could not resolve dependencies:

--- a/cabal-testsuite/PackageTests/MonitorPkgConfig/P.hs
+++ b/cabal-testsuite/PackageTests/MonitorPkgConfig/P.hs
@@ -1,0 +1,1 @@
+module P where

--- a/cabal-testsuite/PackageTests/MonitorPkgConfig/cabal.out
+++ b/cabal-testsuite/PackageTests/MonitorPkgConfig/cabal.out
@@ -1,0 +1,6 @@
+# cabal v2-build
+# cabal v2-build
+# cabal v2-build
+# cabal v2-build
+# cabal v2-build
+# cabal v2-build

--- a/cabal-testsuite/PackageTests/MonitorPkgConfig/cabal.project
+++ b/cabal-testsuite/PackageTests/MonitorPkgConfig/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/MonitorPkgConfig/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/MonitorPkgConfig/cabal.test.hs
@@ -1,0 +1,35 @@
+import System.Directory (copyFile, createDirectoryIfMissing)
+import Test.Cabal.Prelude
+
+main = do
+  skipIfWindows "no pkg-config on Windows CI"
+  cabalTest $ do
+    env <- getTestEnv
+
+    cabal' "v2-build" ["--dry-run", "p", "-v2"]
+      >>= assertOutputContains "Querying pkg-config database..."
+
+    cabal' "v2-build" ["--dry-run", "p", "-v2"]
+      >>= assertOutputDoesNotContain "Querying pkg-config database..."
+
+    -- Check that changing PKG_CONFIG_PATH invalidates the cache
+
+    let pkgConfigPath = testWorkDir env </> "pkgconfig"
+    liftIO $ createDirectoryIfMissing True pkgConfigPath
+
+    withEnv [("PKG_CONFIG_PATH", Just pkgConfigPath)] $ do
+      cabal' "v2-build" ["--dry-run", "p", "-v2"]
+        >>= assertOutputContains "Querying pkg-config database..."
+
+      cabal' "v2-build" ["--dry-run", "p", "-v2"]
+        >>= assertOutputDoesNotContain "Querying pkg-config database..."
+
+      -- Check that changing a file in PKG_CONFIG_PATH invalidates the cache
+
+      liftIO $ copyFile (testCurrentDir env </> "test.pc") (pkgConfigPath </> "test.pc")
+
+      cabal' "v2-build" ["--dry-run", "p", "-v2"]
+        >>= assertOutputContains "Querying pkg-config database..."
+
+      cabal' "v2-build" ["--dry-run", "p", "-v2"]
+        >>= assertOutputDoesNotContain "Querying pkg-config database..."

--- a/cabal-testsuite/PackageTests/MonitorPkgConfig/p.cabal
+++ b/cabal-testsuite/PackageTests/MonitorPkgConfig/p.cabal
@@ -1,0 +1,12 @@
+name:                p
+version:             1.0
+license:             BSD3
+author:              Somebody
+maintainer:          some@email.address
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  exposed-modules:     P
+  build-depends:       base
+  default-language:    Haskell2010

--- a/cabal-testsuite/PackageTests/MonitorPkgConfig/test.pc
+++ b/cabal-testsuite/PackageTests/MonitorPkgConfig/test.pc
@@ -1,0 +1,3 @@
+Name: test
+Version: 0
+Description: a test .pc file

--- a/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.test.hs
@@ -11,8 +11,8 @@ main = skipIfCIAndWindows 10230 >> cabalTest (flakyIfCI 9530 $ withProjectFile "
           . resultOutput
         <$> recordMode DoNotRecord (cabal' "update" [])
   -- update golden output with actual timestamp
-  shell "cp" ["cabal.out.in", "cabal.out"]
-  shell "sed" [ "-i" ++ if not isWindows then "''" else "", "-e", "s/REPLACEME/" <> output <> "/g", "cabal.out"]
+  shell "rm" ["-f", "cabal.out"]
+  shell "sed" ["-e", "s/REPLACEME/" <> output <> "/g; w cabal.out", "cabal.out.in"]
   -- This shall fail with an error message as specified in `cabal.out`
   fails $ cabal "build" ["--index-state=4000-01-01T00:00:00Z", "fake-pkg"]
   -- This shall fail by not finding the package, what indicates that it

--- a/changelog.d/pr-9422
+++ b/changelog.d/pr-9422
@@ -1,0 +1,12 @@
+synopsis: Add separate cache for getPkgConfigDb
+packages: cabal-install
+prs: #9422
+issues: #8930
+
+description: {
+  Querying pkg-config for the version of every module can be a very expensive
+  operation on some systems. This change adds a separate, per-project, cache for
+  pkgConfigDB; reducing the cost from "every plan change" to "every pkg-config-db
+  change per project". A notice is also presented to the user when refreshing the
+  packagedb.
+}


### PR DESCRIPTION
Querying pkg-config for the version of every module can be a very expensive operation on some systems. This change adds a separate, per-project, cache for pkgConfigDB; reducing the cost from "every plan change" to "every pkg-config-db change per project".

No input key is required since getPkgConfigDb already specifies the directories to monitor for changes. These are obtained from pkg-config itself as `pkg-config --variable pc_path pkg-config` as documented in pkg-config(1).

A notice is presented to the user when refreshing the packagedb.

Closes #8930 and subsumes #9360.

changelog entry to follow