### PR TITLE
haddock-project: added `--all` switch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,7 +344,7 @@ description: {
 }
 ```
 
-Only the `synopsis` field is actually required, but you should also set the others where applicable.
+Only the `synopsis` and `prs` fields are required, but you should also set the others where applicable.
 
 | Field          | Description                                                                                                        |
 | -----          | -----------                                                                                                        |

--- a/Cabal/src/Distribution/Simple/Setup/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Haddock.hs
@@ -586,6 +586,27 @@ haddockProjectOptions _showOrParseArgs =
       trueArg
   , option
       ""
+      ["all", "haddock-all"]
+      "Run haddock for all targets"
+      ( \f ->
+          allFlags
+            [ haddockProjectExecutables f
+            , haddockProjectTestSuites f
+            , haddockProjectBenchmarks f
+            , haddockProjectForeignLibs f
+            ]
+      )
+      ( \v flags ->
+          flags
+            { haddockProjectExecutables = v
+            , haddockProjectTestSuites = v
+            , haddockProjectBenchmarks = v
+            , haddockProjectForeignLibs = v
+            }
+      )
+      trueArg
+  , option
+      ""
       ["internal"]
       "Run haddock for internal modules and include all symbols"
       haddockProjectInternal

--- a/changelog.d/issue-10051
+++ b/changelog.d/issue-10051
@@ -1,0 +1,4 @@
+synopsis: Added `--all` and `--haddock-all` switches to `haddock-project` subcommand
+packages: cabal-install
+issues: #10051
+prs: #2272


### PR DESCRIPTION
Added `--all` (`--haddock-all`) switches for compatibility with
`haddock` command.  `--haddock-all` alias is added, since that's what is
suggested by some warning messages.

Fixes #10051
