### PR TITLE
Add a --dry-run build check of cabal.project.release

### DIFF
--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -141,5 +141,5 @@ jobs:
         run: cabal v2-update
       - uses: actions/checkout@v4
       - name: Check release project
-        run: cabal build all --enable-tests --enable-benchmarks --dry-run --project-file=cabal.project.release --index-state="hackage.haskell.org HEAD"
+        run: cabal build all --dry-run --project-file=cabal.project.release --index-state="hackage.haskell.org HEAD"
 

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -124,4 +124,22 @@ jobs:
       - uses: actions/checkout@v4
       - name: Are buildinfo docs up to date?
         run: make doc/buildinfo-fields-reference.rst
+  release-project:
+    name: Check Release Project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set PATH
+        run: |
+          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+      - name: ghcup
+        run: |
+          ghcup --version
+          ghcup config set cache true
+          ghcup install ghc --set recommended
+          ghcup install cabal --set latest
+      - name: Update Hackage index
+        run: cabal v2-update
+      - uses: actions/checkout@v4
+      - name: Check release project
+        run: cabal build all --enable-tests --enable-benchmarks --dry-run --project-file=cabal.project.release --index-state="hackage.haskell.org HEAD"
 

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -137,9 +137,11 @@ jobs:
           ghcup config set cache true
           ghcup install ghc --set recommended
           ghcup install cabal --set latest
-      - name: Update Hackage index
+      - name: Update Hackage Index
         run: cabal v2-update
       - uses: actions/checkout@v4
-      - name: Check release project
+      - name: Check Release with Pinned Hackage
+        run: cabal build all --dry-run --project-file=cabal.project.release
+      - name: Check Release with Latest Hackage
         run: cabal build all --dry-run --project-file=cabal.project.release --index-state="hackage.haskell.org HEAD"
 


### PR DESCRIPTION
Fixes #9601. Add a `build --dry-run` quick job for lightweight checking `cabal.project.release`. Increases duplication in `workflows/quick-jobs.yml`.

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

