### PR TITLE
CI: don't allow-newer for GHC 9.10

### DIFF
--- a/buildinfo-reference-generator/buildinfo-reference-generator.cabal
+++ b/buildinfo-reference-generator/buildinfo-reference-generator.cabal
@@ -8,7 +8,7 @@ executable buildinfo-reference-generator
   ghc-options:      -Wall
   main-is:          Main.hs
   build-depends:
-    , base             >=4.11 && <4.20
+    , base             >=4.11 && <4.21
     , Cabal
     , Cabal-described
     , containers

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -26,7 +26,7 @@ common shared
   default-language: Haskell2010
 
   build-depends:
-    , base >= 4.11 && < 4.20
+    , base >= 4.11 && < 4.21
     -- this needs to match the in-tree lib:Cabal version
     , Cabal ^>= 3.13.0.0
 

--- a/project-cabal/ghc-latest.config
+++ b/project-cabal/ghc-latest.config
@@ -6,8 +6,10 @@
 --   - cabal.validate.project (Cabal CI),
 -- Commented out below are the usual suspects. Feel free to add more.
 
--- NOTE: don't forget to update the compiler version in the conditional
+-- NOTE: don't forget to update the compiler version in the conditionals
 -- when upgrading to a newer GHC
+if impl(ghc >= 9.10.0)
+    allow-newer: rere:base
 if impl(ghc >= 9.12.0)
     allow-newer:
     --windns:*, rere:*, tree-diff:*, uuid-types:*, these:*, hashable:*, assoc:*, semialign:*, indexed-traversable-instances:*, indexed-traversable:*, OneTuple:*, scientific:*, time-compat:*, text-short:*, integer-conversion:*, generically:*, data-fix:*, binary:*

--- a/project-cabal/ghc-latest.config
+++ b/project-cabal/ghc-latest.config
@@ -8,7 +8,7 @@
 
 -- NOTE: don't forget to update the compiler version in the conditional
 -- when upgrading to a newer GHC
-if impl(ghc >= 9.10.0)
+if impl(ghc >= 9.12.0)
     allow-newer:
     --windns:*, rere:*, tree-diff:*, uuid-types:*, these:*, hashable:*, assoc:*, semialign:*, indexed-traversable-instances:*, indexed-traversable:*, OneTuple:*, scientific:*, time-compat:*, text-short:*, integer-conversion:*, generically:*, data-fix:*, binary:*
     -- Artem, 2024-04-21: I started and then gave up...


### PR DESCRIPTION
When updating to GHC 9.10 (https://github.com/haskell/cabal/pull/9914), we had to put a bunch of allow-newer's and pull some patches from head.hackage. This shouldn't be needed after the ecosystem has caught up. This PR shows that the only issue remaining is `rere` (https://github.com/phadej/rere/issues/28).

We didn't apply the bandaids (allow-newer's and head.hackage source repo) unconditionally and instead used `impl(ghc >= 9.10.0)`. Now, we don't remove this stuff, we bump the conditional from 9.10.0 to 9.12.0 anticipating the same procedure for the future (yet unplanned) release of GHC 9.12.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
