### PR TITLE
Don't merge: Remove `includes`-field

### DIFF
--- a/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/PackageDescription/FieldGrammar.hs
@@ -666,7 +666,6 @@ buildInfoFieldGrammar =
     <*> monoidalFieldAla "extra-lib-dirs-static" (alaList' FSep SymbolicPathNT) L.extraLibDirsStatic
       ^^^ availableSince CabalSpecV3_8 []
     <*> monoidalFieldAla "include-dirs" (alaList' FSep SymbolicPathNT) L.includeDirs
-    <*> monoidalFieldAla "includes" (alaList' FSep SymbolicPathNT) L.includes
     <*> monoidalFieldAla "autogen-includes" (alaList' FSep RelativePathNT) L.autogenIncludes
       ^^^ availableSince CabalSpecV3_0 []
     <*> monoidalFieldAla "install-includes" (alaList' FSep RelativePathNT) L.installIncludes

--- a/Cabal-syntax/src/Distribution/Types/BuildInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/BuildInfo.hs
@@ -125,8 +125,6 @@ data BuildInfo = BuildInfo
   , extraLibDirsStatic :: [SymbolicPath Pkg (Dir Lib)]
   , includeDirs :: [SymbolicPath Pkg (Dir Include)]
   -- ^ directories to find .h files
-  , includes :: [SymbolicPath Include File]
-  -- ^ The .h files to be found in includeDirs
   , autogenIncludes :: [RelativePath Include File]
   -- ^ The .h files to be generated (e.g. by @autoconf@)
   , installIncludes :: [RelativePath Include File]
@@ -189,7 +187,6 @@ instance Monoid BuildInfo where
       , extraLibDirs = []
       , extraLibDirsStatic = []
       , includeDirs = []
-      , includes = []
       , autogenIncludes = []
       , installIncludes = []
       , options = mempty
@@ -242,7 +239,6 @@ instance Semigroup BuildInfo where
       , extraLibDirs = combineNub extraLibDirs
       , extraLibDirsStatic = combineNub extraLibDirsStatic
       , includeDirs = combineNub includeDirs
-      , includes = combineNub includes
       , autogenIncludes = combineNub autogenIncludes
       , installIncludes = combineNub installIncludes
       , options = combine options

--- a/Cabal-syntax/src/Distribution/Types/BuildInfo/Lens.hs
+++ b/Cabal-syntax/src/Distribution/Types/BuildInfo/Lens.hs
@@ -327,9 +327,6 @@ instance HasBuildInfo BuildInfo where
   includeDirs f s = fmap (\x -> s{T.includeDirs = x}) (f (T.includeDirs s))
   {-# INLINE includeDirs #-}
 
-  includes f s = fmap (\x -> s{T.includes = x}) (f (T.includes s))
-  {-# INLINE includes #-}
-
   autogenIncludes f s = fmap (\x -> s{T.autogenIncludes = x}) (f (T.autogenIncludes s))
   {-# INLINE autogenIncludes #-}
 

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo.hs
@@ -81,7 +81,6 @@ data InstalledPackageInfo = InstalledPackageInfo
   , extraLibrariesStatic :: [String]
   , extraGHCiLibraries :: [String] -- overrides extraLibraries for GHCi
   , includeDirs :: [FilePath]
-  , includes :: [String]
   , -- INVARIANT: if the package is definite, UnitId is NOT
     -- a ComponentId of an indefinite package
     depends :: [UnitId]
@@ -163,7 +162,6 @@ emptyInstalledPackageInfo =
     , extraLibrariesStatic = []
     , extraGHCiLibraries = []
     , includeDirs = []
-    , includes = []
     , depends = []
     , abiDepends = []
     , ccOptions = []

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/FieldGrammar.hs
@@ -114,7 +114,6 @@ ipiFieldGrammar =
     <@> monoidalFieldAla "extra-libraries-static" (alaList' FSep Token) L.extraLibrariesStatic
     <@> monoidalFieldAla "extra-ghci-libraries" (alaList' FSep Token) L.extraGHCiLibraries
     <@> monoidalFieldAla "include-dirs" (alaList' FSep FilePathNT) L.includeDirs
-    <@> monoidalFieldAla "includes" (alaList' FSep FilePathNT) L.includes
     <@> monoidalFieldAla "depends" (alaList FSep) L.depends
     <@> monoidalFieldAla "abi-depends" (alaList FSep) L.abiDepends
     <@> monoidalFieldAla "cc-options" (alaList' FSep Token) L.ccOptions

--- a/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/Lens.hs
+++ b/Cabal-syntax/src/Distribution/Types/InstalledPackageInfo/Lens.hs
@@ -147,10 +147,6 @@ includeDirs :: Lens' InstalledPackageInfo [FilePath]
 includeDirs f s = fmap (\x -> s{T.includeDirs = x}) (f (T.includeDirs s))
 {-# INLINE includeDirs #-}
 
-includes :: Lens' InstalledPackageInfo [String]
-includes f s = fmap (\x -> s{T.includes = x}) (f (T.includes s))
-{-# INLINE includes #-}
-
 depends :: Lens' InstalledPackageInfo [UnitId]
 depends f s = fmap (\x -> s{T.depends = x}) (f (T.depends s))
 {-# INLINE depends #-}

--- a/Cabal/src/Distribution/PackageDescription/Check/Target.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Target.hs
@@ -443,8 +443,6 @@ checkBuildInfoPathsWellFormedness bi = do
   mapM_
     (checkPath False "hs-source-dirs" PathKindDirectory . getSymbolicPath)
     (hsSourceDirs bi)
-  -- Possibly absolute paths.
-  mapM_ (checkPath True "includes" PathKindFile . getSymbolicPath) (includes bi)
   mapM_
     (checkPath True "include-dirs" PathKindDirectory . getSymbolicPath)
     (includeDirs bi)

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -2499,7 +2499,7 @@ checkForeignDeps pkg lbi verbosity =
         explainErrors missingHdr missingLibs
     )
   where
-    allHeaders = collectField (fmap getSymbolicPath . includes)
+    allHeaders = []
     allLibs =
       collectField $
         if withFullyStaticExe lbi

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -550,7 +550,6 @@ componentGhcOptions verbosity lbi bi clbi odir =
         , ghcOptCppIncludes =
             toNubListR $
               [coerceSymbolicPath (autogenComponentModulesDir lbi clbi </> makeRelativePathEx cppHeaderName)]
-        , ghcOptFfiIncludes = toNubListR $ map getSymbolicPath $ includes bi
         , ghcOptObjDir = toFlag $ coerceSymbolicPath odir
         , ghcOptHiDir = toFlag $ coerceSymbolicPath odir
         , ghcOptHieDir = bool NoFlag (toFlag $ coerceSymbolicPath odir </> (extraCompilationArtifacts </> makeRelativePathEx "hie")) $ flagHie implInfo

--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -511,8 +511,6 @@ data GhcOptions = GhcOptions
   -- ^ Search path for CPP includes like header files; the @ghc -I@ flag.
   , ghcOptCppIncludes :: NubListR (SymbolicPath Pkg File)
   -- ^ Extra header files to include at CPP stage; the @ghc -optP-include@ flag.
-  , ghcOptFfiIncludes :: NubListR FilePath
-  -- ^ Extra header files to include for old-style FFI; the @ghc -#include@ flag.
   , ghcOptCcProgram :: Flag FilePath
   -- ^ Program to use for the C and C++ compiler; the @ghc -pgmc@ flag.
   , ----------------------------

--- a/Cabal/src/Distribution/Simple/Register.hs
+++ b/Cabal/src/Distribution/Simple/Register.hs
@@ -538,7 +538,6 @@ generalInstalledPackageInfo adjustRelIncDirs pkg abi_hash lib lbi clbi installDi
     , IPI.extraLibrariesStatic = extraLibsStatic bi
     , IPI.extraGHCiLibraries = extraGHCiLibs bi
     , IPI.includeDirs = absinc ++ adjustRelIncDirs relinc
-    , IPI.includes = map getSymbolicPath $ includes bi
     , IPI.depends = depends
     , IPI.abiDepends = [] -- due to #5465
     , IPI.ccOptions = [] -- Note. NOT ccOptions bi!


### PR DESCRIPTION
**This PR is not meant to be merged!**

This PR demonstrates that `includes` are not used by anything.  It's meant to aid the discussion of #10145 and #10147; it can be closed after.