### PR TITLE
add squash+merge for backports

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -71,6 +71,21 @@ pull_request_rules:
       - body~=backport
       - '#approved-reviews-by>=1'
 
+  # merge+squash strategy for backports: require 1 approver instead of 2
+  - actions:
+      queue:
+        name: default
+        method: squash
+        # both update methods get absorbed by the squash, so we use the most
+        # reliable
+        update_method: merge
+    name: Put backports in the squash+merge queue
+    conditions:
+      - label=squash+merge me
+      - base!=master
+      - body~=backport
+      - '#approved-reviews-by>=1'
+
   # backports should be labeled as such
   - actions:
       label:


### PR DESCRIPTION
Made by copying things from the master squash+merge into a copy of the backport strategy. I'm a neophyte at Mergify, so someone should check this.

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

Testing notes:
* since this affects only CI of backports, there's no way to test on `master`
* I disrecommend testing on actual release branches. I suspect we need to create a test branch to "backport" things to.