### PR TITLE
`cabal-validate`: Better output verbosity defaults 

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -192,12 +192,6 @@ jobs:
           fi
           echo "FLAGS=$FLAGS" >> "$GITHUB_ENV"
 
-      - name: Validate print-config
-        run: sh validate.sh $FLAGS -s print-config
-
-      - name: Validate print-tool-versions
-        run: sh validate.sh $FLAGS -s print-tool-versions
-
       - name: Validate build
         run: sh validate.sh $FLAGS -s build
 
@@ -453,9 +447,6 @@ jobs:
 
       - name: Untar the cabal executable
         run: tar -xzf "./cabal-head/cabal-head-${{ runner.os }}-$CABAL_ARCH.tar.gz" -C cabal-head
-
-      - name: print-config using cabal HEAD
-        run: sh validate.sh ${{ env.COMMON_FLAGS }} --with-cabal ./cabal-head/cabal -s print-config
 
       # We dont use cache to force a build with a fresh store dir and build dir
       # This way we check cabal can build all its dependencies

--- a/cabal-validate/src/Cli.hs
+++ b/cabal-validate/src/Cli.hs
@@ -179,11 +179,7 @@ resolveOpts opts = do
           then rawSteps opts
           else
             concat
-              [
-                [ PrintConfig
-                , PrintToolVersions
-                , Build
-                ]
+              [ [Build]
               , optional (rawDoctest opts) Doctest
               , optional (rawRunLibTests opts) LibTests
               , optional (rawRunLibSuite opts) LibSuite
@@ -191,7 +187,6 @@ resolveOpts opts = do
               , optional (rawRunCliTests opts && not (rawLibOnly opts)) CliTests
               , optional (rawRunCliSuite opts && not (rawLibOnly opts)) CliSuite
               , optionals (rawSolverBenchmarks opts) [SolverBenchmarksTests, SolverBenchmarksRun]
-              , [TimeSummary]
               ]
 
       targets' =

--- a/cabal-validate/src/Main.hs
+++ b/cabal-validate/src/Main.hs
@@ -7,7 +7,7 @@ module Main
   , runStep
   ) where
 
-import Control.Monad (forM_, when)
+import Control.Monad (forM_)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as T (toStrict)
@@ -16,7 +16,7 @@ import Data.Version (makeVersion, showVersion)
 import System.FilePath ((</>))
 import System.Process.Typed (proc, readProcessStdout_)
 
-import Cli (Compiler (..), HackageTests (..), Opts (..), parseOpts)
+import Cli (Compiler (..), HackageTests (..), Opts (..), parseOpts, whenVerbose)
 import OutputUtil (printHeader, withTiming)
 import ProcessUtil (timed, timedWithCwd)
 import Step (Step (..), displayStep)
@@ -137,7 +137,7 @@ timedCabalBin opts package component args = do
 -- | Print the configuration for CI logs.
 printConfig :: Opts -> IO ()
 printConfig opts =
-  when (verbose opts) $
+  whenVerbose opts $ do
     printHeader "Configuration"
     putStr $
       unlines
@@ -151,8 +151,8 @@ printConfig opts =
             <> unwords (map displayStep (steps opts))
         , "Hackage tests:     "
             <> show (hackageTests opts)
-        , "verbose:           "
-            <> show (verbose opts)
+        , "verbosity:         "
+            <> show (verbosity opts)
         , "extra compilers:   "
             <> unwords (extraCompilers opts)
         , "extra RTS options: "
@@ -162,7 +162,7 @@ printConfig opts =
 -- | Print the versions of tools being used.
 printToolVersions :: Opts -> IO ()
 printToolVersions opts =
-  when (verbose opts) $ do
+  whenVerbose opts $ do
     printHeader "Tool versions"
     timed opts (cabal opts) ["--version"]
     timed opts (compilerExecutable (compiler opts)) ["--version"]
@@ -173,7 +173,7 @@ printToolVersions opts =
 -- | Run the build step.
 build :: Opts -> IO ()
 build opts = do
-  when (verbose opts) $ do
+  whenVerbose opts $ do
     printHeader "build (dry run)"
     timed
       opts

--- a/cabal-validate/src/Main.hs
+++ b/cabal-validate/src/Main.hs
@@ -173,24 +173,25 @@ printToolVersions opts =
 -- | Run the build step.
 build :: Opts -> IO ()
 build opts = do
-  printHeader "build (dry run)"
-  timed
-    opts
-    (cabal opts)
-    ( cabalNewBuildArgs opts
-        ++ targets opts
-        ++ ["--dry-run"]
-    )
+  when (verbose opts) $ do
+    printHeader "build (dry run)"
+    timed
+      opts
+      (cabal opts)
+      ( cabalNewBuildArgs opts
+          ++ targets opts
+          ++ ["--dry-run"]
+      )
 
-  printHeader "build (full build plan; cached and to-be-built dependencies)"
-  timed
-    opts
-    "jq"
-    [ "-r"
-    , -- TODO: Maybe use `cabal-plan`? It's a heavy dependency though...
-      ".\"install-plan\" | map(.\"pkg-name\" + \"-\" + .\"pkg-version\" + \" \" + .\"component-name\") | join(\"\n\")"
-    , baseBuildDir opts </> "cache" </> "plan.json"
-    ]
+    printHeader "build (full build plan; cached and to-be-built dependencies)"
+    timed
+      opts
+      "jq"
+      [ "-r"
+      , -- TODO: Maybe use `cabal-plan`? It's a heavy dependency though...
+        ".\"install-plan\" | map(.\"pkg-name\" + \"-\" + .\"pkg-version\" + \" \" + .\"component-name\") | join(\"\n\")"
+      , baseBuildDir opts </> "cache" </> "plan.json"
+      ]
 
   printHeader "build (actual build)"
   timed

--- a/cabal-validate/src/ProcessUtil.hs
+++ b/cabal-validate/src/ProcessUtil.hs
@@ -62,7 +62,7 @@ timed opts command args = do
       <> setSGR [Reset]
 
   (exitCode, rawStdout, rawStderr) <-
-    if verbosity opts >= Verbose
+    if verbosity opts > Quiet
       then do
         exitCode <- runProcess process
         pure (exitCode, ByteString.empty, ByteString.empty)
@@ -81,9 +81,9 @@ timed opts command args = do
 
   case exitCode of
     ExitSuccess -> do
-      -- Output is captured unless `--verbose` is used, so only print it here
-      -- if `--verbose` _isn't_ used.
-      when (verbosity opts <= Info) $ do
+      -- Output is captured when `--quiet` is used, so only print it here
+      -- if `--quiet` _isn't_ used.
+      when (verbosity opts > Quiet) $ do
         if hiddenLines <= 0
           then T.putStrLn output
           else

--- a/cabal-validate/src/Step.hs
+++ b/cabal-validate/src/Step.hs
@@ -11,9 +11,7 @@ import qualified Data.Map.Strict as Map
 
 -- | A step to be run by @cabal-validate@.
 data Step
-  = PrintConfig
-  | PrintToolVersions
-  | Build
+  = Build
   | Doctest
   | LibTests
   | LibSuite
@@ -22,7 +20,6 @@ data Step
   | CliSuite
   | SolverBenchmarksTests
   | SolverBenchmarksRun
-  | TimeSummary
   deriving (Eq, Enum, Bounded, Show)
 
 -- | Get the display identifier for a given `Step`.
@@ -34,8 +31,6 @@ data Step
 displayStep :: Step -> String
 displayStep step =
   case step of
-    PrintConfig -> "print-config"
-    PrintToolVersions -> "print-tool-versions"
     Build -> "build"
     Doctest -> "doctest"
     LibTests -> "lib-tests"
@@ -45,7 +40,6 @@ displayStep step =
     CliSuite -> "cli-suite"
     SolverBenchmarksTests -> "solver-benchmarks-tests"
     SolverBenchmarksRun -> "solver-benchmarks-run"
-    TimeSummary -> "time-summary"
 
 -- | A map from step names to `Steps`.
 --


### PR DESCRIPTION
Closes #10569
Closes #10570

A new `--quiet` switch has been added, and some behavior in `./validate.sh` (without `--verbose`) has been moved into `--quiet` mode:

- `--hide-successes` will be passed to test suites in `--quiet` mode, making it easier to track tests as they run
- Subprocess output is only captured in `--quiet` mode, making it easier to watch `cabal build` and test suite output

Some output has been hidden unless `--verbose` is used:
- The build plan (listing of all local packages and transitive dependencies) and the dry-run build used to produce the build plan are skipped unless `--verbose` is given
- The runtime configuration (e.g. the `ghc` and `cabal-install` executables being used) and tool versions are not printed unless `--verbose` is given

Additionally, `print-config`, `print-tool-versions`, and `time-summary` are no longer explicit steps, and are instead run implicitly. This means that `./validate.sh -v -s build` will print the config and tool versions; they do not have to be listed explicitly.

`time-summary` is redundant in its current form and is removed. It may be added back in the future with more detailed output (e.g., which steps were run, how long did they take individually). (Partially closes #10571)
