### PR TITLE
Add “Significant change” guideline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@ Include the following checklist in your PR:
 
 * [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
 * [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
+  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
 * [ ] The documentation has been updated, if necessary.
 * [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
 * [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -439,6 +439,18 @@ At release time, the entries will be merged with
 In addition, if you're changing the `.cabal` file format specification you should
 add an entry in `doc/file-format-changelog.rst`.
 
+### Is my change `significant`?
+
+Use your best judgement and if unsure ask other maintainers. If your PR fixes
+a specific ticket, how busy was the discussion there? A new command or option
+most likely warrants a `significance: significant` tag, same with command
+line changes that disrupts the workflow of many users or an API change
+that requires substantial time to integrate in a program.
+
+Put yourself in the shoes of the user: would you appreciate seeing this
+change highlighted in the announcement post or release notes overview? If
+so, add `significance: significant`.
+
 ## Communicating
 
 There are a few main venues of communication:


### PR DESCRIPTION
Add some heuristic to decide which changes are “significant” and a checkbox to remind PR authors to add the tag if appropriate.

We talked about this in the “release post-mortem” meeting. Rewrites and comments welcome.

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
