### PR TITLE
Remove read-only mark on `dist-newstyle` when doing `cabal clean` on Windows

### DIFF
--- a/cabal-install/src/Distribution/Client/VCS.hs
+++ b/cabal-install/src/Distribution/Client/VCS.hs
@@ -64,6 +64,10 @@ import Distribution.Simple.Program
 import Distribution.Simple.Program.Db
   ( prependProgramSearchPath
   )
+import Distribution.System
+  ( OS (Windows)
+  , buildOS
+  )
 import Distribution.Types.SourceRepo
   ( KnownRepoType (..)
   , RepoType (..)
@@ -93,6 +97,7 @@ import qualified Data.Map as Map
 import System.Directory
   ( doesDirectoryExist
   , removeDirectoryRecursive
+  , removePathForcibly
   )
 import System.FilePath
   ( takeDirectory
@@ -100,7 +105,9 @@ import System.FilePath
   )
 import System.IO.Error
   ( isDoesNotExistError
+  , isPermissionError
   )
+import qualified System.Process as Process
 
 -- | A driver for a version control system, e.g. git, darcs etc.
 data VCS program = VCS
@@ -509,7 +516,19 @@ vcsGit =
       git localDir ["submodule", "deinit", "--force", "--all"]
       let gitModulesDir = localDir </> ".git" </> "modules"
       gitModulesExists <- doesDirectoryExist gitModulesDir
-      when gitModulesExists $ removeDirectoryRecursive gitModulesDir
+      when gitModulesExists $
+        if buildOS == Windows
+          then do
+            -- Windows can't delete some git files #10182
+            void $
+              Process.createProcess_ "attrib" $
+                Process.shell $
+                  "attrib -s -h -r " <> gitModulesDir <> "\\*.* /s /d"
+
+            catch
+              (removePathForcibly gitModulesDir)
+              (\e -> if isPermissionError e then removePathForcibly gitModulesDir else throw e)
+          else removeDirectoryRecursive gitModulesDir
       git localDir resetArgs
       git localDir $ ["submodule", "sync", "--recursive"] ++ verboseArg
       git localDir $ ["submodule", "update", "--force", "--init", "--recursive"] ++ verboseArg

--- a/cabal-testsuite/PackageTests/NewBuild/CmdClean/CleanSourceRepositoryPackage/a.cabal
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdClean/CleanSourceRepositoryPackage/a.cabal
@@ -1,0 +1,6 @@
+cabal-version: 3.0
+name: aa
+version: 0.1.0.0
+build-type: Simple
+
+library

--- a/cabal-testsuite/PackageTests/NewBuild/CmdClean/CleanSourceRepositoryPackage/cabal.out
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdClean/CleanSourceRepositoryPackage/cabal.out
@@ -1,0 +1,6 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following would be built:
+ - aa-0.1.0.0 (lib) (first run)
+# cabal clean

--- a/cabal-testsuite/PackageTests/NewBuild/CmdClean/CleanSourceRepositoryPackage/cabal.project
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdClean/CleanSourceRepositoryPackage/cabal.project
@@ -1,0 +1,5 @@
+packages: .
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell-hvr/Only

--- a/cabal-testsuite/PackageTests/NewBuild/CmdClean/CleanSourceRepositoryPackage/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NewBuild/CmdClean/CleanSourceRepositoryPackage/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+
+main = cabalTest $ withProjectFile "cabal.project" $ do
+    void $ cabal' "build" ["--dry-run"]
+    void $ cabal' "clean" []

--- a/changelog.d/pr-10190
+++ b/changelog.d/pr-10190
@@ -1,0 +1,11 @@
+synopsis: Fix `cabal clean` permissions on Windows
+packages: cabal-install
+prs: #10190
+issues: #10182
+significance:
+
+description: {
+
+- `cabal clean` now removes the read-only mark recursively in the `dist-newstyle` folder on Windows before attempting to delete it.
+
+}


### PR DESCRIPTION
Just one commit, the rest are from the base branch #10255. This still doesn't ensure that the directory can be deleted on the first go, but at least a second cabal clean will for sure clean it.

Closes #10182 #6933

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary.
* [X] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

Depends-On: #10225 

# QA

Very simple, just doing `cabal clean` if there is a `source-repository-package`
```
❯ cat cabal.project
packages: .

source-repository-package
  type: git
  location: https://github.com/haskell/bytestring

❯ cabal build
Cloning into 'C:\Users\Javier\code\aa\dist-newstyle\src\bytestring-ea6cd2d51c6ca30b'...
...

❯ cabal clean
C:\Users\Javier\code\aa\dist-newstyle\src\bytestring-ea6cd2d51c6ca30b\.git\objects\pack\pack-8793205445310ec514631949079f7ebb57de3771.rev: removeDirectoryRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removePathRecursive:DeleteFile "\\\\?\\C:\\Users\\Javier\\code\\aa\\dist-newstyle\\src\\bytestring-ea6cd2d51c6ca30b\\.git\\objects\\pack\\pack-8793205445310ec514631949079f7ebb57de3771.rev": permission denied (Access is denied.)
```

The above will work with this patch.