### PR TITLE
CI validate-old-ghcs: pin to haskell-actions/setup@v2.6

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -258,7 +258,9 @@ jobs:
           apt-get update
           apt-get install -y ghc-${{ matrix.extra-ghc }}-dyn
 
-      - uses: haskell-actions/setup@v2
+      - uses: haskell-actions/setup@v2.6
+          # From 2.7 the setup action uses node20,
+          # which is not supported by the phadej/ghc:8.8.4-xenial container.
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
This provides temporary life support to the `validate-old-ghcs` action
until node16 will be finally axed by GHA in May 2024.

Workaround for:
- https://github.com/haskell/cabal/issues/9858
