### PR TITLE
Die if dynamic executable is requested on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ register.sh
 # listed explicitly to show which files are generated but ignored
 testdb/intree/cabal.project-test
 testdb/intree/store/**/bin/alex
+testdb/intree/store/**/bin/alex.exe
 testdb/intree/store/**/cabal-hash.txt
 testdb/intree/store/**/share/AlexTemplate.hs
 testdb/intree/store/**/share/AlexWrappers.hs

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -1305,6 +1305,9 @@ configureComponents
       when (LBC.relocatable $ LBC.withBuildOptions lbc) $
         checkRelocatable verbosity pkg_descr lbi
 
+      when (LBC.withDynExe $ LBC.withBuildOptions lbc) $
+        checkSharedExes verbosity lbi
+
       -- TODO: This is not entirely correct, because the dirs may vary
       -- across libraries/executables
       let dirs = absoluteInstallDirs pkg_descr lbi NoCopyDest
@@ -2719,6 +2722,18 @@ checkPackageProblems verbosity dir gpkg pkg = do
     classEW (PackageDistSuspiciousWarn _) = Nothing
     classEW (PackageDistInexcusable _) = Nothing
 
+-- | Perform checks if a shared executable can be built
+checkSharedExes
+  :: Verbosity
+  -> LocalBuildInfo
+  -> IO ()
+checkSharedExes verbosity lbi =
+  when (os == Windows) $
+    dieWithException verbosity $
+      NoOSSupport os "shared executables"
+  where
+    (Platform _ os) = hostPlatform lbi
+
 -- | Preform checks if a relocatable build is allowed
 checkRelocatable
   :: Verbosity
@@ -2741,7 +2756,7 @@ checkRelocatable verbosity pkg lbi =
     checkOS =
       unless (os `elem` [OSX, Linux]) $
         dieWithException verbosity $
-          NoOSSupport os
+          NoOSSupport os "relocatable builds"
       where
         (Platform _ os) = hostPlatform lbi
 

--- a/Cabal/src/Distribution/Simple/Errors.hs
+++ b/Cabal/src/Distribution/Simple/Errors.hs
@@ -138,7 +138,7 @@ data CabalException
   | BadVersion String String PkgconfigVersion
   | UnknownCompilerException
   | NoWorkingGcc
-  | NoOSSupport OS
+  | NoOSSupport OS String
   | NoCompilerSupport String
   | InstallDirsNotPrefixRelative (InstallDirs FilePath)
   | ExplainErrors (Maybe (Either [Char] [Char])) [String]
@@ -622,10 +622,11 @@ exceptionMessage e = case e of
           ++ "non-standard location you can use the --with-gcc "
           ++ "flag to specify it."
       ]
-  NoOSSupport os ->
+  NoOSSupport os what ->
     "Operating system: "
       ++ prettyShow os
-      ++ ", does not support relocatable builds"
+      ++ ", does not support "
+      ++ what
   NoCompilerSupport comp ->
     "Compiler: "
       ++ comp

--- a/cabal-testsuite/PackageTests/NoOSSupport/DynExe/Main.hs
+++ b/cabal-testsuite/PackageTests/NoOSSupport/DynExe/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = pure ()

--- a/cabal-testsuite/PackageTests/NoOSSupport/DynExe/a.cabal
+++ b/cabal-testsuite/PackageTests/NoOSSupport/DynExe/a.cabal
@@ -1,0 +1,8 @@
+cabal-version: 3.0
+name: aa
+version: 0.1.0.0
+build-type: Simple
+
+executable a
+  default-language: Haskell2010
+  main-is: Main.hs

--- a/cabal-testsuite/PackageTests/NoOSSupport/DynExe/cabal.out
+++ b/cabal-testsuite/PackageTests/NoOSSupport/DynExe/cabal.out
@@ -1,0 +1,12 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - aa-0.1.0.0 (exe:a) (first run)
+Configuring executable 'a' for aa-0.1.0.0...
+Warning: Executables will use dynamic linking, but a shared library is not
+being built. Linking will fail if any executables depend on the library.
+Error: [Cabal-3339]
+Operating system: windows, does not support shared executables
+Error: [Cabal-7125]
+Failed to build aa-0.1.0.0-inplace-a. The failure occurred during the configure step.

--- a/cabal-testsuite/PackageTests/NoOSSupport/DynExe/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NoOSSupport/DynExe/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+
+main = do
+    skipUnlessWindows
+    cabalTest $ fails $ cabal "build" ["--enable-executable-dynamic", "--disable-shared"]

--- a/cabal-testsuite/PackageTests/NoOSSupport/RelocatableExe/Main.hs
+++ b/cabal-testsuite/PackageTests/NoOSSupport/RelocatableExe/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = pure ()

--- a/cabal-testsuite/PackageTests/NoOSSupport/RelocatableExe/a.cabal
+++ b/cabal-testsuite/PackageTests/NoOSSupport/RelocatableExe/a.cabal
@@ -1,0 +1,8 @@
+cabal-version: 3.0
+name: aa
+version: 0.1.0.0
+build-type: Simple
+
+executable a
+  default-language: Haskell2010
+  main-is: Main.hs

--- a/cabal-testsuite/PackageTests/NoOSSupport/RelocatableExe/cabal.out
+++ b/cabal-testsuite/PackageTests/NoOSSupport/RelocatableExe/cabal.out
@@ -1,0 +1,10 @@
+# cabal build
+Resolving dependencies...
+Build profile: -w ghc-<GHCVER> -O1
+In order, the following will be built:
+ - aa-0.1.0.0 (exe:a) (first run)
+Configuring executable 'a' for aa-0.1.0.0...
+Error: [Cabal-3339]
+Operating system: windows, does not support relocatable builds
+Error: [Cabal-7125]
+Failed to build aa-0.1.0.0-inplace-a. The failure occurred during the configure step.

--- a/cabal-testsuite/PackageTests/NoOSSupport/RelocatableExe/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/NoOSSupport/RelocatableExe/cabal.test.hs
@@ -1,0 +1,5 @@
+import Test.Cabal.Prelude
+
+main = do
+    skipUnlessWindows
+    cabalTest $ fails $ cabal "build" ["--enable-relocatable"]

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -937,6 +937,9 @@ isJavaScript = buildArch == JavaScript
 skipIfWindows :: String -> IO ()
 skipIfWindows why = skipIfIO ("Windows " <> why) isWindows
 
+skipUnlessWindows :: IO ()
+skipUnlessWindows = skipIfIO "Only interesting in Windows" (not isWindows)
+
 getOpenFilesLimit :: TestM (Maybe Integer)
 #ifdef mingw32_HOST_OS
 -- No MS-specified limit, was determined experimentally on Windows 10 Pro x64,

--- a/changelog.d/pr-10217
+++ b/changelog.d/pr-10217
@@ -1,0 +1,10 @@
+synopsis: Do not try to build dynamic executables on Windows
+packages: Cabal
+prs: #10217
+
+description: {
+
+- Cabal will now exit with a descriptive error message instead of attempting to
+  build a dynamic executable on Windows.
+
+}


### PR DESCRIPTION
Closes #9807

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

# QA

Trying to build with `--enable-executable-dynamic` will now stop before attempting to compile.