### PR TITLE
Cabal: Take into account compilerBuildWay when computing final library ways

### DIFF
--- a/cabal-testsuite/PackageTests/BuildWays/p/CHANGELOG.md
+++ b/cabal-testsuite/PackageTests/BuildWays/p/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for p
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cabal-testsuite/PackageTests/BuildWays/p/p.cabal
+++ b/cabal-testsuite/PackageTests/BuildWays/p/p.cabal
@@ -1,0 +1,18 @@
+cabal-version:   3.12
+name:            p
+version:         0.1.0.0
+license:         NONE
+author:          Matthew Pickering
+maintainer:      matthewtpickering@gmail.com
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+common warnings
+    ghc-options: -Wall
+
+library
+    import:           warnings
+    exposed-modules:  MyLib
+    build-depends:    base
+    hs-source-dirs:   src
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/BuildWays/p/src/MyLib.hs
+++ b/cabal-testsuite/PackageTests/BuildWays/p/src/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/cabal-testsuite/PackageTests/BuildWays/q/CHANGELOG.md
+++ b/cabal-testsuite/PackageTests/BuildWays/q/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for q
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/cabal-testsuite/PackageTests/BuildWays/q/app/Main.hs
+++ b/cabal-testsuite/PackageTests/BuildWays/q/app/Main.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Main where
+
+import MyLib
+
+main :: IO ()
+main = someFunc

--- a/cabal-testsuite/PackageTests/BuildWays/q/q.cabal
+++ b/cabal-testsuite/PackageTests/BuildWays/q/q.cabal
@@ -1,0 +1,19 @@
+cabal-version:   3.12
+name:            q
+version:         0.1.0.0
+license:         NONE
+author:          Matthew Pickering
+maintainer:      matthewtpickering@gmail.com
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+common warnings
+    ghc-options: -Wall
+
+executable q
+    import:           warnings
+    main-is:          Main.hs
+    build-depends:    p, base
+    hs-source-dirs:   app
+    ghc-options: -dynamic-too
+    default-language: Haskell2010

--- a/cabal-testsuite/PackageTests/BuildWays/setup.test.hs
+++ b/cabal-testsuite/PackageTests/BuildWays/setup.test.hs
@@ -1,0 +1,10 @@
+import Test.Cabal.Prelude
+
+opts = ["--enable-shared", "--enable-library-vanilla", "--enable-library-profiling"]
+
+-- See #10418
+main = setupTest $ recordMode DoNotRecord $ withPackageDb $ do
+    skipIfNoSharedLibraries
+    skipIfNoProfiledLibraries
+    withDirectory "p" $ setup_install opts
+    withDirectory "q" $ setup_install opts

--- a/changelog.d/i10418
+++ b/changelog.d/i10418
@@ -1,0 +1,13 @@
+synopsis: Fix build ways for modules in executables
+packages: Cabal
+prs: #10419
+issues: #10418
+significance: significant
+
+description: {
+
+- Modules belonging to executables were being built in too many ways. For instance, if you
+had configured to build profiled library files then your executable modules would also
+be built profiled. Which was a regression in behaviour since `Cabal-3.12`.
+
+}


### PR DESCRIPTION
In the profiling dynamic patch I made a mistake when computing the needed ways for a build.

When building an executable, the Haskell modules need to be built

* For the final link way
* For the build way of the compiler if TH is enabled

Before this patch, the modules were being built for all the configured library ways, which built modules in more configurations than the previous version of Cabal.

Fixes #10418

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
