### PR TITLE
cabal-install: update curl transport to support Basic authentication

### DIFF
--- a/cabal-install/src/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/src/Distribution/Client/HttpUtils.hs
@@ -251,18 +251,27 @@ downloadURI transport verbosity uri path = do
 -- Utilities for repo url management
 --
 
+-- | If the remote repo is accessed over HTTPS, ensure that the transport
+-- supports HTTPS.
 remoteRepoCheckHttps :: Verbosity -> HttpTransport -> RemoteRepo -> IO ()
-remoteRepoCheckHttps verbosity transport repo
-  | isHttpsURI (remoteRepoURI repo)
-  , not (transportSupportsHttps transport) =
-      dieWithException verbosity $ RemoteRepoCheckHttps (unRepoName (remoteRepoName repo)) requiresHttpsErrorMessage
-  | otherwise = return ()
+remoteRepoCheckHttps verbosity transport repo =
+  transportCheckHttpsWithError verbosity transport (remoteRepoURI repo) $
+    RemoteRepoCheckHttps (unRepoName (remoteRepoName repo)) requiresHttpsErrorMessage
 
+-- | If the URI scheme is HTTPS, ensure the transport supports HTTPS.
 transportCheckHttps :: Verbosity -> HttpTransport -> URI -> IO ()
-transportCheckHttps verbosity transport uri
+transportCheckHttps verbosity transport uri =
+  transportCheckHttpsWithError verbosity transport uri $
+    TransportCheckHttps uri requiresHttpsErrorMessage
+
+-- | If the URI scheme is HTTPS, ensure the transport supports HTTPS.
+-- If not, fail with the given error.
+transportCheckHttpsWithError
+  :: Verbosity -> HttpTransport -> URI -> CabalInstallException -> IO ()
+transportCheckHttpsWithError verbosity transport uri err
   | isHttpsURI uri
   , not (transportSupportsHttps transport) =
-      dieWithException verbosity $ TransportCheckHttps uri requiresHttpsErrorMessage
+      dieWithException verbosity err
   | otherwise = return ()
 
 isHttpsURI :: URI -> Bool

--- a/changelog.d/pr-10089
+++ b/changelog.d/pr-10089
@@ -1,0 +1,12 @@
+synopsis: `curl` transport now supports Basic authentication
+packages: cabal-install
+prs: #10089
+
+description: {
+
+- The `curl` HTTP transport previously only supported the HTTP Digest
+  authentication scheme.  Basic authentication is now supported
+  when using HTTPS; Curl will use the scheme offered by the server.
+  The `wget` transport already supports HTTPS.
+
+}


### PR DESCRIPTION
This PR updates the curl transport to support HTTP Basic authentication scheme.  There are a
couple of preliminary small refactors.  Best review the commits independently and in order.

Targeting branch `3.12` because I couldn't build `master` (GHC panic, don't worry about it).
It rebases cleanly onto `master`.



### QA Notes

Ensure that authenticated operations **using username and password** against `hackage.haskell.org` succeed, when using the Curl transport.

### Checklist

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
