### PR TITLE
validate dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,17 @@
+# copied from https://github.com/ubuntu/authd/commit/3f9df8f21d952cd33fd44d3834d0edeec1f5766f
+
+name: Dependabot rules validation
+
+on:
+  pull_request:
+    paths:
+      - '.github/dependabot.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: marocchino/validate-dependabot@v3
+        id: validate


### PR DESCRIPTION
Borrowed from Ubuntu
(https://github.com/ubuntu/authd/commit/3f9df8f21d952cd33fd44d3834d0edeec1f5766f)

Sadly, this won't check our existing config unless I make a dummy update.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). (only matters on `master`)
