### PR TITLE
add new options for ghc 9.12

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/GHC.hs
+++ b/Cabal/src/Distribution/Simple/Program/GHC.hs
@@ -329,6 +329,7 @@ normaliseGhcArgs (Just ghcVersion) PackageDescription{..} ghcArgs
           ]
         , from [8, 2] ["-fmax-uncovered-patterns", "-fmax-errors"]
         , from [8, 4] $ to [8, 6] ["-fmax-valid-substitutions"]
+        , from [9, 12] ["-fmax-forced-spec-args", "-fwrite-if-compression"]
         ]
 
     dropIntFlag :: Bool -> String -> String -> Any

--- a/changelog.d/pr-10468
+++ b/changelog.d/pr-10468
@@ -1,0 +1,31 @@
+synopsis: Add new options from ghc 9.12
+packages: Cabal
+prs: #10468
+significance:
+
+description: {
+
+- ghc 9.12 adds several new command line options, divided between
+  `LANGUAGE`s (already added), warnings, new preprocessor control options,
+  and compilation control options. Two options needed to be added to the
+  list of options requiring `Int` parameters.
+
+  The new options, excluding warning and language options, are:
+
+  * `-fexpose-overloaded-unfoldings`
+  * `-fmax-forced-spec-args=N`
+  * `-fno-expose-overloaded-unfoldings`
+  * `-fno-object-determinism`
+  * `-fobject-determinism`
+  * `-fwrite-if-compression=N`
+  * `-optCmmP…`
+  * `-optJSP…`
+  * `-pgmCmmP`
+  * `-pgmJSP`
+
+  As they all affect compilation and store hashes, the only necessary
+  change was to list the two numeric options so they will be parsed
+  correctly. To the best of our understanding, `-pgm*` and `-opt*`
+  options are already handled as a group.
+
+}


### PR DESCRIPTION
ghc 9.12 adds several new command line options, divided between
`LANGUAGE`s (already added), warnings, new preprocessor control options,
and compilation control options. Two options needed to be added to the
list of options requiring `Int` parameters.

The new options, excluding warning and language options, are:

* `-fexpose-overloaded-unfoldings`
* `-fmax-forced-spec-args=N`
* `-fno-expose-overloaded-unfoldings`
* `-fno-object-determinism`
* `-fobject-determinism`
* `-fwrite-if-compression=N`
* `-optCmmP…`
* `-optJSP…`
* `-pgmCmmP`
* `-pgmJSP`

As they all affect compilation and store hashes, the only necessary
change was to list the two numeric options so they will be parsed
correctly. To the best of our understanding, `-pgm*` and `-opt*`
options are already handled as a group.

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
