### PR TITLE
add "ready and waiting" Mergify label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -18,6 +18,32 @@ pull_request_rules:
         - label=merge+no rebase
       - '#approved-reviews-by>=2'
 
+  # label when Mergify is ready but waiting for the above
+  - actions:
+      label:
+        add:
+          - ready and waiting
+    name: Waiting out merge delay (used by bot)
+    conditions:
+      - base=master
+      - -draft
+      - -closed
+      - or:
+        - label=merge me
+        - label=squash+merge me
+        - label=merge+no rebase
+      - '#approved-reviews-by>=2'
+      - '#changes-requested-reviews-by=0'
+      # oy
+      # lifted these from branch protection imports
+      - check-success=fourmolu
+      - check-success=hlint
+      - check-success=Meta checks
+      - check-success=Doctest Cabal
+      - check-success=Validate post job
+      - check-success=Bootstrap post job
+      - 'check-success=docs/readthedocs.org:cabal'
+
   # rebase+merge strategy
   - actions:
       queue:


### PR DESCRIPTION
The bot can use this to announce PRs that are entering the 2-day waiting period.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). —not relevant as it is only read on `master`
