### PR TITLE
Add support for building profiled dynamic way

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/BuildInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/BuildInfo.hs
@@ -12,6 +12,7 @@ module Distribution.Types.BuildInfo
   , hcOptions
   , hcProfOptions
   , hcSharedOptions
+  , hcProfSharedOptions
   , hcStaticOptions
   ) where
 
@@ -133,6 +134,7 @@ data BuildInfo = BuildInfo
   , options :: PerCompilerFlavor [String]
   , profOptions :: PerCompilerFlavor [String]
   , sharedOptions :: PerCompilerFlavor [String]
+  , profSharedOptions :: PerCompilerFlavor [String]
   , staticOptions :: PerCompilerFlavor [String]
   , customFieldsBI :: [(String, String)]
   -- ^ Custom fields starting
@@ -193,6 +195,7 @@ instance Monoid BuildInfo where
       , options = mempty
       , profOptions = mempty
       , sharedOptions = mempty
+      , profSharedOptions = mempty
       , staticOptions = mempty
       , customFieldsBI = []
       , targetBuildDepends = []
@@ -245,6 +248,7 @@ instance Semigroup BuildInfo where
       , options = combine options
       , profOptions = combine profOptions
       , sharedOptions = combine sharedOptions
+      , profSharedOptions = combine profSharedOptions
       , staticOptions = combine staticOptions
       , customFieldsBI = combine customFieldsBI
       , targetBuildDepends = combineNub targetBuildDepends
@@ -294,6 +298,9 @@ hcProfOptions = lookupHcOptions profOptions
 
 hcSharedOptions :: CompilerFlavor -> BuildInfo -> [String]
 hcSharedOptions = lookupHcOptions sharedOptions
+
+hcProfSharedOptions :: CompilerFlavor -> BuildInfo -> [String]
+hcProfSharedOptions = lookupHcOptions profSharedOptions
 
 hcStaticOptions :: CompilerFlavor -> BuildInfo -> [String]
 hcStaticOptions = lookupHcOptions staticOptions

--- a/Cabal-syntax/src/Distribution/Types/BuildInfo/Lens.hs
+++ b/Cabal-syntax/src/Distribution/Types/BuildInfo/Lens.hs
@@ -195,6 +195,10 @@ class HasBuildInfo a where
   sharedOptions = buildInfo . sharedOptions
   {-# INLINE sharedOptions #-}
 
+  profSharedOptions :: Lens' a (PerCompilerFlavor [String])
+  profSharedOptions = buildInfo . profSharedOptions
+  {-# INLINE profSharedOptions #-}
+
   staticOptions :: Lens' a (PerCompilerFlavor [String])
   staticOptions = buildInfo . staticOptions
   {-# INLINE staticOptions #-}
@@ -340,6 +344,9 @@ instance HasBuildInfo BuildInfo where
 
   sharedOptions f s = fmap (\x -> s{T.sharedOptions = x}) (f (T.sharedOptions s))
   {-# INLINE sharedOptions #-}
+
+  profSharedOptions f s = fmap (\x -> s{T.profSharedOptions = x}) (f (T.profSharedOptions s))
+  {-# INLINE profSharedOptions #-}
 
   staticOptions f s = fmap (\x -> s{T.staticOptions = x}) (f (T.staticOptions s))
   {-# INLINE staticOptions #-}

--- a/Cabal-tests/tests/ParserTests/regressions/Octree-0.5.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/Octree-0.5.expr
@@ -132,6 +132,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -238,6 +240,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],
@@ -338,6 +342,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/anynone.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/anynone.expr
@@ -95,6 +95,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/big-version.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/big-version.expr
@@ -96,6 +96,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/common-conditional.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/common-conditional.expr
@@ -112,6 +112,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -186,6 +188,8 @@ GenericPackageDescription {
                   []
                   [],
                 sharedOptions =
+                PerCompilerFlavor [] [],
+                profSharedOptions =
                 PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
@@ -278,6 +282,8 @@ GenericPackageDescription {
                         [],
                       sharedOptions =
                       PerCompilerFlavor [] [],
+                      profSharedOptions =
+                      PerCompilerFlavor [] [],
                       staticOptions =
                       PerCompilerFlavor [] [],
                       customFieldsBI = [],
@@ -356,6 +362,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],
@@ -432,6 +440,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -500,6 +510,8 @@ GenericPackageDescription {
                     []
                     [],
                   sharedOptions =
+                  PerCompilerFlavor [] [],
+                  profSharedOptions =
                   PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
@@ -593,6 +605,8 @@ GenericPackageDescription {
                           [],
                         sharedOptions =
                         PerCompilerFlavor [] [],
+                        profSharedOptions =
+                        PerCompilerFlavor [] [],
                         staticOptions =
                         PerCompilerFlavor [] [],
                         customFieldsBI = [],
@@ -669,6 +683,8 @@ GenericPackageDescription {
                           []
                           [],
                         sharedOptions =
+                        PerCompilerFlavor [] [],
+                        profSharedOptions =
                         PerCompilerFlavor [] [],
                         staticOptions =
                         PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/common.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/common.expr
@@ -110,6 +110,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -185,6 +187,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/common2.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/common2.expr
@@ -106,6 +106,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -205,6 +207,8 @@ GenericPackageDescription {
                   [],
                 sharedOptions =
                 PerCompilerFlavor [] [],
+                profSharedOptions =
+                PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
                 customFieldsBI = [],
@@ -284,6 +288,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -386,6 +392,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -461,6 +469,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -562,6 +572,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -639,6 +651,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -715,6 +729,8 @@ GenericPackageDescription {
                     []
                     [],
                   sharedOptions =
+                  PerCompilerFlavor [] [],
+                  profSharedOptions =
                   PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/common3.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/common3.expr
@@ -110,6 +110,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -185,6 +187,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/elif.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/elif.expr
@@ -105,6 +105,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -171,6 +173,8 @@ GenericPackageDescription {
                   []
                   [],
                 sharedOptions =
+                PerCompilerFlavor [] [],
+                profSharedOptions =
                 PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/elif2.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/elif2.expr
@@ -105,6 +105,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -171,6 +173,8 @@ GenericPackageDescription {
                   []
                   [],
                 sharedOptions =
+                PerCompilerFlavor [] [],
+                profSharedOptions =
                 PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
@@ -245,6 +249,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -311,6 +317,8 @@ GenericPackageDescription {
                           []
                           [],
                         sharedOptions =
+                        PerCompilerFlavor [] [],
+                        profSharedOptions =
                         PerCompilerFlavor [] [],
                         staticOptions =
                         PerCompilerFlavor [] [],
@@ -384,6 +392,8 @@ GenericPackageDescription {
                             []
                             [],
                           sharedOptions =
+                          PerCompilerFlavor [] [],
+                          profSharedOptions =
                           PerCompilerFlavor [] [],
                           staticOptions =
                           PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/encoding-0.8.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/encoding-0.8.expr
@@ -114,6 +114,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/generics-sop.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/generics-sop.expr
@@ -242,6 +242,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -373,6 +375,8 @@ GenericPackageDescription {
                   [],
                 sharedOptions =
                 PerCompilerFlavor [] [],
+                profSharedOptions =
+                PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
                 customFieldsBI = [],
@@ -456,6 +460,8 @@ GenericPackageDescription {
                   []
                   [],
                 sharedOptions =
+                PerCompilerFlavor [] [],
+                profSharedOptions =
                 PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
@@ -561,6 +567,8 @@ GenericPackageDescription {
                   [],
                 sharedOptions =
                 PerCompilerFlavor [] [],
+                profSharedOptions =
+                PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
                 customFieldsBI = [],
@@ -630,6 +638,8 @@ GenericPackageDescription {
                   []
                   [],
                 sharedOptions =
+                PerCompilerFlavor [] [],
+                profSharedOptions =
                 PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
@@ -701,6 +711,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -797,6 +809,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/hasktorch.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/hasktorch.expr
@@ -322,6 +322,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -642,6 +644,8 @@ GenericPackageDescription {
                   [],
                 sharedOptions =
                 PerCompilerFlavor [] [],
+                profSharedOptions =
+                PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
                 customFieldsBI = [],
@@ -884,6 +888,8 @@ GenericPackageDescription {
                   [],
                 sharedOptions =
                 PerCompilerFlavor [] [],
+                profSharedOptions =
+                PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
                 customFieldsBI = [],
@@ -1083,6 +1089,8 @@ GenericPackageDescription {
                         []
                         [],
                       sharedOptions =
+                      PerCompilerFlavor [] [],
+                      profSharedOptions =
                       PerCompilerFlavor [] [],
                       staticOptions =
                       PerCompilerFlavor [] [],
@@ -1437,6 +1445,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -2740,6 +2750,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -2828,6 +2840,8 @@ GenericPackageDescription {
                       []
                       [],
                     sharedOptions =
+                    PerCompilerFlavor [] [],
+                    profSharedOptions =
                     PerCompilerFlavor [] [],
                     staticOptions =
                     PerCompilerFlavor [] [],
@@ -5072,6 +5086,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],
@@ -6424,6 +6440,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -6513,6 +6531,8 @@ GenericPackageDescription {
                       []
                       [],
                     sharedOptions =
+                    PerCompilerFlavor [] [],
+                    profSharedOptions =
                     PerCompilerFlavor [] [],
                     staticOptions =
                     PerCompilerFlavor [] [],
@@ -8182,6 +8202,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],
@@ -8669,6 +8691,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -9433,6 +9457,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],
@@ -9554,6 +9580,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],
@@ -9658,6 +9686,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -9764,6 +9794,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],
@@ -9857,6 +9889,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -9977,6 +10011,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/hidden-main-lib.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/hidden-main-lib.expr
@@ -97,6 +97,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/indentation.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/indentation.expr
@@ -106,6 +106,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/indentation2.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/indentation2.expr
@@ -99,6 +99,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/indentation3.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/indentation3.expr
@@ -101,6 +101,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/issue-5055.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-5055.expr
@@ -100,6 +100,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],
@@ -182,6 +184,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -266,6 +270,8 @@ GenericPackageDescription {
                     []
                     [],
                   sharedOptions =
+                  PerCompilerFlavor [] [],
+                  profSharedOptions =
                   PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/issue-5846.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-5846.expr
@@ -94,6 +94,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/issue-6083-a.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-6083-a.expr
@@ -94,6 +94,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -189,6 +191,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],
@@ -254,6 +258,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -334,6 +340,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/issue-6083-b.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-6083-b.expr
@@ -94,6 +94,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -189,6 +191,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],
@@ -254,6 +258,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -344,6 +350,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/issue-6083-c.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-6083-c.expr
@@ -94,6 +94,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -188,6 +190,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/issue-6083-pkg-pkg.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-6083-pkg-pkg.expr
@@ -94,6 +94,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/issue-774.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-774.expr
@@ -108,6 +108,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/jaeger-flamegraph.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/jaeger-flamegraph.expr
@@ -139,6 +139,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -237,6 +239,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -402,6 +406,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/leading-comma-2.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/leading-comma-2.expr
@@ -104,6 +104,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/leading-comma.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/leading-comma.expr
@@ -97,6 +97,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/libpq1.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/libpq1.expr
@@ -190,6 +190,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -289,6 +291,8 @@ GenericPackageDescription {
                   [],
                 sharedOptions =
                 PerCompilerFlavor [] [],
+                profSharedOptions =
+                PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
                 customFieldsBI = [],
@@ -372,6 +376,8 @@ GenericPackageDescription {
                   []
                   [],
                 sharedOptions =
+                PerCompilerFlavor [] [],
+                profSharedOptions =
                 PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
@@ -464,6 +470,8 @@ GenericPackageDescription {
                   [],
                 sharedOptions =
                 PerCompilerFlavor [] [],
+                profSharedOptions =
+                PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
                 customFieldsBI = [],
@@ -528,6 +536,8 @@ GenericPackageDescription {
                     []
                     [],
                   sharedOptions =
+                  PerCompilerFlavor [] [],
+                  profSharedOptions =
                   PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
@@ -596,6 +606,8 @@ GenericPackageDescription {
                           [],
                         sharedOptions =
                         PerCompilerFlavor [] [],
+                        profSharedOptions =
+                        PerCompilerFlavor [] [],
                         staticOptions =
                         PerCompilerFlavor [] [],
                         customFieldsBI = [],
@@ -660,6 +672,8 @@ GenericPackageDescription {
                             []
                             [],
                           sharedOptions =
+                          PerCompilerFlavor [] [],
+                          profSharedOptions =
                           PerCompilerFlavor [] [],
                           staticOptions =
                           PerCompilerFlavor [] [],
@@ -727,6 +741,8 @@ GenericPackageDescription {
                                   []
                                   [],
                                 sharedOptions =
+                                PerCompilerFlavor [] [],
+                                profSharedOptions =
                                 PerCompilerFlavor [] [],
                                 staticOptions =
                                 PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/libpq2.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/libpq2.expr
@@ -195,6 +195,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -294,6 +296,8 @@ GenericPackageDescription {
                   [],
                 sharedOptions =
                 PerCompilerFlavor [] [],
+                profSharedOptions =
+                PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
                 customFieldsBI = [],
@@ -377,6 +381,8 @@ GenericPackageDescription {
                   []
                   [],
                 sharedOptions =
+                PerCompilerFlavor [] [],
+                profSharedOptions =
                 PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
@@ -466,6 +472,8 @@ GenericPackageDescription {
                   [],
                 sharedOptions =
                 PerCompilerFlavor [] [],
+                profSharedOptions =
+                PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
                 customFieldsBI = [],
@@ -530,6 +538,8 @@ GenericPackageDescription {
                     []
                     [],
                   sharedOptions =
+                  PerCompilerFlavor [] [],
+                  profSharedOptions =
                   PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
@@ -598,6 +608,8 @@ GenericPackageDescription {
                           [],
                         sharedOptions =
                         PerCompilerFlavor [] [],
+                        profSharedOptions =
+                        PerCompilerFlavor [] [],
                         staticOptions =
                         PerCompilerFlavor [] [],
                         customFieldsBI = [],
@@ -662,6 +674,8 @@ GenericPackageDescription {
                             []
                             [],
                           sharedOptions =
+                          PerCompilerFlavor [] [],
+                          profSharedOptions =
                           PerCompilerFlavor [] [],
                           staticOptions =
                           PerCompilerFlavor [] [],
@@ -729,6 +743,8 @@ GenericPackageDescription {
                                   []
                                   [],
                                 sharedOptions =
+                                PerCompilerFlavor [] [],
+                                profSharedOptions =
                                 PerCompilerFlavor [] [],
                                 staticOptions =
                                 PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/mixin-1.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/mixin-1.expr
@@ -98,6 +98,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/mixin-2.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/mixin-2.expr
@@ -98,6 +98,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/mixin-3.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/mixin-3.expr
@@ -98,6 +98,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/monad-param.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/monad-param.expr
@@ -120,6 +120,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/multiple-libs-2.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/multiple-libs-2.expr
@@ -97,6 +97,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -174,6 +176,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/noVersion.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/noVersion.expr
@@ -97,6 +97,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/nothing-unicode.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/nothing-unicode.expr
@@ -112,6 +112,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -178,6 +180,8 @@ GenericPackageDescription {
                   []
                   [],
                 sharedOptions =
+                PerCompilerFlavor [] [],
+                profSharedOptions =
                 PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/shake.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/shake.expr
@@ -306,6 +306,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -519,6 +521,8 @@ GenericPackageDescription {
                   [],
                 sharedOptions =
                 PerCompilerFlavor [] [],
+                profSharedOptions =
+                PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
                 customFieldsBI = [],
@@ -585,6 +589,8 @@ GenericPackageDescription {
                         []
                         [],
                       sharedOptions =
+                      PerCompilerFlavor [] [],
+                      profSharedOptions =
                       PerCompilerFlavor [] [],
                       staticOptions =
                       PerCompilerFlavor [] [],
@@ -660,6 +666,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -726,6 +734,8 @@ GenericPackageDescription {
                           []
                           [],
                         sharedOptions =
+                        PerCompilerFlavor [] [],
+                        profSharedOptions =
                         PerCompilerFlavor [] [],
                         staticOptions =
                         PerCompilerFlavor [] [],
@@ -804,6 +814,8 @@ GenericPackageDescription {
                   []
                   [],
                 sharedOptions =
+                PerCompilerFlavor [] [],
+                profSharedOptions =
                 PerCompilerFlavor [] [],
                 staticOptions =
                 PerCompilerFlavor [] [],
@@ -981,6 +993,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -1206,6 +1220,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -1271,6 +1287,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -1334,6 +1352,8 @@ GenericPackageDescription {
                           []
                           [],
                         sharedOptions =
+                        PerCompilerFlavor [] [],
+                        profSharedOptions =
                         PerCompilerFlavor [] [],
                         staticOptions =
                         PerCompilerFlavor [] [],
@@ -1406,6 +1426,8 @@ GenericPackageDescription {
                       [],
                     sharedOptions =
                     PerCompilerFlavor [] [],
+                    profSharedOptions =
+                    PerCompilerFlavor [] [],
                     staticOptions =
                     PerCompilerFlavor [] [],
                     customFieldsBI = [],
@@ -1469,6 +1491,8 @@ GenericPackageDescription {
                             []
                             [],
                           sharedOptions =
+                          PerCompilerFlavor [] [],
+                          profSharedOptions =
                           PerCompilerFlavor [] [],
                           staticOptions =
                           PerCompilerFlavor [] [],
@@ -1544,6 +1568,8 @@ GenericPackageDescription {
                     []
                     [],
                   sharedOptions =
+                  PerCompilerFlavor [] [],
+                  profSharedOptions =
                   PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
@@ -1763,6 +1789,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -1992,6 +2020,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -2060,6 +2090,8 @@ GenericPackageDescription {
                     []
                     [],
                   sharedOptions =
+                  PerCompilerFlavor [] [],
+                  profSharedOptions =
                   PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
@@ -2130,6 +2162,8 @@ GenericPackageDescription {
                     [],
                   sharedOptions =
                   PerCompilerFlavor [] [],
+                  profSharedOptions =
+                  PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],
                   customFieldsBI = [],
@@ -2197,6 +2231,8 @@ GenericPackageDescription {
                           []
                           [],
                         sharedOptions =
+                        PerCompilerFlavor [] [],
+                        profSharedOptions =
                         PerCompilerFlavor [] [],
                         staticOptions =
                         PerCompilerFlavor [] [],
@@ -2273,6 +2309,8 @@ GenericPackageDescription {
                       [],
                     sharedOptions =
                     PerCompilerFlavor [] [],
+                    profSharedOptions =
+                    PerCompilerFlavor [] [],
                     staticOptions =
                     PerCompilerFlavor [] [],
                     customFieldsBI = [],
@@ -2340,6 +2378,8 @@ GenericPackageDescription {
                             []
                             [],
                           sharedOptions =
+                          PerCompilerFlavor [] [],
+                          profSharedOptions =
                           PerCompilerFlavor [] [],
                           staticOptions =
                           PerCompilerFlavor [] [],
@@ -2419,6 +2459,8 @@ GenericPackageDescription {
                     []
                     [],
                   sharedOptions =
+                  PerCompilerFlavor [] [],
+                  profSharedOptions =
                   PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/spdx-1.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/spdx-1.expr
@@ -95,6 +95,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/spdx-2.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/spdx-2.expr
@@ -99,6 +99,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/spdx-3.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/spdx-3.expr
@@ -99,6 +99,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/th-lift-instances.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/th-lift-instances.expr
@@ -127,6 +127,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -297,6 +299,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
@@ -473,6 +477,8 @@ GenericPackageDescription {
               [],
             sharedOptions =
             PerCompilerFlavor [] [],
+            profSharedOptions =
+            PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],
             customFieldsBI = [],
@@ -576,6 +582,8 @@ GenericPackageDescription {
                     []
                     [],
                   sharedOptions =
+                  PerCompilerFlavor [] [],
+                  profSharedOptions =
                   PerCompilerFlavor [] [],
                   staticOptions =
                   PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/ParserTests/regressions/version-sets.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/version-sets.expr
@@ -121,6 +121,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],

--- a/Cabal-tests/tests/ParserTests/regressions/wl-pprint-indef.expr
+++ b/Cabal-tests/tests/ParserTests/regressions/wl-pprint-indef.expr
@@ -114,6 +114,8 @@ GenericPackageDescription {
             [],
           sharedOptions =
           PerCompilerFlavor [] [],
+          profSharedOptions =
+          PerCompilerFlavor [] [],
           staticOptions =
           PerCompilerFlavor [] [],
           customFieldsBI = [],
@@ -201,6 +203,8 @@ GenericPackageDescription {
               []
               [],
             sharedOptions =
+            PerCompilerFlavor [] [],
+            profSharedOptions =
             PerCompilerFlavor [] [],
             staticOptions =
             PerCompilerFlavor [] [],

--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -33,15 +33,15 @@ md5Check proxy md5Int = structureHash proxy @?= md5FromInteger md5Int
 md5CheckGenericPackageDescription :: Proxy GenericPackageDescription -> Assertion
 md5CheckGenericPackageDescription proxy = md5Check proxy
 #if MIN_VERSION_base(4,19,0)
-    0x44f8430d7366cf849e09669627573040
+    0xe28f08e7ac644f836d8b3fe7f9428dcf
 #else
-    0x8ed837568017bde3abb4fcee244b9c9f
+    0x3442058190aa48c2f795b83ee995f702
 #endif
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
 #if MIN_VERSION_base(4,19,0)
-    0xdff58fe5e7f9568c67cd982eaba7edc2
+    0x31b94dc3e61eb01fea1a1c3c73d984ee
 #else
-    0x4e50a4a95779b862edde3d6696797251
+    0xdc2f5e7a9c696a4e0bd64f02a0140b74
 #endif

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -101,6 +101,7 @@ library
     Distribution.Simple.BuildPaths
     Distribution.Simple.BuildTarget
     Distribution.Simple.BuildToolDepends
+    Distribution.Simple.BuildWay
     Distribution.Simple.CCompiler
     Distribution.Simple.Command
     Distribution.Simple.Compiler

--- a/Cabal/src/Distribution/Simple/BuildPaths.hs
+++ b/Cabal/src/Distribution/Simple/BuildPaths.hs
@@ -32,6 +32,7 @@ module Distribution.Simple.BuildPaths
   , mkProfLibName
   , mkGenericSharedLibName
   , mkSharedLibName
+  , mkProfSharedLibName
   , mkStaticLibName
   , mkGenericSharedBundledLibName
   , exeExtension
@@ -282,6 +283,10 @@ mkGenericSharedLibName platform (CompilerId compilerFlavor compilerVersion) lib 
 mkSharedLibName :: Platform -> CompilerId -> UnitId -> String
 mkSharedLibName platform comp lib =
   mkGenericSharedLibName platform comp (getHSLibraryName lib)
+
+mkProfSharedLibName :: Platform -> CompilerId -> UnitId -> String
+mkProfSharedLibName platform comp lib =
+  mkGenericSharedLibName platform comp (getHSLibraryName lib ++ "_p")
 
 -- Static libs are named the same as shared libraries, only with
 -- a different extension.

--- a/Cabal/src/Distribution/Simple/BuildWay.hs
+++ b/Cabal/src/Distribution/Simple/BuildWay.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Distribution.Simple.BuildWay where
+
+data BuildWay = StaticWay | DynWay | ProfWay | ProfDynWay
+  deriving (Eq, Ord, Show, Read, Enum)
+
+-- | Returns the object/interface extension prefix for the given build way (e.g. "dyn_" for 'DynWay')
+buildWayPrefix :: BuildWay -> String
+buildWayPrefix = \case
+  StaticWay -> ""
+  ProfWay -> "p_"
+  DynWay -> "dyn_"
+  ProfDynWay -> "p_dyn_"

--- a/Cabal/src/Distribution/Simple/Compiler.hs
+++ b/Cabal/src/Distribution/Simple/Compiler.hs
@@ -63,6 +63,11 @@ module Distribution.Simple.Compiler
   , unitIdSupported
   , coverageSupported
   , profilingSupported
+  , profilingDynamicSupported
+  , profilingDynamicSupportedOrUnknown
+  , profilingVanillaSupported
+  , profilingVanillaSupportedOrUnknown
+  , dynamicSupported
   , backpackSupported
   , arResponseFilesSupported
   , arDashLSupported
@@ -427,6 +432,49 @@ profilingSupported comp =
     GHC -> True
     GHCJS -> True
     _ -> False
+
+-- | Returns Just if we can certainly determine whether a way is supported
+-- if we don't know, return Nothing
+waySupported :: String -> Compiler -> Maybe Bool
+waySupported way comp =
+  case compilerFlavor comp of
+    GHC ->
+      -- Infomation about compiler ways is only accurately reported after
+      -- 9.10.1. Which is useful as this is before profiling dynamic support
+      -- was introduced. (See GHC #24881)
+      if compilerVersion comp >= mkVersion [9, 10, 1]
+        then case Map.lookup "RTS ways" (compilerProperties comp) of
+          Just ways -> Just (way `elem` words ways)
+          Nothing -> Just False
+        else Nothing
+    _ -> Nothing
+
+-- | Either profiling is definitely supported or we don't know (so assume
+-- it is)
+profilingVanillaSupportedOrUnknown :: Compiler -> Bool
+profilingVanillaSupportedOrUnknown comp = profilingVanillaSupported comp `elem` [Just True, Nothing]
+
+-- | Is the compiler distributed with profiling libraries
+profilingVanillaSupported :: Compiler -> Maybe Bool
+profilingVanillaSupported comp = waySupported "p" comp
+
+-- | Is the compiler distributed with profiling dynamic libraries
+profilingDynamicSupported :: Compiler -> Maybe Bool
+profilingDynamicSupported comp =
+  -- Certainly not before this version, as it was not implemented yet.
+  if compilerVersion comp <= mkVersion [9, 11, 0]
+    then Just False
+    else waySupported "p_dyn" comp
+
+-- | Either profiling dynamic is definitely supported or we don't know (so assume
+-- it is)
+profilingDynamicSupportedOrUnknown :: Compiler -> Bool
+profilingDynamicSupportedOrUnknown comp =
+  profilingDynamicSupported comp `elem` [Just True, Nothing]
+
+-- | Is the compiler distributed with dynamic libraries
+dynamicSupported :: Compiler -> Maybe Bool
+dynamicSupported comp = waySupported "dyn" comp
 
 -- | Does this compiler support a package database entry with:
 -- "visibility"?

--- a/Cabal/src/Distribution/Simple/GHC/Build/Utils.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Build/Utils.hs
@@ -13,6 +13,7 @@ import qualified Distribution.ModuleName as ModuleName
 import Distribution.PackageDescription as PD
 import Distribution.PackageDescription.Utils (cabalBug)
 import Distribution.Simple.BuildPaths
+import Distribution.Simple.BuildWay
 import Distribution.Simple.Compiler
 import qualified Distribution.Simple.GHC.Internal as Internal
 import Distribution.Simple.Program.GHC
@@ -47,9 +48,20 @@ findExecutableMain verbosity mbWorkDir buildDir (bnfo, modPath) =
 supportsDynamicToo :: Compiler -> Bool
 supportsDynamicToo = Internal.ghcLookupProperty "Support dynamic-too"
 
+compilerBuildWay :: Compiler -> BuildWay
+compilerBuildWay c =
+  case (isDynamic c, isProfiled c) of
+    (True, True) -> ProfDynWay
+    (True, False) -> DynWay
+    (False, True) -> ProfWay
+    (False, False) -> StaticWay
+
 -- | Is this compiler's RTS dynamically linked?
 isDynamic :: Compiler -> Bool
 isDynamic = Internal.ghcLookupProperty "GHC Dynamic"
+
+isProfiled :: Compiler -> Bool
+isProfiled = Internal.ghcLookupProperty "GHC Profiled"
 
 -- | Should we dynamically link the foreign library, based on its 'foreignLibType'?
 withDynFLib :: ForeignLib -> Bool

--- a/Cabal/src/Distribution/Simple/Hpc.hs
+++ b/Cabal/src/Distribution/Simple/Hpc.hs
@@ -58,7 +58,7 @@ import System.Directory (createDirectoryIfMissing, doesFileExist)
 -- -------------------------------------------------------------------------
 -- Haskell Program Coverage
 
-data Way = Vanilla | Prof | Dyn
+data Way = Vanilla | Prof | Dyn | ProfDyn
   deriving (Bounded, Enum, Eq, Read, Show)
 
 hpcDir
@@ -73,6 +73,7 @@ hpcDir distPref way = distPref </> makeRelativePathEx ("hpc" </> wayDir)
       Vanilla -> "vanilla"
       Prof -> "prof"
       Dyn -> "dyn"
+      ProfDyn -> "prof_dyn"
 
 mixDir
   :: SymbolicPath Pkg (Dir Dist)

--- a/Cabal/src/Distribution/Simple/LocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Simple/LocalBuildInfo.hs
@@ -36,6 +36,7 @@ module Distribution.Simple.LocalBuildInfo
   , interpretSymbolicPathLBI
   , mbWorkDirLBI
   , absoluteWorkingDirLBI
+  , buildWays
 
     -- * Buildable package components
   , Component (..)

--- a/Cabal/src/Distribution/Simple/Setup/Config.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Config.hs
@@ -127,6 +127,8 @@ data ConfigFlags = ConfigFlags
   , configProf :: Flag Bool
   -- ^ Enable profiling in the library
   --  and executables.
+  , configProfShared :: Flag Bool
+  -- ^ Enable shared profiling objects
   , configProfDetail :: Flag ProfDetailLevel
   -- ^ Profiling detail level
   --   in the library and executables.
@@ -286,6 +288,7 @@ instance Eq ConfigFlags where
       && equal configProfExe
       && equal configProf
       && equal configProfDetail
+      && equal configProfShared
       && equal configProfLibDetail
       && equal configConfigureArgs
       && equal configOptimization
@@ -517,6 +520,13 @@ configureOptions showOrParseArgs =
           "Executable and library profiling"
           configProf
           (\v flags -> flags{configProf = v})
+          (boolOpt [] [])
+       , option
+          ""
+          ["profiling-shared"]
+          "Build profiling shared libraries"
+          configProfShared
+          (\v flags -> flags{configProfShared = v})
           (boolOpt [] [])
        , option
           ""

--- a/Cabal/src/Distribution/Types/LocalBuildConfig.hs
+++ b/Cabal/src/Distribution/Types/LocalBuildConfig.hs
@@ -151,6 +151,8 @@ data BuildOptions = BuildOptions
   { withVanillaLib :: Bool
   -- ^ Whether to build normal libs.
   , withProfLib :: Bool
+  -- ^ Whether to build normal libs.
+  , withProfLibShared :: Bool
   -- ^ Whether to build profiling versions of libs.
   , withSharedLib :: Bool
   -- ^ Whether to build shared versions of libs.
@@ -211,6 +213,7 @@ buildOptionsConfigFlags (BuildOptions{..}) =
     , configGHCiLib = toFlag $ withGHCiLib
     , configProfExe = toFlag $ withProfExe
     , configProfLib = toFlag $ withProfLib
+    , configProfShared = toFlag $ withProfLibShared
     , configProf = mempty
     , -- configProfDetail is for exe+lib, but overridden by configProfLibDetail
       -- so we specify both so we can specify independently

--- a/Cabal/src/Distribution/Types/LocalBuildInfo.hs
+++ b/Cabal/src/Distribution/Types/LocalBuildInfo.hs
@@ -28,11 +28,12 @@ module Distribution.Types.LocalBuildInfo
       , withPackageDB
       , withVanillaLib
       , withProfLib
-      , withSharedLib
-      , withStaticLib
+      , withProfLibShared
       , withDynExe
       , withFullyStaticExe
       , withProfExe
+      , withSharedLib
+      , withStaticLib
       , withProfLibDetail
       , withProfExeDetail
       , withOptimization
@@ -82,6 +83,7 @@ module Distribution.Types.LocalBuildInfo
   , neededTargetsInBuildOrder'
   , withNeededTargetsInBuildOrder'
   , testCoverage
+  , buildWays
 
     -- * Functions you SHOULD NOT USE (yet), but are defined here to
 
@@ -111,6 +113,7 @@ import Distribution.Utils.Path
 
 import Distribution.PackageDescription
 import Distribution.Pretty
+import Distribution.Simple.BuildWay
 import Distribution.Simple.Compiler
 import Distribution.Simple.Flag
 import Distribution.Simple.InstallDirs hiding
@@ -169,6 +172,7 @@ pattern LocalBuildInfo
   -> Bool
   -> Bool
   -> Bool
+  -> Bool
   -> ProfDetailLevel
   -> ProfDetailLevel
   -> OptimisationLevel
@@ -201,6 +205,7 @@ pattern LocalBuildInfo
   , withPackageDB
   , withVanillaLib
   , withProfLib
+  , withProfLibShared
   , withSharedLib
   , withStaticLib
   , withDynExe
@@ -252,6 +257,7 @@ pattern LocalBuildInfo
           LBC.BuildOptions
             { withVanillaLib
             , withProfLib
+            , withProfLibShared
             , withSharedLib
             , withStaticLib
             , withDynExe
@@ -428,6 +434,49 @@ withNeededTargetsInBuildOrder' pkg_descr lbi uids f =
 testCoverage :: LocalBuildInfo -> Bool
 testCoverage (LocalBuildInfo{exeCoverage = exes, libCoverage = libs}) =
   exes && libs
+
+-- | Returns a list of ways, in the order which they should be built, and the
+-- way we build executable and foreign library components.
+--
+-- Ideally all this info should be fixed at configure time and not dependent on
+-- additional info but `LocalBuildInfo` is per package (not per component) so it's
+-- currently not possible to configure components to be built in certain ways.
+buildWays :: LocalBuildInfo -> (Bool -> [BuildWay], Bool -> BuildWay, BuildWay)
+buildWays lbi =
+  let
+    -- enable-library-profiling (enable (static profiling way)) .p_o
+    -- enable-shared (enabled dynamic way)  .dyn_o
+    -- enable-profiling-shared (enable dyanmic profilng way) .p_dyn_o
+    -- enable-library-vanilla (enable vanilla way) .o
+    --
+    -- enable-executable-dynamic => build dynamic executables
+    -- => --enable-profiling + --enable-executable-dynamic => build dynamic profiled executables
+    -- => --enable-profiling => build vanilla profiled executables
+
+    wantedLibWays is_indef =
+      [ProfDynWay | withProfLibShared lbi && not is_indef]
+        <> [ProfWay | withProfLib lbi]
+        -- I don't see why we shouldn't build with dynamic-- indefinite components.
+        <> [DynWay | withSharedLib lbi && not is_indef]
+        -- MP: Ideally we should have `BuildOptions` on a per component basis, in
+        -- which case this `is_indef` check could be moved to configure time.
+        <> [StaticWay | withVanillaLib lbi || withStaticLib lbi]
+
+    wantedFLibWay is_dyn_flib =
+      case (is_dyn_flib, withProfExe lbi) of
+        (True, True) -> ProfDynWay
+        (False, True) -> ProfWay
+        (True, False) -> DynWay
+        (False, False) -> StaticWay
+
+    wantedExeWay =
+      case (withDynExe lbi, withProfExe lbi) of
+        (True, True) -> ProfDynWay
+        (True, False) -> DynWay
+        (False, True) -> ProfWay
+        (False, False) -> StaticWay
+   in
+    (wantedLibWays, wantedFLibWay, wantedExeWay)
 
 -------------------------------------------------------------------------------
 -- Stub functions to prevent someone from accidentally defining them

--- a/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
@@ -41,6 +41,10 @@ data ConstraintSource =
   -- from Cabal >= 3.11
   | ConstraintSourceMultiRepl
 
+  | ConstraintSourceProfiledDynamic
+  -- | Constraint introduced by --enable-profiling-shared, which requires features
+  -- from Cabal >= 3.13
+
   -- | The source of the constraint is not specified.
   | ConstraintSourceUnknown
 
@@ -72,6 +76,8 @@ showConstraintSource ConstraintSourceConfigFlagOrTarget =
     "config file, command line flag, or user target"
 showConstraintSource ConstraintSourceMultiRepl =
     "--enable-multi-repl"
+showConstraintSource ConstraintSourceProfiledDynamic =
+    "--enable-profiling-shared"
 showConstraintSource ConstraintSourceUnknown = "unknown source"
 showConstraintSource ConstraintSetupCabalMinVersion =
     "minimum version of Cabal used by Setup.hs"

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -490,6 +490,7 @@ instance Semigroup SavedConfig where
           , configVanillaLib = combine configVanillaLib
           , configProfLib = combine configProfLib
           , configProf = combine configProf
+          , configProfShared = combine configProfShared
           , configSharedLib = combine configSharedLib
           , configStaticLib = combine configStaticLib
           , configDynExe = combine configDynExe

--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -64,6 +64,7 @@ module Distribution.Client.Dependency
   , addDefaultSetupDependencies
   , addSetupCabalMinVersionConstraint
   , addSetupCabalMaxVersionConstraint
+  , addSetupCabalProfiledDynamic
   ) where
 
 import Distribution.Client.Compat.Prelude
@@ -667,6 +668,22 @@ addSetupCabalMaxVersionConstraint maxVersion =
             (PackagePropertyVersion $ earlierVersion maxVersion)
         )
         ConstraintSetupCabalMaxVersion
+    ]
+  where
+    cabalPkgname = mkPackageName "Cabal"
+
+-- | Add an a lower bound @setup.Cabal >= 3.13@ labeled with 'ConstraintSourceProfiledDynamic'
+addSetupCabalProfiledDynamic
+  :: DepResolverParams
+  -> DepResolverParams
+addSetupCabalProfiledDynamic =
+  addConstraints
+    [ LabeledPackageConstraint
+        ( PackageConstraint
+            (ScopeAnySetupQualifier cabalPkgname)
+            (PackagePropertyVersion $ orLaterVersion (mkVersion [3, 13, 0]))
+        )
+        ConstraintSourceProfiledDynamic
     ]
   where
     cabalPkgname = mkPackageName "Cabal"

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -102,9 +102,8 @@ import Distribution.Client.HttpUtils
 import Distribution.Client.Types
 import Distribution.Client.Utils.Parsec (renderParseError)
 
+import Distribution.Solver.Types.ConstraintSource
 import Distribution.Solver.Types.PackageConstraint
-  ( PackageProperty (..)
-  )
 import Distribution.Solver.Types.Settings
 import Distribution.Solver.Types.SourcePackage
 
@@ -116,6 +115,7 @@ import Distribution.Client.Setup
 import Distribution.Client.SrcDist
   ( packageDirToSdist
   )
+import Distribution.Client.Targets
 import Distribution.Client.Types.SourceRepo
   ( SourceRepoList
   , SourceRepositoryPackage (..)
@@ -136,11 +136,6 @@ import Distribution.Fields
   , showPWarning
   )
 import Distribution.Package
-  ( PackageId
-  , PackageName
-  , UnitId
-  , packageId
-  )
 import Distribution.PackageDescription.Parsec
   ( parseGenericPackageDescription
   )
@@ -195,8 +190,6 @@ import Distribution.Verbosity
   , verbose
   )
 import Distribution.Version
-  ( Version
-  )
 
 import qualified Codec.Archive.Tar as Tar
 import qualified Codec.Archive.Tar.Entry as Tar
@@ -317,9 +310,34 @@ resolveSolverSettings
     where
       -- TODO: [required eventually] some of these settings need validation, e.g.
       -- the flag assignments need checking.
+      cabalPkgname = mkPackageName "Cabal"
+
+      profilingDynamicConstraint =
+        ( UserConstraint
+            (UserAnySetupQualifier cabalPkgname)
+            (PackagePropertyVersion $ orLaterVersion (mkVersion [3, 13, 0]))
+        , ConstraintSourceProfiledDynamic
+        )
+
+      profDynEnabledGlobally = fromFlagOrDefault False (packageConfigProfShared projectConfigLocalPackages)
+
+      profDynEnabledAnyLocally =
+        or
+          [ fromFlagOrDefault False (packageConfigProfShared ppc)
+          | (_, ppc) <- Map.toList (getMapMappend projectConfigSpecificPackage)
+          ]
+
+      -- Add a setup.Cabal >= 3.13 constraint if prof+dyn is enabled globally
+      -- or any package in the project enables it.
+      -- Ideally we'd apply this constraint only on the closure of packages requiring prof+dyn,
+      -- but that would require another solver run for marginal advantages that
+      -- will further shrink as 3.13 is adopted.
+      solverCabalLibConstraints =
+        [profilingDynamicConstraint | profDynEnabledGlobally || profDynEnabledAnyLocally]
+
       solverSettingRemoteRepos = fromNubList projectConfigRemoteRepos
       solverSettingLocalNoIndexRepos = fromNubList projectConfigLocalNoIndexRepos
-      solverSettingConstraints = projectConfigConstraints
+      solverSettingConstraints = solverCabalLibConstraints ++ projectConfigConstraints
       solverSettingPreferences = projectConfigPreferences
       solverSettingFlagAssignment = packageConfigFlagAssignment projectConfigLocalPackages
       solverSettingFlagAssignments =

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -768,6 +768,7 @@ convertLegacyPerPackageFlags
         , configFullyStaticExe = packageConfigFullyStaticExe
         , configProfExe = packageConfigProfExe
         , configProf = packageConfigProf
+        , configProfShared = packageConfigProfShared
         , configProfDetail = packageConfigProfDetail
         , configProfLibDetail = packageConfigProfLibDetail
         , configConfigureArgs = packageConfigConfigureArgs
@@ -1074,6 +1075,7 @@ convertToLegacyAllPackageConfig
           , configFullyStaticExe = mempty
           , configProfExe = mempty
           , configProf = mempty
+          , configProfShared = mempty
           , configProfDetail = mempty
           , configProfLibDetail = mempty
           , configConfigureArgs = mempty
@@ -1150,6 +1152,7 @@ convertToLegacyPerPackageConfig PackageConfig{..} =
         , configFullyStaticExe = packageConfigFullyStaticExe
         , configProfExe = packageConfigProfExe
         , configProf = packageConfigProf
+        , configProfShared = packageConfigProfShared
         , configProfDetail = packageConfigProfDetail
         , configProfLibDetail = packageConfigProfLibDetail
         , configConfigureArgs = packageConfigConfigureArgs
@@ -1545,11 +1548,13 @@ legacyPackageConfigFieldDescrs =
         , "program-suffix"
         , "library-vanilla"
         , "library-profiling"
+        , "library-vanilla"
         , "shared"
         , "static"
         , "executable-dynamic"
         , "executable-static"
         , "profiling"
+        , "profiling-shared"
         , "executable-profiling"
         , "profiling-detail"
         , "library-profiling-detail"

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Types.hs
@@ -265,6 +265,7 @@ data PackageConfig = PackageConfig
   , packageConfigFullyStaticExe :: Flag Bool
   , packageConfigProf :: Flag Bool -- TODO: [code cleanup] sort out
   , packageConfigProfLib :: Flag Bool --      this duplication
+  , packageConfigProfShared :: Flag Bool
   , packageConfigProfExe :: Flag Bool --      and consistency
   , packageConfigProfDetail :: Flag ProfDetailLevel
   , packageConfigProfLibDetail :: Flag ProfDetailLevel

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -1061,7 +1061,7 @@ printPlan
             nubFlag x (Setup.Flag x') | x == x' = Setup.NoFlag
             nubFlag _ f = f
 
-            (tryLibProfiling, tryExeProfiling) =
+            (tryLibProfiling, tryLibProfilingShared, tryExeProfiling) =
               computeEffectiveProfiling fullConfigureFlags
 
             partialConfigureFlags =
@@ -1072,7 +1072,8 @@ printPlan
                     nubFlag tryExeProfiling (configProfExe fullConfigureFlags)
                 , configProfLib =
                     nubFlag tryLibProfiling (configProfLib fullConfigureFlags)
-                    -- Maybe there are more we can add
+                , configProfShared =
+                    nubFlag tryLibProfilingShared (configProfShared fullConfigureFlags)
                 }
          in -- Not necessary to "escape" it, it's just for user output
             unwords . ("" :) $

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -165,6 +165,8 @@ import Distribution.Simple.LocalBuildInfo
   , componentName
   , pkgComponents
   )
+
+import Distribution.Simple.BuildWay
 import Distribution.Simple.PackageIndex (InstalledPackageIndex)
 import Distribution.Simple.Program
 import Distribution.Simple.Program.Db
@@ -1627,13 +1629,18 @@ elaborateInstallPlan
                 (map fst src_comps)
             let whyNotPerComp = why_not_per_component src_comps
             case NE.nonEmpty whyNotPerComp of
-              Nothing -> return comps
+              Nothing -> do
+                elaborationWarnings
+                return comps
               Just notPerCompReasons -> do
                 checkPerPackageOk comps notPerCompReasons
-                return
-                  [ elaborateSolverToPackage notPerCompReasons spkg g $
-                      comps ++ maybeToList setupComponent
-                  ]
+                pkgComp <-
+                  elaborateSolverToPackage
+                    notPerCompReasons
+                    spkg
+                    g
+                    (comps ++ maybeToList setupComponent)
+                return [pkgComp]
           Left cns ->
             dieProgress $
               hang
@@ -1696,7 +1703,7 @@ elaborateInstallPlan
                   <+> fsep (punctuate comma $ map (text . whyNotPerComponent) $ toList reasons)
           -- TODO: Maybe exclude Backpack too
 
-          elab0 = elaborateSolverToCommon spkg
+          (elab0, elaborationWarnings) = elaborateSolverToCommon spkg
           pkgid = elabPkgSourceId elab0
           pd = elabPkgDescription elab0
 
@@ -1992,7 +1999,7 @@ elaborateInstallPlan
         -> SolverPackage UnresolvedPkgLoc
         -> ComponentsGraph
         -> [ElaboratedConfiguredPackage]
-        -> ElaboratedConfiguredPackage
+        -> LogProgress ElaboratedConfiguredPackage
       elaborateSolverToPackage
         pkgWhyNotPerComponent
         pkg@( SolverPackage
@@ -2003,13 +2010,14 @@ elaborateInstallPlan
                 _exe_deps0
               )
         compGraph
-        comps =
+        comps = do
           -- Knot tying: the final elab includes the
           -- pkgInstalledId, which is calculated by hashing many
           -- of the other fields of the elaboratedPackage.
-          elab
+          elaborationWarnings
+          return elab
           where
-            elab0@ElaboratedConfiguredPackage{..} =
+            (elab0@ElaboratedConfiguredPackage{..}, elaborationWarnings) =
               elaborateSolverToCommon pkg
 
             elab1 =
@@ -2095,7 +2103,7 @@ elaborateInstallPlan
 
       elaborateSolverToCommon
         :: SolverPackage UnresolvedPkgLoc
-        -> ElaboratedConfiguredPackage
+        -> (ElaboratedConfiguredPackage, LogProgress ())
       elaborateSolverToCommon
         pkg@( SolverPackage
                 (SourcePackage pkgid gdesc srcloc descOverride)
@@ -2104,7 +2112,7 @@ elaborateInstallPlan
                 deps0
                 _exe_deps0
               ) =
-          elaboratedPackage
+          (elaboratedPackage, wayWarnings pkgid)
           where
             elaboratedPackage = ElaboratedConfiguredPackage{..}
 
@@ -2212,13 +2220,14 @@ elaborateInstallPlan
             elabBuildOptions =
               LBC.BuildOptions
                 { withVanillaLib = perPkgOptionFlag pkgid True packageConfigVanillaLib -- TODO: [required feature]: also needs to be handled recursively
-                , withSharedLib = pkgid `Set.member` pkgsUseSharedLibrary
+                , withSharedLib = canBuildSharedLibs && pkgid `Set.member` pkgsUseSharedLibrary
                 , withStaticLib = perPkgOptionFlag pkgid False packageConfigStaticLib
                 , withDynExe = perPkgOptionFlag pkgid False packageConfigDynExe
                 , withFullyStaticExe = perPkgOptionFlag pkgid False packageConfigFullyStaticExe
                 , withGHCiLib = perPkgOptionFlag pkgid False packageConfigGHCiLib -- TODO: [required feature] needs to default to enabled on windows still
                 , withProfExe = perPkgOptionFlag pkgid False packageConfigProf
-                , withProfLib = pkgid `Set.member` pkgsUseProfilingLibrary
+                , withProfLib = canBuildProfilingLibs && pkgid `Set.member` pkgsUseProfilingLibrary
+                , withProfLibShared = canBuildProfilingSharedLibs && pkgid `Set.member` pkgsUseProfilingLibraryShared
                 , exeCoverage = perPkgOptionFlag pkgid False packageConfigCoverage
                 , libCoverage = perPkgOptionFlag pkgid False packageConfigCoverage
                 , withOptimization = perPkgOptionFlag pkgid NormalOptimisation packageConfigOptimization
@@ -2377,35 +2386,112 @@ elaborateInstallPlan
       pkgsUseSharedLibrary :: Set PackageId
       pkgsUseSharedLibrary =
         packagesWithLibDepsDownwardClosedProperty needsSharedLib
+
+      needsSharedLib pkgid =
+        fromMaybe
+          compilerShouldUseSharedLibByDefault
+          -- Case 1: --enable-shared or --disable-shared is passed explicitly, honour that.
+          ( case pkgSharedLib of
+              Just v -> Just v
+              Nothing -> case pkgDynExe of
+                -- case 2: If --enable-executable-dynamic is passed then turn on
+                -- shared library generation.
+                Just True ->
+                  -- Case 3: If --enable-profiling is passed, then we are going to
+                  -- build profiled dynamic, so no need for shared libraries.
+                  case pkgProf of
+                    Just True -> if canBuildProfilingSharedLibs then Nothing else Just True
+                    _ -> Just True
+                -- But don't necessarily turn off shared library generation if
+                -- --disable-executable-dynamic is passed. The shared objects might
+                -- be needed for something different.
+                _ -> Nothing
+          )
         where
-          needsSharedLib pkg =
-            fromMaybe
-              compilerShouldUseSharedLibByDefault
-              (liftM2 (||) pkgSharedLib pkgDynExe)
-            where
-              pkgid = packageId pkg
-              pkgSharedLib = perPkgOptionMaybe pkgid packageConfigSharedLib
-              pkgDynExe = perPkgOptionMaybe pkgid packageConfigDynExe
+          pkgSharedLib = perPkgOptionMaybe pkgid packageConfigSharedLib
+          pkgDynExe = perPkgOptionMaybe pkgid packageConfigDynExe
+          pkgProf = perPkgOptionMaybe pkgid packageConfigProf
 
       -- TODO: [code cleanup] move this into the Cabal lib. It's currently open
       -- coded in Distribution.Simple.Configure, but should be made a proper
       -- function of the Compiler or CompilerInfo.
       compilerShouldUseSharedLibByDefault =
         case compilerFlavor compiler of
-          GHC -> GHC.isDynamic compiler
+          GHC -> GHC.compilerBuildWay compiler == DynWay && canBuildSharedLibs
           GHCJS -> GHCJS.isDynamic compiler
           _ -> False
+
+      compilerShouldUseProfilingLibByDefault =
+        case compilerFlavor compiler of
+          GHC -> GHC.compilerBuildWay compiler == ProfWay && canBuildProfilingLibs
+          _ -> False
+
+      compilerShouldUseProfilingSharedLibByDefault =
+        case compilerFlavor compiler of
+          GHC -> GHC.compilerBuildWay compiler == ProfDynWay && canBuildProfilingSharedLibs
+          _ -> False
+
+      -- Returns False if we definitely can't build shared libs
+      canBuildWayLibs predicate = case predicate compiler of
+        Just can_build -> can_build
+        -- If we don't know for certain, just assume we can
+        -- which matches behaviour in previous cabal releases
+        Nothing -> True
+
+      canBuildSharedLibs = canBuildWayLibs dynamicSupported
+      canBuildProfilingLibs = canBuildWayLibs profilingVanillaSupported
+      canBuildProfilingSharedLibs = canBuildWayLibs profilingDynamicSupported
+
+      wayWarnings pkg = do
+        when
+          (needsProfilingLib pkg && not canBuildProfilingLibs)
+          (warnProgress (text "Compiler does not support building p libraries, profiling is disabled"))
+        when
+          (needsSharedLib pkg && not canBuildSharedLibs)
+          (warnProgress (text "Compiler does not support building dyn libraries, dynamic libraries are disabled"))
+        when
+          (needsProfilingLibShared pkg && not canBuildProfilingSharedLibs)
+          (warnProgress (text "Compiler does not support building p_dyn libraries, profiling dynamic libraries are disabled."))
 
       pkgsUseProfilingLibrary :: Set PackageId
       pkgsUseProfilingLibrary =
         packagesWithLibDepsDownwardClosedProperty needsProfilingLib
+
+      needsProfilingLib pkg =
+        fromFlagOrDefault compilerShouldUseProfilingLibByDefault (profBothFlag <> profLibFlag)
         where
-          needsProfilingLib pkg =
-            fromFlagOrDefault False (profBothFlag <> profLibFlag)
-            where
-              pkgid = packageId pkg
-              profBothFlag = lookupPerPkgOption pkgid packageConfigProf
-              profLibFlag = lookupPerPkgOption pkgid packageConfigProfLib
+          pkgid = packageId pkg
+          profBothFlag = lookupPerPkgOption pkgid packageConfigProf
+          profLibFlag = lookupPerPkgOption pkgid packageConfigProfLib
+
+      pkgsUseProfilingLibraryShared :: Set PackageId
+      pkgsUseProfilingLibraryShared =
+        packagesWithLibDepsDownwardClosedProperty needsProfilingLibShared
+
+      needsProfilingLibShared pkg =
+        fromMaybe
+          compilerShouldUseProfilingSharedLibByDefault
+          -- case 1: If --enable-profiling-shared is passed explicitly, honour that
+          ( case profLibSharedFlag of
+              Just v -> Just v
+              Nothing -> case pkgDynExe of
+                Just True ->
+                  case pkgProf of
+                    -- case 2: --enable-executable-dynamic + --enable-profiling
+                    -- turn on shared profiling libraries
+                    Just True -> if canBuildProfilingSharedLibs then Just True else Nothing
+                    _ -> Nothing
+                -- But don't necessarily turn off shared library generation is
+                -- --disable-executable-dynamic is passed. The shared objects might
+                -- be needed for something different.
+                _ -> Nothing
+          )
+        where
+          pkgid = packageId pkg
+          profLibSharedFlag = perPkgOptionMaybe pkgid packageConfigProfShared
+          pkgDynExe = perPkgOptionMaybe pkgid packageConfigDynExe
+          pkgProf = perPkgOptionMaybe pkgid packageConfigProf
+
       -- TODO: [code cleanup] unused: the old deprecated packageConfigProfExe
 
       libDepGraph =
@@ -2422,7 +2508,7 @@ elaborateInstallPlan
             libDepGraph
             [ Graph.nodeKey pkg
             | pkg <- SolverInstallPlan.toList solverPlan
-            , property pkg -- just the packages that satisfy the property
+            , property (packageId pkg) -- just the packages that satisfy the property
             -- TODO: [nice to have] this does not check the config consistency,
             -- e.g. a package explicitly turning off profiling, but something
             -- depending on it that needs profiling. This really needs a separate
@@ -3837,7 +3923,7 @@ setupHsConfigureFlags
     sanityCheckElaboratedConfiguredPackage
       sharedConfig
       elab
-      (Cabal.ConfigFlags{..})
+      Cabal.ConfigFlags{..}
     where
       Cabal.ConfigFlags
         { configVanillaLib
@@ -3848,6 +3934,7 @@ setupHsConfigureFlags
         , configGHCiLib
         , -- , configProfExe -- overridden
         configProfLib
+        , configProfShared
         , -- , configProf -- overridden
         configProfDetail
         , configProfLibDetail

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -679,7 +679,7 @@ filterConfigureFlags' :: ConfigFlags -> Version -> ConfigFlags
 filterConfigureFlags' flags cabalLibVersion
   -- NB: we expect the latest version to be the most common case,
   -- so test it first.
-  | cabalLibVersion >= mkVersion [3, 11, 0] = flags_latest
+  | cabalLibVersion >= mkVersion [3, 13, 0] = flags_latest
   -- The naming convention is that flags_version gives flags with
   -- all flags *introduced* in version eliminated.
   -- It is NOT the latest version of Cabal library that
@@ -701,6 +701,7 @@ filterConfigureFlags' flags cabalLibVersion
   | cabalLibVersion < mkVersion [2, 5, 0] = flags_2_5_0
   | cabalLibVersion < mkVersion [3, 7, 0] = flags_3_7_0
   | cabalLibVersion < mkVersion [3, 11, 0] = flags_3_11_0
+  | cabalLibVersion < mkVersion [3, 13, 0] = flags_3_13_0
   | otherwise = error "the impossible just happened" -- see first guard
   where
     flags_latest =
@@ -712,8 +713,15 @@ filterConfigureFlags' flags cabalLibVersion
           configConstraints = []
         }
 
-    flags_3_11_0 =
+    flags_3_13_0 =
+      -- Earlier Cabal versions don't understand about ..
       flags_latest
+        { -- Building profiled shared libraries
+          configProfShared = NoFlag
+        }
+
+    flags_3_11_0 =
+      flags_3_13_0
         { -- It's too late to convert configPromisedDependencies to anything
           -- meaningful, so we just assert that it's empty.
           -- We add a Cabal>=3.11 constraint before solving when multi-repl is
@@ -783,7 +791,7 @@ filterConfigureFlags' flags cabalLibVersion
     -- Cabal < 1.23 doesn't know about '--profiling-detail'.
     -- Cabal < 1.23 has a hacked up version of 'enable-profiling'
     -- which we shouldn't use.
-    (tryLibProfiling, tryExeProfiling) = computeEffectiveProfiling flags
+    (tryLibProfiling, _tryLibProfilingShared, tryExeProfiling) = computeEffectiveProfiling flags
     flags_1_23_0 =
       flags_1_25_0
         { configProfDetail = NoFlag

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -683,6 +683,7 @@ instance Arbitrary PackageConfig where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
       <*> shortListOf 5 arbitraryShortToken
       <*> arbitrary
       <*> arbitrary
@@ -751,6 +752,7 @@ instance Arbitrary PackageConfig where
       , packageConfigFullyStaticExe = x50
       , packageConfigProf = x07
       , packageConfigProfLib = x08
+      , packageConfigProfShared = x08_1
       , packageConfigProfExe = x09
       , packageConfigProfDetail = x10
       , packageConfigProfLibDetail = x11
@@ -814,6 +816,7 @@ instance Arbitrary PackageConfig where
         , packageConfigFullyStaticExe = x50'
         , packageConfigProf = x07'
         , packageConfigProfLib = x08'
+        , packageConfigProfShared = x08_1'
         , packageConfigProfExe = x09'
         , packageConfigProfDetail = x10'
         , packageConfigProfLibDetail = x11'
@@ -866,7 +869,7 @@ instance Arbitrary PackageConfig where
         , packageConfigBenchmarkOptions = x52'
         }
       | ( ( (x00', x01', x02', x03', x04')
-            , (x05', x42', x06', x50', x07', x08', x09')
+            , (x05', x42', x06', x50', x07', x08', x08_1', x09')
             , (x10', x11', x12', x13', x14')
             , (x15', x16', x53', x17', x18', x19')
             )
@@ -883,7 +886,7 @@ instance Arbitrary PackageConfig where
           shrink
             (
               ( (preShrink_Paths x00, preShrink_Args x01, x02, x03, x04)
-              , (x05, x42, x06, x50, x07, x08, x09)
+              , (x05, x42, x06, x50, x07, x08, x08_1, x09)
               , (x10, x11, map NonEmpty x12, x13, x14)
               ,
                 ( x15

--- a/cabal-testsuite/PackageTests/ProfShared/Lib.hs
+++ b/cabal-testsuite/PackageTests/ProfShared/Lib.hs
@@ -1,0 +1,3 @@
+module Lib where
+
+lib = 10

--- a/cabal-testsuite/PackageTests/ProfShared/exe/Prof.hs
+++ b/cabal-testsuite/PackageTests/ProfShared/exe/Prof.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Lib
+
+main = print lib

--- a/cabal-testsuite/PackageTests/ProfShared/profShared.cabal
+++ b/cabal-testsuite/PackageTests/ProfShared/profShared.cabal
@@ -1,0 +1,13 @@
+Cabal-Version: 3.8
+Name: prof-shared
+Version: 0.1
+Build-Type: Simple
+
+library
+    exposed-modules: Lib
+    Build-Depends: base
+
+executable Prof
+  main-is: Prof.hs
+  hs-source-dirs: exe
+  build-depends: base, prof-shared

--- a/cabal-testsuite/PackageTests/ProfShared/setup.test.hs
+++ b/cabal-testsuite/PackageTests/ProfShared/setup.test.hs
@@ -1,0 +1,145 @@
+import Test.Cabal.Prelude
+import Data.List
+import Data.Bifunctor
+
+data BuildWay = StaticWay | DynWay | ProfWay | ProfDynWay
+        deriving (Eq, Ord, Show, Read, Enum)
+
+-- Test building with profiling shared support
+main = do
+    setupTest $ recordMode DoNotRecord $ do
+        has_prof_shared <- hasProfiledSharedLibraries
+        has_shared <- hasSharedLibraries
+        -- Tests are not robust against missing dynamic libraries yet. Would
+        -- be better to fix this.
+        skipUnless "Missing shared libraries" has_shared
+
+    let analyse_result expected r = do
+
+          let ls = lines (resultOutput r)
+
+              library_prefix = "Wanted build ways(True): "
+              executable_prefix = "Wanted build ways(False): "
+
+              get_ways prefix = map (drop (length prefix)) (filter (prefix `isPrefixOf`) ls)
+              library_ways = read_ways (get_ways library_prefix)
+              executable_ways = read_ways (get_ways executable_prefix)
+
+              read_ways raw_ways =
+                case raw_ways of
+                  -- There should only be one
+                  [x] -> (read :: String -> [BuildWay]) x
+                  -- Unless there are none, when we don't built the executable for example
+                  [] -> []
+                  xs -> error "Unexpected number of log lines"
+
+              way = (library_ways, executable_ways)
+
+          unless (bimap (nub . sort) (nub . sort) expected == bimap (nub . sort) (nub . sort) way) $
+            assertFailure $ "Expected:" ++ show expected ++ "\n" ++ "Got:" ++ show way
+
+          requireSuccess r
+    setupTest $ recordMode DoNotRecord $ do
+
+        has_prof_shared <- hasProfiledSharedLibraries
+        has_shared <- hasSharedLibraries
+
+        let v = [ StaticWay ]
+            dyn = [ DynWay | has_shared ]
+            p_dyn = if has_prof_shared then [ProfDynWay] else p
+            p = [ ProfWay ]
+            none = []
+
+        let run_test args expected =  do
+              setup "configure" args
+              res <- setup' "build" []
+              analyse_result expected res
+              setup "clean" []
+
+
+        run_test []
+          (v <> dyn, v)
+
+
+        run_test ["--disable-library-vanilla", "--enable-executable-dynamic"]
+          (dyn, dyn)
+
+        run_test ["--enable-profiling-shared"]
+          (v <> dyn <> p_dyn, v)
+
+        run_test ["--enable-profiling-shared", "--enable-executable-dynamic"]
+          (v <> dyn <> p_dyn, dyn)
+
+        run_test ["--enable-executable-dynamic", "--disable-library-vanilla"]
+          (dyn, dyn)
+
+        run_test ["--enable-profiling"]
+          (v <> dyn <> p, p)
+
+        run_test ["--enable-executable-profiling"]
+          (v <> dyn <> p, p)
+
+        run_test ["--enable-executable-profiling", "--enable-executable-dynamic"]
+          (v <> dyn <> p_dyn, p_dyn)
+
+        run_test ["--enable-profiling", "--enable-executable-dynamic"]
+          (v <> dyn <> p_dyn, p_dyn)
+
+        --v dyn p (p exe)
+        run_test ["--enable-library-profiling", "--enable-executable-profiling"]
+          (v <> dyn <> p, p)
+
+        run_test ["prof-shared", "--enable-profiling-shared", "--disable-library-vanilla", "--disable-shared"]
+          (p_dyn, none)
+
+        -- p p_dyn
+        run_test ["prof-shared", "--enable-profiling-shared", "--enable-library-profiling", "--disable-library-vanilla", "--disable-shared"]
+          (p <> p_dyn, [])
+
+        -- v p p_dyn
+        run_test ["prof-shared","--enable-profiling-shared", "--enable-library-profiling", "--enable-library-vanilla", "--disable-shared"]
+          (v <> p <> p_dyn, none)
+
+        -- v dyn p p_dyn
+        run_test ["prof-shared", "--enable-profiling-shared", "--enable-library-profiling", "--enable-library-vanilla", "--enable-shared"]
+          (v <> dyn <> p <> p_dyn, none)
+
+    let run_cabal_test args expected =  cabalTest $ recordMode DoNotRecord $ do
+          has_prof_shared <- hasProfiledSharedLibraries
+          has_shared <- hasSharedLibraries
+          -- See GHC commit e400b9babdcf11669f963aeec20078fe7ccfca0d
+          -- Only installing profiled library is broken on very old ghc-pkg versions
+          broken_ghc_pkg <- isGhcVersion "<= 8.6.5"
+
+          let cvt_l StaticWay = [ StaticWay ]
+              cvt_l DynWay = [ DynWay | has_shared ]
+              cvt_l ProfDynWay = [ProfDynWay | has_prof_shared ]
+              cvt_l ProfWay = [ ProfWay ]
+
+          let cvt_e StaticWay =  StaticWay
+              cvt_e DynWay = if has_shared then DynWay else error "DynWay"
+              cvt_e ProfDynWay = if has_prof_shared then ProfDynWay else ProfWay
+              cvt_e ProfWay = ProfWay
+
+          unless (broken_ghc_pkg && (fst expected == [ProfWay])) $ do
+            res <- cabal' "v2-build" args
+            void $ analyse_result (bimap (concatMap cvt_l) (map cvt_e) expected) res
+
+    run_cabal_test ["--disable-shared"] ([StaticWay], [StaticWay])
+    run_cabal_test ["--disable-shared", "--disable-executable-dynamic"] ([StaticWay], [StaticWay])
+    run_cabal_test ["--enable-shared"] ([DynWay, StaticWay], [StaticWay])
+    run_cabal_test ["--enable-executable-dynamic"] ([DynWay, StaticWay], [DynWay])
+    run_cabal_test ["--enable-shared", "--disable-library-vanilla", "--enable-executable-dynamic"] ([DynWay], [DynWay])
+
+    run_cabal_test ["--disable-shared", "--disable-library-vanilla", "--enable-profiling"] ([ProfWay], [ProfWay])
+
+    run_cabal_test ["--disable-shared", "--enable-profiling"] ([ProfWay, StaticWay], [ProfWay])
+
+    run_cabal_test ["--disable-shared", "--enable-profiling-shared", "--enable-profiling"] ([ProfDynWay, ProfWay, StaticWay], [ProfWay])
+
+    run_cabal_test ["--disable-shared", "--enable-profiling", "--enable-profiling-shared", "--enable-executable-dynamic"] ([ProfWay, ProfDynWay, StaticWay], [ProfDynWay])
+
+    run_cabal_test ["--enable-profiling", "--enable-executable-dynamic"] ([ProfDynWay, ProfWay, DynWay, StaticWay], [ProfDynWay])
+
+    run_cabal_test ["prof-shared", "--disable-library-profiling", "--enable-profiling", "--enable-executable-dynamic"] ([ProfDynWay, DynWay, StaticWay], [])
+

--- a/cabal-testsuite/PackageTests/ProfSharedWarning/Lib.hs
+++ b/cabal-testsuite/PackageTests/ProfSharedWarning/Lib.hs
@@ -1,0 +1,3 @@
+module Lib where
+
+lib = 10

--- a/cabal-testsuite/PackageTests/ProfSharedWarning/cabal.project
+++ b/cabal-testsuite/PackageTests/ProfSharedWarning/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/ProfSharedWarning/exe/Prof.hs
+++ b/cabal-testsuite/PackageTests/ProfSharedWarning/exe/Prof.hs
@@ -1,0 +1,5 @@
+module Main where
+
+import Lib
+
+main = print lib

--- a/cabal-testsuite/PackageTests/ProfSharedWarning/profShared.cabal
+++ b/cabal-testsuite/PackageTests/ProfSharedWarning/profShared.cabal
@@ -1,0 +1,13 @@
+Cabal-Version: 3.8
+Name: prof-shared
+Version: 0.1
+Build-Type: Simple
+
+library
+    exposed-modules: Lib
+    Build-Depends: base
+
+executable Prof
+  main-is: Prof.hs
+  hs-source-dirs: exe
+  build-depends: base, prof-shared

--- a/cabal-testsuite/PackageTests/ProfSharedWarning/setup.out
+++ b/cabal-testsuite/PackageTests/ProfSharedWarning/setup.out
@@ -1,0 +1,3 @@
+# Setup configure
+Configuring prof-shared-0.1...
+Warning: Executables will use dynamic linking, but a shared library is not being built. Linking will fail if any executables depend on the library.

--- a/cabal-testsuite/PackageTests/ProfSharedWarning/setup_prof.out
+++ b/cabal-testsuite/PackageTests/ProfSharedWarning/setup_prof.out
@@ -1,0 +1,4 @@
+# Setup configure
+Configuring prof-shared-0.1...
+Warning: The flag --enable-executable-profiling is deprecated. Please use --enable-profiling instead.
+Warning: Executables will use profiled dynamic linking, but a profiled shared library is not being built. Linking will fail if any executables depend on the library.

--- a/changelog.d/issue-4816
+++ b/changelog.d/issue-4816
@@ -1,0 +1,23 @@
+synopsis: Add support for building profiled dynamic way
+packages: Cabal Cabal-syntax cabal-install
+prs: #9900
+issues: #4816
+
+description: {
+Add support for profiled dynamic way
+
+New options for cabal.project and ./Setup interface:
+
+* `profiling-shared`: Enable building profiling dynamic way
+* Passing `--enable-profiling` and `--enable-executable-dynamic` builds
+  profiled dynamic executables.
+
+Support for using `profiling-shared` is guarded behind a constraint
+which ensures you are using `Cabal >= 3.13`.
+
+In the cabal file:
+
+* `ghc-prof-shared-options`, for passing options when building in
+  profiling dynamic way
+
+}

--- a/changelog.d/issue-4816-2
+++ b/changelog.d/issue-4816-2
@@ -1,0 +1,26 @@
+synopsis: Fix interaction of `--*-shared` and `--*-executable-dynamic` options.
+packages: cabal-install
+prs: #9900
+issues: #10050
+
+description: {
+
+If you explicitly request `--disable-shared` it should disable the building of
+a shared library and override any automatic ways this option is turned on.
+
+Passing `--enable-executable-dynamic` turns on `--enable-shared` if the option is
+not specified explicitly.
+
+Before this patch, writing `--disable-shared` on its own would not disable the building of shared libraries. Writing `--disable-shared` and `--disable-executable-dynamic` would disable shared library
+creation (despite `--disable-executable-dynamic` being the default).
+
+Now:
+
+* If you specify `--enable-shared` then shared objects are built.
+* If you specify `--disabled-shared` then shared objects are not built.
+* If you don't explicitly specify whether you want to build shared libraries then
+  * `--enable-executable-dynamic` will automatically turn on building shared libraries
+  * `--enable-executable-dynamic --enable-profiling` will automatically turn on building
+    shared profiling libraries (if supported by your compiler).
+
+}

--- a/doc/buildinfo-fields-reference.rst
+++ b/doc/buildinfo-fields-reference.rst
@@ -387,6 +387,14 @@ ghc-prof-options
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
 
+ghc-prof-shared-options
+    * Monoidal field
+    * Available since ``cabal-version: 3.14``.
+    * Documentation of :pkg-field:`library:ghc-prof-shared-options`
+
+    .. math::
+        {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
+
 ghc-shared-options
     * Monoidal field
     * Documentation of :pkg-field:`library:ghc-shared-options`
@@ -404,6 +412,14 @@ ghcjs-options
 ghcjs-prof-options
     * Monoidal field
     * Documentation of :pkg-field:`library:ghcjs-prof-options`
+
+    .. math::
+        {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}
+
+ghcjs-prof-shared-options
+    * Monoidal field
+    * Available since ``cabal-version: 3.14``.
+    * Documentation of :pkg-field:`library:ghcjs-prof-shared-options`
 
     .. math::
         {\left\{ \mathop{\mathit{hs\text{-}string}}\mid{{[\mathop{\mathord{``}\mathtt{\ }\mathord{"}}]^c}}^+_{} \right\}}^\ast_{\bullet}

--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -1930,6 +1930,13 @@ system-dependent values for these fields.
     ones specified via :pkg-field:`ghc-options`, and are passed to GHC during
     both the compile and link phases.
 
+.. pkg-field:: ghc-prof-shared-options: token list
+
+    Additional options for GHC when the package is built as shared profiling
+    library. The options specified via this field are combined with the
+    ones specified via :pkg-field:`ghc-options`, and are passed to GHC during
+    both the compile and link phases.
+
 .. pkg-field:: ghcjs-options: token list
 
    Like :pkg-field:`ghc-options` but applies to GHCJS
@@ -1941,6 +1948,10 @@ system-dependent values for these fields.
 .. pkg-field:: ghcjs-shared-options: token list
 
    Like :pkg-field:`ghc-shared-options` but applies to GHCJS
+
+.. pkg-field:: ghcjs-prof-shared-options: token list
+
+   Like :pkg-field:`ghc-prof-shared-options` but applies to GHCJS
 
 .. pkg-field:: includes: filename list
 

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -795,9 +795,20 @@ Miscellaneous options
     Build shared library. This implies a separate compiler run to
     generate position independent code as required on most platforms.
 
+    ``--enable-shared`` is enabled automatically if GHC is dynamically linked or
+    you request to build dynamic executables.
+
 .. option:: --disable-shared
 
     (default) Do not build shared library.
+
+.. option:: --enable-profiling-shared
+
+   Build a profiling shared library.
+
+.. option:: --disable-profiling-shared
+
+   (default) Do not built a profiling shared library.
 
 .. option:: --enable-static
 


### PR DESCRIPTION
    Add support for profiled dynamic way
    
    New options for cabal.project and ./Setup interface:
    
    * `profiling-shared`: Enable building profiling dynamic way
    * Passing `--enable-profiling` and `--enable-executable-dynamic` builds
      profiled dynamic executables.
    
    Support for using `profiling-shared` is guarded behind a constraint
    which ensures you are using `Cabal >= 3.13`.
    
    In the cabal file:
    
    * `ghc-prof-shared-options`, for passing options when building in
      profiling dynamic way
    
    Other miscellenious fixes and improvements
    
    * Some refactoring around ways so that which
      ways we should build for a library, foreign library and executable is
      computed by the `buildWays` function (rather than ad-hoc in three
      different places).
    
    * Improved logic for detecting whether a compiler supports compiling
      a specific way. See functions `profilingVanillaSupported`,
      `dynamicSupported`, `profilingDynamicSupported` etc
      These functions report accurate infomation after ghc-9.10.1.
    
    * Fixed logic for determining whether to build shared libraries. (see
      #10050)
      Now, if you explicitly enable `--*-shared`, then that will always take
      effect. If it's not specified then `--enable-executable-dynamic` will
      turn on shared libraries IF `--enable-profiling` is not enabled.
    
    * Remove assumption that dynamically linked compilers can build dynamic
      libraries (they might be cross compilers.
    
    * Query the build compiler to determine which library way is necessary
      to be built for TH support to work.
      (rather than assume all compilers are dynamically linked)
    
    * An extensive test which checks how options for `./Setup` and
      `cabal-install` are translated into build ways.
    
    Fixes #4816, #10049, #10050