### PR TITLE
patchups to `changelog.d` file descriptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,14 +350,15 @@ description: {
 
 Changelogs may also be written in "markdown-frontmatter" format. This is useful if your
 description contains braces, which must be escaped with backslashes in `.cabal` file
-format.
+format. The front matter is in YAML syntax, not `.cabal` file syntax, and the file
+_must_ begin with a line containing only hyphens.
 
 ```markdown
 ---
 synopsis: Add feature xyz
 packages: [cabal-install]
-prs: #0000
-issues: #0000 #0000
+prs: 0000
+issues: [0000, 0000]
 significance: significant
 ---
 
@@ -365,7 +366,11 @@ significance: significant
 - Detail number 2
 
 ```
-The package list must be enclosed in square brackets and comma-separated, but this isn't needed for `prs` or `issues`.
+The package list must be enclosed in square brackets and comma-separated, but this
+isn't needed for `prs` or `issues`; those are free-form and any YAML syntax will
+be accepted. Note that the number signs on PR and issue numbers are required in
+`.cabal` file syntax, but won't work in markdown-frontmatter syntax because they
+signify comments in YAML.
 
 Only the `synopsis` and `prs` fields are required, but you should also set the others where applicable.
 


### PR DESCRIPTION
Bug copied from `changelog-d`'s `README.md`. A good example of why copying it into `CONTRIBUTING.md` because we can't reference it from there is a bad idea. ☹

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
