### PR TITLE
Haddock: use buildSettingKeepTempFiles

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -168,7 +168,7 @@ buildAndRegisterUnpackedPackage
   verbosity
   distDirLayout@DistDirLayout{distTempDirectory}
   maybe_semaphore
-  BuildTimeSettings{buildSettingNumJobs}
+  buildTimeSettings@BuildTimeSettings{buildSettingNumJobs}
   registerLock
   cacheLock
   pkgshared@ElaboratedSharedConfig
@@ -329,6 +329,7 @@ buildAndRegisterUnpackedPackage
           setupHsHaddockFlags
             pkg
             pkgshared
+            buildTimeSettings
             (commonFlags v)
       haddockArgs v =
         flip filterHaddockArgs v $

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -4101,41 +4101,46 @@ setupHsRegisterFlags
 setupHsHaddockFlags
   :: ElaboratedConfiguredPackage
   -> ElaboratedSharedConfig
+  -> BuildTimeSettings
   -> Cabal.CommonSetupFlags
   -> Cabal.HaddockFlags
-setupHsHaddockFlags (ElaboratedConfiguredPackage{..}) (ElaboratedSharedConfig{..}) common =
-  Cabal.HaddockFlags
-    { haddockCommonFlags = common
-    , haddockProgramPaths =
-        case lookupProgram haddockProgram pkgConfigCompilerProgs of
-          Nothing -> mempty
-          Just prg ->
-            [
-              ( programName haddockProgram
-              , locationPath (programLocation prg)
-              )
-            ]
-    , haddockProgramArgs = mempty -- unused, set at configure time
-    , haddockHoogle = toFlag elabHaddockHoogle
-    , haddockHtml = toFlag elabHaddockHtml
-    , haddockHtmlLocation = maybe mempty toFlag elabHaddockHtmlLocation
-    , haddockForHackage = toFlag elabHaddockForHackage
-    , haddockForeignLibs = toFlag elabHaddockForeignLibs
-    , haddockExecutables = toFlag elabHaddockExecutables
-    , haddockTestSuites = toFlag elabHaddockTestSuites
-    , haddockBenchmarks = toFlag elabHaddockBenchmarks
-    , haddockInternal = toFlag elabHaddockInternal
-    , haddockCss = maybe mempty toFlag elabHaddockCss
-    , haddockLinkedSource = toFlag elabHaddockLinkedSource
-    , haddockQuickJump = toFlag elabHaddockQuickJump
-    , haddockHscolourCss = maybe mempty toFlag elabHaddockHscolourCss
-    , haddockContents = maybe mempty toFlag elabHaddockContents
-    , haddockKeepTempFiles = mempty -- TODO: from build settings
-    , haddockIndex = maybe mempty toFlag elabHaddockIndex
-    , haddockBaseUrl = maybe mempty toFlag elabHaddockBaseUrl
-    , haddockLib = maybe mempty toFlag elabHaddockLib
-    , haddockOutputDir = maybe mempty toFlag elabHaddockOutputDir
-    }
+setupHsHaddockFlags
+  (ElaboratedConfiguredPackage{..})
+  (ElaboratedSharedConfig{..})
+  (BuildTimeSettings{buildSettingKeepTempFiles = keepTmpFiles})
+  common =
+    Cabal.HaddockFlags
+      { haddockCommonFlags = common
+      , haddockProgramPaths =
+          case lookupProgram haddockProgram pkgConfigCompilerProgs of
+            Nothing -> mempty
+            Just prg ->
+              [
+                ( programName haddockProgram
+                , locationPath (programLocation prg)
+                )
+              ]
+      , haddockProgramArgs = mempty -- unused, set at configure time
+      , haddockHoogle = toFlag elabHaddockHoogle
+      , haddockHtml = toFlag elabHaddockHtml
+      , haddockHtmlLocation = maybe mempty toFlag elabHaddockHtmlLocation
+      , haddockForHackage = toFlag elabHaddockForHackage
+      , haddockForeignLibs = toFlag elabHaddockForeignLibs
+      , haddockExecutables = toFlag elabHaddockExecutables
+      , haddockTestSuites = toFlag elabHaddockTestSuites
+      , haddockBenchmarks = toFlag elabHaddockBenchmarks
+      , haddockInternal = toFlag elabHaddockInternal
+      , haddockCss = maybe mempty toFlag elabHaddockCss
+      , haddockLinkedSource = toFlag elabHaddockLinkedSource
+      , haddockQuickJump = toFlag elabHaddockQuickJump
+      , haddockHscolourCss = maybe mempty toFlag elabHaddockHscolourCss
+      , haddockContents = maybe mempty toFlag elabHaddockContents
+      , haddockKeepTempFiles = toFlag keepTmpFiles
+      , haddockIndex = maybe mempty toFlag elabHaddockIndex
+      , haddockBaseUrl = maybe mempty toFlag elabHaddockBaseUrl
+      , haddockLib = maybe mempty toFlag elabHaddockLib
+      , haddockOutputDir = maybe mempty toFlag elabHaddockOutputDir
+      }
 
 setupHsHaddockArgs :: ElaboratedConfiguredPackage -> [String]
 -- TODO: Does the issue #3335 affects test as well

--- a/cabal-testsuite/PackageTests/HaddockKeepsTmps/Simple.hs
+++ b/cabal-testsuite/PackageTests/HaddockKeepsTmps/Simple.hs
@@ -1,0 +1,4 @@
+module Simple where
+
+-- | For hiding needles.
+data Haystack = Haystack

--- a/cabal-testsuite/PackageTests/HaddockKeepsTmps/cabal.project
+++ b/cabal-testsuite/PackageTests/HaddockKeepsTmps/cabal.project
@@ -1,0 +1,3 @@
+packages: .
+
+haddock-keep-temp-files: true

--- a/cabal-testsuite/PackageTests/HaddockKeepsTmps/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockKeepsTmps/cabal.test.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE LambdaCase #-}
+import Test.Cabal.Prelude
+import Distribution.Verbosity
+import Distribution.Simple.Glob
+import Distribution.Simple.Glob.Internal
+
+-- Test that "cabal haddock" preserves temporary files
+-- We use haddock-keep-temp-file: True in the cabal.project.
+main = cabalTest $ recordMode DoNotRecord $ do
+  skipIfWindows
+
+  cabal "haddock" []
+
+  cwd <- fmap testCurrentDir getTestEnv
+
+  (globMatches <$> liftIO (runDirFileGlob silent Nothing cwd (GlobDirRecursive [WildCard, Literal "response", WildCard, Literal "txt"]))) >>= \case
+    [] -> error "Expecting a response file to exist"
+    (m:_) ->
+      -- Assert the matched response file is not empty.
+      assertFileDoesContain (cwd </> m) "Simple.hs"

--- a/cabal-testsuite/PackageTests/HaddockKeepsTmps/my.cabal
+++ b/cabal-testsuite/PackageTests/HaddockKeepsTmps/my.cabal
@@ -1,0 +1,13 @@
+cabal-version: 3.0
+name: HaddockKeepsTmps
+version: 0.1
+license: BSD-3-Clause
+author: Rodrigo Mesquita
+stability: stable
+category: PackageTests
+build-type: Simple
+
+library
+    default-language: Haskell2010
+    exposed-modules: Simple
+    build-depends: base


### PR DESCRIPTION
This commit initialises the Haddock flag `haddockKeepTempFiles` with the value of `buildSettingKeepTempFiles`.

The only change in the patch is the following, in `setupHsHaddockFlags`:

```diff
- haddockKeepTempFiles = mempty -- TODO: from build settings
+ haddockKeepTempFiles = toFlag keepTmpFiles
```

where `keepTmpFiles` is retrieved from `BuildTimeSettings`.

This addresses an 8 year old TODO in the code.

**Template Α**: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog).

TODO:

* [x] Patches conform to the coding conventions.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated.
* [x] Tests have been added.
