### PR TITLE
Conform BSD-2-Clause and BSD-3-Clause text to SPDX

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Licenses.hs
+++ b/cabal-install/src/Distribution/Client/Init/Licenses.hs
@@ -30,7 +30,6 @@ bsd2 :: String -> String -> License
 bsd2 authors year =
   unlines
     [ "Copyright (c) " ++ year ++ ", " ++ authors
-    , "All rights reserved."
     , ""
     , "Redistribution and use in source and binary forms, with or without"
     , "modification, are permitted provided that the following conditions are"
@@ -48,7 +47,7 @@ bsd2 authors year =
     , "\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT"
     , "LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR"
     , "A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT"
-    , "OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,"
+    , "HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,"
     , "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT"
     , "LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,"
     , "DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY"
@@ -62,7 +61,6 @@ bsd3 authors year =
   unlines
     [ "Copyright (c) " ++ year ++ ", " ++ authors
     , ""
-    , "All rights reserved."
     , ""
     , "Redistribution and use in source and binary forms, with or without"
     , "modification, are permitted provided that the following conditions are met:"
@@ -75,7 +73,7 @@ bsd3 authors year =
     , "      disclaimer in the documentation and/or other materials provided"
     , "      with the distribution."
     , ""
-    , "    * Neither the name of " ++ authors ++ " nor the names of other"
+    , "    * Neither the name of the copyright holder nor the names of its"
     , "      contributors may be used to endorse or promote products derived"
     , "      from this software without specific prior written permission."
     , ""
@@ -83,7 +81,7 @@ bsd3 authors year =
     , "\"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT"
     , "LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR"
     , "A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT"
-    , "OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,"
+    , "HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,"
     , "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT"
     , "LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,"
     , "DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY"

--- a/changelog.d/pr-9813
+++ b/changelog.d/pr-9813
@@ -1,0 +1,12 @@
+synopsis: Adjust BSD-2-Clause and BSD-3-Clause licence text
+packages: cabal-install
+prs: #9813
+issues: #9812
+
+description: {
+
+This change matters to BSD-2-Clause and BSD-3-Clause licences. For these two
+licences, `cabal init` created a licence file that slightly differed from
+wording published at SPDX.  This has been rectified.
+
+}


### PR DESCRIPTION
`cabal init` text for BSD-2-Clause and BSD-3-Clause licence differed slightly from the one published at SPDX. [1] [2]

This caused some problems to users when dealing with licence-recognition software. [3]

[1] https://spdx.org/licenses/BSD-2-Clause.html
[2] https://spdx.org/licenses/BSD-3-Clause.html
[3] https://discourse.haskell.org/t/non-standard-license-generated-by-stack-new/9059

---

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] ~~Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)~~ automated tests not needed

---

**QA Notes**
1. `cabal init` and a series of ⏎ (it should select a BSD licence)
2. `LICENSE` file does not contain the sentence “All rights reserved.”.