### PR TITLE
formatting: Add style-commit makefile target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,8 +155,15 @@ Code Style
 ---------------
 
 We use automated formatting with Fourmolu to enforce a unified style across the code bases. It is checked in the CI process.
-After installing Fourmolu 0.12, you can automatically format the code bases with `make style` at the top level of the project.
-You can also use `make style-modified` to only format modified files.
+After installing Fourmolu 0.12, there are some makefile targets to help formatting
+the code base.
+
+
+* `make style` - Format the `Cabal`, `Cabal-syntax` and `cabal-install` directories.
+* `make style-modified` - Format files modified in the current tree.
+* `make style-commit COMMIT=<ref>` - Format files modified between HEAD and the given reference.
+
+
 
 Other Conventions
 -----------------

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ style-modified: ## Run the code styler on modified files
 	@git ls-files --modified Cabal Cabal-syntax cabal-install \
 		| grep '.hs$$' | xargs -P $(PROCS) -I {} fourmolu -q -i {}
 
+style-commit: ## Run the code styler on the previous commit
+	@git diff --name-only HEAD $(COMMIT) Cabal Cabal-syntax cabal-install \
+		| grep '.hs$$' | xargs -P $(PROCS) -I {} fourmolu -q -i {}
+
 # source generation: SPDX
 
 SPDX_LICENSE_HS:=Cabal-syntax/src/Distribution/SPDX/LicenseId.hs


### PR DESCRIPTION
This target allows you to format a range of commits, for example:

```
make style-commit COMMIT=HEAD~1
> Last commit is formatted
make style-commit COMMIT=abcde
> Commits between HEAD and abcde are formatted
```



