### PR TITLE
 Include the GHC "Project Unit Id" in the cabal store path

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -82,7 +82,7 @@ module Distribution.Simple.GHC
 import Distribution.Compat.Prelude
 import Prelude ()
 
-import Control.Monad (forM_, msum)
+import Control.Monad (forM_)
 import Data.List (stripPrefix)
 import qualified Data.Map as Map
 import Distribution.CabalSpecVersion

--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
 
@@ -81,7 +82,8 @@ module Distribution.Simple.GHC
 import Distribution.Compat.Prelude
 import Prelude ()
 
-import Control.Monad (forM_)
+import Control.Monad (forM_, msum)
+import Data.List (stripPrefix)
 import qualified Data.Map as Map
 import Distribution.CabalSpecVersion
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
@@ -236,10 +238,16 @@ configure verbosity hcPath hcPkgPath conf0 = do
 
       filterExt ext = filter ((/= EnableExtension ext) . fst)
 
+      compilerId :: CompilerId
+      compilerId = CompilerId GHC ghcVersion
+
+      compilerAbiTag :: AbiTag
+      compilerAbiTag = maybe NoAbiTag AbiTag (Map.lookup "Project Unit Id" ghcInfoMap >>= stripPrefix (prettyShow compilerId <> "-"))
+
   let comp =
         Compiler
-          { compilerId = CompilerId GHC ghcVersion
-          , compilerAbiTag = NoAbiTag
+          { compilerId
+          , compilerAbiTag
           , compilerCompat = []
           , compilerLanguages = languages
           , compilerExtensions = extensions

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -54,9 +54,6 @@ import Distribution.Client.TargetProblem (TargetProblem (..))
 import Distribution.Simple.Command
   ( CommandUI (..)
   )
-import Distribution.Simple.Compiler
-  ( Compiler (..)
-  )
 import Distribution.Simple.Flag
   ( Flag (..)
   , fromFlag
@@ -319,7 +316,7 @@ haddockProjectAction flags _extraArgs globalFlags = do
                     packageDir =
                       storePackageDirectory
                         (cabalStoreDirLayout cabalLayout)
-                        (compilerId (pkgConfigCompiler sharedConfig'))
+                        (pkgConfigCompiler sharedConfig')
                         (elabUnitId package)
                     docDir = packageDir </> "share" </> "doc" </> "html"
                     destDir = outputDir </> packageName

--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -517,8 +517,7 @@ installAction flags@NixStyleFlags{extraFlags = clientInstallFlags', ..} targetSt
 
   -- progDb is a program database with compiler tools configured properly
   ( compiler@Compiler
-      { compilerId =
-        compilerId@(CompilerId compilerFlavor compilerVersion)
+      { compilerId = CompilerId compilerFlavor compilerVersion
       }
     , platform
     , progDb
@@ -531,7 +530,7 @@ installAction flags@NixStyleFlags{extraFlags = clientInstallFlags', ..} targetSt
   envFile <- getEnvFile clientInstallFlags platform compilerVersion
   existingEnvEntries <-
     getExistingEnvEntries verbosity compilerFlavor supportsPkgEnvFiles envFile
-  packageDbs <- getPackageDbStack compilerId projectConfigStoreDir projectConfigLogsDir
+  packageDbs <- getPackageDbStack compiler projectConfigStoreDir projectConfigLogsDir
   installedIndex <- getInstalledPackages verbosity compiler packageDbs progDb
 
   let
@@ -840,7 +839,7 @@ prepareExeInstall
         mkUnitBinDir :: UnitId -> FilePath
         mkUnitBinDir =
           InstallDirs.bindir
-            . storePackageInstallDirs' storeDirLayout (compilerId compiler)
+            . storePackageInstallDirs' storeDirLayout compiler
 
         mkExeName :: UnqualComponentName -> FilePath
         mkExeName exe = unUnqualComponentName exe <.> exeExtension platform
@@ -1212,16 +1211,16 @@ getLocalEnv dir platform compilerVersion =
     <> ghcPlatformAndVersionString platform compilerVersion
 
 getPackageDbStack
-  :: CompilerId
+  :: Compiler
   -> Flag FilePath
   -> Flag FilePath
   -> IO PackageDBStack
-getPackageDbStack compilerId storeDirFlag logsDirFlag = do
+getPackageDbStack compiler storeDirFlag logsDirFlag = do
   mstoreDir <- traverse makeAbsolute $ flagToMaybe storeDirFlag
   let
     mlogsDir = flagToMaybe logsDirFlag
   cabalLayout <- mkCabalDirLayout mstoreDir mlogsDir
-  pure $ storePackageDBStack (cabalStoreDirLayout cabalLayout) compilerId
+  pure $ storePackageDBStack (cabalStoreDirLayout cabalLayout) compiler
 
 -- | This defines what a 'TargetSelector' means for the @bench@ command.
 -- It selects the 'AvailableTarget's that the 'TargetSelector' refers to,

--- a/cabal-install/src/Distribution/Client/PackageHash.hs
+++ b/cabal-install/src/Distribution/Client/PackageHash.hs
@@ -10,6 +10,8 @@
 --   * the package tarball
 --   * the ids of all the direct dependencies
 --   * other local configuration (flags, profiling, etc)
+--
+-- See 'PackageHashInputs' for a detailed list of what determines the hash.
 module Distribution.Client.PackageHash
   ( -- * Calculating package hashes
     PackageHashInputs (..)
@@ -38,7 +40,8 @@ import Distribution.Package
   , mkComponentId
   )
 import Distribution.Simple.Compiler
-  ( CompilerId
+  ( AbiTag (..)
+  , CompilerId
   , DebugInfoLevel (..)
   , OptimisationLevel (..)
   , PackageDB
@@ -191,6 +194,7 @@ type PackageSourceHash = HashValue
 -- package hash.
 data PackageHashConfigInputs = PackageHashConfigInputs
   { pkgHashCompilerId :: CompilerId
+  , pkgHashCompilerABI :: AbiTag
   , pkgHashPlatform :: Platform
   , pkgHashFlagAssignment :: FlagAssignment -- complete not partial
   , pkgHashConfigureScriptArgs :: [String] -- just ./configure for build-type Configure
@@ -301,6 +305,7 @@ renderPackageHashInputs
               pkgHashDirectDeps
           , -- and then all the config
             entry "compilerid" prettyShow pkgHashCompilerId
+          , entry "compilerabi" prettyShow pkgHashCompilerABI
           , entry "platform" prettyShow pkgHashPlatform
           , opt "flags" mempty showFlagAssignment pkgHashFlagAssignment
           , opt "configure-script" [] unwords pkgHashConfigureScriptArgs

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -71,7 +71,6 @@ import Distribution.Simple.BuildPaths (haddockDirName)
 import Distribution.Simple.Command (CommandUI)
 import Distribution.Simple.Compiler
   ( PackageDBStack
-  , compilerId
   )
 import qualified Distribution.Simple.InstallDirs as InstallDirs
 import Distribution.Simple.LocalBuildInfo

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -681,12 +681,12 @@ buildAndInstallUnpackedPackage
                 | otherwise = do
                     assert
                       ( elabRegisterPackageDBStack pkg
-                          == storePackageDBStack compid
+                          == storePackageDBStack compiler
                       )
                       (return ())
                     _ <-
                       runRegister
-                        (storePackageDBStack compid)
+                        (storePackageDBStack compiler)
                         Cabal.defaultRegisterOptions
                           { Cabal.registerMultiInstance = True
                           , Cabal.registerSuppressFilesCheck = True
@@ -698,7 +698,7 @@ buildAndInstallUnpackedPackage
             newStoreEntry
               verbosity
               storeDirLayout
-              compid
+              compiler
               uid
               (copyPkgFiles verbosity pkgshared pkg runCopy)
               registerPkg
@@ -735,7 +735,6 @@ buildAndInstallUnpackedPackage
     where
       uid = installedUnitId rpkg
       pkgid = packageId rpkg
-      compid = compilerId compiler
 
       dispname :: String
       dispname = case elabPkgOrComp pkg of

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -854,7 +854,7 @@ rebuildInstallPlan
         -> Rebuild ElaboratedInstallPlan
       phaseImprovePlan elaboratedPlan elaboratedShared = do
         liftIO $ debug verbosity "Improving the install plan..."
-        storePkgIdSet <- getStoreEntries cabalStoreDirLayout compid
+        storePkgIdSet <- getStoreEntries cabalStoreDirLayout compiler
         let improvedPlan =
               improveInstallPlanWithInstalledPackages
                 storePkgIdSet
@@ -866,7 +866,7 @@ rebuildInstallPlan
         -- matches up as expected, e.g. no dangling deps, files deleted.
         return improvedPlan
         where
-          compid = compilerId (pkgConfigCompiler elaboratedShared)
+          compiler = pkgConfigCompiler elaboratedShared
 
 -- | If a 'PackageSpecifier' refers to a single package, return Just that
 -- package.
@@ -2319,7 +2319,7 @@ elaborateInstallPlan
 
       corePackageDbs =
         applyPackageDbFlags
-          (storePackageDBStack (compilerId compiler))
+          (storePackageDBStack compiler)
           (projectConfigPackageDBs sharedPackageConfig)
 
       -- For this local build policy, every package that lives in a local source
@@ -3768,15 +3768,15 @@ userInstallDirTemplates compiler = do
 
 storePackageInstallDirs
   :: StoreDirLayout
-  -> CompilerId
+  -> Compiler
   -> InstalledPackageId
   -> InstallDirs.InstallDirs FilePath
-storePackageInstallDirs storeDirLayout compid ipkgid =
-  storePackageInstallDirs' storeDirLayout compid $ newSimpleUnitId ipkgid
+storePackageInstallDirs storeDirLayout compiler ipkgid =
+  storePackageInstallDirs' storeDirLayout compiler $ newSimpleUnitId ipkgid
 
 storePackageInstallDirs'
   :: StoreDirLayout
-  -> CompilerId
+  -> Compiler
   -> UnitId
   -> InstallDirs.InstallDirs FilePath
 storePackageInstallDirs'
@@ -3784,12 +3784,12 @@ storePackageInstallDirs'
     { storePackageDirectory
     , storeDirectory
     }
-  compid
+  compiler
   unitid =
     InstallDirs.InstallDirs{..}
     where
-      store = storeDirectory compid
-      prefix = storePackageDirectory compid unitid
+      store = storeDirectory compiler
+      prefix = storePackageDirectory compiler unitid
       bindir = prefix </> "bin"
       libdir = prefix </> "lib"
       libsubdir = ""
@@ -3839,7 +3839,7 @@ computeInstallDirs storeDirLayout defaultInstallDirs elaboratedShared elab
       -- use special simplified install dirs
       storePackageInstallDirs'
         storeDirLayout
-        (compilerId (pkgConfigCompiler elaboratedShared))
+        (pkgConfigCompiler elaboratedShared)
         (elabUnitId elab)
 
 -- TODO: [code cleanup] perhaps reorder this code

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -4303,6 +4303,7 @@ packageHashConfigInputs
 packageHashConfigInputs shared@ElaboratedSharedConfig{..} pkg =
   PackageHashConfigInputs
     { pkgHashCompilerId = compilerId pkgConfigCompiler
+    , pkgHashCompilerABI = compilerAbiTag pkgConfigCompiler
     , pkgHashPlatform = pkgConfigPlatform
     , pkgHashFlagAssignment = elabFlagAssignment
     , pkgHashConfigureScriptArgs = elabConfigureScriptArgs

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -63,7 +63,7 @@ import Test.Cabal.TestCode
 import Distribution.Pretty (prettyShow)
 import Distribution.Simple.Compiler
     ( PackageDBStack, PackageDB(..), compilerFlavor
-    , Compiler, compilerVersion, showCompilerId )
+    , Compiler, compilerVersion, showCompilerIdWithAbi )
 import Distribution.System
 import Distribution.Simple.Program.Db
 import Distribution.Simple.Program
@@ -582,7 +582,7 @@ testLibInstallDir env = libDir </> compilerDir
     libDir = case os of
       Windows -> testPrefixDir env
       _ -> testPrefixDir env </> "lib"
-    compilerDir = prettyShow platform ++ "-" ++ showCompilerId (testCompiler env)
+    compilerDir = prettyShow platform ++ "-" ++ showCompilerIdWithAbi (testCompiler env)
 
 -- | The absolute path to the build directory that should be used
 -- for the current package in a test.

--- a/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
+++ b/cabal-testsuite/src/Test/Cabal/OutputNormalizer.hs
@@ -58,7 +58,9 @@ normalizeOutput nenv =
   . (if normalizerGhcVersion nenv /= nullVersion
         then resub (posixRegexEscape (display (normalizerGhcVersion nenv))
                         -- Also glob the date, for nightly GHC builds
-                        ++ "(\\.[0-9]+)?")
+                        ++ "(\\.[0-9]+)?"
+                        -- Also glob the ABI hash, for GHCs which support it
+                        ++ "(-[a-z0-9]+)?")
                    "<GHCVER>"
         else id)
   -- hackage-security locks occur non-deterministically

--- a/changelog.d/pr-9326
+++ b/changelog.d/pr-9326
@@ -1,0 +1,10 @@
+synopsis: Include the GHC "Project Unit Id" in the cabal store path
+packages: Cabal cabal-install
+prs: #9326
+issues: #8114
+description: {
+- This allows the use of several **API incompatible builds of the same version
+  of GHC** without corrupting the cabal store.
+- This relies on the "Project Unit Id" which is available since GHC 9.8.1,
+  older versions of GHC do not benefit from this change.
+}


### PR DESCRIPTION
* This allows the use of several API incompatible builds of the same version of GHC without corrupting the cabal store.
* This relies on the "Project Unit Id" which is available since GHC 9.8.1, older versions of GHC do not benefit from this change.

This PR is an alternative to #9325. It changes the store path from e.g. [...]store/ghc-9.8.1 to [..]store/ghc-9.8.1-f7d8.
It is a continuation of #9326 that rebases and finalizes it.

[fixes #8114]
