### PR TITLE
Prefer ErrorCall to ErrorCallWithLocation

### DIFF
--- a/Cabal-syntax/src/Distribution/Compat/Binary.hs
+++ b/Cabal-syntax/src/Distribution/Compat/Binary.hs
@@ -20,4 +20,4 @@ decodeOrFailIO :: Binary a => ByteString -> IO (Either String a)
 decodeOrFailIO bs =
   catch (evaluate (decode bs) >>= return . Right) handler
   where
-    handler (ErrorCallWithLocation str _) = return $ Left str
+    handler (ErrorCall str) = return $ Left str

--- a/Cabal-syntax/src/Distribution/Utils/Structured.hs
+++ b/Cabal-syntax/src/Distribution/Utils/Structured.hs
@@ -277,7 +277,7 @@ structuredDecodeOrFailIO :: (Binary.Binary a, Structured a) => LBS.ByteString ->
 structuredDecodeOrFailIO bs =
   catch (evaluate (structuredDecode bs) >>= return . Right) handler
   where
-    handler (ErrorCallWithLocation str _) = return $ Left str
+    handler (ErrorCall str) = return $ Left str
 
 -- | Lazily reconstruct a value previously written to a file.
 structuredDecodeFileOrFail :: (Binary.Binary a, Structured a) => FilePath -> IO (Either String a)


### PR DESCRIPTION
This future proofs the code for CLC#285, which will remove `ErrorCallWithLocation` to de-duplicate duplicate CallStacks.

ErrorCall is already a pattern synonym with the same meaning as it will have in the future, so this change is backwards compatible too.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
