### PR TITLE
update the pinned index-state to get the new `rere`

### DIFF
--- a/cabal.bootstrap.project
+++ b/cabal.bootstrap.project
@@ -14,4 +14,4 @@ benchmarks: False
 constraints:
   hashable -arch-native
 
-index-state: hackage.haskell.org 2024-06-17T00:00:01Z
+index-state: hackage.haskell.org 2024-07-15T21:05:18Z

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -5,4 +5,4 @@ import: project-cabal/pkgs/tests.config
 constraints:
   hashable -arch-native
 
-index-state: hackage.haskell.org 2024-06-17T00:00:01Z
+index-state: hackage.haskell.org 2024-07-15T21:05:18Z


### PR DESCRIPTION
Without this, #10202 breaks `cabal.project.release` on ghc 9.10.1.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
