### PR TITLE
Comment workflows and Mergify config a bit better

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,5 +1,6 @@
-# Note: We do not use the rebase strategy to merge PRs, because that
-# loses information needed by changelog-d to associate commits with PRs.
+# Note: We do not use the rebase or fast-forward strategies to merge PRs,
+# because that loses information needed by changelog-d to associate commits
+# with PRs.
 
 pull_request_rules:
 
@@ -11,6 +12,8 @@ pull_request_rules:
           - merge delay passed
     name: Wait for 2 days before validating merge
     conditions:
+      # nobody seeems to know why this conditional is reversed, but
+      # it works.
       - updated-at<2 days ago
       - or:
         - label=merge me
@@ -19,6 +22,8 @@ pull_request_rules:
       - '#approved-reviews-by>=2'
 
   # label when Mergify is ready but waiting for the above
+  # the bot reports these in #hackage:matrix.org, plus it's a
+  # useful way to track PR progress
   - actions:
       label:
         add:
@@ -69,6 +74,9 @@ pull_request_rules:
       - '-label~=^blocked:'
 
   # merge+no rebase strategy
+  # use this only in cases where the normal merge workflow won't work, as
+  # when a PR is from an organization account and we don't have permissions
+  # on it so can't rebase. IMPORTANT: THE PR OWNER MUST REBASE MANUALLY.
   - actions:
       merge:
         method: merge

--- a/.github/workflows/bootstrap.skip.yml
+++ b/.github/workflows/bootstrap.skip.yml
@@ -1,18 +1,6 @@
 name: Bootstrap Skip
 
-# This Workflow is special and contains a workaround for a known limitation of GitHub CI.
-#
-# The problem: We don't want to run the "bootstrap" jobs on PRs which contain only changes
-# to the docs, since these jobs take a long time to complete without providing any benefit.
-# We therefore use path-filtering in the workflow triggers for the bootstrap jobs, namely
-# "paths-ignore: doc/**". But the "Bootstrap post job" is a required job, therefore a PR cannot
-# be merged unless the "Bootstrap post job" completes succesfully, which it doesn't do if we
-# filter it out.
-#
-# The solution: We use a second job with the same name which always returns the exit code 0.
-# The logic implemented for "required" workflows accepts if 1) at least one job with that name
-# runs through, AND 2) If multiple jobs of that name exist, then all jobs of that name have to
-# finish successfully.
+# See validate.skip.yml for details of why this workflow is necessary.
 on:
   push:
     paths:
@@ -41,6 +29,7 @@ on:
 
 jobs:
   bootstrap-post-job:
+    # NB. the conditional overrides workflow cancellation
     if: always()
     name: Bootstrap post job
     runs-on: ubuntu-latest

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -7,7 +7,7 @@ concurrency:
 
 # Note: This workflow file contains the required job "Bootstrap post job". We are using path filtering
 # here to ignore PRs which only change documentation. This can cause a problem, see the workflow file
-# "bootstrap.skip.yml" for a description of the problem and the solution provided in that file.
+# "validate.skip.yml" for a description of the problem and the solution provided in that file.
 on:
   push:
     paths-ignore:
@@ -88,6 +88,7 @@ jobs:
   # This way we can use it exclusively in branch protection rules
   # and abstract away the concrete jobs of the workflow, including their names
   bootstrap-post-job:
+    # This conditional overrides job cancellation
     if: always()
     name: Bootstrap post job
     runs-on: ubuntu-latest

--- a/.github/workflows/quick-jobs.yml
+++ b/.github/workflows/quick-jobs.yml
@@ -85,7 +85,7 @@ jobs:
       # It is complicated to get a proper cache key for the dependencies of a package
       # (here: doctest) that we just `cabal install`.
       # So, as a heuristics we update the cache once per day.
-      # Updating it with each run would be an alternative, but we a short of cache space,
+      # Updating it with each run would be an alternative, but we are short of cache space,
       # and this would generate too many new caches.
       - name: Use date as cache key
         run: |
@@ -145,6 +145,7 @@ jobs:
         run: make doc/buildinfo-fields-reference.rst
       - name: Cache dependencies
         uses: actions/cache/save@v4
+        # 'always()' here overrides job cancellation
         if: always() && steps.cache.outputs.cache-hit != 'true'
         with:
           path: ~/.local/state/cabal

--- a/.github/workflows/validate.skip.yml
+++ b/.github/workflows/validate.skip.yml
@@ -41,6 +41,7 @@ on:
 
 jobs:
   validate-post-job:
+    # 'always()' makes this run even if the job is cancelled
     if: always()
     name: Validate post job
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -74,7 +74,7 @@ jobs:
           - { os: ubuntu-latest, shell: bash }
           - { os: macos-13, shell: bash }
         # If you remove something from here, then add it to the old-ghcs job.
-        # Also a removed GHC from here means that we are actually dropping
+        # Also removing a GHC from here means that we are actually dropping
         # support, so the PR *must* have a changelog entry.
         ghc:
           [
@@ -105,7 +105,7 @@ jobs:
       run:
         shell: ${{ matrix.sys.shell }}
     steps:
-      - name: Work around XDG directories existence (haskell-actions/setup#62)
+      - name: Work around the existence of XDG directories (haskell-actions/setup#62)
         if: runner.os == 'macOS'
         run: |
           rm -rf ~/.config/cabal
@@ -203,7 +203,8 @@ jobs:
           tar -czvf "$CABAL_EXEC_TAR" -C "$DIR" "$FILE"
           echo "CABAL_EXEC_TAR=$CABAL_EXEC_TAR" >> "$GITHUB_ENV"
 
-      # We upload the cabal executable built with the ghc used in the release for:
+      # We upload the cabal executable built with the ghc used in the release so
+      # we can:
       # - Reuse it in the dogfooding job (although we could use the cached build dir)
       # - Make it available in the workflow to make easier testing it locally
       - name: Upload cabal-install executable to workflow artifacts
@@ -262,6 +263,7 @@ jobs:
         run: ghcup install ghc ${{ matrix.extra-ghc }}
 
       - name: GHCup logs
+        # 'always()' here overrides workflow cancellation. (Is it needed here?)
         if: always()
         run: cat /usr/local/.ghcup/logs/*
 
@@ -369,7 +371,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        # We only use one ghc version the used one for the next release (defined at top of the workflow)
+        # We only use the ghc version used for the next release (defined at top of the workflow)
         # We need to build an array dynamically to inject the appropiate env var in a previous job,
         # see https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
         ghc: ${{ fromJSON (needs.validate.outputs.GHC_FOR_RELEASE) }}
@@ -401,7 +403,7 @@ jobs:
       - name: print-config using cabal HEAD
         run: sh validate.sh ${{ env.COMMON_FLAGS }} --with-cabal ./cabal-head/cabal -s print-config
 
-      # We dont use cache to force a build with a fresh store dir and build dir
+      # We don't use cache to force a build with a fresh store dir and build dir
       # This way we check cabal can build all its dependencies
       - name: Build using cabal HEAD
         run: sh validate.sh ${{ env.COMMON_FLAGS }} --with-cabal ./cabal-head/cabal -s build
@@ -449,6 +451,7 @@ jobs:
   # This way we can use it exclusively in branch protection rules
   # and abstract away the concrete jobs of the workflow, including their names
   validate-post-job:
+    # 'always()' overrides workflow cancellation
     if: always()
     name: Validate post job
     runs-on: ubuntu-latest


### PR DESCRIPTION
If you have any "favorite" confusing places in the workflows or Mergify config, please comment on them here so I can try to do something about them. Also, I need some clarification myself, in particular on why we're redundantly using `always()` in a number of places and why it seems to be important to use it on doc-skip post jobs when cancellation will correctly fail the workflow and post-job anyway.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* ~~[ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ it's just comments, not worth it unless we think it'll lead to merge conflicts later
