### PR TITLE
Add a cabal target command

### DIFF
--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -110,6 +110,7 @@ library
         Distribution.Client.CmdRepl
         Distribution.Client.CmdRun
         Distribution.Client.CmdSdist
+        Distribution.Client.CmdTarget
         Distribution.Client.CmdTest
         Distribution.Client.CmdUpdate
         Distribution.Client.Compat.Directory

--- a/cabal-install/src/Distribution/Client/CmdTarget.hs
+++ b/cabal-install/src/Distribution/Client/CmdTarget.hs
@@ -1,0 +1,224 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Distribution.Client.CmdTarget
+  ( targetCommand
+  , targetAction
+  ) where
+
+import Distribution.Client.Compat.Prelude
+import Prelude ()
+
+import qualified Data.Map as Map
+import Distribution.Client.CmdBuild (selectComponentTarget, selectPackageTargets)
+import Distribution.Client.CmdErrorMessages
+import Distribution.Client.InstallPlan
+import qualified Distribution.Client.InstallPlan as InstallPlan
+import Distribution.Client.NixStyleOptions
+  ( NixStyleFlags (..)
+  , defaultNixStyleFlags
+  , nixStyleOptions
+  )
+import Distribution.Client.ProjectOrchestration
+import Distribution.Client.ProjectPlanning
+import Distribution.Client.Setup
+  ( ConfigFlags (..)
+  , GlobalFlags
+  )
+import Distribution.Client.TargetProblem
+  ( TargetProblem'
+  )
+import Distribution.Package
+import Distribution.Simple.Command
+  ( CommandUI (..)
+  , usageAlternatives
+  )
+import Distribution.Simple.Flag (fromFlagOrDefault)
+import Distribution.Simple.Utils
+  ( noticeDoc
+  , safeHead
+  , wrapText
+  )
+import Distribution.Verbosity
+  ( normal
+  )
+import Text.PrettyPrint
+import qualified Text.PrettyPrint as Pretty
+
+-------------------------------------------------------------------------------
+-- Command
+-------------------------------------------------------------------------------
+
+targetCommand :: CommandUI (NixStyleFlags ())
+targetCommand =
+  CommandUI
+    { commandName = "v2-target"
+    , commandSynopsis = "Target a subset of all targets."
+    , commandUsage = usageAlternatives "v2-target" ["[TARGETS]"]
+    , commandDescription =
+        Just . const . render $
+          vcat
+            [ intro
+            , vcat $ punctuate (text "\n") [targetForms, ctypes, Pretty.empty]
+            , caution
+            , unique
+            ]
+    , commandNotes = Just $ \pname -> render $ examples pname
+    , commandDefaultFlags = defaultNixStyleFlags ()
+    , commandOptions = nixStyleOptions (const [])
+    }
+  where
+    intro =
+      text . wrapText $
+        "Discover targets in a project for use with other commands taking [TARGETS].\n\n"
+          ++ "This command, like many others, takes [TARGETS]. Taken together, these will"
+          ++ " select for a set of targets in the project. When none are supplied, the"
+          ++ " command acts as if 'all' was supplied."
+          ++ " Targets in the returned subset are shown sorted and fully-qualified."
+
+    targetForms =
+      vcat
+        [ text "A [TARGETS] item can be one of these target forms:"
+        , nest 1 . vcat $
+            (char '-' <+>)
+              <$> [ text "a package target (e.g. [pkg:]package)"
+                  , text "a component target (e.g. [package:][ctype:]component)"
+                  , text "all packages (e.g. all)"
+                  , text "components of a particular type (e.g. package:ctypes or all:ctypes)"
+                  , text "a module target: (e.g. [package:][ctype:]module)"
+                  , text "a filepath target: (e.g. [package:][ctype:]filepath)"
+                  ]
+        ]
+
+    ctypes =
+      vcat
+        [ text "The ctypes, in short form and (long form), can be one of:"
+        , nest 1 . vcat $
+            (char '-' <+>)
+              <$> [ "libs" <+> parens "libraries"
+                  , "exes" <+> parens "executables"
+                  , "tests"
+                  , "benches" <+> parens "benchmarks"
+                  , "flibs" <+> parens "foreign-libraries"
+                  ]
+        ]
+
+    caution =
+      text . wrapText $
+        "WARNING: For a package, all, module or filepath target, cabal target [TARGETS] \
+        \ will only show 'libs' and 'exes' of the [TARGETS] by default. To also show \
+        \ tests and benchmarks, enable them with '--enable-tests' and \
+        \ '--enable-benchmarks'."
+
+    unique =
+      text . wrapText $
+        "NOTE: For commands expecting a unique TARGET, a fully-qualified target is the safe \
+        \ way to go but it may be convenient to type out a shorter TARGET. For example, if the \
+        \ set of 'cabal target all:exes' has one item then 'cabal list-bin all:exes' will \
+        \ work too."
+
+    examples pname =
+      vcat
+        [ text "Examples" Pretty.<> colon
+        , nest 2 $
+            vcat
+              [ vcat
+                  [ text pname <+> text "v2-target all"
+                  , nest 2 $ text "Targets of the package in the current directory or all packages in the project"
+                  ]
+              , vcat
+                  [ text pname <+> text "v2-target pkgname"
+                  , nest 2 $ text "Targets of the package named pkgname in the project"
+                  ]
+              , vcat
+                  [ text pname <+> text "v2-target ./pkgfoo"
+                  , nest 2 $ text "Targets of the package in the ./pkgfoo directory"
+                  ]
+              , vcat
+                  [ text pname <+> text "v2-target cname"
+                  , nest 2 $ text "Targets of the component named cname in the project"
+                  ]
+              ]
+        ]
+
+-------------------------------------------------------------------------------
+-- Action
+-------------------------------------------------------------------------------
+
+targetAction :: NixStyleFlags () -> [String] -> GlobalFlags -> IO ()
+targetAction flags@NixStyleFlags{..} ts globalFlags = do
+  ProjectBaseContext
+    { distDirLayout
+    , cabalDirLayout
+    , projectConfig
+    , localPackages
+    } <-
+    establishProjectBaseContext verbosity cliConfig OtherCommand
+
+  (_, elaboratedPlan, _, _, _) <-
+    rebuildInstallPlan
+      verbosity
+      distDirLayout
+      cabalDirLayout
+      projectConfig
+      localPackages
+      Nothing
+
+  targetSelectors <-
+    either (reportTargetSelectorProblems verbosity) return
+      =<< readTargetSelectors localPackages Nothing targetStrings
+
+  targets :: TargetsMap <-
+    either (reportBuildTargetProblems verbosity) return $
+      resolveTargets
+        selectPackageTargets
+        selectComponentTarget
+        elaboratedPlan
+        Nothing
+        targetSelectors
+
+  printTargetForms verbosity targetStrings targets elaboratedPlan
+  where
+    verbosity = fromFlagOrDefault normal (configVerbosity configFlags)
+    targetStrings = if null ts then ["all"] else ts
+    cliConfig =
+      commandLineFlagsToProjectConfig
+        globalFlags
+        flags
+        mempty
+
+reportBuildTargetProblems :: Verbosity -> [TargetProblem'] -> IO a
+reportBuildTargetProblems verbosity = reportTargetProblems verbosity "target"
+
+printTargetForms :: Verbosity -> [String] -> TargetsMap -> ElaboratedInstallPlan -> IO ()
+printTargetForms verbosity targetStrings targets elaboratedPlan =
+  noticeDoc verbosity $
+    vcat
+      [ text "Fully qualified target forms" Pretty.<> colon
+      , nest 1 $ vcat [text "-" <+> text tf | tf <- targetForms]
+      , found
+      ]
+  where
+    found =
+      let n = length targets
+          t = if n == 1 then "target" else "targets"
+          query = intercalate ", " targetStrings
+       in text "Found" <+> int n <+> text t <+> text "matching" <+> text query Pretty.<> char '.'
+
+    localPkgs =
+      [x | Configured x@ElaboratedConfiguredPackage{elabLocalToProject = True} <- InstallPlan.toList elaboratedPlan]
+
+    targetForm ct x =
+      let pkgId@PackageIdentifier{pkgName = n} = elabPkgSourceId x
+       in render $ pretty n Pretty.<> colon Pretty.<> text (showComponentTarget pkgId ct)
+
+    targetForms =
+      sort $
+        catMaybes
+          [ targetForm ct <$> pkg
+          | (u :: UnitId, xs) <- Map.toAscList targets
+          , let pkg = safeHead $ filter ((== u) . elabUnitId) localPkgs
+          , (ct :: ComponentTarget, _) <- xs
+          ]

--- a/cabal-install/src/Distribution/Client/Main.hs
+++ b/cabal-install/src/Distribution/Client/Main.hs
@@ -130,6 +130,7 @@ import qualified Distribution.Client.CmdPath as CmdPath
 import qualified Distribution.Client.CmdRepl as CmdRepl
 import qualified Distribution.Client.CmdRun as CmdRun
 import qualified Distribution.Client.CmdSdist as CmdSdist
+import qualified Distribution.Client.CmdTarget as CmdTarget
 import qualified Distribution.Client.CmdTest as CmdTest
 import qualified Distribution.Client.CmdUpdate as CmdUpdate
 
@@ -460,6 +461,7 @@ mainWorker args = do
           , newCmd CmdExec.execCommand CmdExec.execAction
           , newCmd CmdClean.cleanCommand CmdClean.cleanAction
           , newCmd CmdSdist.sdistCommand CmdSdist.sdistAction
+          , newCmd CmdTarget.targetCommand CmdTarget.targetAction
           , legacyCmd configureExCommand configureAction
           , legacyCmd buildCommand buildAction
           , legacyCmd replCommand replAction

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -934,7 +934,6 @@ distinctTargetComponents targetsMap =
 
 ------------------------------------------------------------------------------
 -- Displaying what we plan to do
---
 
 -- | Print a user-oriented presentation of the install plan, indicating what
 -- will be built.

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -282,6 +282,7 @@ globalCommand commands =
               , "unpack"
               , "init"
               , "configure"
+              , "target"
               , "build"
               , "clean"
               , "run"
@@ -302,6 +303,7 @@ globalCommand commands =
               , "path"
               , "new-build"
               , "new-configure"
+              , "new-target"
               , "new-repl"
               , "new-freeze"
               , "new-run"
@@ -334,7 +336,8 @@ globalCommand commands =
               , "v1-register"
               , "v1-reconfigure"
               , -- v2 commands, nix-style
-                "v2-build"
+                "v2-target"
+              , "v2-build"
               , "v2-configure"
               , "v2-repl"
               , "v2-freeze"
@@ -379,6 +382,7 @@ globalCommand commands =
                 , addCmd "gen-bounds"
                 , addCmd "outdated"
                 , addCmd "path"
+                , addCmd "target"
                 , par
                 , startGroup "project building and installing"
                 , addCmd "build"
@@ -406,6 +410,7 @@ globalCommand commands =
                 , addCmd "hscolour"
                 , par
                 , startGroup "new-style projects (forwards-compatible aliases)"
+                , addCmd "v2-target"
                 , addCmd "v2-build"
                 , addCmd "v2-configure"
                 , addCmd "v2-repl"

--- a/cabal-testsuite/PackageTests/Target/cabal.all-benches.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.all-benches.out
@@ -1,0 +1,8 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:bench:a-bench
+ - b:bench:b-bench
+Found 2 targets matching all:benches.

--- a/cabal-testsuite/PackageTests/Target/cabal.all-enable-benches.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.all-enable-benches.out
@@ -1,0 +1,15 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:bench:a-bench
+ - a:exe:a-exe
+ - a:lib:a
+ - a:lib:a-sublib
+ - b:bench:b-bench
+ - b:exe:b-exe
+ - b:lib:b
+ - b:lib:b-sublib
+ - c:lib:c
+Found 9 targets matching all.

--- a/cabal-testsuite/PackageTests/Target/cabal.all-enable-tests.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.all-enable-tests.out
@@ -1,0 +1,15 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:exe:a-exe
+ - a:lib:a
+ - a:lib:a-sublib
+ - a:test:a-test
+ - b:exe:b-exe
+ - b:lib:b
+ - b:lib:b-sublib
+ - b:test:b-test
+ - c:lib:c
+Found 9 targets matching all.

--- a/cabal-testsuite/PackageTests/Target/cabal.all-exes.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.all-exes.out
@@ -1,0 +1,8 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:exe:a-exe
+ - b:exe:b-exe
+Found 2 targets matching all:exes.

--- a/cabal-testsuite/PackageTests/Target/cabal.all-tests.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.all-tests.out
@@ -1,0 +1,8 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:test:a-test
+ - b:test:b-test
+Found 2 targets matching all:tests.

--- a/cabal-testsuite/PackageTests/Target/cabal.component-target-bench.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.component-target-bench.out
@@ -1,0 +1,19 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:bench:a-bench
+Found 1 target matching a:bench:a-bench.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Fully qualified target forms:
+ - a:bench:a-bench
+Found 1 target matching bench:a-bench.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Fully qualified target forms:
+ - a:bench:a-bench
+Found 1 target matching a:a-bench.

--- a/cabal-testsuite/PackageTests/Target/cabal.component-target-exe.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.component-target-exe.out
@@ -1,0 +1,19 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:exe:a-exe
+Found 1 target matching a:exe:a-exe.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Fully qualified target forms:
+ - a:exe:a-exe
+Found 1 target matching exe:a-exe.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Fully qualified target forms:
+ - a:exe:a-exe
+Found 1 target matching a:a-exe.

--- a/cabal-testsuite/PackageTests/Target/cabal.component-target-lib.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.component-target-lib.out
@@ -1,0 +1,19 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:lib:a
+Found 1 target matching a:lib:a.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Fully qualified target forms:
+ - a:lib:a
+Found 1 target matching lib:a.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Fully qualified target forms:
+ - a:lib:a
+Found 1 target matching a:a.

--- a/cabal-testsuite/PackageTests/Target/cabal.component-target-test.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.component-target-test.out
@@ -1,0 +1,19 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:test:a-test
+Found 1 target matching a:test:a-test.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Fully qualified target forms:
+ - a:test:a-test
+Found 1 target matching test:a-test.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Fully qualified target forms:
+ - a:test:a-test
+Found 1 target matching a:a-test.

--- a/cabal-testsuite/PackageTests/Target/cabal.ctype-target.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.ctype-target.out
@@ -1,0 +1,26 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:lib:a
+ - a:lib:a-sublib
+Found 2 targets matching a:libs.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Fully qualified target forms:
+ - a:exe:a-exe
+Found 1 target matching a:exes.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Fully qualified target forms:
+ - a:test:a-test
+Found 1 target matching a:tests.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Fully qualified target forms:
+ - a:bench:a-bench
+Found 1 target matching a:benches.

--- a/cabal-testsuite/PackageTests/Target/cabal.default-all.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.default-all.out
@@ -1,0 +1,13 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:exe:a-exe
+ - a:lib:a
+ - a:lib:a-sublib
+ - b:exe:b-exe
+ - b:lib:b
+ - b:lib:b-sublib
+ - c:lib:c
+Found 7 targets matching all.

--- a/cabal-testsuite/PackageTests/Target/cabal.everything.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.everything.out
@@ -1,0 +1,17 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:bench:a-bench
+ - a:exe:a-exe
+ - a:lib:a
+ - a:lib:a-sublib
+ - a:test:a-test
+ - b:bench:b-bench
+ - b:exe:b-exe
+ - b:lib:b
+ - b:lib:b-sublib
+ - b:test:b-test
+ - c:lib:c
+Found 11 targets matching all.

--- a/cabal-testsuite/PackageTests/Target/cabal.explicit-all.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.explicit-all.out
@@ -1,0 +1,13 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:exe:a-exe
+ - a:lib:a
+ - a:lib:a-sublib
+ - b:exe:b-exe
+ - b:lib:b
+ - b:lib:b-sublib
+ - c:lib:c
+Found 7 targets matching all.

--- a/cabal-testsuite/PackageTests/Target/cabal.missing-target.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.missing-target.out
@@ -1,0 +1,16 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Error: [Cabal-7127]
+Cannot target the executables in the package c-0.1 because it does not contain any executables. Check the .cabal file for the package and make sure that it properly declares the components that you expect.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Error: [Cabal-7127]
+Cannot target the test suites in the package c-0.1 because it does not contain any test suites. Check the .cabal file for the package and make sure that it properly declares the components that you expect.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Error: [Cabal-7127]
+Cannot target the benchmarks in the package c-0.1 because it does not contain any benchmarks. Check the .cabal file for the package and make sure that it properly declares the components that you expect.

--- a/cabal-testsuite/PackageTests/Target/cabal.package-target.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.package-target.out
@@ -1,0 +1,20 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:exe:a-exe
+ - a:lib:a
+ - a:lib:a-sublib
+Found 3 targets matching a.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:bench:a-bench
+ - a:exe:a-exe
+ - a:lib:a
+ - a:lib:a-sublib
+ - a:test:a-test
+Found 5 targets matching a.

--- a/cabal-testsuite/PackageTests/Target/cabal.path-target.out
+++ b/cabal-testsuite/PackageTests/Target/cabal.path-target.out
@@ -1,0 +1,20 @@
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:exe:a-exe
+ - a:lib:a
+ - a:lib:a-sublib
+Found 3 targets matching dir-a/.
+# cabal v2-target
+Configuration is affected by the following files:
+- cabal.project
+Resolving dependencies...
+Fully qualified target forms:
+ - a:bench:a-bench
+ - a:exe:a-exe
+ - a:lib:a
+ - a:lib:a-sublib
+ - a:test:a-test
+Found 5 targets matching dir-a/.

--- a/cabal-testsuite/PackageTests/Target/cabal.project
+++ b/cabal-testsuite/PackageTests/Target/cabal.project
@@ -1,0 +1,1 @@
+packages: dir-a dir-b dir-c

--- a/cabal-testsuite/PackageTests/Target/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Target/cabal.test.hs
@@ -1,0 +1,65 @@
+import Test.Cabal.Prelude
+
+main = do
+  cabalTest' "default-all" $ do
+    cabal "v2-target" []
+
+  cabalTest' "explicit-all" $ do
+    cabal "v2-target" ["all"]
+
+  cabalTest' "all-enable-tests" $ do
+    cabal "v2-target" ["all", "--enable-tests"]
+
+  cabalTest' "all-enable-benches" $ do
+    cabal "v2-target" ["all", "--enable-benchmarks"]
+
+  cabalTest' "everything" $ do
+    cabal "v2-target" ["all", "--enable-tests", "--enable-benchmarks"]
+
+  cabalTest' "all-exes" $ do
+    cabal "v2-target" ["all:exes"]
+
+  cabalTest' "all-tests" $ do
+    cabal "v2-target" ["all:tests"]
+
+  cabalTest' "all-benches" $ do
+    cabal "v2-target" ["all:benches"]
+
+  cabalTest' "package-target" $ do
+    cabal "v2-target" ["a"]
+    cabal "v2-target" ["a", "--enable-tests", "--enable-benchmarks"]
+
+  cabalTest' "path-target" $ do
+    cabal "v2-target" ["dir-a/"]
+    cabal "v2-target" ["dir-a/", "--enable-tests", "--enable-benchmarks"]
+
+  cabalTest' "component-target-lib" $ do
+    cabal "v2-target" ["a:lib:a"]
+    cabal "v2-target" ["lib:a"]
+    cabal "v2-target" ["a:a"]
+
+  cabalTest' "component-target-exe" $ do
+    cabal "v2-target" ["a:exe:a-exe"]
+    cabal "v2-target" ["exe:a-exe"]
+    cabal "v2-target" ["a:a-exe"]
+
+  cabalTest' "component-target-bench" $ do
+    cabal "v2-target" ["a:bench:a-bench"]
+    cabal "v2-target" ["bench:a-bench"]
+    cabal "v2-target" ["a:a-bench"]
+
+  cabalTest' "component-target-test" $ do
+    cabal "v2-target" ["a:test:a-test"]
+    cabal "v2-target" ["test:a-test"]
+    cabal "v2-target" ["a:a-test"]
+
+  cabalTest' "ctype-target" $ do
+    cabal "v2-target" ["a:libs"]
+    cabal "v2-target" ["a:exes"]
+    cabal "v2-target" ["a:tests"]
+    cabal "v2-target" ["a:benches"]
+
+  cabalTest' "missing-target" $ do
+    fails $ cabal "v2-target" ["c:exes"]
+    fails $ cabal "v2-target" ["c:tests"]
+    fails $ cabal "v2-target" ["c:benches"]

--- a/cabal-testsuite/PackageTests/Target/dir-a/a.cabal
+++ b/cabal-testsuite/PackageTests/Target/dir-a/a.cabal
@@ -1,0 +1,15 @@
+name:           a
+version:        0.1
+license:        BSD3
+cabal-version:  >= 1.8
+build-type:     Simple
+
+library
+library a-sublib
+executable a-exe
+test-suite a-test
+    type: exitcode-stdio-1.0
+    main-is: Test.hs
+benchmark a-bench
+    type: exitcode-stdio-1.0
+    main-is: Bench.hs

--- a/cabal-testsuite/PackageTests/Target/dir-b/b.cabal
+++ b/cabal-testsuite/PackageTests/Target/dir-b/b.cabal
@@ -1,0 +1,15 @@
+name:           b
+version:        0.1
+license:        BSD3
+cabal-version:  >= 1.8
+build-type:     Simple
+
+library
+library b-sublib
+executable b-exe
+test-suite b-test
+    type: exitcode-stdio-1.0
+    main-is: Test.hs
+benchmark b-bench
+    type: exitcode-stdio-1.0
+    main-is: Bench.hs

--- a/cabal-testsuite/PackageTests/Target/dir-c/c.cabal
+++ b/cabal-testsuite/PackageTests/Target/dir-c/c.cabal
@@ -1,0 +1,7 @@
+name:           c
+version:        0.1
+license:        BSD3
+cabal-version:  >= 1.8
+build-type:     Simple
+
+library

--- a/changelog.d/pr-9744.md
+++ b/changelog.d/pr-9744.md
@@ -1,0 +1,18 @@
+---
+synopsis: Discover targets in a project
+packages: [cabal-install]
+prs: 9744
+issues: [4070,8953]
+significance: significant
+---
+
+Adds a `cabal target` command that is useful for discovering targets in a
+project for use with other commands taking ``[TARGETS]``.
+
+Any target form except for a script target can be used with ``cabal target``.
+
+This command, like many others, takes ``[TARGETS]``. Taken together, these will
+select for a set of targets in the project. When none are supplied, the command
+acts as if ``all`` was supplied. Targets in the returned subset are shown sorted
+and fully-qualified with package, component type and component name such as
+`Cabal-tests:test:hackage-tests`.

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -36,6 +36,7 @@ Commands
       gen-bounds             Generate dependency bounds.
       outdated               Check for outdated dependencies.
       path                   Query for simple project information.
+      target                 Target a subset of all targets.
 
      [project building and installing]
       build                  Compile targets within the project.
@@ -211,6 +212,8 @@ Arguments and flags common to some or all commands are:
     (default) Do not generate detailed build information for built components.
 
     Already generated `build-info.json` files will be removed since they would be stale otherwise.
+
+.. _target-forms:
 
 Target Forms
 ------------
@@ -733,6 +736,53 @@ Scripting example:
 
    $ ls $(cabal path --installdir)
    ...
+
+cabal target
+^^^^^^^^^^^^
+
+This command is useful for discovering targets in a project for use with other
+commands taking ``[TARGETS]``.
+
+Any :ref:`target form<target-forms>` except for a script target can be used with
+``cabal target``.
+
+This command, like many others, takes ``[TARGETS]``. Taken together, these will
+select for a set of targets in the project. When none are supplied, the command
+acts as if ``all`` was supplied. Targets in the returned subset are shown sorted
+and fully-qualified.
+
+.. code-block:: console
+
+    $ cabal target all:tests
+    ...
+    Fully qualified target forms:
+     - Cabal-tests:test:check-tests
+     - Cabal-tests:test:custom-setup-tests
+     - Cabal-tests:test:hackage-tests
+     - Cabal-tests:test:no-thunks-test
+     - Cabal-tests:test:parser-tests
+     - Cabal-tests:test:rpmvercmp
+     - Cabal-tests:test:unit-tests
+     - cabal-benchmarks:test:cabal-benchmarks
+     - cabal-install-solver:test:unit-tests
+     - cabal-install:test:integration-tests2
+     - cabal-install:test:long-tests
+     - cabal-install:test:mem-use-tests
+     - cabal-install:test:unit-tests
+     - solver-benchmarks:test:unit-tests
+
+.. warning::
+
+    For a package, all, module or filepath target, ``cabal target [TARGETS]`` will
+    only show ``libs`` and ``exes`` of the ``[TARGETS]`` by default. To also show tests and
+    benchmarks, enable them with ``--enable-tests`` and ``--enable-benchmarks``.
+
+.. note::
+
+    For commands expecting a unique ``TARGET``, a fully-qualified target is the safe
+    way to go but it may be convenient to type out a shorter ``TARGET``. For
+    example, if the set of ``cabal target all:exes`` has one item then ``cabal
+    list-bin all:exes`` will work too.
 
 .. _command-group-build:
 


### PR DESCRIPTION
Fixes #8953. Adds a `cabal target` command for showing targets that can be supplied to other commands like the `cabal build` command.

> [!NOTE]
> Comments prior to https://github.com/haskell/cabal/pull/9744#pullrequestreview-2143366261, prior to Jun 26 2024, refer to an earlier implementation that was a cut down build command. The newer implementation is based off of a suggestion by @andreabedini.

## Motivation

When a project has but one package the targets are easy to find by looking inside the `.cabal` file but when a project has hundreds of packages that method is hard with information under layers of folders and files.

Using grep in `.cabal` files is tough to get right when we need to exclude stuff that is not in the project.

![image](https://github.com/user-attachments/assets/1b6dcbda-dde5-4612-9059-d537e3ef3b9c)

Here's `all:exes` found with this new target command:

```
$ cabal run cabal-install:exe:cabal -- target all:exes
...
Fully qualified target forms:
 - buildinfo-reference-generator:exe:buildinfo-reference-generator
 - cabal-install:exe:cabal
 - cabal-testsuite:exe:cabal-tests
 - cabal-testsuite:exe:setup
 - cabal-testsuite:exe:test-runtime-deps
 - cabal-validate:exe:cabal-validate
 - solver-benchmarks:exe:hackage-benchmark
Found 7 targets matching all:exes.
```

The initial motivation would have been #8953. Other related issues are #8683, #9732, #1382 and #4070.

## Help

Here's the help;

```diff
$ cabal --help
...
  [project building and installing]
+  target                 Disclose selected targets.
   build                  Compile targets within the project.
```

The command specific help, a lot of which is taken straight from the user guide on [target forms](https://cabal.readthedocs.io/en/latest/cabal-commands.html#target-forms);

```
$ cabal -- target --help
...
Discover targets in a project for use with other commands taking [TARGETS].

Discloses fully-qualified targets from a selection of target form [TARGETS]
(or 'all' if none given). Can also check if a target form is unique as some
commands require a unique TARGET.

A [TARGETS] item can be one of these target forms:
 - a package target (e.g. [pkg:]package)
 - a component target (e.g. [package:][ctype:]component)
 - all packages (e.g. all)
 - components of a particular type (e.g. package:ctypes or all:ctypes)
 - a module target: (e.g. [package:][ctype:]module)
 - a filepath target: (e.g. [package:][ctype:]filepath)

The ctypes, in short form and (long form), can be one of:
 - libs (libraries)
 - exes (executables)
 - tests
 - benches (benchmarks)
 - flibs (foreign-libraries)

For a package, all, module or filepath target, cabal target [TARGETS] will
*only* show 'libs' and 'exes' of the [TARGETS]. To also show tests and
benchmarks, enable them with '--enable-tests' and '--enable-benchmarks'.

Flags for target:
 -h, --help                     Show this help text

...
Examples:
  cabal target all
    Targets of the package in the current directory or all packages in the project
  cabal target pkgname
    Targets of the package named pkgname in the project
  cabal target ./pkgfoo
    Targets of the package in the ./pkgfoo directory
  cabal target cname
    Targets of the component named cname in the project
```

## Use

The command in action on the [haskell/cabal](https://github.com/haskell/cabal) project:

```
$ cabal target
...
Fully qualified target forms:
 - Cabal-QuickCheck:lib:Cabal-QuickCheck
 - Cabal-described:lib:Cabal-described
 - Cabal-hooks:lib:Cabal-hooks
 - Cabal-syntax:lib:Cabal-syntax
 - Cabal-tests:lib:Cabal-tests
 - Cabal-tests:test:check-tests
 - Cabal-tests:test:custom-setup-tests
 - Cabal-tests:test:hackage-tests
 - Cabal-tests:test:no-thunks-test
 - Cabal-tests:test:parser-tests
 - Cabal-tests:test:rpmvercmp
 - Cabal-tests:test:unit-tests
 - Cabal-tree-diff:lib:Cabal-tree-diff
 - Cabal:lib:Cabal
 - cabal-benchmarks:test:cabal-benchmarks
 - cabal-install-solver:lib:cabal-install-solver
 - cabal-install-solver:test:unit-tests
 - cabal-install:lib:cabal-install
 - cabal-install:test:integration-tests2
 - cabal-install:test:long-tests
 - cabal-install:test:mem-use-tests
 - cabal-install:test:unit-tests
 - cabal-testsuite:lib:cabal-testsuite
 - solver-benchmarks:lib:solver-benchmarks
 - solver-benchmarks:test:unit-tests
Found 25 targets matching all.
```

> [!NOTE]
> Tests are included above because the project enables them:
> https://github.com/haskell/cabal/blob/1082c0bb4e498fc9ea3b7b8cbfa78a99f2edb3b9/cabal.project#L6
>
> The query 'all' is used when none is given.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [x] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added.

## QA Notes

`cabal target` is a new command that produces a list of fully-qualified targets. Please check that these are unique. I haven't added a module test to `cabal-testsuite/PackageTests/Target/cabal.test.hs` but it does work:

```
$ cabal run cabal-install:exe:cabal -- target Distribution.Client.CmdTarget
...
Fully qualified target forms:
 - cabal-install:lib:cabal-install
Found 1 target matching Distribution.Client.CmdTarget.
```
