### PR TITLE
Filter Setup flags: filter working dir on < 3.13

### DIFF
--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -635,22 +635,22 @@ filterCommonFlags :: CommonSetupFlags -> Version -> CommonSetupFlags
 filterCommonFlags flags cabalLibVersion
   -- NB: we expect the latest version to be the most common case,
   -- so test it first.
-  | cabalLibVersion >= mkVersion [3, 11, 0] = flags_latest
+  | cabalLibVersion >= mkVersion [3, 13, 0] = flags_latest
   | cabalLibVersion < mkVersion [1, 2, 5] = flags_1_2_5
   | cabalLibVersion < mkVersion [2, 1, 0] = flags_2_1_0
-  | cabalLibVersion < mkVersion [3, 11, 0] = flags_3_11_0
+  | cabalLibVersion < mkVersion [3, 13, 0] = flags_3_13_0
   | otherwise = error "the impossible just happened" -- see first guard
   where
     flags_latest = flags
-    flags_3_11_0 =
+    flags_3_13_0 =
       flags_latest
         { setupWorkingDir = NoFlag
         }
-    -- Cabal < 3.11 does not support the --working-dir flag.
+    -- Cabal < 3.13 does not support the --working-dir flag.
     flags_2_1_0 =
-      flags_3_11_0
+      flags_3_13_0
         { -- Cabal < 2.1 doesn't know about -v +timestamp modifier
-          setupVerbosity = fmap verboseNoTimestamp (setupVerbosity flags_3_11_0)
+          setupVerbosity = fmap verboseNoTimestamp (setupVerbosity flags_3_13_0)
         }
     flags_1_2_5 =
       flags_2_1_0

--- a/cabal-testsuite/PackageTests/WorkingDir/Main.hs
+++ b/cabal-testsuite/PackageTests/WorkingDir/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Dep(foo)
+
+main :: IO ()
+main = print foo

--- a/cabal-testsuite/PackageTests/WorkingDir/Setup.hs
+++ b/cabal-testsuite/PackageTests/WorkingDir/Setup.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import Distribution.Simple ( defaultMain )
+
+main :: IO ()
+main = defaultMain
+

--- a/cabal-testsuite/PackageTests/WorkingDir/cabal.project
+++ b/cabal-testsuite/PackageTests/WorkingDir/cabal.project
@@ -1,0 +1,1 @@
+packages: ., dep

--- a/cabal-testsuite/PackageTests/WorkingDir/dep/Dep.hs
+++ b/cabal-testsuite/PackageTests/WorkingDir/dep/Dep.hs
@@ -1,0 +1,4 @@
+module Dep where
+
+foo :: Int
+foo = 17

--- a/cabal-testsuite/PackageTests/WorkingDir/dep/Setup.hs
+++ b/cabal-testsuite/PackageTests/WorkingDir/dep/Setup.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import Distribution.Simple ( defaultMain )
+
+main :: IO ()
+main = defaultMain
+

--- a/cabal-testsuite/PackageTests/WorkingDir/dep/dep.cabal
+++ b/cabal-testsuite/PackageTests/WorkingDir/dep/dep.cabal
@@ -1,0 +1,18 @@
+cabal-version:       2.4
+name:                dep
+version:             0.1.0.0
+synopsis:            Test that we don't pass --working-dir when unsupported
+license:             BSD-3-Clause
+author:              NA
+maintainer:          NA
+category:            Testing
+build-type:          Custom
+
+custom-setup
+  setup-depends: base, Cabal >= 2.4 && < 3.13
+
+library
+  build-depends: base
+  default-language: Haskell2010
+  hs-source-dirs: .
+  exposed-modules: Dep

--- a/cabal-testsuite/PackageTests/WorkingDir/setup.test.hs
+++ b/cabal-testsuite/PackageTests/WorkingDir/setup.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ recordMode DoNotRecord $ do
+  skipUnlessAnyCabalVersion "< 3.13"
+  cabalWithStdin "v2-build" [] ""
+  return ()

--- a/cabal-testsuite/PackageTests/WorkingDir/working-dir-test.cabal
+++ b/cabal-testsuite/PackageTests/WorkingDir/working-dir-test.cabal
@@ -1,0 +1,18 @@
+cabal-version:       2.4
+name:                working-dir-test
+version:             0.1.0.0
+synopsis:            Test that we don't pass --working-dir when unsupported
+license:             BSD-3-Clause
+author:              NA
+maintainer:          NA
+category:            Testing
+build-type:          Custom
+
+custom-setup
+  setup-depends: base, Cabal >= 2.4 && < 3.13
+
+executable Exe
+  default-language: Haskell2010
+  build-depends: base, dep
+  hs-source-dirs: .
+  main-is: Main.hs


### PR DESCRIPTION
The --working-dir flag is only available for Cabal >= 3.13. This commit fixes an incorrect conditional: we only filtered out this flag for Cabal < 3.11, instead of < 3.13.

Fixes #9940