### PR TITLE
fix: Make newSemaphoreJobControl respect verbosity

### DIFF
--- a/cabal-install/src/Distribution/Client/JobControl.hs
+++ b/cabal-install/src/Distribution/Client/JobControl.hs
@@ -45,7 +45,6 @@ import Control.Monad (forever, replicateM_)
 import Distribution.Client.Compat.Semaphore
 import Distribution.Compat.Stack
 import Distribution.Simple.Utils
-import Distribution.Verbosity
 import System.Semaphore
 
 -- | A simple concurrency abstraction. Jobs can be spawned and can complete
@@ -171,13 +170,13 @@ readAllTChan qvar = go []
 --
 -- This uses the GHC -jsem option to allow GHC to take additional semaphore slots
 -- if we are not using them all.
-newSemaphoreJobControl :: WithCallStack (Int -> IO (JobControl IO a))
-newSemaphoreJobControl n
+newSemaphoreJobControl :: WithCallStack (Verbosity -> Int -> IO (JobControl IO a))
+newSemaphoreJobControl _ n
   | n < 1 || n > 1000 =
       error $ "newParallelJobControl: not a sensible number of jobs: " ++ show n
-newSemaphoreJobControl maxJobLimit = do
+newSemaphoreJobControl verbosity maxJobLimit = do
   sem <- freshSemaphore "cabal_semaphore" maxJobLimit
-  notice normal $
+  notice verbosity $
     "Created semaphore called "
       ++ getSemaphoreName (semaphoreName sem)
       ++ " with "

--- a/cabal-install/src/Distribution/Client/ProjectBuilding.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding.hs
@@ -366,7 +366,7 @@ rebuildTargets
           NumJobs n -> newParallelJobControl (fromMaybe numberOfProcessors n)
           UseSem n ->
             if jsemSupported compiler
-              then newSemaphoreJobControl n
+              then newSemaphoreJobControl verbosity n
               else do
                 warn verbosity "-jsem is not supported by the selected compiler, falling back to normal parallelism control."
                 newParallelJobControl n


### PR DESCRIPTION
**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

This PR fixes the message “Created semaphore called cabal_semaphore_XXX with NNN slots.” appearing even with `--verbosity=0`.