### PR TITLE
Show abbreviated mixed versions with suffix

### DIFF
--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/Solver.hs
@@ -961,7 +961,7 @@ tests =
                     , Right $ exAv "B" 1 [ExFix "A" 4]
                     ]
                   rejecting = "rejecting: A-3.0.0/installed-3.0.0"
-                  skipping = "skipping: A-2.0.0/installed-2.0.0, A-1.0.0/installed-1.0.0"
+                  skipping = "skipping: A; 2.0.0/installed-2.0.0, 1.0.0/installed-1.0.0"
                in mkTest db "show skipping versions list, installed" ["B"] $
                     solverFailure (\msg -> rejecting `isInfixOf` msg && skipping `isInfixOf` msg)
           ]

--- a/changelog.d/pr-9824
+++ b/changelog.d/pr-9824
@@ -1,0 +1,10 @@
+synopsis: Abbrevate solver rejection messages with installed versions
+packages: cabal-install-solver
+prs: #9824
+issues: #9823
+
+description: {
+
+Abbreviate solver rejection messages even in the presence of installed versions.
+
+}


### PR DESCRIPTION
Fixes #9823.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*), the expected output has changed for existing doctests.

With this fix, the solver rejection message of the reproduction for #9823 is shorter[^1];

```
$ cabal build all --enable-tests --enable-benchmarks --dry-run
Warning: this is a debug build of cabal-install with assertions enabled.
Resolving dependencies...
Error: [Cabal-7107]
Could not resolve dependencies:
[__0] next goal: Cabal (user goal)
[__0] rejecting: Cabal-3.11.0.0 (constraint from project config /home/.../cabal.project.local requires ==2.4.1.0 || ==3.0.2.0 || ==3.2.1.0)
[__0] rejecting: Cabal; 3.10.2.1, 3.10.2.0/installed-fd40, 3.10.2.0, 3.10.1.0, 3.8.1.0, 3.6.3.0, 3.6.2.0, 3.6.1.0, 3.6.0.0, 3.4.1.0, 3.4.0.0, 3.2.1.0, 3.2.0.0, 3.0.2.0, 3.0.1.0, 3.0.0.0, 2.4.1.0, 2.4.0.1, 2.4.0.0, 2.2.0.1, 2.2.0.0, 2.0.1.1, 2.0.1.0, 2.0.0.2, 1.24.2.0, 1.24.0.0, 1.22.8.0, 1.22.7.0, 1.22.6.0, 1.22.5.0, 1.22.4.0, 1.22.3.0, 1.22.2.0, 1.22.1.1, 1.22.1.0, 1.22.0.0, 1.20.0.4, 1.20.0.3, 1.20.0.2, 1.20.0.1, 1.20.0.0, 1.18.1.7, 1.18.1.6, 1.18.1.5, 1.18.1.4, 1.18.1.3, 1.18.1.2, 1.18.1.1, 1.18.1, 1.18.0, 1.16.0.3, 1.16.0.2, 1.16.0.1, 1.16.0, 1.14.0, 1.12.0, 1.10.2.0, 1.10.1.0, 1.10.0.0, 1.8.0.6, 1.8.0.4, 1.8.0.2, 1.6.0.3, 1.6.0.2, 1.6.0.1, 1.4.0.2, 1.4.0.1, 1.4.0.0, 1.2.4.0, 1.2.3.0, 1.2.2.0, 1.2.1, 1.1.6, 1.24.1.0 (constraint from user target requires ==3.11.0.0)
[__0] fail (backjumping, conflict set: Cabal)
After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: Cabal
```

[^1]: I see that the full path to `cabal.project.local` is shown. ~I'll need to check if I introduced that change inadvertently.~ I checked on master at `git rev-parse HEAD == 46e822152c9b3f38044870115d7a198b3a509d66` and the full path to `cabal.project.local` is shown there so I did not introduce this change with this fix.