### PR TITLE
Fix `<more complex packages>` link lost in doc/cabal-package-description-file.rs

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -200,7 +200,7 @@ builds packages for all the Haskell implementations.
 The simple build infrastructure can also handle packages where building
 is governed by system-dependent parameters, if you specify a little more
 (see the section on `system-dependent parameters`_).
-A few packages require `more elaborate solutions <more complex packages>`_.
+A few packages require `more elaborate solutions <#more-complex-packages>`_.
 
 .. _pkg-desc:
 


### PR DESCRIPTION
**This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).

---

Currently, search the text "A few packages require more elaborate solutions" in https://cabal.readthedocs.io/en/stable/cabal-package.html#example-a-package-containing-a-library-and-executable-programs, click [more elaborate solutions](https://cabal.readthedocs.io/en/stable/morecomplexpackages), result 404 Not Found.

There are many ways to fix this issue.

I use this approach, i.e.

```
`more elaborate solutions <#more-complex-packages>`_
```

because there is a similar internal hyperlink on this page:

```
 `find these files at run-time <#accessing-data-files-from-package-code>`_
```

My patch is consistent with it.
