### PR TITLE
emergency switch to macos-13 runner

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -32,7 +32,7 @@ jobs:
         os: [ubuntu-latest]
         ghc: ["8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.4", "9.8.2"]
         include:
-          - os: macos-latest
+          - os: macos-13
             ghc: "9.2.8"
     name: Bootstrap ${{ matrix.os }} ghc-${{ matrix.ghc }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -66,7 +66,7 @@ jobs:
       GHC_FOR_RELEASE: ${{ format('["{0}"]', env.GHC_FOR_RELEASE) }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         # If you remove something from here.. then add it to the old-ghcs job.
         ghc: ['9.8.2', '9.6.4', '9.4.8', '9.2.8', '9.0.2', '8.10.7', '8.8.4', '8.6.5']
         exclude:


### PR DESCRIPTION
https://github.com/haskell/cabal/pull/9947 is the long term solution, but it seems `macos-14` is missing both ghcup and LLVM. This switches us back to `macos-13` for now so CI works.

**Template Β: This PR does not modify `cabal` behaviour (documentation, tests, refactoring, etc.)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

