### PR TITLE
[3.12] PackageTests/NewUpdate: fix skipping flaky tests

### DIFF
--- a/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewUpdate/RejectFutureIndexStates/cabal.test.hs
@@ -1,9 +1,13 @@
 import Test.Cabal.Prelude
 import Data.List (isPrefixOf)
 
-main = cabalTest $ withProjectFile "cabal.project" $ withRemoteRepo "repo" $ do
+main = cabalTest $ do
 
   skip "Flaky test failing in `curl`, see #9530"
+
+  testBody
+
+testBody = withProjectFile "cabal.project" $ withRemoteRepo "repo" $ do
 
   output <- last
           . words

--- a/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.test.hs
+++ b/cabal-testsuite/PackageTests/NewUpdate/UpdateIndexState/update-index-state.test.hs
@@ -1,8 +1,12 @@
 import Test.Cabal.Prelude
 
-main = cabalTest $ withRemoteRepo "repo" $ do
+main = cabalTest $ do
 
   skip "Flaky test failing in `curl`, see #9530"
+
+  testBody
+
+testBody = withRemoteRepo "repo" $ do
 
   -- The _first_ update call causes a warning about missing mirrors, the warning
   -- is platform-dependent and it's not part of the test expectations, so we


### PR DESCRIPTION
RejectFutureIndexStates and UpdateIndexState are marked "skip", but it's under withRemoteRepo, which causes flakiness before skip is called.

backport of #10035