### PR TITLE
Depend on tar-0.6.3.0

### DIFF
--- a/bootstrap/generate_bootstrap_plans
+++ b/bootstrap/generate_bootstrap_plans
@@ -3,7 +3,7 @@ PATH+=:$PWD/jq-bin/bin
 
 ghcs_nix="https://gitlab.haskell.org/bgamari/ghcs-nix/-/archive/master/ghcs-nix-master.tar.gz"
 
-nix build -f "$ghcs_nix" ghc-8_10_7 -o boot_ghc
+nix build -f "$ghcs_nix" ghc-9_6_5 -o boot_ghc
 
 run() {
   local ver="$1"

--- a/bootstrap/linux-8.10.7.json
+++ b/bootstrap/linux-8.10.7.json
@@ -1,574 +1,575 @@
 {
-    "builtin": [
-        {
-            "package": "rts",
-            "version": "1.0.1"
-        },
-        {
-            "package": "ghc-prim",
-            "version": "0.6.1"
-        },
-        {
-            "package": "integer-gmp",
-            "version": "1.0.3.0"
-        },
-        {
-            "package": "base",
-            "version": "4.14.3.0"
-        },
-        {
-            "package": "array",
-            "version": "0.5.4.0"
-        },
-        {
-            "package": "deepseq",
-            "version": "1.4.4.0"
-        },
-        {
-            "package": "containers",
-            "version": "0.6.5.1"
-        },
-        {
-            "package": "ghc-boot-th",
-            "version": "8.10.7"
-        },
-        {
-            "package": "pretty",
-            "version": "1.1.3.6"
-        },
-        {
-            "package": "template-haskell",
-            "version": "2.16.0.0"
-        },
-        {
-            "package": "transformers",
-            "version": "0.5.6.2"
-        },
-        {
-            "package": "mtl",
-            "version": "2.2.2"
-        },
-        {
-            "package": "stm",
-            "version": "2.5.0.1"
-        },
-        {
-            "package": "exceptions",
-            "version": "0.10.4"
-        },
-        {
-            "package": "time",
-            "version": "1.9.3"
-        }
-    ],
-    "dependencies": [
-        {
-            "cabal_sha256": "a4a1975fde77e289b605c45a3ef78d731d8c1834e4cef311152d910a1e94d98c",
-            "component": "lib:data-array-byte",
-            "flags": [],
-            "package": "data-array-byte",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
-            "version": "0.1.0.1"
-        },
-        {
-            "cabal_sha256": "98e79e1c97117143e4012983509ec95f7e5e4f6adff6914d07812a39f83404b9",
-            "component": "lib:bytestring",
-            "flags": [
-                "-pure-haskell"
-            ],
-            "package": "bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "ebc3b8a6ef74a5cd6ddbb8d447d1c9a5fd4964c7975ebcae0b8ab0bcc406cc8c",
-            "version": "0.12.1.0"
-        },
-        {
-            "cabal_sha256": "d9e181e1acae0ac505d8b217dec3805c68554878f1e32b3d8351b9ce17061623",
-            "component": "lib:filepath",
-            "flags": [
-                "-cpphs"
-            ],
-            "package": "filepath",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "337a0b5bcf0898cb7f51ff327528cf26f4ac38baed7b66b28fbdea334699d8ed",
-            "version": "1.4.300.1"
-        },
-        {
-            "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
-            "component": "lib:unix",
-            "flags": [
-                "-os-string"
-            ],
-            "package": "unix",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "5ab6c346aef2eb9bf80b4d29ca7e22063fc23e52fd69fbc4d18a9f98b154e424",
-            "version": "2.8.5.1"
-        },
-        {
-            "cabal_sha256": "ae1730011f547153bb52139f217d1d524202b3da730a369660fc539e5dcfff31",
-            "component": "lib:directory",
-            "flags": [
-                "-os-string"
-            ],
-            "package": "directory",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "a4e798a4e5339a7aa9577515886271386280bfbc1fe4a29fd4aa6464d4792064",
-            "version": "1.3.8.4"
-        },
-        {
-            "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
-            "component": "exe:alex",
-            "flags": [],
-            "package": "alex",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
-            "version": "3.5.1.0"
-        },
-        {
-            "cabal_sha256": "03381e511429c44d13990c6d76281c4fc2468371cede4fe684b0c98d9b7d5f5a",
-            "component": "lib:binary",
-            "flags": [],
-            "package": "binary",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "8437116b4eccdba13cb9badb62331c0d4598c3f0252a587e37d8f5990d9bf74c",
-            "version": "0.8.9.2"
-        },
-        {
-            "cabal_sha256": "aa7a5a92fe430a34d24d33878323c8a010021e05e410fe98b7fac3015c88dc74",
-            "component": "lib:text",
-            "flags": [
-                "-developer",
-                "-pure-haskell",
-                "+simdutf"
-            ],
-            "package": "text",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "e40cdda8b285f4d72476ed35dc2f5f167d524e6b38bb5ec964d00ee1ff24feab",
-            "version": "2.1.1"
-        },
-        {
-            "cabal_sha256": "8407cbd428d7f640a0fff8891bd2f7aca13cebe70a5e654856f8abec9a648b56",
-            "component": "lib:parsec",
-            "flags": [],
-            "package": "parsec",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "58c500bec1ec3c849c8243ddfd675a5983b17a8e5da55acea6adade5ae179d36",
-            "version": "3.1.17.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-syntax",
-            "flags": [],
-            "package": "Cabal-syntax",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "7785a72bc140ae5a9ef2439f10637b5fd104999832f1d93328d4973f37cb8469",
-            "component": "lib:process",
-            "flags": [],
-            "package": "process",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "b468355ab46966537eb171ed5593a0a1facc8d2eefc38659e43768f68f5dcb96",
-            "version": "1.6.19.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal",
-            "flags": [],
-            "package": "Cabal",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-hooks",
-            "flags": [],
-            "package": "Cabal-hooks",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "0.1"
-        },
-        {
-            "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
-            "component": "exe:hsc2hs",
-            "flags": [
-                "-in-ghc-tree"
-            ],
-            "package": "hsc2hs",
-            "revision": 2,
-            "source": "hackage",
-            "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
-            "version": "0.68.10"
-        },
-        {
-            "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
-            "component": "lib:network",
-            "flags": [
-                "-devel"
-            ],
-            "package": "network",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
-            "version": "3.2.0.0"
-        },
-        {
-            "cabal_sha256": "0a6ee328b71119d7dfcd004f0ec8feb77e6e78d8f6de1a281568edd3d3b6d83f",
-            "component": "lib:th-compat",
-            "flags": [],
-            "package": "th-compat",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
-            "version": "0.1.5"
-        },
-        {
-            "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
-            "component": "lib:network-uri",
-            "flags": [],
-            "package": "network-uri",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
-            "version": "2.6.4.2"
-        },
-        {
-            "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
-            "component": "lib:HTTP",
-            "flags": [
-                "-conduit10",
-                "+network-uri",
-                "-warn-as-error",
-                "-warp-tests"
-            ],
-            "package": "HTTP",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
-        },
-        {
-            "cabal_sha256": "c4733d09f798fc4304e936924a1a7d9fc2425aefad6c46ad4592035254b46051",
-            "component": "lib:base-orphans",
-            "flags": [],
-            "package": "base-orphans",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "5bbf2da382c5b212d6a8be2f8c49edee0eba30f272a15fd32c13e6e4091ef172",
-            "version": "0.9.1"
-        },
-        {
-            "cabal_sha256": "ae22238274c572aa91e90c6c353e7206386708912ac5e6dc40ac61d1dcc553db",
-            "component": "lib:hashable",
-            "flags": [
-                "+integer-gmp",
-                "-random-initial-seed"
-            ],
-            "package": "hashable",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1fa3d64548440942b2b38b99c76d8dcaa94fa2ea3912cd7a6354ea4ec4af4758",
-            "version": "1.4.4.0"
-        },
-        {
-            "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
-            "component": "lib:async",
-            "flags": [
-                "-bench"
-            ],
-            "package": "async",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
-        },
-        {
-            "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
-            "component": "lib:base16-bytestring",
-            "flags": [],
-            "package": "base16-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
-            "version": "1.0.2.0"
-        },
-        {
-            "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
-            "component": "lib:base64-bytestring",
-            "flags": [],
-            "package": "base64-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
-            "version": "1.2.1.0"
-        },
-        {
-            "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
-            "component": "lib:splitmix",
-            "flags": [
-                "-optimised-mixer"
-            ],
-            "package": "splitmix",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
-            "version": "0.1.0.5"
-        },
-        {
-            "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
-            "component": "lib:random",
-            "flags": [],
-            "package": "random",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
-            "version": "1.2.1.2"
-        },
-        {
-            "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
-            "component": "lib:edit-distance",
-            "flags": [],
-            "package": "edit-distance",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
-            "version": "0.2.2.1"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install-solver",
-            "flags": [
-                "-debug-expensive-assertions",
-                "-debug-tracetree"
-            ],
-            "package": "cabal-install-solver",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
-            "component": "lib:cryptohash-sha256",
-            "flags": [
-                "-exe",
-                "+use-cbits"
-            ],
-            "package": "cryptohash-sha256",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
-            "version": "0.11.102.1"
-        },
-        {
-            "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
-            "component": "lib:echo",
-            "flags": [
-                "-example"
-            ],
-            "package": "echo",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
-            "version": "0.1.4"
-        },
-        {
-            "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
-            "component": "lib:ed25519",
-            "flags": [
-                "+no-donna",
-                "+test-doctests",
-                "+test-hlint",
-                "+test-properties"
-            ],
-            "package": "ed25519",
-            "revision": 8,
-            "source": "hackage",
-            "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
-            "version": "0.0.5.0"
-        },
-        {
-            "cabal_sha256": "17786545dce60c4d5783ba6125c0a6499a1abddd3d7417b15500ccd767c35f07",
-            "component": "lib:lukko",
-            "flags": [
-                "+ofd-locking"
-            ],
-            "package": "lukko",
-            "revision": 5,
-            "source": "hackage",
-            "src_sha256": "a80efb60cfa3dae18682c01980d76d5f7e413e191cd186992e1bf7388d48ab1f",
-            "version": "0.1.1.3"
-        },
-        {
-            "cabal_sha256": "32fa47f8345a2c0662fb602fc42e4b674e41ec48079b68bdecb4b6f68032c24e",
-            "component": "lib:os-string",
-            "flags": [],
-            "package": "os-string",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0953126e962966719753c98d71f596f5fea07e100bce191b7453735a1ff2caa1",
-            "version": "2.0.2"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar-internal",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "64a1925c93e9a26cd4c40c470736950c4b5ea7bae68418cb996c5c7df4873cba",
-            "component": "lib:zlib",
-            "flags": [
-                "-bundled-c-zlib",
-                "+non-blocking-ffi",
-                "-pkg-config"
-            ],
-            "package": "zlib",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "7e43c205e1e1ff5a4b033086ec8cce82ab658879e977c8ba02a6701946ff7a47",
-            "version": "0.7.0.0"
-        },
-        {
-            "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
-            "component": "lib:hackage-security",
-            "flags": [
-                "+cabal-syntax",
-                "+lukko"
-            ],
-            "package": "hackage-security",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
-            "version": "0.6.2.6"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "lib:open-browser",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        },
-        {
-            "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
-            "component": "lib:regex-base",
-            "flags": [],
-            "package": "regex-base",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
-            "version": "0.94.0.2"
-        },
-        {
-            "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
-            "component": "lib:regex-posix",
-            "flags": [
-                "-_regex-posix-clib"
-            ],
-            "package": "regex-posix",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
-            "version": "0.96.0.1"
-        },
-        {
-            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
-            "component": "lib:resolv",
-            "flags": [],
-            "package": "resolv",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
-        },
-        {
-            "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
-            "component": "lib:safe-exceptions",
-            "flags": [],
-            "package": "safe-exceptions",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
-            "version": "0.1.7.4"
-        },
-        {
-            "cabal_sha256": "a8f76076a40409a36ee975970c53273c2089aec9d9ece8168dfc736dfec24b9d",
-            "component": "lib:semaphore-compat",
-            "flags": [],
-            "package": "semaphore-compat",
-            "revision": 2,
-            "source": "hackage",
-            "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
-            "version": "1.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "exe:cabal",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "exe:example",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        }
-    ]
+  "builtin": [
+    {
+      "package": "rts",
+      "version": "1.0.1"
+    },
+    {
+      "package": "ghc-prim",
+      "version": "0.6.1"
+    },
+    {
+      "package": "integer-gmp",
+      "version": "1.0.3.0"
+    },
+    {
+      "package": "base",
+      "version": "4.14.3.0"
+    },
+    {
+      "package": "array",
+      "version": "0.5.4.0"
+    },
+    {
+      "package": "deepseq",
+      "version": "1.4.4.0"
+    },
+    {
+      "package": "containers",
+      "version": "0.6.5.1"
+    },
+    {
+      "package": "ghc-boot-th",
+      "version": "8.10.7"
+    },
+    {
+      "package": "pretty",
+      "version": "1.1.3.6"
+    },
+    {
+      "package": "template-haskell",
+      "version": "2.16.0.0"
+    },
+    {
+      "package": "transformers",
+      "version": "0.5.6.2"
+    },
+    {
+      "package": "mtl",
+      "version": "2.2.2"
+    },
+    {
+      "package": "stm",
+      "version": "2.5.0.1"
+    },
+    {
+      "package": "exceptions",
+      "version": "0.10.4"
+    },
+    {
+      "package": "time",
+      "version": "1.9.3"
+    }
+  ],
+  "dependencies": [
+    {
+      "cabal_sha256": "a4a1975fde77e289b605c45a3ef78d731d8c1834e4cef311152d910a1e94d98c",
+      "component": "lib:data-array-byte",
+      "flags": [],
+      "package": "data-array-byte",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
+      "version": "0.1.0.1"
+    },
+    {
+      "cabal_sha256": "98e79e1c97117143e4012983509ec95f7e5e4f6adff6914d07812a39f83404b9",
+      "component": "lib:bytestring",
+      "flags": [
+        "-pure-haskell"
+      ],
+      "package": "bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "ebc3b8a6ef74a5cd6ddbb8d447d1c9a5fd4964c7975ebcae0b8ab0bcc406cc8c",
+      "version": "0.12.1.0"
+    },
+    {
+      "cabal_sha256": "345cbb1afe414a09e47737e4d14cbd51891a734e67c0ef3d77a1439518bb81e8",
+      "component": "lib:filepath",
+      "flags": [
+        "-cpphs"
+      ],
+      "package": "filepath",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "88d6452fd199e333e66e68d2dc5d715f5c6d361661a4a8add88320a82864b788",
+      "version": "1.4.300.2"
+    },
+    {
+      "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
+      "component": "lib:unix",
+      "flags": [
+        "-os-string"
+      ],
+      "package": "unix",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "5ab6c346aef2eb9bf80b4d29ca7e22063fc23e52fd69fbc4d18a9f98b154e424",
+      "version": "2.8.5.1"
+    },
+    {
+      "cabal_sha256": "fbeec9ec346e5272167f63dcb86af513b457a7b9fc36dc818e4c7b81608d612b",
+      "component": "lib:directory",
+      "flags": [
+        "-os-string"
+      ],
+      "package": "directory",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "e864ed54ddfc6e15d2eb02c87f4be8edd7719e1f9cea13e0f86909400b6ea768",
+      "version": "1.3.8.5"
+    },
+    {
+      "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
+      "component": "exe:alex",
+      "flags": [],
+      "package": "alex",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
+      "version": "3.5.1.0"
+    },
+    {
+      "cabal_sha256": "03381e511429c44d13990c6d76281c4fc2468371cede4fe684b0c98d9b7d5f5a",
+      "component": "lib:binary",
+      "flags": [],
+      "package": "binary",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "8437116b4eccdba13cb9badb62331c0d4598c3f0252a587e37d8f5990d9bf74c",
+      "version": "0.8.9.2"
+    },
+    {
+      "cabal_sha256": "78c3fb91055d0607a80453327f087b9dc82168d41d0dca3ff410d21033b5e87d",
+      "component": "lib:text",
+      "flags": [
+        "-developer",
+        "-pure-haskell",
+        "+simdutf"
+      ],
+      "package": "text",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "e40cdda8b285f4d72476ed35dc2f5f167d524e6b38bb5ec964d00ee1ff24feab",
+      "version": "2.1.1"
+    },
+    {
+      "cabal_sha256": "8407cbd428d7f640a0fff8891bd2f7aca13cebe70a5e654856f8abec9a648b56",
+      "component": "lib:parsec",
+      "flags": [],
+      "package": "parsec",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "58c500bec1ec3c849c8243ddfd675a5983b17a8e5da55acea6adade5ae179d36",
+      "version": "3.1.17.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-syntax",
+      "flags": [],
+      "package": "Cabal-syntax",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "2a9393de33f18415fb8f4826957a87a94ffe8840ca8472a9b69dca6de45aca03",
+      "component": "lib:process",
+      "flags": [],
+      "package": "process",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "cefda221c3009fa2316b5cf148215cb340dad7eb8503f22e49e33722559df99a",
+      "version": "1.6.20.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal",
+      "flags": [],
+      "package": "Cabal",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-hooks",
+      "flags": [],
+      "package": "Cabal-hooks",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "0.1"
+    },
+    {
+      "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
+      "component": "exe:hsc2hs",
+      "flags": [
+        "-in-ghc-tree"
+      ],
+      "package": "hsc2hs",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
+      "version": "0.68.10"
+    },
+    {
+      "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
+      "component": "lib:network",
+      "flags": [
+        "-devel"
+      ],
+      "package": "network",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
+      "version": "3.2.0.0"
+    },
+    {
+      "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
+      "component": "lib:th-compat",
+      "flags": [],
+      "package": "th-compat",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
+      "version": "0.1.5"
+    },
+    {
+      "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
+      "component": "lib:network-uri",
+      "flags": [],
+      "package": "network-uri",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
+      "version": "2.6.4.2"
+    },
+    {
+      "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
+      "component": "lib:HTTP",
+      "flags": [
+        "-conduit10",
+        "+network-uri",
+        "-warn-as-error",
+        "-warp-tests"
+      ],
+      "package": "HTTP",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
+      "version": "4000.4.1"
+    },
+    {
+      "cabal_sha256": "455d863c96cf4b1804772c630a235f535fdb52ca9137a4150967b521ee4734ab",
+      "component": "lib:base-orphans",
+      "flags": [],
+      "package": "base-orphans",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "6211900916955b84687c61b5e4fa98ce110e511a96086b7a93f06dd63c97ba93",
+      "version": "0.9.2"
+    },
+    {
+      "cabal_sha256": "82503a1ef0a625c210e118f2785c4138f8502aacbbfd4e5d987f6baffbb87115",
+      "component": "lib:hashable",
+      "flags": [
+        "+arch-native",
+        "+integer-gmp",
+        "-random-initial-seed"
+      ],
+      "package": "hashable",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "34652a7a1d2fc9e3d764b150bd35bcd2220761c1d4c6b446b0cfac5ad5b778cb",
+      "version": "1.4.6.0"
+    },
+    {
+      "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
+      "component": "lib:async",
+      "flags": [
+        "-bench"
+      ],
+      "package": "async",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
+      "version": "2.2.5"
+    },
+    {
+      "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
+      "component": "lib:base16-bytestring",
+      "flags": [],
+      "package": "base16-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
+      "version": "1.0.2.0"
+    },
+    {
+      "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
+      "component": "lib:base64-bytestring",
+      "flags": [],
+      "package": "base64-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
+      "version": "1.2.1.0"
+    },
+    {
+      "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
+      "component": "lib:splitmix",
+      "flags": [
+        "-optimised-mixer"
+      ],
+      "package": "splitmix",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
+      "version": "0.1.0.5"
+    },
+    {
+      "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
+      "component": "lib:random",
+      "flags": [],
+      "package": "random",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
+      "version": "1.2.1.2"
+    },
+    {
+      "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
+      "component": "lib:edit-distance",
+      "flags": [],
+      "package": "edit-distance",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
+      "version": "0.2.2.1"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install-solver",
+      "flags": [
+        "-debug-expensive-assertions",
+        "-debug-tracetree"
+      ],
+      "package": "cabal-install-solver",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
+      "component": "lib:cryptohash-sha256",
+      "flags": [
+        "-exe",
+        "+use-cbits"
+      ],
+      "package": "cryptohash-sha256",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
+      "version": "0.11.102.1"
+    },
+    {
+      "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
+      "component": "lib:echo",
+      "flags": [
+        "-example"
+      ],
+      "package": "echo",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
+      "version": "0.1.4"
+    },
+    {
+      "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
+      "component": "lib:ed25519",
+      "flags": [
+        "+no-donna",
+        "+test-doctests",
+        "+test-hlint",
+        "+test-properties"
+      ],
+      "package": "ed25519",
+      "revision": 8,
+      "source": "hackage",
+      "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
+      "version": "0.0.5.0"
+    },
+    {
+      "cabal_sha256": "8a3004c2de2a0b5ef0634d3da6eae62ba8d8a734bab9ed8c6cfd749e7ca08997",
+      "component": "lib:lukko",
+      "flags": [
+        "+ofd-locking"
+      ],
+      "package": "lukko",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "72d86f8aa625b461f4397f737346f78a1700a7ffbff55cf6375c5e18916e986d",
+      "version": "0.1.2"
+    },
+    {
+      "cabal_sha256": "4d4186bb8d711435765253c7dc076c44a1d52896300689507ba135706ab35866",
+      "component": "lib:os-string",
+      "flags": [],
+      "package": "os-string",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "f6b388b9f9002622901d3f71437b98f95f54fbf7fe10490d319cb801c2a061ea",
+      "version": "2.0.3"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar-internal",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "d6696f2b55ab4a50b8de57947abca308604eb7cf8287c40bf69cfa26133e24d3",
+      "component": "lib:zlib",
+      "flags": [
+        "-bundled-c-zlib",
+        "+non-blocking-ffi",
+        "-pkg-config"
+      ],
+      "package": "zlib",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
+      "version": "0.7.1.0"
+    },
+    {
+      "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
+      "component": "lib:hackage-security",
+      "flags": [
+        "+cabal-syntax",
+        "+lukko"
+      ],
+      "package": "hackage-security",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
+      "version": "0.6.2.6"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "lib:open-browser",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    },
+    {
+      "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
+      "component": "lib:regex-base",
+      "flags": [],
+      "package": "regex-base",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
+      "version": "0.94.0.2"
+    },
+    {
+      "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
+      "component": "lib:regex-posix",
+      "flags": [
+        "-_regex-posix-clib"
+      ],
+      "package": "regex-posix",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
+      "version": "0.96.0.1"
+    },
+    {
+      "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
+      "component": "lib:resolv",
+      "flags": [],
+      "package": "resolv",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
+      "version": "0.2.0.2"
+    },
+    {
+      "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
+      "component": "lib:safe-exceptions",
+      "flags": [],
+      "package": "safe-exceptions",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
+      "version": "0.1.7.4"
+    },
+    {
+      "cabal_sha256": "2de5218cef72b8ef090bd7d0fd930ffa143242a120c62e013b5cf039858f1855",
+      "component": "lib:semaphore-compat",
+      "flags": [],
+      "package": "semaphore-compat",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
+      "version": "1.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "exe:cabal",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "exe:example",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    }
+  ]
 }

--- a/bootstrap/linux-9.0.2.json
+++ b/bootstrap/linux-9.0.2.json
@@ -1,574 +1,575 @@
 {
-    "builtin": [
-        {
-            "package": "rts",
-            "version": "1.0.2"
-        },
-        {
-            "package": "ghc-prim",
-            "version": "0.7.0"
-        },
-        {
-            "package": "ghc-bignum",
-            "version": "1.1"
-        },
-        {
-            "package": "base",
-            "version": "4.15.1.0"
-        },
-        {
-            "package": "array",
-            "version": "0.5.4.0"
-        },
-        {
-            "package": "deepseq",
-            "version": "1.4.5.0"
-        },
-        {
-            "package": "containers",
-            "version": "0.6.4.1"
-        },
-        {
-            "package": "ghc-boot-th",
-            "version": "9.0.2"
-        },
-        {
-            "package": "pretty",
-            "version": "1.1.3.6"
-        },
-        {
-            "package": "template-haskell",
-            "version": "2.17.0.0"
-        },
-        {
-            "package": "transformers",
-            "version": "0.5.6.2"
-        },
-        {
-            "package": "mtl",
-            "version": "2.2.2"
-        },
-        {
-            "package": "stm",
-            "version": "2.5.0.0"
-        },
-        {
-            "package": "exceptions",
-            "version": "0.10.4"
-        },
-        {
-            "package": "time",
-            "version": "1.9.3"
-        }
-    ],
-    "dependencies": [
-        {
-            "cabal_sha256": "a4a1975fde77e289b605c45a3ef78d731d8c1834e4cef311152d910a1e94d98c",
-            "component": "lib:data-array-byte",
-            "flags": [],
-            "package": "data-array-byte",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
-            "version": "0.1.0.1"
-        },
-        {
-            "cabal_sha256": "98e79e1c97117143e4012983509ec95f7e5e4f6adff6914d07812a39f83404b9",
-            "component": "lib:bytestring",
-            "flags": [
-                "-pure-haskell"
-            ],
-            "package": "bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "ebc3b8a6ef74a5cd6ddbb8d447d1c9a5fd4964c7975ebcae0b8ab0bcc406cc8c",
-            "version": "0.12.1.0"
-        },
-        {
-            "cabal_sha256": "d9e181e1acae0ac505d8b217dec3805c68554878f1e32b3d8351b9ce17061623",
-            "component": "lib:filepath",
-            "flags": [
-                "-cpphs"
-            ],
-            "package": "filepath",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "337a0b5bcf0898cb7f51ff327528cf26f4ac38baed7b66b28fbdea334699d8ed",
-            "version": "1.4.300.1"
-        },
-        {
-            "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
-            "component": "lib:unix",
-            "flags": [
-                "-os-string"
-            ],
-            "package": "unix",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "5ab6c346aef2eb9bf80b4d29ca7e22063fc23e52fd69fbc4d18a9f98b154e424",
-            "version": "2.8.5.1"
-        },
-        {
-            "cabal_sha256": "ae1730011f547153bb52139f217d1d524202b3da730a369660fc539e5dcfff31",
-            "component": "lib:directory",
-            "flags": [
-                "-os-string"
-            ],
-            "package": "directory",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "a4e798a4e5339a7aa9577515886271386280bfbc1fe4a29fd4aa6464d4792064",
-            "version": "1.3.8.4"
-        },
-        {
-            "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
-            "component": "exe:alex",
-            "flags": [],
-            "package": "alex",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
-            "version": "3.5.1.0"
-        },
-        {
-            "cabal_sha256": "03381e511429c44d13990c6d76281c4fc2468371cede4fe684b0c98d9b7d5f5a",
-            "component": "lib:binary",
-            "flags": [],
-            "package": "binary",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "8437116b4eccdba13cb9badb62331c0d4598c3f0252a587e37d8f5990d9bf74c",
-            "version": "0.8.9.2"
-        },
-        {
-            "cabal_sha256": "aa7a5a92fe430a34d24d33878323c8a010021e05e410fe98b7fac3015c88dc74",
-            "component": "lib:text",
-            "flags": [
-                "-developer",
-                "-pure-haskell",
-                "+simdutf"
-            ],
-            "package": "text",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "e40cdda8b285f4d72476ed35dc2f5f167d524e6b38bb5ec964d00ee1ff24feab",
-            "version": "2.1.1"
-        },
-        {
-            "cabal_sha256": "8407cbd428d7f640a0fff8891bd2f7aca13cebe70a5e654856f8abec9a648b56",
-            "component": "lib:parsec",
-            "flags": [],
-            "package": "parsec",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "58c500bec1ec3c849c8243ddfd675a5983b17a8e5da55acea6adade5ae179d36",
-            "version": "3.1.17.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-syntax",
-            "flags": [],
-            "package": "Cabal-syntax",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "7785a72bc140ae5a9ef2439f10637b5fd104999832f1d93328d4973f37cb8469",
-            "component": "lib:process",
-            "flags": [],
-            "package": "process",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "b468355ab46966537eb171ed5593a0a1facc8d2eefc38659e43768f68f5dcb96",
-            "version": "1.6.19.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal",
-            "flags": [],
-            "package": "Cabal",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-hooks",
-            "flags": [],
-            "package": "Cabal-hooks",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "0.1"
-        },
-        {
-            "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
-            "component": "exe:hsc2hs",
-            "flags": [
-                "-in-ghc-tree"
-            ],
-            "package": "hsc2hs",
-            "revision": 2,
-            "source": "hackage",
-            "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
-            "version": "0.68.10"
-        },
-        {
-            "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
-            "component": "lib:network",
-            "flags": [
-                "-devel"
-            ],
-            "package": "network",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
-            "version": "3.2.0.0"
-        },
-        {
-            "cabal_sha256": "0a6ee328b71119d7dfcd004f0ec8feb77e6e78d8f6de1a281568edd3d3b6d83f",
-            "component": "lib:th-compat",
-            "flags": [],
-            "package": "th-compat",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
-            "version": "0.1.5"
-        },
-        {
-            "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
-            "component": "lib:network-uri",
-            "flags": [],
-            "package": "network-uri",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
-            "version": "2.6.4.2"
-        },
-        {
-            "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
-            "component": "lib:HTTP",
-            "flags": [
-                "-conduit10",
-                "+network-uri",
-                "-warn-as-error",
-                "-warp-tests"
-            ],
-            "package": "HTTP",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
-        },
-        {
-            "cabal_sha256": "c4733d09f798fc4304e936924a1a7d9fc2425aefad6c46ad4592035254b46051",
-            "component": "lib:base-orphans",
-            "flags": [],
-            "package": "base-orphans",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "5bbf2da382c5b212d6a8be2f8c49edee0eba30f272a15fd32c13e6e4091ef172",
-            "version": "0.9.1"
-        },
-        {
-            "cabal_sha256": "ae22238274c572aa91e90c6c353e7206386708912ac5e6dc40ac61d1dcc553db",
-            "component": "lib:hashable",
-            "flags": [
-                "+integer-gmp",
-                "-random-initial-seed"
-            ],
-            "package": "hashable",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1fa3d64548440942b2b38b99c76d8dcaa94fa2ea3912cd7a6354ea4ec4af4758",
-            "version": "1.4.4.0"
-        },
-        {
-            "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
-            "component": "lib:async",
-            "flags": [
-                "-bench"
-            ],
-            "package": "async",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
-        },
-        {
-            "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
-            "component": "lib:base16-bytestring",
-            "flags": [],
-            "package": "base16-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
-            "version": "1.0.2.0"
-        },
-        {
-            "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
-            "component": "lib:base64-bytestring",
-            "flags": [],
-            "package": "base64-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
-            "version": "1.2.1.0"
-        },
-        {
-            "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
-            "component": "lib:splitmix",
-            "flags": [
-                "-optimised-mixer"
-            ],
-            "package": "splitmix",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
-            "version": "0.1.0.5"
-        },
-        {
-            "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
-            "component": "lib:random",
-            "flags": [],
-            "package": "random",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
-            "version": "1.2.1.2"
-        },
-        {
-            "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
-            "component": "lib:edit-distance",
-            "flags": [],
-            "package": "edit-distance",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
-            "version": "0.2.2.1"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install-solver",
-            "flags": [
-                "-debug-expensive-assertions",
-                "-debug-tracetree"
-            ],
-            "package": "cabal-install-solver",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
-            "component": "lib:cryptohash-sha256",
-            "flags": [
-                "-exe",
-                "+use-cbits"
-            ],
-            "package": "cryptohash-sha256",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
-            "version": "0.11.102.1"
-        },
-        {
-            "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
-            "component": "lib:echo",
-            "flags": [
-                "-example"
-            ],
-            "package": "echo",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
-            "version": "0.1.4"
-        },
-        {
-            "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
-            "component": "lib:ed25519",
-            "flags": [
-                "+no-donna",
-                "+test-doctests",
-                "+test-hlint",
-                "+test-properties"
-            ],
-            "package": "ed25519",
-            "revision": 8,
-            "source": "hackage",
-            "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
-            "version": "0.0.5.0"
-        },
-        {
-            "cabal_sha256": "17786545dce60c4d5783ba6125c0a6499a1abddd3d7417b15500ccd767c35f07",
-            "component": "lib:lukko",
-            "flags": [
-                "+ofd-locking"
-            ],
-            "package": "lukko",
-            "revision": 5,
-            "source": "hackage",
-            "src_sha256": "a80efb60cfa3dae18682c01980d76d5f7e413e191cd186992e1bf7388d48ab1f",
-            "version": "0.1.1.3"
-        },
-        {
-            "cabal_sha256": "32fa47f8345a2c0662fb602fc42e4b674e41ec48079b68bdecb4b6f68032c24e",
-            "component": "lib:os-string",
-            "flags": [],
-            "package": "os-string",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0953126e962966719753c98d71f596f5fea07e100bce191b7453735a1ff2caa1",
-            "version": "2.0.2"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar-internal",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "64a1925c93e9a26cd4c40c470736950c4b5ea7bae68418cb996c5c7df4873cba",
-            "component": "lib:zlib",
-            "flags": [
-                "-bundled-c-zlib",
-                "+non-blocking-ffi",
-                "-pkg-config"
-            ],
-            "package": "zlib",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "7e43c205e1e1ff5a4b033086ec8cce82ab658879e977c8ba02a6701946ff7a47",
-            "version": "0.7.0.0"
-        },
-        {
-            "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
-            "component": "lib:hackage-security",
-            "flags": [
-                "+cabal-syntax",
-                "+lukko"
-            ],
-            "package": "hackage-security",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
-            "version": "0.6.2.6"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "lib:open-browser",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        },
-        {
-            "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
-            "component": "lib:regex-base",
-            "flags": [],
-            "package": "regex-base",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
-            "version": "0.94.0.2"
-        },
-        {
-            "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
-            "component": "lib:regex-posix",
-            "flags": [
-                "-_regex-posix-clib"
-            ],
-            "package": "regex-posix",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
-            "version": "0.96.0.1"
-        },
-        {
-            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
-            "component": "lib:resolv",
-            "flags": [],
-            "package": "resolv",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
-        },
-        {
-            "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
-            "component": "lib:safe-exceptions",
-            "flags": [],
-            "package": "safe-exceptions",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
-            "version": "0.1.7.4"
-        },
-        {
-            "cabal_sha256": "a8f76076a40409a36ee975970c53273c2089aec9d9ece8168dfc736dfec24b9d",
-            "component": "lib:semaphore-compat",
-            "flags": [],
-            "package": "semaphore-compat",
-            "revision": 2,
-            "source": "hackage",
-            "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
-            "version": "1.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "exe:cabal",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "exe:example",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        }
-    ]
+  "builtin": [
+    {
+      "package": "rts",
+      "version": "1.0.2"
+    },
+    {
+      "package": "ghc-prim",
+      "version": "0.7.0"
+    },
+    {
+      "package": "ghc-bignum",
+      "version": "1.1"
+    },
+    {
+      "package": "base",
+      "version": "4.15.1.0"
+    },
+    {
+      "package": "array",
+      "version": "0.5.4.0"
+    },
+    {
+      "package": "deepseq",
+      "version": "1.4.5.0"
+    },
+    {
+      "package": "containers",
+      "version": "0.6.4.1"
+    },
+    {
+      "package": "ghc-boot-th",
+      "version": "9.0.2"
+    },
+    {
+      "package": "pretty",
+      "version": "1.1.3.6"
+    },
+    {
+      "package": "template-haskell",
+      "version": "2.17.0.0"
+    },
+    {
+      "package": "transformers",
+      "version": "0.5.6.2"
+    },
+    {
+      "package": "mtl",
+      "version": "2.2.2"
+    },
+    {
+      "package": "stm",
+      "version": "2.5.0.0"
+    },
+    {
+      "package": "exceptions",
+      "version": "0.10.4"
+    },
+    {
+      "package": "time",
+      "version": "1.9.3"
+    }
+  ],
+  "dependencies": [
+    {
+      "cabal_sha256": "a4a1975fde77e289b605c45a3ef78d731d8c1834e4cef311152d910a1e94d98c",
+      "component": "lib:data-array-byte",
+      "flags": [],
+      "package": "data-array-byte",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
+      "version": "0.1.0.1"
+    },
+    {
+      "cabal_sha256": "98e79e1c97117143e4012983509ec95f7e5e4f6adff6914d07812a39f83404b9",
+      "component": "lib:bytestring",
+      "flags": [
+        "-pure-haskell"
+      ],
+      "package": "bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "ebc3b8a6ef74a5cd6ddbb8d447d1c9a5fd4964c7975ebcae0b8ab0bcc406cc8c",
+      "version": "0.12.1.0"
+    },
+    {
+      "cabal_sha256": "345cbb1afe414a09e47737e4d14cbd51891a734e67c0ef3d77a1439518bb81e8",
+      "component": "lib:filepath",
+      "flags": [
+        "-cpphs"
+      ],
+      "package": "filepath",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "88d6452fd199e333e66e68d2dc5d715f5c6d361661a4a8add88320a82864b788",
+      "version": "1.4.300.2"
+    },
+    {
+      "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
+      "component": "lib:unix",
+      "flags": [
+        "-os-string"
+      ],
+      "package": "unix",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "5ab6c346aef2eb9bf80b4d29ca7e22063fc23e52fd69fbc4d18a9f98b154e424",
+      "version": "2.8.5.1"
+    },
+    {
+      "cabal_sha256": "fbeec9ec346e5272167f63dcb86af513b457a7b9fc36dc818e4c7b81608d612b",
+      "component": "lib:directory",
+      "flags": [
+        "-os-string"
+      ],
+      "package": "directory",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "e864ed54ddfc6e15d2eb02c87f4be8edd7719e1f9cea13e0f86909400b6ea768",
+      "version": "1.3.8.5"
+    },
+    {
+      "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
+      "component": "exe:alex",
+      "flags": [],
+      "package": "alex",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
+      "version": "3.5.1.0"
+    },
+    {
+      "cabal_sha256": "03381e511429c44d13990c6d76281c4fc2468371cede4fe684b0c98d9b7d5f5a",
+      "component": "lib:binary",
+      "flags": [],
+      "package": "binary",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "8437116b4eccdba13cb9badb62331c0d4598c3f0252a587e37d8f5990d9bf74c",
+      "version": "0.8.9.2"
+    },
+    {
+      "cabal_sha256": "78c3fb91055d0607a80453327f087b9dc82168d41d0dca3ff410d21033b5e87d",
+      "component": "lib:text",
+      "flags": [
+        "-developer",
+        "-pure-haskell",
+        "+simdutf"
+      ],
+      "package": "text",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "e40cdda8b285f4d72476ed35dc2f5f167d524e6b38bb5ec964d00ee1ff24feab",
+      "version": "2.1.1"
+    },
+    {
+      "cabal_sha256": "8407cbd428d7f640a0fff8891bd2f7aca13cebe70a5e654856f8abec9a648b56",
+      "component": "lib:parsec",
+      "flags": [],
+      "package": "parsec",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "58c500bec1ec3c849c8243ddfd675a5983b17a8e5da55acea6adade5ae179d36",
+      "version": "3.1.17.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-syntax",
+      "flags": [],
+      "package": "Cabal-syntax",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "2a9393de33f18415fb8f4826957a87a94ffe8840ca8472a9b69dca6de45aca03",
+      "component": "lib:process",
+      "flags": [],
+      "package": "process",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "cefda221c3009fa2316b5cf148215cb340dad7eb8503f22e49e33722559df99a",
+      "version": "1.6.20.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal",
+      "flags": [],
+      "package": "Cabal",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-hooks",
+      "flags": [],
+      "package": "Cabal-hooks",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "0.1"
+    },
+    {
+      "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
+      "component": "exe:hsc2hs",
+      "flags": [
+        "-in-ghc-tree"
+      ],
+      "package": "hsc2hs",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
+      "version": "0.68.10"
+    },
+    {
+      "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
+      "component": "lib:network",
+      "flags": [
+        "-devel"
+      ],
+      "package": "network",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
+      "version": "3.2.0.0"
+    },
+    {
+      "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
+      "component": "lib:th-compat",
+      "flags": [],
+      "package": "th-compat",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
+      "version": "0.1.5"
+    },
+    {
+      "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
+      "component": "lib:network-uri",
+      "flags": [],
+      "package": "network-uri",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
+      "version": "2.6.4.2"
+    },
+    {
+      "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
+      "component": "lib:HTTP",
+      "flags": [
+        "-conduit10",
+        "+network-uri",
+        "-warn-as-error",
+        "-warp-tests"
+      ],
+      "package": "HTTP",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
+      "version": "4000.4.1"
+    },
+    {
+      "cabal_sha256": "455d863c96cf4b1804772c630a235f535fdb52ca9137a4150967b521ee4734ab",
+      "component": "lib:base-orphans",
+      "flags": [],
+      "package": "base-orphans",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "6211900916955b84687c61b5e4fa98ce110e511a96086b7a93f06dd63c97ba93",
+      "version": "0.9.2"
+    },
+    {
+      "cabal_sha256": "82503a1ef0a625c210e118f2785c4138f8502aacbbfd4e5d987f6baffbb87115",
+      "component": "lib:hashable",
+      "flags": [
+        "+arch-native",
+        "+integer-gmp",
+        "-random-initial-seed"
+      ],
+      "package": "hashable",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "34652a7a1d2fc9e3d764b150bd35bcd2220761c1d4c6b446b0cfac5ad5b778cb",
+      "version": "1.4.6.0"
+    },
+    {
+      "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
+      "component": "lib:async",
+      "flags": [
+        "-bench"
+      ],
+      "package": "async",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
+      "version": "2.2.5"
+    },
+    {
+      "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
+      "component": "lib:base16-bytestring",
+      "flags": [],
+      "package": "base16-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
+      "version": "1.0.2.0"
+    },
+    {
+      "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
+      "component": "lib:base64-bytestring",
+      "flags": [],
+      "package": "base64-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
+      "version": "1.2.1.0"
+    },
+    {
+      "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
+      "component": "lib:splitmix",
+      "flags": [
+        "-optimised-mixer"
+      ],
+      "package": "splitmix",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
+      "version": "0.1.0.5"
+    },
+    {
+      "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
+      "component": "lib:random",
+      "flags": [],
+      "package": "random",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
+      "version": "1.2.1.2"
+    },
+    {
+      "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
+      "component": "lib:edit-distance",
+      "flags": [],
+      "package": "edit-distance",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
+      "version": "0.2.2.1"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install-solver",
+      "flags": [
+        "-debug-expensive-assertions",
+        "-debug-tracetree"
+      ],
+      "package": "cabal-install-solver",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
+      "component": "lib:cryptohash-sha256",
+      "flags": [
+        "-exe",
+        "+use-cbits"
+      ],
+      "package": "cryptohash-sha256",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
+      "version": "0.11.102.1"
+    },
+    {
+      "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
+      "component": "lib:echo",
+      "flags": [
+        "-example"
+      ],
+      "package": "echo",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
+      "version": "0.1.4"
+    },
+    {
+      "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
+      "component": "lib:ed25519",
+      "flags": [
+        "+no-donna",
+        "+test-doctests",
+        "+test-hlint",
+        "+test-properties"
+      ],
+      "package": "ed25519",
+      "revision": 8,
+      "source": "hackage",
+      "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
+      "version": "0.0.5.0"
+    },
+    {
+      "cabal_sha256": "8a3004c2de2a0b5ef0634d3da6eae62ba8d8a734bab9ed8c6cfd749e7ca08997",
+      "component": "lib:lukko",
+      "flags": [
+        "+ofd-locking"
+      ],
+      "package": "lukko",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "72d86f8aa625b461f4397f737346f78a1700a7ffbff55cf6375c5e18916e986d",
+      "version": "0.1.2"
+    },
+    {
+      "cabal_sha256": "4d4186bb8d711435765253c7dc076c44a1d52896300689507ba135706ab35866",
+      "component": "lib:os-string",
+      "flags": [],
+      "package": "os-string",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "f6b388b9f9002622901d3f71437b98f95f54fbf7fe10490d319cb801c2a061ea",
+      "version": "2.0.3"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar-internal",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "d6696f2b55ab4a50b8de57947abca308604eb7cf8287c40bf69cfa26133e24d3",
+      "component": "lib:zlib",
+      "flags": [
+        "-bundled-c-zlib",
+        "+non-blocking-ffi",
+        "-pkg-config"
+      ],
+      "package": "zlib",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
+      "version": "0.7.1.0"
+    },
+    {
+      "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
+      "component": "lib:hackage-security",
+      "flags": [
+        "+cabal-syntax",
+        "+lukko"
+      ],
+      "package": "hackage-security",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
+      "version": "0.6.2.6"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "lib:open-browser",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    },
+    {
+      "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
+      "component": "lib:regex-base",
+      "flags": [],
+      "package": "regex-base",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
+      "version": "0.94.0.2"
+    },
+    {
+      "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
+      "component": "lib:regex-posix",
+      "flags": [
+        "-_regex-posix-clib"
+      ],
+      "package": "regex-posix",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
+      "version": "0.96.0.1"
+    },
+    {
+      "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
+      "component": "lib:resolv",
+      "flags": [],
+      "package": "resolv",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
+      "version": "0.2.0.2"
+    },
+    {
+      "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
+      "component": "lib:safe-exceptions",
+      "flags": [],
+      "package": "safe-exceptions",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
+      "version": "0.1.7.4"
+    },
+    {
+      "cabal_sha256": "2de5218cef72b8ef090bd7d0fd930ffa143242a120c62e013b5cf039858f1855",
+      "component": "lib:semaphore-compat",
+      "flags": [],
+      "package": "semaphore-compat",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
+      "version": "1.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "exe:cabal",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "exe:example",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    }
+  ]
 }

--- a/bootstrap/linux-9.2.8.json
+++ b/bootstrap/linux-9.2.8.json
@@ -1,534 +1,535 @@
 {
-    "builtin": [
-        {
-            "package": "rts",
-            "version": "1.0.2"
-        },
-        {
-            "package": "ghc-prim",
-            "version": "0.8.0"
-        },
-        {
-            "package": "ghc-bignum",
-            "version": "1.2"
-        },
-        {
-            "package": "base",
-            "version": "4.16.4.0"
-        },
-        {
-            "package": "array",
-            "version": "0.5.4.0"
-        },
-        {
-            "package": "deepseq",
-            "version": "1.4.6.1"
-        },
-        {
-            "package": "containers",
-            "version": "0.6.5.1"
-        },
-        {
-            "package": "ghc-boot-th",
-            "version": "9.2.8"
-        },
-        {
-            "package": "pretty",
-            "version": "1.1.3.6"
-        },
-        {
-            "package": "template-haskell",
-            "version": "2.18.0.0"
-        },
-        {
-            "package": "bytestring",
-            "version": "0.11.4.0"
-        },
-        {
-            "package": "transformers",
-            "version": "0.5.6.2"
-        },
-        {
-            "package": "mtl",
-            "version": "2.2.2"
-        },
-        {
-            "package": "stm",
-            "version": "2.5.0.2"
-        },
-        {
-            "package": "exceptions",
-            "version": "0.10.4"
-        },
-        {
-            "package": "time",
-            "version": "1.11.1.1"
-        },
-        {
-            "package": "binary",
-            "version": "0.8.9.0"
-        },
-        {
-            "package": "text",
-            "version": "1.2.5.0"
-        },
-        {
-            "package": "parsec",
-            "version": "3.1.15.0"
-        }
-    ],
-    "dependencies": [
-        {
-            "cabal_sha256": "d9e181e1acae0ac505d8b217dec3805c68554878f1e32b3d8351b9ce17061623",
-            "component": "lib:filepath",
-            "flags": [
-                "-cpphs"
-            ],
-            "package": "filepath",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "337a0b5bcf0898cb7f51ff327528cf26f4ac38baed7b66b28fbdea334699d8ed",
-            "version": "1.4.300.1"
-        },
-        {
-            "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
-            "component": "lib:unix",
-            "flags": [
-                "-os-string"
-            ],
-            "package": "unix",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "5ab6c346aef2eb9bf80b4d29ca7e22063fc23e52fd69fbc4d18a9f98b154e424",
-            "version": "2.8.5.1"
-        },
-        {
-            "cabal_sha256": "ae1730011f547153bb52139f217d1d524202b3da730a369660fc539e5dcfff31",
-            "component": "lib:directory",
-            "flags": [
-                "-os-string"
-            ],
-            "package": "directory",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "a4e798a4e5339a7aa9577515886271386280bfbc1fe4a29fd4aa6464d4792064",
-            "version": "1.3.8.4"
-        },
-        {
-            "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
-            "component": "exe:alex",
-            "flags": [],
-            "package": "alex",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
-            "version": "3.5.1.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-syntax",
-            "flags": [],
-            "package": "Cabal-syntax",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "7785a72bc140ae5a9ef2439f10637b5fd104999832f1d93328d4973f37cb8469",
-            "component": "lib:process",
-            "flags": [],
-            "package": "process",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "b468355ab46966537eb171ed5593a0a1facc8d2eefc38659e43768f68f5dcb96",
-            "version": "1.6.19.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal",
-            "flags": [],
-            "package": "Cabal",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-hooks",
-            "flags": [],
-            "package": "Cabal-hooks",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "0.1"
-        },
-        {
-            "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
-            "component": "exe:hsc2hs",
-            "flags": [
-                "-in-ghc-tree"
-            ],
-            "package": "hsc2hs",
-            "revision": 2,
-            "source": "hackage",
-            "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
-            "version": "0.68.10"
-        },
-        {
-            "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
-            "component": "lib:network",
-            "flags": [
-                "-devel"
-            ],
-            "package": "network",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
-            "version": "3.2.0.0"
-        },
-        {
-            "cabal_sha256": "0a6ee328b71119d7dfcd004f0ec8feb77e6e78d8f6de1a281568edd3d3b6d83f",
-            "component": "lib:th-compat",
-            "flags": [],
-            "package": "th-compat",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
-            "version": "0.1.5"
-        },
-        {
-            "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
-            "component": "lib:network-uri",
-            "flags": [],
-            "package": "network-uri",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
-            "version": "2.6.4.2"
-        },
-        {
-            "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
-            "component": "lib:HTTP",
-            "flags": [
-                "-conduit10",
-                "+network-uri",
-                "-warn-as-error",
-                "-warp-tests"
-            ],
-            "package": "HTTP",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
-        },
-        {
-            "cabal_sha256": "a4a1975fde77e289b605c45a3ef78d731d8c1834e4cef311152d910a1e94d98c",
-            "component": "lib:data-array-byte",
-            "flags": [],
-            "package": "data-array-byte",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
-            "version": "0.1.0.1"
-        },
-        {
-            "cabal_sha256": "32fa47f8345a2c0662fb602fc42e4b674e41ec48079b68bdecb4b6f68032c24e",
-            "component": "lib:os-string",
-            "flags": [],
-            "package": "os-string",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0953126e962966719753c98d71f596f5fea07e100bce191b7453735a1ff2caa1",
-            "version": "2.0.2"
-        },
-        {
-            "cabal_sha256": "ae22238274c572aa91e90c6c353e7206386708912ac5e6dc40ac61d1dcc553db",
-            "component": "lib:hashable",
-            "flags": [
-                "+integer-gmp",
-                "-random-initial-seed"
-            ],
-            "package": "hashable",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1fa3d64548440942b2b38b99c76d8dcaa94fa2ea3912cd7a6354ea4ec4af4758",
-            "version": "1.4.4.0"
-        },
-        {
-            "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
-            "component": "lib:async",
-            "flags": [
-                "-bench"
-            ],
-            "package": "async",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
-        },
-        {
-            "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
-            "component": "lib:base16-bytestring",
-            "flags": [],
-            "package": "base16-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
-            "version": "1.0.2.0"
-        },
-        {
-            "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
-            "component": "lib:base64-bytestring",
-            "flags": [],
-            "package": "base64-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
-            "version": "1.2.1.0"
-        },
-        {
-            "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
-            "component": "lib:splitmix",
-            "flags": [
-                "-optimised-mixer"
-            ],
-            "package": "splitmix",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
-            "version": "0.1.0.5"
-        },
-        {
-            "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
-            "component": "lib:random",
-            "flags": [],
-            "package": "random",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
-            "version": "1.2.1.2"
-        },
-        {
-            "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
-            "component": "lib:edit-distance",
-            "flags": [],
-            "package": "edit-distance",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
-            "version": "0.2.2.1"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install-solver",
-            "flags": [
-                "-debug-expensive-assertions",
-                "-debug-tracetree"
-            ],
-            "package": "cabal-install-solver",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
-            "component": "lib:cryptohash-sha256",
-            "flags": [
-                "-exe",
-                "+use-cbits"
-            ],
-            "package": "cryptohash-sha256",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
-            "version": "0.11.102.1"
-        },
-        {
-            "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
-            "component": "lib:echo",
-            "flags": [
-                "-example"
-            ],
-            "package": "echo",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
-            "version": "0.1.4"
-        },
-        {
-            "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
-            "component": "lib:ed25519",
-            "flags": [
-                "+no-donna",
-                "+test-doctests",
-                "+test-hlint",
-                "+test-properties"
-            ],
-            "package": "ed25519",
-            "revision": 8,
-            "source": "hackage",
-            "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
-            "version": "0.0.5.0"
-        },
-        {
-            "cabal_sha256": "17786545dce60c4d5783ba6125c0a6499a1abddd3d7417b15500ccd767c35f07",
-            "component": "lib:lukko",
-            "flags": [
-                "+ofd-locking"
-            ],
-            "package": "lukko",
-            "revision": 5,
-            "source": "hackage",
-            "src_sha256": "a80efb60cfa3dae18682c01980d76d5f7e413e191cd186992e1bf7388d48ab1f",
-            "version": "0.1.1.3"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar-internal",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "64a1925c93e9a26cd4c40c470736950c4b5ea7bae68418cb996c5c7df4873cba",
-            "component": "lib:zlib",
-            "flags": [
-                "-bundled-c-zlib",
-                "+non-blocking-ffi",
-                "-pkg-config"
-            ],
-            "package": "zlib",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "7e43c205e1e1ff5a4b033086ec8cce82ab658879e977c8ba02a6701946ff7a47",
-            "version": "0.7.0.0"
-        },
-        {
-            "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
-            "component": "lib:hackage-security",
-            "flags": [
-                "+cabal-syntax",
-                "+lukko"
-            ],
-            "package": "hackage-security",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
-            "version": "0.6.2.6"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "lib:open-browser",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        },
-        {
-            "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
-            "component": "lib:regex-base",
-            "flags": [],
-            "package": "regex-base",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
-            "version": "0.94.0.2"
-        },
-        {
-            "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
-            "component": "lib:regex-posix",
-            "flags": [
-                "-_regex-posix-clib"
-            ],
-            "package": "regex-posix",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
-            "version": "0.96.0.1"
-        },
-        {
-            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
-            "component": "lib:resolv",
-            "flags": [],
-            "package": "resolv",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
-        },
-        {
-            "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
-            "component": "lib:safe-exceptions",
-            "flags": [],
-            "package": "safe-exceptions",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
-            "version": "0.1.7.4"
-        },
-        {
-            "cabal_sha256": "a8f76076a40409a36ee975970c53273c2089aec9d9ece8168dfc736dfec24b9d",
-            "component": "lib:semaphore-compat",
-            "flags": [],
-            "package": "semaphore-compat",
-            "revision": 2,
-            "source": "hackage",
-            "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
-            "version": "1.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "exe:cabal",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "exe:example",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        }
-    ]
+  "builtin": [
+    {
+      "package": "rts",
+      "version": "1.0.2"
+    },
+    {
+      "package": "ghc-prim",
+      "version": "0.8.0"
+    },
+    {
+      "package": "ghc-bignum",
+      "version": "1.2"
+    },
+    {
+      "package": "base",
+      "version": "4.16.4.0"
+    },
+    {
+      "package": "array",
+      "version": "0.5.4.0"
+    },
+    {
+      "package": "deepseq",
+      "version": "1.4.6.1"
+    },
+    {
+      "package": "containers",
+      "version": "0.6.5.1"
+    },
+    {
+      "package": "ghc-boot-th",
+      "version": "9.2.8"
+    },
+    {
+      "package": "pretty",
+      "version": "1.1.3.6"
+    },
+    {
+      "package": "template-haskell",
+      "version": "2.18.0.0"
+    },
+    {
+      "package": "bytestring",
+      "version": "0.11.4.0"
+    },
+    {
+      "package": "transformers",
+      "version": "0.5.6.2"
+    },
+    {
+      "package": "mtl",
+      "version": "2.2.2"
+    },
+    {
+      "package": "stm",
+      "version": "2.5.0.2"
+    },
+    {
+      "package": "exceptions",
+      "version": "0.10.4"
+    },
+    {
+      "package": "time",
+      "version": "1.11.1.1"
+    },
+    {
+      "package": "binary",
+      "version": "0.8.9.0"
+    },
+    {
+      "package": "text",
+      "version": "1.2.5.0"
+    },
+    {
+      "package": "parsec",
+      "version": "3.1.15.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "cabal_sha256": "4d4186bb8d711435765253c7dc076c44a1d52896300689507ba135706ab35866",
+      "component": "lib:os-string",
+      "flags": [],
+      "package": "os-string",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "f6b388b9f9002622901d3f71437b98f95f54fbf7fe10490d319cb801c2a061ea",
+      "version": "2.0.3"
+    },
+    {
+      "cabal_sha256": "8af7a843cba7eddc8d44ae94002b766ee8c23cbcd3ecdb2cc79ee6e0a694419a",
+      "component": "lib:filepath",
+      "flags": [
+        "-cpphs"
+      ],
+      "package": "filepath",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "d2606db4fa8517932a2d9ea6415c365da4d1794afcb264a5b3c10110123978a7",
+      "version": "1.5.2.0"
+    },
+    {
+      "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
+      "component": "lib:unix",
+      "flags": [
+        "+os-string"
+      ],
+      "package": "unix",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "5ab6c346aef2eb9bf80b4d29ca7e22063fc23e52fd69fbc4d18a9f98b154e424",
+      "version": "2.8.5.1"
+    },
+    {
+      "cabal_sha256": "fbeec9ec346e5272167f63dcb86af513b457a7b9fc36dc818e4c7b81608d612b",
+      "component": "lib:directory",
+      "flags": [
+        "+os-string"
+      ],
+      "package": "directory",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "e864ed54ddfc6e15d2eb02c87f4be8edd7719e1f9cea13e0f86909400b6ea768",
+      "version": "1.3.8.5"
+    },
+    {
+      "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
+      "component": "exe:alex",
+      "flags": [],
+      "package": "alex",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
+      "version": "3.5.1.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-syntax",
+      "flags": [],
+      "package": "Cabal-syntax",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "2a9393de33f18415fb8f4826957a87a94ffe8840ca8472a9b69dca6de45aca03",
+      "component": "lib:process",
+      "flags": [],
+      "package": "process",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "cefda221c3009fa2316b5cf148215cb340dad7eb8503f22e49e33722559df99a",
+      "version": "1.6.20.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal",
+      "flags": [],
+      "package": "Cabal",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-hooks",
+      "flags": [],
+      "package": "Cabal-hooks",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "0.1"
+    },
+    {
+      "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
+      "component": "exe:hsc2hs",
+      "flags": [
+        "-in-ghc-tree"
+      ],
+      "package": "hsc2hs",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
+      "version": "0.68.10"
+    },
+    {
+      "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
+      "component": "lib:network",
+      "flags": [
+        "-devel"
+      ],
+      "package": "network",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
+      "version": "3.2.0.0"
+    },
+    {
+      "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
+      "component": "lib:th-compat",
+      "flags": [],
+      "package": "th-compat",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
+      "version": "0.1.5"
+    },
+    {
+      "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
+      "component": "lib:network-uri",
+      "flags": [],
+      "package": "network-uri",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
+      "version": "2.6.4.2"
+    },
+    {
+      "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
+      "component": "lib:HTTP",
+      "flags": [
+        "-conduit10",
+        "+network-uri",
+        "-warn-as-error",
+        "-warp-tests"
+      ],
+      "package": "HTTP",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
+      "version": "4000.4.1"
+    },
+    {
+      "cabal_sha256": "a4a1975fde77e289b605c45a3ef78d731d8c1834e4cef311152d910a1e94d98c",
+      "component": "lib:data-array-byte",
+      "flags": [],
+      "package": "data-array-byte",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "1bb6eca0b3e02d057fe7f4e14c81ef395216f421ab30fdaa1b18017c9c025600",
+      "version": "0.1.0.1"
+    },
+    {
+      "cabal_sha256": "82503a1ef0a625c210e118f2785c4138f8502aacbbfd4e5d987f6baffbb87115",
+      "component": "lib:hashable",
+      "flags": [
+        "+arch-native",
+        "+integer-gmp",
+        "-random-initial-seed"
+      ],
+      "package": "hashable",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "34652a7a1d2fc9e3d764b150bd35bcd2220761c1d4c6b446b0cfac5ad5b778cb",
+      "version": "1.4.6.0"
+    },
+    {
+      "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
+      "component": "lib:async",
+      "flags": [
+        "-bench"
+      ],
+      "package": "async",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
+      "version": "2.2.5"
+    },
+    {
+      "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
+      "component": "lib:base16-bytestring",
+      "flags": [],
+      "package": "base16-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
+      "version": "1.0.2.0"
+    },
+    {
+      "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
+      "component": "lib:base64-bytestring",
+      "flags": [],
+      "package": "base64-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
+      "version": "1.2.1.0"
+    },
+    {
+      "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
+      "component": "lib:splitmix",
+      "flags": [
+        "-optimised-mixer"
+      ],
+      "package": "splitmix",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
+      "version": "0.1.0.5"
+    },
+    {
+      "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
+      "component": "lib:random",
+      "flags": [],
+      "package": "random",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
+      "version": "1.2.1.2"
+    },
+    {
+      "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
+      "component": "lib:edit-distance",
+      "flags": [],
+      "package": "edit-distance",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
+      "version": "0.2.2.1"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install-solver",
+      "flags": [
+        "-debug-expensive-assertions",
+        "-debug-tracetree"
+      ],
+      "package": "cabal-install-solver",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
+      "component": "lib:cryptohash-sha256",
+      "flags": [
+        "-exe",
+        "+use-cbits"
+      ],
+      "package": "cryptohash-sha256",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
+      "version": "0.11.102.1"
+    },
+    {
+      "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
+      "component": "lib:echo",
+      "flags": [
+        "-example"
+      ],
+      "package": "echo",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
+      "version": "0.1.4"
+    },
+    {
+      "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
+      "component": "lib:ed25519",
+      "flags": [
+        "+no-donna",
+        "+test-doctests",
+        "+test-hlint",
+        "+test-properties"
+      ],
+      "package": "ed25519",
+      "revision": 8,
+      "source": "hackage",
+      "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
+      "version": "0.0.5.0"
+    },
+    {
+      "cabal_sha256": "8a3004c2de2a0b5ef0634d3da6eae62ba8d8a734bab9ed8c6cfd749e7ca08997",
+      "component": "lib:lukko",
+      "flags": [
+        "+ofd-locking"
+      ],
+      "package": "lukko",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "72d86f8aa625b461f4397f737346f78a1700a7ffbff55cf6375c5e18916e986d",
+      "version": "0.1.2"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar-internal",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "d6696f2b55ab4a50b8de57947abca308604eb7cf8287c40bf69cfa26133e24d3",
+      "component": "lib:zlib",
+      "flags": [
+        "-bundled-c-zlib",
+        "+non-blocking-ffi",
+        "-pkg-config"
+      ],
+      "package": "zlib",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
+      "version": "0.7.1.0"
+    },
+    {
+      "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
+      "component": "lib:hackage-security",
+      "flags": [
+        "+cabal-syntax",
+        "+lukko"
+      ],
+      "package": "hackage-security",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
+      "version": "0.6.2.6"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "lib:open-browser",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    },
+    {
+      "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
+      "component": "lib:regex-base",
+      "flags": [],
+      "package": "regex-base",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
+      "version": "0.94.0.2"
+    },
+    {
+      "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
+      "component": "lib:regex-posix",
+      "flags": [
+        "-_regex-posix-clib"
+      ],
+      "package": "regex-posix",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
+      "version": "0.96.0.1"
+    },
+    {
+      "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
+      "component": "lib:resolv",
+      "flags": [],
+      "package": "resolv",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
+      "version": "0.2.0.2"
+    },
+    {
+      "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
+      "component": "lib:safe-exceptions",
+      "flags": [],
+      "package": "safe-exceptions",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
+      "version": "0.1.7.4"
+    },
+    {
+      "cabal_sha256": "2de5218cef72b8ef090bd7d0fd930ffa143242a120c62e013b5cf039858f1855",
+      "component": "lib:semaphore-compat",
+      "flags": [],
+      "package": "semaphore-compat",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
+      "version": "1.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "exe:cabal",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "exe:example",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    }
+  ]
 }

--- a/bootstrap/linux-9.4.8.json
+++ b/bootstrap/linux-9.4.8.json
@@ -1,524 +1,525 @@
 {
-    "builtin": [
-        {
-            "package": "rts",
-            "version": "1.0.2"
-        },
-        {
-            "package": "ghc-prim",
-            "version": "0.9.1"
-        },
-        {
-            "package": "ghc-bignum",
-            "version": "1.3"
-        },
-        {
-            "package": "base",
-            "version": "4.17.2.1"
-        },
-        {
-            "package": "array",
-            "version": "0.5.4.0"
-        },
-        {
-            "package": "deepseq",
-            "version": "1.4.8.0"
-        },
-        {
-            "package": "ghc-boot-th",
-            "version": "9.4.8"
-        },
-        {
-            "package": "pretty",
-            "version": "1.1.3.6"
-        },
-        {
-            "package": "template-haskell",
-            "version": "2.19.0.0"
-        },
-        {
-            "package": "containers",
-            "version": "0.6.7"
-        },
-        {
-            "package": "bytestring",
-            "version": "0.11.5.3"
-        },
-        {
-            "package": "transformers",
-            "version": "0.5.6.2"
-        },
-        {
-            "package": "mtl",
-            "version": "2.2.2"
-        },
-        {
-            "package": "stm",
-            "version": "2.5.1.0"
-        },
-        {
-            "package": "exceptions",
-            "version": "0.10.5"
-        },
-        {
-            "package": "time",
-            "version": "1.12.2"
-        },
-        {
-            "package": "binary",
-            "version": "0.8.9.1"
-        },
-        {
-            "package": "text",
-            "version": "2.0.2"
-        },
-        {
-            "package": "parsec",
-            "version": "3.1.16.1"
-        }
-    ],
-    "dependencies": [
-        {
-            "cabal_sha256": "d9e181e1acae0ac505d8b217dec3805c68554878f1e32b3d8351b9ce17061623",
-            "component": "lib:filepath",
-            "flags": [
-                "-cpphs"
-            ],
-            "package": "filepath",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "337a0b5bcf0898cb7f51ff327528cf26f4ac38baed7b66b28fbdea334699d8ed",
-            "version": "1.4.300.1"
-        },
-        {
-            "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
-            "component": "lib:unix",
-            "flags": [
-                "-os-string"
-            ],
-            "package": "unix",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "5ab6c346aef2eb9bf80b4d29ca7e22063fc23e52fd69fbc4d18a9f98b154e424",
-            "version": "2.8.5.1"
-        },
-        {
-            "cabal_sha256": "ae1730011f547153bb52139f217d1d524202b3da730a369660fc539e5dcfff31",
-            "component": "lib:directory",
-            "flags": [
-                "-os-string"
-            ],
-            "package": "directory",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "a4e798a4e5339a7aa9577515886271386280bfbc1fe4a29fd4aa6464d4792064",
-            "version": "1.3.8.4"
-        },
-        {
-            "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
-            "component": "exe:alex",
-            "flags": [],
-            "package": "alex",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
-            "version": "3.5.1.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-syntax",
-            "flags": [],
-            "package": "Cabal-syntax",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "7785a72bc140ae5a9ef2439f10637b5fd104999832f1d93328d4973f37cb8469",
-            "component": "lib:process",
-            "flags": [],
-            "package": "process",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "b468355ab46966537eb171ed5593a0a1facc8d2eefc38659e43768f68f5dcb96",
-            "version": "1.6.19.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal",
-            "flags": [],
-            "package": "Cabal",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-hooks",
-            "flags": [],
-            "package": "Cabal-hooks",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "0.1"
-        },
-        {
-            "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
-            "component": "exe:hsc2hs",
-            "flags": [
-                "-in-ghc-tree"
-            ],
-            "package": "hsc2hs",
-            "revision": 2,
-            "source": "hackage",
-            "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
-            "version": "0.68.10"
-        },
-        {
-            "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
-            "component": "lib:network",
-            "flags": [
-                "-devel"
-            ],
-            "package": "network",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
-            "version": "3.2.0.0"
-        },
-        {
-            "cabal_sha256": "0a6ee328b71119d7dfcd004f0ec8feb77e6e78d8f6de1a281568edd3d3b6d83f",
-            "component": "lib:th-compat",
-            "flags": [],
-            "package": "th-compat",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
-            "version": "0.1.5"
-        },
-        {
-            "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
-            "component": "lib:network-uri",
-            "flags": [],
-            "package": "network-uri",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
-            "version": "2.6.4.2"
-        },
-        {
-            "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
-            "component": "lib:HTTP",
-            "flags": [
-                "-conduit10",
-                "+network-uri",
-                "-warn-as-error",
-                "-warp-tests"
-            ],
-            "package": "HTTP",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
-        },
-        {
-            "cabal_sha256": "32fa47f8345a2c0662fb602fc42e4b674e41ec48079b68bdecb4b6f68032c24e",
-            "component": "lib:os-string",
-            "flags": [],
-            "package": "os-string",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0953126e962966719753c98d71f596f5fea07e100bce191b7453735a1ff2caa1",
-            "version": "2.0.2"
-        },
-        {
-            "cabal_sha256": "ae22238274c572aa91e90c6c353e7206386708912ac5e6dc40ac61d1dcc553db",
-            "component": "lib:hashable",
-            "flags": [
-                "+integer-gmp",
-                "-random-initial-seed"
-            ],
-            "package": "hashable",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1fa3d64548440942b2b38b99c76d8dcaa94fa2ea3912cd7a6354ea4ec4af4758",
-            "version": "1.4.4.0"
-        },
-        {
-            "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
-            "component": "lib:async",
-            "flags": [
-                "-bench"
-            ],
-            "package": "async",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
-        },
-        {
-            "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
-            "component": "lib:base16-bytestring",
-            "flags": [],
-            "package": "base16-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
-            "version": "1.0.2.0"
-        },
-        {
-            "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
-            "component": "lib:base64-bytestring",
-            "flags": [],
-            "package": "base64-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
-            "version": "1.2.1.0"
-        },
-        {
-            "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
-            "component": "lib:splitmix",
-            "flags": [
-                "-optimised-mixer"
-            ],
-            "package": "splitmix",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
-            "version": "0.1.0.5"
-        },
-        {
-            "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
-            "component": "lib:random",
-            "flags": [],
-            "package": "random",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
-            "version": "1.2.1.2"
-        },
-        {
-            "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
-            "component": "lib:edit-distance",
-            "flags": [],
-            "package": "edit-distance",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
-            "version": "0.2.2.1"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install-solver",
-            "flags": [
-                "-debug-expensive-assertions",
-                "-debug-tracetree"
-            ],
-            "package": "cabal-install-solver",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
-            "component": "lib:cryptohash-sha256",
-            "flags": [
-                "-exe",
-                "+use-cbits"
-            ],
-            "package": "cryptohash-sha256",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
-            "version": "0.11.102.1"
-        },
-        {
-            "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
-            "component": "lib:echo",
-            "flags": [
-                "-example"
-            ],
-            "package": "echo",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
-            "version": "0.1.4"
-        },
-        {
-            "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
-            "component": "lib:ed25519",
-            "flags": [
-                "+no-donna",
-                "+test-doctests",
-                "+test-hlint",
-                "+test-properties"
-            ],
-            "package": "ed25519",
-            "revision": 8,
-            "source": "hackage",
-            "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
-            "version": "0.0.5.0"
-        },
-        {
-            "cabal_sha256": "17786545dce60c4d5783ba6125c0a6499a1abddd3d7417b15500ccd767c35f07",
-            "component": "lib:lukko",
-            "flags": [
-                "+ofd-locking"
-            ],
-            "package": "lukko",
-            "revision": 5,
-            "source": "hackage",
-            "src_sha256": "a80efb60cfa3dae18682c01980d76d5f7e413e191cd186992e1bf7388d48ab1f",
-            "version": "0.1.1.3"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar-internal",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "64a1925c93e9a26cd4c40c470736950c4b5ea7bae68418cb996c5c7df4873cba",
-            "component": "lib:zlib",
-            "flags": [
-                "-bundled-c-zlib",
-                "+non-blocking-ffi",
-                "-pkg-config"
-            ],
-            "package": "zlib",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "7e43c205e1e1ff5a4b033086ec8cce82ab658879e977c8ba02a6701946ff7a47",
-            "version": "0.7.0.0"
-        },
-        {
-            "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
-            "component": "lib:hackage-security",
-            "flags": [
-                "+cabal-syntax",
-                "+lukko"
-            ],
-            "package": "hackage-security",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
-            "version": "0.6.2.6"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "lib:open-browser",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        },
-        {
-            "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
-            "component": "lib:regex-base",
-            "flags": [],
-            "package": "regex-base",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
-            "version": "0.94.0.2"
-        },
-        {
-            "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
-            "component": "lib:regex-posix",
-            "flags": [
-                "-_regex-posix-clib"
-            ],
-            "package": "regex-posix",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
-            "version": "0.96.0.1"
-        },
-        {
-            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
-            "component": "lib:resolv",
-            "flags": [],
-            "package": "resolv",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
-        },
-        {
-            "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
-            "component": "lib:safe-exceptions",
-            "flags": [],
-            "package": "safe-exceptions",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
-            "version": "0.1.7.4"
-        },
-        {
-            "cabal_sha256": "a8f76076a40409a36ee975970c53273c2089aec9d9ece8168dfc736dfec24b9d",
-            "component": "lib:semaphore-compat",
-            "flags": [],
-            "package": "semaphore-compat",
-            "revision": 2,
-            "source": "hackage",
-            "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
-            "version": "1.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "exe:cabal",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "exe:example",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        }
-    ]
+  "builtin": [
+    {
+      "package": "rts",
+      "version": "1.0.2"
+    },
+    {
+      "package": "ghc-prim",
+      "version": "0.9.1"
+    },
+    {
+      "package": "ghc-bignum",
+      "version": "1.3"
+    },
+    {
+      "package": "base",
+      "version": "4.17.2.1"
+    },
+    {
+      "package": "array",
+      "version": "0.5.4.0"
+    },
+    {
+      "package": "deepseq",
+      "version": "1.4.8.0"
+    },
+    {
+      "package": "ghc-boot-th",
+      "version": "9.4.8"
+    },
+    {
+      "package": "pretty",
+      "version": "1.1.3.6"
+    },
+    {
+      "package": "template-haskell",
+      "version": "2.19.0.0"
+    },
+    {
+      "package": "containers",
+      "version": "0.6.7"
+    },
+    {
+      "package": "bytestring",
+      "version": "0.11.5.3"
+    },
+    {
+      "package": "transformers",
+      "version": "0.5.6.2"
+    },
+    {
+      "package": "mtl",
+      "version": "2.2.2"
+    },
+    {
+      "package": "stm",
+      "version": "2.5.1.0"
+    },
+    {
+      "package": "exceptions",
+      "version": "0.10.5"
+    },
+    {
+      "package": "time",
+      "version": "1.12.2"
+    },
+    {
+      "package": "binary",
+      "version": "0.8.9.1"
+    },
+    {
+      "package": "text",
+      "version": "2.0.2"
+    },
+    {
+      "package": "parsec",
+      "version": "3.1.16.1"
+    }
+  ],
+  "dependencies": [
+    {
+      "cabal_sha256": "4d4186bb8d711435765253c7dc076c44a1d52896300689507ba135706ab35866",
+      "component": "lib:os-string",
+      "flags": [],
+      "package": "os-string",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "f6b388b9f9002622901d3f71437b98f95f54fbf7fe10490d319cb801c2a061ea",
+      "version": "2.0.3"
+    },
+    {
+      "cabal_sha256": "8af7a843cba7eddc8d44ae94002b766ee8c23cbcd3ecdb2cc79ee6e0a694419a",
+      "component": "lib:filepath",
+      "flags": [
+        "-cpphs"
+      ],
+      "package": "filepath",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "d2606db4fa8517932a2d9ea6415c365da4d1794afcb264a5b3c10110123978a7",
+      "version": "1.5.2.0"
+    },
+    {
+      "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
+      "component": "lib:unix",
+      "flags": [
+        "+os-string"
+      ],
+      "package": "unix",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "5ab6c346aef2eb9bf80b4d29ca7e22063fc23e52fd69fbc4d18a9f98b154e424",
+      "version": "2.8.5.1"
+    },
+    {
+      "cabal_sha256": "fbeec9ec346e5272167f63dcb86af513b457a7b9fc36dc818e4c7b81608d612b",
+      "component": "lib:directory",
+      "flags": [
+        "+os-string"
+      ],
+      "package": "directory",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "e864ed54ddfc6e15d2eb02c87f4be8edd7719e1f9cea13e0f86909400b6ea768",
+      "version": "1.3.8.5"
+    },
+    {
+      "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
+      "component": "exe:alex",
+      "flags": [],
+      "package": "alex",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
+      "version": "3.5.1.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-syntax",
+      "flags": [],
+      "package": "Cabal-syntax",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "2a9393de33f18415fb8f4826957a87a94ffe8840ca8472a9b69dca6de45aca03",
+      "component": "lib:process",
+      "flags": [],
+      "package": "process",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "cefda221c3009fa2316b5cf148215cb340dad7eb8503f22e49e33722559df99a",
+      "version": "1.6.20.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal",
+      "flags": [],
+      "package": "Cabal",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-hooks",
+      "flags": [],
+      "package": "Cabal-hooks",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "0.1"
+    },
+    {
+      "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
+      "component": "exe:hsc2hs",
+      "flags": [
+        "-in-ghc-tree"
+      ],
+      "package": "hsc2hs",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
+      "version": "0.68.10"
+    },
+    {
+      "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
+      "component": "lib:network",
+      "flags": [
+        "-devel"
+      ],
+      "package": "network",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
+      "version": "3.2.0.0"
+    },
+    {
+      "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
+      "component": "lib:th-compat",
+      "flags": [],
+      "package": "th-compat",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
+      "version": "0.1.5"
+    },
+    {
+      "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
+      "component": "lib:network-uri",
+      "flags": [],
+      "package": "network-uri",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
+      "version": "2.6.4.2"
+    },
+    {
+      "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
+      "component": "lib:HTTP",
+      "flags": [
+        "-conduit10",
+        "+network-uri",
+        "-warn-as-error",
+        "-warp-tests"
+      ],
+      "package": "HTTP",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
+      "version": "4000.4.1"
+    },
+    {
+      "cabal_sha256": "82503a1ef0a625c210e118f2785c4138f8502aacbbfd4e5d987f6baffbb87115",
+      "component": "lib:hashable",
+      "flags": [
+        "+arch-native",
+        "+integer-gmp",
+        "-random-initial-seed"
+      ],
+      "package": "hashable",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "34652a7a1d2fc9e3d764b150bd35bcd2220761c1d4c6b446b0cfac5ad5b778cb",
+      "version": "1.4.6.0"
+    },
+    {
+      "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
+      "component": "lib:async",
+      "flags": [
+        "-bench"
+      ],
+      "package": "async",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
+      "version": "2.2.5"
+    },
+    {
+      "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
+      "component": "lib:base16-bytestring",
+      "flags": [],
+      "package": "base16-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
+      "version": "1.0.2.0"
+    },
+    {
+      "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
+      "component": "lib:base64-bytestring",
+      "flags": [],
+      "package": "base64-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
+      "version": "1.2.1.0"
+    },
+    {
+      "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
+      "component": "lib:splitmix",
+      "flags": [
+        "-optimised-mixer"
+      ],
+      "package": "splitmix",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
+      "version": "0.1.0.5"
+    },
+    {
+      "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
+      "component": "lib:random",
+      "flags": [],
+      "package": "random",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
+      "version": "1.2.1.2"
+    },
+    {
+      "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
+      "component": "lib:edit-distance",
+      "flags": [],
+      "package": "edit-distance",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
+      "version": "0.2.2.1"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install-solver",
+      "flags": [
+        "-debug-expensive-assertions",
+        "-debug-tracetree"
+      ],
+      "package": "cabal-install-solver",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
+      "component": "lib:cryptohash-sha256",
+      "flags": [
+        "-exe",
+        "+use-cbits"
+      ],
+      "package": "cryptohash-sha256",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
+      "version": "0.11.102.1"
+    },
+    {
+      "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
+      "component": "lib:echo",
+      "flags": [
+        "-example"
+      ],
+      "package": "echo",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
+      "version": "0.1.4"
+    },
+    {
+      "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
+      "component": "lib:ed25519",
+      "flags": [
+        "+no-donna",
+        "+test-doctests",
+        "+test-hlint",
+        "+test-properties"
+      ],
+      "package": "ed25519",
+      "revision": 8,
+      "source": "hackage",
+      "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
+      "version": "0.0.5.0"
+    },
+    {
+      "cabal_sha256": "8a3004c2de2a0b5ef0634d3da6eae62ba8d8a734bab9ed8c6cfd749e7ca08997",
+      "component": "lib:lukko",
+      "flags": [
+        "+ofd-locking"
+      ],
+      "package": "lukko",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "72d86f8aa625b461f4397f737346f78a1700a7ffbff55cf6375c5e18916e986d",
+      "version": "0.1.2"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar-internal",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "d6696f2b55ab4a50b8de57947abca308604eb7cf8287c40bf69cfa26133e24d3",
+      "component": "lib:zlib",
+      "flags": [
+        "-bundled-c-zlib",
+        "+non-blocking-ffi",
+        "-pkg-config"
+      ],
+      "package": "zlib",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
+      "version": "0.7.1.0"
+    },
+    {
+      "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
+      "component": "lib:hackage-security",
+      "flags": [
+        "+cabal-syntax",
+        "+lukko"
+      ],
+      "package": "hackage-security",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
+      "version": "0.6.2.6"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "lib:open-browser",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    },
+    {
+      "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
+      "component": "lib:regex-base",
+      "flags": [],
+      "package": "regex-base",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
+      "version": "0.94.0.2"
+    },
+    {
+      "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
+      "component": "lib:regex-posix",
+      "flags": [
+        "-_regex-posix-clib"
+      ],
+      "package": "regex-posix",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
+      "version": "0.96.0.1"
+    },
+    {
+      "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
+      "component": "lib:resolv",
+      "flags": [],
+      "package": "resolv",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
+      "version": "0.2.0.2"
+    },
+    {
+      "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
+      "component": "lib:safe-exceptions",
+      "flags": [],
+      "package": "safe-exceptions",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
+      "version": "0.1.7.4"
+    },
+    {
+      "cabal_sha256": "2de5218cef72b8ef090bd7d0fd930ffa143242a120c62e013b5cf039858f1855",
+      "component": "lib:semaphore-compat",
+      "flags": [],
+      "package": "semaphore-compat",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
+      "version": "1.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "exe:cabal",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "exe:example",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    }
+  ]
 }

--- a/bootstrap/linux-9.6.4.json
+++ b/bootstrap/linux-9.6.4.json
@@ -1,494 +1,495 @@
 {
-    "builtin": [
-        {
-            "package": "rts",
-            "version": "1.0.2"
-        },
-        {
-            "package": "ghc-prim",
-            "version": "0.10.0"
-        },
-        {
-            "package": "ghc-bignum",
-            "version": "1.3"
-        },
-        {
-            "package": "base",
-            "version": "4.18.2.0"
-        },
-        {
-            "package": "array",
-            "version": "0.5.6.0"
-        },
-        {
-            "package": "deepseq",
-            "version": "1.4.8.1"
-        },
-        {
-            "package": "ghc-boot-th",
-            "version": "9.6.4"
-        },
-        {
-            "package": "pretty",
-            "version": "1.1.3.6"
-        },
-        {
-            "package": "template-haskell",
-            "version": "2.20.0.0"
-        },
-        {
-            "package": "containers",
-            "version": "0.6.7"
-        },
-        {
-            "package": "bytestring",
-            "version": "0.11.5.3"
-        },
-        {
-            "package": "transformers",
-            "version": "0.6.1.0"
-        },
-        {
-            "package": "mtl",
-            "version": "2.3.1"
-        },
-        {
-            "package": "stm",
-            "version": "2.5.1.0"
-        },
-        {
-            "package": "exceptions",
-            "version": "0.10.7"
-        },
-        {
-            "package": "filepath",
-            "version": "1.4.200.1"
-        },
-        {
-            "package": "time",
-            "version": "1.12.2"
-        },
-        {
-            "package": "unix",
-            "version": "2.8.4.0"
-        },
-        {
-            "package": "directory",
-            "version": "1.3.8.1"
-        },
-        {
-            "package": "binary",
-            "version": "0.8.9.1"
-        },
-        {
-            "package": "text",
-            "version": "2.0.2"
-        },
-        {
-            "package": "parsec",
-            "version": "3.1.16.1"
-        },
-        {
-            "package": "process",
-            "version": "1.6.17.0"
-        }
-    ],
-    "dependencies": [
-        {
-            "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
-            "component": "exe:alex",
-            "flags": [],
-            "package": "alex",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
-            "version": "3.5.1.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-syntax",
-            "flags": [],
-            "package": "Cabal-syntax",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal",
-            "flags": [],
-            "package": "Cabal",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-hooks",
-            "flags": [],
-            "package": "Cabal-hooks",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "0.1"
-        },
-        {
-            "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
-            "component": "exe:hsc2hs",
-            "flags": [
-                "-in-ghc-tree"
-            ],
-            "package": "hsc2hs",
-            "revision": 2,
-            "source": "hackage",
-            "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
-            "version": "0.68.10"
-        },
-        {
-            "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
-            "component": "lib:network",
-            "flags": [
-                "-devel"
-            ],
-            "package": "network",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
-            "version": "3.2.0.0"
-        },
-        {
-            "cabal_sha256": "0a6ee328b71119d7dfcd004f0ec8feb77e6e78d8f6de1a281568edd3d3b6d83f",
-            "component": "lib:th-compat",
-            "flags": [],
-            "package": "th-compat",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
-            "version": "0.1.5"
-        },
-        {
-            "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
-            "component": "lib:network-uri",
-            "flags": [],
-            "package": "network-uri",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
-            "version": "2.6.4.2"
-        },
-        {
-            "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
-            "component": "lib:HTTP",
-            "flags": [
-                "-conduit10",
-                "+network-uri",
-                "-warn-as-error",
-                "-warp-tests"
-            ],
-            "package": "HTTP",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
-        },
-        {
-            "cabal_sha256": "32fa47f8345a2c0662fb602fc42e4b674e41ec48079b68bdecb4b6f68032c24e",
-            "component": "lib:os-string",
-            "flags": [],
-            "package": "os-string",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0953126e962966719753c98d71f596f5fea07e100bce191b7453735a1ff2caa1",
-            "version": "2.0.2"
-        },
-        {
-            "cabal_sha256": "ae22238274c572aa91e90c6c353e7206386708912ac5e6dc40ac61d1dcc553db",
-            "component": "lib:hashable",
-            "flags": [
-                "+integer-gmp",
-                "-random-initial-seed"
-            ],
-            "package": "hashable",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1fa3d64548440942b2b38b99c76d8dcaa94fa2ea3912cd7a6354ea4ec4af4758",
-            "version": "1.4.4.0"
-        },
-        {
-            "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
-            "component": "lib:async",
-            "flags": [
-                "-bench"
-            ],
-            "package": "async",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
-        },
-        {
-            "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
-            "component": "lib:base16-bytestring",
-            "flags": [],
-            "package": "base16-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
-            "version": "1.0.2.0"
-        },
-        {
-            "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
-            "component": "lib:base64-bytestring",
-            "flags": [],
-            "package": "base64-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
-            "version": "1.2.1.0"
-        },
-        {
-            "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
-            "component": "lib:splitmix",
-            "flags": [
-                "-optimised-mixer"
-            ],
-            "package": "splitmix",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
-            "version": "0.1.0.5"
-        },
-        {
-            "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
-            "component": "lib:random",
-            "flags": [],
-            "package": "random",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
-            "version": "1.2.1.2"
-        },
-        {
-            "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
-            "component": "lib:edit-distance",
-            "flags": [],
-            "package": "edit-distance",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
-            "version": "0.2.2.1"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install-solver",
-            "flags": [
-                "-debug-expensive-assertions",
-                "-debug-tracetree"
-            ],
-            "package": "cabal-install-solver",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
-            "component": "lib:cryptohash-sha256",
-            "flags": [
-                "-exe",
-                "+use-cbits"
-            ],
-            "package": "cryptohash-sha256",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
-            "version": "0.11.102.1"
-        },
-        {
-            "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
-            "component": "lib:echo",
-            "flags": [
-                "-example"
-            ],
-            "package": "echo",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
-            "version": "0.1.4"
-        },
-        {
-            "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
-            "component": "lib:ed25519",
-            "flags": [
-                "+no-donna",
-                "+test-doctests",
-                "+test-hlint",
-                "+test-properties"
-            ],
-            "package": "ed25519",
-            "revision": 8,
-            "source": "hackage",
-            "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
-            "version": "0.0.5.0"
-        },
-        {
-            "cabal_sha256": "17786545dce60c4d5783ba6125c0a6499a1abddd3d7417b15500ccd767c35f07",
-            "component": "lib:lukko",
-            "flags": [
-                "+ofd-locking"
-            ],
-            "package": "lukko",
-            "revision": 5,
-            "source": "hackage",
-            "src_sha256": "a80efb60cfa3dae18682c01980d76d5f7e413e191cd186992e1bf7388d48ab1f",
-            "version": "0.1.1.3"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar-internal",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "64a1925c93e9a26cd4c40c470736950c4b5ea7bae68418cb996c5c7df4873cba",
-            "component": "lib:zlib",
-            "flags": [
-                "-bundled-c-zlib",
-                "+non-blocking-ffi",
-                "-pkg-config"
-            ],
-            "package": "zlib",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "7e43c205e1e1ff5a4b033086ec8cce82ab658879e977c8ba02a6701946ff7a47",
-            "version": "0.7.0.0"
-        },
-        {
-            "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
-            "component": "lib:hackage-security",
-            "flags": [
-                "+cabal-syntax",
-                "+lukko"
-            ],
-            "package": "hackage-security",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
-            "version": "0.6.2.6"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "lib:open-browser",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        },
-        {
-            "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
-            "component": "lib:regex-base",
-            "flags": [],
-            "package": "regex-base",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
-            "version": "0.94.0.2"
-        },
-        {
-            "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
-            "component": "lib:regex-posix",
-            "flags": [
-                "-_regex-posix-clib"
-            ],
-            "package": "regex-posix",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
-            "version": "0.96.0.1"
-        },
-        {
-            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
-            "component": "lib:resolv",
-            "flags": [],
-            "package": "resolv",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
-        },
-        {
-            "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
-            "component": "lib:safe-exceptions",
-            "flags": [],
-            "package": "safe-exceptions",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
-            "version": "0.1.7.4"
-        },
-        {
-            "cabal_sha256": "a8f76076a40409a36ee975970c53273c2089aec9d9ece8168dfc736dfec24b9d",
-            "component": "lib:semaphore-compat",
-            "flags": [],
-            "package": "semaphore-compat",
-            "revision": 2,
-            "source": "hackage",
-            "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
-            "version": "1.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "exe:cabal",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "exe:example",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        }
-    ]
+  "builtin": [
+    {
+      "package": "rts",
+      "version": "1.0.2"
+    },
+    {
+      "package": "ghc-prim",
+      "version": "0.10.0"
+    },
+    {
+      "package": "ghc-bignum",
+      "version": "1.3"
+    },
+    {
+      "package": "base",
+      "version": "4.18.2.0"
+    },
+    {
+      "package": "array",
+      "version": "0.5.6.0"
+    },
+    {
+      "package": "deepseq",
+      "version": "1.4.8.1"
+    },
+    {
+      "package": "ghc-boot-th",
+      "version": "9.6.4"
+    },
+    {
+      "package": "pretty",
+      "version": "1.1.3.6"
+    },
+    {
+      "package": "template-haskell",
+      "version": "2.20.0.0"
+    },
+    {
+      "package": "containers",
+      "version": "0.6.7"
+    },
+    {
+      "package": "bytestring",
+      "version": "0.11.5.3"
+    },
+    {
+      "package": "transformers",
+      "version": "0.6.1.0"
+    },
+    {
+      "package": "mtl",
+      "version": "2.3.1"
+    },
+    {
+      "package": "stm",
+      "version": "2.5.1.0"
+    },
+    {
+      "package": "exceptions",
+      "version": "0.10.7"
+    },
+    {
+      "package": "filepath",
+      "version": "1.4.200.1"
+    },
+    {
+      "package": "time",
+      "version": "1.12.2"
+    },
+    {
+      "package": "unix",
+      "version": "2.8.4.0"
+    },
+    {
+      "package": "directory",
+      "version": "1.3.8.1"
+    },
+    {
+      "package": "binary",
+      "version": "0.8.9.1"
+    },
+    {
+      "package": "text",
+      "version": "2.0.2"
+    },
+    {
+      "package": "parsec",
+      "version": "3.1.16.1"
+    },
+    {
+      "package": "process",
+      "version": "1.6.17.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
+      "component": "exe:alex",
+      "flags": [],
+      "package": "alex",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
+      "version": "3.5.1.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-syntax",
+      "flags": [],
+      "package": "Cabal-syntax",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal",
+      "flags": [],
+      "package": "Cabal",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-hooks",
+      "flags": [],
+      "package": "Cabal-hooks",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "0.1"
+    },
+    {
+      "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
+      "component": "exe:hsc2hs",
+      "flags": [
+        "-in-ghc-tree"
+      ],
+      "package": "hsc2hs",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
+      "version": "0.68.10"
+    },
+    {
+      "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
+      "component": "lib:network",
+      "flags": [
+        "-devel"
+      ],
+      "package": "network",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
+      "version": "3.2.0.0"
+    },
+    {
+      "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
+      "component": "lib:th-compat",
+      "flags": [],
+      "package": "th-compat",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
+      "version": "0.1.5"
+    },
+    {
+      "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
+      "component": "lib:network-uri",
+      "flags": [],
+      "package": "network-uri",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
+      "version": "2.6.4.2"
+    },
+    {
+      "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
+      "component": "lib:HTTP",
+      "flags": [
+        "-conduit10",
+        "+network-uri",
+        "-warn-as-error",
+        "-warp-tests"
+      ],
+      "package": "HTTP",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
+      "version": "4000.4.1"
+    },
+    {
+      "cabal_sha256": "4d4186bb8d711435765253c7dc076c44a1d52896300689507ba135706ab35866",
+      "component": "lib:os-string",
+      "flags": [],
+      "package": "os-string",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "f6b388b9f9002622901d3f71437b98f95f54fbf7fe10490d319cb801c2a061ea",
+      "version": "2.0.3"
+    },
+    {
+      "cabal_sha256": "82503a1ef0a625c210e118f2785c4138f8502aacbbfd4e5d987f6baffbb87115",
+      "component": "lib:hashable",
+      "flags": [
+        "+arch-native",
+        "+integer-gmp",
+        "-random-initial-seed"
+      ],
+      "package": "hashable",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "34652a7a1d2fc9e3d764b150bd35bcd2220761c1d4c6b446b0cfac5ad5b778cb",
+      "version": "1.4.6.0"
+    },
+    {
+      "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
+      "component": "lib:async",
+      "flags": [
+        "-bench"
+      ],
+      "package": "async",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
+      "version": "2.2.5"
+    },
+    {
+      "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
+      "component": "lib:base16-bytestring",
+      "flags": [],
+      "package": "base16-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
+      "version": "1.0.2.0"
+    },
+    {
+      "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
+      "component": "lib:base64-bytestring",
+      "flags": [],
+      "package": "base64-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
+      "version": "1.2.1.0"
+    },
+    {
+      "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
+      "component": "lib:splitmix",
+      "flags": [
+        "-optimised-mixer"
+      ],
+      "package": "splitmix",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
+      "version": "0.1.0.5"
+    },
+    {
+      "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
+      "component": "lib:random",
+      "flags": [],
+      "package": "random",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
+      "version": "1.2.1.2"
+    },
+    {
+      "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
+      "component": "lib:edit-distance",
+      "flags": [],
+      "package": "edit-distance",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
+      "version": "0.2.2.1"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install-solver",
+      "flags": [
+        "-debug-expensive-assertions",
+        "-debug-tracetree"
+      ],
+      "package": "cabal-install-solver",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
+      "component": "lib:cryptohash-sha256",
+      "flags": [
+        "-exe",
+        "+use-cbits"
+      ],
+      "package": "cryptohash-sha256",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
+      "version": "0.11.102.1"
+    },
+    {
+      "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
+      "component": "lib:echo",
+      "flags": [
+        "-example"
+      ],
+      "package": "echo",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
+      "version": "0.1.4"
+    },
+    {
+      "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
+      "component": "lib:ed25519",
+      "flags": [
+        "+no-donna",
+        "+test-doctests",
+        "+test-hlint",
+        "+test-properties"
+      ],
+      "package": "ed25519",
+      "revision": 8,
+      "source": "hackage",
+      "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
+      "version": "0.0.5.0"
+    },
+    {
+      "cabal_sha256": "8a3004c2de2a0b5ef0634d3da6eae62ba8d8a734bab9ed8c6cfd749e7ca08997",
+      "component": "lib:lukko",
+      "flags": [
+        "+ofd-locking"
+      ],
+      "package": "lukko",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "72d86f8aa625b461f4397f737346f78a1700a7ffbff55cf6375c5e18916e986d",
+      "version": "0.1.2"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar-internal",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "d6696f2b55ab4a50b8de57947abca308604eb7cf8287c40bf69cfa26133e24d3",
+      "component": "lib:zlib",
+      "flags": [
+        "-bundled-c-zlib",
+        "+non-blocking-ffi",
+        "-pkg-config"
+      ],
+      "package": "zlib",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
+      "version": "0.7.1.0"
+    },
+    {
+      "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
+      "component": "lib:hackage-security",
+      "flags": [
+        "+cabal-syntax",
+        "+lukko"
+      ],
+      "package": "hackage-security",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
+      "version": "0.6.2.6"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "lib:open-browser",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    },
+    {
+      "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
+      "component": "lib:regex-base",
+      "flags": [],
+      "package": "regex-base",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
+      "version": "0.94.0.2"
+    },
+    {
+      "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
+      "component": "lib:regex-posix",
+      "flags": [
+        "-_regex-posix-clib"
+      ],
+      "package": "regex-posix",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
+      "version": "0.96.0.1"
+    },
+    {
+      "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
+      "component": "lib:resolv",
+      "flags": [],
+      "package": "resolv",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
+      "version": "0.2.0.2"
+    },
+    {
+      "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
+      "component": "lib:safe-exceptions",
+      "flags": [],
+      "package": "safe-exceptions",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
+      "version": "0.1.7.4"
+    },
+    {
+      "cabal_sha256": "2de5218cef72b8ef090bd7d0fd930ffa143242a120c62e013b5cf039858f1855",
+      "component": "lib:semaphore-compat",
+      "flags": [],
+      "package": "semaphore-compat",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "1c6e6fab021c2ccee5d86112fb1c0bd016d15e0cf70c489dae5fb5ec156ed9e2",
+      "version": "1.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "exe:cabal",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "exe:example",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    }
+  ]
 }

--- a/bootstrap/linux-9.8.2.json
+++ b/bootstrap/linux-9.8.2.json
@@ -1,488 +1,489 @@
 {
-    "builtin": [
-        {
-            "package": "rts",
-            "version": "1.0.2"
-        },
-        {
-            "package": "ghc-prim",
-            "version": "0.11.0"
-        },
-        {
-            "package": "ghc-bignum",
-            "version": "1.3"
-        },
-        {
-            "package": "base",
-            "version": "4.19.1.0"
-        },
-        {
-            "package": "array",
-            "version": "0.5.6.0"
-        },
-        {
-            "package": "deepseq",
-            "version": "1.5.0.0"
-        },
-        {
-            "package": "ghc-boot-th",
-            "version": "9.8.2"
-        },
-        {
-            "package": "pretty",
-            "version": "1.1.3.6"
-        },
-        {
-            "package": "template-haskell",
-            "version": "2.21.0.0"
-        },
-        {
-            "package": "containers",
-            "version": "0.6.8"
-        },
-        {
-            "package": "bytestring",
-            "version": "0.12.1.0"
-        },
-        {
-            "package": "transformers",
-            "version": "0.6.1.0"
-        },
-        {
-            "package": "mtl",
-            "version": "2.3.1"
-        },
-        {
-            "package": "stm",
-            "version": "2.5.2.1"
-        },
-        {
-            "package": "exceptions",
-            "version": "0.10.7"
-        },
-        {
-            "package": "filepath",
-            "version": "1.4.200.1"
-        },
-        {
-            "package": "time",
-            "version": "1.12.2"
-        },
-        {
-            "package": "unix",
-            "version": "2.8.4.0"
-        },
-        {
-            "package": "directory",
-            "version": "1.3.8.1"
-        },
-        {
-            "package": "binary",
-            "version": "0.8.9.1"
-        },
-        {
-            "package": "text",
-            "version": "2.1.1"
-        },
-        {
-            "package": "parsec",
-            "version": "3.1.17.0"
-        },
-        {
-            "package": "process",
-            "version": "1.6.18.0"
-        },
-        {
-            "package": "semaphore-compat",
-            "version": "1.0.0"
-        }
-    ],
-    "dependencies": [
-        {
-            "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
-            "component": "exe:alex",
-            "flags": [],
-            "package": "alex",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
-            "version": "3.5.1.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-syntax",
-            "flags": [],
-            "package": "Cabal-syntax",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal",
-            "flags": [],
-            "package": "Cabal",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:Cabal-hooks",
-            "flags": [],
-            "package": "Cabal-hooks",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "0.1"
-        },
-        {
-            "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
-            "component": "exe:hsc2hs",
-            "flags": [
-                "-in-ghc-tree"
-            ],
-            "package": "hsc2hs",
-            "revision": 2,
-            "source": "hackage",
-            "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
-            "version": "0.68.10"
-        },
-        {
-            "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
-            "component": "lib:network",
-            "flags": [
-                "-devel"
-            ],
-            "package": "network",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
-            "version": "3.2.0.0"
-        },
-        {
-            "cabal_sha256": "0a6ee328b71119d7dfcd004f0ec8feb77e6e78d8f6de1a281568edd3d3b6d83f",
-            "component": "lib:th-compat",
-            "flags": [],
-            "package": "th-compat",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
-            "version": "0.1.5"
-        },
-        {
-            "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
-            "component": "lib:network-uri",
-            "flags": [],
-            "package": "network-uri",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
-            "version": "2.6.4.2"
-        },
-        {
-            "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
-            "component": "lib:HTTP",
-            "flags": [
-                "-conduit10",
-                "+network-uri",
-                "-warn-as-error",
-                "-warp-tests"
-            ],
-            "package": "HTTP",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
-            "version": "4000.4.1"
-        },
-        {
-            "cabal_sha256": "32fa47f8345a2c0662fb602fc42e4b674e41ec48079b68bdecb4b6f68032c24e",
-            "component": "lib:os-string",
-            "flags": [],
-            "package": "os-string",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0953126e962966719753c98d71f596f5fea07e100bce191b7453735a1ff2caa1",
-            "version": "2.0.2"
-        },
-        {
-            "cabal_sha256": "ae22238274c572aa91e90c6c353e7206386708912ac5e6dc40ac61d1dcc553db",
-            "component": "lib:hashable",
-            "flags": [
-                "+integer-gmp",
-                "-random-initial-seed"
-            ],
-            "package": "hashable",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1fa3d64548440942b2b38b99c76d8dcaa94fa2ea3912cd7a6354ea4ec4af4758",
-            "version": "1.4.4.0"
-        },
-        {
-            "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
-            "component": "lib:async",
-            "flags": [
-                "-bench"
-            ],
-            "package": "async",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
-            "version": "2.2.5"
-        },
-        {
-            "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
-            "component": "lib:base16-bytestring",
-            "flags": [],
-            "package": "base16-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
-            "version": "1.0.2.0"
-        },
-        {
-            "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
-            "component": "lib:base64-bytestring",
-            "flags": [],
-            "package": "base64-bytestring",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
-            "version": "1.2.1.0"
-        },
-        {
-            "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
-            "component": "lib:splitmix",
-            "flags": [
-                "-optimised-mixer"
-            ],
-            "package": "splitmix",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
-            "version": "0.1.0.5"
-        },
-        {
-            "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
-            "component": "lib:random",
-            "flags": [],
-            "package": "random",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
-            "version": "1.2.1.2"
-        },
-        {
-            "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
-            "component": "lib:edit-distance",
-            "flags": [],
-            "package": "edit-distance",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
-            "version": "0.2.2.1"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install-solver",
-            "flags": [
-                "-debug-expensive-assertions",
-                "-debug-tracetree"
-            ],
-            "package": "cabal-install-solver",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
-            "component": "lib:cryptohash-sha256",
-            "flags": [
-                "-exe",
-                "+use-cbits"
-            ],
-            "package": "cryptohash-sha256",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
-            "version": "0.11.102.1"
-        },
-        {
-            "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
-            "component": "lib:echo",
-            "flags": [
-                "-example"
-            ],
-            "package": "echo",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
-            "version": "0.1.4"
-        },
-        {
-            "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
-            "component": "lib:ed25519",
-            "flags": [
-                "+no-donna",
-                "+test-doctests",
-                "+test-hlint",
-                "+test-properties"
-            ],
-            "package": "ed25519",
-            "revision": 8,
-            "source": "hackage",
-            "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
-            "version": "0.0.5.0"
-        },
-        {
-            "cabal_sha256": "17786545dce60c4d5783ba6125c0a6499a1abddd3d7417b15500ccd767c35f07",
-            "component": "lib:lukko",
-            "flags": [
-                "+ofd-locking"
-            ],
-            "package": "lukko",
-            "revision": 5,
-            "source": "hackage",
-            "src_sha256": "a80efb60cfa3dae18682c01980d76d5f7e413e191cd186992e1bf7388d48ab1f",
-            "version": "0.1.1.3"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar-internal",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "619828cae098a7b6deeb0316e12f55011101d88f756787ed024ceedb81cf1eba",
-            "component": "lib:tar",
-            "flags": [],
-            "package": "tar",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "08c61e82b59ed6fe7e85e9fe7cceaaf853ba54511d1ec57efa511ddc55ef1998",
-            "version": "0.6.2.0"
-        },
-        {
-            "cabal_sha256": "64a1925c93e9a26cd4c40c470736950c4b5ea7bae68418cb996c5c7df4873cba",
-            "component": "lib:zlib",
-            "flags": [
-                "-bundled-c-zlib",
-                "+non-blocking-ffi",
-                "-pkg-config"
-            ],
-            "package": "zlib",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "7e43c205e1e1ff5a4b033086ec8cce82ab658879e977c8ba02a6701946ff7a47",
-            "version": "0.7.0.0"
-        },
-        {
-            "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
-            "component": "lib:hackage-security",
-            "flags": [
-                "+cabal-syntax",
-                "+lukko"
-            ],
-            "package": "hackage-security",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
-            "version": "0.6.2.6"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "lib:open-browser",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        },
-        {
-            "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
-            "component": "lib:regex-base",
-            "flags": [],
-            "package": "regex-base",
-            "revision": 4,
-            "source": "hackage",
-            "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
-            "version": "0.94.0.2"
-        },
-        {
-            "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
-            "component": "lib:regex-posix",
-            "flags": [
-                "-_regex-posix-clib"
-            ],
-            "package": "regex-posix",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
-            "version": "0.96.0.1"
-        },
-        {
-            "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
-            "component": "lib:resolv",
-            "flags": [],
-            "package": "resolv",
-            "revision": 3,
-            "source": "hackage",
-            "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
-            "version": "0.2.0.2"
-        },
-        {
-            "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
-            "component": "lib:safe-exceptions",
-            "flags": [],
-            "package": "safe-exceptions",
-            "revision": 1,
-            "source": "hackage",
-            "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
-            "version": "0.1.7.4"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "lib:cabal-install",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": null,
-            "component": "exe:cabal",
-            "flags": [
-                "+lukko",
-                "+native-dns"
-            ],
-            "package": "cabal-install",
-            "revision": null,
-            "source": "local",
-            "src_sha256": null,
-            "version": "3.13.0.0"
-        },
-        {
-            "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
-            "component": "exe:example",
-            "flags": [],
-            "package": "open-browser",
-            "revision": 0,
-            "source": "hackage",
-            "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
-            "version": "0.2.1.0"
-        }
-    ]
+  "builtin": [
+    {
+      "package": "rts",
+      "version": "1.0.2"
+    },
+    {
+      "package": "ghc-prim",
+      "version": "0.11.0"
+    },
+    {
+      "package": "ghc-bignum",
+      "version": "1.3"
+    },
+    {
+      "package": "base",
+      "version": "4.19.1.0"
+    },
+    {
+      "package": "array",
+      "version": "0.5.6.0"
+    },
+    {
+      "package": "deepseq",
+      "version": "1.5.0.0"
+    },
+    {
+      "package": "ghc-boot-th",
+      "version": "9.8.2"
+    },
+    {
+      "package": "pretty",
+      "version": "1.1.3.6"
+    },
+    {
+      "package": "template-haskell",
+      "version": "2.21.0.0"
+    },
+    {
+      "package": "containers",
+      "version": "0.6.8"
+    },
+    {
+      "package": "bytestring",
+      "version": "0.12.1.0"
+    },
+    {
+      "package": "transformers",
+      "version": "0.6.1.0"
+    },
+    {
+      "package": "mtl",
+      "version": "2.3.1"
+    },
+    {
+      "package": "stm",
+      "version": "2.5.2.1"
+    },
+    {
+      "package": "exceptions",
+      "version": "0.10.7"
+    },
+    {
+      "package": "filepath",
+      "version": "1.4.200.1"
+    },
+    {
+      "package": "time",
+      "version": "1.12.2"
+    },
+    {
+      "package": "unix",
+      "version": "2.8.4.0"
+    },
+    {
+      "package": "directory",
+      "version": "1.3.8.1"
+    },
+    {
+      "package": "binary",
+      "version": "0.8.9.1"
+    },
+    {
+      "package": "text",
+      "version": "2.1.1"
+    },
+    {
+      "package": "parsec",
+      "version": "3.1.17.0"
+    },
+    {
+      "package": "process",
+      "version": "1.6.18.0"
+    },
+    {
+      "package": "semaphore-compat",
+      "version": "1.0.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "cabal_sha256": "de553eefe0b6548a560e9d8100486310548470a403c1fa21108dd03713da5fc7",
+      "component": "exe:alex",
+      "flags": [],
+      "package": "alex",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c92efe86f8eb959ee03be6c04ee57ebc7e4abc75a6c4b26551215d7443e92a07",
+      "version": "3.5.1.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-syntax",
+      "flags": [],
+      "package": "Cabal-syntax",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal",
+      "flags": [],
+      "package": "Cabal",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:Cabal-hooks",
+      "flags": [],
+      "package": "Cabal-hooks",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "0.1"
+    },
+    {
+      "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",
+      "component": "exe:hsc2hs",
+      "flags": [
+        "-in-ghc-tree"
+      ],
+      "package": "hsc2hs",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "6f4e34d788fe2ca7091ee0a10307ee8a7c060a1ba890f2bffad16a7d4d5cef76",
+      "version": "0.68.10"
+    },
+    {
+      "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
+      "component": "lib:network",
+      "flags": [
+        "-devel"
+      ],
+      "package": "network",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
+      "version": "3.2.0.0"
+    },
+    {
+      "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
+      "component": "lib:th-compat",
+      "flags": [],
+      "package": "th-compat",
+      "revision": 2,
+      "source": "hackage",
+      "src_sha256": "81f55fafc7afad7763c09cb8b7b4165ca3765edcf70ffa42c7393043a1382a1e",
+      "version": "0.1.5"
+    },
+    {
+      "cabal_sha256": "6fffb57373962b5651a2db8b0af732098b3bf029a7ced76a9855615de2026588",
+      "component": "lib:network-uri",
+      "flags": [],
+      "package": "network-uri",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9c188973126e893250b881f20e8811dca06c223c23402b06f7a1f2e995797228",
+      "version": "2.6.4.2"
+    },
+    {
+      "cabal_sha256": "b90ce97917703f6613ed5a8cfe1a51525b990244f5610509baa15c8499eadca3",
+      "component": "lib:HTTP",
+      "flags": [
+        "-conduit10",
+        "+network-uri",
+        "-warn-as-error",
+        "-warp-tests"
+      ],
+      "package": "HTTP",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "df31d8efec775124dab856d7177ddcba31be9f9e0836ebdab03d94392f2dd453",
+      "version": "4000.4.1"
+    },
+    {
+      "cabal_sha256": "4d4186bb8d711435765253c7dc076c44a1d52896300689507ba135706ab35866",
+      "component": "lib:os-string",
+      "flags": [],
+      "package": "os-string",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "f6b388b9f9002622901d3f71437b98f95f54fbf7fe10490d319cb801c2a061ea",
+      "version": "2.0.3"
+    },
+    {
+      "cabal_sha256": "82503a1ef0a625c210e118f2785c4138f8502aacbbfd4e5d987f6baffbb87115",
+      "component": "lib:hashable",
+      "flags": [
+        "+arch-native",
+        "+integer-gmp",
+        "-random-initial-seed"
+      ],
+      "package": "hashable",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "34652a7a1d2fc9e3d764b150bd35bcd2220761c1d4c6b446b0cfac5ad5b778cb",
+      "version": "1.4.6.0"
+    },
+    {
+      "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
+      "component": "lib:async",
+      "flags": [
+        "-bench"
+      ],
+      "package": "async",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
+      "version": "2.2.5"
+    },
+    {
+      "cabal_sha256": "a694e88f9ec9fc79f0b03f233d3fea592b68f70a34aac2ddb5bcaecb6562e2fd",
+      "component": "lib:base16-bytestring",
+      "flags": [],
+      "package": "base16-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "1d5a91143ef0e22157536093ec8e59d226a68220ec89378d5dcaeea86472c784",
+      "version": "1.0.2.0"
+    },
+    {
+      "cabal_sha256": "45305ccf8914c66d385b518721472c7b8c858f1986945377f74f85c1e0d49803",
+      "component": "lib:base64-bytestring",
+      "flags": [],
+      "package": "base64-bytestring",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "fbf8ed30edde271eb605352021431d8f1b055f95a56af31fe2eacf6bdfdc49c9",
+      "version": "1.2.1.0"
+    },
+    {
+      "cabal_sha256": "caa9b4a92abf1496c7f6a3c0f4e357426a54880077cb9f04e260a8bfa034b77b",
+      "component": "lib:splitmix",
+      "flags": [
+        "-optimised-mixer"
+      ],
+      "package": "splitmix",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "9df07a9611ef45f1b1258a0b412f4d02c920248f69d2e2ce8ccda328f7e13002",
+      "version": "0.1.0.5"
+    },
+    {
+      "cabal_sha256": "32397de181e20ccaacf806ec70de9308cf044f089a2be37c936f3f8967bde867",
+      "component": "lib:random",
+      "flags": [],
+      "package": "random",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "790f4dc2d2327c453ff6aac7bf15399fd123d55e927935f68f84b5df42d9a4b4",
+      "version": "1.2.1.2"
+    },
+    {
+      "cabal_sha256": "4d33a49cd383d50af090f1b888642d10116e43809f9da6023d9fc6f67d2656ee",
+      "component": "lib:edit-distance",
+      "flags": [],
+      "package": "edit-distance",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3e8885ee2f56ad4da940f043ae8f981ee2fe336b5e8e4ba3f7436cff4f526c4a",
+      "version": "0.2.2.1"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install-solver",
+      "flags": [
+        "-debug-expensive-assertions",
+        "-debug-tracetree"
+      ],
+      "package": "cabal-install-solver",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
+      "component": "lib:cryptohash-sha256",
+      "flags": [
+        "-exe",
+        "+use-cbits"
+      ],
+      "package": "cryptohash-sha256",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
+      "version": "0.11.102.1"
+    },
+    {
+      "cabal_sha256": "ccce771562c49a2b29a52046ca68c62179e97e8fbeacdae32ca84a85445e8f42",
+      "component": "lib:echo",
+      "flags": [
+        "-example"
+      ],
+      "package": "echo",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "c9fe1bf2904825a65b667251ec644f197b71dc5c209d2d254be5de3d496b0e43",
+      "version": "0.1.4"
+    },
+    {
+      "cabal_sha256": "48383789821af5cc624498f3ee1d0939a070cda9468c0bfe63c951736be81c75",
+      "component": "lib:ed25519",
+      "flags": [
+        "+no-donna",
+        "+test-doctests",
+        "+test-hlint",
+        "+test-properties"
+      ],
+      "package": "ed25519",
+      "revision": 8,
+      "source": "hackage",
+      "src_sha256": "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
+      "version": "0.0.5.0"
+    },
+    {
+      "cabal_sha256": "8a3004c2de2a0b5ef0634d3da6eae62ba8d8a734bab9ed8c6cfd749e7ca08997",
+      "component": "lib:lukko",
+      "flags": [
+        "+ofd-locking"
+      ],
+      "package": "lukko",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "72d86f8aa625b461f4397f737346f78a1700a7ffbff55cf6375c5e18916e986d",
+      "version": "0.1.2"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar-internal",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+      "component": "lib:tar",
+      "flags": [],
+      "package": "tar",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
+      "version": "0.6.3.0"
+    },
+    {
+      "cabal_sha256": "d6696f2b55ab4a50b8de57947abca308604eb7cf8287c40bf69cfa26133e24d3",
+      "component": "lib:zlib",
+      "flags": [
+        "-bundled-c-zlib",
+        "+non-blocking-ffi",
+        "-pkg-config"
+      ],
+      "package": "zlib",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
+      "version": "0.7.1.0"
+    },
+    {
+      "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
+      "component": "lib:hackage-security",
+      "flags": [
+        "+cabal-syntax",
+        "+lukko"
+      ],
+      "package": "hackage-security",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
+      "version": "0.6.2.6"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "lib:open-browser",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    },
+    {
+      "cabal_sha256": "0322b2fcd1358f3355e0c8608efa60d27b14d1c9d476451dbcb9181363bd8b27",
+      "component": "lib:regex-base",
+      "flags": [],
+      "package": "regex-base",
+      "revision": 4,
+      "source": "hackage",
+      "src_sha256": "7b99408f580f5bb67a1c413e0bc735886608251331ad36322020f2169aea2ef1",
+      "version": "0.94.0.2"
+    },
+    {
+      "cabal_sha256": "816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd",
+      "component": "lib:regex-posix",
+      "flags": [
+        "-_regex-posix-clib"
+      ],
+      "package": "regex-posix",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "c7827c391919227711e1cff0a762b1678fd8739f9c902fc183041ff34f59259c",
+      "version": "0.96.0.1"
+    },
+    {
+      "cabal_sha256": "4868265ab5760d2fdeb96625b138c8df25d41b9ee2651fa299ed019a69403045",
+      "component": "lib:resolv",
+      "flags": [],
+      "package": "resolv",
+      "revision": 3,
+      "source": "hackage",
+      "src_sha256": "880d283df9132a7375fa28670f71e86480a4f49972256dc2a204c648274ae74b",
+      "version": "0.2.0.2"
+    },
+    {
+      "cabal_sha256": "8bb7261bd54bd58acfcb154be6a161fb6d0d31a1852aadc8e927d2ad2d7651d1",
+      "component": "lib:safe-exceptions",
+      "flags": [],
+      "package": "safe-exceptions",
+      "revision": 1,
+      "source": "hackage",
+      "src_sha256": "3c51d8d50c9b60ff8bf94f942fd92e3bea9e62c5afa778dfc9f707b79da41ef6",
+      "version": "0.1.7.4"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "lib:cabal-install",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": null,
+      "component": "exe:cabal",
+      "flags": [
+        "+lukko",
+        "+native-dns"
+      ],
+      "package": "cabal-install",
+      "revision": null,
+      "source": "local",
+      "src_sha256": null,
+      "version": "3.13.0.0"
+    },
+    {
+      "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",
+      "component": "exe:example",
+      "flags": [],
+      "package": "open-browser",
+      "revision": 0,
+      "source": "hackage",
+      "src_sha256": "0bed2e63800f738e78a4803ed22902accb50ac02068b96c17ce83a267244ca66",
+      "version": "0.2.1.0"
+    }
+  ]
 }

--- a/cabal.bootstrap.project
+++ b/cabal.bootstrap.project
@@ -9,4 +9,4 @@ packages:
 tests: False
 benchmarks: False
 
-index-state: hackage.haskell.org 2024-04-22T06:16:57Z
+index-state: hackage.haskell.org 2024-06-17T00:00:01Z

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -2,4 +2,4 @@ import: project-cabal/pkgs/cabal.config
 import: project-cabal/pkgs/install.config
 import: project-cabal/pkgs/tests.config
 
-index-state: hackage.haskell.org 2024-04-22T06:16:57Z
+index-state: hackage.haskell.org 2024-06-17T00:00:01Z


### PR DESCRIPTION
tar-0.6.3.0 has much improved performance of deserialising .tar index
which has significant ramifications for the start-up time of
cabal-install.

See https://github.com/haskell/cabal/issues/10110