### PR TITLE
Add static pre-release job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -283,6 +283,68 @@ jobs:
           EXTRA_GHC: "/opt/ghc/${{ matrix.extra-ghc }}/bin/ghc-${{ matrix.extra-ghc }}"
         run: sh validate.sh ${{ env.COMMON_FLAGS }} --lib-only -s lib-suite-extras --extra-hc ${{ env.EXTRA_GHC }}
 
+  build-alpine:
+    name: Build statically linked using alpine 
+    runs-on: "ubuntu-latest"
+    container: "alpine:3.19"
+    steps:
+      - name: Install extra dependencies
+        shell: sh
+        run: |
+          apk add bash curl sudo jq pkgconfig \
+          zlib-dev zlib-static binutils-gold curl \
+          gcc g++ gmp-dev libc-dev libffi-dev make \
+          musl-dev ncurses-dev perl tar xz
+
+      - uses: actions/checkout@v4
+
+      # See https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#hackage-revisions
+      - name: Manually supplied constraints/allow-newer
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo 'allow-newer:' ${ALLOWNEWER}  >> cabal.project.validate
+          echo 'constraints:' ${CONSTRAINTS} >> cabal.project.validate
+
+      #  See the following link for a breakdown of the following step
+      #  https://github.com/haskell/actions/issues/7#issuecomment-745697160
+      - uses: actions/cache@v3
+        with:
+          # validate.sh uses a special build dir
+          path: |
+            ${{ steps.setup-haskell.outputs.cabal-store }}
+            dist-*
+          key: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-
+
+      - uses: haskell-actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: ${{ env.GHC_FOR_RELEASE }}
+          cabal-version: latest # latest is mandatory for cabal-testsuite, see https://github.com/haskell/cabal/issues/8133
+
+      - name: Enable statically linked executables
+        run: |
+          echo 'executable-static: true' >> cabal.project.validate
+
+      - name: Build
+        run: sh validate.sh $FLAGS -s build
+
+      - name: Tar cabal head executable
+        run: |
+          CABAL_EXEC=$(cabal list-bin --builddir=dist-newstyle-validate-ghc-${{ env.GHC_FOR_RELEASE }} --project-file=cabal.project.validate cabal-install:exe:cabal)
+          # We have to tar the executable to preserve executable permissions
+          # see https://github.com/actions/upload-artifact/issues/38
+          export CABAL_EXEC_TAR="cabal-head-${{ runner.os }}-static-x86_64.tar.gz"
+          tar -czvf $CABAL_EXEC_TAR -C $(dirname "$CABAL_EXEC") $(basename "$CABAL_EXEC")
+          echo "CABAL_EXEC_TAR=$CABAL_EXEC_TAR" >> $GITHUB_ENV
+
+      - name: Upload cabal-install executable to workflow artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: cabal-${{ runner.os }}-static-x86_64
+          path: ${{ env.CABAL_EXEC_TAR }}
+
+
   # The previous jobs use a released version of cabal to build cabal HEAD itself
   # This one uses the cabal HEAD generated executable in the previous step
   # to build itself again, as sanity check
@@ -346,7 +408,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
 
     # IMPORTANT! Any job added to the workflow should be added here too
-    needs: [validate, validate-old-ghcs, dogfooding]
+    needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
 
     steps:
     - uses: actions/download-artifact@v3
@@ -356,6 +418,10 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: cabal-Linux-x86_64
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: cabal-Linux-static-x86_64
 
     - uses: actions/download-artifact@v3
       with:
@@ -371,6 +437,7 @@ jobs:
         files: |
           cabal-head-Windows-x86_64.tar.gz
           cabal-head-Linux-x86_64.tar.gz
+          cabal-head-Linux-static-x86_64.tar.gz
           cabal-head-macOS-x86_64.tar.gz
 
   # We use this job as a summary of the workflow
@@ -382,7 +449,7 @@ jobs:
     name: Validate post job
     runs-on: ubuntu-latest
     # IMPORTANT! Any job added to the workflow should be added here too
-    needs: [validate, validate-old-ghcs, dogfooding]
+    needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
 
     steps:
       - run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,6 +337,25 @@ Currently, [@emilypi](https://github.com/emilypi), [@fgaz](https://github.com/fg
 `haskell.org/cabal`, and [@Mikolaj](https://github.com/Mikolaj) is the point of contact for getting
 permissions.
 
+Preview Releases
+----------------
+
+We make preview releases available to facilitate testing of development builds.
+
+Artifacts can be found on the [`cabal-head` release page](https://github.com/haskell/cabal/releases/tag/cabal-head).
+The Validate CI pipeline generates tarballs with a `cabal` executable. The executable gets uploaded to this release by the pipelines that run on `master`.
+
+We currently make available builds for:
+  - Linux, dynamically linked (requiring `zlib`, `gmp`, `glibc`)
+  - Linux, statically linked
+  - MacOS
+  - Windows
+
+The statically linked Linux executables are built using Alpine.
+To reproduce these locally, set up an Alpine build environment using GHCup,
+and then build by calling `cabal build cabal-install --enable-executable-static`.
+
+
 API Documentation
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Ways to get the `cabal-install` binary
 2. _[Download from official website](https://www.haskell.org/cabal/download.html)_:
     the `cabal-install` binary download for your platform should contain the `cabal` executable.
 
+#### Preview Releases
+
 _Getting unreleased versions of `cabal-install`_: gives you a chance to try out yet-unreleased features.
 Currently, we only provide binaries for `x86_64` platforms.
 
@@ -40,10 +42,28 @@ Currently, we only provide binaries for `x86_64` platforms.
     ```
 
     Replace "Linux" with "Windows" or "macOS" as appropriate.
+    
+    The default Linux build is dynamically linked against `zlib`, `gmp` and `glibc`.
+    You will need to have appropriate versions of these libraries installed to use it.
+    Alternatively a statically linked "Linux-static" binary is also provided.
+
+    You might need to add the following to your `cabal.project` file
+    if your build fails because of an out-of-date `Cabal` library:
+    ```
+    allow-newer: 
+      *:Cabal,
+      *:Cabal-syntax
+
+    source-repository-package
+        type: git
+        location: https://github.com/haskell/cabal.git
+        subdir: Cabal Cabal-syntax
+    ```
 
 
 2. Even more cutting-edge binaries built from pull requests are always available
-   from the `Validate` worklow page on GitHub, at the very bottom of the page.
+   from the `Validate` worklow page on GitHub, at the very bottom of the page,
+   or from the `build-alpine` workflow for statically linked Linux builds.
 
 Ways to build `cabal-install` for everyday use
 --------------------------------------------


### PR DESCRIPTION
Add a job that builds a statically linked cabal-install executable, and make it available for pre-releases.

Resolves #9631.

Feedback is appreciated! 
In particular, I'm not sure how we want to specify the GHC version we want for this job. I've used a singleton matrix but maybe something else is better.

I've chosen to use a standard alpine image and the haskell setup action rather than a pre-baked alpine image with GHC, since we need to install the latest version of cabal-install for the test suite anyway, and this keeps things similar to the other jobs.

