### PR TITLE
Re-enable Windows CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -79,6 +79,11 @@ jobs:
             "8.8.4",
           ]
         exclude:
+          # Throws fatal "cabal-tests.exe: fd:8: hGetLine: end of file" exception
+          # even with --io-manager=native
+          - sys:
+              { os: windows-latest, shell: "C:/msys64/usr/bin/bash.exe -e {0}" }
+            ghc: "9.0.2"
           # corrupts GHA cache or the fabric of reality itself, see https://github.com/haskell/cabal/issues/8356
           - sys:
               { os: windows-latest, shell: "C:/msys64/usr/bin/bash.exe -e {0}" }
@@ -211,7 +216,6 @@ jobs:
         run: sh validate.sh $FLAGS -s cli-tests
 
       - name: Validate cli-suite
-        if: runner.os != 'Windows'
         run: sh validate.sh $FLAGS -s cli-suite
 
       - name: Validate solver-benchmarks-tests

--- a/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-external.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-external.test.hs
@@ -3,7 +3,8 @@ import Test.Cabal.Prelude
 main = cabalTest $ do
     ghcVer <- isGhcVersion ">= 9.10"
     skipUnlessGhcVersion ">= 8.1"
-    expectBrokenIf (isWindows && ghcVer) 10191 $ withProjectFile "cabal.external.project" $ do
+    skipIf "Windows + 9.10.1 (#10191)" (isWindows && ghcVer)
+    withProjectFile "cabal.external.project" $ do
         cabal "v2-build" ["exe"]
         withPlan $ do
             r <- runPlanExe' "exe" "exe" []

--- a/validate.sh
+++ b/validate.sh
@@ -324,12 +324,8 @@ CABAL_TESTSUITE_BDIR="$(pwd)/$BUILDDIR/build/$ARCH/$BASEHC/cabal-testsuite-3"
 CABALNEWBUILD="${CABAL} build $JOBS -w $HC --builddir=$BUILDDIR --project-file=$PROJECTFILE"
 CABALLISTBIN="${CABAL} list-bin --builddir=$BUILDDIR --project-file=$PROJECTFILE"
 
-# This was needed in some local Windows MSYS2 environments
-# but breaks CI for Windows + GHC 9.0.2, thus it is set only on non-CI executions
-# of validate.sh
-# https://github.com/haskell/cabal/issues/9571
-# https://github.com/haskell/cabal/pull/10114
-RTSOPTS="$([ $ARCH = "x86_64-windows" ] &&  [ -z "$CI" ] && [ "$($HC --numeric-version)" != "8.10.7" ] && echo "+RTS --io-manager=native" || echo "")"
+# See https://github.com/haskell/cabal/issues/9571 for why we set this for Windows
+RTSOPTS="$([ $ARCH = "x86_64-windows" ] && [ "$($HC --numeric-version)" != "9.0.2" ] && [ "$(echo -e "$(ghc --numeric-version)\n9.0.2" | sort -V | head -n1)" = "9.0.2" ] && echo "+RTS --io-manager=native" || echo "")"
 
 # header
 #######################################################################


### PR DESCRIPTION
This PR disables the 9.0.2 validate job for Windows and provides `--io-manager=native` for every other GHC. See #9571 for the reasons.
