### PR TITLE
Add “Add default-language” suggestion

### DIFF
--- a/Cabal-tests/tests/ParserTests/regressions/issue-6288-d.cabal
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-6288-d.cabal
@@ -4,7 +4,8 @@ version:       6288
 build-type:    Simple
 synopsis:      default-language optionality
 category:      Test
-description:   Field is introduced in 1.10, defaulted in 3.4
+description:   Field is introduced in 1.10, defaulted in 3.4,
+               suggested in cabal 3.12.
 license:       BSD3
 license-file:  LICENSE
 maintainer:    Cabal Contributors

--- a/Cabal-tests/tests/ParserTests/regressions/issue-6288-f.check
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-6288-f.check
@@ -1,0 +1,1 @@
+[add-language] Without `default-language`, cabal will default to Haskell98, which is probably not what you want. Please add `default-language` to all targets.

--- a/Cabal-tests/tests/ParserTests/regressions/issue-7776-a.cabal
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-7776-a.cabal
@@ -24,3 +24,4 @@ library
             GHC.Hs.Type
         hs-source-dirs:
             compat-8.10
+    default-language: Haskell2010

--- a/Cabal-tests/tests/ParserTests/regressions/issue-7776-b.cabal
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-7776-b.cabal
@@ -15,6 +15,7 @@ library
     -- the base lower bound makes the package not buildable with ghc < 6.8
     -- but cabal is not smart enough to know it :-P
     build-depends: base >= 4.5 && < 4.15
+    default-language: Haskell2010
 
 benchmark benchmarks
     main-is: Benchmarks.hs
@@ -25,3 +26,4 @@ benchmark benchmarks
         Ghc-options: -fwarn-tabs
     else
         other-modules: Data.Hashable.RandomSource
+    default-language: Haskell2010

--- a/Cabal-tests/tests/ParserTests/regressions/issue-7776-c.cabal
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-7776-c.cabal
@@ -17,3 +17,4 @@ library
         compat
     other-modules:
         GHC.Hs.Type
+    default-language: Haskell2010

--- a/Cabal/src/Distribution/PackageDescription/Check/Warning.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Warning.hs
@@ -233,6 +233,7 @@ data CheckExplanation
   | CVTestSuite
   | CVDefaultLanguage
   | CVDefaultLanguageComponent
+  | CVDefaultLanguageComponentSoft
   | CVExtraDocFiles
   | CVMultiLib
   | CVReexported
@@ -394,6 +395,7 @@ data CheckExplanationID
   | CICVTestSuite
   | CICVDefaultLanguage
   | CICVDefaultLanguageComponent
+  | CICVDefaultLanguageComponentSoft
   | CICVExtraDocFiles
   | CICVMultiLib
   | CICVReexported
@@ -534,6 +536,7 @@ checkExplanationId (FilePathEmpty{}) = CIFilePathEmpty
 checkExplanationId (CVTestSuite{}) = CICVTestSuite
 checkExplanationId (CVDefaultLanguage{}) = CICVDefaultLanguage
 checkExplanationId (CVDefaultLanguageComponent{}) = CICVDefaultLanguageComponent
+checkExplanationId (CVDefaultLanguageComponentSoft{}) = CICVDefaultLanguageComponentSoft
 checkExplanationId (CVExtraDocFiles{}) = CICVExtraDocFiles
 checkExplanationId (CVMultiLib{}) = CICVMultiLib
 checkExplanationId (CVReexported{}) = CICVReexported
@@ -679,6 +682,7 @@ ppCheckExplanationId CIFilePathEmpty = "empty-path"
 ppCheckExplanationId CICVTestSuite = "test-cabal-ver"
 ppCheckExplanationId CICVDefaultLanguage = "default-language"
 ppCheckExplanationId CICVDefaultLanguageComponent = "no-default-language"
+ppCheckExplanationId CICVDefaultLanguageComponentSoft = "add-language"
 ppCheckExplanationId CICVExtraDocFiles = "extra-doc-files"
 ppCheckExplanationId CICVMultiLib = "multilib"
 ppCheckExplanationId CICVReexported = "reexported-modules"
@@ -1163,6 +1167,10 @@ ppExplanation CVDefaultLanguageComponent =
     ++ "Haskell98 or Haskell2010). If a component uses different languages "
     ++ "in different modules then list the other ones in the "
     ++ "'other-languages' field."
+ppExplanation CVDefaultLanguageComponentSoft =
+  "Without `default-language`, cabal will default to Haskell98, which is "
+    ++ "probably not what you want. Please add `default-language` to all "
+    ++ "targets."
 ppExplanation CVExtraDocFiles =
   "To use the 'extra-doc-files' field the package needs to specify "
     ++ "'cabal-version: 1.18' or higher."

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/DefaultLanguageSoft/cabal.out
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/DefaultLanguageSoft/cabal.out
@@ -1,0 +1,4 @@
+# cabal check
+The following errors will cause portability problems on other environments:
+Error: [add-language] Without `default-language`, cabal will default to Haskell98, which is probably not what you want. Please add `default-language` to all targets.
+Error: Hackage would reject this package.

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/DefaultLanguageSoft/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/DefaultLanguageSoft/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+
+-- Please specify `default-language`.
+main = cabalTest $
+  fails $ cabal "check" []

--- a/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/DefaultLanguageSoft/pkg.cabal
+++ b/cabal-testsuite/PackageTests/Check/ConfiguredPackage/CabalVersion/DefaultLanguageSoft/pkg.cabal
@@ -1,0 +1,11 @@
+cabal-version: 3.4
+name: pkg
+synopsis: synopsis
+description: description
+version: 0
+category: example
+maintainer: none@example.com
+license: GPL-3.0-or-later
+
+library
+  exposed-modules: Module

--- a/changelog.d/pr-9766
+++ b/changelog.d/pr-9766
@@ -1,0 +1,11 @@
+synopsis: Warn on missing `default-language`
+packages: Cabalcabal-install
+prs: #9766
+issues: #9620
+
+description: {
+
+- To help the adoption of GHC language editions, `cabal check` will now
+  warn about missing `default-language`.
+
+}

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -1276,6 +1276,7 @@ A list of all warnings with their constructor:
 - ``test-cabal-ver``: ``test-suite`` used with ``cabal-version`` < 1.10.
 - ``default-language``: ``default-language`` used with ``cabal-version`` < 1.10.
 - ``no-default-language``: missing ``default-language``.
+- ``add-default-language``: suggested ``default-language``.
 - ``extra-doc-files``: ``extra-doc-files`` used with ``cabal-version`` < 1.18.
 - ``multilib``: multiple ``library`` sections with ``cabal-version`` < 2.0.
 - ``reexported-modules``: ``reexported-modules`` with ``cabal-version`` < 1.22.


### PR DESCRIPTION
Closes #9620 

Add a warning ("Hackage would refuse this package") when `default-language` is missing. Done to prepare the user to GHC language editions.

---

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

** QA notes **

1. `cabal init` a package, choose `cabal-version` 3.4
2. run `cabal check`
3. old cabal: it will not complain about missing `default-language`
4. new cabal: it wil complain about missing `default-language`