### PR TITLE
Switch from criterion to tasty-bench

### DIFF
--- a/cabal-benchmarks/bench/CabalBenchmarks.hs
+++ b/cabal-benchmarks/bench/CabalBenchmarks.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 module Main where
 
-import Criterion.Main                         (bench, bgroup, defaultMain, env, nf, whnf)
+import Test.Tasty.Bench                       (bench, bgroup, defaultMain, env, nf, whnf)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescriptionMaybe)
 import Distribution.Parsec                    (eitherParsec)
 import Distribution.Version

--- a/cabal-benchmarks/cabal-benchmarks.cabal
+++ b/cabal-benchmarks/cabal-benchmarks.cabal
@@ -31,4 +31,4 @@ test-suite cabal-benchmarks
       base
     , bytestring
     , Cabal-syntax
-    , criterion   >=1.5.6.2 && <1.7
+    , tasty-bench >= 0.3.5 && < 0.4


### PR DESCRIPTION
**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

I've recently got frustrated by long CI build times. The patch improves them by eliminating 10 transitive dependencies:

* base-compat-batteries
* binary-orphans
* cassava
* code-page
* criterion
* criterion-measurement
* Glob
* js-chart
* microstache
* Only

As an author of `tasty-bench` I'm obviously biased, so feel free to ignore this shameless act of self-promotion ;) But otherwise `criterion` and `tasty-bench` have compatible APIs; `tasty-bench` capabilities seem sufficient for Cabal purposes, but dependency footprint is much smaller.