### PR TITLE
`haddock-project`: add `CommonSetupFlags`

### DIFF
--- a/Cabal/src/Distribution/Simple/Setup/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Setup/Haddock.hs
@@ -413,7 +413,8 @@ data Visibility = Visible | Hidden
   deriving (Eq, Show)
 
 data HaddockProjectFlags = HaddockProjectFlags
-  { haddockProjectHackage :: Flag Bool
+  { haddockProjectCommonFlags :: !CommonSetupFlags
+  , haddockProjectHackage :: Flag Bool
   -- ^ a shortcut option which builds documentation linked to hackage.  It implies:
   -- * `--html-location='https://hackage.haskell.org/package/$prg-$version/docs'
   -- * `--quickjump`
@@ -457,7 +458,8 @@ data HaddockProjectFlags = HaddockProjectFlags
 defaultHaddockProjectFlags :: HaddockProjectFlags
 defaultHaddockProjectFlags =
   HaddockProjectFlags
-    { haddockProjectHackage = Flag False
+    { haddockProjectCommonFlags = defaultCommonSetupFlags
+    , haddockProjectHackage = Flag False
     , haddockProjectDir = Flag "./haddocks"
     , haddockProjectPrologue = NoFlag
     , haddockProjectTestSuites = Flag False
@@ -517,140 +519,141 @@ haddockProjectCommand =
           emptyProgramDb
 
 haddockProjectOptions :: ShowOrParseArgs -> [OptionField HaddockProjectFlags]
-haddockProjectOptions _showOrParseArgs =
-  [ option
-      ""
-      ["hackage"]
-      ( concat
-          [ "A short-cut option to build documentation linked to hackage."
-          ]
-      )
-      haddockProjectHackage
-      (\v flags -> flags{haddockProjectHackage = v})
-      trueArg
-  , option
-      ""
-      ["output"]
-      "Output directory"
-      haddockProjectDir
-      (\v flags -> flags{haddockProjectDir = v})
-      (optArg' "DIRECTORY" maybeToFlag (fmap Just . flagToList))
-  , option
-      ""
-      ["prologue"]
-      "File path to a prologue file in haddock format"
-      haddockProjectPrologue
-      (\v flags -> flags{haddockProjectPrologue = v})
-      (optArg' "PATH" maybeToFlag (fmap Just . flagToList))
-  , option
-      ""
-      ["hoogle"]
-      "Generate a hoogle database"
-      haddockProjectHoogle
-      (\v flags -> flags{haddockProjectHoogle = v})
-      trueArg
-  , option
-      ""
-      ["html-location"]
-      "Location of HTML documentation for pre-requisite packages"
-      haddockProjectHtmlLocation
-      (\v flags -> flags{haddockProjectHtmlLocation = v})
-      (reqArgFlag "URL")
-  , option
-      ""
-      ["executables"]
-      "Run haddock for Executables targets"
-      haddockProjectExecutables
-      (\v flags -> flags{haddockProjectExecutables = v})
-      trueArg
-  , option
-      ""
-      ["tests"]
-      "Run haddock for Test Suite targets"
-      haddockProjectTestSuites
-      (\v flags -> flags{haddockProjectTestSuites = v})
-      trueArg
-  , option
-      ""
-      ["benchmarks"]
-      "Run haddock for Benchmark targets"
-      haddockProjectBenchmarks
-      (\v flags -> flags{haddockProjectBenchmarks = v})
-      trueArg
-  , option
-      ""
-      ["foreign-libraries"]
-      "Run haddock for Foreign Library targets"
-      haddockProjectForeignLibs
-      (\v flags -> flags{haddockProjectForeignLibs = v})
-      trueArg
-  , option
-      ""
-      ["all", "haddock-all"]
-      "Run haddock for all targets"
-      ( \f ->
-          allFlags
-            [ haddockProjectExecutables f
-            , haddockProjectTestSuites f
-            , haddockProjectBenchmarks f
-            , haddockProjectForeignLibs f
+haddockProjectOptions showOrParseArgs =
+  withCommonSetupOptions
+    haddockProjectCommonFlags
+    (\c f -> f{haddockProjectCommonFlags = c})
+    showOrParseArgs
+    [ option
+        ""
+        ["hackage"]
+        ( concat
+            [ "A short-cut option to build documentation linked to hackage."
             ]
-      )
-      ( \v flags ->
-          flags
-            { haddockProjectExecutables = v
-            , haddockProjectTestSuites = v
-            , haddockProjectBenchmarks = v
-            , haddockProjectForeignLibs = v
-            }
-      )
-      trueArg
-  , option
-      ""
-      ["internal"]
-      "Run haddock for internal modules and include all symbols"
-      haddockProjectInternal
-      (\v flags -> flags{haddockProjectInternal = v})
-      trueArg
-  , option
-      ""
-      ["css"]
-      "Use PATH as the haddock stylesheet"
-      haddockProjectCss
-      (\v flags -> flags{haddockProjectCss = v})
-      (reqArgFlag "PATH")
-  , option
-      ""
-      ["hscolour-css"]
-      "Use PATH as the HsColour stylesheet"
-      haddockProjectHscolourCss
-      (\v flags -> flags{haddockProjectHscolourCss = v})
-      (reqArgFlag "PATH")
-  , option
-      ""
-      ["keep-temp-files"]
-      "Keep temporary files"
-      haddockProjectKeepTempFiles
-      (\b flags -> flags{haddockProjectKeepTempFiles = b})
-      trueArg
-  , optionVerbosity
-      haddockProjectVerbosity
-      (\v flags -> flags{haddockProjectVerbosity = v})
-  , option
-      ""
-      ["resources-dir"]
-      "location of Haddocks static / auxiliary files"
-      haddockProjectResourcesDir
-      (\v flags -> flags{haddockProjectResourcesDir = v})
-      (reqArgFlag "DIR")
-  , option
-      ""
-      ["use-unicode"]
-      "Pass --use-unicode option to haddock"
-      haddockProjectUseUnicode
-      (\v flags -> flags{haddockProjectUseUnicode = v})
-      trueArg
-  ]
+        )
+        haddockProjectHackage
+        (\v flags -> flags{haddockProjectHackage = v})
+        trueArg
+    , option
+        ""
+        ["output"]
+        "Output directory"
+        haddockProjectDir
+        (\v flags -> flags{haddockProjectDir = v})
+        (optArg' "DIRECTORY" maybeToFlag (fmap Just . flagToList))
+    , option
+        ""
+        ["prologue"]
+        "File path to a prologue file in haddock format"
+        haddockProjectPrologue
+        (\v flags -> flags{haddockProjectPrologue = v})
+        (optArg' "PATH" maybeToFlag (fmap Just . flagToList))
+    , option
+        ""
+        ["hoogle"]
+        "Generate a hoogle database"
+        haddockProjectHoogle
+        (\v flags -> flags{haddockProjectHoogle = v})
+        trueArg
+    , option
+        ""
+        ["html-location"]
+        "Location of HTML documentation for pre-requisite packages"
+        haddockProjectHtmlLocation
+        (\v flags -> flags{haddockProjectHtmlLocation = v})
+        (reqArgFlag "URL")
+    , option
+        ""
+        ["executables"]
+        "Run haddock for Executables targets"
+        haddockProjectExecutables
+        (\v flags -> flags{haddockProjectExecutables = v})
+        trueArg
+    , option
+        ""
+        ["tests"]
+        "Run haddock for Test Suite targets"
+        haddockProjectTestSuites
+        (\v flags -> flags{haddockProjectTestSuites = v})
+        trueArg
+    , option
+        ""
+        ["benchmarks"]
+        "Run haddock for Benchmark targets"
+        haddockProjectBenchmarks
+        (\v flags -> flags{haddockProjectBenchmarks = v})
+        trueArg
+    , option
+        ""
+        ["foreign-libraries"]
+        "Run haddock for Foreign Library targets"
+        haddockProjectForeignLibs
+        (\v flags -> flags{haddockProjectForeignLibs = v})
+        trueArg
+    , option
+        ""
+        ["all", "haddock-all"]
+        "Run haddock for all targets"
+        ( \f ->
+            allFlags
+              [ haddockProjectExecutables f
+              , haddockProjectTestSuites f
+              , haddockProjectBenchmarks f
+              , haddockProjectForeignLibs f
+              ]
+        )
+        ( \v flags ->
+            flags
+              { haddockProjectExecutables = v
+              , haddockProjectTestSuites = v
+              , haddockProjectBenchmarks = v
+              , haddockProjectForeignLibs = v
+              }
+        )
+        trueArg
+    , option
+        ""
+        ["internal"]
+        "Run haddock for internal modules and include all symbols"
+        haddockProjectInternal
+        (\v flags -> flags{haddockProjectInternal = v})
+        trueArg
+    , option
+        ""
+        ["css"]
+        "Use PATH as the haddock stylesheet"
+        haddockProjectCss
+        (\v flags -> flags{haddockProjectCss = v})
+        (reqArgFlag "PATH")
+    , option
+        ""
+        ["hscolour-css"]
+        "Use PATH as the HsColour stylesheet"
+        haddockProjectHscolourCss
+        (\v flags -> flags{haddockProjectHscolourCss = v})
+        (reqArgFlag "PATH")
+    , option
+        ""
+        ["keep-temp-files"]
+        "Keep temporary files"
+        haddockProjectKeepTempFiles
+        (\b flags -> flags{haddockProjectKeepTempFiles = b})
+        trueArg
+    , option
+        ""
+        ["resources-dir"]
+        "location of Haddocks static / auxiliary files"
+        haddockProjectResourcesDir
+        (\v flags -> flags{haddockProjectResourcesDir = v})
+        (reqArgFlag "DIR")
+    , option
+        ""
+        ["use-unicode"]
+        "Pass --use-unicode option to haddock"
+        haddockProjectUseUnicode
+        (\v flags -> flags{haddockProjectUseUnicode = v})
+        trueArg
+    ]
 
 emptyHaddockProjectFlags :: HaddockProjectFlags
 emptyHaddockProjectFlags = mempty

--- a/cabal-install/src/Distribution/Client/Config.hs
+++ b/cabal-install/src/Distribution/Client/Config.hs
@@ -1844,7 +1844,7 @@ haddockFlagsFields =
   , name `notElem` exclusions
   ]
   where
-    exclusions = ["verbose", "builddir", "for-hackage"]
+    exclusions = ["verbose", "builddir", "cabal-file", "for-hackage"]
 
 -- | Fields for the 'init' section.
 initFlagsFields :: [FieldDescr IT.InitFlags]

--- a/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig/Legacy.hs
@@ -862,8 +862,8 @@ convertLegacyBuildOnlyFlags
   installFlags
   clientInstallFlags
   haddockFlags
-  _
-  _ =
+  _testFlags
+  _benchmarkFlags =
     ProjectConfigBuildOnly{..}
     where
       projectConfigClientInstallFlags = clientInstallFlags

--- a/cabal-install/tests/IntegrationTests2.hs
+++ b/cabal-install/tests/IntegrationTests2.hs
@@ -49,7 +49,7 @@ import qualified Distribution.Client.CmdListBin        as CmdListBin
 import Distribution.Package
 import Distribution.PackageDescription
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
-import Distribution.Simple.Setup (toFlag, HaddockFlags(..), defaultHaddockFlags)
+import Distribution.Simple.Setup (toFlag, CommonSetupFlags(..), HaddockFlags(..), defaultHaddockFlags, defaultCommonSetupFlags)
 import Distribution.Client.Setup (globalCommand)
 import Distribution.Client.Config (loadConfig, SavedConfig(savedGlobalFlags), createDefaultConfigFile)
 import Distribution.Simple.Compiler
@@ -2289,7 +2289,12 @@ testHaddockProjectDependencies config = do
       cleanHaddockProject testdir
       withCurrentDirectory dir $ do
         CmdHaddockProject.haddockProjectAction
-          defaultHaddockProjectFlags { haddockProjectVerbosity = Flag verbosity }
+          defaultHaddockProjectFlags
+            { haddockProjectCommonFlags =
+                defaultCommonSetupFlags
+                  { setupVerbosity = Flag verbosity
+                  }
+            }
           ["all"]
           defaultGlobalFlags { globalStoreDir = Flag "store" }
 


### PR DESCRIPTION
Split off of #10292. This lets `cabal haddock-project` use the standard `CommonFlags` that other commands use to set verbosity and so on.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)