### PR TITLE
Support `ghc-9.12.*`

### DIFF
--- a/Cabal/src/Distribution/Simple/GHC.hs
+++ b/Cabal/src/Distribution/Simple/GHC.hs
@@ -163,14 +163,14 @@ configure verbosity hcPath hcPkgPath conf0 = do
       (userMaybeSpecifyPath "ghc" hcPath conf0)
   let implInfo = ghcVersionImplInfo ghcVersion
 
-  -- Cabal currently supports ghc >= 7.0.1 && < 9.12
+  -- Cabal currently supports ghc >= 7.0.1 && < 9.14
   -- ... and the following odd development version
-  unless (ghcVersion < mkVersion [9, 12]) $
+  unless (ghcVersion < mkVersion [9, 14]) $
     warn verbosity $
       "Unknown/unsupported 'ghc' version detected "
         ++ "(Cabal "
         ++ prettyShow cabalVersion
-        ++ " supports 'ghc' version < 9.12): "
+        ++ " supports 'ghc' version < 9.14): "
         ++ programPath ghcProg
         ++ " is version "
         ++ prettyShow ghcVersion


### PR DESCRIPTION
I'm trying out `-XMultilineStrings` in `cabal-testsuite` and struck this warning, having installed `ghc-9.12.1` with ghcup:

```
+Warning: Unknown/unsupported 'ghc' version detected (Cabal 3.15.0.0 supports 'ghc' version < 9.12):
/.../.ghcup/bin/ghc is version <GHCVER>
```

This pull request is the same as #9928 (that adds support for `ghc-9.10.*`) but bumps the GHC version once more.

---

Include the following checklist in your PR:

* [x] Patches conform to the [coding conventions](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#other-conventions).
* [ ] Any changes that could be relevant to users [have been recorded in the changelog](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#changelog).
  * [ ] [Is the change significant?](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#is-my-change-significant) If so, remember to add `significance: significant` in the changelog file.
* [ ] The documentation has been updated, if necessary.
* [ ] [Manual QA notes](https://github.com/haskell/cabal/blob/master/CONTRIBUTING.md#qa-notes) have been included.
* [ ] Tests have been added. (*Ask for help if you don’t know how to write them! Ask for an exemption if tests are too complex for too little coverage!*)

