### PR TITLE
Add support for 64-bit SPARC as a separate architecture

### DIFF
--- a/Cabal-syntax/src/Distribution/System.hs
+++ b/Cabal-syntax/src/Distribution/System.hs
@@ -182,13 +182,12 @@ buildOS = classifyOS Permissive System.Info.os
 -- ------------------------------------------------------------
 
 -- | These are the known Arches: I386, X86_64, PPC, PPC64, Sparc,
--- Arm, AArch64, Mips, SH, IA64, S390, S390X, Alpha, Hppa, Rs6000,
--- M68k, Vax, RISCV64, LoongArch64, JavaScript and Wasm32.
+-- Sparc64, Arm, AArch64, Mips, SH, IA64, S390, S390X, Alpha, Hppa,
+-- Rs6000, M68k, Vax, RISCV64, LoongArch64, JavaScript and Wasm32.
 --
 -- The following aliases can also be used:
 --    * PPC alias: powerpc
 --    * PPC64 alias : powerpc64, powerpc64le
---    * Sparc aliases: sparc64, sun4
 --    * Mips aliases: mipsel, mipseb
 --    * Arm aliases: armeb, armel
 --    * AArch64 aliases: arm64
@@ -198,6 +197,7 @@ data Arch
   | PPC
   | PPC64
   | Sparc
+  | Sparc64
   | Arm
   | AArch64
   | Mips
@@ -228,6 +228,7 @@ knownArches =
   , PPC
   , PPC64
   , Sparc
+  , Sparc64
   , Arm
   , AArch64
   , Mips
@@ -251,7 +252,6 @@ archAliases Strict _ = []
 archAliases Compat _ = []
 archAliases _ PPC = ["powerpc"]
 archAliases _ PPC64 = ["powerpc64", "powerpc64le"]
-archAliases _ Sparc = ["sparc64", "sun4"]
 archAliases _ Mips = ["mipsel", "mipseb"]
 archAliases _ Arm = ["armeb", "armel"]
 archAliases _ AArch64 = ["arm64"]

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -27,9 +27,9 @@ tests = testGroup "Distribution.Utils.Structured"
     -- The difference is in encoding of newtypes
 #if MIN_VERSION_base(4,7,0)
     , testCase "GenericPackageDescription" $
-      md5Check (Proxy :: Proxy GenericPackageDescription) 0x6ad1e12c6f88291e9b8c131d239eda70
+      md5Check (Proxy :: Proxy GenericPackageDescription) 0xb287a6f04e34ef990cdd15bc6cb01c76
     , testCase "LocalBuildInfo" $
-      md5Check (Proxy :: Proxy LocalBuildInfo) 0xbc7ac84a9bc43345c812af222c3e5ba0
+      md5Check (Proxy :: Proxy LocalBuildInfo) 0x26e91a71ebd19d4d6ce37f798ede249a
 #endif
     ]
 

--- a/Cabal/src/Distribution/Simple/PreProcess.hs
+++ b/Cabal/src/Distribution/Simple/PreProcess.hs
@@ -850,6 +850,7 @@ platformDefines lbi =
       PPC -> ["powerpc"]
       PPC64 -> ["powerpc64"]
       Sparc -> ["sparc"]
+      Sparc64 -> ["sparc64"]
       Arm -> ["arm"]
       AArch64 -> ["aarch64"]
       Mips -> ["mips"]

--- a/changelog.d/pr-9445
+++ b/changelog.d/pr-9445
@@ -1,0 +1,3 @@
+synopsis: Add support for 64-bit SPARC as a separate architecture
+prs: #9445
+packages: Cabal Cabal-syntax


### PR DESCRIPTION
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.

Previously, sparc64 was defined as an alias for the 32-bit SPARC architecture which was true while SPARC mainland was mostly 32 bits. More recently, 64-bit SPARC has become a port of its own, so it needs to be treated as a separate architecture.