### PR TITLE
Fix --program-suffix resulting in invalid symlink

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdInstall.hs
+++ b/cabal-install/src/Distribution/Client/CmdInstall.hs
@@ -540,7 +540,7 @@ installAction flags@NixStyleFlags{extraFlags, configFlags, installFlags, project
         -- BuildOutcomes because we also need the component names
           traverseInstall (installCheckUnitExes InstallCheckInstall) installCfg
   where
-    configFlags' = disableTestsBenchsByDefault configFlags
+    configFlags' = disableTestsBenchsByDefault . ignoreProgramAffixes $ configFlags
     verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags')
     ignoreProject = flagIgnoreProject projectFlags
     cliConfig =
@@ -1099,6 +1099,18 @@ disableTestsBenchsByDefault configFlags =
   configFlags
     { configTests = Flag False <> configTests configFlags
     , configBenchmarks = Flag False <> configBenchmarks configFlags
+    }
+
+-- | Disables program prefix and suffix, in order to get the /canonical/
+-- executable name in the store and thus:
+--
+-- * avoid making the package hash depend on these options and needless rebuild;
+-- * provide the correct executable path to the install methods (copy, symlink).
+ignoreProgramAffixes :: ConfigFlags -> ConfigFlags
+ignoreProgramAffixes configFlags =
+  configFlags
+    { configProgPrefix = NoFlag
+    , configProgSuffix = NoFlag
     }
 
 -- | Prepares a record containing the information needed to either symlink or

--- a/cabal-testsuite/PackageTests/Install/ProgramAffixes/Main.hs
+++ b/cabal-testsuite/PackageTests/Install/ProgramAffixes/Main.hs
@@ -1,0 +1,1 @@
+main = pure ()

--- a/cabal-testsuite/PackageTests/Install/ProgramAffixes/cabal.project
+++ b/cabal-testsuite/PackageTests/Install/ProgramAffixes/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/Install/ProgramAffixes/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Install/ProgramAffixes/cabal.test.hs
@@ -1,0 +1,27 @@
+import Test.Cabal.Prelude
+import Data.Foldable (traverse_)
+
+-- Test that program affixes options result in successful installation:
+-- • Valid symlinks (--install-method=symlink)
+-- • Valid copy of executables (--install-method=copy)
+main = cabalTest $ do
+  env <- getTestEnv
+  recordMode DoNotRecord $ do
+    let installdir = testPrefixDir env </> "bin"
+        commonOpts = ["p", "--installdir", installdir, "--overwrite-policy=always"]
+        testAllAffixes installMethod = do
+          let testAffixes' = testAffixes
+                (commonOpts ++ ["--install-method", installMethod])
+          testAffixes' Nothing Nothing
+          testAffixes' (Just "a-") Nothing
+          testAffixes' Nothing (Just "-z")
+          testAffixes' (Just "a-") (Just "-z")
+    traverse_ testAllAffixes ["symlink", "copy"]
+  where
+    mkAffixOption option = maybe [] (\a -> ["--program-" ++ option, a])
+    mkProgramName p s = maybe [] id p ++ "p" ++ maybe [] id s
+    testAffixes commonOpts prefix suffix = do
+      cabal "install" (  commonOpts
+                      ++ mkAffixOption "prefix" prefix
+                      ++ mkAffixOption "suffix" suffix)
+      runInstalledExe (mkProgramName prefix suffix) []

--- a/cabal-testsuite/PackageTests/Install/ProgramAffixes/p.cabal
+++ b/cabal-testsuite/PackageTests/Install/ProgramAffixes/p.cabal
@@ -1,0 +1,8 @@
+name: p
+version: 1.0
+build-type: Simple
+cabal-version: >= 1.2
+
+executable p
+  main-is: Main.hs
+  build-depends: base

--- a/changelog.d/issue-9919
+++ b/changelog.d/issue-9919
@@ -1,0 +1,4 @@
+synopsis: Fix --program-suffix resulting in invalid installation
+packages: cabal-install
+issues: #8823 #9919
+prs: #10056


### PR DESCRIPTION
Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

Fixes #9919
Fixes #8823

Based on [this comment](https://github.com/haskell/cabal/issues/8823#issuecomment-2079197342).

It took me a lot of time to understand where to look at and I am still unsure this fix does not introduce side effects. I would need some guidance if improvements are needed.