### PR TITLE
3.14: make Cabal-hooks version track Cabal version

### DIFF
--- a/Cabal-hooks/Cabal-hooks.cabal
+++ b/Cabal-hooks/Cabal-hooks.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name:          Cabal-hooks
-version:       0.1
+version:       3.14
 copyright:     2023, Cabal Development Team
 license:       BSD-3-Clause
 license-file:  LICENSE

--- a/Cabal-hooks/changelog.md
+++ b/Cabal-hooks/changelog.md
@@ -1,6 +1,6 @@
 # Changelog for `Cabal-hooks`
 
-## 0.1 – December 2023
+## 3.14 – December 2023
 
   * Initial release of the `Hooks` API.
 

--- a/Cabal-hooks/changelog.md
+++ b/Cabal-hooks/changelog.md
@@ -1,6 +1,6 @@
 # Changelog for `Cabal-hooks`
 
-## 3.14 – December 2023
+## 3.14 – November 2024
 
   * Initial release of the `Hooks` API.
 

--- a/Cabal-hooks/src/Distribution/Simple/SetupHooks.hs
+++ b/Cabal-hooks/src/Distribution/Simple/SetupHooks.hs
@@ -260,7 +260,7 @@ Usage example:
 > custom-setup
 >   setup-depends:
 >     base        >= 4.18 && < 5,
->     Cabal-hooks >= 0.1  && < 0.2
+>     Cabal-hooks >= 3.14 && < 3.15
 >
 > The declared Cabal version should also be at least 3.14.
 

--- a/bootstrap/linux-9.0.2.json
+++ b/bootstrap/linux-9.0.2.json
@@ -202,7 +202,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "0.1"
+            "version": "3.14"
         },
         {
             "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",

--- a/bootstrap/linux-9.2.8.json
+++ b/bootstrap/linux-9.2.8.json
@@ -172,7 +172,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "0.1"
+            "version": "3.14"
         },
         {
             "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",

--- a/bootstrap/linux-9.4.8.json
+++ b/bootstrap/linux-9.4.8.json
@@ -172,7 +172,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "0.1"
+            "version": "3.14"
         },
         {
             "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",

--- a/bootstrap/linux-9.6.4.json
+++ b/bootstrap/linux-9.6.4.json
@@ -132,7 +132,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "0.1"
+            "version": "3.14"
         },
         {
             "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",

--- a/bootstrap/linux-9.8.2.json
+++ b/bootstrap/linux-9.8.2.json
@@ -136,7 +136,7 @@
             "revision": null,
             "source": "local",
             "src_sha256": null,
-            "version": "0.1"
+            "version": "3.14"
         },
         {
             "cabal_sha256": "60e78b6c60dc32a77ce6c37ed5ca4e838fc5f76f02836ef64d93cd21cc002325",

--- a/cabal-testsuite/main/cabal-tests.hs
+++ b/cabal-testsuite/main/cabal-tests.hs
@@ -161,12 +161,10 @@ buildCabalLibsSpecific ver verb mbGhc builddir_rel = do
   csgot <- doesDirectoryExist (dir </> "Cabal-syntax-" ++ ver)
   unless csgot $
     runProgramInvocation verb ((programInvocation cabal ["get", "Cabal-syntax-" ++ ver]) { progInvokeCwd = Just dir })
-  let hooksVerFromVer _ = "0.1"
-      hooksVer = hooksVerFromVer ver
-  chgot <- doesDirectoryExist (dir </> "Cabal-hooks-" ++ hooksVer)
+  chgot <- doesDirectoryExist (dir </> "Cabal-hooks-" ++ ver)
   unless chgot $
-    runProgramInvocation verb ((programInvocation cabal ["get", "Cabal-hooks-" ++ hooksVer]) { progInvokeCwd = Just dir })
-  buildCabalLibsProject ("packages: Cabal-" ++ ver ++ " Cabal-syntax-" ++ ver ++ " Cabal-hooks-" ++ hooksVer) verb mbGhc dir
+    runProgramInvocation verb ((programInvocation cabal ["get", "Cabal-hooks-" ++ ver]) { progInvokeCwd = Just dir })
+  buildCabalLibsProject ("packages: Cabal-" ++ ver ++ " Cabal-syntax-" ++ ver ++ " Cabal-hooks-" ++ ver) verb mbGhc dir
 
 
 buildCabalLibsIntree :: String -> Verbosity -> Maybe FilePath -> FilePath -> IO [FilePath]


### PR DESCRIPTION
This PR targets the Cabal 3.14 branch.

As pointed out in #10412, it isn't currently feasible to version the Cabal-hooks version separately from Cabal due to the large amount of re-exports (in particular the LocalBuildInfo type and its dependencies).

For the time being, we version Cabal-hooks along with the major Cabal library version.

Companion to #10580.