### PR TITLE
Add `TypeAbstractions` extension

### DIFF
--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -540,6 +540,8 @@ data KnownExtension
     AlternativeLayoutRuleTransitional
   | -- | Undocumented parsing-related extensions introduced in GHC 7.2.
     RelaxedLayout
+  | -- | Allow the use of type abstraction syntax.
+    TypeAbstractions
   deriving (Generic, Show, Read, Eq, Ord, Enum, Bounded, Typeable, Data)
 
 instance Binary KnownExtension

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -33,15 +33,15 @@ md5Check proxy md5Int = structureHash proxy @?= md5FromInteger md5Int
 md5CheckGenericPackageDescription :: Proxy GenericPackageDescription -> Assertion
 md5CheckGenericPackageDescription proxy = md5Check proxy
 #if MIN_VERSION_base(4,19,0)
-    0xf5fdb32b43aca790192f44d9ecaa9689
+    0x87037bc65fba873f53c03ce572a42229
 #else
-    0xb287a6f04e34ef990cdd15bc6cb01c76
+    0x5817c798e23df281d794ad27754ad43f
 #endif
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
 #if MIN_VERSION_base(4,19,0)
-    0x205fbe2649bc5e488bce50c07a71cadb
+    0x83cb87bceb4c1634e7dda192c3ad6579
 #else
-    0x26e91a71ebd19d4d6ce37f798ede249a
+    0x4beeb42e94807be904bc5d15355c98cd
 #endif

--- a/changelog.d/pr-9502
+++ b/changelog.d/pr-9502
@@ -1,0 +1,11 @@
+synopsis: Add language extension `TypeAbstractions`
+packages: Cabal-syntax
+prs: #9502
+issues: #9496
+
+description: {
+
+- Adds support for the TypeAbstractions language extension.
+
+}
+

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -268,6 +268,7 @@ syn keyword cabalExtension contained
   \ TraditionalRecordSyntax
   \ TransformListComp
   \ TupleSections
+  \ TypeAbstractions
   \ TypeApplications
   \ TypeData
   \ TypeFamilies
@@ -408,6 +409,7 @@ syn keyword cabalExtension contained
   \ NoTraditionalRecordSyntax
   \ NoTransformListComp
   \ NoTupleSections
+  \ NoTypeAbstractions
   \ NoTypeApplications
   \ NoTypeData
   \ NoTypeFamilies


### PR DESCRIPTION
Towards #9496.

If needed, the correct `cabal check` behaviour can be backported to 3.10 *without* adding `| TypeAbstractions` constructor (a breaking change).

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] ~Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)~ We do not write tests on adding extensions.

---

**QA Notes**

1. `mkdir prova && cd prova`
2. `cabal init -nm`
3. add a `default-extensions: TypeAbstractions` in the executable stanza
4. `cabal check` should *not* complain with `unknown-extension` (compare with 3.10 where it does)