### PR TITLE
change the backport label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -170,3 +170,8 @@ queue_rules:
     update_bot_account: Mikolaj
     merge_method: squash
     update_method: merge
+
+defaults:
+  actions:
+    backport:
+      title: "Backport #{{ number }}: {{ title }}"


### PR DESCRIPTION
By request in Matrix. If anyone else has an opinion, speak now or forever hold your peace! ☺

The new format is `Backport #NNN: title`, which with GitHub's addenda (which can't be changed) will be
```
[haskell/cabal] Backport #NNN: title (PR #MMM)
```

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* ~~[ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ (Mergify only reads this file on `master`.)
