### PR TITLE
Don't use redundant alias Prelude as Prelude

### DIFF
--- a/Cabal-syntax/src/Distribution/Fields/Lexer.x
+++ b/Cabal-syntax/src/Distribution/Fields/Lexer.x
@@ -20,7 +20,7 @@ module Distribution.Fields.Lexer
   ,mkLexState) where
 
 import Prelude ()
-import qualified Prelude as Prelude
+import qualified Prelude
 import Distribution.Compat.Prelude
 
 import Distribution.Fields.LexerMonad


### PR DESCRIPTION
Minor, fixes #10581.