### PR TITLE
Mergify and actions upgrades

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -19,10 +19,6 @@ pull_request_rules:
   - actions:
       queue:
         name: default
-        # Merge into master with a merge commit
-        method: merge
-        # Update the pr branch with rebase, so the history is clean
-        update_method: rebase
     name: Put pull requests in the rebase+merge queue
     conditions:
       - base=master
@@ -33,11 +29,7 @@ pull_request_rules:
   # merge+squash strategy
   - actions:
       queue:
-        name: default
-        method: squash
-        # both update methods get absorbed by the squash, so we use the most
-        # reliable
-        update_method: merge
+        name: squash-merge
     name: Put pull requests in the squash+merge queue
     conditions:
       - base=master
@@ -61,9 +53,6 @@ pull_request_rules:
       queue:
         name: default
         # Merge with a merge commit
-        method: merge
-        # Update the pr branch with rebase, so the history is clean
-        update_method: rebase
     name: Put backports in the rebase+merge queue
     conditions:
       - label=merge me
@@ -74,11 +63,7 @@ pull_request_rules:
   # merge+squash strategy for backports: require 1 approver instead of 2
   - actions:
       queue:
-        name: default
-        method: squash
-        # both update methods get absorbed by the squash, so we use the most
-        # reliable
-        update_method: merge
+        name: squash-merge
     name: Put backports in the squash+merge queue
     conditions:
       - label=squash+merge me
@@ -96,5 +81,12 @@ pull_request_rules:
       - body~=automatic backport
 
 queue_rules:
+  # Mergify now requires different queues for different strategies
   - name: default
     update_bot_account: Mikolaj
+    merge_method: merge
+    update_method: rebase
+  - name: squash-merge
+    update_bot_account: Mikolaj
+    merge_method: squash
+    update_method: merge

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           _build/bin/cabal --version
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cabal-${{ matrix.os }}-${{ matrix.ghc }}-bootstrapped
           path: _build/artifacts/*

--- a/.github/workflows/users-guide.yml
+++ b/.github/workflows/users-guide.yml
@@ -73,7 +73,7 @@ jobs:
       run: |
         make SPHINX_HTML_OUTDIR=html users-guide
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: users-guide-html
         path: html/

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -191,7 +191,7 @@ jobs:
       # - Make it available in the workflow to make easier testing it locally
       - name: Upload cabal-install executable to workflow artifacts
         if: matrix.ghc == env.GHC_FOR_RELEASE
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cabal-${{ runner.os }}-x86_64
           path: ${{ env.CABAL_EXEC_TAR }}
@@ -338,7 +338,7 @@ jobs:
           echo "CABAL_EXEC_TAR=$CABAL_EXEC_TAR" >> "$GITHUB_ENV"
 
       - name: Upload cabal-install executable to workflow artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cabal-${{ runner.os }}-static-x86_64
           path: ${{ env.CABAL_EXEC_TAR }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -374,7 +374,7 @@ jobs:
           cabal-version: latest # default, we are not using it in this job
 
       - name: Download cabal executable from workflow artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cabal-${{ runner.os }}-x86_64
           path: cabal-head
@@ -399,19 +399,19 @@ jobs:
     needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cabal-Windows-x86_64
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cabal-Linux-x86_64
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cabal-Linux-static-x86_64
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: cabal-macOS-x86_64
 
@@ -429,7 +429,7 @@ jobs:
             cabal-head-macOS-x86_64.tar.gz
 
   # We use this job as a summary of the workflow
-  # It will fail if any of the previous jobs does it
+  # It will fail if any of the previous jobs does
   # This way we can use it exclusively in branch protection rules
   # and abstract away the concrete jobs of the workflow, including their names
   validate-post-job:


### PR DESCRIPTION
Mergify is requiring different queues for different merge strategies as of mid-September.
`actions/upload-artifact@v3` and `actions/download-artifact@v3` are being removed in November.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
