### PR TITLE
cabal-install: justify why legacy-fallback is used

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -740,9 +740,13 @@ buildAndInstallUnpackedPackage
 
       dispname :: String
       dispname = case elabPkgOrComp pkg of
-        ElabPackage _ ->
+        -- Packages built altogether, instead of per component
+        ElabPackage ElaboratedPackage{pkgWhyNotPerComponent} ->
           prettyShow pkgid
-            ++ " (all, legacy fallback)"
+            ++ " (all, legacy fallback: "
+            ++ unwords (map whyNotPerComponent $ NE.toList pkgWhyNotPerComponent)
+            ++ ")"
+        -- Packages built per component
         ElabComponent comp ->
           prettyShow pkgid
             ++ " ("


### PR DESCRIPTION
This commit makes it so that cabal-install can explain the reason why it used the legacy fallback, instead of building per-component.