### PR TITLE
Add `haddock --keep-temp-files` test

### DIFF
--- a/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/Setup.hs
+++ b/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple
+
+main = defaultMain

--- a/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/Simple.hs
+++ b/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/Simple.hs
@@ -1,0 +1,4 @@
+module Simple where
+
+-- | For hiding needles.
+data Haystack = Haystack

--- a/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/cabal.project
+++ b/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/cabal.project
@@ -1,0 +1,3 @@
+packages: .
+
+haddock-keep-temp-files: true

--- a/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/cabal.test.hs
@@ -1,0 +1,22 @@
+import Test.Cabal.Prelude
+
+-- Test that "cabal haddock" preserves temporary files
+-- We use haddock-keep-temp-file: True in the cabal.project.
+main = cabalTest $ recordMode DoNotRecord $ withProjectFile "cabal.project" $ do
+  cabal "haddock" []
+
+  -- From the docs for `System.IO.openTempFile`:
+  --
+  --   On Windows, the template prefix may be truncated to 3 chars, e.g.
+  --   "foobar.ext" will be "fooXXX.ext".
+  let glob =
+        if isWindows
+          then "**/had*.txt"
+          else "**/haddock-response*.txt"
+
+  -- Check that there is a response file.
+  responseFiles <- assertGlobMatchesTestDir testDistDir glob
+
+  -- Check that the matched response file is not empty, and is indeed a Haddock
+  -- response file.
+  assertAnyFileContains responseFiles "--package-name"

--- a/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/my.cabal
+++ b/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/my.cabal
@@ -1,0 +1,16 @@
+cabal-version: 3.0
+name: HaddockKeepsTmpsCustom
+version: 0.1
+license: BSD-3-Clause
+author: Rodrigo Mesquita
+stability: stable
+category: PackageTests
+build-type: Custom
+
+custom-setup
+    setup-depends: Cabal, base
+
+library
+    default-language: Haskell2010
+    exposed-modules: Simple
+    build-depends: base


### PR DESCRIPTION
Split off of https://github.com/haskell/cabal/pull/10292

Thanks to @mpickering for helping with this test case.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

Depends-on: #10388