### PR TITLE
Explicit export lists for Main

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/Defaults.hs
+++ b/cabal-install/src/Distribution/Client/Init/Defaults.hs
@@ -165,7 +165,7 @@ myLibHs =
 
 myExeHs :: [String]
 myExeHs =
-  [ "module Main where"
+  [ "module Main (main) where"
   , ""
   , "main :: IO ()"
   , "main = putStrLn \"Hello, Haskell!\""
@@ -173,7 +173,7 @@ myExeHs =
 
 myLibExeHs :: [String]
 myLibExeHs =
-  [ "module Main where"
+  [ "module Main (main) where"
   , ""
   , "import qualified MyLib (someFunc)"
   , ""

--- a/changelog.d/pr-9890
+++ b/changelog.d/pr-9890
@@ -1,0 +1,10 @@
+synopsis: `cabal init` generates explicit export lists for Main
+packages: cabal-install
+prs: #9890
+issues: #9889
+
+description: {
+
+- Lack of explicit export list can degrade performance. The `Main` module in particular should always have an explicit export list that contains just the main function. Then, the compiler can do more aggressive optimizations on all the other non-exported functions.
+
+}


### PR DESCRIPTION
Lack of explicit export list can degrade performance. The Main module in particular should always have an explicit export list that contains just the main function.

Fixes #9889 

---

**Template Α: This PR modifies `cabal` behaviour**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
