### PR TITLE
hurd: Enable using $ORIGIN in RPATH

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -2022,7 +2022,7 @@ getRPaths lbi clbi | supportRPaths hostOS = do
     supportRPaths Android = False
     supportRPaths Ghcjs = False
     supportRPaths Wasi = False
-    supportRPaths Hurd = False
+    supportRPaths Hurd = True
     supportRPaths Haiku = False
     supportRPaths (OtherOS _) = False
 -- Do _not_ add a default case so that we get a warning here when a new OS

--- a/Cabal/src/Distribution/Simple/GHCJS.hs
+++ b/Cabal/src/Distribution/Simple/GHCJS.hs
@@ -1697,7 +1697,7 @@ getRPaths lbi clbi | supportRPaths hostOS = do
     supportRPaths Android = False
     supportRPaths Ghcjs = False
     supportRPaths Wasi = False
-    supportRPaths Hurd = False
+    supportRPaths Hurd = True
     supportRPaths Haiku = False
     supportRPaths (OtherOS _) = False
 -- Do _not_ add a default case so that we get a warning here when a new OS

--- a/changelog.d/pr-9441
+++ b/changelog.d/pr-9441
@@ -1,0 +1,3 @@
+synopsis: Enable using $ORIGIN in RPATH on GNU/Hurd
+packages: Cabal
+prs: #9441


### PR DESCRIPTION
GNU/Hurd fully supports RPATH and the $ORIGIN development, and we indeed want to use it for relocatable installations shipped in Debian GNU/Hurd.

**Template Α: This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [N/A] The documentation has been updated, if necessary.
* [N/A] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

