### PR TITLE
Cosmetic changes to `cabal-install` summarized solver output

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Modular/Log.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Log.hs
@@ -7,10 +7,12 @@ import Prelude ()
 import Distribution.Solver.Compat.Prelude
 
 import Distribution.Solver.Types.Progress
-
-import Distribution.Solver.Modular.Dependency
-import Distribution.Solver.Modular.Message
+    ( Progress(Done, Fail), foldProgress, SummarizedMessage, Message )
+import Distribution.Solver.Modular.ConflictSet
+    ( ConflictMap, ConflictSet )
 import Distribution.Solver.Modular.RetryLog
+    ( RetryLog, toProgress, fromProgress )
+import Distribution.Solver.Modular.Message (summarizeMessages)
 
 -- | Information about a dependency solver failure.
 data SolverFailure =
@@ -22,10 +24,10 @@ data SolverFailure =
 -- 'keepLog'), for efficiency.
 displayLogMessages :: Bool
                    -> RetryLog Message SolverFailure a
-                   -> RetryLog SolverTrace SolverFailure a
+                   -> RetryLog SummarizedMessage SolverFailure a
 displayLogMessages keepLog lg = fromProgress $
     if keepLog
-    then groupMessages progress
+    then summarizeMessages progress
     else foldProgress (const id) Fail Done progress
   where
     progress = toProgress lg

--- a/cabal-install-solver/src/Distribution/Solver/Modular/Log.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular/Log.hs
@@ -22,10 +22,10 @@ data SolverFailure =
 -- 'keepLog'), for efficiency.
 displayLogMessages :: Bool
                    -> RetryLog Message SolverFailure a
-                   -> RetryLog String SolverFailure a
+                   -> RetryLog SolverTrace SolverFailure a
 displayLogMessages keepLog lg = fromProgress $
     if keepLog
-    then showMessages progress
+    then groupMessages progress
     else foldProgress (const id) Fail Done progress
   where
     progress = toProgress lg

--- a/cabal-install-solver/src/Distribution/Solver/Types/DependencyResolver.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/DependencyResolver.hs
@@ -2,22 +2,25 @@ module Distribution.Solver.Types.DependencyResolver
     ( DependencyResolver
     ) where
 
-import Distribution.Solver.Compat.Prelude
+import Distribution.Solver.Compat.Prelude ( String, Set )
 import Prelude ()
 
 import Distribution.Solver.Types.LabeledPackageConstraint
+    ( LabeledPackageConstraint )
 import Distribution.Solver.Types.PkgConfigDb ( PkgConfigDb )
 import Distribution.Solver.Types.PackagePreferences
+    ( PackagePreferences )
 import Distribution.Solver.Types.PackageIndex ( PackageIndex )
 import Distribution.Solver.Types.Progress
+    ( Progress, SummarizedMessage )
 import Distribution.Solver.Types.ResolverPackage
-import Distribution.Solver.Types.SourcePackage
+    ( ResolverPackage )
+import Distribution.Solver.Types.SourcePackage ( SourcePackage )
 
 import Distribution.Simple.PackageIndex ( InstalledPackageIndex )
 import Distribution.Package ( PackageName )
 import Distribution.Compiler ( CompilerInfo )
 import Distribution.System ( Platform )
-import Distribution.Solver.Modular.Message ( SolverTrace )
 
 -- | A dependency resolver is a function that works out an installation plan
 -- given the set of installed and available packages and a set of deps to
@@ -35,4 +38,4 @@ type DependencyResolver loc = Platform
                            -> (PackageName -> PackagePreferences)
                            -> [LabeledPackageConstraint]
                            -> Set PackageName
-                           -> Progress SolverTrace String [ResolverPackage loc]
+                           -> Progress SummarizedMessage String [ResolverPackage loc]

--- a/cabal-install-solver/src/Distribution/Solver/Types/DependencyResolver.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/DependencyResolver.hs
@@ -17,6 +17,7 @@ import Distribution.Simple.PackageIndex ( InstalledPackageIndex )
 import Distribution.Package ( PackageName )
 import Distribution.Compiler ( CompilerInfo )
 import Distribution.System ( Platform )
+import Distribution.Solver.Modular.Message ( SolverTrace )
 
 -- | A dependency resolver is a function that works out an installation plan
 -- given the set of installed and available packages and a set of deps to
@@ -34,4 +35,4 @@ type DependencyResolver loc = Platform
                            -> (PackageName -> PackagePreferences)
                            -> [LabeledPackageConstraint]
                            -> Set PackageName
-                           -> Progress String String [ResolverPackage loc]
+                           -> Progress SolverTrace String [ResolverPackage loc]

--- a/cabal-install-solver/src/Distribution/Solver/Types/Progress.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/Progress.hs
@@ -1,10 +1,22 @@
 module Distribution.Solver.Types.Progress
     ( Progress(..)
     , foldProgress
+    , Message(..)
+    , Entry(..)
+    , EntryMsg(..)
+    , SummarizedMessage(..)
     ) where
 
 import Prelude ()
 import Distribution.Solver.Compat.Prelude hiding (fail)
+
+import Distribution.Solver.Modular.Tree
+    ( FailReason(..), POption(..) )
+import Distribution.Solver.Types.PackagePath ( QPN )
+import Distribution.Solver.Modular.Flag ( QSN, QFN )
+import Distribution.Solver.Modular.Dependency
+    ( ConflictSet, QGoalReason, GoalReason, Goal )
+import qualified Distribution.Solver.Modular.ConflictSet as CS
 
 -- | A type to represent the unfolding of an expensive long running
 -- calculation that may fail. We may get intermediate steps before the final
@@ -47,3 +59,32 @@ instance Applicative (Progress step fail) where
 instance Monoid fail => Alternative (Progress step fail) where
   empty   = Fail mempty
   p <|> q = foldProgress Step (const q) Done p
+
+data Message =
+    Enter           -- ^ increase indentation level
+  | Leave           -- ^ decrease indentation level
+  | TryP QPN POption
+  | TryF QFN Bool
+  | TryS QSN Bool
+  | Next (Goal QPN)
+  | Skip (Set CS.Conflict)
+  | Success
+  | Failure ConflictSet FailReason
+
+data Entry
+  = LogPackageGoal QPN QGoalReason
+  | LogRejectF QFN Bool ConflictSet FailReason
+  | LogRejectS QSN Bool ConflictSet FailReason
+  | LogSkipping (Set CS.Conflict)
+  | LogTryingF QFN Bool
+  | LogTryingP QPN POption (Maybe (GoalReason QPN))
+  | LogTryingS QSN Bool
+  | LogRejectMany QPN [POption] ConflictSet FailReason
+  | LogSkipMany QPN [POption] (Set CS.Conflict)
+  | LogUnknownPackage QPN (GoalReason QPN)
+  | LogSuccessMsg
+  | LogFailureMsg ConflictSet FailReason
+
+data EntryMsg = AtLevel Int Entry
+
+data SummarizedMessage = SummarizedMsg EntryMsg | ErrorMsg String

--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -159,6 +159,7 @@ import Data.List
   )
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import Distribution.Solver.Modular.Message (SolverTrace)
 
 -- ------------------------------------------------------------
 
@@ -769,32 +770,33 @@ resolveDependencies
 resolveDependencies platform comp pkgConfigDB params =
   Step (showDepResolverParams finalparams) $
     fmap (validateSolverResult platform comp indGoals) $
-      runSolver
-        ( SolverConfig
-            reordGoals
-            cntConflicts
-            fineGrained
-            minimize
-            indGoals
-            noReinstalls
-            shadowing
-            strFlags
-            onlyConstrained_
-            maxBkjumps
-            enableBj
-            solveExes
-            order
-            verbosity
-            (PruneAfterFirstSuccess False)
-        )
-        platform
-        comp
-        installedPkgIndex
-        sourcePkgIndex
-        pkgConfigDB
-        preferences
-        constraints
-        targets
+      formatProgress $
+        runSolver
+          ( SolverConfig
+              reordGoals
+              cntConflicts
+              fineGrained
+              minimize
+              indGoals
+              noReinstalls
+              shadowing
+              strFlags
+              onlyConstrained_
+              maxBkjumps
+              enableBj
+              solveExes
+              order
+              verbosity
+              (PruneAfterFirstSuccess False)
+          )
+          platform
+          comp
+          installedPkgIndex
+          sourcePkgIndex
+          pkgConfigDB
+          preferences
+          constraints
+          targets
   where
     finalparams@( DepResolverParams
                     targets
@@ -822,6 +824,9 @@ resolveDependencies platform comp pkgConfigDB params =
         if asBool (depResolverAllowBootLibInstalls params)
           then params
           else dontInstallNonReinstallablePackages params
+
+    formatProgress :: Progress SolverTrace String a -> Progress String String a
+    formatProgress p = foldProgress (\x xs -> Step (show x) xs) Fail Done p
 
     preferences :: PackageName -> PackagePreferences
     preferences = interpretPackagesPreference targets defpref prefs


### PR DESCRIPTION
This PR modifies the `cabal-install` CLI behavior by aiming to enhance the solver output slightly (fixing https://github.com/haskell/cabal/issues/4251 by grouping rejected versions by package names). This PR is part of the initiative described in this RFC https://github.com/haskell/cabal/issues/8939, and aims to be a discussion about cosmetic changes that could be done to improve **summarized** solver output (bold text, ANSI colors?), as pointed out by @grayjay.

**Checklist:**

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
