### PR TITLE
add the applicable new (version 9.10) GHC flags to normaliseGhcArgs

### DIFF
--- a/Cabal/src/Distribution/Simple/Program.hs
+++ b/Cabal/src/Distribution/Simple/Program.hs
@@ -1,3 +1,10 @@
+{- FUTUREWORK:
+ -
+ - Currently the logic in this module is not tested.
+ -
+ - Ideally, a set of unit tests that check whether certain
+ - flags trigger recompilation should be added.
+ - -}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -227,8 +228,27 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
                   , "keep-going" -- try harder, the build will still fail if it's erroneous
                   , "print-axiom-incomps" -- print more debug info for closed type families
                   ]
+              , from
+                  [9, 2]
+                  [ "family-application-cache"
+                  ]
+              , from
+                  [9, 6]
+                  [ "print-redundant-promotion-ticks"
+                  , "show-error-context"
+                  ]
+              , from
+                  [9, 8]
+                  [ "unoptimized-core-for-interpreter"
+                  ]
+              , from
+                  [9, 10]
+                  [ "diagnostics-as-json"
+                  , "print-error-index-links"
+                  , "break-points"
+                  ]
               ]
-          , flagIn . invertibleFlagSet "-d" $ ["ppr-case-as-let", "ppr-ticks"]
+          , flagIn $ invertibleFlagSet "-d" ["ppr-case-as-let", "ppr-ticks"]
           , isOptIntFlag
           , isIntFlag
           , if safeToFilterWarnings
@@ -289,6 +309,7 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
         , from [8, 6] ["-dhex-word-literals"]
         , from [8, 8] ["-fshow-docs-of-hole-fits", "-fno-show-docs-of-hole-fits"]
         , from [9, 0] ["-dlinear-core-lint"]
+        , from [9, 10] ["-dipe-stats"]
         ]
 
     isOptIntFlag :: String -> Any
@@ -709,7 +730,10 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
               | flagProfAuto implInfo -> ["-fprof-auto-exported"]
               | otherwise -> ["-auto"]
         , ["-split-sections" | flagBool ghcOptSplitSections]
-        , ["-split-objs" | flagBool ghcOptSplitObjs]
+        , case compilerCompatVersion GHC comp of
+            -- the -split-objs flag was removed in GHC 9.8
+            Just ver | ver >= mkVersion [9, 8] -> []
+            _ -> ["-split-objs" | flagBool ghcOptSplitObjs]
         , case flagToMaybe (ghcOptHPCDir opts) of
             Nothing -> []
             Just hpcdir -> ["-fhpc", "-hpcdir", u hpcdir]
@@ -799,8 +823,7 @@ renderGhcOptions comp _platform@(Platform _arch os) opts
           -- Packages
 
           concat
-            [ [ case () of
-                  _
+            [ [ if
                     | unitIdSupported comp -> "-this-unit-id"
                     | packageKeySupported comp -> "-this-package-key"
                     | otherwise -> "-package-name"

--- a/changelog.d/pr-10014
+++ b/changelog.d/pr-10014
@@ -1,0 +1,11 @@
+synopsis: Update ghc args normalization and ghc option rendering
+packages: Cabal
+issues: #9729
+prs: #10014
+
+description: {
+
+The flags fdiagnostics-as-json, fprint-error-index-lists, fbreak-points, dipe-stats, ffamily-application-cache, fprint-redundant-promotion-ticks, show-error-context and unoptimized-core-for-interpreter have been added to the flags that do not cause recompilation. 
+
+--{enable,disable}-split-objs is not shown on in the helper for GHC >= 9.8
+}

--- a/changelog.d/pr-10014
+++ b/changelog.d/pr-10014
@@ -5,7 +5,7 @@ prs: #10014
 
 description: {
 
-The flags fdiagnostics-as-json, fprint-error-index-lists, fbreak-points, dipe-stats, ffamily-application-cache, fprint-redundant-promotion-ticks, show-error-context and unoptimized-core-for-interpreter have been added to the flags that do not cause recompilation. 
+The flags -fdiagnostics-as-json, -fprint-error-index-lists, -fbreak-points, -dipe-stats, -ffamily-application-cache, -fprint-redundant-promotion-ticks, -fshow-error-context and -funoptimized-core-for-interpreter have been added to the flags that do not cause recompilation. 
 
 --{enable,disable}-split-objs is not shown on in the helper for GHC >= 9.8
 }


### PR DESCRIPTION
Relevant issue https://github.com/haskell/cabal/issues/9729 (blocked by this PR)

## Overview

This PR is concerned with updating the `Distribution.Simple.Program.GHC` module to include flags added since (inclusively) 9.2 into `normalizeGHCArgs` and remove flags that have since removed in `renderGhcOptions`.

The file didn't seem to be updated since ghc 8.10. I hope to address that in this PR.

Actionable flags, as far as I can tell, are (see commit message):

- `-fdiagnostics-as-json` (changes the format GHC outputs its diagnostics)
- `-fprint-error-index-lists=<always|never|auto>` (changes the way GHC displays compile time)
- `-fbreak-points` (enables/disables break-points in GHCi)
- `-dipe-stats` (dumps information about which info tables have IPE
  information)
- `-ffamily-application-cache` (only changes the speed of the compiler)
- `-fprint-redundant-promotion-ticks`
- `-fshow-error-context`
- `-funoptimized-core-for-interpreter` (only applies to GHCi)

For a diff of flags between GHC 8.10 and 9.10, see https://github.com/haskell/cabal/pull/10014#issuecomment-2141550854

## QA notes

- `cabal-install` with GHC 9.8 and newer *must not* list the cabal equivalent of the GHC `split-objs` flag, before GHC 9.8 it *must* list it
- changing either of the flags: 
  - `-fdiagnostics-as-json`
  - `-fprint-error-index-lists`
  - `-fbreak-points`
  - `-dipe-stats`
  - `-ffamily-application-cache`
  - `-fprint-redundant-promotion-ticks`
  - `-fshow-error-context`
  - `-funoptimized-core-for-interpreter`
  
  *must not* cause recompilation 

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* n/a ~~The documentation has been updated, if necessary.~~
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
