### PR TITLE
Fix #9694 Don't imply that Haddock docs exist, when warning not installed

### DIFF
--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -1382,7 +1382,7 @@ haddockPackagePaths ipkgs mkHtmlPath = do
 
   let missing = [pkgid | Left pkgid <- interfaces]
       warning =
-        "The documentation for the following packages are not "
+        "The following packages have no Haddock documentation "
           ++ "installed. No links will be generated to these packages: "
           ++ intercalate ", " (map prettyShow missing)
       flags = rights interfaces

--- a/changelog.d/issue-9694
+++ b/changelog.d/issue-9694
@@ -1,0 +1,4 @@
+synopsis: Don't imply that Haddock docs exist, when warning not installed
+packages: Cabal
+issues: #9694
+prs: #9695


### PR DESCRIPTION
Link to issue: #9694 

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions). Follows existing code.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog). None relevant.
* [x] The documentation has been updated, if necessary. No update necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included. No QA notes needed.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*) No tests required.