### PR TITLE
index Paths and Paths_ (resp. for PackageInfo)

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -3015,6 +3015,9 @@ Right now :pkg-field:`executable:main-is` modules are not supported on
 Accessing data files from package code
 --------------------------------------
 
+.. index:: Paths
+.. index:: Paths_
+
 The placement on the target system of files listed in
 the :pkg-field:`data-files` field varies between systems, and in some cases
 one can even move packages around after installation
@@ -3069,6 +3072,9 @@ the configured data directory for ``pretty-show`` is controlled with the
 
 Accessing the package version
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index:: PackageInfo
+.. index:: PackageInfo_
 
 The auto generated :file:`PackageInfo_{pkgname}` module exports the constant
 ``version ::`` `Version <http://hackage.haskell.org/package/base/docs/Data-Version.html>`__


### PR DESCRIPTION
These can currently be found by searching the documentation for `Paths_pkgname` and `PackageInfo_pkgname`, but you pretty much need to know that to begin with to find them. Add Sphinx index entries to make them more discoverable.

Fixes: #10233

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
