### PR TITLE
Revert "have Mergify insist on all-green CI"

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -85,6 +85,10 @@ pull_request_rules:
       - label=merge delay passed
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
+      # unlike the others, we need to force this one to be up to date
+      # because it's intended for when Mergify doesn't have permission
+      # to rebase
+      - '#commits-behind=0'
 
   # merge+no rebase strategy
   - actions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -52,7 +52,15 @@ pull_request_rules:
         - label=merge+no rebase
       - '#approved-reviews-by>=2'
       - '#changes-requested-reviews-by=0'
-      - '#check-failure=0'
+      # oy
+      # lifted these from branch protection imports
+      - check-success=fourmolu
+      - check-success=hlint
+      - check-success=Meta checks
+      - check-success=Doctest Cabal
+      - check-success=Validate post job
+      - check-success=Bootstrap post job
+      - 'check-success=docs/readthedocs.org:cabal'
 
   # rebase+merge strategy
   - actions:
@@ -65,7 +73,6 @@ pull_request_rules:
       - label=merge delay passed
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
-      - '#check-failure=0'
 
   # merge+squash strategy
   - actions:
@@ -78,7 +85,6 @@ pull_request_rules:
       - label=merge delay passed
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
-      - '#check-failure=0'
 
   # merge+no rebase strategy
   - actions:
@@ -91,11 +97,6 @@ pull_request_rules:
       - label=merge delay passed
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
-      - '#check-failure=0'
-      # unlike the others, we need to force this one to be up to date
-      # because it's intended for when Mergify doesn't have permission
-      # to rebase
-      - '#commits-behind=0'
 
   # merge strategy for release branches
   - actions:
@@ -108,7 +109,6 @@ pull_request_rules:
       - -body~=backport
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
-      - '#check-failure=0'
 
   # merge+squash strategy for release branches
   - actions:
@@ -121,7 +121,6 @@ pull_request_rules:
       - -body~=backport
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
-      - '#check-failure=0'
 
   # merge strategy for backports: require 1 approver instead of 2
   - actions:
@@ -134,7 +133,6 @@ pull_request_rules:
       - body~=backport
       - '#approved-reviews-by>=1'
       - '-label~=^blocked:'
-      - '#check-failure=0'
 
   # merge+squash strategy for backports: require 1 approver instead of 2
   - actions:
@@ -147,7 +145,6 @@ pull_request_rules:
       - body~=backport
       - '#approved-reviews-by>=1'
       - '-label~=^blocked:'
-      - '#check-failure=0'
 
   # backports should be labeled as such
   - actions:


### PR DESCRIPTION
It didn't do what was intended, and apparently Mergify is now tripping over its own feet about it (see #10425). May require manual merge.

This reverts commit d9c2b4093824c7bdf171b3a2113ff41cd09fd0de.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
