### PR TITLE
Remove dead code

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -550,7 +550,6 @@ componentGhcOptions verbosity lbi bi clbi odir =
         , ghcOptCppIncludes =
             toNubListR $
               [coerceSymbolicPath (autogenComponentModulesDir lbi clbi </> makeRelativePathEx cppHeaderName)]
-        , ghcOptFfiIncludes = toNubListR $ map getSymbolicPath $ includes bi
         , ghcOptObjDir = toFlag $ coerceSymbolicPath odir
         , ghcOptHiDir = toFlag $ coerceSymbolicPath odir
         , ghcOptHieDir = bool NoFlag (toFlag $ coerceSymbolicPath odir </> (extraCompilationArtifacts </> makeRelativePathEx "hie")) $ flagHie implInfo

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -511,8 +511,6 @@ data GhcOptions = GhcOptions
   -- ^ Search path for CPP includes like header files; the @ghc -I@ flag.
   , ghcOptCppIncludes :: NubListR (SymbolicPath Pkg File)
   -- ^ Extra header files to include at CPP stage; the @ghc -optP-include@ flag.
-  , ghcOptFfiIncludes :: NubListR FilePath
-  -- ^ Extra header files to include for old-style FFI; the @ghc -#include@ flag.
   , ghcOptCcProgram :: Flag FilePath
   -- ^ Program to use for the C and C++ compiler; the @ghc -pgmc@ flag.
   , ----------------------------


### PR DESCRIPTION
Support for `-#include` has been removed in https://github.com/haskell/cabal/commit/e1c39fc9ff4bf4eb8e956e2ee77da95d6cc73bbe.  As a result `ghcOptFfiIncludes` is unused, making it dead  code.