### PR TITLE
`validate.sh`: Use Bash explicitly

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # shellcheck disable=SC2086
 
 # default config


### PR DESCRIPTION
We were already relying on Bash features like `echo -e`, so let's make it official.