### PR TITLE
Fix the platform string for GNU/Hurd

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -785,6 +785,7 @@ ghcOsString :: OS -> String
 ghcOsString Windows = "mingw32"
 ghcOsString OSX = "darwin"
 ghcOsString Solaris = "solaris2"
+ghcOsString Hurd = "gnu"
 ghcOsString other = prettyShow other
 
 -- | GHC's rendering of its platform and compiler version string as used in

--- a/changelog.d/pr-9434
+++ b/changelog.d/pr-9434
@@ -1,0 +1,11 @@
+synopsis: Fix the platform string for GNU/Hurd
+packages: Cabal
+prs: #9434
+
+description: {
+
+Depending who you ask, GNU/Hurd will be labelled "gnu" or "hurd". The autotools
+use "gnu", so ghc follows this for installed files, even if the ghc source code
+uses OSHurd. We thus need to add the translation between the two.
+
+}


### PR DESCRIPTION
Since version 9.4.7-1, ghc fails to build on the GNU/Hurd port of Debian, see

https://buildd.debian.org/status/fetch.php?pkg=ghc&arch=hurd-i386&ver=9.4.7-1&stamp=1697717885&raw=0

```
Error, rule finished running but did not produce file:
  _build/stage0/lib/i386-gnu-ghc-9.4.6/ghc-boot-th-9.4.7/libHSghc-boot-th-9.4.7.a
```

and indeed, what did get produce was rather
`_build/stage0/lib/i386-hurd-ghc-9.4.6/ghc-boot-th-9.4.7/libHSghc-boot-th-9.4.7.a` (`i386-hurd` instead of `i386-gnu`).

This is due to confusion between hurd and gnu in various places.  Apparently previous versions of ghc were using gnu for the GNU/Hurd port, and thus putting libraries etc. in i386-gnu. So we have to follow the existing practice.