### PR TITLE
CI: cabal-head prerelease: move to a current GitHub Action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -448,6 +448,8 @@ jobs:
     name: Create a GitHub prerelease with the binary artifacts
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
 
     # IMPORTANT! Any job added to the workflow should be added here too
     needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
@@ -456,32 +458,15 @@ jobs:
       # for now this is hardcoded. is there a better way?
       - uses: actions/download-artifact@v4
         with:
-          name: cabal-Windows-x86_64
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: cabal-Linux-x86_64
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: cabal-Linux-static-x86_64
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: cabal-macOS-aarch64
+          pattern: cabal-*
+          path: binaries
 
       - name: Create GitHub prerelease
-        uses: marvinpinto/action-automatic-releases@v1.2.1
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: cabal-head
+          tag_name: cabal-head
           prerelease: true
-          title: cabal-head
-          files: |
-            cabal-head-Windows-x86_64.tar.gz
-            cabal-head-Linux-x86_64.tar.gz
-            cabal-head-Linux-static-x86_64.tar.gz
-            cabal-head-macOS-aarch64.tar.gz
+          files: binaries/cabal-*
 
   prerelease-lts:
     name: Create a GitHub LTS prerelease with the binary artifacts
@@ -495,39 +480,22 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: cabal-Windows-x86_64
-
-    - uses: actions/download-artifact@v4
-      with:
-        name: cabal-Linux-x86_64
-
-    - uses: actions/download-artifact@v4
-      with:
-        name: cabal-Linux-static-x86_64
-
-    - uses: actions/download-artifact@v4
-      with:
-        name: cabal-macOS-x86_64
+        pattern: cabal-*
+        path: binaries
 
     - run: |
         # bash-ism, but we forced bash above
         mv cabal-{,lts-}head-Windows-x86_64.tar.gz
         mv cabal-{,lts-}head-Linux-x86_64.tar.gz
         mv cabal-{,lts-}head-Linux-static-x86_64.tar.gz
-        mv cabal-{,lts-}head-macOS-x86_64.tar.gz
+        mv cabal-{,lts-}head-macOS-aarch64.tar.gz
 
     - name: Create GitHub prerelease
-      uses: marvinpinto/action-automatic-releases@v1.2.1
+      uses: softprops/action-gh-release@v2
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        automatic_release_tag: cabal-lts-head
+        tag_name: cabal-lts-head
         prerelease: true
-        title: cabal-lts-head
-        files: |
-          cabal-lts-head-Windows-x86_64.tar.gz
-          cabal-lts-head-Linux-x86_64.tar.gz
-          cabal-lts-head-Linux-static-x86_64.tar.gz
-          cabal-lts-head-macOS-x86_64.tar.gz
+        files: binaries/cabal-*
 
   # We use this job as a summary of the workflow
   # It will fail if any of the previous jobs does


### PR DESCRIPTION
I don't believe we need to backport it since cabal-head only concerns `master`. 

Explanation of the changes (based on the docs for the new action):

- title will be the same as tag (cabal-head)
- auth token has a default value that should work, I hope.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
