### PR TITLE
remove references to git protocol

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -2739,7 +2739,7 @@ The exact fields are as follows:
     on the repository type. For example:
 
     -  for darcs: ``http://code.haskell.org/foo/``
-    -  for git: ``git://github.com/foo/bar.git``
+    -  for git: ``https://github.com/foo/bar.git``
     -  for CVS: ``anoncvs@cvs.foo.org:/cvs``
 
     This field is required.


### PR DESCRIPTION
The original PR (#10306) won't backport because the docs were rearranged on `master`.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
