### PR TITLE
Downgrade NoLibraryFound from an error to a warning

### DIFF
--- a/Cabal/src/Distribution/Simple/Errors.hs
+++ b/Cabal/src/Distribution/Simple/Errors.hs
@@ -47,7 +47,8 @@ data CabalException
   | EnableBenchMark
   | BenchMarkNameDisabled String
   | NoBenchMark String
-  | NoLibraryFound
+  | -- | @NoLibraryFound@ has been downgraded to a warning, and is therefore no longer emitted.
+    NoLibraryFound
   | CompilerNotInstalled CompilerFlavor
   | CantFindIncludeFile String
   | UnsupportedTestSuite String

--- a/Cabal/src/Distribution/Simple/Install.hs
+++ b/Cabal/src/Distribution/Simple/Install.hs
@@ -147,7 +147,7 @@ install_setupHooks
 
       checkHasLibsOrExes =
         unless (hasLibs pkg_descr || hasForeignLibs pkg_descr || hasExes pkg_descr) $
-          dieWithException verbosity NoLibraryFound
+          warn verbosity "No executables and no library found. Nothing to do."
 
 -- | Copy package global files.
 copyPackage

--- a/cabal-testsuite/PackageTests/OnlyTestSuite/OnlyTestSuite.cabal
+++ b/cabal-testsuite/PackageTests/OnlyTestSuite/OnlyTestSuite.cabal
@@ -1,0 +1,15 @@
+cabal-version:      3.0
+name:               OnlyTestSuite
+version:            0.1.0.0
+build-type:         Simple
+
+common warnings
+    ghc-options: -Wall
+
+test-suite OnlyTestSuite-test
+    import:           warnings
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Main.hs
+    build-depends:    base

--- a/cabal-testsuite/PackageTests/OnlyTestSuite/cabal.cabal.out
+++ b/cabal-testsuite/PackageTests/OnlyTestSuite/cabal.cabal.out
@@ -1,0 +1,6 @@
+# Setup configure
+Configuring OnlyTestSuite-0.1.0.0...
+# Setup build
+Building OnlyTestSuite-0.1.0.0...
+# Setup copy
+Warning: No executables and no library found. Nothing to do.

--- a/cabal-testsuite/PackageTests/OnlyTestSuite/cabal.out
+++ b/cabal-testsuite/PackageTests/OnlyTestSuite/cabal.out
@@ -1,0 +1,6 @@
+# Setup configure
+Configuring OnlyTestSuite-0.1.0.0...
+# Setup build
+Building OnlyTestSuite-0.1.0.0...
+# Setup copy
+Warning: No executables and no library found. Nothing to do.

--- a/cabal-testsuite/PackageTests/OnlyTestSuite/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/OnlyTestSuite/cabal.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+main = setupAndCabalTest $ do
+  withPackageDb $ do
+    setup "configure" []
+    setup "build" []
+    setup "copy" []

--- a/cabal-testsuite/PackageTests/OnlyTestSuite/test/Main.hs
+++ b/cabal-testsuite/PackageTests/OnlyTestSuite/test/Main.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "Test suite not yet implemented."

--- a/changelog.d/issue-6750
+++ b/changelog.d/issue-6750
@@ -1,0 +1,13 @@
+synopsis: Make Setup copy/install succeed when there's no executable or library
+packages: Cabal
+prs: #9926
+issues: #6750
+
+description: {
+  Historically the Setup copy and install steps would fail if the package didn't
+  contain an executable or library component. In this case there's nothing to do.
+
+  This required workarounds for downstream users of Cabal to handle this edge case.
+  Now that this error has been downgraded to a warning, Cabal will succeed if 
+  there's nothing to do.
+}


### PR DESCRIPTION
This makes Setup copy/install succeed if there's
nothing to do because the package doesn't contain
a library or executable.

This allows downstream users of Cabal to avoid having to add workarounds for this edge case.

Resolves #6750

Let me know what you think. If this sounds OK, I'll add a test case, which test suite would be best?

---

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

