### PR TITLE
Use getLocalBuildInfoM not getTestEnv

### DIFF
--- a/cabal-testsuite/PackageTests/CopyHie/setup.test.hs
+++ b/cabal-testsuite/PackageTests/CopyHie/setup.test.hs
@@ -1,7 +1,9 @@
 import Test.Cabal.Prelude
+import Distribution.Simple.LocalBuildInfo
 
 main = setupAndCabalTest $ withPackageDb $ do
   skipUnlessGhcVersion ">= 8.8"
   setup_install ["hie-local"]
-  env <- getTestEnv
-  shouldExist $ testLibInstallDir env </> "hie-local-0.1.0.0" </> "extra-compilation-artifacts" </> "hie" </> "HieLocal.hie"
+  lbi <- getLocalBuildInfoM
+  let installedLibPath = libdir $ absoluteInstallDirs (localPkgDescr lbi) lbi NoCopyDest
+  shouldExist $ installedLibPath </> "extra-compilation-artifacts" </> "hie" </> "HieLocal.hie"


### PR DESCRIPTION
Fixes #9725 using `getLocalBuildInfoM` similar to the way it is done in the following snippet;

https://github.com/haskell/cabal/blob/2acae632a0d625cd5b54aeb257fc83188344fa03/cabal-testsuite/PackageTests/ExtraCompilationArtifacts/test.hs#L14-L19

The previous `getTestEnv` method was expecting a path that didn't include the ABI hash suffix.

When the test runs it logs the library path (unchanged by this fix);

```
library-dirs:
    /.../CopyHie/setup.cabal.dist/usr/lib/x86_64-linux-ghc-9.8.1-eb95/hie-local-0.1.0.0
```

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

