### PR TITLE
cabal-validate: --no-hide-successes

### DIFF
--- a/cabal-validate/src/Cli.hs
+++ b/cabal-validate/src/Cli.hs
@@ -233,8 +233,8 @@ resolveOpts opts = do
           else "cabal.validate.project"
 
       tastyArgs' =
-        "--hide-successes"
-          : maybe
+        optional (rawTastyHideSuccesses opts) "--hide-successes"
+          ++ maybe
             []
             (\tastyPattern -> ["--pattern", tastyPattern])
             (rawTastyPattern opts)
@@ -282,6 +282,7 @@ data RawOpts = RawOpts
   , rawExtraCompilers :: [FilePath]
   , rawTastyPattern :: Maybe String
   , rawTastyArgs :: [String]
+  , rawTastyHideSuccesses :: Bool
   , rawDoctest :: Bool
   , rawSteps :: [Step]
   , rawListSteps :: Bool
@@ -351,6 +352,11 @@ rawOptsParser =
           ( long "tasty-arg"
               <> help "Extra arguments to pass to Tasty test suites"
           )
+      )
+    <*> boolOption
+      True
+      "hide-successes"
+      ( help "Do not print tests that passed successfully"
       )
     <*> boolOption
       False


### PR DESCRIPTION
Add `./validate.sh --no-hide-successes`, which causes the test suites to print out tests that are run when they succeed. This significantly increases visibility into which tests are running.

NB: Maybe we should have `--no-default-tasty-args` or something...?

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
