### PR TITLE
Detect duplicate non-cyclical project imports

### DIFF
--- a/cabal-testsuite/PackageTests/ConditionalAndImport/cabal.out
+++ b/cabal-testsuite/PackageTests/ConditionalAndImport/cabal.out
@@ -254,131 +254,17 @@ Could not resolve dependencies:
       (constraint from oops-0.project requires ==1.4.3.0)
 [__1] fail (backjumping, conflict set: hashable, oops)
 After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: hashable (3), oops (2)
-# checking if we detect when the same config is imported via many different paths (we don't)
+# checking that we detect when the same config is imported via many different paths
 # cabal v2-build
-Configuration is affected by the following files:
-- yops-0.project
-- yops-2.config
-    imported by: yops/yops-1.config
+Error: [Cabal-7090]
+Error parsing project file <ROOT>/yops-0.project:
+duplicate import of yops/yops-3.config;
+  yops/yops-3.config
     imported by: yops-0.project
-- yops-4.config
-    imported by: yops/yops-3.config
-    imported by: yops-0.project
-- yops-4.config
-    imported by: yops/yops-3.config
+  yops/yops-3.config
     imported by: yops-2.config
     imported by: yops/yops-1.config
     imported by: yops-0.project
-- yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-0.project
-- yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-4.config
-    imported by: yops/yops-3.config
-    imported by: yops-0.project
-- yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-4.config
-    imported by: yops/yops-3.config
-    imported by: yops-2.config
-    imported by: yops/yops-1.config
-    imported by: yops-0.project
-- yops-8.config
-    imported by: yops/yops-7.config
-    imported by: yops-0.project
-- yops-8.config
-    imported by: yops/yops-7.config
-    imported by: yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-0.project
-- yops-8.config
-    imported by: yops/yops-7.config
-    imported by: yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-4.config
-    imported by: yops/yops-3.config
-    imported by: yops-0.project
-- yops-8.config
-    imported by: yops/yops-7.config
-    imported by: yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-4.config
-    imported by: yops/yops-3.config
-    imported by: yops-2.config
-    imported by: yops/yops-1.config
-    imported by: yops-0.project
-- yops/yops-1.config
-    imported by: yops-0.project
-- yops/yops-3.config
-    imported by: yops-0.project
-- yops/yops-3.config
-    imported by: yops-2.config
-    imported by: yops/yops-1.config
-    imported by: yops-0.project
-- yops/yops-5.config
-    imported by: yops-0.project
-- yops/yops-5.config
-    imported by: yops-4.config
-    imported by: yops/yops-3.config
-    imported by: yops-0.project
-- yops/yops-5.config
-    imported by: yops-4.config
-    imported by: yops/yops-3.config
-    imported by: yops-2.config
-    imported by: yops/yops-1.config
-    imported by: yops-0.project
-- yops/yops-7.config
-    imported by: yops-0.project
-- yops/yops-7.config
-    imported by: yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-0.project
-- yops/yops-7.config
-    imported by: yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-4.config
-    imported by: yops/yops-3.config
-    imported by: yops-0.project
-- yops/yops-7.config
-    imported by: yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-4.config
-    imported by: yops/yops-3.config
-    imported by: yops-2.config
-    imported by: yops/yops-1.config
-    imported by: yops-0.project
-- yops/yops-9.config
-    imported by: yops-0.project
-- yops/yops-9.config
-    imported by: yops-8.config
-    imported by: yops/yops-7.config
-    imported by: yops-0.project
-- yops/yops-9.config
-    imported by: yops-8.config
-    imported by: yops/yops-7.config
-    imported by: yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-0.project
-- yops/yops-9.config
-    imported by: yops-8.config
-    imported by: yops/yops-7.config
-    imported by: yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-4.config
-    imported by: yops/yops-3.config
-    imported by: yops-0.project
-- yops/yops-9.config
-    imported by: yops-8.config
-    imported by: yops/yops-7.config
-    imported by: yops-6.config
-    imported by: yops/yops-5.config
-    imported by: yops-4.config
-    imported by: yops/yops-3.config
-    imported by: yops-2.config
-    imported by: yops/yops-1.config
-    imported by: yops-0.project
-Up to date
 # checking bad conditional
 # cabal v2-build
 Error: [Cabal-7090]

--- a/cabal-testsuite/PackageTests/ConditionalAndImport/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ConditionalAndImport/cabal.test.hs
@@ -254,7 +254,7 @@ main = cabalTest . withRepo "repo" . recordMode RecordMarked $ do
   --  +-- yops/yops-9.config (no further imports)
   log "checking that we detect when the same config is imported via many different paths"
   yopping <- fails $ cabal' "v2-build" [ "--project-file=yops-0.project" ]
-  assertOutputContains "duplicate import of yops/yops-3.config" yopping
+  assertOutputContains (normalizeWindowsOutput "duplicate import of yops/yops-3.config") yopping
 
   log "checking bad conditional"
   badIf <- fails $ cabal' "v2-build" [ "--project-file=bad-conditional.project" ]

--- a/cabal-testsuite/PackageTests/ConditionalAndImport/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/ConditionalAndImport/cabal.test.hs
@@ -252,11 +252,9 @@ main = cabalTest . withRepo "repo" . recordMode RecordMarked $ do
   --   +-- yops-8.config
   --    +-- yops/yops-9.config (no further imports)
   --  +-- yops/yops-9.config (no further imports)
-  --
-  -- We don't check and don't error or warn on the same config being imported
-  -- via many different paths.
-  log "checking if we detect when the same config is imported via many different paths (we don't)"
-  yopping <- cabal' "v2-build" [ "--project-file=yops-0.project" ]
+  log "checking that we detect when the same config is imported via many different paths"
+  yopping <- fails $ cabal' "v2-build" [ "--project-file=yops-0.project" ]
+  assertOutputContains "duplicate import of yops/yops-3.config" yopping
 
   log "checking bad conditional"
   badIf <- fails $ cabal' "v2-build" [ "--project-file=bad-conditional.project" ]

--- a/changelog.d/pr-9933
+++ b/changelog.d/pr-9933
@@ -1,0 +1,23 @@
+synopsis: Detect non-cyclical duplicate project imports
+description:
+  Detect and report on duplicate imports that are non-cyclical and expand the
+  detail in cyclical import reporting, being more explicit and consistent with
+  non-cyclical duplicate reporting.
+
+  ```
+  $ cabal build --project-file=yops-0.project
+  ...
+  Error: [Cabal-7090]
+  Error parsing project file yops-0.project:
+  duplicate import of yops/yops-3.config;
+    yops/yops-3.config
+      imported by: yops-0.project
+    yops/yops-3.config
+      imported by: yops-2.config
+      imported by: yops/yops-1.config
+      imported by: yops-0.project
+  ```
+
+packages: cabal-install-solver cabal-install
+prs: #9578 #9933
+issues: #9562


### PR DESCRIPTION
A follow on from #9578. Uses an `IORef` to better report on duplicates (including cycles) and to detect duplicates that are not cycles. This was originally included in #9578 but punted at review, https://github.com/haskell/cabal/pull/9578#issuecomment-1949624489.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)


