### PR TITLE
Remove skipIfGhcVersion "== 9.6.3"

### DIFF
--- a/cabal-testsuite/PackageTests/VersionPriority/1-web.test.hs
+++ b/cabal-testsuite/PackageTests/VersionPriority/1-web.test.hs
@@ -5,9 +5,5 @@ testVersionWin project =
         fails $ cabal "v2-build" ["--dry-run"]
 
 main = cabalTest . withRepo "repo" $ do
-    -- To avoid this diff:
-    --   -Build profile: -w ghc-9.6.3 -O1
-    --   +Build profile: -w ghc-<GHCVER> -O1
-    skipIfGhcVersion "== 9.6.3"
     testVersionWin "1-web-constraints-import.project"
     testVersionWin "1-web-import-constraints.project"

--- a/cabal-testsuite/PackageTests/VersionPriority/2-web.test.hs
+++ b/cabal-testsuite/PackageTests/VersionPriority/2-web.test.hs
@@ -5,9 +5,5 @@ testVersionWin project =
         fails $ cabal "v2-build" ["--dry-run"]
 
 main = cabalTest . withRepo "repo" $ do
-    -- To avoid this diff:
-    --   -Build profile: -w ghc-9.6.3 -O1
-    --   +Build profile: -w ghc-<GHCVER> -O1
-    skipIfGhcVersion "== 9.6.3"
     testVersionWin "2-web-constraints-import.project"
     testVersionWin "2-web-import-constraints.project"

--- a/cabal-testsuite/PackageTests/VersionPriority/3-web.test.hs
+++ b/cabal-testsuite/PackageTests/VersionPriority/3-web.test.hs
@@ -5,9 +5,5 @@ testVersionWin project =
         fails $ cabal "v2-build" ["--dry-run"]
 
 main = cabalTest . withRepo "repo" $ do
-    -- To avoid this diff:
-    --   -Build profile: -w ghc-9.6.3 -O1
-    --   +Build profile: -w ghc-<GHCVER> -O1
-    skipIfGhcVersion "== 9.6.3"
     testVersionWin "3-web-constraints-import.project"
     testVersionWin "3-web-import-constraints.project"


### PR DESCRIPTION
Not a fix for #9738. I'm able to reproduce that problem (that I've written up on #9738) but these tests don't need the `skipIfGhcVersion "== 9.6.3"` because the `.out` files don't include the differing output, the `ghc-<GHCVER>` versus `ghc-9.6.3` difference.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).


