### PR TITLE
Fix build ways for foreign libs

### DIFF
--- a/cabal-testsuite/PackageTests/ProfShared/setup.test.hs
+++ b/cabal-testsuite/PackageTests/ProfShared/setup.test.hs
@@ -16,8 +16,8 @@ main = do
 
           let ls = lines (resultOutput r)
 
-              library_prefix = "Wanted build ways(True): "
-              executable_prefix = "Wanted build ways(False): "
+              library_prefix = "Wanted module build ways(library): "
+              executable_prefix = "Wanted module build ways(executable 'Prof'): "
 
               get_ways prefix = map (drop (length prefix)) (filter (prefix `isPrefixOf`) ls)
               library_ways = read_ways (get_ways library_prefix)


### PR DESCRIPTION
Patches the component build ways for foreign library components.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

