### PR TITLE
Fix Haddock docs for `Distribution.Types.Dependency`

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/Dependency.hs
+++ b/Cabal-syntax/src/Distribution/Types/Dependency.hs
@@ -33,10 +33,6 @@ import qualified Text.PrettyPrint as PP
 --
 -- /Invariant:/ package name does not appear as 'LSubLibName' in
 -- set of library names.
---
--- /Note:/ 'Dependency' is not an instance of 'Ord', and so it cannot be used
--- in 'Set' or as the key to a 'Map'.  For these and similar use cases see
--- 'DependencyMap'.
 data Dependency
   = -- | The set of libraries required from the package.
     -- Only the selected libraries will be built.


### PR DESCRIPTION
Type `Dependency` is an instance of `Ord`, from `Cabal-syntax-3.10.1.0` following:
* b7afc9709d120c7b90155a29f41366743c61d133

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). Not applicable.