### PR TITLE
testsuite: Refactor withShorterPathForNewBuildStore

### DIFF
--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -22,7 +22,7 @@ source-repository head
 library
   hs-source-dirs: lib
   exposed-modules: Test.Utils.TempTestDir
-  build-depends: base, directory, Cabal, filepath
+  build-depends: base, directory, Cabal, filepath, exceptions
 
 -- Small, fast running tests.
 test-suite unit-tests

--- a/Cabal-tests/tests/UnitTests/Distribution/PackageDescription/Check.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/PackageDescription/Check.hs
@@ -3,7 +3,7 @@
 
 module UnitTests.Distribution.PackageDescription.Check (tests) where
 
-import Distribution.Compat.Prelude.Internal
+import Distribution.Compat.Prelude
 import Prelude ()
 
 import Distribution.PackageDescription.Check

--- a/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-repo.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-repo.test.hs
@@ -1,8 +1,7 @@
 import Test.Cabal.Prelude
-main = withShorterPathForNewBuildStore $ \storeDir ->
-  cabalTest $ do
+main = cabalTest $ withShorterPathForNewBuildStore $ do
     skipUnlessGhcVersion ">= 8.1"
     skipIfWindows -- TODO: https://github.com/haskell/cabal/issues/6271
     withProjectFile "cabal.repo.project" $ do
       withRepo "repo" $ do
-        cabalG ["--store-dir=" ++ storeDir] "v2-build" ["exe"]
+        cabal "v2-build" ["exe"]

--- a/cabal-testsuite/PackageTests/Backpack/T6385/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T6385/cabal.test.hs
@@ -1,7 +1,7 @@
 import Test.Cabal.Prelude
-main = withShorterPathForNewBuildStore $ \storeDir ->
-  cabalTest $ do
+main =
+  cabalTest $ withShorterPathForNewBuildStore $ do
     skipUnlessGhcVersion ">= 8.1"
     skipIfWindows -- TODO: https://github.com/haskell/cabal/issues/6271
     withRepo "repo" $ do
-      cabalG ["--store-dir=" ++ storeDir] "v2-build" ["T6385"]
+      cabal "v2-build" ["T6385"]

--- a/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.test.hs
+++ b/cabal-testsuite/PackageTests/BuildTargets/UseLocalPackageForSetup/use-local-package-as-setup-dep.test.hs
@@ -10,16 +10,16 @@ import Test.Cabal.Prelude
 -- qualifier as pkg, even though they are both build targets of the project.
 -- The solution must use --independent-goals to give pkg and setup-dep different
 -- qualifiers.
-main = withShorterPathForNewBuildStore $ \storeDir ->
-  cabalTest $ do
+main =
+  cabalTest $ withShorterPathForNewBuildStore $ do
     skipUnless "no v2-build compatible boot-Cabal" =<< hasNewBuildCompatBootCabal
     withRepo "repo" $ do
-      fails $ cabalG ["--store-dir=" ++ storeDir] "v2-build" ["pkg:my-exe", "--dry-run"]
+      fails $ cabal "v2-build" ["pkg:my-exe", "--dry-run"]
       -- Disabled recording because whether or not we get
       -- detailed information for the build of my-exe depends
       -- on whether or not the Cabal library version is recent
       -- enough
-      r1 <- recordMode DoNotRecord $ cabalG' ["--store-dir=" ++ storeDir] "v2-build" ["pkg:my-exe", "--independent-goals"]
+      r1 <- recordMode DoNotRecord $ cabal' "v2-build" ["pkg:my-exe", "--independent-goals"]
       assertOutputContains "Setup.hs: setup-dep from project" r1
       withPlan $ do
         r2 <- runPlanExe' "pkg" "my-exe" []

--- a/cabal-testsuite/PackageTests/CopyHie/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/CopyHie/cabal.test.hs
@@ -1,8 +1,7 @@
 import Test.Cabal.Prelude
 
-main = withShorterPathForNewBuildStore $ \storeDir -> cabalTest $ withRepo "repo" $ do
+main = cabalTest $ withShorterPathForNewBuildStore $ withRepo "repo" $ do
   skipUnlessGhcVersion ">= 8.8"
-  cabalG ["--store-dir=" ++ storeDir] "v2-build" ["hie"]
-  liftIO $ do
-    installedDependencyLibDir <- findDependencyInStore storeDir "hie-dependency"
-    shouldExist $ installedDependencyLibDir </> "lib" </> "extra-compilation-artifacts" </> "hie" </> "HieDependency.hie"
+  cabal "v2-build" ["hie"]
+  installedDependencyLibDir <- findDependencyInStore "hie-dependency"
+  shouldExist $ installedDependencyLibDir </> "lib" </> "extra-compilation-artifacts" </> "hie" </> "HieDependency.hie"

--- a/cabal-testsuite/PackageTests/HaddockArgs/hoogle.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockArgs/hoogle.test.hs
@@ -1,10 +1,10 @@
 import Test.Cabal.Prelude
 
-main = withShorterPathForNewBuildStore $ \storeDir -> cabalTest $ withRepo "repo" $ do
+main = cabalTest $ withShorterPathForNewBuildStore $ withRepo "repo" $ do
   -- Checks if hoogle txt files are generated.
   -- Logs contain something like "Documentation created: dist/doc/html/indef/indef.txt", so we don't need
   -- to do extra check
-  cabalG ["--store-dir=" ++ storeDir] "v2-build"
+  cabal "v2-build"
     [ "example"
     , "--enable-documentation"
     , "--haddock-hoogle"

--- a/cabal-testsuite/PackageTests/HaddockArgs/quickjump.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockArgs/quickjump.test.hs
@@ -3,14 +3,13 @@ import Test.Cabal.Prelude
 import System.Directory
 import System.FilePath
 
-main = withShorterPathForNewBuildStore $ \storeDir -> cabalTest $ withRepo "repo" $ do
-  cabalG ["--store-dir=" ++ storeDir] "v2-build"
+main = cabalTest $ withShorterPathForNewBuildStore $ withRepo "repo" $ do
+  cabal "v2-build"
     [ "example"
     , "--enable-documentation"
     , "--haddock-quickjump"
     ]
-  liftIO $ do
-    libDir <- findDependencyInStore storeDir "indef"
-    assertFileDoesContain (libDir </> "cabal-hash.txt") "haddock-quickjump: True"
-    docIndexJsonExists <- doesFileExist (libDir </> "share" </> "doc" </> "html" </> "doc-index.json")
-    assertBool "doc-index.json doesn't exist, --quickjump is probably not passed to haddock" docIndexJsonExists
+  libDir <- findDependencyInStore "indef"
+  assertFileDoesContain (libDir </> "cabal-hash.txt") "haddock-quickjump: True"
+  docIndexJsonExists <- liftIO $ doesFileExist (libDir </> "share" </> "doc" </> "html" </> "doc-index.json")
+  assertBool "doc-index.json doesn't exist, --quickjump is probably not passed to haddock" docIndexJsonExists

--- a/cabal-testsuite/PackageTests/HaddockBuildDepends/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockBuildDepends/cabal.test.hs
@@ -5,17 +5,16 @@ main = cabalTest . withRepo "repo" $ do
     cabal "build" ["--enable-documentation"]
 
     env <- getTestEnv
-    let storeDir = testCabalDir env </> "store"
 
     -- Check properties of executable component
-    libDir <- liftIO $ findDependencyInStore storeDir "exe"
+    libDir <- findDependencyInStore "exe"
     -- Documentation is enabled..
     assertFileDoesContain (libDir </> "cabal-hash.txt") "documentation: True"
     -- But not built
     shouldDirectoryNotExist (  libDir </> "share" </> "doc" )
 
     -- Check properties of library
-    libDir <- liftIO $ findDependencyInStore storeDir "lib"
+    libDir <- findDependencyInStore "lib"
     -- Documentation is enabled..
     assertFileDoesContain (libDir </> "cabal-hash.txt") "documentation: True"
     -- and has been built

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/build-local-package-with-custom-setup.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/LocalPackageWithCustomSetup/build-local-package-with-custom-setup.test.hs
@@ -2,11 +2,10 @@ import Test.Cabal.Prelude
 
 -- The one local package, pkg, has a setup dependency on setup-dep-2.0, which is
 -- in the repository.
-main = withShorterPathForNewBuildStore $ \storeDir ->
-  cabalTest $ do
+main = cabalTest $ withShorterPathForNewBuildStore $ do
     skipUnless "no v2-build compatible boot-Cabal" =<< hasNewBuildCompatBootCabal
     withRepo "repo" $ do
-      r <- recordMode DoNotRecord $ cabalG' ["--store-dir=" ++ storeDir] "v2-build" ["pkg"]
+      r <- recordMode DoNotRecord $ cabal' "v2-build" ["pkg"]
       -- pkg's setup script should print out a message that it imported from
       -- setup-dep:
       assertOutputContains "pkg Setup.hs: setup-dep-2.0" r

--- a/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/build-package-from-repo-with-custom-setup.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CustomSetup/RemotePackageWithCustomSetup/build-package-from-repo-with-custom-setup.test.hs
@@ -2,15 +2,15 @@ import Test.Cabal.Prelude
 
 -- The one local package, pkg, has a dependency on remote-pkg-2.0, which has a
 -- setup dependency on remote-setup-dep-3.0.
-main = withShorterPathForNewBuildStore $ \storeDir ->
-  cabalTest $ do
+main =
+  cabalTest $ withShorterPathForNewBuildStore $ do
 
     -- TODO: Debug this failure on Windows.
     skipIfWindows
 
     skipUnless "no v2-build compatible boot-Cabal" =<< hasNewBuildCompatBootCabal
     withRepo "repo" $ do
-      r1 <- recordMode DoNotRecord $ cabalG' ["--store-dir=" ++ storeDir] "v2-build" ["pkg:my-exe"]
+      r1 <- recordMode DoNotRecord $ cabal' "v2-build" ["pkg:my-exe"]
       -- remote-pkg's setup script should print out a message that it imported from
       -- remote-setup-dep:
       assertOutputContains "remote-pkg Setup.hs: remote-setup-dep-3.0" r1

--- a/cabal-testsuite/PackageTests/NewBuild/T4375/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/T4375/cabal.test.hs
@@ -1,7 +1,7 @@
 import Test.Cabal.Prelude
-main = withShorterPathForNewBuildStore $ \storeDir ->
+main =
   -- TODO: is this test ever run?
-  cabalTest $ do
+  cabalTest $ withShorterPathForNewBuildStore $ do
     -- Don't run this test unless the GHC is sufficiently recent
     -- to not ship boot old-time/old-locale
     skipUnlessGhcVersion ">= 7.11"
@@ -10,4 +10,4 @@ main = withShorterPathForNewBuildStore $ \storeDir ->
     -- we had the full Hackage index, we'd try it.)
     skipUnlessGhcVersion "< 8.1"
     withRepo "repo" $ do
-        cabalG ["--store-dir=" ++ storeDir] "v2-build" ["a"]
+        cabal "v2-build" ["a"]

--- a/cabal-testsuite/PackageTests/NewConfigure/ConfigFile/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewConfigure/ConfigFile/cabal.test.hs
@@ -1,18 +1,18 @@
 import Test.Cabal.Prelude
 
 -- Test that 'cabal v2-configure' generates the config file appropriately
-main = withShorterPathForNewBuildStore $ \storeDir ->
-  cabalTest $ do
+main =
+  cabalTest . withShorterPathForNewBuildStore $ do
     cwd <- fmap testCurrentDir getTestEnv
     let configFile = cwd </> "cabal.project.local"
 
     shouldNotExist configFile
 
     -- should not create config file with --dry-run or --only-download
-    cabalG ["--store-dir=" ++ storeDir] "v2-configure" ["--dry-run"]
-    cabalG ["--store-dir=" ++ storeDir] "v2-configure" ["--only-download"]
+    cabal "v2-configure" ["--dry-run"]
+    cabal "v2-configure" ["--only-download"]
     shouldNotExist configFile
 
     -- should create the config file
-    cabalG ["--store-dir=" ++ storeDir] "v2-configure" []
+    cabal "v2-configure" []
     shouldExist configFile

--- a/cabal-testsuite/PackageTests/NewFreeze/FreezeFile/new_freeze.test.hs
+++ b/cabal-testsuite/PackageTests/NewFreeze/FreezeFile/new_freeze.test.hs
@@ -5,8 +5,8 @@ import System.Directory
 
 -- Test for 'cabal v2-freeze' with only a single library dependency.
 -- my-local-package depends on my-library-dep, which has versions 1.0 and 2.0.
-main = withShorterPathForNewBuildStore $ \storeDir ->
-  cabalTest $
+main =
+  cabalTest $ withShorterPathForNewBuildStore $
     withRepo "repo" $ do
       cwd <- fmap testCurrentDir getTestEnv
       let freezeFile = cwd </> "cabal.project.freeze"
@@ -14,15 +14,15 @@ main = withShorterPathForNewBuildStore $ \storeDir ->
       shouldNotExist freezeFile
 
       -- v2-build should choose the latest version for the dependency.
-      cabalG' ["--store-dir=" ++ storeDir] "v2-build" ["--dry-run"] >>= assertUsesLatestDependency
+      cabal' "v2-build" ["--dry-run"] >>= assertUsesLatestDependency
 
       -- should not create freeze file with --dry-run or --only-download flags
-      cabalG' ["--store-dir=" ++ storeDir] "v2-freeze" ["--dry-run"]
-      cabalG' ["--store-dir=" ++ storeDir] "v2-freeze" ["--only-download"]
+      cabal' "v2-freeze" ["--dry-run"]
+      cabal' "v2-freeze" ["--only-download"]
       shouldNotExist freezeFile
 
       -- Freeze a dependency on the older version.
-      cabalG ["--store-dir=" ++ storeDir] "v2-freeze" ["--constraint=my-library-dep==1.0"]
+      cabal "v2-freeze" ["--constraint=my-library-dep==1.0"]
 
       -- The file should constrain the dependency, but not the local package.
       shouldExist freezeFile
@@ -31,21 +31,21 @@ main = withShorterPathForNewBuildStore $ \storeDir ->
 
       -- cabal should be able to build the package using the constraint from the
       -- freeze file.
-      cabalG' ["--store-dir=" ++ storeDir] "v2-build" [] >>= assertDoesNotUseLatestDependency
+      cabal' "v2-build" [] >>= assertDoesNotUseLatestDependency
 
       -- Re-running v2-freeze should not change the constraints, because cabal
       -- should use the existing freeze file when choosing the new install plan.
-      cabalG ["--store-dir=" ++ storeDir] "v2-freeze" []
+      cabal "v2-freeze" []
       assertFileDoesContain freezeFile "any.my-library-dep ==1.0"
 
       -- cabal should choose the latest version again after the freeze file is
       -- removed.
       liftIO $ removeFile freezeFile
-      cabalG' ["--store-dir=" ++ storeDir] "v2-build" ["--dry-run"] >>= assertUsesLatestDependency
+      cabal' "v2-build" ["--dry-run"] >>= assertUsesLatestDependency
 
       -- Re-running v2-freeze with no constraints or freeze file should constrain
       -- the dependency to the latest version.
-      cabalG ["--store-dir=" ++ storeDir] "v2-freeze" []
+      cabal "v2-freeze" []
       assertFileDoesContain freezeFile "any.my-library-dep ==2.0"
       assertFileDoesNotContain freezeFile "my-local-package"
     where

--- a/cabal-testsuite/PackageTests/OfflineFlag/offlineFlag.test.hs
+++ b/cabal-testsuite/PackageTests/OfflineFlag/offlineFlag.test.hs
@@ -1,11 +1,11 @@
 import Test.Cabal.Prelude
 
-main = withShorterPathForNewBuildStore $ \storeDir ->
-  cabalTest $ do
+main =
+  cabalTest $ withShorterPathForNewBuildStore $ do
     skipUnlessGhcVersion ">= 8.1"
     skipIfWindows
     withProjectFile "cabal.repo.project" $ do
       withRepo "repo" $ do
-        fails $ cabalG ["--store-dir=" ++ storeDir] "v2-build" ["current", "--offline"]
-        cabalG ["--store-dir=" ++ storeDir] "v2-build" ["current"]
-        cabalG ["--store-dir=" ++ storeDir] "v2-build" ["current", "--offline"]
+        fails $ cabal "v2-build" ["current", "--offline"]
+        cabal "v2-build" ["current"]
+        cabal "v2-build" ["current", "--offline"]

--- a/cabal-testsuite/PackageTests/Regression/T5409/use-different-versions-of-dependency-for-library-and-build-tool.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5409/use-different-versions-of-dependency-for-library-and-build-tool.test.hs
@@ -10,12 +10,11 @@ import Test.Cabal.Prelude
 -- Issue #5409 caused v2-build to use the same instance of build-tool-pkg for
 -- the build-depends and build-tool-depends dependencies, even though it
 -- violated the version constraints.
-main = withShorterPathForNewBuildStore $ \storeDir ->
-  cabalTest $ do
+main = cabalTest $ withShorterPathForNewBuildStore $ do
     skipUnless "not v2-build compatible boot Cabal" =<< hasNewBuildCompatBootCabal
     withRepo "repo" $ do
       r1 <- recordMode DoNotRecord $
-            cabalG' ["--store-dir=" ++ storeDir] "v2-build" ["pkg:my-exe"]
+            cabal' "v2-build" ["pkg:my-exe"]
 
       let msg = concat
               [ "In order, the following will be built:"

--- a/cabal-testsuite/PackageTests/Regression/T5782Diamond/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T5782Diamond/cabal.test.hs
@@ -20,25 +20,27 @@
 -- as failed compilation or wrong exe output, which I do check.
 
 import Test.Cabal.Prelude
-main = withShorterPathForNewBuildStore $ \storeDir ->
-  cabalTest $ withDelay $ do
+main =
+  cabalTest $ withShorterPathForNewBuildStore .
+    withDelay $ do
+        storeDir <- testStoreDir <$> getTestEnv
         writeSourceFile "issue5782/src/Module.hs" "module Module where\nf = \"AAA\""
         recordMode DoNotRecord $
-          cabalG ["--store-dir=" ++ storeDir, "--installdir=" ++ storeDir, "--overwrite-policy=always"] "v2-install" ["issue5782"]
+          cabalG ["--installdir=" ++ storeDir, "--overwrite-policy=always"] "v2-install" ["issue5782"]
         withPlan $
             runPlanExe' "issue5782" "E" []
                 >>= assertOutputContains "AAA"
         delay
         writeSourceFile "issue5782/src/Module.hs" "module Module where\nf = \"BBB\""
         recordMode DoNotRecord $
-          cabalG ["--store-dir=" ++ storeDir, "--installdir=" ++ storeDir, "--overwrite-policy=always"] "v2-install" ["issue5782"]
+          cabalG ["--installdir=" ++ storeDir, "--overwrite-policy=always"] "v2-install" ["issue5782"]
         withPlan $
             runPlanExe' "issue5782" "E" []
                 >>= assertOutputContains "BBB"
         writeSourceFile "issue5782/src/Module.hs" "module Module where\nf = \"CCC\""
         delay  -- different spot to try another scenario
         recordMode DoNotRecord $
-          cabalG ["--store-dir=" ++ storeDir, "--installdir=" ++ storeDir, "--overwrite-policy=always"] "v2-install" ["issue5782"]
+          cabalG ["--installdir=" ++ storeDir, "--overwrite-policy=always"] "v2-install" ["issue5782"]
         withPlan $
             runPlanExe' "issue5782" "E" []
                 >>= assertOutputContains "CCC"

--- a/cabal-testsuite/PackageTests/WarnEarlyOverwrite/clean-install-by-copy.test.hs
+++ b/cabal-testsuite/PackageTests/WarnEarlyOverwrite/clean-install-by-copy.test.hs
@@ -1,7 +1,8 @@
 import Test.Cabal.Prelude
 
-main = withShorterPathForNewBuildStore $ \storeDir -> cabalTest $ do
-    let options = ["--store-dir=" ++ storeDir, "--installdir=" ++ storeDir]
+main = cabalTest $ withShorterPathForNewBuildStore $ do
+    storeDir <- testStoreDir <$> getTestEnv
+    let options = ["--installdir=" ++ storeDir]
     -- Use install method copy that should surely work on Windows too but our
     -- path normalization for testing is not good enough yet as can be seen in
     -- this CI failure snippet diff:

--- a/cabal-testsuite/PackageTests/WarnEarlyOverwrite/clean-install-by-symlink.test.hs
+++ b/cabal-testsuite/PackageTests/WarnEarlyOverwrite/clean-install-by-symlink.test.hs
@@ -1,7 +1,8 @@
 import Test.Cabal.Prelude
 
-main = withShorterPathForNewBuildStore $ \storeDir -> cabalTest $ do
+main = cabalTest $ withShorterPathForNewBuildStore $ do
+    storeDir <- testStoreDir <$> getTestEnv
     -- The default install method is symlink that may not work on Windows.
     skipIfWindows
-    let options = ["--store-dir=" ++ storeDir, "--installdir=" ++ storeDir]
+    let options = ["--installdir=" ++ storeDir]
     cabalG options "v2-install" []

--- a/cabal-testsuite/PackageTests/WarnEarlyOverwrite/dirty-install.test.hs
+++ b/cabal-testsuite/PackageTests/WarnEarlyOverwrite/dirty-install.test.hs
@@ -2,11 +2,13 @@ import Test.Cabal.Prelude
 
 import System.FilePath
 
-main = withShorterPathForNewBuildStore $ \storeDir -> cabalTest $ do
+main = cabalTest $ withShorterPathForNewBuildStore $ do
+
+    storeDir <- testStoreDir <$> getTestEnv
     -- Windows does not natively include a touch command.
     -- SEE: https://stackoverflow.com/questions/30011267/create-an-empty-file-on-the-commandline-in-windows-like-the-linux-touch-command
     skipIfWindows
-    let options = ["--store-dir=" ++ storeDir, "--installdir=" ++ storeDir]
+    let options = ["--installdir=" ++ storeDir]
     -- Touch the target to see if the warning is made early before the build.
     _ <- runM "touch" [storeDir </> "warn-early-overwrite"] Nothing
     fails $ cabalG options "v2-install" []

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -40,6 +40,7 @@ module Test.Cabal.Monad (
     testKeysDir,
     testSourceCopyDir,
     testCabalDir,
+    testStoreDir,
     testUserCabalConfigFile,
     testActualFile,
     -- * Skipping tests
@@ -353,7 +354,8 @@ runTestM mode m =
                     testCabalProjectFile = Nothing,
                     testPlan = Nothing,
                     testRecordDefaultMode = DoNotRecord,
-                    testRecordUserMode = Nothing
+                    testRecordUserMode = Nothing,
+                    testMaybeStoreDir = Nothing
                 }
     let go = do cleanup
                 r <- withSourceCopy m
@@ -620,6 +622,7 @@ data TestEnv = TestEnv
       testSourceDir     :: FilePath
     -- | Somewhere to stow temporary files needed by the test.
     , testTmpDir        :: FilePath
+
     -- | Test sub-name, used to qualify dist/database directory to avoid
     -- conflicts.
     , testSubName       :: String
@@ -678,6 +681,8 @@ data TestEnv = TestEnv
     , testRecordDefaultMode :: RecordMode
     -- | User explicitly set record mode.  Not implemented ATM.
     , testRecordUserMode :: Maybe RecordMode
+    -- | Path to the storedir used by the test, if not the default
+    , testMaybeStoreDir      :: Maybe FilePath
     }
     deriving Show
 
@@ -752,6 +757,11 @@ testSourceCopyDir env = testTmpDir env
 -- | The user cabal directory
 testCabalDir :: TestEnv -> FilePath
 testCabalDir env = testHomeDir env </> ".cabal"
+
+testStoreDir :: TestEnv -> FilePath
+testStoreDir env = case testMaybeStoreDir env of
+                      Just dir -> dir
+                      Nothing -> testCabalDir env </> "store"
 
 -- | The user cabal config file
 testUserCabalConfigFile :: TestEnv -> FilePath

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -111,6 +111,10 @@ withDirectory :: FilePath -> TestM a -> TestM a
 withDirectory f = withReaderT
     (\env -> env { testRelativeCurrentDir = testRelativeCurrentDir env </> f })
 
+withStoreDir :: FilePath -> TestM a -> TestM a
+withStoreDir fp =
+  withReaderT (\env -> env { testMaybeStoreDir = Just fp })
+
 -- We append to the environment list, as per 'getEffectiveEnvironment'
 -- which prefers the latest override.
 withEnv :: [(String, Maybe String)] -> TestM a -> TestM a
@@ -330,7 +334,11 @@ cabalGArgs global_args cmd args input = do
           | cmd == "v1-install" || cmd == "v1-build" = [ "-j1" ]
           | otherwise                                = []
 
-        cabal_args = global_args
+        global_args' =
+            [ "--store-dir=" ++ storeDir | Just storeDir <- [testMaybeStoreDir env] ]
+            ++ global_args
+
+        cabal_args = global_args'
                   ++ [ cmd, marked_verbose ]
                   ++ extra_args
                   ++ args
@@ -1088,26 +1096,27 @@ copySourceFileTo src dest = do
 -- limit) by creating a temporary directory for the new-build store. This
 -- function creates a directory immediately under the current drive on Windows.
 -- The directory must be passed to new- commands with --store-dir.
-withShorterPathForNewBuildStore :: (FilePath -> IO a) -> IO a
+withShorterPathForNewBuildStore :: TestM a -> TestM a
 withShorterPathForNewBuildStore test =
-  withTestDir normal "cabal-test-store" test
+  withTestDir normal "cabal-test-store" (\f -> withStoreDir f test)
 
 -- | Find where a package locates in the store dir. This works only if there is exactly one 1 ghc version
 -- and exactly 1 directory for the given package in the store dir.
-findDependencyInStore :: FilePath -- ^store dir
-                      -> String -- ^package name prefix
-                      -> IO FilePath -- ^package dir
-findDependencyInStore storeDir pkgName = do
-    (storeDirForGhcVersion : _) <- listDirectory storeDir
-    packageDirs <- listDirectory (storeDir </> storeDirForGhcVersion)
-    -- Ideally, we should call 'hashedInstalledPackageId' from 'Distribution.Client.PackageHash'.
-    -- But 'PackageHashInputs', especially 'PackageHashConfigInputs', is too hard to construct.
-    let pkgName' =
-            if buildOS == OSX
-            then filter (not . flip elem "aeiou") pkgName
-                -- simulates the way 'hashedInstalledPackageId' uses to compress package name
-            else pkgName
-    let libDir = case filter (pkgName' `isPrefixOf`) packageDirs of
-                    [] -> error $ "Could not find " <> pkgName' <> " when searching for " <> pkgName' <> " in\n" <> show packageDirs
-                    (dir:_) -> dir
-    pure (storeDir </> storeDirForGhcVersion </> libDir)
+findDependencyInStore :: String -- ^package name prefix
+                      -> TestM FilePath -- ^package dir
+findDependencyInStore pkgName = do
+    storeDir <- testStoreDir <$> getTestEnv
+    liftIO $ do
+      storeDirForGhcVersion:_ <- listDirectory storeDir
+      packageDirs <- listDirectory (storeDir </> storeDirForGhcVersion)
+      -- Ideally, we should call 'hashedInstalledPackageId' from 'Distribution.Client.PackageHash'.
+      -- But 'PackageHashInputs', especially 'PackageHashConfigInputs', is too hard to construct.
+      let pkgName' =
+              if buildOS == OSX
+              then filter (not . flip elem "aeiou") pkgName
+                  -- simulates the way 'hashedInstalledPackageId' uses to compress package name
+              else pkgName
+      let libDir = case filter (pkgName' `isPrefixOf`) packageDirs of
+                      [] -> error $ "Could not find " <> pkgName' <> " when searching for " <> pkgName' <> " in\n" <> show packageDirs
+                      (dir:_) -> dir
+      pure (storeDir </> storeDirForGhcVersion </> libDir)


### PR DESCRIPTION
This makes `withShorterPathForNewBuildStore` fit more nicely into the rest of the testing infrastructure.

* Move `withShorterPathForNewBuildStore` to `TestM` monad
* Move responsibility for passing `--store-dir` to `cabalGArgs` function
* Move `findDependencyInStore` into `TestM`, and remove requirement to pass path to store directory.
* Introduce `testStoreDir` function which returns the store location (and honours `withShorterPathForNewBuildStore`)
* Migrate tests which use `withShorterPathForNewBuildStore`.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.
