### PR TITLE
add Makefile targets for fix-whitespace

### DIFF
--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -7,10 +7,21 @@ on:
 
 jobs:
   whitespace:
+    defaults:
+      run:
+        shell: bash
     runs-on: ubuntu-latest
 
     steps:
+
     - uses: actions/checkout@v4
-    - uses: andreasabel/fix-whitespace-action@v1
-      with:
-        verbose:    true
+
+    - run: |
+        # no longer using the action because apparently we're supposed to use the Makefile here
+        wget -q https://github.com/agda/fix-whitespace/releases/download/v0.1/fix-whitespace-0.1-linux.binary
+        mkdir -p "$HOME/.local/bin"
+        mv fix-whitespace-0.1-linux.binary "$HOME/.local/bin/fix-whitespace"
+        chmod +x "$HOME/.local/bin/fix-whitespace"
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - run: make whitespace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,9 @@ the code base.
 
 We use automated whitespace convention checking. Violations can be fixed by
 running [fix-whitespace](https://hackage.haskell.org/package/fix-whitespace). If
-you push a fix of a whitespace violation, please do so in a _separate commit_.
+you push a fix of a whitespace violation, please do so in a _separate commit_. For convenience,
+`make whitespace` will show violations and `make fix-whitespace` will fix them, if the
+`fix-whitespace` utility is installed.
 
 ## Other Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,14 @@ style-commit: ## Run the code styler on the previous commit
 	@git diff --name-only HEAD $(COMMIT) Cabal Cabal-syntax cabal-install \
 		| grep '.hs$$' | xargs -P $(PROCS) -I {} fourmolu -q -i {}
 
+.PHONY: whitespace
+whitespace: ## Run fix-whitespace in check mode
+	fix-whitespace --check --verbose
+
+.PHONY: fix-whitespace
+fix-whitespace: ## Run fix-whitespace in fix mode
+	fix-whitespace --verbose
+
 # source generation: SPDX
 
 SPDX_LICENSE_HS:=Cabal-syntax/src/Distribution/SPDX/LicenseId.hs


### PR DESCRIPTION
`make whitespace` now runs `fix-whitespace --check --verbose` and `make fix-whitespace` runs `fix-whitespace --verbose`. You will need to install `fix-whitespace` yourself, but that's just a `cabal install` away.

This is another step in the direction of fixing #10263.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
