### PR TITLE
Add required-fields to changelog.d config

### DIFF
--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -48,12 +48,14 @@ jobs:
           ghcup set ghc recommended
       - name: Update Hackage index
         run: cabal v2-update
-      # Cannot install it from tarball due to
+      # Cannot install it directly from remote tarball due to
       # https://github.com/haskell/cabal/issues/7360
-      - uses: actions/checkout@v4
-        with:
-          repository: "fgaz/changelog-d"
-          path: "changelog-d"
+      - name: Fetch changelog-d
+        run: |
+          changelog_d_latest="$(curl https://codeberg.org/api/v1/repos/fgaz/changelog-d/branches/master | jq -r .commit.id)"
+          echo "Using changelog-d revision $changelog_d_latest"
+          curl "https://codeberg.org/fgaz/changelog-d/archive/$changelog_d_latest.tar.gz" -o changelog-d.tar.gz
+          tar -xf changelog-d.tar.gz
       - name: Install changelog-d
         run: |
           pushd changelog-d

--- a/changelog.d/config
+++ b/changelog.d/config
@@ -1,2 +1,3 @@
 organization: haskell
 repository:   cabal
+required-fields: packages prs

--- a/changelog.d/issue-8680
+++ b/changelog.d/issue-8680
@@ -1,6 +1,7 @@
 synopsis: `cabal init` should not suggest Cabal < 2.0
 packages: Cabal
 issues: #8680
+prs: #8700
 
 description: {
 

--- a/changelog.d/issue-9098-lexbraces
+++ b/changelog.d/issue-9098-lexbraces
@@ -1,6 +1,7 @@
 synopsis: Add LexBraces lexer warning
 packages: Cabal-syntax
-issues: #8577
+issues: #9098
+prs: #9099
 
 description: {
 

--- a/changelog.d/issue-9678
+++ b/changelog.d/issue-9678
@@ -2,6 +2,7 @@ synopsis: Clarify the semantics of the -package-db flag
 packages: cabal-install
 prs:
 issues: #9678
+prs: #9683
 
 description: {
 

--- a/changelog.d/issue-9736
+++ b/changelog.d/issue-9736
@@ -1,6 +1,7 @@
 synopsis: Add support for `GHC2024`
 packages: Cabal cabal-install
 issues: #9736
+prs: #9791
 
 description: {
 

--- a/changelog.d/pkgconfig-once
+++ b/changelog.d/pkgconfig-once
@@ -1,5 +1,6 @@
 synopsis: PkgConfig individual calls
 prs: #9134
+packages: cabal-install-solver
 
 description: {
 


### PR DESCRIPTION
See https://codeberg.org/fgaz/changelog-d/issues/6

---

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

