### PR TITLE
Update .cabal files

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -15,7 +15,7 @@ description:
 category:       Distribution
 build-type:     Simple
 
-extra-source-files:
+extra-doc-files:
   README.md ChangeLog.md
 
 source-repository head

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -21,7 +21,7 @@ build-type:     Simple
 -- If we use a new Cabal feature, this needs to be changed to Custom so
 -- we can bootstrap.
 
-extra-source-files:
+extra-doc-files:
   README.md ChangeLog.md
 
 source-repository head

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -14,7 +14,7 @@ maintainer:    Cabal Development Team <cabal-devel@haskell.org>
 copyright:     2003-2024, Cabal Development Team
 category:      Distribution
 build-type:    Simple
-Extra-Source-Files:
+extra-doc-files:
   ChangeLog.md
 
 source-repository head

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -17,8 +17,9 @@ Copyright:          2003-2024, Cabal Development Team
 Category:           Distribution
 Build-type:         Simple
 Extra-Source-Files:
-  README.md
   bash-completion/cabal
+extra-doc-files:
+  README.md
   changelog
 
 source-repository head
@@ -67,6 +68,8 @@ library
     default-extensions: TypeOperators
 
     hs-source-dirs:   src
+    autogen-modules:
+        Paths_cabal_install
     other-modules:
         Paths_cabal_install
     exposed-modules:


### PR DESCRIPTION
`extra-doc-files` and `no-autogen-paths` warnings.


**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ not CI

