### PR TITLE
CI changelogs: switch to XDG, fix cache key

### DIFF
--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -1,4 +1,4 @@
-name: Assorted
+name: Changelogs
 
 on:
   push:
@@ -25,43 +25,48 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set PATH
-        # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
-        run: |
-          echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cabal/store
-          key: linux-store-changelogs
-      # See https://github.com/haskell/cabal/pull/8739
-      - name: Sudo chmod to permit ghcup to update its cache
-        run: |
-          if [[ "${{ runner.os }}" == "Linux" ]]; then
-            sudo mkdir -p /usr/local/.ghcup/cache
-            sudo chown -R $USER /usr/local/.ghcup
-            sudo chmod -R 777 /usr/local/.ghcup
-          fi
-      - name: ghcup
-        run: |
-          ghcup config set cache true
-          ghcup install ghc recommended
-          ghcup set ghc recommended
-      - name: Update Hackage index
-        run: cabal v2-update
-      # Cannot install it directly from remote tarball due to
+
+      # Cannot install changelog-d directly from remote tarball due to
       # https://github.com/haskell/cabal/issues/7360
+      # Also, we would like to get the build plan for the cache key.
       - name: Fetch changelog-d
         run: |
           changelog_d_latest="$(curl https://codeberg.org/api/v1/repos/fgaz/changelog-d/branches/master | jq -r .commit.id)"
           echo "Using changelog-d revision $changelog_d_latest"
           curl "https://codeberg.org/fgaz/changelog-d/archive/$changelog_d_latest.tar.gz" -o changelog-d.tar.gz
           tar -xf changelog-d.tar.gz
-      - name: Install changelog-d
+
+      - name: Update Hackage index
+        run: cabal v2-update
+
+      - name: Build plan for changelog-d
+        working-directory: changelog-d
         run: |
-          pushd changelog-d
-          cabal v2-install
-          popd
-      - uses: actions/checkout@v4
+          cabal v2-build --dry-run --allow-newer=changelog-d:base
+
+      - name: Restore dependencies of changelog-d
+        uses: actions/cache/restore@v4
+        id: cache
+        with:
+          path: ~/.local/state/cabal
+          key: linux-store-changelogs-${{ hashfiles('changelog-d/dist-newstyle/cache/plan.json') }}
+          restore-keys: linux-store-changelogs
+
+      - name: Install changelog-d
+        working-directory: changelog-d
+        run: |
+          cabal v2-install --allow-newer=changelog-d:base
+
+      - name: Cache dependencies of changelog-d
+        uses: actions/cache/save@v4
+        if: always() && steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ~/.local/state/cabal
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Checkout cabal sources
+        uses: actions/checkout@v4
+
       - name: Run changelog-d
         run: |
           changelog-d changelog.d


### PR DESCRIPTION
This is the same as #9845 but for the changelogs.yml workflow.
