### PR TITLE
wip: feature: pass ParStrat to build extra sources

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC/Build.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build.hs
@@ -136,5 +136,5 @@ build numJobs pkg_descr pbci = do
   -- after Haskell modules, because C sources may depend on stub headers
   -- generated from compiling Haskell modules (#842, #3294).
   buildOpts <- buildHaskellModules numJobs ghcProg pkg_descr buildTargetDir_absolute wantedWays pbci
-  extraSources <- buildAllExtraSources ghcProg buildTargetDir pbci
+  extraSources <- buildAllExtraSources numJobs ghcProg buildTargetDir pbci
   linkOrLoadComponent ghcProg pkg_descr (fromNubListR extraSources) (buildTargetDir, targetDir_absolute) (wantedWays, buildOpts) pbci

--- a/Cabal/src/Distribution/Simple/GHC/Build/ExtraSources.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/ExtraSources.hs
@@ -4,7 +4,7 @@
 
 module Distribution.Simple.GHC.Build.ExtraSources where
 
-import Control.Monad
+import Control.Monad ( when, forM )
 import Data.Foldable
 import Distribution.Simple.Flag
 import qualified Distribution.Simple.GHC.Internal as Internal
@@ -14,6 +14,7 @@ import Distribution.Utils.NubList
 
 import Distribution.Types.BuildInfo
 import Distribution.Types.Component
+import Distribution.Types.ParStrat
 import Distribution.Types.TargetInfo
 
 import Distribution.Simple.GHC.Build.Utils
@@ -29,7 +30,8 @@ import Distribution.Simple.Build.Inputs
 -- | An action that builds all the extra build sources of a component, i.e. C,
 -- C++, Js, Asm, C-- sources.
 buildAllExtraSources
-  :: ConfiguredProgram
+  :: Flag ParStrat
+  -> ConfiguredProgram
   -- ^ The GHC configured program
   -> FilePath
   -- ^ The build directory for this target
@@ -51,7 +53,8 @@ buildCSources
   , buildJsSources
   , buildAsmSources
   , buildCmmSources
-    :: ConfiguredProgram
+    :: Flag ParStrat
+    -> ConfiguredProgram
     -- ^ The GHC configured program
     -> FilePath
     -- ^ The build directory for this target
@@ -81,7 +84,7 @@ buildCxxSources =
             CExe exe | isCxx (modulePath exe) -> [modulePath exe]
             _otherwise -> []
     )
-buildJsSources ghcProg buildTargetDir = do
+buildJsSources parStrat ghcProg buildTargetDir = do
   Platform hostArch _ <- hostPlatform <$> localBuildInfo
   let hasJsSupport = hostArch == JavaScript
   buildExtraSources
@@ -97,6 +100,7 @@ buildJsSources ghcProg buildTargetDir = do
             jsSources (componentBuildInfo c)
           else mempty
     )
+    parStrat
     ghcProg
     buildTargetDir
 buildAsmSources =
@@ -118,7 +122,7 @@ buildCmmSources =
 buildExtraSources
   :: String
   -- ^ String describing the extra sources being built, for printing.
-  -> (Verbosity -> LocalBuildInfo -> BuildInfo -> ComponentLocalBuildInfo -> FilePath -> FilePath -> GhcOptions)
+  -> (Verbosity -> LocalBuildInfo -> BuildInfo -> ComponentLocalBuildInfo -> FilePath -> GhcOptions)
   -- ^ Function to determine the @'GhcOptions'@ for the
   -- invocation of GHC when compiling these extra sources (e.g.
   -- @'Internal.componentCxxGhcOptions'@,
@@ -133,6 +137,7 @@ buildExtraSources
   -- @'Executable'@ components might additionally add the
   -- program entry point (@main-is@ file) to the extra sources,
   -- if it should be compiled as the rest of them.
+  -> Flag ParStrat
   -> ConfiguredProgram
   -- ^ The GHC configured program
   -> FilePath
@@ -141,7 +146,7 @@ buildExtraSources
   -- ^ The context and component being built in it.
   -> IO (NubListR FilePath)
   -- ^ Returns the list of extra sources that were built
-buildExtraSources description componentSourceGhcOptions wantDyn viewSources ghcProg buildTargetDir =
+buildExtraSources description componentSourceGhcOptions wantDyn viewSources parStrat ghcProg buildTargetDir =
   \PreBuildComponentInputs{buildingWhat, localBuildInfo = lbi, targetInfo} ->
     let
       bi = componentBuildInfo (targetComponent targetInfo)
@@ -159,9 +164,9 @@ buildExtraSources description componentSourceGhcOptions wantDyn viewSources ghcP
       isGhcDynamic = isDynamic comp
       doingTH = usesTemplateHaskellOrQQ bi
       forceSharedLib = doingTH && isGhcDynamic
-      runGhcProg = runGHC verbosity ghcProg comp platform
+      runGhcProg = runGHC verbosity ghcProg  comp platform
 
-      buildAction sourceFile = do
+      buildAction sourceFiles = do
         let baseSrcOpts =
               componentSourceGhcOptions
                 verbosity
@@ -169,12 +174,17 @@ buildExtraSources description componentSourceGhcOptions wantDyn viewSources ghcP
                 bi
                 clbi
                 buildTargetDir
-                sourceFile
+            parSrcOpts = baseSrcOpts
+                `mappend` mempty
+                  { ghcOptNumJobs = parStrat
+                  -- ^ note that because we don't use `--make` to build extra
+                  -- sources, the only option that adds parallelism is -jsem
+                  }
             vanillaSrcOpts
               -- Dynamic GHC requires C sources to be built
               -- with -fPIC for REPL to work. See #2207.
-              | isGhcDynamic && wantDyn = baseSrcOpts{ghcOptFPic = toFlag True}
-              | otherwise = baseSrcOpts
+              | isGhcDynamic && wantDyn = parSrcOpts `mappend` mempty {ghcOptFPic = toFlag True}
+              | otherwise = parSrcOpts
             profSrcOpts =
               vanillaSrcOpts
                 `mappend` mempty
@@ -191,52 +201,53 @@ buildExtraSources description componentSourceGhcOptions wantDyn viewSources ghcP
             --       consider this a user error. However, we should strive to
             --       add a warning if this occurs.
             odir = fromFlag (ghcOptObjDir vanillaSrcOpts)
-            compileIfNeeded opts = do
-              needsRecomp <- checkNeedsRecompilation sourceFile opts
-              when needsRecomp $ runGhcProg opts
 
         -- TODO: This whole section can be streamlined to the
         -- wantedWays+neededWays logic used in Build/Modules.hs
         createDirectoryIfMissingVerbose verbosity True odir
-        case targetComponent targetInfo of
-          -- For libraries, we compile extra objects in the three ways: vanilla, shared, and profiled.
-          -- We suffix shared objects with .dyn_o and profiled ones with .p_o.
-          CLib _lib
-            -- Unless for repl, in which case we only need the vanilla way
-            | BuildRepl _ <- buildingWhat ->
-                compileIfNeeded vanillaSrcOpts
-            | otherwise ->
-                do
-                  compileIfNeeded vanillaSrcOpts
-                  when (wantDyn && (forceSharedLib || withSharedLib lbi)) $
-                    compileIfNeeded sharedSrcOpts{ghcOptObjSuffix = toFlag "dyn_o"}
-                  when (withProfLib lbi) $
-                    compileIfNeeded profSrcOpts{ghcOptObjSuffix = toFlag "p_o"}
+        let allOpts =
+              case targetComponent targetInfo of
+                -- For libraries, we compile extra objects in the three ways: vanilla, shared, and profiled.
+                -- We suffix shared objects with .dyn_o and profiled ones with .p_o.
+                CLib _lib
+                  -- Unless for repl, in which case we only need the vanilla way
+                  | BuildRepl _ <- buildingWhat ->
+                      [vanillaSrcOpts]
+                  | otherwise ->
+                      [vanillaSrcOpts]
+                      ++ [sharedSrcOpts{ghcOptObjSuffix = toFlag "dyn_o"} | wantDyn && (forceSharedLib || withSharedLib lbi)]
+                      ++ [profSrcOpts{ghcOptObjSuffix = toFlag "p_o"} | withProfLib lbi]
 
-          -- For foreign libraries, we determine with which options to build the
-          -- objects (vanilla vs shared vs profiled)
-          CFLib flib
-            | withProfExe lbi -> -- It doesn't sound right to query "ProfExe" for a foreign library...
-                compileIfNeeded profSrcOpts
-            | withDynFLib flib && wantDyn ->
-                compileIfNeeded sharedSrcOpts
-            | otherwise ->
-                compileIfNeeded vanillaSrcOpts
-          -- For the remaining component types (Exec, Test, Bench), we also
-          -- determine with which options to build the objects (vanilla vs shared vs
-          -- profiled), but predicate is the same for the three kinds.
-          _exeLike
-            | withProfExe lbi ->
-                compileIfNeeded profSrcOpts
-            | withDynExe lbi && wantDyn ->
-                compileIfNeeded sharedSrcOpts
-            | otherwise ->
-                compileIfNeeded vanillaSrcOpts
+                -- For foreign libraries, we determine with which options to build the
+                -- objects (vanilla vs shared vs profiled)
+                CFLib flib
+                  | withProfExe lbi -> -- It doesn't sound right to query "ProfExe" for a foreign library...
+                      [profSrcOpts]
+                  | withDynFLib flib && wantDyn ->
+                      [sharedSrcOpts]
+                  | otherwise ->
+                      [vanillaSrcOpts]
+                -- For the remaining component types (Exec, Test, Bench), we also
+                -- determine with which options to build the objects (vanilla vs shared vs
+                -- profiled), but predicate is the same for the three kinds.
+                _exeLike
+                  | withProfExe lbi ->
+                      [profSrcOpts]
+                  | withDynExe lbi && wantDyn ->
+                      [sharedSrcOpts]
+                  | otherwise ->
+                      [vanillaSrcOpts]
+        forM_ allOpts $ \opts -> do
+          files <- fmap concat $ forM sourceFiles $ \sourceFile -> do
+            needsRecomp <- checkNeedsRecompilation sourceFile opts
+            return [sourceFile | needsRecomp]
+          when (not (null files)) $
+            runGhcProg opts { ghcOptInputFiles = toNubListR files }
      in
       -- build any sources
       if (null sources || componentIsIndefinite clbi)
         then return mempty
         else do
           info verbosity ("Building " ++ description ++ "...")
-          traverse_ buildAction sources
+          buildAction sources
           return (toNubListR sources)

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -344,15 +344,13 @@ componentCcGhcOptions
   -> BuildInfo
   -> ComponentLocalBuildInfo
   -> FilePath
-  -> FilePath
   -> GhcOptions
-componentCcGhcOptions verbosity lbi bi clbi odir filename =
+componentCcGhcOptions verbosity lbi bi clbi odir =
   mempty
     { -- Respect -v0, but don't crank up verbosity on GHC if
       -- Cabal verbosity is requested. For that, use --ghc-option=-v instead!
       ghcOptVerbosity = toFlag (min verbosity normal)
     , ghcOptMode = toFlag GhcModeCompile
-    , ghcOptInputFiles = toNubListR [filename]
     , ghcOptCppIncludePath =
         toNubListR $
           [ autogenComponentModulesDir lbi clbi
@@ -393,15 +391,13 @@ componentCxxGhcOptions
   -> BuildInfo
   -> ComponentLocalBuildInfo
   -> FilePath
-  -> FilePath
   -> GhcOptions
-componentCxxGhcOptions verbosity lbi bi clbi odir filename =
+componentCxxGhcOptions verbosity lbi bi clbi odir =
   mempty
     { -- Respect -v0, but don't crank up verbosity on GHC if
       -- Cabal verbosity is requested. For that, use --ghc-option=-v instead!
       ghcOptVerbosity = toFlag (min verbosity normal)
     , ghcOptMode = toFlag GhcModeCompile
-    , ghcOptInputFiles = toNubListR [filename]
     , ghcOptCppIncludePath =
         toNubListR $
           [ autogenComponentModulesDir lbi clbi
@@ -442,15 +438,13 @@ componentAsmGhcOptions
   -> BuildInfo
   -> ComponentLocalBuildInfo
   -> FilePath
-  -> FilePath
   -> GhcOptions
-componentAsmGhcOptions verbosity lbi bi clbi odir filename =
+componentAsmGhcOptions verbosity lbi bi clbi odir =
   mempty
     { -- Respect -v0, but don't crank up verbosity on GHC if
       -- Cabal verbosity is requested. For that, use --ghc-option=-v instead!
       ghcOptVerbosity = toFlag (min verbosity normal)
     , ghcOptMode = toFlag GhcModeCompile
-    , ghcOptInputFiles = toNubListR [filename]
     , ghcOptCppIncludePath =
         toNubListR $
           [ autogenComponentModulesDir lbi clbi
@@ -486,15 +480,13 @@ componentJsGhcOptions
   -> BuildInfo
   -> ComponentLocalBuildInfo
   -> FilePath
-  -> FilePath
   -> GhcOptions
-componentJsGhcOptions verbosity lbi bi clbi odir filename =
+componentJsGhcOptions verbosity lbi bi clbi odir =
   mempty
     { -- Respect -v0, but don't crank up verbosity on GHC if
       -- Cabal verbosity is requested. For that, use --ghc-option=-v instead!
       ghcOptVerbosity = toFlag (min verbosity normal)
     , ghcOptMode = toFlag GhcModeCompile
-    , ghcOptInputFiles = toNubListR [filename]
     , ghcOptCppIncludePath =
         toNubListR $
           [ autogenComponentModulesDir lbi clbi
@@ -614,15 +606,13 @@ componentCmmGhcOptions
   -> BuildInfo
   -> ComponentLocalBuildInfo
   -> FilePath
-  -> FilePath
   -> GhcOptions
-componentCmmGhcOptions verbosity lbi bi clbi odir filename =
+componentCmmGhcOptions verbosity lbi bi clbi odir =
   mempty
     { -- Respect -v0, but don't crank up verbosity on GHC if
       -- Cabal verbosity is requested. For that, use --ghc-option=-v instead!
       ghcOptVerbosity = toFlag (min verbosity normal)
     , ghcOptMode = toFlag GhcModeCompile
-    , ghcOptInputFiles = toNubListR [filename]
     , ghcOptCppIncludePath =
         toNubListR $
           [ autogenComponentModulesDir lbi clbi

--- a/Cabal/src/Distribution/Simple/GHCJS.hs
+++ b/Cabal/src/Distribution/Simple/GHCJS.hs
@@ -1422,7 +1422,6 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
                 bnfo
                 clbi
                 tmpDir
-                filename
             vanillaCxxOpts =
               if isGhcDynamic
                 then -- Dynamic GHC requires C++ sources to be built
@@ -1452,7 +1451,7 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
         createDirectoryIfMissingVerbose verbosity True odir
         needsRecomp <- checkNeedsRecompilation filename opts
         when needsRecomp $
-          runGhcProg opts
+          runGhcProg opts { ghcOptInputFiles = toNubListR [filename] }
       | filename <- cxxSrcs
       ]
 
@@ -1468,7 +1467,6 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
                 bnfo
                 clbi
                 tmpDir
-                filename
             vanillaCcOpts =
               if isGhcDynamic
                 then -- Dynamic GHC requires C sources to be built
@@ -1494,7 +1492,7 @@ gbuild verbosity numJobs pkg_descr lbi bm clbi = do
         createDirectoryIfMissingVerbose verbosity True odir
         needsRecomp <- checkNeedsRecompilation filename opts
         when needsRecomp $
-          runGhcProg opts
+          runGhcProg opts { ghcOptInputFiles = toNubListR [filename] }
       | filename <- cSrcs
       ]
 


### PR DESCRIPTION
Pass `ParStrat` to GHC when we build extra sources, and batch up file paths into GHC invocations, so that GHC can build them in parallel.

This doesn't actually make GHC build these sources in parallel right now, because GHC in one-shot mode doesn't even listen to `-j`, though it doesn't cause an error or anything. But it hopefully will soon! https://gitlab.haskell.org/ghc/ghc/-/merge_requests/12388

An alternative would be to make GHC's `--make` understand that it has to build foreign sources after Haskell modules. I didn't investigate that possibility too thoroughly.

## QA Notes

GHC invocations when building projects with foreign sources should have a) all of those sources in a single GHC invocation and b) `-jsem` if `--semaphore` was passed to cabal.

**Template Α: This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
