### PR TITLE
OpenBSD `--strip-unneeded` strips too much

### DIFF
--- a/Cabal/src/Distribution/Simple/Program/Strip.hs
+++ b/Cabal/src/Distribution/Simple/Program/Strip.hs
@@ -58,6 +58,10 @@ stripLib verbosity (Platform arch os) progdb path = do
     IOS -> return ()
     AIX -> return ()
     Solaris -> return ()
+    OpenBSD ->
+      -- '--strip-unneeded' sometimes strips too much on OpenBSD.
+      -- -- See https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/lang/ghc/patches/patch-libraries_Cabal_Cabal_Distribution_Simple_Program_Strip_hs
+      return ()
     Windows ->
       -- Stripping triggers a bug in 'strip.exe' for
       -- libraries with lots identically named modules. See

--- a/changelog.d/pr-10616
+++ b/changelog.d/pr-10616
@@ -1,0 +1,11 @@
+---
+synopsis: "OpenBSD `--strip-unneeded` sometimes strips too much"
+packages: [Cabal]
+prs: 10616
+---
+
+OpenBSD's `--strip-unneeded` thinks some symbols are unneeded that are in fact
+needed when C bits are involved, so suppress its use.
+
+Taken from the OpenBSD ports repo (https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/lang/ghc/patches/patch-libraries_Cabal_Cabal_Distribution_Simple_Program_Strip_hs);
+brought to our attention by maerwald.


### PR DESCRIPTION
Brought to our attention by maerwald; see https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/lang/ghc/patches/patch-libraries_Cabal_Cabal_Distribution_Simple_Program_Strip_hs.

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)
