### PR TITLE
VCS: Don't run submodule commands unless necessary

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/Run.hs
+++ b/Cabal/src/Distribution/Simple/Program/Run.hs
@@ -61,6 +61,7 @@ data ProgramInvocation = ProgramInvocation
   , progInvokeInputEncoding :: IOEncoding
   -- ^ TODO: remove this, make user decide when constructing 'progInvokeInput'.
   , progInvokeOutputEncoding :: IOEncoding
+  , progInvokeWhen :: IO Bool
   }
 
 data IOEncoding
@@ -82,6 +83,7 @@ emptyProgramInvocation =
     , progInvokeInput = Nothing
     , progInvokeInputEncoding = IOEncodingText
     , progInvokeOutputEncoding = IOEncodingText
+    , progInvokeWhen = pure True
     }
 
 simpleProgramInvocation

--- a/changelog.d/pr-10590
+++ b/changelog.d/pr-10590
@@ -1,0 +1,14 @@
+---
+synopsis: "Don't run submodule commands unless necessary"
+packages: [cabal-install]
+prs: 10590
+---
+
+When `cabal` clones a Git repo for a `source-repository-package` listed in a
+`cabal.project`, it will run various commands to check out the correct
+revision, initialize submodules if they're present, and so on.
+
+Now, `cabal` will avoid running `git submodule` commands unless the cloned
+repository contains a `.gitmodules` file. This will declutter `cabal`'s debug
+output by running fewer commands.
+


### PR DESCRIPTION
Running `git submodule` commands is harmless but clutters up the logs, making the tests difficult to debug when run in verbose-mode.

Doesn't seem to impact performance much. I measured a ~1.5% speedup with this code, which is well within error margins.

See: https://github.com/haskell/cabal/pull/7625/files#r709617991