### PR TITLE
Print info about current project file in use to stderr and ignore the imports by default

### DIFF
--- a/cabal-install-solver/src/Distribution/Solver/Types/ProjectConfigPath.hs
+++ b/cabal-install-solver/src/Distribution/Solver/Types/ProjectConfigPath.hs
@@ -16,6 +16,7 @@ module Distribution.Solver.Types.ProjectConfigPath
 
     -- * Checks and Normalization
     , isCyclicConfigPath
+    , isTopLevelConfigPath
     , canonicalizeConfigPath
     ) where
 
@@ -137,6 +138,11 @@ nullProjectConfigPath = ProjectConfigPath $ "unused" :| []
 -- the project root directory.
 isCyclicConfigPath :: ProjectConfigPath -> Bool
 isCyclicConfigPath (ProjectConfigPath p) = length p /= length (NE.nub p)
+
+-- | Check if the project config path is top-level, meaning it was not included by
+-- some other project config.
+isTopLevelConfigPath :: ProjectConfigPath -> Bool
+isTopLevelConfigPath (ProjectConfigPath p) = NE.length p == 1
 
 -- | Prepends the path of the importee to the importer path.
 consProjectConfigPath :: FilePath -> ProjectConfigPath -> ProjectConfigPath

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -37,6 +37,7 @@ module Distribution.Client.ProjectConfig
   , writeProjectLocalFreezeConfig
   , writeProjectConfigFile
   , commandLineFlagsToProjectConfig
+  , onlyTopLevelProvenance
 
     -- * Packages within projects
   , ProjectPackageLocation (..)
@@ -1753,3 +1754,9 @@ checkBadPerPackageCompilerPaths compilerPrograms packagesConfig =
        ] of
     [] -> return ()
     ps -> throwIO (BadPerPackageCompilerPaths ps)
+
+-- | Filter out non-top-level project configs
+onlyTopLevelProvenance :: Set ProjectConfigProvenance -> Set ProjectConfigProvenance
+onlyTopLevelProvenance = Set.filter $ \case
+  Implicit -> False
+  Explicit ps -> isTopLevelConfigPath ps

--- a/cabal-install/src/Distribution/Client/ProjectConfig.hs
+++ b/cabal-install/src/Distribution/Client/ProjectConfig.hs
@@ -1755,7 +1755,7 @@ checkBadPerPackageCompilerPaths compilerPrograms packagesConfig =
     [] -> return ()
     ps -> throwIO (BadPerPackageCompilerPaths ps)
 
--- | Filter out non-top-level project configs
+-- | Filter out non-top-level project configs.
 onlyTopLevelProvenance :: Set ProjectConfigProvenance -> Set ProjectConfigProvenance
 onlyTopLevelProvenance = Set.filter $ \case
   Implicit -> False

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -195,6 +195,7 @@ import Distribution.Backpack.LinkedComponent
 import Distribution.Backpack.ModuleShape
 
 import Distribution.Simple.Utils
+import Distribution.Verbosity
 import Distribution.Version
 
 import qualified Distribution.InstalledPackageInfo as IPI
@@ -397,13 +398,11 @@ rebuildProjectConfig
           localPackages <- phaseReadLocalPackages (projectConfig <> cliConfig)
           return (projectConfig, localPackages)
 
-    sequence_
-      [ do
-        notice verbosity . render . vcat $
-          text "Configuration is affected by the following files:"
-            : [text "-" <+> docProjectConfigPath path]
-      | Explicit path <- Set.toList $ projectConfigProvenance projectConfig
-      ]
+    notice (verboseStderr verbosity) . render . vcat $
+      text "Configuration is affected by the following files:"
+        : [ text "-" <+> docProjectConfigPath path
+          | Explicit path <- Set.toList $ projectConfigProvenance projectConfig
+          ]
 
     return (projectConfig <> cliConfig, localPackages)
     where

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -398,11 +398,13 @@ rebuildProjectConfig
           localPackages <- phaseReadLocalPackages (projectConfig <> cliConfig)
           return (projectConfig, localPackages)
 
-    notice (verboseStderr verbosity) . render . vcat $
-      text "Configuration is affected by the following files:"
-        : [ text "-" <+> docProjectConfigPath path
+    let configfiles =
+          [ text "-" <+> docProjectConfigPath path
           | Explicit path <- Set.toList . (if verbosity >= verbose then id else onlyTopLevelProvenance) $ projectConfigProvenance projectConfig
           ]
+    unless (null configfiles) $
+      notice (verboseStderr verbosity) . render . vcat $
+        text "Configuration is affected by the following files:" : configfiles
 
     return (projectConfig <> cliConfig, localPackages)
     where

--- a/cabal-install/src/Distribution/Client/ProjectPlanning.hs
+++ b/cabal-install/src/Distribution/Client/ProjectPlanning.hs
@@ -401,7 +401,7 @@ rebuildProjectConfig
     notice (verboseStderr verbosity) . render . vcat $
       text "Configuration is affected by the following files:"
         : [ text "-" <+> docProjectConfigPath path
-          | Explicit path <- Set.toList $ projectConfigProvenance projectConfig
+          | Explicit path <- Set.toList . (if verbosity >= verbose then id else onlyTopLevelProvenance) $ projectConfigProvenance projectConfig
           ]
 
     return (projectConfig <> cliConfig, localPackages)

--- a/cabal-testsuite/PackageTests/ConditionalAndImport/cabal.out
+++ b/cabal-testsuite/PackageTests/ConditionalAndImport/cabal.out
@@ -3,7 +3,6 @@ Downloading the latest package list from test-local-repo
 # cabal v2-run
 Configuration is affected by the following files:
 - cabal.project
-Configuration is affected by the following files:
 - extra.project
     imported by: cabal.project
 Resolving dependencies...
@@ -70,9 +69,7 @@ cyclical import of cyclical-2-out-out-self-b.config;
 Configuration is affected by the following files:
 - noncyclical-same-filename-a.config
     imported by: noncyclical-same-filename-a.project
-Configuration is affected by the following files:
 - noncyclical-same-filename-a.project
-Configuration is affected by the following files:
 - same-filename/noncyclical-same-filename-a.config
     imported by: noncyclical-same-filename-a.config
     imported by: noncyclical-same-filename-a.project
@@ -89,9 +86,7 @@ Configuration is affected by the following files:
 - noncyclical-same-filename-b.config
     imported by: same-filename/noncyclical-same-filename-b.config
     imported by: noncyclical-same-filename-b.project
-Configuration is affected by the following files:
 - noncyclical-same-filename-b.project
-Configuration is affected by the following files:
 - same-filename/noncyclical-same-filename-b.config
     imported by: noncyclical-same-filename-b.project
 Up to date
@@ -126,17 +121,14 @@ cyclical import of cyclical-same-filename-out-out-back.config;
 # cabal v2-build
 Configuration is affected by the following files:
 - hops-0.project
-Configuration is affected by the following files:
 - hops-2.config
     imported by: hops/hops-1.config
     imported by: hops-0.project
-Configuration is affected by the following files:
 - hops-4.config
     imported by: hops/hops-3.config
     imported by: hops-2.config
     imported by: hops/hops-1.config
     imported by: hops-0.project
-Configuration is affected by the following files:
 - hops-6.config
     imported by: hops/hops-5.config
     imported by: hops-4.config
@@ -144,7 +136,6 @@ Configuration is affected by the following files:
     imported by: hops-2.config
     imported by: hops/hops-1.config
     imported by: hops-0.project
-Configuration is affected by the following files:
 - hops-8.config
     imported by: hops/hops-7.config
     imported by: hops-6.config
@@ -154,22 +145,18 @@ Configuration is affected by the following files:
     imported by: hops-2.config
     imported by: hops/hops-1.config
     imported by: hops-0.project
-Configuration is affected by the following files:
 - hops/hops-1.config
     imported by: hops-0.project
-Configuration is affected by the following files:
 - hops/hops-3.config
     imported by: hops-2.config
     imported by: hops/hops-1.config
     imported by: hops-0.project
-Configuration is affected by the following files:
 - hops/hops-5.config
     imported by: hops-4.config
     imported by: hops/hops-3.config
     imported by: hops-2.config
     imported by: hops/hops-1.config
     imported by: hops-0.project
-Configuration is affected by the following files:
 - hops/hops-7.config
     imported by: hops-6.config
     imported by: hops/hops-5.config
@@ -178,7 +165,6 @@ Configuration is affected by the following files:
     imported by: hops-2.config
     imported by: hops/hops-1.config
     imported by: hops-0.project
-Configuration is affected by the following files:
 - hops/hops-9.config
     imported by: hops-8.config
     imported by: hops/hops-7.config
@@ -194,17 +180,14 @@ Up to date
 # cabal v2-build
 Configuration is affected by the following files:
 - oops-0.project
-Configuration is affected by the following files:
 - oops-2.config
     imported by: oops/oops-1.config
     imported by: oops-0.project
-Configuration is affected by the following files:
 - oops-4.config
     imported by: oops/oops-3.config
     imported by: oops-2.config
     imported by: oops/oops-1.config
     imported by: oops-0.project
-Configuration is affected by the following files:
 - oops-6.config
     imported by: oops/oops-5.config
     imported by: oops-4.config
@@ -212,7 +195,6 @@ Configuration is affected by the following files:
     imported by: oops-2.config
     imported by: oops/oops-1.config
     imported by: oops-0.project
-Configuration is affected by the following files:
 - oops-8.config
     imported by: oops/oops-7.config
     imported by: oops-6.config
@@ -222,22 +204,18 @@ Configuration is affected by the following files:
     imported by: oops-2.config
     imported by: oops/oops-1.config
     imported by: oops-0.project
-Configuration is affected by the following files:
 - oops/oops-1.config
     imported by: oops-0.project
-Configuration is affected by the following files:
 - oops/oops-3.config
     imported by: oops-2.config
     imported by: oops/oops-1.config
     imported by: oops-0.project
-Configuration is affected by the following files:
 - oops/oops-5.config
     imported by: oops-4.config
     imported by: oops/oops-3.config
     imported by: oops-2.config
     imported by: oops/oops-1.config
     imported by: oops-0.project
-Configuration is affected by the following files:
 - oops/oops-7.config
     imported by: oops-6.config
     imported by: oops/oops-5.config
@@ -246,7 +224,6 @@ Configuration is affected by the following files:
     imported by: oops-2.config
     imported by: oops/oops-1.config
     imported by: oops-0.project
-Configuration is affected by the following files:
 - oops/oops-9.config
     imported by: oops-8.config
     imported by: oops/oops-7.config
@@ -281,31 +258,25 @@ After searching the rest of the dependency tree exhaustively, these were the goa
 # cabal v2-build
 Configuration is affected by the following files:
 - yops-0.project
-Configuration is affected by the following files:
 - yops-2.config
     imported by: yops/yops-1.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops-4.config
     imported by: yops/yops-3.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops-4.config
     imported by: yops/yops-3.config
     imported by: yops-2.config
     imported by: yops/yops-1.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops-6.config
     imported by: yops/yops-5.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops-6.config
     imported by: yops/yops-5.config
     imported by: yops-4.config
     imported by: yops/yops-3.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops-6.config
     imported by: yops/yops-5.config
     imported by: yops-4.config
@@ -313,17 +284,14 @@ Configuration is affected by the following files:
     imported by: yops-2.config
     imported by: yops/yops-1.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops-8.config
     imported by: yops/yops-7.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops-8.config
     imported by: yops/yops-7.config
     imported by: yops-6.config
     imported by: yops/yops-5.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops-8.config
     imported by: yops/yops-7.config
     imported by: yops-6.config
@@ -331,7 +299,6 @@ Configuration is affected by the following files:
     imported by: yops-4.config
     imported by: yops/yops-3.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops-8.config
     imported by: yops/yops-7.config
     imported by: yops-6.config
@@ -341,48 +308,38 @@ Configuration is affected by the following files:
     imported by: yops-2.config
     imported by: yops/yops-1.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-1.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-3.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-3.config
     imported by: yops-2.config
     imported by: yops/yops-1.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-5.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-5.config
     imported by: yops-4.config
     imported by: yops/yops-3.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-5.config
     imported by: yops-4.config
     imported by: yops/yops-3.config
     imported by: yops-2.config
     imported by: yops/yops-1.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-7.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-7.config
     imported by: yops-6.config
     imported by: yops/yops-5.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-7.config
     imported by: yops-6.config
     imported by: yops/yops-5.config
     imported by: yops-4.config
     imported by: yops/yops-3.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-7.config
     imported by: yops-6.config
     imported by: yops/yops-5.config
@@ -391,22 +348,18 @@ Configuration is affected by the following files:
     imported by: yops-2.config
     imported by: yops/yops-1.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-9.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-9.config
     imported by: yops-8.config
     imported by: yops/yops-7.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-9.config
     imported by: yops-8.config
     imported by: yops/yops-7.config
     imported by: yops-6.config
     imported by: yops/yops-5.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-9.config
     imported by: yops-8.config
     imported by: yops/yops-7.config
@@ -415,7 +368,6 @@ Configuration is affected by the following files:
     imported by: yops-4.config
     imported by: yops/yops-3.config
     imported by: yops-0.project
-Configuration is affected by the following files:
 - yops/yops-9.config
     imported by: yops-8.config
     imported by: yops/yops-7.config

--- a/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/cabal.out
+++ b/cabal-testsuite/PackageTests/NewConfigure/LocalConfigOverwrite/cabal.out
@@ -1,12 +1,10 @@
 # cabal v2-configure
 Configuration is affected by the following files:
 - cabal.project
-Configuration is affected by the following files:
 - cabal.project.local
 'cabal.project.local' already exists, backing it up to 'cabal.project.local~'.
 # cabal v2-configure
 Configuration is affected by the following files:
 - foo.project
-Configuration is affected by the following files:
 - foo.project.local
 'foo.project.local' already exists, backing it up to 'foo.project.local~'.

--- a/cabal-testsuite/PackageTests/NewFreeze/BuildTools/new_freeze.out
+++ b/cabal-testsuite/PackageTests/NewFreeze/BuildTools/new_freeze.out
@@ -18,7 +18,6 @@ Wrote freeze file: <ROOT>/cabal.project.freeze
 # cabal v2-build
 Configuration is affected by the following files:
 - cabal.project
-Configuration is affected by the following files:
 - cabal.project.freeze
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1

--- a/cabal-testsuite/PackageTests/NewFreeze/Flags/new_freeze.out
+++ b/cabal-testsuite/PackageTests/NewFreeze/Flags/new_freeze.out
@@ -17,7 +17,6 @@ Wrote freeze file: <ROOT>/cabal.project.freeze
 # cabal v2-build
 Configuration is affected by the following files:
 - cabal.project
-Configuration is affected by the following files:
 - cabal.project.freeze
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1

--- a/cabal-testsuite/PackageTests/NewFreeze/FreezeFile/new_freeze.out
+++ b/cabal-testsuite/PackageTests/NewFreeze/FreezeFile/new_freeze.out
@@ -24,7 +24,6 @@ Wrote freeze file: <ROOT>/cabal.project.freeze
 # cabal v2-build
 Configuration is affected by the following files:
 - cabal.project
-Configuration is affected by the following files:
 - cabal.project.freeze
 Resolving dependencies...
 Build profile: -w ghc-<GHCVER> -O1
@@ -41,7 +40,6 @@ Building executable 'my-exe' for my-local-package-1.0...
 # cabal v2-freeze
 Configuration is affected by the following files:
 - cabal.project
-Configuration is affected by the following files:
 - cabal.project.freeze
 Wrote freeze file: <ROOT>/cabal.project.freeze
 # cabal v2-build

--- a/cabal-testsuite/PackageTests/Path/Config/cabal.out
+++ b/cabal-testsuite/PackageTests/Path/Config/cabal.out
@@ -47,10 +47,13 @@ test-dir
 # cabal path
 <ROOT>/cabal.dist/home/.cabal
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal
 # cabal path
+Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","cache-home":"<ROOT>/cabal.dist/home/.cabal"}
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal
 # cabal path
 Configuration is affected by the following files:
@@ -71,10 +74,13 @@ my-cache-dir
 # cabal path
 my-cache-dir
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/packages
 # cabal path
+Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","remote-repo-cache":"<ROOT>/cabal.dist/home/.cabal/packages"}
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/packages
 # cabal path
 Configuration is affected by the following files:
@@ -95,10 +101,13 @@ my-logs-dir
 # cabal path
 my-logs-dir
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/logs
 # cabal path
+Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","logs-dir":"<ROOT>/cabal.dist/home/.cabal/logs"}
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/logs
 # cabal path
 Configuration is affected by the following files:
@@ -119,10 +128,13 @@ my-store-dir
 # cabal path
 my-store-dir
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/store
 # cabal path
+Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","store-dir":"<ROOT>/cabal.dist/home/.cabal/store"}
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/store
 # cabal path
 Configuration is affected by the following files:
@@ -143,10 +155,13 @@ fake-cabal.config
 # cabal path
 fake-cabal.config
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/config
 # cabal path
+Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","config-file":"<ROOT>/cabal.dist/home/.cabal/config"}
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/config
 # cabal path
 Configuration is affected by the following files:
@@ -167,10 +182,13 @@ my-installdir
 # cabal path
 my-installdir
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/bin
 # cabal path
+Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","installdir":"<ROOT>/cabal.dist/home/.cabal/bin"}
 # cabal path
+Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/bin
 # cabal path
 Configuration is affected by the following files:

--- a/cabal-testsuite/PackageTests/Path/Config/cabal.out
+++ b/cabal-testsuite/PackageTests/Path/Config/cabal.out
@@ -47,13 +47,10 @@ test-dir
 # cabal path
 <ROOT>/cabal.dist/home/.cabal
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal
 # cabal path
-Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","cache-home":"<ROOT>/cabal.dist/home/.cabal"}
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal
 # cabal path
 Configuration is affected by the following files:
@@ -74,13 +71,10 @@ my-cache-dir
 # cabal path
 my-cache-dir
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/packages
 # cabal path
-Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","remote-repo-cache":"<ROOT>/cabal.dist/home/.cabal/packages"}
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/packages
 # cabal path
 Configuration is affected by the following files:
@@ -101,13 +95,10 @@ my-logs-dir
 # cabal path
 my-logs-dir
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/logs
 # cabal path
-Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","logs-dir":"<ROOT>/cabal.dist/home/.cabal/logs"}
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/logs
 # cabal path
 Configuration is affected by the following files:
@@ -128,13 +119,10 @@ my-store-dir
 # cabal path
 my-store-dir
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/store
 # cabal path
-Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","store-dir":"<ROOT>/cabal.dist/home/.cabal/store"}
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/store
 # cabal path
 Configuration is affected by the following files:
@@ -155,13 +143,10 @@ fake-cabal.config
 # cabal path
 fake-cabal.config
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/config
 # cabal path
-Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","config-file":"<ROOT>/cabal.dist/home/.cabal/config"}
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/config
 # cabal path
 Configuration is affected by the following files:
@@ -182,13 +167,10 @@ my-installdir
 # cabal path
 my-installdir
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/bin
 # cabal path
-Configuration is affected by the following files:
 {"cabal-version":"<CABAL_INSTALL_VER>","installdir":"<ROOT>/cabal.dist/home/.cabal/bin"}
 # cabal path
-Configuration is affected by the following files:
 <ROOT>/cabal.dist/home/.cabal/bin
 # cabal path
 Configuration is affected by the following files:

--- a/cabal-testsuite/PackageTests/RelativePathProjectImports/cabal.out
+++ b/cabal-testsuite/PackageTests/RelativePathProjectImports/cabal.out
@@ -1,7 +1,6 @@
 # cabal build
 Configuration is affected by the following files:
 - cabal.project
-Configuration is affected by the following files:
 - dep/cabal.project
     imported by: cabal.project
 Resolving dependencies...
@@ -22,7 +21,6 @@ Building library for main-0.1...
 # cabal build
 Configuration is affected by the following files:
 - cabal.project
-Configuration is affected by the following files:
 - dep/cabal.project
     imported by: cabal.project
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/VersionPriority/1-local.out
+++ b/cabal-testsuite/PackageTests/VersionPriority/1-local.out
@@ -3,7 +3,6 @@ Downloading the latest package list from test-local-repo
 # cabal v2-build
 Configuration is affected by the following files:
 - 1-local-constraints-import.project
-Configuration is affected by the following files:
 - stackage-local.config
     imported by: 1-local-constraints-import.project
 Resolving dependencies...
@@ -21,7 +20,6 @@ After searching the rest of the dependency tree exhaustively, these were the goa
 # cabal v2-build
 Configuration is affected by the following files:
 - 1-local-import-constraints.project
-Configuration is affected by the following files:
 - stackage-local.config
     imported by: 1-local-import-constraints.project
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/VersionPriority/1-web.out
+++ b/cabal-testsuite/PackageTests/VersionPriority/1-web.out
@@ -3,10 +3,8 @@ Downloading the latest package list from test-local-repo
 # cabal v2-build
 Configuration is affected by the following files:
 - 1-web-constraints-import.project
-Configuration is affected by the following files:
 - project-stackage/nightly-2023-12-07.config
     imported by: 1-web-constraints-import.project
-Configuration is affected by the following files:
 - with-ghc.config
     imported by: 1-web-constraints-import.project
 Resolving dependencies...
@@ -24,10 +22,8 @@ After searching the rest of the dependency tree exhaustively, these were the goa
 # cabal v2-build
 Configuration is affected by the following files:
 - 1-web-import-constraints.project
-Configuration is affected by the following files:
 - project-stackage/nightly-2023-12-07.config
     imported by: 1-web-import-constraints.project
-Configuration is affected by the following files:
 - with-ghc.config
     imported by: 1-web-import-constraints.project
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/VersionPriority/2-local.out
+++ b/cabal-testsuite/PackageTests/VersionPriority/2-local.out
@@ -3,10 +3,8 @@ Downloading the latest package list from test-local-repo
 # cabal v2-build
 Configuration is affected by the following files:
 - 2-local-constraints-import.project
-Configuration is affected by the following files:
 - hop-local.config
     imported by: 2-local-constraints-import.project
-Configuration is affected by the following files:
 - stackage-local.config
     imported by: hop-local.config
     imported by: 2-local-constraints-import.project
@@ -26,10 +24,8 @@ After searching the rest of the dependency tree exhaustively, these were the goa
 # cabal v2-build
 Configuration is affected by the following files:
 - 2-local-import-constraints.project
-Configuration is affected by the following files:
 - hop-local.config
     imported by: 2-local-import-constraints.project
-Configuration is affected by the following files:
 - stackage-local.config
     imported by: hop-local.config
     imported by: 2-local-import-constraints.project

--- a/cabal-testsuite/PackageTests/VersionPriority/2-web.out
+++ b/cabal-testsuite/PackageTests/VersionPriority/2-web.out
@@ -3,14 +3,11 @@ Downloading the latest package list from test-local-repo
 # cabal v2-build
 Configuration is affected by the following files:
 - 2-web-constraints-import.project
-Configuration is affected by the following files:
 - project-stackage/nightly-2023-12-07.config
     imported by: stackage-web.config
     imported by: 2-web-constraints-import.project
-Configuration is affected by the following files:
 - stackage-web.config
     imported by: 2-web-constraints-import.project
-Configuration is affected by the following files:
 - with-ghc.config
     imported by: 2-web-constraints-import.project
 Resolving dependencies...
@@ -29,14 +26,11 @@ After searching the rest of the dependency tree exhaustively, these were the goa
 # cabal v2-build
 Configuration is affected by the following files:
 - 2-web-import-constraints.project
-Configuration is affected by the following files:
 - project-stackage/nightly-2023-12-07.config
     imported by: stackage-web.config
     imported by: 2-web-import-constraints.project
-Configuration is affected by the following files:
 - stackage-web.config
     imported by: 2-web-import-constraints.project
-Configuration is affected by the following files:
 - with-ghc.config
     imported by: 2-web-import-constraints.project
 Resolving dependencies...

--- a/cabal-testsuite/PackageTests/VersionPriority/3-web.out
+++ b/cabal-testsuite/PackageTests/VersionPriority/3-web.out
@@ -3,19 +3,15 @@ Downloading the latest package list from test-local-repo
 # cabal v2-build
 Configuration is affected by the following files:
 - 3-web-constraints-import.project
-Configuration is affected by the following files:
 - hop-web.config
     imported by: 3-web-constraints-import.project
-Configuration is affected by the following files:
 - project-stackage/nightly-2023-12-07.config
     imported by: stackage-web.config
     imported by: hop-web.config
     imported by: 3-web-constraints-import.project
-Configuration is affected by the following files:
 - stackage-web.config
     imported by: hop-web.config
     imported by: 3-web-constraints-import.project
-Configuration is affected by the following files:
 - with-ghc.config
     imported by: 3-web-constraints-import.project
 Resolving dependencies...
@@ -35,19 +31,15 @@ After searching the rest of the dependency tree exhaustively, these were the goa
 # cabal v2-build
 Configuration is affected by the following files:
 - 3-web-import-constraints.project
-Configuration is affected by the following files:
 - hop-web.config
     imported by: 3-web-import-constraints.project
-Configuration is affected by the following files:
 - project-stackage/nightly-2023-12-07.config
     imported by: stackage-web.config
     imported by: hop-web.config
     imported by: 3-web-import-constraints.project
-Configuration is affected by the following files:
 - stackage-web.config
     imported by: hop-web.config
     imported by: 3-web-import-constraints.project
-Configuration is affected by the following files:
 - with-ghc.config
     imported by: 3-web-import-constraints.project
 Resolving dependencies...


### PR DESCRIPTION
fix #10547 by printing the project config info to stderr. 

Also, report only top-level project configs with the default verbosity. Otherwise, imported config files can still be seen in the verbose mode.

## Manual Q/A

Try to reproduce  #10547

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [N/A] This fixes code that has not been released yet. ~~Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).~~
  * [x] NO ~~[Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.~~
* [N/A] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

