### PR TITLE
solver: Prevent ghc-internal from being reinstalled (see #10087)

### DIFF
--- a/cabal-install/src/Distribution/Client/Dependency.hs
+++ b/cabal-install/src/Distribution/Client/Dependency.hs
@@ -463,6 +463,7 @@ nonReinstallablePackages :: [PackageName]
 nonReinstallablePackages =
   [ mkPackageName "base"
   , mkPackageName "ghc-bignum"
+  , mkPackageName "ghc-internal"
   , mkPackageName "ghc-prim"
   , mkPackageName "ghc"
   , mkPackageName "integer-gmp"


### PR DESCRIPTION
GHC 9.10 ships with a new wired-in package, `ghc-internal`, which cannot be reinstalled. This commit prevents `cabal-install` from attempting it. See #10087.

It would be good to include this alongside GHC 9.10 support, if possible.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

## QA Notes

Attempting to build a package called `ghc-internal` that has no dependencies should result in a dependency solving error "constraint from non-reinstallable package requires installed instance".