### PR TITLE
offline flag disables `source-repository-package` sync

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -1192,6 +1192,7 @@ fetchAndReadSourcePackages
         verbosity
         distDirLayout
         projectConfigShared
+        (fromFlag (projectConfigOfflineMode projectConfigBuildOnly))
         [repo | ProjectPackageRemoteRepo repo <- pkgLocations]
 
     let pkgsNamed =
@@ -1308,6 +1309,7 @@ syncAndReadSourcePackagesRemoteRepos
   :: Verbosity
   -> DistDirLayout
   -> ProjectConfigShared
+  -> Bool
   -> [SourceRepoList]
   -> Rebuild [PackageSpecifier (SourcePackage UnresolvedPkgLoc)]
 syncAndReadSourcePackagesRemoteRepos
@@ -1316,6 +1318,7 @@ syncAndReadSourcePackagesRemoteRepos
   ProjectConfigShared
     { projectConfigProgPathExtra
     }
+  offlineMode
   repos = do
     repos' <-
       either reportSourceRepoProblems return $
@@ -1370,12 +1373,18 @@ syncAndReadSourcePackagesRemoteRepos
 
         -- For syncing we don't care about different 'SourceRepo' values that
         -- are just different subdirs in the same repo.
-        syncSourceRepos
-          verbosity
-          vcs
-          [ (repo, repoPath)
-          | (repo, _, repoPath) <- repoGroupWithPaths
-          ]
+        -- Do not sync source repositories when `--offline` flag applied.
+        if not offlineMode
+          then
+            syncSourceRepos
+              verbosity
+              vcs
+              [ (repo, repoPath)
+              | (repo, _, repoPath) <- repoGroupWithPaths
+              ]
+          else do
+            liftIO . warn verbosity $ "--offline was specified, skipping sync of repositories:"
+            liftIO . for_ repoGroupWithPaths $ \(repo, _, _) -> warn verbosity $ srpLocation repo
 
         -- Run post-checkout-command if it is specified
         for_ repoGroupWithPaths $ \(repo, _, repoPath) ->

--- a/changelog.d/issue-9641
+++ b/changelog.d/issue-9641
@@ -1,0 +1,8 @@
+synopsis: offline flag applied to `source-repository-package`s
+packages: Cabal-install
+prs: #9771
+issues: #9641
+
+description: {
+`--offline` flag is already used to block access to Hackage. Now with this PR, this also applies to remote dependency `source-repository-package` in `cabal.project`.
+}


### PR DESCRIPTION
Closes: https://github.com/haskell/cabal/issues/9641

How this was tested:
- use the example project: https://github.com/peterbecich/cabal2nix-project-issue
  - this example pulls the `text` library as a `source-repository-package`
- build, install Cabal from this PR
  - `cabal install cabal --overwrite-policy=always`
- in the example project, delete `dist-newstyle` to remove the `text` library cached there
  - `rm -rf dist-newstyle; ~/.cabal/bin/cabal build`
  - `text` library pulled, build succeeds
- next, build with the cached `text` library and `offline` flag
  - `~/.cabal/bin/cabal build  --offline`
  - this succeeds
  - offline flag does not break the cached library
- next, delete `dist-newstyle` again, and attempt build with `--offline`
  - `rm -rf dist-newstyle; ~/.cabal/bin/cabal build --offline`
  - this fails, as intended
  - this proves the offline flag is preventing the `text` library from being pulled
  - the error message could be improved:
```
$ rm -rf dist-newstyle; ~/.cabal/bin/cabal build --offline
.../dist-newstyle/src/text-8e814f5854032da8: getDirectoryContents:openDirStream:
  does not exist (No such file or directory)
```

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)


