### PR TITLE
Catch exception if git is not installed

### DIFF
--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
@@ -164,7 +164,7 @@ guessAuthorName = guessGitInfo "user.name"
 guessAuthorEmail :: Interactive m => m (Maybe String)
 guessAuthorEmail = guessGitInfo "user.email"
 
-guessGitInfo :: String -> IO (Maybe String)
+guessGitInfo :: Interactive m => String -> m (Maybe String)
 guessGitInfo target =
   ( do
       localInfo <- readProcessWithExitCode "git" ["config", "--local", target] ""

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
@@ -175,7 +175,8 @@ guessGitInfo target =
             ExitSuccess -> return $ Just (trim $ snd' globalInfo)
             _ -> return Nothing
         else return $ Just (trim $ snd' localInfo)
-  ) `catch` const @_ @IOError (pure Nothing)
+  )
+    `catch` const @_ @IOError (pure Nothing)
   where
     fst' (x, _, _) = x
     snd' (_, x, _) = x

--- a/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
+++ b/cabal-install/src/Distribution/Client/Init/NonInteractive/Heuristics.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeApplications #-}
 
 -----------------------------------------------------------------------------
 
@@ -165,18 +164,15 @@ guessAuthorEmail :: Interactive m => m (Maybe String)
 guessAuthorEmail = guessGitInfo "user.email"
 
 guessGitInfo :: Interactive m => String -> m (Maybe String)
-guessGitInfo target =
-  ( do
-      localInfo <- readProcessWithExitCode "git" ["config", "--local", target] ""
-      if null $ snd' localInfo
-        then do
-          globalInfo <- readProcessWithExitCode "git" ["config", "--global", target] ""
-          case fst' globalInfo of
-            ExitSuccess -> return $ Just (trim $ snd' globalInfo)
-            _ -> return Nothing
-        else return $ Just (trim $ snd' localInfo)
-  )
-    `catch` const @_ @IOError (pure Nothing)
+guessGitInfo target = do
+  localInfo <- readProcessWithExitCode "git" ["config", "--local", target] ""
+  if null $ snd' localInfo
+    then do
+      globalInfo <- readProcessWithExitCode "git" ["config", "--global", target] ""
+      case fst' globalInfo of
+        ExitSuccess -> return $ Just (trim $ snd' globalInfo)
+        _ -> return Nothing
+    else return $ Just (trim $ snd' localInfo)
   where
     fst' (x, _, _) = x
     snd' (_, x, _) = x

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -346,6 +346,7 @@ class Monad m => Interactive m where
   doesFileExist :: FilePath -> m Bool
   canonicalizePathNoThrow :: FilePath -> m FilePath
   readProcessWithExitCode :: FilePath -> [String] -> String -> m (ExitCode, String, String)
+  maybeReadProcessWithExitCode :: FilePath -> [String] -> String -> m (Maybe (ExitCode, String, String))
   getEnvironment :: m [(String, String)]
   getCurrentYear :: m Integer
   listFilesInside :: (FilePath -> m Bool) -> FilePath -> m [FilePath]
@@ -389,6 +390,7 @@ instance Interactive PromptIO where
   doesFileExist = liftIO <$> P.doesFileExist
   canonicalizePathNoThrow = liftIO <$> P.canonicalizePathNoThrow
   readProcessWithExitCode a b c = liftIO $ Process.readProcessWithExitCode a b c
+  maybeReadProcessWithExitCode a b c = liftIO $ (Just <$> Process.readProcessWithExitCode a b c) `catch` const @_ @IOError (pure Nothing)
   getEnvironment = liftIO P.getEnvironment
   getCurrentYear = liftIO P.getCurrentYear
   listFilesInside test dir = do
@@ -438,6 +440,7 @@ instance Interactive PurePrompt where
   readProcessWithExitCode !_ !_ !_ = do
     input <- pop
     return (ExitSuccess, input, "")
+  maybeReadProcessWithExitCode = Just <$> readProcessWithExitCode
   getEnvironment = fmap (map read) popList
   getCurrentYear = fmap read pop
   listFilesInside pred' !_ = do

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module      :  Distribution.Client.Init.Types

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -390,7 +390,7 @@ instance Interactive PromptIO where
   doesFileExist = liftIO <$> P.doesFileExist
   canonicalizePathNoThrow = liftIO <$> P.canonicalizePathNoThrow
   readProcessWithExitCode a b c = liftIO $ Process.readProcessWithExitCode a b c
-  maybeReadProcessWithExitCode a b c = liftIO $ (Just <$> Process.readProcessWithExitCode a b c) `catch` const @_ @IOError (pure Nothing)
+  maybeReadProcessWithExitCode a b c = liftIO $ (Just <$> Process.readProcessWithExitCode a b c) `P.catch` const @_ @IOError (pure Nothing)
   getEnvironment = liftIO P.getEnvironment
   getCurrentYear = liftIO P.getCurrentYear
   listFilesInside test dir = do

--- a/cabal-install/src/Distribution/Client/Init/Types.hs
+++ b/cabal-install/src/Distribution/Client/Init/Types.hs
@@ -441,7 +441,7 @@ instance Interactive PurePrompt where
   readProcessWithExitCode !_ !_ !_ = do
     input <- pop
     return (ExitSuccess, input, "")
-  maybeReadProcessWithExitCode = Just <$> readProcessWithExitCode
+  maybeReadProcessWithExitCode a b c = Just <$> readProcessWithExitCode a b c
   getEnvironment = fmap (map read) popList
   getCurrentYear = fmap read pop
   listFilesInside pred' !_ = do

--- a/cabal-testsuite/PackageTests/Init/init-without-git.out
+++ b/cabal-testsuite/PackageTests/Init/init-without-git.out
@@ -1,0 +1,6 @@
+# cabal init
+# Setup configure
+Configuring app-0.1.0.0...
+# Setup build
+Preprocessing executable 'app' for app-0.1.0.0..
+Building executable 'app' for app-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Init/init-without-git.out
+++ b/cabal-testsuite/PackageTests/Init/init-without-git.out
@@ -1,6 +1,1 @@
 # cabal init
-# Setup configure
-Configuring app-0.1.0.0...
-# Setup build
-Preprocessing executable 'app' for app-0.1.0.0..
-Building executable 'app' for app-0.1.0.0..

--- a/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
@@ -1,0 +1,27 @@
+import Test.Cabal.Prelude
+import System.Directory
+import System.FilePath
+import Distribution.Simple.Utils
+import Distribution.Verbosity
+
+-- Test cabal init when git is not installed
+main = do
+  tmp <- getTemporaryDirectory
+  withTempDirectory normal tmp "bin.XXXX" $
+    \bin -> cabalTest . withSourceCopyDir "app" $
+      do
+        ghc_path <- programPathM ghcProgram
+        cabal_path <- programPathM cabalProgram
+        withSymlink ghc_path (bin </> "ghc") . withSymlink cabal_path (bin </> "cabal") .
+          withEnv [("PATH", Just bin)] .
+            withSourceCopyDir "app" $ do
+              cwd <- fmap testSourceCopyDir getTestEnv
+
+              buildOut <- withDirectory cwd $ do
+                cabalWithStdin "init" ["-i"]
+                  "2\n\n5\n\n\n2\n\n\n\n\n\n\n\n\n\n"
+                setup "configure" []
+                setup' "build" ["app"]
+
+              assertFileDoesContain (cwd </> "app.cabal")   "3.0"
+              assertOutputContains "Linking" buildOut

--- a/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
@@ -8,7 +8,7 @@ import Distribution.Verbosity
 main = do
   tmp <- getTemporaryDirectory
   withTempDirectory normal tmp "bin.XXXX" $
-    \bin -> cabalTest . withSourceCopyDir "app" $
+    \bin -> cabalTest $
       do
         ghc_path <- programPathM ghcProgram
         cabal_path <- programPathM cabalProgram

--- a/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
@@ -13,15 +13,14 @@ main = do
         ghc_path <- programPathM ghcProgram
         cabal_path <- programPathM cabalProgram
         withSymlink ghc_path (bin </> "ghc") . withSymlink cabal_path (bin </> "cabal") .
-          withEnv [("PATH", Just bin)] .
-            withSourceCopyDir "app" $ do
-              cwd <- fmap testSourceCopyDir getTestEnv
+          withEnv [("PATH", Just bin)] $ do
+            cwd <- fmap testSourceCopyDir getTestEnv
 
-              buildOut <- withDirectory cwd $ do
-                cabalWithStdin "init" ["-i"]
-                  "2\n\n5\n\n\n2\n\n\n\n\n\n\n\n\n\n"
-                setup "configure" []
-                setup' "build" ["app"]
+            buildOut <- withDirectory cwd $ do
+              cabalWithStdin "init" ["-i"]
+                "2\n\n5\n\n\n2\n\n\n\n\n\n\n\n\n\n"
+              setup "configure" []
+              setup' "build" ["app"]
 
-              assertFileDoesContain (cwd </> "app.cabal")   "3.0"
-              assertOutputContains "Linking" buildOut
+            assertFileDoesContain (cwd </> "app.cabal")   "3.0"
+            assertOutputContains "Linking" buildOut

--- a/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
@@ -6,6 +6,7 @@ import Distribution.Verbosity
 
 -- Test cabal init when git is not installed
 main = do
+  skipIfWindows "Might fail on windows."
   tmp <- getTemporaryDirectory
   withTempDirectory normal tmp "bin" $
     \bin -> cabalTest $

--- a/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
@@ -16,11 +16,8 @@ main = do
           withEnv [("PATH", Just bin)] $ do
             cwd <- fmap testSourceCopyDir getTestEnv
 
-            buildOut <- withDirectory cwd $ do
+            withDirectory cwd $ do
               cabalWithStdin "init" ["-i"]
                 "2\n\n5\n\n\n2\n\n\n\n\n\n\n\n\n\n"
-              setup "configure" []
-              setup' "build" ["app"]
 
             assertFileDoesContain (cwd </> "app.cabal")   "3.0"
-            assertOutputContains "Linking" buildOut

--- a/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
+++ b/cabal-testsuite/PackageTests/Init/init-without-git.test.hs
@@ -7,7 +7,7 @@ import Distribution.Verbosity
 -- Test cabal init when git is not installed
 main = do
   tmp <- getTemporaryDirectory
-  withTempDirectory normal tmp "bin.XXXX" $
+  withTempDirectory normal tmp "bin" $
     \bin -> cabalTest $
       do
         ghc_path <- programPathM ghcProgram
@@ -16,8 +16,6 @@ main = do
           withEnv [("PATH", Just bin)] $ do
             cwd <- fmap testSourceCopyDir getTestEnv
 
-            withDirectory cwd $ do
+            void . withDirectory cwd $ do
               cabalWithStdin "init" ["-i"]
                 "2\n\n5\n\n\n2\n\n\n\n\n\n\n\n\n\n"
-
-            assertFileDoesContain (cwd </> "app.cabal")   "3.0"

--- a/changelog.d/pr-10486
+++ b/changelog.d/pr-10486
@@ -1,0 +1,12 @@
+synopsis: Fix a bug that causes `cabal init` to crash if `git` is not installed
+packages: cabal-install
+prs: #10486
+issues: #10484 #8478
+significance:
+
+description: {
+
+- `cabal init` tries to use `git config` to guess the user's name and email.
+  It no longer crashes if there is no executable named `git` on $PATH.
+
+}


### PR DESCRIPTION
This is a trivial pr that should fix a bug in `cabal init` when `git` is not installed.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [x] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [x] Tests have been added.

## QA Notes

`cabal init` should work correctly even if `git` is not installed. This can be tested by running the following commands in an empty directory and answering the prompts:

```
mkdir /tmp/bin
ln -s "$(which ghc)" "$(which cabal)" /tmp/bin/
PATH=/tmp/bin/ cabal init
```