### PR TITLE
Regen cabal help after #9583

### DIFF
--- a/cabal-install/src/Distribution/Client/CmdPath.hs
+++ b/cabal-install/src/Distribution/Client/CmdPath.hs
@@ -95,7 +95,7 @@ pathCommand :: CommandUI (NixStyleFlags PathFlags)
 pathCommand =
   CommandUI
     { commandName = "path"
-    , commandSynopsis = "Query for simple project information"
+    , commandSynopsis = "Query for simple project information."
     , commandDescription = Just $ \_ ->
         wrapText $
           "Query for configuration and project information such as project GHC.\n"

--- a/doc/cabal-commands.rst
+++ b/doc/cabal-commands.rst
@@ -19,7 +19,6 @@ Commands
      [global]
       user-config            Display and update the user's global cabal configuration.
       help                   Help about commands.
-      path                   Display paths used by cabal.
 
      [package database]
       update                 Updates list of known packages.
@@ -36,6 +35,7 @@ Commands
       freeze                 Freeze dependencies.
       gen-bounds             Generate dependency bounds.
       outdated               Check for outdated dependencies.
+      path                   Query for simple project information.
 
      [project building and installing]
       build                  Compile targets within the project.


### PR DESCRIPTION
Minor, regenerate `cabal help` output in command docs.

