### PR TITLE
Fix multi-package Haddock CSS handling

### DIFF
--- a/Cabal/src/Distribution/Simple/Haddock.hs
+++ b/Cabal/src/Distribution/Simple/Haddock.hs
@@ -617,6 +617,7 @@ fromHaddockProjectFlags flags =
     , argInterfaces = fromFlagOrDefault [] (haddockProjectInterfaces flags)
     , argLinkedSource = Flag True
     , argResourcesDir = haddockProjectResourcesDir flags
+    , argCssFile = haddockProjectCss flags
     }
 
 fromPackageDescription :: HaddockTarget -> PackageDescription -> HaddockArgs

--- a/cabal-install/src/Distribution/Client/CmdHaddock.hs
+++ b/cabal-install/src/Distribution/Client/CmdHaddock.hs
@@ -136,7 +136,8 @@ mkFlagsAbsolute :: NixStyleFlags ClientHaddockFlags -> IO (NixStyleFlags ClientH
 mkFlagsAbsolute relFlags = do
   let relHaddockFlags = haddockFlags relFlags
   absHaddockOutputDir <- traverse makeAbsolute (haddockOutputDir relHaddockFlags)
-  return (relFlags{haddockFlags = relHaddockFlags{haddockOutputDir = absHaddockOutputDir}})
+  absHaddockCss <- traverse makeAbsolute (haddockCss relHaddockFlags)
+  return (relFlags{haddockFlags = relHaddockFlags{haddockOutputDir = absHaddockOutputDir, haddockCss = absHaddockCss}})
 
 -- | The @haddock@ command is TODO.
 --

--- a/changelog.d/pr-10637
+++ b/changelog.d/pr-10637
@@ -1,0 +1,11 @@
+---
+synopsis: Fix Haddock CSS handling in multi-package projects
+packages: [cabal-install, Cabal]
+prs: 10637
+issues: [10636]
+---
+
+When `--css=<css-file>` flag is provided to `cabal haddock-project`:
+
+- the Haddock index is now properly styled by the provided CSS file
+- each package in the project now has their docs properly styled by the provided CSS file


### PR DESCRIPTION
Fixes #10636

This PR fixes the linked issue by making the stylesheet path absolute before passing it to Haddock, and also passing the stylesheet to the index generator as well.

## QA Notes
Calling `cabal haddock-project --css=<css-file>` on a multi-package project where every package has its own subdirectory (and not have their source files at the _project_ root) should produce documentation such that:
- The index (i.e. `./haddocks/index.html`) is styled by the provided CSS file
- Each package has their docs (i.e. `./haddocs/<package>/<module>.html`) styled by the provided CSS file

[This reproducer](https://github.com/ozkutuk/cabal-multi-css-repro) of the original issue can be used for QA purposes. 

---

**Template Α: This PR modifies [behaviour or interface](https://github.com/cabalism/cabal/blob/master/CONTRIBUTING.md#changelog)**

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [x] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [x] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)