### PR TITLE
Fix ./setup install comand

### DIFF
--- a/Cabal/src/Distribution/Simple.hs
+++ b/Cabal/src/Distribution/Simple.hs
@@ -1094,6 +1094,7 @@ defaultInstallHook_setupHooks inst_hooks pkg_descr localbuildinfo _ flags = do
         defaultRegisterFlags
           { regInPlace = installInPlace flags
           , regPackageDB = installPackageDB flags
+          , registerCommonFlags = installCommonFlags flags
           }
   when (hasLibs pkg_descr) $
     register pkg_descr localbuildinfo registerFlags

--- a/cabal-testsuite/PackageTests/Install/DistPrefInstall/CHANGELOG.md
+++ b/cabal-testsuite/PackageTests/Install/DistPrefInstall/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for DistPrefInstall
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cabal-testsuite/PackageTests/Install/DistPrefInstall/DistPrefInstall.cabal
+++ b/cabal-testsuite/PackageTests/Install/DistPrefInstall/DistPrefInstall.cabal
@@ -1,0 +1,18 @@
+cabal-version:   3.12
+name:            DistPrefInstall
+version:         0.1.0.0
+license:         NONE
+author:          Matthew Pickering
+maintainer:      matthewtpickering@gmail.com
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  MyLib
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/Install/DistPrefInstall/Setup.hs
+++ b/cabal-testsuite/PackageTests/Install/DistPrefInstall/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/cabal-testsuite/PackageTests/Install/DistPrefInstall/setup.test.hs
+++ b/cabal-testsuite/PackageTests/Install/DistPrefInstall/setup.test.hs
@@ -1,0 +1,8 @@
+import Test.Cabal.Prelude
+
+main = setupTest $ recordMode DoNotRecord $ withPackageDb $ do
+    setup "configure" []
+    setup "build" []
+    setup "copy" []
+    setup "install" []
+    setup "sdist" []

--- a/cabal-testsuite/PackageTests/Install/DistPrefInstall/src/MyLib.hs
+++ b/cabal-testsuite/PackageTests/Install/DistPrefInstall/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/changelog.d/t10416
+++ b/changelog.d/t10416
@@ -1,0 +1,11 @@
+synopsis: Fix ./setup install command
+packages: Cabal
+prs: #10417
+issues: #10416
+significance: significant
+
+description: {
+
+- `./setup install` was failing with a `fromFlag NoFlag` error. It is now fixed.
+
+}


### PR DESCRIPTION
Running ./setup install will give you an error:

```
fromFlag NoFlag. Use fromFlagOrDefault
CallStack (from HasCallStack):
  error, called at src/Distribution/Simple/Flag.hs:110:19 in Cabal-3.15.0.0-inplace:Distribution.Simple.Flag
  fromFlag, called at src/Distribution/Simple/Register.hs:161:16 in Cabal-3.15.0.0-inplace:Distribution.Simple.Register
```

This seems to not be tested anywhere and most people will use ./setup register in any case, but we should fix this for the next point release in 3.14 series. # Please enter the commit message for your changes. Lines starting

Fixes #10416

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
