### PR TITLE
Fix Markdown frontmatter syntax in changelog-d example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,8 +356,8 @@ format.
 ---
 synopsis: Add feature xyz
 packages: [cabal-install]
-prs: #0000
-issues: #0000 #0000
+prs: 0000
+issues: [0000, 0000]
 significance: significant
 ---
 


### PR DESCRIPTION
`#` is the comment marker for YAML, so it's not used in PR and issue numbers.

See: https://github.com/haskell/cabal/pull/10383/files#r1783455984