### PR TITLE
Override imported package version equalities

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Modular.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular.hs
@@ -66,7 +66,7 @@ modularResolver sc (Platform arch os) cinfo iidx sidx pkgConfigDB pprefs pcs pns
       -- Indices have to be converted into solver-specific uniform index.
       idx    = convPIs os arch cinfo gcs (shadowPkgs sc) (strongFlags sc) (solveExecutables sc) iidx sidx
       -- Constraints have to be converted into a finite map indexed by PN.
-      gcs    = M.fromListWith (++) (map pair $ traceShowId pcs)
+      gcs    = M.fromListWith (++) (map pair pcs)
         where
           pair lpc = (pcName $ unlabelPackageConstraint lpc, [lpc])
 

--- a/cabal-install-solver/src/Distribution/Solver/Modular.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular.hs
@@ -66,7 +66,7 @@ modularResolver sc (Platform arch os) cinfo iidx sidx pkgConfigDB pprefs pcs pns
       -- Indices have to be converted into solver-specific uniform index.
       idx    = convPIs os arch cinfo gcs (shadowPkgs sc) (strongFlags sc) (solveExecutables sc) iidx sidx
       -- Constraints have to be converted into a finite map indexed by PN.
-      gcs    = M.fromListWith (++) (map pair pcs)
+      gcs    = M.fromListWith (++) (map pair $ traceShowId pcs)
         where
           pair lpc = (pcName $ unlabelPackageConstraint lpc, [lpc])
 

--- a/cabal-install-solver/src/Distribution/Solver/Modular.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Distribution.Solver.Modular
          ( modularResolver, SolverConfig(..), PruneAfterFirstSuccess(..) ) where
@@ -122,14 +121,14 @@ solve' :: SolverConfig
        -> Map PN [LabeledPackageConstraint]
        -> Set PN
        -> Progress String String (Assignment, RevDepMap)
-solve' sc cinfo idx pkgConfigDB pprefs (fmap weedLabeledPackageConstraints -> gcs) pns =
+solve' sc cinfo idx pkgConfigDB pprefs gcs pns =
     toProgress $ retry (runSolver printFullLog sc) createErrorMsg
   where
     runSolver :: Bool -> SolverConfig
               -> RetryLog String SolverFailure (Assignment, RevDepMap)
     runSolver keepLog sc' =
         displayLogMessages keepLog $
-        solve sc' cinfo idx pkgConfigDB pprefs gcs pns
+        solve sc' cinfo idx pkgConfigDB pprefs (weedLabeledPackageConstraints <$> gcs) pns
 
     createErrorMsg :: SolverFailure
                    -> RetryLog String String (Assignment, RevDepMap)

--- a/cabal-install-solver/src/Distribution/Solver/Modular.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Distribution.Solver.Modular
          ( modularResolver, SolverConfig(..), PruneAfterFirstSuccess(..) ) where
@@ -121,7 +122,7 @@ solve' :: SolverConfig
        -> Map PN [LabeledPackageConstraint]
        -> Set PN
        -> Progress String String (Assignment, RevDepMap)
-solve' sc cinfo idx pkgConfigDB pprefs gcs pns =
+solve' sc cinfo idx pkgConfigDB pprefs (fmap weedLabeledPackageConstraints -> gcs) pns =
     toProgress $ retry (runSolver printFullLog sc) createErrorMsg
   where
     runSolver :: Bool -> SolverConfig

--- a/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Distribution.Solver.Types.ConstraintSource
     ( ConstraintSource(..)
-    , ProjectConfigImport(..)
+    , ProjectConfigImport
     , showConstraintSource
+    , mkProjectConfigImport
+    , setProjectImportDepth
+    , getProjectImportPath
     ) where
 
 import Distribution.Solver.Compat.Prelude
@@ -10,13 +13,22 @@ import Prelude ()
 
 data ProjectConfigImport =
   ProjectConfigImport
-    { importDepth :: Int
+    { importDepth :: [(String, Int)]
     , importPath :: FilePath
     }
     deriving (Eq, Show, Generic)
 
 instance Binary ProjectConfigImport
 instance Structured ProjectConfigImport
+
+mkProjectConfigImport :: String -> FilePath -> ProjectConfigImport
+mkProjectConfigImport tag = ProjectConfigImport [(tag, 0)]
+
+setProjectImportDepth :: String -> Int -> ProjectConfigImport -> ProjectConfigImport
+setProjectImportDepth tag depth pci = pci { importDepth = (tag, depth) : importDepth pci }
+
+getProjectImportPath :: ProjectConfigImport -> FilePath
+getProjectImportPath = importPath
 
 -- | Source of a 'PackageConstraint'.
 data ConstraintSource =

--- a/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
@@ -1,12 +1,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Distribution.Solver.Types.ConstraintSource
     ( ConstraintSource(..)
-    , ProjectConfigImport
+    , ProjectConfigImport(..)
     , showConstraintSource
-    , mkProjectConfigImport
-    , setProjectImportDepth
-    , getProjectImportDepth
-    , getProjectImportPath
     ) where
 
 import Distribution.Solver.Compat.Prelude
@@ -24,18 +20,6 @@ data ProjectConfigImport =
 
 instance Binary ProjectConfigImport
 instance Structured ProjectConfigImport
-
-mkProjectConfigImport :: FilePath -> ProjectConfigImport
-mkProjectConfigImport = ProjectConfigImport 0
-
-setProjectImportDepth :: Int -> ProjectConfigImport -> ProjectConfigImport
-setProjectImportDepth depth pci = pci { importDepth = depth }
-
-getProjectImportDepth :: ProjectConfigImport -> Int
-getProjectImportDepth pci = importDepth pci
-
-getProjectImportPath :: ProjectConfigImport -> FilePath
-getProjectImportPath = importPath
 
 -- | Source of a 'PackageConstraint'.
 data ConstraintSource =

--- a/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
@@ -14,8 +14,11 @@ import Prelude ()
 
 data ProjectConfigImport =
   ProjectConfigImport
-    { importDepth :: [Int]
+    { importDepth :: Int
+    -- ^ Depth of the import. The main project config file has depth 0, and each
+    -- import increases the depth by 1.
     , importPath :: FilePath
+    -- ^ Path to the imported file contributing to the project config.
     }
     deriving (Eq, Show, Generic)
 
@@ -23,15 +26,13 @@ instance Binary ProjectConfigImport
 instance Structured ProjectConfigImport
 
 mkProjectConfigImport :: FilePath -> ProjectConfigImport
-mkProjectConfigImport = ProjectConfigImport []
+mkProjectConfigImport = ProjectConfigImport 0
 
 setProjectImportDepth :: Int -> ProjectConfigImport -> ProjectConfigImport
-setProjectImportDepth depth pci = pci { importDepth = depth : importDepth pci }
+setProjectImportDepth depth pci = pci { importDepth = depth }
 
 getProjectImportDepth :: ProjectConfigImport -> Int
-getProjectImportDepth pci = case importDepth pci of
-    [] -> maxBound
-    depth : _ -> depth
+getProjectImportDepth pci = importDepth pci
 
 getProjectImportPath :: ProjectConfigImport -> FilePath
 getProjectImportPath = importPath

--- a/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
@@ -5,6 +5,7 @@ module Distribution.Solver.Types.ConstraintSource
     , showConstraintSource
     , mkProjectConfigImport
     , setProjectImportDepth
+    , getProjectImportDepth
     , getProjectImportPath
     ) where
 
@@ -26,6 +27,11 @@ mkProjectConfigImport tag = ProjectConfigImport [(tag, 0)]
 
 setProjectImportDepth :: String -> Int -> ProjectConfigImport -> ProjectConfigImport
 setProjectImportDepth tag depth pci = pci { importDepth = (tag, depth) : importDepth pci }
+
+getProjectImportDepth :: ProjectConfigImport -> Int
+getProjectImportDepth pci = case importDepth pci of
+    [] -> maxBound
+    (_, depth) : _ -> depth
 
 getProjectImportPath :: ProjectConfigImport -> FilePath
 getProjectImportPath = importPath

--- a/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
@@ -1,11 +1,22 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Distribution.Solver.Types.ConstraintSource
     ( ConstraintSource(..)
+    , ProjectConfigImport(..)
     , showConstraintSource
     ) where
 
 import Distribution.Solver.Compat.Prelude
 import Prelude ()
+
+data ProjectConfigImport =
+  ProjectConfigImport
+    { importDepth :: Int
+    , importPath :: FilePath
+    }
+    deriving (Eq, Show, Generic)
+
+instance Binary ProjectConfigImport
+instance Structured ProjectConfigImport
 
 -- | Source of a 'PackageConstraint'.
 data ConstraintSource =
@@ -14,7 +25,7 @@ data ConstraintSource =
   ConstraintSourceMainConfig FilePath
 
   -- | Local cabal.project file
-  | ConstraintSourceProjectConfig FilePath
+  | ConstraintSourceProjectConfig ProjectConfigImport
 
   -- | User config file, which is ./cabal.config by default.
   | ConstraintSourceUserConfig FilePath
@@ -59,8 +70,8 @@ instance Structured ConstraintSource
 showConstraintSource :: ConstraintSource -> String
 showConstraintSource (ConstraintSourceMainConfig path) =
     "main config " ++ path
-showConstraintSource (ConstraintSourceProjectConfig path) =
-    "project config " ++ path
+showConstraintSource (ConstraintSourceProjectConfig projectConfig) =
+    "project config " ++ show projectConfig
 showConstraintSource (ConstraintSourceUserConfig path)= "user config " ++ path
 showConstraintSource ConstraintSourceCommandlineFlag = "command line flag"
 showConstraintSource ConstraintSourceUserTarget = "user target"

--- a/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
@@ -14,7 +14,7 @@ import Prelude ()
 
 data ProjectConfigImport =
   ProjectConfigImport
-    { importDepth :: [(String, Int)]
+    { importDepth :: [Int]
     , importPath :: FilePath
     }
     deriving (Eq, Show, Generic)
@@ -22,16 +22,16 @@ data ProjectConfigImport =
 instance Binary ProjectConfigImport
 instance Structured ProjectConfigImport
 
-mkProjectConfigImport :: String -> FilePath -> ProjectConfigImport
-mkProjectConfigImport tag = ProjectConfigImport [(tag, 0)]
+mkProjectConfigImport :: FilePath -> ProjectConfigImport
+mkProjectConfigImport = ProjectConfigImport []
 
-setProjectImportDepth :: String -> Int -> ProjectConfigImport -> ProjectConfigImport
-setProjectImportDepth tag depth pci = pci { importDepth = (tag, depth) : importDepth pci }
+setProjectImportDepth :: Int -> ProjectConfigImport -> ProjectConfigImport
+setProjectImportDepth depth pci = pci { importDepth = depth : importDepth pci }
 
 getProjectImportDepth :: ProjectConfigImport -> Int
 getProjectImportDepth pci = case importDepth pci of
     [] -> maxBound
-    (_, depth) : _ -> depth
+    depth : _ -> depth
 
 getProjectImportPath :: ProjectConfigImport -> FilePath
 getProjectImportPath = importPath

--- a/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
@@ -38,7 +38,7 @@ weedLabeledPackageConstraints :: [LabeledPackageConstraint] -> [LabeledPackageCo
 weedLabeledPackageConstraints =
     -- Partition into ConstraintSourceProjectConfig and rest, pick one of former.
     (\(xs, ys) -> take 1 (sortBy (comparing (\(LabeledPackageConstraint _ src) -> case src of
-        ConstraintSourceProjectConfig pci -> getProjectImportDepth pci
+        ConstraintSourceProjectConfig pci -> importDepth pci
         _ -> maxBound)) xs) ++ ys
     )
     . partition (\(LabeledPackageConstraint _ src) -> case src of

--- a/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
@@ -13,7 +13,6 @@ import Distribution.Compat.Prelude
 import Prelude ()
 import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.PackageConstraint
-import Distribution.Types.PackageName
 import Distribution.Types.VersionRange
 import qualified Data.Map.Strict as Map
 import Data.List (groupBy)
@@ -21,21 +20,6 @@ import Data.List (groupBy)
 -- | 'PackageConstraint' labeled with its source.
 data LabeledPackageConstraint
    = LabeledPackageConstraint PackageConstraint ConstraintSource
-
-instance {-# INCOHERENT #-} Show [LabeledPackageConstraint] where
-    show [] = ""
-    show xs = intercalate "\n" $
-        filter (/= "") (showLabeledPackageConstraint <$> xs)
-
-instance Show LabeledPackageConstraint where
-    show = showLabeledPackageConstraint
-
-showLabeledPackageConstraint :: LabeledPackageConstraint -> String
-showLabeledPackageConstraint (LabeledPackageConstraint pc@(PackageConstraint scope _) src@ConstraintSourceProjectConfig{}) =
-    if unPackageName (scopeToPackageName scope) == "hashable"
-        then "SOURCE: " ++ showConstraintSource src ++ ", CONSTRAINT: " ++ show pc
-        else ""
-showLabeledPackageConstraint _ = ""
 
 unlabelPackageConstraint :: LabeledPackageConstraint -> PackageConstraint
 unlabelPackageConstraint (LabeledPackageConstraint pc _) = pc

--- a/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
@@ -3,6 +3,7 @@
 module Distribution.Solver.Types.LabeledPackageConstraint
     ( LabeledPackageConstraint(..)
     , unlabelPackageConstraint
+    , weedLabeledPackageConstraints
     ) where
 
 import Distribution.Compat.Prelude
@@ -32,3 +33,9 @@ showLabeledPackageConstraint _ = ""
 
 unlabelPackageConstraint :: LabeledPackageConstraint -> PackageConstraint
 unlabelPackageConstraint (LabeledPackageConstraint pc _) = pc
+
+weedLabeledPackageConstraints :: [LabeledPackageConstraint] -> [LabeledPackageConstraint]
+weedLabeledPackageConstraints =
+    take 1 .
+    sortBy (comparing (\(LabeledPackageConstraint _ src) ->
+        showConstraintSource src))

--- a/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
@@ -36,6 +36,11 @@ unlabelPackageConstraint (LabeledPackageConstraint pc _) = pc
 
 weedLabeledPackageConstraints :: [LabeledPackageConstraint] -> [LabeledPackageConstraint]
 weedLabeledPackageConstraints =
-    take 1 .
-    sortBy (comparing (\(LabeledPackageConstraint _ src) ->
-        showConstraintSource src))
+    -- Partition into ConstraintSourceProjectConfig and rest, pick one of former.
+    (\(xs, ys) -> take 1 (sortBy (comparing (\(LabeledPackageConstraint _ src) -> case src of
+        ConstraintSourceProjectConfig pci -> getProjectImportDepth pci
+        _ -> maxBound)) xs) ++ ys
+    )
+    . partition (\(LabeledPackageConstraint _ src) -> case src of
+            ConstraintSourceProjectConfig{} -> True
+            _ -> False)

--- a/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE FlexibleInstances #-}
+
 module Distribution.Solver.Types.LabeledPackageConstraint
     ( LabeledPackageConstraint(..)
     , unlabelPackageConstraint
     ) where
 
+import Distribution.Compat.Prelude
+import Prelude ()
 import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.PackageConstraint
 import Distribution.Types.PackageName
@@ -11,12 +15,20 @@ import Distribution.Types.PackageName
 data LabeledPackageConstraint
    = LabeledPackageConstraint PackageConstraint ConstraintSource
 
+instance {-# INCOHERENT #-} Show [LabeledPackageConstraint] where
+    show [] = ""
+    show xs = intercalate "\n" $
+        filter (/= "") (showLabeledPackageConstraint <$> xs)
+
 instance Show LabeledPackageConstraint where
-    show (LabeledPackageConstraint pc@(PackageConstraint scope _) src@ConstraintSourceProjectConfig{}) =
-        if unPackageName (scopeToPackageName scope) == "hashable"
-            then "SOURCE: " ++ showConstraintSource src ++ ", CONSTRAINT: " ++ show pc ++ "\n"
-            else "\n"
-    show LabeledPackageConstraint{} = "\n"
+    show = showLabeledPackageConstraint
+
+showLabeledPackageConstraint :: LabeledPackageConstraint -> String
+showLabeledPackageConstraint (LabeledPackageConstraint pc@(PackageConstraint scope _) src@ConstraintSourceProjectConfig{}) =
+    if unPackageName (scopeToPackageName scope) == "hashable"
+        then "SOURCE: " ++ showConstraintSource src ++ ", CONSTRAINT: " ++ show pc
+        else ""
+showLabeledPackageConstraint _ = ""
 
 unlabelPackageConstraint :: LabeledPackageConstraint -> PackageConstraint
 unlabelPackageConstraint (LabeledPackageConstraint pc _) = pc

--- a/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
@@ -5,10 +5,18 @@ module Distribution.Solver.Types.LabeledPackageConstraint
 
 import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.PackageConstraint
+import Distribution.Types.PackageName
 
 -- | 'PackageConstraint' labeled with its source.
 data LabeledPackageConstraint
    = LabeledPackageConstraint PackageConstraint ConstraintSource
+
+instance Show LabeledPackageConstraint where
+    show (LabeledPackageConstraint pc@(PackageConstraint scope _) src@ConstraintSourceProjectConfig{}) =
+        if unPackageName (scopeToPackageName scope) == "hashable"
+            then "SOURCE: " ++ showConstraintSource src ++ ", CONSTRAINT: " ++ show pc ++ "\n"
+            else "\n"
+    show LabeledPackageConstraint{} = "\n"
 
 unlabelPackageConstraint :: LabeledPackageConstraint -> PackageConstraint
 unlabelPackageConstraint (LabeledPackageConstraint pc _) = pc

--- a/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/LabeledPackageConstraint.hs
@@ -48,8 +48,7 @@ unscopePackageConstraint (PackageConstraint scope _) = scope
 -- rest.  Constraints such as installed, source, flags and stanzas are untouched
 -- by weeding.
 --
--- Flags that may have applied to weeded version equality constraints may be
--- orphaned.
+-- Flags that may have applied to weeded versions of a package may be orphaned.
 weedLabeledPackageConstraints :: [LabeledPackageConstraint] -> [LabeledPackageConstraint]
 weedLabeledPackageConstraints =
     (\(xs, ys) ->

--- a/cabal-install/src/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/src/Distribution/Client/CmdFreeze.hs
@@ -173,16 +173,17 @@ projectFreezeConfig
   -> TotalIndexState
   -> ActiveRepos
   -> ProjectConfig
-projectFreezeConfig elaboratedPlan totalIndexState activeRepos0 = trace (InstallPlan.showInstallPlan elaboratedPlan) $
-  mempty
-    { projectConfigShared =
-        mempty
-          { projectConfigConstraints =
-              concat (Map.elems (projectFreezeConstraints elaboratedPlan))
-          , projectConfigIndexState = Flag totalIndexState
-          , projectConfigActiveRepos = Flag activeRepos
-          }
-    }
+projectFreezeConfig elaboratedPlan totalIndexState activeRepos0 =
+  trace (InstallPlan.showInstallPlan elaboratedPlan) $
+    mempty
+      { projectConfigShared =
+          mempty
+            { projectConfigConstraints =
+                concat (Map.elems (projectFreezeConstraints elaboratedPlan))
+            , projectConfigIndexState = Flag totalIndexState
+            , projectConfigActiveRepos = Flag activeRepos
+            }
+      }
   where
     activeRepos :: ActiveRepos
     activeRepos = filterSkippedActiveRepos activeRepos0

--- a/cabal-install/src/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/src/Distribution/Client/CmdFreeze.hs
@@ -174,16 +174,15 @@ projectFreezeConfig
   -> ActiveRepos
   -> ProjectConfig
 projectFreezeConfig elaboratedPlan totalIndexState activeRepos0 =
-  trace (InstallPlan.showInstallPlan elaboratedPlan) $
-    mempty
-      { projectConfigShared =
-          mempty
-            { projectConfigConstraints =
-                concat (Map.elems (projectFreezeConstraints elaboratedPlan))
-            , projectConfigIndexState = Flag totalIndexState
-            , projectConfigActiveRepos = Flag activeRepos
-            }
-      }
+  mempty
+    { projectConfigShared =
+        mempty
+          { projectConfigConstraints =
+              concat (Map.elems (projectFreezeConstraints elaboratedPlan))
+          , projectConfigIndexState = Flag totalIndexState
+          , projectConfigActiveRepos = Flag activeRepos
+          }
+    }
   where
     activeRepos :: ActiveRepos
     activeRepos = filterSkippedActiveRepos activeRepos0

--- a/cabal-install/src/Distribution/Client/CmdFreeze.hs
+++ b/cabal-install/src/Distribution/Client/CmdFreeze.hs
@@ -173,7 +173,7 @@ projectFreezeConfig
   -> TotalIndexState
   -> ActiveRepos
   -> ProjectConfig
-projectFreezeConfig elaboratedPlan totalIndexState activeRepos0 =
+projectFreezeConfig elaboratedPlan totalIndexState activeRepos0 = trace (InstallPlan.showInstallPlan elaboratedPlan) $
   mempty
     { projectConfigShared =
         mempty

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -224,7 +224,7 @@ import System.IO
   , withBinaryFile
   )
 
-import Distribution.Solver.Types.ConstraintSource (getProjectImportPath)
+import Distribution.Solver.Types.ConstraintSource (ProjectConfigImport(importPath))
 
 ----------------------------------------
 -- Resolving configuration to settings
@@ -751,7 +751,7 @@ readProjectFileSkeleton
       then do
         monitorFiles [monitorFileHashed extensionFile]
         pcs <- liftIO readExtensionFile
-        monitorFiles $ map monitorFileHashed (getProjectImportPath <$> projectSkeletonImports pcs)
+        monitorFiles $ map monitorFileHashed (importPath <$> projectSkeletonImports pcs)
         pure pcs
       else do
         monitorFiles [monitorNonExistentFile extensionFile]
@@ -798,7 +798,7 @@ readGlobalConfig verbosity configFileFlag = do
 reportParseResult :: Verbosity -> String -> FilePath -> OldParser.ParseResult ProjectConfigSkeleton -> IO ProjectConfigSkeleton
 reportParseResult verbosity _filetype filename (OldParser.ParseOk warnings x) = do
   unless (null warnings) $
-    let msg = unlines (map (OldParser.showPWarning (intercalate ", " $ filename : (getProjectImportPath <$> projectSkeletonImports x))) warnings)
+    let msg = unlines (map (OldParser.showPWarning (intercalate ", " $ filename : (importPath <$> projectSkeletonImports x))) warnings)
      in warn verbosity msg
   return x
 reportParseResult verbosity filetype filename (OldParser.ParseFailed err) =

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -224,7 +224,7 @@ import System.IO
   , withBinaryFile
   )
 
-import Distribution.Solver.Types.ConstraintSource (ProjectConfigImport(importPath))
+import Distribution.Solver.Types.ConstraintSource (ProjectConfigImport (importPath))
 
 ----------------------------------------
 -- Resolving configuration to settings

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
 
 -- | Handling project configuration.
 module Distribution.Client.ProjectConfig
@@ -222,6 +223,8 @@ import System.IO
   ( IOMode (ReadMode)
   , withBinaryFile
   )
+
+import Distribution.Solver.Types.ConstraintSource (ProjectConfigImport (..))
 
 ----------------------------------------
 -- Resolving configuration to settings
@@ -759,7 +762,7 @@ readProjectFileSkeleton
       readExtensionFile =
         reportParseResult verbosity extensionDescription extensionFile
           =<< parseProjectSkeleton distDownloadSrcDirectory httpTransport verbosity [] extensionFile
-          =<< BS.readFile extensionFile
+          =<< (fmap (0,) $ BS.readFile extensionFile)
 
 -- | Render the 'ProjectConfig' format.
 --

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -224,7 +224,7 @@ import System.IO
   , withBinaryFile
   )
 
-import Distribution.Solver.Types.ConstraintSource (ProjectConfigImport (..))
+import Distribution.Solver.Types.ConstraintSource (getProjectImportPath)
 
 ----------------------------------------
 -- Resolving configuration to settings
@@ -751,7 +751,7 @@ readProjectFileSkeleton
       then do
         monitorFiles [monitorFileHashed extensionFile]
         pcs <- liftIO readExtensionFile
-        monitorFiles $ map monitorFileHashed (importPath <$> projectSkeletonImports pcs)
+        monitorFiles $ map monitorFileHashed (getProjectImportPath <$> projectSkeletonImports pcs)
         pure pcs
       else do
         monitorFiles [monitorNonExistentFile extensionFile]
@@ -798,7 +798,7 @@ readGlobalConfig verbosity configFileFlag = do
 reportParseResult :: Verbosity -> String -> FilePath -> OldParser.ParseResult ProjectConfigSkeleton -> IO ProjectConfigSkeleton
 reportParseResult verbosity _filetype filename (OldParser.ParseOk warnings x) = do
   unless (null warnings) $
-    let msg = unlines (map (OldParser.showPWarning (intercalate ", " $ filename : (importPath <$> projectSkeletonImports x))) warnings)
+    let msg = unlines (map (OldParser.showPWarning (intercalate ", " $ filename : (getProjectImportPath <$> projectSkeletonImports x))) warnings)
      in warn verbosity msg
   return x
 reportParseResult verbosity filetype filename (OldParser.ParseFailed err) =

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -748,7 +748,7 @@ readProjectFileSkeleton
       then do
         monitorFiles [monitorFileHashed extensionFile]
         pcs <- liftIO readExtensionFile
-        monitorFiles $ map monitorFileHashed (projectSkeletonImports pcs)
+        monitorFiles $ map monitorFileHashed (importPath <$> projectSkeletonImports pcs)
         pure pcs
       else do
         monitorFiles [monitorNonExistentFile extensionFile]
@@ -795,7 +795,7 @@ readGlobalConfig verbosity configFileFlag = do
 reportParseResult :: Verbosity -> String -> FilePath -> OldParser.ParseResult ProjectConfigSkeleton -> IO ProjectConfigSkeleton
 reportParseResult verbosity _filetype filename (OldParser.ParseOk warnings x) = do
   unless (null warnings) $
-    let msg = unlines (map (OldParser.showPWarning (intercalate ", " $ filename : projectSkeletonImports x)) warnings)
+    let msg = unlines (map (OldParser.showPWarning (intercalate ", " $ filename : (importPath <$> projectSkeletonImports x))) warnings)
      in warn verbosity msg
   return x
 reportParseResult verbosity filetype filename (OldParser.ParseFailed err) =

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -270,11 +270,16 @@ parseProjectSkeleton cacheDir httpTransport verbosity seenImports source (depthI
                 <*> elseClauses
         pure . fmap mconcat . sequence $ [fs, condNode, rest]
       _ ->
-        trace ("GO " ++ show depth ++ " X:ACC " ++ src) $
-        go src (depth + 1) (x : acc) xs
+        if null acc
+          then
+            trace ("GO " ++ show depth ++ " X:ACC@[]" ++ src) $
+            go src depth (x : acc) xs
+          else
+            trace ("GO " ++ show (depth + 1) ++ " X:ACC " ++ src) $
+            go src (depth + 1) (x : acc) xs
     go src depth acc [] =
       trace ("GO " ++ show depth ++ " [] " ++ src) $
-      pure . fmap singletonProjectConfigSkeleton . fieldsToConfig "UUU" (depth + 1) $ reverse acc
+      pure . fmap singletonProjectConfigSkeleton . fieldsToConfig "UUU" depth $ reverse acc
 
     parseElseClauses :: FilePath -> [ParseUtils.Field] -> IO (ParseResult (Maybe ProjectConfigSkeleton), ParseResult ProjectConfigSkeleton)
     parseElseClauses src x = case x of

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -242,8 +242,8 @@ parseProjectSkeleton cacheDir httpTransport verbosity seenImports source (depthI
               fetchImportConfig depthImport
                 >>= ( \sourceNext ->
                         let depthNext = depth + 1
-                            depthImport' = ProjectConfigImport depthNext importLoc
-                         in parseProjectSkeleton cacheDir httpTransport verbosity (depthImport' : seenImports) importLoc (depthNext, sourceNext)
+                            imports = ProjectConfigImport depthNext importLoc : seenImports
+                         in parseProjectSkeleton cacheDir httpTransport verbosity imports importLoc (depthNext, sourceNext)
                     )
             rest <- go depth [] xs
             pure . fmap mconcat . sequence $ [fs, res, rest]

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -188,6 +188,7 @@ import Distribution.Client.HttpUtils
 import Distribution.Client.ReplFlags (multiReplOption)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (isAbsolute, isPathSeparator, makeValid, takeDirectory, (</>))
+import Distribution.Solver.Types.ConstraintSource (mkProjectConfigImport)
 
 ------------------------------------------------------------------
 -- Handle extended project config files with conditionals and imports.
@@ -235,25 +236,30 @@ parseProjectSkeleton cacheDir httpTransport verbosity seenImports source (depthI
     go (depth, acc) (x : xs) = case x of
       (ParseUtils.F l "import" importLoc) ->
         trace ("ZZZ importing " ++ importLoc ++ " at depth " ++ show depth) $
-        if importLoc `elem` (importPath <$> seenImports)
+        if importLoc `elem` (getProjectImportPath <$> seenImports)
           then pure . parseFail $ ParseUtils.FromString ("cyclical import of " ++ importLoc) (Just l)
           else do
             let depthNext = depth + 1
             let !depthImport =
-                  trace ("XXX importing " ++ importLoc ++ " at depth 0") $
-                  ProjectConfigImport 101 {-- depth --} importLoc
-            let fs = fmap (\z -> CondNode z [depthImport] mempty) $ fieldsToConfig depth (reverse acc)
+                  trace ("XXX importing " ++ importLoc ++ " at depthNext " ++ show depthNext) $
+                  setProjectImportDepth "XXX" depthNext $
+                  mkProjectConfigImport "XXX" importLoc
+
+                  --ProjectConfigImport 101 {-- depth --} importLoc
+            let fs = fmap (\z -> CondNode z [depthImport] mempty) $ fieldsToConfig "WWW" depth (reverse acc)
             res <-
               fetchImportConfig depthImport >>= (\cfg@(depthBump, sourceNext) ->
                 let !depthImport' =
                       trace ("YYY importing " ++ importLoc ++ " at next depth " ++ show depth ++ " with bump " ++ show depthBump ++ ", effective depth = " ++ show (depth + depthBump)) $
-                      ProjectConfigImport 202 {-- (depth + depthBump) --} importLoc
+                      setProjectImportDepth "YYY" (depthNext + depthBump) $
+                      mkProjectConfigImport "YYY" importLoc
+
                 in parseProjectSkeleton cacheDir httpTransport verbosity (depthImport' : seenImports) importLoc (depth + depthBump, sourceNext))
             rest <- go (depth, []) xs
             pure . fmap mconcat . sequence $ [fs, res, rest]
       (ParseUtils.Section l "if" p xs') -> do
         subpcs <- go (depth, []) xs'
-        let fs = fmap singletonProjectConfigSkeleton $ fieldsToConfig depth (reverse acc)
+        let fs = fmap singletonProjectConfigSkeleton $ fieldsToConfig "VVV" depth (reverse acc)
         (elseClauses, rest) <- parseElseClauses xs
         let condNode =
               (\c pcs e -> CondNode mempty mempty [CondBranch c pcs e])
@@ -264,7 +270,7 @@ parseProjectSkeleton cacheDir httpTransport verbosity seenImports source (depthI
                 <*> elseClauses
         pure . fmap mconcat . sequence $ [fs, condNode, rest]
       _ -> go (depth, (x : acc)) xs
-    go (_depth, acc) [] = pure . fmap singletonProjectConfigSkeleton . fieldsToConfig 707 $ reverse acc
+    go (depth, acc) [] = pure . fmap singletonProjectConfigSkeleton . fieldsToConfig "UUU" (depth + 1) $ reverse acc
 
     parseElseClauses :: [ParseUtils.Field] -> IO (ParseResult (Maybe ProjectConfigSkeleton), ParseResult ProjectConfigSkeleton)
     parseElseClauses x = case x of
@@ -283,7 +289,7 @@ parseProjectSkeleton cacheDir httpTransport verbosity seenImports source (depthI
         pure (Just <$> condNode, rest)
       _ -> (\r -> (pure Nothing, r)) <$> go (0, []) x
 
-    fieldsToConfig depth xs = fmap (addProvenance . convertLegacyProjectConfig) $ parseLegacyProjectConfigFields (depth, source) xs
+    fieldsToConfig tag depth xs = fmap (addProvenance . convertLegacyProjectConfig) $ parseLegacyProjectConfigFields tag (depth, source) xs
     addProvenance x = x{projectConfigProvenance = Set.singleton (Explicit source)}
 
     adaptParseError _ (Right x) = pure x
@@ -297,14 +303,14 @@ parseProjectSkeleton cacheDir httpTransport verbosity seenImports source (depthI
     liftPR _ (ParseFailed e) = pure $ ParseFailed e
 
     fetchImportConfig :: ProjectConfigImport -> IO (Int, BS.ByteString)
-    fetchImportConfig ProjectConfigImport{importPath = pci} = case parseURI pci of
+    fetchImportConfig (getProjectImportPath -> pci) = case parseURI pci of
       Just uri -> do
         let fp = cacheDir </> map (\x -> if isPathSeparator x then '_' else x) (makeValid $ show uri)
         createDirectoryIfMissing True cacheDir
         _ <- downloadURI httpTransport verbosity uri fp
-        (fmap (303,)) $ BS.readFile fp
+        (fmap (0,)) $ BS.readFile fp
       Nothing ->
-        (fmap (404,)) $
+        (fmap (0,)) $
         BS.readFile $
           if isAbsolute pci then pci else takeDirectory source </> pci
 
@@ -1187,8 +1193,8 @@ convertToLegacyPerPackageConfig PackageConfig{..} =
 -- Parsing and showing the project config file
 --
 
-parseLegacyProjectConfigFields :: (Int, FilePath) -> [ParseUtils.Field] -> ParseResult LegacyProjectConfig
-parseLegacyProjectConfigFields (depth, source) =
+parseLegacyProjectConfigFields :: String -> (Int, FilePath) -> [ParseUtils.Field] -> ParseResult LegacyProjectConfig
+parseLegacyProjectConfigFields tag (depth, source) =
   parseFieldsAndSections
     (legacyProjectConfigFieldDescrs constraintSrc)
     legacyPackageConfigSectionDescrs
@@ -1196,11 +1202,11 @@ parseLegacyProjectConfigFields (depth, source) =
     mempty
   where
     constraintSrc =
-      let bump = if isJust (parseURI source) then 100 else 1
-      in ConstraintSourceProjectConfig $ ProjectConfigImport (depth + bump) source
+      let bump = if isJust (parseURI source) then 0 else 0
+      in ConstraintSourceProjectConfig $ setProjectImportDepth tag (depth + bump) $ mkProjectConfigImport tag source
 
 parseLegacyProjectConfig :: FilePath -> BS.ByteString -> ParseResult LegacyProjectConfig
-parseLegacyProjectConfig source bs = parseLegacyProjectConfigFields (1000, source) =<< ParseUtils.readFields bs
+parseLegacyProjectConfig source bs = parseLegacyProjectConfigFields "AAA" (1000, source) =<< ParseUtils.readFields bs
 
 showLegacyProjectConfig :: LegacyProjectConfig -> String
 showLegacyProjectConfig config =
@@ -1215,7 +1221,7 @@ showLegacyProjectConfig config =
     -- Note: ConstraintSource is unused when pretty-printing. We fake
     -- it here to avoid having to pass it on call-sites. It's not great
     -- but requires re-work of how we annotate provenance.
-    constraintSrc = ConstraintSourceProjectConfig $ ProjectConfigImport 1 "unused"
+    constraintSrc = ConstraintSourceProjectConfig $ mkProjectConfigImport "BBB" "unused"
 
 legacyProjectConfigFieldDescrs :: ConstraintSource -> [FieldDescr LegacyProjectConfig]
 legacyProjectConfigFieldDescrs constraintSrc =

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1190,9 +1190,7 @@ parseLegacyProjectConfigFields (depth, source) =
     legacyPackageConfigFGSectionDescrs
     mempty
   where
-    constraintSrc =
-      let bump = if isJust (parseURI source) then 0 else 0
-       in ConstraintSourceProjectConfig $ ProjectConfigImport (depth + bump) source
+    constraintSrc = ConstraintSourceProjectConfig $ ProjectConfigImport depth source
 
 parseLegacyProjectConfig :: FilePath -> BS.ByteString -> ParseResult LegacyProjectConfig
 parseLegacyProjectConfig source bs = parseLegacyProjectConfigFields (1000, source) =<< ParseUtils.readFields bs

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -229,10 +229,10 @@ projectSkeletonImports = view traverseCondTreeC
 
 parseProjectSkeleton :: FilePath -> HttpTransport -> Verbosity -> [ProjectConfigImport] -> FilePath -> (Int, BS.ByteString) -> IO (ParseResult ProjectConfigSkeleton)
 parseProjectSkeleton cacheDir httpTransport verbosity seenImports source (depthInitial, bs) =
-  (sanityWalkPCS False =<<) <$> liftPR (go source depthInitial []) (ParseUtils.readFields bs)
+  (sanityWalkPCS False =<<) <$> liftPR (go depthInitial []) (ParseUtils.readFields bs)
   where
-    go :: FilePath -> Int -> [ParseUtils.Field] -> [ParseUtils.Field] -> IO (ParseResult ProjectConfigSkeleton)
-    go src depth acc (x : xs) = case x of
+    go :: Int -> [ParseUtils.Field] -> [ParseUtils.Field] -> IO (ParseResult ProjectConfigSkeleton)
+    go depth acc (x : xs) = case x of
       (ParseUtils.F l "import" importLoc) ->
         if importLoc `elem` (getProjectImportPath <$> seenImports)
           then pure . parseFail $ ParseUtils.FromString ("cyclical import of " ++ importLoc) (Just l)
@@ -246,12 +246,12 @@ parseProjectSkeleton cacheDir httpTransport verbosity seenImports source (depthI
                             depthImport' = setProjectImportDepth depthNext $ mkProjectConfigImport importLoc
                          in parseProjectSkeleton cacheDir httpTransport verbosity (depthImport' : seenImports) importLoc (depthNext, sourceNext)
                     )
-            rest <- go src depth [] xs
+            rest <- go depth [] xs
             pure . fmap mconcat . sequence $ [fs, res, rest]
       (ParseUtils.Section l "if" p xs') -> do
-        subpcs <- go src depth [] xs'
+        subpcs <- go depth [] xs'
         let fs = fmap singletonProjectConfigSkeleton $ fieldsToConfig depth (reverse acc)
-        (elseClauses, rest) <- parseElseClauses src xs
+        (elseClauses, rest) <- parseElseClauses xs
         let condNode =
               (\c pcs e -> CondNode mempty mempty [CondBranch c pcs e])
                 <$>
@@ -260,25 +260,25 @@ parseProjectSkeleton cacheDir httpTransport verbosity seenImports source (depthI
                 <*> subpcs
                 <*> elseClauses
         pure . fmap mconcat . sequence $ [fs, condNode, rest]
-      _ -> go src depth (x : acc) xs
-    go _ depth acc [] = pure . fmap singletonProjectConfigSkeleton . fieldsToConfig depth $ reverse acc
+      _ -> go depth (x : acc) xs
+    go depth acc [] = pure . fmap singletonProjectConfigSkeleton . fieldsToConfig depth $ reverse acc
 
-    parseElseClauses :: FilePath -> [ParseUtils.Field] -> IO (ParseResult (Maybe ProjectConfigSkeleton), ParseResult ProjectConfigSkeleton)
-    parseElseClauses src x = case x of
+    parseElseClauses :: [ParseUtils.Field] -> IO (ParseResult (Maybe ProjectConfigSkeleton), ParseResult ProjectConfigSkeleton)
+    parseElseClauses x = case x of
       (ParseUtils.Section _l "else" _p xs' : xs) -> do
-        subpcs <- go src 0 [] xs'
-        rest <- go src 0 [] xs
+        subpcs <- go 0 [] xs'
+        rest <- go 0 [] xs
         pure (Just <$> subpcs, rest)
       (ParseUtils.Section l "elif" p xs' : xs) -> do
-        subpcs <- go src 0 [] xs'
-        (elseClauses, rest) <- parseElseClauses src xs
+        subpcs <- go 0 [] xs'
+        (elseClauses, rest) <- parseElseClauses xs
         let condNode =
               (\c pcs e -> CondNode mempty mempty [CondBranch c pcs e])
                 <$> adaptParseError l (parseConditionConfVarFromClause . BS.pack $ "else(" <> p <> ")")
                 <*> subpcs
                 <*> elseClauses
         pure (Just <$> condNode, rest)
-      _ -> (\r -> (pure Nothing, r)) <$> go src 0 [] x
+      _ -> (\r -> (pure Nothing, r)) <$> go 0 [] x
 
     fieldsToConfig depth xs = fmap (addProvenance . convertLegacyProjectConfig) $ parseLegacyProjectConfigFields (depth, source) xs
     addProvenance x = x{projectConfigProvenance = Set.singleton (Explicit source)}

--- a/cabal-install/src/Distribution/Client/ScriptUtils.hs
+++ b/cabal-install/src/Distribution/Client/ScriptUtils.hs
@@ -506,7 +506,7 @@ readProjectBlockFromScript verbosity httpTransport DistDirLayout{distDownloadSrc
     Left _ -> return mempty
     Right x ->
       reportParseResult verbosity "script" scriptName
-        =<< parseProjectSkeleton distDownloadSrcDirectory httpTransport verbosity [] scriptName x
+        =<< parseProjectSkeleton distDownloadSrcDirectory httpTransport verbosity [] scriptName (0, x)
 
 -- | Extract the first encountered script metadata block started end
 -- terminated by the tokens

--- a/cabal-install/src/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/src/Distribution/Client/TargetSelector.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 -- TODO
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -fprint-potential-instances #-}
 
 -----------------------------------------------------------------------------
 

--- a/cabal-install/src/Distribution/Client/TargetSelector.hs
+++ b/cabal-install/src/Distribution/Client/TargetSelector.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 -- TODO
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
-{-# OPTIONS_GHC -fprint-potential-instances #-}
 
 -----------------------------------------------------------------------------
 

--- a/cabal-testsuite/PackageTests/VersionPriority/CHANGELOG.md
+++ b/cabal-testsuite/PackageTests/VersionPriority/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for cabal-version-override
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cabal-testsuite/PackageTests/VersionPriority/LICENSE
+++ b/cabal-testsuite/PackageTests/VersionPriority/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/cabal-testsuite/PackageTests/VersionPriority/app/Main.hs
+++ b/cabal-testsuite/PackageTests/VersionPriority/app/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Data.Hashable
+
+main :: IO ()
+main = print $ hash "foo"

--- a/cabal-testsuite/PackageTests/VersionPriority/cabal-version-override.cabal
+++ b/cabal-testsuite/PackageTests/VersionPriority/cabal-version-override.cabal
@@ -1,0 +1,20 @@
+cabal-version:      3.0
+name:               cabal-version-override
+version:            0.1.0.0
+license:            MPL-2.0
+license-file:       LICENSE
+author:             Phil de Joux
+maintainer:         philderbeast@gmail.com
+category:           Development
+build-type:         Simple
+extra-doc-files:    CHANGELOG.md
+
+common warnings
+    ghc-options: -Wall
+
+executable cabal-version-override
+    import:           warnings
+    main-is:          Main.hs
+    build-depends:    base, hashable
+    hs-source-dirs:   app
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/VersionPriority/cabal.1-stackage-local.project
+++ b/cabal-testsuite/PackageTests/VersionPriority/cabal.1-stackage-local.project
@@ -1,0 +1,6 @@
+packages: .
+
+-- hash "foo" = 250092161292133802
+constraints: hashable ==1.4.2.0
+
+import: stackage-local.config

--- a/cabal-testsuite/PackageTests/VersionPriority/cabal.1-stackage-web.project
+++ b/cabal-testsuite/PackageTests/VersionPriority/cabal.1-stackage-web.project
@@ -1,0 +1,5 @@
+packages: .
+import: stackage-web.config
+
+-- hash "foo" = 250092161292133802
+constraints: hashable ==1.4.2.0

--- a/cabal-testsuite/PackageTests/VersionPriority/cabal.2-stackage-local.project
+++ b/cabal-testsuite/PackageTests/VersionPriority/cabal.2-stackage-local.project
@@ -1,0 +1,4 @@
+packages: .
+import: cabal.2a-local.project
+
+constraints: hashable ==1.4.2.0

--- a/cabal-testsuite/PackageTests/VersionPriority/cabal.2-stackage-web.project
+++ b/cabal-testsuite/PackageTests/VersionPriority/cabal.2-stackage-web.project
@@ -1,0 +1,4 @@
+packages: .
+import: cabal.2a-web.project
+
+constraints: hashable ==1.4.2.0

--- a/cabal-testsuite/PackageTests/VersionPriority/cabal.2a-local.project
+++ b/cabal-testsuite/PackageTests/VersionPriority/cabal.2a-local.project
@@ -1,0 +1,1 @@
+import: stackage-local.config

--- a/cabal-testsuite/PackageTests/VersionPriority/cabal.2a-web.project
+++ b/cabal-testsuite/PackageTests/VersionPriority/cabal.2a-web.project
@@ -1,0 +1,1 @@
+import: stackage-web.config

--- a/cabal-testsuite/PackageTests/VersionPriority/cabal.local-vs-local.project
+++ b/cabal-testsuite/PackageTests/VersionPriority/cabal.local-vs-local.project
@@ -1,0 +1,8 @@
+packages: .
+
+constraints: hashable ==1.4.3.0
+-- hash "foo" = 4462868336266686512
+
+-- hash "foo" = 250092161292133802
+constraints: hashable ==1.4.2.0
+

--- a/cabal-testsuite/PackageTests/VersionPriority/cabal.local-vs-stackage.project
+++ b/cabal-testsuite/PackageTests/VersionPriority/cabal.local-vs-stackage.project
@@ -1,0 +1,10 @@
+packages: .
+
+-- hash "foo" = 250092161292133802
+constraints: hashable ==1.4.2.0
+
+-- hashable ==1.4.3.0
+-- hash "foo" = 4462868336266686512
+import: https://www.stackage.org/nightly-2023-12-07/cabal.config
+
+

--- a/cabal-testsuite/PackageTests/VersionPriority/local-vs-local.test.hs
+++ b/cabal-testsuite/PackageTests/VersionPriority/local-vs-local.test.hs
@@ -1,0 +1,13 @@
+import Test.Cabal.Prelude
+import System.Directory
+
+main = cabalTest $ do
+    cabal "update" []
+    cabal "v2-build" ["--project-file=cabal.local-vs-stackage.project",  "--dry-run"]
+    -- cabal' "v2-freeze" ["--project-file=cabal.local-vs-web.project",  "--dry-run"]
+
+    -- cwd <- fmap testCurrentDir getTestEnv
+    -- let freezeFile = cwd </> "cabal.local-vs-local.project.freeze"
+
+    -- assertFileDoesContain freezeFile "any.hashable ==1.4.2.0"
+    -- assertFileDoesNotContain freezeFile "any.hashable ==1.4.3.0"

--- a/cabal-testsuite/PackageTests/VersionPriority/stackage-local.config
+++ b/cabal-testsuite/PackageTests/VersionPriority/stackage-local.config
@@ -1,0 +1,2 @@
+-- Same constraint as on stackage at https://www.stackage.org/nightly-2023-12-07/cabal.config
+constraints: hashable ==1.4.3.0

--- a/cabal-testsuite/PackageTests/VersionPriority/stackage-web.config
+++ b/cabal-testsuite/PackageTests/VersionPriority/stackage-web.config
@@ -1,0 +1,4 @@
+-- hashable ==1.4.3.0
+-- hash "foo" = 4462868336266686512
+import: https://www.stackage.org/nightly-2023-12-07/cabal.config
+


### PR DESCRIPTION
Allows overriding package version equalities by giving priority to shallower constraints in the project import tree.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)


