### PR TITLE
Document `program-options`

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -1451,6 +1451,8 @@ to have a way of finding out where a platform library got installed (other than 
 searching the ``lib/`` directory). Instead, we install foreign libraries in
 ``~/.local/lib``.
 
+.. _build-info:
+
 Build information
 ^^^^^^^^^^^^^^^^^
 .. pkg-section:: None
@@ -1892,8 +1894,11 @@ system-dependent values for these fields.
 
 .. pkg-field:: ghc-options: token list
 
-    Additional options for GHC. You can often achieve the same effect
-    using the :pkg-field:`default-extensions` field, which is preferred.
+    Additional options for GHC.
+
+    If specifying extensions (via ``-X<Extension>`` flags) one can often achieve
+    the same effect using the :pkg-field:`default-extensions` field, which is
+    preferred.
 
     Options required only by one module may be specified by placing an
     ``OPTIONS_GHC`` pragma in the source file affected.

--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -785,20 +785,17 @@ ways a package option can be specified:
    apply to all packages, local ones from the project and also external
    dependencies.
 
-
 For example, the following options specify that :cfg-field:`optimization`
-should be turned off for all local packages, and that ``bytestring`` (possibly
-an external dependency) should be built with ``-fno-state-hack``::
+should be turned off for all local packages, and that ``awesome-package`` (possibly
+an external dependency) should have the flag ``some-flag`` disabled ::
 
     optimization: False
 
-    package bytestring
-        ghc-options: -fno-state-hack
+    package awesome-package
+        flags: -some-flag
 
-``ghc-options`` is not specifically described in this documentation, but is one
-of many fields for configuring programs.  They take the form
-``progname-options`` and ``progname-location``, and can be set for all local
-packages in a ``program-options`` stanza or under a package stanza.
+Note that options at the top level take precedence over those at the ``package``
+stanza for local packages.
 
 On the command line, these options are applied to all local packages.
 There is no per-package command line interface.
@@ -807,6 +804,26 @@ Some flags were added by more recent versions of the Cabal library. This
 means that they are NOT supported by packages which use Custom setup
 scripts that require a version of the Cabal library older than when the
 feature was added.
+
+.. cfg-section:: package name or *
+
+    Specify package configuration options for the specific package (be it an
+    external or local package) or for all packages (external and local).
+
+    A ``package`` stanza can contain the configuration fields listed in this
+    section and ``<progname>-options``:
+
+    ::
+
+        package awesome-package
+          flags: -some-flag
+          profiling: True
+          cxx-options: -Wall
+
+    Program options are not extensively described in this documentation but a
+    good amount of them can be found in the :ref:`build-info` section.
+
+.. cfg-section:: None
 
 .. cfg-field:: flags: list of +flagname or -flagname (space separated)
                -f FLAGS or -fFLAGS, --flags=FLAGS
@@ -1639,11 +1656,36 @@ running ``setup haddock``.
     when complete. This will use ``xdg-open`` on Linux and BSD systems,
     ``open`` on macOS, and ``start`` on Windows.
 
+Program options
+^^^^^^^^^^^^^^^
+
+.. cfg-section:: program-options
+
+Program options can be specified once for all local packages by means of the
+``program-options`` stanza. For example:
+
+::
+
+    program-options
+        ghc-options: -Werror
+
+indicates that all **local packages** will provide ``-Werror`` to GHC when being
+built. On the other hand, the following snippet:
+
+::
+
+    package *
+        ghc-options: -Werror
+
+will apply ``-Werror`` to all packages, local and remote.
+
 Advanced global configuration options
 -------------------------------------
 
+.. cfg-section:: None
+
 .. cfg-field:: write-ghc-environment-files: always, never, or ghc8.4.4+
-               --write-ghc-environment-files=always\|never\|ghc8.4.4+
+               --write-ghc-environment-files=always|never|ghc8.4.4+
     :synopsis: Whether a ``.ghc.environment`` should be created after a successful build.
 
     :default: ``never``

--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -1661,7 +1661,7 @@ Program options
 
 .. cfg-section:: program-options
 
-Program options can be specified once for all local packages by means of the
+:ref:`Program options<program_options>` can be specified once for all local packages by means of the
 ``program-options`` stanza. For example:
 
 ::

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -297,3 +297,102 @@ recommended instead to use a *secure* local repository:
 The layout of these secure local repos matches the layout of remote
 repositories exactly; the :hackage-pkg:`hackage-repo-tool`
 can be used to create and manage such repositories.
+
+.. _program_options:
+
+Program options
+---------------
+
+Programs that ``cabal`` knows about can be provided with options that will be
+passed in whenever the program is invoked by ``cabal``. The configuration file
+can contain a stanza of ``program-default-options`` with ``<prog>-options``
+fields to specify these.
+
+::
+
+  program-default-options
+    ghc-options: ...
+    happy-options: ...
+
+The list of known programs is:
+
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| Program               | Notes                                                                                                                              |
++=======================+====================================================================================================================================+
+| ``alex``              | `<https://haskell-alex.readthedocs.io/en/latest/>`_                                                                                |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``ar``                | Usually provided by GHC's ``"ar command"`` entry in ``ghc --info``. Note this might refer to ``llvm-ar`` instead of GNU's ``ar``.  |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``c2hs``              | `<https://hackage.haskell.org/package/c2hs>`_                                                                                      |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``doctest``           | `<https://hackage.haskell.org/package/doctest>`_                                                                                   |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``gcc``               | Usually provided by GHC's ``"C compiler command"`` entry in ``ghc --info``. Note this might refer to ``clang`` instead of ``gcc``. |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``ghc``               |                                                                                                                                    |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``ghc-pkg``           |                                                                                                                                    |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``ghcjs``             |                                                                                                                                    |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``ghcjs-pkg``         |                                                                                                                                    |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``greencard``         | Greencard hasn't been updated since 2014, it doesn't build with newer GHCs `<https://hackage.haskell.org/package/greencard>`_      |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``haddock``           | `<https://haskell-haddock.readthedocs.io/latest/>`_                                                                                |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``happy``             | `<https://haskell-happy.readthedocs.io/en/latest/>`_                                                                               |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``haskell-suite``     | Haskell suite was abandoned a long time ago.                                                                                       |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``haskell-suite-pkg`` | Haskell suite was abandoned a long time ago.                                                                                       |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``hmake``             | Seems like hmake disappeared a long time ago `<https://www.haskell.org/cabal/proposal-1.1/x756.html>`_                             |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``hpc``               | `<https://hackage.haskell.org/package/hpc>`_                                                                                       |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``hsc2hs``            | `<https://hackage.haskell.org/package/hsc2hs>`_                                                                                    |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``hscolour``          | `<https://hackage.haskell.org/package/hscolour>`_                                                                                  |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``jhc``               | `<http://repetae.net/computer/jhc/>`_                                                                                              |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``ld``                | Usually provided by GHC's ``"ld command"`` entry in ``ghc --info``.                                                                |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``pkg-config``        |                                                                                                                                    |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``runghc``            |                                                                                                                                    |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``strip``             |                                                                                                                                    |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``tar``               |                                                                                                                                    |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``uhc``               | `<https://github.com/UU-ComputerScience/uhc>`_                                                                                     |
++-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+
+.. warning::
+
+  It is important to not confuse these options with the ones listed in the
+  :ref:`build info<build-info>` section. The ``*-options`` fields mentioned are in
+  fact syntactic sugar for specific ``ghc-options`` that will be passed only on
+  certain phases.
+
+.. warning::
+
+  These options will be used when ``cabal`` invokes the tool as part of the build process or as part of a
+  :pkg-field:`build-tool-depends` declaration, not whenever the tool is invoked by
+  third parties.
+
+  In particular this means that for example ``gcc-options`` will be used when ``cabal``
+  invokes ``gcc``, which is **not** when C sources are compiled by GHC (even though GHC
+  might invoke ``gcc`` internally). In order to provide options through GHC for those programs, one has to check the
+  GHC User guide's `Section <https://downloads.haskell.org/ghc/latest/docs/users_guide/phases.html#forcing-options-to-a-particular-phase>`_.
+  In short, those options have to be given as ``-opt<phase>`` flags to GHC.
+
+.. note::
+
+  The only case that violates the rule specified in this last warning above is
+  ``ld-options``, which get passed as ``-optl`` options when GHC is invoked for
+  linking, as with the :pkg-field:`ld-options` field in package descriptions.
+  Notably, although ``gcc-options`` could be passed as :pkg-field:`cc-options`
+  in the appropriate phases, they are actually **not** passed.


### PR DESCRIPTION
Best to read the documentation online 
- https://cabal--10173.org.readthedocs.build/en/10173/config.html#program-options
- https://cabal--10173.org.readthedocs.build/en/10173/cabal-project-description-file.html#program-options
- The clarification in the `*-options` fields following this one https://cabal--10173.org.readthedocs.build/en/10173/cabal-package-description-file.html#pkg-field-cc-options