### PR TITLE
Don't inherit package database to tests

### DIFF
--- a/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/setup.test.hs
+++ b/cabal-testsuite/PackageTests/PathsModule/Executable-Relocatable/setup.test.hs
@@ -4,4 +4,4 @@ import Test.Cabal.Prelude
 main = setupAndCabalTest $ do
   skipIfWindows
   skipUnlessGhcVersion ">= 8.0"
-  setup_build ["--enable-relocatable"]
+  withPackageDb $ setup_build ["--enable-relocatable"]

--- a/cabal-testsuite/main/cabal-tests.hs
+++ b/cabal-testsuite/main/cabal-tests.hs
@@ -34,6 +34,35 @@ import Data.Monoid ((<>))
 import Data.Monoid (mempty)
 #endif
 
+{- Note [Testsuite package environments]
+
+There are three different package environments which are used when running the
+testsuite.
+
+1. Environment used to compile `cabal-tests` executable
+2. Environment used to run test scripts "setup.test.hs"
+3. Environment made available to tests themselves via `./Setup configure`
+
+These are all distinct from each other and should be specified separately.
+
+Where are these environments specified:
+
+1. The build-depends on `cabal-tests` executable in `cabal-testsuite.cabal`
+2. The build-depends of `test-runtime-deps` executable in `cabal-testsuite.cabal`
+   These dependencies are injected in a special module (`Test.Cabal.ScriptEnv0`) which
+   then is consulted in `Test.Cabal.Monad` in order to pass the right environmnet.
+   This is mechanism by which the `./Setup` tests have access to the in-tree `Cabal`
+   and `Cabal-syntax` libraries.
+3. No specification, only the `GlobalPackageDb` is available (see
+   `testPackageDBStack`) unless the test itself augments the environment with
+   `withPackageDb`.
+
+At the moment, `cabal-install` tests always use the bootstrap cabal, which is a
+bit confusing but `cabal-install` is not flexible enough to be given additional
+package databases (yet).
+
+-}
+
 -- | Record for arguments that can be passed to @cabal-tests@ executable.
 data MainArgs = MainArgs {
         mainArgThreads :: Int,

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -289,24 +289,7 @@ runTestM mode m = withSystemTempDirectory "cabal-testsuite" $ \tmp_dir -> do
     -- them up we must configure them
     program_db <- configureAllKnownPrograms verbosity program_db3
 
-    let ghcAndRunnedGhcAreTheSame :: Bool
-        ghcAndRunnedGhcAreTheSame = fromMaybe False $ do
-            ghc_program        <- lookupProgram ghcProgram program_db
-            runner_ghc_program <- lookupProgram ghcProgram (runnerProgramDb senv)
-            return $ programPath ghc_program == programPath runner_ghc_program
-
-    let db_stack =
-            case argGhcPath (testCommonArgs args) of
-                Nothing -> runnerPackageDbStack senv -- NB: canonicalized
-                -- Can't use the build package db stack since they
-                -- are all for the wrong versions!  TODO: Make
-                -- this configurable
-                --
-                -- Oleg: if runner ghc and provided ghc are the same,
-                -- use runnerPackageDbStack. See 'hasCabalForGhc' check.
-                Just _
-                    | ghcAndRunnedGhcAreTheSame -> runnerPackageDbStack senv
-                    | otherwise                 -> [GlobalPackageDB]
+    let db_stack = [GlobalPackageDB]
         env = TestEnv {
                     testSourceDir = script_dir,
                     testTmpDir = tmp_dir,


### PR DESCRIPTION
I can't think of a reason why it would be desirable to expose the user's cabal store or local dist-newstyle to the test runner. In fact, this can break test output in certain situations depending on what is in your store.

Tests should run in as hemertic environment as possible and not depend on anything to do with external system configuration.

Here to test on CI if this breaks any test cases.


**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

