### PR TITLE
Expand and unify `--keep-temp-files`

### DIFF
--- a/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Utils/Structured.hs
@@ -34,4 +34,4 @@ md5CheckGenericPackageDescription proxy = md5Check proxy
 
 md5CheckLocalBuildInfo :: Proxy LocalBuildInfo -> Assertion
 md5CheckLocalBuildInfo proxy = md5Check proxy
-    0x93b7e8ebb5b9f879fa5fe49b1708b43b
+    0x8fa7b2c8cc611407bfdcb734ecb460a2

--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -67,12 +67,9 @@ import Distribution.Simple.Program.GHC
 import qualified Distribution.Simple.Program.HcPkg as HcPkg
 import Distribution.Simple.Program.ResponseFile
 import Distribution.Simple.Register
-import Distribution.Simple.Setup.Common
-import Distribution.Simple.Setup.Haddock
-import Distribution.Simple.Setup.Hscolour
+import Distribution.Simple.Setup
 import Distribution.Simple.SetupHooks.Internal
   ( BuildHooks (..)
-  , BuildingWhat (..)
   , noBuildHooks
   )
 import qualified Distribution.Simple.SetupHooks.Internal as SetupHooks
@@ -265,6 +262,7 @@ haddock_setupHooks
         mbWorkDir = flagToMaybe $ haddockWorkingDir flags
         comp = compiler lbi
         platform = hostPlatform lbi
+        config = configFlags lbi
 
         quickJmpFlag = haddockQuickJump flags'
         flags = case haddockTarget of
@@ -282,9 +280,7 @@ haddock_setupHooks
         flag f = fromFlag $ f flags
 
         tmpFileOpts =
-          defaultTempFileOptions
-            { optKeepTempFiles = flag haddockKeepTempFiles
-            }
+          commonSetupTempFileOptions $ configCommonFlags config
         htmlTemplate =
           fmap toPathTemplate . flagToMaybe . haddockHtmlLocation $
             flags
@@ -553,9 +549,11 @@ createHaddockIndex
   -> IO ()
 createHaddockIndex verbosity programDb comp platform mbWorkDir flags = do
   let args = fromHaddockProjectFlags flags
+      tmpFileOpts =
+        commonSetupTempFileOptions $ haddockProjectCommonFlags $ flags
   (haddockProg, _version) <-
     getHaddockProg verbosity programDb comp args (Flag True)
-  runHaddock verbosity mbWorkDir defaultTempFileOptions comp platform haddockProg False args
+  runHaddock verbosity mbWorkDir tmpFileOpts comp platform haddockProg False args
 
 -- ------------------------------------------------------------------------------
 -- Contributions to HaddockArgs (see also Doctest.hs for very similar code).

--- a/Cabal/src/Distribution/Simple/Setup.hs
+++ b/Cabal/src/Distribution/Simple/Setup.hs
@@ -41,6 +41,7 @@ module Distribution.Simple.Setup
   , globalCommand
   , CommonSetupFlags (..)
   , defaultCommonSetupFlags
+  , commonSetupTempFileOptions
   , ConfigFlags (..)
   , emptyConfigFlags
   , defaultConfigFlags

--- a/Cabal/src/Distribution/Simple/Setup/Common.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Common.hs
@@ -23,6 +23,7 @@ module Distribution.Simple.Setup.Common
   ( CommonSetupFlags (..)
   , defaultCommonSetupFlags
   , withCommonSetupOptions
+  , commonSetupTempFileOptions
   , CopyDest (..)
   , configureCCompiler
   , configureLinker
@@ -85,6 +86,13 @@ data CommonSetupFlags = CommonSetupFlags
   --
   -- TODO: this one should not be here, it's just that the silly
   -- UserHooks stop us from passing extra info in other ways
+  , setupKeepTempFiles :: Flag Bool
+  -- ^ When this flag is set, temporary files will be kept after building.
+  --
+  -- Note: Keeping temporary files is important functionality for HLS, which
+  -- runs @cabal repl@ with a fake GHC to get CLI arguments. It will need the
+  -- temporary files (including multi unit repl response files) to stay, even
+  -- after the @cabal repl@ command exits.
   }
   deriving (Eq, Show, Read, Generic)
 
@@ -106,6 +114,15 @@ defaultCommonSetupFlags =
     , setupDistPref = NoFlag
     , setupCabalFilePath = NoFlag
     , setupTargets = []
+    , setupKeepTempFiles = NoFlag
+    }
+
+-- | Get `TempFileOptions` that respect the `setupKeepTempFiles` flag.
+commonSetupTempFileOptions :: CommonSetupFlags -> TempFileOptions
+commonSetupTempFileOptions options =
+  TempFileOptions
+    { optKeepTempFiles =
+        fromFlagOrDefault False (setupKeepTempFiles options)
     }
 
 commonSetupOptions :: ShowOrParseArgs -> [OptionField CommonSetupFlags]
@@ -124,6 +141,14 @@ commonSetupOptions showOrParseArgs =
       setupCabalFilePath
       (\v flags -> flags{setupCabalFilePath = v})
       (reqSymbolicPathArgFlag "PATH")
+  , option
+      ""
+      ["keep-temp-files"]
+      ( "Keep temporary files."
+      )
+      setupKeepTempFiles
+      (\keepTempFiles flags -> flags{setupKeepTempFiles = keepTempFiles})
+      trueArg
       -- NB: no --working-dir flag, as that value is populated using the
       -- global flag (see Distribution.Simple.Setup.Global.globalCommand).
   ]

--- a/Cabal/src/Distribution/Simple/Setup/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Haddock.hs
@@ -111,7 +111,6 @@ data HaddockFlags = HaddockFlags
   , haddockHscolourCss :: Flag FilePath
   , haddockContents :: Flag PathTemplate
   , haddockIndex :: Flag PathTemplate
-  , haddockKeepTempFiles :: Flag Bool
   , haddockBaseUrl :: Flag String
   , haddockResourcesDir :: Flag String
   , haddockOutputDir :: Flag FilePath
@@ -166,7 +165,6 @@ defaultHaddockFlags =
     , haddockQuickJump = Flag False
     , haddockHscolourCss = NoFlag
     , haddockContents = NoFlag
-    , haddockKeepTempFiles = Flag False
     , haddockIndex = NoFlag
     , haddockBaseUrl = NoFlag
     , haddockResourcesDir = NoFlag
@@ -219,13 +217,6 @@ haddockOptions showOrParseArgs =
     (\c f -> f{haddockCommonFlags = c})
     showOrParseArgs
     [ option
-        ""
-        ["keep-temp-files"]
-        "Keep temporary files"
-        haddockKeepTempFiles
-        (\b flags -> flags{haddockKeepTempFiles = b})
-        trueArg
-    , option
         ""
         ["hoogle"]
         "Generate a hoogle database"
@@ -447,9 +438,7 @@ data HaddockProjectFlags = HaddockProjectFlags
   , -- haddockContent is not supported, a fixed value is provided
     -- haddockIndex is not supported, a fixed value is provided
     -- haddockDistPerf is not supported, note: it changes location of the haddocks
-    haddockProjectKeepTempFiles :: Flag Bool
-  , haddockProjectVerbosity :: Flag Verbosity
-  , -- haddockBaseUrl is not supported, a fixed value is provided
+    -- haddockBaseUrl is not supported, a fixed value is provided
     haddockProjectResourcesDir :: Flag String
   , haddockProjectUseUnicode :: Flag Bool
   }
@@ -473,8 +462,6 @@ defaultHaddockProjectFlags =
     , haddockProjectInternal = Flag False
     , haddockProjectCss = NoFlag
     , haddockProjectHscolourCss = NoFlag
-    , haddockProjectKeepTempFiles = Flag False
-    , haddockProjectVerbosity = Flag normal
     , haddockProjectResourcesDir = NoFlag
     , haddockProjectInterfaces = NoFlag
     , haddockProjectUseUnicode = NoFlag
@@ -632,13 +619,6 @@ haddockProjectOptions showOrParseArgs =
         haddockProjectHscolourCss
         (\v flags -> flags{haddockProjectHscolourCss = v})
         (reqArgFlag "PATH")
-    , option
-        ""
-        ["keep-temp-files"]
-        "Keep temporary files"
-        haddockProjectKeepTempFiles
-        (\b flags -> flags{haddockProjectKeepTempFiles = b})
-        trueArg
     , option
         ""
         ["resources-dir"]

--- a/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddockProject.hs
@@ -391,7 +391,6 @@ haddockProjectAction flags _extraArgs globalFlags = do
             if localStyle
               then Flag (toPathTemplate "../doc-index.html")
               else NoFlag
-        , haddockKeepTempFiles = haddockProjectKeepTempFiles flags
         , haddockResourcesDir = haddockProjectResourcesDir flags
         , haddockUseUnicode = haddockProjectUseUnicode flags
         -- NOTE: we don't pass `haddockOutputDir`. If we do, we'll need to

--- a/cabal-install/src/Distribution/Client/CmdRepl.hs
+++ b/cabal-install/src/Distribution/Client/CmdRepl.hs
@@ -103,11 +103,11 @@ import Distribution.Simple.Compiler
   )
 import Distribution.Simple.Setup
   ( ReplOptions (..)
+  , commonSetupTempFileOptions
   , setupVerbosity
   )
 import Distribution.Simple.Utils
-  ( TempFileOptions (..)
-  , debugNoWrap
+  ( debugNoWrap
   , dieWithException
   , withTempDirectoryEx
   , wrapText
@@ -411,7 +411,7 @@ replAction flags@NixStyleFlags{extraFlags = r@ReplFlags{..}, ..} targetStrings g
     -- Multi Repl implemention see: https://well-typed.com/blog/2023/03/cabal-multi-unit/ for
     -- a high-level overview about how everything fits together.
     if Set.size (distinctTargetComponents targets) > 1
-      then withTempDirectoryEx verbosity (TempFileOptions keepTempFiles) distDir "multi-out" $ \dir' -> do
+      then withTempDirectoryEx verbosity tempFileOptions distDir "multi-out" $ \dir' -> do
         -- multi target repl
         dir <- makeAbsolute dir'
         -- Modify the replOptions so that the ./Setup repl command will write options
@@ -507,7 +507,7 @@ replAction flags@NixStyleFlags{extraFlags = r@ReplFlags{..}, ..} targetStrings g
         go m _ = m
 
     verbosity = fromFlagOrDefault normal (setupVerbosity $ configCommonFlags configFlags)
-    keepTempFiles = fromFlagOrDefault False replKeepTempFiles
+    tempFileOptions = commonSetupTempFileOptions $ configCommonFlags configFlags
 
     validatedTargets ctx compiler elaboratedPlan targetSelectors = do
       let multi_repl_enabled = multiReplDecision ctx compiler r

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -470,6 +470,7 @@ instance Semigroup SavedConfig where
           , setupCabalFilePath = combine setupCabalFilePath
           , setupVerbosity = combine setupVerbosity
           , setupTargets = lastNonEmpty setupTargets
+          , setupKeepTempFiles = combine setupKeepTempFiles
           }
         where
           lastNonEmpty = lastNonEmpty' which
@@ -630,7 +631,6 @@ instance Semigroup SavedConfig where
           , haddockQuickJump = combine haddockQuickJump
           , haddockHscolourCss = combine haddockHscolourCss
           , haddockContents = combine haddockContents
-          , haddockKeepTempFiles = combine haddockKeepTempFiles
           , haddockIndex = combine haddockIndex
           , haddockBaseUrl = combine haddockBaseUrl
           , haddockResourcesDir = combine haddockResourcesDir

--- a/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
+++ b/cabal-install/src/Distribution/Client/ProjectBuilding/UnpackedPackage.hs
@@ -173,7 +173,7 @@ buildAndRegisterUnpackedPackage
   verbosity
   distDirLayout@DistDirLayout{distTempDirectory}
   maybe_semaphore
-  buildTimeSettings@BuildTimeSettings{buildSettingNumJobs}
+  buildTimeSettings@BuildTimeSettings{buildSettingNumJobs, buildSettingKeepTempFiles}
   registerLock
   cacheLock
   pkgshared@ElaboratedSharedConfig
@@ -276,7 +276,7 @@ buildAndRegisterUnpackedPackage
         | otherwise = return ()
 
       mbWorkDir = useWorkingDir scriptOptions
-      commonFlags = setupHsCommonFlags verbosity mbWorkDir builddir
+      commonFlags = setupHsCommonFlags verbosity mbWorkDir builddir buildSettingKeepTempFiles
 
       configureCommand = Cabal.configureCommand defaultProgramDb
       configureFlags v =

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -1408,7 +1408,8 @@ legacySharedConfigFieldDescrs constraintSrc =
               configPackageDBs
               (\v conf -> conf{configPackageDBs = v})
           ]
-        . filterFields (["verbose", "builddir"] ++ map optionName installDirsOptions)
+        . aliasField "keep-temp-files" "haddock-keep-temp-files"
+        . filterFields (["verbose", "builddir", "keep-temp-files"] ++ map optionName installDirsOptions)
         . commandOptionsToFields
         $ configureOptions ParseArgs
     , liftFields

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -2073,9 +2073,3 @@ showTokenQ "" = Disp.empty
 showTokenQ x@('-' : '-' : _) = Disp.text (show x)
 showTokenQ x@('.' : []) = Disp.text (show x)
 showTokenQ x = showToken x
-
--- Handy util
-addFields
-  :: [FieldDescr a]
-  -> ([FieldDescr a] -> [FieldDescr a])
-addFields = (++)

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -861,7 +861,7 @@ convertLegacyBuildOnlyFlags
   configFlags
   installFlags
   clientInstallFlags
-  haddockFlags
+  _haddockFlags
   _testFlags
   _benchmarkFlags =
     ProjectConfigBuildOnly{..}
@@ -880,6 +880,7 @@ convertLegacyBuildOnlyFlags
 
       CommonSetupFlags
         { setupVerbosity = projectConfigVerbosity
+        , setupKeepTempFiles = projectConfigKeepTempFiles
         } = commonFlags
 
       InstallFlags
@@ -898,10 +899,6 @@ convertLegacyBuildOnlyFlags
         , installKeepGoing = projectConfigKeepGoing
         , installOfflineMode = projectConfigOfflineMode
         } = installFlags
-
-      HaddockFlags
-        { haddockKeepTempFiles = projectConfigKeepTempFiles -- TODO: this ought to live elsewhere
-        } = haddockFlags
 
 convertToLegacyProjectConfig :: ProjectConfig -> LegacyProjectConfig
 convertToLegacyProjectConfig
@@ -975,6 +972,7 @@ convertToLegacySharedConfig
         mempty
           { setupVerbosity = projectConfigVerbosity
           , setupDistPref = fmap makeSymbolicPath $ projectConfigDistDir
+          , setupKeepTempFiles = projectConfigKeepTempFiles
           }
 
       configFlags =
@@ -1047,8 +1045,7 @@ convertToLegacySharedConfig
 convertToLegacyAllPackageConfig :: ProjectConfig -> LegacyPackageConfig
 convertToLegacyAllPackageConfig
   ProjectConfig
-    { projectConfigBuildOnly = ProjectConfigBuildOnly{..}
-    , projectConfigShared = ProjectConfigShared{..}
+    { projectConfigShared = ProjectConfigShared{..}
     } =
     LegacyPackageConfig
       { legacyConfigureFlags = configFlags
@@ -1124,8 +1121,6 @@ convertToLegacyAllPackageConfig
 
       haddockFlags =
         mempty
-          { haddockKeepTempFiles = projectConfigKeepTempFiles
-          }
 
 convertToLegacyPerPackageConfig :: PackageConfig -> LegacyPackageConfig
 convertToLegacyPerPackageConfig PackageConfig{..} =
@@ -1225,7 +1220,6 @@ convertToLegacyPerPackageConfig PackageConfig{..} =
         , haddockQuickJump = packageConfigHaddockQuickJump
         , haddockHscolourCss = packageConfigHaddockHscolourCss
         , haddockContents = packageConfigHaddockContents
-        , haddockKeepTempFiles = mempty
         , haddockIndex = packageConfigHaddockIndex
         , haddockBaseUrl = packageConfigHaddockBaseUrl
         , haddockResourcesDir = packageConfigHaddockResourcesDir
@@ -1631,7 +1625,6 @@ legacyPackageConfigFieldDescrs =
             , "hscolour-css"
             , "contents-location"
             , "index-location"
-            , "keep-temp-files"
             , "base-url"
             , "resources-dir"
             , "output-dir"

--- a/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
+++ b/cabal-install/src/Distribution/Client/ProjectOrchestration.hs
@@ -946,7 +946,7 @@ printPlan
 printPlan
   verbosity
   ProjectBaseContext
-    { buildSettings = BuildTimeSettings{buildSettingDryRun}
+    { buildSettings = BuildTimeSettings{buildSettingDryRun, buildSettingKeepTempFiles}
     , projectConfig =
       ProjectConfig
         { projectConfigAllPackages =
@@ -1048,6 +1048,7 @@ printPlan
                 verbosity
                 Nothing -- omit working directory
                 (makeSymbolicPath "$builddir")
+                buildSettingKeepTempFiles
             fullConfigureFlags =
               runIdentity $
                 ( setupHsConfigureFlags

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -4093,14 +4093,16 @@ setupHsCommonFlags
   :: Verbosity
   -> Maybe (SymbolicPath CWD (Dir Pkg))
   -> SymbolicPath Pkg (Dir Dist)
+  -> Bool
   -> Cabal.CommonSetupFlags
-setupHsCommonFlags verbosity mbWorkDir builddir =
+setupHsCommonFlags verbosity mbWorkDir builddir keepTempFiles =
   Cabal.CommonSetupFlags
     { setupDistPref = toFlag builddir
     , setupVerbosity = toFlag verbosity
     , setupCabalFilePath = mempty
     , setupWorkingDir = maybeToFlag mbWorkDir
     , setupTargets = []
+    , setupKeepTempFiles = toFlag keepTempFiles
     }
 
 setupHsBuildFlags
@@ -4229,7 +4231,7 @@ setupHsHaddockFlags
 setupHsHaddockFlags
   (ElaboratedConfiguredPackage{..})
   (ElaboratedSharedConfig{..})
-  (BuildTimeSettings{buildSettingKeepTempFiles = keepTmpFiles})
+  _buildTimeSettings
   common =
     Cabal.HaddockFlags
       { haddockCommonFlags = common
@@ -4257,7 +4259,6 @@ setupHsHaddockFlags
       , haddockQuickJump = toFlag elabHaddockQuickJump
       , haddockHscolourCss = maybe mempty toFlag elabHaddockHscolourCss
       , haddockContents = maybe mempty toFlag elabHaddockContents
-      , haddockKeepTempFiles = toFlag keepTmpFiles
       , haddockIndex = maybe mempty toFlag elabHaddockIndex
       , haddockBaseUrl = maybe mempty toFlag elabHaddockBaseUrl
       , haddockResourcesDir = maybe mempty toFlag elabHaddockResourcesDir

--- a/cabal-install/src/Distribution/Client/ReplFlags.hs
+++ b/cabal-install/src/Distribution/Client/ReplFlags.hs
@@ -27,7 +27,6 @@ import Distribution.Simple.Setup
   , falseArg
   , replOptions
   , toFlag
-  , trueArg
   )
 import Distribution.Types.Dependency
   ( Dependency (..)
@@ -55,11 +54,10 @@ data ReplFlags = ReplFlags
   { configureReplOptions :: ReplOptions
   , replEnvFlags :: EnvFlags
   , replUseMulti :: Flag Bool
-  , replKeepTempFiles :: Flag Bool
   }
 
 instance Semigroup ReplFlags where
-  (ReplFlags a1 a2 a3 a4) <> (ReplFlags b1 b2 b3 b4) = ReplFlags (a1 <> b1) (a2 <> b2) (a3 <> b3) (a4 <> b4)
+  (ReplFlags a1 a2 a3) <> (ReplFlags b1 b2 b3) = ReplFlags (a1 <> b1) (a2 <> b2) (a3 <> b3)
 
 instance Monoid ReplFlags where
   mempty = defaultReplFlags
@@ -70,7 +68,6 @@ defaultReplFlags =
     { configureReplOptions = mempty
     , replEnvFlags = defaultEnvFlags
     , replUseMulti = NoFlag
-    , replKeepTempFiles = NoFlag
     }
 
 topReplOptions :: ShowOrParseArgs -> [OptionField ReplFlags]
@@ -78,18 +75,6 @@ topReplOptions showOrParseArgs =
   liftOptions configureReplOptions set1 (replOptions showOrParseArgs)
     ++ liftOptions replEnvFlags set2 (envOptions showOrParseArgs)
     ++ [ liftOption replUseMulti set3 multiReplOption
-       , -- keeping temporary files is important functionality for HLS,
-         -- which runs @cabal repl@ with fake GHC to get cli arguments.
-         -- It will need the temporary files (incl. multi unit repl response files)
-         -- to stay, even after the @cabal repl@ command exits.
-         --
-         option
-          []
-          ["keep-temp-files"]
-          "Keep temporary files"
-          replKeepTempFiles
-          (\b flags -> flags{replKeepTempFiles = b})
-          trueArg
        ]
   where
     set1 a x = x{configureReplOptions = a}

--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -652,9 +652,11 @@ filterCommonFlags flags cabalLibVersion
     flags_latest = flags
     flags_3_13_0 =
       flags_latest
-        { setupWorkingDir = NoFlag
+        { -- Cabal < 3.13 does not support the --working-dir flag.
+          setupWorkingDir = NoFlag
+        , -- Or the --keep-temp-files flag.
+          setupKeepTempFiles = NoFlag
         }
-    -- Cabal < 3.13 does not support the --working-dir flag.
     flags_2_1_0 =
       flags_3_13_0
         { -- Cabal < 2.1 doesn't know about -v +timestamp modifier
@@ -1268,7 +1270,10 @@ filterReplFlags :: ReplFlags -> Version -> ReplFlags
 filterReplFlags flags cabalLibVersion =
   flags
     { replCommonFlags =
-        filterCommonFlags (replCommonFlags flags) cabalLibVersion
+        (filterCommonFlags (replCommonFlags flags) cabalLibVersion)
+          { -- `cabal repl` knew about `--keep-temp-files` before other commands did.
+            setupKeepTempFiles = setupKeepTempFiles (replCommonFlags flags)
+          }
     }
 
 -- ------------------------------------------------------------
@@ -2471,7 +2476,10 @@ filterHaddockFlags flags cabalLibVersion
     flags_latest =
       flags
         { haddockCommonFlags =
-            filterCommonFlags (haddockCommonFlags flags) cabalLibVersion
+            (filterCommonFlags (haddockCommonFlags flags) cabalLibVersion)
+              { -- `cabal haddock` knew about `--keep-temp-files` before other commands did.
+                setupKeepTempFiles = setupKeepTempFiles (haddockCommonFlags flags)
+              }
         }
 
     flags_2_3_0 =

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -2059,6 +2059,7 @@ testConfigOptionComments = do
   "-- verbose" `assertHasCommentLine` "verbose"
   "-- compiler" `assertHasCommentLine` "compiler"
   "-- cabal-file" `assertHasCommentLine` "cabal-file"
+  "-- keep-temp-files" `assertHasCommentLine` "keep-temp-files"
   "-- with-compiler" `assertHasCommentLine` "with-compiler"
   "-- with-hc-pkg" `assertHasCommentLine` "with-hc-pkg"
   "-- program-prefix" `assertHasCommentLine` "program-prefix"
@@ -2152,7 +2153,6 @@ testConfigOptionComments = do
   "-- password-command" `assertHasCommentLine` "password-command"
   "-- builddir" `assertHasCommentLine` "builddir"
 
-  "  -- keep-temp-files" `assertHasCommentLine` "keep-temp-files"
   "  -- hoogle" `assertHasCommentLine` "hoogle"
   "  -- html" `assertHasCommentLine` "html"
   "  -- html-location" `assertHasCommentLine` "html-location"


### PR DESCRIPTION
This is blocking #9367.

Currently, `cabal repl` has a `--keep-temp-files` option, and `cabal.project` has a `keep-temp-files` option but it only affects Haddock builds.

This patch adds `--keep-temp-files` to `CommonSetupFlags`, making it available to all commands. The expanded `--keep-temp-files` flag is used for the `cabal repl` command and Haddock builds (retaining compatibility with the previous behavior). The flag will also be used for response files; see https://github.com/haskell/cabal/pull/9367.

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

Depends-on: #10395
Depends-on: #10392
Depends-on: #10391
Depends-on: #10390
Depends-on: #10389
Depends-on: #10388
Depends-on: #10393