### PR TITLE
Fix multi-repl closure computation with invalid Custom setup

### DIFF
--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/cabal.out
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/cabal.out
@@ -1,0 +1,9 @@
+# cabal v2-repl
+Resolving dependencies...
+Error: [Cabal-7107]
+Could not resolve dependencies:
+[__0] trying: pkg-b-0 (user goal)
+[__1] next goal: pkg-b:setup.Cabal (dependency of pkg-b)
+[__1] rejecting: pkg-b:setup.Cabal-<VERSION>/installed-<HASH> (constraint from --enable-multi-repl requires >=3.11)
+[__1] fail (backjumping, conflict set: pkg-b, pkg-b:setup.Cabal)
+After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: pkg-b (2), pkg-b:setup.Cabal (2)

--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/cabal.project
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/cabal.project
@@ -1,0 +1,3 @@
+packages: pkg-a/*.cabal
+packages: pkg-b/*.cabal
+packages: pkg-c/*.cabal

--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/cabal.test.hs
@@ -1,0 +1,11 @@
+import Test.Cabal.Prelude
+
+main = do
+  cabalTest $ do
+    -- MP: TODO: This should query Cabal library version
+    skipIfGhcVersion ">= 9.10"
+    -- Note: only the last package is interactive.
+    -- this test should load pkg-b too.
+    res <- fails $ cabalWithStdin "v2-repl" ["--enable-multi-repl","pkg-c", "pkg-a"] "Quu.quu"
+
+    assertOutputContains "constraint from --enable-multi-repl requires >=3.11" res

--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-a/Foo.hs
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-a/Foo.hs
@@ -1,0 +1,5 @@
+module Foo where
+
+foo :: Int
+foo = 42
+

--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-a/pkg-a.cabal
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-a/pkg-a.cabal
@@ -1,0 +1,8 @@
+cabal-version: 2.2
+name: pkg-a
+version: 0
+
+library
+  default-language: Haskell2010
+  build-depends: base
+  exposed-modules: Foo

--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-b/Bar.hs
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-b/Bar.hs
@@ -1,0 +1,6 @@
+module Bar where
+
+import Foo
+
+bar :: Int
+bar = foo + foo

--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-b/Setup.hs
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-b/Setup.hs
@@ -1,0 +1,5 @@
+module Setup where
+
+import Distribution.Simple
+
+main = defaultMain

--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-b/pkg-b.cabal
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-b/pkg-b.cabal
@@ -1,0 +1,12 @@
+cabal-version: 2.2
+name: pkg-b
+version: 0
+build-type: Custom
+
+custom-setup
+  setup-depends: Cabal <= 3.11
+
+library
+  default-language: Haskell2010
+  build-depends: base, pkg-a
+  exposed-modules: Bar

--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-c/Quu.hs
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-c/Quu.hs
@@ -1,0 +1,6 @@
+module Quu where
+
+import Bar
+
+quu :: Int
+quu = bar + bar

--- a/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-c/pkg-c.cabal
+++ b/cabal-testsuite/PackageTests/MultiRepl/EnabledBadClosure/pkg-c/pkg-c.cabal
@@ -1,0 +1,8 @@
+cabal-version: 2.2
+name: pkg-c
+version: 0
+
+library
+  default-language: Haskell2010
+  build-depends: base, pkg-b
+  exposed-modules: Quu

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/cabal.out
@@ -1,0 +1,7 @@
+# cabal v2-repl
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - foo-0.1.0.0 (interactive) (first run)
+Configuring foo-0.1.0.0...
+Preprocessing executable 'foo' for foo-0.1.0.0..

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/cabal.project
@@ -1,0 +1,2 @@
+packages: foo/
+

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/cabal.test.hs
@@ -1,0 +1,9 @@
+import Test.Cabal.Prelude
+
+main = do
+  cabalTest $ do
+    -- custom-setup stanza is not supported by Cabal's bundled with GHC's before 8.8
+    skipUnlessGhcVersion ">= 8.8"
+    skipIfGhcVersion ">= 9.10"
+    res <- cabalWithStdin "v2-repl" ["foo"] ""
+    assertOutputContains "- foo-0.1.0.0 (interactive)" res

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/foo/CHANGELOG.md
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/foo/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for foo
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/foo/LICENSE
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/foo/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2024, Teo Camarasu
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Teo Camarasu nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/foo/Setup.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/foo/Setup.hs
@@ -1,0 +1,8 @@
+import           Control.Monad
+import           Distribution.PackageDescription
+import           Distribution.Simple
+import qualified Distribution.Simple as DS
+import           Distribution.Simple.Setup
+
+main :: IO ()
+main = DS.defaultMainWithHooks DS.simpleUserHooks 

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/foo/app/Main.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/foo/app/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"

--- a/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/foo/foo.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdRepl/CustomSetup/foo/foo.cabal
@@ -1,0 +1,38 @@
+cabal-version:      3.0
+name:               foo
+version:            0.1.0.0
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Teo Camarasu
+build-type:         Custom
+extra-doc-files:    CHANGELOG.md
+
+custom-setup
+  setup-depends:
+      Cabal <= 3.11
+    , base
+
+common warnings
+    ghc-options: -Wall
+
+executable foo
+    -- Import common warning flags.
+    import:           warnings
+
+    -- .hs or .lhs file containing the Main module.
+    main-is:          Main.hs
+
+    -- Modules included in this executable, other than Main.
+    -- other-modules:
+
+    -- LANGUAGE extensions used by modules in this package.
+    -- other-extensions:
+
+    -- Other library packages from which modules are imported.
+    build-depends:    base
+
+    -- Directories containing source files.
+    hs-source-dirs:   app
+
+    -- Base language which the package is written in.
+    default-language: Haskell2010


### PR DESCRIPTION
This patch deletes a lot of hairy logic to do with removing "bad" edges from the closure. Now the solver just forces `Cabal >= 3.11` universally when `--enable-multi-repl` is enabled.

Fixes #9710

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

