### PR TITLE
Duplicate VCS content

### DIFF
--- a/doc/cabal-package-description-file.rst
+++ b/doc/cabal-package-description-file.rst
@@ -2747,21 +2747,27 @@ The :ref:`VCS fields<vcs-fields>` of ``source-repository`` are:
 
     This field is required.
 
+    .. include:: vcs/kind.rst
+
 .. pkg-field:: location: VCS location
 
     This field is required.
 
-.. pkg-field:: module: token
+    .. include:: vcs/location.rst
 
-    CVS requires a named module, as each CVS server can host multiple
-    named repositories.
+.. pkg-field:: module: token
 
     This field is required for the CVS repository type and should not be
     used otherwise.
 
+    CVS requires a named module, as each CVS server can host multiple
+    named repositories.
+
 .. pkg-field:: branch: VCS branch
 
     This field is optional.
+
+    .. include:: vcs/branch.rst
 
 .. pkg-field:: tag: VCS tag
 
@@ -2770,10 +2776,13 @@ The :ref:`VCS fields<vcs-fields>` of ``source-repository`` are:
     This might be used to indicate what sources to get if someone needs to fix a
     bug in an older branch that is no longer an active head branch.
 
+    .. include:: vcs/tag.rst
+
 .. pkg-field:: subdir: VCS subdirectory
 
     This field is optional but, if given, specifies a single subdirectory.
 
+    .. include:: vcs/subdir.rst
 
 .. _setup-hooks:
 

--- a/doc/cabal-project-description-file.rst
+++ b/doc/cabal-project-description-file.rst
@@ -269,22 +269,32 @@ The :ref:`VCS fields<vcs-fields>` of ``source-repository-package`` are:
 
     This field is required.
 
+    .. include:: vcs/kind.rst
+
 .. cfg-field:: location: VCS location
 
     This field is required.
+
+    .. include:: vcs/location.rst
 
 .. cfg-field:: branch: VCS branch
 
     This field is optional.
 
+    .. include:: vcs/branch.rst
+
 .. cfg-field:: tag: VCS tag
 
     This field is optional.
+
+    .. include:: vcs/tag.rst
 
 .. cfg-field:: subdir: VCS subdirectory list
 
     Look in one or more subdirectories of the repository for cabal files, rather
     than the root. This field is optional.
+
+    .. include:: vcs/subdir.rst
 
 .. cfg-field:: post-checkout-command: command
 

--- a/doc/vcs/branch.rst
+++ b/doc/vcs/branch.rst
@@ -1,0 +1,8 @@
+..
+  VCS branch
+
+Many source control systems support the notion of a branch, as a distinct
+concept from having repositories in separate locations. For example CVS, SVN and
+git use branches while darcs uses different locations for different branches. If
+you need to specify a branch to identify a your repository then specify it in
+this field.

--- a/doc/vcs/fields.rst
+++ b/doc/vcs/fields.rst
@@ -1,0 +1,34 @@
+..
+  VCS common fields
+
+Most of the version control system (VCS) fields types are common to both
+``source-repository`` and ``source-repository-package`` stanzas.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 30 30 40
+
+    * - Field Name
+      - source-repository (head|this)
+      - source-repository-package
+    * - type
+      - [x]
+      - [x]
+    * - location
+      - [x]
+      - [x]
+    * - branch
+      - [x]
+      - [x]
+    * - tag
+      - [x]
+      - [x]
+    * - subdir
+      - [x] (0 or 1)
+      - [x] (0 or 1 for each dependency)
+    * - module (CVS only)
+      - [x]
+      - [_]
+    * - post-checkout-command
+      - [_]
+      - [x]

--- a/doc/vcs/kind.rst
+++ b/doc/vcs/kind.rst
@@ -1,0 +1,19 @@
+..
+  VCS kind
+
+Cabal supports specifying different information for various common source
+control systems. This is the name of the source control system used for a
+repository. The currently recognised types are:
+
+-  ``darcs``
+-  ``git``
+-  ``svn``
+-  ``cvs``
+-  ``mercurial`` (or alias ``hg``)
+-  ``bazaar`` (or alias ``bzr``)
+-  ``arch``
+-  ``monotone``
+-  ``pijul``
+
+The VCS kind will determine what other fields are appropriate to specify for a
+particular version control system.

--- a/doc/vcs/location.rst
+++ b/doc/vcs/location.rst
@@ -1,0 +1,9 @@
+..
+  VCS location
+
+The location of the repository, usually a URL but the exact form of this field
+depends on the repository type. For example:
+
+-  for Darcs: ``http://code.haskell.org/foo/``
+-  for Git: ``https://github.com/foo/bar.git``
+-  for CVS: ``anoncvs@cvs.foo.org:/cvs``

--- a/doc/vcs/subdir.rst
+++ b/doc/vcs/subdir.rst
@@ -1,0 +1,11 @@
+..
+  VCS subdirectory
+
+A field of this type is always optional because it defaults to empty, which
+corresponds to the root directory of the repository and is the same as
+specifying ``.`` explicitly.
+
+Some projects put the sources for multiple packages inside a single VCS
+repository. This field lets you specify the relative path from the root of the
+repository to the top directory for the package, i.e. the directory containing
+the package's ``.cabal`` file.

--- a/doc/vcs/tag.rst
+++ b/doc/vcs/tag.rst
@@ -1,0 +1,5 @@
+..
+  VCS tag
+
+A tag identifies a particular state of a source repository.  The exact form of
+the tag depends on the repository type.

--- a/doc/version-control-fields.rst
+++ b/doc/version-control-fields.rst
@@ -3,93 +3,31 @@ Version Control System Fields
 
 .. _vcs-fields:
 
-Most of the version control system (VCS) fields types are common to both
-``source-repository`` and ``source-repository-package`` stanzas.
-
-.. list-table::
-    :header-rows: 1
-    :widths: 30 30 40
-
-    * - Field Name
-      - source-repository (head|this)
-      - source-repository-package
-    * - type
-      - [x]
-      - [x]
-    * - location
-      - [x]
-      - [x]
-    * - branch
-      - [x]
-      - [x]
-    * - tag
-      - [x]
-      - [x]
-    * - subdir
-      - [x] (0 or 1)
-      - [x] (0 or 1 for each dependency)
-    * - module (CVS only)
-      - [x]
-      - [_]
-    * - post-checkout-command
-      - [_]
-      - [x]
+.. include:: vcs/fields.rst
 
 .. _vcs-kind:
 
 VCS kind
 ^^^^^^^^
 
-Cabal supports specifying different information for various common source
-control systems. This is the name of the source control system used for a
-repository. The currently recognised types are:
-
--  ``darcs``
--  ``git``
--  ``svn``
--  ``cvs``
--  ``mercurial`` (or alias ``hg``)
--  ``bazaar`` (or alias ``bzr``)
--  ``arch``
--  ``monotone``
--  ``pijul``
-
-The VCS kind will determine what other fields are appropriate to specify for a
-particular version control system.
+.. include:: vcs/kind.rst
 
 VCS location
 ^^^^^^^^^^^^
 
-The location of the repository, usually a URL but the exact form of this field
-depends on the repository type. For example:
-
--  for Darcs: ``http://code.haskell.org/foo/``
--  for Git: ``https://github.com/foo/bar.git``
--  for CVS: ``anoncvs@cvs.foo.org:/cvs``
+.. include:: vcs/location.rst
 
 VCS branch
 ^^^^^^^^^^
 
-Many source control systems support the notion of a branch, as a distinct
-concept from having repositories in separate locations. For example CVS, SVN and
-git use branches while darcs uses different locations for different branches. If
-you need to specify a branch to identify a your repository then specify it in
-this field.
+.. include:: vcs/branch.rst
 
 VCS tag
 ^^^^^^^
 
-A tag identifies a particular state of a source repository.  The exact form of
-the tag depends on the repository type.
+.. include:: vcs/tag.rst
 
 VCS subdirectory
 ^^^^^^^^^^^^^^^^
 
-A field of this type is always optional because it defaults to empty, which
-corresponds to the root directory of the repository and is the same as
-specifying ``.`` explicitly.
-
-Some projects put the sources for multiple packages inside a single VCS
-repository. This field lets you specify the relative path from the root of the
-repository to the top directory for the package, i.e. the directory containing
-the package's ``.cabal`` file.
+.. include:: vcs/subdir.rst


### PR DESCRIPTION
Duplicate the VCS content by include reuse, avoiding copy and paste, as I suggested in https://github.com/haskell/cabal/pull/10543#issuecomment-2471095352.

## Background

Both package and project pages have content for version control system (VCS) fields.

> [!NOTE]
> With #9701 I'd moved VCS field content to its own page, ["Version Control System Fields"](https://cabal.readthedocs.io/en/latest/version-control-fields.html) page. This PR doesn't change that, neither in the table of contents or how that page is rendered.

## Include Reuse

I am proposing this change, to create a folder for these includes and in that put `*.rst` snippet content for `.. include::` inclusion by other pages. I duplicate the VCS field content, as it exists now, within both package and project pages and retain the "Version Control System Fields" page.

> [!NOTE]
> Initially, I'd moved the VCS fields page to a new "Version Control Reference" in the table of contents, outside the "Cabal Reference", but have reverted that.

## Merge Order

I would like to see this merged before #10543 so that any further changes that are in addition to the duplication of content are proposed on their own.

> [!WARNING]
> Copy and paste duplication (as #10543 proposes) would be vulnerable to the two copies (on the package and project pages) drifting apart. That would be a maintenance burden (if we noticed) or a user let down (if we updated one copy but not the other).

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
