### PR TITLE
make LTS branch pre-releases

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -444,6 +444,52 @@ jobs:
             cabal-head-Linux-static-x86_64.tar.gz
             cabal-head-macOS-x86_64.tar.gz
 
+  prerelease-lts:
+    name: Create a GitHub LTS prerelease with the binary artifacts
+    runs-on: ubuntu-latest
+    # The LTS branch is hardcoded for now, update it on a new LTS!
+    if: github.ref == 'refs/heads/3.12'
+
+    # IMPORTANT! Any job added to the workflow should be added here too
+    needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
+
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: cabal-Windows-x86_64
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: cabal-Linux-x86_64
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: cabal-Linux-static-x86_64
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: cabal-macOS-x86_64
+
+    - run: |
+        # bash-ism, but we forced bash above
+        mv cabal-{,lts-}head-Windows-x86_64.tar.gz
+        mv cabal-{,lts-}head-Linux-x86_64.tar.gz
+        mv cabal-{,lts-}head-Linux-static-x86_64.tar.gz
+        mv cabal-{,lts-}head-macOS-x86_64.tar.gz
+
+    - name: Create GitHub prerelease
+      uses: marvinpinto/action-automatic-releases@v1.2.1
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        automatic_release_tag: cabal-lts-head
+        prerelease: true
+        title: cabal-lts-head
+        files: |
+          cabal-lts-head-Windows-x86_64.tar.gz
+          cabal-lts-head-Linux-x86_64.tar.gz
+          cabal-lts-head-Linux-static-x86_64.tar.gz
+          cabal-lts-head-macOS-x86_64.tar.gz
+
   # We use this job as a summary of the workflow
   # It will fail if any of the previous jobs does
   # This way we can use it exclusively in branch protection rules


### PR DESCRIPTION
This is pretty much a copy of the HEAD pre-release with "lts" added.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). (NB. backport to 3.14 is optional, since it's not an LTS branch; 3.12 needs to get it)
