### PR TITLE
Add simple QuickCheck test for solver exceptions

### DIFF
--- a/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
+++ b/cabal-install/tests/UnitTests/Distribution/Solver/Modular/QuickCheck.hs
@@ -52,7 +52,20 @@ import UnitTests.Distribution.Solver.Modular.QuickCheck.Utils
 
 tests :: [TestTree]
 tests =
-  [ -- This test checks that certain solver parameters do not affect the
+  [ testPropertyWithSeed "solver does not throw exceptions" $
+      \test goalOrder reorderGoals indepGoals prefOldest ->
+        let r =
+              solve
+                (EnableBackjumping True)
+                (FineGrainedConflicts True)
+                reorderGoals
+                (CountConflicts True)
+                indepGoals
+                prefOldest
+                (getBlind <$> goalOrder)
+                test
+         in resultPlan r `seq` ()
+  , -- This test checks that certain solver parameters do not affect the
     -- existence of a solution. It runs the solver twice, and only sets those
     -- parameters on the second run. The test also applies parameters that
     -- can affect the existence of a solution to both runs.
@@ -515,6 +528,11 @@ instance Arbitrary IndependentGoals where
   arbitrary = IndependentGoals <$> arbitrary
 
   shrink (IndependentGoals indep) = [IndependentGoals False | indep]
+
+instance Arbitrary PreferOldest where
+  arbitrary = PreferOldest <$> arbitrary
+
+  shrink (PreferOldest prefOldest) = [PreferOldest False | prefOldest]
 
 instance Arbitrary Component where
   arbitrary =


### PR DESCRIPTION
The solver QuickCheck tests can already detect exceptions, but this test is simpler and easier to debug.

-----------------

This PR doesn't have a corresponding issue because it only adds tests.

-----------------

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
