### PR TITLE
Remove unused packages

### DIFF
--- a/Cabal-described/Cabal-described.cabal
+++ b/Cabal-described/Cabal-described.cabal
@@ -19,7 +19,6 @@ library
     , rere              >=0.1 && <0.3
     , tasty
     , tasty-quickcheck
-    , transformers
 
   exposed-modules:
     Distribution.Described

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -59,7 +59,9 @@ library
   if impl(ghc >= 8.0) && impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
-  if impl(ghc >= 8.10)
+  -- Warning: even though introduced with GHC 8.10, -Wunused-packages gives
+  -- false positives with GHC 8.10.
+  if impl(ghc >= 9)
     ghc-options: -Wunused-packages
 
   build-tool-depends: alex:alex

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -59,11 +59,6 @@ library
   if impl(ghc >= 8.0) && impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
-  -- Warning: even though introduced with GHC 8.10, -Wunused-packages gives
-  -- false positives with GHC 8.10.
-  if impl(ghc >= 9)
-    ghc-options: -Wunused-packages
-
   build-tool-depends: alex:alex
 
   exposed-modules:

--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -57,31 +57,23 @@ test-suite unit-tests
   main-is:          UnitTests.hs
   build-depends:
       array
-    , async               >=2.2.2 && <2.3
     , base                >=4.9     && <5
-    , binary
     , bytestring
     , Cabal
     , Cabal-described
     , Cabal-syntax
     , Cabal-QuickCheck
-    , Cabal-tests
     , containers
-    , deepseq
     , Diff                >=0.4   && <0.6
     , directory
     , filepath
-    , integer-logarithms  >=1.0.2 && <1.1
     , pretty
     , QuickCheck          >=2.14  && <2.15
-    , rere                >=0.1   && <0.3
-    , tagged
     , tasty               >=1.2.3 && <1.6
     , tasty-hunit
     , tasty-quickcheck
     , temporary
     , text
-    , transformers
 
   ghc-options:      -Wall
   default-language: Haskell2010
@@ -102,7 +94,6 @@ test-suite parser-tests
     , tasty             >=1.2.3   && <1.6
     , tasty-golden      >=2.3.1.1 && <2.4
     , tasty-hunit
-    , tasty-quickcheck
     , tree-diff         >=0.1     && <0.4
 
   ghc-options:      -Wall
@@ -121,7 +112,6 @@ test-suite check-tests
     , directory
     , filepath
     , tasty         >=1.2.3   && <1.6
-    , tasty-expected-failure
     , tasty-golden  >=2.3.1.1 && <2.4
 
   ghc-options:      -Wall
@@ -157,7 +147,6 @@ test-suite hackage-tests
     , Cabal
     , Cabal-syntax
     , Cabal-tree-diff
-    , containers
     , deepseq
     , directory
     , filepath
@@ -167,7 +156,6 @@ test-suite hackage-tests
     , base-orphans          >=0.6      && <0.10
     , clock                 >=0.8      && <0.9
     , optparse-applicative  >=0.13.2.0 && <0.19
-    , stm                   >=2.4.5.0  && <2.6
     , tar                   >=0.5.0.3  && <0.7
     , tree-diff             >=0.1      && <0.4
 

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -65,7 +65,9 @@ library
   if impl(ghc >= 8.0) && impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
-  if impl(ghc >= 8.10)
+  -- Warning: even though introduced with GHC 8.10, -Wunused-packages gives
+  -- false positives with GHC 8.10.
+  if impl(ghc >= 9)
     ghc-options: -Wunused-packages
 
   exposed-modules:

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -65,11 +65,6 @@ library
   if impl(ghc >= 8.0) && impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
-  -- Warning: even though introduced with GHC 8.10, -Wunused-packages gives
-  -- false positives with GHC 8.10.
-  if impl(ghc >= 9)
-    ghc-options: -Wunused-packages
-
   exposed-modules:
     Distribution.Backpack.Configure
     Distribution.Backpack.ComponentsGraph

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -40,10 +40,12 @@ library
     -Wall -Wcompat -Wnoncanonical-monad-instances
     -fwarn-tabs -fwarn-incomplete-uni-patterns
 
-  if impl(ghc <8.8)
+  if impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
-  if impl(ghc >=8.10)
+  -- Warning: even though introduced with GHC 8.10, -Wunused-packages gives
+  -- false positives with GHC 8.10.
+  if impl(ghc >= 9)
     ghc-options: -Wunused-packages
 
   exposed-modules:

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -43,11 +43,6 @@ library
   if impl(ghc < 8.8)
     ghc-options: -Wnoncanonical-monadfail-instances
 
-  -- Warning: even though introduced with GHC 8.10, -Wunused-packages gives
-  -- false positives with GHC 8.10.
-  if impl(ghc >= 9)
-    ghc-options: -Wunused-packages
-
   exposed-modules:
     Distribution.Client.Utils.Assertion
 

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -135,7 +135,6 @@ Test-Suite unit-tests
 
    build-depends:
      , base        >= 4.10  && <4.20
-     , Cabal
      , Cabal-syntax
      , cabal-install-solver
      , tasty       >= 1.2.3 && <1.6

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -51,9 +51,9 @@ common warnings
     if impl(ghc < 8.8)
       ghc-options: -Wnoncanonical-monadfail-instances
 
-    if impl(ghc >=9.0)
-      -- Warning: even though introduced with GHC 8.10, -Wunused-packages
-      -- gives false positives with GHC 8.10.
+    -- Warning: even though introduced with GHC 8.10, -Wunused-packages gives
+    -- false positives with GHC 8.10.
+    if impl(ghc >= 9)
       ghc-options: -Wunused-packages
 
 common base-dep

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -51,11 +51,6 @@ common warnings
     if impl(ghc < 8.8)
       ghc-options: -Wnoncanonical-monadfail-instances
 
-    -- Warning: even though introduced with GHC 8.10, -Wunused-packages gives
-    -- false positives with GHC 8.10.
-    if impl(ghc >= 9)
-      ghc-options: -Wunused-packages
-
 common base-dep
     build-depends: base >=4.10 && <4.20
 

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -29,8 +29,6 @@ common shared
     , base >= 4.9 && <4.20
     -- this needs to match the in-tree lib:Cabal version
     , Cabal ^>= 3.11.0.0
-    , Cabal-syntax ^>= 3.11.0.0
-    , Cabal-tests
 
   ghc-options:
     -Wall
@@ -62,9 +60,9 @@ library
     Test.Cabal.ScriptEnv0
 
   build-depends:
+    , Cabal-tests
     , aeson                 ^>= 1.4.2.0 || ^>=1.5.0.0 || ^>= 2.0.0.0 || ^>= 2.1.0.0 || ^>= 2.2.1.0
     , async                 ^>= 2.2.1
-    , attoparsec            ^>= 0.13.2.2 || ^>=0.14.1
     , base16-bytestring     ^>= 0.1.1.5 || ^>= 1.0
     , bytestring            ^>= 0.10.0.2 || ^>= 0.11.0.0 || ^>= 0.12.0.0
     , containers            ^>= 0.5.0.0 || ^>= 0.6.0.1 || ^>= 0.7
@@ -79,7 +77,6 @@ library
     , regex-tdfa            ^>= 1.2.3.1 || ^>=1.3.1.0
     , retry                 ^>= 0.9.1.0
     , array                 ^>= 0.4.0.1 || ^>= 0.5.0.0
-    , temporary             ^>= 1.3
     , text                  ^>= 1.2.3.1 || ^>= 2.0.1   || ^>= 2.1
     , transformers          ^>= 0.3.0.0 || ^>= 0.4.2.0 || ^>= 0.5.2.0 || ^>= 0.6.0.2
 
@@ -101,11 +98,9 @@ executable cabal-tests
     , cabal-testsuite
     -- constraints inherited via lib:cabal-testsuite component
     , async
-    , exceptions
     , filepath
     , optparse-applicative
     , process
-    , transformers
     -- dependencies specific to exe:cabal-tests
     , clock                 ^>= 0.7.2 || ^>=0.8
     , directory
@@ -127,23 +122,24 @@ executable setup
 -- If you require an external dependency for a test it must be listed here.
 executable test-runtime-deps
   default-language: Haskell2010
-  build-depends: cabal-testsuite,
-                 base,
-                 directory,
-                 Cabal,
-                 Cabal-syntax,
-                 filepath,
-                 transformers,
-                 bytestring,
-                 time,
-                 process,
-                 exceptions
+  -- Apart from base that is a compile-time dependency, the rest are runtime dependencies
+  build-depends:
+    , Cabal
+    , Cabal-syntax
+    , base
+    , bytestring
+    , cabal-testsuite
+    , directory
+    , exceptions
+    , filepath
+    , process
+    , time
+    , transformers
   main-is: static/Main.hs
   if !os(windows)
     build-depends: unix
   else
-    build-depends:
-      , Win32
+    build-depends: Win32
 
 custom-setup
   -- we only depend on even stable releases of lib:Cabal

--- a/project-cabal/ghc-options.config
+++ b/project-cabal/ghc-options.config
@@ -3,7 +3,9 @@ program-options
     -fno-ignore-asserts
     -Werror
 
-if impl(ghc >= 8.10)
+-- Warning: even though introduced with GHC 8.10, -Wunused-packages gives false
+-- positives with GHC 8.10.
+if impl(ghc >= 9)
   program-options
     ghc-options: -Wunused-packages
   package cabal-testsuite

--- a/project-cabal/ghc-options.config
+++ b/project-cabal/ghc-options.config
@@ -1,2 +1,5 @@
 program-options
   ghc-options: -fno-ignore-asserts -Werror -Wunused-packages
+
+package cabal-testsuite
+  ghc-options: -Wwarn=unused-packages

--- a/project-cabal/ghc-options.config
+++ b/project-cabal/ghc-options.config
@@ -1,5 +1,10 @@
 program-options
-  ghc-options: -fno-ignore-asserts -Werror -Wunused-packages
+  ghc-options:
+    -fno-ignore-asserts
+    -Werror
 
-package cabal-testsuite
-  ghc-options: -Wwarn=unused-packages
+if impl(ghc >= 8.10)
+  program-options
+    ghc-options: -Wunused-packages
+  package cabal-testsuite
+    ghc-options: -Wwarn=unused-packages

--- a/project-cabal/ghc-options.config
+++ b/project-cabal/ghc-options.config
@@ -1,2 +1,2 @@
 program-options
-  ghc-options: -fno-ignore-asserts -Werror
+  ghc-options: -fno-ignore-asserts -Werror -Wunused-packages


### PR DESCRIPTION
Fixes #9853. I am a bit frustrated that I've not been able fix or suppress the `-Werror=unused-package` with `cabal-testsuite` except with the following setting in `project-cabal/ghc-options.config`;

```cabal
package cabal-testsuite
  ghc-options: -Wwarn=unused-packages
```

I tried adding similar `ghc-options` to `cabal-testsuite:test:test-runtime-deps` (the intentional source of unused package dependencies) but suppose project settings override package settings.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

