### PR TITLE
State supported GHC versions in release notes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,7 +67,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        # If you remove something from here.. then add it to the old-ghcs job.
+        # If you remove something from here, then add it to the old-ghcs job.
+        # Also a removed GHC from here means that we are actually dropping
+        # support, so the PR *must* have a changelog entry.
         ghc: ['9.8.2', '9.6.4', '9.4.8', '9.2.8', '9.0.2', '8.10.7', '8.8.4', '8.6.5']
         exclude:
           # corrupts GHA cache or the fabric of reality itself, see https://github.com/haskell/cabal/issues/8356

--- a/release-notes/Cabal-3.12.0.0.md
+++ b/release-notes/Cabal-3.12.0.0.md
@@ -73,6 +73,10 @@ Cabal and Cabal-syntax 3.12.0.0 changelog and release notes
   If you are dealing with a custom setup, you have to invoke
   `./Setup repl --repl-multi-file`.
 
+- Cabal and Cabal-syntax 3.12 support GHC version 8.4.4 and up.
+
+  Support for all previous GHC versions is deprecated.
+
 ### Other changes
 
 - `cabal init` should not suggest Cabal < 2.0 [#8680](https://github.com/haskell/cabal/issues/8680)


### PR DESCRIPTION
We have a five-year support policy for GHC, but this was never stated in release notes (specifically, list GHCs we stop supporting).
This patch rectifies this for 3.12 release notes, plus I have added a new point to the [“Making a release” document](https://github.com/haskell/cabal/wiki/Making-a-release#c1-preflight-checks), that is: 

> `cabal` has a five-year support window for GHC. Check the [GHC/base table](https://wiki.haskell.org/Base_package), bump `base` lower bound accordingly in all packages, write a changelog file that states we drop support for `GHC x.y`.

---

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ no

