### PR TITLE
Use alice as username in cabal path examples

### DIFF
--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -294,36 +294,41 @@ installed binaries, and so on.
 
 ::
 
+    $ whoami
+    alice
+
     $ cabal path
-    cache-home: /home/haskell/.cache/cabal/
-    remote-repo-cache: /home/haskell/.cache/cabal/packages
-    logs-dir: /home/haskell/.cache/cabal/logs
-    store-dir: /home/haskell/.local/state/cabal/store
-    config-file: /home/haskell/.config/cabal/config
-    installdir: /home/haskell/.local/bin
-    ...
+    compiler-flavour: ghc
+    compiler-id: ghc-9.8.2
+    compiler-path: /home/alice/.ghcup/bin/ghc
+    cache-home: /home/alice/.cabal
+    remote-repo-cache: /home/alice/.cabal/packages
+    logs-dir: /home/alice/.cabal/logs
+    store-dir: /home/alice/.cabal/store
+    config-file: /home/alice/.cabal/config
+    installdir: /home/alice/.cabal/bin
 
 Or using the json output:
 
 ::
 
-    $ cabal path --output-format=json
+    $ cabal path --output-format=json | jq
 
 .. code-block:: json
 
     {
-        "cabal-version": "3.13.0.0",
-        "compiler": {
-            "flavour": "ghc",
-            "id": "ghc-9.6.4",
-            "path": "/home/user/.ghcup/bin/ghc"
-        },
-        "cache-home": "/home/user/.cabal",
-        "remote-repo-cache": "/home/user/.cabal/packages",
-        "logs-dir": "/home/user/.cabal/logs",
-        "store-dir": "/home/user/.cabal/store",
-        "config-file": "/home/user/.cabal/config",
-        "installdir": "/home/user/.cabal/bin"
+      "cabal-version": "3.13.0.0",
+      "compiler": {
+        "flavour": "ghc",
+        "id": "ghc-9.8.2",
+        "path": "/home/alice/.ghcup/bin/ghc"
+      },
+      "cache-home": "/home/alice/.cabal",
+      "remote-repo-cache": "/home/alice/.cabal/packages",
+      "logs-dir": "/home/alice/.cabal/logs",
+      "store-dir": "/home/alice/.cabal/store",
+      "config-file": "/home/alice/.cabal/config",
+      "installdir": "/home/alice/.cabal/bin"
     }
 
 If ``cabal path`` is passed a single option naming a path, then that
@@ -332,7 +337,7 @@ path will be printed *without* any label:
 ::
 
    $ cabal path --installdir
-   /home/haskell/.local/bin
+   /home/alice/.cabal/bin
 
 While this interface is intended to be used for scripting, it is an experimental command.
 Scripting example:


### PR DESCRIPTION
Fixes #9930 using a common [placeholder name](https://en.wikipedia.org/wiki/Placeholder_name), Alice of Alice and Bob. A follow on from #9583.

