### PR TITLE
Counter fromListWith reversing constraints order

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Modular.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Modular.hs
@@ -66,7 +66,9 @@ modularResolver sc (Platform arch os) cinfo iidx sidx pkgConfigDB pprefs pcs pns
       -- Indices have to be converted into solver-specific uniform index.
       idx    = convPIs os arch cinfo gcs (shadowPkgs sc) (strongFlags sc) (solveExecutables sc) iidx sidx
       -- Constraints have to be converted into a finite map indexed by PN.
-      gcs    = M.fromListWith (++) (map pair pcs)
+      -- Preserve the order of the constraints, countering fromListWith
+      -- reversing the order by using flip (++).
+      gcs    = M.fromListWith (flip (++)) (map pair pcs)
         where
           pair lpc = (pcName $ unlabelPackageConstraint lpc, [lpc])
 


### PR DESCRIPTION
This does not change behaviour because all constraints are passed to the solver but when we fix #9511, the order will matter if we pick the lastest version equality constraint as the winning one of these constraints and discard the rest before solving. I'm proposing this fix now so that whoever works on this or review it will not be surprised when constraints are given in reversed order.

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

