### PR TITLE
Define a user-visible change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,9 +290,13 @@ issues) when appropriate.
 Changelog
 ---------
 
-When opening a pull request with a user-visible change, you should write one changelog entry
-(or more in case of multiple independent changes) — the information will end up in
-our release notes.
+Anything that changes `cabal-install:exe:cabal` or changes exports from library
+modules or changes behaviour of functions exported from packages published to
+hackage is a <a id="user-visible-change">user-visible change</a>.
+
+When opening a pull request with a user-visible change, you should write one
+changelog entry (or more in case of multiple independent changes) — the
+information will end up in our release notes.
 
 Changelogs for the next release are stored in the `changelog.d` directory.
 The files follow a simple key-value format similar to the one for `.cabal` files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,7 +292,9 @@ Changelog
 
 Anything that changes `cabal-install:exe:cabal` or changes exports from library
 modules or changes behaviour of functions exported from packages published to
-hackage is a <a id="user-visible-change">user-visible change</a>.
+hackage is a <a id="user-visible-change">user-visible change</a>. Raising the
+lower bound on `base` is most definitely a user-visible change because it
+excludes versions of GHC from being able to build these packages.
 
 When opening a pull request with a user-visible change, you should write one
 changelog entry (or more in case of multiple independent changes) — the


### PR DESCRIPTION
In support of #9944, define what a user-visible change is in `CONTRIBUTING.md`.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

