### PR TITLE
Fix `cabal-install:long-tests` with Git >=2.38.1

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -133,9 +133,6 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
           restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
 
-      - name: "Work around git problem https://bugs.launchpad.net/ubuntu/+source/git/+bug/1993586 (cabal PR #8546)"
-        run: git config --global protocol.file.allow always
-
       # The tool is not essential to the rest of the test suite. If
       # hackage-repo-tool is not present, any test that requires it will
       # be skipped.


### PR DESCRIPTION
Closes #10312.

Git 2.38.1 and newer fails to clone from local paths with `fatal: transport 'file' not allowed` unless `protocol.file.allow=always` is set.

This is not safe in general, but it's fine in the test suite.

See: https://github.blog/open-source/git/git-security-vulnerabilities-announced/#fn-67904-1
See: https://git-scm.com/docs/git-config#Documentation/git-config.txt-protocolallow