### PR TITLE
remove recomp hack

### DIFF
--- a/cabal-testsuite/cabal-testsuite.cabal
+++ b/cabal-testsuite/cabal-testsuite.cabal
@@ -90,7 +90,7 @@ executable cabal-tests
   import: shared
   main-is: cabal-tests.hs
   hs-source-dirs: main
-  ghc-options: -threaded -rtsopts -fforce-recomp
+  ghc-options: -threaded -rtsopts
   -- Make sure these are built before the executable is run
   build-tool-depends: cabal-testsuite:test-runtime-deps
   build-depends:


### PR DESCRIPTION
Forgot to remove the merge label while testing if the cache was interfering with the Windows fix. (Flip side, that _should_ have fixed the cache, I hope.) Remove the `-fforce-recomp` on `cabal-testsuite` that shouldn't have been merged.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
