### PR TITLE
Make `check` recognise `TypeAbstractions`

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -1193,9 +1193,10 @@ checkFields pkg =
     unknownCompilers  = [ name | (OtherCompiler name, _) <- testedWith pkg ]
     unknownLanguages  = [ name | bi <- allBuildInfo pkg
                                , UnknownLanguage name <- allLanguages bi ]
-    unknownExtensions = [ name | bi <- allBuildInfo pkg
-                               , UnknownExtension name <- allExtensions bi
-                               , name `notElem` map prettyShow knownLanguages ]
+    unknownExtensions = filter (/= "TypeAbstractions")
+                          [ name | bi <- allBuildInfo pkg
+                                 , UnknownExtension name <- allExtensions bi
+                                 , name `notElem` map prettyShow knownLanguages ]
     ourDeprecatedExtensions = nub $ catMaybes
       [ find ((==ext) . fst) deprecatedExtensions
       | bi <- allBuildInfo pkg

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/KnownTypeAbstractions/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/KnownTypeAbstractions/cabal.out
@@ -1,0 +1,2 @@
+# cabal check
+No errors or warnings could be found in the package.

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/KnownTypeAbstractions/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/KnownTypeAbstractions/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+
+-- Uknown extension, exception for TypeAbstractions, see #9496
+main = cabalTest $
+  cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/KnownTypeAbstractions/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/Fields/KnownTypeAbstractions/pkg.cabal
@@ -1,0 +1,13 @@
+cabal-version: 3.0
+name: pkg
+synopsis: synopsis
+description: description
+version: 0
+category: example
+maintainer: none@example.com
+license: GPL-3.0-or-later
+
+library
+  exposed-modules: Module
+  default-language: Haskell2010
+  default-extensions: TypeAbstractions

--- a/changelog.d/pr-9503
+++ b/changelog.d/pr-9503
@@ -1,0 +1,11 @@
+synopsis: Make `check` recognise `TypeAbstractions`
+packages: cabal-install
+prs: #9503
+issues: #9496
+
+description: {
+
+- `cabal check` will not complain about “Unknown extension” when
+  finding `TypeAbstractions`.
+
+}

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -267,6 +267,7 @@ syn keyword cabalExtension contained
   \ TraditionalRecordSyntax
   \ TransformListComp
   \ TupleSections
+  \ TypeAbstractions
   \ TypeApplications
   \ TypeData
   \ TypeFamilies
@@ -405,6 +406,7 @@ syn keyword cabalExtension contained
   \ NoTraditionalRecordSyntax
   \ NoTransformListComp
   \ NoTupleSections
+  \ NoTypeAbstractions
   \ NoTypeApplications
   \ NoTypeFamilies
   \ NoTypeFamilyDependencies


### PR DESCRIPTION
See #9496, backport of #9502.

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**QA notes**

- create a new package
- put `TypeAbstractions` in `default-extensions`
- run `cabal check`
- it should not complain about “Uknown extensions”.