### PR TITLE
ci: Fix quick-jobs GHC version to 9.6

### DIFF
--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -14,6 +14,9 @@ on:
     types:
       - created
 
+env:
+  GHC_FOR_QUICK_JOBS: 9.6.5
+
 jobs:
   meta:
     name: Meta checks
@@ -25,15 +28,13 @@ jobs:
         gen-paths-module
         gen-spdx
         gen-spdx-exc
-    # This job is not run in a container, any recent GHC should be fine
     steps:
-      # SKIP installation of ghc and cabal and use the preinstalled versions.
-      # - name: ghcup
-      #   run: |
-      #     ghcup --version
-      #     ghcup config set cache true
-      #     ghcup install ghc recommended
-      #     ghcup set ghc recommended
+      - name: ghcup
+        run: |
+          ghcup --version
+          ghcup config set cache true
+          ghcup install ghc $GHC_FOR_QUICK_JOBS
+          ghcup set ghc $GHC_FOR_QUICK_JOBS
       - name: Haskell versions
         run: |
           ghc --version
@@ -71,6 +72,16 @@ jobs:
     name: Doctest Cabal
     runs-on: ubuntu-latest
     steps:
+      - name: ghcup
+        run: |
+          ghcup --version
+          ghcup config set cache true
+          ghcup install ghc $GHC_FOR_QUICK_JOBS
+          ghcup set ghc $GHC_FOR_QUICK_JOBS
+      - name: Haskell versions
+        run: |
+          ghc --version
+          cabal --version
       # It is complicated to get a proper cache key for the dependencies of a package
       # (here: doctest) that we just `cabal install`.
       # So, as a heuristics we update the cache once per day.
@@ -106,6 +117,16 @@ jobs:
     env:
       cabal_build: cabal build buildinfo-reference-generator
     steps:
+      - name: ghcup
+        run: |
+          ghcup --version
+          ghcup config set cache true
+          ghcup install ghc $GHC_FOR_QUICK_JOBS
+          ghcup set ghc $GHC_FOR_QUICK_JOBS
+      - name: Haskell versions
+        run: |
+          ghc --version
+          cabal --version
       - name: Update Hackage index
         run: cabal v2-update
       - uses: actions/checkout@v4
@@ -133,6 +154,16 @@ jobs:
     name: Check Release Project
     runs-on: ubuntu-latest
     steps:
+      - name: ghcup
+        run: |
+          ghcup --version
+          ghcup config set cache true
+          ghcup install ghc $GHC_FOR_QUICK_JOBS
+          ghcup set ghc $GHC_FOR_QUICK_JOBS
+      - name: Haskell versions
+        run: |
+          ghc --version
+          cabal --version
       - name: Update Hackage Index
         run: cabal v2-update
       - uses: actions/checkout@v4


### PR DESCRIPTION
This should fix the CI quick jobs that have been failing recently. Could you please have a look @Mikolaj 