### PR TITLE
Refactor Rebuild monad into writer over sets

### DIFF
--- a/Cabal/src/Distribution/Simple/Glob/Internal.hs
+++ b/Cabal/src/Distribution/Simple/Glob/Internal.hs
@@ -457,8 +457,8 @@ checkNameMatches spec glob candidate
       -- if multidot is supported, then this is a clean match
       if enableMultidot spec
         then pure (GlobMatch ())
-        else -- if not, issue a warning saying multidot is needed for the match
 
+        else -- if not, issue a warning saying multidot is needed for the match
           let (_, candidateExts) = splitExtensions $ takeFileName candidate
               extractExts :: GlobPieces -> Maybe String
               extractExts [] = Nothing

--- a/Cabal/src/Distribution/Simple/Glob/Internal.hs
+++ b/Cabal/src/Distribution/Simple/Glob/Internal.hs
@@ -49,7 +49,7 @@ data Glob
     GlobFile !GlobPieces
   | -- | Trailing dir; a glob ending in @/@.
     GlobDirTrailing
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance Binary Glob
 instance Structured Glob
@@ -65,7 +65,7 @@ data GlobPiece
     Literal String
   | -- | A union of patterns, e.g. @dir/{a,*.txt,c}/...@
     Union [GlobPieces]
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance Binary GlobPiece
 instance Structured GlobPiece

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -247,7 +247,8 @@ library
         regex-base  >= 0.94.0.0 && <0.95,
         regex-posix >= 0.96.0.0 && <0.97,
         safe-exceptions >= 0.1.7.0 && < 0.2,
-        semaphore-compat >= 1.0.0 && < 1.1
+        semaphore-compat >= 1.0.0 && < 1.1,
+        transformers >= 0.5.6.2 && < 0.7
 
     if flag(native-dns)
       if os(windows)

--- a/cabal-install/src/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/src/Distribution/Client/FileMonitor.hs
@@ -286,9 +286,9 @@ instance Structured MonitorStateGlobRel
 -- direction by just forgetting the extra info.
 reconstructMonitorFilePaths :: MonitorStateFileSet -> Set MonitorFilePath
 reconstructMonitorFilePaths (MonitorStateFileSet singlePaths globPaths) =
-  Set.fromList
-    $ map getSinglePath (Set.toList singlePaths)
-    <> map getGlobPath (Set.toList globPaths)
+  Set.fromList $
+    map getSinglePath (Set.toList singlePaths)
+      <> map getGlobPath (Set.toList globPaths)
   where
     getSinglePath :: MonitorStateFile -> MonitorFilePath
     getSinglePath (MonitorStateFile kindfile kinddir filepath _) =
@@ -576,10 +576,11 @@ probeFileSystem root (MonitorStateFileSet singlePaths globPaths) =
       ]
     -- The glob monitors can require state changes
     globPaths' <-
-      Set.fromList <$> sequence
-        [ probeMonitorStateGlob root globPath
-        | globPath <- Set.toList globPaths
-        ]
+      Set.fromList
+        <$> sequence
+          [ probeMonitorStateGlob root globPath
+          | globPath <- Set.toList globPaths
+          ]
     return (MonitorStateFileSet singlePaths globPaths')
 
 -----------------------------------------------

--- a/cabal-install/src/Distribution/Client/Glob.hs
+++ b/cabal-install/src/Distribution/Client/Glob.hs
@@ -39,7 +39,7 @@ data RootedGlob
       -- ^ what the glob is relative to
       Glob
       -- ^ the glob
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance Binary RootedGlob
 instance Structured RootedGlob
@@ -49,7 +49,7 @@ data FilePathRoot
   | -- | e.g. @"/"@, @"c:\"@ or result of 'takeDrive'
     FilePathRoot FilePath
   | FilePathHomeDir
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance Binary FilePathRoot
 instance Structured FilePathRoot

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/PackageFileMonitor.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/PackageFileMonitor.hs
@@ -226,7 +226,7 @@ updatePackageConfigFileMonitor
       pkgFileMonitorConfig
       srcdir
       Nothing
-      []
+      mempty
       pkgconfig
       ()
     where
@@ -238,7 +238,7 @@ updatePackageBuildFileMonitor
   -> MonitorTimestamp
   -> ElaboratedConfiguredPackage
   -> BuildStatusRebuild
-  -> [MonitorFilePath]
+  -> Set MonitorFilePath
   -> BuildResultMisc
   -> IO ()
 updatePackageBuildFileMonitor
@@ -285,7 +285,7 @@ updatePackageRegFileMonitor
       pkgFileMonitorReg
       srcdir
       Nothing
-      []
+      mempty
       ()
       mipkg
 

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -473,7 +473,8 @@ buildInplaceUnpackedPackage
 
             let listSimple =
                   execRebuild srcdir (needElaboratedConfiguredPackage pkg)
-                listSdist = fmap (Set.fromList . map monitorFileHashed) $
+                listSdist =
+                  fmap (Set.fromList . map monitorFileHashed) $
                     allPackageSourceFiles verbosity srcdir
                 ifNullThen m m' = do
                   xs <- m
@@ -500,12 +501,12 @@ buildInplaceUnpackedPackage
 
             let dep_monitors =
                   Set.fromList $
-                  map monitorFileHashed $
-                    elabInplaceDependencyBuildCacheFiles
-                      distDirLayout
-                      pkgshared
-                      plan
-                      pkg
+                    map monitorFileHashed $
+                      elabInplaceDependencyBuildCacheFiles
+                        distDirLayout
+                        pkgshared
+                        plan
+                        pkg
             updatePackageBuildFileMonitor
               packageFileMonitor
               srcdir

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -91,6 +91,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as LBS.Char8
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Set as Set
 
 import Control.Exception (ErrorCall, Handler (..), SomeAsyncException, assert, catches)
 import System.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, removeFile)
@@ -472,8 +473,7 @@ buildInplaceUnpackedPackage
 
             let listSimple =
                   execRebuild srcdir (needElaboratedConfiguredPackage pkg)
-                listSdist =
-                  fmap (map monitorFileHashed) $
+                listSdist = fmap (Set.fromList . map monitorFileHashed) $
                     allPackageSourceFiles verbosity srcdir
                 ifNullThen m m' = do
                   xs <- m
@@ -499,6 +499,7 @@ buildInplaceUnpackedPackage
                     listSimple
 
             let dep_monitors =
+                  Set.fromList $
                   map monitorFileHashed $
                     elabInplaceDependencyBuildCacheFiles
                       distDirLayout
@@ -511,7 +512,7 @@ buildInplaceUnpackedPackage
               timestamp
               pkg
               buildStatus
-              (monitors ++ dep_monitors)
+              (monitors <> dep_monitors)
               buildResult
         PBHaddockPhase{runHaddock} -> do
           runHaddock
@@ -933,4 +934,3 @@ withTempInstalledPackageInfoFile verbosity tempdir action =
           unlines warns
 
       return ipkg
-

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -488,7 +488,7 @@ configureCompiler
         -- the compiler will configure (and it does vary between compilers).
         -- We do know however that the compiler will only configure the
         -- programs it cares about, and those are the ones we monitor here.
-        monitorFiles (programsMonitorFiles progdb'')
+        monitorFiles (Set.fromList (programsMonitorFiles progdb''))
 
         return result
     where
@@ -941,7 +941,7 @@ getInstalledPackages
   -> PackageDBStack
   -> Rebuild InstalledPackageIndex
 getInstalledPackages verbosity compiler progdb platform packagedbs = do
-  monitorFiles . map monitorFileOrDirectory
+  monitorFiles . Set.fromList . map monitorFileOrDirectory
     =<< liftIO
       ( IndexUtils.getInstalledPackagesMonitorFiles
           verbosity
@@ -1166,6 +1166,7 @@ getPackageSourceHashes verbosity withRepoCtx solverPlan = do
           | (pkgid, tarball) <- allTarballFilePkgs
           ]
   monitorFiles
+    $ Set.fromList
     [ monitorFile tarball
     | (_pkgid, tarball) <- allTarballFilePkgs
     ]

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -1165,11 +1165,11 @@ getPackageSourceHashes verbosity withRepoCtx solverPlan = do
             return (pkgid, srchash)
           | (pkgid, tarball) <- allTarballFilePkgs
           ]
-  monitorFiles
-    $ Set.fromList
-    [ monitorFile tarball
-    | (_pkgid, tarball) <- allTarballFilePkgs
-    ]
+  monitorFiles $
+    Set.fromList
+      [ monitorFile tarball
+      | (_pkgid, tarball) <- allTarballFilePkgs
+      ]
 
   -- Return the combination
   return $!

--- a/cabal-install/src/Distribution/Client/RebuildMonad.hs
+++ b/cabal-install/src/Distribution/Client/RebuildMonad.hs
@@ -257,12 +257,12 @@ createDirectoryMonitored createParents dir = do
 monitorDirectoryStatus :: FilePath -> Rebuild Bool
 monitorDirectoryStatus dir = do
   exists <- liftIO $ doesDirectoryExist dir
-  monitorFiles
-    $ Set.singleton
-    ( if exists
-        then monitorDirectory dir
-        else monitorNonExistentDirectory dir
-    )
+  monitorFiles $
+    Set.singleton
+      ( if exists
+          then monitorDirectory dir
+          else monitorNonExistentDirectory dir
+      )
   return exists
 
 -- | Like 'doesFileExist', but in the 'Rebuild' monad.  This does
@@ -271,12 +271,12 @@ doesFileExistMonitored :: FilePath -> Rebuild Bool
 doesFileExistMonitored f = do
   root <- askRoot
   exists <- liftIO $ doesFileExist (root </> f)
-  monitorFiles
-    $ Set.singleton
-    ( if exists
-        then monitorFileExistence f
-        else monitorNonExistentFile f
-    )
+  monitorFiles $
+    Set.singleton
+      ( if exists
+          then monitorFileExistence f
+          else monitorNonExistentFile f
+      )
   return exists
 
 -- | Monitor a single file
@@ -292,12 +292,12 @@ needIfExists :: FilePath -> Rebuild ()
 needIfExists f = do
   root <- askRoot
   exists <- liftIO $ doesFileExist (root </> f)
-  monitorFiles
-    $ Set.singleton
-    ( if exists
-        then monitorFileHashed f
-        else monitorNonExistentFile f
-    )
+  monitorFiles $
+    Set.singleton
+      ( if exists
+          then monitorFileHashed f
+          else monitorNonExistentFile f
+      )
 
 -- | Like 'findFileWithExtension', but in the 'Rebuild' monad.
 findFileWithExtensionMonitored

--- a/cabal-install/src/Distribution/Client/VCS.hs
+++ b/cabal-install/src/Distribution/Client/VCS.hs
@@ -90,6 +90,7 @@ import Control.Monad.Trans
 import qualified Data.Char as Char
 import qualified Data.List as List
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import System.Directory
   ( doesDirectoryExist
   , removeDirectoryRecursive
@@ -274,7 +275,7 @@ syncSourceRepos
   -> Rebuild ()
 syncSourceRepos verbosity vcs repos = do
   files <- liftIO $ vcsSyncRepos vcs verbosity (vcsProgram vcs) repos
-  monitorFiles files
+  monitorFiles (Set.fromList files)
 
 -- ------------------------------------------------------------
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/FileMonitor.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/FileMonitor.hs
@@ -450,10 +450,11 @@ testMultipleMonitorKinds mtimeChange =
     updateMonitor
       root
       monitor
-      (Set.fromList
-      [ monitorDirectory "dir"
-      , monitorDirectoryExistence "dir"
-      ])
+      ( Set.fromList
+          [ monitorDirectory "dir"
+          , monitorDirectoryExistence "dir"
+          ]
+      )
       ()
       ()
     (res2, files2) <- expectMonitorUnchanged root monitor ()


### PR DESCRIPTION
Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

-----

I noticed that this seemed like a more natural way for the Rebuild monad to work. Perhaps this even saves us some file watching, I didn't look into it that deeply.
