### PR TITLE
Only munge internal dependencies when printing when there is no explicit syntax

### DIFF
--- a/Cabal-syntax/src/Distribution/PackageDescription/PrettyPrint.hs
+++ b/Cabal-syntax/src/Distribution/PackageDescription/PrettyPrint.hs
@@ -271,7 +271,7 @@ preProcessInternalDeps specVer gpd
 
     transformD :: Dependency -> [Dependency]
     transformD (Dependency pn vr ln)
-      | pn == thisPn =
+      | pn == thisPn && specVer < CabalSpecV3_0 =
           if LMainLibName `NES.member` ln
             then Dependency thisPn vr mainLibSet : sublibs
             else sublibs
@@ -282,9 +282,12 @@ preProcessInternalDeps specVer gpd
           ]
     transformD d = [d]
 
+    -- Always perform transformation for mixins as syntax was only introduced in 3.4
+    -- This guard is uncessary as no transformations take place when cabalSpec >= CabalSpecV3_4 but
+    -- it more clearly signifies the intent. (See the specVer >= CabalSpecV3_4 line above).
     transformM :: Mixin -> Mixin
     transformM (Mixin pn (LSubLibName uqn) inc)
-      | pn == thisPn =
+      | pn == thisPn && specVer < CabalSpecV3_4 =
           mkMixin (unqualComponentNameToPackageName uqn) LMainLibName inc
     transformM m = m
 

--- a/Cabal-tests/tests/ParserTests/regressions/issue-6083-b.format
+++ b/Cabal-tests/tests/ParserTests/regressions/issue-6083-b.format
@@ -6,7 +6,7 @@ library
     default-language: Haskell2010
     build-depends:
         base,
-        sublib
+        issue:sublib
 
 library sublib
     default-language: Haskell2010
@@ -15,10 +15,10 @@ executable demo-a
     main-is:       Main.hs
     build-depends:
         issue,
-        sublib
+        issue:sublib
 
 executable demo-b
     main-is:       Main.hs
     build-depends:
         issue,
-        sublib
+        issue:sublib

--- a/cabal-validate/src/Main.hs
+++ b/cabal-validate/src/Main.hs
@@ -290,7 +290,7 @@ runHackageTests opts
 
       let
         -- See #10284 for why this value is pinned.
-        hackageTestsIndexState = "--index-state=2024-08-25"
+        hackageTestsIndexState = "--index-state=2025-01-12"
 
         hackageTest args =
           timedWithCwd


### PR DESCRIPTION
Only munge internal dependencies when printing when there is no explicit syntax

* In `postProcessInternalDeps` the shadowing logic which existed prior to cabal format 3.4 is implemented in a post processing step.

  The algorithm there replaces any references to internal sublibraries with an explicit qualifier. For example if you write..

  ``` 
  library build-depends: foo

  library foo ... 
  ```

  this is reinterpreted as

  ``` 
  library build-depends: mylib:foo

  library foo ... 
  ```

* In `preProcessInternalDeps` the inverse transformation takes place, the goal is to replace `mylib:foo` with just `foo`.

* Things go wrong if you are using version 3.0 for your cabal file because
  - In 3.0 the qualifier syntax is introduced so you can be expliciit about sublibrary dependencies
  - The shadowing semantics of non-qualified dependencies still exists.

  So the situation is that the user is explicit about the sublibrary

  ```
  library

  library qux
    build-depends: mylib:{mylib, foo}

  library foo
  ```

  1. Post-process leaves this alone, the user is already explicit about depending on a sublibrary.
  2. Pre-processing then rewrites `mylib:{mylib, foo}` into two dependencies, `mylib` and `foo` (no qualifier).
  3. When parsed these are two separate dependencies rather than treated as one dependency, roundtrip test fails.

Solution: Only perform the reverse transformation when the cabal library version is <= 3.0 and doesn't support the explicit syntax.

Now what happens in these two situations:

1. ``` 
   library build-depends: foo

   library foo ... 
   ```

   this is reinterpreted as

   ```
   library
     build-depends: mylib:foo

   library foo
     ...
   ```

   then printed and parsed exactly the same way.

2. Explicit syntax is parsed and printed without being munged (when supported)

Note: Mixins only supported sublibrary qualifiers from 3.4 whilst dependencies supported this from 3.0, hence the lack of guard on the mixins case.

Fixes #10283

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
