### PR TITLE
Support GHC2024 (fixes #9736)

### DIFF
--- a/Cabal-syntax/src/Language/Haskell/Extension.hs
+++ b/Cabal-syntax/src/Language/Haskell/Extension.hs
@@ -54,6 +54,9 @@ data Language
   | -- | The GHC2021 collection of language extensions.
     -- <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0380-ghc2021.rst>
     GHC2021
+  | -- | The GHC2024 collection of language extensions.
+    -- <https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0613-ghc2024.rst>
+    GHC2024
   | -- | An unknown language, identified by its name.
     UnknownLanguage String
   deriving (Generic, Show, Read, Eq, Ord, Typeable, Data)
@@ -65,7 +68,7 @@ instance NFData Language where rnf = genericRnf
 
 -- | List of known (supported) languages for GHC, oldest first.
 knownLanguages :: [Language]
-knownLanguages = [Haskell98, Haskell2010, GHC2021]
+knownLanguages = [Haskell98, Haskell2010, GHC2021, GHC2024]
 
 instance Pretty Language where
   pretty (UnknownLanguage other) = Disp.text other

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -33,15 +33,15 @@ md5Check proxy md5Int = structureHash proxy @?= md5FromInteger md5Int
 md5CheckGenericPackageDescription :: Proxy GenericPackageDescription -> Assertion
 md5CheckGenericPackageDescription proxy = md5Check proxy
 #if MIN_VERSION_base(4,19,0)
-    0x4136daf844669c3c272845160cb5a908
+    0x7559521b9eb2e2fa4a608a86c629dc17
 #else
-    0x196b441722dfe556ed5b5d1d874741b3
+    0xa78ea118e2e29b5809d359c9431df3ba
 #endif
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
 #if MIN_VERSION_base(4,19,0)
-    0x8a30fa23374160aac9cdd1996dc5112b
+    0x8a8e81b52a34b8610acdcd0b9d488940
 #else
-    0x2e959a7f1da8f0d11f6923831ab6ab55
+    0xb53fbd58281a6f329f7b659d91fcd86e
 #endif

--- a/Cabal/src/Distribution/Simple/GHC/ImplInfo.hs
+++ b/Cabal/src/Distribution/Simple/GHC/ImplInfo.hs
@@ -38,6 +38,8 @@ data GhcImplInfo = GhcImplInfo
   -- ^ -XHaskell2010 and -XHaskell98 flags
   , supportsGHC2021 :: Bool
   -- ^ -XGHC2021 flag
+  , supportsGHC2024 :: Bool
+  -- ^ -XGHC2024 flag
   , reportsNoExt :: Bool
   -- ^ --supported-languages gives Ext and NoExt
   , alwaysNondecIndent :: Bool
@@ -88,6 +90,7 @@ ghcVersionImplInfo ver =
   GhcImplInfo
     { supportsHaskell2010 = v >= [7]
     , supportsGHC2021 = v >= [9, 1]
+    , supportsGHC2024 = v >= [9, 9]
     , reportsNoExt = v >= [7]
     , alwaysNondecIndent = v < [7, 1]
     , flagGhciScript = v >= [7, 2]
@@ -114,6 +117,7 @@ ghcjsVersionImplInfo _ghcjsver ghcver =
   GhcImplInfo
     { supportsHaskell2010 = True
     , supportsGHC2021 = True
+    , supportsGHC2024 = ghcv >= [9, 9]
     , reportsNoExt = True
     , alwaysNondecIndent = False
     , flagGhciScript = True

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -258,6 +258,13 @@ getLanguages
   -> IO [(Language, String)]
 getLanguages _ implInfo _
   -- TODO: should be using --supported-languages rather than hard coding
+  | supportsGHC2024 implInfo =
+      return
+        [ (GHC2024, "-XGHC2024")
+        , (GHC2021, "-XGHC2021")
+        , (Haskell2010, "-XHaskell2010")
+        , (Haskell98, "-XHaskell98")
+        ]
   | supportsGHC2021 implInfo =
       return
         [ (GHC2021, "-XGHC2021")

--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -456,11 +456,12 @@ languagePrompt flags pkgType = getLanguage flags $ do
   let h2010 = "Haskell2010"
       h98 = "Haskell98"
       ghc2021 = "GHC2021 (requires at least GHC 9.2)"
+      ghc2024 = "GHC2024 (requires at least GHC 9.10)"
 
   l <-
     promptList
       ("Choose a language for your " ++ pkgType)
-      [h2010, h98, ghc2021]
+      [h2010, h98, ghc2021, ghc2024]
       (DefaultPrompt h2010)
       Nothing
       True
@@ -469,6 +470,7 @@ languagePrompt flags pkgType = getLanguage flags $ do
       | l == h2010 -> return Haskell2010
       | l == h98 -> return Haskell98
       | l == ghc2021 -> return GHC2021
+      | l == ghc2024 -> return GHC2024
       | otherwise -> return $ UnknownLanguage l
 
 noCommentsPrompt :: Interactive m => InitFlags -> m Bool

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
@@ -1014,19 +1014,19 @@ interactiveTests srcDb =
             [ testNumberedPrompt
                 "Language indices"
                 (`languagePrompt` "test")
-                [Haskell2010, Haskell98, GHC2021]
+                [Haskell2010, Haskell98, GHC2021, GHC2024]
             , testSimplePrompt
                 "Other language"
                 (`languagePrompt` "test")
                 (UnknownLanguage "Haskell2022")
-                [ "4"
+                [ "5"
                 , "Haskell2022"
                 ]
             , testSimplePrompt
                 "Invalid language"
                 (`languagePrompt` "test")
                 (UnknownLanguage "Lang_TS!")
-                [ "4"
+                [ "5"
                 , "Lang_TS!"
                 ]
             ]

--- a/changelog.d/issue-9736
+++ b/changelog.d/issue-9736
@@ -1,0 +1,11 @@
+synopsis: Add support for `GHC2024`
+packages: Cabal cabal-install
+issues: #9736
+
+description: {
+
+Support for the `GHC2024` language edition, introduced by GHC 9.10, has been
+added. It can now be used in the `default-language` and `other-languages`
+fields, and will be offered as an option by `cabal init`.
+
+}

--- a/doc/buildinfo-fields-reference.rst
+++ b/doc/buildinfo-fields-reference.rst
@@ -290,7 +290,7 @@ default-language
     * Documentation of :pkg-field:`library:default-language`
 
     .. math::
-        \left\{ \mathop{\mathord{``}\mathtt{GHC2021}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{Haskell2010}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{Haskell98}\mathord{"}} \right\}
+        \left\{ \begin{gathered}\mathop{\mathord{``}\mathtt{GHC2024}\mathord{"}}\\\mathop{\mathord{``}\mathtt{GHC2021}\mathord{"}}\\\mathop{\mathord{``}\mathtt{Haskell2010}\mathord{"}}\\\mathop{\mathord{``}\mathtt{Haskell98}\mathord{"}}\end{gathered} \right\}
 
 extensions
     * Monoidal field
@@ -494,7 +494,7 @@ other-languages
     * Documentation of :pkg-field:`library:other-languages`
 
     .. math::
-        \mathrm{optcommalist}\left\{ \mathop{\mathord{``}\mathtt{GHC2021}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{Haskell2010}\mathord{"}}\mid\mathop{\mathord{``}\mathtt{Haskell98}\mathord{"}} \right\}
+        \mathrm{optcommalist}\left\{ \begin{gathered}\mathop{\mathord{``}\mathtt{GHC2024}\mathord{"}}\\\mathop{\mathord{``}\mathtt{GHC2021}\mathord{"}}\\\mathop{\mathord{``}\mathtt{Haskell2010}\mathord{"}}\\\mathop{\mathord{``}\mathtt{Haskell98}\mathord{"}}\end{gathered} \right\}
 
 other-modules
     * Monoidal field

--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -1730,7 +1730,8 @@ system-dependent values for these fields.
 
     The possible values are:
 
-    -  ``GHC2021`` (only available for GHC version newer than ``9.2``)
+    -  ``GHC2024`` (only available for GHC version ``9.10`` or later)
+    -  ``GHC2021`` (only available for GHC version ``9.2`` or later)
     -  ``Haskell2010``
     -  ``Haskell98``
 

--- a/editors/vim/syntax/cabal.vim
+++ b/editors/vim/syntax/cabal.vim
@@ -39,6 +39,7 @@ syn keyword cabalLanguage contained
   \ Haskell98
   \ Haskell2010
   \ GHC2021
+  \ GHC2024
 
 " To update this in Cabal, `cabal repl Cabal` and:
 " >>> :m *Distribution.PackageDescription.FieldGrammar


### PR DESCRIPTION
This adds support for the `GHC2024` language edition, which will be introduced with GHC 9.10. I've grepped for `GHC2021` and copy-pasted; I'm not sure what QA notes or additional tests are needed (if any).

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added.