### PR TITLE
Use knownLanguages for describing Language

### DIFF
--- a/Cabal-described/src/Distribution/Described.hs
+++ b/Cabal-described/src/Distribution/Described.hs
@@ -39,8 +39,10 @@ module Distribution.Described (
     ) where
 
 import Prelude
-       (Bool (..), Char, Either (..), Enum (..), Eq (..), Ord (..), Show (..), String, elem, fmap, foldr, id, map, maybe, otherwise, return, undefined, ($),
-       (.))
+       ( Bool (..), Char, Either (..), Enum (..), Eq (..), Ord (..), Show (..), String
+       , elem, fmap, foldr, id, map, maybe, otherwise, return, reverse, undefined
+       , ($), (.), (<$>)
+       )
 
 import Data.Functor.Identity (Identity (..))
 import Data.Maybe            (fromMaybe)
@@ -100,7 +102,7 @@ import Distribution.Types.UnqualComponentName      (UnqualComponentName)
 import Distribution.Utils.Path                     (LicenseFile, PackageDir, SourceDir, SymbolicPath)
 import Distribution.Verbosity                      (Verbosity)
 import Distribution.Version                        (Version, VersionRange)
-import Language.Haskell.Extension                  (Extension, Language)
+import Language.Haskell.Extension                  (Extension, Language, knownLanguages)
 
 -- | Class describing the pretty/parsec format of a.
 class (Pretty a, Parsec a) => Described a where
@@ -422,7 +424,7 @@ instance Described IncludeRenaming where
         mr = describe (Proxy :: Proxy ModuleRenaming)
 
 instance Described Language where
-    describe _ = REUnion ["GHC2021", "Haskell2010", "Haskell98"]
+    describe _ = REUnion $ (REString . show) <$> reverse knownLanguages
 
 instance Described LegacyExeDependency where
     describe _ = RETodo

--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -63,7 +63,7 @@ instance Structured Language
 
 instance NFData Language where rnf = genericRnf
 
--- | List of known (supported) languages for GHC
+-- | List of known (supported) languages for GHC, oldest first.
 knownLanguages :: [Language]
 knownLanguages = [Haskell98, Haskell2010, GHC2021]
 


### PR DESCRIPTION
Helps with #9186. Follow up on #9573. Update `knownLanguages` haddocks to mention sort order. Uses `knownLanguages` for describing the grammar of `Language`.

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

To test:

```
$ make doc/buildinfo-fields-reference.rst --always-make
```


