### PR TITLE
Add test cabal install remote-pkg for #9697

### DIFF
--- a/cabal-testsuite/PackageTests/Install/T7297-8909-7236/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Install/T7297-8909-7236/cabal.test.hs
@@ -11,6 +11,9 @@ main = cabalTest $ do
         runInstalledExe' "my-exe" []
           >>= assertOutputContains ("hi" ++ show v)
 
+      installExternalWithTgt tgt v = withRepo "repo" (installWithTgt tgt v)
+
+
     cabal "install" (commonOpts 1) -- no target
     runInstalledExe' "my-exe" []
       >>= assertOutputContains "hi1"
@@ -20,3 +23,6 @@ main = cabalTest $ do
     installWithTgt "my-exe" 4
     installWithTgt "all" 5
     installWithTgt "all:exes" 6
+
+    -- And test it works when installing from an external repo (think Hackage)
+    installExternalWithTgt "external-lib" 2

--- a/cabal-testsuite/PackageTests/Install/T7297-8909-7236/repo/external-lib-0.1.0.0/CHANGELOG.md
+++ b/cabal-testsuite/PackageTests/Install/T7297-8909-7236/repo/external-lib-0.1.0.0/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for external-lib0100
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cabal-testsuite/PackageTests/Install/T7297-8909-7236/repo/external-lib-0.1.0.0/Main.hs
+++ b/cabal-testsuite/PackageTests/Install/T7297-8909-7236/repo/external-lib-0.1.0.0/Main.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE CPP #-}
+
+#ifdef TEST1
+main = putStrLn "hi1"
+#endif
+
+#ifdef TEST2
+main = putStrLn "hi2"
+#endif
+
+#ifdef TEST3
+main = putStrLn "hi3"
+#endif
+
+#ifdef TEST4
+main = putStrLn "hi4"
+#endif
+
+#ifdef TEST5
+main = putStrLn "hi5"
+#endif
+
+#ifdef TEST6
+main = putStrLn "hi6"
+#endif

--- a/cabal-testsuite/PackageTests/Install/T7297-8909-7236/repo/external-lib-0.1.0.0/external-lib.cabal
+++ b/cabal-testsuite/PackageTests/Install/T7297-8909-7236/repo/external-lib-0.1.0.0/external-lib.cabal
@@ -1,0 +1,18 @@
+cabal-version:   3.0
+name:            external-lib
+version:         0.1.0.0
+license:         NONE
+author:          matthewtpickering@gmail.com
+maintainer:      Matthew Pickering
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+common warnings
+    ghc-options: -Wall
+
+executable my-exe
+    import:           warnings
+    main-is: Main.hs
+    build-depends:    base
+    hs-source-dirs:   .
+    default-language: Haskell2010


### PR DESCRIPTION
In #9697 we fixed passing local options to cabal install targets, but rebasing accidentally dropped one of the added the tests for that PR which tested cabal install target, where target was only available from a remote repository.
