### PR TITLE
Update changelog for per-component with coverage #9464

### DIFF
--- a/changelog.d/pr-9464
+++ b/changelog.d/pr-9464
@@ -1,0 +1,22 @@
+synopsis: Support per-component builds when coverage is enabled
+packages: Cabal cabal-install
+prs: #9464
+issues: #4798 #5213 #6440 #6397
+significance: significant
+
+description: {
+
+Cabal now supports per-component builds when coverage is enabled.  This enables
+coverage for packages with internal libraries (#6440), and enables coverage for
+packages that use backpack (#6397), even though we do not get coverage for
+instantiations of an indefinite module (it is not clear what it means for HPC
+to support backpack, regardless of Cabal).
+
+To achieve this, hpc information (`.mix` files) from a library is now written
+into the package database of a library under `extraCompilationArtifacts`.
+
+Cabal configure (via the Setup interface) now accepts --coverage-for=<unit-id>,
+a flag which specifies which libraries should be included in the coverage
+report for some testsuite.
+
+}


### PR DESCRIPTION
Additionally, a Manual QA note for the same ticket:

## QA Note

Running `cabal test cabal-install --enable-coverage` in the root of the cabal project should succeed and generate a coverage report for `cabal-install`.

---

@fgaz I've addressed your comment from #9464. I think all the relevant documentation has already been added but correct me if I'm wrong.