### PR TITLE
Be more careful in handling unconfigured programs in the program database

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/Builtin.hs
+++ b/Cabal/src/Distribution/Simple/Program/Builtin.hs
@@ -226,21 +226,13 @@ hpcProgram =
 -- during the configure phase.
 haskellSuiteProgram :: Program
 haskellSuiteProgram =
-  (simpleProgram "haskell-suite")
-    { -- pretend that the program exists, otherwise it won't be in the
-      -- "configured" state
-      programFindLocation = \_verbosity _searchPath ->
-        return $ Just ("haskell-suite-dummy-location", [])
-    }
+  simpleProgram "haskell-suite"
 
 -- This represent a haskell-suite package manager. See the comments for
 -- haskellSuiteProgram.
 haskellSuitePkgProgram :: Program
 haskellSuitePkgProgram =
-  (simpleProgram "haskell-suite-pkg")
-    { programFindLocation = \_verbosity _searchPath ->
-        return $ Just ("haskell-suite-pkg-dummy-location", [])
-    }
+  simpleProgram "haskell-suite-pkg"
 
 happyProgram :: Program
 happyProgram =

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -483,7 +483,7 @@ configureCompiler
         let extraPath = fromNubList packageConfigProgramPathExtra
         progdb <- liftIO $ prependProgramSearchPath verbosity extraPath [] defaultProgramDb
         let progdb' = userSpecifyPaths (Map.toList (getMapLast packageConfigProgramPaths)) progdb
-        result@(_, _, progdb'') <-
+        (comp, plat, progdb'') <-
           liftIO $
             Cabal.configCompilerEx
               hcFlavor
@@ -500,7 +500,12 @@ configureCompiler
         -- programs it cares about, and those are the ones we monitor here.
         monitorFiles (programsMonitorFiles progdb'')
 
-        return result
+        -- Configure the unconfigured programs in the program database,
+        -- as we can't serialise unconfigured programs.
+        -- See also #2241 and #9840.
+        finalProgDb <- liftIO $ configureAllKnownPrograms verbosity progdb''
+
+        return (comp, plat, finalProgDb)
     where
       hcFlavor = flagToMaybe projectConfigHcFlavor
       hcPath = flagToMaybe projectConfigHcPath

--- a/cabal-install/src/Distribution/Client/SetupWrapper.hs
+++ b/cabal-install/src/Distribution/Client/SetupWrapper.hs
@@ -90,7 +90,8 @@ import Distribution.Simple.Program
   , runDbProgramCwd
   )
 import Distribution.Simple.Program.Db
-  ( prependProgramSearchPath
+  ( configureAllKnownPrograms
+  , prependProgramSearchPath
   , progOverrideEnv
   )
 import Distribution.Simple.Program.Find
@@ -1035,11 +1036,19 @@ getExternalSetupMethod verbosity options pkg bt = do
                 createDirectoryIfMissingVerbose verbosity True setupCacheDir
                 installExecutableFile verbosity src cachedSetupProgFile
                 -- Do not strip if we're using GHCJS, since the result may be a script
-                when (maybe True ((/= GHCJS) . compilerFlavor) $ useCompiler options') $
+                when (maybe True ((/= GHCJS) . compilerFlavor) $ useCompiler options') $ do
+                  -- Add the relevant PATH overrides for the package to the
+                  -- program database.
+                  setupProgDb
+                    <- prependProgramSearchPath verbosity
+                          (useExtraPathEnv options)
+                          (useExtraEnvOverrides options)
+                          (useProgramDb options')
+                         >>= configureAllKnownPrograms verbosity
                   Strip.stripExe
                     verbosity
                     platform
-                    (useProgramDb options')
+                    setupProgDb
                     cachedSetupProgFile
         return cachedSetupProgFile
         where

--- a/cabal-testsuite/PackageTests/ExtraProgPath/setup.out
+++ b/cabal-testsuite/PackageTests/ExtraProgPath/setup.out
@@ -1,8 +1,6 @@
 # cabal v2-build
 Warning: cannot determine version of <ROOT>/pkg-config :
 ""
-Warning: cannot determine version of <ROOT>/pkg-config :
-""
 Resolving dependencies...
 Error: [Cabal-7107]
 Could not resolve dependencies:


### PR DESCRIPTION
This PR contains several commits that address problems with how we were handling unconfigured programs in the program database:

  - We should configure unconfigured programs before serialising them (using the `Binary ProgramDb` instance) in
    `Distribution.Client.ProjectPlanning.configureCompiler`, as otherwise we can accidentally discard information.
    Not doing so can lead to situations in which we can build a package just fine, but if we re-start a build we will fail,
    because the program database on disk stored after configuring doesn't match the program database in memory.
  - As a follow-on from the above, `configureRequiredProgram` needs to gracefully handle an already-configured program.
    Not doing so means we would fall back to the `simpleProgram` treatment, which can cause `Cabal` to fail to configure a program such as `hsc2hs` which has custom logic for parsing its version number.
  - When compiling a `Setup` executable, we would pass a program database for use of the `stripExe` command. However,
    the `strip` program might not be configured in this program database; so we make sure to configure it (in the correct
    environment).

**Template Α**: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog).

TODO:

* [x] Patches conform to the coding conventions.
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated.
* [x] Tests have been added.