### PR TITLE
Warn that scripts cannot be package executables

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -198,8 +198,8 @@ the following file named ``myscript``:
     main :: IO ()
     main = haskellSay "Hello, Haskell!"
 
-The necessary sections of a ``.cabal`` file are placed
-directly into the script as a comment.
+The necessary sections of a package description that would otherwise be in a
+``.cabal`` file are placed directly into the script as a comment.
 
 Use the familiar ``cabal run`` command to execute this script:
 
@@ -221,6 +221,36 @@ can be run directly after setting the execute permission (+x):
            \ ... /
 
 See more in the documentation for :ref:`cabal run`.
+
+.. warning::
+
+    Single-file scripts cannot also be part of a package, as an executable or
+    listed as a module.
+
+    .. code-block:: console
+
+        $ cat script-exclusivity.cabal
+        cabal-version: 3.0
+        name: script-exclusitivity
+        version: 1
+
+        executable my-script-exe
+            build-depends:
+                base,
+                haskell-say
+            main-is: myscript.hs
+
+        $ ./myscript.hs
+        Error: [Cabal-7070]
+        The run command can only run an executable as a whole, not files or modules
+        within them, but the target 'myscript.hs' refers to the file myscript.hs in the
+        executable my-script-exe.
+
+        $ cabal run myscript.hs
+        Error: [Cabal-7070]
+        The run command can only run an executable as a whole, not files or modules
+        within them, but the target 'myscript.hs' refers to the file myscript.hs in the
+        executable my-script-exe.
 
 What Next?
 ----------

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -225,32 +225,8 @@ See more in the documentation for :ref:`cabal run`.
 .. warning::
 
     Single-file scripts cannot also be part of a package, as an executable or
-    listed as a module.
-
-    .. code-block:: console
-
-        $ cat script-exclusivity.cabal
-        cabal-version: 3.0
-        name: script-exclusitivity
-        version: 1
-
-        executable my-script-exe
-            build-depends:
-                base,
-                haskell-say
-            main-is: myscript.hs
-
-        $ ./myscript.hs
-        Error: [Cabal-7070]
-        The run command can only run an executable as a whole, not files or modules
-        within them, but the target 'myscript.hs' refers to the file myscript.hs in the
-        executable my-script-exe.
-
-        $ cabal run myscript.hs
-        Error: [Cabal-7070]
-        The run command can only run an executable as a whole, not files or modules
-        within them, but the target 'myscript.hs' refers to the file myscript.hs in the
-        executable my-script-exe.
+    listed as a module. Trying to run a module that is included in a package
+    will error with `Cabal-7070`_.
 
 What Next?
 ----------
@@ -259,3 +235,5 @@ Now that you know how to set up a simple Haskell package using Cabal, check out
 some of the resources on the Haskell website's `documentation page
 <https://www.haskell.org/documentation/>`__ or read more about packages and
 Cabal on the :doc:`What Cabal does <cabal-context>` page.
+
+.. _Cabal-7070: https://errors.haskell.org/messages/Cabal-7070/


### PR DESCRIPTION
See #10324. Add a warning to the user guide to say that scripts cannot be part of a package, as executable mains or other modules.
