### PR TITLE
Hackage as a proper noun, capitalized in docs

### DIFF
--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -892,7 +892,7 @@ By default the documentation will be put in ``./haddocks`` folder, this can be
 modified with the ``--output`` flag.
 
 This command supports two primary modes: building a self contained directory
-(which is the default mode) or documentation that links to hackage (with
+(which is the default mode) or documentation that links to Hackage (with
 ``--hackage`` flag).
 
 In both cases the html index as well as quickjump index will include all terms

--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -1510,7 +1510,7 @@ system-dependent values for these fields.
        `containers <https://hackage.haskell.org/package/containers/preferred>`_
        and `aeson <https://hackage.haskell.org/package/aeson/preferred>`_ for
        example. Deprecating package versions is not the same deprecating a
-       package as a whole, for which hackage keeps a `deprecated packages list
+       package as a whole, for which Hackage keeps a `deprecated packages list
        <https://hackage.haskell.org/packages/deprecated>`_.
 
     If no version constraint is specified, any version is assumed to be


### PR DESCRIPTION
I didn't think this warranted raising an issue beforehand. Fixes two instances of the proper noun Hackage not being capitalized. This was originally brought to my attention during a code review by @malteneuss, https://github.com/haskell/cabal/pull/9701#discussion_r1582365958.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
