### PR TITLE
Use bootstrap project in bootstrapping

### DIFF
--- a/bootstrap/generate_bootstrap_plans
+++ b/bootstrap/generate_bootstrap_plans
@@ -10,7 +10,7 @@ run() {
   local drv="ghc-$ver"
   echo "$ver"
   nix build -f "$ghcs_nix" $drv
-  (cd ../; rm -r dist-bootstrap; cabal --distdir=dist-bootstrap build --project-file=cabal.release.project --dry-run cabal-install:exe:cabal -w bootstrap/result/bin/ghc)
+  (cd ../; rm -r dist-bootstrap; cabal --distdir=dist-bootstrap build --project-file=cabal.bootstrap.project --dry-run cabal-install:exe:cabal -w bootstrap/result/bin/ghc)
   jq --sort-keys < ../dist-bootstrap/cache/plan.json > "plan-$ver.json"
   cabal run --with-ghc-pkg $PWD/boot_ghc/bin/ghc-pkg -w $PWD/boot_ghc/bin/ghc -v0 cabal-bootstrap-gen -- "plan-$ver.json" | jq --sort-keys | tee "linux-$(echo $ver | tr "_" ".").json"
 }


### PR DESCRIPTION
We need to use the cabal.bootstrap.project file to generate the bootstrap plans, otherwise we try to include test components when bootstrapping, which is not useful (and significantly complicates bootstrapping).

I forgot to include this change in 88737ef, but I used this change to generate the plans.

---

**Template B: This PR does not modify behaviour or interface**

* [x] Patch conforms to the coding conventions.
* [x] This does not need to be backported to older release branches; it applies to 3.13 onwards only.
