### PR TITLE
Modularise LocalBuildInfo and configure phase

### DIFF
--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -41,7 +41,7 @@ md5CheckGenericPackageDescription proxy = md5Check proxy
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
 #if MIN_VERSION_base(4,19,0)
-    0x023b3cd1665b2acdedf72d231c96336b
+    0xceb2a9b9aa0555228a98bd875534be77
 #else
-    0xc6c0cc122cc60ce7943764cbaaacdc2d
+    0xc94d93ef5dd99410a5b2f1f3c9853f00
 #endif

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -146,6 +146,7 @@ library
     Distribution.Types.DumpBuildInfo
     Distribution.Types.PackageName.Magic
     Distribution.Types.ComponentLocalBuildInfo
+    Distribution.Types.LocalBuildConfig
     Distribution.Types.LocalBuildInfo
     Distribution.Types.TargetInfo
     Distribution.Types.GivenComponent

--- a/Cabal/src/Distribution/Backpack/Configure.hs
+++ b/Cabal/src/Distribution/Backpack/Configure.hs
@@ -85,7 +85,7 @@ configureComponentLocalBuildInfos
   cid_flag
   pkg_descr
   (prePkgDeps, promisedPkgDeps)
-  flagAssignment
+  flags
   instantiate_with
   installedPackageSet
   comp = do
@@ -123,7 +123,7 @@ configureComponentLocalBuildInfos
     graph1 <-
       toConfiguredComponents
         use_external_internal_deps
-        flagAssignment
+        flags
         deterministic
         ipid_flag
         cid_flag

--- a/Cabal/src/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/src/Distribution/Simple/BuildTarget.hs
@@ -1046,11 +1046,11 @@ checkBuildTargets _ pkg_descr lbi [] =
 checkBuildTargets
   verbosity
   pkg_descr
-  lbi@(LocalBuildInfo{componentEnabledSpec})
+  lbi@(LocalBuildInfo{componentEnabledSpec = enabledComps})
   targets = do
     let (enabled, disabled) =
           partitionEithers
-            [ case componentDisabledReason componentEnabledSpec comp of
+            [ case componentDisabledReason enabledComps comp of
               Nothing -> Left target'
               Just reason -> Right (cname, reason)
             | target <- targets

--- a/Cabal/src/Distribution/Simple/BuildTarget.hs
+++ b/Cabal/src/Distribution/Simple/BuildTarget.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 
 -----------------------------------------------------------------------------
@@ -1041,64 +1043,68 @@ checkBuildTargets
   -> IO [TargetInfo]
 checkBuildTargets _ pkg_descr lbi [] =
   return (allTargetsInBuildOrder' pkg_descr lbi)
-checkBuildTargets verbosity pkg_descr lbi targets = do
-  let (enabled, disabled) =
-        partitionEithers
-          [ case componentDisabledReason (componentEnabledSpec lbi) comp of
-            Nothing -> Left target'
-            Just reason -> Right (cname, reason)
-          | target <- targets
-          , let target'@(cname, _) = swizzleTarget target
-          , let comp = getComponent pkg_descr cname
-          ]
+checkBuildTargets
+  verbosity
+  pkg_descr
+  lbi@(LocalBuildInfo{componentEnabledSpec})
+  targets = do
+    let (enabled, disabled) =
+          partitionEithers
+            [ case componentDisabledReason componentEnabledSpec comp of
+              Nothing -> Left target'
+              Just reason -> Right (cname, reason)
+            | target <- targets
+            , let target'@(cname, _) = swizzleTarget target
+            , let comp = getComponent pkg_descr cname
+            ]
 
-  case disabled of
-    [] -> return ()
-    ((cname, reason) : _) -> dieWithException verbosity $ CheckBuildTargets $ formatReason (showComponentName cname) reason
+    case disabled of
+      [] -> return ()
+      ((cname, reason) : _) -> dieWithException verbosity $ CheckBuildTargets $ formatReason (showComponentName cname) reason
 
-  for_ [(c, t) | (c, Just t) <- enabled] $ \(c, t) ->
-    warn verbosity $
-      "Ignoring '"
-        ++ either prettyShow id t
-        ++ ". The whole "
-        ++ showComponentName c
-        ++ " will be processed. (Support for "
-        ++ "module and file targets has not been implemented yet.)"
+    for_ [(c, t) | (c, Just t) <- enabled] $ \(c, t) ->
+      warn verbosity $
+        "Ignoring '"
+          ++ either prettyShow id t
+          ++ ". The whole "
+          ++ showComponentName c
+          ++ " will be processed. (Support for "
+          ++ "module and file targets has not been implemented yet.)"
 
-  -- Pick out the actual CLBIs for each of these cnames
-  enabled' <- for enabled $ \(cname, _) -> do
-    case componentNameTargets' pkg_descr lbi cname of
-      [] -> error "checkBuildTargets: nothing enabled"
-      [target] -> return target
-      _targets -> error "checkBuildTargets: multiple copies enabled"
+    -- Pick out the actual CLBIs for each of these cnames
+    enabled' <- for enabled $ \(cname, _) -> do
+      case componentNameTargets' pkg_descr lbi cname of
+        [] -> error "checkBuildTargets: nothing enabled"
+        [target] -> return target
+        _targets -> error "checkBuildTargets: multiple copies enabled"
 
-  return enabled'
-  where
-    swizzleTarget (BuildTargetComponent c) = (c, Nothing)
-    swizzleTarget (BuildTargetModule c m) = (c, Just (Left m))
-    swizzleTarget (BuildTargetFile c f) = (c, Just (Right f))
+    return enabled'
+    where
+      swizzleTarget (BuildTargetComponent c) = (c, Nothing)
+      swizzleTarget (BuildTargetModule c m) = (c, Just (Left m))
+      swizzleTarget (BuildTargetFile c f) = (c, Just (Right f))
 
-    formatReason cn DisabledComponent =
-      "Cannot process the "
-        ++ cn
-        ++ " because the component is marked "
-        ++ "as disabled in the .cabal file."
-    formatReason cn DisabledAllTests =
-      "Cannot process the "
-        ++ cn
-        ++ " because test suites are not "
-        ++ "enabled. Run configure with the flag --enable-tests"
-    formatReason cn DisabledAllBenchmarks =
-      "Cannot process the "
-        ++ cn
-        ++ " because benchmarks are not "
-        ++ "enabled. Re-run configure with the flag --enable-benchmarks"
-    formatReason cn (DisabledAllButOne cn') =
-      "Cannot process the "
-        ++ cn
-        ++ " because this package was "
-        ++ "configured only to build "
-        ++ cn'
-        ++ ". Re-run configure "
-        ++ "with the argument "
-        ++ cn
+      formatReason cn DisabledComponent =
+        "Cannot process the "
+          ++ cn
+          ++ " because the component is marked "
+          ++ "as disabled in the .cabal file."
+      formatReason cn DisabledAllTests =
+        "Cannot process the "
+          ++ cn
+          ++ " because test suites are not "
+          ++ "enabled. Run configure with the flag --enable-tests"
+      formatReason cn DisabledAllBenchmarks =
+        "Cannot process the "
+          ++ cn
+          ++ " because benchmarks are not "
+          ++ "enabled. Re-run configure with the flag --enable-benchmarks"
+      formatReason cn (DisabledAllButOne cn') =
+        "Cannot process the "
+          ++ cn
+          ++ " because this package was "
+          ++ "configured only to build "
+          ++ cn'
+          ++ ". Re-run configure "
+          ++ "with the argument "
+          ++ cn

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -449,11 +449,11 @@ configure (pkg_descr0, pbi) cfg = do
   checkExactConfiguration verbosity pkg_descr0 cfg
 
   -- Where to build the package
-  let buildDir :: FilePath -- e.g. dist/build
+  let build_dir :: FilePath -- e.g. dist/build
   -- fromFlag OK due to Distribution.Simple calling
   -- findDistPrefOrDefault to fill it in
-      buildDir = fromFlag (configDistPref cfg) </> "build"
-  createDirectoryIfMissingVerbose (lessVerbose verbosity) True buildDir
+      build_dir = fromFlag (configDistPref cfg) </> "build"
+  createDirectoryIfMissingVerbose (lessVerbose verbosity) True build_dir
 
   -- What package database(s) to use
   let packageDbs :: PackageDBStack
@@ -905,8 +905,6 @@ configure (pkg_descr0, pbi) cfg = do
             , installDirTemplates = installDirs
             , compiler = comp
             , hostPlatform = compPlatform
-            , buildDir = buildDir
-            , cabalFilePath = flagToMaybe (configCabalFilePath cfg)
             , componentGraph = Graph.fromDistinctList buildComponents
             , componentNameMap = buildComponentsMap
             , installedPkgs = packageDependsIndex
@@ -933,8 +931,6 @@ configure (pkg_descr0, pbi) cfg = do
             , exeCoverage = False
             , libCoverage = False
             , withPackageDB = packageDbs
-            , progPrefix = fromFlag $ configProgPrefix cfg
-            , progSuffix = fromFlag $ configProgSuffix cfg
             , relocatable = reloc
             }
 

--- a/Cabal/src/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Simple/LocalBuildInfo.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 
 -----------------------------------------------------------------------------
@@ -24,6 +26,12 @@ module Distribution.Simple.LocalBuildInfo
   , localComponentId
   , localUnitId
   , localCompatPackageKey
+
+    -- * Convenience accessors
+  , buildDir
+  , cabalFilePath
+  , progPrefix
+  , progSuffix
 
     -- * Buildable package components
   , Component (..)
@@ -200,8 +208,8 @@ withAllComponentsInBuildOrder pkg lbi f =
 allComponentsInBuildOrder
   :: LocalBuildInfo
   -> [ComponentLocalBuildInfo]
-allComponentsInBuildOrder lbi =
-  Graph.topSort (componentGraph lbi)
+allComponentsInBuildOrder (LocalBuildInfo{componentGraph}) =
+  Graph.topSort componentGraph
 
 -- -----------------------------------------------------------------------------
 -- A random function that has no business in this module
@@ -219,94 +227,101 @@ depLibraryPaths
   -> ComponentLocalBuildInfo
   -- ^ Component that is being built
   -> IO [FilePath]
-depLibraryPaths inplace relative lbi clbi = do
-  let pkgDescr = localPkgDescr lbi
-      installDirs = absoluteComponentInstallDirs pkgDescr lbi (componentUnitId clbi) NoCopyDest
-      executable = case clbi of
-        ExeComponentLocalBuildInfo{} -> True
-        _ -> False
-      relDir
-        | executable = bindir installDirs
-        | otherwise = libdir installDirs
+depLibraryPaths
+  inplace
+  relative
+  lbi@( LocalBuildInfo
+          { localPkgDescr = pkgDescr
+          , installedPkgs
+          }
+        )
+  clbi = do
+    let installDirs = absoluteComponentInstallDirs pkgDescr lbi (componentUnitId clbi) NoCopyDest
+        executable = case clbi of
+          ExeComponentLocalBuildInfo{} -> True
+          _ -> False
+        relDir
+          | executable = bindir installDirs
+          | otherwise = libdir installDirs
 
-  let
-    -- TODO: this is kind of inefficient
-    internalDeps =
-      [ uid
-      | (uid, _) <- componentPackageDeps clbi
-      , -- Test that it's internal
-      sub_target <- allTargetsInBuildOrder' pkgDescr lbi
-      , componentUnitId (targetCLBI (sub_target)) == uid
-      ]
-    internalLibs =
-      [ getLibDir (targetCLBI sub_target)
-      | sub_target <-
-          neededTargetsInBuildOrder'
-            pkgDescr
-            lbi
-            internalDeps
-      ]
-    {-
-    -- This is better, but it doesn't work, because we may be passed a
-    -- CLBI which doesn't actually exist, and was faked up when we
-    -- were building a test suite/benchmark.  See #3599 for proposal
-    -- to fix this.
-    let internalCLBIs = filter ((/= componentUnitId clbi) . componentUnitId)
-                      . map targetCLBI
-                      $ neededTargetsInBuildOrder lbi [componentUnitId clbi]
-        internalLibs = map getLibDir internalCLBIs
-    -}
-    getLibDir sub_clbi
-      | inplace = componentBuildDir lbi sub_clbi
-      | otherwise = dynlibdir (absoluteComponentInstallDirs pkgDescr lbi (componentUnitId sub_clbi) NoCopyDest)
+    let
+      -- TODO: this is kind of inefficient
+      internalDeps =
+        [ uid
+        | (uid, _) <- componentPackageDeps clbi
+        , -- Test that it's internal
+        sub_target <- allTargetsInBuildOrder' pkgDescr lbi
+        , componentUnitId (targetCLBI (sub_target)) == uid
+        ]
+      internalLibs =
+        [ getLibDir (targetCLBI sub_target)
+        | sub_target <-
+            neededTargetsInBuildOrder'
+              pkgDescr
+              lbi
+              internalDeps
+        ]
+      {-
+      -- This is better, but it doesn't work, because we may be passed a
+      -- CLBI which doesn't actually exist, and was faked up when we
+      -- were building a test suite/benchmark.  See #3599 for proposal
+      -- to fix this.
+      let internalCLBIs = filter ((/= componentUnitId clbi) . componentUnitId)
+                        . map targetCLBI
+                        $ neededTargetsInBuildOrder lbi [componentUnitId clbi]
+          internalLibs = map getLibDir internalCLBIs
+      -}
+      getLibDir sub_clbi
+        | inplace = componentBuildDir lbi sub_clbi
+        | otherwise = dynlibdir (absoluteComponentInstallDirs pkgDescr lbi (componentUnitId sub_clbi) NoCopyDest)
 
-  -- Why do we go through all the trouble of a hand-crafting
-  -- internalLibs, when 'installedPkgs' actually contains the
-  -- internal libraries?  The trouble is that 'installedPkgs'
-  -- may contain *inplace* entries, which we must NOT use for
-  -- not inplace 'depLibraryPaths' (e.g., for RPATH calculation).
-  -- See #4025 for more details. This is all horrible but it
-  -- is a moot point if you are using a per-component build,
-  -- because you never have any internal libraries in this case;
-  -- they're all external.
-  let external_ipkgs = filter is_external (allPackages (installedPkgs lbi))
-      is_external ipkg = not (installedUnitId ipkg `elem` internalDeps)
-      -- First look for dynamic libraries in `dynamic-library-dirs`, and use
-      -- `library-dirs` as a fall back.
-      getDynDir pkg = case Installed.libraryDynDirs pkg of
-        [] -> Installed.libraryDirs pkg
-        d -> d
-      allDepLibDirs = concatMap getDynDir external_ipkgs
+    -- Why do we go through all the trouble of a hand-crafting
+    -- internalLibs, when 'installedPkgs' actually contains the
+    -- internal libraries?  The trouble is that 'installedPkgs'
+    -- may contain *inplace* entries, which we must NOT use for
+    -- not inplace 'depLibraryPaths' (e.g., for RPATH calculation).
+    -- See #4025 for more details. This is all horrible but it
+    -- is a moot point if you are using a per-component build,
+    -- because you never have any internal libraries in this case;
+    -- they're all external.
+    let external_ipkgs = filter is_external (allPackages installedPkgs)
+        is_external ipkg = not (installedUnitId ipkg `elem` internalDeps)
+        -- First look for dynamic libraries in `dynamic-library-dirs`, and use
+        -- `library-dirs` as a fall back.
+        getDynDir pkg = case Installed.libraryDynDirs pkg of
+          [] -> Installed.libraryDirs pkg
+          d -> d
+        allDepLibDirs = concatMap getDynDir external_ipkgs
 
-      allDepLibDirs' = internalLibs ++ allDepLibDirs
-  allDepLibDirsC <- traverse canonicalizePathNoFail allDepLibDirs'
+        allDepLibDirs' = internalLibs ++ allDepLibDirs
+    allDepLibDirsC <- traverse canonicalizePathNoFail allDepLibDirs'
 
-  let p = prefix installDirs
-      prefixRelative l = isJust (stripPrefix p l)
-      libPaths
-        | relative
-            && prefixRelative relDir =
-            map
-              ( \l ->
-                  if prefixRelative l
-                    then shortRelativePath relDir l
-                    else l
-              )
-              allDepLibDirsC
-        | otherwise = allDepLibDirsC
+    let p = prefix installDirs
+        prefixRelative l = isJust (stripPrefix p l)
+        libPaths
+          | relative
+              && prefixRelative relDir =
+              map
+                ( \l ->
+                    if prefixRelative l
+                      then shortRelativePath relDir l
+                      else l
+                )
+                allDepLibDirsC
+          | otherwise = allDepLibDirsC
 
-  -- For some reason, this function returns lots of duplicates. Avoid
-  -- exceeding `ARG_MAX` (the result of this function is used to populate
-  -- `LD_LIBRARY_PATH`) by deduplicating the list.
-  return $ ordNub libPaths
-  where
-    -- 'canonicalizePath' fails on UNIX when the directory does not exists.
-    -- So just don't canonicalize when it doesn't exist.
-    canonicalizePathNoFail p = do
-      exists <- doesDirectoryExist p
-      if exists
-        then canonicalizePath p
-        else return p
+    -- For some reason, this function returns lots of duplicates. Avoid
+    -- exceeding `ARG_MAX` (the result of this function is used to populate
+    -- `LD_LIBRARY_PATH`) by deduplicating the list.
+    return $ ordNub libPaths
+    where
+      -- 'canonicalizePath' fails on UNIX when the directory does not exists.
+      -- So just don't canonicalize when it doesn't exist.
+      canonicalizePathNoFail p = do
+        exists <- doesDirectoryExist p
+        if exists
+          then canonicalizePath p
+          else return p
 
 -- | Get all module names that needed to be built by GHC; i.e., all
 -- of these 'ModuleName's have interface files associated with them
@@ -341,14 +356,18 @@ absoluteComponentInstallDirs
   -> UnitId
   -> CopyDest
   -> InstallDirs FilePath
-absoluteComponentInstallDirs pkg lbi uid copydest =
-  InstallDirs.absoluteInstallDirs
-    (packageId pkg)
-    uid
-    (compilerInfo (compiler lbi))
-    copydest
-    (hostPlatform lbi)
-    (installDirTemplates lbi)
+absoluteComponentInstallDirs
+  pkg
+  (LocalBuildInfo{compiler, hostPlatform, installDirTemplates})
+  uid
+  copydest =
+    InstallDirs.absoluteInstallDirs
+      (packageId pkg)
+      uid
+      (compilerInfo compiler)
+      copydest
+      hostPlatform
+      installDirTemplates
 
 absoluteInstallCommandDirs
   :: PackageDescription
@@ -397,13 +416,16 @@ prefixRelativeComponentInstallDirs
   -> LocalBuildInfo
   -> UnitId
   -> InstallDirs (Maybe FilePath)
-prefixRelativeComponentInstallDirs pkg_descr lbi uid =
-  InstallDirs.prefixRelativeInstallDirs
-    (packageId pkg_descr)
-    uid
-    (compilerInfo (compiler lbi))
-    (hostPlatform lbi)
-    (installDirTemplates lbi)
+prefixRelativeComponentInstallDirs
+  pkg_descr
+  (LocalBuildInfo{compiler, hostPlatform, installDirTemplates})
+  uid =
+    InstallDirs.prefixRelativeInstallDirs
+      (packageId pkg_descr)
+      uid
+      (compilerInfo compiler)
+      hostPlatform
+      installDirTemplates
 
 substPathTemplate
   :: PackageId
@@ -411,13 +433,16 @@ substPathTemplate
   -> UnitId
   -> PathTemplate
   -> FilePath
-substPathTemplate pkgid lbi uid =
-  fromPathTemplate
-    . (InstallDirs.substPathTemplate env)
-  where
-    env =
-      initialPathTemplateEnv
-        pkgid
-        uid
-        (compilerInfo (compiler lbi))
-        (hostPlatform lbi)
+substPathTemplate
+  pkgid
+  (LocalBuildInfo{compiler, hostPlatform})
+  uid =
+    fromPathTemplate
+      . (InstallDirs.substPathTemplate env)
+    where
+      env =
+        initialPathTemplateEnv
+          pkgid
+          uid
+          (compilerInfo compiler)
+          hostPlatform

--- a/Cabal/src/Distribution/Simple/Test.hs
+++ b/Cabal/src/Distribution/Simple/Test.hs
@@ -143,7 +143,10 @@ test args pkg_descr lbi0 flags = do
   -- install time, is copied into the ghc-pkg database files.
   -- Now, we get the path to the HPC artifacts and exposed modules of each
   -- library by querying the package database keyed by unit-id:
-  let coverageFor = fromFlagOrDefault [] (configCoverageFor (configFlags lbi))
+  let coverageFor =
+        nub $
+          fromFlagOrDefault [] (configCoverageFor (configFlags lbi))
+            <> extraCoverageFor lbi
   ipkginfos <- getInstalledPackagesById verbosity lbi MissingCoveredInstalledLibrary coverageFor
   let ( concat -> pathsToLibsArtifacts
         , concat -> libsModulesToInclude

--- a/Cabal/src/Distribution/Simple/Test/ExeV10.hs
+++ b/Cabal/src/Distribution/Simple/Test/ExeV10.hs
@@ -17,12 +17,20 @@ import Distribution.Simple.Flag
 import Distribution.Simple.Hpc
 import Distribution.Simple.InstallDirs
 import qualified Distribution.Simple.LocalBuildInfo as LBI
+  ( ComponentLocalBuildInfo (..)
+  , buildDir
+  , depLibraryPaths
+  )
 import Distribution.Simple.Setup.Test
 import Distribution.Simple.Test.Log
 import Distribution.Simple.Utils
 import Distribution.System
 import Distribution.TestSuite
 import qualified Distribution.Types.LocalBuildInfo as LBI
+  ( LocalBuildInfo (..)
+  , localUnitId
+  , testCoverage
+  )
 import Distribution.Types.UnqualComponentName
 import Distribution.Verbosity
 

--- a/Cabal/src/Distribution/Types/LocalBuildConfig.hs
+++ b/Cabal/src/Distribution/Types/LocalBuildConfig.hs
@@ -1,0 +1,220 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Distribution.Types.LocalBuildConfig
+  ( -- * The types
+    PackageBuildDescr (..)
+  , ComponentBuildDescr (..)
+  , LocalBuildDescr (..)
+  , LocalBuildConfig (..)
+  , BuildOptions (..)
+
+    -- * Conversion functions
+  , buildOptionsConfigFlags
+  ) where
+
+import Distribution.Compat.Prelude
+import Prelude ()
+
+import Distribution.Types.ComponentId
+import Distribution.Types.ComponentLocalBuildInfo
+import Distribution.Types.ComponentRequestedSpec
+import Distribution.Types.PackageDescription
+
+import Distribution.PackageDescription
+import Distribution.Simple.Compiler
+import Distribution.Simple.Flag
+import Distribution.Simple.InstallDirs hiding
+  ( absoluteInstallDirs
+  , prefixRelativeInstallDirs
+  , substPathTemplate
+  )
+import Distribution.Simple.PackageIndex
+import Distribution.Simple.Program
+import Distribution.Simple.Setup.Config
+import Distribution.System
+
+import Distribution.Compat.Graph (Graph)
+
+-- | 'PackageBuildDescr' contains the information Cabal determines after
+-- performing package-wide configuration of a package, before doing any
+-- per-component configuration.
+data PackageBuildDescr = PackageBuildDescr
+  { configFlags :: ConfigFlags
+  -- ^ Options passed to the configuration step.
+  -- Needed to re-run configuration when .cabal is out of date
+  , flagAssignment :: FlagAssignment
+  -- ^ The final set of flags which were picked for this package
+  , componentEnabledSpec :: ComponentRequestedSpec
+  -- ^ What components were enabled during configuration, and why.
+  , compiler :: Compiler
+  -- ^ The compiler we're building with
+  , hostPlatform :: Platform
+  -- ^ The platform we're building for
+  , pkgDescrFile :: Maybe FilePath
+  -- ^ the filename containing the .cabal file, if available
+  , localPkgDescr :: PackageDescription
+  -- ^ WARNING WARNING WARNING Be VERY careful about using
+  -- this function; we haven't deprecated it but using it
+  -- could introduce subtle bugs related to
+  -- 'HookedBuildInfo'.
+  --
+  -- In principle, this is supposed to contain the
+  -- resolved package description, that does not contain
+  -- any conditionals.  However, it MAY NOT contain
+  -- the description with a 'HookedBuildInfo' applied
+  -- to it; see 'HookedBuildInfo' for the whole sordid saga.
+  -- As much as possible, Cabal library should avoid using
+  -- this parameter.
+  , installDirTemplates :: InstallDirTemplates
+  -- ^ The installation directories for the various different
+  -- kinds of files
+  -- TODO: inplaceDirTemplates :: InstallDirs FilePath
+  , withPackageDB :: PackageDBStack
+  -- ^ What package database to use, global\/user
+  }
+  deriving (Generic, Read, Show)
+
+-- | Information about individual components in a package,
+-- determined after the configure step.
+data ComponentBuildDescr = ComponentBuildDescr
+  { componentGraph :: Graph ComponentLocalBuildInfo
+  -- ^ All the components to build, ordered by topological
+  -- sort, and with their INTERNAL dependencies over the
+  -- intrapackage dependency graph.
+  -- TODO: this is assumed to be short; otherwise we want
+  -- some sort of ordered map.
+  , componentNameMap :: Map ComponentName [ComponentLocalBuildInfo]
+  -- ^ A map from component name to all matching
+  -- components.  These coincide with 'componentGraph'
+  -- There may be more than one matching component because of backpack instantiations
+  , promisedPkgs :: Map (PackageName, ComponentName) ComponentId
+  -- ^ The packages we were promised, but aren't already installed.
+  -- MP: Perhaps this just needs to be a Set UnitId at this stage.
+  , installedPkgs :: InstalledPackageIndex
+  -- ^ All the info about the installed packages that the
+  -- current package depends on (directly or indirectly).
+  -- The copy saved on disk does NOT include internal
+  -- dependencies (because we just don't have enough
+  -- information at this point to have an
+  -- 'InstalledPackageInfo' for an internal dep), but we
+  -- will often update it with the internal dependencies;
+  -- see for example 'Distribution.Simple.Build.build'.
+  -- (This admonition doesn't apply for per-component builds.)
+  }
+  deriving (Generic, Read, Show)
+
+-- | 'LocalBuildDescr ' contains the information Cabal determines after
+-- performing package-wide and per-component configuration of a package.
+--
+-- This information can no longer be changed after that point.
+data LocalBuildDescr = LocalBuildDescr
+  { packageBuildDescr :: PackageBuildDescr
+  -- ^ Information that is available after configuring the package itself,
+  -- before looking at individual components.
+  , componentBuildDescr :: ComponentBuildDescr
+  -- ^ Information about individual components in the package
+  -- determined after the configure step.
+  }
+  deriving (Generic, Read, Show)
+
+-- | 'LocalBuildConfig' contains options that can be controlled
+-- by the user and serve as inputs to the configuration of a package.
+data LocalBuildConfig = LocalBuildConfig
+  { extraConfigArgs :: [String]
+  -- ^ Extra args on the command line for the configuration step.
+  -- Needed to re-run configuration when .cabal is out of date
+  , withPrograms :: ProgramDb
+  -- ^ Location and args for all programs
+  , withBuildOptions :: BuildOptions
+  -- ^ Options to control the build, e.g. whether to
+  -- enable profiling or to enable program coverage.
+  }
+  deriving (Generic, Read, Show)
+
+-- | 'BuildOptions' contains configuration options that can be controlled
+-- by the user.
+data BuildOptions = BuildOptions
+  { withVanillaLib :: Bool
+  -- ^ Whether to build normal libs.
+  , withProfLib :: Bool
+  -- ^ Whether to build profiling versions of libs.
+  , withSharedLib :: Bool
+  -- ^ Whether to build shared versions of libs.
+  , withStaticLib :: Bool
+  -- ^ Whether to build static versions of libs (with all other libs rolled in)
+  , withDynExe :: Bool
+  -- ^ Whether to link executables dynamically
+  , withFullyStaticExe :: Bool
+  -- ^ Whether to link executables fully statically
+  , withProfExe :: Bool
+  -- ^ Whether to build executables for profiling.
+  , withProfLibDetail :: ProfDetailLevel
+  -- ^ Level of automatic profile detail.
+  , withProfExeDetail :: ProfDetailLevel
+  -- ^ Level of automatic profile detail.
+  , withOptimization :: OptimisationLevel
+  -- ^ Whether to build with optimization (if available).
+  , withDebugInfo :: DebugInfoLevel
+  -- ^ Whether to emit debug info (if available).
+  , withGHCiLib :: Bool
+  -- ^ Whether to build libs suitable for use with GHCi.
+  , splitSections :: Bool
+  -- ^ Use -split-sections with GHC, if available
+  , splitObjs :: Bool
+  -- ^ Use -split-objs with GHC, if available
+  , stripExes :: Bool
+  -- ^ Whether to strip executables during install
+  , stripLibs :: Bool
+  -- ^ Whether to strip libraries during install
+  , exeCoverage :: Bool
+  -- ^ Whether to enable executable program coverage
+  , libCoverage :: Bool
+  -- ^ Whether to enable library program coverage
+  , relocatable :: Bool
+  -- ^ Whether to build a relocatable package
+  }
+  deriving (Eq, Generic, Read, Show)
+
+instance Binary PackageBuildDescr
+instance Structured PackageBuildDescr
+instance Binary ComponentBuildDescr
+instance Structured ComponentBuildDescr
+instance Binary LocalBuildDescr
+instance Structured LocalBuildDescr
+instance Binary LocalBuildConfig
+instance Structured LocalBuildConfig
+instance Binary BuildOptions
+instance Structured BuildOptions
+
+buildOptionsConfigFlags :: BuildOptions -> ConfigFlags
+buildOptionsConfigFlags (BuildOptions{..}) =
+  mempty
+    { configVanillaLib = toFlag $ withVanillaLib
+    , configSharedLib = toFlag $ withSharedLib
+    , configStaticLib = toFlag $ withStaticLib
+    , configDynExe = toFlag $ withDynExe
+    , configFullyStaticExe = toFlag $ withFullyStaticExe
+    , configGHCiLib = toFlag $ withGHCiLib
+    , configProfExe = toFlag $ withProfExe
+    , configProfLib = toFlag $ withProfLib
+    , configProf = mempty
+    , -- configProfDetail is for exe+lib, but overridden by configProfLibDetail
+      -- so we specify both so we can specify independently
+      configProfDetail = toFlag $ withProfExeDetail
+    , configProfLibDetail = toFlag $ withProfLibDetail
+    , configCoverage = toFlag $ exeCoverage
+    , configLibCoverage = mempty
+    , configRelocatable = toFlag $ relocatable
+    , configOptimization = toFlag $ withOptimization
+    , configSplitSections = toFlag $ splitSections
+    , configSplitObjs = toFlag $ splitObjs
+    , configStripExes = toFlag $ stripExes
+    , configStripLibs = toFlag $ stripLibs
+    , configDebugInfo = toFlag $ withDebugInfo
+    }

--- a/Cabal/src/Distribution/Types/LocalBuildConfig.hs
+++ b/Cabal/src/Distribution/Types/LocalBuildConfig.hs
@@ -25,6 +25,7 @@ import Distribution.Types.ComponentId
 import Distribution.Types.ComponentLocalBuildInfo
 import Distribution.Types.ComponentRequestedSpec
 import Distribution.Types.PackageDescription
+import Distribution.Types.UnitId
 
 import Distribution.PackageDescription
 import Distribution.Simple.Compiler
@@ -77,6 +78,11 @@ data PackageBuildDescr = PackageBuildDescr
   -- TODO: inplaceDirTemplates :: InstallDirs FilePath
   , withPackageDB :: PackageDBStack
   -- ^ What package database to use, global\/user
+  , extraCoverageFor :: [UnitId]
+  -- ^ For per-package builds-only: an extra list of libraries to be included in
+  -- the hpc coverage report for testsuites run with @--enable-coverage@.
+  -- Notably, this list must exclude indefinite libraries and instantiations
+  -- because HPC does not support backpack (Nov. 2023).
   }
   deriving (Generic, Read, Show)
 

--- a/Cabal/src/Distribution/Types/LocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/LocalBuildInfo.hs
@@ -1,17 +1,63 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Distribution.Types.LocalBuildInfo
-  ( -- * The type
-    LocalBuildInfo (..)
+  ( -- * The types
+    LocalBuildInfo
+      ( LocalBuildInfo
+      , configFlags
+      , flagAssignment
+      , componentEnabledSpec
+      , extraConfigArgs
+      , installDirTemplates
+      , compiler
+      , hostPlatform
+      , pkgDescrFile
+      , componentGraph
+      , componentNameMap
+      , promisedPkgs
+      , installedPkgs
+      , localPkgDescr
+      , withPrograms
+      , withPackageDB
+      , withVanillaLib
+      , withProfLib
+      , withSharedLib
+      , withStaticLib
+      , withDynExe
+      , withFullyStaticExe
+      , withProfExe
+      , withProfLibDetail
+      , withProfExeDetail
+      , withOptimization
+      , withDebugInfo
+      , withGHCiLib
+      , splitSections
+      , splitObjs
+      , stripExes
+      , stripLibs
+      , exeCoverage
+      , libCoverage
+      , relocatable
+      , ..
+      )
 
     -- * Convenience accessors
   , localComponentId
   , localUnitId
   , localCompatPackageKey
   , localPackage
+  , buildDir
+  , buildDirPBD
+  , configFlagsBuildDir
+  , cabalFilePath
+  , progPrefix
+  , progSuffix
 
     -- * Build targets of the 'LocalBuildInfo'.
   , componentNameCLBIs
@@ -52,6 +98,7 @@ import Prelude ()
 import Distribution.Types.ComponentId
 import Distribution.Types.ComponentLocalBuildInfo
 import Distribution.Types.ComponentRequestedSpec
+import qualified Distribution.Types.LocalBuildConfig as LBC
 import Distribution.Types.PackageDescription
 import Distribution.Types.PackageId
 import Distribution.Types.TargetInfo
@@ -60,6 +107,7 @@ import Distribution.Types.UnitId
 import Distribution.PackageDescription
 import Distribution.Pretty
 import Distribution.Simple.Compiler
+import Distribution.Simple.Flag
 import Distribution.Simple.InstallDirs hiding
   ( absoluteInstallDirs
   , prefixRelativeInstallDirs
@@ -73,123 +121,174 @@ import Distribution.System
 import qualified Data.Map as Map
 import Distribution.Compat.Graph (Graph)
 import qualified Distribution.Compat.Graph as Graph
+import System.FilePath ((</>))
 
 -- | Data cached after configuration step.  See also
 -- 'Distribution.Simple.Setup.ConfigFlags'.
-data LocalBuildInfo = LocalBuildInfo
-  { configFlags :: ConfigFlags
-  -- ^ Options passed to the configuration step.
-  -- Needed to re-run configuration when .cabal is out of date
-  , flagAssignment :: FlagAssignment
-  -- ^ The final set of flags which were picked for this package
-  , componentEnabledSpec :: ComponentRequestedSpec
-  -- ^ What components were enabled during configuration, and why.
-  , extraConfigArgs :: [String]
-  -- ^ Extra args on the command line for the configuration step.
-  -- Needed to re-run configuration when .cabal is out of date
-  , installDirTemplates :: InstallDirTemplates
-  -- ^ The installation directories for the various different
-  -- kinds of files
-  -- TODO: inplaceDirTemplates :: InstallDirs FilePath
-  , compiler :: Compiler
-  -- ^ The compiler we're building with
-  , hostPlatform :: Platform
-  -- ^ The platform we're building for
-  , buildDir :: FilePath
-  -- ^ Where to build the package.
-  , cabalFilePath :: Maybe FilePath
-  -- ^ Path to the cabal file, if given during configuration.
-  , componentGraph :: Graph ComponentLocalBuildInfo
-  -- ^ All the components to build, ordered by topological
-  -- sort, and with their INTERNAL dependencies over the
-  -- intrapackage dependency graph.
-  -- TODO: this is assumed to be short; otherwise we want
-  -- some sort of ordered map.
-  , componentNameMap :: Map ComponentName [ComponentLocalBuildInfo]
-  -- ^ A map from component name to all matching
-  -- components.  These coincide with 'componentGraph'
-  -- There may be more than one matching component because of backpack instantiations
-  , promisedPkgs :: Map (PackageName, ComponentName) ComponentId
-  -- ^ The packages we were promised, but aren't already installed.
-  -- MP: Perhaps this just needs to be a Set UnitId at this stage.
-  , installedPkgs :: InstalledPackageIndex
-  -- ^ All the info about the installed packages that the
-  -- current package depends on (directly or indirectly).
-  -- The copy saved on disk does NOT include internal
-  -- dependencies (because we just don't have enough
-  -- information at this point to have an
-  -- 'InstalledPackageInfo' for an internal dep), but we
-  -- will often update it with the internal dependencies;
-  -- see for example 'Distribution.Simple.Build.build'.
-  -- (This admonition doesn't apply for per-component builds.)
-  , pkgDescrFile :: Maybe FilePath
-  -- ^ the filename containing the .cabal file, if available
-  , localPkgDescr :: PackageDescription
-  -- ^ WARNING WARNING WARNING Be VERY careful about using
-  -- this function; we haven't deprecated it but using it
-  -- could introduce subtle bugs related to
-  -- 'HookedBuildInfo'.
-  --
-  -- In principle, this is supposed to contain the
-  -- resolved package description, that does not contain
-  -- any conditionals.  However, it MAY NOT contain
-  -- the description with a 'HookedBuildInfo' applied
-  -- to it; see 'HookedBuildInfo' for the whole sordid saga.
-  -- As much as possible, Cabal library should avoid using
-  -- this parameter.
-  , withPrograms :: ProgramDb
-  -- ^ Location and args for all programs
-  , withPackageDB :: PackageDBStack
-  -- ^ What package database to use, global\/user
-  , withVanillaLib :: Bool
-  -- ^ Whether to build normal libs.
-  , withProfLib :: Bool
-  -- ^ Whether to build profiling versions of libs.
-  , withSharedLib :: Bool
-  -- ^ Whether to build shared versions of libs.
-  , withStaticLib :: Bool
-  -- ^ Whether to build static versions of libs (with all other libs rolled in)
-  , withDynExe :: Bool
-  -- ^ Whether to link executables dynamically
-  , withFullyStaticExe :: Bool
-  -- ^ Whether to link executables fully statically
-  , withProfExe :: Bool
-  -- ^ Whether to build executables for profiling.
-  , withProfLibDetail :: ProfDetailLevel
-  -- ^ Level of automatic profile detail.
-  , withProfExeDetail :: ProfDetailLevel
-  -- ^ Level of automatic profile detail.
-  , withOptimization :: OptimisationLevel
-  -- ^ Whether to build with optimization (if available).
-  , withDebugInfo :: DebugInfoLevel
-  -- ^ Whether to emit debug info (if available).
-  , withGHCiLib :: Bool
-  -- ^ Whether to build libs suitable for use with GHCi.
-  , splitSections :: Bool
-  -- ^ Use -split-sections with GHC, if available
-  , splitObjs :: Bool
-  -- ^ Use -split-objs with GHC, if available
-  , stripExes :: Bool
-  -- ^ Whether to strip executables during install
-  , stripLibs :: Bool
-  -- ^ Whether to strip libraries during install
-  , exeCoverage :: Bool
-  -- ^ Whether to enable executable program coverage
-  , libCoverage :: Bool
-  -- ^ Whether to enable library program coverage
-  , progPrefix :: PathTemplate
-  -- ^ Prefix to be prepended to installed executables
-  , progSuffix :: PathTemplate
-  -- ^ Suffix to be appended to installed executables
-  , relocatable :: Bool --  ^Whether to build a relocatable package
+data LocalBuildInfo = NewLocalBuildInfo
+  { localBuildDescr :: LBC.LocalBuildDescr
+  -- ^ Information about a package determined by Cabal
+  -- after the configuration step.
+  , localBuildConfig :: LBC.LocalBuildConfig
+  -- ^ Information about a package configuration
+  -- that can be modified by the user at configuration time.
   }
   deriving (Generic, Read, Show, Typeable)
+
+{-# COMPLETE LocalBuildInfo #-}
+
+-- | This pattern synonym is for backwards compatibility, to adapt
+-- to 'LocalBuildInfo' being split into 'LocalBuildDescr' and 'LocalBuildConfig'.
+pattern LocalBuildInfo
+  :: ConfigFlags
+  -> FlagAssignment
+  -> ComponentRequestedSpec
+  -> [String]
+  -> InstallDirTemplates
+  -> Compiler
+  -> Platform
+  -> Maybe FilePath
+  -> Graph ComponentLocalBuildInfo
+  -> Map ComponentName [ComponentLocalBuildInfo]
+  -> Map (PackageName, ComponentName) ComponentId
+  -> InstalledPackageIndex
+  -> PackageDescription
+  -> ProgramDb
+  -> PackageDBStack
+  -> Bool
+  -> Bool
+  -> Bool
+  -> Bool
+  -> Bool
+  -> Bool
+  -> Bool
+  -> ProfDetailLevel
+  -> ProfDetailLevel
+  -> OptimisationLevel
+  -> DebugInfoLevel
+  -> Bool
+  -> Bool
+  -> Bool
+  -> Bool
+  -> Bool
+  -> Bool
+  -> Bool
+  -> Bool
+  -> LocalBuildInfo
+pattern LocalBuildInfo
+  { configFlags
+  , flagAssignment
+  , componentEnabledSpec
+  , extraConfigArgs
+  , installDirTemplates
+  , compiler
+  , hostPlatform
+  , pkgDescrFile
+  , componentGraph
+  , componentNameMap
+  , promisedPkgs
+  , installedPkgs
+  , localPkgDescr
+  , withPrograms
+  , withPackageDB
+  , withVanillaLib
+  , withProfLib
+  , withSharedLib
+  , withStaticLib
+  , withDynExe
+  , withFullyStaticExe
+  , withProfExe
+  , withProfLibDetail
+  , withProfExeDetail
+  , withOptimization
+  , withDebugInfo
+  , withGHCiLib
+  , splitSections
+  , splitObjs
+  , stripExes
+  , stripLibs
+  , exeCoverage
+  , libCoverage
+  , relocatable
+  } =
+  NewLocalBuildInfo
+    { localBuildDescr =
+      LBC.LocalBuildDescr
+        { packageBuildDescr =
+          LBC.PackageBuildDescr
+            { configFlags
+            , flagAssignment
+            , componentEnabledSpec
+            , compiler
+            , hostPlatform
+            , localPkgDescr
+            , installDirTemplates
+            , withPackageDB
+            , pkgDescrFile
+            }
+        , componentBuildDescr =
+          LBC.ComponentBuildDescr
+            { componentGraph
+            , componentNameMap
+            , promisedPkgs
+            , installedPkgs
+            }
+        }
+    , localBuildConfig =
+      LBC.LocalBuildConfig
+        { extraConfigArgs
+        , withPrograms
+        , withBuildOptions =
+          LBC.BuildOptions
+            { withVanillaLib
+            , withProfLib
+            , withSharedLib
+            , withStaticLib
+            , withDynExe
+            , withFullyStaticExe
+            , withProfExe
+            , withProfLibDetail
+            , withProfExeDetail
+            , withOptimization
+            , withDebugInfo
+            , withGHCiLib
+            , splitSections
+            , splitObjs
+            , stripExes
+            , stripLibs
+            , exeCoverage
+            , libCoverage
+            , relocatable
+            }
+        }
+    }
 
 instance Binary LocalBuildInfo
 instance Structured LocalBuildInfo
 
 -------------------------------------------------------------------------------
 -- Accessor functions
+
+buildDir :: LocalBuildInfo -> FilePath
+buildDir lbi =
+  buildDirPBD $ LBC.packageBuildDescr $ localBuildDescr lbi
+
+buildDirPBD :: LBC.PackageBuildDescr -> FilePath
+buildDirPBD (LBC.PackageBuildDescr{configFlags = cfg}) =
+  configFlagsBuildDir cfg
+
+configFlagsBuildDir :: ConfigFlags -> FilePath
+configFlagsBuildDir cfg = fromFlag (configDistPref cfg) </> "build"
+
+cabalFilePath :: LocalBuildInfo -> Maybe FilePath
+cabalFilePath (LocalBuildInfo{configFlags = cfg}) =
+  flagToMaybe (configCabalFilePath cfg)
+
+progPrefix, progSuffix :: LocalBuildInfo -> PathTemplate
+progPrefix (LocalBuildInfo{configFlags = cfg}) =
+  fromFlag $ configProgPrefix cfg
+progSuffix (LocalBuildInfo{configFlags = cfg}) =
+  fromFlag $ configProgSuffix cfg
 
 -- TODO: Get rid of these functions, as much as possible.  They are
 -- a bit useful in some cases, but you should be very careful!
@@ -207,7 +306,7 @@ localComponentId lbi =
 -- | Extract the 'PackageIdentifier' of a 'LocalBuildInfo'.
 -- This is a "safe" use of 'localPkgDescr'
 localPackage :: LocalBuildInfo -> PackageId
-localPackage lbi = package (localPkgDescr lbi)
+localPackage (LocalBuildInfo{localPkgDescr}) = package localPkgDescr
 
 -- | Extract the 'UnitId' from the library component of a
 -- 'LocalBuildInfo' if it exists, or make a fake unit ID based on
@@ -248,22 +347,22 @@ mkTargetInfo pkg_descr _lbi clbi =
 -- Has a prime because it takes a 'PackageDescription' argument
 -- which may disagree with 'localPkgDescr' in 'LocalBuildInfo'.
 componentNameTargets' :: PackageDescription -> LocalBuildInfo -> ComponentName -> [TargetInfo]
-componentNameTargets' pkg_descr lbi cname =
-  case Map.lookup cname (componentNameMap lbi) of
+componentNameTargets' pkg_descr lbi@(LocalBuildInfo{componentNameMap}) cname =
+  case Map.lookup cname componentNameMap of
     Just clbis -> map (mkTargetInfo pkg_descr lbi) clbis
     Nothing -> []
 
 unitIdTarget' :: PackageDescription -> LocalBuildInfo -> UnitId -> Maybe TargetInfo
-unitIdTarget' pkg_descr lbi uid =
-  case Graph.lookup uid (componentGraph lbi) of
+unitIdTarget' pkg_descr lbi@(LocalBuildInfo{componentGraph}) uid =
+  case Graph.lookup uid componentGraph of
     Just clbi -> Just (mkTargetInfo pkg_descr lbi clbi)
     Nothing -> Nothing
 
 -- | Return all 'ComponentLocalBuildInfo's associated with 'ComponentName'.
 -- In the presence of Backpack there may be more than one!
 componentNameCLBIs :: LocalBuildInfo -> ComponentName -> [ComponentLocalBuildInfo]
-componentNameCLBIs lbi cname =
-  case Map.lookup cname (componentNameMap lbi) of
+componentNameCLBIs (LocalBuildInfo{componentNameMap}) cname =
+  case Map.lookup cname componentNameMap of
     Just clbis -> clbis
     Nothing -> []
 
@@ -274,8 +373,8 @@ componentNameCLBIs lbi cname =
 -- Has a prime because it takes a 'PackageDescription' argument
 -- which may disagree with 'localPkgDescr' in 'LocalBuildInfo'.
 allTargetsInBuildOrder' :: PackageDescription -> LocalBuildInfo -> [TargetInfo]
-allTargetsInBuildOrder' pkg_descr lbi =
-  map (mkTargetInfo pkg_descr lbi) (Graph.revTopSort (componentGraph lbi))
+allTargetsInBuildOrder' pkg_descr lbi@(LocalBuildInfo{componentGraph}) =
+  map (mkTargetInfo pkg_descr lbi) (Graph.revTopSort componentGraph)
 
 -- | Execute @f@ for every 'TargetInfo' in the package, respecting the
 -- build dependency order.  (TODO: We should use Shake!)
@@ -290,8 +389,8 @@ withAllTargetsInBuildOrder' pkg_descr lbi f =
 -- Has a prime because it takes a 'PackageDescription' argument
 -- which may disagree with 'localPkgDescr' in 'LocalBuildInfo'.
 neededTargetsInBuildOrder' :: PackageDescription -> LocalBuildInfo -> [UnitId] -> [TargetInfo]
-neededTargetsInBuildOrder' pkg_descr lbi uids =
-  case Graph.closure (componentGraph lbi) uids of
+neededTargetsInBuildOrder' pkg_descr lbi@(LocalBuildInfo{componentGraph}) uids =
+  case Graph.closure componentGraph uids of
     Nothing -> error $ "localBuildPlan: missing uids " ++ intercalate ", " (map prettyShow uids)
     Just clos -> map (mkTargetInfo pkg_descr lbi) (Graph.revTopSort (Graph.fromDistinctList clos))
 
@@ -306,21 +405,21 @@ withNeededTargetsInBuildOrder' pkg_descr lbi uids f =
 -- | Is coverage enabled for test suites? In practice, this requires library
 -- and executable profiling to be enabled.
 testCoverage :: LocalBuildInfo -> Bool
-testCoverage lbi = exeCoverage lbi && libCoverage lbi
+testCoverage (LocalBuildInfo{exeCoverage, libCoverage}) = exeCoverage && libCoverage
 
 -------------------------------------------------------------------------------
 -- Stub functions to prevent someone from accidentally defining them
 
 {-# WARNING componentNameTargets, unitIdTarget, allTargetsInBuildOrder, withAllTargetsInBuildOrder, neededTargetsInBuildOrder, withNeededTargetsInBuildOrder "By using this function, you may be introducing a bug where you retrieve a 'Component' which does not have 'HookedBuildInfo' applied to it.  See the documentation for 'HookedBuildInfo' for an explanation of the issue.  If you have a 'PackageDescription' handy (NOT from the 'LocalBuildInfo'), try using the primed version of the function, which takes it as an extra argument." #-}
 componentNameTargets :: LocalBuildInfo -> ComponentName -> [TargetInfo]
-componentNameTargets lbi = componentNameTargets' (localPkgDescr lbi) lbi
+componentNameTargets lbi@(LocalBuildInfo{localPkgDescr}) = componentNameTargets' localPkgDescr lbi
 unitIdTarget :: LocalBuildInfo -> UnitId -> Maybe TargetInfo
-unitIdTarget lbi = unitIdTarget' (localPkgDescr lbi) lbi
+unitIdTarget lbi@(LocalBuildInfo{localPkgDescr}) = unitIdTarget' localPkgDescr lbi
 allTargetsInBuildOrder :: LocalBuildInfo -> [TargetInfo]
-allTargetsInBuildOrder lbi = allTargetsInBuildOrder' (localPkgDescr lbi) lbi
+allTargetsInBuildOrder lbi@(LocalBuildInfo{localPkgDescr}) = allTargetsInBuildOrder' localPkgDescr lbi
 withAllTargetsInBuildOrder :: LocalBuildInfo -> (TargetInfo -> IO ()) -> IO ()
-withAllTargetsInBuildOrder lbi = withAllTargetsInBuildOrder' (localPkgDescr lbi) lbi
+withAllTargetsInBuildOrder lbi@(LocalBuildInfo{localPkgDescr}) = withAllTargetsInBuildOrder' localPkgDescr lbi
 neededTargetsInBuildOrder :: LocalBuildInfo -> [UnitId] -> [TargetInfo]
-neededTargetsInBuildOrder lbi = neededTargetsInBuildOrder' (localPkgDescr lbi) lbi
+neededTargetsInBuildOrder lbi@(LocalBuildInfo{localPkgDescr}) = neededTargetsInBuildOrder' localPkgDescr lbi
 withNeededTargetsInBuildOrder :: LocalBuildInfo -> [UnitId] -> (TargetInfo -> IO ()) -> IO ()
-withNeededTargetsInBuildOrder lbi = withNeededTargetsInBuildOrder' (localPkgDescr lbi) lbi
+withNeededTargetsInBuildOrder lbi@(LocalBuildInfo{localPkgDescr}) = withNeededTargetsInBuildOrder' localPkgDescr lbi

--- a/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Types used while planning how to build everything in a project.
@@ -103,6 +104,7 @@ import Distribution.Simple.Setup
   )
 import Distribution.System
 import Distribution.Types.ComponentRequestedSpec
+import qualified Distribution.Types.LocalBuildConfig as LBC
 import Distribution.Types.PackageDescription (PackageDescription (..))
 import Distribution.Types.PkgconfigVersion
 import Distribution.Verbosity (normal)
@@ -264,23 +266,7 @@ data ElaboratedConfiguredPackage = ElaboratedConfiguredPackage
   , elabInplaceRegisterPackageDBStack :: PackageDBStack
   , elabPkgDescriptionOverride :: Maybe CabalFileText
   , -- TODO: make per-component variants of these flags
-    elabVanillaLib :: Bool
-  , elabSharedLib :: Bool
-  , elabStaticLib :: Bool
-  , elabDynExe :: Bool
-  , elabFullyStaticExe :: Bool
-  , elabGHCiLib :: Bool
-  , elabProfLib :: Bool
-  , elabProfExe :: Bool
-  , elabProfLibDetail :: ProfDetailLevel
-  , elabProfExeDetail :: ProfDetailLevel
-  , elabCoverage :: Bool
-  , elabOptimization :: OptimisationLevel
-  , elabSplitObjs :: Bool
-  , elabSplitSections :: Bool
-  , elabStripLibs :: Bool
-  , elabStripExes :: Bool
-  , elabDebugInfo :: DebugInfoLevel
+    elabBuildOptions :: LBC.BuildOptions
   , elabDumpBuildInfo :: DumpBuildInfo
   , elabProgramPaths :: Map String FilePath
   , elabProgramArgs :: Map String [String]
@@ -542,7 +528,7 @@ elabDistDirParams shared elab =
         ElabPackage _ -> Nothing
     , distParamCompilerId = compilerId (pkgConfigCompiler shared)
     , distParamPlatform = pkgConfigPlatform shared
-    , distParamOptimization = elabOptimization elab
+    , distParamOptimization = LBC.withOptimization $ elabBuildOptions elab
     }
 
 -- | The full set of dependencies which dictate what order we

--- a/cabal-install/src/Distribution/Client/Run.hs
+++ b/cabal-install/src/Distribution/Client/Run.hs
@@ -32,8 +32,8 @@ import Distribution.Simple.Compiler (CompilerFlavor (..), compilerFlavor)
 import Distribution.Simple.LocalBuildInfo
   ( ComponentName (..)
   , LocalBuildInfo (..)
-  , depLibraryPaths
   , buildDir
+  , depLibraryPaths
   )
 import Distribution.Simple.Utils
   ( addLibraryPath

--- a/cabal-install/src/Distribution/Client/Run.hs
+++ b/cabal-install/src/Distribution/Client/Run.hs
@@ -33,6 +33,7 @@ import Distribution.Simple.LocalBuildInfo
   ( ComponentName (..)
   , LocalBuildInfo (..)
   , depLibraryPaths
+  , buildDir
   )
 import Distribution.Simple.Utils
   ( addLibraryPath


### PR DESCRIPTION
The aim of these commits is to modularise `LocalBuildInfo` to better
reflect implicit invariants.

The top-level split

```haskell
data LocalBuildInfo =
  NewLocalBuildInfo
    { localBuildDescr  :: LocalBuildDescr
    , localBuildConfig :: LocalBuildConfig
    }
```

reflects which part of a `LocalBuildInfo` are set in stone by `Cabal`
(the `LocalBuildDescr`), while `LocalBuildConfig` contains options that
can be controlled/modified by the user in some way.

The split

```haskell
data LocalBuildDescr =
  LocalBuildDescr
  { packageBuildDescr :: PackageBuildDescr
  , componentBuildDescr :: ComponentBuildDescr
  }
```

reflects that some parts of the information determined at configuration
time resides at the package level, while other pieces of information
are pertinent to individual components.

Finally the structure of `LocalBuildConfig` is aimed to reduce code
duplication between the `Cabal` library and `cabal-install`.

These changes to the datatypes then allow us to modularise the configure phase
(i.e. the function `Distribution.Simple.Configure.configure`). The aim of this change
is to make explicit the control flow of the function: it starts off
with a package-wide phase, and then componentwise configuration. Splitting up
the datatypes was necessary in order to reflect the flow of information, as some
parts of the `LocalBuildInfo` are known early on after only package-wide configuration,
while other parts are only discovered once we have done per-component configuration.