### PR TITLE
ci(validate.yml): Allow workflow_dispatch with no allow-newer or constraints

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,11 +31,11 @@ on:
     inputs:
       allow-newer:
         description: allow-newer line
-        required: true
+        required: false
         type: string
       constraints:
         description: constraints line
-        required: true
+        required: false
         type: string
 
 env:
@@ -92,11 +92,15 @@ jobs:
       - uses: actions/checkout@v4
 
       # See https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#hackage-revisions
-      - name: Manually supplied constraints/allow-newer
-        if: github.event_name == 'workflow_dispatch'
+      - name: Add manually supplied allow-newer
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.allow-newer != ''
         run: |
-          echo "allow-newer: ${ALLOWNEWER}"  >> cabal.validate.project
-          echo "constraints: ${CONSTRAINTS}" >> cabal.validate.project
+          echo "allow-newer: ${{ github.event.inputs.allow-newer }}" >> cabal.validate.project
+
+      - name: Add manually supplied constraints
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.constraints != ''
+        run: |
+          echo "constraints: ${{ github.event.inputs.constraints }}" >> cabal.validate.project
 
       - uses: haskell-actions/setup@v2
         id: setup-haskell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -429,7 +429,7 @@ it, someone with enough permissions needs to go on the
 [Validate workflow page](https://github.com/haskell/cabal/actions/workflows/validate.yml)
 and dispatch it manually by clicking "Run workflow".
 
-Running workflow manually as discussed above requires you to supply two inputs:
+Running workflow manually as discussed above allows you to supply two inputs:
 
 > allow-newer line
 > constraints line


### PR DESCRIPTION
This slightly changes the `validate.yml` workflow to allow workflow_dispatch without allow-newer or constraints. It is useful when testing CI or various automations.

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
