### PR TITLE
split "validate old ghcs" into a separate workflow

### DIFF
--- a/.github/workflows/old-ghcs.skip.yml
+++ b/.github/workflows/old-ghcs.skip.yml
@@ -1,0 +1,48 @@
+name: Validate old ghcs Skip
+
+# This Workflow is special and contains a workaround for a known limitation of GitHub CI.
+#
+# The problem: We don't want to run the "old ghcs" jobs on PRs which contain only changes
+# to the docs, since these jobs take a long time to complete without providing any benefit.
+# We therefore use path-filtering in the workflow triggers for the old ghcs jobs, namely
+# "paths-ignore: doc/**". But the "Validate old ghcs post job" is a required job, therefore
+# a PR cannot be merged unless the "Validate old ghcs post job" completes succesfully, which
+# it doesn't do if we filter it out.
+#
+# The solution: We use a second job with the same name which always returns the exit code 0.
+# The logic implemented for "required" workflows accepts if 1) at least one job with that name
+# runs through, AND 2) If multiple jobs of that name exist, then all jobs of that name have to
+# finish successfully.
+on:
+  push:
+    paths:
+      - 'doc/**'
+      - '**/README.md'
+      - 'CONTRIBUTING.md'
+      - "changelog.d/**"
+      # only top level for these, because various test packages have them too
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'doc/**'
+      - '**/README.md'
+      - 'CONTRIBUTING.md'
+      - "changelog.d/**"
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
+  release:
+    types:
+      - created
+
+jobs:
+  validate-old-ghcs-post-job:
+    if: always()
+    name: Validate old ghcs post job
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0

--- a/.github/workflows/old-ghcs.yml
+++ b/.github/workflows/old-ghcs.yml
@@ -1,0 +1,126 @@
+name: Validate old ghcs
+
+# See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+# Note: This workflow file contains the required job "Validate old ghcs post job". We are using path
+# filtering here to ignore PRs which only change documentation. This can cause a problem, see the
+# workflow file "old-ghcs.skip.yml" for a description of the problem and the solution provided in
+# that file.
+on:
+  push:
+    paths-ignore:
+      - "doc/**"
+      - "**/README.md"
+      - "CONTRIBUTING.md"
+      - "changelog.d/**"
+      # only top level for these, because various test packages have them too
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
+    branches:
+      - master
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+      - "**/README.md"
+      - "CONTRIBUTING.md"
+      - "changelog.d/**"
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
+  release:
+    types:
+      - created
+  workflow_call:
+
+env:
+  # We choose a stable ghc version across all os's
+  # which will be used to do the next release
+  GHC_FOR_RELEASE: "9.4.8"
+  COMMON_FLAGS: "-j 2 -v"
+
+jobs:
+
+  validate-old-ghcs:
+    name: Validate old ghcs ${{ matrix.extra-ghc }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        extra-ghc:
+          ["8.4.4", "8.2.2", "8.0.2"]
+          ## GHC 7.10.3 does not install on ubuntu-22.04 with ghcup.
+          ## Older GHCs are not supported by ghcup in the first place.
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install prerequisites for old GHCs
+        run: |
+          sudo apt-get update
+          sudo apt-get install libncurses5 libtinfo5
+
+      - name: Install extra compiler
+        run: ghcup install ghc ${{ matrix.extra-ghc }}
+
+      - name: GHCup logs
+        # Does anyone know why the explicit "always()" here and below?
+        # By default steps always run.
+        if: always()
+        run: cat /usr/local/.ghcup/logs/*
+
+      - name: Install primary compiler
+        uses: haskell-actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: ${{ env.GHC_FOR_RELEASE }}
+          cabal-version: latest
+
+      - name: GHC versions
+        run: |
+          ghc --version
+          "ghc-${{ matrix.extra-ghc }}" --version
+
+      # This will get us an outdated cache, because this workflow runs before
+      # validate.yml can update it. As a result, we end up rebuilding the PR.
+      # The only way to fix this is to move it back into validate.yml, because
+      # we can't force this to run synchronously with steps in a different
+      # workflow.
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-
+
+      - name: Validate build
+        run: sh validate.sh ${{ env.COMMON_FLAGS }} -s build
+
+      - name: "Validate lib-suite-extras --extra-hc ghc-${{ matrix.extra-ghc }}"
+        env:
+          EXTRA_GHC: ghc-${{ matrix.extra-ghc }}
+        run: sh validate.sh ${{ env.COMMON_FLAGS }} --lib-only -s lib-suite-extras --extra-hc "${{ env.EXTRA_GHC }}"
+
+  # We use this job as a summary of the workflow
+  # It will fail if any of the previous jobs does
+  # This way we can use it exclusively in branch protection rules
+  # and abstract away the concrete jobs of the workflow, including their names.
+  # See also the "skip" workflows, which these must match.
+  validate-old-ghcs-post-job:
+    if: always()
+    name: Validate old ghcs post job
+    runs-on: ubuntu-latest
+    # IMPORTANT! Any job added to the workflow should be added here too
+    # (This one is true because of the abstraction described above, and the
+    # corresponding branch protection rules. ++bsa)
+    needs: [validate-old-ghcs]
+
+    steps:
+      - run: |
+          echo "jobs info: ${{ toJSON(needs) }}"
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -237,65 +237,6 @@ jobs:
         if: matrix.ghc == env.GHC_FOR_SOLVER_BENCHMARKS
         run: sh validate.sh $FLAGS -s solver-benchmarks-run
 
-  validate-old-ghcs:
-    name: Validate old ghcs ${{ matrix.extra-ghc }}
-    runs-on: ubuntu-latest
-    needs: validate
-
-    strategy:
-      matrix:
-        extra-ghc:
-          ["8.4.4", "8.2.2", "8.0.2"]
-          ## GHC 7.10.3 does not install on ubuntu-22.04 with ghcup.
-          ## Older GHCs are not supported by ghcup in the first place.
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install prerequisites for old GHCs
-        run: |
-          sudo apt-get update
-          sudo apt-get install libncurses5 libtinfo5
-
-      - name: Install extra compiler
-        run: ghcup install ghc ${{ matrix.extra-ghc }}
-
-      - name: GHCup logs
-        if: always()
-        run: cat /usr/local/.ghcup/logs/*
-
-      - name: Install primary compiler
-        uses: haskell-actions/setup@v2
-        id: setup-haskell
-        with:
-          ghc-version: ${{ env.GHC_FOR_RELEASE }}
-          cabal-version: latest
-
-      - name: GHC versions
-        run: |
-          ghc --version
-          "ghc-${{ matrix.extra-ghc }}" --version
-
-      # As we are reusing the cached build dir from the previous step
-      # the generated artifacts are available here,
-      # including the cabal executable and the test suite
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ${{ steps.setup-haskell.outputs.cabal-store }}
-            dist-*
-          key: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-${{ env.GHC_FOR_RELEASE }}-
-
-      - name: Validate build
-        run: sh validate.sh ${{ env.COMMON_FLAGS }} -s build
-
-      - name: "Validate lib-suite-extras --extra-hc ghc-${{ matrix.extra-ghc }}"
-        env:
-          EXTRA_GHC: ghc-${{ matrix.extra-ghc }}
-        run: sh validate.sh ${{ env.COMMON_FLAGS }} --lib-only -s lib-suite-extras --extra-hc "${{ env.EXTRA_GHC }}"
-
   build-alpine:
     name: Build statically linked using alpine
     runs-on: ubuntu-latest
@@ -412,7 +353,11 @@ jobs:
     if: github.ref == 'refs/heads/master'
 
     # IMPORTANT! Any job added to the workflow should be added here too
-    needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
+    # (This doesn't appear to be true, or we'd have merges with failed
+    # bootstrap tests. The pre-merge CI check is sufficient, but we do
+    # need validate and build-alpine to save the corresponding artifacts.
+    # ++bsa)
+    needs: [validate, build-alpine]
 
     steps:
       - uses: actions/download-artifact@v4
@@ -453,7 +398,9 @@ jobs:
     name: Validate post job
     runs-on: ubuntu-latest
     # IMPORTANT! Any job added to the workflow should be added here too
-    needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
+    # (This one is true because of the abstraction described above, and the
+    # corresponding branch protection rules. ++bsa)
+    needs: [validate, build-alpine, dogfooding]
 
     steps:
       - run: |


### PR DESCRIPTION
I am not convinced this is a good idea, for the same reason that Artem wants it: complexity. I'm very worried that this will break things, although as far as I can tell it should be okay as long as nobody commits anything overriding branch protection.

All branch protection rules will need to be updated to check for "Validate old ghcs post job" the same way they check for "Bootstrap post job" and "Validate post job".

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

NOTE re backporting: branch protection rules need to be updated, but branch protections are currently applied to a rather widely-matching pattern and I don't think we want to backport this to _every_ 3.x branch. It would be possible to restrict this rule to `3.1*` because we have no 3.1 release, but then we need to backport to 3.10 branch in case a security problem is found that forces us to make another 3.10 release or something similar.