### PR TITLE
Skip tasty-quickcheck 0.11

### DIFF
--- a/Cabal-described/Cabal-described.cabal
+++ b/Cabal-described/Cabal-described.cabal
@@ -18,8 +18,8 @@ library
     , pretty
     , QuickCheck
     , rere              >=0.1 && <0.3
-    , tasty
-    , tasty-quickcheck
+    , tasty             <1.6
+    , tasty-quickcheck  <0.11
 
   exposed-modules:
     Distribution.Described

--- a/Cabal-tests/Cabal-tests.cabal
+++ b/Cabal-tests/Cabal-tests.cabal
@@ -71,7 +71,7 @@ test-suite unit-tests
     , QuickCheck          >=2.14  && <2.15
     , tasty               >=1.2.3 && <1.6
     , tasty-hunit
-    , tasty-quickcheck
+    , tasty-quickcheck    <0.11
     , temporary
     , text
 
@@ -176,7 +176,7 @@ test-suite rpmvercmp
       QuickCheck
     , tasty             >=1.2.3 && <1.6
     , tasty-hunit
-    , tasty-quickcheck
+    , tasty-quickcheck  <0.11
 
   c-sources:        tests/cbits/rpmvercmp.c
   cc-options:       -Wall

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -135,5 +135,5 @@ Test-Suite unit-tests
      , Cabal-syntax
      , cabal-install-solver
      , tasty       >= 1.2.3 && <1.6
-     , tasty-quickcheck
+     , tasty-quickcheck <0.11
      , tasty-hunit >= 0.10

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -350,7 +350,7 @@ test-suite unit-tests
           zlib,
           tasty >= 1.2.3 && <1.6,
           tasty-golden >=2.3.1.1 && <2.4,
-          tasty-quickcheck,
+          tasty-quickcheck <0.11,
           tasty-expected-failure,
           tasty-hunit >= 0.10,
           tree-diff,
@@ -438,6 +438,6 @@ test-suite long-tests
         tasty >= 1.2.3 && <1.6,
         tasty-expected-failure,
         tasty-hunit >= 0.10,
-        tasty-quickcheck,
+        tasty-quickcheck <0.11,
         QuickCheck >= 2.14 && <2.16,
         pretty-show >= 1.6.15


### PR DESCRIPTION
tasty-quickcheck 0.11, which was just released, is API incompatible with earlier versions. Exclude it from build plans. (Why were we using it without an upper bound?)

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
