### PR TITLE
Fix predicate which determines whether to build a shared library

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -219,6 +219,7 @@ import Distribution.Solver.Types.ProjectConfigPath
 import System.FilePath
 import Text.PrettyPrint (colon, comma, fsep, hang, punctuate, quotes, text, vcat, ($$))
 import qualified Text.PrettyPrint as Disp
+import Data.Semigroup
 
 -- | Check that an 'ElaboratedConfiguredPackage' actually makes
 -- sense under some 'ElaboratedSharedConfig'.
@@ -2365,7 +2366,7 @@ elaborateInstallPlan
           needsSharedLib pkg =
             fromMaybe
               compilerShouldUseSharedLibByDefault
-              (liftM2 (||) pkgSharedLib pkgDynExe)
+              (getMax <$> ((Max <$> pkgSharedLib) <> (Max <$> pkgDynExe)))
             where
               pkgid = packageId pkg
               pkgSharedLib = perPkgOptionMaybe pkgid packageConfigSharedLib

--- a/changelog.d/issue-10050
+++ b/changelog.d/issue-10050
@@ -1,0 +1,10 @@
+synopsis: Fix behaviour of --disable-shared
+packages: cabal-install
+prs: #10054
+issues: #10050
+
+description: Previously `--disable-shared` was not applied unless `--disable-executable-dynamic` was
+also explicitly configured.
+
+Now `--disable-shared` will turn off building shared libraries irrespective of whether
+`--disable-executable-dynamic` is specified.


### PR DESCRIPTION
Consider the which determines whether we should build shared libraries.

      pkgsUseSharedLibrary :: Set PackageId
      pkgsUseSharedLibrary =
        packagesWithLibDepsDownwardClosedProperty needsSharedLib
        where
          needsSharedLib pkg =
            fromMaybe
              compilerShouldUseSharedLibByDefault
              (liftM2 (||) pkgSharedLib pkgDynExe)
            where
              pkgid = packageId pkg
              pkgSharedLib = perPkgOptionMaybe pkgid packageConfigSharedLib
              pkgDynExe = perPkgOptionMaybe pkgid packageConfigDynExe

In English the intended logic is:

If we have enabled shared libraries or dynamic executables then we need to build a shared libary.

but, a common mistake:

(liftM2 (||) pkgSharedLib pkgDynExe)

instead says, if we explicitly request shared libraries and also explicitly configure whether we want dynamic executables then build a shared library.

It should instead use the monoid instance:

getMax <$> ((Max <$> pkgSharedLib) <> (Max <$> pkgDynExe))

which captures the original logic.

This failure is currently manifested in the way that if you write --disable-shared then --enable-shared is still passed to ./Setup.

If you pass both --disable-shared and --disable-executable-dynamic then you don't build a shared object.

Fixes #10050

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

