### PR TITLE
use fixed cabal version per #10175

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -113,7 +113,7 @@ jobs:
         id: setup-haskell
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: latest # latest is mandatory for cabal-testsuite, see https://github.com/haskell/cabal/issues/8133
+          cabal-version: 3.12.1.0 # see https://github.com/haskell/cabal/pull/10251
           ghcup-release-channel: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml
 
       #  See the following link for a breakdown of the following step

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -145,9 +145,8 @@ executable test-runtime-deps
 
 custom-setup
   -- we only depend on even stable releases of lib:Cabal
-  -- and due to Custom complexity and ConstraintSetupCabalMaxVersion
-  -- it has to be the latest release version plus
-  -- you have to use the latest cabal-install release
-  setup-depends: Cabal == 3.12.*,
-                 Cabal-syntax == 3.12.*,
+  -- and must match the release used in validate.yml (see
+  -- https://github.com/haskell/cabal/pull/10251)
+  setup-depends: Cabal ^>= 3.12.1,
+                 Cabal-syntax ^>= 3.12.1,
                  base, filepath, directory


### PR DESCRIPTION
Implement #10175 by fixing cabal version to (for now) 3.12.1.* (originally 3.10.3.0 but that broke tests added post-3.10). We should decide when we should update this and record it and its rationale in the making-a-release wiki page.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
