### PR TITLE
end the `#commits-behind=0` experiment

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -97,10 +97,6 @@ pull_request_rules:
       - label=merge delay passed
       - '#approved-reviews-by>=2'
       - '-label~=^blocked:'
-      # unlike the others, we need to force this one to be up to date
-      # because it's intended for when Mergify doesn't have permission
-      # to rebase
-      - '#commits-behind=0'
 
   # merge strategy for release branches
   - actions:


### PR DESCRIPTION
The problem with it turns out to be that you get no warning at all if it's waiting to be manually rebased; you have to inspect the Mergify state to find out. At least with the old behavior you got an error when Mergify tried to rebase it, and you knew why.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ Mergify ignores config files not on `master`
