### PR TITLE
validate.sh: `--jobs` should default to `nproc`

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -12,7 +12,7 @@
 #   See https://github.com/haskell/cabal/issues/8049
 HC=ghc
 CABAL=cabal
-JOBS=4
+JOBS=""
 LIBTESTS=true
 CLITESTS=true
 CABALSUITETESTS=true
@@ -292,6 +292,15 @@ fi
 
 # Adjust runtime configuration
 #######################################################################
+
+if [ -z "$JOBS" ]; then
+    if command -v nproc >/dev/null; then
+        JOBS=$(nproc)
+    else
+        echo "Warning: \`nproc\` not found, setting \`--jobs\` to default of 4."
+        JOBS=4
+    fi
+fi
 
 TESTSUITEJOBS="-j$JOBS"
 JOBS="-j$JOBS"


### PR DESCRIPTION
If `nproc` is available and `--jobs` is not given, this will use the output of `nproc` as the value for `--jobs`.

Otherwise, the old default value of 4 will be used and a warning will be printed.

The default value of 4 has remained unchanged since it was added in 6a9a101ca5e1731b9f099a94579a84d2e19667f8 in 2018; that may have been a reasonable number of cores then, but my development machine today has 20 cores, so setting the parallelism to 4 leaves a lot of performance on the table!