### PR TITLE
Fix mistake in BuildInfo.Lens.hs

### DIFF
--- a/Cabal-syntax/src/Distribution/Types/BuildInfo/Lens.hs
+++ b/Cabal-syntax/src/Distribution/Types/BuildInfo/Lens.hs
@@ -274,7 +274,7 @@ instance HasBuildInfo BuildInfo where
   cSources f s = fmap (\x -> s{T.cSources = x}) (f (T.cSources s))
   {-# INLINE cSources #-}
 
-  cxxSources f s = fmap (\x -> s{T.cSources = x}) (f (T.cxxSources s))
+  cxxSources f s = fmap (\x -> s{T.cxxSources = x}) (f (T.cxxSources s))
   {-# INLINE cxxSources #-}
 
   jsSources f s = fmap (\x -> s{T.jsSources = x}) (f (T.jsSources s))

--- a/changelog.d/pr-10609
+++ b/changelog.d/pr-10609
@@ -1,5 +1,5 @@
 ---
-synopsis: Fix 
+synopsis: Fix mistake in BuildInfo/Lens.hs mixing up `c-sources` and `cxx-sources`
 packages: [Cabal-syntax]
 prs: 10609
 ---

--- a/changelog.d/pr-10609
+++ b/changelog.d/pr-10609
@@ -1,0 +1,7 @@
+---
+synopsis: Fix 
+packages: [Cabal-syntax]
+prs: 10609
+---
+
+Fix a typo that would cause cxx-source and c-sources get mixed up.


### PR DESCRIPTION
```
  cxxSources f s = fmap (\x -> s{T.cSources = x}) (f (T.cxxSources s))
```
should be
```
  cxxSources f s = fmap (\x -> s{T.cxxSources = x}) (f (T.cxxSources s))
```