### PR TITLE
Update haddock example for recent changes.

### DIFF
--- a/Cabal/src/Distribution/Simple/PreProcess/Types.hs
+++ b/Cabal/src/Distribution/Simple/PreProcess/Types.hs
@@ -44,11 +44,12 @@ import qualified Text.PrettyPrint as Disp
 --  > ppTestHandler =
 --  >   PreProcessor {
 --  >     platformIndependent = True,
+--  >     ppOrdering = \_ _ -> return,
 --  >     runPreProcessor = mkSimplePreProcessor $ \inFile outFile verbosity ->
 --  >       do info verbosity (inFile++" has been preprocessed to "++outFile)
 --  >          stuff <- readFile inFile
 --  >          writeFile outFile ("-- preprocessed as a test\n\n" ++ stuff)
---  >          return ExitSuccess
+--  >          return ()
 --
 --  We split the input and output file names into a base directory and the
 --  rest of the file name. The input base dir is the path in the list of search


### PR DESCRIPTION
The example for using the `PreProcessor` is somewhat out of date.  This patch provides the minimal set of changes to the example to match Cabal 3.8.1 or later.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

**This PR does not modify behaviour or interface**

This PR updates documentation only.


* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
