### PR TITLE
Don't build unnecessary targets of legacy-fallback deps.

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -109,12 +109,12 @@ import Distribution.Client.ProjectBuilding.PackageFileMonitor
 --
 -- * Configure phase
 -- * Build phase
+-- * Haddock phase
 -- * Install phase (copy + register)
 -- * Register phase
 -- * Test phase
 -- * Bench phase
 -- * Repl phase
--- * Haddock phase
 --
 -- Depending on whether we are installing the package or building it inplace,
 -- the phases will be carried out differently. For example, when installing,
@@ -183,7 +183,7 @@ buildAndRegisterUnpackedPackage
     -- Build phase
     delegate $
       PBBuildPhase $
-        annotateFailure mlogFile BuildFailed $
+        annotateFailure mlogFile BuildFailed $ do
           setup buildCommand buildFlags buildArgs
 
     -- Haddock phase
@@ -198,7 +198,7 @@ buildAndRegisterUnpackedPackage
       PBInstallPhase
         { runCopy = \destdir ->
             annotateFailure mlogFile InstallFailed $
-              setup Cabal.copyCommand (copyFlags destdir) (const [])
+              setup Cabal.copyCommand (copyFlags destdir) copyArgs
         , runRegister = \pkgDBStack registerOpts ->
             annotateFailure mlogFile InstallFailed $ do
               -- We register ourselves rather than via Setup.hs. We need to
@@ -284,6 +284,9 @@ buildAndRegisterUnpackedPackage
           verbosity
           builddir
           destdir
+      -- In theory, we could want to copy less things than those that were
+      -- built, but instead, we simply copy the targets that were built.
+      copyArgs = buildArgs
 
       testCommand = Cabal.testCommand -- defaultProgramDb
       testFlags v =

--- a/cabal-testsuite/PackageTests/Regression/T9640/CHANGELOG.md
+++ b/cabal-testsuite/PackageTests/Regression/T9640/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for depend-on-custom-with-exe
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cabal-testsuite/PackageTests/Regression/T9640/LICENSE
+++ b/cabal-testsuite/PackageTests/Regression/T9640/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2024, Rodrigo Mesquita
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Rodrigo Mesquita nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cabal-testsuite/PackageTests/Regression/T9640/cabal.out
+++ b/cabal-testsuite/PackageTests/Regression/T9640/cabal.out
@@ -1,0 +1,16 @@
+# cabal v2-update
+Downloading the latest package list from test-local-repo
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - one-custom-0.1.0.0 (lib:one-custom) (requires build)
+ - depend-on-custom-with-exe-0.1.0.0 (lib) (first run)
+Configuring one-custom-0.1.0.0...
+Preprocessing library for one-custom-0.1.0.0..
+Building library for one-custom-0.1.0.0..
+Installing library in <PATH>
+Warning: depend-on-custom-with-exe.cabal:16:1: Ignoring trailing fields after sections: "ghc-options"
+Configuring library for depend-on-custom-with-exe-0.1.0.0...
+Preprocessing library for depend-on-custom-with-exe-0.1.0.0...
+Building library for depend-on-custom-with-exe-0.1.0.0...

--- a/cabal-testsuite/PackageTests/Regression/T9640/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T9640/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+extra-packages: one-custom

--- a/cabal-testsuite/PackageTests/Regression/T9640/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T9640/cabal.test.hs
@@ -1,0 +1,4 @@
+import Test.Cabal.Prelude
+main = cabalTest $ withRepo "repo" $ do
+  skipUnlessGhcVersion ">= 8.8"
+  cabal "build" ["depend-on-custom-with-exe"]

--- a/cabal-testsuite/PackageTests/Regression/T9640/depend-on-custom-with-exe.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T9640/depend-on-custom-with-exe.cabal
@@ -1,0 +1,23 @@
+cabal-version:      2.4
+name:               depend-on-custom-with-exe
+version:            0.1.0.0
+-- synopsis:
+-- description:
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Rodrigo Mesquita
+maintainer:         rodrigo.m.mesquita@gmail.com
+-- copyright:
+build-type:         Simple
+extra-doc-files:    CHANGELOG.md
+-- extra-source-files:
+
+common warnings
+ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  MyLib
+    build-depends:    base, one-custom
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/CHANGELOG.md
+++ b/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for one-custom
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/Main.hs
+++ b/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/Main.hs
@@ -1,0 +1,1 @@
+main = putStrLn "Hello"

--- a/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/Setup.hs
+++ b/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/one-custom.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/one-custom.cabal
@@ -1,0 +1,24 @@
+cabal-version:      2.4
+name:               one-custom
+version:            0.1.0.0
+license:            NONE
+build-type:         Custom
+extra-doc-files:    CHANGELOG.md
+
+custom-setup
+    setup-depends: base, Cabal
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  MyLib
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+executable example
+    main-is: Main.hs
+    default-language: Haskell2010
+    build-depends: base

--- a/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/src/MyLib.hs
+++ b/cabal-testsuite/PackageTests/Regression/T9640/repo/one-custom-0.1.0.0/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/cabal-testsuite/PackageTests/Regression/T9640/src/MyLib.hs
+++ b/cabal-testsuite/PackageTests/Regression/T9640/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"


### PR DESCRIPTION
The refactor in f70fc980dca50e7e62c5e803f56d2ef0c9fc7e18 solved an inconsistency in `buildAndInstallUnpackedPackage`. Namely, before the refactor, we didn't pass `hsSetupBuildArgs` to the build invocations, and afterwards we did.

The result is that build targets of (legacy) package `B`, that a package `A` depends on, are now passed to the ./Setup build invocation of package `B` (e.g. `./Setup build lib:openapi3` rather than just `./Setup build`).

This means we no longer /build always all targets of a legacy-package/ (for example, the lib, the testsuites and the executables). Instead only the required target (just the lib) will be built.

However, despite now passing the build args to `./Setup build`, we weren't passing the same arguments to the `./Setup copy` invocation. Therefore, `./Setup copy` would also try to copy targets of the package that weren't built, resulting in a failure.

This fixes that failure by correctly passing the build targets to the `./Setup copy` invocation, just like we do for the `./Setup build` one.

Fixes #9640

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

