### PR TITLE
make cabal-install integration tests hermetic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ bootstrap/*.plan.json
 /cabal-install/dist/
 /cabal-install/Setup
 /cabal-install/source-file-list
+/cabal-install/tests/IntegrationTests2/config/cabal-config
 
 .stylish-haskell.yaml
 .stylish-haskell.yml

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -399,6 +399,7 @@ test-suite integration-tests2
         containers,
         directory,
         filepath,
+        process,
         tasty >= 1.2.3 && <1.6,
         tasty-hunit >= 0.10,
         tagged

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -74,7 +74,9 @@ import Control.Concurrent (threadDelay)
 import Control.Exception hiding (assert)
 import System.FilePath
 import System.Directory
+import System.Environment (setEnv)
 import System.IO (hPutStrLn, stderr)
+import System.Process (callProcess)
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -93,7 +95,16 @@ removePathForcibly = removeDirectoryRecursive
 #endif
 
 main :: IO ()
-main =
+main = do
+  -- this is needed to ensure tests aren't affected by the user's cabal config
+  cwd <- getCurrentDirectory
+  let configDir = cwd </> basedir </> "config" </> "cabal-config"
+  setEnv "CABAL_DIR" configDir
+  removeDirectoryRecursive configDir <|> return ()
+  createDirectoryIfMissing True configDir
+  -- sigh
+  callProcess "cabal" ["user-config", "init", "-f"]
+  callProcess "cabal" ["update"]
   defaultMainWithIngredients
     (defaultIngredients ++ [includingOptions projectConfigOptionDescriptions])
     (withProjectConfig $ \config ->
@@ -1971,8 +1982,8 @@ testNixFlags = do
 -- Tests whether config options are commented or not
 testConfigOptionComments :: Assertion
 testConfigOptionComments = do
-  _ <- createDefaultConfigFile verbosity [] (basedir </> "config/default-config")
-  defaultConfigFile <- readFile (basedir </> "config/default-config")
+  _ <- createDefaultConfigFile verbosity [] (basedir </> "config" </> "default-config")
+  defaultConfigFile <- readFile (basedir </> "config" </> "default-config")
 
   "  url" @=? findLineWith False "url" defaultConfigFile
   "  -- secure" @=? findLineWith True "secure" defaultConfigFile


### PR DESCRIPTION
They were using the user's config, which is a problem if they don't have one or if it contains settings that interfere with tests (such as `documentation: True`).

I'm not entirely certain of this, but it seems to work here. It's a bit of a hack, though.

Closes: #10187 

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
