### PR TITLE
Fix release notes grammar

### DIFF
--- a/release-notes/Cabal-3.12.0.0.md
+++ b/release-notes/Cabal-3.12.0.0.md
@@ -66,7 +66,7 @@ Cabal and Cabal-syntax 3.12.0.0 changelog and release notes
 - `cabal init` should not suggest Cabal < 2.0 [#8680](https://github.com/haskell/cabal/issues/8680)
 
     'cabal init' no longer suggests users to set cabal-version to less than
-    2.0
+    2.0.
 
 - Remove Distribution.Utils.TempTestDir module from Cabal library [#9453](https://github.com/haskell/cabal/issues/9453) [#9454](https://github.com/haskell/cabal/pull/9454)
 
@@ -76,7 +76,7 @@ Cabal and Cabal-syntax 3.12.0.0 changelog and release notes
 - PkgConfig individual calls [#9134](https://github.com/haskell/cabal/pull/9134)
 
     `cabal` invokes `pkg-config` individually for each lib if querying for all
-    doesn't return the expected result
+    doesn't return the expected result.
 
 - Split up `Distribution.Simple.Setup` [#8130](https://github.com/haskell/cabal/pull/8130)
 
@@ -94,7 +94,7 @@ Cabal and Cabal-syntax 3.12.0.0 changelog and release notes
 
    - `checkPackage` signature has been simplified,
      you do not need to pass a specific configuration of the package, since
-     we do not flatten GenericPackageDescription no more.
+     we do not flatten GenericPackageDescription any more.
    - `checkPackageFileNames` has been removed,
      use `checkPackageFiles` instead.
    - `checkPackageFilesGPD` has been introduced,

--- a/release-notes/WIP-cabal-install-3.12.x.0.md
+++ b/release-notes/WIP-cabal-install-3.12.x.0.md
@@ -57,8 +57,8 @@ cabal-install and cabal-install-solver 3.12.1.0 changelog and release notes
 
 - Add support for authentication tokens for uploading to Hackage [#6738](https://github.com/haskell/cabal/issues/6738) [#9058](https://github.com/haskell/cabal/pull/9058)
 
-    A new flag `--token` (`-t`) has been created. Token authentication takes 
-    precedence over username and password meaning that, if a token is set, 
+    A new flag `--token` (`-t`) has been created. Token authentication takes
+    precedence over username and password meaning that, if a token is set,
     the username and password flags are ignored.
 
 - Make --(test-)show-details=direct the default [#8942](https://github.com/haskell/cabal/pull/8942)


### PR DESCRIPTION
See #9920.

---

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ n/a

