### PR TITLE
Disable arch-native flag when building releases that we distribute

### DIFF
--- a/cabal.release.project
+++ b/cabal.release.project
@@ -2,7 +2,7 @@ import: project-cabal/pkgs/cabal.config
 import: project-cabal/pkgs/install.config
 import: project-cabal/pkgs/tests.config
 
-package *
-  flags: -arch-native
+constraints:
+  hashable -arch-native
 
 index-state: hackage.haskell.org 2024-06-17T00:00:01Z

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -2,4 +2,7 @@ import: project-cabal/pkgs/cabal.config
 import: project-cabal/pkgs/install.config
 import: project-cabal/pkgs/tests.config
 
+package *
+  flags: -arch-native
+
 index-state: hackage.haskell.org 2024-06-17T00:00:01Z

--- a/cabal.validate.project
+++ b/cabal.validate.project
@@ -7,3 +7,8 @@ tests: True
 write-ghc-environment-files: never
 program-options
   ghc-options: -Werror
+
+-- This project file is used to distribute the cabal-head binary,
+-- as such we cannot enable "-march=native".
+constraints:
+  hashable -arch-native


### PR DESCRIPTION
We don't want to accidentally create binaries that contain CPU instructions only available in some machines. Hashable has this flag that enables the usage of `-march=native` for its FFI C code, so we have to disable it explicitly.

The `cabal.validate.project` file is also concerned because [we use it to build the `cabal-head` binary that we distribute.](https://github.com/haskell/cabal/blob/c39022a2297bf54f2b77d6be70c33957f224abb4/.github/workflows/validate.yml#L159)