### PR TITLE
try to fix LTS prerelease workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,8 @@ on:
       - "release-notes/**"
     branches:
       - master
+      # hardcoded LTS branch, change when new LTS released!
+      - '3.12'
   pull_request:
     paths-ignore:
       - "doc/**"
@@ -481,7 +483,9 @@ jobs:
     name: Create a GitHub LTS prerelease with the binary artifacts
     runs-on: ubuntu-latest
     # The LTS branch is hardcoded for now, update it on a new LTS!
-    if: github.ref == 'refs/heads/3.12'
+    # if: github.ref == 'refs/heads/3.12'
+    permissions:
+      contents: write
 
     # IMPORTANT! Any job added to the workflow should be added here too
     needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
@@ -494,12 +498,15 @@ jobs:
 
     - run: |
         # bash-ism, but we forced bash above
-        mv cabal-{,lts-}head-Windows-x86_64.tar.gz
-        mv cabal-{,lts-}head-Linux-x86_64.tar.gz
-        mv cabal-{,lts-}head-Linux-static-x86_64.tar.gz
-        mv cabal-{,lts-}head-macOS-aarch64.tar.gz
+        cd binaries
+        for f in cabal-*; do
+          mv "$f" "cabal-lts-${f##cabal-}"
+        done
+
+    - run: echo ${{ github.ref }}
 
     - name: Create GitHub prerelease
+      if: github.ref == 'refs/heads/3.12'
       uses: softprops/action-gh-release@v2
       with:
         tag_name: cabal-lts-head


### PR DESCRIPTION
It's being skipped, not failing to fire, implying the wrong ref? This subsumes #10415.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions). (3.12 only; 3.14 isn't an LTS release.)
