### PR TITLE
Add "no command line variant" for `source-repository-package`.

### DIFF
--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -216,6 +216,14 @@ consider during package retrieval. This allows use of a package from a
 remote version control system, rather than looking for that package in
 Hackage.
 
+Since version 3.4, cabal-install creates tarballs for each package coming from a
+``source-repository-package`` stanza (effectively applying cabal sdists to such
+packages). It gathers the names of the packages from the appropriate ``.cabal``
+file in the version control repository, and allows their use just like Hackage
+or locally defined packages.
+
+There is no command line variant of this stanza.
+
 .. code-block:: cabal
 
     packages: .
@@ -236,12 +244,6 @@ Hackage.
         location: https://github.com/haskell/network.git
         tag: e76fdc753e660dfa615af6c8b6a2ad9ddf6afe70
         post-checkout-command: autoreconf -i
-
-Since version 3.4, cabal-install creates tarballs for each package coming
-from a ``source-repository-package`` stanza (effectively applying cabal
-sdists to such packages). It gathers the names of the packages from the
-appropriate ``.cabal`` file in the version control repository, and allows
-their use just like Hackage or locally defined packages.
 
 .. _source-repository-package-fields:
 


### PR DESCRIPTION
Adds a note that `source-repository-package` is not for the command line.

```
$ cabal build solver-benchmarks --source-repository-package=https://github.com/haskell/vector
Error: cabal: unrecognized 'build' option
`--source-repository-package=https://github.com/haskell/vector'
```

Also shows ".cabal file" as "`.cabal` file" and moves this paragraph up so that it is placed before the note and before any code blocks in this section.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
