### PR TITLE
Account for .buildinfo in repl when build-type: Configure

### DIFF
--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -743,8 +743,7 @@ simpleUserHooks =
 --
 -- * 'postConf' runs @.\/configure@, if present.
 --
--- * the pre-hooks 'preBuild', 'preClean', 'preCopy', 'preInst',
---   'preReg' and 'preUnreg' read additional build information from
+-- * the pre-hooks, except for pre-conf, read additional build information from
 --   /package/@.buildinfo@, if present.
 --
 -- Thus @configure@ can use local system information to generate
@@ -753,7 +752,8 @@ autoconfUserHooks :: UserHooks
 autoconfUserHooks =
   simpleUserHooks
     { postConf = defaultPostConf
-    , preBuild = readHookWithArgs buildVerbosity buildDistPref -- buildCabalFilePath,
+    , preBuild = readHookWithArgs buildVerbosity buildDistPref
+    , preRepl = readHookWithArgs replVerbosity replDistPref
     , preCopy = readHookWithArgs copyVerbosity copyDistPref
     , preClean = readHook cleanVerbosity cleanDistPref
     , preInst = readHook installVerbosity installDistPref
@@ -761,6 +761,8 @@ autoconfUserHooks =
     , preHaddock = readHookWithArgs haddockVerbosity haddockDistPref
     , preReg = readHook regVerbosity regDistPref
     , preUnreg = readHook regVerbosity regDistPref
+    , preTest = readHookWithArgs testVerbosity testDistPref
+    , preBench = readHookWithArgs benchmarkVerbosity benchmarkDistPref
     }
   where
     defaultPostConf

--- a/changelog.d/issue-9401
+++ b/changelog.d/issue-9401
@@ -1,0 +1,11 @@
+synopsis: Account for .buildinfo in repl, test, and bench
+packages: Cabal
+prs: #9440
+issues: #9401
+
+description: {
+
+Generated <project>.buildinfo is now respected in cabal repl, cabal test and cabal bench.
+
+}
+


### PR DESCRIPTION
In `autoconfUserHooks` we were not updating the `preRepl` hook to read additional build information from /package/@.buildinfo@.

Fixes #9401 