### PR TITLE
move ncommits check to correct place

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -85,10 +85,6 @@ pull_request_rules:
       - label=merge delay passed
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
-      # unlike the others, we need to force this one to be up to date
-      # because it's intended for when Mergify doesn't have permission
-      # to rebase
-      - '#commits-behind=0'
 
   # merge+no rebase strategy
   - actions:
@@ -101,6 +97,10 @@ pull_request_rules:
       - label=merge delay passed
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
+      # unlike the others, we need to force this one to be up to date
+      # because it's intended for when Mergify doesn't have permission
+      # to rebase
+      - '#commits-behind=0'
 
   # merge strategy for release branches
   - actions:


### PR DESCRIPTION
It's on `squash+merge me` but belongs on `merge+no rebase`. Oops!

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ `mergify.yml` is only read from `master`
