### PR TITLE
hpc: Don't cover non-dependency libraries

### DIFF
--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -1280,7 +1280,9 @@ configureComponents
           extraCoverageUnitIds = case enabled of
             -- Whole package configure, add package libs
             ComponentRequestedSpec{} -> mapMaybe mbCompUnitId buildComponents
-            -- Component configure, no need to do anything
+            -- Component configure, no need to do anything since
+            -- extra-coverage-for will be passed for all other components that
+            -- should be covered.
             OneComponentRequestedSpec{} -> []
           mbCompUnitId LibComponentLocalBuildInfo{componentUnitId} = Just componentUnitId
           mbCompUnitId _ = Nothing

--- a/cabal-testsuite/PackageTests/Regression/T10046/aa.cabal
+++ b/cabal-testsuite/PackageTests/Regression/T10046/aa.cabal
@@ -1,0 +1,28 @@
+cabal-version:      3.0
+name:               aa
+version:            0.1.0.0
+license:            NONE
+build-type:         Simple
+extra-doc-files:    CHANGELOG.md
+
+library
+    exposed-modules:  MyLib
+    build-depends:    base, template-haskell
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite bb-test
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   testbb
+    main-is:          Main.hs
+    build-depends:
+        base, aa
+
+test-suite aa-test
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test
+    main-is:          Main.hs
+    build-depends:
+        base

--- a/cabal-testsuite/PackageTests/Regression/T10046/app/Main.hs
+++ b/cabal-testsuite/PackageTests/Regression/T10046/app/Main.hs
@@ -1,0 +1,1 @@
+main = pure ()

--- a/cabal-testsuite/PackageTests/Regression/T10046/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T10046/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal-testsuite/PackageTests/Regression/T10046/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Regression/T10046/cabal.test.hs
@@ -1,0 +1,6 @@
+import Test.Cabal.Prelude
+
+-- T10046
+main = cabalTest $ recordMode DoNotRecord $ do
+  out <- cabal' "test" ["all"]
+  assertOutputDoesNotContain "Failed to find the installed unit 'aa-0.1.0.0-inplace'" out

--- a/cabal-testsuite/PackageTests/Regression/T10046/src/MyLib.hs
+++ b/cabal-testsuite/PackageTests/Regression/T10046/src/MyLib.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE TemplateHaskell #-}
+module MyLib where
+
+import Control.Concurrent
+import Language.Haskell.TH
+
+-- Must take longer to compile than the testsuite
+$(do runIO $
+       threadDelay (5*1000*1000) -- 5s
+     [d| data X |]
+  )

--- a/cabal-testsuite/PackageTests/Regression/T10046/test/Main.hs
+++ b/cabal-testsuite/PackageTests/Regression/T10046/test/Main.hs
@@ -1,0 +1,1 @@
+main = pure ()

--- a/cabal-testsuite/PackageTests/Regression/T10046/testbb/Main.hs
+++ b/cabal-testsuite/PackageTests/Regression/T10046/testbb/Main.hs
@@ -1,0 +1,1 @@
+main = pure ()

--- a/changelog.d/issue-10046
+++ b/changelog.d/issue-10046
@@ -1,0 +1,4 @@
+synopsis: Bug fix - Don't pass --coverage-for for non-dependency libs of testsuite
+packages: cabal-install
+issues: #10046
+prs: #10250


### PR DESCRIPTION
We were passing the flag --coverage-for for every library in the package when building the testsuites.

However, if a particular testsuite doesn't depend on one of the packages passed with --coverage-for we would crash.

Since we look for the unit ids of all packages given in --coverage-for in the package database (to find hpc artifacts), if the testsuite builds before the library this lookup would fail.

The fix is easy: don't pass --coverage-for=<lib> to <testsuite> if <testsuite> doesn't depend on <lib>. If <lib> is an indirect dependency of <testsuite> it'll no longer be covered by HPC, but this is a weird behaviour that I doubt anyone relies on.

Fixes #10046

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
