### PR TITLE
[cabal-9417] Fix cabal haddock --open on Windows

### DIFF
--- a/cabal-install/src/Distribution/Client/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Utils.hs
@@ -408,7 +408,7 @@ findOpenProgramLocation (Platform _ os) =
     xdg = locate "xdg-open"
    in
     case os of
-      Windows -> pure (Right "explore")
+      Windows -> pure (Right "explorer")
       OSX -> locate "open"
       Linux -> xdg
       FreeBSD -> xdg

--- a/cabal-install/src/Distribution/Client/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Utils.hs
@@ -408,7 +408,7 @@ findOpenProgramLocation (Platform _ os) =
     xdg = locate "xdg-open"
    in
     case os of
-      Windows -> pure (Right "explorer")
+      Windows -> pure (Right "open")
       OSX -> locate "open"
       Linux -> xdg
       FreeBSD -> xdg

--- a/cabal-install/src/Distribution/Client/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Utils.hs
@@ -408,7 +408,7 @@ findOpenProgramLocation (Platform _ os) =
     xdg = locate "xdg-open"
    in
     case os of
-      Windows -> pure (Right "start")
+      Windows -> pure (Right "explore")
       OSX -> locate "open"
       Linux -> xdg
       FreeBSD -> xdg


### PR DESCRIPTION
closes #9417

I've tested it locally, but Windows users are encouraged to provide feedback as well.

## QA Notes

On a Windows machine, build a haskell project with haddock enabled, and run `cabal haddock --open`. The default browser should be started with the index.html page