### PR TITLE
Generate doc/buildinfo-fields-reference.rst

### DIFF
--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -92,3 +92,36 @@ jobs:
         run: make doctest-install
       - name: Doctest
         run: make doctest
+  buildinfo:
+    name: Check buildinfo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set PATH
+        run: |
+          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cabal/store
+          key: linux-store-buildinfo-doc-diff
+      # See https://github.com/haskell/cabal/pull/8739
+      - name: Sudo chmod to permit ghcup to update its cache
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            sudo ls -lah /usr/local/.ghcup/cache
+            sudo mkdir -p /usr/local/.ghcup/cache
+            sudo ls -lah /usr/local/.ghcup/cache
+            sudo chown -R $USER /usr/local/.ghcup
+            sudo chmod -R 777 /usr/local/.ghcup
+          fi
+      - name: ghcup
+        run: |
+          ghcup --version
+          ghcup config set cache true
+          ghcup install ghc --set recommended
+          ghcup install cabal --set latest
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v4
+      - name: Are buildinfo docs up to date?
+        run: make doc/buildinfo-fields-reference.rst
+

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Doctest
         run: make doctest
   buildinfo:
-    name: Check buildinfo
+    name: Check Field Syntax Reference
     runs-on: ubuntu-latest
     steps:
       - name: Set PATH

--- a/Cabal-described/src/Distribution/Described.hs
+++ b/Cabal-described/src/Distribution/Described.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Distribution.Described (
@@ -65,6 +66,7 @@ import Distribution.Utils.GrammarRegex
 -- Types
 import Distribution.Compat.Newtype
 import Distribution.Compiler                       (CompilerFlavor, CompilerId, knownCompilerFlavors)
+import Distribution.PackageDescription.FieldGrammar (CompatFilePath, CompatLicenseFile)
 import Distribution.FieldGrammar.Newtypes
 import Distribution.ModuleName                     (ModuleName)
 import Distribution.System                         (Arch, OS, knownArches, knownOSs)
@@ -95,6 +97,7 @@ import Distribution.Types.SourceRepo               (RepoType)
 import Distribution.Types.TestType                 (TestType)
 import Distribution.Types.UnitId                   (UnitId)
 import Distribution.Types.UnqualComponentName      (UnqualComponentName)
+import Distribution.Utils.Path                     (LicenseFile, PackageDir, SourceDir, SymbolicPath)
 import Distribution.Verbosity                      (Verbosity)
 import Distribution.Version                        (Version, VersionRange)
 import Language.Haskell.Extension                  (Extension, Language)
@@ -575,3 +578,15 @@ instance Described TestedWith where
 
 instance Described FilePathNT where
     describe _ = describe ([] :: [Token])
+
+instance Described (SymbolicPath PackageDir SourceDir) where
+    describe _ = describe ([] :: [Token])
+
+instance Described (SymbolicPath PackageDir LicenseFile) where
+    describe _ = describe ([] :: [Token])
+
+instance Described CompatLicenseFile where
+    describe _ = describe ([] :: [Token])
+
+instance Described CompatFilePath where
+    describe _ = describe ([] :: [Token]) 

--- a/Cabal-described/src/Distribution/Described.hs
+++ b/Cabal-described/src/Distribution/Described.hs
@@ -422,7 +422,7 @@ instance Described IncludeRenaming where
         mr = describe (Proxy :: Proxy ModuleRenaming)
 
 instance Described Language where
-    describe _ = REUnion ["Haskell98", "Haskell2010"]
+    describe _ = REUnion ["GHC2021", "Haskell2010", "Haskell98"]
 
 instance Described LegacyExeDependency where
     describe _ = RETodo

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,14 @@ $(TEMPLATE_PATHS) : templates/Paths_pkg.template.hs cabal-dev-scripts/src/GenPat
 	cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-paths-module -- $< $@
 
 # generated docs
-
-buildinfo-fields-reference : phony
-	cabal build --builddir=dist-newstyle-bi --project-file=cabal.project.buildinfo buildinfo-reference-generator
-	$$(cabal list-bin --builddir=dist-newstyle-bi buildinfo-reference-generator) buildinfo-reference-generator/template.zinza | tee $@
+# Use cabal build before cabal run to avoid output of the build on stdout when running
+doc/buildinfo-fields-reference.rst : \
+  $(wildcard Cabal-syntax/src/*/*.hs Cabal-syntax/src/*/*/*.hs Cabal-syntax/src/*/*/*/*.hs) \
+  $(wildcard Cabal-described/src/Distribution/Described.hs Cabal-described/src/Distribution/Utils/*.hs) \
+  buildinfo-reference-generator/src/Main.hs \
+  buildinfo-reference-generator/template.zinza
+	cabal build --project-file=cabal.project.buildinfo buildinfo-reference-generator
+	cabal run --project-file=cabal.project.buildinfo buildinfo-reference-generator buildinfo-reference-generator/template.zinza | tee $@
 
 # analyse-imports
 analyse-imports : phony

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ doc/buildinfo-fields-reference.rst : \
   buildinfo-reference-generator/template.zinza
 	cabal build --project-file=cabal.project.buildinfo buildinfo-reference-generator
 	cabal run --project-file=cabal.project.buildinfo buildinfo-reference-generator buildinfo-reference-generator/template.zinza | tee $@
+	git diff --exit-code $@
 
 # analyse-imports
 analyse-imports : phony

--- a/buildinfo-reference-generator/buildinfo-reference-generator.cabal
+++ b/buildinfo-reference-generator/buildinfo-reference-generator.cabal
@@ -8,7 +8,7 @@ executable buildinfo-reference-generator
   ghc-options:      -Wall
   main-is:          Main.hs
   build-depends:
-    , base             ^>=4.12 || ^>=4.13
+    , base             >=4.12 && <4.20
     , Cabal
     , Cabal-described
     , containers

--- a/buildinfo-reference-generator/buildinfo-reference-generator.cabal
+++ b/buildinfo-reference-generator/buildinfo-reference-generator.cabal
@@ -8,7 +8,7 @@ executable buildinfo-reference-generator
   ghc-options:      -Wall
   main-is:          Main.hs
   build-depends:
-    , base             >=4.12 && <4.20
+    , base             >=4.11 && <4.20
     , Cabal
     , Cabal-described
     , containers

--- a/buildinfo-reference-generator/template.zinza
+++ b/buildinfo-reference-generator/template.zinza
@@ -157,7 +157,7 @@ Build info fields
 {# We show documentation link only for non deprecated fields #}
 {% if null field.deprecatedSince.fst %}
 {% if null field.removedIn.fst %}
-    * Documentation of :pkg-field:`{{field.name}}<library:{{field.name}}>`
+    * Documentation of :pkg-field:`library:{{field.name}}`
 {% endif %}
 {% endif %}
 {% if notNull field.syntax %}

--- a/buildinfo-reference-generator/template.zinza
+++ b/buildinfo-reference-generator/template.zinza
@@ -157,7 +157,7 @@ Build info fields
 {# We show documentation link only for non deprecated fields #}
 {% if null field.deprecatedSince.fst %}
 {% if null field.removedIn.fst %}
-    * Documentation of :pkg-field:`{{field.name}}`
+    * Documentation of :pkg-field:`{{field.name}}<library:{{field.name}}>`
 {% endif %}
 {% endif %}
 {% if notNull field.syntax %}

--- a/cabal.project.buildinfo
+++ b/cabal.project.buildinfo
@@ -4,7 +4,6 @@ packages: Cabal-described
 packages: buildinfo-reference-generator/
 tests: False
 optimization: False
-with-compiler: ghc-8.8.3
 
 -- avoiding extra dependencies
 constraints: rere -rere-cfg

--- a/doc/buildinfo-fields-reference.rst
+++ b/doc/buildinfo-fields-reference.rst
@@ -164,7 +164,7 @@ Build info fields
 asm-options
     * Monoidal field
     * Available since ``cabal-version: 3.0``.
-    * Documentation of :pkg-field:`asm-options`
+    * Documentation of :pkg-field:`library:asm-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
@@ -172,7 +172,7 @@ asm-options
 asm-sources
     * Monoidal field
     * Available since ``cabal-version: 3.0``.
-    * Documentation of :pkg-field:`asm-sources`
+    * Documentation of :pkg-field:`library:asm-sources`
 
     .. math::
         \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
@@ -180,7 +180,7 @@ asm-sources
 autogen-includes
     * Monoidal field
     * Available since ``cabal-version: 3.0``.
-    * Documentation of :pkg-field:`autogen-includes`
+    * Documentation of :pkg-field:`library:autogen-includes`
 
     .. math::
         \mathrm{optcommalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
@@ -188,21 +188,21 @@ autogen-includes
 autogen-modules
     * Monoidal field
     * Available since ``cabal-version: 2.0``.
-    * Documentation of :pkg-field:`autogen-modules`
+    * Documentation of :pkg-field:`library:autogen-modules`
 
     .. math::
         \mathrm{commalist}\left({\left(\mathop{\mathit{upper}}{\left\{ \mathop{\mathit{alpha\text{-}num}}\mid[\mathop{\mathord{``}\mathtt{\text{'}}\mathord{"}}\mathop{\mathord{``}\mathtt{\text{_}}\mathord{"}}] \right\}}^\ast_{}\right)}^+_{\mathop{\mathord{``}\mathtt{\text{.}}\mathord{"}}}\right)
 
 build-depends
     * Monoidal field
-    * Documentation of :pkg-field:`build-depends`
+    * Documentation of :pkg-field:`library:build-depends`
 
     .. math::
         \mathrm{commalist}\left(\mathop{\mathit{pkg\text{-}name}}{\left(\mathop{\mathord{``}\mathtt{\text{:}}\mathord{"}}\left\{ \mathop{\mathit{unqual\text{-}name}}\mid\mathop{\mathord{``}\mathtt{\{}\mathord{"}}\circ{\mathop{\mathit{unqual\text{-}name}}}^+_{\left(\circ\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}\circ\right)}\circ\mathop{\mathord{``}\mathtt{\}}\mathord{"}} \right\}\right)}^?{\left(\circ\mathop{\mathit{version\text{-}range}}\right)}^?\right)
 
 build-tool-depends
     * Monoidal field
-    * Documentation of :pkg-field:`build-tool-depends`
+    * Documentation of :pkg-field:`library:build-tool-depends`
 
     .. math::
         \mathrm{commalist}\mathsf{\color{red}{TODO}}
@@ -218,21 +218,21 @@ build-tools
 buildable
     * Boolean field
     * Default: ``True``
-    * Documentation of :pkg-field:`buildable`
+    * Documentation of :pkg-field:`library:buildable`
 
     .. math::
         \left\{ \mathop{\mathord{``}\mathtt{True}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{False}\mathord{"}} \right\}
 
 c-sources
     * Monoidal field
-    * Documentation of :pkg-field:`c-sources`
+    * Documentation of :pkg-field:`library:c-sources`
 
     .. math::
         \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 cc-options
     * Monoidal field
-    * Documentation of :pkg-field:`cc-options`
+    * Documentation of :pkg-field:`library:cc-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
@@ -240,7 +240,7 @@ cc-options
 cmm-options
     * Monoidal field
     * Available since ``cabal-version: 3.0``.
-    * Documentation of :pkg-field:`cmm-options`
+    * Documentation of :pkg-field:`library:cmm-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
@@ -248,14 +248,14 @@ cmm-options
 cmm-sources
     * Monoidal field
     * Available since ``cabal-version: 3.0``.
-    * Documentation of :pkg-field:`cmm-sources`
+    * Documentation of :pkg-field:`library:cmm-sources`
 
     .. math::
         \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 cpp-options
     * Monoidal field
-    * Documentation of :pkg-field:`cpp-options`
+    * Documentation of :pkg-field:`library:cpp-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
@@ -263,7 +263,7 @@ cpp-options
 cxx-options
     * Monoidal field
     * Available since ``cabal-version: 2.2``.
-    * Documentation of :pkg-field:`cxx-options`
+    * Documentation of :pkg-field:`library:cxx-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
@@ -271,7 +271,7 @@ cxx-options
 cxx-sources
     * Monoidal field
     * Available since ``cabal-version: 2.2``.
-    * Documentation of :pkg-field:`cxx-sources`
+    * Documentation of :pkg-field:`library:cxx-sources`
 
     .. math::
         \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
@@ -279,7 +279,7 @@ cxx-sources
 default-extensions
     * Monoidal field
     * Available since ``cabal-version: 1.10``.
-    * Documentation of :pkg-field:`default-extensions`
+    * Documentation of :pkg-field:`library:default-extensions`
 
     .. math::
         \mathrm{optcommalist}\mathsf{\color{red}{TODO}}
@@ -287,10 +287,10 @@ default-extensions
 default-language
     * Optional field
     * Available since ``cabal-version: 1.10``.
-    * Documentation of :pkg-field:`default-language`
+    * Documentation of :pkg-field:`library:default-language`
 
     .. math::
-        \left\{ \mathop{\mathord{``}\mathtt{Haskell98}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{Haskell2010}\mathord{"}} \right\}
+        \left\{ \mathop{\mathord{``}\mathtt{GHC2021}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{Haskell2010}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{Haskell98}\mathord{"}} \right\}
 
 extensions
     * Monoidal field
@@ -302,7 +302,7 @@ extensions
 
 extra-bundled-libraries
     * Monoidal field
-    * Documentation of :pkg-field:`extra-bundled-libraries`
+    * Documentation of :pkg-field:`library:extra-bundled-libraries`
 
     .. math::
         \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
@@ -310,105 +310,107 @@ extra-bundled-libraries
 extra-dynamic-library-flavours
     * Monoidal field
     * Available since ``cabal-version: 3.0``.
-    * Documentation of :pkg-field:`extra-dynamic-library-flavours`
+    * Documentation of :pkg-field:`library:extra-dynamic-library-flavours`
 
     .. math::
         \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 extra-framework-dirs
     * Monoidal field
-    * Documentation of :pkg-field:`extra-framework-dirs`
+    * Documentation of :pkg-field:`library:extra-framework-dirs`
 
     .. math::
         \mathrm{optcommalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 extra-ghci-libraries
     * Monoidal field
-    * Documentation of :pkg-field:`extra-ghci-libraries`
+    * Documentation of :pkg-field:`library:extra-ghci-libraries`
 
     .. math::
         \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 extra-lib-dirs
     * Monoidal field
-    * Documentation of :pkg-field:`extra-lib-dirs`
+    * Documentation of :pkg-field:`library:extra-lib-dirs`
 
     .. math::
         \mathrm{optcommalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 extra-lib-dirs-static
     * Monoidal field
-    * Documentation of :pkg-field:`extra-lib-dirs-static`
+    * Available since ``cabal-version: 3.8``.
+    * Documentation of :pkg-field:`library:extra-lib-dirs-static`
 
     .. math::
         \mathrm{optcommalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 extra-libraries
     * Monoidal field
-    * Documentation of :pkg-field:`extra-libraries`
+    * Documentation of :pkg-field:`library:extra-libraries`
+
+    .. math::
+        \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
+
+extra-libraries-static
+    * Monoidal field
+    * Available since ``cabal-version: 3.8``.
+    * Documentation of :pkg-field:`library:extra-libraries-static`
 
     .. math::
         \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 extra-library-flavours
     * Monoidal field
-    * Documentation of :pkg-field:`extra-library-flavours`
-
-    .. math::
-        \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
-
-extra-libraries
-    * Monoidal field
-    * Documentation of :pkg-field:`extra-libraries-static`
+    * Documentation of :pkg-field:`library:extra-library-flavours`
 
     .. math::
         \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 frameworks
     * Monoidal field
-    * Documentation of :pkg-field:`frameworks`
+    * Documentation of :pkg-field:`library:frameworks`
 
     .. math::
         \mathrm{optcommalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 ghc-options
     * Monoidal field
-    * Documentation of :pkg-field:`ghc-options`
+    * Documentation of :pkg-field:`library:ghc-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
 
 ghc-prof-options
     * Monoidal field
-    * Documentation of :pkg-field:`ghc-prof-options`
+    * Documentation of :pkg-field:`library:ghc-prof-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
 
 ghc-shared-options
     * Monoidal field
-    * Documentation of :pkg-field:`ghc-shared-options`
+    * Documentation of :pkg-field:`library:ghc-shared-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
 
 ghcjs-options
     * Monoidal field
-    * Documentation of :pkg-field:`ghcjs-options`
+    * Documentation of :pkg-field:`library:ghcjs-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
 
 ghcjs-prof-options
     * Monoidal field
-    * Documentation of :pkg-field:`ghcjs-prof-options`
+    * Documentation of :pkg-field:`library:ghcjs-prof-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
 
 ghcjs-shared-options
     * Monoidal field
-    * Documentation of :pkg-field:`ghcjs-shared-options`
+    * Documentation of :pkg-field:`library:ghcjs-shared-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
@@ -423,42 +425,50 @@ hs-source-dir
 
 hs-source-dirs
     * Monoidal field
-    * Documentation of :pkg-field:`hs-source-dirs`
+    * Documentation of :pkg-field:`library:hs-source-dirs`
 
     .. math::
         \mathrm{optcommalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
+hsc2hs-options
+    * Monoidal field
+    * Available since ``cabal-version: 3.6``.
+    * Documentation of :pkg-field:`library:hsc2hs-options`
+
+    .. math::
+        {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
+
 include-dirs
     * Monoidal field
-    * Documentation of :pkg-field:`include-dirs`
+    * Documentation of :pkg-field:`library:include-dirs`
 
     .. math::
         \mathrm{optcommalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 includes
     * Monoidal field
-    * Documentation of :pkg-field:`includes`
+    * Documentation of :pkg-field:`library:includes`
 
     .. math::
         \mathrm{optcommalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 install-includes
     * Monoidal field
-    * Documentation of :pkg-field:`install-includes`
+    * Documentation of :pkg-field:`library:install-includes`
 
     .. math::
         \mathrm{optcommalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 js-sources
     * Monoidal field
-    * Documentation of :pkg-field:`js-sources`
+    * Documentation of :pkg-field:`library:js-sources`
 
     .. math::
         \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 ld-options
     * Monoidal field
-    * Documentation of :pkg-field:`ld-options`
+    * Documentation of :pkg-field:`library:ld-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
@@ -466,15 +476,14 @@ ld-options
 mixins
     * Monoidal field
     * Available since ``cabal-version: 2.0``.
-    * Documentation of :pkg-field:`mixins`
+    * Documentation of :pkg-field:`library:mixins`
 
     .. math::
         \mathrm{commalist}\left(\mathop{\mathit{package\text{-}name}}{\left(\mathop{\mathord{``}\mathtt{\text{:}}\mathord{"}}\mathop{\mathit{library\text{-}name}}\right)}^?{\left(\bullet\left\{ \mid\mathop{\mathord{``}\mathtt{hiding}\mathord{"}}\circ\mathop{\mathord{``}\mathtt{\text{(}}\mathord{"}}\circ{\mathop{\mathit{module\text{-}name}}}^\ast_{\left(\circ\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}\circ\right)}\circ\mathop{\mathord{``}\mathtt{\text{)}}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{\text{(}}\mathord{"}}\circ{\left(\mathop{\mathit{module\text{-}name}}{\left(\bullet\mathop{\mathord{``}\mathtt{as}\mathord{"}}\bullet\mathop{\mathit{module\text{-}name}}\right)}^?\right)}^\ast_{\left(\circ\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}\circ\right)}\circ\mathop{\mathord{``}\mathtt{\text{)}}\mathord{"}} \right\}{\left(\circ\mathop{\mathord{``}\mathtt{requires}\mathord{"}}\bullet\left\{ \mid\mathop{\mathord{``}\mathtt{hiding}\mathord{"}}\circ\mathop{\mathord{``}\mathtt{\text{(}}\mathord{"}}\circ{\mathop{\mathit{module\text{-}name}}}^\ast_{\left(\circ\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}\circ\right)}\circ\mathop{\mathord{``}\mathtt{\text{)}}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{\text{(}}\mathord{"}}\circ{\left(\mathop{\mathit{module\text{-}name}}{\left(\bullet\mathop{\mathord{``}\mathtt{as}\mathord{"}}\bullet\mathop{\mathit{module\text{-}name}}\right)}^?\right)}^\ast_{\left(\circ\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}\circ\right)}\circ\mathop{\mathord{``}\mathtt{\text{)}}\mathord{"}} \right\}\right)}^?\right)}^?\right)
 
 other-extensions
     * Monoidal field
-    * Available since ``cabal-version: 1.10``.
-    * Documentation of :pkg-field:`other-extensions`
+    * Documentation of :pkg-field:`library:other-extensions`
 
     .. math::
         \mathrm{optcommalist}\mathsf{\color{red}{TODO}}
@@ -482,21 +491,21 @@ other-extensions
 other-languages
     * Monoidal field
     * Available since ``cabal-version: 1.10``.
-    * Documentation of :pkg-field:`other-languages`
+    * Documentation of :pkg-field:`library:other-languages`
 
     .. math::
-        \mathrm{optcommalist}\left\{ \mathop{\mathord{``}\mathtt{Haskell98}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{Haskell2010}\mathord{"}} \right\}
+        \mathrm{optcommalist}\left\{ \mathop{\mathord{``}\mathtt{GHC2021}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{Haskell2010}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{Haskell98}\mathord{"}} \right\}
 
 other-modules
     * Monoidal field
-    * Documentation of :pkg-field:`other-modules`
+    * Documentation of :pkg-field:`library:other-modules`
 
     .. math::
         \mathrm{commalist}\left({\left(\mathop{\mathit{upper}}{\left\{ \mathop{\mathit{alpha\text{-}num}}\mid[\mathop{\mathord{``}\mathtt{\text{'}}\mathord{"}}\mathop{\mathord{``}\mathtt{\text{_}}\mathord{"}}] \right\}}^\ast_{}\right)}^+_{\mathop{\mathord{``}\mathtt{\text{.}}\mathord{"}}}\right)
 
 pkgconfig-depends
     * Monoidal field
-    * Documentation of :pkg-field:`pkgconfig-depends`
+    * Documentation of :pkg-field:`library:pkgconfig-depends`
 
     .. math::
         \mathrm{commalist}\mathsf{\color{red}{TODO}}
@@ -508,17 +517,6 @@ virtual-modules
 
     .. math::
         \mathrm{commalist}\left({\left(\mathop{\mathit{upper}}{\left\{ \mathop{\mathit{alpha\text{-}num}}\mid[\mathop{\mathord{``}\mathtt{\text{'}}\mathord{"}}\mathop{\mathord{``}\mathtt{\text{_}}\mathord{"}}] \right\}}^\ast_{}\right)}^+_{\mathop{\mathord{``}\mathtt{\text{.}}\mathord{"}}}\right)
-
-
-Library fields
---------------
-
-visibility
-    * Optional field
-    * Documentation of :pkg-field:`library:visibility`
-
-    .. math::
-        \left\{ \mathop{\mathord{``}\mathtt{public}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{private}\mathord{"}} \right\}
 
 
 Package description fields
@@ -557,7 +555,7 @@ copyright
 
 data-dir
     * Optional field
-    * Default: ``""``
+    * Default: ``.``
     * Documentation of :pkg-field:`data-dir`
 
     .. math::
@@ -612,7 +610,7 @@ license-file
     * Documentation of :pkg-field:`license-file`
 
     .. math::
-        \mathrm{optcommalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
+        \left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
 
 maintainer
     * Free text field
@@ -655,6 +653,14 @@ version
 Test-suite fields
 -----------------
 
+code-generators
+    * Monoidal field
+    * Available since ``cabal-version: 3.8``.
+    * Documentation of :pkg-field:`test-suite:code-generators`
+
+    .. math::
+        \mathrm{commalist}\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}\mathop{\mathord{``}\mathtt{\text{,}}\mathord{"}}]^c}}^+_{} \right\}
+
 main-is
     * Optional field
     * Documentation of :pkg-field:`test-suite:main-is`
@@ -675,3 +681,5 @@ type
 
     .. math::
         \left\{ \mathop{\mathord{``}\mathtt{exitcode\text{-}stdio\text{-}1\text{.}0}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{detailed\text{-}0\text{.}9}\mathord{"}} \right\}
+
+


### PR DESCRIPTION
Helps with #9186. Revives the `buildinfo-reference-generator` package, replaces a `PHONY` target with `doc/buildinfo-fields-reference.rst` as the target in the Makefile and updates a field reference. Includes the output generated by the Makefile recipe, `doc/buildinfo-fields-reference.rst`.

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

To test:

```
$ make doc/buildinfo-fields-reference.rst --always-make
```

