### PR TITLE
Add `initialBuildSteps` removal notice

### DIFF
--- a/release-notes/Cabal-3.12.0.0.md
+++ b/release-notes/Cabal-3.12.0.0.md
@@ -70,7 +70,7 @@ Cabal and Cabal-syntax 3.12.0.0 changelog and release notes
   To mimick `initialBuildSteps` behaviour when there is no custom Setup, you
   can call `repl_setupHooks`.
 
-  If you are dealing with a custion setup, you have to invoke
+  If you are dealing with a custom setup, you have to invoke
   `./Setup repl --repl-multi-file`.
 
 ### Other changes

--- a/release-notes/Cabal-3.12.0.0.md
+++ b/release-notes/Cabal-3.12.0.0.md
@@ -61,6 +61,18 @@ Cabal and Cabal-syntax 3.12.0.0 changelog and release notes
   added. It can now be used in the `default-language` and `other-languages`
   fields, and will be offered as an option by `cabal init`.
 
+- Remove `initialBuildSteps` from `Distribution.Simple.Build` [#9474](https://github.com/haskell/cabal/pull/9474)
+
+  Calling `initialBuildSteps` to prepare source files for a package is error
+  prone, as `initialBuildSteps` only handles things like the paths module
+  and nothing else.
+
+  To mimick `initialBuildSteps` behaviour when there is no custom Setup, you
+  can call `repl_setupHooks`.
+
+  If you are dealing with a custion setup, you have to invoke
+  `./Setup repl --repl-multi-file`.
+
 ### Other changes
 
 - `cabal init` should not suggest Cabal < 2.0 [#8680](https://github.com/haskell/cabal/issues/8680)


### PR DESCRIPTION
And suggestion on what to use (`preBuildComponent`) instead.

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ no

