### PR TITLE
Build cabal-dev-scripts with ghc-9.8.1

### DIFF
--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -17,7 +17,7 @@ executable gen-spdx
   hs-source-dirs:   src
   ghc-options:      -Wall
   build-depends:
-    , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.1.1.0
+    , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.2.1.0
     , base                  >=4.10     && <4.20
     , bytestring
     , containers
@@ -34,7 +34,7 @@ executable gen-spdx-exc
   hs-source-dirs:   src
   ghc-options:      -Wall
   build-depends:
-    , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.1.1.0
+    , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.2.1.0
     , base                  >=4.10     && <4.20
     , bytestring
     , containers

--- a/cabal-dev-scripts/src/GenSPDX.hs
+++ b/cabal-dev-scripts/src/GenSPDX.hs
@@ -5,7 +5,6 @@ module Main (main) where
 import Control.Lens     (imap)
 import Data.Aeson       (FromJSON (..), eitherDecode, withObject, (.!=), (.:), (.:?))
 import Data.List        (sortOn)
-import Data.Semigroup   ((<>))
 import Data.Text        (Text)
 import Data.Traversable (for)
 

--- a/cabal-dev-scripts/src/GenSPDXExc.hs
+++ b/cabal-dev-scripts/src/GenSPDXExc.hs
@@ -4,7 +4,6 @@ module Main (main) where
 import Control.Lens     (imap)
 import Data.Aeson       (FromJSON (..), eitherDecode, withObject, (.:))
 import Data.List        (sortOn)
-import Data.Semigroup   ((<>))
 import Data.Text        (Text)
 import Data.Traversable (for)
 


### PR DESCRIPTION
Bumps `aeson` upper bounds so that `cabal-dev-scripts` builds with `ghc-9.8.1`. Also satisfies `-Wunused-imports` of `(<>)`.

This can be tested with:

```
$ cabal repl gen-spdx --project-file=cabal.project.meta
$ make spdx --always-make
$ cabal build all --project-file=cabal.project.meta
```

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

