### PR TITLE
Fix #10042 Don't recommend deprecated/removed 'extensions:' field

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check/Target.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Target.hs
@@ -860,14 +860,14 @@ checkGHCOptions title t opts = do
       let ghcNoRts = rmRtsOpts opts
       checkAlternatives
         title
-        "extensions"
+        "default-extensions"
         [ (flag, prettyShow extension)
         | flag <- ghcNoRts
         , Just extension <- [ghcExtension flag]
         ]
       checkAlternatives
         title
-        "extensions"
+        "default-extensions"
         [ (flag, extension)
         | flag@('-' : 'X' : extension) <- ghcNoRts
         ]

--- a/changelog.d/issue-10042
+++ b/changelog.d/issue-10042
@@ -1,0 +1,9 @@
+synopsis: Don't recommend deprecated/removed 'extensions:' field
+packages: Cabal
+prs: #10044
+issues: #10042
+
+description: {
+  When applicable, field 'default-extensions:' is recommended (rather than
+  deprecated/removed 'extensions:').
+}


### PR DESCRIPTION
Related issue:
* #10042

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary. Not necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included. None needed.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*) None needed.