### PR TITLE
testsuite: Fix hardcoded /bin/bash in custom-cc wrapper

### DIFF
--- a/cabal-testsuite/PackageTests/CCompilerOverride/custom-cc
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/custom-cc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if which cc >/dev/null 2>&1; then
     cc -DNOERROR6 "${@}"


### PR DESCRIPTION
Not all operating systems have `/bin/bash` available, it is more portable to use `/usr/bin/env bash`

For example: https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.


---

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

