### PR TITLE
Add PHONY rules for lint and lint-json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,18 @@ whitespace: ## Run fix-whitespace in check mode
 fix-whitespace: ## Run fix-whitespace in fix mode
 	fix-whitespace --verbose
 
+.PHONY: lint
+lint: ## Run HLint
+	hlint -j .
+
+.PHONY: lint-json
+lint-json: ## Run HLint in JSON mode
+	hlint -j --json -- .
+
 # local checks
 
 .PHONY: checks
-checks: whitespace style
-	# this should probably be a rule
-	hlint -j --json -- .
+checks: whitespace style lint-json
 
 # source generation: SPDX
 


### PR DESCRIPTION
Fixes #10583, adding `PHONY` rules for `lint` and `lint-json`.

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
