### PR TITLE
make sure downloaded artifacts are all in the same dir

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -478,6 +478,7 @@ jobs:
         with:
           pattern: cabal-*
           path: binaries
+          merge-multiple: true
 
       - name: Create GitHub prerelease
         uses: softprops/action-gh-release@v2
@@ -502,6 +503,7 @@ jobs:
       with:
         pattern: cabal-*
         path: binaries
+        merge-multiple: true
 
     - run: |
         # bash-ism, but we forced bash above


### PR DESCRIPTION
It seems that when we request multiple artifacts at the same time, they are by default placed in their own subdirectories. There's a key to override this; this commit sets it.

Fixes #10515.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
