### PR TITLE
Fix cabal install in the presence of extra-packages

### DIFF
--- a/cabal-testsuite/PackageTests/Install/T8848/Main.hs
+++ b/cabal-testsuite/PackageTests/Install/T8848/Main.hs
@@ -1,0 +1,1 @@
+main = pure ()

--- a/cabal-testsuite/PackageTests/Install/T8848/cabal.project
+++ b/cabal-testsuite/PackageTests/Install/T8848/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+extra-packages: containers

--- a/cabal-testsuite/PackageTests/Install/T8848/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Install/T8848/cabal.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ do
+  recordMode DoNotRecord $
+    cabal' "install" ["t8848"]
+      >>= assertOutputContains "Wrote tarball sdist to"

--- a/cabal-testsuite/PackageTests/Install/T8848/t8848.cabal
+++ b/cabal-testsuite/PackageTests/Install/T8848/t8848.cabal
@@ -1,0 +1,8 @@
+name: t8848
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.2
+
+executable t8848
+  main-is: Main.hs
+  build-depends: base


### PR DESCRIPTION
Extra-packages listed in a cabal project are to be fetched from hackage,
and will be in memory as 'NamedPackages' rather than resolved to
'SpecificSourcePackage'.

On install, we need to make source-dists for all the specific source
packages, and fetch other packages from hackage. Since extra-packages
are already 'NamedPackages', we simply return them along the sdistize-d
specific source packages and the hackage source packages -- they will be
correctly fetched from Hackage from install.

Previously, cabal install <tgt> on a project with extra-packages would
fail because the branch of 'NamedPackage' for 'PackageSpecifier' was
simply unimplemented.

Fixes #8848
