### PR TITLE
second attempt at catching stale PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -54,12 +54,14 @@ pull_request_rules:
       - '#changes-requested-reviews-by=0'
       # oy
       # lifted these from branch protection imports
+      - check-success=whitespace
       - check-success=fourmolu
       - check-success=hlint
       - check-success=Meta checks
       - check-success=Doctest Cabal
       - check-success=Validate post job
       - check-success=Bootstrap post job
+      - check-success=Check sdist post job
       - 'check-success=docs/readthedocs.org:cabal'
 
   # label when Mergify didn't trigger a merge automatically
@@ -75,16 +77,19 @@ pull_request_rules:
       - -merged
       - '#approved-reviews-by>=2'
       - '#changes-requested-reviews-by=0'
-      - updated-at<4 days ago
       - label=merge delay passed
+      - label!=waiting too long
+      - 'check-failure~=^Rule: Put pull requests in the '
       # oy
       # lifted these from branch protection imports
+      - check-success=whitespace
       - check-success=fourmolu
       - check-success=hlint
       - check-success=Meta checks
       - check-success=Doctest Cabal
       - check-success=Validate post job
       - check-success=Bootstrap post job
+      - check-success=Check sdist post job
       - 'check-success=docs/readthedocs.org:cabal'
 
   # rebase+merge strategy


### PR DESCRIPTION
The first one didn't fire, despite there being 3 PRs that should have matched. This one tries to match the queue failure itself instead of checking for lack of activity.

Please read [Github PR Conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#github-pull-request-conventions) and then fill in *one* of these two templates.

**Template B: This PR does not modify behaviour or interface**

*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] ~~Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).~~ Mergify only reads `mergify.yml` on `master`
