### PR TITLE
testsuite: Introduce Cabal-tests library for common testsuite functions

### DIFF
--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -18,6 +18,12 @@ source-repository head
   location: https://github.com/haskell/cabal/
   subdir:   Cabal-tests
 
+-- Common utilities which can be used by all tests.
+library
+  hs-source-dirs: lib
+  exposed-modules: Test.Utils.TempTestDir
+  build-depends: base, directory, Cabal
+
 -- Small, fast running tests.
 test-suite unit-tests
   type:             exitcode-stdio-1.0
@@ -58,6 +64,7 @@ test-suite unit-tests
     , Cabal-described
     , Cabal-syntax
     , Cabal-QuickCheck
+    , Cabal-tests
     , containers
     , deepseq
     , Diff                >=0.4   && <0.6

--- a/Cabal-tests/lib/Test/Utils/TempTestDir.hs
+++ b/Cabal-tests/lib/Test/Utils/TempTestDir.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 
-module Distribution.Utils.TempTestDir
+module Test.Utils.TempTestDir
   ( withTestDir
   , removeDirectoryRecursiveHack
   ) where

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -153,7 +153,6 @@ library
     Distribution.Utils.Json
     Distribution.Utils.NubList
     Distribution.Utils.Progress
-    Distribution.Utils.TempTestDir
     Distribution.Verbosity
     Distribution.Verbosity.Internal
 

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -324,6 +324,7 @@ test-suite unit-tests
           cabal-install,
           Cabal-tree-diff,
           Cabal-QuickCheck,
+          Cabal-tests,
           containers,
           directory,
           filepath,
@@ -409,6 +410,7 @@ test-suite long-tests
   build-depends:
         Cabal-QuickCheck,
         Cabal-described,
+        Cabal-tests,
         cabal-install,
         containers,
         directory,

--- a/cabal-install/tests/UnitTests/Distribution/Client/FetchUtils.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/FetchUtils.hs
@@ -16,12 +16,12 @@ import Distribution.Client.Types.Repo (Repo (..), emptyRemoteRepo)
 import Distribution.Client.Types.RepoName (RepoName (..))
 import Distribution.Types.PackageId (PackageIdentifier (..))
 import Distribution.Types.PackageName (mkPackageName)
-import Distribution.Utils.TempTestDir (withTestDir)
 import qualified Distribution.Verbosity as Verbosity
 import Distribution.Version (mkVersion)
 import Network.URI (URI, uriPath)
 import Test.Tasty
 import Test.Tasty.HUnit
+import Test.Utils.TempTestDir (withTestDir)
 
 tests :: [TestTree]
 tests =

--- a/cabal-install/tests/UnitTests/Distribution/Client/Get.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Get.hs
@@ -20,9 +20,9 @@ import System.Exit
 import System.FilePath
 import System.IO.Error
 
-import Distribution.Utils.TempTestDir (withTestDir)
 import Test.Tasty
 import Test.Tasty.HUnit
+import Test.Utils.TempTestDir (withTestDir)
 import UnitTests.Options (RunNetworkTests (..))
 
 tests :: [TestTree]

--- a/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
@@ -16,8 +16,8 @@ import Distribution.Client.Types.SourceRepo (SourceRepoProxy, SourceRepositoryPa
 import Distribution.Client.VCS
 import Distribution.Simple.Program
 import Distribution.System (OS (Windows), buildOS)
-import Distribution.Utils.TempTestDir (removeDirectoryRecursiveHack, withTestDir)
 import Distribution.Verbosity as Verbosity
+import Test.Utils.TempTestDir (removeDirectoryRecursiveHack, withTestDir)
 
 import Data.List (mapAccumL)
 import qualified Data.Map as Map

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -30,6 +30,7 @@ common shared
     -- this needs to match the in-tree lib:Cabal version
     , Cabal ^>= 3.11.0.0
     , Cabal-syntax ^>= 3.11.0.0
+    , Cabal-tests
 
   ghc-options: -Wall -fwarn-tabs -fwarn-incomplete-uni-patterns
 

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -72,7 +72,7 @@ import Distribution.Simple.Configure
 import qualified Distribution.Simple.Utils as U (cabalVersion)
 import Distribution.Text
 
-import Distribution.Utils.TempTestDir (removeDirectoryRecursiveHack)
+import Test.Utils.TempTestDir (removeDirectoryRecursiveHack)
 import Distribution.Verbosity
 import Distribution.Version
 

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -39,7 +39,7 @@ import Distribution.Parsec (eitherParsec)
 import Distribution.Types.UnqualComponentName
 import Distribution.Types.LocalBuildInfo
 import Distribution.PackageDescription
-import Distribution.Utils.TempTestDir (withTestDir)
+import Test.Utils.TempTestDir (withTestDir)
 import Distribution.Verbosity (normal)
 
 import Distribution.Compat.Stack

--- a/changelog.d/issue-9453
+++ b/changelog.d/issue-9453
@@ -1,0 +1,12 @@
+synopsis: Remove Distribution.Utils.TempTestDir module from Cabal library
+packages: Cabal
+prs: #9454
+issues: #9453
+
+description: {
+
+This library was only used by internal tests, and now lives in the `Cabal-tests` library
+which is shared across test components.
+
+}
+


### PR DESCRIPTION
I noticed that Distribution.Utils.TempTestDir was only used in the testsuite but defined in the Cabal library. Rather than expose this in the public interface of the `Cabal` library, it is cleaner to refactor it into a separate library (`Cabal-tests`) which can be used by any testsuite component.

Also, in future it gives a clearer place to put utility functions which need to be shared across the testsuite but not exposed in Cabal. Cabal-tests can also freely add dependencies (such as exceptions) which we might want to avoid adding to the Cabal library.

Fixes #9453


