### PR TITLE
make sure cabal-install is compatible with Cabal

### DIFF
--- a/.github/workflows/check-sdist.yml
+++ b/.github/workflows/check-sdist.yml
@@ -1,0 +1,82 @@
+name: Check sdist
+
+# See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  push:
+    paths-ignore:
+      - "doc/**"
+      - "**/README.md"
+      - "CONTRIBUTING.md"
+    branches:
+      - master
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+      - "**/README.md"
+      - "CONTRIBUTING.md"
+  release:
+    types:
+      - created
+
+jobs:
+
+  # Dogfood the generated sdist, to avoid bugs like https://github.com/haskell/cabal/issues/9833
+  # No caching, since the point is to verify they can be installed "from scratch"
+  # Don't run on master or a PR targeting master, because there's never an installable Cabal
+  dogfood-sdists:
+    name: Dogfood sdist on ${{ matrix.os }} ghc-${{ matrix.ghc }}
+    if: github.ref != 'refs/heads/master' && github.base_ref != 'master'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        # this should be kept up to date with the list in validate.yml, but should be the
+        # *first* compiler release so we validate against what is hopefully the first
+        # release of a corresponding Cabal and friends. it can also be short since it's
+        # highly unlikely that we are releasing really old branches.
+        ghc:
+          [
+            "9.10.1",
+            "9.8.1",
+            "9.6.1",
+            "9.4.1",
+          ]
+
+    steps:
+
+      - uses: haskell-actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: latest
+
+      - uses: actions/checkout@v4
+
+      - name: Make sdist
+        run: cabal sdist cabal-install
+
+      - name: Install from sdist
+        run: |
+          # skip if a suitable Cabal isn't in this ghc's bootlibs, since that's the case
+          # that causes failures for users (otherwise cabal-install will install a matching
+          # version itself)
+          # we only want to test cabal-install, to ensure that it works with existing Cabals
+          # (don't look at this too closely)
+          sdist="$(ls dist-newstyle/sdist/cabal-install-*.tar.gz | sed -n '\,^dist-newstyle/sdist/cabal-install-[0-9.]*\.tar\.gz$,{;p;q;}')"
+          # extract the cabal-install major version
+          ver="$(echo "$sdist" | sed -n 's,^dist-newstyle/sdist/cabal-install-\([0-9][0-9]*\.[0-9][0-9]*\)\.[0-9.]*$,\1,p')"
+          # dunno if this will ever be extended to freebsd, but grep -q is a gnu-ism
+          if ghc-pkg --global --simple-output list Cabal | grep "^Cabal-$cbl\\." >/dev/null; then
+            # sigh, someone broke installing from tarballs
+            rm -rf cabal*.project Cabal Cabal-syntax cabal-install-solver cabal-install
+            tar xfz "$sdist"
+            cd "cabal-install-$cbl"*
+            cabal install
+          else
+            echo No matching bootlib Cabal version to test against.
+            exit 0
+          fi


### PR DESCRIPTION
See https://github.com/haskell/cabal/issues/9833

If a ghc ships with a compatible Cabal, it will be preferred by the solver on `cabal install cabal-install`; the new `cabal-install` should in fact be compatible. So we test this on release branches that have been included in at least one GHC release.

Fixes: #9833
Fixes: #9835
Fixes: #9838
Fixes: #9863

CI note: there's really no way to test this, aside from reproducing #9833 for which it's a bit too late. Testing will only be possible with the 9.12 branch and future release branches. As such, manual CI would mean making an sdist of the `HEAD` of `9.12` branch, then trying to build that sdist against 9.10.1 (which is essentially what this does, except that it won't actually do that test until it's backported). Note that that build may well succeed, because I've been trying to be careful with backports specifically to avoid repeating the mistakes we made with 3.10.3; the point of this PR is to try to catch that kind of failure in CI before we make a release with a breaking change.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
