### PR TITLE
Avoid redundant glob checking

### DIFF
--- a/Cabal/src/Distribution/PackageDescription/Check.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check.hs
@@ -870,7 +870,7 @@ checkGlobFile ddir title parsedGlob = do
       pure []
     Just po -> do
       rs <- liftCM $ runDirFileGlobM po dir parsedGlob
-      mapM_ tellP (checkGlobResult title parsedGlob rs)
+      mapM_ tellCM (checkGlobResult title parsedGlob rs)
       return rs
 
 -- | Checks for matchless globs and too strict matching (<2.4 spec).

--- a/Cabal/src/Distribution/PackageDescription/Check/Monad.hs
+++ b/Cabal/src/Distribution/PackageDescription/Check/Monad.hs
@@ -39,6 +39,7 @@ module Distribution.PackageDescription.Check.Monad
   , liftInt
   , liftCM
   , tellP
+  , tellCM
   , checkSpecVer
   ) where
 

--- a/Cabal/src/Distribution/Simple/Glob/Internal.hs
+++ b/Cabal/src/Distribution/Simple/Glob/Internal.hs
@@ -61,6 +61,9 @@ instance Structured GlobPiece
 -- Parsing & pretty-printing
 
 instance Pretty Glob where
+  pretty (GlobDir [Literal "/"] pathglob) =
+    Disp.char '/'
+      Disp.<> pretty pathglob
   pretty (GlobDir glob pathglob) =
     dispGlobPieces glob
       Disp.<> Disp.char '/'


### PR DESCRIPTION
This PR modifies the glob logic to avoid doing redundant work. Results of operations are now passed forward into further checks.

Locally, this improves the time for a no-op `cabal repl` from 50s to 32s. 

Combined with my other PRs on this, I think this whole operation on our large `extra-source-files` will go from 35s to 65ms 😄 

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

---

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
