### PR TITLE
Create temp files in temp directory

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -124,6 +124,11 @@ jobs:
           rm -rf ~/.config/cabal
           rm -rf ~/.cache/cabal
 
+      - name: "WIN: Setup TMP environment variable"
+        if: runner.os == 'Windows'
+        run: |
+           echo "TMP=${{ runner.temp }}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
 
       # See https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#hackage-revisions
@@ -396,7 +401,6 @@ jobs:
         # We need to build an array dynamically to inject the appropiate env var in a previous job,
         # see https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson
         ghc: ${{ fromJSON (needs.validate.outputs.GHC_FOR_RELEASE) }}
-
     defaults:
       run:
         shell: ${{ matrix.sys.shell }}
@@ -413,11 +417,16 @@ jobs:
           esac
           echo "CABAL_ARCH=$arch" >> "$GITHUB_ENV"
 
-      - name: Work around XDG directories existence (haskell-actions/setup#62)
+      - name: "MAC: Work around XDG directories existence (haskell-actions/setup#62)"
         if: runner.os == 'macOS'
         run: |
           rm -rf ~/.config/cabal
           rm -rf ~/.cache/cabal
+
+      - name: "WIN: Setup TMP environment variable"
+        if: runner.os == 'Windows'
+        run: |
+           echo "TMP=${{ runner.temp }}" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@v4
 

--- a/Cabal-tests/tests/UnitTests/Distribution/Simple/Utils.hs
+++ b/Cabal-tests/tests/UnitTests/Distribution/Simple/Utils.hs
@@ -23,16 +23,14 @@ import Test.Tasty.HUnit
 withTempFileTest :: Assertion
 withTempFileTest = do
   fileName <- newIORef ""
-  tempDir  <- getTemporaryDirectory
-  withTempFile tempDir ".foo" $ \fileName' _handle -> do
+  withTempFile ".foo" $ \fileName' _handle -> do
     writeIORef fileName fileName'
   fileExists <- readIORef fileName >>= doesFileExist
   assertBool "Temporary file not deleted by 'withTempFile'!" (not fileExists)
 
 withTempFileRemovedTest :: Assertion
 withTempFileRemovedTest = do
-  tempDir <- getTemporaryDirectory
-  withTempFile tempDir ".foo" $ \fileName handle -> do
+  withTempFile ".foo" $ \fileName handle -> do
     hClose handle
     removeFile fileName
 
@@ -58,9 +56,8 @@ rawSystemStdInOutTextDecodingTest ghcPath
     -- so skip the test if it's not.
     | show localeEncoding /= "UTF-8" = return ()
     | otherwise = do
-  tempDir  <- getTemporaryDirectory
-  res <- withTempFile tempDir ".hs" $ \filenameHs handleHs -> do
-    withTempFile tempDir ".exe" $ \filenameExe handleExe -> do
+  res <- withTempFile ".hs" $ \filenameHs handleHs -> do
+    withTempFile ".exe" $ \filenameExe handleExe -> do
       -- Small program printing not utf8
       hPutStrLn handleHs "import Data.ByteString"
       hPutStrLn handleHs "main = Data.ByteString.putStr (Data.ByteString.pack [32, 32, 255])"

--- a/Cabal/src/Distribution/Simple/Configure.hs
+++ b/Cabal/src/Distribution/Simple/Configure.hs
@@ -156,7 +156,6 @@ import System.Directory
   ( canonicalizePath
   , createDirectoryIfMissing
   , doesFileExist
-  , getTemporaryDirectory
   , removeFile
   )
 import System.FilePath
@@ -2693,10 +2692,9 @@ checkForeignDeps pkg lbi verbosity =
 
     builds :: String -> [ProgArg] -> IO Bool
     builds program args =
-      do
-        tempDir <- makeSymbolicPath <$> getTemporaryDirectory
-        withTempFileCwd mbWorkDir tempDir ".c" $ \cName cHnd ->
-          withTempFileCwd mbWorkDir tempDir "" $ \oNname oHnd -> do
+      withTempFileCwd ".c" $ \cName cHnd ->
+        withTempFileCwd "" $ \oNname oHnd ->
+          do
             hPutStrLn cHnd program
             hClose cHnd
             hClose oHnd
@@ -2708,8 +2706,8 @@ checkForeignDeps pkg lbi verbosity =
                 (withPrograms lbi)
                 (getSymbolicPath cName : "-o" : getSymbolicPath oNname : args)
             return True
-        `catchIO` (\_ -> return False)
-        `catchExit` (\_ -> return False)
+            `catchIO` (\_ -> return False)
+            `catchExit` (\_ -> return False)
 
     explainErrors Nothing [] = return () -- should be impossible!
     explainErrors _ _

--- a/Cabal/src/Distribution/Simple/GHC/Internal.hs
+++ b/Cabal/src/Distribution/Simple/GHC/Internal.hs
@@ -85,7 +85,7 @@ import Distribution.Utils.Path
 import Distribution.Verbosity
 import Distribution.Version (Version)
 import Language.Haskell.Extension
-import System.Directory (getDirectoryContents, getTemporaryDirectory)
+import System.Directory (getDirectoryContents)
 import System.Environment (getEnv)
 import System.FilePath
   ( takeDirectory
@@ -221,9 +221,8 @@ configureToolchain _implInfo ghcProg ghcInfo =
     -- we need to find out if ld supports the -x flag
     configureLd' :: Verbosity -> ConfiguredProgram -> IO ConfiguredProgram
     configureLd' verbosity ldProg = do
-      tempDir <- getTemporaryDirectory
-      ldx <- withTempFile tempDir ".c" $ \testcfile testchnd ->
-        withTempFile tempDir ".o" $ \testofile testohnd -> do
+      ldx <- withTempFile ".c" $ \testcfile testchnd ->
+        withTempFile ".o" $ \testofile testohnd -> do
           hPutStrLn testchnd "int foo() { return 0; }"
           hClose testchnd
           hClose testohnd
@@ -236,7 +235,7 @@ configureToolchain _implInfo ghcProg ghcInfo =
             , "-o"
             , testofile
             ]
-          withTempFile tempDir ".o" $ \testofile' testohnd' ->
+          withTempFile ".o" $ \testofile' testohnd' ->
             do
               hClose testohnd'
               _ <-

--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -1133,8 +1133,6 @@ renderArgs verbosity mbWorkDir tmpFileOpts version comp platform args k = do
                 withResponseFile
                   verbosity
                   tmpFileOpts
-                  mbWorkDir
-                  outputDir
                   "haddock-response.txt"
                   (if haddockSupportsUTF8 then Just utf8 else Nothing)
                   renderedArgs
@@ -1144,7 +1142,7 @@ renderArgs verbosity mbWorkDir tmpFileOpts version comp platform args k = do
     (Flag pfile, _) ->
       withPrologueArgs ["--prologue=" ++ pfile]
     (_, Flag prologueText) ->
-      withTempFileEx tmpFileOpts mbWorkDir outputDir "haddock-prologue.txt" $
+      withTempFileEx tmpFileOpts "haddock-prologue.txt" $
         \prologueFileName h -> do
           when haddockSupportsUTF8 (hSetEncoding h utf8)
           hPutStrLn h prologueText

--- a/Cabal/src/Distribution/Simple/PreProcess.hs
+++ b/Cabal/src/Distribution/Simple/PreProcess.hs
@@ -511,8 +511,6 @@ ppHsc2hs bi lbi clbi =
             withResponseFile
               verbosity
               defaultTempFileOptions
-              mbWorkDir
-              (makeSymbolicPath $ takeDirectory outFile)
               "hsc2hs-response.txt"
               Nothing
               pureArgs

--- a/Cabal/src/Distribution/Simple/Program/Ar.hs
+++ b/Cabal/src/Distribution/Simple/Program/Ar.hs
@@ -154,7 +154,7 @@ createArLibArchive verbosity lbi targetPath files = do
                 (initial, middle, final)
                 (map getSymbolicPath files)
           ]
-      else withResponseFile verbosity defaultTempFileOptions mbWorkDir tmpDir "ar.rsp" Nothing (map getSymbolicPath files) $
+      else withResponseFile verbosity defaultTempFileOptions "ar.rsp" Nothing (map getSymbolicPath files) $
         \path -> runProgramInvocation verbosity $ invokeWithResponseFile path
 
     unless

--- a/Cabal/src/Distribution/Simple/Program/Ld.hs
+++ b/Cabal/src/Distribution/Simple/Program/Ld.hs
@@ -83,8 +83,6 @@ combineObjectFiles verbosity lbi ldProg target files = do
     middle = ld middleArgs
     final = ld finalArgs
 
-    targetDir = takeDirectorySymbolicPath target
-
     invokeWithResponseFile :: FilePath -> ProgramInvocation
     invokeWithResponseFile atFile =
       ld $ simpleArgs ++ ['@' : atFile]
@@ -106,7 +104,7 @@ combineObjectFiles verbosity lbi ldProg target files = do
 
   if oldVersionManualOverride || responseArgumentsNotSupported
     then run $ multiStageProgramInvocation simple (initial, middle, final) (map getSymbolicPath files)
-    else withResponseFile verbosity defaultTempFileOptions mbWorkDir targetDir "ld.rsp" Nothing (map getSymbolicPath files) $
+    else withResponseFile verbosity defaultTempFileOptions "ld.rsp" Nothing (map getSymbolicPath files) $
       \path -> runProgramInvocation verbosity $ invokeWithResponseFile path
   where
     tmpfile = target <.> "tmp" -- perhaps should use a proper temp file

--- a/Cabal/src/Distribution/Simple/Program/ResponseFile.hs
+++ b/Cabal/src/Distribution/Simple/Program/ResponseFile.hs
@@ -27,10 +27,6 @@ import Distribution.Verbosity
 withResponseFile
   :: Verbosity
   -> TempFileOptions
-  -> Maybe (SymbolicPath CWD (Dir Pkg))
-  -- ^ Working directory
-  -> SymbolicPath Pkg (Dir Response)
-  -- ^ Directory to create response file in.
   -> String
   -- ^ Template for response file name.
   -> Maybe TextEncoding
@@ -39,8 +35,8 @@ withResponseFile
   -- ^ Arguments to put into response file.
   -> (FilePath -> IO a)
   -> IO a
-withResponseFile verbosity tmpFileOpts mbWorkDir responseDir fileNameTemplate encoding arguments f =
-  withTempFileEx tmpFileOpts mbWorkDir responseDir fileNameTemplate $ \responsePath hf -> do
+withResponseFile verbosity tmpFileOpts fileNameTemplate encoding arguments f =
+  withTempFileEx tmpFileOpts fileNameTemplate $ \responsePath hf -> do
     let responseFileName = getSymbolicPath responsePath
     traverse_ (hSetEncoding hf) encoding
     let responseContents =

--- a/cabal-install/src/Distribution/Client/HttpUtils.hs
+++ b/cabal-install/src/Distribution/Client/HttpUtils.hs
@@ -467,7 +467,6 @@ curlTransport prog =
   where
     gethttp verbosity uri etag destPath reqHeaders = do
       withTempFile
-        (takeDirectory destPath)
         "curl-headers.txt"
         $ \tmpFile tmpHandle -> do
           hClose tmpHandle
@@ -675,10 +674,9 @@ wgetTransport prog =
 
     posthttpfile verbosity uri path auth =
       withTempFile
-        (takeDirectory path)
         (takeFileName path)
         $ \tmpFile tmpHandle ->
-          withTempFile (takeDirectory path) "response" $
+          withTempFile "response" $
             \responseFile responseHandle -> do
               hClose responseHandle
               (body, boundary) <- generateMultipartBody path
@@ -702,7 +700,7 @@ wgetTransport prog =
                 evaluate $ force (code, resp)
 
     puthttpfile verbosity uri path auth headers =
-      withTempFile (takeDirectory path) "response" $
+      withTempFile "response" $
         \responseFile responseHandle -> do
           hClose responseHandle
           let args =
@@ -824,7 +822,6 @@ powershellTransport prog =
 
     posthttpfile verbosity uri path auth =
       withTempFile
-        (takeDirectory path)
         (takeFileName path)
         $ \tmpFile tmpHandle -> do
           (body, boundary) <- generateMultipartBody path

--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.test.hs
@@ -2,7 +2,7 @@ import Test.Cabal.Prelude
 
 main = cabalTest $ do
     skipUnlessGhcVersion ">= 8.1"
-    expectBrokenIfWindowsCI 10191 $ withProjectFile "cabal.internal.project" $ do
+    withProjectFile "cabal.internal.project" $ do
         cabal "v2-build" ["exe"]
         withPlan $ do
             r <- runPlanExe' "I" "exe" []

--- a/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-external.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-external.test.hs
@@ -2,8 +2,6 @@ import Test.Cabal.Prelude
 
 main = cabalTest $ do
     skipUnlessGhcVersion ">= 8.1"
-    ghcVer <- isGhcVersion ">= 9.10"
-    skipIf "Windows + 9.10.1 (#10191)" (isWindows && ghcVer)
     withProjectFile "cabal.external.project" $ do
         cabal "v2-build" ["exe"]
         withPlan $ do

--- a/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-internal.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-internal.test.hs
@@ -2,7 +2,7 @@ import Test.Cabal.Prelude
 
 main = cabalTest $ do
     skipUnlessGhcVersion ">= 8.1"
-    expectBrokenIfWindowsCI 10191 $ withProjectFile "cabal.internal.project" $ do
+    withProjectFile "cabal.internal.project" $ do
         cabal "v2-build" ["exe"]
         withPlan $ do
             r <- runPlanExe' "I" "exe" []

--- a/cabal-testsuite/PackageTests/Backpack/T6385/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T6385/cabal.test.hs
@@ -1,6 +1,6 @@
 import Test.Cabal.Prelude
 main =
-  cabalTest $ expectBrokenIfWindows 10191 $ withShorterPathForNewBuildStore $ do
+  cabalTest $ withShorterPathForNewBuildStore $ do
     skipUnlessGhcVersion ">= 8.1"
     withRepo "repo" $ do
       cabal "v2-build" ["T6385"]

--- a/cabal-testsuite/PackageTests/HaddockKeepsTmps/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockKeepsTmps/cabal.test.hs
@@ -1,21 +1,23 @@
 {-# LANGUAGE LambdaCase #-}
 import Test.Cabal.Prelude
-import Data.List (sort)
+import Data.List (sort, isPrefixOf)
 import Distribution.Verbosity
 import Distribution.Simple.Glob
 import Distribution.Simple.Glob.Internal
 import Distribution.Simple.Utils
+import System.Directory
 
 -- Test that "cabal haddock" preserves temporary files
 -- We use haddock-keep-temp-file: True in the cabal.project.
-main = cabalTest $ recordMode DoNotRecord $ withProjectFile "cabal.project" $ do
-    cabal "haddock" []
-
-    cwd <- fmap testCurrentDir getTestEnv
-
-    -- Windows has multiple response files, and only the last one (alphabetically) is the important one.
-    (safeLast . sort . globMatches <$> liftIO (runDirFileGlob silent Nothing cwd (GlobDirRecursive [WildCard, Literal "txt"]))) >>= \case
-      Nothing -> error "Expecting a response file to exist"
-      Just m -> do
-        -- Assert the matched response file is not empty, and indeed a haddock rsp
-        assertFileDoesContain (cwd </> m) "--package-name"
+main =
+  cabalTest $ recordMode DoNotRecord $ withProjectFile "cabal.project" $ do
+      pwd <- testTmpDir <$> getTestEnv
+      liftIO $ createDirectory (pwd </> "temp")
+      withEnv [(if isWindows then "TMP" else "TMPDIR", Just $ pwd </> "temp")] $
+        cabal "haddock" []
+      files <- liftIO $ listDirectory (pwd </> "temp")
+      case [ pwd </> "temp" </> f | f <- files, takeExtension f == ".txt" ] of
+        [] -> error "Expecting a response file being mentioned in the outcome"
+        files' ->
+          -- Assert the matched response file is not empty, and indeed a haddock rsp
+          assertAnyFileContains files' "--package-name"


### PR DESCRIPTION
## TL;DR

This change ensures all temporal files are created in the system temp directory which usually is in a short path. This helps with Windows not being capable of creating temp files in long directories, like the ones that result from Backpack.

## Description 

To be precise, purely temporary files (ghc intermediate files, rsps, etc) were already created in this system temporary directory, because the code called `withTempFile` always with the result from `getTemporaryDirectory`. I just made it so that the user doesn't even have the option to provide a different directory now.

And the other case is the `writeFileAtomic` function which used to create temporary files already in the destination directory and then rename them. If the destination directory was a long path, this would fail on Windows. This function now creates the temp file in the temp directory too.

Note that the "system temporary directory" is what `getTemporaryDirectory` returns which can be controlled via environment variables as `$TMPDIR`. See [`getTemporaryDirectory` haddocks](https://hackage.haskell.org/package/directory-1.3.8.5/docs/System-Directory.html#v:getTemporaryDirectory).

## Reference

See how [GetTempFileNameW](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettempfilenamew) specifies:

> The string cannot be longer than MAX_PATH–14 characters or GetTempFileName
will fail.

And actually there is a TODO in `Win32Utils.c` in GHC:

https://gitlab.haskell.org/ghc/ghc/-/blob/3939a8bf93e27d8151aa1d92bf3ce10bbbc96a72/libraries/ghc-internal/cbits/Win32Utils.c#L259

Therefore Windows cannot create temporary files in long paths. To be precise, it can do so if using `--io-manager=native` but this is not yet the default and it seems reasonable to not make people face other complications that might arise from using that always, even more if it is as easy as creating the temp files somewhere else.

------------------

Closes #10191.

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. *No new tests are needed as most of them already create temp files*