### PR TITLE
docs: correct references to location of global store

### DIFF
--- a/doc/how-to-build-like-nix.rst
+++ b/doc/how-to-build-like-nix.rst
@@ -28,7 +28,7 @@ Nix-style local builds combine the best of non-sandboxed and sandboxed Cabal:
    will rebuild all its dependencies with profiling automatically.
 
 2. Like non-sandboxed Cabal today, builds of external packages are
-   cached in ``~/.cabal/store``, so that a package can be built once,
+   cached in a global store, so that a package can be built once,
    and then reused anywhere else it is also used. No need to continually
    rebuild dependencies whenever you make a new sandbox: dependencies
    which can be shared, are shared.

--- a/doc/nix-local-build.rst
+++ b/doc/nix-local-build.rst
@@ -170,8 +170,9 @@ identify the result of a build; if we compute this identifier and we
 find that we already have this ID built, we can just use the already
 built version.
 
-The global package store is ``~/.cabal/store`` (configurable via
-global `store-dir` option); if you need to clear your store for
+Use ``cabal path --store-dir`` to show where your global package store is located.
+This is configurable via the global ``store-dir`` option.
+If you need to clear your store for
 whatever reason (e.g., to reclaim disk space or because the global
 store is corrupted), deleting this directory is safe (``build``
 will just rebuild everything it needs on its next invocation).


### PR DESCRIPTION
These are just some trivial docs fixes I noticed while wondering where my store had got to.

---

This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

