### PR TITLE
Fix recomp bug by invalidating cache on build exception

### DIFF
--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -99,7 +99,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as LBS.Char8
 import qualified Data.List.NonEmpty as NE
 
-import Control.Exception (ErrorCall, Handler (..), SomeAsyncException, assert, catches)
+import Control.Exception (ErrorCall, Handler (..), SomeAsyncException, assert, catches, onException)
 import System.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, removeFile)
 import System.FilePath (dropDrive, normalise, takeDirectory, (<.>), (</>))
 import System.IO (Handle, IOMode (AppendMode), withFile)
@@ -480,6 +480,10 @@ buildInplaceUnpackedPackage
           whenRebuild $ do
             timestamp <- beginUpdateFileMonitor
             runBuild
+              -- Be sure to invalidate the cache if building throws an exception!
+              -- If not, we'll abort execution with a stale recompilation cache.
+              -- See ghc#24926 for an example of how this can go wrong.
+              `onException` invalidatePackageRegFileMonitor packageFileMonitor
 
             let listSimple =
                   execRebuild (getSymbolicPath srcdir) (needElaboratedConfiguredPackage pkg)

--- a/cabal-testsuite/PackageTests/Recompilation/GHC24926/Repro.hs
+++ b/cabal-testsuite/PackageTests/Recompilation/GHC24926/Repro.hs
@@ -1,0 +1,6 @@
+import Process (a)
+import Internal (Unused)
+
+main :: IO ()
+main = a
+

--- a/cabal-testsuite/PackageTests/Recompilation/GHC24926/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Recompilation/GHC24926/cabal.test.hs
@@ -1,0 +1,36 @@
+import Test.Cabal.Prelude
+
+-- See ghc#24926
+main = cabalTest $ do
+  recordMode DoNotRecord $ do
+
+    root <- testTmpDir <$> getTestEnv
+
+    writeInternalOrig root
+    cabal "test" []
+
+    liftIO $ writeFile (root ++ "/src/Internal.hs")
+      " module Internal where;\
+
+      \ data Unused = Unused;"
+    fails $ cabal "test" [] -- broken module on purpose
+
+    writeInternalOrig root
+    out <- cabal' "test" [] -- shouldn't fail!
+
+    assertOutputDoesNotContain
+      "<no location info>: error:" out
+    assertOutputDoesNotContain
+      "Cannot continue after interface file error" out
+
+  where
+
+    writeInternalOrig r = liftIO $ do
+      writeFile (r ++ "/src/Internal.hs")
+        " module Internal where;\
+
+        \ data Unused = Unused;\
+
+        \ b :: IO (); \
+        \ b = pure ();"
+

--- a/cabal-testsuite/PackageTests/Recompilation/GHC24926/repro.cabal
+++ b/cabal-testsuite/PackageTests/Recompilation/GHC24926/repro.cabal
@@ -1,0 +1,19 @@
+cabal-version:      3.0
+name:               repro
+version:            0.1.0.0
+build-type:         Simple
+
+library
+  default-language: Haskell2010
+  exposed-modules:
+    Internal
+    Process
+  build-depends: base
+  hs-source-dirs: src
+
+test-suite repro
+  default-language: Haskell2010
+  type:          exitcode-stdio-1.0
+  main-is:       Repro.hs
+  build-depends: base, repro
+

--- a/cabal-testsuite/PackageTests/Recompilation/GHC24926/src/Process.hs
+++ b/cabal-testsuite/PackageTests/Recompilation/GHC24926/src/Process.hs
@@ -1,0 +1,7 @@
+module Process where
+
+import Internal
+
+a :: IO ()
+a = b
+


### PR DESCRIPTION
Be sure to invalidate the cache if building throws an exception! If not, we'll abort execution with a stale recompilation cache. See ghc#24926 for an example of how this can go wrong.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
