### PR TITLE
Fix typo

### DIFF
--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -3408,7 +3408,7 @@ pathCommand :: CommandUI PathFlags
 pathCommand =
   CommandUI
     { commandName = "path"
-    , commandSynopsis = "Display paths used by cabal"
+    , commandSynopsis = "Display paths used by cabal."
     , commandDescription = Just $ \_ ->
         wrapText $
           "This command prints the directories that are used by cabal,"


### PR DESCRIPTION
Missing full stop.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* ~~[ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).~~ not present in 3.10, so I would say a changelog entry is not needed.
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* ~~[ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)~~ one-liner, not needed