### PR TITLE
Cabal-syntax: Drop dependencies on unix and Win32

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -45,11 +45,6 @@ library
     -- See also https://github.com/ekmett/transformers-compat/issues/35
     transformers (>= 0.3      && < 0.4) || (>=0.4.1.0 && <0.7)
 
-  if os(windows)
-    build-depends: Win32 >= 2.3.0.0 && < 2.14
-  else
-    build-depends: unix  >= 2.6.0.0 && < 2.9
-
   ghc-options: -Wall -fno-ignore-asserts -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
 
   if impl(ghc >= 8.0)


### PR DESCRIPTION
Neither of these dependencies appear to be used. I suspect that they were cargo-culted from `Cabal`.

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

