### PR TITLE
FreeBSD calls "x86_64" "amd64"

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -314,7 +314,7 @@ case "$ARCH" in
     arm64)
         ARCH=aarch64
         ;;
-    x86_64)
+    x86_64 | amd64)
         ARCH=x86_64
         ;;
     i386)

--- a/validate.sh
+++ b/validate.sh
@@ -317,6 +317,9 @@ case "$ARCH" in
     x86_64)
         ARCH=x86_64
         ;;
+    i386)
+        ARCH=i386
+        ;;
     *)
         echo "Warning: Unknown architecture '$ARCH'"
         ;;


### PR DESCRIPTION
This prepares for a "tier 2 platforms" validate job: currently there are platforms for which we make official releases, but never validate beyond building them.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

Depends-on: #10405 (note: includes its commit, which should drop out when this lands)