### PR TITLE
move 8.8.4 and 8.6.5 to the old-ghcs run

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -68,7 +68,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # If you remove something from here.. then add it to the old-ghcs job.
-        ghc: ['9.8.2', '9.6.4', '9.4.8', '9.2.8', '9.0.2', '8.10.7', '8.8.4', '8.6.5']
+        ghc: ['9.8.2', '9.6.4', '9.4.8', '9.2.8', '9.0.2', '8.10.7']
         exclude:
           # corrupts GHA cache or the fabric of reality itself, see https://github.com/haskell/cabal/issues/8356
           - os: windows-latest
@@ -215,7 +215,7 @@ jobs:
 
     strategy:
       matrix:
-        extra-ghc: ['8.4.4', '8.2.2', '8.0.2']
+        extra-ghc: ['8.8.4', '8.6.5', '8.4.4', '8.2.2', '8.0.2']
           ## GHC 7.10.3 does not install on ubuntu-22.04 with ghcup.
           ## Older GHCs are not supported by ghcup in the first place.
       fail-fast: false


### PR DESCRIPTION
Github has moved `macos-latest` to `macos-14` on ARM, so those jobs can't find a working `ghc` (ARM support started in 8.10.5). The alternative is to split the main validate run in half so that 8.6 and 8.4 can be run on `macos-13` instead of `macos-latest`.

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

