### PR TITLE
Improve online docs for `includes:` field

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -1954,6 +1954,11 @@ system-dependent values for these fields.
    Like :pkg-field:`ghc-prof-shared-options` but applies to GHCJS
 
 .. pkg-field:: includes: filename list
+    :since: 1.0
+    :deprecated: 2.0
+
+    From GHC 6.10.1, :pkg-field:`includes` has no effect when compiling with
+    GHC. From Cabal 2.0, support for GHC versions before GHC 6.12 was removed.
 
     A list of header files to be included in any compilations via C.
     This field applies to both header files that are already installed


### PR DESCRIPTION
Bases for additions to online docs:
* https://downloads.haskell.org/~ghc/6.10.1/docs/html/users_guide/release-6-10-1.html ("... the `includes` field in `.cabal` files ... all have no effect when compiling Haskell source code.")
* EDIT: https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/ffi.html#using-header-files ("... the `include-files` field in a Cabal package specification is ignored.") (The reference to `include-files` is as in the original; it can be understood to mean `includes`.) EDIT2: https://gitlab.haskell.org/ghc/ghc/-/issues/25032
* https://hackage.haskell.org/package/Cabal-2.0.0.2/changelog ("Dropped support for versions of GHC earlier than 6.12 ...")
* https://github.com/haskell/cabal/commit/e1c39fc9ff4bf4eb8e956e2ee77da95d6cc73bbe (removes use of GHC's `-#include` option)

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions). N/A
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). N/A