### PR TITLE
Cabal-syntax: Bump containers upper bound to <0.8

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -32,7 +32,7 @@ library
     base       >= 4.9      && < 5,
     binary     >= 0.7      && < 0.9,
     bytestring >= 0.10.0.0 && < 0.13,
-    containers >= 0.5.0.0  && < 0.7,
+    containers >= 0.5.0.0  && < 0.8,
     deepseq    >= 1.3.0.1  && < 1.6,
     directory  >= 1.2      && < 1.4,
     filepath   >= 1.3.0.1  && < 1.6,


### PR DESCRIPTION
Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

