### PR TITLE
Workaround CI for XDG directories existence

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -37,6 +37,12 @@ jobs:
     name: Bootstrap ${{ matrix.os }} ghc-${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Work around XDG directories existence (haskell-actions/setup#62)
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          rm -rf ~/.config/cabal
+          rm -rf ~/.cache/cabal
+
       - uses: actions/cache@v3
         name: Cache the downloads
         id: bootstrap-cache

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -84,6 +84,12 @@ jobs:
 
     steps:
 
+      - name: Work around XDG directories existence (haskell-actions/setup#62)
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          rm -rf ~/.config/cabal
+          rm -rf ~/.cache/cabal
+
       - uses: actions/checkout@v4
 
       # See https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#hackage-revisions
@@ -281,6 +287,12 @@ jobs:
         ghc: ${{ fromJSON (needs.validate.outputs.GHC_FOR_RELEASE) }}
 
     steps:
+      - name: Work around XDG directories existence (haskell-actions/setup#62)
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          rm -rf ~/.config/cabal
+          rm -rf ~/.cache/cabal
+
       - uses: actions/checkout@v4
 
       # See https://github.com/haskell/cabal/pull/8739


### PR DESCRIPTION
On MacOS, deletes the cabal XDG directories as a first step. Workaround for haskell-actions/setup#62.

