### PR TITLE
VCS tests: Quieter output

### DIFF
--- a/cabal-install/src/Distribution/Client/VCS.hs
+++ b/cabal-install/src/Distribution/Client/VCS.hs
@@ -516,7 +516,7 @@ vcsGit =
       -- is needed because sometimes `git submodule sync` does not actually
       -- update the submodule source URL. Detailed description here:
       -- https://git.coop/-/snippets/85
-      git localDir ["submodule", "deinit", "--force", "--all"]
+      git localDir $ ["submodule", "deinit", "--force", "--all"] ++ verboseArg
       let gitModulesDir = localDir </> ".git" </> "modules"
       gitModulesExists <- doesDirectoryExist gitModulesDir
       when gitModulesExists $

--- a/changelog.d/pr-10587
+++ b/changelog.d/pr-10587
@@ -1,0 +1,12 @@
+---
+synopsis: "Quieter Git output"
+packages: [cabal-install]
+prs: 10587
+---
+
+When `cabal` clones a Git repo for a `source-repository-package` listed in a
+`cabal.project`, it will run various commands to check out the correct
+revision, initialize submodules if they're present, and so on.
+
+Now, `cabal` will pass `--quiet` to Git in more cases to help prevent
+cluttering command-line output.


### PR DESCRIPTION
This prevents the tests from spamming lots of output, making it easier to watch them as they run.

Before:

```
      check VCS test framework:                                                 10% warning: refname 'd6077f476a7c17fe8528e62688a19cc5bddbfbdc' is ambiguous.
Git normally never creates a ref that ends with 40 hex characters
because it will be ignored when you just specify 40-hex. These refs
may be created by mistake. For example,

  git switch -c $br $(git rev-parse ...)

where "$br" is somehow empty and a 40-hex ref is created. Please
examine these refs and maybe delete them. Turn this message off by
running "git config advice.objectNameWarning false"
rm 'file/C'
Cloning into '/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/vcstest-64269/src/file/C'...
done.
Submodule path 'file/C': checked out '210af0166ade8b306b425782305b8c6e910aa2c0'
Cloning into '/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/vcstest-64267/src/file/D'...
done.
Submodule path 'file/D': checked out '95b580ef06aec22b38f6e0a5c3305d5c293669a0'
branch 'branch_D' set up to track 'main'.
branch 'branch_C' set up to track 'main'.
rm 'file/C'
Cloning into '/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/vcstest-64269/src/file/C'...
done.
rm 'file/D'
Submodule path 'file/C': checked out 'ee47ffdda57945d841bc7f59ea72a78043c4ac02'
Cloning into '/private/var/folders/z5/fclwwdms3r1gq4k4p3pkvvc00000gn/T/vcstest-64267/src/file/D'...
done.
Submodule path 'file/D': checked out '23d9b5f39ae56c429dd9498d42338d27ea4e6545'
```

After:

```
  UnitTests.Distribution.Client.VCS
    git
      check VCS test framework:                                                 warning: --depth is ignored in local clones; use file:// instead.
warning: refname 'fbfe708a98c79a7c97e83609275b0f604f26e18b' is ambiguous.
Git normally never creates a ref that ends with 40 hex characters
because it will be ignored when you just specify 40-hex. These refs
may be created by mistake. For example,

  git switch -c $br $(git rev-parse ...)

where "$br" is somehow empty and a 40-hex ref is created. Please
examine these refs and maybe delete them. Turn this message off by
running "git config advice.objectNameWarning false"
warning: --depth is ignored in local clones; use file:// instead.
warning: --depth is ignored in local clones; use file:// instead.
warning: refname 'dc2abca0fd032b5cdd8904e6931679b4d6e6b25b' is ambiguous.
Git normally never creates a ref that ends with 40 hex characters
because it will be ignored when you just specify 40-hex. These refs
may be created by mistake. For example,

  git switch -c $br $(git rev-parse ...)

where "$br" is somehow empty and a 40-hex ref is created. Please
examine these refs and maybe delete them. Turn this message off by
running "git config advice.objectNameWarning false"
```

These warnings require semantic changes which will come in a separate PR (#10586).

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
