### PR TITLE
Add NoImplicitPrelude to buildTypeScript

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectPlanning/SetupPolicy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning/SetupPolicy.hs
@@ -133,11 +133,10 @@ mkDefaultSetupDeps compiler platform pkg =
 
     -- For other build types (like Simple) if we still need to compile an
     -- external Setup.hs, it'll be one of the simple ones that only depends
-    -- on Cabal and base.
+    -- on Cabal.
     SetupNonCustomExternalLib ->
       Just
         [ Dependency cabalPkgname cabalConstraint mainLibSet
-        , Dependency basePkgname anyVersion mainLibSet
         ]
       where
         cabalConstraint = orLaterVersion (csvToVersion (specVersion pkg))
@@ -217,9 +216,8 @@ packageSetupScriptSpecVersion _ pkg libDepGraph deps =
         fromMaybe [] $
           Graph.closure libDepGraph (CD.setupDeps deps)
 
-cabalPkgname, basePkgname :: PackageName
+cabalPkgname :: PackageName
 cabalPkgname = mkPackageName "Cabal"
-basePkgname = mkPackageName "base"
 
 legacyCustomSetupPkgs :: Compiler -> Platform -> [PackageName]
 legacyCustomSetupPkgs compiler (Platform _ os) =

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNoBase/A.hs
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNoBase/A.hs
@@ -1,0 +1,2 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module A where {}

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNoBase/SetupHooks.hs
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNoBase/SetupHooks.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module SetupHooks ( setupHooks ) where
+
+import Distribution.Simple.SetupHooks ( SetupHooks, noSetupHooks )
+
+setupHooks :: SetupHooks
+setupHooks = noSetupHooks

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNoBase/cabal.project
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNoBase/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNoBase/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNoBase/cabal.test.hs
@@ -1,0 +1,14 @@
+import Test.Cabal.Prelude
+
+-- Test that we can compile the Setup.hs script for a package with
+-- build-type:Hooks without requiring a dependency on 'base'.
+--
+-- NB: we specifically don't include a 'Setup.hs' file in this package,
+-- as we rely on 'cabal-install' generating one that does not incur an extra
+-- dependency on base.
+main = cabalTest $ do
+  mpkgdb <- testPackageDbPath <$> getTestEnv
+  case mpkgdb of
+    Nothing -> skip "Cabal-hooks library unavailable."
+    Just _pkgdb -> recordMode DoNotRecord $ do
+      cabal "v2-build" [ "all" ]

--- a/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNoBase/setup-hooks-no-base-test.cabal
+++ b/cabal-testsuite/PackageTests/SetupHooks/SetupHooksNoBase/setup-hooks-no-base-test.cabal
@@ -1,0 +1,16 @@
+cabal-version:       3.14
+name:                setup-hooks-no-base-test
+version:             0.1.0.0
+synopsis:            Test that we can build Setup.hs without base
+license:             BSD-3-Clause
+author:              NA
+maintainer:          NA
+category:            Testing
+build-type:          Hooks
+
+custom-setup
+  setup-depends: Cabal-hooks
+
+library
+  exposed-modules:  A
+  default-language: Haskell2010


### PR DESCRIPTION
This allows us to compile Setup.hs without depending on base. In particular, this ensures that a package with `build-type: Hooks` and a custom setup stanza that does not depend on base successfully compiles.

Tested in `PackageTests/SetupHooks/SetupHooksNoBase`.

---

**Template B: This PR does not modify behaviour or interface**

* [x] Patch conforms to the coding conventions.
* [x] Test included.
