### PR TITLE
Fix `HaddockKeepTmpsCustom` test for merge skew

### DIFF
--- a/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/cabal.test.hs
+++ b/cabal-testsuite/PackageTests/HaddockKeepTmpsCustom/cabal.test.hs
@@ -11,11 +11,11 @@ main = cabalTest $ recordMode DoNotRecord $ withProjectFile "cabal.project" $ do
   --   "foobar.ext" will be "fooXXX.ext".
   let glob =
         if isWindows
-          then "**/had*.txt"
-          else "**/haddock-response*.txt"
+          then "had*.txt"
+          else "haddock-response*.txt"
 
   -- Check that there is a response file.
-  responseFiles <- assertGlobMatchesTestDir testDistDir glob
+  responseFiles <- assertGlobMatchesTestDir testTmpDir glob
 
   -- Check that the matched response file is not empty, and is indeed a Haddock
   -- response file.

--- a/cabal-testsuite/src/Test/Cabal/Monad.hs
+++ b/cabal-testsuite/src/Test/Cabal/Monad.hs
@@ -410,6 +410,10 @@ runTestM mode m =
                         -- effect on Windows.
                         , ("CABAL_DIR", Just (testCabalDir env))
                         , ("CABAL_CONFIG", Just (testUserCabalConfigFile env))
+                        -- Set `TMPDIR` so that temporary files aren't created in the global `TMPDIR`.
+                        , ("TMPDIR", Just tmp_dir)
+                        -- Windows uses `TMP` for the `TMPDIR`.
+                        , ("TMP", Just tmp_dir)
                         ],
                     testShouldFail = False,
                     testRelativeCurrentDir = ".",


### PR DESCRIPTION
The `HaddockKeepTmpsCustom` test added in #10392 skewed against #10366, which changes where temporary files are written.

We can work around this by setting `$TMPDIR` and `$TEMP` while running tests, so that temporary files are written to the test's temporary directory rather than the system one.