### PR TITLE
try to alert (via webhook) when Mergify is stuck

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -62,6 +62,31 @@ pull_request_rules:
       - check-success=Bootstrap post job
       - 'check-success=docs/readthedocs.org:cabal'
 
+  # label when Mergify didn't trigger a merge automatically
+  - actions:
+      label:
+        add:
+          - waiting too long
+    name: Mergify hasn't merged a PR yet
+    conditions:
+      - base=master
+      - -draft
+      - -closed
+      - -merged
+      - '#approved-reviews-by>=2'
+      - '#changes-requested-reviews-by=0'
+      - updated-at<4 days ago
+      - label=merge delay passed
+      # oy
+      # lifted these from branch protection imports
+      - check-success=fourmolu
+      - check-success=hlint
+      - check-success=Meta checks
+      - check-success=Doctest Cabal
+      - check-success=Validate post job
+      - check-success=Bootstrap post job
+      - 'check-success=docs/readthedocs.org:cabal'
+
   # rebase+merge strategy
   - actions:
       queue:


### PR DESCRIPTION
Add a label "waiting too long" if a PR has "merge delay passed" but is still open without any activity. Somewhat hacky, since GitHub's API doesn't provide any real hooks for it so I'm guessing at ways to try to catch it. Can only be tested by merging, since Mergify won't apply it unless it's on `master`.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ Mergify only pays attention to `master`
