### PR TITLE
Bump deepseq bounds to allow 1.6

### DIFF
--- a/Cabal-syntax/Cabal-syntax.cabal
+++ b/Cabal-syntax/Cabal-syntax.cabal
@@ -33,7 +33,7 @@ library
     binary     >= 0.7      && < 0.9,
     bytestring >= 0.10.0.0 && < 0.13,
     containers >= 0.5.0.0  && < 0.8,
-    deepseq    >= 1.3.0.1  && < 1.6,
+    deepseq    >= 1.3.0.1  && < 1.7,
     directory  >= 1.2      && < 1.4,
     filepath   >= 1.3.0.1  && < 1.6,
     mtl        >= 2.1      && < 2.4,

--- a/Cabal/Cabal.cabal
+++ b/Cabal/Cabal.cabal
@@ -39,7 +39,7 @@ library
     base       >= 4.13     && < 5,
     bytestring >= 0.10.0.0 && < 0.13,
     containers >= 0.5.0.0  && < 0.8,
-    deepseq    >= 1.3.0.1  && < 1.6,
+    deepseq    >= 1.3.0.1  && < 1.7,
     directory  >= 1.2      && < 1.4,
     filepath   >= 1.3.0.1  && < 1.6,
     pretty     >= 1.1.1    && < 1.2,


### PR DESCRIPTION
Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] no ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~