### PR TITLE
Improve bat scripts for CCompilerOverride

### DIFF
--- a/cabal-testsuite/PackageTests/CCompilerOverride/custom-cc-clang.bat
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/custom-cc-clang.bat
@@ -1,11 +1,7 @@
 @echo OFF
 
-where /q clang.exe
-
-IF %ERRORLEVEL% EQU 0 (
-   call clang.exe -DNOERROR6 %*
-   EXIT /B %ERRORLEVEL%
-)
-
-ECHO "Cannot find C compiler"
-EXIT /B 1
+REM replace the libdir with the path to the compiler
+FOR /f "delims=" %%A in ('call ghc.exe --print-libdir') do set "var=%%A"
+setlocal EnableDelayedExpansion
+CALL !var:lib=mingw\bin\clang.exe! -DNOERROR6 %*
+EXIT /B %ERRORLEVEL%

--- a/cabal-testsuite/PackageTests/CCompilerOverride/custom-cc.bat
+++ b/cabal-testsuite/PackageTests/CCompilerOverride/custom-cc.bat
@@ -1,11 +1,7 @@
 @echo OFF
 
-where /q gcc.exe
-
-IF %ERRORLEVEL% EQU 0 (
-   call gcc.exe -DNOERROR6 %*
-   EXIT /B %ERRORLEVEL%
-)
-
-ECHO "Cannot find C compiler"
-EXIT /B 1
+REM replace the libdir with the path to the compiler
+FOR /f "delims=" %%A in ('call ghc.exe --print-libdir') do set "var=%%A"
+setlocal EnableDelayedExpansion
+CALL !var:lib=mingw\bin\gcc.exe! -DNOERROR6 %*
+EXIT /B %ERRORLEVEL%


### PR DESCRIPTION
This PR improves the CCompilerOverride bat scripts so that they point to the gcc or clang shipped with GHC, and not try to find one on the system. CI happens to have one installed but the user might not (see why one would do that in the warning in this section https://cabal.readthedocs.io/en/latest/how-to-run-in-windows.html#ensure-that-cabal-can-use-system-libraries)