### PR TITLE
Filter out -dinitial-unique and -dunique-increment from hash flags

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -324,6 +324,8 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
           , "-ddpr-cols"
           , "-dtrace-level"
           , "-fghci-hist-size"
+          , "-dinitial-unique"
+          , "-dunique-increment"
           ]
         , from [8, 2] ["-fmax-uncovered-patterns", "-fmax-errors"]
         , from [8, 4] $ to [8, 6] ["-fmax-valid-substitutions"]

--- a/changelog.d/pr-10240
+++ b/changelog.d/pr-10240
@@ -1,0 +1,13 @@
+synopsis: Filter out dinitial-unique and dunique-increment from package hash
+packages: cabal-install
+prs: #10122
+
+description: {
+
+`-dinitial-unique` and `-dunique-increment` are now filtered out when computing the
+store hash of a package.
+
+These options shouldn't affect the output of the package and hence
+shouldn't affect the store hash of a package.
+
+}


### PR DESCRIPTION
These options shouldn't affect the output of the package and hence
shouldn't affect the store hash of a package.