### PR TITLE
Let `cabal init` remember chosen language within current session

### DIFF
--- a/cabal-install/src/Distribution/Client/Init.hs
+++ b/cabal-install/src/Distribution/Client/Init.hs
@@ -41,11 +41,7 @@ initCmd v packageDBs repoCtxt comp progdb initFlags = do
   installedPkgIndex <- getInstalledPackages v comp packageDBs progdb
   sourcePkgDb <- getSourcePackages v repoCtxt
   hSetBuffering stdout NoBuffering
-  runPromptIO
-    ( do
-        settings <- createProject v installedPkgIndex sourcePkgDb initFlags
-        writeProject settings
-    )
+  runPromptIO (writeProject =<< createProject v installedPkgIndex sourcePkgDb initFlags)
   where
     -- When no flag is set, default to interactive.
     --

--- a/cabal-install/src/Distribution/Client/Init.hs
+++ b/cabal-install/src/Distribution/Client/Init.hs
@@ -41,8 +41,11 @@ initCmd v packageDBs repoCtxt comp progdb initFlags = do
   installedPkgIndex <- getInstalledPackages v comp packageDBs progdb
   sourcePkgDb <- getSourcePackages v repoCtxt
   hSetBuffering stdout NoBuffering
-  settings <- createProject v installedPkgIndex sourcePkgDb initFlags
-  writeProject settings
+  runPromptIO
+    ( do
+        settings <- createProject v installedPkgIndex sourcePkgDb initFlags
+        writeProject settings
+    )
   where
     -- When no flag is set, default to interactive.
     --

--- a/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
+++ b/cabal-install/src/Distribution/Client/Init/Interactive/Command.hs
@@ -460,13 +460,17 @@ languagePrompt flags pkgType = getLanguage flags $ do
       ghc2021 = "GHC2021 (requires at least GHC 9.2)"
       ghc2024 = "GHC2024 (requires at least GHC 9.10)"
 
+  lastChosenLanguage <- getLastChosenLanguage
+
   l <-
     promptList
       ("Choose a language for your " ++ pkgType)
       [h2010, h98, ghc2021, ghc2024]
-      (DefaultPrompt h2010)
+      (DefaultPrompt (maybe h2010 id lastChosenLanguage))
       Nothing
       True
+
+  setLastChosenLanguage (Just l)
 
   if
       | l == h2010 -> return Haskell2010

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -296,7 +296,7 @@ runPromptIO pio =
   (Data.IORef.newIORef _newSessionState) >>= (runReaderT pio)
 
 newtype PurePrompt a = PurePrompt
-  { _runPromptState
+  { runPromptState
       :: (NonEmpty String, SessionState)
       -> Either BreakException (a, (NonEmpty String, SessionState))
   }
@@ -304,7 +304,7 @@ newtype PurePrompt a = PurePrompt
 
 runPrompt :: PurePrompt a -> NonEmpty String -> Either BreakException (a, NonEmpty String)
 runPrompt act args =
-  (fmap (\(a, (s, _)) -> (a, s))) (_runPromptState act (args, _newSessionState))
+  (fmap (\(a, (s, _)) -> (a, s))) (runPromptState act (args, _newSessionState))
 
 evalPrompt :: PurePrompt a -> NonEmpty String -> a
 evalPrompt act s = case runPrompt act s of
@@ -323,7 +323,7 @@ instance Monad PurePrompt where
   return = pure
   PurePrompt a >>= k = PurePrompt $ \s -> case a s of
     Left e -> Left e
-    Right (a', s') -> _runPromptState (k a') s'
+    Right (a', s') -> runPromptState (k a') s'
 
 class Monad m => Interactive m where
   -- input functions

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -291,7 +291,10 @@ mkLiterate _ hs = hs
 -- Interactive prompt monad
 
 newtype PromptIO a = PromptIO (ReaderT (Data.IORef.IORef SessionState) IO a)
-  deriving (Functor, Applicative, Monad, MonadIO, MonadReader (Data.IORef.IORef SessionState))
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+sessionState :: PromptIO (Data.IORef.IORef SessionState)
+sessionState = PromptIO ask
 
 runPromptIO :: PromptIO a -> IO a
 runPromptIO (PromptIO pio) =
@@ -410,11 +413,11 @@ instance Interactive PromptIO where
   throwPrompt = liftIO <$> throwM
 
   getLastChosenLanguage = do
-    stateRef <- ask
+    stateRef <- sessionState
     liftIO $ lastChosenLanguage <$> Data.IORef.readIORef stateRef
 
   setLastChosenLanguage value = do
-    stateRef <- ask
+    stateRef <- sessionState
     liftIO $
       Data.IORef.modifyIORef
         stateRef

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -294,7 +294,7 @@ type PromptIO = ReaderT (Data.IORef.IORef SessionState) IO
 
 runPromptIO :: PromptIO a -> IO a
 runPromptIO pio =
-  (Data.IORef.newIORef _newSessionState) >>= (runReaderT pio)
+  (Data.IORef.newIORef newSessionState) >>= (runReaderT pio)
 
 type Inputs = NonEmpty String
 
@@ -307,7 +307,9 @@ newtype PurePrompt a = PurePrompt
 
 runPrompt :: PurePrompt a -> Inputs -> Either BreakException (a, Inputs)
 runPrompt act args =
-  (fmap (\(a, (s, _)) -> (a, s))) (runPromptState act (args, _newSessionState))
+  fmap 
+    (\(a, (s, _)) -> (a, s)) 
+    (runPromptState act (args, newSessionState))
 
 evalPrompt :: PurePrompt a -> Inputs -> a
 evalPrompt act s = case runPrompt act s of
@@ -369,8 +371,8 @@ newtype SessionState = SessionState
   { lastChosenLanguage :: (Maybe String)
   }
 
-_newSessionState :: SessionState
-_newSessionState = SessionState{lastChosenLanguage = Nothing}
+newSessionState :: SessionState
+newSessionState = SessionState{lastChosenLanguage = Nothing}
 
 instance Interactive PromptIO where
   getLine = liftIO P.getLine

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -458,18 +458,18 @@ instance Interactive PurePrompt where
     _ -> return ()
 
   break = return True
-  throwPrompt (BreakException e) = PurePrompt $ \(s, _) ->
+  throwPrompt (BreakException e) = PurePrompt $ \(i, _) ->
     Left $
       BreakException
-        ("Error: " ++ e ++ "\nStacktrace: " ++ show s)
+        ("Error: " ++ e ++ "\nStacktrace: " ++ show i)
 
-  getLastChosenLanguage = PurePrompt $ \(s, ss) ->
-    Right (lastChosenLanguage ss, (s, ss))
-  setLastChosenLanguage l = PurePrompt $ \(s, ss) ->
-    Right ((), (s, ss{lastChosenLanguage = l}))
+  getLastChosenLanguage = PurePrompt $ \(i, s) ->
+    Right (lastChosenLanguage s, (i, s))
+  setLastChosenLanguage l = PurePrompt $ \(i, s) ->
+    Right ((), (i, s{lastChosenLanguage = l}))
 
 pop :: PurePrompt String
-pop = PurePrompt $ \(p :| ps, ss) -> Right (p, (fromList ps, ss))
+pop = PurePrompt $ \(i :| is, s) -> Right (i, (fromList is, s))
 
 popAbsolute :: PurePrompt String
 popAbsolute = do
@@ -481,7 +481,7 @@ popBool =
   pop >>= \case
     "True" -> pure True
     "False" -> pure False
-    s -> throwPrompt $ BreakException $ "popBool: " ++ s
+    i -> throwPrompt $ BreakException $ "popBool: " ++ i
 
 popList :: PurePrompt [String]
 popList =

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -44,7 +44,7 @@ module Distribution.Client.Init.Types
   , PromptIO
   , runPromptIO
   , PurePrompt
-  , _runPrompt
+  , runPrompt
   , evalPrompt
   , Severity (..)
 
@@ -302,12 +302,12 @@ newtype PurePrompt a = PurePrompt
   }
   deriving (Functor)
 
-_runPrompt :: PurePrompt a -> NonEmpty String -> Either BreakException (a, NonEmpty String)
-_runPrompt act args =
+runPrompt :: PurePrompt a -> NonEmpty String -> Either BreakException (a, NonEmpty String)
+runPrompt act args =
   (fmap (\(a, (s, _)) -> (a, s))) (_runPromptState act (args, _newSessionState))
 
 evalPrompt :: PurePrompt a -> NonEmpty String -> a
-evalPrompt act s = case _runPrompt act s of
+evalPrompt act s = case runPrompt act s of
   Left e -> error $ show e
   Right (a, _) -> a
 

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -43,6 +43,7 @@ module Distribution.Client.Init.Types
   , BreakException (..)
   , PromptIO
   , runPromptIO
+  , Inputs
   , PurePrompt
   , runPrompt
   , evalPrompt
@@ -295,18 +296,20 @@ runPromptIO :: PromptIO a -> IO a
 runPromptIO pio =
   (Data.IORef.newIORef _newSessionState) >>= (runReaderT pio)
 
+type Inputs = NonEmpty String
+
 newtype PurePrompt a = PurePrompt
   { runPromptState
-      :: (NonEmpty String, SessionState)
-      -> Either BreakException (a, (NonEmpty String, SessionState))
+      :: (Inputs, SessionState)
+      -> Either BreakException (a, (Inputs, SessionState))
   }
   deriving (Functor)
 
-runPrompt :: PurePrompt a -> NonEmpty String -> Either BreakException (a, NonEmpty String)
+runPrompt :: PurePrompt a -> Inputs -> Either BreakException (a, Inputs)
 runPrompt act args =
   (fmap (\(a, (s, _)) -> (a, s))) (runPromptState act (args, _newSessionState))
 
-evalPrompt :: PurePrompt a -> NonEmpty String -> a
+evalPrompt :: PurePrompt a -> Inputs -> a
 evalPrompt act s = case runPrompt act s of
   Left e -> error $ show e
   Right (a, _) -> a

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 
 -- |
 -- Module      :  Distribution.Client.Init.Types

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- |
 -- Module      :  Distribution.Client.Init.Types
@@ -310,8 +310,8 @@ newtype PurePrompt a = PurePrompt
 
 runPrompt :: PurePrompt a -> Inputs -> Either BreakException (a, Inputs)
 runPrompt act args =
-  fmap 
-    (\(a, (s, _)) -> (a, s)) 
+  fmap
+    (\(a, (s, _)) -> (a, s))
     (runPromptState act (args, newSessionState))
 
 evalPrompt :: PurePrompt a -> Inputs -> a

--- a/cabal-install/src/Distribution/Client/InstallSymlink.hs
+++ b/cabal-install/src/Distribution/Client/InstallSymlink.hs
@@ -99,7 +99,7 @@ import System.IO.Error
 
 import Distribution.Client.Compat.Directory (createFileLink, getSymbolicLinkTarget, pathIsSymbolicLink)
 import Distribution.Client.Init.Prompt (promptYesNo)
-import Distribution.Client.Init.Types (DefaultPrompt (MandatoryPrompt))
+import Distribution.Client.Init.Types (DefaultPrompt (MandatoryPrompt), runPromptIO)
 import Distribution.Client.Types.OverwritePolicy
 
 import qualified Data.ByteString as BS
@@ -336,7 +336,7 @@ symlinkBinary inputs@Symlink{publicBindir, privateBindir, publicName, privateNam
 
 promptRun :: String -> IO Bool -> IO Bool
 promptRun s m = do
-  a <- promptYesNo s MandatoryPrompt
+  a <- runPromptIO $ promptYesNo s MandatoryPrompt
   if a then m else pure a
 
 -- | Check a file path of a symlink that we would like to create to see if it

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/PackageFileMonitor.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/PackageFileMonitor.hs
@@ -26,7 +26,7 @@ import Distribution.Simple.LocalBuildInfo
   )
 
 import qualified Data.Set as Set
-import Distribution.Client.Init.Types (removeExistingFile)
+import Distribution.Client.Init.Types (removeExistingFile, runPromptIO)
 
 -----------------------------
 -- Package change detection
@@ -291,4 +291,4 @@ updatePackageRegFileMonitor
 
 invalidatePackageRegFileMonitor :: PackageFileMonitor -> IO ()
 invalidatePackageRegFileMonitor PackageFileMonitor{pkgFileMonitorReg} =
-  removeExistingFile (fileMonitorCacheFile pkgFileMonitorReg)
+  runPromptIO $ removeExistingFile (fileMonitorCacheFile pkgFileMonitorReg)

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/FileCreators.hs
@@ -81,7 +81,7 @@ tests _v _initFlags comp pkgIx srcDb =
                 "False"
               ]
 
-        case flip _runPrompt inputs $ do
+        case flip runPrompt inputs $ do
           projSettings <- createProject comp silent pkgIx srcDb dummyFlags'
           writeProject projSettings of
           Left (BreakException ex) -> assertFailure $ show ex

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Golden.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Golden.hs
@@ -105,7 +105,7 @@ goldenPkgDescTests v srcDb pkgDir pkgName =
     ]
   where
     runPkgDesc opts flags args = do
-      case _runPrompt (genPkgDescription flags srcDb) args of
+      case runPrompt (genPkgDescription flags srcDb) args of
         Left e -> assertFailure $ show e
         Right (pkg, _) -> mkStanza $ mkPkgDescription opts pkg
 
@@ -146,7 +146,7 @@ goldenExeTests v pkgIx pkgDir pkgName =
     ]
   where
     runGoldenExe opts args flags =
-      case _runPrompt (genExeTarget flags pkgIx) args of
+      case runPrompt (genExeTarget flags pkgIx) args of
         Right (t, _) -> mkStanza [mkExeStanza opts $ t{_exeDependencies = mangleBaseDep t _exeDependencies}]
         Left e -> assertFailure $ show e
 
@@ -192,7 +192,7 @@ goldenLibTests v pkgIx pkgDir pkgName =
     ]
   where
     runGoldenLib opts args flags =
-      case _runPrompt (genLibTarget flags pkgIx) args of
+      case runPrompt (genLibTarget flags pkgIx) args of
         Right (t, _) -> mkStanza [mkLibStanza opts $ t{_libDependencies = mangleBaseDep t _libDependencies}]
         Left e -> assertFailure $ show e
 
@@ -243,7 +243,7 @@ goldenTestTests v pkgIx pkgDir pkgName =
     ]
   where
     runGoldenTest opts args flags =
-      case _runPrompt (genTestTarget flags pkgIx) args of
+      case runPrompt (genTestTarget flags pkgIx) args of
         Left e -> assertFailure $ show e
         Right (Nothing, _) ->
           assertFailure
@@ -286,7 +286,7 @@ goldenCabalTests v pkgIx srcDb =
     ]
   where
     runGoldenTest args flags =
-      case _runPrompt (createProject v pkgIx srcDb flags) args of
+      case runPrompt (createProject v pkgIx srcDb flags) args of
         Left e -> assertFailure $ show e
         (Right (ProjectSettings opts pkgDesc (Just libTarget) (Just exeTarget) (Just testTarget), _)) -> do
           let pkgFields = mkPkgDescription opts pkgDesc

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
@@ -1031,6 +1031,20 @@ interactiveTests srcDb =
                 ]
             ]
         , testGroup
+            "Check languagePrompt session state"
+            [ testSimplePrompt
+                "Use last language"
+                ( \flags -> do
+                    a <- languagePrompt flags "first language"
+                    b <- languagePrompt flags "second language"
+                    pure (a, b)
+                )
+                (GHC2024, GHC2024)
+                [ "4"
+                , "" -- default
+                ]
+            ]
+        , testGroup
             "Check srcDirsPrompt output"
             [ testNumberedPrompt
                 "Source dirs indices"

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Interactive.hs
@@ -76,7 +76,7 @@ createProjectTest pkgIx srcDb =
                     , dependencies = Flag []
                     }
 
-            case (_runPrompt $ createProject silent pkgIx srcDb dummyFlags') (fromList ["[]", "3", "quxTest/Main.hs"]) of
+            case (runPrompt $ createProject silent pkgIx srcDb dummyFlags') (fromList ["[]", "3", "quxTest/Main.hs"]) of
               Right (ProjectSettings opts desc (Just lib) (Just exe) (Just test), _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -186,7 +186,7 @@ createProjectTest pkgIx srcDb =
                       "y"
                     ]
 
-            case (_runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc (Just lib) (Just exe) (Just test), _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -286,7 +286,7 @@ createProjectTest pkgIx srcDb =
                       "y"
                     ]
 
-            case (_runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc (Just lib) Nothing (Just test), _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -372,7 +372,7 @@ createProjectTest pkgIx srcDb =
                       "y"
                     ]
 
-            case (_runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc Nothing Nothing (Just test), _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -460,7 +460,7 @@ createProjectTest pkgIx srcDb =
                       "y"
                     ]
 
-            case (_runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc (Just lib) (Just exe) Nothing, _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -546,7 +546,7 @@ createProjectTest pkgIx srcDb =
                       "y"
                     ]
 
-            case (_runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc (Just lib) Nothing Nothing, _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -631,7 +631,7 @@ createProjectTest pkgIx srcDb =
                     , extraSrc = Flag ["README.md"]
                     }
 
-            case (_runPrompt $ createProject silent pkgIx srcDb flags) inputs of
+            case (runPrompt $ createProject silent pkgIx srcDb flags) inputs of
               Right (ProjectSettings opts desc (Just lib) Nothing Nothing, _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -709,7 +709,7 @@ createProjectTest pkgIx srcDb =
                       "y"
                     ]
 
-            case (_runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject silent pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc Nothing (Just exe) Nothing, _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -809,7 +809,7 @@ fileCreatorTests pkgIx srcDb _pkgName =
         ]
     ]
   where
-    runGenTest inputs go = case _runPrompt go inputs of
+    runGenTest inputs go = case runPrompt go inputs of
       Left e -> assertFailure $ show e
       Right{} -> return ()
 
@@ -1127,7 +1127,7 @@ testPrompt
   -> [String]
   -> TestTree
 testPrompt label f g h input = testCase label $
-  case (_runPrompt $ f emptyFlags) (fromList input) of
+  case (runPrompt $ f emptyFlags) (fromList input) of
     Left x -> g x -- :: BreakException
     Right x -> h x -- :: (a, other inputs)
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/NonInteractive.hs
@@ -93,7 +93,7 @@ driverFunctionTest pkgIx srcDb comp =
                     , "[\"quxTest/Main.hs\"]"
                     ]
 
-            case (_runPrompt $ createProject comp silent pkgIx srcDb dummyFlags') inputs of
+            case (runPrompt $ createProject comp silent pkgIx srcDb dummyFlags') inputs of
               Right (ProjectSettings opts desc (Just lib) (Just exe) (Just test), _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -180,7 +180,7 @@ driverFunctionTest pkgIx srcDb comp =
                       "False"
                     ]
 
-            case (_runPrompt $ createProject comp silent pkgIx srcDb dummyFlags') inputs of
+            case (runPrompt $ createProject comp silent pkgIx srcDb dummyFlags') inputs of
               Right (ProjectSettings opts desc (Just lib) (Just exe) (Just test), _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -356,7 +356,7 @@ driverFunctionTest pkgIx srcDb comp =
                     , "[\"test/Main.hs\", \"test/Foo.hs\", \"test/bar.y\"]"
                     ]
 
-            case ( _runPrompt $
+            case ( runPrompt $
                     createProject
                       comp
                       silent
@@ -508,7 +508,7 @@ driverFunctionTest pkgIx srcDb comp =
                     , "[\"test/Main.hs\", \"test/Foo.hs\", \"test/bar.y\"]"
                     ]
 
-            case ( _runPrompt $
+            case ( runPrompt $
                     createProject
                       comp
                       silent
@@ -664,7 +664,7 @@ driverFunctionTest pkgIx srcDb comp =
                     , "[\"app/Main.hs\", \"src/Foo.hs\", \"src/bar.y\"]"
                     ]
 
-            case (_runPrompt $ createProject comp silent pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject comp silent pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc (Just lib) (Just exe) Nothing, _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -774,7 +774,7 @@ driverFunctionTest pkgIx srcDb comp =
                     , "[\"app/Main.hs\", \"src/Foo.hs\", \"src/bar.y\"]"
                     ]
 
-            case (_runPrompt $ createProject comp silent pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject comp silent pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc (Just lib) Nothing Nothing, _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -865,7 +865,7 @@ driverFunctionTest pkgIx srcDb comp =
                     , "[\"app/Main.hs\", \"src/Foo.hs\", \"src/bar.y\"]"
                     ]
 
-            case (_runPrompt $ createProject comp silent pkgIx srcDb emptyFlags) inputs of
+            case (runPrompt $ createProject comp silent pkgIx srcDb emptyFlags) inputs of
               Right (ProjectSettings opts desc Nothing (Just exe) Nothing, _) -> do
                 _optOverwrite opts @?= False
                 _optMinimal opts @?= False
@@ -931,7 +931,7 @@ fileCreatorTests pkgIx srcDb comp =
                     , "[]"
                     ]
 
-            case (_runPrompt $ genPkgDescription emptyFlags srcDb) inputs of
+            case (runPrompt $ genPkgDescription emptyFlags srcDb) inputs of
               Left e -> assertFailure $ show e
               Right{} -> return ()
         ]
@@ -980,7 +980,7 @@ fileCreatorTests pkgIx srcDb comp =
                     , "[\"app/Main.hs\", \"src/Foo.hs\", \"src/bar.y\"]"
                     ]
 
-            case (_runPrompt $ genLibTarget emptyFlags comp pkgIx defaultCabalVersion) inputs of
+            case (runPrompt $ genLibTarget emptyFlags comp pkgIx defaultCabalVersion) inputs of
               Left e -> assertFailure $ show e
               Right{} -> return ()
         ]
@@ -1021,7 +1021,7 @@ fileCreatorTests pkgIx srcDb comp =
                     , "[\"app/Main.hs\", \"src/Foo.hs\", \"src/bar.y\"]"
                     ]
 
-            case (_runPrompt $ genExeTarget emptyFlags comp pkgIx defaultCabalVersion) inputs of
+            case (runPrompt $ genExeTarget emptyFlags comp pkgIx defaultCabalVersion) inputs of
               Left e -> assertFailure $ show e
               Right{} -> return ()
         ]
@@ -1058,7 +1058,7 @@ fileCreatorTests pkgIx srcDb comp =
                     ]
                 flags = emptyFlags{initializeTestSuite = Flag True}
 
-            case (_runPrompt $ genTestTarget flags comp pkgIx defaultCabalVersion) inputs of
+            case (runPrompt $ genTestTarget flags comp pkgIx defaultCabalVersion) inputs of
               Left e -> assertFailure $ show e
               Right{} -> return ()
         ]
@@ -1403,7 +1403,7 @@ testGo
   -> [String]
   -> TestTree
 testGo label f g h inputs = testCase label $
-  case (_runPrompt $ f emptyFlags) (NEL.fromList inputs) of
+  case (runPrompt $ f emptyFlags) (NEL.fromList inputs) of
     Left x -> g x
     Right x -> h x
 

--- a/cabal-install/tests/UnitTests/Distribution/Client/Init/Simple.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Client/Init/Simple.hs
@@ -69,7 +69,7 @@ simpleCreateProjectTests v pkgIx srcDb pkgName =
                 Nothing
                 Nothing
 
-        case _runPrompt (createProject v pkgIx srcDb flags) inputs of
+        case runPrompt (createProject v pkgIx srcDb flags) inputs of
           Left e -> assertFailure $ "Failed to create simple lib project: " ++ show e
           Right (settings', _) -> settings @=? settings'
     , testCase "Simple lib createProject - with tests" $ do
@@ -83,7 +83,7 @@ simpleCreateProjectTests v pkgIx srcDb pkgName =
                 Nothing
                 (Just $ simpleTestTarget (Just pkgName) baseDep)
 
-        case _runPrompt (createProject v pkgIx srcDb flags) inputs of
+        case runPrompt (createProject v pkgIx srcDb flags) inputs of
           Left e -> assertFailure $ "Failed to create simple lib (with tests)project: " ++ show e
           Right (settings', _) -> settings @=? settings'
     , testCase "Simple exe createProject" $ do
@@ -97,7 +97,7 @@ simpleCreateProjectTests v pkgIx srcDb pkgName =
                 (Just $ simpleExeTarget Nothing baseDep)
                 Nothing
 
-        case _runPrompt (createProject v pkgIx srcDb flags) inputs of
+        case runPrompt (createProject v pkgIx srcDb flags) inputs of
           Left e -> assertFailure $ "Failed to create simple exe project: " ++ show e
           Right (settings', _) -> settings @=? settings'
     , testCase "Simple lib+exe createProject - no tests" $ do
@@ -111,7 +111,7 @@ simpleCreateProjectTests v pkgIx srcDb pkgName =
                 (Just $ simpleExeTarget (Just pkgName) baseDep)
                 Nothing
 
-        case _runPrompt (createProject v pkgIx srcDb flags) inputs of
+        case runPrompt (createProject v pkgIx srcDb flags) inputs of
           Left e -> assertFailure $ "Failed to create simple lib+exe project: " ++ show e
           Right (settings', _) -> settings @=? settings'
     , testCase "Simple lib+exe createProject - with tests" $ do
@@ -125,7 +125,7 @@ simpleCreateProjectTests v pkgIx srcDb pkgName =
                 (Just $ simpleExeTarget (Just pkgName) baseDep)
                 (Just $ simpleTestTarget (Just pkgName) baseDep)
 
-        case _runPrompt (createProject v pkgIx srcDb flags) inputs of
+        case runPrompt (createProject v pkgIx srcDb flags) inputs of
           Left e -> assertFailure $ "Failed to create simple lib+exe (with tests) project: " ++ show e
           Right (settings', _) -> settings @=? settings'
     , testCase "Simple standalone tests" $ do
@@ -139,12 +139,12 @@ simpleCreateProjectTests v pkgIx srcDb pkgName =
                 Nothing
                 (Just $ simpleTestTarget Nothing baseDep)
 
-        case _runPrompt (createProject v pkgIx srcDb flags) inputs of
+        case runPrompt (createProject v pkgIx srcDb flags) inputs of
           Left e -> assertFailure $ "Failed to create simple standalone test project: " ++ show e
           Right (settings', _) -> settings @=? settings'
     ]
   where
-    baseDep = case _runPrompt (getBaseDep pkgIx emptyFlags) $ fromList [] of
+    baseDep = case runPrompt (getBaseDep pkgIx emptyFlags) $ fromList [] of
       Left e -> error $ show e
       Right a -> fst a
 

--- a/changelog.d/pr-10115
+++ b/changelog.d/pr-10115
@@ -1,0 +1,10 @@
+synopsis: Let cabal init remember chosen language within current session
+packages: cabal-install
+prs: #10115
+issues: #10096
+
+description: {
+
+When cabal init asks for a language, the last choice will be used as the new default for the current session.
+
+}


### PR DESCRIPTION
Fixes #10096

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

## QA Notes

Call `cabal init` and choose a package build that will end up asking for multiple languages. The last language you choose it should be the default option the next time. This way the user will just need to confirm that the same language is wanted.

```
% cabal init

Warning: The package list for 'hackage.haskell.org' is 24 days old.
Run 'cabal update' to get the latest list of available packages.
What does the package build:
   1) Library
 * 2) Executable
   3) Library and Executable
   4) Test suite
Your choice? [default: Executable] 3

...

Choose a language for your library:
 * 1) Haskell2010
   2) Haskell98
   3) GHC2021 (requires at least GHC 9.2)
   4) Other (specify)
Your choice? [default: Haskell2010] 3

...

Choose a language for your executable:
   1) Haskell2010
   2) Haskell98
 * 3) GHC2021 (requires at least GHC 9.2)
   4) Other (specify)
Your choice? [default: GHC2021]

...

Choose a language for your test suite:
   1) Haskell2010
   2) Haskell98
 * 3) GHC2021 (requires at least GHC 9.2)
   4) Other (specify)
Your choice? [default: GHC2021]
```