### PR TITLE
Document `Haskell98` as default `default-language`

### DIFF
--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -16,6 +16,7 @@
 module Language.Haskell.Extension
   ( Language (..)
   , knownLanguages
+  , defaultDefLang
   , classifyLanguage
   , Extension (..)
   , KnownExtension (..)
@@ -66,6 +67,10 @@ instance NFData Language where rnf = genericRnf
 -- | List of known (supported) languages for GHC, oldest first.
 knownLanguages :: [Language]
 knownLanguages = [Haskell98, Haskell2010, GHC2021]
+
+-- | When @default-language@ is missing, 'Haskell98' is the choice.
+defaultDefLang :: Language
+defaultDefLang = Haskell98
 
 instance Pretty Language where
   pretty (UnknownLanguage other) = Disp.text other

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -583,7 +583,7 @@ componentGhcOptions verbosity lbi bi clbi odir =
         , ghcOptDebugInfo = toFlag (withDebugInfo lbi)
         , ghcOptExtra = hcOptions GHC bi
         , ghcOptExtraPath = toNubListR $ exe_paths
-        , ghcOptLanguage = toFlag (fromMaybe Haskell98 (defaultLanguage bi))
+        , ghcOptLanguage = toFlag (fromMaybe defaultDefLang (defaultLanguage bi))
         , -- Unsupported extensions have already been checked by configure
           ghcOptExtensions = toNubListR $ usedExtensions bi
         , ghcOptExtensionMap = Map.fromList . compilerExtensions $ (compiler lbi)

--- a/Cabal/src/Distribution/Simple/HaskellSuite.hs
+++ b/Cabal/src/Distribution/Simple/HaskellSuite.hs
@@ -181,7 +181,7 @@ buildLib verbosity pkg_descr lbi lib clbi = do
       bi = libBuildInfo lib
       srcDirs = map getSymbolicPath (hsSourceDirs bi) ++ [odir]
       dbStack = withPackageDB lbi
-      language = fromMaybe Haskell98 (defaultLanguage bi)
+      language = fromMaybe defaultDefLang (defaultLanguage bi)
       progdb = withPrograms lbi
       pkgid = packageId pkg_descr
 

--- a/cabal-install/src/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/src/Distribution/Client/CmdRepl.hs
@@ -154,7 +154,7 @@ import Distribution.Verbosity
   , normal
   )
 import Language.Haskell.Extension
-  ( Language (..)
+  ( defaultDefLang
   )
 
 import Control.Monad (mapM)
@@ -304,7 +304,7 @@ replAction flags@NixStyleFlags{extraFlags = r@ReplFlags{..}, ..} targetStrings g
           lBuildInfo =
             emptyBuildInfo
               { targetBuildDepends = [baseDep]
-              , defaultLanguage = Just Haskell2010
+              , defaultLanguage = Just defaultDefLang
               }
           baseDep = Dependency "base" anyVersion mainLibSet
 

--- a/cabal-install/src/Distribution/Client/ScriptUtils.hs
+++ b/cabal-install/src/Distribution/Client/ScriptUtils.hs
@@ -179,7 +179,7 @@ import Distribution.Verbosity
   ( normal
   )
 import Language.Haskell.Extension
-  ( Language (..)
+  ( defaultDefLang
   )
 
 import Control.Concurrent.MVar
@@ -377,7 +377,7 @@ withContextAndSelectors noTargets kind flags@NixStyleFlags{..} targetStrings glo
 
               executable' =
                 executable
-                  & L.buildInfo . L.defaultLanguage %~ maybe (Just Haskell2010) Just
+                  & L.buildInfo . L.defaultLanguage %~ maybe (Just defaultDefLang) Just
                   & L.buildInfo . L.options %~ fmap (setExePath exePathRel)
 
           createDirectoryIfMissingVerbose verbosity True (takeDirectory exePath)

--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -1732,7 +1732,7 @@ system-dependent values for these fields.
 
     -  ``GHC2021`` (only available for GHC version newer than ``9.2``)
     -  ``Haskell2010``
-    -  ``Haskell98``
+    -  ``Haskell98`` (default)
 
 .. pkg-field:: other-languages: identifier
    :since: 1.12


### PR DESCRIPTION
Closes #9668.

Also correct two `Haskell2010` in the codebase which were not influencing `cabal` behaviour (i.e. `Haskell98` default).

---

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

