### PR TITLE
Improve cabal update message

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdUpdate.hs
+++ b/cabal-install/src/Distribution/Client/CmdUpdate.hs
@@ -283,7 +283,7 @@ updateRepo verbosity _updateFlags repoCtxt (repo, indexState) = do
               warn verbosity $ "Could not set modification time of index tarball -- " ++ displayException e
           head_ts <- getIndexHeadTimestamp verbosity index
           noticeNoWrap verbosity $
-            "Package list of " ++ prettyShow rname ++ " is up to date to " ++ prettyShow head_ts ++ "."
+            "Package list of " ++ prettyShow rname ++ " is up to date at " ++ prettyShow head_ts ++ "."
         Sec.HasUpdates -> do
           updateRepoIndexCache verbosity index
           head_ts <- getIndexHeadTimestamp verbosity index
@@ -298,7 +298,7 @@ updateRepo verbosity _updateFlags repoCtxt (repo, indexState) = do
       noticeNoWrap verbosity $
         "The global index-state for "
           ++ prettyShow rname
-          ++ " now resolves to "
+          ++ " now is "
           ++ prettyShow (IndexStateTime new_ts)
           ++ "."
 

--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -40,6 +40,7 @@ module Distribution.Client.IndexUtils
   , updatePackageIndexCacheFile
   , writeIndexTimestamp
   , currentIndexTimestamp
+  , getIndexHeadTimestamp
   , BuildTreeRefType (..)
   , refTypeFromTypeCode
   , typeCodeFromRefType
@@ -973,6 +974,10 @@ getIndexCache :: Verbosity -> Index -> RepoIndexState -> IO (Cache, IndexStateIn
 getIndexCache verbosity index idxState =
   filterCache idxState <$> readIndexCache verbosity index
 
+getIndexHeadTimestamp :: Verbosity -> Index -> IO Timestamp
+getIndexHeadTimestamp verbosity index =
+  cacheHeadTs <$> readIndexCache verbosity index
+
 packageIndexFromCache
   :: Package pkg
   => Verbosity
@@ -1189,7 +1194,7 @@ currentIndexTimestamp verbosity index = do
       return ts
     -- Otherwise used the head time as stored in the index cache
     _otherwise ->
-      fmap (isiHeadTime . snd) (getIndexCache verbosity index IndexStateHead)
+      getIndexHeadTimestamp verbosity index
         `catchIO` \e ->
           if isDoesNotExistError e
             then return NoTimestamp

--- a/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.test.hs
@@ -10,8 +10,7 @@ main = cabalTest $ withProjectFile "cabal.project" $ withRemoteRepo "repo" $ do
           . resultOutput
         <$> recordMode DoNotRecord (cabal' "update" [])
   -- update golden output with actual timestamp
-  shell "cp" ["cabal.out.in", "cabal.out"]
-  shell "sed" ["-i''", "-e", "s/REPLACEME/" <> output <> "/g", "cabal.out"]
+  shell "sed" ["-e", "s/REPLACEME/" <> output <> "/g; w cabal.out", "cabal.out.in"]
   -- This shall fail with an error message as specified in `cabal.out`
   fails $ cabal "build" ["--index-state=4000-01-01T00:00:00Z", "fake-pkg"]
   -- This shall fail by not finding the package, what indicates that it

--- a/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.out
+++ b/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.out
@@ -1,12 +1,12 @@
 # cabal update
 Downloading the latest package list from repository.localhost
-Package list of repository.localhost is up to date to 2023-12-15T04:30:20Z.
-The global index-state for repository.localhost now resolves to 2016-09-24T17:47:48Z.
+The repository repository.localhost is up to date. Its most recent known index-state is 2024-01-19T07:22:23Z.
+The default index-state for the repository repository.localhost has been updated to 2016-09-24T17:47:48Z.
 To revert to previous state run:
     cabal v2-update 'repository.localhost,2022-01-28T02:36:41Z'
 # cabal update
 Downloading the latest package list from repository.localhost
-Package list of repository.localhost is up to date to 2023-12-15T04:30:20Z.
-The global index-state for repository.localhost now resolves to 2022-01-28T02:36:41Z.
+The repository repository.localhost is up to date. Its most recent known index-state is 2024-01-19T07:22:23Z.
+The default index-state for the repository repository.localhost has been updated to 2022-01-28T02:36:41Z.
 To revert to previous state run:
     cabal v2-update 'repository.localhost,2016-09-24T17:47:48Z'

--- a/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.out
+++ b/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.out
@@ -1,12 +1,12 @@
 # cabal update
 Downloading the latest package list from repository.localhost
-Package list of repository.localhost is up to date.
-The index-state is set to 2016-09-24T17:47:48Z.
+Package list of repository.localhost is up to date to 2023-12-15T04:30:20Z.
+The global index-state for repository.localhost now resolves to 2016-09-24T17:47:48Z.
 To revert to previous state run:
     cabal v2-update 'repository.localhost,2022-01-28T02:36:41Z'
 # cabal update
 Downloading the latest package list from repository.localhost
-Package list of repository.localhost is up to date.
-The index-state is set to 2022-01-28T02:36:41Z.
+Package list of repository.localhost is up to date to 2023-12-15T04:30:20Z.
+The global index-state for repository.localhost now resolves to 2022-01-28T02:36:41Z.
 To revert to previous state run:
     cabal v2-update 'repository.localhost,2016-09-24T17:47:48Z'

--- a/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.test.hs
+++ b/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.test.hs
@@ -4,9 +4,10 @@ main = cabalTest $ withRemoteRepo "repo" $ do
   -- The _first_ update call causes a warning about missing mirrors, the warning
   -- is platform-dependent and it's not part of the test expectations, so we
   -- check the output manually.
-  res <- recordMode DoNotRecord $
-           cabal' "update" ["repository.localhost,2022-01-28T02:36:41Z"]
-  assertOutputContains "The global index-state for repository.localhost now resolves to 2022-01-28T02:36:41Z." res
+  res <-
+    recordMode DoNotRecord $
+      cabal' "update" ["repository.localhost,2022-01-28T02:36:41Z"]
+  assertOutputContains "The default index-state for the repository repository.localhost has been updated to" res
   assertOutputDoesNotContain "revert" res
   cabal "update" ["repository.localhost,2016-09-24T17:47:48Z"]
   cabal "update" ["repository.localhost,2022-01-28T02:36:41Z"]

--- a/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.test.hs
+++ b/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.test.hs
@@ -6,7 +6,7 @@ main = cabalTest $ withRemoteRepo "repo" $ do
   -- check the output manually.
   res <- recordMode DoNotRecord $
            cabal' "update" ["repository.localhost,2022-01-28T02:36:41Z"]
-  assertOutputContains "The index-state is set to 2022-01-28T02:36:41Z" res
+  assertOutputContains "The global index-state for repository.localhost now resolves to 2022-01-28T02:36:41Z." res
   assertOutputDoesNotContain "revert" res
   cabal "update" ["repository.localhost,2016-09-24T17:47:48Z"]
   cabal "update" ["repository.localhost,2022-01-28T02:36:41Z"]


### PR DESCRIPTION
This change tries to address #9039 and similar issues.

- `cabal update` now mentions a "global index-state".
- `cabal update` reports the head timestamp of the package index as well as the set index-state.

Example:

```
$ cabal update repository.localhost,2016-09-24T17:47:48Z
Downloading the latest package list from repository.localhost
Package list of repository.localhost is up to date to 2023-12-15T04:30:20Z.
The global index-state for repository.localhost now resolves to 2016-09-24T17:47:48Z.
To revert to previous state run:
    cabal v2-update 'repository.localhost,2022-01-28T02:36:41Z'

$ cabal update repository.localhost,2022-01-28T02:36:41Z
Downloading the latest package list from repository.localhost
Package list of repository.localhost is up to date to 2023-12-15T04:30:20Z.
The global index-state for repository.localhost now resolves to 2022-01-28T02:36:41Z.
To revert to previous state run:
    cabal v2-update 'repository.localhost,2016-09-24T17:47:48Z'
```