### PR TITLE
[3.14] Bump version numbers to 3.14

### DIFF
--- a/Cabal-QuickCheck/Cabal-QuickCheck.cabal
+++ b/Cabal-QuickCheck/Cabal-QuickCheck.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-QuickCheck
-version:       3.13.0.0
+version:       3.14.0.0
 synopsis:      QuickCheck instances for types in Cabal
 category:      Testing
 build-type:    Simple
@@ -14,8 +14,8 @@ library
   build-depends:
     , base
     , bytestring
-    , Cabal         ^>=3.13.0.0
-    , Cabal-syntax  ^>=3.13.0.0
+    , Cabal         ^>=3.14.0.0
+    , Cabal-syntax  ^>=3.14.0.0
     , QuickCheck    ^>=2.13.2 || ^>=2.14
 
   exposed-modules:

--- a/Cabal-described/Cabal-described.cabal
+++ b/Cabal-described/Cabal-described.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-described
-version:       3.13.0.0
+version:       3.14.0.0
 synopsis:      Described functionality for types in Cabal
 category:      Testing, Parsec
 description:   Provides rere bindings
@@ -12,8 +12,8 @@ library
   ghc-options:      -Wall
   build-depends:
     , base
-    , Cabal             ^>=3.13.0.0
-    , Cabal-syntax      ^>=3.13.0.0
+    , Cabal             ^>=3.14.0.0
+    , Cabal-syntax      ^>=3.14.0.0
     , containers
     , pretty
     , QuickCheck

--- a/Cabal-hooks/Cabal-hooks.cabal
+++ b/Cabal-hooks/Cabal-hooks.cabal
@@ -27,8 +27,8 @@ library
   hs-source-dirs: src
 
   build-depends:
-    Cabal-syntax    >= 3.13      && < 3.15,
-    Cabal           >= 3.13      && < 3.15,
+    Cabal-syntax    >= 3.14      && < 3.15,
+    Cabal           >= 3.14      && < 3.15,
     base            >= 4.13      && < 5,
     containers      >= 0.5.0.0   && < 0.8,
     transformers    >= 0.5.6.0   && < 0.7

--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-syntax
-version:       3.13.0.0
+version:       3.14.0.0
 copyright:     2003-2024, Cabal Development Team (see AUTHORS file)
 license:       BSD-3-Clause
 license-file:  LICENSE

--- a/Cabal-tree-diff/Cabal-tree-diff.cabal
+++ b/Cabal-tree-diff/Cabal-tree-diff.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-tree-diff
-version:       3.13.0.0
+version:       3.14.0.0
 synopsis:      QuickCheck instances for types in Cabal
 category:      Testing
 description:   Provides tree-diff ToExpr instances for some types in Cabal
@@ -11,8 +11,8 @@ library
   ghc-options:      -Wall
   build-depends:
     , base
-    , Cabal-syntax  ^>=3.13.0.0
-    , Cabal         ^>=3.13.0.0
+    , Cabal-syntax  ^>=3.14.0.0
+    , Cabal         ^>=3.14.0.0
     , tree-diff     ^>=0.1 || ^>=0.2 || ^>=0.3
 
   exposed-modules:  Data.TreeDiff.Instances.Cabal

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          Cabal
-version:       3.13.0.0
+version:       3.14.0.0
 copyright:     2003-2024, Cabal Development Team (see AUTHORS file)
 license:       BSD-3-Clause
 license-file:  LICENSE
@@ -34,7 +34,7 @@ library
   hs-source-dirs: src
 
   build-depends:
-    Cabal-syntax ^>= 3.13,
+    Cabal-syntax ^>= 3.14,
     array      >= 0.4.0.1  && < 0.6,
     base       >= 4.13     && < 5,
     bytestring >= 0.10.0.0 && < 0.13,

--- a/bootstrap/cabal-bootstrap-gen.cabal
+++ b/bootstrap/cabal-bootstrap-gen.cabal
@@ -11,8 +11,8 @@ executable cabal-bootstrap-gen
     , aeson                  ^>=1.5.2.0  || ^>=2.0.3.0 || ^>=2.1.0.0
     , base                   ^>=4.12.0.0 || ^>=4.13.0.0 || ^>=4.14.0.0 || ^>=4.15.0.0 || ^>=4.16.0.0 || ^>=4.17.0.0 || ^>=4.18.0.0
     , bytestring             ^>=0.10.8.2 || ^>=0.11.0.0
-    , Cabal                  ^>=3.4.1.0  || ^>=3.6.3.0 || ^>=3.10.1.0 || ^>=3.12.1.0
-    , Cabal-syntax           ^>=3.8.1.0 || ^>=3.10.1.0 || ^>=3.12.1.0
+    , Cabal                  ^>=3.12.1.0 || ^>=3.14.0.0
+    , Cabal-syntax           ^>=3.12.1.0 || ^>=3.14.0.0
         -- For the release process, we need the last *two* Cabal-syntax
         -- versions here: one to make CI green when release Cabal-syntax is
         -- not yet on Hackage and we are bumping versions.  The second for

--- a/bootstrap/linux-9.0.2.json
+++ b/bootstrap/linux-9.0.2.json
@@ -172,17 +172,17 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
-            "cabal_sha256": "2a9393de33f18415fb8f4826957a87a94ffe8840ca8472a9b69dca6de45aca03",
+            "cabal_sha256": "e16e2fd54934028fb21665bc0045f6133487ff77f95a37643d14bfdf339cbaff",
             "component": "lib:process",
             "flags": [],
             "package": "process",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "cefda221c3009fa2316b5cf148215cb340dad7eb8503f22e49e33722559df99a",
-            "version": "1.6.20.0"
+            "src_sha256": "fa06e25ce7f59205a8f41a449654f6d1b4f79d3959193006cfbc34f4c4bc68fb",
+            "version": "1.6.22.0"
         },
         {
             "cabal_sha256": null,
@@ -192,7 +192,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -217,7 +217,7 @@
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
+            "cabal_sha256": "17b834d2b75df8a8aef05de523280f613bb9c9aa9c31f269d5b90c1431a3749b",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -225,8 +225,8 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
-            "version": "3.2.0.0"
+            "src_sha256": "efb04947946f52cccba802c2a8fc2f4259f0bdfd0bce95094c84e71583647f0c",
+            "version": "3.2.2.0"
         },
         {
             "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
@@ -274,7 +274,7 @@
             "version": "0.9.2"
         },
         {
-            "cabal_sha256": "82503a1ef0a625c210e118f2785c4138f8502aacbbfd4e5d987f6baffbb87115",
+            "cabal_sha256": "573f3ab242f75465a0d67ce9d84202650a1606575e6dbd6d31ffcf4767a9a379",
             "component": "lib:hashable",
             "flags": [
                 "-arch-native",
@@ -284,17 +284,17 @@
             "package": "hashable",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "34652a7a1d2fc9e3d764b150bd35bcd2220761c1d4c6b446b0cfac5ad5b778cb",
-            "version": "1.4.6.0"
+            "src_sha256": "3baee4c9027a08830d148ec524cbc0471de645e1e8426d46780ef2758df0e8da",
+            "version": "1.4.7.0"
         },
         {
-            "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
+            "cabal_sha256": "cf9e6afba8e01830ca0d32a12b98d481cf389688762c80d1870a1db2061ebf35",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
             "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
             "version": "2.2.5"
@@ -362,17 +362,17 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
-            "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
+            "cabal_sha256": "acb64f2af52d81b0bb92c266f11d43def726a7a7b74a2c23d219e160b54edec7",
             "component": "lib:cryptohash-sha256",
             "flags": [
                 "-exe",
                 "+use-cbits"
             ],
             "package": "cryptohash-sha256",
-            "revision": 4,
+            "revision": 5,
             "source": "hackage",
             "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
             "version": "0.11.102.1"
@@ -417,58 +417,58 @@
             "version": "0.1.2"
         },
         {
-            "cabal_sha256": "4d4186bb8d711435765253c7dc076c44a1d52896300689507ba135706ab35866",
+            "cabal_sha256": "7699e7ae9bf74d056a62f384ceef8dfb2aa660f3f7c8016e9703f3b995e5e030",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "f6b388b9f9002622901d3f71437b98f95f54fbf7fe10490d319cb801c2a061ea",
-            "version": "2.0.3"
+            "src_sha256": "22fcc7d5fc66676b5dfc57b714d2caf93cce2d5a79d242168352f9eb0fe2f18a",
+            "version": "2.0.6"
         },
         {
-            "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+            "cabal_sha256": "e9f151d9999be8953443e730524b2792e9c0a4fb5b1463097fa1a8230870fd8a",
             "component": "lib:tar-internal",
             "flags": [],
             "package": "tar",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+            "cabal_sha256": "e9f151d9999be8953443e730524b2792e9c0a4fb5b1463097fa1a8230870fd8a",
             "component": "lib:tar",
             "flags": [],
             "package": "tar",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "d6696f2b55ab4a50b8de57947abca308604eb7cf8287c40bf69cfa26133e24d3",
+            "cabal_sha256": "bae1c5a6092d65c5e763246f91e04fef3f43e37cb055130725c9a973c88a250f",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
                 "+non-blocking-ffi",
-                "+pkg-config"
+                "-pkg-config"
             ],
             "package": "zlib",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
             "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
+            "cabal_sha256": "a7311a70ce2cc820ee430c389f57f82a082f148230b37526c34eac72b7b3ff34",
             "component": "lib:hackage-security",
             "flags": [
                 "+cabal-syntax",
                 "+lukko"
             ],
             "package": "hackage-security",
-            "revision": 1,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
             "version": "0.6.2.6"
@@ -546,7 +546,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -559,7 +559,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",

--- a/bootstrap/linux-9.2.8.json
+++ b/bootstrap/linux-9.2.8.json
@@ -79,26 +79,26 @@
     ],
     "dependencies": [
         {
-            "cabal_sha256": "4d4186bb8d711435765253c7dc076c44a1d52896300689507ba135706ab35866",
+            "cabal_sha256": "7699e7ae9bf74d056a62f384ceef8dfb2aa660f3f7c8016e9703f3b995e5e030",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "f6b388b9f9002622901d3f71437b98f95f54fbf7fe10490d319cb801c2a061ea",
-            "version": "2.0.3"
+            "src_sha256": "22fcc7d5fc66676b5dfc57b714d2caf93cce2d5a79d242168352f9eb0fe2f18a",
+            "version": "2.0.6"
         },
         {
-            "cabal_sha256": "8af7a843cba7eddc8d44ae94002b766ee8c23cbcd3ecdb2cc79ee6e0a694419a",
+            "cabal_sha256": "0c64bc9a4f5946c86a8f0527bf40c8ba51e2c02d36eea0e20ea558c8d94166e8",
             "component": "lib:filepath",
             "flags": [
                 "-cpphs"
             ],
             "package": "filepath",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "d2606db4fa8517932a2d9ea6415c365da4d1794afcb264a5b3c10110123978a7",
-            "version": "1.5.2.0"
+            "src_sha256": "d807ec44fe53de7c7e0eeb41c9ee9185a09163821cf50549d73d875197931a5a",
+            "version": "1.5.3.0"
         },
         {
             "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
@@ -142,17 +142,17 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
-            "cabal_sha256": "2a9393de33f18415fb8f4826957a87a94ffe8840ca8472a9b69dca6de45aca03",
+            "cabal_sha256": "e16e2fd54934028fb21665bc0045f6133487ff77f95a37643d14bfdf339cbaff",
             "component": "lib:process",
             "flags": [],
             "package": "process",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "cefda221c3009fa2316b5cf148215cb340dad7eb8503f22e49e33722559df99a",
-            "version": "1.6.20.0"
+            "src_sha256": "fa06e25ce7f59205a8f41a449654f6d1b4f79d3959193006cfbc34f4c4bc68fb",
+            "version": "1.6.22.0"
         },
         {
             "cabal_sha256": null,
@@ -162,7 +162,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -187,7 +187,7 @@
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
+            "cabal_sha256": "17b834d2b75df8a8aef05de523280f613bb9c9aa9c31f269d5b90c1431a3749b",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -195,8 +195,8 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
-            "version": "3.2.0.0"
+            "src_sha256": "efb04947946f52cccba802c2a8fc2f4259f0bdfd0bce95094c84e71583647f0c",
+            "version": "3.2.2.0"
         },
         {
             "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
@@ -244,7 +244,7 @@
             "version": "0.1.0.1"
         },
         {
-            "cabal_sha256": "82503a1ef0a625c210e118f2785c4138f8502aacbbfd4e5d987f6baffbb87115",
+            "cabal_sha256": "573f3ab242f75465a0d67ce9d84202650a1606575e6dbd6d31ffcf4767a9a379",
             "component": "lib:hashable",
             "flags": [
                 "-arch-native",
@@ -254,17 +254,17 @@
             "package": "hashable",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "34652a7a1d2fc9e3d764b150bd35bcd2220761c1d4c6b446b0cfac5ad5b778cb",
-            "version": "1.4.6.0"
+            "src_sha256": "3baee4c9027a08830d148ec524cbc0471de645e1e8426d46780ef2758df0e8da",
+            "version": "1.4.7.0"
         },
         {
-            "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
+            "cabal_sha256": "cf9e6afba8e01830ca0d32a12b98d481cf389688762c80d1870a1db2061ebf35",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
             "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
             "version": "2.2.5"
@@ -332,17 +332,17 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
-            "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
+            "cabal_sha256": "acb64f2af52d81b0bb92c266f11d43def726a7a7b74a2c23d219e160b54edec7",
             "component": "lib:cryptohash-sha256",
             "flags": [
                 "-exe",
                 "+use-cbits"
             ],
             "package": "cryptohash-sha256",
-            "revision": 4,
+            "revision": 5,
             "source": "hackage",
             "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
             "version": "0.11.102.1"
@@ -387,48 +387,48 @@
             "version": "0.1.2"
         },
         {
-            "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+            "cabal_sha256": "e9f151d9999be8953443e730524b2792e9c0a4fb5b1463097fa1a8230870fd8a",
             "component": "lib:tar-internal",
             "flags": [],
             "package": "tar",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+            "cabal_sha256": "e9f151d9999be8953443e730524b2792e9c0a4fb5b1463097fa1a8230870fd8a",
             "component": "lib:tar",
             "flags": [],
             "package": "tar",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "d6696f2b55ab4a50b8de57947abca308604eb7cf8287c40bf69cfa26133e24d3",
+            "cabal_sha256": "bae1c5a6092d65c5e763246f91e04fef3f43e37cb055130725c9a973c88a250f",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
                 "+non-blocking-ffi",
-                "+pkg-config"
+                "-pkg-config"
             ],
             "package": "zlib",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
             "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
+            "cabal_sha256": "a7311a70ce2cc820ee430c389f57f82a082f148230b37526c34eac72b7b3ff34",
             "component": "lib:hackage-security",
             "flags": [
                 "+cabal-syntax",
                 "+lukko"
             ],
             "package": "hackage-security",
-            "revision": 1,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
             "version": "0.6.2.6"
@@ -506,7 +506,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -519,7 +519,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",

--- a/bootstrap/linux-9.4.8.json
+++ b/bootstrap/linux-9.4.8.json
@@ -79,26 +79,26 @@
     ],
     "dependencies": [
         {
-            "cabal_sha256": "4d4186bb8d711435765253c7dc076c44a1d52896300689507ba135706ab35866",
+            "cabal_sha256": "7699e7ae9bf74d056a62f384ceef8dfb2aa660f3f7c8016e9703f3b995e5e030",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "f6b388b9f9002622901d3f71437b98f95f54fbf7fe10490d319cb801c2a061ea",
-            "version": "2.0.3"
+            "src_sha256": "22fcc7d5fc66676b5dfc57b714d2caf93cce2d5a79d242168352f9eb0fe2f18a",
+            "version": "2.0.6"
         },
         {
-            "cabal_sha256": "8af7a843cba7eddc8d44ae94002b766ee8c23cbcd3ecdb2cc79ee6e0a694419a",
+            "cabal_sha256": "0c64bc9a4f5946c86a8f0527bf40c8ba51e2c02d36eea0e20ea558c8d94166e8",
             "component": "lib:filepath",
             "flags": [
                 "-cpphs"
             ],
             "package": "filepath",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "d2606db4fa8517932a2d9ea6415c365da4d1794afcb264a5b3c10110123978a7",
-            "version": "1.5.2.0"
+            "src_sha256": "d807ec44fe53de7c7e0eeb41c9ee9185a09163821cf50549d73d875197931a5a",
+            "version": "1.5.3.0"
         },
         {
             "cabal_sha256": "3f702a252a313a7bcb56e3908a14e7f9f1b40e41b7bdc8ae8a9605a1a8686f06",
@@ -142,17 +142,17 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
-            "cabal_sha256": "2a9393de33f18415fb8f4826957a87a94ffe8840ca8472a9b69dca6de45aca03",
+            "cabal_sha256": "e16e2fd54934028fb21665bc0045f6133487ff77f95a37643d14bfdf339cbaff",
             "component": "lib:process",
             "flags": [],
             "package": "process",
-            "revision": 1,
+            "revision": 0,
             "source": "hackage",
-            "src_sha256": "cefda221c3009fa2316b5cf148215cb340dad7eb8503f22e49e33722559df99a",
-            "version": "1.6.20.0"
+            "src_sha256": "fa06e25ce7f59205a8f41a449654f6d1b4f79d3959193006cfbc34f4c4bc68fb",
+            "version": "1.6.22.0"
         },
         {
             "cabal_sha256": null,
@@ -162,7 +162,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -187,7 +187,7 @@
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
+            "cabal_sha256": "17b834d2b75df8a8aef05de523280f613bb9c9aa9c31f269d5b90c1431a3749b",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -195,8 +195,8 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
-            "version": "3.2.0.0"
+            "src_sha256": "efb04947946f52cccba802c2a8fc2f4259f0bdfd0bce95094c84e71583647f0c",
+            "version": "3.2.2.0"
         },
         {
             "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
@@ -234,7 +234,7 @@
             "version": "4000.4.1"
         },
         {
-            "cabal_sha256": "82503a1ef0a625c210e118f2785c4138f8502aacbbfd4e5d987f6baffbb87115",
+            "cabal_sha256": "573f3ab242f75465a0d67ce9d84202650a1606575e6dbd6d31ffcf4767a9a379",
             "component": "lib:hashable",
             "flags": [
                 "-arch-native",
@@ -244,17 +244,17 @@
             "package": "hashable",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "34652a7a1d2fc9e3d764b150bd35bcd2220761c1d4c6b446b0cfac5ad5b778cb",
-            "version": "1.4.6.0"
+            "src_sha256": "3baee4c9027a08830d148ec524cbc0471de645e1e8426d46780ef2758df0e8da",
+            "version": "1.4.7.0"
         },
         {
-            "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
+            "cabal_sha256": "cf9e6afba8e01830ca0d32a12b98d481cf389688762c80d1870a1db2061ebf35",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
             "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
             "version": "2.2.5"
@@ -322,17 +322,17 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
-            "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
+            "cabal_sha256": "acb64f2af52d81b0bb92c266f11d43def726a7a7b74a2c23d219e160b54edec7",
             "component": "lib:cryptohash-sha256",
             "flags": [
                 "-exe",
                 "+use-cbits"
             ],
             "package": "cryptohash-sha256",
-            "revision": 4,
+            "revision": 5,
             "source": "hackage",
             "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
             "version": "0.11.102.1"
@@ -377,48 +377,48 @@
             "version": "0.1.2"
         },
         {
-            "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+            "cabal_sha256": "e9f151d9999be8953443e730524b2792e9c0a4fb5b1463097fa1a8230870fd8a",
             "component": "lib:tar-internal",
             "flags": [],
             "package": "tar",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+            "cabal_sha256": "e9f151d9999be8953443e730524b2792e9c0a4fb5b1463097fa1a8230870fd8a",
             "component": "lib:tar",
             "flags": [],
             "package": "tar",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "d6696f2b55ab4a50b8de57947abca308604eb7cf8287c40bf69cfa26133e24d3",
+            "cabal_sha256": "bae1c5a6092d65c5e763246f91e04fef3f43e37cb055130725c9a973c88a250f",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
                 "+non-blocking-ffi",
-                "+pkg-config"
+                "-pkg-config"
             ],
             "package": "zlib",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
             "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
+            "cabal_sha256": "a7311a70ce2cc820ee430c389f57f82a082f148230b37526c34eac72b7b3ff34",
             "component": "lib:hackage-security",
             "flags": [
                 "+cabal-syntax",
                 "+lukko"
             ],
             "package": "hackage-security",
-            "revision": 1,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
             "version": "0.6.2.6"
@@ -496,7 +496,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -509,7 +509,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",

--- a/bootstrap/linux-9.6.4.json
+++ b/bootstrap/linux-9.6.4.json
@@ -112,7 +112,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -122,7 +122,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -147,7 +147,7 @@
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
+            "cabal_sha256": "17b834d2b75df8a8aef05de523280f613bb9c9aa9c31f269d5b90c1431a3749b",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -155,8 +155,8 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
-            "version": "3.2.0.0"
+            "src_sha256": "efb04947946f52cccba802c2a8fc2f4259f0bdfd0bce95094c84e71583647f0c",
+            "version": "3.2.2.0"
         },
         {
             "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
@@ -194,37 +194,36 @@
             "version": "4000.4.1"
         },
         {
-            "cabal_sha256": "4d4186bb8d711435765253c7dc076c44a1d52896300689507ba135706ab35866",
+            "cabal_sha256": "7699e7ae9bf74d056a62f384ceef8dfb2aa660f3f7c8016e9703f3b995e5e030",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "f6b388b9f9002622901d3f71437b98f95f54fbf7fe10490d319cb801c2a061ea",
-            "version": "2.0.3"
+            "src_sha256": "22fcc7d5fc66676b5dfc57b714d2caf93cce2d5a79d242168352f9eb0fe2f18a",
+            "version": "2.0.6"
         },
         {
-            "cabal_sha256": "82503a1ef0a625c210e118f2785c4138f8502aacbbfd4e5d987f6baffbb87115",
+            "cabal_sha256": "fc68b07d957ade5a0a0beadd560a8d093ceac30b2f35c85eed3bcf7889a25975",
             "component": "lib:hashable",
             "flags": [
                 "-arch-native",
-                "+integer-gmp",
                 "-random-initial-seed"
             ],
             "package": "hashable",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "34652a7a1d2fc9e3d764b150bd35bcd2220761c1d4c6b446b0cfac5ad5b778cb",
-            "version": "1.4.6.0"
+            "src_sha256": "e58b3a8e18da5f6cd7e937e5fd683e500bb1f8276b3768269759119ca0cddb6a",
+            "version": "1.5.0.0"
         },
         {
-            "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
+            "cabal_sha256": "cf9e6afba8e01830ca0d32a12b98d481cf389688762c80d1870a1db2061ebf35",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
             "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
             "version": "2.2.5"
@@ -292,17 +291,17 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
-            "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
+            "cabal_sha256": "acb64f2af52d81b0bb92c266f11d43def726a7a7b74a2c23d219e160b54edec7",
             "component": "lib:cryptohash-sha256",
             "flags": [
                 "-exe",
                 "+use-cbits"
             ],
             "package": "cryptohash-sha256",
-            "revision": 4,
+            "revision": 5,
             "source": "hackage",
             "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
             "version": "0.11.102.1"
@@ -347,48 +346,48 @@
             "version": "0.1.2"
         },
         {
-            "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+            "cabal_sha256": "e9f151d9999be8953443e730524b2792e9c0a4fb5b1463097fa1a8230870fd8a",
             "component": "lib:tar-internal",
             "flags": [],
             "package": "tar",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+            "cabal_sha256": "e9f151d9999be8953443e730524b2792e9c0a4fb5b1463097fa1a8230870fd8a",
             "component": "lib:tar",
             "flags": [],
             "package": "tar",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "d6696f2b55ab4a50b8de57947abca308604eb7cf8287c40bf69cfa26133e24d3",
+            "cabal_sha256": "bae1c5a6092d65c5e763246f91e04fef3f43e37cb055130725c9a973c88a250f",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
                 "+non-blocking-ffi",
-                "+pkg-config"
+                "-pkg-config"
             ],
             "package": "zlib",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
             "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
+            "cabal_sha256": "a7311a70ce2cc820ee430c389f57f82a082f148230b37526c34eac72b7b3ff34",
             "component": "lib:hackage-security",
             "flags": [
                 "+cabal-syntax",
                 "+lukko"
             ],
             "package": "hackage-security",
-            "revision": 1,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
             "version": "0.6.2.6"
@@ -466,7 +465,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -479,7 +478,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",

--- a/bootstrap/linux-9.8.2.json
+++ b/bootstrap/linux-9.8.2.json
@@ -116,7 +116,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -126,7 +126,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -151,7 +151,7 @@
             "version": "0.68.10"
         },
         {
-            "cabal_sha256": "25440c1bbd5772fdbbeec068f20138121131e1a56453db0adc113dcdf9044105",
+            "cabal_sha256": "17b834d2b75df8a8aef05de523280f613bb9c9aa9c31f269d5b90c1431a3749b",
             "component": "lib:network",
             "flags": [
                 "-devel"
@@ -159,8 +159,8 @@
             "package": "network",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "c45696744dc437d93a56871a3dd869965b7b50eda3fe3c1a90a35e2fbb9cb9ca",
-            "version": "3.2.0.0"
+            "src_sha256": "efb04947946f52cccba802c2a8fc2f4259f0bdfd0bce95094c84e71583647f0c",
+            "version": "3.2.2.0"
         },
         {
             "cabal_sha256": "129a59ba3ccfcd06192fd6da899e2711ae276a466915a047bd6727e4a0321d2e",
@@ -198,37 +198,36 @@
             "version": "4000.4.1"
         },
         {
-            "cabal_sha256": "4d4186bb8d711435765253c7dc076c44a1d52896300689507ba135706ab35866",
+            "cabal_sha256": "7699e7ae9bf74d056a62f384ceef8dfb2aa660f3f7c8016e9703f3b995e5e030",
             "component": "lib:os-string",
             "flags": [],
             "package": "os-string",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "f6b388b9f9002622901d3f71437b98f95f54fbf7fe10490d319cb801c2a061ea",
-            "version": "2.0.3"
+            "src_sha256": "22fcc7d5fc66676b5dfc57b714d2caf93cce2d5a79d242168352f9eb0fe2f18a",
+            "version": "2.0.6"
         },
         {
-            "cabal_sha256": "82503a1ef0a625c210e118f2785c4138f8502aacbbfd4e5d987f6baffbb87115",
+            "cabal_sha256": "fc68b07d957ade5a0a0beadd560a8d093ceac30b2f35c85eed3bcf7889a25975",
             "component": "lib:hashable",
             "flags": [
                 "-arch-native",
-                "+integer-gmp",
                 "-random-initial-seed"
             ],
             "package": "hashable",
             "revision": 0,
             "source": "hackage",
-            "src_sha256": "34652a7a1d2fc9e3d764b150bd35bcd2220761c1d4c6b446b0cfac5ad5b778cb",
-            "version": "1.4.6.0"
+            "src_sha256": "e58b3a8e18da5f6cd7e937e5fd683e500bb1f8276b3768269759119ca0cddb6a",
+            "version": "1.5.0.0"
         },
         {
-            "cabal_sha256": "9d5d9e605f52958d099e13a8b8f30ee56cb137c9192996245e3c533adb682cf8",
+            "cabal_sha256": "cf9e6afba8e01830ca0d32a12b98d481cf389688762c80d1870a1db2061ebf35",
             "component": "lib:async",
             "flags": [
                 "-bench"
             ],
             "package": "async",
-            "revision": 1,
+            "revision": 2,
             "source": "hackage",
             "src_sha256": "1818473ebab9212afad2ed76297aefde5fae8b5d4404daf36939aece6a8f16f7",
             "version": "2.2.5"
@@ -296,17 +295,17 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
-            "cabal_sha256": "200d756a7b3bab7ca2bac6eb50ed8252f26de77ac8def490a3ad743f2933acbd",
+            "cabal_sha256": "acb64f2af52d81b0bb92c266f11d43def726a7a7b74a2c23d219e160b54edec7",
             "component": "lib:cryptohash-sha256",
             "flags": [
                 "-exe",
                 "+use-cbits"
             ],
             "package": "cryptohash-sha256",
-            "revision": 4,
+            "revision": 5,
             "source": "hackage",
             "src_sha256": "73a7dc7163871a80837495039a099967b11f5c4fe70a118277842f7a713c6bf6",
             "version": "0.11.102.1"
@@ -351,48 +350,48 @@
             "version": "0.1.2"
         },
         {
-            "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+            "cabal_sha256": "e9f151d9999be8953443e730524b2792e9c0a4fb5b1463097fa1a8230870fd8a",
             "component": "lib:tar-internal",
             "flags": [],
             "package": "tar",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "b853b4296cb23386feda17dc0d9065af6709d22d684ec734aab65403d59ed547",
+            "cabal_sha256": "e9f151d9999be8953443e730524b2792e9c0a4fb5b1463097fa1a8230870fd8a",
             "component": "lib:tar",
             "flags": [],
             "package": "tar",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "50bb660feec8a524416d6934251b996eaa7e39d49ae107ad505ab700d43f6814",
             "version": "0.6.3.0"
         },
         {
-            "cabal_sha256": "d6696f2b55ab4a50b8de57947abca308604eb7cf8287c40bf69cfa26133e24d3",
+            "cabal_sha256": "bae1c5a6092d65c5e763246f91e04fef3f43e37cb055130725c9a973c88a250f",
             "component": "lib:zlib",
             "flags": [
                 "-bundled-c-zlib",
                 "+non-blocking-ffi",
-                "+pkg-config"
+                "-pkg-config"
             ],
             "package": "zlib",
-            "revision": 0,
+            "revision": 1,
             "source": "hackage",
             "src_sha256": "6edd38b6b81df8d274952aa85affa6968ae86b2231e1d429ce8bc9083e6a55bc",
             "version": "0.7.1.0"
         },
         {
-            "cabal_sha256": "8ff70524314f9ad706f8e5051d7150ee44cb82170147879b245bdab279604b16",
+            "cabal_sha256": "a7311a70ce2cc820ee430c389f57f82a082f148230b37526c34eac72b7b3ff34",
             "component": "lib:hackage-security",
             "flags": [
                 "+cabal-syntax",
                 "+lukko"
             ],
             "package": "hackage-security",
-            "revision": 1,
+            "revision": 4,
             "source": "hackage",
             "src_sha256": "2e4261576b3e11b9f5175392947f56a638cc1a3584b8acbb962b809d7c69db69",
             "version": "0.6.2.6"
@@ -460,7 +459,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": null,
@@ -473,7 +472,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "3.13.0.0"
+            "version": "3.14.0.0"
         },
         {
             "cabal_sha256": "e4be4a206f5ab6ddb5ae4fbb39101529196e20af5670c5d33326fea6eff886fd",

--- a/cabal-install-solver/cabal-install-solver.cabal
+++ b/cabal-install-solver/cabal-install-solver.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          cabal-install-solver
-version:       3.13.0.0
+version:       3.14.0.0
 synopsis:      The solver component of cabal-install
 description:
   The solver component used in the cabal-install command-line program.
@@ -101,8 +101,8 @@ library
     , array         >=0.4      && <0.6
     , base          >=4.13     && <4.21
     , bytestring    >=0.10.6.0 && <0.13
-    , Cabal         ^>=3.13
-    , Cabal-syntax  ^>=3.13
+    , Cabal         ^>=3.14
+    , Cabal-syntax  ^>=3.14
     , containers    >=0.5.6.2  && <0.8
     , edit-distance ^>= 0.2.2
     , directory     >= 1.3.7.0  && < 1.4

--- a/cabal-install/cabal-install.cabal
+++ b/cabal-install/cabal-install.cabal
@@ -1,7 +1,7 @@
 Cabal-Version:      3.0
 
 Name:               cabal-install
-Version:            3.13.0.0
+Version:            3.14.0.0
 Synopsis:           The command-line interface for Cabal and Hackage.
 Description:
     The \'cabal\' command-line program simplifies the process of managing
@@ -55,13 +55,13 @@ common base-dep
     build-depends: base >=4.13 && <4.21
 
 common cabal-dep
-    build-depends: Cabal ^>=3.13
+    build-depends: Cabal ^>=3.14
 
 common cabal-syntax-dep
-    build-depends: Cabal-syntax ^>=3.13
+    build-depends: Cabal-syntax ^>=3.14
 
 common cabal-install-solver-dep
-    build-depends: cabal-install-solver ^>=3.13
+    build-depends: cabal-install-solver ^>=3.14
 
 library
     import: warnings, base-dep, cabal-dep, cabal-syntax-dep, cabal-install-solver-dep

--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -28,7 +28,7 @@ common shared
   build-depends:
     , base >= 4.11 && < 4.21
     -- this needs to match the in-tree lib:Cabal version
-    , Cabal ^>= 3.13.0.0
+    , Cabal ^>= 3.14.0.0
 
   ghc-options:
     -Wall

--- a/cabal.bootstrap.project
+++ b/cabal.bootstrap.project
@@ -14,4 +14,4 @@ benchmarks: False
 constraints:
   hashable -arch-native
 
-index-state: hackage.haskell.org 2024-07-15T21:05:18Z
+index-state: hackage.haskell.org 2024-09-05T17:19:45Z

--- a/cabal.release.project
+++ b/cabal.release.project
@@ -5,4 +5,4 @@ import: project-cabal/pkgs/tests.config
 constraints:
   hashable -arch-native
 
-index-state: hackage.haskell.org 2024-07-15T21:05:18Z
+index-state: hackage.haskell.org 2024-09-05T17:19:45Z

--- a/solver-benchmarks/solver-benchmarks.cabal
+++ b/solver-benchmarks/solver-benchmarks.cabal
@@ -31,7 +31,7 @@ library
     base,
     bytestring,
     containers,
-    Cabal-syntax ^>= 3.13,
+    Cabal-syntax ^>= 3.14,
     directory,
     filepath,
     optparse-applicative,


### PR DESCRIPTION
#10241

https://github.com/haskell/cabal/wiki/Making-a-release#c3-bumping-version-numbers

- [x] hackage-security release/revision (point 6 of the checklist) https://github.com/haskell/hackage-security/pull/319
- [x] Regenerate bootstrap files

---
<!--
**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---
-->
**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
