### PR TITLE
Fix extra-prog-path propagation in the codebase.

### DIFF
--- a/Cabal/src/Distribution/Simple/ConfigureScript.hs
+++ b/Cabal/src/Distribution/Simple/ConfigureScript.hs
@@ -169,10 +169,7 @@ runConfigureScript verbosity flags lbi = do
       maybeHostFlag = if hp == buildPlatform then [] else ["--host=" ++ show (pretty hp)]
       args' = configureFile' : args ++ ["CC=" ++ ccProgShort] ++ maybeHostFlag
       shProg = simpleProgram "sh"
-      progDb =
-        modifyProgramSearchPath
-          (\p -> map ProgramSearchPathDir extraPath ++ p)
-          emptyProgramDb
+  progDb <- appendProgramSearchPath verbosity extraPath emptyProgramDb
   shConfiguredProg <-
     lookupProgram shProg
       `fmap` configureProgram verbosity shProg progDb

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -697,10 +697,12 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
       | otherwise = error "libAbiHash: Can't find an enabled library way"
 
   (ghcProg, _) <- requireProgram verbosity ghcProgram (withPrograms lbi)
+
   hash <-
     getProgramInvocationOutput
       verbosity
-      (ghcInvocation ghcProg comp platform ghcArgs)
+      =<< ghcInvocation verbosity ghcProg comp platform ghcArgs
+
   return (takeWhile (not . isSpace) hash)
 
 componentCcGhcOptions

--- a/Cabal/src/Distribution/Simple/GHCJS.hs
+++ b/Cabal/src/Distribution/Simple/GHCJS.hs
@@ -1769,7 +1769,7 @@ libAbiHash verbosity _pkg_descr lbi lib clbi = do
   hash <-
     getProgramInvocationOutput
       verbosity
-      (ghcInvocation ghcjsProg comp platform ghcArgs)
+      =<< ghcInvocation verbosity ghcjsProg comp platform ghcArgs
   return (takeWhile (not . isSpace) hash)
 
 componentGhcOptions

--- a/Cabal/src/Distribution/Simple/Program/Db.hs
+++ b/Cabal/src/Distribution/Simple/Program/Db.hs
@@ -34,6 +34,7 @@ module Distribution.Simple.Program.Db
     -- ** Query and manipulate the program db
   , addKnownProgram
   , addKnownPrograms
+  , appendProgramSearchPath
   , lookupKnownProgram
   , knownPrograms
   , getProgramSearchPath
@@ -220,6 +221,21 @@ modifyProgramSearchPath
   -> ProgramDb
 modifyProgramSearchPath f db =
   setProgramSearchPath (f $ getProgramSearchPath db) db
+
+-- | Modify the current 'ProgramSearchPath' used by the 'ProgramDb'
+-- by appending the provided extra paths. Also logs the added paths
+-- in info verbosity.
+appendProgramSearchPath
+  :: Verbosity
+  -> [FilePath]
+  -> ProgramDb
+  -> IO ProgramDb
+appendProgramSearchPath verbosity extraPaths db =
+  if not $ null extraPaths
+    then do
+      logExtraProgramSearchPath verbosity extraPaths
+      pure $ modifyProgramSearchPath (map ProgramSearchPathDir extraPaths ++) db
+    else pure db
 
 -- | User-specify this path.  Basically override any path information
 --  for this program in the configuration. If it's not a known

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -28,6 +28,7 @@ import Distribution.Pretty
 import Distribution.Simple.Compiler
 import Distribution.Simple.Flag
 import Distribution.Simple.GHC.ImplInfo
+import Distribution.Simple.Program.Find (getExtraPathEnv)
 import Distribution.Simple.Program.Run
 import Distribution.Simple.Program.Types
 import Distribution.System
@@ -554,8 +555,6 @@ data GhcOptions = GhcOptions
   , ghcOptExtraPath :: NubListR FilePath
   -- ^ Put the extra folders in the PATH environment variable we invoke
   -- GHC with
-  -- | Put the extra folders in the PATH environment variable we invoke
-  -- GHC with
   , ghcOptCabal :: Flag Bool
   -- ^ Let GHC know that it is Cabal that's calling it.
   -- Modifies some of the GHC error messages.
@@ -616,18 +615,24 @@ runGHC
   -> GhcOptions
   -> IO ()
 runGHC verbosity ghcProg comp platform opts = do
-  runProgramInvocation verbosity (ghcInvocation ghcProg comp platform opts)
+  runProgramInvocation verbosity =<< ghcInvocation verbosity ghcProg comp platform opts
 
 ghcInvocation
-  :: ConfiguredProgram
+  :: Verbosity
+  -> ConfiguredProgram
   -> Compiler
   -> Platform
   -> GhcOptions
-  -> ProgramInvocation
-ghcInvocation prog comp platform opts =
-  (programInvocation prog (renderGhcOptions comp platform opts))
-    { progInvokePathEnv = fromNubListR (ghcOptExtraPath opts)
-    }
+  -> IO ProgramInvocation
+ghcInvocation verbosity ghcProg comp platform opts = do
+  -- NOTE: GHC is the only program whose path we modify with more values than
+  -- the standard @extra-prog-path@, namely the folders of the executables in
+  -- the components, see @componentGhcOptions@.
+  let envOverrides = programOverrideEnv ghcProg
+  extraPath <- getExtraPathEnv verbosity envOverrides (fromNubListR (ghcOptExtraPath opts))
+  let ghcProg' = ghcProg{programOverrideEnv = envOverrides ++ extraPath}
+
+  pure $ programInvocation ghcProg' (renderGhcOptions comp platform opts)
 
 renderGhcOptions :: Compiler -> Platform -> GhcOptions -> [String]
 renderGhcOptions comp _platform@(Platform _arch os) opts

--- a/Cabal/src/Distribution/Simple/Program/Run.hs
+++ b/Cabal/src/Distribution/Simple/Program/Run.hs
@@ -36,7 +36,6 @@ import Distribution.Simple.Program.Types
 import Distribution.Simple.Utils
 import Distribution.Utils.Generic
 import Distribution.Verbosity
-import System.FilePath (searchPathSeparator)
 
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map as Map
@@ -51,8 +50,6 @@ data ProgramInvocation = ProgramInvocation
   { progInvokePath :: FilePath
   , progInvokeArgs :: [String]
   , progInvokeEnv :: [(String, Maybe String)]
-  , -- Extra paths to add to PATH
-    progInvokePathEnv :: [FilePath]
   , progInvokeCwd :: Maybe FilePath
   , progInvokeInput :: Maybe IOData
   , progInvokeInputEncoding :: IOEncoding
@@ -75,7 +72,6 @@ emptyProgramInvocation =
     { progInvokePath = ""
     , progInvokeArgs = []
     , progInvokeEnv = []
-    , progInvokePathEnv = []
     , progInvokeCwd = Nothing
     , progInvokeInput = Nothing
     , progInvokeInputEncoding = IOEncodingText
@@ -107,7 +103,6 @@ runProgramInvocation
     { progInvokePath = path
     , progInvokeArgs = args
     , progInvokeEnv = []
-    , progInvokePathEnv = []
     , progInvokeCwd = Nothing
     , progInvokeInput = Nothing
     } =
@@ -118,12 +113,10 @@ runProgramInvocation
     { progInvokePath = path
     , progInvokeArgs = args
     , progInvokeEnv = envOverrides
-    , progInvokePathEnv = extraPath
     , progInvokeCwd = mcwd
     , progInvokeInput = Nothing
     } = do
-    pathOverride <- getExtraPathEnv envOverrides extraPath
-    menv <- getEffectiveEnvironment (envOverrides ++ pathOverride)
+    menv <- getEffectiveEnvironment envOverrides
     maybeExit $
       rawSystemIOWithEnv
         verbosity
@@ -140,13 +133,11 @@ runProgramInvocation
     { progInvokePath = path
     , progInvokeArgs = args
     , progInvokeEnv = envOverrides
-    , progInvokePathEnv = extraPath
     , progInvokeCwd = mcwd
     , progInvokeInput = Just inputStr
     , progInvokeInputEncoding = encoding
     } = do
-    pathOverride <- getExtraPathEnv envOverrides extraPath
-    menv <- getEffectiveEnvironment (envOverrides ++ pathOverride)
+    menv <- getEffectiveEnvironment envOverrides
     (_, errors, exitCode) <-
       rawSystemStdInOut
         verbosity
@@ -202,29 +193,15 @@ getProgramInvocationIODataAndErrors
     { progInvokePath = path
     , progInvokeArgs = args
     , progInvokeEnv = envOverrides
-    , progInvokePathEnv = extraPath
     , progInvokeCwd = mcwd
     , progInvokeInput = minputStr
     , progInvokeInputEncoding = encoding
     }
   mode = do
-    pathOverride <- getExtraPathEnv envOverrides extraPath
-    menv <- getEffectiveEnvironment (envOverrides ++ pathOverride)
+    menv <- getEffectiveEnvironment envOverrides
     rawSystemStdInOut verbosity path args mcwd menv input mode
     where
       input = encodeToIOData encoding <$> minputStr
-
-getExtraPathEnv :: [(String, Maybe String)] -> [FilePath] -> IO [(String, Maybe String)]
-getExtraPathEnv _ [] = return []
-getExtraPathEnv env extras = do
-  mb_path <- case lookup "PATH" env of
-    Just x -> return x
-    Nothing -> lookupEnv "PATH"
-  let extra = intercalate [searchPathSeparator] extras
-      path' = case mb_path of
-        Nothing -> extra
-        Just path -> extra ++ searchPathSeparator : path
-  return [("PATH", Just path')]
 
 -- | Return the current environment extended with the given overrides.
 -- If an entry is specified twice in @overrides@, the second entry takes

--- a/Cabal/src/Distribution/Simple/Program/Types.hs
+++ b/Cabal/src/Distribution/Simple/Program/Types.hs
@@ -93,6 +93,13 @@ type ProgArg = String
 -- dir to search after the usual ones.
 --
 -- > ['ProgramSearchPathDefault', 'ProgramSearchPathDir' dir]
+--
+-- We also use this path to set the environment when running child processes.
+--
+-- The @ProgramDb@ is created with a @ProgramSearchPath@ to which we
+-- @appendProgramSearchPath@ to add the ones that come from cli flags and from
+-- configurations. Then each of the programs that are configured in the db
+-- inherits the same path as part of @configureProgram@.
 type ProgramSearchPath = [ProgramSearchPathEntry]
 
 data ProgramSearchPathEntry

--- a/cabal-install/src/Distribution/Client/CmdExec.hs
+++ b/cabal-install/src/Distribution/Client/CmdExec.hs
@@ -268,6 +268,7 @@ withTempEnvFile verbosity baseCtx buildCtx buildStatus action = do
         action envOverrides
     )
 
+-- | Get paths to all dependency executables to be included in PATH.
 pathAdditions :: ProjectBaseContext -> ProjectBuildContext -> [FilePath]
 pathAdditions ProjectBaseContext{..} ProjectBuildContext{..} =
   paths ++ cabalConfigPaths
@@ -281,6 +282,7 @@ pathAdditions ProjectBaseContext{..} ProjectBuildContext{..} =
       S.toList $
         binDirectories distDirLayout elaboratedShared elaboratedPlanToExecute
 
+-- | Get paths to all dependency executables to be included in PATH.
 binDirectories
   :: DistDirLayout
   -> ElaboratedSharedConfig

--- a/cabal-install/src/Distribution/Client/CmdRun.hs
+++ b/cabal-install/src/Distribution/Client/CmdRun.hs
@@ -48,6 +48,10 @@ import Distribution.Client.NixStyleOptions
   , defaultNixStyleFlags
   , nixStyleOptions
   )
+import Distribution.Client.ProjectConfig.Types
+  ( ProjectConfig (projectConfigShared)
+  , ProjectConfigShared (projectConfigProgPathExtra)
+  )
 import Distribution.Client.ProjectOrchestration
 import Distribution.Client.ProjectPlanning
   ( ElaboratedConfiguredPackage (..)
@@ -82,6 +86,12 @@ import Distribution.Simple.Command
 import Distribution.Simple.Flag
   ( fromFlagOrDefault
   )
+import Distribution.Simple.Program.Find
+  ( ProgramSearchPathEntry (ProgramSearchPathDir)
+  , defaultProgramSearchPath
+  , logExtraProgramSearchPath
+  , programSearchPathAsPATHVar
+  )
 import Distribution.Simple.Program.Run
   ( ProgramInvocation (..)
   , emptyProgramInvocation
@@ -104,6 +114,9 @@ import Distribution.Types.UnitId
 import Distribution.Types.UnqualComponentName
   ( UnqualComponentName
   , unUnqualComponentName
+  )
+import Distribution.Utils.NubList
+  ( fromNubList
   )
 import Distribution.Verbosity
   ( normal
@@ -288,6 +301,17 @@ runAction flags@NixStyleFlags{..} targetAndArgs globalFlags =
           buildSettingDryRun (buildSettings baseCtx)
             || buildSettingOnlyDownload (buildSettings baseCtx)
 
+    let extraPath =
+          fromNubList
+            . projectConfigProgPathExtra
+            . projectConfigShared
+            . projectConfig
+            $ baseCtx
+
+    logExtraProgramSearchPath verbosity extraPath
+
+    progPath <- programSearchPathAsPATHVar (map ProgramSearchPathDir extraPath ++ defaultProgramSearchPath)
+
     if dryRun
       then notice verbosity "Running of executable suppressed by flag(s)"
       else
@@ -297,9 +321,10 @@ runAction flags@NixStyleFlags{..} targetAndArgs globalFlags =
             { progInvokePath = exePath
             , progInvokeArgs = args
             , progInvokeEnv =
-                dataDirsEnvironmentForPlan
-                  (distDirLayout baseCtx)
-                  elaboratedPlan
+                ("PATH", Just $ progPath)
+                  : dataDirsEnvironmentForPlan
+                    (distDirLayout baseCtx)
+                    elaboratedPlan
             }
   where
     (targetStr, args) = splitAt 1 targetAndArgs

--- a/cabal-install/src/Distribution/Client/CmdRun.hs
+++ b/cabal-install/src/Distribution/Client/CmdRun.hs
@@ -60,6 +60,7 @@ import Distribution.Client.ProjectPlanning
   )
 import Distribution.Client.ProjectPlanning.Types
   ( dataDirsEnvironmentForPlan
+  , elabExeDependencyPaths
   )
 import Distribution.Client.ScriptUtils
   ( AcceptNoTargets (..)
@@ -302,11 +303,13 @@ runAction flags@NixStyleFlags{..} targetAndArgs globalFlags =
             || buildSettingOnlyDownload (buildSettings baseCtx)
 
     let extraPath =
-          fromNubList
-            . projectConfigProgPathExtra
-            . projectConfigShared
-            . projectConfig
-            $ baseCtx
+          elabExeDependencyPaths pkg
+            ++ ( fromNubList
+                  . projectConfigProgPathExtra
+                  . projectConfigShared
+                  . projectConfig
+                  $ baseCtx
+               )
 
     logExtraProgramSearchPath verbosity extraPath
 

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -1540,6 +1540,14 @@ parseConfig src initial = \str -> do
                       splitMultiPath
                         (configConfigureArgs scf)
                   }
+        , savedGlobalFlags =
+            let sgf = savedGlobalFlags conf
+             in sgf
+                  { globalProgPathExtra =
+                      toNubList $
+                        splitMultiPath
+                          (fromNubList $ globalProgPathExtra sgf)
+                  }
         }
 
     parse =

--- a/cabal-install/src/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/src/Distribution/Client/HttpUtils.hs
@@ -38,7 +38,6 @@ import Distribution.Simple.Program
   ( ConfiguredProgram
   , Program
   , ProgramInvocation (..)
-  , ProgramSearchPathEntry (..)
   , getProgramInvocationOutput
   , programInvocation
   , programPath
@@ -47,10 +46,10 @@ import Distribution.Simple.Program
 import Distribution.Simple.Program.Db
   ( ProgramDb
   , addKnownPrograms
+  , appendProgramSearchPath
   , configureAllKnownPrograms
   , emptyProgramDb
   , lookupProgram
-  , modifyProgramSearchPath
   , requireProgram
   )
 import Distribution.Simple.Program.Run
@@ -409,7 +408,7 @@ configureTransport verbosity extraPath (Just name) =
 
   case find (\(name', _, _, _) -> name' == name) supportedTransports of
     Just (_, mprog, _tls, mkTrans) -> do
-      let baseProgDb = modifyProgramSearchPath (\p -> map ProgramSearchPathDir extraPath ++ p) emptyProgramDb
+      baseProgDb <- appendProgramSearchPath verbosity extraPath emptyProgramDb
       progdb <- case mprog of
         Nothing -> return emptyProgramDb
         Just prog -> snd <$> requireProgram verbosity prog baseProgDb
@@ -425,7 +424,7 @@ configureTransport verbosity extraPath Nothing = do
 
   -- for all the transports except plain-http we need to try and find
   -- their external executable
-  let baseProgDb = modifyProgramSearchPath (\p -> map ProgramSearchPathDir extraPath ++ p) emptyProgramDb
+  baseProgDb <- appendProgramSearchPath verbosity extraPath emptyProgramDb
   progdb <-
     configureAllKnownPrograms verbosity $
       addKnownPrograms

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -1351,11 +1351,10 @@ syncAndReadSourcePackagesRemoteRepos
             | (repo, rloc, rtype, vcs) <- repos'
             ]
 
-    -- TODO: pass progPathExtra on to 'configureVCS'
-    let _progPathExtra = fromNubList projectConfigProgPathExtra
+    let progPathExtra = fromNubList projectConfigProgPathExtra
     getConfiguredVCS <- delayInitSharedResources $ \repoType ->
       let vcs = Map.findWithDefault (error $ "Unknown VCS: " ++ prettyShow repoType) repoType knownVCSs
-       in configureVCS verbosity {-progPathExtra-} vcs
+       in configureVCS verbosity progPathExtra vcs
 
     concat
       <$> sequenceA

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -231,7 +231,7 @@ data CurrentCommand = InstallCommand | HaddockCommand | BuildCommand | ReplComma
   deriving (Show, Eq)
 
 -- | This holds the context of a project prior to solving: the content of the
--- @cabal.project@ and all the local package @.cabal@ files.
+-- @cabal.project@, @cabal/config@ and all the local package @.cabal@ files.
 data ProjectBaseContext = ProjectBaseContext
   { distDirLayout :: DistDirLayout
   , cabalDirLayout :: CabalDirLayout

--- a/cabal-install/src/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/src/Distribution/Client/SetupWrapper.hs
@@ -88,9 +88,11 @@ import Distribution.Simple.Program
   , ghcjsProgram
   , runDbProgram
   )
+import Distribution.Simple.Program.Db
+  ( appendProgramSearchPath
+  )
 import Distribution.Simple.Program.Find
-  ( ProgramSearchPathEntry (ProgramSearchPathDir)
-  , programSearchPathAsPATHVar
+  ( programSearchPathAsPATHVar
   )
 import Distribution.Simple.Program.Run
   ( getEffectiveEnvironment
@@ -537,11 +539,11 @@ invoke verbosity path args options = do
     Nothing -> return ()
     Just logHandle -> info verbosity $ "Redirecting build log to " ++ show logHandle
 
+  progDb <- appendProgramSearchPath verbosity (useExtraPathEnv options) (useProgramDb options)
+
   searchpath <-
-    programSearchPathAsPATHVar
-      ( map ProgramSearchPathDir (useExtraPathEnv options)
-          ++ getProgramSearchPath (useProgramDb options)
-      )
+    programSearchPathAsPATHVar $ getProgramSearchPath progDb
+
   env <-
     getEffectiveEnvironment $
       [ ("PATH", Just searchpath)

--- a/cabal-install/src/Distribution/Client/VCS.hs
+++ b/cabal-install/src/Distribution/Client/VCS.hs
@@ -61,6 +61,9 @@ import Distribution.Simple.Program
   , runProgramInvocation
   , simpleProgram
   )
+import Distribution.Simple.Program.Db
+  ( appendProgramSearchPath
+  )
 import Distribution.Types.SourceRepo
   ( KnownRepoType (..)
   , RepoType (..)
@@ -198,18 +201,23 @@ validateSourceRepos rs =
 
 configureVCS
   :: Verbosity
+  -> [FilePath]
+  -- ^ Extra prog paths
   -> VCS Program
   -> IO (VCS ConfiguredProgram)
-configureVCS verbosity vcs@VCS{vcsProgram = prog} =
-  asVcsConfigured <$> requireProgram verbosity prog emptyProgramDb
+configureVCS verbosity progPaths vcs@VCS{vcsProgram = prog} = do
+  progPath <- appendProgramSearchPath verbosity progPaths emptyProgramDb
+  asVcsConfigured <$> requireProgram verbosity prog progPath
   where
     asVcsConfigured (prog', _) = vcs{vcsProgram = prog'}
 
 configureVCSs
   :: Verbosity
+  -> [FilePath]
+  -- ^ Extra prog paths
   -> Map RepoType (VCS Program)
   -> IO (Map RepoType (VCS ConfiguredProgram))
-configureVCSs verbosity = traverse (configureVCS verbosity)
+configureVCSs verbosity progPaths = traverse (configureVCS verbosity progPaths)
 
 -- ------------------------------------------------------------
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/Get.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Get.hs
@@ -64,7 +64,7 @@ testNoRepos :: Assertion
 testNoRepos = do
   e <-
     assertException $
-      clonePackagesFromSourceRepo verbosity "." Nothing pkgrepos
+      clonePackagesFromSourceRepo verbosity "." Nothing [] pkgrepos
   e @?= ClonePackageNoSourceRepos pkgidfoo
   where
     pkgrepos = [(pkgidfoo, [])]
@@ -73,7 +73,7 @@ testNoReposOfKind :: Assertion
 testNoReposOfKind = do
   e <-
     assertException $
-      clonePackagesFromSourceRepo verbosity "." repokind pkgrepos
+      clonePackagesFromSourceRepo verbosity "." repokind [] pkgrepos
   e @?= ClonePackageNoSourceReposOfKind pkgidfoo repokind
   where
     pkgrepos = [(pkgidfoo, [repo])]
@@ -84,7 +84,7 @@ testNoRepoType :: Assertion
 testNoRepoType = do
   e <-
     assertException $
-      clonePackagesFromSourceRepo verbosity "." Nothing pkgrepos
+      clonePackagesFromSourceRepo verbosity "." Nothing [] pkgrepos
   e @?= ClonePackageNoRepoType pkgidfoo repo
   where
     pkgrepos = [(pkgidfoo, [repo])]
@@ -94,7 +94,7 @@ testUnsupportedRepoType :: Assertion
 testUnsupportedRepoType = do
   e <-
     assertException $
-      clonePackagesFromSourceRepo verbosity "." Nothing pkgrepos
+      clonePackagesFromSourceRepo verbosity "." Nothing [] pkgrepos
   e @?= ClonePackageUnsupportedRepoType pkgidfoo repo' repotype
   where
     pkgrepos = [(pkgidfoo, [repo])]
@@ -118,7 +118,7 @@ testNoRepoLocation :: Assertion
 testNoRepoLocation = do
   e <-
     assertException $
-      clonePackagesFromSourceRepo verbosity "." Nothing pkgrepos
+      clonePackagesFromSourceRepo verbosity "." Nothing [] pkgrepos
   e @?= ClonePackageNoRepoLocation pkgidfoo repo
   where
     pkgrepos = [(pkgidfoo, [repo])]
@@ -139,7 +139,7 @@ testSelectRepoKind =
       e' @?= ClonePackageNoRepoType pkgidfoo expectedRepo
     | let test rt rs =
             assertException $
-              clonePackagesFromSourceRepo verbosity "." rt rs
+              clonePackagesFromSourceRepo verbosity "." rt [] rs
     , (requestedRepoType, expectedRepo) <- cases
     ]
   where
@@ -161,14 +161,14 @@ testRepoDestinationExists =
     createDirectory pkgdir
     e1 <-
       assertException $
-        clonePackagesFromSourceRepo verbosity tmpdir Nothing pkgrepos
+        clonePackagesFromSourceRepo verbosity tmpdir Nothing [] pkgrepos
     e1 @?= ClonePackageDestinationExists pkgidfoo pkgdir True {- isdir -}
     removeDirectory pkgdir
 
     writeFile pkgdir ""
     e2 <-
       assertException $
-        clonePackagesFromSourceRepo verbosity tmpdir Nothing pkgrepos
+        clonePackagesFromSourceRepo verbosity tmpdir Nothing [] pkgrepos
     e2 @?= ClonePackageDestinationExists pkgidfoo pkgdir False {- isfile -}
   where
     pkgrepos = [(pkgidfoo, [repo])]
@@ -199,7 +199,7 @@ testGitFetchFailed =
         pkgrepos = [(pkgidfoo, [repo])]
     e1 <-
       assertException $
-        clonePackagesFromSourceRepo verbosity tmpdir Nothing pkgrepos
+        clonePackagesFromSourceRepo verbosity tmpdir Nothing [] pkgrepos
     e1 @?= ClonePackageFailedWithExitCode pkgidfoo repo' "git" (ExitFailure 128)
 
 testNetworkGitClone :: Assertion
@@ -214,6 +214,7 @@ testNetworkGitClone =
       verbosity
       tmpdir
       Nothing
+      []
       [(mkpkgid "zlib1", [repo1])]
     assertFileContains (tmpdir </> "zlib1/zlib.cabal") ["name:", "zlib"]
 
@@ -226,6 +227,7 @@ testNetworkGitClone =
       verbosity
       tmpdir
       Nothing
+      []
       [(mkpkgid "zlib2", [repo2])]
     assertFileContains (tmpdir </> "zlib2/zlib.cabal") ["name:", "zlib"]
 
@@ -239,6 +241,7 @@ testNetworkGitClone =
       verbosity
       tmpdir
       Nothing
+      []
       [(mkpkgid "zlib3", [repo3])]
     assertFileContains (tmpdir </> "zlib3/zlib.cabal") ["version:", "0.5.0.0"]
   where

--- a/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/VCS.hs
@@ -57,7 +57,7 @@ tests :: MTimeChange -> [TestTree]
 tests mtimeChange =
   map
     (localOption $ QuickCheckTests 10)
-    [ ignoreInWindows "See issue #8048" $
+    [ ignoreInWindows "See issue #8048 and #9519" $
         testGroup
           "git"
           [ testProperty "check VCS test framework" prop_framework_git
@@ -227,7 +227,7 @@ testSetup
   -> IO a
 testSetup vcs mkVCSTestDriver repoRecipe theTest = do
   -- test setup
-  vcs' <- configureVCS verbosity vcs
+  vcs' <- configureVCS verbosity [] vcs
   withTestDir verbosity "vcstest" $ \tmpdir -> do
     let srcRepoPath = tmpdir </> "src"
         submodulesPath = tmpdir </> "submodules"

--- a/changelog.d/pr-9341
+++ b/changelog.d/pr-9341
@@ -1,0 +1,11 @@
+synopsis: Fix run command environment
+packages: cabal-install
+prs: #9341
+issues: #8391
+
+description: {
+
+- The Run command will now add binary paths of dependencies
+  (build-tool-depends) to PATH, just like Exec and Test commands.
+
+}

--- a/changelog.d/propagate-extra-prog-path
+++ b/changelog.d/propagate-extra-prog-path
@@ -1,0 +1,13 @@
+synopsis: Fix extra-prog-path propagation
+packages: cabal-install Cabal
+prs: #9527
+issues: #7649 #9519
+
+description: {
+
+- extra-prog-paths are now propagated to all commands. This in particular helps
+  when running a MinGW cabal in the PowerShell, where the MSYS2 paths are
+  usually not available in the PowerShell PATH. GHCup already sets them up for
+  us but they were sometimes lost on the way.
+
+}


### PR DESCRIPTION
Fixes #9519.
Fixes #8391.

This allows finding system executables in:
- `cabal exec` will find whatever executable
- `cabal build` when cloning `source-repository-packages` will find git
- `cabal get` if invoking git (with `-s` for example) will work
- `cabal run`'ed executable inherits the path

In particular this fixes PATH issues when running MinGW cabal in PowerShell.

Paths added are also now logged in info verbosity.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

# QA Notes

In a Windows system with MSYS2/MinGW installed, either system-wide or by ghcup.

Running the following in a PowerShell with previous cabal should fail:
```
PS C:\Users\Javier\code> cabal exec sh
Error: cabal-3.10.2.0.exe: The program 'sh' is required but it could not be
found.
```

And now it should work:
```
PS C:\Users\Javier\code> C:\\Users\\Javier\\code\\cabal\\dist-newstyle\\build\\x86_64-windows\\ghc-9.6.3\\cabal-install-3.11.0.0\\x\\cabal\\build\\cabal\\cabal.exe exec sh
sh-5.2$
```

Also when you have `source-repository-package` stanzas in your cabal.project, it doesn't work:
```
PS C:\Users\Javier\code\foo> cabal build
Error: cabal-3.10.2.0.exe: The program 'git' is required but it could not be
found.
```

And after this PR it does:
```
PS C:\Users\Javier\code\foo> C:\\Users\\Javier\\code\\cabal\\dist-newstyle\\build\\x86_64-windows\\ghc-9.6.3\\cabal-install-3.11.0.0\\x\\cabal\\build\\cabal\\cabal.exe build
Warning: this is a debug build of cabal-install with assertions enabled.
Cloning into '/c/Users/Javier/code/foo/dist-newstyle/src/quickchec_-904b1af1c882c12e'...
remote: Enumerating objects: 6266, done.
...
```

`cabal get -s` used to fail:
```
PS C:\Users\Javier\code\tasty> cabal get quickcheck-state-machine -s --verbose=3
...
Searching for git in path.
Cannot find git on the path
CallStack (from HasCallStack):
  withMetadata, called at src\\Distribution\\Simple\\Utils.hs:368:14 in Cabal-3.10.2.1-inplace:Distribution.Simple.Utils
Error: cabal-3.10.2.0.exe: The program 'git' is required but it could not be
found.
```

not anymore:
```
PS C:\Users\Javier\code\tasty> C:\\Users\\Javier\\code\\cabal\\dist-newstyle\\build\\x86_64-windows\\ghc-9.6.3\\cabal-install-3.11.0.0\\x\\cabal\\build\\cabal\\cabal.exe get quickcheck-state-machine-0.7.0 -s --verbose=3
...
Searching for git in path.
Found git at C:\msys64\usr\bin\git.exe
Running: "C:\msys64\usr\bin\git.exe" "--version"
C:\msys64\usr\bin\git.exe is version 2.43.0
```

The PATH printed in the verbose mode used to sometimes have `\n` interleaved, can be seen with `cabal get -s ... --verbose=3`:
```
("PATH","C:\\ghcup\\bin,\nC:\\cabal\\bin,\nC:\\msys64\\mingw64\\bin,\nC:\\msys64\\usr\\bin;C:\\Program Files\\...")
```
not anymore after this change.
