### PR TITLE
Satisfy `-Werror=unused-top-binds`

### DIFF
--- a/Cabal-tests/tests/UnitTests/Distribution/SPDX.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/SPDX.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 module UnitTests.Distribution.SPDX (spdxTests) where
 
@@ -11,14 +10,6 @@ import Distribution.Pretty (prettyShow)
 
 import Test.Tasty
 import Test.Tasty.QuickCheck
-
-#if MIN_VERSION_binary(0,7,0)
-import qualified Data.Binary as Binary
-import qualified Data.Binary.Get as Binary
-import qualified Data.Binary.Put as Binary
-import qualified Data.ByteString.Lazy as LBS
-import GHC.Generics (to, from)
-#endif
 
 import Test.QuickCheck.Instances.Cabal ()
 
@@ -42,29 +33,6 @@ licenseExceptionIdRoundtrip :: LicenseExceptionId -> Property
 licenseExceptionIdRoundtrip x =
     counterexample (prettyShow x) $
     Right x === eitherParsec (prettyShow x)
-
-#if MIN_VERSION_binary(0,7,0)
-licenseExceptionIdBinaryPut :: LicenseExceptionId -> Property
-licenseExceptionIdBinaryPut x =
-    Binary.runPut (Binary.put x)
-    ===
-    Binary.runPut (Binary.gput (from x))
-
-licenseExceptionIdBinaryGet :: Word8 -> Property
-licenseExceptionIdBinaryGet w0 =
-    stripMsg id (Binary.runGetOrFail Binary.get bs)
-    ===
-    stripMsg to (Binary.runGetOrFail Binary.gget bs)
-  where
-    bs = LBS.pack [w0]
-
-    stripMsg
-        :: (a -> LicenseExceptionId)
-        -> Either (x, y, String) (x, y, a)
-        -> Either (x, y) (x, y, LicenseExceptionId)
-    stripMsg _ (Left (x,y,_))  = Left (x,y)
-    stripMsg f (Right (x,y,t)) = Right (x,y,f t)
-#endif
 
 licenseRefRoundtrip :: LicenseRef -> Property
 licenseRefRoundtrip x =

--- a/Cabal-tests/tests/UnitTests/Distribution/Simple/Program/GHC.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Simple/Program/GHC.hs
@@ -191,34 +191,3 @@ options_9_0_affects :: [String]
 options_9_0_affects =
     [ "-fcmm-static-pred"
     ]
-
--------------------------------------------------------------------------------
--- GHC-9.2
--------------------------------------------------------------------------------
-
-options_9_2_all :: [String]
-options_9_2_all =
-    [ "-dynohi"
-    , "-ddump-c-backend"
-    , "-ddump-stg-from-core"
-    , "-ddump-stg"
-    , "-ddump-faststrings"
-    , "--run"
-    , "-ffamily-application-cache"
-    , "-fno-family-application-cache"
-    ] ++ options_9_2_affects
-
-options_9_2_affects :: [String]
-options_9_2_affects =
-    [ "-fprof-callers"
-    , "-funfolding-case-threshold"
-    , "-funfolding-case-scaling"
-    , "-fdistinct-constructor-tables"
-    , "-finfo-table-map"
-    , "-fexpose-internal-symbols"
-    , "-finline-generics"
-    , "-finline-generics-aggressively"
-    , "-fno-expose-internal-symbols"
-    , "-fno-inline-generics"
-    , "-fno-inline-generics-aggressively"
-    ]


### PR DESCRIPTION
Satisfy the build with this (uncommited) change:

```diff
git diff
diff --git a/cabal.project b/cabal.project
index d0b2fbabc..c0695f378 100644
--- a/cabal.project
+++ b/cabal.project
@@ -20,4 +20,4 @@ constraints: rere -rere-cfg
 constraints: these -assoc
 
 program-options
-  ghc-options: -fno-ignore-asserts
+  ghc-options: -fno-ignore-asserts -Werror=unused-top-binds
```
* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

We can pick up the deleted top binds of `Cabal-tests/tests/UnitTests/Distribution/Simple/Program/GHC.hs` in #9435.