### PR TITLE
CI: remove cabal-head before updating it (fix #10537)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -464,7 +464,10 @@ jobs:
     needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
 
     steps:
-      # for now this is hardcoded. is there a better way?
+      - uses: liudonghua123/delete-release-action@v1
+        with:
+          release_name: 'cabal-head'
+
       - uses: actions/download-artifact@v4
         with:
           pattern: cabal-*
@@ -490,6 +493,10 @@ jobs:
     needs: [validate, validate-old-ghcs, build-alpine, dogfooding]
 
     steps:
+    - uses: liudonghua123/delete-release-action@v1
+      with:
+        release_name: 'cabal-lts-head'
+
     - uses: actions/download-artifact@v4
       with:
         pattern: cabal-*


### PR DESCRIPTION
This PR is https://github.com/haskell/cabal/pull/10540 rebased.

It should fix https://github.com/haskell/cabal/issues/10537 and its duplicate https://github.com/haskell/cabal/issues/10652

----
*E.g. the PR only touches documentation or tests, does refactorings, etc.*

Include the following checklist in your PR:

* [X] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [n/a] Is this a PR that fixes CI? If so, it will need to be backported to older cabal release branches (ask maintainers for directions).
