### PR TITLE
Add check on project root file and fail if broken link

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -542,13 +542,13 @@ getProjectRootUsability filePath = do
   if exists
     then return ProjectRootUsabilityPresentAndUsable
     else do
-      let isUsableAciton =
+      let isUsableAction =
             handle @IOException
               -- NOTE: if any IOException is raised, we assume the file does not exist.
-              -- That is what happen when we call @pathIsSymbolicLink@ on an @FilePath@ that does not exist.
+              -- That is what happen when we call @pathIsSymbolicLink@ on a @FilePath@ that does not exist.
               (const $ pure False)
               ((||) <$> pathIsSymbolicLink filePath <*> doesPathExist filePath)
-      isUnusable <- isUsableAciton
+      isUnusable <- isUsableAction
       if isUnusable
         then return ProjectRootUsabilityPresentAndUnusable
         else return ProjectRootUsabilityNotPresent
@@ -651,7 +651,6 @@ data BadProjectRoot
   | BadProjectRootAbsoluteFileNotFound FilePath
   | BadProjectRootDirFileNotFound FilePath FilePath
   | BadProjectRootFileBroken FilePath
-
   deriving (Show, Typeable, Eq)
 
 instance Exception BadProjectRoot where

--- a/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/ProjectConfig.hs
@@ -129,8 +129,8 @@ testGetProjectRootUsability =
     test name fileName expectedState =
       testCase name $
         withCurrentDirectory dir $
-          getProjectRootUsability fileName >>=
-          (@?= expectedState)
+          getProjectRootUsability fileName
+            >>= (@?= expectedState)
 
 testFindProjectRoot :: TestTree
 testFindProjectRoot =
@@ -142,6 +142,10 @@ testFindProjectRoot =
     , test "explicit file in lib" (cd libDir) Nothing (Just file) (succeeds dir file)
     , test "other file" (cd dir) Nothing (Just fileOther) (succeeds dir fileOther)
     , test "other file in lib" (cd libDir) Nothing (Just fileOther) (succeeds dir fileOther)
+    , test "symbolic link" (cd dir) Nothing (Just fileSymlink) (succeeds dir fileSymlink)
+    , test "symbolic link in lib" (cd libDir) Nothing (Just fileSymlink) (succeeds dir fileSymlink)
+    , test "broken symbolic link" (cd dir) Nothing (Just fileSymlinkBroken) (failsWith $ BadProjectRootFileBroken fileSymlinkBroken)
+    , test "broken symbolic link in lib" (cd libDir) Nothing (Just fileSymlinkBroken) (failsWith $ BadProjectRootFileBroken fileSymlinkBroken)
     , -- Deprecated use-case
       test "absolute file" Nothing Nothing (Just absFile) (succeeds dir file)
     , test "nested file" (cd dir) Nothing (Just nixFile) (succeeds dir nixFile)
@@ -162,6 +166,9 @@ testFindProjectRoot =
 
     nixFile = "nix" </> file
     nixOther = nixFile <.> "other"
+
+    fileSymlink = file <.> "symlink"
+    fileSymlinkBroken = fileSymlink <.> "broken"
 
     missing path = Just (path <.> "does_not_exist")
 
@@ -189,6 +196,18 @@ testFindProjectRoot =
 
     fails result = case result of
       Left _ -> pure ()
+      Right x -> assertFailure $ "Expected an error, but found " <> show x
+
+    failsWith expectedError result = case result of
+      Left actualError ->
+        if actualError == expectedError
+          then pure ()
+          else
+            assertFailure $
+              "Expected an error "
+                <> show expectedError
+                <> ", but found "
+                <> show actualError
       Right x -> assertFailure $ "Expected an error, but found " <> show x
 
 fixturesDir :: FilePath

--- a/cabal-install/tests/fixtures/project-root/cabal.project.symlink
+++ b/cabal-install/tests/fixtures/project-root/cabal.project.symlink
@@ -1,0 +1,1 @@
+cabal.project

--- a/cabal-install/tests/fixtures/project-root/cabal.project.symlink.broken
+++ b/cabal-install/tests/fixtures/project-root/cabal.project.symlink.broken
@@ -1,0 +1,1 @@
+does-not-exist

--- a/cabal-install/tests/fixtures/project-root/lib/cabal.project.symlink
+++ b/cabal-install/tests/fixtures/project-root/lib/cabal.project.symlink
@@ -1,0 +1,1 @@
+cabal.project

--- a/cabal-install/tests/fixtures/project-root/lib/cabal.project.symlink
+++ b/cabal-install/tests/fixtures/project-root/lib/cabal.project.symlink
@@ -1,1 +1,0 @@
-cabal.project

--- a/cabal-install/tests/fixtures/project-root/lib/cabal.project.symlink.broken
+++ b/cabal-install/tests/fixtures/project-root/lib/cabal.project.symlink.broken
@@ -1,1 +1,0 @@
-does-not-exist

--- a/cabal-install/tests/fixtures/project-root/lib/cabal.project.symlink.broken
+++ b/cabal-install/tests/fixtures/project-root/lib/cabal.project.symlink.broken
@@ -1,0 +1,1 @@
+does-not-exist

--- a/changelog.d/pr-10103
+++ b/changelog.d/pr-10103
@@ -1,0 +1,14 @@
+synopsis: Enhance error detection for cabal root project files, including broken symlinks
+
+packages: cabal-install
+
+prs: #10103
+
+issues: #9937
+
+description: {
+
+- Added proper detection and reporting for issues with cabal root project files. Previously, these files were silently ignored if they were broken symlinks. Now, `cabal` will exit 
+with an error in such case.
+
+}


### PR DESCRIPTION
This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**


Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added.

## QA Notes

#### Build patched version 
```bash
cabal build cabal-install
alias patchedCabal=$(cabal list-bin cabal-install)
```

### Reproduce
#### Not patched version
```bash
cd "$(mktemp --directory)"
cabal init --exe --simple
ln -s I-do-not-exist cabal.project
cabal build
```
**Expected behavour:** cabal ignores the broken link and builds the project (ignoring the `cabal.project` and not signaling anything)

#### Patched version

Then, slighly adapting the example provided in the issue
```bash
cd "$(mktemp --directory)"
patchedCabal init --exe --simple
ln -s I-do-not-exist cabal.project
patchedCabal build
```
**Expected behavour:**  cabal should exit with status code `1` and should print:
```
The given project file 'cabal.project' is broken. Is it a broken symbolic link?
```
--- 
Resolves #9937 