### PR TITLE
Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# See: https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+
+[*.hs]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This adds a `.editorconfig` file to automatically configure the indentation of files in this repo in a variety of editors.

See: https://editorconfig.org/