### PR TITLE
Have hlint ignore dist-*

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,8 +1,8 @@
 # Warnings currently triggered by your code
 - ignore: {name: "Avoid NonEmpty.unzip"} # 1 hint
-- ignore: {name: "Avoid lambda"} # 46 hints
+- ignore: {name: "Avoid lambda"} # 47 hints
 - ignore: {name: "Avoid lambda using `infix`"} # 22 hints
-- ignore: {name: "Eta reduce"} # 116 hints
+- ignore: {name: "Eta reduce"} # 124 hints
 - ignore: {name: "Evaluate"} # 10 hints
 - ignore: {name: "Functor law"} # 10 hints
 - ignore: {name: "Fuse concatMap/map"} # 3 hints
@@ -16,27 +16,27 @@
 - ignore: {name: "Monoid law, right identity"} # 3 hints
 - ignore: {name: "Move filter"} # 4 hints
 - ignore: {name: "Move guards forward"} # 4 hints
-- ignore: {name: "Redundant $"} # 175 hints
+- ignore: {name: "Redundant $"} # 179 hints
 - ignore: {name: "Redundant $!"} # 1 hint
 - ignore: {name: "Redundant <$>"} # 16 hints
 - ignore: {name: "Redundant =="} # 1 hint
-- ignore: {name: "Redundant bracket"} # 232 hints
+- ignore: {name: "Redundant bracket"} # 239 hints
 - ignore: {name: "Redundant fmap"} # 1 hint
 - ignore: {name: "Redundant guard"} # 2 hints
-- ignore: {name: "Redundant if"} # 3 hints
+- ignore: {name: "Redundant if"} # 6 hints
 - ignore: {name: "Redundant lambda"} # 19 hints
 - ignore: {name: "Redundant multi-way if"} # 1 hint
-- ignore: {name: "Redundant return"} # 7 hints
-- ignore: {name: "Replace case with fromMaybe"} # 5 hints
+- ignore: {name: "Redundant return"} # 9 hints
+- ignore: {name: "Replace case with fromMaybe"} # 6 hints
 - ignore: {name: "Replace case with maybe"} # 10 hints
-- ignore: {name: "Unused LANGUAGE pragma"} # 167 hints
+- ignore: {name: "Unused LANGUAGE pragma"} # 168 hints
 - ignore: {name: "Use $>"} # 5 hints
 - ignore: {name: "Use ++"} # 4 hints
-- ignore: {name: "Use :"} # 25 hints
+- ignore: {name: "Use :"} # 30 hints
 - ignore: {name: "Use <$"} # 2 hints
-- ignore: {name: "Use <$>"} # 86 hints
+- ignore: {name: "Use <$>"} # 87 hints
 - ignore: {name: "Use <&>"} # 14 hints
-- ignore: {name: "Use <=<"} # 5 hints
+- ignore: {name: "Use <=<"} # 4 hints
 - ignore: {name: "Use =<<"} # 7 hints
 - ignore: {name: "Use =="} # 3 hints
 - ignore: {name: "Use >=>"} # 3 hints
@@ -44,40 +44,40 @@
 - ignore: {name: "Use Down"} # 3 hints
 - ignore: {name: "Use Just"} # 2 hints
 - ignore: {name: "Use bimap"} # 7 hints
-- ignore: {name: "Use camelCase"} # 96 hints
+- ignore: {name: "Use camelCase"} # 98 hints
 - ignore: {name: "Use catMaybes"} # 3 hints
-- ignore: {name: "Use concatMap"} # 1 hint
+- ignore: {name: "Use concatMap"} # 2 hints
 - ignore: {name: "Use const"} # 36 hints
 - ignore: {name: "Use elem"} # 2 hints
-- ignore: {name: "Use fewer imports"} # 19 hints
+- ignore: {name: "Use fewer imports"} # 13 hints
 - ignore: {name: "Use first"} # 4 hints
-- ignore: {name: "Use fmap"} # 24 hints
+- ignore: {name: "Use fmap"} # 26 hints
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use for"} # 1 hint
 - ignore: {name: "Use forM_"} # 1 hint
-- ignore: {name: "Use fromMaybe"} # 1 hint
+- ignore: {name: "Use fromMaybe"} # 4 hints
 - ignore: {name: "Use fromRight"} # 1 hint
 - ignore: {name: "Use fst"} # 1 hint
-- ignore: {name: "Use if"} # 4 hints
+- ignore: {name: "Use if"} # 2 hints
 - ignore: {name: "Use infix"} # 20 hints
 - ignore: {name: "Use isAsciiLower"} # 2 hints
 - ignore: {name: "Use isAsciiUpper"} # 2 hints
 - ignore: {name: "Use isDigit"} # 2 hints
 - ignore: {name: "Use isJust"} # 1 hint
 - ignore: {name: "Use isNothing"} # 1 hint
-- ignore: {name: "Use lambda-case"} # 47 hints
+- ignore: {name: "Use lambda-case"} # 55 hints
 - ignore: {name: "Use lefts"} # 1 hint
-- ignore: {name: "Use list comprehension"} # 16 hints
+- ignore: {name: "Use list comprehension"} # 18 hints
 - ignore: {name: "Use list literal"} # 3 hints
 - ignore: {name: "Use list literal pattern"} # 11 hints
 - ignore: {name: "Use map once"} # 7 hints
 - ignore: {name: "Use map with tuple-section"} # 3 hints
 - ignore: {name: "Use mapMaybe"} # 13 hints
-- ignore: {name: "Use max"} # 1 hint
+- ignore: {name: "Use max"} # 2 hints
 - ignore: {name: "Use maybe"} # 8 hints
 - ignore: {name: "Use minimumBy"} # 1 hint
 - ignore: {name: "Use newtype instead of data"} # 26 hints
-- ignore: {name: "Use notElem"} # 8 hints
+- ignore: {name: "Use notElem"} # 9 hints
 - ignore: {name: "Use null"} # 2 hints
 - ignore: {name: "Use record patterns"} # 16 hints
 - ignore: {name: "Use replicateM"} # 1 hint
@@ -88,11 +88,11 @@
 - ignore: {name: "Use traverse"} # 1 hint
 - ignore: {name: "Use tuple-section"} # 28 hints
 - ignore: {name: "Use typeRep"} # 2 hints
-- ignore: {name: "Use unless"} # 20 hints
-- ignore: {name: "Use unwords"} # 8 hints
-- ignore: {name: "Use void"} # 22 hints
-- ignore: {name: "Use when"} # 1 hint
 - ignore: {name: "Use uncurry"} # 1 hint
+- ignore: {name: "Use unless"} # 22 hints
+- ignore: {name: "Use unwords"} # 8 hints
+- ignore: {name: "Use void"} # 23 hints
+- ignore: {name: "Use when"} # 1 hint
 
 - arguments:
     - --ignore-glob=Cabal-syntax/src/Distribution/Fields/Lexer.hs

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -102,3 +102,4 @@
     - --ignore-glob=templates/Paths_pkg.template.hs
     - --ignore-glob=templates/SPDX.LicenseExceptionId.template.hs
     - --ignore-glob=templates/SPDX.LicenseId.template.hs
+    - --ignore-glob=dist-*


### PR DESCRIPTION
For #10560, configure `hlint` to ignore `dist-*` folders. Also bump the `hlint` warnings counts (they're getting worse).

---

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
