### PR TITLE
Fix #9815: fix caching for quick-jobs CI (XDG, cache keys)

### DIFF
--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -81,10 +81,21 @@ jobs:
     name: Doctest Cabal
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/cache@v4
+      # It is complicated to get a proper cache key for the dependencies of a package
+      # (here: doctest) that we just `cabal install`.
+      # So, as a heuristics we update the cache once per day.
+      # Updating it with each run would be an alternative, but we a short of cache space,
+      # and this would generate too many new caches.
+      - name: Use date as cache key
+        run: |
+          echo "DATE=$(date +'%Y-%m-%d')" >> "${GITHUB_ENV}"
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v4
+        id: cache
         with:
           path: ~/.local/state/cabal
-          key: linux-store-doctest
+          key: linux-store-doctest-${{ env.DATE }}
+          restore-keys: linux-store-doctest
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v4
@@ -92,6 +103,13 @@ jobs:
         run: make doctest-install
       - name: Doctest
         run: make doctest
+      - name: Cache dependencies
+        if: always() && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.local/state/cabal
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
   buildinfo:
     name: Check Field Syntax Reference
     runs-on: ubuntu-latest

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -27,16 +27,6 @@ jobs:
         gen-spdx-exc
     # This job is not run in a container, any recent GHC should be fine
     steps:
-      # OBSOLETE: workaround to fix ghcup directory rights.
-      # # See https://github.com/haskell/cabal/pull/8739
-      # - name: Sudo chmod to permit ghcup to update its cache
-      #   if: runner.os == 'Linux'
-      #   run: |
-      #       sudo ls -lah /usr/local/.ghcup/cache
-      #       sudo mkdir -p /usr/local/.ghcup/cache
-      #       sudo ls -lah /usr/local/.ghcup/cache
-      #       sudo chown -R "${USER}" /usr/local/.ghcup
-      #       sudo chmod -R 777 /usr/local/.ghcup
       # SKIP installation of ghc and cabal and use the preinstalled versions.
       # - name: ghcup
       #   run: |

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -113,16 +113,32 @@ jobs:
   buildinfo:
     name: Check Field Syntax Reference
     runs-on: ubuntu-latest
+    env:
+      cabal_build: cabal build buildinfo-reference-generator
     steps:
-      - uses: actions/cache@v4
-        with:
-          path: ~/.local/state/cabal
-          key: linux-store-buildinfo-doc-diff
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v4
+      - name: Generate build plan for correct cache key
+        run: ${{ env.cabal_build }} --dry-run
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v4
+        id: cache
+        with:
+          path: ~/.local/state/cabal
+          key: linux-store-buildinfo-doc-diff-${{ hashfiles('dist-newstyle/cache/plan.json') }}
+          restore-keys: linux-store-buildinfo-doc-diff
+      - name: Build buildinfo-reference-generator
+        run: ${{ env.cabal_build }}
       - name: Are buildinfo docs up to date?
         run: make doc/buildinfo-fields-reference.rst
+      - name: Cache dependencies
+        uses: actions/cache/save@v4
+        if: always() && steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/.local/state/cabal
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
   release-project:
     name: Check Release Project
     runs-on: ubuntu-latest

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -20,24 +20,19 @@ jobs:
     runs-on: ubuntu-latest
     # This job is not run in a container, any recent GHC should be fine
     steps:
-      - name: Set PATH
-        # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
-        run: |
-          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
-          path: ~/.cabal/store
+          path: ~/.local/state/cabal
           key: linux-store-meta
       # See https://github.com/haskell/cabal/pull/8739
       - name: Sudo chmod to permit ghcup to update its cache
+        if: runner.os == 'Linux'
         run: |
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
             sudo ls -lah /usr/local/.ghcup/cache
             sudo mkdir -p /usr/local/.ghcup/cache
             sudo ls -lah /usr/local/.ghcup/cache
-            sudo chown -R $USER /usr/local/.ghcup
+            sudo chown -R "${USER}" /usr/local/.ghcup
             sudo chmod -R 777 /usr/local/.ghcup
-          fi
       - name: ghcup
         run: |
           ghcup --version
@@ -47,7 +42,8 @@ jobs:
       - name: Update Hackage index
         run: cabal v2-update
       - name: Install alex
-        run: cabal v2-install alex --constraint='alex ==3.2.7.3'
+        run: cabal v2-install alex --constraint='alex >=3.2.7.3'
+      - run: alex --version
       - uses: actions/checkout@v4
       - name: Regenerate files
         run: |
@@ -62,23 +58,19 @@ jobs:
     name: Doctest Cabal
     runs-on: ubuntu-latest
     steps:
-      - name: Set PATH
-        run: |
-          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
-          path: ~/.cabal/store
+          path: ~/.local/state/cabal
           key: linux-store-doctest
       # See https://github.com/haskell/cabal/pull/8739
       - name: Sudo chmod to permit ghcup to update its cache
+        if: runner.os == 'Linux'
         run: |
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
             sudo ls -lah /usr/local/.ghcup/cache
             sudo mkdir -p /usr/local/.ghcup/cache
             sudo ls -lah /usr/local/.ghcup/cache
-            sudo chown -R $USER /usr/local/.ghcup
+            sudo chown -R "${USER}" /usr/local/.ghcup
             sudo chmod -R 777 /usr/local/.ghcup
-          fi
       - name: ghcup
         run: |
           ghcup --version
@@ -96,23 +88,19 @@ jobs:
     name: Check Field Syntax Reference
     runs-on: ubuntu-latest
     steps:
-      - name: Set PATH
-        run: |
-          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
-          path: ~/.cabal/store
+          path: ~/.local/state/cabal
           key: linux-store-buildinfo-doc-diff
       # See https://github.com/haskell/cabal/pull/8739
       - name: Sudo chmod to permit ghcup to update its cache
+        if: runner.os == 'Linux'
         run: |
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
             sudo ls -lah /usr/local/.ghcup/cache
             sudo mkdir -p /usr/local/.ghcup/cache
             sudo ls -lah /usr/local/.ghcup/cache
-            sudo chown -R $USER /usr/local/.ghcup
+            sudo chown -R "${USER}" /usr/local/.ghcup
             sudo chmod -R 777 /usr/local/.ghcup
-          fi
       - name: ghcup
         run: |
           ghcup --version
@@ -128,9 +116,6 @@ jobs:
     name: Check Release Project
     runs-on: ubuntu-latest
     steps:
-      - name: Set PATH
-        run: |
-          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
       - name: ghcup
         run: |
           ghcup --version
@@ -144,4 +129,3 @@ jobs:
         run: cabal build all --dry-run --project-file=cabal.project.release
       - name: Check Release with Latest Hackage
         run: cabal build all --dry-run --project-file=cabal.project.release --index-state="hackage.haskell.org HEAD"
-

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -44,6 +44,10 @@ jobs:
       #     ghcup config set cache true
       #     ghcup install ghc recommended
       #     ghcup set ghc recommended
+      - name: Haskell versions
+        run: |
+          ghc --version
+          cabal --version
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v4

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -18,12 +18,15 @@ jobs:
   meta:
     name: Meta checks
     runs-on: ubuntu-latest
+    env:
+      cabal_build: >-
+        cabal build --builddir=dist-newstyle-meta --project-file=cabal.project.meta
+        gen-cabal-macros
+        gen-paths-module
+        gen-spdx
+        gen-spdx-exc
     # This job is not run in a container, any recent GHC should be fine
     steps:
-      - uses: actions/cache@v4
-        with:
-          path: ~/.local/state/cabal
-          key: linux-store-meta
       # OBSOLETE: workaround to fix ghcup directory rights.
       # # See https://github.com/haskell/cabal/pull/8739
       # - name: Sudo chmod to permit ghcup to update its cache
@@ -44,6 +47,17 @@ jobs:
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v4
+      - name: Generate build plan for correct cache key
+        run: ${{ env.cabal_build }} --dry-run
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v4
+        id: cache
+        with:
+          path: ~/.local/state/cabal
+          key: linux-store-meta-${{ hashfiles('dist-newstyle-meta/cache/plan.json') }}
+          restore-keys: linux-store-meta-
+      - name: Build tools
+        run: ${{ env.cabal_build }}
       - name: Regenerate files
         run: |
           make -B spdx
@@ -52,6 +66,13 @@ jobs:
         run: |
           git status > /dev/null
           git diff-files -p --exit-code
+      - name: Cache dependencies
+        uses: actions/cache/save@v4
+        if: always() && steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/.local/state/cabal
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
   doctest:
     name: Doctest Cabal
     runs-on: ubuntu-latest

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -43,13 +43,9 @@ jobs:
       #     ghcup set ghc recommended
       - name: Update Hackage index
         run: cabal v2-update
-      - name: Install alex
-        run: cabal v2-install alex --constraint='alex >=3.2.7.3'
-      - run: alex --version
       - uses: actions/checkout@v4
       - name: Regenerate files
         run: |
-          make -B lexer
           make -B spdx
           make -B templates
       - name: Check that diff is clean

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -24,21 +24,23 @@ jobs:
         with:
           path: ~/.local/state/cabal
           key: linux-store-meta
-      # See https://github.com/haskell/cabal/pull/8739
-      - name: Sudo chmod to permit ghcup to update its cache
-        if: runner.os == 'Linux'
-        run: |
-            sudo ls -lah /usr/local/.ghcup/cache
-            sudo mkdir -p /usr/local/.ghcup/cache
-            sudo ls -lah /usr/local/.ghcup/cache
-            sudo chown -R "${USER}" /usr/local/.ghcup
-            sudo chmod -R 777 /usr/local/.ghcup
-      - name: ghcup
-        run: |
-          ghcup --version
-          ghcup config set cache true
-          ghcup install ghc recommended
-          ghcup set ghc recommended
+      # OBSOLETE: workaround to fix ghcup directory rights.
+      # # See https://github.com/haskell/cabal/pull/8739
+      # - name: Sudo chmod to permit ghcup to update its cache
+      #   if: runner.os == 'Linux'
+      #   run: |
+      #       sudo ls -lah /usr/local/.ghcup/cache
+      #       sudo mkdir -p /usr/local/.ghcup/cache
+      #       sudo ls -lah /usr/local/.ghcup/cache
+      #       sudo chown -R "${USER}" /usr/local/.ghcup
+      #       sudo chmod -R 777 /usr/local/.ghcup
+      # SKIP installation of ghc and cabal and use the preinstalled versions.
+      # - name: ghcup
+      #   run: |
+      #     ghcup --version
+      #     ghcup config set cache true
+      #     ghcup install ghc recommended
+      #     ghcup set ghc recommended
       - name: Update Hackage index
         run: cabal v2-update
       - name: Install alex
@@ -62,21 +64,6 @@ jobs:
         with:
           path: ~/.local/state/cabal
           key: linux-store-doctest
-      # See https://github.com/haskell/cabal/pull/8739
-      - name: Sudo chmod to permit ghcup to update its cache
-        if: runner.os == 'Linux'
-        run: |
-            sudo ls -lah /usr/local/.ghcup/cache
-            sudo mkdir -p /usr/local/.ghcup/cache
-            sudo ls -lah /usr/local/.ghcup/cache
-            sudo chown -R "${USER}" /usr/local/.ghcup
-            sudo chmod -R 777 /usr/local/.ghcup
-      - name: ghcup
-        run: |
-          ghcup --version
-          ghcup config set cache true
-          ghcup install ghc --set recommended
-          ghcup install cabal --set latest
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v4
@@ -92,21 +79,6 @@ jobs:
         with:
           path: ~/.local/state/cabal
           key: linux-store-buildinfo-doc-diff
-      # See https://github.com/haskell/cabal/pull/8739
-      - name: Sudo chmod to permit ghcup to update its cache
-        if: runner.os == 'Linux'
-        run: |
-            sudo ls -lah /usr/local/.ghcup/cache
-            sudo mkdir -p /usr/local/.ghcup/cache
-            sudo ls -lah /usr/local/.ghcup/cache
-            sudo chown -R "${USER}" /usr/local/.ghcup
-            sudo chmod -R 777 /usr/local/.ghcup
-      - name: ghcup
-        run: |
-          ghcup --version
-          ghcup config set cache true
-          ghcup install ghc --set recommended
-          ghcup install cabal --set latest
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v4
@@ -116,12 +88,6 @@ jobs:
     name: Check Release Project
     runs-on: ubuntu-latest
     steps:
-      - name: ghcup
-        run: |
-          ghcup --version
-          ghcup config set cache true
-          ghcup install ghc --set recommended
-          ghcup install cabal --set latest
       - name: Update Hackage Index
         run: cabal v2-update
       - uses: actions/checkout@v4

--- a/Cabal/src/Distribution/Simple/Build/Macros/Z.hs
+++ b/Cabal/src/Distribution/Simple/Build/Macros/Z.hs
@@ -3,8 +3,8 @@
 module Distribution.Simple.Build.Macros.Z (render, Z(..), ZPackage (..), ZTool (..)) where
 import Distribution.ZinzaPrelude
 data Z
-    = Z {zPackages :: ([ZPackage]),
-         zTools :: ([ZTool]),
+    = Z {zPackages :: [ZPackage],
+         zTools :: [ZTool],
          zPackageKey :: String,
          zComponentId :: String,
          zPackageVersion :: Version,

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ style-commit: ## Run the code styler on the previous commit
 SPDX_LICENSE_HS:=Cabal-syntax/src/Distribution/SPDX/LicenseId.hs
 SPDX_EXCEPTION_HS:=Cabal-syntax/src/Distribution/SPDX/LicenseExceptionId.hs
 
+# Note: the 'spdx' goal is used in .github/workflows/quick-jobs.yml.
+# Any changes to this goal need to be reconciled with this workflow.
+#
 .PHONY: spdx
 spdx : $(SPDX_LICENSE_HS) $(SPDX_EXCEPTION_HS)
 
@@ -65,6 +68,9 @@ $(SPDX_EXCEPTION_HS) : templates/SPDX.LicenseExceptionId.template.hs cabal-dev-s
 TEMPLATE_MACROS:=Cabal/src/Distribution/Simple/Build/Macros/Z.hs
 TEMPLATE_PATHS:=Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
 
+# Note: the 'templates' goal is used in .github/workflows/quick-jobs.yml.
+# Any changes to this goal need to be reconciled with this workflow.
+#
 .PHONY: templates
 templates : $(TEMPLATE_MACROS) $(TEMPLATE_PATHS)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-.PHONY : all lexer sdpx lib exe doctest
-.PHONY : phony
+.PHONY: phony
+  # Adding dependency "phony" is like declaring a target as ".PHONY":
+  # See https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
 
 CABALBUILD := cabal build
 CABALRUN   := cabal run
@@ -13,25 +14,32 @@ DOCTEST := cabal repl --with-ghc=doctest --repl-options="-w" --ghc-options="-Wwa
 
 # default rules
 
+.PHONY: all
 all : exe lib
 
-lib : $(LEXER_HS)
+.PHONY: lib
+lib :
 	$(CABALBUILD) Cabal:libs
 
-exe : $(LEXER_HS)
+.PHONY: exe
+exe :
 	$(CABALBUILD) cabal-install:exes
 
+.PHONY: init
 init: ## Set up git hooks and ignored revisions
 	@git config core.hooksPath .githooks
 	## TODO
 
+.PHONY: style
 style: ## Run the code styler
 	@fourmolu -q -i Cabal Cabal-syntax cabal-install
 
+.PHONY: style-modified
 style-modified: ## Run the code styler on modified files
 	@git ls-files --modified Cabal Cabal-syntax cabal-install \
 		| grep '.hs$$' | xargs -P $(PROCS) -I {} fourmolu -q -i {}
 
+.PHONY: style-commit
 style-commit: ## Run the code styler on the previous commit
 	@git diff --name-only HEAD $(COMMIT) Cabal Cabal-syntax cabal-install \
 		| grep '.hs$$' | xargs -P $(PROCS) -I {} fourmolu -q -i {}
@@ -41,6 +49,7 @@ style-commit: ## Run the code styler on the previous commit
 SPDX_LICENSE_HS:=Cabal-syntax/src/Distribution/SPDX/LicenseId.hs
 SPDX_EXCEPTION_HS:=Cabal-syntax/src/Distribution/SPDX/LicenseExceptionId.hs
 
+.PHONY: spdx
 spdx : $(SPDX_LICENSE_HS) $(SPDX_EXCEPTION_HS)
 
 SPDX_LICENSE_VERSIONS:=3.0 3.2 3.6 3.9 3.10 3.16
@@ -56,7 +65,8 @@ $(SPDX_EXCEPTION_HS) : templates/SPDX.LicenseExceptionId.template.hs cabal-dev-s
 TEMPLATE_MACROS:=Cabal/src/Distribution/Simple/Build/Macros/Z.hs
 TEMPLATE_PATHS:=Cabal/src/Distribution/Simple/Build/PathsModule/Z.hs
 
-templates : phony $(TEMPLATE_MACROS) $(TEMPLATE_PATHS)
+.PHONY: templates
+templates : $(TEMPLATE_MACROS) $(TEMPLATE_PATHS)
 
 $(TEMPLATE_MACROS) : templates/cabal_macros.template.h cabal-dev-scripts/src/GenCabalMacros.hs
 	cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta gen-cabal-macros -- $< $@
@@ -75,18 +85,21 @@ doc/buildinfo-fields-reference.rst : \
 	cabal run buildinfo-reference-generator buildinfo-reference-generator/template.zinza | tee $@
 	git diff --exit-code $@
 
-# analyse-imports
-analyse-imports : phony
+.PHONY: analyse-imports
+analyse-imports :
 	find Cabal-syntax/src Cabal/src cabal-install/src -type f -name '*.hs' | xargs cabal run --builddir=dist-newstyle-meta --project-file=cabal.project.meta analyse-imports --
 
 # ghcid
 
+.PHONY: ghcid-lib
 ghcid-lib :
 	ghcid -c 'cabal repl Cabal'
 
+.PHONY: ghcid-cli
 ghcid-cli :
 	ghcid -c 'cabal repl cabal-install'
 
+.PHONY: doctest
 doctest :
 	$(DOCTEST) Cabal-syntax
 	$(DOCTEST) Cabal-described
@@ -95,32 +108,41 @@ doctest :
 	$(DOCTEST) cabal-install
 
 # This is not run as part of validate.sh (we need hackage-security, which is tricky to get).
+.PHONY: doctest-cli
 doctest-cli :
 	doctest -D__DOCTEST__ --fast cabal-install/src cabal-install-solver/src cabal-install-solver/src-assertion
 
+.PHONY: doctest-install
 doctest-install:
 	cabal install doctest --overwrite-policy=always --ignore-project
 
 # tests
 
+.PHONY: check-tests
 check-tests :
 	$(CABALRUN) check-tests -- --cwd Cabal-tests ${TEST}
 
+.PHONY: parser-tests
 parser-tests :
 	$(CABALRUN) parser-tests -- --cwd Cabal-tests ${TEST}
 
+.PHONY: parser-tests-accept
 parser-tests-accept :
 	$(CABALRUN) parser-tests -- --cwd Cabal-tests --accept ${TEST}
 
+.PHONY: custom-setup-tests
 custom-setup-tests :
 	$(CABALRUN) custom-setup-tests --
 
+.PHONY: hackage-parsec-tests
 hackage-parsec-tests :
 	$(CABALRUN) hackage-tests -- parsec +RTS -s -qg -I0 -A64M -N${THREADS} -RTS ${TEST}
 
+.PHONY: hackage-rountrip-tests
 hackage-roundtrip-tests :
 	$(CABALRUN) hackage-tests -- roundtrip +RTS -s -qg -I0 -A64M -N${THREADS} -RTS ${TEST}
 
+.PHONY: cabal-install-test
 cabal-install-test:
 	$(CABALBUILD) -j3 cabal-tests cabal
 	rm -rf .ghc.environment.*
@@ -128,6 +150,7 @@ cabal-install-test:
 
 # hackage-benchmarks (solver)
 
+.PHONY: hackage-benchmarks-run
 hackage-benchmarks-run:
 	$(CABALBUILD) -j3 hackage-benchmark cabal
 	rm -rf .ghc.environment.*
@@ -135,6 +158,7 @@ hackage-benchmarks-run:
 
 
 # This doesn't run build, as you first need to test with cabal-install-test :)
+.PHONY: cabal-install-test-accept
 cabal-install-test-accept:
 	rm -rf .ghc.environment.*
 	cd cabal-testsuite && `cabal list-bin cabal-tests` --with-cabal=`cabal list-bin cabal` --hide-successes -j3 --accept ${TEST}
@@ -145,12 +169,14 @@ cabal-install-test-accept:
 #
 #   make validate-via-docker-all -j4 -O
 #
+.PHONY: validate-via-docker-all
 validate-via-docker-all : validate-via-docker-8.2.2
 validate-via-docker-all : validate-via-docker-8.4.4
 validate-via-docker-all : validate-via-docker-8.6.5
 validate-via-docker-all : validate-via-docker-8.8.4
 validate-via-docker-all : validate-via-docker-8.10.4
 
+.PHONY: validate-dockerfiles
 validate-dockerfiles : .docker/validate-8.10.4.dockerfile
 validate-dockerfiles : .docker/validate-8.8.4.dockerfile
 validate-dockerfiles : .docker/validate-8.6.5.dockerfile
@@ -164,21 +190,27 @@ validate-dockerfiles : .docker/validate-8.2.2.dockerfile
 # and we have a test relying on this limit being sufficiently small
 DOCKERARGS:=--ulimit nofile=1024:1024
 
+.PHONY: validate-via-docker-8.2.2
 validate-via-docker-8.2.2:
 	docker build $(DOCKERARGS) -t cabal-validate:8.2.2 -f .docker/validate-8.2.2.dockerfile .
 
+.PHONY: validate-via-docker-8.4.4
 validate-via-docker-8.4.4:
 	docker build $(DOCKERARGS) -t cabal-validate:8.4.4 -f .docker/validate-8.4.4.dockerfile .
 
+.PHONY: validate-via-docker-8.6.5
 validate-via-docker-8.6.5:
 	docker build $(DOCKERARGS) -t cabal-validate:8.6.5 -f .docker/validate-8.6.5.dockerfile .
 
+.PHONY: validate-via-docker-8.8.4
 validate-via-docker-8.8.4:
 	docker build $(DOCKERARGS) -t cabal-validate:8.8.4 -f .docker/validate-8.8.4.dockerfile .
 
+.PHONY: validate-via-docker-8.10.4
 validate-via-docker-8.10.4:
 	docker build $(DOCKERARGS) -t cabal-validate:8.10.4 -f .docker/validate-8.10.4.dockerfile .
 
+.PHONY: validate-via-docker-old
 validate-via-docker-old:
 	docker build $(DOCKERARGS) -t cabal-validate:older -f .docker/validate-old.dockerfile .
 
@@ -199,6 +231,7 @@ bootstrap-json-%: phony
 
 BOOTSTRAP_GHC_VERSIONS := 8.10.7 9.0.2 9.2.7 9.4.4
 
+.PHONY: bootstrap-jsons
 bootstrap-jsons: $(BOOTSTRAP_GHC_VERSIONS:%=bootstrap-json-%)
 
 # documentation


### PR DESCRIPTION
Fix #9815:
- Cache `~/.local/state/cabal` instead of `~/.cabal/store`
- `~/.local/bin` is used instead of `~/.cabal/bin` and is already in the PATH
  (verify this by calling `alex` after installing it)

As I am passing by:
- bump cache action to v4
- double-quote `$USER` to keep actionlint happy
- move `if` from shell-level to job-level
- allow newest `alex`

UPDATE:  This PR has been extended to
- use preinstalled GHC and Cabal in this workflow (saves 90sec on each job)
- clear the remains of the `lexer` goal in the `Makefile` (was removed in #8980)
- while I am add it, use `.PHONY` systematically in `Makefile`
- fix caching for the quick-jobs
  * Use key from the build plan where possible
  * Use daily key for the doctest job
- update a generated file to make "Meta checks" pass
