### PR TITLE
Fix `withFileContents` documentation (lazy IO strikes again)

### DIFF
--- a/Cabal-syntax/src/Distribution/Utils/Generic.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Generic.hs
@@ -153,8 +153,8 @@ wrapLine width = wrap 0 []
 
 -- | Gets the contents of a file, but guarantee that it gets closed.
 --
--- The file is read lazily but if it is not fully consumed by the action then
--- the remaining input is truncated and the file is closed.
+-- The file is read lazily; if it is not fully consumed by the action then an
+-- exception is thrown.
 withFileContents :: FilePath -> (String -> IO a) -> IO a
 withFileContents name action =
   withFile


### PR DESCRIPTION
The documentation for `Distribution.Utils.Generic.withFileContents` is incorrect:

```
$ cabal repl Cabal-syntax
ghci> import Distribution.Utils.Generic
ghci> withFileContents "README.md" $ \contents -> pure ("foo" `isInfixOf` contents)
*** Exception: README.md: hGetContents: illegal operation (delayed read on closed handle)
```

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
