### PR TITLE
implement mergify rules for release branches

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -58,10 +58,6 @@ pull_request_rules:
   - actions:
       queue:
         name: default
-        # Merge with a merge commit
-        method: merge
-        # Update the pr branch with rebase, so the history is clean
-        update_method: rebase
     name: Put release branch pull requests in the rebase+merge queue
     conditions:
       - label=merge me
@@ -73,11 +69,7 @@ pull_request_rules:
   # merge+squash strategy for release branches
   - actions:
       queue:
-        name: default
-        method: squash
-        # both update methods get absorbed by the squash, so we use the most
-        # reliable
-        update_method: merge
+        name: squash-merge
     name: Put release branch pull requests in the squash+merge queue
     conditions:
       - base!=master
@@ -90,7 +82,6 @@ pull_request_rules:
   - actions:
       queue:
         name: default
-        # Merge with a merge commit
     name: Put backports in the rebase+merge queue
     conditions:
       - label=merge me
@@ -126,6 +117,7 @@ queue_rules:
     update_bot_account: Mikolaj
     merge_method: merge
     update_method: rebase
+
   - name: squash-merge
     update_bot_account: Mikolaj
     merge_method: squash

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,6 @@
+# Note: We do not use the rebase strategy to merge PRs, because that
+# loses information needed by changelog-d to associate commits with PRs.
+
 pull_request_rules:
 
   # implementing PR delay logic: apply a label after 2 days of inactivity
@@ -48,7 +51,37 @@ pull_request_rules:
       - label=merge delay passed
       - '#approved-reviews-by>=2'
 
-  # rebase+merge strategy for backports: require 1 approver instead of 2
+  # merge strategy for release branches
+  - actions:
+      queue:
+        name: default
+        # Merge with a merge commit
+        method: merge
+        # Update the pr branch with rebase, so the history is clean
+        update_method: rebase
+    name: Put release branch pull requests in the rebase+merge queue
+    conditions:
+      - label=merge me
+      - base!=master
+      - -body~=backport
+      - '#approved-reviews-by>=2'
+
+  # merge+squash strategy for release branches
+  - actions:
+      queue:
+        name: default
+        method: squash
+        # both update methods get absorbed by the squash, so we use the most
+        # reliable
+        update_method: merge
+    name: Put release branch pull requests in the squash+merge queue
+    conditions:
+      - base!=master
+      - label=squash+merge me
+      - -body~=backport
+      - '#approved-reviews-by>=2'
+
+  # merge strategy for backports: require 1 approver instead of 2
   - actions:
       queue:
         name: default

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -28,6 +28,7 @@ pull_request_rules:
       - label=merge me
       - label=merge delay passed
       - '#approved-reviews-by>=2'
+      - '-label~=^blocked:'
 
   # merge+squash strategy
   - actions:
@@ -39,6 +40,7 @@ pull_request_rules:
       - label=squash+merge me
       - label=merge delay passed
       - '#approved-reviews-by>=2'
+      - '-label~=^blocked:'
 
   # merge+no rebase strategy
   - actions:
@@ -50,6 +52,7 @@ pull_request_rules:
       - label=merge+no rebase
       - label=merge delay passed
       - '#approved-reviews-by>=2'
+      - '-label~=^blocked:'
 
   # merge strategy for release branches
   - actions:
@@ -65,6 +68,7 @@ pull_request_rules:
       - base!=master
       - -body~=backport
       - '#approved-reviews-by>=2'
+      - '-label~=^blocked:'
 
   # merge+squash strategy for release branches
   - actions:
@@ -80,6 +84,7 @@ pull_request_rules:
       - label=squash+merge me
       - -body~=backport
       - '#approved-reviews-by>=2'
+      - '-label~=^blocked:'
 
   # merge strategy for backports: require 1 approver instead of 2
   - actions:
@@ -92,6 +97,7 @@ pull_request_rules:
       - base!=master
       - body~=backport
       - '#approved-reviews-by>=1'
+      - '-label~=^blocked:'
 
   # merge+squash strategy for backports: require 1 approver instead of 2
   - actions:
@@ -103,6 +109,7 @@ pull_request_rules:
       - base!=master
       - body~=backport
       - '#approved-reviews-by>=1'
+      - '-label~=^blocked:'
 
   # backports should be labeled as such
   - actions:


### PR DESCRIPTION
We only handled the case of backports previously, but the current release checklist expects that we can commit PRs to release branches during a release (e.g. changelogs, because we want the list of changelog.d files that are actually part of the release).

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). — It is, but Mergify only uses the config file on `master`
