### PR TITLE
 synchronize source repos concurrently

### DIFF
--- a/changelog.d/synchronize-source-repos-concurrently
+++ b/changelog.d/synchronize-source-repos-concurrently
@@ -1,0 +1,5 @@
+synopsis: Synchronize source repositories concurrently
+packages: cabal-install
+prs: #0000
+significance: significant
+


### PR DESCRIPTION
Synchronizes source repos concurrently with 4 repos being synchronized at once. I couldn't find a good way to make this number a flag, and so I figured that if someone wants to do that, they can do it later, because doing this concurrently is already a significant speedup for me and seems to be mostly free.

I didn't write any tests, because I figured this is guaranteed to be correct and I don't know how I'd even test it.

~~This PR depends on #9843 just because that PR makes it more obvious that `sequenceConcurrentlyBoundedRebuild` is correct.~~ This no longer depends on #9843.

## QA Notes

Ran this on a work project which has 12 git source repositories. Observed the interleaved output from git and the much faster build from clean.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
