### PR TITLE
Fix haddock open on windows

### DIFF
--- a/bootstrap/linux-8.10.7.json
+++ b/bootstrap/linux-8.10.7.json
@@ -63,14 +63,14 @@
     ],
     "dependencies": [
         {
-            "cabal_sha256": "458d4794a5ced371a844e325fe539dd5fee8fe41f78b6f00e6c70920b7dd18e3",
+            "cabal_sha256": "446ad0a558ee7efcb0aeebfe147bf3897c50241231a9131ff7d7d24f2c3c1f2f",
             "component": "lib:bytestring",
             "flags": [],
             "package": "bytestring",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "76193d39b66197107f452184597a4e458194c64731efbba1e9605550c732f7f4",
-            "version": "0.11.5.0"
+            "src_sha256": "043a323d506c37e6c71e822f54bca11631c86919d02bc414940935700bfc5c8d",
+            "version": "0.11.5.2"
         },
         {
             "cabal_sha256": "2de84756d3907308230e34fcc7c1917a73f218f6d53838618b7d5b95dd33e2c3",
@@ -85,21 +85,21 @@
             "version": "1.4.100.4"
         },
         {
-            "cabal_sha256": "91cbc951a742fc2c95d5902be38fcf1b859c2891241bc353ff16154a8f7c35ae",
+            "cabal_sha256": "6dfdbb57fcfe5b0b6ecdaf633bc1cceb98a87800a22544f42354375016c6e66c",
             "component": "lib:unix",
             "flags": [],
             "package": "unix",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "cc287659427c80f3598c199387ba7eb7d4cc3270cbb31f75e2f677e879f26384",
-            "version": "2.8.1.1"
+            "src_sha256": "a9dc7868d42ec10e38c4d785eaec7f98d401590d4ebfd8f17ef59da3f18a5dab",
+            "version": "2.8.3.0"
         },
         {
-            "cabal_sha256": "e384a4831b0ac0f8908a1d99d14ce44bf9c5fe2092eec5b2c47ea072d477a493",
+            "cabal_sha256": "bd3b0a0947a365d2da80b9f4a960a864d42ffa7a46577fdc7a0611703486a7f9",
             "component": "lib:directory",
             "flags": [],
             "package": "directory",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "bd8253197587d32d4553070d2de89d3817176860932b0e9ab7bb7ba3759d8e9c",
             "version": "1.3.8.1"
@@ -125,27 +125,37 @@
             "version": "0.8.9.1"
         },
         {
-            "cabal_sha256": "71b5fa8c64d3c1fd0a08f993463220867b08290a2256e94b0952bf0e8f5a45cc",
+            "cabal_sha256": "ad89e28b2b046175698fbf542af2ce43e5d2af50aae9f48d12566b1bb3de1d3c",
+            "component": "lib:data-array-byte",
+            "flags": [],
+            "package": "data-array-byte",
+            "revision": 2,
+            "source": "hackage",
+            "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
+            "version": "0.1.0.1"
+        },
+        {
+            "cabal_sha256": "471b9a22f88b1d51bc343e7d1db7bf88b84e1582eb6d5fbe643fe7afc683c256",
             "component": "lib:text",
             "flags": [
                 "-developer",
                 "+simdutf"
             ],
             "package": "text",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "c735be650a898606ce9f2c8642bc6ac6123eea82871d5e90f92797801f59efad",
-            "version": "2.0.2"
+            "src_sha256": "cbe65b04a28a96a1de364d19c5ee33dc63cd253aa2716d22ceb8496b2062b6c8",
+            "version": "2.1"
         },
         {
-            "cabal_sha256": "5769242043b01bf759b07b7efedcb19607837ee79015fcddde34645664136aed",
+            "cabal_sha256": "6cf18e59d9f1c5b40385457b82ab679dc18d3c5bd3c2c67b2f94e1e8732e6624",
             "component": "lib:parsec",
             "flags": [],
             "package": "parsec",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "a41962e5d76ea68658876735b8d5b755e0eff336b079d0a2f439c364755d1246",
-            "version": "3.1.16.1"
+            "src_sha256": "58c500bec1ec3c849c8243ddfd675a5983b17a8e5da55acea6adade5ae179d36",
+            "version": "3.1.17.0"
         },
         {
             "cabal_sha256": null,
@@ -158,14 +168,14 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "49d8a7f372d35363011591b253cae4c8db8b9ec594590448e20b7bed7acaee98",
+            "cabal_sha256": "69fbbca4151e1a6d1a5da41a1e17c254871675a4f2aed5213bbdfb10b5e52742",
             "component": "lib:process",
             "flags": [],
             "package": "process",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "4c5c454e0f5c864c79b9fabd850307b26d8ac4037e45a6a39ab87e20b583bf06",
-            "version": "1.6.17.0"
+            "src_sha256": "aa5f4c4fe4974f89f5ab998c7509daa4bda3926cfb06daacd5eba892aad8a37e",
+            "version": "1.6.18.0"
         },
         {
             "cabal_sha256": null,
@@ -178,16 +188,16 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "115b8c34b9f83603cfd9eb8b1e2d7ac520da0a4a43d96be435f06ce01a7bc95e",
+            "cabal_sha256": "488cca2a179a5141da8f35a3a7e6699a0ef690f834f589d6b152c4947aa8fe2d",
             "component": "exe:hsc2hs",
             "flags": [
                 "-in-ghc-tree"
             ],
             "package": "hsc2hs",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "c95b10ce0b2c881480e35118d738dcc9cefc435ec72baa0031af81d0d4d3bc0a",
-            "version": "0.68.9"
+            "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
+            "version": "0.68.10"
         },
         {
             "cabal_sha256": "e152cdb03243afb52bbc740cfbe96905ca298a6f6342f0c47b3f2e227ff19def",
@@ -202,27 +212,27 @@
             "version": "3.1.4.0"
         },
         {
-            "cabal_sha256": "e5ae7c083ef3a22248558f8451669bb1c55ea8090f5908b86b9033743c161730",
+            "cabal_sha256": "3e7d1b8f9c72cab04c8dfdfd26589dd7f31e015ad640a207aca3b654577532ff",
             "component": "lib:th-compat",
             "flags": [],
             "package": "th-compat",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "d8f97ac14ab47b6b8a7b0fdb4ff95426322ec56badd01652ac15da4a44d4bab8",
             "version": "0.1.4"
         },
         {
-            "cabal_sha256": "1fde59abf5d82a9666b4415bc2b2e9e33f6c1309074fda12d50410c7dbd95f3b",
+            "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
             "component": "lib:network-uri",
             "flags": [],
             "package": "network-uri",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
             "version": "2.6.4.2"
         },
         {
-            "cabal_sha256": "d9220cc1b8c1f287248d650910710b96e62e54530772e3bcd19dbdec6547f8ae",
+            "cabal_sha256": "0e37572590743e49d7a610f472e1618a594dc861410846f64d9f2347923c4f5b",
             "component": "lib:HTTP",
             "flags": [
                 "-conduit10",
@@ -231,33 +241,23 @@
                 "-warp-tests"
             ],
             "package": "HTTP",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
             "version": "4000.4.1"
         },
         {
-            "cabal_sha256": "0bdd3486d3a1bcbed0513b46af4a13ca74b395313fa5b6e0068d6b7413b76a04",
+            "cabal_sha256": "c4733d09f798fc4304e936924a1a7d9fc2425aefad6c46ad4592035254b46051",
             "component": "lib:base-orphans",
             "flags": [],
             "package": "base-orphans",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "613ed4d8241ed5a648a59ae6569a6962990bb545711d020d49fb83fa12d16e62",
-            "version": "0.9.0"
+            "src_sha256": "5bbf2da382c5b212d6a8be2f8c49edee0eba30f272a15fd32c13e6e4091ef172",
+            "version": "0.9.1"
         },
         {
-            "cabal_sha256": "2ef1bd3511e82ba56f7f23cd793dd2da84338a1e7c2cbea5b151417afe3baada",
-            "component": "lib:data-array-byte",
-            "flags": [],
-            "package": "data-array-byte",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
-            "version": "0.1.0.1"
-        },
-        {
-            "cabal_sha256": "585792335d5541dba78fa8dfcb291a89cd5812a281825ff7a44afa296ab5d58a",
+            "cabal_sha256": "f3bf68acfa0df7a064a378ef2cdcfeb55e6fb96100675f4c593556dcbf3d7194",
             "component": "lib:hashable",
             "flags": [
                 "+integer-gmp",
@@ -266,27 +266,27 @@
             "package": "hashable",
             "revision": 1,
             "source": "hackage",
-            "src_sha256": "1b4000ea82b81f69d46d0af4152c10c6303873510738e24cfc4767760d30e3f8",
-            "version": "1.4.2.0"
+            "src_sha256": "32efb16c2891786209b7cbe5c39df9b3a9ae51e836f1a54f646bc4602b7ab0f5",
+            "version": "1.4.3.0"
         },
         {
-            "cabal_sha256": "46367dc0c8326dcbeb7b93f200b567491c2f6029bccf822b8bb26ee660397e08",
+            "cabal_sha256": "9b8ceefce014e490f9e1335fa5f511161309926c55d01cec795016f4363b5d2d",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 3,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "484df85be0e76c4fed9376451e48e1d0c6e97952ce79735b72d54297e7e0a725",
             "version": "2.2.4"
         },
         {
-            "cabal_sha256": "64abad7816ab8cabed8489e29f807b3a6f828e0b2cec0eae404323d69d36df9a",
+            "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
             "component": "lib:base16-bytestring",
             "flags": [],
             "package": "base16-bytestring",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
             "version": "1.0.2.0"
@@ -302,23 +302,23 @@
             "version": "1.2.1.0"
         },
         {
-            "cabal_sha256": "db25c2e17967aa6b6046ab8b1b96ba3f344ca59a62b60fb6113d51ea305a3d8e",
+            "cabal_sha256": "bac0ae8d46a04e410666b0c8081cff63f060f29157983b569ca86ddb6e6e0dc6",
             "component": "lib:splitmix",
             "flags": [
                 "-optimised-mixer"
             ],
             "package": "splitmix",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "6d065402394e7a9117093dbb4530a21342c9b1e2ec509516c8a8d0ffed98ecaa",
-            "version": "0.1.0.4"
+            "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
+            "version": "0.1.0.5"
         },
         {
-            "cabal_sha256": "dea1f11e5569332dc6c8efaad1cb301016a5587b6754943a49f9de08ae0e56d9",
+            "cabal_sha256": "e7c1f881159d5cc788619c9ee8b8f340ba2ff0db571cdf3d1a1968ebc5108789",
             "component": "lib:random",
             "flags": [],
             "package": "random",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "3e1272f7ed6a4d7bd1712b90143ec326fee9b225789222379fea20a9c90c9b76",
             "version": "1.2.1.1"
@@ -347,14 +347,14 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "72ce9095872eae653addca5f412ac8070d6282d8e1c8578c2237c33f2cbbf4bc",
+            "cabal_sha256": "03db065161987f614a3a2bbcd16264f78e47efe231fb5bd161be2043eaf20488",
             "component": "lib:cryptohash-sha256",
             "flags": [
                 "-exe",
                 "+use-cbits"
             ],
             "package": "cryptohash-sha256",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
             "version": "0.11.102.1"
@@ -372,7 +372,7 @@
             "version": "0.1.4"
         },
         {
-            "cabal_sha256": "3db04d7c18b9e68ba5eef3fa7eeca05e1e248958dd182290c8e6b010c81ef73e",
+            "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
             "component": "lib:ed25519",
             "flags": [
                 "+no-donna",
@@ -381,38 +381,38 @@
                 "+test-properties"
             ],
             "package": "ed25519",
-            "revision": 7,
+            "revision": 8,
             "source": "hackage",
             "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
             "version": "0.0.5.0"
         },
         {
-            "cabal_sha256": "9ab54ee4f80bbd8a3fddd639ea142b7039ee2deb27f7df031a93de1819e34146",
+            "cabal_sha256": "17786545dce60c4d5783ba6125c0a6499a1abddd3d7417b15500ccd767c35f07",
             "component": "lib:lukko",
             "flags": [
                 "+ofd-locking"
             ],
             "package": "lukko",
-            "revision": 4,
+            "revision": 5,
             "source": "hackage",
             "src_sha256": "a80efb60cfa3dae18682c01980d76d5f7e413e191cd186992e1bf7388d48ab1f",
             "version": "0.1.1.3"
         },
         {
-            "cabal_sha256": "63dbcb0f507273a8331363e4c13a1fe91f4ea0c495883cf65f314629582a2630",
+            "cabal_sha256": "aaf5dd3ef327aaf203b1cb199760efd463fac2256453dd0e05d5cd707cdbd6e1",
             "component": "lib:tar",
             "flags": [
                 "-old-bytestring",
                 "-old-time"
             ],
             "package": "tar",
-            "revision": 6,
+            "revision": 10,
             "source": "hackage",
             "src_sha256": "b384449f62b2b0aa3e6d2cb1004b8060b01f21ec93e7b63e7af6d8fad8a9f1de",
             "version": "0.5.1.1"
         },
         {
-            "cabal_sha256": "386dd93bc0352bf6ad5c6bca4dee0442b52d95b4c34e85901064f3eb05c81731",
+            "cabal_sha256": "19eb7759af71957811d5ec10ddb1e2f4c98700ddb9c0da6860c0441d811f0e6d",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -420,13 +420,13 @@
                 "-pkg-config"
             ],
             "package": "zlib",
-            "revision": 2,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "9eaa989ad4534438b5beb51c1d3a4c8f6a088fdff0b259a5394fbf39aaee04da",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "2e5893334ee8967a990349a04953331b28e83bebd64d4f7cb46b71603d183d0c",
+            "cabal_sha256": "2b2e560ac449e49f86a10d79957b2409da5be4b77edabd7425696780334cf3bf",
             "component": "lib:hackage-security",
             "flags": [
                 "+base48",
@@ -437,49 +437,59 @@
                 "+use-network-uri"
             ],
             "package": "hackage-security",
-            "revision": 5,
+            "revision": 8,
             "source": "hackage",
             "src_sha256": "52ee0576971955571d846b8e6c09638f89f4f7881f4a95173e44ccc0d856a066",
             "version": "0.6.2.3"
         },
         {
-            "cabal_sha256": "3a76c313f9f75e8e0b3c103c1bff5bbaf754da30cbddedc1d5b7061d001030e0",
+            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+            "component": "lib:open-browser",
+            "flags": [],
+            "package": "open-browser",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+            "version": "0.2.1.0"
+        },
+        {
+            "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
             "component": "lib:regex-base",
             "flags": [],
             "package": "regex-base",
-            "revision": 2,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
             "version": "0.94.0.2"
         },
         {
-            "cabal_sha256": "d479ca2cc6274c15801169f83dae883c9b62b78af3c7b30ed3fbd4b4612156b8",
+            "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
             "component": "lib:regex-posix",
             "flags": [
                 "-_regex-posix-clib"
             ],
             "package": "regex-posix",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
             "version": "0.96.0.1"
         },
         {
-            "cabal_sha256": "a42b4a473478db92f4728f755403db232b55445e3091a957be073fc8e84e5d46",
+            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 1,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
             "version": "0.2.0.2"
         },
         {
-            "cabal_sha256": "f4aad0eca90044cb1eba53b84f75d5fa142d25d695117730bf31178d409c4fe0",
+            "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
             "component": "lib:safe-exceptions",
             "flags": [],
             "package": "safe-exceptions",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
             "version": "0.1.7.4"
@@ -519,6 +529,16 @@
             "source": "local",
             "src_sha256": null,
             "version": "3.11.0.0"
+        },
+        {
+            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+            "component": "exe:example",
+            "flags": [],
+            "package": "open-browser",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+            "version": "0.2.1.0"
         }
     ]
 }

--- a/bootstrap/linux-9.0.2.json
+++ b/bootstrap/linux-9.0.2.json
@@ -63,14 +63,14 @@
     ],
     "dependencies": [
         {
-            "cabal_sha256": "458d4794a5ced371a844e325fe539dd5fee8fe41f78b6f00e6c70920b7dd18e3",
+            "cabal_sha256": "446ad0a558ee7efcb0aeebfe147bf3897c50241231a9131ff7d7d24f2c3c1f2f",
             "component": "lib:bytestring",
             "flags": [],
             "package": "bytestring",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "76193d39b66197107f452184597a4e458194c64731efbba1e9605550c732f7f4",
-            "version": "0.11.5.0"
+            "src_sha256": "043a323d506c37e6c71e822f54bca11631c86919d02bc414940935700bfc5c8d",
+            "version": "0.11.5.2"
         },
         {
             "cabal_sha256": "2de84756d3907308230e34fcc7c1917a73f218f6d53838618b7d5b95dd33e2c3",
@@ -85,21 +85,21 @@
             "version": "1.4.100.4"
         },
         {
-            "cabal_sha256": "91cbc951a742fc2c95d5902be38fcf1b859c2891241bc353ff16154a8f7c35ae",
+            "cabal_sha256": "6dfdbb57fcfe5b0b6ecdaf633bc1cceb98a87800a22544f42354375016c6e66c",
             "component": "lib:unix",
             "flags": [],
             "package": "unix",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "cc287659427c80f3598c199387ba7eb7d4cc3270cbb31f75e2f677e879f26384",
-            "version": "2.8.1.1"
+            "src_sha256": "a9dc7868d42ec10e38c4d785eaec7f98d401590d4ebfd8f17ef59da3f18a5dab",
+            "version": "2.8.3.0"
         },
         {
-            "cabal_sha256": "e384a4831b0ac0f8908a1d99d14ce44bf9c5fe2092eec5b2c47ea072d477a493",
+            "cabal_sha256": "bd3b0a0947a365d2da80b9f4a960a864d42ffa7a46577fdc7a0611703486a7f9",
             "component": "lib:directory",
             "flags": [],
             "package": "directory",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "bd8253197587d32d4553070d2de89d3817176860932b0e9ab7bb7ba3759d8e9c",
             "version": "1.3.8.1"
@@ -125,27 +125,37 @@
             "version": "0.8.9.1"
         },
         {
-            "cabal_sha256": "71b5fa8c64d3c1fd0a08f993463220867b08290a2256e94b0952bf0e8f5a45cc",
+            "cabal_sha256": "ad89e28b2b046175698fbf542af2ce43e5d2af50aae9f48d12566b1bb3de1d3c",
+            "component": "lib:data-array-byte",
+            "flags": [],
+            "package": "data-array-byte",
+            "revision": 2,
+            "source": "hackage",
+            "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
+            "version": "0.1.0.1"
+        },
+        {
+            "cabal_sha256": "471b9a22f88b1d51bc343e7d1db7bf88b84e1582eb6d5fbe643fe7afc683c256",
             "component": "lib:text",
             "flags": [
                 "-developer",
                 "+simdutf"
             ],
             "package": "text",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "c735be650a898606ce9f2c8642bc6ac6123eea82871d5e90f92797801f59efad",
-            "version": "2.0.2"
+            "src_sha256": "cbe65b04a28a96a1de364d19c5ee33dc63cd253aa2716d22ceb8496b2062b6c8",
+            "version": "2.1"
         },
         {
-            "cabal_sha256": "5769242043b01bf759b07b7efedcb19607837ee79015fcddde34645664136aed",
+            "cabal_sha256": "6cf18e59d9f1c5b40385457b82ab679dc18d3c5bd3c2c67b2f94e1e8732e6624",
             "component": "lib:parsec",
             "flags": [],
             "package": "parsec",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "a41962e5d76ea68658876735b8d5b755e0eff336b079d0a2f439c364755d1246",
-            "version": "3.1.16.1"
+            "src_sha256": "58c500bec1ec3c849c8243ddfd675a5983b17a8e5da55acea6adade5ae179d36",
+            "version": "3.1.17.0"
         },
         {
             "cabal_sha256": null,
@@ -158,14 +168,14 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "49d8a7f372d35363011591b253cae4c8db8b9ec594590448e20b7bed7acaee98",
+            "cabal_sha256": "69fbbca4151e1a6d1a5da41a1e17c254871675a4f2aed5213bbdfb10b5e52742",
             "component": "lib:process",
             "flags": [],
             "package": "process",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "4c5c454e0f5c864c79b9fabd850307b26d8ac4037e45a6a39ab87e20b583bf06",
-            "version": "1.6.17.0"
+            "src_sha256": "aa5f4c4fe4974f89f5ab998c7509daa4bda3926cfb06daacd5eba892aad8a37e",
+            "version": "1.6.18.0"
         },
         {
             "cabal_sha256": null,
@@ -178,16 +188,16 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "115b8c34b9f83603cfd9eb8b1e2d7ac520da0a4a43d96be435f06ce01a7bc95e",
+            "cabal_sha256": "488cca2a179a5141da8f35a3a7e6699a0ef690f834f589d6b152c4947aa8fe2d",
             "component": "exe:hsc2hs",
             "flags": [
                 "-in-ghc-tree"
             ],
             "package": "hsc2hs",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "c95b10ce0b2c881480e35118d738dcc9cefc435ec72baa0031af81d0d4d3bc0a",
-            "version": "0.68.9"
+            "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
+            "version": "0.68.10"
         },
         {
             "cabal_sha256": "e152cdb03243afb52bbc740cfbe96905ca298a6f6342f0c47b3f2e227ff19def",
@@ -202,27 +212,27 @@
             "version": "3.1.4.0"
         },
         {
-            "cabal_sha256": "e5ae7c083ef3a22248558f8451669bb1c55ea8090f5908b86b9033743c161730",
+            "cabal_sha256": "3e7d1b8f9c72cab04c8dfdfd26589dd7f31e015ad640a207aca3b654577532ff",
             "component": "lib:th-compat",
             "flags": [],
             "package": "th-compat",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "d8f97ac14ab47b6b8a7b0fdb4ff95426322ec56badd01652ac15da4a44d4bab8",
             "version": "0.1.4"
         },
         {
-            "cabal_sha256": "1fde59abf5d82a9666b4415bc2b2e9e33f6c1309074fda12d50410c7dbd95f3b",
+            "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
             "component": "lib:network-uri",
             "flags": [],
             "package": "network-uri",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
             "version": "2.6.4.2"
         },
         {
-            "cabal_sha256": "d9220cc1b8c1f287248d650910710b96e62e54530772e3bcd19dbdec6547f8ae",
+            "cabal_sha256": "0e37572590743e49d7a610f472e1618a594dc861410846f64d9f2347923c4f5b",
             "component": "lib:HTTP",
             "flags": [
                 "-conduit10",
@@ -231,33 +241,23 @@
                 "-warp-tests"
             ],
             "package": "HTTP",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
             "version": "4000.4.1"
         },
         {
-            "cabal_sha256": "0bdd3486d3a1bcbed0513b46af4a13ca74b395313fa5b6e0068d6b7413b76a04",
+            "cabal_sha256": "c4733d09f798fc4304e936924a1a7d9fc2425aefad6c46ad4592035254b46051",
             "component": "lib:base-orphans",
             "flags": [],
             "package": "base-orphans",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "613ed4d8241ed5a648a59ae6569a6962990bb545711d020d49fb83fa12d16e62",
-            "version": "0.9.0"
+            "src_sha256": "5bbf2da382c5b212d6a8be2f8c49edee0eba30f272a15fd32c13e6e4091ef172",
+            "version": "0.9.1"
         },
         {
-            "cabal_sha256": "2ef1bd3511e82ba56f7f23cd793dd2da84338a1e7c2cbea5b151417afe3baada",
-            "component": "lib:data-array-byte",
-            "flags": [],
-            "package": "data-array-byte",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
-            "version": "0.1.0.1"
-        },
-        {
-            "cabal_sha256": "585792335d5541dba78fa8dfcb291a89cd5812a281825ff7a44afa296ab5d58a",
+            "cabal_sha256": "f3bf68acfa0df7a064a378ef2cdcfeb55e6fb96100675f4c593556dcbf3d7194",
             "component": "lib:hashable",
             "flags": [
                 "+integer-gmp",
@@ -266,27 +266,27 @@
             "package": "hashable",
             "revision": 1,
             "source": "hackage",
-            "src_sha256": "1b4000ea82b81f69d46d0af4152c10c6303873510738e24cfc4767760d30e3f8",
-            "version": "1.4.2.0"
+            "src_sha256": "32efb16c2891786209b7cbe5c39df9b3a9ae51e836f1a54f646bc4602b7ab0f5",
+            "version": "1.4.3.0"
         },
         {
-            "cabal_sha256": "46367dc0c8326dcbeb7b93f200b567491c2f6029bccf822b8bb26ee660397e08",
+            "cabal_sha256": "9b8ceefce014e490f9e1335fa5f511161309926c55d01cec795016f4363b5d2d",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 3,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "484df85be0e76c4fed9376451e48e1d0c6e97952ce79735b72d54297e7e0a725",
             "version": "2.2.4"
         },
         {
-            "cabal_sha256": "64abad7816ab8cabed8489e29f807b3a6f828e0b2cec0eae404323d69d36df9a",
+            "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
             "component": "lib:base16-bytestring",
             "flags": [],
             "package": "base16-bytestring",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
             "version": "1.0.2.0"
@@ -302,23 +302,23 @@
             "version": "1.2.1.0"
         },
         {
-            "cabal_sha256": "db25c2e17967aa6b6046ab8b1b96ba3f344ca59a62b60fb6113d51ea305a3d8e",
+            "cabal_sha256": "bac0ae8d46a04e410666b0c8081cff63f060f29157983b569ca86ddb6e6e0dc6",
             "component": "lib:splitmix",
             "flags": [
                 "-optimised-mixer"
             ],
             "package": "splitmix",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "6d065402394e7a9117093dbb4530a21342c9b1e2ec509516c8a8d0ffed98ecaa",
-            "version": "0.1.0.4"
+            "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
+            "version": "0.1.0.5"
         },
         {
-            "cabal_sha256": "dea1f11e5569332dc6c8efaad1cb301016a5587b6754943a49f9de08ae0e56d9",
+            "cabal_sha256": "e7c1f881159d5cc788619c9ee8b8f340ba2ff0db571cdf3d1a1968ebc5108789",
             "component": "lib:random",
             "flags": [],
             "package": "random",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "3e1272f7ed6a4d7bd1712b90143ec326fee9b225789222379fea20a9c90c9b76",
             "version": "1.2.1.1"
@@ -347,14 +347,14 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "72ce9095872eae653addca5f412ac8070d6282d8e1c8578c2237c33f2cbbf4bc",
+            "cabal_sha256": "03db065161987f614a3a2bbcd16264f78e47efe231fb5bd161be2043eaf20488",
             "component": "lib:cryptohash-sha256",
             "flags": [
                 "-exe",
                 "+use-cbits"
             ],
             "package": "cryptohash-sha256",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
             "version": "0.11.102.1"
@@ -372,7 +372,7 @@
             "version": "0.1.4"
         },
         {
-            "cabal_sha256": "3db04d7c18b9e68ba5eef3fa7eeca05e1e248958dd182290c8e6b010c81ef73e",
+            "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
             "component": "lib:ed25519",
             "flags": [
                 "+no-donna",
@@ -381,38 +381,38 @@
                 "+test-properties"
             ],
             "package": "ed25519",
-            "revision": 7,
+            "revision": 8,
             "source": "hackage",
             "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
             "version": "0.0.5.0"
         },
         {
-            "cabal_sha256": "9ab54ee4f80bbd8a3fddd639ea142b7039ee2deb27f7df031a93de1819e34146",
+            "cabal_sha256": "17786545dce60c4d5783ba6125c0a6499a1abddd3d7417b15500ccd767c35f07",
             "component": "lib:lukko",
             "flags": [
                 "+ofd-locking"
             ],
             "package": "lukko",
-            "revision": 4,
+            "revision": 5,
             "source": "hackage",
             "src_sha256": "a80efb60cfa3dae18682c01980d76d5f7e413e191cd186992e1bf7388d48ab1f",
             "version": "0.1.1.3"
         },
         {
-            "cabal_sha256": "63dbcb0f507273a8331363e4c13a1fe91f4ea0c495883cf65f314629582a2630",
+            "cabal_sha256": "aaf5dd3ef327aaf203b1cb199760efd463fac2256453dd0e05d5cd707cdbd6e1",
             "component": "lib:tar",
             "flags": [
                 "-old-bytestring",
                 "-old-time"
             ],
             "package": "tar",
-            "revision": 6,
+            "revision": 10,
             "source": "hackage",
             "src_sha256": "b384449f62b2b0aa3e6d2cb1004b8060b01f21ec93e7b63e7af6d8fad8a9f1de",
             "version": "0.5.1.1"
         },
         {
-            "cabal_sha256": "386dd93bc0352bf6ad5c6bca4dee0442b52d95b4c34e85901064f3eb05c81731",
+            "cabal_sha256": "19eb7759af71957811d5ec10ddb1e2f4c98700ddb9c0da6860c0441d811f0e6d",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -420,13 +420,13 @@
                 "-pkg-config"
             ],
             "package": "zlib",
-            "revision": 2,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "9eaa989ad4534438b5beb51c1d3a4c8f6a088fdff0b259a5394fbf39aaee04da",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "2e5893334ee8967a990349a04953331b28e83bebd64d4f7cb46b71603d183d0c",
+            "cabal_sha256": "2b2e560ac449e49f86a10d79957b2409da5be4b77edabd7425696780334cf3bf",
             "component": "lib:hackage-security",
             "flags": [
                 "+base48",
@@ -437,49 +437,59 @@
                 "+use-network-uri"
             ],
             "package": "hackage-security",
-            "revision": 5,
+            "revision": 8,
             "source": "hackage",
             "src_sha256": "52ee0576971955571d846b8e6c09638f89f4f7881f4a95173e44ccc0d856a066",
             "version": "0.6.2.3"
         },
         {
-            "cabal_sha256": "3a76c313f9f75e8e0b3c103c1bff5bbaf754da30cbddedc1d5b7061d001030e0",
+            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+            "component": "lib:open-browser",
+            "flags": [],
+            "package": "open-browser",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+            "version": "0.2.1.0"
+        },
+        {
+            "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
             "component": "lib:regex-base",
             "flags": [],
             "package": "regex-base",
-            "revision": 2,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
             "version": "0.94.0.2"
         },
         {
-            "cabal_sha256": "d479ca2cc6274c15801169f83dae883c9b62b78af3c7b30ed3fbd4b4612156b8",
+            "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
             "component": "lib:regex-posix",
             "flags": [
                 "-_regex-posix-clib"
             ],
             "package": "regex-posix",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
             "version": "0.96.0.1"
         },
         {
-            "cabal_sha256": "a42b4a473478db92f4728f755403db232b55445e3091a957be073fc8e84e5d46",
+            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 1,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
             "version": "0.2.0.2"
         },
         {
-            "cabal_sha256": "f4aad0eca90044cb1eba53b84f75d5fa142d25d695117730bf31178d409c4fe0",
+            "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
             "component": "lib:safe-exceptions",
             "flags": [],
             "package": "safe-exceptions",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
             "version": "0.1.7.4"
@@ -519,6 +529,16 @@
             "source": "local",
             "src_sha256": null,
             "version": "3.11.0.0"
+        },
+        {
+            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+            "component": "exe:example",
+            "flags": [],
+            "package": "open-browser",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+            "version": "0.2.1.0"
         }
     ]
 }

--- a/bootstrap/linux-9.2.7.json
+++ b/bootstrap/linux-9.2.7.json
@@ -91,21 +91,21 @@
             "version": "1.4.100.4"
         },
         {
-            "cabal_sha256": "91cbc951a742fc2c95d5902be38fcf1b859c2891241bc353ff16154a8f7c35ae",
+            "cabal_sha256": "6dfdbb57fcfe5b0b6ecdaf633bc1cceb98a87800a22544f42354375016c6e66c",
             "component": "lib:unix",
             "flags": [],
             "package": "unix",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "cc287659427c80f3598c199387ba7eb7d4cc3270cbb31f75e2f677e879f26384",
-            "version": "2.8.1.1"
+            "src_sha256": "a9dc7868d42ec10e38c4d785eaec7f98d401590d4ebfd8f17ef59da3f18a5dab",
+            "version": "2.8.3.0"
         },
         {
-            "cabal_sha256": "e384a4831b0ac0f8908a1d99d14ce44bf9c5fe2092eec5b2c47ea072d477a493",
+            "cabal_sha256": "bd3b0a0947a365d2da80b9f4a960a864d42ffa7a46577fdc7a0611703486a7f9",
             "component": "lib:directory",
             "flags": [],
             "package": "directory",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "bd8253197587d32d4553070d2de89d3817176860932b0e9ab7bb7ba3759d8e9c",
             "version": "1.3.8.1"
@@ -131,14 +131,14 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "49d8a7f372d35363011591b253cae4c8db8b9ec594590448e20b7bed7acaee98",
+            "cabal_sha256": "69fbbca4151e1a6d1a5da41a1e17c254871675a4f2aed5213bbdfb10b5e52742",
             "component": "lib:process",
             "flags": [],
             "package": "process",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "4c5c454e0f5c864c79b9fabd850307b26d8ac4037e45a6a39ab87e20b583bf06",
-            "version": "1.6.17.0"
+            "src_sha256": "aa5f4c4fe4974f89f5ab998c7509daa4bda3926cfb06daacd5eba892aad8a37e",
+            "version": "1.6.18.0"
         },
         {
             "cabal_sha256": null,
@@ -151,16 +151,16 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "115b8c34b9f83603cfd9eb8b1e2d7ac520da0a4a43d96be435f06ce01a7bc95e",
+            "cabal_sha256": "488cca2a179a5141da8f35a3a7e6699a0ef690f834f589d6b152c4947aa8fe2d",
             "component": "exe:hsc2hs",
             "flags": [
                 "-in-ghc-tree"
             ],
             "package": "hsc2hs",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "c95b10ce0b2c881480e35118d738dcc9cefc435ec72baa0031af81d0d4d3bc0a",
-            "version": "0.68.9"
+            "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
+            "version": "0.68.10"
         },
         {
             "cabal_sha256": "e152cdb03243afb52bbc740cfbe96905ca298a6f6342f0c47b3f2e227ff19def",
@@ -175,27 +175,27 @@
             "version": "3.1.4.0"
         },
         {
-            "cabal_sha256": "e5ae7c083ef3a22248558f8451669bb1c55ea8090f5908b86b9033743c161730",
+            "cabal_sha256": "3e7d1b8f9c72cab04c8dfdfd26589dd7f31e015ad640a207aca3b654577532ff",
             "component": "lib:th-compat",
             "flags": [],
             "package": "th-compat",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "d8f97ac14ab47b6b8a7b0fdb4ff95426322ec56badd01652ac15da4a44d4bab8",
             "version": "0.1.4"
         },
         {
-            "cabal_sha256": "1fde59abf5d82a9666b4415bc2b2e9e33f6c1309074fda12d50410c7dbd95f3b",
+            "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
             "component": "lib:network-uri",
             "flags": [],
             "package": "network-uri",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
             "version": "2.6.4.2"
         },
         {
-            "cabal_sha256": "d9220cc1b8c1f287248d650910710b96e62e54530772e3bcd19dbdec6547f8ae",
+            "cabal_sha256": "0e37572590743e49d7a610f472e1618a594dc861410846f64d9f2347923c4f5b",
             "component": "lib:HTTP",
             "flags": [
                 "-conduit10",
@@ -204,23 +204,23 @@
                 "-warp-tests"
             ],
             "package": "HTTP",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
             "version": "4000.4.1"
         },
         {
-            "cabal_sha256": "2ef1bd3511e82ba56f7f23cd793dd2da84338a1e7c2cbea5b151417afe3baada",
+            "cabal_sha256": "ad89e28b2b046175698fbf542af2ce43e5d2af50aae9f48d12566b1bb3de1d3c",
             "component": "lib:data-array-byte",
             "flags": [],
             "package": "data-array-byte",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
             "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
             "version": "0.1.0.1"
         },
         {
-            "cabal_sha256": "585792335d5541dba78fa8dfcb291a89cd5812a281825ff7a44afa296ab5d58a",
+            "cabal_sha256": "f3bf68acfa0df7a064a378ef2cdcfeb55e6fb96100675f4c593556dcbf3d7194",
             "component": "lib:hashable",
             "flags": [
                 "+integer-gmp",
@@ -229,27 +229,27 @@
             "package": "hashable",
             "revision": 1,
             "source": "hackage",
-            "src_sha256": "1b4000ea82b81f69d46d0af4152c10c6303873510738e24cfc4767760d30e3f8",
-            "version": "1.4.2.0"
+            "src_sha256": "32efb16c2891786209b7cbe5c39df9b3a9ae51e836f1a54f646bc4602b7ab0f5",
+            "version": "1.4.3.0"
         },
         {
-            "cabal_sha256": "46367dc0c8326dcbeb7b93f200b567491c2f6029bccf822b8bb26ee660397e08",
+            "cabal_sha256": "9b8ceefce014e490f9e1335fa5f511161309926c55d01cec795016f4363b5d2d",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 3,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "484df85be0e76c4fed9376451e48e1d0c6e97952ce79735b72d54297e7e0a725",
             "version": "2.2.4"
         },
         {
-            "cabal_sha256": "64abad7816ab8cabed8489e29f807b3a6f828e0b2cec0eae404323d69d36df9a",
+            "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
             "component": "lib:base16-bytestring",
             "flags": [],
             "package": "base16-bytestring",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
             "version": "1.0.2.0"
@@ -265,23 +265,23 @@
             "version": "1.2.1.0"
         },
         {
-            "cabal_sha256": "db25c2e17967aa6b6046ab8b1b96ba3f344ca59a62b60fb6113d51ea305a3d8e",
+            "cabal_sha256": "bac0ae8d46a04e410666b0c8081cff63f060f29157983b569ca86ddb6e6e0dc6",
             "component": "lib:splitmix",
             "flags": [
                 "-optimised-mixer"
             ],
             "package": "splitmix",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "6d065402394e7a9117093dbb4530a21342c9b1e2ec509516c8a8d0ffed98ecaa",
-            "version": "0.1.0.4"
+            "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
+            "version": "0.1.0.5"
         },
         {
-            "cabal_sha256": "dea1f11e5569332dc6c8efaad1cb301016a5587b6754943a49f9de08ae0e56d9",
+            "cabal_sha256": "e7c1f881159d5cc788619c9ee8b8f340ba2ff0db571cdf3d1a1968ebc5108789",
             "component": "lib:random",
             "flags": [],
             "package": "random",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "3e1272f7ed6a4d7bd1712b90143ec326fee9b225789222379fea20a9c90c9b76",
             "version": "1.2.1.1"
@@ -310,14 +310,14 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "72ce9095872eae653addca5f412ac8070d6282d8e1c8578c2237c33f2cbbf4bc",
+            "cabal_sha256": "03db065161987f614a3a2bbcd16264f78e47efe231fb5bd161be2043eaf20488",
             "component": "lib:cryptohash-sha256",
             "flags": [
                 "-exe",
                 "+use-cbits"
             ],
             "package": "cryptohash-sha256",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
             "version": "0.11.102.1"
@@ -335,7 +335,7 @@
             "version": "0.1.4"
         },
         {
-            "cabal_sha256": "3db04d7c18b9e68ba5eef3fa7eeca05e1e248958dd182290c8e6b010c81ef73e",
+            "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
             "component": "lib:ed25519",
             "flags": [
                 "+no-donna",
@@ -344,38 +344,38 @@
                 "+test-properties"
             ],
             "package": "ed25519",
-            "revision": 7,
+            "revision": 8,
             "source": "hackage",
             "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
             "version": "0.0.5.0"
         },
         {
-            "cabal_sha256": "9ab54ee4f80bbd8a3fddd639ea142b7039ee2deb27f7df031a93de1819e34146",
+            "cabal_sha256": "17786545dce60c4d5783ba6125c0a6499a1abddd3d7417b15500ccd767c35f07",
             "component": "lib:lukko",
             "flags": [
                 "+ofd-locking"
             ],
             "package": "lukko",
-            "revision": 4,
+            "revision": 5,
             "source": "hackage",
             "src_sha256": "a80efb60cfa3dae18682c01980d76d5f7e413e191cd186992e1bf7388d48ab1f",
             "version": "0.1.1.3"
         },
         {
-            "cabal_sha256": "63dbcb0f507273a8331363e4c13a1fe91f4ea0c495883cf65f314629582a2630",
+            "cabal_sha256": "aaf5dd3ef327aaf203b1cb199760efd463fac2256453dd0e05d5cd707cdbd6e1",
             "component": "lib:tar",
             "flags": [
                 "-old-bytestring",
                 "-old-time"
             ],
             "package": "tar",
-            "revision": 6,
+            "revision": 10,
             "source": "hackage",
             "src_sha256": "b384449f62b2b0aa3e6d2cb1004b8060b01f21ec93e7b63e7af6d8fad8a9f1de",
             "version": "0.5.1.1"
         },
         {
-            "cabal_sha256": "386dd93bc0352bf6ad5c6bca4dee0442b52d95b4c34e85901064f3eb05c81731",
+            "cabal_sha256": "19eb7759af71957811d5ec10ddb1e2f4c98700ddb9c0da6860c0441d811f0e6d",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -383,13 +383,13 @@
                 "-pkg-config"
             ],
             "package": "zlib",
-            "revision": 2,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "9eaa989ad4534438b5beb51c1d3a4c8f6a088fdff0b259a5394fbf39aaee04da",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "2e5893334ee8967a990349a04953331b28e83bebd64d4f7cb46b71603d183d0c",
+            "cabal_sha256": "2b2e560ac449e49f86a10d79957b2409da5be4b77edabd7425696780334cf3bf",
             "component": "lib:hackage-security",
             "flags": [
                 "+base48",
@@ -400,49 +400,59 @@
                 "+use-network-uri"
             ],
             "package": "hackage-security",
-            "revision": 5,
+            "revision": 8,
             "source": "hackage",
             "src_sha256": "52ee0576971955571d846b8e6c09638f89f4f7881f4a95173e44ccc0d856a066",
             "version": "0.6.2.3"
         },
         {
-            "cabal_sha256": "3a76c313f9f75e8e0b3c103c1bff5bbaf754da30cbddedc1d5b7061d001030e0",
+            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+            "component": "lib:open-browser",
+            "flags": [],
+            "package": "open-browser",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+            "version": "0.2.1.0"
+        },
+        {
+            "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
             "component": "lib:regex-base",
             "flags": [],
             "package": "regex-base",
-            "revision": 2,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
             "version": "0.94.0.2"
         },
         {
-            "cabal_sha256": "d479ca2cc6274c15801169f83dae883c9b62b78af3c7b30ed3fbd4b4612156b8",
+            "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
             "component": "lib:regex-posix",
             "flags": [
                 "-_regex-posix-clib"
             ],
             "package": "regex-posix",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
             "version": "0.96.0.1"
         },
         {
-            "cabal_sha256": "a42b4a473478db92f4728f755403db232b55445e3091a957be073fc8e84e5d46",
+            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 1,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
             "version": "0.2.0.2"
         },
         {
-            "cabal_sha256": "f4aad0eca90044cb1eba53b84f75d5fa142d25d695117730bf31178d409c4fe0",
+            "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
             "component": "lib:safe-exceptions",
             "flags": [],
             "package": "safe-exceptions",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
             "version": "0.1.7.4"
@@ -482,6 +492,16 @@
             "source": "local",
             "src_sha256": null,
             "version": "3.11.0.0"
+        },
+        {
+            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+            "component": "exe:example",
+            "flags": [],
+            "package": "open-browser",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+            "version": "0.2.1.0"
         }
     ]
 }

--- a/bootstrap/linux-9.4.4.json
+++ b/bootstrap/linux-9.4.4.json
@@ -91,21 +91,21 @@
             "version": "1.4.100.4"
         },
         {
-            "cabal_sha256": "91cbc951a742fc2c95d5902be38fcf1b859c2891241bc353ff16154a8f7c35ae",
+            "cabal_sha256": "6dfdbb57fcfe5b0b6ecdaf633bc1cceb98a87800a22544f42354375016c6e66c",
             "component": "lib:unix",
             "flags": [],
             "package": "unix",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "cc287659427c80f3598c199387ba7eb7d4cc3270cbb31f75e2f677e879f26384",
-            "version": "2.8.1.1"
+            "src_sha256": "a9dc7868d42ec10e38c4d785eaec7f98d401590d4ebfd8f17ef59da3f18a5dab",
+            "version": "2.8.3.0"
         },
         {
-            "cabal_sha256": "e384a4831b0ac0f8908a1d99d14ce44bf9c5fe2092eec5b2c47ea072d477a493",
+            "cabal_sha256": "bd3b0a0947a365d2da80b9f4a960a864d42ffa7a46577fdc7a0611703486a7f9",
             "component": "lib:directory",
             "flags": [],
             "package": "directory",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "bd8253197587d32d4553070d2de89d3817176860932b0e9ab7bb7ba3759d8e9c",
             "version": "1.3.8.1"
@@ -131,14 +131,14 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "49d8a7f372d35363011591b253cae4c8db8b9ec594590448e20b7bed7acaee98",
+            "cabal_sha256": "69fbbca4151e1a6d1a5da41a1e17c254871675a4f2aed5213bbdfb10b5e52742",
             "component": "lib:process",
             "flags": [],
             "package": "process",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "4c5c454e0f5c864c79b9fabd850307b26d8ac4037e45a6a39ab87e20b583bf06",
-            "version": "1.6.17.0"
+            "src_sha256": "aa5f4c4fe4974f89f5ab998c7509daa4bda3926cfb06daacd5eba892aad8a37e",
+            "version": "1.6.18.0"
         },
         {
             "cabal_sha256": null,
@@ -151,16 +151,16 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "115b8c34b9f83603cfd9eb8b1e2d7ac520da0a4a43d96be435f06ce01a7bc95e",
+            "cabal_sha256": "488cca2a179a5141da8f35a3a7e6699a0ef690f834f589d6b152c4947aa8fe2d",
             "component": "exe:hsc2hs",
             "flags": [
                 "-in-ghc-tree"
             ],
             "package": "hsc2hs",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
-            "src_sha256": "c95b10ce0b2c881480e35118d738dcc9cefc435ec72baa0031af81d0d4d3bc0a",
-            "version": "0.68.9"
+            "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
+            "version": "0.68.10"
         },
         {
             "cabal_sha256": "e152cdb03243afb52bbc740cfbe96905ca298a6f6342f0c47b3f2e227ff19def",
@@ -175,27 +175,27 @@
             "version": "3.1.4.0"
         },
         {
-            "cabal_sha256": "e5ae7c083ef3a22248558f8451669bb1c55ea8090f5908b86b9033743c161730",
+            "cabal_sha256": "3e7d1b8f9c72cab04c8dfdfd26589dd7f31e015ad640a207aca3b654577532ff",
             "component": "lib:th-compat",
             "flags": [],
             "package": "th-compat",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "d8f97ac14ab47b6b8a7b0fdb4ff95426322ec56badd01652ac15da4a44d4bab8",
             "version": "0.1.4"
         },
         {
-            "cabal_sha256": "1fde59abf5d82a9666b4415bc2b2e9e33f6c1309074fda12d50410c7dbd95f3b",
+            "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
             "component": "lib:network-uri",
             "flags": [],
             "package": "network-uri",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
             "version": "2.6.4.2"
         },
         {
-            "cabal_sha256": "d9220cc1b8c1f287248d650910710b96e62e54530772e3bcd19dbdec6547f8ae",
+            "cabal_sha256": "0e37572590743e49d7a610f472e1618a594dc861410846f64d9f2347923c4f5b",
             "component": "lib:HTTP",
             "flags": [
                 "-conduit10",
@@ -204,13 +204,13 @@
                 "-warp-tests"
             ],
             "package": "HTTP",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
             "version": "4000.4.1"
         },
         {
-            "cabal_sha256": "585792335d5541dba78fa8dfcb291a89cd5812a281825ff7a44afa296ab5d58a",
+            "cabal_sha256": "f3bf68acfa0df7a064a378ef2cdcfeb55e6fb96100675f4c593556dcbf3d7194",
             "component": "lib:hashable",
             "flags": [
                 "+integer-gmp",
@@ -219,27 +219,27 @@
             "package": "hashable",
             "revision": 1,
             "source": "hackage",
-            "src_sha256": "1b4000ea82b81f69d46d0af4152c10c6303873510738e24cfc4767760d30e3f8",
-            "version": "1.4.2.0"
+            "src_sha256": "32efb16c2891786209b7cbe5c39df9b3a9ae51e836f1a54f646bc4602b7ab0f5",
+            "version": "1.4.3.0"
         },
         {
-            "cabal_sha256": "46367dc0c8326dcbeb7b93f200b567491c2f6029bccf822b8bb26ee660397e08",
+            "cabal_sha256": "9b8ceefce014e490f9e1335fa5f511161309926c55d01cec795016f4363b5d2d",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 3,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "484df85be0e76c4fed9376451e48e1d0c6e97952ce79735b72d54297e7e0a725",
             "version": "2.2.4"
         },
         {
-            "cabal_sha256": "64abad7816ab8cabed8489e29f807b3a6f828e0b2cec0eae404323d69d36df9a",
+            "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
             "component": "lib:base16-bytestring",
             "flags": [],
             "package": "base16-bytestring",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
             "version": "1.0.2.0"
@@ -255,23 +255,23 @@
             "version": "1.2.1.0"
         },
         {
-            "cabal_sha256": "db25c2e17967aa6b6046ab8b1b96ba3f344ca59a62b60fb6113d51ea305a3d8e",
+            "cabal_sha256": "bac0ae8d46a04e410666b0c8081cff63f060f29157983b569ca86ddb6e6e0dc6",
             "component": "lib:splitmix",
             "flags": [
                 "-optimised-mixer"
             ],
             "package": "splitmix",
-            "revision": 2,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "6d065402394e7a9117093dbb4530a21342c9b1e2ec509516c8a8d0ffed98ecaa",
-            "version": "0.1.0.4"
+            "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
+            "version": "0.1.0.5"
         },
         {
-            "cabal_sha256": "dea1f11e5569332dc6c8efaad1cb301016a5587b6754943a49f9de08ae0e56d9",
+            "cabal_sha256": "e7c1f881159d5cc788619c9ee8b8f340ba2ff0db571cdf3d1a1968ebc5108789",
             "component": "lib:random",
             "flags": [],
             "package": "random",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "3e1272f7ed6a4d7bd1712b90143ec326fee9b225789222379fea20a9c90c9b76",
             "version": "1.2.1.1"
@@ -300,14 +300,14 @@
             "version": "3.11.0.0"
         },
         {
-            "cabal_sha256": "72ce9095872eae653addca5f412ac8070d6282d8e1c8578c2237c33f2cbbf4bc",
+            "cabal_sha256": "03db065161987f614a3a2bbcd16264f78e47efe231fb5bd161be2043eaf20488",
             "component": "lib:cryptohash-sha256",
             "flags": [
                 "-exe",
                 "+use-cbits"
             ],
             "package": "cryptohash-sha256",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
             "version": "0.11.102.1"
@@ -325,7 +325,7 @@
             "version": "0.1.4"
         },
         {
-            "cabal_sha256": "3db04d7c18b9e68ba5eef3fa7eeca05e1e248958dd182290c8e6b010c81ef73e",
+            "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
             "component": "lib:ed25519",
             "flags": [
                 "+no-donna",
@@ -334,38 +334,38 @@
                 "+test-properties"
             ],
             "package": "ed25519",
-            "revision": 7,
+            "revision": 8,
             "source": "hackage",
             "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
             "version": "0.0.5.0"
         },
         {
-            "cabal_sha256": "9ab54ee4f80bbd8a3fddd639ea142b7039ee2deb27f7df031a93de1819e34146",
+            "cabal_sha256": "17786545dce60c4d5783ba6125c0a6499a1abddd3d7417b15500ccd767c35f07",
             "component": "lib:lukko",
             "flags": [
                 "+ofd-locking"
             ],
             "package": "lukko",
-            "revision": 4,
+            "revision": 5,
             "source": "hackage",
             "src_sha256": "a80efb60cfa3dae18682c01980d76d5f7e413e191cd186992e1bf7388d48ab1f",
             "version": "0.1.1.3"
         },
         {
-            "cabal_sha256": "63dbcb0f507273a8331363e4c13a1fe91f4ea0c495883cf65f314629582a2630",
+            "cabal_sha256": "aaf5dd3ef327aaf203b1cb199760efd463fac2256453dd0e05d5cd707cdbd6e1",
             "component": "lib:tar",
             "flags": [
                 "-old-bytestring",
                 "-old-time"
             ],
             "package": "tar",
-            "revision": 6,
+            "revision": 10,
             "source": "hackage",
             "src_sha256": "b384449f62b2b0aa3e6d2cb1004b8060b01f21ec93e7b63e7af6d8fad8a9f1de",
             "version": "0.5.1.1"
         },
         {
-            "cabal_sha256": "386dd93bc0352bf6ad5c6bca4dee0442b52d95b4c34e85901064f3eb05c81731",
+            "cabal_sha256": "19eb7759af71957811d5ec10ddb1e2f4c98700ddb9c0da6860c0441d811f0e6d",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
@@ -373,13 +373,13 @@
                 "-pkg-config"
             ],
             "package": "zlib",
-            "revision": 2,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "9eaa989ad4534438b5beb51c1d3a4c8f6a088fdff0b259a5394fbf39aaee04da",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "2e5893334ee8967a990349a04953331b28e83bebd64d4f7cb46b71603d183d0c",
+            "cabal_sha256": "2b2e560ac449e49f86a10d79957b2409da5be4b77edabd7425696780334cf3bf",
             "component": "lib:hackage-security",
             "flags": [
                 "+base48",
@@ -390,49 +390,59 @@
                 "+use-network-uri"
             ],
             "package": "hackage-security",
-            "revision": 5,
+            "revision": 8,
             "source": "hackage",
             "src_sha256": "52ee0576971955571d846b8e6c09638f89f4f7881f4a95173e44ccc0d856a066",
             "version": "0.6.2.3"
         },
         {
-            "cabal_sha256": "3a76c313f9f75e8e0b3c103c1bff5bbaf754da30cbddedc1d5b7061d001030e0",
+            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+            "component": "lib:open-browser",
+            "flags": [],
+            "package": "open-browser",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+            "version": "0.2.1.0"
+        },
+        {
+            "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
             "component": "lib:regex-base",
             "flags": [],
             "package": "regex-base",
-            "revision": 2,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
             "version": "0.94.0.2"
         },
         {
-            "cabal_sha256": "d479ca2cc6274c15801169f83dae883c9b62b78af3c7b30ed3fbd4b4612156b8",
+            "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
             "component": "lib:regex-posix",
             "flags": [
                 "-_regex-posix-clib"
             ],
             "package": "regex-posix",
-            "revision": 2,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
             "version": "0.96.0.1"
         },
         {
-            "cabal_sha256": "a42b4a473478db92f4728f755403db232b55445e3091a957be073fc8e84e5d46",
+            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
             "component": "lib:resolv",
             "flags": [],
             "package": "resolv",
-            "revision": 1,
+            "revision": 3,
             "source": "hackage",
             "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
             "version": "0.2.0.2"
         },
         {
-            "cabal_sha256": "f4aad0eca90044cb1eba53b84f75d5fa142d25d695117730bf31178d409c4fe0",
+            "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
             "component": "lib:safe-exceptions",
             "flags": [],
             "package": "safe-exceptions",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
             "version": "0.1.7.4"
@@ -472,6 +482,16 @@
             "source": "local",
             "src_sha256": null,
             "version": "3.11.0.0"
+        },
+        {
+            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+            "component": "exe:example",
+            "flags": [],
+            "package": "open-browser",
+            "revision": 0,
+            "source": "hackage",
+            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+            "version": "0.2.1.0"
         }
     ]
 }

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -238,6 +238,7 @@ library
         hackage-security >= 0.6.2.0 && < 0.7,
         text       >= 1.2.3    && < 1.3 || >= 2.0 && < 2.2,
         parsec     >= 3.1.13.0 && < 3.2,
+        open-browser >= 0.2.1.0 && < 0.3,
         regex-base  >= 0.94.0.0 && <0.95,
         regex-posix >= 0.96.0.0 && <0.97,
         safe-exceptions >= 0.1.7.0 && < 0.2,

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | This module exposes functions to build and register unpacked packages.
 --
@@ -58,7 +59,6 @@ import Distribution.Client.Types hiding
   )
 import Distribution.Client.Utils
   ( ProgressPhase (..)
-  , findOpenProgramLocation
   , progressMessage
   )
 
@@ -85,6 +85,7 @@ import Distribution.Types.BuildType
 import Distribution.Types.PackageDescription.Lens (componentModules)
 
 import Distribution.Simple.Utils
+import Distribution.System (Platform (..))
 import Distribution.Version
 
 import qualified Data.ByteString as BS
@@ -92,11 +93,13 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as LBS.Char8
 import qualified Data.List.NonEmpty as NE
 
-import Control.Exception (Handler (..), SomeAsyncException, assert, catches)
+import Control.Exception (ErrorCall, Handler (..), SomeAsyncException, assert, catches)
 import System.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, removeFile)
 import System.FilePath (dropDrive, normalise, takeDirectory, (<.>), (</>))
 import System.IO (Handle, IOMode (AppendMode), withFile)
 import System.Semaphore (SemaphoreName (..))
+
+import Web.Browser (openBrowser)
 
 import Distribution.Client.Errors
 import Distribution.Compat.Directory (listDirectory)
@@ -420,7 +423,7 @@ buildInplaceUnpackedPackage
   buildSettings@BuildTimeSettings{buildSettingHaddockOpen}
   registerLock
   cacheLock
-  pkgshared@ElaboratedSharedConfig{pkgConfigPlatform = platform}
+  pkgshared@ElaboratedSharedConfig{pkgConfigPlatform = Platform _ os}
   plan
   rpkg@(ReadyPackage pkg)
   buildStatus
@@ -527,10 +530,13 @@ buildInplaceUnpackedPackage
                 docDir = case distHaddockOutputDir of
                   Nothing -> distBuildDirectory distDirLayout dparams </> "doc" </> "html" </> name
                   Just dir -> dir
-            exe <- findOpenProgramLocation platform
-            case exe of
-              Right open -> runProgramInvocation verbosity (simpleProgramInvocation open [dest])
-              Left err -> dieWithException verbosity $ FindOpenProgramLocationErr err
+            catch
+              (void $ openBrowser dest)
+              ( \(_ :: ErrorCall) ->
+                  dieWithException verbosity $
+                    FindOpenProgramLocationErr $
+                      "Unsupported OS: " <> show os
+              )
         PBInstallPhase{runCopy = _runCopy, runRegister} -> do
           -- PURPOSELY omitted: no copy!
 

--- a/cabal-install/src/Distribution/Client/Utils.hs
+++ b/cabal-install/src/Distribution/Client/Utils.hs
@@ -28,7 +28,6 @@ module Distribution.Client.Utils
   , existsAndIsMoreRecentThan
   , tryFindAddSourcePackageDesc
   , tryFindPackageDesc
-  , findOpenProgramLocation
   , relaxEncodingErrors
   , ProgressPhase (..)
   , progressMessage
@@ -69,13 +68,11 @@ import Distribution.Compat.Environment
 import Distribution.Compat.Time (getModTime)
 import Distribution.Simple.Setup (Flag (..))
 import Distribution.Simple.Utils (dieWithException, findPackageDesc, noticeNoWrap)
-import Distribution.System (OS (..), Platform (..))
 import Distribution.Version
 import System.Directory
   ( canonicalizePath
   , doesDirectoryExist
   , doesFileExist
-  , findExecutable
   , getCurrentDirectory
   , getDirectoryContents
   , removeFile
@@ -396,26 +393,6 @@ tryFindPackageDesc verbosity depPath err = do
   case errOrCabalFile of
     Right file -> return file
     Left _ -> dieWithException verbosity $ TryFindPackageDescErr err
-
-findOpenProgramLocation :: Platform -> IO (Either String FilePath)
-findOpenProgramLocation (Platform _ os) =
-  let
-    locate name = do
-      exe <- findExecutable name
-      case exe of
-        Just s -> pure (Right s)
-        Nothing -> pure (Left ("Couldn't find file-opener program `" <> name <> "`"))
-    xdg = locate "xdg-open"
-   in
-    case os of
-      Windows -> pure (Right "start")
-      OSX -> locate "open"
-      Linux -> xdg
-      FreeBSD -> xdg
-      OpenBSD -> xdg
-      NetBSD -> xdg
-      DragonFly -> xdg
-      _ -> pure (Left ("Couldn't determine file-opener program for " <> show os))
 
 -- | Phase of building a dependency. Represents current status of package
 -- dependency processing. See #4040 for details.


### PR DESCRIPTION
A revisit of #9428. Closes #9417

Tested it on my Windows machine, seems to work both in MinGW shell and in PowerShell.

## QA Notes

On a Windows machine, build a haskell project with haddock enabled, and run `cabal haddock --open`. The default browser should be started with the index.html page
