### PR TITLE
changelogs are docs

### DIFF
--- a/.github/workflows/bootstrap.skip.yml
+++ b/.github/workflows/bootstrap.skip.yml
@@ -19,6 +19,11 @@ on:
       - 'doc/**'
       - '**/README.md'
       - 'CONTRIBUTING.md'
+      - "changelog.d/**"
+      # only top level for these, because various test packages have them too
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
     branches:
       - master
   pull_request:
@@ -26,6 +31,10 @@ on:
       - 'doc/**'
       - '**/README.md'
       - 'CONTRIBUTING.md'
+      - "changelog.d/**"
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
   release:
     types:
       - created

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -14,6 +14,11 @@ on:
       - 'doc/**'
       - '**/README.md'
       - 'CONTRIBUTING.md'
+      - "changelog.d/**"
+      # only top level for these, because various test packages have them too
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
     branches:
       - master
   pull_request:
@@ -21,6 +26,10 @@ on:
       - 'doc/**'
       - '**/README.md'
       - 'CONTRIBUTING.md'
+      - "changelog.d/**"
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
   release:
     types:
       - created

--- a/.github/workflows/check-sdist.yml
+++ b/.github/workflows/check-sdist.yml
@@ -11,6 +11,11 @@ on:
       - "doc/**"
       - "**/README.md"
       - "CONTRIBUTING.md"
+      - "changelog.d/**"
+      # only top level for these, because various test packages have them too
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
     branches:
       - master
   pull_request:
@@ -18,6 +23,10 @@ on:
       - "doc/**"
       - "**/README.md"
       - "CONTRIBUTING.md"
+      - "changelog.d/**"
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
   release:
     types:
       - created

--- a/.github/workflows/validate.skip.yml
+++ b/.github/workflows/validate.skip.yml
@@ -19,6 +19,11 @@ on:
       - 'doc/**'
       - '**/README.md'
       - 'CONTRIBUTING.md'
+      - "changelog.d/**"
+      # only top level for these, because various test packages have them too
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
     branches:
       - master
   pull_request:
@@ -26,6 +31,10 @@ on:
       - 'doc/**'
       - '**/README.md'
       - 'CONTRIBUTING.md'
+      - "changelog.d/**"
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
   release:
     types:
       - created

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,11 @@ on:
       - "doc/**"
       - "**/README.md"
       - "CONTRIBUTING.md"
+      - "changelog.d/**"
+      # only top level for these, because various test packages have them too
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
     branches:
       - master
   pull_request:
@@ -21,6 +26,10 @@ on:
       - "doc/**"
       - "**/README.md"
       - "CONTRIBUTING.md"
+      - "changelog.d/**"
+      - "*/ChangeLog.md"
+      - "*/changelog.md"
+      - "release-notes/**"
   release:
     types:
       - created


### PR DESCRIPTION
We don't mark changelogs as documentation, so CI unnecessarily does full checks when we add changelogs. Correct this.

NOTE: we only accept changelog files from top-level subdirectories. There are changelog files in package tests that must be considered "code" from the standpoint of CI.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
