### PR TITLE
reorder Haddock markup for dynprof constructor

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ConstraintSource.hs
@@ -41,9 +41,9 @@ data ConstraintSource =
   -- from Cabal >= 3.11
   | ConstraintSourceMultiRepl
 
-  | ConstraintSourceProfiledDynamic
   -- | Constraint introduced by --enable-profiling-shared, which requires features
   -- from Cabal >= 3.13
+  | ConstraintSourceProfiledDynamic
 
   -- | The source of the constraint is not specified.
   | ConstraintSourceUnknown


### PR DESCRIPTION
Older ghcs don't like it being after the constructor: https://github.com/haskell/cabal/pull/10092#issuecomment-2246287132

**Template B: This PR does not modify behaviour or interface**
(N.B. while this doesn't change interface, it corrects an error in #9900 which very much does.)

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
