### PR TITLE
Deprecate `cabal format`

### DIFF
--- a/cabal-install/src/Distribution/Client/Setup.hs
+++ b/cabal-install/src/Distribution/Client/Setup.hs
@@ -73,6 +73,7 @@ module Distribution.Client.Setup
   , checkCommand
   , CheckFlags (..)
   , formatCommand
+  , dumpPackageDescriptionCommand
   , uploadCommand
   , UploadFlags (..)
   , IsCandidate (..)
@@ -301,6 +302,7 @@ globalCommand commands =
               , "hscolour"
               , "exec"
               , "path"
+              , "format"
               , "new-build"
               , "new-configure"
               , "new-repl"
@@ -405,6 +407,7 @@ globalCommand commands =
                 , startGroup "deprecated"
                 , addCmd "unpack"
                 , addCmd "hscolour"
+                , addCmd "format"
                 , par
                 , startGroup "new-style projects (forwards-compatible aliases)"
                 , addCmd "v2-build"
@@ -1745,14 +1748,41 @@ cleanCommand =
         "Usage: " ++ pname ++ " v1-clean [FLAGS]\n"
     }
 
+-- If you read this comment after cabal-install 3.16 has already been released,
+-- it seems we forgot to delete the command, which we said we would do for 3.16.
+-- So please: do remove this command.
 formatCommand :: CommandUI (Flag Verbosity)
 formatCommand =
   CommandUI
     { commandName = "format"
-    , commandSynopsis = "Reformat the .cabal file using the standard style."
-    , commandDescription = Nothing
+    , commandSynopsis = "Rewrite the .cabal file using the parsed package description."
+    , commandDescription = Just $ \_ ->
+        wrapText $
+          "cabal-install parses the .cabal file into its internal package description "
+            ++ "datatype. This command rewrites the file with the parsed description.\n"
+            ++ "\n"
+            ++ "Note that the parsed description does not include the comments "
+            ++ "in the original file nor the common stanzas, which are expanded "
+            ++ "during the package description resolution.\n"
+            ++ "\n"
+            ++ "This command is barely a raw formatter. Its functionality has "
+            ++ "been moved to `cabal dump-package-description` which will not "
+            ++ "overwrite the file. In cabal-install 3.16 this command will be "
+            ++ "removed."
     , commandNotes = Nothing
     , commandUsage = usageAlternatives "format" ["[FILE]"]
+    , commandDefaultFlags = toFlag normal
+    , commandOptions = \_ -> []
+    }
+
+dumpPackageDescriptionCommand :: CommandUI (Flag Verbosity)
+dumpPackageDescriptionCommand =
+  CommandUI
+    { commandName = "dump-package-description"
+    , commandSynopsis = "Dump the parsed package description to stdout"
+    , commandDescription = Nothing
+    , commandNotes = Nothing
+    , commandUsage = usageAlternatives "dump-package-description" ["[FILE]"]
     , commandDefaultFlags = toFlag normal
     , commandOptions = \_ -> []
     }

--- a/changelog.d/pr-10469
+++ b/changelog.d/pr-10469
@@ -1,0 +1,10 @@
+synopsis: Deprecate `cabal format`
+packages: cabal-install
+prs: #10469
+significance:
+
+description: {
+
+- Deprecate `cabal format` in favor of `cabal dump-package-description` which is still a hidden, internal command.
+
+}


### PR DESCRIPTION
`cabal format` was never production ready, and it is mistakenly used to format cabal files. I kept the functionality as `cabal dump-package-description` because I still think it might be useful.

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [X] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [X] The documentation has been updated, if necessary. _The help text was the only documentation about cabal format._
* [ ] ~[Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.~
* [ ] ~Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)~
