### PR TITLE
Bump dependencies and cabal-version

### DIFF
--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.0
 name:          Cabal
 version:       3.13.0.0
 copyright:     2003-2024, Cabal Development Team (see AUTHORS file)

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -99,7 +99,7 @@ library
 
   build-depends:
     , array         >=0.4      && <0.6
-    , base          >=4.11     && <4.20
+    , base          >=4.11     && <4.21
     , bytestring    >=0.10.6.0 && <0.13
     , Cabal         ^>=3.13
     , Cabal-syntax  ^>=3.13
@@ -131,7 +131,7 @@ Test-Suite unit-tests
      UnitTests.Distribution.Solver.Modular.MessageUtils
 
    build-depends:
-     , base        >= 4.11  && <4.20
+     , base        >= 4.11  && <4.21
      , Cabal-syntax
      , cabal-install-solver
      , tasty       >= 1.2.3 && <1.6

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -1,4 +1,4 @@
-Cabal-Version:      2.2
+Cabal-Version:      3.0
 
 Name:               cabal-install
 Version:            3.13.0.0

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -52,7 +52,7 @@ common warnings
       ghc-options: -Wnoncanonical-monadfail-instances
 
 common base-dep
-    build-depends: base >=4.11 && <4.20
+    build-depends: base >=4.11 && <4.21
 
 common cabal-dep
     build-depends: Cabal ^>=3.13
@@ -354,7 +354,7 @@ test-suite unit-tests
           tasty-expected-failure,
           tasty-hunit >= 0.10,
           tree-diff,
-          QuickCheck >= 2.14.3 && <2.15
+          QuickCheck >= 2.14.3 && <2.16
 
 
 -- Tests to run with a limited stack and heap size
@@ -439,5 +439,5 @@ test-suite long-tests
         tasty-expected-failure,
         tasty-hunit >= 0.10,
         tasty-quickcheck,
-        QuickCheck >= 2.14 && <2.15,
+        QuickCheck >= 2.14 && <2.16,
         pretty-show >= 1.6.15


### PR DESCRIPTION
`base` and `QuickCheck` + cabal-version since 2.2 seems to have been released [around December 2017](https://cabal.readthedocs.io/en/stable/file-format-changelog.html#cabal-version-2-2).

---

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ no
