### PR TITLE
Disable flaky index-state related tests, which often fail to `curl`

### DIFF
--- a/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.test.hs
@@ -2,6 +2,9 @@ import Test.Cabal.Prelude
 import Data.List (isPrefixOf)
 
 main = cabalTest $ withProjectFile "cabal.project" $ withRemoteRepo "repo" $ do
+
+  skip "Flaky test failing in `curl`, see #9530"
+
   output <- last
           . words
           . head

--- a/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.test.hs
+++ b/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.test.hs
@@ -1,6 +1,9 @@
 import Test.Cabal.Prelude
 
 main = cabalTest $ withRemoteRepo "repo" $ do
+
+  skip "Flaky test failing in `curl`, see #9530"
+
   -- The _first_ update call causes a warning about missing mirrors, the warning
   -- is platform-dependent and it's not part of the test expectations, so we
   -- check the output manually.


### PR DESCRIPTION
Tracking ticket https://github.com/haskell/cabal/issues/9530

---

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

