### PR TITLE
Document `Setup.hs repl`

### DIFF
--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -1412,8 +1412,7 @@ Usage:
 .. program:: runhaskell Setup.hs repl [COMPONENT] [FLAGS]
 
 If the current directory contains no package, ignores COMPONENT parameters and
-opens an interactive interpreter session; if a sandbox is present, its package
-database will be used.
+opens an interactive interpreter session.
 
 Otherwise, (re)configures with the given or default flags, and loads the
 interpreter with the relevant modules. For executables, tests and benchmarks,

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -1399,3 +1399,63 @@ This command takes the following option:
 
 
 .. include:: references.inc
+
+runhaskell Setup.hs repl 
+------------------------
+
+Open an interpreter session for the given component.
+
+Usage: 
+
+.. program:: runhaskell Setup.hs repl [COMPONENT] [FLAGS]
+
+If the current directory contains no package, ignores COMPONENT parameters and
+opens an interactive interpreter session; if a sandbox is present, its package
+database will be used.
+
+Otherwise, (re)configures with the given or default flags, and loads the
+interpreter with the relevant modules. For executables, tests and benchmarks,
+loads the main module (and its dependencies); for libraries all exposed/other
+modules.
+
+The default component is the library itself, or the executable if that is the
+only component.
+
+Support for loading specific modules is planned but not implemented yet. For
+certain scenarios, ``Setup.hs exec -- ghci :l Foo`` may be used instead. Note
+that ``exec`` will not (re)configure and you will have to specify the location
+of other modules, if required.
+
+Flags for repl:
+
+.. option:: -h, --help
+
+    Show this help text
+
+.. option:: -v, --verbose[=n]
+
+    Control verbosity (n is 0--3, default verbosity level is 1)
+
+.. option:: --builddir=DIR
+    
+    The directory where Cabal puts generated build files (default dist)
+
+.. option:: --with-PROG=PATH
+    
+    give the path to PROG
+
+.. option:: --PROG-option=OPT
+    
+    give an extra option to PROG (no need to quote options containing spaces)
+
+.. option:: --PROG-options=OPTS
+    
+    give extra options to PROG
+
+.. option:: --repl-no-load
+    
+    Disable loading of project modules at REPL startup.
+
+.. option:: --repl-options=FLAG
+    
+    Use the option(s) for the repl

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -1400,12 +1400,14 @@ This command takes the following option:
 
 .. include:: references.inc
 
-runhaskell Setup.hs repl 
+.. _setup-repl:
+
+runhaskell Setup.hs repl
 ------------------------
 
 Open an interpreter session for the given component.
 
-Usage: 
+Usage:
 
 .. program:: runhaskell Setup.hs repl [COMPONENT] [FLAGS]
 
@@ -1437,25 +1439,25 @@ Flags for repl:
     Control verbosity (n is 0--3, default verbosity level is 1)
 
 .. option:: --builddir=DIR
-    
+
     The directory where Cabal puts generated build files (default dist)
 
 .. option:: --with-PROG=PATH
-    
+
     give the path to PROG
 
 .. option:: --PROG-option=OPT
-    
+
     give an extra option to PROG (no need to quote options containing spaces)
 
 .. option:: --PROG-options=OPTS
-    
+
     give extra options to PROG
 
 .. option:: --repl-no-load
-    
+
     Disable loading of project modules at REPL startup.
 
 .. option:: --repl-options=FLAG
-    
+
     Use the option(s) for the repl

--- a/doc/setup-commands.rst
+++ b/doc/setup-commands.rst
@@ -1429,29 +1429,25 @@ of other modules, if required.
 
 Flags for repl:
 
-.. option:: -h, --help
-
-    Show this help text
-
 .. option:: -v, --verbose[=n]
 
-    Control verbosity (n is 0--3, default verbosity level is 1)
+    Control verbosity (n is 0--3, default verbosity level is 1).
 
 .. option:: --builddir=DIR
 
-    The directory where Cabal puts generated build files (default dist)
+    The directory where Cabal puts generated build files (default dist).
 
 .. option:: --with-PROG=PATH
 
-    give the path to PROG
+    Give the path to PROG.
 
 .. option:: --PROG-option=OPT
 
-    give an extra option to PROG (no need to quote options containing spaces)
+    Give an extra option to PROG (no need to quote options containing spaces).
 
 .. option:: --PROG-options=OPTS
 
-    give extra options to PROG
+    Give extra options to PROG.
 
 .. option:: --repl-no-load
 
@@ -1459,4 +1455,4 @@ Flags for repl:
 
 .. option:: --repl-options=FLAG
 
-    Use the option(s) for the repl
+    Use the option(s) for the repl.


### PR DESCRIPTION
The PR only touches documentation.
Fix #8906.

Include the following checklist in your PR:
* [Y] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [N] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).

The PR docmuments `Setup.hs repl` by reverting the output of `runhaskell Setup.hs repl --help` into rst format.