### PR TITLE
Bump index-state in the release project file

### DIFF
--- a/cabal.project.release
+++ b/cabal.project.release
@@ -2,4 +2,4 @@ import: project-cabal/pkgs/cabal.config
 import: project-cabal/pkgs/install.config
 import: project-cabal/pkgs/tests.config
 
-index-state: hackage.haskell.org 2024-02-13T10:16:13Z
+index-state: hackage.haskell.org 2024-04-22T06:16:57Z


### PR DESCRIPTION
I have backports failing on 3.12 because the index state update from #9897 is not on 3.12: https://github.com/haskell/cabal/actions/runs/9080152427/job/24950912901?pr=10002

Does it look reasonable to backport this change? @ffaf1 @Mikolaj

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
