### PR TITLE
Delete second `checkPackageDescription` call

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -268,8 +268,6 @@ checkGenericPackageDescription
       checkP
         (not . null $ dups names)
         (PackageBuildImpossible $ DuplicateSections dupes)
-      -- PackageDescription checks.
-      checkPackageDescription packageDescription_
       -- Flag names.
       mapM_ checkFlagName genPackageFlags_
 


### PR DESCRIPTION
While diagnosing slow `check` times, I identified that file glob expansion was very slow, even on literal paths (#10495). This was made worse because Cabal would expand a glob four times for each `extra-source-files` line.

Fortunately, we can halve this easily: we call `checkPackageDescription` twice in `checkGenericPackageDescription`. This PR simply removes one of the calls in the function.

On our codebase, this patch has the effect of reducing the time spent expanding globs from 34s to 17s, bringing the time to do `cabal repl --repl-options "-e ()"` from 50s to 33s.

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)