### PR TITLE
fix non-POSIX [[ ]]

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -329,7 +329,7 @@ CABALLISTBIN="${CABAL} list-bin --builddir=$BUILDDIR --project-file=$PROJECTFILE
 # of validate.sh
 # https://github.com/haskell/cabal/issues/9571
 # https://github.com/haskell/cabal/pull/10114
-RTSOPTS="$([[ $ARCH = "x86_64-windows" && -z "$CI" ]] && echo "+RTS --io-manager=native" || echo "")"
+RTSOPTS="$([ $ARCH = "x86_64-windows" ] &&  [ -z "$CI" ] && echo "+RTS --io-manager=native" || echo "")"
 
 # header
 #######################################################################


### PR DESCRIPTION
Otherwise CI prints `validate.sh: 332: [[: not found` and the line does nothing (but `validate.sh` continues to run), unless the system shell is `ksh` / `bash` / `zsh`. This may explain https://github.com/haskell/cabal/pull/10114#issuecomment-2178163927.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). —only indirectly
