### PR TITLE
ux: add warning when cabal reads from no index cache

### DIFF
--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -1138,7 +1138,13 @@ readNoIndexCache verbosity index = do
       either (dieWithException verbosity . CorruptedIndexCache) return =<< readNoIndexCache' index
 
     -- we don't hash cons local repository cache, they are hopefully small
-    Right res -> return res
+    Right res -> do
+      warn verbosity $
+        concat
+          [ "Cabal is reading .cache file. "
+          , "Delete this file if the repository has changed."
+          ]
+      return res
 
 -- | Read the 'Index' cache from the filesystem. Throws IO exceptions
 -- if any arise and returns Left on invalid input.


### PR DESCRIPTION
Fixes #9136.

Since, I am a new contributor, I didn't follow the provided PR template and wrote what I thought would be best in this PR. Let me know if following the provided PR template is necessary.

- [x] Add warning in code
- [ ] Add tests
- [ ] Add QA Notes
- [ ] Conform to coding conventions

@andreabedini Please check if that is the right place for the warning and let me know about changes. I'll work on adding the tests next.