### PR TITLE
Support ARM / M1 macOS in `validate.sh`

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -299,15 +299,35 @@ JOBS="-j$JOBS"
 # assume compiler is GHC
 RUNHASKELL=$(echo "$HC" | sed -E 's/ghc(-[0-9.]*)$/runghc\1/')
 
-case "$(uname)" in
-    MINGW64*)
-        ARCH="x86_64-windows"
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    arm64)
+        ARCH=aarch64
         ;;
-    Linux   )
-        ARCH="x86_64-linux"
+    x86_64)
+        ARCH=x86_64
         ;;
     *)
-        ARCH="x86_64-osx"
+        echo "Warning: Unknown architecture '$ARCH'"
+        ;;
+esac
+
+OS=$(uname)
+
+case "$OS" in
+    MINGW64*)
+        ARCH="$ARCH-windows"
+        ;;
+    Linux)
+        ARCH="$ARCH-linux"
+        ;;
+    Darwin)
+        ARCH="$ARCH-osx"
+        ;;
+    *)
+        echo "Warning: Unknown operating system '$OS'"
+        ARCH="$ARCH-$OS"
         ;;
 esac
 


### PR DESCRIPTION
Previously, `validate.sh` would assume that all non-Linux and non-Windows builds were x86_64 macOS. ARM64 macOS and Linux machines (and, to an extent, Windows machines) are now quite common. The test suite should work with them.