### PR TITLE
Pass `io-manager=native` to tests

### DIFF
--- a/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes2/cabal-internal.test.hs
@@ -2,7 +2,7 @@ import Test.Cabal.Prelude
 
 main = cabalTest $ do
     skipUnlessGhcVersion ">= 8.1"
-    expectBrokenIfWindowsCI 10191 $ withProjectFile "cabal.internal.project" $ do
+    withProjectFile "cabal.internal.project" $ do
         cabal "v2-build" ["exe"]
         withPlan $ do
             r <- runPlanExe' "I" "exe" []

--- a/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-external.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-external.test.hs
@@ -2,8 +2,6 @@ import Test.Cabal.Prelude
 
 main = cabalTest $ do
     skipUnlessGhcVersion ">= 8.1"
-    ghcVer <- isGhcVersion ">= 9.10"
-    skipIf "Windows + 9.10.1 (#10191)" (isWindows && ghcVer)
     withProjectFile "cabal.external.project" $ do
         cabal "v2-build" ["exe"]
         withPlan $ do

--- a/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-internal.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/Includes3/cabal-internal.test.hs
@@ -2,7 +2,7 @@ import Test.Cabal.Prelude
 
 main = cabalTest $ do
     skipUnlessGhcVersion ">= 8.1"
-    expectBrokenIfWindowsCI 10191 $ withProjectFile "cabal.internal.project" $ do
+    withProjectFile "cabal.internal.project" $ do
         cabal "v2-build" ["exe"]
         withPlan $ do
             r <- runPlanExe' "I" "exe" []

--- a/cabal-testsuite/PackageTests/Backpack/T6385/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/Backpack/T6385/cabal.test.hs
@@ -1,6 +1,6 @@
 import Test.Cabal.Prelude
 main =
-  cabalTest $ expectBrokenIfWindows 10191 $ withShorterPathForNewBuildStore $ do
+  cabalTest $ withShorterPathForNewBuildStore $ do
     skipUnlessGhcVersion ">= 8.1"
     withRepo "repo" $ do
       cabal "v2-build" ["T6385"]

--- a/cabal-testsuite/src/Test/Cabal/Prelude.hs
+++ b/cabal-testsuite/src/Test/Cabal/Prelude.hs
@@ -356,9 +356,15 @@ cabalGArgs global_args cmd args input = do
             [ "--store-dir=" ++ storeDir | Just storeDir <- [testMaybeStoreDir env] ]
             ++ global_args
 
+        rts_args =
+            if buildOS == Windows
+            then ["+RTS", "--io-manager=native", "-RTS"]
+            else []
+
         cabal_args = global_args'
                   ++ [ cmd, marked_verbose ]
                   ++ extra_args
+                  ++ rts_args
                   ++ args
     defaultRecordMode RecordMarked $ do
     recordHeader ["cabal", cmd]

--- a/cabal-testsuite/src/Test/Cabal/Server.hs
+++ b/cabal-testsuite/src/Test/Cabal/Server.hs
@@ -29,6 +29,7 @@ import System.Exit
 import Data.List (intercalate, isPrefixOf)
 import Distribution.Simple.Program.Db
 import Distribution.Simple.Program
+import Distribution.System
 import Control.Exception
 import qualified Control.Exception as E
 import Control.Monad
@@ -221,7 +222,11 @@ runMain ref m = do
 startServer :: Chan ServerLogMsg -> ScriptEnv -> IO Server
 startServer chan senv = do
     (prog, _) <- requireProgram verbosity ghcProgram (runnerProgramDb senv)
-    let ghc_args = runnerGhcArgs senv Nothing ++ ["--interactive", "-v0", "-ignore-dot-ghci"]
+    let rts_args =
+          if buildOS == Windows
+          then ["+RTS", "--io-manager=native", "-RTS"]
+          else []
+        ghc_args = runnerGhcArgs senv Nothing ++ ["--interactive", "-v0", "-ignore-dot-ghci"] ++ rts_args
         proc_spec = (proc (programPath prog) ghc_args) {
                         create_group = True,
                         -- Closing fds is VERY important to avoid


### PR DESCRIPTION
This PR is an alternative to #10366, which makes use of `--io-manager=native` in the ghci and cabal invocations in tests. Although this ought to make the tests pass, the question of whether cabal should use the system temp directory still remains.

This should close #10191 too, although not really for final users, only for our test-suite. End users will still have problems when building long-path'ed projects like backpack projects, but they can use `--io-manager=native` too 🤷 .

--

**This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). *Probably worth backporting*
