### PR TITLE
Don't glob if glob ain't glob

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -859,7 +859,14 @@ checkGlobFile cv ddir title fp = do
   case parseFileGlob cv fp of
     -- We just skip over parse errors here; they're reported elsewhere.
     Left _ -> return ()
-    Right parsedGlob -> do
+    Right (Left filepath) -> do
+      liftInt ciPackageOps $ \po -> do
+        exist <- doesFileExist po filepath
+        return $
+          if not exist
+          then [PackageBuildWarning $ GlobNoMatch title filepath ]
+          else []
+    Right (Right parsedGlob) -> do
       liftInt ciPreDistOps $ \po -> do
         rs <- runDirFileGlobM po dir parsedGlob
         return $ checkGlobResult title fp rs
@@ -999,14 +1006,14 @@ pd2gpd pd = gpd
 -- present in our .cabal file.
 checkMissingDocs
   :: Monad m
-  => [Glob] -- data-files globs.
-  -> [Glob] -- extra-source-files globs.
-  -> [Glob] -- extra-doc-files globs.
-  -> [Glob] -- extra-files globs.
+  => [Either FilePath Glob] -- data-files globs.
+  -> [Either FilePath Glob] -- extra-source-files globs.
+  -> [Either FilePath Glob] -- extra-doc-files globs.
+  -> [Either FilePath Glob] -- extra-files globs.
   -> CheckM m ()
 checkMissingDocs dgs esgs edgs efgs = do
   extraDocSupport <- (>= CabalSpecV1_18) <$> asksCM ccSpecVersion
-
+  mpackageOps <- asksCM $ ciPackageOps . ccInterface
   -- Everything in this block uses CheckPreDistributionOps interface.
   liftInt
     ciPreDistOps
@@ -1019,7 +1026,20 @@ checkMissingDocs dgs esgs edgs efgs = do
         -- 2. Realise Globs.
         let realGlob t =
               concatMap globMatches
-                <$> mapM (runDirFileGlobM ops "") t
+                <$> mapM (\efpg ->
+                  case efpg of
+                    Left filepath -> do
+                      case mpackageOps of
+                        Nothing ->
+                          pure []
+                        Just packageOps -> do
+                          exist <- doesFileExist packageOps filepath
+                          pure $
+                            if exist
+                            then [GlobMatch filepath]
+                            else [] -- TODO: probably should signal failure here
+                    Right glob ->
+                      runDirFileGlobM ops "" glob) t
         rgs <- realGlob dgs
         res <- realGlob esgs
         red <- realGlob edgs

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -864,8 +864,8 @@ checkGlobFile cv ddir title fp = do
         exist <- doesFileExist po filepath
         return $
           if not exist
-          then [PackageBuildWarning $ GlobNoMatch title filepath ]
-          else []
+            then [PackageBuildWarning $ GlobNoMatch title filepath]
+            else []
     Right (Right parsedGlob) -> do
       liftInt ciPreDistOps $ \po -> do
         rs <- runDirFileGlobM po dir parsedGlob
@@ -1026,20 +1026,23 @@ checkMissingDocs dgs esgs edgs efgs = do
         -- 2. Realise Globs.
         let realGlob t =
               concatMap globMatches
-                <$> mapM (\efpg ->
-                  case efpg of
-                    Left filepath -> do
-                      case mpackageOps of
-                        Nothing ->
-                          pure []
-                        Just packageOps -> do
-                          exist <- doesFileExist packageOps filepath
-                          pure $
-                            if exist
-                            then [GlobMatch filepath]
-                            else [] -- TODO: probably should signal failure here
-                    Right glob ->
-                      runDirFileGlobM ops "" glob) t
+                <$> mapM
+                  ( \efpg ->
+                      case efpg of
+                        Left filepath -> do
+                          case mpackageOps of
+                            Nothing ->
+                              pure []
+                            Just packageOps -> do
+                              exist <- doesFileExist packageOps filepath
+                              pure $
+                                if exist
+                                  then [GlobMatch filepath]
+                                  else [] -- TODO: probably should signal failure here
+                        Right glob ->
+                          runDirFileGlobM ops "" glob
+                  )
+                  t
         rgs <- realGlob dgs
         res <- realGlob esgs
         red <- realGlob edgs

--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -169,7 +169,9 @@ checkPackageFilesGPD verbosity gpd root =
   where
     checkFilesIO =
       CheckPackageContentOps
-        { doesFileExist = System.doesFileExist . relative
+        { doesFileExist = \fp -> do
+            debug verbosity $ "doesFileExist: " <> fp
+            System.doesFileExist . relative $ fp
         , doesDirectoryExist = System.doesDirectoryExist . relative
         , getDirectoryContents = System.Directory.getDirectoryContents . relative
         , getFileContents = BS.readFile . relative
@@ -1027,8 +1029,8 @@ checkMissingDocs dgs esgs edgs efgs = do
         let realGlob t =
               concatMap globMatches
                 <$> mapM
-                  ( \efpg ->
-                      case efpg of
+                  ( \pathOrGlob ->
+                      case pathOrGlob of
                         Left filepath -> do
                           case mpackageOps of
                             Nothing ->

--- a/Cabal/src/Distribution/PackageDescription/Check/Paths.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Paths.hs
@@ -169,7 +169,7 @@ checkGlob
   :: Monad m
   => CabalField -- .cabal field we are checking.
   -> FilePath -- glob filepath pattern
-  -> CheckM m (Maybe Glob)
+  -> CheckM m (Maybe (Either FilePath Glob))
 checkGlob title pat = do
   ver <- asksCM ccSpecVersion
 
@@ -181,7 +181,9 @@ checkGlob title pat = do
             GlobSyntaxError title (explainGlobSyntaxError pat e)
         )
       return Nothing
-    Right wglob -> do
+    Right (Left filepath) -> do
+      pure (Just (Left filepath))
+    Right (Right wglob) -> do
       -- \* Miscellaneous checks on sane glob.
       -- Checks for recursive glob in root.
       checkP
@@ -189,7 +191,7 @@ checkGlob title pat = do
         ( PackageDistSuspiciousWarn $
             RecursiveGlobInRoot title pat
         )
-      return (Just wglob)
+      return (Just (Right wglob))
 
 -- | Whether a path is a good relative path.  We aren't worried about perfect
 -- cross-platform compatibility here; this function just checks the paths in

--- a/Cabal/src/Distribution/Simple/Glob.hs
+++ b/Cabal/src/Distribution/Simple/Glob.hs
@@ -167,7 +167,7 @@ matchDirFileGlobWithDie verbosity rip version mbWorkDir symPath =
         Right (Left filepath) -> do
           exist <- doesFileExist (dir </> filepath)
           if exist
-            then pure [ unsafeMakeSymbolicPath filepath ]
+            then pure [unsafeMakeSymbolicPath filepath]
             else rip verbosity $ MatchDirFileGlobErrors ["The filepath '" <> filepath <> "' listed in Cabal package does not exist on disk."]
         Right (Right glob) -> do
           results <- runDirFileGlob verbosity (Just version) dir glob
@@ -225,7 +225,7 @@ matchDirFileGlobWithDie verbosity rip version mbWorkDir symPath =
 parseFileGlob :: CabalSpecVersion -> FilePath -> Either GlobSyntaxError (Either FilePath Glob)
 parseFileGlob _version filepath
   | all (`notElem` filepath) "*{}," =
-    Right (Left filepath)
+      Right (Left filepath)
 parseFileGlob version filepath = case reverse (splitDirectories filepath) of
   [] ->
     Left EmptyGlob


### PR DESCRIPTION
This PR modifies the behavior around globs, such that literal filepaths (ie a string that does not contain a glob special character `"{,}*"`) skip the glob logic and are treated as bare filepaths.

Why?

I've identified that the glob logic is quite slow. Locally, it takes about 5-10ms to run through the glob checker on literal filepaths. Meanwhile, `doesFileExist` is measured in ~200ns or so. This wouldn't be a huge deal on it's own, but we have about 1,800 lines of `extra-source-files`, and the time spent in `Expanding glob` on our codebase is about 35 seconds, the vast majority of the 45-50 second lag time between `cabal repl --repl-no-load` and an empty GHCi prompt being available.

On our codebase, this patch reduces the initial boot time to just 14 seconds.

This patch followed a "type directed" approach, and this resulted in several breaking changes to the API. I can rework this to be a less breaking change, but it felt like the easiest way to ensure I covered all points of behavior.

This PR addresses the primary slowdown experienced in #10495.

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)