### PR TITLE
update `base` bounds for desupported ghc 8.2

### DIFF
--- a/Cabal-hooks/Cabal-hooks.cabal
+++ b/Cabal-hooks/Cabal-hooks.cabal
@@ -29,7 +29,7 @@ library
   build-depends:
     Cabal-syntax    >= 3.13      && < 3.15,
     Cabal           >= 3.13      && < 3.15,
-    base            >= 4.9       && < 5,
+    base            >= 4.11      && < 5,
     containers      >= 0.5.0.0   && < 0.8,
     filepath        >= 1.3.0.1   && < 1.5,
     transformers    >= 0.5.6.0   && < 0.7

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -29,7 +29,7 @@ library
 
   build-depends:
     array      >= 0.4.0.1  && < 0.6,
-    base       >= 4.9      && < 5,
+    base       >= 4.11     && < 5,
     binary     >= 0.7      && < 0.9,
     bytestring >= 0.10.0.0 && < 0.13,
     containers >= 0.5.0.0  && < 0.8,

--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -57,7 +57,7 @@ test-suite unit-tests
   main-is:          UnitTests.hs
   build-depends:
       array
-    , base                >=4.9     && <5
+    , base                >=4.11    && <5
     , bytestring
     , Cabal
     , Cabal-described

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -36,7 +36,7 @@ library
   build-depends:
     Cabal-syntax ^>= 3.13,
     array      >= 0.4.0.1  && < 0.6,
-    base       >= 4.9      && < 5,
+    base       >= 4.11     && < 5,
     bytestring >= 0.10.0.0 && < 0.13,
     containers >= 0.5.0.0  && < 0.8,
     deepseq    >= 1.3.0.1  && < 1.6,

--- a/cabal-dev-scripts/cabal-dev-scripts.cabal
+++ b/cabal-dev-scripts/cabal-dev-scripts.cabal
@@ -18,7 +18,7 @@ executable gen-spdx
   ghc-options:      -Wall
   build-depends:
     , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.2.1.0
-    , base                  >=4.10     && <4.20
+    , base                  >=4.11     && <4.20
     , bytestring
     , containers
     , Diff                  ^>=0.4
@@ -35,7 +35,7 @@ executable gen-spdx-exc
   ghc-options:      -Wall
   build-depends:
     , aeson                 ^>=1.4.1.0 || ^>=1.5.2.0 || ^>=2.2.1.0
-    , base                  >=4.10     && <4.20
+    , base                  >=4.11     && <4.20
     , bytestring
     , containers
     , Diff                  ^>=0.4

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -99,7 +99,7 @@ library
 
   build-depends:
     , array         >=0.4      && <0.6
-    , base          >=4.10     && <4.20
+    , base          >=4.11     && <4.20
     , bytestring    >=0.10.6.0 && <0.13
     , Cabal         ^>=3.13
     , Cabal-syntax  ^>=3.13
@@ -131,7 +131,7 @@ Test-Suite unit-tests
      UnitTests.Distribution.Solver.Modular.MessageUtils
 
    build-depends:
-     , base        >= 4.10  && <4.20
+     , base        >= 4.11  && <4.20
      , Cabal-syntax
      , cabal-install-solver
      , tasty       >= 1.2.3 && <1.6

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -52,7 +52,7 @@ common warnings
       ghc-options: -Wnoncanonical-monadfail-instances
 
 common base-dep
-    build-depends: base >=4.10 && <4.20
+    build-depends: base >=4.11 && <4.20
 
 common cabal-dep
     build-depends: Cabal ^>=3.13

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -26,7 +26,7 @@ common shared
   default-language: Haskell2010
 
   build-depends:
-    , base >= 4.9 && < 4.20
+    , base >= 4.11 && < 4.20
     -- this needs to match the in-tree lib:Cabal version
     , Cabal ^>= 3.13.0.0
 


### PR DESCRIPTION
Per https://github.com/haskell/cabal/issues/9952#issuecomment-2088287364.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
