### PR TITLE
Update cabal-commands.rst

### DIFF
--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -343,6 +343,7 @@ While this interface is intended to be used for scripting, it is an experimental
 Scripting example:
 
 ::
+
    $ ls $(cabal path --installdir)
    ...
 


### PR DESCRIPTION
This is currently not rendered as a code block at

https://cabal.readthedocs.io/en/stable/cabal-commands.html#cabal-path

![IMG_1558](https://github.com/user-attachments/assets/bf0e8abb-de4f-461f-8f4c-e176bcd912e5)



I'm actually not sure if this change fixes it, I haven't tried, it's just an educated guess.

 **NOTE: I'll probably not have the bandwidth to finish this up myself, so if somebody wants to include this fix when doing something on the documentation, then that would be very much appreciated.**